### PR TITLE
Render flow input description

### DIFF
--- a/ui/src/components/flows/FlowRun.vue
+++ b/ui/src/components/flows/FlowRun.vue
@@ -77,7 +77,7 @@
                     v-model="inputs[input.name]"
                 />
 
-                <small v-if="input.description" class="text-muted">{{ input.description }}</small>
+                <markdown v-if="input.description" class="markdown-tooltip text-muted" :source="input.description" font-size-var="font-size-xs" />
             </el-form-item>
             <el-form-item
                 :label="$t('execution labels')"
@@ -119,6 +119,7 @@
     import {executeTask} from "../../utils/submitTask"
     import Editor from "../../components/inputs/Editor.vue";
     import LabelInput from "../../components/labels/LabelInput.vue";
+    import Markdown from "../layout/Markdown.vue";
     import {pageFromRoute} from "../../utils/eventsRouter";
 
     export default {

--- a/ui/src/components/layout/Markdown.vue
+++ b/ui/src/components/layout/Markdown.vue
@@ -24,6 +24,10 @@
                 type: Boolean,
                 default: false,
             },
+            fontSizeVar: {
+                type: String,
+                default: "font-size-sm"
+            }
         },
         emits: ["rendered"],
         computed: {
@@ -41,6 +45,9 @@
 
                 return outHtml;
             },
+            fontSizeCss() {
+                return `var(--${this.fontSizeVar})`;
+            }
         },
     };
 </script>
@@ -71,7 +78,7 @@
         }
 
 
-        font-size: var(--font-size-sm);
+        font-size: v-bind(fontSizeCss);
 
         a.header-anchor {
             color: var(--bs-gray-600);


### PR DESCRIPTION
The input `description` field is [meant to hold Markdown](https://kestra.io/docs/developer-guide/inputs#input-properties).
