### PR TITLE
fix(core): ensure child-first strategy for plugin class loading (#4621)

### DIFF
--- a/core/src/main/java/io/kestra/core/plugins/PluginClassLoader.java
+++ b/core/src/main/java/io/kestra/core/plugins/PluginClassLoader.java
@@ -7,9 +7,7 @@ import java.net.URL;
 import java.net.URLClassLoader;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
-import java.util.Collections;
 import java.util.Enumeration;
-import java.util.NoSuchElementException;
 import java.util.Objects;
 import java.util.regex.Pattern;
 
@@ -19,22 +17,31 @@ import java.util.regex.Pattern;
  */
 @Slf4j
 public class PluginClassLoader extends URLClassLoader {
+
     static {
         ClassLoader.registerAsParallelCapable();
     }
 
-    // The default list of packages to delegate loading to parent classloader.
-    private static Pattern DEFAULT_PACKAGES_TO_IGNORE = Pattern.compile("(?:"
+    // The list of package to exclude from classloader isolation.
+    // IMPORTANT - This list must contain system and common libraries to delegate loading to parent classloader to:
+    // - protect from impersonation of system classes (e.g: java.*)
+    // - avoid experiencing java.lang.LinkageError: loader constraint violation.
+    private static final Pattern EXCLUDES = Pattern.compile("^(?:"
+        + "java"
+        + "|javax"
         + "|io.kestra.core"
         + "|io.kestra.plugin.core"
         + "|org.slf4j"
+        + "|com.fasterxml.jackson.core"
+        + "|com.fasterxml.jackson.databind"
+        + "|com.fasterxml.jackson.dataformat.ion"
+        + "|com.fasterxml.jackson.dataformat.yaml"
+        + "|com.fasterxml.jackson.dataformat.xml"
         + ")\\..*$");
 
     private final ClassLoader parent;
 
     private final URL pluginLocation;
-
-    private final ClassLoader systemClassLoader;
 
     @SuppressWarnings("removal")
     public static PluginClassLoader of(final URL pluginLocation, final URL[] urls, final ClassLoader parent) {
@@ -54,13 +61,16 @@ public class PluginClassLoader extends URLClassLoader {
         super(urls, parent);
         this.parent = parent;
         this.pluginLocation = pluginLocation;
-        this.systemClassLoader = getSystemClassLoader();
     }
 
     public String location() {
         return pluginLocation.toString();
     }
 
+    /**
+     * {@inheritDoc}
+     */
+    @Override
     public Class<?> loadClass(String name) throws ClassNotFoundException {
         return loadClass(name, false);
     }
@@ -74,16 +84,11 @@ public class PluginClassLoader extends URLClassLoader {
             // First, check if the class has already been loaded
             Class<?> loadedClass = findLoadedClass(name);
 
-            if (loadedClass == null) {
-                // protect from impersonation of system classes (e.g: java.*)
-                loadedClass = mayLoadFromSystemClassLoader(name);
-            }
-
             if (loadedClass == null && shouldLoadFromUrls(name)) {
                 try {
-                    // find the class from given jar urls
                     loadedClass = findClass(name);
-                } catch (final ClassNotFoundException e) {
+                }
+                catch (final ClassNotFoundException e) {
                     log.debug(
                         "Class '{}' not found on '{}' for plugin '{}', delegating to parent '{}'",
                         name,
@@ -107,36 +112,16 @@ public class PluginClassLoader extends URLClassLoader {
     }
 
     private static boolean shouldLoadFromUrls(final String name) {
-        return !DEFAULT_PACKAGES_TO_IGNORE.matcher(name).matches();
+        return !EXCLUDES.matcher(name).matches();
     }
 
     /**
      * {@inheritDoc}
      */
     @Override
-    @SuppressWarnings("unchecked")
     public Enumeration<URL> getResources(String name) throws IOException {
         Objects.requireNonNull(name);
-
-        final Enumeration<URL>[] e = (Enumeration<URL>[]) new Enumeration<?>[3];
-
-        // First, load resources from system class loader
-        // e[0] = getResourcesFromSystem(name);
-
-        // load resource from this classloader
-        e[1] = findResources(name);
-
-        // then try finding resources from parent class-loaders
-        // e[2] = getParent().getResources(name);
-
-        return new CompoundEnumeration<>(e);
-    }
-
-    private Enumeration<URL> getResourcesFromSystem(final String name) throws IOException {
-        if (systemClassLoader != null) {
-            return systemClassLoader.getResources(name);
-        }
-        return Collections.emptyEnumeration();
+        return findResources(name); // Only find resources locally.
     }
 
     /**
@@ -145,33 +130,7 @@ public class PluginClassLoader extends URLClassLoader {
     @Override
     public URL getResource(final String name) {
         Objects.requireNonNull(name);
-        URL res = null;
-
-        // if (systemClassLoader != null) {
-        //     res = systemClassLoader.getResource(name);
-        // }
-
-        if (res == null) {
-            res = findResource(name);
-        }
-
-        // if (res == null) {
-        //     res = getParent().getResource(name);
-        // }
-
-        return res;
-    }
-
-    private Class<?> mayLoadFromSystemClassLoader(final String name) {
-        Class<?> loadedClass = null;
-        try {
-            if (systemClassLoader != null) {
-                loadedClass = systemClassLoader.loadClass(name);
-            }
-        } catch (final ClassNotFoundException ex) {
-            // silently ignored
-        }
-        return loadedClass;
+        return findResource(name);
     }
 
     /**
@@ -180,35 +139,5 @@ public class PluginClassLoader extends URLClassLoader {
     @Override
     public String toString() {
         return "PluginClassLoader[location=" + pluginLocation + "] ";
-    }
-
-    static final class CompoundEnumeration<E> implements Enumeration<E> {
-        private final Enumeration<E>[] enums;
-        private int index;
-
-        CompoundEnumeration(Enumeration<E>[] enums) {
-            this.enums = enums;
-        }
-
-        private boolean next() {
-            while (index < enums.length) {
-                if (enums[index] != null && enums[index].hasMoreElements()) {
-                    return true;
-                }
-                index++;
-            }
-            return false;
-        }
-
-        public boolean hasMoreElements() {
-            return next();
-        }
-
-        public E nextElement() {
-            if (!next()) {
-                throw new NoSuchElementException();
-            }
-            return enums[index].nextElement();
-        }
     }
 }


### PR DESCRIPTION
Changes:
- fix child-first strategy
- cleanup the PluginClassLoader class

Fix: #4621

With this classloader:

![new-classloader](https://github.com/user-attachments/assets/441ff703-0640-431b-a00d-870fe57a56e6)
