### PR TITLE
fix: Allow topo edition when creating

### DIFF
--- a/ui/src/components/graph/Topology.vue
+++ b/ui/src/components/graph/Topology.vue
@@ -432,7 +432,7 @@
     })
 
     onBeforeUnmount(() => {
-        store.commit("plugin/setEditorPlugin",undefined);
+        store.commit("plugin/setEditorPlugin", undefined);
         document.removeEventListener("keydown", save);
         document.removeEventListener("popstate", () => {
             stopTour();
@@ -483,11 +483,7 @@
     });
 
     const isAllowedEdit = () => {
-        if (props.isCreating) {
-            return user && getFlowMetadata().namespace && user.isAllowed(permission.FLOW, action.CREATE, getFlowMetadata().namespace);
-        } else {
-            return user && user.isAllowed(permission.FLOW, action.UPDATE, props.namespace);
-        }
+        return user && user.isAllowed(permission.FLOW, action.UPDATE, props.namespace);
     };
 
     const onMouseOver = (node) => {


### PR DESCRIPTION
At creation, we do not know the final namespace, so we should let the user edit everything.