### PR TITLE
fi(ui,webserver): hide secret input from the webserver

### DIFF
--- a/ui/src/components/executions/Overview.vue
+++ b/ui/src/components/executions/Overview.vue
@@ -113,7 +113,6 @@
             }
         },
         computed: {
-            ...mapState("flow", ["flow"]),
             ...mapState("execution", ["execution"]),
             items() {
                 if (!this.execution) {
@@ -164,19 +163,7 @@
                 return ret;
             },
             inputs() {
-              if (!this.flow) {
-                return []
-              }
-
-              let inputs = toRaw(this.execution.inputs);
-              Object.keys(inputs).forEach(key => {
-                this.flow.inputs.forEach(input => {
-                  if(key === input.name && input.type === 'SECRET') {
-                    inputs[key] = '******';
-                  }
-                })
-              })
-              return inputs;
+                return toRaw(this.execution.inputs);
             }
         },
     };


### PR DESCRIPTION
Note that from the UI, the API button will still show the secret input and I don't think we can do something about it. Maybe this button should have special RBAC on EE. When loading the execution information programmatively from the API the secret input will also be in clear.

@Skraye I don't know if it's what you expected to fix [#442](https://github.com/kestra-io/kestra-ee/issues/442), I only do it for the follow endpoint that is used from the UI but not from the API (and the API button inside the UI).