### PR TITLE
feat(core): support ARRAY inputs

### DIFF
--- a/core/src/main/java/io/kestra/core/models/flows/Input.java
+++ b/core/src/main/java/io/kestra/core/models/flows/Input.java
@@ -24,6 +24,7 @@ import jakarta.validation.constraints.Pattern;
 @JsonInclude(JsonInclude.Include.NON_DEFAULT)
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type", visible = true, include = JsonTypeInfo.As.EXISTING_PROPERTY)
 @JsonSubTypes({
+    @JsonSubTypes.Type(value = ArrayInput.class, name = "ARRAY"),
     @JsonSubTypes.Type(value = BooleanInput.class, name = "BOOLEAN"),
     @JsonSubTypes.Type(value = DateInput.class, name = "DATE"),
     @JsonSubTypes.Type(value = DateTimeInput.class, name = "DATETIME"),

--- a/core/src/main/java/io/kestra/core/models/flows/Type.java
+++ b/core/src/main/java/io/kestra/core/models/flows/Type.java
@@ -20,7 +20,8 @@ public enum Type {
     FILE(FileInput.class.getName()),
     JSON(JsonInput.class.getName()),
     URI(URIInput.class.getName()),
-    SECRET(SecretInput.class.getName());
+    SECRET(SecretInput.class.getName()),
+    ARRAY(ArrayInput.class.getName());
 
     private final String clsName;
 

--- a/core/src/main/java/io/kestra/core/models/flows/input/ArrayInput.java
+++ b/core/src/main/java/io/kestra/core/models/flows/input/ArrayInput.java
@@ -1,0 +1,40 @@
+package io.kestra.core.models.flows.input;
+
+import io.kestra.core.models.flows.Input;
+import io.kestra.core.models.flows.Type;
+import io.kestra.core.models.validations.ManualConstraintViolation;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.ConstraintViolationException;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+import java.util.List;
+import java.util.Set;
+
+@SuperBuilder
+@Getter
+@NoArgsConstructor
+public class ArrayInput extends Input<List<?>> {
+    @Schema(
+        title = "Type of the array items.",
+        description = "Cannot be of type `ARRAY`."
+    )
+    @NotNull
+    private Type itemType;
+
+    @Override
+    public void validate(List<?> input) throws ConstraintViolationException {
+        if (Type.ARRAY.equals(itemType)) {
+            throw new ConstraintViolationException("Invalid input definition: `itemType` cannot be `ARRAY`",
+                Set.of(ManualConstraintViolation.of(
+                    "Invalid input",
+                    this,
+                    ArrayInput.class,
+                    getId(),
+                    input
+                )));
+        }
+    }
+}

--- a/core/src/main/java/io/kestra/core/serializers/JacksonMapper.java
+++ b/core/src/main/java/io/kestra/core/serializers/JacksonMapper.java
@@ -30,11 +30,13 @@ import io.kestra.core.serializers.ion.IonModule;
 import org.yaml.snakeyaml.LoaderOptions;
 
 import java.time.ZoneId;
+import java.util.List;
 import java.util.Map;
 import java.util.TimeZone;
 
 public final class JacksonMapper {
 
+    private static final TypeReference<List<Object>> LIST_TYPE_REFERENCE = new TypeReference<>() {};
     private JacksonMapper() {}
 
     private static final ObjectMapper MAPPER = JacksonMapper.configure(
@@ -89,6 +91,10 @@ public final class JacksonMapper {
 
     public static Map<String, Object> toMap(String json) throws JsonProcessingException {
         return MAPPER.readValue(json, TYPE_REFERENCE);
+    }
+
+    public static List<Object> toList(String json) throws JsonProcessingException {
+        return MAPPER.readValue(json, LIST_TYPE_REFERENCE);
     }
 
     private static final TypeReference<Object> TYPE_REFERENCE_OBJECT = new TypeReference<>() {};

--- a/core/src/test/java/io/kestra/core/runners/InputsTest.java
+++ b/core/src/test/java/io/kestra/core/runners/InputsTest.java
@@ -22,6 +22,7 @@ import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalTime;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.TimeoutException;
@@ -55,6 +56,8 @@ public class InputsTest extends AbstractMemoryRunnerTest {
         .put("validatedFloat", "0.42")
         .put("validatedTime", "11:27:49")
         .put("secret", "secret")
+        .put("array", """
+            ["s1", "s2", "s3"]""")
         .build();
 
     @Inject
@@ -128,10 +131,13 @@ public class InputsTest extends AbstractMemoryRunnerTest {
         assertThat(typeds.get("validatedFloat"), is(0.42F));
         assertThat(typeds.get("validatedTime"), is(LocalTime.parse("11:27:49")));
         assertThat(typeds.get("secret"), not("secret")); // secret inputs are encrypted
+        assertThat(typeds.get("array"), instanceOf(List.class));
+        assertThat((List<String>)typeds.get("array"), hasSize(3));
+        assertThat((List<String>)typeds.get("array"), contains("s1", "s2", "s3"));
     }
 
     @Test
-    void allValidTypedInputs() throws URISyntaxException, IOException {
+    void allValidTypedInputs() {
         Map<String, Object> typeds = typedInputs(inputs);
         typeds.put("int", 42);
         typeds.put("float", 42.42F);
@@ -154,7 +160,7 @@ public class InputsTest extends AbstractMemoryRunnerTest {
             (flow, execution1) -> runnerUtils.typedInputs(flow, execution1, inputs)
         );
 
-        assertThat(execution.getTaskRunList(), hasSize(6));
+        assertThat(execution.getTaskRunList(), hasSize(10));
         assertThat(execution.getState().getCurrent(), is(State.Type.SUCCESS));
         assertThat(
             (String) execution.findTaskRunsByTaskId("file").get(0).getOutputs().get("value"),

--- a/core/src/test/java/io/kestra/core/serializers/JacksonMapperTest.java
+++ b/core/src/test/java/io/kestra/core/serializers/JacksonMapperTest.java
@@ -1,5 +1,6 @@
 package io.kestra.core.serializers;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -11,11 +12,11 @@ import org.junitpioneer.jupiter.RetryingTest;
 import java.io.IOException;
 import java.time.Instant;
 import java.time.ZonedDateTime;
+import java.util.List;
 import java.util.TimeZone;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.containsString;
-import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.*;
 
 class JacksonMapperTest {
     Pojo pojo() {
@@ -54,6 +55,16 @@ class JacksonMapperTest {
         assertThat(s, containsString("nullable:null"));
         Pojo deserialize = mapper.readValue(s, Pojo.class);
         test(original, deserialize);
+    }
+
+    @Test
+    void toList() throws JsonProcessingException {
+        String list = "[1, 2, 3]";
+
+        List<Object> integerList = JacksonMapper.toList(list);
+
+        assertThat(integerList.size(), is(3));
+        assertThat(integerList, containsInAnyOrder(1, 2, 3));
     }
 
     void test(Pojo original, Pojo deserialize) {

--- a/core/src/test/java/io/kestra/core/serializers/YamlFlowParserTest.java
+++ b/core/src/test/java/io/kestra/core/serializers/YamlFlowParserTest.java
@@ -123,8 +123,8 @@ class YamlFlowParserTest {
     void inputs() {
         Flow flow = this.parse("flows/valids/inputs.yaml");
 
-        assertThat(flow.getInputs().size(), is(26));
-        assertThat(flow.getInputs().stream().filter(Input::getRequired).count(), is(8L));
+        assertThat(flow.getInputs().size(), is(27));
+        assertThat(flow.getInputs().stream().filter(Input::getRequired).count(), is(9L));
         assertThat(flow.getInputs().stream().filter(r -> !r.getRequired()).count(), is(18L));
         assertThat(flow.getInputs().stream().filter(r -> r.getDefaults() != null).count(), is(1L));
         assertThat(flow.getInputs().stream().filter(r -> r instanceof StringInput && ((StringInput)r).getValidator() != null).count(), is(1L));

--- a/core/src/test/resources/flows/valids/inputs.yaml
+++ b/core/src/test/resources/flows/valids/inputs.yaml
@@ -92,6 +92,9 @@ inputs:
   required: false
 - name: secret
   type: SECRET
+- name: array
+  type: ARRAY
+  itemType: STRING
 
 tasks:
 - id: string
@@ -112,3 +115,10 @@ tasks:
 - id: secret
   type: io.kestra.core.tasks.debugs.Return
   format: "{{inputs.secret}}"
+- id: array
+  type: io.kestra.core.tasks.flows.EachSequential
+  value: "{{inputs.array}}"
+  tasks:
+    - id: log
+      type: io.kestra.core.tasks.debugs.Return
+      format: "{{taskrun.value}}"

--- a/ui/src/components/flows/FlowRun.vue
+++ b/ui/src/components/flows/FlowRun.vue
@@ -95,7 +95,7 @@
                     :full-height="false"
                     :input="true"
                     :navbar="false"
-                    v-if="input.type === 'JSON'"
+                    v-if="input.type === 'JSON' || input.type === 'ARRAY'"
                     lang="json"
                     v-model="inputs[input.id]"
                 />

--- a/webserver/src/test/java/io/kestra/webserver/controllers/api/ExecutionControllerTest.java
+++ b/webserver/src/test/java/io/kestra/webserver/controllers/api/ExecutionControllerTest.java
@@ -96,6 +96,8 @@ class ExecutionControllerTest extends JdbcH2ControllerTest {
         .put("instant", "2019-10-06T18:27:49Z")
         .put("file", Objects.requireNonNull(InputsTest.class.getClassLoader().getResource("data/hello.txt")).getPath())
         .put("secret", "secret")
+        .put("array", """
+            ["s1", "s2", "s3"]""")
         .build();
 
     @Test
@@ -135,6 +137,8 @@ class ExecutionControllerTest extends JdbcH2ControllerTest {
             .addPart("files", "file", MediaType.TEXT_PLAIN_TYPE, applicationFile)
             .addPart("files", "optionalFile", MediaType.TEXT_XML_TYPE, logbackFile)
             .addPart("secret", "secret")
+            .addPart("array", """
+            ["s1", "s2", "s3"]""")
             .build();
     }
 
@@ -168,7 +172,7 @@ class ExecutionControllerTest extends JdbcH2ControllerTest {
         Execution result = triggerInputsFlowExecution(true);
 
         assertThat(result.getState().getCurrent(), is(State.Type.SUCCESS));
-        assertThat(result.getTaskRunList().size(), is(6));
+        assertThat(result.getTaskRunList().size(), is(10));
     }
 
     @Test
@@ -527,7 +531,7 @@ class ExecutionControllerTest extends JdbcH2ControllerTest {
     @Test
     void downloadFile() throws TimeoutException {
         Execution execution = runnerUtils.runOne(null, TESTS_FLOW_NS, "inputs", null, (flow, execution1) -> runnerUtils.typedInputs(flow, execution1, inputs));
-        assertThat(execution.getTaskRunList(), hasSize(6));
+        assertThat(execution.getTaskRunList(), hasSize(10));
 
         String path = (String) execution.getInputs().get("file");
 
@@ -562,7 +566,7 @@ class ExecutionControllerTest extends JdbcH2ControllerTest {
     @Test
     void filePreview() throws TimeoutException {
         Execution defaultExecution = runnerUtils.runOne(null, TESTS_FLOW_NS, "inputs", null, (flow, execution1) -> runnerUtils.typedInputs(flow, execution1, inputs));
-        assertThat(defaultExecution.getTaskRunList(), hasSize(6));
+        assertThat(defaultExecution.getTaskRunList(), hasSize(10));
 
         String defaultPath = (String) defaultExecution.getInputs().get("file");
 
@@ -582,10 +586,12 @@ class ExecutionControllerTest extends JdbcH2ControllerTest {
             .put("instant", "2019-10-06T18:27:49Z")
             .put("file", Objects.requireNonNull(ExecutionControllerTest.class.getClassLoader().getResource("data/iso88591.txt")).getPath())
             .put("secret", "secret")
+            .put("array", """
+            ["s1", "s2", "s3"]""")
             .build();
 
         Execution latin1Execution = runnerUtils.runOne(null, TESTS_FLOW_NS, "inputs", null, (flow, execution1) -> runnerUtils.typedInputs(flow, execution1, latin1FileInputs));
-        assertThat(latin1Execution.getTaskRunList(), hasSize(6));
+        assertThat(latin1Execution.getTaskRunList(), hasSize(10));
 
         String latin1Path = (String) latin1Execution.getInputs().get("file");
 

--- a/webserver/src/test/java/io/kestra/webserver/controllers/api/PluginControllerTest.java
+++ b/webserver/src/test/java/io/kestra/webserver/controllers/api/PluginControllerTest.java
@@ -203,7 +203,7 @@ class PluginControllerTest {
                 Argument.listOf(InputType.class)
             );
 
-            assertThat(doc.size(), is(13));
+            assertThat(doc.size(), is(14));
         });
     }
 


### PR DESCRIPTION
Fixes #771

Example flow:

```yaml
id: array-input
namespace: myteam

inputs:
  - id: payload
    type: ARRAY
    elementType: STRING

tasks:
  - id: each
    type: io.kestra.core.tasks.flows.EachSequential
    value: "{{inputs.payload}}"
    tasks:
      - id: log
        type: io.kestra.core.tasks.log.Log
        message: "{{taskrun.value}}"
```