### PR TITLE
feat(*): update execution labels

### DIFF
--- a/core/src/main/java/io/kestra/core/repositories/ExecutionRepositoryInterface.java
+++ b/core/src/main/java/io/kestra/core/repositories/ExecutionRepositoryInterface.java
@@ -139,7 +139,9 @@ public interface ExecutionRepositoryInterface extends SaveRepositoryInterface<Ex
         @Nullable ZonedDateTime endDate
     );
 
-    Execution save(Execution flow);
+    Execution save(Execution execution);
+
+    Execution update(Execution execution);
 
     default Function<String, String> sortMapping() throws IllegalArgumentException {
         return s -> s;

--- a/core/src/test/java/io/kestra/core/repositories/AbstractExecutionRepositoryTest.java
+++ b/core/src/test/java/io/kestra/core/repositories/AbstractExecutionRepositoryTest.java
@@ -515,4 +515,19 @@ public abstract class AbstractExecutionRepositoryTest {
         assertThat(result.stream().filter(executionCount -> executionCount.getFlowId().equals("second")).findFirst().get().getCount(), is(3L));
         assertThat(result.stream().filter(executionCount -> executionCount.getFlowId().equals("third")).findFirst().get().getCount(), is(9L));
     }
+
+    @Test
+    protected void update() {
+        Execution execution = ExecutionFixture.EXECUTION_1;
+        executionRepository.save(ExecutionFixture.EXECUTION_1);
+
+        Label label = new Label("key", "value");
+        Execution updated = execution.toBuilder().labels(List.of(label)).build();
+        executionRepository.update(updated);
+
+        Optional<Execution> validation = executionRepository.findById(null, updated.getId());
+        assertThat(validation.isPresent(), is(true));
+        assertThat(validation.get().getLabels().size(), is(1));
+        assertThat(validation.get().getLabels().get(0), is(label));
+    }
 }

--- a/jdbc/src/main/java/io/kestra/jdbc/repository/AbstractJdbcExecutionRepository.java
+++ b/jdbc/src/main/java/io/kestra/jdbc/repository/AbstractJdbcExecutionRepository.java
@@ -852,6 +852,21 @@ public abstract class AbstractJdbcExecutionRepository extends AbstractJdbcReposi
         return execution;
     }
 
+    @Override
+    public Execution update(Execution execution) {
+        return this.jdbcRepository
+            .getDslContextWrapper()
+            .transactionResult(configuration -> {
+                DSL.using(configuration)
+                    .update(this.jdbcRepository.getTable())
+                    .set(this.jdbcRepository.persistFields((execution)))
+                    .where(field("key").eq(execution.getId()))
+                    .execute();
+
+                return execution;
+            });
+    }
+
     @SneakyThrows
     @Override
     public Execution delete(Execution execution) {

--- a/repository-memory/src/main/java/io/kestra/repository/memory/MemoryExecutionRepository.java
+++ b/repository-memory/src/main/java/io/kestra/repository/memory/MemoryExecutionRepository.java
@@ -94,6 +94,11 @@ public class MemoryExecutionRepository implements ExecutionRepositoryInterface {
     }
 
     @Override
+    public Execution update(Execution execution) {
+        return executions.put(execution.getId(), execution);
+    }
+
+    @Override
     public Map<String, Map<String, List<DailyExecutionStatistics>>> dailyGroupByFlowStatistics(
         @Nullable String query,
         @Nullable String tenantId,

--- a/ui/src/components/executions/Executions.vue
+++ b/ui/src/components/executions/Executions.vue
@@ -743,14 +743,14 @@
                                     data: this.executionLabels
                                 })
                                 .then(r => {
-                                    this.$toast().success(this.$t("bulk set labels", {executionCount: r.data.count}));
+                                    this.$toast().success(this.$t("Set labels done", {executionCount: r.data.count}));
                                     this.loadData();
                                 })
                         } else {
                             return this.$store
                                 .dispatch("execution/bulkSetLabels", {executionsId: this.selection, executionLabels: this.executionLabels})
                                 .then(r => {
-                                    this.$toast().success(this.$t("bulk set labels", {executionCount: r.data.count}));
+                                    this.$toast().success(this.$t("Set labels done", {executionCount: r.data.count}));
                                     this.loadData();
                                 }).catch(e => this.$toast().error(e.invalids.map(exec => {
                                     return {message: this.$t(exec.message, {executionId: exec.invalidValue})}
@@ -760,6 +760,7 @@
                     () => {
                     }
                 )
+                this.isOpenLabelsModal = false;
             },
             editFlow() {
                 this.$router.push({

--- a/ui/src/components/executions/Overview.vue
+++ b/ui/src/components/executions/Overview.vue
@@ -5,6 +5,7 @@
                 <crud type="CREATE" permission="EXECUTION" :detail="{executionId: execution.id}" />
             </el-col>
             <el-col :span="12" class="text-end">
+                <setLabels :execution="execution" />
                 <restart is-replay :execution="execution" @follow="forwardEvent('follow', $event)" />
                 <restart :execution="execution" @follow="forwardEvent('follow', $event)" />
                 <resume :execution="execution" />
@@ -70,6 +71,7 @@
     import {mapState} from "vuex";
     import Status from "../Status.vue";
     import Vars from "./Vars.vue";
+    import SetLabels from "./SetLabels.vue";
     import Restart from "./Restart.vue";
     import Resume from "./Resume.vue";
     import Kill from "./Kill.vue";
@@ -84,6 +86,7 @@
         components: {
             Duration,
             Status,
+            SetLabels,
             Restart,
             Vars,
             Resume,

--- a/ui/src/components/executions/SetLabels.vue
+++ b/ui/src/components/executions/SetLabels.vue
@@ -1,0 +1,99 @@
+<template>
+    <el-tooltip
+        :persistent="false"
+        transition=""
+        :hide-after="0"
+        :content="$t('Set labels tooltip')"
+        raw-content
+        :placement="tooltipPosition"
+    >
+        <component
+            :is="component"
+            :icon="LabelMultiple"
+            @click="isOpen = !isOpen"
+            :disabled="!enabled"
+        >
+            {{ $t("Set labels") }}
+        </component>
+    </el-tooltip>
+    <el-dialog v-if="isOpen" v-model="isOpen" destroy-on-close :append-to-body="true">
+        <template #header>
+            <h5>{{ $t("Set labels") }}</h5>
+        </template>
+
+        <template #footer>
+            <el-button @click="isOpen = false">
+                {{ $t("cancel") }}
+            </el-button>
+            <el-button type="primary" @click="setLabels()">
+                {{ $t("ok") }}
+            </el-button>
+        </template>
+
+        <p v-html="$t('Set labels to execution', {id: execution.id})" />
+
+        <el-form>
+            <el-form-item :label="$t('execution labels')">
+                <label-input
+                    :key="executionLabels"
+                    v-model:labels="executionLabels"
+                />
+            </el-form-item>
+        </el-form>
+    </el-dialog>
+</template>
+
+<script setup>
+    import LabelMultiple from "vue-material-design-icons/LabelMultiple.vue";
+</script>
+
+<script>
+    import {mapState} from "vuex";
+    import LabelInput from "../../components/labels/LabelInput.vue";
+    import State from "../../utils/state";
+
+    export default {
+        components: {LabelInput,},
+        props: {
+            component: {
+                type: String,
+                default: "el-button"
+            },
+            execution: {
+                type: Object,
+                required: true
+            },
+            tooltipPosition: {
+                type: String,
+                default: "bottom"
+            }
+        },
+        methods: {
+            setLabels() {
+                this.isOpen = false;
+                this.$store.dispatch("execution/setLabels", {
+                    labels: this.executionLabels,
+                    executionId: this.execution.id
+                }).then(response => {
+                    this.$store.commit("execution/setExecution", response.data)
+                    this.$toast().success(this.$t("Set labels done"));
+                })
+            },
+        },
+        computed: {
+            ...mapState("auth", ["user"]),
+            enabled() {
+                if (State.isRunning(this.execution.state.current)) {
+                    return false;
+                }
+                return true;
+            }
+        },
+        data() {
+            return {
+                isOpen: false,
+                executionLabels: [],
+            };
+        },
+    };
+</script>

--- a/ui/src/stores/executions.js
+++ b/ui/src/stores/executions.js
@@ -171,6 +171,23 @@ export default {
             }).then(response => {
                 commit("setFilePreview", response.data)
             })
+        },
+        setLabels(_, options) {
+            return this.$http.post(
+                `${apiUrl(this)}/executions/${options.executionId}/labels`,
+                options.labels,
+                {
+                    headers: {
+                        "Content-Type": "application/json"
+                    }
+                })
+        },
+        querySetLabels({_commit}, options) {
+            return this.$http.post(`${apiUrl(this)}/executions/labels/by-query`, options.data, {
+                params: options.params})
+        },
+        bulkSetLabels({_commit}, options) {
+            return this.$http.post(`${apiUrl(this)}/executions/labels/by-ids`,  options)
         }
     },
     mutations: {

--- a/ui/src/translations.json
+++ b/ui/src/translations.json
@@ -319,7 +319,7 @@
     "bulk kill": "Are you sure you want to kill <code>{executionCount}</code> execution(s)?",
     "selection": {
       "selected": "<strong>{count}</strong> selected",
-      "all": "Select all <em>({count})</em>"
+      "all": "Select all ({count})"
     },
     "cancel": "Cancel",
     "homeDashboard": {
@@ -587,7 +587,12 @@
     "relative end date": "Relative end date",
     "now": "Now",
     "absolute": "Absolute",
-    "backfill": "Backfill"
+    "backfill": "Backfill",
+    "Set labels tooltip": "Set labels to the execution",
+    "Set labels": "Set labels",
+    "Set labels to execution": "Add or update the labels of the execution <code>{id}</code>",
+    "Set labels done": "Successfully set the labels of the execution",
+    "bulk set labels": "Are you sure you want to set labels to <code>{executionCount}</code>  executions(s)?"
   },
   "fr": {
     "id": "Identifiant",
@@ -1165,7 +1170,12 @@
     "pause backfill": "Mettre en pause le backfill",
     "backfill executions": "Backfill d'éxécutions",
     "execute backfill": "Éxécuter le backfill",
-    "backfill": "Backfill"
+    "backfill": "Backfill",
+    "Set labels tooltip": "Ajouter des labels à l'éxécution",
+    "Set labels": "Ajouter des labels",
+    "Set labels to execution": "Ajouter ou mettre à jour des labels à l'éxécution <code>{id}</code>",
+    "Set labels done": "Labels ajoutés avec succès à l'éxécution",
+    "bulk set labels": "Etes-vous sûr de vouloir ajouter des labels à <code>{executionCount}</code>  éxécutions(s)?"
   }
 }
 


### PR DESCRIPTION
Fixes #2633

Allow to set (add and update) execution labels for terminated executions.

![image](https://github.com/kestra-io/kestra/assets/1819009/0fb11e51-e27d-4645-985e-3c4ff989b923)

Also provide bulk action for that.

![image](https://github.com/kestra-io/kestra/assets/1819009/5297e464-ed72-4e37-873e-12daff903a53)


