### PR TITLE
feat: add flow labels to execution labels

### DIFF
--- a/core/src/main/java/io/kestra/core/models/triggers/types/Flow.java
+++ b/core/src/main/java/io/kestra/core/models/triggers/types/Flow.java
@@ -85,6 +85,7 @@ public class Flow extends AbstractTrigger implements TriggerOutput<Flow.Output> 
             .namespace(flow.getNamespace())
             .flowId(flow.getId())
             .flowRevision(flow.getRevision())
+            .labels(flow.getLabels())
             .state(new State())
             .trigger(ExecutionTrigger.of(
                 this,

--- a/core/src/main/java/io/kestra/core/models/triggers/types/Schedule.java
+++ b/core/src/main/java/io/kestra/core/models/triggers/types/Schedule.java
@@ -273,6 +273,7 @@ public class Schedule extends AbstractTrigger implements PollingTriggerInterface
             .namespace(context.getNamespace())
             .flowId(context.getFlowId())
             .flowRevision(context.getFlowRevision())
+            .labels(conditionContext.getFlow().getLabels())
             .state(new State())
             .trigger(executionTrigger)
             // keep to avoid breaking compatibility

--- a/core/src/main/java/io/kestra/core/runners/RunnerUtils.java
+++ b/core/src/main/java/io/kestra/core/runners/RunnerUtils.java
@@ -391,8 +391,15 @@ public class RunnerUtils {
             execution = execution.withInputs(inputs.apply(flow, execution));
         }
 
+        Map<String, String> executionLabels = new HashMap<>();
+        if (flow.getLabels() != null) {
+            executionLabels.putAll(flow.getLabels());
+        }
         if (labels != null) {
-            execution = execution.withLabels(labels);
+            executionLabels.putAll(labels);
+        }
+        if (!executionLabels.isEmpty()) {
+            execution = execution.withLabels(executionLabels);
         }
 
         return execution;

--- a/core/src/main/java/io/kestra/core/runners/Worker.java
+++ b/core/src/main/java/io/kestra/core/runners/Worker.java
@@ -205,6 +205,16 @@ public class Worker implements Runnable, Closeable {
                                     );
                                 }
 
+                                var flowLabels = workerTrigger.getConditionContext().getFlow().getLabels();
+                                if (flowLabels != null) {
+                                    evaluate = evaluate.map( execution -> {
+                                            Map<String, String> executionLabels = execution.getLabels() != null ? execution.getLabels() : new HashMap<>();
+                                            executionLabels.putAll(flowLabels);
+                                            return execution.withLabels(executionLabels);
+                                        }
+                                    );
+                                }
+
                                 workerTrigger.getConditionContext().getRunContext().cleanup();
 
                                 this.workerTriggerResultQueue.emit(

--- a/core/src/test/java/io/kestra/core/models/triggers/types/ScheduleTest.java
+++ b/core/src/test/java/io/kestra/core/models/triggers/types/ScheduleTest.java
@@ -91,6 +91,8 @@ class ScheduleTest {
         assertThat(dateFromVars(vars.get("date"), date), is(date));
         assertThat(dateFromVars(vars.get("next"), date), is(date.plusMonths(1)));
         assertThat(dateFromVars(vars.get("previous"), date), is(date.minusMonths(1)));
+        assertThat(evaluate.get().getLabels().get("flow-label-1"), is("flow-label-1"));
+        assertThat(evaluate.get().getLabels().get("flow-label-2"), is("flow-label-2"));
     }
 
     @SuppressWarnings("unchecked")
@@ -393,6 +395,11 @@ class ScheduleTest {
         Flow flow = Flow.builder()
             .id(IdUtils.create())
             .namespace("io.kestra.tests")
+            .labels(
+                Map.of(
+                    "flow-label-1", "flow-label-1",
+                    "flow-label-2", "flow-label-2")
+            )
             .build();
 
         TriggerContext triggerContext = TriggerContext.builder()

--- a/core/src/test/java/io/kestra/core/schedulers/AbstractSchedulerTest.java
+++ b/core/src/test/java/io/kestra/core/schedulers/AbstractSchedulerTest.java
@@ -17,15 +17,14 @@ import io.kestra.core.models.triggers.PollingTriggerInterface;
 import io.kestra.core.models.triggers.TriggerContext;
 import io.kestra.core.queues.QueueFactoryInterface;
 import io.kestra.core.queues.QueueInterface;
-import io.kestra.core.runners.RunContext;
 import io.kestra.core.tasks.debugs.Return;
 import io.kestra.core.utils.IdUtils;
 
 import java.time.Duration;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
-import java.util.concurrent.atomic.AtomicInteger;
 import jakarta.inject.Inject;
 import jakarta.inject.Named;
 
@@ -61,6 +60,11 @@ abstract public class AbstractSchedulerTest {
                     .build()
             ))
             .revision(1)
+            .labels(
+                Map.of(
+                    "flow-label-1", "flow-label-1",
+                    "flow-label-2", "flow-label-2")
+            )
             .triggers(triggers)
             .tasks(Collections.singletonList(Return.builder()
                 .id("test")

--- a/core/src/test/java/io/kestra/core/schedulers/SchedulerThreadTest.java
+++ b/core/src/test/java/io/kestra/core/schedulers/SchedulerThreadTest.java
@@ -94,6 +94,8 @@ public class SchedulerThreadTest extends AbstractSchedulerTest {
 
             assertThat(last.get().getVariables().get("defaultInjected"), is("done"));
             assertThat(last.get().getVariables().get("counter"), is(3));
+            assertThat(last.get().getLabels().get("flow-label-1"), is("flow-label-1"));
+            assertThat(last.get().getLabels().get("flow-label-2"), is("flow-label-2"));
             AbstractSchedulerTest.COUNTER = 0;
         }
     }

--- a/core/src/test/resources/flows/valids/inputs.yaml
+++ b/core/src/test/resources/flows/valids/inputs.yaml
@@ -1,5 +1,8 @@
 id: inputs
 namespace: io.kestra.tests
+labels:
+  flow-label-1: flow-label-1
+  flow-label-2: flow-label-2
 
 inputs:
 - name: string

--- a/core/src/test/resources/flows/valids/webhook.yaml
+++ b/core/src/test/resources/flows/valids/webhook.yaml
@@ -1,5 +1,8 @@
 id: webhook
 namespace: io.kestra.tests
+labels:
+  flow-label-1: flow-label-1
+  flow-label-2: flow-label-2
 
 tasks:
   - id: out

--- a/webserver/src/test/java/io/kestra/webserver/controllers/ExecutionControllerTest.java
+++ b/webserver/src/test/java/io/kestra/webserver/controllers/ExecutionControllerTest.java
@@ -125,6 +125,8 @@ class ExecutionControllerTest extends AbstractMemoryRunnerTest {
         assertThat(result.getInputs().get("file").toString(), startsWith("kestra:///io/kestra/tests/inputs/executions/"));
         assertThat(result.getLabels().get("a"), is("label-1"));
         assertThat(result.getLabels().get("b"), is("label-2"));
+        assertThat(result.getLabels().get("flow-label-1"), is("flow-label-1"));
+        assertThat(result.getLabels().get("flow-label-2"), is("flow-label-2"));
     }
 
     @Test
@@ -456,6 +458,8 @@ class ExecutionControllerTest extends AbstractMemoryRunnerTest {
         assertThat(((Map<String, Object>) execution.getTrigger().getVariables().get("body")).get("b"), is(true));
         assertThat(((Map<String, Object>) execution.getTrigger().getVariables().get("parameters")).get("name"), is(List.of("john")));
         assertThat(((Map<String, List<Integer>>) execution.getTrigger().getVariables().get("parameters")).get("age"), containsInAnyOrder("12", "13"));
+        assertThat(execution.getLabels().get("flow-label-1"), is("flow-label-1"));
+        assertThat(execution.getLabels().get("flow-label-2"), is("flow-label-2"));
 
         execution = client.toBlocking().retrieve(
             HttpRequest


### PR DESCRIPTION
close [#1325](https://github.com/kestra-io/kestra/issues/1325)

Only polling triggers will not push flow labels to execution labels, as they are totally refactored in the poll trigger on worker PR this must be evaluated later if it can be done for all polling triggers. I'll create an issue for that.