### PR TITLE
fix/allow-tenant-in-marketplace-filter

### DIFF
--- a/webserver/src/main/java/io/kestra/webserver/filter/MarketplaceFilter.java
+++ b/webserver/src/main/java/io/kestra/webserver/filter/MarketplaceFilter.java
@@ -20,7 +20,7 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.Optional;
 
-@Filter("/api/v1/editor/marketplace/**")
+@Filter("/api/v1/**/editor/marketplace/**")
 public class MarketplaceFilter implements HttpServerFilter {
     @Inject
     @Client("proxy")


### PR DESCRIPTION
This prevents VSCode editor from working under a tenant