### PR TITLE
feat(core): remove newline to allow multi-line secret

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -192,6 +192,7 @@ subprojects {
         systemProperty 'user.country', 'US'
 
         environment 'SECRET_MY_SECRET', "{\"secretKey\":\"secretValue\"}".bytes.encodeBase64().toString()
+        environment 'SECRET_NEW_LINE', "cGFzc3dvcmR2ZXJ5dmVyeXZleXJsb25ncGFzc3dvcmR2ZXJ5dmVyeXZleXJsb25ncGFzc3dvcmR2\nZXJ5dmVyeXZleXJsb25ncGFzc3dvcmR2ZXJ5dmVyeXZleXJsb25ncGFzc3dvcmR2ZXJ5dmVyeXZl\neXJsb25n"
         environment 'SECRET_WEBHOOK_KEY', "secretKey".bytes.encodeBase64().toString()
         environment 'SECRET_NON_B64_SECRET', "some secret value"
         environment 'KESTRA_TEST1', "true"

--- a/core/src/main/java/io/kestra/core/secret/SecretService.java
+++ b/core/src/main/java/io/kestra/core/secret/SecretService.java
@@ -23,7 +23,8 @@ public class SecretService {
             .filter(entry -> entry.getKey().startsWith(SECRET_PREFIX))
             .<Map.Entry<String, String>>mapMulti((entry, consumer) -> {
                 try {
-                    consumer.accept(Map.entry(entry.getKey(), new String(Base64.getDecoder().decode(entry.getValue()))));
+                    String value = entry.getValue().replaceAll("\\R", "");
+                    consumer.accept(Map.entry(entry.getKey(), new String(Base64.getDecoder().decode(value))));
                 } catch (Exception e) {
                     log.error("Could not decode secret '{}', make sure it is Base64-encoded: {}", entry.getKey(), e.getMessage());
                 }

--- a/core/src/test/java/io/kestra/core/secret/SecretFunctionTest.java
+++ b/core/src/test/java/io/kestra/core/secret/SecretFunctionTest.java
@@ -26,9 +26,11 @@ public class SecretFunctionTest extends AbstractMemoryRunnerTest {
 
     @Test
     @EnabledIfEnvironmentVariable(named = "SECRET_MY_SECRET", matches = ".*")
+    @EnabledIfEnvironmentVariable(named = "SECRET_NEW_LINE", matches = ".*")
     void getSecret() throws TimeoutException {
         Execution execution = runnerUtils.runOne(null, "io.kestra.tests", "secrets");
         assertThat(execution.getTaskRunList().get(0).getOutputs().get("value"), is("secretValue"));
+        assertThat(execution.getTaskRunList().get(1).getOutputs().get("value"), is("passwordveryveryveyrlongpasswordveryveryveyrlongpasswordveryveryveyrlongpasswordveryveryveyrlongpasswordveryveryveyrlong"));
     }
 
     @Test

--- a/core/src/test/resources/flows/valids/secrets.yaml
+++ b/core/src/test/resources/flows/valids/secrets.yaml
@@ -5,3 +5,6 @@ tasks:
   - id: get-secret
     type: io.kestra.core.tasks.debugs.Return
     format: "{{json(secret('my_secret')).secretKey}}"
+  - id: get-multiline-secret
+    type: io.kestra.core.tasks.debugs.Return
+    format: "{{json(secret('new_line'))}}"


### PR DESCRIPTION
As some old base64 tool may add some.

Fixes #2249
