### PR TITLE
fix(core): add unique prefix identifier for output files (#3991)

### DIFF
--- a/core/src/main/java/io/kestra/core/runners/FilesService.java
+++ b/core/src/main/java/io/kestra/core/runners/FilesService.java
@@ -2,6 +2,7 @@ package io.kestra.core.runners;
 
 import io.kestra.core.exceptions.IllegalVariableEvaluationException;
 import io.kestra.core.models.tasks.runners.PluginUtilsService;
+import io.kestra.core.utils.IdUtils;
 import io.kestra.core.utils.ListUtils;
 import org.apache.commons.io.IOUtils;
 import org.slf4j.Logger;
@@ -85,10 +86,14 @@ public abstract class FilesService {
                 .filter(path -> pathMatcher.matches(runContext.tempDir().relativize(path)))
                 .map(throwFunction(path -> new AbstractMap.SimpleEntry<>(
                     runContext.tempDir().relativize(path).toString(),
-                    runContext.storage().putFile(path.toFile())
+                    runContext.storage().putFile(path.toFile(), resolveUniqueNameForFile(path))
                 )))
                 .toList()
                 .stream();
         }
+    }
+
+    private static String resolveUniqueNameForFile(final Path path) {
+        return IdUtils.from(path.toString()) + "-" + path.toFile().getName();
     }
 }

--- a/core/src/test/java/io/kestra/plugin/core/flow/WorkingDirectoryTest.java
+++ b/core/src/test/java/io/kestra/plugin/core/flow/WorkingDirectoryTest.java
@@ -11,6 +11,7 @@ import io.kestra.core.runners.RunnerUtils;
 import io.kestra.core.storages.InternalStorage;
 import io.kestra.core.storages.StorageContext;
 import io.kestra.core.storages.StorageInterface;
+import io.kestra.core.utils.IdUtils;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 import org.junit.jupiter.api.Test;
@@ -30,7 +31,6 @@ import java.util.concurrent.TimeoutException;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
-import static org.hamcrest.io.FileMatchers.anExistingFile;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -154,8 +154,15 @@ public class WorkingDirectoryTest extends AbstractMemoryRunnerTest {
                 storageContext
                 , storageInterface
             );
-            URI fileURI = URI.create("kestra:" + storageContext.getContextStorageURI() + "/input.txt");
-            assertThat(new String(storage.getFile(fileURI).readAllBytes()), is("Hello World"));
+
+            TaskRun taskRun = execution.getTaskRunList().get(1);
+            Map<String, Object> outputs = taskRun.getOutputs();
+            assertThat(outputs, hasKey("uris"));
+
+            URI uri = URI.create(((Map<String, String>) outputs.get("uris")).get("input.txt"));
+
+            assertTrue(uri.toString().endsWith("input.txt"));
+            assertThat(new String(storage.getFile(uri).readAllBytes()), is("Hello World"));
         }
 
         @SuppressWarnings("unchecked")


### PR DESCRIPTION
fix: #3991