### PR TITLE
feat: allow encryption via the RunContext

### DIFF
--- a/core/src/main/java/io/kestra/core/runners/RunContext.java
+++ b/core/src/main/java/io/kestra/core/runners/RunContext.java
@@ -534,6 +534,10 @@ public class RunContext {
             ));
     }
 
+    public String encrypt(String plaintext) throws GeneralSecurityException {
+        return this.cryptoService.encrypt(plaintext);
+    }
+
     public org.slf4j.Logger logger() {
         return runContextLogger.logger();
     }

--- a/jdbc/src/test/java/io/kestra/jdbc/runner/JdbcRunnerTest.java
+++ b/jdbc/src/test/java/io/kestra/jdbc/runner/JdbcRunnerTest.java
@@ -206,7 +206,7 @@ public abstract class JdbcRunnerTest {
         taskDefaultsCaseTest.taskDefaults();
     }
 
-    @Test
+    @RetryingTest(5)
     void flowWaitSuccess() throws Exception {
         flowCaseTest.waitSuccess();
     }


### PR DESCRIPTION
This will allow easily encryption of output from a task (for ex for GCP OauthAccessToken).
