### PR TITLE
feat(ci): add commit details to `index.html` file with each fresh build

### DIFF
--- a/ui/build.gradle
+++ b/ui/build.gradle
@@ -37,3 +37,15 @@ final linterTask = tasks.register('lintFrontend', RunNpm) {
 }
 
 check.dependsOn linterTask
+
+task addCommitInfo(type: Exec) {
+    dependsOn assembleFrontend
+    group = 'Frontend'
+    description = 'Adds the comment with commit details at the beginning of index.html'
+
+    commandLine 'node', 'scripts/commits.js'
+    
+    workingDir = projectDir
+}
+
+assembleFrontend.finalizedBy addCommitInfo

--- a/ui/scripts/commits.js
+++ b/ui/scripts/commits.js
@@ -1,0 +1,25 @@
+const fs = require("fs");
+const {execSync} = require("child_process");
+
+// Get the last commit hash and date details
+const hash = execSync("git rev-parse HEAD").toString().trim();
+const date = execSync("git log -1 --format=%cd").toString().trim();
+
+// Prepare the comment to add to the file
+const comment = `
+<!--
+  Commit: ${hash}
+  Date: ${date}
+-->
+`;
+
+// Define the path to the index.html file
+const path = "../webserver/src/main/resources/ui/index.html";
+
+// Read the content of index.html
+const content = fs.readFileSync(path, "utf8");
+
+// Write the comment at the beginning of index.html
+fs.writeFileSync(path, comment + content);
+
+console.log(`Added commit details to ${path}`);


### PR DESCRIPTION
This PR should introduce the functionality to add comment at the top of `index.html` file in format like this:

```
<!--
  Commit: ${hash}
  Date: ${date}
-->
```

To help debug which version is the one deployed at any given moment in time.