### PR TITLE
fix(cli): avoid calling the taskdefault service when reindexing flow

### DIFF
--- a/cli/src/main/java/io/kestra/cli/commands/sys/ReindexCommand.java
+++ b/cli/src/main/java/io/kestra/cli/commands/sys/ReindexCommand.java
@@ -36,10 +36,9 @@ public class ReindexCommand extends AbstractCommand {
 
         if ("flow".equals(type)) {
             FlowRepositoryInterface flowRepository = applicationContext.getBean(FlowRepositoryInterface.class);
-            TaskDefaultService taskDefaultService = applicationContext.getBean(TaskDefaultService.class);
 
             List<FlowWithSource> flows = flowRepository.findWithSource(null, null, null);
-            flows.forEach(flow -> flowRepository.update(flow.toFlow(), flow.toFlow(), flow.getSource(), taskDefaultService.injectDefaults(flow.toFlow())));
+            flows.forEach(flow -> flowRepository.update(flow.toFlow(), flow.toFlow(), flow.getSource(), flow.toFlow()));
 
             stdOut("Successfully reindex " + flows.size() + " flow(s).");
         }


### PR DESCRIPTION
It generates an exception on EE as it has dependencies not available in the CLI.
