### PR TITLE
fix(#1032):  avoid restarting errors task

### DIFF
--- a/core/src/main/java/io/kestra/core/models/flows/Flow.java
+++ b/core/src/main/java/io/kestra/core/models/flows/Flow.java
@@ -171,6 +171,17 @@ public class Flow implements DeletedInterface {
         }
     }
 
+    public List<Task> allErrorsWithChilds() {
+        var allErrors = allTasksWithChilds().stream()
+            .filter(task -> task.isFlowable() && ((FlowableTask<?>) task).getErrors() != null)
+            .flatMap(task -> ((FlowableTask<?>) task).getErrors().stream())
+            .collect(Collectors.toCollection(ArrayList::new));
+        if(this.getErrors() != null && !this.getErrors().isEmpty()) {
+            allErrors.addAll(this.getErrors());
+        }
+        return allErrors;
+    }
+
     public Task findTaskByTaskId(String taskId) throws InternalException {
         return allTasks()
             .flatMap(t -> t.findById(taskId).stream())

--- a/core/src/main/java/io/kestra/core/models/flows/Flow.java
+++ b/core/src/main/java/io/kestra/core/models/flows/Flow.java
@@ -30,7 +30,6 @@ import javax.validation.ConstraintViolationException;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 
-
 @SuperBuilder(toBuilder = true)
 @Getter
 @AllArgsConstructor
@@ -176,9 +175,11 @@ public class Flow implements DeletedInterface {
             .filter(task -> task.isFlowable() && ((FlowableTask<?>) task).getErrors() != null)
             .flatMap(task -> ((FlowableTask<?>) task).getErrors().stream())
             .collect(Collectors.toCollection(ArrayList::new));
-        if(this.getErrors() != null && !this.getErrors().isEmpty()) {
+
+        if (this.getErrors() != null && !this.getErrors().isEmpty()) {
             allErrors.addAll(this.getErrors());
         }
+
         return allErrors;
     }
 

--- a/core/src/main/java/io/kestra/core/services/ExecutionService.java
+++ b/core/src/main/java/io/kestra/core/services/ExecutionService.java
@@ -8,7 +8,6 @@ import io.kestra.core.models.flows.Flow;
 import io.kestra.core.models.flows.State;
 import io.kestra.core.models.hierarchies.AbstractGraphTask;
 import io.kestra.core.models.hierarchies.GraphCluster;
-import io.kestra.core.models.tasks.FlowableTask;
 import io.kestra.core.models.tasks.Task;
 import io.kestra.core.repositories.ExecutionRepositoryInterface;
 import io.kestra.core.repositories.FlowRepositoryInterface;
@@ -87,7 +86,9 @@ public class ExecutionService {
             .forEach(r -> newTaskRuns.removeIf(taskRun -> taskRun.getId().equals(r)));
 
         // We need to remove global error tasks and flowable error tasks if any
-        flow.allErrorsWithChilds().forEach(task -> newTaskRuns.removeIf(taskRun -> taskRun.getTaskId().equals(task.getId())));
+        flow
+            .allErrorsWithChilds()
+            .forEach(task -> newTaskRuns.removeIf(taskRun -> taskRun.getTaskId().equals(task.getId())));
 
         // Build and launch new execution
         Execution newExecution = execution

--- a/core/src/main/java/io/kestra/core/services/ExecutionService.java
+++ b/core/src/main/java/io/kestra/core/services/ExecutionService.java
@@ -87,8 +87,7 @@ public class ExecutionService {
             .forEach(r -> newTaskRuns.removeIf(taskRun -> taskRun.getId().equals(r)));
 
         // We need to remove global error tasks and flowable error tasks if any
-        Set<Task> errorTasks = this.errorTaskIds(flow);
-        errorTasks.forEach(task -> newTaskRuns.removeIf(taskRun -> taskRun.getTaskId().equals(task.getId())));
+        flow.allErrorsWithChilds().forEach(task -> newTaskRuns.removeIf(taskRun -> taskRun.getTaskId().equals(task.getId())));
 
         // Build and launch new execution
         Execution newExecution = execution
@@ -303,17 +302,6 @@ public class ExecutionService {
             .filter(s -> !workerTaskRunId.contains(s.getTaskRun().getId()))
             .map(s -> mappingTaskRunId.get(s.getTaskRun().getId()))
             .collect(Collectors.toSet());
-    }
-
-    private Set<Task> errorTaskIds(Flow flow) {
-        var allErrors = flow.getTasks().stream()
-            .filter(task -> task.isFlowable() && ((FlowableTask<?>) task).getErrors() != null)
-            .flatMap(task -> ((FlowableTask<?>) task).getErrors().stream())
-            .collect(Collectors.toCollection(HashSet::new));
-        if(flow.getErrors() != null && !flow.getErrors().isEmpty()) {
-            allErrors.addAll(flow.getErrors());
-        }
-        return allErrors;
     }
 
     private Set<String> getAncestors(Execution execution, TaskRun taskRun) {

--- a/core/src/test/java/io/kestra/core/Helpers.java
+++ b/core/src/test/java/io/kestra/core/Helpers.java
@@ -19,7 +19,7 @@ import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 
 public class Helpers {
-    public static long FLOWS_COUNT = 53;
+    public static long FLOWS_COUNT = 54;
 
     public static ApplicationContext applicationContext() throws URISyntaxException {
         return applicationContext(

--- a/core/src/test/java/io/kestra/core/Helpers.java
+++ b/core/src/test/java/io/kestra/core/Helpers.java
@@ -19,7 +19,7 @@ import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 
 public class Helpers {
-    public static long FLOWS_COUNT = 54;
+    public static long FLOWS_COUNT = 55;
 
     public static ApplicationContext applicationContext() throws URISyntaxException {
         return applicationContext(

--- a/core/src/test/java/io/kestra/core/runners/RestartCaseTest.java
+++ b/core/src/test/java/io/kestra/core/runners/RestartCaseTest.java
@@ -34,7 +34,7 @@ public class RestartCaseTest {
     @Named(QueueFactoryInterface.EXECUTION_NAMED)
     private QueueInterface<Execution> executionQueue;
 
-    public void restartFailed() throws Exception {
+    public void restartFailedThenSuccess() throws Exception {
         Flow flow = flowRepository.findById("io.kestra.tests", "restart_last_failed").orElseThrow();
 
         Execution firstExecution = runnerUtils.runOne(flow.getNamespace(), flow.getId(), Duration.ofSeconds(60));
@@ -72,6 +72,42 @@ public class RestartCaseTest {
             .stream()
             .map(TaskRun::getState)
             .forEach(state -> assertThat(state.getCurrent(), is(State.Type.SUCCESS)));
+    }
+
+    public void restartFailedThenFailure() throws Exception {
+        Flow flow = flowRepository.findById("io.kestra.tests", "restart_always_failed").orElseThrow();
+
+        Execution firstExecution = runnerUtils.runOne(flow.getNamespace(), flow.getId(), Duration.ofSeconds(60));
+
+        assertThat(firstExecution.getState().getCurrent(), is(State.Type.FAILED));
+        assertThat(firstExecution.getTaskRunList(), hasSize(2));
+        assertThat(firstExecution.getTaskRunList().get(0).getState().getCurrent(), is(State.Type.FAILED));
+
+        // wait
+        Execution finishedRestartedExecution = runnerUtils.awaitExecution(
+            execution -> execution.getState().getCurrent() == State.Type.FAILED,
+            throwRunnable(() -> {
+                Thread.sleep(1000);
+                Execution restartedExec = executionService.restart(firstExecution, null);
+                executionQueue.emit(restartedExec);
+
+                assertThat(restartedExec, notNullValue());
+                assertThat(restartedExec.getId(), is(firstExecution.getId()));
+                assertThat(restartedExec.getParentId(), nullValue());
+                assertThat(restartedExec.getTaskRunList().size(), is(1));
+                assertThat(restartedExec.getState().getCurrent(), is(State.Type.RESTARTED));
+            }),
+            Duration.ofSeconds(60)
+        );
+
+        assertThat(finishedRestartedExecution, notNullValue());
+        assertThat(finishedRestartedExecution.getId(), is(firstExecution.getId()));
+        assertThat(finishedRestartedExecution.getParentId(), nullValue());
+        assertThat(finishedRestartedExecution.getTaskRunList().size(), is(2));
+
+        assertThat(finishedRestartedExecution.getTaskRunList().get(0).getAttempts().size(), is(2));
+
+        assertThat(finishedRestartedExecution.getState().getCurrent(), is(State.Type.FAILED));
     }
 
     public void replay() throws Exception {

--- a/core/src/test/java/io/kestra/core/runners/RestartCaseTest.java
+++ b/core/src/test/java/io/kestra/core/runners/RestartCaseTest.java
@@ -74,7 +74,7 @@ public class RestartCaseTest {
             .forEach(state -> assertThat(state.getCurrent(), is(State.Type.SUCCESS)));
     }
 
-    public void restartFailedThenFailure() throws Exception {
+    public void restartFailedThenFailureWithGlobalErrors() throws Exception {
         Flow flow = flowRepository.findById("io.kestra.tests", "restart_always_failed").orElseThrow();
 
         Execution firstExecution = runnerUtils.runOne(flow.getNamespace(), flow.getId(), Duration.ofSeconds(60));
@@ -106,6 +106,42 @@ public class RestartCaseTest {
         assertThat(finishedRestartedExecution.getTaskRunList().size(), is(2));
 
         assertThat(finishedRestartedExecution.getTaskRunList().get(0).getAttempts().size(), is(2));
+
+        assertThat(finishedRestartedExecution.getState().getCurrent(), is(State.Type.FAILED));
+    }
+
+    public void restartFailedThenFailureWithLocalErrors() throws Exception {
+        Flow flow = flowRepository.findById("io.kestra.tests", "restart_local_errors").orElseThrow();
+
+        Execution firstExecution = runnerUtils.runOne(flow.getNamespace(), flow.getId(), Duration.ofSeconds(60));
+
+        assertThat(firstExecution.getState().getCurrent(), is(State.Type.FAILED));
+        assertThat(firstExecution.getTaskRunList(), hasSize(5));
+        assertThat(firstExecution.getTaskRunList().get(3).getState().getCurrent(), is(State.Type.FAILED));
+
+        // wait
+        Execution finishedRestartedExecution = runnerUtils.awaitExecution(
+            execution -> execution.getState().getCurrent() == State.Type.FAILED,
+            throwRunnable(() -> {
+                Thread.sleep(1000);
+                Execution restartedExec = executionService.restart(firstExecution, null);
+                executionQueue.emit(restartedExec);
+
+                assertThat(restartedExec, notNullValue());
+                assertThat(restartedExec.getId(), is(firstExecution.getId()));
+                assertThat(restartedExec.getParentId(), nullValue());
+                assertThat(restartedExec.getTaskRunList().size(), is(4));
+                assertThat(restartedExec.getState().getCurrent(), is(State.Type.RESTARTED));
+            }),
+            Duration.ofSeconds(60)
+        );
+
+        assertThat(finishedRestartedExecution, notNullValue());
+        assertThat(finishedRestartedExecution.getId(), is(firstExecution.getId()));
+        assertThat(finishedRestartedExecution.getParentId(), nullValue());
+        assertThat(finishedRestartedExecution.getTaskRunList().size(), is(5));
+
+        assertThat(finishedRestartedExecution.getTaskRunList().get(3).getAttempts().size(), is(2));
 
         assertThat(finishedRestartedExecution.getState().getCurrent(), is(State.Type.FAILED));
     }

--- a/core/src/test/java/io/kestra/core/runners/RestartTest.java
+++ b/core/src/test/java/io/kestra/core/runners/RestartTest.java
@@ -14,8 +14,13 @@ public class RestartTest extends AbstractMemoryRunnerTest {
     }
 
     @Test
-    void restartFailedThenFailure() throws Exception {
-        restartCaseTest.restartFailedThenFailure();
+    void restartFailedThenFailureWithGlobalErrors() throws Exception {
+        restartCaseTest.restartFailedThenFailureWithGlobalErrors();
+    }
+
+    @Test
+    void restartFailedThenFailureWithLocalErrors() throws Exception {
+        restartCaseTest.restartFailedThenFailureWithLocalErrors();
     }
 
 

--- a/core/src/test/java/io/kestra/core/runners/RestartTest.java
+++ b/core/src/test/java/io/kestra/core/runners/RestartTest.java
@@ -23,7 +23,6 @@ public class RestartTest extends AbstractMemoryRunnerTest {
         restartCaseTest.restartFailedThenFailureWithLocalErrors();
     }
 
-
     @Test
     void replay() throws Exception {
         restartCaseTest.replay();

--- a/core/src/test/java/io/kestra/core/runners/RestartTest.java
+++ b/core/src/test/java/io/kestra/core/runners/RestartTest.java
@@ -9,9 +9,15 @@ public class RestartTest extends AbstractMemoryRunnerTest {
     private RestartCaseTest restartCaseTest;
 
     @Test
-    void restartFailed() throws Exception {
-        restartCaseTest.restartFailed();
+    void restartFailedThenSuccess() throws Exception {
+        restartCaseTest.restartFailedThenSuccess();
     }
+
+    @Test
+    void restartFailedThenFailure() throws Exception {
+        restartCaseTest.restartFailedThenFailure();
+    }
+
 
     @Test
     void replay() throws Exception {

--- a/core/src/test/resources/flows/valids/restart_always_failed.yaml
+++ b/core/src/test/resources/flows/valids/restart_always_failed.yaml
@@ -1,0 +1,14 @@
+id: restart_always_failed
+namespace: io.kestra.tests
+
+tasks:
+  - id: failStep
+    type: io.kestra.core.tasks.scripts.Bash
+    description: "This fails"
+    commands:
+      - 'exit 1'
+errors:
+  - id: errorHandler
+    type: io.kestra.core.tasks.debugs.Echo
+    format: I'm failing {{task.id}}
+    level: INFO

--- a/core/src/test/resources/flows/valids/restart_local_errors.yaml
+++ b/core/src/test/resources/flows/valids/restart_local_errors.yaml
@@ -1,0 +1,27 @@
+id: restart_local_errors
+namespace: io.kestra.tests
+
+tasks:
+  - id: before
+    type: io.kestra.core.tasks.debugs.Echo
+    format: I'm before
+
+  - id: sequential
+    type: io.kestra.core.tasks.flows.Sequential
+    tasks:
+    - id: close
+      type: io.kestra.core.tasks.debugs.Echo
+      format: I'm close to fail
+    - id: failStep
+      type: io.kestra.core.tasks.scripts.Bash
+      description: "This fails"
+      commands:
+        - 'exit 1'
+    errors:
+    - id: errorHandler
+      type: io.kestra.core.tasks.debugs.Echo
+      format: I'm failing {{task.id}}
+
+  - id: after
+    type: io.kestra.core.tasks.debugs.Echo
+    format: I'm after

--- a/jdbc/src/test/java/io/kestra/jdbc/runner/JdbcRunnerTest.java
+++ b/jdbc/src/test/java/io/kestra/jdbc/runner/JdbcRunnerTest.java
@@ -143,7 +143,7 @@ public abstract class JdbcRunnerTest {
 
     @Test
     void restartFailed() throws Exception {
-        restartCaseTest.restartFailed();
+        restartCaseTest.restartFailedThenSuccess();
     }
 
     @Test


### PR DESCRIPTION
As they else they will run un-conditionnaly and the flow will be SUCCESSFUL

close #1032
