### PR TITLE
Feat/improve worker

### DIFF
--- a/core/src/main/java/io/kestra/core/endpoints/WorkerEndpoint.java
+++ b/core/src/main/java/io/kestra/core/endpoints/WorkerEndpoint.java
@@ -30,11 +30,11 @@ public class WorkerEndpoint {
                 .sum()
             )
             .runnings(
-                worker.getWorkerThreadReferences()
+                worker.getWorkerThreadTasks()
                     .stream()
-                    .map(workerThread -> new WorkerEndpointWorkerTask(
-                        workerThread.getWorkerTask().getTaskRun(),
-                        workerThread.getWorkerTask().getTask())
+                    .map(workerTask -> new WorkerEndpointWorkerTask(
+                        workerTask.getTaskRun(),
+                        workerTask.getTask())
                     )
                     .collect(Collectors.toList())
             )

--- a/core/src/main/java/io/kestra/core/runners/Worker.java
+++ b/core/src/main/java/io/kestra/core/runners/Worker.java
@@ -134,6 +134,9 @@ public class Worker implements Runnable, Closeable {
                             runContext.cleanup();
                         }
                     }
+                    else {
+                        throw new RuntimeException("Unable to process the task '" + workerTask.getTask().getId() + "' as it's not a runnable task");
+                    }
                 });
             }
         );


### PR DESCRIPTION
@tchiotludo we discuss about using a concurrent list for the `workerThreadReferences` but reading the code carefully as all write access are synchronized and read access are _informative_ this should not be needed so I propose only a subset of the changes we discuss.

If this ends up not being necessary (so if we still encounter Workers that refuse to stops) we may revisit this later.

I also added in a separate commit a "fault tolerance" on worker receiving a task that is not a worker task, there is no test case for it as it's a little complex to reproduce but I tested it manually. Keep in mind this should never occur ;)
