### PR TITLE
fix(core): Avoid creating empty files when splitting

### DIFF
--- a/core/src/main/java/io/kestra/core/services/StorageService.java
+++ b/core/src/main/java/io/kestra/core/services/StorageService.java
@@ -45,6 +45,7 @@ public abstract class StorageService {
 
             return splited
                 .stream()
+                .filter(path -> path.toFile().length() > 0)
                 .map(throwFunction(path -> runContext.putTempFile(path.toFile())))
                 .collect(Collectors.toList());
         }


### PR DESCRIPTION
closes #3210 