### PR TITLE
fix(webserver): mark the execution as killing to avoid ghost execution

### DIFF
--- a/core/src/main/java/io/kestra/core/runners/ExecutorService.java
+++ b/core/src/main/java/io/kestra/core/runners/ExecutorService.java
@@ -4,6 +4,7 @@ import com.google.common.collect.ImmutableMap;
 import io.kestra.core.exceptions.InternalException;
 import io.kestra.core.metrics.MetricRegistry;
 import io.kestra.core.models.executions.Execution;
+import io.kestra.core.models.executions.ExecutionKilled;
 import io.kestra.core.models.executions.NextTaskRun;
 import io.kestra.core.models.executions.TaskRun;
 import io.kestra.core.models.executions.TaskRunAttempt;
@@ -14,11 +15,14 @@ import io.kestra.core.models.tasks.FlowableTask;
 import io.kestra.core.models.tasks.Output;
 import io.kestra.core.models.tasks.ResolvedTask;
 import io.kestra.core.models.tasks.Task;
+import io.kestra.core.queues.QueueFactoryInterface;
+import io.kestra.core.queues.QueueInterface;
 import io.kestra.core.services.ConditionService;
 import io.kestra.core.tasks.flows.Pause;
 import io.kestra.core.tasks.flows.WorkingDirectory;
 import io.micronaut.context.ApplicationContext;
 import jakarta.inject.Inject;
+import jakarta.inject.Named;
 import jakarta.inject.Singleton;
 import lombok.extern.slf4j.Slf4j;
 import org.slf4j.Logger;
@@ -47,6 +51,10 @@ public class ExecutorService {
 
     @Inject
     protected ConditionService conditionService;
+
+    @Inject
+    @Named(QueueFactoryInterface.KILL_NAMED)
+    protected QueueInterface<ExecutionKilled> killQueue;
 
     protected FlowExecutorInterface flowExecutorInterface;
 
@@ -463,7 +471,7 @@ public class ExecutorService {
         return executor.withWorkerTaskDelays(list, "handlePausedDelay");
     }
 
-    private Executor handleCreatedKilling(Executor executor) throws InternalException {
+    private Executor handleCreatedKilling(Executor executor) {
         if (executor.getExecution().getTaskRunList() == null || executor.getExecution().getState().getCurrent() != State.Type.KILLING) {
             return executor;
         }
@@ -473,8 +481,6 @@ public class ExecutorService {
             .stream()
             .filter(taskRun -> taskRun.getState().getCurrent().isCreated())
             .map(throwFunction(t -> {
-                Task task = executor.getFlow().findTaskByTaskId(t.getTaskId());
-
                 return childWorkerTaskTypeToWorkerTask(
                     Optional.of(State.Type.KILLED),
                     t
@@ -559,7 +565,12 @@ public class ExecutorService {
         );
 
         if (executor.getExecution().hasRunning(currentTasks) || executor.getExecution().hasCreated()) {
-            return executor;
+            // if some tasks are not killed, send a killing event to the worker
+            killQueue.emit(ExecutionKilled
+                .builder()
+                .executionId(executor.getExecution().getId())
+                .build()
+            );
         }
 
         Execution newExecution = executor.getExecution().withState(State.Type.KILLED);

--- a/core/src/test/resources/flows/valids/sleep.yml
+++ b/core/src/test/resources/flows/valids/sleep.yml
@@ -1,0 +1,7 @@
+id: sleep
+namespace: io.kestra.tests
+
+tasks:
+  - id: sleep
+    type: io.kestra.core.tasks.test.Sleep
+    duration: 1000

--- a/webserver/src/main/java/io/kestra/webserver/controllers/ExecutionController.java
+++ b/webserver/src/main/java/io/kestra/webserver/controllers/ExecutionController.java
@@ -114,10 +114,6 @@ public class ExecutionController {
     protected QueueInterface<Execution> executionQueue;
 
     @Inject
-    @Named(QueueFactoryInterface.KILL_NAMED)
-    protected QueueInterface<ExecutionKilled> killQueue;
-
-    @Inject
     private ApplicationEventPublisher<CrudEvent<Execution>> eventPublisher;
 
     @Inject
@@ -810,11 +806,7 @@ public class ExecutionController {
             return HttpResponse.noContent();
         }
 
-        killQueue.emit(ExecutionKilled
-            .builder()
-            .executionId(executionId)
-            .build()
-        );
+        executionQueue.emit(execution.withState(State.Type.KILLING));
 
         return HttpResponse.noContent();
     }
@@ -895,11 +887,7 @@ public class ExecutionController {
                     log.warn("Unable to kill the paused execution {}, ignoring it", execution.getId(), e);
                 }
             } else {
-                killQueue.emit(ExecutionKilled
-                    .builder()
-                    .executionId(execution.getId())
-                    .build()
-                );
+                executionQueue.emit(execution.withState(State.Type.KILLING));
             }
         });
 

--- a/webserver/src/test/java/io/kestra/webserver/controllers/ExecutionControllerTest.java
+++ b/webserver/src/test/java/io/kestra/webserver/controllers/ExecutionControllerTest.java
@@ -3,6 +3,7 @@ package io.kestra.webserver.controllers;
 import com.google.common.collect.ImmutableMap;
 import io.kestra.core.models.Label;
 import io.kestra.core.models.executions.Execution;
+import io.kestra.core.models.executions.ExecutionKilled;
 import io.kestra.core.models.flows.Flow;
 import io.kestra.core.models.flows.State;
 import io.kestra.core.models.storage.FileMetas;
@@ -38,13 +39,17 @@ import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 import java.io.File;
 import java.time.Duration;
 import java.util.*;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.IntStream;
 
 import static io.kestra.core.utils.Rethrow.throwRunnable;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class ExecutionControllerTest extends JdbcH2ControllerTest {
     @Inject
@@ -53,6 +58,10 @@ class ExecutionControllerTest extends JdbcH2ControllerTest {
     @Inject
     @Named(QueueFactoryInterface.EXECUTION_NAMED)
     protected QueueInterface<Execution> executionQueue;
+
+    @Inject
+    @Named(QueueFactoryInterface.KILL_NAMED)
+    protected QueueInterface<ExecutionKilled> killQueue;
 
     @Inject
     FlowRepositoryInterface flowRepositoryInterface;
@@ -660,5 +669,52 @@ class ExecutionControllerTest extends JdbcH2ControllerTest {
 
         assertThat(executions.getTotal(), is(0L));
 
+    }
+
+    @Test
+    void kill() throws TimeoutException, InterruptedException {
+        // Run execution until it is paused
+        Execution runningExecution = runnerUtils.runOneUntilRunning(null, TESTS_FLOW_NS, "sleep");
+        assertThat(runningExecution.getState().isRunning(), is(true));
+
+        // listen to the execution queue
+        CountDownLatch killingLatch = new CountDownLatch(1);
+        CountDownLatch killedLatch = new CountDownLatch(1);
+        executionQueue.receive(e -> {
+            if (e.getLeft().getId().equals(runningExecution.getId()) && e.getLeft().getState().getCurrent() == State.Type.KILLING) {
+                killingLatch.countDown();
+            }
+            if (e.getLeft().getId().equals(runningExecution.getId()) && e.getLeft().getState().getCurrent() == State.Type.KILLED) {
+                killedLatch.countDown();
+            }
+        });
+
+        // listen to the executionkilled queue
+        CountDownLatch executionKilledLatch = new CountDownLatch(1);
+        killQueue.receive(e -> {
+            if (e.getLeft().getExecutionId().equals(runningExecution.getId())) {
+                executionKilledLatch.countDown();
+            }
+        });
+
+        // kill the execution
+        HttpResponse<?> killResponse = client.toBlocking().exchange(
+            HttpRequest.DELETE("/api/v1/executions/" + runningExecution.getId() + "/kill"));
+        assertThat(killResponse.getStatus(), is(HttpStatus.NO_CONTENT));
+
+        // check that the execution has been set to killing then killed
+        assertTrue(killingLatch.await(10, TimeUnit.SECONDS));
+        assertTrue(killedLatch.await(10, TimeUnit.SECONDS));
+        //check that an executionkilled message has been sent
+        assertTrue(executionKilledLatch.await(10, TimeUnit.SECONDS));
+
+        // retrieve the execution from the API and check that the task has been set to killed
+        Thread.sleep(250);
+        Execution execution = client.toBlocking().retrieve(
+            HttpRequest.GET("/api/v1/executions/" + runningExecution.getId()),
+            Execution.class);
+        assertThat(execution.getState().getCurrent(), is(State.Type.KILLED));
+        assertThat(execution.getTaskRunList().size(), is(1));
+        assertThat(execution.getTaskRunList().get(0).getState().getCurrent(), is(State.Type.KILLED));
     }
 }


### PR DESCRIPTION
Fixes #309 

I tried this when working on #1746, and it allows to kill the infinite loop the executor enters while without this, there is no way to kill an execution when the issue is in a flowable.

I open the PR in draft to open a discussion about it.
