### PR TITLE
fix(jdbc-postgres): drop the queues_pk and use an hash index instead

### DIFF
--- a/jdbc-postgres/src/main/resources/migrations/postgres/V1_3__postgres-queues-pkey.sql
+++ b/jdbc-postgres/src/main/resources/migrations/postgres/V1_3__postgres-queues-pkey.sql
@@ -1,0 +1,5 @@
+-- We drop the PK, otherwise its index is used by the poll query which is sub-optimal.
+-- We create an hash index on offset that will be used instead when filtering on offset.
+ALTER TABLE queues DROP CONSTRAINT IF EXISTS queues_pkey;
+
+CREATE INDEX IF NOT EXISTS queues_offset ON queues USING hash ("offset");


### PR DESCRIPTION
This avoids the queues_pkey index to be used by the poll query which is suboptimal.
