### PR TITLE
feat: change the key of SubflowExecutionResult

### DIFF
--- a/core/src/main/java/io/kestra/core/queues/QueueService.java
+++ b/core/src/main/java/io/kestra/core/queues/QueueService.java
@@ -38,7 +38,7 @@ public class QueueService {
         } else if (object.getClass() == SubflowExecution.class) {
             return ((SubflowExecution<?>) object).getExecution().getId();
         } else if (object.getClass() == SubflowExecutionResult.class) {
-            return ((SubflowExecutionResult) object).getParentTaskRun().getId();
+            return ((SubflowExecutionResult) object).getExecutionId();
         } else if (object.getClass() == ExecutionDelay.class) {
             return ((ExecutionDelay) object).uid();
         } else if (object.getClass() == ExecutorState.class) {


### PR DESCRIPTION
There can be multiple subflow execution results er parent taskrun id: one for each generated subflow executions. So we must use executionId as a key instead.
