### PR TITLE
Feat/task allow failure

### DIFF
--- a/core/src/main/java/io/kestra/core/models/executions/Execution.java
+++ b/core/src/main/java/io/kestra/core/models/executions/Execution.java
@@ -413,12 +413,12 @@ public class Execution implements DeletedInterface, TenantInterface {
     }
 
     public State.Type guessFinalState(Flow flow) {
-        return this.guessFinalState(ResolvedTask.of(flow.getTasks()), null);
+        return this.guessFinalState(ResolvedTask.of(flow.getTasks()), null, false);
     }
 
-    public State.Type guessFinalState(List<ResolvedTask> currentTasks, TaskRun parentTaskRun) {
+    public State.Type guessFinalState(List<ResolvedTask> currentTasks, TaskRun parentTaskRun, boolean allowFailure) {
         List<TaskRun> taskRuns = this.findTaskRunByTasks(currentTasks, parentTaskRun);
-        return this
+        var state = this
             .findLastByState(taskRuns, State.Type.KILLED)
             .map(taskRun -> taskRun.getState().getCurrent())
             .or(() -> this
@@ -434,6 +434,11 @@ public class Execution implements DeletedInterface, TenantInterface {
                 .map(taskRun -> taskRun.getState().getCurrent())
             )
             .orElse(State.Type.SUCCESS);
+
+        if (state == State.Type.FAILED && allowFailure) {
+            return State.Type.WARNING;
+        }
+        return state;
     }
 
     @JsonIgnore

--- a/core/src/main/java/io/kestra/core/models/tasks/FlowableTask.java
+++ b/core/src/main/java/io/kestra/core/models/tasks/FlowableTask.java
@@ -53,6 +53,11 @@ public interface FlowableTask <T extends Output> {
     List<NextTaskRun> resolveNexts(RunContext runContext, Execution execution, TaskRun parentTaskRun) throws IllegalVariableEvaluationException;
 
     /**
+     * Whether the task is allowed to fail.
+     */
+    boolean isAllowFailure();
+
+    /**
      * Resolve the state of a flowable task.
      */
     default Optional<State.Type> resolveState(RunContext runContext, Execution execution, TaskRun parentTaskRun) throws IllegalVariableEvaluationException {
@@ -61,7 +66,8 @@ public interface FlowableTask <T extends Output> {
             this.childTasks(runContext, parentTaskRun),
             FlowableUtils.resolveTasks(this.getErrors(), parentTaskRun),
             parentTaskRun,
-            runContext
+            runContext,
+            isAllowFailure()
         );
     }
 

--- a/core/src/main/java/io/kestra/core/models/tasks/Task.java
+++ b/core/src/main/java/io/kestra/core/models/tasks/Task.java
@@ -56,6 +56,9 @@ abstract public class Task {
 
     private Level logLevel;
 
+    @Builder.Default
+    private boolean allowFailure = false;
+
     public Optional<Task> findById(String id) {
         if (this.getId().equals(id)) {
             return Optional.of(this);

--- a/core/src/main/java/io/kestra/core/runners/WorkerTask.java
+++ b/core/src/main/java/io/kestra/core/runners/WorkerTask.java
@@ -2,6 +2,7 @@ package io.kestra.core.runners;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import io.kestra.core.models.executions.TaskRun;
+import io.kestra.core.models.flows.State;
 import io.kestra.core.models.tasks.Task;
 import lombok.Builder;
 import lombok.Data;
@@ -45,5 +46,15 @@ public class WorkerTask extends WorkerJob {
     @Override
     public String taskRunId() {
         return this.taskRun.getId();
+    }
+
+    /**
+     * This method will fail the tasks with a FAILED or WARNING state depending on the allowFailure attribute of the task.
+     *
+     * @return this worker task, updated
+     */
+    public WorkerTask fail() {
+        var state = this.task.isAllowFailure() ? State.Type.WARNING : State.Type.FAILED;
+        return this.withTaskRun(this.getTaskRun().withState(state));
     }
 }

--- a/core/src/main/java/io/kestra/core/tasks/flows/AllowFailure.java
+++ b/core/src/main/java/io/kestra/core/tasks/flows/AllowFailure.java
@@ -64,7 +64,8 @@ public class AllowFailure extends Sequential implements FlowableTask<VoidOutput>
             resolvedTasks,
             resolvedErrors,
             parentTaskRun,
-            runContext
+            runContext,
+            this.isAllowFailure()
         );
 
         if (type.isEmpty()) {
@@ -75,7 +76,8 @@ public class AllowFailure extends Sequential implements FlowableTask<VoidOutput>
                 resolvedTasks,
                 null,
                 parentTaskRun,
-                runContext
+                runContext,
+                this.isAllowFailure()
             );
 
             if (normalState.isPresent() && normalState.get().isFailed()) {

--- a/core/src/main/java/io/kestra/core/tasks/flows/EachParallel.java
+++ b/core/src/main/java/io/kestra/core/tasks/flows/EachParallel.java
@@ -132,7 +132,7 @@ public class EachParallel extends Parallel implements FlowableTask<VoidOutput> {
     public Optional<State.Type> resolveState(RunContext runContext, Execution execution, TaskRun parentTaskRun) throws IllegalVariableEvaluationException {
         List<ResolvedTask> childTasks = this.childTasks(runContext, parentTaskRun);
 
-        if (childTasks.size() == 0) {
+        if (childTasks.isEmpty()) {
             return Optional.of(State.Type.SUCCESS);
         }
 
@@ -141,7 +141,8 @@ public class EachParallel extends Parallel implements FlowableTask<VoidOutput> {
             childTasks,
             FlowableUtils.resolveTasks(this.getErrors(), parentTaskRun),
             parentTaskRun,
-            runContext
+            runContext,
+            this.isAllowFailure()
         );
     }
 

--- a/core/src/main/java/io/kestra/core/tasks/flows/EachSequential.java
+++ b/core/src/main/java/io/kestra/core/tasks/flows/EachSequential.java
@@ -102,7 +102,7 @@ public class EachSequential extends Sequential implements FlowableTask<VoidOutpu
     public Optional<State.Type> resolveState(RunContext runContext, Execution execution, TaskRun parentTaskRun) throws IllegalVariableEvaluationException {
         List<ResolvedTask> childTasks = this.childTasks(runContext, parentTaskRun);
 
-        if (childTasks.size() == 0) {
+        if (childTasks.isEmpty()) {
             return Optional.of(State.Type.SUCCESS);
         }
 
@@ -111,7 +111,8 @@ public class EachSequential extends Sequential implements FlowableTask<VoidOutpu
             childTasks,
             FlowableUtils.resolveTasks(this.getErrors(), parentTaskRun),
             parentTaskRun,
-            runContext
+            runContext,
+            this.isAllowFailure()
         );
     }
 

--- a/core/src/main/java/io/kestra/core/tasks/flows/If.java
+++ b/core/src/main/java/io/kestra/core/tasks/flows/If.java
@@ -159,7 +159,7 @@ public class If extends Task implements FlowableTask<VoidOutput> {
         List<ResolvedTask> childTask = this.childTasks(runContext, parentTaskRun);
         if (childTask == null) {
             // no next task to run, we guess the state from the parent task
-            return Optional.of(execution.guessFinalState(null, parentTaskRun));
+            return Optional.of(execution.guessFinalState(null, parentTaskRun, this.isAllowFailure()));
         }
 
         return FlowableUtils.resolveState(
@@ -167,7 +167,8 @@ public class If extends Task implements FlowableTask<VoidOutput> {
             this.childTasks(runContext, parentTaskRun),
             FlowableUtils.resolveTasks(this.getErrors(), parentTaskRun),
             parentTaskRun,
-            runContext
+            runContext,
+            this.isAllowFailure()
         );
     }
 }

--- a/core/src/main/java/io/kestra/core/tasks/flows/Switch.java
+++ b/core/src/main/java/io/kestra/core/tasks/flows/Switch.java
@@ -168,7 +168,8 @@ public class Switch extends Task implements FlowableTask<Switch.Output> {
             this.childTasks(runContext, parentTaskRun),
             FlowableUtils.resolveTasks(this.getErrors(), parentTaskRun),
             parentTaskRun,
-            runContext
+            runContext,
+            this.isAllowFailure()
         );
     }
 

--- a/core/src/test/java/io/kestra/core/runners/TaskWithAllowFailureTest.java
+++ b/core/src/test/java/io/kestra/core/runners/TaskWithAllowFailureTest.java
@@ -3,15 +3,30 @@ package io.kestra.core.runners;
 import io.kestra.core.exceptions.InternalException;
 import io.kestra.core.models.executions.Execution;
 import io.kestra.core.models.flows.State;
+import io.kestra.core.storages.StorageInterface;
+import jakarta.inject.Inject;
+import org.apache.commons.lang3.StringUtils;
 import org.junit.jupiter.api.Test;
 
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.nio.file.Files;
+import java.util.List;
+import java.util.Map;
 import java.util.concurrent.TimeoutException;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 
 public class TaskWithAllowFailureTest extends AbstractMemoryRunnerTest {
+    @Inject
+    private StorageInterface storageInterface;
 
     @Test
     void runnableTask() throws TimeoutException, InternalException {
@@ -20,5 +35,42 @@ public class TaskWithAllowFailureTest extends AbstractMemoryRunnerTest {
         assertThat(execution.getState().getCurrent(), is(State.Type.WARNING));
         assertThat(execution.getTaskRunList(), hasSize(2));
         assertThat(execution.findTaskRunsByTaskId("fail").get(0).getAttempts().size(), is(3));
+    }
+
+    @Test
+    void executableTask_Flow() throws TimeoutException {
+        Execution execution = runnerUtils.runOne(null, "io.kestra.tests", "task-allow-failure-executable-flow");
+
+        assertThat(execution.getState().getCurrent(), is(State.Type.WARNING));
+        assertThat(execution.getTaskRunList(), hasSize(2));
+    }
+
+    @Test
+    void executableTask_ForEachItem() throws TimeoutException, URISyntaxException, IOException {
+        URI file = storageUpload(10);
+        Map<String, Object> inputs = Map.of("file", file.toString());
+        Execution execution = runnerUtils.runOne(null, "io.kestra.tests", "task-allow-failure-executable-foreachitem", null, (flow, execution1) -> runnerUtils.typedInputs(flow, execution1, inputs));
+
+        assertThat(execution.getState().getCurrent(), is(State.Type.WARNING));
+        assertThat(execution.getTaskRunList(), hasSize(2));
+    }
+
+    private URI storageUpload(int count) throws URISyntaxException, IOException {
+        File tempFile = File.createTempFile("file", ".txt");
+
+        Files.write(tempFile.toPath(), content(count));
+
+        return storageInterface.put(
+            null,
+            new URI("/file/storage/file.txt"),
+            new FileInputStream(tempFile)
+        );
+    }
+
+    private List<String> content(int count) {
+        return IntStream
+            .range(0, count)
+            .mapToObj(value -> StringUtils.leftPad(value + "", 20))
+            .collect(Collectors.toList());
     }
 }

--- a/core/src/test/java/io/kestra/core/runners/TaskWithAllowFailureTest.java
+++ b/core/src/test/java/io/kestra/core/runners/TaskWithAllowFailureTest.java
@@ -1,0 +1,24 @@
+package io.kestra.core.runners;
+
+import io.kestra.core.exceptions.InternalException;
+import io.kestra.core.models.executions.Execution;
+import io.kestra.core.models.flows.State;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.TimeoutException;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+
+public class TaskWithAllowFailureTest extends AbstractMemoryRunnerTest {
+
+    @Test
+    void runnableTask() throws TimeoutException, InternalException {
+        Execution execution = runnerUtils.runOne(null, "io.kestra.tests", "task-allow-failure-runnable");
+
+        assertThat(execution.getState().getCurrent(), is(State.Type.WARNING));
+        assertThat(execution.getTaskRunList(), hasSize(2));
+        assertThat(execution.findTaskRunsByTaskId("fail").get(0).getAttempts().size(), is(3));
+    }
+}

--- a/core/src/test/java/io/kestra/core/runners/TaskWithAllowFailureTest.java
+++ b/core/src/test/java/io/kestra/core/runners/TaskWithAllowFailureTest.java
@@ -55,6 +55,14 @@ public class TaskWithAllowFailureTest extends AbstractMemoryRunnerTest {
         assertThat(execution.getTaskRunList(), hasSize(2));
     }
 
+    @Test
+    void flowableTask() throws TimeoutException {
+        Execution execution = runnerUtils.runOne(null, "io.kestra.tests", "task-allow-failure-flowable");
+
+        assertThat(execution.getState().getCurrent(), is(State.Type.WARNING));
+        assertThat(execution.getTaskRunList(), hasSize(3));
+    }
+
     private URI storageUpload(int count) throws URISyntaxException, IOException {
         File tempFile = File.createTempFile("file", ".txt");
 

--- a/core/src/test/java/io/kestra/core/serializers/YamlFlowParserTest.java
+++ b/core/src/test/java/io/kestra/core/serializers/YamlFlowParserTest.java
@@ -212,7 +212,7 @@ class YamlFlowParserTest {
             () -> this.parse("flows/invalids/invalid-property.yaml")
         );
 
-        assertThat(exception.getMessage(), is("Unrecognized field \"invalid\" (class io.kestra.core.tasks.debugs.Return), not marked as ignorable (9 known properties: \"logLevel\", \"timeout\", \"format\", \"retry\", \"type\", \"id\", \"description\", \"workerGroup\", \"disabled\"])"));
+        assertThat(exception.getMessage(), is("Unrecognized field \"invalid\" (class io.kestra.core.tasks.debugs.Return), not marked as ignorable (10 known properties: \"logLevel\", \"timeout\", \"format\", \"retry\", \"type\", \"id\", \"description\", \"workerGroup\", \"disabled\", \"allowFailure\"])"));
         assertThat(exception.getConstraintViolations().size(), is(1));
         assertThat(exception.getConstraintViolations().iterator().next().getPropertyPath().toString(), is("io.kestra.core.models.flows.Flow[\"tasks\"]->java.util.ArrayList[0]->io.kestra.core.tasks.debugs.Return[\"invalid\"]"));
     }

--- a/core/src/test/resources/flows/valids/task-allow-failure-executable-flow.yml
+++ b/core/src/test/resources/flows/valids/task-allow-failure-executable-flow.yml
@@ -1,0 +1,16 @@
+id: task-allow-failure-executable-flow
+namespace: io.kestra.tests
+
+tasks:
+  - id: fail
+    type: io.kestra.core.tasks.flows.Flow
+    allowFailure: true
+    namespace: io.kestra.tests
+    flowId: for-each-item-subflow-failed
+    inputs:
+      items: "You will fail"
+    transmitFailed: true
+    wait: true
+  - id: log
+    type: io.kestra.core.tasks.log.Log
+    message: I'm allowed

--- a/core/src/test/resources/flows/valids/task-allow-failure-executable-foreachitem.yml
+++ b/core/src/test/resources/flows/valids/task-allow-failure-executable-foreachitem.yml
@@ -1,0 +1,23 @@
+id: task-allow-failure-executable-foreachitem
+namespace: io.kestra.tests
+
+inputs:
+  - name: file
+    type: FILE
+
+tasks:
+  - id: each
+    type: io.kestra.core.tasks.flows.ForEachItem
+    allowFailure: true
+    items: "{{ inputs.file }}"
+    batch:
+      rows: 4
+    namespace: io.kestra.tests
+    flowId: for-each-item-subflow-failed
+    wait: true
+    transmitFailed: true
+    inputs:
+      items: "{{ taskrun.items }}"
+  - id: log-allowed
+    type: io.kestra.core.tasks.log.Log
+    message: I'm allowed

--- a/core/src/test/resources/flows/valids/task-allow-failure-flowable.yml
+++ b/core/src/test/resources/flows/valids/task-allow-failure-flowable.yml
@@ -1,0 +1,16 @@
+id: task-allow-failure-flowable
+namespace: io.kestra.tests
+
+tasks:
+  - id: seq
+    type: io.kestra.core.tasks.flows.Sequential
+    allowFailure: true
+    tasks:
+      - id: fail
+        type: io.kestra.core.tasks.executions.Fail
+      - id: log-not-allowed
+        type: io.kestra.core.tasks.log.Log
+        message: not allowed
+  - id: log-allowed
+    type: io.kestra.core.tasks.log.Log
+    message: I'm allowed

--- a/core/src/test/resources/flows/valids/task-allow-failure-runnable.yml
+++ b/core/src/test/resources/flows/valids/task-allow-failure-runnable.yml
@@ -1,0 +1,14 @@
+id: task-allow-failure-runnable
+namespace: io.kestra.tests
+
+tasks:
+  - id: fail
+    type: io.kestra.core.tasks.executions.Fail
+    allowFailure: true
+    retry:
+      type: constant
+      interval: PT0.100S
+      maxAttempt: 3
+  - id: log
+    type: io.kestra.core.tasks.log.Log
+    message: I'm allowed

--- a/jdbc/src/main/java/io/kestra/jdbc/runner/JdbcExecutor.java
+++ b/jdbc/src/main/java/io/kestra/jdbc/runner/JdbcExecutor.java
@@ -536,7 +536,7 @@ public class JdbcExecutor implements ExecutorInterface {
                     Task task = flow.findTaskByTaskId(message.getTaskRun().getTaskId());
                     TaskRun taskRun;
                     if (task instanceof ForEachItem forEachItem) {
-                        taskRun = ExecutableUtils.manageIterations(message.getTaskRun(), current.getExecution(), forEachItem.getTransmitFailed());
+                        taskRun = ExecutableUtils.manageIterations(message.getTaskRun(), current.getExecution(), forEachItem.getTransmitFailed(), forEachItem.isAllowFailure());
                     } else {
                         taskRun = message.getTaskRun();
                     }

--- a/runner-memory/src/main/java/io/kestra/runner/memory/MemoryExecutor.java
+++ b/runner-memory/src/main/java/io/kestra/runner/memory/MemoryExecutor.java
@@ -469,7 +469,7 @@ public class MemoryExecutor implements ExecutorInterface {
             Task task = flow.findTaskByTaskId(workerTaskResult.getTaskRun().getTaskId());
             TaskRun taskRun;
             if (task instanceof ForEachItem forEachItem) {
-                taskRun = ExecutableUtils.manageIterations(workerTaskResult.getTaskRun(), this.execution, forEachItem.getTransmitFailed());
+                taskRun = ExecutableUtils.manageIterations(workerTaskResult.getTaskRun(), this.execution, forEachItem.getTransmitFailed(), forEachItem.isAllowFailure());
             } else {
                 taskRun = workerTaskResult.getTaskRun();
             }

--- a/webserver/src/test/java/io/kestra/webserver/controllers/PluginControllerTest.java
+++ b/webserver/src/test/java/io/kestra/webserver/controllers/PluginControllerTest.java
@@ -138,7 +138,7 @@ class PluginControllerTest {
             Map<String, Map<String, Object>> properties = (Map<String, Map<String, Object>>) doc.getSchema().getProperties().get("properties");
 
             assertThat(doc.getMarkdown(), containsString("io.kestra.plugin.templates.ExampleTask"));
-            assertThat(properties.size(), is(12));
+            assertThat(properties.size(), is(13));
             assertThat(properties.get("id").size(), is(4));
             assertThat(((Map<String, Object>) doc.getSchema().getOutputs().get("properties")).size(), is(1));
         });


### PR DESCRIPTION
Fixes [#2248](https://github.com/kestra-io/kestra/issues/2248)

To QA, you can use as example the test YAML that has been added.

For runnable tasks, the attempts will be in FAILED state as we cannot know that we need to restart an attempt if it is in WARNING as WARNING can come from the task execution itself and not the allowFailure handling code.