### PR TITLE
feat(core): shortcircuit variable rendering when it's not a template

### DIFF
--- a/core/src/main/java/io/kestra/core/runners/VariableRenderer.java
+++ b/core/src/main/java/io/kestra/core/runners/VariableRenderer.java
@@ -97,6 +97,11 @@ public class VariableRenderer {
             return null;
         }
 
+        if (inline.indexOf('{') == -1) {
+            // it's not a Pebble template so we short-circuit rendering
+            return inline;
+        }
+
         // pre-process raw tags
         Matcher rawMatcher = RAW_PATTERN.matcher(inline);
         Map<String, String> replacers = new HashMap<>((int) Math.ceil(rawMatcher.groupCount() / 0.75));


### PR DESCRIPTION
This avoids a lot of allocation so improves performance when there is a lot of variable rendering that doesn't contain a template.

On a contrived benchmark, variable rendering cause up to 30% of allocations, with the fix down to 0 (as all variables are not templates).

![image](https://github.com/kestra-io/kestra/assets/1819009/3773b861-c81a-41d1-a51d-fb31afdc9396)
