### PR TITLE
Feat/gh 2952

### DIFF
--- a/cli/src/main/resources/application.yml
+++ b/cli/src/main/resources/application.yml
@@ -176,7 +176,15 @@ kestra:
     repositories:
       central:
         url: https://repo.maven.apache.org/maven2/
-
+    configurations:
+      - type: io.kestra.core.tasks.flows.Subflow
+        values:
+          flowOutputs:
+            enabled: true # backward-compatibility with version prior to v0.15.0
+      - type: io.kestra.core.tasks.flows.Flow
+        values:
+          flowOutputs:
+            enabled: true # backward-compatibility with version prior to v0.15.0
   variables:
     env-vars-prefix: KESTRA_
     disable-handlebars: true
@@ -206,9 +214,3 @@ kestra:
   heartbeat:
     frequency: 10s
     heartbeat-missed: 3
-
-  tasks:
-    # Global configuration for task 'Subflow'
-    subflow:
-      # Enable/Disable the task parameter's outputs.
-      allow-parameter-outputs: false

--- a/core/src/main/java/io/kestra/core/plugins/PluginConfiguration.java
+++ b/core/src/main/java/io/kestra/core/plugins/PluginConfiguration.java
@@ -1,0 +1,17 @@
+package io.kestra.core.plugins;
+
+import io.micronaut.context.annotation.EachProperty;
+import io.micronaut.context.annotation.Parameter;
+import io.micronaut.core.convert.format.MapFormat;
+import jakarta.validation.constraints.NotNull;
+
+import java.util.Comparator;
+import java.util.Map;
+
+@EachProperty(value = "kestra.plugins.configurations", list = true)
+public record PluginConfiguration(@Parameter Integer order,
+                                  @NotNull String type,
+                                  @MapFormat(transformation = MapFormat.MapTransformation.FLAT) Map<String, Object> values) {
+
+    static final Comparator<PluginConfiguration> COMPARATOR = Comparator.comparing(PluginConfiguration::order);
+}

--- a/core/src/main/java/io/kestra/core/plugins/PluginConfigurations.java
+++ b/core/src/main/java/io/kestra/core/plugins/PluginConfigurations.java
@@ -1,0 +1,50 @@
+package io.kestra.core.plugins;
+
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Class holding all the static plugin configurations passed through the Kestra application configuration file.
+ *
+ * @see PluginConfiguration
+ */
+@Singleton
+public final class PluginConfigurations {
+
+    private final List<PluginConfiguration> configurations;
+
+    /**
+     * Creates a new {@link PluginConfigurations} instance.
+     *
+     * @param configurations the list of configuration - must not be {@code null}.
+     */
+    @Inject
+    public PluginConfigurations(final List<PluginConfiguration> configurations) {
+        Objects.requireNonNull(configurations, "configuration cannot be null");
+        this.configurations = new ArrayList<>(configurations);
+        this.configurations.sort(PluginConfiguration.COMPARATOR);
+    }
+
+    /**
+     * Returns the key/value properties for the given plugin name.
+     *
+     * @param pluginType The fully qualified class name of a plugin.  Must not be {@code null}.
+     * @return a flat {@link Map} containing the key/value properties associated to the plugin.
+     * If no configuration exists for the given plugin, an empty {@link Map} is returned.
+     */
+    public Map<String, Object> getConfigurationByPluginType(final String pluginType) {
+        return configurations.stream()
+            .filter(config -> config.type().equalsIgnoreCase(pluginType))
+            .map(PluginConfiguration::values)
+            .reduce(new HashMap<>(), (accumulator, map) -> {
+                accumulator.putAll(map);
+                return accumulator;
+            });
+    }
+}

--- a/core/src/main/java/io/kestra/core/runners/RunContextFactory.java
+++ b/core/src/main/java/io/kestra/core/runners/RunContextFactory.java
@@ -2,6 +2,7 @@ package io.kestra.core.runners;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableMap;
+import io.kestra.core.plugins.PluginConfigurations;
 import io.micronaut.context.ApplicationContext;
 import io.kestra.core.models.executions.Execution;
 import io.kestra.core.models.executions.TaskRun;

--- a/core/src/main/java/io/kestra/core/runners/RunContextFactory.java
+++ b/core/src/main/java/io/kestra/core/runners/RunContextFactory.java
@@ -2,7 +2,6 @@ package io.kestra.core.runners;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableMap;
-import io.kestra.core.plugins.PluginConfigurations;
 import io.micronaut.context.ApplicationContext;
 import io.kestra.core.models.executions.Execution;
 import io.kestra.core.models.executions.TaskRun;

--- a/core/src/main/java/io/kestra/core/tasks/flows/Subflow.java
+++ b/core/src/main/java/io/kestra/core/tasks/flows/Subflow.java
@@ -61,7 +61,7 @@ import java.util.stream.Collectors;
 )
 public class Subflow extends Task implements ExecutableTask<Subflow.Output> {
 
-    static final String ALLOW_PARAMETER_OUTPUTS_PROPERTY = "kestra.tasks.subflow.allow-parameter-outputs";
+    static final String PLUGIN_FLOW_OUTPUTS_ENABLED = "flowOutputs.enabled";
 
     @NotEmpty
     @Schema(
@@ -176,12 +176,9 @@ public class Subflow extends Task implements ExecutableTask<Subflow.Output> {
             return Optional.empty();
         }
 
-        // Ugly hack to get access to worker's configuration.
-        // MUST be changed when the RunContext class will be refactored, or remove when
-        // the `outputs` parameter is removed after being deprecated.
-        boolean isOutputsAllowed = runContext.getApplicationContext()
-            .getProperty(ALLOW_PARAMETER_OUTPUTS_PROPERTY, Boolean.class)
-            .orElse(false);
+        boolean isOutputsAllowed = runContext
+            .<Boolean>pluginConfiguration(PLUGIN_FLOW_OUTPUTS_ENABLED)
+            .orElse(true);
 
         final Output.OutputBuilder builder = Output.builder()
             .executionId(execution.getId())

--- a/core/src/test/java/io/kestra/core/plugins/PluginConfigurationTest.java
+++ b/core/src/test/java/io/kestra/core/plugins/PluginConfigurationTest.java
@@ -1,0 +1,32 @@
+package io.kestra.core.plugins;
+
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.IntStream;
+
+@MicronautTest
+class PluginConfigurationTest {
+
+    private static final String PLUGIN_TEST = "io.kestra.plugin.Test";
+
+    @Inject
+    private List<PluginConfiguration> configurations;
+
+    @Test
+    void testInjectEachProperty() {
+        // Given
+        this.configurations.sort(PluginConfiguration.COMPARATOR);
+
+        // Then
+        List<PluginConfiguration> expected = IntStream.range(0, 3)
+            .mapToObj(idx -> new PluginConfiguration(idx, PLUGIN_TEST + idx, Map.of("prop" + idx, "value" + idx)))
+            .toList();
+        Assertions.assertEquals(expected, configurations);
+    }
+
+}

--- a/core/src/test/java/io/kestra/core/plugins/PluginConfigurationsTest.java
+++ b/core/src/test/java/io/kestra/core/plugins/PluginConfigurationsTest.java
@@ -1,0 +1,43 @@
+package io.kestra.core.plugins;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+class PluginConfigurationsTest {
+
+    private static final String PLUGIN_TEST = "io.kestra.plugin.Test";
+
+    @Test
+    void shouldGetOrderedMergeConfigurationProperties() {
+        // Given
+        PluginConfigurations configurations = new PluginConfigurations(List.of(
+            new PluginConfiguration(0, PLUGIN_TEST, Map.of(
+                "prop1", "v1",
+                "prop2", "v1",
+                "prop3", "v1"
+            )),
+            new PluginConfiguration(2, PLUGIN_TEST, Map.of(
+                "prop1", "v1",
+                "prop2", "v2",
+                "prop3", "v3"
+            )),
+            new PluginConfiguration(1, PLUGIN_TEST, Map.of(
+                "prop1", "v2",
+                "prop2", "v2",
+                "prop3", "v2"
+            ))
+        ));
+        // When
+        Map<String, Object> result = configurations.getConfigurationByPluginType(PLUGIN_TEST);
+
+        // Then
+        Assertions.assertEquals(Map.of(
+            "prop1", "v1",
+            "prop2", "v2",
+            "prop3", "v3"
+        ), result);
+    }
+}

--- a/core/src/test/java/io/kestra/core/tasks/flows/SubflowTest.java
+++ b/core/src/test/java/io/kestra/core/tasks/flows/SubflowTest.java
@@ -70,7 +70,7 @@ class SubflowTest {
     @Test
     void shouldNotReturnOutputsForSubflowOutputsDisabled() {
         // Given
-        Mockito.when(applicationContext.getProperty(Subflow.ALLOW_PARAMETER_OUTPUTS_PROPERTY, Boolean.class))
+        Mockito.when(applicationContext.getProperty(Subflow.PLUGIN_FLOW_OUTPUTS_ENABLED, Boolean.class))
             .thenReturn(Optional.of(false));
 
         Map<String, Object> outputs = Map.of("key", "value");
@@ -99,7 +99,7 @@ class SubflowTest {
     @Test
     void shouldReturnOutputsForSubflowOutputsEnabled() throws IllegalVariableEvaluationException {
         // Given
-        Mockito.when(applicationContext.getProperty(Subflow.ALLOW_PARAMETER_OUTPUTS_PROPERTY, Boolean.class))
+        Mockito.when(applicationContext.getProperty(Subflow.PLUGIN_FLOW_OUTPUTS_ENABLED, Boolean.class))
             .thenReturn(Optional.of(true));
 
         Map<String, Object> outputs = Map.of("key", "value");
@@ -132,7 +132,7 @@ class SubflowTest {
     @Test
     void shouldOnlyReturnOutputsFromFlowOutputs() throws IllegalVariableEvaluationException {
         // Given
-        Mockito.when(applicationContext.getProperty(Subflow.ALLOW_PARAMETER_OUTPUTS_PROPERTY, Boolean.class))
+        Mockito.when(applicationContext.getProperty(Subflow.PLUGIN_FLOW_OUTPUTS_ENABLED, Boolean.class))
             .thenReturn(Optional.of(true));
 
         Output output = Output.builder().id("key").value("value").build();

--- a/core/src/test/resources/application-test.yml
+++ b/core/src/test/resources/application-test.yml
@@ -42,3 +42,15 @@ kestra:
     uri: http://localhost:8080/
 
   unittest: true
+
+  plugins:
+    configurations:
+      - type: io.kestra.plugin.Test0
+        values:
+          prop0: value0
+      - type: io.kestra.plugin.Test1
+        values:
+          prop1: value1
+      - type: io.kestra.plugin.Test2
+        values:
+          prop2: value2

--- a/jdbc-h2/src/test/resources/application-test.yml
+++ b/jdbc-h2/src/test/resources/application-test.yml
@@ -82,7 +82,3 @@ kestra:
       min-poll-interval: 10ms
       max-poll-interval: 100ms
       poll-switch-interval: 5s
-
-  tasks:
-    subflow:
-      allow-parameter-outputs: true

--- a/jdbc-mysql/src/test/resources/application-test.yml
+++ b/jdbc-mysql/src/test/resources/application-test.yml
@@ -83,7 +83,3 @@ kestra:
       min-poll-interval: 10ms
       max-poll-interval: 100ms
       poll-switch-interval: 5s
-
-  tasks:
-    subflow:
-      allow-parameter-outputs: true

--- a/jdbc-postgres/src/test/resources/application-test.yml
+++ b/jdbc-postgres/src/test/resources/application-test.yml
@@ -84,7 +84,3 @@ kestra:
       min-poll-interval: 10ms
       max-poll-interval: 100ms
       poll-switch-interval: 5s
-
-  tasks:
-    subflow:
-      allow-parameter-outputs: true


### PR DESCRIPTION
See #2952

This PR allows configuring key/values properties for plugins allowing, for example, to disable features: 

```
kestra:
  plugins:
    configurations:
      - type: io.kestra.core.tasks.flows.Subflow
        values:
          flowOutputs:
            enabled: true # backward-compatibility with version prior to v0.15.0
      - type: io.kestra.core.tasks.flows.Flow
        values:
          flowOutputs:
            enabled: true # backward-compatibility with version prior to v0.15.0
```