### PR TITLE
fix(): Removed front access verification

### DIFF
--- a/ui/src/components/executions/Executions.vue
+++ b/ui/src/components/executions/Executions.vue
@@ -52,7 +52,7 @@
                     @sort-change="onSort"
                     @selection-change="handleSelectionChange"
                 >
-                    <el-table-column type="selection" v-if="!hidden.includes('selection') && (canUpdate || canDelete)" />
+                    <el-table-column type="selection" v-if="!hidden.includes('selection') && (canCheck)" />
 
                     <el-table-column prop="id" v-if="!hidden.includes('id')" sortable="custom" :sort-orders="['ascending', 'descending']" :label="$t('id')">
                         <template #default="scope">
@@ -248,11 +248,14 @@
                 return (this.executionsSelection.length !== 0 && (this.canUpdate || this.canDelete)) ||
                     (this.$route.name === "flows/update");
             },
+            canCheck() {
+                return this.canDelete || this.canUpdate;
+            },
             canUpdate() {
-                return this.user && this.user.isAllowed(permission.EXECUTION, action.UPDATE);
+                return this.user && this.user.isAllowed(permission.EXECUTION, action.UPDATE, this.$route.query.namespace);
             },
             canDelete() {
-                return this.user && this.user.isAllowed(permission.EXECUTION, action.DELETE);
+                return this.user && this.user.isAllowed(permission.EXECUTION, action.DELETE, this.$route.query.namespace);
             },
             isAllowedEdit() {
                 return this.user.isAllowed(permission.FLOW, action.UPDATE, this.flow.namespace);

--- a/ui/src/components/flows/Flows.vue
+++ b/ui/src/components/flows/Flows.vue
@@ -41,7 +41,7 @@
                         :row-class-name="rowClasses"
                         @selection-change="handleSelectionChange"
                     >
-                        <el-table-column type="selection" v-if="(canRead)" />
+                        <el-table-column type="selection" v-if="(canCheck)" />
                         <el-table-column prop="id" sortable="custom" :sort-orders="['ascending', 'descending']" :label="$t('id')">
                             <template #default="scope">
                                 <router-link
@@ -229,14 +229,17 @@
                     .add(-30, "days")
                     .toDate();
             },
+            canCheck() {
+                return this.canRead || this.canDelete || this.canDisable;
+            },
             canRead() {
-                return this.user && this.user.isAllowed(permission.FLOW, action.READ);
+                return this.user && this.user.isAllowed(permission.FLOW, action.READ, this.$route.query.namespace);
             },
             canDelete() {
-                return this.user && this.user.isAllowed(permission.FLOW, action.DELETE);
+                return this.user && this.user.isAllowed(permission.FLOW, action.DELETE, this.$route.query.namespace);
             },
             canDisable() {
-                return this.user && this.user.isAllowed(permission.FLOW, action.UPDATE);
+                return this.user && this.user.isAllowed(permission.FLOW, action.UPDATE, this.$route.query.namespace);
             },
         },
         methods: {


### PR DESCRIPTION
Actual conditions required to be Kestra Admin to display `Select` in executions and flow list, which makes nonsense.
I removed conditions and let the backend handle it because we can't check for every row if the user has the right access.

