### PR TITLE
Fix/invalid flow

### DIFF
--- a/core/src/main/java/io/kestra/core/runners/Executor.java
+++ b/core/src/main/java/io/kestra/core/runners/Executor.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.kestra.core.models.executions.Execution;
 import io.kestra.core.models.executions.TaskRun;
 import io.kestra.core.models.flows.Flow;
+import io.kestra.core.models.flows.FlowWithException;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -37,7 +38,7 @@ public class Executor {
     }
 
     public Boolean canBeProcessed() {
-        return !(this.getException() != null || this.getFlow() == null || this.getExecution().isDeleted());
+        return !(this.getException() != null || this.getFlow() == null || this.getFlow() instanceof FlowWithException || this.getExecution().isDeleted());
     }
 
     public Executor withFlow(Flow flow) {

--- a/core/src/main/java/io/kestra/core/tasks/flows/Flow.java
+++ b/core/src/main/java/io/kestra/core/tasks/flows/Flow.java
@@ -8,6 +8,7 @@ import io.kestra.core.models.annotations.PluginProperty;
 import io.kestra.core.models.executions.Execution;
 import io.kestra.core.models.executions.ExecutionTrigger;
 import io.kestra.core.models.executions.TaskRun;
+import io.kestra.core.models.flows.FlowWithException;
 import io.kestra.core.models.flows.State;
 import io.kestra.core.models.tasks.RunnableTask;
 import io.kestra.core.models.tasks.Task;
@@ -141,6 +142,10 @@ public class Flow extends Task implements RunnableTask<Flow.Output> {
 
         if (flow.isDisabled()) {
             throw new IllegalStateException("Cannot execute disabled flow");
+        }
+
+        if (flow instanceof FlowWithException fwe) {
+            throw new IllegalStateException("Cannot execute an invalid flow: " + fwe.getException());
         }
 
         return runnerUtils

--- a/core/src/test/java/io/kestra/core/schedulers/SchedulerInvalidFlowTest.java
+++ b/core/src/test/java/io/kestra/core/schedulers/SchedulerInvalidFlowTest.java
@@ -1,0 +1,94 @@
+package io.kestra.core.schedulers;
+
+import io.kestra.core.models.flows.Flow;
+import io.kestra.core.models.flows.FlowWithException;
+import io.kestra.core.models.tasks.Task;
+import io.kestra.core.models.triggers.types.Schedule;
+import io.kestra.core.runners.FlowListeners;
+import io.kestra.core.runners.TestMethodScopedWorker;
+import io.kestra.core.runners.Worker;
+import io.kestra.core.utils.IdUtils;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.List;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.empty;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.spy;
+
+public class SchedulerInvalidFlowTest extends AbstractSchedulerTest {
+    @Inject
+    protected FlowListeners flowListenersService;
+
+    @Inject
+    protected SchedulerTriggerStateInterface triggerState;
+
+    protected AbstractScheduler scheduler(FlowListeners flowListenersServiceSpy) {
+        return new DefaultScheduler(
+            applicationContext,
+            flowListenersServiceSpy,
+            triggerState
+        );
+    }
+
+    @Test
+    void invalidFlow() throws Exception {
+        // mock flow listeners
+        FlowListeners flowListenersServiceSpy = spy(this.flowListenersService);
+
+        Flow flow = createScheduleFlow();
+
+        doReturn(Collections.singletonList(flow))
+            .when(flowListenersServiceSpy)
+            .flows();
+
+        // scheduler
+        try (AbstractScheduler scheduler = scheduler(flowListenersServiceSpy);
+             Worker worker = new TestMethodScopedWorker(applicationContext, 8, null)) {
+            // check that no executions are triggered
+            executionQueue.receive(execution -> {
+                fail();
+            });
+
+            worker.run();
+            scheduler.run();
+
+            // wait for the scheduler to start
+            Thread.sleep(100);
+
+            // invalid flow must be filtered from the schedulable list
+            assertThat(scheduler.getSchedulable(), empty());
+        }
+    }
+
+    private static Flow createScheduleFlow() {
+        Schedule schedule = Schedule.builder()
+            .id("hourly")
+            .type(Schedule.class.getName())
+            .cron("0 * * * *")
+            .build();
+
+        return FlowWithException.builder()
+            .id(IdUtils.create())
+            .namespace("io.kestra.unittest")
+            .revision(1)
+            .exception("Invalid type io.kestra.test.task.NotExisting")
+            .triggers(List.of(schedule))
+            .tasks(List.of(new Task() {
+                @Override
+                public String getId() {
+                    return "id";
+                }
+
+                @Override
+                public String getType() {
+                    return "io.kestra.test.task.NotExisting";
+                }
+            }))
+            .build();
+    }
+}

--- a/ui/src/components/inputs/EditorView.vue
+++ b/ui/src/components/inputs/EditorView.vue
@@ -162,7 +162,9 @@
     const initYamlSource = async () => {
         flowYaml.value = props.flow.source;
 
-        await generateGraph();
+        if (flowHaveTasks() && ["topology", "source-topology"].includes(viewType.value)) {
+          await generateGraph();
+        }
 
         if (!props.isReadOnly) {
             let restoredLocalStorageKey;

--- a/ui/src/components/inputs/EditorView.vue
+++ b/ui/src/components/inputs/EditorView.vue
@@ -179,6 +179,12 @@
                 localStorage.removeItem(restoredLocalStorageKey);
             }
         }
+
+        // validate flow on first load
+        store.dispatch("flow/validateFlow", {flow: flowYaml.value})
+            .then(value => {
+              return value;
+            });
     }
 
     const persistEditorWidth = () => {

--- a/webserver/src/main/java/io/kestra/webserver/controllers/ExecutionController.java
+++ b/webserver/src/main/java/io/kestra/webserver/controllers/ExecutionController.java
@@ -9,6 +9,7 @@ import io.kestra.core.models.executions.Execution;
 import io.kestra.core.models.executions.ExecutionKilled;
 import io.kestra.core.models.executions.TaskRun;
 import io.kestra.core.models.flows.Flow;
+import io.kestra.core.models.flows.FlowWithException;
 import io.kestra.core.models.flows.State;
 import io.kestra.core.models.hierarchies.FlowGraph;
 import io.kestra.core.models.storage.FileMetas;
@@ -410,6 +411,10 @@ public class ExecutionController {
             throw new IllegalStateException("Cannot execute disabled flow");
         }
 
+        if (flow instanceof FlowWithException fwe) {
+            throw new IllegalStateException("Cannot execute an invalid flow: " + fwe.getException());
+        }
+
         Optional<Webhook> webhook = (flow.getTriggers() == null ? new ArrayList<AbstractTrigger>() : flow
             .getTriggers())
             .stream()
@@ -465,12 +470,17 @@ public class ExecutionController {
             return null;
         }
 
-        if (find.get().isDisabled()) {
+        Flow found = find.get();
+        if (found.isDisabled()) {
             throw new IllegalStateException("Cannot execute disabled flow");
         }
 
+        if (found instanceof FlowWithException fwe) {
+            throw new IllegalStateException("Cannot execute an invalid flow: " + fwe.getException());
+        }
+
         Execution current = runnerUtils.newExecution(
-            find.get(),
+            found,
             (flow, execution) -> runnerUtils.typedInputs(flow, execution, inputs, files),
             parseLabels(labels)
         );


### PR DESCRIPTION
This PR will:
- Validate the flow when loading it from the editor so it will be correctly be flaged as in error state (yaml and low-code)
- Only generate the graph when needed (small optimization)
- Generates an exception when triggering an execution from the API, from a webhook, or from a Flow task.

close #1866

Works still to be done for the topology tab but as topology is under a wide rewrite it should be done after the rewrite to avoid too much merge issue. https://github.com/kestra-io/kestra/issues/1423 is till open to track this.
