### PR TITLE
Propagate the environment name to the page title

### DIFF
--- a/ui/src/App.vue
+++ b/ui/src/App.vue
@@ -53,14 +53,18 @@
                 }
 
                 return true;
+            },
+            envName() {
+                return this.$store.getters["layout/envName"] || this.configs?.environment?.name;
             }
         },
         async created() {
             if (this.created === false) {
-                await this.loadGeneralRessources()
-                this.displayApp()
+                await this.loadGeneralResources();
+                this.displayApp();
                 this.initGuidedTour();
             }
+            this.setTitleEnvSuffix();
         },
         methods: {
             onMenuCollapse(collapse) {
@@ -74,7 +78,14 @@
                 document.getElementById("app-container").style.display = "block";
                 this.loaded = true;
             },
-            async loadGeneralRessources() {
+            setTitleEnvSuffix() {
+                if (!this.envName) {
+                    return;
+                }
+
+                document.title = document.title.replace(/( - .+)?$/, ` - ${this.envName}`);
+            },
+            async loadGeneralResources() {
                 let uid = localStorage.getItem("uid");
                 if (uid === null) {
                     uid = Utils.uid();
@@ -108,6 +119,9 @@
                 if (this.user && to.name === "home" && this.overallTotal === 0) {
                     this.$router.push({name: "welcome"});
                 }
+            },
+            envName() {
+                this.setTitleEnvSuffix();
             }
         }
     };

--- a/ui/src/App.vue
+++ b/ui/src/App.vue
@@ -79,11 +79,9 @@
                 this.loaded = true;
             },
             setTitleEnvSuffix() {
-                if (!this.envName) {
-                    return;
-                }
+                const envSuffix = this.envName ? ` - ${this.envName}` : "";
 
-                document.title = document.title.replace(/( - .+)?$/, ` - ${this.envName}`);
+                document.title = document.title.replace(/( - .+)?$/, envSuffix);
             },
             async loadGeneralResources() {
                 let uid = localStorage.getItem("uid");


### PR DESCRIPTION
It's useful to have the environment displayed in the title. For example, password manager auto-type or visual info in browser tabs.