### PR TITLE
fix(core): remove the killed execution from the map after killing it

### DIFF
--- a/core/src/main/java/io/kestra/core/runners/Worker.java
+++ b/core/src/main/java/io/kestra/core/runners/Worker.java
@@ -481,7 +481,7 @@ public class Worker implements Service, Runnable, AutoCloseable {
 
             this.logTerminated(workerTask);
 
-            //FIXME should we remove it from the killedExecution set ?
+            killedExecution.remove(workerTask.getTaskRun().getExecutionId());
 
             return workerTaskResult;
         }


### PR DESCRIPTION
This should be safe to purge the map at this stage.
And should fix a small memory leak when killing task often.