### PR TITLE
Finish as SUCCESS when no retry attempt

### DIFF
--- a/core/src/main/java/io/kestra/core/runners/Worker.java
+++ b/core/src/main/java/io/kestra/core/runners/Worker.java
@@ -355,7 +355,7 @@ public class Worker implements Runnable, AutoCloseable {
 
         if (workerTask.getTask().getRetry() != null &&
             workerTask.getTask().getRetry().getWarningOnRetry() &&
-            finalWorkerTask.getTaskRun().getAttempts().size() > 0 &&
+            finalWorkerTask.getTaskRun().attemptNumber() > 1 &&
             state == State.Type.SUCCESS
         ) {
             state = State.Type.WARNING;

--- a/core/src/test/java/io/kestra/core/runners/RetryTest.java
+++ b/core/src/test/java/io/kestra/core/runners/RetryTest.java
@@ -30,6 +30,15 @@ public class RetryTest extends AbstractMemoryRunnerTest {
     }
 
     @Test
+    void retrySuccessAtFirstAttempt() throws TimeoutException {
+        Execution execution = runnerUtils.runOne("io.kestra.tests", "retry-success-first-attempt");
+
+        assertThat(execution.getState().getCurrent(), is(State.Type.SUCCESS));
+        assertThat(execution.getTaskRunList(), hasSize(1));
+        assertThat(execution.getTaskRunList().get(0).getAttempts(), hasSize(1));
+    }
+
+    @Test
     void retryFailed() throws TimeoutException {
         List<Execution> executions = new ArrayList<>();
         executionQueue.receive(executions::add);

--- a/core/src/test/resources/flows/valids/retry-success-first-attempt.yaml
+++ b/core/src/test/resources/flows/valids/retry-success-first-attempt.yaml
@@ -1,0 +1,18 @@
+id: retry-success-first-attempt
+namespace: io.kestra.tests
+
+tasks:
+- id: not-retry-and-no-warning
+  type: io.kestra.core.tasks.log.Log
+  message: "foo"
+  retry:
+    type: constant
+    interval: PT0.250S
+    maxAttempt: 5
+    maxDuration: PT15S
+    warningOnRetry: true
+
+errors:
+  - id: never-happen
+    type: io.kestra.core.tasks.log.Log
+    message: Never {{task.id}}


### PR DESCRIPTION
An attempt to set the `WARNING` state only when there was an actual retry attempt.

close #1929
