### PR TITLE
feat(jdbc): avoid loading all excutions in memory

### DIFF
--- a/jdbc/src/main/java/io/kestra/jdbc/repository/AbstractJdbcExecutionRepository.java
+++ b/jdbc/src/main/java/io/kestra/jdbc/repository/AbstractJdbcExecutionRepository.java
@@ -213,11 +213,13 @@ public abstract class AbstractJdbcExecutionRepository extends AbstractJdbcReposi
                         deleted
                     );
 
-                    select.fetch()
-                        .map(this.jdbcRepository::map)
-                        .forEach(emitter::next);
-
-                    emitter.complete();
+                    // fetchSize will fetch rows 100 by 100 even for databases where the driver loads all in memory
+                    // using a stream will fetch lazily, otherwise all fetches would be done before starting emitting the items
+                    try (var stream = select.fetchSize(100).stream()) {
+                        stream.map(this.jdbcRepository::map).forEach(emitter::next);
+                    } finally {
+                        emitter.complete();
+                    }
                 }),
             FluxSink.OverflowStrategy.BUFFER
         );


### PR DESCRIPTION
Fixes https://github.com/kestra-io/kestra-ee/issues/1262