### PR TITLE
feat(*): schedule an execution at a fixed date

### DIFF
--- a/core/src/main/java/io/kestra/core/models/executions/Execution.java
+++ b/core/src/main/java/io/kestra/core/models/executions/Execution.java
@@ -32,6 +32,7 @@ import lombok.With;
 import lombok.extern.slf4j.Slf4j;
 
 import java.time.Instant;
+import java.time.ZonedDateTime;
 import java.util.*;
 import java.util.function.BiFunction;
 import java.util.stream.Collectors;
@@ -96,6 +97,10 @@ public class Execution implements DeletedInterface, TenantInterface {
     @With
     ExecutionMetadata metadata;
 
+    @With
+    @Nullable
+    Instant scheduleDate;
+
     /**
      * Factory method for constructing a new {@link Execution} object for the given {@link Flow} and inputs.
      *
@@ -106,7 +111,8 @@ public class Execution implements DeletedInterface, TenantInterface {
      */
     public static Execution newExecution(final Flow flow,
                                          final BiFunction<Flow, Execution, Map<String, Object>> inputs,
-                                         final List<Label> labels) {
+                                         final List<Label> labels,
+                                         final Optional<ZonedDateTime> scheduleDate) {
         Execution execution = builder()
             .id(IdUtils.create())
             .tenantId(flow.getTenantId())
@@ -114,6 +120,7 @@ public class Execution implements DeletedInterface, TenantInterface {
             .flowId(flow.getId())
             .flowRevision(flow.getRevision())
             .state(new State())
+            .scheduleDate(scheduleDate.map(date -> date.toInstant()).orElse(null))
             .build();
 
         if (inputs != null) {
@@ -172,7 +179,8 @@ public class Execution implements DeletedInterface, TenantInterface {
             this.originalId,
             this.trigger,
             this.deleted,
-            this.metadata
+            this.metadata,
+            this.scheduleDate
         );
     }
 
@@ -205,7 +213,8 @@ public class Execution implements DeletedInterface, TenantInterface {
             this.originalId,
             this.trigger,
             this.deleted,
-            this.metadata
+            this.metadata,
+            this.scheduleDate
         );
     }
 
@@ -226,7 +235,8 @@ public class Execution implements DeletedInterface, TenantInterface {
             this.originalId,
             this.trigger,
             this.deleted,
-            this.metadata
+            this.metadata,
+            this.scheduleDate
         );
     }
 

--- a/core/src/main/java/io/kestra/core/models/flows/State.java
+++ b/core/src/main/java/io/kestra/core/models/flows/State.java
@@ -178,7 +178,7 @@ public class State {
 
     @JsonIgnore
     public boolean isResumable() {
-        return this.current.isPaused() || this.current.isRetrying();
+        return this.current.isPaused() || this.current.isRetrying() || this.current.isCreated();
     }
 
 

--- a/core/src/main/java/io/kestra/core/models/triggers/PollingTriggerInterface.java
+++ b/core/src/main/java/io/kestra/core/models/triggers/PollingTriggerInterface.java
@@ -20,12 +20,23 @@ public interface PollingTriggerInterface extends WorkerTriggerInterface {
     @PluginProperty
     Duration getInterval();
 
+    /**
+     * Evaluate the trigger and create an execution if needed.
+     */
     Optional<Execution> evaluate(ConditionContext conditionContext, TriggerContext context) throws Exception;
 
+    /**
+     * Compute the next evaluation date of the trigger based on the existing trigger context: by default, it uses the current date and the interval.
+     * Schedulable triggers must override this method.
+     */
     default ZonedDateTime nextEvaluationDate(ConditionContext conditionContext, Optional<? extends TriggerContext> last) throws Exception {
         return ZonedDateTime.now().plus(this.getInterval());
     }
 
+    /**
+     * Compute the next evaluation date of the trigger: by default, it uses the current date and the interval.
+     * Schedulable triggers must override this method as it's used to init them when there is no evaluation date.
+     */
     default ZonedDateTime nextEvaluationDate() {
         return ZonedDateTime.now().plus(this.getInterval());
     }

--- a/core/src/main/java/io/kestra/core/models/triggers/RecoverMissedSchedules.java
+++ b/core/src/main/java/io/kestra/core/models/triggers/RecoverMissedSchedules.java
@@ -1,0 +1,7 @@
+package io.kestra.core.models.triggers;
+
+public enum RecoverMissedSchedules {
+    LAST,
+    NONE,
+    ALL
+}

--- a/core/src/main/java/io/kestra/core/models/triggers/Schedulable.java
+++ b/core/src/main/java/io/kestra/core/models/triggers/Schedulable.java
@@ -1,0 +1,29 @@
+package io.kestra.core.models.triggers;
+
+import io.kestra.core.exceptions.IllegalVariableEvaluationException;
+import io.kestra.core.models.conditions.ConditionContext;
+import io.kestra.core.runners.RunContext;
+
+import java.time.ZonedDateTime;
+
+public interface Schedulable extends PollingTriggerInterface{
+    String PLUGIN_PROPERTY_RECOVER_MISSED_SCHEDULES = "recoverMissedSchedules";
+
+    /**
+     * Compute the previous evaluation of a trigger.
+     * This is used when a trigger misses some schedule to compute the next date to evaluate in the past.
+     */
+    ZonedDateTime previousEvaluationDate(ConditionContext conditionContext) throws IllegalVariableEvaluationException;
+
+    RecoverMissedSchedules getRecoverMissedSchedules();
+
+    /**
+     * Load the default RecoverMissedSchedules from plugin property, or else ALL.
+     */
+    default RecoverMissedSchedules defaultRecoverMissedSchedules(RunContext runContext) {
+        return runContext
+            .<String>pluginConfiguration(PLUGIN_PROPERTY_RECOVER_MISSED_SCHEDULES)
+            .map(conf -> RecoverMissedSchedules.valueOf(conf))
+            .orElse(RecoverMissedSchedules.ALL);
+    }
+}

--- a/core/src/main/java/io/kestra/core/models/triggers/TriggerService.java
+++ b/core/src/main/java/io/kestra/core/models/triggers/TriggerService.java
@@ -1,14 +1,18 @@
 package io.kestra.core.models.triggers;
 
+import io.kestra.core.models.Label;
 import io.kestra.core.models.conditions.ConditionContext;
 import io.kestra.core.models.executions.Execution;
 import io.kestra.core.models.executions.ExecutionTrigger;
 import io.kestra.core.models.tasks.Output;
 import io.kestra.core.models.flows.State;
+import io.kestra.core.runners.DefaultRunContext;
+import io.kestra.core.runners.FlowInputOutput;
 import io.kestra.core.runners.RunContext;
 import io.kestra.core.utils.IdUtils;
 
-import java.util.Map;
+import java.time.ZonedDateTime;
+import java.util.*;
 
 public abstract class TriggerService {
     public static Execution generateExecution(
@@ -45,6 +49,52 @@ public abstract class TriggerService {
         ExecutionTrigger executionTrigger = ExecutionTrigger.of(trigger, output, runContext.logFileURI());
 
         return generateExecution(IdUtils.create(), trigger, context, executionTrigger, conditionContext.getFlow().getRevision());
+    }
+
+    public static Execution generateScheduledExecution(
+        AbstractTrigger trigger,
+        ConditionContext conditionContext,
+        TriggerContext context,
+        List<Label> labels,
+        Map<String, Object> inputs,
+        Map<String, Object> variables,
+        Optional<ZonedDateTime> scheduleDate
+    ) {
+        RunContext runContext = conditionContext.getRunContext();
+        ExecutionTrigger executionTrigger = ExecutionTrigger.of(trigger, variables);
+
+        Execution execution = Execution.builder()
+            .id(runContext.getTriggerExecutionId())
+            .tenantId(context.getTenantId())
+            .namespace(context.getNamespace())
+            .flowId(context.getFlowId())
+            .flowRevision(conditionContext.getFlow().getRevision())
+            .labels(labels)
+            .state(new State())
+            .trigger(executionTrigger)
+            .scheduleDate(scheduleDate.map(date -> date.toInstant()).orElse(null))
+            .build();
+
+        Map<String, Object> allInputs = new HashMap<>();
+        // add flow inputs with default value
+        var flow = conditionContext.getFlow();
+        if (flow.getInputs() != null) {
+            flow.getInputs().stream()
+                .filter(input -> input.getDefaults() != null)
+                .forEach(input -> allInputs.put(input.getId(), input.getDefaults()));
+        }
+
+        if (inputs != null) {
+            allInputs.putAll(inputs);
+        }
+
+        // add inputs and inject defaults
+        if (!allInputs.isEmpty()) {
+            FlowInputOutput flowInputOutput = ((DefaultRunContext)runContext).getApplicationContext().getBean(FlowInputOutput.class);
+            execution = execution.withInputs(flowInputOutput.typedInputs(conditionContext.getFlow(), execution, allInputs));
+        }
+
+        return execution;
     }
 
     private static Execution generateExecution(

--- a/core/src/main/java/io/kestra/core/runners/ExecutorService.java
+++ b/core/src/main/java/io/kestra/core/runners/ExecutorService.java
@@ -490,9 +490,7 @@ public class ExecutorService {
                 Instant nextRetryDate;
                 AbstractRetry retry;
                 AbstractRetry.Behavior behavior;
-                ExecutionDelay.ExecutionDelayBuilder executionDelayBuilder = ExecutionDelay.builder()
-                    .taskRunId(taskRun.getId())
-                    .executionId(executor.getExecution().getId());
+
                 // Case task has a retry
                 if (task.getRetry() != null) {
                     retry = task.getRetry();
@@ -518,7 +516,9 @@ public class ExecutorService {
                         taskRun.nextRetryDate(retry);
                 }
                 if (nextRetryDate != null) {
-                    executionDelayBuilder
+                    ExecutionDelay.ExecutionDelayBuilder executionDelayBuilder = ExecutionDelay.builder()
+                        .taskRunId(taskRun.getId())
+                        .executionId(executor.getExecution().getId())
                         .date(nextRetryDate)
                         .state(State.Type.RUNNING)
                         .delayType(behavior.equals(AbstractRetry.Behavior.CREATE_NEW_EXECUTION) ?

--- a/core/src/main/java/io/kestra/core/runners/RunnerUtils.java
+++ b/core/src/main/java/io/kestra/core/runners/RunnerUtils.java
@@ -83,7 +83,7 @@ public class RunnerUtils {
             duration = Duration.ofSeconds(15);
         }
 
-        Execution execution = Execution.newExecution(flow, inputs, labels);
+        Execution execution = Execution.newExecution(flow, inputs, labels, Optional.empty());
 
         return this.awaitExecution(isTerminatedExecution(execution, flow), throwRunnable(() -> {
             this.executionQueue.emit(execution);
@@ -109,7 +109,7 @@ public class RunnerUtils {
             duration = DEFAULT_MAX_WAIT_DURATION;
         }
 
-        Execution execution = Execution.newExecution(flow, inputs, null);
+        Execution execution = Execution.newExecution(flow, inputs, null, Optional.empty());
 
         return this.awaitExecution(isPausedExecution(execution), throwRunnable(() -> {
             this.executionQueue.emit(execution);
@@ -135,7 +135,7 @@ public class RunnerUtils {
             duration = DEFAULT_MAX_WAIT_DURATION;
         }
 
-        Execution execution = Execution.newExecution(flow, inputs, null);
+        Execution execution = Execution.newExecution(flow, inputs, null, Optional.empty());
 
         return this.awaitExecution(isRunningExecution(execution), throwRunnable(() -> {
             this.executionQueue.emit(execution);

--- a/core/src/main/java/io/kestra/core/services/ExecutionService.java
+++ b/core/src/main/java/io/kestra/core/services/ExecutionService.java
@@ -193,7 +193,7 @@ public class ExecutionService {
                     .toList()
             );
 
-        if (finalTaskRunToRestart.size() == 0) {
+        if (finalTaskRunToRestart.isEmpty()) {
             throw new IllegalArgumentException("No task found to restart execution from!");
         }
 

--- a/core/src/main/java/io/kestra/core/topologies/FlowTopologyService.java
+++ b/core/src/main/java/io/kestra/core/topologies/FlowTopologyService.java
@@ -20,10 +20,7 @@ import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 import lombok.extern.slf4j.Slf4j;
 
-import java.util.HashSet;
-import java.util.List;
-import java.util.Objects;
-import java.util.Set;
+import java.util.*;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -172,7 +169,7 @@ public class FlowTopologyService {
         List<AbstractTrigger> triggers = ListUtils.emptyOnNull(child.getTriggers());
 
         // simulated execution
-        Execution execution = Execution.newExecution(parent, (f, e) -> null, null);
+        Execution execution = Execution.newExecution(parent, (f, e) -> null, null, Optional.empty());
 
         // keep only flow trigger
         List<io.kestra.plugin.core.trigger.Flow> flowTriggers = triggers

--- a/core/src/main/java/io/kestra/plugin/core/flow/Subflow.java
+++ b/core/src/main/java/io/kestra/plugin/core/flow/Subflow.java
@@ -6,6 +6,7 @@ import io.kestra.core.models.annotations.Example;
 import io.kestra.core.models.annotations.Plugin;
 import io.kestra.core.models.annotations.PluginProperty;
 import io.kestra.core.models.executions.Execution;
+import io.kestra.core.models.property.Property;
 import io.kestra.core.models.executions.TaskRun;
 import io.kestra.core.models.executions.TaskRunAttempt;
 import io.kestra.core.models.flows.State;
@@ -30,6 +31,8 @@ import lombok.ToString;
 
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
+
+import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -142,6 +145,11 @@ public class Subflow extends Task implements ExecutableTask<Subflow.Output>, Chi
     @Deprecated(since = "0.15.0")
     private Map<String, Object> outputs;
 
+    @Schema(
+        title = "Don't trigger the subflow now but schedule it on a specific date."
+   )
+    private Property<ZonedDateTime> scheduleDate;
+
     @Override
     public List<SubflowExecution<?>> createSubflowExecutions(RunContext runContext,
                                                              FlowExecutorInterface flowExecutorInterface,
@@ -172,7 +180,8 @@ public class Subflow extends Task implements ExecutableTask<Subflow.Output>, Chi
             this,
             currentTaskRun,
             inputs,
-            labels
+            labels,
+            scheduleDate
         ));
     }
 

--- a/core/src/main/java/io/kestra/plugin/core/trigger/ScheduleOnDates.java
+++ b/core/src/main/java/io/kestra/plugin/core/trigger/ScheduleOnDates.java
@@ -1,0 +1,149 @@
+package io.kestra.plugin.core.trigger;
+
+import io.kestra.core.exceptions.IllegalVariableEvaluationException;
+import io.kestra.core.models.Label;
+import io.kestra.core.models.annotations.Plugin;
+import io.kestra.core.models.annotations.PluginProperty;
+import io.kestra.core.models.conditions.ConditionContext;
+import io.kestra.core.models.executions.Execution;
+import io.kestra.core.models.property.Property;
+import io.kestra.core.models.tasks.VoidOutput;
+import io.kestra.core.models.triggers.*;
+import io.kestra.core.runners.RunContext;
+import io.kestra.core.validations.TimezoneId;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Null;
+import lombok.*;
+import lombok.experimental.SuperBuilder;
+import lombok.extern.slf4j.Slf4j;
+
+import java.time.Duration;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.temporal.ChronoUnit;
+import java.util.*;
+import java.util.function.Predicate;
+
+import static io.kestra.core.utils.Rethrow.throwFunction;
+
+@Slf4j
+@SuperBuilder
+@ToString
+@EqualsAndHashCode
+@Getter
+@NoArgsConstructor
+@Schema(
+    title = "Schedule a flow on specific dates."
+)
+@Plugin
+public class ScheduleOnDates extends AbstractTrigger implements Schedulable, TriggerOutput<VoidOutput> {
+    private static final String PLUGIN_PROPERTY_RECOVER_MISSED_SCHEDULES = "recoverMissedSchedules";
+
+    @Schema(hidden = true)
+    @Builder.Default
+    @Null
+    private final Duration interval = null;
+
+    @Schema(
+        title = "The inputs to pass to the scheduled flow."
+    )
+    @PluginProperty(dynamic = true)
+    private Map<String, Object> inputs;
+
+    @TimezoneId
+    @Schema(
+        title = "The [time zone identifier](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones) (i.e. the second column in [the Wikipedia table](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones#List)) to use for evaluating the cron expression. Default value is the server default zone ID."
+    )
+    @PluginProperty(dynamic = true)
+    @Builder.Default
+    private String timezone = ZoneId.systemDefault().toString();
+
+    @NotNull
+    private Property<List<ZonedDateTime>> dates;
+
+    @Schema(
+        title = "What to do in case of missed schedules",
+        description = "`ALL` will recover all missed schedules, `LAST`  will only recovered the last missing one, `NONE` will not recover any missing schedule.\n" +
+            "The default is `ALL` unless a different value is configured using the global plugin configuration."
+    )
+    @PluginProperty
+    private RecoverMissedSchedules recoverMissedSchedules;
+
+    @Override
+    public Optional<Execution> evaluate(ConditionContext conditionContext, TriggerContext triggerContext) throws Exception {
+        RunContext runContext = conditionContext.getRunContext();
+        ZonedDateTime lastEvaluation = triggerContext.getDate();
+        Optional<ZonedDateTime> nextDate = nextDate(runContext, date -> date.isEqual(lastEvaluation) || date.isAfter(lastEvaluation));
+
+        if (nextDate.isPresent()) {
+            log.info("Schedule execution on {}", nextDate.get());
+
+            Execution execution = TriggerService.generateScheduledExecution(
+                this,
+                conditionContext,
+                triggerContext,
+                generateLabels(conditionContext),
+                this.inputs != null ? runContext.render(this.inputs) : Collections.emptyMap(),
+                Collections.emptyMap(),
+                nextDate
+            );
+
+            return Optional.of(execution);
+        }
+
+        return Optional.empty();
+    }
+
+    @Override
+    public ZonedDateTime nextEvaluationDate(ConditionContext conditionContext, Optional<? extends TriggerContext> last) throws Exception {
+        // lastEvaluation date is the last one from the trigger context or the first date of the list
+        return last
+            .map(throwFunction(context -> nextDate(conditionContext.getRunContext(), date -> date.isAfter(context.getDate()))
+                .orElse(ZonedDateTime.now().plusYears(1) // it's not ideal, but we need a date or the trigger will keep evaluated
+            )))
+            .orElse(dates.asList(conditionContext.getRunContext(), ZonedDateTime.class).stream().sorted().findFirst().orElse(ZonedDateTime.now()))
+            .truncatedTo(ChronoUnit.SECONDS);
+    }
+
+    @Override
+    public ZonedDateTime nextEvaluationDate() {
+        // TODO this may be the next date from now?
+        return ZonedDateTime.now();
+    }
+
+    @Override
+    public ZonedDateTime previousEvaluationDate(ConditionContext conditionContext) throws IllegalVariableEvaluationException {
+        // the previous date is "the previous date of the next date"
+        ZonedDateTime now = ZonedDateTime.now();
+        List<ZonedDateTime> previousDates = dates.asList(conditionContext.getRunContext(), ZonedDateTime.class).stream()
+            .sorted()
+            .takeWhile(date -> date.isBefore(now))
+            .toList()
+            .reversed();
+
+        return previousDates.isEmpty() ? ZonedDateTime.now() : previousDates.getFirst();
+    }
+
+    private Optional<ZonedDateTime> nextDate(RunContext runContext, Predicate<ZonedDateTime> filter) throws IllegalVariableEvaluationException {
+        return dates.asList(runContext, ZonedDateTime.class).stream().sorted()
+            .filter(date -> filter.test(date))
+            .map(throwFunction(date -> timezone == null ? date : date.withZoneSameInstant(ZoneId.of(runContext.render(timezone)))))
+            .findFirst()
+            .map(date -> date.truncatedTo(ChronoUnit.SECONDS));
+    }
+
+    private List<Label> generateLabels(ConditionContext conditionContext) {
+        List<Label> labels = new ArrayList<>();
+
+        if (conditionContext.getFlow().getLabels() != null) {
+            labels.addAll(conditionContext.getFlow().getLabels());
+        }
+
+        if (this.getLabels() != null) {
+            labels.addAll(this.getLabels());
+        }
+
+        return labels;
+    }
+}

--- a/core/src/test/java/io/kestra/core/runners/FlowConcurrencyCaseTest.java
+++ b/core/src/test/java/io/kestra/core/runners/FlowConcurrencyCaseTest.java
@@ -88,7 +88,7 @@ public class FlowConcurrencyCaseTest {
         Flow flow = flowRepository
             .findById(null, "io.kestra.tests", "flow-concurrency-queue", Optional.empty())
             .orElseThrow();
-        Execution execution2 = Execution.newExecution(flow, null, null);
+        Execution execution2 = Execution.newExecution(flow, null, null, Optional.empty());
         executionQueue.emit(execution2);
 
         assertThat(execution1.getState().isRunning(), is(true));
@@ -137,7 +137,7 @@ public class FlowConcurrencyCaseTest {
         Flow flow = flowRepository
             .findById(null, "io.kestra.tests", "flow-concurrency-queue-pause", Optional.empty())
             .orElseThrow();
-        Execution execution2 = Execution.newExecution(flow, null, null);
+        Execution execution2 = Execution.newExecution(flow, null, null, Optional.empty());
         executionQueue.emit(execution2);
 
         assertThat(execution1.getState().isRunning(), is(true));
@@ -186,7 +186,7 @@ public class FlowConcurrencyCaseTest {
         Flow flow = flowRepository
             .findById(null, "io.kestra.tests", "flow-concurrency-cancel-pause", Optional.empty())
             .orElseThrow();
-        Execution execution2 = Execution.newExecution(flow, null, null);
+        Execution execution2 = Execution.newExecution(flow, null, null, Optional.empty());
         executionQueue.emit(execution2);
 
         assertThat(execution1.getState().isRunning(), is(true));

--- a/core/src/test/java/io/kestra/core/runners/ScheduleDateCaseTest.java
+++ b/core/src/test/java/io/kestra/core/runners/ScheduleDateCaseTest.java
@@ -1,0 +1,56 @@
+package io.kestra.core.runners;
+
+import io.kestra.core.models.executions.Execution;
+import io.kestra.core.models.flows.Flow;
+import io.kestra.core.models.flows.State;
+import io.kestra.core.queues.QueueException;
+import io.kestra.core.queues.QueueFactoryInterface;
+import io.kestra.core.queues.QueueInterface;
+import io.kestra.core.repositories.FlowRepositoryInterface;
+import io.kestra.core.utils.TestsUtils;
+import jakarta.inject.Inject;
+import jakarta.inject.Named;
+import jakarta.inject.Singleton;
+import reactor.core.publisher.Flux;
+
+import java.time.ZonedDateTime;
+import java.util.Optional;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+@Singleton
+public class ScheduleDateCaseTest {
+    @Inject
+    private FlowRepositoryInterface flowRepository;
+
+    @Inject
+    @Named(QueueFactoryInterface.EXECUTION_NAMED)
+    protected QueueInterface<Execution> executionQueue;
+
+    public void shouldScheduleOnDate() throws QueueException, InterruptedException {
+        ZonedDateTime scheduleOn = ZonedDateTime.now().plusSeconds(1);
+        Flow flow = flowRepository.findById(null, "io.kestra.tests", "minimal").orElseThrow();
+        Execution execution = Execution.newExecution(flow, null, null, Optional.of(scheduleOn));
+        this.executionQueue.emit(execution);
+
+        assertThat(execution.getState().getCurrent(), is(State.Type.CREATED));
+        assertThat(execution.getScheduleDate(), is(scheduleOn.toInstant()));
+
+        CountDownLatch latch1 = new CountDownLatch(1);
+
+        Flux<Execution> receive = TestsUtils.receive(executionQueue, e -> {
+            if (e.getLeft().getId().equals(execution.getId())) {
+                if (e.getLeft().getState().getCurrent() == State.Type.SUCCESS) {
+                    latch1.countDown();
+                }
+            }
+        });
+
+        latch1.await(1, TimeUnit.MINUTES);
+
+        assertThat(receive.blockLast().getState().getCurrent(), is(State.Type.SUCCESS));
+    }
+}

--- a/core/src/test/java/io/kestra/core/runners/SkipExecutionCaseTest.java
+++ b/core/src/test/java/io/kestra/core/runners/SkipExecutionCaseTest.java
@@ -16,6 +16,7 @@ import jakarta.inject.Singleton;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.TimeoutException;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -38,7 +39,7 @@ public class SkipExecutionCaseTest {
 
     public void skipExecution() throws TimeoutException, QueueException, InterruptedException {
         Flow flow = createFlow();
-        Execution execution1 = Execution.newExecution(flow, null, null);
+        Execution execution1 = Execution.newExecution(flow, null, null, Optional.empty());
         String execution1Id = execution1.getId();
         skipExecutionService.setSkipExecutions(List.of(execution1Id));
 

--- a/core/src/test/java/io/kestra/core/schedulers/SchedulerScheduleOnDatesTest.java
+++ b/core/src/test/java/io/kestra/core/schedulers/SchedulerScheduleOnDatesTest.java
@@ -1,0 +1,257 @@
+package io.kestra.core.schedulers;
+
+import io.kestra.core.models.executions.Execution;
+import io.kestra.core.models.flows.Flow;
+import io.kestra.core.models.flows.State;
+import io.kestra.core.models.property.Property;
+import io.kestra.core.models.triggers.RecoverMissedSchedules;
+import io.kestra.core.models.triggers.Trigger;
+import io.kestra.core.runners.FlowListeners;
+import io.kestra.core.utils.Await;
+import io.kestra.core.utils.TestsUtils;
+import io.kestra.jdbc.runner.JdbcScheduler;
+import io.kestra.plugin.core.trigger.ScheduleOnDates;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Flux;
+
+import java.time.Duration;
+import java.time.ZonedDateTime;
+import java.time.temporal.ChronoUnit;
+import java.util.*;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import static io.kestra.core.utils.Rethrow.throwConsumer;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.spy;
+
+public class SchedulerScheduleOnDatesTest extends AbstractSchedulerTest {
+    @Inject
+    protected FlowListeners flowListenersService;
+
+    @Inject
+    protected SchedulerTriggerStateInterface triggerState;
+
+    private ScheduleOnDates.ScheduleOnDatesBuilder<?, ?> createScheduleOnDatesTrigger(String zone, List<ZonedDateTime> dates, String triggerId) {
+        return ScheduleOnDates.builder()
+            .id(triggerId)
+            .type(ScheduleOnDates.class.getName())
+            .dates(Property.of(dates))
+            .timezone(zone)
+            .inputs(Map.of(
+                "testInputs", "test-inputs"
+            ));
+    }
+
+    private Flow createScheduleFlow(String zone, String triggerId) {
+        var now = ZonedDateTime.now();
+        var before = now.minusSeconds(1).truncatedTo(ChronoUnit.SECONDS);
+        var after = now.plusSeconds(1).truncatedTo(ChronoUnit.SECONDS);
+        var later = now.plusSeconds(2).truncatedTo(ChronoUnit.SECONDS);
+        ScheduleOnDates schedule = createScheduleOnDatesTrigger(zone, List.of(before, after, later), triggerId).build();
+
+        return createFlow(Collections.singletonList(schedule));
+    }
+
+    protected AbstractScheduler scheduler(FlowListeners flowListenersServiceSpy) {
+        return new JdbcScheduler(
+            applicationContext,
+            flowListenersServiceSpy
+        );
+    }
+
+
+    @Test
+    void scheduleOnDates() throws Exception {
+        // mock flow listeners
+        FlowListeners flowListenersServiceSpy = spy(this.flowListenersService);
+        CountDownLatch queueCount = new CountDownLatch(4);
+        Set<String> date = new HashSet<>();
+        Set<String> executionId = new HashSet<>();
+
+        // then flow should be executed 4 times
+        Flow flow = createScheduleFlow("Europe/Paris", "schedule");
+
+        doReturn(List.of(flow))
+            .when(flowListenersServiceSpy)
+            .flows();
+
+        Trigger trigger = Trigger
+            .builder()
+            .triggerId("schedule")
+            .flowId(flow.getId())
+            .namespace(flow.getNamespace())
+            .date(ZonedDateTime.now())
+            .build();
+
+        triggerState.create(trigger);
+
+        // scheduler
+        try (AbstractScheduler scheduler = scheduler(flowListenersServiceSpy)) {
+            // wait for execution
+            Flux<Execution> receiveExecutions = TestsUtils.receive(executionQueue, throwConsumer(either -> {
+                Execution execution = either.getLeft();
+                assertThat(execution.getInputs().get("testInputs"), is("test-inputs"));
+                assertThat(execution.getInputs().get("def"), is("awesome"));
+
+                date.add((String) execution.getTrigger().getVariables().get("date"));
+                executionId.add(execution.getId());
+
+                queueCount.countDown();
+                if (execution.getState().getCurrent() == State.Type.CREATED) {
+                    executionQueue.emit(execution.withState(State.Type.SUCCESS));
+                }
+                assertThat(execution.getFlowId(), is(flow.getId()));
+            }));
+
+            scheduler.run();
+            queueCount.await(1, TimeUnit.MINUTES);
+            // needed for RetryingTest to work since there is no context cleaning between method => we have to clear assertion receiver manually
+            receiveExecutions.blockLast();
+
+            assertThat(queueCount.getCount(), is(0L));
+        }
+    }
+
+    @Test
+    void recoverALLMissing() throws Exception {
+        // mock flow listeners
+        FlowListeners flowListenersServiceSpy = spy(this.flowListenersService);
+        var now = ZonedDateTime.now();
+        var earlier = now.minusSeconds(2).truncatedTo(ChronoUnit.SECONDS);
+        var before = now.minusSeconds(1).truncatedTo(ChronoUnit.SECONDS);
+        var after = now.plusSeconds(1).truncatedTo(ChronoUnit.SECONDS);
+        var later = now.plusSeconds(2).truncatedTo(ChronoUnit.SECONDS);
+        ScheduleOnDates schedule = createScheduleOnDatesTrigger(null, List.of(earlier, before, after, later), "recoverALLMissing")
+            .recoverMissedSchedules(RecoverMissedSchedules.ALL)
+            .build();
+        Flow flow = createFlow(List.of(schedule));
+        doReturn(List.of(flow))
+            .when(flowListenersServiceSpy)
+            .flows();
+
+        ZonedDateTime lastDate = ZonedDateTime.now().minusHours(3L);
+        Trigger lastTrigger = Trigger
+            .builder()
+            .triggerId("recoverALLMissing")
+            .flowId(flow.getId())
+            .namespace(flow.getNamespace())
+            .date(lastDate)
+            .build();
+        triggerState.create(lastTrigger);
+
+        CountDownLatch queueCount = new CountDownLatch(1);
+
+        // scheduler
+        try (AbstractScheduler scheduler = scheduler(flowListenersServiceSpy)) {
+            // wait for execution
+            Flux<Execution> receive = TestsUtils.receive(executionQueue, either -> {
+                Execution execution = either.getLeft();
+                assertThat(execution.getFlowId(), is(flow.getId()));
+                queueCount.countDown();
+            });
+
+            scheduler.run();
+
+            queueCount.await(1, TimeUnit.MINUTES);
+            // needed for RetryingTest to work since there is no context cleaning between method => we have to clear assertion receiver manually
+            receive.blockLast();
+
+            assertThat(queueCount.getCount(), is(0L));
+            Trigger newTrigger = this.triggerState.findLast(lastTrigger).orElseThrow();
+            assertThat(newTrigger.getDate().toLocalDateTime(), is(earlier.toLocalDateTime()));
+            assertThat(newTrigger.getNextExecutionDate().toLocalDateTime(), is(before.toLocalDateTime()));
+        }
+    }
+
+    @Test
+    void recoverLASTMissing() throws Exception {
+        // mock flow listeners
+        FlowListeners flowListenersServiceSpy = spy(this.flowListenersService);
+        var now = ZonedDateTime.now();
+        var earlier = now.minusSeconds(2).truncatedTo(ChronoUnit.SECONDS);
+        var before = now.minusSeconds(1).truncatedTo(ChronoUnit.SECONDS);
+        var after = now.plusSeconds(1).truncatedTo(ChronoUnit.SECONDS);
+        var later = now.plusSeconds(2).truncatedTo(ChronoUnit.SECONDS);
+        ScheduleOnDates schedule = createScheduleOnDatesTrigger(null, List.of(earlier, before, after, later), "recoverLASTMissing")
+            .recoverMissedSchedules(RecoverMissedSchedules.LAST)
+            .build();
+        Flow flow = createFlow(List.of(schedule));
+        doReturn(List.of(flow))
+            .when(flowListenersServiceSpy)
+            .flows();
+
+        ZonedDateTime lastDate = ZonedDateTime.now().minusHours(3L);
+        Trigger lastTrigger = Trigger
+            .builder()
+            .triggerId("recoverLASTMissing")
+            .flowId(flow.getId())
+            .namespace(flow.getNamespace())
+            .date(lastDate)
+            .build();
+        triggerState.create(lastTrigger);
+
+        CountDownLatch queueCount = new CountDownLatch(1);
+
+        // scheduler
+        try (AbstractScheduler scheduler = scheduler(flowListenersServiceSpy)) {
+            // wait for execution
+            Flux<Execution> receive = TestsUtils.receive(executionQueue, either -> {
+                Execution execution = either.getLeft();
+                assertThat(execution.getFlowId(), is(flow.getId()));
+                queueCount.countDown();
+            });
+
+            scheduler.run();
+
+            queueCount.await(1, TimeUnit.MINUTES);
+            // needed for RetryingTest to work since there is no context cleaning between method => we have to clear assertion receiver manually
+            receive.blockLast();
+
+            assertThat(queueCount.getCount(), is(0L));
+            Trigger newTrigger = this.triggerState.findLast(lastTrigger).orElseThrow();
+            assertThat(newTrigger.getDate().toLocalDateTime(), is(before.toLocalDateTime()));
+            assertThat(newTrigger.getNextExecutionDate().toLocalDateTime(), is(after.toLocalDateTime()));
+        }
+    }
+
+    @Test
+    void recoverNONEMissing() throws Exception {
+        // mock flow listeners
+        FlowListeners flowListenersServiceSpy = spy(this.flowListenersService);
+        var now = ZonedDateTime.now();
+        var before = now.minusSeconds(1).truncatedTo(ChronoUnit.SECONDS);
+        var after = now.plusSeconds(1).truncatedTo(ChronoUnit.SECONDS);
+        var later = now.plusSeconds(2).truncatedTo(ChronoUnit.SECONDS);
+        ScheduleOnDates schedule = createScheduleOnDatesTrigger(null, List.of(before, after, later), "recoverNONEMissing")
+            .recoverMissedSchedules(RecoverMissedSchedules.NONE)
+            .build();
+        Flow flow = createFlow(List.of(schedule));
+        doReturn(List.of(flow))
+            .when(flowListenersServiceSpy)
+            .flows();
+
+        ZonedDateTime lastDate = ZonedDateTime.now().minusHours(3L);
+        Trigger lastTrigger = Trigger
+            .builder()
+            .triggerId("recoverNONEMissing")
+            .flowId(flow.getId())
+            .namespace(flow.getNamespace())
+            .date(lastDate)
+            .build();
+        triggerState.create(lastTrigger);
+
+        // scheduler
+        try (AbstractScheduler scheduler = scheduler(flowListenersServiceSpy)) {
+            scheduler.run();
+
+            Await.until(() -> scheduler.isReady(), Duration.ofMillis(100), Duration.ofSeconds(5));
+
+            Trigger newTrigger = this.triggerState.findLast(lastTrigger).orElseThrow();
+            assertThat(newTrigger.getNextExecutionDate().toLocalDateTime().truncatedTo(ChronoUnit.SECONDS), is(now.toLocalDateTime().truncatedTo(ChronoUnit.SECONDS)));
+        }
+    }
+}

--- a/core/src/test/java/io/kestra/core/schedulers/SchedulerScheduleTest.java
+++ b/core/src/test/java/io/kestra/core/schedulers/SchedulerScheduleTest.java
@@ -9,6 +9,7 @@ import io.kestra.core.models.flows.Flow;
 import io.kestra.core.models.flows.State;
 import io.kestra.core.models.triggers.Backfill;
 import io.kestra.core.models.triggers.Trigger;
+import io.kestra.core.models.triggers.RecoverMissedSchedules;
 import io.kestra.plugin.core.trigger.Schedule;
 import io.kestra.core.queues.QueueFactoryInterface;
 import io.kestra.core.queues.QueueInterface;
@@ -231,7 +232,7 @@ public class SchedulerScheduleTest extends AbstractSchedulerTest {
         // mock flow listeners
         FlowListeners flowListenersServiceSpy = spy(this.flowListenersService);
         Schedule schedule = createScheduleTrigger(null, "0 * * * *", "recoverLASTMissing", false)
-            .recoverMissedSchedules(Schedule.RecoverMissedSchedules.LAST)
+            .recoverMissedSchedules(RecoverMissedSchedules.LAST)
             .build();
         Flow flow = createFlow(List.of(schedule));
         doReturn(List.of(flow))
@@ -277,7 +278,7 @@ public class SchedulerScheduleTest extends AbstractSchedulerTest {
         // mock flow listeners
         FlowListeners flowListenersServiceSpy = spy(this.flowListenersService);
         Schedule schedule = createScheduleTrigger(null, "0 * * * *", "recoverNONEMissing", false)
-            .recoverMissedSchedules(Schedule.RecoverMissedSchedules.NONE)
+            .recoverMissedSchedules(RecoverMissedSchedules.NONE)
             .build();
         Flow flow = createFlow(List.of(schedule));
         doReturn(List.of(flow))

--- a/core/src/test/java/io/kestra/plugin/core/trigger/ScheduleOnDatesTest.java
+++ b/core/src/test/java/io/kestra/plugin/core/trigger/ScheduleOnDatesTest.java
@@ -1,0 +1,128 @@
+package io.kestra.plugin.core.trigger;
+
+import io.kestra.core.junit.annotations.KestraTest;
+import io.kestra.core.models.Label;
+import io.kestra.core.models.conditions.ConditionContext;
+import io.kestra.core.models.flows.Flow;
+import io.kestra.core.models.flows.Type;
+import io.kestra.core.models.flows.input.StringInput;
+import io.kestra.core.models.property.Property;
+import io.kestra.core.models.triggers.AbstractTrigger;
+import io.kestra.core.models.triggers.Trigger;
+import io.kestra.core.models.triggers.TriggerContext;
+import io.kestra.core.runners.DefaultRunContext;
+import io.kestra.core.runners.RunContextFactory;
+import io.kestra.core.runners.RunContextInitializer;
+import io.kestra.core.utils.IdUtils;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.Test;
+
+import java.time.ZonedDateTime;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+import java.util.Optional;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.CoreMatchers.is;
+
+@KestraTest
+class ScheduleOnDatesTest {
+    @Inject
+    RunContextFactory runContextFactory;
+
+    @Inject
+    RunContextInitializer runContextInitializer;
+
+    @Test
+    public void shouldReturnNextDateWhenNextEvaluationDateAndAnExistingTriggerDate() throws Exception {
+        // given
+        var now = ZonedDateTime.now();
+        var before = now.minusMinutes(1).truncatedTo(ChronoUnit.SECONDS);
+        var after = now.plusMinutes(1).truncatedTo(ChronoUnit.SECONDS);
+        var later = now.plusMinutes(2).truncatedTo(ChronoUnit.SECONDS);
+        var scheduleOnDates = ScheduleOnDates.builder()
+            .id(IdUtils.create())
+            .interval(null)
+            .dates(Property.of(List.of(before, after, later)))
+            .build();
+        var triggerContext = TriggerContext.builder().date(now).build();
+        var trigger = Trigger.of(triggerContext, now);
+        var conditionContext =conditionContext(scheduleOnDates);
+
+        // when
+        ZonedDateTime nextDate = scheduleOnDates.nextEvaluationDate(conditionContext, Optional.of(trigger));
+
+        // then
+        assertThat(nextDate, is(after));
+    }
+
+    @Test
+    public void shouldReturnFirstDateWhenNextEvaluationDateAndNoExistingTriggerDate() throws Exception {
+        // given
+        var now = ZonedDateTime.now();
+        var before = now.minusMinutes(1).truncatedTo(ChronoUnit.SECONDS);
+        var after = now.plusMinutes(1).truncatedTo(ChronoUnit.SECONDS);
+        var later = now.plusMinutes(2).truncatedTo(ChronoUnit.SECONDS);
+        var scheduleOnDates = ScheduleOnDates.builder()
+            .id(IdUtils.create())
+            .interval(null)
+            .dates(Property.of(List.of(before, after, later)))
+            .build();
+        var conditionContext = conditionContext(scheduleOnDates);
+
+        // when
+        ZonedDateTime nextDate = scheduleOnDates.nextEvaluationDate(conditionContext, Optional.empty());
+
+        // then
+        assertThat(nextDate, is(before));
+    }
+
+    @Test
+    public void shouldReturnPreviousDateWhenPreviousEvaluationDate() throws Exception {
+        // given
+        var now = ZonedDateTime.now();
+        var first = now.minusMinutes(2).truncatedTo(ChronoUnit.SECONDS);
+        var before = now.minusMinutes(1).truncatedTo(ChronoUnit.SECONDS);
+        var next = now.plusMinutes(1).truncatedTo(ChronoUnit.SECONDS);
+        var scheduleOnDates = ScheduleOnDates.builder()
+            .id(IdUtils.create())
+            .interval(null)
+            .dates(Property.of(List.of(first, before, next)))
+            .build();
+        var conditionContext = conditionContext(scheduleOnDates);
+
+        // when
+        ZonedDateTime previousDate = scheduleOnDates.previousEvaluationDate(conditionContext);
+
+        // then
+        assertThat(previousDate, is(before));
+    }
+
+    private ConditionContext conditionContext(AbstractTrigger trigger) {
+        io.kestra.core.models.flows.Flow flow = Flow.builder()
+            .id(IdUtils.create())
+            .namespace("io.kestra.tests")
+            .labels(
+                List.of(
+                    new Label("flow-label-1", "flow-label-1"),
+                    new Label("flow-label-2", "flow-label-2")
+                )
+            )
+            .inputs(List.of(
+                StringInput.builder().id("input1").type(Type.STRING).required(false).build(),
+                StringInput.builder().id("input2").type(Type.STRING).defaults("default").build()
+            ))
+            .build();
+
+        TriggerContext triggerContext = TriggerContext.builder()
+            .namespace(flow.getNamespace())
+            .flowId(flow.getId())
+            .triggerId(trigger.getId())
+            .build();
+
+        return ConditionContext.builder()
+            .runContext(runContextInitializer.forScheduler((DefaultRunContext) runContextFactory.of(), triggerContext, trigger))
+            .flow(flow)
+            .build();
+    }
+}

--- a/jdbc/src/test/java/io/kestra/jdbc/runner/JdbcRunnerTest.java
+++ b/jdbc/src/test/java/io/kestra/jdbc/runner/JdbcRunnerTest.java
@@ -86,6 +86,9 @@ public abstract class JdbcRunnerTest {
     private FlowConcurrencyCaseTest flowConcurrencyCaseTest;
 
     @Inject
+    private ScheduleDateCaseTest scheduleDateCaseTest;
+
+    @Inject
     private FlowInputOutput flowIO;
 
     @BeforeAll
@@ -445,5 +448,10 @@ public abstract class JdbcRunnerTest {
         assertThat(execution.getState().getCurrent(), is(State.Type.FAILED));
         assertThat(execution.getTaskRunList().size(), is(1));
 
+    }
+
+    @Test
+    void shouldScheduleOnDate() throws QueueException, InterruptedException {
+        scheduleDateCaseTest.shouldScheduleOnDate();
     }
 }

--- a/ui/src/components/executions/Overview.vue
+++ b/ui/src/components/executions/Overview.vue
@@ -144,6 +144,7 @@
                     {key: this.$t("steps"), value: stepCount},
                     {key: this.$t("attempt"), value: this.execution?.metadata?.attemptNumber},
                     {key: this.$t("originalCreatedDate"), value: this.execution?.metadata?.originalCreatedDate, date: true},
+                    {key: this.$t("scheduleDate"), value: this.execution?.scheduleDate, date: true},
                 ];
 
                 if (this.execution.parentId) {

--- a/ui/src/components/flows/FlowRun.vue
+++ b/ui/src/components/flows/FlowRun.vue
@@ -18,6 +18,15 @@
                             v-model:labels="executionLabels"
                         />
                     </el-form-item>
+                    <el-form-item
+                        :label="$t('scheduleDate')"
+                    >
+                        <el-date-picker
+                            :key="scheduleDate"
+                            v-model="scheduleDate"
+                            type="datetime"
+                        />
+                    </el-form-item>
                 </el-collapse-item>
                 <el-collapse-item :title="$t('curl.command')" name="curl">
                     <curl :flow="flow" :execution-labels="executionLabels" :inputs="inputs" />
@@ -69,6 +78,8 @@
     import Curl from "./Curl.vue";
     import {executeFlowBehaviours, storageKeys} from "../../utils/constants";
     import Inputs from "../../utils/inputs";
+    import {TIMEZONE_STORAGE_KEY} from "../settings/BasicSettings.vue";
+    import moment from "moment-timezone";
 
     export default {
         components: {LabelInput, InputsForm, Curl},
@@ -87,6 +98,7 @@
                 inputs: {},
                 inputNewLabel: "",
                 executionLabels: [],
+                scheduleDate: undefined,
                 inputVisible: false,
                 collapseName: undefined,
                 newTab: localStorage.getItem(storageKeys.EXECUTE_FLOW_BEHAVIOUR) === executeFlowBehaviours.NEW_TAB
@@ -155,6 +167,7 @@
                             labels: this.executionLabels
                                 .filter(label => label.key && label.value)
                                 .map(label => `${label.key}:${label.value}`),
+                            scheduleDate: this.$moment(this.scheduleDate).tz(localStorage.getItem(TIMEZONE_STORAGE_KEY) ?? moment.tz.guess()).toISOString(true),
                             nextStep: true
                         })
                         this.$emit("executionTrigger");

--- a/ui/src/stores/executions.js
+++ b/ui/src/stores/executions.js
@@ -160,7 +160,8 @@ export default {
                     "content-type": "multipart/form-data"
                 },
                 params: {
-                    labels: options.labels ?? []
+                    labels: options.labels ?? [],
+                    scheduleDate: options.scheduleDate
                 }
             })
         },

--- a/ui/src/translations/en.json
+++ b/ui/src/translations/en.json
@@ -841,6 +841,7 @@
     },
     "data": "Data",
     "webhook link copied": "Webhook link copied.",
-    "copy url": "Copy URL"
+    "copy url": "Copy URL",
+    "scheduleDate": "Schedule date"
   }
 }

--- a/webserver/src/main/java/io/kestra/webserver/controllers/api/ExecutionController.java
+++ b/webserver/src/main/java/io/kestra/webserver/controllers/api/ExecutionController.java
@@ -538,7 +538,7 @@ public class ExecutionController {
         @Parameter(description = "If the server will wait the end of the execution") @QueryValue(defaultValue = "false") Boolean wait,
         @Parameter(description = "The flow revision or latest if null") @QueryValue Optional<Integer> revision
     ) throws IOException {
-        return this.create(namespace, id, inputs, labels, wait, revision);
+        return this.create(namespace, id, inputs, labels, wait, revision, Optional.empty());
     }
 
     @ExecuteOn(TaskExecutors.IO)
@@ -552,7 +552,8 @@ public class ExecutionController {
         @Parameter(description = "The inputs") @Nullable @Body MultipartBody inputs,
         @Parameter(description = "The labels as a list of 'key:value'") @Nullable @QueryValue @Format("MULTI") List<String> labels,
         @Parameter(description = "If the server will wait the end of the execution") @QueryValue(defaultValue = "false") Boolean wait,
-        @Parameter(description = "The flow revision or latest if null") @QueryValue Optional<Integer> revision
+        @Parameter(description = "The flow revision or latest if null") @QueryValue Optional<Integer> revision,
+        @Parameter(description = "Schedule the flow on a specific date") @QueryValue Optional<ZonedDateTime> scheduleDate
     ) throws IOException {
         return Mono.<Execution>create(
             sink -> {
@@ -577,7 +578,8 @@ public class ExecutionController {
                     Execution current = Execution.newExecution(
                         found,
                         throwBiFunction((flow, execution) -> flowInputOutput.typedInputs(flow, execution, inputs)),
-                        parseLabels(labels)
+                        parseLabels(labels),
+                        scheduleDate
                     );
 
                     executionQueue.emit(current);


### PR DESCRIPTION
Fixes #3818

This is a WIP.

There are 3 new features.

## Schedule a flow on a specific date from the API/UI
Select a date in the advanced configuration of the execution run modal:
![image](https://github.com/user-attachments/assets/7b34cf7c-7634-4f8c-afa9-c9b97d17357f)

The flow will be CREATED, and will only goes into the RUNNING state at the scheduled date (which can be seen in the Overview page)

## Schedule a subflow on a specific date
Both `Subflow` and `ForEachItem` tasks have been enhanced to specify on which date the subflow must be scheduled:

Example to schedule a sublflow for 1 after the task execution:

```yaml
id: subflow-for-later
namespace: company.team

tasks:
  - id: subflow
    type: io.kestra.plugin.core.flow.Subflow
    namespace: company.team
    flowId: myflow
    scheduleDate: "{{now() | dateAdd(1, 'MINUTES')}}"
```

The flow will be CREATED, and will only goes into the RUNNING state at the scheduled date (which can be seen in the Overview page)

## Trigger executions at a specific date
A new trigger `ScheduleOnDates` has been created that allows to start a flow at specific dates.
A new trigger has been created because the Schedule trigger is already very complex and triggering on specific dates is functionality different than triggering based on a schedule.

Example to start 3 executions on specific dates:

```yaml
id: scheduled-at
namespace: company.team

triggers:
  - id: at8
    type: io.kestra.plugin.core.trigger.ScheduleOnDates
    timezone: Europe/Paris
    recoverMissedSchedules: LAST
    dates:
      - 2024-09-16T14:57:10+02:00
      - 2024-09-16T14:58:10+02:00
      - 2024-09-16T14:59:10+02:00

tasks:
  - id: hello
    type: io.kestra.plugin.core.log.Log
    message: Hello World! 🚀
```

After starting all defined dates, the trigger will have a next evaluation date in one year for now as it's the only way to avoid re-evaluating the trigger each second. We may change that if needed.