### PR TITLE
fix(core): retry can crash the Worker

### DIFF
--- a/core/src/main/java/io/kestra/core/runners/Worker.java
+++ b/core/src/main/java/io/kestra/core/runners/Worker.java
@@ -36,6 +36,7 @@ import lombok.Getter;
 import lombok.Synchronized;
 import lombok.extern.slf4j.Slf4j;
 import net.jodah.failsafe.Failsafe;
+import net.jodah.failsafe.RetryPolicy;
 import net.jodah.failsafe.Timeout;
 import org.slf4j.Logger;
 
@@ -345,9 +346,25 @@ public class Worker implements Runnable, AutoCloseable {
 
         AtomicReference<WorkerTask> current = new AtomicReference<>(workerTask);
 
+        // creating the retry can fail
+        RetryPolicy<WorkerTask> workerTaskRetryPolicy;
+        try {
+            workerTaskRetryPolicy = AbstractRetry.retryPolicy(workerTask.getTask().getRetry());
+        } catch(IllegalStateException e) {
+            WorkerTask finalWorkerTask = workerTask.fail();
+            WorkerTaskResult workerTaskResult = new WorkerTaskResult(finalWorkerTask);
+            RunContext runContext = workerTask
+                .getRunContext()
+                .forWorker(this.applicationContext, workerTask);
+
+            runContext.logger().error("Exception while trying to build the retry policy", e);
+            this.workerTaskResultQueue.emit(workerTaskResult);
+            return workerTaskResult;
+        }
+
         // run
         WorkerTask finalWorkerTask = Failsafe
-            .with(AbstractRetry.<WorkerTask>retryPolicy(workerTask.getTask().getRetry())
+            .with(workerTaskRetryPolicy
                 .handleResultIf(result -> result.getTaskRun().lastAttempt() != null &&
                         result.getTaskRun().lastAttempt().getState().getCurrent() == State.Type.FAILED &&
                         !killedExecution.contains(result.getTaskRun().getExecutionId())

--- a/core/src/test/java/io/kestra/core/runners/RetryTest.java
+++ b/core/src/test/java/io/kestra/core/runners/RetryTest.java
@@ -46,4 +46,13 @@ public class RetryTest extends AbstractMemoryRunnerTest {
         assertThat(execution.getTaskRunList().get(0).getAttempts(), hasSize(5));
         assertThat(execution.getState().getCurrent(), is(State.Type.FAILED));
     }
+
+    @Test
+    void retryInvalid() throws TimeoutException {
+        Execution execution = runnerUtils.runOne(null, "io.kestra.tests", "retry-invalid");
+
+        assertThat(execution.getTaskRunList(), hasSize(1));
+        assertThat(execution.getTaskRunList().get(0).getAttempts(), nullValue());
+        assertThat(execution.getState().getCurrent(), is(State.Type.FAILED));
+    }
 }

--- a/core/src/test/resources/flows/valids/retry-invalid.yml
+++ b/core/src/test/resources/flows/valids/retry-invalid.yml
@@ -1,0 +1,12 @@
+id: retry-invalid
+namespace: io.kestra.tests
+
+tasks:
+  - id: log
+    type: io.kestra.core.tasks.log.Log
+    message: Hello World!
+    retry:
+      type: constant
+      interval: PT0.250S
+      maxAttempt: 5
+      maxDuration: PT0.250S


### PR DESCRIPTION
Fixes #2835 

I'm not very convinced by this, we can fix it like I did at the worker level or we can add a big try/catch on the whole method.

Another way of doing it would be to add a validation to the retry setting, for ex a validation that try to build the object and fail validation if it cannot be created. Or both the validation and this fix.