### PR TITLE
ForEachItem task

### DIFF
--- a/core/src/main/java/io/kestra/core/models/executions/TaskRun.java
+++ b/core/src/main/java/io/kestra/core/models/executions/TaskRun.java
@@ -10,7 +10,6 @@ import io.kestra.core.models.flows.State;
 import io.kestra.core.models.tasks.ResolvedTask;
 import io.kestra.core.utils.IdUtils;
 
-import java.net.URI;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -46,9 +45,6 @@ public class TaskRun {
     String value;
 
     @With
-    URI items;
-
-    @With
     List<TaskRunAttempt> attempts;
 
     @With
@@ -74,7 +70,6 @@ public class TaskRun {
             this.taskId,
             this.parentTaskRunId,
             this.value,
-            this.items,
             this.attempts,
             this.outputs,
             this.state.withState(state)
@@ -91,7 +86,6 @@ public class TaskRun {
             .taskId(this.getTaskId())
             .parentTaskRunId(this.getParentTaskRunId() != null ? remapTaskRunId.get(this.getParentTaskRunId()) : null)
             .value(this.getValue())
-            .items(this.getItems())
             .attempts(this.getAttempts())
             .outputs(this.getOutputs())
             .state(state == null ? this.getState() : state)

--- a/core/src/main/java/io/kestra/core/models/executions/TaskRun.java
+++ b/core/src/main/java/io/kestra/core/models/executions/TaskRun.java
@@ -53,6 +53,9 @@ public class TaskRun {
     @NotNull
     State state;
 
+    @With
+    String items;
+
     public void destroyOutputs() {
         // DANGER ZONE: this method is only used to deals with issues with messages too big that must be stripped down
         // to avoid crashing the platform. Don't use it for anything else.
@@ -72,7 +75,8 @@ public class TaskRun {
             this.value,
             this.attempts,
             this.outputs,
-            this.state.withState(state)
+            this.state.withState(state),
+            this.items
         );
     }
 
@@ -89,6 +93,7 @@ public class TaskRun {
             .attempts(this.getAttempts())
             .outputs(this.getOutputs())
             .state(state == null ? this.getState() : state)
+            .items(this.getItems())
             .build();
     }
 

--- a/core/src/main/java/io/kestra/core/models/executions/TaskRun.java
+++ b/core/src/main/java/io/kestra/core/models/executions/TaskRun.java
@@ -10,6 +10,7 @@ import io.kestra.core.models.flows.State;
 import io.kestra.core.models.tasks.ResolvedTask;
 import io.kestra.core.utils.IdUtils;
 
+import java.net.URI;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -41,7 +42,11 @@ public class TaskRun {
 
     String parentTaskRunId;
 
+    @With
     String value;
+
+    @With
+    URI items;
 
     @With
     List<TaskRunAttempt> attempts;
@@ -69,6 +74,7 @@ public class TaskRun {
             this.taskId,
             this.parentTaskRunId,
             this.value,
+            this.items,
             this.attempts,
             this.outputs,
             this.state.withState(state)
@@ -85,6 +91,7 @@ public class TaskRun {
             .taskId(this.getTaskId())
             .parentTaskRunId(this.getParentTaskRunId() != null ? remapTaskRunId.get(this.getParentTaskRunId()) : null)
             .value(this.getValue())
+            .items(this.getItems())
             .attempts(this.getAttempts())
             .outputs(this.getOutputs())
             .state(state == null ? this.getState() : state)
@@ -128,7 +135,7 @@ public class TaskRun {
     public TaskRun onRunningResend() {
         TaskRunBuilder taskRunBuilder = this.toBuilder();
 
-        if (taskRunBuilder.attempts == null || taskRunBuilder.attempts.size() == 0) {
+        if (taskRunBuilder.attempts == null || taskRunBuilder.attempts.isEmpty()) {
             taskRunBuilder.attempts = new ArrayList<>();
 
             taskRunBuilder.attempts.add(TaskRunAttempt.builder()
@@ -172,7 +179,7 @@ public class TaskRun {
             ", parentTaskRunId=" + this.getParentTaskRunId() +
             ", state=" + this.getState().getCurrent().toString() +
             ", outputs=" + this.getOutputs() +
-            ", attemps=" + this.getAttempts() +
+            ", attempts=" + this.getAttempts() +
             ")";
     }
 

--- a/core/src/main/java/io/kestra/core/models/hierarchies/SubflowGraphTask.java
+++ b/core/src/main/java/io/kestra/core/models/hierarchies/SubflowGraphTask.java
@@ -1,19 +1,19 @@
 package io.kestra.core.models.hierarchies;
 
 import io.kestra.core.models.executions.TaskRun;
-import io.kestra.core.tasks.flows.Flow;
+import io.kestra.core.models.tasks.ExecutableTask;
+import io.kestra.core.models.tasks.Task;
 import lombok.Getter;
 
 import java.util.List;
 
 @Getter
 public class SubflowGraphTask extends AbstractGraphTask {
-    public SubflowGraphTask(Flow task, TaskRun taskRun, List<String> values, RelationType relationType) {
-        super(task, taskRun, values, relationType);
+    public SubflowGraphTask(ExecutableTask task, TaskRun taskRun, List<String> values, RelationType relationType) {
+        super((Task) task, taskRun, values, relationType);
     }
 
-    @Override
-    public Flow getTask() {
-        return (Flow) super.getTask();
+    public ExecutableTask getExecutableTask() {
+        return (ExecutableTask) super.getTask();
     }
 }

--- a/core/src/main/java/io/kestra/core/models/tasks/ExecutableTask.java
+++ b/core/src/main/java/io/kestra/core/models/tasks/ExecutableTask.java
@@ -46,12 +46,12 @@ public interface ExecutableTask {
     record SubflowId(String namespace, String flowId, Optional<Integer> revision) {
         public String flowUid() {
             // as the Flow task can only be used in the same tenant we can hardcode null here
-            return io.kestra.core.models.flows.Flow.uid(null, this.namespace, this.flowId, this.revision);
+            return Flow.uid(null, this.namespace, this.flowId, this.revision);
         }
 
         public String flowUidWithoutRevision() {
             // as the Flow task can only be used in the same tenant we can hardcode null here
-            return io.kestra.core.models.flows.Flow.uidWithoutRevision(null, this.namespace, this.flowId);
+            return Flow.uidWithoutRevision(null, this.namespace, this.flowId);
         }
     }
 }

--- a/core/src/main/java/io/kestra/core/models/tasks/ExecutableTask.java
+++ b/core/src/main/java/io/kestra/core/models/tasks/ExecutableTask.java
@@ -1,6 +1,5 @@
 package io.kestra.core.models.tasks;
 
-import io.kestra.core.exceptions.IllegalVariableEvaluationException;
 import io.kestra.core.exceptions.InternalException;
 import io.kestra.core.models.executions.Execution;
 import io.kestra.core.models.executions.TaskRun;
@@ -13,15 +12,29 @@ import io.kestra.core.runners.WorkerTaskResult;
 import java.util.List;
 import java.util.Optional;
 
-public interface ExecutableTask<T extends Output>  {
-    List<TaskRun> createTaskRun(RunContext runContext, Execution currentExecution, TaskRun executionTaskRun);
+/**
+ * Interface for tasks that generates subflow execution(s). Those tasks are handled in the Executor.
+ */
+public interface ExecutableTask {
+    /**
+     * Creates a list of WorkerTaskExecution for this task definition.
+     * Each WorkerTaskExecution will generate a subflow execution.
+     */
+    List<WorkerTaskExecution<?>> createWorkerTaskExecutions(RunContext runContext,
+                                     FlowExecutorInterface flowExecutorInterface,
+                                     Flow currentFlow, Execution currentExecution,
+                                     TaskRun currentTaskRun) throws InternalException;
 
-    Execution createExecution(RunContext runContext, FlowExecutorInterface flowExecutorInterface, Execution currentExecution) throws InternalException;
+    /**
+     * Creates a WorkerTaskResult for a given WorkerTaskExecution
+     */
+    Optional<WorkerTaskResult> createWorkerTaskResult(RunContext runContext,
+                                                      WorkerTaskExecution<?> workerTaskExecution,
+                                                      Flow flow,
+                                                      Execution execution);
 
-    WorkerTaskResult createWorkerTaskResult(RunContext runContext,
-                                                     WorkerTaskExecution<?> workerTaskExecution,
-                                                     Flow flow,
-                                                     Execution execution);
-
+    /**
+     * Whether to wait for the execution(s) of the subflow before terminating this tasks
+     */
     boolean waitForExecution();
 }

--- a/core/src/main/java/io/kestra/core/models/tasks/ExecutableTask.java
+++ b/core/src/main/java/io/kestra/core/models/tasks/ExecutableTask.java
@@ -1,0 +1,27 @@
+package io.kestra.core.models.tasks;
+
+import io.kestra.core.exceptions.IllegalVariableEvaluationException;
+import io.kestra.core.exceptions.InternalException;
+import io.kestra.core.models.executions.Execution;
+import io.kestra.core.models.executions.TaskRun;
+import io.kestra.core.models.flows.Flow;
+import io.kestra.core.runners.FlowExecutorInterface;
+import io.kestra.core.runners.RunContext;
+import io.kestra.core.runners.WorkerTaskExecution;
+import io.kestra.core.runners.WorkerTaskResult;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface ExecutableTask<T extends Output>  {
+    List<TaskRun> createTaskRun(RunContext runContext, Execution currentExecution, TaskRun executionTaskRun);
+
+    Execution createExecution(RunContext runContext, FlowExecutorInterface flowExecutorInterface, Execution currentExecution) throws InternalException;
+
+    WorkerTaskResult createWorkerTaskResult(RunContext runContext,
+                                                     WorkerTaskExecution<?> workerTaskExecution,
+                                                     Flow flow,
+                                                     Execution execution);
+
+    boolean waitForExecution();
+}

--- a/core/src/main/java/io/kestra/core/models/tasks/ExecutableTask.java
+++ b/core/src/main/java/io/kestra/core/models/tasks/ExecutableTask.java
@@ -37,4 +37,21 @@ public interface ExecutableTask {
      * Whether to wait for the execution(s) of the subflow before terminating this tasks
      */
     boolean waitForExecution();
+
+    /**
+     * @return the subflow identifier, used by the flow topology and related dependency code.
+     */
+    SubflowId subflowId();
+
+    record SubflowId(String namespace, String flowId, Optional<Integer> revision) {
+        public String flowUid() {
+            // as the Flow task can only be used in the same tenant we can hardcode null here
+            return io.kestra.core.models.flows.Flow.uid(null, this.namespace, this.flowId, this.revision);
+        }
+
+        public String flowUidWithoutRevision() {
+            // as the Flow task can only be used in the same tenant we can hardcode null here
+            return io.kestra.core.models.flows.Flow.uidWithoutRevision(null, this.namespace, this.flowId);
+        }
+    }
 }

--- a/core/src/main/java/io/kestra/core/models/tasks/FlowableTask.java
+++ b/core/src/main/java/io/kestra/core/models/tasks/FlowableTask.java
@@ -14,6 +14,9 @@ import io.kestra.core.runners.RunContext;
 import java.util.List;
 import java.util.Optional;
 
+/**
+ * Interface for tasks that orchestrate other tasks. Those tasks are handled by the Executor.
+ */
 public interface FlowableTask <T extends Output> {
     @Schema(
         title = "List of tasks to run if any tasks failed on this FlowableTask"
@@ -21,14 +24,37 @@ public interface FlowableTask <T extends Output> {
     @PluginProperty
     List<Task> getErrors();
 
+    /**
+     * Create the topology representation of a flowable task.
+     * <p>
+     * A flowable task always contains subtask to it returns a cluster that displays the subtasks.
+     */
     GraphCluster tasksTree(Execution execution, TaskRun taskRun, List<String> parentValues) throws IllegalVariableEvaluationException;
 
+    /**
+     * @return all child tasks including errors
+     */
     List<Task> allChildTasks();
 
+    /**
+     * Resolve child tasks of a flowable task.
+     * <p>
+     * For a normal flowable, it should be the list of its tasks, for an iterative flowable (such as EachSequential, ForEachItem, ...),
+     * it should be the list of its tasks for all iterations.
+     */
     List<ResolvedTask> childTasks(RunContext runContext, TaskRun parentTaskRun) throws IllegalVariableEvaluationException;
 
+    /**
+     * Resolve next tasks to run for an execution.
+     * <p>
+     * For a normal flowable, it should be <b>the</b> subsequent task, for a parallel flowable (such as Parallel, ForEachItem, ...),
+     * it should be a list of the next subsequent tasks of the size of the concurrency of the task.
+     */
     List<NextTaskRun> resolveNexts(RunContext runContext, Execution execution, TaskRun parentTaskRun) throws IllegalVariableEvaluationException;
 
+    /**
+     * Resolve the state of a flowable task.
+     */
     default Optional<State.Type> resolveState(RunContext runContext, Execution execution, TaskRun parentTaskRun) throws IllegalVariableEvaluationException {
         return FlowableUtils.resolveState(
             execution,

--- a/core/src/main/java/io/kestra/core/models/tasks/RunnableTask.java
+++ b/core/src/main/java/io/kestra/core/models/tasks/RunnableTask.java
@@ -2,6 +2,12 @@ package io.kestra.core.models.tasks;
 
 import io.kestra.core.runners.RunContext;
 
+/**
+ * Interface for tasks that are run in the Worker.
+ */
 public interface RunnableTask <T extends Output> {
+    /**
+     * Thsis method is called inside the Worker to run (execute) the task.
+     */
     T run(RunContext runContext) throws Exception;
 }

--- a/core/src/main/java/io/kestra/core/runners/ExecutableUtils.java
+++ b/core/src/main/java/io/kestra/core/runners/ExecutableUtils.java
@@ -1,0 +1,33 @@
+package io.kestra.core.runners;
+
+import io.kestra.core.models.executions.Execution;
+import io.kestra.core.models.executions.TaskRun;
+import io.kestra.core.models.executions.TaskRunAttempt;
+import io.kestra.core.models.flows.State;
+
+import java.util.Collections;
+
+public final class ExecutableUtils {
+
+    private ExecutableUtils() {
+        // prevent initialization
+    }
+
+    public static State.Type guessState(Execution execution, boolean transmitFailed) {
+        if (transmitFailed &&
+            (execution.getState().isFailed() || execution.getState().isPaused() || execution.getState().getCurrent() == State.Type.KILLED || execution.getState().getCurrent() == State.Type.WARNING)
+        ) {
+            return execution.getState().getCurrent();
+        } else {
+            return State.Type.SUCCESS;
+        }
+    }
+
+    public static WorkerTaskResult workerTaskResult(TaskRun taskRun) {
+        return WorkerTaskResult.builder()
+            .taskRun(taskRun.withAttempts(
+                Collections.singletonList(TaskRunAttempt.builder().state(new State().withState(taskRun.getState().getCurrent())).build())
+            ))
+            .build();
+    }
+}

--- a/core/src/main/java/io/kestra/core/runners/ExecutableUtils.java
+++ b/core/src/main/java/io/kestra/core/runners/ExecutableUtils.java
@@ -1,11 +1,22 @@
 package io.kestra.core.runners;
 
+import com.google.common.collect.ImmutableMap;
+import io.kestra.core.models.Label;
 import io.kestra.core.models.executions.Execution;
+import io.kestra.core.models.executions.ExecutionTrigger;
 import io.kestra.core.models.executions.TaskRun;
 import io.kestra.core.models.executions.TaskRunAttempt;
+import io.kestra.core.models.flows.Flow;
+import io.kestra.core.models.flows.FlowWithException;
 import io.kestra.core.models.flows.State;
+import io.kestra.core.models.tasks.ExecutableTask;
+import io.kestra.core.models.tasks.Task;
 
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 
 public final class ExecutableUtils {
 
@@ -28,6 +39,69 @@ public final class ExecutableUtils {
             .taskRun(taskRun.withAttempts(
                 Collections.singletonList(TaskRunAttempt.builder().state(new State().withState(taskRun.getState().getCurrent())).build())
             ))
+            .build();
+    }
+
+    public static <T extends Task & ExecutableTask> WorkerTaskExecution<?> workerTaskExecution(
+        RunContext runContext,
+        FlowExecutorInterface flowExecutorInterface,
+        Execution currentExecution,
+        Flow currentFlow,
+        T currentTask,
+        TaskRun currentTaskRun,
+        String subflowNamespace,
+        String subflowId,
+        Integer subflowRevision,
+        Map<String, Object> inputs,
+        List<Label> labels,
+        Map<String, Object> additionalVariables
+    ) {
+        io.kestra.core.models.flows.Flow flow = flowExecutorInterface.findByIdFromFlowTask(
+                currentExecution.getTenantId(),
+                subflowNamespace,
+                subflowId,
+                Optional.ofNullable(subflowRevision),
+                currentExecution.getTenantId(),
+                currentFlow.getNamespace(),
+                currentFlow.getId()
+            )
+            .orElseThrow(() -> new IllegalStateException("Unable to find flow '" + subflowNamespace + "'.'" + subflowId + "' with revision + '" + subflowRevision + "'"));
+
+        if (flow.isDisabled()) {
+            throw new IllegalStateException("Cannot execute a flow which is disabled");
+        }
+
+        if (flow instanceof FlowWithException fwe) {
+            throw new IllegalStateException("Cannot execute an invalid flow: " + fwe.getException());
+        }
+
+        Map<String, Object> variables = new HashMap<>(
+            ImmutableMap.of(
+                "executionId", currentExecution.getId(),
+                "namespace", currentFlow.getNamespace(),
+                "flowId", currentFlow.getId(),
+                "flowRevision", currentFlow.getRevision()
+            )
+        );
+        variables.putAll(additionalVariables);
+
+        RunnerUtils runnerUtils = runContext.getApplicationContext().getBean(RunnerUtils.class);
+        Execution execution = runnerUtils
+            .newExecution(
+                flow,
+                (f, e) -> runnerUtils.typedInputs(f, e, inputs),
+                labels)
+            .withTrigger(ExecutionTrigger.builder()
+                .id(currentTask.getId())
+                .type(currentTask.getType())
+                .variables(variables)
+                .build()
+            );
+
+        return WorkerTaskExecution.builder()
+            .task(currentTask)
+            .taskRun(currentTaskRun)
+            .execution(execution)
             .build();
     }
 }

--- a/core/src/main/java/io/kestra/core/runners/ExecutableUtils.java
+++ b/core/src/main/java/io/kestra/core/runners/ExecutableUtils.java
@@ -51,8 +51,7 @@ public final class ExecutableUtils {
         T currentTask,
         TaskRun currentTaskRun,
         Map<String, Object> inputs,
-        List<Label> labels,
-        Map<String, Object> additionalVariables
+        List<Label> labels
     ) throws IllegalVariableEvaluationException {
         String subflowNamespace = runContext.render(currentTask.subflowId().namespace());
         String subflowId = runContext.render(currentTask.subflowId().flowId());
@@ -77,15 +76,12 @@ public final class ExecutableUtils {
             throw new IllegalStateException("Cannot execute an invalid flow: " + fwe.getException());
         }
 
-        Map<String, Object> variables = new HashMap<>(
-            ImmutableMap.of(
-                "executionId", currentExecution.getId(),
-                "namespace", currentFlow.getNamespace(),
-                "flowId", currentFlow.getId(),
-                "flowRevision", currentFlow.getRevision()
-            )
+        Map<String, Object> variables = ImmutableMap.of(
+            "executionId", currentExecution.getId(),
+            "namespace", currentFlow.getNamespace(),
+            "flowId", currentFlow.getId(),
+            "flowRevision", currentFlow.getRevision()
         );
-        variables.putAll(additionalVariables);
 
         RunnerUtils runnerUtils = runContext.getApplicationContext().getBean(RunnerUtils.class);
         Execution execution = runnerUtils

--- a/core/src/main/java/io/kestra/core/runners/Executor.java
+++ b/core/src/main/java/io/kestra/core/runners/Executor.java
@@ -91,7 +91,7 @@ public class Executor {
         return this;
     }
 
-    public Executor withWorkerTaskExecutions(List<WorkerTaskExecution> newExecutions, String from) {
+    public Executor withWorkerTaskExecutions(List<WorkerTaskExecution<?>> newExecutions, String from) {
         this.workerTaskExecutions.addAll(newExecutions);
         this.from.add(from);
 

--- a/core/src/main/java/io/kestra/core/runners/RunContext.java
+++ b/core/src/main/java/io/kestra/core/runners/RunContext.java
@@ -325,6 +325,10 @@ public class RunContext {
             builder.put("value", taskRun.getValue());
         }
 
+        if(taskRun.getItems() != null) {
+            builder.put("items", taskRun.getItems());
+        }
+
         return builder.build();
     }
 

--- a/core/src/main/java/io/kestra/core/runners/RunContext.java
+++ b/core/src/main/java/io/kestra/core/runners/RunContext.java
@@ -325,10 +325,6 @@ public class RunContext {
             builder.put("value", taskRun.getValue());
         }
 
-        if(taskRun.getItems() != null) {
-            builder.put("items", taskRun.getItems());
-        }
-
         return builder.build();
     }
 
@@ -611,7 +607,7 @@ public class RunContext {
         URI uri = URI.create(this.taskStateFilePathPrefix(state, isNamespace, useTaskRun));
         URI resolve = uri.resolve(uri.getPath() + "/" + name);
 
-        return this.storageInterface.get(getTenantId(), resolve);
+       return this.storageInterface.get(getTenantId(), resolve);
     }
 
     public URI putTaskStateFile(byte[] content, String state, String name) throws IOException {

--- a/core/src/main/java/io/kestra/core/runners/RunContext.java
+++ b/core/src/main/java/io/kestra/core/runners/RunContext.java
@@ -325,6 +325,10 @@ public class RunContext {
             builder.put("value", taskRun.getValue());
         }
 
+        if(taskRun.getItems() != null) {
+            builder.put("items", taskRun.getItems());
+        }
+
         return builder.build();
     }
 
@@ -607,7 +611,7 @@ public class RunContext {
         URI uri = URI.create(this.taskStateFilePathPrefix(state, isNamespace, useTaskRun));
         URI resolve = uri.resolve(uri.getPath() + "/" + name);
 
-       return this.storageInterface.get(getTenantId(), resolve);
+        return this.storageInterface.get(getTenantId(), resolve);
     }
 
     public URI putTaskStateFile(byte[] content, String state, String name) throws IOException {

--- a/core/src/main/java/io/kestra/core/runners/WorkerTaskExecution.java
+++ b/core/src/main/java/io/kestra/core/runners/WorkerTaskExecution.java
@@ -11,7 +11,7 @@ import javax.validation.constraints.NotNull;
 
 @Data
 @Builder
-public class WorkerTaskExecution<T extends Task & ExecutableTask<?>> {
+public class WorkerTaskExecution<T extends Task & ExecutableTask> {
     @NotNull
     private TaskRun taskRun;
 

--- a/core/src/main/java/io/kestra/core/runners/WorkerTaskExecution.java
+++ b/core/src/main/java/io/kestra/core/runners/WorkerTaskExecution.java
@@ -2,7 +2,8 @@ package io.kestra.core.runners;
 
 import io.kestra.core.models.executions.Execution;
 import io.kestra.core.models.executions.TaskRun;
-import io.kestra.core.tasks.flows.Flow;
+import io.kestra.core.models.tasks.ExecutableTask;
+import io.kestra.core.models.tasks.Task;
 import lombok.Builder;
 import lombok.Data;
 
@@ -10,12 +11,12 @@ import javax.validation.constraints.NotNull;
 
 @Data
 @Builder
-public class WorkerTaskExecution {
+public class WorkerTaskExecution<T extends Task & ExecutableTask<?>> {
     @NotNull
     private TaskRun taskRun;
 
     @NotNull
-    private Flow task;
+    private T task;
 
     @NotNull
     private Execution execution;

--- a/core/src/main/java/io/kestra/core/services/GraphService.java
+++ b/core/src/main/java/io/kestra/core/services/GraphService.java
@@ -52,15 +52,15 @@ public class GraphService {
         subflowToReplaceByParent.map(Rethrow.throwFunction(parentWithSubflowGraphTask -> {
                 SubflowGraphTask subflowGraphTask = parentWithSubflowGraphTask.getValue();
                 Flow subflow = flowByUid.computeIfAbsent(
-                    subflowGraphTask.getTask().flowUid(),
+                    subflowGraphTask.getExecutableTask().subflowId().flowUid(),
                     uid -> flowRepository.findById(
                         tenantId,
-                        subflowGraphTask.getTask().getNamespace(),
-                        subflowGraphTask.getTask().getFlowId(),
-                        Optional.ofNullable(subflowGraphTask.getTask().getRevision())
+                        subflowGraphTask.getExecutableTask().subflowId().namespace(),
+                        subflowGraphTask.getExecutableTask().subflowId().flowId(),
+                        subflowGraphTask.getExecutableTask().subflowId().revision()
                     ).orElseThrow(() -> new NoSuchElementException(
                         "Unable to find subflow " +
-                            (subflowGraphTask.getTask().getRevision() == null ? subflowGraphTask.getTask().flowUidWithoutRevision() : subflowGraphTask.getTask().flowUid())
+                            (subflowGraphTask.getExecutableTask().subflowId().revision().isEmpty() ? subflowGraphTask.getExecutableTask().subflowId().flowUidWithoutRevision() : subflowGraphTask.getExecutableTask().subflowId().flowUid())
                             + " for task " + subflowGraphTask.getTask().getId()
                     ))
                 );

--- a/core/src/main/java/io/kestra/core/tasks/flows/Flow.java
+++ b/core/src/main/java/io/kestra/core/tasks/flows/Flow.java
@@ -49,41 +49,40 @@ import java.util.*;
 public class Flow extends Task implements ExecutableTask {
     @NotNull
     @Schema(
-        title = "The namespace of the flow that should be executed as a subflow"
+        title = "The namespace of the subflow to be executed"
     )
     @PluginProperty(dynamic = true)
     private String namespace;
 
     @NotNull
     @Schema(
-        title = "The identifier of the flow that should be executed as a subflow"
+        title = "The identifier of the subflow to be executed"
     )
     @PluginProperty(dynamic = true)
     private String flowId;
 
     @Schema(
-        title = "The revision of the flow that should be executed as a subflow",
-        description = "By default, the last i.e. the most recent revision of the flow is triggered."
+        title = "The revision of the subflow to be executed",
+        description = "By default, the last, i.e. the most recent, revision of the subflow is executed."
     )
     @PluginProperty(dynamic = true)
     private Integer revision;
 
     @Schema(
-        title = "The inputs to pass to the subflow"
+        title = "The inputs to pass to the subflow to be executed"
     )
     @PluginProperty(dynamic = true)
     private Map<String, Object> inputs;
 
     @Schema(
-        title = "The labels to pass to the subflow execution"
+        title = "The labels to pass to the subflow to be executed"
     )
     @PluginProperty(dynamic = true)
     private Map<String, String> labels;
 
     @Builder.Default
     @Schema(
-        title = "Whether to wait for the subflow execution to finish before continuing the current execution",
-        description = "By default, the subflow will be executed in a fire-and-forget manner without waiting for the subflow execution to finish. If you set this option to `true`, the current execution will wait for the subflow execution to finish before continuing with the next task."
+        title = "Whether to wait for the subflow execution to finish before continuing the current execution."
     )
     @PluginProperty
     private final Boolean wait = false;
@@ -91,7 +90,7 @@ public class Flow extends Task implements ExecutableTask {
     @Builder.Default
     @Schema(
         title = "Whether to fail the current execution if the subflow execution fails or is killed",
-        description = "Note that this option only has an effect if `wait` is set to `true`."
+        description = "Note that this option works only if `wait` is set to `true`."
     )
     @PluginProperty
     private final Boolean transmitFailed = false;
@@ -106,8 +105,7 @@ public class Flow extends Task implements ExecutableTask {
 
     @Schema(
         title = "Outputs from the subflow executions.",
-        description = "Allows to specify key-value pairs (with the value rendered) in order to extract any outputs from the " +
-            "subflow execution."
+        description = "Allows to specify outputs as key-value pairs to extract any outputs from the subflow execution into output of this task execution."
     )
     @PluginProperty(dynamic = true)
     private Map<String, Object> outputs;

--- a/core/src/main/java/io/kestra/core/tasks/flows/Flow.java
+++ b/core/src/main/java/io/kestra/core/tasks/flows/Flow.java
@@ -137,8 +137,7 @@ public class Flow extends Task implements ExecutableTask {
             this,
             currentTaskRun,
             inputs,
-            labels,
-            Map.of()
+            labels
         ));
     }
 

--- a/core/src/main/java/io/kestra/core/tasks/flows/Flow.java
+++ b/core/src/main/java/io/kestra/core/tasks/flows/Flow.java
@@ -107,16 +107,6 @@ public class Flow extends Task implements ExecutableTask {
     @PluginProperty(dynamic = true)
     private Map<String, Object> outputs;
 
-    public String flowUid() {
-        // as the Flow task can only be used in the same tenant we can hardcode null here
-        return io.kestra.core.models.flows.Flow.uid(null, this.getNamespace(), this.getFlowId(), Optional.ofNullable(this.revision));
-    }
-
-    public String flowUidWithoutRevision() {
-        // as the Flow task can only be used in the same tenant we can hardcode null here
-        return io.kestra.core.models.flows.Flow.uidWithoutRevision(null, this.getNamespace(), this.getFlowId());
-    }
-
     @SuppressWarnings("unchecked")
     @Override
     public List<WorkerTaskExecution<?>> createWorkerTaskExecutions(RunContext runContext,
@@ -196,6 +186,11 @@ public class Flow extends Task implements ExecutableTask {
     @Override
     public boolean waitForExecution() {
         return this.wait;
+    }
+
+    @Override
+    public SubflowId subflowId() {
+        return new SubflowId(this.namespace, this.flowId, Optional.ofNullable(this.revision));
     }
 
     @Builder

--- a/core/src/main/java/io/kestra/core/tasks/flows/Flow.java
+++ b/core/src/main/java/io/kestra/core/tasks/flows/Flow.java
@@ -129,9 +129,6 @@ public class Flow extends Task implements ExecutableTask {
             }
         }
 
-        String namespace = runContext.render(this.namespace);
-        String flowId = runContext.render(this.flowId);
-
         return List.of(ExecutableUtils.workerTaskExecution(
             runContext,
             flowExecutorInterface,
@@ -139,9 +136,6 @@ public class Flow extends Task implements ExecutableTask {
             currentFlow,
             this,
             currentTaskRun,
-            namespace,
-            flowId,
-            this.revision,
             inputs,
             labels,
             Map.of()

--- a/core/src/main/java/io/kestra/core/tasks/flows/ForEachItem.java
+++ b/core/src/main/java/io/kestra/core/tasks/flows/ForEachItem.java
@@ -53,7 +53,7 @@ import static io.kestra.core.utils.Rethrow.throwFunction;
 @NoArgsConstructor
 @Schema(
     title = "Execute a subflow for each batch of items",
-    description = "This tasks allow to execute a subflow for each batch of items. The items must come from Kestra's internal storage."
+    description = "Execute a subflow for each batch of items. The `items` value must be internal storage URI e.g. an output file from a previous task, or a file from inputs of FILE type."
 )
 @Plugin(
     examples = {
@@ -72,7 +72,7 @@ import static io.kestra.core.utils.Rethrow.throwFunction;
                       inputs:
                         file: "{{ taskrun.items }}" # special variable that contains the items of the batch
                       wait: true # wait for the subflow execution
-                      transmitFailed: true # fail the task run if the subflow fail"""
+                      transmitFailed: true # fail the task run if the subflow execution fails"""
             }
         )
     }
@@ -82,7 +82,7 @@ public class ForEachItem extends Task implements ExecutableTask {
 
     @NotEmpty
     @PluginProperty(dynamic = true)
-    @Schema(title = "The items, must be an URI from Kestra's internal storage")
+    @Schema(title = "The items to be split into batches and processed. Make sure to set it to Kestra's internal storage URI, e.g. output from a previous task in the format `{{ outputs.task_id.uri }}` or an input parameter of FILE type e.g. `{{ inputs.myfile }}`.")
     private String items;
 
     @Positive
@@ -94,7 +94,7 @@ public class ForEachItem extends Task implements ExecutableTask {
 
     @NotNull
     @PluginProperty
-    @Schema(title = "The subflow that will be executed on each batch of items")
+    @Schema(title = "The subflow that will be executed for each batch of items")
     private ForEachItem.Subflow subflow;
 
     @Override
@@ -257,56 +257,56 @@ public class ForEachItem extends Task implements ExecutableTask {
     public static class Subflow {
         @NotEmpty
         @Schema(
-            title = "The namespace of the flow to trigger"
+            title = "The namespace of the subflow to be executed"
         )
         @PluginProperty(dynamic = true)
         private String namespace;
 
         @NotEmpty
         @Schema(
-            title = "The identifier of the flow to trigger"
+            title = "The identifier of the subflow to be executed"
         )
         @PluginProperty(dynamic = true)
         private String flowId;
 
         @Schema(
-            title = "The revision of the flow to trigger",
-            description = "By default, we trigger the last version."
+            title = "The revision of the subflow to be executed",
+            description = "By default, the last, i.e. the most recent, revision of the subflow is executed."
         )
         @PluginProperty
         private Integer revision;
 
         @Schema(
-            title = "The inputs to pass to the triggered flow"
+            title = "The inputs to pass to the subflow to be executed"
         )
         @PluginProperty(dynamic = true)
         private Map<String, Object> inputs;
 
         @Schema(
-            title = "The labels to pass to the triggered flow execution"
+            title = "The labels to pass to the subflow to be executed"
         )
         @PluginProperty(dynamic = true)
         private Map<String, String> labels;
 
         @Builder.Default
         @Schema(
-            title = "Wait the end of the execution."
+            title = "Whether to wait for the subflows execution to finish before continuing the current execution."
         )
         @PluginProperty
         private final Boolean wait = true;
 
         @Builder.Default
         @Schema(
-            title = "Fail the current execution if the waited execution is failed or killed.",
-            description = "`wait` need to be true to make it work"
+            title = "Whether to fail the current execution if the subflow execution fails or is killed",
+            description = "Note that this option works only if `wait` is set to `true`."
         )
         @PluginProperty
         private final Boolean transmitFailed = true;
 
         @Builder.Default
         @Schema(
-            title = "Inherit labels from the calling execution",
-            description = "By default, we don't inherit any labels of the calling execution"
+            title = "Whether the subflow should inherit labels from this execution that triggered it.",
+            description = "By default, labels are not passed to the subflow execution. If you set this option to `true`, the child flow execution will inherit all labels from the parent execution."
         )
         @PluginProperty
         private final Boolean inheritLabels = false;

--- a/core/src/main/java/io/kestra/core/tasks/flows/ForEachItem.java
+++ b/core/src/main/java/io/kestra/core/tasks/flows/ForEachItem.java
@@ -1,0 +1,308 @@
+package io.kestra.core.tasks.flows;
+
+import com.google.common.collect.ImmutableMap;
+import io.kestra.core.exceptions.IllegalVariableEvaluationException;
+import io.kestra.core.exceptions.InternalException;
+import io.kestra.core.models.Label;
+import io.kestra.core.models.annotations.Example;
+import io.kestra.core.models.annotations.Plugin;
+import io.kestra.core.models.annotations.PluginProperty;
+import io.kestra.core.models.executions.Execution;
+import io.kestra.core.models.executions.ExecutionTrigger;
+import io.kestra.core.models.executions.TaskRun;
+import io.kestra.core.models.flows.FlowWithException;
+import io.kestra.core.models.tasks.ExecutableTask;
+import io.kestra.core.models.tasks.Task;
+import io.kestra.core.models.tasks.VoidOutput;
+import io.kestra.core.runners.ExecutableUtils;
+import io.kestra.core.runners.FlowExecutorInterface;
+import io.kestra.core.runners.RunContext;
+import io.kestra.core.runners.RunnerUtils;
+import io.kestra.core.runners.WorkerTaskExecution;
+import io.kestra.core.runners.WorkerTaskResult;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+import lombok.experimental.SuperBuilder;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import javax.validation.constraints.NotEmpty;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Positive;
+
+@SuperBuilder(toBuilder = true)
+@ToString
+@EqualsAndHashCode
+@Getter
+@NoArgsConstructor
+@Schema(
+    title = "Execute a subflow for each batch of items",
+    description = "This tasks allow to execute a subflow for each batch of items. The items must come from Kestra's internal storage."
+)
+@Plugin(
+    examples = {
+        @Example(
+            title = "Execute a subflow for each batch of items",
+            code = {
+                """
+                    id: each
+                    type: io.kestra.core.tasks.flows.ForEachItem
+                    items: "{{ outputs.extract.uri }}" # works with API payloads too. Kestra can detect if this output is not a file,\s
+                    # and will make it to a file, split into (batches of) items
+                    maxItemsPerBatch: 10
+                    subflow:
+                      flowId: file
+                      namespace: dev
+                      inputs:
+                        file: "{{ taskrun.items }}" # special variable that contains the items of the batch
+                      wait: true # wait for the subflow execution
+                      transmitFailed: true # fail the task run if the subflow fail"""
+            }
+        )
+    }
+)
+public class ForEachItem extends Task implements ExecutableTask<VoidOutput> {
+    private static final String URI_FORMAT = "kestra:///%s/%s/executions/%s/tasks/%s/%s/bach-%s.ion";
+
+    @NotEmpty
+    @PluginProperty(dynamic = true)
+    @Schema(title = "The items, must be an URI from Kestra's internal storage")
+    private String items;
+
+    @Positive
+    @NotNull
+    @PluginProperty
+    @Builder.Default
+    @Schema(title = "Maximum number of items per batch")
+    private Integer maxItemsPerBatch = 10;
+
+    @NotNull
+    @PluginProperty
+    @Schema(title = "The subflow that will be executed on each batch of items")
+    private SubFlow subFlow;
+
+    @Override
+    public List<TaskRun> createTaskRun(RunContext runContext, Execution currentExecution, TaskRun executionTaskRun) {
+        try {
+            int splits = readSplits(runContext);
+
+            return IntStream.range(1, splits + 1)
+                .mapToObj( split -> executionTaskRun
+                    .withItems(readItems(currentExecution, executionTaskRun.getId(), split))
+                    .withValue(String.valueOf(split))
+                    .withOutputs(ImmutableMap.of(
+                        "currentIteration", split,
+                        "maxIteration", splits
+                    ))
+                )
+                .toList();
+
+        } catch (IllegalVariableEvaluationException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public Execution createExecution(RunContext runContext, FlowExecutorInterface flowExecutorInterface, Execution currentExecution) throws InternalException {
+        //FIXME duplicated with the flow task
+        RunnerUtils runnerUtils = runContext.getApplicationContext().getBean(RunnerUtils.class);
+
+        Map<String, Object> inputs = new HashMap<>();
+        if (this.subFlow.inputs != null) {
+            inputs.putAll(runContext.render(this.subFlow.inputs));
+        }
+
+        List<Label> labels = new ArrayList<>();
+        if (this.subFlow.inheritLabels) {
+            labels.addAll(currentExecution.getLabels());
+        }
+        if (this.subFlow.labels != null) {
+            for (Map.Entry<String, String> entry: this.subFlow.labels.entrySet()) {
+                labels.add(new Label(entry.getKey(), runContext.render(entry.getValue())));
+            }
+        }
+
+        Map<String, String> flowVars = (Map<String, String>) runContext.getVariables().get("flow");
+
+        String namespace = runContext.render(this.subFlow.namespace);
+        String flowId = runContext.render(this.subFlow.flowId);
+        Optional<Integer> revision = this.subFlow.revision != null ? Optional.of(this.subFlow.revision) : Optional.empty();
+
+        io.kestra.core.models.flows.Flow flow = flowExecutorInterface.findByIdFromFlowTask(
+                flowVars.get("tenantId"),
+                namespace,
+                flowId,
+                revision,
+                flowVars.get("tenantId"),
+                flowVars.get("namespace"),
+                flowVars.get("id")
+            )
+            .orElseThrow(() -> new IllegalStateException("Unable to find flow '" + namespace + "'.'" + flowId + "' with revision + '" + revision + "'"));
+
+        if (flow.isDisabled()) {
+            throw new IllegalStateException("Cannot execute disabled flow");
+        }
+
+        if (flow instanceof FlowWithException fwe) {
+            throw new IllegalStateException("Cannot execute an invalid flow: " + fwe.getException());
+        }
+
+        return runnerUtils
+            .newExecution(
+                flow,
+                (f, e) -> runnerUtils.typedInputs(f, e, inputs),
+                labels)
+            .withTrigger(ExecutionTrigger.builder()
+                .id(this.getId())
+                .type(this.getType())
+                .variables(ImmutableMap.of(
+                    "executionId", ((Map<String, Object>) runContext.getVariables().get("execution")).get("id"),
+                    "namespace", flowVars.get("namespace"),
+                    "flowId", flowVars.get("id"),
+                    "flowRevision", flowVars.get("revision")
+                ))
+                .build()
+            );
+    }
+
+    @Override
+    public WorkerTaskResult createWorkerTaskResult(
+        RunContext runContext,
+        WorkerTaskExecution<?> workerTaskExecution,
+        io.kestra.core.models.flows.Flow flow,
+        Execution execution
+    ) {
+        TaskRun taskRun = workerTaskExecution.getTaskRun();
+
+        taskRun = taskRun.withState(ExecutableUtils.guessState(execution, this.subFlow.transmitFailed));
+
+        return ExecutableUtils.workerTaskResult(taskRun);
+    }
+
+    @Override
+    public boolean waitForExecution() {
+        return this.subFlow.wait;
+    }
+
+    private URI readItems(Execution execution, String taskRunId, int split) {
+        // Recreate the URI from the execution context and the value.
+        // It should be kestra:///$ns/$flow/executions/$execution_id/tasks/$task_id/$taskrun_id/bach-$value.ion
+        String uri = URI_FORMAT.formatted(execution.getNamespace(), execution.getFlowId(), execution.getId(), this.id, taskRunId, split);
+        return URI.create(uri);
+    }
+
+    private int readSplits(RunContext runContext) throws IllegalVariableEvaluationException {
+        URI data = URI.create(runContext.render(this.items));
+
+        try (var reader = new BufferedReader(new InputStreamReader(runContext.uriToInputStream(data)))) {
+            int batches = 0;
+            int lineNb = 0;
+            String row;
+            List<String> rows = new ArrayList<>(maxItemsPerBatch);
+            while ((row = reader.readLine()) != null) {
+                rows.add(row);
+                lineNb++;
+
+                if (lineNb == maxItemsPerBatch) {
+                    createBatchFile(runContext, rows, batches);
+
+                    batches++;
+                    lineNb = 0;
+                    rows.clear();
+                }
+            }
+
+            if (!rows.isEmpty()) {
+                createBatchFile(runContext, rows, batches);
+                batches++;
+            }
+
+            return batches;
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private void createBatchFile(RunContext runContext, List<String> rows, int batch) throws IOException {
+        byte[] bytes = rows.stream().collect(Collectors.joining(System.lineSeparator())).getBytes();
+        File batchFile = runContext.tempFile(bytes, ".ion").toFile();
+        runContext.putTempFile(batchFile, "bach-" + batch + ".ion");
+    }
+
+    @SuperBuilder
+    @ToString
+    @EqualsAndHashCode
+    @Getter
+    @NoArgsConstructor
+    public static class SubFlow {
+        @NotEmpty
+        @Schema(
+            title = "The namespace of the flow to trigger"
+        )
+        @PluginProperty(dynamic = true)
+        private String namespace;
+
+        @NotEmpty
+        @Schema(
+            title = "The identifier of the flow to trigger"
+        )
+        @PluginProperty(dynamic = true)
+        private String flowId;
+
+        @Schema(
+            title = "The revision of the flow to trigger",
+            description = "By default, we trigger the last version."
+        )
+        @PluginProperty
+        private Integer revision;
+
+        @Schema(
+            title = "The inputs to pass to the triggered flow"
+        )
+        @PluginProperty(dynamic = true)
+        private Map<String, Object> inputs;
+
+        @Schema(
+            title = "The labels to pass to the triggered flow execution"
+        )
+        @PluginProperty(dynamic = true)
+        private Map<String, String> labels;
+
+        @Builder.Default
+        @Schema(
+            title = "Wait the end of the execution."
+        )
+        @PluginProperty
+        private final Boolean wait = true;
+
+        @Builder.Default
+        @Schema(
+            title = "Fail the current execution if the waited execution is failed or killed.",
+            description = "`wait` need to be true to make it work"
+        )
+        @PluginProperty
+        private final Boolean transmitFailed = true;
+
+        @Builder.Default
+        @Schema(
+            title = "Inherit labels from the calling execution",
+            description = "By default, we don't inherit any labels of the calling execution"
+        )
+        @PluginProperty
+        private final Boolean inheritLabels = false;
+    }
+}

--- a/core/src/main/java/io/kestra/core/tasks/flows/ForEachItem.java
+++ b/core/src/main/java/io/kestra/core/tasks/flows/ForEachItem.java
@@ -78,7 +78,7 @@ import static io.kestra.core.utils.Rethrow.throwFunction;
     }
 )
 public class ForEachItem extends Task implements ExecutableTask {
-    private static final String URI_FORMAT = "kestra:///%s/%s/executions/%s/tasks/%s/%s/bach-%s.ion";
+    private static final String URI_FORMAT = "kestra:///%s/%s/executions/%s/tasks/%s/%s/batch-%s.ion";
 
     @NotEmpty
     @PluginProperty(dynamic = true)
@@ -246,7 +246,7 @@ public class ForEachItem extends Task implements ExecutableTask {
     private void createBatchFile(RunContext runContext, List<String> rows, int batch) throws IOException {
         byte[] bytes = rows.stream().collect(Collectors.joining(System.lineSeparator())).getBytes();
         File batchFile = runContext.tempFile(bytes, ".ion").toFile();
-        runContext.putTempFile(batchFile, "bach-" + batch + ".ion");
+        runContext.putTempFile(batchFile, "batch-" + (batch + 1) + ".ion");
     }
 
     @SuperBuilder

--- a/core/src/main/java/io/kestra/core/tasks/flows/ForEachItem.java
+++ b/core/src/main/java/io/kestra/core/tasks/flows/ForEachItem.java
@@ -106,9 +106,10 @@ public class ForEachItem extends Task implements ExecutableTask {
         return splits.stream()
             .<WorkerTaskExecution<?>>map(throwFunction(
                  split -> {
+                     Map<String, Object> intemsVariable = Map.of("taskrun", Map.of("items", split.toString()));
                      Map<String, Object> inputs = new HashMap<>();
                      if (this.subflow.inputs != null) {
-                         inputs.putAll(runContext.render(this.subflow.inputs));
+                         inputs.putAll(runContext.render(this.subflow.inputs, intemsVariable));
                      }
 
                      List<Label> labels = new ArrayList<>();
@@ -133,10 +134,10 @@ public class ForEachItem extends Task implements ExecutableTask {
                              .withOutputs(ImmutableMap.of(
                                  "currentIteration", interation,
                                  "maxIterations", splits.size()
-                             )),
+                             ))
+                             .withItems(split.toString()),
                          inputs,
-                         labels,
-                         Map.of("items", split.toString())
+                         labels
                      );
                 }
             ))

--- a/core/src/main/java/io/kestra/core/tasks/flows/ForEachItem.java
+++ b/core/src/main/java/io/kestra/core/tasks/flows/ForEachItem.java
@@ -120,9 +120,6 @@ public class ForEachItem extends Task implements ExecutableTask {
                         }
                     }
 
-                    String namespace = runContext.render(this.subflow.namespace);
-                    String flowId = runContext.render(this.subflow.flowId);
-
                      return ExecutableUtils.workerTaskExecution(
                          runContext,
                          flowExecutorInterface,
@@ -135,9 +132,6 @@ public class ForEachItem extends Task implements ExecutableTask {
                                  "currentIteration", split,
                                  "maxIterations", splits
                              )),
-                         namespace,
-                         flowId,
-                         this.subflow.revision,
                          inputs,
                          labels,
                          Map.of("items", readItems(currentExecution, currentTaskRun.getId(), split))

--- a/core/src/main/java/io/kestra/core/tasks/flows/ForEachItem.java
+++ b/core/src/main/java/io/kestra/core/tasks/flows/ForEachItem.java
@@ -169,6 +169,11 @@ public class ForEachItem extends Task implements ExecutableTask {
         return this.subflow.wait;
     }
 
+    @Override
+    public SubflowId subflowId() {
+        return new SubflowId(subflow.namespace, subflow.flowId, Optional.ofNullable(subflow.revision));
+    }
+
     private URI readItems(Execution execution, String taskRunId, int split) {
         // Recreate the URI from the execution context and the value.
         // It should be kestra:///$ns/$flow/executions/$execution_id/tasks/$task_id/$taskrun_id/bach-$value.ion

--- a/core/src/main/java/io/kestra/core/tasks/flows/ForEachItem.java
+++ b/core/src/main/java/io/kestra/core/tasks/flows/ForEachItem.java
@@ -10,7 +10,6 @@ import io.kestra.core.models.annotations.PluginProperty;
 import io.kestra.core.models.executions.Execution;
 import io.kestra.core.models.executions.TaskRun;
 import io.kestra.core.models.flows.Flow;
-import io.kestra.core.models.flows.State;
 import io.kestra.core.models.tasks.ExecutableTask;
 import io.kestra.core.models.tasks.Task;
 import io.kestra.core.runners.ExecutableUtils;
@@ -153,12 +152,12 @@ public class ForEachItem extends Task implements ExecutableTask {
     ) {
         TaskRun taskRun = workerTaskExecution.getTaskRun();
 
+        taskRun = taskRun.withState(ExecutableUtils.guessState(execution, this.subflow.transmitFailed));
+
         int currentIteration = (Integer) taskRun.getOutputs().get("currentIteration");
         int maxIterations = (Integer) taskRun.getOutputs().get("maxIterations");
 
-        State.Type taskState =  currentIteration == maxIterations ? ExecutableUtils.guessState(execution, this.subflow.transmitFailed) : State.Type.RUNNING;
-        taskRun = taskRun.withState(taskState);
-        return Optional.of(ExecutableUtils.workerTaskResult(taskRun));
+        return currentIteration == maxIterations ? Optional.of(ExecutableUtils.workerTaskResult(taskRun)) : Optional.empty();
     }
 
     @Override

--- a/core/src/main/java/io/kestra/core/topologies/FlowTopologyService.java
+++ b/core/src/main/java/io/kestra/core/topologies/FlowTopologyService.java
@@ -5,6 +5,7 @@ import io.kestra.core.models.conditions.types.*;
 import io.kestra.core.models.executions.Execution;
 import io.kestra.core.models.flows.Flow;
 import io.kestra.core.models.hierarchies.Graph;
+import io.kestra.core.models.tasks.ExecutableTask;
 import io.kestra.core.models.topologies.FlowNode;
 import io.kestra.core.models.topologies.FlowRelation;
 import io.kestra.core.models.topologies.FlowTopology;
@@ -161,10 +162,10 @@ public class FlowTopologyService {
             return parent
                 .allTasksWithChilds()
                 .stream()
-                .filter(t -> t instanceof io.kestra.core.tasks.flows.Flow)
-                .map(t -> (io.kestra.core.tasks.flows.Flow) t)
+                .filter(t -> t instanceof ExecutableTask)
+                .map(t -> (ExecutableTask) t)
                 .anyMatch(t ->
-                    t.getNamespace().equals(child.getNamespace()) && t.getFlowId().equals(child.getId())
+                    t.subflowId().namespace().equals(child.getNamespace()) && t.subflowId().flowId().equals(child.getId())
                 );
         } catch (Exception e) {
             log.warn("Failed to detect flow task on namespace:'" + parent.getNamespace() + "', flowId:'" + parent.getId()  + "'", e);

--- a/core/src/main/java/io/kestra/core/utils/GraphUtils.java
+++ b/core/src/main/java/io/kestra/core/utils/GraphUtils.java
@@ -5,6 +5,7 @@ import io.kestra.core.models.executions.Execution;
 import io.kestra.core.models.executions.TaskRun;
 import io.kestra.core.models.flows.Flow;
 import io.kestra.core.models.hierarchies.*;
+import io.kestra.core.models.tasks.ExecutableTask;
 import io.kestra.core.models.tasks.FlowableTask;
 import io.kestra.core.models.tasks.Task;
 import io.kestra.core.models.triggers.AbstractTrigger;
@@ -270,7 +271,7 @@ public class GraphUtils {
                 // detect kids
                 if (currentTask instanceof FlowableTask<?> flowableTask) {
                     currentGraph = flowableTask.tasksTree(execution, currentTaskRun, parentValues);
-                } else if (currentTask instanceof io.kestra.core.tasks.flows.Flow subflowTask) {
+                } else if (currentTask instanceof ExecutableTask subflowTask) {
                     currentGraph = new SubflowGraphTask(subflowTask, currentTaskRun, parentValues, relationType);
                 } else {
                     currentGraph = new GraphTask(currentTask, currentTaskRun, parentValues, relationType);

--- a/core/src/main/java/io/kestra/core/validations/ValidationFactory.java
+++ b/core/src/main/java/io/kestra/core/validations/ValidationFactory.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.kestra.core.models.conditions.types.MultipleCondition;
 import io.kestra.core.models.flows.Flow;
 import io.kestra.core.models.flows.Input;
+import io.kestra.core.models.tasks.ExecutableTask;
 import io.kestra.core.models.tasks.RunnableTask;
 import io.kestra.core.models.tasks.Task;
 import io.kestra.core.models.tasks.WorkerGroup;
@@ -216,10 +217,10 @@ public class ValidationFactory {
                 .stream()
                 .forEach(
                     task -> {
-                        if (task instanceof io.kestra.core.tasks.flows.Flow taskFlow
-                            && value.getId().equals(taskFlow.getFlowId())
-                            && value.getNamespace().equals(taskFlow.getNamespace())) {
-                            violations.add("Recursive call to flow [" + value.getId() + "]");
+                        if (task instanceof ExecutableTask executableTask
+                            && value.getId().equals(executableTask.subflowId().flowId())
+                            && value.getNamespace().equals(executableTask.subflowId().namespace())) {
+                            violations.add("Recursive call to flow [" + value.getNamespace() + "." + value.getId() + "]");
                         }
                     }
                 );

--- a/core/src/test/java/io/kestra/core/models/hierarchies/FlowGraphTest.java
+++ b/core/src/test/java/io/kestra/core/models/hierarchies/FlowGraphTest.java
@@ -236,7 +236,7 @@ class FlowGraphTest extends AbstractMemoryRunnerTest {
         assertThat(flowGraph.getEdges().size(), is(20));
         assertThat(flowGraph.getClusters().size(), is(3));
 
-        assertThat(((SubflowGraphTask) ((SubflowGraphCluster) cluster(flowGraph, "root\\.launch").getCluster()).getTaskNode()).getTask().getFlowId(), is("switch"));
+        assertThat(((SubflowGraphTask) ((SubflowGraphCluster) cluster(flowGraph, "root\\.launch").getCluster()).getTaskNode()).getExecutableTask().subflowId().flowId(), is("switch"));
         SubflowGraphTask subflowGraphTask = (SubflowGraphTask) nodeByUid(flowGraph, "root.launch");
         assertThat(subflowGraphTask.getTask(), instanceOf(io.kestra.core.tasks.flows.Flow.class));
         assertThat(subflowGraphTask.getRelationType(), is(RelationType.SEQUENTIAL));

--- a/core/src/test/java/io/kestra/core/tasks/flows/ForEachItemCaseTest.java
+++ b/core/src/test/java/io/kestra/core/tasks/flows/ForEachItemCaseTest.java
@@ -67,7 +67,7 @@ public class ForEachItemCaseTest {
         // assert on the last subflow execution
         assertThat(triggered.get().getState().getCurrent(), is(State.Type.SUCCESS));
         assertThat(triggered.get().getFlowId(), is("for-each-item-subflow"));
-        assertThat((String) triggered.get().getTrigger().getVariables().get("items"), matchesRegex("kestra:///io/kestra/tests/for-each-item/executions/.*/tasks/.*/.*/batch-.*\\.ion"));
+        assertThat((String) triggered.get().getInputs().get("items"), matchesRegex("kestra:///io/kestra/tests/for-each-item/executions/.*/tasks/.*/.*/batch-.*\\.ion"));
         assertThat(triggered.get().getTaskRunList(), hasSize(1));
     }
 
@@ -100,7 +100,7 @@ public class ForEachItemCaseTest {
         // assert on the last subflow execution
         assertThat(triggered.get().getState().getCurrent(), is(State.Type.SUCCESS));
         assertThat(triggered.get().getFlowId(), is("for-each-item-subflow"));
-        assertThat((String) triggered.get().getTrigger().getVariables().get("items"), matchesRegex("kestra:///io/kestra/tests/for-each-item-no-wait/executions/.*/tasks/.*/.*/batch-.*\\.ion"));
+        assertThat((String) triggered.get().getInputs().get("items"), matchesRegex("kestra:///io/kestra/tests/for-each-item-no-wait/executions/.*/tasks/.*/.*/batch-.*\\.ion"));
         assertThat(triggered.get().getTaskRunList(), hasSize(1));
     }
 

--- a/core/src/test/java/io/kestra/core/tasks/flows/ForEachItemCaseTest.java
+++ b/core/src/test/java/io/kestra/core/tasks/flows/ForEachItemCaseTest.java
@@ -67,7 +67,7 @@ public class ForEachItemCaseTest {
         // assert on the last subflow execution
         assertThat(triggered.get().getState().getCurrent(), is(State.Type.SUCCESS));
         assertThat(triggered.get().getFlowId(), is("for-each-item-subflow"));
-        assertThat((String) triggered.get().getTrigger().getVariables().get("items"), matchesRegex("kestra:///io\\.kestra\\.tests/for-each-item/executions/.*/tasks/.*/.*/batch-.*\\.ion"));
+        assertThat((String) triggered.get().getTrigger().getVariables().get("items"), matchesRegex("kestra:///io/kestra/tests/for-each-item/executions/.*/tasks/.*/.*/batch-.*\\.ion"));
         assertThat(triggered.get().getTaskRunList(), hasSize(1));
     }
 
@@ -100,7 +100,7 @@ public class ForEachItemCaseTest {
         // assert on the last subflow execution
         assertThat(triggered.get().getState().getCurrent(), is(State.Type.SUCCESS));
         assertThat(triggered.get().getFlowId(), is("for-each-item-subflow"));
-        assertThat((String) triggered.get().getTrigger().getVariables().get("items"), matchesRegex("kestra:///io\\.kestra\\.tests/for-each-item-no-wait/executions/.*/tasks/.*/.*/batch-.*\\.ion"));
+        assertThat((String) triggered.get().getTrigger().getVariables().get("items"), matchesRegex("kestra:///io/kestra/tests/for-each-item-no-wait/executions/.*/tasks/.*/.*/batch-.*\\.ion"));
         assertThat(triggered.get().getTaskRunList(), hasSize(1));
     }
 

--- a/core/src/test/java/io/kestra/core/tasks/flows/ForEachItemCaseTest.java
+++ b/core/src/test/java/io/kestra/core/tasks/flows/ForEachItemCaseTest.java
@@ -67,6 +67,7 @@ public class ForEachItemCaseTest {
         // assert on the last subflow execution
         assertThat(triggered.get().getState().getCurrent(), is(State.Type.SUCCESS));
         assertThat(triggered.get().getFlowId(), is("for-each-item-subflow"));
+        assertThat((String) triggered.get().getTrigger().getVariables().get("item"), matchesRegex("kestra:///io\\.kestra\\.tests/for-each-item/executions/.*/tasks/.*/.*/bach-.*\\.ion"));
         assertThat(triggered.get().getTaskRunList(), hasSize(1));
     }
 
@@ -99,6 +100,7 @@ public class ForEachItemCaseTest {
         // assert on the last subflow execution
         assertThat(triggered.get().getState().getCurrent(), is(State.Type.SUCCESS));
         assertThat(triggered.get().getFlowId(), is("for-each-item-subflow"));
+        assertThat((String) triggered.get().getTrigger().getVariables().get("item"), matchesRegex("kestra:///io\\.kestra\\.tests/for-each-item/executions/.*/tasks/.*/.*/bach-.*\\.ion"));
         assertThat(triggered.get().getTaskRunList(), hasSize(1));
     }
 

--- a/core/src/test/java/io/kestra/core/tasks/flows/ForEachItemCaseTest.java
+++ b/core/src/test/java/io/kestra/core/tasks/flows/ForEachItemCaseTest.java
@@ -67,7 +67,7 @@ public class ForEachItemCaseTest {
         // assert on the last subflow execution
         assertThat(triggered.get().getState().getCurrent(), is(State.Type.SUCCESS));
         assertThat(triggered.get().getFlowId(), is("for-each-item-subflow"));
-        assertThat((String) triggered.get().getTrigger().getVariables().get("item"), matchesRegex("kestra:///io\\.kestra\\.tests/for-each-item/executions/.*/tasks/.*/.*/bach-.*\\.ion"));
+        assertThat((String) triggered.get().getTrigger().getVariables().get("items"), matchesRegex("kestra:///io\\.kestra\\.tests/for-each-item/executions/.*/tasks/.*/.*/batch-.*\\.ion"));
         assertThat(triggered.get().getTaskRunList(), hasSize(1));
     }
 
@@ -100,7 +100,7 @@ public class ForEachItemCaseTest {
         // assert on the last subflow execution
         assertThat(triggered.get().getState().getCurrent(), is(State.Type.SUCCESS));
         assertThat(triggered.get().getFlowId(), is("for-each-item-subflow"));
-        assertThat((String) triggered.get().getTrigger().getVariables().get("item"), matchesRegex("kestra:///io\\.kestra\\.tests/for-each-item/executions/.*/tasks/.*/.*/bach-.*\\.ion"));
+        assertThat((String) triggered.get().getTrigger().getVariables().get("items"), matchesRegex("kestra:///io\\.kestra\\.tests/for-each-item-no-wait/executions/.*/tasks/.*/.*/batch-.*\\.ion"));
         assertThat(triggered.get().getTaskRunList(), hasSize(1));
     }
 

--- a/core/src/test/java/io/kestra/core/tasks/flows/ForEachItemCaseTest.java
+++ b/core/src/test/java/io/kestra/core/tasks/flows/ForEachItemCaseTest.java
@@ -4,12 +4,12 @@ import io.kestra.core.models.executions.Execution;
 import io.kestra.core.models.flows.State;
 import io.kestra.core.queues.QueueFactoryInterface;
 import io.kestra.core.queues.QueueInterface;
-import io.kestra.core.runners.AbstractMemoryRunnerTest;
+import io.kestra.core.runners.RunnerUtils;
 import io.kestra.core.storages.StorageInterface;
 import jakarta.inject.Inject;
 import jakarta.inject.Named;
+import jakarta.inject.Singleton;
 import org.apache.commons.lang3.StringUtils;
-import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -27,10 +27,10 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.hasSize;
-import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.*;
 
-public class ForEachItemTest  extends AbstractMemoryRunnerTest {
+@Singleton
+public class ForEachItemCaseTest {
     @Inject
     @Named(QueueFactoryInterface.EXECUTION_NAMED)
     private QueueInterface<Execution> executionQueue;
@@ -38,9 +38,10 @@ public class ForEachItemTest  extends AbstractMemoryRunnerTest {
     @Inject
     private StorageInterface storageInterface;
 
-    @Test
-    void sequential() throws TimeoutException, InterruptedException, URISyntaxException, IOException {
+    @Inject
+    protected RunnerUtils runnerUtils;
 
+    public void forEachItem() throws TimeoutException, InterruptedException, URISyntaxException, IOException {
         CountDownLatch countDownLatch = new CountDownLatch(3);
         AtomicReference<Execution> triggered = new AtomicReference<>();
 
@@ -53,20 +54,52 @@ public class ForEachItemTest  extends AbstractMemoryRunnerTest {
         });
 
         URI file = storageUpload(10);
-        Map<String, Object> inputs = Map.of("file", file);
+        Map<String, Object> inputs = Map.of("file", file.toString());
         Execution execution = runnerUtils.runOne(null, "io.kestra.tests", "for-each-item", null, (flow, execution1) -> runnerUtils.typedInputs(flow, execution1, inputs));
 
         // we should have triggered 3 subflows
         assertThat(countDownLatch.await(1, TimeUnit.MINUTES), is(true));
 
         // assert on the main flow execution
-        assertThat(execution.getTaskRunList(), hasSize(11));
+        assertThat(execution.getTaskRunList(), hasSize(1));
         assertThat(execution.getState().getCurrent(), is(State.Type.SUCCESS));
 
         // assert on the last subflow execution
         assertThat(triggered.get().getState().getCurrent(), is(State.Type.SUCCESS));
         assertThat(triggered.get().getFlowId(), is("for-each-item-subflow"));
-        assertThat(triggered.get().getTaskRunList(), hasSize(4));
+        assertThat(triggered.get().getTaskRunList(), hasSize(1));
+    }
+
+    public void forEachItemNoWait() throws TimeoutException, InterruptedException, URISyntaxException, IOException {
+        CountDownLatch countDownLatch = new CountDownLatch(3);
+        AtomicReference<Execution> triggered = new AtomicReference<>();
+
+        executionQueue.receive(either -> {
+            Execution execution = either.getLeft();
+            if (execution.getFlowId().equals("for-each-item-subflow") && execution.getState().getCurrent().isTerminated()) {
+                countDownLatch.countDown();
+                triggered.set(execution);
+            }
+        });
+
+        URI file = storageUpload(10);
+        Map<String, Object> inputs = Map.of("file", file.toString());
+        Execution execution = runnerUtils.runOne(null, "io.kestra.tests", "for-each-item-no-wait", null, (flow, execution1) -> runnerUtils.typedInputs(flow, execution1, inputs));
+
+        // assert on the main flow execution
+        assertThat(execution.getTaskRunList(), hasSize(1));
+        assertThat(execution.getState().getCurrent(), is(State.Type.SUCCESS));
+        // assert that not all subflows ran (depending on the speed of execution there can be some)
+        // be careful that it's racy.
+        assertThat(countDownLatch.getCount(), greaterThan(0L));
+
+        // wait for the 3 flows to ends
+        assertThat(countDownLatch.await(1, TimeUnit.MINUTES), is(true));
+
+        // assert on the last subflow execution
+        assertThat(triggered.get().getState().getCurrent(), is(State.Type.SUCCESS));
+        assertThat(triggered.get().getFlowId(), is("for-each-item-subflow"));
+        assertThat(triggered.get().getTaskRunList(), hasSize(1));
     }
 
     private URI storageUpload(int count) throws URISyntaxException, IOException {

--- a/core/src/test/java/io/kestra/core/validations/FlowValidationTest.java
+++ b/core/src/test/java/io/kestra/core/validations/FlowValidationTest.java
@@ -30,7 +30,7 @@ class FlowValidationTest {
         Optional<ConstraintViolationException> validate = modelValidator.isValid(flow);
 
         assertThat(validate.isPresent(), is(true));
-        assertThat(validate.get().getMessage(), containsString(": Invalid Flow: Recursive call to flow [recursive-flow]"));
+        assertThat(validate.get().getMessage(), containsString(": Invalid Flow: Recursive call to flow [io.kestra.tests.recursive-flow]"));
     }
 
     private Flow parse(String path) {

--- a/core/src/test/resources/flows/valids/for-each-item-no-wait.yaml
+++ b/core/src/test/resources/flows/valids/for-each-item-no-wait.yaml
@@ -15,3 +15,5 @@ tasks:
       flowId: for-each-item-subflow
       wait: false
       transmitFailed: true
+      inputs:
+        items: "{{ taskrun.items }}"

--- a/core/src/test/resources/flows/valids/for-each-item-no-wait.yaml
+++ b/core/src/test/resources/flows/valids/for-each-item-no-wait.yaml
@@ -1,4 +1,4 @@
-id: for-each-item
+id: for-each-item-no-wait
 namespace: io.kestra.tests
 
 inputs:
@@ -13,5 +13,5 @@ tasks:
     subflow:
       namespace: io.kestra.tests
       flowId: for-each-item-subflow
-      wait: true
+      wait: false
       transmitFailed: true

--- a/core/src/test/resources/flows/valids/for-each-item-subflow.yaml
+++ b/core/src/test/resources/flows/valids/for-each-item-subflow.yaml
@@ -1,0 +1,11 @@
+id: for-each-item-subflow
+namespace: io.kestra.tests
+
+inputs:
+  - name: items
+    type: STRING
+
+tasks:
+  - id: per-item
+    type: io.kestra.core.tasks.log.Log
+    message: "{{ inputs.items }}"

--- a/core/src/test/resources/flows/valids/for-each-item-subflow.yaml
+++ b/core/src/test/resources/flows/valids/for-each-item-subflow.yaml
@@ -1,11 +1,7 @@
 id: for-each-item-subflow
 namespace: io.kestra.tests
 
-inputs:
-  - name: items
-    type: STRING
-
 tasks:
   - id: per-item
     type: io.kestra.core.tasks.log.Log
-    message: "{{ inputs.items }}"
+    message: "{{ trigger.items }}"

--- a/core/src/test/resources/flows/valids/for-each-item-subflow.yaml
+++ b/core/src/test/resources/flows/valids/for-each-item-subflow.yaml
@@ -1,7 +1,11 @@
 id: for-each-item-subflow
 namespace: io.kestra.tests
 
+inputs:
+  - name: items
+    type: STRING
+
 tasks:
   - id: per-item
     type: io.kestra.core.tasks.log.Log
-    message: "{{ trigger.items }}"
+    message: "{{ inputs.items }}"

--- a/core/src/test/resources/flows/valids/for-each-item.yaml
+++ b/core/src/test/resources/flows/valids/for-each-item.yaml
@@ -15,3 +15,5 @@ tasks:
       flowId: for-each-item-subflow
       wait: true
       transmitFailed: true
+      inputs:
+        items: "{{ taskrun.items }}"

--- a/core/src/test/resources/flows/valids/for-each-item.yaml
+++ b/core/src/test/resources/flows/valids/for-each-item.yaml
@@ -1,0 +1,19 @@
+id: for-each-item
+namespace: io.kestra.tests
+
+inputs:
+  - name: file
+    type: FILE
+
+tasks:
+  - id: each
+    type: io.kestra.core.tasks.flows.ForEachItem
+    items: "{{ inputs.file }}"
+    maxItemsPerBatch: 4
+    subFlow:
+      namespace: dev
+      flowId: per-item
+      inputs:
+        items: "{{ taskrun.items }}"
+      wait: true
+      transmitFailed: true

--- a/jdbc/src/main/java/io/kestra/jdbc/runner/JdbcExecutor.java
+++ b/jdbc/src/main/java/io/kestra/jdbc/runner/JdbcExecutor.java
@@ -389,26 +389,26 @@ public class JdbcExecutor implements ExecutorInterface {
                 workerTaskExecutionStorage.get(execution.getId())
                     .ifPresent(workerTaskExecution -> {
                         // If we didn't wait for the flow execution, the worker task execution has already been created by the Executor service.
-                        if (workerTaskExecution.getTask().getWait()) {
+                        if (((ExecutableTask)workerTaskExecution.getTask()).waitForExecution()) {
                             Flow workerTaskFlow = this.flowRepository.findByExecution(execution);
 
                             ExecutableTask executableTask = (ExecutableTask) workerTaskExecution.getTask();
 
-                        RunContext runContext = runContextFactory.of(
-                            workerTaskFlow,
-                            workerTaskExecution.getTask(),
+                            RunContext runContext = runContextFactory.of(
+                                workerTaskFlow,
+                                workerTaskExecution.getTask(),
                                 execution,
-                            workerTaskExecution.getTaskRun()
-                        );
-                        try {
-                            Optional<WorkerTaskResult> maybeWorkerTaskResult = executableTask
-                                .createWorkerTaskResult(runContext, workerTaskExecution, workerTaskFlow, execution);
+                                workerTaskExecution.getTaskRun()
+                            );
+                            try {
+                                Optional<WorkerTaskResult> maybeWorkerTaskResult = executableTask
+                                    .createWorkerTaskResult(runContext, workerTaskExecution, workerTaskFlow, execution);
 
-                            maybeWorkerTaskResult.ifPresent(workerTaskResult -> this.workerTaskResultQueue.emit(workerTaskResult));
-                        }
-                        catch (Exception e) {
-                            // TODO maybe create a FAILED Worker Task Result instead
-                            log.error("Unable to create the Worker Task Result", e);
+                                maybeWorkerTaskResult.ifPresent(workerTaskResult -> this.workerTaskResultQueue.emit(workerTaskResult));
+                            } catch (Exception e) {
+                                // TODO maybe create a FAILED Worker Task Result instead
+                                log.error("Unable to create the Worker Task Result", e);
+                            }
                         }
 
                         workerTaskExecutionStorage.delete(workerTaskExecution);

--- a/jdbc/src/test/java/io/kestra/jdbc/runner/JdbcRunnerTest.java
+++ b/jdbc/src/test/java/io/kestra/jdbc/runner/JdbcRunnerTest.java
@@ -12,6 +12,7 @@ import io.kestra.core.repositories.LocalFlowRepositoryLoader;
 import io.kestra.core.runners.*;
 import io.kestra.core.tasks.flows.EachSequentialTest;
 import io.kestra.core.tasks.flows.FlowCaseTest;
+import io.kestra.core.tasks.flows.ForEachItemCaseTest;
 import io.kestra.core.tasks.flows.PauseTest;
 import io.kestra.core.tasks.flows.WorkingDirectoryTest;
 import io.kestra.core.utils.TestsUtils;
@@ -76,6 +77,9 @@ public abstract class JdbcRunnerTest {
 
     @Inject
     private SkipExecutionCaseTest skipExecutionCaseTest;
+
+    @Inject
+    private ForEachItemCaseTest forEachItemCaseTest;
 
     @BeforeAll
     void init() throws IOException, URISyntaxException {
@@ -261,5 +265,15 @@ public abstract class JdbcRunnerTest {
     @Test
     void skipExecution() throws TimeoutException, InterruptedException {
         skipExecutionCaseTest.skipExecution();
+    }
+
+    @Test
+    void forEachItem() throws URISyntaxException, IOException, InterruptedException, TimeoutException {
+        forEachItemCaseTest.forEachItem();
+    }
+
+    @Test
+    void forEachItemNoWait() throws URISyntaxException, IOException, InterruptedException, TimeoutException {
+        forEachItemCaseTest.forEachItemNoWait();
     }
 }

--- a/runner-memory/src/main/java/io/kestra/runner/memory/MemoryExecutor.java
+++ b/runner-memory/src/main/java/io/kestra/runner/memory/MemoryExecutor.java
@@ -9,6 +9,7 @@ import io.kestra.core.models.executions.TaskRun;
 import io.kestra.core.models.flows.Flow;
 import io.kestra.core.models.flows.State;
 import io.kestra.core.models.tasks.ExecutableTask;
+import io.kestra.core.models.tasks.Task;
 import io.kestra.core.models.triggers.multipleflows.MultipleConditionStorageInterface;
 import io.kestra.core.queues.QueueFactoryInterface;
 import io.kestra.core.queues.QueueInterface;
@@ -251,28 +252,28 @@ public class MemoryExecutor implements ExecutorInterface {
                 WorkerTaskExecution<?> workerTaskExecution = WORKERTASKEXECUTIONS_WATCHER.get(execution.getId());
 
                 // If we didn't wait for the flow execution, the worker task execution has already been created by the Executor service.
-                if (workerTaskExecution.getTask().getWait()) {
+                if (workerTaskExecution.getTask().waitForExecution()) {
+
                     Flow workerTaskFlow = this.flowRepository.findByExecution(execution);
 
                     ExecutableTask executableTask = workerTaskExecution.getTask();
 
-                RunContext runContext = runContextFactory.of(
-                    workerTaskFlow,
-                    workerTaskExecution.getTask(),
+                    RunContext runContext = runContextFactory.of(
+                        workerTaskFlow,
+                        workerTaskExecution.getTask(),
                         execution,
-                    workerTaskExecution.getTaskRun()
-                );
-                try {
-                    Optional<WorkerTaskResult> maybeWorkerTaskResult = executableTask
-                        .createWorkerTaskResult(runContext, workerTaskExecution, workerTaskFlow, execution);
+                        workerTaskExecution.getTaskRun()
+                    );
+                    try {
+                        Optional<WorkerTaskResult> maybeWorkerTaskResult = executableTask
+                            .createWorkerTaskResult(runContext, workerTaskExecution, workerTaskFlow, execution);
 
-                    maybeWorkerTaskResult.ifPresent(workerTaskResult -> this.workerTaskResultQueue.emit(workerTaskResult));
+                        maybeWorkerTaskResult.ifPresent(workerTaskResult -> this.workerTaskResultQueue.emit(workerTaskResult));
+                    } catch (Exception e) {
+                        // TODO maybe create a FAILED Worker Task Result instead<>
+                        log.error("Unable to create the Worker Task Result", e);
+                    }
                 }
-                catch (Exception e) {
-                    // TODO maybe create a FAILED Worker Task Result instead<>
-                    log.error("Unable to create the Worker Task Result", e);
-                }
-
 
                 WORKERTASKEXECUTIONS_WATCHER.remove(execution.getId());
             }


### PR DESCRIPTION
Fixes https://github.com/kestra-io/kestra/issues/2131

### What changes are being made and why?

Add a `ForEachItem` task that will split a file in batches and will trigger a subflow execution for each batch.

The current implementation will generates as many subflows as there is batches with unlimited concurrency.

---

### How the changes have been QAed?

Parent flow

```yaml
id: each-item
namespace: dev

tasks:
  - id: extract
    type: io.kestra.plugin.gcp.bigquery.Query
    sql: |
      SELECT DATETIME(datehour) as date, title, views FROM `bigquery-public-data.wikipedia.pageviews_2023` 
      WHERE DATE(datehour) = current_date() and wiki = 'fr' and title not in ('Cookie_(informatique)', 'Wikipédia:Accueil_principal', 'Spécial:Recherche')
      ORDER BY datehour desc, views desc
      LIMIT 10000
    store: true
  
  - id: each
    type: io.kestra.core.tasks.flows.ForEachItem
    items: "{{ outputs.extract.uri }}"
    maxItemsPerBatch: 10
    subflow:
      namespace: dev
      flowId: per-item
      wait: true
      transmitFailed: true
```

Sub flow:

```yaml
id: per-item
namespace: dev

tasks:
  - id: per-item
    type: io.kestra.core.tasks.log.Log
    message: "{{ trigger.items }}"
```
