### PR TITLE
feat(core,ui): display an error message for execution level exception

### DIFF
--- a/core/src/test/java/io/kestra/core/runners/FlowConcurrencyCaseTest.java
+++ b/core/src/test/java/io/kestra/core/runners/FlowConcurrencyCaseTest.java
@@ -65,6 +65,7 @@ public class FlowConcurrencyCaseTest {
 
         assertThat(execution1.getState().isRunning(), is(true));
         assertThat(execution2.getState().getCurrent(), is(State.Type.FAILED));
+        assertThat(execution2.getExceptionMessage(), is("Flow is FAILED due to concurrency limit exceeded"));
 
         var executionResult1  = new AtomicReference<Execution>();
 

--- a/ui/src/components/executions/Overview.vue
+++ b/ui/src/components/executions/Overview.vue
@@ -133,7 +133,8 @@
                     {key: this.$t("created date"), value: this.execution.state.histories[0].date, date: true},
                     {key: this.$t("updated date"), value: this.stop(), date: true},
                     {key: this.$t("duration"), value: this.execution.state.histories, duration: true},
-                    {key: this.$t("steps"), value: stepCount}
+                    {key: this.$t("steps"), value: stepCount},
+                    {key: this.$t("exception message"), value: this.execution.exceptionMessage},
                 ];
 
                 if (this.execution.parentId) {

--- a/ui/src/translations.json
+++ b/ui/src/translations.json
@@ -523,7 +523,8 @@
     "show": "Show",
     "advanced configuration": "Advanced configuration",
     "all executions": "All executions",
-    "trigger execution id": "Parent Id"
+    "trigger execution id": "Parent Id",
+    "exception message": "Exception message"
   },
   "fr": {
     "id": "Identifiant",
@@ -1039,7 +1040,8 @@
     "row count": "Nombre de lignes",
     "encoding": "Encodage",
     "all executions": "Toutes les exécutions",
-    "trigger execution id": "Id parent"
+    "trigger execution id": "Id parent",
+    "exception message": "Message d'exception"
   }
 }
 


### PR DESCRIPTION
Today, error message are only displayed when a task fail. But there can be failure at the execution level inside the executor for a number or reason including deserialization issue or concurrency failures. This PR adds an exception message inside the exeution and displays it in the UI.

The easiest way to QA it is to trigger a concurrency failed execution for ex by triggering two times this flow:

```yaml
id: hello-pause-concurrency
namespace: company.team

concurrency:
  behavior: FAIL
  limit: 1

tasks:
  - id: pause
    type: io.kestra.plugin.scripts.shell.Commands
    runner: PROCESS
    commands:
      - sleep 10
  - id: hello
    type: io.kestra.core.tasks.log.Log
    message: Kestra team wishes you a great day! 👋
```