### PR TITLE
fix(ui): fix labels filter regression

### DIFF
--- a/ui/src/components/layout/Labels.vue
+++ b/ui/src/components/layout/Labels.vue
@@ -4,7 +4,7 @@
         <el-tag
             v-for="(value, key) in labelMap"
             :key="key"
-            :type="checked(key) ? 'info' : ''"
+            :type="checked(key, value) ? 'info' : ''"
             class="me-1 labels"
             size="small"
             disable-transitions
@@ -31,16 +31,13 @@
         },
         // this is needed as flows uses a Map and Execution a List of Labels.
         // if we align both of them this can be removed
-        mounted() {
-            if (Array.isArray(this.labels)) {
-                this.labelMap = Object.fromEntries(this.labels.map(label => [label.key, label.value]))
-            } else {
-                this.labelMap = this.labels;
-            }
-        },
-        data() {
-            return {
-                labelMap: {}
+        computed: {
+            labelMap() {
+                if (Array.isArray(this.labels)) {
+                    return Object.fromEntries(this.labels.map(label => [label.key, label.value]));
+                } else {
+                    return this.labels;
+                }
             }
         },
         methods: {
@@ -58,8 +55,8 @@
 
                 return labels;
             },
-            checked(key) {
-                return this.getLabelsFromQuery().has(key);
+            checked(key, value) {
+                return this.getLabelsFromQuery().has(key) && this.getLabelsFromQuery().get(key) === value;
             },
             link(key, value) {
                 const labels = this.getLabelsFromQuery();


### PR DESCRIPTION
### What changes are being made and why?

The execution table can be filtered by simply clicking on an execution label. This did not work anymore - the filtering action brought seemingly random lines instead.

The same applies to the flows view filter.

---

### How the changes have been QAed?

Using a local PgSQL Kestra instance.

1. Save any flow
2. Start a new execution with label `A:B`
3. Start a new execution with label `C:D`
4. Start a new execution with label `A:B`
5. Go to Executions
6. Click on the `A:B` label
7. Only the executions featuring `A:B` are shown

---