### PR TITLE
fix(core): Serialize null as null and not "null" in the ION file

### DIFF
--- a/core/src/main/java/io/kestra/core/serializers/FileSerde.java
+++ b/core/src/main/java/io/kestra/core/serializers/FileSerde.java
@@ -18,8 +18,10 @@ abstract public class FileSerde {
     private static final TypeReference<Object> TYPE_REFERENCE = new TypeReference<>(){};
 
     public static void write(OutputStream output, Object row) throws IOException {
-        output.write(MAPPER.writeValueAsBytes(row));
-        output.write("\n".getBytes());
+        if (row != null) { // avoid writing "null"
+            output.write(MAPPER.writeValueAsBytes(row));
+            output.write("\n".getBytes());
+        }
     }
 
     public static FlowableOnSubscribe<Object> reader(BufferedReader input) {

--- a/core/src/main/java/io/kestra/core/tasks/storages/Concat.java
+++ b/core/src/main/java/io/kestra/core/tasks/storages/Concat.java
@@ -18,7 +18,6 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.net.URI;
 import java.util.List;
-import java.util.Map;
 
 import static io.kestra.core.utils.Rethrow.throwConsumer;
 

--- a/ui/src/utils/utils.js
+++ b/ui/src/utils/utils.js
@@ -84,6 +84,10 @@ export default class Utils {
      * @return Formatted string.
      */
     static humanFileSize(bytes, si = false, dp = 1) {
+        if (bytes === undefined) {
+           // when the size is 0 it arrives as undefined here!
+           return "0B";
+        }
         const thresh = si ? 1000 : 1024;
 
         if (Math.abs(bytes) < thresh) {


### PR DESCRIPTION
Currently, when a row is null it is written as the "null" string instead as a null / empty line.

This fixes the issue and also fix a small UI bug when a null file results in a "NaN Kb" in the output tab.
