### PR TITLE
fix(ui): homepage dashboard incorrect results

### DIFF
--- a/ui/src/components/home/Home.vue
+++ b/ui/src/components/home/Home.vue
@@ -258,8 +258,8 @@
                         let sorted = data.sort((a, b) => {
                             return new Date(b.date) - new Date(a.date);
                         });
-                        this.today = sorted.shift();
-                        this.yesterday = sorted.shift();
+                        this.today = sorted.at(sorted.length - 1);
+                        this.yesterday = sorted.length >= 2 ? sorted.at(sorted.length - 2) : {};
                         this.alls = this.mergeStats(sorted);
                         this.dailyReady = true;
                     });


### PR DESCRIPTION
Array.shift() return the last item and modify the array so the "last 30 days" widget didn,'t contains today and yesterday. Usingt Array.at() didn't modify the array, fixing the issue of incorrect results.

Fixes #2232