### PR TITLE
fix(core): serialization inclusion is a single property not a list

### DIFF
--- a/core/src/main/java/io/kestra/core/serializers/JacksonMapper.java
+++ b/core/src/main/java/io/kestra/core/serializers/JacksonMapper.java
@@ -101,7 +101,6 @@ abstract public class JacksonMapper {
             new IonObjectMapper(new IonFactory())
         )
         .registerModule(new IonModule())
-        .setSerializationInclusion(JsonInclude.Include.USE_DEFAULTS)
         .setSerializationInclusion(JsonInclude.Include.ALWAYS);
 
     public static ObjectMapper ofIon() {
@@ -117,7 +116,6 @@ abstract public class JacksonMapper {
 
         return mapper
             .configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false)
-            .setSerializationInclusion(JsonInclude.Include.NON_NULL)
             .setSerializationInclusion(JsonInclude.Include.NON_EMPTY)
             .registerModule(new JavaTimeModule())
             .registerModule(new Jdk8Module())


### PR DESCRIPTION
So setting it two times will override the previous one.
