### PR TITLE
fix(ui): Make the main Monaco editor focused by default

### DIFF
--- a/ui/src/components/inputs/Editor.vue
+++ b/ui/src/components/inputs/Editor.vue
@@ -218,6 +218,8 @@
                     this.editor.onDidFocusEditorText(() => {
                         this.focus = true;
                     })
+
+                    this.$refs.monacoEditor.focus();
                 }
 
                 this.editor.addAction({


### PR DESCRIPTION
### What changes are being made and why?

The _Flow - Editor_ view should feature the Monaco editor focused - it is the main focal point of the view. Having the editor focused makes the GUI-based flow editing UX smoother. There is one click less required between activating the view and typing.

---

### How the changes have been QAed?

Just try to edit any flow

---