### PR TITLE
feat(core): add Shell argument Pebble filter

### DIFF
--- a/core/src/main/java/io/kestra/core/runners/pebble/Extension.java
+++ b/core/src/main/java/io/kestra/core/runners/pebble/Extension.java
@@ -60,6 +60,7 @@ public class Extension extends AbstractExtension {
         filters.put("timestampMicro", new TimestampMicroFilter());
         filters.put("timestampNano", new TimestampNanoFilter());
         filters.put("jq", new JqFilter());
+        filters.put("sh", new ShFilter());
         filters.put("json", new JsonFilter());
         filters.put("keys", new KeysFilter());
         filters.put("number", new NumberFilter());

--- a/core/src/main/java/io/kestra/core/runners/pebble/filters/ShFilter.java
+++ b/core/src/main/java/io/kestra/core/runners/pebble/filters/ShFilter.java
@@ -1,0 +1,27 @@
+package io.kestra.core.runners.pebble.filters;
+
+import io.pebbletemplates.pebble.error.PebbleException;
+import io.pebbletemplates.pebble.extension.Filter;
+import io.pebbletemplates.pebble.template.EvaluationContext;
+import io.pebbletemplates.pebble.template.PebbleTemplate;
+
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Matcher;
+
+public class ShFilter implements Filter {
+
+    @Override
+    public List<String> getArgumentNames() {
+        return null;
+    }
+
+    @Override
+    public Object apply(Object input, Map<String, Object> args, PebbleTemplate self, EvaluationContext context, int lineNumber) throws PebbleException {
+        if (input == null) {
+            return null;
+        }
+
+        return input.toString().replaceAll("'",  Matcher.quoteReplacement("'\\''"));
+    }
+}

--- a/core/src/test/java/io/kestra/core/runners/pebble/filters/ShFilterTest.java
+++ b/core/src/test/java/io/kestra/core/runners/pebble/filters/ShFilterTest.java
@@ -1,0 +1,30 @@
+package io.kestra.core.runners.pebble.filters;
+
+import io.kestra.core.exceptions.IllegalVariableEvaluationException;
+import io.kestra.core.runners.VariableRenderer;
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+
+@MicronautTest
+public class ShFilterTest {
+    @Inject
+    private VariableRenderer variableRenderer;
+
+    @Test
+    void bashShellFormat() throws IllegalVariableEvaluationException {
+        String render = variableRenderer.render(
+            "echo '{{ shellVar | sh }}'",
+            Map.of("shellVar", "foo' bar'baz")
+        );
+
+        assertThat(render, is("echo 'foo'\\'' bar'\\''baz'"));
+    }
+}


### PR DESCRIPTION
Passing arbitrary arguments to Shell requires escaping their values. Arguments rendered by Pebble templates should use single quotes with escaping using the `replace` filter.

This newly introduced `sh` filter eases the sanitizatinon process.

### What changes are being made and why?

Added `sh` Pebble filter to remove the need to use a specific `replace` filter repeatedly.

---

### How the changes have been QAed?

```yaml
id: hello-world
namespace: dev

variables:
  quoted: "Can't"

tasks:
  - id: hello
    type: io.kestra.plugin.scripts.shell.Commands
    commands:
      - "echo '--- {{ vars.quoted | sh }} ---'"
      - "echo '--- {{ vars.quoted }} ---'" # FIXME
```