### PR TITLE
fix(ui): prevent superfluous API requests

### DIFF
--- a/ui/src/mixins/dataTableActions.js
+++ b/ui/src/mixins/dataTableActions.js
@@ -81,7 +81,6 @@ export default {
                 }
             }
 
-            delete query.page;
             this.internalPageNumber = 1
 
             this.$router.push({query: query})

--- a/ui/src/utils/eventsRouter.js
+++ b/ui/src/utils/eventsRouter.js
@@ -1,4 +1,5 @@
 import {nextTick} from "vue";
+import _isEqual from "lodash/isEqual";
 
 export const pageFromRoute = (route) => {
     return {
@@ -16,8 +17,11 @@ export const pageFromRoute = (route) => {
 }
 
 export default (app, store, router) => {
-    router.afterEach((to) => {
+    router.afterEach((to, from) => {
         nextTick().then(() => {
+            if (_isEqual(from, to)) {
+                return;
+            }
             store.dispatch("api/events", {
                 type: "PAGE",
                 page: pageFromRoute(to)


### PR DESCRIPTION
### What changes are being made and why?

Redundant API requests waste backend resources.

* Applying a data table (e.g. Executions or Flows) filter, such as a specific namespace, resulted in two identical search requests. Since the `page` query param is present even when its value equals `1` this proposed fix is valid.

* Navigation often emitted multiple identical stats events. Identical events most probably skewed the stats.