### PR TITLE
fix(core): Avoid creating empty files when splitting

### DIFF
--- a/core/src/main/java/io/kestra/core/services/StorageService.java
+++ b/core/src/main/java/io/kestra/core/services/StorageService.java
@@ -107,7 +107,7 @@ public abstract class StorageService {
 
         writers.forEach(throwConsumer(RandomAccessFile::close));
 
-        return files;
+        return files.stream().filter(p -> p.toFile().length() > 0).toList();
     }
 
 }


### PR DESCRIPTION
closes #3207 