### PR TITLE
feat(jdbc,runner-memory): send a FAILED worker task result when we ca…

### DIFF
--- a/core/src/test/java/io/kestra/core/tasks/flows/BadExecutableTest.java
+++ b/core/src/test/java/io/kestra/core/tasks/flows/BadExecutableTest.java
@@ -1,0 +1,22 @@
+package io.kestra.core.tasks.flows;
+
+import io.kestra.core.models.executions.Execution;
+import io.kestra.core.models.flows.State;
+import io.kestra.core.runners.AbstractMemoryRunnerTest;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.TimeoutException;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+public class BadExecutableTest extends AbstractMemoryRunnerTest {
+    @Test
+    void badExecutable() throws TimeoutException {
+        Execution execution = runnerUtils.runOne(null, "io.kestra.tests", "executable-fail");
+
+        assertThat(execution.getTaskRunList().size(), is(1));
+        assertThat(execution.getTaskRunList().get(0).getState().getCurrent(), is(State.Type.FAILED));
+        assertThat(execution.getState().getCurrent(), is(State.Type.FAILED));
+    }
+}

--- a/core/src/test/java/io/kestra/core/tasks/test/BadExecutable.java
+++ b/core/src/test/java/io/kestra/core/tasks/test/BadExecutable.java
@@ -1,0 +1,43 @@
+package io.kestra.core.tasks.test;
+
+import io.kestra.core.models.annotations.Example;
+import io.kestra.core.models.annotations.Plugin;
+import io.kestra.core.models.executions.Execution;
+import io.kestra.core.models.executions.TaskRun;
+import io.kestra.core.runners.RunContext;
+import io.kestra.core.runners.WorkerTaskResult;
+import io.kestra.core.tasks.flows.Flow;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+import lombok.experimental.SuperBuilder;
+
+import java.util.Optional;
+
+@SuperBuilder
+@ToString
+@EqualsAndHashCode
+@Getter
+@NoArgsConstructor
+@Schema(
+    title = "Test executable task that generates an exception on createWorkerTaskResult"
+)
+@Plugin(
+    examples = {
+        @Example(
+            full = true,
+            code = {
+                "no example here"
+            }
+        )
+    }
+)
+public class BadExecutable extends Flow {
+    
+    @Override
+    public Optional<WorkerTaskResult> createWorkerTaskResult(RunContext runContext, TaskRun taskRun, io.kestra.core.models.flows.Flow flow, Execution execution) {
+        throw new RuntimeException("An error!");
+    }
+}

--- a/core/src/test/resources/flows/valids/executable-fail.yml
+++ b/core/src/test/resources/flows/valids/executable-fail.yml
@@ -1,0 +1,9 @@
+id: executable-fail
+namespace: io.kestra.tests
+
+tasks:
+  - id: launch
+    type: io.kestra.core.tasks.test.BadExecutable
+    namespace: io.kestra.tests
+    flowId: logs
+    wait: true

--- a/jdbc/src/test/java/io/kestra/jdbc/runner/JdbcRunnerTest.java
+++ b/jdbc/src/test/java/io/kestra/jdbc/runner/JdbcRunnerTest.java
@@ -301,4 +301,13 @@ public abstract class JdbcRunnerTest {
     void concurrencyCancelPause() throws TimeoutException, InterruptedException  {
         flowConcurrencyCaseTest.flowConcurrencyCancelPause();
     }
+
+    @Test
+    void badExecutable() throws TimeoutException {
+        Execution execution = runnerUtils.runOne(null, "io.kestra.tests", "executable-fail");
+
+        assertThat(execution.getTaskRunList().size(), is(1));
+        assertThat(execution.getTaskRunList().get(0).getState().getCurrent(), is(State.Type.FAILED));
+        assertThat(execution.getState().getCurrent(), is(State.Type.FAILED));
+    }
 }


### PR DESCRIPTION
…nnot create it from the executable task

