### PR TITLE
fix/jackson-ignore-graph-cluster-level-setters

### DIFF
--- a/core/src/main/java/io/kestra/core/models/hierarchies/GraphCluster.java
+++ b/core/src/main/java/io/kestra/core/models/hierarchies/GraphCluster.java
@@ -104,6 +104,7 @@ public class GraphCluster extends AbstractGraph {
     }
 
     @Override
+    @JsonIgnore
     public void setUid(String uid) {
         graph.nodes().stream().filter(node ->
                 // filter other clusters' root & end to prevent setting uid multiple times
@@ -116,6 +117,7 @@ public class GraphCluster extends AbstractGraph {
     }
 
     @Override
+    @JsonIgnore
     public void setError(boolean error) {
         this.error = error;
 


### PR DESCRIPTION
Needed for EE tests to pass as the flowgraph is tested on a more thorough flow and Jackson using setError setter of GraphCluster will perform multiple time the mutations leading to incorrect graph