### PR TITLE
fix(controller): return 404 when flow not found in follow API

### DIFF
--- a/core/src/main/java/io/kestra/core/repositories/FlowRepositoryInterface.java
+++ b/core/src/main/java/io/kestra/core/repositories/FlowRepositoryInterface.java
@@ -38,6 +38,15 @@ public interface FlowRepositoryInterface {
         }
     }
 
+    default Optional<Flow> findOptionalByExecution(Execution execution) {
+        return this.findById(
+            execution.getTenantId(),
+            execution.getNamespace(),
+            execution.getFlowId(),
+            Optional.of(execution.getFlowRevision())
+        );
+    }
+
     default Optional<Flow> findById(String tenantId, String namespace, String id) {
         return this.findById(tenantId, namespace, id, Optional.empty(), false);
     }

--- a/core/src/main/java/io/kestra/core/repositories/FlowRepositoryInterface.java
+++ b/core/src/main/java/io/kestra/core/repositories/FlowRepositoryInterface.java
@@ -38,15 +38,6 @@ public interface FlowRepositoryInterface {
         }
     }
 
-    default Optional<Flow> findOptionalByExecution(Execution execution) {
-        return this.findById(
-            execution.getTenantId(),
-            execution.getNamespace(),
-            execution.getFlowId(),
-            Optional.of(execution.getFlowRevision())
-        );
-    }
-
     default Optional<Flow> findById(String tenantId, String namespace, String id) {
         return this.findById(tenantId, namespace, id, Optional.empty(), false);
     }


### PR DESCRIPTION
To reproduce it, create a flow with a task that will log, execute it and then delete it from the database (not from the UI!)
Go to the execution logs page/query the `/follow` endpoint, error is now 404. 

closes #1299 

