### PR TITLE
fix(core): set taskrun value in workingDirectory children task

### DIFF
--- a/core/src/main/java/io/kestra/core/runners/RunContext.java
+++ b/core/src/main/java/io/kestra/core/runners/RunContext.java
@@ -398,6 +398,16 @@ public class RunContext {
         clone.remove("task");
         clone.put("task", this.variables(workerTask.getTask()));
 
+        if (clone.containsKey("workerTaskrun") && ((Map<String, Object>) clone.get("workerTaskrun")).containsKey("value")) {
+            Map<String, Object> workerTaskrun = ((Map<String, Object>) clone.get("workerTaskrun"));
+            Map<String, Object> taskrun = new HashMap<>((Map<String, Object>) clone.get("taskrun"));
+
+            taskrun.put("value", workerTaskrun.get("value"));
+
+            clone.remove("taskrun");
+            clone.put("taskrun", taskrun);
+        }
+
         this.variables = ImmutableMap.copyOf(clone);
         this.storageExecutionPrefix = URI.create("/" + this.storageInterface.executionPrefix(workerTask.getTaskRun()));
 
@@ -421,25 +431,6 @@ public class RunContext {
 
         this.variables = ImmutableMap.copyOf(clone);
 
-        return this;
-    }
-
-    public RunContext forWorkerHandleDirectoryTask(ApplicationContext applicationContext, WorkerTask workerTask) {
-        forWorker(applicationContext, workerTask);
-
-        Map<String, Object> clone = new HashMap<>(this.variables);
-
-        if (clone.containsKey("workerTaskrun") && ((Map<String, Object>) clone.get("workerTaskrun")).containsKey("value")) {
-            Map<String, Object> workerTaskrun = ((Map<String, Object>) clone.get("workerTaskrun"));
-            Map<String, Object> taskrun = new HashMap<>((Map<String, Object>) clone.get("taskrun"));
-
-            taskrun.put("value", workerTaskrun.get("value"));
-
-            clone.remove("taskrun");
-            clone.put("taskrun", taskrun);
-        }
-
-        this.variables = ImmutableMap.copyOf(clone);
         return this;
     }
 

--- a/core/src/main/java/io/kestra/core/runners/RunContext.java
+++ b/core/src/main/java/io/kestra/core/runners/RunContext.java
@@ -418,15 +418,28 @@ public class RunContext {
         Map<String, Object> clone = new HashMap<>(this.variables);
 
         clone.put("workerTaskrun", clone.get("taskrun"));
-        if (clone.containsKey("parents")) {
-            clone.put("parents", clone.get("parents"));
-        }
-        if (clone.containsKey("parent")) {
-            clone.put("parent", clone.get("parent"));
-        }
 
         this.variables = ImmutableMap.copyOf(clone);
 
+        return this;
+    }
+
+    public RunContext forWorkerHandleDirectoryTask(ApplicationContext applicationContext, WorkerTask workerTask) {
+        forWorker(applicationContext, workerTask);
+
+        Map<String, Object> clone = new HashMap<>(this.variables);
+
+        if (clone.containsKey("workerTaskrun") && ((Map<String, Object>) clone.get("workerTaskrun")).containsKey("value")) {
+            Map<String, Object> workerTaskrun = ((Map<String, Object>) clone.get("workerTaskrun"));
+            Map<String, Object> taskrun = new HashMap<>((Map<String, Object>) clone.get("taskrun"));
+
+            taskrun.put("value", workerTaskrun.get("value"));
+
+            clone.remove("taskrun");
+            clone.put("taskrun", taskrun);
+        }
+
+        this.variables = ImmutableMap.copyOf(clone);
         return this;
     }
 

--- a/core/src/main/java/io/kestra/core/runners/Worker.java
+++ b/core/src/main/java/io/kestra/core/runners/Worker.java
@@ -454,7 +454,7 @@ public class Worker implements Runnable, AutoCloseable {
     private WorkerTask runAttempt(WorkerTask workerTask) {
         RunContext runContext = workerTask
             .getRunContext()
-            .forWorkerHandleDirectoryTask(this.applicationContext, workerTask);
+            .forWorker(this.applicationContext, workerTask);
 
         Logger logger = runContext.logger();
 

--- a/core/src/main/java/io/kestra/core/runners/Worker.java
+++ b/core/src/main/java/io/kestra/core/runners/Worker.java
@@ -454,7 +454,7 @@ public class Worker implements Runnable, AutoCloseable {
     private WorkerTask runAttempt(WorkerTask workerTask) {
         RunContext runContext = workerTask
             .getRunContext()
-            .forWorker(this.applicationContext, workerTask);
+            .forWorkerHandleDirectoryTask(this.applicationContext, workerTask);
 
         Logger logger = runContext.logger();
 

--- a/core/src/test/java/io/kestra/core/tasks/flows/WorkingDirectoryTest.java
+++ b/core/src/test/java/io/kestra/core/tasks/flows/WorkingDirectoryTest.java
@@ -52,6 +52,11 @@ public class WorkingDirectoryTest extends AbstractMemoryRunnerTest {
     }
 
     @Test
+    void taskrunNested() throws TimeoutException, InternalException {
+        suite.taskRunNested(runnerUtils);
+    }
+
+    @Test
     void namespaceFiles() throws TimeoutException, InternalException, IOException {
         suite.namespaceFiles(runnerUtils);
     }
@@ -109,6 +114,14 @@ public class WorkingDirectoryTest extends AbstractMemoryRunnerTest {
 
         public void taskRun(RunnerUtils runnerUtils) throws TimeoutException, InternalException {
             Execution execution = runnerUtils.runOne(null, "io.kestra.tests", "working-directory-taskrun");
+
+            assertThat(execution.getTaskRunList(), hasSize(3));
+            assertThat(execution.getState().getCurrent(), is(State.Type.SUCCESS));
+            assertThat(((String) execution.findTaskRunByTaskIdAndValue("log-taskrun", List.of("1")).getOutputs().get("value")), containsString("1"));
+        }
+
+        public void taskRunNested(RunnerUtils runnerUtils) throws TimeoutException, InternalException {
+            Execution execution = runnerUtils.runOne(null, "io.kestra.tests", "working-directory-taskrun-nested");
 
             assertThat(execution.getTaskRunList(), hasSize(6));
             assertThat(execution.getState().getCurrent(), is(State.Type.SUCCESS));

--- a/core/src/test/resources/flows/valids/working-directory-taskrun-nested.yml
+++ b/core/src/test/resources/flows/valids/working-directory-taskrun-nested.yml
@@ -1,0 +1,23 @@
+id: working-directory-taskrun-nested
+namespace: io.kestra.tests
+
+tasks:
+  - id: parallel
+    type: io.kestra.core.tasks.flows.EachParallel
+    value: ["1"]
+    tasks:
+      - id: seq
+        type: io.kestra.core.tasks.flows.Sequential
+        tasks:
+          - id: workingDir
+            type: io.kestra.core.tasks.flows.WorkingDirectory
+            tasks:
+              - id: log-taskrun
+                type: io.kestra.core.tasks.debugs.Return
+                format: "{{ workerTaskrun }}"
+              - id: log-workerparents
+                type: io.kestra.core.tasks.debugs.Return
+                format:  "{{ parents }}"
+              - id: log-workerparent
+                type: io.kestra.core.tasks.debugs.Return
+                format:  "{{ parent }}"

--- a/core/src/test/resources/flows/valids/working-directory-taskrun.yml
+++ b/core/src/test/resources/flows/valids/working-directory-taskrun.yml
@@ -6,18 +6,9 @@ tasks:
     type: io.kestra.core.tasks.flows.EachParallel
     value: ["1"]
     tasks:
-      - id: seq
-        type: io.kestra.core.tasks.flows.Sequential
+      - id: workingDir
+        type: io.kestra.core.tasks.flows.WorkingDirectory
         tasks:
-          - id: workingDir
-            type: io.kestra.core.tasks.flows.WorkingDirectory
-            tasks:
-              - id: log-taskrun
-                type: io.kestra.core.tasks.debugs.Return
-                format: "{{ workerTaskrun }}"
-              - id: log-workerparents
-                type: io.kestra.core.tasks.debugs.Return
-                format:  "{{ parents }}"
-              - id: log-workerparent
-                type: io.kestra.core.tasks.debugs.Return
-                format:  "{{ parent }}"
+          - id: log-taskrun
+            type: io.kestra.core.tasks.debugs.Return
+            format:  "{{ taskrun.value }}"


### PR DESCRIPTION
Recap of what has been done and why : 

* Working Directory having a "custom task path," the working Directory task itself wasn't added in the `parents` and `parent` variables, preventing access to the `parent.taskrun.value` that should exist when in a flowable

* My mistake was to use a two nested flowable test for the debugging, so this time, I make a more straightforward test that uses `taskrun.value` 

* I then realized that the taskrun property of the children task was overridden in the runAttempts, and as a workingDirectory can not have flowables inside (meaning children of a `workingDirectory` could never have a `value` inside their `taskrun` property), 
* I created a new method on top of the `forWorker`  to keep logic separated, that will check if the runContext contains the initialized `workerTaskRun` exists and provide its `value` if has one.

TLDR : 
Every task in a `workingDirectory` now have their `taskrun.value` property set if` workingDirectory` is in a flowable that provides a `taskrun.value` so its transparent either you're using a `workingDirectory` or no