### PR TITLE
fix(core): Fix bad redirection on homepage

### DIFF
--- a/ui/src/stores/flow.js
+++ b/ui/src/stores/flow.js
@@ -16,7 +16,7 @@ export default {
         task: undefined,
         search: undefined,
         total: 0,
-        overallTotal: 0,
+        overallTotal: undefined,
         flowGraph: undefined,
         flowGraphParam: undefined,
         revisions: undefined,


### PR DESCRIPTION
Fix an issue where first arriving on the homepage lead to the welcome page as `overallTotal` was set to 0 by default.