### PR TITLE
fix(core): correctly display additional properties in documentation

### DIFF
--- a/core/src/main/resources/docs/task.hbs
+++ b/core/src/main/resources/docs/task.hbs
@@ -56,7 +56,7 @@ icon: {{ icon }}
 * **SubType:** {{> type items }}
     {{~/if~}}
     {{~#if additionalProperties }}
-* **SubType:** =={{ additionalProperties.type }}==
+* **SubType:** {{> type additionalProperties }}
     {{~/if~}}
 {{~/inline~}}
 


### PR DESCRIPTION
close [#1255](https://github.com/kestra-io/kestra/issues/1255)

Note that for the example given in the issue additionalProperties is not needed as the JsonSchemaGenerator correctly read generic parameters so it leads to two times the same type (better than a bug in the doc). additionalProperties usage should be carefully reviewed to discover such duplications.

![image](https://github.com/kestra-io/kestra/assets/1819009/81a6b040-6bfa-4fee-9f44-d586e231d894)

