### PR TITLE
fix(docs): Note that schedule runs on UTC by default

### DIFF
--- a/core/src/main/java/io/kestra/plugin/core/trigger/Schedule.java
+++ b/core/src/main/java/io/kestra/plugin/core/trigger/Schedule.java
@@ -48,7 +48,8 @@ import java.util.stream.Stream;
     title = "Schedule a flow based on a CRON expression.",
     description = "You can add multiple schedule(s) to a flow.\n" +
         "The scheduler keeps track of the last scheduled date, allowing you to easily backfill missed executions.\n" +
-        "Keep in mind that if you change the trigger ID, the scheduler will consider this as a new schedule, and will start creating new scheduled executions from the current date."
+        "Keep in mind that if you change the trigger ID, the scheduler will consider this as a new schedule, and will start creating new scheduled executions from the current date.\n" +
+        "By default, Schedules will use UTC. If you need a different timezone, use the `timezone` property to update it."
 )
 @Plugin(
     examples = {


### PR DESCRIPTION
Added a note at the top of the `Schedule` documentation to state that it runs on UTC by default to clear up confusion seen with users confused why the schedule didn't run on the same timezone set in the UI settings.