### PR TITLE
feat(core): add EscapeChar Pebble filter

### DIFF
--- a/core/src/main/java/io/kestra/core/runners/pebble/Extension.java
+++ b/core/src/main/java/io/kestra/core/runners/pebble/Extension.java
@@ -65,6 +65,7 @@ public class Extension extends AbstractExtension {
         filters.put("timestampMicro", new TimestampMicroFilter());
         filters.put("timestampNano", new TimestampNanoFilter());
         filters.put("jq", new JqFilter());
+        filters.put("escapeChar", new EscapeCharFilter());
         filters.put("json", new JsonFilter());
         filters.put("keys", new KeysFilter());
         filters.put("number", new NumberFilter());

--- a/core/src/main/java/io/kestra/core/runners/pebble/filters/EscapeCharFilter.java
+++ b/core/src/main/java/io/kestra/core/runners/pebble/filters/EscapeCharFilter.java
@@ -1,0 +1,73 @@
+package io.kestra.core.runners.pebble.filters;
+
+import io.kestra.core.utils.Enums;
+import io.pebbletemplates.pebble.error.PebbleException;
+import io.pebbletemplates.pebble.extension.Filter;
+import io.pebbletemplates.pebble.template.EvaluationContext;
+import io.pebbletemplates.pebble.template.PebbleTemplate;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+public class EscapeCharFilter implements Filter {
+    private static final String ARG_NAME = "type";
+
+    private final List<String> argumentNames = new ArrayList<>();
+
+    public EscapeCharFilter() {
+        this.argumentNames.add(ARG_NAME);
+    }
+
+    @Override
+    public List<String> getArgumentNames() {
+        return this.argumentNames;
+    }
+
+    @Override
+    public Object apply(Object input, Map<String, Object> args, PebbleTemplate self, EvaluationContext context, int lineNumber) throws PebbleException {
+        if (input == null) {
+            return null;
+        }
+
+        final String inputValue = input.toString();
+
+        return switch (argsToType(args, self, lineNumber)) {
+            case SHELL -> escape(inputValue, "'", "'\\''");
+            case SINGLE -> escape(inputValue, "'", "\\'");
+            case DOUBLE -> escape(inputValue, "\"", "\\\"");
+        };
+    }
+
+    private FilterType argsToType(Map<String, Object> args, PebbleTemplate self, int lineNumber) {
+        if (!args.containsKey(ARG_NAME)) {
+            throw new PebbleException(null, "The 'escapeChar' filter expects an argument '" + ARG_NAME + "'.", lineNumber, self.getName());
+        }
+
+        final String type = (String) args.get(ARG_NAME);
+
+        try {
+            return Enums.getForNameIgnoreCase(type, FilterType.class);
+        } catch (IllegalArgumentException e) {
+            throw new PebbleException(
+                null,
+                "The 'escapeChar' filter expects the value of '" + ARG_NAME + "' to be either 'single', 'double', or 'shell'.",
+                lineNumber,
+                self.getName()
+            );
+        }
+    }
+
+    private String escape(String input, String original, String replacement) {
+        return input.replace(original, replacement);
+    }
+
+    /**
+     * Supported escape styles.
+     */
+    enum FilterType {
+        SINGLE,
+        DOUBLE,
+        SHELL
+    }
+}

--- a/core/src/test/java/io/kestra/core/runners/pebble/filters/EscapeCharFilterTest.java
+++ b/core/src/test/java/io/kestra/core/runners/pebble/filters/EscapeCharFilterTest.java
@@ -1,0 +1,57 @@
+package io.kestra.core.runners.pebble.filters;
+
+import io.kestra.core.exceptions.IllegalVariableEvaluationException;
+import io.kestra.core.runners.VariableRenderer;
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import jakarta.inject.Inject;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.util.Map;
+import java.util.stream.Stream;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@MicronautTest
+class EscapeCharFilterTest {
+    @Inject
+    private VariableRenderer variableRenderer;
+
+    @ParameterizedTest
+    @MethodSource("provideValidTypes")
+    void validTypes(String type, String input, String expected) throws IllegalVariableEvaluationException {
+        String render = variableRenderer.render(
+            "{{ " + input + " | escapeChar('" + type + "') }}",
+            Map.of()
+        );
+
+        assertThat(render, is(expected));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"foo", ""})
+    void invalidTypes(String type) {
+        assertThrows(
+            IllegalVariableEvaluationException.class,
+            () -> variableRenderer.render(
+                "{{ 'Hello' | escapeChar('" + type + "') }}",
+                Map.of()
+            )
+        );
+    }
+
+    private static Stream<Arguments> provideValidTypes() {
+        return Stream.of(
+            Arguments.of("single", "\"L'eau c'est la vie\"", "L\\'eau c\\'est la vie"),
+            Arguments.of("double", "'\"Hello\"'", "\\\"Hello\\\""),
+            Arguments.of("shell", "\"L'eau c'est la vie\"", "L'\\''eau c'\\''est la vie"),
+            Arguments.of("single", "''", ""),
+            Arguments.of("double", "''", ""),
+            Arguments.of("shell", "''", "")
+        );
+    }
+}


### PR DESCRIPTION
### What changes are being made and why?

The newly introduced `escapeChar` filter eases the string sanitization process. This PR is an evolution of #2361.

---

### How the changes have been QAed?

```yaml
id: escape-char-filter
namespace: dev

variables:
  quoted: "Can't"

tasks:
  - id: hello
    type: io.kestra.plugin.scripts.python.Commands
    commands:
      - "echo '--- {{ vars.quoted | escapeChar('shell') }} ---'"
      - "echo '--- {{ vars.quoted }} ---'" # FIXME
```