### PR TITLE
fix(core): invalid log, should log task id and not flow id twice

### DIFF
--- a/core/src/main/java/io/kestra/core/models/flows/Flow.java
+++ b/core/src/main/java/io/kestra/core/models/flows/Flow.java
@@ -234,7 +234,7 @@ public class Flow implements DeletedInterface, TenantInterface {
         return allTasks()
             .flatMap(t -> t.findById(taskId).stream())
             .findFirst()
-            .orElseThrow(() -> new InternalException("Can't find task with id '" + id + "' on flow '" + this.id + "'"));
+            .orElseThrow(() -> new InternalException("Can't find task with id '" + taskId + "' on flow '" + this.id + "'"));
     }
 
     public Flow updateTask(String taskId, Task newValue) throws InternalException {

--- a/core/src/main/java/io/kestra/core/runners/ExecutorService.java
+++ b/core/src/main/java/io/kestra/core/runners/ExecutorService.java
@@ -471,12 +471,10 @@ public class ExecutorService {
             .getTaskRunList()
             .stream()
             .filter(taskRun -> taskRun.getState().getCurrent().isCreated())
-            .map(throwFunction(t -> {
-                return childWorkerTaskTypeToWorkerTask(
+            .map(t -> childWorkerTaskTypeToWorkerTask(
                     Optional.of(State.Type.KILLED),
-                    t
-                );
-            }))
+                    t)
+            )
             .filter(Optional::isPresent)
             .map(Optional::get)
             .collect(Collectors.toList());


### PR DESCRIPTION
Small fix of an incorrect log.

I also remove one `throwFunction` usage that was not needed. 
