### PR TITLE
fix(ui): fix task run logs download

### DIFF
--- a/ui/src/components/executions/TaskRunLine.vue
+++ b/ui/src/components/executions/TaskRunLine.vue
@@ -238,6 +238,9 @@
             isSubflow(taskRun) {
                 return taskRun.outputs?.executionId;
             },
+            downloadName(currentTaskRunId) {
+                return `kestra-execution-${this.$moment().format("YYYYMMDDHHmmss")}-${this.followedExecution.id}-${currentTaskRunId}.log`
+            },
             selectedAttempt(taskRun) {
                 return this.attempts(taskRun)[this.selectedAttemptNumberByTaskRunId[taskRun.id] ?? 0];
             },

--- a/ui/src/components/logs/TaskRunDetails.vue
+++ b/ui/src/components/logs/TaskRunDetails.vue
@@ -401,9 +401,6 @@
                     });
                 }
             },
-            downloadName(currentTaskRunId) {
-                return `kestra-execution-${this.$moment().format("YYYYMMDDHHmmss")}-${this.followedExecution.id}-${currentTaskRunId}.log`
-            },
             uniqueTaskRunDisplayFilter(currentTaskRun) {
                 return !(this.taskRunId && this.taskRunId !== currentTaskRun.id);
             },


### PR DESCRIPTION
### What changes are being made and why?

Task run-specific logs couldn't be downloaded - the `downloadName()` function was missing.
