### PR TITLE
fix(ui): prevent chart to load when data are not ready

### DIFF
--- a/ui/src/components/executions/Executions.vue
+++ b/ui/src/components/executions/Executions.vue
@@ -11,6 +11,7 @@
 
             <template v-slot:top>
                 <state-global-chart
+                    v-if="daily"
                     :ready="dailyReady"
                     :data="daily"
                 />

--- a/ui/src/components/flows/Flows.vue
+++ b/ui/src/components/flows/Flows.vue
@@ -16,6 +16,7 @@
 
                 <template v-slot:top>
                     <state-global-chart
+                        v-if="daily"
                         :ready="dailyReady"
                         :data="daily"
                     />


### PR DESCRIPTION
prevent this error : 
![image](https://user-images.githubusercontent.com/5399780/92477765-76208600-f1e1-11ea-8cfc-b2d85b562157.png)
