### PR TITLE
fix: add jansi lib for coloured logs support on Windows

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -127,6 +127,7 @@ allprojects {
         implementation group: 'org.apache.logging.log4j', name: 'log4j-to-slf4j', version: '2.19.0'
         implementation group: 'org.slf4j', name: 'jul-to-slf4j', version: '1.7.36'
         implementation group: 'org.slf4j', name: 'jcl-over-slf4j', version: '1.7.36'
+        implementation group: 'org.fusesource.jansi', name: 'jansi', version: '2.4.0'
 
         // jackson
         implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind'


### PR DESCRIPTION
Reading https://stackoverflow.com/questions/27843562/how-to-configure-logback-in-spring-boot-for-ansi-color-feature Windows coloring should work by including the Jansi library.

However, this has not been tested.

close [#1958](https://github.com/kestra-io/kestra/issues/1958)
