### PR TITLE
feat(core): add new Filter task for filtering records from file

### DIFF
--- a/core/src/main/java/io/kestra/core/tasks/storages/FilterItems.java
+++ b/core/src/main/java/io/kestra/core/tasks/storages/FilterItems.java
@@ -1,0 +1,237 @@
+package io.kestra.core.tasks.storages;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.kestra.core.exceptions.IllegalVariableEvaluationException;
+import io.kestra.core.models.annotations.Example;
+import io.kestra.core.models.annotations.Plugin;
+import io.kestra.core.models.annotations.PluginProperty;
+import io.kestra.core.models.tasks.RunnableTask;
+import io.kestra.core.models.tasks.Task;
+import io.kestra.core.runners.RunContext;
+import io.kestra.core.serializers.JacksonMapper;
+import io.kestra.core.utils.TruthUtils;
+import io.micronaut.core.util.functional.ThrowingFunction;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.ToString;
+import lombok.experimental.SuperBuilder;
+
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+
+@Schema(
+    title = "Filter a file by retaining only the items that match a given expression."
+)
+@Plugin(
+    examples = {
+        @Example(
+            full = true,
+            code = {
+                """
+                tasks:
+                   - id: filter
+                     type: io.kestra.core.tasks.storages.FilterItems
+                     from: "{{ inputs.file }}"
+                     filterCondition: " {{ value == null }}"
+                     filterType: EXCLUDE
+                     errorOrNullBehavior: EXCLUDE
+                """
+            }
+        )
+    }
+)
+@SuperBuilder
+@ToString
+@EqualsAndHashCode
+@Getter
+public class FilterItems extends Task implements RunnableTask<FilterItems.Output> {
+
+    @Schema(
+        title = "The file to be filtered.",
+        description = "Must be a `kestra://` internal storage URI."
+    )
+    @PluginProperty(dynamic = true)
+    @NotNull
+    private String from;
+
+    @Schema(
+        title = "The 'pebble' expression used to match items to be included or excluded.",
+        description = "The 'pebble' expression should return a BOOLEAN value (i.e. `true` or `false`). Values `0`, `-0`, and `\"\"` are interpreted as `false`. " +
+            "Otherwise, any non empty value will be interpreted as `true`."
+    )
+    @PluginProperty
+    @NotNull
+    private String filterCondition;
+
+    @Schema(
+        title = "Specifies the action to perform with items that match the `filterCondition` predicate",
+        description = "Use `INCLUDE` to pass the item through, or `EXCLUDE` to drop the items."
+    )
+    @PluginProperty
+    @Builder.Default
+    private FilterType filterType = FilterType.INCLUDE;
+
+    @Schema(
+        title = "Specifies the behavior when the expression fail to be evaluated on an item or return `null`.",
+        description = "Use `FAIL` to throw the exception and fail the task, `INCLUDE` to pass the item through, or `EXCLUDE` to drop the item."
+    )
+    @PluginProperty
+    @Builder.Default
+    private ErrorOrNullBehavior errorOrNullBehavior = ErrorOrNullBehavior.FAIL;
+
+    /**
+     * {@inheritDoc}
+     **/
+    @Override
+    public Output run(RunContext runContext) throws Exception {
+
+        URI from = new URI(runContext.render(this.from));
+
+        final PebbleExpressionPredicate predicate = getExpressionPredication(runContext);
+
+        final Path path = runContext.tempFile(".ion");
+        long processedItemsTotal = 0L;
+        long droppedItemsTotal = 0L;
+        try (final BufferedWriter writer = Files.newBufferedWriter(path);
+             final BufferedReader reader = newBufferedReader(runContext, from)) {
+
+            String item;
+            while ((item = reader.readLine()) != null) {
+                IllegalVariableEvaluationException exception = null;
+                Boolean match = null;
+                try {
+                    match = predicate.apply(item);
+                } catch (IllegalVariableEvaluationException e) {
+                    exception = e;
+                }
+
+                FilterType action = this.filterType;
+
+                if (match == null) {
+                    switch (errorOrNullBehavior) {
+                        case FAIL -> {
+                            if (exception != null) {
+                                throw exception;
+                            } else {
+                                throw new IllegalVariableEvaluationException(String.format(
+                                    "Expression `%s` return `null` on item `%s`",
+                                    filterCondition,
+                                    item
+                                ));
+                            }
+                        }
+                        case INCLUDE -> action = FilterType.INCLUDE;
+                        case EXCLUDE ->  action = FilterType.EXCLUDE;
+                    }
+                    match = true;
+                }
+
+                if (!match) {
+                    action = action.reverse();
+                }
+
+                switch (action) {
+                    case INCLUDE -> {
+                        writer.write(item);
+                        writer.newLine();
+                    }
+                    case EXCLUDE -> droppedItemsTotal++;
+                }
+                processedItemsTotal++;
+            }
+        }
+        URI uri = runContext.storage().putFile(path.toFile());
+        return Output.builder()
+            .uri(uri)
+            .processedItemsTotal(processedItemsTotal)
+            .droppedItemsTotal(droppedItemsTotal)
+            .build();
+    }
+
+    private PebbleExpressionPredicate getExpressionPredication(RunContext runContext) {
+        return new PebbleExpressionPredicate(runContext, filterCondition);
+    }
+
+    private BufferedReader newBufferedReader(final RunContext runContext, final URI objectURI) throws IOException {
+        InputStream is = runContext.storage().getFile(objectURI);
+        return new BufferedReader(new InputStreamReader(is));
+    }
+
+    @Builder
+    @Getter
+    public static class Output implements io.kestra.core.models.tasks.Output {
+        @Schema(
+            title = "The filtered file URI."
+        )
+        private final URI uri;
+
+        @Schema(
+            title = "The total number of items that was processed by the task."
+        )
+        private final Long processedItemsTotal;
+
+        @Schema(
+            title = "The total number of items that was dropped by the task."
+        )
+        private final Long droppedItemsTotal;
+    }
+
+    private static class PebbleExpressionPredicate implements ThrowingFunction<String, Boolean, Exception> {
+
+        protected static final ObjectMapper MAPPER = JacksonMapper.ofIon();
+        private final RunContext runContext;
+        private final String expression;
+
+        /** {@inheritDoc} */
+        @Override
+        public Boolean apply(String data) throws Exception {
+            try {
+                String rendered = extract(MAPPER.readTree(data));
+                return rendered == null ? null : TruthUtils.isTruthy(rendered.trim());
+            } catch (JsonProcessingException e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        /**
+         * Creates a new {@link PebbleExpressionPredicate} instance.
+         *
+         * @param expression the 'pebble' expression.
+         */
+        public PebbleExpressionPredicate(final RunContext runContext,
+                                         final String expression) {
+            this.runContext = runContext;
+            this.expression = expression;
+        }
+
+        public String extract(final JsonNode jsonNode) throws Exception {
+            @SuppressWarnings("unchecked")
+            Map<String, Object> map = MAPPER.convertValue(jsonNode, Map.class);
+            return runContext.render(expression, map);
+        }
+    }
+
+    public enum FilterType {
+        INCLUDE, EXCLUDE;
+
+        public FilterType reverse() {
+            return equals(INCLUDE) ? EXCLUDE : INCLUDE;
+        }
+    }
+
+    public enum ErrorOrNullBehavior {
+        FAIL, INCLUDE, EXCLUDE;
+    }
+}

--- a/core/src/test/java/io/kestra/core/tasks/storages/FilterItemsTest.java
+++ b/core/src/test/java/io/kestra/core/tasks/storages/FilterItemsTest.java
@@ -1,0 +1,217 @@
+package io.kestra.core.tasks.storages;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import io.kestra.core.exceptions.IllegalVariableEvaluationException;
+import io.kestra.core.runners.RunContext;
+import io.kestra.core.runners.RunContextFactory;
+import io.kestra.core.serializers.JacksonMapper;
+import io.kestra.core.storages.StorageInterface;
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+@MicronautTest
+class FilterItemsTest {
+    private static final List<KeyValue> TEST_VALID_ITEMS = List.of(
+        new KeyValue("k1", 1),
+        new KeyValue("k2", 2),
+        new KeyValue("k3", 3),
+        new KeyValue("k4", 4)
+    );
+
+    private static final List<KeyValue> TEST_INVALID_ITEMS = List.of(
+        new KeyValue("k1", 1),
+        new KeyValue("k2", "dummy"),
+        new KeyValue("k3", 3),
+        new KeyValue("k4", 4)
+    );
+
+    @Inject
+    RunContextFactory runContextFactory;
+
+    @Inject
+    StorageInterface storageInterface;
+
+    @Test
+    void shouldFilterGivenValidBooleanExpressionForInclude() throws Exception {
+        // Given
+        RunContext runContext = runContextFactory.of();
+
+        FilterItems task = FilterItems
+            .builder()
+            .from(generateKeyValueFile(TEST_VALID_ITEMS, runContext).toString())
+            .filterCondition(" {{ value % 2 == 0 }} ")
+            .filterType(FilterItems.FilterType.INCLUDE)
+            .build();
+
+        // When
+        FilterItems.Output output = task.run(runContext);
+
+        // Then
+        Assertions.assertNotNull(output);
+        Assertions.assertNotNull(output.getUri());
+        Assertions.assertEquals(2, output.getDroppedItemsTotal());
+        Assertions.assertEquals(4, output.getProcessedItemsTotal());
+        assertFile(runContext, output, List.of(new KeyValue("k2", 2), new KeyValue("k4", 4)), KeyValue.class);
+    }
+
+    @Test
+    void shouldFilterGivenValidBooleanExpressionForExclude() throws Exception {
+        // Given
+        RunContext runContext = runContextFactory.of();
+
+        FilterItems task = FilterItems
+            .builder()
+            .from(generateKeyValueFile(TEST_VALID_ITEMS, runContext).toString())
+            .filterCondition(" {{ value % 2 == 0 }} ")
+            .filterType(FilterItems.FilterType.EXCLUDE)
+            .build();
+
+        // When
+        FilterItems.Output output = task.run(runContext);
+
+        // Then
+        Assertions.assertNotNull(output);
+        Assertions.assertNotNull(output.getUri());
+        Assertions.assertEquals(2, output.getDroppedItemsTotal());
+        Assertions.assertEquals(4, output.getProcessedItemsTotal());
+        assertFile(runContext, output, List.of(new KeyValue("k1", 1), new KeyValue("k3", 3)), KeyValue.class);
+    }
+
+    @Test
+    void shouldThrowExceptionGivenInvalidRecordsForFail() throws Exception {
+        // Given
+        RunContext runContext = runContextFactory.of();
+
+        FilterItems task = FilterItems
+            .builder()
+            .from(generateKeyValueFile(TEST_INVALID_ITEMS, runContext).toString())
+            .filterCondition(" {{ value % 2 == 0 }}")
+            .filterType(FilterItems.FilterType.INCLUDE)
+            .errorOrNullBehavior(FilterItems.ErrorOrNullBehavior.FAIL)
+            .build();
+
+        // When/Then
+        Assertions.assertThrows(IllegalVariableEvaluationException.class, () -> task.run(runContext));
+    }
+
+    @Test
+    void shouldFilterGivenInvalidRecordsForInclude() throws Exception {
+        // Given
+        RunContext runContext = runContextFactory.of();
+
+        FilterItems task = FilterItems
+            .builder()
+            .from(generateKeyValueFile(TEST_INVALID_ITEMS, runContext).toString())
+            .filterCondition(" {{ value % 2 == 0 }}")
+            .filterType(FilterItems.FilterType.INCLUDE)
+            .errorOrNullBehavior(FilterItems.ErrorOrNullBehavior.INCLUDE)
+            .build();
+
+        // When
+        FilterItems.Output output = task.run(runContext);
+
+        // Then
+        Assertions.assertNotNull(output);
+        Assertions.assertNotNull(output.getUri());
+        Assertions.assertEquals(2, output.getDroppedItemsTotal());
+        Assertions.assertEquals(4, output.getProcessedItemsTotal());
+        assertFile(runContext, output, List.of(new KeyValue("k2", "dummy"), new KeyValue("k4", 4)), KeyValue.class);
+    }
+
+    @Test
+    void shouldFilterGivenInvalidRecordsForExclude() throws Exception {
+        // Given
+        RunContext runContext = runContextFactory.of();
+
+        FilterItems task = FilterItems
+            .builder()
+            .from(generateKeyValueFile(TEST_INVALID_ITEMS, runContext).toString())
+            .filterCondition(" {{ value % 2 == 0 }}")
+            .filterType(FilterItems.FilterType.INCLUDE)
+            .errorOrNullBehavior(FilterItems.ErrorOrNullBehavior.EXCLUDE)
+            .build();
+
+        // When
+        FilterItems.Output output = task.run(runContext);
+
+        // Then
+        Assertions.assertNotNull(output);
+        Assertions.assertNotNull(output.getUri());
+        Assertions.assertEquals(3, output.getDroppedItemsTotal());
+        Assertions.assertEquals(4, output.getProcessedItemsTotal());
+        assertFile(runContext, output, List.of(new KeyValue("k4", 4)), KeyValue.class);
+    }
+
+    @Test
+    void shouldFilterWithNotMatchGivenNonBooleanValue() throws Exception {
+        // Given
+        RunContext runContext = runContextFactory.of();
+
+        FilterItems task = FilterItems
+            .builder()
+            .from(generateKeyValueFile(TEST_VALID_ITEMS, runContext).toString())
+            .filterCondition("{{ value }}")
+            .filterType(FilterItems.FilterType.INCLUDE)
+            .errorOrNullBehavior(FilterItems.ErrorOrNullBehavior.FAIL)
+            .build();
+
+        // When
+        FilterItems.Output output = task.run(runContext);
+
+        // Then
+        Assertions.assertNotNull(output);
+        Assertions.assertNotNull(output.getUri());
+        Assertions.assertEquals(0, output.getDroppedItemsTotal());
+        Assertions.assertEquals(4, output.getProcessedItemsTotal());
+        assertFile(runContext, output, TEST_VALID_ITEMS, KeyValue.class);
+    }
+
+    private static <T> void assertFile(final RunContext runContext,
+                                       final FilterItems.Output output,
+                                       final List<T> expected,
+                                       final Class<T> type) throws IOException {
+        try (InputStream resource = runContext.storage().getFile(output.getUri());
+             InputStreamReader inputStreamReader = new InputStreamReader(resource, StandardCharsets.UTF_8);
+             BufferedReader bufferedReader = new BufferedReader(inputStreamReader)) {
+            List<T> list = bufferedReader.lines()
+                .map(line -> {
+                    try {
+                        return JacksonMapper.ofIon().readValue(line, type);
+                    } catch (JsonProcessingException e) {
+                        throw new RuntimeException(e);
+                    }
+                }).toList();
+            Assertions.assertEquals(expected, list);
+        }
+    }
+
+    private URI generateKeyValueFile(final List<?> items, RunContext runContext) throws IOException {
+        Path path = runContext.tempFile(".ion");
+        try (final BufferedWriter writer = Files.newBufferedWriter(path)) {
+            items.forEach(object -> {
+                try {
+                    writer.write(JacksonMapper.ofIon().writeValueAsString(object));
+                    writer.newLine();
+                } catch (IOException e) {
+                    throw new RuntimeException(e);
+                }
+            });
+        }
+        return runContext.storage().putFile(path.toFile());
+    }
+
+    record KeyValue(String key, Object value) { }
+}


### PR DESCRIPTION
This PR adds a new core task named Filter: Filter a file by retaining only the records that match a given expression.

Example:

```yaml
tasks:
    - id: filter
      type: io.kestra.core.tasks.storages.Filter
      filterCondition: " {{ value % 2 == 0 }}"
      filterType: INCLUDE 
      errorOrNullBehavior: EXCLUDE
```

Given the following input file :

```json
{"key": "k1", "value": 1}
{"key": "k2", "value": "invalid"} // will be excluded
{"key": "k3", "value": 3}
{"key": "k4", "value": 4}
```

The task will give the following output file :

```json
{"key": "k4", "value": 4}
```