### PR TITLE
fix(cli): load flows for webservers and standalone (#3783)

### DIFF
--- a/cli/src/main/java/io/kestra/cli/AbstractCommand.java
+++ b/cli/src/main/java/io/kestra/cli/AbstractCommand.java
@@ -6,6 +6,7 @@ import io.kestra.cli.commands.servers.ServerCommandInterface;
 import io.kestra.cli.services.StartupHookInterface;
 import io.kestra.core.contexts.KestraContext;
 import io.kestra.core.plugins.PluginRegistry;
+import io.kestra.webserver.services.FlowAutoLoaderService;
 import io.micronaut.context.ApplicationContext;
 import io.micronaut.context.env.yaml.YamlPropertySourceLoader;
 import io.micronaut.core.annotation.Introspected;
@@ -171,7 +172,17 @@ abstract public class AbstractCommand implements Callable<Integer> {
                 } else {
                     log.info("Server Running: {}", server.getURL());
                 }
+
+                if (isFlowAutoLoadEnabled()) {
+                    applicationContext
+                        .findBean(FlowAutoLoaderService.class)
+                        .ifPresent(FlowAutoLoaderService::load);
+                }
             });
+    }
+
+    public boolean isFlowAutoLoadEnabled() {
+        return false;
     }
 
     protected void shutdownHook(Rethrow.RunnableChecked<Exception> run) {

--- a/cli/src/main/java/io/kestra/cli/commands/servers/StandAloneCommand.java
+++ b/cli/src/main/java/io/kestra/cli/commands/servers/StandAloneCommand.java
@@ -45,6 +45,14 @@ public class StandAloneCommand extends AbstractServerCommand {
     @CommandLine.Option(names = {"--skip-flows"}, split=",", description = "a list of flow identifiers (namespace.flowId) to skip, separated by a coma; for troubleshooting purpose only")
     private List<String> skipFlows = Collections.emptyList();
 
+    @CommandLine.Option(names = {"--no-tutorials"}, description = "Flag to disable auto-loading of tutorial flows.")
+    boolean tutorialsDisabled = false;
+
+    @Override
+    public boolean isFlowAutoLoadEnabled() {
+        return !tutorialsDisabled;
+    }
+
     @SuppressWarnings("unused")
     public static Map<String, Object> propertiesOverrides() {
         return ImmutableMap.of(

--- a/cli/src/main/java/io/kestra/cli/commands/servers/WebServerCommand.java
+++ b/cli/src/main/java/io/kestra/cli/commands/servers/WebServerCommand.java
@@ -8,6 +8,7 @@ import io.micronaut.context.ApplicationContext;
 import jakarta.inject.Inject;
 import lombok.extern.slf4j.Slf4j;
 import picocli.CommandLine;
+import picocli.CommandLine.Option;
 
 import java.util.Map;
 
@@ -19,6 +20,15 @@ import java.util.Map;
 public class WebServerCommand extends AbstractServerCommand {
     @Inject
     private ApplicationContext applicationContext;
+
+    @Option(names = {"--no-tutorials"}, description = "Flag to disable auto-loading of tutorial flows.")
+    boolean tutorialsDisabled = false;
+
+
+    @Override
+    public boolean isFlowAutoLoadEnabled() {
+        return !tutorialsDisabled;
+    }
 
     @SuppressWarnings("unused")
     public static Map<String, Object> propertiesOverrides() {

--- a/webserver/src/main/java/io/kestra/webserver/services/FlowAutoLoaderService.java
+++ b/webserver/src/main/java/io/kestra/webserver/services/FlowAutoLoaderService.java
@@ -5,7 +5,6 @@ import io.kestra.core.repositories.FlowRepositoryInterface;
 import io.kestra.core.serializers.YamlFlowParser;
 import io.kestra.core.services.TaskDefaultService;
 import io.kestra.webserver.annotation.WebServerEnabled;
-import io.kestra.webserver.controllers.api.BlueprintController;
 import io.kestra.webserver.controllers.api.BlueprintController.BlueprintItem;
 import io.kestra.webserver.controllers.api.BlueprintController.BlueprintTagItem;
 import io.kestra.webserver.responses.PagedResults;
@@ -16,20 +15,14 @@ import io.micronaut.http.HttpRequest;
 import io.micronaut.http.HttpResponse;
 import io.micronaut.http.client.HttpClient;
 import io.micronaut.http.client.annotation.Client;
-import io.micronaut.runtime.event.annotation.EventListener;
-import io.micronaut.runtime.server.event.ServerStartupEvent;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
-import org.reactivestreams.Publisher;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 import java.util.Collection;
-import java.util.List;
 import java.util.Optional;
-import java.util.function.BiConsumer;
 import java.util.function.Function;
 
 /**
@@ -55,13 +48,8 @@ public class FlowAutoLoaderService {
     @Inject
     private YamlFlowParser yamlFlowParser;
 
-    @EventListener
-    public void onStartupEvent(final ServerStartupEvent event) {
-        load();
-    }
-
     @SuppressWarnings("unchecked")
-    protected void load() {
+    public void load() {
         // Gets the tag ID for 'Getting Started'.
         try {
             Optional<String> optionalTagId = Mono.from(httpClient


### PR DESCRIPTION
Changes:
- add new option --no-tutorials to disable auto loading of tutorial flows from CLI.

Fix: #3783