### PR TITLE
fix(ui): render HTML inside bulk select button

### DIFF
--- a/ui/src/components/layout/BulkSelect.vue
+++ b/ui/src/components/layout/BulkSelect.vue
@@ -13,7 +13,7 @@
                 @click="toggleAll"
                 v-if="selections.length < total"
             >
-                {{ $t('selection.all', {count: total}) }}
+                <span v-html="$t('selection.all', {count: total})" />
             </el-button>
             <slot />
         </el-button-group>


### PR DESCRIPTION
### What changes are being made and why?
The _Select all_ bulk selection button was missing inner HTML rendering which is used by the English translation.