### PR TITLE
fix(cli): Make the CLI help clearer

### DIFF
--- a/cli/src/main/java/io/kestra/cli/AbstractApiCommand.java
+++ b/cli/src/main/java/io/kestra/cli/AbstractApiCommand.java
@@ -17,13 +17,13 @@ import java.util.List;
 import java.util.Map;
 
 public abstract class AbstractApiCommand extends AbstractCommand {
-    @CommandLine.Option(names = {"--server"}, description = " Kestra server url", defaultValue = "http://localhost:8080")
+    @CommandLine.Option(names = {"--server"}, description = "Kestra server url", defaultValue = "http://localhost:8080")
     protected URL server;
 
-    @CommandLine.Option(names = {"--headers"}, description = "Headers to add to the request")
+    @CommandLine.Option(names = {"--headers"}, paramLabel = "<name=value>", description = "Headers to add to the request")
     protected Map<CharSequence, CharSequence> headers;
 
-    @CommandLine.Option(names = {"--user"}, description = "<user:password> Server user and password")
+    @CommandLine.Option(names = {"--user"}, paramLabel = "<user:password>", description = "Server user and password")
     protected String user;
 
     @CommandLine.Option(names = {"--tenant"}, description = "Tenant identifier (EE only, when multi-tenancy is enabled)")

--- a/cli/src/main/java/io/kestra/cli/AbstractCommand.java
+++ b/cli/src/main/java/io/kestra/cli/AbstractCommand.java
@@ -31,7 +31,8 @@ import java.util.concurrent.Callable;
 import jakarta.inject.Inject;
 
 @CommandLine.Command(
-    mixinStandardHelpOptions = true
+    mixinStandardHelpOptions = true,
+    showDefaultValues = true
 )
 @Slf4j
 @Introspected
@@ -45,19 +46,19 @@ abstract public class AbstractCommand implements Callable<Integer> {
     @Inject
     private StartupHookInterface startupHook;
 
-    @CommandLine.Option(names = {"-v", "--verbose"}, description = "Change log level. Multiple -v options increase the verbosity.")
+    @CommandLine.Option(names = {"-v", "--verbose"}, description = "Change log level. Multiple -v options increase the verbosity.", showDefaultValue = CommandLine.Help.Visibility.NEVER)
     private boolean[] verbose = new boolean[0];
 
-    @CommandLine.Option(names = {"-l", "--log-level"}, description = "Change log level (values: ${COMPLETION-CANDIDATES}; default: ${DEFAULT-VALUE})")
+    @CommandLine.Option(names = {"-l", "--log-level"}, description = "Change log level (values: ${COMPLETION-CANDIDATES})")
     private LogLevel logLevel = LogLevel.INFO;
 
-    @CommandLine.Option(names = {"--internal-log"}, description = "Change also log level for internal log, default: ${DEFAULT-VALUE})")
+    @CommandLine.Option(names = {"--internal-log"}, description = "Change also log level for internal log")
     private boolean internalLog = false;
 
-    @CommandLine.Option(names = {"-c", "--config"}, description = "Path to a configuration file, default: ${DEFAULT-VALUE})")
+    @CommandLine.Option(names = {"-c", "--config"}, description = "Path to a configuration file")
     private Path config = Paths.get(System.getProperty("user.home"), ".kestra/config.yml");
 
-    @CommandLine.Option(names = {"-p", "--plugins"}, description = "Path to plugins directory , default: ${DEFAULT-VALUE})")
+    @CommandLine.Option(names = {"-p", "--plugins"}, description = "Path to plugins directory")
     protected Path pluginsPath = System.getenv("KESTRA_PLUGINS_PATH") != null ? Paths.get(System.getenv("KESTRA_PLUGINS_PATH")) : null;
 
     public enum LogLevel {


### PR DESCRIPTION
### What changes are being made and why?

The CLI help output regarding the default values was a bit confusing. Used just the Picocli features.

---

### How the changes have been QAed?

`./build/executable/kestra-0.14.0-SNAPSHOT -h`