### PR TITLE
fix(docs): Leverage utm_campaign instead of duplicating utm_content in EE tooltips

### DIFF
--- a/ui/src/components/EnterpriseTooltip.vue
+++ b/ui/src/components/EnterpriseTooltip.vue
@@ -74,7 +74,7 @@
         computed: {
             link() {
 
-                let link = "https://kestra.io/demo?utm_source=app&utm_content=ee-tooltip";
+                let link = "https://kestra.io/demo?utm_source=app&utm_campaign=ee-tooltip";
 
                 if (this.term) {
                     link = link + "&utm_term=" + this.term;

--- a/ui/src/components/ErrorToastContainer.vue
+++ b/ui/src/components/ErrorToastContainer.vue
@@ -1,6 +1,6 @@
 <template>
     <a
-        href="https://kestra.io/slack?utm_source=app&utm_content=error"
+        href="https://kestra.io/slack?utm_source=app&utm_campaign=slack&utm_content=error"
         class="position-absolute slack-on-error el-button el-button--small is-text is-has-bg"
         target="_blank"
     >

--- a/ui/src/components/admin/stats/EditionComparator.vue
+++ b/ui/src/components/admin/stats/EditionComparator.vue
@@ -61,7 +61,7 @@
                         ],
                         button: {
                             text: "Talk to us",
-                            href: "https://kestra.io/demo?utm_source=app&utm_content=stats"
+                            href: "https://kestra.io/demo?utm_source=app$&utm_campaign=enterprise&utm_content=stats"
                         }
                     },
                     {
@@ -73,7 +73,7 @@
                         ],
                         button: {
                             text: "Sign up for a private Alpha",
-                            href: "https://kestra.io/cloud?utm_source=app&utm_content=stats"
+                            href: "https://kestra.io/cloud?utm_source=app&utm_campaign=cloud&utm_content=stats"
                         }
                     }
                 ]

--- a/ui/src/components/layout/TopNavBar.vue
+++ b/ui/src/components/layout/TopNavBar.vue
@@ -27,7 +27,7 @@
                     <template #dropdown>
                         <el-dropdown-menu>
                             <a
-                                href="https://kestra.io/slack?utm_source=app&utm_content=top-nav-bar"
+                                href="https://kestra.io/slack?utm_source=app&utm_campaign=slack&utm_content=top-nav-bar"
                                 target="_blank"
                                 class="d-flex gap-2 el-dropdown-menu__item"
                             >
@@ -42,7 +42,7 @@
                             </a>
 
                             <a
-                                href="https://kestra.io/docs?utm_source=app&utm_content=top-nav-bar"
+                                href="https://kestra.io/docs?utm_source=app&utm_campaign=docs&utm_content=top-nav-bar"
                                 target="_blank"
                                 class="d-flex gap-2 el-dropdown-menu__item"
                             >
@@ -56,14 +56,14 @@
                                 <Github class="align-middle" /> {{ $t("documentation.github") }}
                             </a>
                             <a
-                                href="https://kestra.io/slack?utm_source=app&utm_content=top-nav-bar"
+                                href="https://kestra.io/slack?utm_source=app&utm_campaign=slack&utm_content=top-nav-bar"
                                 target="_blank"
                                 class="d-flex gap-2 el-dropdown-menu__item"
                             >
                                 <Slack class="align-middle" /> {{ $t("join community") }}
                             </a>
                             <a
-                                href="https://kestra.io/demo?utm_source=app&utm_content=top-nav-bar"
+                                href="https://kestra.io/demo?utm_source=app&utm_campaign=sales&utm_content=top-nav-bar"
                                 target="_blank"
                                 class="d-flex gap-2 el-dropdown-menu__item"
                             >


### PR DESCRIPTION
Current EE tooltips in the app link to:
`https://kestra.io/demo?utm_source=app&utm_content=ee-tooltip&utm_term=iam&utm_content=left-menu` (notice the duplicated `utm_content` ; checked in GA and the latter actually overrides the former)

GA4 by default mainly supports `utm_source`, `utm_medium` & `utm_campaign`. Let's make sure we have `campaign` well populated.

**Environment**

- Kestra Version: 0.19.0 SNAPSHOT (c184aa1)
- Operating System (OS/Docker/Kubernetes): Docker