### PR TITLE
fix(ui): better label input

### DIFF
--- a/core/src/test/java/io/kestra/core/schedulers/SchedulerConditionTest.java
+++ b/core/src/test/java/io/kestra/core/schedulers/SchedulerConditionTest.java
@@ -51,7 +51,7 @@ class SchedulerConditionTest extends AbstractSchedulerTest {
         return createFlow(Collections.singletonList(schedule));
     }
 
-    @RetryingTest(5)
+    @RetryingTest(10)
     void schedule() throws Exception {
         // mock flow listeners
         FlowListeners flowListenersServiceSpy = spy(this.flowListenersService);

--- a/ui/src/components/labels/LabelInput.vue
+++ b/ui/src/components/labels/LabelInput.vue
@@ -1,0 +1,68 @@
+<template>
+    <div class="d-flex w-100 mb-2" v-for="(label, index) in locals" :key="index">
+        <div class="flex-grow-1 d-flex align-items-center">
+            <el-input
+                class="form-control me-2"
+                :placeholder="$t('key')"
+                v-model="label.key"
+                @update:model-value="update(index, $event, 'key')"
+            />
+            <el-input
+                class="form-control me-2"
+                :placeholder="$t('value')"
+                v-model="label.value"
+                @update:model-value="update(index, $event, 'value')"
+            />
+        </div>
+        <div class="flex-shrink-1">
+            <el-button-group class="d-flex">
+                <el-button :icon="Plus" @click="addItem" />
+                <el-button :icon="Minus" @click="removeItem(index)" :disabled="index === 0 && locals.length === 1" />
+            </el-button-group>
+        </div>
+    </div>
+</template>
+
+<script setup>
+    import Plus from "vue-material-design-icons/Plus.vue";
+    import Minus from "vue-material-design-icons/Minus.vue";
+</script>
+
+
+<script>
+    export default {
+        props: {
+            labels: {
+                type: Array,
+                required: true
+            }
+        },
+        data() {
+            return {
+                locals: []
+            }
+        },
+        emits: ["update:labels"],
+        created() {
+            if (this.labels.length === 0) {
+                this.addItem();
+            } else {
+                this.locals = this.labels
+            }
+        },
+        methods: {
+            addItem() {
+                this.locals.push({key: null, value: null});
+                this.$emit("update:labels", this.locals);
+            },
+            removeItem(index) {
+                this.locals.splice(index, 1);
+                this.$emit("update:labels", this.locals);
+            },
+            update(index, value, prop) {
+                this.locals[index][prop] = value;
+                this.$emit("update:labels", this.locals);
+            },
+        },
+    }
+</script>

--- a/ui/src/translations.json
+++ b/ui/src/translations.json
@@ -262,6 +262,7 @@
     "labels": "Labels",
     "label filter placeholder": "Label as 'key:value'",
     "execution labels": "Execution labels",
+    "wrong labels": "Empty key or value is not allowed in labels",
     "feeds": {
       "title": "What's new at Kestra"
     },
@@ -719,8 +720,9 @@
     "disabled flow desc": "Ce flow est désactivé, veuillez le réactiver pour l'exécuter.",
     "label": "Label",
     "labels": "Labels",
-    "label filter placeholder": "Label as 'key:value'",
+    "label filter placeholder": "Label au format 'clé:valeur'",
     "execution labels": "Labels d'exécution",
+    "wrong labels": "Clé ou valeur vide détecté dans les labels",
     "feeds": {
       "title": "Quoi de neuf sur Kestra"
     },


### PR DESCRIPTION
New label input when starting a new execution :
![image](https://github.com/kestra-io/kestra/assets/37600690/f71cca09-015e-49fa-aeb7-1853958af08f)

That is more close to the label edition in a flow :
![image](https://github.com/kestra-io/kestra/assets/37600690/02bf94e9-1484-40a7-86a3-21feb066b005)

Which also cover bad values : 
![image](https://github.com/kestra-io/kestra/assets/37600690/30b14b3c-d6de-4ce4-a66a-ce803ec928bb)

When both key & value are empty, we just ignore them : 
![image](https://github.com/kestra-io/kestra/assets/37600690/20efd939-fe03-446f-ae40-139c4bdfcd53)


close #1630
