### PR TITLE
feat: lower the size of the Micronaut executor that handle @Scheduled

### DIFF
--- a/cli/src/main/resources/application.yml
+++ b/cli/src/main/resources/application.yml
@@ -36,6 +36,13 @@ micronaut:
         connect-timeout: 180s
         read-timeout: 180s
 
+  # By default, Micronaut uses a scheduled executor with 2*nbProc for @Scheduled which is a lot as we didn't use much scheduling tasks.
+  # Using core-pool-size to set the minimum nb threads to keep when idle instead.
+  executors:
+    scheduled:
+      type: scheduled
+      core-pool-size: 1
+
 jackson:
   serialization:
     writeDatesAsTimestamps: false


### PR DESCRIPTION
We use it for the JDBC queue purge and the usage.
core-pool-size is the number of threads to keep in the pool, even if they are idle. Setting it to one seems enough as we schedule tasks each hour. By default, the executor uses 2*nbProc.

