### PR TITLE
feat(core): add support for pebble filters/functions as plugin

### DIFF
--- a/core/src/main/java/io/kestra/core/expression/PebbleExtension.java
+++ b/core/src/main/java/io/kestra/core/expression/PebbleExtension.java
@@ -1,0 +1,9 @@
+package io.kestra.core.expression;
+
+import io.kestra.core.models.Plugin;
+
+/**
+ * Top-level interface for providing an extension Pebble expression language.
+ */
+public interface PebbleExtension extends Plugin {
+}

--- a/core/src/main/java/io/kestra/core/expression/PebbleFilter.java
+++ b/core/src/main/java/io/kestra/core/expression/PebbleFilter.java
@@ -1,0 +1,23 @@
+package io.kestra.core.expression;
+
+import io.kestra.core.models.annotations.Plugin;
+import io.pebbletemplates.pebble.extension.Filter;
+
+/**
+ * Class for defining a Pebble filter.
+ */
+@Plugin
+public abstract class PebbleFilter implements Filter, PebbleExtension {
+
+    /**
+     * Returns the {@link Filter} name.
+     * 
+     * @return the string name  - cannot be {@link null}.
+     */
+    public String name() {
+        String className = getClass().getSimpleName()
+            .replace(PebbleFilter.class.getSimpleName(), "")
+            .replace("Filter", "");
+        return className.substring(0, 1).toLowerCase() + className.substring(1);
+    }
+}

--- a/core/src/main/java/io/kestra/core/expression/PebbleFunction.java
+++ b/core/src/main/java/io/kestra/core/expression/PebbleFunction.java
@@ -1,0 +1,23 @@
+package io.kestra.core.expression;
+
+import io.kestra.core.models.annotations.Plugin;
+import io.pebbletemplates.pebble.extension.Function;
+
+/**
+ * Class for defining a Pebble function.
+ */
+@Plugin
+public abstract class PebbleFunction implements Function, PebbleExtension {
+
+    /**
+     * Returns the {@link Function} name.
+     *
+     * @return the string name  - cannot be {@link null}.
+     */
+    public String name() {
+        String className = getClass().getSimpleName()
+            .replace(PebbleFunction.class.getSimpleName(), "")
+            .replace("Function", "");
+        return className.substring(0, 1).toLowerCase() + className.substring(1);
+    }
+}

--- a/core/src/main/java/io/kestra/core/plugins/PluginScanner.java
+++ b/core/src/main/java/io/kestra/core/plugins/PluginScanner.java
@@ -1,5 +1,6 @@
 package io.kestra.core.plugins;
 
+import io.kestra.core.expression.PebbleExtension;
 import io.kestra.core.models.Plugin;
 import io.kestra.core.models.conditions.Condition;
 import io.kestra.core.models.tasks.runners.TaskRunner;
@@ -97,6 +98,7 @@ public class PluginScanner {
         List<Class<? extends StorageInterface>> storages = new ArrayList<>();
         List<Class<? extends SecretPluginInterface>> secrets = new ArrayList<>();
         List<Class<? extends TaskRunner>> taskRunners = new ArrayList<>();
+        List<Class<? extends PebbleExtension>> pebbleExtensions = new ArrayList<>();
         List<String> guides = new ArrayList<>();
         Map<String, Class<?>> aliases = new HashMap<>();
 
@@ -135,6 +137,10 @@ public class PluginScanner {
                     case TaskRunner runner -> {
                         log.debug("Loading TaskRunner plugin: '{}'", plugin.getClass());
                         taskRunners.add(runner.getClass());
+                    }
+                    case PebbleExtension extension -> {
+                        log.debug("Loading PebbleExtension plugin: '{}'", plugin.getClass());
+                        pebbleExtensions.add(extension.getClass());
                     }
                     default -> {
                     }
@@ -179,6 +185,7 @@ public class PluginScanner {
             .storages(storages)
             .secrets(secrets)
             .taskRunners(taskRunners)
+            .pebbleExtensions(pebbleExtensions)
             .guides(guides)
             .aliases(aliases.entrySet().stream().collect(Collectors.toMap(
                 e -> e.getKey().toLowerCase(),

--- a/core/src/main/java/io/kestra/core/plugins/RegisteredPlugin.java
+++ b/core/src/main/java/io/kestra/core/plugins/RegisteredPlugin.java
@@ -1,5 +1,6 @@
 package io.kestra.core.plugins;
 
+import io.kestra.core.expression.PebbleExtension;
 import io.kestra.core.models.annotations.PluginSubGroup;
 import io.kestra.core.models.conditions.Condition;
 import io.kestra.core.models.tasks.runners.TaskRunner;
@@ -36,6 +37,7 @@ public class RegisteredPlugin {
     private final List<Class<? extends StorageInterface>> storages;
     private final List<Class<? extends SecretPluginInterface>> secrets;
     private final List<Class<? extends TaskRunner>> taskRunners;
+    private final List<Class<? extends PebbleExtension>> pebbleExtensions;
     private final List<String> guides;
     // Map<lowercasealias, <Alias, Class>>
     private final Map<String, Map.Entry<String, Class<?>>> aliases;
@@ -85,6 +87,10 @@ public class RegisteredPlugin {
             return TaskRunner.class;
         }
 
+        if (this.getPebbleExtensions().stream().anyMatch(r -> r.getName().equals(cls))) {
+            return PebbleExtension.class;
+        }
+
         if(this.getAliases().containsKey(cls.toLowerCase())) {
             // This is a quick-win, but it may trigger an infinite loop ... or not ...
             return baseClass(this.getAliases().get(cls.toLowerCase()).getValue().getName());
@@ -112,6 +118,7 @@ public class RegisteredPlugin {
         result.put("storages", Arrays.asList(this.getStorages().toArray(Class[]::new)));
         result.put("secrets", Arrays.asList(this.getSecrets().toArray(Class[]::new)));
         result.put("task-runners", Arrays.asList(this.getTaskRunners().toArray(Class[]::new)));
+        result.put("pebble-extensions", Arrays.asList(this.getPebbleExtensions().toArray(Class[]::new)));
 
         return result;
     }
@@ -284,6 +291,15 @@ public class RegisteredPlugin {
 
         if (!this.getAliases().isEmpty()) {
             b.append("[Aliases: ");
+            b.append(this.getAliases().values().stream().collect(Collectors.toMap(
+                Map.Entry::getKey,
+                Map.Entry::getValue
+            )));
+            b.append("] ");
+        }
+
+        if (!this.getPebbleExtensions().isEmpty()) {
+            b.append("[Pebble Extensions: ");
             b.append(this.getAliases().values().stream().collect(Collectors.toMap(
                 Map.Entry::getKey,
                 Map.Entry::getValue

--- a/core/src/main/java/io/kestra/core/runners/VariableRendererFactory.java
+++ b/core/src/main/java/io/kestra/core/runners/VariableRendererFactory.java
@@ -1,0 +1,135 @@
+package io.kestra.core.runners;
+
+import io.kestra.core.expression.PebbleExtension;
+import io.kestra.core.expression.PebbleFilter;
+import io.kestra.core.expression.PebbleFunction;
+import io.kestra.core.plugins.PluginRegistry;
+import io.kestra.core.plugins.RegisteredPlugin;
+import io.kestra.core.runners.pebble.ExtensionCustomizer;
+import io.kestra.core.runners.pebble.PebbleLruCache;
+import io.kestra.core.storages.StorageInterface;
+import io.kestra.core.utils.Classes;
+import io.micronaut.context.annotation.Factory;
+import io.micronaut.context.annotation.Requires;
+import io.pebbletemplates.pebble.PebbleEngine;
+import io.pebbletemplates.pebble.extension.AbstractExtension;
+import io.pebbletemplates.pebble.extension.Filter;
+import io.pebbletemplates.pebble.extension.Function;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+@Factory
+public class VariableRendererFactory {
+
+    private static final Logger log = LoggerFactory.getLogger(VariableRendererFactory.class);
+
+    @Inject
+    VariableRenderer.VariableConfiguration configuration;
+
+    @Inject
+    List<AbstractExtension> extensions;
+
+    @Inject
+    PluginRegistry pluginRegistry;
+
+    @Singleton
+    @Requires(missingBeans = VariableRenderer.class)
+    public VariableRenderer variableRenderer(PebbleEngine pebbleEngine) {
+        return new VariableRenderer(pebbleEngine, configuration.recursiveRendering());
+    }
+
+    @Singleton
+    public PebbleEngine pebbleEngine() {
+        PebbleEngine.Builder builder = new PebbleEngine.Builder()
+            .registerExtensionCustomizer(ExtensionCustomizer::new)
+            .strictVariables(true)
+            .cacheActive(configuration.cacheEnabled())
+            .newLineTrimming(false)
+            .autoEscaping(false);
+
+        // register core extensions
+        extensions.forEach(builder::extension);
+
+        // register custom extensions
+        Map<Class<?>, List<PebbleExtension>> extensions = allPebbleExtensionClasses(pluginRegistry)
+            .map(Classes::newInstance)
+            .collect(Collectors.groupingBy(it -> {
+                if (it instanceof PebbleFunction) {
+                    return PebbleFunction.class;
+                }
+                if (it instanceof PebbleFilter) {
+                    return PebbleFilter.class;
+                }
+                return Object.class; // will be silently ignored
+            }));
+
+        Map<String, Filter> filters = loadCustomPebbleFilters(extensions);
+        Map<String, Function> functions = loadCustomPebbleFunctions(extensions);
+
+        builder.extension(new AbstractExtension() {
+            @Override
+            public Map<String, Filter> getFilters() {
+                return filters;
+            }
+
+            @Override
+            public Map<String, Function> getFunctions() {
+                return functions;
+            }
+        });
+
+        if (configuration.cacheEnabled()) {
+            builder.templateCache(new PebbleLruCache(configuration.cacheSize()));
+        }
+
+        return builder.build();
+    }
+
+    private static Map<String, Function> loadCustomPebbleFunctions(Map<Class<?>, List<PebbleExtension>> extensions) {
+        return extensions.getOrDefault(PebbleFunction.class, List.of()).stream()
+            .map(it -> (PebbleFunction) it)
+            .filter(Objects::nonNull)
+            .peek(it -> {
+                if (log.isDebugEnabled()) {
+                    log.debug("Registered PebbleFunction for name '{}': {}", it.name(), it.getClass());
+                }
+            })
+            .collect(Collectors.toMap(PebbleFunction::name, it -> it, (existing, duplicate) -> {
+                log.warn("Duplicate PebbleFunction detected for name: {}", ((PebbleFunction)existing).name());
+                return existing;
+            }));
+    }
+
+    private static Map<String, Filter> loadCustomPebbleFilters(Map<Class<?>, List<PebbleExtension>> extensions) {
+        return extensions.getOrDefault(PebbleFilter.class, List.of()).stream()
+            .map(it -> (PebbleFilter) it)
+            .filter(Objects::nonNull)
+            .peek(it -> {
+                if (log.isDebugEnabled()) {
+                    log.debug("Registered PebbleFilter for name '{}': {}", it.name(), it.getClass());
+                }
+            })
+            .collect(Collectors.toMap(PebbleFilter::name, it -> it, (existing, duplicate) -> {
+                log.warn("Duplicate PebbleFilter plugin detected for name: {}", ((PebbleFilter)existing).name());
+                return existing;
+            }));
+    }
+
+    /**
+     * @return all plugin classes for the {@link StorageInterface}s.
+     */
+    private static Stream<Class<? extends PebbleExtension>> allPebbleExtensionClasses(final PluginRegistry pluginRegistry) {
+        return pluginRegistry.plugins()
+            .stream()
+            .map(RegisteredPlugin::getPebbleExtensions)
+            .flatMap(List::stream);
+    }
+}

--- a/core/src/main/java/io/kestra/core/utils/Classes.java
+++ b/core/src/main/java/io/kestra/core/utils/Classes.java
@@ -1,0 +1,21 @@
+package io.kestra.core.utils;
+
+import io.kestra.core.exceptions.KestraRuntimeException;
+
+/**
+ * Utility class to manipulate {@link Class} objects.
+ */
+public interface Classes {
+
+    static <T> T newInstance(final Class<T> c) {
+        if (c == null)
+            throw new IllegalArgumentException("class cannot be null");
+        try {
+            return c.getDeclaredConstructor().newInstance();
+        } catch (NoSuchMethodException e) {
+            throw new KestraRuntimeException("Could not find a public no-argument constructor for " + c.getName(), e);
+        } catch (ReflectiveOperationException | RuntimeException e) {
+            throw new KestraRuntimeException("Could not instantiate class " + c.getName(), e);
+        }
+    }
+}

--- a/core/src/test/java/io/kestra/core/expression/PebbleFilterTest.java
+++ b/core/src/test/java/io/kestra/core/expression/PebbleFilterTest.java
@@ -1,0 +1,46 @@
+package io.kestra.core.expression;
+
+import io.pebbletemplates.pebble.error.PebbleException;
+import io.pebbletemplates.pebble.template.EvaluationContext;
+import io.pebbletemplates.pebble.template.PebbleTemplate;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+
+class PebbleFilterTest {
+
+    @Test
+    void shouldGetDefaultName() {
+        Assertions.assertEquals("testCustom", new TestCustomFilter().name());
+        Assertions.assertEquals("testCustom", new TestCustomPebbleFilter().name());
+    }
+
+    public static class TestCustomFilter extends PebbleFilter {
+
+        @Override
+        public Object apply(Object input, Map<String, Object> args, PebbleTemplate self, EvaluationContext context, int lineNumber) throws PebbleException {
+            return null;
+        }
+
+        @Override
+        public List<String> getArgumentNames() {
+            return null;
+        }
+    }
+
+    public static class TestCustomPebbleFilter extends PebbleFilter {
+
+        @Override
+        public Object apply(Object input, Map<String, Object> args, PebbleTemplate self, EvaluationContext context, int lineNumber) throws PebbleException {
+            return null;
+        }
+
+        @Override
+        public List<String> getArgumentNames() {
+            return null;
+        }
+    }
+}

--- a/core/src/test/java/io/kestra/core/expression/PebbleFunctionTest.java
+++ b/core/src/test/java/io/kestra/core/expression/PebbleFunctionTest.java
@@ -1,0 +1,43 @@
+package io.kestra.core.expression;
+
+import io.pebbletemplates.pebble.template.EvaluationContext;
+import io.pebbletemplates.pebble.template.PebbleTemplate;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+
+class PebbleFunctionTest {
+
+    @Test
+    void shouldGetDefaultName() {
+        Assertions.assertEquals("testCustom", new TestCustomFunction().name());
+        Assertions.assertEquals("testCustom", new TestCustomPebbleFunction().name());
+    }
+
+    public static class TestCustomFunction extends PebbleFunction {
+        @Override
+        public Object execute(Map<String, Object> args, PebbleTemplate self, EvaluationContext context, int lineNumber) {
+            return null;
+        }
+
+        @Override
+        public List<String> getArgumentNames() {
+            return null;
+        }
+    }
+
+    public static class TestCustomPebbleFunction extends PebbleFunction {
+        @Override
+        public Object execute(Map<String, Object> args, PebbleTemplate self, EvaluationContext context, int lineNumber) {
+            return null;
+        }
+
+        @Override
+        public List<String> getArgumentNames() {
+            return null;
+        }
+    }
+}

--- a/core/src/test/java/io/kestra/core/runners/VariableRendererTest.java
+++ b/core/src/test/java/io/kestra/core/runners/VariableRendererTest.java
@@ -6,6 +6,7 @@ import static org.hamcrest.Matchers.contains;
 import io.kestra.core.exceptions.IllegalVariableEvaluationException;
 import io.micronaut.context.ApplicationContext;
 import io.kestra.core.junit.annotations.KestraTest;
+import io.pebbletemplates.pebble.PebbleEngine;
 import jakarta.inject.Inject;
 import java.util.LinkedHashMap;
 import org.junit.jupiter.api.Assertions;
@@ -20,14 +21,17 @@ class VariableRendererTest {
     ApplicationContext applicationContext;
 
     @Inject
+    VariableRenderer variableRenderer;
+
+    @Inject
     VariableRenderer.VariableConfiguration variableConfiguration;
 
     @Inject
-    VariableRenderer variableRenderer;
+    PebbleEngine pebbleEngine;
 
     @Test
     void shouldRenderUsingAlternativeRendering() throws IllegalVariableEvaluationException {
-        TestVariableRenderer renderer = new TestVariableRenderer(applicationContext, variableConfiguration);
+        TestVariableRenderer renderer = new TestVariableRenderer(pebbleEngine, variableConfiguration.recursiveRendering());
         String render = renderer.render("{{ dummy }}", Map.of());
         Assertions.assertEquals("result", render);
     }
@@ -54,9 +58,9 @@ class VariableRendererTest {
 
     public static class TestVariableRenderer extends VariableRenderer {
 
-        public TestVariableRenderer(ApplicationContext applicationContext,
-                                    VariableConfiguration variableConfiguration) {
-            super(applicationContext, variableConfiguration);
+        public TestVariableRenderer(PebbleEngine pebbleEngine,
+                                    boolean recursiveRendering) {
+            super(pebbleEngine, recursiveRendering);
         }
 
         @Override
@@ -64,6 +68,5 @@ class VariableRendererTest {
             return "result";
         }
     }
-
 
 }

--- a/model/src/main/java/io/kestra/core/models/Plugin.java
+++ b/model/src/main/java/io/kestra/core/models/Plugin.java
@@ -4,8 +4,6 @@ import io.kestra.core.models.annotations.Plugin.Id;
 import jakarta.validation.constraints.NotNull;
 
 import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashSet;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;


### PR DESCRIPTION
This PR is a POC to allow users to define custom filters and functions for pebble as plugins:

**Examples:** 

A custom Pebble Filter :

```java
public class UppercaseFilter extends PebbleFilter {

    @Override
    public Object apply(Object input, Map<String, Object> args, PebbleTemplate self, EvaluationContext context, int lineNumber) throws PebbleException {
        return Optional.ofNullable(input)
            .map(Object::toString)
            .map(s -> s.toUpperCase(Locale.ROOT)).orElse(null);
    }

    @Override
    public List<String> getArgumentNames() {
        return List.of();
    }
}
```

A custom Pebble Function :

```java
public class UppercaseFunction extends PebbleFunction {

    @Override
    public Object execute(Map<String, Object> args, PebbleTemplate self, EvaluationContext context, int lineNumber) {
        if (!args.containsKey("value")) {
            throw new PebbleException(null, "The 'uppercase' function expects one arguments 'value'", lineNumber, self.getName());
        }
        String value = (String) args.get("value");
        return Optional.ofNullable(value).map(s -> s.toUpperCase(Locale.ROOT)).orElse(null);
    }

    @Override
    public List<String> getArgumentNames() {
        return List.of("value");
    }
}
```

**Limitations:**

 * This PR doesn't provide embedded plugin doc for Pebble functions/filters (i.e., those plugin are not visible in the UI).
 * This PR doesn't allow to provide custom unary/binary operators