### PR TITLE
feat(core): add new deduplicate task for storage

### DIFF
--- a/core/src/main/java/io/kestra/core/runners/RunContext.java
+++ b/core/src/main/java/io/kestra/core/runners/RunContext.java
@@ -42,10 +42,12 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.security.GeneralSecurityException;
 import java.util.*;
+import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import static io.kestra.core.utils.MapUtils.mergeWithNullableValues;
 import static io.kestra.core.utils.Rethrow.throwFunction;
 
 @NoArgsConstructor
@@ -520,32 +522,36 @@ public class RunContext {
         return variableRenderer.render(inline, this.variables);
     }
 
+    @SuppressWarnings("unchecked")
     public String render(String inline, Map<String, Object> variables) throws IllegalVariableEvaluationException {
-        return variableRenderer.render(inline, mergeVariables(variables));
+        return variableRenderer.render(inline, mergeWithNullableValues(this.variables, variables));
     }
-
+    @SuppressWarnings("unchecked")
     public List<String> render(List<String> inline) throws IllegalVariableEvaluationException {
         return variableRenderer.render(inline, this.variables);
     }
 
+    @SuppressWarnings("unchecked")
     public List<String> render(List<String> inline, Map<String, Object> variables) throws IllegalVariableEvaluationException {
-        return variableRenderer.render(inline, mergeVariables(variables));
+        return variableRenderer.render(inline, mergeWithNullableValues(this.variables, variables));
     }
 
     public Set<String> render(Set<String> inline) throws IllegalVariableEvaluationException {
         return variableRenderer.render(inline, this.variables);
     }
 
+    @SuppressWarnings("unchecked")
     public Set<String> render(Set<String> inline, Map<String, Object> variables) throws IllegalVariableEvaluationException {
-        return variableRenderer.render(inline, mergeVariables(variables));
+        return variableRenderer.render(inline, mergeWithNullableValues(this.variables, variables));
     }
 
     public Map<String, Object> render(Map<String, Object> inline) throws IllegalVariableEvaluationException {
         return variableRenderer.render(inline, this.variables);
     }
 
+    @SuppressWarnings("unchecked")
     public Map<String, Object> render(Map<String, Object> inline, Map<String, Object> variables) throws IllegalVariableEvaluationException {
-        return variableRenderer.render(inline, mergeVariables(variables));
+        return variableRenderer.render(inline, mergeWithNullableValues(this.variables, variables));
     }
 
     public Map<String, String> renderMap(Map<String, String> inline) throws IllegalVariableEvaluationException {
@@ -553,20 +559,10 @@ public class RunContext {
             .entrySet()
             .stream()
             .map(throwFunction(entry -> new AbstractMap.SimpleEntry<>(
-                this.render(entry.getKey(), mergeVariables(variables)),
-                this.render(entry.getValue(), mergeVariables(variables))
+                this.render(entry.getKey(), variables),
+                this.render(entry.getValue(), variables)
             )))
             .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
-    }
-
-    private Map<String, Object> mergeVariables(Map<String, Object> variables) {
-        return Stream
-            .concat(this.variables.entrySet().stream(), variables.entrySet().stream())
-            .collect(Collectors.toMap(
-                Map.Entry::getKey,
-                Map.Entry::getValue,
-                (o, o2) -> o2
-            ));
     }
 
     private String decrypt(String encrypted) throws GeneralSecurityException {

--- a/core/src/main/java/io/kestra/core/tasks/storages/Deduplicate.java
+++ b/core/src/main/java/io/kestra/core/tasks/storages/Deduplicate.java
@@ -1,0 +1,176 @@
+package io.kestra.core.tasks.storages;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.kestra.core.models.annotations.Example;
+import io.kestra.core.models.annotations.Plugin;
+import io.kestra.core.models.annotations.PluginProperty;
+import io.kestra.core.models.tasks.RunnableTask;
+import io.kestra.core.models.tasks.Task;
+import io.kestra.core.runners.RunContext;
+import io.kestra.core.serializers.JacksonMapper;
+import io.micronaut.core.util.functional.ThrowingFunction;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.ToString;
+import lombok.experimental.SuperBuilder;
+
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.Map;
+
+@Schema(
+    title = "Deduplicate a file by retaining only the latest row for each extracted key.",
+    description = """
+        The `Deduplicate` task involves reading the input file twice, rather than loading the entire file into memory.
+        The first iteration is used to build a deduplication map in memory containing the last lines observed for each key.
+        The second iteration is used to rewrite the file without the duplicates. The task must be used with this in mind.
+        """
+)
+@Plugin(
+    examples = {
+        @Example(
+            full = true,
+            code = {
+                """
+                tasks:
+                   - id: deduplicate
+                     type: io.kestra.core.tasks.storages.Deduplicate
+                     expr: " {{ key }}"
+                """
+            }
+        )
+    }
+)
+@SuperBuilder
+@ToString
+@EqualsAndHashCode
+@Getter
+public class Deduplicate extends Task implements RunnableTask<Deduplicate.Output> {
+
+    @Schema(
+        title = "The file to be compacted.",
+        description = "Must be a `kestra://` internal storage URI."
+    )
+    @PluginProperty(dynamic = true)
+    @NotNull
+    private String from;
+
+    @Schema(
+        title = "The 'pebble' expression to be used for extracting a row key.",
+        description = "The 'pebble' expression can be used for constructing a composite key."
+    )
+    @PluginProperty
+    @NotNull
+    private String expr;
+
+    /**
+     * {@inheritDoc}
+     **/
+    @Override
+    public Output run(RunContext runContext) throws Exception {
+
+        URI from = new URI(runContext.render(this.from));
+
+        final PebbleFieldExtractor keyExtractor = getKeyExtractor(runContext);
+
+        final Map<String, Long> index = new HashMap<>(); // can be replaced by small-footprint Map implementation
+
+        // 1st iteration: build a map of key->offset
+        try (final BufferedReader reader = newBufferedReader(runContext, from)) {
+            long offset = 0L;
+            String line;
+            while ((line = reader.readLine()) != null) {
+                String key = keyExtractor.apply(line);
+                index.put(key, offset);
+                offset++;
+            }
+        }
+
+        final Path path = runContext.tempFile(".ion");
+        // 2nd iteration: write deduplicate
+        try (final BufferedWriter writer = Files.newBufferedWriter(path);
+             final BufferedReader reader = newBufferedReader(runContext, from)) {
+            long offset = 0L;
+            String line;
+            while ((line = reader.readLine()) != null) {
+                String key = keyExtractor.apply(line);
+                Long lastOffset = index.get(key);
+                if (lastOffset != null && lastOffset == offset) {
+                    writer.write(line);
+                    writer.newLine();
+                }
+                offset++;
+            }
+        }
+        URI uri = runContext.storage().putFile(path.toFile());
+        index.clear();
+        return Output.builder().uri(uri).build();
+    }
+
+    private PebbleFieldExtractor getKeyExtractor(RunContext runContext) {
+        return new PebbleFieldExtractor(runContext, expr);
+    }
+
+    private BufferedReader newBufferedReader(final RunContext runContext, final URI objectURI) throws IOException {
+        InputStream is = runContext.storage().getFile(objectURI);
+        return new BufferedReader(new InputStreamReader(is));
+    }
+
+    @Builder
+    @Getter
+    public static class Output implements io.kestra.core.models.tasks.Output {
+        @Schema(
+            title = "The deduplicated file URI."
+        )
+        private final URI uri;
+    }
+
+    /**
+     * Extracts a key from data using a 'pebble' expression.
+     */
+    private static class PebbleFieldExtractor implements ThrowingFunction<String, String, Exception> {
+
+        protected static final ObjectMapper MAPPER = JacksonMapper.ofIon();
+        private final RunContext runContext;
+        private final String expression;
+
+        /** {@inheritDoc} */
+        @Override
+        public String apply(String data) throws Exception {
+            try {
+                return extract(MAPPER.readTree(data));
+            } catch (JsonProcessingException e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        /**
+         * Creates a new {@link PebbleFieldExtractor} instance.
+         *
+         * @param expression the 'pebble' expression.
+         */
+        public PebbleFieldExtractor(final RunContext runContext,
+                                    final String expression) {
+            this.runContext = runContext;
+            this.expression = expression;
+        }
+
+        public String extract(final JsonNode jsonNode) throws Exception {
+            @SuppressWarnings("unchecked")
+            Map<String, Object> map = MAPPER.convertValue(jsonNode, Map.class);
+            return runContext.render(expression, map);
+        }
+    }
+}

--- a/core/src/main/java/io/kestra/core/utils/MapUtils.java
+++ b/core/src/main/java/io/kestra/core/utils/MapUtils.java
@@ -4,6 +4,7 @@ import com.google.common.collect.Lists;
 
 import java.util.*;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 @SuppressWarnings({"rawtypes", "unchecked"})
 public class MapUtils {
@@ -108,5 +109,19 @@ public class MapUtils {
         } catch (Exception e) {
             return new ArrayList<>(elements);
         }
+    }
+
+    /**
+     * Utility method for merging multiple {@link Map}s that can contains nullable values.
+     * Note that the maps provided are assumed to be flat, so this method does not perform a recursive merge.
+     *
+     * @param maps  The Map to be merged.
+     * @return     the merged Map.
+     */
+    public static Map<String, Object> mergeWithNullableValues(final Map<String, Object>...maps) {
+        return Arrays.stream(maps)
+            .flatMap(map -> map.entrySet().stream())
+            // https://bugs.openjdk.org/browse/JDK-8148463
+            .collect(HashMap::new, (m, v) -> m.put(v.getKey(), v.getValue()), HashMap::putAll);
     }
 }

--- a/core/src/test/java/io/kestra/core/tasks/storages/DeduplicateTest.java
+++ b/core/src/test/java/io/kestra/core/tasks/storages/DeduplicateTest.java
@@ -1,0 +1,140 @@
+package io.kestra.core.tasks.storages;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import io.kestra.core.runners.RunContext;
+import io.kestra.core.runners.RunContextFactory;
+import io.kestra.core.serializers.JacksonMapper;
+import io.kestra.core.storages.StorageInterface;
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+@MicronautTest
+class DeduplicateTest {
+    private static final List<KeyValue1> TEST_ITEMS_WITH_NULLS = List.of(
+        new KeyValue1("k1", "v1"),
+        new KeyValue1("k2", "v1"),
+        new KeyValue1("k3", "v1"),
+        new KeyValue1("k1", "v2"),
+        new KeyValue1("k2", "v2"),
+        new KeyValue1("k2", null),
+        new KeyValue1("k3", "v2"),
+        new KeyValue1("k1", "v3")
+    );
+
+    @Inject
+    RunContextFactory runContextFactory;
+
+    @Inject
+    StorageInterface storageInterface;
+
+    @Test
+    void shouldCompactFileGivenKeyExpression() throws Exception {
+        // Given
+        RunContext runContext = runContextFactory.of();
+
+        Deduplicate task = Deduplicate
+            .builder()
+            .from(generateKeyValueFile(TEST_ITEMS_WITH_NULLS, runContext).toString())
+            .expr(" {{ key }}")
+            .build();
+
+        // When
+        Deduplicate.Output output = task.run(runContext);
+
+        // Then
+        Assertions.assertNotNull(output);
+        Assertions.assertNotNull(output.getUri());
+
+        List<KeyValue1> expected = List.of(new KeyValue1("k2", null), new KeyValue1("k3", "v2"), new KeyValue1("k1", "v3"));
+        assertSimpleCompactedFile(runContext, output, expected, KeyValue1.class);
+    }
+
+    @Test
+    void shouldCompactFileGivenKeyExpressionReturningArray() throws Exception {
+        // Given
+        RunContext runContext = runContextFactory.of();
+
+        List<KeyValue2> values = List.of(
+            new KeyValue2("k1", "k1", "v1"),
+            new KeyValue2("k2", "k2", "v1"),
+            new KeyValue2("k3", "k3", "v1"),
+            new KeyValue2("k1", "k1", "v2"),
+            new KeyValue2("k2", "k2", null),
+            new KeyValue2("k3", "k3", "v2"),
+            new KeyValue2("k1", "k1", "v3")
+        );
+
+        Deduplicate task = Deduplicate
+            .builder()
+            .from(generateKeyValueFile(values, runContext).toString())
+            .expr(" {{ key }}-{{ v1 }}")
+            .build();
+
+        // When
+        Deduplicate.Output output = task.run(runContext);
+
+        // Then
+        Assertions.assertNotNull(output);
+        Assertions.assertNotNull(output.getUri());
+
+        List<KeyValue2> expected = List.of(
+            new KeyValue2("k2", "k2", null),
+            new KeyValue2("k3", "k3", "v2"),
+            new KeyValue2("k1", "k1", "v3")
+        );
+        assertSimpleCompactedFile(runContext, output, expected, KeyValue2.class);
+    }
+
+    private static <T> void assertSimpleCompactedFile(final RunContext runContext,
+                                                      final Deduplicate.Output output,
+                                                      final List<T> expected,
+                                                      final Class<T> type) throws IOException {
+        try (InputStream resource = runContext.storage().getFile(output.getUri());
+             InputStreamReader inputStreamReader = new InputStreamReader(resource, StandardCharsets.UTF_8);
+             BufferedReader bufferedReader = new BufferedReader(inputStreamReader)) {
+            List<T> list = bufferedReader.lines()
+                .map(line -> {
+                    try {
+                        return JacksonMapper.ofIon().readValue(line, type);
+                    } catch (JsonProcessingException e) {
+                        throw new RuntimeException(e);
+                    }
+                }).toList();
+            Assertions.assertEquals(expected, list);
+        }
+    }
+
+    private URI generateKeyValueFile(final List<?> items, RunContext runContext) throws IOException {
+        Path path = runContext.tempFile(".ion");
+        try (final BufferedWriter writer = Files.newBufferedWriter(path)) {
+            items.forEach(object -> {
+                try {
+                    writer.write(JacksonMapper.ofIon().writeValueAsString(object));
+                    writer.newLine();
+                } catch (IOException e) {
+                    throw new RuntimeException(e);
+                }
+            });
+        }
+        return runContext.storage().putFile(path.toFile());
+    }
+
+    record KeyValue1(String key, Object value) {
+    }
+
+    record KeyValue2(String key, Object v1, Object v2) {
+    }
+}

--- a/core/src/test/java/io/kestra/core/utils/MapUtilsTest.java
+++ b/core/src/test/java/io/kestra/core/utils/MapUtilsTest.java
@@ -1,5 +1,6 @@
 package io.kestra.core.utils;
 
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
@@ -70,5 +71,25 @@ class MapUtilsTest {
         assertThat(((Map<String, Object>) merge.get("map")).size(), is(3));
         assertThat(((Map<String, Object>) merge.get("map")).get("map_c"), is("e"));
         assertThat(((Map<String, Object>) ((Map<String, Object>) ((Map<String, Object>) merge.get("map")).get("map_a")).get("sub")).get("null"), nullValue());
+    }
+
+    @Test
+    void shouldMergeWithNullableValuesGivenNullAndDuplicate() {
+        @SuppressWarnings("unchecked")
+        Map<String, Object> results = MapUtils.mergeWithNullableValues(
+            Map.of("k1", "v1", "k2", "v1", "k3", "v1"),
+            Map.of("k1", "v2"),
+            Map.of("k2", "v2"),
+            Map.of("k3", "v2"),
+            new HashMap<>() {{
+                put("k4", null);
+            }}
+        );
+
+        Assertions.assertEquals(4, results.size());
+        Assertions.assertEquals("v2", results.get("k1"));
+        Assertions.assertEquals("v2", results.get("k2"));
+        Assertions.assertEquals("v2", results.get("k3"));
+        Assertions.assertNull(results.get("k4"));
     }
 }


### PR DESCRIPTION
This PR adds a new core task named `Deduplicate`: Deduplicate a file by retaining only the latest row for each extracted key.


Example:

```yaml
tasks:
    - id: deduplicate
      type: io.kestra.core.tasks.storages.Deduplicate
      expr: " {{ key }}"
```

Given the following input file : 

```json
{"key": "k1", "value": "v1"}
{"key": "k2", "value": "v1"}
{"key": "k3", "value": "v1"}
{"key": "k1", "value": "v2"}
{"key": "k2", "value": "v2"}
{"key": "k2", "value": null } 
{"key": "k3", "value": "v2"}
{"key": "k1", "value": "v3"}
```
The task will give the following output file :  
```json
{"key": "k2", "value": null } 
{"key": "k3", "value": "v2"}
{"key": "k1", "value": "v3"}
```