### PR TITLE
feat(ui): add cURL command to execute window

### DIFF
--- a/ui/src/components/flows/Curl.vue
+++ b/ui/src/components/flows/Curl.vue
@@ -1,0 +1,110 @@
+<template>
+    <div class="position-relative">
+        <code>
+            {{ curlCommand }}
+        </code>
+
+        <copy-to-clipboard class="position-absolute" :text="curlCommand" />
+
+        <el-alert class="mt-3" type="warning" show-icon :closable="false">
+            {{ $t('curl.note') }}
+        </el-alert>
+    </div>
+</template>
+
+<script>
+    import {baseUrl, basePath, apiUrl} from "override/utils/route";
+    import CopyToClipboard from "../layout/CopyToClipboard.vue";
+
+    export default {
+        components: {CopyToClipboard},
+        props: {
+            flow: {
+                type: Object,
+                required: true
+            },
+            inputs: {
+                type: Object,
+                default: () => {}
+            },
+            executionLabels: {
+                type: Array,
+                default: () => []
+            },
+            verbose: {
+                type: Boolean,
+                default: true
+            }
+        },
+        computed: {
+            curlCommand() {
+                return this.generateCurlCommand();
+            }
+        },
+        methods: {
+            addHeader(command, name, value) {
+                command.push("-H", `'${name}: ${value}'`);
+            },
+            addInputs(command) {
+                if (!this.flow.inputs) {
+                    return;
+                }
+
+                this.flow.inputs.forEach((input) => {
+                    if (this.isUnsupportedType(input.type)) {
+                        return;
+                    }
+
+                    const inputValue = this.inputs[input.id];
+
+                    if (inputValue === undefined) {
+                        return;
+                    }
+
+                    command.push("-F", `'${input.id}=${inputValue}'`);
+                });
+            },
+            isUnsupportedType(type) {
+                const unsupportedTypes = ["SECRET", "FILE"];
+
+                return unsupportedTypes.indexOf(type) > -1;
+            },
+            generateExecutionLabel(key, value) {
+                return `labels=${encodeURIComponent(key)}:${encodeURIComponent(value)}`;
+            },
+            generateUrl() {
+                const queryParams = this.executionLabels
+                    .filter((label) => label.key !== null && label.value !== null && label.key !== "" && label.value !== "")
+                    .map((label) => this.generateExecutionLabel(label.key, label.value));
+
+                const origin = baseUrl ? apiUrl(this.$store) : `${location.origin}${basePath()}`;
+
+                var url = `${origin}/executions/${this.flow.namespace}/${this.flow.id}`;
+
+                if (queryParams.length > 0) {
+                    url += `?${queryParams.join("&")}`;
+                }
+
+                return url;
+            },
+            generateCurlCommand() {
+                const command = ["curl"];
+
+                if (this.verbose) {
+                    command.push("-v");
+                }
+
+                command.push("-X", "POST");
+
+                this.addHeader(command, "Transfer-Encoding", "chunked");
+                this.addHeader(command, "Content-Type", "multipart/form-data");
+
+                this.addInputs(command);
+
+                command.push(`'${this.generateUrl()}'`);
+
+                return command.join(" ");
+            }
+        }
+    }
+</script>

--- a/ui/src/components/flows/FlowRun.vue
+++ b/ui/src/components/flows/FlowRun.vue
@@ -7,6 +7,7 @@
 
         <el-form label-position="top" :model="inputs" ref="form" @submit.prevent="false">
             <inputs-form :inputs-list="flow.inputs" v-model="inputs" />
+
             <el-collapse class="mt-4" v-model="collapseName">
                 <el-collapse-item :title="$t('advanced configuration')" name="advanced">
                     <el-form-item
@@ -17,6 +18,9 @@
                             v-model:labels="executionLabels"
                         />
                     </el-form-item>
+                </el-collapse-item>
+                <el-collapse-item :title="$t('curl.command')" name="curl">
+                    <curl :flow="flow" :execution-labels="executionLabels" :inputs="inputs" />
                 </el-collapse-item>
             </el-collapse>
 
@@ -62,11 +66,12 @@
     import {executeTask} from "../../utils/submitTask"
     import InputsForm from "../../components/inputs/InputsForm.vue";
     import LabelInput from "../../components/labels/LabelInput.vue";
+    import Curl from "./Curl.vue";
     import {executeFlowBehaviours, storageKeys} from "../../utils/constants";
     import Inputs from "../../utils/inputs";
 
     export default {
-        components: {LabelInput, InputsForm},
+        components: {LabelInput, InputsForm, Curl},
         props: {
             redirect: {
                 type: Boolean,

--- a/ui/src/components/flows/blueprints/BlueprintDetail.vue
+++ b/ui/src/components/flows/blueprints/BlueprintDetail.vue
@@ -43,11 +43,7 @@
                 <el-card>
                     <editor class="position-relative" :read-only="true" :full-height="false" :minimap="false" :model-value="blueprint.flow" lang="yaml">
                         <template #nav>
-                            <div class="position-absolute copy-wrapper">
-                                <el-tooltip trigger="click" content="Copied" placement="left" :auto-close="2000" effect="light">
-                                    <el-button text round :icon="icon.ContentCopy" @click="Utils.copy(blueprint.flow)" />
-                                </el-tooltip>
-                            </div>
+                            <copy-to-clipboard class="position-absolute" :text="blueprint.flow" />
                         </template>
                     </editor>
                 </el-card>
@@ -73,27 +69,22 @@
     import LowCodeEditor from "../../inputs/LowCodeEditor.vue";
     import TaskIcon from  "@kestra-io/ui-libs/src/components/misc/TaskIcon.vue";
     import TopNavBar from "../../layout/TopNavBar.vue";
-    import Utils from "../../../utils/utils";
 </script>
 <script>
     import YamlUtils from "../../../utils/yamlUtils";
-    import {shallowRef} from "vue";
-    import ContentCopy from "vue-material-design-icons/ContentCopy.vue";
     import Markdown from "../../layout/Markdown.vue";
+    import CopyToClipboard from "../../layout/CopyToClipboard.vue";
     import {mapState} from "vuex";
     import permission from "../../../models/permission";
     import action from "../../../models/action";
     import {apiUrl} from "override/utils/route";
 
     export default {
-        components: {Markdown},
+        components: {Markdown, CopyToClipboard},
         emits: ["back"],
         data() {
             return {
                 flowGraph: undefined,
-                icon: {
-                    ContentCopy: shallowRef(ContentCopy)
-                },
                 blueprint: undefined,
                 breadcrumb: [
                     {
@@ -211,12 +202,6 @@
                 overflow: hidden;
             }
         }
-    }
-
-    .copy-wrapper {
-        right: $spacer;
-        top: $spacer;
-        z-index: 1
     }
 
     .blueprint-container {

--- a/ui/src/components/layout/CopyToClipboard.vue
+++ b/ui/src/components/layout/CopyToClipboard.vue
@@ -1,0 +1,34 @@
+<template>
+    <div class="copy-wrapper">
+        <el-tooltip trigger="click" :content="$t('copied')" placement="left" :auto-close="2000" effect="light">
+            <el-button text round :icon="ContentCopy" @click="Utils.copy(text)" />
+        </el-tooltip>
+    </div>
+</template>
+
+<script setup>
+    import ContentCopy from "vue-material-design-icons/ContentCopy.vue";
+</script>
+
+<script>
+    import Utils from "../../utils/utils";
+
+    export default {
+        props: {
+            text: {
+                type: String,
+                required: true
+            }
+        }
+    }
+</script>
+
+<style scoped lang="scss">
+    @import "@kestra-io/ui-libs/src/scss/variables.scss";
+
+    .copy-wrapper {
+        right: $spacer;
+        top: $spacer;
+        z-index: 1
+    }
+</style>

--- a/ui/src/translations/en.json
+++ b/ui/src/translations/en.json
@@ -875,6 +875,10 @@
         "title": "No tabs currently opened",
         "message": "You can create or import namespace files from the sidebar and you can check out the introduction video for our Editor."
       }
+    },
+    "curl": {
+      "command": "cURL command",
+      "note": "Note that credentials and FILE/SECRET input types are not shown."
     }
   }
 }

--- a/ui/src/translations/en.json
+++ b/ui/src/translations/en.json
@@ -878,7 +878,7 @@
     },
     "curl": {
       "command": "cURL command",
-      "note": "Note that credentials and FILE/SECRET input types are not shown."
+      "note": "Note that for SECRET and FILE input type, the command must be accommodate to match the real values."
     }
   }
 }

--- a/ui/src/translations/fr.json
+++ b/ui/src/translations/fr.json
@@ -852,6 +852,10 @@
         "title": "Aucun onglet actuellement ouvert",
         "message": "Vous pouvez créer ou importer des fichiers de namespace à partir de la barre latérale et vous pouvez consulter la vidéo d'introduction pour notre éditeur."
       }
+    },
+    "curl": {
+      "command": "Commande cURL",
+      "note": "Notez que les informations d'identification et les types d'entrée FILE/SECRET ne sont pas affichés."
     }
   }
 }

--- a/ui/src/translations/fr.json
+++ b/ui/src/translations/fr.json
@@ -855,7 +855,7 @@
     },
     "curl": {
       "command": "Commande cURL",
-      "note": "Notez que les informations d'identification et les types d'entrée FILE/SECRET ne sont pas affichés."
+      "note": "Notez que pour les types d'entrée SECRET et FILE, la commande doit être adaptée pour correspondre aux valeurs réelles."
     }
   }
 }


### PR DESCRIPTION
### What changes are being made and why?

* Provided just the UNIX shell version - no support for Windows CMD/PowerShell.
* Displayed the cURL command preview as it IMHO improves the UX - the user actually sees what is copied. However, it can easily be transformed to just the _Copy as cURL_ button.
* The `FILE` input can't be really supported since browser doesn't have the full path.
* User credentials nor `SECRET` inputs should be presented.
* Componentized the copy-to-clipboard button.
* The French translation was done via Google Translate, sorry.

closes #3585

![20240711-195924_snap](https://github.com/kestra-io/kestra/assets/13468636/564182b7-9786-43e2-b51e-2690b0392f51)
