### PR TITLE
feat: add the ability for a task or trigger to log to a file

### DIFF
--- a/core/src/main/java/io/kestra/core/models/executions/ExecutionTrigger.java
+++ b/core/src/main/java/io/kestra/core/models/executions/ExecutionTrigger.java
@@ -1,11 +1,13 @@
 package io.kestra.core.models.executions;
 
+import io.kestra.plugin.core.trigger.Webhook;
 import io.micronaut.core.annotation.Introspected;
 import lombok.Builder;
 import lombok.Value;
 import io.kestra.core.models.tasks.Output;
 import io.kestra.core.models.triggers.AbstractTrigger;
 
+import java.net.URI;
 import java.util.Collections;
 import java.util.Map;
 import jakarta.validation.constraints.NotNull;
@@ -22,19 +24,31 @@ public class ExecutionTrigger {
 
     Map<String, Object> variables;
 
+    URI logFile;
+
     public static ExecutionTrigger of(AbstractTrigger abstractTrigger, Output output) {
+        return of(abstractTrigger, output, null);
+    }
+
+    public static ExecutionTrigger of(AbstractTrigger abstractTrigger, Output output, URI logFile) {
         return ExecutionTrigger.builder()
             .id(abstractTrigger.getId())
             .type(abstractTrigger.getType())
             .variables(output != null ? output.toMap() : Collections.emptyMap())
+            .logFile(logFile)
             .build();
     }
 
     public static ExecutionTrigger of(AbstractTrigger abstractTrigger, Map<String, Object> variables) {
+        return of(abstractTrigger, variables, null);
+    }
+
+    public static ExecutionTrigger of(AbstractTrigger abstractTrigger, Map<String, Object> variables, URI logFile) {
         return ExecutionTrigger.builder()
             .id(abstractTrigger.getId())
             .type(abstractTrigger.getType())
             .variables(variables)
+            .logFile(logFile)
             .build();
     }
 }

--- a/core/src/main/java/io/kestra/core/models/executions/TaskRunAttempt.java
+++ b/core/src/main/java/io/kestra/core/models/executions/TaskRunAttempt.java
@@ -4,9 +4,11 @@ import lombok.Builder;
 import lombok.Value;
 import io.kestra.core.models.flows.State;
 
+import java.net.URI;
 import java.util.List;
 
 import jakarta.validation.constraints.NotNull;
+import lombok.With;
 
 @Value
 @Builder
@@ -22,9 +24,13 @@ public class TaskRunAttempt {
     @NotNull
     State state;
 
+    @With
+    URI logFile;
+
     public TaskRunAttempt withState(State.Type state) {
         return new TaskRunAttempt(
-            this.state.withState(state)
+            this.state.withState(state),
+            this.logFile
         );
     }
 }

--- a/core/src/main/java/io/kestra/core/models/tasks/Task.java
+++ b/core/src/main/java/io/kestra/core/models/tasks/Task.java
@@ -48,6 +48,9 @@ abstract public class Task implements TaskInterface {
     @Builder.Default
     private boolean allowFailure = false;
 
+    @Builder.Default
+    private boolean logToFile = false;
+
     public Optional<Task> findById(String id) {
         if (this.getId().equals(id)) {
             return Optional.of(this);

--- a/core/src/main/java/io/kestra/core/models/triggers/AbstractTrigger.java
+++ b/core/src/main/java/io/kestra/core/models/triggers/AbstractTrigger.java
@@ -63,6 +63,9 @@ abstract public class AbstractTrigger implements TriggerInterface {
     )
     private List<State.Type> stopAfter;
 
+    @Builder.Default
+    private boolean logToFile = false;
+
     /**
      * For backward compatibility: we rename minLogLevel to logLevel.
      * @deprecated use {@link #logLevel} instead

--- a/core/src/main/java/io/kestra/core/models/triggers/TriggerService.java
+++ b/core/src/main/java/io/kestra/core/models/triggers/TriggerService.java
@@ -17,8 +17,8 @@ public abstract class TriggerService {
         TriggerContext context,
         Map<String, Object> variables
     ) {
-        ExecutionTrigger executionTrigger = ExecutionTrigger.of(trigger, variables);
         RunContext runContext = conditionContext.getRunContext();
+        ExecutionTrigger executionTrigger = ExecutionTrigger.of(trigger, variables, runContext.logFileURI());
 
         return generateExecution(runContext.getTriggerExecutionId(), trigger, context, executionTrigger, conditionContext.getFlow().getRevision());
     }
@@ -29,8 +29,8 @@ public abstract class TriggerService {
         TriggerContext context,
         Output output
     ) {
-        ExecutionTrigger executionTrigger = ExecutionTrigger.of(trigger, output);
         RunContext runContext = conditionContext.getRunContext();
+        ExecutionTrigger executionTrigger = ExecutionTrigger.of(trigger, output, runContext.logFileURI());
 
         return generateExecution(runContext.getTriggerExecutionId(), trigger, context, executionTrigger, conditionContext.getFlow().getRevision());
     }
@@ -41,7 +41,8 @@ public abstract class TriggerService {
         TriggerContext context,
         Output output
     ) {
-        ExecutionTrigger executionTrigger = ExecutionTrigger.of(trigger, output);
+        RunContext runContext = conditionContext.getRunContext();
+        ExecutionTrigger executionTrigger = ExecutionTrigger.of(trigger, output, runContext.logFileURI());
 
         return generateExecution(IdUtils.create(), trigger, context, executionTrigger, conditionContext.getFlow().getRevision());
     }

--- a/core/src/main/java/io/kestra/core/runners/DefaultRunContext.java
+++ b/core/src/main/java/io/kestra/core/runners/DefaultRunContext.java
@@ -20,10 +20,13 @@ import jakarta.inject.Provider;
 import lombok.AllArgsConstructor;
 import lombok.NoArgsConstructor;
 import lombok.With;
+import org.apache.commons.lang3.RandomStringUtils;
 import org.slf4j.Logger;
 
-import java.io.IOException;
+import java.io.*;
 import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.security.GeneralSecurityException;
 import java.util.*;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -59,7 +62,7 @@ public class DefaultRunContext extends RunContext {
 
     private Map<String, Object> variables;
     private List<AbstractMetricEntry<?>> metrics = new ArrayList<>();
-    private Supplier<Logger> logger;
+    private RunContextLogger logger;
     private final List<WorkerTaskResult> dynamicWorkerTaskResult = new ArrayList<>();
     private String triggerExecutionId;
     private Storage storage;
@@ -118,7 +121,7 @@ public class DefaultRunContext extends RunContext {
         this.storage = storage;
     }
 
-    void setLogger(final Supplier<Logger> logger) {
+    void setLogger(final RunContextLogger logger) {
         this.logger = logger;
     }
 
@@ -271,6 +274,31 @@ public class DefaultRunContext extends RunContext {
         return logger.get();
     }
 
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public URI logFileURI() {
+        if (logger.getLogFile() != null) {
+            try {
+                logger.closeLogFile();
+                String logName = "log-" + RandomStringUtils.randomAlphanumeric(5).toLowerCase() + ".txt";
+                Path logFile = this.workingDir.createFile(logName);
+                try (OutputStream out = new BufferedOutputStream(Files.newOutputStream(logFile))) {
+                    Files.copy(logger.getLogFile().toPath(), out);
+                }
+                URI logFileURI = this.storage.putFile(logFile.toFile());
+                if (!logger.getLogFile().delete()) {
+                    logger().warn("Unable to delete the log file {}", logger.getLogFile().toPath());
+                }
+                return logFileURI;
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        }
+        return null;
+    }
+
     // for serialization backward-compatibility
     @Override
     @JsonIgnore
@@ -376,9 +404,9 @@ public class DefaultRunContext extends RunContext {
     @Override
     public void cleanup() {
         try {
-           workingDir.cleanup();
+            workingDir.cleanup();
         } catch (IOException ex) {
-            new RunContextLogger().logger().warn("Unable to cleanup worker task", ex);
+            logger().warn("Unable to cleanup worker task", ex);
         }
     }
 
@@ -458,7 +486,7 @@ public class DefaultRunContext extends RunContext {
         private WorkingDir workingDir;
         private Storage storage;
         private String triggerExecutionId;
-        private Supplier<Logger> logger;
+        private RunContextLogger logger;
         private KVStoreService kvStoreService;
 
         /**

--- a/core/src/main/java/io/kestra/core/runners/RunContext.java
+++ b/core/src/main/java/io/kestra/core/runners/RunContext.java
@@ -84,6 +84,14 @@ public abstract class RunContext {
      */
     public abstract Logger logger();
 
+    /**
+     * Gets the log file URI inside the internal storage.
+     * Only populated if the task or trigger is configured to log o a file.<br>
+     *
+     * Warning: this method can be called only once for an attempt.
+     */
+    public abstract URI logFileURI();
+
     // for serialization backward-compatibility
     @JsonIgnore
     public abstract URI getStorageOutputPrefix();

--- a/core/src/main/java/io/kestra/core/runners/RunContextLoggerFactory.java
+++ b/core/src/main/java/io/kestra/core/runners/RunContextLoggerFactory.java
@@ -9,9 +9,8 @@ import io.kestra.core.models.triggers.AbstractTrigger;
 import io.kestra.core.models.triggers.TriggerContext;
 import io.kestra.core.queues.QueueFactoryInterface;
 import io.kestra.core.queues.QueueInterface;
-import io.micronaut.context.ApplicationContext;
-import io.micronaut.inject.qualifiers.Qualifiers;
 import jakarta.inject.Inject;
+import jakarta.inject.Named;
 import jakarta.inject.Singleton;
 
 /**
@@ -21,44 +20,42 @@ import jakarta.inject.Singleton;
 public class RunContextLoggerFactory {
 
     @Inject
-    protected ApplicationContext applicationContext;
+    @Named(QueueFactoryInterface.WORKERTASKLOG_NAMED)
+    private QueueInterface<LogEntry> logQueue;
 
     public RunContextLogger create(TaskRun taskRun, Task task) {
         return new RunContextLogger(
-            getLogQueue(),
+            logQueue,
             LogEntry.of(taskRun),
-            task.getLogLevel()
+            task.getLogLevel(),
+            task.isLogToFile()
         );
     }
 
     public RunContextLogger create(Execution execution) {
         return new RunContextLogger(
-            getLogQueue(),
+            logQueue,
             LogEntry.of(execution),
-            null
+            null,
+            false
         );
     }
 
     public RunContextLogger create(TriggerContext triggerContext, AbstractTrigger trigger) {
         return new RunContextLogger(
-            getLogQueue(),
+            logQueue,
             LogEntry.of(triggerContext, trigger),
-            trigger.getLogLevel()
+            trigger.getLogLevel(),
+            trigger.isLogToFile()
         );
     }
 
     public RunContextLogger create(Flow flow, AbstractTrigger trigger) {
         return new RunContextLogger(
-            getLogQueue(),
+            logQueue,
             LogEntry.of(flow, trigger),
-            trigger.getLogLevel()
+            trigger.getLogLevel(),
+            trigger.isLogToFile()
         );
-    }
-    @SuppressWarnings("unchecked")
-    private QueueInterface<LogEntry> getLogQueue() {
-        return applicationContext.findBean(
-            QueueInterface.class,
-            Qualifiers.byName(QueueFactoryInterface.WORKERTASKLOG_NAMED)
-        ).orElseThrow();
     }
 }

--- a/core/src/main/java/io/kestra/plugin/core/flow/WorkingDirectory.java
+++ b/core/src/main/java/io/kestra/plugin/core/flow/WorkingDirectory.java
@@ -329,9 +329,9 @@ public class WorkingDirectory extends Sequential implements NamespaceFilesInterf
                     }
 
                     archive.finish();
-                    File archiveFile = File.createTempFile("archive", ".zip");
-                    Files.write(archiveFile.toPath(), bos.toByteArray());
-                    URI uri = runContext.storage().putCacheFile(archiveFile, getId(), taskRun.getValue());
+                    Path archiveFile = runContext.workingDir().createTempFile( ".zip");
+                    Files.write(archiveFile, bos.toByteArray());
+                    URI uri = runContext.storage().putCacheFile(archiveFile.toFile(), getId(), taskRun.getValue());
                     runContext.logger().debug("Caching in {}", uri);
                 }
             } else {

--- a/core/src/main/resources/logback/base.xml
+++ b/core/src/main/resources/logback/base.xml
@@ -2,6 +2,10 @@
 <included>
     <!-- Remove logback startup log -->
     <statusListener class="ch.qos.logback.core.status.NopStatusListener" />
+    <!--
+        The pattern is also defined in RunContextLogger.FileAppender.
+        Be careful to change it in both places.
+    -->
     <property name="pattern" value="%d{ISO8601} %highlight(%-5.5level) %magenta(%-12.36thread) %cyan(%-12.36logger{36}) %msg%n" />
 
     <logger name="io.kestra" level="INFO" />

--- a/core/src/test/java/io/kestra/core/docs/ClassPluginDocumentationTest.java
+++ b/core/src/test/java/io/kestra/core/docs/ClassPluginDocumentationTest.java
@@ -140,7 +140,7 @@ class ClassPluginDocumentationTest {
             assertThat(doc.getCls(), is("io.kestra.core.models.property.DynamicPropertyExampleTask"));
             assertThat(doc.getDefs(), aMapWithSize(4));
             Map<String, Object> properties = (Map<String, Object>) doc.getPropertiesSchema().get("properties");
-            assertThat(properties, aMapWithSize(15));
+            assertThat(properties, aMapWithSize(16));
 
             Map<String, Object> number = (Map<String, Object>) properties.get("number");
             assertThat(number.get("oneOf"), notNullValue());

--- a/core/src/test/java/io/kestra/core/runners/LogToFileTest.java
+++ b/core/src/test/java/io/kestra/core/runners/LogToFileTest.java
@@ -1,0 +1,41 @@
+package io.kestra.core.runners;
+
+import io.kestra.core.models.executions.Execution;
+import io.kestra.core.models.executions.TaskRun;
+import io.kestra.core.models.executions.TaskRunAttempt;
+import io.kestra.core.models.flows.State;
+import io.kestra.core.storages.StorageInterface;
+import jakarta.inject.Inject;
+import org.apache.commons.io.IOUtils;
+import org.junit.jupiter.api.Test;
+
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+
+public class LogToFileTest extends AbstractMemoryRunnerTest {
+    @Inject
+    private StorageInterface storage;
+
+    @Test
+    void task() throws Exception {
+        Execution execution = runnerUtils.runOne(null, "io.kestra.tests", "log-to-file");
+
+        assertThat(execution.getTaskRunList(), hasSize(1));
+        assertThat(execution.getState().getCurrent(), is(State.Type.SUCCESS));
+        TaskRun taskRun = execution.getTaskRunList().getFirst();
+        assertThat(taskRun.getAttempts(), hasSize(1));
+        TaskRunAttempt attempt = taskRun.getAttempts().getFirst();
+        assertThat(attempt.getLogFile(), notNullValue());
+
+        InputStream inputStream = storage.get(null, attempt.getLogFile());
+        List<String> strings = IOUtils.readLines(inputStream, StandardCharsets.UTF_8);
+        assertThat(strings, notNullValue());
+        assertThat(strings.size(), is(1));
+        assertThat(strings.getFirst(), containsString("INFO"));
+        assertThat(strings.getFirst(), containsString("Hello World!"));
+    }
+}

--- a/core/src/test/java/io/kestra/core/runners/RunContextLoggerTest.java
+++ b/core/src/test/java/io/kestra/core/runners/RunContextLoggerTest.java
@@ -43,7 +43,8 @@ class RunContextLoggerTest {
         RunContextLogger runContextLogger = new RunContextLogger(
             logQueue,
             LogEntry.of(execution),
-            Level.TRACE
+            Level.TRACE,
+            false
         );
 
         Logger logger = runContextLogger.logger();
@@ -74,7 +75,8 @@ class RunContextLoggerTest {
         RunContextLogger runContextLogger = new RunContextLogger(
             logQueue,
             LogEntry.of(execution),
-            Level.TRACE
+            Level.TRACE,
+            false
         );
 
         Logger logger = runContextLogger.logger();
@@ -97,7 +99,8 @@ class RunContextLoggerTest {
         RunContextLogger runContextLogger = new RunContextLogger(
             logQueue,
             LogEntry.of(execution),
-            Level.TRACE
+            Level.TRACE,
+            false
         );
 
         runContextLogger.usedSecret("doe.com");

--- a/core/src/test/java/io/kestra/core/serializers/YamlFlowParserTest.java
+++ b/core/src/test/java/io/kestra/core/serializers/YamlFlowParserTest.java
@@ -197,7 +197,7 @@ class YamlFlowParserTest {
             () -> this.parse("flows/invalids/invalid-property.yaml")
         );
 
-        assertThat(exception.getMessage(), is("Unrecognized field \"invalid\" (class io.kestra.plugin.core.debug.Return), not marked as ignorable (10 known properties: \"logLevel\", \"timeout\", \"format\", \"retry\", \"type\", \"id\", \"description\", \"workerGroup\", \"disabled\", \"allowFailure\"])"));
+        assertThat(exception.getMessage(), is("Unrecognized field \"invalid\" (class io.kestra.plugin.core.debug.Return), not marked as ignorable (11 known properties: \"logLevel\", \"timeout\", \"format\", \"retry\", \"type\", \"id\", \"description\", \"workerGroup\", \"logToFile\", \"disabled\", \"allowFailure\"])"));
         assertThat(exception.getConstraintViolations().size(), is(1));
         assertThat(exception.getConstraintViolations().iterator().next().getPropertyPath().toString(), is("io.kestra.core.models.flows.Flow[\"tasks\"]->java.util.ArrayList[0]->io.kestra.plugin.core.debug.Return[\"invalid\"]"));
     }

--- a/core/src/test/resources/flows/valids/log-to-file.yaml
+++ b/core/src/test/resources/flows/valids/log-to-file.yaml
@@ -1,0 +1,8 @@
+id: log-to-file
+namespace: io.kestra.tests
+
+tasks:
+  - id: hello
+    type: io.kestra.plugin.core.log.Log
+    message: Hello World!
+    logToFile: true

--- a/ui/src/components/executions/TaskRunLine.vue
+++ b/ui/src/components/executions/TaskRunLine.vue
@@ -189,7 +189,7 @@
             },
             flow: {
                 type: Object,
-                default: null
+                default: undefined
             },
             forcedAttemptNumber: {
                 type: Number,
@@ -263,7 +263,7 @@
                 return this.attempts(taskRun)[this.selectedAttemptNumberByTaskRunId[taskRun.id] ?? 0];
             },
             taskType(taskRun) {
-                if(!taskRun) return undefined;        
+                if(!taskRun) return undefined;
 
                 const task = FlowUtils.findTaskById(this.flow, taskRun.taskId);
                 const parentTaskRunId = taskRun.parentTaskRunId;

--- a/ui/src/components/logs/LogLine.vue
+++ b/ui/src/components/logs/LogLine.vue
@@ -159,7 +159,6 @@
         cursor: text;
         white-space: pre-wrap;
         word-break: break-all;
-        padding: calc(var(--spacer) / 2);
         display: flex;
         align-items: start;
         gap: $spacer;

--- a/ui/src/components/logs/TaskRunDetails.vue
+++ b/ui/src/components/logs/TaskRunDetails.vue
@@ -49,12 +49,23 @@
                                 :size-dependencies="[item.message, item.image]"
                                 :data-index="index"
                             >
+                                <el-button-group class="line" v-if="item.logFile">
+                                    <a class="el-button el-button--small el-button--primary" :href="fileUrl(item.logFile)" target="_blank">
+                                        <Download />
+                                        {{ $t('download') }}
+                                    </a>
+                                    <FilePreview :value="item.logFile" :execution-id="followedExecution.id" />
+                                    <el-button disabled size="small" type="primary" v-if="logFileSizeByPath[item.logFile]">
+                                        ({{ logFileSizeByPath[item.logFile] }})
+                                    </el-button>
+                                </el-button-group>
                                 <log-line
+                                    class="line"
                                     :key="index"
                                     :level="level"
                                     :log="item"
                                     :exclude-metas="excludeMetas"
-                                    v-if="filter === '' || item.message?.toLowerCase().includes(filter)"
+                                    v-else-if="filter === '' || item.message?.toLowerCase().includes(filter)"
                                 />
                                 <TaskRunDetails
                                     v-if="!taskRunId && isSubflow(currentTaskRun) && shouldDisplaySubflow(index, currentTaskRun) && currentTaskRun.outputs?.executionId"
@@ -92,15 +103,20 @@
     import TaskRunLine from "../executions/TaskRunLine.vue";
     import FlowUtils from "../../utils/flowUtils";
     import throttle from "lodash/throttle";
+    import FilePreview from "../executions/FilePreview.vue";
+    import {apiUrl} from "override/utils/route.js";
+    import Utils from "../../utils/utils.js";
 
     export default {
         name: "TaskRunDetails",
         components: {
+            FilePreview,
             TaskRunLine,
             ForEachStatus,
             LogLine,
             DynamicScroller,
             DynamicScrollerItem,
+            Download
         },
         emits: ["opened-taskruns-count", "follow", "reset-expand-collapse-all-switch"],
         props: {
@@ -170,6 +186,7 @@
                 flow: undefined,
                 logsBuffer: [],
                 shownSubflowsIds: [],
+                logFileSizeByPath: {},
                 throttledExecutionUpdate: throttle(function (event) {
                     this.followedExecution = JSON.parse(event.data)
                 }, 500)
@@ -286,8 +303,16 @@
                 return Object.fromEntries(this.currentTaskRuns.map(taskRun => [taskRun.id, taskRun]));
             },
             logsWithIndexByAttemptUid() {
-                const indexedLogs = this.logs
-                    .filter(logLine => this.filter === "" || logLine?.message.toLowerCase().includes(this.filter) || this.isSubflow(this.taskRunById[logLine.taskRunId]))
+                const logFilesWrappers = this.currentTaskRuns.flatMap(taskRun =>
+                    this.attempts(taskRun)
+                        .filter(attempt => attempt.logFile !== undefined)
+                        .map((attempt, attemptNumber) => ({logFile: attempt.logFile, taskRunId: taskRun.id, attemptNumber}))
+                );
+
+                logFilesWrappers.forEach(logFileWrapper => this.fetchAndStoreLogFileSize(logFileWrapper.logFile))
+
+                const indexedLogs = [...this.logs, ...logFilesWrappers]
+                    .filter(logLine => logLine.logFile !== undefined || (this.filter === "" || logLine?.message.toLowerCase().includes(this.filter) || this.isSubflow(this.taskRunById[logLine.taskRunId])))
                     .map((logLine, index) => ({...logLine, index}));
 
                 return _groupBy(indexedLogs, indexedLog => this.attemptUid(indexedLog.taskRunId, indexedLog.attemptNumber));
@@ -316,6 +341,19 @@
             }
         },
         methods: {
+            fileUrl(path) {
+                return `${apiUrl(this.$store)}/executions/${this.followedExecution.id}/file?path=${path}`;
+            },
+            async fetchAndStoreLogFileSize(path){
+                if (this.logFileSizeByPath[path] !== undefined) {
+                    return;
+                }
+
+                const axiosResponse = await this.$http(`${apiUrl(this.$store)}/executions/${this.followedExecution.id}/file/metas?path=${path}`, {
+                    validateStatus: (status) => status === 200 || status === 404 || status === 422
+                });
+                this.logFileSizeByPath[path] = Utils.humanFileSize(axiosResponse.data.size);
+            },
             closeExecutionSSE() {
                 if (this.executionSSE) {
                     this.executionSSE.close();
@@ -590,6 +628,10 @@
             max-height: 50vh;
             transition: max-height 0.2s ease-out;
             margin-top: calc(var(--spacer) / 2);
+
+            .line {
+                padding: calc(var(--spacer) / 2);
+            }
 
             &::-webkit-scrollbar {
                 width: 5px;

--- a/ui/src/stores/executions.js
+++ b/ui/src/stores/executions.js
@@ -241,12 +241,14 @@ export default {
             return this.$http.get(`${apiUrl(this)}/executions/flows/${options.namespace}/${options.flowId}`, {params: {revision: options.revision}})
                 .then(response => {
                     commit("setFlow", response.data)
+                    return response.data;
                 });
         },
         loadFlowForExecutionByExecutionId({commit}, options) {
             return this.$http.get(`${apiUrl(this)}/executions/${options.id}/flow`)
                 .then(response => {
                     commit("setFlow", response.data)
+                    return response.data;
                 });
         },
         loadGraph({commit}, options) {

--- a/webserver/src/test/java/io/kestra/webserver/controllers/api/PluginControllerTest.java
+++ b/webserver/src/test/java/io/kestra/webserver/controllers/api/PluginControllerTest.java
@@ -159,7 +159,7 @@ class PluginControllerTest {
             Map<String, Map<String, Object>> properties = (Map<String, Map<String, Object>>) doc.getSchema().getProperties().get("properties");
 
             assertThat(doc.getMarkdown(), containsString("io.kestra.plugin.templates.ExampleTask"));
-            assertThat(properties.size(), is(13));
+            assertThat(properties.size(), is(14));
             assertThat(properties.get("id").size(), is(4));
             assertThat(((Map<String, Object>) doc.getSchema().getOutputs().get("properties")).size(), is(1));
         });


### PR DESCRIPTION
Fixes #4688

Flow example:

```yaml
id: myflow
namespace: company.team
tasks:
  - id: hello
    type: io.kestra.plugin.core.log.Log
    message: Hello World! 🚀
    logToFile: true
```

When run, the log is in a file wich is stored in the internal storage.
From the Gantt or logs page you'll be able to preview or download the file.
![image](https://github.com/user-attachments/assets/b3b72238-371a-4b2a-828b-0e76a7b0b813)

The same for a triggers, in this case the file is added as a trigger properties that can be previewed or downloaded.
![image](https://github.com/user-attachments/assets/0e153ca3-8ddd-4462-befb-f1ab7d15419f)

