### PR TITLE
fix(plugin): add mn advice to ensure use of proper ClassLoader for plugins

### DIFF
--- a/core/src/main/java/io/kestra/core/annotations/ClassLoaderIsolated.java
+++ b/core/src/main/java/io/kestra/core/annotations/ClassLoaderIsolated.java
@@ -1,0 +1,17 @@
+package io.kestra.core.annotations;
+
+import io.micronaut.aop.Around;
+import io.micronaut.aop.AroundConstruct;
+import io.micronaut.aop.InterceptorBinding;
+import io.micronaut.aop.InterceptorKind;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+@Retention(RetentionPolicy.RUNTIME)
+@AroundConstruct
+@InterceptorBinding(kind = InterceptorKind.POST_CONSTRUCT)
+@InterceptorBinding(kind = InterceptorKind.PRE_DESTROY)
+@Around
+public @interface ClassLoaderIsolated {
+}

--- a/core/src/main/java/io/kestra/core/plugins/ClassLoaderIsolatedInterceptor.java
+++ b/core/src/main/java/io/kestra/core/plugins/ClassLoaderIsolatedInterceptor.java
@@ -1,0 +1,77 @@
+package io.kestra.core.plugins;
+
+import com.google.common.annotations.VisibleForTesting;
+import io.kestra.core.annotations.ClassLoaderIsolated;
+import io.micronaut.aop.*;
+import io.micronaut.context.annotation.Factory;
+import io.micronaut.core.util.functional.ThrowingSupplier;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Advice for enforcing Java ClassLoader isolation for pluggable classes/interfaces.
+ */
+@Factory
+@InterceptorBean(ClassLoaderIsolated.class)
+public class ClassLoaderIsolatedInterceptor implements MethodInterceptor<Object, Object> {
+
+    private static final Logger LOG = LoggerFactory.getLogger(ClassLoaderIsolatedInterceptor.class);
+
+    // By default, only intercept PluginClassLoader
+    private boolean interceptAnyClassLoader = false;
+
+    /**
+     * {@inheritDoc}
+     **/
+    @Override
+    public Object intercept(MethodInvocationContext<Object, Object> context) {
+        final Class<Object> type = context.getDeclaringType();
+        final ClassLoader classLoader = type.getClassLoader();
+        if (interceptAnyClassLoader || classLoader instanceof PluginClassLoader) {
+            LOG.trace("Method '{}' intercepted for class '{}', applying ClassLoader isolation for: {}",
+                context.getMethodName(),
+                type.getName(),
+                classLoader
+            );
+            return classLoaderIsolation(classLoader, context::proceed);
+        }
+        return context.proceed();
+    }
+
+    @InterceptorBean(ClassLoaderIsolated.class)
+    public ConstructorInterceptor<Object> aroundConstruct() {
+        return context -> {
+            final Class<Object> type = context.getDeclaringType();
+            final ClassLoader classLoader = type.getClassLoader();
+            if (interceptAnyClassLoader || classLoader instanceof PluginClassLoader) {
+                if (LOG.isTraceEnabled()) {
+                    InterceptorKind kind = context.getKind();
+                    String annotationName = kind.getAnnotationType().getSimpleName(); // @PostConstruct, @PreDestroy
+                    LOG.trace("Bean constructor intercepted for class '{}' on @{}, applying ClassLoader isolation for: {}",
+                        type.getName(),
+                        annotationName,
+                        classLoader
+                    );
+                }
+                return classLoaderIsolation(classLoader, context::proceed);
+            }
+            return context.proceed();
+        };
+    }
+
+    @VisibleForTesting
+    void setInterceptAnyClassLoader(final boolean interceptAnyClassLoader) {
+        this.interceptAnyClassLoader = interceptAnyClassLoader;
+    }
+
+    private static <T, E extends Exception> T classLoaderIsolation(final ClassLoader cl,
+                                                                   final ThrowingSupplier<T, E> supplier) throws E {
+        final ClassLoader saved = Thread.currentThread().getContextClassLoader();
+        try {
+            Thread.currentThread().setContextClassLoader(cl);
+            return supplier.get();
+        } finally {
+            Thread.currentThread().setContextClassLoader(saved);
+        }
+    }
+}

--- a/core/src/test/java/io/kestra/core/plugins/ClassLoaderIsolatedInterceptorTest.java
+++ b/core/src/test/java/io/kestra/core/plugins/ClassLoaderIsolatedInterceptorTest.java
@@ -1,0 +1,60 @@
+package io.kestra.core.plugins;
+
+import io.kestra.core.annotations.ClassLoaderIsolated;
+import io.micronaut.context.ApplicationContext;
+import io.micronaut.core.annotation.Introspected;
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+@MicronautTest
+class ClassLoaderIsolatedInterceptorTest {
+
+    @Inject
+    ApplicationContext context;
+
+    @Inject
+    ClassLoaderIsolatedInterceptor interceptor;
+
+    @Test
+    void test() {
+        // Given
+        interceptor.setInterceptAnyClassLoader(true); // only for-testing
+
+        ClassLoader parent = ClassLoaderIsolatedInterceptorTest.class.getClassLoader().getParent();
+        Thread.currentThread().setContextClassLoader(parent);
+
+        // When
+        CaptureClassLoaderTest testBean = context.createBean(CaptureClassLoaderTest.class); // trigger interceptor on constructor
+        Assertions.assertEquals(parent, getContextClassLoader());
+
+        testBean.run(); // trigger interceptor on method
+
+        // Then
+        Assertions.assertEquals(parent, getContextClassLoader());
+
+        Assertions.assertNotEquals(testBean.capturedConstructClassLoader, getContextClassLoader());
+        Assertions.assertNotEquals(testBean.capturedMethodClassLoader, getContextClassLoader());
+    }
+
+    private static ClassLoader getContextClassLoader() {
+        return Thread.currentThread().getContextClassLoader();
+    }
+
+    @Introspected
+    @ClassLoaderIsolated
+    public static class CaptureClassLoaderTest {
+
+        public ClassLoader capturedConstructClassLoader;
+        public ClassLoader capturedMethodClassLoader;
+
+        public CaptureClassLoaderTest() {
+            capturedConstructClassLoader = getContextClassLoader();
+        }
+
+        public void run() {
+            capturedMethodClassLoader = getContextClassLoader();
+        }
+    }
+}


### PR DESCRIPTION
This commit adds a `ClassLoaderIsolated` annotation and `ClassLoaderIsolatedInterceptor` to ensure the use of the proper ClassLoader for injected plugin services (e.g., StorageInterface).