### PR TITLE
feat(core): handle PollingTrigger in a dedicated pool

### DIFF
--- a/core/src/main/java/org/kestra/core/docs/DocumentationGenerator.java
+++ b/core/src/main/java/org/kestra/core/docs/DocumentationGenerator.java
@@ -52,9 +52,18 @@ abstract public class DocumentationGenerator {
         .registerHelpers(DateHelper.class)
         .registerHelpers(JsonHelper.class);
 
-    public static List<Document> generate(RegisteredPlugin registeredPlugin) throws IOException {
-        return registeredPlugin
-            .getTasks()
+    public static List<Document> generate(RegisteredPlugin registeredPlugin) {
+        ArrayList<Document> result = new ArrayList<>();
+
+        result.addAll(DocumentationGenerator.generate(registeredPlugin, registeredPlugin.getTasks(), "tasks"));
+        result.addAll(DocumentationGenerator.generate(registeredPlugin, registeredPlugin.getTriggers(), "triggers"));
+        result.addAll(DocumentationGenerator.generate(registeredPlugin, registeredPlugin.getConditions(), "conditions"));
+
+        return result;
+    }
+
+    private static <T> List<Document> generate(RegisteredPlugin registeredPlugin, List<Class<? extends T>> cls, String type) {
+        return cls
             .stream()
             .map(r -> PluginDocumentation.of(registeredPlugin, r))
             .map(pluginDocumentation -> {
@@ -66,7 +75,7 @@ abstract public class DocumentationGenerator {
                     );
 
                     return new Document(
-                        project + "/tasks/" +
+                        project + "/" + type + "/" +
                             (pluginDocumentation.getSubGroup() != null ? pluginDocumentation.getSubGroup() + "/" : "") +
                             pluginDocumentation.getCls() + ".md",
                         render(pluginDocumentation)

--- a/core/src/main/java/org/kestra/core/models/triggers/PollingTriggerInterface.java
+++ b/core/src/main/java/org/kestra/core/models/triggers/PollingTriggerInterface.java
@@ -1,15 +1,18 @@
 package org.kestra.core.models.triggers;
 
 import org.kestra.core.models.executions.Execution;
+import org.kestra.core.runners.RunContext;
 
-import java.time.ZoneId;
+import java.time.Duration;
 import java.time.ZonedDateTime;
 import java.util.Optional;
 
 public interface PollingTriggerInterface {
-    Optional<Execution> evaluate(TriggerContext context);
+    Optional<Execution> evaluate(RunContext runContext, TriggerContext context) throws Exception;
 
     default ZonedDateTime nextDate(Optional<? extends TriggerContext> last) {
-        return ZonedDateTime.now(ZoneId.systemDefault());
+        return ZonedDateTime.now();
     }
+
+    Duration getInterval();
 }

--- a/core/src/main/java/org/kestra/core/plugins/PluginRegistry.java
+++ b/core/src/main/java/org/kestra/core/plugins/PluginRegistry.java
@@ -31,6 +31,9 @@ public class PluginRegistry  {
                 plugin.getTasks()
                     .stream()
                     .map(r -> new AbstractMap.SimpleEntry<>(r.getName(), plugin)),
+                plugin.getTriggers()
+                    .stream()
+                    .map(r -> new AbstractMap.SimpleEntry<>(r.getName(), plugin)),
                 plugin.getConditions()
                     .stream()
                     .map(r -> new AbstractMap.SimpleEntry<>(r.getName(), plugin)),

--- a/core/src/main/java/org/kestra/core/plugins/PluginScanner.java
+++ b/core/src/main/java/org/kestra/core/plugins/PluginScanner.java
@@ -8,6 +8,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.io.IOUtils;
 import org.kestra.core.models.conditions.Condition;
 import org.kestra.core.models.tasks.Task;
+import org.kestra.core.models.triggers.AbstractTrigger;
 import org.kestra.core.storages.StorageInterface;
 
 import java.io.IOException;
@@ -81,6 +82,7 @@ public class PluginScanner {
     @SuppressWarnings({"unchecked", "rawtypes"})
     private RegisteredPlugin scanClassLoader(final ClassLoader classLoader, ExternalPlugin externalPlugin, Manifest manifest) {
         List<Class<? extends Task>> tasks = new ArrayList<>();
+        List<Class<? extends AbstractTrigger>> triggers = new ArrayList<>();
         List<Class<? extends Condition>> conditions = new ArrayList<>();
         List<Class<? extends StorageInterface>> storages = new ArrayList<>();
         List<Class<?>> controllers = new ArrayList<>();
@@ -107,6 +109,10 @@ public class PluginScanner {
                     tasks.add(beanType);
                 }
 
+                if (AbstractTrigger.class.isAssignableFrom(beanType)) {
+                    triggers.add(beanType);
+                }
+                
                 if (Condition.class.isAssignableFrom(beanType)) {
                     conditions.add(beanType);
                 }
@@ -126,6 +132,7 @@ public class PluginScanner {
             .manifest(manifest)
             .classLoader(classLoader)
             .tasks(tasks)
+            .triggers(triggers)
             .conditions(conditions)
             .controllers(controllers)
             .storages(storages)

--- a/core/src/main/java/org/kestra/core/plugins/RegisteredPlugin.java
+++ b/core/src/main/java/org/kestra/core/plugins/RegisteredPlugin.java
@@ -6,6 +6,7 @@ import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import org.kestra.core.models.conditions.Condition;
 import org.kestra.core.models.tasks.Task;
+import org.kestra.core.models.triggers.AbstractTrigger;
 import org.kestra.core.storages.StorageInterface;
 
 import java.util.ArrayList;
@@ -24,12 +25,13 @@ public class RegisteredPlugin {
     private Manifest manifest;
     private ClassLoader classLoader;
     private List<Class<? extends Task>> tasks;
+    private List<Class<? extends AbstractTrigger>> triggers;
     private List<Class<? extends Condition>> conditions;
     private List<Class<?>> controllers;
     private List<Class<? extends StorageInterface>> storages;
 
     public boolean isValid() {
-        return tasks.size() > 0 || conditions.size() > 0 || controllers.size() > 0 || storages.size() > 0;
+        return tasks.size() > 0 || triggers.size() > 0 || conditions.size() > 0 || controllers.size() > 0 || storages.size() > 0;
     }
 
     public boolean hasClass(String cls) {
@@ -50,6 +52,7 @@ public class RegisteredPlugin {
         List<Class> result = new ArrayList<>();
 
         result.addAll(Arrays.asList(this.getTasks().toArray(Class[]::new)));
+        result.addAll(Arrays.asList(this.getTriggers().toArray(Class[]::new)));
         result.addAll(Arrays.asList(this.getConditions().toArray(Class[]::new)));
         result.addAll(Arrays.asList(this.getControllers().toArray(Class[]::new)));
         result.addAll(Arrays.asList(this.getStorages().toArray(Class[]::new)));
@@ -73,6 +76,12 @@ public class RegisteredPlugin {
             b.append("] ");
         }
 
+        if (!this.getTriggers().isEmpty()) {
+            b.append("[Triggers: ");
+            b.append(this.getTriggers().stream().map(Class::getName).collect(Collectors.joining(", ")));
+            b.append("] ");
+        }
+        
         if (!this.getConditions().isEmpty()) {
             b.append("[Conditions: ");
             b.append(this.getConditions().stream().map(Class::getName).collect(Collectors.joining(", ")));

--- a/core/src/main/java/org/kestra/core/runners/RunContextFactory.java
+++ b/core/src/main/java/org/kestra/core/runners/RunContextFactory.java
@@ -7,6 +7,7 @@ import org.kestra.core.models.executions.Execution;
 import org.kestra.core.models.executions.TaskRun;
 import org.kestra.core.models.flows.Flow;
 import org.kestra.core.models.tasks.Task;
+import org.kestra.core.models.triggers.AbstractTrigger;
 
 import java.util.Map;
 import javax.inject.Inject;
@@ -23,6 +24,10 @@ public class RunContextFactory {
 
     public RunContext of(Flow flow, Task task, Execution execution, TaskRun taskRun) {
         return new RunContext(applicationContext, flow, task, execution, taskRun);
+    }
+
+    public RunContext of(Flow flow, AbstractTrigger trigger) {
+        return new RunContext(applicationContext, flow, trigger);
     }
 
     @VisibleForTesting

--- a/core/src/main/java/org/kestra/core/schedulers/Scheduler.java
+++ b/core/src/main/java/org/kestra/core/schedulers/Scheduler.java
@@ -1,5 +1,6 @@
 package org.kestra.core.schedulers;
 
+import com.google.common.util.concurrent.*;
 import io.micronaut.context.ApplicationContext;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -16,18 +17,17 @@ import org.kestra.core.queues.QueueFactoryInterface;
 import org.kestra.core.queues.QueueInterface;
 import org.kestra.core.repositories.ExecutionRepositoryInterface;
 import org.kestra.core.repositories.TriggerRepositoryInterface;
+import org.kestra.core.runners.RunContextFactory;
 import org.kestra.core.services.FlowListenersService;
 import org.kestra.core.utils.Await;
+import org.kestra.core.utils.ExecutorsUtils;
 
-import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.time.temporal.ChronoUnit;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Optional;
+import java.util.*;
 import java.util.concurrent.*;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import javax.inject.Inject;
 import javax.inject.Named;
 
@@ -38,13 +38,18 @@ public class Scheduler implements Runnable, AutoCloseable {
     private final FlowListenersService flowListenersService;
     private final TriggerRepositoryInterface triggerContextRepository;
     private final ExecutionRepositoryInterface executionRepository;
+    private final RunContextFactory runContextFactory;
 
-    private final ScheduledExecutorService executor = Executors.newSingleThreadScheduledExecutor();
+    private final ScheduledExecutorService scheduleExecutor = Executors.newSingleThreadScheduledExecutor();
+    private final ListeningExecutorService cachedExecutor;
     private Map<String, Trigger> lastTriggers = new ConcurrentHashMap<>();
+    private final Map<String, ZonedDateTime> lastEvaluate = new ConcurrentHashMap<>();
+    private final List<String> evaluateRunning = new ArrayList<>();
 
     @Inject
     public Scheduler(
         ApplicationContext applicationContext,
+        ExecutorsUtils executorsUtils,
         @Named(QueueFactoryInterface.EXECUTION_NAMED) QueueInterface<Execution> executionQueue,
         FlowListenersService flowListenersService,
         ExecutionRepositoryInterface executionRepository,
@@ -55,11 +60,13 @@ public class Scheduler implements Runnable, AutoCloseable {
         this.flowListenersService = flowListenersService;
         this.triggerContextRepository = triggerContextRepository;
         this.executionRepository = executionRepository;
+        this.runContextFactory = applicationContext.getBean(RunContextFactory.class);
+        this.cachedExecutor = MoreExecutors.listeningDecorator(executorsUtils.cachedThreadPool("scheduler_executor"));
     }
 
     @Override
     public void run() {
-        ScheduledFuture<?> handle  = executor.scheduleAtFixedRate(
+        ScheduledFuture<?> handle  = scheduleExecutor.scheduleAtFixedRate(
             this::handle,
             0,
             1,
@@ -94,6 +101,7 @@ public class Scheduler implements Runnable, AutoCloseable {
 
     private void handle() {
         synchronized (this) {
+            // get all PollingTriggerInterface from flow
             List<FlowWithTrigger> schedulable = this.flowListenersService
                 .getFlows()
                 .stream()
@@ -110,11 +118,13 @@ public class Scheduler implements Runnable, AutoCloseable {
                 );
             }
 
-            schedulable
+            // get all that is ready from evaluation
+            List<FlowWithPollingTriggerNextDate> readyForEvaluate = schedulable
                 .stream()
                 .map(flowWithTrigger -> FlowWithPollingTrigger.builder()
                     .flow(flowWithTrigger.getFlow())
-                    .trigger((PollingTriggerInterface) flowWithTrigger.getTrigger())
+                    .trigger(flowWithTrigger.getTrigger())
+                    .pollingTrigger((PollingTriggerInterface) flowWithTrigger.getTrigger())
                     .triggerContext(TriggerContext
                         .builder()
                         .namespace(flowWithTrigger.getFlow().getNamespace())
@@ -126,6 +136,7 @@ public class Scheduler implements Runnable, AutoCloseable {
                     )
                     .build()
                 )
+                .filter(this::isEvaluationInterval)
                 .peek(this::getLastTrigger)
                 .filter(this::isExecutionNotRunning)
                 .map(f -> {
@@ -136,17 +147,64 @@ public class Scheduler implements Runnable, AutoCloseable {
 
                         return FlowWithPollingTriggerNextDate.of(
                             f,
-                            f.getTrigger().nextDate(Optional.of(lastTriggers.get(f.getTriggerContext().uid())))
+                            f.getPollingTrigger().nextDate(Optional.of(lastTriggers.get(f.getTriggerContext().uid())))
                         );
                     }
                 })
                 .filter(Objects::nonNull)
-                .map(this::evaluatePollingTrigger)
+                .collect(Collectors.toList());
+
+            // submit ready one to cached thread pool
+            readyForEvaluate
+                .forEach(f -> {
+                    this.evaluateRunning.add(f.getTriggerContext().uid());
+
+                    ListenableFuture<SchedulerExecutionWithTrigger> result = cachedExecutor
+                        .submit(() -> this.evaluatePollingTrigger(f));
+
+                    Futures.addCallback(
+                        result,
+                        new EvaluateFuture(this, f),
+                        cachedExecutor
+                    );
+                });
+        }
+    }
+
+    private static class EvaluateFuture implements FutureCallback<SchedulerExecutionWithTrigger> {
+        private final Scheduler scheduler;
+        private final FlowWithPollingTriggerNextDate flowWithPollingTriggerNextDate;
+
+        public EvaluateFuture(Scheduler scheduler, FlowWithPollingTriggerNextDate flowWithPollingTriggerNextDate) {
+            this.scheduler = scheduler;
+            this.flowWithPollingTriggerNextDate = flowWithPollingTriggerNextDate;
+        }
+
+        @Override
+        public void onSuccess(SchedulerExecutionWithTrigger result) {
+            scheduler.evaluateRunning.remove(flowWithPollingTriggerNextDate.getTriggerContext().uid());
+
+            Stream.of(result)
                 .filter(Objects::nonNull)
-                .peek(this::log)
-                .peek(this::saveLastTrigger)
-                .map(ExecutionWithTrigger::getExecution)
-                .forEach(executionQueue::emit);
+                .peek(scheduler::log)
+                .peek(scheduler::saveLastTrigger)
+                .map(SchedulerExecutionWithTrigger::getExecution)
+                .forEach(scheduler.executionQueue::emit);
+        }
+
+        @Override
+        public void onFailure(Throwable e) {
+            scheduler.evaluateRunning.remove(flowWithPollingTriggerNextDate.getTriggerContext().uid());
+
+            log.warn(
+                "Evaluate failed for flow '{}.{}' started at '{}' for trigger [{}] with error '{}",
+                flowWithPollingTriggerNextDate.getFlow().getNamespace(),
+                flowWithPollingTriggerNextDate.getFlow().getId(),
+                flowWithPollingTriggerNextDate.getTriggerContext().getDate(),
+                flowWithPollingTriggerNextDate.getTriggerContext().getTriggerId(),
+                e.getMessage(),
+                e
+            );
         }
     }
 
@@ -187,7 +245,7 @@ public class Scheduler implements Runnable, AutoCloseable {
         return false;
     }
 
-    private void log(ExecutionWithTrigger executionWithTrigger) {
+    private void log(SchedulerExecutionWithTrigger executionWithTrigger) {
         log.info(
             "Schedule execution '{}' for flow '{}.{}' started at '{}' for trigger [{}]",
             executionWithTrigger.getExecution().getId(),
@@ -207,8 +265,8 @@ public class Scheduler implements Runnable, AutoCloseable {
                 // this allow some edge case when the evaluation loop of schedulers will change second
                 // between start and end
                 .orElseGet(() -> {
-                    ZonedDateTime nextDate = f.getTrigger().nextDate(Optional.empty());
-                    ZonedDateTime now = ZonedDateTime.now(ZoneId.systemDefault());
+                    ZonedDateTime nextDate = f.getPollingTrigger().nextDate(Optional.empty());
+                    ZonedDateTime now = ZonedDateTime.now();
 
                     return Trigger.builder()
                             .date(nextDate.toEpochSecond() < now.toEpochSecond() ? nextDate : now)
@@ -222,7 +280,31 @@ public class Scheduler implements Runnable, AutoCloseable {
         );
     }
 
-    private void saveLastTrigger(ExecutionWithTrigger executionWithTrigger) {
+    private boolean isEvaluationInterval(FlowWithPollingTrigger flowWithPollingTrigger) {
+        String key = flowWithPollingTrigger.getTriggerContext().uid();
+        ZonedDateTime now = ZonedDateTime.now();
+
+        if (this.evaluateRunning.contains(key)) {
+            return false;
+        }
+
+        if (!this.lastEvaluate.containsKey(key)) {
+            this.lastEvaluate.put(key, now);
+            return true;
+        }
+
+        boolean result = this.lastEvaluate.get(key)
+            .plus(flowWithPollingTrigger.getPollingTrigger().getInterval())
+            .compareTo(now) < 0;
+
+        if (result) {
+            this.lastEvaluate.put(key, now);
+        }
+
+        return result;
+    }
+
+    private void saveLastTrigger(SchedulerExecutionWithTrigger executionWithTrigger) {
         Trigger trigger = Trigger.of(
             executionWithTrigger.getTriggerContext(),
             executionWithTrigger.getExecution()
@@ -233,11 +315,14 @@ public class Scheduler implements Runnable, AutoCloseable {
     }
 
     private ZonedDateTime now() {
-        return ZonedDateTime.now(ZoneId.systemDefault()).truncatedTo(ChronoUnit.SECONDS);
+        return ZonedDateTime.now().truncatedTo(ChronoUnit.SECONDS);
     }
 
-    private ExecutionWithTrigger evaluatePollingTrigger(FlowWithPollingTrigger flowWithTrigger) {
-        Optional<Execution> evaluate = flowWithTrigger.getTrigger().evaluate(flowWithTrigger.getTriggerContext());
+    private SchedulerExecutionWithTrigger evaluatePollingTrigger(FlowWithPollingTrigger flowWithTrigger) throws Exception {
+        Optional<Execution> evaluate = flowWithTrigger.getPollingTrigger().evaluate(
+            runContextFactory.of(flowWithTrigger.getFlow(), flowWithTrigger.getTrigger()),
+            flowWithTrigger.getTriggerContext()
+        );
 
         if (log.isDebugEnabled() && evaluate.isEmpty()) {
             log.debug("Empty evaluation for flow '{}.{}' for date '{}, waiting !",
@@ -251,7 +336,7 @@ public class Scheduler implements Runnable, AutoCloseable {
             return null;
         }
 
-        return new ExecutionWithTrigger(
+        return new SchedulerExecutionWithTrigger(
             evaluate.get(),
             flowWithTrigger.getTriggerContext()
         );
@@ -259,7 +344,7 @@ public class Scheduler implements Runnable, AutoCloseable {
 
     @Override
     public void close() {
-        this.executor.shutdown();
+        this.scheduleExecutor.shutdown();
     }
 
     @SuperBuilder
@@ -267,7 +352,8 @@ public class Scheduler implements Runnable, AutoCloseable {
     @NoArgsConstructor
     private static class FlowWithPollingTrigger {
         private Flow flow;
-        private PollingTriggerInterface trigger;
+        private AbstractTrigger trigger;
+        private PollingTriggerInterface pollingTrigger;
         private TriggerContext triggerContext;
     }
 
@@ -281,6 +367,7 @@ public class Scheduler implements Runnable, AutoCloseable {
             return FlowWithPollingTriggerNextDate.builder()
                 .flow(f.getFlow())
                 .trigger(f.getTrigger())
+                .pollingTrigger(f.getPollingTrigger())
                 .triggerContext(TriggerContext.builder()
                     .namespace(f.getTriggerContext().getNamespace())
                     .flowId(f.getTriggerContext().getFlowId())
@@ -299,12 +386,5 @@ public class Scheduler implements Runnable, AutoCloseable {
     private static class FlowWithTrigger {
         private final Flow flow;
         private final AbstractTrigger trigger;
-    }
-
-    @AllArgsConstructor
-    @Getter
-    private static class ExecutionWithTrigger {
-        private final Execution execution;
-        private final TriggerContext triggerContext;
     }
 }

--- a/core/src/main/java/org/kestra/core/schedulers/SchedulerExecutionWithTrigger.java
+++ b/core/src/main/java/org/kestra/core/schedulers/SchedulerExecutionWithTrigger.java
@@ -1,0 +1,13 @@
+package org.kestra.core.schedulers;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.kestra.core.models.executions.Execution;
+import org.kestra.core.models.triggers.TriggerContext;
+
+@AllArgsConstructor
+@Getter
+class SchedulerExecutionWithTrigger {
+    private final Execution execution;
+    private final TriggerContext triggerContext;
+}

--- a/core/src/main/java/org/kestra/core/storages/StorageInterface.java
+++ b/core/src/main/java/org/kestra/core/storages/StorageInterface.java
@@ -21,7 +21,7 @@ public interface StorageInterface {
 
     boolean delete(URI uri) throws IOException;
 
-    default String executionPrefix(Flow flow, Execution execution) throws  URISyntaxException {
+    default String executionPrefix(Flow flow, Execution execution) {
         return String.join(
             "/",
             Arrays.asList(
@@ -60,7 +60,21 @@ public interface StorageInterface {
         return this.from(flow, execution, input.getName(), file);
     }
 
-    static URI outputPrefix(Flow flow, Task task, Execution execution, TaskRun taskRun)  {
+    default URI outputPrefix(Flow flow)  {
+        try {
+            return new URI("/" + String.join(
+                "/",
+                Arrays.asList(
+                    flow.getNamespace().replace(".", "/"),
+                    Slugify.of(flow.getId())
+                )
+            ));
+        } catch (URISyntaxException e) {
+            throw new IllegalArgumentException(e);
+        }
+    }
+
+    default URI outputPrefix(Flow flow, Task task, Execution execution, TaskRun taskRun)  {
         try {
             return new URI("/" + String.join(
                 "/",

--- a/core/src/main/java/org/kestra/core/utils/ExecutorsUtils.java
+++ b/core/src/main/java/org/kestra/core/utils/ExecutorsUtils.java
@@ -1,0 +1,35 @@
+package org.kestra.core.utils;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.binder.jvm.ExecutorServiceMetrics;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
+@Singleton
+public class ExecutorsUtils {
+    @Inject
+    private ThreadMainFactoryBuilder threadFactoryBuilder;
+
+    @Inject
+    private MeterRegistry meterRegistry;
+
+    public ExecutorService cachedThreadPool(String name) {
+        return this.wrap(
+            name,
+            Executors.newCachedThreadPool(
+                threadFactoryBuilder.build(name + "_%d")
+            )
+        );
+    }
+
+    private ExecutorService wrap(String name, ExecutorService executorService) {
+        return ExecutorServiceMetrics.monitor(
+            meterRegistry,
+            executorService,
+            name
+        );
+    }
+}

--- a/core/src/main/java/org/kestra/core/utils/TestsUtils.java
+++ b/core/src/main/java/org/kestra/core/utils/TestsUtils.java
@@ -9,6 +9,8 @@ import org.kestra.core.models.executions.TaskRun;
 import org.kestra.core.models.flows.Flow;
 import org.kestra.core.models.flows.State;
 import org.kestra.core.models.tasks.Task;
+import org.kestra.core.models.triggers.AbstractTrigger;
+import org.kestra.core.models.triggers.TriggerContext;
 import org.kestra.core.repositories.LocalFlowRepositoryLoader;
 import org.kestra.core.runners.RunContext;
 import org.kestra.core.runners.RunContextFactory;
@@ -18,6 +20,8 @@ import java.io.File;
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.time.ZonedDateTime;
+import java.util.AbstractMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -91,6 +95,24 @@ abstract public class TestsUtils {
             .state(new State())
             .build()
             .withState(State.Type.RUNNING);
+    }
+
+    public static Map.Entry<RunContext, TriggerContext> mockTrigger(RunContextFactory runContextFactory, AbstractTrigger trigger) {
+        StackTraceElement caller = Thread.currentThread().getStackTrace()[2];
+        Flow flow = TestsUtils.mockFlow(caller);
+
+        TriggerContext triggerContext = TriggerContext.builder()
+            .triggerId(trigger.getId())
+            .flowId(flow.getId())
+            .namespace(flow.getNamespace())
+            .flowRevision(flow.getRevision())
+            .date(ZonedDateTime.now())
+            .build();
+
+        return new AbstractMap.SimpleEntry<>(
+            runContextFactory.of(flow, trigger),
+            triggerContext
+        );
     }
 
     public static RunContext mockRunContext(RunContextFactory runContextFactory, Task task, Map<String, Object> inputs) {

--- a/core/src/test/java/org/kestra/core/schedulers/AbstractSchedulerTest.java
+++ b/core/src/test/java/org/kestra/core/schedulers/AbstractSchedulerTest.java
@@ -1,0 +1,52 @@
+package org.kestra.core.schedulers;
+
+import io.micronaut.context.ApplicationContext;
+import io.micronaut.test.annotation.MicronautTest;
+import org.kestra.core.models.executions.Execution;
+import org.kestra.core.models.flows.Flow;
+import org.kestra.core.models.triggers.AbstractTrigger;
+import org.kestra.core.queues.QueueFactoryInterface;
+import org.kestra.core.queues.QueueInterface;
+import org.kestra.core.repositories.ExecutionRepositoryInterface;
+import org.kestra.core.repositories.TriggerRepositoryInterface;
+import org.kestra.core.services.FlowListenersService;
+import org.kestra.core.tasks.debugs.Return;
+import org.kestra.core.utils.ExecutorsUtils;
+import org.kestra.core.utils.IdUtils;
+
+import java.util.Collections;
+import java.util.List;
+import javax.inject.Inject;
+import javax.inject.Named;
+
+@MicronautTest
+abstract class AbstractSchedulerTest {
+    @Inject
+    protected ApplicationContext applicationContext;
+
+    @Inject
+    protected ExecutorsUtils executorsUtils;
+
+    @Inject
+    protected TriggerRepositoryInterface triggerContextRepository;
+
+    @Inject
+    protected ExecutionRepositoryInterface executionRepository;
+
+    @Inject
+    protected FlowListenersService flowListenersService;
+
+    @Inject
+    @Named(QueueFactoryInterface.EXECUTION_NAMED)
+    protected QueueInterface<Execution> executionQueue;
+
+    protected  static Flow createFlow(List<AbstractTrigger> triggers) {
+        return Flow.builder()
+            .id(IdUtils.create())
+            .namespace("org.kestra.unittest")
+            .revision(1)
+            .triggers(triggers)
+            .tasks(Collections.singletonList(Return.builder().id("test").type(Return.class.getName()).format("test").build()))
+            .build();
+    }
+}

--- a/core/src/test/java/org/kestra/core/schedulers/SchedulerThreadTest.java
+++ b/core/src/test/java/org/kestra/core/schedulers/SchedulerThreadTest.java
@@ -1,0 +1,116 @@
+package org.kestra.core.schedulers;
+
+import com.google.common.collect.ImmutableMap;
+import lombok.*;
+import lombok.experimental.SuperBuilder;
+import org.junit.jupiter.api.Test;
+import org.kestra.core.models.executions.Execution;
+import org.kestra.core.models.flows.Flow;
+import org.kestra.core.models.flows.State;
+import org.kestra.core.models.triggers.AbstractTrigger;
+import org.kestra.core.models.triggers.PollingTriggerInterface;
+import org.kestra.core.models.triggers.TriggerContext;
+import org.kestra.core.repositories.ExecutionRepositoryInterface;
+import org.kestra.core.runners.RunContext;
+import org.kestra.core.services.FlowListenersService;
+import org.kestra.core.utils.IdUtils;
+
+import java.time.Duration;
+import java.util.Collections;
+import java.util.Optional;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+class SchedulerThreadTest extends AbstractSchedulerTest {
+    private static Flow createThreadFlow() {
+        UnitTest schedule = UnitTest.builder()
+            .id("sleep")
+            .type(UnitTest.class.getName())
+            .build();
+
+        return createFlow(Collections.singletonList(schedule));
+    }
+
+    @Test
+    void thread() throws Exception {
+        // mock flow listeners
+        FlowListenersService flowListenersServiceSpy = spy(this.flowListenersService);
+        ExecutionRepositoryInterface executionRepositorySpy = spy(this.executionRepository);
+        CountDownLatch queueCount = new CountDownLatch(2);
+
+        Flow flow = createThreadFlow();
+
+        doReturn(Collections.singletonList(flow))
+            .when(flowListenersServiceSpy)
+            .getFlows();
+
+        // mock the backfill execution is ended
+        doAnswer(invocation -> Optional.of(Execution.builder().state(new State().withState(State.Type.SUCCESS)).build()))
+            .when(executionRepositorySpy)
+            .findById(any());
+
+        // scheduler
+        try (Scheduler scheduler = new Scheduler(
+            applicationContext,
+            executorsUtils,
+            executionQueue,
+            flowListenersServiceSpy,
+            executionRepositorySpy,
+            triggerContextRepository
+        )) {
+
+            AtomicReference<Execution> last = new AtomicReference<>();
+
+            // wait for execution
+            executionQueue.receive(SchedulerThreadTest.class, execution -> {
+                last.set(execution);
+                queueCount.countDown();
+                assertThat(execution.getFlowId(), is(flow.getId()));
+            });
+
+            scheduler.run();
+            queueCount.await();
+
+            assertThat(last.get().getVariables().get("counter"), is(3));
+        }
+    }
+
+    @SuperBuilder
+    @ToString
+    @EqualsAndHashCode
+    @Getter
+    @NoArgsConstructor
+    public static class UnitTest extends AbstractTrigger implements PollingTriggerInterface {
+        @Builder.Default
+        private final Duration interval = Duration.ofSeconds(2);
+
+        @Builder.Default
+        private transient int counter = 0;
+
+        public Optional<Execution> evaluate(RunContext runContext, TriggerContext context) throws InterruptedException {
+            counter++;
+
+            if (counter % 2 == 0) {
+                Thread.sleep(4000);
+
+                return Optional.empty();
+            } else {
+                Execution execution = Execution.builder()
+                    .id(IdUtils.create())
+                    .namespace(context.getNamespace())
+                    .flowId(context.getFlowId())
+                    .flowRevision(context.getFlowRevision())
+                    .state(new State())
+                    .variables(ImmutableMap.of("counter", counter))
+                    .build();
+
+                return Optional.of(execution);
+            }
+        }
+    }
+}

--- a/webserver/src/main/java/org/kestra/webserver/controllers/PluginController.java
+++ b/webserver/src/main/java/org/kestra/webserver/controllers/PluginController.java
@@ -85,6 +85,7 @@ public class PluginController {
     public static class Plugin {
         private Map<String, String> manifest;
         private List<String> tasks;
+        private List<String> triggers;
         private List<String> conditions;
         private List<String> controllers;
         private List<String> storages;
@@ -104,6 +105,7 @@ public class PluginController {
                 .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
 
             plugin.tasks = className(registeredPlugin.getTasks().toArray(Class[]::new));
+            plugin.triggers = className(registeredPlugin.getTriggers().toArray(Class[]::new));
             plugin.conditions = className(registeredPlugin.getConditions().toArray(Class[]::new));
             plugin.controllers = className(registeredPlugin.getControllers().toArray(Class[]::new));
             plugin.storages = className(registeredPlugin.getStorages().toArray(Class[]::new));


### PR DESCRIPTION
PollingTrigger will be handle by a dedicted poll in order to support long running Trigger
We also honor the `interval` parameters in order to control the frequency of the test