### PR TITLE
feat(core): assert that task default works for Trigger and Condition

### DIFF
--- a/core/src/test/java/io/kestra/core/services/TaskDefaultServiceTest.java
+++ b/core/src/test/java/io/kestra/core/services/TaskDefaultServiceTest.java
@@ -85,6 +85,8 @@ class TaskDefaultServiceTest {
         assertThat(((DefaultTester) injected.getTasks().get(0)).getProperty().getLists().size(), is(1));
         assertThat(((DefaultTester) injected.getTasks().get(0)).getProperty().getLists().get(0).getVal().size(), is(1));
         assertThat(((DefaultTester) injected.getTasks().get(0)).getProperty().getLists().get(0).getVal().get("key"), is("test"));
+        assertThat(((DefaultTriggerTester) injected.getTriggers().get(0)).getSet(), is(123));
+        assertThat(((VariableCondition) injected.getTriggers().get(0).getConditions().get(0)).getExpression(), is("{{ test }}"));
     }
 
     @Test


### PR DESCRIPTION
Adding assertions on defaults for Triggers and Conditions.

This is not documented so I wonder if we should update the documentation site here: https://kestra.io/docs/administrator-guide/configuration/others#task-defaults.