### PR TITLE
feat(ui): add minimal version of saved search filters

### DIFF
--- a/ui/src/components/executions/Executions.vue
+++ b/ui/src/components/executions/Executions.vue
@@ -94,7 +94,7 @@
                     </el-select>
                 </el-form-item>
                 <el-form-item>
-                    <filters />
+                    <filters :storage-key="filterStorageKey" />
                 </el-form-item>
                 <el-form-item>
                     <refresh-button
@@ -570,6 +570,9 @@
             },
             isDisplayedTop() {
                 return this.embed === false || this.filter
+            },
+            filterStorageKey(){
+                return storageKeys.EXECUTIONS_FILTERS
             }
         },
         methods: {

--- a/ui/src/components/executions/Executions.vue
+++ b/ui/src/components/executions/Executions.vue
@@ -94,6 +94,9 @@
                     </el-select>
                 </el-form-item>
                 <el-form-item>
+                    <filters />
+                </el-form-item>
+                <el-form-item>
                     <refresh-button
                         :can-auto-refresh="canAutoRefresh"
                         class="float-right"
@@ -365,6 +368,7 @@
     import LabelFilter from "../labels/LabelFilter.vue";
     import DateFilter from "./date-select/DateFilter.vue";
     import RefreshButton from "../layout/RefreshButton.vue"
+    import Filters from "../saved-filters/Filters.vue";
     import StatusFilterButtons from "../layout/StatusFilterButtons.vue"
     import StateGlobalChart from "../../components/stats/StateGlobalChart.vue";
     import TriggerAvatar from "../../components/flows/TriggerAvatar.vue";
@@ -392,6 +396,7 @@
             LabelFilter,
             DateFilter,
             RefreshButton,
+            Filters,
             StatusFilterButtons,
             StateGlobalChart,
             TriggerAvatar,

--- a/ui/src/components/flows/Flows.vue
+++ b/ui/src/components/flows/Flows.vue
@@ -60,6 +60,9 @@
                             @update:model-value="onDataTableValue('labels', $event)"
                         />
                     </el-form-item>
+                    <el-form-item>
+                        <filters :storage-key="storageKeys.FLOWS_FILTERS" />
+                    </el-form-item>
                 </template>
 
                 <template #top>
@@ -213,6 +216,7 @@
     import TrashCan from "vue-material-design-icons/TrashCan.vue";
     import FileDocumentRemoveOutline from "vue-material-design-icons/FileDocumentRemoveOutline.vue";
     import FileDocumentCheckOutline from "vue-material-design-icons/FileDocumentCheckOutline.vue";
+    import Filters from "../saved-filters/Filters.vue";
 </script>
 
 <script>
@@ -239,6 +243,7 @@
     import Labels from "../layout/Labels.vue"
     import Upload from "vue-material-design-icons/Upload.vue";
     import LabelFilter from "../labels/LabelFilter.vue";
+    import {storageKeys} from "../../utils/constants";
 
     export default {
         mixins: [RouteContext, RestoreUrl, DataTableActions, SelectTableActions],

--- a/ui/src/components/logs/LogsWrapper.vue
+++ b/ui/src/components/logs/LogsWrapper.vue
@@ -29,6 +29,11 @@
                         />
                     </el-form-item>
                     <el-form-item>
+                        <el-form-item>
+                            <filters :storage-key="storageKeys.LOGS_FILTERS" />
+                        </el-form-item>
+                    </el-form-item>
+                    <el-form-item>
                         <refresh-button class="float-right" @refresh="refresh" />
                     </el-form-item>
                 </template>
@@ -92,10 +97,14 @@
     import RefreshButton from "../../components/layout/RefreshButton.vue";
     import _merge from "lodash/merge";
     import LogChart from "../stats/LogChart.vue";
+    import Filters from "../saved-filters/Filters.vue";
+    import {storageKeys} from "../../utils/constants";
 
     export default {
         mixins: [RouteContext, RestoreUrl, DataTableActions],
-        components: {DataTable, LogLine, NamespaceSelect, DateRange, SearchField, LogLevelSelector, RefreshButton, TopNavBar, LogChart},
+        components: {
+            Filters,
+            DataTable, LogLine, NamespaceSelect, DateRange, SearchField, LogLevelSelector, RefreshButton, TopNavBar, LogChart},
         props: {
             logLevel: {
                 type: String,
@@ -113,6 +122,9 @@
             };
         },
         computed: {
+            storageKeys() {
+                return storageKeys
+            },
             ...mapState("log", ["logs", "total", "level"]),
             ...mapState("stat", ["logDaily"]),
             routeInfo() {

--- a/ui/src/components/saved-filters/Filters.vue
+++ b/ui/src/components/saved-filters/Filters.vue
@@ -1,0 +1,128 @@
+<template>
+    <el-tooltip
+        :content="$t('search filters.manage desc')"
+        placement="bottom"
+        :persistent="false"
+        :hide-after="0"
+        transition=""
+    >
+        <el-button :icon="ContentSave" @click="isDrawerOpen = !isDrawerOpen" />
+    </el-tooltip>
+
+    <drawer
+        v-model="isDrawerOpen"
+        :title="$t('search filters.manage')"
+    >
+        <el-card
+            v-if="hasSavedFilters()"
+            :header="$t('search filters.saved')"
+            class="w-100"
+        >
+            <saved-filter
+                v-for="(query, label) in relevantFilters"
+                :key="label"
+                :query="query"
+                :label="label"
+                @clicked="isDrawerOpen = false"
+                @deleted="removeSavedFilter($event)"
+            />
+
+            <template #footer>
+                <el-input
+                    v-model="labelFilter"
+                    :prefix-icon="Magnify"
+                    :maxlength="15"
+                    :placeholder="$t('search')"
+                    clearable
+                />
+            </template>
+        </el-card>
+
+
+        <el-input
+            class="py-3"
+            v-model="newFilterLabel"
+            :autofocus="true"
+            :maxlength="15"
+            :placeholder="$t('search filters.filter name')"
+            @keyup.enter="saveCurrentFilter()"
+        >
+            <template #append>
+                <el-button
+                    :icon="Plus"
+                    :disabled="newFilterLabel === EMPTY_LABEL"
+                    @click="saveCurrentFilter()"
+                >
+                    {{ $t('search filters.save filter') }}
+                </el-button>
+            </template>
+        </el-input>
+    </drawer>
+</template>
+
+<script setup>
+    import ContentSave from "vue-material-design-icons/ContentSave.vue";
+    import Plus from "vue-material-design-icons/Plus.vue";
+    import Magnify from "vue-material-design-icons/Magnify.vue";
+</script>
+
+<script>
+    import Drawer from "../Drawer.vue";
+    import SavedFilter from "./SavedFilter.vue";
+    import {mapGetters} from "vuex";
+
+    export default {
+        components: {
+            Drawer,
+            SavedFilter
+        },
+        data() {
+            return {
+                isDrawerOpen: false,
+                newFilterLabel: undefined,
+                labelFilter: undefined
+            };
+        },
+        computed: {
+            ...mapGetters("filters", ["savedFilters"]),
+            relevantFilters() {
+                return Object.entries(this.savedFilters)
+                    .filter(([key, _]) => this.labelFilter ? key.includes(this.labelFilter) : true)
+                    .sort(([a, _], [b, __]) => {
+                        const keyA = a.toLowerCase();
+                        const keyB = b.toLowerCase();
+
+                        return (keyA < keyB ? -1 : (keyA > keyB ? 1 : 0));
+                    })
+                    .reduce((acc, [key, value]) => { acc[key] = value; return acc; }, {});
+            }
+        },
+        created() {
+            this.resetNewFilterLabel();
+            this.EMPTY_LABEL = "";
+        },
+        methods: {
+            hasSavedFilters() {
+                return Object.keys(this.savedFilters).length > 0;
+            },
+            saveCurrentFilter() {
+                if (!this.newFilterLabel) {
+                    return;
+                }
+                this.savedFilters[this.newFilterLabel] = this.$route.query;
+                this.storeSavedFilters();
+                this.resetNewFilterLabel();
+            },
+            resetNewFilterLabel() {
+                this.newFilterLabel = this.EMPTY_LABEL;
+            },
+            removeSavedFilter(label) {
+                delete this.savedFilters[label];
+                this.storeSavedFilters();
+            },
+            storeSavedFilters() {
+                this.$store.commit("filters/setSavedFilters", this.savedFilters);
+            }
+        }
+    }
+</script>

--- a/ui/src/components/saved-filters/SavedFilter.vue
+++ b/ui/src/components/saved-filters/SavedFilter.vue
@@ -1,0 +1,93 @@
+<template>
+    <el-tooltip
+        placement="bottom"
+        trigger="hover"
+        :persistent="false"
+        :show-after="750"
+        :hide-after="0"
+    >
+        <template #content>
+            <div v-for="(queryPart) in getReadableQuery()" :key="queryPart">
+                {{ queryPart }}
+            </div>
+        </template>
+        <el-tag
+            :type="isSelected() ? 'primary' : 'info'"
+            size="large"
+            @click="onClick"
+            @close="showConfirmDialog()"
+            closable
+            class="me-1"
+            disable-transitions
+        >
+            <router-link :to="searchLink">
+                {{ label }}
+            </router-link>
+        </el-tag>
+    </el-tooltip>
+</template>
+
+<script>
+    import _isEqual from "lodash/isEqual";
+
+    export default {
+        emits: [
+            "clicked",
+            "deleted"
+        ],
+        props: {
+            query: {
+                type: Object,
+                required: true
+            },
+            label: {
+                type: String,
+                required: true
+            }
+        },
+        computed: {
+            searchLink() {
+                return {
+                    name: this.$route.name,
+                    params: this.$route.params,
+                    query: this.query
+                };
+            }
+        },
+        methods: {
+            showConfirmDialog() {
+                this.$toast().confirm(
+                    this.$t("delete confirm", {name: this.label}),
+                    this.onDelete,
+                    () => {
+                    }
+                );
+            },
+            onClick() {
+                this.$emit("clicked");
+            },
+            onDelete() {
+                this.$emit("deleted", this.label);
+            },
+            isSelected() {
+                return _isEqual(this.query, this.$route.query);
+            },
+            getReadableQuery() {
+                return Object.entries(this.query)
+                    .map(([key, value]) => `${key}: ${value}`);
+            }
+        }
+    }
+</script>
+
+<style lang="scss" scoped>
+    .el-tag {
+        & a, span, :deep(.el-icon) {
+            color: var(--bs-white);
+        }
+
+        &.el-tag--info {
+            background: var(--bs-gray-600);
+        }
+    }
+</style>

--- a/ui/src/components/saved-filters/SavedFilter.vue
+++ b/ui/src/components/saved-filters/SavedFilter.vue
@@ -20,9 +20,7 @@
             class="me-1"
             disable-transitions
         >
-            <router-link :to="searchLink">
-                {{ label }}
-            </router-link>
+            <span>{{ label }}</span>
         </el-tag>
     </el-tooltip>
 </template>
@@ -45,15 +43,6 @@
                 required: true
             }
         },
-        computed: {
-            searchLink() {
-                return {
-                    name: this.$route.name,
-                    params: this.$route.params,
-                    query: this.query
-                };
-            }
-        },
         methods: {
             showConfirmDialog() {
                 this.$toast().confirm(
@@ -64,6 +53,7 @@
                 );
             },
             onClick() {
+                this.$router.push({query: this.query})
                 this.$emit("clicked");
             },
             onDelete() {
@@ -84,6 +74,7 @@
     .el-tag {
         & a, span, :deep(.el-icon) {
             color: var(--bs-white);
+            cursor: pointer;
         }
 
         &.el-tag--info {

--- a/ui/src/stores/filters.js
+++ b/ui/src/stores/filters.js
@@ -1,0 +1,20 @@
+export default {
+    namespaced: true,
+    state: {
+        savedFilters: undefined
+    },
+    mutations: {
+        setSavedFilters(state, value) {
+            state.filters = (value);
+            localStorage.setItem("savedFilters", JSON.stringify(state.filters));
+        }
+    },
+    getters: {
+        savedFilters(state) {
+            if (!state.savedFilters) {
+                state.savedFilters = JSON.parse(localStorage.getItem("savedFilters")) ?? {};
+            }
+            return state.savedFilters;
+        }
+    }
+}

--- a/ui/src/stores/filters.js
+++ b/ui/src/stores/filters.js
@@ -1,20 +1,18 @@
 export default {
     namespaced: true,
     state: {
-        savedFilters: undefined
+        lastFilters: undefined
     },
     mutations: {
         setSavedFilters(state, value) {
-            state.filters = (value);
-            localStorage.setItem("savedFilters", JSON.stringify(state.filters));
+            localStorage.setItem(value.storageKey, JSON.stringify(value.filters));
         }
     },
     getters: {
-        savedFilters(state) {
-            if (!state.savedFilters) {
-                state.savedFilters = JSON.parse(localStorage.getItem("savedFilters")) ?? {};
+        savedFilters() {
+            return (storageKey) => {
+                return JSON.parse(localStorage.getItem(storageKey)) ?? {}
             }
-            return state.savedFilters;
         }
     }
 }

--- a/ui/src/stores/store.js
+++ b/ui/src/stores/store.js
@@ -2,6 +2,7 @@ import api from "./api"
 import auth from "./auth"
 import core from "./core"
 import execution from "./executions"
+import filters from "./filters";
 import flow from "./flow"
 import graph from "./graph"
 import layout from "./layout"
@@ -19,6 +20,7 @@ export default {
     modules: {
         api,
         core,
+        filters,
         flow,
         template,
         execution,

--- a/ui/src/translations.json
+++ b/ui/src/translations.json
@@ -100,6 +100,13 @@
     "add flow": "Add flow",
     "from": "From",
     "to": "To",
+    "search filters": {
+      "saved": "Saved filters",
+      "manage": "Manage search filters",
+      "manage desc": "Manage saved search filters",
+      "save filter": "Save filter",
+      "filter name": "Filter name"
+    },
     "steps": "Steps",
     "state": "State",
     "search term in message": "Search term in message",

--- a/ui/src/utils/constants.js
+++ b/ui/src/utils/constants.js
@@ -32,9 +32,13 @@ export const storageKeys = {
     DEFAULT_NAMESPACE: "defaultNamespace",
     LATEST_NAMESPACE: "latestNamespace",
     PAGINATION_SIZE: "paginationSize",
+    EXECUTIONS_FILTERS: "executionsSavedFilters",
+    FLOWS_FILTERS: "flowsSavedFilters",
+    LOGS_FILTERS: "logsSavedFilters",
 }
 
 export const executeFlowBehaviours = {
     SAME_TAB: "same tab",
     NEW_TAB: "new tab"
 }
+


### PR DESCRIPTION
### What changes are being made and why?

This PR brings a minimal working version of user-specific saved execution filters. Now it's possible to improve UX by recalling frequently used queries by a single click. 

* This implementation targets the `localStorage` - no advanced features like sharing or persisting the saved filters are present.
* Styling/UX/naming needs to be reviewed & corrected to fit Kestra visuals.
* French translation is missing 🙃

close #1397

---

### How the changes have been QAed?

![20240317-111107_snap](https://github.com/kestra-io/kestra/assets/13468636/1fafa2b7-a5a9-4da3-b2b6-9e581958d0dc)
