### PR TITLE
fix(ui): amend editor height under namespace tabs

### DIFF
--- a/ui/src/components/inputs/Editor.vue
+++ b/ui/src/components/inputs/Editor.vue
@@ -407,7 +407,7 @@
 <style lang="scss">
     @import "../../styles/layout/root-dark.scss";
 
-    :not(.el-drawer__body) > .ks-editor {
+    :not(.namespace-form, .el-drawer__body) > .ks-editor{
         flex-direction: column;
         height: 100%;
     }


### PR DESCRIPTION
Closes https://github.com/kestra-io/kestra-ee/issues/1421.