### PR TITLE
fix(core): allow usage of Pebble verbatim tag in our recursive renderer

### DIFF
--- a/core/src/main/java/io/kestra/core/runners/VariableRenderer.java
+++ b/core/src/main/java/io/kestra/core/runners/VariableRenderer.java
@@ -97,7 +97,7 @@ public class VariableRenderer {
         String currentTemplate = inline;
         String current = "";
         PebbleTemplate compiledTemplate;
-        do {
+        while (!isSame) {
             try {
                 compiledTemplate = pebbleEngine.getLiteralTemplate(currentTemplate);
 
@@ -128,17 +128,14 @@ public class VariableRenderer {
             isSame = currentTemplate.equals(current);
             currentTemplate = current;
         }
-        while(!isSame && !isVerbatim(inline));
 
         return current;
     }
 
-    private boolean isVerbatim(String inline) {
-        return inline.startsWith("{%verbatim") || inline.startsWith("{% verbatim") || inline.startsWith("\"{{\"");
-    }
-
     public IllegalVariableEvaluationException properPebbleException(PebbleException e) {
-        if (e instanceof AttributeNotFoundException current) {
+        if (e instanceof AttributeNotFoundException) {
+            AttributeNotFoundException current = (AttributeNotFoundException) e;
+
             return new IllegalVariableEvaluationException(
                 "Missing variable: '" + current.getAttributeName() +
                     "' on '" + current.getFileName() +

--- a/core/src/main/java/io/kestra/core/runners/VariableRenderer.java
+++ b/core/src/main/java/io/kestra/core/runners/VariableRenderer.java
@@ -93,15 +93,15 @@ public class VariableRenderer {
             return null;
         }
 
-        // pre-process inline for escape sequence
-
-
         boolean isSame = false;
         String currentTemplate = inline;
         String current = "";
         PebbleTemplate compiledTemplate;
         while (!isSame) {
             try {
+                // pre-process currentTemplate for escape sequence
+                currentTemplate = currentTemplate.replace("\\{{", "<||").replace("\\}}", "||>");
+
                 compiledTemplate = pebbleEngine.getLiteralTemplate(currentTemplate);
 
                 Writer writer = new JsonWriter(new StringWriter());
@@ -132,6 +132,8 @@ public class VariableRenderer {
             currentTemplate = current;
         }
 
+        // post-process currentTemplate for escape sequence
+        current = current.replace("<||", "{{").replace("||>", "}}");
         return current;
     }
 

--- a/core/src/main/java/io/kestra/core/runners/VariableRenderer.java
+++ b/core/src/main/java/io/kestra/core/runners/VariableRenderer.java
@@ -93,6 +93,9 @@ public class VariableRenderer {
             return null;
         }
 
+        // pre-process inline for escape sequence
+
+
         boolean isSame = false;
         String currentTemplate = inline;
         String current = "";

--- a/core/src/main/java/io/kestra/core/runners/VariableRenderer.java
+++ b/core/src/main/java/io/kestra/core/runners/VariableRenderer.java
@@ -97,7 +97,7 @@ public class VariableRenderer {
         String currentTemplate = inline;
         String current = "";
         PebbleTemplate compiledTemplate;
-        while (!isSame) {
+        do {
             try {
                 compiledTemplate = pebbleEngine.getLiteralTemplate(currentTemplate);
 
@@ -128,14 +128,17 @@ public class VariableRenderer {
             isSame = currentTemplate.equals(current);
             currentTemplate = current;
         }
+        while(!isSame && !isVerbatim(inline));
 
         return current;
     }
 
-    public IllegalVariableEvaluationException properPebbleException(PebbleException e) {
-        if (e instanceof AttributeNotFoundException) {
-            AttributeNotFoundException current = (AttributeNotFoundException) e;
+    private boolean isVerbatim(String inline) {
+        return inline.startsWith("{%verbatim") || inline.startsWith("{% verbatim") || inline.startsWith("\"{{\"");
+    }
 
+    public IllegalVariableEvaluationException properPebbleException(PebbleException e) {
+        if (e instanceof AttributeNotFoundException current) {
             return new IllegalVariableEvaluationException(
                 "Missing variable: '" + current.getAttributeName() +
                     "' on '" + current.getFileName() +

--- a/core/src/test/java/io/kestra/core/runners/pebble/PebbleVariableRendererTest.java
+++ b/core/src/test/java/io/kestra/core/runners/pebble/PebbleVariableRendererTest.java
@@ -5,7 +5,6 @@ import io.kestra.core.exceptions.IllegalVariableEvaluationException;
 import io.kestra.core.runners.VariableRenderer;
 import io.kestra.core.utils.Rethrow;
 import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import java.time.ZonedDateTime;
@@ -162,29 +161,6 @@ class PebbleVariableRendererTest {
         String render = variableRenderer.render("{{ second }}", vars);
 
         assertThat(render, is("1"));
-    }
-
-    @Test
-    void verbatim() throws IllegalVariableEvaluationException {
-        ImmutableMap<String, Object> vars = ImmutableMap.of(
-            "var", "1"
-        );
-
-        String render = variableRenderer.render("{% verbatim %}{{ var }}{% endverbatim %}", vars);
-
-        assertThat(render, is("{{ var }}"));
-    }
-
-    @Test
-    @Disabled("Due to recursion in our VariableRenderer, we cannot use inline verbatim")
-    void inlineVerbatim() throws IllegalVariableEvaluationException {
-        ImmutableMap<String, Object> vars = ImmutableMap.of(
-            "var", "1"
-        );
-
-        String render = variableRenderer.render("{{ \"{{\" }} var {{ \"}}\" }}", vars);
-
-        assertThat(render, is("{{ var }}"));
     }
 
     @Test

--- a/core/src/test/java/io/kestra/core/runners/pebble/PebbleVariableRendererTest.java
+++ b/core/src/test/java/io/kestra/core/runners/pebble/PebbleVariableRendererTest.java
@@ -5,6 +5,7 @@ import io.kestra.core.exceptions.IllegalVariableEvaluationException;
 import io.kestra.core.runners.VariableRenderer;
 import io.kestra.core.utils.Rethrow;
 import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import java.time.ZonedDateTime;
@@ -161,6 +162,29 @@ class PebbleVariableRendererTest {
         String render = variableRenderer.render("{{ second }}", vars);
 
         assertThat(render, is("1"));
+    }
+
+    @Test
+    void verbatim() throws IllegalVariableEvaluationException {
+        ImmutableMap<String, Object> vars = ImmutableMap.of(
+            "var", "1"
+        );
+
+        String render = variableRenderer.render("{% verbatim %}{{ var }}{% endverbatim %}", vars);
+
+        assertThat(render, is("{{ var }}"));
+    }
+
+    @Test
+    @Disabled("Due to recursion in our VariableRenderer, we cannot use inline verbatim")
+    void inlineVerbatim() throws IllegalVariableEvaluationException {
+        ImmutableMap<String, Object> vars = ImmutableMap.of(
+            "var", "1"
+        );
+
+        String render = variableRenderer.render("{{ \"{{\" }} var {{ \"}}\" }}", vars);
+
+        assertThat(render, is("{{ var }}"));
     }
 
     @Test

--- a/core/src/test/java/io/kestra/core/runners/pebble/PebbleVariableRendererTest.java
+++ b/core/src/test/java/io/kestra/core/runners/pebble/PebbleVariableRendererTest.java
@@ -164,6 +164,29 @@ class PebbleVariableRendererTest {
     }
 
     @Test
+    void escape() throws IllegalVariableEvaluationException {
+        ImmutableMap<String, Object> vars = ImmutableMap.of(
+            "first", "1"
+        );
+
+        String render = variableRenderer.render("\\{{first\\}}", vars);
+
+        assertThat(render, is("{{first}}"));
+    }
+
+    @Test
+    void escapeRecursive() throws IllegalVariableEvaluationException {
+        ImmutableMap<String, Object> vars = ImmutableMap.of(
+            "first", "1",
+            "second", "\\{{first\\}}"
+        );
+
+        String render = variableRenderer.render("{{ second }}", vars);
+
+        assertThat(render, is("{{first}}"));
+    }
+
+    @Test
     void eval() throws IllegalVariableEvaluationException {
         ImmutableMap<String, Object> vars = ImmutableMap.of(
             "block", ImmutableMap.of("test", ImmutableMap.of("child", "awesome")),


### PR DESCRIPTION
close #1244

After investigation, due to the fact that we render a template recursively, we cannot use an operator like `\{{` nor a function, nor a filter :(

I ended up using a hack to stop the recursivity if using the verbatim tag that is the tag that should have been working for this. Inline verbatim is not possible.

More advanced solutions (function, tag, filter) would need to hook into the template engine itself as at the render level we only have access to the template and its result.

Another solution would be to stop inline rendering and provide a `render` function so users opt-in for recursive rendering.

I'm not very happy with the solution so if someone has a better idea I'm open to suggestions.
