### PR TITLE
fix(core): default documentation to required false

### DIFF
--- a/cli/src/test/java/io/kestra/cli/commands/plugins/PluginDocCommandTest.java
+++ b/cli/src/test/java/io/kestra/cli/commands/plugins/PluginDocCommandTest.java
@@ -99,7 +99,7 @@ class PluginDocCommandTest {
                 ### `example`
                 * **Type:** ==string==
                 * **Dynamic:** ✔️
-                * **Required:** ❓
+                * **Required:** ❌
 
                 > Example interface
                 """));

--- a/core/src/main/java/io/kestra/core/docs/AbstractClassDocumentation.java
+++ b/core/src/main/java/io/kestra/core/docs/AbstractClassDocumentation.java
@@ -112,6 +112,8 @@ public abstract class AbstractClassDocumentation<T> {
             Map<String, Object> finalValue = (Map<String, Object>) current.getValue();
             if (required.contains(current.getKey())) {
                 finalValue.put("$required", true);
+            } else {
+                finalValue.put("$required", false);
             }
 
             result.put(flattenKey(current.getKey(), parentName), finalValue);


### PR DESCRIPTION
In case a task is not required, default to false or the documentation will display '?'.

Fixes #3145