### PR TITLE
fix(): add taskrun values inside workerDirectory task

### DIFF
--- a/core/src/main/java/io/kestra/core/runners/RunContext.java
+++ b/core/src/main/java/io/kestra/core/runners/RunContext.java
@@ -426,12 +426,18 @@ public class RunContext {
         return forScheduler(workerTrigger.getTriggerContext(), workerTrigger.getTrigger());
     }
 
-    public RunContext withWorkerDirectoryTaskrun() {
+    public RunContext forWorkerDirectory(ApplicationContext applicationContext, WorkerTask workerTask) {
+        forWorker(applicationContext, workerTask);
+
         Map<String, Object> clone = new HashMap<>(this.variables);
 
         clone.put("workerTaskrun", clone.get("taskrun"));
-        clone.put("parents", clone.get("parents"));
-        clone.put("parent", clone.get("parent"));
+        if (clone.containsKey("parents")) {
+            clone.put("parents", clone.get("parents"));
+        }
+        if (clone.containsKey("parent")) {
+            clone.put("parent", clone.get("parent"));
+        }
 
         this.variables = ImmutableMap.copyOf(clone);
 

--- a/core/src/main/java/io/kestra/core/runners/RunContext.java
+++ b/core/src/main/java/io/kestra/core/runners/RunContext.java
@@ -426,6 +426,18 @@ public class RunContext {
         return forScheduler(workerTrigger.getTriggerContext(), workerTrigger.getTrigger());
     }
 
+    public RunContext withWorkerDirectoryTaskrun() {
+        Map<String, Object> clone = new HashMap<>(this.variables);
+
+        clone.put("workerTaskrun", clone.get("taskrun"));
+        clone.put("parents", clone.get("parents"));
+        clone.put("parent", clone.get("parent"));
+
+        this.variables = ImmutableMap.copyOf(clone);
+
+        return this;
+    }
+
     public String render(String inline) throws IllegalVariableEvaluationException {
         return variableRenderer.render(inline, this.variables);
     }

--- a/core/src/main/java/io/kestra/core/runners/Worker.java
+++ b/core/src/main/java/io/kestra/core/runners/Worker.java
@@ -158,11 +158,10 @@ public class Worker implements Runnable, AutoCloseable {
                     if (Boolean.TRUE.equals(currentTask.getDisabled())) {
                         continue;
                     }
-
                     WorkerTask currentWorkerTask = workingDirectory.workerTask(
                         workerTask.getTaskRun(),
                         currentTask,
-                        runContext
+                        runContext.withWorkerDirectoryTaskrun()
                     );
 
                     // all tasks will be handled immediately by the worker

--- a/core/src/main/java/io/kestra/core/runners/Worker.java
+++ b/core/src/main/java/io/kestra/core/runners/Worker.java
@@ -149,7 +149,7 @@ public class Worker implements Runnable, AutoCloseable {
         if (workerTask.getTask() instanceof RunnableTask) {
             this.run(workerTask, true);
         } else if (workerTask.getTask() instanceof WorkingDirectory workingDirectory) {
-            RunContext runContext = workerTask.getRunContext().forWorker(applicationContext, workerTask);
+            RunContext runContext = workerTask.getRunContext().forWorkerDirectory(applicationContext, workerTask);
 
             try {
                 workingDirectory.preExecuteTasks(runContext, workerTask.getTaskRun());
@@ -161,7 +161,7 @@ public class Worker implements Runnable, AutoCloseable {
                     WorkerTask currentWorkerTask = workingDirectory.workerTask(
                         workerTask.getTaskRun(),
                         currentTask,
-                        runContext.withWorkerDirectoryTaskrun()
+                        runContext
                     );
 
                     // all tasks will be handled immediately by the worker

--- a/core/src/test/java/io/kestra/core/tasks/flows/WorkingDirectoryTest.java
+++ b/core/src/test/java/io/kestra/core/tasks/flows/WorkingDirectoryTest.java
@@ -4,6 +4,7 @@ import com.google.common.collect.ImmutableMap;
 import io.kestra.core.models.executions.Execution;
 import io.kestra.core.models.flows.State;
 import io.kestra.core.runners.AbstractMemoryRunnerTest;
+import io.kestra.core.runners.RunContextFactory;
 import io.kestra.core.runners.RunnerUtils;
 import io.kestra.core.storages.StorageInterface;
 import jakarta.inject.Inject;
@@ -41,6 +42,11 @@ public class WorkingDirectoryTest extends AbstractMemoryRunnerTest {
     @Test
     void cache() throws TimeoutException, IOException {
         suite.cache(runnerUtils);
+    }
+
+    @Test
+    void taskrun() throws TimeoutException {
+        suite.taskRun(runnerUtils);
     }
 
     @Singleton
@@ -92,6 +98,15 @@ public class WorkingDirectoryTest extends AbstractMemoryRunnerTest {
 
             assertThat(execution.getTaskRunList(), hasSize(2));
             assertThat(execution.getState().getCurrent(), is(State.Type.FAILED));
+        }
+
+        public void taskRun(RunnerUtils runnerUtils) throws TimeoutException {
+            Execution execution = runnerUtils.runOne(null, "io.kestra.tests", "working-directory-taskrun");
+
+            assertThat(execution.getTaskRunList(), hasSize(6));
+            assertThat(execution.getState().getCurrent(), is(State.Type.SUCCESS));
+            assertThat(((String) execution.getTaskRunList().get(5).getOutputs().get("value")), containsString("{\"taskrun\":{\"value\":\"1\"}}"));
+
         }
     }
 }

--- a/core/src/test/resources/flows/valids/working-directory-taskrun.yml
+++ b/core/src/test/resources/flows/valids/working-directory-taskrun.yml
@@ -1,0 +1,23 @@
+id: working-directory-taskrun
+namespace: io.kestra.tests
+
+tasks:
+  - id: parallel
+    type: io.kestra.core.tasks.flows.EachParallel
+    value: ["1"]
+    tasks:
+      - id: seq
+        type: io.kestra.core.tasks.flows.Sequential
+        tasks:
+          - id: workingDir
+            type: io.kestra.core.tasks.flows.WorkingDirectory
+            tasks:
+              - id: log-taskrun
+                type: io.kestra.core.tasks.debugs.Return
+                format: "{{ workerTaskrun }}"
+              - id: log-workerparents
+                type: io.kestra.core.tasks.debugs.Return
+                format:  "{{ parents }}"
+              - id: log-workerparent
+                type: io.kestra.core.tasks.debugs.Return
+                format:  "{{ parent }}"


### PR DESCRIPTION
The issue here is that when in a workerDirectory, we don't follow the usual paths [here](https://github.com/kestra-io/kestra/blob/4a1a8a2515dcf0931c95b2fca57407df46b28a2e/core/src/main/java/io/kestra/core/runners/ExecutorService.java#L226), the parents & parent variable isn't provided

So when we pass in[ this method](https://github.com/kestra-io/kestra/blob/4a1a8a2515dcf0931c95b2fca57407df46b28a2e/core/src/main/java/io/kestra/core/runners/RunContext.java#L403), the variable taskrun is erased.

So, in my solution, when creating children tasks inside the worker, I create a new workerTaskrun with taskRun (maybe useless, but at least the data are here), and copy parents and parent of the workerDirectory.

close #1809
