### PR TITLE
fix(): display actions buttons on topology view

### DIFF
--- a/ui/src/components/inputs/Editor.vue
+++ b/ui/src/components/inputs/Editor.vue
@@ -456,15 +456,15 @@
             }
 
             .bottom-right {
-                bottom: var(--spacer);
-                right: var(--spacer);
+                bottom: 0px;
+                right: 0px;
 
                 ul {
                     display: flex;
                     list-style: none;
                     padding: 0;
                     margin: 0;
-                    gap: calc(var(--spacer) / 2);
+                    //gap: calc(var(--spacer) / 2);
                 }
             }
         }

--- a/ui/src/components/inputs/EditorButtons.vue
+++ b/ui/src/components/inputs/EditorButtons.vue
@@ -1,0 +1,121 @@
+<template>
+    <div class="to-action-button">
+        <div v-if="isAllowedEdit || canDelete" class="mx-2">
+            <el-dropdown>
+                <el-button type="default" :disabled="isReadOnly">
+                    <DotsVertical title=""/>
+                    {{ $t("actions") }}
+                </el-button>
+                <template #dropdown>
+                    <el-dropdown-menu class="m-dropdown-menu">
+                        <el-dropdown-item
+                            v-if="!isCreating && canDelete"
+                            :icon="Delete"
+                            size="large"
+                            @click="forwardEvent('delete-flow', $event)"
+                        >
+                            {{ $t("delete") }}
+                        </el-dropdown-item>
+
+                        <el-dropdown-item
+                            v-if="!isCreating"
+                            :icon="ContentCopy"
+                            size="large"
+                            @click="forwardEvent('copy', $event)"
+                        >
+                            {{ $t("copy") }}
+                        </el-dropdown-item>
+                        <el-dropdown-item
+                            v-if="isAllowedEdit"
+                            :icon="Exclamation"
+                            size="large"
+                            @click="forwardEvent('open-new-error', null)"
+                            :disabled="!flowHaveTasks"
+                        >
+                            {{ $t("add global error handler") }}
+                        </el-dropdown-item>
+                        <el-dropdown-item
+                            v-if="isAllowedEdit"
+                            :icon="LightningBolt"
+                            size="large"
+                            @click="forwardEvent('open-new-trigger', null)"
+                            :disabled="!flowHaveTasks"
+                        >
+                            {{ $t("add trigger") }}
+                        </el-dropdown-item>
+                        <el-dropdown-item
+                            v-if="isAllowedEdit"
+                            :icon="FileEdit"
+                            size="large"
+                            @click="forwardEvent('open-edit-metadata', null)"
+                        >
+                            {{ $t("edit metadata") }}
+                        </el-dropdown-item>
+                    </el-dropdown-menu>
+                </template>
+            </el-dropdown>
+        </div>
+        <div>
+            <el-button
+                :icon="ContentSave"
+                @click="forwardEvent('save', $event)"
+                v-if="isAllowedEdit"
+                :type="flowError ? 'danger' : 'primary'"
+                :disabled="!haveChange && !isCreating"
+                class="edit-flow-save-button"
+            >
+                {{ $t("save") }}
+            </el-button>
+        </div>
+    </div>
+</template>
+<script setup>
+    import DotsVertical from "vue-material-design-icons/DotsVertical.vue";
+    import Delete from "vue-material-design-icons/Delete.vue";
+    import ContentCopy from "vue-material-design-icons/ContentCopy.vue";
+    import Exclamation from "vue-material-design-icons/Exclamation.vue";
+    import LightningBolt from "vue-material-design-icons/LightningBolt.vue";
+    import FileEdit from "vue-material-design-icons/FileEdit.vue";
+    import ContentSave from "vue-material-design-icons/ContentSave.vue";
+</script>
+<script>
+    import {defineComponent} from "vue";
+
+    export default defineComponent({
+        props: {
+            isCreating: {
+                type: Boolean,
+                default: false
+            },
+            isReadOnly: {
+                type: Boolean,
+                default: false
+            },
+            canDelete: {
+                type: Boolean,
+                default: false
+            },
+            isAllowedEdit: {
+                type: Boolean,
+                default: false
+            },
+            haveChange: {
+                type: Boolean,
+                default: false
+            },
+            flowHaveTasks: {
+                type: Boolean,
+                default: false
+            },
+            flowError: {
+                type: String,
+                default: null
+            }
+        },
+        methods: {
+            forwardEvent(type, event) {
+                this.$emit(type, event);
+            }
+        }
+    })
+</script>

--- a/ui/src/components/inputs/EditorView.vue
+++ b/ui/src/components/inputs/EditorView.vue
@@ -28,6 +28,7 @@
     import {editorViewTypes} from "../../utils/constants";
     import Utils from "@kestra-io/ui-libs/src/utils/Utils";
     import {apiUrl} from "override/utils/route";
+    import EditorButtons from "./EditorButtons.vue";
 
     const store = useStore();
     const router = getCurrentInstance().appContext.config.globalProperties.$router;
@@ -675,75 +676,22 @@
                 <ValidationError ref="validationDomElement" tooltip-placement="bottom-start" size="small" class="ms-2" :error="flowError" :warnings="flowWarnings" />
             </template>
             <template #buttons>
-                <ul>
-                    <li v-if="isAllowedEdit || canDelete">
-                        <el-dropdown>
-                            <el-button type="default" :disabled="isReadOnly">
-                                <DotsVertical title="" />
-                                {{ $t("actions") }}
-                            </el-button>
-                            <template #dropdown>
-                                <el-dropdown-menu class="m-dropdown-menu">
-                                    <el-dropdown-item
-                                        v-if="!props.isCreating && canDelete"
-                                        :icon="Delete"
-                                        size="large"
-                                        @click="deleteFlow"
-                                    >
-                                        {{ $t("delete") }}
-                                    </el-dropdown-item>
-
-                                    <el-dropdown-item
-                                        v-if="!props.isCreating"
-                                        :icon="ContentCopy"
-                                        size="large"
-                                        @click="() => router.push({name: 'flows/create', query: {copy: true}})"
-                                    >
-                                        {{ $t("copy") }}
-                                    </el-dropdown-item>
-                                    <el-dropdown-item
-                                        v-if="isAllowedEdit"
-                                        :icon="Exclamation"
-                                        size="large"
-                                        @click="isNewErrorOpen = true;"
-                                        :disabled="!flowHaveTasks()"
-                                    >
-                                        {{ $t("add global error handler") }}
-                                    </el-dropdown-item>
-                                    <el-dropdown-item
-                                        v-if="isAllowedEdit"
-                                        :icon="LightningBolt"
-                                        size="large"
-                                        @click="isNewTriggerOpen = true;"
-                                        :disabled="!flowHaveTasks()"
-                                    >
-                                        {{ $t("add trigger") }}
-                                    </el-dropdown-item>
-                                    <el-dropdown-item
-                                        v-if="isAllowedEdit"
-                                        :icon="FileEdit"
-                                        size="large"
-                                        @click="isEditMetadataOpen = true;"
-                                    >
-                                        {{ $t("edit metadata") }}
-                                    </el-dropdown-item>
-                                </el-dropdown-menu>
-                            </template>
-                        </el-dropdown>
-                    </li>
-                    <li>
-                        <el-button
-                            :icon="ContentSave"
-                            @click="save"
-                            v-if="isAllowedEdit"
-                            :type="flowError ? 'danger' : 'primary'"
-                            :disabled="!haveChange && !isCreating"
-                            class="edit-flow-save-button"
-                        >
-                            {{ $t("save") }}
-                        </el-button>
-                    </li>
-                </ul>
+                <EditorButtons
+                    v-if="![editorViewTypes.TOPOLOGY, editorViewTypes.SOURCE_TOPOLOGY].includes(viewType)"
+                    :is-creating="props.isCreating"
+                    :is-read-only="props.isReadOnly"
+                    :can-delete="canDelete"
+                    :is-allowed-edit="isAllowedEdit"
+                    :have-change="haveChange"
+                    :flow-have-tasks="flowHaveTasks()"
+                    :flow-error="flowError"
+                    @delete-flow="deleteFlow"
+                    @save="save"
+                    @copy="() => router.push({name: 'flows/create', query: {copy: true}})"
+                    @open-new-error="isNewErrorOpen = true;"
+                    @open-new-trigger="isNewTriggerOpen = true;"
+                    @open-edit-metadata="isEditMetadataOpen = true;"
+                />
             </template>
         </editor>
         <div class="slider" @mousedown="dragEditor" v-if="combinedEditor" />
@@ -859,6 +807,22 @@
             class="to-topology-button"
             @switch-view="switchViewType"
         />
+        <EditorButtons
+            v-if="[editorViewTypes.TOPOLOGY, editorViewTypes.SOURCE_TOPOLOGY].includes(viewType)"
+            :is-creating="props.isCreating"
+            :is-read-only="props.isReadOnly"
+            :can-delete="canDelete"
+            :is-allowed-edit="isAllowedEdit"
+            :have-change="haveChange"
+            :flow-have-tasks="flowHaveTasks()"
+            :flow-error="flowError"
+            @delete-flow="deleteFlow"
+            @save="save"
+            @copy="() => router.push({name: 'flows/create', query: {copy: true}})"
+            @open-new-error="isNewErrorOpen = true;"
+            @open-new-trigger="isNewTriggerOpen = true;"
+            @open-edit-metadata="isEditMetadataOpen = true;"
+        />
     </el-card>
 </template>
 
@@ -877,6 +841,13 @@
         position: absolute;
         top: 30px;
         right: 45px;
+    }
+
+    .to-action-button {
+        position: absolute;
+        bottom: 30px;
+        right: 45px;
+        display: flex;
     }
 
     .editor-combined {


### PR DESCRIPTION
Buttons were only in the editor, so if it wasn't displayed, the actions weren't too.
To fix that, I made the bottom buttons a component used at the bottom of the "editorView" if the topology is displayed.

On other views than the topology, the buttons were hiding documentation or blueprints paginations, so it will be displayed inside the editor in those case

closes #2553 