### PR TITLE
feat(core, ui): save the worker id in the trigger context

### DIFF
--- a/core/src/main/java/io/kestra/core/models/triggers/Trigger.java
+++ b/core/src/main/java/io/kestra/core/models/triggers/Trigger.java
@@ -6,10 +6,7 @@ import io.kestra.core.models.flows.Flow;
 import io.kestra.core.models.flows.State;
 import io.kestra.core.utils.IdUtils;
 import io.micronaut.core.annotation.Nullable;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.ToString;
+import lombok.*;
 import lombok.experimental.SuperBuilder;
 
 import java.time.Instant;
@@ -34,6 +31,10 @@ public class Trigger extends TriggerContext {
 
     @Nullable
     private ZonedDateTime evaluateRunningDate; // this is used as an evaluation lock to avoid duplicate evaluation
+
+    @Nullable
+    @Setter // it's unfortunate but neither toBuilder() not @With works so using @Setter here
+    private String workerId;
 
     protected Trigger(TriggerBuilder<?, ?> b) {
         super(b);

--- a/core/src/main/java/io/kestra/core/runners/WorkerTrigger.java
+++ b/core/src/main/java/io/kestra/core/runners/WorkerTrigger.java
@@ -3,7 +3,7 @@ package io.kestra.core.runners;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import io.kestra.core.models.conditions.ConditionContext;
 import io.kestra.core.models.triggers.AbstractTrigger;
-import io.kestra.core.models.triggers.TriggerContext;
+import io.kestra.core.models.triggers.Trigger;
 import lombok.Builder;
 import lombok.Data;
 
@@ -22,7 +22,7 @@ public class WorkerTrigger extends WorkerJob {
     private AbstractTrigger trigger;
 
     @NotNull
-    private TriggerContext triggerContext;
+    private Trigger triggerContext;
 
     @NotNull
     private ConditionContext conditionContext;

--- a/core/src/main/java/io/kestra/core/runners/WorkerTriggerRunning.java
+++ b/core/src/main/java/io/kestra/core/runners/WorkerTriggerRunning.java
@@ -3,7 +3,7 @@ package io.kestra.core.runners;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import io.kestra.core.models.conditions.ConditionContext;
 import io.kestra.core.models.triggers.AbstractTrigger;
-import io.kestra.core.models.triggers.TriggerContext;
+import io.kestra.core.models.triggers.Trigger;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
@@ -24,7 +24,7 @@ public class WorkerTriggerRunning extends WorkerJobRunning {
     private AbstractTrigger trigger;
 
     @NotNull
-    private TriggerContext triggerContext;
+    private Trigger triggerContext;
 
     @NotNull
     private ConditionContext conditionContext;

--- a/core/src/main/java/io/kestra/core/schedulers/AbstractScheduler.java
+++ b/core/src/main/java/io/kestra/core/schedulers/AbstractScheduler.java
@@ -471,10 +471,10 @@ public abstract class AbstractScheduler implements Scheduler, Service {
                                 // If it has an interval, the Worker will execute the trigger.
                                 // Normally, only the Schedule trigger has no interval.
                                 Trigger triggerRunning = Trigger.of(f.getTriggerContext(), now);
-
+                                var flowWithTrigger = f.toBuilder().triggerContext(triggerRunning).build();
                                 try {
                                     this.triggerState.save(triggerRunning, scheduleContext);
-                                    this.sendWorkerTriggerToWorker(f);
+                                    this.sendWorkerTriggerToWorker(flowWithTrigger);
                                 } catch (InternalException e) {
                                     logService.logTrigger(
                                         f.getTriggerContext(),

--- a/core/src/test/java/io/kestra/core/runners/RunContextTest.java
+++ b/core/src/test/java/io/kestra/core/runners/RunContextTest.java
@@ -18,6 +18,7 @@ import io.kestra.core.models.flows.input.StringInput;
 import io.kestra.core.models.tasks.common.EncryptedString;
 import io.kestra.core.models.triggers.AbstractTrigger;
 import io.kestra.core.models.triggers.PollingTriggerInterface;
+import io.kestra.core.models.triggers.Trigger;
 import io.kestra.core.models.triggers.TriggerContext;
 import io.kestra.core.queues.QueueFactoryInterface;
 import io.kestra.core.queues.QueueInterface;
@@ -294,7 +295,7 @@ class RunContextTest extends AbstractMemoryRunnerTest {
             .format("john {{ secret('PASSWORD') }} doe")
             .build();
 
-        Map.Entry<ConditionContext, TriggerContext> mockedTrigger = TestsUtils.mockTrigger(runContextFactory, trigger);
+        Map.Entry<ConditionContext, Trigger> mockedTrigger = TestsUtils.mockTrigger(runContextFactory, trigger);
 
         WorkerTrigger workerTrigger = WorkerTrigger.builder()
             .trigger(trigger)

--- a/jdbc/src/test/java/io/kestra/jdbc/runner/JdbcServiceLivenessCoordinatorTest.java
+++ b/jdbc/src/test/java/io/kestra/jdbc/runner/JdbcServiceLivenessCoordinatorTest.java
@@ -7,6 +7,7 @@ import io.kestra.core.models.executions.TaskRun;
 import io.kestra.core.models.flows.Flow;
 import io.kestra.core.models.flows.State.Type;
 import io.kestra.core.models.tasks.ResolvedTask;
+import io.kestra.core.models.triggers.Trigger;
 import io.kestra.core.models.triggers.TriggerContext;
 import io.kestra.core.queues.QueueFactoryInterface;
 import io.kestra.core.queues.QueueInterface;
@@ -228,7 +229,7 @@ public abstract class JdbcServiceLivenessCoordinatorTest {
             .duration(sleep.toMillis())
             .build();
 
-        Map.Entry<ConditionContext, TriggerContext> mockedTrigger = TestsUtils.mockTrigger(runContextFactory, trigger);
+        Map.Entry<ConditionContext, Trigger> mockedTrigger = TestsUtils.mockTrigger(runContextFactory, trigger);
 
         return WorkerTrigger.builder()
             .trigger(trigger)

--- a/tests/src/main/java/io/kestra/core/utils/TestsUtils.java
+++ b/tests/src/main/java/io/kestra/core/utils/TestsUtils.java
@@ -12,6 +12,7 @@ import io.kestra.core.models.flows.Flow;
 import io.kestra.core.models.flows.State;
 import io.kestra.core.models.tasks.Task;
 import io.kestra.core.models.triggers.AbstractTrigger;
+import io.kestra.core.models.triggers.Trigger;
 import io.kestra.core.models.triggers.TriggerContext;
 import io.kestra.core.queues.QueueInterface;
 import io.kestra.core.repositories.LocalFlowRepositoryLoader;
@@ -151,11 +152,11 @@ abstract public class TestsUtils {
             .withState(State.Type.RUNNING);
     }
 
-    public static Map.Entry<ConditionContext, TriggerContext> mockTrigger(RunContextFactory runContextFactory, AbstractTrigger trigger) {
+    public static Map.Entry<ConditionContext, Trigger> mockTrigger(RunContextFactory runContextFactory, AbstractTrigger trigger) {
         StackTraceElement caller = Thread.currentThread().getStackTrace()[2];
         Flow flow = TestsUtils.mockFlow(caller);
 
-        TriggerContext triggerContext = TriggerContext.builder()
+        Trigger triggerContext = Trigger.builder()
             .triggerId(trigger.getId())
             .flowId(flow.getId())
             .namespace(flow.getNamespace())

--- a/ui/src/components/admin/Triggers.vue
+++ b/ui/src/components/admin/Triggers.vue
@@ -126,6 +126,14 @@
                                 />
                             </template>
                         </el-table-column>
+                        <el-table-column prop="workerId" :label="$t('workerId')">
+                            <template #default="scope">
+                                <id
+                                    :value="scope.row.workerId"
+                                    :shrink="true"
+                                />
+                            </template>
+                        </el-table-column>
                         <el-table-column :label="$t('date')">
                             <template #default="scope">
                                 <date-ago :inverted="true" :date="scope.row.date" />

--- a/ui/src/components/flows/FlowTriggers.vue
+++ b/ui/src/components/flows/FlowTriggers.vue
@@ -16,6 +16,15 @@
 
         <el-table-column prop="type" :label="$t('type')" />
 
+        <el-table-column prop="workerId" :label="$t('workerId')">
+            <template #default="scope">
+                <id
+                    :value="scope.row.workerId"
+                    :shrink="true"
+                />
+            </template>
+        </el-table-column>
+
         <el-table-column prop="nextExecutionDate" :label="$t('next execution date')">
             <template #default="scope">
                 <date-ago :inverted="true" :date="scope.row.nextExecutionDate" />
@@ -182,6 +191,7 @@
     import CalendarCollapseHorizontalOutline from "vue-material-design-icons/CalendarCollapseHorizontalOutline.vue"
     import FlowRun from "./FlowRun.vue";
     import RefreshButton from "../layout/RefreshButton.vue";
+    import Id from "../Id.vue";
 </script>
 
 <script>

--- a/ui/src/translations/en.json
+++ b/ui/src/translations/en.json
@@ -830,6 +830,7 @@
     "bulk success disabled status": {
       "true": "{count} trigger(s) disabled",
       "false": "{count} trigger(s) enabled"
-    }
+    },
+    "workerId": "Worker Id"
   }
 }

--- a/ui/src/translations/fr.json
+++ b/ui/src/translations/fr.json
@@ -803,6 +803,7 @@
     "bulk success disabled status": {
       "true": "{count} triggers désactivés",
       "false": "{count} triggers activés"
-    }
+    },
+    "workerId": "Worker Id"
   }
 }


### PR DESCRIPTION
Part of https://github.com/kestra-io/kestra-ee/issues/1256

@anna-geller this will add a new columns on the flow triggers page with the worker identfier:
![image](https://github.com/kestra-io/kestra/assets/1819009/a1474562-f091-4881-a3cb-2ff8ed161b87)

And a new column in the administration triggers page with the worker identifier:
![image](https://github.com/kestra-io/kestra/assets/1819009/62d663f7-2fd0-4d5f-88e7-6c81824c76c8)

I'll create an issue on EE to add a link to the service page from the trigger page, and on the service page add the list of currently evaluating triggers on a worker.