### PR TITLE
feat/flow executor

### DIFF
--- a/cli/src/main/resources/application.yml
+++ b/cli/src/main/resources/application.yml
@@ -118,6 +118,12 @@ kestra:
         properties:
           cleanup.policy: "delete,compact"
 
+      executorworkertaskexecution:
+        cls: io.kestra.core.runners.WorkerTaskExecution
+        name: "${kestra.kafka.defaults.topic-prefix}executor_workertaskexecution"
+        properties:
+          cleanup.policy: "delete,compact"
+
       workertask:
         name: "${kestra.kafka.defaults.topic-prefix}workertask"
         cls: io.kestra.core.runners.WorkerTask
@@ -157,6 +163,7 @@ kestra:
         name: "${kestra.kafka.defaults.topic-prefix}trigger"
         properties:
           cleanup.policy: "compact"
+
 
   elasticsearch:
     defaults:

--- a/core/src/main/java/io/kestra/core/runners/Executor.java
+++ b/core/src/main/java/io/kestra/core/runners/Executor.java
@@ -22,6 +22,7 @@ public class Executor {
     private final List<WorkerTask> workerTasks = new ArrayList<>();
     private final List<WorkerTaskResult> workerTaskResults = new ArrayList<>();
     private WorkerTaskResult joined;
+    private final List<WorkerTaskExecution> workerTaskExecutions = new ArrayList<>();
 
     public Executor(Execution execution, Long offset) {
         this.execution = execution;
@@ -70,6 +71,13 @@ public class Executor {
 
     public Executor withWorkerTaskResults(List<WorkerTaskResult> workerTaskResults, String from) {
         this.workerTaskResults.addAll(workerTaskResults);
+        this.from.add(from);
+
+        return this;
+    }
+
+    public Executor withWorkerTaskExecutions(List<WorkerTaskExecution> newExecutions, String from) {
+        this.workerTaskExecutions.addAll(newExecutions);
         this.from.add(from);
 
         return this;

--- a/core/src/main/java/io/kestra/core/runners/WorkerTaskExecution.java
+++ b/core/src/main/java/io/kestra/core/runners/WorkerTaskExecution.java
@@ -1,0 +1,25 @@
+package io.kestra.core.runners;
+
+import io.kestra.core.models.executions.Execution;
+import io.kestra.core.models.executions.TaskRun;
+import io.kestra.core.tasks.flows.Flow;
+import lombok.Builder;
+import lombok.Data;
+
+import javax.validation.constraints.NotNull;
+
+@Data
+@Builder
+public class WorkerTaskExecution {
+    @NotNull
+    private TaskRun taskRun;
+
+    @NotNull
+    private Flow task;
+
+    @NotNull
+    private Execution execution;
+
+    @NotNull
+    private RunContext runContext;
+}

--- a/core/src/main/java/io/kestra/core/services/FlowService.java
+++ b/core/src/main/java/io/kestra/core/services/FlowService.java
@@ -82,7 +82,7 @@ public class FlowService {
     }
 
     private static Stream<Flow> removeSelf(Stream<Flow> flowStream, Execution execution) {
-        // we don't allow recursive 
+        // we don't allow recursive
         return flowStream
             .filter(f -> !f.uidWithoutRevision().equals(Flow.uidWithoutRevision(execution)));
     }
@@ -159,6 +159,7 @@ public class FlowService {
 
                 return f.getMultipleConditionWindow().with(results);
             })
+            .filter(multipleConditionWindow -> multipleConditionWindow.getResults().size() > 0)
             .collect(Collectors.toList());
     }
 

--- a/core/src/test/java/io/kestra/core/Helpers.java
+++ b/core/src/test/java/io/kestra/core/Helpers.java
@@ -17,7 +17,7 @@ import java.util.Objects;
 import java.util.function.BiConsumer;
 
 public class Helpers {
-    public static long FLOWS_COUNT = 45;
+    public static long FLOWS_COUNT = 46;
 
     public static ApplicationContext applicationContext() throws URISyntaxException {
         return applicationContext(Paths.get(Objects.requireNonNull(Helpers.class.getClassLoader().getResource("plugins")).toURI()));

--- a/core/src/test/java/io/kestra/core/tasks/flows/FlowCaseTest.java
+++ b/core/src/test/java/io/kestra/core/tasks/flows/FlowCaseTest.java
@@ -1,0 +1,75 @@
+package io.kestra.core.tasks.flows;
+
+import com.google.common.collect.ImmutableMap;
+import io.kestra.core.models.executions.Execution;
+import io.kestra.core.models.flows.State;
+import io.kestra.core.queues.QueueFactoryInterface;
+import io.kestra.core.queues.QueueInterface;
+import io.kestra.core.runners.RunnerUtils;
+
+import java.time.Duration;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.inject.Singleton;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+
+@Singleton
+public class FlowCaseTest {
+    @Inject
+    @Named(QueueFactoryInterface.EXECUTION_NAMED)
+    QueueInterface<Execution> executionQueue;
+
+    @Inject
+    protected RunnerUtils runnerUtils;
+
+    public void waitSuccess() throws Exception {
+        this.run("OK", State.Type.SUCCESS, 2);
+    }
+
+    public void waitFailed() throws Exception {
+        this.run("THIRD", State.Type.FAILED, 4);
+    }
+
+    @SuppressWarnings("ResultOfMethodCallIgnored")
+    void run(String input, State.Type type, int count) throws Exception {
+        CountDownLatch countDownLatch = new CountDownLatch(1);
+        AtomicReference<Execution> triggered = new AtomicReference<>();
+
+        executionQueue.receive(execution -> {
+            if (execution.getFlowId().equals("switch") && execution.getState().getCurrent().isTerninated()) {
+                countDownLatch.countDown();
+                triggered.set(execution);
+            }
+        });
+
+        Execution execution = runnerUtils.runOne(
+            "io.kestra.tests",
+            "task-flow",
+            null,
+            (f, e) -> ImmutableMap.of("string", input),
+            Duration.ofMinutes(1)
+        );
+
+        countDownLatch.await(1, TimeUnit.MINUTES);
+
+        assertThat(execution.getTaskRunList(), hasSize(1));
+        assertThat(execution.getState().getCurrent(), is(type));
+
+        assertThat(execution.getTaskRunList().get(0).getOutputs().get("executionId"), is(triggered.get().getId()));
+        assertThat(execution.getTaskRunList().get(0).getOutputs().get("state"), is(triggered.get().getState().getCurrent().name()));
+
+        assertThat(triggered.get().getTrigger().getType(), is(Flow.class.getName()));
+        assertThat(triggered.get().getTrigger().getVariables().get("executionId"), is(execution.getId()));
+        assertThat(triggered.get().getTrigger().getVariables().get("flowId"), is(execution.getFlowId()));
+        assertThat(triggered.get().getTrigger().getVariables().get("namespace"), is(execution.getNamespace()));
+
+        assertThat(triggered.get().getTaskRunList(), hasSize(count));
+        assertThat(triggered.get().getState().getCurrent(), is(type));
+    }
+}

--- a/core/src/test/java/io/kestra/core/tasks/flows/FlowTest.java
+++ b/core/src/test/java/io/kestra/core/tasks/flows/FlowTest.java
@@ -1,66 +1,21 @@
 package io.kestra.core.tasks.flows;
 
-import com.google.common.collect.ImmutableMap;
+import io.kestra.core.runners.AbstractMemoryRunnerTest;
 import org.junit.jupiter.api.Test;
-import io.kestra.core.models.executions.Execution;
-import io.kestra.core.models.flows.State;
-import io.kestra.core.queues.QueueFactoryInterface;
-import io.kestra.core.queues.QueueInterface;
-import io.kestra.core.repositories.ExecutionRepositoryInterface;
-import io.kestra.core.repositories.FlowRepositoryInterface;
-import io.kestra.core.runners.*;
-import io.kestra.core.utils.TestsUtils;
 
-import java.util.Map;
-import java.util.Optional;
 import javax.inject.Inject;
-import javax.inject.Named;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.is;
-
-class FlowTest extends AbstractMemoryRunnerTest {
+public class FlowTest extends AbstractMemoryRunnerTest {
     @Inject
-    RunContextFactory runContextFactory;
+    FlowCaseTest flowCaseTest;
 
-    @Inject
-    FlowRepositoryInterface flowRepositoryInterface;
-
-    @Inject
-    @Named(QueueFactoryInterface.EXECUTION_NAMED)
-    QueueInterface<Execution> executionQueue;
-
-    @Inject
-    ExecutionRepositoryInterface executionRepository;
-
-    @SuppressWarnings("unchecked")
     @Test
-    void run() throws Exception {
-        Flow flow = Flow.builder()
-            .id("unit-test")
-            .type(Flow.class.getName())
-            .namespace("{{inputs.namespace}}")
-            .flowId("{{inputs.flow}}")
-            .inputs(InputsTest.inputs)
-            .wait(true)
-            .build();
+    public void waitSuccess() throws Exception {
+        flowCaseTest.waitSuccess();
+    }
 
-        RunContext runContext = TestsUtils.mockRunContext(runContextFactory, flow, ImmutableMap.of(
-            "namespace", "io.kestra.tests",
-            "flow", "inputs"
-        ));
-
-        Flow.Output run = flow.run(runContext);
-
-        assertThat(run.getExecutionId() == null, is(false));
-        assertThat(run.getState(), is(State.Type.SUCCESS));
-
-        Optional<Execution> execution = executionRepository.findById(run.getExecutionId());
-
-        assertThat(execution.isPresent(), is(true));
-        assertThat(execution.get().getTrigger().getType(), is(Flow.class.getName()));
-        assertThat(execution.get().getTrigger().getVariables().get("executionId"), is(((Map<String, String>) runContext.getVariables().get("execution")).get("id")));
-        assertThat(execution.get().getTrigger().getVariables().get("flowId"), is(((Map<String, String>) runContext.getVariables().get("flow")).get("id")));
-        assertThat(execution.get().getTrigger().getVariables().get("namespace"), is(((Map<String, String>) runContext.getVariables().get("flow")).get("namespace")));
+    @Test
+    public void waitFailed() throws Exception {
+        flowCaseTest.waitFailed();
     }
 }

--- a/core/src/test/java/io/kestra/core/tasks/flows/FlowTest.java
+++ b/core/src/test/java/io/kestra/core/tasks/flows/FlowTest.java
@@ -18,4 +18,9 @@ public class FlowTest extends AbstractMemoryRunnerTest {
     public void waitFailed() throws Exception {
         flowCaseTest.waitFailed();
     }
+
+    @Test
+    public void invalidOutputs() throws Exception {
+        flowCaseTest.invalidOutputs();
+    }
 }

--- a/core/src/test/resources/flows/valids/task-flow.yaml
+++ b/core/src/test/resources/flows/valids/task-flow.yaml
@@ -14,3 +14,5 @@ tasks:
       string: "{{ inputs.string }}"
     wait: true
     transmitFailed: true
+    outputs:
+      extracted: "{{ firstDefined outputs.default.value outputs.error-t1.value }}"

--- a/core/src/test/resources/flows/valids/task-flow.yaml
+++ b/core/src/test/resources/flows/valids/task-flow.yaml
@@ -1,0 +1,16 @@
+id: task-flow
+namespace: io.kestra.tests
+
+inputs:
+  - name: string
+    type: STRING
+
+tasks:
+  - id: launch
+    type: io.kestra.core.tasks.flows.Flow
+    namespace: io.kestra.tests
+    flowId: switch
+    inputs:
+      string: "{{ inputs.string }}"
+    wait: true
+    transmitFailed: true

--- a/runner-kafka/src/main/java/io/kestra/runner/kafka/streams/WorkerTaskExecutionTransformer.java
+++ b/runner-kafka/src/main/java/io/kestra/runner/kafka/streams/WorkerTaskExecutionTransformer.java
@@ -1,0 +1,54 @@
+package io.kestra.runner.kafka.streams;
+
+import io.kestra.core.models.flows.Flow;
+import io.kestra.core.runners.Executor;
+import io.kestra.core.runners.RunContextFactory;
+import io.kestra.core.runners.WorkerTaskExecution;
+import io.kestra.core.runners.WorkerTaskResult;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.streams.kstream.ValueTransformerWithKey;
+import org.apache.kafka.streams.processor.ProcessorContext;
+import org.apache.kafka.streams.state.KeyValueStore;
+import org.apache.kafka.streams.state.ValueAndTimestamp;
+
+@Slf4j
+public class WorkerTaskExecutionTransformer implements ValueTransformerWithKey<String, Executor, WorkerTaskResult> {
+    private final String workerTaskExecutionStoreName;
+    private final RunContextFactory runContextFactory;
+
+    private KeyValueStore<String, ValueAndTimestamp<WorkerTaskExecution>> workerTaskExecutionStore;
+    private KeyValueStore<String, ValueAndTimestamp<Flow>> flowStore;
+
+    public WorkerTaskExecutionTransformer(RunContextFactory runContextFactory, String workerTaskExecutionStoreName) {
+        this.runContextFactory = runContextFactory;
+        this.workerTaskExecutionStoreName = workerTaskExecutionStoreName;
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public void init(final ProcessorContext context) {
+        this.flowStore = (KeyValueStore<String, ValueAndTimestamp<Flow>>) context.getStateStore("flow");
+        this.workerTaskExecutionStore = (KeyValueStore<String, ValueAndTimestamp<WorkerTaskExecution>>) context.getStateStore(this.workerTaskExecutionStoreName);
+    }
+
+    @Override
+    public WorkerTaskResult transform(final String key, final Executor value) {
+        ValueAndTimestamp<WorkerTaskExecution> workerTaskExecutionStoreValue = workerTaskExecutionStore.get(key);
+        if (workerTaskExecutionStoreValue == null) {
+            return null;
+        }
+
+        WorkerTaskExecution workerTaskExecution = workerTaskExecutionStoreValue.value();
+
+        ValueAndTimestamp<Flow> flowValueAndTimestamp = this.flowStore.get(Flow.uid(value.getExecution()));
+        Flow flow = flowValueAndTimestamp.value();
+
+        return workerTaskExecution
+            .getTask()
+            .createWorkerTaskResult(runContextFactory, workerTaskExecution, flow, value.getExecution());
+    }
+
+    @Override
+    public void close() {
+    }
+}

--- a/runner-kafka/src/test/java/io/kestra/runner/kafka/KafkaRunnerTest.java
+++ b/runner-kafka/src/test/java/io/kestra/runner/kafka/KafkaRunnerTest.java
@@ -265,5 +265,8 @@ class KafkaRunnerTest extends AbstractKafkaRunnerTest {
         flowCaseTest.waitFailed();
     }
 
-
+    @Test
+    public void invalidOutputs() throws Exception {
+        flowCaseTest.invalidOutputs();
+    }
 }

--- a/runner-kafka/src/test/java/io/kestra/runner/kafka/KafkaRunnerTest.java
+++ b/runner-kafka/src/test/java/io/kestra/runner/kafka/KafkaRunnerTest.java
@@ -10,10 +10,10 @@ import io.kestra.core.queues.QueueInterface;
 import io.kestra.core.repositories.TemplateRepositoryInterface;
 import io.kestra.core.runners.*;
 import io.kestra.core.tasks.flows.EachSequentialTest;
+import io.kestra.core.tasks.flows.FlowCaseTest;
 import io.kestra.core.tasks.flows.TemplateTest;
 import io.kestra.core.utils.TestsUtils;
 import org.apache.kafka.common.errors.RecordTooLargeException;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
@@ -45,6 +45,9 @@ class KafkaRunnerTest extends AbstractKafkaRunnerTest {
 
     @Inject
     private TemplateRepositoryInterface templateRepository;
+
+    @Inject
+    private FlowCaseTest flowCaseTest;
 
     @Inject
     @Named(QueueFactoryInterface.WORKERTASKLOG_NAMED)
@@ -251,4 +254,16 @@ class KafkaRunnerTest extends AbstractKafkaRunnerTest {
         repositoryLoader.load(Objects.requireNonNull(ListenersTest.class.getClassLoader().getResource("flows/tests/invalid-task-defaults.yaml")));
         taskDefaultsCaseTest.invalidTaskDefaults();
     }
+
+    @Test
+    void flowWaitSuccess() throws Exception {
+        flowCaseTest.waitSuccess();
+    }
+
+    @Test
+    void flowWaitFailed() throws Exception {
+        flowCaseTest.waitFailed();
+    }
+
+
 }

--- a/runner-kafka/src/test/resources/application.yml
+++ b/runner-kafka/src/test/resources/application.yml
@@ -93,6 +93,12 @@ kestra:
         properties:
           cleanup.policy: "delete,compact"
 
+      executorworkertaskexecution:
+        cls: io.kestra.core.runners.WorkerTaskExecution
+        name: "${kestra.kafka.defaults.topic-prefix}executor_workertaskexecution"
+        properties:
+          cleanup.policy: "delete,compact"
+
       workertask:
         name: "${kestra.kafka.defaults.topic-prefix}workertask"
         cls: io.kestra.core.runners.WorkerTask

--- a/runner-memory/src/main/java/io/kestra/runner/memory/MemoryExecutor.java
+++ b/runner-memory/src/main/java/io/kestra/runner/memory/MemoryExecutor.java
@@ -168,10 +168,11 @@ public class MemoryExecutor extends AbstractExecutor {
             // worker task execution
             if (conditionService.isTerminatedWithListeners(flow, execution) && WORKERTASKEXECUTIONS_WATCHER.containsKey(execution.getId())) {
                 WorkerTaskExecution workerTaskExecution = WORKERTASKEXECUTIONS_WATCHER.get(execution.getId());
+                Flow workerTaskFlow = this.flowRepository.findByExecution(execution);
 
                 WorkerTaskResult workerTaskResult = workerTaskExecution
                     .getTask()
-                    .createWorkerTaskResult(workerTaskExecution, execution);
+                    .createWorkerTaskResult(runContextFactory, workerTaskExecution, workerTaskFlow, execution);
 
                 this.workerTaskResultQueue.emit(workerTaskResult);
 


### PR DESCRIPTION
- fix(kafka-runner): refactor the whole logic of KafkaExecutor
- fix(kafka-runner): save offset & from in header on KafkaExecutor
- refactor(core): flatten the whole executor
- fix(kafka-runner): don't use join to avoid event deduplication
- fix(kafka-runner): cleanup executor topic & execution one
- feat(core): move Flow task to executor
