### PR TITLE
feat(docker): don't wait for Postgres to be ready before starting Kestra

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -55,4 +55,4 @@ services:
       - "8080:8080"
     depends_on:
       postgres:
-        condition: service_healthy
+        condition: service_started


### PR DESCRIPTION
Postgres will be ready after the first health check wich is after 30s! We can starts Kestra as soon as Postgres is started.

An other solution would be to lower the Postgres health check interval.
