### PR TITLE
fix(ui): remove absolute filter on switch away to the relative one

### DIFF
--- a/ui/src/components/executions/date-select/DateFilter.vue
+++ b/ui/src/components/executions/date-select/DateFilter.vue
@@ -65,7 +65,11 @@
         },
         methods: {
             onSelectedFilterType() {
-                this.$emit("update:isRelative", this.selectedFilterType === this.filterType.RELATIVE);
+                const relativeFilterSelected = this.selectedFilterType === this.filterType.RELATIVE;
+
+                this.$emit("update:isRelative", relativeFilterSelected);
+
+                this.tryOverrideAbsFilter(relativeFilterSelected);
             },
             onAbsFilterChange(event) {
                 const filter = {
@@ -85,6 +89,12 @@
             },
             updateFilter(filter) {
                 this.$emit("update:filterValue", filter);
+            },
+            tryOverrideAbsFilter(relativeFilterSelected) {
+                if (relativeFilterSelected && (this.$route.query.startDate || this.$route.query.endDate)) {
+                    const forcedDefaultRelativeFilter = {timeRange: undefined};
+                    this.onRelFilterChange(forcedDefaultRelativeFilter);
+                }
             }
         }
     }


### PR DESCRIPTION
### What changes are being made and why?

A rather crude way to apply the default relative filter value was added.

close #3289