### PR TITLE
feat(core): add installation command to the documentation

### DIFF
--- a/core/src/main/java/io/kestra/core/docs/DocumentationGenerator.java
+++ b/core/src/main/java/io/kestra/core/docs/DocumentationGenerator.java
@@ -89,6 +89,10 @@ public class DocumentationGenerator {
         ImmutableMap.Builder<String, Object> builder = ImmutableMap.builder();
 
         builder.put("title", plugin.title().replace("plugin-", ""));
+        if (!"core".equals(Slugify.of(plugin.path()))) {
+            // handlebar 'if' can only check on booleans or empty values
+            builder.put("name", Slugify.of(plugin.path()));
+        }
 
         if (plugin.description() != null) {
             builder.put("description", plugin.description());

--- a/core/src/main/resources/docs/index.hbs
+++ b/core/src/main/resources/docs/index.hbs
@@ -10,6 +10,19 @@ editLink: false
 
 {{ longDescription }}
 
+{{~#if name}}
+## Installation
+
+If you use one of our Docker images tagged __*-full__, this plugin is already included.
+If not, you can install it with the following command:
+
+```shell
+./kestra plugins install io.kestra.plugin:{{ name }}:LATEST
+```
+
+This command will automatically install the latest available version. You can replace `LATEST` with a specific version or a version range like `[0.12,0.13.0-SNAPSHOT)`.
+{{/if}}
+
 {{~#each classPlugins }}
     {{~#if @key.title}}
 ## {{#if @key.icon ~}}<img width="25" src="data:image/svg+xml;base64,{{@key.icon}}" /> {{/if }}{{ @key.title }}


### PR DESCRIPTION
This will add the following section on top of the plugin documentation page (unless it's the core plugin):


## Installation

If you use one of our Docker images tagged __*-full__ this plugin is already included.
If not, you can install it with the following command:

```shell
./kestra plugins install io.kestra.plugin:plugin-script-shell:LATEST
```

This command will automatically install the latest available version. You can replace `LATEST` with a specific version or a version range like `[0.12,0.13.0-SNAPSHOT)`.
