### PR TITLE
fix(ui): autofocus in the textarea

### DIFF
--- a/ui/src/components/flows/FlowEdit.vue
+++ b/ui/src/components/flows/FlowEdit.vue
@@ -88,6 +88,10 @@ export default {
         editorInit: function() {
             require("brace/mode/yaml");
             require("brace/theme/chrome");
+            // div col -> div ace_editor -> textarea
+            var textarea = editor.firstChild.firstChild.firstChild;
+            textarea.focus()
+
         },
         save() {
             if (this.flow) {

--- a/ui/src/components/flows/FlowEdit.vue
+++ b/ui/src/components/flows/FlowEdit.vue
@@ -88,10 +88,7 @@ export default {
         editorInit: function() {
             require("brace/mode/yaml");
             require("brace/theme/chrome");
-            // div col -> div ace_editor -> textarea
-            var textarea = editor.firstChild.firstChild.firstChild;
-            textarea.focus()
-
+            this.$refs.aceEditor.editor.textInput.focus()
         },
         save() {
             if (this.flow) {


### PR DESCRIPTION
Related to R01:
> Lorsque l'on clique sur Add flow, le focus n'est pas mis
> dans l'éditeur par défaut. Il faut donc cliquer dans
> l'éditeur pour pouvoir coller notre yaml.