### PR TITLE
fix(core, webserver): only change the alert block for the UI

### DIFF
--- a/core/src/main/java/io/kestra/core/docs/DocumentationGenerator.java
+++ b/core/src/main/java/io/kestra/core/docs/DocumentationGenerator.java
@@ -260,10 +260,6 @@ public class DocumentationGenerator {
         Pattern pattern = Pattern.compile("`\\{\\{(.*?)\\}\\}`", Pattern.MULTILINE);
         renderer = pattern.matcher(renderer).replaceAll("<code v-pre>{{ $1 }}</code>");
 
-        // alert
-        renderer = renderer.replaceAll("\n::alert\\{type=\"(.*)\"\\}\n", "\n::: $1\n");
-        renderer = renderer.replaceAll("\n::\n", "\n:::\n");
-
         return renderer;
     }
 }

--- a/core/src/test/java/io/kestra/core/docs/DocumentationGeneratorTest.java
+++ b/core/src/test/java/io/kestra/core/docs/DocumentationGeneratorTest.java
@@ -7,6 +7,7 @@ import io.kestra.core.tasks.debugs.Echo;
 import io.kestra.core.tasks.debugs.Return;
 import io.kestra.core.tasks.flows.Dag;
 import io.kestra.core.tasks.flows.Flow;
+import io.kestra.core.tasks.states.Set;
 import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
 import jakarta.inject.Inject;
 import org.junit.jupiter.api.Test;
@@ -129,6 +130,20 @@ class DocumentationGeneratorTest {
 
         assertThat(render, containsString("Echo"));
         assertThat(render, containsString("- \uD83D\uDD12 Deprecated"));
+    }
+
+    @Test
+    void state() throws IOException {
+        PluginScanner pluginScanner = new PluginScanner(ClassPluginDocumentationTest.class.getClassLoader());
+        RegisteredPlugin scan = pluginScanner.scan();
+        Class<Set> set = scan.findClass(Set.class.getName()).orElseThrow();
+
+        ClassPluginDocumentation<? extends Task> doc = ClassPluginDocumentation.of(jsonSchemaGenerator, scan, set, Task.class);
+
+        String render = DocumentationGenerator.render(doc);
+
+        assertThat(render, containsString("Set"));
+        assertThat(render, containsString("::alert{type=\"warning\"}\n"));
     }
 
     @Test

--- a/webserver/src/main/java/io/kestra/webserver/controllers/PluginController.java
+++ b/webserver/src/main/java/io/kestra/webserver/controllers/PluginController.java
@@ -10,6 +10,7 @@ import io.kestra.core.models.triggers.AbstractTrigger;
 import io.kestra.core.plugins.RegisteredPlugin;
 import io.kestra.core.services.PluginService;
 import io.micronaut.cache.annotation.Cacheable;
+import io.micronaut.core.annotation.NonNull;
 import io.micronaut.http.HttpResponse;
 import io.micronaut.http.MutableHttpResponse;
 import io.micronaut.http.annotation.Controller;
@@ -95,7 +96,7 @@ public class PluginController {
 
         return HttpResponse.ok()
             .body(new DocumentationWithSchema(
-                DocumentationGenerator.render(classInputDocumentation),
+                alertReplacement(DocumentationGenerator.render(classInputDocumentation)),
                 new Schema(
                     classInputDocumentation.getPropertiesSchema(),
                     null,
@@ -164,7 +165,7 @@ public class PluginController {
             allProperties
         );
 
-        var doc = DocumentationGenerator.render(classPluginDocumentation);
+        var doc = alertReplacement(DocumentationGenerator.render(classPluginDocumentation));
 
         return HttpResponse.ok()
             .body(new DocumentationWithSchema(
@@ -195,5 +196,11 @@ public class PluginController {
             .baseClass(className);
 
         return ClassPluginDocumentation.of(jsonSchemaGenerator, registeredPlugin, cls, allProperties ? null : baseCls);
+    }
+
+    private String alertReplacement(@NonNull String original) {
+        // we need to replace the NuxtJS ::alert{type=} :: with the more standard ::: warning :::
+        return original.replaceAll("\n::alert\\{type=\"(.*)\"\\}\n", "\n::: $1\n")
+            .replaceAll("\n::\n", "\n:::\n");
     }
 }

--- a/webserver/src/test/java/io/kestra/webserver/controllers/PluginControllerTest.java
+++ b/webserver/src/test/java/io/kestra/webserver/controllers/PluginControllerTest.java
@@ -108,6 +108,21 @@ class PluginControllerTest {
         });
     }
 
+    @Test
+    void docWithAlert() throws URISyntaxException {
+        Helpers.runApplicationContext((applicationContext, embeddedServer) -> {
+            RxHttpClient client = RxHttpClient.create(embeddedServer.getURL());
+
+            DocumentationWithSchema doc = client.toBlocking().retrieve(
+                HttpRequest.GET("/api/v1/plugins/io.kestra.core.tasks.states.Set"),
+                DocumentationWithSchema.class
+            );
+
+            assertThat(doc.getMarkdown(), containsString("io.kestra.core.tasks.states.Set"));
+            assertThat(doc.getMarkdown(), containsString("::: warning\n"));
+        });
+    }
+
 
     @SuppressWarnings("unchecked")
     @Test


### PR DESCRIPTION
Previously, we change the alert block in the DocumentationGenerator so it was changed when generating the markdown used in the documentation site and for the documentation provided by th e PluginController. Moving this replacement on the PluginController only do this for the UI and not the documentation site that uses NutxJS alert block.

close #1902
