### PR TITLE
Make the Dark theme's `.text-muted` visible

### DIFF
--- a/ui/src/styles/layout/root-dark.scss
+++ b/ui/src/styles/layout/root-dark.scss
@@ -24,6 +24,7 @@ html.dark {
     #{--bs-border-color}: $border-color;
     #{--bs-link-color}: $secondary;
     #{--bs-link-color-rgb}: to-rgb($secondary);
+    #{--bs-secondary-color}: var(--bs-gray-700);
     --bs-link-hover-color: #D0CDF9;
     #{--card-bg}: $card-bg;
     #{--input-bg}: $input-bg;


### PR DESCRIPTION
For instance, input description was unreadable.

Feel free to tune the color according to UX rules.