### PR TITLE
feat(core): set parallel tasks parallelism default to 2*nbProc

### DIFF
--- a/core/src/main/java/io/kestra/core/tasks/flows/Dag.java
+++ b/core/src/main/java/io/kestra/core/tasks/flows/Dag.java
@@ -42,10 +42,12 @@ public class Dag extends Task implements FlowableTask<VoidOutput> {
     @Builder.Default
     @Schema(
         title = "Number of concurrent parallel tasks",
-        description = "If the value is `0`, no limit exist and all the tasks will start at the same time"
+        defaultValue = "nbProcessor * 2",
+        description = "Default to two times the available number of processors.\n" +
+            "If the value is `0`, no limit exist and all the tasks will start at the same time"
     )
     @PluginProperty
-    private final Integer concurrent = 0;
+    private final Integer concurrent = Runtime.getRuntime().availableProcessors() * 2;
 
     @NotEmpty
     private List<DagTask> tasks;

--- a/core/src/main/java/io/kestra/core/tasks/flows/EachParallel.java
+++ b/core/src/main/java/io/kestra/core/tasks/flows/EachParallel.java
@@ -93,10 +93,12 @@ public class EachParallel extends Parallel implements FlowableTask<VoidOutput> {
     @Builder.Default
     @Schema(
         title = "Number of concurrent parallel tasks",
-        description = "If the value is `0`, no limit exist and all the tasks will start at the same time"
+        defaultValue = "nbProcessor * 2",
+        description = "Default to two times the available number of processors.\n" +
+            "If the value is `0`, no limit exist and all the tasks will start at the same time"
     )
     @PluginProperty
-    private final Integer concurrent = 0;
+    private final Integer concurrent = Runtime.getRuntime().availableProcessors() * 2;
 
     @NotNull
     @NotBlank

--- a/core/src/main/java/io/kestra/core/tasks/flows/Parallel.java
+++ b/core/src/main/java/io/kestra/core/tasks/flows/Parallel.java
@@ -68,10 +68,12 @@ public class Parallel extends Task implements FlowableTask<VoidOutput> {
     @Builder.Default
     @Schema(
         title = "Number of concurrent parallel tasks",
-        description = "If the value is `0`, no limit exist and all the tasks will start at the same time"
+        defaultValue = "nbProcessor * 2",
+        description = "Default to two times the available number of processors.\n" +
+            "If the value is `0`, no limit exist and all the tasks will start at the same time"
     )
     @PluginProperty
-    private final Integer concurrent = 0;
+    private final Integer concurrent = Runtime.getRuntime().availableProcessors() * 2;
 
     @Valid
     @PluginProperty


### PR DESCRIPTION
2*nbProc is a better defaults as unbounded concurrency is never a good idea.

I tested it with a flow with 200 parallel tasks and it performs better 25% to 30% with this setting than with unbounded parallelism.

Moreover, worker threads are limited so even unbounded parallelism is not really unbounded as they will be handled by the worker threads.
