### PR TITLE
fix(ui): make dependencies expand more clear

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -8,7 +8,7 @@
       "name": "kestra",
       "version": "0.1.0",
       "dependencies": {
-        "@kestra-io/ui-libs": "^0.0.36",
+        "@kestra-io/ui-libs": "^0.0.37",
         "@popperjs/core": "npm:@sxzz/popperjs-es@2.11.7",
         "@vue-flow/background": "^1.2.0",
         "@vue-flow/controls": "1.0.6",
@@ -292,9 +292,9 @@
       "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg=="
     },
     "node_modules/@kestra-io/ui-libs": {
-      "version": "0.0.36",
-      "resolved": "https://registry.npmjs.org/@kestra-io/ui-libs/-/ui-libs-0.0.36.tgz",
-      "integrity": "sha512-yJJa0+tVlcWVllMVHoFQVrWzR7nIyF/+6aN8u+OPnMaHR0zSUx9MwaxF6u/YYPoBw6J4zq4ysn3pspq/DGB4ag==",
+      "version": "0.0.37",
+      "resolved": "https://registry.npmjs.org/@kestra-io/ui-libs/-/ui-libs-0.0.37.tgz",
+      "integrity": "sha512-86l7zSjXkjyjc1pKTH3sYj4NemWdgq718yUiif8zye8XaI1np/gAeHtovyS+VF57Sx5rd3exKzMnN7HDwFgb0A==",
       "peerDependencies": {
         "@vue-flow/background": "^1.2.0",
         "@vue-flow/controls": "1.0.6",

--- a/ui/package.json
+++ b/ui/package.json
@@ -12,7 +12,7 @@
     "lint": "eslint . --ext .vue,.js,.jsx,.cjs,.mjs --fix"
   },
   "dependencies": {
-    "@kestra-io/ui-libs": "^0.0.36",
+    "@kestra-io/ui-libs": "^0.0.37",
     "@popperjs/core": "npm:@sxzz/popperjs-es@2.11.7",
     "@vue-flow/background": "^1.2.0",
     "@vue-flow/controls": "1.0.6",

--- a/ui/src/components/ErrorToast.vue
+++ b/ui/src/components/ErrorToast.vue
@@ -99,7 +99,7 @@
                     title: this.title || "Error",
                     message: h("div",  children),
                     position: "bottom-right",
-                    type: "error",
+                    type: this.message.variant,
                     duration: 0,
                     dangerouslyUseHTMLString: true,
                     customClass: "error-notification" + (children.length > 1 ? " large" : "")

--- a/ui/src/components/flows/FlowDependencies.vue
+++ b/ui/src/components/flows/FlowDependencies.vue
@@ -20,14 +20,17 @@
     const store = useStore();
     const axios = inject("axios")
     const router = getCurrentInstance().appContext.config.globalProperties.$router;
+    const t = getCurrentInstance().appContext.config.globalProperties.$t;
 
     const loaded = ref([]);
     const dependencies = ref({
         nodes: [],
         edges: []
     });
+    const expanded = ref([]);
 
     const isLoading = ref(false);
+    const initialLoad = ref(true);
 
     const load = (options) => {
         isLoading.value = true;
@@ -41,8 +44,21 @@
                     dependencies.value.edges.push(...response.data.edges)
                 }
 
+                if (!initialLoad.value) {
+                    let newNodes = new Set(response.data.nodes.map(n => n.uid))
+                    let oldNodes = new Set(getNodes.value.map(n => n.id))
+                    console.log(response.data.nodes)
+                    console.log(getNodes.value)
+                    store.dispatch("core/showMessage", {
+                        variant: "success",
+                        title: t("dependencies loaded"),
+                        message: t("loaded x dependencies", [...newNodes].filter(node => !oldNodes.has(node)).length),
+                    })
+                }
+
                 removeEdges(getEdges.value)
                 removeNodes(getNodes.value)
+                initialLoad.value = false
 
                 nextTick(() => {
                     generateGraph();
@@ -59,6 +75,7 @@
     };
 
     const expand = (data) => {
+        expanded.value.push(data.node.uid)
         load({namespace: data.namespace, id: data.flowId})
     };
 
@@ -110,7 +127,8 @@
                     flowId: node.id,
                     current: node.namespace === route.params.namespace && node.id === route.params.id,
                     color: "pink",
-                    link: true
+                    link: true,
+                    expandEnabled: !expanded.value.includes(node.uid)
                 }
             }]);
         }

--- a/ui/src/translations.json
+++ b/ui/src/translations.json
@@ -599,7 +599,9 @@
     "Set labels": "Set labels",
     "Set labels to execution": "Add or update the labels of the execution <code>{id}</code>",
     "Set labels done": "Successfully set the labels of the execution",
-    "bulk set labels": "Are you sure you want to set labels to <code>{executionCount}</code>  executions(s)?"
+    "bulk set labels": "Are you sure you want to set labels to <code>{executionCount}</code>  executions(s)?",
+    "dependencies loaded": "Dependencies loaded",
+    "loaded x dependencies": "{count} dependencies loaded"
   },
   "fr": {
     "id": "Identifiant",
@@ -1188,7 +1190,9 @@
     "Set labels": "Ajouter des labels",
     "Set labels to execution": "Ajouter ou mettre à jour des labels à l'exécution <code>{id}</code>",
     "Set labels done": "Labels ajoutés avec succès à l'exécution",
-    "bulk set labels": "Etes-vous sûr de vouloir ajouter des labels à <code>{executionCount}</code>  exécutions(s)?"
+    "bulk set labels": "Etes-vous sûr de vouloir ajouter des labels à <code>{executionCount}</code>  exécutions(s)?",
+    "dependencies loaded": "Dépendances chargées",
+    "loaded x dependencies": "{count} dépendances chargées"
   }
 }
 


### PR DESCRIPTION
Now hide the expand button once loaded and display a success message including the count of dependencies
![image](https://github.com/kestra-io/kestra/assets/37600690/862a63a7-499d-4072-9014-9deef9e884be)

required https://github.com/kestra-io/ui-libs/pull/29