### PR TITLE
Fix - FATAL:  role "root" does not exist

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ services:
       POSTGRES_USER: kestra
       POSTGRES_PASSWORD: k3str4
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready", "-U", "kestra"]
+      test: ["CMD-SHELL", "pg_isready -d $${POSTGRES_DB} -U $${POSTGRES_USER}"]
       interval: 30s
       timeout: 10s
       retries: 10


### PR DESCRIPTION
I got that error ` FATAL:  role "root" does not exist ` by some searching, i got that possible generic solution. So, may we consider changing that?

Issue #628 
