### PR TITLE
feat(core): create a Data type that can be used for multi-type property

### DIFF
--- a/core/src/main/java/io/kestra/core/models/property/Data.java
+++ b/core/src/main/java/io/kestra/core/models/property/Data.java
@@ -1,0 +1,127 @@
+package io.kestra.core.models.property;
+
+import io.kestra.core.exceptions.IllegalVariableEvaluationException;
+import io.kestra.core.runners.RunContext;
+import io.kestra.core.serializers.FileSerde;
+import io.kestra.core.validations.DataValidation;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.UncheckedIOException;
+import java.net.URI;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+@Getter
+@Builder
+@DataValidation
+@Schema(
+    title = "A carrier for some data that can comes from either an internal storage URI, an object or an array of objects."
+)
+public class Data<T> {
+    @Schema(title = "A Kestra internal storage URI")
+    private Property<URI> fromURI;
+
+    @Schema(title = "An object (which is equivalent to a map)")
+    private Property<Map<String, Object>> fromMap;
+
+    @Schema(title = "An array of objects (which is equivalent to a list of maps)")
+    private Property<List<Map<String, Object>>> fromList;
+
+    /**
+     * Generates a flux of objects for the data property, using either of its three properties.
+     * The mapper passed to this method will be used to map the map to the desired type when using 'fromMap' or 'fromList',
+     * it can be omitted when using 'fromURI'.
+     */
+    public Flux<T> flux(RunContext runContext, Class<T> clazz, Function<Map<String, Object>, T> mapper) throws IllegalVariableEvaluationException {
+        if (isFromURI()) {
+            URI uri = fromURI.as(runContext, URI.class);
+            try {
+                var reader = new BufferedReader(new InputStreamReader(runContext.storage().getFile(uri)));
+                return FileSerde.readAll(reader, clazz)
+                    .publishOn(Schedulers.boundedElastic())
+                    .doFinally(signalType -> {
+                        try {
+                            reader.close();
+                        } catch (IOException e) {
+                            throw new UncheckedIOException(e);
+                        }
+                    });
+            } catch (IOException e) {
+                throw new UncheckedIOException(e);
+            }
+        }
+
+        if (isFromMap()) {
+            Map<String, Object> map = fromMap.asMap(runContext, String.class, Object.class);
+            return Mono.just(map).flux().map(mapper);
+        }
+
+        if (isFromList()) {
+            List<Map<String, Object>> list = fromList.asList(runContext, Map.class);
+            return Flux.fromIterable(list).map(mapper);
+        }
+
+        return Flux.empty();
+    }
+
+    /**
+     * @return true if fromURI is set
+     */
+    public boolean isFromURI() {
+        return fromURI != null;
+    }
+
+    /**
+     * If a fromURI is present, performs the given action with the URI, otherwise does nothing.
+     */
+    public void ifFromURI(RunContext runContext, Consumer<URI> consumer) throws IllegalVariableEvaluationException {
+        if (isFromURI()) {
+            URI uri = fromURI.as(runContext, URI.class);
+            consumer.accept(uri);
+        }
+    }
+
+    /**
+     * @return true if fromMap is set
+     */
+    public boolean isFromMap() {
+        return fromMap != null;
+    }
+
+    /**
+     * If a fromMap is present, performs the given action with the mat, otherwise does nothing.
+     */
+    public void ifFromMap(RunContext runContext, Consumer<Map<String, Object>> consumer) throws IllegalVariableEvaluationException {
+        if (isFromMap()) {
+            Map<String, Object> map = fromMap.asMap(runContext, String.class, Object.class);
+            consumer.accept(map);
+        }
+    }
+
+    /**
+     * @return true if fromList is set
+     */
+    public boolean isFromList() {
+        return fromList != null;
+    }
+
+    /**
+     * If a fromList is present, performs the given action with the list of maps, otherwise does nothing.
+     */
+    public void ifFromList(RunContext runContext, Consumer<List<Map<String, Object>>> consumer) throws IllegalVariableEvaluationException {
+        if (isFromList()) {
+            List<Map<String, Object>> list = fromList.asList(runContext, Map.class);
+            consumer.accept(list);
+        }
+    }
+}

--- a/core/src/main/java/io/kestra/core/models/property/Property.java
+++ b/core/src/main/java/io/kestra/core/models/property/Property.java
@@ -182,9 +182,6 @@ public class Property<T> {
         @Serial
         private static final long serialVersionUID = 1L;
 
-        private static final TypeReference<List<String>> LIST_OF_STRING = new TypeReference<>() {};
-        private static final TypeReference<Map<String, String>> MAP_OF_STRING_STRING = new TypeReference<>() {};
-
         protected PropertyDeserializer() {
             super(Property.class);
         }
@@ -193,10 +190,10 @@ public class Property<T> {
         public Property<?> deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
             String s;
             if (p.isExpectedStartArrayToken()) {
-                List<String> list = p.readValueAs(LIST_OF_STRING);
+                List<Object> list = p.readValueAs(JacksonMapper.LIST_TYPE_REFERENCE);
                 s = MAPPER.writeValueAsString(list);
             } else if (p.isExpectedStartObjectToken()) {
-                Map<String, String> list = p.readValueAs(MAP_OF_STRING_STRING);
+                Map<String, Object> list = p.readValueAs(JacksonMapper.MAP_TYPE_REFERENCE);
                 s = MAPPER.writeValueAsString(list);
             } else {
                 s = p.getValueAsString();

--- a/core/src/main/java/io/kestra/core/validations/DataValidation.java
+++ b/core/src/main/java/io/kestra/core/validations/DataValidation.java
@@ -1,0 +1,16 @@
+package io.kestra.core.validations;
+
+import io.kestra.core.validations.validator.DataValidator;
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Constraint(validatedBy = DataValidator.class)
+public @interface DataValidation {
+    String message() default "invalid data property";
+    Class<?>[] groups() default {};
+    Class<? extends Payload>[] payload() default {};
+}

--- a/core/src/main/java/io/kestra/core/validations/validator/DataValidator.java
+++ b/core/src/main/java/io/kestra/core/validations/validator/DataValidator.java
@@ -1,0 +1,37 @@
+package io.kestra.core.validations.validator;
+
+import io.kestra.core.models.property.Data;
+import io.kestra.core.validations.DataValidation;
+import io.micronaut.core.annotation.AnnotationValue;
+import io.micronaut.core.annotation.Introspected;
+import io.micronaut.core.annotation.NonNull;
+import io.micronaut.core.annotation.Nullable;
+import io.micronaut.validation.validator.constraints.ConstraintValidator;
+import io.micronaut.validation.validator.constraints.ConstraintValidatorContext;
+import jakarta.inject.Singleton;
+
+@Singleton
+@Introspected
+@SuppressWarnings("rawtypes")
+public class DataValidator implements ConstraintValidator<DataValidation, Data> {
+    @Override
+    public boolean isValid(
+        @Nullable Data value,
+        @NonNull AnnotationValue<DataValidation> annotationMetadata,
+        @NonNull ConstraintValidatorContext context) {
+        if (value == null) {
+            return true;
+        }
+
+        if (value.isFromList() && value.isFromMap() ||
+            value.isFromList() && value.isFromURI() ||
+            value.isFromMap() && value.isFromURI()) {
+            context.disableDefaultConstraintViolation();
+            context.buildConstraintViolationWithTemplate( "Only one of 'fromURI', 'fromMap' or 'fromList' can be set.")
+                .addConstraintViolation();
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/core/src/test/java/io/kestra/core/docs/ClassPluginDocumentationTest.java
+++ b/core/src/test/java/io/kestra/core/docs/ClassPluginDocumentationTest.java
@@ -138,9 +138,9 @@ class ClassPluginDocumentationTest {
             ClassPluginDocumentation<? extends DynamicPropertyExampleTask> doc = ClassPluginDocumentation.of(jsonSchemaGenerator, scan, DynamicPropertyExampleTask.class, null);
 
             assertThat(doc.getCls(), is("io.kestra.core.models.property.DynamicPropertyExampleTask"));
-            assertThat(doc.getDefs(), aMapWithSize(4));
+            assertThat(doc.getDefs(), aMapWithSize(6));
             Map<String, Object> properties = (Map<String, Object>) doc.getPropertiesSchema().get("properties");
-            assertThat(properties, aMapWithSize(15));
+            assertThat(properties, aMapWithSize(16));
 
             Map<String, Object> number = (Map<String, Object>) properties.get("number");
             assertThat(number.get("oneOf"), notNullValue());

--- a/core/src/test/java/io/kestra/core/models/property/DynamicPropertyExampleTask.java
+++ b/core/src/test/java/io/kestra/core/models/property/DynamicPropertyExampleTask.java
@@ -43,6 +43,9 @@ public class DynamicPropertyExampleTask extends Task implements RunnableTask<Dyn
     @NotNull
     private Property<Map<String, String>> properties;
 
+    @NotNull
+    private Data<Message> data;
+
 
     @Override
     public Output run(RunContext runContext) throws Exception {
@@ -60,11 +63,16 @@ public class DynamicPropertyExampleTask extends Task implements RunnableTask<Dyn
 
         Map<String, String> map = properties.asMap(runContext, String.class, String.class);
 
+        List<Message> outputMessages = data.flux(runContext, Message.class, message -> Message.fromMap(message))
+            .collectList()
+            .block();
+
         return Output.builder()
             .value(value)
             .level(level)
             .list(list)
             .map(map)
+            .messages(outputMessages)
             .build();
     }
 
@@ -75,5 +83,21 @@ public class DynamicPropertyExampleTask extends Task implements RunnableTask<Dyn
         private Level level;
         private List<String> list;
         private Map<String, String> map;
+        private List<Message> messages;
+    }
+
+    @SuperBuilder(toBuilder = true)
+    @Getter
+    @NoArgsConstructor
+    public static class Message {
+        private Object key;
+        private Object value;
+
+        private static Message fromMap(Map<String, Object> map) {
+            return Message.builder()
+                .key(map.get("key"))
+                .value(map.get("value"))
+                .build();
+        }
     }
 }

--- a/core/src/test/java/io/kestra/core/models/property/PropertyTest.java
+++ b/core/src/test/java/io/kestra/core/models/property/PropertyTest.java
@@ -1,21 +1,35 @@
 package io.kestra.core.models.property;
 
+import io.kestra.core.exceptions.IllegalVariableEvaluationException;
 import io.kestra.core.junit.annotations.KestraTest;
 import io.kestra.core.runners.RunContextFactory;
+import io.kestra.core.serializers.FileSerde;
+import io.kestra.core.storages.StorageInterface;
 import jakarta.inject.Inject;
 import org.junit.jupiter.api.Test;
 import org.slf4j.event.Level;
+import reactor.core.publisher.Flux;
 
+import java.io.FileInputStream;
+import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
 import java.util.Map;
 
+import static java.util.Map.entry;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @KestraTest
 class PropertyTest {
 
     @Inject
     private RunContextFactory runContextFactory;
+
+    @Inject
+    private StorageInterface storage;
 
     @Test
     void test() throws Exception {
@@ -32,17 +46,27 @@ class PropertyTest {
                   "key1": "{{value1}}",
                   "key2": "{{value2}}"
                 }"""))
+            .data(Data.<DynamicPropertyExampleTask.Message>builder()
+                .fromMap(new Property<>("""
+                    {
+                      "key": "{{mapKey}}",
+                      "value": "{{mapValue}}"
+                    }"""))
+                .build()
+            )
             .build();
-        var runContext = runContextFactory.of(Map.of(
-            "numberValue", 9,
-            "stringValue", "test",
-            "levelValue", "INFO",
-            "durationValue", "PT60S",
-            "defaultValue", "not-default",
-            "item1", "item1",
-            "item2", "item2",
-            "value1", "value1",
-            "value2", "value2"
+        var runContext = runContextFactory.of(Map.ofEntries(
+            entry("numberValue", 9),
+            entry("stringValue", "test"),
+            entry("levelValue", "INFO"),
+            entry("durationValue", "PT60S"),
+            entry("defaultValue", "not-default"),
+            entry("item1", "item1"),
+            entry("item2", "item2"),
+            entry("value1", "value1"),
+            entry("value2", "value2"),
+            entry("mapKey", "mapKey"),
+            entry("mapValue", "mapValue")
         ));
 
         var output = task.run(runContext);
@@ -54,10 +78,13 @@ class PropertyTest {
         assertThat(output.getMap(), aMapWithSize(2));
         assertThat(output.getMap().get("key1"), is("value1"));
         assertThat(output.getMap().get("key2"), is("value2"));
+        assertThat(output.getMessages(), hasSize(1));
+        assertThat(output.getMessages().getFirst().getKey(), is("mapKey"));
+        assertThat(output.getMessages().getFirst().getValue(), is("mapValue"));
     }
 
     @Test
-    void withDefaults() throws Exception {
+    void withDefaultsAndMessagesFromList() throws Exception {
         var task = DynamicPropertyExampleTask.builder()
             .number(new Property<>("{{numberValue}}"))
             .string(new Property<>("{{stringValue}}"))
@@ -70,16 +97,34 @@ class PropertyTest {
                   "key1": "{{value1}}",
                   "key2": "{{value2}}"
                 }"""))
+            .data(Data.<DynamicPropertyExampleTask.Message>builder()
+                .fromList(new Property<>("""
+                    [
+                      {
+                         "key": "{{mapKey1}}",
+                         "value": "{{mapValue1}}"
+                      },
+                      {
+                         "key": "{{mapKey2}}",
+                         "value": "{{mapValue2}}"
+                       }
+                    ]"""))
+                .build()
+            )
             .build();
-        var runContext = runContextFactory.of(Map.of(
-            "numberValue", 9,
-            "stringValue", "test",
-            "levelValue", "INFO",
-            "durationValue", "PT60S",
-            "item1", "item1",
-            "item2", "item2",
-            "value1", "value1",
-            "value2", "value2"
+        var runContext = runContextFactory.of(Map.ofEntries(
+            entry("numberValue", 9),
+            entry("stringValue", "test"),
+            entry("levelValue", "INFO"),
+            entry("durationValue", "PT60S"),
+            entry("item1", "item1"),
+            entry("item2", "item2"),
+            entry("value1", "value1"),
+            entry("value2", "value2"),
+            entry("mapKey1", "mapKey1"),
+            entry("mapValue1", "mapValue1"),
+            entry("mapKey2", "mapKey2"),
+            entry("mapValue2", "mapValue2")
         ));
 
         var output = task.run(runContext);
@@ -91,5 +136,90 @@ class PropertyTest {
         assertThat(output.getMap(), aMapWithSize(2));
         assertThat(output.getMap().get("key1"), is("value1"));
         assertThat(output.getMap().get("key2"), is("value2"));
+        assertThat(output.getMessages(), hasSize(2));
+        assertThat(output.getMessages().getFirst().getKey(), is("mapKey1"));
+        assertThat(output.getMessages().getFirst().getValue(), is("mapValue1"));
+        assertThat(output.getMessages().get(1).getKey(), is("mapKey2"));
+        assertThat(output.getMessages().get(1).getValue(), is("mapValue2"));
+    }
+
+    @Test
+    void withMessagesFromURI() throws Exception {
+        Path messages = Files.createTempFile("messages", ".ion");
+        final List<DynamicPropertyExampleTask.Message> inputValues = List.of(
+            DynamicPropertyExampleTask.Message.builder().key("key1").value("value1").build(),
+            DynamicPropertyExampleTask.Message.builder().key("key2").value("value2").build()
+        );
+        FileSerde.writeAll(Files.newBufferedWriter(messages), Flux.fromIterable(inputValues)).block();
+        URI uri;
+        try (var input = new FileInputStream(messages.toFile())) {
+            uri = storage.put(null, URI.create("/messages.ion"), input);
+        }
+
+        var task = DynamicPropertyExampleTask.builder()
+            .number(new Property<>("{{numberValue}}"))
+            .string(new Property<>("{{stringValue}}"))
+            .level(new Property<>("{{levelValue}}"))
+            .someDuration(new Property<>("{{durationValue}}"))
+            .withDefault(new Property<>("{{defaultValue}}"))
+            .items(new Property<>("""
+                ["{{item1}}", "{{item2}}"]"""))
+            .properties(new Property<>("""
+                {
+                  "key1": "{{value1}}",
+                  "key2": "{{value2}}"
+                }"""))
+            .data(Data.<DynamicPropertyExampleTask.Message>builder().fromURI(new Property<>("{{uri}}")).build())
+            .build();
+        var runContext = runContextFactory.of(Map.ofEntries(
+            entry("numberValue", 9),
+            entry("stringValue", "test"),
+            entry("levelValue", "INFO"),
+            entry("durationValue", "PT60S"),
+            entry("defaultValue", "not-default"),
+            entry("item1", "item1"),
+            entry("item2", "item2"),
+            entry("value1", "value1"),
+            entry("value2", "value2"),
+            entry("uri", uri)
+        ));
+
+        var output = task.run(runContext);
+
+        assertThat(output, notNullValue());
+        assertThat(output.getValue(), is("test - 9 - not-default - PT1M"));
+        assertThat(output.getLevel(), is(Level.INFO));
+        assertThat(output.getList(), containsInAnyOrder("item1", "item2"));
+        assertThat(output.getMap(), aMapWithSize(2));
+        assertThat(output.getMap().get("key1"), is("value1"));
+        assertThat(output.getMap().get("key2"), is("value2"));
+        assertThat(output.getMessages(), hasSize(2));
+        assertThat(output.getMessages().getFirst().getKey(), is("key1"));
+        assertThat(output.getMessages().getFirst().getValue(), is("value1"));
+        assertThat(output.getMessages().get(1).getKey(), is("key2"));
+        assertThat(output.getMessages().get(1).getValue(), is("value2"));
+    }
+
+    @Test
+    void failingToRender() throws Exception {
+        var task = DynamicPropertyExampleTask.builder()
+            .number(new Property<>("{{numberValue}}"))
+            .string(new Property<>("{{stringValue}}"))
+            .level(new Property<>("{{levelValue}}"))
+            .someDuration(new Property<>("{{durationValue}}"))
+            .withDefault(new Property<>("{{defaultValue}}"))
+            .items(new Property<>("""
+                ["{{item1}}", "{{item2}}"]"""))
+            .data(Data.<DynamicPropertyExampleTask.Message>builder()
+                .fromMap(new Property<>("""
+                    {
+                      "key": "{{mapValue}}"
+                    }"""))
+                .build()
+            )
+            .build();
+        var runContext = runContextFactory.of();
+
+        assertThrows(IllegalVariableEvaluationException.class, () -> task.run(runContext));
     }
 }

--- a/core/src/test/java/io/kestra/core/validations/DataValidationTest.java
+++ b/core/src/test/java/io/kestra/core/validations/DataValidationTest.java
@@ -1,0 +1,40 @@
+package io.kestra.core.validations;
+
+import io.kestra.core.junit.annotations.KestraTest;
+import io.kestra.core.models.property.Data;
+import io.kestra.core.models.property.Property;
+import io.kestra.core.models.validations.ModelValidator;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.Test;
+
+import java.net.URI;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
+
+@KestraTest
+public class DataValidationTest {
+    @Inject
+    private ModelValidator modelValidator;
+
+    @Test
+    void valid() throws Exception {
+        Data<?> data = Data.builder()
+            .fromURI(Property.of(URI.create("kestra:///uri")))
+            .build();
+
+        assertThat(modelValidator.isValid(data).isEmpty(), is(true));
+    }
+
+    @Test
+    void invalid() throws Exception {
+        Data<?> data = Data.builder()
+            .fromURI(Property.of(URI.create("kestra:///uri")))
+            .fromList(new Property<>())
+            .build();
+
+        assertThat(modelValidator.isValid(data).isEmpty(), is(false));
+        assertThat(modelValidator.isValid(data).get().getMessage(), containsString("Only one of 'fromURI', 'fromMap' or 'fromList' can be set."));
+    }
+}


### PR DESCRIPTION
We very often use Object for a traditional 'from' property that can come from either an internal storage UI, an inline Map, or an inline list of maps. This class provides more declarative support for that.

Example usage in a task:

```java
@Plugin
public class DynamicPropertyExampleTask extends Task implements RunnableTask<DynamicPropertyExampleTask.Output> {
    @NotNull
    private DataProperty messages;


    @Override
    public Output run(RunContext runContext) throws Exception {
        List<Message> outputMessages = new ArrayList<>();
        messages.ifFromMap(runContext, message -> outputMessages.add(Message.fromMap(message)));
        messages.ifFromList(runContext, messages -> messages.forEach(message -> outputMessages.add(Message.fromMap(message))));
        messages.ifFromURI(runContext, uri -> {
            try (var reader = new BufferedReader(new InputStreamReader(runContext.storage().getFile(uri)))) {
                FileSerde.readAll(reader, Message.class)
                    .doOnEach(message -> outputMessages.add(message.get()))
                    .blockLast();
            } catch (IOException e) {
                throw new UncheckedIOException(e);
            }
        });

        return Output.builder()
            .messages(outputMessages)
            .build();
    }

    @SuperBuilder(toBuilder = true)
    @Getter
    public static class Output implements io.kestra.core.models.tasks.Output {
        private List<Message> messages;
    }

    @SuperBuilder(toBuilder = true)
    @Getter
    @NoArgsConstructor
    public static class Message {
        private Object key;
        private Object value;

        private static Message fromMap(Map<String, Object> map) {
            return Message.builder()
                .key(map.get("key"))
                .value(map.get("value"))
                .build();
        }
    }
}
``` 

Example usage of the `fromMap` attribute:
```yaml
id: dynamic
namespace: company.team

tasks:
  - id: hello
    type: io.kestra.plugin.core.dynamic.DynamicPropertyExampleTask
    messages:
      fromMap:
        key: "{{flow.namespace}}"
        value: "{{flow.id}}"
```

Example usage of the `fromList` attribute:
```yaml
id: dynamic
namespace: company.team

tasks:
  - id: hello
    type: io.kestra.plugin.core.dynamic.DynamicPropertyExampleTask
    messages:
      fromList:
        - key: "{{flow.namespace}}"
          value: "{{flow.id}}"
        - key: "{{taskrun.id}}"
          value: "no idea"
```

Example usage of the `fromURI` attribute:
```yaml
id: dynamic
namespace: company.team

inputs:
  - id: file
    type: FILE

tasks:
  - id: hello
    type: io.kestra.plugin.core.dynamic.DynamicPropertyExampleTask
    messages:
    messages:
      fromURI: "{{inputs.file}}"
```