### PR TITLE
fix(webserver): trim the rendered webhook key

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -187,6 +187,7 @@ subprojects {
         systemProperty 'user.country', 'US'
 
         environment 'SECRET_MY_SECRET', "{\"secretKey\":\"secretValue\"}".bytes.encodeBase64().toString()
+        environment 'SECRET_WEBHOOK_KEY', "secretKey".bytes.encodeBase64().toString()
         environment 'SECRET_NON_B64_SECRET', "some secret value"
     }
 

--- a/core/src/test/resources/flows/valids/webhook-secret-key.yaml
+++ b/core/src/test/resources/flows/valids/webhook-secret-key.yaml
@@ -1,0 +1,13 @@
+id: webhook-secret-key
+namespace: io.kestra.tests
+
+tasks:
+  - id: out
+    type: io.kestra.core.tasks.debugs.Return
+    format: "{{trigger | json }}"
+
+
+triggers:
+  - id: webhook
+    type: io.kestra.core.models.triggers.types.Webhook
+    key: "{{ secret('WEBHOOK_KEY') }}"

--- a/webserver/src/main/java/io/kestra/webserver/controllers/ExecutionController.java
+++ b/webserver/src/main/java/io/kestra/webserver/controllers/ExecutionController.java
@@ -391,7 +391,7 @@ public class ExecutionController {
             .filter(w -> {
                 RunContext runContext = runContextFactory.of(flow, w);
                 try {
-                    String webhookKey = runContext.render(w.getKey());
+                    String webhookKey = runContext.render(w.getKey()).trim();
                     return webhookKey.equals(key);
                 } catch (IllegalVariableEvaluationException e) {
                     // be conservative, don't crash but filter the webhook

--- a/webserver/src/test/java/io/kestra/webserver/controllers/ExecutionControllerTest.java
+++ b/webserver/src/test/java/io/kestra/webserver/controllers/ExecutionControllerTest.java
@@ -33,6 +33,7 @@ import io.micronaut.rxjava2.http.client.sse.RxSseClient;
 import jakarta.inject.Inject;
 import jakarta.inject.Named;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 
 import java.io.File;
 import java.time.Duration;
@@ -518,6 +519,21 @@ class ExecutionControllerTest extends JdbcH2ControllerTest {
             HttpRequest
                 .GET(
                     "/api/v1/executions/webhook/" + TESTS_FLOW_NS + "/webhook-dynamic-key/webhook-dynamic-key"
+                ),
+            Execution.class
+        );
+
+        assertThat(execution, notNullValue());
+        assertThat(execution.getId(), notNullValue());
+    }
+
+    @Test
+    @EnabledIfEnvironmentVariable(named = "SECRET_WEBHOOK_KEY", matches = ".*")
+    void webhookDynamicKeyFromASecret() {
+        Execution execution = client.toBlocking().retrieve(
+            HttpRequest
+                .GET(
+                    "/api/v1/executions/webhook/" + TESTS_FLOW_NS + "/webhook-secret-key/secretKey"
                 ),
             Execution.class
         );


### PR DESCRIPTION
As the secret function adds a new line at the end of the rendered value.

close #2138
