### PR TITLE
feat(cli): descriptive server start error via bean

### DIFF
--- a/cli/src/main/java/io/kestra/cli/ServerCommandValidator.java
+++ b/cli/src/main/java/io/kestra/cli/ServerCommandValidator.java
@@ -1,0 +1,55 @@
+package io.kestra.cli;
+
+import io.micronaut.context.annotation.Context;
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.context.env.Environment;
+import jakarta.annotation.PostConstruct;
+import jakarta.inject.Inject;
+import lombok.extern.slf4j.Slf4j;
+
+import java.io.Serial;
+import java.util.List;
+import java.util.Map;
+
+@Slf4j
+@Context
+@Requires(property = "kestra.server-type")
+public class ServerCommandValidator {
+    private static final Map<String, String> VALIDATED_PROPERTIES = Map.of(
+        "kestra.queue.type", "https://kestra.io/docs/configuration-guide/setup#queue-configuration",
+        "kestra.repository.type", "https://kestra.io/docs/configuration-guide/setup#repository-configuration",
+        "kestra.storage.type", "https://kestra.io/docs/configuration-guide/setup#internal-storage-configuration"
+    );
+
+    private final Environment environment;
+
+    @Inject
+    public ServerCommandValidator(final Environment environment) {
+        this.environment = environment;
+    }
+
+    @PostConstruct
+    void validate() {
+        final List<Map.Entry<String, String>> missingProperties = VALIDATED_PROPERTIES.entrySet().stream()
+            .filter((property) -> !environment.containsProperty(property.getKey()))
+            .toList();
+
+        missingProperties.forEach(property -> log.error("""
+            Server configuration requires the '{}' property to be defined.
+            For more details, please follow the official setup guide at: {}""", property.getKey(), property.getValue())
+        );
+
+        if (!missingProperties.isEmpty()) {
+            throw new ServerCommandException("Incomplete server configuration - missing required properties");
+        }
+    }
+
+    public static class ServerCommandException extends RuntimeException {
+        @Serial
+        private static final long serialVersionUID = 1L;
+
+        public ServerCommandException(String errorMessage) {
+            super(errorMessage);
+        }
+    }
+}

--- a/cli/src/test/java/io/kestra/cli/ServerCommandValidatorTest.java
+++ b/cli/src/test/java/io/kestra/cli/ServerCommandValidatorTest.java
@@ -1,0 +1,53 @@
+package io.kestra.cli;
+
+import io.micronaut.context.ApplicationContext;
+import io.micronaut.context.exceptions.BeanInstantiationException;
+import io.micronaut.context.exceptions.NoSuchBeanException;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+class ServerCommandValidatorTest {
+
+    @Test
+    void noServerCommandIssued() {
+        try (ApplicationContext context = ApplicationContext.run()) {
+            Assertions.assertThrows(NoSuchBeanException.class, () -> context.getBean(ServerCommandValidator.class));
+        }
+    }
+
+    @Test
+    void serverCommandIssued() {
+        Assertions.assertDoesNotThrow(() -> ApplicationContext.builder()
+            .deduceEnvironment(false)
+            .properties(Map.of(
+                "kestra.server-type", "webserver",
+                "kestra.queue.type", "memory",
+                "kestra.repository.type", "memory",
+                "kestra.storage.type", "local"
+            ))
+            .start()
+        );
+
+        final Throwable exception = Assertions.assertThrows(BeanInstantiationException.class, () ->
+            ApplicationContext.builder()
+                .deduceEnvironment(false)
+                .properties(Map.of("kestra.server-type", "webserver"))
+                .start()
+        );
+        final Throwable rootException = getRootException(exception);
+        assertThat(rootException.getClass(), is(ServerCommandValidator.ServerCommandException.class));
+        assertThat(rootException.getMessage(), is("Incomplete server configuration - missing required properties"));
+    }
+
+    private Throwable getRootException(Throwable exception) {
+        while (exception.getCause() != null) {
+            exception = exception.getCause();
+        }
+        return exception;
+    }
+}


### PR DESCRIPTION
### What changes are being made and why?

This is a new iteration of #4171 attempting to resolve #4155 properly. The `MICRONAUT_ENVIRONMENTS` env variable is no longer ignored.

The validation is performed via a `@Context`-scoped bean. I'm no Micronaut DI expert 😐