### PR TITLE
feat(FlowRun): Enter key validate inputs form and trigger the execution

### DIFF
--- a/ui/src/components/flows/FlowRun.vue
+++ b/ui/src/components/flows/FlowRun.vue
@@ -13,6 +13,7 @@
                 :prop="input.name"
             >
                 <el-input
+                    @keydown.enter.prevent
                     v-if="input.type === 'STRING' || input.type === 'URI'"
                     v-model="inputs[input.name]"
                 />
@@ -114,12 +115,12 @@
             }, 500)
 
             this._keyListener = function(e) {
-                if (e.keyCode === 13) {
-                    if(e.shiftKey){
-                        return true;
+                if (e.keyCode === 13)  {
+                    if(e.ctrlKey || e.metaKey) {
+                        e.preventDefault();
+                        this.onSubmit(this.$refs.form);
                     }
-                    e.preventDefault()
-                    this.onSubmit(this.$refs.form);
+                    return true
                 }
             };
 

--- a/ui/src/components/flows/FlowRun.vue
+++ b/ui/src/components/flows/FlowRun.vue
@@ -131,18 +131,20 @@
         },
         methods: {
             onSubmit(formRef) {
-                formRef.validate((valid) => {
-                    if (!valid) {
-                        return false;
-                    }
+                if (formRef) {
+                    formRef.validate((valid) => {
+                        if (!valid) {
+                            return false;
+                        }
 
-                    executeTask(this, this.flow, this.inputs, {
-                        redirect: this.redirect,
-                        id: this.flow.id,
-                        namespace: this.flow.namespace
-                    })
-                    this.$emit("executionTrigger");
-                });
+                        executeTask(this, this.flow, this.inputs, {
+                            redirect: this.redirect,
+                            id: this.flow.id,
+                            namespace: this.flow.namespace
+                        })
+                        this.$emit("executionTrigger");
+                    });
+                }
             },
             onFileChange(input, e) {
                 if (!e.target) {

--- a/ui/src/components/flows/FlowRun.vue
+++ b/ui/src/components/flows/FlowRun.vue
@@ -115,12 +115,9 @@
             }, 500)
 
             this._keyListener = function(e) {
-                if (e.keyCode === 13)  {
-                    if(e.ctrlKey || e.metaKey) {
-                        e.preventDefault();
-                        this.onSubmit(this.$refs.form);
-                    }
-                    return true
+                if (e.keyCode === 13 && (e.ctrlKey || e.metaKey))  {
+                    e.preventDefault();
+                    this.onSubmit(this.$refs.form);
                 }
             };
 

--- a/ui/src/components/flows/FlowRun.vue
+++ b/ui/src/components/flows/FlowRun.vue
@@ -112,6 +112,21 @@
                     input.focus()
                 }
             }, 500)
+
+            this._keyListener = function(e) {
+                if (e.keyCode === 13) {
+                    if(e.shiftKey){
+                        return true;
+                    }
+                    e.preventDefault()
+                    this.onSubmit(this.$refs.form);
+                }
+            };
+
+            document.addEventListener("keydown", this._keyListener.bind(this));
+        },
+        beforeUnmount() {
+            document.removeEventListener("keydown", this._keyListener);
         },
         computed: {
             ...mapState("flow", ["flow"]),


### PR DESCRIPTION
Pressing  `enter` in the flowRun component now trigger the execution.

To keep possibility to add newline in text-area form use for JSON, the shortcut `shit + enter` is now available to creating newline

close #903
