### PR TITLE
chore: don't sign JARs if it's not to publish them

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -460,6 +460,8 @@ subprojects {
     }
 
     signing {
+        // only sign JARs that we publish to Sonatype
+        required { gradle.taskGraph.hasTask("publishSonatypePublicationPublicationToSonatypeRepository") }
         sign publishing.publications.sonatypePublication
     }
 }


### PR DESCRIPTION
This allows to install locally without signing the JARs