### PR TITLE
docs: update ForEach examples and docs

### DIFF
--- a/core/src/main/java/io/kestra/plugin/core/flow/ForEach.java
+++ b/core/src/main/java/io/kestra/plugin/core/flow/ForEach.java
@@ -33,13 +33,22 @@ import java.util.Optional;
     title = "Execute a group of tasks for each value in the list.",
     description = """
         You can control how many task groups are executed concurrently by setting the `concurrencyLimit` property. \
-        If you set the `concurrencyLimit` property to 0, Kestra will execute all task groups concurrently for all values. \
-        If you set the `concurrencyLimit` property to 1, Kestra will execute each task group one after the other starting with the first value in the list. \
-        Regardless of the `concurrencyLimit` property, the `tasks` will run one after the other — to run those in parallel, wrap them in a Parallel task as shown in one of the examples below. \
+
+        - If you set the `concurrencyLimit` property to `0`, Kestra will execute all task groups concurrently for all values. \
+
+        - If you set the `concurrencyLimit` property to `1`, Kestra will execute each task group one after the other starting with the task group for the first value in the list. \
+
+
+        Regardless of the `concurrencyLimit` property, the `tasks` will run one after the other — to run those in parallel, wrap them in a [Parallel](https://kestra.io/plugins/core/tasks/flow/io.kestra.plugin.core.flow.parallel) task as shown in the last example below (_see the flow `parallel_tasks_example`_). \
+
+
         The `values` should be defined as a JSON string or an array, e.g. a list of string values `["value1", "value2"]` or a list of key-value pairs `[{"key": "value1"}, {"key": "value2"}]`.\s
 
-        You can access the current iteration value using the variable `{{ taskrun.value }}`. \
-        If you need to access the value in a nested child task, you can use the syntax `{{ parent.taskrun.value }}`. \
+
+        You can access the current iteration value using the variable `{{ taskrun.value }}` \
+        or `{{ parent.taskrun.value }}` if you are in a nested child task. \
+
+
         If you need to execute more than 2-5 tasks for each value, we recommend triggering a subflow for each value for better performance and modularity. \
         Check the [flow best practices documentation](https://kestra.io/docs/best-practices/flows) for more details."""
 )
@@ -143,8 +152,10 @@ public class ForEach extends Sequential implements FlowableTask<VoidOutput> {
     @Schema(
         title = "The number of concurrent task groups for each value in the `values` array.",
         description = """
-        If you set the `concurrencyLimit` property to 0, Kestra will execute all task groups concurrently for all values. \
-        If you set the `concurrencyLimit` property to 1, Kestra will execute each task group one after the other starting with the first value in the list."""
+        If you set the `concurrencyLimit` property to 0, Kestra will execute all task groups concurrently for all values (zero limits!). \
+
+
+        If you set the `concurrencyLimit` property to 1, Kestra will execute each task group one after the other starting with the first value in the list (limit concurrency to one task group that can be actively running at any time)."""
     )
     @PluginProperty
     private final Integer concurrencyLimit = 1;

--- a/core/src/main/java/io/kestra/plugin/core/flow/ForEach.java
+++ b/core/src/main/java/io/kestra/plugin/core/flow/ForEach.java
@@ -30,23 +30,29 @@ import java.util.Optional;
 @Getter
 @NoArgsConstructor
 @Schema(
-    title = "For each value in the list, execute one or more tasks sequentially.",
-    description = "The list of `tasks` will be executed for each value sequentially, but values can be executed concurrently if concurrency is set to more than one." +
-        "The values must be a valid JSON string representing an array, e.g. a list of strings `[\"value1\", \"value2\"]` or a list of dictionaries `[{\"key\": \"value1\"}, {\"key\": \"value2\"}]`. \n\n" +
-        "You can access the current iteration value using the variable `{{ taskrun.value }}`. " +
-        "The task list will be executed sequentially for each value, if you want them to be executed in parallel you can use a Parallel task.\n\n" +
-        "We highly recommend triggering a subflow for each value. " +
-        "This allows much better scalability and modularity. Check the [flow best practices documentation](https://kestra.io/docs/developer-guide/best-practices) " +
-        "and the [following Blueprint](https://kestra.io/blueprints/128-run-a-subflow-for-each-value-in-parallel-and-wait-for-their-completion-recommended-pattern-to-iterate-over-hundreds-or-thousands-of-list-items) " +
-        "for more details."
+    title = "Execute a group of tasks for each value in the list.",
+    description = """
+        You can control how many task groups are executed concurrently by setting the `concurrencyLimit` property. \
+        If you set the `concurrencyLimit` property to 0, Kestra will execute all task groups concurrently for all values. \
+        If you set the `concurrencyLimit` property to 1, Kestra will execute each task group one after the other starting with the first value in the list. \
+        Regardless of the `concurrencyLimit` property, the `tasks` will run one after the other — to run those in parallel, wrap them in a Parallel task as shown in one of the examples below. \
+        The `values` should be defined as a JSON string or an array, e.g. a list of string values `["value1", "value2"]` or a list of key-value pairs `[{"key": "value1"}, {"key": "value2"}]`.\s
+
+        You can access the current iteration value using the variable `{{ taskrun.value }}`. \
+        If you need to access the value in a nested child task, you can use the syntax `{{ parent.taskrun.value }}`. \
+        If you need to execute more than 2-5 tasks for each value, we recommend triggering a subflow for each value for better performance and modularity. \
+        Check the [flow best practices documentation](https://kestra.io/docs/best-practices/flows) for more details."""
 )
 @Plugin(
     examples = {
         @Example(
             full = true,
-            title = "The taskrun.value from the `each_sequential` task is available only to immediate child tasks such as the `before_if` and the `if` tasks. To access the taskrun value in child tasks of the `if` task (such as in the `after_if` task), you need to use the syntax `{{ parent.taskrun.value }}` as this allows you to access the taskrun value of the parent task `each_sequential`.",
+            title = """
+                The `{{ taskrun.value }}` from the `for_each` task is available only to direct child tasks \
+                such as the `before_if` and the `if` tasks. To access the taskrun value of the parent task \
+                in a nested child task such as the `after_if` task, use `{{ parent.taskrun.value }}`.""",
             code = """
-                id: loop_example
+                id: for_loop_example
                 namespace: company.team
 
                 tasks:
@@ -67,9 +73,14 @@ import java.util.Optional;
         ),
         @Example(
             full = true,
-            title = "This task shows that the value can be a bullet-style list. The task iterates over the list of values and executes the `each-value` child task for each value. It also process the values concurrently 2 by 2.",
+            title = """
+                This flow uses YAML-style array for `values`. The task `for_each` iterates over a list of values \
+                and executes the `return` child task for each value. The `concurrencyLimit` property is set to 2, \
+                so the `return` task will run concurrently for the first two values in the list at first. \
+                The `return` task will run for the next two values only after the task runs for the first two values \
+                have completed.""",
             code = {
-                "id: for_each",
+                "id: for_each_value",
                 "namespace: company.team",
                 "",
                 "tasks:",
@@ -79,36 +90,41 @@ import java.util.Optional;
                 "      - value 1",
                 "      - value 2",
                 "      - value 3",
-                "    concurrency: 2",
+                "      - value 4",
+                "    concurrencyLimit: 2",
                 "    tasks:",
-                "      - id: each-value",
+                "      - id: return",
                 "        type: io.kestra.plugin.core.debug.Return",
                 "        format: \"{{ task.id }} with value '{{ taskrun.value }}'\"",
             }
         ),
         @Example(
             full = true,
-            title = "This task shows how to process the sub-tasks in parallel.",
+            title = """
+                This example shows how to run tasks in parallel for each value in the list. \
+                All child tasks of the `parallel` task will run in parallel. \
+                However, due to the `concurrencyLimit` property set to 2, \
+                only two `parallel` task groups will run at any given time.""",
             code = """
-                id: loop_example
+                id: parallel_tasks_example
                 namespace: company.team
 
                 tasks:
                   - id: for_each
                     type: io.kestra.plugin.core.flow.ForEach
-                    values: ["value 1", "value 2", "value 3"]
-                    concurrency: 2
+                    values: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+                    concurrencyLimit: 2
                     tasks:
                       - id: parallel
                         type: io.kestra.plugin.core.flow.Parallel
                         tasks:
                         - id: log
                           type: io.kestra.plugin.core.log.Log
-                          message: Processing
+                          message: Processing {{ parent.taskrun.value }}
                         - id: shell
                           type: io.kestra.plugin.scripts.shell.Commands
                           commands:
-                            - sleep 5"""
+                            - sleep {{ parent.taskrun.value }}"""
         ),
     }
 )
@@ -116,8 +132,8 @@ public class ForEach extends Sequential implements FlowableTask<VoidOutput> {
     @NotNull
     @PluginProperty(dynamic = true)
     @Schema(
-        title = "The list of values for this task.",
-        description = "The values car be passed as a string, a list of strings, or a list of objects.",
+        title = "The list of values for which Kestra will execute a group of tasks.",
+        description = "The values can be passed as a string, a list of strings, or a list of objects.",
         oneOf = {String.class, Object[].class}
     )
     private Object values;
@@ -125,11 +141,13 @@ public class ForEach extends Sequential implements FlowableTask<VoidOutput> {
     @NotNull
     @Builder.Default
     @Schema(
-        title = "Number of concurrent values that can be running at any point in time.",
-        description = "If the concurrency is `0`, no limit exist and all the values will start at the same time."
+        title = "The number of concurrent task groups for each value in the `values` array.",
+        description = """
+        If you set the `concurrencyLimit` property to 0, Kestra will execute all task groups concurrently for all values. \
+        If you set the `concurrencyLimit` property to 1, Kestra will execute each task group one after the other starting with the first value in the list."""
     )
     @PluginProperty
-    private final Integer concurrency = 1;
+    private final Integer concurrencyLimit = 1;
 
     @Override
     public GraphCluster tasksTree(Execution execution, TaskRun taskRun, List<String> parentValues) throws IllegalVariableEvaluationException {
@@ -171,7 +189,7 @@ public class ForEach extends Sequential implements FlowableTask<VoidOutput> {
 
     @Override
     public List<NextTaskRun> resolveNexts(RunContext runContext, Execution execution, TaskRun parentTaskRun) throws IllegalVariableEvaluationException {
-        if (this.concurrency == 1) {
+        if (this.concurrencyLimit == 1) {
             return FlowableUtils.resolveSequentialNexts(
                 execution,
                 this.childTasks(runContext, parentTaskRun),
@@ -185,7 +203,7 @@ public class ForEach extends Sequential implements FlowableTask<VoidOutput> {
             FlowableUtils.resolveEachTasks(runContext, parentTaskRun, this.getTasks(), this.values),
             FlowableUtils.resolveTasks(this.errors, parentTaskRun),
             parentTaskRun,
-            this.concurrency
+            this.concurrencyLimit
         );
     }
 }

--- a/core/src/test/resources/flows/valids/foreach-concurrent-parallel.yaml
+++ b/core/src/test/resources/flows/valids/foreach-concurrent-parallel.yaml
@@ -5,7 +5,7 @@ tasks:
   - id: for_each
     type: io.kestra.plugin.core.flow.ForEach
     values: ["value 1", "value 2", "value 3"]
-    concurrency: 2
+    concurrencyLimit: 2
     tasks:
       - id: parallel
         type: io.kestra.plugin.core.flow.Parallel

--- a/core/src/test/resources/flows/valids/foreach-concurrent.yaml
+++ b/core/src/test/resources/flows/valids/foreach-concurrent.yaml
@@ -5,7 +5,7 @@ tasks:
   - id: for_each
     type: io.kestra.plugin.core.flow.ForEach
     values: ["value 1", "value 2", "value 3"]
-    concurrency: 2
+    concurrencyLimit: 2
     tasks:
       - id: log
         type: io.kestra.plugin.core.log.Log


### PR DESCRIPTION
Renamed `concurrency` to `concurrencyLimit` since `concurrency: 0` doesn't seem to imply that everything will run concurrently, quite the opposite — some might think that this means no concurrency at all. I feel like `concurrencyLimit: 0` more clearly indicates that there are no limits in concurrency and all task groups can run concurrently.

also changed some wording and examples 

@loicmathieu can you check if any tests must be adjusted for that renaming?