### PR TITLE
Revert "fix(): prerender variables (#2588)"

### DIFF
--- a/core/src/main/java/io/kestra/core/runners/RunContext.java
+++ b/core/src/main/java/io/kestra/core/runners/RunContext.java
@@ -598,7 +598,7 @@ public class RunContext {
         URI uri = URI.create(this.taskStateFilePathPrefix(state, isNamespace, useTaskRun));
         URI resolve = uri.resolve(uri.getPath() + "/" + name);
 
-        return this.storageInterface.get(getTenantId(), resolve);
+       return this.storageInterface.get(getTenantId(), resolve);
     }
 
     public URI putTaskStateFile(byte[] content, String state, String name) throws IOException {

--- a/core/src/test/java/io/kestra/core/models/hierarchies/FlowGraphTest.java
+++ b/core/src/test/java/io/kestra/core/models/hierarchies/FlowGraphTest.java
@@ -36,8 +36,8 @@ class FlowGraphTest extends AbstractMemoryRunnerTest {
         Flow flow = this.parse("flows/valids/return.yaml");
         FlowGraph flowGraph = GraphUtils.flowGraph(flow, null);
 
-        assertThat(flowGraph.getNodes().size(), is(6));
-        assertThat(flowGraph.getEdges().size(), is(5));
+        assertThat(flowGraph.getNodes().size(), is(5));
+        assertThat(flowGraph.getEdges().size(), is(4));
         assertThat(flowGraph.getClusters().size(), is(0));
 
         assertThat(((AbstractGraphTask) flowGraph.getNodes().get(2)).getTask().getId(), is("date"));

--- a/core/src/test/java/io/kestra/core/runners/RunContextTest.java
+++ b/core/src/test/java/io/kestra/core/runners/RunContextTest.java
@@ -30,7 +30,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.*;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -114,7 +113,7 @@ class RunContextTest extends AbstractMemoryRunnerTest {
     void variables() throws TimeoutException {
         Execution execution = runnerUtils.runOne(null, "io.kestra.tests", "return");
 
-        assertThat(execution.getTaskRunList(), hasSize(4));
+        assertThat(execution.getTaskRunList(), hasSize(3));
 
         assertThat(
             ZonedDateTime.from(ZonedDateTime.parse((String) execution.getTaskRunList().get(0).getOutputs().get("value"))),
@@ -122,7 +121,6 @@ class RunContextTest extends AbstractMemoryRunnerTest {
         );
         assertThat(execution.getTaskRunList().get(1).getOutputs().get("value"), is("task-id"));
         assertThat(execution.getTaskRunList().get(2).getOutputs().get("value"), is("return"));
-        assertThat((String) execution.getTaskRunList().get(3).getOutputs().get("value"), containsString("toto"));
     }
 
     @Test

--- a/core/src/test/java/io/kestra/core/runners/pebble/PebbleVariableRendererTest.java
+++ b/core/src/test/java/io/kestra/core/runners/pebble/PebbleVariableRendererTest.java
@@ -5,13 +5,13 @@ import io.kestra.core.exceptions.IllegalVariableEvaluationException;
 import io.kestra.core.runners.VariableRenderer;
 import io.kestra.core.utils.Rethrow;
 import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
-import jakarta.inject.Inject;
 import org.junit.jupiter.api.Test;
 
 import java.time.ZonedDateTime;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import jakarta.inject.Inject;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;

--- a/core/src/test/resources/flows/templates/with-template.yaml
+++ b/core/src/test/resources/flows/templates/with-template.yaml
@@ -10,7 +10,7 @@ inputs:
 
 variables:
   var-1: var-1
-  var-2: "{{ 'var-1' }}"
+  var-2: '{{ var-1 }}'
 
 taskDefaults:
   - type: io.kestra.core.tasks.log.Log

--- a/core/src/test/resources/flows/valids/return.yaml
+++ b/core/src/test/resources/flows/valids/return.yaml
@@ -1,9 +1,6 @@
 id: return
 namespace: io.kestra.tests
 
-variables:
-  period: "{{ schedule.date ?? execution.startDate }}"
-
 tasks:
 - id: date
   type: io.kestra.core.tasks.debugs.Return
@@ -14,6 +11,3 @@ tasks:
 - id: flow-id
   type: io.kestra.core.tasks.debugs.Return
   format: "{{flow.id}}"
-- id: variables
-  type: io.kestra.core.tasks.debugs.Return
-  format: "{{ vars.period | replace({':': 'toto'}) }}"


### PR DESCRIPTION
This reverts commit 2e1c3733a4a96bb494be1aa8acad01df55b41284.

#2588 and #2585 will be re-openned after merge

Pre-rendering variables can be problematic if some variables are dynamic and costly to render (for ex using the secret function with a cloud backend).
