### PR TITLE
fix: naming of Execution States for consistency and clarity

### DIFF
--- a/ui/src/components/executions/ChangeExecutionStatus.vue
+++ b/ui/src/components/executions/ChangeExecutionStatus.vue
@@ -127,7 +127,7 @@
                             });
                         }
 
-                        this.$toast().success(this.$t("change execution status done"));
+                        this.$toast().success(this.$t("change execution state done"));
                     })
             },
         },

--- a/ui/src/components/executions/ChangeStatus.vue
+++ b/ui/src/components/executions/ChangeStatus.vue
@@ -129,7 +129,7 @@
                             });
                         }
 
-                        this.$toast().success(this.$t("change status done"));
+                        this.$toast().success(this.$t("change state done"));
                     })
             },
         },

--- a/ui/src/components/executions/Executions.vue
+++ b/ui/src/components/executions/Executions.vue
@@ -166,7 +166,7 @@
                                 {{ $t("replay") }}
                             </el-button>
                             <el-button v-if="canUpdate" :icon="StateMachine" @click="changeStatusDialogVisible = !changeStatusDialogVisible">
-                                {{ $t("change status") }}
+                                {{ $t("change state") }}
                             </el-button>
                             <el-button v-if="canUpdate" :icon="StopCircleOutline" @click="killExecutions()">
                                 {{ $t("kill") }}
@@ -829,7 +829,7 @@
                 this.genericConfirmCallback(
                     "execution/queryChangeExecutionStatus",
                     "execution/bulkChangeExecutionStatus",
-                    "executions status changed"
+                    "executions state changed"
                 );
             },
             changeStatusToast() {

--- a/ui/src/translations/de.json
+++ b/ui/src/translations/de.json
@@ -171,10 +171,10 @@
     "replay confirm": "Sind Sie sicher, dass Sie diese Ausführung <code>{id}</code> wiederholen und eine neue erstellen möchten?",
     "prefill inputs": "Vorausfüllen",
     "current": "aktuell",
-    "change status": "Status ändern",
-    "change status done": "Task-Status wurde aktualisiert",
-    "change status confirm": "Sind Sie sicher, dass Sie den Status des Tasks <code>{task}</code> für die Ausführung <code>{id}</code> ändern möchten?",
-    "change status hint": {
+    "change state": "Status ändern",
+    "change state done": "Task-Status wurde aktualisiert",
+    "change state confirm": "Sind Sie sicher, dass Sie den Status des Tasks <code>{task}</code> für die Ausführung <code>{id}</code> ändern möchten?",
+    "change state hint": {
       "WARNING": "['Der Flow wird als WARNING markiert.', 'Die nächsten Tasks werden ausgeführt.', 'Die Fehler-Tasks werden ausgeführt.']",
       "FAILED": "['Der Flow wird als FAILED markiert.', 'Keine weiteren Tasks werden ausgeführt.', 'Die Fehler-Tasks werden ausgeführt.']",
       "SUCCESS": "['Der Flow wird neu gestartet, da dieser Task erfolgreich war.', 'Alle blockierten Tasks werden ausgeführt.', 'Der Flow wird im SUCCESS-Zustand sein, wenn alle Task-Ausführungen erfolgreich sind.']",
@@ -272,7 +272,7 @@
       "please": "Bitte wählen Sie rechts einen Task aus, um dessen Dokumentation zu sehen"
     },
     "last execution date": "Letztes Ausführungsdatum",
-    "last execution status": "Letzter Status",
+    "last execution state": "Letzter Status",
     "last X days count": "{count} in den letzten {days} Tagen",
     "date range count": "{count} zwischen dem {startDate} und dem {endDate}",
     "date count": "{count} am {date}",
@@ -810,10 +810,10 @@
       "storage": "Interne Speicherdateien löschen"
     },
     "show chart": "Diagramm anzeigen",
-    "change execution status done": "Ausführungsstatus aktualisiert",
-    "change execution status confirm": "Sind Sie sicher, dass Sie den Status der Ausführung <code>{id}</code> ändern möchten?",
-    "change status tooltip": "Ändere den Ausführungsstatus",
-    "executions status changed": "Der Status von <code>{executionCount}</code> Ausführung(en) wurde geändert",
-    "bulk change status": "Sind Sie sicher, dass Sie den Zustand von <code>{executionCount}</code> Ausführung(en) ändern möchten?"
+    "change execution state done": "Ausführungsstatus aktualisiert",
+    "change execution state confirm": "Sind Sie sicher, dass Sie den Status der Ausführung <code>{id}</code> ändern möchten?",
+    "change state tooltip": "Ändere den Ausführungsstatus",
+    "executions state changed": "Der Status von <code>{executionCount}</code> Ausführung(en) wurde geändert",
+    "bulk change state": "Sind Sie sicher, dass Sie den Zustand von <code>{executionCount}</code> Ausführung(en) ändern möchten?"
   }
 }

--- a/ui/src/translations/en.json
+++ b/ui/src/translations/en.json
@@ -171,10 +171,10 @@
     "replay confirm": "Are you sure to replay this execution <code>{id}</code> and create a new one?",
     "prefill inputs": "Prefill",
     "current": "current",
-    "change status": "Change status",
-    "change status done": "Task status has been updated",
-    "change status confirm": "Are you sure to change the status on task <code>{task}</code> for execution <code>{id}</code>?",
-    "change status hint": {
+    "change state": "Change state",
+    "change state done": "Task state has been updated",
+    "change state confirm": "Are you sure you want to change the task run state for the <code>{task}</code> task in execution <code>{id}</code>?",
+    "change state hint": {
       "WARNING": [
         "The flow will be marked as WARNING.",
         "The next tasks will be executed.",
@@ -195,9 +195,9 @@
         "All blocked tasks will be executed."
       ]
     },
-    "change status tooltip": "Change the execution status",
-    "change execution status confirm": "Are you sure you want to change the status of the execution <code>{id}</code>?",
-    "change execution status done": "Execution status updated",
+    "change state tooltip": "Change the execution state",
+    "change execution state confirm": "Are you sure you want to change the state of the execution <code>{id}</code>?",
+    "change execution state done": "Execution state updated",
     "mark as": "Mark as <code>{status}</code>",
     "kill": "Kill",
     "kill parents and subflow": "Kill parents and subflows",
@@ -290,7 +290,7 @@
       "please": "Please choose a task on the right to see its documentation"
     },
     "last execution date": "Last execution date",
-    "last execution status": "Last status",
+    "last execution state": "Last state",
     "last X days count": "{count} in last {days} days",
     "date range count": "{count} between the {startDate} and the {endDate}",
     "date count": "{count} on the {date}",
@@ -366,7 +366,7 @@
     "restore confirm": "Are you sure to restore the revision <code>{revision}</code>?",
     "bulk delete": "Are you sure you want to delete <code>{executionCount}</code> execution(s)?",
     "bulk replay": "Are you sure you want to replay <code>{executionCount}</code> execution(s)?",
-    "bulk change status": "Are you sure you want to change the state of <code>{executionCount}</code> execution(s)?",
+    "bulk change state": "Are you sure you want to change the state of <code>{executionCount}</code> execution(s)?",
     "bulk resume": "Are you sure you want to resume <code>{executionCount}</code> execution(s)?",
     "bulk restart": "Are you sure you want to restart <code>{executionCount}</code> execution(s)?",
     "bulk kill": "Are you sure you want to kill <code>{executionCount}</code> execution(s)?",
@@ -388,7 +388,7 @@
       "no executions": "Ready to see your flow in action?"
     },
     "executions replayed": "<code>{executionCount}</code> executions(s) replayed",
-    "executions status changed": "The status of <code>{executionCount}</code> execution(s) has been changed",
+    "executions state changed": "The state of <code>{executionCount}</code> execution(s) has been changed",
     "executions resumed": "<code>{executionCount}</code> executions(s) resumed",
     "executions restarted": "<code>{executionCount}</code> executions(s) restarted",
     "executions killed": "<code>{executionCount}</code> executions(s) killed",

--- a/ui/src/translations/es.json
+++ b/ui/src/translations/es.json
@@ -171,10 +171,10 @@
     "replay confirm": "¿Estás seguro de repetir esta ejecución <code>{id}</code> y crear una nueva?",
     "prefill inputs": "Prefill",
     "current": "actual",
-    "change status": "Cambiar estado",
-    "change status done": "El estado de la tarea se ha actualizado",
-    "change status confirm": "¿Estás seguro de cambiar el estado en la tarea <code>{task}</code> para la ejecución <code>{id}</code>?",
-    "change status hint": {
+    "change state": "Cambiar estado",
+    "change state done": "El estado de la tarea se ha actualizado",
+    "change state confirm": "¿Estás seguro de cambiar el estado en la tarea <code>{task}</code> para la ejecución <code>{id}</code>?",
+    "change state hint": {
       "WARNING": "['El flujo será marcado como WARNING.', 'Las siguientes tareas serán ejecutadas.', 'Las tareas de error serán ejecutadas.']",
       "FAILED": "['El flujo será marcado como FAILED.', 'No se ejecutará ninguna otra tarea.', 'Las tareas de error serán ejecutadas.']",
       "SUCCESS": "['El flujo se reiniciará ya que esta tarea fue exitosa.', 'Todas las tareas bloqueadas serán ejecutadas.', 'El flujo estará en estado SUCCESS si todas las ejecuciones de tareas son exitosas.']",
@@ -272,7 +272,7 @@
       "please": "Por favor elige una tarea a la derecha para ver su documentación"
     },
     "last execution date": "Fecha de última ejecución",
-    "last execution status": "Último estado",
+    "last execution state": "Último estado",
     "last X days count": "{count} en los últimos {days} días",
     "date range count": "{count} entre el {startDate} y el {endDate}",
     "date count": "{count} en el {date}",
@@ -810,10 +810,10 @@
       "storage": "Eliminar archivos de almacenamiento interno"
     },
     "show chart": "Mostrar Gráfico",
-    "change execution status done": "Estado de ejecución actualizado",
-    "change execution status confirm": "¿Está seguro de que desea cambiar el estado de la ejecución <code>{id}</code>?",
-    "change status tooltip": "Cambia el estado de ejecución",
-    "executions status changed": "El estado de <code>{executionCount}</code> ejecución(es) ha sido cambiado",
-    "bulk change status": "¿Está seguro de que desea cambiar el estado de <code>{executionCount}</code> ejecución(es)?"
+    "change execution state done": "Estado de ejecución actualizado",
+    "change execution state confirm": "¿Está seguro de que desea cambiar el estado de la ejecución <code>{id}</code>?",
+    "change state tooltip": "Cambia el estado de ejecución",
+    "executions state changed": "El estado de <code>{executionCount}</code> ejecución(es) ha sido cambiado",
+    "bulk change state": "¿Está seguro de que desea cambiar el estado de <code>{executionCount}</code> ejecución(es)?"
   }
 }

--- a/ui/src/translations/fr.json
+++ b/ui/src/translations/fr.json
@@ -170,10 +170,10 @@
     "replay confirm": "Êtes-vous sur de vouloir relancer l'exécution <code>{id}</code> et créer une nouvelle exécution ?",
     "prefill inputs": "Pré-remplir",
     "current": "actuel",
-    "change status": "Changer le statut",
-    "change status done": "Le statut de la tâche a été mis à jour",
-    "change status confirm": "Êtes-vous sur de vouloir changer le statut de la tâche <code>{task}</code> pour l'exécution <code>{id}</code> ?",
-    "change status hint": {
+    "change state": "Changer le statut",
+    "change state done": "Le statut de la tâche a été mis à jour",
+    "change state confirm": "Êtes-vous sur de vouloir changer le statut de la tâche <code>{task}</code> pour l'exécution <code>{id}</code> ?",
+    "change state hint": {
       "WARNING": [
         "Le flow serra marqué en état WARNING.",
         "Les tâches suivantes seront executées.",
@@ -287,7 +287,7 @@
     },
     "last X days count": "{count} lors des {days} derniers jours",
     "last execution date": "Dernière exécution",
-    "last execution status": "Dernier statut",
+    "last execution state": "Dernier statut",
     "date range count": "{count} entre le {startDate} et le {endDate}",
     "date count": "{count} le {date}",
     "revisions": "Révisions",
@@ -824,10 +824,10 @@
       "storage": "Supprimer les fichiers de stockage interne"
     },
     "show chart": "Afficher le graphique",
-    "change execution status done": "Statut d'exécution mis à jour",
-    "change execution status confirm": "Êtes-vous sûr de vouloir changer le statut de l'exécution <code>{id}</code> ?",
-    "change status tooltip": "Changer le statut d'exécution",
-    "executions status changed": "Le statut de <code>{executionCount}</code> exécution(s) a été modifié",
-    "bulk change status": "Êtes-vous sûr de vouloir changer l'état de <code>{executionCount}</code> exécution(s) ?"
+    "change execution state done": "Statut d'exécution mis à jour",
+    "change execution state confirm": "Êtes-vous sûr de vouloir changer le statut de l'exécution <code>{id}</code> ?",
+    "change state tooltip": "Changer le statut d'exécution",
+    "executions state changed": "Le statut de <code>{executionCount}</code> exécution(s) a été modifié",
+    "bulk change state": "Êtes-vous sûr de vouloir changer l'état de <code>{executionCount}</code> exécution(s) ?"
   }
 }

--- a/ui/src/translations/hi.json
+++ b/ui/src/translations/hi.json
@@ -171,10 +171,10 @@
     "replay confirm": "क्या आप वाकई इस निष्पादन <code>{id}</code> को पुनः चलाना चाहते हैं और एक नया निष्पादन बनाना चाहते हैं?",
     "prefill inputs": "पूर्व-भरण",
     "current": "वर्तमान",
-    "change status": "स्थिति बदलें",
-    "change status done": "Task स्थिति को अपडेट किया गया है",
-    "change status confirm": "क्या आप वाकई निष्पादन <code>{id}</code> के लिए Task <code>{task}</code> पर स्थिति बदलना चाहते हैं?",
-    "change status hint": {
+    "change state": "स्थिति बदलें",
+    "change state done": "Task स्थिति को अपडेट किया गया है",
+    "change state confirm": "क्या आप वाकई निष्पादन <code>{id}</code> के लिए Task <code>{task}</code> पर स्थिति बदलना चाहते हैं?",
+    "change state hint": {
       "WARNING": "['Flow को WARNING के रूप में चिह्नित किया जाएगा।', 'अगले tasks निष्पादित किए जाएंगे।', 'त्रुटि tasks निष्पादित किए जाएंगे।']",
       "FAILED": "['Flow को FAILED के रूप में चिह्नित किया जाएगा।', 'कोई अन्य task निष्पादित नहीं किया जाएगा।', 'त्रुटि tasks निष्पादित किए जाएंगे।']",
       "SUCCESS": "['Flow पुनः प्रारंभ होगा क्योंकि यह task सफल था।', 'सभी अवरुद्ध tasks निष्पादित किए जाएंगे।', 'यदि सभी task रन सफल होते हैं तो Flow SUCCESS स्थिति में होगा।']",
@@ -272,7 +272,7 @@
       "please": "कृपया दाईं ओर एक task चुनें ताकि इसका दस्तावेज़ीकरण देखा जा सके"
     },
     "last execution date": "अंतिम निष्पादन तिथि",
-    "last execution status": "अंतिम स्थिति",
+    "last execution state": "अंतिम स्थिति",
     "last X days count": "{दिनों} दिनों में {गिनती}",
     "date range count": "{startDate} और {endDate} के बीच {गिनती}",
     "date count": "{तारीख} पर {गिनती}",
@@ -810,10 +810,10 @@
       "storage": "आंतरिक स्टोरेज फाइलें हटाएं"
     },
     "show chart": "चार्ट दिखाएं",
-    "change execution status done": "निष्पादन स्थिति अपडेट की गई",
-    "change execution status confirm": "क्या आप सुनिश्चित हैं कि आप execution <code>{id}</code> की स्थिति बदलना चाहते हैं?",
-    "change status tooltip": "निष्पादन स्थिति बदलें",
-    "executions status changed": "<code>{executionCount}</code> निष्पादन की स्थिति बदल दी गई है",
-    "bulk change status": "क्या आप सुनिश्चित हैं कि आप <code>{executionCount}</code> execution(s) की स्थिति बदलना चाहते हैं?"
+    "change execution state done": "निष्पादन स्थिति अपडेट की गई",
+    "change execution state confirm": "क्या आप सुनिश्चित हैं कि आप execution <code>{id}</code> की स्थिति बदलना चाहते हैं?",
+    "change state tooltip": "निष्पादन स्थिति बदलें",
+    "executions state changed": "<code>{executionCount}</code> निष्पादन की स्थिति बदल दी गई है",
+    "bulk change state": "क्या आप सुनिश्चित हैं कि आप <code>{executionCount}</code> execution(s) की स्थिति बदलना चाहते हैं?"
   }
 }

--- a/ui/src/translations/it.json
+++ b/ui/src/translations/it.json
@@ -171,10 +171,10 @@
     "replay confirm": "Sei sicuro di voler ripetere questa esecuzione <code>{id}</code> e crearne una nuova?",
     "prefill inputs": "Precompila",
     "current": "corrente",
-    "change status": "Cambia stato",
-    "change status done": "Lo stato del task è stato aggiornato",
-    "change status confirm": "Sei sicuro di voler cambiare lo stato del task <code>{task}</code> per l'esecuzione <code>{id}</code>?",
-    "change status hint": {
+    "change state": "Cambia stato",
+    "change state done": "Lo stato del task è stato aggiornato",
+    "change state confirm": "Sei sicuro di voler cambiare lo stato del task <code>{task}</code> per l'esecuzione <code>{id}</code>?",
+    "change state hint": {
       "WARNING": "['Il flow sarà contrassegnato come WARNING.', 'I prossimi tasks verranno eseguiti.', 'I tasks di errore verranno eseguiti.']",
       "FAILED": "['Il flow sarà contrassegnato come FAILED.', 'Nessun altro task verrà eseguito.', 'I tasks di errore verranno eseguiti.']",
       "SUCCESS": "['Il flow verrà riavviato poiché questo task è stato completato con successo.', 'Tutti i tasks bloccati verranno eseguiti.', 'Il flow sarà in stato di SUCCESS se tutte le esecuzioni dei tasks saranno completate con successo.']",
@@ -272,7 +272,7 @@
       "please": "Per favore scegli un task a destra per vedere la sua documentazione"
     },
     "last execution date": "Data ultima esecuzione",
-    "last execution status": "Ultimo stato",
+    "last execution state": "Ultimo stato",
     "last X days count": "{count} negli ultimi {days} giorni",
     "date range count": "{count} tra il {startDate} e il {endDate}",
     "date count": "{count} il {date}",
@@ -810,10 +810,10 @@
       "storage": "Elimina file di storage interni"
     },
     "show chart": "Mostra Grafico",
-    "change execution status done": "Stato di esecuzione aggiornato",
-    "change execution status confirm": "Sei sicuro di voler cambiare lo stato dell'esecuzione <code>{id}</code>?",
-    "change status tooltip": "Cambia lo stato di esecuzione",
-    "executions status changed": "Lo stato di <code>{executionCount}</code> esecuzione/i è stato cambiato",
-    "bulk change status": "Sei sicuro di voler cambiare lo stato di <code>{executionCount}</code> esecuzione/i?"
+    "change execution state done": "Stato di esecuzione aggiornato",
+    "change execution state confirm": "Sei sicuro di voler cambiare lo stato dell'esecuzione <code>{id}</code>?",
+    "change state tooltip": "Cambia lo stato di esecuzione",
+    "executions state changed": "Lo stato di <code>{executionCount}</code> esecuzione/i è stato cambiato",
+    "bulk change state": "Sei sicuro di voler cambiare lo stato di <code>{executionCount}</code> esecuzione/i?"
   }
 }

--- a/ui/src/translations/ja.json
+++ b/ui/src/translations/ja.json
@@ -171,10 +171,10 @@
     "replay confirm": "この実行<code>{id}</code>をリプレイして新しいものを作成してもよろしいですか？",
     "prefill inputs": "自動入力",
     "current": "現在",
-    "change status": "ステータスを変更",
-    "change status done": "Taskステータスが更新されました",
-    "change status confirm": "実行<code>{id}</code>のTask <code>{task}</code>のステータスを変更してもよろしいですか？",
-    "change status hint": {
+    "change state": "ステータスを変更",
+    "change state done": "Taskステータスが更新されました",
+    "change state confirm": "実行<code>{id}</code>のTask <code>{task}</code>のステータスを変更してもよろしいですか？",
+    "change state hint": {
       "WARNING": "['FlowはWARNINGとしてマークされます。', '次のタスクが実行されます。', 'エラータスクが実行されます。']",
       "FAILED": "['FlowはFAILEDとしてマークされます。', '他のタスクは実行されません。', 'エラータスクが実行されます。']",
       "SUCCESS": "['このタスクが成功したため、Flowは再起動します。', 'すべてのブロックされたタスクが実行されます。', 'すべてのタスク実行が成功した場合、FlowはSUCCESS状態になります。']",
@@ -272,7 +272,7 @@
       "please": "ドキュメントを見るには右側のTaskを選択してください"
     },
     "last execution date": "最後の実行日",
-    "last execution status": "最後のステータス",
+    "last execution state": "最後のステータス",
     "last X days count": "過去{days}日間に{count}",
     "date range count": "{startDate}から{endDate}の間に{count}",
     "date count": "{date}に{count}",
@@ -810,10 +810,10 @@
       "storage": "内部ストレージファイルを削除"
     },
     "show chart": "チャートを表示",
-    "change execution status done": "実行ステータスが更新されました",
-    "change execution status confirm": "実行<code>{id}</code>のステータスを変更してもよろしいですか？",
-    "change status tooltip": "実行ステータスを変更",
-    "executions status changed": "<code>{executionCount}</code> 回の実行のステータスが変更されました",
-    "bulk change status": "以下の実行の状態を変更してもよろしいですか？<code>{executionCount}</code>"
+    "change execution state done": "実行ステータスが更新されました",
+    "change execution state confirm": "実行<code>{id}</code>のステータスを変更してもよろしいですか？",
+    "change state tooltip": "実行ステータスを変更",
+    "executions state changed": "<code>{executionCount}</code> 回の実行のステータスが変更されました",
+    "bulk change state": "以下の実行の状態を変更してもよろしいですか？<code>{executionCount}</code>"
   }
 }

--- a/ui/src/translations/ko.json
+++ b/ui/src/translations/ko.json
@@ -171,10 +171,10 @@
     "replay confirm": "재실행 하시겠습니까?",
     "prefill inputs": "미리 채우기",
     "current": "현재",
-    "change status": "상태 변경",
-    "change status done": "Task 상태가 업데이트되었습니다.",
-    "change status confirm": "실행 <code>{id}</code>의 task <code>{task}</code>의 상태를 변경하시겠습니까?",
-    "change status hint": {
+    "change state": "상태 변경",
+    "change state done": "Task 상태가 업데이트되었습니다.",
+    "change state confirm": "실행 <code>{id}</code>의 task <code>{task}</code>의 상태를 변경하시겠습니까?",
+    "change state hint": {
       "WARNING": "['Flow가 WARNING으로 표시됩니다.', '다음 Task가 실행됩니다.', 'Error Tasks가 실행됩니다.']",
       "FAILED": "['Flow가 FAILED로 표시됩니다.', '다른 Task는 실행되지 않습니다.', 'Error Tasks가 실행됩니다.']",
       "SUCCESS": "['해당ask가 성공했기 때문에 Flow가 재시작됩니다.', '모든 Block된 Tasks가 실행됩니다.', '모든 Task 실행이 성공하면 Flow가 SUCCESS 상태가 됩니다.']",
@@ -272,7 +272,7 @@
       "please": "오른쪽에서 task를 선택하여 해당 문서를 확인하세요."
     },
     "last execution date": "마지막 실행 날짜",
-    "last execution status": "마지막 상태",
+    "last execution state": "마지막 상태",
     "last X days count": "지난 {days}일 동안 {count}",
     "date range count": "{startDate}와 {endDate} 사이에 {count}",
     "date count": "{date}에 {count}",
@@ -810,10 +810,10 @@
       "storage": "내부 저장소 파일 삭제"
     },
     "show chart": "차트 보기",
-    "change execution status done": "실행 상태가 업데이트되었습니다",
-    "change execution status confirm": "실행 <code>{id}</code>의 상태를 변경하시겠습니까?",
-    "change status tooltip": "실행 상태 변경",
-    "executions status changed": "<code>{executionCount}</code> 실행 상태가 변경되었습니다",
-    "bulk change status": "확실히 <code>{executionCount}</code> 개의 실행 상태를 변경하시겠습니까?"
+    "change execution state done": "실행 상태가 업데이트되었습니다",
+    "change execution state confirm": "실행 <code>{id}</code>의 상태를 변경하시겠습니까?",
+    "change state tooltip": "실행 상태 변경",
+    "executions state changed": "<code>{executionCount}</code> 실행 상태가 변경되었습니다",
+    "bulk change state": "확실히 <code>{executionCount}</code> 개의 실행 상태를 변경하시겠습니까?"
   }
 }

--- a/ui/src/translations/pl.json
+++ b/ui/src/translations/pl.json
@@ -171,10 +171,10 @@
     "replay confirm": "Czy na pewno chcesz odtworzyć to wykonanie <code>{id}</code> i utworzyć nowe?",
     "prefill inputs": "Wypełnij",
     "current": "bieżący",
-    "change status": "Zmień status",
-    "change status done": "Status task został zaktualizowany",
-    "change status confirm": "Czy na pewno chcesz zmienić status task <code>{task}</code> dla wykonania <code>{id}</code>?",
-    "change status hint": {
+    "change state": "Zmień status",
+    "change state done": "Status task został zaktualizowany",
+    "change state confirm": "Czy na pewno chcesz zmienić status task <code>{task}</code> dla wykonania <code>{id}</code>?",
+    "change state hint": {
       "WARNING": "['Flow zostanie oznaczony jako WARNING.', 'Następne taski zostaną wykonane.', 'Taski błędów zostaną wykonane.']",
       "FAILED": "['Flow zostanie oznaczony jako FAILED.', 'Żaden inny task nie zostanie wykonany.', 'Taski błędów zostaną wykonane.']",
       "SUCCESS": "['Flow zostanie ponownie uruchomiony, ponieważ ten task zakończył się sukcesem.', 'Wszystkie zablokowane taski zostaną wykonane.', 'Flow będzie w stanie SUCCESS, jeśli wszystkie uruchomienia task zakończą się sukcesem.']",
@@ -272,7 +272,7 @@
       "please": "Proszę wybrać task po prawej, aby zobaczyć jego dokumentację"
     },
     "last execution date": "Data ostatniego wykonania",
-    "last execution status": "Ostatni status",
+    "last execution state": "Ostatni status",
     "last X days count": "{count} w ostatnich {days} dniach",
     "date range count": "{count} między {startDate} a {endDate}",
     "date count": "{count} w dniu {date}",
@@ -810,10 +810,10 @@
       "storage": "Usuń wewnętrzne pliki storage"
     },
     "show chart": "Pokaż Wykres",
-    "change execution status done": "Status wykonania zaktualizowany",
-    "change execution status confirm": "Czy na pewno chcesz zmienić status wykonania <code>{id}</code>?",
-    "change status tooltip": "Zmień status wykonania",
-    "executions status changed": "Status <code>{executionCount}</code> wykonania/wykonań został zmieniony",
-    "bulk change status": "Czy na pewno chcesz zmienić stan <code>{executionCount}</code> wykonania/wykonań?"
+    "change execution state done": "Status wykonania zaktualizowany",
+    "change execution state confirm": "Czy na pewno chcesz zmienić status wykonania <code>{id}</code>?",
+    "change state tooltip": "Zmień status wykonania",
+    "executions state changed": "Status <code>{executionCount}</code> wykonania/wykonań został zmieniony",
+    "bulk change state": "Czy na pewno chcesz zmienić stan <code>{executionCount}</code> wykonania/wykonań?"
   }
 }

--- a/ui/src/translations/pt.json
+++ b/ui/src/translations/pt.json
@@ -171,10 +171,10 @@
     "replay confirm": "Tem certeza de que deseja repetir esta execução <code>{id}</code> e criar uma nova?",
     "prefill inputs": "Preencher automaticamente",
     "current": "atual",
-    "change status": "Alterar status",
-    "change status done": "Status da task foi atualizado",
-    "change status confirm": "Tem certeza de que deseja alterar o status da task <code>{task}</code> para a execução <code>{id}</code>?",
-    "change status hint": {
+    "change state": "Alterar status",
+    "change state done": "Status da task foi atualizado",
+    "change state confirm": "Tem certeza de que deseja alterar o status da task <code>{task}</code> para a execução <code>{id}</code>?",
+    "change state hint": {
       "WARNING": "['O flow será marcado como WARNING.', 'As próximas tasks serão executadas.', 'As tasks de erro serão executadas.']",
       "FAILED": "['O flow será marcado como FAILED.', 'Nenhuma outra task será executada.', 'As tasks de erro serão executadas.']",
       "SUCCESS": "['O flow será reiniciado pois esta task foi bem-sucedida.', 'Todas as tasks bloqueadas serão executadas.', 'O flow estará em estado de SUCCESS se todas as execuções de tasks forem bem-sucedidas.']",
@@ -272,7 +272,7 @@
       "please": "Por favor, escolha uma task à direita para ver sua documentação"
     },
     "last execution date": "Data da última execução",
-    "last execution status": "Último status",
+    "last execution state": "Último status",
     "last X days count": "{count} nos últimos {days} dias",
     "date range count": "{count} entre {startDate} e {endDate}",
     "date count": "{count} em {date}",
@@ -810,10 +810,10 @@
       "storage": "Excluir arquivos de armazenamento interno"
     },
     "show chart": "Mostrar Gráfico",
-    "change execution status done": "Status de execução atualizado",
-    "change execution status confirm": "Tem certeza de que deseja alterar o status da execução <code>{id}</code>?",
-    "change status tooltip": "Alterar o status de execução",
-    "executions status changed": "O status de <code>{executionCount}</code> execução(ões) foi alterado",
-    "bulk change status": "Tem certeza de que deseja alterar o estado de <code>{executionCount}</code> execução(ões)?"
+    "change execution state done": "Status de execução atualizado",
+    "change execution state confirm": "Tem certeza de que deseja alterar o status da execução <code>{id}</code>?",
+    "change state tooltip": "Alterar o status de execução",
+    "executions state changed": "O status de <code>{executionCount}</code> execução(ões) foi alterado",
+    "bulk change state": "Tem certeza de que deseja alterar o estado de <code>{executionCount}</code> execução(ões)?"
   }
 }

--- a/ui/src/translations/ru.json
+++ b/ui/src/translations/ru.json
@@ -171,10 +171,10 @@
     "replay confirm": "Вы уверены, что хотите повторить это выполнение <code>{id}</code> и создать новое?",
     "prefill inputs": "Предзаполнение",
     "current": "текущий",
-    "change status": "Изменить статус",
-    "change status done": "Статус task был обновлен",
-    "change status confirm": "Вы уверены, что хотите изменить статус task <code>{task}</code> для выполнения <code>{id}</code>?",
-    "change status hint": {
+    "change state": "Изменить статус",
+    "change state done": "Статус task был обновлен",
+    "change state confirm": "Вы уверены, что хотите изменить статус task <code>{task}</code> для выполнения <code>{id}</code>?",
+    "change state hint": {
       "WARNING": "['Flow будет помечен как WARNING.', 'Следующие tasks будут выполнены.', 'Tasks с ошибками будут выполнены.']",
       "FAILED": "['Flow будет помечен как FAILED.', 'Другие tasks не будут выполнены.', 'Tasks с ошибками будут выполнены.']",
       "SUCCESS": "['Flow перезапустится, так как этот task был успешным.', 'Все заблокированные tasks будут выполнены.', 'Flow будет в состоянии SUCCESS, если все запуски tasks будут успешными.']",
@@ -272,7 +272,7 @@
       "please": "Пожалуйста, выберите task справа, чтобы увидеть его документацию"
     },
     "last execution date": "Дата последнего выполнения",
-    "last execution status": "Последний статус",
+    "last execution state": "Последний статус",
     "last X days count": "{count} за последние {days} дней",
     "date range count": "{count} между {startDate} и {endDate}",
     "date count": "{count} на {date}",
@@ -810,10 +810,10 @@
       "storage": "Удалить внутренние файлы хранения"
     },
     "show chart": "Показать диаграмму",
-    "change execution status done": "Статус выполнения обновлен",
-    "change execution status confirm": "Вы уверены, что хотите изменить статус выполнения <code>{id}</code>?",
-    "change status tooltip": "Изменить статус выполнения",
-    "executions status changed": "Статус выполнения <code>{executionCount}</code> был изменен",
-    "bulk change status": "Вы уверены, что хотите изменить состояние выполнения <code>{executionCount}</code>?"
+    "change execution state done": "Статус выполнения обновлен",
+    "change execution state confirm": "Вы уверены, что хотите изменить статус выполнения <code>{id}</code>?",
+    "change state tooltip": "Изменить статус выполнения",
+    "executions state changed": "Статус выполнения <code>{executionCount}</code> был изменен",
+    "bulk change state": "Вы уверены, что хотите изменить состояние выполнения <code>{executionCount}</code>?"
   }
 }

--- a/ui/src/translations/zh_CN.json
+++ b/ui/src/translations/zh_CN.json
@@ -171,10 +171,10 @@
     "replay confirm": "确定要重放此执行 <code>{id}</code> 并创建一个新的吗？",
     "prefill inputs": "预填",
     "current": "当前",
-    "change status": "更改状态",
-    "change status done": "任务状态已更新",
-    "change status confirm": "确定要更改执行 <code>{id}</code> 的任务 <code>{task}</code> 的状态吗？",
-    "change status hint": {
+    "change state": "更改状态",
+    "change state done": "任务状态已更新",
+    "change state confirm": "确定要更改执行 <code>{id}</code> 的任务 <code>{task}</code> 的状态吗？",
+    "change state hint": {
       "WARNING": [
         "流程将标记为警告。",
         "将执行下一个任务。",
@@ -287,7 +287,7 @@
       "please": "请选择右侧的一个任务以查看其文档"
     },
     "last execution date": "最后执行日期",
-    "last execution status": "最后状态",
+    "last execution state": "最后状态",
     "last X days count": "{days}天内的{count}",
     "date range count": "{startDate}到{endDate}之间的{count}",
     "date count": "{date}的{count}",
@@ -825,10 +825,10 @@
       "storage": "删除内部存储文件"
     },
     "show chart": "显示图表",
-    "change execution status done": "执行状态已更新",
-    "change execution status confirm": "您确定要更改执行 <code>{id}</code> 的状态吗？",
-    "change status tooltip": "更改执行状态",
-    "executions status changed": "<code>{executionCount}</code> 次执行的状态已更改",
-    "bulk change status": "您确定要更改<code>{executionCount}</code>次执行的状态吗？"
+    "change execution state done": "执行状态已更新",
+    "change execution state confirm": "您确定要更改执行 <code>{id}</code> 的状态吗？",
+    "change state tooltip": "更改执行状态",
+    "executions state changed": "<code>{executionCount}</code> 次执行的状态已更改",
+    "bulk change state": "您确定要更改<code>{executionCount}</code>次执行的状态吗？"
   }
 }


### PR DESCRIPTION
we typically say state machine rather than status machine, so it seems worth using the term state to describe Execution States consistently everywhere

hope this doesn't break any tests, if it does, can someone help address the change there too?