### PR TITLE
fix(jdbc): handle duplicate key on flow topology save

### DIFF
--- a/jdbc-mysql/src/main/java/io/kestra/repository/mysql/MysqlFlowTopologyRepository.java
+++ b/jdbc-mysql/src/main/java/io/kestra/repository/mysql/MysqlFlowTopologyRepository.java
@@ -2,9 +2,13 @@ package io.kestra.repository.mysql;
 
 import io.kestra.core.models.topologies.FlowTopology;
 import io.kestra.jdbc.repository.AbstractJdbcFlowTopologyRepository;
+import io.kestra.jdbc.repository.AbstractJdbcRepository;
 import jakarta.inject.Inject;
 import jakarta.inject.Named;
 import jakarta.inject.Singleton;
+import org.jooq.DMLQuery;
+import org.jooq.DSLContext;
+import org.jooq.Record;
 
 @Singleton
 @MysqlRepositoryEnabled
@@ -12,5 +16,14 @@ public class MysqlFlowTopologyRepository extends AbstractJdbcFlowTopologyReposit
     @Inject
     public MysqlFlowTopologyRepository(@Named("flowtopologies") MysqlRepository<FlowTopology> repository) {
         super(repository);
+    }
+
+    @Override
+    protected DMLQuery<Record> buildMergeStatement(DSLContext context, FlowTopology flowTopology) {
+        return context.insertInto(this.jdbcRepository.getTable())
+            .set(AbstractJdbcRepository.field("key"), this.jdbcRepository.key(flowTopology))
+            .set(this.jdbcRepository.persistFields(flowTopology))
+            .onDuplicateKeyUpdate()
+            .set(this.jdbcRepository.persistFields(flowTopology));
     }
 }

--- a/jdbc/src/main/java/io/kestra/jdbc/repository/AbstractJdbcFlowTopologyRepository.java
+++ b/jdbc/src/main/java/io/kestra/jdbc/repository/AbstractJdbcFlowTopologyRepository.java
@@ -4,14 +4,13 @@ import io.kestra.core.models.flows.Flow;
 import io.kestra.core.models.topologies.FlowTopology;
 import io.kestra.core.repositories.FlowTopologyRepositoryInterface;
 import io.kestra.jdbc.runner.JdbcIndexerInterface;
-import jakarta.inject.Singleton;
 import org.jooq.*;
+import org.jooq.Record;
 import org.jooq.impl.DSL;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 public abstract class AbstractJdbcFlowTopologyRepository extends AbstractJdbcRepository implements FlowTopologyRepositoryInterface, JdbcIndexerInterface<FlowTopology> {
     protected final io.kestra.jdbc.AbstractJdbcRepository<FlowTopology> jdbcRepository;
@@ -105,15 +104,23 @@ public abstract class AbstractJdbcFlowTopologyRepository extends AbstractJdbcRep
                     context
                         .batch(flowTopologies
                             .stream()
-                            .map(flowTopology -> context.insertInto(this.jdbcRepository.getTable())
-                                .set(AbstractJdbcRepository.field("key"), this.jdbcRepository.key(flowTopology))
-                                .set(this.jdbcRepository.persistFields(flowTopology))
-                            )
+                            .map(flowTopology -> buildMergeStatement(context, flowTopology))
                             .toList()
                         )
                         .execute();
                 }
             });
+    }
+
+    protected DMLQuery<Record> buildMergeStatement(DSLContext context, FlowTopology flowTopology) {
+        return context.mergeInto(this.jdbcRepository.getTable())
+            .using(context.selectOne())
+            .on(AbstractJdbcRepository.field("key").eq(this.jdbcRepository.key(flowTopology)))
+            .whenMatchedThenUpdate()
+            .set(this.jdbcRepository.persistFields(flowTopology))
+            .whenNotMatchedThenInsert()
+            .set(AbstractJdbcRepository.field("key"), this.jdbcRepository.key(flowTopology))
+            .set(this.jdbcRepository.persistFields(flowTopology));
     }
 
     @Override


### PR DESCRIPTION
We usually always include `onDuplicateKeyUpdate()` when we save an object in the database, it was missing for batch insert of flow topologies.

Fixes #4825
