### PR TITLE
feat(core): rename Pebble context() function to printContext()

### DIFF
--- a/core/src/main/java/io/kestra/core/runners/pebble/Extension.java
+++ b/core/src/main/java/io/kestra/core/runners/pebble/Extension.java
@@ -114,7 +114,7 @@ public class Extension extends AbstractExtension {
         functions.put("encrypt", new EncryptFunction());
         functions.put("decrypt", new DecryptFunction());
         functions.put("yaml", new YamlFunction());
-        functions.put("context", new ContextFunction());
+        functions.put("printContext", new PrintContextFunction());
 
         return functions;
     }

--- a/core/src/main/java/io/kestra/core/runners/pebble/functions/PrintContextFunction.java
+++ b/core/src/main/java/io/kestra/core/runners/pebble/functions/PrintContextFunction.java
@@ -11,7 +11,7 @@ import java.util.List;
 import java.util.Map;
 
 @Singleton
-public class ContextFunction implements Function {
+public class PrintContextFunction implements Function {
     public List<String> getArgumentNames() {
         return List.of();
     }

--- a/core/src/test/java/io/kestra/core/runners/pebble/functions/PrintContextFunctionTest.java
+++ b/core/src/test/java/io/kestra/core/runners/pebble/functions/PrintContextFunctionTest.java
@@ -15,13 +15,13 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
 @MicronautTest
-class ContextFunctionTest {
+class PrintContextFunctionTest {
     @Inject
     VariableRenderer variableRenderer;
 
     @Test
     void fromString() throws IllegalVariableEvaluationException, JsonProcessingException {
-        String render = variableRenderer.render("{{ dump() }}", Map.of("test", "value", "array", List.of("a", "b", "c")));
+        String render = variableRenderer.render("{{ printContext() }}", Map.of("test", "value", "array", List.of("a", "b", "c")));
         assertThat(JacksonMapper.toMap(render).get("test"), is("value"));
         assertThat(JacksonMapper.toMap(render).get("array"), is(List.of("a", "b", "c")));
     }


### PR DESCRIPTION
Fixes #3674

The fucntion was already renamed to context() in the previous commit, this PR renamed it again to printContext()