### PR TITLE
fix(core): improve performance of Execution.outputs()

### DIFF
--- a/core/src/main/java/io/kestra/core/models/executions/Execution.java
+++ b/core/src/main/java/io/kestra/core/models/executions/Execution.java
@@ -165,7 +165,7 @@ public class Execution implements DeletedInterface {
 
     public List<TaskRun> findTaskRunsByTaskId(String id) {
         if (this.taskRunList == null) {
-            return new ArrayList<>();
+            return Collections.emptyList();
         }
 
         return this.taskRunList
@@ -175,7 +175,7 @@ public class Execution implements DeletedInterface {
     }
 
     public TaskRun findTaskRunByTaskRunId(String id) throws InternalException {
-        Optional<TaskRun> find = (this.taskRunList == null ? new ArrayList<TaskRun>() : this.taskRunList)
+        Optional<TaskRun> find = (this.taskRunList == null ? Collections.<TaskRun>emptyList() : this.taskRunList)
             .stream()
             .filter(taskRun -> taskRun.getId().equals(id))
             .findFirst();
@@ -188,7 +188,7 @@ public class Execution implements DeletedInterface {
     }
 
     public TaskRun findTaskRunByTaskIdAndValue(String id, List<String> values) throws InternalException {
-        Optional<TaskRun> find = (this.taskRunList == null ? new ArrayList<TaskRun>() : this.taskRunList)
+        Optional<TaskRun> find = (this.taskRunList == null ? Collections.<TaskRun>emptyList() : this.taskRunList)
             .stream()
             .filter(taskRun -> taskRun.getTaskId().equals(id) && findChildsValues(taskRun, true).equals(values))
             .findFirst();
@@ -230,7 +230,7 @@ public class Execution implements DeletedInterface {
         List<TaskRun> errorsFlow = this.findTaskRunByTasks(resolvedErrors, parentTaskRun);
 
         if (errorsFlow.size() > 0 || this.hasFailed(resolvedTasks, parentTaskRun)) {
-            return resolvedErrors == null ? new ArrayList<>() : resolvedErrors;
+            return resolvedErrors == null ? Collections.emptyList() : resolvedErrors;
         }
 
         return resolvedTasks;
@@ -255,7 +255,7 @@ public class Execution implements DeletedInterface {
 
     public List<TaskRun> findTaskRunByTasks(List<ResolvedTask> resolvedTasks, TaskRun parentTaskRun) {
         if (resolvedTasks == null || this.taskRunList == null) {
-            return new ArrayList<>();
+            return Collections.emptyList();
         }
 
         return this
@@ -615,7 +615,8 @@ public class Execution implements DeletedInterface {
 
         for (TaskRun current : this.taskRunList) {
             if (current.getOutputs() != null) {
-                result = MapUtils.merge(result, outputs(current));
+                Map<String, Object> taskRunOutput = outputs(current);
+                result.putAll(taskRunOutput);
             }
         }
 
@@ -623,39 +624,11 @@ public class Execution implements DeletedInterface {
     }
 
     private Map<String, Object> outputs(TaskRun taskRun) {
-        List<TaskRun> childs = findChilds(taskRun)
-            .stream()
-            .filter(r -> r.getValue() != null)
-            .collect(Collectors.toList());
-
-        if (childs.size() == 0) {
-            if (taskRun.getValue() == null) {
-                return Map.of(taskRun.getTaskId(), taskRun.getOutputs());
-            } else {
-                return Map.of(taskRun.getTaskId(), Map.of(taskRun.getValue(), taskRun.getOutputs()));
-            }
+        if (taskRun.getValue() == null) {
+            return Map.of(taskRun.getTaskId(), taskRun.getOutputs());
+        } else {
+            return Map.of(taskRun.getTaskId(), Map.of(taskRun.getValue(), taskRun.getOutputs()));
         }
-
-        Map<String, Object> result = new HashMap<>();
-        Map<String, Object> current = result;
-
-        for (TaskRun t : childs) {
-            if (t.getValue() != null) {
-                HashMap<String, Object> item = new HashMap<>();
-                current.put(t.getValue(), item);
-                current = item;
-            }
-        }
-
-        if (taskRun.getOutputs() != null) {
-            if (taskRun.getValue() != null) {
-                current.put(taskRun.getValue(), taskRun.getOutputs());
-            } else {
-                current.putAll(taskRun.getOutputs());
-            }
-        }
-
-        return Map.of(taskRun.getTaskId(), result);
     }
 
 
@@ -694,7 +667,7 @@ public class Execution implements DeletedInterface {
      */
     public List<TaskRun> findChilds(TaskRun taskRun) {
         if (taskRun.getParentTaskRunId() == null) {
-            return new ArrayList<>();
+            return Collections.emptyList();
         }
 
         ArrayList<TaskRun> result = new ArrayList<>();


### PR DESCRIPTION
The main performance issue was the usage of the `MapUtils.merge()` at line 618, it seems un-necessary as each taskrun has its outputs prefixed by the taskRun ID so there is no risk of clash.

I also remove most of the code of the `Execution.outputs(Taskrun)` because looking at the code it seems noop (an empty map is overriding the existing map for each tasks ...).

Following is a CPU profile for an execution with 1000 taskruns, it shows that 30% of CPU usage is in the `MapUtils.merge()` so if it can be removed it will save a lot of CPU time.

![image](https://github.com/kestra-io/kestra/assets/1819009/423a2bfe-12a7-47fb-b535-499fc4a95201)

