### PR TITLE
Tune Gradle defaults

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -91,7 +91,7 @@ jobs:
           python3 -m pip install virtualenv
           echo $GOOGLE_SERVICE_ACCOUNT | base64 -d > ~/.gcp-service-account.json
           export GOOGLE_APPLICATION_CREDENTIALS=$HOME/.gcp-service-account.json
-          ./gradlew check jacoco --parallel --no-daemon
+          ./gradlew check jacoco --no-daemon
 
       # Codecov
       - uses: codecov/codecov-action@v3
@@ -260,7 +260,7 @@ jobs:
           echo "signing.password=${SONATYPE_GPG_PASSWORD}" >> ~/.gradle/gradle.properties
           echo "signing.secretKeyRingFile=${HOME}/.gradle/secring.gpg" >> ~/.gradle/gradle.properties
           echo ${SONATYPE_GPG_FILE} | base64 -d > ~/.gradle/secring.gpg
-          ./gradlew publishToSonatype --parallel --no-daemon
+          ./gradlew publishToSonatype --no-daemon
 
       # Release
       - name: Release package to Maven Central

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -91,7 +91,7 @@ jobs:
           python3 -m pip install virtualenv
           echo $GOOGLE_SERVICE_ACCOUNT | base64 -d > ~/.gcp-service-account.json
           export GOOGLE_APPLICATION_CREDENTIALS=$HOME/.gcp-service-account.json
-          ./gradlew check jacoco --no-daemon
+          ./gradlew check jacoco --no-daemon --priority=normal
 
       # Codecov
       - uses: codecov/codecov-action@v3
@@ -101,7 +101,7 @@ jobs:
 
       # Shadow Jar
       - name: Build jars
-        run: ./gradlew executableJar --no-daemon
+        run: ./gradlew executableJar --no-daemon --priority=normal
 
       # Upload artifacts
       - name: Upload jar
@@ -260,7 +260,7 @@ jobs:
           echo "signing.password=${SONATYPE_GPG_PASSWORD}" >> ~/.gradle/gradle.properties
           echo "signing.secretKeyRingFile=${HOME}/.gradle/secring.gpg" >> ~/.gradle/gradle.properties
           echo ${SONATYPE_GPG_FILE} | base64 -d > ~/.gradle/secring.gpg
-          ./gradlew publishToSonatype --no-daemon
+          ./gradlew publishToSonatype --no-daemon --priority=normal
 
       # Release
       - name: Release package to Maven Central
@@ -276,7 +276,7 @@ jobs:
           echo "signing.password=${SONATYPE_GPG_PASSWORD}" >> ~/.gradle/gradle.properties
           echo "signing.secretKeyRingFile=${HOME}/.gradle/secring.gpg" >> ~/.gradle/gradle.properties
           echo ${SONATYPE_GPG_FILE} | base64 -d > ~/.gradle/secring.gpg
-          ./gradlew publishToSonatype closeAndReleaseSonatypeStagingRepository --no-daemon
+          ./gradlew publishToSonatype closeAndReleaseSonatypeStagingRepository --no-daemon --priority=normal
 
   pip:
     name: Publish to Pip

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,6 +1,6 @@
 
 tasks:
-  - init: ./gradlew build
+  - init: ./gradlew build --priority=normal
 
 
 vscode:

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,7 @@
 version=0.10.0-SNAPSHOT
 micronautVersion=3.9.0
 lombokVersion=1.18.26
+
+org.gradle.parallel=true
+org.gradle.caching=true
+org.gradle.priority=low


### PR DESCRIPTION
Set Gradle defaults to _common_ ones. Any of them should be safe to use with Gradle 8.

* Subprojects are built in parallel when possible.
* Task outputs can be reused.
* Gradle processes get deprioritized - keeping your machine responsive.