### PR TITLE
feat: per tenant internal storage location

### DIFF
--- a/core/src/main/java/io/kestra/core/storages/StorageConfiguration.java
+++ b/core/src/main/java/io/kestra/core/storages/StorageConfiguration.java
@@ -1,0 +1,10 @@
+package io.kestra.core.storages;
+
+import lombok.Value;
+
+import java.util.Map;
+
+@Value
+public class StorageConfiguration {
+    Map<String, Object> configuration;
+}

--- a/core/src/main/java/io/kestra/core/storages/StorageInterface.java
+++ b/core/src/main/java/io/kestra/core/storages/StorageInterface.java
@@ -41,7 +41,7 @@ public interface StorageInterface {
      * @param tenantId the tenant identifier.
      * @return true if the uri points to a file/object that exist in the internal storage.
      */
-    default boolean exists(String tenantId, URI uri) {
+    default boolean exists(String tenantId, URI uri) throws IOException {
         try (InputStream ignored = get(tenantId, uri)){
             return true;
         } catch (IOException ieo) {

--- a/core/src/main/java/io/kestra/core/tenant/TenantService.java
+++ b/core/src/main/java/io/kestra/core/tenant/TenantService.java
@@ -1,6 +1,9 @@
 package io.kestra.core.tenant;
 
+import io.kestra.core.storages.StorageConfiguration;
 import jakarta.inject.Singleton;
+
+import java.util.Optional;
 
 @Singleton
 public class TenantService {
@@ -13,5 +16,13 @@ public class TenantService {
      */
     public String resolveTenant() {
         return null;
+    }
+
+    /**
+     * Load the Internal Storage configuration for the given tenant identifier if there is any configured.
+     * As tenant is an EE feature, it always returns an empty Optional on OSS.
+     */
+    public Optional<StorageConfiguration> storageConfiguration(String tenantId) {
+        return Optional.empty();
     }
 }

--- a/core/src/test/java/io/kestra/core/tenant/TenantServiceTest.java
+++ b/core/src/test/java/io/kestra/core/tenant/TenantServiceTest.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.nullValue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @MicronautTest
 class TenantServiceTest {
@@ -13,9 +14,14 @@ class TenantServiceTest {
     private TenantService tenantService;
 
     @Test
-    void test() {
+    void resolveTenant() {
         var tenant = tenantService.resolveTenant();
         assertThat(tenant, nullValue());
     }
 
+    @Test
+    void storageConfiguration() {
+        var storageConfiguration = tenantService.storageConfiguration("tenantId");
+        assertTrue(storageConfiguration.isEmpty());
+    }
 }

--- a/jdbc/src/test/java/io/kestra/jdbc/runner/JdbcRunnerTest.java
+++ b/jdbc/src/test/java/io/kestra/jdbc/runner/JdbcRunnerTest.java
@@ -174,12 +174,12 @@ public abstract class JdbcRunnerTest {
         restartCaseTest.replay();
     }
 
-    @Test
+    @RetryingTest(5)
     void restartMultiple() throws Exception {
         restartCaseTest.restartMultiple();
     }
 
-    @Test
+    @RetryingTest(5)
     void flowTrigger() throws Exception {
         flowTriggerCaseTest.trigger();
     }


### PR DESCRIPTION
Allow configuring the internal storage at the tenant level.

The local storage has been updated to allow defining a different base path per tenant.