### PR TITLE
fix/wrong-inputstream-size-on-put-file

### DIFF
--- a/webserver/src/main/java/io/kestra/webserver/controllers/NamespaceFileController.java
+++ b/webserver/src/main/java/io/kestra/webserver/controllers/NamespaceFileController.java
@@ -178,7 +178,13 @@ public class NamespaceFileController {
                 }
             }
         } else {
-            try(BufferedInputStream inputStream = new BufferedInputStream(fileContent.getInputStream())) {
+            try(BufferedInputStream inputStream = new BufferedInputStream(fileContent.getInputStream()) {
+                // Done to bypass the wrong available() output of the CompletedFileUpload InputStream
+                @Override
+                public synchronized int available() {
+                    return (int) fileContent.getSize();
+                }
+            }) {
                 putNamespaceFile(tenantId, namespace, path, inputStream);
             }
         }


### PR DESCRIPTION
fixes an issue where S3 storage would not write data properly as we provide a wrong size value from the available() method of the InputStream. I decided to go for this override instead of modifying S3 storage implementation as it would require passing a new parameter (ence add a new method signature to storage and change every storage).