### PR TITLE
Revert "fix(jdbc): fix postgres migration with non default schema (#1…

### DIFF
--- a/jdbc-postgres/src/main/resources/migrations/postgres/V6__queue_index_optim.sql
+++ b/jdbc-postgres/src/main/resources/migrations/postgres/V6__queue_index_optim.sql
@@ -1,7 +1,7 @@
 -- We drop the PK and the queues_type__offset, otherwise they are used by the poll query which is sub-optimal.
 -- We create an hash index on offset that will be used instead when filtering on offset.
 
-ALTER TABLE queues DROP CONSTRAINT queues_pkey;
+ALTER TABLE public.queues DROP CONSTRAINT queues_pkey;
 
 DROP INDEX queues_type__offset;
 


### PR DESCRIPTION
…111)"

This reverts commit bbcea0a8f49d104687051f5dd4598c036a04d236.

@tchiotludo @stdrone we need to revert it as migrations are stored in the database with a verification ID that depends on the migration content, so each modification of a migration that is already preformed will crash the validation.

Updating a migration created on a past released version is not possible.

close #<issue number>
