### PR TITLE
Fix/waitfor issue

### DIFF
--- a/core/src/main/java/io/kestra/core/models/tasks/ResolvedTask.java
+++ b/core/src/main/java/io/kestra/core/models/tasks/ResolvedTask.java
@@ -1,14 +1,13 @@
 package io.kestra.core.models.tasks;
 
-import lombok.Builder;
-import lombok.Value;
 import io.kestra.core.models.executions.Execution;
 import io.kestra.core.models.executions.NextTaskRun;
 import io.kestra.core.models.executions.TaskRun;
+import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
+import lombok.Value;
 
 import java.util.List;
-import java.util.stream.Collectors;
-import jakarta.validation.constraints.NotNull;
 
 @Builder
 @Value
@@ -23,6 +22,13 @@ public class ResolvedTask {
     public NextTaskRun toNextTaskRun(Execution execution) {
         return new NextTaskRun(
             TaskRun.of(execution, this),
+            this.getTask()
+        );
+    }
+
+    public NextTaskRun toNextTaskRunIncrementIteration(Execution execution, Integer iteration) {
+        return new NextTaskRun(
+            TaskRun.of(execution, this).withIteration(iteration != null ? iteration : 1),
             this.getTask()
         );
     }

--- a/core/src/main/java/io/kestra/core/runners/FlowableUtils.java
+++ b/core/src/main/java/io/kestra/core/runners/FlowableUtils.java
@@ -105,7 +105,7 @@ public class FlowableUtils {
         List<TaskRun> taskRuns = execution.findTaskRunByTasks(currentTasks, parentTaskRun);
         if (taskRuns.isEmpty()) {
             return Collections.singletonList(
-                currentTasks.getFirst().toNextTaskRun(execution)
+                currentTasks.getFirst().toNextTaskRunIncrementIteration(execution, parentTaskRun.getIteration())
             );
         }
 
@@ -127,9 +127,9 @@ public class FlowableUtils {
             int lastIndex = taskRuns.indexOf(lastTerminated.get());
 
             if (currentTasks.size() > lastIndex + 1) {
-                return Collections.singletonList(currentTasks.get(lastIndex + 1).toNextTaskRun(execution));
+                return Collections.singletonList(currentTasks.get(lastIndex + 1).toNextTaskRunIncrementIteration(execution, parentTaskRun.getIteration()));
             } else {
-                return Collections.singletonList(currentTasks.getFirst().toNextTaskRun(execution));
+                return Collections.singletonList(currentTasks.getFirst().toNextTaskRunIncrementIteration(execution, parentTaskRun.getIteration()));
             }
         }
 

--- a/ui/src/components/logs/LogLine.vue
+++ b/ui/src/components/logs/LogLine.vue
@@ -2,6 +2,7 @@
     <div class="line font-monospace" v-if="filtered">
         <span :class="levelClass" class="header-badge log-level el-tag noselect fw-bold">{{ log.level }}</span>
         <div class="log-content d-inline-block">
+            <span v-if="title" class="fw-bold">{{ (log.taskId ?? log.flowId ?? "").capitalize() }}</span>
             <div
                 class="header"
                 :class="{'d-inline-block': metaWithValue.length === 0, 'me-3': metaWithValue.length === 0}"
@@ -53,6 +54,10 @@
             excludeMetas: {
                 type: Array,
                 default: () => [],
+            },
+            title: {
+                type: Boolean,
+                default: false
             }
         },
         data() {
@@ -184,11 +189,11 @@
         }
 
         .header-badge {
-            display: inline-block;
             font-size: 95%;
             text-align: center;
             white-space: nowrap;
             vertical-align: baseline;
+            width: 40px;
 
             span:first-child {
                 margin-right: 6px;

--- a/ui/src/components/logs/TaskRunDetails.vue
+++ b/ui/src/components/logs/TaskRunDetails.vue
@@ -255,6 +255,8 @@
                 return Download
             },
             currentTaskRuns() {
+                // console.log(this.followedExecution?.taskRunList?.filter(tr => this.taskRunId ? tr.id === this.taskRunId : true))
+                // return this.logs.map(log => log.taskRunId).filter(tr => this.taskRunId ? tr.id === this.taskRunId : true)
                 return this.followedExecution?.taskRunList?.filter(tr => this.taskRunId ? tr.id === this.taskRunId : true) ?? [];
             },
             params() {

--- a/ui/src/stores/executions.js
+++ b/ui/src/stores/executions.js
@@ -165,11 +165,7 @@ export default {
                 if (options.store === false) {
                     return response.data
                 }
-                if(options.params.page !== 1) {
-                    commit("appendLogs", response.data)
-                } else {
-                    commit("setLogs", response.data)
-                }
+                commit("setLogs", response.data)
 
                 return response.data
             });

--- a/ui/src/translations/en.json
+++ b/ui/src/translations/en.json
@@ -881,6 +881,12 @@
     "curl": {
       "command": "cURL command",
       "note": "Note that for SECRET and FILE input type, the command must be accommodate to match the real values."
+    },
+    "logs_view": {
+      "raw": "Raw view",
+      "raw_details": "Show full logs in datetime order, but with less features",
+      "compact": "Compact view",
+      "compact_details": "Show compact logs group by Task, but may display less logs"
     }
   }
 }

--- a/ui/src/translations/en.json
+++ b/ui/src/translations/en.json
@@ -883,10 +883,10 @@
       "note": "Note that for SECRET and FILE input type, the command must be accommodate to match the real values."
     },
     "logs_view": {
-      "raw": "Raw view",
-      "raw_details": "Show full logs in datetime order, but with less features",
-      "compact": "Compact view",
-      "compact_details": "Show compact logs group by Task, but may display less logs"
+      "raw": "Temporal view",
+      "raw_details": "Show full task logs and flow logs in a raw timestamp-ordered format",
+      "compact": "Default view",
+      "compact_details": "Show task logs in a compact view grouped by each task"
     }
   }
 }

--- a/ui/src/translations/fr.json
+++ b/ui/src/translations/fr.json
@@ -860,10 +860,10 @@
       "note": "Notez que pour les types d'entrée SECRET et FILE, la commande doit être adaptée pour correspondre aux valeurs réelles."
     },
     "logs_view": {
-      "raw": "Vue simple",
-      "raw_details": "Affiche toutes les logs dans l'ordre de la date, mais avec moins de fonctionnalité",
-      "compact": "Vue compacte",
-      "compact_details": "Affiche les logs groupés par tâche, mais peut afficher moins de logs"
+      "raw": "Vue temporelle",
+      "raw_details": "Affiche les logs des tâches et du flow dans un format brut ordonné par horodatage",
+      "compact": "Vue par défaut",
+      "compact_details": "Affiche les logs dans un format compacte regroupé par tâche"
     }
   }
 }

--- a/ui/src/translations/fr.json
+++ b/ui/src/translations/fr.json
@@ -858,6 +858,12 @@
     "curl": {
       "command": "Commande cURL",
       "note": "Notez que pour les types d'entrée SECRET et FILE, la commande doit être adaptée pour correspondre aux valeurs réelles."
+    },
+    "logs_view": {
+      "raw": "Vue simple",
+      "raw_details": "Affiche toutes les logs dans l'ordre de la date, mais avec moins de fonctionnalité",
+      "compact": "Vue compacte",
+      "compact_details": "Affiche les logs groupés par tâche, mais peut afficher moins de logs"
     }
   }
 }


### PR DESCRIPTION
Children's tasks from WaitFor are now executed in the correct order after the first loop.

As it required to clean all taskRuns (previously, we were just erasing the state to make them run again with a new iteration),
the current log view will only display the log from the last task execution.

So I've added a new button that shows a raw list of the logs, which will close #2521 at the same time:

![image](https://github.com/user-attachments/assets/fe2907ea-bf0e-40e4-9930-6d4f875d3f04)

To make our logs cleaner, we would need to rework our log components. Currently, we go from the flow's taskRuns list to the logs, but this doesn't allow us to display flow logs or delete taskRun logs. 

We would need to reverse that, so we would go from the logs and group them by taskId if needed. This "raw view" is only here to offer a temporary solution.

close #4092