### PR TITLE
feat(core): add task restart strategy on worker failure (#3343,#3351)

### DIFF
--- a/cli/src/main/resources/application.yml
+++ b/cli/src/main/resources/application.yml
@@ -216,6 +216,7 @@ kestra:
       max-rows: 5000
     # The expected time for this server to complete all its tasks before initiating a graceful shutdown.
     terminationGracePeriod: 5m
+    workerTaskRestartStrategy: AFTER_TERMINATION_GRACE_PERIOD
     # Configuration for Liveness and Heartbeat mechanism between servers.
     liveness:
       enabled: true
@@ -224,7 +225,7 @@ kestra:
       # The timeout used to detect service failures.
       timeout: 45s
       # The time to wait before executing a liveness probe.
-      initialDelay: 30s
+      initialDelay: 45s
       # The expected time between service heartbeats.
       heartbeatInterval: 3s
   anonymous-usage-report:

--- a/core/src/main/java/io/kestra/core/repositories/ServiceInstanceRepositoryInterface.java
+++ b/core/src/main/java/io/kestra/core/repositories/ServiceInstanceRepositoryInterface.java
@@ -59,20 +59,6 @@ public interface ServiceInstanceRepositoryInterface {
     ServiceInstance save(ServiceInstance service);
 
     /**
-     * Finds all running service instances which have not sent a state update for more than their associated timeout,
-     * and thus should be considered in failure.
-     *
-     * @param now the time instant to be used for querying.
-     * @return the list of {@link ServiceInstance}.
-     */
-    default List<ServiceInstance> findAllTimeoutRunningInstances(final Instant now) {
-        return findAllInstancesInStates(List.of(Service.ServiceState.CREATED, Service.ServiceState.RUNNING))
-            .stream()
-            .filter(instance -> instance.isSessionTimeoutElapsed(now))
-            .toList();
-    }
-
-    /**
      * Finds all service instances which are in the given state.
      *
      * @return the list of {@link ServiceInstance}.
@@ -84,7 +70,7 @@ public interface ServiceInstanceRepositoryInterface {
      *
      * @return the list of {@link ServiceInstance}.
      */
-    List<ServiceInstance> findAllInstancesInStates(final List<Service.ServiceState> states);
+    List<ServiceInstance> findAllInstancesInStates(final Set<Service.ServiceState> states);
 
     /**
      * Attempt to transition the state of a given service to given new state.

--- a/core/src/main/java/io/kestra/core/server/AbstractServiceLivenessTask.java
+++ b/core/src/main/java/io/kestra/core/server/AbstractServiceLivenessTask.java
@@ -56,7 +56,7 @@ public abstract class AbstractServiceLivenessTask implements Runnable, AutoClose
             long timeout = serverConfig.liveness().timeout().toMillis();
             if (elapsed > timeout) {
                 // useful for debugging unexpected heartbeat timeout
-                log.warn("Thread starvation or clock leap detected (elapsed since previous schedule {}", elapsed);
+                log.warn("Thread starvation or clock leap detected (elapsed since previous schedule {}ms", elapsed);
             }
             onSchedule(now);
         } catch (Exception e) {
@@ -89,18 +89,17 @@ public abstract class AbstractServiceLivenessTask implements Runnable, AutoClose
     public void start() {
         if (!isLivenessEnabled()) {
             log.warn(
-                "Server liveness is currently disabled (`kestra.server.liveness.enabled=false`) " +
-                    "If you are running in production environment, please ensure this property is configured to `true`. "
+                "Server liveness is currently disabled (kestra.server.liveness.enabled=false) " +
+                "If you are running in production environment, please ensure this property is configured to 'true'. "
             );
         }
         if (scheduledExecutorService == null && !isStopped.get()) {
             scheduledExecutorService = Executors.newSingleThreadScheduledExecutor(r -> new Thread(r, name));
             Duration scheduleInterval = getScheduleInterval();
             log.debug("Scheduling '{}' at fixed rate {}.", name, scheduleInterval);
-            Duration initialDelay = serverConfig.liveness().initialDelay();
             scheduledExecutorService.scheduleAtFixedRate(
                 this,
-                initialDelay.toSeconds(),
+                0,
                 scheduleInterval.toSeconds(),
                 TimeUnit.SECONDS
             );

--- a/core/src/main/java/io/kestra/core/server/ServerConfig.java
+++ b/core/src/main/java/io/kestra/core/server/ServerConfig.java
@@ -1,10 +1,12 @@
 package io.kestra.core.server;
 
 import io.micronaut.context.annotation.ConfigurationProperties;
+import io.micronaut.core.annotation.Nullable;
 import io.micronaut.core.bind.annotation.Bindable;
 import jakarta.validation.constraints.NotNull;
 
 import java.time.Duration;
+import java.util.Optional;
 
 /**
  * Server configuration.
@@ -18,9 +20,21 @@ public record ServerConfig(
     @Bindable(defaultValue = "5m")
     Duration terminationGracePeriod,
 
+    @Bindable(defaultValue = "AFTER_TERMINATION_GRACE_PERIOD")
+    @Nullable
+    WorkerTaskRestartStrategy workerTaskRestartStrategy,
+
     Liveness liveness
 
 ) {
+
+    /** {@inheritDoc} **/
+    public WorkerTaskRestartStrategy workerTaskRestartStrategy() {
+        return Optional
+            .ofNullable(workerTaskRestartStrategy)
+            .orElse(WorkerTaskRestartStrategy.AFTER_TERMINATION_GRACE_PERIOD);
+    }
+
     /**
      * Configuration for Liveness and Heartbeat mechanism between Kestra Services, and Executor.
      *
@@ -39,7 +53,7 @@ public record ServerConfig(
         @NotNull @Bindable(defaultValue = "5s")
         Duration interval,
         @NotNull @Bindable(defaultValue = "45s") Duration timeout,
-        @NotNull @Bindable(defaultValue = "30s") Duration initialDelay,
+        @NotNull @Bindable(defaultValue = "45s") Duration initialDelay,
         @NotNull @Bindable(defaultValue = "3s") Duration heartbeatInterval
     ) {
     }

--- a/core/src/main/java/io/kestra/core/server/Service.java
+++ b/core/src/main/java/io/kestra/core/server/Service.java
@@ -2,6 +2,7 @@ package io.kestra.core.server;
 
 import java.util.Arrays;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
 /**
@@ -134,8 +135,7 @@ public interface Service {
         }
 
         public boolean isRunning() {
-            return equals(CREATED)
-                || equals(RUNNING);
+            return allRunningStates().contains(this);
         }
 
         public boolean isDisconnectedOrTerminating() {
@@ -148,6 +148,10 @@ public interface Service {
                 || equals(TERMINATED_FORCED)
                 || equals(NOT_RUNNING)
                 || equals(EMPTY);
+        }
+
+        public static Set<ServiceState> allRunningStates() {
+            return Set.of(CREATED, RUNNING);
         }
     }
 }

--- a/core/src/main/java/io/kestra/core/server/WorkerConfig.java
+++ b/core/src/main/java/io/kestra/core/server/WorkerConfig.java
@@ -1,7 +1,0 @@
-package io.kestra.core.server;
-
-import io.micronaut.context.annotation.ConfigurationProperties;
-
-@ConfigurationProperties("kestra.server")
-public class WorkerConfig {
-}

--- a/core/src/main/java/io/kestra/core/server/WorkerTaskRestartStrategy.java
+++ b/core/src/main/java/io/kestra/core/server/WorkerTaskRestartStrategy.java
@@ -1,0 +1,32 @@
+package io.kestra.core.server;
+
+/**
+ * The supported strategies for restarting tasks on worker failure.
+ */
+public enum WorkerTaskRestartStrategy {
+
+    /**
+     * Tasks are never restarted on worker failure.
+     */
+    NEVER,
+    /**
+     * Tasks are restarted immediately on worker failure, i.e., as soon as a worker id detected as disconnected.
+     * This strategy is used to reduce task recovery times at the risk of introducing duplicate executions.
+     */
+    IMMEDIATELY,
+    /**
+     * Tasks are restarted on worker failure after the termination grace period is elapsed.
+     * This strategy is used to limit the risk of task duplication.
+     */
+    AFTER_TERMINATION_GRACE_PERIOD;
+
+    /**
+     * Checks whether tasks are restartable for that strategy.
+     *
+     * @return {@code true} if tasks are restartable.
+     */
+    public boolean isRestartable() {
+        return this.equals(IMMEDIATELY) || this.equals(AFTER_TERMINATION_GRACE_PERIOD);
+    }
+
+}

--- a/core/src/test/java/io/kestra/core/server/ServiceInstanceTest.java
+++ b/core/src/test/java/io/kestra/core/server/ServiceInstanceTest.java
@@ -11,7 +11,9 @@ import java.util.Set;
 
 class ServiceInstanceTest {
 
-    public static final ServerConfig CONFIG = new ServerConfig(Duration.ZERO,
+    public static final ServerConfig CONFIG = new ServerConfig(
+        Duration.ZERO,
+        WorkerTaskRestartStrategy.AFTER_TERMINATION_GRACE_PERIOD,
         new ServerConfig.Liveness(
             true,
             Duration.ZERO,

--- a/core/src/test/java/io/kestra/core/server/ServiceLivenessManagerTest.java
+++ b/core/src/test/java/io/kestra/core/server/ServiceLivenessManagerTest.java
@@ -47,7 +47,9 @@ public class ServiceLivenessManagerTest {
     @BeforeEach
     void beforeEach() {
         KestraContext kestraContext = Mockito.mock(KestraContext.class);
-        ServerConfig config = new ServerConfig(Duration.ZERO,
+        ServerConfig config = new ServerConfig(
+            Duration.ZERO,
+            WorkerTaskRestartStrategy.AFTER_TERMINATION_GRACE_PERIOD,
             new ServerConfig.Liveness(
                 true,
                 Duration.ZERO,
@@ -180,7 +182,9 @@ public class ServiceLivenessManagerTest {
     }
 
     public static ServiceInstance serviceInstanceFor(final Service service) {
-        ServerConfig config = new ServerConfig(Duration.ZERO,
+        ServerConfig config = new ServerConfig(
+            Duration.ZERO,
+            WorkerTaskRestartStrategy.AFTER_TERMINATION_GRACE_PERIOD,
             new ServerConfig.Liveness(
                 true,
                 Duration.ZERO,

--- a/jdbc/src/test/java/io/kestra/jdbc/server/JdbcServiceLivenessManagerTest.java
+++ b/jdbc/src/test/java/io/kestra/jdbc/server/JdbcServiceLivenessManagerTest.java
@@ -3,7 +3,6 @@ package io.kestra.jdbc.server;
 import io.kestra.core.contexts.KestraContext;
 import io.kestra.core.models.ServerType;
 import io.kestra.core.repositories.ServiceInstanceRepositoryInterface;
-import io.kestra.core.runners.RunContext;
 import io.kestra.core.server.ServerConfig;
 import io.kestra.core.server.ServerInstanceFactory;
 import io.kestra.core.server.Service;
@@ -11,6 +10,7 @@ import io.kestra.core.server.ServiceInstance;
 import io.kestra.core.server.LocalServiceStateFactory;
 import io.kestra.core.server.ServiceRegistry;
 import io.kestra.core.server.ServiceStateTransition;
+import io.kestra.core.server.WorkerTaskRestartStrategy;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -47,7 +47,9 @@ class JdbcServiceLivenessManagerTest {
         Mockito.when(context.getServerType()).thenReturn(ServerType.WORKER);
         Mockito.when(context.getVersion()).thenReturn("");
         KestraContext.setContext(context);
-        ServerConfig config = new ServerConfig(Duration.ZERO,
+        ServerConfig config = new ServerConfig(
+            Duration.ZERO,
+            WorkerTaskRestartStrategy.AFTER_TERMINATION_GRACE_PERIOD,
             new ServerConfig.Liveness(
                 true,
                 Duration.ZERO,

--- a/repository-memory/src/main/java/io/kestra/repository/memory/MemoryServiceInstanceRepository.java
+++ b/repository-memory/src/main/java/io/kestra/repository/memory/MemoryServiceInstanceRepository.java
@@ -68,7 +68,7 @@ public class MemoryServiceInstanceRepository implements ServiceInstanceRepositor
 
     /** {@inheritDoc} **/
     @Override
-    public List<ServiceInstance> findAllInstancesInStates(List<Service.ServiceState> states) {
+    public List<ServiceInstance> findAllInstancesInStates(Set<Service.ServiceState> states) {
         List<ServiceInstance> instancesInStates = new ArrayList<>();
         for (ServiceInstance instance : data.values()) {
             if (states.contains(instance.state())) {


### PR DESCRIPTION
Changes:
- add new config 'kestra.server.taskRestartStrategyOnWorkerFailure'
- update default value for 'kestra.server.liveness.initialDelay' to match timeout
- fix schedule initial delay to 0
- cleanup javadoc

Fix: #3343
Fix: #3351
