### PR TITLE
feat: Plugin Property v2

### DIFF
--- a/core/src/main/java/io/kestra/core/models/property/Property.java
+++ b/core/src/main/java/io/kestra/core/models/property/Property.java
@@ -1,0 +1,222 @@
+package io.kestra.core.models.property;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+import com.fasterxml.jackson.databind.ser.std.StdSerializer;
+import io.kestra.core.exceptions.IllegalVariableEvaluationException;
+import io.kestra.core.runners.RunContext;
+import io.kestra.core.serializers.JacksonMapper;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+
+import java.io.IOException;
+import java.io.Serial;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Define a plugin properties that will be rendered and converted to a target type at use time.
+ *
+ * @param <T> the target type of the property
+ */
+@JsonDeserialize(using = Property.PropertyDeserializer.class)
+@JsonSerialize(using = Property.PropertySerializer.class)
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor(access = AccessLevel.PACKAGE)
+public class Property<T> {
+    private static final ObjectMapper MAPPER = JacksonMapper.ofJson();
+
+    private String expression;
+    private T value;
+
+    // used only by the deserializer
+    Property(String expression) {
+        this.expression = expression;
+    }
+
+    /**
+     * Build a new Property object with a value already set.<br>
+     *
+     * A property build with this method will always return the value passed at build time, no rendering will be done.
+     */
+    public static <V> Property<V> of(V value) {
+        // trick the serializer so the property would not be null at deserialization time
+        Property<V> p = new Property<>(MAPPER.convertValue(value, String.class));
+        p.value = value;
+        return p;
+    }
+
+    /**
+     * Render a property then convert it to its target type.<br>
+     *
+     * This method is safe to be used as many times as you want as the rendering and conversion will be cached.
+     * Warning, due to the caching mechanism, this method is not thread-safe.
+     */
+    public T as(RunContext runContext, Class<T> clazz) throws IllegalVariableEvaluationException {
+        if (this.value == null) {
+            String rendered =  runContext.render(expression);
+            this.value = MAPPER.convertValue(rendered, clazz);
+        }
+
+        return this.value;
+    }
+
+    /**
+     * Render a property with additional variables, then convert it to its target type.<br>
+     *
+     * This method is safe to be used as many times as you want as the rendering and conversion will be cached.
+     * Warning, due to the caching mechanism, this method is not thread-safe.
+     */
+    public T as(RunContext runContext, Class<T> clazz, Map<String, Object> variables) throws IllegalVariableEvaluationException {
+        if (this.value == null) {
+            String rendered =  runContext.render(expression, variables);
+            this.value = MAPPER.convertValue(rendered, clazz);
+        }
+
+        return this.value;
+    }
+
+    /**
+     * Render a property then convert it as a list of target type.<br>
+     *
+     * This method is safe to be used as many times as you want as the rendering and conversion will be cached.
+     * Warning, due to the caching mechanism, this method is not thread-safe.
+     */
+    public <I> T asList(RunContext runContext, Class<I> clazz) throws IllegalVariableEvaluationException {
+        if (this.value == null) {
+            String rendered =  runContext.render(expression);
+            JavaType type = MAPPER.getTypeFactory().constructCollectionLikeType(List.class, clazz);
+            try {
+                this.value = MAPPER.readValue(rendered, type);
+            } catch (JsonProcessingException e) {
+                throw new IllegalVariableEvaluationException(e);
+            }
+        }
+
+        return this.value;
+    }
+
+    /**
+     * Render a property with additional variables, then convert it as a list of target type.<br>
+     *
+     * This method is safe to be used as many times as you want as the rendering and conversion will be cached.
+     * Warning, due to the caching mechanism, this method is not thread-safe.
+     */
+    public <I> T asList(RunContext runContext, Class<I> clazz, Map<String, Object> variables) throws IllegalVariableEvaluationException {
+        if (this.value == null) {
+            String rendered =  runContext.render(expression, variables);
+            JavaType type = MAPPER.getTypeFactory().constructCollectionLikeType(List.class, clazz);
+            try {
+                this.value = MAPPER.readValue(rendered, type);
+            } catch (JsonProcessingException e) {
+                throw new IllegalVariableEvaluationException(e);
+            }
+        }
+
+        return this.value;
+    }
+
+    /**
+     * Render a property then convert it as a list of target type.<br>
+     *
+     * This method is safe to be used as many times as you want as the rendering and conversion will be cached.
+     * Warning, due to the caching mechanism, this method is not thread-safe.
+     */
+    public <K,V> T asMap(RunContext runContext, Class<K> keyClass, Class<V> valueClass) throws IllegalVariableEvaluationException {
+        if (this.value == null) {
+            String rendered =  runContext.render(expression);
+            JavaType type = MAPPER.getTypeFactory().constructMapType(Map.class, keyClass, valueClass);
+            try {
+                this.value = MAPPER.readValue(rendered, type);
+            } catch (JsonProcessingException e) {
+                throw new IllegalVariableEvaluationException(e);
+            }
+        }
+
+        return this.value;
+    }
+
+    /**
+     * Render a property with additional variables, then convert it as a list of target type.<br>
+     *
+     * This method is safe to be used as many times as you want as the rendering and conversion will be cached.
+     * Warning, due to the caching mechanism, this method is not thread-safe.
+     */
+    public <K,V> T asMap(RunContext runContext, Class<K> keyClass, Class<V> valueClass, Map<String, Object> variables) throws IllegalVariableEvaluationException {
+        if (this.value == null) {
+            String rendered =  runContext.render(expression, variables);
+            JavaType type = MAPPER.getTypeFactory().constructMapType(Map.class, keyClass, valueClass);
+            try {
+                this.value = MAPPER.readValue(rendered, type);
+            } catch (JsonProcessingException e) {
+                throw new IllegalVariableEvaluationException(e);
+            }
+        }
+
+        return this.value;
+    }
+
+    @Override
+    public String toString() {
+        return value != null ? value.toString() : expression;
+    }
+
+    // used only by the serializer
+    String getExpression() {
+        return this.expression;
+    }
+
+    static class PropertyDeserializer extends StdDeserializer<Property<?>> {
+        @Serial
+        private static final long serialVersionUID = 1L;
+
+        private static final TypeReference<List<String>> LIST_OF_STRING = new TypeReference<>() {};
+        private static final TypeReference<Map<String, String>> MAP_OF_STRING_STRING = new TypeReference<>() {};
+
+        protected PropertyDeserializer() {
+            super(Property.class);
+        }
+
+        @Override
+        public Property<?> deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
+            String s;
+            if (p.isExpectedStartArrayToken()) {
+                List<String> list = p.readValueAs(LIST_OF_STRING);
+                s = MAPPER.writeValueAsString(list);
+            } else if (p.isExpectedStartObjectToken()) {
+                Map<String, String> list = p.readValueAs(MAP_OF_STRING_STRING);
+                s = MAPPER.writeValueAsString(list);
+            } else {
+                s = p.getValueAsString();
+            }
+            return new Property<>(s);
+        }
+    }
+
+    @SuppressWarnings("rawtypes")
+    static class PropertySerializer extends StdSerializer<Property> {
+        @Serial
+        private static final long serialVersionUID = 1L;
+
+        protected PropertySerializer() {
+            super(Property.class);
+        }
+
+        @Override
+        public void serialize(Property value, JsonGenerator gen, SerializerProvider provider) throws IOException {
+            gen.writeString(value.getExpression());
+        }
+    }
+}

--- a/core/src/main/java/io/kestra/core/runners/DefaultRunContext.java
+++ b/core/src/main/java/io/kestra/core/runners/DefaultRunContext.java
@@ -46,9 +46,6 @@ public class DefaultRunContext extends RunContext {
     private VariableRenderer variableRenderer;
 
     @Inject
-    private StorageInterface storageInterface;
-
-    @Inject
     private MetricRegistry meterRegistry;
 
     @Inject
@@ -173,11 +170,15 @@ public class DefaultRunContext extends RunContext {
         return variableRenderer.renderTyped(inline, this.variables);
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     @SuppressWarnings("unchecked")
     public String render(String inline, Map<String, Object> variables) throws IllegalVariableEvaluationException {
         return variableRenderer.render(inline, mergeWithNullableValues(this.variables, variables));
     }
+
     /**
      * {@inheritDoc}
      */
@@ -469,7 +470,6 @@ public class DefaultRunContext extends RunContext {
             DefaultRunContext context = new DefaultRunContext();
             context.applicationContext = applicationContext;
             context.variableRenderer = variableRenderer;
-            context.storageInterface = storageInterface;
             context.meterRegistry = meterRegistry;
             context.variables = Optional.ofNullable(variables).map(ImmutableMap::copyOf).orElse(ImmutableMap.of());
             context.pluginConfiguration = Optional.ofNullable(pluginConfiguration).map(ImmutableMap::copyOf).orElse(ImmutableMap.of());

--- a/core/src/main/java/io/kestra/core/serializers/TenantSerializer.java
+++ b/core/src/main/java/io/kestra/core/serializers/TenantSerializer.java
@@ -7,13 +7,16 @@ import com.fasterxml.jackson.databind.ser.BeanSerializerModifier;
 import io.kestra.core.models.TenantInterface;
 import io.micronaut.core.annotation.Introspected;
 
+import java.io.Serial;
 import java.util.List;
-import java.util.stream.Collectors;
 import jakarta.inject.Singleton;
 
 @Introspected
 @Singleton
 public class TenantSerializer extends BeanSerializerModifier {
+    @Serial
+    private static final long serialVersionUID = 1L;
+
     @Override
     public List<BeanPropertyWriter> changeProperties(
         SerializationConfig config,

--- a/core/src/main/resources/docs/macro.peb
+++ b/core/src/main/resources/docs/macro.peb
@@ -42,6 +42,25 @@ This property is currently in beta. While it is considered safe for use, please 
 {% endif -%}
 {% endmacro %}
 
+{% macro dynamic(data) -%}
+    {%- set dynamic = "❓" -%}
+    {%- if data['$dynamic'] != null -%}
+        {%- if data['$dynamic'] == true -%}
+            {%- set dynamic = "✔️" -%}
+        {%- else -%}
+            {%- set dynamic = "❌" -%}
+        {% endif -%}
+    {%- elseif data.oneOf != null -%}
+        {%- for current in data.oneOf -%}
+            {%- if current['$dynamic'] == true -%}
+                {%- set dynamic = "✔️" -%}
+            {%- else -%}
+                {%- set dynamic = "❌" -%}
+            {% endif -%}
+        {%- endfor -%}
+    {% endif -%}
+    {{ dynamic }}
+{% endmacro %}
 
 
 {% macro fieldDetail(data) %}

--- a/core/src/main/resources/docs/task.peb
+++ b/core/src/main/resources/docs/task.peb
@@ -66,7 +66,7 @@ type: "{{ cls }}"
     {%- for entry in inputs %}
 ### `{{ entry.key }}`
 {{ fieldType(entry.value) }}
-* **Dynamic:** {{ entry.value['$dynamic'] == true ? "✔️" : (entry.value['$dynamic'] == false ? "❌" : "❓") }}
+* **Dynamic:** {{ dynamic(entry.value) -}}
 * **Required:** {{ entry.value['$required'] == true ? "✔️" : (entry.value['$required'] == false ? "❌" : "❓") }}
 {{ fieldDetail(entry.value) }}
     {%- endfor -%}
@@ -78,7 +78,6 @@ type: "{{ cls }}"
     {%- for entry in outputs %}
 ### `{{ entry.key }}`
 {{ fieldType(entry.value) }}
-* **Dynamic:** {{ entry.value['$dynamic'] == true ? "✔️" : (entry.value['$dynamic'] == false ? "❌" : "❓") }}
 * **Required:** {{ entry.value['$required'] == true ? "✔️" : (entry.value['$required'] == false ? "❌" : "❓") }}
 {{ fieldDetail(entry.value) }}
     {%- endfor -%}
@@ -94,7 +93,7 @@ type: "{{ cls }}"
     {%- for entryProps in entry.value.properties %}
 ##### `{{ entryProps.key }}`
 {{ fieldType(entryProps.value) }}
-* **Dynamic:** {{ entryProps.value['$dynamic'] == true ? "✔️" : (entryProps.value['$dynamic'] == false ? "❌" : "❓") }}
+* **Dynamic:** {{ dynamic(entryProps.value) }}
 * **Required:** {{ entryProps.value['$required'] == true ? "✔️" : (entryProps.value['$required'] == false ? "❌" : "❓") }}
 {{ fieldDetail(entryProps.value) }}
     {%- endfor -%}

--- a/core/src/test/java/io/kestra/core/docs/ClassPluginDocumentationTest.java
+++ b/core/src/test/java/io/kestra/core/docs/ClassPluginDocumentationTest.java
@@ -1,6 +1,7 @@
 package io.kestra.core.docs;
 
 import io.kestra.core.Helpers;
+import io.kestra.core.models.property.DynamicPropertyExampleTask;
 import io.kestra.core.models.tasks.runners.TaskRunner;
 import io.kestra.plugin.core.runner.Process;
 import io.kestra.core.models.tasks.Task;
@@ -122,6 +123,39 @@ class ClassPluginDocumentationTest {
             assertThat(doc.getCls(), is("io.kestra.plugin.core.runner.Process"));
             assertThat(doc.getPropertiesSchema().get("title"), is("Task runner that executes a task as a subprocess on the Kestra host."));
             assertThat(doc.getDefs(), anEmptyMap());
+        }));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void dynamicProperty() throws URISyntaxException {
+        Helpers.runApplicationContext(throwConsumer((applicationContext) -> {
+            JsonSchemaGenerator jsonSchemaGenerator = applicationContext.getBean(JsonSchemaGenerator.class);
+
+            PluginScanner pluginScanner = new PluginScanner(ClassPluginDocumentationTest.class.getClassLoader());
+            RegisteredPlugin scan = pluginScanner.scan();
+
+            ClassPluginDocumentation<? extends DynamicPropertyExampleTask> doc = ClassPluginDocumentation.of(jsonSchemaGenerator, scan, DynamicPropertyExampleTask.class, null);
+
+            assertThat(doc.getCls(), is("io.kestra.core.models.property.DynamicPropertyExampleTask"));
+            assertThat(doc.getDefs(), aMapWithSize(4));
+            Map<String, Object> properties = (Map<String, Object>) doc.getPropertiesSchema().get("properties");
+            assertThat(properties, aMapWithSize(15));
+
+            Map<String, Object> number = (Map<String, Object>) properties.get("number");
+            assertThat(number.get("oneOf"), notNullValue());
+            List<Map<String, Object>> oneOf = (List<Map<String, Object>>) number.get("oneOf");
+            assertThat(oneOf, hasSize(2));
+            assertThat(oneOf.getFirst().get("type"), is("integer"));
+            assertThat(oneOf.getFirst().get("$dynamic"), is(true));
+            assertThat(oneOf.get(1).get("type"), is("string"));
+            assertThat(oneOf.get(1).get("format"), is(".*{{.*}}.*"));
+
+            Map<String, Object> withDefault = (Map<String, Object>) properties.get("withDefault");
+            assertThat(withDefault.get("type"), is("string"));
+            assertThat(withDefault.get("default"), is("Default Value"));
+            assertThat(withDefault.get("$dynamic"), is(true));
+            System.out.println(withDefault);
         }));
     }
 }

--- a/core/src/test/java/io/kestra/core/models/property/DynamicPropertyExampleTask.java
+++ b/core/src/test/java/io/kestra/core/models/property/DynamicPropertyExampleTask.java
@@ -1,0 +1,79 @@
+package io.kestra.core.models.property;
+
+import io.kestra.core.models.annotations.Plugin;
+import io.kestra.core.models.tasks.RunnableTask;
+import io.kestra.core.models.tasks.Task;
+import io.kestra.core.runners.RunContext;
+import jakarta.validation.constraints.NotNull;
+import lombok.*;
+import lombok.experimental.SuperBuilder;
+import org.slf4j.event.Level;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+
+@SuperBuilder
+@ToString
+@EqualsAndHashCode
+@Getter
+@NoArgsConstructor
+@Plugin
+public class DynamicPropertyExampleTask extends Task implements RunnableTask<DynamicPropertyExampleTask.Output> {
+    @NotNull
+    private Property<Integer> number;
+
+    @NotNull
+    private Property<String> string;
+
+    @NotNull
+    @Builder.Default
+    private Property<String> withDefault = Property.of("Default Value");
+
+    @NotNull
+    @Builder.Default
+    private Property<Level> level = Property.of(Level.INFO);
+
+    @NotNull
+    private Property<Duration> someDuration;
+
+    @NotNull
+    private Property<List<String>> items;
+
+    @NotNull
+    private Property<Map<String, String>> properties;
+
+
+    @Override
+    public Output run(RunContext runContext) throws Exception {
+        String value = String.format(
+                "%s - %s - %s - %s",
+                string.as(runContext, String.class),
+                number.as(runContext, Integer.class),
+                withDefault.as(runContext, String.class),
+                someDuration.as(runContext, Duration.class)
+            );
+
+        Level level = this.level.as(runContext, Level.class);
+
+        List<String> list = items.asList(runContext, String.class);
+
+        Map<String, String> map = properties.asMap(runContext, String.class, String.class);
+
+        return Output.builder()
+            .value(value)
+            .level(level)
+            .list(list)
+            .map(map)
+            .build();
+    }
+
+    @SuperBuilder(toBuilder = true)
+    @Getter
+    public static class Output implements io.kestra.core.models.tasks.Output {
+        private String value;
+        private Level level;
+        private List<String> list;
+        private Map<String, String> map;
+    }
+}

--- a/core/src/test/java/io/kestra/core/models/property/PropertyTest.java
+++ b/core/src/test/java/io/kestra/core/models/property/PropertyTest.java
@@ -1,0 +1,95 @@
+package io.kestra.core.models.property;
+
+import io.kestra.core.junit.annotations.KestraTest;
+import io.kestra.core.runners.RunContextFactory;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.Test;
+import org.slf4j.event.Level;
+
+import java.util.Map;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+
+@KestraTest
+class PropertyTest {
+
+    @Inject
+    private RunContextFactory runContextFactory;
+
+    @Test
+    void test() throws Exception {
+        var task = DynamicPropertyExampleTask.builder()
+            .number(new Property<>("{{numberValue}}"))
+            .string(new Property<>("{{stringValue}}"))
+            .level(new Property<>("{{levelValue}}"))
+            .someDuration(new Property<>("{{durationValue}}"))
+            .withDefault(new Property<>("{{defaultValue}}"))
+            .items(new Property<>("""
+                ["{{item1}}", "{{item2}}"]"""))
+            .properties(new Property<>("""
+                {
+                  "key1": "{{value1}}",
+                  "key2": "{{value2}}"
+                }"""))
+            .build();
+        var runContext = runContextFactory.of(Map.of(
+            "numberValue", 9,
+            "stringValue", "test",
+            "levelValue", "INFO",
+            "durationValue", "PT60S",
+            "defaultValue", "not-default",
+            "item1", "item1",
+            "item2", "item2",
+            "value1", "value1",
+            "value2", "value2"
+        ));
+
+        var output = task.run(runContext);
+
+        assertThat(output, notNullValue());
+        assertThat(output.getValue(), is("test - 9 - not-default - PT1M"));
+        assertThat(output.getLevel(), is(Level.INFO));
+        assertThat(output.getList(), containsInAnyOrder("item1", "item2"));
+        assertThat(output.getMap(), aMapWithSize(2));
+        assertThat(output.getMap().get("key1"), is("value1"));
+        assertThat(output.getMap().get("key2"), is("value2"));
+    }
+
+    @Test
+    void withDefaults() throws Exception {
+        var task = DynamicPropertyExampleTask.builder()
+            .number(new Property<>("{{numberValue}}"))
+            .string(new Property<>("{{stringValue}}"))
+            .level(new Property<>("{{levelValue}}"))
+            .someDuration(new Property<>("{{durationValue}}"))
+            .items(new Property<>("""
+                ["{{item1}}", "{{item2}}"]"""))
+            .properties(new Property<>("""
+                {
+                  "key1": "{{value1}}",
+                  "key2": "{{value2}}"
+                }"""))
+            .build();
+        var runContext = runContextFactory.of(Map.of(
+            "numberValue", 9,
+            "stringValue", "test",
+            "levelValue", "INFO",
+            "durationValue", "PT60S",
+            "item1", "item1",
+            "item2", "item2",
+            "value1", "value1",
+            "value2", "value2"
+        ));
+
+        var output = task.run(runContext);
+
+        assertThat(output, notNullValue());
+        assertThat(output.getValue(), is("test - 9 - Default Value - PT1M"));
+        assertThat(output.getLevel(), is(Level.INFO));
+        assertThat(output.getList(), containsInAnyOrder("item1", "item2"));
+        assertThat(output.getMap(), aMapWithSize(2));
+        assertThat(output.getMap().get("key1"), is("value1"));
+        assertThat(output.getMap().get("key2"), is("value2"));
+    }
+}


### PR DESCRIPTION
Fixes #893

Exampe flow:

```yaml
id: dynamic
namespace: company.team

inputs:
  - id: level
    type: STRING
    defaults: WARN

tasks:
  - id: hello
    type: io.kestra.plugin.core.dynamic.DynamicPropertyExampleTask
    number: "{{flow.revision}}"
    string: "{{flow.namespace}}.{{flow.id}}"
    someDuration: "PT30S"
    level: "{{inputs.level}}"
    items:
      - "{{flow.namespace}}"
      - "{{flow.id}}"
    properties:
      revision:  "{{flow.revision}}"
```

Using this task:

```java
@SuperBuilder
@ToString
@EqualsAndHashCode
@Getter
@NoArgsConstructor
@Plugin
class DynamicPropertyExampleTask extends Task implements RunnableTask<DynamicPropertyExampleTask.Output> {
    @NotNull
    private Property<Integer> number;

    @NotNull
    private Property<String> string;

    @NotNull
    @Builder.Default
    private Property<String> withDefault = Property.of("Default Value");

    @NotNull
    @Builder.Default
    private Property<Level> level = Property.of(Level.INFO);

    @NotNull
    private Property<Duration> someDuration;

    @NotNull
    private Property<List<String>> items;

    @NotNull
    private Property<Map<String, String>> properties;


    @Override
    public Output run(RunContext runContext) throws Exception {
        String value = String.format(
                "%s - %s - %s - %s",
                string.as(runContext, String.class),
                number.as(runContext, Integer.class),
                withDefault.as(runContext, String.class),
                someDuration.as(runContext, Duration.class)
            );

        Level level = this.level.as(runContext, Level.class);

        List<String> list = items.asList(runContext, String.class);

        Map<String, String> map = properties.asMap(runContext, String.class, String.class);

        return Output.builder()
            .value(value)
            .level(level)
            .list(list)
            .map(map)
            .build();
    }

    @SuperBuilder(toBuilder = true)
    @Getter
    public static class Output implements io.kestra.core.models.tasks.Output {
        private String value;
        private Level level;
        private List<String> list;
        private Map<String, String> map;
    }
}
```

It generates the following schema (partial) which is correctly rendered in the documentation and validated:

```json
{
  "properties": {
    "$schema": "https://json-schema.org/draft/2019-09/schema",
    "properties": {
      "number": {
        "oneOf": [
          {
            "type": "integer",
            "$dynamic": true
          },
          {
            "type": "string",
            "format": ".*{{.*}}.*",
            "$dynamic": true
          }
        ],
        "$required": true
      },
      "string": {
        "type": "string",
        "$dynamic": true,
        "$required": true
      },
      "withDefault": {
        "type": "string",
        "$dynamic": true,
        "$required": false
      }
    },
    "required": [
      "number",
      "string"
    ]
  },
  "outputs": {
    "$schema": "https://json-schema.org/draft/2019-09/schema"
  },
  "definitions": {}
}
```