### PR TITLE
Fix/invalid flow from the UI

### DIFF
--- a/core/src/main/java/io/kestra/core/models/flows/FlowWithException.java
+++ b/core/src/main/java/io/kestra/core/models/flows/FlowWithException.java
@@ -4,7 +4,7 @@ import io.micronaut.core.annotation.Introspected;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
 
-@SuperBuilder
+@SuperBuilder(toBuilder = true)
 @Getter
 @AllArgsConstructor
 @NoArgsConstructor

--- a/jdbc/src/main/java/io/kestra/jdbc/repository/AbstractJdbcFlowRepository.java
+++ b/jdbc/src/main/java/io/kestra/jdbc/repository/AbstractJdbcFlowRepository.java
@@ -65,7 +65,6 @@ public abstract class AbstractJdbcFlowRepository extends AbstractJdbcRepository 
                         .id(jsonNode.get("id").asText())
                         .namespace(jsonNode.get("namespace").asText())
                         .revision(jsonNode.get("revision").asInt())
-                        .source(JacksonMapper.ofJson().writeValueAsString(JacksonMapper.toMap(source)))
                         .exception(e.getMessage())
                         .tasks(List.of())
                         .build();
@@ -142,10 +141,12 @@ public abstract class AbstractJdbcFlowRepository extends AbstractJdbcRepository 
                     return Optional.empty();
                 }
 
-                 return Optional.of(FlowWithSource.of(
-                    jdbcRepository.map(fetched),
-                    fetched.get("source_code", String.class)
-                ));
+                Flow flow = jdbcRepository.map(fetched);
+                String source = fetched.get("source_code", String.class);
+                if (flow instanceof FlowWithException fwe) {
+                    return Optional.of(fwe.toBuilder().source(source).build());
+                }
+                return Optional.of(FlowWithSource.of(flow, source));
             });
     }
 

--- a/ui/src/components/inputs/EditorView.vue
+++ b/ui/src/components/inputs/EditorView.vue
@@ -161,7 +161,9 @@
     const initYamlSource = async () => {
         flowYaml.value = props.flow.source;
 
-        await generateGraph();
+        if (flowHaveTasks() && [editorViewTypes.TOPOLOGY, editorViewTypes.SOURCE_TOPOLOGY].includes(viewType.value)) {
+          await generateGraph();
+        }
 
         if (!props.isReadOnly) {
             let restoredLocalStorageKey;

--- a/ui/src/components/inputs/EditorView.vue
+++ b/ui/src/components/inputs/EditorView.vue
@@ -180,6 +180,12 @@
                 localStorage.removeItem(restoredLocalStorageKey);
             }
         }
+
+        // validate flow on first load
+        store.dispatch("flow/validateFlow", {flow: flowYaml.value})
+            .then(value => {
+              return value;
+            });
     }
 
     const persistEditorWidth = () => {

--- a/ui/src/stores/flow.js
+++ b/ui/src/stores/flow.js
@@ -69,11 +69,9 @@ export default {
                             variant: "danger"
                         }, {root: true});
                         delete response.data.exception;
-                        commit("setFlow", JSON.parse(response.data.source));
-                    } else {
-                        commit("setFlow", response.data);
                     }
 
+                    commit("setFlow", response.data);
                     commit("setOverallTotal", 1)
                     return response.data;
                 })


### PR DESCRIPTION
Properly handle invalid flows from the UI, part of https://github.com/kestra-io/kestra/issues/1866 based on top of #1944, both PR can be review together or separately.

Some code was not compatible with FlowWithSource anymore.

@tchiotludo I keep validation on the flow editor as, even with the current code now correctly displaying an exception when loading the flow, without it when opening the editor the flow is validated (green mark) so I think it's better to validate the flow after loading it.
