### PR TITLE
feat(core): add outputs support for conditional flow trigger (#3595)

### DIFF
--- a/core/src/main/java/io/kestra/core/models/conditions/types/ExecutionOutputsCondition.java
+++ b/core/src/main/java/io/kestra/core/models/conditions/types/ExecutionOutputsCondition.java
@@ -28,12 +28,12 @@ import static io.kestra.core.utils.MapUtils.mergeWithNullableValues;
 @NoArgsConstructor
 @Schema(
     title = "Condition based on the outputs of an execution.",
-    description = "If the result is an empty string, a string containing only space or `false`, the condition will be considered as `false`. The condition always return `false` if the execution has no output."
+    description = "The condition returns `false` if the execution has no output. If the result is an empty string `""`, a space `" "`, or `false`, the condition will also be considered as `false`."
 )
 @Plugin(
     examples = {
         @Example(
-            title = "A condition that will return true for an output equals to a specific value.",
+            title = "A condition that will return true for an output matching a specific value.",
             full = true,
             code = {
                 "- conditions:",

--- a/core/src/main/java/io/kestra/core/models/conditions/types/ExecutionOutputsCondition.java
+++ b/core/src/main/java/io/kestra/core/models/conditions/types/ExecutionOutputsCondition.java
@@ -1,0 +1,76 @@
+package io.kestra.core.models.conditions.types;
+
+import io.kestra.core.exceptions.InternalException;
+import io.kestra.core.models.annotations.Example;
+import io.kestra.core.models.annotations.Plugin;
+import io.kestra.core.models.annotations.PluginProperty;
+import io.kestra.core.models.conditions.Condition;
+import io.kestra.core.models.conditions.ConditionContext;
+import io.kestra.core.models.conditions.ScheduleCondition;
+import io.kestra.core.models.executions.Execution;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+import lombok.experimental.SuperBuilder;
+
+import java.util.Map;
+
+import static io.kestra.core.utils.MapUtils.mergeWithNullableValues;
+
+@SuperBuilder
+@ToString
+@EqualsAndHashCode
+@Getter
+@NoArgsConstructor
+@Schema(
+    title = "Condition based on the outputs of an execution.",
+    description = "If the result is an empty string, a string containing only space or `false`, the condition will be considered as `false`. The condition always return `false` if the execution has no output."
+)
+@Plugin(
+    examples = {
+        @Example(
+            title = "A condition that will return true for an output equals to a specific value.",
+            full = true,
+            code = {
+                "- conditions:",
+                "    - type: io.kestra.core.models.conditions.types.ExecutionOutputsCondition",
+                "      expression: {{ trigger.outputs.status_code == '200' }}",
+            }
+        )
+    }
+)
+public class ExecutionOutputsCondition extends Condition implements ScheduleCondition {
+
+    private static final String TRIGGER_VAR = "trigger";
+    private static final String OUTPUTS_VAR = "outputs";
+
+    @NotNull
+    @NotEmpty
+    @PluginProperty
+    private String expression;
+
+    /** {@inheritDoc} **/
+    @Override
+    public boolean test(ConditionContext conditionContext) throws InternalException {
+
+        if (hasNoOutputs(conditionContext.getExecution())) {
+            return false; // shortcut for not evaluating the expression.
+        }
+
+        Map<String, Object> variables = mergeWithNullableValues(
+            conditionContext.getVariables(),
+            Map.of(TRIGGER_VAR, Map.of(OUTPUTS_VAR, conditionContext.getExecution().getOutputs()))
+        );
+
+        String render = conditionContext.getRunContext().render(expression, variables);
+        return !(render.isBlank() || render.isEmpty() || render.trim().equals("false"));
+    }
+
+    private boolean hasNoOutputs(final Execution execution) {
+        return execution.getOutputs() == null || execution.getOutputs().isEmpty();
+    }
+}

--- a/core/src/main/java/io/kestra/core/utils/TestsUtils.java
+++ b/core/src/main/java/io/kestra/core/utils/TestsUtils.java
@@ -105,10 +105,17 @@ abstract public class TestsUtils {
     }
 
     public static Execution mockExecution(Flow flow, Map<String, Object> inputs) {
-        return TestsUtils.mockExecution(Thread.currentThread().getStackTrace()[2], flow, inputs);
+        return TestsUtils.mockExecution(Thread.currentThread().getStackTrace()[2], flow, inputs, null);
     }
 
-    private static Execution mockExecution(StackTraceElement caller, Flow flow, Map<String, Object> inputs) {
+    public static Execution mockExecution(Flow flow, Map<String, Object> inputs, Map<String, Object> outputs) {
+        return TestsUtils.mockExecution(Thread.currentThread().getStackTrace()[2], flow, inputs, outputs);
+    }
+
+    private static Execution mockExecution(StackTraceElement caller,
+                                           Flow flow,
+                                           Map<String, Object> inputs,
+                                           Map<String, Object> outputs) {
         return Execution.builder()
             .id(IdUtils.create())
             .tenantId(flow.getTenantId())
@@ -116,6 +123,7 @@ abstract public class TestsUtils {
             .flowId(flow.getId())
             .inputs(inputs)
             .state(new State())
+            .outputs(outputs)
             .build()
             .withState(State.Type.RUNNING);
     }
@@ -161,7 +169,7 @@ abstract public class TestsUtils {
         StackTraceElement caller = Thread.currentThread().getStackTrace()[2];
 
         Flow flow = TestsUtils.mockFlow(caller);
-        Execution execution = TestsUtils.mockExecution(caller, flow, inputs);
+        Execution execution = TestsUtils.mockExecution(caller, flow, inputs, null);
         TaskRun taskRun = TestsUtils.mockTaskRun(caller, execution, task);
 
         return runContextFactory.of(flow, task, execution, taskRun);

--- a/core/src/test/java/io/kestra/core/models/conditions/types/ExecutionOutputsConditionTest.java
+++ b/core/src/test/java/io/kestra/core/models/conditions/types/ExecutionOutputsConditionTest.java
@@ -1,0 +1,68 @@
+package io.kestra.core.models.conditions.types;
+
+import io.kestra.core.models.executions.Execution;
+import io.kestra.core.models.flows.Flow;
+import io.kestra.core.services.ConditionService;
+import io.kestra.core.utils.TestsUtils;
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+@MicronautTest
+class ExecutionOutputsConditionTest {
+    @Inject
+    ConditionService conditionService;
+
+    @Test
+    void shouldEvaluateToTrueGivenValidExpression() {
+        Flow flow = TestsUtils.mockFlow();
+        Execution execution = TestsUtils.mockExecution(
+            flow,
+            Map.of(),
+            Map.of("test", "value"));
+
+        ExecutionOutputsCondition build = ExecutionOutputsCondition.builder()
+            .expression("{{ trigger.outputs.test == 'value' }}")
+            .build();
+
+        boolean test = conditionService.isValid(build, flow, execution);
+
+        assertThat(test, is(true));
+    }
+
+    @Test
+    void shouldEvaluateToFalseGivenInvalidExpression() {
+        Flow flow = TestsUtils.mockFlow();
+        Execution execution = TestsUtils.mockExecution(
+            flow,
+            Map.of(),
+            Map.of("test", "value"));
+
+        ExecutionOutputsCondition build = ExecutionOutputsCondition.builder()
+            .expression("{{ unknown is defined }}")
+            .build();
+
+        boolean test = conditionService.isValid(build, flow, execution);
+
+        assertThat(test, is(false));
+    }
+
+    @Test
+    void shouldEvaluateToFalseGivenExecutionWithNoOutputs() {
+        Flow flow = TestsUtils.mockFlow();
+        Execution execution = TestsUtils.mockExecution(flow, Map.of());
+
+        ExecutionOutputsCondition build = ExecutionOutputsCondition.builder()
+            .expression("{{ not evaluated }}")
+            .build();
+
+        boolean test = conditionService.isValid(build, flow, execution);
+
+        assertThat(test, is(false));
+    }
+}


### PR DESCRIPTION
Changes:
- add new ExecutionOutputsCondition
- allow outputs to be available for rendering trigger inputs

Fix: #3559

Example: 

**Flow-A**
```
id: flow-a
namespace: test
tasks:
  - id: return
    type: io.kestra.core.tasks.debugs.Return
    format: "OK"
outputs:
  - id: result
    type: STRING
    value: "{{ outputs.return.value }}"
```

**Flow-B**
```
id: flow-b
namespace: test
inputs:
  - id: message
    type: STRING
tasks:
  - id: log
    type: io.kestra.core.tasks.log.Log
    message: "{{ inputs.message }}"
triggers:
  - id: flow-a
    type: io.kestra.core.models.triggers.types.Flow
    conditions:
      - type: io.kestra.core.models.conditions.types.ExecutionNamespaceCondition
        namespace: test
      - type: io.kestra.core.models.conditions.types.ExecutionOutputsCondition
        expression:  "{{ trigger.outputs.result == 'OK' }}"
    inputs:
      message: "{{ trigger.outputs.result }}"
```
