### PR TITLE
fix/sub-menu-item-active

### DIFF
--- a/ui/src/override/components/LeftMenu.vue
+++ b/ui/src/override/components/LeftMenu.vue
@@ -71,7 +71,7 @@
                             r.class = "vsm--link_active";
                         }
 
-                        if (r.child && r.child.some(c => this.$route.path.startsWith(c.href))) {
+                        if (r.child && r.child.some(c => this.$route.path.startsWith(c.href) || c.routes?.includes(this.$route.name))) {
                             r.class = "vsm--link_active";
                             r.child = this.disabledCurrentRoute(r.child);
                         }


### PR DESCRIPTION
Without that, going into any entity detail (user overview / edit for eg.) will not highlight their left menu properly (in the user case, we want Administration & Users to be highlighted)