### PR TITLE
feat: add a tenant tag in the runcontext metrics

### DIFF
--- a/core/src/main/java/io/kestra/core/runners/RunContext.java
+++ b/core/src/main/java/io/kestra/core/runners/RunContext.java
@@ -711,9 +711,13 @@ public class RunContext {
         ImmutableMap.Builder<String, String> builder = ImmutableMap.<String, String>builder();
 
         if (this.variables.containsKey("flow")) {
+            var flowVars = ((Map<String, String>) this.variables.get("flow"));
             builder
-                .put(MetricRegistry.TAG_FLOW_ID, ((Map<String, String>) this.variables.get("flow")).get("id"))
-                .put(MetricRegistry.TAG_NAMESPACE_ID, ((Map<String, String>) this.variables.get("flow")).get("namespace"));
+                .put(MetricRegistry.TAG_FLOW_ID, flowVars.get("id"))
+                .put(MetricRegistry.TAG_NAMESPACE_ID, flowVars.get("namespace"));
+            if (flowVars.containsKey("tenantId")) {
+                builder.put(MetricRegistry.TAG_TENANT_ID, flowVars.get("tenantId"));
+            }
         }
 
         return builder.build();

--- a/core/src/main/java/io/kestra/core/runners/Worker.java
+++ b/core/src/main/java/io/kestra/core/runners/Worker.java
@@ -332,8 +332,7 @@ public class Worker implements Runnable, AutoCloseable {
                             MetricRegistry.METRIC_WORKER_RETRYED_COUNT,
                             metricRegistry.tags(
                                 current.get(),
-                                MetricRegistry.TAG_ATTEMPT_COUNT, String.valueOf(e.getAttemptCount()),
-                                MetricRegistry.TAG_WORKER_GROUP, workerGroup
+                                MetricRegistry.TAG_ATTEMPT_COUNT, String.valueOf(e.getAttemptCount())
                             )
                         )
                         .increment();
@@ -663,8 +662,7 @@ public class Worker implements Runnable, AutoCloseable {
                                     MetricRegistry.METRIC_WORKER_TIMEOUT_COUNT,
                                     metricRegistry.tags(
                                         this.workerTask,
-                                        MetricRegistry.TAG_ATTEMPT_COUNT, String.valueOf(event.getAttemptCount()),
-                                        MetricRegistry.TAG_WORKER_GROUP, workerGroup
+                                        MetricRegistry.TAG_ATTEMPT_COUNT, String.valueOf(event.getAttemptCount())
                                     )
                                 )
                                 .increment()


### PR DESCRIPTION
Also avoid double put of the worker group tag from the Worker
