### PR TITLE
fix(ui): slightly increase timeout before next step when saving guided tour flow

### DIFF
--- a/ui/src/components/onboarding/VueTour.vue
+++ b/ui/src/components/onboarding/VueTour.vue
@@ -277,7 +277,7 @@
                             this.dispatchEvent(this.$tours["guidedTour"].currentStep._value, "created")
                             setTimeout(() => {
                                 resolve(true);
-                            }, 300);
+                            }, 500);
                         }),
                     },
                     {
@@ -294,7 +294,7 @@
                             localStorage.setItem("tourDoneOrSkip", "true");
                             setTimeout(() => {
                                 resolve(true);
-                            }, 300);
+                            }, 500);
                         }),
                     }
                 ],


### PR DESCRIPTION
So the next step doesnt appear before the flow is saved and get out of scope.

close #1464
