### PR TITLE
feat: improve logs indexes

### DIFF
--- a/jdbc-h2/src/main/resources/migrations/h2/V18_index_logs.sql
+++ b/jdbc-h2/src/main/resources/migrations/h2/V18_index_logs.sql
@@ -1,0 +1,3 @@
+DROP INDEX logs_namespace;
+DROP INDEX logs_timestamp;
+CREATE INDEX logs_namespace_flow ON logs (deleted, timestamp, level, namespace, flow_id);

--- a/jdbc-mysql/src/main/resources/migrations/mysql/V16_index_logs.sql
+++ b/jdbc-mysql/src/main/resources/migrations/mysql/V16_index_logs.sql
@@ -1,0 +1,3 @@
+DROP INDEX ix_namespace ON logs;
+DROP INDEX ix_timestamp ON logs;
+CREATE INDEX ix_namespace_flow ON logs (deleted, timestamp, level, namespace, flow_id);

--- a/jdbc-postgres/src/main/resources/migrations/postgres/V21_index_logs.sql
+++ b/jdbc-postgres/src/main/resources/migrations/postgres/V21_index_logs.sql
@@ -1,0 +1,3 @@
+DROP INDEX logs_namespace;
+DROP INDEX logs_timestamp;
+CREATE INDEX logs_namespace_flow ON logs (deleted, timestamp, level, namespace, flow_id);


### PR DESCRIPTION
Without this new index, the index on timestamp is always used. 
Fixes #1810 


