### PR TITLE
chore(): add concurrency property to avoid duplicate develop CI running

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,11 @@ on:
       - develop
     tags:
       - v*
-
+      
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+  
   pull_request:
     branches:
       - master


### PR DESCRIPTION
close https://github.com/kestra-io/kestra/issues/2747