### PR TITLE
feat(core): make scheduler scalable

### DIFF
--- a/core/src/main/java/org/kestra/core/models/flows/Flow.java
+++ b/core/src/main/java/org/kestra/core/models/flows/Flow.java
@@ -249,7 +249,7 @@ public class Flow implements DeletedInterface {
         return new Flow(
             this.id,
             this.namespace,
-            this.revision,
+            this.revision + 1,
             this.description,
             this.inputs,
             this.variables,

--- a/core/src/main/java/org/kestra/core/repositories/FlowRepositoryInterface.java
+++ b/core/src/main/java/org/kestra/core/repositories/FlowRepositoryInterface.java
@@ -46,5 +46,5 @@ public interface FlowRepositoryInterface {
 
     Flow update(Flow flow, Flow previous) throws ConstraintViolationException;
 
-    void delete(Flow flow);
+    Flow delete(Flow flow);
 }

--- a/core/src/test/java/org/kestra/core/schedulers/AbstractSchedulerTest.java
+++ b/core/src/test/java/org/kestra/core/schedulers/AbstractSchedulerTest.java
@@ -9,7 +9,7 @@ import org.kestra.core.queues.QueueFactoryInterface;
 import org.kestra.core.queues.QueueInterface;
 import org.kestra.core.repositories.ExecutionRepositoryInterface;
 import org.kestra.core.repositories.TriggerRepositoryInterface;
-import org.kestra.core.services.FlowListenersService;
+import org.kestra.runner.memory.MemoryFlowListeners;
 import org.kestra.core.tasks.debugs.Return;
 import org.kestra.core.utils.ExecutorsUtils;
 import org.kestra.core.utils.IdUtils;
@@ -20,7 +20,7 @@ import javax.inject.Inject;
 import javax.inject.Named;
 
 @MicronautTest
-abstract class AbstractSchedulerTest {
+abstract public class AbstractSchedulerTest {
     @Inject
     protected ApplicationContext applicationContext;
 
@@ -34,7 +34,7 @@ abstract class AbstractSchedulerTest {
     protected ExecutionRepositoryInterface executionRepository;
 
     @Inject
-    protected FlowListenersService flowListenersService;
+    protected MemoryFlowListeners flowListenersService;
 
     @Inject
     @Named(QueueFactoryInterface.EXECUTION_NAMED)

--- a/core/src/test/java/org/kestra/core/schedulers/SchedulerScheduleTest.java
+++ b/core/src/test/java/org/kestra/core/schedulers/SchedulerScheduleTest.java
@@ -6,7 +6,7 @@ import org.kestra.core.models.flows.Flow;
 import org.kestra.core.models.flows.State;
 import org.kestra.core.models.triggers.types.Schedule;
 import org.kestra.core.repositories.ExecutionRepositoryInterface;
-import org.kestra.core.services.FlowListenersService;
+import org.kestra.runner.memory.MemoryFlowListeners;
 
 import java.time.ZonedDateTime;
 import java.time.temporal.ChronoUnit;
@@ -43,7 +43,7 @@ class SchedulerScheduleTest extends AbstractSchedulerTest {
     @Test
     void schedule() throws Exception {
         // mock flow listeners
-        FlowListenersService flowListenersServiceSpy = spy(this.flowListenersService);
+        MemoryFlowListeners flowListenersServiceSpy = spy(this.flowListenersService);
         ExecutionRepositoryInterface executionRepositorySpy = spy(this.executionRepository);
         CountDownLatch queueCount = new CountDownLatch(5);
 

--- a/core/src/test/java/org/kestra/core/schedulers/SchedulerThreadTest.java
+++ b/core/src/test/java/org/kestra/core/schedulers/SchedulerThreadTest.java
@@ -12,7 +12,7 @@ import org.kestra.core.models.triggers.PollingTriggerInterface;
 import org.kestra.core.models.triggers.TriggerContext;
 import org.kestra.core.repositories.ExecutionRepositoryInterface;
 import org.kestra.core.runners.RunContext;
-import org.kestra.core.services.FlowListenersService;
+import org.kestra.runner.memory.MemoryFlowListeners;
 import org.kestra.core.utils.IdUtils;
 
 import java.time.Duration;
@@ -39,7 +39,7 @@ class SchedulerThreadTest extends AbstractSchedulerTest {
     @Test
     void thread() throws Exception {
         // mock flow listeners
-        FlowListenersService flowListenersServiceSpy = spy(this.flowListenersService);
+        MemoryFlowListeners flowListenersServiceSpy = spy(this.flowListenersService);
         ExecutionRepositoryInterface executionRepositorySpy = spy(this.executionRepository);
         CountDownLatch queueCount = new CountDownLatch(2);
 

--- a/core/src/test/java/org/kestra/core/services/FlowServiceTest.java
+++ b/core/src/test/java/org/kestra/core/services/FlowServiceTest.java
@@ -1,0 +1,102 @@
+package org.kestra.core.services;
+
+import io.micronaut.test.annotation.MicronautTest;
+import org.junit.jupiter.api.Test;
+import org.kestra.core.models.flows.Flow;
+import org.kestra.core.tasks.debugs.Return;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import javax.inject.Inject;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+@MicronautTest
+class FlowServiceTest {
+    @Inject
+    private FlowService flowService;
+
+    private static Flow create(String flowId, String taskId, Integer revision) {
+        return Flow.builder()
+            .id(flowId)
+            .namespace("org.kestra.unittest")
+            .revision(revision)
+            .tasks(Collections.singletonList(Return.builder()
+                .id(taskId)
+                .type(Return.class.getName())
+                .format("test")
+                .build()))
+            .build();
+    }
+
+    @Test
+    public void sameRevisionWithDeletedOrdered() {
+        Stream<Flow> stream = Stream.of(
+            create("test", "test", 1),
+            create("test", "test2", 2),
+            create("test", "test2", 2).toDeleted(),
+            create("test", "test2", 4)
+        );
+
+        List<Flow> collect = flowService.keepLastVersion(stream).collect(Collectors.toList());
+
+        assertThat(collect.size(), is(1));
+        assertThat(collect.get(0).isDeleted(), is(false));
+        assertThat(collect.get(0).getRevision(), is(4));
+    }
+
+    @Test
+    public void sameRevisionWithDeletedSameRevision() {
+        Stream<Flow> stream = Stream.of(
+            create("test", "test", 1),
+            create("test", "test2", 2),
+            create("test", "test3", 3),
+            create("test", "test2", 2).toDeleted()
+        );
+
+        List<Flow> collect = flowService.keepLastVersion(stream).collect(Collectors.toList());
+
+        assertThat(collect.size(), is(1));
+        assertThat(collect.get(0).isDeleted(), is(false));
+        assertThat(collect.get(0).getRevision(), is(3));
+    }
+
+    @Test
+    public void sameRevisionWithDeletedUnordered() {
+        Stream<Flow> stream = Stream.of(
+            create("test", "test", 1),
+            create("test", "test2", 2),
+            create("test", "test2", 4),
+            create("test", "test2", 2).toDeleted()
+        );
+
+        List<Flow> collect = flowService.keepLastVersion(stream).collect(Collectors.toList());
+
+        assertThat(collect.size(), is(1));
+        assertThat(collect.get(0).isDeleted(), is(false));
+        assertThat(collect.get(0).getRevision(), is(4));
+    }
+
+    @Test
+    public void multipleFlow() {
+        Stream<Flow> stream = Stream.of(
+            create("test", "test", 2),
+            create("test", "test2", 1),
+            create("test2", "test2", 1),
+            create("test2", "test3", 3),
+            create("test3", "test1", 2),
+            create("test3", "test2", 3)
+
+        );
+
+        List<Flow> collect = flowService.keepLastVersion(stream).collect(Collectors.toList());
+
+        assertThat(collect.size(), is(3));
+        assertThat(collect.stream().filter(flow -> flow.getId().equals("test")).findFirst().orElseThrow().getRevision(), is(2));
+        assertThat(collect.stream().filter(flow -> flow.getId().equals("test2")).findFirst().orElseThrow().getRevision(), is(3));
+        assertThat(collect.stream().filter(flow -> flow.getId().equals("test3")).findFirst().orElseThrow().getRevision(), is(3));
+    }
+}

--- a/repository-elasticsearch/src/main/java/org/kestra/repository/elasticsearch/ElasticSearchFlowRepository.java
+++ b/repository-elasticsearch/src/main/java/org/kestra/repository/elasticsearch/ElasticSearchFlowRepository.java
@@ -161,9 +161,13 @@ public class ElasticSearchFlowRepository extends AbstractElasticSearchRepository
     }
 
     @Override
-    public void delete(Flow flow) {
-        flowQueue.emit(flow.toDeleted());
-        this.deleteRequest(INDEX_NAME, flowId(flow));
+    public Flow delete(Flow flow) {
+        Flow deleted = flow.toDeleted();
+
+        flowQueue.emit(deleted);
+        this.deleteRequest(INDEX_NAME, flowId(deleted));
+
+        return deleted;
     }
 
     public List<String> findDistinctNamespace() {

--- a/repository-memory/src/main/java/org/kestra/repository/memory/MemoryFlowRepository.java
+++ b/repository-memory/src/main/java/org/kestra/repository/memory/MemoryFlowRepository.java
@@ -140,13 +140,17 @@ public class MemoryFlowRepository implements FlowRepositoryInterface {
     }
 
     @Override
-    public void delete(Flow flow) {
+    public Flow delete(Flow flow) {
         if (this.findById(flow.getNamespace(), flow.getId(), Optional.of(flow.getRevision())).isEmpty()) {
             throw new IllegalStateException("Flow " + flow.getId() + " doesn't exists");
         }
 
-        flowQueue.emit(flow.toDeleted());
-        this.flows.remove(flowId(flow));
+        Flow deleted = flow.toDeleted();
+
+        flowQueue.emit(deleted);
+        this.flows.remove(flowId(deleted));
+
+        return deleted;
     }
 
     @Override

--- a/runner-kafka/build.gradle
+++ b/runner-kafka/build.gradle
@@ -12,6 +12,7 @@ dependencies {
 
     testImplementation project(':core').sourceSets.test.output
     testImplementation project(':repository-memory')
+    testImplementation project(':runner-memory').sourceSets.test.output
     testImplementation project(':storage-local')
 
     testImplementation group: 'com.bakdata.fluent-kafka-streams-tests', name: 'fluent-kafka-streams-tests', version: "2.1.0"

--- a/runner-kafka/src/main/java/org/kestra/runner/kafka/KafkaFlowListeners.java
+++ b/runner-kafka/src/main/java/org/kestra/runner/kafka/KafkaFlowListeners.java
@@ -1,0 +1,116 @@
+package org.kestra.runner.kafka;
+
+import com.google.common.collect.Streams;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.common.utils.Bytes;
+import org.apache.kafka.streams.KafkaStreams;
+import org.apache.kafka.streams.StreamsBuilder;
+import org.apache.kafka.streams.Topology;
+import org.apache.kafka.streams.errors.InvalidStateStoreException;
+import org.apache.kafka.streams.kstream.Consumed;
+import org.apache.kafka.streams.kstream.Materialized;
+import org.apache.kafka.streams.state.KeyValueIterator;
+import org.apache.kafka.streams.state.KeyValueStore;
+import org.apache.kafka.streams.state.QueryableStoreTypes;
+import org.apache.kafka.streams.state.ReadOnlyKeyValueStore;
+import org.kestra.core.models.flows.Flow;
+import org.kestra.core.services.FlowListenersInterface;
+import org.kestra.core.services.FlowService;
+import org.kestra.runner.kafka.serializers.JsonSerde;
+import org.kestra.runner.kafka.services.KafkaAdminService;
+import org.kestra.runner.kafka.services.KafkaStreamService;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
+@Singleton
+@Slf4j
+@KafkaQueueEnabled
+public class KafkaFlowListeners implements FlowListenersInterface {
+    private final KafkaAdminService kafkaAdminService;
+    private final FlowService flowService;
+
+    private ReadOnlyKeyValueStore<String, Flow> store;
+    private final List<Consumer<List<Flow>>> consumers = new ArrayList<>();
+    private final KafkaStreamService.Stream stream;
+
+    @Inject
+    public KafkaFlowListeners(
+        KafkaAdminService kafkaAdminService,
+        KafkaStreamService kafkaStreamService,
+        FlowService flowService
+    ) {
+        this.kafkaAdminService = kafkaAdminService;
+        this.flowService = flowService;
+
+        kafkaAdminService.createIfNotExist(Flow.class);
+
+        stream = kafkaStreamService.of(this.getClass(), this.topology());
+        stream.start((newState, oldState) -> {
+            if (newState == KafkaStreams.State.RUNNING) {
+                try {
+                    this.store = stream.store("flow", QueryableStoreTypes.keyValueStore());
+                } catch (InvalidStateStoreException e) {
+                    this.store = null;
+                    log.warn(e.getMessage(), e);
+                }
+            }
+        });
+    }
+
+    public Topology topology() {
+        StreamsBuilder builder = new StreamsBuilder();
+
+        builder
+            .table(
+                kafkaAdminService.getTopicName(Flow.class),
+                Consumed.with(Serdes.String(), JsonSerde.of(Flow.class)),
+                Materialized.<String, Flow, KeyValueStore<Bytes, byte[]>>as("flow")
+                    .withKeySerde(Serdes.String())
+                    .withValueSerde(JsonSerde.of(Flow.class))
+            )
+            .toStream()
+            .peek((key, value) -> {
+                this.consumers
+                    .forEach(consumer -> consumer.accept(new ArrayList<>(flows())));
+            });
+
+        Topology topology = builder.build();
+
+        if (log.isTraceEnabled()) {
+            log.trace(topology.describe().toString());
+        }
+
+        return topology;
+    }
+
+    @SuppressWarnings("UnstableApiUsage")
+    @Override
+    public List<Flow> flows() {
+        if (this.store == null || stream.state() != KafkaStreams.State.RUNNING) {
+            return Collections.emptyList();
+        }
+
+        try (KeyValueIterator<String, Flow> all = this.store.all()) {
+            List<Flow> alls = Streams.stream(all).map(r -> r.value).collect(Collectors.toList());
+
+            return flowService
+                .keepLastVersion(alls)
+                .stream()
+                .filter(flow -> !flow.isDeleted())
+                .collect(Collectors.toList());
+        }
+    }
+
+    @Override
+    public void listen(Consumer<List<Flow>> consumer) {
+        consumers.add(consumer);
+        consumer.accept(this.flows());
+    }
+}

--- a/runner-kafka/src/test/java/org/kestra/runner/kafka/KafkaFlowListenersTest.java
+++ b/runner-kafka/src/test/java/org/kestra/runner/kafka/KafkaFlowListenersTest.java
@@ -1,0 +1,16 @@
+package org.kestra.runner.kafka;
+
+import org.junit.jupiter.api.Test;
+import org.kestra.core.runners.FlowListenersTest;
+
+import javax.inject.Inject;
+
+class KafkaFlowListenersTest extends FlowListenersTest {
+    @Inject
+    KafkaFlowListeners flowListenersService;
+
+    @Test
+    public void all() {
+        this.suite(flowListenersService);
+    }
+}

--- a/runner-memory/src/main/java/org/kestra/runner/memory/MemoryFlowListeners.java
+++ b/runner-memory/src/main/java/org/kestra/runner/memory/MemoryFlowListeners.java
@@ -1,10 +1,11 @@
-package org.kestra.core.services;
+package org.kestra.runner.memory;
 
 import lombok.extern.slf4j.Slf4j;
 import org.kestra.core.models.flows.Flow;
 import org.kestra.core.queues.QueueFactoryInterface;
 import org.kestra.core.queues.QueueInterface;
 import org.kestra.core.repositories.FlowRepositoryInterface;
+import org.kestra.core.services.FlowListenersInterface;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -15,7 +16,8 @@ import javax.inject.Singleton;
 
 @Singleton
 @Slf4j
-public class FlowListenersService implements FlowListenersInterface {
+@MemoryQueueEnabled
+public class MemoryFlowListeners implements FlowListenersInterface {
     private final QueueInterface<Flow> flowQueue;
 
     private final List<Flow> flows;
@@ -23,7 +25,7 @@ public class FlowListenersService implements FlowListenersInterface {
     private final List<Consumer<List<Flow>>> consumers = new ArrayList<>();
 
     @Inject
-    public FlowListenersService(
+    public MemoryFlowListeners(
         FlowRepositoryInterface flowRepository,
         @Named(QueueFactoryInterface.FLOW_NAMED) QueueInterface<Flow> flowQueue
     ) {

--- a/runner-memory/src/test/java/org/kestra/runner/memory/MemoryFlowListenersTest.java
+++ b/runner-memory/src/test/java/org/kestra/runner/memory/MemoryFlowListenersTest.java
@@ -1,0 +1,16 @@
+package org.kestra.runner.memory;
+
+import org.junit.jupiter.api.Test;
+import org.kestra.core.runners.FlowListenersTest;
+
+import javax.inject.Inject;
+
+class MemoryFlowListenersTest extends FlowListenersTest {
+    @Inject
+    MemoryFlowListeners flowListenersService;
+
+    @Test
+    public void all() {
+        this.suite(flowListenersService);
+    }
+}


### PR DESCRIPTION
Now scheduler can be scalable and deploy as many time as you want.
We use kafka to dispatch flow between different scheduler.