### PR TITLE
fix(runner-kafka): handle queue emit exception

### DIFF
--- a/core/src/main/java/org/kestra/core/queues/QueueException.java
+++ b/core/src/main/java/org/kestra/core/queues/QueueException.java
@@ -1,0 +1,7 @@
+package org.kestra.core.queues;
+
+public class QueueException extends RuntimeException {
+    public QueueException(String message, Throwable e) {
+        super(message, e);
+    }
+}

--- a/core/src/main/java/org/kestra/core/queues/QueueInterface.java
+++ b/core/src/main/java/org/kestra/core/queues/QueueInterface.java
@@ -4,7 +4,7 @@ import java.io.Closeable;
 import java.util.function.Consumer;
 
 public interface QueueInterface<T> extends Closeable {
-    void emit(T message);
+    void emit(T message) throws QueueException;
 
     Runnable receive(Consumer<T> consumer);
 

--- a/runner-kafka/src/main/java/org/kestra/runner/kafka/KafkaExecutor.java
+++ b/runner-kafka/src/main/java/org/kestra/runner/kafka/KafkaExecutor.java
@@ -248,6 +248,9 @@ public class KafkaExecutor extends AbstractExecutor {
         KafkaAdminService kafkaAdminService;
 
         private Topology topology() {
+            this.kafkaAdminService.createIfNotExist(WorkerTaskResult.class);
+            this.kafkaAdminService.createIfNotExist(Execution.class);
+
             StreamsBuilder builder = new StreamsBuilder();
 
             builder

--- a/runner-kafka/src/main/java/org/kestra/runner/kafka/services/KafkaAdminService.java
+++ b/runner-kafka/src/main/java/org/kestra/runner/kafka/services/KafkaAdminService.java
@@ -36,7 +36,7 @@ public class KafkaAdminService {
         return AdminClient.create(properties);
     }
 
-    private TopicsConfig getTopicConfig(Class cls) {
+    private TopicsConfig getTopicConfig(Class<?> cls) {
         return this.topicsConfig
             .stream()
             .filter(r -> r.getCls().equals(cls.getName().toLowerCase().replace(".", "-")))
@@ -45,7 +45,7 @@ public class KafkaAdminService {
     }
 
     @SuppressWarnings("deprecation")
-    public boolean createIfNotExist(Class cls) {
+    public void createIfNotExist(Class<?> cls) {
         TopicsConfig topicConfig = this.getTopicConfig(cls);
 
         AdminClient admin = this.of();
@@ -70,7 +70,6 @@ public class KafkaAdminService {
         try {
             admin.createTopics(Collections.singletonList(newTopic)).all().get();
             log.info("Topic '{}' created", newTopic.name());
-            return true;
         } catch (ExecutionException | InterruptedException e) {
             if (e.getCause() instanceof TopicExistsException) {
                 try {
@@ -97,12 +96,9 @@ public class KafkaAdminService {
                 throw new RuntimeException(e);
             }
         }
-
-        return false;
     }
 
-
-    public String getTopicName(Class cls) {
+    public String getTopicName(Class<?> cls) {
         return this.getTopicConfig(cls).getName();
     }
 }

--- a/runner-kafka/src/main/java/org/kestra/runner/kafka/services/KafkaConsumerService.java
+++ b/runner-kafka/src/main/java/org/kestra/runner/kafka/services/KafkaConsumerService.java
@@ -28,7 +28,7 @@ public class KafkaConsumerService {
     @Inject
     private ConsumerDefaultsConfig consumerConfig;
 
-    public <V> Consumer<V> of(Class group, Serde<V> serde) {
+    public <V> Consumer<V> of(Class<?> group, Serde<V> serde) {
         Properties properties = new Properties();
         properties.putAll(clientConfig.getProperties());
 

--- a/runner-kafka/src/main/java/org/kestra/runner/kafka/services/KafkaProducerService.java
+++ b/runner-kafka/src/main/java/org/kestra/runner/kafka/services/KafkaProducerService.java
@@ -20,7 +20,7 @@ public class KafkaProducerService {
     @Inject
     private ProducerDefaultsConfig producerConfig;
 
-    public <V> KafkaProducerService.Producer<V> of(Class name, Serde<V> serde) {
+    public <V> KafkaProducerService.Producer<V> of(Class<?> name, Serde<V> serde) {
         Properties properties = new Properties();
         properties.putAll(clientConfig.getProperties());
 

--- a/runner-kafka/src/main/java/org/kestra/runner/kafka/services/KafkaStreamService.java
+++ b/runner-kafka/src/main/java/org/kestra/runner/kafka/services/KafkaStreamService.java
@@ -26,7 +26,7 @@ public class KafkaStreamService {
     @Inject
     private StreamDefaultsConfig streamConfig;
 
-    public KafkaStreamService.Stream of(Class group, Topology topology) {
+    public KafkaStreamService.Stream of(Class<?> group, Topology topology) {
         Properties properties = new Properties();
         properties.putAll(clientConfig.getProperties());
 

--- a/runner-kafka/src/test/java/org/kestra/runner/kafka/KafkaRunnerTest.java
+++ b/runner-kafka/src/test/java/org/kestra/runner/kafka/KafkaRunnerTest.java
@@ -2,25 +2,33 @@ package org.kestra.runner.kafka;
 
 import com.google.common.collect.ImmutableMap;
 import io.micronaut.test.annotation.MicronautTest;
-import org.kestra.core.runners.ListenersTest;
-import org.kestra.core.utils.TestsUtils;
-import org.kestra.core.models.executions.Execution;
-import org.kestra.core.repositories.LocalFlowRepositoryLoader;
-import org.kestra.core.runners.RunnerUtils;
-import org.kestra.core.runners.StandAloneRunner;
+import org.apache.kafka.common.errors.RecordTooLargeException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.kestra.core.models.executions.Execution;
+import org.kestra.core.models.flows.State;
+import org.kestra.core.queues.QueueException;
+import org.kestra.core.repositories.LocalFlowRepositoryLoader;
+import org.kestra.core.runners.InputsTest;
+import org.kestra.core.runners.ListenersTest;
+import org.kestra.core.runners.RunnerUtils;
+import org.kestra.core.runners.StandAloneRunner;
+import org.kestra.core.utils.TestsUtils;
 
-import javax.inject.Inject;
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.time.Duration;
+import java.util.Arrays;
+import java.util.HashMap;
 import java.util.Objects;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeoutException;
+import javax.inject.Inject;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @MicronautTest
 class KafkaRunnerTest {
@@ -41,28 +49,28 @@ class KafkaRunnerTest {
     }
 
     @Test
-    void full() throws TimeoutException {
+    void full() throws TimeoutException, QueueException {
         Execution execution = runnerUtils.runOne("org.kestra.tests", "full", null, null, Duration.ofSeconds(15));
 
         assertThat(execution.getTaskRunList(), hasSize(13));
     }
 
     @Test
-    void errors() throws TimeoutException {
+    void errors() throws TimeoutException, QueueException {
         Execution execution = runnerUtils.runOne("org.kestra.tests", "errors", null, null, Duration.ofSeconds(15));
 
         assertThat(execution.getTaskRunList(), hasSize(7));
     }
 
     @Test
-    void sequential() throws TimeoutException {
+    void sequential() throws TimeoutException, QueueException {
         Execution execution = runnerUtils.runOne("org.kestra.tests", "sequential");
 
         assertThat(execution.getTaskRunList(), hasSize(11));
     }
 
     @Test
-    void listeners() throws TimeoutException, IOException, URISyntaxException {
+    void listeners() throws TimeoutException, QueueException, IOException, URISyntaxException {
         repositoryLoader.load(Objects.requireNonNull(ListenersTest.class.getClassLoader().getResource("flows/tests")));
 
         Execution execution = runnerUtils.runOne(
@@ -75,5 +83,44 @@ class KafkaRunnerTest {
         assertThat(execution.getTaskRunList().get(1).getTaskId(), is("ok"));
         assertThat(execution.getTaskRunList().size(), is(3));
         assertThat(execution.getTaskRunList().get(2).getTaskId(), is("execution-success-listener"));
+    }
+
+    @Test
+    void recordTooLarge() {
+        char[] chars = new char[2000000];
+        Arrays.fill(chars, 'a');
+
+        HashMap<String, String> inputs = new HashMap<>(InputsTest.inputs);
+        inputs.put("string", new String(chars));
+
+        RuntimeException e = assertThrows(RuntimeException.class, () -> {
+            runnerUtils.runOne(
+                "org.kestra.tests",
+                "inputs",
+                null,
+                (flow, execution1) -> runnerUtils.typedInputs(flow, execution1, inputs)
+            );
+        });
+
+        assertThat(e.getCause().getClass(), is(ExecutionException.class));
+        assertThat(e.getCause().getCause().getClass(), is(RecordTooLargeException.class));
+    }
+
+    @Test
+    void workerRecordTooLarge() throws TimeoutException {
+        char[] chars = new char[600000];
+        Arrays.fill(chars, 'a');
+
+        HashMap<String, String> inputs = new HashMap<>(InputsTest.inputs);
+        inputs.put("string", new String(chars));
+
+        Execution execution = runnerUtils.runOne(
+            "org.kestra.tests",
+            "inputs",
+            null,
+            (flow, execution1) -> runnerUtils.typedInputs(flow, execution1, inputs)
+        );
+
+        assertThat(execution.getState().getCurrent(), is(State.Type.FAILED));
     }
 }


### PR DESCRIPTION
If an emit failed, before the error was silenced and the thread is removed silently.
Now, we try the save mark the WorkerTask has failed and if we can't we just kill the application