### PR TITLE
Allow a subflow to inherit calling flow's labels

### DIFF
--- a/core/src/main/java/io/kestra/core/runners/ExecutorService.java
+++ b/core/src/main/java/io/kestra/core/runners/ExecutorService.java
@@ -579,7 +579,7 @@ public class ExecutorService {
                 );
 
                 try {
-                    Execution execution = flowTask.createExecution(runContext, flowExecutorInterface());
+                    Execution execution = flowTask.createExecution(runContext, flowExecutorInterface(), executor.getExecution());
 
                     WorkerTaskExecution workerTaskExecution = WorkerTaskExecution.builder()
                         .task(flowTask)

--- a/core/src/main/java/io/kestra/core/tasks/flows/Flow.java
+++ b/core/src/main/java/io/kestra/core/tasks/flows/Flow.java
@@ -13,7 +13,6 @@ import io.kestra.core.models.flows.FlowWithException;
 import io.kestra.core.models.flows.State;
 import io.kestra.core.models.tasks.RunnableTask;
 import io.kestra.core.models.tasks.Task;
-import io.kestra.core.repositories.ExecutionRepositoryInterface;
 import io.kestra.core.runners.*;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.*;
@@ -126,9 +125,8 @@ public class Flow extends Task implements RunnableTask<Flow.Output> {
     }
 
     @SuppressWarnings("unchecked")
-    public Execution createExecution(RunContext runContext, FlowExecutorInterface flowExecutorInterface) throws Exception {
+    public Execution createExecution(RunContext runContext, FlowExecutorInterface flowExecutorInterface, Execution currentExecution) throws Exception {
         RunnerUtils runnerUtils = runContext.getApplicationContext().getBean(RunnerUtils.class);
-        ExecutionRepositoryInterface executionRepository = runContext.getApplicationContext().getBean(ExecutionRepositoryInterface.class);
 
         Map<String, String> inputs = new HashMap<>();
         if (this.inputs != null) {
@@ -139,8 +137,7 @@ public class Flow extends Task implements RunnableTask<Flow.Output> {
 
         List<Label> labels = new ArrayList<>();
         if (this.inheritLabels) {
-            Optional<Execution> currentExecution = getCurrentExecution(runContext, executionRepository);
-            labels.addAll(currentExecution.orElseThrow().getLabels());
+            labels.addAll(currentExecution.getLabels());
         }
         if (this.labels != null) {
             for (Map.Entry<String, String> entry: this.labels.entrySet()) {
@@ -256,11 +253,5 @@ public class Flow extends Task implements RunnableTask<Flow.Output> {
             title = "The extracted outputs from triggered executions."
         )
         private final Map<String, Object> outputs;
-    }
-
-    private Optional<Execution> getCurrentExecution(RunContext runContext, ExecutionRepositoryInterface executionRepository) {
-        final String executionId = ((Map<String, String>) runContext.getVariables().get("execution")).get("id");
-
-        return executionRepository.findById(executionId);
     }
 }

--- a/core/src/test/java/io/kestra/core/tasks/flows/FlowCaseTest.java
+++ b/core/src/test/java/io/kestra/core/tasks/flows/FlowCaseTest.java
@@ -1,6 +1,7 @@
 package io.kestra.core.tasks.flows;
 
 import com.google.common.collect.ImmutableMap;
+import io.kestra.core.models.Label;
 import io.kestra.core.models.executions.Execution;
 import io.kestra.core.models.flows.State;
 import io.kestra.core.queues.QueueFactoryInterface;
@@ -8,6 +9,8 @@ import io.kestra.core.queues.QueueInterface;
 import io.kestra.core.runners.RunnerUtils;
 
 import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
@@ -58,7 +61,8 @@ public class FlowCaseTest {
             "task-flow",
             null,
             (f, e) -> ImmutableMap.of("string", input),
-            Duration.ofMinutes(1)
+            Duration.ofMinutes(1),
+            List.of(new Label("executionLabel", "execFoo"))
         );
 
         countDownLatch.await(1, TimeUnit.MINUTES);
@@ -85,5 +89,7 @@ public class FlowCaseTest {
 
         assertThat(triggered.get().getTaskRunList(), hasSize(count));
         assertThat(triggered.get().getState().getCurrent(), is(triggerState));
+
+        assertThat(triggered.get().getLabels(), hasItems(new Label("executionLabel", "execFoo"), new Label("flowLabel", "flowFoo")));
     }
 }

--- a/core/src/test/java/io/kestra/core/tasks/flows/FlowCaseTest.java
+++ b/core/src/test/java/io/kestra/core/tasks/flows/FlowCaseTest.java
@@ -9,12 +9,12 @@ import io.kestra.core.queues.QueueInterface;
 import io.kestra.core.runners.RunnerUtils;
 
 import java.time.Duration;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
+
 import jakarta.inject.Inject;
 import jakarta.inject.Named;
 import jakarta.inject.Singleton;
@@ -44,7 +44,7 @@ public class FlowCaseTest {
     }
 
     @SuppressWarnings({"ResultOfMethodCallIgnored", "unchecked"})
-    void run(String input, State.Type fromState, State.Type triggerState,  int count, String outputs) throws Exception {
+    void run(String input, State.Type fromState, State.Type triggerState, int count, String outputs) throws Exception {
         CountDownLatch countDownLatch = new CountDownLatch(1);
         AtomicReference<Execution> triggered = new AtomicReference<>();
 
@@ -62,7 +62,7 @@ public class FlowCaseTest {
             null,
             (f, e) -> ImmutableMap.of("string", input),
             Duration.ofMinutes(1),
-            List.of(new Label("executionLabel", "execFoo"))
+            List.of(new Label("mainFlowExecutionLabel", "execFoo"))
         );
 
         countDownLatch.await(1, TimeUnit.MINUTES);
@@ -90,6 +90,11 @@ public class FlowCaseTest {
         assertThat(triggered.get().getTaskRunList(), hasSize(count));
         assertThat(triggered.get().getState().getCurrent(), is(triggerState));
 
-        assertThat(triggered.get().getLabels(), hasItems(new Label("executionLabel", "execFoo"), new Label("flowLabel", "flowFoo")));
+        assertThat(triggered.get().getLabels(), hasItems(
+            new Label("mainFlowExecutionLabel", "execFoo"),
+            new Label("mainFlowLabel", "flowFoo"),
+            new Label("launchTaskLabel", "launchFoo"),
+            new Label("switchFlowLabel", "switchFoo")
+        ));
     }
 }

--- a/core/src/test/resources/flows/valids/switch.yaml
+++ b/core/src/test/resources/flows/valids/switch.yaml
@@ -8,6 +8,9 @@ inputs:
     type: STRING
     defaults: amazing
 
+labels:
+  switchFlowLabel: switchFoo
+
 tasks:
   - id: parent-seq
     type: io.kestra.core.tasks.flows.Switch

--- a/core/src/test/resources/flows/valids/task-flow.yaml
+++ b/core/src/test/resources/flows/valids/task-flow.yaml
@@ -6,7 +6,7 @@ inputs:
     type: STRING
 
 labels:
-  flowLabel: flowFoo
+  mainFlowLabel: flowFoo
 
 tasks:
   - id: launch
@@ -18,5 +18,7 @@ tasks:
     wait: true
     transmitFailed: true
     inheritLabels: true
+    labels:
+      launchTaskLabel: launchFoo
     outputs:
       extracted: "{{ outputs.default.value ?? outputs['error-t1'].value }}"

--- a/core/src/test/resources/flows/valids/task-flow.yaml
+++ b/core/src/test/resources/flows/valids/task-flow.yaml
@@ -5,6 +5,9 @@ inputs:
   - name: string
     type: STRING
 
+labels:
+  flowLabel: flowFoo
+
 tasks:
   - id: launch
     type: io.kestra.core.tasks.flows.Flow
@@ -14,5 +17,6 @@ tasks:
       string: "{{ inputs.string }}"
     wait: true
     transmitFailed: true
+    inheritLabels: true
     outputs:
       extracted: "{{ outputs.default.value ?? outputs['error-t1'].value }}"


### PR DESCRIPTION
The label inheritance is disabled by default.

Please, validate the usage of the exec repo.

close #2114
