### PR TITLE
fix(ui): load outputs `apiUrl` from alias override location

### DIFF
--- a/ui/src/components/executions/outputs/Wrapper.vue
+++ b/ui/src/components/executions/outputs/Wrapper.vue
@@ -113,7 +113,7 @@
     import {useI18n} from "vue-i18n";
     const {t} = useI18n({useScope: "global"});
 
-    import {apiUrl} from "../../../override/utils/route";
+    import {apiUrl} from "override/utils/route";
 
     import Editor from "../../inputs/Editor.vue";
     const debugEditor = ref(null);


### PR DESCRIPTION
Relates to https://github.com/kestra-io/kestra-ee/issues/1471.