### PR TITLE
fix(core): include all files as input files

### DIFF
--- a/core/src/main/java/io/kestra/core/models/tasks/runners/TaskCommands.java
+++ b/core/src/main/java/io/kestra/core/models/tasks/runners/TaskCommands.java
@@ -46,7 +46,7 @@ public interface TaskCommands {
         }
 
         try (Stream<Path> walk = Files.walk(workingDirectory)) {
-            Stream<Path> filtered = walk.filter(Files::isRegularFile);
+            Stream<Path> filtered = walk.filter(path -> !Files.isDirectory(path));
             Path outputDirectory = this.getOutputDirectory();
             if (outputDirectory != null) {
                 filtered = filtered.filter(Predicate.not(path -> path.startsWith(outputDirectory)));


### PR DESCRIPTION
isRegularFile filter too many files, !isDirectory will include more files. I'm not sure why but for ex isRegularFile didn't include files in the DBT .profile dir