### PR TITLE
feat(core): improve performance for flowable tasks methods

### DIFF
--- a/core/src/main/java/io/kestra/core/models/executions/Execution.java
+++ b/core/src/main/java/io/kestra/core/models/executions/Execution.java
@@ -290,7 +290,6 @@ public class Execution implements DeletedInterface {
             .findFirst();
     }
 
-    @SuppressWarnings("UnstableApiUsage")
     public Optional<TaskRun> findLastNotTerminated() {
         if (this.taskRunList == null) {
             return Optional.empty();
@@ -302,37 +301,29 @@ public class Execution implements DeletedInterface {
         );
     }
 
-    @SuppressWarnings("UnstableApiUsage")
-    public Optional<TaskRun> findLastByState(List<ResolvedTask> resolvedTasks, State.Type state, TaskRun taskRun) {
-        return Streams.findLast(this.findTaskRunByTasks(resolvedTasks, taskRun)
+    public Optional<TaskRun> findLastByState(List<TaskRun> taskRuns, State.Type state) {
+        return Streams.findLast(taskRuns
             .stream()
             .filter(t -> t.getState().getCurrent() == state)
         );
     }
 
-    @SuppressWarnings("UnstableApiUsage")
-    public Optional<TaskRun> findLastCreated(List<ResolvedTask> resolvedTasks, TaskRun taskRun) {
-        return Streams.findLast(this.findTaskRunByTasks(resolvedTasks, taskRun)
+    public Optional<TaskRun> findLastCreated(List<TaskRun> taskRuns) {
+        return Streams.findLast(taskRuns
             .stream()
             .filter(t -> t.getState().isCreated())
         );
     }
 
-    @SuppressWarnings("UnstableApiUsage")
-    public Optional<TaskRun> findLastRunning(List<ResolvedTask> resolvedTasks, TaskRun taskRun) {
-        return Streams.findLast(this.findTaskRunByTasks(resolvedTasks, taskRun)
+    public Optional<TaskRun> findLastRunning(List<TaskRun> taskRuns) {
+        return Streams.findLast(taskRuns
             .stream()
             .filter(t -> t.getState().isRunning())
         );
     }
 
-    public Optional<TaskRun> findLastTerminated(List<ResolvedTask> resolvedTasks, TaskRun taskRun) {
-        List<TaskRun> taskRuns = this.findTaskRunByTasks(resolvedTasks, taskRun);
-
-        ArrayList<TaskRun> reverse = new ArrayList<>(taskRuns);
-        Collections.reverse(reverse);
-
-        return Streams.findLast(this.findTaskRunByTasks(resolvedTasks, taskRun)
+    public Optional<TaskRun> findLastTerminated(List<TaskRun> taskRuns) {
+        return Streams.findLast(taskRuns
             .stream()
             .filter(t -> t.getState().isTerminated())
         );
@@ -415,19 +406,20 @@ public class Execution implements DeletedInterface {
     }
 
     public State.Type guessFinalState(List<ResolvedTask> currentTasks, TaskRun parentTaskRun) {
+        List<TaskRun> taskRuns = this.findTaskRunByTasks(currentTasks, parentTaskRun);
         return this
-            .findLastByState(currentTasks, State.Type.KILLED, parentTaskRun)
+            .findLastByState(taskRuns, State.Type.KILLED)
             .map(taskRun -> taskRun.getState().getCurrent())
             .or(() -> this
-                .findLastByState(currentTasks, State.Type.FAILED, parentTaskRun)
+                .findLastByState(taskRuns, State.Type.FAILED)
                 .map(taskRun -> taskRun.getState().getCurrent())
             )
             .or(() -> this
-                .findLastByState(currentTasks, State.Type.WARNING, parentTaskRun)
+                .findLastByState(taskRuns, State.Type.WARNING)
                 .map(taskRun -> taskRun.getState().getCurrent())
             )
             .or(() -> this
-                .findLastByState(currentTasks, State.Type.PAUSED, parentTaskRun)
+                .findLastByState(taskRuns, State.Type.PAUSED)
                 .map(taskRun -> taskRun.getState().getCurrent())
             )
             .orElse(State.Type.SUCCESS);

--- a/core/src/main/java/io/kestra/core/runners/ExecutorService.java
+++ b/core/src/main/java/io/kestra/core/runners/ExecutorService.java
@@ -10,6 +10,7 @@ import io.kestra.core.models.executions.TaskRunAttempt;
 import io.kestra.core.models.flows.Flow;
 import io.kestra.core.models.flows.State;
 import io.kestra.core.models.tasks.FlowableTask;
+import io.kestra.core.models.tasks.Output;
 import io.kestra.core.models.tasks.ResolvedTask;
 import io.kestra.core.models.tasks.Task;
 import io.kestra.core.services.ConditionService;
@@ -272,11 +273,8 @@ public class ExecutorService {
                         t.getTaskRun()
                     );
 
-                    taskRun = taskRun.withOutputs(
-                        flowableTask.outputs(runContext, executor.getExecution(), parentTaskRun) != null ?
-                            flowableTask.outputs(runContext, executor.getExecution(), parentTaskRun).toMap() :
-                            ImmutableMap.of()
-                    );
+                    Output outputs = flowableTask.outputs(runContext, executor.getExecution(), parentTaskRun);
+                    taskRun = taskRun.withOutputs(outputs != null ? outputs.toMap() : ImmutableMap.of());
                 } catch (Exception e) {
                     executor.getFlow().logger().warn("Unable to save output on taskRun '{}'", taskRun, e);
                 }

--- a/core/src/main/java/io/kestra/core/runners/FlowableUtils.java
+++ b/core/src/main/java/io/kestra/core/runners/FlowableUtils.java
@@ -64,19 +64,19 @@ public class FlowableUtils {
         }
 
         // first created, leave
-        Optional<TaskRun> lastCreated = execution.findLastCreated(currentTasks, parentTaskRun);
+        Optional<TaskRun> lastCreated = execution.findLastCreated(taskRuns);
         if (lastCreated.isPresent()) {
             return Collections.emptyList();
         }
 
         // have running, leave
-        Optional<TaskRun> lastRunning = execution.findLastRunning(currentTasks, parentTaskRun);
+        Optional<TaskRun> lastRunning = execution.findLastRunning(taskRuns);
         if (lastRunning.isPresent()) {
             return Collections.emptyList();
         }
 
         // last success, find next
-        Optional<TaskRun> lastTerminated = execution.findLastTerminated(currentTasks, parentTaskRun);
+        Optional<TaskRun> lastTerminated = execution.findLastTerminated(taskRuns);
         if (lastTerminated.isPresent()) {
             int lastIndex = taskRuns.indexOf(lastTerminated.get());
 
@@ -236,7 +236,7 @@ public class FlowableUtils {
         }
 
         // first created, leave
-        Optional<TaskRun> lastCreated = execution.findLastCreated(currentTasks, parentTaskRun);
+        Optional<TaskRun> lastCreated = execution.findLastCreated(taskRuns);
 
         if (!notFinds.isEmpty() && lastCreated.isEmpty()) {
             Stream<NextTaskRun> nextTaskRunStream = notFinds


### PR DESCRIPTION
Flowable tasks methods `resolveSequentialNext` and `resolveState` call multiple times `Execution.findTaskRunByTasks` which is a slow operation. This refactoring avoid some of these duplication and grealy improve perfrormance when an execution has a lot of task runs.

On contrieved benchmarks with more than 1000 task runs `ExecutorService.process` goes down from 50% of CPU time to 20%

**BEFORE**
![image](https://github.com/kestra-io/kestra/assets/1819009/1e71503b-8560-4a30-83ad-30840dcb7b24)

**AFTER**
![image](https://github.com/kestra-io/kestra/assets/1819009/743e97c2-e97a-40fe-8b0a-b1583e3065a4)



