### PR TITLE
fix(cli): add missing help outputs

### DIFF
--- a/cli/src/main/java/io/kestra/cli/commands/flows/namespaces/FlowNamespaceCommand.java
+++ b/cli/src/main/java/io/kestra/cli/commands/flows/namespaces/FlowNamespaceCommand.java
@@ -1,5 +1,8 @@
 package io.kestra.cli.commands.flows.namespaces;
 
+import io.kestra.cli.App;
+import io.micronaut.configuration.picocli.PicocliRunner;
+import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 import io.kestra.cli.AbstractCommand;
 import picocli.CommandLine;
@@ -14,5 +17,13 @@ import picocli.CommandLine;
 )
 @Slf4j
 public class FlowNamespaceCommand extends AbstractCommand {
+    @SneakyThrows
+    @Override
+    public Integer call() throws Exception {
+        super.call();
 
+        PicocliRunner.call(App.class, "flow", "namespace",  "--help");
+
+        return 0;
+    }
 }

--- a/cli/src/main/java/io/kestra/cli/commands/namespaces/NamespaceCommand.java
+++ b/cli/src/main/java/io/kestra/cli/commands/namespaces/NamespaceCommand.java
@@ -23,7 +23,7 @@ public class NamespaceCommand extends AbstractCommand {
     public Integer call() throws Exception {
         super.call();
 
-        PicocliRunner.call(App.class, "namespaces", "--help");
+        PicocliRunner.call(App.class, "namespace", "--help");
 
         return 0;
     }

--- a/cli/src/main/java/io/kestra/cli/commands/namespaces/files/NamespaceFilesCommand.java
+++ b/cli/src/main/java/io/kestra/cli/commands/namespaces/files/NamespaceFilesCommand.java
@@ -1,6 +1,9 @@
 package io.kestra.cli.commands.namespaces.files;
 
 import io.kestra.cli.AbstractCommand;
+import io.kestra.cli.App;
+import io.micronaut.configuration.picocli.PicocliRunner;
+import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 import picocli.CommandLine;
 
@@ -14,5 +17,13 @@ import picocli.CommandLine;
 )
 @Slf4j
 public class NamespaceFilesCommand extends AbstractCommand {
+    @SneakyThrows
+    @Override
+    public Integer call() throws Exception {
+        super.call();
 
+        PicocliRunner.call(App.class, "namespace", "files",  "--help");
+
+        return 0;
+    }
 }

--- a/cli/src/main/java/io/kestra/cli/commands/sys/database/DatabaseCommand.java
+++ b/cli/src/main/java/io/kestra/cli/commands/sys/database/DatabaseCommand.java
@@ -1,6 +1,9 @@
 package io.kestra.cli.commands.sys.database;
 
 import io.kestra.cli.AbstractCommand;
+import io.kestra.cli.App;
+import io.micronaut.configuration.picocli.PicocliRunner;
+import lombok.SneakyThrows;
 import picocli.CommandLine;
 
 @CommandLine.Command(
@@ -12,4 +15,13 @@ import picocli.CommandLine;
     }
 )
 public class DatabaseCommand extends AbstractCommand {
+    @SneakyThrows
+    @Override
+    public Integer call() throws Exception {
+        super.call();
+
+        PicocliRunner.call(App.class, "sys", "database", "--help");
+
+        return 0;
+    }
 }

--- a/cli/src/main/java/io/kestra/cli/commands/templates/namespaces/TemplateNamespaceCommand.java
+++ b/cli/src/main/java/io/kestra/cli/commands/templates/namespaces/TemplateNamespaceCommand.java
@@ -1,7 +1,10 @@
 package io.kestra.cli.commands.templates.namespaces;
 
 import io.kestra.cli.AbstractCommand;
+import io.kestra.cli.App;
 import io.kestra.core.models.templates.TemplateEnabled;
+import io.micronaut.configuration.picocli.PicocliRunner;
+import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 import picocli.CommandLine;
 
@@ -16,5 +19,13 @@ import picocli.CommandLine;
 @Slf4j
 @TemplateEnabled
 public class TemplateNamespaceCommand extends AbstractCommand {
+    @SneakyThrows
+    @Override
+    public Integer call() throws Exception {
+        super.call();
 
+        PicocliRunner.call(App.class, "template", "namespace", "--help");
+
+        return 0;
+    }
 }

--- a/cli/src/test/java/io/kestra/cli/commands/flows/namespaces/FlowNamespaceCommandTest.java
+++ b/cli/src/test/java/io/kestra/cli/commands/flows/namespaces/FlowNamespaceCommandTest.java
@@ -1,0 +1,33 @@
+package io.kestra.cli.commands.flows.namespaces;
+
+import io.micronaut.configuration.picocli.PicocliRunner;
+import io.micronaut.context.ApplicationContext;
+import io.micronaut.context.env.Environment;
+import io.micronaut.runtime.server.EmbeddedServer;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.StringStartsWith.startsWith;
+
+class FlowNamespaceCommandTest {
+    @Test
+    void runWithNoParam() {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        System.setOut(new PrintStream(out));
+
+        try (ApplicationContext ctx = ApplicationContext.run(Environment.CLI, Environment.TEST)) {
+            EmbeddedServer embeddedServer = ctx.getBean(EmbeddedServer.class);
+            embeddedServer.start();
+
+            String[] args = {};
+            Integer call = PicocliRunner.call(FlowNamespaceCommand.class, ctx, args);
+
+            assertThat(call, is(0));
+            assertThat(out.toString(), startsWith("Usage: kestra flow namespace"));
+        }
+    }
+}

--- a/cli/src/test/java/io/kestra/cli/commands/namespaces/NamespaceCommandTest.java
+++ b/cli/src/test/java/io/kestra/cli/commands/namespaces/NamespaceCommandTest.java
@@ -1,0 +1,33 @@
+package io.kestra.cli.commands.namespaces;
+
+import io.micronaut.configuration.picocli.PicocliRunner;
+import io.micronaut.context.ApplicationContext;
+import io.micronaut.context.env.Environment;
+import io.micronaut.runtime.server.EmbeddedServer;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.StringStartsWith.startsWith;
+
+class NamespaceCommandTest {
+    @Test
+    void runWithNoParam() {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        System.setOut(new PrintStream(out));
+
+        try (ApplicationContext ctx = ApplicationContext.run(Environment.CLI, Environment.TEST)) {
+            EmbeddedServer embeddedServer = ctx.getBean(EmbeddedServer.class);
+            embeddedServer.start();
+
+            String[] args = {};
+            Integer call = PicocliRunner.call(NamespaceCommand.class, ctx, args);
+
+            assertThat(call, is(0));
+            assertThat(out.toString(), startsWith("Usage: kestra namespace"));
+        }
+    }
+}

--- a/cli/src/test/java/io/kestra/cli/commands/namespaces/files/NamespaceFilesCommandTest.java
+++ b/cli/src/test/java/io/kestra/cli/commands/namespaces/files/NamespaceFilesCommandTest.java
@@ -1,0 +1,33 @@
+package io.kestra.cli.commands.namespaces.files;
+
+import io.micronaut.configuration.picocli.PicocliRunner;
+import io.micronaut.context.ApplicationContext;
+import io.micronaut.context.env.Environment;
+import io.micronaut.runtime.server.EmbeddedServer;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.StringStartsWith.startsWith;
+
+class NamespaceFilesCommandTest {
+    @Test
+    void runWithNoParam() {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        System.setOut(new PrintStream(out));
+
+        try (ApplicationContext ctx = ApplicationContext.run(Environment.CLI, Environment.TEST)) {
+            EmbeddedServer embeddedServer = ctx.getBean(EmbeddedServer.class);
+            embeddedServer.start();
+
+            String[] args = {};
+            Integer call = PicocliRunner.call(NamespaceFilesCommand.class, ctx, args);
+
+            assertThat(call, is(0));
+            assertThat(out.toString(), startsWith("Usage: kestra namespace files"));
+        }
+    }
+}

--- a/cli/src/test/java/io/kestra/cli/commands/sys/database/DatabaseCommandTest.java
+++ b/cli/src/test/java/io/kestra/cli/commands/sys/database/DatabaseCommandTest.java
@@ -1,0 +1,33 @@
+package io.kestra.cli.commands.sys.database;
+
+import io.micronaut.configuration.picocli.PicocliRunner;
+import io.micronaut.context.ApplicationContext;
+import io.micronaut.context.env.Environment;
+import io.micronaut.runtime.server.EmbeddedServer;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.StringStartsWith.startsWith;
+
+class DatabaseCommandTest {
+    @Test
+    void runWithNoParam() {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        System.setOut(new PrintStream(out));
+
+        try (ApplicationContext ctx = ApplicationContext.run(Environment.CLI, Environment.TEST)) {
+            EmbeddedServer embeddedServer = ctx.getBean(EmbeddedServer.class);
+            embeddedServer.start();
+
+            String[] args = {};
+            Integer call = PicocliRunner.call(DatabaseCommand.class, ctx, args);
+
+            assertThat(call, is(0));
+            assertThat(out.toString(), startsWith("Usage: kestra sys database"));
+        }
+    }
+}

--- a/cli/src/test/java/io/kestra/cli/commands/templates/namespaces/TemplateNamespaceCommandTest.java
+++ b/cli/src/test/java/io/kestra/cli/commands/templates/namespaces/TemplateNamespaceCommandTest.java
@@ -1,0 +1,33 @@
+package io.kestra.cli.commands.templates.namespaces;
+
+import io.micronaut.configuration.picocli.PicocliRunner;
+import io.micronaut.context.ApplicationContext;
+import io.micronaut.context.env.Environment;
+import io.micronaut.runtime.server.EmbeddedServer;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.StringStartsWith.startsWith;
+
+class TemplateNamespaceCommandTest {
+    @Test
+    void runWithNoParam() {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        System.setOut(new PrintStream(out));
+
+        try (ApplicationContext ctx = ApplicationContext.run(Environment.CLI, Environment.TEST)) {
+            EmbeddedServer embeddedServer = ctx.getBean(EmbeddedServer.class);
+            embeddedServer.start();
+
+            String[] args = {};
+            Integer call = PicocliRunner.call(TemplateNamespaceCommand.class, ctx, args);
+
+            assertThat(call, is(0));
+            assertThat(out.toString(), startsWith("Usage: kestra template namespace"));
+        }
+    }
+}


### PR DESCRIPTION
### What changes are being made and why?

Improved QoL of situations when interacting purely with the CLI (no documentation at hand).

Commands with missing implicit help output are hopefully gone.

---

### How the changes have been QAed?

Unit tests
