### PR TITLE
feat(ui): humanize cron expressions

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -19,6 +19,7 @@
         "chart.js": "^4.4.3",
         "chartjs-chart-treemap": "^2.3.1",
         "core-js": "^3.37.1",
+        "cronstrue": "^2.50.0",
         "dagre": "^0.8.5",
         "element-plus": "^2.7.5",
         "humanize-duration": "^3.32.1",
@@ -1692,6 +1693,15 @@
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
       "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
       "dev": true
+    },
+    "node_modules/cronstrue": {
+      "version": "2.50.0",
+      "resolved": "https://registry.npmjs.org/cronstrue/-/cronstrue-2.50.0.tgz",
+      "integrity": "sha512-ULYhWIonJzlScCCQrPUG5uMXzXxSixty4djud9SS37DoNxDdkeRocxzHuAo4ImRBUK+mAuU5X9TSwEDccnnuPg==",
+      "license": "MIT",
+      "bin": {
+        "cronstrue": "bin/cli.js"
+      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.3",

--- a/ui/package.json
+++ b/ui/package.json
@@ -41,6 +41,7 @@
     "node-modules-polyfill": "^0.1.4",
     "nprogress": "^0.2.0",
     "posthog-js": "^1.138.2",
+    "cronstrue": "^2.50.0",
     "throttle-debounce": "^5.0.0",
     "vite-plugin-eslint": "^1.8.1",
     "vue": "^3.4.27",

--- a/ui/src/components/flows/TriggerAvatar.vue
+++ b/ui/src/components/flows/TriggerAvatar.vue
@@ -6,7 +6,7 @@
                     placement="left"
                     :persistent="true"
                     :title="`${$t('trigger details')}: ${trigger ? trigger.id : ''}`"
-                    width=""
+                    width="35em"
                     transition=""
                     :hide-after="0"
                 >

--- a/ui/src/components/flows/TriggerVars.vue
+++ b/ui/src/components/flows/TriggerVars.vue
@@ -11,6 +11,9 @@
                 <template v-if="scope.row.key === 'description'">
                     <markdown :source="scope.row.value" />
                 </template>
+                <template v-else-if="scope.row.key === 'cron'">
+                    <cron :cron-expression="scope.row.value" />
+                </template>
                 <template v-else>
                     <var-value :value="scope.row.value" :execution="execution" />
                 </template>
@@ -23,11 +26,13 @@
     import Utils from "../../utils/utils";
     import VarValue from "../executions/VarValue.vue";
     import Markdown from "../layout/Markdown.vue";
+    import Cron from "../layout/Cron.vue";
 
     export default {
         components: {
             VarValue,
-            Markdown
+            Markdown,
+            Cron
         },
         props: {
             data: {

--- a/ui/src/components/layout/Cron.vue
+++ b/ui/src/components/layout/Cron.vue
@@ -1,0 +1,25 @@
+<template>
+    <span data-component="FILENAME_PLACEHOLDER">
+        {{ humanReadableCron }}
+    </span>
+</template>
+
+<script>
+    import Utils from "../../utils/utils.js";
+    import cronstrue from "cronstrue";
+    import "cronstrue/locales/fr";
+
+    export default {
+        props: {
+            cronExpression: {
+                type: String,
+                default: undefined
+            }
+        },
+        computed: {
+            humanReadableCron() {
+                return cronstrue.toString(this.cronExpression, {locale: Utils.getLang()});
+            }
+        }
+    }
+</script>

--- a/ui/src/components/onboarding/OnboardingCard.vue
+++ b/ui/src/components/onboarding/OnboardingCard.vue
@@ -18,6 +18,7 @@
     import imageDoc from "../../assets/onboarding/onboarding-docs-dark.svg"
     import imageProduct from "../../assets/onboarding/onboarding-product-dark.svg"
     import Markdown from "../layout/Markdown.vue";
+    import Utils from "../../utils/utils.js";
 
     export default {
         name: "OnboardingCard",
@@ -50,7 +51,7 @@
         },
         computed: {
             lang() {
-                const lang = localStorage.getItem("lang") || "en";
+                const lang = Utils.getLang();
                 if (lang === "fr") {
                     return "_fr"
                 }

--- a/ui/src/components/settings/BasicSettings.vue
+++ b/ui/src/components/settings/BasicSettings.vue
@@ -246,7 +246,7 @@
 
             this.defaultNamespace = localStorage.getItem("defaultNamespace") || "";
             this.defaultLogLevel = localStorage.getItem("defaultLogLevel") || "INFO";
-            this.lang = localStorage.getItem("lang") || "en";
+            this.lang = Utils.getLang();
             this.theme = localStorage.getItem("theme") || "light";
             this.editorTheme = localStorage.getItem("editorTheme") || (darkTheme ? "dark" : "vs");
             this.dateFormat = localStorage.getItem(DATE_FORMAT_STORAGE_KEY) || "llll";

--- a/ui/src/utils/filters.js
+++ b/ui/src/utils/filters.js
@@ -12,7 +12,7 @@ export default {
         return Utils.humanDuration(value, options);
     },
     humanizeNumber: (value) => {
-        return parseInt(value).toLocaleString(localStorage.getItem("lang") || "en")
+        return parseInt(value).toLocaleString(Utils.getLang());
     },
     cap: value => value ? value.toString().capitalize() : "",
     lower: value => value ? value.toString().toLowerCase() : "",

--- a/ui/src/utils/init.js
+++ b/ui/src/utils/init.js
@@ -49,6 +49,7 @@ import TaskSubflowId from "../components/flows/tasks/TaskSubflowId.vue";
 import TaskSubflowInputs from "../components/flows/tasks/TaskSubflowInputs.vue";
 import LeftMenuLink from "../components/LeftMenuLink.vue";
 import RouterMd from "../components/utils/RouterMd.vue";
+import Utils from "./utils";
 
 export default (app, routes, stores, translations) => {
     // charts
@@ -102,7 +103,7 @@ export default (app, routes, stores, translations) => {
 
 
     // l18n
-    let locale = localStorage.getItem("lang") || "en";
+    let locale = Utils.getLang();
 
     let i18n = createI18n({
         locale: locale,

--- a/ui/src/utils/utils.js
+++ b/ui/src/utils/utils.js
@@ -120,7 +120,7 @@ export default class Utils {
     static humanDuration(value, options) {
         options = options || {maxDecimalPoints: 2};
         options.spacer = "";
-        options.language = localStorage.getItem("lang") || "en";
+        options.language = Utils.getLang();
         options.languages = humanizeDurationLanguages;
         options.largest = 2;
 
@@ -185,6 +185,10 @@ export default class Utils {
 
     static getTheme() {
         return localStorage.getItem("theme") || "light";
+    }
+
+    static getLang() {
+        return localStorage.getItem("lang") || "en";
     }
 
     static splitFirst(str, separator){


### PR DESCRIPTION
### What changes are being made and why?

* Added [*cRonstrue*](https://github.com/bradymholt/cronstrue) as dependency.
* Enabled English/French localization.
* Created a dedicated component providing a way to display human-readable cron expressions app-wide.
* Displaying the cron expressions on Flow listing using as human-readable; no work on Executions has been done.
* Refactored the app locale/lang config access.

closes #4211

### How the changes have been QAed?

```yaml
id: minuteFlow
namespace: company.team

tasks:
  - id: log
    type: io.kestra.plugin.core.log.Log
    message: It's {{ trigger.date ?? taskrun.startDate | date("HH:mm") }} 

triggers:
  - id: schedule
    type: io.kestra.plugin.core.trigger.Schedule
    cron: "* * * * *"
```