### PR TITLE
Feat/lowcode improvements

### DIFF
--- a/ui/src/components/flows/MetadataEditor.vue
+++ b/ui/src/components/flows/MetadataEditor.vue
@@ -210,7 +210,7 @@
                     namespace: this.newMetadata.namespace,
                     description: this.newMetadata.description,
                     labels: this.arrayToObject(this.newMetadata.labels),
-                    inputs: this.newMetadata.inputs,
+                    inputs: this.newMetadata.inputs.filter(e => e.name && e.type),
                     variables: this.arrayToObject(this.newMetadata.variables),
                     taskDefaults: taskDefaults,
                     disabled: this.newMetadata.disabled

--- a/ui/src/components/flows/MetadataInputs.vue
+++ b/ui/src/components/flows/MetadataInputs.vue
@@ -93,7 +93,7 @@
             </div>
         </el-drawer>
         <div class="w-100">
-            <div v-if="newInputs.length > 0">
+            <div>
                 <div class="d-flex w-100" v-for="(input, index) in newInputs" :key="index">
                     <div class="flex-fill flex-grow-1 w-100 me-2">
                         <el-input
@@ -112,11 +112,6 @@
                         </el-button-group>
                     </div>
                 </div>
-            </div>
-            <div v-else class="d-flex justify-content-center">
-                <el-button :icon="Plus" type="success" class="w-25" @click="addInput">
-                    Add
-                </el-button>
             </div>
         </div>
     </div>
@@ -150,7 +145,7 @@
             }
 
             return {
-                newInputs: [],
+                newInputs: [{}],
                 inputsType: [
                     {
                         component: "editor",

--- a/ui/src/components/graph/Topology.vue
+++ b/ui/src/components/graph/Topology.vue
@@ -634,9 +634,8 @@
 
     onNodeDragStart((e) => {
         dragging.value = true;
-        getNodes.value.forEach(n => {
-            n.style = {...n.style, border: "none"}
-        })
+        resetNodesStyle();
+        e.node.style = {...e.node.style, zIndex: 1976}
         lastPosition.value = e.node.position;
     })
 
@@ -654,11 +653,8 @@
         } else {
             getNodes.value.find(n => n.id === e.node.id).position = lastPosition.value;
         }
-        getNodes.value.forEach(n => {
-            if (n.type === "task" || n.type === "trigger") {
-                n.style = {...n.style, opacity: "1"}
-            }
-        })
+        resetNodesStyle();
+        e.node.style = {...e.node.style, zIndex: 1}
         lastPosition.value = null;
     })
 

--- a/ui/src/components/graph/Topology.vue
+++ b/ui/src/components/graph/Topology.vue
@@ -535,17 +535,24 @@
     }
 
     const onDelete = (event) => {
-        const section = event.section ? event.section : "tasks";
         const flowParsed = YamlUtils.parse(flowYaml.value);
-        if (section === "tasks" && flowParsed.tasks.length === 1 && flowParsed.tasks.map(e => e.id).includes(event.id)) {
-            store.dispatch("core/showMessage", {
-                variant: "error",
-                title: t("can not delete"),
-                message: t("can not have less than 1 task")
-            });
-            return;
-        }
-        onEdit(YamlUtils.deleteTask(flowYaml.value, event.id, section));
+        toast.confirm(
+            t("delete task confirm", {taskId: flowParsed.id}),
+            () => {
+
+                const section = event.section ? event.section : "tasks";
+                if (section === "tasks" && flowParsed.tasks.length === 1 && flowParsed.tasks.map(e => e.id).includes(event.id)) {
+                    store.dispatch("core/showMessage", {
+                        variant: "error",
+                        title: t("can not delete"),
+                        message: t("can not have less than 1 task")
+                    });
+                    return;
+                }
+                onEdit(YamlUtils.deleteTask(flowYaml.value, event.id, section));
+            },
+            () => {}
+        )
     }
 
     const onCreateNewTask = (event) => {
@@ -694,7 +701,7 @@
                 n.style = {...n.style, opacity: "1", border: "none"}
             })
     }
-    
+
     const editorUpdate = (event) => {
         updatedFromEditor.value = true;
         flowYaml.value = event;

--- a/ui/src/components/graph/Topology.vue
+++ b/ui/src/components/graph/Topology.vue
@@ -754,7 +754,11 @@
                     })
                 return;
             } else {
-                isEditMetadataOpen.value = true;
+                store.dispatch("core/showMessage", {
+                    variant: "error",
+                    title: t("can not save"),
+                    message: t("flow must have id and namespace")
+                });
                 return;
             }
         }

--- a/ui/src/components/graph/Topology.vue
+++ b/ui/src/components/graph/Topology.vue
@@ -473,7 +473,7 @@
         if (!dragging.value) {
             linkedElements(id, node.uid).forEach((n) => {
                 if (n.type === "task") {
-                    n.style = {...n.style, border: "0.5px solid yellow"}
+                    n.style = {...n.style, outline: "0.5px solid " + cssVariable('--bs-yellow')}
                 }
             });
         }
@@ -670,10 +670,10 @@
         if (!checkIntersections(e.intersections, e.node) && e.intersections.filter(n => n.type === "task").length === 1) {
             e.intersections.forEach(n => {
                 if (n.type === "task") {
-                    n.style = {...n.style, border: "0.5px solid yellow"}
+                    n.style = {...n.style, outline: "0.5px solid " + cssVariable('--bs-primary')}
                 }
             })
-            e.node.style = {...e.node.style, border: "0.5px solid yellow"}
+            e.node.style = {...e.node.style, outline: "0.5px solid " + cssVariable('--bs-primary')}
         }
     })
 
@@ -694,7 +694,7 @@
     const resetNodesStyle = () => {
         getNodes.value.filter(n => n.type === "task" || n.type === " trigger")
             .forEach(n => {
-                n.style = {...n.style, opacity: "1", border: "none"}
+                n.style = {...n.style, opacity: "1", outline: "none"}
             })
     }
 

--- a/ui/src/components/graph/Topology.vue
+++ b/ui/src/components/graph/Topology.vue
@@ -647,26 +647,11 @@
     })
 
     onNodeDrag((e) => {
-        if (checkIntersections(e.intersections, e.node)) {
-            const taskNodeIds = e.intersections.filter(n => n.type === "task" || n.type === "trigger").map(n => n.id)
-            getNodes.value.forEach(n => {
-                if (n.type === "task" || n.type === "trigger") {
-                    if (taskNodeIds.includes(n.id)) {
-                        n.style = {...n.style, opacity: "0.5"}
-                    } else {
-                        n.style = {...n.style, opacity: "1"}
-                    }
-                }
-            })
-        } else {
-            const tasksMeet = e.intersections.filter(n => n.type === "task").map(n => n.id);
-
-            getNodes.value.forEach(n => {
-                if (n.type === "task" || n.type === "trigger") {
-                    n.style = {...n.style, opacity: "1"}
-                }
-            })
-        }
+        getNodes.value.filter(n => n.id !== e.node.id).forEach(n => {
+            if (n.type === "trigger" || (n.type === "task" && YamlUtils.isParentChildrenRelation(flowYaml.value, n.id, e.node.id))) {
+                n.style = {...n.style, opacity: "0.5"}
+            }
+        })
     })
 
     const checkIntersections = (intersections, node) => {

--- a/ui/src/translations.json
+++ b/ui/src/translations.json
@@ -402,7 +402,8 @@
     "switch-view": "Switch view",
     "source and topology": "Source and topology",
     "editor": "Editor",
-    "error in editor": "An error have been found in the editor"
+    "error in editor": "An error have been found in the editor",
+    "delete task confirm": "Do you want to delete the task <code>{taskId}</code> ?"
   },
   "fr": {
     "id": "Identifiant",
@@ -808,7 +809,7 @@
     "switch-view": "Changer de vue",
     "source and topology": "Source et topologie",
     "editor": "Éditeur",
-    "error in editor": "Une erreur a été trouvé dans l'éditeur"
-
+    "error in editor": "Une erreur a été trouvé dans l'éditeur",
+    "delete task confirm": "Êtes-vous sûr de vouloir supprimer la tâche <code>{taskId}</code> ?"
   }
 }

--- a/ui/src/translations.json
+++ b/ui/src/translations.json
@@ -403,7 +403,9 @@
     "source and topology": "Source and topology",
     "editor": "Editor",
     "error in editor": "An error have been found in the editor",
-    "delete task confirm": "Do you want to delete the task <code>{taskId}</code> ?"
+    "delete task confirm": "Do you want to delete the task <code>{taskId}</code> ?",
+    "can not save": "Can not save",
+    "flow must have id and namespace": "Flow must have an id and a namespace."
   },
   "fr": {
     "id": "Identifiant",
@@ -810,6 +812,8 @@
     "source and topology": "Source et topologie",
     "editor": "Éditeur",
     "error in editor": "Une erreur a été trouvé dans l'éditeur",
-    "delete task confirm": "Êtes-vous sûr de vouloir supprimer la tâche <code>{taskId}</code> ?"
+    "delete task confirm": "Êtes-vous sûr de vouloir supprimer la tâche <code>{taskId}</code> ?",
+    "can not save": "Impossible de sauvegarder",
+    "flow must have id and namespace": "Le flow doit avoir un id et un namespace."
   }
 }


### PR DESCRIPTION
Added different QOL regarding the low code first iteration :

* When the id or namespace is empty on save, show an error
* Remove the useless Add button in the metadata editor
* Dragged node has increased zIndex, so it's always above other nodes
* Confirm task deletion
* Highlight the path when hovering over a task and when two tasks a swappable
* reduce the opacity of all nodes that can not* be swapped with the node being dragged
*  Fix an issue where empty inputs are added to the flow
