### PR TITLE
feat: automatic encryption and decryption of task outputs

### DIFF
--- a/core/src/main/java/io/kestra/core/models/tasks/common/EncryptedString.java
+++ b/core/src/main/java/io/kestra/core/models/tasks/common/EncryptedString.java
@@ -1,0 +1,24 @@
+package io.kestra.core.models.tasks.common;
+
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import io.kestra.core.runners.RunContext;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+
+import java.security.GeneralSecurityException;
+
+@Getter
+@JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, property = "type", visible = true)
+@Schema(title = "A string that will be automatically encrypted and decrypted using AES.")
+public class EncryptedString {
+    private final String value;
+
+    private EncryptedString(String value) {
+        this.value = value;
+    }
+
+    public static EncryptedString from(String plainText, RunContext runContext) throws GeneralSecurityException {
+        String encrypted = runContext.encrypt(plainText);
+        return new EncryptedString(encrypted);
+    }
+}

--- a/core/src/test/java/io/kestra/core/tasks/test/Encrypted.java
+++ b/core/src/test/java/io/kestra/core/tasks/test/Encrypted.java
@@ -1,0 +1,54 @@
+package io.kestra.core.tasks.test;
+
+import io.kestra.core.models.annotations.Example;
+import io.kestra.core.models.annotations.Metric;
+import io.kestra.core.models.annotations.Plugin;
+import io.kestra.core.models.annotations.PluginProperty;
+import io.kestra.core.models.executions.metrics.Counter;
+import io.kestra.core.models.executions.metrics.Timer;
+import io.kestra.core.models.tasks.RunnableTask;
+import io.kestra.core.models.tasks.Task;
+import io.kestra.core.models.tasks.common.EncryptedString;
+import io.kestra.core.runners.RunContext;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.*;
+import lombok.experimental.SuperBuilder;
+
+@SuperBuilder
+@ToString
+@EqualsAndHashCode
+@Getter
+@NoArgsConstructor
+@Schema(
+    title = "Debugging task that returns an encrypted value."
+)
+@Plugin(
+    examples = {
+        @Example(
+            code = "format: \"Hello World\""
+        )
+    }
+)
+public class Encrypted extends Task implements RunnableTask<Encrypted.Output> {
+    @Schema(
+        title = "The templated string to encrypt."
+    )
+    @PluginProperty(dynamic = true)
+    private String format;
+
+    @Override
+    public Encrypted.Output run(RunContext runContext) throws Exception {
+        return Encrypted.Output.builder()
+            .value(EncryptedString.from(format, runContext))
+            .build();
+    }
+
+    @Builder
+    @Getter
+    public static class Output implements io.kestra.core.models.tasks.Output {
+        @Schema(
+            title = "The encrypted string."
+        )
+        private EncryptedString value;
+    }
+}

--- a/core/src/test/resources/flows/valids/encrypted-string.yaml
+++ b/core/src/test/resources/flows/valids/encrypted-string.yaml
@@ -1,0 +1,10 @@
+id: encrypted-string
+namespace: io.kestra.tests
+
+tasks:
+  - id: hello
+    type: io.kestra.core.tasks.test.Encrypted
+    format: "Hello World"
+  - id: return
+    type: io.kestra.core.tasks.debugs.Return
+    format: "{{outputs.hello.value}}"


### PR DESCRIPTION
Will allow to automatically encrypt an output property and decrypt it at run context creation time.

Such output will be visible like that:
![image](https://github.com/kestra-io/kestra/assets/1819009/955291b2-3c1b-4b5b-b812-5f89acd1d34f)

A use site in another task, it will be automatically decrypted, the test example uses a Return task and this task will  access the decrypted value.
