### PR TITLE
fix(core): don't crash upon injecting Namespace Files if the root folder doesn't exist

### DIFF
--- a/core/src/main/java/io/kestra/core/runners/NamespaceFilesService.java
+++ b/core/src/main/java/io/kestra/core/runners/NamespaceFilesService.java
@@ -9,6 +9,7 @@ import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 import lombok.extern.slf4j.Slf4j;
 
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
@@ -78,7 +79,13 @@ public class NamespaceFilesService {
         URI uri = uri(namespace, path);
 
         List<URI> result = new ArrayList<>();
-        List<FileAttributes> list = storageInterface.list(tenantId, uri);
+        List<FileAttributes> list;
+        try {
+            list = storageInterface.list(tenantId, uri);
+        } catch (FileNotFoundException e) {
+            // prevent crashing upon trying to inject namespace files while the root namespace files folder doesn't exist
+            return result;
+        }
 
         for (var file: list) {
             URI current = URI.create((path != null ? path.getPath() : "") +  "/" + file.getFileName());

--- a/core/src/test/java/io/kestra/core/runners/NamespaceFilesServiceTest.java
+++ b/core/src/test/java/io/kestra/core/runners/NamespaceFilesServiceTest.java
@@ -168,6 +168,22 @@ class NamespaceFilesServiceTest {
         assertThat(content, is("2"));
     }
 
+    @Test
+    public void nsFilesRootFolderDoesntExist() throws Exception {
+        RunContext runContext = runContextFactory.of();
+        List<URI> injected = namespaceFilesService.inject(
+            runContextFactory.of(),
+            "tenant1",
+            "io.kestra." + IdUtils.create(),
+            runContext.tempDir(),
+            NamespaceFiles
+                .builder()
+                .enabled(true)
+                .build()
+        );
+        assertThat(injected.size(), is(0));
+    }
+
     private void put(@Nullable String tenantId, String namespace, String path, String content) throws IOException {
         storageInterface.put(
             tenantId,


### PR DESCRIPTION
closes #2965 