### PR TITLE
refactor(core): add reactive methods in FileSerde to optimize read/write performance of ION files

### DIFF
--- a/core/src/main/java/io/kestra/core/serializers/FileSerde.java
+++ b/core/src/main/java/io/kestra/core/serializers/FileSerde.java
@@ -1,26 +1,41 @@
 package io.kestra.core.serializers;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
+import static io.kestra.core.utils.Rethrow.throwBiFunction;
+import static io.kestra.core.utils.Rethrow.throwConsumer;
+import static io.kestra.core.utils.Rethrow.throwFunction;
+
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.MappingIterator;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SequenceWriter;
+import reactor.core.publisher.Flux;
 import reactor.core.publisher.FluxSink;
+import reactor.core.publisher.Mono;
 
+import java.io.BufferedInputStream;
+import java.io.BufferedOutputStream;
 import java.io.BufferedReader;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.UncheckedIOException;
+import java.util.Optional;
 import java.util.function.Consumer;
 
-abstract public class FileSerde {
-    private static final ObjectMapper MAPPER = JacksonMapper.ofIon()
-        .setSerializationInclusion(JsonInclude.Include.ALWAYS);
+public final class FileSerde {
 
-    private static final TypeReference<Object> TYPE_REFERENCE = new TypeReference<>(){};
+    private static final ObjectMapper DEFAULT_OBJECT_MAPPER = JacksonMapper.ofIon();
+    private static final TypeReference<Object> DEFAULT_TYPE_REFERENCE = new TypeReference<>(){};
+
+    /** The size of the buffer used for reading and writing data from streams. */
+    private static final int BUFFER_SIZE = 65535;
+
+    private FileSerde() {}
 
     public static void write(OutputStream output, Object row) throws IOException {
         if (row != null) { // avoid writing "null"
-            output.write(MAPPER.writeValueAsBytes(row));
+            output.write(DEFAULT_OBJECT_MAPPER.writeValueAsBytes(row));
             output.write("\n".getBytes());
         }
     }
@@ -78,10 +93,54 @@ abstract public class FileSerde {
     }
 
     private static Object convert(String row) throws JsonProcessingException {
-        return MAPPER.readValue(row, TYPE_REFERENCE);
+        return DEFAULT_OBJECT_MAPPER.readValue(row, DEFAULT_TYPE_REFERENCE);
     }
 
     private static <T> T convert(String row, Class<T> cls) throws JsonProcessingException {
-        return MAPPER.readValue(row, cls);
+        return DEFAULT_OBJECT_MAPPER.readValue(row, cls);
+    }
+
+    public static Flux<Object> readAll(InputStream in) throws IOException {
+        return readAll(DEFAULT_OBJECT_MAPPER, in, DEFAULT_TYPE_REFERENCE);
+    }
+
+    public static <T> Flux<T> readAll(InputStream in, TypeReference<T> type) throws IOException {
+        return readAll(DEFAULT_OBJECT_MAPPER, in, type);
+    }
+
+    public static Flux<Object> readAll(ObjectMapper objectMapper, InputStream in) throws IOException {
+        return readAll(objectMapper, in, DEFAULT_TYPE_REFERENCE);
+    }
+
+    public static <T> Flux<T> readAll(ObjectMapper objectMapper, InputStream in, TypeReference<T> type) throws IOException {
+        return Flux.generate(
+            () -> createMappingIterator(objectMapper, in, type),
+            throwBiFunction((iterator, sink) -> {
+                final T value = iterator.hasNextValue() ? iterator.nextValue() : null;
+                Optional.ofNullable(value).ifPresentOrElse(sink::next, sink::complete);
+                return iterator;
+            }),
+            throwConsumer(MappingIterator::close)
+        );
+    }
+
+    public static <T> Mono<Long> writeAll(OutputStream out, Flux<T> values) throws IOException {
+        return writeAll(DEFAULT_OBJECT_MAPPER, out, values);
+    }
+
+    public static <T> Mono<Long> writeAll(ObjectMapper objectMapper, OutputStream out, Flux<T> values) throws IOException {
+        return Mono.using(
+            () -> createSequenceWriter(objectMapper, out),
+            throwFunction((writer) -> values.doOnNext(throwConsumer(writer::write)).count()),
+            throwConsumer(SequenceWriter::close)
+        );
+    }
+
+    private static <T> MappingIterator<T> createMappingIterator(ObjectMapper objectMapper, InputStream in, TypeReference<T> type) throws IOException {
+        return objectMapper.readerFor(type).readValues(new BufferedInputStream(in, BUFFER_SIZE));
+    }
+
+    private static SequenceWriter createSequenceWriter(ObjectMapper objectMapper, OutputStream out) throws IOException {
+        return objectMapper.writer().writeValues(new BufferedOutputStream(out, BUFFER_SIZE));
     }
 }

--- a/core/src/main/java/io/kestra/core/serializers/FileSerde.java
+++ b/core/src/main/java/io/kestra/core/serializers/FileSerde.java
@@ -29,7 +29,7 @@ public final class FileSerde {
     private static final TypeReference<Object> DEFAULT_TYPE_REFERENCE = new TypeReference<>(){};
 
     /** The size of the buffer used for reading and writing data from streams. */
-    private static final int BUFFER_SIZE = 65535;
+    private static final int BUFFER_SIZE = 32 * 1024;
 
     private FileSerde() {}
 

--- a/core/src/main/java/io/kestra/core/serializers/JacksonMapper.java
+++ b/core/src/main/java/io/kestra/core/serializers/JacksonMapper.java
@@ -8,7 +8,6 @@ import com.amazon.ion.impl._Private_IonBinaryWriterBuilder;
 import com.amazon.ion.impl._Private_Utils;
 import com.amazon.ion.system.IonBinaryWriterBuilder;
 import com.amazon.ion.system.IonReaderBuilder;
-import com.amazon.ion.system.IonSystemBuilder;
 import com.amazon.ion.system.IonTextWriterBuilder;
 import com.amazon.ion.system.SimpleCatalog;
 import com.fasterxml.jackson.annotation.JsonInclude;
@@ -139,11 +138,20 @@ public final class JacksonMapper {
             .registerModule(new IonModule());
     }
 
-    /**
-     * @see IonSystemBuilder#build()
-     */
-    // TODO simplify after https://github.com/amazon-ion/ion-java/pull/781
     private static IonSystem createIonSystem() {
+        // This code is inspired by the IonSystemBuilder#build() method and the usage of "withWriteTopLevelValuesOnNewLines(true)".
+        //
+        // After the integration of the relevant pull request (https://github.com/amazon-ion/ion-java/pull/781),
+        // it is expected that this code should be replaced with a more simplified version.
+        //
+        // The simplified code would look like below:
+        //
+        // return IonSystemBuilder.standard()
+        //    .withIonTextWriterBuilder(IonTextWriterBuilder.standard().withWriteTopLevelValuesOnNewLines(true))
+        //    .build();
+        //
+        // TODO: Simplify this code once the pull request is integrated.
+
         final var catalog = new SimpleCatalog();
 
         final var textWriterBuilder = IonTextWriterBuilder.standard()

--- a/core/src/main/java/io/kestra/core/serializers/ion/IonFactory.java
+++ b/core/src/main/java/io/kestra/core/serializers/ion/IonFactory.java
@@ -1,6 +1,7 @@
 package io.kestra.core.serializers.ion;
 
 import com.amazon.ion.IonReader;
+import com.amazon.ion.IonSystem;
 import com.amazon.ion.IonWriter;
 import com.amazon.ion.system.IonSystemBuilder;
 import com.fasterxml.jackson.core.JsonParser;
@@ -12,6 +13,10 @@ import java.io.Reader;
 
 public class IonFactory extends com.fasterxml.jackson.dataformat.ion.IonFactory {
     private static final long serialVersionUID = 1L;
+
+    public IonFactory(IonSystem system) {
+        super(null, system);
+    }
 
     @Override
     protected JsonParser _createParser(Reader r, IOContext ctxt) throws IOException {


### PR DESCRIPTION
Hi Kestra!

This pull-request introduces several enhancements to I/O operations on ION files, aimed at improving performance, optimizing memory usage and providing better management of large datasets.

### What changes are being made and why?

- Following [Jackson library best practices](https://github.com/FasterXML/jackson-docs/wiki/Presentation:-Jackson-Performance#basics-things-you-should-do-anyway), the new code uses `MappingIterator` and `SequenceWriter`, combined with an `IonSystem` configured to support line-by-line writing.

- The instances of `MappingIterator` and `SequenceWriter` maintain their own context, resulting in faster processing, as their internal objects are reused for each line. Also, these instances also improve memory usage as they read/write data directly from/to the stream, avoiding the need for an intermediate `byte[]`.

- The `readAll` and `writeAll` methods hide the read/write logic by providing/consuming a `Flux` or `Mono`, making it easy to use files - all you have to do is manipulate the objects you want. The current `read` and `write` methods are untouched, but could be deprecated.

- Configuring the `IonSystem` seems a bit complex, so I've made a [PR](https://github.com/amazon-ion/ion-java/pull/781) to make it easier to configure a writer. The only interesting method here is `IonTextWriterBuilder#withWriteTopLevelValuesOnNewLines`, the rest are default values.

---

### How the changes have been QAed?

We use these methods internally on a custom plugin used in our production environment.

I'll add a few unit tests after discussing the suggested changes.
