### PR TITLE
Select character encoding for file preview

### DIFF
--- a/ui/src/components/executions/FilePreview.vue
+++ b/ui/src/components/executions/FilePreview.vue
@@ -14,7 +14,7 @@
             <h3>{{ $t("preview") }}</h3>
         </template>
         <template #default>
-            <el-alert v-if="filePreview.truncated"  show-icon type="warning" :closable="false" class="mb-2">
+            <el-alert v-if="filePreview.truncated" show-icon type="warning" :closable="false" class="mb-2">
                 {{ $t('file preview truncated') }}
             </el-alert>
             <list-preview v-if="filePreview.type === 'LIST'" :value="filePreview.content" />
@@ -36,6 +36,23 @@
                             :key="item"
                             :label="item"
                             :value="item"
+                        />
+                    </el-select>
+                </el-form-item>
+                <el-form-item :label="$t('encoding')">
+                    <el-select
+                        v-model="encoding"
+                        filterable
+                        clearable
+                        :required="true"
+                        :persistent="false"
+                        @change="getFilePreview"
+                    >
+                        <el-option
+                            v-for="item in encodingOptions"
+                            :key="item.value"
+                            :label="item.label"
+                            :value="item.value"
                         />
                     </el-select>
                 </el-form-item>
@@ -71,10 +88,21 @@
                 isPreviewOpen: false,
                 selectedPreview: null,
                 maxPreview: undefined,
+                encoding: undefined,
+                encodingOptions: [
+                    {value: "UTF-8", label: "UTF-8"},
+                    {value: "ISO-8859-1", label: "ISO-8859-1/Latin-1"},
+                    {value: "Cp1250", label: "Windows 1250"},
+                    {value: "Cp1251", label: "Windows 1251"},
+                    {value: "Cp1252", label: "Windows 1252"},
+                    {value: "UTF-16", label: "UTF-16"},
+                    {value: "Cp500", label: "EBCDIC IBM-500"},
+                ]
             }
         },
         mounted() {
             this.maxPreview = this.configs.preview.initial;
+            this.encoding = this.encodingOptions[0];
         },
         computed: {
             ...mapState("execution", ["filePreview"]),
@@ -113,7 +141,8 @@
                     .dispatch("execution/filePreview", {
                         executionId: this.executionId,
                         path: this.value,
-                        maxRows: this.maxPreview
+                        maxRows: this.maxPreview,
+                        encoding: this.encoding
                     })
                     .then(() => {
                         this.isPreviewOpen = true;

--- a/ui/src/components/executions/FilePreview.vue
+++ b/ui/src/components/executions/FilePreview.vue
@@ -22,7 +22,7 @@
             <markdown v-else-if="filePreview.type === 'MARKDOWN'" :source="filePreview.content" />
             <editor v-else :full-height="false" :input="true" :navbar="false" :model-value="filePreview.content" :lang="extensionToMonacoLang" read-only />
             <el-form class="ks-horizontal max-size mt-3">
-                <el-form-item :label="$t('show')">
+                <el-form-item :label="$t('row count')">
                     <el-select
                         v-model="maxPreview"
                         filterable

--- a/ui/src/translations.json
+++ b/ui/src/translations.json
@@ -514,8 +514,8 @@
     "management port": "Management port",
     "file preview truncated": "Displayed content has been truncated",
     "show": "Show",
+    "encoding": "Encoding",
     "advanced configuration": "Advanced configuration",
-    "encoding": "Encoding"
   },
   "fr": {
     "id": "Identifiant",

--- a/ui/src/translations.json
+++ b/ui/src/translations.json
@@ -513,9 +513,10 @@
     "port": "Port",
     "management port": "Management port",
     "file preview truncated": "Displayed content has been truncated",
-    "show": "Show",
+    "row count": "Row count",
     "encoding": "Encoding",
-    "advanced configuration": "Advanced configuration",
+    "show": "Show",
+    "advanced configuration": "Advanced configuration"
   },
   "fr": {
     "id": "Identifiant",
@@ -1021,9 +1022,10 @@
     "port": "Port",
     "management port": "Port de gestion",
     "file preview truncated": "Displayed content has been truncated",
-    "show": "Voir",
+    "show": "Afficher",
     "advanced configuration": "Configuration avancée",
-    "encoding": "Encoding"
+    "row count": "Nombre de lignes",
+    "encoding": "Encodage"
   }
 }
 

--- a/ui/src/translations.json
+++ b/ui/src/translations.json
@@ -514,7 +514,8 @@
     "management port": "Management port",
     "file preview truncated": "Displayed content has been truncated",
     "show": "Show",
-    "advanced configuration": "Advanced configuration"
+    "advanced configuration": "Advanced configuration",
+    "encoding": "Encoding"
   },
   "fr": {
     "id": "Identifiant",
@@ -1021,7 +1022,8 @@
     "management port": "Port de gestion",
     "file preview truncated": "Displayed content has been truncated",
     "show": "Voir",
-    "advanced configuration": "Configuration avancée"
+    "advanced configuration": "Configuration avancée",
+    "encoding": "Encoding"
   }
 }
 

--- a/webserver/src/main/java/io/kestra/webserver/utils/filepreview/DefaultFileRender.java
+++ b/webserver/src/main/java/io/kestra/webserver/utils/filepreview/DefaultFileRender.java
@@ -6,25 +6,26 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.nio.charset.Charset;
 
 @Getter
 public class DefaultFileRender extends FileRender {
-    DefaultFileRender(String extension, InputStream filestream, Integer maxLine) throws IOException {
+    DefaultFileRender(String extension, InputStream filestream, Charset charset, Integer maxLine) throws IOException {
         super(extension, maxLine);
-        renderContent(filestream);
+        renderContent(filestream, charset);
 
         this.type = Type.TEXT;
     }
 
-    DefaultFileRender(String extension, InputStream filestream, Type type, Integer maxLine) throws IOException {
+    DefaultFileRender(String extension, InputStream filestream, Charset charset, Type type, Integer maxLine) throws IOException {
         super(extension, maxLine);
-        renderContent(filestream);
+        renderContent(filestream, charset);
 
         this.type = type;
     }
 
-    private void renderContent(InputStream fileStream) throws IOException {
-        BufferedReader reader = new BufferedReader(new InputStreamReader(fileStream));
+    private void renderContent(InputStream fileStream, Charset charset) throws IOException {
+        BufferedReader reader = new BufferedReader(new InputStreamReader(fileStream, charset));
         String line = reader.readLine();
         int lineCount = 0;
 

--- a/webserver/src/main/java/io/kestra/webserver/utils/filepreview/FileRenderBuilder.java
+++ b/webserver/src/main/java/io/kestra/webserver/utils/filepreview/FileRenderBuilder.java
@@ -2,17 +2,22 @@ package io.kestra.webserver.utils.filepreview;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.util.Optional;
 
 public class FileRenderBuilder {
-    public static FileRender of(String extension, InputStream filestream, Integer maxLine) throws IOException {
+    private static final Charset DEFAULT_FILE_CHARSET = StandardCharsets.UTF_8;
+
+    public static FileRender of(String extension, InputStream filestream, Optional<Charset> charset, Integer maxLine) throws IOException {
         if (ImageFileRender.ImageFileExtension.isImageFileExtension(extension)) {
             return new ImageFileRender(extension, filestream, maxLine);
         }
 
         return switch (extension) {
             case "ion" -> new IonFileRender(extension, filestream, maxLine);
-            case "md" -> new DefaultFileRender(extension, filestream, FileRender.Type.MARKDOWN, maxLine);
-            default -> new DefaultFileRender(extension, filestream, maxLine);
+            case "md" -> new DefaultFileRender(extension, filestream, DEFAULT_FILE_CHARSET, FileRender.Type.MARKDOWN, maxLine);
+            default -> new DefaultFileRender(extension, filestream, charset.orElse(DEFAULT_FILE_CHARSET), maxLine);
         };
     }
 }

--- a/webserver/src/test/java/io/kestra/webserver/utils/filepreview/DefaultFileRenderTest.java
+++ b/webserver/src/test/java/io/kestra/webserver/utils/filepreview/DefaultFileRenderTest.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.params.provider.CsvSource;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -16,14 +17,16 @@ class DefaultFileRenderTest {
     @CsvSource({"0, false", "100, false", "101, true"})
     void testTruncatedByLineCount(int lineCount, boolean truncated) throws IOException {
         final String line = "foo\n";
+        final Charset charset = StandardCharsets.UTF_8;
         StringBuilder contentBuffer = new StringBuilder(lineCount * line.length());
 
         for (int i = 0; i < lineCount; i++) {
             contentBuffer.append(line);
         }
-        InputStream is = new ByteArrayInputStream(contentBuffer.toString().getBytes(StandardCharsets.UTF_8));
 
-        DefaultFileRender render = new DefaultFileRender("txt", is, 100);
+        InputStream is = new ByteArrayInputStream(contentBuffer.toString().getBytes(charset));
+
+        DefaultFileRender render = new DefaultFileRender("txt", is, charset, 100);
 
         assertThat(render.truncated, is(truncated));
     }
@@ -32,14 +35,15 @@ class DefaultFileRenderTest {
     @CsvSource({"0, false", "1024, false", "3072, true"})
     void testTruncatedBySize(int sizeInKibiBytes, boolean truncated) throws IOException {
         final int sizeInBytes = sizeInKibiBytes * 1024;
+        final Charset charset = StandardCharsets.UTF_8;
         StringBuilder contentBuffer = new StringBuilder(sizeInBytes);
 
         for (int i = 0; i < sizeInBytes; i++) {
             contentBuffer.append("0");
         }
-        InputStream is = new ByteArrayInputStream(contentBuffer.toString().getBytes(StandardCharsets.UTF_8));
+        InputStream is = new ByteArrayInputStream(contentBuffer.toString().getBytes(charset));
 
-        DefaultFileRender render = new DefaultFileRender("txt", is, 100);
+        DefaultFileRender render = new DefaultFileRender("txt", is, charset, 100);
 
         assertThat(render.truncated, is(truncated));
     }

--- a/webserver/src/test/resources/data/iso88591.txt
+++ b/webserver/src/test/resources/data/iso88591.txt
@@ -1,0 +1,1 @@
+Düsseldorf


### PR DESCRIPTION
* Generic files might be encoded/previewed using various code pages (such as IBM-500).
* Common encoding options were selected.