### PR TITLE
Show execution labels

### DIFF
--- a/ui/src/components/executions/Executions.vue
+++ b/ui/src/components/executions/Executions.vue
@@ -83,6 +83,12 @@
 
                     <el-table-column v-if="$route.name !== 'flows/update' && !hidden.includes('namespace')" prop="namespace" sortable="custom" :sort-orders="['ascending', 'descending']" :label="$t('namespace')" :formatter="(_, __, cellValue) => $filters.invisibleSpace(cellValue)" />
 
+                    <el-table-column v-if="!hidden.includes('labels')" :label="$t('labels')">
+                        <template #default="scope">
+                            <labels :labels="scope.row.labels" />
+                        </template>
+                    </el-table-column>
+
                     <el-table-column v-if="$route.name !== 'flows/update' && !hidden.includes('flowId')" prop="flowId" sortable="custom" :sort-orders="['ascending', 'descending']" :label="$t('flow')">
                         <template #default="scope">
                             <router-link :to="{name: 'flows/update', params: {namespace: scope.row.namespace, id: scope.row.flowId}}">
@@ -174,6 +180,7 @@
     import TriggerAvatar from "../../components/flows/TriggerAvatar.vue";
     import DateAgo from "../layout/DateAgo.vue";
     import Kicon from "../Kicon.vue"
+    import Labels from "../layout/Labels.vue"
     import RestoreUrl from "../../mixins/restoreUrl";
     import State from "../../utils/state";
     import Id from "../Id.vue";
@@ -199,6 +206,7 @@
             TriggerAvatar,
             DateAgo,
             Kicon,
+            Labels,
             Id,
             BottomLine,
             BottomLineCounter,

--- a/ui/src/components/executions/Overview.vue
+++ b/ui/src/components/executions/Overview.vue
@@ -29,6 +29,9 @@
                     <span v-else-if="scope.row.duration">
                         <duration :histories="scope.row.value" />
                     </span>
+                    <span v-else-if="scope.row.key === $t('labels')">
+                        <labels :labels="scope.row.value" :filterEnabled="false" />
+                    </span>
                     <span v-else>
                         <span v-if="scope.row.key === $t('revision')">
                             <router-link
@@ -67,6 +70,7 @@
     import DateAgo from "../layout/DateAgo.vue";
     import Crud from "override/components/auth/Crud.vue";
     import Duration from "../layout/Duration.vue";
+    import Labels from "../layout/Labels.vue"
 
     export default {
         components: {
@@ -76,6 +80,7 @@
             Vars,
             Kill,
             DateAgo,
+            Labels,
             Crud
         },
         emits: ["follow"],
@@ -120,6 +125,7 @@
                         key: this.$t("revision"),
                         value: this.execution.flowRevision
                     },
+                    {key: this.$t("labels"), value: this.execution.labels},
                     {key: this.$t("created date"), value: this.execution.state.histories[0].date, date: true},
                     {key: this.$t("updated date"), value: this.stop(), date: true},
                     {key: this.$t("duration"), value: this.execution.state.histories, duration: true},

--- a/ui/src/components/executions/Overview.vue
+++ b/ui/src/components/executions/Overview.vue
@@ -30,7 +30,7 @@
                         <duration :histories="scope.row.value" />
                     </span>
                     <span v-else-if="scope.row.key === $t('labels')">
-                        <labels :labels="scope.row.value" :filterEnabled="false" />
+                        <labels :labels="scope.row.value" :filter-enabled="false" />
                     </span>
                     <span v-else>
                         <span v-if="scope.row.key === $t('revision')">

--- a/ui/src/components/home/HomeSummaryFailed.vue
+++ b/ui/src/components/home/HomeSummaryFailed.vue
@@ -9,7 +9,7 @@
             :restore-url="false"
             :statuses="['FAILED', 'KILLED', 'WARNING']"
             :embed="true"
-            :hidden="['id', 'state.endDate', 'triggers', 'selection']"
+            :hidden="['id', 'state.endDate', 'triggers', 'selection', 'labels']"
         />
     </el-card>
 </template>

--- a/ui/src/components/layout/Labels.vue
+++ b/ui/src/components/layout/Labels.vue
@@ -1,15 +1,18 @@
 <template>
     <span v-if="labels">
+        <!-- 'el-check-tag' would be a better fit but it currently lacks customization -->
         <el-tag
             v-for="(value, key) in labels"
             :key="key"
+            :type="checked(key) ? 'primary' : ''"
             class="me-1 labels"
             size="small"
             disable-transitions
         >
-            <router-link :to="link(key, value)">
+            <router-link v-if="filterEnabled" :to="link(key, value)">
                 {{ key }}: {{ value }}
             </router-link>
+            <template v-else>{{ key }}: {{ value }}</template>
         </el-tag>
     </span>
 </template>
@@ -21,9 +24,13 @@
                 type: Object,
                 default: () => {}
             },
+            filterEnabled: {
+                type: Boolean,
+                default: true
+            }
         },
         methods: {
-            link(key, value) {
+            getLabelsFromQuery() {
                 const labels = new Map();
                 (this.$route.query.labels !== undefined ?
                     (typeof(this.$route.query.labels) === "string" ? [this.$route.query.labels] : this.$route.query.labels)  :
@@ -32,18 +39,31 @@
                     .forEach(label => {
                         const split = label.split(":");
 
-                        labels[split[0]] = split[1];
+                        labels.set(split[0], split[1]);
                     })
-                labels[key] = value;
+
+                return labels;
+            },
+            checked(key) {
+                return this.getLabelsFromQuery().has(key);
+            },
+            link(key, value) {
+                const labels = this.getLabelsFromQuery();
+
+                if (labels.has(key)) {
+                    labels.delete(key);
+                } else {
+                    labels.set(key, value);
+                }
 
                 const qs = {
                     ...this.$route.query,
-                    ...{"labels": Object.entries(labels).map((label) => label[0] + ":" + label[1])}
+                    ...{"labels": Array.from(labels.keys()).map((key) => key + ":" + labels.get(key))}
                 };
 
                 delete qs.page;
 
-                return {name: this.$route.name, query: qs}
+                return {name: this.$route.name, params: this.$route.params, query: qs};
             }
         }
     };
@@ -51,8 +71,8 @@
 
 <style lang="scss" scoped>
     :deep(.el-tag) {
-        & a {
-            color: var(--bs-white);;
+        & a, span {
+            color: var(--bs-white);
         }
     }
 </style>

--- a/ui/src/components/layout/Labels.vue
+++ b/ui/src/components/layout/Labels.vue
@@ -4,7 +4,7 @@
         <el-tag
             v-for="(value, key) in labels"
             :key="key"
-            :type="checked(key) ? 'primary' : ''"
+            :type="checked(key) ? 'info' : ''"
             class="me-1 labels"
             size="small"
             disable-transitions
@@ -73,6 +73,10 @@
     :deep(.el-tag) {
         & a, span {
             color: var(--bs-white);
+        }
+
+        &.el-tag--info {
+            background: var(--bs-primary);
         }
     }
 </style>


### PR DESCRIPTION
* Execution labels are presented at both execution list and overview.
* Filtering 'by the label' works for both flow and execution list.
* An active 'by the label' filter can be deactivated by clicking at the label again.
* Labels being a part of the active filter are highlighted.

Related to #1527