### PR TITLE
fix possible duplicate workerTask submitted

### DIFF
--- a/runner-kafka/src/main/java/org/kestra/runner/kafka/streams/ExecutionNextsDeduplicationTransformer.java
+++ b/runner-kafka/src/main/java/org/kestra/runner/kafka/streams/ExecutionNextsDeduplicationTransformer.java
@@ -1,0 +1,66 @@
+package org.kestra.runner.kafka.streams;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.streams.kstream.ValueTransformerWithKey;
+import org.apache.kafka.streams.processor.ProcessorContext;
+import org.apache.kafka.streams.state.KeyValueStore;
+import org.kestra.runner.kafka.KafkaExecutor;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Slf4j
+public class ExecutionNextsDeduplicationTransformer implements ValueTransformerWithKey<String, KafkaExecutor.ExecutionNexts, KafkaExecutor.ExecutionNexts> {
+    private final String storeName;
+    private KeyValueStore<String, Store> store;
+
+    public ExecutionNextsDeduplicationTransformer(String storeName) {
+        this.storeName = storeName;
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public void init(final ProcessorContext context) {
+        this.store = (KeyValueStore<String, Store>) context.getStateStore(this.storeName);
+    }
+
+    @Override
+    public KafkaExecutor.ExecutionNexts transform(final String key, final KafkaExecutor.ExecutionNexts value) {
+        if (value.getNexts() == null) {
+            return null;
+        }
+
+        Store store = this.store.get(key) == null ? new Store() : this.store.get(key);
+
+        Map<Boolean, List<String>> groups = value.getNexts()
+            .stream()
+            .map(taskRun -> taskRun.getParentTaskRunId() + "-" + taskRun.getTaskId() + "-" + taskRun.getValue())
+            .collect(Collectors.partitioningBy(store::contains));
+
+        if (groups.get(true).size() > 0) {
+            groups.get(true).forEach(s ->
+                log.warn("Duplicate next taskRun for execution '{}', value '{}'", key, s)
+            );
+
+            return null;
+        }
+
+        store.addAll(groups.get(false));
+        this.store.put(key, store);
+
+        return value;
+    }
+
+    @Override
+    public void close() {
+    }
+
+    @Getter
+    @NoArgsConstructor
+    public static class Store extends ArrayList<String> {
+    }
+}

--- a/runner-kafka/src/test/java/org/kestra/runner/kafka/KafkaRunnerTest.java
+++ b/runner-kafka/src/test/java/org/kestra/runner/kafka/KafkaRunnerTest.java
@@ -21,7 +21,9 @@ import java.util.concurrent.TimeoutException;
 import javax.inject.Inject;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.*;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.core.StringContains.containsString;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class KafkaRunnerTest extends AbstractKafkaRunnerTest {
@@ -58,16 +60,23 @@ class KafkaRunnerTest extends AbstractKafkaRunnerTest {
 
     @Test
     void parallel() throws TimeoutException, QueueException {
-        Execution execution = runnerUtils.runOne("org.kestra.tests", "parallel", null, null, Duration.ofSeconds(120));
+        Execution execution = runnerUtils.runOne("org.kestra.tests", "parallel", null, null, Duration.ofSeconds(60));
 
         assertThat(execution.getTaskRunList(), hasSize(8));
     }
 
     @Test
     void parallelNested() throws TimeoutException, QueueException {
-        Execution execution = runnerUtils.runOne("org.kestra.tests", "parallel-nested");
+        Execution execution = runnerUtils.runOne("org.kestra.tests", "parallel-nested", null, null, Duration.ofSeconds(60));
 
         assertThat(execution.getTaskRunList(), hasSize(11));
+    }
+
+    @Test
+    void sequentialNested() throws TimeoutException {
+        Execution execution = runnerUtils.runOne("org.kestra.tests", "each-sequential-nested", null, null, Duration.ofSeconds(60));
+
+        assertThat(execution.getTaskRunList(), hasSize(23));
     }
 
     @Test


### PR DESCRIPTION
On high concurrency, some WorkerTasK can be send multiple time led to error Can't find taskRun.
We need to add a deduplication and flatten the KafkaStream tree for KafkaExecutor.