### PR TITLE
fix(ui): fix labels filter by route

### DIFF
--- a/ui/src/mixins/dataTableActions.js
+++ b/ui/src/mixins/dataTableActions.js
@@ -4,8 +4,7 @@ import _isEqual from "lodash/isEqual";
 
 export default {
     created() {
-        this.internalPageSize = this.pageSize ?? this.$route.query.size ?? 25;
-        this.internalPageNumber = this.pageNumber ?? this.$route.query.page ?? 1;
+        this.refreshPaging();
 
         // @TODO: ugly hack from restoreUrl
         if (this.loadInit) {
@@ -38,6 +37,7 @@ export default {
     watch: {
         $route(newValue, oldValue) {
             if (oldValue.name === newValue.name && !_isEqual(newValue.query, oldValue.query)) {
+                this.refreshPaging();
                 this.load(this.onDataLoaded);
             }
         }
@@ -124,5 +124,9 @@ export default {
                 this.$refs.dataTable.isLoading = false;
             }
         },
+        refreshPaging() {
+            this.internalPageSize = this.pageSize ?? this.$route.query.size ?? 25;
+            this.internalPageNumber = this.pageNumber ?? this.$route.query.page ?? 1;
+        }
     }
 }


### PR DESCRIPTION
### What changes are being made and why?

This PR attempts to fix a specific filtering bug:

* Execute more executions than the current Execution's table page size
* Skip to a page no. >1
* Add a specific unique label to an Execution on the page no. >1
* Click on the added label to filter by its value
* No executions are displayed - the page query parameter was not reset

---

Filtering by clicking on a label invokes a routing event which did not affect the paging state.
