### PR TITLE
feat(ui): add shortcut to Output Debugger

### DIFF
--- a/ui/src/components/executions/outputs/Wrapper.vue
+++ b/ui/src/components/executions/outputs/Wrapper.vue
@@ -65,6 +65,7 @@
                                 :input="true"
                                 :navbar="false"
                                 :model-value="computedDebugValue"
+                                @confirm="onDebugExpression($event)"
                                 class="w-100"
                             />
 

--- a/ui/src/components/inputs/Editor.vue
+++ b/ui/src/components/inputs/Editor.vue
@@ -96,7 +96,7 @@
         components: {
             MonacoEditor,
         },
-        emits: ["save", "execute", "focusout", "tab", "update:modelValue", "cursor"],
+        emits: ["save", "execute", "focusout", "tab", "update:modelValue", "cursor", "confirm"],
         editor: undefined,
         data() {
             return {
@@ -259,6 +259,19 @@
                     contextMenuOrder: 1.5,
                     run: (ed) => {
                         this.$emit("execute", ed.getValue())
+                    }
+                });
+
+                this.editor.addAction({
+                    id: "confirm",
+                    label: "Confirm",
+                    keybindings: [
+                        KeyMod.CtrlCmd | KeyCode.Enter,
+                    ],
+                    contextMenuGroupId: "navigation",
+                    contextMenuOrder: 1.5,
+                    run: (ed) => {
+                        this.$emit("confirm", ed.getValue())
                     }
                 });
 


### PR DESCRIPTION
### What changes are being made and why?

Use _Ctrl+Enter_ to run the debug expression.

Let me know if this change should not be applied globally.