### PR TITLE
Filter executions by labels

### DIFF
--- a/ui/src/components/executions/Executions.vue
+++ b/ui/src/components/executions/Executions.vue
@@ -28,7 +28,7 @@
                 </el-form-item>
                 <el-form-item>
                     <label-filter
-                        :value="asArrayProp($route.query.labels)"
+                        :model-value="$route.query.labels"
                         @update:model-value="onDataTableValue('labels', $event)"
                     />
                 </el-form-item>
@@ -89,17 +89,17 @@
 
                     <el-table-column v-if="$route.name !== 'flows/update' && !hidden.includes('namespace')" prop="namespace" sortable="custom" :sort-orders="['ascending', 'descending']" :label="$t('namespace')" :formatter="(_, __, cellValue) => $filters.invisibleSpace(cellValue)" />
 
-                    <el-table-column v-if="!hidden.includes('labels')" :label="$t('labels')">
-                        <template #default="scope">
-                            <labels :labels="scope.row.labels" />
-                        </template>
-                    </el-table-column>
-
                     <el-table-column v-if="$route.name !== 'flows/update' && !hidden.includes('flowId')" prop="flowId" sortable="custom" :sort-orders="['ascending', 'descending']" :label="$t('flow')">
                         <template #default="scope">
                             <router-link :to="{name: 'flows/update', params: {namespace: scope.row.namespace, id: scope.row.flowId}}">
                                 {{ $filters.invisibleSpace(scope.row.flowId) }}
                             </router-link>
+                        </template>
+                    </el-table-column>
+
+                    <el-table-column v-if="!hidden.includes('labels')" :label="$t('labels')">
+                        <template #default="scope">
+                            <labels :labels="scope.row.labels" />
                         </template>
                     </el-table-column>
 
@@ -426,9 +426,6 @@
                     tab: "editor"
                 }})
             },
-            asArrayProp(unknownValue) {
-                return (!Array.isArray(unknownValue) && unknownValue !== undefined) ? [unknownValue] : unknownValue;
-            }
         }
     };
 </script>

--- a/ui/src/components/executions/Executions.vue
+++ b/ui/src/components/executions/Executions.vue
@@ -27,6 +27,12 @@
                     />
                 </el-form-item>
                 <el-form-item>
+                    <label-filter
+                        :value="asArrayProp($route.query.labels)"
+                        @update:model-value="onDataTableValue('labels', $event)"
+                    />
+                </el-form-item>
+                <el-form-item>
                     <refresh-button class="float-right" @refresh="load" />
                 </el-form-item>
             </template>
@@ -173,6 +179,7 @@
     import DataTableActions from "../../mixins/dataTableActions";
     import SearchField from "../layout/SearchField.vue";
     import NamespaceSelect from "../namespace/NamespaceSelect.vue";
+    import LabelFilter from "../labels/LabelFilter.vue";
     import DateRange from "../layout/DateRange.vue";
     import RefreshButton from "../layout/RefreshButton.vue"
     import StatusFilterButtons from "../layout/StatusFilterButtons.vue"
@@ -199,6 +206,7 @@
             DataTable,
             SearchField,
             NamespaceSelect,
+            LabelFilter,
             DateRange,
             RefreshButton,
             StatusFilterButtons,
@@ -418,6 +426,9 @@
                     tab: "editor"
                 }})
             },
+            asArrayProp(unknownValue) {
+                return (!Array.isArray(unknownValue) && unknownValue !== undefined) ? [unknownValue] : unknownValue;
+            }
         }
     };
 </script>

--- a/ui/src/components/flows/Flows.vue
+++ b/ui/src/components/flows/Flows.vue
@@ -17,6 +17,12 @@
                             @update:model-value="onDataTableValue('namespace', $event)"
                         />
                     </el-form-item>
+                    <el-form-item>
+                        <label-filter
+                            :model-value="$route.query.labels"
+                            @update:model-value="onDataTableValue('labels', $event)"
+                        />
+                    </el-form-item>
                 </template>
 
                 <template #top>
@@ -185,6 +191,8 @@
     import Labels from "../layout/Labels.vue"
     import BottomLineCounter from "../layout/BottomLineCounter.vue";
     import Upload from "vue-material-design-icons/Upload.vue";
+    import LabelFilter from "../labels/LabelFilter.vue";
+
     export default {
         mixins: [RouteContext, RestoreUrl, DataTableActions],
         components: {
@@ -200,7 +208,8 @@
             Kicon,
             Labels,
             BottomLineCounter,
-            Upload
+            Upload,
+            LabelFilter
         },
         data() {
             return {

--- a/ui/src/components/labels/LabelFilter.vue
+++ b/ui/src/components/labels/LabelFilter.vue
@@ -1,42 +1,29 @@
 <template>
-    <div>
-        <el-tag
+    <el-select
+        :model-value="labels"
+        @update:model-value="onInput"
+        multiple
+        filterable
+        allow-create
+        clearable
+        collapse-tags
+        default-first-option
+        :persistent="false"
+        :reserve-keyword="false"
+        @focus="hover = true"
+        @blur="hover = false"
+        :placeholder="hover ? $t('label filter placeholder') : $t('labels')"
+    >
+        <el-option
             v-for="label in labels"
             :key="label"
-            closable
-            class="me-1 labels"
-            size="small"
-            disable-transitions
-            @close="handleClose(label)"
-        >
-            {{ label }}
-        </el-tag>
-
-        <el-input
-            v-if="inputVisible"
-            ref="input"
-            v-model="inputValue"
-            :placeholder="$t('label filter placeholder')"
-            @keyup.enter="handleInputConfirm"
-            @blur="handleInputConfirm"
-        >
-            <template #suffix>
-                <tag-outline />
-            </template>
-        </el-input>
-
-        <el-button v-else @click="showInput">
-            <plus /> {{ $t('label') }}
-        </el-button>
-    </div>
-  </template>
+            :label="label"
+            :value="label"
+        />
+    </el-select>
+</template>
 
 <script>
-    import { nextTick } from "vue";
-    import { ElInput } from "element-plus";
-    import TagOutline from "vue-material-design-icons/TagOutline.vue";
-    import Plus from "vue-material-design-icons/Plus.vue";
-
     const isValidLabel = (label) => {
         return label.match(".+:.+") !== null;
     };
@@ -46,13 +33,9 @@
     };
 
     export default {
-        components: {
-            TagOutline,
-            Plus
-        },
         props: {
-            value: {
-                type: Array,
+            modelValue: {
+                type: [Array, String],
                 default: [],
                 validator(value) {
                     return isValidLabels(value);
@@ -60,43 +43,31 @@
             }
         },
         emits: ["update:modelValue"],
+        created() {
+            this.labels = this.asArrayProp(this.modelValue);
+        },
         data() {
             return {
-                inputVisible: false,
-                inputValue: "",
-                labels: this.value.slice()
+                hover: false,
+                inputValue: undefined,
+                labels: [],
             }
         },
         watch: {
-            value: {
+            modelValue: {
                 handler (newValue, _) {
-                    this.labels = newValue.slice();
+                    this.labels = this.asArrayProp(newValue);
                 }
             }
         },
         methods: {
-            handleClose(tag) {
-                this.labels.splice(this.labels.indexOf(tag), 1);
-                this.$emit("update:modelValue", this.labels);
+            asArrayProp(unknownValue) {
+                return (!Array.isArray(unknownValue) && unknownValue !== undefined) ? [unknownValue] : unknownValue;
             },
-            showInput() {
-                this.inputVisible = true;
-                nextTick(() => {
-                    this.$refs.input.focus();
-                })
+            onInput(value) {
+                this.labels = value;
+                this.$emit("update:modelValue", value)
             },
-            handleInputConfirm() {
-                if (this.inputValue) {
-                    if (isValidLabel(this.inputValue)) {
-                        this.labels.push(this.inputValue);
-                        this.$emit("update:modelValue", this.labels);
-                    } else {
-                        return;
-                    }
-                }
-                this.inputVisible = false;
-                this.inputValue = "";
-            }
         }
     };
 </script>

--- a/ui/src/components/labels/LabelFilter.vue
+++ b/ui/src/components/labels/LabelFilter.vue
@@ -67,6 +67,13 @@
                 labels: this.value.slice()
             }
         },
+        watch: {
+            value: {
+                handler (newValue, _) {
+                    this.labels = newValue.slice();
+                }
+            }
+        },
         methods: {
             handleClose(tag) {
                 this.labels.splice(this.labels.indexOf(tag), 1);
@@ -90,6 +97,6 @@
                 this.inputVisible = false;
                 this.inputValue = "";
             }
-      }
+        }
     };
 </script>

--- a/ui/src/components/labels/LabelFilter.vue
+++ b/ui/src/components/labels/LabelFilter.vue
@@ -1,0 +1,95 @@
+<template>
+    <div>
+        <el-tag
+            v-for="label in labels"
+            :key="label"
+            closable
+            class="me-1 labels"
+            size="small"
+            disable-transitions
+            @close="handleClose(label)"
+        >
+            {{ label }}
+        </el-tag>
+
+        <el-input
+            v-if="inputVisible"
+            ref="input"
+            v-model="inputValue"
+            placeholder="Label as 'key:value'"
+            @keyup.enter="handleInputConfirm"
+            @blur="handleInputConfirm"
+        >
+            <template #suffix>
+                <tag-outline />
+            </template>
+        </el-input>
+
+        <el-button v-else @click="showInput">
+            <plus /> Label
+        </el-button>
+    </div>
+  </template>
+
+<script>
+    import { nextTick } from "vue";
+    import { ElInput } from "element-plus";
+    import TagOutline from "vue-material-design-icons/TagOutline.vue";
+    import Plus from "vue-material-design-icons/Plus.vue";
+
+    const isValidLabel = (label) => {
+        return label.match(".+:.+") !== null;
+    };
+
+    const isValidLabels = (labels) => {
+        return labels.every((label) => isValidLabel(label));
+    };
+
+    export default {
+        components: {
+            TagOutline,
+            Plus
+        },
+        props: {
+            value: {
+                type: Array,
+                default: [],
+                validator(value) {
+                    return isValidLabels(value);
+                }
+            }
+        },
+        emits: ["update:modelValue"],
+        data() {
+            return {
+                inputVisible: false,
+                inputValue: "",
+                labels: this.value.slice()
+            }
+        },
+        methods: {
+            handleClose(tag) {
+                this.labels.splice(this.labels.indexOf(tag), 1);
+                this.$emit("update:modelValue", this.labels);
+            },
+            showInput() {
+                this.inputVisible = true;
+                nextTick(() => {
+                    this.$refs.input.focus();
+                })
+            },
+            handleInputConfirm() {
+                if (this.inputValue) {
+                    if (isValidLabel(this.inputValue)) {
+                        this.labels.push(this.inputValue);
+                        this.$emit("update:modelValue", this.labels);
+                    } else {
+                        return;
+                    }
+                }
+                this.inputVisible = false;
+                this.inputValue = "";
+            }
+      }
+    };
+</script>

--- a/ui/src/components/labels/LabelFilter.vue
+++ b/ui/src/components/labels/LabelFilter.vue
@@ -16,7 +16,7 @@
             v-if="inputVisible"
             ref="input"
             v-model="inputValue"
-            placeholder="Label as 'key:value'"
+            :placeholder="$t('label filter placeholder')"
             @keyup.enter="handleInputConfirm"
             @blur="handleInputConfirm"
         >
@@ -26,7 +26,7 @@
         </el-input>
 
         <el-button v-else @click="showInput">
-            <plus /> Label
+            <plus /> {{ $t('label') }}
         </el-button>
     </div>
   </template>

--- a/ui/src/translations.json
+++ b/ui/src/translations.json
@@ -254,7 +254,9 @@
     "tags": "Tags",
     "disabled flow title": "This flow is disabled",
     "disabled flow desc": "This flow is disabled, please enable it in order to execute it.",
+    "label": "Label",
     "labels": "Labels",
+    "label filter placeholder": "Label as 'key:value'",
     "feeds": {
       "title": "What's new at Kestra"
     },
@@ -696,7 +698,9 @@
     "tags": "Tags",
     "disabled flow title": "Ce flow est désactivé",
     "disabled flow desc": "Ce flow est désactivé, veuillez le réactiver pour l'exécuter.",
+    "label": "Label",
     "labels": "Labels",
+    "label filter placeholder": "Label as 'key:value'",
     "feeds": {
       "title": "Quoi de neuf sur Kestra"
     },


### PR DESCRIPTION
The execution listing view can be filtered by multiple execution labels.

This is based on the existing backend functionality built as #1190.

This is more or less just a design proposition - I'm no UI/UX designer so this tag-based attempt most probably doesn't perfectly fit to the overall feel.

close #1308 
