### PR TITLE
feat(core): add global jobs metrics to the server

### DIFF
--- a/core/src/main/java/io/kestra/core/metrics/MetricRegistry.java
+++ b/core/src/main/java/io/kestra/core/metrics/MetricRegistry.java
@@ -23,10 +23,12 @@ import org.apache.commons.lang3.ArrayUtils;
 @Singleton
 @Slf4j
 public class MetricRegistry {
+    public final static String METRIC_WORKER_JOB_PENDING_COUNT = "worker.job.pending";
+    public final static String METRIC_WORKER_JOB_RUNNING_COUNT = "worker.job.running";
+    public final static String METRIC_WORKER_JOB_THREAD_COUNT = "worker.job.thread";
     public final static String METRIC_WORKER_RUNNING_COUNT = "worker.running.count";
     public final static String METRIC_WORKER_QUEUED_DURATION = "worker.queued.duration";
     public final static String METRIC_WORKER_STARTED_COUNT = "worker.started.count";
-    public final static String METRIC_WORKER_RETRYED_COUNT = "worker.retryed.count";
     public final static String METRIC_WORKER_TIMEOUT_COUNT = "worker.timeout.count";
     public final static String METRIC_WORKER_ENDED_COUNT = "worker.ended.count";
     public final static String METRIC_WORKER_ENDED_DURATION = "worker.ended.duration";

--- a/core/src/main/java/io/kestra/core/runners/Worker.java
+++ b/core/src/main/java/io/kestra/core/runners/Worker.java
@@ -34,6 +34,7 @@ import io.micronaut.context.annotation.Parameter;
 import io.micronaut.context.event.ApplicationEventPublisher;
 import io.micronaut.core.annotation.Introspected;
 import io.micronaut.core.annotation.Nullable;
+import jakarta.annotation.PostConstruct;
 import jakarta.annotation.PreDestroy;
 import jakarta.inject.Inject;
 import jakarta.inject.Named;
@@ -135,6 +136,10 @@ public class Worker implements Service, Runnable, AutoCloseable {
 
     private final List<Runnable> receiveCancellations = new ArrayList<>();
 
+    private final Integer numThreads;
+    private final AtomicInteger pendingJobCount = new AtomicInteger(0);
+    private final AtomicInteger runningJobCount = new AtomicInteger(0);
+
     /**
      * Creates a new {@link Worker} instance.
      *
@@ -152,10 +157,20 @@ public class Worker implements Service, Runnable, AutoCloseable {
         ExecutorsUtils executorsUtils
     ) {
         this.id = workerId;
+        this.numThreads = numThreads;
         this.workerGroup = workerGroupService.resolveGroupFromKey(workerGroupKey);
         this.eventPublisher = eventPublisher;
         this.executorService = executorsUtils.maxCachedThreadPool(numThreads, "worker");
         this.setState(ServiceState.CREATED);
+    }
+
+    @PostConstruct
+    void initMetrics() {
+        String[] tags = this.workerGroup == null ? new String[0] : new String[] { MetricRegistry.TAG_WORKER_GROUP, this.workerGroup };
+        // create metrics to store thread count, pending jobs and running jobs, so we can have autoscaling easily
+        this.metricRegistry.gauge(MetricRegistry.METRIC_WORKER_JOB_THREAD_COUNT, numThreads, tags);
+        this.metricRegistry.gauge(MetricRegistry.METRIC_WORKER_JOB_PENDING_COUNT, pendingJobCount, tags);
+        this.metricRegistry.gauge(MetricRegistry.METRIC_WORKER_JOB_RUNNING_COUNT, runningJobCount, tags);
     }
 
     @Override
@@ -196,19 +211,29 @@ public class Worker implements Service, Runnable, AutoCloseable {
             this.workerGroup,
             Worker.class,
             either -> {
+                pendingJobCount.incrementAndGet();
+
                 executorService.execute(() -> {
-                    if (either.isRight()) {
-                        log.error("Unable to deserialize a worker job: {}", either.getRight().getMessage());
-                        handleDeserializationError(either.getRight());
-                        return;
+                    pendingJobCount.decrementAndGet();
+                    runningJobCount.incrementAndGet();
+
+                    try {
+                        if (either.isRight()) {
+                            log.error("Unable to deserialize a worker job: {}", either.getRight().getMessage());
+                            handleDeserializationError(either.getRight());
+                            return;
+                        }
+
+                        WorkerJob workerTask = either.getLeft();
+                        if (workerTask instanceof WorkerTask task) {
+                            handleTask(task);
+                        } else if (workerTask instanceof WorkerTrigger trigger) {
+                            handleTrigger(trigger);
+                        }
+                    } finally {
+                        runningJobCount.decrementAndGet();
                     }
 
-                    WorkerJob workerTask = either.getLeft();
-                    if (workerTask instanceof WorkerTask task) {
-                        handleTask(task);
-                    } else if (workerTask instanceof WorkerTrigger trigger) {
-                        handleTrigger(trigger);
-                    }
                 });
             }
         ));


### PR DESCRIPTION
This PR adds 3 metrics to the worker:
- kestra_worker_job_thread: number of threads to process jobs
- kestra_worker_job_pending: number of jobs pending to be process (waiting for a thread to be available)
- kestra_worker_job_running: number of jobs running / processing (using a thread)

Those metrics will allow to autoscale Worker pods based on the worker job pending and currently running counts. The thread count can be used to compute a usage in percent.
