### PR TITLE
fix/better-jwt-expiration-detection

### DIFF
--- a/ui/src/override/components/flows/blueprints/BlueprintsBrowser.vue
+++ b/ui/src/override/components/flows/blueprints/BlueprintsBrowser.vue
@@ -17,7 +17,7 @@
                         {{ $t("all tags") }}
                     </el-radio-button>
                     <el-radio-button
-                        v-for="tag in Object.values(tags)"
+                        v-for="tag in Object.values(tags || {})"
                         :key="tag.id"
                         :label="tag.id"
                         class="hoverable"

--- a/ui/src/utils/axios.js
+++ b/ui/src/utils/axios.js
@@ -108,11 +108,11 @@ export default (callback, store, router) => {
 
             // Authentication expired
             if (errorResponse.response.status === 401 &&
-                store.getters["auth/isLogged"]) {
+                store.getters["auth/isLogged"] &&
+                !document.cookie.split("; ").map(cookie => cookie.split("=")[0]).includes("JWT")) {
                 document.body.classList.add("login")
 
                 store.dispatch("core/isUnsaved", false);
-                store.commit("auth/setUser", undefined);
                 store.commit("layout/setTopNavbar", undefined);
                 router.push({
                     name: "login",
@@ -133,11 +133,6 @@ export default (callback, store, router) => {
                     content: errorResponse.response.data,
                     variant: "error"
                 })
-
-                if(errorResponse.response.status === 401 &&
-                    store.getters["auth/isLogged"]){
-                    store.commit("auth/setExpired", true);
-                }
 
                 return Promise.reject(errorResponse);
             }


### PR DESCRIPTION
Had to add a default empty object for Blueprint tags because on token expiration you could have a failing call resulting in the unability to navigate through app anymore