### PR TITLE
fix(docs): update link to templates migration page

### DIFF
--- a/ui/src/translations/en.json
+++ b/ui/src/translations/en.json
@@ -278,7 +278,7 @@
     "template": "Template",
     "template creation": "Template creation",
     "templates": "Templates",
-    "templates deprecated": "Templates are deprecated. Please use subflows instead. See the <a href=\"https://kestra.io/docs/migrations/templates\" target=\"_blank\">Migrations section</a> explaining how you can migrate from templates to subflows.",
+    "templates deprecated": "Templates are deprecated. Please use subflows instead. See the <a href=\"https://kestra.io/docs/migration-guide/templates\" target=\"_blank\">Migrations section</a> explaining how you can migrate from templates to subflows.",
     "no result": "No results for the current selection",
     "trigger": "Trigger",
     "triggers": "Triggers",

--- a/ui/src/translations/fr.json
+++ b/ui/src/translations/fr.json
@@ -267,7 +267,7 @@
     "template": "Template",
     "template creation": "Création de template",
     "templates": "Templates",
-    "templates deprecated": "Les templates sont obsolètes. Veuillez utiliser des sous-flux au lieu des templates. Consultez <a href=\"https://kestra.io/docs/migrations/templates\" target=\"_blank\">section Migrations</a> expliquant comment vous pouvez migrer vers les sous-flux.",
+    "templates deprecated": "Les templates sont obsolètes. Veuillez utiliser des sous-flux au lieu des templates. Consultez <a href=\"https://kestra.io/docs/migration-guide/templates\" target=\"_blank\">section Migrations</a> expliquant comment vous pouvez migrer vers les sous-flux.",
     "no result": "Aucun résultat pour la selection courante.",
     "trigger": "Déclencheur",
     "triggers": "Déclencheurs",


### PR DESCRIPTION
<!-- Thanks for submitting a Pull Request to kestra. To help us review your contribution, please follow the guidelines below:

- Make sure that your commits follow the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) specification e.g. `feat(ui): add a new navigation menu item` or `fix(core): fix a bug in the core model` or `docs: update the README.md`. This will help us automatically generate the changelog.
- The title should briefly summarize the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share a flow example to help the reviewer understand and QA the change.
- Use "close" to automatically close an issue. For example, `close #1234` will close issue #1234. -->

### What changes are being made and why?

The link to templates' migrations section document is incorrect on the following lines:

https://github.com/kestra-io/kestra/blob/b2ea51da09feac4818e7f3d766fba824cc01473e/ui/src/translations/en.json#L281

https://github.com/kestra-io/kestra/blob/b2ea51da09feac4818e7f3d766fba824cc01473e/ui/src/translations/fr.json#L270

Incorrect Link: [https://kestra.io/docs/migrations/templates](https://kestra.io/docs/migrations/templates)
Correct Link: [https://kestra.io/docs/migration-guide/templates](https://kestra.io/docs/migration-guide/templates)


closes #3738 

---
