### PR TITLE
fix(ui): hide the export template button if template is not enabled.

### DIFF
--- a/ui/src/components/settings/BasicSettings.vue
+++ b/ui/src/components/settings/BasicSettings.vue
@@ -94,7 +94,7 @@
                 <el-button v-if="canReadFlows" :icon="Download" size="large" @click="exportFlows()">
                     {{ $t('export all flows') }}
                 </el-button>
-                <el-button v-if="canReadTemplates" :icon="Download" size="large" @click="exportTemplates()">
+                <el-button v-if="canReadTemplates" :icon="Download" size="large" @click="exportTemplates()" :hidden="!configs.isTemplateEnabled">
                     {{ $t('export all templates') }}
                 </el-button>
             </el-form-item>


### PR DESCRIPTION
Trivial modification, the check that Template is enabled was not present so the button was displayed even if Template is disabled.