### PR TITLE
Simplify bug report issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -9,46 +9,19 @@ body:
         NOTE: If you are unsure about something and the issue is more of a question a better place to ask questions is on [Github Discussions](https://github.com/kestra-io/kestra/discussions) or [Slack](https://kestra.io/slack).
   - type: textarea
     attributes:
-      label: Expected Behavior
-      description: A concise description of what you expected to happen.
-      placeholder: Tell us what should happen
+      label: Explain the bug
+      description: A concise description of the problem
+      placeholder: Describe the problem and provide steps to reproduce the behavior.
     validations:
-      required: false
-  - type: textarea
-    attributes:
-      label: Actual Behaviour
-      description: A concise description of what you're experiencing.
-      placeholder: Tell us what happens instead
-    validations:
-      required: false
-  - type: textarea
-    attributes:
-      label: Steps To Reproduce
-      description: Steps to reproduce the behavior.
-      placeholder: |
-        1. In this environment...
-        2. With this config...
-        3. Run '...'
-        4. See error...
-    validations:
-      required: false
+      required: true
   - type: textarea
     attributes:
       label: Environment Information
       description: Environment information where the problem occurs.
       value: |
         - Kestra Version:
-        - Operating System (OS / Docker / Kubernetes):
-        - Java Version (If not docker):
+        - Operating System and Java Version (if not using Kestra Docker image):
     validations:
       required: true
-  - type: textarea
-    attributes:
-      label: Example flow
-      description: Example flow source.
-      placeholder: |
-        If relevant, an example flow
-    validations:
-      required: false
 labels:
   - bug


### PR DESCRIPTION
It seems that very few people are splitting the bug report into the fields `expected` vs `actual` behavior vs `flow example`. Instead, most seem to use the first field to describe the bug they see - perhaps we can use only this field + the field to explain the environment?