### PR TITLE
fix(jdbc): JDBC concurrency limit

### DIFF
--- a/core/src/main/java/io/kestra/core/runners/ExecutorState.java
+++ b/core/src/main/java/io/kestra/core/runners/ExecutorState.java
@@ -14,7 +14,6 @@ public class ExecutorState {
     private Map<String, State.Type> workerTaskDeduplication = new ConcurrentHashMap<>();
     private Map<String, String> childDeduplication = new ConcurrentHashMap<>();
     private Map<String, State.Type> subflowExecutionDeduplication = new ConcurrentHashMap<>();
-    private Boolean flowTriggerDeduplication = false;
 
     public ExecutorState(String executionId) {
         this.executionId = executionId;


### PR DESCRIPTION
Fixes #2976

Previously, action that must be done when an execution is terminated was done inside the method that handle messages from the execution queue. As there is a last execution message send when the execution is terminated, this lead to those methods being called two times. Moving those action after the sending of the execution solves the issue and also allow to remove a deduplication that was in place to fix the same issue on a different action.