### PR TITLE
fix(core): fix Pause task topology when no sub-tasks

### DIFF
--- a/core/src/main/java/io/kestra/core/models/tasks/FlowableTask.java
+++ b/core/src/main/java/io/kestra/core/models/tasks/FlowableTask.java
@@ -1,6 +1,7 @@
 package io.kestra.core.models.tasks;
 
 import io.kestra.core.models.annotations.PluginProperty;
+import io.kestra.core.models.hierarchies.AbstractGraph;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.kestra.core.exceptions.IllegalVariableEvaluationException;
 import io.kestra.core.models.executions.Execution;
@@ -27,9 +28,10 @@ public interface FlowableTask <T extends Output> {
     /**
      * Create the topology representation of a flowable task.
      * <p>
-     * A flowable task always contains subtask to it returns a cluster that displays the subtasks.
+     * If a flowable task contains subtask, it must return a cluster that displays the subtasks.
+     * If not, it must return a single GraphTask.
      */
-    GraphCluster tasksTree(Execution execution, TaskRun taskRun, List<String> parentValues) throws IllegalVariableEvaluationException;
+    AbstractGraph tasksTree(Execution execution, TaskRun taskRun, List<String> parentValues) throws IllegalVariableEvaluationException;
 
     /**
      * @return all child tasks including errors

--- a/core/src/main/java/io/kestra/core/tasks/flows/Pause.java
+++ b/core/src/main/java/io/kestra/core/tasks/flows/Pause.java
@@ -8,7 +8,9 @@ import io.kestra.core.models.executions.Execution;
 import io.kestra.core.models.executions.NextTaskRun;
 import io.kestra.core.models.executions.TaskRun;
 import io.kestra.core.models.flows.State;
+import io.kestra.core.models.hierarchies.AbstractGraph;
 import io.kestra.core.models.hierarchies.GraphCluster;
+import io.kestra.core.models.hierarchies.GraphTask;
 import io.kestra.core.models.hierarchies.RelationType;
 import io.kestra.core.models.tasks.FlowableTask;
 import io.kestra.core.models.tasks.Task;
@@ -87,14 +89,16 @@ public class Pause extends Sequential implements FlowableTask<VoidOutput> {
     private List<Task> tasks;
 
     @Override
-    public GraphCluster tasksTree(Execution execution, TaskRun taskRun, List<String> parentValues) throws IllegalVariableEvaluationException {
-        GraphCluster subGraph = new GraphCluster(this, taskRun, parentValues, RelationType.SEQUENTIAL);
+    public AbstractGraph tasksTree(Execution execution, TaskRun taskRun, List<String> parentValues) throws IllegalVariableEvaluationException {
+        if (this.tasks == null || this.tasks.isEmpty()) {
+            return new GraphTask(this, taskRun, parentValues, RelationType.SEQUENTIAL);
+        }
 
-        List<Task> tasks = this.tasks != null && !this.tasks.isEmpty() ? this.tasks : List.of(this);
+        GraphCluster subGraph = new GraphCluster(this, taskRun, parentValues, RelationType.SEQUENTIAL);
 
         GraphUtils.sequential(
             subGraph,
-            tasks,
+            this.tasks,
             this.errors,
             taskRun,
             execution

--- a/core/src/main/java/io/kestra/core/tasks/flows/Sequential.java
+++ b/core/src/main/java/io/kestra/core/tasks/flows/Sequential.java
@@ -7,6 +7,7 @@ import io.kestra.core.models.annotations.PluginProperty;
 import io.kestra.core.models.executions.Execution;
 import io.kestra.core.models.executions.NextTaskRun;
 import io.kestra.core.models.executions.TaskRun;
+import io.kestra.core.models.hierarchies.AbstractGraph;
 import io.kestra.core.models.hierarchies.GraphCluster;
 import io.kestra.core.models.hierarchies.RelationType;
 import io.kestra.core.models.tasks.FlowableTask;
@@ -73,7 +74,7 @@ public class Sequential extends Task implements FlowableTask<VoidOutput> {
     private List<Task> tasks;
 
     @Override
-    public GraphCluster tasksTree(Execution execution, TaskRun taskRun, List<String> parentValues) throws IllegalVariableEvaluationException {
+    public AbstractGraph tasksTree(Execution execution, TaskRun taskRun, List<String> parentValues) throws IllegalVariableEvaluationException {
         GraphCluster subGraph = new GraphCluster(this, taskRun, parentValues, RelationType.SEQUENTIAL);
 
         GraphUtils.sequential(


### PR DESCRIPTION
Fixes #3158

In case there is no sub-tasks, the graph will generate a single node instead of a cluster of nodes.

![image (3)](https://github.com/kestra-io/kestra/assets/1819009/e19a22d6-ba6c-49a5-a420-7debf5e4d79e)
