### PR TITLE
feat(jdbc*): add an index on logs.timestamp

### DIFF
--- a/jdbc-h2/src/main/resources/migrations/h2/V1_16__log_timestamp_index.sql
+++ b/jdbc-h2/src/main/resources/migrations/h2/V1_16__log_timestamp_index.sql
@@ -1,0 +1,1 @@
+CREATE INDEX IF NOT EXISTS logs_timestamp ON logs ("timestamp");

--- a/jdbc-mysql/src/main/resources/migrations/mysql/V1_16__log_timestamp_index.sql
+++ b/jdbc-mysql/src/main/resources/migrations/mysql/V1_16__log_timestamp_index.sql
@@ -1,0 +1,1 @@
+CREATE INDEX ix_timestamp ON logs (`timestamp`);

--- a/jdbc-postgres/src/main/resources/migrations/postgres/V1_16__log_timestamp_index.sql
+++ b/jdbc-postgres/src/main/resources/migrations/postgres/V1_16__log_timestamp_index.sql
@@ -1,0 +1,1 @@
+CREATE INDEX IF NOT EXISTS logs_timestamp ON logs ("timestamp");


### PR DESCRIPTION
Fixes #2376

An issue exists in Postgres when we request ERROR logs on a wide timestamp range, it's cardinality calculation leads to ignore the existing indexes. Adding an index only on the timestamp column is a last resort for queries not finding existing indexes useful. The same index is added to the other databases even if we didn't have clues on the same issue for consistency.
