### PR TITLE
feat(core): save Flowable output at taskRun creation

### DIFF
--- a/core/src/main/java/org/kestra/core/models/executions/NextTaskRun.java
+++ b/core/src/main/java/org/kestra/core/models/executions/NextTaskRun.java
@@ -1,0 +1,17 @@
+package org.kestra.core.models.executions;
+
+import lombok.AllArgsConstructor;
+import lombok.Value;
+import org.kestra.core.models.tasks.Task;
+
+import javax.validation.constraints.NotNull;
+
+@Value
+@AllArgsConstructor
+public class NextTaskRun {
+    @NotNull
+    TaskRun taskRun;
+
+    @NotNull
+    Task task;
+}

--- a/core/src/main/java/org/kestra/core/models/tasks/FlowableTask.java
+++ b/core/src/main/java/org/kestra/core/models/tasks/FlowableTask.java
@@ -2,6 +2,7 @@ package org.kestra.core.models.tasks;
 
 import org.kestra.core.exceptions.IllegalVariableEvaluationException;
 import org.kestra.core.models.executions.Execution;
+import org.kestra.core.models.executions.NextTaskRun;
 import org.kestra.core.models.executions.TaskRun;
 import org.kestra.core.models.flows.State;
 import org.kestra.core.models.hierarchies.TaskTree;
@@ -20,7 +21,7 @@ public interface FlowableTask <T extends Output> {
 
     List<ResolvedTask> childTasks(RunContext runContext, TaskRun parentTaskRun) throws IllegalVariableEvaluationException;
 
-    List<TaskRun> resolveNexts(RunContext runContext, Execution execution, TaskRun parentTaskRun) throws IllegalVariableEvaluationException;
+    List<NextTaskRun> resolveNexts(RunContext runContext, Execution execution, TaskRun parentTaskRun) throws IllegalVariableEvaluationException;
 
     default Optional<State.Type> resolveState(RunContext runContext, Execution execution, TaskRun parentTaskRun) throws IllegalVariableEvaluationException {
         return FlowableUtils.resolveState(

--- a/core/src/main/java/org/kestra/core/models/tasks/ResolvedTask.java
+++ b/core/src/main/java/org/kestra/core/models/tasks/ResolvedTask.java
@@ -3,6 +3,7 @@ package org.kestra.core.models.tasks;
 import lombok.Builder;
 import lombok.Value;
 import org.kestra.core.models.executions.Execution;
+import org.kestra.core.models.executions.NextTaskRun;
 import org.kestra.core.models.executions.TaskRun;
 
 import java.util.List;
@@ -19,8 +20,11 @@ public class ResolvedTask {
 
     protected String parentId;
 
-    public TaskRun toTaskRun(Execution execution) {
-        return TaskRun.of(execution, this);
+    public NextTaskRun toNextTaskRun(Execution execution) {
+        return new NextTaskRun(
+            TaskRun.of(execution, this),
+            this.getTask()
+        );
     }
 
     public static ResolvedTask of(Task task) {

--- a/core/src/main/java/org/kestra/core/models/triggers/AbstractTrigger.java
+++ b/core/src/main/java/org/kestra/core/models/triggers/AbstractTrigger.java
@@ -3,6 +3,7 @@ package org.kestra.core.models.triggers;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import io.micronaut.core.annotation.Introspected;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
@@ -24,15 +25,20 @@ abstract public class AbstractTrigger {
     @NotNull
     @NotBlank
     @Pattern(regexp="[a-zA-Z0-9_-]+")
+    @Schema(title = "A unique id for the while flow")
     protected String id;
 
     @NotNull
     @NotBlank
     @Pattern(regexp="\\p{javaJavaIdentifierStart}\\p{javaJavaIdentifierPart}*(\\.\\p{javaJavaIdentifierStart}\\p{javaJavaIdentifierPart}*)*")
+    @Schema(title = "The class name for this current trigger")
     protected String type;
 
     private String description;
 
     @Valid
+    @Schema(
+        title = "List of Conditions in order to limit the flow trigger."
+    )
     private List<Condition> conditions;
 }

--- a/core/src/main/java/org/kestra/core/runners/AbstractExecutor.java
+++ b/core/src/main/java/org/kestra/core/runners/AbstractExecutor.java
@@ -6,6 +6,7 @@ import org.kestra.core.exceptions.IllegalVariableEvaluationException;
 import org.kestra.core.exceptions.InternalException;
 import org.kestra.core.metrics.MetricRegistry;
 import org.kestra.core.models.executions.Execution;
+import org.kestra.core.models.executions.NextTaskRun;
 import org.kestra.core.models.executions.TaskRun;
 import org.kestra.core.models.flows.Flow;
 import org.kestra.core.models.flows.State;
@@ -94,9 +95,7 @@ public abstract class AbstractExecutor implements Runnable {
                 flowableParent
                     .resolveState(runContext, execution, parentTaskRun),
                 parent,
-                parentTaskRun,
-                runContext,
-                execution
+                parentTaskRun
             );
 
             if (endedTask.isPresent()) {
@@ -110,9 +109,7 @@ public abstract class AbstractExecutor implements Runnable {
                     return childWorkerTaskTypeToWorkerTask(
                         Optional.of(State.Type.KILLING),
                         parent,
-                        parentTaskRun,
-                        runContext,
-                        execution
+                        parentTaskRun
                     );
                 }
 
@@ -128,9 +125,7 @@ public abstract class AbstractExecutor implements Runnable {
                     return childWorkerTaskTypeToWorkerTask(
                         Optional.of(State.Type.KILLED),
                         parent,
-                        parentTaskRun,
-                        runContext,
-                        execution
+                        parentTaskRun
                     );
                 }
             }
@@ -142,21 +137,11 @@ public abstract class AbstractExecutor implements Runnable {
     private Optional<WorkerTaskResult> childWorkerTaskTypeToWorkerTask(
         Optional<State.Type> findState,
         Task parentTask,
-        TaskRun parentTaskRun,
-        RunContext runContext,
-        Execution execution
-    ) throws IllegalVariableEvaluationException {
-        FlowableTask<?> flowableParent = (FlowableTask<?>) parentTask;
-
+        TaskRun parentTaskRun
+    ) {
         return findState
             .map(throwFunction(type -> new WorkerTaskResult(
-                parentTaskRun
-                    .withState(type)
-                    .withOutputs(
-                        flowableParent.outputs(runContext, execution, parentTaskRun) != null ?
-                            flowableParent.outputs(runContext, execution, parentTaskRun).toMap() :
-                            ImmutableMap.of()
-                    ),
+                parentTaskRun.withState(type),
                 parentTask
             )))
             .stream()
@@ -172,28 +157,68 @@ public abstract class AbstractExecutor implements Runnable {
             .findFirst();
     }
 
-    private Optional<List<TaskRun>> childNextsTaskRun(Flow flow, Execution execution, TaskRun taskRun) throws IllegalVariableEvaluationException, InternalException {
-        Task parent = flow.findTaskByTaskId(taskRun.getTaskId());
+    private Optional<List<TaskRun>> childNextsTaskRun(Flow flow, Execution execution, TaskRun parentTaskRun) throws IllegalVariableEvaluationException, InternalException {
+        Task parent = flow.findTaskByTaskId(parentTaskRun.getTaskId());
 
         if (parent instanceof FlowableTask) {
             FlowableTask<?> flowableParent = (FlowableTask<?>) parent;
-            List<TaskRun> nexts = flowableParent.resolveNexts(
-                runContextFactory.of(
-                    flow,
-                    parent,
-                    execution,
-                    taskRun
-                ),
+            RunContext runContext = runContextFactory.of(
+                flow,
+                parent,
                 execution,
-                taskRun
+                parentTaskRun
+            );
+
+            List<NextTaskRun> nexts = flowableParent.resolveNexts(
+                runContext,
+                execution,
+                parentTaskRun
             );
 
             if (nexts.size() > 0) {
-                return Optional.of(nexts);
+                return Optional
+                    .of(nexts)
+                    .map(throwFunction(nextTaskRuns -> this.saveFlowableOutput(
+                        nextTaskRuns,
+                        runContext,
+                        execution,
+                        parentTaskRun
+                    )));
             }
         }
 
         return Optional.empty();
+    }
+
+    private List<TaskRun> saveFlowableOutput(
+        List<NextTaskRun> nextTaskRuns,
+        RunContext runContext,
+        Execution execution,
+        TaskRun parentTaskRun
+    ) {
+        return nextTaskRuns
+            .stream()
+            .map(throwFunction(t -> {
+                TaskRun taskRun = t.getTaskRun();
+
+                if (!(t.getTask() instanceof FlowableTask)) {
+                    return taskRun;
+                }
+                FlowableTask<?> flowableTask = (FlowableTask<?>) t.getTask();
+
+                try {
+                    taskRun = taskRun.withOutputs(
+                        flowableTask.outputs(runContext, execution, parentTaskRun) != null ?
+                            flowableTask.outputs(runContext, execution, parentTaskRun).toMap() :
+                            ImmutableMap.of()
+                    );
+                } catch (Exception e) {
+                    log.warn("Unable to save output on taskRun '{}'", taskRun);
+                }
+
+                return taskRun;
+            }))
+            .collect(Collectors.toList());
     }
 
     private Execution onEnd(Flow flow, Execution execution) {
@@ -282,10 +307,16 @@ public abstract class AbstractExecutor implements Runnable {
     }
 
     private List<TaskRun> handleNext(Execution execution, Flow flow) {
-        return FlowableUtils.resolveSequentialNexts(
+        return this.saveFlowableOutput(
+            FlowableUtils
+                .resolveSequentialNexts(
+                    execution,
+                    ResolvedTask.of(flow.getTasks()),
+                    ResolvedTask.of(flow.getErrors())
+                ),
+            runContextFactory.of(flow, execution),
             execution,
-            ResolvedTask.of(flow.getTasks()),
-            ResolvedTask.of(flow.getErrors())
+            null
         );
     }
 
@@ -327,10 +358,15 @@ public abstract class AbstractExecutor implements Runnable {
 
         List<ResolvedTask> currentTasks = conditionService.findValidListeners(flow, execution);
 
-        return FlowableUtils.resolveSequentialNexts(
+        return this.saveFlowableOutput(
+            FlowableUtils.resolveSequentialNexts(
+                execution,
+                currentTasks,
+                new ArrayList<>()
+            ),
+            runContextFactory.of(flow, execution),
             execution,
-            currentTasks,
-            new ArrayList<>()
+            null
         );
     }
 

--- a/core/src/main/java/org/kestra/core/runners/FlowableUtils.java
+++ b/core/src/main/java/org/kestra/core/runners/FlowableUtils.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.extern.slf4j.Slf4j;
 import org.kestra.core.exceptions.IllegalVariableEvaluationException;
 import org.kestra.core.models.executions.Execution;
+import org.kestra.core.models.executions.NextTaskRun;
 import org.kestra.core.models.executions.TaskRun;
 import org.kestra.core.models.flows.State;
 import org.kestra.core.models.tasks.ResolvedTask;
@@ -15,7 +16,7 @@ import java.util.stream.Collectors;
 
 @Slf4j
 public class FlowableUtils {
-    public static List<TaskRun> resolveSequentialNexts(
+    public static List<NextTaskRun> resolveSequentialNexts(
         Execution execution,
         List<ResolvedTask> tasks,
         List<ResolvedTask> errors
@@ -23,7 +24,7 @@ public class FlowableUtils {
         return FlowableUtils.resolveSequentialNexts(execution, tasks, errors, null);
     }
 
-    public static List<TaskRun> resolveSequentialNexts(
+    public static List<NextTaskRun> resolveSequentialNexts(
         Execution execution,
         List<ResolvedTask> tasks,
         List<ResolvedTask> errors,
@@ -39,7 +40,7 @@ public class FlowableUtils {
         // first one
         List<TaskRun> taskRuns = execution.findTaskRunByTasks(currentTasks, parentTaskRun);
         if (taskRuns.size() == 0) {
-            return Collections.singletonList(currentTasks.get(0).toTaskRun(execution));
+            return Collections.singletonList(currentTasks.get(0).toNextTaskRun(execution));
         }
 
         // first created, leave
@@ -60,7 +61,7 @@ public class FlowableUtils {
             int lastIndex = taskRuns.indexOf(lastTerminated.get());
 
             if (currentTasks.size() > lastIndex + 1) {
-                return Collections.singletonList(currentTasks.get(lastIndex + 1).toTaskRun(execution));
+                return Collections.singletonList(currentTasks.get(lastIndex + 1).toNextTaskRun(execution));
             }
         }
 
@@ -115,7 +116,7 @@ public class FlowableUtils {
     }
 
 
-    public static List<TaskRun> resolveParallelNexts(
+    public static List<NextTaskRun> resolveParallelNexts(
         Execution execution,
         List<ResolvedTask> tasks,
         List<ResolvedTask> errors,
@@ -145,7 +146,7 @@ public class FlowableUtils {
         if (notFinds.size() > 0 && lastCreated.isEmpty()) {
             return notFinds
                 .stream()
-                .map(resolvedTask -> resolvedTask.toTaskRun(execution))
+                .map(resolvedTask -> resolvedTask.toNextTaskRun(execution))
                 .limit(1)
                 .collect(Collectors.toList());
         }

--- a/core/src/main/java/org/kestra/core/runners/RunContext.java
+++ b/core/src/main/java/org/kestra/core/runners/RunContext.java
@@ -177,7 +177,12 @@ public class RunContext {
         }
 
         if (taskRun != null && execution != null) {
-            builder.put("parents", execution.parents(taskRun));
+            List<Map<String, Object>> parents = execution.parents(taskRun);
+
+            builder.put("parents", parents);
+            if (parents.size() > 0) {
+                builder.put("parent", parents.get(0));
+            }
         }
 
         // special cases for listeners

--- a/core/src/main/java/org/kestra/core/tasks/flows/EachParallel.java
+++ b/core/src/main/java/org/kestra/core/tasks/flows/EachParallel.java
@@ -10,6 +10,7 @@ import org.kestra.core.exceptions.IllegalVariableEvaluationException;
 import org.kestra.core.models.annotations.Example;
 import org.kestra.core.models.annotations.Plugin;
 import org.kestra.core.models.executions.Execution;
+import org.kestra.core.models.executions.NextTaskRun;
 import org.kestra.core.models.executions.TaskRun;
 import org.kestra.core.models.flows.State;
 import org.kestra.core.models.hierarchies.ParentTaskTree;
@@ -124,7 +125,7 @@ public class EachParallel extends Parallel implements FlowableTask<VoidOutput> {
     }
 
     @Override
-    public List<TaskRun> resolveNexts(RunContext runContext, Execution execution, TaskRun parentTaskRun) throws IllegalVariableEvaluationException {
+    public List<NextTaskRun> resolveNexts(RunContext runContext, Execution execution, TaskRun parentTaskRun) throws IllegalVariableEvaluationException {
         return FlowableUtils.resolveParallelNexts(
             execution,
             FlowableUtils.resolveEachTasks(runContext, parentTaskRun, this.getTasks(), this.value),

--- a/core/src/main/java/org/kestra/core/tasks/flows/EachSequential.java
+++ b/core/src/main/java/org/kestra/core/tasks/flows/EachSequential.java
@@ -1,7 +1,5 @@
 package org.kestra.core.tasks.flows;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -12,6 +10,7 @@ import org.kestra.core.exceptions.IllegalVariableEvaluationException;
 import org.kestra.core.models.annotations.Example;
 import org.kestra.core.models.annotations.Plugin;
 import org.kestra.core.models.executions.Execution;
+import org.kestra.core.models.executions.NextTaskRun;
 import org.kestra.core.models.executions.TaskRun;
 import org.kestra.core.models.flows.State;
 import org.kestra.core.models.hierarchies.ParentTaskTree;
@@ -25,11 +24,9 @@ import org.kestra.core.runners.FlowableUtils;
 import org.kestra.core.runners.RunContext;
 import org.kestra.core.services.TreeService;
 
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
 import javax.validation.Valid;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
@@ -104,7 +101,7 @@ public class EachSequential extends Sequential implements FlowableTask<VoidOutpu
     }
 
     @Override
-    public List<TaskRun> resolveNexts(RunContext runContext, Execution execution, TaskRun parentTaskRun) throws IllegalVariableEvaluationException {
+    public List<NextTaskRun> resolveNexts(RunContext runContext, Execution execution, TaskRun parentTaskRun) throws IllegalVariableEvaluationException {
         return FlowableUtils.resolveSequentialNexts(
             execution,
             FlowableUtils.resolveEachTasks(runContext, parentTaskRun, this.getTasks(), this.value),

--- a/core/src/main/java/org/kestra/core/tasks/flows/Parallel.java
+++ b/core/src/main/java/org/kestra/core/tasks/flows/Parallel.java
@@ -10,8 +10,8 @@ import org.kestra.core.exceptions.IllegalVariableEvaluationException;
 import org.kestra.core.models.annotations.Example;
 import org.kestra.core.models.annotations.Plugin;
 import org.kestra.core.models.executions.Execution;
+import org.kestra.core.models.executions.NextTaskRun;
 import org.kestra.core.models.executions.TaskRun;
-import org.kestra.core.models.flows.State;
 import org.kestra.core.models.hierarchies.ParentTaskTree;
 import org.kestra.core.models.hierarchies.TaskTree;
 import org.kestra.core.models.tasks.FlowableTask;
@@ -22,10 +22,8 @@ import org.kestra.core.runners.FlowableUtils;
 import org.kestra.core.runners.RunContext;
 import org.kestra.core.services.TreeService;
 
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import javax.validation.Valid;
@@ -103,7 +101,7 @@ public class Parallel extends Task implements FlowableTask<VoidOutput> {
     }
 
     @Override
-    public List<TaskRun> resolveNexts(RunContext runContext, Execution execution, TaskRun parentTaskRun) throws IllegalVariableEvaluationException {
+    public List<NextTaskRun> resolveNexts(RunContext runContext, Execution execution, TaskRun parentTaskRun) throws IllegalVariableEvaluationException {
         return FlowableUtils.resolveParallelNexts(
             execution,
             this.childTasks(runContext, parentTaskRun),

--- a/core/src/main/java/org/kestra/core/tasks/flows/Sequential.java
+++ b/core/src/main/java/org/kestra/core/tasks/flows/Sequential.java
@@ -10,6 +10,7 @@ import org.kestra.core.exceptions.IllegalVariableEvaluationException;
 import org.kestra.core.models.annotations.Example;
 import org.kestra.core.models.annotations.Plugin;
 import org.kestra.core.models.executions.Execution;
+import org.kestra.core.models.executions.NextTaskRun;
 import org.kestra.core.models.executions.TaskRun;
 import org.kestra.core.models.hierarchies.ParentTaskTree;
 import org.kestra.core.models.hierarchies.TaskTree;
@@ -100,7 +101,7 @@ public class Sequential extends Task implements FlowableTask<VoidOutput> {
     }
 
     @Override
-    public List<TaskRun> resolveNexts(RunContext runContext, Execution execution, TaskRun parentTaskRun) throws IllegalVariableEvaluationException {
+    public List<NextTaskRun> resolveNexts(RunContext runContext, Execution execution, TaskRun parentTaskRun) throws IllegalVariableEvaluationException {
         return FlowableUtils.resolveSequentialNexts(
             execution,
             this.childTasks(runContext, parentTaskRun),

--- a/core/src/main/java/org/kestra/core/tasks/flows/Switch.java
+++ b/core/src/main/java/org/kestra/core/tasks/flows/Switch.java
@@ -8,6 +8,7 @@ import org.kestra.core.exceptions.IllegalVariableEvaluationException;
 import org.kestra.core.models.annotations.Example;
 import org.kestra.core.models.annotations.Plugin;
 import org.kestra.core.models.executions.Execution;
+import org.kestra.core.models.executions.NextTaskRun;
 import org.kestra.core.models.executions.TaskRun;
 import org.kestra.core.models.flows.State;
 import org.kestra.core.models.hierarchies.ParentTaskTree;
@@ -159,7 +160,7 @@ public class Switch extends Task implements FlowableTask<Switch.Output>, TaskVal
     }
 
     @Override
-    public List<TaskRun> resolveNexts(RunContext runContext, Execution execution, TaskRun parentTaskRun) throws IllegalVariableEvaluationException {
+    public List<NextTaskRun> resolveNexts(RunContext runContext, Execution execution, TaskRun parentTaskRun) throws IllegalVariableEvaluationException {
         return FlowableUtils.resolveSequentialNexts(
             execution,
             this.childTasks(runContext, parentTaskRun),

--- a/core/src/main/java/org/kestra/core/utils/Await.java
+++ b/core/src/main/java/org/kestra/core/utils/Await.java
@@ -57,7 +57,7 @@ public class Await {
             } else {
                 return false;
             }
-        }, null);
+        }, sleep);
 
         return result.get();
     }

--- a/core/src/test/java/org/kestra/core/tasks/flows/TemplateTest.java
+++ b/core/src/test/java/org/kestra/core/tasks/flows/TemplateTest.java
@@ -25,7 +25,7 @@ public class TemplateTest extends AbstractMemoryRunnerTest {
     public static final org.kestra.core.models.templates.Template TEMPLATE = org.kestra.core.models.templates.Template.builder()
         .id("template")
         .namespace("org.kestra.tests")
-        .tasks(Collections.singletonList(Return.builder().id("test").type(Return.class.getName()).format("{{ inputs.with-string }}").build())).build();
+        .tasks(Collections.singletonList(Return.builder().id("test").type(Return.class.getName()).format("{{ parent.outputs.args.my-forward }}").build())).build();
 
     public static void withTemplate(RunnerUtils runnerUtils, TemplateRepositoryInterface templateRepository) throws TimeoutException {
         templateRepository.create(TEMPLATE);

--- a/core/src/test/resources/flows/valids/with-template.yaml
+++ b/core/src/test/resources/flows/valids/with-template.yaml
@@ -20,6 +20,8 @@ tasks:
     type: org.kestra.core.tasks.flows.Template
     namespace: org.kestra.tests
     templateId: template
+    args:
+      my-forward: "{{ inputs.with-string }}"
   - id: 3-end
     type: org.kestra.core.tasks.debugs.Return
     format: "{{task.id}} > {{taskrun.startDate}}"


### PR DESCRIPTION
Later the outputs are save later and unusable for childs tasks.
Also add input on template to rename a vars on a template and don't depend on global context