### PR TITLE
Suggestion :  Remove fields validation from DAG generation

### DIFF
--- a/ui/src/components/graph/Topology.vue
+++ b/ui/src/components/graph/Topology.vue
@@ -231,20 +231,18 @@
     };
 
     const regenerateGraph = () => {
-        if(!props.flowError) {
-            removeEdges(getEdges.value)
-            removeNodes(getNodes.value)
-            removeSelectedElements(getElements.value)
-            elements.value = []
-            nextTick(() => {
-                generateGraph();
-            })
-        }
+        removeEdges(getEdges.value)
+        removeNodes(getNodes.value)
+        removeSelectedElements(getElements.value)
+        elements.value = []
+        nextTick(() => {
+            generateGraph();
+        })
     }
 
     const generateGraph = () => {
         isLoading.value = true;
-        if (!props.flowGraph) {
+        if (!props.flowGraph || !flowHaveTasks()) {
             elements.value.push({
                 id: "start",
                 label: "",
@@ -578,10 +576,7 @@
         store.dispatch("core/isUnsaved", true);
         return store.dispatch("flow/validateFlow", {flow: event})
             .then(value => {
-                if (!value[0].constraints) {
-                    // flowYaml need to be update before
-                    // loadGraphFromSource to avoid
-                    // generateGraph to be triggered with the old value
+                if (flowHaveTasks()) {
                     store.dispatch("flow/loadGraphFromSource", {
                         flow: event, config: {
                             validateStatus: (status) => {
@@ -589,6 +584,8 @@
                             }
                         }
                     })
+                } else {
+                    regenerateGraph();
                 }
 
                 return value;

--- a/webserver/src/main/java/io/kestra/webserver/controllers/FlowController.java
+++ b/webserver/src/main/java/io/kestra/webserver/controllers/FlowController.java
@@ -96,8 +96,7 @@ public class FlowController {
     public FlowGraph flowGraphSource(
         @Parameter(description = "The flow") @Body String flow
     ) throws ConstraintViolationException, IllegalVariableEvaluationException {
-        Flow flowParsed = taskDefaultService.injectDefaults(yamlFlowParser.parse(flow, Flow.class));
-        modelValidator.validate(flowParsed);
+        Flow flowParsed = yamlFlowParser.parse(flow, Flow.class);
 
         return FlowGraph.of(flowParsed);
     }


### PR DESCRIPTION
Currently, we validate the flow before generating the graph of the topology. However, this validation doesn't make sense because the graph generation process only requires the task's ID and type, not the task properties.
https://github.com/kestra-io/kestra/blob/dbd7725bea3e154d59e9670b7f281bd6e160a5db/webserver/src/main/java/io/kestra/webserver/controllers/FlowController.java#L100

On the UI side, we have a flow validation that will bring errors to the users [using the /validate endpoints](https://github.com/kestra-io/kestra/blob/dbd7725bea3e154d59e9670b7f281bd6e160a5db/webserver/src/main/java/io/kestra/webserver/controllers/FlowController.java#L443). So validation properties in graph generation does not bring anything to the frontend.
It even reduces user experience because any error on a field will prevent the graph from generating and cause a discrepancy between the source code and the DAG displayed.

Removing this validation on the graph generation endpoint and allowing graph generation when there are issues in the flow would eliminate this discrepancy. 

There would be only one last case when the graph can not generate (except by sending a wrong input, like anything but a flow). It's when the type of task does not exist, but then we could warn the users.
