### PR TITLE
fix(webserver): don't consume inputs on errors

### DIFF
--- a/webserver/src/main/java/io/kestra/webserver/controllers/api/ExecutionController.java
+++ b/webserver/src/main/java/io/kestra/webserver/controllers/api/ExecutionController.java
@@ -597,14 +597,6 @@ public class ExecutionController {
                 } catch (IOException e) {
                     sink.error(new RuntimeException(e));
                 }
-            })
-            .doOnError(t -> {
-                // need to consume the inputs in case of error, that can failed, but we ignored
-                try {
-                    Flux.from(inputs).subscribeOn(Schedulers.boundedElastic()).blockLast();
-                } catch (IllegalStateException ignored) {
-
-                }
             });
     }
 


### PR DESCRIPTION
Consuming inputs on error seems to be the right things to do ... but it causes a memory leak and can totally hang the webserver pretty quickly with the error: java.lang.OutOfMemoryError: Cannot reserve 65562 bytes of direct buffer memory.

Removing the consumption of inputs seems to fix the issue.

This can be reproducible by the following flow when disabled (this send an error which was before consuming inputs).

```yaml
id: flow-with-inputs
namespace: company.team
disabled: true

inputs:
  - id: file1
    type: FILE
  - id: file2
    type: FILE

tasks:
  - id: hello1
    type: io.kestra.plugin.core.log.Log
    message: "{{inputs.file1}}"
  - id: hello2
    type: io.kestra.plugin.core.log.Log
    message: "{{inputs.file2}}"
```

Called via this cURL:

```
curl -X POST -H 'Content-Type: multipart/form-data' -F 'files=@file1.txt;filename=file1' -F 'files=@file2.txt;filename=file2' 'http://localhost:8080/api/v1/executions/company.team/flow-with-inputs' 
```

Before the fix, the memory keep increasing until the webserver hang with an OutOfMemoryError caused by native memory limit

![image](https://github.com/user-attachments/assets/ed0a1483-61f5-429e-986b-86e75a11ab86)

```
java.lang.OutOfMemoryError: Cannot reserve 65562 bytes of direct buffer memory (allocated: 1073696539, limit: 1073741824)
	at java.base/java.nio.Bits.reserveMemory(Bits.java:178)
	at java.base/java.nio.DirectByteBuffer.<init>(DirectByteBuffer.java:111)
	at java.base/java.nio.ByteBuffer.allocateDirect(ByteBuffer.java:360)
	at io.netty.buffer.PoolArena$DirectArena.allocateDirect(PoolArena.java:705)
	at io.netty.buffer.PoolArena$DirectArena.newUnpooledChunk(PoolArena.java:694)
	at io.netty.buffer.PoolArena.allocateHuge(PoolArena.java:223)
	at io.netty.buffer.PoolArena.allocate(PoolArena.java:141)
	at io.netty.buffer.PoolArena.allocate(PoolArena.java:126)
	at io.netty.buffer.PooledByteBufAllocator.newDirectBuffer(PooledByteBufAllocator.java:403)
	at io.netty.buffer.AbstractByteBufAllocator.directBuffer(AbstractByteBufAllocator.java:188)
	at io.netty.buffer.UnsafeByteBufUtil.copy(UnsafeByteBufUtil.java:454)
	at io.netty.buffer.PooledUnsafeDirectByteBuf.copy(PooledUnsafeDirectByteBuf.java:216)
	at io.netty.buffer.AbstractByteBuf.copy(AbstractByteBuf.java:1194)
	at io.netty.handler.codec.http.multipart.HttpPostMultipartRequestDecoder.loadDataMultipartOptimized(HttpPostMultipartRequestDecoder.java:1251)
	at io.netty.handler.codec.http.multipart.HttpPostMultipartRequestDecoder.getFileUpload(HttpPostMultipartRequestDecoder.java:981)
	at io.netty.handler.codec.http.multipart.HttpPostMultipartRequestDecoder.decodeMultipart(HttpPostMultipartRequestDecoder.java:615)
	at io.netty.handler.codec.http.multipart.HttpPostMultipartRequestDecoder.parseBodyMultipart(HttpPostMultipartRequestDecoder.java:506)
	at io.netty.handler.codec.http.multipart.HttpPostMultipartRequestDecoder.parseBody(HttpPostMultipartRequestDecoder.java:472)
	at io.netty.handler.codec.http.multipart.HttpPostMultipartRequestDecoder.offer(HttpPostMultipartRequestDecoder.java:384)
	at io.netty.handler.codec.http.multipart.HttpPostMultipartRequestDecoder.offer(HttpPostMultipartRequestDecoder.java:55)
	at io.micronaut.http.server.netty.FormDataHttpContentProcessor.onData(FormDataHttpContentProcessor.java:118)
	at io.micronaut.http.server.netty.FormDataHttpContentProcessor.add(FormDataHttpContentProcessor.java:187)
	at io.micronaut.http.server.netty.HttpContentProcessorAsReactiveProcessor.lambda$asPublisher$1(HttpContentProcessorAsReactiveProcessor.java:66)
	at reactor.core.publisher.FluxConcatMapNoPrefetch$FluxConcatMapNoPrefetchSubscriber.onNext(FluxConcatMapNoPrefetch.java:183)
	at reactor.core.publisher.FluxPeekFuseable$PeekFuseableSubscriber.onNext(FluxPeekFuseable.java:210)
	at reactor.core.publisher.FluxMapFuseable$MapFuseableSubscriber.onNext(FluxMapFuseable.java:129)
	at reactor.core.publisher.FluxPeekFuseable$PeekFuseableSubscriber.onNext(FluxPeekFuseable.java:210)
	at reactor.core.publisher.FluxContextWrite$ContextWriteSubscriber.onNext(FluxContextWrite.java:107)
	at reactor.core.publisher.FluxPeekFuseable$PeekFuseableConditionalSubscriber.onNext(FluxPeekFuseable.java:503)
	at reactor.core.publisher.FluxPeekFuseable$PeekFuseableConditionalSubscriber.onNext(FluxPeekFuseable.java:503)
	at reactor.core.publisher.SinkManyUnicast.drainRegular(SinkManyUnicast.java:284)
	at reactor.core.publisher.SinkManyUnicast.drain(SinkManyUnicast.java:365)
	at reactor.core.publisher.SinkManyUnicast.tryEmitNext(SinkManyUnicast.java:239)
	at reactor.core.publisher.SinkManySerialized.tryEmitNext(SinkManySerialized.java:100)
	at io.micronaut.http.server.netty.body.StreamingNettyByteBody$1.add(StreamingNettyByteBody.java:115)
	at io.micronaut.http.server.netty.body.StreamingNettyByteBody$SharedBuffer.add(StreamingNettyByteBody.java:462)
	at io.micronaut.http.server.netty.handler.PipeliningServerHandler$StreamingInboundHandler.read(PipeliningServerHandler.java:561)
	at io.micronaut.http.server.netty.handler.PipeliningServerHandler.channelRead(PipeliningServerHandler.java:221)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:444)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412)
	at io.netty.channel.ChannelInboundHandlerAdapter.channelRead(ChannelInboundHandlerAdapter.java:93)
	at io.netty.handler.codec.http.websocketx.extensions.WebSocketServerExtensionHandler.channelRead(WebSocketServerExtensionHandler.java:87)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:442)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412)
	at io.netty.channel.CombinedChannelDuplexHandler$DelegatingChannelHandlerContext.fireChannelRead(CombinedChannelDuplexHandler.java:436)
	at io.netty.handler.codec.ByteToMessageDecoder.fireChannelRead(ByteToMessageDecoder.java:346)
	at io.netty.handler.codec.ByteToMessageDecoder.channelRead(ByteToMessageDecoder.java:318)
	at io.netty.channel.CombinedChannelDuplexHandler.channelRead(CombinedChannelDuplexHandler.java:251)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:442)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412)
	at io.netty.handler.timeout.IdleStateHandler.channelRead(IdleStateHandler.java:289)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:442)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412)
	at io.netty.channel.DefaultChannelPipeline$HeadContext.channelRead(DefaultChannelPipeline.java:1407)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:440)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
	at io.netty.channel.DefaultChannelPipeline.fireChannelRead(DefaultChannelPipeline.java:918)
	at io.netty.channel.nio.AbstractNioByteChannel$NioByteUnsafe.read(AbstractNioByteChannel.java:166)
	at io.netty.channel.nio.NioEventLoop.processSelectedKey(NioEventLoop.java:788)
	at io.netty.channel.nio.NioEventLoop.processSelectedKeysOptimized(NioEventLoop.java:724)
	at io.netty.channel.nio.NioEventLoop.processSelectedKeys(NioEventLoop.java:650)
	at io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:562)
	at io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:994)
	at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74)
	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
	at java.base/java.lang.Thread.run(Thread.java:1583)
```

After the fix the webserver successfully handle all calls without hanging and the memory consumption is flat
![image](https://github.com/user-attachments/assets/93ed4315-8f3b-4eca-923a-591551355f31)

This may fix the following issue but we need confirmation of the user: https://github.com/kestra-io/kestra-ee/issues/3083

