### PR TITLE
feat(jdbc): add indices on tenant_id

### DIFF
--- a/jdbc-h2/src/main/resources/migrations/h2/V1_9__multitenant_indices.sql
+++ b/jdbc-h2/src/main/resources/migrations/h2/V1_9__multitenant_indices.sql
@@ -1,0 +1,37 @@
+DROP INDEX IF EXISTS flows_namespace;
+DROP INDEX IF EXISTS flows_namespace__id__revision;
+CREATE INDEX IF NOT EXISTS flows_namespace ON flows ("deleted", "tenant_id", "namespace");
+CREATE INDEX IF NOT EXISTS flows_namespace__id__revision ON flows ("deleted", "tenant_id", "namespace", "id", "revision");
+
+DROP INDEX IF EXISTS templates_namespace;
+DROP INDEX IF EXISTS templates_namespace__id;
+CREATE INDEX IF NOT EXISTS templates_namespace ON templates ("deleted", "tenant_id", "namespace");
+CREATE INDEX IF NOT EXISTS templates_namespace__id ON templates ("deleted", "tenant_id", "namespace", "id");
+
+DROP INDEX IF EXISTS executions_namespace;
+DROP INDEX IF EXISTS executions_flow_id;
+DROP INDEX IF EXISTS executions_state_current;
+DROP INDEX IF EXISTS executions_start_date;
+DROP INDEX IF EXISTS executions_end_date;
+DROP INDEX IF EXISTS executions_state_duration;
+CREATE INDEX IF NOT EXISTS executions_namespace ON executions ("deleted", "tenant_id", "namespace");
+CREATE INDEX IF NOT EXISTS executions_flow_id ON executions ("deleted", "tenant_id", "flow_id");
+CREATE INDEX IF NOT EXISTS executions_state_current ON executions ("deleted", "tenant_id", "state_current");
+CREATE INDEX IF NOT EXISTS executions_start_date ON executions ("deleted", "tenant_id", "start_date");
+CREATE INDEX IF NOT EXISTS executions_end_date ON executions ("deleted", "tenant_id", "end_date");
+CREATE INDEX IF NOT EXISTS executions_state_duration ON executions ("deleted", "tenant_id", "state_duration");
+
+CREATE INDEX IF NOT EXISTS triggers__tenant ON triggers ("tenant_id");
+
+DROP INDEX IF EXISTS flow_topologies_destination;
+DROP INDEX IF EXISTS flow_topologies_destination__source;
+CREATE INDEX IF NOT EXISTS flow_topologies_destination ON flow_topologies ("destination_tenant_id", "destination_namespace", "destination_id");
+CREATE INDEX IF NOT EXISTS flow_topologies_destination__source ON flow_topologies ("destination_tenant_id", "destination_namespace", "destination_id", "source_tenant_id", "source_namespace", "source_id");
+
+DROP INDEX IF EXISTS metrics_flow_id;
+DROP INDEX IF EXISTS metrics_timestamp;
+CREATE INDEX IF NOT EXISTS metrics_flow_id ON metrics ("deleted", "tenant_id", "namespace", "flow_id");
+CREATE INDEX IF NOT EXISTS metrics_timestamp ON metrics ("deleted", "tenant_id", "timestamp");
+
+DROP INDEX IF EXISTS logs_namespace_flow;
+CREATE INDEX IF NOT EXISTS logs_namespace_flow ON logs ("deleted", "tenant_id", "timestamp", "level", "namespace", "flow_id");

--- a/jdbc-mysql/src/main/resources/migrations/mysql/V1_10__multitenant_indices.sql
+++ b/jdbc-mysql/src/main/resources/migrations/mysql/V1_10__multitenant_indices.sql
@@ -1,0 +1,37 @@
+DROP INDEX ix_namespace ON flows;
+DROP INDEX ix_namespace__id__revision ON flows;
+CREATE INDEX ix_namespace ON flows (`deleted`, `tenant_id`, `namespace`);
+CREATE INDEX ix_namespace__id__revision ON flows (`deleted`, `tenant_id`, `namespace`, `id`, `revision`);
+
+DROP INDEX ix_namespace ON templates;
+DROP INDEX ix_namespace__id ON templates;
+CREATE INDEX ix_namespace ON templates (`deleted`, `tenant_id`, `namespace`);
+CREATE INDEX ix_namespace__id ON templates (`deleted`, `tenant_id`, `namespace`, `id`);
+
+DROP INDEX ix_namespace ON executions;
+DROP INDEX ix_flowId ON executions;
+DROP INDEX ix_state_current ON executions;
+DROP INDEX ix_start_date ON executions;
+DROP INDEX ix_end_date ON executions;
+DROP INDEX ix_state_duration ON executions;
+CREATE INDEX ix_namespace ON executions (`deleted`, `tenant_id`, `namespace`);
+CREATE INDEX ix_flowId ON executions (`deleted`, `tenant_id`, `flow_id`);
+CREATE INDEX ix_state_current ON executions (`deleted`, `tenant_id`, `state_current`);
+CREATE INDEX ix_start_date ON executions (`deleted`, `tenant_id`, `start_date`);
+CREATE INDEX ix_end_date ON executions (`deleted`, `tenant_id`, `end_date`);
+CREATE INDEX ix_state_duration ON executions (`deleted`, `tenant_id`, `state_duration`);
+
+CREATE INDEX ix_tenant_id ON triggers (`tenant_id`);
+
+DROP INDEX ix_destination ON flow_topologies;
+DROP INDEX ix_destination__source ON flow_topologies;
+CREATE INDEX ix_destination ON flow_topologies (`destination_tenant_id`, `destination_namespace`, `destination_id`);
+CREATE INDEX ix_source ON flow_topologies (`source_tenant_id`, `source_namespace`, `source_id`);
+
+DROP INDEX ix_metrics_flow_id ON metrics;
+DROP INDEX ix_metrics_timestamp ON metrics;
+CREATE INDEX metrics_flow_id ON metrics (`deleted`, `tenant_id`, `namespace`, `flow_id`);
+CREATE INDEX metrics_timestamp ON metrics (`deleted`, `tenant_id`, `timestamp`);
+
+DROP INDEX ix_namespace_flow ON logs;
+CREATE INDEX ix_namespace_flow ON logs (`deleted`, `tenant_id`, `timestamp`, `level`, `namespace`, `flow_id`);

--- a/jdbc-postgres/src/main/resources/migrations/postgres/V1_10__multitenant_indices.sql
+++ b/jdbc-postgres/src/main/resources/migrations/postgres/V1_10__multitenant_indices.sql
@@ -1,0 +1,37 @@
+DROP INDEX IF EXISTS flows_namespace;
+DROP INDEX IF EXISTS flows_namespace__id__revision;
+CREATE INDEX IF NOT EXISTS flows_namespace ON flows ("deleted", "tenant_id", "namespace");
+CREATE INDEX IF NOT EXISTS flows_namespace__id__revision ON flows ("deleted", "tenant_id", "namespace", "id", "revision");
+
+DROP INDEX IF EXISTS templates_namespace;
+DROP INDEX IF EXISTS templates_namespace__id;
+CREATE INDEX IF NOT EXISTS templates_namespace ON templates ("deleted", "tenant_id", "namespace");
+CREATE INDEX IF NOT EXISTS templates_namespace__id ON templates ("deleted", "tenant_id", "namespace", "id");
+
+DROP INDEX IF EXISTS executions_namespace;
+DROP INDEX IF EXISTS executions_flow_id;
+DROP INDEX IF EXISTS executions_state_current;
+DROP INDEX IF EXISTS executions_start_date;
+DROP INDEX IF EXISTS executions_end_date;
+DROP INDEX IF EXISTS executions_state_duration;
+CREATE INDEX IF NOT EXISTS executions_namespace ON executions ("deleted", "tenant_id", "namespace");
+CREATE INDEX IF NOT EXISTS executions_flow_id ON executions ("deleted", "tenant_id", "flow_id");
+CREATE INDEX IF NOT EXISTS executions_state_current ON executions ("deleted", "tenant_id", "state_current");
+CREATE INDEX IF NOT EXISTS executions_start_date ON executions ("deleted", "tenant_id", "start_date");
+CREATE INDEX IF NOT EXISTS executions_end_date ON executions ("deleted", "tenant_id", "end_date");
+CREATE INDEX IF NOT EXISTS executions_state_duration ON executions ("deleted", "tenant_id", "state_duration");
+
+CREATE INDEX IF NOT EXISTS triggers__tenant ON triggers ("tenant_id");
+
+DROP INDEX IF EXISTS flow_topologies_destination;
+DROP INDEX IF EXISTS flow_topologies_destination__source;
+CREATE INDEX IF NOT EXISTS flow_topologies_destination ON flow_topologies ("destination_tenant_id", "destination_namespace", "destination_id");
+CREATE INDEX IF NOT EXISTS flow_topologies_destination__source ON flow_topologies ("destination_tenant_id", "destination_namespace", "destination_id", "source_tenant_id", "source_namespace", "source_id");
+
+DROP INDEX IF EXISTS metrics_flow_id;
+DROP INDEX IF EXISTS metrics_timestamp;
+CREATE INDEX IF NOT EXISTS metrics_flow_id ON metrics ("deleted", "tenant_id", "namespace", "flow_id");
+CREATE INDEX IF NOT EXISTS metrics_timestamp ON metrics ("deleted", "tenant_id", "timestamp");
+
+DROP INDEX IF EXISTS logs_namespace_flow;
+CREATE INDEX IF NOT EXISTS logs_namespace_flow ON logs ("deleted", "tenant_id", "timestamp", "level", "namespace", "flow_id");


### PR DESCRIPTION
~Only add a new index for optimizing findAll(), other access should use existing indices.~

The rational is that:
- There should not be a lot of tenants in an instance (a few tens or hundreds at most)
- Existing indices will still be highly distributed as the same flow/namespace has low chance to be on multiple tenants
So the cost of updating all indexes (which means reindexing potentially large tables) with the new columns seems too high with respect to the added value.