### PR TITLE
fix(core): remove input FILE validation

### DIFF
--- a/core/src/main/java/io/kestra/core/models/flows/input/FileInput.java
+++ b/core/src/main/java/io/kestra/core/models/flows/input/FileInput.java
@@ -15,20 +15,8 @@ import javax.validation.ConstraintViolationException;
 @Getter
 @NoArgsConstructor
 public class FileInput extends Input<URI> {
-    @Schema(title = "The file extension.")
-    String extension;
-
     @Override
     public void validate(URI input) throws ConstraintViolationException {
-        if (extension != null && !input.getPath().endsWith(extension)) {
-            throw new ConstraintViolationException("Invalid input '" + input + "', it must be a file with the extension '" + extension + "'",
-                Set.of(ManualConstraintViolation.of(
-                    "Invalid input",
-                    this,
-                    FileInput.class,
-                    getName(),
-                    input
-                )));
-        }
+        // no validation yet
     }
 }

--- a/core/src/test/java/io/kestra/core/runners/InputsTest.java
+++ b/core/src/test/java/io/kestra/core/runners/InputsTest.java
@@ -52,7 +52,6 @@ public class InputsTest extends AbstractMemoryRunnerTest {
         .put("validatedDate", "2023-01-02")
         .put("validatedDateTime", "2023-01-01T00:00:10Z")
         .put("validatedDuration", "PT15S")
-        .put("validatedFile", Objects.requireNonNull(InputsTest.class.getClassLoader().getResource("application.yml")).getPath())
         .put("validatedFloat", "0.42")
         .put("validatedTime", "11:27:49")
         .build();
@@ -114,7 +113,6 @@ public class InputsTest extends AbstractMemoryRunnerTest {
         assertThat(typeds.get("validatedDate"), is(LocalDate.parse("2023-01-02")));
         assertThat(typeds.get("validatedDateTime"), is(Instant.parse("2023-01-01T00:00:10Z")));
         assertThat(typeds.get("validatedDuration"), is(Duration.parse("PT15S")));
-        assertThat(typeds.get("validatedFile"), is(new URI("kestra:///io/kestra/tests/inputs/executions/test/inputs/validatedFile/application.yml")));
         assertThat(typeds.get("validatedFloat"), is(0.42F));
         assertThat(typeds.get("validatedTime"), is(LocalTime.parse("11:27:49")));
     }
@@ -222,18 +220,6 @@ public class InputsTest extends AbstractMemoryRunnerTest {
         });
 
         assertThat(e.getMessage(), is("Invalid input 'PT30S', it must be less than 'PT20S'"));
-    }
-
-    @Test
-    void inputValidatedFileBadValue() throws URISyntaxException {
-        HashMap<String, String> map = new HashMap<>(inputs);
-        map.put("validatedFile", Objects.requireNonNull(InputsTest.class.getClassLoader().getResource("docs/index.hbs")).getPath());
-
-        ConstraintViolationException e = assertThrows(ConstraintViolationException.class, () -> {
-            Map<String, Object> typeds = typedInputs(map);
-        });
-
-        assertThat(e.getMessage(), is("Invalid input 'kestra:///io/kestra/tests/inputs/executions/test/inputs/validatedFile/index.hbs', it must be a file with the extension '.yml'"));
     }
 
     @Test

--- a/core/src/test/java/io/kestra/core/serializers/YamlFlowParserTest.java
+++ b/core/src/test/java/io/kestra/core/serializers/YamlFlowParserTest.java
@@ -125,9 +125,9 @@ class YamlFlowParserTest {
     void inputs() {
         Flow flow = this.parse("flows/valids/inputs.yaml");
 
-        assertThat(flow.getInputs().size(), is(25));
+        assertThat(flow.getInputs().size(), is(24));
         assertThat(flow.getInputs().stream().filter(Input::getRequired).count(), is(6L));
-        assertThat(flow.getInputs().stream().filter(r -> !r.getRequired()).count(), is(19L));
+        assertThat(flow.getInputs().stream().filter(r -> !r.getRequired()).count(), is(18L));
         assertThat(flow.getInputs().stream().filter(r -> r.getDefaults() != null).count(), is(1L));
         assertThat(flow.getInputs().stream().filter(r -> r instanceof StringInput && ((StringInput)r).getValidator() != null).count(), is(1L));
     }

--- a/core/src/test/resources/flows/valids/inputs.yaml
+++ b/core/src/test/resources/flows/valids/inputs.yaml
@@ -72,10 +72,6 @@ inputs:
   min: PT10S
   max: PT20S
   required: false
-- name: validatedFile
-  type: FILE
-  extension: .yml
-  required: false
 - name: validatedFloat
   type: FLOAT
   min: 0.1


### PR DESCRIPTION
Due to the way we upload them, it's not possible to validate the FILE input as we didn't have the file name.