### PR TITLE
fix(core): possible NPE on validation

### DIFF
--- a/core/src/main/java/io/kestra/core/services/FlowService.java
+++ b/core/src/main/java/io/kestra/core/services/FlowService.java
@@ -50,7 +50,7 @@ public class FlowService {
     }
 
     private Stream<String> deprecationTraversal(String prefix, Object object) {
-        if (ClassUtils.isPrimitiveOrWrapper(object.getClass()) || String.class.equals(object.getClass())) {
+        if (object == null || ClassUtils.isPrimitiveOrWrapper(object.getClass()) || String.class.equals(object.getClass())) {
             return Stream.empty();
         }
 


### PR DESCRIPTION
This occurs when the validation is triggered on a non-yet completed flow, for ex when typing or hitting save too early.
