### PR TITLE
feat(core): add Pebble filters indent, nindent

### DIFF
--- a/core/src/main/java/io/kestra/core/runners/pebble/AbstractIndent.java
+++ b/core/src/main/java/io/kestra/core/runners/pebble/AbstractIndent.java
@@ -1,0 +1,37 @@
+package io.kestra.core.runners.pebble;
+
+import java.util.List;
+import java.util.Map;
+
+public abstract class AbstractIndent {
+    public List<String> getArgumentNames() {
+        return List.of("amount", "prefix");
+    }
+
+    protected static String prefix(Map<String, Object> args) {
+        if (args.containsKey("prefix")) {
+            return (String) args.get("prefix");
+        } else {
+            return " ";
+        }
+    }
+
+    protected static String getLineSeparator(String input) {
+        if (input == null)
+            return System.lineSeparator();
+
+        if (input.contains("\r\n"))
+            return "\r\n"; // CRLF
+
+        if (input.contains("\n\r"))
+            return "\n\r"; // LFCR
+
+        if (input.contains("\n"))
+            return "\n"; // LF
+
+        if (input.contains("\r"))
+            return "\r"; // CR
+
+        return System.lineSeparator(); // System default
+    }
+}

--- a/core/src/main/java/io/kestra/core/runners/pebble/AbstractIndent.java
+++ b/core/src/main/java/io/kestra/core/runners/pebble/AbstractIndent.java
@@ -1,5 +1,9 @@
 package io.kestra.core.runners.pebble;
 
+import io.pebbletemplates.pebble.error.PebbleException;
+import io.pebbletemplates.pebble.template.EvaluationContext;
+import io.pebbletemplates.pebble.template.PebbleTemplate;
+
 import java.util.List;
 import java.util.Map;
 
@@ -33,5 +37,36 @@ public abstract class AbstractIndent {
             return "\r"; // CR
 
         return System.lineSeparator(); // System default
+    }
+
+    protected Object abstractApply(Object input, Map<String, Object> args, PebbleTemplate self, EvaluationContext context, int lineNumber, String indentType) throws PebbleException {
+        if (input == null) {
+            return null;
+        }
+        if (input.toString().isEmpty()) {
+            return input.toString();
+        }
+
+        if (!args.containsKey("amount")) {
+            throw new PebbleException(null, String.format("The '%s' filter expects an integer as argument 'amount'.", indentType), lineNumber, self.getName());
+        }
+
+        int amount = ((Long) args.get("amount")).intValue();
+        if (!(amount >= 0)) {
+            throw new PebbleException(null, String.format("The '%s' filter expects a positive integer >=0 as argument 'amount'.", indentType), lineNumber, self.getName());
+        }
+
+        String prefix = prefix(args);
+        String newLine = getLineSeparator(input.toString());
+
+        if (indentType.equals("indent"))
+            // indent filter adds N amount of spaces to each line except for the first one (assuming the first line is already indented in place)
+            return input.toString().replace(newLine, newLine + prefix.repeat(amount));
+        else if (indentType.equals("nindent")) {
+            // nindent filter adds a newline to the string and indents each line by defined amount of spaces
+            return (newLine + input).replace(newLine, newLine + prefix.repeat(amount));
+        }
+        throw new PebbleException(null, String.format("Unknow indent type '%s'.", indentType), lineNumber, self.getName());
+
     }
 }

--- a/core/src/main/java/io/kestra/core/runners/pebble/Extension.java
+++ b/core/src/main/java/io/kestra/core/runners/pebble/Extension.java
@@ -75,6 +75,8 @@ public class Extension extends AbstractExtension {
         filters.put("substringAfter", new SubstringAfterFilter());
         filters.put("substringAfterLast", new SubstringAfterLastFilter());
         filters.put("flatten",new FlattenFilter());
+        filters.put("indent",new IndentFilter());
+        filters.put("nindent",new NindentFilter());
         return filters;
     }
 

--- a/core/src/main/java/io/kestra/core/runners/pebble/filters/IndentFilter.java
+++ b/core/src/main/java/io/kestra/core/runners/pebble/filters/IndentFilter.java
@@ -1,0 +1,36 @@
+package io.kestra.core.runners.pebble.filters;
+
+import io.kestra.core.runners.pebble.AbstractIndent;
+import io.pebbletemplates.pebble.error.PebbleException;
+import io.pebbletemplates.pebble.extension.Filter;
+import io.pebbletemplates.pebble.template.EvaluationContext;
+import io.pebbletemplates.pebble.template.PebbleTemplate;
+
+import java.util.Map;
+
+public class IndentFilter extends AbstractIndent implements Filter {
+    @Override
+    public Object apply(Object input, Map<String, Object> args, PebbleTemplate self, EvaluationContext context, int lineNumber) throws PebbleException {
+        if (input == null) {
+            return null;
+        }
+        if (input.toString().isEmpty()) {
+            return input.toString();
+        }
+
+        if (!args.containsKey("amount")) {
+            throw new PebbleException(null, "The 'indent' filter expects an integer as argument 'amount'.", lineNumber, self.getName());
+        }
+
+        int amount = ((Long) args.get("amount")).intValue();
+        if (!(amount >= 0)) {
+            throw new PebbleException(null, "The 'indent' filter expects a positive integer >=0 as argument 'amount'.", lineNumber, self.getName());
+        }
+
+        String prefix = prefix(args);
+        String newLine = getLineSeparator(input.toString());
+
+        // indent filter adds N amount of spaces to each line except for the first one (assuming the first line is already indented in place)
+        return input.toString().replace(newLine, newLine + prefix.repeat(amount));
+    }
+}

--- a/core/src/main/java/io/kestra/core/runners/pebble/filters/IndentFilter.java
+++ b/core/src/main/java/io/kestra/core/runners/pebble/filters/IndentFilter.java
@@ -11,26 +11,6 @@ import java.util.Map;
 public class IndentFilter extends AbstractIndent implements Filter {
     @Override
     public Object apply(Object input, Map<String, Object> args, PebbleTemplate self, EvaluationContext context, int lineNumber) throws PebbleException {
-        if (input == null) {
-            return null;
-        }
-        if (input.toString().isEmpty()) {
-            return input.toString();
-        }
-
-        if (!args.containsKey("amount")) {
-            throw new PebbleException(null, "The 'indent' filter expects an integer as argument 'amount'.", lineNumber, self.getName());
-        }
-
-        int amount = ((Long) args.get("amount")).intValue();
-        if (!(amount >= 0)) {
-            throw new PebbleException(null, "The 'indent' filter expects a positive integer >=0 as argument 'amount'.", lineNumber, self.getName());
-        }
-
-        String prefix = prefix(args);
-        String newLine = getLineSeparator(input.toString());
-
-        // indent filter adds N amount of spaces to each line except for the first one (assuming the first line is already indented in place)
-        return input.toString().replace(newLine, newLine + prefix.repeat(amount));
+        return abstractApply(input, args, self, context, lineNumber, "indent");
     }
 }

--- a/core/src/main/java/io/kestra/core/runners/pebble/filters/NindentFilter.java
+++ b/core/src/main/java/io/kestra/core/runners/pebble/filters/NindentFilter.java
@@ -1,0 +1,36 @@
+package io.kestra.core.runners.pebble.filters;
+
+import io.kestra.core.runners.pebble.AbstractIndent;
+import io.pebbletemplates.pebble.error.PebbleException;
+import io.pebbletemplates.pebble.extension.Filter;
+import io.pebbletemplates.pebble.template.EvaluationContext;
+import io.pebbletemplates.pebble.template.PebbleTemplate;
+
+import java.util.Map;
+
+public class NindentFilter extends AbstractIndent implements Filter {
+    @Override
+    public Object apply(Object input, Map<String, Object> args, PebbleTemplate self, EvaluationContext context, int lineNumber) throws PebbleException {
+        if (input == null) {
+            return null;
+        }
+        if (input.toString().isEmpty()) {
+            return input.toString();
+        }
+
+        if (!args.containsKey("amount")) {
+            throw new PebbleException(null, "The 'nindent' filter expects an integer as argument 'amount'.", lineNumber, self.getName());
+        }
+
+        int amount = ((Long) args.get("amount")).intValue();
+        if (!(amount >= 0)) {
+            throw new PebbleException(null, "The 'nindent' filter expects a positive integer >=0 as argument 'amount'.", lineNumber, self.getName());
+        }
+
+        String prefix = prefix(args);
+        String newLine = getLineSeparator(input.toString());
+
+        // nindent filter adds a newline to the string and indents each line by defined amount of spaces
+        return (newLine + input).replace(newLine, newLine + prefix.repeat(amount));
+    }
+}

--- a/core/src/main/java/io/kestra/core/runners/pebble/filters/NindentFilter.java
+++ b/core/src/main/java/io/kestra/core/runners/pebble/filters/NindentFilter.java
@@ -11,26 +11,6 @@ import java.util.Map;
 public class NindentFilter extends AbstractIndent implements Filter {
     @Override
     public Object apply(Object input, Map<String, Object> args, PebbleTemplate self, EvaluationContext context, int lineNumber) throws PebbleException {
-        if (input == null) {
-            return null;
-        }
-        if (input.toString().isEmpty()) {
-            return input.toString();
-        }
-
-        if (!args.containsKey("amount")) {
-            throw new PebbleException(null, "The 'nindent' filter expects an integer as argument 'amount'.", lineNumber, self.getName());
-        }
-
-        int amount = ((Long) args.get("amount")).intValue();
-        if (!(amount >= 0)) {
-            throw new PebbleException(null, "The 'nindent' filter expects a positive integer >=0 as argument 'amount'.", lineNumber, self.getName());
-        }
-
-        String prefix = prefix(args);
-        String newLine = getLineSeparator(input.toString());
-
-        // nindent filter adds a newline to the string and indents each line by defined amount of spaces
-        return (newLine + input).replace(newLine, newLine + prefix.repeat(amount));
+        return abstractApply(input, args, self, context, lineNumber, "nindent");
     }
 }

--- a/core/src/test/java/io/kestra/core/runners/pebble/filters/IndentFilterTest.java
+++ b/core/src/test/java/io/kestra/core/runners/pebble/filters/IndentFilterTest.java
@@ -1,0 +1,79 @@
+package io.kestra.core.runners.pebble.filters;
+
+import io.kestra.core.exceptions.IllegalVariableEvaluationException;
+import io.kestra.core.runners.VariableRenderer;
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+import jakarta.inject.Inject;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+
+@MicronautTest
+class IndentFilterTest {
+    @Inject
+    VariableRenderer variableRenderer;
+
+    @Test
+    void indentNull() throws IllegalVariableEvaluationException {
+        String render = variableRenderer.render("{{ null | indent(2) }}", Map.of());
+        assertThat(render, emptyOrNullString());
+    }
+
+    @Test
+    void indentEmpty() throws IllegalVariableEvaluationException {
+        String render = variableRenderer.render("{{ '' | indent(2) }}", Map.of());
+        assertThat(render, is(""));
+    }
+
+    @Test
+    void indentEmptyLines() throws IllegalVariableEvaluationException {
+        String render = variableRenderer.render("{{ \"\n\n\" | indent(2) }}", Map.of());
+        assertThat(render, is("\n  \n  "));
+    }
+
+    @Test
+    void indentString() throws IllegalVariableEvaluationException {
+        String render = variableRenderer.render("{{ 'string' | indent(2) }}", Map.of());
+        assertThat(render, is("string"));
+    }
+
+    @Test
+    void indentInteger() throws IllegalVariableEvaluationException {
+        String render = variableRenderer.render("{{ 1 | indent(2) }}", Map.of());
+        assertThat(render, is("1"));
+    }
+
+    @Test
+    void indentStringWithCRLF() throws IllegalVariableEvaluationException {
+        String render = variableRenderer.render("{{ \"first line\r\nsecond line\" | indent(2) }}", Map.of());
+        assertThat(render, is("first line\r\n  second line"));
+    }
+
+    @Test
+    void indentStringWithLF() throws IllegalVariableEvaluationException {
+        String render = variableRenderer.render("{{ \"first line\nsecond line\" | indent(2) }}", Map.of());
+        assertThat(render, is("first line\n  second line"));
+    }
+
+    @Test
+    void indentStringWithCR() throws IllegalVariableEvaluationException {
+        String render = variableRenderer.render("{{ \"first line\rsecond line\" | indent(2) }}", Map.of());
+        assertThat(render, is("first line\r  second line"));
+    }
+
+    @Test
+    void indentStringWithSystemNewLine() throws IllegalVariableEvaluationException {
+        String render = variableRenderer.render("{{ \"first line"+System.lineSeparator()+"second line\" | indent(2) }}", Map.of());
+        assertThat(render, is("first line"+System.lineSeparator()+"  second line"));
+    }
+
+    @Test
+    void indentWithTab() throws IllegalVariableEvaluationException {
+        String render = variableRenderer.render("{{ \"first line\nsecond line\" | indent(2, \"\t\") }}", Map.of());
+        assertThat(render, is("first line\n\t\tsecond line"));
+    }
+
+}

--- a/core/src/test/java/io/kestra/core/runners/pebble/filters/NindentFilterTest.java
+++ b/core/src/test/java/io/kestra/core/runners/pebble/filters/NindentFilterTest.java
@@ -1,0 +1,79 @@
+package io.kestra.core.runners.pebble.filters;
+
+import io.kestra.core.exceptions.IllegalVariableEvaluationException;
+import io.kestra.core.runners.VariableRenderer;
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+import jakarta.inject.Inject;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+
+@MicronautTest
+class NindentFilterTest {
+    @Inject
+    VariableRenderer variableRenderer;
+
+    @Test
+    void nindentNull() throws IllegalVariableEvaluationException {
+        String render = variableRenderer.render("{{ null | nindent(2) }}", Map.of());
+        assertThat(render, emptyOrNullString());
+    }
+
+    @Test
+    void nindentEmpty() throws IllegalVariableEvaluationException {
+        String render = variableRenderer.render("{{ '' | nindent(2) }}", Map.of());
+        assertThat(render, is(""));
+    }
+
+    @Test
+    void nindentEmptyLines() throws IllegalVariableEvaluationException {
+        String render = variableRenderer.render("{{ \"\n\n\" | nindent(2) }}", Map.of());
+        assertThat(render, is("\n  \n  \n  "));
+    }
+
+    @Test
+    void nindentString() throws IllegalVariableEvaluationException {
+        String render = variableRenderer.render("{{ 'string' | nindent(2) }}", Map.of());
+        assertThat(render, is("\n  string"));
+    }
+
+    @Test
+    void nindentInteger() throws IllegalVariableEvaluationException {
+        String render = variableRenderer.render("{{ 1 | nindent(2) }}", Map.of());
+        assertThat(render, is("\n  1"));
+    }
+
+    @Test
+    void nindentStringWithCRLF() throws IllegalVariableEvaluationException {
+        String render = variableRenderer.render("{{ \"first line\r\nsecond line\" | nindent(2) }}", Map.of());
+        assertThat(render, is("\r\n  first line\r\n  second line"));
+    }
+
+    @Test
+    void nindentStringWithLF() throws IllegalVariableEvaluationException {
+        String render = variableRenderer.render("{{ \"first line\nsecond line\" | nindent(2) }}", Map.of());
+        assertThat(render, is("\n  first line\n  second line"));
+    }
+
+    @Test
+    void nindentStringWithCR() throws IllegalVariableEvaluationException {
+        String render = variableRenderer.render("{{ \"first line\rsecond line\" | nindent(2) }}", Map.of());
+        assertThat(render, is("\r  first line\r  second line"));
+    }
+
+    @Test
+    void nindentStringWithSystemNewLine() throws IllegalVariableEvaluationException {
+        String render = variableRenderer.render("{{ \"first line"+System.lineSeparator()+"second line\" | nindent(2) }}", Map.of());
+        assertThat(render, is(System.lineSeparator()+"  first line"+System.lineSeparator()+"  second line"));
+    }
+
+    @Test
+    void nindentWithTab() throws IllegalVariableEvaluationException {
+        String render = variableRenderer.render("{{ \"first line\nsecond line\" | nindent(2, \"\t\") }}", Map.of());
+        assertThat(render, is("\n\t\tfirst line\n\t\tsecond line"));
+    }
+
+}


### PR DESCRIPTION
feat(core): add Pebble filters indent, nindent

### What changes are being made and why?
In reference to issue #3258

With the use of YAML comes the _issue_ of indentation - especially when constructing YAML from multiple objects separately or having to nest generated YAML within an existing templated structure. Thus I created filters that would enable to add indentation.

Both filters support original line breaks that were used in the input string, nindent adds the same type of newline, thus it should be safe to use with for example, jq configuration, shell scripts, etc. Support is for CRLF, LFCR, CR, LF.

### `| indent(amount, prefix=" ")` filter

Use `indent` to _indent_ all lines except for the first one.
Amount is required and defines how many times prefix is repeated before each line (except for the first one).
Prefix defines what is used to indent the lines. By default prefix is " " (a space).

### `| nindent(amount, prefix=" ")` filter

Use `nindent` to _indent_ add a new line before the code and then indent all lines.
Amount is required and defines how many times prefix is repeated before each line.
Prefix defines what is used to indent the lines. By default prefix is " " (a space).


### Sample usage in conjunction with Pebble YAML filter and TemplatedTask
```yaml
id: templated-task
namespace: kestra.test

labels:
  my-label: "will-be-sent-to-k8s"
  other-label: "value"

inputs:
  # the following represents the object resources with nested structure as supported by Kestra
  # thus they are accessible under the inputs.resources object
  - name: resources.limits.cpu
    type: STRING
    defaults: "1"
    required: true

  - name: resources.limits.memory
    type: STRING
    defaults: "1000Mi"
    required: true

  - name: resources.requests.cpu
    type: STRING
    required: false # note that this is optional and when not filled, it should be skipped in the definition

  - name: resources.requests.memory
    type: STRING
    required: false # note that this is optional and when not filled, it should be skipped in the definition

# other sample using variables, since they allow to explicitly define lists in yaml
variables:
  env: # is presented as a list of objects
    - name: "var_string"
      value: "VALUE"
    - name: "var_int"
      value: 123

tasks:
  - id: dynamic
    type: io.kestra.core.tasks.templating.TemplatedTask
    spec: |
      id: "{{ flow.namespace | slugify }}-{{ flow.id | slugify }}"
      type: io.kestra.plugin.kubernetes.PodCreate
      namespace: kestra
      metadata:
        labels:
          {{ labels | yaml | indent(4) }} # indenting from the next line, 4 spaces here
      spec:
        containers:
        - name: debug
          image: alpine:latest
          env: {{ variables.env | yaml | indent(6) }} # adding a newline and indenting at 6 spaces
          command:
            - 'bash'
            - '-c'
            - 'printenv'
        resources:
          {{ inputs.resources | yaml | indent(2, "  ") }} # indenting from the next line by 2 times "  " (two spaces)
```

### How the changes have been QAed?
Tests for both IndentFilter and NindentFilter are included in the PR.
Sample code for testing YAML filters are as follows.


#### `pebble-indent-filter` flow
```yaml
id: pebble-indent-filter
namespace: kestra.test

# https://kestra.io/docs/workflow-components/labels
labels:
  label: value

# https://kestra.io/docs/workflow-components/inputs
inputs:
  - id: string
    type: STRING
    required: false
    defaults: "string"

  - id: int
    type: INT
    required: false
    defaults: 123

  - id: bool
    type: BOOLEAN
    required: false
    defaults: true

  - id: float
    type: FLOAT
    required: false
    defaults: 1.23

  - id: instant
    type: DATETIME
    required: false
    defaults: "1918-02-24T01:02:03.04Z"

  - id: date
    type: DATE
    required: false
    defaults: "1991-08-20"

  - id: json
    type: JSON
    required: false
    defaults: |
      {
        "string": "string",
        "integer": 123,
        "float": 1.23,
        "boolean": false,
        "null": null,
        "object": {},
        "array": [
          "string",
          123,
          1.23,
          false,
          null,
          {},
          []
        ]
      }

  - id: uri
    type: URI
    required: false
    defaults: "https://kestra.io"

# https://kestra.io/docs/workflow-components/variables
variables:
  inputEmptyLines: "\n\n"
  inputString: 'string'
  inputInteger: 1
  inputStringWithCRLF: "first line\r\nsecond line"
  inputStringWithLF: "first line\nsecond line"
  inputStringWithCR: "first line\rsecond line"
  inputWithTab: "first line\nsecond line"

  indentEmptyLines: "\n  \n  "
  indentString: "string"
  indentInteger: "1"
  indentStringWithCRLF: "first line\r\n  second line"
  indentStringWithLF: "first line\n  second line"
  indentStringWithCR: "first line\r  second line"
  indentWithTab: "first line\n\t\tsecond line"

tasks:
  - id: debug
    description: "Debug task run"
    type: "io.kestra.core.tasks.log.Log"
    level: INFO
    # disabled: true
    message: |
      {
        "flow"      : {{ flow      ?? 'null' }},
        "execution" : {{ execution ?? 'null' }},
        "task"      : {{ task      ?? 'null' }},
        "taskrun"   : {{ taskrun   ?? 'null' }},
        "parent"    : {{ parent    ?? 'null' }},
        "parents"   : {{ parents   ?? 'null' }},
        "trigger"   : {{ trigger   ?? 'null' }},
        "vars"      : {{ vars      ?? 'null' }},
        "inputs"    : {{ inputs    ?? 'null' }},
        "outputs"   : {{ outputs   ?? 'null' }},
        "labels"    : {{ labels    ?? 'null' }}
      }

  - id: inputs-string
    type: "io.kestra.core.tasks.log.Log"
    message: |
      {{ (inputs.string | indent(2)) == "" + inputs.string  }} - {{ inputs.string | indent(2) }}

  - id: inputs-int
    type: "io.kestra.core.tasks.log.Log"
    message: |
      {{ (inputs.int | indent(2)) == "" + inputs.int  }} - {{ inputs.int | indent(2) }}

  - id: inputs-bool
    type: "io.kestra.core.tasks.log.Log"
    message: |
      {{ (inputs.bool | indent(2)) == "" + inputs.bool  }} - {{ inputs.bool | indent(2) }}

  - id: inputs-float
    type: "io.kestra.core.tasks.log.Log"
    message: |
      {{ (inputs.float | indent(2)) == "" + inputs.float  }} - {{ inputs.float | indent(2) }}

  - id: inputs-instant
    type: "io.kestra.core.tasks.log.Log"
    message: |
      {{ (inputs.instant | indent(2)) == "" + inputs.instant  }} - {{ inputs.instant | indent(2) }}

  - id: inputs-date
    type: "io.kestra.core.tasks.log.Log"
    message: |
      {{ (inputs.date | indent(2)) == "" + inputs.date  }} - {{ inputs.date | indent(2) }}

  - id: inputs-json
    type: "io.kestra.core.tasks.log.Log"
    message: |
      {{ (inputs.json | indent(2)) == "" + inputs.json  }} - {{ inputs.json | indent(2) }}

  - id: inputs-uri
    type: "io.kestra.core.tasks.log.Log"
    message: |
      {{ (inputs.uri | indent(2)) == "" + inputs.uri  }} - {{ inputs.uri | indent(2) }}

  - id: variables-inputNull
    type: "io.kestra.core.tasks.log.Log"
    message: |
      {{ (null | indent(2)) == "" }} - {{ (null | indent(2)) }}

  - id: variables-inputEmpty
    type: "io.kestra.core.tasks.log.Log"
    message: |
      {{ ("" | indent(2)) == "" }} - {{ ("" | indent(2)) }}

  - id: variables-inputEmptyLines
    type: "io.kestra.core.tasks.log.Log"
    message: |
      {{ (vars.inputEmptyLines | indent(2)) == vars.indentEmptyLines }} - {{ (vars.inputEmptyLines | indent(2)) }}

  - id: variables-inputString
    type: "io.kestra.core.tasks.log.Log"
    message: |
      {{ (vars.inputString | indent(2)) == vars.indentString }} - {{ (vars.inputString | indent(2)) }}

  - id: variables-inputInteger
    type: "io.kestra.core.tasks.log.Log"
    message: |
      {{ (vars.inputInteger | indent(2)) == vars.indentInteger }} - {{ (vars.inputInteger | indent(2)) }}

  - id: variables-inputStringWithCRLF
    type: "io.kestra.core.tasks.log.Log"
    message: |
      {{ (vars.inputStringWithCRLF | indent(2)) == vars.indentStringWithCRLF }} - {{ (vars.inputStringWithCRLF | indent(2)) }}

  - id: variables-inputStringWithLF
    type: "io.kestra.core.tasks.log.Log"
    message: |
      {{ (vars.inputStringWithLF | indent(2)) == vars.indentStringWithLF }} - {{ (vars.inputStringWithLF | indent(2)) }}

  - id: variables-inputStringWithCR
    type: "io.kestra.core.tasks.log.Log"
    message: |
      {{ (vars.inputStringWithCR | indent(2)) == vars.indentStringWithCR }} - {{ (vars.inputStringWithCR | indent(2)) }}

  - id: variables-inputWithTab
    type: "io.kestra.core.tasks.log.Log"
    message: |
      {{ (vars.inputWithTab | indent(2)) == vars.indentWithTab }} - {{ (vars.inputWithTab | indent(2, "\t")) }}
```

#### `pebble-nindent-filter` flow
```yaml
id: pebble-nindent-filter
namespace: kestra.test

# https://kestra.io/docs/workflow-components/labels
labels:
  label: value

# https://kestra.io/docs/workflow-components/inputs
inputs:
  - id: string
    type: STRING
    required: false
    defaults: "string"

  - id: int
    type: INT
    required: false
    defaults: 123

  - id: bool
    type: BOOLEAN
    required: false
    defaults: true

  - id: float
    type: FLOAT
    required: false
    defaults: 1.23

  - id: instant
    type: DATETIME
    required: false
    defaults: "1918-02-24T01:02:03.04Z"

  - id: date
    type: DATE
    required: false
    defaults: "1991-08-20"

  - id: json
    type: JSON
    required: false
    defaults: |
      {
        "string": "string",
        "integer": 123,
        "float": 1.23,
        "boolean": false,
        "null": null,
        "object": {},
        "array": [
          "string",
          123,
          1.23,
          false,
          null,
          {},
          []
        ]
      }

  - id: uri
    type: URI
    required: false
    defaults: "https://kestra.io"

# https://kestra.io/docs/workflow-components/variables
variables:
  inputEmptyLines: "\n\n"
  inputString: 'string'
  inputInteger: 1
  inputStringWithCRLF: "first line\r\nsecond line"
  inputStringWithLF: "first line\nsecond line"
  inputStringWithCR: "first line\rsecond line"
  inputWithTab: "first line\nsecond line"

  nindentEmptyLines: "\n  \n  \n  "
  nindentString: "\n  string"
  nindentInteger: "\n  1"
  nindentStringWithCRLF: "\r\n  first line\r\n  second line"
  nindentStringWithLF: "\n  first line\n  second line"
  nindentStringWithCR: "\r  first line\r  second line"
  nindentWithTab: "\n\t\tfirst line\n\t\tsecond line"


tasks:
  - id: debug
    description: "Debug task run"
    type: "io.kestra.core.tasks.log.Log"
    level: INFO
    # disabled: true
    message: |
      {
        "flow"      : {{ flow      ?? 'null' }},
        "execution" : {{ execution ?? 'null' }},
        "task"      : {{ task      ?? 'null' }},
        "taskrun"   : {{ taskrun   ?? 'null' }},
        "parent"    : {{ parent    ?? 'null' }},
        "parents"   : {{ parents   ?? 'null' }},
        "trigger"   : {{ trigger   ?? 'null' }},
        "vars"      : {{ vars      ?? 'null' }},
        "inputs"    : {{ inputs    ?? 'null' }},
        "outputs"   : {{ outputs   ?? 'null' }},
        "labels"    : {{ labels    ?? 'null' }}
      }

  - id: inputs-string
    type: "io.kestra.core.tasks.log.Log"
    message: |
      {{ (inputs.string | nindent(2)) == "" + inputs.string  }} - {{ inputs.string | nindent(2) }}

  - id: inputs-int
    type: "io.kestra.core.tasks.log.Log"
    message: |
      {{ (inputs.int | nindent(2)) == "" + inputs.int  }} - {{ inputs.int | nindent(2) }}

  - id: inputs-bool
    type: "io.kestra.core.tasks.log.Log"
    message: |
      {{ (inputs.bool | nindent(2)) == "" + inputs.bool  }} - {{ inputs.bool | nindent(2) }}

  - id: inputs-float
    type: "io.kestra.core.tasks.log.Log"
    message: |
      {{ (inputs.float | nindent(2)) == "" + inputs.float  }} - {{ inputs.float | nindent(2) }}

  - id: inputs-instant
    type: "io.kestra.core.tasks.log.Log"
    message: |
      {{ (inputs.instant | nindent(2)) == "" + inputs.instant  }} - {{ inputs.instant | nindent(2) }}

  - id: inputs-date
    type: "io.kestra.core.tasks.log.Log"
    message: |
      {{ (inputs.date | nindent(2)) == "" + inputs.date  }} - {{ inputs.date | nindent(2) }}

  - id: inputs-json
    type: "io.kestra.core.tasks.log.Log"
    message: |
      {{ (inputs.json | nindent(2)) == "" + inputs.json  }} - {{ inputs.json | nindent(2) }}

  - id: inputs-uri
    type: "io.kestra.core.tasks.log.Log"
    message: |
      {{ (inputs.uri | nindent(2)) == "" + inputs.uri  }} - {{ inputs.uri | nindent(2) }}

  - id: variables-inputNull
    type: "io.kestra.core.tasks.log.Log"
    message: |
      {{ (null | nindent(2)) == "" }} - {{ (null | nindent(2)) }}

  - id: variables-inputEmpty
    type: "io.kestra.core.tasks.log.Log"
    message: |
      {{ ("" | nindent(2)) == "" }} - {{ ("" | nindent(2)) }}

  - id: variables-inputEmptyLines
    type: "io.kestra.core.tasks.log.Log"
    message: |
      {{ (vars.inputEmptyLines | nindent(2)) == vars.nindentEmptyLines }} - {{ (vars.inputEmptyLines | nindent(2)) }}

  - id: variables-inputString
    type: "io.kestra.core.tasks.log.Log"
    message: |
      {{ (vars.inputString | nindent(2)) == vars.nindentString }} - {{ (vars.inputString | nindent(2)) }}

  - id: variables-inputInteger
    type: "io.kestra.core.tasks.log.Log"
    message: |
      {{ (vars.inputInteger | nindent(2)) == vars.nindentInteger }} - {{ (vars.inputInteger | nindent(2)) }}

  - id: variables-inputStringWithCRLF
    type: "io.kestra.core.tasks.log.Log"
    message: |
      {{ (vars.inputStringWithCRLF | nindent(2)) == vars.nindentStringWithCRLF }} - {{ (vars.inputStringWithCRLF | nindent(2)) }}

  - id: variables-inputStringWithLF
    type: "io.kestra.core.tasks.log.Log"
    message: |
      {{ (vars.inputStringWithLF | nindent(2)) == vars.nindentStringWithLF }} - {{ (vars.inputStringWithLF | nindent(2)) }}

  - id: variables-inputStringWithCR
    type: "io.kestra.core.tasks.log.Log"
    message: |
      {{ (vars.inputStringWithCR | nindent(2)) == vars.nindentStringWithCR }} - {{ (vars.inputStringWithCR | nindent(2)) }}

  - id: variables-inputWithTab
    type: "io.kestra.core.tasks.log.Log"
    message: |
      {{ (vars.inputWithTab | nindent(2)) == vars.nindentWithTab }} - {{ (vars.inputWithTab | nindent(2, "\t")) }}
```
