### PR TITLE
fix: BOOLEAN input should use BooleanInput and not StringInput

### DIFF
--- a/core/src/main/java/io/kestra/core/models/flows/Input.java
+++ b/core/src/main/java/io/kestra/core/models/flows/Input.java
@@ -60,7 +60,7 @@ public abstract class Input<T> {
         STRING(StringInput.class.getName()),
         INT(IntInput.class.getName()),
         FLOAT(FloatInput.class.getName()),
-        BOOLEAN(StringInput.class.getName()),
+        BOOLEAN(BooleanInput.class.getName()),
         DATETIME(DateTimeInput.class.getName()),
         DATE(DateInput.class.getName()),
         TIME(TimeInput.class.getName()),


### PR DESCRIPTION
This has no strong consequences but allow to set validation for a string input in a boolean input
