### PR TITLE
chore: delete all instead of truncate in tests

### DIFF
--- a/jdbc/src/test/java/io/kestra/jdbc/JdbcTestUtils.java
+++ b/jdbc/src/test/java/io/kestra/jdbc/JdbcTestUtils.java
@@ -41,7 +41,11 @@ public class JdbcTestUtils {
                     configuration.dialect() == SQLDialect.POSTGRES
                 ))
                 .filter(table -> !table.getName().equals("flyway_schema_history"))
-                .forEach(t -> dslContext.truncate(t.getName()).execute());
+                .forEach(t -> {
+                    try (var delete = dslContext.delete(t)) {
+                        delete.execute();
+                    }
+                });
         });
     }
 


### PR DESCRIPTION
This is 4.5x quicker for MySQL and 2x for Postgres
