### PR TITLE
feat(core): allow the Pebble read() function to read from the interna…

### DIFF
--- a/core/src/main/java/io/kestra/core/runners/pebble/functions/ReadFileFunction.java
+++ b/core/src/main/java/io/kestra/core/runners/pebble/functions/ReadFileFunction.java
@@ -17,7 +17,8 @@ import java.util.Map;
 
 @Singleton
 public class ReadFileFunction implements Function {
-    private static final String ERROR_MESSAGE = "The 'read' function expects an argument 'path' with structure {filePath}.";
+    private static final String ERROR_MESSAGE = "The 'read' function expects an argument 'path' that is a path to a namespace file or an internal storage URI.";
+    private static final String KESTRA_SCHEME = "kestra:///";
 
     @Inject
     private StorageInterface storageInterface;
@@ -29,24 +30,41 @@ public class ReadFileFunction implements Function {
         return List.of("path");
     }
 
-    @SuppressWarnings("unchecked")
     @Override
     public Object execute(Map<String, Object> args, PebbleTemplate self, EvaluationContext context, int lineNumber) {
-        Map<String, String> flow = (Map<String, String>) context.getVariable("flow");
-
-        try {
-            return new String(storageInterface.get(tenantService.resolveTenant(), getStorageUri(flow.get("namespace"), args, self, lineNumber)).readAllBytes(), StandardCharsets.UTF_8);
-        } catch (IOException e) {
-            throw new PebbleException(e, e.getMessage(), lineNumber, self.getName());
-        }
-    }
-
-    protected URI getStorageUri(String namespace, Map<String, Object> args, PebbleTemplate self, int lineNumber) {
         if (!args.containsKey("path")) {
             throw new PebbleException(null, ERROR_MESSAGE, lineNumber, self.getName());
         }
 
         String path = (String) args.get("path");
-        return URI.create(storageInterface.namespaceFilePrefix(namespace) + "/" + path);
+        try {
+            return path.startsWith(KESTRA_SCHEME) ? readFromInternalStorageUri(context, path) : readFromNamespaceFile(context, path);
+        }
+        catch (IOException e) {
+            throw new PebbleException(e, e.getMessage(), lineNumber, self.getName());
+        }
+    }
+
+    private String readFromNamespaceFile(EvaluationContext context, String path) throws IOException {
+        Map<String, String> flow = (Map<String, String>) context.getVariable("flow");
+        URI namespaceFile = URI.create(storageInterface.namespaceFilePrefix(flow.get("namespace")) + "/" + path);
+        return new String(storageInterface.get(tenantService.resolveTenant(), namespaceFile).readAllBytes(), StandardCharsets.UTF_8);
+    }
+
+    private String readFromInternalStorageUri(EvaluationContext context, String path) throws IOException {
+        Map<String, String> flow = (Map<String, String>) context.getVariable("flow");
+        Map<String, String> execution = (Map<String, String>) context.getVariable("execution");
+        validateFileUri(flow.get("namespace"), flow.get("id"), execution.get("id"), path);
+        URI internalStorageFile = URI.create(path);
+        return new String(storageInterface.get(tenantService.resolveTenant(), internalStorageFile).readAllBytes(), StandardCharsets.UTF_8);
+    }
+
+    private void validateFileUri(String namespace, String flowId, String executionId, String path) {
+        // Internal storage URI should be: kestra:///$namespace/$flowId/executions/$executionId/tasks/$taskName/$taskRunId/$random.ion or kestra:///$namespace/$flowId/executions/$executionId/trigger/$triggerName/$random.ion
+        // We check that the file is for the given flow execution
+        String authorizedBasePath = KESTRA_SCHEME + namespace + "/" + flowId + "/executions/" + executionId + "/";
+        if (!path.startsWith(authorizedBasePath)) {
+            throw new IllegalArgumentException("Unable to read a file that didn't belong to the current execution");
+        }
     }
 }


### PR DESCRIPTION
…l storage

Fixes #2426

## QA

This flow shows how to use it for inputs, launch it twice, and update the last task to use a previous URI to check that a file that exists is not accessible if it's not for the current execution.

It also works for tasks and trigger outputs as they share the same prefix as inputs so the check will validate them.

```yaml
id: read-internal-storage
namespace: dev

inputs:
  - name: file
    type: FILE

tasks:
  - id: log-uri
    type: io.kestra.core.tasks.log.Log
    message: "{{ inputs.file }}"

  - id: log-content
    type: io.kestra.core.tasks.log.Log
    message: "{{ read(inputs.file) }}"    

  # use the URI of a previous execution
  - id: log-unauthorized
    type: io.kestra.core.tasks.log.Log
    message: "{{ read('kestra:///dev/read-internal-storage/executions/7Twz4FXx0Rx2WHwdQWXG17/inputs/file/file_12387099138682102581.upl') }}"
```