### PR TITLE
Added REST methods for task and trigger validation that accept JSON body

### DIFF
--- a/webserver/src/main/java/io/kestra/webserver/controllers/api/FlowController.java
+++ b/webserver/src/main/java/io/kestra/webserver/controllers/api/FlowController.java
@@ -562,6 +562,50 @@ public class FlowController {
     }
 
     @ExecuteOn(TaskExecutors.IO)
+    @Post(uri = "/validate/task", consumes = MediaType.APPLICATION_JSON)
+    @Operation(tags = {"Flows"}, summary = "Validate task")
+    public ValidateConstraintViolation validateTask(
+        @Parameter(description = "Task") @Body Task task
+    ) {
+        ValidateConstraintViolation.ValidateConstraintViolationBuilder<?, ?> validateConstraintViolationBuilder = ValidateConstraintViolation.builder();
+
+        try {
+            modelValidator.validate(task);
+        } catch (ConstraintViolationException e) {
+            validateConstraintViolationBuilder.constraints(e.getMessage());
+        } catch (RuntimeException re) {
+            // In case of any error, we add a validation violation so the error is displayed in the UI.
+            // We may change that by throwing an internal error and handle it in the UI, but this should not occur except for rare cases
+            // in dev like incompatible plugin versions.
+            log.error("Unable to validate the task", re);
+            validateConstraintViolationBuilder.constraints("Unable to validate the task: " + re.getMessage());
+        }
+        return validateConstraintViolationBuilder.build();
+    }
+
+    @ExecuteOn(TaskExecutors.IO)
+    @Post(uri = "/validate/trigger", consumes = MediaType.APPLICATION_JSON)
+    @Operation(tags = {"Flows"}, summary = "Validate trigger")
+    public ValidateConstraintViolation validateTrigger(
+        @Parameter(description = "Trigger") @Body AbstractTrigger trigger
+    ) {
+        ValidateConstraintViolation.ValidateConstraintViolationBuilder<?, ?> validateConstraintViolationBuilder = ValidateConstraintViolation.builder();
+
+        try {
+            modelValidator.validate(trigger);
+        } catch (ConstraintViolationException e) {
+            validateConstraintViolationBuilder.constraints(e.getMessage());
+        } catch (RuntimeException re) {
+            // In case of any error, we add a validation violation so the error is displayed in the UI.
+            // We may change that by throwing an internal error and handle it in the UI, but this should not occur except for rare cases
+            // in dev like incompatible plugin versions.
+            log.error("Unable to validate the trigger", re);
+            validateConstraintViolationBuilder.constraints("Unable to validate the trigger: " + re.getMessage());
+        }
+        return validateConstraintViolationBuilder.build();
+    }
+
+    @ExecuteOn(TaskExecutors.IO)
     @Post(uri = "/validate/task", consumes = MediaType.APPLICATION_YAML)
     @Operation(tags = {"Flows"}, summary = "Validate a list of flows")
     public ValidateConstraintViolation validateTask(

--- a/webserver/src/main/java/io/kestra/webserver/controllers/api/FlowController.java
+++ b/webserver/src/main/java/io/kestra/webserver/controllers/api/FlowController.java
@@ -566,6 +566,7 @@ public class FlowController {
             .collect(Collectors.toList());
     }
 
+    // This endpoint is not used by the Kestra UI nor our CLI but is provided for the API users for convenience
     @ExecuteOn(TaskExecutors.IO)
     @Post(uri = "/validate/task", consumes = MediaType.APPLICATION_JSON)
     @Operation(tags = {"Flows"}, summary = "Validate task")
@@ -590,6 +591,7 @@ public class FlowController {
         return validateConstraintViolationBuilder.build();
     }
 
+    // This endpoint is not used by the Kestra UI nor our CLI but is provided for the API users for convenience
     @ExecuteOn(TaskExecutors.IO)
     @Post(uri = "/validate/trigger", consumes = MediaType.APPLICATION_JSON)
     @Operation(tags = {"Flows"}, summary = "Validate trigger")

--- a/webserver/src/test/java/io/kestra/webserver/controllers/api/FlowControllerTest.java
+++ b/webserver/src/test/java/io/kestra/webserver/controllers/api/FlowControllerTest.java
@@ -778,6 +778,96 @@ class FlowControllerTest extends JdbcH2ControllerTest {
         assertThat(flows.getTotal(), is(1L));
     }
 
+    @Test
+    void validateTask() throws IOException {
+        URL resource = TestsUtils.class.getClassLoader().getResource("tasks/validTask.json");
+
+        String task = Files.readString(Path.of(Objects.requireNonNull(resource).getPath()), Charset.defaultCharset());
+
+        HttpResponse<List<ValidateConstraintViolation>> response = client.toBlocking().exchange(POST("/api/v1/flows/validate/task", task).contentType(MediaType.APPLICATION_JSON), Argument.listOf(ValidateConstraintViolation.class));
+
+        List<ValidateConstraintViolation> body = response.body();
+        assertThat(body.size(), is(1));
+        assertThat(body, everyItem(
+            Matchers.hasProperty("constraints", is(nullValue()))
+        ));
+
+        resource = TestsUtils.class.getClassLoader().getResource("tasks/invalidTaskUnknownType.json");
+        task = Files.readString(Path.of(Objects.requireNonNull(resource).getPath()), Charset.defaultCharset());
+
+        response = client.toBlocking().exchange(POST("/api/v1/flows/validate/task", task).contentType(MediaType.APPLICATION_JSON), Argument.listOf(ValidateConstraintViolation.class));
+
+        body = response.body();
+
+        assertThat(body.size(), is(1));
+        assertThat(body.get(0).getConstraints(), containsString("Invalid type: io.kestra.plugin.core.debug.UnknownTask"));
+
+        resource = TestsUtils.class.getClassLoader().getResource("tasks/invalidTaskUnknownProp.json");
+        task = Files.readString(Path.of(Objects.requireNonNull(resource).getPath()), Charset.defaultCharset());
+
+        response = client.toBlocking().exchange(POST("/api/v1/flows/validate/task", task).contentType(MediaType.APPLICATION_JSON), Argument.listOf(ValidateConstraintViolation.class));
+
+        body = response.body();
+
+        assertThat(body.size(), is(1));
+        assertThat(body.get(0).getConstraints(), containsString("Unrecognized field \"unknownProp\""));
+
+        resource = TestsUtils.class.getClassLoader().getResource("tasks/invalidTaskMissingProp.json");
+        task = Files.readString(Path.of(Objects.requireNonNull(resource).getPath()), Charset.defaultCharset());
+
+        response = client.toBlocking().exchange(POST("/api/v1/flows/validate/task", task).contentType(MediaType.APPLICATION_JSON), Argument.listOf(ValidateConstraintViolation.class));
+
+        body = response.body();
+
+        assertThat(body.size(), is(1));
+        assertThat(body.get(0).getConstraints(), containsString("message: must not be null"));
+    }
+
+    @Test
+    void validateTrigger() throws IOException {
+        URL resource = TestsUtils.class.getClassLoader().getResource("triggers/validTrigger.json");
+
+        String task = Files.readString(Path.of(Objects.requireNonNull(resource).getPath()), Charset.defaultCharset());
+
+        HttpResponse<List<ValidateConstraintViolation>> response = client.toBlocking().exchange(POST("/api/v1/flows/validate/trigger", task).contentType(MediaType.APPLICATION_JSON), Argument.listOf(ValidateConstraintViolation.class));
+
+        List<ValidateConstraintViolation> body = response.body();
+        assertThat(body.size(), is(1));
+        assertThat(body, everyItem(
+            Matchers.hasProperty("constraints", is(nullValue()))
+        ));
+
+        resource = TestsUtils.class.getClassLoader().getResource("triggers/invalidTriggerUnknownType.json");
+        task = Files.readString(Path.of(Objects.requireNonNull(resource).getPath()), Charset.defaultCharset());
+
+        response = client.toBlocking().exchange(POST("/api/v1/flows/validate/trigger", task).contentType(MediaType.APPLICATION_JSON), Argument.listOf(ValidateConstraintViolation.class));
+
+        body = response.body();
+
+        assertThat(body.size(), is(1));
+        assertThat(body.get(0).getConstraints(), containsString("Invalid type: io.kestra.plugin.core.debug.UnknownTrigger"));
+
+        resource = TestsUtils.class.getClassLoader().getResource("triggers/invalidTriggerUnknownProp.json");
+        task = Files.readString(Path.of(Objects.requireNonNull(resource).getPath()), Charset.defaultCharset());
+
+        response = client.toBlocking().exchange(POST("/api/v1/flows/validate/trigger", task).contentType(MediaType.APPLICATION_JSON), Argument.listOf(ValidateConstraintViolation.class));
+
+        body = response.body();
+
+        assertThat(body.size(), is(1));
+        assertThat(body.get(0).getConstraints(), containsString("Unrecognized field \"unknownProp\""));
+
+        resource = TestsUtils.class.getClassLoader().getResource("triggers/invalidTriggerMissingProp.json");
+        task = Files.readString(Path.of(Objects.requireNonNull(resource).getPath()), Charset.defaultCharset());
+
+        response = client.toBlocking().exchange(POST("/api/v1/flows/validate/trigger", task).contentType(MediaType.APPLICATION_JSON), Argument.listOf(ValidateConstraintViolation.class));
+
+        body = response.body();
+
+        assertThat(body.size(), is(1));
+        assertThat(body.get(0).getConstraints(), containsString("cron: must not be null"));
+    }
+
     private Flow generateFlow(String namespace, String inputName) {
         return generateFlow(IdUtils.create(), namespace, inputName);
     }

--- a/webserver/src/test/resources/tasks/invalidTaskMissingProp.json
+++ b/webserver/src/test/resources/tasks/invalidTaskMissingProp.json
@@ -1,0 +1,4 @@
+{
+  "id": "task_one",
+  "type": "io.kestra.plugin.core.log.Log"
+}

--- a/webserver/src/test/resources/tasks/invalidTaskUnknownProp.json
+++ b/webserver/src/test/resources/tasks/invalidTaskUnknownProp.json
@@ -1,0 +1,5 @@
+{
+  "id": "task-two",
+  "type": "io.kestra.plugin.core.log.Log",
+  "unknownProp": "strange---string"
+}

--- a/webserver/src/test/resources/tasks/invalidTaskUnknownType.json
+++ b/webserver/src/test/resources/tasks/invalidTaskUnknownType.json
@@ -1,0 +1,4 @@
+{
+  "id": "task-two",
+  "type": "io.kestra.plugin.core.debug.UnknownTask"
+}

--- a/webserver/src/test/resources/tasks/validTask.json
+++ b/webserver/src/test/resources/tasks/validTask.json
@@ -1,0 +1,5 @@
+{
+  "id": "task_one",
+  "type": "io.kestra.plugin.core.log.Log",
+  "message": "strange---string"
+}

--- a/webserver/src/test/resources/triggers/invalidTriggerMissingProp.json
+++ b/webserver/src/test/resources/triggers/invalidTriggerMissingProp.json
@@ -1,0 +1,4 @@
+{
+  "id": "schedule",
+  "type": "io.kestra.plugin.core.trigger.Schedule"
+}

--- a/webserver/src/test/resources/triggers/invalidTriggerUnknownProp.json
+++ b/webserver/src/test/resources/triggers/invalidTriggerUnknownProp.json
@@ -1,0 +1,6 @@
+{
+  "id": "unknown-trigger",
+  "type": "io.kestra.plugin.core.trigger.Schedule",
+  "cron": "*/15 * * * *",
+  "unknownProp": "strange---string"
+}

--- a/webserver/src/test/resources/triggers/invalidTriggerUnknownType.json
+++ b/webserver/src/test/resources/triggers/invalidTriggerUnknownType.json
@@ -1,0 +1,4 @@
+{
+  "id": "unknown-trigger",
+  "type": "io.kestra.plugin.core.debug.UnknownTrigger"
+}

--- a/webserver/src/test/resources/triggers/validTrigger.json
+++ b/webserver/src/test/resources/triggers/validTrigger.json
@@ -1,0 +1,5 @@
+{
+  "id": "schedule",
+  "type": "io.kestra.plugin.core.trigger.Schedule",
+  "cron": "*/15 * * * *"
+}


### PR DESCRIPTION
<!-- Thanks for submitting a Pull Request to kestra. To help us review your contribution, please follow the guidelines below:

- Make sure that your commits follow the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) specification e.g. `feat(ui): add a new navigation menu item` or `fix(core): fix a bug in the core model` or `docs: update the README.md`. This will help us automatically generate the changelog.
- The title should briefly summarize the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share a flow example to help the reviewer understand and QA the change.
- Use "close" to automatically close an issue. For example, `close #1234` will close issue #1234. -->

### What changes are being made and why?
Kestra doesn't provide rest endpoints for validation of task and triggers in JSON format. Endpoint for task/trigger validation /validate/task accepts only YAML body.
Following PR adds two new endpoints:
- /validate/task - endpoint for task validation, accepts JSON body
- /validate/trigger - endpoint for trigger validation, accepts JSON body
