### PR TITLE
feat(core): enable Flyway migration logs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -126,6 +126,7 @@ allprojects {
         // logs
         implementation "org.slf4j:slf4j-api"
         implementation "ch.qos.logback:logback-classic"
+        implementation "org.codehaus.janino:janino:3.1.12"
         implementation group: 'org.apache.logging.log4j', name: 'log4j-to-slf4j', version: '2.23.0'
         implementation group: 'org.slf4j', name: 'jul-to-slf4j', version: slf4jVersion
         implementation group: 'org.slf4j', name: 'jcl-over-slf4j', version: slf4jVersion

--- a/core/src/main/resources/logback/base.xml
+++ b/core/src/main/resources/logback/base.xml
@@ -32,7 +32,11 @@
     <!-- Elastic deprecation warning that is not compatible with OpenSearch, we must disable all warnings ... -->
     <logger name="org.opensearch.client.RestClient" level="ERROR" />
 
-    <!-- Flyway log warnings for out-of-order or when using IF NOT EXISTS -->
-    <logger name="org.flywaydb.core.internal.command.DbMigrate" level="ERROR" />
+    <!--
+        We enable INFO for DbMigrate otherwise there is nothing displayed on the console when a migration is ongoing,
+        which can be make thinking Kestra is not starting when the migration is long.
+    -->
+    <logger name="org.flywaydb.core.internal.command.DbMigrate" level="INFO" />
+    <!-- Flyway log when using IF NOT EXISTS -->
     <logger name="org.flywaydb.core.internal.sqlscript.DefaultSqlScriptExecutor" level="ERROR" />
 </included>

--- a/core/src/main/resources/logback/ecs.xml
+++ b/core/src/main/resources/logback/ecs.xml
@@ -20,6 +20,13 @@
         <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
             <level>WARN</level>
         </filter>
+        <filter class="ch.qos.logback.core.filter.EvaluatorFilter">
+            <evaluator>
+                <expression>return message.contains("outOfOrder mode is active. Migration of schema");</expression>
+            </evaluator>
+            <OnMismatch>NEUTRAL</OnMismatch>
+            <OnMatch>DENY</OnMatch>
+        </filter>
         <encoder class="co.elastic.logging.logback.EcsEncoder" />
     </appender>
 </included>

--- a/core/src/main/resources/logback/gcp.xml
+++ b/core/src/main/resources/logback/gcp.xml
@@ -23,6 +23,13 @@
         <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
             <level>WARN</level>
         </filter>
+        <filter class="ch.qos.logback.core.filter.EvaluatorFilter">
+            <evaluator>
+                <expression>return message.contains("outOfOrder mode is active. Migration of schema");</expression>
+            </evaluator>
+            <OnMismatch>NEUTRAL</OnMismatch>
+            <OnMatch>DENY</OnMatch>
+        </filter>
         <encoder class="ch.qos.logback.core.encoder.LayoutWrappingEncoder">
             <layout class="io.kestra.cli.logger.StackdriverJsonLayout">
             </layout>

--- a/core/src/main/resources/logback/text.xml
+++ b/core/src/main/resources/logback/text.xml
@@ -22,6 +22,13 @@
         <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
             <level>WARN</level>
         </filter>
+        <filter class="ch.qos.logback.core.filter.EvaluatorFilter">
+            <evaluator>
+                <expression>return message.contains("outOfOrder mode is active. Migration of schema");</expression>
+            </evaluator>
+            <OnMismatch>NEUTRAL</OnMismatch>
+            <OnMatch>DENY</OnMatch>
+        </filter>
         <encoder>
             <pattern>${pattern}</pattern>
         </encoder>


### PR DESCRIPTION
Fixes #3172

Thanks to this new log configuration, there is now logs for Flyway which would avoid thinking that nothing happens when a long migration is in process:

```
2024-03-12 10:52:47,520 INFO  main         o.f.core.internal.command.DbMigrate Current version of schema "public": 1.20
2024-03-12 10:52:47,523 INFO  main         o.f.core.internal.command.DbMigrate Schema "public" is up to date. No migration necessary.
```