### PR TITLE
chore: upgrade to Micronaut 4.3.8

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,8 +1,7 @@
 version=0.17.0-SNAPSHOT
 
 jacksonVersion=2.16.2
-# Cannot upgrade for now due to https://github.com/kestra-io/kestra-ee/issues/1085
-micronautVersion=4.3.4
+micronautVersion=4.3.8
 lombokVersion=1.18.32
 slf4jVersion=2.0.12
 

--- a/webserver/src/main/resources/META-INF/services/io.micronaut.http.cookie.DefaultServerCookieEncoder
+++ b/webserver/src/main/resources/META-INF/services/io.micronaut.http.cookie.DefaultServerCookieEncoder
@@ -1,0 +1,1 @@
+io.micronaut.http.cookie.DefaultServerCookieEncoder

--- a/webserver/src/main/resources/META-INF/services/io.micronaut.http.cookie.ServerCookieDecoder
+++ b/webserver/src/main/resources/META-INF/services/io.micronaut.http.cookie.ServerCookieDecoder
@@ -1,1 +1,0 @@
-io.micronaut.http.netty.cookies.NettyLaxServerCookieDecoder


### PR DESCRIPTION
Fixes micronaut-projects/micronaut-core#3553

Using the trick explained [here](https://github.com/micronaut-projects/micronaut-security/issues/1683) to use a different cookie encoder to fix https://github.com/micronaut-projects/micronaut-security/issues/1683