### PR TITLE
feat(ui): structured settings page by sections

### DIFF
--- a/ui/src/components/settings/BasicSettings.vue
+++ b/ui/src/components/settings/BasicSettings.vue
@@ -1,144 +1,175 @@
 <template>
     <top-nav-bar :title="routeInfo.title" />
-    <section class="container">
-        <el-form class="ks-horizontal max-size">
-            <el-form-item :label="$t('Language')">
-                <el-select :model-value="lang" @update:model-value="onLang">
-                    <el-option
-                        v-for="item in langOptions"
-                        :key="item.value"
-                        :label="item.text"
-                        :value="item.value"
-                    />
-                </el-select>
-            </el-form-item>
 
-            <el-form-item :label="$t('theme')">
-                <el-select :model-value="theme" @update:model-value="onTheme">
-                    <el-option
-                        v-for="item in themesOptions"
-                        :key="item.value"
-                        :label="item.text"
-                        :value="item.value"
-                    />
-                </el-select>
-            </el-form-item>
+    <Wrapper>
+        <Block :heading="$t('settings.blocks.configuration.label')">
+            <template #content>
+                <Row>
+                    <Column v-if="allowDefaultNamespace" :label="$t('settings.blocks.configuration.fields.default_namespace')">
+                        <namespace-select data-type="flow" :value="defaultNamespace" @update:model-value="onNamespaceSelect" />
+                    </Column>
 
-            <el-form-item :label="$t('date format')">
-                <el-select :model-value="dateFormat" @update:model-value="onDateFormat">
-                    <el-option
-                        v-for="item in dateFormats"
-                        :key="timezone + item.value"
-                        :label="$filters.date(now, item.value)"
-                        :value="item.value"
-                    />
-                </el-select>
-            </el-form-item>
+                    <Column :label="$t('settings.blocks.configuration.fields.log_level')">
+                        <log-level-selector clearable :value="defaultLogLevel" @update:model-value="onLevelChange" />
+                    </Column>
 
-            <el-form-item :label="$t('timezone')">
-                <el-select :model-value="timezone" @update:model-value="onTimezone" filterable>
-                    <el-option
-                        v-for="item in zonesWithOffset"
-                        :key="item.zone"
-                        :label="`${item.zone} (UTC${item.offset === 0 ? '' : item.formattedOffset})`"
-                        :value="item.zone"
-                    />
-                </el-select>
-            </el-form-item>
+                    <Column :label="$t('settings.blocks.configuration.fields.log_display')">
+                        <el-select :model-value="logDisplay" @update:model-value="onLogDisplayChange">
+                            <el-option
+                                v-for="item in logDisplayOptions"
+                                :key="item.value"
+                                :label="item.text"
+                                :value="item.value"
+                            />
+                        </el-select>
+                    </Column>
 
-            <el-form-item :label="$t('Editor theme')">
-                <el-select :model-value="editorTheme" @update:model-value="onEditorTheme">
-                    <el-option
-                        v-for="item in editorThemesOptions"
-                        :key="item.value"
-                        :label="item.text"
-                        :value="item.value"
-                    />
-                </el-select>
-            </el-form-item>
+                    <Column :label="$t('settings.blocks.configuration.fields.execute_flow')">
+                        <el-select :model-value="executeFlowBehaviour" @update:model-value="onExecuteFlowBehaviourChange">
+                            <el-option
+                                v-for="item in Object.values(executeFlowBehaviours)"
+                                :key="item"
+                                :label="$t(`open in ${item}`)"
+                                :value="item"
+                            />
+                        </el-select>
+                    </Column>
+                </Row>
+            </template>
+        </Block>
 
-            <el-form-item :label="$t('Editor fontsize')">
-                <el-input-number
-                    :model-value="editorFontSize"
-                    @update:model-value="onFontSize"
-                    controls-position="right"
-                    :min="1"
-                    :max="50"
-                />
-            </el-form-item>
+        <Block :heading="$t('settings.blocks.theme.label')">
+            <template #content>
+                <Row>
+                    <Column :label="$t('settings.blocks.theme.fields.mode')">
+                        <el-select :model-value="theme" @update:model-value="onTheme">
+                            <el-option
+                                v-for="item in themesOptions"
+                                :key="item.value"
+                                :label="item.text"
+                                :value="item.value"
+                            />
+                        </el-select>
+                    </Column>
+                </Row>
 
-            <el-form-item :label="$t('Editor fontfamily')">
-                <el-select :model-value="editorFontFamily" @update:model-value="onFontFamily">
-                    <el-option
-                        v-for="item in fontFamilyOptions"
-                        :key="item.value"
-                        :label="item.text"
-                        :value="item.value"
-                    />
-                </el-select>
-            </el-form-item>
+                <Row>
+                    <Column :label="$t('settings.blocks.theme.fields.editor_theme')">
+                        <el-select :model-value="editorTheme" @update:model-value="onEditorTheme">
+                            <el-option
+                                v-for="item in editorThemesOptions"
+                                :key="item.value"
+                                :label="item.text"
+                                :value="item.value"
+                            />
+                        </el-select>
+                    </Column>
 
-            <el-form-item label="&nbsp;">
-                <el-checkbox :label="$t('Fold auto')" :model-value="autofoldTextEditor" @update:model-value="onAutofoldTextEditor" />
-            </el-form-item>
+                    <Column :label="$t('settings.blocks.theme.fields.editor_font_size')">
+                        <el-input-number
+                            :model-value="editorFontSize"
+                            @update:model-value="onFontSize"
+                            controls-position="right"
+                            :min="1"
+                            :max="50"
+                        />
+                    </Column>
+                    
+                    <Column :label="$t('settings.blocks.theme.fields.editor_font_family')">
+                        <el-select :model-value="editorFontFamily" @update:model-value="onFontFamily">
+                            <el-option
+                                v-for="item in fontFamilyOptions"
+                                :key="item.value"
+                                :label="item.text"
+                                :value="item.value"
+                            />
+                        </el-select>
+                    </Column>
+                </Row>
 
-            <el-form-item :label="$t('Default namespace')" v-if="allowDefaultNamespace">
-                <namespace-select data-type="flow" :value="defaultNamespace" @update:model-value="onNamespaceSelect" />
-            </el-form-item>
+                <Row>
+                    <Column :overrides="{sm: 24, md: 24, lg: 24, xl: 24}" :label="$t('settings.blocks.theme.fields.editor_folding_stratgy')">
+                        <el-switch :aria-label="$t('Fold auto')" :model-value="autofoldTextEditor" @update:model-value="onAutofoldTextEditor" />
+                    </Column>
+                </Row>
 
-            <el-form-item :label="$t('Default log level')">
-                <log-level-selector clearable :value="defaultLogLevel" @update:model-value="onLevelChange" />
-            </el-form-item>
+                <Row>
+                    <Column :label="$t('settings.blocks.theme.fields.environment_name')">
+                        <el-input
+                            v-model="envName"
+                            @change="onEnvNameChange"
+                            :placeholder="$t('name')"
+                            clearable
+                        />
+                    </Column>
 
-            <el-form-item v-if="canReadFlows || canReadTemplates" :label="$t('exports')">
-                <el-button v-if="canReadFlows" :icon="Download" size="large" @click="exportFlows()">
-                    {{ $t('export all flows') }}
-                </el-button>
-                <el-button v-if="canReadTemplates" :icon="Download" size="large" @click="exportTemplates()" :hidden="!configs?.isTemplateEnabled">
-                    {{ $t('export all templates') }}
-                </el-button>
-            </el-form-item>
+                    <Column :label="$t('settings.blocks.theme.fields.environment_color')">
+                        <el-color-picker
+                            v-model="envColor"
+                            @change="onEnvColorChange"
+                            show-alpha
+                        />
+                    </Column>
+                </Row>
+            </template>
+        </Block>
 
-            <el-form-item :label="$t('log expand setting')">
-                <el-select :model-value="logDisplay" @update:model-value="onLogDisplayChange">
-                    <el-option
-                        v-for="item in logDisplayOptions"
-                        :key="item.value"
-                        :label="item.text"
-                        :value="item.value"
-                    />
-                </el-select>
-            </el-form-item>
+        <Block :heading="$t('settings.blocks.localization.label')">
+            <template #content>
+                <Row>
+                    <Column :label="$t('settings.blocks.localization.fields.language')">
+                        <el-select :model-value="lang" @update:model-value="onLang">
+                            <el-option
+                                v-for="item in langOptions"
+                                :key="item.value"
+                                :label="item.text"
+                                :value="item.value"
+                            />
+                        </el-select>
+                    </Column>
+                </Row>
 
-            <el-form-item :label="$t('environment name setting')">
-                <el-input
-                    v-model="envName"
-                    @change="onEnvNameChange"
-                    :placeholder="$t('name')"
-                    clearable
-                />
-            </el-form-item>
+                <Row>
+                    <Column :label="$t('settings.blocks.localization.fields.time_zone')">
+                        <el-select :model-value="timezone" @update:model-value="onTimezone" filterable>
+                            <el-option
+                                v-for="item in zonesWithOffset"
+                                :key="item.zone"
+                                :label="`${item.zone} (UTC${item.offset === 0 ? '' : item.formattedOffset})`"
+                                :value="item.zone"
+                            />
+                        </el-select>
+                    </Column>
 
-            <el-form-item :label="$t('environment color setting')">
-                <el-color-picker
-                    v-model="envColor"
-                    @change="onEnvColorChange"
-                    show-alpha
-                />
-            </el-form-item>
-            <el-form-item :label="$t('execute flow behaviour')">
-                <el-select :model-value="executeFlowBehaviour" @update:model-value="onExecuteFlowBehaviourChange">
-                    <el-option
-                        v-for="item in Object.values(executeFlowBehaviours)"
-                        :key="item"
-                        :label="$t(`open in ${item}`)"
-                        :value="item"
-                    />
-                </el-select>
-            </el-form-item>
-        </el-form>
-        <slot name="form-items" />
-    </section>
+                    <Column :label="$t('settings.blocks.localization.fields.date_format')">
+                        <el-select :model-value="dateFormat" @update:model-value="onDateFormat">
+                            <el-option
+                                v-for="item in dateFormats"
+                                :key="timezone + item.value"
+                                :label="$filters.date(now, item.value)"
+                                :value="item.value"
+                            />
+                        </el-select>
+                    </Column>
+                </Row>
+            </template>
+        </Block>
+
+        <Block :heading="$t('settings.blocks.export.label')" last>
+            <template #content>
+                <Row>
+                    <Column v-if="canReadFlows || canReadTemplates">
+                        <el-button v-if="canReadFlows" :icon="Download" size="large" @click="exportFlows()">
+                            {{ $t("settings.blocks.export.fields.flows") }}
+                        </el-button>
+                        <el-button v-if="canReadTemplates" :icon="Download" size="large" @click="exportTemplates()" :hidden="!configs?.isTemplateEnabled">
+                            {{ $t("settings.blocks.export.fields.templates") }}
+                        </el-button>                    
+                    </Column>
+                </Row>
+            </template>
+        </Block>
+    </Wrapper>
 </template>
 
 <script setup>
@@ -157,6 +188,11 @@
     import action from "../../models/action";
     import {logDisplayTypes, storageKeys} from "../../utils/constants";
 
+    import Wrapper from "./components/Wrapper.vue"
+    import Block from "./components/block/Block.vue"
+    import Row from "./components/block/Row.vue"
+    import Column from "./components/block/Column.vue"
+
     export const DATE_FORMAT_STORAGE_KEY = "dateFormat";
     export const TIMEZONE_STORAGE_KEY = "timezone";
     export default {
@@ -164,7 +200,12 @@
         components: {
             NamespaceSelect,
             LogLevelSelector,
-            TopNavBar
+            TopNavBar,
+
+            Wrapper,
+            Block,
+            Row,
+            Column
         },
         props: {
             allowDefaultNamespace: {
@@ -229,7 +270,7 @@
                 } else {
                     localStorage.removeItem("defaultNamespace")
                 }
-                this.$toast().saved(this.$t("settings"), undefined, {multiple: true});
+                this.$toast().saved(this.$t("settings.label"), undefined, {multiple: true});
             },
             onLevelChange(value) {
                 this.defaultLogLevel = value;
@@ -239,39 +280,39 @@
                 } else {
                     localStorage.removeItem("defaultLogLevel")
                 }
-                this.$toast().saved(this.$t("settings"), undefined, {multiple: true});
+                this.$toast().saved(this.$t("settings.label"), undefined, {multiple: true});
             },
             onLang(value) {
                 localStorage.setItem("lang", value);
                 this.$moment.locale(value);
                 this.$i18n.locale = value;
                 this.lang = value;
-                this.$toast().saved(this.$t("settings"), undefined, {multiple: true});
+                this.$toast().saved(this.$t("settings.label"), undefined, {multiple: true});
             },
             onTheme(value) {
                 Utils.switchTheme(value)
                 this.theme = value;
-                this.$toast().saved(this.$t("settings"), undefined, {multiple: true});
+                this.$toast().saved(this.$t("settings.label"), undefined, {multiple: true});
             },
             onDateFormat(value) {
                 localStorage.setItem(DATE_FORMAT_STORAGE_KEY, value);
                 this.dateFormat = value;
-                this.$toast().saved(this.$t("settings"), undefined, {multiple: true});
+                this.$toast().saved(this.$t("settings.label"), undefined, {multiple: true});
             },
             onTimezone(value) {
                 localStorage.setItem(TIMEZONE_STORAGE_KEY, value);
                 this.timezone = value;
-                this.$toast().saved(this.$t("settings"), undefined, {multiple: true});
+                this.$toast().saved(this.$t("settings.label"), undefined, {multiple: true});
             },
             onEditorTheme(value) {
                 localStorage.setItem("editorTheme", value);
                 this.editorTheme = value;
-                this.$toast().saved(this.$t("settings"), undefined, {multiple: true});
+                this.$toast().saved(this.$t("settings.label"), undefined, {multiple: true});
             },
             onAutofoldTextEditor(value) {
                 localStorage.setItem("autofoldTextEditor", value);
                 this.autofoldTextEditor = value;
-                this.$toast().saved(this.$t("settings"), undefined, {multiple: true});
+                this.$toast().saved(this.$t("settings.label"), undefined, {multiple: true});
             },
             exportFlows() {
                 return this.$store
@@ -290,38 +331,38 @@
             onLogDisplayChange(value) {
                 localStorage.setItem("logDisplay", value);
                 this.logDisplay = value;
-                this.$toast().saved(this.$t("settings"), undefined, {multiple: true});
+                this.$toast().saved(this.$t("settings.label"), undefined, {multiple: true});
             },
             onFontSize(value) {
                 localStorage.setItem("editorFontSize", value);
                 this.editorFontSize = value;
-                this.$toast().saved(this.$t("settings"), undefined, {multiple: true});
+                this.$toast().saved(this.$t("settings.label"), undefined, {multiple: true});
             },
             onFontFamily(value) {
                 localStorage.setItem("editorFontFamily", value);
                 this.editorFontFamily = value;
-                this.$toast().saved(this.$t("settings"), undefined, {multiple: true});
+                this.$toast().saved(this.$t("settings.label"), undefined, {multiple: true});
             },
             onEnvNameChange(value) {
                 if (value !== this.configs?.environment?.name) {
                     this.$store.commit("layout/setEnvName", value);
                 }
 
-                this.$toast().saved(this.$t("settings"), undefined, {multiple: true});
+                this.$toast().saved(this.$t("settings.label"), undefined, {multiple: true});
             },
             onEnvColorChange(value) {
                 if (value !== this.configs?.environment?.color) {
                     this.$store.commit("layout/setEnvColor", value);
                 }
 
-                this.$toast().saved(this.$t("settings"), undefined, {multiple: true});
+                this.$toast().saved(this.$t("settings.label"), undefined, {multiple: true});
             },
             onExecuteFlowBehaviourChange(value) {
                 this.executeFlowBehaviour = value;
 
                 localStorage.setItem(storageKeys.EXECUTE_FLOW_BEHAVIOUR, value);
 
-                this.$toast().saved(this.$t("settings"), undefined, {multiple: true});
+                this.$toast().saved(this.$t("settings.label"), undefined, {multiple: true});
             }
         },
         computed: {
@@ -330,7 +371,7 @@
             ...mapGetters("misc", ["configs"]),
             routeInfo() {
                 return {
-                    title: this.$t("settings")
+                    title: this.$t("settings.label")
                 };
             },
             langOptions() {

--- a/ui/src/components/settings/components/Wrapper.vue
+++ b/ui/src/components/settings/components/Wrapper.vue
@@ -1,0 +1,19 @@
+<template>
+    <el-row class="my-5">
+        <el-col
+            :xs="layout(24, 0)"
+            :sm="layout(20, 2)"
+            :md="layout(18, 3)"
+            :lg="layout(16, 4)"
+            :xl="layout(14, 5)"
+        >
+            <slot />
+        </el-col>
+    </el-row>
+</template>
+
+<script setup lang="ts">
+    const layout = (span, offset) => {
+        return {span, offset};
+    };
+</script>

--- a/ui/src/components/settings/components/block/Block.vue
+++ b/ui/src/components/settings/components/block/Block.vue
@@ -1,0 +1,30 @@
+<template>
+    <section>
+        <h1 class="heading" v-text="heading" />
+        <slot name="content" />
+        <el-divider v-if="!last" />
+    </section>
+</template>
+
+<script setup lang="ts">
+    import {defineProps} from "vue";
+
+    defineProps({
+        heading: {type: String, required: true},
+        last: {type: Boolean, default: false},
+    });
+</script>
+
+<style scoped lang="scss">
+@import "@kestra-io/ui-libs/src/scss/variables.scss";
+
+section {
+    margin: calc($spacer * 2);
+
+    & > h1.heading {
+        margin-bottom: calc($spacer * 2);
+        font-size: calc($font-size-base * 1.5);
+        font-weight: 600;
+    }
+}
+</style>

--- a/ui/src/components/settings/components/block/Column.vue
+++ b/ui/src/components/settings/components/block/Column.vue
@@ -1,0 +1,46 @@
+<template>
+    <el-col
+        :xs="layout.xs"
+        :sm="layout.sm"
+        :md="layout.md"
+        :lg="layout.lg"
+        :xl="layout.xl"
+        class="column"
+    >
+        <p v-if="label" v-text="label" class="label" />
+        <slot />
+    </el-col>
+</template>
+
+<script setup lang="ts">
+    import {defineProps, computed} from "vue";
+
+    const props = defineProps({
+        overrides: {type: Object, default: () => {}},
+        label: {type: [String, undefined], default: undefined},
+    });
+
+    const layout = computed(() => {
+        return {
+            xs: props.overrides?.xs || 24,
+            sm: props.overrides?.sm || 12,
+            md: props.overrides?.md || 12,
+            lg: props.overrides?.lg || 8,
+            xl: props.overrides?.xl || 6,
+        };
+    });
+</script>
+
+<style scoped lang="scss">
+@import "@kestra-io/ui-libs/src/scss/variables.scss";
+
+.column {
+    margin-bottom: $spacer;
+
+    & p.label {
+        margin-bottom: calc($spacer / 3);
+        font-size: $font-size-sm;
+        font-weight: 500;
+    }
+}
+</style>

--- a/ui/src/components/settings/components/block/Row.vue
+++ b/ui/src/components/settings/components/block/Row.vue
@@ -1,0 +1,13 @@
+<template>
+    <el-row :gutter="24" class="row">
+        <slot />
+    </el-row>
+</template>
+
+<style scoped lang="scss">
+@import "@kestra-io/ui-libs/src/scss/variables.scss";
+
+.row {
+    margin-bottom: $spacer;
+}
+</style>

--- a/ui/src/override/components/LeftMenu.vue
+++ b/ui/src/override/components/LeftMenu.vue
@@ -201,7 +201,7 @@
                     {
                         href: {name: "settings"},
                         routes: this.routeStartWith("admin/settings"),
-                        title: this.$t("settings"),
+                        title: this.$t("settings.label"),
                         icon: {
                             element: shallowRef(CogOutline),
                             class: "menu-icon"

--- a/ui/src/translations/en.json
+++ b/ui/src/translations/en.json
@@ -10,7 +10,6 @@
     "revision": "Revision",
     "Language": "Language",
     "Set default page": "Set default page",
-    "settings": "Settings",
     "theme": "Theme",
     "flows": "Flows",
     "flow": "Flow",
@@ -695,6 +694,47 @@
       "title2": "Search for tasks and triggers to build your flow.",
       "search": "Search across +{count} plugins"
     },
-    "no inputs": "This flow has no inputs."
+    "no inputs": "This flow has no inputs.",
+    "settings": {
+      "label": "Settings",
+      "blocks": {
+        "configuration": {
+          "label": "Main Configuration",
+          "fields": {
+            "default_namespace": "Default Namespace",
+            "log_level": "Default Log Level",
+            "log_display": "Default Log Display",
+            "execute_flow": "Execute the Flow"
+          }
+        },
+        "theme": {
+          "label": "Theme Preferences",
+          "fields": {
+            "mode": "Theme Mode",
+            "editor_theme": "Editor Theme",
+            "editor_font_size": "Editor Font Size",
+            "editor_font_family": "Editor Font Family",
+            "editor_folding_stratgy": "Editor Automatic Fold or Multi Lines",
+            "environment_name": "Environment Name",
+            "environment_color": "Environment Color"
+          }
+        },
+        "localization": {
+          "label": "Date and Time Settings",
+          "fields": {
+            "language": "Language",
+            "time_zone": "Time Zone",
+            "date_format": "Date Format"
+          }
+        },
+        "export": {
+          "label": "Export",
+          "fields": {
+            "flows": "Export All Flows",
+            "templates": "Export All Templates"
+          }
+        }
+      }
+    }
   }
 }

--- a/ui/src/translations/fr.json
+++ b/ui/src/translations/fr.json
@@ -10,7 +10,6 @@
     "revision": "Révision",
     "Language": "Langue",
     "Set default page": "Définir la page par défaut",
-    "settings": "Paramètres",
     "theme": "Thème",
     "flows": "Flows",
     "flow": "Flow",
@@ -671,6 +670,47 @@
       "title2": "Cherchez des tâches et des déclencheurs pour créer vos flux.",
       "search": "Cherchez à travers +{count} plugins"
     },
-    "no inputs": "Ce flow n'a pas d'entrée."
+    "no inputs": "Ce flow n'a pas d'entrée.",    
+    "settings": {
+      "label": "Paramètres",
+      "blocks": {
+        "configuration": {
+          "label": "Configuration Principale",
+          "fields": {
+            "default_namespace": "Espace de Noms par Défaut",
+            "log_level": "Niveau de Journalisation par Défaut",
+            "log_display": "Affichage de Journal par Défaut",
+            "execute_flow": "Exécuter le Flux"
+          }
+        },
+        "theme": {
+          "label": "Préférences de Thème",
+          "fields": {
+            "mode": "Mode Thème",
+            "editor_theme": "Thème de l'Éditeur",
+            "editor_font_size": "Taille de Police de l'Éditeur",
+            "editor_font_family": "Police de Caractères de l'Éditeur",
+            "editor_folding_stratgy": "Stratégie de Pliage Automatique ou Multi-Lignes de l'Éditeur",
+            "environment_name": "Nom de l'Environnement",
+            "environment_color": "Couleur de l'Environnement"
+          }
+        },
+        "localization": {
+          "label": "Paramètres de Date et d'Heure",
+          "fields": {
+            "language": "Langue",
+            "time_zone": "Fuseau Horaire",
+            "date_format": "Format de Date"
+          }
+        },
+        "export": {
+          "label": "Exporter",
+          "fields": {
+            "flows": "Exporter Tous les Flux",
+            "templates": "Exporter Tous les Modèles"
+          }
+        }
+      }
+    }    
   }
 }


### PR DESCRIPTION
Did a bit of visual restructuring of the `Settings` page to have sections organized by topic.

![image](https://github.com/kestra-io/kestra/assets/62475782/00f427e0-43a5-417a-8b89-a27e33286dd3)

There only remains a question for @anna-geller, regarding this: https://github.com/kestra-io/kestra/issues/2010#issuecomment-1705539836 comment - are the templates still deprecated and can I remove code related to them?

Closes #1947.