### PR TITLE
fix(core): remove misleading default value for polling triggers

### DIFF
--- a/core/src/main/java/io/kestra/core/models/triggers/PollingTriggerInterface.java
+++ b/core/src/main/java/io/kestra/core/models/triggers/PollingTriggerInterface.java
@@ -21,8 +21,7 @@ public interface PollingTriggerInterface {
         description = "The interval between 2 different test of schedule, this can avoid to overload the remote system " +
             "with too many call. For most of trigger that depend on external system, a minimal interval must be " +
             "at least PT30S.\n" +
-            "See [ISO_8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations) for more information of available interval value",
-        defaultValue = "PT1S"
+            "See [ISO_8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations) for more information of available interval value"
     )
     @PluginProperty
     Duration getInterval();


### PR DESCRIPTION
This is not the real default that is on the implementation. Unfortunately, the documentation display this default value instead of the real one.
