### PR TITLE
fix(webserver): Query distinct task that have metrics

### DIFF
--- a/core/src/main/java/io/kestra/core/repositories/MetricRepositoryInterface.java
+++ b/core/src/main/java/io/kestra/core/repositories/MetricRepositoryInterface.java
@@ -21,6 +21,8 @@ public interface MetricRepositoryInterface extends SaveRepositoryInterface<Metri
 
     List<String> taskMetrics(String namespace, String flowId, String taskId);
 
+    List<String> tasksWithMetrics(String namespace, String flowId);
+
     MetricAggregations aggregateByFlowId(String namespace, String flowId, @Nullable String taskId, String metric, ZonedDateTime startDate, ZonedDateTime endDate, String aggregation);
 
     Integer purge(Execution execution);

--- a/core/src/test/java/io/kestra/core/repositories/AbstractMetricRepositoryTest.java
+++ b/core/src/test/java/io/kestra/core/repositories/AbstractMetricRepositoryTest.java
@@ -26,9 +26,9 @@ public abstract class AbstractMetricRepositoryTest {
     @Test
     void all() {
         String executionId = FriendlyId.createFriendlyId();
-        TaskRun taskRun1 = taskRun(executionId);
-        MetricEntry counter = MetricEntry.of(taskRun1, counter());
-        TaskRun taskRun2 = taskRun(executionId);
+        TaskRun taskRun1 = taskRun(executionId, "task");
+        MetricEntry counter = MetricEntry.of(taskRun1, counter("counter"));
+        TaskRun taskRun2 = taskRun(executionId, "task");
         MetricEntry timer = MetricEntry.of(taskRun2, timer());
         metricRepository.save(counter);
         metricRepository.save(timer);
@@ -70,20 +70,42 @@ public abstract class AbstractMetricRepositoryTest {
 
     }
 
-    private Counter counter() {
-        return Counter.of("counter", 1);
+     @Test
+     void names() {
+         String executionId = FriendlyId.createFriendlyId();
+         TaskRun taskRun1 = taskRun(executionId, "task");
+         MetricEntry counter = MetricEntry.of(taskRun1, counter("counter"));
+
+         TaskRun taskRun2 = taskRun(executionId, "task2");
+         MetricEntry counter2 = MetricEntry.of(taskRun2, counter("counter2"));
+
+         metricRepository.save(counter);
+         metricRepository.save(counter2);
+
+
+         List<String> flowMetricsNames = metricRepository.flowMetrics("namespace", "flow");
+         List<String> taskMetricsNames = metricRepository.taskMetrics("namespace", "flow", "task");
+         List<String> tasksWithMetrics = metricRepository.tasksWithMetrics("namespace", "flow");
+
+         assertThat(flowMetricsNames.size(), is(2));
+         assertThat(taskMetricsNames.size(), is(1));
+         assertThat(tasksWithMetrics.size(), is(2));
+     }
+
+    private Counter counter(String metricName) {
+        return Counter.of(metricName, 1);
     }
 
     private Timer timer() {
         return Timer.of("counter", Duration.ofSeconds(5));
     }
 
-    private TaskRun taskRun(String executionId) {
+    private TaskRun taskRun(String executionId, String taskId) {
         return TaskRun.builder()
             .flowId("flow")
             .namespace("namespace")
             .executionId(executionId)
-            .taskId("task")
+            .taskId(taskId)
             .id(FriendlyId.createFriendlyId())
             .build();
     }

--- a/repository-memory/src/main/java/io/kestra/repository/memory/MemoryMetricRepository.java
+++ b/repository-memory/src/main/java/io/kestra/repository/memory/MemoryMetricRepository.java
@@ -46,6 +46,11 @@ public class MemoryMetricRepository implements MetricRepositoryInterface {
     }
 
     @Override
+    public List<String> tasksWithMetrics(String namespace, String flowId) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
     public MetricAggregations aggregateByFlowId(String namespace, String flowId, @Nullable String taskId, String metric, @Nullable ZonedDateTime startDate, @Nullable ZonedDateTime endDate, String aggregation) {
         throw new UnsupportedOperationException();
     }

--- a/ui/src/components/flows/FlowMetrics.vue
+++ b/ui/src/components/flows/FlowMetrics.vue
@@ -11,7 +11,7 @@
                     @update:model-value="updateQuery('task', $event)"
                 >
                     <el-option
-                        v-for="item in tasks"
+                        v-for="item in tasksWithMetrics"
                         :key="item"
                         :label="item"
                         :value="item"
@@ -83,12 +83,11 @@
                 <BarChart ref="chartRef" :chart-data="chartData" :options="options" v-if="aggregatedMetric" />
             </el-tooltip>
             <span v-else>
-            <el-alert type="info" :closable="false">
-                {{ $t("metric choice") }}
-            </el-alert>
-        </span>
+                <el-alert type="info" :closable="false">
+                    {{ $t("metric choice") }}
+                </el-alert>
+            </span>
         </el-card>
-
     </div>
 </template>
 
@@ -118,7 +117,7 @@
             }
         },
         computed: {
-            ...mapState("flow", ["flow", "metrics", "aggregatedMetric"]),
+            ...mapState("flow", ["flow", "metrics", "aggregatedMetric","tasksWithMetrics"]),
             theme() {
                 return localStorage.getItem("theme") || "light";
             },
@@ -192,9 +191,6 @@
                     }
                 })
             },
-            tasks() {
-                return this.flow.tasks.map(e => e.id);
-            },
             display() {
                 return this.$route.query.metric && this.$route.query.aggregation;
             }
@@ -207,6 +203,7 @@
         },
         methods: {
             loadMetrics() {
+                this.$store.dispatch("flow/loadTasksWithMetrics",{...this.$route.params})
                 this.$store
                     .dispatch(this.$route.query.task ? "flow/loadTaskMetrics" : "flow/loadFlowMetrics", {
                         ...this.$route.params,

--- a/ui/src/stores/flow.js
+++ b/ui/src/stores/flow.js
@@ -23,7 +23,8 @@ export default {
         flowError: undefined,
         taskError: undefined,
         metrics: [],
-        aggregatedMetrics: undefined
+        aggregatedMetrics: undefined,
+        tasksWithMetrics: []
     },
 
     actions: {
@@ -240,6 +241,13 @@ export default {
                     return response.data
                 })
         },
+        loadTasksWithMetrics({commit}, options) {
+            return axios.get(`${apiRoot}metrics/tasks/${options.namespace}/${options.id}`)
+                .then(response => {
+                    commit("setTasksWithMetrics", response.data)
+                    return response.data
+                })
+        },
         loadFlowAggregatedMetrics({commit}, options) {
             return axios.get(`${apiRoot}metrics/aggregates/${options.namespace}/${options.id}/${options.metric}`, {params: options})
                 .then(response => {
@@ -335,6 +343,9 @@ export default {
         setAggregatedMetric(state, aggregatedMetric) {
             state.aggregatedMetric = aggregatedMetric
         },
+        setTasksWithMetrics(state, tasksWithMetrics) {
+            state.tasksWithMetrics = tasksWithMetrics
+        }
     },
     getters: {
         flow(state) {

--- a/webserver/src/main/java/io/kestra/webserver/controllers/MetricController.java
+++ b/webserver/src/main/java/io/kestra/webserver/controllers/MetricController.java
@@ -80,6 +80,16 @@ public class MetricController {
     }
 
     @ExecuteOn(TaskExecutors.IO)
+    @Get(uri = "/tasks/{namespace}/{flowId}", produces = MediaType.TEXT_JSON)
+    @Operation(tags = {"Metrics"}, summary = "Get tasks id that have metrics for a specific flow, include deleted or renamed tasks")
+    public List<String> tasks(
+        @Parameter(description = "The namespace") @PathVariable String namespace,
+        @Parameter(description = "The flow Id") @PathVariable String flowId
+    ) {
+        return metricsRepository.tasksWithMetrics(namespace, flowId);
+    }
+
+    @ExecuteOn(TaskExecutors.IO)
     @Get(uri = "/aggregates/{namespace}/{flowId}/{metric}", produces = MediaType.TEXT_JSON)
     @Operation(tags = {"Metrics"}, summary = "Get metrics aggregations for a specific flow")
     public MetricAggregations aggregateByFlowId(


### PR DESCRIPTION
Shame on me for doing it the lazy way. Now we correctly query all tasks that have metrics, including deleted ones.

close #1297
