### PR TITLE
fix: downgrade Micronaut

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,8 @@
 version=0.17.0-SNAPSHOT
 
 jacksonVersion=2.16.2
-micronautVersion=4.3.7
+# Cannot upgrade for now due to https://github.com/kestra-io/kestra-ee/issues/1085
+micronautVersion=4.3.4
 lombokVersion=1.18.32
 slf4jVersion=2.0.12
 


### PR DESCRIPTION
Go back to previously working version 4.3.4 as 4.3.7 have a bug when randomly the routeMatch is null on the security filter. See https://github.com/kestra-io/kestra-ee/issues/1085