### PR TITLE
fix(jdbc): update the executor even if we cannot emit logs

### DIFF
--- a/jdbc/src/main/java/io/kestra/jdbc/runner/JdbcExecutor.java
+++ b/jdbc/src/main/java/io/kestra/jdbc/runner/JdbcExecutor.java
@@ -729,15 +729,14 @@ public class JdbcExecutor implements ExecutorInterface {
 
     private Executor handleFailedExecutionFromExecutor(Executor executor, Exception e) {
         Execution.FailedExecutionWithLog failedExecutionWithLog = executor.getExecution().failedExecutionFromExecutor(e);
+
         try {
             failedExecutionWithLog.getLogs().forEach(logQueue::emitAsync);
-
-            return executor.withExecution(failedExecutionWithLog.getExecution(), "exception");
         } catch (Exception ex) {
             log.error("Failed to produce {}", e.getMessage(), ex);
         }
 
-        return executor;
+        return executor.withExecution(failedExecutionWithLog.getExecution(), "exception");
     }
 
     @Override


### PR DESCRIPTION
Very small fix for a potential executor misbehavior
