### PR TITLE
fix(ui, websever): rename startDateRange to timeRange and add support…

### DIFF
--- a/ui/src/components/executions/Executions.vue
+++ b/ui/src/components/executions/Executions.vue
@@ -514,17 +514,14 @@
                 if (this.$route.query.endDate) {
                     return this.$route.query.endDate;
                 }
-                if (this.$route.query.endDateRange) {
-                    return this.$moment().subtract(this.$moment.duration(this.$route.query.endDateRange).as("milliseconds")).toISOString(true);
-                }
                 return undefined;
             },
             startDate() {
                 if (this.$route.query.startDate) {
                     return this.$route.query.startDate;
                 }
-                if (this.$route.query.startDateRange) {
-                    return this.$moment().subtract(this.$moment.duration(this.$route.query.startDateRange).as("milliseconds")).toISOString(true);
+                if (this.$route.query.timeRange) {
+                    return this.$moment().subtract(this.$moment.duration(this.$route.query.timeRange).as("milliseconds")).toISOString(true);
                 }
                 return undefined;
             },
@@ -572,8 +569,7 @@
                 let queryFilter = this.queryWithFilter();
 
                 if (stats) {
-                    delete queryFilter["startDateRange"];
-                    delete queryFilter["endDateRange"];
+                    delete queryFilter["timeRange"];
                     delete queryFilter["startDate"];
                     delete queryFilter["endDate"];
                 }

--- a/ui/src/components/executions/date-select/DateFilter.vue
+++ b/ui/src/components/executions/date-select/DateFilter.vue
@@ -19,7 +19,7 @@
     />
     <relative-date-select
         v-if="selectedFilterType === filterType.RELATIVE"
-        :start-range="startRange"
+        :time-range="timeRange"
         @update:model-value="onRelFilterChange($event)"
     />
 </template>
@@ -51,8 +51,8 @@
             }
         },
         computed: {
-            startRange() {
-                return this.$route.query.startDateRange ? this.$route.query.startDateRange : "P30D";
+            timeRange() {
+                return this.$route.query.timeRange ? this.$route.query.timeRange : "P30D";
             },
             startDate() {
                 return this.$route.query.startDate ? this.$route.query.startDate : this.$moment(this.endDate).add(-30, "days").toISOString(true);
@@ -69,8 +69,7 @@
                 const filter = {
                     "startDate": event.startDate,
                     "endDate": event.endDate,
-                    "startDateRange": undefined,
-                    "endDateRange": undefined
+                    "timeRange": undefined
                 };
                 this.updateFilter(filter);
             },
@@ -78,7 +77,7 @@
                 const filter = {
                     "startDate": undefined,
                     "endDate": undefined,
-                    "startDateRange": event.startDateRange
+                    "timeRange": event.timeRange
                 };
                 this.updateFilter(filter);
             },

--- a/ui/src/components/executions/date-select/RelativeDateSelect.vue
+++ b/ui/src/components/executions/date-select/RelativeDateSelect.vue
@@ -1,9 +1,9 @@
 <template>
     <date-select
-        :value="startRange"
+        :value="timeRange"
         :options="timeFilterPresets"
         :tooltip="$t('relative start date')"
-        @change="onChangeStart($event)"
+        @change="onChangeRange($event)"
     />
 </template>
 
@@ -56,14 +56,14 @@
             }
         },
         props: {
-            startRange: {
+            timeRange: {
                 type: String,
                 default: undefined
             }
         },
         methods: {
-            onChangeStart(range) {
-                this.$emit("update:modelValue", {"startDateRange": range, "endDateRange": this.endRange});
+            onChangeRange(range) {
+                this.$emit("update:modelValue", {"timeRange": range});
             },
         }
     }

--- a/webserver/src/main/java/io/kestra/webserver/controllers/ExecutionController.java
+++ b/webserver/src/main/java/io/kestra/webserver/controllers/ExecutionController.java
@@ -165,10 +165,10 @@ public class ExecutionController {
         @Parameter(description = "A flow id filter") @Nullable @QueryValue String flowId,
         @Parameter(description = "The start datetime") @Nullable @Format("yyyy-MM-dd'T'HH:mm[:ss][.SSS][XXX]") @QueryValue ZonedDateTime startDate,
         @Parameter(description = "The end datetime") @Nullable @Format("yyyy-MM-dd'T'HH:mm[:ss][.SSS][XXX]") @QueryValue ZonedDateTime endDate,
-        @Parameter(description = "A start time range filter relative to the current time", examples = {
+        @Parameter(description = "A time range filter relative to the current time", examples = {
             @ExampleObject(name = "Filter last 5 minutes", value = "PT5M"),
             @ExampleObject(name = "Filter last 24 hours", value = "P1D")
-        }) @Nullable @QueryValue Duration startDateRange,
+        }) @Nullable @QueryValue Duration timeRange,
         @Parameter(description = "A state filter") @Nullable @QueryValue List<State.Type> state,
         @Parameter(description = "A labels filter as a list of 'key:value'") @Nullable @QueryValue List<String> labels,
         @Parameter(description = "The trigger execution id") @Nullable @QueryValue String triggerExecutionId,
@@ -182,8 +182,8 @@ public class ExecutionController {
             tenantService.resolveTenant(),
             namespace,
             flowId,
-            resolveAbsoluteDateTime(startDate, startDateRange, now),
-            null,
+            resolveAbsoluteDateTime(startDate, timeRange, now),
+            endDate,
             state,
             RequestUtils.toMap(labels),
             triggerExecutionId,
@@ -195,7 +195,7 @@ public class ExecutionController {
     ZonedDateTime resolveAbsoluteDateTime(ZonedDateTime absoluteDateTime, Duration timeRange, ZonedDateTime now) {
         if (timeRange != null) {
             if (absoluteDateTime != null) {
-                throw new IllegalArgumentException("Parameters 'Date' and 'DateRange' are mutually exclusive");
+                throw new IllegalArgumentException("Parameters 'startDate' and 'timeRange' are mutually exclusive");
             }
             return now.minus(timeRange.abs());
         }
@@ -346,6 +346,10 @@ public class ExecutionController {
         @Parameter(description = "A flow id filter") @Nullable @QueryValue String flowId,
         @Parameter(description = "The start datetime") @Nullable @Format("yyyy-MM-dd'T'HH:mm[:ss][.SSS][XXX]") @QueryValue ZonedDateTime startDate,
         @Parameter(description = "The end datetime") @Nullable @Format("yyyy-MM-dd'T'HH:mm[:ss][.SSS][XXX]") @QueryValue ZonedDateTime endDate,
+        @Parameter(description = "A time range filter relative to the current time", examples = {
+            @ExampleObject(name = "Filter last 5 minutes", value = "PT5M"),
+            @ExampleObject(name = "Filter last 24 hours", value = "P1D")
+        }) @Nullable @QueryValue Duration timeRange,
         @Parameter(description = "A state filter") @Nullable @QueryValue List<State.Type> state,
         @Parameter(description = "A labels filter as a list of 'key:value'") @Nullable @QueryValue List<String> labels,
         @Parameter(description = "The trigger execution id") @Nullable @QueryValue String triggerExecutionId,
@@ -357,7 +361,7 @@ public class ExecutionController {
                 tenantService.resolveTenant(),
                 namespace,
                 flowId,
-                startDate,
+                resolveAbsoluteDateTime(startDate, timeRange, ZonedDateTime.now()),
                 endDate,
                 state,
                 RequestUtils.toMap(labels),
@@ -748,6 +752,10 @@ public class ExecutionController {
         @Parameter(description = "A flow id filter") @Nullable @QueryValue String flowId,
         @Parameter(description = "The start datetime") @Nullable @Format("yyyy-MM-dd'T'HH:mm[:ss][.SSS][XXX]") @QueryValue ZonedDateTime startDate,
         @Parameter(description = "The end datetime") @Nullable @Format("yyyy-MM-dd'T'HH:mm[:ss][.SSS][XXX]") @QueryValue ZonedDateTime endDate,
+        @Parameter(description = "A time range filter relative to the current time", examples = {
+            @ExampleObject(name = "Filter last 5 minutes", value = "PT5M"),
+            @ExampleObject(name = "Filter last 24 hours", value = "P1D")
+        }) @Nullable @QueryValue Duration timeRange,
         @Parameter(description = "A state filter") @Nullable @QueryValue List<State.Type> state,
         @Parameter(description = "A labels filter as a list of 'key:value'") @Nullable @QueryValue List<String> labels,
         @Parameter(description = "The trigger execution id") @Nullable @QueryValue String triggerExecutionId,
@@ -759,7 +767,7 @@ public class ExecutionController {
                 tenantService.resolveTenant(),
                 namespace,
                 flowId,
-                startDate,
+                resolveAbsoluteDateTime(startDate, timeRange, ZonedDateTime.now()),
                 endDate,
                 state,
                 RequestUtils.toMap(labels),
@@ -965,6 +973,10 @@ public class ExecutionController {
         @Parameter(description = "A flow id filter") @Nullable @QueryValue String flowId,
         @Parameter(description = "The start datetime") @Nullable @Format("yyyy-MM-dd'T'HH:mm[:ss][.SSS][XXX]") @QueryValue ZonedDateTime startDate,
         @Parameter(description = "The end datetime") @Nullable @Format("yyyy-MM-dd'T'HH:mm[:ss][.SSS][XXX]") @QueryValue ZonedDateTime endDate,
+        @Parameter(description = "A time range filter relative to the current time", examples = {
+            @ExampleObject(name = "Filter last 5 minutes", value = "PT5M"),
+            @ExampleObject(name = "Filter last 24 hours", value = "P1D")
+        }) @Nullable @QueryValue Duration timeRange,
         @Parameter(description = "A state filter") @Nullable @QueryValue List<State.Type> state,
         @Parameter(description = "A labels filter as a list of 'key:value'") @Nullable @QueryValue List<String> labels,
         @Parameter(description = "The trigger execution id") @Nullable @QueryValue String triggerExecutionId,
@@ -976,7 +988,7 @@ public class ExecutionController {
                 tenantService.resolveTenant(),
                 namespace,
                 flowId,
-                startDate,
+                resolveAbsoluteDateTime(startDate, timeRange, ZonedDateTime.now()),
                 endDate,
                 state,
                 RequestUtils.toMap(labels),


### PR DESCRIPTION
… for it in the mass actions

@anna-geller relative time range was not supported on bulk action. While doing that, I renamed the query parameter from `startDateRange` to `timeRange` as we decided to not support end range, is it OK for you?
