### PR TITLE
ci: add the Kestra Python library to oiur full Docker image

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -157,6 +157,7 @@ jobs:
           - name: ""
             plugins: ""
             packages: ""
+            python-libs: ""
           - name: "-full"
             plugins: >-
               io.kestra.plugin:plugin-airbyte:LATEST
@@ -231,7 +232,8 @@ jobs:
               io.kestra.storage:storage-gcs:LATEST
               io.kestra.storage:storage-minio:LATEST
               io.kestra.storage:storage-s3:LATEST
-            packages: python3 python3-venv python-is-python3 nodejs npm curl zip unzip
+            packages: python3 python3-venv python-is-python3 python3-pip nodejs npm curl zip unzip
+            python-libs: kestra
     steps:
       - uses: actions/checkout@v4
 
@@ -293,6 +295,7 @@ jobs:
           build-args: |
             KESTRA_PLUGINS=${{ steps.vars.outputs.plugins }}
             APT_PACKAGES=${{ matrix.image.packages }}
+            PYTHON_LIBRARIES=${{ matrix.image.python-libs }}
 
   maven:
     name: Publish to Maven

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@ FROM eclipse-temurin:17-jre
 
 ARG KESTRA_PLUGINS=""
 ARG APT_PACKAGES=""
+ARG PYTHON_LIBRARIES=""
 
 WORKDIR /app
 
@@ -16,6 +17,7 @@ RUN apt-get update -y && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* /var/tmp/* /tmp/* && \
     if [ -n "${KESTRA_PLUGINS}" ]; then /app/kestra plugins install ${KESTRA_PLUGINS} && rm -rf /tmp/*; fi && \
+    if [ -n "${PYTHON_LIBRARIES}" ]; then pip install ${PYTHON_LIBRARIES}; fi && \
     chown -R kestra:kestra /app
 
 USER kestra


### PR DESCRIPTION
This added 15MB to the image as we need to install pip to do it. 

Fixes #2357
