### PR TITLE
feat(core): validate that an input of type FILE didn't have any defaults

### DIFF
--- a/core/src/main/java/io/kestra/core/models/flows/input/FileInput.java
+++ b/core/src/main/java/io/kestra/core/models/flows/input/FileInput.java
@@ -1,6 +1,7 @@
 package io.kestra.core.models.flows.input;
 
 import io.kestra.core.models.flows.Input;
+import io.kestra.core.validations.FileInputValidation;
 import jakarta.validation.ConstraintViolationException;
 import lombok.Builder;
 import lombok.Getter;
@@ -12,6 +13,7 @@ import java.net.URI;
 @SuperBuilder
 @Getter
 @NoArgsConstructor
+@FileInputValidation
 public class FileInput extends Input<URI> {
     @Builder.Default
     public String extension = ".upl";

--- a/core/src/main/java/io/kestra/core/validations/FileInputValidation.java
+++ b/core/src/main/java/io/kestra/core/validations/FileInputValidation.java
@@ -1,0 +1,16 @@
+package io.kestra.core.validations;
+
+import io.kestra.core.validations.validator.FileInputValidator;
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Constraint(validatedBy = FileInputValidator.class)
+public @interface FileInputValidation {
+    String message() default "invalid file input";
+    Class<?>[] groups() default {};
+    Class<? extends Payload>[] payload() default {};
+}

--- a/core/src/main/java/io/kestra/core/validations/validator/FileInputValidator.java
+++ b/core/src/main/java/io/kestra/core/validations/validator/FileInputValidator.java
@@ -1,0 +1,31 @@
+package io.kestra.core.validations.validator;
+
+import io.kestra.core.models.flows.input.FileInput;
+import io.kestra.core.validations.FileInputValidation;
+import io.micronaut.core.annotation.AnnotationValue;
+import io.micronaut.core.annotation.Introspected;
+import io.micronaut.core.annotation.NonNull;
+import io.micronaut.core.annotation.Nullable;
+import io.micronaut.validation.validator.constraints.ConstraintValidator;
+import io.micronaut.validation.validator.constraints.ConstraintValidatorContext;
+import jakarta.inject.Singleton;
+
+@Singleton
+@Introspected
+public class FileInputValidator implements ConstraintValidator<FileInputValidation, FileInput> {
+    @Override
+    public boolean isValid(@Nullable FileInput value, @NonNull AnnotationValue<FileInputValidation> annotationMetadata, @NonNull ConstraintValidatorContext context) {
+        if (value == null) {
+            return true; // nulls are allowed according to spec
+        }
+
+        if (value.getDefaults() != null) {
+            context.disableDefaultConstraintViolation();
+            context.buildConstraintViolationWithTemplate("no `defaults` can be set for inputs of type 'FILE'")
+                .addConstraintViolation();
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/core/src/test/java/io/kestra/core/models/flows/FlowTest.java
+++ b/core/src/test/java/io/kestra/core/models/flows/FlowTest.java
@@ -142,6 +142,18 @@ class FlowTest {
         assertThat(all.size(), is(3));
     }
 
+    @Test
+    void inputValidation() {
+        Flow flow = this.parse("flows/invalids/inputs-validation.yaml");
+        Optional<ConstraintViolationException> validate = modelValidator.isValid(flow);
+
+        assertThat(validate.isPresent(), is(true));
+        assertThat(validate.get().getConstraintViolations().size(), is(2));
+
+        assertThat(validate.get().getMessage(), containsString("inputs[0]: no `defaults` can be set for inputs of type 'FILE'"));
+        assertThat(validate.get().getMessage(), containsString("inputs[1]: `itemType` cannot be `ARRAY"));
+    }
+
     private Flow parse(String path) {
         URL resource = TestsUtils.class.getClassLoader().getResource(path);
         assert resource != null;

--- a/core/src/test/resources/flows/invalids/inputs-validation.yaml
+++ b/core/src/test/resources/flows/invalids/inputs-validation.yaml
@@ -1,0 +1,15 @@
+id: inputs-validations
+namespace: io.kestra.tests
+
+inputs:
+  - id: file
+    type: FILE
+    defaults: something
+  - id: array
+    type: ARRAY
+    itemType: ARRAY
+
+tasks:
+  - id: hello
+    type: io.kestra.plugin.core.log.Log
+    message: Hello World! 🚀


### PR DESCRIPTION
Fixes #1091

Example flow:
```yaml
id: bar-input-file
namespace: company.myteam

inputs:
  - id: file
    type: FILE
    defaults: something

tasks:
  - id: hello
    type: io.kestra.plugin.core.log.Log
    message: Hello World! 🚀
```

Result:
![image](https://github.com/kestra-io/kestra/assets/1819009/98573d87-786f-4aeb-a0bb-6a8f91ef0848)
