### PR TITLE
fix(ui): Remove useless API call

### DIFF
--- a/ui/src/components/inputs/Editor.vue
+++ b/ui/src/components/inputs/Editor.vue
@@ -193,7 +193,6 @@
             }
         },
         created() {
-            this.$store.dispatch("plugin/list");
             this.editorDocumentation = localStorage.getItem("editorDocumentation") !== "false" && this.navbar;
         },
         methods: {


### PR DESCRIPTION
This call was used when task documentation was integrated into the editor component.

close #1349