### PR TITLE
feat(webserver): allow restarting a trigger

### DIFF
--- a/ui/src/components/admin/Triggers.vue
+++ b/ui/src/components/admin/Triggers.vue
@@ -171,6 +171,23 @@
                                 </el-button>
                             </template>
                         </el-table-column>
+                        <el-table-column
+                            v-if="user.hasAnyAction(permission.EXECUTION, action.UPDATE)"
+                            column-key="restart"
+                            class-name="row-action"
+                        >
+                            <template #default="scope">
+                                <el-button size="small" v-if=" scope.row.evaluateRunningDate">
+                                    <kicon
+                                        :tooltip="$t(`restart trigger.tooltip`)"
+                                        placement="left"
+                                        @click="restart(scope.row)"
+                                    >
+                                        <Restart />
+                                    </kicon>
+                                </el-button>
+                            </template>
+                        </el-table-column>
 
                         <el-table-column :label="$t('backfill')" column-key="backfill">
                             <template #default="scope">
@@ -231,6 +248,7 @@
     import AlertCircle from "vue-material-design-icons/AlertCircle.vue";
     import SelectTable from "../layout/SelectTable.vue";
     import BulkSelect from "../layout/BulkSelect.vue";
+    import Restart from "vue-material-design-icons/Restart.vue";
 </script>
 <script>
     import NamespaceSelect from "../namespace/NamespaceSelect.vue";
@@ -313,6 +331,21 @@
                 }
 
                 this.triggerToUnlock = undefined;
+            },
+            restart(trigger) {
+                this.$store.dispatch("trigger/restart", {
+                    namespace: trigger.namespace,
+                    flowId: trigger.flowId,
+                    triggerId: trigger.triggerId
+                }).then(newTrigger => {
+                    this.$toast().saved(newTrigger.id);
+                    this.triggers = this.triggers.map(t => {
+                        if (t.id === newTrigger.id) {
+                            return newTrigger
+                        }
+                        return t
+                    })
+                })
             },
             setDisabled(trigger, value) {
                 if (trigger.codeDisabled) {

--- a/ui/src/components/flows/FlowTriggers.vue
+++ b/ui/src/components/flows/FlowTriggers.vue
@@ -102,6 +102,16 @@
             </template>
         </el-table-column>
 
+        <el-table-column column-key="restart" class-name="row-action" v-if="userCan(action.UPDATE)">
+            <template #default="scope">
+                <el-button size="small" v-if="scope.row.evaluateRunningDate" @click="restart(scope.row)">
+                    <kicon :tooltip="$t('restart trigger.button')">
+                        <Restart />
+                    </kicon>
+                </el-button>
+            </template>
+        </el-table-column>
+
         <el-table-column column-key="unlock" class-name="row-action" v-if="userCan(action.UPDATE)">
             <template #default="scope">
                 <el-button size="small" v-if="scope.row.executionId" @click="unlock(scope.row)">
@@ -188,6 +198,7 @@
     import Delete from "vue-material-design-icons/Delete.vue";
     import LockOff from "vue-material-design-icons/LockOff.vue";
     import Check from "vue-material-design-icons/Check.vue";
+    import Restart from "vue-material-design-icons/Restart.vue";
     import CalendarCollapseHorizontalOutline from "vue-material-design-icons/CalendarCollapseHorizontalOutline.vue"
     import FlowRun from "./FlowRun.vue";
     import RefreshButton from "../layout/RefreshButton.vue";
@@ -371,6 +382,21 @@
             },
             unlock(trigger) {
                 this.$store.dispatch("trigger/unlock", {
+                    namespace: trigger.namespace,
+                    flowId: trigger.flowId,
+                    triggerId: trigger.triggerId
+                }).then(newTrigger => {
+                    this.$toast().saved(newTrigger.id);
+                    this.triggers = this.triggers.map(t => {
+                        if (t.id === newTrigger.id) {
+                            return newTrigger
+                        }
+                        return t
+                    })
+                })
+            },
+            restart(trigger) {
+                this.$store.dispatch("trigger/restart", {
                     namespace: trigger.namespace,
                     flowId: trigger.flowId,
                     triggerId: trigger.triggerId

--- a/ui/src/stores/trigger.js
+++ b/ui/src/stores/trigger.js
@@ -16,6 +16,9 @@ export default {
         async unlock({_commit}, options) {
             return (await this.$http.post(`${apiUrl(this)}/triggers/${options.namespace}/${options.flowId}/${options.triggerId}/unlock`)).data;
         },
+        async restart({_commit}, options) {
+            return (await this.$http.post(`${apiUrl(this)}/triggers/${options.namespace}/${options.flowId}/${options.triggerId}/restart`)).data;
+        },
         find({_commit}, options) {
             return this.$http.get(`${apiUrl(this)}/triggers/${options.namespace}/${options.flowId}`, {params: options}).then(response => {
                 return response.data;

--- a/ui/src/translations/en.json
+++ b/ui/src/translations/en.json
@@ -590,6 +590,9 @@
       "button": "Unlock trigger",
       "success": "Trigger is unlocked"
     },
+    "restart trigger": {
+      "button": "Restart trigger"
+    },
     "date format": "Date format",
     "timezone": "Timezone",
     "add task": "Add a task",
@@ -849,8 +852,8 @@
     },
     "no_namespaces": "Zero namespaces match the search criteria.",
     "plugin defaults": "Plugin defaults",
-    "secret": {           
-      "names": "Secrets",           
+    "secret": {
+      "names": "Secrets",
       "inherited": "Inherited secrets"
     },
     "workerId": "Worker Id",

--- a/ui/src/translations/fr.json
+++ b/ui/src/translations/fr.json
@@ -571,6 +571,9 @@
       "button": "Débloquer le déclencheur",
       "success": "Le déclencheur est débloqué"
     },
+    "restart trigger": {
+      "button": "Redémarrer trigger"
+    },
     "date format": "Format de date",
     "timezone": "Fuseau horaire",
     "add task": "Ajouter une tâche",


### PR DESCRIPTION
This will kill it then restart it

Fixes [#4146](https://github.com/kestra-io/kestra/issues/4146)

A restart button will be displayed on triggers currently evaluated (always the case for realtime triggers, occur for polling triggers while they are evaluating an the worker).

On the Flow Triggers tab
![image](https://github.com/kestra-io/kestra/assets/1819009/f7745cff-02e4-4afa-a8e2-85c6d8017e08)

On the Admin Triggers page
![image](https://github.com/kestra-io/kestra/assets/1819009/dd21bc02-cfbd-43e6-bbff-fc8cf2ce150b)
