### PR TITLE
feat: allow running Flyway migration with a command

### DIFF
--- a/cli/src/main/java/io/kestra/cli/commands/sys/SysCommand.java
+++ b/cli/src/main/java/io/kestra/cli/commands/sys/SysCommand.java
@@ -1,5 +1,6 @@
 package io.kestra.cli.commands.sys;
 
+import io.kestra.cli.commands.sys.database.DatabaseCommand;
 import io.micronaut.configuration.picocli.PicocliRunner;
 import lombok.extern.slf4j.Slf4j;
 import io.kestra.cli.AbstractCommand;
@@ -11,7 +12,8 @@ import picocli.CommandLine;
     description = "handle systems maintenance",
     mixinStandardHelpOptions = true,
     subcommands = {
-        ReindexCommand.class
+        ReindexCommand.class,
+        DatabaseCommand.class
     }
 )
 @Slf4j

--- a/cli/src/main/java/io/kestra/cli/commands/sys/database/DatabaseCommand.java
+++ b/cli/src/main/java/io/kestra/cli/commands/sys/database/DatabaseCommand.java
@@ -1,0 +1,15 @@
+package io.kestra.cli.commands.sys.database;
+
+import io.kestra.cli.AbstractCommand;
+import picocli.CommandLine;
+
+@CommandLine.Command(
+    name = "database",
+    description = "manage Kestra database",
+    mixinStandardHelpOptions = true,
+    subcommands = {
+        DatabaseMigrateCommand.class,
+    }
+)
+public class DatabaseCommand extends AbstractCommand {
+}

--- a/cli/src/main/java/io/kestra/cli/commands/sys/database/DatabaseMigrateCommand.java
+++ b/cli/src/main/java/io/kestra/cli/commands/sys/database/DatabaseMigrateCommand.java
@@ -1,0 +1,40 @@
+package io.kestra.cli.commands.sys.database;
+
+import ch.qos.logback.classic.Level;
+import io.kestra.cli.AbstractCommand;
+import lombok.extern.slf4j.Slf4j;
+import picocli.CommandLine;
+
+import java.util.Map;
+
+@CommandLine.Command(
+    name = "migrate",
+    description = "Force database schema migration.\nKestra uses Flyway to manage database schema evolution, this command will run Flyway then exit.",
+    mixinStandardHelpOptions = true
+)
+@Slf4j
+public class DatabaseMigrateCommand extends AbstractCommand {
+
+    static {
+        // Force enable Flyway logs
+        ch.qos.logback.classic.Logger flywayLogger = (ch.qos.logback.classic.Logger) org.slf4j.LoggerFactory.getLogger("org.flywaydb");
+        flywayLogger.setLevel(Level.INFO);
+    }
+
+    @Override
+    public Integer call() throws Exception {
+        // Flyway will run automatically
+        super.call();
+        stdOut("Successfully run the database schema migration.");
+        return 0;
+    }
+
+    public static Map<String, Object> propertiesOverrides() {
+        // Forcing the props to enabled Flyway: it allows to disable Flyway globally and still using this command.
+        return Map.of(
+            "flyway.datasources.postgres.enabled", "true",
+            "flyway.datasources.mysql.enabled", "true",
+            "flyway.datasources.h2.enabled", "true"
+        );
+    }
+}


### PR DESCRIPTION
Fixes #2291

To use it, the user can run Kestra in a separate container/pod or start Kestra with Flyway disabled and run the command.
To disable Flyway migration the following configuration should be used:

```properties
flyway:
  datasources:
    postgres:
      enabled: false
    mysql:
      enabled: false
    h2:
      enabled: false
```

It needs to be documented on the migration guide, noted on each release note that have migration and our Helm chart should be improved to include a shell pod.