### PR TITLE
chore(deps): update frontend Gradle plugin to Java 17

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,7 @@ plugins {
     id "com.github.ben-manes.versions" version "0.51.0"
 
     // front
-    id 'org.siouan.frontend-jdk11' version '8.0.0' apply false
+    id 'org.siouan.frontend-jdk17' version '8.0.0' apply false
 
     // release
     id "io.github.gradle-nexus.publish-plugin" version "2.0.0"

--- a/ui/build.gradle
+++ b/ui/build.gradle
@@ -1,7 +1,7 @@
 import org.siouan.frontendgradleplugin.infrastructure.gradle.RunNpm
 
 plugins {
-    id 'org.siouan.frontend-jdk11'
+    id 'org.siouan.frontend-jdk17'
 }
 
 publishSonatypePublicationPublicationToSonatypeRepository.enabled = false


### PR DESCRIPTION
### What changes are being made and why?

JDK17+ has been the target for a while.