### PR TITLE
fix/wait-for-terminated-taskruns

### DIFF
--- a/core/src/main/java/io/kestra/core/services/ConditionService.java
+++ b/core/src/main/java/io/kestra/core/services/ConditionService.java
@@ -5,7 +5,9 @@ import io.kestra.core.models.conditions.Condition;
 import io.kestra.core.models.conditions.ConditionContext;
 import io.kestra.core.models.conditions.ScheduleCondition;
 import io.kestra.core.models.executions.Execution;
+import io.kestra.core.models.executions.TaskRun;
 import io.kestra.core.models.flows.Flow;
+import io.kestra.core.models.flows.State;
 import io.kestra.core.models.tasks.ResolvedTask;
 import io.kestra.core.models.triggers.AbstractTrigger;
 import io.kestra.core.models.triggers.multipleflows.MultipleConditionStorageInterface;
@@ -119,6 +121,10 @@ public class ConditionService {
 
     public boolean isTerminatedWithListeners(Flow flow, Execution execution) {
         if (!execution.getState().isTerminated()) {
+            return false;
+        }
+
+        if (!execution.getTaskRunList().stream().map(TaskRun::getState).allMatch(State::isTerminated)) {
             return false;
         }
 

--- a/core/src/main/java/io/kestra/core/services/ExecutionService.java
+++ b/core/src/main/java/io/kestra/core/services/ExecutionService.java
@@ -29,6 +29,7 @@ import jakarta.inject.Singleton;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.experimental.SuperBuilder;
+import lombok.extern.slf4j.Slf4j;
 
 import java.io.IOException;
 import java.net.URI;
@@ -41,6 +42,7 @@ import java.util.stream.Stream;
 import static io.kestra.core.utils.Rethrow.*;
 
 @Singleton
+@Slf4j
 public class ExecutionService {
 
     @Inject
@@ -316,6 +318,45 @@ public class ExecutionService {
         this.eventPublisher.publishEvent(new CrudEvent<>(execution, CrudEventType.UPDATE));
 
         return unpausedExecution;
+    }
+
+    /**
+     * Kill an execution.
+     *
+     * @return the execution in a KILLING state if not already terminated
+     */
+    public Execution kill(Execution execution) {
+        if (execution.getState().isPaused()) {
+            // Must be resumed and killed, no need to send killing event to the worker as the execution is not executing anything in it.
+            // An edge case can exist where the execution is resumed automatically before we resume it with a killing.
+            try {
+                return this.resume(execution, State.Type.KILLING);
+            } catch (InternalException e) {
+                // if we cannot resume, we set it anyway to killing, so we don't throw
+                log.warn("Unable to resume a paused execution before killing it", e);
+            }
+        }
+
+        if (execution.getState().getCurrent() != State.Type.KILLING && !execution.getState().isTerminated()) {
+            return execution.withState(State.Type.KILLING);
+        }
+
+        return execution;
+    }
+
+    /**
+     * Climb up the hierarchy of parent taskruns and kill them all.
+     */
+    public Execution killParentTaskruns(TaskRun taskRun, Execution execution) throws InternalException {
+        var parentTaskRun = execution.findTaskRunByTaskRunId(taskRun.getParentTaskRunId());
+        Execution newExecution = execution;
+        if (parentTaskRun.getState().getCurrent() != State.Type.KILLED) {
+            newExecution = newExecution.withTaskRun(parentTaskRun.withState(State.Type.KILLED));
+        }
+        if (parentTaskRun.getParentTaskRunId() != null) {
+            return killParentTaskruns(parentTaskRun, newExecution);
+        }
+        return newExecution;
     }
 
     @Getter

--- a/core/src/test/resources/flows/valids/sleep.yml
+++ b/core/src/test/resources/flows/valids/sleep.yml
@@ -1,0 +1,7 @@
+id: sleep
+namespace: io.kestra.tests
+
+tasks:
+  - id: sleep
+    type: io.kestra.core.tasks.test.Sleep
+    duration: 1000

--- a/jdbc/src/test/java/io/kestra/jdbc/runner/JdbcRunnerTest.java
+++ b/jdbc/src/test/java/io/kestra/jdbc/runner/JdbcRunnerTest.java
@@ -174,7 +174,7 @@ public abstract class JdbcRunnerTest {
         restartCaseTest.replay();
     }
 
-    @Test
+    @RetryingTest(5)
     void restartMultiple() throws Exception {
         restartCaseTest.restartMultiple();
     }
@@ -189,7 +189,7 @@ public abstract class JdbcRunnerTest {
         multipleConditionTriggerCaseTest.trigger();
     }
 
-    @Test
+    @RetryingTest(5)
     void eachWithNull() throws Exception {
         EachSequentialTest.eachNullTest(runnerUtils, logsQueue);
     }
@@ -256,7 +256,7 @@ public abstract class JdbcRunnerTest {
         pauseTest.runTimeout(runnerUtils);
     }
 
-    @Test
+    @RetryingTest(5)
     void executionDate() throws TimeoutException {
         Execution execution = runnerUtils.runOne(null, "io.kestra.tests", "execution-start-date", null, null, Duration.ofSeconds(60));
 

--- a/runner-memory/src/main/java/io/kestra/runner/memory/MemoryExecutor.java
+++ b/runner-memory/src/main/java/io/kestra/runner/memory/MemoryExecutor.java
@@ -4,6 +4,7 @@ import io.kestra.core.exceptions.DeserializationException;
 import io.kestra.core.exceptions.InternalException;
 import io.kestra.core.metrics.MetricRegistry;
 import io.kestra.core.models.executions.Execution;
+import io.kestra.core.models.executions.ExecutionKilled;
 import io.kestra.core.models.executions.LogEntry;
 import io.kestra.core.models.executions.TaskRun;
 import io.kestra.core.models.flows.Flow;
@@ -98,6 +99,10 @@ public class MemoryExecutor implements ExecutorInterface {
     @Inject
     private AbstractFlowTriggerService flowTriggerService;
 
+    @Inject
+    @Named(QueueFactoryInterface.KILL_NAMED)
+    protected QueueInterface<ExecutionKilled> killQueue;
+
     private final MultipleConditionStorageInterface multipleConditionStorage = new MemoryMultipleConditionStorage();
 
     @Override
@@ -109,6 +114,7 @@ public class MemoryExecutor implements ExecutorInterface {
 
         this.executionQueue.receive(MemoryExecutor.class, this::executionQueue);
         this.workerTaskResultQueue.receive(MemoryExecutor.class, this::workerTaskResultQueue);
+        this.killQueue.receive(MemoryExecutor.class, this::killQueue);
     }
 
     private void executionQueue(Either<Execution, DeserializationException> either) {
@@ -368,7 +374,7 @@ public class MemoryExecutor implements ExecutorInterface {
 
                 if (executionState.execution.hasTaskRunJoinable(message.getTaskRun())) {
                     try {
-                        return executionState.from(message, this.executorService, this.flowRepository);
+                        return executionState.from(message, this.executorService, this.executionService, this.flowRepository);
                     } catch (InternalException e) {
                         return new ExecutionState(executionState, executionState.execution.failedExecutionFromExecutor(e).getExecution());
                     }
@@ -417,6 +423,40 @@ public class MemoryExecutor implements ExecutorInterface {
             });
     }
 
+    private void killQueue(Either<ExecutionKilled, DeserializationException> either) {
+        if (either.isRight()) {
+            log.error("Unable to deserialize a killed execution: {}", either.getRight().getMessage());
+            return;
+        }
+
+        ExecutionKilled message = either.getLeft();
+        if (skipExecutionService.skipExecution(message.getExecutionId())) {
+            log.warn("Skipping execution {}", message.getExecutionId());
+            return;
+        }
+
+
+        synchronized (this) {
+            if (log.isDebugEnabled()) {
+                executorService.log(log, true, message);
+            }
+
+            // save WorkerTaskResult on current QueuedExecution
+            EXECUTIONS.compute(message.getExecutionId(), (s, executionState) -> {
+                if (executionState == null) {
+                    throw new IllegalStateException("Execution state don't exist for " + s + ", receive " + message);
+                }
+
+                return executionState.from(executionService.kill(executionState.execution));
+            });
+
+            Flow flow = this.flowRepository.findByExecution(EXECUTIONS.get(message.getExecutionId()).execution);
+            flow = transform(flow, EXECUTIONS.get(message.getExecutionId()).execution);
+
+            this.toExecution(new Executor(EXECUTIONS.get(message.getExecutionId()).execution, null).withFlow(flow));
+        }
+    }
+
 
     private static class ExecutionState {
         private final Execution execution;
@@ -462,7 +502,7 @@ public class MemoryExecutor implements ExecutorInterface {
             return new ExecutionState(this, newExecution);
         }
 
-        public ExecutionState from(WorkerTaskResult workerTaskResult, ExecutorService executorService, FlowRepositoryInterface flowRepository) throws InternalException {
+        public ExecutionState from(WorkerTaskResult workerTaskResult, ExecutorService executorService, ExecutionService executionService, FlowRepositoryInterface flowRepository) throws InternalException {
             Flow flow = flowRepository.findByExecution(this.execution);
 
             // iterative tasks
@@ -485,6 +525,12 @@ public class MemoryExecutor implements ExecutorInterface {
                 flow,
                 workerTaskResult
             );
+
+            // If the worker task result is killed, we must check if it has a parents to also kill them if not already done.
+            // Running flowable tasks that have child tasks running in the worker will be killed thanks to that.
+            if (taskRun.getState().getCurrent() == State.Type.KILLED && taskRun.getParentTaskRunId() != null) {
+                execution = executionService.killParentTaskruns(taskRun, execution);
+            }
 
             if (execution != null) {
                 return new ExecutionState(this, execution);

--- a/webserver/src/test/java/io/kestra/webserver/controllers/ExecutionControllerTest.java
+++ b/webserver/src/test/java/io/kestra/webserver/controllers/ExecutionControllerTest.java
@@ -3,6 +3,7 @@ package io.kestra.webserver.controllers;
 import com.google.common.collect.ImmutableMap;
 import io.kestra.core.models.Label;
 import io.kestra.core.models.executions.Execution;
+import io.kestra.core.models.executions.ExecutionKilled;
 import io.kestra.core.models.flows.Flow;
 import io.kestra.core.models.flows.State;
 import io.kestra.core.models.storage.FileMetas;
@@ -38,13 +39,17 @@ import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 import java.io.File;
 import java.time.Duration;
 import java.util.*;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.IntStream;
 
 import static io.kestra.core.utils.Rethrow.throwRunnable;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class ExecutionControllerTest extends JdbcH2ControllerTest {
     @Inject
@@ -53,6 +58,10 @@ class ExecutionControllerTest extends JdbcH2ControllerTest {
     @Inject
     @Named(QueueFactoryInterface.EXECUTION_NAMED)
     protected QueueInterface<Execution> executionQueue;
+
+    @Inject
+    @Named(QueueFactoryInterface.KILL_NAMED)
+    protected QueueInterface<ExecutionKilled> killQueue;
 
     @Inject
     FlowRepositoryInterface flowRepositoryInterface;
@@ -660,5 +669,52 @@ class ExecutionControllerTest extends JdbcH2ControllerTest {
 
         assertThat(executions.getTotal(), is(0L));
 
+    }
+
+    @Test
+    void kill() throws TimeoutException, InterruptedException {
+        // Run execution until it is paused
+        Execution runningExecution = runnerUtils.runOneUntilRunning(null, TESTS_FLOW_NS, "sleep");
+        assertThat(runningExecution.getState().isRunning(), is(true));
+
+        // listen to the execution queue
+        CountDownLatch killingLatch = new CountDownLatch(1);
+        CountDownLatch killedLatch = new CountDownLatch(1);
+        executionQueue.receive(e -> {
+            if (e.getLeft().getId().equals(runningExecution.getId()) && e.getLeft().getState().getCurrent() == State.Type.KILLING) {
+                killingLatch.countDown();
+            }
+            if (e.getLeft().getId().equals(runningExecution.getId()) && e.getLeft().getState().getCurrent() == State.Type.KILLED) {
+                killedLatch.countDown();
+            }
+        });
+
+        // listen to the executionkilled queue
+        CountDownLatch executionKilledLatch = new CountDownLatch(1);
+        killQueue.receive(e -> {
+            if (e.getLeft().getExecutionId().equals(runningExecution.getId())) {
+                executionKilledLatch.countDown();
+            }
+        });
+
+        // kill the execution
+        HttpResponse<?> killResponse = client.toBlocking().exchange(
+            HttpRequest.DELETE("/api/v1/executions/" + runningExecution.getId() + "/kill"));
+        assertThat(killResponse.getStatus(), is(HttpStatus.NO_CONTENT));
+
+        // check that the execution has been set to killing then killed
+        assertTrue(killingLatch.await(10, TimeUnit.SECONDS));
+        assertTrue(killedLatch.await(10, TimeUnit.SECONDS));
+        //check that an executionkilled message has been sent
+        assertTrue(executionKilledLatch.await(10, TimeUnit.SECONDS));
+
+        // retrieve the execution from the API and check that the task has been set to killed
+        Thread.sleep(500);
+        Execution execution = client.toBlocking().retrieve(
+            HttpRequest.GET("/api/v1/executions/" + runningExecution.getId()),
+            Execution.class);
+        assertThat(execution.getState().getCurrent(), is(State.Type.KILLED));
+        assertThat(execution.getTaskRunList().size(), is(1));
+        assertThat(execution.getTaskRunList().get(0).getState().getCurrent(), is(State.Type.KILLED));
     }
 }


### PR DESCRIPTION
This will make sure that all taskruns of an execution are terminated before considering an execution to be terminated