### PR TITLE
feat(core): public holiday condition

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -23,6 +23,8 @@ dependencies {
     implementation 'com.github.oshi:oshi-core:6.4.6'
     implementation 'io.pebbletemplates:pebble:3.2.1'
     implementation group: 'co.elastic.logging', name: 'logback-ecs-encoder', version: '1.5.0'
+    implementation group: 'de.focus-shift', name: 'jollyday-core', version: '0.22.0'
+    implementation group: 'de.focus-shift', name: 'jollyday-jaxb', version: '0.22.0'
 
     // scheduler
     implementation group: 'com.cronutils', name: 'cron-utils', version: '9.2.1'

--- a/core/src/main/java/io/kestra/core/models/conditions/types/DateTimeBetweenCondition.java
+++ b/core/src/main/java/io/kestra/core/models/conditions/types/DateTimeBetweenCondition.java
@@ -40,11 +40,11 @@ public class DateTimeBetweenCondition extends Condition implements ScheduleCondi
     @NotNull
     @Schema(
         title = "The date to test",
-        description = "Can be any variable or any valid ISO 8601 datetime, default will use `{{ now() }}`"
+        description = "Can be any variable or any valid ISO 8601 datetime, default will use the trigger date"
     )
     @Builder.Default
     @PluginProperty(dynamic = true)
-    private final String date = "{{ now() }}";
+    private final String date = "{{ trigger.date }}";
 
     @Schema(
         title = "The date to test must be after this one",

--- a/core/src/main/java/io/kestra/core/models/conditions/types/DayWeekCondition.java
+++ b/core/src/main/java/io/kestra/core/models/conditions/types/DayWeekCondition.java
@@ -40,11 +40,11 @@ public class DayWeekCondition extends Condition implements ScheduleCondition {
     @NotNull
     @Schema(
         title = "The date to test",
-        description = "Can be any variable or any valid ISO 8601 datetime, default will use `{{ now(format=\"iso_local_date\") }}`"
+        description = "Can be any variable or any valid ISO 8601 datetime, default will use the trigger date"
     )
     @Builder.Default
     @PluginProperty(dynamic = true)
-    private final String date = "{{ now(format=\"iso_local_date\") }}";
+    private final String date = "{{ trigger.date }}";
 
     @NotNull
     @Schema(title = "The day of week")

--- a/core/src/main/java/io/kestra/core/models/conditions/types/DayWeekInMonthCondition.java
+++ b/core/src/main/java/io/kestra/core/models/conditions/types/DayWeekInMonthCondition.java
@@ -42,11 +42,11 @@ public class DayWeekInMonthCondition extends Condition implements ScheduleCondit
     @NotNull
     @Schema(
         title = "The date to test",
-        description = "Can be any variable or any valid ISO 8601 datetime, default will use `{{ now(format=\"iso_local_date\") }}`"
+        description = "Can be any variable or any valid ISO 8601 datetime, default will use the trigger date`"
     )
     @Builder.Default
     @PluginProperty(dynamic = true)
-    private final String date = "{{ now(format=\"iso_local_date\") }}";
+    private final String date = "{{ trigger.date }}";
 
     @NotNull
     @Schema(title = "The day of week")

--- a/core/src/main/java/io/kestra/core/models/conditions/types/PublicHolidayCondition.java
+++ b/core/src/main/java/io/kestra/core/models/conditions/types/PublicHolidayCondition.java
@@ -1,0 +1,91 @@
+package io.kestra.core.models.conditions.types;
+
+import de.focus_shift.jollyday.core.HolidayManager;
+import de.focus_shift.jollyday.core.ManagerParameters;
+import io.kestra.core.exceptions.InternalException;
+import io.kestra.core.models.annotations.Example;
+import io.kestra.core.models.annotations.Plugin;
+import io.kestra.core.models.annotations.PluginProperty;
+import io.kestra.core.models.conditions.Condition;
+import io.kestra.core.models.conditions.ConditionContext;
+import io.kestra.core.models.conditions.ScheduleCondition;
+import io.kestra.core.utils.DateUtils;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.*;
+import lombok.experimental.SuperBuilder;
+
+import javax.validation.constraints.NotEmpty;
+import java.time.LocalDate;
+import java.util.Locale;
+
+@SuperBuilder
+@ToString
+@EqualsAndHashCode
+@Getter
+@NoArgsConstructor
+@Schema(
+    title = "Condition to allow events on public holidays"
+)
+@Plugin(
+    examples = {
+        @Example(
+            full = true,
+            title = "Condition to allow events on public holidays",
+            code = {
+                """
+                - conditions:
+                    - type: io.kestra.core.models.conditions.types.PublicHolidayCondition
+                      country: FR
+                """
+            }
+        ),
+        @Example(
+            full = true,
+            title = "Conditions to allow events on work days",
+            code = {
+                """
+                - conditions:
+                    - type: io.kestra.core.models.conditions.types.NotCondition
+                      conditions:
+                        - type: io.kestra.core.models.conditions.types.PublicHolidayCondition
+                          country: FR
+                        - type: io.kestra.core.models.conditions.types.WeekendCondition
+                """
+            }
+        )
+    }
+)
+public class PublicHolidayCondition extends Condition implements ScheduleCondition {
+    @NotEmpty
+    @Schema(
+        title = "The date to test",
+        description = "Can be any variable or any valid ISO 8601 datetime, default will use the trigger date"
+    )
+    @Builder.Default
+    @PluginProperty(dynamic = true)
+    private String date = "{{ trigger.date }}";
+
+    @Schema(
+        title = "[ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2) country code. If not set it uses the country code from the default locale.",
+        description = "It uses the [Jollyday](https://github.com/focus-shift/jollyday) library for public holiday calendar that support more than 70 countries."
+    )
+    @PluginProperty(dynamic = true)
+    private String country;
+
+    @Schema(
+        title = "[ISO 3166-2](https://en.wikipedia.org/wiki/ISO_3166-2) country subdivision (e.g., provinces and states) code.",
+        description = "It uses the [Jollyday](https://github.com/focus-shift/jollyday) library for public holiday calendar that support more than 70 countries."
+    )
+    @PluginProperty(dynamic = true)
+    private String subDivision;
+
+    @Override
+    public boolean test(ConditionContext conditionContext) throws InternalException {
+        var renderedCountry = conditionContext.getRunContext().render(this.country);
+        var renderedSubDivision = conditionContext.getRunContext().render(this.subDivision);
+
+        HolidayManager holidayManager = renderedCountry != null ? HolidayManager.getInstance(ManagerParameters.create(renderedCountry)) : HolidayManager.getInstance();
+        LocalDate currentDate = DateUtils.parseLocalDate(conditionContext.getRunContext().render(date));
+        return renderedSubDivision == null ? holidayManager.isHoliday(currentDate) : holidayManager.isHoliday(currentDate, renderedSubDivision);
+    }
+}

--- a/core/src/main/java/io/kestra/core/models/conditions/types/TimeBetweenCondition.java
+++ b/core/src/main/java/io/kestra/core/models/conditions/types/TimeBetweenCondition.java
@@ -40,11 +40,11 @@ public class TimeBetweenCondition extends Condition implements ScheduleCondition
     @NotNull
     @Schema(
         title = "The time to test",
-        description = "Can be any variable or any valid ISO 8601 time, default will use `{{ now(format='iso_offset_time') }}`"
+        description = "Can be any variable or any valid ISO 8601 time, default will use the trigger date"
     )
     @Builder.Default
     @PluginProperty(dynamic = true)
-    private final String date = "{{ now(format='iso_offset_time') }}";
+    private final String date = "{{ trigger.date }}";
 
     @Schema(
         title = "The time to test must be after this one",

--- a/core/src/main/java/io/kestra/core/models/conditions/types/WeekendCondition.java
+++ b/core/src/main/java/io/kestra/core/models/conditions/types/WeekendCondition.java
@@ -39,11 +39,11 @@ public class WeekendCondition extends Condition implements ScheduleCondition {
     @NotNull
     @Schema(
         title = "The date to test",
-        description = "Can be any variable or any valid ISO 8601 datetime, default will use `{{ now(format=\"iso_local_date\") }}`"
+        description = "Can be any variable or any valid ISO 8601 datetime, default will use the trigger date"
     )
     @Builder.Default
     @PluginProperty(dynamic = true)
-    private final String date = "{{ now(format='iso_local_date') }}";
+    private final String date = "{{ trigger.date }}";
 
     @Override
     public boolean test(ConditionContext conditionContext) throws InternalException {

--- a/core/src/main/java/io/kestra/core/models/conditions/types/WeekendCondition.java
+++ b/core/src/main/java/io/kestra/core/models/conditions/types/WeekendCondition.java
@@ -22,7 +22,7 @@ import javax.validation.constraints.NotNull;
 @Getter
 @NoArgsConstructor
 @Schema(
-    title = "Condition for allows events on weekend"
+    title = "Condition to allow events on weekend"
 )
 @Plugin(
     examples = {
@@ -43,7 +43,7 @@ public class WeekendCondition extends Condition implements ScheduleCondition {
     )
     @Builder.Default
     @PluginProperty(dynamic = true)
-    private final String date = "{{ now(format(\"iso_local_date\") }}";
+    private final String date = "{{ now(format='iso_local_date') }}";
 
     @Override
     public boolean test(ConditionContext conditionContext) throws InternalException {

--- a/core/src/test/java/io/kestra/core/models/conditions/types/PublicHolidayConditionTest.java
+++ b/core/src/test/java/io/kestra/core/models/conditions/types/PublicHolidayConditionTest.java
@@ -1,0 +1,61 @@
+package io.kestra.core.models.conditions.types;
+
+import com.google.common.collect.ImmutableMap;
+import io.kestra.core.models.executions.Execution;
+import io.kestra.core.models.flows.Flow;
+import io.kestra.core.services.ConditionService;
+import io.kestra.core.utils.TestsUtils;
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+@MicronautTest
+class PublicHolidayConditionTest {
+    @Inject
+    ConditionService conditionService;
+
+    @Test
+    void valid() {
+        Flow flow = TestsUtils.mockFlow();
+        Execution execution = TestsUtils.mockExecution(flow, ImmutableMap.of());
+
+        PublicHolidayCondition publicHoliday = PublicHolidayCondition.builder()
+            .date("2023-01-01")
+            .build();
+        assertThat(conditionService.isValid(publicHoliday, flow, execution), is(true));
+
+        publicHoliday = PublicHolidayCondition.builder()
+            .date("2023-07-14")
+            .country("FR")
+            .build();
+        assertThat(conditionService.isValid(publicHoliday, flow, execution), is(true));
+
+        publicHoliday = PublicHolidayCondition.builder()
+            .date("2023-03-08")
+            .country("DE")
+            .subDivision("BE")
+            .build();
+        assertThat(conditionService.isValid(publicHoliday, flow, execution), is(true));
+    }
+
+    @Test
+    void invalid() {
+        Flow flow = TestsUtils.mockFlow();
+        Execution execution = TestsUtils.mockExecution(flow, ImmutableMap.of());
+
+        PublicHolidayCondition publicHoliday = PublicHolidayCondition.builder()
+            .date("2023-01-02")
+            .country("FR")
+            .build();
+        assertThat(conditionService.isValid(publicHoliday, flow, execution), is(false));
+
+        publicHoliday = PublicHolidayCondition.builder()
+            .date("2023-03-08")
+            .country("DE")
+            .build();
+        assertThat(conditionService.isValid(publicHoliday, flow, execution), is(false));
+    }
+}


### PR DESCRIPTION
Fixes #2629 

To QA it you can use the following flow and play with country and subdivision:

```yaml
id: schedule
namespace: company.team

triggers:
  - id: schedule
    type: io.kestra.core.models.triggers.types.Schedule
    cron: "* * * * *"
    conditions:
      - type: io.kestra.core.models.conditions.types.PublicHolidayCondition
        country: DE
        # subDivision: BE
        date: "2023-03-08"
    
tasks:
  - id: hello
    type: io.kestra.core.tasks.log.Log
    message: Kestra team wishes you a great day! 👋
```

In this example, 2023-03-08 will not trigger a flow for country DE but will trigger a flow for country DE and subDivision BE.