### PR TITLE
Fix/read function parent execution

### DIFF
--- a/core/src/main/java/io/kestra/core/runners/pebble/functions/ReadFileFunction.java
+++ b/core/src/main/java/io/kestra/core/runners/pebble/functions/ReadFileFunction.java
@@ -54,17 +54,29 @@ public class ReadFileFunction implements Function {
     private String readFromInternalStorageUri(EvaluationContext context, String path) throws IOException {
         Map<String, String> flow = (Map<String, String>) context.getVariable("flow");
         Map<String, String> execution = (Map<String, String>) context.getVariable("execution");
-        validateFileUri(flow.get("namespace"), flow.get("id"), execution.get("id"), path);
+
+        // check if the file is from the current execution
+        if (!validateFileUri(flow.get("namespace"), flow.get("id"), execution.get("id"), path)) {
+            // if not, it can be from the parent execution, so we check if there is a trigger of type execution
+            if (context.getVariable("trigger") != null) {
+                // if there is a trigger of type execution, we also allow accessing a file from the parent execution
+                Map<String, String> trigger = (Map<String, String>) context.getVariable("trigger");
+                if (!validateFileUri(trigger.get("namespace"), trigger.get("flowId"), trigger.get("executionId"), path)) {
+                    throw new IllegalArgumentException("Unable to read a file that didn't belong to the current execution");
+                }
+            }
+            else {
+                throw new IllegalArgumentException("Unable to read a file that didn't belong to the current execution");
+            }
+        }
         URI internalStorageFile = URI.create(path);
         return new String(storageInterface.get(tenantService.resolveTenant(), internalStorageFile).readAllBytes(), StandardCharsets.UTF_8);
     }
 
-    private void validateFileUri(String namespace, String flowId, String executionId, String path) {
+    private boolean validateFileUri(String namespace, String flowId, String executionId, String path) {
         // Internal storage URI should be: kestra:///$namespace/$flowId/executions/$executionId/tasks/$taskName/$taskRunId/$random.ion or kestra:///$namespace/$flowId/executions/$executionId/trigger/$triggerName/$random.ion
         // We check that the file is for the given flow execution
         String authorizedBasePath = KESTRA_SCHEME + namespace + "/" + flowId + "/executions/" + executionId + "/";
-        if (!path.startsWith(authorizedBasePath)) {
-            throw new IllegalArgumentException("Unable to read a file that didn't belong to the current execution");
-        }
+        return path.startsWith(authorizedBasePath);
     }
 }

--- a/core/src/test/java/io/kestra/core/runners/pebble/functions/ReadFileFunctionTest.java
+++ b/core/src/test/java/io/kestra/core/runners/pebble/functions/ReadFileFunctionTest.java
@@ -98,7 +98,7 @@ class ReadFileFunctionTest {
         );
 
         var exception = assertThrows(IllegalArgumentException.class, () -> variableRenderer.render("{{ read('" + internalStorageFile + "') }}", variables));
-        assertThat(exception.getMessage(), is("Unable to read a file that didn't belong to the current execution"));
+        assertThat(exception.getMessage(), is("Unable to read the file '" + internalStorageFile + "' as it didn't belong to the current execution"));
 
         // test for an un-authorized execution with a trigger of type execution
         Map<String, Object> executionTriggerVariables = Map.of(
@@ -114,7 +114,7 @@ class ReadFileFunctionTest {
         );
 
         exception = assertThrows(IllegalArgumentException.class, () -> variableRenderer.render("{{ read('" + internalStorageFile + "') }}", executionTriggerVariables));
-        assertThat(exception.getMessage(), is("Unable to read a file that didn't belong to the current execution"));
+        assertThat(exception.getMessage(), is("Unable to read the file '" + internalStorageFile + "' as it didn't belong to the current execution"));
 
         // test for an un-authorized execution with a trigger of another type
         Map<String, Object> triggerVariables = Map.of(
@@ -129,6 +129,6 @@ class ReadFileFunctionTest {
         );
 
         exception = assertThrows(IllegalArgumentException.class, () -> variableRenderer.render("{{ read('" + internalStorageFile + "') }}", triggerVariables));
-        assertThat(exception.getMessage(), is("Unable to read a file that didn't belong to the current execution"));
+        assertThat(exception.getMessage(), is("Unable to read the file '" + internalStorageFile + "' as it didn't belong to the current execution"));
     }
 }


### PR DESCRIPTION
Fixes #2442

Also allow a subflow to read a file from the parent flow.

This allow to pass the URI of the internal storage and read the file in a subflow.

For example:

```yaml
id: each-item
namespace: dev


tasks:
  - id: extract
    type: io.kestra.plugin.gcp.bigquery.Query
    sql: |
      SELECT DATETIME(datehour) as date, title, views FROM `bigquery-public-data.wikipedia.pageviews_2023` 
      WHERE DATE(datehour) = current_date() and wiki = 'fr' and title not in ('Cookie_(informatique)', 'Wikipédia:Accueil_principal', 'Spécial:Recherche')
      ORDER BY datehour desc, views desc
      LIMIT 10
    store: true
  
  - id: each
    type: io.kestra.core.tasks.flows.ForEachItem
    items: "{{ outputs.extract.uri }}"
    batch: 
      rows: 4
    namespace: dev
    flowId: per-item
    wait: true
    transmitFailed: true
    inputs:
      items: "{{taskrun.items}}"
```


With a child flow:

```yaml
id: per-item
namespace: dev

inputs:
  - name: items
    type: STRING

tasks:
  - id: per-item
    type: io.kestra.core.tasks.log.Log
    message: "{{ inputs.items }}"
  - id: read
    type: io.kestra.core.tasks.log.Log
    message: "{{ read(inputs.items) }}"    
```