### PR TITLE
fix(ui): highlight also labels featuring colon mark

### DIFF
--- a/ui/src/components/layout/Labels.vue
+++ b/ui/src/components/layout/Labels.vue
@@ -48,9 +48,13 @@
                     []
                 )
                     .forEach(label => {
-                        const split = label.split(":");
+                        const separatorIndex = label.indexOf(":");
 
-                        labels.set(split[0], split[1]);
+                        if (separatorIndex === -1) {
+                            return;
+                        }
+
+                        labels.set(label.slice(0, separatorIndex), label.slice(separatorIndex + 1));
                     })
 
                 return labels;


### PR DESCRIPTION
### What changes are being made and why?

The label highlight function was not working on labels featuring more than one `:` character (e.g. `timestamp:2024-06-13T13:46T`).

![20240613-213227_snap](https://github.com/kestra-io/kestra/assets/13468636/20eee6f1-6a0b-430b-98d0-e029f91213d8)
