### PR TITLE
fix/delete-should-not-work-by-prefix

### DIFF
--- a/core/src/test/java/io/kestra/core/storage/StorageTestSuite.java
+++ b/core/src/test/java/io/kestra/core/storage/StorageTestSuite.java
@@ -663,6 +663,7 @@ public abstract class StorageTestSuite {
         List<String> path = Arrays.asList(
             "/" + prefix + "/storage/root.yml",
             "/" + prefix + "/storage/level1/1.yml",
+            "/" + prefix + "/storage/level12.yml",
             "/" + prefix + "/storage/level1/level2/1.yml",
             "/" + prefix + "/storage/another/1.yml"
         );
@@ -673,6 +674,7 @@ public abstract class StorageTestSuite {
         assertThat(storageInterface.exists(tenantId, new URI("/" + prefix + "/storage/root.yml")), is(true));
         assertThat(storageInterface.exists(tenantId, new URI("/" + prefix + "/storage/another/1.yml")), is(true));
         assertThat(storageInterface.exists(tenantId, new URI("/" + prefix + "/storage/level1")), is(false));
+        assertThat(storageInterface.exists(tenantId, new URI("/" + prefix + "/storage/level12.yml")), is(true));
         assertThat(storageInterface.exists(tenantId, new URI("/" + prefix + "/storage/level1/1.yml")), is(false));
         assertThat(storageInterface.exists(tenantId, new URI("/" + prefix + "/storage/level1/level2/1.yml")), is(false));
         deleted = storageInterface.delete(tenantId, new URI("/" + prefix + "/storage/root.yml"));


### PR DESCRIPTION
Currently S3 will fail to pass deletion test (and I think that's the case for all storages except local) as currently if you delete /folder you will also delete /folder2, /folder2/file...

You can see what's wrong by creating a folder or file named 'f' and another folder or file named 'file" and deleting 'f' will also delete 'file'...