### PR TITLE
fix(core) Introduced protections against "zip slip" attacks  

### DIFF
--- a/core/src/main/java/io/kestra/core/serializers/FileSerde.java
+++ b/core/src/main/java/io/kestra/core/serializers/FileSerde.java
@@ -1,5 +1,6 @@
 package io.kestra.core.serializers;
 
+import io.github.pixee.security.BoundedLineReader;
 import static io.kestra.core.utils.Rethrow.throwBiFunction;
 import static io.kestra.core.utils.Rethrow.throwConsumer;
 import static io.kestra.core.utils.Rethrow.throwFunction;
@@ -45,7 +46,7 @@ public final class FileSerde {
             String row;
 
             try {
-                while ((row = input.readLine()) != null) {
+                while ((row = BoundedLineReader.readLine(input, 5_000_000)) != null) {
                     s.next(convert(row));
                 }
                 s.complete();
@@ -60,7 +61,7 @@ public final class FileSerde {
             String row;
 
             try {
-                while ((row = input.readLine()) != null) {
+                while ((row = BoundedLineReader.readLine(input, 5_000_000)) != null) {
                     s.next(convert(row, cls));
                 }
                 s.complete();
@@ -72,7 +73,7 @@ public final class FileSerde {
 
     public static void reader(BufferedReader input, Consumer<Object> consumer) throws IOException {
         String row;
-        while ((row = input.readLine()) != null) {
+        while ((row = BoundedLineReader.readLine(input, 5_000_000)) != null) {
             consumer.accept(convert(row));
         }
     }
@@ -80,7 +81,7 @@ public final class FileSerde {
     public static boolean reader(BufferedReader input, int maxLines, Consumer<Object> consumer) throws IOException {
         String row;
         int nbLines = 0;
-        while ((row = input.readLine()) != null) {
+        while ((row = BoundedLineReader.readLine(input, 5_000_000)) != null) {
             if (nbLines >= maxLines) {
                 return true;
             }

--- a/core/src/main/java/io/kestra/core/services/StorageService.java
+++ b/core/src/main/java/io/kestra/core/services/StorageService.java
@@ -1,5 +1,6 @@
 package io.kestra.core.services;
 
+import io.github.pixee.security.BoundedLineReader;
 import io.kestra.core.runners.RunContext;
 import io.kestra.core.storages.StorageSplitInterface;
 import io.micronaut.core.convert.format.ReadableBytesTypeConverter;
@@ -57,7 +58,7 @@ public abstract class StorageService {
         int totalRows = 0;
         String row;
 
-        while ((row = bufferedReader.readLine()) != null) {
+        while ((row = BoundedLineReader.readLine(bufferedReader, 5_000_000)) != null) {
             if (write == null || predicate.apply(totalBytes, totalRows)) {
                 if (write != null) {
                     write.close();
@@ -99,7 +100,7 @@ public abstract class StorageService {
 
         String row;
         int index = 0;
-        while ((row = bufferedReader.readLine()) != null) {
+        while ((row = BoundedLineReader.readLine(bufferedReader, 5_000_000)) != null) {
             writers.get(index).getChannel().write(ByteBuffer.wrap((row + separator).getBytes(StandardCharsets.UTF_8)));
 
             index = index >= writers.size() - 1 ? 0 : index + 1;

--- a/core/src/main/java/io/kestra/plugin/core/flow/WorkingDirectory.java
+++ b/core/src/main/java/io/kestra/plugin/core/flow/WorkingDirectory.java
@@ -1,6 +1,7 @@
 package io.kestra.plugin.core.flow;
 
 import com.fasterxml.jackson.core.type.TypeReference;
+import io.github.pixee.security.ZipSecurity;
 import io.kestra.core.exceptions.IllegalVariableEvaluationException;
 import io.kestra.core.models.annotations.Example;
 import io.kestra.core.models.annotations.Plugin;
@@ -242,7 +243,7 @@ public class WorkingDirectory extends Sequential implements NamespaceFilesInterf
             if (maybeCacheFile.isPresent()) {
                 runContext.logger().debug("Cache exist, downloading it");
                 // download the cache if exist and unzip all entries
-                try (ZipInputStream archive = new ZipInputStream(maybeCacheFile.get())) {
+                try (ZipInputStream archive = ZipSecurity.createHardenedInputStream(maybeCacheFile.get())) {
                     ZipEntry entry;
                     while ((entry = archive.getNextEntry()) != null) {
                         if (!entry.isDirectory()) {

--- a/core/src/main/java/io/kestra/plugin/core/runner/Process.java
+++ b/core/src/main/java/io/kestra/plugin/core/runner/Process.java
@@ -1,5 +1,6 @@
 package io.kestra.plugin.core.runner;
 
+import io.github.pixee.security.BoundedLineReader;
 import io.kestra.core.models.annotations.Example;
 import io.kestra.core.models.annotations.Plugin;
 import io.kestra.core.models.tasks.runners.*;
@@ -172,7 +173,7 @@ public class Process extends TaskRunner {
                 InputStreamReader inputStreamReader = new InputStreamReader(inputStream, StandardCharsets.UTF_8);
                 try (BufferedReader bufferedReader = new BufferedReader(inputStreamReader)) {
                     String line;
-                    while ((line = bufferedReader.readLine()) != null) {
+                    while ((line = BoundedLineReader.readLine(bufferedReader, 5_000_000)) != null) {
                         this.logConsumerInterface.accept(line, this.isStdErr);
                     }
                 }

--- a/core/src/main/java/io/kestra/plugin/core/storage/DeduplicateItems.java
+++ b/core/src/main/java/io/kestra/plugin/core/storage/DeduplicateItems.java
@@ -2,6 +2,7 @@ package io.kestra.plugin.core.storage;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.github.pixee.security.BoundedLineReader;
 import io.kestra.core.models.annotations.Example;
 import io.kestra.core.models.annotations.Plugin;
 import io.kestra.core.models.annotations.PluginProperty;
@@ -89,7 +90,7 @@ public class DeduplicateItems extends Task implements RunnableTask<DeduplicateIt
         try (final BufferedReader reader = newBufferedReader(runContext, from)) {
             long offset = 0L;
             String item;
-            while ((item = reader.readLine()) != null) {
+            while ((item = BoundedLineReader.readLine(reader, 5_000_000)) != null) {
                 String key = keyExtractor.apply(item);
                 index.put(key, offset);
                 offset++;
@@ -107,7 +108,7 @@ public class DeduplicateItems extends Task implements RunnableTask<DeduplicateIt
              final BufferedReader reader = newBufferedReader(runContext, from)) {
             long offset = 0L;
             String item;
-            while ((item = reader.readLine()) != null) {
+            while ((item = BoundedLineReader.readLine(reader, 5_000_000)) != null) {
                 String key = keyExtractor.apply(item);
                 Long lastOffset = index.get(key);
                 if (lastOffset != null && lastOffset == offset) {

--- a/core/src/main/java/io/kestra/plugin/core/storage/FilterItems.java
+++ b/core/src/main/java/io/kestra/plugin/core/storage/FilterItems.java
@@ -3,6 +3,7 @@ package io.kestra.plugin.core.storage;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.github.pixee.security.BoundedLineReader;
 import io.kestra.core.exceptions.IllegalVariableEvaluationException;
 import io.kestra.core.models.annotations.Example;
 import io.kestra.core.models.annotations.Plugin;
@@ -107,7 +108,7 @@ public class FilterItems extends Task implements RunnableTask<FilterItems.Output
              final BufferedReader reader = newBufferedReader(runContext, from)) {
 
             String item;
-            while ((item = reader.readLine()) != null) {
+            while ((item = BoundedLineReader.readLine(reader, 5_000_000)) != null) {
                 IllegalVariableEvaluationException exception = null;
                 Boolean match = null;
                 try {

--- a/processor/src/main/java/io/kestra/core/plugins/processor/ServicesFiles.java
+++ b/processor/src/main/java/io/kestra/core/plugins/processor/ServicesFiles.java
@@ -1,5 +1,6 @@
 package io.kestra.core.plugins.processor;
 
+import io.github.pixee.security.BoundedLineReader;
 import java.io.BufferedReader;
 import java.io.BufferedWriter;
 import java.io.IOException;
@@ -39,7 +40,7 @@ final class ServicesFiles {
         Set<String> serviceClasses = new HashSet<String>();
         try (BufferedReader reader = new BufferedReader(new InputStreamReader(input, StandardCharsets.UTF_8))) {
             String line;
-            while ((line = reader.readLine()) != null) {
+            while ((line = BoundedLineReader.readLine(reader, 5_000_000)) != null) {
                 int commentStart = line.indexOf('#');
                 if (commentStart >= 0) {
                     line = line.substring(0, commentStart);

--- a/webserver/src/main/java/io/kestra/webserver/controllers/api/FlowController.java
+++ b/webserver/src/main/java/io/kestra/webserver/controllers/api/FlowController.java
@@ -1,5 +1,6 @@
 package io.kestra.webserver.controllers.api;
 
+import io.github.pixee.security.ZipSecurity;
 import io.kestra.core.exceptions.IllegalVariableEvaluationException;
 import io.kestra.core.exceptions.InternalException;
 import io.kestra.core.models.SearchResult;
@@ -754,7 +755,7 @@ public class FlowController {
                 this.importFlow(tenantId, source.trim());
             }
         } else if (fileName.endsWith(".zip")) {
-            try (ZipInputStream archive = new ZipInputStream(fileUpload.getInputStream())) {
+            try (ZipInputStream archive = ZipSecurity.createHardenedInputStream(fileUpload.getInputStream())) {
                 ZipEntry entry;
                 while ((entry = archive.getNextEntry()) != null) {
                     if (entry.isDirectory() || !entry.getName().endsWith(".yml") && !entry.getName().endsWith(".yaml")) {

--- a/webserver/src/main/java/io/kestra/webserver/controllers/api/NamespaceFileController.java
+++ b/webserver/src/main/java/io/kestra/webserver/controllers/api/NamespaceFileController.java
@@ -1,5 +1,6 @@
 package io.kestra.webserver.controllers.api;
 
+import io.github.pixee.security.ZipSecurity;
 import io.kestra.core.services.FlowService;
 import io.kestra.core.storages.FileAttributes;
 import io.kestra.core.storages.NamespaceFile;
@@ -137,7 +138,7 @@ public class NamespaceFileController {
     ) throws IOException, URISyntaxException {
         String tenantId = tenantService.resolveTenant();
         if(fileContent.getFilename().toLowerCase().endsWith(".zip")) {
-            try (ZipInputStream archive = new ZipInputStream(fileContent.getInputStream())) {
+            try (ZipInputStream archive = ZipSecurity.createHardenedInputStream(fileContent.getInputStream())) {
                 ZipEntry entry;
                 while ((entry = archive.getNextEntry()) != null) {
                     if (entry.isDirectory()) {

--- a/webserver/src/main/java/io/kestra/webserver/controllers/api/TemplateController.java
+++ b/webserver/src/main/java/io/kestra/webserver/controllers/api/TemplateController.java
@@ -1,5 +1,6 @@
 package io.kestra.webserver.controllers.api;
 
+import io.github.pixee.security.ZipSecurity;
 import io.kestra.core.models.templates.Template;
 import io.kestra.core.models.templates.TemplateEnabled;
 import io.kestra.core.models.validations.ManualConstraintViolation;
@@ -356,7 +357,7 @@ public class TemplateController {
                 importTemplate(parsed);
             }
         } else if (fileName.endsWith(".zip")) {
-            try (ZipInputStream archive = new ZipInputStream(fileUpload.getInputStream())) {
+            try (ZipInputStream archive = ZipSecurity.createHardenedInputStream(fileUpload.getInputStream())) {
                 ZipEntry entry;
                 while ((entry = archive.getNextEntry()) != null) {
                     if (entry.isDirectory() || !entry.getName().endsWith(".yml") && !entry.getName().endsWith(".yaml")) {

--- a/webserver/src/main/java/io/kestra/webserver/utils/filepreview/DefaultFileRender.java
+++ b/webserver/src/main/java/io/kestra/webserver/utils/filepreview/DefaultFileRender.java
@@ -1,5 +1,6 @@
 package io.kestra.webserver.utils.filepreview;
 
+import io.github.pixee.security.BoundedLineReader;
 import lombok.Getter;
 
 import java.io.BufferedReader;
@@ -26,7 +27,7 @@ public class DefaultFileRender extends FileRender {
 
     private void renderContent(InputStream fileStream, Charset charset) throws IOException {
         BufferedReader reader = new BufferedReader(new InputStreamReader(fileStream, charset));
-        String line = reader.readLine();
+        String line = BoundedLineReader.readLine(reader, 5_000_000);
         int lineCount = 0;
 
         StringBuilder contentBuilder = new StringBuilder();
@@ -34,7 +35,7 @@ public class DefaultFileRender extends FileRender {
         while (line != null && lineCount < this.maxLine) {
             contentBuilder.append(line);
             lineCount++;
-            if ((line = reader.readLine()) != null) {
+            if ((line = BoundedLineReader.readLine(reader, 5_000_000)) != null) {
                 contentBuilder.append("\n");
 
                 if(lineCount == this.maxLine) {


### PR DESCRIPTION
This change updates all new instances of [ZipInputStream](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/util/zip/ZipInputStream.html) to protect against malicious entries that attempt to escape their "file root" and overwrite other files on the running filesystem.

Normally, when you're using `ZipInputStream` it's because you're processing zip files. That code might look like this:

```java
File file = new File(unzipTargetDirectory, zipEntry.getName()); // use file name from zip entry
InputStream is = zip.getInputStream(zipEntry); // get the contents of the zip entry
IOUtils.copy(is, new FileOutputStream(file)); // write the contents to the provided file name
```

This looks fine when it encounters a normal zip entry within a zip file, looking something like this pseudo-data:
```binary
path: data/names.txt
contents: Zeus\nHelen\nLeda...
```

However, there's nothing to prevent an attacker from sending an evil entry in the zip that looks more like this:
```binary
path: ../../../../../etc/passwd
contents: root::0:0:root:/:/bin/sh
```

Yes, in the above code, which looks like [every](https://stackoverflow.com/a/23870468) [piece](https://stackoverflow.com/a/51285801) of [zip-processing](https://kodejava.org/how-do-i-decompress-a-zip-file-using-zipinputstream/)  code you can [find](https://www.tabnine.com/code/java/classes/java.util.zip.ZipInputStream) on the [Internet](https://www.baeldung.com/java-compress-and-uncompress), attackers could overwrite any files to which the application has access. This rule replaces the standard `ZipInputStream` with a hardened subclass which prevents access to entry paths that attempt to traverse directories above the current directory (which no normal zip file should ever do.) Our changes end up looking something like this:

```diff
+ import io.github.pixee.security.ZipSecurity;
  ...
- var zip = new ZipInputStream(is, StandardCharsets.UTF_8);
+ var zip = ZipSecurity.createHardenedInputStream(is, StandardCharsets.UTF_8);
```


:x: The following packages couldn't be installed automatically, probably because the dependency manager is unsupported. Please install them manually:
<details open>
    <summary>Gradle</summary>

    dependencies {
      implementation("io.github.pixee:java-security-toolkit:1.2.0")
    }

</details>

<details>
    <summary>Maven</summary>

    <dependencies>
      <dependency>
        <groupId>io.github.pixee</groupId>
        <artifactId>java-security-toolkit</artifactId>
        <version>1.2.0</version>
      </dependency>
    <dependencies>

</details>

<details>
  <summary>More reading</summary>

  * [https://snyk.io/research/zip-slip-vulnerability](https://snyk.io/research/zip-slip-vulnerability)
  * [https://github.com/snyk/zip-slip-vulnerability](https://github.com/snyk/zip-slip-vulnerability)
  * [https://wiki.sei.cmu.edu/confluence/display/java/IDS04-J.+Safely+extract+files+from+ZipInputStream](https://wiki.sei.cmu.edu/confluence/display/java/IDS04-J.+Safely+extract+files+from+ZipInputStream)
  * [https://vulncat.fortify.com/en/detail?id=desc.dataflow.java.path_manipulation_zip_entry_overwrite](https://vulncat.fortify.com/en/detail?id=desc.dataflow.java.path_manipulation_zip_entry_overwrite)
</details>


🧚🤖  Powered by Pixeebot  

[Feedback](https://ask.pixee.ai/feedback) | [Community](https://pixee-community.slack.com/signup#/domain-signup) | [Docs](https://docs.pixee.ai/) | Codemod ID: [pixee:java/harden-zip-entry-paths](https://docs.pixee.ai/codemods/java/pixee_java_harden-zip-entry-paths) ![](https://d1zaessa2hpsmj.cloudfront.net/pixel/v1/track?writeKey=2PI43jNm7atYvAuK7rJUz3Kcd6A&event=DRIP_PR%7CPixee-Bot-Java%2Fkestra%7C0811359d3a1b4d0c943480fbd7ac75e089e93f9b)


<!--{"type":"DRIP","codemod":"pixee:java/harden-zip-entry-paths"}-->