### PR TITLE
fix(ui): set execution default sort when all the logic does not provide sort information in route

### DIFF
--- a/ui/src/components/executions/Executions.vue
+++ b/ui/src/components/executions/Executions.vue
@@ -241,7 +241,7 @@
                     size: parseInt(this.$route.query.size || 25),
                     page: parseInt(this.$route.query.page || 1),
                     q: this.executionQuery,
-                    sort: this.$route.query.sort,
+                    sort: this.$route.query.sort || "state.startDate:desc",
                     state: this.$route.query.status
                 }).finally(callback);
             },


### PR DESCRIPTION
so the execution are always sorted by default now