### PR TITLE
Fix/kill created

### DIFF
--- a/ui/src/utils/state.js
+++ b/ui/src/utils/state.js
@@ -47,7 +47,7 @@ const STATE = Object.freeze({
         colorClass: "yellow",
         icon: CloseCircle,
         isRunning: true,
-        isKillable: false,
+        isKillable: true,
         isFailed: true,
     },
     KILLED: {
@@ -79,7 +79,7 @@ const STATE = Object.freeze({
         colorClass: "indigo",
         icon: PauseCircle,
         isRunning: true,
-        isKillable: false,
+        isKillable: true,
         isFailed: false,
     }
 });


### PR DESCRIPTION
I also enable to kill "killing" and "paused" task from the UI because it's allowed on the backend.
Kiling killing allow to resend a kill if it didn't have effect.
Killing paused didn't seems to have effect but it's a separate issue, at least the command is send to the executor.

close #1306
