### PR TITLE
fix(core): fix plugin definition conflict

### DIFF
--- a/ui/src/components/flows/TaskEditor.vue
+++ b/ui/src/components/flows/TaskEditor.vue
@@ -77,6 +77,7 @@
                 this.$store
                     .dispatch("plugin/load", {
                         cls: this.selectedTaskType,
+                        all: true
                     })
                     .then((response) => {
                         this.plugin = response;

--- a/ui/src/stores/plugins.js
+++ b/ui/src/stores/plugins.js
@@ -2,6 +2,7 @@ export default {
     namespaced: true,
     state: {
         plugin: undefined,
+        pluginAllProps: undefined,
         plugins: undefined,
         pluginSingleList: undefined,
         icons: undefined,
@@ -22,9 +23,12 @@ export default {
                 throw new Error("missing required cls");
             }
 
-            return this.$http.get(`/api/v1/plugins/${options.cls}?all=true`, {}).then(response => {
-                commit("setPlugin", response.data)
-
+            return this.$http.get(`/api/v1/plugins/${options.cls}`, {params: options}).then(response => {
+                if(options.all === true) {
+                    commit("setPluginAllProps", response.data)
+                } else {
+                    commit("setPlugin", response.data)
+                }
                 return response.data;
             })
         },
@@ -47,6 +51,9 @@ export default {
     mutations: {
         setPlugin(state, plugin) {
             state.plugin = plugin
+        },
+        setPluginAllProps(state, pluginAllProps) {
+            state.pluginAllProps = pluginAllProps
         },
         setPlugins(state, plugins) {
             state.plugins = plugins


### PR DESCRIPTION
This PR fixes a conflict between this PR https://github.com/kestra-io/kestra/pull/1294 and this one https://github.com/kestra-io/kestra/pull/1229, as @loicmathieu noticed.

The issue is that we cannot set `all=true` by default because it brings all the task default properties to each task definition in the documentation, making the documentation noisier (especially in tasks like the [Bash](https://kestra.io/plugins/core/tasks/scripts/io.kestra.core.tasks.scripts.bash#properties) one which already have a lot of properties).

But on the other side, we need those properties for the low-code form.

So to avoid duplicate code, as the only difference is a param in the URL, I store the result in a different state variable depending if the param was given or not.

Note that the new variable `pluginAllProps` is not used yet since the `TaskEditor` use the then() method of the Promise to get the result, but I thought it was more clear to add it still.