### PR TITLE
docs: Update PurgeLogs.java

### DIFF
--- a/core/src/main/java/io/kestra/plugin/core/log/PurgeLogs.java
+++ b/core/src/main/java/io/kestra/plugin/core/log/PurgeLogs.java
@@ -46,7 +46,7 @@ import java.util.List;
                 "- TRACE",
                 "- DEBUG",
                 "- INFO",
-                "- WARNING",
+                "- WARN",
             }
         )
     }


### PR DESCRIPTION
Fix `WARNING` => `WARN`


Following this example gave me this error:

```
Illegal flow yaml: Cannot deserialize value of type org.slf4j.event.Level from String “WARNING”: not one of the values accepted for Enum class: [ERROR, DEBUG, TRACE, INFO, WARN]
 at [Source: UNKNOWN; byte offset: #UNKNOWN] (through reference chain: io.kestra.core.models.flows.Flow[“tasks”]->java.util.ArrayList[0]->io.kestra.plugin.core.log.PurgeLogs[“logLevels”]->java.util.ArrayList[3])
```

See also: https://www.slf4j.org/api/org/slf4j/event/Level.html
