### PR TITLE
fix(core): fix null coalesce, created undefined coalesce, allow empty string in inputs

### DIFF
--- a/core/src/main/java/io/kestra/core/runners/pebble/Extension.java
+++ b/core/src/main/java/io/kestra/core/runners/pebble/Extension.java
@@ -1,6 +1,7 @@
 package io.kestra.core.runners.pebble;
 
 import io.kestra.core.runners.pebble.expression.NullCoalescingExpression;
+import io.kestra.core.runners.pebble.expression.UndefinedCoalescingExpression;
 import io.kestra.core.runners.pebble.filters.*;
 import io.kestra.core.runners.pebble.functions.*;
 import io.kestra.core.runners.pebble.tests.JsonTest;
@@ -55,6 +56,7 @@ public class Extension extends AbstractExtension {
         List<BinaryOperator> operators = new ArrayList<>();
 
         operators.add(new BinaryOperatorImpl("??", 120, NullCoalescingExpression::new, NORMAL, Associativity.LEFT));
+        operators.add(new BinaryOperatorImpl("???", 120, UndefinedCoalescingExpression::new, NORMAL, Associativity.LEFT));
 
         return operators;
     }

--- a/core/src/main/java/io/kestra/core/runners/pebble/expression/UndefinedCoalescingExpression.java
+++ b/core/src/main/java/io/kestra/core/runners/pebble/expression/UndefinedCoalescingExpression.java
@@ -6,23 +6,18 @@ import io.pebbletemplates.pebble.node.expression.Expression;
 import io.pebbletemplates.pebble.template.EvaluationContextImpl;
 import io.pebbletemplates.pebble.template.PebbleTemplateImpl;
 
-public class NullCoalescingExpression extends BinaryExpression<Object> {
-    public NullCoalescingExpression() {
+public class UndefinedCoalescingExpression extends BinaryExpression<Object> {
+    public UndefinedCoalescingExpression() {
     }
 
-    public NullCoalescingExpression(Expression<?> left, Expression<?> right) {
+    public UndefinedCoalescingExpression(Expression<?> left, Expression<?> right) {
         super(left, right);
     }
 
     @Override
     public Object evaluate(PebbleTemplateImpl self, EvaluationContextImpl context) {
         try {
-            var result = getLeftExpression().evaluate(self, context);
-            if (result != null) {
-                return result;
-            } else {
-                return getRightExpression().evaluate(self, context);
-            }
+            return getLeftExpression().evaluate(self, context);
         } catch (AttributeNotFoundException e) {
             return getRightExpression().evaluate(self, context);
         }

--- a/core/src/test/java/io/kestra/core/runners/pebble/expression/NullCoalescingExpressionTest.java
+++ b/core/src/test/java/io/kestra/core/runners/pebble/expression/NullCoalescingExpressionTest.java
@@ -2,12 +2,12 @@ package io.kestra.core.runners.pebble.expression;
 
 import com.google.common.collect.ImmutableMap;
 import io.kestra.core.exceptions.IllegalVariableEvaluationException;
-import io.kestra.core.runners.VariableRenderer;
 import io.kestra.core.junit.annotations.KestraTest;
+import io.kestra.core.runners.VariableRenderer;
+import jakarta.inject.Inject;
 import org.junit.jupiter.api.Test;
 
-import jakarta.inject.Inject;
-
+import java.util.HashMap;
 import java.util.Map;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -76,5 +76,19 @@ class NullCoalescingExpressionTest {
         String render = variableRenderer.render("{{ block ?? 'UNDEFINED' }}", vars);
 
         assertThat(render, is("{}"));
+    }
+
+    @Test
+    void nullOrUndefined() throws IllegalVariableEvaluationException {
+        Map<String, Object> vars = new HashMap<>();
+        vars.put("null", null);
+
+        String render = variableRenderer.render("{{ null ?? 'IS NULL' }}", vars);
+
+        assertThat(render, is("IS NULL"));
+
+        render = variableRenderer.render("{{ undefined ?? 'IS UNDEFINED' }}", vars);
+
+        assertThat(render, is("IS UNDEFINED"));
     }
 }

--- a/core/src/test/java/io/kestra/core/runners/pebble/expression/UndefinedCoalescingExpressionTest.java
+++ b/core/src/test/java/io/kestra/core/runners/pebble/expression/UndefinedCoalescingExpressionTest.java
@@ -1,0 +1,33 @@
+package io.kestra.core.runners.pebble.expression;
+
+import io.kestra.core.exceptions.IllegalVariableEvaluationException;
+import io.kestra.core.junit.annotations.KestraTest;
+import io.kestra.core.runners.VariableRenderer;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+@KestraTest
+class UndefinedCoalescingExpressionTest {
+    @Inject
+    VariableRenderer variableRenderer;
+
+    @Test
+    void nullOrUndefined() throws IllegalVariableEvaluationException {
+        Map<String, Object> vars = new HashMap<>();
+        vars.put("null", null);
+
+        String render = variableRenderer.render("{{ null ??? 'IS NULL' }}", vars);
+
+        assertThat(render, is(""));
+
+        render = variableRenderer.render("{{ undefined ??? 'IS UNDEFINED' }}", vars);
+
+        assertThat(render, is("IS UNDEFINED"));
+    }
+}

--- a/ui/src/components/flows/FlowRun.vue
+++ b/ui/src/components/flows/FlowRun.vue
@@ -134,7 +134,7 @@
             purgeInputs(inputs){
                 for (let input in inputs) {
                     if (inputs[input] === undefined || inputs[input] === "") {
-                        inputs[input] = null;
+                        delete inputs[input];
                     }
                 }
                 return inputs;


### PR DESCRIPTION
Short resume: null coalescing, aka ` X ?? Y` was confusing, so we decided that null coalescing will return Y if the value of X is `null` or `undefined`

For people that want to keep the difference between `null` and `undefined`, we created an "undefined coalesce" using this comparator: `???`, that returns Y only if X is `undefined`

Example, this flow will now return the following (see image below):
```yaml
inputs:
  - id: input1
    type: STRING
    required: false
    
  - id: input2
    type: STRING
    required: false
    defaults: ""
tasks:

  - id: null-coalesce-null
    type: io.kestra.plugin.core.log.Log
    message: "{{ inputs.input1 ?? 'nop' }}"

  - id: null-coalesce-undefined
    type: io.kestra.plugin.core.log.Log
    message: "{{ inputs.input12 ?? 'nop' }}"

  - id: null-coalesce-empty
    type: io.kestra.plugin.core.log.Log
    message: "{{ inputs.input2 ??? 'nop' }}"

  - id: undefined-coalesce-null
    type: io.kestra.plugin.core.log.Log
    message: "{{ inputs.input1 ??? 'nop' }}"
```
Result:
![image](https://github.com/user-attachments/assets/21dc2416-ccc1-460a-92b4-1f2ea9865806)

Note:
As it was helpful to have it in this PR and pretty related, the front end will now not send "null" as a string if the input (of type STRING) is not set, this allows to have a real null for input string, and if users want to send an empty string (which was not possible before), they can set an empty string as default, but will need to have the property `required` at false (however front end validation will prevent to launch execution)


close #2396
close #4134