### PR TITLE
Fix/maputils perf

### DIFF
--- a/core/src/main/java/io/kestra/core/services/ExecutionService.java
+++ b/core/src/main/java/io/kestra/core/services/ExecutionService.java
@@ -453,7 +453,7 @@ public class ExecutionService {
         return Stream
             .concat(
                 execution
-                    .findChilds(taskRun)
+                    .findParents(taskRun)
                     .stream(),
                 Stream.of(taskRun)
             )

--- a/core/src/main/java/io/kestra/core/utils/GraphUtils.java
+++ b/core/src/main/java/io/kestra/core/utils/GraphUtils.java
@@ -283,7 +283,7 @@ public class GraphUtils {
                 );
 
                 if (execution != null && currentTaskRun != null) {
-                    parentValues = execution.findChildsValues(currentTaskRun, true);
+                    parentValues = execution.findParentsValues(currentTaskRun, true);
                 }
 
 
@@ -386,7 +386,7 @@ public class GraphUtils {
                     );
 
                     if (execution != null && currentTaskRun != null) {
-                        parentValues = execution.findChildsValues(currentTaskRun, true);
+                        parentValues = execution.findParentsValues(currentTaskRun, true);
                     }
 
                     // detect kids

--- a/core/src/main/java/io/kestra/core/utils/MapUtils.java
+++ b/core/src/main/java/io/kestra/core/utils/MapUtils.java
@@ -4,7 +4,6 @@ import com.google.common.collect.Lists;
 
 import java.util.*;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 @SuppressWarnings({"rawtypes", "unchecked"})
 public class MapUtils {
@@ -23,12 +22,11 @@ public class MapUtils {
 
         Map copy = copyMap(a);
 
-
         Map<String, Object> copyMap = b
             .entrySet()
             .stream()
             .collect(
-                HashMap::new,
+                () -> newHashMap(copy.size()),
                 (m, v) -> {
                     Object original = copy.get(v.getKey());
                     Object value = v.getValue();
@@ -45,19 +43,14 @@ public class MapUtils {
                     } else if (value instanceof Collection
                         && original instanceof Collection) {
                         try {
-                            Collection merge =
-                                copyCollection(
+                            found = Lists
+                                .newArrayList(
                                     (Collection) original,
-                                    (List) Lists
-                                        .newArrayList(
-                                            (Collection) original,
-                                            (Collection) value
-                                        )
-                                        .stream()
-                                        .flatMap(Collection::stream)
-                                        .collect(Collectors.toList())
-                                );
-                            found = merge;
+                                    (Collection) value
+                                )
+                                .stream()
+                                .flatMap(Collection::stream)
+                                .collect(Collectors.toList());
                         } catch (Exception e) {
                             throw new RuntimeException(e);
                         }
@@ -81,15 +74,15 @@ public class MapUtils {
             .entrySet()
             .stream()
             .collect(
-                HashMap::new,
+                () -> newHashMap(original.size()),
                 (map, entry) -> {
                     Object value = entry.getValue();
                     Object found;
 
                     if (value instanceof Map) {
-                        found = copyMap((Map) value);
+                        found = cloneMap((Map) value);
                     } else if (value instanceof Collection) {
-                        found = copyCollection((Collection) value, (Collection) value);
+                        found = cloneCollection((Collection) value);
                     } else {
                         found = value;
                     }
@@ -101,9 +94,19 @@ public class MapUtils {
             );
     }
 
-    private static Collection copyCollection(Collection collection, Collection elements) {
+    private static Map cloneMap(Map elements) {
         try {
-            Collection newInstance = collection.getClass().getDeclaredConstructor().newInstance();
+            Map newInstance = elements.getClass().getDeclaredConstructor().newInstance();
+            newInstance.putAll(elements);
+            return newInstance;
+        } catch (Exception e) {
+            return new HashMap(elements);
+        }
+    }
+
+    private static Collection cloneCollection(Collection elements) {
+        try {
+            Collection newInstance = elements.getClass().getDeclaredConstructor().newInstance();
             newInstance.addAll(elements);
             return newInstance;
         } catch (Exception e) {
@@ -131,5 +134,18 @@ public class MapUtils {
      */
     public static <K, V> Map<K, V> emptyOnNull(Map<K, V> map) {
         return map == null ? new HashMap<>() : map;
+    }
+
+    /**
+     * Creates a hash map that can hold <code>numMappings</code> entry.
+     * This is a copy of the same methods available starting with Java 19.
+     */
+    public static <K, V> HashMap<K, V> newHashMap(int numMappings) {
+        if (numMappings < 0) {
+            throw new IllegalArgumentException("Negative number of mappings: " + numMappings);
+        }
+
+        int hashMapCapacity = (int) Math.ceil(numMappings / 0.75d);
+        return new HashMap<>(hashMapCapacity);
     }
 }


### PR DESCRIPTION
On a contrieved example involving an EachParallel with 150 values and a hierarchy of subflows this improve the flow execution time from 22mn down to 11mn which is an improvement of 50%.

The two main changes, apart for some collection pre-sizing are:
- Avoid the deep clone in MapUtils to a simple defensive map copy using a new map and putAll
- Avoid traersing the list of taskrun for each taskrun when computing the output as it's very costly by pre-computing a list of taskrun by id.

@tchiotludo do you remember why MapUtils did a deep clone on maps and lists? Here I replace the recursive deep clone with basic cloning using a new HashMap and the putAll method. If it's OK this would greatly improve the performance.