### PR TITLE
Chore/worker refacto

### DIFF
--- a/core/src/main/java/io/kestra/core/runners/AbstractWorkerCallable.java
+++ b/core/src/main/java/io/kestra/core/runners/AbstractWorkerCallable.java
@@ -1,19 +1,20 @@
 package io.kestra.core.runners;
 
 import io.kestra.core.models.WorkerJobLifecycle;
+import io.kestra.core.models.flows.State;
 import lombok.Getter;
 import lombok.Synchronized;
 import org.slf4j.Logger;
 
 import java.time.Duration;
+import java.util.concurrent.Callable;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
-import static io.kestra.core.models.flows.State.Type.FAILED;
-import static io.kestra.core.models.flows.State.Type.KILLED;
+import static io.kestra.core.models.flows.State.Type.*;
 
 @SuppressWarnings("this-escape")
-public abstract class AbstractWorkerThread extends Thread {
+abstract class AbstractWorkerCallable implements Callable<State.Type> {
     volatile boolean killed = false;
 
     Logger logger;
@@ -25,19 +26,15 @@ public abstract class AbstractWorkerThread extends Thread {
     String type;
 
     @Getter
-    io.kestra.core.models.flows.State.Type taskState;
-
-    @Getter
     Throwable exception;
 
     private final CountDownLatch shutdownLatch = new CountDownLatch(1);
 
     private final ClassLoader classLoader;
 
-    public AbstractWorkerThread(RunContext runContext, String type, ClassLoader classLoader) {
-        super("WorkerThread");
-        this.setUncaughtExceptionHandler(this::exceptionHandler);
+    private Thread currentThread;
 
+    AbstractWorkerCallable(RunContext runContext, String type, ClassLoader classLoader) {
         this.logger = runContext.logger();
         this.runContext = runContext;
         this.type = type;
@@ -51,18 +48,20 @@ public abstract class AbstractWorkerThread extends Thread {
 
     /** {@inheritDoc} **/
     @Override
-    public void run() {
-        Thread.currentThread().setContextClassLoader(classLoader);
+    public State.Type call() {
+        this.currentThread = Thread.currentThread();
+        this.currentThread.setContextClassLoader(classLoader);
+
         try {
-            doRun();
+            return doCall();
         } catch (Exception e) {
-            this.exceptionHandler(this, e);
+            return this.exceptionHandler(e);
         } finally {
             shutdownLatch.countDown();
         }
     }
 
-    protected abstract void doRun() throws Exception;
+    protected abstract State.Type doCall() throws Exception;
 
     /**
      * Signals to the job executed by this worker thread to stop.
@@ -87,21 +86,28 @@ public abstract class AbstractWorkerThread extends Thread {
 
     protected void kill(boolean markAsKilled) {
         this.killed = markAsKilled;
-        this.taskState = KILLED;
 
         // When we arrive here, the thread run() method may be ended but the thread "in the stopping process".
         // So we don't interrupt if the shutdownLatch is 0 as this means the run() method is done or if the thread is no more alive.
-        if (shutdownLatch.getCount() > 0 && this.isAlive()) {
+        if (shutdownLatch.getCount() > 0) {
             this.interrupt();
         }
     }
 
-    protected void exceptionHandler(Thread t, Throwable e) {
+    protected State.Type exceptionHandler(Throwable e) {
         this.exception = e;
 
-        if (!this.killed) {
+        if (this.killed) {
+            return KILLED;
+        } else {
             logger.error(e.getMessage(), e);
-            taskState = FAILED;
+            return FAILED;
+        }
+    }
+
+    public void interrupt() {
+        if (this.currentThread != null && this.currentThread.isAlive()) {
+            this.currentThread.interrupt();
         }
     }
 }

--- a/core/src/main/java/io/kestra/core/runners/AbstractWorkerTriggerCallable.java
+++ b/core/src/main/java/io/kestra/core/runners/AbstractWorkerTriggerCallable.java
@@ -5,14 +5,14 @@ import lombok.Getter;
 
 import java.time.Duration;
 
-public abstract class AbstractWorkerTriggerThread extends AbstractWorkerThread {
+abstract class AbstractWorkerTriggerCallable extends AbstractWorkerCallable {
     // This duration is by design low as we don't want to hang a thread for too long when we kill a trigger
     private static final Duration AWAIT_ON_KILL = Duration.ofMillis(50);
 
     @Getter
     WorkerTrigger workerTrigger;
 
-    public AbstractWorkerTriggerThread(RunContext runContext, String type, WorkerTrigger workerTrigger) {
+    AbstractWorkerTriggerCallable(RunContext runContext, String type, WorkerTrigger workerTrigger) {
         super(runContext, type, workerTrigger.getTrigger().getClass().getClassLoader());
         this.workerTrigger = workerTrigger;
     }

--- a/core/src/main/java/io/kestra/core/runners/WorkerTaskCallable.java
+++ b/core/src/main/java/io/kestra/core/runners/WorkerTaskCallable.java
@@ -4,6 +4,7 @@ import dev.failsafe.Failsafe;
 import dev.failsafe.Timeout;
 import io.kestra.core.exceptions.TimeoutExceededException;
 import io.kestra.core.metrics.MetricRegistry;
+import io.kestra.core.models.flows.State;
 import io.kestra.core.models.tasks.Output;
 import io.kestra.core.models.tasks.RunnableTask;
 import io.kestra.core.models.tasks.RunnableTaskException;
@@ -13,7 +14,7 @@ import java.time.Duration;
 
 import static io.kestra.core.models.flows.State.Type.*;
 
-public class WorkerTaskThread extends AbstractWorkerThread {
+class WorkerTaskCallable extends AbstractWorkerCallable {
     RunnableTask<?> task;
     MetricRegistry metricRegistry;
 
@@ -23,7 +24,7 @@ public class WorkerTaskThread extends AbstractWorkerThread {
     @Getter
     Output taskOutput;
 
-    public WorkerTaskThread(WorkerTask workerTask, RunnableTask<?> task, RunContext runContext, MetricRegistry metricRegistry) {
+    WorkerTaskCallable(WorkerTask workerTask, RunnableTask<?> task, RunContext runContext, MetricRegistry metricRegistry) {
         super(runContext, task.getClass().getName(), task.getClass().getClassLoader());
         this.workerTask = workerTask;
         this.task = task;
@@ -51,8 +52,9 @@ public class WorkerTaskThread extends AbstractWorkerThread {
     }
 
     @Override
-    public void doRun() throws Exception {
+    public State.Type doCall() throws Exception {
         final Duration workerTaskTimeout = workerTask.getTask().getTimeout();
+
         try {
             if (workerTaskTimeout != null) {
                 Timeout<Object> taskTimeout = Timeout
@@ -72,20 +74,20 @@ public class WorkerTaskThread extends AbstractWorkerThread {
                         .increment()
                     )
                     .run(() -> taskOutput = task.run(runContext));
-
             } else {
                 taskOutput = task.run(runContext);
             }
-            taskState = SUCCESS;
+
             if (taskOutput != null && taskOutput.finalState().isPresent()) {
-                taskState = taskOutput.finalState().get();
+                return taskOutput.finalState().get();
             }
+            return SUCCESS;
         } catch (dev.failsafe.TimeoutExceededException e) {
             kill(false);
-            this.exceptionHandler(this, new TimeoutExceededException(workerTaskTimeout));
+            return this.exceptionHandler(new TimeoutExceededException(workerTaskTimeout));
         } catch (RunnableTaskException e) {
             taskOutput = e.getOutput();
-            this.exceptionHandler(this, e);
+            return this.exceptionHandler(e);
         }
     }
 }

--- a/core/src/main/java/io/kestra/core/runners/WorkerTriggerCallable.java
+++ b/core/src/main/java/io/kestra/core/runners/WorkerTriggerCallable.java
@@ -1,6 +1,7 @@
 package io.kestra.core.runners;
 
 import io.kestra.core.models.executions.Execution;
+import io.kestra.core.models.flows.State;
 import io.kestra.core.models.triggers.PollingTriggerInterface;
 import lombok.Getter;
 
@@ -8,23 +9,23 @@ import java.util.Optional;
 
 import static io.kestra.core.models.flows.State.Type.SUCCESS;
 
-public class WorkerTriggerThread extends AbstractWorkerTriggerThread {
+class WorkerTriggerCallable extends AbstractWorkerTriggerCallable {
     PollingTriggerInterface pollingTrigger;
 
     @Getter
     Optional<Execution> evaluate;
 
-    public WorkerTriggerThread(RunContext runContext, WorkerTrigger workerTrigger, PollingTriggerInterface pollingTrigger) {
+    WorkerTriggerCallable(RunContext runContext, WorkerTrigger workerTrigger, PollingTriggerInterface pollingTrigger) {
         super(runContext, pollingTrigger.getClass().getName(), workerTrigger);
         this.pollingTrigger = pollingTrigger;
     }
 
     @Override
-    public void doRun() throws Exception {
+    public State.Type doCall() throws Exception {
         this.evaluate = this.pollingTrigger.evaluate(
             workerTrigger.getConditionContext().withRunContext(runContext),
             workerTrigger.getTriggerContext()
         );
-        taskState = SUCCESS;
+        return SUCCESS;
     }
 }


### PR DESCRIPTION
Currently we use 2 thread for each worker job:
- One thread of the main executorService which is used immediately after queue consumption to not block the queue. It also limit concurrency of job execution.
- One thread to effectively execute the task or evaluate the trigger, this is needed to be able to interrupt it.

This PR keeps the first thread pool as we don't want to block the queue reception (or we will deadlock in JDBC), and we need to limit concurrency. But it then uses a virtual thread to execute the task / evaluate the trigger to reduce resource consumption and switch from the low level thread API to a Callable<State.Type>.