### PR TITLE
feat(core): allow listing trigger without multiple conditions

### DIFF
--- a/core/src/main/java/io/kestra/core/services/FlowService.java
+++ b/core/src/main/java/io/kestra/core/services/FlowService.java
@@ -1,6 +1,7 @@
 package io.kestra.core.services;
 
 import io.micronaut.context.ApplicationContext;
+import io.micronaut.core.annotation.Nullable;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.ToString;
@@ -98,7 +99,7 @@ public class FlowService {
         return !f.uidWithoutRevision().equals(Flow.uidWithoutRevision(execution));
     }
 
-    public List<Execution> flowTriggerExecution(Stream<Flow> flowStream, Execution execution, MultipleConditionStorageInterface multipleConditionStorage) {
+    public List<Execution> flowTriggerExecution(Stream<Flow> flowStream, Execution execution, @Nullable MultipleConditionStorageInterface multipleConditionStorage) {
         return flowStream
             .filter(flow -> flow.getTriggers() != null && flow.getTriggers().size() > 0)
             .filter(flow -> !flow.isDisabled())


### PR DESCRIPTION
Very small PR to indicate that multiple-condition is optional.
This method will be used with null multiple-condition storage from the Kafka runner.
