### PR TITLE
fix(core): avoid infinite loop in the executor for Flowable tasks

### DIFF
--- a/core/src/main/java/io/kestra/core/runners/ExecutorService.java
+++ b/core/src/main/java/io/kestra/core/runners/ExecutorService.java
@@ -221,23 +221,27 @@ public class ExecutorService {
 
         if (parent instanceof FlowableTask<?> flowableParent) {
 
-            List<NextTaskRun> nexts = flowableParent.resolveNexts(
-                runContextFactory.of(
-                    executor.getFlow(),
-                    parent,
+            try {
+                List<NextTaskRun> nexts = flowableParent.resolveNexts(
+                    runContextFactory.of(
+                        executor.getFlow(),
+                        parent,
+                        executor.getExecution(),
+                        parentTaskRun
+                    ),
                     executor.getExecution(),
                     parentTaskRun
-                ),
-                executor.getExecution(),
-                parentTaskRun
-            );
-
-            if (nexts.size() > 0) {
-                return this.saveFlowableOutput(
-                    nexts,
-                    executor,
-                    parentTaskRun
                 );
+
+                if (nexts.size() > 0) {
+                    return this.saveFlowableOutput(
+                        nexts,
+                        executor,
+                        parentTaskRun
+                    );
+                }
+            } catch (Exception e) {
+                log.warn("Unable to resolve the next tasks to run", e);
             }
         }
 

--- a/core/src/test/java/io/kestra/core/tasks/flows/BadFlowableTest.java
+++ b/core/src/test/java/io/kestra/core/tasks/flows/BadFlowableTest.java
@@ -19,4 +19,12 @@ public class BadFlowableTest extends AbstractMemoryRunnerTest {
         assertThat(execution.getTaskRunList(), hasSize(2));
         assertThat(execution.getState().getCurrent(), is(State.Type.FAILED));
     }
+
+    @Test // this test is a non-reg for an infinite loop in the executor
+    void flowableWithParentFail() throws TimeoutException {
+        Execution execution = runnerUtils.runOne("io.kestra.tests", "flowable-with-parent-fail");
+
+        assertThat(execution.getTaskRunList(), hasSize(5));
+        assertThat(execution.getState().getCurrent(), is(State.Type.FAILED));
+    }
 }

--- a/core/src/test/java/io/kestra/core/tasks/flows/TemplateTest.java
+++ b/core/src/test/java/io/kestra/core/tasks/flows/TemplateTest.java
@@ -85,7 +85,7 @@ public class TemplateTest extends AbstractMemoryRunnerTest {
 
         assertThat(execution.getTaskRunList(), hasSize(1));
         assertThat(execution.getState().getCurrent(), is(State.Type.FAILED));
-        LogEntry matchingLog = TestsUtils.awaitLog(logs, logEntry -> logEntry.getMessage().equals("Can't find flow template 'io.kestra.tests.invalid'") && logEntry.getLevel() == Level.ERROR);
+        LogEntry matchingLog = TestsUtils.awaitLog(logs, logEntry -> logEntry.getMessage().endsWith("Can't find flow template 'io.kestra.tests.invalid'") && logEntry.getLevel() == Level.ERROR);
         assertThat(matchingLog, notNullValue());
     }
 

--- a/core/src/test/resources/flows/valids/flowable-with-parent-fail.yaml
+++ b/core/src/test/resources/flows/valids/flowable-with-parent-fail.yaml
@@ -1,0 +1,23 @@
+id: flowable-with-parent-fail
+namespace: io.kestra.tests
+
+tasks:
+  - id: vision
+    type: io.kestra.core.tasks.flows.EachParallel
+    tasks:
+      - id: metaseg_date
+        type: io.kestra.core.tasks.flows.EachParallel
+        tasks:
+          - id: if
+            type: io.kestra.core.tasks.flows.If
+            condition: "{{parents[0].taskrun.value == 'CUMULATIVE' and {% for entry in json(taskrun.value) %}{{ entry.key }}{% endfor %}== 'NEW_MONTH'}}"
+            then:
+              - id: when-true
+                type: io.kestra.core.tasks.log.Log
+                message: 'Condition was true'
+            else:
+              - id: when-false
+                type: io.kestra.core.tasks.log.Log
+                message: 'Condition was false'
+        value: "[{\"NEW_MONTH\":\"2018-01-01\"}]"
+    value: "[\"MONTHLY\", \"CUMULATIVE\"]"


### PR DESCRIPTION
Fixes #1745

In the executor, when a flowable task throw an exception when calling `resolveNexts()` this will fail the current evaluation of the executor that will be retried indefinitly. Catching exception and returing an empty next will avoid the infinite loop and the task will fail properly.
