### PR TITLE
feat(core): missing secret env var should return a null secret

### DIFF
--- a/core/src/main/java/io/kestra/core/runners/RunContextLogger.java
+++ b/core/src/main/java/io/kestra/core/runners/RunContextLogger.java
@@ -126,7 +126,9 @@ public class RunContextLogger {
     }
 
     public void usedSecret(String secret) {
-        this.useSecrets.add(secret);
+        if (secret != null) {
+            this.useSecrets.add(secret);
+        }
     }
 
     public org.slf4j.Logger logger() {

--- a/core/src/main/java/io/kestra/core/secret/SecretService.java
+++ b/core/src/main/java/io/kestra/core/secret/SecretService.java
@@ -8,7 +8,6 @@ import jakarta.annotation.PostConstruct;
 import java.io.IOException;
 import java.util.Base64;
 import java.util.Map;
-import java.util.Optional;
 import java.util.stream.Collectors;
 
 @Singleton
@@ -36,11 +35,6 @@ public class SecretService {
     }
 
     public String findSecret(String tenantId, String namespace, String key) throws IOException, IllegalVariableEvaluationException {
-        return Optional
-            .ofNullable(decodedSecrets.get(key.toUpperCase()))
-            .orElseThrow(() -> new IllegalVariableEvaluationException("Unable to find secret '" + key + "'. " +
-                "You should add it in your environment variables as '" + SECRET_PREFIX + key.toUpperCase() +
-                "' with base64-encoded value."
-            ));
+        return decodedSecrets.get(key.toUpperCase());
     }
 }

--- a/core/src/test/java/io/kestra/core/runners/RunContextLoggerTest.java
+++ b/core/src/test/java/io/kestra/core/runners/RunContextLoggerTest.java
@@ -103,6 +103,7 @@ class RunContextLoggerTest {
 
         runContextLogger.usedSecret("doe.com");
         runContextLogger.usedSecret("myawesomepass");
+        runContextLogger.usedSecret(null);
 
         Logger logger = runContextLogger.logger();
         // exception are not handle and secret will not be replaced

--- a/core/src/test/java/io/kestra/core/secret/SecretFunctionTest.java
+++ b/core/src/test/java/io/kestra/core/secret/SecretFunctionTest.java
@@ -15,13 +15,13 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 
+import java.io.IOException;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.TimeoutException;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.containsString;
-import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.*;
 
 @MicronautTest
 public class SecretFunctionTest extends AbstractMemoryRunnerTest {
@@ -51,11 +51,9 @@ public class SecretFunctionTest extends AbstractMemoryRunnerTest {
     }
 
     @Test
-    void getUnknownSecret() {
-        IllegalVariableEvaluationException exception = Assertions.assertThrows(IllegalVariableEvaluationException.class, () ->
-            secretService.findSecret(null, null, "unknown_secret_key")
-        );
+    void getUnknownSecret() throws IllegalVariableEvaluationException, IOException {
+        String secret = secretService.findSecret(null, null, "unknown_secret_key");
 
-        assertThat(exception.getMessage(), containsString("Unable to find secret 'unknown_secret_key'"));
+        assertThat(secret, nullValue());
     }
 }


### PR DESCRIPTION
Fixes #3162

The only caveat is that we miss the nice message explaining that a secret is missing and how to add it.