### PR TITLE
Publish the monitoring endpoint

### DIFF
--- a/docker-compose-ha.yml
+++ b/docker-compose-ha.yml
@@ -114,6 +114,7 @@ services:
           url: http://localhost:8080/
     ports:
       - "8080:8080"
+      - "8081:8081"
     depends_on:
       kafka:
         condition: service_healthy

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -53,6 +53,7 @@ services:
           url: http://localhost:8080/
     ports:
       - "8080:8080"
+      - "8081:8081"
     depends_on:
       postgres:
         condition: service_started


### PR DESCRIPTION
The runtime presents both 8080/tcp and 8081/tcp. Both should be accessible.
