### PR TITLE
fix(example): correct the url in http download example

### DIFF
--- a/core/src/main/java/io/kestra/plugin/core/http/Download.java
+++ b/core/src/main/java/io/kestra/plugin/core/http/Download.java
@@ -32,13 +32,13 @@ import static io.kestra.core.utils.Rethrow.throwFunction;
 @Getter
 @NoArgsConstructor
 @Schema(
-    title = "Download a file from a HTTP server",
-    description = "This task connects to a HTTP server and copy a file to Kestra's internal storage"
+    title = "Download a file from a HTTP server.",
+    description = "This task connects to a HTTP server and copy a file to Kestra's internal storage."
 )
 @Plugin(
     examples = {
         @Example(
-            title = "Download a CSV file",
+            title = "Download a CSV file.",
             full = true,
             code = """
 id: download
@@ -46,7 +46,7 @@ namespace: company.team
 tasks:
   - id: extract
     type: io.kestra.plugin.core.http.Download
-    uri: https://huggingface.co/datasets/kestra/datasets/blob/main/csv/orders.csv"""            
+    uri: https://huggingface.co/datasets/kestra/datasets/raw/main/csv/orders.csv"""            
         )
     },
     metrics = {
@@ -178,22 +178,22 @@ public class Download extends AbstractHttp implements RunnableTask<Download.Outp
     @Getter
     public static class Output implements io.kestra.core.models.tasks.Output {
         @Schema(
-            title = "The URL of the downloaded file on Kestra's internal storage"
+            title = "The URL of the downloaded file on Kestra's internal storage."
         )
         private final URI uri;
 
         @Schema(
-            title = "The status code of the response"
+            title = "The status code of the response."
         )
         private final Integer code;
 
         @Schema(
-                title = "The content-length of the response"
+                title = "The content-length of the response."
         )
         private final Long length;
 
         @Schema(
-            title = "The headers of the response"
+            title = "The headers of the response."
         )
         private final Map<String, List<String>> headers;
     }

--- a/core/src/main/java/io/kestra/plugin/core/http/Request.java
+++ b/core/src/main/java/io/kestra/plugin/core/http/Request.java
@@ -57,7 +57,7 @@ import java.util.OptionalInt;
             """
         ),
         @Example(
-            title = "Send an HTTP POST request to a webserver",
+            title = "Send an HTTP POST request to a webserver.",
             code = {
                 "uri: \"https://server.com/login\"",
                 "headers: ",
@@ -69,7 +69,7 @@ import java.util.OptionalInt;
             }
         ),
         @Example(
-            title = "Send a multipart HTTP POST request to a webserver",
+            title = "Send a multipart HTTP POST request to a webserver.",
             code = {
                 "uri: \"https://server.com/upload\"",
                 "headers: ",
@@ -81,7 +81,7 @@ import java.util.OptionalInt;
             }
         ),
         @Example(
-            title = "Send a multipart HTTP POST request to a webserver and set a custom file name",
+            title = "Send a multipart HTTP POST request to a webserver and set a custom file name.",
             code = {
                 "uri: \"https://server.com/upload\"",
                 "headers: ",
@@ -172,29 +172,29 @@ public class Request extends AbstractHttp implements RunnableTask<Request.Output
     @Getter
     public static class Output implements io.kestra.core.models.tasks.Output {
         @Schema(
-            title = "The URL of the current request"
+            title = "The URL of the current request."
         )
         private final URI uri;
 
         @Schema(
-            title = "The status code of the response"
+            title = "The status code of the response."
         )
         private final Integer code;
 
         @Schema(
-            title = "The headers of the response"
+            title = "The headers of the response."
         )
         @PluginProperty(additionalProperties = List.class)
         private final Map<String, List<String>> headers;
 
         @Schema(
-            title = "The body of the response",
+            title = "The body of the response.",
             description = "Kestra will by default store the task output using this property. However, if the `encryptBody` property is set to `true`, kestra will instead encrypt the output and store it using the `encryptedBody` output property."
         )
         private Object body;
 
         @Schema(
-            title = "The encrypted body of the response",
+            title = "The encrypted body of the response.",
             description = "If the `encryptBody` property is set to `true`, kestra will automatically encrypt the output before storing it, and decrypt it when the output is retrieved in a downstream task."
         )
         private EncryptedString encryptedBody;


### PR DESCRIPTION
The http download task is using the blob url, instead it should use the raw url.