### PR TITLE
Adapt the inputs names within 'New execution'

### DIFF
--- a/ui/src/components/flows/FlowRun.vue
+++ b/ui/src/components/flows/FlowRun.vue
@@ -4,7 +4,7 @@
             <strong>{{ $t('disabled flow title') }}</strong><br>
             {{ $t('disabled flow desc') }}
         </el-alert>
-        <el-form class="ks-horizontal" :model="inputs" ref="form">
+        <el-form label-position="top" :model="inputs" ref="form">
             <el-form-item
                 v-for="input in flow.inputs || []"
                 :key="input.id"

--- a/ui/src/styles/layout/element-plus-overload.scss
+++ b/ui/src/styles/layout/element-plus-overload.scss
@@ -142,23 +142,7 @@
 // form horizontal
 form.ks-horizontal {
     .el-form-item {
-        @include res(xs) {
-            display: block;
-        }
-
-        @include res(sm) {
-            .el-form-item__label {
-                max-width: (math.div(1, 24) * 4 * 100) * 1%;
-                flex: 0 0 (math.div(1, 24) * 4 * 100) * 1%;
-                text-align: right;
-            }
-
-            .el-form-item__content {
-                align-items: flex-start;
-                max-width: (math.div(1, 24) * 20 * 100) * 1%;
-                flex: 0 0 (math.div(1, 24) * 20 * 100) * 1%;
-            }
-        }
+        display: block;
     }
 
     .submit {

--- a/ui/src/styles/layout/element-plus-overload.scss
+++ b/ui/src/styles/layout/element-plus-overload.scss
@@ -142,7 +142,23 @@
 // form horizontal
 form.ks-horizontal {
     .el-form-item {
-        display: block;
+        @include res(xs) {
+            display: block;
+        }
+
+        @include res(sm) {
+            .el-form-item__label {
+                max-width: (math.div(1, 24) * 4 * 100) * 1%;
+                flex: 0 0 (math.div(1, 24) * 4 * 100) * 1%;
+                text-align: right;
+            }
+
+            .el-form-item__content {
+                align-items: flex-start;
+                max-width: (math.div(1, 24) * 20 * 100) * 1%;
+                flex: 0 0 (math.div(1, 24) * 20 * 100) * 1%;
+            }
+        }
     }
 
     .submit {


### PR DESCRIPTION
Slightly longer input variable names caused overflow at a lowend 1600x900px display.

This is a simple hotfix.

Before:
![after](https://user-images.githubusercontent.com/13468636/227320128-3a9138e4-1956-43cc-867d-f06ef4168140.png)
After:
![before](https://user-images.githubusercontent.com/13468636/227320113-461e6d1d-f864-4e0e-8412-45be8d97c44b.png)

