### PR TITLE
fet(core): add validation to the Webhook trigger

### DIFF
--- a/core/src/main/java/io/kestra/core/models/triggers/types/Webhook.java
+++ b/core/src/main/java/io/kestra/core/models/triggers/types/Webhook.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.kestra.core.models.annotations.PluginProperty;
+import io.kestra.core.validations.WebhookValidation;
 import io.micronaut.http.HttpRequest;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.*;
@@ -32,10 +33,10 @@ import javax.validation.constraints.Size;
 @Schema(
     title = "Trigger a flow from a webhook",
     description = """
-        Webhook trigger allows you to create a unique URL that you can use to trigger a Kestra flow execution based on a presence of events in another application such as GitHub or Amazon EventBridge. In order to use that URL, you have to add a secret key that will secure your webhook URL. 
-        
+        Webhook trigger allows you to create a unique URL that you can use to trigger a Kestra flow execution based on a presence of events in another application such as GitHub or Amazon EventBridge. In order to use that URL, you have to add a secret key that will secure your webhook URL.
+
         The URL will then follow the following format: `https://{your_hostname}/api/v1/executions/webhook/{namespace}/{flowId}/{key}`. Replace the templated values accordingly to your workflow setup.
-        
+
         The webhook URL accepts `GET`, `POST` and `PUT` requests.
 
         You can access the request body and headers sent by another application using the following template variables:
@@ -45,7 +46,9 @@ import javax.validation.constraints.Size;
         The webhook response will be one of the following HTTP status codes:
         - 404 if the namespace, flow or webhook key is not found
         - 200 if the webhook triggers an execution
-        - 204 if the webhook cannot trigger an execution due to a lack of matching event conditions sent by other application."""
+        - 204 if the webhook cannot trigger an execution due to a lack of matching event conditions sent by other application.
+
+        A Webhook trigger can have conditions but it didn't support conditions of type `MultipleCondition`."""
 )
 @Plugin(
     examples = {
@@ -76,6 +79,7 @@ import javax.validation.constraints.Size;
         )
     }
 )
+@WebhookValidation
 public class Webhook extends AbstractTrigger implements TriggerOutput<Webhook.Output> {
     @Size(max = 256)
     @NotNull

--- a/core/src/main/java/io/kestra/core/validations/ValidationFactory.java
+++ b/core/src/main/java/io/kestra/core/validations/ValidationFactory.java
@@ -2,11 +2,13 @@ package io.kestra.core.validations;
 
 import com.cronutils.model.Cron;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.kestra.core.models.conditions.types.MultipleCondition;
 import io.kestra.core.models.flows.Flow;
 import io.kestra.core.models.flows.Input;
 import io.kestra.core.models.tasks.RunnableTask;
 import io.kestra.core.models.tasks.Task;
 import io.kestra.core.models.tasks.WorkerGroup;
+import io.kestra.core.models.triggers.types.Webhook;
 import io.kestra.core.tasks.flows.Dag;
 import io.kestra.core.tasks.flows.Switch;
 import io.kestra.core.tasks.flows.WorkingDirectory;
@@ -277,6 +279,25 @@ public class ValidationFactory {
 
             context.messageTemplate("Worker Group is an Enterprise Edition functionality");
             return false;
+        };
+    }
+
+    @Singleton
+    ConstraintValidator<WebhookValidation, Webhook> webhookValidator() {
+        return (value, annotationMetadata, context) -> {
+            if (value == null) {
+                return true;
+            }
+
+            if (value.getConditions() != null) {
+                if (value.getConditions().stream().anyMatch(condition -> condition instanceof MultipleCondition)) {
+                    context.messageTemplate("invalid webhook: conditions of type MultipleCondition are not supported");
+
+                    return false;
+                }
+            }
+
+            return true;
         };
     }
 }

--- a/core/src/main/java/io/kestra/core/validations/WebhookValidation.java
+++ b/core/src/main/java/io/kestra/core/validations/WebhookValidation.java
@@ -1,0 +1,11 @@
+package io.kestra.core.validations;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import javax.validation.Constraint;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Constraint(validatedBy = { })
+public @interface WebhookValidation {
+    String message() default "invalid webhook ({validatedValue})";
+}

--- a/core/src/test/java/io/kestra/core/validations/WebhookTest.java
+++ b/core/src/test/java/io/kestra/core/validations/WebhookTest.java
@@ -1,0 +1,37 @@
+package io.kestra.core.validations;
+
+import io.kestra.core.models.conditions.types.MultipleCondition;
+import io.kestra.core.models.triggers.types.Webhook;
+import io.kestra.core.models.validations.ModelValidator;
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
+
+@MicronautTest
+public class WebhookTest {
+    @Inject
+    private ModelValidator modelValidator;
+
+    @Test
+    void webhookValidation()  {
+        var webhook = Webhook.builder()
+            .id("webhook")
+            .type(Webhook.class.getName())
+            .key("webhook")
+            .conditions(
+                List.of(
+                    MultipleCondition.builder().id("multiple").type(MultipleCondition.class.getName()).build()
+                )
+            )
+            .build();
+
+        assertThat(modelValidator.isValid(webhook).isPresent(), is(true));
+        assertThat(modelValidator.isValid(webhook).get().getMessage(), containsString("invalid webhook: conditions of type MultipleCondition are not supported"));
+    }
+}


### PR DESCRIPTION
Validate that a Webhook trigger cannot have a condition of type MultipleCondition as this is not supported.
