### PR TITLE
fix(script): task runner override

### DIFF
--- a/script/src/main/java/io/kestra/plugin/scripts/exec/AbstractExecScript.java
+++ b/script/src/main/java/io/kestra/plugin/scripts/exec/AbstractExecScript.java
@@ -145,27 +145,28 @@ public abstract class AbstractExecScript extends Task implements RunnableTask<Sc
     }
 
     protected CommandsWrapper commands(RunContext runContext) throws IllegalVariableEvaluationException {
+        runContext.logger().debug("Using task runner '{}'", this.getTaskRunner().getType());
         return new CommandsWrapper(runContext)
             .withEnv(this.getEnv())
             .withWarningOnStdErr(this.getWarningOnStdErr())
             .withRunnerType(this.getRunner())
             .withContainerImage(runContext.render(this.getContainerImage()))
-            .withTaskRunner(this.taskRunner)
-            .withDockerOptions(this.docker != null ? this.injectDefaults(this.docker) : null)
-            .withNamespaceFiles(this.namespaceFiles)
-            .withInputFiles(this.inputFiles)
-            .withOutputFiles(this.outputFiles)
+            .withTaskRunner(this.getTaskRunner())
+            .withDockerOptions(this.getDocker() != null ? this.injectDefaults(this.getDocker()) : null)
+            .withNamespaceFiles(this.getNamespaceFiles())
+            .withInputFiles(this.getInputFiles())
+            .withOutputFiles(this.getOutputFiles())
             .withEnableOutputDirectory(this.getOutputDirectory())
             .withTimeout(this.getTimeout())
-            .withTargetOS(this.targetOS);
+            .withTargetOS(this.getTargetOS());
     }
 
     protected List<String> getBeforeCommandsWithOptions() {
-        return mayAddExitOnErrorCommands(this.beforeCommands);
+        return mayAddExitOnErrorCommands(this.getBeforeCommands());
     }
 
     protected List<String> mayAddExitOnErrorCommands(List<String> commands) {
-        if (!failFast) {
+        if (!this.getFailFast()) {
             return commands;
         }
 
@@ -185,7 +186,7 @@ public abstract class AbstractExecScript extends Task implements RunnableTask<Sc
      */
     protected List<String> getExitOnErrorCommands() {
         // If targetOS is Windows OR targetOS is AUTO && current system is windows and we use process as a runner.(TLDR will run on windows)
-        if (targetOS.equals(TargetOS.WINDOWS) || targetOS.equals(TargetOS.AUTO) && SystemUtils.IS_OS_WINDOWS && this.taskRunner instanceof Process) {
+        if (this.getTargetOS().equals(TargetOS.WINDOWS) || this.getTargetOS().equals(TargetOS.AUTO) && SystemUtils.IS_OS_WINDOWS && this.getTaskRunner() instanceof Process) {
             return List.of("");
         }
         // errexit option may be unsupported by non-shell interpreter.
@@ -195,8 +196,8 @@ public abstract class AbstractExecScript extends Task implements RunnableTask<Sc
     /** {@inheritDoc} **/
     @Override
     public void kill() {
-        if (this.taskRunner != null) {
-            this.taskRunner.kill();
+        if (this.getTaskRunner() != null) {
+            this.getTaskRunner().kill();
         }
     }
 }


### PR DESCRIPTION
Lombok is buggy when working with `@Builder.Default` it didn't take into accont overrides from properties so you should use getter everywhere.

Fixes https://github.com/kestra-io/plugin-dbt/issues/114