### PR TITLE
fix/outputs-generate-without-recursive-needed

### DIFF
--- a/core/src/main/java/io/kestra/core/tasks/PluginUtilsService.java
+++ b/core/src/main/java/io/kestra/core/tasks/PluginUtilsService.java
@@ -62,7 +62,7 @@ abstract public class PluginUtilsService {
                         tempFile = File.createTempFile(s + "_", null, tempDirectory.toFile());
                     }
 
-                    result.put(s, "{{workingDir}}/" + tempFile.getName());
+                    result.put(s, additionalVars.get("workingDir") + "/" + tempFile.getName());
                 }));
 
             if (!isDir) {

--- a/core/src/test/java/io/kestra/core/tasks/PluginUtilsServiceTest.java
+++ b/core/src/test/java/io/kestra/core/tasks/PluginUtilsServiceTest.java
@@ -1,0 +1,27 @@
+package io.kestra.core.tasks;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.startsWith;
+
+public class PluginUtilsServiceTest {
+    @Test
+    void outputFiles() throws IOException {
+        Path tempDirectory = Files.createTempDirectory("plugin-utils");
+        Map<String, String> outputFilesMap = PluginUtilsService.createOutputFiles(
+            tempDirectory,
+            List.of("out"),
+            new HashMap<>(Map.of("workingDir", tempDirectory.toAbsolutePath().toString()))
+        );
+
+        assertThat(outputFilesMap.get("out"), startsWith(tempDirectory.resolve("out_").toString()));
+    }
+}


### PR DESCRIPTION
Allows https://github.com/kestra-io/plugin-jdbc/actions/runs/7567861151/job/20607850314 to work without the need to add render(...) wrapper for recursive rendering