### PR TITLE
RFC: feature(core): relative time filter

### DIFF
--- a/ui/src/components/executions/date-select/DateFilter.vue
+++ b/ui/src/components/executions/date-select/DateFilter.vue
@@ -1,0 +1,94 @@
+<template>
+    <el-radio-group
+        v-model="selectedFilterType"
+        @change="onSelectedFilterType()"
+    >
+        <el-radio-button :label="filterType.RELATIVE">
+            {{ $t("relative") }}
+        </el-radio-button>
+        <el-radio-button :label="filterType.ABSOLUTE">
+            {{ $t("absolute") }}
+        </el-radio-button>
+    </el-radio-group>
+    <date-range
+        v-if="selectedFilterType === filterType.ABSOLUTE"
+        :start-date="startDate"
+        :end-date="endDate"
+        @update:model-value="onAbsFilterChange($event)"
+    />
+    <relative-date-select
+        v-if="selectedFilterType === filterType.RELATIVE"
+        :start-range="startRange"
+        :end-range="endRange"
+        @update:model-value="onRelFilterChange($event)"
+    />
+</template>
+
+<script>
+    import DateRange from "../../layout/DateRange.vue";
+    import RelativeDateSelect from "./RelativeDateSelect.vue";
+
+    export default {
+        components: {
+            DateRange,
+            RelativeDateSelect
+        },
+        emits: [
+            "update:isRelative",
+            "update:filterValue"
+        ],
+        created() {
+            this.filterType = {
+                RELATIVE: "REL",
+                ABSOLUTE: "ABS"
+            };
+
+            this.selectedFilterType = (this.$route.query.startDate || this.$route.query.endDate) ? this.filterType.ABSOLUTE : this.filterType.RELATIVE;
+        },
+        data() {
+            return {
+                selectedFilterType: undefined
+            }
+        },
+        computed: {
+            startRange() {
+                return this.$route.query.startDateRange ? this.$route.query.startDateRange : "P1M";
+            },
+            endRange() {
+                return this.$route.query.endDateRange ? this.$route.query.endDateRange : "PT0";
+            },
+            startDate() {
+                return this.$route.query.startDate ? this.$route.query.startDate : this.$moment(this.endDate).add(-30, "days").toISOString(true);
+            },
+            endDate() {
+                return this.$route.query.endDate ? this.$route.query.endDate : undefined;
+            }
+        },
+        methods: {
+            onSelectedFilterType() {
+                this.$emit("update:isRelative", this.selectedFilterType === this.filterType.RELATIVE);
+            },
+            onAbsFilterChange(event) {
+                const filter = {
+                    "startDate": event.startDate,
+                    "endDate": event.endDate,
+                    "startDateRange": undefined,
+                    "endDateRange": undefined
+                };
+                this.updateFilter(filter);
+            },
+            onRelFilterChange(event) {
+                const filter = {
+                    "startDate": undefined,
+                    "endDate": undefined,
+                    "startDateRange": event.startDateRange,
+                    "endDateRange": event.endDateRange
+                };
+                this.updateFilter(filter);
+            },
+            updateFilter(filter) {
+                this.$emit("update:filterValue", filter);
+            }
+        }
+    }
+</script>

--- a/ui/src/components/executions/date-select/DateSelect.vue
+++ b/ui/src/components/executions/date-select/DateSelect.vue
@@ -1,0 +1,45 @@
+<template>
+    <el-tooltip :content="tooltip">
+        <el-select
+            :model-value="value"
+            @change="$emit('change', $event)"
+        >
+            <template #prefix>
+                <clock-outline />
+            </template>
+            <el-option
+                v-for="preset in options"
+                :key="preset.value"
+                :label="$t(preset.label)"
+                :value="preset.value"
+            />
+        </el-select>
+    </el-tooltip>
+</template>
+
+<script>
+    import ClockOutline from "vue-material-design-icons/ClockOutline.vue";
+
+    export default {
+        components: {
+            ClockOutline
+        },
+        emits: [
+            "change"
+        ],
+        props: {
+            value: {
+                type: String,
+                required: true
+            },
+            options: {
+                type: Array,
+                default: () => []
+            },
+            tooltip: {
+                type: String,
+                required: true
+            }
+        }
+    }
+</script>

--- a/ui/src/components/executions/date-select/RelativeDateSelect.vue
+++ b/ui/src/components/executions/date-select/RelativeDateSelect.vue
@@ -1,0 +1,94 @@
+<template>
+    <date-select
+        :value="startRange"
+        :options="applicableFilterPresets"
+        :tooltip="$t('relative start date')"
+        @change="onChangeStart($event)"
+    />
+    <date-select
+        :value="endRange"
+        :options="applicableFilterPresetsEnd"
+        :tooltip="$t('relative end date')"
+        @change="onChangeEnd($event)"
+    />
+</template>
+
+<script>
+    import DateSelect from "./DateSelect.vue";
+
+    export default {
+        components: {
+            DateSelect
+        },
+        emits: [
+            "update:modelValue"
+        ],
+        data() {
+            return {
+                timeFilterPresets: [
+                    {
+                        value: "PT5M",
+                        label: "datepicker.last5minutes"
+                    },
+                    {
+                        value: "PT15M",
+                        label: "datepicker.last15minutes"
+                    },
+                    {
+                        value: "PT1H",
+                        label: "datepicker.last1hour"
+                    },
+                    {
+                        value: "PT12H",
+                        label: "datepicker.last12hours"
+                    },
+                    {
+                        value: "P1D",
+                        label: "datepicker.last24hours"
+                    },
+                    {
+                        value: "P1W",
+                        label: "datepicker.thisWeekSoFar"
+                    },
+                    {
+                        value: "P1M",
+                        label: "datepicker.thisMonthSoFar"
+                    },
+                    {
+                        value: "P1Y",
+                        label: "datepicker.thisYearSoFar"
+                    }
+                ]
+            }
+        },
+        props: {
+            startRange: {
+                type: String,
+                default: undefined
+            },
+            endRange: {
+                type: String,
+                default: undefined
+            }
+        },
+        computed: {
+            timeFilterPresetsEnd() {
+                return [ {value: "PT0", label: "now"} ].concat(this.timeFilterPresets);
+            },
+            applicableFilterPresets() {
+                return this.timeFilterPresets.filter((filterPreset) => this.$moment.duration(filterPreset.value) > this.$moment.duration(this.endRange));
+            },
+            applicableFilterPresetsEnd() {
+                return this.timeFilterPresetsEnd.filter((filterPreset) => this.$moment.duration(filterPreset.value) < this.$moment.duration(this.startRange));
+            }
+        },
+        methods: {
+            onChangeStart(range) {
+                this.$emit("update:modelValue", {"startDateRange": range, "endDateRange": this.endRange});
+            },
+            onChangeEnd(range) {
+                this.$emit("update:modelValue", {"startDateRange": this.startRange, "endDateRange": range});
+            }
+        }
+    }
+</script>

--- a/ui/src/components/layout/DateRange.vue
+++ b/ui/src/components/layout/DateRange.vue
@@ -23,34 +23,6 @@
                 },
                 shortcuts: [
                     {
-                        text: this.$t("datepicker.last5minutes"),
-                        value: () => ([
-                            this.$moment().add(-5, "minutes").toDate(),
-                            this.$moment().toDate()
-                        ]),
-                    },
-                    {
-                        text: this.$t("datepicker.last1hour"),
-                        value: () => ([
-                            this.$moment().add(-1, "hour").toDate(),
-                            this.$moment().toDate()
-                        ]),
-                    },
-                    {
-                        text: this.$t("datepicker.last12hours"),
-                        value: () => ([
-                            this.$moment().add(-12, "hour").toDate(),
-                            this.$moment().toDate()
-                        ]),
-                    },
-                    {
-                        text: this.$t("datepicker.last24hours"),
-                        value: () => ([
-                            this.$moment().add(-1, "day").toDate(),
-                            this.$moment().toDate()
-                        ]),
-                    },
-                    {
                         text: this.$t("datepicker.today"),
                         value: () => ([
                             this.$moment().startOf("day").toDate(),
@@ -79,13 +51,6 @@
                         ]),
                     },
                     {
-                        text: this.$t("datepicker.thisWeekSoFar"),
-                        value: () => ([
-                            this.$moment().add(-1, "isoWeek").toDate(),
-                            this.$moment().toDate()
-                        ]),
-                    },
-                    {
                         text: this.$t("datepicker.previousWeek"),
                         value: () => ([
                             this.$moment().add(-1, "week").startOf("isoWeek").toDate(),
@@ -100,13 +65,6 @@
                         ]),
                     },
                     {
-                        text: this.$t("datepicker.thisMonthSoFar"),
-                        value: () => ([
-                            this.$moment().add(-1, "month").toDate(),
-                            this.$moment().toDate()
-                        ]),
-                    },
-                    {
                         text: this.$t("datepicker.previousMonth"),
                         value: () => ([
                             this.$moment().add(-1, "month").startOf("month").toDate(),
@@ -118,13 +76,6 @@
                         value: () => ([
                             this.$moment().startOf("year").toDate(),
                             this.$moment().endOf("year").toDate(),
-                        ]),
-                    },
-                    {
-                        text: this.$t("datepicker.thisYearSoFar"),
-                        value: () => ([
-                            this.$moment().add(-1, "year").toDate(),
-                            this.$moment().toDate()
                         ]),
                     },
                     {

--- a/ui/src/components/layout/RefreshButton.vue
+++ b/ui/src/components/layout/RefreshButton.vue
@@ -1,6 +1,6 @@
 <template>
     <el-button-group>
-        <el-button :active="autoRefresh" @click="toggleAutoRefresh">
+        <el-button :disabled="!canAutoRefresh" :active="autoRefresh" @click="toggleAutoRefresh">
             <kicon :tooltip="$t('toggle periodic refresh each 10 seconds')" placement="bottom">
                 <component :is="autoRefresh ? 'auto-renew' : 'auto-renew-off'" class="auto-refresh-icon" />
             </kicon>
@@ -20,6 +20,12 @@
     export default {
         components: {Refresh, AutoRenew, AutoRenewOff, Kicon},
         emits: ["refresh"],
+        props: {
+            canAutoRefresh: {
+                type: Boolean,
+                default: true
+            }
+        },
         data() {
             return {
                 autoRefresh: false,
@@ -48,6 +54,12 @@
             this.stopRefresh();
         },
         watch: {
+            canAutoRefresh(newValue) {
+                if (!newValue && this.autoRefresh) {
+                    this.toggleAutoRefresh();
+                    this.stopRefresh();
+                }
+            },
             autoRefresh(newValue) {
                 if (newValue) {
                     this.refreshHandler = setInterval(this.triggerRefresh, 10000);

--- a/ui/src/translations.json
+++ b/ui/src/translations.json
@@ -69,6 +69,7 @@
     "date": "Date",
     "datepicker": {
       "last5minutes": "Last 5 minutes",
+      "last15minutes": "Last 15 minutes",
       "last1hour": "Last 1 hour",
       "last12hours": "Last 12 hours",
       "last24hours": "Last 24 hours",
@@ -570,7 +571,12 @@
         "error": "Error(s) occurred while importing the file(s)"
       },
       "export": "Export as a ZIP file"
-    }
+    },
+    "relative": "Relative",
+    "relative start date": "Relative start date",
+    "relative end date": "Relative end date",
+    "now": "Now",
+    "absolute": "Absolute"
   },
   "fr": {
     "id": "Identifiant",


### PR DESCRIPTION
### What changes are being made and why?

As a part of the initiative towards making a "stored execution filter" (#1397) possible there is a need to deal with the current implementation of the time filter. The current implementation is not capable of filtering based on a relative date.

close #2211

---

Making the API capable of dealing with both absolute and relative time filters seems like a good idea since it adds flexibility for the clients.

The _ISO 8601 duration_ format was chosen as the representation of the relative filter as it is commonly understood.

Since the query param-based filtering was kept (it is a good thing), the absolute and relative filter pairs were made mutually exclusive.

As a part of the RFC only the `executions/search` API endpoint got modified.

---

On the UI front, the Executions view date filter was altered to make it possible to use either the relative or absolute date filter.

The relative filter features a set of predefined time ranges. The ranges were mostly migrated from the existing date filter.

The auto-refresh search can be activated only with the relative filter active.

As a part of the RFC only the bare core functionality got covered.

---

### Feedback needed

Comments and feedback are needed to either continue in this direction, pick a different approach, or completely rethink the solution. Thanks