### PR TITLE
fix(webserver): do not accept invalid labels

### DIFF
--- a/webserver/src/main/java/io/kestra/webserver/controllers/api/ExecutionController.java
+++ b/webserver/src/main/java/io/kestra/webserver/controllers/api/ExecutionController.java
@@ -64,6 +64,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import jakarta.inject.Inject;
 import jakarta.inject.Named;
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -1317,7 +1318,7 @@ public class ExecutionController {
     @ApiResponse(responseCode = "400", description = "If the execution is not terminated")
     public HttpResponse<?> setLabels(
         @Parameter(description = "The execution id") @PathVariable String executionId,
-        @Parameter(description = "The labels to add to the execution") @Body @NotNull List<Label> labels
+        @Parameter(description = "The labels to add to the execution") @Body @NotNull @Valid List<Label> labels
     ) {
         Optional<Execution> maybeExecution = executionRepository.findById(tenantService.resolveTenant(), executionId);
         if (maybeExecution.isEmpty()) {
@@ -1424,7 +1425,7 @@ public class ExecutionController {
         @Parameter(description = "A labels filter as a list of 'key:value'") @Nullable @QueryValue List<String> labels,
         @Parameter(description = "The trigger execution id") @Nullable @QueryValue String triggerExecutionId,
         @Parameter(description = "A execution child filter") @Nullable @QueryValue ExecutionRepositoryInterface.ChildFilter childFilter,
-        @Parameter(description = "The labels to add to the execution") @Body @NotNull List<Label> setLabels
+        @Parameter(description = "The labels to add to the execution") @Body @NotNull @Valid List<Label> setLabels
     ) {
         validateTimeline(startDate, endDate);
 

--- a/webserver/src/test/java/io/kestra/webserver/controllers/api/ExecutionControllerTest.java
+++ b/webserver/src/test/java/io/kestra/webserver/controllers/api/ExecutionControllerTest.java
@@ -1106,6 +1106,12 @@ class ExecutionControllerTest extends JdbcH2ControllerTest {
             () -> client.toBlocking().exchange(HttpRequest.POST("/api/v1/executions/notfound/labels", List.of(new Label("key", "value"))))
         );
         assertThat(exception.getStatus(), is(HttpStatus.NOT_FOUND));
+
+        exception = assertThrows(
+            HttpClientResponseException.class,
+            () -> client.toBlocking().exchange(HttpRequest.POST("/api/v1/executions/" + result.getId() + "/labels", List.of(new Label(null, null))))
+        );
+        assertThat(exception.getStatus(), is(HttpStatus.UNPROCESSABLE_ENTITY));
     }
 
     @Test
@@ -1138,6 +1144,15 @@ class ExecutionControllerTest extends JdbcH2ControllerTest {
         );
 
         assertThat(response.getCount(), is(3));
+
+        var exception = assertThrows(
+            HttpClientResponseException.class,
+            () -> client.toBlocking().exchange(HttpRequest.POST(
+                "/api/v1/executions/labels/by-query?namespace=" + result1.getNamespace(),
+                List.of(new Label(null, null)))
+            )
+        );
+        assertThat(exception.getStatus(), is(HttpStatus.UNPROCESSABLE_ENTITY));
     }
 
     @Test


### PR DESCRIPTION
### What changes are being made and why?

Enabled entity validation instead of the API returning a HTTP 500 response.

This PR extends the UI fix of the #4225 issue.