### PR TITLE
fx: Show suggestion modal on Mac using Command + Space is now working

### DIFF
--- a/ui/src/components/inputs/MonacoEditor.vue
+++ b/ui/src/components/inputs/MonacoEditor.vue
@@ -166,6 +166,13 @@
                         options["model"] = monaco.editor.createModel(this.value, this.language);
                     }
 
+                    monaco.editor.addKeybindingRule(
+                        {
+                            keybinding:  monaco.KeyMod.CtrlCmd | monaco.KeyCode.Space,
+                            command: "editor.action.triggerSuggest"
+                        }
+                    )
+
                     this.editor = monaco.editor.create(this.$el, options);
                 }
 


### PR DESCRIPTION
We can now use the Command (⌘) + Space shortcut to show the suggestion modal back again

close #1080
