### PR TITLE
fix(core): keep key order when rendering a Map

### DIFF
--- a/core/src/main/java/io/kestra/core/runners/VariableRenderer.java
+++ b/core/src/main/java/io/kestra/core/runners/VariableRenderer.java
@@ -182,7 +182,7 @@ public class VariableRenderer {
     }
 
     public Map<String, Object> render(Map<String, Object> in, Map<String, Object> variables, boolean recursive) throws IllegalVariableEvaluationException {
-        Map<String, Object> map = new HashMap<>();
+        Map<String, Object> map = new LinkedHashMap<>();
 
         for (Map.Entry<String, Object> r : in.entrySet()) {
             String key = this.render(r.getKey(), variables);

--- a/core/src/test/java/io/kestra/core/runners/VariableRendererTest.java
+++ b/core/src/test/java/io/kestra/core/runners/VariableRendererTest.java
@@ -1,9 +1,13 @@
 package io.kestra.core.runners;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+
 import io.kestra.core.exceptions.IllegalVariableEvaluationException;
 import io.micronaut.context.ApplicationContext;
 import io.kestra.core.junit.annotations.KestraTest;
 import jakarta.inject.Inject;
+import java.util.LinkedHashMap;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -18,6 +22,9 @@ class VariableRendererTest {
     @Inject
     VariableRenderer.VariableConfiguration variableConfiguration;
 
+    @Inject
+    VariableRenderer variableRenderer;
+
     @Test
     void shouldRenderUsingAlternativeRendering() throws IllegalVariableEvaluationException {
         TestVariableRenderer renderer = new TestVariableRenderer(applicationContext, variableConfiguration);
@@ -25,6 +32,25 @@ class VariableRendererTest {
         Assertions.assertEquals("result", render);
     }
 
+    @Test
+    void shouldKeepKeyOrderWhenRenderingMap() throws IllegalVariableEvaluationException {
+        final Map<String, Object> input = new LinkedHashMap<>();
+        input.put("foo-1", "A");
+        input.put("foo-2", "B");
+
+        final Map<String, Object> input_value3 = new LinkedHashMap<>();
+        input_value3.put("bar-1", "C");
+        input_value3.put("bar-2", "D");
+        input_value3.put("bar-3", "E");
+        //
+        input.put("foo-3", input_value3);
+
+        final Map<String, Object> result = variableRenderer.render(input, Map.of());
+        assertThat(result.keySet(), contains("foo-1", "foo-2", "foo-3"));
+
+        final Map<String, Object> result_value3 = (Map<String, Object>) result.get("foo-3");
+        assertThat(result_value3.keySet(), contains("bar-1", "bar-2", "bar-3"));
+    }
 
     public static class TestVariableRenderer extends VariableRenderer {
 


### PR DESCRIPTION
The `VariableRenderer#render()` method currently uses a `HashMap` to store rendered values, and this `Map` implementation does not preserve order.

This causes a problem when the `in` parameter is a `LinkedHashMap`, and you want the order to be preserved.
For example, when using the `Produce` task in the Kafka plugin ([here](https://github.com/kestra-io/plugin-kafka/blob/master/src/main/java/io/kestra/plugin/kafka/Produce.java#L274)) with an Avro serializer: the event value is part of the `map` that is first rendered; the order of the keys must be preserved in order to respect the schema, and currently this leads to serialization problems.

I changed it to `LinkedHashMap`, ensuring that key ordering is maintained in case a `LinkedHashMap` is passed as an input.