### PR TITLE
fix(docs): add migration note for LocalFiles

### DIFF
--- a/core/src/main/java/io/kestra/plugin/core/storage/LocalFiles.java
+++ b/core/src/main/java/io/kestra/plugin/core/storage/LocalFiles.java
@@ -23,7 +23,7 @@ import java.util.Map;
 @NoArgsConstructor
 @Schema(
     title = "Allow to create files in the local filesystem or to send files from the local filesystem to the Kestra's internal storage.",
-    description = "This task should be used with the WorkingDirectory task to be able to access the same local filesystem within multiple tasks. Note that this task cannot be skipped, so setting `disabled: true` will not work on this task."
+    description = "Replaced by `inputFiles` property on the WorkingDirectory task. Previously, this task should be used with the WorkingDirectory task to be able to access the same local filesystem within multiple tasks. Note that this task cannot be skipped, so setting `disabled: true` will not work on this task."
 )
 @Deprecated
 @Plugin(examples = {


### PR DESCRIPTION
Adds a note to highlight what the alternative solution should be instead of LocalFiles.