### PR TITLE
Remove log from Execution

### DIFF
--- a/cli/src/main/resources/application.yml
+++ b/cli/src/main/resources/application.yml
@@ -38,8 +38,6 @@ kestra:
       topic:
         partitions: 16
         replication-factor: 1
-        properties:
-          compression.type: "lz4"
 
       consumer:
         properties:
@@ -51,12 +49,16 @@ kestra:
       producer:
         properties:
           acks: "all"
+          compression.type: "lz4"
+          max.request.size: "10485760"
 
       stream:
         properties:
           processing.guarantee: "exactly_once"
           replication.factor: "${kestra.kafka.defaults.topic.replication-factor}"
           acks: "all"
+          compression.type: "lz4"
+          max.request.size: "10485760"
 
     topics:
       execution:
@@ -92,7 +94,8 @@ kestra:
         properties:
           cleanup.policy: "delete,compact"
 
-      org-kestra-core-models-executions-logentry:
+      logentry:
+        cls: org.kestra.core.models.executions.LogEntry
         name: "kestra_logs"
 
   elasticsearch:

--- a/cli/src/main/resources/application.yml
+++ b/cli/src/main/resources/application.yml
@@ -92,6 +92,9 @@ kestra:
         properties:
           cleanup.policy: "delete,compact"
 
+      org-kestra-core-models-executions-logentry:
+        name: "kestra_logs"
+
   elasticsearch:
     indices:
       flows:
@@ -110,6 +113,10 @@ kestra:
         index: "kestra_triggers"
         cls: org.kestra.core.models.triggers.Trigger
         mapping-file: trigger
+      logs:
+        index: "kestra_logs"
+        cls: org.kestra.core.models.executions.LogEntry
+        mapping-file: log
 
   plugins:
     repositories:

--- a/core/src/main/java/org/kestra/core/models/executions/Execution.java
+++ b/core/src/main/java/org/kestra/core/models/executions/Execution.java
@@ -15,16 +15,15 @@ import org.kestra.core.models.DeletedInterface;
 import org.kestra.core.models.flows.Flow;
 import org.kestra.core.models.flows.State;
 import org.kestra.core.models.tasks.ResolvedTask;
-import org.kestra.core.queues.QueueInterface;
 import org.kestra.core.runners.FlowableUtils;
 import org.kestra.core.runners.RunContextLogger;
 import org.kestra.core.utils.MapUtils;
 
-import javax.validation.constraints.NotNull;
 import java.time.Instant;
 import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import javax.validation.constraints.NotNull;
 import java.util.zip.CRC32;
 
 @Value
@@ -203,7 +202,7 @@ public class Execution implements DeletedInterface {
         if (this.taskRunList == null) {
             return Optional.empty();
         }
-        
+
         return this.taskRunList
             .stream()
             .filter(t -> t.getState().getCurrent() == state)
@@ -329,51 +328,57 @@ public class Execution implements DeletedInterface {
      * In the worst case, we FAILED the execution (must not exists).
      *
      * @param e the exception throw from {@link org.kestra.core.runners.AbstractExecutor}
-     * @param logQueue the log queue in order to emit log
      * @return a new execution with taskrun failed if possible or execution failed is other case
      */
-    public Execution failedExecutionFromExecutor(Exception e, QueueInterface<LogEntry> logQueue) {
+    public FailedExecutionWithLog failedExecutionFromExecutor(Exception e) {
         return this
             .findFirstByState(State.Type.RUNNING)
             .map(taskRun -> {
                 TaskRunAttempt lastAttempt = taskRun.lastAttempt();
                 if (lastAttempt == null) {
-                    return newAttemptsTaskRunForFailedExecution(taskRun, e, logQueue);
+                    return newAttemptsTaskRunForFailedExecution(taskRun, e);
                 } else {
-                    return lastAttemptsTaskRunForFailedExecution(taskRun, lastAttempt, e, logQueue);
+                    return lastAttemptsTaskRunForFailedExecution(taskRun, lastAttempt, e);
                 }
             })
             .map(t -> {
                 try {
-                    return this.withTaskRun(t);
+                    return new FailedExecutionWithLog(
+                        this.withTaskRun(t.getTaskRun()),
+                        t.getLogs()
+                    );
                 } catch (InternalException ex) {
                     return null;
                 }
             })
             .filter(Objects::nonNull)
-            .orElseGet(() -> this.withState(State.Type.FAILED));
+            .orElseGet(() -> new FailedExecutionWithLog(
+                this.withState(State.Type.FAILED),
+                Collections.emptyList()
+            )
+        );
     }
+
 
     /**
      * Create a new attemps for failed worker execution
      *
      * @param taskRun the task run where we need to add an attempt
      * @param e the exception raise
-     * @param logQueue the log queue in order to emit log
      * @return new taskRun with added attempt
      */
-    private static TaskRun newAttemptsTaskRunForFailedExecution(TaskRun taskRun, Exception e, QueueInterface<LogEntry> logQueue) {
-        RunContextLogger.logEntries(loggingEventFromException(e), taskRun)
-            .forEach(logQueue::emit);
-
-        return taskRun
-            .withAttempts(
-                Collections.singletonList(TaskRunAttempt.builder()
-                    .state(new State())
-                    .build()
-                    .withState(State.Type.FAILED))
-            )
-            .withState(State.Type.FAILED);
+    private static FailedTaskRunWithLog newAttemptsTaskRunForFailedExecution(TaskRun taskRun, Exception e) {
+        return new FailedTaskRunWithLog(
+            taskRun
+                .withAttempts(
+                    Collections.singletonList(TaskRunAttempt.builder()
+                        .state(new State())
+                        .build()
+                        .withState(State.Type.FAILED))
+                )
+                .withState(State.Type.FAILED),
+            RunContextLogger.logEntries(loggingEventFromException(e), taskRun)
+        );
     }
 
     /**
@@ -381,27 +386,37 @@ public class Execution implements DeletedInterface {
      *
      * @param taskRun the task run where we need to add an attempt
      * @param lastAttempt the lastAttempt found to add
-     * @param logQueue the log queue in order to emit log
      * @param e the exception raise
      * @return new taskRun with updated attempt with logs
      */
-    private static TaskRun lastAttemptsTaskRunForFailedExecution(TaskRun taskRun, TaskRunAttempt lastAttempt, Exception e, QueueInterface<LogEntry> logQueue) {
-        RunContextLogger.logEntries(loggingEventFromException(e), taskRun)
-            .forEach(logQueue::emit);
+    private static FailedTaskRunWithLog lastAttemptsTaskRunForFailedExecution(TaskRun taskRun, TaskRunAttempt lastAttempt, Exception e) {
+        return new FailedTaskRunWithLog(
+            taskRun
+                .withAttempts(
+                    Stream
+                        .concat(
+                            taskRun.getAttempts().stream().limit(taskRun.getAttempts().size() - 1),
+                            Stream.of(lastAttempt
+                                .withState(State.Type.FAILED))
+                        )
+                        .collect(Collectors.toList())
+                )
+                .withState(State.Type.FAILED),
+            RunContextLogger.logEntries(loggingEventFromException(e), taskRun)
+        );
+    }
 
-        lastAttempt
-            .withState(State.Type.FAILED);
+    @Value
+    public static class FailedTaskRunWithLog {
+        private TaskRun taskRun;
+        private List<LogEntry> logs;
+    }
 
-        return taskRun
-            .withAttempts(
-                Stream
-                    .concat(
-                        taskRun.getAttempts().stream().limit(taskRun.getAttempts().size() - 1),
-                        Stream.of(lastAttempt)
-                    )
-                    .collect(Collectors.toList())
-            )
-            .withState(State.Type.FAILED);
+    @Value
+    @Builder
+    public static class FailedExecutionWithLog {
+        private Execution execution;
+        private List<LogEntry> logs;
     }
 
     /**

--- a/core/src/main/java/org/kestra/core/models/executions/LogEntry.java
+++ b/core/src/main/java/org/kestra/core/models/executions/LogEntry.java
@@ -5,15 +5,34 @@ import lombok.Value;
 import org.slf4j.event.Level;
 
 import java.time.Instant;
+import javax.validation.constraints.NotNull;
 
 @Value
 @Builder
 public class LogEntry {
-    Instant timestamp;
+    @NotNull
+    private String namespace;
 
-    Level level;
+    @NotNull
+    private String flowId;
 
-    String thread;
+    @NotNull
+    private String taskId;
 
-    String message;
+    @NotNull
+    private String executionId;
+
+    @NotNull
+    private String taskRunId;
+
+    @NotNull
+    private int attemptNumber;
+
+    private Instant timestamp;
+
+    private Level level;
+
+    private String thread;
+
+    private String message;
 }

--- a/core/src/main/java/org/kestra/core/models/executions/LogEntry.java
+++ b/core/src/main/java/org/kestra/core/models/executions/LogEntry.java
@@ -2,14 +2,18 @@ package org.kestra.core.models.executions;
 
 import lombok.Builder;
 import lombok.Value;
+import org.kestra.core.models.DeletedInterface;
 import org.slf4j.event.Level;
 
 import java.time.Instant;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
 import javax.validation.constraints.NotNull;
 
 @Value
 @Builder
-public class LogEntry {
+public class LogEntry implements DeletedInterface {
     @NotNull
     private String namespace;
 
@@ -35,4 +39,17 @@ public class LogEntry {
     private String thread;
 
     private String message;
+
+    @NotNull
+    private boolean deleted = false;
+
+    public static List<Level> findLevelsByMin(Level minLevel) {
+        if (minLevel == null) {
+            return Arrays.asList(Level.values());
+        }
+
+        return Arrays.stream(Level.values())
+            .filter(level -> level.toInt() >= minLevel.toInt())
+            .collect(Collectors.toList());
+    }
 }

--- a/core/src/main/java/org/kestra/core/models/executions/TaskRun.java
+++ b/core/src/main/java/org/kestra/core/models/executions/TaskRun.java
@@ -14,6 +14,7 @@ import java.util.Map;
 @Value
 @Builder
 public class TaskRun {
+    @NotNull
     private String id;
 
     @NotNull
@@ -82,6 +83,14 @@ public class TaskRun {
             .value(resolvedTask.getValue())
             .state(new State())
             .build();
+    }
+
+    public int attemptNumber() {
+        if (this.attempts == null) {
+            return 0;
+        }
+
+        return this.attempts.size();
     }
 
     public TaskRunAttempt lastAttempt() {

--- a/core/src/main/java/org/kestra/core/models/executions/TaskRunAttempt.java
+++ b/core/src/main/java/org/kestra/core/models/executions/TaskRunAttempt.java
@@ -13,9 +13,6 @@ import java.util.Optional;
 @Builder
 public class TaskRunAttempt {
     @With
-    private List<LogEntry> logs;
-
-    @With
     private List<AbstractMetricEntry<?>> metrics;
 
     @NotNull
@@ -23,7 +20,6 @@ public class TaskRunAttempt {
 
     public TaskRunAttempt withState(State.Type state) {
         return new TaskRunAttempt(
-            this.logs,
             this.metrics,
             this.state.withState(state)
         );

--- a/core/src/main/java/org/kestra/core/models/executions/TaskRunAttempt.java
+++ b/core/src/main/java/org/kestra/core/models/executions/TaskRunAttempt.java
@@ -5,9 +5,9 @@ import lombok.Value;
 import lombok.With;
 import org.kestra.core.models.flows.State;
 
-import javax.validation.constraints.NotNull;
 import java.util.List;
 import java.util.Optional;
+import javax.validation.constraints.NotNull;
 
 @Value
 @Builder

--- a/core/src/main/java/org/kestra/core/queues/QueueFactoryInterface.java
+++ b/core/src/main/java/org/kestra/core/queues/QueueFactoryInterface.java
@@ -2,6 +2,7 @@ package org.kestra.core.queues;
 
 import org.kestra.core.models.executions.Execution;
 import org.kestra.core.models.flows.Flow;
+import org.kestra.core.models.executions.LogEntry;
 import org.kestra.core.runners.WorkerTask;
 import org.kestra.core.runners.WorkerTaskResult;
 
@@ -10,12 +11,15 @@ public interface QueueFactoryInterface {
     String WORKERTASK_NAMED = "workerTaskQueue";
     String WORKERTASKRESULT_NAMED = "workerTaskResultQueue";
     String FLOW_NAMED = "flowQueue";
+    String WORKERTASKLOG_NAMED = "workerTaskLogQueue";
 
     QueueInterface<Execution> execution();
 
     QueueInterface<WorkerTask> workerTask();
 
     QueueInterface<WorkerTaskResult> workerTaskResult();
+
+    QueueInterface<LogEntry> logEntry();
 
     QueueInterface<Flow> flow();
 }

--- a/core/src/main/java/org/kestra/core/repositories/LogRepositoryInterface.java
+++ b/core/src/main/java/org/kestra/core/repositories/LogRepositoryInterface.java
@@ -1,0 +1,14 @@
+package org.kestra.core.repositories;
+
+import io.micronaut.data.model.Pageable;
+import org.kestra.core.models.executions.LogEntry;
+
+public interface LogRepositoryInterface {
+    ArrayListTotal<LogEntry> findByExecutionId(String id, Pageable pageable);
+
+    ArrayListTotal<LogEntry> findByExecutionIdAndTaskRunId(String executionId, String TaskId, Pageable pageable);
+
+    ArrayListTotal<LogEntry> find(String query, Pageable pageable);
+
+    LogEntry save(LogEntry flow);
+}

--- a/core/src/main/java/org/kestra/core/repositories/LogRepositoryInterface.java
+++ b/core/src/main/java/org/kestra/core/repositories/LogRepositoryInterface.java
@@ -10,5 +10,5 @@ public interface LogRepositoryInterface {
 
     ArrayListTotal<LogEntry> find(String query, Pageable pageable);
 
-    LogEntry save(LogEntry flow);
+    LogEntry save(LogEntry log);
 }

--- a/core/src/main/java/org/kestra/core/repositories/LogRepositoryInterface.java
+++ b/core/src/main/java/org/kestra/core/repositories/LogRepositoryInterface.java
@@ -2,11 +2,14 @@ package org.kestra.core.repositories;
 
 import io.micronaut.data.model.Pageable;
 import org.kestra.core.models.executions.LogEntry;
+import org.slf4j.event.Level;
+
+import java.util.List;
 
 public interface LogRepositoryInterface {
-    ArrayListTotal<LogEntry> findByExecutionId(String id, Pageable pageable);
+    List<LogEntry> findByExecutionId(String id, Level minLevel);
 
-    ArrayListTotal<LogEntry> findByExecutionIdAndTaskRunId(String executionId, String TaskId, Pageable pageable);
+    List<LogEntry> findByExecutionIdAndTaskRunId(String executionId, String TaskId, Level minLevel);
 
     ArrayListTotal<LogEntry> find(String query, Pageable pageable);
 

--- a/core/src/main/java/org/kestra/core/runners/Indexer.java
+++ b/core/src/main/java/org/kestra/core/runners/Indexer.java
@@ -4,28 +4,36 @@ import io.micronaut.context.annotation.Prototype;
 import io.micronaut.context.annotation.Requires;
 import org.kestra.core.metrics.MetricRegistry;
 import org.kestra.core.models.executions.Execution;
+import org.kestra.core.models.executions.LogEntry;
 import org.kestra.core.queues.QueueFactoryInterface;
 import org.kestra.core.queues.QueueInterface;
 import org.kestra.core.repositories.ExecutionRepositoryInterface;
+import org.kestra.core.repositories.LogRepositoryInterface;
 
 import javax.inject.Inject;
 import javax.inject.Named;
 
 @Prototype
-@Requires(beans = ExecutionRepositoryInterface.class)
+@Requires(beans = {ExecutionRepositoryInterface.class, LogRepositoryInterface.class})
 public class Indexer implements Runnable {
     private ExecutionRepositoryInterface executionRepository;
+    private LogRepositoryInterface logRepository;
     private QueueInterface<Execution> executionQueue;
+    private QueueInterface<LogEntry> logQueue;
     private MetricRegistry metricRegistry;
 
     @Inject
     public Indexer(
         @Named(QueueFactoryInterface.EXECUTION_NAMED) QueueInterface<Execution> executionQueue,
+        @Named(QueueFactoryInterface.WORKERTASKLOG_NAMED) QueueInterface<LogEntry> logQueue,
         ExecutionRepositoryInterface executionRepository,
+        LogRepositoryInterface logRepository,
         MetricRegistry metricRegistry
     ) {
         this.executionQueue = executionQueue;
+        this.logQueue = logQueue;
         this.executionRepository = executionRepository;
+        this.logRepository = logRepository;
         this.metricRegistry = metricRegistry;
     }
 
@@ -36,6 +44,14 @@ public class Indexer implements Runnable {
 
             this.metricRegistry.timer(MetricRegistry.METRIC_INDEXER_DURATION).record(() -> {
                 executionRepository.save(execution);
+            });
+        });
+
+        logQueue.receive(Indexer.class, logEntry -> {
+            this.metricRegistry.counter(MetricRegistry.METRIC_INDEXER_COUNT).increment();
+
+            this.metricRegistry.timer(MetricRegistry.METRIC_INDEXER_DURATION).record(() -> {
+                logRepository.save(logEntry);
             });
         });
     }

--- a/core/src/main/java/org/kestra/core/runners/RunContextLogger.java
+++ b/core/src/main/java/org/kestra/core/runners/RunContextLogger.java
@@ -23,9 +23,9 @@ import java.util.stream.StreamSupport;
 
 public class RunContextLogger {
     private static final int MAX_MESSAGE_LENGTH = 1024*10;
+    private final String loggerName;
     private Logger logger;
     private QueueInterface<LogEntry> logQueue;
-    private String loggerName;
     private TaskRun taskRun;
 
     @Deprecated
@@ -65,6 +65,7 @@ public class RunContextLogger {
             .collect(Collectors.toList());
     }
 
+    @SuppressWarnings("UnstableApiUsage")
     public static List<LogEntry> logEntries(ILoggingEvent event, TaskRun taskRun) {
         Throwable throwable = throwable(event);
 
@@ -127,8 +128,8 @@ public class RunContextLogger {
     }
 
     public static class ContextAppender extends AppenderBase<ILoggingEvent> {
-        private QueueInterface<LogEntry> logQueue;
-        private TaskRun taskRun;
+        private final QueueInterface<LogEntry> logQueue;
+        private final TaskRun taskRun;
 
         public ContextAppender(QueueInterface<LogEntry> logQueue, TaskRun taskRun) {
             this.logQueue = logQueue;
@@ -156,7 +157,10 @@ public class RunContextLogger {
 
         @Override
         protected void append(ILoggingEvent e) {
-            ((ch.qos.logback.classic.Logger) log).callAppenders(e);
+            var logger = ((ch.qos.logback.classic.Logger) log);
+            if (logger.isEnabledFor(e.getLevel())) {
+                ((ch.qos.logback.classic.Logger) log).callAppenders(e);
+            }
         }
     }
 }

--- a/core/src/main/java/org/kestra/core/runners/Worker.java
+++ b/core/src/main/java/org/kestra/core/runners/Worker.java
@@ -7,15 +7,13 @@ import com.google.common.hash.Hashing;
 import io.micronaut.context.ApplicationContext;
 import lombok.Getter;
 import net.jodah.failsafe.Failsafe;
-import net.jodah.failsafe.RetryPolicy;
-import org.kestra.core.models.tasks.retrys.AbstractRetry;
-import org.kestra.core.queues.QueueException;
 import org.kestra.core.metrics.MetricRegistry;
 import org.kestra.core.models.executions.TaskRunAttempt;
 import org.kestra.core.models.flows.State;
 import org.kestra.core.models.tasks.Output;
 import org.kestra.core.models.tasks.RunnableTask;
-import org.kestra.core.models.tasks.Task;
+import org.kestra.core.models.tasks.retrys.AbstractRetry;
+import org.kestra.core.queues.QueueException;
 import org.kestra.core.queues.QueueInterface;
 import org.kestra.core.serializers.JacksonMapper;
 import org.slf4j.Logger;
@@ -165,6 +163,15 @@ public class Worker implements Runnable {
         WorkerThread workerThread = new WorkerThread(logger, task, runContext);
         workerThread.start();
 
+        // emit attempts
+        this.workerTaskResultQueue.emit(new WorkerTaskResult(workerTask
+            .withTaskRun(
+                workerTask.getTaskRun()
+                    .withAttempts(this.addAttempt(workerTask, builder.build()))
+            )
+        ));
+
+        // run it
         State.Type state;
         try {
             workerThread.join();
@@ -182,6 +189,7 @@ public class Worker implements Runnable {
             .build()
             .withState(state);
 
+        // logs
         if (workerThread.getTaskOutput() != null) {
             logger.debug("Outputs\n{}", JacksonMapper.log(workerThread.getTaskOutput()));
         }
@@ -190,18 +198,22 @@ public class Worker implements Runnable {
             logger.trace("Metrics\n{}", JacksonMapper.log(runContext.metrics()));
         }
 
-        ImmutableList<TaskRunAttempt> attempts = ImmutableList.<TaskRunAttempt>builder()
-            .addAll(workerTask.getTaskRun().getAttempts() == null ? new ArrayList<>() : workerTask.getTaskRun().getAttempts())
-            .add(taskRunAttempt)
-            .build();
-
         // save outputs
+        List<TaskRunAttempt> attempts = this.addAttempt(workerTask, taskRunAttempt);
+
         return workerTask
             .withTaskRun(
                 workerTask.getTaskRun()
                     .withAttempts(attempts)
                     .withOutputs(workerThread.getTaskOutput() != null ? workerThread.getTaskOutput().toMap() : ImmutableMap.of())
             );
+    }
+
+    public List<TaskRunAttempt> addAttempt(WorkerTask workerTask, TaskRunAttempt taskRunAttempt) {
+        return ImmutableList.<TaskRunAttempt>builder()
+            .addAll(workerTask.getTaskRun().getAttempts() == null ? new ArrayList<>() : workerTask.getTaskRun().getAttempts())
+            .add(taskRunAttempt)
+            .build();
     }
 
     @SuppressWarnings("UnstableApiUsage")

--- a/core/src/main/java/org/kestra/core/runners/Worker.java
+++ b/core/src/main/java/org/kestra/core/runners/Worker.java
@@ -153,7 +153,7 @@ public class Worker implements Runnable {
             .getRunContext()
             .forWorker(this.applicationContext, workerTask.getTaskRun());
 
-        Logger logger = runContext.logger(workerTask.getTask().getClass());
+        Logger logger = runContext.logger();
 
         TaskRunAttempt.TaskRunAttemptBuilder builder = TaskRunAttempt.builder()
             .state(new State());
@@ -178,7 +178,6 @@ public class Worker implements Runnable {
 
         // attempt
         TaskRunAttempt taskRunAttempt = builder
-            .logs(runContext.logs())
             .metrics(runContext.metrics())
             .build()
             .withState(state);

--- a/core/src/main/java/org/kestra/core/services/ExecutionService.java
+++ b/core/src/main/java/org/kestra/core/services/ExecutionService.java
@@ -1,6 +1,7 @@
 package org.kestra.core.services;
 
 import com.devskiller.friendly_id.FriendlyId;
+import io.micronaut.context.ApplicationContext;
 import io.micronaut.core.util.StringUtils;
 import org.kestra.core.models.executions.Execution;
 import org.kestra.core.models.executions.TaskRun;
@@ -27,6 +28,9 @@ import static org.kestra.core.utils.Rethrow.throwPredicate;
  */
 @Singleton
 public class ExecutionService {
+    @Inject
+    ApplicationContext applicationContext;
+
     @Inject
     private FlowRepositoryInterface flowRepositoryInterface;
 

--- a/core/src/main/java/org/kestra/core/tasks/debugs/Echo.java
+++ b/core/src/main/java/org/kestra/core/tasks/debugs/Echo.java
@@ -22,7 +22,7 @@ public class Echo extends Task implements RunnableTask<VoidOutput> {
 
     @Override
     public VoidOutput run(RunContext runContext) throws Exception {
-        Logger logger = runContext.logger(Echo.class);
+        Logger logger = runContext.logger();
 
         String render = runContext.render(this.format);
         

--- a/core/src/main/java/org/kestra/core/tasks/debugs/Return.java
+++ b/core/src/main/java/org/kestra/core/tasks/debugs/Return.java
@@ -37,7 +37,7 @@ public class Return extends Task implements RunnableTask<Return.Output> {
     public Return.Output run(RunContext runContext) throws Exception {
         long start = System.nanoTime();
 
-        Logger logger = runContext.logger(this.getClass());
+        Logger logger = runContext.logger();
 
         String render = runContext.render(format);
         logger.debug(render);

--- a/core/src/main/java/org/kestra/core/tasks/flows/Flow.java
+++ b/core/src/main/java/org/kestra/core/tasks/flows/Flow.java
@@ -65,7 +65,7 @@ public class Flow extends Task implements RunnableTask<Flow.Output> {
     @SuppressWarnings("unchecked")
     @Override
     public Flow.Output run(RunContext runContext) throws Exception {
-        Logger logger = runContext.logger(this.getClass());
+        Logger logger = runContext.logger();
         RunnerUtils runnerUtils = runContext.getApplicationContext().getBean(RunnerUtils.class);
         FlowRepositoryInterface flowRepository = runContext.getApplicationContext().getBean(FlowRepositoryInterface.class);
         QueueInterface<Execution> executionQueue = (QueueInterface<Execution>) runContext.getApplicationContext().getBean(

--- a/core/src/main/java/org/kestra/core/tasks/scripts/Bash.java
+++ b/core/src/main/java/org/kestra/core/tasks/scripts/Bash.java
@@ -103,7 +103,7 @@ public class Bash extends Task implements RunnableTask<Bash.Output> {
 
     @Override
     public Bash.Output run(RunContext runContext) throws Exception {
-        Logger logger = runContext.logger(this.getClass());
+        Logger logger = runContext.logger();
 
         // final command
         List<String> renderer = new ArrayList<>();

--- a/core/src/main/java/org/kestra/core/utils/TestsUtils.java
+++ b/core/src/main/java/org/kestra/core/utils/TestsUtils.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Charsets;
 import com.google.common.io.Files;
 import org.kestra.core.models.executions.Execution;
+import org.kestra.core.models.executions.LogEntry;
 import org.kestra.core.models.executions.TaskRun;
 import org.kestra.core.models.flows.Flow;
 import org.kestra.core.models.flows.State;
@@ -19,8 +20,10 @@ import java.io.File;
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.stream.Collectors;
 
 abstract public class TestsUtils {
     private static final ObjectMapper mapper = JacksonMapper.ofYaml();
@@ -40,6 +43,13 @@ abstract public class TestsUtils {
 
     public static void loads(LocalFlowRepositoryLoader repositoryLoader, URL url) throws IOException, URISyntaxException {
         repositoryLoader.load(url);
+    }
+
+    public static List<LogEntry> filterLogs(List<LogEntry> logs, TaskRun taskRun) {
+        return logs
+            .stream()
+            .filter(r -> r.getTaskRunId().equals(taskRun.getId()))
+            .collect(Collectors.toList());
     }
 
     public static Flow mockFlow() {

--- a/core/src/test/java/org/kestra/core/runners/RunContextTest.java
+++ b/core/src/test/java/org/kestra/core/runners/RunContextTest.java
@@ -3,14 +3,25 @@ package org.kestra.core.runners;
 import org.exparity.hamcrest.date.ZonedDateTimeMatchers;
 import org.junit.jupiter.api.Test;
 import org.kestra.core.models.executions.Execution;
+import org.kestra.core.models.executions.LogEntry;
+import org.kestra.core.models.executions.TaskRun;
 import org.kestra.core.models.executions.TaskRunAttempt;
 import org.kestra.core.models.executions.metrics.Counter;
 import org.kestra.core.models.executions.metrics.Timer;
+import org.kestra.core.queues.QueueFactoryInterface;
+import org.kestra.core.queues.QueueInterface;
+import org.kestra.core.utils.TestsUtils;
 import org.slf4j.event.Level;
 
 import java.time.ZonedDateTime;
 import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.TimeoutException;
+import java.util.stream.Collectors;
+
+import javax.inject.Inject;
+import javax.inject.Named;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasSize;
@@ -18,23 +29,35 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.number.OrderingComparison.greaterThan;
 
 class RunContextTest extends AbstractMemoryRunnerTest {
+    @Inject
+    @Named(QueueFactoryInterface.WORKERTASKLOG_NAMED)
+    QueueInterface<LogEntry> workerTaskLogQueue;
+
     @Test
     void logs() throws TimeoutException {
+        List<LogEntry> logs = new ArrayList<>();
+        List<LogEntry> filters;
+        workerTaskLogQueue.receive(logs::add);
+
         Execution execution = runnerUtils.runOne("org.kestra.tests", "logs");
 
         assertThat(execution.getTaskRunList(), hasSize(3));
 
-        assertThat(execution.getTaskRunList().get(0).getAttempts().get(0).getLogs(), hasSize(1));
-        assertThat(execution.getTaskRunList().get(0).getAttempts().get(0).getLogs().get(0).getLevel(), is(Level.TRACE));
-        assertThat(execution.getTaskRunList().get(0).getAttempts().get(0).getLogs().get(0).getMessage(), is("first t1"));
+        filters = TestsUtils.filterLogs(logs, execution.getTaskRunList().get(0));
+        assertThat(filters, hasSize(1));
+        assertThat(filters.get(0).getLevel(), is(Level.TRACE));
+        assertThat(filters.get(0).getMessage(), is("first t1"));
 
-        assertThat(execution.getTaskRunList().get(1).getAttempts().get(0).getLogs(), hasSize(1));
-        assertThat(execution.getTaskRunList().get(1).getAttempts().get(0).getLogs().get(0).getLevel(), is(Level.WARN));
-        assertThat(execution.getTaskRunList().get(1).getAttempts().get(0).getLogs().get(0).getMessage(), is("second org.kestra.core.tasks.debugs.Echo"));
+        filters = TestsUtils.filterLogs(logs, execution.getTaskRunList().get(1));
+        assertThat(filters, hasSize(1));
+        assertThat(filters.get(0).getLevel(), is(Level.WARN));
+        assertThat(filters.get(0).getMessage(), is("second org.kestra.core.tasks.debugs.Echo"));
 
-        assertThat(execution.getTaskRunList().get(2).getAttempts().get(0).getLogs(), hasSize(1));
-        assertThat(execution.getTaskRunList().get(2).getAttempts().get(0).getLogs().get(0).getLevel(), is(Level.ERROR));
-        assertThat(execution.getTaskRunList().get(2).getAttempts().get(0).getLogs().get(0).getMessage(), is("third logs"));
+
+        filters = TestsUtils.filterLogs(logs, execution.getTaskRunList().get(2));
+        assertThat(filters, hasSize(1));
+        assertThat(filters.get(0).getLevel(), is(Level.ERROR));
+        assertThat(filters.get(0).getMessage(), is("third logs"));
     }
 
     @Test

--- a/repository-elasticsearch/src/main/java/org/kestra/repository/elasticsearch/ElasticSearchLogRepository.java
+++ b/repository-elasticsearch/src/main/java/org/kestra/repository/elasticsearch/ElasticSearchLogRepository.java
@@ -58,9 +58,9 @@ public class ElasticSearchLogRepository extends AbstractElasticSearchRepository<
     }
 
     @Override
-    public LogEntry save(LogEntry logEntry) {
-        this.putRequest(INDEX_NAME, FriendlyId.createFriendlyId(), logEntry);
+    public LogEntry save(LogEntry log) {
+        this.putRequest(INDEX_NAME, FriendlyId.createFriendlyId(), log);
 
-        return logEntry;
+        return log;
     }
 }

--- a/repository-elasticsearch/src/main/java/org/kestra/repository/elasticsearch/ElasticSearchLogRepository.java
+++ b/repository-elasticsearch/src/main/java/org/kestra/repository/elasticsearch/ElasticSearchLogRepository.java
@@ -1,0 +1,66 @@
+package org.kestra.repository.elasticsearch;
+
+import com.devskiller.friendly_id.FriendlyId;
+import io.micronaut.data.model.Pageable;
+import org.elasticsearch.client.RestHighLevelClient;
+import org.elasticsearch.index.query.BoolQueryBuilder;
+import org.elasticsearch.index.query.QueryBuilders;
+import org.elasticsearch.search.builder.SearchSourceBuilder;
+import org.kestra.core.models.executions.LogEntry;
+import org.kestra.core.models.validations.ModelValidator;
+import org.kestra.core.repositories.ArrayListTotal;
+import org.kestra.core.repositories.LogRepositoryInterface;
+import org.kestra.repository.elasticsearch.configs.IndicesConfig;
+
+import java.util.List;
+import java.util.Optional;
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
+@Singleton
+@ElasticSearchRepositoryEnabled
+public class ElasticSearchLogRepository extends AbstractElasticSearchRepository<LogEntry> implements LogRepositoryInterface {
+    private static final String INDEX_NAME = "logs";
+
+    @Inject
+    public ElasticSearchLogRepository(
+        RestHighLevelClient client,
+        List<IndicesConfig> indicesConfigs,
+        ModelValidator modelValidator
+    ) {
+        super(client, indicesConfigs, modelValidator, LogEntry.class);
+    }
+
+    @Override
+    public ArrayListTotal<LogEntry> find(String query, Pageable pageable) {
+        return super.findQueryString(INDEX_NAME, query, pageable);
+    }
+
+    @Override
+    public ArrayListTotal<LogEntry> findByExecutionId(String id, Pageable pageable) {
+        BoolQueryBuilder bool = QueryBuilders.boolQuery()
+            .must(QueryBuilders.termQuery("executionId", id));
+
+        SearchSourceBuilder sourceBuilder = this.searchSource(bool, Optional.empty(), pageable);
+
+        return this.query(INDEX_NAME, sourceBuilder);
+    }
+
+    @Override
+    public ArrayListTotal<LogEntry> findByExecutionIdAndTaskRunId(String executionId, String taskRunId, Pageable pageable) {
+        BoolQueryBuilder bool = QueryBuilders.boolQuery()
+            .must(QueryBuilders.termQuery("executionId", executionId))
+            .must(QueryBuilders.termQuery("taskRunId", taskRunId));
+
+        SearchSourceBuilder sourceBuilder = this.searchSource(bool, Optional.empty(), pageable);
+
+        return this.query(INDEX_NAME, sourceBuilder);
+    }
+
+    @Override
+    public LogEntry save(LogEntry logEntry) {
+        this.putRequest(INDEX_NAME, FriendlyId.createFriendlyId(), logEntry);
+
+        return logEntry;
+    }
+}

--- a/repository-elasticsearch/src/main/java/org/kestra/repository/elasticsearch/ElasticSearchLogRepository.java
+++ b/repository-elasticsearch/src/main/java/org/kestra/repository/elasticsearch/ElasticSearchLogRepository.java
@@ -5,16 +5,18 @@ import io.micronaut.data.model.Pageable;
 import org.elasticsearch.client.RestHighLevelClient;
 import org.elasticsearch.index.query.BoolQueryBuilder;
 import org.elasticsearch.index.query.QueryBuilders;
+import org.elasticsearch.index.query.TermsQueryBuilder;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
+import org.elasticsearch.search.sort.SortOrder;
 import org.kestra.core.models.executions.LogEntry;
 import org.kestra.core.models.validations.ModelValidator;
 import org.kestra.core.repositories.ArrayListTotal;
 import org.kestra.core.repositories.LogRepositoryInterface;
 import org.kestra.core.utils.ThreadMainFactoryBuilder;
 import org.kestra.repository.elasticsearch.configs.IndicesConfig;
+import org.slf4j.event.Level;
 
 import java.util.List;
-import java.util.Optional;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 
@@ -39,24 +41,36 @@ public class ElasticSearchLogRepository extends AbstractElasticSearchRepository<
     }
 
     @Override
-    public ArrayListTotal<LogEntry> findByExecutionId(String id, Pageable pageable) {
-        BoolQueryBuilder bool = QueryBuilders.boolQuery()
+    public List<LogEntry> findByExecutionId(String id, Level minLevel) {
+        BoolQueryBuilder bool = this.defaultFilter()
             .must(QueryBuilders.termQuery("executionId", id));
 
-        SearchSourceBuilder sourceBuilder = this.searchSource(bool, Optional.empty(), pageable);
+        if (minLevel != null) {
+            bool.must(minLevel(minLevel));
+        }
 
-        return this.query(INDEX_NAME, sourceBuilder);
+        SearchSourceBuilder sourceBuilder = new SearchSourceBuilder()
+            .query(bool)
+            .sort("timestamp", SortOrder.ASC);
+
+        return this.scroll(INDEX_NAME, sourceBuilder);
     }
 
     @Override
-    public ArrayListTotal<LogEntry> findByExecutionIdAndTaskRunId(String executionId, String taskRunId, Pageable pageable) {
-        BoolQueryBuilder bool = QueryBuilders.boolQuery()
+    public List<LogEntry> findByExecutionIdAndTaskRunId(String executionId, String taskRunId, Level minLevel) {
+        BoolQueryBuilder bool = this.defaultFilter()
             .must(QueryBuilders.termQuery("executionId", executionId))
             .must(QueryBuilders.termQuery("taskRunId", taskRunId));
 
-        SearchSourceBuilder sourceBuilder = this.searchSource(bool, Optional.empty(), pageable);
+        if (minLevel != null) {
+            bool.must(minLevel(minLevel));
+        }
 
-        return this.query(INDEX_NAME, sourceBuilder);
+        SearchSourceBuilder sourceBuilder = new SearchSourceBuilder()
+            .query(bool)
+            .sort("timestamp", SortOrder.ASC);
+
+        return this.scroll(INDEX_NAME, sourceBuilder);
     }
 
     @Override
@@ -64,5 +78,9 @@ public class ElasticSearchLogRepository extends AbstractElasticSearchRepository<
         this.putRequest(INDEX_NAME, FriendlyId.createFriendlyId(), log);
 
         return log;
+    }
+
+    private TermsQueryBuilder minLevel(Level minLevel) {
+        return QueryBuilders.termsQuery("level", LogEntry.findLevelsByMin(minLevel));
     }
 }

--- a/repository-elasticsearch/src/main/java/org/kestra/repository/elasticsearch/ElasticSearchLogRepository.java
+++ b/repository-elasticsearch/src/main/java/org/kestra/repository/elasticsearch/ElasticSearchLogRepository.java
@@ -10,6 +10,7 @@ import org.kestra.core.models.executions.LogEntry;
 import org.kestra.core.models.validations.ModelValidator;
 import org.kestra.core.repositories.ArrayListTotal;
 import org.kestra.core.repositories.LogRepositoryInterface;
+import org.kestra.core.utils.ThreadMainFactoryBuilder;
 import org.kestra.repository.elasticsearch.configs.IndicesConfig;
 
 import java.util.List;
@@ -26,9 +27,10 @@ public class ElasticSearchLogRepository extends AbstractElasticSearchRepository<
     public ElasticSearchLogRepository(
         RestHighLevelClient client,
         List<IndicesConfig> indicesConfigs,
-        ModelValidator modelValidator
+        ModelValidator modelValidator,
+        ThreadMainFactoryBuilder threadFactoryBuilder
     ) {
-        super(client, indicesConfigs, modelValidator, LogEntry.class);
+        super(client, indicesConfigs, modelValidator, threadFactoryBuilder, LogEntry.class);
     }
 
     @Override

--- a/repository-elasticsearch/src/main/resources/mappings/log.yml
+++ b/repository-elasticsearch/src/main/resources/mappings/log.yml
@@ -1,0 +1,22 @@
+dynamic: false
+properties:
+  namespace:
+    type: keyword
+  flowId:
+    type: keyword
+  taskId:
+    type: keyword
+  executionId:
+    type: keyword
+  taskRunId:
+    type: keyword
+  attemptNumber:
+    type: integer
+  level:
+    type: keyword
+  message:
+    type: text
+  thread:
+    type: text
+  timestamp:
+    type: date

--- a/repository-elasticsearch/src/main/resources/mappings/log.yml
+++ b/repository-elasticsearch/src/main/resources/mappings/log.yml
@@ -20,3 +20,5 @@ properties:
     type: text
   timestamp:
     type: date
+  deleted:
+    type: boolean

--- a/repository-elasticsearch/src/test/java/org/kestra/repository/elasticsearch/ExecutionFixture.java
+++ b/repository-elasticsearch/src/test/java/org/kestra/repository/elasticsearch/ExecutionFixture.java
@@ -30,10 +30,6 @@ class ExecutionFixture {
                 .state(new State())
                 .attempts(Collections.singletonList(
                     TaskRunAttempt.builder()
-                        .logs(Collections.singletonList(LogEntry.builder()
-                            .level(Level.TRACE)
-                            .message("message")
-                            .build()))
                         .metrics(Collections.singletonList(Counter.of("counter", 1)))
                         .build()
                 ))
@@ -59,10 +55,6 @@ class ExecutionFixture {
                 .state(new State())
                 .attempts(Collections.singletonList(
                     TaskRunAttempt.builder()
-                        .logs(Collections.singletonList(LogEntry.builder()
-                            .level(Level.TRACE)
-                            .message("message")
-                            .build()))
                         .metrics(Collections.singletonList(Timer.of("test", Duration.ofMillis(150))))
                         .build()
                 ))

--- a/repository-elasticsearch/src/test/resources/application.yml
+++ b/repository-elasticsearch/src/test/resources/application.yml
@@ -30,9 +30,14 @@ kestra:
         mapping-file: execution
         settings: *settings
 
-
       triggers:
         index: "kestra_triggers"
         cls: org.kestra.core.models.triggers.Trigger
         mapping-file: trigger
+        settings: *settings
+
+      logs:
+        index: "kestra_logs"
+        cls: org.kestra.core.models.executions.LogEntry
+        mapping-file: log
         settings: *settings

--- a/repository-memory/src/main/java/org/kestra/repository/memory/MemoryExecutionRepository.java
+++ b/repository-memory/src/main/java/org/kestra/repository/memory/MemoryExecutionRepository.java
@@ -13,7 +13,6 @@ import javax.inject.Singleton;
 import java.util.*;
 import java.util.stream.Collectors;
 
-
 @Singleton
 @MemoryRepositoryEnabled
 public class MemoryExecutionRepository implements ExecutionRepositoryInterface {
@@ -59,6 +58,6 @@ public class MemoryExecutionRepository implements ExecutionRepositoryInterface {
 
     @Override
     public Map<String, Stats> findLast24hDurationStats(String query, Pageable pageable) {
-        return null;
+        throw new UnsupportedOperationException();
     }
 }

--- a/repository-memory/src/main/java/org/kestra/repository/memory/MemoryLogRepository.java
+++ b/repository-memory/src/main/java/org/kestra/repository/memory/MemoryLogRepository.java
@@ -1,0 +1,38 @@
+package org.kestra.repository.memory;
+
+import io.micronaut.data.model.Pageable;
+import org.kestra.core.models.executions.LogEntry;
+import org.kestra.core.repositories.ArrayListTotal;
+import org.kestra.core.repositories.LogRepositoryInterface;
+
+import java.util.ArrayList;
+import java.util.List;
+import javax.inject.Singleton;
+
+@Singleton
+@MemoryRepositoryEnabled
+public class MemoryLogRepository implements LogRepositoryInterface {
+    private List<LogEntry> logs = new ArrayList<>();
+
+    @Override
+    public ArrayListTotal<LogEntry> findByExecutionId(String id, Pageable pageable) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public ArrayListTotal<LogEntry> findByExecutionIdAndTaskRunId(String executionId, String TaskId, Pageable pageable) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public ArrayListTotal<LogEntry> find(String query, Pageable pageable) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public LogEntry save(LogEntry log) {
+        logs.add(log);
+
+        return log;
+    }
+}

--- a/repository-memory/src/main/java/org/kestra/repository/memory/MemoryLogRepository.java
+++ b/repository-memory/src/main/java/org/kestra/repository/memory/MemoryLogRepository.java
@@ -4,6 +4,7 @@ import io.micronaut.data.model.Pageable;
 import org.kestra.core.models.executions.LogEntry;
 import org.kestra.core.repositories.ArrayListTotal;
 import org.kestra.core.repositories.LogRepositoryInterface;
+import org.slf4j.event.Level;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -12,15 +13,15 @@ import javax.inject.Singleton;
 @Singleton
 @MemoryRepositoryEnabled
 public class MemoryLogRepository implements LogRepositoryInterface {
-    private List<LogEntry> logs = new ArrayList<>();
+    private final List<LogEntry> logs = new ArrayList<>();
 
     @Override
-    public ArrayListTotal<LogEntry> findByExecutionId(String id, Pageable pageable) {
+    public List<LogEntry> findByExecutionId(String id, Level minLevel) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public ArrayListTotal<LogEntry> findByExecutionIdAndTaskRunId(String executionId, String TaskId, Pageable pageable) {
+    public List<LogEntry> findByExecutionIdAndTaskRunId(String executionId, String TaskId, Level minLevel) {
         throw new UnsupportedOperationException();
     }
 

--- a/runner-kafka/src/main/java/org/kestra/runner/kafka/KafkaQueue.java
+++ b/runner-kafka/src/main/java/org/kestra/runner/kafka/KafkaQueue.java
@@ -12,6 +12,7 @@ import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.TopicPartition;
 import org.kestra.core.models.executions.Execution;
+import org.kestra.core.models.executions.LogEntry;
 import org.kestra.core.models.flows.Flow;
 import org.kestra.core.queues.QueueException;
 import org.kestra.core.queues.QueueInterface;
@@ -76,6 +77,8 @@ public class KafkaQueue<T> implements QueueInterface<T>, AutoCloseable {
             return ((WorkerTask) object).getTaskRun().getId();
         } else if (this.cls == WorkerTaskResult.class) {
             return ((WorkerTaskResult) object).getTaskRun().getId();
+        } else if (this.cls == LogEntry.class) {
+            return null;
         } else if (this.cls == Flow.class) {
             return ((Flow) object).uid();
         } else {
@@ -145,6 +148,9 @@ public class KafkaQueue<T> implements QueueInterface<T>, AutoCloseable {
                     }
                 });
             }
+
+            kafkaConsumers.remove(kafkaConsumer);
+            kafkaConsumer.close();
         });
 
         return () -> {

--- a/runner-kafka/src/main/java/org/kestra/runner/kafka/KafkaQueueFactory.java
+++ b/runner-kafka/src/main/java/org/kestra/runner/kafka/KafkaQueueFactory.java
@@ -48,6 +48,7 @@ public class KafkaQueueFactory implements QueueFactoryInterface {
         return new KafkaQueue<>(LogEntry.class, applicationContext);
     }
 
+    @Override
     @Singleton
     @Named(QueueFactoryInterface.FLOW_NAMED)
     public QueueInterface<Flow> flow() {

--- a/runner-kafka/src/main/java/org/kestra/runner/kafka/KafkaQueueFactory.java
+++ b/runner-kafka/src/main/java/org/kestra/runner/kafka/KafkaQueueFactory.java
@@ -4,6 +4,7 @@ import io.micronaut.context.ApplicationContext;
 import io.micronaut.context.annotation.Factory;
 import org.kestra.core.models.executions.Execution;
 import org.kestra.core.models.flows.Flow;
+import org.kestra.core.models.executions.LogEntry;
 import org.kestra.core.queues.QueueFactoryInterface;
 import org.kestra.core.queues.QueueInterface;
 import org.kestra.core.runners.WorkerTask;
@@ -19,22 +20,32 @@ public class KafkaQueueFactory implements QueueFactoryInterface {
     @Inject
     ApplicationContext applicationContext;
 
+    @Override
     @Singleton
     @Named(QueueFactoryInterface.EXECUTION_NAMED)
     public QueueInterface<Execution> execution() {
         return new KafkaQueue<>(Execution.class, applicationContext);
     }
 
+    @Override
     @Singleton
     @Named(QueueFactoryInterface.WORKERTASK_NAMED)
     public QueueInterface<WorkerTask> workerTask() {
         return new KafkaQueue<>(WorkerTask.class, applicationContext);
     }
 
+    @Override
     @Singleton
     @Named(QueueFactoryInterface.WORKERTASKRESULT_NAMED)
     public QueueInterface<WorkerTaskResult> workerTaskResult() {
         return new KafkaQueue<>(WorkerTaskResult.class, applicationContext);
+    }
+
+    @Override
+    @Singleton
+    @Named(QueueFactoryInterface.WORKERTASKLOG_NAMED)
+    public QueueInterface<LogEntry> logEntry() {
+        return new KafkaQueue<>(LogEntry.class, applicationContext);
     }
 
     @Singleton

--- a/runner-kafka/src/test/resources/application.yml
+++ b/runner-kafka/src/test/resources/application.yml
@@ -28,12 +28,16 @@ kestra:
       producer:
         properties:
           acks: "all"
+          compression.type: "lz4"
+          max.request.size: "10485760"
 
       stream:
         properties:
           processing.guarantee: "exactly_once"
           acks: "all"
           state.dir: "/tmp/"
+          compression.type: "lz4"
+          max.request.size: "10485760"
 
     topics:
       execution:

--- a/runner-kafka/src/test/resources/application.yml
+++ b/runner-kafka/src/test/resources/application.yml
@@ -67,3 +67,7 @@ kestra:
         cls: org.kestra.core.runners.WorkerTaskResult
         properties:
           cleanup.policy: "delete,compact"
+
+      logentry:
+        cls: org.kestra.core.models.executions.LogEntry
+        name: "kestra_logs"

--- a/runner-memory/src/main/java/org/kestra/runner/memory/MemoryExecutor.java
+++ b/runner-memory/src/main/java/org/kestra/runner/memory/MemoryExecutor.java
@@ -4,6 +4,7 @@ import io.micronaut.context.annotation.Prototype;
 import lombok.extern.slf4j.Slf4j;
 import org.kestra.core.metrics.MetricRegistry;
 import org.kestra.core.models.executions.Execution;
+import org.kestra.core.models.executions.LogEntry;
 import org.kestra.core.models.executions.TaskRun;
 import org.kestra.core.models.flows.Flow;
 import org.kestra.core.models.flows.State;
@@ -28,6 +29,7 @@ public class MemoryExecutor extends AbstractExecutor {
     private final QueueInterface<Execution> executionQueue;
     private final QueueInterface<WorkerTask> workerTaskQueue;
     private final QueueInterface<WorkerTaskResult> workerTaskResultQueue;
+    private final QueueInterface<LogEntry> logQueue;
     private static final ConcurrentHashMap<String, ExecutionState> executions = new ConcurrentHashMap<>();
 
     public MemoryExecutor(
@@ -36,6 +38,7 @@ public class MemoryExecutor extends AbstractExecutor {
         @Named(QueueFactoryInterface.EXECUTION_NAMED) QueueInterface<Execution> executionQueue,
         @Named(QueueFactoryInterface.WORKERTASK_NAMED) QueueInterface<WorkerTask> workerTaskQueue,
         @Named(QueueFactoryInterface.WORKERTASKRESULT_NAMED) QueueInterface<WorkerTaskResult> workerTaskResultQueue,
+        @Named(QueueFactoryInterface.WORKERTASKLOG_NAMED) QueueInterface<LogEntry> logQueue,
         MetricRegistry metricRegistry
     ) {
         super(runContextFactory, metricRegistry);
@@ -43,6 +46,7 @@ public class MemoryExecutor extends AbstractExecutor {
         this.executionQueue = executionQueue;
         this.workerTaskQueue = workerTaskQueue;
         this.workerTaskResultQueue = workerTaskResultQueue;
+        this.logQueue = logQueue;
     }
 
     @Override
@@ -100,7 +104,7 @@ public class MemoryExecutor extends AbstractExecutor {
                 }
             } catch (Exception e) {
                 log.error("Failed from executor with {}", e.getMessage(), e);
-                this.toExecution(execution.failedExecutionFromExecutor(e));
+                this.toExecution(execution.failedExecutionFromExecutor(e, logQueue));
                 return;
             }
 

--- a/runner-memory/src/main/java/org/kestra/runner/memory/MemoryExecutor.java
+++ b/runner-memory/src/main/java/org/kestra/runner/memory/MemoryExecutor.java
@@ -114,6 +114,19 @@ public class MemoryExecutor extends AbstractExecutor {
         }
     }
 
+    private void handleFailedExecutionFromExecutor(Execution execution, Exception e) {
+        Execution.FailedExecutionWithLog failedExecutionWithLog = execution.failedExecutionFromExecutor(e);
+        try {
+            log.error("Failed from executor with {}", e.getMessage(), e);
+
+            failedExecutionWithLog.getLogs().forEach(logQueue::emit);
+
+            this.toExecution(failedExecutionWithLog.getExecution());
+        } catch (Exception ex) {
+            log.error("Failed to produce {}", e.getMessage(), ex);
+        }
+    }
+
     private ExecutionState saveExecution(Execution execution) {
         ExecutionState queued;
         queued = executions.compute(execution.getId(), (s, executionState) -> {

--- a/runner-memory/src/main/java/org/kestra/runner/memory/MemoryExecutor.java
+++ b/runner-memory/src/main/java/org/kestra/runner/memory/MemoryExecutor.java
@@ -103,8 +103,7 @@ public class MemoryExecutor extends AbstractExecutor {
                     return;
                 }
             } catch (Exception e) {
-                log.error("Failed from executor with {}", e.getMessage(), e);
-                this.toExecution(execution.failedExecutionFromExecutor(e, logQueue));
+                handleFailedExecutionFromExecutor(execution, e);
                 return;
             }
 

--- a/runner-memory/src/main/java/org/kestra/runner/memory/MemoryQueueFactory.java
+++ b/runner-memory/src/main/java/org/kestra/runner/memory/MemoryQueueFactory.java
@@ -47,6 +47,7 @@ public class MemoryQueueFactory implements QueueFactoryInterface {
         return new MemoryQueue<>(LogEntry.class, applicationContext);
     }
 
+    @Override
     @Singleton
     @Named(QueueFactoryInterface.FLOW_NAMED)
     public QueueInterface<Flow> flow() {

--- a/runner-memory/src/main/java/org/kestra/runner/memory/MemoryQueueFactory.java
+++ b/runner-memory/src/main/java/org/kestra/runner/memory/MemoryQueueFactory.java
@@ -3,6 +3,7 @@ package org.kestra.runner.memory;
 import io.micronaut.context.ApplicationContext;
 import io.micronaut.context.annotation.Factory;
 import org.kestra.core.models.executions.Execution;
+import org.kestra.core.models.executions.LogEntry;
 import org.kestra.core.models.flows.Flow;
 import org.kestra.core.queues.QueueFactoryInterface;
 import org.kestra.core.queues.QueueInterface;
@@ -18,22 +19,32 @@ public class MemoryQueueFactory implements QueueFactoryInterface {
     @Inject
     ApplicationContext applicationContext;
 
+    @Override
     @Singleton
     @Named(QueueFactoryInterface.EXECUTION_NAMED)
     public QueueInterface<Execution> execution() {
         return new MemoryQueue<>(Execution.class, applicationContext);
     }
 
+    @Override
     @Singleton
     @Named(QueueFactoryInterface.WORKERTASK_NAMED)
     public QueueInterface<WorkerTask> workerTask() {
         return new MemoryQueue<>(WorkerTask.class, applicationContext);
     }
 
+    @Override
     @Singleton
     @Named(QueueFactoryInterface.WORKERTASKRESULT_NAMED)
     public QueueInterface<WorkerTaskResult> workerTaskResult() {
         return new MemoryQueue<>(WorkerTaskResult.class, applicationContext);
+    }
+
+    @Override
+    @Singleton
+    @Named(QueueFactoryInterface.WORKERTASKLOG_NAMED)
+    public QueueInterface<LogEntry> logEntry() {
+        return new MemoryQueue<>(LogEntry.class, applicationContext);
     }
 
     @Singleton

--- a/ui/src/components/executions/Gantt.vue
+++ b/ui/src/components/executions/Gantt.vue
@@ -33,8 +33,8 @@
                 </div>
                 <hr />
             </b-col>
-            <b-col v-if="hasTaskLog && task.id === taskItem.id" md="12">
-                <log-list />
+            <b-col v-if="task && task.id === taskItem.id" md="12">
+                <log-list :task-run-id="task.id" level="TRACE"/>
                 <br />
             </b-col>
         </b-row>

--- a/ui/src/components/executions/LogLine.vue
+++ b/ui/src/components/executions/LogLine.vue
@@ -27,9 +27,10 @@ export default {
                 TRACE: "badge-info",
                 DEBUG: "badge-secondary",
                 INFO: "badge-primary",
-                WARNING: "badge-warning",
+                WARN: "badge-warning",
                 ERROR: "badge-danger",
-                CRITICAL: "badge-danger font-weight-bold"
+                CRITICAL: "badge-danger font-weight-bold",
+        TRACE: "badge-dark"
             }[this.log.level];
         },
         levels() {

--- a/ui/src/components/executions/LogLine.vue
+++ b/ui/src/components/executions/LogLine.vue
@@ -1,7 +1,7 @@
 <template>
     <div class="line" v-if="filtered">
         <span :class="levelClass" class="badge">{{log.level.padEnd(9)}}</span>
-        <span class="badge bg-light text-dark">{{log.timestamp}}</span>
+        <span class="badge bg-light text-dark">{{log.timestamp  | date('YYYY/MM/DD HH:mm:ss') }}</span>
         <span class="message">{{log.message}}</span>
     </div>
 </template>
@@ -18,7 +18,6 @@ export default {
         },
         level: {
             type: String,
-            default: "ALL"
         }
     },
     computed: {
@@ -29,53 +28,12 @@ export default {
                 INFO: "badge-primary",
                 WARN: "badge-warning",
                 ERROR: "badge-danger",
-                CRITICAL: "badge-danger font-weight-bold",
-        TRACE: "badge-dark"
+                CRITICAL: "badge-danger font-weight-bold"
             }[this.log.level];
         },
-        levels() {
-            return {
-                all: new Set([
-                    "all",
-                    "critical",
-                    "error",
-                    "warning",
-                    "info",
-                    "debug",
-                    "trace"
-                ]),
-                critical: new Set(["all", "critical"]),
-                error: new Set(["all", "critical", "error"]),
-                warning: new Set(["all", "critical", "error", "warning"]),
-                info: new Set(["all", "critical", "error", "warning", "info"]),
-                debug: new Set([
-                    "all",
-                    "critical",
-                    "error",
-                    "warning",
-                    "info",
-                    "debug"
-                ]),
-                trace: new Set([
-                    "all",
-                    "critical",
-                    "error",
-                    "warning",
-                    "info",
-                    "debug",
-                    "trace"
-                ])
-            };
-        },
         filtered() {
-            const level = this.level.toLowerCase();
-            const hasFilter =
-                this.log.message &&
+            return this.log.message &&
                 this.log.message.toLowerCase().includes(this.filter);
-            return (
-                this.levels[level].has(this.log.level.toLowerCase()) &&
-                hasFilter
-            );
         }
     }
 };

--- a/ui/src/components/executions/LogList.vue
+++ b/ui/src/components/executions/LogList.vue
@@ -63,12 +63,12 @@
                             </div>
                         </div>
 
-                        <!-- Log lines -->
-                        <template v-if="logs && logs[taskItem.id]">
-                            <template v-for="log in logs[taskItem.id]">
-                                <log-line :level="level" :filter="filter" :log="log" :key="log.id" />
-                            </template>
-                        </template>
+<!--                        &lt;!&ndash; Log lines &ndash;&gt;-->
+<!--                        <template v-if="logs && logs[taskItem.id]" >-->
+<!--                            <div v-for="log in logs[taskItem.id]" :key="log.id" >-->
+<!--                                <log-line :level="level" :filter="filter" :log="log"/>-->
+<!--                            </div>-->
+<!--                        </template>-->
                     </template>
                 </div>
             </template>
@@ -83,13 +83,14 @@
 </template>
 <script>
 import { mapState } from "vuex";
-import LogLine from "./LogLine";
+// import LogLine from "./LogLine";
 import Restart from "./Restart";
 import Clock from "vue-material-design-icons/Clock";
 import Eye from "vue-material-design-icons/Eye";
 import Menu from "vue-material-design-icons/Menu";
 export default {
-    components: { LogLine, Restart, Clock, Eye, Menu },
+    //components: { LogLine, Restart, Clock, Eye, Menu },
+    components: { Restart, Clock, Eye, Menu },
     props: {
         level: {
             type: String,

--- a/ui/src/components/executions/LogList.vue
+++ b/ui/src/components/executions/LogList.vue
@@ -1,87 +1,88 @@
 <template>
-  <div v-if="execution" class="log-wrapper text-white text-monospace">
-    <div v-for="taskItem in execution.taskRunList" :key="taskItem.id">
-      <template v-if="(!task || task.id === taskItem.id) && taskItem.attempts">
-        <div class="bg-dark attempt-wrapper">
-          <template v-for="(attempt, index) in taskItem.attempts">
-            <div
-              :id="`attempt-${index}-${attempt.state.startDate}`"
-              :key="`attempt-${index}-${attempt.state.startDate}`"
-            >
-              <!-- Tooltip -->
-              <b-tooltip
-                placement="top"
-                :target="`attempt-${index}-${attempt.state.startDate}`"
-                triggers="hover"
-              >
-                {{$t('from')}} : {{attempt.state.startDate | date('LLL:ss') }}
-                <br />
-                {{$t('to')}} : {{attempt.state.endDate | date('LLL:ss') }}
-                <br />
-                <br />
-                <clock />
-                {{$t('duration')}} : {{attempt.state.duration | humanizeDuration}}
-              </b-tooltip>
+    <div v-if="execution" class="log-wrapper text-white text-monospace">
+        <div v-for="taskItem in execution.taskRunList" :key="taskItem.id">
+            <template v-if="(!task || task.id === taskItem.id) && taskItem.attempts">
+                <div class="bg-dark attempt-wrapper">
+                    <template v-for="(attempt, index) in taskItem.attempts">
+                        <div
+                            :id="`attempt-${index}-${attempt.state.startDate}`"
+                            :key="`attempt-${index}-${attempt.state.startDate}`"
+                        >
+                            <!-- Tooltip -->
+                            <b-tooltip
+                                placement="top"
+                                :target="`attempt-${index}-${attempt.state.startDate}`"
+                                triggers="hover"
+                            >
+                                {{$t('from')}} : {{attempt.state.startDate | date('LLL:ss') }}
+                                <br />
+                                {{$t('to')}} : {{attempt.state.endDate | date('LLL:ss') }}
+                                <br />
+                                <br />
+                                <clock />
+                                {{$t('duration')}} : {{attempt.state.duration | humanizeDuration}}
+                            </b-tooltip>
 
-              <div class="attempt">
-                <!-- Attempt Badge -->
-                <div>
-                  <b-badge
-                          :id="`attempt-badge-${taskItem.id}`"
-                          variant="primary mr-1"
-                  >{{$t('attempt')}} {{index + 1}}</b-badge>
-                </div>
+                            <div class="attempt">
+                                <!-- Attempt Badge -->
+                                <div>
+                                    <b-badge
+                                        :id="`attempt-badge-${taskItem.id}`"
+                                        variant="primary mr-1"
+                                    >{{$t('attempt')}} {{index + 1}}</b-badge>
+                                </div>
 
-                <!-- Task id -->
-                <div class="task-id flex-grow-1">
-                  <span>{{taskItem.taskId | ellipsis(30)}}</span>
-                </div>
+                                <!-- Task id -->
+                                <div class="task-id flex-grow-1">
+                                    <span>{{taskItem.taskId | ellipsis(30)}}</span>
+                                </div>
 
-                <!-- Dropdown menu with actions -->
-                <div>
-                  <b-dropdown size="sm" right variant="primary" no-caret>
-                    <template v-slot:button-content>
-                      <Menu />
+                                <!-- Dropdown menu with actions -->
+                                <div>
+                                    <b-dropdown size="sm" right variant="primary" no-caret>
+                                        <template v-slot:button-content>
+                                            <Menu />
+                                        </template>
+                                        <b-dropdown-item
+                                            v-if="taskItem.outputs"
+                                            @click="toggleShowOutput(taskItem)"
+                                        >
+                                            <eye />
+                                            {{$t('toggle output')}}
+                                        </b-dropdown-item>
+                                        <b-dropdown-item>
+                                            <restart
+                                                :key="`restart-${index}-${attempt.state.startDate}`"
+                                                :isButton="false"
+                                                :execution="execution"
+                                                :task="taskItem"
+                                            />
+                                        </b-dropdown-item>
+                                    </b-dropdown>
+                                </div>
+                            </div>
+                        </div>
+
+                        <!-- Log lines -->
+                        <template v-if="attempt.logs">
+                            <template v-for="(log, i) in attempt.logs">
+                                <log-line
+                                    :level="level"
+                                    :filter="filter"
+                                    :log="log"
+                                    :key="`${i}-${log.timestamp}`"
+                                />
+                            </template>
+                        </template>
                     </template>
-                    <b-dropdown-item v-if="taskItem.outputs" @click="toggleShowOutput(taskItem)">
-                      <eye />
-                      {{$t('toggle output')}}
-                    </b-dropdown-item>
-                    <b-dropdown-item>
-                      <restart
-                              :key="`restart-${index}-${attempt.state.startDate}`"
-                              :isButton="false"
-                              :execution="execution"
-                              :task="taskItem"
-                      />
-                    </b-dropdown-item>
-                  </b-dropdown>
                 </div>
-              </div>
-            </div>
-
-            <!-- Log lines -->
-            <template v-if="attempt.logs">
-              <template v-for="(log, i) in attempt.logs">
-                <log-line
-                  :level="level"
-                  :filter="filter"
-                  :log="log"
-                  :key="`${i}-${log.timestamp}`"
-                />
-              </template>
             </template>
-          </template>
-        </div>
-      </template>
-
-      <!-- Outputs -->
-      <div v-if="showOutputs[taskItem.id] && taskItem.outputs" class="bg-dark mb-1 mt-1 outputs">
+            <!-- Outputs -->
+            <div v-if="showOutputs[taskItem.id] && taskItem.outputs" class="bg-dark mb-1 mt-1 outputs">
         <h6 class="p-2 mb-0">{{ $t('outputs') }}</h6>
         <pre class="bg-dark mb-0 mt-0" :key="taskItem.id">{{taskItem.outputs}}</pre>
-      </div>
-    </div>
-  </div>
+        </div>
+    </div></div>
 </template>
 <script>
 import { mapState } from "vuex";
@@ -91,71 +92,69 @@ import Clock from "vue-material-design-icons/Clock";
 import Eye from "vue-material-design-icons/Eye";
 import Menu from "vue-material-design-icons/Menu";
 export default {
-  components: { LogLine, Restart, Clock, Eye, Menu },
-  props: {
-    level: {
-      type: String,
-      default: "ALL"
+    components: { LogLine, Restart, Clock, Eye, Menu },
+    props: {
+        level: {
+            type: String,
+            default: "ALL"
+        },
+        filter: {
+            type: String,
+            default: ""
+        }
     },
-    filter: {
-      type: String,
-      default: ""
+    data() {
+        return {
+            showOutputs: {}
+        };
+    },
+    computed: {
+        ...mapState("execution", ["execution", "task"])
+    },
+    methods: {
+        toggleShowOutput(task) {
+            this.showOutputs[task.id] = !this.showOutputs[task.id];
+            this.$forceUpdate();
+        }
     }
-  },
-  data() {
-    return {
-      showOutputs: {}
-    };
-  },
-  computed: {
-    ...mapState("execution", ["execution", "task"])
-  },
-  methods: {
-    toggleShowOutput(task) {
-      this.showOutputs[task.id] = !this.showOutputs[task.id];
-      this.$forceUpdate();
-    }
-  }
 };
 </script>
 <style lang="scss" scoped>
 @import "../../styles/_variable.scss";
 .log-wrapper {
-  border-radius: 5px;
-  .line:nth-child(odd) {
-    background-color: lighten($dark, 5%);
-  }
-  div.attempt {
-    display: flex;
-    font-family: $font-family-sans-serif;
-    font-size: $font-size-base;
-    margin-top: $paragraph-margin-bottom*1.5;
-    margin-bottom: 2px;
-    .badge {
-      font-size: $font-size-base;
-      height: 100%;
-      line-height: 100%;
-      padding-bottom: 0;
+    border-radius: 5px;
+    .line:nth-child(odd) {
+        background-color: lighten($dark, 5%);
     }
-  }
-  .attempt-wrapper {
-    padding: 0.75rem;
-    div:first-child > *  {
-      margin-top: 0;
+    div.attempt {
+        display: flex;
+        font-family: $font-family-sans-serif;
+        font-size: $font-size-base;
+        margin-top: $paragraph-margin-bottom * 1.5;
+        margin-bottom: 2px;
+        .badge {
+            font-size: $font-size-base;
+            height: 100%;
+            line-height: 100%;
+            padding-bottom: 0;
+        }
     }
-  }
-  .output {
-    margin-right: 5px;
-  }
-  pre {
-    border: 1px solid $light;
-    background-color: $gray-200;
-    padding: 10px;
-    margin-top: 5px;
-    margin-bottom: 20px;
-  }
-
-  .outputs {
+    .attempt-wrapper {
+        padding: 0.75rem;
+        div:first-child > * {
+            margin-top: 0;
+        }
+    }
+    .output {
+        margin-right: 5px;
+    }
+    pre {
+        border: 1px solid $light;
+        background-color: $gray-200;
+        padding: 10px;
+        margin-top: 5px;
+        margin-bottom: 20px;
+    }.outputs {
     h6 {
       border-bottom: 1px solid $gray-600;
     }

--- a/ui/src/components/executions/LogList.vue
+++ b/ui/src/components/executions/LogList.vue
@@ -64,14 +64,9 @@
                         </div>
 
                         <!-- Log lines -->
-                        <template v-if="attempt.logs">
-                            <template v-for="(log, i) in attempt.logs">
-                                <log-line
-                                    :level="level"
-                                    :filter="filter"
-                                    :log="log"
-                                    :key="`${i}-${log.timestamp}`"
-                                />
+                        <template v-if="logs && logs[taskItem.id]">
+                            <template v-for="log in logs[taskItem.id]">
+                                <log-line :level="level" :filter="filter" :log="log" :key="log.id" />
                             </template>
                         </template>
                     </template>
@@ -82,6 +77,8 @@
         <h6 class="p-2 mb-0">{{ $t('outputs') }}</h6>
         <pre class="bg-dark mb-0 mt-0" :key="taskItem.id">{{taskItem.outputs}}</pre>
         </div>
+        <!-- <pre>{{execution}}</pre> -->
+        <!-- <pre>{{logs}}</pre> -->
     </div></div>
 </template>
 <script>
@@ -109,7 +106,7 @@ export default {
         };
     },
     computed: {
-        ...mapState("execution", ["execution", "task"])
+        ...mapState("execution", ["execution", "task", "logs"])
     },
     methods: {
         toggleShowOutput(task) {

--- a/ui/src/components/executions/Logs.vue
+++ b/ui/src/components/executions/Logs.vue
@@ -21,11 +21,12 @@
                 </b-form-group>
             </b-col>
         </b-row>
-        <log-list :filter="filterTerm" :level="level" />
+        <log-list :filter="filterTerm" :level="level"/>
     </div>
 </template>
 <script>
 import LogList from "./LogList";
+import {mapState} from "vuex";
 export default {
     components: { LogList },
     data() {
@@ -33,7 +34,6 @@ export default {
             filter: "",
             level: "INFO",
             levelOptions: [
-                "ALL",
                 "TRACE",
                 "DEBUG",
                 "INFO",
@@ -47,10 +47,12 @@ export default {
         if (this.$route.query.search) {
             this.filter = this.$route.query.search || "";
         }
-        this.$store.dispatch("execution/loadLogs", {
-            executionId: this.$route.params.id,
-            query: { size: 1000, page: 1 }
-        });
+    },
+    computed: {
+        ...mapState("execution", ["execution", "task", "logs"]),
+        filterTerm() {
+            return this.filter.toLowerCase();
+        }
     },
     watch: {
         $route() {
@@ -66,12 +68,7 @@ export default {
                 newRoute.query.search = this.filter;
                 this.$router.push(newRoute);
             }
-        }
-    },
-    computed: {
-        filterTerm() {
-            return this.filter.toLowerCase();
-        }
+        },
     }
 };
 </script>

--- a/ui/src/components/executions/Logs.vue
+++ b/ui/src/components/executions/Logs.vue
@@ -47,6 +47,10 @@ export default {
         if (this.$route.query.search) {
             this.filter = this.$route.query.search || "";
         }
+        this.$store.dispatch("execution/loadLogs", {
+            executionId: this.$route.params.id,
+            query: { size: 1000, page: 1 }
+        });
     },
     watch: {
         $route() {

--- a/ui/src/components/graph/TreeNode.vue
+++ b/ui/src/components/graph/TreeNode.vue
@@ -125,9 +125,11 @@ export default {
     computed: {
         ...mapState("graph", ["node"]),
         hasLogs() {
-            return (
-                this.attempts.filter(attempt => attempt.logs.length).length > 0
-            );
+            // @TODO
+            return true;
+            // return (
+            //     this.attempts.filter(attempt => attempt.logs.length).length > 0
+            // );
         },
         hasOutputs() {
             return this.n.taskRun && this.n.taskRun.outputs;

--- a/ui/src/stores/executions.js
+++ b/ui/src/stores/executions.js
@@ -6,7 +6,8 @@ export default {
         execution: undefined,
         task: undefined,
         total: 0,
-        dataTree: undefined
+        dataTree: undefined,
+        logs: []
     },
     actions: {
         loadExecutions({ commit }, options) {
@@ -16,7 +17,7 @@ export default {
             })
         },
         restartExecution(_, options) {
-            return Vue.axios.post(`/api/v1/executions/${options.id}/restart?taskId=${options.taskId}`, {params: options},{
+            return Vue.axios.post(`/api/v1/executions/${options.id}/restart?taskId=${options.taskId}`, { params: options }, {
                 headers: {
                     'content-type': 'multipart/form-data'
                 }
@@ -34,7 +35,7 @@ export default {
             if (sort) {
                 sortQueryString = `?sort=${sort}`
             }
-            return Vue.axios.get(`/api/v1/executions/search${sortQueryString}`, {params: options}).then(response => {
+            return Vue.axios.get(`/api/v1/executions/search${sortQueryString}`, { params: options }).then(response => {
                 commit('setExecutions', response.data.results)
                 commit('setTotal', response.data.total)
             })
@@ -60,6 +61,25 @@ export default {
                 commit('setDataTree', response.data.tasks)
             })
         },
+        loadLogs({ commit }, options) {
+            return Vue.axios.get(`/api/v1/logs/${options.executionId}`, {
+                query: options.query
+            }).then(response => {
+                const logs = {}
+                response.data.results.forEach(logLine => {
+                    if (!logs[logLine.taskRunId]) {
+                        logs[logLine.taskRunId] = [];
+                    }
+                    logs[logLine.taskRunId].push({
+                        id: `${logLine.timestamp}-${logLine.taskRunId}`,
+                        timestamp: logLine.timestamp,
+                        level: logLine.level,
+                        message: logLine.message
+                    });
+                });
+                commit('setLogs', logs)
+            })
+        }
     },
     mutations: {
         setExecutions(state, executions) {
@@ -76,6 +96,9 @@ export default {
         },
         setDataTree(state, tree) {
             state.dataTree = tree
+        },
+        setLogs(state, logs) {
+            state.logs = logs
         }
     },
     getters: {}

--- a/ui/src/stores/executions.js
+++ b/ui/src/stores/executions.js
@@ -56,6 +56,9 @@ export default {
         followExecution(_, options) {
             return Vue.SSE(`${Vue.axios.defaults.baseURL}api/v1/executions/${options.id}/follow`, { format: 'json' })
         },
+        followLogs(_, options) {
+            return Vue.SSE(`${Vue.axios.defaults.baseURL}api/v1/logs/${options.id}/follow`, { format: 'json', params: options.params })
+        },
         loadTree({ commit }, execution) {
             return Vue.axios.get(`/api/v1/executions/${execution.id}/tree`).then(response => {
                 commit('setDataTree', response.data.tasks)
@@ -63,21 +66,9 @@ export default {
         },
         loadLogs({ commit }, options) {
             return Vue.axios.get(`/api/v1/logs/${options.executionId}`, {
-                query: options.query
+                params: options.params
             }).then(response => {
-                const logs = {}
-                response.data.results.forEach(logLine => {
-                    if (!logs[logLine.taskRunId]) {
-                        logs[logLine.taskRunId] = [];
-                    }
-                    logs[logLine.taskRunId].push({
-                        id: `${logLine.timestamp}-${logLine.taskRunId}`,
-                        timestamp: logLine.timestamp,
-                        level: logLine.level,
-                        message: logLine.message
-                    });
-                });
-                commit('setLogs', logs)
+                commit('setLogs', response.data)
             })
         }
     },
@@ -99,6 +90,9 @@ export default {
         },
         setLogs(state, logs) {
             state.logs = logs
+        },
+        appendLogs(state, logs) {
+            state.logs.push(logs);
         }
     },
     getters: {}

--- a/webserver/src/main/java/org/kestra/webserver/controllers/ExecutionController.java
+++ b/webserver/src/main/java/org/kestra/webserver/controllers/ExecutionController.java
@@ -13,7 +13,6 @@ import io.micronaut.http.sse.Event;
 import io.micronaut.validation.Validated;
 import io.reactivex.BackpressureStrategy;
 import io.reactivex.Flowable;
-import io.reactivex.Maybe;
 import org.apache.commons.io.FilenameUtils;
 import org.kestra.core.exceptions.IllegalVariableEvaluationException;
 import org.kestra.core.models.executions.Execution;
@@ -32,9 +31,6 @@ import org.kestra.webserver.responses.PagedResults;
 import org.kestra.webserver.utils.PageableUtils;
 import org.reactivestreams.Publisher;
 
-import javax.annotation.Nullable;
-import javax.inject.Inject;
-import javax.inject.Named;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
@@ -44,6 +40,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicReference;
+import javax.annotation.Nullable;
+import javax.inject.Inject;
+import javax.inject.Named;
 
 import static org.kestra.core.utils.Rethrow.throwFunction;
 

--- a/webserver/src/main/java/org/kestra/webserver/controllers/ExecutionController.java
+++ b/webserver/src/main/java/org/kestra/webserver/controllers/ExecutionController.java
@@ -262,6 +262,11 @@ public class ExecutionController {
 
                 cancel.set(receive);
             }, BackpressureStrategy.BUFFER)
+            .doOnCancel(() -> {
+                if (cancel.get() != null) {
+                    cancel.get().run();
+                }
+            })
             .doOnComplete(() -> {
                 if (cancel.get() != null) {
                     cancel.get().run();

--- a/webserver/src/main/java/org/kestra/webserver/controllers/LogController.java
+++ b/webserver/src/main/java/org/kestra/webserver/controllers/LogController.java
@@ -1,0 +1,132 @@
+package org.kestra.webserver.controllers;
+
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.http.MediaType;
+import io.micronaut.http.annotation.Controller;
+import io.micronaut.http.annotation.Get;
+import io.micronaut.http.annotation.QueryValue;
+import io.micronaut.http.sse.Event;
+import io.micronaut.validation.Validated;
+import io.reactivex.BackpressureStrategy;
+import io.reactivex.Flowable;
+import org.kestra.core.models.executions.LogEntry;
+import org.kestra.core.queues.QueueFactoryInterface;
+import org.kestra.core.queues.QueueInterface;
+import org.kestra.core.repositories.LogRepositoryInterface;
+import org.kestra.webserver.responses.PagedResults;
+import org.kestra.webserver.utils.PageableUtils;
+
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+import javax.annotation.Nullable;
+import javax.inject.Inject;
+import javax.inject.Named;
+
+@Validated
+@Controller("/api/v1/")
+@Requires(beans = LogRepositoryInterface.class)
+public class LogController {
+    @Inject
+    private LogRepositoryInterface logRepository;
+
+    @Inject
+    @Named(QueueFactoryInterface.WORKERTASKLOG_NAMED)
+    protected QueueInterface<LogEntry> logQueue;
+
+    /**
+     * Search for logs
+     *
+     * @param query The lucene query
+     * @param page The current page
+     * @param size The current page size
+     * @param sort The sort of current page
+     * @return Paged log result
+     */
+    @Get(uri = "logs/search", produces = MediaType.TEXT_JSON)
+    public PagedResults<LogEntry> find(
+        @QueryValue(value = "q") String query,
+        @QueryValue(value = "page", defaultValue = "1") int page,
+        @QueryValue(value = "size", defaultValue = "10") int size,
+        @Nullable @QueryValue(value = "sort") List<String> sort
+    ) {
+        return PagedResults.of(
+            logRepository.find(query, PageableUtils.from(page, size, sort))
+        );
+    }
+
+    /**
+     * Get execution log
+     *
+     * @param executionId The execution identifier
+     * @param page The current page
+     * @param size The current page size
+     * @param sort The sort of current page
+     * @return Paged log result
+     */
+    @Get(uri = "logs/{executionId}", produces = MediaType.TEXT_JSON)
+    public PagedResults<LogEntry> findByExecution(
+        String executionId,
+        @QueryValue(value = "page", defaultValue = "1") int page,
+        @QueryValue(value = "size", defaultValue = "10") int size,
+        @Nullable @QueryValue(value = "sort") List<String> sort
+    ) {
+        return PagedResults.of(
+            logRepository.findByExecutionId(executionId, PageableUtils.from(page, size, sort))
+        );
+    }
+
+    /**
+     * Get execution log for a specific taskRun
+     *
+     * @param executionId The execution identifier
+     * @param taskRunId The taskrun identifier
+     * @param page The current page
+     * @param size The current page size
+     * @param sort The sort of current page
+     * @return Paged log result
+     */
+    @Get(uri = "logs/{executionId}/{taskRunId}", produces = MediaType.TEXT_JSON)
+    public PagedResults<LogEntry> findByTaskrun(
+        String executionId,
+        String taskRunId,
+        @QueryValue(value = "page", defaultValue = "1") int page,
+        @QueryValue(value = "size", defaultValue = "10") int size,
+        @Nullable @QueryValue(value = "sort") List<String> sort
+    ) {
+        return PagedResults.of(
+            logRepository.findByExecutionIdAndTaskRunId(executionId, taskRunId, PageableUtils.from(page, size, sort))
+        );
+    }
+
+    /**
+     * Follow log for a specific execution
+     *
+     * @param executionId The execution id to follow
+     * @return execution log sse event
+     */
+    @Get(uri = "logs/{executionId}/follow", produces = MediaType.TEXT_JSON)
+    public Flowable<Event<LogEntry>> follow(String executionId) {
+        AtomicReference<Runnable> cancel = new AtomicReference<>();
+
+        return Flowable
+            .<Event<LogEntry>>create(emitter -> {
+                Runnable receive = this.logQueue.receive(current -> {
+                    if (current.getExecutionId().equals(executionId)) {
+                        emitter.onNext(Event.of(current).id("progress"));
+                    }
+                });
+
+                cancel.set(receive);
+            }, BackpressureStrategy.BUFFER)
+            .doOnCancel(() -> {
+                if (cancel.get() != null) {
+                    cancel.get().run();
+                }
+            })
+            .doOnComplete(() -> {
+                if (cancel.get() != null) {
+                    cancel.get().run();
+                }
+            });
+    }
+}


### PR DESCRIPTION
Large log can break the Execution object.
Now we put the log a new queue and save it to repository.
This also allow log to be realtime.

close #74
close #34