### PR TITLE
feat(core): stop realtime trigger and generate a FAILED execution if …

### DIFF
--- a/core/src/main/java/io/kestra/core/models/executions/ExecutionTrigger.java
+++ b/core/src/main/java/io/kestra/core/models/executions/ExecutionTrigger.java
@@ -6,6 +6,7 @@ import lombok.Value;
 import io.kestra.core.models.tasks.Output;
 import io.kestra.core.models.triggers.AbstractTrigger;
 
+import java.util.Collections;
 import java.util.Map;
 import jakarta.validation.constraints.NotNull;
 
@@ -25,7 +26,7 @@ public class ExecutionTrigger {
         return ExecutionTrigger.builder()
             .id(abstractTrigger.getId())
             .type(abstractTrigger.getType())
-            .variables(output.toMap())
+            .variables(output != null ? output.toMap() : Collections.emptyMap())
             .build();
     }
 

--- a/core/src/main/java/io/kestra/core/schedulers/AbstractScheduler.java
+++ b/core/src/main/java/io/kestra/core/schedulers/AbstractScheduler.java
@@ -213,17 +213,15 @@ public abstract class AbstractScheduler implements Scheduler, Service {
                 }
 
                 WorkerTriggerResult workerTriggerResult = either.getLeft();
-                if (workerTriggerResult.getSuccess() && workerTriggerResult.getExecution().isPresent()) {
-                    if (workerTriggerResult.getTrigger() instanceof RealtimeTriggerInterface) {
-                        this.emitExecution(workerTriggerResult.getExecution().get(), workerTriggerResult.getTriggerContext());
-                    } else {
-                        SchedulerExecutionWithTrigger triggerExecution = new SchedulerExecutionWithTrigger(
-                            workerTriggerResult.getExecution().get(),
-                            workerTriggerResult.getTriggerContext()
-                        );
-                        ZonedDateTime nextExecutionDate = this.nextEvaluationDate(workerTriggerResult.getTrigger());
-                        this.handleEvaluateWorkerTriggerResult(triggerExecution, nextExecutionDate);
-                    }
+                if (workerTriggerResult.getTrigger() instanceof RealtimeTriggerInterface && workerTriggerResult.getExecution().isPresent()) {
+                    this.emitExecution(workerTriggerResult.getExecution().get(), workerTriggerResult.getTriggerContext());
+                } else if (workerTriggerResult.getSuccess() && workerTriggerResult.getExecution().isPresent()) {
+                    SchedulerExecutionWithTrigger triggerExecution = new SchedulerExecutionWithTrigger(
+                        workerTriggerResult.getExecution().get(),
+                        workerTriggerResult.getTriggerContext()
+                    );
+                    ZonedDateTime nextExecutionDate = this.nextEvaluationDate(workerTriggerResult.getTrigger());
+                    this.handleEvaluateWorkerTriggerResult(triggerExecution, nextExecutionDate);
                 } else {
                     ZonedDateTime nextExecutionDate = this.nextEvaluationDate(workerTriggerResult.getTrigger());
                     this.triggerState.update(Trigger.of(workerTriggerResult.getTriggerContext(), nextExecutionDate));


### PR DESCRIPTION
…the publisher cannot be created

Part-of: [#1256](https://github.com/kestra-io/kestra-ee/issues/1256)

Thanks to that, an error when creating the Publisher (so before  receiving an event) will generate a failed executions and stop the trigger which will not be restarted except if the trigger is manually disabled/enabled.

There is multiple things to do to improve the behaviour:
- The log is not visible in the execution log tab itself but only in the flow logs page. This is a known issue, see [#2521](https://github.com/kestra-io/kestra/issues/2521)
- There is no way to restart a realtime trigger except disabling/re-enabling it in the YAML, we need a button for that in the trigger UI, I created https://github.com/kestra-io/kestra-ee/issues/1350 for that.