### PR TITLE
feat(core): add error logs when ForEachItem fail to create executions

### DIFF
--- a/core/src/main/java/io/kestra/core/tasks/flows/ForEachItem.java
+++ b/core/src/main/java/io/kestra/core/tasks/flows/ForEachItem.java
@@ -178,8 +178,15 @@ public class ForEachItem extends Task implements ExecutableTask<ForEachItem.Outp
         Execution currentExecution,
         TaskRun currentTaskRun
     ) throws InternalException {
+        var renderedUri = runContext.render(this.items);
+        if (! renderedUri.startsWith("kestra://")) {
+            var errorMessage = "Unable to split the items from " + renderedUri + ", this is not an internal storage URI!";
+            runContext.logger().error(errorMessage);
+            throw new IllegalArgumentException(errorMessage);
+        }
+
         try {
-            List<URI> splits = StorageService.split(runContext, this.batch, URI.create(runContext.render(this.items)));
+            List<URI> splits = StorageService.split(runContext, this.batch, URI.create(renderedUri));
 
             AtomicInteger currentIteration = new AtomicInteger(1);
 
@@ -221,6 +228,7 @@ public class ForEachItem extends Task implements ExecutableTask<ForEachItem.Outp
                 ))
                 .toList();
         } catch (IOException e) {
+            runContext.logger().error(e.getMessage(), e);
             throw new InternalException(e);
         }
     }

--- a/core/src/main/java/io/kestra/core/tasks/flows/ForEachItem.java
+++ b/core/src/main/java/io/kestra/core/tasks/flows/ForEachItem.java
@@ -179,7 +179,7 @@ public class ForEachItem extends Task implements ExecutableTask<ForEachItem.Outp
         TaskRun currentTaskRun
     ) throws InternalException {
         var renderedUri = runContext.render(this.items);
-        if (! renderedUri.startsWith("kestra://")) {
+        if (!renderedUri.startsWith("kestra://")) {
             var errorMessage = "Unable to split the items from " + renderedUri + ", this is not an internal storage URI!";
             runContext.logger().error(errorMessage);
             throw new IllegalArgumentException(errorMessage);


### PR DESCRIPTION
Fixes #2517

The following task:

```
  - id: each
    type: io.kestra.core.tasks.flows.ForEachItem
    items: "somefile.txt"
    batch: 
      rows: 10
    namespace: dev
    flowId: per-item
    wait: true
    transmitFailed: true
    inputs:
      items: "{{taskrun.items}}"
```

Will generate the following log visible in the UI:

![image](https://github.com/kestra-io/kestra/assets/1819009/f5594e77-4228-4364-8cc6-e7116dbb72f2)

