### PR TITLE
feat: Implements message protection for the JDBC Queue

### DIFF
--- a/cli/src/main/java/io/kestra/cli/commands/sys/SubmitQueuedCommand.java
+++ b/cli/src/main/java/io/kestra/cli/commands/sys/SubmitQueuedCommand.java
@@ -15,6 +15,8 @@ import picocli.CommandLine;
 
 import java.util.Optional;
 
+import static io.kestra.core.utils.Rethrow.throwConsumer;
+
 @CommandLine.Command(
     name = "submit-queued-execution",
     description = {"Submit all queued execution to the executor",
@@ -49,7 +51,7 @@ public class SubmitQueuedCommand extends AbstractCommand {
             var executionQueuedStorage = applicationContext.getBean(AbstractJdbcExecutionQueuedStorage.class);
 
             for (ExecutionQueued queued : executionQueuedStorage.getAllForAllTenants()) {
-                executionQueuedStorage.pop(queued.getTenantId(), queued.getNamespace(), queued.getFlowId(), execution -> executionQueue.emit(execution.withState(State.Type.CREATED)));
+                executionQueuedStorage.pop(queued.getTenantId(), queued.getNamespace(), queued.getFlowId(), throwConsumer(execution -> executionQueue.emit(execution.withState(State.Type.CREATED))));
                 cpt++;
             }
         }

--- a/core/src/main/java/io/kestra/core/queues/MessageTooBigException.java
+++ b/core/src/main/java/io/kestra/core/queues/MessageTooBigException.java
@@ -1,0 +1,8 @@
+package io.kestra.core.queues;
+
+public class MessageTooBigException extends QueueException {
+
+    public MessageTooBigException(String message) {
+        super(message);
+    }
+}

--- a/core/src/main/java/io/kestra/core/queues/QueueException.java
+++ b/core/src/main/java/io/kestra/core/queues/QueueException.java
@@ -2,9 +2,13 @@ package io.kestra.core.queues;
 
 import java.io.Serial;
 
-public class QueueException extends RuntimeException {
+public class QueueException extends Exception {
     @Serial
-    private static final long serialVersionUID = 1L;
+    private static final long serialVersionUID = 2L;
+
+    public QueueException(String message) {
+        super(message);
+    }
 
     public QueueException(String message, Throwable e) {
         super(message, e);

--- a/core/src/main/java/io/kestra/core/queues/QueueInterface.java
+++ b/core/src/main/java/io/kestra/core/queues/QueueInterface.java
@@ -44,5 +44,5 @@ public interface QueueInterface<T> extends Closeable {
     }
 
     Runnable receive(String consumerGroup, Class<?> queueType, Consumer<Either<T, DeserializationException>> consumer, boolean forUpdate);
-    
+
 }

--- a/core/src/main/java/io/kestra/core/runners/RunContextLogger.java
+++ b/core/src/main/java/io/kestra/core/runners/RunContextLogger.java
@@ -15,6 +15,7 @@ import com.google.common.base.Splitter;
 import com.google.common.base.Throwables;
 import io.kestra.core.exceptions.IllegalVariableEvaluationException;
 import io.kestra.core.models.executions.LogEntry;
+import io.kestra.core.queues.QueueException;
 import io.kestra.core.queues.QueueInterface;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
@@ -294,7 +295,13 @@ public class RunContextLogger implements Supplier<org.slf4j.Logger> {
             e = this.transform(e);
 
             logEntries(e, logEntry)
-                .forEach(logQueue::emitAsync);
+                .forEach(log -> {
+                    try {
+                        logQueue.emitAsync(log);
+                    } catch (QueueException ex) {
+                        // silently do nothing
+                    }
+                });
         }
     }
 

--- a/core/src/main/java/io/kestra/core/runners/RunnerUtils.java
+++ b/core/src/main/java/io/kestra/core/runners/RunnerUtils.java
@@ -4,6 +4,7 @@ import com.google.common.annotations.VisibleForTesting;
 import io.kestra.core.models.Label;
 import io.kestra.core.models.executions.Execution;
 import io.kestra.core.models.flows.Flow;
+import io.kestra.core.queues.QueueException;
 import io.kestra.core.queues.QueueFactoryInterface;
 import io.kestra.core.queues.QueueInterface;
 import io.kestra.core.repositories.FlowRepositoryInterface;
@@ -22,6 +23,8 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiFunction;
 import java.util.function.Predicate;
 
+import static io.kestra.core.utils.Rethrow.throwRunnable;
+
 @Singleton
 public class RunnerUtils {
     public static final Duration DEFAULT_MAX_WAIT_DURATION = Duration.ofSeconds(15);
@@ -37,27 +40,27 @@ public class RunnerUtils {
 
     private ConditionService conditionService;
 
-    public Execution runOne(String tenantId, String namespace, String flowId) throws TimeoutException {
+    public Execution runOne(String tenantId, String namespace, String flowId) throws TimeoutException, QueueException {
         return this.runOne(tenantId, namespace, flowId, null, null, null, null);
     }
 
-    public Execution runOne(String tenantId, String namespace, String flowId, Integer revision) throws TimeoutException {
+    public Execution runOne(String tenantId, String namespace, String flowId, Integer revision) throws TimeoutException, QueueException {
         return this.runOne(tenantId, namespace, flowId, revision, null, null, null);
     }
 
-    public Execution runOne(String tenantId, String namespace, String flowId, Integer revision, BiFunction<Flow, Execution, Map<String, Object>> inputs) throws TimeoutException {
+    public Execution runOne(String tenantId, String namespace, String flowId, Integer revision, BiFunction<Flow, Execution, Map<String, Object>> inputs) throws TimeoutException, QueueException {
         return this.runOne(tenantId, namespace, flowId, revision, inputs, null, null);
     }
 
-    public Execution runOne(String tenantId, String namespace, String flowId, Duration duration) throws TimeoutException {
+    public Execution runOne(String tenantId, String namespace, String flowId, Duration duration) throws TimeoutException, QueueException {
         return this.runOne(tenantId, namespace, flowId, null, null, duration, null);
     }
 
-    public Execution runOne(String tenantId, String namespace, String flowId, Integer revision, BiFunction<Flow, Execution, Map<String, Object>> inputs, Duration duration) throws TimeoutException {
+    public Execution runOne(String tenantId, String namespace, String flowId, Integer revision, BiFunction<Flow, Execution, Map<String, Object>> inputs, Duration duration) throws TimeoutException, QueueException {
         return this.runOne(tenantId, namespace, flowId, revision, inputs, duration, null);
     }
 
-    public Execution runOne(String tenantId, String namespace, String flowId, Integer revision, BiFunction<Flow, Execution, Map<String, Object>> inputs, Duration duration, List<Label> labels) throws TimeoutException {
+    public Execution runOne(String tenantId, String namespace, String flowId, Integer revision, BiFunction<Flow, Execution, Map<String, Object>> inputs, Duration duration, List<Label> labels) throws TimeoutException, QueueException {
         return this.runOne(
             flowRepository
                 .findById(tenantId, namespace, flowId, revision != null ? Optional.of(revision) : Optional.empty())
@@ -67,31 +70,31 @@ public class RunnerUtils {
             labels);
     }
 
-    public Execution runOne(Flow flow, BiFunction<Flow, Execution, Map<String, Object>> inputs) throws TimeoutException {
+    public Execution runOne(Flow flow, BiFunction<Flow, Execution, Map<String, Object>> inputs) throws TimeoutException, QueueException {
         return this.runOne(flow, inputs, null, null);
     }
 
-    public Execution runOne(Flow flow, BiFunction<Flow, Execution, Map<String, Object>> inputs, Duration duration) throws TimeoutException {
+    public Execution runOne(Flow flow, BiFunction<Flow, Execution, Map<String, Object>> inputs, Duration duration) throws TimeoutException, QueueException {
         return this.runOne(flow, inputs, duration, null);
     }
 
-    public Execution runOne(Flow flow, BiFunction<Flow, Execution, Map<String, Object>> inputs, Duration duration, List<Label> labels) throws TimeoutException {
+    public Execution runOne(Flow flow, BiFunction<Flow, Execution, Map<String, Object>> inputs, Duration duration, List<Label> labels) throws TimeoutException, QueueException {
         if (duration == null) {
             duration = Duration.ofSeconds(15);
         }
 
         Execution execution = Execution.newExecution(flow, inputs, labels);
 
-        return this.awaitExecution(isTerminatedExecution(execution, flow), () -> {
+        return this.awaitExecution(isTerminatedExecution(execution, flow), throwRunnable(() -> {
             this.executionQueue.emit(execution);
-        }, duration);
+        }), duration);
     }
 
-    public Execution runOneUntilPaused(String tenantId, String namespace, String flowId) throws TimeoutException {
+    public Execution runOneUntilPaused(String tenantId, String namespace, String flowId) throws TimeoutException, QueueException {
         return this.runOneUntilPaused(tenantId, namespace, flowId, null, null, null);
     }
 
-    public Execution runOneUntilPaused(String tenantId, String namespace, String flowId, Integer revision, BiFunction<Flow, Execution, Map<String, Object>> inputs, Duration duration) throws TimeoutException {
+    public Execution runOneUntilPaused(String tenantId, String namespace, String flowId, Integer revision, BiFunction<Flow, Execution, Map<String, Object>> inputs, Duration duration) throws TimeoutException, QueueException {
         return this.runOneUntilPaused(
             flowRepository
                 .findById(tenantId, namespace, flowId, revision != null ? Optional.of(revision) : Optional.empty())
@@ -101,23 +104,23 @@ public class RunnerUtils {
         );
     }
 
-    public Execution runOneUntilPaused(Flow flow, BiFunction<Flow, Execution, Map<String, Object>> inputs, Duration duration) throws TimeoutException {
+    public Execution runOneUntilPaused(Flow flow, BiFunction<Flow, Execution, Map<String, Object>> inputs, Duration duration) throws TimeoutException, QueueException {
         if (duration == null) {
             duration = DEFAULT_MAX_WAIT_DURATION;
         }
 
         Execution execution = Execution.newExecution(flow, inputs, null);
 
-        return this.awaitExecution(isPausedExecution(execution), () -> {
+        return this.awaitExecution(isPausedExecution(execution), throwRunnable(() -> {
             this.executionQueue.emit(execution);
-        }, duration);
+        }), duration);
     }
 
-    public Execution runOneUntilRunning(String tenantId, String namespace, String flowId) throws TimeoutException {
+    public Execution runOneUntilRunning(String tenantId, String namespace, String flowId) throws TimeoutException, QueueException {
         return this.runOneUntilRunning(tenantId, namespace, flowId, null, null, null);
     }
 
-    public Execution runOneUntilRunning(String tenantId, String namespace, String flowId, Integer revision, BiFunction<Flow, Execution, Map<String, Object>> inputs, Duration duration) throws TimeoutException {
+    public Execution runOneUntilRunning(String tenantId, String namespace, String flowId, Integer revision, BiFunction<Flow, Execution, Map<String, Object>> inputs, Duration duration) throws TimeoutException, QueueException {
         return this.runOneUntilRunning(
             flowRepository
                 .findById(tenantId, namespace, flowId, revision != null ? Optional.of(revision) : Optional.empty())
@@ -127,16 +130,16 @@ public class RunnerUtils {
         );
     }
 
-    public Execution runOneUntilRunning(Flow flow, BiFunction<Flow, Execution, Map<String, Object>> inputs, Duration duration) throws TimeoutException {
+    public Execution runOneUntilRunning(Flow flow, BiFunction<Flow, Execution, Map<String, Object>> inputs, Duration duration) throws TimeoutException, QueueException {
         if (duration == null) {
             duration = DEFAULT_MAX_WAIT_DURATION;
         }
 
         Execution execution = Execution.newExecution(flow, inputs, null);
 
-        return this.awaitExecution(isRunningExecution(execution), () -> {
+        return this.awaitExecution(isRunningExecution(execution), throwRunnable(() -> {
             this.executionQueue.emit(execution);
-        }, duration);
+        }), duration);
     }
 
     @VisibleForTesting

--- a/core/src/test/java/io/kestra/core/models/hierarchies/FlowGraphTest.java
+++ b/core/src/test/java/io/kestra/core/models/hierarchies/FlowGraphTest.java
@@ -5,6 +5,7 @@ import io.kestra.core.exceptions.InternalException;
 import io.kestra.core.models.executions.Execution;
 import io.kestra.core.models.flows.Flow;
 import io.kestra.core.models.triggers.Trigger;
+import io.kestra.core.queues.QueueException;
 import io.kestra.core.runners.RunnerUtils;
 import io.kestra.plugin.core.trigger.Schedule;
 import io.kestra.core.repositories.TriggerRepositoryInterface;
@@ -174,7 +175,7 @@ class FlowGraphTest extends AbstractMemoryRunnerTest {
     }
 
     @Test
-    void parallelWithExecution() throws TimeoutException, IllegalVariableEvaluationException {
+    void parallelWithExecution() throws TimeoutException, IllegalVariableEvaluationException, QueueException {
         Execution execution = runnerUtils.runOne(null, "io.kestra.tests", "parallel");
 
         Flow flow = this.parse("flows/valids/parallel.yaml");
@@ -195,7 +196,7 @@ class FlowGraphTest extends AbstractMemoryRunnerTest {
     }
 
     @Test
-    void eachWithExecution() throws TimeoutException, IllegalVariableEvaluationException {
+    void eachWithExecution() throws TimeoutException, IllegalVariableEvaluationException, QueueException {
         Execution execution = runnerUtils.runOne(null, "io.kestra.tests", "each-sequential");
 
         Flow flow = this.parse("flows/valids/each-sequential.yaml");
@@ -269,7 +270,7 @@ class FlowGraphTest extends AbstractMemoryRunnerTest {
     }
 
     @Test
-    void dynamicIdSubflow() throws IllegalVariableEvaluationException, TimeoutException {
+    void dynamicIdSubflow() throws IllegalVariableEvaluationException, TimeoutException, QueueException {
         Flow flow = this.parse("flows/valids/task-flow-dynamic.yaml").toBuilder().revision(1).build();
 
         IllegalArgumentException illegalArgumentException = Assertions.assertThrows(IllegalArgumentException.class, () -> graphService.flowGraph(flow, Collections.singletonList("root.launch")));

--- a/core/src/test/java/io/kestra/core/repositories/AbstractFlowRepositoryTest.java
+++ b/core/src/test/java/io/kestra/core/repositories/AbstractFlowRepositoryTest.java
@@ -9,6 +9,7 @@ import io.kestra.core.models.executions.Execution;
 import io.kestra.core.models.flows.*;
 import io.kestra.core.models.flows.input.StringInput;
 import io.kestra.core.models.triggers.Trigger;
+import io.kestra.core.queues.QueueException;
 import io.kestra.core.queues.QueueFactoryInterface;
 import io.kestra.core.queues.QueueInterface;
 import io.kestra.core.schedulers.AbstractSchedulerTest;
@@ -398,7 +399,7 @@ public abstract class AbstractFlowRepositoryTest {
     }
 
     @Test
-    void removeTrigger() throws TimeoutException {
+    void removeTrigger() throws TimeoutException, QueueException {
         String flowId = IdUtils.create();
 
         Flow flow = Flow.builder()
@@ -436,7 +437,7 @@ public abstract class AbstractFlowRepositoryTest {
 
 
     @Test
-    void removeTriggerDelete() throws TimeoutException {
+    void removeTriggerDelete() throws TimeoutException, QueueException {
         String flowId = IdUtils.create();
 
         Flow flow = Flow.builder()

--- a/core/src/test/java/io/kestra/core/runners/AliasTest.java
+++ b/core/src/test/java/io/kestra/core/runners/AliasTest.java
@@ -2,6 +2,7 @@ package io.kestra.core.runners;
 
 import io.kestra.core.models.executions.Execution;
 import io.kestra.core.models.flows.State;
+import io.kestra.core.queues.QueueException;
 import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.TimeoutException;
@@ -11,7 +12,7 @@ import static org.hamcrest.Matchers.is;
 
 public class AliasTest extends AbstractMemoryRunnerTest {
     @Test
-    void taskAlias() throws TimeoutException {
+    void taskAlias() throws TimeoutException, QueueException {
         Execution execution = runnerUtils.runOne(null, "io.kestra.tests", "alias-task");
 
         assertThat(execution.getState().getCurrent(), is(State.Type.SUCCESS));
@@ -19,7 +20,7 @@ public class AliasTest extends AbstractMemoryRunnerTest {
     }
 
     @Test
-    void triggerAlias() throws TimeoutException {
+    void triggerAlias() throws TimeoutException, QueueException {
         Execution execution = runnerUtils.runOne(null, "io.kestra.tests", "alias-trigger");
 
         assertThat(execution.getState().getCurrent(), is(State.Type.SUCCESS));

--- a/core/src/test/java/io/kestra/core/runners/DeserializationIssuesCaseTest.java
+++ b/core/src/test/java/io/kestra/core/runners/DeserializationIssuesCaseTest.java
@@ -2,6 +2,7 @@ package io.kestra.core.runners;
 
 import io.kestra.core.models.flows.Flow;
 import io.kestra.core.models.flows.State;
+import io.kestra.core.queues.QueueException;
 import io.kestra.core.queues.QueueFactoryInterface;
 import io.kestra.core.queues.QueueInterface;
 import io.kestra.core.services.FlowListenersInterface;
@@ -225,7 +226,7 @@ public class DeserializationIssuesCaseTest {
     public record QueueMessage(Class<?> type, String key, String value) {}
 
 
-    public void workerTaskDeserializationIssue(Consumer<QueueMessage> sendToQueue) throws TimeoutException {
+    public void workerTaskDeserializationIssue(Consumer<QueueMessage> sendToQueue) throws TimeoutException, QueueException {
         AtomicReference<WorkerTaskResult> workerTaskResult = new AtomicReference<>();
         Flux<WorkerTaskResult> receive = TestsUtils.receive(workerTaskResultQueue, either -> {
             if (either != null) {
@@ -246,7 +247,7 @@ public class DeserializationIssuesCaseTest {
         assertThat(workerTaskResult.get().getTaskRun().getState().getCurrent(), is(State.Type.FAILED));
     }
 
-    public void workerTriggerDeserializationIssue(Consumer<QueueMessage> sendToQueue) throws TimeoutException {
+    public void workerTriggerDeserializationIssue(Consumer<QueueMessage> sendToQueue) throws TimeoutException, QueueException{
         AtomicReference<WorkerTriggerResult> workerTriggerResult = new AtomicReference<>();
         Flux<WorkerTriggerResult> receive = TestsUtils.receive(workerTriggerResultQueue, either -> {
             if (either != null) {
@@ -265,7 +266,7 @@ public class DeserializationIssuesCaseTest {
         assertThat(workerTriggerResult.get().getSuccess(), is(Boolean.FALSE));
     }
 
-    public void flowDeserializationIssue(Consumer<QueueMessage> sendToQueue) throws TimeoutException {
+    public void flowDeserializationIssue(Consumer<QueueMessage> sendToQueue) throws TimeoutException, QueueException{
         AtomicReference<List<Flow>> flows = new AtomicReference<>();
         flowListeners.listen(newFlows -> flows.set(newFlows));
 

--- a/core/src/test/java/io/kestra/core/runners/DisabledTest.java
+++ b/core/src/test/java/io/kestra/core/runners/DisabledTest.java
@@ -1,5 +1,6 @@
 package io.kestra.core.runners;
 
+import io.kestra.core.queues.QueueException;
 import org.junit.jupiter.api.Test;
 import io.kestra.core.models.executions.Execution;
 
@@ -10,21 +11,21 @@ import static org.hamcrest.Matchers.hasSize;
 
 public class DisabledTest extends AbstractMemoryRunnerTest {
     @Test
-    void simple() throws TimeoutException {
+    void simple() throws TimeoutException, QueueException {
         Execution execution = runnerUtils.runOne(null, "io.kestra.tests", "disable-simple");
 
         assertThat(execution.getTaskRunList(), hasSize(2));
     }
 
     @Test
-    void error() throws TimeoutException {
+    void error() throws TimeoutException, QueueException {
         Execution execution = runnerUtils.runOne(null, "io.kestra.tests", "disable-error");
 
         assertThat(execution.getTaskRunList(), hasSize(3));
     }
 
     @Test
-    void flowable() throws TimeoutException {
+    void flowable() throws TimeoutException, QueueException {
         Execution execution = runnerUtils.runOne(null, "io.kestra.tests", "disable-flowable");
 
         assertThat(execution.getTaskRunList(), hasSize(10));

--- a/core/src/test/java/io/kestra/core/runners/EmptyVariablesTest.java
+++ b/core/src/test/java/io/kestra/core/runners/EmptyVariablesTest.java
@@ -2,6 +2,7 @@ package io.kestra.core.runners;
 
 import io.kestra.core.models.executions.Execution;
 import io.kestra.core.models.flows.State;
+import io.kestra.core.queues.QueueException;
 import jakarta.inject.Inject;
 import org.junit.jupiter.api.Test;
 
@@ -17,7 +18,7 @@ public class EmptyVariablesTest extends AbstractMemoryRunnerTest {
     private FlowInputOutput flowIO;
 
     @Test
-    void emptyVariables() throws TimeoutException {
+    void emptyVariables() throws TimeoutException, QueueException {
         Execution execution = runnerUtils.runOne(
             null,
             "io.kestra.tests",

--- a/core/src/test/java/io/kestra/core/runners/ExecutionServiceTest.java
+++ b/core/src/test/java/io/kestra/core/runners/ExecutionServiceTest.java
@@ -4,6 +4,7 @@ import com.google.common.collect.ImmutableMap;
 import io.kestra.core.models.executions.Execution;
 import io.kestra.core.models.flows.Flow;
 import io.kestra.core.models.flows.State;
+import io.kestra.core.queues.QueueException;
 import io.kestra.core.repositories.ExecutionRepositoryInterface;
 import io.kestra.core.repositories.FlowRepositoryInterface;
 import io.kestra.core.repositories.LogRepositoryInterface;
@@ -328,7 +329,7 @@ class ExecutionServiceTest extends AbstractMemoryRunnerTest {
     }
 
     @Test
-    void deleteExecution() throws TimeoutException, IOException {
+    void deleteExecution() throws TimeoutException, QueueException, IOException {
         Execution execution = runnerUtils.runOne(null, "io.kestra.tests", "logs");
         assertThat(execution.getState().getCurrent(), is(State.Type.SUCCESS));
 
@@ -339,7 +340,7 @@ class ExecutionServiceTest extends AbstractMemoryRunnerTest {
     }
 
     @Test
-    void deleteExecutionKeepLogs() throws TimeoutException, IOException {
+    void deleteExecutionKeepLogs() throws TimeoutException, QueueException, IOException {
         Execution execution = runnerUtils.runOne(null, "io.kestra.tests", "logs");
         assertThat(execution.getState().getCurrent(), is(State.Type.SUCCESS));
 

--- a/core/src/test/java/io/kestra/core/runners/FlowConcurrencyCaseTest.java
+++ b/core/src/test/java/io/kestra/core/runners/FlowConcurrencyCaseTest.java
@@ -3,6 +3,7 @@ package io.kestra.core.runners;
 import io.kestra.core.models.executions.Execution;
 import io.kestra.core.models.flows.Flow;
 import io.kestra.core.models.flows.State;
+import io.kestra.core.queues.QueueException;
 import io.kestra.core.queues.QueueFactoryInterface;
 import io.kestra.core.queues.QueueInterface;
 import io.kestra.core.repositories.FlowRepositoryInterface;
@@ -34,7 +35,7 @@ public class FlowConcurrencyCaseTest {
     @Named(QueueFactoryInterface.EXECUTION_NAMED)
     protected QueueInterface<Execution> executionQueue;
 
-    public void flowConcurrencyCancel() throws TimeoutException, InterruptedException {
+    public void flowConcurrencyCancel() throws TimeoutException, QueueException, InterruptedException {
         Execution execution1 = runnerUtils.runOneUntilRunning(null, "io.kestra.tests", "flow-concurrency-cancel", null, null, Duration.ofSeconds(30));
         Execution execution2 = runnerUtils.runOne(null, "io.kestra.tests", "flow-concurrency-cancel");
 
@@ -58,7 +59,7 @@ public class FlowConcurrencyCaseTest {
         assertThat(receive.blockLast().getState().getCurrent(), is(State.Type.SUCCESS));
     }
 
-    public void flowConcurrencyFail() throws TimeoutException, InterruptedException {
+    public void flowConcurrencyFail() throws TimeoutException, QueueException, InterruptedException {
         Execution execution1 = runnerUtils.runOneUntilRunning(null, "io.kestra.tests", "flow-concurrency-fail", null, null, Duration.ofSeconds(30));
         Execution execution2 = runnerUtils.runOne(null, "io.kestra.tests", "flow-concurrency-fail");
 
@@ -82,7 +83,7 @@ public class FlowConcurrencyCaseTest {
         assertThat(receive.blockLast().getState().getCurrent(), is(State.Type.SUCCESS));
     }
 
-    public void flowConcurrencyQueue() throws TimeoutException, InterruptedException {
+    public void flowConcurrencyQueue() throws TimeoutException, QueueException, InterruptedException {
         Execution execution1 = runnerUtils.runOneUntilRunning(null, "io.kestra.tests", "flow-concurrency-queue", null, null, Duration.ofSeconds(30));
         Flow flow = flowRepository
             .findById(null, "io.kestra.tests", "flow-concurrency-queue", Optional.empty())
@@ -131,7 +132,7 @@ public class FlowConcurrencyCaseTest {
         assertThat(executionResult2.get().getState().getHistories().get(2).getState(), is(State.Type.RUNNING));
     }
 
-    public void flowConcurrencyQueuePause() throws TimeoutException, InterruptedException {
+    public void flowConcurrencyQueuePause() throws TimeoutException, QueueException, InterruptedException {
         Execution execution1 = runnerUtils.runOneUntilRunning(null, "io.kestra.tests", "flow-concurrency-queue-pause", null, null, Duration.ofSeconds(30));
         Flow flow = flowRepository
             .findById(null, "io.kestra.tests", "flow-concurrency-queue-pause", Optional.empty())
@@ -180,7 +181,7 @@ public class FlowConcurrencyCaseTest {
         assertThat(executionResult2.get().getState().getHistories().get(2).getState(), is(State.Type.RUNNING));
     }
 
-    public void flowConcurrencyCancelPause() throws TimeoutException, InterruptedException {
+    public void flowConcurrencyCancelPause() throws TimeoutException, QueueException, InterruptedException {
         Execution execution1 = runnerUtils.runOneUntilRunning(null, "io.kestra.tests", "flow-concurrency-cancel-pause", null, null, Duration.ofSeconds(30));
         Flow flow = flowRepository
             .findById(null, "io.kestra.tests", "flow-concurrency-cancel-pause", Optional.empty())

--- a/core/src/test/java/io/kestra/core/runners/FlowTriggerCaseTest.java
+++ b/core/src/test/java/io/kestra/core/runners/FlowTriggerCaseTest.java
@@ -3,6 +3,7 @@ package io.kestra.core.runners;
 import io.kestra.core.models.executions.Execution;
 import io.kestra.core.models.executions.LogEntry;
 import io.kestra.core.models.flows.State;
+import io.kestra.core.queues.QueueException;
 import io.kestra.core.queues.QueueFactoryInterface;
 import io.kestra.core.queues.QueueInterface;
 import io.kestra.core.utils.TestsUtils;
@@ -34,7 +35,7 @@ public class FlowTriggerCaseTest {
     @Inject
     protected RunnerUtils runnerUtils;
 
-    public void trigger() throws InterruptedException, TimeoutException {
+    public void trigger() throws InterruptedException, TimeoutException, QueueException {
         CountDownLatch countDownLatch = new CountDownLatch(3);
         AtomicReference<Execution> flowListener = new AtomicReference<>();
         AtomicReference<Execution> flowListenerNoInput = new AtomicReference<>();

--- a/core/src/test/java/io/kestra/core/runners/InputsTest.java
+++ b/core/src/test/java/io/kestra/core/runners/InputsTest.java
@@ -5,6 +5,7 @@ import com.google.common.io.CharStreams;
 import io.kestra.core.models.executions.Execution;
 import io.kestra.core.models.flows.Flow;
 import io.kestra.core.models.flows.State;
+import io.kestra.core.queues.QueueException;
 import io.kestra.core.repositories.FlowRepositoryInterface;
 import io.kestra.core.storages.StorageInterface;
 import jakarta.inject.Inject;
@@ -160,7 +161,7 @@ public class InputsTest extends AbstractMemoryRunnerTest {
     }
 
     @Test
-    void inputFlow() throws TimeoutException {
+    void inputFlow() throws TimeoutException, QueueException {
         Execution execution = runnerUtils.runOne(
             null,
             "io.kestra.tests",
@@ -329,7 +330,7 @@ public class InputsTest extends AbstractMemoryRunnerTest {
     }
 
     @Test
-    void inputEmptyJsonFlow() throws TimeoutException {
+    void inputEmptyJsonFlow() throws TimeoutException, QueueException {
         HashMap<String, Object> map = new HashMap<>(inputs);
         map.put("json", "{}");
 

--- a/core/src/test/java/io/kestra/core/runners/ListenersTest.java
+++ b/core/src/test/java/io/kestra/core/runners/ListenersTest.java
@@ -1,6 +1,7 @@
 package io.kestra.core.runners;
 
 import com.google.common.collect.ImmutableMap;
+import io.kestra.core.queues.QueueException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import io.kestra.core.models.executions.Execution;
@@ -26,7 +27,7 @@ public class ListenersTest extends AbstractMemoryRunnerTest {
     }
 
     @Test
-    void success() throws TimeoutException {
+    void success() throws TimeoutException, QueueException {
         Execution execution = runnerUtils.runOne(
             null,
             "io.kestra.tests",
@@ -41,7 +42,7 @@ public class ListenersTest extends AbstractMemoryRunnerTest {
     }
 
     @Test
-    void failed() throws TimeoutException {
+    void failed() throws TimeoutException, QueueException {
         Execution execution = runnerUtils.runOne(
             null,
             "io.kestra.tests",
@@ -56,7 +57,7 @@ public class ListenersTest extends AbstractMemoryRunnerTest {
     }
 
     @Test
-    void flowableExecution() throws TimeoutException {
+    void flowableExecution() throws TimeoutException, QueueException{
         Execution execution = runnerUtils.runOne(
             null,
             "io.kestra.tests",
@@ -72,7 +73,7 @@ public class ListenersTest extends AbstractMemoryRunnerTest {
     }
 
     @Test
-    void multipleListeners() throws TimeoutException {
+    void multipleListeners() throws TimeoutException, QueueException {
         Execution execution = runnerUtils.runOne(
             null,
             "io.kestra.tests",
@@ -85,7 +86,7 @@ public class ListenersTest extends AbstractMemoryRunnerTest {
     }
 
     @Test
-    void failedListeners() throws TimeoutException {
+    void failedListeners() throws TimeoutException, QueueException {
         Execution execution = runnerUtils.runOne(
             null,
             "io.kestra.tests",
@@ -99,7 +100,7 @@ public class ListenersTest extends AbstractMemoryRunnerTest {
     }
 
     @Test
-    void failedMultipleListeners() throws TimeoutException {
+    void failedMultipleListeners() throws TimeoutException, QueueException{
         Execution execution = runnerUtils.runOne(
             null,
             "io.kestra.tests",

--- a/core/src/test/java/io/kestra/core/runners/MultipleConditionTriggerCaseTest.java
+++ b/core/src/test/java/io/kestra/core/runners/MultipleConditionTriggerCaseTest.java
@@ -1,5 +1,6 @@
 package io.kestra.core.runners;
 
+import io.kestra.core.queues.QueueException;
 import io.kestra.core.utils.TestsUtils;
 import io.micronaut.context.ApplicationContext;
 import io.kestra.core.models.executions.Execution;
@@ -39,7 +40,7 @@ public class MultipleConditionTriggerCaseTest {
     @Inject
     protected ApplicationContext applicationContext;
 
-    public void trigger() throws InterruptedException, TimeoutException {
+    public void trigger() throws InterruptedException, TimeoutException, QueueException {
         CountDownLatch countDownLatch = new CountDownLatch(3);
         ConcurrentHashMap<String, Execution> ended = new ConcurrentHashMap<>();
         Flow flow = flowRepository.findById(null, "io.kestra.tests.trigger", "trigger-multiplecondition-listener").orElseThrow();
@@ -90,7 +91,7 @@ public class MultipleConditionTriggerCaseTest {
         assertThat(triggerExecution.getTrigger().getVariables().get("flowId"), is("trigger-multiplecondition-flow-b"));
     }
 
-    public void failed() throws InterruptedException, TimeoutException {
+    public void failed() throws InterruptedException, TimeoutException, QueueException {
         CountDownLatch countDownLatch = new CountDownLatch(2);
         ConcurrentHashMap<String, Execution> ended = new ConcurrentHashMap<>();
 

--- a/core/src/test/java/io/kestra/core/runners/NoEncryptionConfiguredTest.java
+++ b/core/src/test/java/io/kestra/core/runners/NoEncryptionConfiguredTest.java
@@ -5,6 +5,7 @@ import io.kestra.core.models.executions.TaskRun;
 import io.kestra.core.models.flows.Flow;
 import io.kestra.core.models.flows.State;
 import io.kestra.core.models.tasks.common.EncryptedString;
+import io.kestra.core.queues.QueueException;
 import io.kestra.core.repositories.FlowRepositoryInterface;
 import io.micronaut.core.annotation.NonNull;
 import io.kestra.core.junit.annotations.KestraTest;
@@ -42,7 +43,7 @@ public class NoEncryptionConfiguredTest extends AbstractMemoryRunnerTest impleme
 
     @SuppressWarnings("unchecked")
     @Test
-    void encryptedStringOutput() throws TimeoutException {
+    void encryptedStringOutput() throws TimeoutException, QueueException {
         Execution execution = runnerUtils.runOne(null, "io.kestra.tests", "encrypted-string");
 
         assertThat(execution.getState().getCurrent(), is(State.Type.SUCCESS));

--- a/core/src/test/java/io/kestra/core/runners/PluginDefaultsCaseTest.java
+++ b/core/src/test/java/io/kestra/core/runners/PluginDefaultsCaseTest.java
@@ -9,6 +9,7 @@ import io.kestra.core.models.hierarchies.RelationType;
 import io.kestra.core.models.tasks.FlowableTask;
 import io.kestra.core.models.tasks.ResolvedTask;
 import io.kestra.core.models.tasks.Task;
+import io.kestra.core.queues.QueueException;
 import io.kestra.core.utils.GraphUtils;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
@@ -35,7 +36,7 @@ public class PluginDefaultsCaseTest {
     @Inject
     private RunnerUtils runnerUtils;
 
-    public void taskDefaults() throws TimeoutException {
+    public void taskDefaults() throws TimeoutException, QueueException {
         Execution execution = runnerUtils.runOne(null, "io.kestra.tests", "plugin-defaults", Duration.ofSeconds(60));
 
         assertThat(execution.getTaskRunList(), hasSize(8));

--- a/core/src/test/java/io/kestra/core/runners/RestartCaseTest.java
+++ b/core/src/test/java/io/kestra/core/runners/RestartCaseTest.java
@@ -190,7 +190,7 @@ public class RestartCaseTest {
 
         Execution restartEnded = runnerUtils.awaitExecution(
             e -> e.getState().getCurrent() == State.Type.FAILED,
-            () -> executionQueue.emit(restart),
+            throwRunnable(() -> executionQueue.emit(restart)),
             Duration.ofSeconds(120)
         );
 
@@ -200,7 +200,7 @@ public class RestartCaseTest {
 
         restartEnded = runnerUtils.awaitExecution(
             e -> e.getState().getCurrent() == State.Type.FAILED,
-            () -> executionQueue.emit(newRestart),
+            throwRunnable(() -> executionQueue.emit(newRestart)),
             Duration.ofSeconds(120)
         );
 

--- a/core/src/test/java/io/kestra/core/runners/RunContextTest.java
+++ b/core/src/test/java/io/kestra/core/runners/RunContextTest.java
@@ -20,6 +20,7 @@ import io.kestra.core.models.triggers.AbstractTrigger;
 import io.kestra.core.models.triggers.PollingTriggerInterface;
 import io.kestra.core.models.triggers.Trigger;
 import io.kestra.core.models.triggers.TriggerContext;
+import io.kestra.core.queues.QueueException;
 import io.kestra.core.queues.QueueFactoryInterface;
 import io.kestra.core.queues.QueueInterface;
 import io.kestra.core.storages.StorageInterface;
@@ -93,7 +94,7 @@ class RunContextTest extends AbstractMemoryRunnerTest {
     private FlowInputOutput flowIO;
 
     @Test
-    void logs() throws TimeoutException {
+    void logs() throws TimeoutException, QueueException {
         List<LogEntry> logs = new CopyOnWriteArrayList<>();
         LogEntry matchingLog;
         Flux<LogEntry> receive = TestsUtils.receive(workerTaskLogQueue, either -> logs.add(either.getLeft()));
@@ -123,7 +124,7 @@ class RunContextTest extends AbstractMemoryRunnerTest {
     }
 
     @Test
-    void inputsLarge() throws TimeoutException {
+    void inputsLarge() throws TimeoutException, QueueException {
         List<LogEntry> logs = new CopyOnWriteArrayList<>();
         Flux<LogEntry> receive = TestsUtils.receive(workerTaskLogQueue, either -> logs.add(either.getLeft()));
 
@@ -153,7 +154,7 @@ class RunContextTest extends AbstractMemoryRunnerTest {
     }
 
     @Test
-    void variables() throws TimeoutException {
+    void variables() throws TimeoutException, QueueException {
         Execution execution = runnerUtils.runOne(null, "io.kestra.tests", "return");
 
         assertThat(execution.getTaskRunList(), hasSize(3));
@@ -167,7 +168,7 @@ class RunContextTest extends AbstractMemoryRunnerTest {
     }
 
     @Test
-    void taskDefaults() throws TimeoutException, IOException, URISyntaxException {
+    void taskDefaults() throws TimeoutException, QueueException, IOException, URISyntaxException {
         repositoryLoader.load(Objects.requireNonNull(ListenersTest.class.getClassLoader().getResource("flows/tests/plugin-defaults.yaml")));
         pluginDefaultsCaseTest.taskDefaults();
     }
@@ -229,7 +230,7 @@ class RunContextTest extends AbstractMemoryRunnerTest {
 
     @SuppressWarnings("unchecked")
     @Test
-    void encryptedStringOutput() throws TimeoutException {
+    void encryptedStringOutput() throws TimeoutException, QueueException {
         Execution execution = runnerUtils.runOne(null, "io.kestra.tests", "encrypted-string");
 
         assertThat(execution.getState().getCurrent(), is(State.Type.SUCCESS));

--- a/core/src/test/java/io/kestra/core/runners/SkipExecutionCaseTest.java
+++ b/core/src/test/java/io/kestra/core/runners/SkipExecutionCaseTest.java
@@ -3,6 +3,7 @@ package io.kestra.core.runners;
 import io.kestra.core.models.executions.Execution;
 import io.kestra.core.models.flows.Flow;
 import io.kestra.core.models.flows.State;
+import io.kestra.core.queues.QueueException;
 import io.kestra.core.queues.QueueFactoryInterface;
 import io.kestra.core.queues.QueueInterface;
 import io.kestra.core.repositories.ExecutionRepositoryInterface;
@@ -35,7 +36,7 @@ public class SkipExecutionCaseTest {
     @Inject
     private SkipExecutionService skipExecutionService;
 
-    public void skipExecution() throws TimeoutException, InterruptedException {
+    public void skipExecution() throws TimeoutException, QueueException, InterruptedException {
         Flow flow = createFlow();
         Execution execution1 = Execution.newExecution(flow, null, null);
         String execution1Id = execution1.getId();

--- a/core/src/test/java/io/kestra/core/runners/TaskWithAllowFailureTest.java
+++ b/core/src/test/java/io/kestra/core/runners/TaskWithAllowFailureTest.java
@@ -2,6 +2,7 @@ package io.kestra.core.runners;
 
 import io.kestra.core.models.executions.Execution;
 import io.kestra.core.models.flows.State;
+import io.kestra.core.queues.QueueException;
 import io.kestra.core.storages.StorageInterface;
 import jakarta.inject.Inject;
 import org.apache.commons.lang3.StringUtils;
@@ -31,7 +32,7 @@ public class TaskWithAllowFailureTest extends AbstractMemoryRunnerTest {
     private FlowInputOutput flowIO;
 
     @Test
-    void runnableTask() throws TimeoutException {
+    void runnableTask() throws TimeoutException, QueueException {
         Execution execution = runnerUtils.runOne(null, "io.kestra.tests", "task-allow-failure-runnable");
 
         assertThat(execution.getState().getCurrent(), is(State.Type.WARNING));
@@ -40,7 +41,7 @@ public class TaskWithAllowFailureTest extends AbstractMemoryRunnerTest {
     }
 
     @Test
-    void executableTask_Flow() throws TimeoutException {
+    void executableTask_Flow() throws TimeoutException, QueueException {
         Execution execution = runnerUtils.runOne(null, "io.kestra.tests", "task-allow-failure-executable-flow");
 
         assertThat(execution.getState().getCurrent(), is(State.Type.WARNING));
@@ -48,7 +49,7 @@ public class TaskWithAllowFailureTest extends AbstractMemoryRunnerTest {
     }
 
     @Test
-    void executableTask_ForEachItem() throws TimeoutException, URISyntaxException, IOException {
+    void executableTask_ForEachItem() throws TimeoutException, QueueException, URISyntaxException, IOException {
         URI file = storageUpload();
         Map<String, Object> inputs = Map.of("file", file.toString());
         Execution execution = runnerUtils.runOne(null, "io.kestra.tests", "task-allow-failure-executable-foreachitem", null, (flow, execution1) -> flowIO.typedInputs(flow, execution1, inputs));
@@ -58,7 +59,7 @@ public class TaskWithAllowFailureTest extends AbstractMemoryRunnerTest {
     }
 
     @Test
-    void flowableTask() throws TimeoutException {
+    void flowableTask() throws TimeoutException, QueueException {
         Execution execution = runnerUtils.runOne(null, "io.kestra.tests", "task-allow-failure-flowable");
 
         assertThat(execution.getState().getCurrent(), is(State.Type.WARNING));

--- a/core/src/test/java/io/kestra/core/runners/WorkerTest.java
+++ b/core/src/test/java/io/kestra/core/runners/WorkerTest.java
@@ -6,6 +6,7 @@ import io.kestra.core.models.executions.*;
 import io.kestra.core.models.flows.Flow;
 import io.kestra.core.models.flows.State;
 import io.kestra.core.models.tasks.ResolvedTask;
+import io.kestra.core.queues.QueueException;
 import io.kestra.core.queues.QueueFactoryInterface;
 import io.kestra.core.queues.QueueInterface;
 import io.kestra.core.serializers.JacksonMapper;
@@ -60,7 +61,7 @@ class WorkerTest {
     RunContextFactory runContextFactory;
 
     @Test
-    void success() throws TimeoutException {
+    void success() throws TimeoutException, QueueException {
         Worker worker = applicationContext.createBean(Worker.class, IdUtils.create(), 8, null);
         worker.run();
 
@@ -87,7 +88,7 @@ class WorkerTest {
     }
 
     @Test
-    void failOnWorkerTaskWithFlowable() throws TimeoutException, JsonProcessingException {
+    void failOnWorkerTaskWithFlowable() throws TimeoutException, QueueException, JsonProcessingException {
         Worker worker = applicationContext.createBean(Worker.class, IdUtils.create(), 8, null);
         worker.run();
 
@@ -140,7 +141,7 @@ class WorkerTest {
     }
 
     @Test
-    void killed() throws InterruptedException, TimeoutException {
+    void killed() throws InterruptedException, TimeoutException, QueueException {
         Flux<LogEntry> receiveLogs = TestsUtils.receive(workerTaskLogQueue);
 
         Worker worker = applicationContext.createBean(Worker.class, IdUtils.create(), 8, null);

--- a/core/src/test/java/io/kestra/core/runners/pebble/functions/KvFunctionTest.java
+++ b/core/src/test/java/io/kestra/core/runners/pebble/functions/KvFunctionTest.java
@@ -5,6 +5,7 @@ import io.kestra.core.models.executions.Execution;
 import io.kestra.core.models.executions.LogEntry;
 import io.kestra.core.models.executions.TaskRun;
 import io.kestra.core.models.flows.State;
+import io.kestra.core.queues.QueueException;
 import io.kestra.core.queues.QueueInterface;
 import io.kestra.core.runners.AbstractMemoryRunnerTest;
 import io.kestra.core.runners.RunnerUtils;
@@ -44,7 +45,7 @@ public class KvFunctionTest extends AbstractMemoryRunnerTest {
     }
 
     @Test
-    void get() throws TimeoutException, IOException {
+    void get() throws TimeoutException, IOException, QueueException {
         KVStore kv = new InternalKVStore(null, "io.kestra.tests", storageInterface);
         kv.put("my-key", new KVValueAndMetadata(null, Map.of("field", "value")));
 
@@ -54,7 +55,7 @@ public class KvFunctionTest extends AbstractMemoryRunnerTest {
     }
 
     @Test
-    void getKeyNotFound() throws TimeoutException {
+    void getKeyNotFound() throws TimeoutException, QueueException {
         Flux<LogEntry> receive = TestsUtils.receive(logQueue);
 
         Execution execution = runnerUtils.runOne(null, "io.kestra.tests", "kv", null, (flow, exec) -> Map.of("errorOnMissing", true));

--- a/core/src/test/java/io/kestra/core/runners/test/WorkerTaskResultTooLarge.java
+++ b/core/src/test/java/io/kestra/core/runners/test/WorkerTaskResultTooLarge.java
@@ -1,0 +1,33 @@
+package io.kestra.core.runners.test;
+
+import io.kestra.core.models.annotations.Plugin;
+import io.kestra.core.models.tasks.RunnableTask;
+import io.kestra.core.models.tasks.Task;
+import io.kestra.core.runners.RunContext;
+import lombok.*;
+import lombok.experimental.SuperBuilder;
+
+import java.util.Arrays;
+
+@SuperBuilder
+@ToString
+@EqualsAndHashCode
+@Getter
+@NoArgsConstructor
+@Plugin
+public class WorkerTaskResultTooLarge extends Task implements RunnableTask<WorkerTaskResultTooLarge.Output> {
+
+    @Override
+    public Output run(RunContext runContext) throws Exception {
+        char[] chars = new char[1100000];
+        Arrays.fill(chars, 'a');
+
+        return Output.builder().value(new String(chars)).build();
+    }
+
+    @Builder
+    @Getter
+    public static class Output implements io.kestra.core.models.tasks.Output {
+        public String value;
+    }
+}

--- a/core/src/test/java/io/kestra/core/schedulers/SchedulerConditionTest.java
+++ b/core/src/test/java/io/kestra/core/schedulers/SchedulerConditionTest.java
@@ -21,6 +21,7 @@ import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
+import static io.kestra.core.utils.Rethrow.throwConsumer;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.Mockito.doReturn;
@@ -80,7 +81,7 @@ class SchedulerConditionTest extends AbstractSchedulerTest {
             flowListenersServiceSpy
         )) {
             // wait for execution
-            Flux<Execution> receive = TestsUtils.receive(executionQueue, either -> {
+            Flux<Execution> receive = TestsUtils.receive(executionQueue, throwConsumer(either -> {
                 Execution execution = either.getLeft();
                 if (execution.getState().getCurrent() == State.Type.CREATED) {
                     executionQueue.emit(execution.withState(State.Type.SUCCESS));
@@ -91,7 +92,7 @@ class SchedulerConditionTest extends AbstractSchedulerTest {
                     }
                 }
                 assertThat(execution.getFlowId(), is(flow.getId()));
-            });
+            }));
 
             scheduler.run();
             queueCount.await(30, TimeUnit.SECONDS);

--- a/core/src/test/java/io/kestra/core/schedulers/SchedulerPollingTriggerTest.java
+++ b/core/src/test/java/io/kestra/core/schedulers/SchedulerPollingTriggerTest.java
@@ -27,6 +27,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
+import static io.kestra.core.utils.Rethrow.throwConsumer;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 import static org.mockito.Mockito.doReturn;
@@ -100,7 +101,7 @@ public class SchedulerPollingTriggerTest extends AbstractSchedulerTest {
         ) {
             AtomicReference<Execution> last = new AtomicReference<>();
 
-            Flux<Execution> receive = TestsUtils.receive(executionQueue, execution -> {
+            Flux<Execution> receive = TestsUtils.receive(executionQueue, throwConsumer(execution -> {
                 if (execution.getLeft().getFlowId().equals(flow.getId())) {
                     last.set(execution.getLeft());
                     queueCount.countDown();
@@ -109,7 +110,7 @@ public class SchedulerPollingTriggerTest extends AbstractSchedulerTest {
                         executionQueue.emit(execution.getLeft().withState(State.Type.FAILED));
                     }
                 }
-            });
+            }));
 
             worker.run();
             scheduler.run();

--- a/core/src/test/java/io/kestra/core/schedulers/SchedulerScheduleTest.java
+++ b/core/src/test/java/io/kestra/core/schedulers/SchedulerScheduleTest.java
@@ -26,6 +26,7 @@ import java.util.*;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
+import static io.kestra.core.utils.Rethrow.throwConsumer;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 import static org.mockito.Mockito.doReturn;
@@ -113,7 +114,7 @@ public class SchedulerScheduleTest extends AbstractSchedulerTest {
         // scheduler
         try (AbstractScheduler scheduler = scheduler(flowListenersServiceSpy)) {
             // wait for execution
-            Flux<Execution> receiveExecutions = TestsUtils.receive(executionQueue, either -> {
+            Flux<Execution> receiveExecutions = TestsUtils.receive(executionQueue, throwConsumer(either -> {
                 Execution execution = either.getLeft();
                 assertThat(execution.getInputs().get("testInputs"), is("test-inputs"));
                 assertThat(execution.getInputs().get("def"), is("awesome"));
@@ -126,7 +127,7 @@ public class SchedulerScheduleTest extends AbstractSchedulerTest {
                     executionQueue.emit(execution.withState(State.Type.SUCCESS));
                 }
                 assertThat(execution.getFlowId(), is(flow.getId()));
-            });
+            }));
 
             Flux<LogEntry> receiveLogs = TestsUtils.receive(logQueue, e -> {
                 if (e.getLeft().getMessage().contains("Unknown time-zone ID: Asia/Delhi")) {
@@ -430,7 +431,7 @@ public class SchedulerScheduleTest extends AbstractSchedulerTest {
         // scheduler
         try (AbstractScheduler scheduler = scheduler(flowListenersServiceSpy)) {
             // wait for execution
-            Flux<Execution> receive = TestsUtils.receive(executionQueue, either -> {
+            Flux<Execution> receive = TestsUtils.receive(executionQueue, throwConsumer(either -> {
                 Execution execution = either.getLeft();
                 assertThat(execution.getInputs().get("testInputs"), is("test-inputs"));
                 assertThat(execution.getInputs().get("def"), is("awesome"));
@@ -440,7 +441,7 @@ public class SchedulerScheduleTest extends AbstractSchedulerTest {
                 if (execution.getState().getCurrent() == State.Type.CREATED) {
                     executionQueue.emit(execution.withState(State.Type.SUCCESS));
                 }
-            });
+            }));
 
             scheduler.run();
 

--- a/core/src/test/java/io/kestra/core/schedulers/SchedulerThreadTest.java
+++ b/core/src/test/java/io/kestra/core/schedulers/SchedulerThreadTest.java
@@ -22,6 +22,7 @@ import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
+import static io.kestra.core.utils.Rethrow.throwConsumer;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 import static org.mockito.Mockito.doReturn;
@@ -40,7 +41,7 @@ public class SchedulerThreadTest extends AbstractSchedulerTest {
         CountDownLatch queueCount = new CountDownLatch(2);
 
         // wait for execution
-        Flux<Execution> receive = TestsUtils.receive(executionQueue, either -> {
+        Flux<Execution> receive = TestsUtils.receive(executionQueue, throwConsumer(either -> {
             Execution execution = either.getLeft();
 
             assertThat(execution.getFlowId(), is(flow.getId()));
@@ -49,7 +50,7 @@ public class SchedulerThreadTest extends AbstractSchedulerTest {
                 executionQueue.emit(execution.withState(State.Type.SUCCESS));
                 queueCount.countDown();
             }
-        });
+        }));
 
         // mock flow listeners
         FlowListeners flowListenersServiceSpy = spy(this.flowListenersService);

--- a/core/src/test/java/io/kestra/core/secret/SecretFunctionTest.java
+++ b/core/src/test/java/io/kestra/core/secret/SecretFunctionTest.java
@@ -3,6 +3,7 @@ package io.kestra.core.secret;
 import io.kestra.core.exceptions.IllegalVariableEvaluationException;
 import io.kestra.core.models.executions.Execution;
 import io.kestra.core.models.executions.LogEntry;
+import io.kestra.core.queues.QueueException;
 import io.kestra.core.queues.QueueFactoryInterface;
 import io.kestra.core.queues.QueueInterface;
 import io.kestra.core.runners.AbstractMemoryRunnerTest;
@@ -38,7 +39,7 @@ public class SecretFunctionTest extends AbstractMemoryRunnerTest {
     @Test
     @EnabledIfEnvironmentVariable(named = "SECRET_MY_SECRET", matches = ".*")
     @EnabledIfEnvironmentVariable(named = "SECRET_NEW_LINE", matches = ".*")
-    void getSecret() throws TimeoutException {
+    void getSecret() throws TimeoutException, QueueException {
         List<LogEntry> logs = new CopyOnWriteArrayList<>();
         Flux<LogEntry> receive = TestsUtils.receive(logQueue, either -> logs.add(either.getLeft()));
 

--- a/core/src/test/java/io/kestra/plugin/core/execution/FailTest.java
+++ b/core/src/test/java/io/kestra/plugin/core/execution/FailTest.java
@@ -2,6 +2,7 @@ package io.kestra.plugin.core.execution;
 
 import io.kestra.core.models.executions.Execution;
 import io.kestra.core.models.flows.State;
+import io.kestra.core.queues.QueueException;
 import io.kestra.core.runners.AbstractMemoryRunnerTest;
 import org.junit.jupiter.api.Test;
 
@@ -15,7 +16,7 @@ import static org.hamcrest.Matchers.is;
 
 public class FailTest extends AbstractMemoryRunnerTest {
     @Test
-    void failOnSwitch() throws TimeoutException {
+    void failOnSwitch() throws TimeoutException, QueueException {
         Execution execution = runnerUtils.runOne(null, "io.kestra.tests", "fail-on-switch", null,
             (f, e) -> Map.of("param", "fail") , Duration.ofSeconds(120));
 
@@ -25,7 +26,7 @@ public class FailTest extends AbstractMemoryRunnerTest {
     }
 
     @Test
-    void failOnCondition() throws TimeoutException {
+    void failOnCondition() throws TimeoutException, QueueException{
         Execution execution = runnerUtils.runOne(null, "io.kestra.tests", "fail-on-condition", null,
             (f, e) -> Map.of("param", "fail") , Duration.ofSeconds(120));
 
@@ -35,7 +36,7 @@ public class FailTest extends AbstractMemoryRunnerTest {
     }
 
     @Test
-    void dontFailOnCondition() throws TimeoutException {
+    void dontFailOnCondition() throws TimeoutException, QueueException{
         Execution execution = runnerUtils.runOne(null, "io.kestra.tests", "fail-on-condition", null,
             (f, e) -> Map.of("param", "success") , Duration.ofSeconds(120));
 

--- a/core/src/test/java/io/kestra/plugin/core/flow/AllowFailureTest.java
+++ b/core/src/test/java/io/kestra/plugin/core/flow/AllowFailureTest.java
@@ -1,6 +1,7 @@
 package io.kestra.plugin.core.flow;
 
 import com.google.common.collect.ImmutableMap;
+import io.kestra.core.queues.QueueException;
 import io.kestra.core.runners.FlowInputOutput;
 import jakarta.inject.Inject;
 import org.junit.jupiter.api.Test;
@@ -20,7 +21,7 @@ class AllowFailureTest extends AbstractMemoryRunnerTest {
     private FlowInputOutput flowIO;
 
     @Test
-    void success() throws TimeoutException {
+    void success() throws TimeoutException, QueueException {
         Execution execution = runnerUtils.runOne(null, "io.kestra.tests", "allow-failure", Duration.ofSeconds(120));
 
         assertThat(execution.getTaskRunList(), hasSize(9));
@@ -31,7 +32,7 @@ class AllowFailureTest extends AbstractMemoryRunnerTest {
     }
 
     @Test
-    void failed() throws TimeoutException {
+    void failed() throws TimeoutException, QueueException {
         Execution execution = runnerUtils.runOne(
             null,
             "io.kestra.tests",

--- a/core/src/test/java/io/kestra/plugin/core/flow/BadExecutableTest.java
+++ b/core/src/test/java/io/kestra/plugin/core/flow/BadExecutableTest.java
@@ -2,6 +2,7 @@ package io.kestra.plugin.core.flow;
 
 import io.kestra.core.models.executions.Execution;
 import io.kestra.core.models.flows.State;
+import io.kestra.core.queues.QueueException;
 import io.kestra.core.runners.AbstractMemoryRunnerTest;
 import org.junit.jupiter.api.Test;
 
@@ -12,7 +13,7 @@ import static org.hamcrest.Matchers.is;
 
 public class BadExecutableTest extends AbstractMemoryRunnerTest {
     @Test
-    void badExecutable() throws TimeoutException {
+    void badExecutable() throws TimeoutException, QueueException {
         Execution execution = runnerUtils.runOne(null, "io.kestra.tests", "executable-fail");
 
         assertThat(execution.getTaskRunList().size(), is(1));

--- a/core/src/test/java/io/kestra/plugin/core/flow/BadFlowableTest.java
+++ b/core/src/test/java/io/kestra/plugin/core/flow/BadFlowableTest.java
@@ -3,6 +3,7 @@ package io.kestra.plugin.core.flow;
 import io.kestra.core.models.executions.Execution;
 import io.kestra.core.models.executions.TaskRun;
 import io.kestra.core.models.flows.State;
+import io.kestra.core.queues.QueueException;
 import io.kestra.core.runners.AbstractMemoryRunnerTest;
 import io.kestra.core.serializers.JacksonMapper;
 import org.junit.jupiter.api.Test;
@@ -16,7 +17,7 @@ import static org.hamcrest.Matchers.*;
 
 public class BadFlowableTest extends AbstractMemoryRunnerTest {
     @Test
-    void sequential() throws TimeoutException {
+    void sequential() throws TimeoutException, QueueException {
         Execution execution = runnerUtils.runOne(null, "io.kestra.tests", "bad-flowable");
 
         assertThat("Task runs were: \n"+ JacksonMapper.log(execution.getTaskRunList()), execution.getTaskRunList().size(), greaterThanOrEqualTo(2));
@@ -24,7 +25,7 @@ public class BadFlowableTest extends AbstractMemoryRunnerTest {
     }
 
     @Test // this test is a non-reg for an infinite loop in the executor
-    void flowableWithParentFail() throws TimeoutException {
+    void flowableWithParentFail() throws TimeoutException, QueueException {
         Execution execution = runnerUtils.runOne(null, "io.kestra.tests", "flowable-with-parent-fail");
 
         assertThat(execution.getTaskRunList(), hasSize(5));

--- a/core/src/test/java/io/kestra/plugin/core/flow/CurrentEachOutputFunctionTest.java
+++ b/core/src/test/java/io/kestra/plugin/core/flow/CurrentEachOutputFunctionTest.java
@@ -1,6 +1,7 @@
 package io.kestra.plugin.core.flow;
 
 import io.kestra.core.models.executions.Execution;
+import io.kestra.core.queues.QueueException;
 import io.kestra.core.runners.AbstractMemoryRunnerTest;
 import org.junit.jupiter.api.Test;
 
@@ -14,7 +15,7 @@ import static org.hamcrest.Matchers.*;
 public class CurrentEachOutputFunctionTest extends AbstractMemoryRunnerTest {
     @SuppressWarnings("unchecked")
     @Test
-    void parallel() throws TimeoutException {
+    void parallel() throws TimeoutException, QueueException {
         Execution execution = runnerUtils.runOne(null, "io.kestra.tests", "test-current-output", Duration.ofSeconds(30));
 
         var output1 = (Map<String, Object>) execution.outputs().get("1-1-1_return");

--- a/core/src/test/java/io/kestra/plugin/core/flow/DagTest.java
+++ b/core/src/test/java/io/kestra/plugin/core/flow/DagTest.java
@@ -4,6 +4,7 @@ import io.kestra.core.models.executions.Execution;
 import io.kestra.core.models.flows.Flow;
 import io.kestra.core.models.flows.State;
 import io.kestra.core.models.validations.ModelValidator;
+import io.kestra.core.queues.QueueException;
 import io.kestra.core.runners.AbstractMemoryRunnerTest;
 import io.kestra.core.serializers.YamlFlowParser;
 import io.kestra.core.utils.TestsUtils;
@@ -28,7 +29,7 @@ public class DagTest extends AbstractMemoryRunnerTest {
     ModelValidator modelValidator;
 
     @Test
-    void dag() throws TimeoutException {
+    void dag() throws TimeoutException, QueueException {
         Execution execution = runnerUtils.runOne(
             null,
             "io.kestra.tests",
@@ -42,7 +43,7 @@ public class DagTest extends AbstractMemoryRunnerTest {
     }
 
     @Test
-    void dagCyclicDependencies() throws TimeoutException {
+    void dagCyclicDependencies() throws TimeoutException, QueueException{
         Flow flow = this.parse("flows/invalids/dag-cyclicdependency.yaml");
         Optional<ConstraintViolationException> validate = modelValidator.isValid(flow);
 
@@ -53,7 +54,7 @@ public class DagTest extends AbstractMemoryRunnerTest {
     }
 
     @Test
-    void dagNotExistTask() throws TimeoutException {
+    void dagNotExistTask() throws TimeoutException, QueueException{
         Flow flow = this.parse("flows/invalids/dag-notexist-task.yaml");
         Optional<ConstraintViolationException> validate = modelValidator.isValid(flow);
 

--- a/core/src/test/java/io/kestra/plugin/core/flow/EachParallelTest.java
+++ b/core/src/test/java/io/kestra/plugin/core/flow/EachParallelTest.java
@@ -15,7 +15,7 @@ import static org.hamcrest.Matchers.is;
 
 public class EachParallelTest extends AbstractMemoryRunnerTest {
     @Test
-    void parallel() throws TimeoutException {
+    void parallel() throws TimeoutException, QueueException {
         Execution execution = runnerUtils.runOne(null, "io.kestra.tests", "each-parallel");
 
         assertThat(execution.getState().getCurrent(), is(State.Type.SUCCESS));
@@ -23,7 +23,7 @@ public class EachParallelTest extends AbstractMemoryRunnerTest {
     }
 
     @Test
-    void parallelNested() throws TimeoutException {
+    void parallelNested() throws TimeoutException, QueueException {
         Execution execution = runnerUtils.runOne(null, "io.kestra.tests", "each-parallel-nested");
 
         assertThat(execution.getState().getCurrent(), is(State.Type.SUCCESS));

--- a/core/src/test/java/io/kestra/plugin/core/flow/EachSequentialTest.java
+++ b/core/src/test/java/io/kestra/plugin/core/flow/EachSequentialTest.java
@@ -1,5 +1,6 @@
 package io.kestra.plugin.core.flow;
 
+import io.kestra.core.queues.QueueException;
 import io.kestra.core.utils.TestsUtils;
 import org.junit.jupiter.api.Test;
 import io.kestra.core.exceptions.InternalException;
@@ -31,7 +32,7 @@ public class EachSequentialTest extends AbstractMemoryRunnerTest {
     QueueInterface<LogEntry> logQueue;
 
     @Test
-    void sequential() throws TimeoutException {
+    void sequential() throws TimeoutException, QueueException {
         Execution execution = runnerUtils.runOne(null, "io.kestra.tests", "each-sequential");
 
         assertThat(execution.getTaskRunList(), hasSize(11));
@@ -39,7 +40,7 @@ public class EachSequentialTest extends AbstractMemoryRunnerTest {
     }
 
     @Test
-    void object() throws TimeoutException {
+    void object() throws TimeoutException, QueueException {
         Execution execution = runnerUtils.runOne(null, "io.kestra.tests", "each-object");
 
         assertThat(execution.getTaskRunList(), hasSize(8));
@@ -48,7 +49,7 @@ public class EachSequentialTest extends AbstractMemoryRunnerTest {
     }
 
     @Test
-    void objectInList() throws TimeoutException {
+    void objectInList() throws TimeoutException, QueueException {
         Execution execution = runnerUtils.runOne(null, "io.kestra.tests", "each-object-in-list");
 
         assertThat(execution.getTaskRunList(), hasSize(8));
@@ -57,7 +58,7 @@ public class EachSequentialTest extends AbstractMemoryRunnerTest {
     }
 
     @Test
-    void sequentialNested() throws TimeoutException, InternalException {
+    void sequentialNested() throws TimeoutException, InternalException, QueueException {
         Execution execution = runnerUtils.runOne(null, "io.kestra.tests", "each-sequential-nested");
 
         assertThat(execution.getTaskRunList(), hasSize(23));
@@ -78,7 +79,7 @@ public class EachSequentialTest extends AbstractMemoryRunnerTest {
     }
 
     @Test
-    void eachEmpty() throws TimeoutException {
+    void eachEmpty() throws TimeoutException, QueueException {
         Execution execution = runnerUtils.runOne(null, "io.kestra.tests", "each-empty");
 
         assertThat(execution.getTaskRunList(), hasSize(2));
@@ -86,11 +87,11 @@ public class EachSequentialTest extends AbstractMemoryRunnerTest {
     }
 
     @Test
-    void eachNull() throws TimeoutException {
+    void eachNull() throws TimeoutException, QueueException {
         EachSequentialTest.eachNullTest(runnerUtils, logQueue);
     }
 
-    public static void eachNullTest(RunnerUtils runnerUtils, QueueInterface<LogEntry> logQueue) throws TimeoutException {
+    public static void eachNullTest(RunnerUtils runnerUtils, QueueInterface<LogEntry> logQueue) throws TimeoutException, QueueException {
         List<LogEntry> logs = new CopyOnWriteArrayList<>();
         Flux<LogEntry> receive = TestsUtils.receive(logQueue, either -> logs.add(either.getLeft()));
 
@@ -104,7 +105,7 @@ public class EachSequentialTest extends AbstractMemoryRunnerTest {
     }
 
     @Test
-    void eachSwitch() throws TimeoutException, InternalException {
+    void eachSwitch() throws TimeoutException, InternalException, QueueException {
         Execution execution = runnerUtils.runOne(null, "io.kestra.tests", "each-switch");
 
         assertThat(execution.getTaskRunList(), hasSize(12));

--- a/core/src/test/java/io/kestra/plugin/core/flow/FlowOutputTest.java
+++ b/core/src/test/java/io/kestra/plugin/core/flow/FlowOutputTest.java
@@ -2,6 +2,7 @@ package io.kestra.plugin.core.flow;
 
 import io.kestra.core.models.executions.Execution;
 import io.kestra.core.models.flows.State;
+import io.kestra.core.queues.QueueException;
 import io.kestra.core.runners.AbstractMemoryRunnerTest;
 import org.junit.jupiter.api.Test;
 
@@ -16,7 +17,7 @@ class FlowOutputTest extends AbstractMemoryRunnerTest {
     static final String NAMESPACE = "io.kestra.tests";
 
     @Test
-    void shouldGetSuccessExecutionForFlowWithOutputs() throws TimeoutException {
+    void shouldGetSuccessExecutionForFlowWithOutputs() throws TimeoutException, QueueException {
         Execution execution = runnerUtils.runOne(null, NAMESPACE, "flow-with-outputs", null, null);
         assertThat(execution.getOutputs(), aMapWithSize(1));
         assertThat(execution.getOutputs().get("key"), is("{\"value\":\"flow-with-outputs\"}"));
@@ -25,7 +26,7 @@ class FlowOutputTest extends AbstractMemoryRunnerTest {
 
     @Test
     @SuppressWarnings("unchecked")
-    void shouldGetSuccessExecutionForFlowWithArrayOutputs() throws TimeoutException {
+    void shouldGetSuccessExecutionForFlowWithArrayOutputs() throws TimeoutException, QueueException {
         Execution execution = runnerUtils.runOne(null, NAMESPACE, "flow-with-array-outputs", null, null);
         assertThat(execution.getOutputs(), aMapWithSize(1));
         assertThat((List<String>) execution.getOutputs().get("myout"), hasItems("1rstValue", "2ndValue"));
@@ -33,7 +34,7 @@ class FlowOutputTest extends AbstractMemoryRunnerTest {
     }
 
     @Test
-    void shouldGetFailExecutionForFlowWithInvalidOutputs() throws TimeoutException {
+    void shouldGetFailExecutionForFlowWithInvalidOutputs() throws TimeoutException, QueueException {
         Execution execution = runnerUtils.runOne(null, NAMESPACE, "flow-with-outputs-failed", null, null);
         assertThat(execution.getOutputs(), nullValue());
         assertThat(execution.getState().getCurrent(), is(State.Type.FAILED));

--- a/core/src/test/java/io/kestra/plugin/core/flow/ForEachItemCaseTest.java
+++ b/core/src/test/java/io/kestra/plugin/core/flow/ForEachItemCaseTest.java
@@ -2,6 +2,7 @@ package io.kestra.plugin.core.flow;
 
 import io.kestra.core.models.executions.Execution;
 import io.kestra.core.models.flows.State;
+import io.kestra.core.queues.QueueException;
 import io.kestra.core.queues.QueueFactoryInterface;
 import io.kestra.core.queues.QueueInterface;
 import io.kestra.core.runners.FlowInputOutput;
@@ -60,7 +61,7 @@ public class ForEachItemCaseTest {
     private FlowInputOutput flowIO;
 
     @SuppressWarnings("unchecked")
-    public void forEachItem() throws TimeoutException, InterruptedException, URISyntaxException, IOException {
+    public void forEachItem() throws TimeoutException, InterruptedException, URISyntaxException, IOException, QueueException {
         CountDownLatch countDownLatch = new CountDownLatch(26);
         AtomicReference<Execution> triggered = new AtomicReference<>();
 
@@ -102,8 +103,7 @@ public class ForEachItemCaseTest {
         assertThat(triggered.get().getTaskRunList(), hasSize(1));
     }
 
-    @SuppressWarnings("unchecked")
-    public void forEachItemEmptyItems() throws TimeoutException, URISyntaxException, IOException {
+    public void forEachItemEmptyItems() throws TimeoutException, URISyntaxException, IOException, QueueException {
         URI file = emptyItems();
         Map<String, Object> inputs = Map.of("file", file.toString());
         Execution execution = runnerUtils.runOne(null, TEST_NAMESPACE, "for-each-item", null,
@@ -118,7 +118,7 @@ public class ForEachItemCaseTest {
     }
 
     @SuppressWarnings("unchecked")
-    public void forEachItemNoWait() throws TimeoutException, InterruptedException, URISyntaxException, IOException {
+    public void forEachItemNoWait() throws TimeoutException, InterruptedException, URISyntaxException, IOException, QueueException {
         CountDownLatch countDownLatch = new CountDownLatch(26);
         AtomicReference<Execution> triggered = new AtomicReference<>();
 
@@ -168,7 +168,7 @@ public class ForEachItemCaseTest {
     }
 
     @SuppressWarnings("unchecked")
-    public void forEachItemFailed() throws TimeoutException, InterruptedException, URISyntaxException, IOException {
+    public void forEachItemFailed() throws TimeoutException, InterruptedException, URISyntaxException, IOException, QueueException {
         CountDownLatch countDownLatch = new CountDownLatch(26);
         AtomicReference<Execution> triggered = new AtomicReference<>();
 
@@ -211,7 +211,7 @@ public class ForEachItemCaseTest {
     }
 
     @SuppressWarnings("unchecked")
-    public void forEachItemWithSubflowOutputs() throws TimeoutException, InterruptedException, URISyntaxException, IOException {
+    public void forEachItemWithSubflowOutputs() throws TimeoutException, InterruptedException, URISyntaxException, IOException, QueueException {
         CountDownLatch countDownLatch = new CountDownLatch(26);
         AtomicReference<Execution> triggered = new AtomicReference<>();
 

--- a/core/src/test/java/io/kestra/plugin/core/flow/ForEachTest.java
+++ b/core/src/test/java/io/kestra/plugin/core/flow/ForEachTest.java
@@ -2,6 +2,7 @@ package io.kestra.plugin.core.flow;
 
 import io.kestra.core.models.executions.Execution;
 import io.kestra.core.models.flows.State;
+import io.kestra.core.queues.QueueException;
 import io.kestra.core.runners.AbstractMemoryRunnerTest;
 import org.junit.jupiter.api.Test;
 
@@ -13,7 +14,7 @@ import static org.hamcrest.Matchers.is;
 
 class ForEachTest  extends AbstractMemoryRunnerTest {
     @Test
-    void nonConcurrent() throws TimeoutException {
+    void nonConcurrent() throws TimeoutException, QueueException {
         Execution execution = runnerUtils.runOne(null, "io.kestra.tests", "foreach-non-concurrent");
 
         assertThat(execution.getState().getCurrent(), is(State.Type.SUCCESS));
@@ -21,7 +22,7 @@ class ForEachTest  extends AbstractMemoryRunnerTest {
     }
 
     @Test
-    void concurrent() throws TimeoutException {
+    void concurrent() throws TimeoutException, QueueException {
         Execution execution = runnerUtils.runOne(null, "io.kestra.tests", "foreach-concurrent");
 
         assertThat(execution.getState().getCurrent(), is(State.Type.SUCCESS));
@@ -29,7 +30,7 @@ class ForEachTest  extends AbstractMemoryRunnerTest {
     }
 
     @Test
-    void concurrentWithParallel() throws TimeoutException {
+    void concurrentWithParallel() throws TimeoutException, QueueException {
         Execution execution = runnerUtils.runOne(null, "io.kestra.tests", "foreach-concurrent-parallel");
 
         assertThat(execution.getState().getCurrent(), is(State.Type.SUCCESS));
@@ -37,7 +38,7 @@ class ForEachTest  extends AbstractMemoryRunnerTest {
     }
 
     @Test
-    void concurrentNoLimit() throws TimeoutException {
+    void concurrentNoLimit() throws TimeoutException, QueueException {
         Execution execution = runnerUtils.runOne(null, "io.kestra.tests", "foreach-concurrent-no-limit");
 
         assertThat(execution.getState().getCurrent(), is(State.Type.SUCCESS));

--- a/core/src/test/java/io/kestra/plugin/core/flow/IfTest.java
+++ b/core/src/test/java/io/kestra/plugin/core/flow/IfTest.java
@@ -2,6 +2,7 @@ package io.kestra.plugin.core.flow;
 
 import io.kestra.core.models.executions.Execution;
 import io.kestra.core.models.flows.State;
+import io.kestra.core.queues.QueueException;
 import io.kestra.core.runners.AbstractMemoryRunnerTest;
 import org.junit.jupiter.api.Test;
 
@@ -14,7 +15,7 @@ import static org.hamcrest.Matchers.*;
 
 class IfTest  extends AbstractMemoryRunnerTest {
     @Test
-    void ifTruthy() throws TimeoutException {
+    void ifTruthy() throws TimeoutException, QueueException {
         Execution execution = runnerUtils.runOne(null, "io.kestra.tests", "if-condition", null,
             (f, e) -> Map.of("param", true) , Duration.ofSeconds(120));
 
@@ -38,7 +39,7 @@ class IfTest  extends AbstractMemoryRunnerTest {
     }
 
     @Test
-    void ifFalsy() throws TimeoutException {
+    void ifFalsy() throws TimeoutException, QueueException {
         Execution execution = runnerUtils.runOne(null, "io.kestra.tests", "if-condition", null,
             (f, e) -> Map.of("param", false) , Duration.ofSeconds(120));
 
@@ -71,7 +72,7 @@ class IfTest  extends AbstractMemoryRunnerTest {
     }
 
     @Test
-    void ifWithoutElse() throws TimeoutException {
+    void ifWithoutElse() throws TimeoutException, QueueException {
         Execution execution = runnerUtils.runOne(null, "io.kestra.tests", "if-without-else", null,
             (f, e) -> Map.of("param", true) , Duration.ofSeconds(120));
 

--- a/core/src/test/java/io/kestra/plugin/core/flow/ParallelTest.java
+++ b/core/src/test/java/io/kestra/plugin/core/flow/ParallelTest.java
@@ -12,7 +12,7 @@ import static org.hamcrest.Matchers.hasSize;
 
 class ParallelTest extends AbstractMemoryRunnerTest {
     @Test
-    void parallel() throws TimeoutException {
+    void parallel() throws TimeoutException, QueueException {
         Execution execution = runnerUtils.runOne(null, "io.kestra.tests", "parallel");
 
         assertThat(execution.getTaskRunList(), hasSize(8));

--- a/core/src/test/java/io/kestra/plugin/core/flow/PauseTest.java
+++ b/core/src/test/java/io/kestra/plugin/core/flow/PauseTest.java
@@ -4,6 +4,7 @@ import com.google.common.io.CharStreams;
 import io.kestra.core.models.executions.Execution;
 import io.kestra.core.models.flows.Flow;
 import io.kestra.core.models.flows.State;
+import io.kestra.core.queues.QueueException;
 import io.kestra.core.queues.QueueFactoryInterface;
 import io.kestra.core.queues.QueueInterface;
 import io.kestra.core.repositories.FlowRepositoryInterface;
@@ -36,6 +37,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeoutException;
 
+import static io.kestra.core.utils.Rethrow.throwRunnable;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -117,7 +119,7 @@ public class PauseTest extends AbstractMemoryRunnerTest {
 
             execution = runnerUtils.awaitExecution(
                 e -> e.getId().equals(executionId) && e.getState().getCurrent() == State.Type.SUCCESS,
-                () -> executionQueue.emit(restarted),
+                throwRunnable(() -> executionQueue.emit(restarted)),
                 Duration.ofSeconds(5)
             );
 
@@ -142,7 +144,7 @@ public class PauseTest extends AbstractMemoryRunnerTest {
             assertThat(execution.getTaskRunList(), hasSize(3));
         }
 
-        public void runParallelDelay(RunnerUtils runnerUtils) throws TimeoutException {
+        public void runParallelDelay(RunnerUtils runnerUtils) throws TimeoutException, QueueException {
             Execution execution = runnerUtils.runOne(null, "io.kestra.tests", "each-parallel-pause", Duration.ofSeconds(30));
 
             assertThat(execution.getState().getCurrent(), is(State.Type.SUCCESS));
@@ -186,7 +188,7 @@ public class PauseTest extends AbstractMemoryRunnerTest {
 
             execution = runnerUtils.awaitExecution(
                 e -> e.getId().equals(executionId) && e.getState().getCurrent() == State.Type.SUCCESS,
-                () -> executionQueue.emit(restarted),
+                throwRunnable(() -> executionQueue.emit(restarted)),
                 Duration.ofSeconds(10)
             );
 
@@ -218,7 +220,7 @@ public class PauseTest extends AbstractMemoryRunnerTest {
 
             execution = runnerUtils.awaitExecution(
                 e -> e.getId().equals(executionId) && e.getState().getCurrent() == State.Type.SUCCESS,
-                () -> executionQueue.emit(restarted),
+                throwRunnable(() -> executionQueue.emit(restarted)),
                 Duration.ofSeconds(10)
             );
 
@@ -259,7 +261,7 @@ public class PauseTest extends AbstractMemoryRunnerTest {
 
             execution = runnerUtils.awaitExecution(
                 e -> e.getId().equals(executionId) && e.getState().getCurrent() == State.Type.SUCCESS,
-                () -> executionQueue.emit(restarted),
+                throwRunnable(() -> executionQueue.emit(restarted)),
                 Duration.ofSeconds(10)
             );
 

--- a/core/src/test/java/io/kestra/plugin/core/flow/RetryCaseTest.java
+++ b/core/src/test/java/io/kestra/plugin/core/flow/RetryCaseTest.java
@@ -2,6 +2,7 @@ package io.kestra.plugin.core.flow;
 
 import io.kestra.core.models.executions.Execution;
 import io.kestra.core.models.flows.State;
+import io.kestra.core.queues.QueueException;
 import io.kestra.core.queues.QueueFactoryInterface;
 import io.kestra.core.queues.QueueInterface;
 import io.kestra.core.runners.RunnerUtils;
@@ -34,7 +35,7 @@ public class RetryCaseTest {
     @Inject
     protected RunnerUtils runnerUtils;
 
-    public void retrySuccess() throws TimeoutException {
+    public void retrySuccess() throws TimeoutException, QueueException {
         Execution execution = runnerUtils.runOne(null, "io.kestra.tests", "retry-success");
 
         assertThat(execution.getState().getCurrent(), is(State.Type.WARNING));
@@ -42,7 +43,7 @@ public class RetryCaseTest {
         assertThat(execution.getTaskRunList().getFirst().getAttempts(), hasSize(4));
     }
 
-    public void retrySuccessAtFirstAttempt() throws TimeoutException {
+    public void retrySuccessAtFirstAttempt() throws TimeoutException, QueueException {
         Execution execution = runnerUtils.runOne(null, "io.kestra.tests", "retry-success-first-attempt");
 
         assertThat(execution.getState().getCurrent(), is(State.Type.SUCCESS));
@@ -50,7 +51,7 @@ public class RetryCaseTest {
         assertThat(execution.getTaskRunList().getFirst().getAttempts(), hasSize(1));
     }
 
-    public void retryFailed() throws TimeoutException {
+    public void retryFailed() throws TimeoutException, QueueException {
         Execution execution = runnerUtils.runOne(null, "io.kestra.tests", "retry-failed");
 
         assertThat(execution.getTaskRunList(), hasSize(2));
@@ -58,7 +59,7 @@ public class RetryCaseTest {
         assertThat(execution.getState().getCurrent(), is(State.Type.FAILED));
     }
 
-    public void retryRandom() throws TimeoutException {
+    public void retryRandom() throws TimeoutException, QueueException {
         Execution execution = runnerUtils.runOne(null, "io.kestra.tests", "retry-random");
 
         assertThat(execution.getTaskRunList(), hasSize(1));
@@ -66,7 +67,7 @@ public class RetryCaseTest {
         assertThat(execution.getState().getCurrent(), is(State.Type.FAILED));
     }
 
-    public void retryExpo() throws TimeoutException {
+    public void retryExpo() throws TimeoutException, QueueException {
         Execution execution = runnerUtils.runOne(null, "io.kestra.tests", "retry-expo");
 
         assertThat(execution.getTaskRunList(), hasSize(1));
@@ -74,7 +75,7 @@ public class RetryCaseTest {
         assertThat(execution.getState().getCurrent(), is(State.Type.FAILED));
     }
 
-    public void retryFail() throws TimeoutException {
+    public void retryFail() throws TimeoutException, QueueException {
         Execution execution = runnerUtils.runOne(null, "io.kestra.tests", "retry-and-fail");
 
         assertThat(execution.getTaskRunList(), hasSize(2));
@@ -83,7 +84,7 @@ public class RetryCaseTest {
 
     }
 
-    public void retryNewExecutionTaskDuration() throws TimeoutException {
+    public void retryNewExecutionTaskDuration() throws TimeoutException, QueueException {
         CountDownLatch countDownLatch = new CountDownLatch(3);
         AtomicReference<List<State.Type>> stateHistory = new AtomicReference<>(new ArrayList<>());
 
@@ -110,7 +111,7 @@ public class RetryCaseTest {
         assertThat(stateHistory.get(), containsInAnyOrder(State.Type.RETRIED, State.Type.RETRIED, State.Type.FAILED));
     }
 
-    public void retryNewExecutionTaskAttempts() throws TimeoutException {
+    public void retryNewExecutionTaskAttempts() throws TimeoutException, QueueException {
         CountDownLatch countDownLatch = new CountDownLatch(3);
         AtomicReference<List<State.Type>> stateHistory = new AtomicReference<>(new ArrayList<>());
 
@@ -137,7 +138,7 @@ public class RetryCaseTest {
         assertThat(stateHistory.get(), containsInAnyOrder(State.Type.RETRIED, State.Type.RETRIED, State.Type.FAILED));
     }
 
-    public void retryNewExecutionFlowDuration() throws TimeoutException {
+    public void retryNewExecutionFlowDuration() throws TimeoutException, QueueException {
         CountDownLatch countDownLatch = new CountDownLatch(3);
         AtomicReference<List<State.Type>> stateHistory = new AtomicReference<>(new ArrayList<>());
 
@@ -164,7 +165,7 @@ public class RetryCaseTest {
         assertThat(stateHistory.get(), containsInAnyOrder(State.Type.RETRIED, State.Type.RETRIED, State.Type.FAILED));
     }
 
-    public void retryNewExecutionFlowAttempts() throws TimeoutException {
+    public void retryNewExecutionFlowAttempts() throws TimeoutException, QueueException {
         CountDownLatch countDownLatch = new CountDownLatch(3);
         AtomicReference<List<State.Type>> stateHistory = new AtomicReference<>(new ArrayList<>());
 
@@ -191,7 +192,7 @@ public class RetryCaseTest {
         assertThat(stateHistory.get(), containsInAnyOrder(State.Type.RETRIED, State.Type.RETRIED, State.Type.FAILED));
     }
 
-    public void retryFailedTaskDuration() throws TimeoutException {
+    public void retryFailedTaskDuration() throws TimeoutException, QueueException {
         Execution execution = runnerUtils.runOne(
             null,
             "io.kestra.tests",
@@ -204,7 +205,7 @@ public class RetryCaseTest {
         assertThat(execution.getTaskRunList().getFirst().attemptNumber(), is(3));
     }
 
-    public void retryFailedTaskAttempts() throws TimeoutException {
+    public void retryFailedTaskAttempts() throws TimeoutException, QueueException {
         Execution execution = runnerUtils.runOne(
             null,
             "io.kestra.tests",
@@ -218,7 +219,7 @@ public class RetryCaseTest {
         assertThat(execution.getTaskRunList().getFirst().attemptNumber(), is(4));
     }
 
-    public void retryFailedFlowDuration() throws TimeoutException {
+    public void retryFailedFlowDuration() throws TimeoutException, QueueException {
         Execution execution = runnerUtils.runOne(
             null,
             "io.kestra.tests",
@@ -231,7 +232,7 @@ public class RetryCaseTest {
         assertThat(execution.getTaskRunList().getFirst().attemptNumber(), is(3));
     }
 
-    public void retryFailedFlowAttempts() throws TimeoutException {
+    public void retryFailedFlowAttempts() throws TimeoutException, QueueException {
         Execution execution = runnerUtils.runOne(
             null,
             "io.kestra.tests",
@@ -244,7 +245,7 @@ public class RetryCaseTest {
         assertThat(execution.getTaskRunList().getFirst().attemptNumber(), is(4));
     }
 
-    public void retryFlowable() throws TimeoutException {
+    public void retryFlowable() throws TimeoutException, QueueException {
         Execution execution = runnerUtils.runOne(
             null,
             "io.kestra.tests",
@@ -257,7 +258,7 @@ public class RetryCaseTest {
         assertThat(execution.getTaskRunList().get(1).attemptNumber(), is(3));
     }
 
-    public void retrySubflow() throws TimeoutException {
+    public void retrySubflow() throws TimeoutException, QueueException {
         Execution execution = runnerUtils.runOne(
             null,
             "io.kestra.tests",
@@ -270,7 +271,7 @@ public class RetryCaseTest {
         assertThat(execution.getTaskRunList().get(0).getAttempts().size(), is(3));
     }
 
-    public void retryFlowableChild() throws TimeoutException {
+    public void retryFlowableChild() throws TimeoutException, QueueException {
         Execution execution = runnerUtils.runOne(
             null,
             "io.kestra.tests",
@@ -283,7 +284,7 @@ public class RetryCaseTest {
         assertThat(execution.getTaskRunList().get(1).attemptNumber(), is(3));
     }
 
-    public void retryFlowableNestedChild() throws TimeoutException {
+    public void retryFlowableNestedChild() throws TimeoutException, QueueException {
         Execution execution = runnerUtils.runOne(
             null,
             "io.kestra.tests",
@@ -296,7 +297,7 @@ public class RetryCaseTest {
         assertThat(execution.getTaskRunList().get(2).attemptNumber(), is(3));
     }
 
-    public void retryFlowableParallel() throws TimeoutException {
+    public void retryFlowableParallel() throws TimeoutException, QueueException {
         Execution execution = runnerUtils.runOne(
             null,
             "io.kestra.tests",
@@ -308,7 +309,7 @@ public class RetryCaseTest {
         assertThat(execution.getTaskRunList().get(2).attemptNumber(), greaterThanOrEqualTo(2));
     }
 
-    public void retryDynamicTask() throws TimeoutException {
+    public void retryDynamicTask() throws TimeoutException, QueueException {
         Execution execution = runnerUtils.runOne(
             null,
             "io.kestra.tests",

--- a/core/src/test/java/io/kestra/plugin/core/flow/RuntimeLabelsTest.java
+++ b/core/src/test/java/io/kestra/plugin/core/flow/RuntimeLabelsTest.java
@@ -3,6 +3,7 @@ package io.kestra.plugin.core.flow;
 import io.kestra.core.models.Label;
 import io.kestra.core.models.executions.Execution;
 import io.kestra.core.models.flows.State;
+import io.kestra.core.queues.QueueException;
 import io.kestra.core.runners.AbstractMemoryRunnerTest;
 import org.junit.jupiter.api.Test;
 
@@ -15,7 +16,7 @@ import static org.hamcrest.Matchers.*;
 
 class RuntimeLabelsTest extends AbstractMemoryRunnerTest {
     @Test
-    void update() throws TimeoutException {
+    void update() throws TimeoutException, QueueException {
         Execution execution = runnerUtils.runOne(
             null,
             "io.kestra.tests",
@@ -52,7 +53,7 @@ class RuntimeLabelsTest extends AbstractMemoryRunnerTest {
 
 
     @Test
-    void noNpeOnNullPreviousExecutionLabels() throws TimeoutException {
+    void noNpeOnNullPreviousExecutionLabels() throws TimeoutException, QueueException {
         Execution execution = runnerUtils.runOne(
             null,
             "io.kestra.tests",

--- a/core/src/test/java/io/kestra/plugin/core/flow/SequentialTest.java
+++ b/core/src/test/java/io/kestra/plugin/core/flow/SequentialTest.java
@@ -1,6 +1,7 @@
 package io.kestra.plugin.core.flow;
 
 import io.kestra.core.models.flows.State;
+import io.kestra.core.queues.QueueException;
 import io.kestra.core.runners.AbstractMemoryRunnerTest;
 import io.kestra.core.models.executions.Execution;
 import org.junit.jupiter.api.Test;
@@ -13,7 +14,7 @@ import static org.hamcrest.Matchers.is;
 
 class SequentialTest extends AbstractMemoryRunnerTest {
     @Test
-    void sequential() throws TimeoutException {
+    void sequential() throws TimeoutException, QueueException {
         Execution execution = runnerUtils.runOne(null, "io.kestra.tests", "sequential");
 
         assertThat(execution.getTaskRunList(), hasSize(11));
@@ -21,7 +22,7 @@ class SequentialTest extends AbstractMemoryRunnerTest {
     }
 
     @Test
-    void sequentialWithGlobalErrors() throws TimeoutException {
+    void sequentialWithGlobalErrors() throws TimeoutException, QueueException {
         Execution execution = runnerUtils.runOne(null, "io.kestra.tests", "sequential-with-global-errors");
 
         assertThat(execution.getTaskRunList(), hasSize(6));
@@ -29,7 +30,7 @@ class SequentialTest extends AbstractMemoryRunnerTest {
     }
 
     @Test
-    void sequentialWithLocalErrors() throws TimeoutException {
+    void sequentialWithLocalErrors() throws TimeoutException, QueueException {
         Execution execution = runnerUtils.runOne(null, "io.kestra.tests", "sequential-with-local-errors");
 
         assertThat(execution.getTaskRunList(), hasSize(6));

--- a/core/src/test/java/io/kestra/plugin/core/flow/StateTest.java
+++ b/core/src/test/java/io/kestra/plugin/core/flow/StateTest.java
@@ -4,6 +4,7 @@ import com.google.common.collect.ImmutableMap;
 import io.kestra.core.exceptions.InternalException;
 import io.kestra.core.models.executions.Execution;
 import io.kestra.core.models.flows.State;
+import io.kestra.core.queues.QueueException;
 import io.kestra.core.runners.AbstractMemoryRunnerTest;
 import io.kestra.core.utils.IdUtils;
 import org.junit.jupiter.api.Test;
@@ -19,7 +20,7 @@ import static org.hamcrest.Matchers.is;
 class StateTest extends AbstractMemoryRunnerTest {
     @SuppressWarnings("unchecked")
     @Test
-    void set() throws TimeoutException {
+    void set() throws TimeoutException, QueueException {
         String stateName = IdUtils.create();
 
         Execution execution = runnerUtils.runOne(null, "io.kestra.tests", "state",  null, (f, e) -> ImmutableMap.of("state", stateName));
@@ -40,7 +41,7 @@ class StateTest extends AbstractMemoryRunnerTest {
 
     @SuppressWarnings("unchecked")
     @Test
-    void each() throws TimeoutException, InternalException {
+    void each() throws TimeoutException, InternalException, QueueException {
 
         Execution execution = runnerUtils.runOne(null, "io.kestra.tests", "state",  null, (f, e) -> ImmutableMap.of("state", "each"));
         assertThat(execution.getTaskRunList(), hasSize(17));

--- a/core/src/test/java/io/kestra/plugin/core/flow/SwitchTest.java
+++ b/core/src/test/java/io/kestra/plugin/core/flow/SwitchTest.java
@@ -2,6 +2,7 @@ package io.kestra.plugin.core.flow;
 
 import com.google.common.collect.ImmutableMap;
 import io.kestra.core.models.flows.State;
+import io.kestra.core.queues.QueueException;
 import io.kestra.core.runners.AbstractMemoryRunnerTest;
 import io.kestra.core.models.executions.Execution;
 import org.junit.jupiter.api.Test;
@@ -13,7 +14,7 @@ import static org.hamcrest.Matchers.is;
 
 class SwitchTest extends AbstractMemoryRunnerTest {
     @Test
-    void switchFirst() throws TimeoutException {
+    void switchFirst() throws TimeoutException, QueueException {
         Execution execution = runnerUtils.runOne(
             null,
             "io.kestra.tests",
@@ -28,7 +29,7 @@ class SwitchTest extends AbstractMemoryRunnerTest {
     }
 
     @Test
-    void switchSecond() throws TimeoutException {
+    void switchSecond() throws TimeoutException, QueueException {
         Execution execution = runnerUtils.runOne(
             null,
             "io.kestra.tests",
@@ -44,7 +45,7 @@ class SwitchTest extends AbstractMemoryRunnerTest {
     }
 
     @Test
-    void switchThird() throws TimeoutException {
+    void switchThird() throws TimeoutException, QueueException {
         Execution execution = runnerUtils.runOne(
             null,
             "io.kestra.tests",
@@ -61,7 +62,7 @@ class SwitchTest extends AbstractMemoryRunnerTest {
     }
 
     @Test
-    void switchDefault() throws TimeoutException {
+    void switchDefault() throws TimeoutException, QueueException {
         Execution execution = runnerUtils.runOne(
             null,
             "io.kestra.tests",
@@ -76,7 +77,7 @@ class SwitchTest extends AbstractMemoryRunnerTest {
     }
 
     @Test
-    void switchImpossible() throws TimeoutException {
+    void switchImpossible() throws TimeoutException, QueueException {
         Execution execution = runnerUtils.runOne(
             null,
             "io.kestra.tests",

--- a/core/src/test/java/io/kestra/plugin/core/flow/TemplateTest.java
+++ b/core/src/test/java/io/kestra/plugin/core/flow/TemplateTest.java
@@ -4,6 +4,7 @@ import com.google.common.collect.ImmutableMap;
 import io.kestra.core.models.executions.Execution;
 import io.kestra.core.models.executions.LogEntry;
 import io.kestra.core.models.flows.State;
+import io.kestra.core.queues.QueueException;
 import io.kestra.core.queues.QueueFactoryInterface;
 import io.kestra.core.queues.QueueInterface;
 import io.kestra.core.repositories.LocalFlowRepositoryLoader;
@@ -57,7 +58,7 @@ public class TemplateTest extends AbstractMemoryRunnerTest {
         LocalFlowRepositoryLoader repositoryLoader,
         QueueInterface<LogEntry> logQueue,
         FlowInputOutput flowIO
-    ) throws TimeoutException, IOException, URISyntaxException {
+    ) throws TimeoutException, IOException, URISyntaxException, QueueException {
         templateRepository.create(TEMPLATE_1);
         repositoryLoader.load(Objects.requireNonNull(ListenersTest.class.getClassLoader().getResource(
             "flows/templates/with-template.yaml")));
@@ -85,12 +86,12 @@ public class TemplateTest extends AbstractMemoryRunnerTest {
     }
 
     @Test
-    void withTemplate() throws TimeoutException, IOException, URISyntaxException {
+    void withTemplate() throws TimeoutException, IOException, URISyntaxException, QueueException {
         TemplateTest.withTemplate(runnerUtils, templateRepository, repositoryLoader, logQueue, flowIO);
     }
 
 
-    public static void withFailedTemplate(RunnerUtils runnerUtils, TemplateRepositoryInterface templateRepository, LocalFlowRepositoryLoader repositoryLoader, QueueInterface<LogEntry> logQueue) throws TimeoutException, IOException, URISyntaxException {
+    public static void withFailedTemplate(RunnerUtils runnerUtils, TemplateRepositoryInterface templateRepository, LocalFlowRepositoryLoader repositoryLoader, QueueInterface<LogEntry> logQueue) throws TimeoutException, IOException, URISyntaxException, QueueException {
         repositoryLoader.load(Objects.requireNonNull(ListenersTest.class.getClassLoader().getResource(
             "flows/templates/with-failed-template.yaml")));
 
@@ -107,7 +108,7 @@ public class TemplateTest extends AbstractMemoryRunnerTest {
     }
 
     @Test
-    void withFailedTemplate() throws TimeoutException, IOException, URISyntaxException {
+    void withFailedTemplate() throws TimeoutException, IOException, URISyntaxException, QueueException {
         TemplateTest.withFailedTemplate(runnerUtils, templateRepository, repositoryLoader, logQueue);
     }
 }

--- a/core/src/test/java/io/kestra/plugin/core/flow/TimeoutTest.java
+++ b/core/src/test/java/io/kestra/plugin/core/flow/TimeoutTest.java
@@ -4,6 +4,7 @@ import io.kestra.core.models.executions.Execution;
 import io.kestra.core.models.executions.LogEntry;
 import io.kestra.core.models.flows.Flow;
 import io.kestra.core.models.flows.State;
+import io.kestra.core.queues.QueueException;
 import io.kestra.core.queues.QueueFactoryInterface;
 import io.kestra.core.queues.QueueInterface;
 import io.kestra.core.repositories.FlowRepositoryInterface;
@@ -38,7 +39,7 @@ class TimeoutTest extends AbstractMemoryRunnerTest {
     private QueueInterface<LogEntry> workerTaskLogQueue;
 
     @Test
-    void timeout() throws TimeoutException {
+    void timeout() throws TimeoutException, QueueException {
         List<LogEntry> logs = new CopyOnWriteArrayList<>();
         Flux<LogEntry> receive = TestsUtils.receive(workerTaskLogQueue, either -> logs.add(either.getLeft()));
 

--- a/core/src/test/java/io/kestra/plugin/core/flow/VariablesTest.java
+++ b/core/src/test/java/io/kestra/plugin/core/flow/VariablesTest.java
@@ -3,6 +3,7 @@ package io.kestra.plugin.core.flow;
 import io.kestra.core.models.executions.Execution;
 import io.kestra.core.models.executions.LogEntry;
 import io.kestra.core.models.flows.State;
+import io.kestra.core.queues.QueueException;
 import io.kestra.core.queues.QueueFactoryInterface;
 import io.kestra.core.queues.QueueInterface;
 import io.kestra.core.runners.AbstractMemoryRunnerTest;
@@ -29,7 +30,7 @@ class VariablesTest extends AbstractMemoryRunnerTest {
     @Test
     @EnabledIfEnvironmentVariable(named = "KESTRA_TEST1", matches = ".*")
     @EnabledIfEnvironmentVariable(named = "KESTRA_TEST2", matches = ".*")
-    void recursiveVars() throws TimeoutException {
+    void recursiveVars() throws TimeoutException, QueueException {
         Execution execution = runnerUtils.runOne(null, "io.kestra.tests", "variables");
 
         assertThat(execution.getTaskRunList(), hasSize(3));
@@ -39,7 +40,7 @@ class VariablesTest extends AbstractMemoryRunnerTest {
     }
 
     @Test
-    void invalidVars() throws TimeoutException {
+    void invalidVars() throws TimeoutException, QueueException {
         List<LogEntry> logs = new CopyOnWriteArrayList<>();
         Flux<LogEntry> receive = TestsUtils.receive(workerTaskLogQueue, either -> logs.add(either.getLeft()));
 
@@ -58,7 +59,7 @@ class VariablesTest extends AbstractMemoryRunnerTest {
     }
 
     @Test
-    void failedFirst() throws TimeoutException {
+    void failedFirst() throws TimeoutException, QueueException {
         Execution execution = runnerUtils.runOne(null, "io.kestra.tests", "failed-first");
 
         assertThat(execution.getTaskRunList(), hasSize(1));

--- a/core/src/test/java/io/kestra/plugin/core/flow/WaitForCaseTest.java
+++ b/core/src/test/java/io/kestra/plugin/core/flow/WaitForCaseTest.java
@@ -2,6 +2,7 @@ package io.kestra.plugin.core.flow;
 
 import io.kestra.core.models.executions.Execution;
 import io.kestra.core.models.flows.State;
+import io.kestra.core.queues.QueueException;
 import io.kestra.core.repositories.FlowRepositoryInterface;
 import io.kestra.core.runners.RunnerUtils;
 import jakarta.inject.Inject;
@@ -19,33 +20,33 @@ public class WaitForCaseTest {
     @Inject
     protected RunnerUtils runnerUtils;
 
-    public void waitfor() throws TimeoutException {
+    public void waitfor() throws TimeoutException, QueueException {
         Execution execution = runnerUtils.runOne(null, "io.kestra.tests", "waitfor");
 
         assertThat(execution.getState().getCurrent(), is(State.Type.SUCCESS));
         assertThat(execution.getTaskRunList().getFirst().getOutputs(), notNullValue());
     }
 
-    public void waitforMaxIterations() throws TimeoutException {
+    public void waitforMaxIterations() throws TimeoutException, QueueException {
         Execution execution = runnerUtils.runOne(null, "io.kestra.tests", "waitfor-max-iterations");
 
         assertThat(execution.getState().getCurrent(), is(State.Type.FAILED));
     }
 
-    public void waitforMaxDuration() throws TimeoutException {
+    public void waitforMaxDuration() throws TimeoutException, QueueException {
         Execution execution = runnerUtils.runOne(null, "io.kestra.tests", "waitfor-max-duration");
 
         assertThat(execution.getState().getCurrent(), is(State.Type.FAILED));
     }
 
-    public void waitforNoSuccess() throws TimeoutException {
+    public void waitforNoSuccess() throws TimeoutException, QueueException {
         Execution execution = runnerUtils.runOne(null, "io.kestra.tests", "waitfor-no-success");
 
         assertThat(execution.getState().getCurrent(), is(State.Type.SUCCESS));
     }
 
     @SuppressWarnings("unchecked")
-    public void waitforMultipleTasks() throws TimeoutException {
+    public void waitforMultipleTasks() throws TimeoutException, QueueException {
         Execution execution = runnerUtils.runOne(null, "io.kestra.tests", "waitfor-multiple-tasks");
 
         assertThat(execution.getState().getCurrent(), is(State.Type.SUCCESS));
@@ -54,7 +55,7 @@ public class WaitForCaseTest {
         assertThat(values.get("count"), is("4"));
     }
 
-    public void waitforMultipleTasksFailed() throws TimeoutException {
+    public void waitforMultipleTasksFailed() throws TimeoutException, QueueException {
         Execution execution = runnerUtils.runOne(null, "io.kestra.tests", "waitfor-multiple-tasks-failed");
 
         assertThat(execution.getState().getCurrent(), is(State.Type.FAILED));

--- a/core/src/test/resources/flows/valids/workertask-result-to-large.yaml
+++ b/core/src/test/resources/flows/valids/workertask-result-to-large.yaml
@@ -1,0 +1,6 @@
+id: workertask-result-too-large
+namespace: io.kestra.tests
+
+tasks:
+  - id: workertask-result-too-large
+    type: io.kestra.core.runners.test.WorkerTaskResultTooLarge

--- a/docker-compose-ci.yml
+++ b/docker-compose-ci.yml
@@ -8,6 +8,7 @@ services:
       MYSQL_ROOT_PASSWORD: "p4ssw0rd"
     command:
       - --log-bin-trust-function-creators=1
+      - --sort-buffer-size=10485760
     ports:
       - 3306:3306
     restart: on-failure

--- a/jdbc-h2/src/test/resources/application-test.yml
+++ b/jdbc-h2/src/test/resources/application-test.yml
@@ -29,6 +29,9 @@ kestra:
       min-poll-interval: 10ms
       max-poll-interval: 100ms
       poll-switch-interval: 5s
+      message-protection:
+        enabled: true
+        limit: 1048576
   worker:
     liveness:
       enabled: false

--- a/jdbc-mysql/src/test/resources/application-test.yml
+++ b/jdbc-mysql/src/test/resources/application-test.yml
@@ -30,6 +30,9 @@ kestra:
       min-poll-interval: 10ms
       max-poll-interval: 100ms
       poll-switch-interval: 5s
+      message-protection:
+        enabled: true
+        limit: 1048576
   worker:
     liveness:
       enabled: false

--- a/jdbc-postgres/src/main/java/io/kestra/runner/postgres/PostgresQueue.java
+++ b/jdbc-postgres/src/main/java/io/kestra/runner/postgres/PostgresQueue.java
@@ -2,6 +2,7 @@ package io.kestra.runner.postgres;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import io.kestra.core.exceptions.DeserializationException;
+import io.kestra.core.queues.QueueException;
 import io.kestra.core.utils.Either;
 import io.kestra.jdbc.repository.AbstractJdbcRepository;
 import io.kestra.jdbc.runner.JdbcQueue;

--- a/jdbc-postgres/src/main/java/io/kestra/runner/postgres/PostgresQueue.java
+++ b/jdbc-postgres/src/main/java/io/kestra/runner/postgres/PostgresQueue.java
@@ -7,7 +7,6 @@ import io.kestra.jdbc.repository.AbstractJdbcRepository;
 import io.kestra.jdbc.runner.JdbcQueue;
 import io.micronaut.context.ApplicationContext;
 import io.micronaut.core.annotation.NonNull;
-import lombok.SneakyThrows;
 import org.jooq.*;
 import org.jooq.Record;
 import org.jooq.impl.DSL;
@@ -30,8 +29,7 @@ public class PostgresQueue<T> extends JdbcQueue<T> {
     }
 
     @Override
-    @SneakyThrows
-    protected Map<Field<Object>, Object> produceFields(String consumerGroup, String key, T message) {
+    protected Map<Field<Object>, Object> produceFields(String consumerGroup, String key, T message) throws QueueException {
         Map<Field<Object>, Object> map = super.produceFields(consumerGroup, key, message);
 
         map.put(

--- a/jdbc-postgres/src/test/resources/application-test.yml
+++ b/jdbc-postgres/src/test/resources/application-test.yml
@@ -31,6 +31,9 @@ kestra:
       min-poll-interval: 10ms
       max-poll-interval: 100ms
       poll-switch-interval: 5s
+      message-protection:
+        enabled: true
+        limit: 1048576
   tasks:
     subflow:
       allow-parameter-outputs: true

--- a/jdbc/src/main/java/io/kestra/jdbc/AbstractJdbcRepository.java
+++ b/jdbc/src/main/java/io/kestra/jdbc/AbstractJdbcRepository.java
@@ -26,7 +26,6 @@ import java.time.ZonedDateTime;
 import java.time.temporal.TemporalAdjusters;
 import java.util.*;
 import java.util.function.Function;
-import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 public abstract class AbstractJdbcRepository<T> {
@@ -71,7 +70,7 @@ public abstract class AbstractJdbcRepository<T> {
     @SneakyThrows
     public Map<Field<Object>, Object> persistFields(T entity) {
         return new HashMap<>(ImmutableMap
-            .of(io.kestra.jdbc.repository.AbstractJdbcRepository.field("value"), JdbcMapper.of().writeValueAsString(entity))
+            .of(io.kestra.jdbc.repository.AbstractJdbcRepository.field("value"), MAPPER.writeValueAsString(entity))
         );
     }
 

--- a/jdbc/src/main/java/io/kestra/jdbc/repository/AbstractJdbcTemplateRepository.java
+++ b/jdbc/src/main/java/io/kestra/jdbc/repository/AbstractJdbcTemplateRepository.java
@@ -3,6 +3,7 @@ package io.kestra.jdbc.repository;
 import io.kestra.core.events.CrudEvent;
 import io.kestra.core.events.CrudEventType;
 import io.kestra.core.models.templates.Template;
+import io.kestra.core.queues.QueueException;
 import io.kestra.core.queues.QueueFactoryInterface;
 import io.kestra.core.queues.QueueInterface;
 import io.kestra.core.repositories.ArrayListTotal;
@@ -158,11 +159,16 @@ public abstract class AbstractJdbcTemplateRepository extends AbstractJdbcReposit
     public Template create(Template template) throws ConstraintViolationException {
         this.jdbcRepository.persist(template);
 
-        templateQueue.emit(template);
-        eventPublisher.publishEvent(new CrudEvent<>(template, CrudEventType.CREATE));
+        try {
+            templateQueue.emit(template);
+            eventPublisher.publishEvent(new CrudEvent<>(template, CrudEventType.CREATE));
 
-        return template;
+            return template;
+        } catch (QueueException e) {
+            throw new RuntimeException(e);
+        }
     }
+
 
     public Template update(Template template, Template previous) throws ConstraintViolationException {
         this
@@ -176,10 +182,14 @@ public abstract class AbstractJdbcTemplateRepository extends AbstractJdbcReposit
 
         this.jdbcRepository.persist(template);
 
-        templateQueue.emit(template);
-        eventPublisher.publishEvent(new CrudEvent<>(template, CrudEventType.UPDATE));
+        try {
+            templateQueue.emit(template);
+            eventPublisher.publishEvent(new CrudEvent<>(template, CrudEventType.UPDATE));
 
-        return template;
+            return template;
+        } catch (QueueException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     @Override
@@ -192,8 +202,12 @@ public abstract class AbstractJdbcTemplateRepository extends AbstractJdbcReposit
 
         this.jdbcRepository.persist(deleted);
 
-        templateQueue.emit(deleted);
-        eventPublisher.publishEvent(new CrudEvent<>(deleted, CrudEventType.DELETE));
+        try {
+            templateQueue.emit(deleted);
+            eventPublisher.publishEvent(new CrudEvent<>(deleted, CrudEventType.DELETE));
+        } catch (QueueException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     @Override

--- a/jdbc/src/main/java/io/kestra/jdbc/runner/JdbcCleaner.java
+++ b/jdbc/src/main/java/io/kestra/jdbc/runner/JdbcCleaner.java
@@ -1,6 +1,5 @@
 package io.kestra.jdbc.runner;
 
-import io.kestra.core.queues.QueueException;
 import io.kestra.jdbc.JdbcTableConfig;
 import io.kestra.jdbc.JooqDSLContextWrapper;
 import io.kestra.jdbc.repository.AbstractJdbcRepository;
@@ -39,7 +38,7 @@ public class JdbcCleaner {
         this.queueTable = DSL.table(jdbcTableConfig.table());
     }
 
-    public void deleteQueue() throws QueueException {
+    public void deleteQueue() {
         dslContextWrapper.transaction(configuration -> {
             int deleted = DSL
                 .using(configuration)

--- a/jdbc/src/main/java/io/kestra/jdbc/runner/MessageProtectionConfiguration.java
+++ b/jdbc/src/main/java/io/kestra/jdbc/runner/MessageProtectionConfiguration.java
@@ -1,0 +1,12 @@
+package io.kestra.jdbc.runner;
+
+import io.micronaut.context.annotation.ConfigurationProperties;
+import lombok.Getter;
+
+@ConfigurationProperties("kestra.jdbc.queues.message-protection")
+@Getter
+public class MessageProtectionConfiguration {
+    boolean enabled = false;
+
+    Integer limit = 10 * 1024 * 1024;
+}

--- a/jdbc/src/test/java/io/kestra/jdbc/runner/AbstractJdbcDeserializationIssuesTest.java
+++ b/jdbc/src/test/java/io/kestra/jdbc/runner/AbstractJdbcDeserializationIssuesTest.java
@@ -1,5 +1,6 @@
 package io.kestra.jdbc.runner;
 
+import io.kestra.core.queues.QueueException;
 import io.kestra.core.runners.DeserializationIssuesCaseTest;
 import io.kestra.core.runners.StandAloneRunner;
 import io.kestra.core.utils.IdUtils;
@@ -58,7 +59,7 @@ public abstract class AbstractJdbcDeserializationIssuesTest {
     }
 
     @Test
-    void flowDeserializationIssue() throws TimeoutException {
+    void flowDeserializationIssue() throws TimeoutException, QueueException {
         deserializationIssuesCaseTest.flowDeserializationIssue(queueMessage -> sendToQueue(queueMessage));
     }
 

--- a/jdbc/src/test/java/io/kestra/jdbc/runner/JdbcRunnerRetryTest.java
+++ b/jdbc/src/test/java/io/kestra/jdbc/runner/JdbcRunnerRetryTest.java
@@ -1,5 +1,6 @@
 package io.kestra.jdbc.runner;
 
+import io.kestra.core.queues.QueueException;
 import io.kestra.core.repositories.LocalFlowRepositoryLoader;
 import io.kestra.core.runners.RunnerUtils;
 import io.kestra.core.runners.StandAloneRunner;
@@ -45,102 +46,102 @@ public abstract class JdbcRunnerRetryTest {
     }
 
     @Test
-    void retrySuccess() throws TimeoutException {
+    void retrySuccess() throws TimeoutException, QueueException {
         retryCaseTest.retrySuccess();
     }
 
     @Test
-    void retrySuccessAtFirstAttempt() throws TimeoutException {
+    void retrySuccessAtFirstAttempt() throws TimeoutException, QueueException {
         retryCaseTest.retrySuccessAtFirstAttempt();
     }
 
     @Test
-    void retryFailed() throws TimeoutException {
+    void retryFailed() throws TimeoutException, QueueException {
         retryCaseTest.retryFailed();
     }
 
     @Test
-    void retryRandom() throws TimeoutException {
+    void retryRandom() throws TimeoutException, QueueException {
         retryCaseTest.retryRandom();
     }
 
     @Test
-    void retryExpo() throws TimeoutException {
+    void retryExpo() throws TimeoutException, QueueException {
         retryCaseTest.retryExpo();
     }
 
     @Test
-    void retryFail() throws TimeoutException {
+    void retryFail() throws TimeoutException, QueueException {
         retryCaseTest.retryFail();
     }
 
     @Test
-    void retryNewExecutionTaskDuration() throws TimeoutException {
+    void retryNewExecutionTaskDuration() throws TimeoutException, QueueException {
         retryCaseTest.retryNewExecutionTaskDuration();
     }
 
     @Test
-    void retryNewExecutionTaskAttempts() throws TimeoutException {
+    void retryNewExecutionTaskAttempts() throws TimeoutException, QueueException {
         retryCaseTest.retryNewExecutionTaskAttempts();
     }
 
     @Test
-    void retryNewExecutionFlowDuration() throws TimeoutException {
+    void retryNewExecutionFlowDuration() throws TimeoutException, QueueException {
         retryCaseTest.retryNewExecutionFlowDuration();
     }
 
     @Test
-    void retryNewExecutionFlowAttempts() throws TimeoutException {
+    void retryNewExecutionFlowAttempts() throws TimeoutException, QueueException {
         retryCaseTest.retryNewExecutionFlowAttempts();
     }
 
     @Test
-    void retryFailedTaskDuration() throws TimeoutException {
+    void retryFailedTaskDuration() throws TimeoutException, QueueException {
         retryCaseTest.retryFailedTaskDuration();
     }
 
     @Test
-    void retryFailedTaskAttempts() throws TimeoutException {
+    void retryFailedTaskAttempts() throws TimeoutException, QueueException {
         retryCaseTest.retryFailedTaskAttempts();
     }
 
     @Test
-    void retryFailedFlowDuration() throws TimeoutException {
+    void retryFailedFlowDuration() throws TimeoutException, QueueException {
         retryCaseTest.retryFailedFlowDuration();
     }
 
     @Test
-    void retryFailedFlowAttempts() throws TimeoutException {
+    void retryFailedFlowAttempts() throws TimeoutException, QueueException {
         retryCaseTest.retryFailedFlowAttempts();
     }
 
     @Test
-    void retryFlowable() throws TimeoutException {
+    void retryFlowable() throws TimeoutException, QueueException {
         retryCaseTest.retryFlowable();
     }
 
     @Test
-    void retrySubflow() throws TimeoutException {
+    void retrySubflow() throws TimeoutException, QueueException {
         retryCaseTest.retrySubflow();
     }
 
     @Test
-    void retryFlowableChild() throws TimeoutException {
+    void retryFlowableChild() throws TimeoutException, QueueException {
         retryCaseTest.retryFlowableChild();
     }
 
     @Test
-    void retryFlowableNestedChild() throws TimeoutException {
+    void retryFlowableNestedChild() throws TimeoutException, QueueException {
         retryCaseTest.retryFlowableNestedChild();
     }
 
     @Test
-    void retryFlowableParallel() throws TimeoutException {
+    void retryFlowableParallel() throws TimeoutException, QueueException {
         retryCaseTest.retryFlowableParallel();
     }
 
     @Test
-    void retryDynamicTask() throws TimeoutException {
+    void retryDynamicTask() throws TimeoutException, QueueException {
         retryCaseTest.retryDynamicTask();
     }
 }

--- a/jdbc/src/test/java/io/kestra/jdbc/runner/JdbcRunnerTest.java
+++ b/jdbc/src/test/java/io/kestra/jdbc/runner/JdbcRunnerTest.java
@@ -1,6 +1,5 @@
 package io.kestra.jdbc.runner;
 
-import io.kestra.core.exceptions.InternalException;
 import io.kestra.core.models.executions.Execution;
 import io.kestra.core.models.executions.LogEntry;
 import io.kestra.core.models.flows.State;
@@ -100,7 +99,7 @@ public abstract class JdbcRunnerTest {
     }
 
     @Test
-    void full() throws TimeoutException, QueueException, InternalException {
+    void full() throws TimeoutException, QueueException {
         Execution execution = runnerUtils.runOne(null, "io.kestra.tests", "full", null, null, Duration.ofSeconds(60));
 
         assertThat(execution.getTaskRunList(), hasSize(13));
@@ -109,7 +108,7 @@ public abstract class JdbcRunnerTest {
     }
 
     @Test
-    void logs() throws TimeoutException {
+    void logs() throws TimeoutException, QueueException {
         Execution execution = runnerUtils.runOne(null, "io.kestra.tests", "logs", null, null, Duration.ofSeconds(60));
 
         assertThat(execution.getTaskRunList(), hasSize(5));
@@ -144,7 +143,7 @@ public abstract class JdbcRunnerTest {
     }
 
     @Test
-    void eachParallelWithSubflowMissing() throws TimeoutException {
+    void eachParallelWithSubflowMissing() throws TimeoutException, QueueException {
         Execution execution =  runnerUtils.runOne(null, "io.kestra.tests", "each-parallel-subflow-notfound");
 
         assertThat(execution, notNullValue());
@@ -156,21 +155,21 @@ public abstract class JdbcRunnerTest {
     }
 
     @Test
-    void eachSequentialNested() throws TimeoutException {
+    void eachSequentialNested() throws TimeoutException, QueueException {
         Execution execution = runnerUtils.runOne(null, "io.kestra.tests", "each-sequential-nested", null, null, Duration.ofSeconds(60));
 
         assertThat(execution.getTaskRunList(), hasSize(23));
     }
 
     @Test
-    void eachParallel() throws TimeoutException {
+    void eachParallel() throws TimeoutException, QueueException {
         Execution execution = runnerUtils.runOne(null, "io.kestra.tests", "each-parallel", null, null, Duration.ofSeconds(60));
 
         assertThat(execution.getTaskRunList(), hasSize(8));
     }
 
     @Test
-    void eachParallelNested() throws TimeoutException {
+    void eachParallelNested() throws TimeoutException, QueueException {
         Execution execution = runnerUtils.runOne(null, "io.kestra.tests", "each-parallel-nested", null, null, Duration.ofSeconds(60));
 
         assertThat(execution.getTaskRunList(), hasSize(11));
@@ -212,7 +211,7 @@ public abstract class JdbcRunnerTest {
     }
 
     @Test
-    void taskDefaults() throws TimeoutException, IOException, URISyntaxException {
+    void taskDefaults() throws TimeoutException, QueueException, IOException, URISyntaxException {
         repositoryLoader.load(Objects.requireNonNull(ListenersTest.class.getClassLoader().getResource("flows/tests/plugin-defaults.yaml")));
         pluginDefaultsCaseTest.taskDefaults();
     }
@@ -268,19 +267,19 @@ public abstract class JdbcRunnerTest {
     }
 
     @RetryingTest(5)
-    void executionDate() throws TimeoutException {
+    void executionDate() throws TimeoutException, QueueException {
         Execution execution = runnerUtils.runOne(null, "io.kestra.tests", "execution-start-date", null, null, Duration.ofSeconds(60));
 
         assertThat((String) execution.getTaskRunList().getFirst().getOutputs().get("value"), matchesPattern("^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d{3}Z"));
     }
 
     @Test
-    void skipExecution() throws TimeoutException, InterruptedException {
+    void skipExecution() throws TimeoutException, QueueException, InterruptedException {
         skipExecutionCaseTest.skipExecution();
     }
 
     @Test
-    void forEachItem() throws URISyntaxException, IOException, InterruptedException, TimeoutException {
+    void forEachItem() throws URISyntaxException, IOException, InterruptedException, TimeoutException, QueueException {
         forEachItemCaseTest.forEachItem();
     }
 
@@ -295,42 +294,42 @@ public abstract class JdbcRunnerTest {
     }
 
     @Test
-    void forEachItemFailed() throws URISyntaxException, IOException, InterruptedException, TimeoutException {
+    void forEachItemFailed() throws URISyntaxException, IOException, InterruptedException, TimeoutException, QueueException {
         forEachItemCaseTest.forEachItemFailed();
     }
 
     @Test
-    void forEachItemSubflowOutputs() throws URISyntaxException, IOException, InterruptedException, TimeoutException {
+    void forEachItemSubflowOutputs() throws URISyntaxException, IOException, InterruptedException, TimeoutException, QueueException {
         forEachItemCaseTest.forEachItemWithSubflowOutputs();
     }
 
     @Test
-    void concurrencyCancel() throws TimeoutException, InterruptedException {
+    void concurrencyCancel() throws TimeoutException, QueueException, InterruptedException {
         flowConcurrencyCaseTest.flowConcurrencyCancel();
     }
 
     @Test
-    void concurrencyFail() throws TimeoutException, InterruptedException  {
+    void concurrencyFail() throws TimeoutException, QueueException, InterruptedException  {
         flowConcurrencyCaseTest.flowConcurrencyFail();
     }
 
     @Test
-    void concurrencyQueue() throws TimeoutException, InterruptedException  {
+    void concurrencyQueue() throws TimeoutException, QueueException, InterruptedException  {
         flowConcurrencyCaseTest.flowConcurrencyQueue();
     }
 
     @Test
-    void concurrencyQueuePause() throws TimeoutException, InterruptedException  {
+    void concurrencyQueuePause() throws TimeoutException, QueueException, InterruptedException  {
         flowConcurrencyCaseTest.flowConcurrencyQueuePause();
     }
 
     @Test
-    void concurrencyCancelPause() throws TimeoutException, InterruptedException  {
+    void concurrencyCancelPause() throws TimeoutException, QueueException, InterruptedException  {
         flowConcurrencyCaseTest.flowConcurrencyCancelPause();
     }
 
     @Test
-    void badExecutable() throws TimeoutException {
+    void badExecutable() throws TimeoutException, QueueException {
         Execution execution = runnerUtils.runOne(null, "io.kestra.tests", "executable-fail");
 
         assertThat(execution.getTaskRunList().size(), is(1));
@@ -339,7 +338,7 @@ public abstract class JdbcRunnerTest {
     }
 
     @Test
-    void dynamicTask() throws TimeoutException {
+    void dynamicTask() throws TimeoutException, QueueException {
         Execution execution = runnerUtils.runOne(null, "io.kestra.tests", "dynamic-task");
 
         assertThat(execution.getTaskRunList().size(), is(2));
@@ -347,37 +346,37 @@ public abstract class JdbcRunnerTest {
     }
 
     @Test
-    void waitFor() throws TimeoutException {
+    void waitFor() throws TimeoutException, QueueException{
         waitForTestCaseTest.waitfor();
     }
 
     @Test
-    void waitforMaxIterations() throws TimeoutException {
+    void waitforMaxIterations() throws TimeoutException, QueueException{
         waitForTestCaseTest.waitforMaxIterations();
     }
 
     @Test
-    void waitforMaxDuration() throws TimeoutException {
+    void waitforMaxDuration() throws TimeoutException, QueueException{
         waitForTestCaseTest.waitforMaxDuration();
     }
 
     @Test
-    void waitforNoSuccess() throws TimeoutException {
+    void waitforNoSuccess() throws TimeoutException, QueueException{
         waitForTestCaseTest.waitforNoSuccess();
     }
 
     @Test
-    void waitforMultipleTasks() throws TimeoutException {
+    void waitforMultipleTasks() throws TimeoutException, QueueException{
         waitForTestCaseTest.waitforMultipleTasks();
     }
 
     @Test
-    void waitforMultipleTasksFailed() throws TimeoutException {
+    void waitforMultipleTasksFailed() throws TimeoutException, QueueException{
         waitForTestCaseTest.waitforMultipleTasksFailed();
     }
 
     @Test
-    void flowTooLarge() throws TimeoutException, IOException, URISyntaxException {
+    void flowTooLarge() throws TimeoutException, IOException, URISyntaxException, QueueException {
         char[] chars = new char[200000];
         Arrays.fill(chars, 'a');
 
@@ -424,7 +423,7 @@ public abstract class JdbcRunnerTest {
     }
 
     @Test
-    void workerTaskResultTooLarge() throws TimeoutException {
+    void workerTaskResultTooLarge() throws TimeoutException, QueueException {
         List<LogEntry> logs = new CopyOnWriteArrayList<>();
         Flux<LogEntry> receive = TestsUtils.receive(logsQueue, either -> logs.add(either.getLeft()));
 

--- a/jdbc/src/test/java/io/kestra/jdbc/runner/JdbcRunnerTest.java
+++ b/jdbc/src/test/java/io/kestra/jdbc/runner/JdbcRunnerTest.java
@@ -279,27 +279,27 @@ public abstract class JdbcRunnerTest {
     }
 
     @Test
-    void forEachItem() throws URISyntaxException, IOException, InterruptedException, TimeoutException, QueueException {
+    protected void forEachItem() throws URISyntaxException, IOException, InterruptedException, TimeoutException, QueueException {
         forEachItemCaseTest.forEachItem();
     }
 
     @Test
-    void forEachItemEmptyItems() throws URISyntaxException, IOException, TimeoutException {
+    protected void forEachItemEmptyItems() throws URISyntaxException, IOException, TimeoutException, QueueException {
         forEachItemCaseTest.forEachItemEmptyItems();
     }
 
     @Test
-    void forEachItemNoWait() throws URISyntaxException, IOException, InterruptedException, TimeoutException {
+    protected void forEachItemNoWait() throws URISyntaxException, IOException, InterruptedException, TimeoutException, QueueException {
         forEachItemCaseTest.forEachItemNoWait();
     }
 
     @Test
-    void forEachItemFailed() throws URISyntaxException, IOException, InterruptedException, TimeoutException, QueueException {
+    protected void forEachItemFailed() throws URISyntaxException, IOException, InterruptedException, TimeoutException, QueueException {
         forEachItemCaseTest.forEachItemFailed();
     }
 
     @Test
-    void forEachItemSubflowOutputs() throws URISyntaxException, IOException, InterruptedException, TimeoutException, QueueException {
+    protected void forEachItemSubflowOutputs() throws URISyntaxException, IOException, InterruptedException, TimeoutException, QueueException {
         forEachItemCaseTest.forEachItemWithSubflowOutputs();
     }
 

--- a/webserver/src/test/java/io/kestra/webserver/controllers/api/ExecutionControllerTest.java
+++ b/webserver/src/test/java/io/kestra/webserver/controllers/api/ExecutionControllerTest.java
@@ -13,6 +13,7 @@ import io.kestra.core.models.flows.State;
 import io.kestra.core.models.storage.FileMetas;
 import io.kestra.core.models.tasks.TaskForExecution;
 import io.kestra.core.models.triggers.AbstractTriggerForExecution;
+import io.kestra.core.queues.QueueException;
 import io.kestra.core.runners.FlowInputOutput;
 import io.kestra.core.utils.TestsUtils;
 import io.kestra.plugin.core.trigger.Webhook;
@@ -285,7 +286,7 @@ class ExecutionControllerTest extends JdbcH2ControllerTest {
     }
 
     @Test
-    void eval() throws TimeoutException {
+    void eval() throws TimeoutException, QueueException {
         Execution execution = runnerUtils.runOne(null, "io.kestra.tests", "each-sequential-nested");
 
         ExecutionController.EvalResult result = this.eval(execution, "my simple string", 0);
@@ -304,7 +305,7 @@ class ExecutionControllerTest extends JdbcH2ControllerTest {
     }
 
     @Test
-    void evalKeepEncryptedValues() throws TimeoutException, JsonProcessingException {
+    void evalKeepEncryptedValues() throws TimeoutException, QueueException, JsonProcessingException {
         Execution execution = runnerUtils.runOne(null, "io.kestra.tests", "encrypted-string");
 
         ExecutionController.EvalResult result = this.eval(execution, "{{outputs.hello.value}}", 0);
@@ -324,7 +325,7 @@ class ExecutionControllerTest extends JdbcH2ControllerTest {
     }
 
     @Test
-    void restartFromUnknownTaskId() throws TimeoutException {
+    void restartFromUnknownTaskId() throws TimeoutException, QueueException {
         final String flowId = "restart_with_inputs";
         final String referenceTaskId = "unknownTaskId";
 
@@ -343,7 +344,7 @@ class ExecutionControllerTest extends JdbcH2ControllerTest {
     }
 
     @Test
-    void restartWithNoFailure() throws TimeoutException {
+    void restartWithNoFailure() throws TimeoutException, QueueException{
         final String flowId = "restart_with_inputs";
 
         // Run execution until it ends
@@ -444,7 +445,7 @@ class ExecutionControllerTest extends JdbcH2ControllerTest {
     }
 
     @Test
-    void restartFromLastFailed() throws TimeoutException {
+    void restartFromLastFailed() throws TimeoutException, QueueException{
         final String flowId = "restart_last_failed";
 
         // Run execution until it ends
@@ -506,7 +507,7 @@ class ExecutionControllerTest extends JdbcH2ControllerTest {
     }
 
     @Test
-    void restartFromLastFailedWithPause() throws TimeoutException {
+    void restartFromLastFailedWithPause() throws TimeoutException, QueueException{
         final String flowId = "restart_pause_last_failed";
 
         // Run execution until it ends
@@ -572,7 +573,7 @@ class ExecutionControllerTest extends JdbcH2ControllerTest {
     }
 
     @Test
-    void downloadFile() throws TimeoutException {
+    void downloadFile() throws TimeoutException, QueueException{
         Execution execution = runnerUtils.runOne(null, TESTS_FLOW_NS, "inputs", null, (flow, execution1) -> flowIO.typedInputs(flow, execution1, inputs));
         assertThat(execution.getTaskRunList(), hasSize(14));
 
@@ -609,7 +610,7 @@ class ExecutionControllerTest extends JdbcH2ControllerTest {
     }
 
     @Test
-    void filePreview() throws TimeoutException {
+    void filePreview() throws TimeoutException, QueueException{
         Execution defaultExecution = runnerUtils.runOne(null, TESTS_FLOW_NS, "inputs", null, (flow, execution1) -> flowIO.typedInputs(flow, execution1, inputs));
         assertThat(defaultExecution.getTaskRunList(), hasSize(14));
 
@@ -840,7 +841,7 @@ class ExecutionControllerTest extends JdbcH2ControllerTest {
     }
 
     @Test
-    void resumePaused() throws TimeoutException, InterruptedException {
+    void resumePaused() throws TimeoutException, InterruptedException, QueueException {
         // Run execution until it is paused
         Execution pausedExecution = runnerUtils.runOneUntilPaused(null, TESTS_FLOW_NS, "pause");
         assertThat(pausedExecution.getState().isPaused(), is(true));
@@ -860,7 +861,7 @@ class ExecutionControllerTest extends JdbcH2ControllerTest {
 
     @SuppressWarnings("unchecked")
     @Test
-    void resumePausedWithInputs() throws TimeoutException, InterruptedException {
+    void resumePausedWithInputs() throws TimeoutException, InterruptedException, QueueException {
         // Run execution until it is paused
         Execution pausedExecution = runnerUtils.runOneUntilPaused(null, TESTS_FLOW_NS, "pause_on_resume");
         assertThat(pausedExecution.getState().isPaused(), is(true));
@@ -894,7 +895,7 @@ class ExecutionControllerTest extends JdbcH2ControllerTest {
     }
 
     @Test
-    void resumeByIds() throws TimeoutException, InterruptedException {
+    void resumeByIds() throws TimeoutException, InterruptedException, QueueException {
         Execution pausedExecution1 = runnerUtils.runOneUntilPaused(null, TESTS_FLOW_NS, "pause");
         Execution pausedExecution2 = runnerUtils.runOneUntilPaused(null, TESTS_FLOW_NS, "pause");
 
@@ -936,7 +937,7 @@ class ExecutionControllerTest extends JdbcH2ControllerTest {
     }
 
     @Test
-    void resumeByQuery() throws TimeoutException, InterruptedException {
+    void resumeByQuery() throws TimeoutException, InterruptedException, QueueException {
         Execution pausedExecution1 = runnerUtils.runOneUntilPaused(null, TESTS_FLOW_NS, "pause");
         Execution pausedExecution2 = runnerUtils.runOneUntilPaused(null, TESTS_FLOW_NS, "pause");
 
@@ -974,7 +975,7 @@ class ExecutionControllerTest extends JdbcH2ControllerTest {
     }
 
     @Test
-    void changeStatus() throws TimeoutException {
+    void changeStatus() throws TimeoutException, QueueException {
         Execution execution = runnerUtils.runOne(null, "io.kestra.tests", "minimal");
         assertThat(execution.getState().getCurrent(), is(State.Type.SUCCESS));
 
@@ -991,7 +992,7 @@ class ExecutionControllerTest extends JdbcH2ControllerTest {
 
     @Test
     @SuppressWarnings("unchecked")
-    void changeStatusByIds() throws TimeoutException {
+    void changeStatusByIds() throws TimeoutException, QueueException {
         Execution execution1 = runnerUtils.runOne(null, "io.kestra.tests", "minimal");
         Execution execution2 = runnerUtils.runOne(null, "io.kestra.tests", "minimal");
 
@@ -1022,7 +1023,7 @@ class ExecutionControllerTest extends JdbcH2ControllerTest {
 
     @Test
     @SuppressWarnings("unchecked")
-    void changeStatusByQuery() throws TimeoutException {
+    void changeStatusByQuery() throws TimeoutException, QueueException {
         Execution execution1 = runnerUtils.runOne(null, "io.kestra.tests", "minimal");
         Execution execution2 = runnerUtils.runOne(null, "io.kestra.tests", "minimal");
 
@@ -1049,7 +1050,7 @@ class ExecutionControllerTest extends JdbcH2ControllerTest {
     }
 
     @Test
-    void replayByIds() throws TimeoutException {
+    void replayByIds() throws TimeoutException, QueueException {
         Execution execution1 = runnerUtils.runOne(null, "io.kestra.tests", "minimal");
         Execution execution2 = runnerUtils.runOne(null, "io.kestra.tests", "minimal");
 
@@ -1078,7 +1079,7 @@ class ExecutionControllerTest extends JdbcH2ControllerTest {
     }
 
     @Test
-    void replayByQuery() throws TimeoutException {
+    void replayByQuery() throws TimeoutException, QueueException {
         Execution execution1 = runnerUtils.runOne(null, "io.kestra.tests", "minimal");
         Execution execution2 = runnerUtils.runOne(null, "io.kestra.tests", "minimal");
 
@@ -1104,7 +1105,7 @@ class ExecutionControllerTest extends JdbcH2ControllerTest {
     }
 
     @RetryingTest(5)
-    void killPaused() throws TimeoutException, InterruptedException {
+    void killPaused() throws TimeoutException, InterruptedException, QueueException {
         // Run execution until it is paused
         Execution pausedExecution = runnerUtils.runOneUntilPaused(null, TESTS_FLOW_NS, "pause");
         assertThat(pausedExecution.getState().isPaused(), is(true));
@@ -1164,7 +1165,7 @@ class ExecutionControllerTest extends JdbcH2ControllerTest {
 
     // This test is flaky on CI as the flow may be already SUCCESS when we kill it if CI is super slow
     @RetryingTest(5)
-    void kill() throws TimeoutException, InterruptedException {
+    void kill() throws TimeoutException, InterruptedException, QueueException {
         // Run execution until it is paused
         Execution runningExecution = runnerUtils.runOneUntilRunning(null, TESTS_FLOW_NS, "sleep");
         assertThat(runningExecution.getState().isRunning(), is(true));
@@ -1236,7 +1237,7 @@ class ExecutionControllerTest extends JdbcH2ControllerTest {
     }
 
     @Test
-    void deleteByIds() throws TimeoutException {
+    void deleteByIds() throws TimeoutException, QueueException {
         Execution result1 = runnerUtils.runOne(null, "io.kestra.tests", "minimal");
         Execution result2 = runnerUtils.runOne(null, "io.kestra.tests", "minimal");
         Execution result3 = runnerUtils.runOne(null, "io.kestra.tests", "minimal");
@@ -1249,7 +1250,7 @@ class ExecutionControllerTest extends JdbcH2ControllerTest {
     }
 
     @Test
-    void deleteByQuery() throws TimeoutException {
+    void deleteByQuery() throws TimeoutException, QueueException {
         Execution result1 = runnerUtils.runOne(null, "io.kestra.tests", "minimal");
         Execution result2 = runnerUtils.runOne(null, "io.kestra.tests", "minimal");
         Execution result3 = runnerUtils.runOne(null, "io.kestra.tests", "minimal");
@@ -1287,7 +1288,7 @@ class ExecutionControllerTest extends JdbcH2ControllerTest {
     }
 
     @Test
-    void setLabelsByIds() throws TimeoutException {
+    void setLabelsByIds() throws TimeoutException, QueueException {
         Execution result1 = runnerUtils.runOne(null, "io.kestra.tests", "minimal");
         Execution result2 = runnerUtils.runOne(null, "io.kestra.tests", "minimal");
         Execution result3 = runnerUtils.runOne(null, "io.kestra.tests", "minimal");
@@ -1303,7 +1304,7 @@ class ExecutionControllerTest extends JdbcH2ControllerTest {
     }
 
     @Test
-    void setLabelsByQuery() throws TimeoutException {
+    void setLabelsByQuery() throws TimeoutException, QueueException {
         Execution result1 = runnerUtils.runOne(null, "io.kestra.tests", "minimal");
         Execution result2 = runnerUtils.runOne(null, "io.kestra.tests", "minimal");
         Execution result3 = runnerUtils.runOne(null, "io.kestra.tests", "minimal");

--- a/webserver/src/test/java/io/kestra/webserver/services/BasicAuthServiceTest.java
+++ b/webserver/src/test/java/io/kestra/webserver/services/BasicAuthServiceTest.java
@@ -2,6 +2,7 @@ package io.kestra.webserver.services;
 
 import com.github.tomakehurst.wiremock.junit5.WireMockTest;
 import io.kestra.core.models.Setting;
+import io.kestra.core.queues.QueueException;
 import io.kestra.core.repositories.SettingRepositoryInterface;
 import io.kestra.core.serializers.JacksonMapper;
 import io.kestra.core.services.InstanceService;
@@ -57,7 +58,7 @@ class BasicAuthServiceTest {
     }
 
     @Test
-    void initFromYamlConfig() throws TimeoutException {
+    void initFromYamlConfig() throws TimeoutException, QueueException {
         assertThat(basicAuthService.isEnabled(), is(true));
 
         assertConfigurationMatchesApplicationYaml();
@@ -66,7 +67,7 @@ class BasicAuthServiceTest {
     }
 
     @Test
-    void secure() throws TimeoutException {
+    void secure() throws TimeoutException, QueueException {
         IllegalArgumentException illegalArgumentException = Assertions.assertThrows(
             IllegalArgumentException.class,
             () -> basicAuthService.save(basicAuthConfiguration.withUsernamePassword("not-an-email", "password"))


### PR DESCRIPTION
Allow to set a limit in size for messages, when exceeded, the message will be refused by the Queue. The JDBC executor and worker has been updated to handle a too big message and fail the execution.

Fixes #4631