### PR TITLE
chore: add optional sequential id to execution

### DIFF
--- a/core/src/main/java/io/kestra/core/runners/Executor.java
+++ b/core/src/main/java/io/kestra/core/runners/Executor.java
@@ -36,6 +36,11 @@ public class Executor {
     private ExecutionResumed joinedExecutionResumed;
 
     /**
+     * The sequence id should be incremented each time the execution is persisted after mutation.
+     */
+    private long seqId = 0L;
+
+    /**
      * List of {@link ExecutionKilled} to be propagated part of the execution.
      */
     private List<ExecutionKilledExecution> executionKilled;
@@ -43,6 +48,12 @@ public class Executor {
     public Executor(Execution execution, Long offset) {
         this.execution = execution;
         this.offset = offset;
+    }
+
+    public Executor(Execution execution, Long offset, long seqId) {
+        this.execution = execution;
+        this.offset = offset;
+        this.seqId = seqId;
     }
 
     public Executor(WorkerTaskResult workerTaskResult) {
@@ -148,7 +159,18 @@ public class Executor {
     public Executor serialize() {
         return new Executor(
             this.execution,
-            this.offset
+            this.offset,
+            this.seqId
         );
+    }
+
+    /**
+     * Increments and returns the execution sequence id.
+     *
+     * @return the sequence id.
+     */
+    public long incrementAndGetSeqId() {
+        this.seqId++;
+        return seqId;
     }
 }


### PR DESCRIPTION
This commit adds an optional seqId property to the Execution model object that can be used to detect concurrent updates.
