### PR TITLE
Improve deserialization error handling

### DIFF
--- a/core/src/main/java/io/kestra/core/models/executions/TaskRun.java
+++ b/core/src/main/java/io/kestra/core/models/executions/TaskRun.java
@@ -86,6 +86,27 @@ public class TaskRun implements TenantInterface {
         );
     }
 
+    public TaskRun fail() {
+        var attempt = TaskRunAttempt.builder().state(new State(State.Type.FAILED)).build();
+        List<TaskRunAttempt> newAttempts = this.attempts == null ? new ArrayList<>(1) : this.attempts;
+        newAttempts.add(attempt);
+
+        return new TaskRun(
+            this.tenantId,
+            this.id,
+            this.executionId,
+            this.namespace,
+            this.flowId,
+            this.taskId,
+            this.parentTaskRunId,
+            this.value,
+            newAttempts,
+            this.outputs,
+            this.state.withState(State.Type.FAILED),
+            this.items
+        );
+    }
+
     public TaskRun forChildExecution(Map<String, String> remapTaskRunId, String executionId, State state) {
         return TaskRun.builder()
             .tenantId(this.getTenantId())

--- a/core/src/test/java/io/kestra/core/runners/DeserializationIssuesCaseTest.java
+++ b/core/src/test/java/io/kestra/core/runners/DeserializationIssuesCaseTest.java
@@ -1,0 +1,171 @@
+package io.kestra.core.runners;
+
+import io.kestra.core.models.flows.State;
+import io.kestra.core.queues.QueueFactoryInterface;
+import io.kestra.core.queues.QueueInterface;
+import io.kestra.core.utils.Await;
+import jakarta.inject.Inject;
+import jakarta.inject.Named;
+import jakarta.inject.Singleton;
+
+import java.time.Duration;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+
+@Singleton
+public class DeserializationIssuesCaseTest {
+    private static final String INVALID_WORKER_TASK_KEY = "5PGRX6ve2cztrRSIbfGphO";
+    private static final String INVALID_WORKER_TASK_VALUE = """
+        {
+          "task": {
+            "id": "invalid",
+            "type": "io.kestra.notfound.Invalid"
+          },
+          "type": "task",
+          "taskRun": {
+            "id": "5PGRX6ve2cztrRSIbfGphO",
+            "state": {
+              "current": "CREATED",
+              "duration": 0.058459656,
+              "histories": [
+                {
+                  "date": "2023-11-28T10:16:22.324536603Z",
+                  "state": "CREATED"
+                }
+              ],
+              "startDate": "2023-11-28T10:16:22.324536603Z"
+            },
+            "flowId": "hello-world",
+            "taskId": "hello",
+            "namespace": "company.team",
+            "executionId": "7IBX10Tg3ZzZuNUnLhoXcT"
+          },
+          "runContext": {
+            "variables": {
+              "envs": {
+                "plugins_path": "/home/loic/dev/kestra-plugins"
+              },
+              "flow": {
+                "id": "hello-world",
+                "revision": 1,
+                "namespace": "company.team"
+              },
+              "task": {
+                "id": "hello",
+                "type": "io.kestra.core.tasks.log.Log"
+              },
+              "taskrun": {
+                "id": "5PGRX6ve2cztrRSIbfGphO",
+                "startDate": "2023-11-28T10:16:22.324536603Z",
+                "attemptsCount": 0
+              },
+              "execution": {
+                "id": "7IBX10Tg3ZzZuNUnLhoXcT",
+                "startDate": "2023-11-28T10:16:21.648Z",
+                "originalId": "7IBX10Tg3ZzZuNUnLhoXcT"
+              }
+            },
+            "storageOutputPrefix": "///company/team/hello-world/executions/7IBX10Tg3ZzZuNUnLhoXcT/tasks/hello/5PGRX6ve2cztrRSIbfGphO"
+          }
+        }""";
+
+    private static final String INVALID_WORKER_TRIGGER_KEY = "dev_http-trigger_http";
+    private static final String INVALID_WORKER_TRIGGER_VALUE = """
+        {
+          "type": "trigger",
+          "trigger": {
+            "id": "invalid",
+            "type": "io.kestra.notfound.Invalid"
+          },
+          "triggerContext": {
+            "date": "2023-11-24T15:48:57.632881597Z",
+            "flowId": "http-trigger",
+            "namespace": "dev",
+            "triggerId": "http",
+            "flowRevision": 3
+          },
+          "conditionContext": {
+            "flow": {
+              "id": "http-trigger",
+              "tasks": [
+                {
+                  "id": "hello",
+                  "type": "io.kestra.core.tasks.log.Log",
+                  "message": "Kestra team wishes you a great day! 👋"
+                }
+              ],
+              "deleted": false,
+              "disabled": false,
+              "revision": 3,
+              "triggers": [
+                {
+                  "id": "invalid",
+                  "type": "io.kestra.notfound.Invalid"
+                }
+              ],
+              "namespace": "dev"
+            },
+            "runContext": {
+              "variables": {
+                "envs": {
+                  "plugins_path": "/home/loic/dev/kestra-plugins"
+                },
+                "flow": {
+                  "id": "http-trigger",
+                  "revision": 3,
+                  "namespace": "dev"
+                },
+                "trigger": {
+                  "id": "invalid",
+                  "type": "io.kestra.notfound.Invalid"
+                }
+              }
+            }
+          }
+        }
+        """;
+
+    @Inject
+    @Named(QueueFactoryInterface.WORKERTASKRESULT_NAMED)
+    protected QueueInterface<WorkerTaskResult> workerTaskResultQueue;
+
+    @Inject
+    @Named(QueueFactoryInterface.WORKERTRIGGERRESULT_NAMED)
+    protected QueueInterface<WorkerTriggerResult> workerTriggerResultQueue;
+
+    public record QueueMessage(Class<?> type, String key, String value) {}
+
+
+    public void workerTaskDeserializationIssue(Consumer<QueueMessage> sendToQueue) throws TimeoutException {
+        AtomicReference<WorkerTaskResult> workerTaskResult = new AtomicReference<>(null);
+        workerTaskResultQueue.receive(either -> workerTaskResult.set(either.getLeft()));
+
+        sendToQueue.accept(new QueueMessage(WorkerJob.class, INVALID_WORKER_TASK_KEY, INVALID_WORKER_TASK_VALUE));
+
+        Await.until(
+            () -> workerTaskResult.get() != null && workerTaskResult.get().getTaskRun().getState().isTerminated(),
+            Duration.ofMillis(100),
+            Duration.ofMinutes(1)
+        );
+        assertThat(workerTaskResult.get().getTaskRun().getState().getHistories().size(), is(2));
+        assertThat(workerTaskResult.get().getTaskRun().getState().getCurrent(), is(State.Type.FAILED));
+    }
+
+    public void workerTriggerDeserializationIssue(Consumer<QueueMessage> sendToQueue) throws InterruptedException {
+        AtomicReference<WorkerTriggerResult> workerTriggerResult = new AtomicReference<>(null);
+        workerTriggerResultQueue.receive(either -> workerTriggerResult.set(either.getLeft()));
+
+        sendToQueue.accept(new QueueMessage(WorkerJob.class, INVALID_WORKER_TRIGGER_KEY, INVALID_WORKER_TRIGGER_VALUE));
+
+        // Invalid worker trigger will be ignored, so we just check that no messages are received
+        Thread.sleep(500);
+        assertThat(workerTriggerResult.get(), nullValue());
+    }
+
+}

--- a/jdbc-h2/src/test/java/io/kestra/runner/h2/H2JdbcDeserializationIssuesTest.java
+++ b/jdbc-h2/src/test/java/io/kestra/runner/h2/H2JdbcDeserializationIssuesTest.java
@@ -1,0 +1,6 @@
+package io.kestra.runner.h2;
+
+import io.kestra.jdbc.runner.AbstractJdbcDeserializationIssuesTest;
+
+class H2JdbcDeserializationIssuesTest extends AbstractJdbcDeserializationIssuesTest {
+}

--- a/jdbc-mysql/src/test/java/io/kestra/runner/mysql/MySqlJdbcDeserializationIssuesTest.java
+++ b/jdbc-mysql/src/test/java/io/kestra/runner/mysql/MySqlJdbcDeserializationIssuesTest.java
@@ -1,0 +1,6 @@
+package io.kestra.runner.mysql;
+
+import io.kestra.jdbc.runner.AbstractJdbcDeserializationIssuesTest;
+
+class MySqlJdbcDeserializationIssuesTest extends AbstractJdbcDeserializationIssuesTest {
+}

--- a/jdbc-postgres/src/test/java/io/kestra/runner/postgres/PostgresJdbcDeserializationIssuesTest.java
+++ b/jdbc-postgres/src/test/java/io/kestra/runner/postgres/PostgresJdbcDeserializationIssuesTest.java
@@ -1,0 +1,17 @@
+package io.kestra.runner.postgres;
+
+import io.kestra.core.runners.DeserializationIssuesCaseTest;
+import io.kestra.jdbc.repository.AbstractJdbcRepository;
+import io.kestra.jdbc.runner.AbstractJdbcDeserializationIssuesTest;
+import org.jooq.Field;
+import org.jooq.impl.DSL;
+
+import java.util.Map;
+
+class PostgresJdbcDeserializationIssuesTest extends AbstractJdbcDeserializationIssuesTest {
+    protected Map<Field<Object>, Object> fields(DeserializationIssuesCaseTest.QueueMessage queueMessage) {
+        Map<Field<Object>, Object> fields = super.fields(queueMessage);
+        fields.put(AbstractJdbcRepository.field("type"), DSL.field("CAST(? AS queue_type)", queueMessage.type().getName()));
+        return fields;
+    }
+}

--- a/jdbc/src/main/java/io/kestra/jdbc/JdbcWorkerTriggerResultQueueService.java
+++ b/jdbc/src/main/java/io/kestra/jdbc/JdbcWorkerTriggerResultQueueService.java
@@ -1,9 +1,14 @@
 package io.kestra.jdbc;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.kestra.core.exceptions.DeserializationException;
+import io.kestra.core.models.triggers.TriggerContext;
 import io.kestra.core.queues.QueueFactoryInterface;
 import io.kestra.core.queues.QueueInterface;
 import io.kestra.core.runners.WorkerTriggerResult;
+import io.kestra.core.serializers.JacksonMapper;
 import io.kestra.core.utils.Either;
 import io.kestra.jdbc.repository.AbstractJdbcWorkerJobRunningRepository;
 import io.kestra.jdbc.runner.JdbcQueue;
@@ -18,6 +23,8 @@ import java.util.function.Consumer;
 @Singleton
 @Slf4j
 public class JdbcWorkerTriggerResultQueueService {
+    private final static ObjectMapper MAPPER = JacksonMapper.ofJson();
+
     private final JdbcQueue<WorkerTriggerResult> workerTriggerResultQueue;
     @Inject
     private AbstractJdbcWorkerJobRunningRepository jdbcWorkerJobRunningRepository;
@@ -35,13 +42,21 @@ public class JdbcWorkerTriggerResultQueueService {
             eithers.forEach(either -> {
                 if (either.isRight()) {
                     log.error("Unable to deserialize a worker job: {}", either.getRight().getMessage());
+                    try {
+                        JsonNode json = MAPPER.readTree(either.getRight().getRecord());
+                        var triggerContext = MAPPER.treeToValue(json.get("triggerContext"), TriggerContext.class);
+                        jdbcWorkerJobRunningRepository.deleteByKey(triggerContext.uid());
+                    } catch (JsonProcessingException e) {
+                        // ignore the message if we cannot do anything about it
+                        log.error("Unexpected exception when trying to handle a deserialization error", e);
+                    }
                     return;
                 }
 
                 WorkerTriggerResult workerTriggerResult = either.getLeft();
                 jdbcWorkerJobRunningRepository.deleteByKey(workerTriggerResult.getTriggerContext().uid());
-
             });
+
             eithers.forEach(consumer);
         });
         return this.queueStop;

--- a/jdbc/src/main/java/io/kestra/jdbc/runner/JdbcExecutor.java
+++ b/jdbc/src/main/java/io/kestra/jdbc/runner/JdbcExecutor.java
@@ -1,5 +1,6 @@
 package io.kestra.jdbc.runner;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.kestra.core.exceptions.DeserializationException;
 import io.kestra.core.exceptions.InternalException;
 import io.kestra.core.metrics.MetricRegistry;
@@ -22,6 +23,7 @@ import io.kestra.core.repositories.FlowRepositoryInterface;
 import io.kestra.core.runners.Executor;
 import io.kestra.core.runners.ExecutorService;
 import io.kestra.core.runners.*;
+import io.kestra.core.serializers.JacksonMapper;
 import io.kestra.core.services.*;
 import io.kestra.core.tasks.flows.ForEachItem;
 import io.kestra.core.tasks.flows.Template;
@@ -56,6 +58,8 @@ import java.util.stream.Stream;
 @JdbcRunnerEnabled
 @Slf4j
 public class JdbcExecutor implements ExecutorInterface {
+    private static final ObjectMapper MAPPER = JacksonMapper.ofJson();
+
     private final ScheduledExecutorService schedulerDelay = Executors.newSingleThreadScheduledExecutor();
 
     private final ScheduledExecutorService schedulerHeartbeat = Executors.newSingleThreadScheduledExecutor();
@@ -207,11 +211,22 @@ public class JdbcExecutor implements ExecutorInterface {
         flowQueue.receive(
             FlowTopology.class,
             either -> {
-                if (either == null || either.isRight() || either.getLeft() == null || either.getLeft() instanceof FlowWithException) {
-                    return;
+                Flow flow;
+                if (either.isRight()) {
+                    log.error("Unable to deserialize a flow: {}", either.getRight().getMessage());
+                    try {
+                        var jsonNode = MAPPER.readTree(either.getRight().getRecord());
+                        flow = FlowWithException.from(jsonNode, either.getRight()).orElseThrow(IOException::new);
+                    } catch (IOException e) {
+                        // if we cannot create a FlowWithException, ignore the message
+                        log.error("Unexpected exception when trying to handle a deserialization error", e);
+                        return;
+                    }
+                }
+                else {
+                    flow = either.getLeft();
                 }
 
-                Flow flow = either.getLeft();
                 flowTopologyRepository.save(
                     flow,
                     (flow.isDeleted() ?

--- a/jdbc/src/test/java/io/kestra/jdbc/runner/AbstractJdbcDeserializationIssuesTest.java
+++ b/jdbc/src/test/java/io/kestra/jdbc/runner/AbstractJdbcDeserializationIssuesTest.java
@@ -1,6 +1,7 @@
 package io.kestra.jdbc.runner;
 
 import io.kestra.core.runners.DeserializationIssuesCaseTest;
+import io.kestra.core.runners.FlowListeners;
 import io.kestra.core.runners.StandAloneRunner;
 import io.kestra.core.utils.IdUtils;
 import io.kestra.jdbc.JdbcConfiguration;
@@ -18,6 +19,7 @@ import org.junit.jupiter.api.TestInstance;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.TimeoutException;
 
 @MicronautTest(transactional = false)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS) // must be per-class to allow calling once init() which took a lot of time
@@ -54,6 +56,11 @@ public abstract class AbstractJdbcDeserializationIssuesTest {
     @Test
     void workerTriggerDeserializationIssue() throws Exception {
         deserializationIssuesCaseTest.workerTriggerDeserializationIssue(queueMessage -> sendToQueue(queueMessage));
+    }
+
+    @Test
+    void flowDeserializationIssue() throws TimeoutException {
+        deserializationIssuesCaseTest.flowDeserializationIssue(queueMessage -> sendToQueue(queueMessage));
     }
 
     private void sendToQueue(DeserializationIssuesCaseTest.QueueMessage queueMessage) {

--- a/jdbc/src/test/java/io/kestra/jdbc/runner/AbstractJdbcDeserializationIssuesTest.java
+++ b/jdbc/src/test/java/io/kestra/jdbc/runner/AbstractJdbcDeserializationIssuesTest.java
@@ -1,7 +1,6 @@
 package io.kestra.jdbc.runner;
 
 import io.kestra.core.runners.DeserializationIssuesCaseTest;
-import io.kestra.core.runners.FlowListeners;
 import io.kestra.core.runners.StandAloneRunner;
 import io.kestra.core.utils.IdUtils;
 import io.kestra.jdbc.JdbcConfiguration;

--- a/jdbc/src/test/java/io/kestra/jdbc/runner/AbstractJdbcDeserializationIssuesTest.java
+++ b/jdbc/src/test/java/io/kestra/jdbc/runner/AbstractJdbcDeserializationIssuesTest.java
@@ -1,0 +1,82 @@
+package io.kestra.jdbc.runner;
+
+import io.kestra.core.runners.DeserializationIssuesCaseTest;
+import io.kestra.core.runners.StandAloneRunner;
+import io.kestra.core.utils.IdUtils;
+import io.kestra.jdbc.JdbcConfiguration;
+import io.kestra.jdbc.JdbcTestUtils;
+import io.kestra.jdbc.JooqDSLContextWrapper;
+import io.kestra.jdbc.repository.AbstractJdbcRepository;
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import jakarta.inject.Inject;
+import org.jooq.*;
+import org.jooq.Record;
+import org.jooq.impl.DSL;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@MicronautTest(transactional = false)
+@TestInstance(TestInstance.Lifecycle.PER_CLASS) // must be per-class to allow calling once init() which took a lot of time
+public abstract class AbstractJdbcDeserializationIssuesTest {
+    @Inject
+    private DeserializationIssuesCaseTest deserializationIssuesCaseTest;
+
+    @Inject
+    private JdbcTestUtils jdbcTestUtils;
+
+    @Inject
+    private JooqDSLContextWrapper dslContextWrapper;
+
+    @Inject
+    private JdbcConfiguration jdbcConfiguration;
+
+    @Inject
+    private StandAloneRunner runner;
+
+    @BeforeAll
+    void init() {
+        jdbcTestUtils.drop();
+        jdbcTestUtils.migrate();
+
+        runner.setSchedulerEnabled(false);
+        runner.run();
+    }
+
+    @Test
+    void workerTaskDeserializationIssue() throws Exception {
+        deserializationIssuesCaseTest.workerTaskDeserializationIssue(queueMessage -> sendToQueue(queueMessage));
+    }
+
+    @Test
+    void workerTriggerDeserializationIssue() throws Exception {
+        deserializationIssuesCaseTest.workerTriggerDeserializationIssue(queueMessage -> sendToQueue(queueMessage));
+    }
+
+    private void sendToQueue(DeserializationIssuesCaseTest.QueueMessage queueMessage) {
+
+        Table<Record> table = DSL.table(jdbcConfiguration.tableConfig("queues").getTable());
+
+        Map<Field<Object>, Object> fields = fields(queueMessage);
+
+        dslContextWrapper.transaction(configuration -> {
+            DSLContext context = DSL.using(configuration);
+
+            context
+                .insertInto(table)
+                .set(fields)
+                .execute();
+        });
+    }
+
+    protected Map<Field<Object>, Object> fields(DeserializationIssuesCaseTest.QueueMessage queueMessage) {
+        Map<Field<Object>, Object> fields = new HashMap<>();
+        fields.put(AbstractJdbcRepository.field("type"), queueMessage.type().getName());
+        fields.put(AbstractJdbcRepository.field("key"), queueMessage.key() != null ? queueMessage.key() : IdUtils.create());
+        fields.put(AbstractJdbcRepository.field("value"), JSONB.valueOf(queueMessage.value()));
+        return fields;
+    }
+}

--- a/jdbc/src/test/java/io/kestra/jdbc/runner/JdbcRunnerTest.java
+++ b/jdbc/src/test/java/io/kestra/jdbc/runner/JdbcRunnerTest.java
@@ -174,12 +174,12 @@ public abstract class JdbcRunnerTest {
         restartCaseTest.replay();
     }
 
-    @Test
+    @RetryingTest(5)
     void restartMultiple() throws Exception {
         restartCaseTest.restartMultiple();
     }
 
-    @Test
+    @RetryingTest(5)
     void flowTrigger() throws Exception {
         flowTriggerCaseTest.trigger();
     }


### PR DESCRIPTION
This PR provides safe deserialization for:
- A WorkerTrigger
- A WorkerTriggerResult
- A WorkerTask
- A Flow

You can QA with a flow that uses a task from a plugin, launching it thousands of times, hard killing Kestra and removing the plugin so you have pending WorkerTask and WorkerTask result to verify that it correctly ends the flow.

You can also use the following instructions to QA features one by one.

To QA an invalid `WorkerTrigger`, you can use the following INSERT statement, there should be error logs but no stacktraces or crashes.

```sql
INSERT INTO queues ("type", "key", value, updated)
VALUES('io.kestra.core.runners.WorkerJob'::"queue_type", 'company.team_hello-world_trigger', '{"type": "trigger", "trigger": {"id": "trigger", "sql": "select CURRENT_TIMESTAMP", "url": "jdbc:postgresql://localhost:5432/kestra", "type": "io.kestra.unknown.Invalid", "password": "k3str4", "username": "kestra"}, "triggerContext": {"date": "2023-12-05T13:29:47.455480928Z", "flowId": "hello-world", "namespace": "company.team", "triggerId": "trigger", "flowRevision": 3}, "conditionContext": {"flow": {"id": "hello-world", "tasks": [{"id": "hello", "type": "io.kestra.core.tasks.log.Log", "message": "Kestra team wishes you a great day! 👋"}], "deleted": false, "disabled": false, "revision": 3, "triggers": [{"id": "trigger", "sql": "select CURRENT_TIMESTAMP", "url": "jdbc:postgresql://localhost:5432/kestra", "type": "io.kestra.plugin.jdbc.postgresql.Trigger", "password": "k3str4", "username": "kestra"}], "namespace": "company.team"}, "runContext": {"variables": {"envs": {"plugins_path": "/home/loic/dev/kestra-plugins"}, "flow": {"id": "hello-world", "revision": 3, "namespace": "company.team"}, "trigger": {"id": "trigger", "type": "io.kestra.plugin.jdbc.postgresql.Trigger"}}}}}'::jsonb, '2023-12-05 13:29:47.942');
```

To QA an invalid `WorkerTriggerResult`, you can use the following INSERT statement, there should be error logs but no stacktraces or crashes.

```sql
INSERT INTO queues("type", "key", value, updated)
VALUES('io.kestra.core.runners.WorkerTriggerResult'::"queue_type", 'company.team_hello-world_trigger', '{"success": true, "trigger": {"id": "trigger", "sql": "select CURRENT_TIMESTAMP", "url": "jdbc:postgresql://localhost:5432/kestra", "type": "io.kestra.unknown.Invalid", "fetchOne": true, "password": "k3str4", "username": "kestra"}, "execution": {"id": "2xpPLaPFjLsfG6rd5N4sWC", "state": {"current": "CREATED", "duration": 0.000485197, "histories": [{"date": "2023-12-05T13:30:49.110397416Z", "state": "CREATED"}], "startDate": "2023-12-05T13:30:49.110397416Z"}, "flowId": "hello-world", "deleted": false, "trigger": {"id": "trigger", "type": "io.kestra.plugin.jdbc.postgresql.Trigger", "variables": {"row": {"current_timestamp": "2023-12-05T13:30:49.101707Z"}, "size": 1}}, "namespace": "company.team", "originalId": "2xpPLaPFjLsfG6rd5N4sWC", "flowRevision": 4}, "triggerContext": {"date": "2023-12-05T13:30:48.453616306Z", "flowId": "hello-world", "namespace": "company.team", "triggerId": "trigger", "flowRevision": 4}}'::jsonb, '2023-12-05 13:30:49.123');
```

To QA an invalid `WorkerTask`, you can use the following INSERT statement, there should be error logs but no stacktraces or crashes.

```sql
INSERT INTO public.queues("type", "key", value, updated)
VALUES('io.kestra.core.runners.WorkerJob'::"queue_type", '2fKi81KTdBbHH1FbkvqntW', '{"task": {"id": "hello", "type": "io.kestra.unknown.Invalid", "message": "Kestra team wishes you a great day! 👋"}, "type": "task", "taskRun": {"id": "2fKi81KTdBbHH1FbkvqntW", "state": {"current": "CREATED", "duration": 0.161643766, "histories": [{"date": "2023-12-05T13:16:58.047066195Z", "state": "CREATED"}], "startDate": "2023-12-05T13:16:58.047066195Z"}, "flowId": "hello-world", "taskId": "hello", "namespace": "company.team", "executionId": "5ojop3jqsa32c5YPy8en65"}, "runContext": {"variables": {"envs": {"plugins_path": "/home/loic/dev/kestra-plugins"}, "flow": {"id": "hello-world", "revision": 1, "namespace": "company.team"}, "task": {"id": "hello", "type": "io.kestra.core.tasks.log.Log"}, "taskrun": {"id": "2fKi81KTdBbHH1FbkvqntW", "startDate": "2023-12-05T13:16:58.047066195Z", "attemptsCount": 0}, "execution": {"id": "5ojop3jqsa32c5YPy8en65", "startDate": "2023-12-05T13:16:57.763Z", "originalId": "5ojop3jqsa32c5YPy8en65"}}, "storageOutputPrefix": "///company/team/hello-world/executions/5ojop3jqsa32c5YPy8en65/tasks/hello/2fKi81KTdBbHH1FbkvqntW"}}'::jsonb, '2023-12-05 13:16:58.236');
```

To QA an invalid `Flow`, you can use the following INSERT statement, there should be error logs but no stacktraces or crashes.

```sql
INSERT INTO queues("type", "key", value, updated)
VALUES('io.kestra.core.models.flows.Flow'::"queue_type", 'company.team_hello-world_1', '{"id": "hello-world", "tasks": [{"id": "hello", "type": "io.kestra.unknown.Invalid", "message": "Kestra team wishes you a great day! 👋"}], "deleted": false, "disabled": false, "revision": 1, "namespace": "company.team"}'::jsonb, '2023-12-05 13:16:54.836');
```