### PR TITLE
Improve jdbc performance

### DIFF
--- a/cli/src/main/resources/application.yml
+++ b/cli/src/main/resources/application.yml
@@ -107,7 +107,7 @@ kestra:
         cls: io.kestra.core.models.topologies.FlowTopology
 
     queues:
-      min-poll-interval: 100ms
+      min-poll-interval: 25ms
       max-poll-interval: 1000ms
       poll-switch-interval: 5s
 

--- a/jdbc-postgres/src/main/resources/migrations/postgres/V6__queue_index_optim.sql
+++ b/jdbc-postgres/src/main/resources/migrations/postgres/V6__queue_index_optim.sql
@@ -1,0 +1,8 @@
+-- We drop the PK and the queues_type__offset, otherwise they are used by the poll query which is sub-optimal.
+-- We create an hash index on offset that will be used instead when filtering on offset.
+
+ALTER TABLE public.queues DROP CONSTRAINT queues_pkey;
+
+DROP INDEX queues_type__offset;
+
+CREATE INDEX queues_offset ON public.queues USING hash ("offset");


### PR DESCRIPTION
Improve JDBC performance by lowering the min poll loop interval and changing PostgreSQL indexing.

Min poll loop interval is the minimum delay between each task execution. When running a single flow that have a lot of tasks, lowering it lower the delay between each tasks. It is currently configured at 100ms, configuring it to 25ms show a nice performance gain and should still be not too low so the database will not be sollicited too much. See performance gains bellow.

On PostgreSQL, the `queues` table unique index disturb the PostgreSQL cost optimizer that chooses this index when doing the poll query resulting in 10ms poll queries on a table with a few thousands of line.
Removing the PK and the index that exists on the columns type and offset, and replacing them with a hash index on the `offset` colm-umn do the trick. There is still an index on the `offset` column but it is no longuer used when doing the poll query. This new index is needed for other queries.

Using this flow;

```
id: slow-flow
namespace: io.kestra.tests

tasks:
  - id: waterconsumption
    type: io.kestra.core.tasks.flows.Template
    namespace: io.kestra.tests
    templateId: for-each-1
  - id: watertemperature
    type: io.kestra.core.tasks.flows.Template
    namespace: io.kestra.tests
    templateId: for-each-2
  - id: internaltemperature
    type: io.kestra.core.tasks.flows.Template
    namespace: io.kestra.tests
    templateId: for-each-3
  - id: internalhumidity
    type: io.kestra.core.tasks.flows.Template
    namespace: io.kestra.tests
    templateId: for-each-4
```

That using this template (all 4 templates are the same):

```
id: for-each-1
namespace: io.kestra.tests
tasks:
  - id: for-each-1
    type: io.kestra.core.tasks.flows.EachSequential
    tasks:
      - id: each-value-1
        type: io.kestra.core.tasks.debugs.Return
        format: "{{ task.id }} with current value '{{ taskrun.value }}'"
    value: "[\"value 1\", \"value 2\", \"value 3\", \"value 4\", \"value 5\", \"value 6\", \"value 7\", \"value 8\", \"value 9\", \"value 10\"]"
```

Gives the following results:

**Baseline: 22s
Min poll interval from 100ms to 25ms: 15s
Changing PG indexing: 7s**

These two optimizations on top of each other gives a 70% execution time reduction (execution time divided by 3 approx).

Even if not tested thoroughly on EachParallel, a quick test switching EachSequential to EachParalle show also a nice improvement.