### PR TITLE
fix(script): container image is not taken into account

### DIFF
--- a/script/src/main/java/io/kestra/plugin/scripts/exec/AbstractExecScript.java
+++ b/script/src/main/java/io/kestra/plugin/scripts/exec/AbstractExecScript.java
@@ -151,7 +151,7 @@ public abstract class AbstractExecScript extends Task implements RunnableTask<Sc
             .withRunnerType(this.getRunner())
             .withContainerImage(runContext.render(this.getContainerImage()))
             .withTaskRunner(this.taskRunner)
-            .withDockerOptions(getDocker() != null ? this.injectDefaults(getDocker()) : null)
+            .withDockerOptions(this.docker != null ? this.injectDefaults(this.docker) : null)
             .withNamespaceFiles(this.namespaceFiles)
             .withInputFiles(this.inputFiles)
             .withOutputFiles(this.outputFiles)


### PR DESCRIPTION
This was due to a bug in Lombok when a property is null but the getter returns an object initialized with the builder default.

Fixes #3997
