### PR TITLE
fix(script): don't display the taskRunner log if the old runner prop …

### DIFF
--- a/script/src/main/java/io/kestra/plugin/scripts/exec/AbstractExecScript.java
+++ b/script/src/main/java/io/kestra/plugin/scripts/exec/AbstractExecScript.java
@@ -145,7 +145,10 @@ public abstract class AbstractExecScript extends Task implements RunnableTask<Sc
     }
 
     protected CommandsWrapper commands(RunContext runContext) throws IllegalVariableEvaluationException {
-        runContext.logger().debug("Using task runner '{}'", this.getTaskRunner().getType());
+        if (this.getRunner() == null) {
+            runContext.logger().debug("Using task runner '{}'", this.getTaskRunner().getType());
+        }
+
         return new CommandsWrapper(runContext)
             .withEnv(this.getEnv())
             .withWarningOnStdErr(this.getWarningOnStdErr())


### PR DESCRIPTION
…is used

Fixes #4499