### PR TITLE
feat(core): add pebble support expression for STRING input (#2287)

### DIFF
--- a/core/src/main/java/io/kestra/core/utils/MapUtils.java
+++ b/core/src/main/java/io/kestra/core/utils/MapUtils.java
@@ -123,6 +123,7 @@ public class MapUtils {
      */
     public static Map<String, Object> mergeWithNullableValues(final Map<String, Object>...maps) {
         return Arrays.stream(maps)
+            .filter(Objects::nonNull)
             .flatMap(map -> map.entrySet().stream())
             // https://bugs.openjdk.org/browse/JDK-8148463
             .collect(HashMap::new, (m, v) -> m.put(v.getKey(), v.getValue()), HashMap::putAll);


### PR DESCRIPTION
Fix: #2287

Example:

```yaml
id: test
namespace: test

inputs:
  - id: "me"
    type: "STRING"
    defaults: "me"

  - id: "username"
    type: "STRING"
    defaults: "{{ inputs.me | capitalize }}"

  - id: "date"
    type: "STRING"
    defaults: "{{ now() }}"
tasks:
  - id: print
    type: io.kestra.core.tasks.log.Log
    message: "Hello World from {{inputs.username}} at {{inputs.date}}!!!"
````
