### PR TITLE
fix: typo in flow trigger example

### DIFF
--- a/core/src/main/java/io/kestra/plugin/core/trigger/Flow.java
+++ b/core/src/main/java/io/kestra/plugin/core/trigger/Flow.java
@@ -56,7 +56,7 @@ import jakarta.validation.constraints.NotNull;
             "    inputs:\n" +
             "      from-parent: '{{ outputs.myTask.uri }}'\n" +
             "    conditions:\n" +
-            "      - type: io.kestra.plugin.cores.condition.ExecutionFlowCondition\n" +
+            "      - type: io.kestra.plugin.core.condition.ExecutionFlowCondition\n" +
             "        namespace: io.kestra.tests\n" +
             "        flowId: trigger-flow\n" +
             "      - type: io.kestra.plugin.core.condition.ExecutionStatusCondition\n" +


### PR DESCRIPTION
Fixed example that had a typo in the `type`:

```
type: io.kestra.plugin.cores.condition.ExecutionFlowCondition
```
to
```
type: io.kestra.plugin.core.condition.ExecutionFlowCondition
```