### PR TITLE
fix(core,ui) Pause task

### DIFF
--- a/core/src/main/java/io/kestra/core/models/executions/Execution.java
+++ b/core/src/main/java/io/kestra/core/models/executions/Execution.java
@@ -283,7 +283,7 @@ public class Execution implements DeletedInterface {
 
         return Streams.findLast(this.taskRunList
             .stream()
-            .filter(t -> !t.getState().isTerminated())
+            .filter(t -> !t.getState().isTerminated() || !t.getState().isPaused())
         );
     }
 

--- a/core/src/main/java/io/kestra/core/models/flows/State.java
+++ b/core/src/main/java/io/kestra/core/models/flows/State.java
@@ -85,7 +85,7 @@ public class State {
 
     @JsonProperty(access = JsonProperty.Access.READ_ONLY)
     public Optional<Instant> getEndDate() {
-        if (!this.isTerminated()) {
+        if (!this.isTerminated() && !this.isPaused()) {
             return Optional.empty();
         }
 
@@ -136,8 +136,13 @@ public class State {
     }
 
     @JsonIgnore
+    public boolean isPaused() {
+        return this.current.isPaused();
+    }
+
+    @JsonIgnore
     public boolean isRestartable() {
-        return this.current.isFailed();
+        return this.current.isFailed() || this.isPaused();
     }
 
 
@@ -154,7 +159,7 @@ public class State {
         KILLED;
 
         public boolean isTerminated() {
-            return this == Type.FAILED || this == Type.WARNING || this == Type.SUCCESS || this == Type.KILLED || this == Type.PAUSED;
+            return this == Type.FAILED || this == Type.WARNING || this == Type.SUCCESS || this == Type.KILLED;
         }
 
         public boolean isCreated() {
@@ -166,7 +171,11 @@ public class State {
         }
 
         public boolean isFailed() {
-            return this == Type.FAILED || this == Type.PAUSED;
+            return this == Type.FAILED;
+        }
+
+        public boolean isPaused() {
+            return this == Type.PAUSED;
         }
     }
 

--- a/core/src/main/java/io/kestra/core/runners/Executor.java
+++ b/core/src/main/java/io/kestra/core/runners/Executor.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.kestra.core.models.executions.Execution;
 import io.kestra.core.models.executions.TaskRun;
 import io.kestra.core.models.flows.Flow;
+import io.kestra.core.models.flows.State;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 

--- a/core/src/main/java/io/kestra/core/runners/ExecutorService.java
+++ b/core/src/main/java/io/kestra/core/runners/ExecutorService.java
@@ -377,6 +377,12 @@ public class ExecutorService {
     }
 
     private Executor handlePausedDelay(Executor executor, List<WorkerTaskResult> workerTaskResults) throws InternalException {
+        if (workerTaskResults
+            .stream()
+            .noneMatch(workerTaskResult -> workerTaskResult.getTaskRun().getState().getCurrent() == State.Type.PAUSED)) {
+            return executor;
+        }
+
         List<ExecutionDelay> list = workerTaskResults
             .stream()
             .filter(workerTaskResult -> workerTaskResult.getTaskRun().getState().getCurrent() == State.Type.PAUSED)
@@ -401,8 +407,10 @@ public class ExecutorService {
             .filter(Objects::nonNull)
             .collect(Collectors.toList());
 
-        if (list.size() == 0) {
-            return executor;
+        if(executor.getExecution().getState().getCurrent() != State.Type.PAUSED) {
+            return executor
+                .withExecution(executor.getExecution().withState(State.Type.PAUSED), "handlePausedDelay")
+                .withWorkerTaskDelays(list, "handlePausedDelay");
         }
 
         return executor.withWorkerTaskDelays(list, "handlePausedDelay");
@@ -458,7 +466,7 @@ public class ExecutorService {
     }
 
     private Executor handleEnd(Executor executor) {
-        if (executor.getExecution().getState().isTerminated()) {
+        if (executor.getExecution().getState().isTerminated() || executor.getExecution().getState().isPaused()) {
             return executor;
         }
 

--- a/core/src/main/java/io/kestra/core/runners/FlowableUtils.java
+++ b/core/src/main/java/io/kestra/core/runners/FlowableUtils.java
@@ -31,9 +31,7 @@ public class FlowableUtils {
         List<ResolvedTask> tasks,
         List<ResolvedTask> errors
     ) {
-        List<ResolvedTask> currentTasks = execution.findTaskDependingFlowState(tasks, errors, null);
-
-        return FlowableUtils.innerResolveSequentialNexts(execution, currentTasks, null);
+        return resolveSequentialNexts(execution, tasks, errors, null);
     }
 
     public static List<NextTaskRun> resolveSequentialNexts(

--- a/core/src/main/java/io/kestra/core/runners/Worker.java
+++ b/core/src/main/java/io/kestra/core/runners/Worker.java
@@ -124,7 +124,7 @@ public class Worker implements Runnable, Closeable {
 
                                 WorkerTaskResult workerTaskResult = this.run(currentWorkerTask, false);
 
-                                if (workerTaskResult.getTaskRun().getState().isFailed()) {
+                                if (workerTaskResult.getTaskRun().getState().isFailed() || workerTaskResult.getTaskRun().getState().isPaused()) {
                                     break;
                                 }
 

--- a/core/src/main/java/io/kestra/core/services/ExecutionService.java
+++ b/core/src/main/java/io/kestra/core/services/ExecutionService.java
@@ -56,7 +56,7 @@ public class ExecutionService {
     private MetricRepositoryInterface metricRepository;
 
     public Execution restart(final Execution execution, @Nullable Integer revision) throws Exception {
-        if (!execution.getState().isTerminated()) {
+        if (!(execution.getState().isTerminated() || execution.getState().isPaused())) {
             throw new IllegalStateException("Execution must be terminated to be restarted, " +
                 "current state is '" + execution.getState().getCurrent() + "' !"
             );
@@ -66,7 +66,7 @@ public class ExecutionService {
 
         Set<String> taskRunToRestart = this.taskRunToRestart(
             execution,
-            taskRun -> taskRun.getState().getCurrent().isFailed()
+            taskRun -> taskRun.getState().getCurrent().isFailed() || taskRun.getState().getCurrent().isPaused()
         );
 
         Map<String, String> mappingTaskRunId = this.mapTaskRunId(execution, revision == null);
@@ -125,7 +125,7 @@ public class ExecutionService {
     }
 
     public Execution replay(final Execution execution, String taskRunId, @Nullable Integer revision) throws Exception {
-        if (!execution.getState().isTerminated()) {
+        if (!(execution.getState().isTerminated() || !(execution.getState().isTerminated() ))) {
             throw new IllegalStateException("Execution must be terminated to be restarted, " +
                 "current state is '" + execution.getState().getCurrent() + "' !"
             );
@@ -184,7 +184,7 @@ public class ExecutionService {
     }
 
     public Execution markAs(final Execution execution, String taskRunId, State.Type newState) throws Exception {
-        if (!execution.getState().isTerminated()) {
+        if (!(execution.getState().isTerminated() || execution.getState().isPaused())) {
             throw new IllegalStateException("Execution must be terminated to be restarted, " +
                 "current state is '" + execution.getState().getCurrent() + "' !"
             );

--- a/core/src/main/java/io/kestra/core/tasks/flows/Flow.java
+++ b/core/src/main/java/io/kestra/core/tasks/flows/Flow.java
@@ -183,7 +183,7 @@ public class Flow extends Task implements RunnableTask<Flow.Output> {
         taskRun = taskRun.withOutputs(builder.build().toMap());
 
         if (transmitFailed &&
-            (execution.getState().isFailed() || execution.getState().getCurrent() == State.Type.KILLED || execution.getState().getCurrent() == State.Type.WARNING)
+            (execution.getState().isFailed() || execution.getState().isPaused() || execution.getState().getCurrent() == State.Type.KILLED || execution.getState().getCurrent() == State.Type.WARNING)
         ) {
             taskRun = taskRun.withState(execution.getState().getCurrent());
         } else {

--- a/core/src/test/java/io/kestra/core/tasks/flows/PauseTest.java
+++ b/core/src/test/java/io/kestra/core/tasks/flows/PauseTest.java
@@ -1,7 +1,6 @@
 package io.kestra.core.tasks.flows;
 
 import io.kestra.core.models.executions.Execution;
-import io.kestra.core.models.flows.Flow;
 import io.kestra.core.models.flows.State;
 import io.kestra.core.queues.QueueFactoryInterface;
 import io.kestra.core.queues.QueueInterface;
@@ -53,8 +52,7 @@ public class PauseTest extends AbstractMemoryRunnerTest {
         protected QueueInterface<Execution> executionQueue;
 
         public void run(RunnerUtils runnerUtils) throws Exception {
-            Flow flow = flowRepository.findById("io.kestra.tests", "pause").orElseThrow();
-            Execution execution = runnerUtils.runOne("io.kestra.tests", "pause", Duration.ofSeconds(120));
+            Execution execution = runnerUtils.runOneUntilPaused("io.kestra.tests", "pause");
 
             assertThat(execution.getState().getCurrent(), is(State.Type.PAUSED));
             assertThat(execution.getTaskRunList().get(0).getState().getCurrent(), is(State.Type.PAUSED));
@@ -76,10 +74,9 @@ public class PauseTest extends AbstractMemoryRunnerTest {
         }
 
         public void runDelay(RunnerUtils runnerUtils) throws Exception {
-            Execution execution = runnerUtils.runOne("io.kestra.tests", "pause-delay");
+            Execution execution = runnerUtils.runOneUntilPaused("io.kestra.tests", "pause-delay");
 
             assertThat(execution.getState().getCurrent(), is(State.Type.PAUSED));
-            assertThat(execution.getTaskRunList().get(0).getState().getCurrent(), is(State.Type.PAUSED));
             assertThat(execution.getTaskRunList(), hasSize(1));
 
             execution = runnerUtils.awaitExecution(
@@ -95,10 +92,9 @@ public class PauseTest extends AbstractMemoryRunnerTest {
 
 
         public void runTimeout(RunnerUtils runnerUtils) throws Exception {
-            Execution execution = runnerUtils.runOne("io.kestra.tests", "pause-timeout");
+            Execution execution = runnerUtils.runOneUntilPaused("io.kestra.tests", "pause-timeout");
 
             assertThat(execution.getState().getCurrent(), is(State.Type.PAUSED));
-            assertThat(execution.getTaskRunList().get(0).getState().getCurrent(), is(State.Type.PAUSED));
             assertThat(execution.getTaskRunList(), hasSize(1));
 
             execution = runnerUtils.awaitExecution(

--- a/core/src/test/resources/flows/valids/pause-delay.yaml
+++ b/core/src/test/resources/flows/valids/pause-delay.yaml
@@ -4,9 +4,9 @@ namespace: io.kestra.tests
 tasks:
   - id: pause
     type: io.kestra.core.tasks.flows.Pause
-    delay: PT10S
+    delay: PT1S
     tasks:
-      - id: ko
+      - id: subtask
         type: io.kestra.core.tasks.scripts.Bash
         commands:
           - echo "trigger 1 seconds pause"

--- a/core/src/test/resources/flows/valids/pause.yaml
+++ b/core/src/test/resources/flows/valids/pause.yaml
@@ -5,10 +5,16 @@ tasks:
   - id: pause
     type: io.kestra.core.tasks.flows.Pause
     tasks:
-      - id: ko
+      - id: subtask
         type: io.kestra.core.tasks.scripts.Bash
         commands:
           - echo "trigger after manual restart"
   - id: last
     type: io.kestra.core.tasks.debugs.Return
     format: "{{task.id}} > {{taskrun.startDate}}"
+
+errors:
+  - id: failed-echo
+    type: io.kestra.core.tasks.debugs.Echo
+    description: "Log the error"
+    format: I'm failing {{task.id}}

--- a/jdbc/src/test/java/io/kestra/jdbc/runner/JdbcRunnerTest.java
+++ b/jdbc/src/test/java/io/kestra/jdbc/runner/JdbcRunnerTest.java
@@ -15,6 +15,7 @@ import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
 import jakarta.inject.Inject;
 import jakarta.inject.Named;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;

--- a/ui/src/components/executions/ChangeStatus.vue
+++ b/ui/src/components/executions/ChangeStatus.vue
@@ -159,6 +159,10 @@
                     return false;
                 }
 
+                if(this.taskRun.state.current === "PAUSED") {
+                    return true;
+                }
+
                 if (State.isRunning(this.execution.state.current)) {
                     return false;
                 }

--- a/ui/src/components/logs/LogList.vue
+++ b/ui/src/components/logs/LogList.vue
@@ -187,7 +187,7 @@
                 this.loadLogs();
             },
             execution: function() {
-                if (this.execution && this.execution.state.current !== State.RUNNING) {
+                if (this.execution && this.execution.state.current !== State.RUNNING && this.execution.state.current !== State.PAUSED ) {
                     this.closeSSE();
                 }
             },

--- a/ui/src/utils/state.js
+++ b/ui/src/utils/state.js
@@ -86,7 +86,7 @@ const STATE = Object.freeze({
         colorClass: "",
         color: "#6d81f5",
         icon: PauseCircle,
-        isRunning: false,
+        isRunning: true,
         isKillable: false,
         isFailed: false,
     }


### PR DESCRIPTION
Fixes #1103
Fixes #1114

@yuri1969 I tested 10k flow executions and all ends up green with this patch so I think it will fix #1114.

My test flow is:

```yaml
id: wait-and-delay
namespace: io.kestra.tests


tasks:
  - id: wait-and-resume
    type: io.kestra.core.tasks.flows.Pause
    description: "Wait 10 sec and then resume"
    delay: PT10S
    tasks:
      - id: hello-world
        type: io.kestra.core.tasks.log.Log
        message: Hello World
```

As soon as this PR is merged this would be great if you can test it and assert your issues are fixed.