### PR TITLE
fix(webserver): don't load the flow from the execution as we already …

### DIFF
--- a/webserver/src/main/java/io/kestra/webserver/controllers/ExecutionController.java
+++ b/webserver/src/main/java/io/kestra/webserver/controllers/ExecutionController.java
@@ -526,12 +526,8 @@ public class ExecutionController {
                     }
 
                     Execution item = either.getLeft();
-                    if (item.getId().equals(current.getId())) {
-                        Flow flow = flowRepository.findByExecution(current);
-
-                        if (this.isStopFollow(flow, item)) {
-                            emitter.success(item);
-                        }
+                    if (item.getId().equals(current.getId()) && this.isStopFollow(found, item)) {
+                        emitter.success(item);
                     }
                 });
 


### PR DESCRIPTION
…have it

Fixes #2959
Today we load again the flow from the execution but we already load it before. Doing this can crash the execution queue if we didn't succeed to load it.
