### PR TITLE
Feat(UI/Execution): Read only task source in logs 

### DIFF
--- a/ui/src/components/executions/Topology.vue
+++ b/ui/src/components/executions/Topology.vue
@@ -1,5 +1,6 @@
 <template>
     <topology
+        :key="execution.id"
         v-if="execution && flowGraph"
         :flow-id="execution.flowId"
         :namespace="execution.namespace"

--- a/ui/src/components/graph/Topology.vue
+++ b/ui/src/components/graph/Topology.vue
@@ -171,6 +171,7 @@
                     node: node,
                     namespace: props.namespace,
                     flowId: props.flowId,
+                    revision: props.execution ? props.execution.flowRevision : undefined,
                 },
             })
         }

--- a/ui/src/components/graph/TreeNode.vue
+++ b/ui/src/components/graph/TreeNode.vue
@@ -7,7 +7,7 @@
         <div class="task-content">
             <div class="card-header">
                 <div class="task-title">
-                    <span>{{ task.id }} {{ state }}</span>
+                    <span>{{ task.id }}</span>
                 </div>
             </div>
             <div v-if="task.state" class="status-wrapper">
@@ -66,6 +66,7 @@
                         :flow-id="flowId"
                         size="small"
                         :namespace="namespace"
+                        :revision="revision"
                     />
                 </el-button-group>
             </div>
@@ -141,7 +142,10 @@
                 type: String,
                 required: true
             },
-
+            revision: {
+                type: Number,
+                default: undefined
+            },
         },
         methods: {
             forwardEvent(type, event) {

--- a/ui/src/components/graph/nodes/Task.vue
+++ b/ui/src/components/graph/nodes/Task.vue
@@ -44,6 +44,7 @@
         :n="data.node"
         :namespace="data.namespace"
         :flow-id="data.flowId"
+        :revision="data.revision"
         @follow="forwardEvent('follow', $event)"
         @mouseover="mouseover"
         @mouseleave="mouseleave"

--- a/ui/src/components/logs/LogList.vue
+++ b/ui/src/components/logs/LogList.vue
@@ -11,6 +11,7 @@
                                 <div class="attempt-number me-1">
                                     {{ $t("attempt") }} {{ index + 1 }}
                                 </div>
+
                                 <div class="task-id flex-grow-1" :id="`attempt-${index}-${currentTaskRun.id}`">
                                     <el-tooltip :persistent="false" transition="" :hide-after="0">
                                         <template #content>
@@ -82,7 +83,6 @@
                                             />
 
                                             <task-edit
-                                                :read-only="true"
                                                 component="el-dropdown-item"
                                                 :task-id="currentTaskRun.taskId"
                                                 :flow-id="execution.flowId"
@@ -203,8 +203,10 @@
                     return false;
                 }
 
-                return !(this.task && this.task.id !== currentTaskRun.taskId);
-
+                if (this.task && this.task.id !== currentTaskRun.taskId) {
+                    return false;
+                }
+                return  true;
             },
             toggleShowOutput(taskRun) {
                 this.showOutputs[taskRun.id] = !this.showOutputs[taskRun.id];

--- a/ui/src/components/logs/LogList.vue
+++ b/ui/src/components/logs/LogList.vue
@@ -11,7 +11,6 @@
                                 <div class="attempt-number me-1">
                                     {{ $t("attempt") }} {{ index + 1 }}
                                 </div>
-
                                 <div class="task-id flex-grow-1" :id="`attempt-${index}-${currentTaskRun.id}`">
                                     <el-tooltip :persistent="false" transition="" :hide-after="0">
                                         <template #content>
@@ -83,10 +82,12 @@
                                             />
 
                                             <task-edit
+                                                :read-only="true"
                                                 component="el-dropdown-item"
                                                 :task-id="currentTaskRun.taskId"
                                                 :flow-id="execution.flowId"
                                                 :namespace="execution.namespace"
+                                                :revision="execution.flowRevision"
                                             />
                                         </el-dropdown-menu>
                                     </template>
@@ -202,10 +203,8 @@
                     return false;
                 }
 
-                if (this.task && this.task.id !== currentTaskRun.taskId) {
-                    return false;
-                }
-                return  true;
+                return !(this.task && this.task.id !== currentTaskRun.taskId);
+
             },
             toggleShowOutput(taskRun) {
                 this.showOutputs[taskRun.id] = !this.showOutputs[taskRun.id];

--- a/ui/src/stores/flow.js
+++ b/ui/src/stores/flow.js
@@ -66,7 +66,7 @@ export default {
                 })
         },
         loadTask({commit}, options) {
-            return this.$http.get(`/api/v1/flows/${options.namespace}/${options.id}/tasks/${options.taskId}`).then(response => {
+            return this.$http.get(`/api/v1/flows/${options.namespace}/${options.id}/tasks/${options.taskId}${options.revision ? "?revision=" + options.revision : ""}`).then(response => {
                 commit("setTask", response.data)
 
                 return response.data;

--- a/ui/src/translations.json
+++ b/ui/src/translations.json
@@ -267,7 +267,8 @@
     "invalid bulk delete": "Could not delete executions",
     "execution not found": "Execution <code>{executionId}</code> not found",
     "execution not in state FAILED": "Execution <code>{executionId}</code> not in state FAILED",
-    "execution already finished": "Execution <code>{executionId}</code> already finished"
+    "execution already finished": "Execution <code>{executionId}</code> already finished",
+    "seeing old revision": "You are seeing an old revision: {revision}"
   },
   "fr": {
     "id": "Identifiant",
@@ -538,7 +539,8 @@
     "execution not found": "Execution <code>{executionId}</code> non trouvée",
     "execution not in state FAILED": "Execution <code>{executionId}</code> n'est pas dans l'état FAILED",
     "execution already finished": "Execution <code>{executionId}</code> déjà terminée",
-    "restore revision": "Êtes-vous sur de vouloir restaurer la revision <code>{revision}</code> ?"
+    "restore revision": "Êtes-vous sur de vouloir restaurer la revision <code>{revision}</code> ?",
+    "seeing old revision": "Vous visualisez une ancienne revision : {revision}"
   },
   "de": {
     "id": "Id",
@@ -808,6 +810,7 @@
     "invalid bulk delete": "Ausführungen konnten nicht gelöscht werden",
     "execution not found": "Ausführung <code>{executionId}</code> nicht gefunden",
     "execution not in state FAILED": "Ausführung <code>{executionId}</code> nicht im Status FAILED",
-    "execution already finished": "Ausführung <code>{executionId}</code> bereits abgeschlossen"
+    "execution already finished": "Ausführung <code>{executionId}</code> bereits abgeschlossen",
+    "seeing old revision": "You are seeing an old revision: {revision}"
   }
 }

--- a/webserver/src/main/java/io/kestra/webserver/controllers/FlowController.java
+++ b/webserver/src/main/java/io/kestra/webserver/controllers/FlowController.java
@@ -105,7 +105,7 @@ public class FlowController {
         @Parameter(description = "The flow namespace") String namespace,
         @Parameter(description = "The flow id") String id,
         @Parameter(description = "The task id") String taskId,
-        @Parameter(description = "The flow revision") @Nullable @QueryValue(value = "source") Integer revision
+        @Parameter(description = "The flow revision") @Nullable @QueryValue(value = "revision") Integer revision
     ) {
         return flowRepository
             .findById(namespace, id, Optional.ofNullable(revision))

--- a/webserver/src/main/java/io/kestra/webserver/controllers/FlowController.java
+++ b/webserver/src/main/java/io/kestra/webserver/controllers/FlowController.java
@@ -104,10 +104,11 @@ public class FlowController {
     public Task flowTask(
         @Parameter(description = "The flow namespace") String namespace,
         @Parameter(description = "The flow id") String id,
-        @Parameter(description = "The task id") String taskId
+        @Parameter(description = "The task id") String taskId,
+        @Parameter(description = "The flow revision") @Nullable @QueryValue(value = "source") Integer revision
     ) {
         return flowRepository
-            .findById(namespace, id)
+            .findById(namespace, id, Optional.ofNullable(revision))
             .flatMap(flow -> {
                 try {
                     return Optional.of(flow.findTaskByTaskId(taskId));


### PR DESCRIPTION
Task source code is now read only in the execution logs tab.
If the execution is from an old revision, warn the user and display the revision number


close #928 
