### PR TITLE
fix(jdbc-postgres): fix migration with schema

### DIFF
--- a/cli/src/main/resources/application.yml
+++ b/cli/src/main/resources/application.yml
@@ -52,6 +52,8 @@ flyway:
       enabled: true
       locations:
         - classpath:migrations/postgres
+      # We must ignore missing migrations as a V6 wrong migration was created and replaced by the V11
+      ignore-migration-patterns: "*:missing"
     mysql:
       enabled: true
       locations:

--- a/jdbc-postgres/src/main/resources/migrations/postgres/V11__queue_index_optim.sql
+++ b/jdbc-postgres/src/main/resources/migrations/postgres/V11__queue_index_optim.sql
@@ -1,8 +1,8 @@
 -- We drop the PK and the queues_type__offset, otherwise they are used by the poll query which is sub-optimal.
 -- We create an hash index on offset that will be used instead when filtering on offset.
 
-ALTER TABLE public.queues DROP CONSTRAINT queues_pkey;
+ALTER TABLE queues DROP CONSTRAINT IF EXISTS queues_pkey;
 
-DROP INDEX queues_type__offset;
+DROP INDEX IF EXISTS queues_type__offset;
 
-CREATE INDEX queues_offset ON public.queues USING hash ("offset");
+CREATE INDEX IF NOT EXISTS queues_offset ON public.queues USING hash ("offset");

--- a/jdbc-postgres/src/test/resources/application.yml
+++ b/jdbc-postgres/src/test/resources/application.yml
@@ -12,6 +12,8 @@ flyway:
       enabled: true
       locations:
         - classpath:migrations/postgres
+      # We must ignore missing migrations as a V6 wrong migration was created and replaced by the V11
+      ignore-migration-patterns: "*:missing"
 
 kestra:
   queue:


### PR DESCRIPTION
Migrations must not have a schema to be able to use a different schema than public.

@stdrone this will fix your issue with the wrong migration.
