### PR TITLE
Feat/docker runner volume

### DIFF
--- a/core/src/main/java/io/kestra/core/runners/LocalWorkingDir.java
+++ b/core/src/main/java/io/kestra/core/runners/LocalWorkingDir.java
@@ -26,6 +26,7 @@ import static java.nio.file.StandardCopyOption.REPLACE_EXISTING;
 public class LocalWorkingDir implements WorkingDir {
 
     private final Path workingDirPath;
+    private final String workingDirId;
 
     /**
      * Creates a new {@link LocalWorkingDir} instance.
@@ -43,6 +44,7 @@ public class LocalWorkingDir implements WorkingDir {
      * @param workingDirId   The working directory id.
      */
     public LocalWorkingDir(final Path tmpdirBasePath, final String workingDirId) {
+        this.workingDirId = workingDirId;
         this.workingDirPath = tmpdirBasePath.resolve(workingDirId);
     }
 
@@ -52,6 +54,11 @@ public class LocalWorkingDir implements WorkingDir {
     @Override
     public Path path() {
         return path(true);
+    }
+
+    @Override
+    public String id() {
+        return workingDirId;
     }
 
     /**

--- a/core/src/main/java/io/kestra/core/runners/WorkingDir.java
+++ b/core/src/main/java/io/kestra/core/runners/WorkingDir.java
@@ -35,6 +35,13 @@ public interface WorkingDir {
     Path path(boolean create);
 
     /**
+     * Gets the working directory identifier.
+     *
+     * @return The identifier.
+     */
+    String id();
+
+    /**
      * Resolve a path inside the working directory (a.k.a. the tempDir).
      * <p>
      * This method is null-friendly: it will return the working directory (a.k.a. the tempDir) if called with a null path.

--- a/script/src/main/java/io/kestra/plugin/scripts/runner/docker/Docker.java
+++ b/script/src/main/java/io/kestra/plugin/scripts/runner/docker/Docker.java
@@ -230,6 +230,14 @@ public class Docker extends TaskRunner {
     @PluginProperty
     private FileHandlingStrategy fileHandlingStrategy = FileHandlingStrategy.VOLUME;
 
+    @Schema(
+        title = "Whether the container should be deleted upon completion."
+    )
+    @NotNull
+    @Builder.Default
+    @PluginProperty
+    private Boolean delete = true;
+
     public static Docker from(DockerOptions dockerOptions) {
         if (dockerOptions == null) {
             return Docker.builder().build();
@@ -441,11 +449,14 @@ public class Docker extends TaskRunner {
                     // kill container if it's still running, this means there was an exception and the container didn't
                     // come to a normal end.
                     kill();
-                    dockerClient.removeContainerCmd(exec.getId()).exec();
-                    logger.debug("Container deleted: {}", exec.getId());
-                    if (needVolume && this.fileHandlingStrategy == FileHandlingStrategy.VOLUME  && filesVolumeName != null) {
-                        dockerClient.removeVolumeCmd(filesVolumeName).exec();
-                        logger.debug("Volume deleted: {}", filesVolumeName);
+
+                    if (Boolean.TRUE.equals(delete)) {
+                        dockerClient.removeContainerCmd(exec.getId()).exec();
+                        logger.debug("Container deleted: {}", exec.getId());
+                        if (needVolume && this.fileHandlingStrategy == FileHandlingStrategy.VOLUME  && filesVolumeName != null) {
+                            dockerClient.removeVolumeCmd(filesVolumeName).exec();
+                            logger.debug("Volume deleted: {}", filesVolumeName);
+                        }
                     }
                 } catch (Exception ignored) {
 


### PR DESCRIPTION
Fixes #3857
May fix #4348 but more tests re needed.

Locally, with the previous way we handled files, I had a `Failed to delete temporary file` when uploading output files from `ScriptService.uploadOutputFiles(ScriptService.java:120)` as using a mount files was created in root locally. With the new change files are correctly created with my non-root user.

More tests needs to be done to check if it fixes more issues.

I added a switch to bring back the mount if needed, if we didn't saw any usage of it in months, we could remove it. 