### PR TITLE
fix(kafka-runner): handle large messsage exception

### DIFF
--- a/core/src/main/java/org/kestra/core/queues/QueueFactoryInterface.java
+++ b/core/src/main/java/org/kestra/core/queues/QueueFactoryInterface.java
@@ -13,6 +13,7 @@ import org.kestra.core.runners.WorkerTaskRunning;
 
 public interface QueueFactoryInterface {
     String EXECUTION_NAMED = "executionQueue";
+    String EXECUTOR_NAMED = "executorQueue";
     String WORKERTASK_NAMED = "workerTaskQueue";
     String WORKERTASKRESULT_NAMED = "workerTaskResultQueue";
     String FLOW_NAMED = "flowQueue";
@@ -22,8 +23,11 @@ public interface QueueFactoryInterface {
     String WORKERINSTANCE_NAMED = "workerInstanceQueue";
     String WORKERTASKRUNNING_NAMED = "workerTaskRuninngQueue";
     String TRIGGER_NAMED = "triggerQueue";
+    String LOG_NAMED = "logQueue";
 
     QueueInterface<Execution> execution();
+
+    QueueInterface<Execution> executor();
 
     QueueInterface<WorkerTask> workerTask();
 
@@ -43,5 +47,8 @@ public interface QueueFactoryInterface {
 
     QueueInterface<Trigger> trigger();
 
+    QueueInterface<LogEntry> logs();
+
     WorkerTaskQueueInterface workerTaskQueue();
+
 }

--- a/core/src/test/java/org/kestra/core/Helpers.java
+++ b/core/src/test/java/org/kestra/core/Helpers.java
@@ -17,7 +17,7 @@ import java.util.Objects;
 import java.util.function.BiConsumer;
 
 public class Helpers {
-    public static long FLOWS_COUNT = 40;
+    public static long FLOWS_COUNT = 41;
 
     public static ApplicationContext applicationContext() throws URISyntaxException {
         return applicationContext(Paths.get(Objects.requireNonNull(Helpers.class.getClassLoader().getResource("plugins")).toURI()));

--- a/core/src/test/resources/flows/valids/inputs-large.yaml
+++ b/core/src/test/resources/flows/valids/inputs-large.yaml
@@ -1,0 +1,15 @@
+id: inputs-large
+namespace: org.kestra.tests
+
+inputs:
+- name: string
+  type: STRING
+
+tasks:
+  - id: 1_each
+    type: org.kestra.core.tasks.flows.EachSequential
+    value: '["1", "2", "3", "4", "5", "6", "7", "8", "9"]'
+    tasks:
+    - id: string
+      type: org.kestra.core.tasks.debugs.Return
+      format: "{{inputs.string}}"

--- a/runner-kafka/src/main/java/org/kestra/runner/kafka/KafkaExecutorProductionExceptionHandler.java
+++ b/runner-kafka/src/main/java/org/kestra/runner/kafka/KafkaExecutorProductionExceptionHandler.java
@@ -1,0 +1,124 @@
+package org.kestra.runner.kafka;
+
+import com.google.common.collect.ImmutableMap;
+import io.micronaut.context.ApplicationContext;
+import io.micronaut.inject.qualifiers.Qualifiers;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.errors.RecordTooLargeException;
+import org.kestra.core.exceptions.InternalException;
+import org.kestra.core.models.executions.Execution;
+import org.kestra.core.models.executions.LogEntry;
+import org.kestra.core.models.executions.TaskRun;
+import org.kestra.core.queues.QueueFactoryInterface;
+import org.kestra.core.queues.QueueInterface;
+import org.kestra.runner.kafka.configs.TopicsConfig;
+import org.kestra.runner.kafka.serializers.JsonDeserializer;
+import org.kestra.runner.kafka.services.KafkaStreamSourceService;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Map;
+
+@Slf4j
+public class KafkaExecutorProductionExceptionHandler implements org.apache.kafka.streams.errors.ProductionExceptionHandler {
+    public static final String APPLICATION_CONTEXT_CONFIG = "application.context";
+
+    private ApplicationContext applicationContext;
+    private KafkaQueue<Execution> executorQueue;
+    private KafkaQueue<LogEntry> logQueue;
+
+    @Override
+    public ProductionExceptionHandlerResponse handle(ProducerRecord<byte[], byte[]> record, Exception exception) {
+        if (log.isDebugEnabled()) {
+            log.error(
+                "Failed to produced message on topic '{}', partition '{}', key '{}', value '{}' with exception '{}'",
+                record.topic(),
+                record.partition(),
+                new String(record.key()),
+                new String(record.value()),
+                exception.getMessage(),
+                exception
+            );
+        } else {
+            log.error(
+                "Failed to produced message on topic '{}', partition '{}', key '{}' with exception '{}'",
+                record.topic(),
+                record.partition(),
+                new String(record.key()),
+                exception.getMessage(),
+                exception
+            );
+        }
+
+        try {
+            TopicsConfig topicsConfig = KafkaQueue.topicsConfigByTopicName(applicationContext, record.topic());
+
+            if (topicsConfig.getKey().equals(KafkaStreamSourceService.TOPIC_EXECUTOR) || topicsConfig.getCls() == Execution.class) {
+                Execution execution = getObject(Execution.class, record);
+
+                Execution.FailedExecutionWithLog failedExecutionWithLog = execution.failedExecutionFromExecutor(exception);
+                Execution sendExecution = failedExecutionWithLog.getExecution();
+
+                failedExecutionWithLog.getLogs().forEach(logEntry -> logQueue.emit(logEntry));
+
+                if (exception instanceof RecordTooLargeException) {
+                    boolean exit = false;
+                    while (!exit) {
+                        try {
+                            sendExecution = reduceOutputs(sendExecution);
+                            executorQueue.emit(sendExecution);
+                            exit = true;
+                        } catch (Exception e) {
+                            exit = sendExecution.getTaskRunList().size() > 0;
+                        }
+                    }
+
+                    return ProductionExceptionHandlerResponse.CONTINUE;
+                } else {
+                    executorQueue.emit(sendExecution);
+                }
+            }
+        } catch (Exception e) {
+            log.warn("Can't resolve failed produce with exception '{}'", e.getMessage(), e);
+        }
+
+        return ProductionExceptionHandlerResponse.FAIL;
+    }
+
+    private Execution reduceOutputs(Execution execution) throws InternalException {
+        if (execution.getTaskRunList().size() == 0) {
+            return execution;
+        }
+
+        ArrayList<TaskRun> reverse = new ArrayList<>(execution.getTaskRunList());
+        Collections.reverse(reverse);
+
+        TaskRun taskRun = reverse.get(0).withOutputs(ImmutableMap.of());
+
+        return execution.withTaskRun(taskRun);
+    }
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    private <T> T getObject(Class<T> cls, ProducerRecord<byte[], byte[]> record) {
+        try (JsonDeserializer jsonDeserializer = new JsonDeserializer(cls)) {
+            return (T) jsonDeserializer.deserialize(record.topic(), record.value());
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public void configure(Map<String, ?> configs) {
+        applicationContext = (ApplicationContext) configs.get(APPLICATION_CONTEXT_CONFIG);
+
+        executorQueue = (KafkaQueue<Execution>) applicationContext.getBean(
+            QueueInterface.class,
+            Qualifiers.byName(QueueFactoryInterface.EXECUTOR_NAMED)
+        );
+
+        logQueue = (KafkaQueue<LogEntry>) applicationContext.getBean(
+            QueueInterface.class,
+            Qualifiers.byName(QueueFactoryInterface.LOG_NAMED)
+        );
+    }
+}

--- a/runner-kafka/src/main/java/org/kestra/runner/kafka/KafkaQueue.java
+++ b/runner-kafka/src/main/java/org/kestra/runner/kafka/KafkaQueue.java
@@ -112,7 +112,6 @@ public class KafkaQueue<T> extends AbstractQueue implements QueueInterface<T>, A
         this.produce(key(message), message);
     }
 
-
     @Override
     public void delete(T message) throws QueueException {
         this.produce(key(message), null);
@@ -167,6 +166,15 @@ public class KafkaQueue<T> extends AbstractQueue implements QueueInterface<T>, A
         return () -> {
             running.set(false);
         };
+    }
+
+    static TopicsConfig topicsConfigByTopicName(ApplicationContext applicationContext, String topicName) {
+        return applicationContext
+            .getBeansOfType(TopicsConfig.class)
+            .stream()
+            .filter(r -> r.getName().equals(topicName))
+            .findFirst()
+            .orElseThrow();
     }
 
     static TopicsConfig topicsConfig(ApplicationContext applicationContext, Class<?> cls) {

--- a/runner-kafka/src/main/java/org/kestra/runner/kafka/KafkaQueueFactory.java
+++ b/runner-kafka/src/main/java/org/kestra/runner/kafka/KafkaQueueFactory.java
@@ -15,6 +15,7 @@ import org.kestra.core.runners.WorkerInstance;
 import org.kestra.core.runners.WorkerTask;
 import org.kestra.core.runners.WorkerTaskResult;
 import org.kestra.core.runners.WorkerTaskRunning;
+import org.kestra.runner.kafka.services.KafkaStreamSourceService;
 
 import javax.inject.Inject;
 import javax.inject.Named;
@@ -31,6 +32,13 @@ public class KafkaQueueFactory implements QueueFactoryInterface {
     @Named(QueueFactoryInterface.EXECUTION_NAMED)
     public QueueInterface<Execution> execution() {
         return new KafkaQueue<>(Execution.class, applicationContext);
+    }
+
+    @Override
+    @Singleton
+    @Named(QueueFactoryInterface.EXECUTOR_NAMED)
+    public QueueInterface<Execution> executor() {
+        return new KafkaQueue<>(KafkaStreamSourceService.TOPIC_EXECUTOR, Execution.class, applicationContext);
     }
 
     @Override
@@ -94,6 +102,13 @@ public class KafkaQueueFactory implements QueueFactoryInterface {
     @Named(QueueFactoryInterface.TRIGGER_NAMED)
     public QueueInterface<Trigger> trigger() {
         return new KafkaQueue<>(Trigger.class, applicationContext);
+    }
+
+    @Override
+    @Singleton
+    @Named(QueueFactoryInterface.LOG_NAMED)
+    public QueueInterface<LogEntry> logs() {
+        return new KafkaQueue<>(LogEntry.class, applicationContext);
     }
 
     @Override

--- a/runner-kafka/src/main/java/org/kestra/runner/kafka/services/KafkaStreamService.java
+++ b/runner-kafka/src/main/java/org/kestra/runner/kafka/services/KafkaStreamService.java
@@ -10,7 +10,6 @@ import org.apache.kafka.streams.Topology;
 import org.apache.kafka.streams.errors.StreamsException;
 import org.apache.kafka.streams.processor.StateRestoreListener;
 import org.kestra.core.metrics.MetricRegistry;
-import org.kestra.runner.kafka.KafkaQueue;
 import org.kestra.runner.kafka.configs.ClientConfig;
 import org.kestra.runner.kafka.configs.StreamDefaultsConfig;
 

--- a/runner-kafka/src/test/java/org/kestra/runner/kafka/KafkaQueueTest.java
+++ b/runner-kafka/src/test/java/org/kestra/runner/kafka/KafkaQueueTest.java
@@ -1,0 +1,34 @@
+package org.kestra.runner.kafka;
+
+import io.micronaut.context.ApplicationContext;
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import org.junit.jupiter.api.Test;
+import org.kestra.core.models.executions.Execution;
+import org.kestra.runner.kafka.configs.TopicsConfig;
+import org.kestra.runner.kafka.services.KafkaStreamSourceService;
+
+import javax.inject.Inject;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+@MicronautTest
+class KafkaQueueTest {
+    @Inject
+    ApplicationContext applicationContext;
+
+    @Test
+    void topicsConfig() {
+        TopicsConfig topicsConfig = KafkaQueue.topicsConfig(applicationContext, Execution.class);
+        assertThat(topicsConfig.getCls(), is(Execution.class));
+
+        TopicsConfig byName = KafkaQueue.topicsConfigByTopicName(applicationContext, topicsConfig.getName());
+        assertThat(byName, is(topicsConfig));
+
+        topicsConfig = KafkaQueue.topicsConfig(applicationContext, KafkaStreamSourceService.TOPIC_EXECUTOR);
+        assertThat(topicsConfig.getKey(), is(KafkaStreamSourceService.TOPIC_EXECUTOR));
+
+        byName = KafkaQueue.topicsConfigByTopicName(applicationContext, topicsConfig.getName());
+        assertThat(byName, is(topicsConfig));
+    }
+}

--- a/runner-memory/src/main/java/org/kestra/runner/memory/MemoryQueueFactory.java
+++ b/runner-memory/src/main/java/org/kestra/runner/memory/MemoryQueueFactory.java
@@ -2,6 +2,7 @@ package org.kestra.runner.memory;
 
 import io.micronaut.context.ApplicationContext;
 import io.micronaut.context.annotation.Factory;
+import org.apache.commons.lang3.NotImplementedException;
 import org.kestra.core.models.executions.Execution;
 import org.kestra.core.models.executions.ExecutionKilled;
 import org.kestra.core.models.executions.LogEntry;
@@ -28,6 +29,13 @@ public class MemoryQueueFactory implements QueueFactoryInterface {
     @Named(QueueFactoryInterface.EXECUTION_NAMED)
     public QueueInterface<Execution> execution() {
         return new MemoryQueue<>(Execution.class, applicationContext);
+    }
+
+    @Override
+    @Singleton
+    @Named(QueueFactoryInterface.EXECUTOR_NAMED)
+    public QueueInterface<Execution> executor() {
+        throw new NotImplementedException();
     }
 
     @Override
@@ -91,6 +99,13 @@ public class MemoryQueueFactory implements QueueFactoryInterface {
     @Named(QueueFactoryInterface.TRIGGER_NAMED)
     public QueueInterface<Trigger> trigger() {
         return new MemoryQueue<>(Trigger.class, applicationContext);
+    }
+
+    @Override
+    @Singleton
+    @Named(QueueFactoryInterface.EXECUTOR_NAMED)
+    public QueueInterface<LogEntry> logs() {
+        return new MemoryQueue<>(LogEntry.class, applicationContext);
     }
 
     @Override


### PR DESCRIPTION
if kafka message is over `max.request.size` this will failed the executor until message is skipped.
we try to send a failed execution and continue the stream
