### PR TITLE
Fix/schedule evaluate failure

### DIFF
--- a/core/src/main/java/io/kestra/core/services/ConditionService.java
+++ b/core/src/main/java/io/kestra/core/services/ConditionService.java
@@ -1,6 +1,7 @@
 package io.kestra.core.services;
 
 import com.cronutils.utils.VisibleForTesting;
+import io.kestra.core.exceptions.InternalException;
 import io.kestra.core.models.conditions.Condition;
 import io.kestra.core.models.conditions.ConditionContext;
 import io.kestra.core.models.conditions.ScheduleCondition;
@@ -19,6 +20,8 @@ import java.util.List;
 import java.util.stream.Collectors;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
+
+import static io.kestra.core.utils.Rethrow.throwPredicate;
 
 /**
  * Provides business logic to manipulate {@link Condition}
@@ -61,18 +64,10 @@ public class ConditionService {
         return this.valid(flow, conditions, conditionContext);
     }
 
-    public boolean isValid(Flow flow, List<ScheduleCondition> conditions, ConditionContext conditionContext) {
+    public boolean isValid(List<ScheduleCondition> conditions, ConditionContext conditionContext) throws InternalException {
         return conditions
             .stream()
-            .allMatch(condition -> {
-                try {
-                    return condition.test(conditionContext);
-                } catch (Exception e) {
-                    logException(flow, condition, conditionContext, e);
-
-                    return false;
-                }
-            });
+            .allMatch(throwPredicate(condition -> condition.test(conditionContext)));
     }
 
     public boolean isValid(AbstractTrigger trigger, Flow flow, Execution execution, MultipleConditionStorageInterface multipleConditionStorage) {

--- a/core/src/test/java/io/kestra/core/schedulers/SchedulerPollingTriggerTest.java
+++ b/core/src/test/java/io/kestra/core/schedulers/SchedulerPollingTriggerTest.java
@@ -121,7 +121,7 @@ public class SchedulerPollingTriggerTest extends AbstractSchedulerTest {
             // Assert that the trigger is now disabled.
             // It needs to await on assertion as it will be disabled AFTER we receive a success execution.
             Trigger trigger = Trigger.of(flow, pollingTrigger);
-            Await.until(() -> this.triggerState.findLast(trigger).map(t -> t.getDisabled()).orElse(false), Duration.ofMillis(100), Duration.ofSeconds(10));
+            Await.until(() -> this.triggerState.findLast(trigger).map(t -> t.getDisabled()).orElse(false).booleanValue(), Duration.ofMillis(100), Duration.ofSeconds(10));
         }
     }
 

--- a/core/src/test/java/io/kestra/core/schedulers/SchedulerScheduleTest.java
+++ b/core/src/test/java/io/kestra/core/schedulers/SchedulerScheduleTest.java
@@ -294,7 +294,9 @@ public class SchedulerScheduleTest extends AbstractSchedulerTest {
     void stopAfterSchedule() throws Exception {
         // mock flow listeners
         FlowListeners flowListenersServiceSpy = spy(this.flowListenersService);
-        Schedule schedule = createScheduleTrigger("Europe/Paris", "* * * * *", "stopAfter", false).build();
+        Schedule schedule = createScheduleTrigger("Europe/Paris", "* * * * *", "stopAfter", false)
+            .stopAfter(List.of(State.Type.SUCCESS))
+            .build();
         Flow flow = createFlow(Collections.singletonList(schedule));
         doReturn(List.of(flow))
             .when(flowListenersServiceSpy)
@@ -340,7 +342,7 @@ public class SchedulerScheduleTest extends AbstractSchedulerTest {
             // Assert that the trigger is now disabled.
             // It needs to await on assertion as it will be disabled AFTER we receive a success execution.
             Trigger trigger = Trigger.of(flow, schedule);
-            Await.until(() -> this.triggerState.findLast(trigger).map(t -> t.getDisabled()).orElse(false), Duration.ofMillis(100), Duration.ofSeconds(10));
+            Await.until(() -> this.triggerState.findLast(trigger).map(t -> t.getDisabled()).orElse(false).booleanValue(), Duration.ofMillis(100), Duration.ofSeconds(10));
         }
     }
 


### PR DESCRIPTION
Fixes #2811

In case a Schedule trigger cannot evaluate its conditions, a failed execution is now created on each evaluation of the trigger.

For ex for the following flow:

```yaml
id: hello-world-var-condition
namespace: company.team

triggers:
  - id: naive-schedule-condition
    type: io.kestra.core.models.triggers.types.Schedule
    description: Schedule featuring an invalid `VariableCondition`
    cron: "*/5 * * * * "
    scheduleConditions:
     - type: io.kestra.core.models.conditions.types.VariableCondition
       expression: "{{ trigger.date | date() < now() }}" # FIXME: invalid Pebble syntax leads to an extreme log spam

tasks:
  - id: hello
    type: io.kestra.core.tasks.log.Log
    message: Kestra team wishes you a great day! 👋
```

We now log only one time the evaluation error each minute (as the cron is to trigger each minute) and creat a failed execution for it.

