### PR TITLE
feat: new SECRET input type

### DIFF
--- a/core/src/main/java/io/kestra/core/models/flows/Input.java
+++ b/core/src/main/java/io/kestra/core/models/flows/Input.java
@@ -32,6 +32,7 @@ import jakarta.validation.constraints.Pattern;
     @JsonSubTypes.Type(value = FloatInput.class, name = "FLOAT"),
     @JsonSubTypes.Type(value = IntInput.class, name = "INT"),
     @JsonSubTypes.Type(value = JsonInput.class, name = "JSON"),
+    @JsonSubTypes.Type(value = SecretInput.class, name = "SECRET"),
     @JsonSubTypes.Type(value = StringInput.class, name = "STRING"),
     @JsonSubTypes.Type(value = TimeInput.class, name = "TIME"),
     @JsonSubTypes.Type(value = URIInput.class, name = "URI")
@@ -76,7 +77,8 @@ public abstract class Input<T> {
         DURATION(DurationInput.class.getName()),
         FILE(FileInput.class.getName()),
         JSON(JsonInput.class.getName()),
-        URI(URIInput.class.getName());
+        URI(URIInput.class.getName()),
+        SECRET(SecretInput.class.getName());
 
         private final String clsName;
 

--- a/core/src/main/java/io/kestra/core/models/flows/input/SecretInput.java
+++ b/core/src/main/java/io/kestra/core/models/flows/input/SecretInput.java
@@ -1,0 +1,38 @@
+package io.kestra.core.models.flows.input;
+
+import io.kestra.core.models.flows.Input;
+import io.kestra.core.models.validations.ManualConstraintViolation;
+import io.kestra.core.validations.Regex;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.ConstraintViolationException;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+import java.util.Set;
+import java.util.regex.Pattern;
+
+@SuperBuilder
+@Getter
+@NoArgsConstructor
+public class SecretInput extends Input<String> {
+    @Schema(
+        title = "Regular expression validating the value."
+    )
+    @Regex
+    String validator;
+
+    @Override
+    public void validate(String input) throws ConstraintViolationException {
+        if (validator != null && ! Pattern.matches(validator, input)) {
+            throw new ConstraintViolationException("Invalid input '" + input + "', it must match the pattern '" + validator + "'",
+                Set.of(ManualConstraintViolation.of(
+                    "Invalid input",
+                    this,
+                    SecretInput.class,
+                    getId(),
+                    input
+                )));
+        }
+    }
+}

--- a/core/src/test/java/io/kestra/core/serializers/YamlFlowParserTest.java
+++ b/core/src/test/java/io/kestra/core/serializers/YamlFlowParserTest.java
@@ -125,8 +125,8 @@ class YamlFlowParserTest {
     void inputs() {
         Flow flow = this.parse("flows/valids/inputs.yaml");
 
-        assertThat(flow.getInputs().size(), is(24));
-        assertThat(flow.getInputs().stream().filter(Input::getRequired).count(), is(6L));
+        assertThat(flow.getInputs().size(), is(25));
+        assertThat(flow.getInputs().stream().filter(Input::getRequired).count(), is(7L));
         assertThat(flow.getInputs().stream().filter(r -> !r.getRequired()).count(), is(18L));
         assertThat(flow.getInputs().stream().filter(r -> r.getDefaults() != null).count(), is(1L));
         assertThat(flow.getInputs().stream().filter(r -> r instanceof StringInput && ((StringInput)r).getValidator() != null).count(), is(1L));

--- a/core/src/test/resources/flows/valids/inputs.yaml
+++ b/core/src/test/resources/flows/valids/inputs.yaml
@@ -85,6 +85,8 @@ inputs:
   after: "01:00:00"
   before: "11:59:59"
   required: false
+- name: secret
+  type: SECRET
 
 tasks:
 - id: string
@@ -102,3 +104,6 @@ tasks:
 - id: file
   type: io.kestra.core.tasks.debugs.Return
   format: "{{inputs.file}}"
+- id: secret
+  type: io.kestra.core.tasks.debugs.Return
+  format: "{{inputs.secret}}"

--- a/ui/src/components/executions/Overview.vue
+++ b/ui/src/components/executions/Overview.vue
@@ -118,6 +118,7 @@
             }
         },
         computed: {
+            ...mapState("flow", ["flow"]),
             ...mapState("execution", ["execution"]),
             items() {
                 if (!this.execution) {
@@ -168,7 +169,19 @@
                 return ret;
             },
             inputs() {
-                return toRaw(this.execution.inputs);
+              if (!this.flow) {
+                return []
+              }
+
+              let inputs = toRaw(this.execution.inputs);
+              Object.keys(inputs).forEach(key => {
+                this.flow.inputs.forEach(input => {
+                  if(key === input.name && input.type === 'SECRET') {
+                    inputs[key] = '******';
+                  }
+                })
+              })
+              return inputs;
             }
         },
     };

--- a/ui/src/components/flows/FlowRun.vue
+++ b/ui/src/components/flows/FlowRun.vue
@@ -23,7 +23,7 @@
                 <el-input
                     type="password"
                     v-if="input.type === 'SECRET'"
-                    v-model="inputs[input.name]"
+                    v-model="inputs[input.id]"
                     show-password
                 />
                 <el-input-number

--- a/ui/src/components/flows/FlowRun.vue
+++ b/ui/src/components/flows/FlowRun.vue
@@ -20,6 +20,12 @@
                     v-if="input.type === 'STRING' || input.type === 'URI'"
                     v-model="inputs[input.id]"
                 />
+                <el-input
+                    type="password"
+                    v-if="input.type === 'SECRET'"
+                    v-model="inputs[input.name]"
+                    show-password
+                />
                 <el-input-number
                     v-if="input.type === 'INT'"
                     v-model="inputs[input.id]"

--- a/webserver/src/test/java/io/kestra/webserver/controllers/ExecutionControllerTest.java
+++ b/webserver/src/test/java/io/kestra/webserver/controllers/ExecutionControllerTest.java
@@ -18,6 +18,7 @@ import io.kestra.core.utils.Await;
 import io.kestra.core.utils.IdUtils;
 import io.kestra.webserver.controllers.h2.JdbcH2ControllerTest;
 import io.kestra.webserver.responses.PagedResults;
+import io.micronaut.context.annotation.Property;
 import io.micronaut.core.type.Argument;
 import io.micronaut.data.model.Pageable;
 import io.micronaut.http.HttpRequest;
@@ -52,6 +53,7 @@ import static org.hamcrest.Matchers.*;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+@Property(name = "kestra.crypto.secret-key", value = "I6EGNzRESu3X3pKZidrqCGOHQFUFC0yK")
 class ExecutionControllerTest extends JdbcH2ControllerTest {
     public static final String URL_LABEL_VALUE = "https://some-url.com";
     public static final String ENCODED_URL_LABEL_VALUE = URL_LABEL_VALUE.replace("/", URLEncoder.encode("/", StandardCharsets.UTF_8));
@@ -89,6 +91,7 @@ class ExecutionControllerTest extends JdbcH2ControllerTest {
         .put("float", "42.42")
         .put("instant", "2019-10-06T18:27:49Z")
         .put("file", Objects.requireNonNull(InputsTest.class.getClassLoader().getResource("data/hello.txt")).getPath())
+        .put("secret", "secret")
         .build();
 
     @Test
@@ -126,6 +129,7 @@ class ExecutionControllerTest extends JdbcH2ControllerTest {
             .addPart("instant", "2019-10-06T18:27:49Z")
             .addPart("files", "file", MediaType.TEXT_PLAIN_TYPE, applicationFile)
             .addPart("files", "optionalFile", MediaType.TEXT_XML_TYPE, logbackFile)
+            .addPart("secret", "secret")
             .build();
     }
 
@@ -159,7 +163,7 @@ class ExecutionControllerTest extends JdbcH2ControllerTest {
         Execution result = triggerInputsFlowExecution(true);
 
         assertThat(result.getState().getCurrent(), is(State.Type.SUCCESS));
-        assertThat(result.getTaskRunList().size(), is(5));
+        assertThat(result.getTaskRunList().size(), is(6));
     }
 
     @Test
@@ -432,7 +436,7 @@ class ExecutionControllerTest extends JdbcH2ControllerTest {
     @Test
     void downloadFile() throws TimeoutException {
         Execution execution = runnerUtils.runOne(null, TESTS_FLOW_NS, "inputs", null, (flow, execution1) -> runnerUtils.typedInputs(flow, execution1, inputs));
-        assertThat(execution.getTaskRunList(), hasSize(5));
+        assertThat(execution.getTaskRunList(), hasSize(6));
 
         String path = (String) execution.getInputs().get("file");
 
@@ -467,7 +471,7 @@ class ExecutionControllerTest extends JdbcH2ControllerTest {
     @Test
     void filePreview() throws TimeoutException {
         Execution defaultExecution = runnerUtils.runOne(null, TESTS_FLOW_NS, "inputs", null, (flow, execution1) -> runnerUtils.typedInputs(flow, execution1, inputs));
-        assertThat(defaultExecution.getTaskRunList(), hasSize(5));
+        assertThat(defaultExecution.getTaskRunList(), hasSize(6));
 
         String defaultPath = (String) defaultExecution.getInputs().get("file");
 
@@ -485,10 +489,11 @@ class ExecutionControllerTest extends JdbcH2ControllerTest {
             .put("float", "42.42")
             .put("instant", "2019-10-06T18:27:49Z")
             .put("file", Objects.requireNonNull(ExecutionControllerTest.class.getClassLoader().getResource("data/iso88591.txt")).getPath())
+            .put("secret", "secret")
             .build();
 
         Execution latin1Execution = runnerUtils.runOne(null, TESTS_FLOW_NS, "inputs", null, (flow, execution1) -> runnerUtils.typedInputs(flow, execution1, latin1FileInputs));
-        assertThat(latin1Execution.getTaskRunList(), hasSize(5));
+        assertThat(latin1Execution.getTaskRunList(), hasSize(6));
 
         String latin1Path = (String) latin1Execution.getInputs().get("file");
 

--- a/webserver/src/test/java/io/kestra/webserver/controllers/PluginControllerTest.java
+++ b/webserver/src/test/java/io/kestra/webserver/controllers/PluginControllerTest.java
@@ -205,7 +205,7 @@ class PluginControllerTest {
                 Argument.listOf(InputType.class)
             );
 
-            assertThat(doc.size(), is(11));
+            assertThat(doc.size(), is(12));
         });
     }
 


### PR DESCRIPTION
Fixes #1442

With this PR, a new SECRET input type is introduced.

A secret input is encoded at execution created time and decoded only when creating the run context, i.e. only in memory inside the executor or the worker before executing a task when computing the list of input variables.