### PR TITLE
fix(core): avoid validation exception when the then property is nul

### DIFF
--- a/core/src/main/java/io/kestra/core/tasks/flows/If.java
+++ b/core/src/main/java/io/kestra/core/tasks/flows/If.java
@@ -129,7 +129,7 @@ public class If extends Task implements FlowableTask<VoidOutput> {
     public List<Task> allChildTasks() {
         return Stream
             .concat(
-                this.then.stream(),
+                this.then != null ? this.then.stream() : Stream.empty(),
                 Stream.concat(
                     this._else != null ? this._else.stream() : Stream.empty(),
                     this.errors != null ? this.errors.stream() : Stream.empty())


### PR DESCRIPTION
The validation calls `allChildTasks()` so it must works with a null then for the validation to return errors and not fail with an exception (status code 422 instead of 500).

close #1309
