### PR TITLE
fix(core): the tenantId is passed via method argument not inside the …

### DIFF
--- a/core/src/main/java/io/kestra/core/models/executions/statistics/Flow.java
+++ b/core/src/main/java/io/kestra/core/models/executions/statistics/Flow.java
@@ -6,8 +6,6 @@ import javax.validation.constraints.NotNull;
 
 @Value
 public class Flow {
-    String tenantId;
-
     @NotNull
     String namespace;
 

--- a/core/src/test/java/io/kestra/core/repositories/AbstractExecutionRepositoryTest.java
+++ b/core/src/test/java/io/kestra/core/repositories/AbstractExecutionRepositoryTest.java
@@ -348,10 +348,10 @@ public abstract class AbstractExecutionRepositoryTest {
         List<ExecutionCount> result = executionRepository.executionCounts(
             null,
             List.of(
-                new io.kestra.core.models.executions.statistics.Flow(null, NAMESPACE, "first"),
-                new io.kestra.core.models.executions.statistics.Flow(null,NAMESPACE, "second"),
-                new io.kestra.core.models.executions.statistics.Flow(null,NAMESPACE, "third"),
-                new Flow(null,NAMESPACE, "missing")
+                new io.kestra.core.models.executions.statistics.Flow(NAMESPACE, "first"),
+                new io.kestra.core.models.executions.statistics.Flow(NAMESPACE, "second"),
+                new io.kestra.core.models.executions.statistics.Flow(NAMESPACE, "third"),
+                new Flow(NAMESPACE, "missing")
             ),
             null,
             ZonedDateTime.now().minusDays(10),


### PR DESCRIPTION
…Flow class

The io.kestra.core.models.executions.statistics.Flow class is only used by the Count task to filter on some flows (I think it should be moved there some day), when the Count task calls the execution repository to count executions by flow it passed the tenantId in the method (as the Count task can only count executions on the tenant it is runned) so it's not needed (it's even incorrect) to have it in the Flow class.