### PR TITLE
feat(jdbc-postgres): improve JSONB performance

### DIFF
--- a/jdbc-postgres/src/main/java/io/kestra/repository/postgres/PostgresRepository.java
+++ b/jdbc-postgres/src/main/java/io/kestra/repository/postgres/PostgresRepository.java
@@ -61,6 +61,7 @@ public class PostgresRepository<T> extends io.kestra.jdbc.AbstractJdbcRepository
     }
 
     @SneakyThrows
+    @Override
     public void persist(T entity, DSLContext context, @Nullable  Map<Field<Object>, Object> fields) {
         Map<Field<Object>, Object> finalFields = fields == null ? this.persistFields(entity) : fields;
 
@@ -75,6 +76,7 @@ public class PostgresRepository<T> extends io.kestra.jdbc.AbstractJdbcRepository
     }
 
     @SuppressWarnings("unchecked")
+    @Override
     public <R extends Record, E> ArrayListTotal<E> fetchPage(DSLContext context, SelectConditionStep<R> select, Pageable pageable, RecordMapper<R, E> mapper) {
         Result<Record> results = this.limit(
             context.select(DSL.asterisk(), DSL.count().over().as("total_count"))
@@ -93,5 +95,14 @@ public class PostgresRepository<T> extends io.kestra.jdbc.AbstractJdbcRepository
             .map((Record record) -> mapper.map((R) record));
 
         return new ArrayListTotal<>(map, totalCount);
+    }
+
+    @Override
+    public <R extends Record> T map(R record) {
+        if (deserializer != null) {
+            return deserializer.apply(record);
+        } else {
+            return this.deserialize(record.get("value", JSONB.class).data());
+        }
     }
 }


### PR DESCRIPTION
I made some quick profiling and discover that parsing JSONB in Postgres uses a lot of CPU/allocation.

I investigate a little, and there are places where we read the JSONB column as a String then parse it using Jackson.
Reading a JSONB column as a String first convert the column to JSONB then to a String, it is way more performance and generate less allocations to get it as a JSONB then call `.data()` to get it's String representation.

Basically, for Postrgres, it replaces `record.get("value", String.class))` by `record.get("value", JSONB.class).data()`.

The same could be done for MySQL, but my tests shows no improvement so I only customize the Postgres code.

Performance improvement details are here under.

For Repository.map():
- CPU profile shows a reduction from 21.1% samples to 4.6%.
- allocation profile shows an reduction from 33% samples to 8.2%.

For Queue.map():
- CPU profile shows a reduction from 3.2% samples to 2.7%.
- allocation profile shows an increase from 2.3% samples to 3.7%

The increase on the allocation profile for Queue.map() is certainly due to an increase in throughput.

CPU profile before
![cpu-before-annotated](https://github.com/user-attachments/assets/c44206a5-0085-43cc-902e-97756319b0ea)

CPU profile after
![cpu-after-annotated](https://github.com/user-attachments/assets/11f17f92-ed72-4609-ad3c-adb393bc88c7)

Allocation profile before
![alloc-before-annotated](https://github.com/user-attachments/assets/90d28bd0-9e15-4b05-8995-71cd828b3885)

Allocation profile after
![alloc-after-annotated](https://github.com/user-attachments/assets/94966539-517a-41ed-9450-f748408a1b24)


