### PR TITLE
feat(jdbc-mysql): force using the index on poll queries

### DIFF
--- a/jdbc-mysql/src/main/java/io/kestra/runner/mysql/MysqlQueue.java
+++ b/jdbc-mysql/src/main/java/io/kestra/runner/mysql/MysqlQueue.java
@@ -43,7 +43,8 @@ public class MysqlQueue<T> extends JdbcQueue<T> {
                 AbstractJdbcRepository.field("value"),
                 AbstractJdbcRepository.field("offset")
             )
-            .from(this.table)
+            // force using the dedicated index, or it made a scan of the PK index
+            .from(this.table.useIndex("ix_type__consumers"))
             .where(AbstractJdbcRepository.field("type").eq(this.cls.getName()))
             .and(DSL.or(List.of(
                 AbstractJdbcRepository.field("consumers").isNull(),


### PR DESCRIPTION
This will improve task execution performance for MySQL.

It is not as effective as the changes made for PostgreSQL on https://github.com/kestra-io/kestra/pull/1012 but on the same flow I still saw on improvement of around 30%.
