### PR TITLE
feat(jdbc): add an index on the execution labels

### DIFF
--- a/jdbc-postgres/src/main/resources/migrations/postgres/V19__index_execution-labels.sql
+++ b/jdbc-postgres/src/main/resources/migrations/postgres/V19__index_execution-labels.sql
@@ -1,0 +1,1 @@
+create index executions_labels ON executions USING GIN((value -> 'labels'));


### PR DESCRIPTION
This can only be done on Postgres:
- H2 didn't support index on JSON array
- MySQL only support index on JSON array of scalar values not JSON array of objects

close #1307

WARNING: if #1845 is merged before the migration must be renamed