### PR TITLE
fix(core): use `_files` as namespace file prefix so it cannot mlix up…

### DIFF
--- a/core/src/main/java/io/kestra/core/storages/StorageInterface.java
+++ b/core/src/main/java/io/kestra/core/storages/StorageInterface.java
@@ -165,7 +165,7 @@ public interface StorageInterface {
     default String namespaceFilePrefix(String namespace) {
         return fromParts(
             namespace.replace(".", "/"),
-            "files"
+            "_files"
         );
     }
 

--- a/core/src/test/java/io/kestra/core/storage/StorageInterfaceTest.java
+++ b/core/src/test/java/io/kestra/core/storage/StorageInterfaceTest.java
@@ -86,6 +86,6 @@ public class StorageInterfaceTest {
     void namespaceFilePrefix() {
         var prefix = storageInterface.namespaceFilePrefix("io.namespace");
         assertThat(prefix, notNullValue());
-        assertThat(prefix, is("/io/namespace/files"));
+        assertThat(prefix, is("/io/namespace/_files"));
     }
 }

--- a/core/src/test/java/io/kestra/core/tasks/flows/VariablesTest.java
+++ b/core/src/test/java/io/kestra/core/tasks/flows/VariablesTest.java
@@ -10,6 +10,7 @@ import io.kestra.core.utils.TestsUtils;
 import jakarta.inject.Inject;
 import jakarta.inject.Named;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 
 import java.util.List;
 import java.util.Objects;
@@ -25,6 +26,8 @@ class VariablesTest extends AbstractMemoryRunnerTest {
     QueueInterface<LogEntry> workerTaskLogQueue;
 
     @Test
+    @EnabledIfEnvironmentVariable(named = "KESTRA_TEST1", matches = ".*")
+    @EnabledIfEnvironmentVariable(named = "KESTRA_TEST2", matches = ".*")
     void recursiveVars() throws TimeoutException {
         Execution execution = runnerUtils.runOne(null, "io.kestra.tests", "variables");
 

--- a/webserver/src/test/java/io/kestra/webserver/controllers/NamespaceFileControllerTest.java
+++ b/webserver/src/test/java/io/kestra/webserver/controllers/NamespaceFileControllerTest.java
@@ -90,7 +90,7 @@ class NamespaceFileControllerTest {
     @Test
     void namespaceRootStatsWithoutPreCreation() {
         FileAttributes res = client.toBlocking().retrieve(HttpRequest.GET("/api/v1/namespaces/" + NAMESPACE + "/files/stats"), TestFileAttributes.class);
-        assertThat(res.getFileName(), is("files"));
+        assertThat(res.getFileName(), is("_files"));
         assertThat(res.getType(), is(FileAttributes.FileType.Directory));
     }
 


### PR DESCRIPTION
… with a flow name

Fixes #2526