### PR TITLE
feat(core): add Pebble YAML filter and YAML function

### DIFF
--- a/core/src/main/java/io/kestra/core/runners/pebble/Extension.java
+++ b/core/src/main/java/io/kestra/core/runners/pebble/Extension.java
@@ -75,6 +75,7 @@ public class Extension extends AbstractExtension {
         filters.put("substringAfter", new SubstringAfterFilter());
         filters.put("substringAfterLast", new SubstringAfterLastFilter());
         filters.put("flatten",new FlattenFilter());
+        filters.put("yaml",new YamlFilter());
         return filters;
     }
 
@@ -101,6 +102,7 @@ public class Extension extends AbstractExtension {
         }
         functions.put("encrypt", new EncryptFunction());
         functions.put("decrypt", new DecryptFunction());
+        functions.put("yaml", new YamlFunction());
 
         return functions;
     }

--- a/core/src/main/java/io/kestra/core/runners/pebble/filters/YamlFilter.java
+++ b/core/src/main/java/io/kestra/core/runners/pebble/filters/YamlFilter.java
@@ -1,0 +1,58 @@
+package io.kestra.core.runners.pebble.filters;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import com.fasterxml.jackson.dataformat.yaml.YAMLGenerator;
+import com.fasterxml.jackson.datatype.guava.GuavaModule;
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.fasterxml.jackson.module.paramnames.ParameterNamesModule;
+import io.pebbletemplates.pebble.error.PebbleException;
+import io.pebbletemplates.pebble.extension.Filter;
+import io.pebbletemplates.pebble.template.EvaluationContext;
+import io.pebbletemplates.pebble.template.PebbleTemplate;
+import org.yaml.snakeyaml.LoaderOptions;
+
+import java.util.List;
+import java.util.Map;
+
+public class YamlFilter implements Filter {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper(
+        YAMLFactory
+            .builder()
+            .loaderOptions(new LoaderOptions())
+            .configure(YAMLGenerator.Feature.MINIMIZE_QUOTES, true)
+            .configure(YAMLGenerator.Feature.WRITE_DOC_START_MARKER, false)
+            .configure(YAMLGenerator.Feature.USE_NATIVE_TYPE_ID, false)
+            .configure(YAMLGenerator.Feature.SPLIT_LINES, false)
+            .configure(YAMLGenerator.Feature.INDENT_ARRAYS, true)
+            .configure(YAMLGenerator.Feature.USE_PLATFORM_LINE_BREAKS, true)
+            .build()
+        )
+        .configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false)
+        .registerModule(new JavaTimeModule())
+        .registerModule(new Jdk8Module())
+        .registerModule(new ParameterNamesModule())
+        .registerModules(new GuavaModule());
+
+    @Override
+    public List<String> getArgumentNames() {
+        return null;
+    }
+
+    @Override
+    public Object apply(Object input, Map<String, Object> args, PebbleTemplate self, EvaluationContext context, int lineNumber) throws PebbleException {
+        if (input == null) {
+            return "null";
+        }
+
+        try {
+            return MAPPER.writeValueAsString(input);
+        } catch (JsonProcessingException e) {
+            throw new PebbleException(e, "Unable to transform to yaml value '" + input +  "' with type '" + input.getClass().getName() + "'", lineNumber, self.getName());
+        }
+    }
+}

--- a/core/src/main/java/io/kestra/core/runners/pebble/filters/YamlFilter.java
+++ b/core/src/main/java/io/kestra/core/runners/pebble/filters/YamlFilter.java
@@ -13,7 +13,6 @@ import io.pebbletemplates.pebble.error.PebbleException;
 import io.pebbletemplates.pebble.extension.Filter;
 import io.pebbletemplates.pebble.template.EvaluationContext;
 import io.pebbletemplates.pebble.template.PebbleTemplate;
-import org.yaml.snakeyaml.LoaderOptions;
 
 import java.util.List;
 import java.util.Map;
@@ -21,16 +20,14 @@ import java.util.Map;
 public class YamlFilter implements Filter {
 
     private static final ObjectMapper MAPPER = new ObjectMapper(
-        YAMLFactory
-            .builder()
-            .loaderOptions(new LoaderOptions())
+        new YAMLFactory()
             .configure(YAMLGenerator.Feature.MINIMIZE_QUOTES, true)
             .configure(YAMLGenerator.Feature.WRITE_DOC_START_MARKER, false)
             .configure(YAMLGenerator.Feature.USE_NATIVE_TYPE_ID, false)
             .configure(YAMLGenerator.Feature.SPLIT_LINES, false)
             .configure(YAMLGenerator.Feature.INDENT_ARRAYS, true)
             .configure(YAMLGenerator.Feature.USE_PLATFORM_LINE_BREAKS, true)
-            .build()
+            .configure(YAMLGenerator.Feature.ALWAYS_QUOTE_NUMBERS_AS_STRINGS, false)
         )
         .configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false)
         .registerModule(new JavaTimeModule())

--- a/core/src/main/java/io/kestra/core/runners/pebble/functions/YamlFunction.java
+++ b/core/src/main/java/io/kestra/core/runners/pebble/functions/YamlFunction.java
@@ -1,0 +1,47 @@
+package io.kestra.core.runners.pebble.functions;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import com.fasterxml.jackson.dataformat.yaml.snakeyaml.error.YAMLException;
+import io.pebbletemplates.pebble.error.PebbleException;
+import io.pebbletemplates.pebble.extension.Function;
+import io.pebbletemplates.pebble.template.EvaluationContext;
+import io.pebbletemplates.pebble.template.PebbleTemplate;
+
+import java.util.List;
+import java.util.Map;
+
+public class YamlFunction implements Function {
+    final static ObjectMapper MAPPER = new ObjectMapper(new YAMLFactory()).findAndRegisterModules();
+    private static final TypeReference<Object> TYPE_REFERENCE = new TypeReference<>() {};
+
+    public List<String> getArgumentNames() {
+        return List.of("yaml");
+    }
+
+    @Override
+    public Object execute(Map<String, Object> args, PebbleTemplate self, EvaluationContext context, int lineNumber) {
+        if (!args.containsKey("yaml")) {
+            throw new PebbleException(null, "The 'yaml' function expects an argument 'yaml'.", lineNumber, self.getName());
+        }
+
+        if (!(args.get("yaml") instanceof String)) {
+            throw new PebbleException(null, "The 'yaml' function expects an argument 'yaml' with type string.", lineNumber, self.getName());
+        }
+
+        String yaml = (String) args.get("yaml");
+
+        try {
+            return MAPPER.readValue(yaml, TYPE_REFERENCE);
+        } catch (YAMLException e) {
+            throw new PebbleException(null, "Invalid yaml: " + e.getMessage(), lineNumber, self.getName());
+        } catch (JsonMappingException e) {
+            throw new PebbleException(null, "Invalid yaml: " + e.getMessage(), lineNumber, self.getName());
+        } catch (JsonProcessingException e) {
+            throw new PebbleException(null, "Invalid yaml: " + e.getMessage(), lineNumber, self.getName());
+        }
+    }
+}

--- a/core/src/main/java/io/kestra/core/runners/pebble/functions/YamlFunction.java
+++ b/core/src/main/java/io/kestra/core/runners/pebble/functions/YamlFunction.java
@@ -15,7 +15,9 @@ import java.util.List;
 import java.util.Map;
 
 public class YamlFunction implements Function {
-    final static ObjectMapper MAPPER = new ObjectMapper(new YAMLFactory()).findAndRegisterModules();
+    final static ObjectMapper MAPPER = new ObjectMapper(
+        new YAMLFactory()
+    ).findAndRegisterModules();
     private static final TypeReference<Object> TYPE_REFERENCE = new TypeReference<>() {};
 
     public List<String> getArgumentNames() {

--- a/core/src/test/java/io/kestra/core/runners/pebble/filters/YamlFilterTest.java
+++ b/core/src/test/java/io/kestra/core/runners/pebble/filters/YamlFilterTest.java
@@ -46,29 +46,27 @@ class YamlFilterTest {
         );
 
         String render = variableRenderer.render("{{ vars.second.string | yaml }}", vars);
-        assertThat(render, is("\"string\""));
+        assertThat(render, is("string\n"));
 
         render = variableRenderer.render("{{ vars.second.int | yaml }}", vars);
-        assertThat(render, is("1"));
+        assertThat(render, is("1\n"));
 
         render = variableRenderer.render("{{ vars.second.float | yaml }}", vars);
-        assertThat(render, is("1.123"));
+        assertThat(render, is("1.123\n"));
 
         render = variableRenderer.render("{{ vars.second.list | yaml }}", vars);
-        assertThat(render, is("[\"string\",1,1.123]"));
+        assertThat(render, is(" - string\n - 1\n - 1.123\n"));
 
         render = variableRenderer.render("{{ vars.second.bool | yaml }}", vars);
-        assertThat(render, is("true"));
+        assertThat(render, is("true\n"));
 
         render = variableRenderer.render("{{ vars.second.date | yaml }}", vars);
-        assertThat(render, is("\"" + date.format(DateTimeFormatter.ISO_OFFSET_DATE_TIME) + "\""));
+        assertThat(render, is( date.format(DateTimeFormatter.ISO_OFFSET_DATE_TIME) + "\n"));
 
         render = variableRenderer.render("{{ vars.second.map | yaml }}", vars);
-        assertThat(render, containsString("\"int\":1"));
-        assertThat(render, containsString("\"int\":1"));
-        assertThat(render, containsString("\"float\":1.123"));
-        assertThat(render, containsString("\"string\":\"string\""));
-        assertThat(render, startsWith("{"));
-        assertThat(render, endsWith("}"));
+        assertThat(render, containsString("int: 1\n"));
+        assertThat(render, containsString("int: 1\n"));
+        assertThat(render, containsString("float: 1.123\n"));
+        assertThat(render, containsString("string: string\n"));
     }
 }

--- a/core/src/test/java/io/kestra/core/runners/pebble/filters/YamlFilterTest.java
+++ b/core/src/test/java/io/kestra/core/runners/pebble/filters/YamlFilterTest.java
@@ -1,0 +1,74 @@
+package io.kestra.core.runners.pebble.filters;
+
+import com.google.common.collect.ImmutableMap;
+import io.kestra.core.exceptions.IllegalVariableEvaluationException;
+import io.kestra.core.runners.VariableRenderer;
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.Test;
+
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Arrays;
+import java.util.Map;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+
+@MicronautTest
+class YamlFilterTest {
+    @Inject
+    VariableRenderer variableRenderer;
+
+    @Test
+    void map() throws IllegalVariableEvaluationException {
+        ZonedDateTime date = ZonedDateTime.parse("2013-09-08T16:19:00+02").withZoneSameLocal(ZoneId.systemDefault());
+
+        ImmutableMap<String, Object> vars = ImmutableMap.of(
+            "vars", ImmutableMap.of("second", Map.of(
+                "string", "string",
+                "int", 1,
+                "float", 1.123F,
+                "list", Arrays.asList(
+                    "string",
+                    1,
+                    1.123F
+                ),
+                "bool", true,
+                "date", date,
+                "map", Map.of(
+                    "string", "string",
+                    "int", 1,
+                    "float", 1.123F
+                )
+            ))
+        );
+
+        String render = variableRenderer.render("{{ vars.second.string | yaml }}", vars);
+        assertThat(render, is("\"string\""));
+
+        render = variableRenderer.render("{{ vars.second.int | yaml }}", vars);
+        assertThat(render, is("1"));
+
+        render = variableRenderer.render("{{ vars.second.float | yaml }}", vars);
+        assertThat(render, is("1.123"));
+
+        render = variableRenderer.render("{{ vars.second.list | yaml }}", vars);
+        assertThat(render, is("[\"string\",1,1.123]"));
+
+        render = variableRenderer.render("{{ vars.second.bool | yaml }}", vars);
+        assertThat(render, is("true"));
+
+        render = variableRenderer.render("{{ vars.second.date | yaml }}", vars);
+        assertThat(render, is("\"" + date.format(DateTimeFormatter.ISO_OFFSET_DATE_TIME) + "\""));
+
+        render = variableRenderer.render("{{ vars.second.map | yaml }}", vars);
+        assertThat(render, containsString("\"int\":1"));
+        assertThat(render, containsString("\"int\":1"));
+        assertThat(render, containsString("\"float\":1.123"));
+        assertThat(render, containsString("\"string\":\"string\""));
+        assertThat(render, startsWith("{"));
+        assertThat(render, endsWith("}"));
+    }
+}

--- a/core/src/test/java/io/kestra/core/runners/pebble/functions/YamlFunctionTest.java
+++ b/core/src/test/java/io/kestra/core/runners/pebble/functions/YamlFunctionTest.java
@@ -1,12 +1,11 @@
 package io.kestra.core.runners.pebble.functions;
 
+import com.google.common.collect.ImmutableMap;
 import io.kestra.core.exceptions.IllegalVariableEvaluationException;
 import io.kestra.core.runners.VariableRenderer;
 import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
 import jakarta.inject.Inject;
 import org.junit.jupiter.api.Test;
-
-import java.util.Map;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
@@ -18,13 +17,68 @@ class YamlFunctionTest {
 
     @Test
     void fromString() throws IllegalVariableEvaluationException {
-        String render = variableRenderer.render("{{ yaml('{\"test1\": 1, \"test2\": 2, \"test3\": 3}').test1 }}", Map.of());
-        assertThat(render, is("1"));
 
-        render = variableRenderer.render("{{ yaml('{\"test1\": [{\"test1\": 666}, 2, 3], \"test2\": 2, \"test3\": 3}').test1[0].test1 }}", Map.of());
-        assertThat(render, is("666"));
+        ImmutableMap<String, Object> runContext = ImmutableMap.of(
+            "yaml",
+            """
+                # comment
+                string: string
+                int: 123
+                bool: true
+                float: 1.23
+                instant: "1918-02-24T00:00:00Z"
+                date: "1991-08-20"
+                time: "23:59:59"
+                duration: "PT5M6S"
+                'null':
+                object:
+                  key: "value"
+                  child:
+                    key: "value"
+                array:
+                  - string
+                reference: &ref
+                    key: reference
+                default: *ref
+                """
+        );
 
-        render = variableRenderer.render("{{ yaml('[1, 2, 3]')[0] }}", Map.of());
-        assertThat(render, is("1"));
+        String render;
+        render = variableRenderer.render("{{ yaml(yaml).string }}", runContext);
+        assertThat(render, is("string"));
+
+        render = variableRenderer.render("{{ yaml(yaml).int }}", runContext);
+        assertThat(render, is("123"));
+
+        render = variableRenderer.render("{{ yaml(yaml).bool }}", runContext);
+        assertThat(render, is("true"));
+
+        render = variableRenderer.render("{{ yaml(yaml).float }}", runContext);
+        assertThat(render, is("1.23"));
+
+        render = variableRenderer.render("{{ yaml(yaml).instant }}", runContext);
+        assertThat(render, is("1918-02-24T00:00:00Z"));
+
+        render = variableRenderer.render("{{ yaml(yaml).date }}", runContext);
+        assertThat(render, is("1991-08-20"));
+
+        render = variableRenderer.render("{{ yaml(yaml).time }}", runContext);
+        assertThat(render, is("23:59:59"));
+
+        // Kestra internally does not handle null values in objects
+        // render = variableRenderer.render("{{ yaml(yaml).null ?? '' }}", runContext);
+        // assertThat(render, is(""));
+
+        render = variableRenderer.render("{{ yaml(yaml).object.child.key }}", runContext);
+        assertThat(render, is("value"));
+
+        render = variableRenderer.render("{{ yaml(yaml).array[0] }}", runContext);
+        assertThat(render, is("string"));
+
+        // as of 2024-03-15 Jackson YAML does not support anchors
+        // https://github.com/FasterXML/jackson-dataformats-text/issues/98
+        // render = variableRenderer.render("{{ yaml(yaml).default.key }}", runContext);
+        // assertThat(render, is("reference"));
+
     }
 }

--- a/core/src/test/java/io/kestra/core/runners/pebble/functions/YamlFunctionTest.java
+++ b/core/src/test/java/io/kestra/core/runners/pebble/functions/YamlFunctionTest.java
@@ -1,0 +1,30 @@
+package io.kestra.core.runners.pebble.functions;
+
+import io.kestra.core.exceptions.IllegalVariableEvaluationException;
+import io.kestra.core.runners.VariableRenderer;
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+@MicronautTest
+class YamlFunctionTest {
+    @Inject
+    VariableRenderer variableRenderer;
+
+    @Test
+    void fromString() throws IllegalVariableEvaluationException {
+        String render = variableRenderer.render("{{ yaml('{\"test1\": 1, \"test2\": 2, \"test3\": 3}').test1 }}", Map.of());
+        assertThat(render, is("1"));
+
+        render = variableRenderer.render("{{ yaml('{\"test1\": [{\"test1\": 666}, 2, 3], \"test2\": 2, \"test3\": 3}').test1[0].test1 }}", Map.of());
+        assertThat(render, is("666"));
+
+        render = variableRenderer.render("{{ yaml('[1, 2, 3]')[0] }}", Map.of());
+        assertThat(render, is("1"));
+    }
+}

--- a/ui/src/components/logs/LogsWrapper.vue
+++ b/ui/src/components/logs/LogsWrapper.vue
@@ -3,7 +3,7 @@
     <section :class="{'container': !embed}" class="log-panel">
         <div class="log-content">
             <data-table @page-changed="onPageChanged" ref="dataTable" :total="total" :size="pageSize" :page="pageNumber" :embed="embed">
-                <template #navbar>
+                <template #navbar v-if="!embed">
                     <el-form-item>
                         <search-field />
                     </el-form-item>


### PR DESCRIPTION
### What changes are being made and why?
In reference to issue #3258

#### `yaml()` function
Similarily to `json()` [function](https://kestra.io/docs/concepts/expression/function#json) [[code](https://github.com/kestra-io/kestra/blob/develop/core/src/main/java/io/kestra/core/runners/pebble/functions/JsonFunction.java)] support the deserialization / objectification of YAML strings to variables.

#### `| yaml` filter
Similarily to `| json` [filter](https://kestra.io/docs/concepts/expression/filter/json#json) [[code](https://github.com/kestra-io/kestra/blob/develop/core/src/main/java/io/kestra/core/runners/pebble/filters/JsonFilter.java)] support the serialization / construction of YAML strings from variables.

### How the changes have been QAed?
Tests for both YamlFilter and YamlFunction are included in the PR.
Sample code for testing YAML filter and function in Kestra tasks.

```yaml
id: pebble-yaml-filter-function
namespace: kestra.test

# https://kestra.io/docs/workflow-components/labels
labels:
  label: value

# https://kestra.io/docs/workflow-components/inputs
inputs:
  - name: string
    type: STRING
    required: false
    defaults: "string"

  - name: int
    type: INT
    required: false
    defaults: 123

  - name: bool
    type: BOOLEAN
    required: false
    defaults: true

  - name: float
    type: FLOAT
    required: false
    defaults: 1.23

  - name: instant
    type: DATETIME
    required: false
    defaults: "1918-02-24T01:02:03.04Z"

  - name: date
    type: DATE
    required: false
    defaults: "1991-08-20"

  - name: json
    type: JSON
    required: false
    defaults: |
      {
        "string": "string",
        "integer": 123,
        "float": 1.23,
        "boolean": false,
        "null": null,
        "object": {},
        "array": [
          "string",
          123,
          1.23,
          false,
          null,
          {},
          []
        ]
      }

  - name: uri
    type: URI
    required: false
    defaults: "https://kestra.io"

  - name: nested.object
    type: STRING
    required: false
    defaults: "value"

  - name: nested.object.child
    type: STRING
    required: false
    defaults: "value"

# https://kestra.io/docs/workflow-components/variables
variables:
  string: "string"
  int: 123
  bool: true
  float: 1.23
  instant: "1918-02-24T00:00:00Z"
  date: "1991-08-20"
  time: "23:59:59"
  duration: "PT5M6S"
  json:
    string: string
    integer: 123
    float: 1.23
    boolean: false
    'null':
    object: {}
    array:
      - string
      - 123
      - 1.23
      - false
      -
      - {}
      - []
  uri: "https://kestra.io"
  object:
    key: "value"
    child:
      key: "value"
  array:
    - Value 1
    - Value 2
    - Value 3
  yaml: |
    string: string
    integer: 123
    float: 1.23
    boolean: false
    'null':
    object: {}
    array:
      - string
      - 123
      - 1.23
      - false
      -
      - {}
      - []  

tasks:
  - id: yaml_filter
    type: "io.kestra.core.tasks.log.Log"
    message: |
      {{ "string" | yaml }}
      {{ 1 | yaml }}
      {{ 1.123 | yaml }}
      {{ true | yaml }}
      {{ 1 | yaml }}
      {{ [1, true, "string", [0, false, "string"]] | yaml }}
      {{ {"key": "value", "object": {"a":"b"}} | yaml }}

  - id: yaml_kestra
    type: "io.kestra.core.tasks.log.Log"
    disabled: false
    message: |
      ---
      # flow
      {{ flow      ?? null | yaml }}
      ---
      # execution
      {{ execution ?? null | yaml }}
      ---
      # task
      {{ task      ?? null | yaml }}
      ---
      # taskrun
      {{ taskrun   ?? null | yaml }}
      ---
      # parent
      {{ parent    ?? null | yaml }}
      ---
      # parents
      {{ parents   ?? null | yaml }}
      ---
      # trigger
      {{ trigger   ?? null | yaml }}
      ---
      # vars
      {{ vars      ?? null | yaml }}
      ---
      # inputs
      {{ inputs    ?? null | yaml }}
      ---
      # outputs
      {{ outputs   ?? null | yaml }}
      ---
      # labels
      {{ labels    ?? null | yaml }}


  - id: yaml_function
    type: "io.kestra.core.tasks.log.Log"
    message: |
      {{ yaml(vars.yaml) }}

  - id: yaml2yaml
    type: "io.kestra.core.tasks.log.Log"
    message: |
      {{ yaml(vars.yaml) | yaml }}      
```
