### PR TITLE
fix(ui): disabling flow trigger toggle

### DIFF
--- a/ui/src/components/flows/FlowTriggers.vue
+++ b/ui/src/components/flows/FlowTriggers.vue
@@ -82,6 +82,7 @@
         <el-table-column column-key="disable" class-name="row-action" v-if="userCan(action.UPDATE)">
             <template #default="scope">
                 <el-switch
+                    disabled
                     size="small"
                     :active-text="$t('enabled')"
                     :model-value="!scope.row.disabled"


### PR DESCRIPTION
Resolves #3236.

![image](https://github.com/kestra-io/kestra/assets/62475782/c5eb175a-fcbf-4f15-86e7-9860b68c2fc1)

Toggle is now disabled but the text remains `enabled`. Does the text need switching, as well?