### PR TITLE
feat(): only list namespace from endpoint in files editor

### DIFF
--- a/ui/src/components/namespace/Editor.vue
+++ b/ui/src/components/namespace/Editor.vue
@@ -7,6 +7,7 @@
                 :value="namespace"
                 @update:model-value="namespaceUpdate"
                 allow-create
+                :is-filter="false"
             />
             <trigger-flow
                 :disabled="!flow"

--- a/ui/src/components/namespace/NamespaceSelect.vue
+++ b/ui/src/components/namespace/NamespaceSelect.vue
@@ -34,6 +34,10 @@
             allowCreate: {
                 type: Boolean,
                 default: false
+            },
+            isFilter: {
+                type: Boolean,
+                default: true
             }
         },
         emits: ["update:modelValue"],
@@ -78,7 +82,7 @@
                 });
 
                 // Remove duplicate namespaces ...
-                return _uniqBy(res,"code");
+                return _uniqBy(res,"code").filter(ns => namespaces.includes(ns.code) || this.isFilter);
             },
         }
     };


### PR DESCRIPTION
By default our `namespaceSelect` component will display a namespace and all his level.
Example, the namespace `com.kestra.dev` will have in the select options:
* `com`
* `com.kestra`
* `com.kestra.dev`

This is great for filtering to display all flows in `com.kestra` and its children, but in the namespace files editor we only want to display the returned namespace by the endpoints, if lower level aren't returned its because there is no flows or user doesn't have access to the namespace.