### PR TITLE
Keep the Editor preference persisted

### DIFF
--- a/ui/src/components/graph/Topology.vue
+++ b/ui/src/components/graph/Topology.vue
@@ -111,10 +111,18 @@
 
     const showTopologyStorageKey = "show-topology";
 
-    const initShowTopology = () => {
-        const defaultValue = (props.execution || props.isReadOnly) ? "topology" : "doc";
-        const storedValue = localStorage.getItem(showTopologyStorageKey);
+    const loadShowTopology = () => {
+        return localStorage.getItem(showTopologyStorageKey);
+    }
 
+    const initShowTopology = () => {
+        const defaultValue = "doc";
+
+        if (props.execution || props.isReadOnly) {
+            return "topology";
+        }
+
+        const storedValue = loadShowTopology();
         if (storedValue) {
             return storedValue;
         }
@@ -519,12 +527,31 @@
         resizeObserver.observe(document.getElementById("el-col-vueflow"));
     }
 
+    const showTopologyOnReadOnly = () => {
+        const defaultValue = "combined";
+
+        if (props.isCreating) {
+            return "source";
+        }
+
+        if (props.execution || props.isReadOnly ) {
+            return "topology";
+        }
+
+        const storedValue = loadShowTopology();
+        if (storedValue) {
+            return storedValue;
+        }
+
+        return defaultValue;
+    }
+
     watch(() => props.flowGraph, async () => {
         regenerateGraph()
     });
 
     watch(() => props.isReadOnly, async () => {
-        persistShowTopology(props.isCreating ? "source" : (props.execution || props.isReadOnly ? "topology" : "combined"));
+        showTopology.value = showTopologyOnReadOnly();
     });
 
     watch(() => props.guidedProperties, () => {

--- a/ui/src/components/graph/Topology.vue
+++ b/ui/src/components/graph/Topology.vue
@@ -489,6 +489,7 @@
         });
 
         window.removeEventListener("beforeunload", persistEditorWidth);
+        persistEditorWidth();
 
         // Will get redirected to login page
         if (!store.getters["auth/isLogged"] && haveChange.value) {


### PR DESCRIPTION
* Added a new item representing the chosen Editor visual style to the local storage.
* Enabled persisting the editor width even on regular component removal.

close #1411