### PR TITLE
feat(cli): add warnings to the flow validate command

### DIFF
--- a/cli/src/main/java/io/kestra/cli/AbstractValidateCommand.java
+++ b/cli/src/main/java/io/kestra/cli/AbstractValidateCommand.java
@@ -74,7 +74,8 @@ public abstract class AbstractValidateCommand extends AbstractApiCommand {
         Class<?> cls,
         YamlFlowParser yamlFlowParser,
         ModelValidator modelValidator,
-        Function<Object, String> identity
+        Function<Object, String> identity,
+        Function<Object, List<String>> warningsFunction
     ) throws Exception {
         super.call();
 
@@ -90,6 +91,8 @@ public abstract class AbstractValidateCommand extends AbstractApiCommand {
                             Object parse = yamlFlowParser.parse(path.toFile(), cls);
                             modelValidator.validate(parse);
                             stdOut("@|green \u2713|@ - " + identity.apply(parse));
+                            List<String> warnings = warningsFunction.apply(parse);
+                            warnings.forEach(warning -> stdOut("@|bold,yellow \u26A0|@ - " + warning));
                         } catch (ConstraintViolationException e) {
                             stdErr("@|red \u2718|@ - " + path);
                             FlowValidateCommand.handleException(e, clsName);

--- a/cli/src/main/java/io/kestra/cli/commands/flows/FlowValidateCommand.java
+++ b/cli/src/main/java/io/kestra/cli/commands/flows/FlowValidateCommand.java
@@ -4,8 +4,12 @@ import io.kestra.cli.AbstractValidateCommand;
 import io.kestra.core.models.flows.Flow;
 import io.kestra.core.models.validations.ModelValidator;
 import io.kestra.core.serializers.YamlFlowParser;
+import io.kestra.core.services.FlowService;
 import jakarta.inject.Inject;
 import picocli.CommandLine;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @CommandLine.Command(
     name = "validate",
@@ -18,6 +22,9 @@ public class FlowValidateCommand extends AbstractValidateCommand {
     @Inject
     private ModelValidator modelValidator;
 
+    @Inject
+    private FlowService flowService;
+
     @Override
     public Integer call() throws Exception {
         return this.call(
@@ -27,6 +34,13 @@ public class FlowValidateCommand extends AbstractValidateCommand {
             (Object object) -> {
                 Flow flow = (Flow) object;
                 return flow.getNamespace() + " / " + flow.getId();
+            },
+            (Object object) -> {
+                Flow flow = (Flow) object;
+                List<String> warnings = new ArrayList<>();
+                warnings.addAll(flowService.deprecationPaths(flow).stream().map(deprecation -> deprecation + " is deprecated").toList());
+                warnings.addAll(flowService.warnings(flow));
+                return warnings;
             }
         );
     }

--- a/cli/src/main/java/io/kestra/cli/commands/templates/TemplateValidateCommand.java
+++ b/cli/src/main/java/io/kestra/cli/commands/templates/TemplateValidateCommand.java
@@ -8,6 +8,8 @@ import io.kestra.core.serializers.YamlFlowParser;
 import jakarta.inject.Inject;
 import picocli.CommandLine;
 
+import java.util.Collections;
+
 @CommandLine.Command(
     name = "validate",
     description = "validate a template"
@@ -29,7 +31,8 @@ public class TemplateValidateCommand extends AbstractValidateCommand {
             (Object object) -> {
                 Template template = (Template) object;
                 return template.getNamespace() + " / " + template.getId();
-            }
+            },
+            (Object object) -> Collections.emptyList()
         );
     }
 }

--- a/cli/src/test/java/io/kestra/cli/commands/flows/FlowValidateCommandTest.java
+++ b/cli/src/test/java/io/kestra/cli/commands/flows/FlowValidateCommandTest.java
@@ -33,4 +33,25 @@ class FlowValidateCommandTest {
             assertThat(out.toString(), containsString("✓ - io.kestra.cli / include"));
         }
     }
+
+    @Test
+    void warning() {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        System.setOut(new PrintStream(out));
+
+        try (ApplicationContext ctx = ApplicationContext.run(Environment.CLI, Environment.TEST)) {
+            EmbeddedServer embeddedServer = ctx.getBean(EmbeddedServer.class);
+            embeddedServer.start();
+
+            String[] args = {
+                "--local",
+                "src/test/resources/warning/flow-with-warning.yaml"
+            };
+            Integer call = PicocliRunner.call(FlowValidateCommand.class, ctx, args);
+
+            assertThat(call, is(0));
+            assertThat(out.toString(), containsString("tasks[0] is deprecated"));
+            assertThat(out.toString(), containsString("The system namespace is reserved for background workflows"));
+        }
+    }
 }

--- a/cli/src/test/resources/warning/flow-with-warning.yaml
+++ b/cli/src/test/resources/warning/flow-with-warning.yaml
@@ -1,0 +1,7 @@
+id: warning
+namespace: system
+
+tasks:
+  - id: deprecated
+    type: io.kestra.core.tasks.debugs.Echo
+    format: Hello World


### PR DESCRIPTION
Fixes #3124

When a flow has warning, they are now displayed in the console when calling the `flow validate` command.

See for ex:
```
✓ - system / warning
⚠ - tasks[0] is deprecated
⚠ - The system namespace is reserved for background workflows intended to perform routine tasks such as sending alerts and purging logs. Please use another namespace name.
```