### PR TITLE
Sort Metrics by name by default

### DIFF
--- a/ui/src/components/executions/MetricsTable.vue
+++ b/ui/src/components/executions/MetricsTable.vue
@@ -128,6 +128,8 @@
 
                 if (this.internalSort) {
                     params.sort = this.internalSort;
+                } else {
+                    params.sort = "name:asc";
                 }
 
                 this.$store.dispatch("execution/loadMetrics", {


### PR DESCRIPTION
Execution metrics were not ordered at all by default.