### PR TITLE
fix(core): make flow plugin defaults override global ones

### DIFF
--- a/core/src/main/java/io/kestra/core/services/PluginDefaultService.java
+++ b/core/src/main/java/io/kestra/core/services/PluginDefaultService.java
@@ -68,6 +68,10 @@ public class PluginDefaultService {
     protected List<PluginDefault> mergeAllDefaults(Flow flow) {
         List<PluginDefault> list = new ArrayList<>();
 
+        if (flow.getPluginDefaults() != null) {
+            list.addAll(flow.getPluginDefaults());
+        }
+
         if (taskGlobalDefault != null && taskGlobalDefault.getDefaults() != null) {
             if (warnOnce.compareAndSet(false, true)) {
                 log.warn("Global Task Defaults are deprecated, please use Global Plugin Defaults instead via the 'kestra.plugins.defaults' property.");
@@ -77,10 +81,6 @@ public class PluginDefaultService {
 
         if (pluginGlobalDefault != null && pluginGlobalDefault.getDefaults() != null) {
             list.addAll(pluginGlobalDefault.getDefaults());
-        }
-
-        if (flow.getPluginDefaults() != null) {
-            list.addAll(flow.getPluginDefaults());
         }
 
         return list;


### PR DESCRIPTION
### What changes are being made and why?

This handles the OSS precedence. Sadly, EE namespaces remain to be verified.

closes #4897