### PR TITLE
feat: make the queue fault tolerant

### DIFF
--- a/core/src/main/java/io/kestra/core/exceptions/DeserializationException.java
+++ b/core/src/main/java/io/kestra/core/exceptions/DeserializationException.java
@@ -1,15 +1,22 @@
 package io.kestra.core.exceptions;
 
-import com.fasterxml.jackson.databind.exc.InvalidTypeIdException;
+import java.io.IOException;
 
 public class DeserializationException extends RuntimeException {
     private static final long serialVersionUID = 1L;
 
-    public DeserializationException(InvalidTypeIdException cause) {
-        super(cause);
+    private String record;
+
+    public String getRecord() {
+        return record;
     }
 
-    public DeserializationException(Throwable cause) {
+    public DeserializationException(IOException cause, String record) {
         super(cause);
+        this.record = record;
+    }
+
+    public DeserializationException(String message) {
+        super(message);
     }
 }

--- a/core/src/main/java/io/kestra/core/queues/QueueInterface.java
+++ b/core/src/main/java/io/kestra/core/queues/QueueInterface.java
@@ -1,5 +1,8 @@
 package io.kestra.core.queues;
 
+import io.kestra.core.exceptions.DeserializationException;
+import io.kestra.core.utils.Either;
+
 import java.io.Closeable;
 import java.util.function.Consumer;
 
@@ -22,17 +25,17 @@ public interface QueueInterface<T> extends Closeable {
 
     void delete(String consumerGroup, T message) throws QueueException;
 
-    default Runnable receive(Consumer<T> consumer) {
+    default Runnable receive(Consumer<Either<T, DeserializationException>> consumer) {
         return receive((String) null, consumer);
     }
 
-    Runnable receive(String consumerGroup, Consumer<T> consumer);
+    Runnable receive(String consumerGroup, Consumer<Either<T, DeserializationException>> consumer);
 
-    default Runnable receive(Class<?> queueType, Consumer<T> consumer) {
+    default Runnable receive(Class<?> queueType, Consumer<Either<T, DeserializationException>> consumer) {
         return receive(null, queueType, consumer);
     }
 
-    Runnable receive(String consumerGroup, Class<?> queueType, Consumer<T> consumer);
+    Runnable receive(String consumerGroup, Class<?> queueType, Consumer<Either<T, DeserializationException>> consumer);
 
     void pause();
 }

--- a/core/src/main/java/io/kestra/core/queues/WorkerJobQueueInterface.java
+++ b/core/src/main/java/io/kestra/core/queues/WorkerJobQueueInterface.java
@@ -1,12 +1,14 @@
 package io.kestra.core.queues;
 
+import io.kestra.core.exceptions.DeserializationException;
 import io.kestra.core.runners.WorkerJob;
+import io.kestra.core.utils.Either;
 
 import java.io.Closeable;
 import java.util.function.Consumer;
 
 public interface WorkerJobQueueInterface extends Closeable {
-    Runnable receive(String consumerGroup, Class<?> queueType, Consumer<WorkerJob> consumer);
+    Runnable receive(String consumerGroup, Class<?> queueType, Consumer<Either<WorkerJob, DeserializationException>> consumer);
 
     void pause();
 }

--- a/core/src/main/java/io/kestra/core/runners/FlowListeners.java
+++ b/core/src/main/java/io/kestra/core/runners/FlowListeners.java
@@ -54,7 +54,13 @@ public class FlowListeners implements FlowListenersInterface {
             if (!this.isStarted) {
                 this.isStarted = true;
 
-                this.flowQueue.receive(flow -> {
+                this.flowQueue.receive(either -> {
+                    if (either.isRight()) {
+                        log.error("Unable to deserialize a flow: {}", either.getRight().getMessage());
+                        return;
+                    }
+
+                    Flow flow = either.getLeft();
                     Optional<Flow> previous = this.previous(flow);
 
                     if (flow.isDeleted()) {

--- a/core/src/main/java/io/kestra/core/runners/RunnerUtils.java
+++ b/core/src/main/java/io/kestra/core/runners/RunnerUtils.java
@@ -342,8 +342,8 @@ public class RunnerUtils {
         AtomicReference<Execution> receive = new AtomicReference<>();
 
         Runnable cancel = this.executionQueue.receive(current -> {
-            if (predicate.test(current)) {
-                receive.set(current);
+            if (predicate.test(current.getLeft())) {
+                receive.set(current.getLeft());
             }
         });
 

--- a/core/src/main/java/io/kestra/core/schedulers/AbstractScheduler.java
+++ b/core/src/main/java/io/kestra/core/schedulers/AbstractScheduler.java
@@ -153,7 +153,13 @@ public abstract class AbstractScheduler implements Scheduler {
         // listen to WorkerTriggerResult from polling triggers
         this.workerTriggerResultQueue.receive(
             Scheduler.class,
-            workerTriggerResult -> {
+            either -> {
+                if (either.isRight()) {
+                    log.error("Unable to deserialize a worker trigger result: {}", either.getRight().getMessage());
+                    return;
+                }
+
+                WorkerTriggerResult workerTriggerResult = either.getLeft();
                 if (workerTriggerResult.getSuccess() && workerTriggerResult.getExecution().isPresent()) {
                     var triggerExecution = new SchedulerExecutionWithTrigger(
                         workerTriggerResult.getExecution().get(),

--- a/core/src/main/java/io/kestra/core/tasks/flows/Template.java
+++ b/core/src/main/java/io/kestra/core/tasks/flows/Template.java
@@ -191,7 +191,7 @@ public class Template extends Task implements FlowableTask<Template.Output> {
 
     protected io.kestra.core.models.templates.Template findTemplate(ApplicationContext applicationContext) throws IllegalVariableEvaluationException {
         if (!applicationContext.containsBean(TemplateExecutorInterface.class)) {
-            throw new DeserializationException(new Exception("Templates are disabled, please check your configuration"));
+            throw new DeserializationException("Templates are disabled, please check your configuration");
         }
 
         TemplateExecutorInterface templateExecutor = applicationContext.getBean(TemplateExecutorInterface.class);

--- a/core/src/test/java/io/kestra/core/runners/FlowTriggerCaseTest.java
+++ b/core/src/test/java/io/kestra/core/runners/FlowTriggerCaseTest.java
@@ -35,7 +35,8 @@ public class FlowTriggerCaseTest {
         AtomicReference<Execution> flowListener = new AtomicReference<>();
         AtomicReference<Execution> flowListenerNoInput = new AtomicReference<>();
 
-        executionQueue.receive(execution -> {
+        executionQueue.receive(either -> {
+            Execution execution = either.getLeft();
             if (execution.getState().getCurrent() == State.Type.SUCCESS) {
                 if (flowListenerNoInput.get() == null && execution.getFlowId().equals("trigger-flow-listener-no-inputs")) {
                     flowListenerNoInput.set(execution);

--- a/core/src/test/java/io/kestra/core/runners/MultipleConditionTriggerCaseTest.java
+++ b/core/src/test/java/io/kestra/core/runners/MultipleConditionTriggerCaseTest.java
@@ -41,7 +41,8 @@ public class MultipleConditionTriggerCaseTest {
         ConcurrentHashMap<String, Execution> ended = new ConcurrentHashMap<>();
         Flow flow = flowRepository.findById("io.kestra.tests", "trigger-multiplecondition-listener").orElseThrow();
 
-        executionQueue.receive(execution -> {
+        executionQueue.receive(either -> {
+            Execution execution = either.getLeft();
             synchronized (ended) {
                 if (execution.getState().getCurrent() == State.Type.SUCCESS) {
                     if (!ended.containsKey(execution.getId())) {
@@ -89,8 +90,9 @@ public class MultipleConditionTriggerCaseTest {
         CountDownLatch countDownLatch = new CountDownLatch(3);
         ConcurrentHashMap<String, Execution> ended = new ConcurrentHashMap<>();
 
-        executionQueue.receive(execution -> {
+        executionQueue.receive(either -> {
             synchronized (ended) {
+                Execution execution = either.getLeft();
                 if (execution.getState().getCurrent().isTerminated()) {
                     if (!ended.containsKey(execution.getId())) {
                         ended.put(execution.getId(), execution);

--- a/core/src/test/java/io/kestra/core/runners/RetryTest.java
+++ b/core/src/test/java/io/kestra/core/runners/RetryTest.java
@@ -40,9 +40,6 @@ public class RetryTest extends AbstractMemoryRunnerTest {
 
     @Test
     void retryFailed() throws TimeoutException {
-        List<Execution> executions = new ArrayList<>();
-        executionQueue.receive(executions::add);
-
         Execution execution = runnerUtils.runOne("io.kestra.tests", "retry-failed");
 
         assertThat(execution.getTaskRunList(), hasSize(2));

--- a/core/src/test/java/io/kestra/core/runners/RunContextTest.java
+++ b/core/src/test/java/io/kestra/core/runners/RunContextTest.java
@@ -54,7 +54,7 @@ class RunContextTest extends AbstractMemoryRunnerTest {
     void logs() throws TimeoutException {
         List<LogEntry> logs = new CopyOnWriteArrayList<>();
         LogEntry matchingLog;
-        workerTaskLogQueue.receive(logs::add);
+        workerTaskLogQueue.receive(either -> logs.add(either.getLeft()));
 
         Execution execution = runnerUtils.runOne("io.kestra.tests", "logs");
 
@@ -79,7 +79,7 @@ class RunContextTest extends AbstractMemoryRunnerTest {
     @Test
     void inputsLarge() throws TimeoutException {
         List<LogEntry> logs = new CopyOnWriteArrayList<>();
-        workerTaskLogQueue.receive(logs::add);
+        workerTaskLogQueue.receive(either -> logs.add(either.getLeft()));
 
         char[] chars = new char[1024 * 11];
         Arrays.fill(chars, 'a');

--- a/core/src/test/java/io/kestra/core/runners/TaskDefaultsCaseTest.java
+++ b/core/src/test/java/io/kestra/core/runners/TaskDefaultsCaseTest.java
@@ -77,7 +77,7 @@ public class TaskDefaultsCaseTest {
 
     public void invalidTaskDefaults() throws TimeoutException {
         List<LogEntry> logs = new CopyOnWriteArrayList<>();
-        logQueue.receive(logs::add);
+        logQueue.receive(either -> logs.add(either.getLeft()));
 
         Execution execution = runnerUtils.runOne("io.kestra.tests", "invalid-task-defaults", Duration.ofSeconds(60));
 

--- a/core/src/test/java/io/kestra/core/runners/WorkerTest.java
+++ b/core/src/test/java/io/kestra/core/runners/WorkerTest.java
@@ -64,7 +64,7 @@ class WorkerTest {
         worker.run();
 
         AtomicReference<WorkerTaskResult> workerTaskResult = new AtomicReference<>(null);
-        workerTaskResultQueue.receive(workerTaskResult::set);
+        workerTaskResultQueue.receive(either -> workerTaskResult.set(either.getLeft()));
 
         workerTaskQueue.emit(workerTask(1000));
 
@@ -89,7 +89,7 @@ class WorkerTest {
         worker.run();
 
         AtomicReference<WorkerTaskResult> workerTaskResult = new AtomicReference<>(null);
-        workerTaskResultQueue.receive(workerTaskResult::set);
+        workerTaskResultQueue.receive(either -> workerTaskResult.set(either.getLeft()));
 
         Pause pause = Pause.builder()
             .type(Pause.class.getName())
@@ -133,13 +133,13 @@ class WorkerTest {
     @Test
     void killed() throws InterruptedException, TimeoutException {
         List<LogEntry> logs = new CopyOnWriteArrayList<>();
-        workerTaskLogQueue.receive(logs::add);
+        workerTaskLogQueue.receive(either -> logs.add(either.getLeft()));
 
         Worker worker = new Worker(applicationContext, 8, null);
         worker.run();
 
         List<WorkerTaskResult> workerTaskResult = new ArrayList<>();
-        workerTaskResultQueue.receive(workerTaskResult::add);
+        workerTaskResultQueue.receive(either -> workerTaskResult.add(either.getLeft()));
 
         WorkerTask workerTask = workerTask(999000);
 

--- a/core/src/test/java/io/kestra/core/schedulers/SchedulerConditionTest.java
+++ b/core/src/test/java/io/kestra/core/schedulers/SchedulerConditionTest.java
@@ -1,6 +1,7 @@
 package io.kestra.core.schedulers;
 
 import io.kestra.core.models.conditions.types.DayWeekInMonthCondition;
+import io.kestra.core.models.executions.Execution;
 import io.kestra.core.models.flows.Flow;
 import io.kestra.core.models.flows.State;
 import io.kestra.core.models.triggers.Trigger;
@@ -79,7 +80,8 @@ class SchedulerConditionTest extends AbstractSchedulerTest {
             triggerState);
              Worker worker = new TestMethodScopedWorker(applicationContext, 8, null)) {
             // wait for execution
-            Runnable assertionStop = executionQueue.receive(SchedulerConditionTest.class, execution -> {
+            Runnable assertionStop = executionQueue.receive(SchedulerConditionTest.class, either -> {
+                Execution execution = either.getLeft();
                 if (execution.getState().getCurrent() == State.Type.CREATED) {
                     executionQueue.emit(execution.withState(State.Type.SUCCESS));
 

--- a/core/src/test/java/io/kestra/core/schedulers/SchedulerScheduleTest.java
+++ b/core/src/test/java/io/kestra/core/schedulers/SchedulerScheduleTest.java
@@ -1,5 +1,6 @@
 package io.kestra.core.schedulers;
 
+import io.kestra.core.models.executions.Execution;
 import io.kestra.core.models.flows.Flow;
 import io.kestra.core.models.flows.State;
 import io.kestra.core.models.triggers.types.Schedule;
@@ -10,6 +11,7 @@ import jakarta.inject.Inject;
 import org.junitpioneer.jupiter.RetryingTest;
 import org.junitpioneer.jupiter.RetryingTest;
 
+import java.lang.reflect.Executable;
 import java.time.ZonedDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.*;
@@ -76,7 +78,8 @@ public class SchedulerScheduleTest extends AbstractSchedulerTest {
         try (AbstractScheduler scheduler = scheduler(flowListenersServiceSpy);
              Worker worker = new TestMethodScopedWorker(applicationContext, 8, null)) {
             // wait for execution
-            Runnable assertionStop = executionQueue.receive(execution -> {
+            Runnable assertionStop = executionQueue.receive(either -> {
+                Execution execution = either.getLeft();
                 assertThat(execution.getInputs().get("testInputs"), is("test-inputs"));
                 assertThat(execution.getInputs().get("def"), is("awesome"));
 

--- a/core/src/test/java/io/kestra/core/schedulers/SchedulerThreadTest.java
+++ b/core/src/test/java/io/kestra/core/schedulers/SchedulerThreadTest.java
@@ -75,7 +75,8 @@ public class SchedulerThreadTest extends AbstractSchedulerTest {
             AtomicReference<Execution> last = new AtomicReference<>();
 
             // wait for execution
-            Runnable assertionStop = executionQueue.receive(SchedulerThreadTest.class, execution -> {
+            Runnable assertionStop = executionQueue.receive(SchedulerThreadTest.class, either -> {
+                Execution execution = either.getLeft();
                 last.set(execution);
 
                 assertThat(execution.getFlowId(), is(flow.getId()));

--- a/core/src/test/java/io/kestra/core/services/ConditionServiceTest.java
+++ b/core/src/test/java/io/kestra/core/services/ConditionServiceTest.java
@@ -67,7 +67,7 @@ class ConditionServiceTest {
     @Test
     void exception() {
         List<LogEntry> logs = new CopyOnWriteArrayList<>();
-        logQueue.receive(logs::add);
+        logQueue.receive(either -> logs.add(either.getLeft()));
 
         Flow flow = TestsUtils.mockFlow();
         Schedule schedule = Schedule.builder().id("unit").type(Schedule.class.getName()).cron("0 0 1 * *").build();

--- a/core/src/test/java/io/kestra/core/tasks/flows/EachSequentialTest.java
+++ b/core/src/test/java/io/kestra/core/tasks/flows/EachSequentialTest.java
@@ -91,7 +91,7 @@ public class EachSequentialTest extends AbstractMemoryRunnerTest {
 
     public static void eachNullTest(RunnerUtils runnerUtils, QueueInterface<LogEntry> logQueue) throws TimeoutException {
         List<LogEntry> logs = new CopyOnWriteArrayList<>();
-        logQueue.receive(logs::add);
+        logQueue.receive(either -> logs.add(either.getLeft()));
 
         Execution execution = runnerUtils.runOne("io.kestra.tests", "each-null", Duration.ofSeconds(60));
 

--- a/core/src/test/java/io/kestra/core/tasks/flows/FlowCaseTest.java
+++ b/core/src/test/java/io/kestra/core/tasks/flows/FlowCaseTest.java
@@ -45,7 +45,8 @@ public class FlowCaseTest {
         CountDownLatch countDownLatch = new CountDownLatch(1);
         AtomicReference<Execution> triggered = new AtomicReference<>();
 
-        executionQueue.receive(execution -> {
+        executionQueue.receive(either -> {
+            Execution execution = either.getLeft();
             if (execution.getFlowId().equals("switch") && execution.getState().getCurrent().isTerminated()) {
                 countDownLatch.countDown();
                 triggered.set(execution);

--- a/core/src/test/java/io/kestra/core/tasks/flows/TemplateTest.java
+++ b/core/src/test/java/io/kestra/core/tasks/flows/TemplateTest.java
@@ -53,7 +53,7 @@ public class TemplateTest extends AbstractMemoryRunnerTest {
             "flows/templates/with-template.yaml")));
 
         List<LogEntry> logs = new CopyOnWriteArrayList<>();
-        logQueue.receive(logs::add);
+        logQueue.receive(either -> logs.add(either.getLeft()));
 
 
         Execution execution = runnerUtils.runOne(
@@ -84,7 +84,7 @@ public class TemplateTest extends AbstractMemoryRunnerTest {
             "flows/templates/with-failed-template.yaml")));
 
         List<LogEntry> logs = new CopyOnWriteArrayList<>();
-        logQueue.receive(logs::add);
+        logQueue.receive(either -> logs.add(either.getLeft()));
 
         Execution execution = runnerUtils.runOne("io.kestra.tests", "with-failed-template", Duration.ofSeconds(60));
 

--- a/core/src/test/java/io/kestra/core/tasks/flows/TimeoutTest.java
+++ b/core/src/test/java/io/kestra/core/tasks/flows/TimeoutTest.java
@@ -39,7 +39,7 @@ class TimeoutTest extends AbstractMemoryRunnerTest {
     @Test
     void timeout() throws TimeoutException {
         List<LogEntry> logs = new CopyOnWriteArrayList<>();
-        workerTaskLogQueue.receive(logs::add);
+        workerTaskLogQueue.receive(either -> logs.add(either.getLeft()));
 
         Flow flow = Flow.builder()
             .id(IdUtils.create())

--- a/core/src/test/java/io/kestra/core/tasks/flows/VariablesTest.java
+++ b/core/src/test/java/io/kestra/core/tasks/flows/VariablesTest.java
@@ -42,7 +42,7 @@ class VariablesTest extends AbstractMemoryRunnerTest {
     @Test
     void invalidVars() throws TimeoutException {
         List<LogEntry> logs = new CopyOnWriteArrayList<>();
-        workerTaskLogQueue.receive(logs::add);
+        workerTaskLogQueue.receive(either -> logs.add(either.getLeft()));
 
         Execution execution = runnerUtils.runOne("io.kestra.tests", "variables-invalid");
 

--- a/jdbc-h2/src/main/java/io/kestra/runner/h2/H2WorkerJobQueue.java
+++ b/jdbc-h2/src/main/java/io/kestra/runner/h2/H2WorkerJobQueue.java
@@ -1,9 +1,11 @@
 package io.kestra.runner.h2;
 
+import io.kestra.core.exceptions.DeserializationException;
 import io.kestra.core.queues.QueueFactoryInterface;
 import io.kestra.core.queues.QueueInterface;
 import io.kestra.core.queues.WorkerJobQueueInterface;
 import io.kestra.core.runners.WorkerJob;
+import io.kestra.core.utils.Either;
 import io.micronaut.context.ApplicationContext;
 import io.micronaut.inject.qualifiers.Qualifiers;
 
@@ -21,7 +23,7 @@ public class H2WorkerJobQueue implements WorkerJobQueueInterface {
     }
 
     @Override
-    public Runnable receive(String consumerGroup, Class<?> queueType, Consumer<WorkerJob> consumer) {
+    public Runnable receive(String consumerGroup, Class<?> queueType, Consumer<Either<WorkerJob, DeserializationException>> consumer) {
         return workerTaskQueue.receive(consumerGroup, queueType, consumer);
     }
 

--- a/jdbc-mysql/src/main/java/io/kestra/runner/mysql/MysqlWorkerJobQueue.java
+++ b/jdbc-mysql/src/main/java/io/kestra/runner/mysql/MysqlWorkerJobQueue.java
@@ -1,9 +1,11 @@
 package io.kestra.runner.mysql;
 
+import io.kestra.core.exceptions.DeserializationException;
 import io.kestra.core.queues.QueueFactoryInterface;
 import io.kestra.core.queues.QueueInterface;
 import io.kestra.core.queues.WorkerJobQueueInterface;
 import io.kestra.core.runners.WorkerJob;
+import io.kestra.core.utils.Either;
 import io.micronaut.context.ApplicationContext;
 import io.micronaut.inject.qualifiers.Qualifiers;
 
@@ -21,7 +23,7 @@ public class MysqlWorkerJobQueue implements WorkerJobQueueInterface {
     }
 
     @Override
-    public Runnable receive(String consumerGroup, Class<?> queueType, Consumer<WorkerJob> consumer) {
+    public Runnable receive(String consumerGroup, Class<?> queueType, Consumer<Either<WorkerJob, DeserializationException>> consumer) {
         return workerTaskQueue.receive(consumerGroup, queueType, consumer);
     }
 

--- a/jdbc-postgres/src/main/java/io/kestra/runner/postgres/PostgresWorkerJobQueue.java
+++ b/jdbc-postgres/src/main/java/io/kestra/runner/postgres/PostgresWorkerJobQueue.java
@@ -1,9 +1,11 @@
 package io.kestra.runner.postgres;
 
+import io.kestra.core.exceptions.DeserializationException;
 import io.kestra.core.queues.QueueFactoryInterface;
 import io.kestra.core.queues.QueueInterface;
 import io.kestra.core.queues.WorkerJobQueueInterface;
 import io.kestra.core.runners.WorkerJob;
+import io.kestra.core.utils.Either;
 import io.micronaut.context.ApplicationContext;
 import io.micronaut.inject.qualifiers.Qualifiers;
 
@@ -21,7 +23,7 @@ public class PostgresWorkerJobQueue implements WorkerJobQueueInterface {
     }
 
     @Override
-    public Runnable receive(String consumerGroup, Class<?> queueType, Consumer<WorkerJob> consumer) {
+    public Runnable receive(String consumerGroup, Class<?> queueType, Consumer<Either<WorkerJob, DeserializationException>> consumer) {
         return workerTaskQueue.receive(consumerGroup, queueType, consumer);
     }
 

--- a/jdbc/src/main/java/io/kestra/jdbc/AbstractJdbcRepository.java
+++ b/jdbc/src/main/java/io/kestra/jdbc/AbstractJdbcRepository.java
@@ -1,6 +1,5 @@
-    package io.kestra.jdbc;
+package io.kestra.jdbc;
 
-import com.fasterxml.jackson.databind.exc.InvalidTypeIdException;
 import com.google.common.collect.ImmutableMap;
 import io.kestra.core.exceptions.DeserializationException;
 import io.kestra.core.models.executions.metrics.MetricAggregation;
@@ -164,10 +163,8 @@ public abstract class AbstractJdbcRepository<T> {
     public T deserialize(String record) {
         try {
             return JacksonMapper.ofJson().readValue(record, cls);
-        } catch (InvalidTypeIdException e) {
-            throw new DeserializationException(e);
         } catch (IOException e) {
-            throw new DeserializationException(e);
+            throw new DeserializationException(e, record);
         }
     }
 

--- a/jdbc/src/main/java/io/kestra/jdbc/repository/AbstractJdbcFlowRepository.java
+++ b/jdbc/src/main/java/io/kestra/jdbc/repository/AbstractJdbcFlowRepository.java
@@ -69,7 +69,7 @@ public abstract class AbstractJdbcFlowRepository extends AbstractJdbcRepository 
                         .tasks(List.of())
                         .build();
                 } catch (JsonProcessingException ex) {
-                    throw new DeserializationException(ex);
+                    throw new DeserializationException(ex, source);
                 }
             }
         });

--- a/jdbc/src/main/java/io/kestra/jdbc/runner/JdbcScheduler.java
+++ b/jdbc/src/main/java/io/kestra/jdbc/runner/JdbcScheduler.java
@@ -53,7 +53,13 @@ public class JdbcScheduler extends AbstractScheduler {
 
         executionQueue.receive(
             Scheduler.class,
-            execution -> {
+            either -> {
+                if (either.isRight()) {
+                    log.error("Unable to dserialize an execution: {}", either.getRight().getMessage());
+                    return;
+                }
+
+                Execution execution = either.getLeft();
                 if (execution.getTrigger() != null) {
                     var flow = flowRepository.findById(execution.getNamespace(), execution.getFlowId()).orElse(null);
                     if (execution.isDeleted() || conditionService.isTerminatedWithListeners(flow, execution)) {

--- a/jdbc/src/test/java/io/kestra/jdbc/runner/JdbcQueueTest.java
+++ b/jdbc/src/test/java/io/kestra/jdbc/runner/JdbcQueueTest.java
@@ -34,7 +34,8 @@ abstract public class JdbcQueueTest {
     void noGroup() throws InterruptedException {
         CountDownLatch countDownLatch = new CountDownLatch(2);
 
-        flowQueue.receive(flow -> {
+        flowQueue.receive(either -> {
+            Flow flow = either.getLeft();
             if (flow.getNamespace().equals("io.kestra.f1")) {
                 flowQueue.emit(builder("io.kestra.f2"));
             }
@@ -53,7 +54,8 @@ abstract public class JdbcQueueTest {
     void withGroup() throws InterruptedException {
         CountDownLatch countDownLatch = new CountDownLatch(2);
 
-        flowQueue.receive("consumer_group", flow -> {
+        flowQueue.receive("consumer_group", either -> {
+            Flow flow = either.getLeft();
             if (flow.getNamespace().equals("io.kestra.f1")) {
                 flowQueue.emit("consumer_group", builder("io.kestra.f2"));
             }
@@ -76,7 +78,8 @@ abstract public class JdbcQueueTest {
         AtomicReference<String> namespace = new AtomicReference<>();
 
         CountDownLatch countDownLatch = new CountDownLatch(1);
-        flowQueue.receive(Indexer.class, flow -> {
+        flowQueue.receive(Indexer.class, either -> {
+            Flow flow = either.getLeft();
             namespace.set(flow.getNamespace());
             countDownLatch.countDown();
         });
@@ -89,7 +92,8 @@ abstract public class JdbcQueueTest {
         flowQueue.emit(builder("io.kestra.f2"));
 
         CountDownLatch countDownLatch2 = new CountDownLatch(1);
-        flowQueue.receive(Indexer.class, flow -> {
+        flowQueue.receive(Indexer.class, either -> {
+            Flow flow = either.getLeft();
             namespace.set(flow.getNamespace());
             countDownLatch2.countDown();
         });
@@ -106,7 +110,8 @@ abstract public class JdbcQueueTest {
         AtomicReference<String> namespace = new AtomicReference<>();
 
         CountDownLatch countDownLatch = new CountDownLatch(1);
-        flowQueue.receive("consumer_group", Indexer.class, flow -> {
+        flowQueue.receive("consumer_group", Indexer.class, either -> {
+            Flow flow = either.getLeft();
             namespace.set(flow.getNamespace());
             countDownLatch.countDown();
         });
@@ -119,7 +124,8 @@ abstract public class JdbcQueueTest {
         flowQueue.emit("consumer_group", builder("io.kestra.f2"));
 
         CountDownLatch countDownLatch2 = new CountDownLatch(1);
-        flowQueue.receive("consumer_group", Indexer.class, flow -> {
+        flowQueue.receive("consumer_group", Indexer.class, either -> {
+            Flow flow = either.getLeft();
             namespace.set(flow.getNamespace());
             countDownLatch2.countDown();
         });

--- a/runner-memory/src/main/java/io/kestra/runner/memory/MemoryWorkerJobQueue.java
+++ b/runner-memory/src/main/java/io/kestra/runner/memory/MemoryWorkerJobQueue.java
@@ -1,5 +1,7 @@
 package io.kestra.runner.memory;
 
+import io.kestra.core.exceptions.DeserializationException;
+import io.kestra.core.utils.Either;
 import io.micronaut.context.ApplicationContext;
 import io.micronaut.inject.qualifiers.Qualifiers;
 import io.kestra.core.queues.QueueFactoryInterface;
@@ -21,7 +23,7 @@ public class MemoryWorkerJobQueue implements WorkerJobQueueInterface {
     }
 
     @Override
-    public Runnable receive(String consumerGroup, Class<?> queueType, Consumer<WorkerJob> consumer) {
+    public Runnable receive(String consumerGroup, Class<?> queueType, Consumer<Either<WorkerJob, DeserializationException>> consumer) {
         return workerTaskQueue.receive(consumerGroup, queueType, consumer);
     }
 

--- a/webserver/src/main/java/io/kestra/webserver/controllers/ExecutionController.java
+++ b/webserver/src/main/java/io/kestra/webserver/controllers/ExecutionController.java
@@ -463,7 +463,13 @@ public class ExecutionController {
 
         return Single
             .<Execution>create(emitter -> {
-                Runnable receive = this.executionQueue.receive(item -> {
+                Runnable receive = this.executionQueue.receive(either -> {
+                    if (either.isRight()) {
+                        log.error("Unable to deserialize the execution: {}", either.getRight().getMessage());
+                        return;
+                    }
+
+                    Execution item = either.getLeft();
                     if (item.getId().equals(current.getId())) {
                         Flow flow = flowRepository.findByExecution(current);
 
@@ -921,7 +927,13 @@ public class ExecutionController {
                 emitter.onNext(Event.of(execution).id("progress"));
 
                 // consume new value
-                Runnable receive = this.executionQueue.receive(current -> {
+                Runnable receive = this.executionQueue.receive(either -> {
+                    if (either.isRight()) {
+                        log.error("Unable to deserialize the execution: {}", either.getRight().getMessage());
+                        return;
+                    }
+
+                    Execution current = either.getLeft();
                     if (current.getId().equals(executionId)) {
 
                         emitter.onNext(Event.of(current).id("progress"));

--- a/webserver/src/main/java/io/kestra/webserver/controllers/LogController.java
+++ b/webserver/src/main/java/io/kestra/webserver/controllers/LogController.java
@@ -131,7 +131,12 @@ public class LogController {
                     .forEach(logEntry -> emitter.onNext(Event.of(logEntry).id("progress")));
 
                 // consume in realtime
-                Runnable receive = this.logQueue.receive(current -> {
+                Runnable receive = this.logQueue.receive(either -> {
+                    if (either.isRight()) {
+                        return;
+                    }
+
+                    LogEntry current = either.getLeft();
                     if (current.getExecutionId() != null && current.getExecutionId().equals(executionId)) {
                         if (levels.contains(current.getLevel().name())) {
                             emitter.onNext(Event.of(current).id("progress"));


### PR DESCRIPTION
The Queue is modified to consume `Either<T, DeserializationException>`.

On the JDBC queue, each JSON exception (not only for missing type) will return an Either with the deserialization exception that now includes the source (not yet used).

All components that read a queue now check for a deserialization exception, if it exists will log it and skip the message.