### PR TITLE
feat: new SECRET input type

### DIFF
--- a/core/src/main/java/io/kestra/core/models/flows/Input.java
+++ b/core/src/main/java/io/kestra/core/models/flows/Input.java
@@ -31,6 +31,7 @@ import javax.validation.constraints.Pattern;
     @JsonSubTypes.Type(value = FloatInput.class, name = "FLOAT"),
     @JsonSubTypes.Type(value = IntInput.class, name = "INT"),
     @JsonSubTypes.Type(value = JsonInput.class, name = "JSON"),
+    @JsonSubTypes.Type(value = SecretInput.class, name = "SECRET"),
     @JsonSubTypes.Type(value = StringInput.class, name = "STRING"),
     @JsonSubTypes.Type(value = TimeInput.class, name = "TIME"),
     @JsonSubTypes.Type(value = URIInput.class, name = "URI")
@@ -67,7 +68,8 @@ public abstract class Input<T> {
         DURATION(DurationInput.class.getName()),
         FILE(FileInput.class.getName()),
         JSON(JsonInput.class.getName()),
-        URI(URIInput.class.getName());
+        URI(URIInput.class.getName()),
+        SECRET(SecretInput.class.getName());
 
         private final String clsName;
 

--- a/core/src/main/java/io/kestra/core/models/flows/input/SecretInput.java
+++ b/core/src/main/java/io/kestra/core/models/flows/input/SecretInput.java
@@ -1,0 +1,38 @@
+package io.kestra.core.models.flows.input;
+
+import io.kestra.core.models.flows.Input;
+import io.kestra.core.models.validations.ManualConstraintViolation;
+import io.kestra.core.validations.Regex;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+import java.util.Set;
+import java.util.regex.Pattern;
+import javax.validation.ConstraintViolationException;
+
+@SuperBuilder
+@Getter
+@NoArgsConstructor
+public class SecretInput extends Input<String> {
+    @Schema(
+        title = "Regular expression validating the value."
+    )
+    @Regex
+    String validator;
+
+    @Override
+    public void validate(String input) throws ConstraintViolationException {
+        if (validator != null && ! Pattern.matches(validator, input)) {
+            throw new ConstraintViolationException("Invalid input '" + input + "', it must match the pattern '" + validator + "'",
+                Set.of(ManualConstraintViolation.of(
+                    "Invalid input",
+                    this,
+                    SecretInput.class,
+                    getName(),
+                    input
+                )));
+        }
+    }
+}

--- a/core/src/main/java/io/kestra/core/runners/RunnerUtils.java
+++ b/core/src/main/java/io/kestra/core/runners/RunnerUtils.java
@@ -135,31 +135,31 @@ public class RunnerUtils {
 
     private Optional<AbstractMap.SimpleEntry<String, Object>> parseInput(Flow flow, Execution execution, Input<?> input, String current) {
         switch (input.getType()) {
-            case STRING:
+            case STRING, SECRET -> {
                 return Optional.of(new AbstractMap.SimpleEntry<>(
                     input.getName(),
                     current
                 ));
-
-            case INT:
+            }
+            case INT -> {
                 return Optional.of(new AbstractMap.SimpleEntry<>(
                     input.getName(),
                     Integer.valueOf(current)
                 ));
-
-            case FLOAT:
+            }
+            case FLOAT -> {
                 return Optional.of(new AbstractMap.SimpleEntry<>(
                     input.getName(),
                     Float.valueOf(current)
                 ));
-
-            case BOOLEAN:
+            }
+            case BOOLEAN -> {
                 return Optional.of(new AbstractMap.SimpleEntry<>(
                     input.getName(),
                     Boolean.valueOf(current)
                 ));
-
-            case DATETIME:
+            }
+            case DATETIME -> {
                 try {
                     return Optional.of(new AbstractMap.SimpleEntry<>(
                         input.getName(),
@@ -168,8 +168,8 @@ public class RunnerUtils {
                 } catch (DateTimeParseException e) {
                     throw new MissingRequiredInput("Invalid DATETIME format for '" + input.getName() + "' for '" + current + "' with error " + e.getMessage(), e);
                 }
-
-            case DATE:
+            }
+            case DATE -> {
                 try {
                     return Optional.of(new AbstractMap.SimpleEntry<>(
                         input.getName(),
@@ -178,8 +178,8 @@ public class RunnerUtils {
                 } catch (DateTimeParseException e) {
                     throw new MissingRequiredInput("Invalid DATE format for '" + input.getName() + "' for '" + current + "' with error " + e.getMessage(), e);
                 }
-
-            case TIME:
+            }
+            case TIME -> {
                 try {
                     return Optional.of(new AbstractMap.SimpleEntry<>(
                         input.getName(),
@@ -188,8 +188,8 @@ public class RunnerUtils {
                 } catch (DateTimeParseException e) {
                     throw new MissingRequiredInput("Invalid TIME format for '" + input.getName() + "' for '" + current + "' with error " + e.getMessage(), e);
                 }
-
-            case DURATION:
+            }
+            case DURATION -> {
                 try {
                     return Optional.of(new AbstractMap.SimpleEntry<>(
                         input.getName(),
@@ -198,8 +198,8 @@ public class RunnerUtils {
                 } catch (DateTimeParseException e) {
                     throw new MissingRequiredInput("Invalid DURATION format for '" + input.getName() + "' for '" + current + "' with error " + e.getMessage(), e);
                 }
-
-            case FILE:
+            }
+            case FILE -> {
                 try {
                     URI uri = URI.create(current.replace(File.separator, "/"));
 
@@ -217,8 +217,8 @@ public class RunnerUtils {
                 } catch (Exception e) {
                     throw new MissingRequiredInput("Invalid input arguments for file on input '" + input.getName() + "'", e);
                 }
-
-            case JSON:
+            }
+            case JSON -> {
                 try {
                     return Optional.of(new AbstractMap.SimpleEntry<>(
                         input.getName(),
@@ -227,8 +227,8 @@ public class RunnerUtils {
                 } catch (JsonProcessingException e) {
                     throw new MissingRequiredInput("Invalid JSON format for '" + input.getName() + "' for '" + current + "' with error " + e.getMessage(), e);
                 }
-
-            case URI:
+            }
+            case URI -> {
                 Matcher matcher = URI_PATTERN.matcher(current);
                 if (matcher.matches()) {
                     return Optional.of(new AbstractMap.SimpleEntry<>(
@@ -238,8 +238,8 @@ public class RunnerUtils {
                 } else {
                     throw new MissingRequiredInput("Invalid URI format for '" + input.getName() + "' for '" + current + "'");
                 }
-
-            default:
+            }
+            default ->
                 throw new MissingRequiredInput("Invalid input type '" + input.getType() + "' for '" + input.getName() + "'");
         }
     }

--- a/core/src/test/java/io/kestra/core/runners/InputsTest.java
+++ b/core/src/test/java/io/kestra/core/runners/InputsTest.java
@@ -54,6 +54,7 @@ public class InputsTest extends AbstractMemoryRunnerTest {
         .put("validatedDuration", "PT15S")
         .put("validatedFloat", "0.42")
         .put("validatedTime", "11:27:49")
+        .put("secret", "secret")
         .build();
 
     @Inject

--- a/core/src/test/java/io/kestra/core/serializers/YamlFlowParserTest.java
+++ b/core/src/test/java/io/kestra/core/serializers/YamlFlowParserTest.java
@@ -123,8 +123,8 @@ class YamlFlowParserTest {
     void inputs() {
         Flow flow = this.parse("flows/valids/inputs.yaml");
 
-        assertThat(flow.getInputs().size(), is(24));
-        assertThat(flow.getInputs().stream().filter(Input::getRequired).count(), is(6L));
+        assertThat(flow.getInputs().size(), is(25));
+        assertThat(flow.getInputs().stream().filter(Input::getRequired).count(), is(7L));
         assertThat(flow.getInputs().stream().filter(r -> !r.getRequired()).count(), is(18L));
         assertThat(flow.getInputs().stream().filter(r -> r.getDefaults() != null).count(), is(1L));
         assertThat(flow.getInputs().stream().filter(r -> r instanceof StringInput && ((StringInput)r).getValidator() != null).count(), is(1L));

--- a/core/src/test/resources/flows/valids/inputs.yaml
+++ b/core/src/test/resources/flows/valids/inputs.yaml
@@ -85,6 +85,8 @@ inputs:
   after: "01:00:00"
   before: "11:59:59"
   required: false
+- name: secret
+  type: SECRET
 
 tasks:
 - id: string

--- a/ui/src/components/executions/Overview.vue
+++ b/ui/src/components/executions/Overview.vue
@@ -113,6 +113,7 @@
             }
         },
         computed: {
+            ...mapState("flow", ["flow"]),
             ...mapState("execution", ["execution"]),
             items() {
                 if (!this.execution) {
@@ -163,7 +164,19 @@
                 return ret;
             },
             inputs() {
-                return toRaw(this.execution.inputs);
+              if (!this.flow) {
+                return []
+              }
+
+              let inputs = toRaw(this.execution.inputs);
+              Object.keys(inputs).forEach(key => {
+                this.flow.inputs.forEach(input => {
+                  if(key === input.name && input.type === 'SECRET') {
+                    inputs[key] = '******';
+                  }
+                })
+              })
+              return inputs;
             }
         },
     };

--- a/ui/src/components/flows/FlowRun.vue
+++ b/ui/src/components/flows/FlowRun.vue
@@ -20,6 +20,12 @@
                     v-if="input.type === 'STRING' || input.type === 'URI'"
                     v-model="inputs[input.name]"
                 />
+                <el-input
+                    type="password"
+                    v-if="input.type === 'SECRET'"
+                    v-model="inputs[input.name]"
+                    show-password
+                />
                 <el-input-number
                     v-if="input.type === 'INT'"
                     v-model="inputs[input.name]"

--- a/webserver/src/test/java/io/kestra/webserver/controllers/ExecutionControllerTest.java
+++ b/webserver/src/test/java/io/kestra/webserver/controllers/ExecutionControllerTest.java
@@ -72,6 +72,7 @@ class ExecutionControllerTest extends JdbcH2ControllerTest {
         .put("float", "42.42")
         .put("instant", "2019-10-06T18:27:49Z")
         .put("file", Objects.requireNonNull(InputsTest.class.getClassLoader().getResource("application.yml")).getPath())
+        .put("secret", "secret")
         .build();
 
     @Test
@@ -109,6 +110,7 @@ class ExecutionControllerTest extends JdbcH2ControllerTest {
             .addPart("instant", "2019-10-06T18:27:49Z")
             .addPart("files", "file", MediaType.TEXT_PLAIN_TYPE, applicationFile)
             .addPart("files", "optionalFile", MediaType.TEXT_XML_TYPE, logbackFile)
+            .addPart("secret", "secret")
             .build();
     }
 

--- a/webserver/src/test/java/io/kestra/webserver/controllers/PluginControllerTest.java
+++ b/webserver/src/test/java/io/kestra/webserver/controllers/PluginControllerTest.java
@@ -192,7 +192,7 @@ class PluginControllerTest {
                 Argument.listOf(InputType.class)
             );
 
-            assertThat(doc.size(), is(11));
+            assertThat(doc.size(), is(12));
         });
     }
 


### PR DESCRIPTION
close [#1442](https://github.com/kestra-io/kestra/issues/1442)

When entering inputs, the input is of type password.
![image](https://github.com/kestra-io/kestra/assets/1819009/e9e81df8-4e48-4599-a1d7-f933dedc4270)


In the overview tab of the flow, the secret is masked.
![image](https://github.com/kestra-io/kestra/assets/1819009/e5aa1bb3-e9c1-4558-a9d7-9fd6e34096c5)


We cannot do anything inside logs or outputs but as we don't log inputs by default, if a user logs a secret this is his responsibility (or if he copies an input into an output).