### PR TITLE
fix(core): log empty messages

### DIFF
--- a/core/src/main/java/io/kestra/core/models/executions/LogEntry.java
+++ b/core/src/main/java/io/kestra/core/models/executions/LogEntry.java
@@ -54,6 +54,7 @@ public class LogEntry implements DeletedInterface, TenantInterface {
 
     String thread;
 
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     String message;
 
     @NotNull


### PR DESCRIPTION
### What changes are being made and why?

Empty log lines were presented as `null` in downloaded log files. Some scripts tend to use empty log lines quite often.

```txt
2024-02-28T19:03:36.006Z INFO foo
2024-02-28T19:03:36.011Z INFO null
2024-02-28T19:03:36.016Z INFO bar
```
vs

```txt
2024-02-28T19:02:56.411Z INFO foo
2024-02-28T19:02:56.415Z INFO 
2024-02-28T19:02:56.419Z INFO bar
```

---

### How the changes have been QAed?

```yaml
id: hello-world-log
namespace: company.team
tasks:
  - id: log-lines
    type: io.kestra.plugin.scripts.shell.Commands
    runner: PROCESS
    commands:
      - 'echo "foo"'
      - 'echo' # empty log line
      - 'echo "bar"'
```