### PR TITLE
fix(ui): enhanced email and password length constraint in basic authentication

### DIFF
--- a/ui/src/components/admin/stats/BasicAuthPrompt.vue
+++ b/ui/src/components/admin/stats/BasicAuthPrompt.vue
@@ -66,7 +66,7 @@
                         {
                             validator: (rule, value, callback) => {
                                 if (value && value.length > 256) {
-                                    callback(new Error(this.$t("Email must not exceed 256 characters")));
+                                    callback(new Error(this.$t("email length constraint")));
                                 } else {
                                     callback();
                                 }
@@ -78,7 +78,7 @@
                         {
                             validator: (rule, value, callback) => {
                                 if (value && value.length > 256) {
-                                    callback(new Error(this.$t("Password must not exceed 256 characters")));
+                                    callback(new Error(this.$t("password length constraint")));
                                 } else {
                                     callback();
                                 }

--- a/ui/src/components/admin/stats/BasicAuthPrompt.vue
+++ b/ui/src/components/admin/stats/BasicAuthPrompt.vue
@@ -20,7 +20,7 @@
                 <el-form-item
                     :label="$t('password')"
                     required
-                    prop="email"
+                    prop="password"
                 >
                     <el-input v-model="form.password" type="password" show-password />
                 </el-form-item>
@@ -85,6 +85,7 @@
                             },
                             trigger: ["blur", "change"]
                         }
+                    ],
                     confirmPassword: [
                         {
                             validator: (rule, value, callback) => {

--- a/ui/src/components/admin/stats/BasicAuthPrompt.vue
+++ b/ui/src/components/admin/stats/BasicAuthPrompt.vue
@@ -20,6 +20,7 @@
                 <el-form-item
                     :label="$t('password')"
                     required
+                    prop="email"
                 >
                     <el-input v-model="form.password" type="password" show-password />
                 </el-form-item>
@@ -62,7 +63,28 @@
                             trigger: ["blur"],
                             pattern: "^$|^[a-zA-Z0-9_!#$%&’*+/=?`{|}~^.-]+@[a-zA-Z0-9.-]+$"
                         },
+                        {
+                            validator: (rule, value, callback) => {
+                                if (value && value.length > 256) {
+                                    callback(new Error(this.$t("Email must not exceed 256 characters")));
+                                } else {
+                                    callback();
+                                }
+                            },
+                            trigger: ["blur", "change"]
+                        }
                     ],
+                    password: [
+                        {
+                            validator: (rule, value, callback) => {
+                                if (value && value.length > 256) {
+                                    callback(new Error(this.$t("Password must not exceed 256 characters")));
+                                } else {
+                                    callback();
+                                }
+                            },
+                            trigger: ["blur", "change"]
+                        }
                     confirmPassword: [
                         {
                             validator: (rule, value, callback) => {

--- a/ui/src/translations/en.json
+++ b/ui/src/translations/en.json
@@ -251,6 +251,8 @@
     "email": "Email",
     "password": "Password",
     "confirm password": "Confirm password",
+    "email length constraint": "Email must not exceed 256 characters",
+    "password length constraint": "Password must not exceed 256 characters",
     "passwords do not match": "Passwords do not match",
     "avg duration": "Avg. execution duration",
     "neutral trend": "Stable",

--- a/ui/src/translations/fr.json
+++ b/ui/src/translations/fr.json
@@ -244,6 +244,8 @@
     "email": "Email",
     "password": "Mot de passe",
     "confirm password": "Confirmer le mot de passe",
+    "email length constraint": "L'e-mail ne doit pas dépasser 256 caractères.",
+    "password length constraint": "Le mot de passe ne doit pas dépasser 256 caractères.",
     "passwords do not match": "Les mots de passe ne correspondent pas",
     "avg duration": "Durée moyenne d'exécution",
     "neutral trend": "Stable",

--- a/webserver/src/main/java/io/kestra/webserver/services/BasicAuthService.java
+++ b/webserver/src/main/java/io/kestra/webserver/services/BasicAuthService.java
@@ -78,7 +78,7 @@ public class BasicAuthService {
 
         if (basicAuthConfiguration.getUsername().length() > EMAIL_PASSWORD_MAX_LEN ||
             basicAuthConfiguration.password.length() > EMAIL_PASSWORD_MAX_LEN) {
-            throw new IllegalArgumentException("The length of email or password should not exceed 256.");
+            throw new IllegalArgumentException("The length of email or password should not exceed 256 characters.");
         }
 
 

--- a/webserver/src/main/java/io/kestra/webserver/services/BasicAuthService.java
+++ b/webserver/src/main/java/io/kestra/webserver/services/BasicAuthService.java
@@ -31,6 +31,7 @@ import java.util.regex.Pattern;
 public class BasicAuthService {
     public static final String BASIC_AUTH_SETTINGS_KEY = "kestra.server.basic-auth";
     private static final Pattern EMAIL_PATTERN = Pattern.compile("^[a-zA-Z0-9_!#$%&’*+/=?`{|}~^.-]+@[a-zA-Z0-9.-]+$");
+    private static final int EMAIL_PASSWORD_MAX_LEN = 256;
 
     @Inject
     private SettingRepositoryInterface settingRepository;
@@ -74,6 +75,12 @@ public class BasicAuthService {
         if (basicAuthConfiguration.getPassword() == null) {
             throw new IllegalArgumentException("No password set for Basic Authentication. Please provide a password.");
         }
+
+        if (basicAuthConfiguration.getUsername().length() > EMAIL_PASSWORD_MAX_LEN ||
+            basicAuthConfiguration.password.length() > EMAIL_PASSWORD_MAX_LEN) {
+            throw new IllegalArgumentException("The length of email or password should not exceed 256.");
+        }
+
 
         SaltedBasicAuthConfiguration previousConfiguration = this.configuration();
         String salt = previousConfiguration == null


### PR DESCRIPTION
<!-- Thanks for submitting a Pull Request to Kestra. To help us review your contribution, please follow the guidelines below:

- Make sure that your commits follow the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) specification e.g. `feat(ui): add a new navigation menu item` or `fix(core): fix a bug in the core model` or `docs: update the README.md`. This will help us automatically generate the changelog.
- The title should briefly summarize the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share a flow example to help the reviewer understand and QA the change.
- Use "closes" to automatically close an issue. For example, `closes #1234` will close issue #1234. -->

### What changes are being made and why?
Per issue [3871](https://github.com/kestra-io/kestra/issues/3871), we want to add additional requirement for the length of email and password in basic authentication as the current implementation will cause a crash if input credentials are too large. This change includes:

1. add frontend validator for restricting length of email and password to be 256.
2. add backend check as well that verifies length constraint

### How the changes have been QAed?

Verify that if email and password are too long the frontend will prevent users from signing up.

<img width="732" alt="Screenshot 2024-07-07 at 6 14 04 PM" src="https://github.com/kestra-io/kestra/assets/20346113/359c1940-7dff-4c51-b4b9-7b925a892760">
