### PR TITLE
Removed small margin before first (or after last) item of Dropdowns

### DIFF
--- a/ui/src/styles/layout/element-plus-overload.scss
+++ b/ui/src/styles/layout/element-plus-overload.scss
@@ -464,6 +464,11 @@ form.ks-horizontal {
         display: flex;
         flex-direction: column;
         width: 20rem;
+        padding: 0;
+    }
+    
+    .el-dropdown-menu {
+        padding: 0;
     }
 
     // no longer require focus to get hover effect on dropdowns


### PR DESCRIPTION
Removed vertical padding from the dropdown-menu to remove unnecessary small margins before the first (or after the last) item