### PR TITLE
feat(core): add support for dependsOn on input (#3610)

### DIFF
--- a/cli/src/main/java/io/kestra/cli/commands/flows/FlowTestCommand.java
+++ b/cli/src/main/java/io/kestra/cli/commands/flows/FlowTestCommand.java
@@ -98,7 +98,7 @@ public class FlowTestCommand extends AbstractCommand {
 
             runnerUtils.runOne(
                 all.getFirst(),
-                (flow, execution) -> flowInputOutput.typedInputs(flow, execution, inputs),
+                (flow, execution) -> flowInputOutput.readExecutionInputs(flow, execution, inputs),
                 Duration.ofHours(1)
             );
 

--- a/core/src/main/java/io/kestra/core/models/executions/Execution.java
+++ b/core/src/main/java/io/kestra/core/models/executions/Execution.java
@@ -33,6 +33,7 @@ import lombok.extern.slf4j.Slf4j;
 
 import java.time.Instant;
 import java.time.ZonedDateTime;
+import java.time.chrono.ChronoZonedDateTime;
 import java.util.*;
 import java.util.function.BiFunction;
 import java.util.stream.Collectors;
@@ -102,6 +103,17 @@ public class Execution implements DeletedInterface, TenantInterface {
     Instant scheduleDate;
 
     /**
+     * Factory method for constructing a new {@link Execution} object for the given {@link Flow}.
+     *
+     * @param flow   The Flow.
+     * @param labels The Flow labels.
+     * @return a new {@link Execution}.
+     */
+    public static Execution newExecution(final Flow flow, final List<Label> labels) {
+        return newExecution(flow, null, labels, Optional.empty());
+    }
+
+    /**
      * Factory method for constructing a new {@link Execution} object for the given {@link Flow} and inputs.
      *
      * @param flow   The Flow.
@@ -120,22 +132,23 @@ public class Execution implements DeletedInterface, TenantInterface {
             .flowId(flow.getId())
             .flowRevision(flow.getRevision())
             .state(new State())
-            .scheduleDate(scheduleDate.map(date -> date.toInstant()).orElse(null))
+            .scheduleDate(scheduleDate.map(ChronoZonedDateTime::toInstant).orElse(null))
             .build();
-
-        if (inputs != null) {
-            execution = execution.withInputs(inputs.apply(flow, execution));
-        }
 
         List<Label> executionLabels = new ArrayList<>();
         if (flow.getLabels() != null) {
             executionLabels.addAll(flow.getLabels());
         }
+
         if (labels != null) {
             executionLabels.addAll(labels);
         }
         if (!executionLabels.isEmpty()) {
             execution = execution.withLabels(executionLabels);
+        }
+
+        if (inputs != null) {
+            execution = execution.withInputs(inputs.apply(flow, execution));
         }
 
         return execution;

--- a/core/src/main/java/io/kestra/core/models/flows/Data.java
+++ b/core/src/main/java/io/kestra/core/models/flows/Data.java
@@ -4,7 +4,7 @@ import io.kestra.core.models.validations.ManualConstraintViolation;
 import jakarta.validation.ConstraintViolationException;
 
 /**
- * Interface for defining on identifiable and typed data.
+ * Interface for defining an identifiable and typed data.
  */
 public interface Data {
 
@@ -21,7 +21,6 @@ public interface Data {
      * @return a type.
      */
     Type getType();
-
 
     @SuppressWarnings("unchecked")
     default ConstraintViolationException toConstraintViolationException(String message, Object value) {

--- a/core/src/main/java/io/kestra/core/models/flows/DependsOn.java
+++ b/core/src/main/java/io/kestra/core/models/flows/DependsOn.java
@@ -1,0 +1,19 @@
+package io.kestra.core.models.flows;
+
+import jakarta.annotation.Nullable;
+
+import java.util.List;
+
+/**
+ * Defines a dependency between inputs.
+ *
+ * @see io.kestra.core.models.flows.Input
+ *
+ * @param inputs        The inputs
+ * @param condition     The conditional expression.
+ */
+public record DependsOn(
+    @Nullable List<String> inputs,
+    @Nullable String condition
+) {
+}

--- a/core/src/main/java/io/kestra/core/models/flows/Input.java
+++ b/core/src/main/java/io/kestra/core/models/flows/Input.java
@@ -56,6 +56,8 @@ public abstract class Input<T> implements Data {
 
     String description;
 
+    DependsOn dependsOn;
+
     @Builder.Default
     Boolean required = true;
 

--- a/core/src/main/java/io/kestra/core/models/flows/RenderableInput.java
+++ b/core/src/main/java/io/kestra/core/models/flows/RenderableInput.java
@@ -1,0 +1,35 @@
+package io.kestra.core.models.flows;
+
+import jakarta.validation.constraints.NotNull;
+
+import java.util.function.Function;
+
+/**
+ * Represents an {@link Input} having properties that can be rendered.
+ */
+public interface RenderableInput {
+
+    /**
+     * Renders the {@link Input}.
+     *
+     * @param renderer The function to be used for rendering expression.
+     * @return the rendered input.
+     */
+    Input<?> render(@NotNull Function<String, Object> renderer);
+
+    /**
+     * Static helper method that will render an input only if it implements
+     * the {@link RenderableInput} interface.
+     *
+     * @param input    The input.
+     * @param renderer The function to be used for rendering expression.
+     * @return the rendered input.
+     */
+    static Input<?> mayRenderInput(
+        @NotNull final Input<?> input,
+        @NotNull final Function<String, Object> renderer
+    ) {
+        return input instanceof RenderableInput renderableInput ? renderableInput.render(renderer) : input;
+    }
+
+}

--- a/core/src/main/java/io/kestra/core/models/flows/input/FileInput.java
+++ b/core/src/main/java/io/kestra/core/models/flows/input/FileInput.java
@@ -3,23 +3,38 @@ package io.kestra.core.models.flows.input;
 import io.kestra.core.models.flows.Input;
 import io.kestra.core.validations.FileInputValidation;
 import jakarta.validation.ConstraintViolationException;
+import jakarta.validation.constraints.NotNull;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
 
 import java.net.URI;
+import java.util.List;
 
 @SuperBuilder
 @Getter
 @NoArgsConstructor
 @FileInputValidation
 public class FileInput extends Input<URI> {
+
+    private static final String DEFAULT_EXTENSION = ".upl";
+
     @Builder.Default
-    public String extension = ".upl";
+    public String extension = DEFAULT_EXTENSION;
 
     @Override
     public void validate(URI input) throws ConstraintViolationException {
         // no validation yet
+    }
+
+    public static String findFileInputExtension(@NotNull final List<Input<?>> inputs, @NotNull final String fileName) {
+        String res = inputs.stream()
+            .filter(in -> in instanceof FileInput)
+            .filter(in -> in.getId().equals(fileName))
+            .map(flowInput -> ((FileInput) flowInput).getExtension())
+            .findFirst()
+            .orElse(FileInput.DEFAULT_EXTENSION);
+        return res.startsWith(".") ? res : "." + res;
     }
 }

--- a/core/src/main/java/io/kestra/core/models/flows/input/InputAndValue.java
+++ b/core/src/main/java/io/kestra/core/models/flows/input/InputAndValue.java
@@ -1,0 +1,31 @@
+package io.kestra.core.models.flows.input;
+
+import io.kestra.core.models.flows.Input;
+import jakarta.annotation.Nullable;
+import jakarta.validation.ConstraintViolationException;
+import jakarta.validation.constraints.NotNull;
+
+/**
+ * Represents a
+ *
+ * @param input     The flow's {@link Input}.
+ * @param value     The flow's input value/data.
+ * @param enabled   Specify whether the input is enabled.
+ * @param exception The input validation exception.
+ */
+public record InputAndValue(
+    Input<?> input,
+    Object value,
+    boolean enabled,
+    ConstraintViolationException exception) {
+
+    /**
+     * Creates a new {@link InputAndValue} instance.
+     *
+     * @param input The {@link Input}
+     * @param value The value.
+     */
+    public InputAndValue(@NotNull Input<?> input, @Nullable Object value) {
+        this(input, value, true, null);
+    }
+}

--- a/core/src/main/java/io/kestra/core/models/flows/input/MultiselectInput.java
+++ b/core/src/main/java/io/kestra/core/models/flows/input/MultiselectInput.java
@@ -1,6 +1,7 @@
 package io.kestra.core.models.flows.input;
 
 import io.kestra.core.models.flows.Input;
+import io.kestra.core.models.flows.RenderableInput;
 import io.kestra.core.models.flows.Type;
 import io.kestra.core.models.validations.ManualConstraintViolation;
 import io.kestra.core.validations.Regex;
@@ -13,11 +14,12 @@ import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
 
 import java.util.List;
+import java.util.function.Function;
 
 @SuperBuilder
 @Getter
 @NoArgsConstructor
-public class MultiselectInput extends Input<List<String>> implements ItemTypeInterface {
+public class MultiselectInput extends Input<List<String>> implements ItemTypeInterface, RenderableInput {
     @Schema(
         title = "Deprecated, please use `values` instead."
     )
@@ -31,6 +33,11 @@ public class MultiselectInput extends Input<List<String>> implements ItemTypeInt
     // FIXME: REMOVE `options` in 0.20 and bring back the NotNull
     // @NotNull
     List<@Regex String> values;
+
+    @Schema(
+        title = "Expression to be used for dynamically generating the list of values"
+    )
+    String expression;
 
     @Schema(
         title = "Type of the different values available.",
@@ -73,5 +80,25 @@ public class MultiselectInput extends Input<List<String>> implements ItemTypeInt
                 }
             }
         }
+    }
+
+    /** {@inheritDoc} **/
+    @Override
+    public Input<?> render(final Function<String, Object> renderer) {
+        if (expression != null) {
+            return MultiselectInput
+                .builder()
+                .values((List<String>)renderer.apply(expression))
+                .id(getId())
+                .type(getType())
+                .allowInput(getAllowInput())
+                .required(getRequired())
+                .defaults(getDefaults())
+                .description(getDescription())
+                .dependsOn(getDependsOn())
+                .itemType(getItemType())
+                .build();
+        }
+        return this;
     }
 }

--- a/core/src/main/java/io/kestra/core/models/flows/input/SelectInput.java
+++ b/core/src/main/java/io/kestra/core/models/flows/input/SelectInput.java
@@ -1,6 +1,7 @@
 package io.kestra.core.models.flows.input;
 
 import io.kestra.core.models.flows.Input;
+import io.kestra.core.models.flows.RenderableInput;
 import io.kestra.core.models.validations.ManualConstraintViolation;
 import io.kestra.core.validations.Regex;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -12,16 +13,21 @@ import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
 
 import java.util.List;
+import java.util.function.Function;
 
 @SuperBuilder
 @Getter
 @NoArgsConstructor
-public class SelectInput extends Input<String> {
+public class SelectInput extends Input<String> implements RenderableInput {
     @Schema(
         title = "List of values."
     )
-    @NotNull
     List<@Regex String> values;
+
+    @Schema(
+        title = "Expression to be used for dynamically generating the list of values"
+    )
+    String expression;
 
     @Schema(
         title = "If the user can provide a custom value."
@@ -29,7 +35,6 @@ public class SelectInput extends Input<String> {
     @NotNull
     @Builder.Default
     Boolean allowInput = false;
-
 
     @Override
     public void validate(String input) throws ConstraintViolationException {
@@ -45,5 +50,24 @@ public class SelectInput extends Input<String> {
                 input
             );
         }
+    }
+
+    /** {@inheritDoc} **/
+    @Override
+    public Input<?> render(final Function<String, Object> renderer) {
+        if (expression != null) {
+            return SelectInput
+                .builder()
+                .values((List<String>)renderer.apply(expression))
+                .id(getId())
+                .type(getType())
+                .allowInput(getAllowInput())
+                .required(getRequired())
+                .defaults(getDefaults())
+                .description(getDescription())
+                .dependsOn(getDependsOn())
+                .build();
+        }
+        return this;
     }
 }

--- a/core/src/main/java/io/kestra/core/models/triggers/TriggerService.java
+++ b/core/src/main/java/io/kestra/core/models/triggers/TriggerService.java
@@ -91,7 +91,7 @@ public abstract class TriggerService {
         // add inputs and inject defaults
         if (!allInputs.isEmpty()) {
             FlowInputOutput flowInputOutput = ((DefaultRunContext)runContext).getApplicationContext().getBean(FlowInputOutput.class);
-            execution = execution.withInputs(flowInputOutput.typedInputs(conditionContext.getFlow(), execution, allInputs));
+            execution = execution.withInputs(flowInputOutput.readExecutionInputs(conditionContext.getFlow(), execution, allInputs));
         }
 
         return execution;

--- a/core/src/main/java/io/kestra/core/runners/ExecutableUtils.java
+++ b/core/src/main/java/io/kestra/core/runners/ExecutableUtils.java
@@ -95,7 +95,7 @@ public final class ExecutableUtils {
         Execution execution = Execution
             .newExecution(
                 flow,
-                (f, e) -> flowInputOutput.typedInputs(f, e, inputs),
+                (f, e) -> flowInputOutput.readExecutionInputs(f, e, inputs),
                 labels,
                 Optional.empty())
             .withTrigger(ExecutionTrigger.builder()

--- a/core/src/test/java/io/kestra/core/models/flows/input/FileInputTest.java
+++ b/core/src/test/java/io/kestra/core/models/flows/input/FileInputTest.java
@@ -1,0 +1,31 @@
+package io.kestra.core.models.flows.input;
+
+import io.kestra.core.models.flows.Input;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+class FileInputTest {
+
+    @Test
+    void shouldGetExtensionWhenFindingFileExtensionForExistingFile() {
+        List<Input<?>> inputs = List.of(
+            FileInput.builder().id("test-file1").extension(".zip").build(),
+            FileInput.builder().id("test-file2").extension(".gz").build()
+        );
+
+        String result = FileInput.findFileInputExtension(inputs, "test-file1");
+        Assertions.assertEquals(".zip", result);
+    }
+
+    @Test
+    void shouldReturnDefaultExtensionWhenFindingExtensionForUnknownFile() {
+        List<Input<?>> inputs = List.of(
+            FileInput.builder().id("test-file1").extension(".zip").build(),
+            FileInput.builder().id("test-file2").extension(".gz").build()
+        );
+
+        String result = FileInput.findFileInputExtension(inputs, "???");
+        Assertions.assertEquals(".upl", result);
+    }
+}

--- a/core/src/test/java/io/kestra/core/models/flows/input/MultiselectInputTest.java
+++ b/core/src/test/java/io/kestra/core/models/flows/input/MultiselectInputTest.java
@@ -1,0 +1,42 @@
+package io.kestra.core.models.flows.input;
+
+import io.kestra.core.exceptions.IllegalVariableEvaluationException;
+import io.kestra.core.junit.annotations.KestraTest;
+import io.kestra.core.models.flows.Input;
+import io.kestra.core.models.flows.RenderableInput;
+import io.kestra.core.runners.RunContext;
+import io.kestra.core.runners.RunContextFactory;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+@KestraTest
+class MultiselectInputTest {
+
+    @Inject
+    RunContextFactory runContextFactory;
+
+    @Test
+    void shouldRenderInputGivenExpression() {
+        // Given
+        RunContext runContext = runContextFactory.of(Map.of("values", List.of("V1", "V2")));
+        MultiselectInput input = MultiselectInput
+            .builder()
+            .id("id")
+            .expression("{{ values }}")
+            .build();
+        // When
+        Input<?> renderInput = RenderableInput.mayRenderInput(input, s -> {
+            try {
+                return runContext.renderTyped(s);
+            } catch (IllegalVariableEvaluationException e) {
+                throw new RuntimeException(e);
+            }
+        });
+        // Then
+        Assertions.assertEquals(((MultiselectInput)renderInput).getValues(), List.of("V1", "V2"));
+    }
+}

--- a/core/src/test/java/io/kestra/core/models/flows/input/SelectInputTest.java
+++ b/core/src/test/java/io/kestra/core/models/flows/input/SelectInputTest.java
@@ -1,0 +1,42 @@
+package io.kestra.core.models.flows.input;
+
+import io.kestra.core.exceptions.IllegalVariableEvaluationException;
+import io.kestra.core.junit.annotations.KestraTest;
+import io.kestra.core.models.flows.Input;
+import io.kestra.core.models.flows.RenderableInput;
+import io.kestra.core.runners.RunContext;
+import io.kestra.core.runners.RunContextFactory;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+@KestraTest
+class SelectInputTest {
+
+    @Inject
+    RunContextFactory runContextFactory;
+
+    @Test
+    void shouldRenderInputGivenExpression() {
+        // Given
+        RunContext runContext = runContextFactory.of(Map.of("values", List.of("V1", "V2")));
+        SelectInput input = SelectInput
+            .builder()
+            .id("id")
+            .expression("{{ values }}")
+            .build();
+        // When
+        Input<?> renderInput = RenderableInput.mayRenderInput(input, s -> {
+            try {
+                return runContext.renderTyped(s);
+            } catch (IllegalVariableEvaluationException e) {
+                throw new RuntimeException(e);
+            }
+        });
+        // Then
+        Assertions.assertEquals(((SelectInput)renderInput).getValues(), List.of("V1", "V2"));
+    }
+}

--- a/core/src/test/java/io/kestra/core/runners/EmptyVariablesTest.java
+++ b/core/src/test/java/io/kestra/core/runners/EmptyVariablesTest.java
@@ -24,7 +24,7 @@ public class EmptyVariablesTest extends AbstractMemoryRunnerTest {
             "io.kestra.tests",
             "empty-variables",
             null,
-            (flow, exec) -> flowIO.typedInputs(flow, exec, Map.of("emptyKey", "{ \"foo\": \"\" }", "emptySubObject", "{\"json\":{\"someEmptyObject\":{}}}"))
+            (flow, exec) -> flowIO.readExecutionInputs(flow, exec, Map.of("emptyKey", "{ \"foo\": \"\" }", "emptySubObject", "{\"json\":{\"someEmptyObject\":{}}}"))
         );
 
         assertThat(execution, notNullValue());

--- a/core/src/test/java/io/kestra/core/runners/FlowInputOutputTest.java
+++ b/core/src/test/java/io/kestra/core/runners/FlowInputOutputTest.java
@@ -1,0 +1,289 @@
+package io.kestra.core.runners;
+
+import io.kestra.core.junit.annotations.KestraTest;
+import io.kestra.core.models.executions.Execution;
+import io.kestra.core.models.flows.DependsOn;
+import io.kestra.core.models.flows.Input;
+import io.kestra.core.models.flows.input.FileInput;
+import io.kestra.core.models.flows.input.InputAndValue;
+import io.kestra.core.models.flows.input.StringInput;
+import io.kestra.core.storages.StorageInterface;
+import io.kestra.core.utils.IdUtils;
+import io.micronaut.http.MediaType;
+import io.micronaut.http.multipart.CompletedFileUpload;
+import io.micronaut.http.multipart.CompletedPart;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.reactivestreams.Publisher;
+import reactor.core.publisher.Mono;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URI;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+@KestraTest
+class FlowInputOutputTest {
+
+    static final Execution DEFAULT_TEST_EXECUTION = Execution.builder()
+        .id(IdUtils.create())
+        .flowId(IdUtils.create())
+        .flowRevision(1)
+        .namespace("io.kestra.test")
+        .build();
+
+    @Inject
+    FlowInputOutput flowInputOutput;
+
+    @Inject
+    StorageInterface storageInterface;
+
+    @Test
+    void shouldResolveEnabledInputsGivenInputWithConditionalExpressionMatchingTrue() {
+        // Given
+
+        StringInput input1 = StringInput.builder()
+            .id("input1")
+            .build();
+        StringInput input2 = StringInput.builder()
+            .id("input2")
+            .dependsOn(new DependsOn(
+                List.of("input1"),
+                "{{ inputs.input1 equals 'value1' }}"))
+            .build();
+
+        List<Input<?>> inputs = List.of(input1, input2);
+
+        Map<String, Object> data = Map.of("input1", "value1", "input2", "value2");
+
+        // When
+        List<InputAndValue> values = flowInputOutput.resolveInputs(inputs, DEFAULT_TEST_EXECUTION, data);
+
+        // Then
+        Assertions.assertEquals(
+            List.of(
+                new InputAndValue(input1, "value1", true, null),
+                new InputAndValue(input2, "value2", true, null)),
+            values
+        );
+    }
+
+    @Test
+    void shouldResolveEnabledInputsGivenInputWithConditionalInputTrue() {
+        // Given
+
+        StringInput input1 = StringInput.builder()
+            .id("input1")
+            .build();
+        // ENABLED
+        StringInput input2 = StringInput.builder()
+            .id("input2")
+            .dependsOn(new DependsOn(List.of("input1"), "{{ inputs.input1 equals 'v1' }}"))
+            .build();
+        // ENABLED
+        StringInput input3 = StringInput.builder()
+            .id("input3")
+            .dependsOn(new DependsOn(List.of("input2"), null))
+            .build();
+        List<Input<?>> inputs = List.of(input1, input2, input3);
+
+        Map<String, Object> data = Map.of("input1", "v1", "input2", "v2", "input3", "v3");
+
+        // When
+        List<InputAndValue> values = flowInputOutput.resolveInputs(inputs, DEFAULT_TEST_EXECUTION, data);
+
+        // Then
+        Assertions.assertEquals(
+            List.of(
+                new InputAndValue(input1, "v1", true, null),
+                new InputAndValue(input2, "v2", true, null),
+                new InputAndValue(input3, "v3", true, null)),
+            values
+        );
+    }
+
+    @Test
+    void shouldResolveDisabledInputsGivenInputWithConditionalInputFalse() {
+        // Given
+
+        StringInput input1 = StringInput.builder()
+            .id("input1")
+            .build();
+        // DISABLED
+        StringInput input2 = StringInput.builder()
+            .id("input2")
+            .dependsOn(new DependsOn(List.of("input1"), "{{ inputs.input1 equals '???' }}"))
+            .build();
+        // DISABLED
+        StringInput input3 = StringInput.builder()
+            .id("input3")
+            .dependsOn(new DependsOn(List.of("input2"), null))
+            .build();
+        List<Input<?>> inputs = List.of(input1, input2, input3);
+
+        Map<String, Object> data = Map.of("input1", "v1", "input2", "v2", "input3", "v3");
+
+        // When
+        List<InputAndValue> values = flowInputOutput.resolveInputs(inputs, DEFAULT_TEST_EXECUTION, data);
+
+        // Then
+        Assertions.assertEquals(
+            List.of(
+                new InputAndValue(input1, "v1", true, null),
+                new InputAndValue(input2, "v2", false, null),
+                new InputAndValue(input3, "v3", false, null)),
+            values
+        );
+    }
+
+    @Test
+    void shouldResolveDisabledInputsGivenInputWithConditionalExpressionMatchingFalse() {
+        // Given
+        StringInput input1 = StringInput.builder()
+            .id("input1")
+            .build();
+        StringInput input2 = StringInput.builder()
+            .id("input2")
+            .dependsOn(new DependsOn(
+                List.of("input1"),
+                "{{ inputs.input1 equals 'dummy' }}"))
+            .build();
+
+        List<Input<?>> inputs = List.of(input1, input2);
+
+        Map<String, Object> data = Map.of("input1", "value1", "input2", "value2");
+
+        // When
+        List<InputAndValue> values = flowInputOutput.resolveInputs(inputs, DEFAULT_TEST_EXECUTION, data);
+
+        // Then
+        Assertions.assertEquals(
+            List.of(
+                new InputAndValue(input1, "value1", true, null),
+                new InputAndValue(input2, "value2", false, null)),
+            values
+        );
+    }
+
+    @Test
+    void shouldResolveDisabledInputsGivenInputWithErroneousConditionalExpression() {
+        // Given
+        StringInput input1 = StringInput.builder()
+            .id("input1")
+            .build();
+        StringInput input2 = StringInput.builder()
+            .id("input2")
+            .dependsOn(new DependsOn(
+                List.of("input1"),
+                "{{ inputs.dummy equals 'dummy' }}"))
+            .build();
+
+        List<Input<?>> inputs = List.of(input1, input2);
+
+        Map<String, Object> data = Map.of("input1", "value1", "input2", "value2");
+
+        // When
+        List<InputAndValue> values = flowInputOutput.resolveInputs(inputs, DEFAULT_TEST_EXECUTION, data);
+
+        // Then
+        Assertions.assertEquals(2, values.size());
+        Assertions.assertFalse(values.get(1).enabled());
+        Assertions.assertNotNull(values.get(1).exception());
+    }
+
+    @Test
+    void shouldDeleteFileInputAfterValidationGivenDeleteTrue() throws IOException {
+        // Given
+        FileInput input = FileInput.builder()
+            .id("input")
+            .build();
+
+        Publisher<CompletedPart> data = Mono.just(new MemoryCompletedFileUpload("input", "input", "???".getBytes(StandardCharsets.UTF_8)));
+
+        // When
+        List<InputAndValue> values = flowInputOutput.validateExecutionInputs(List.of(input), DEFAULT_TEST_EXECUTION, data, true);
+
+        // Then
+        Assertions.assertFalse(storageInterface.exists(null, URI.create(values.get(0).value().toString())));
+    }
+
+    @Test
+    void shouldNotDeleteFileInputAfterValidationGivenDeleteFalse() throws IOException {
+        // Given
+        FileInput input = FileInput.builder()
+            .id("input")
+            .build();
+
+        Publisher<CompletedPart> data = Mono.just(new MemoryCompletedFileUpload("input", "input", "???".getBytes(StandardCharsets.UTF_8)));
+
+        // When
+        List<InputAndValue> values = flowInputOutput.validateExecutionInputs(List.of(input), DEFAULT_TEST_EXECUTION, data, false);
+
+        // Then
+        Assertions.assertTrue(storageInterface.exists(null, URI.create(values.get(0).value().toString())));
+    }
+
+    private static final class MemoryCompletedFileUpload implements CompletedFileUpload {
+
+        private final String name;
+        private final String fileName;
+        private final byte[] content;
+
+        public MemoryCompletedFileUpload(String name, String fileName, byte[] content) {
+            this.name = name;
+            this.fileName = fileName;
+            this.content = content;
+        }
+
+        @Override
+        public InputStream getInputStream() {
+            return new ByteArrayInputStream(content);
+        }
+
+        @Override
+        public byte[] getBytes() {
+            return content;
+        }
+
+        @Override
+        public ByteBuffer getByteBuffer() {
+            return ByteBuffer.wrap(content);
+        }
+
+        @Override
+        public Optional<MediaType> getContentType() {
+            return Optional.empty();
+        }
+
+        @Override
+        public String getName() {
+            return name;
+        }
+
+        @Override
+        public String getFilename() {
+            return fileName;
+        }
+
+        @Override
+        public long getSize() {
+            return content.length;
+        }
+
+        @Override
+        public long getDefinedSize() {
+            return content.length;
+        }
+
+        @Override
+        public boolean isComplete() {
+            return true;
+        }
+    }
+}

--- a/core/src/test/java/io/kestra/core/runners/InputsTest.java
+++ b/core/src/test/java/io/kestra/core/runners/InputsTest.java
@@ -9,6 +9,7 @@ import io.kestra.core.queues.QueueException;
 import io.kestra.core.repositories.FlowRepositoryInterface;
 import io.kestra.core.storages.StorageInterface;
 import jakarta.inject.Inject;
+import org.jcodings.util.Hash;
 import org.junit.jupiter.api.Test;
 
 import jakarta.validation.ConstraintViolationException;
@@ -78,7 +79,7 @@ public class InputsTest extends AbstractMemoryRunnerTest {
     }
 
     private Map<String, Object> typedInputs(Map<String, Object> map, Flow flow) {
-        return flowIO.typedInputs(
+        return flowIO.readExecutionInputs(
             flow,
             Execution.builder()
                 .id("test")
@@ -92,8 +93,9 @@ public class InputsTest extends AbstractMemoryRunnerTest {
 
     @Test
     void missingRequired() {
-        ConstraintViolationException e = assertThrows(ConstraintViolationException.class, () -> typedInputs(new HashMap<>()));
-
+        HashMap<String, Object> inputs = new HashMap<>(InputsTest.inputs);
+        inputs.put("string", null);
+        ConstraintViolationException e = assertThrows(ConstraintViolationException.class, () -> typedInputs(inputs));
         assertThat(e.getMessage(), containsString("Invalid input for `string`, missing required input, but received `null`"));
     }
 
@@ -167,7 +169,7 @@ public class InputsTest extends AbstractMemoryRunnerTest {
             "io.kestra.tests",
             "inputs",
             null,
-            (flow, execution1) -> flowIO.typedInputs(flow, execution1, inputs)
+            (flow, execution1) -> flowIO.readExecutionInputs(flow, execution1, inputs)
         );
 
         assertThat(execution.getTaskRunList(), hasSize(14));
@@ -339,7 +341,7 @@ public class InputsTest extends AbstractMemoryRunnerTest {
             "io.kestra.tests",
             "inputs",
             null,
-            (flow, execution1) -> flowIO.typedInputs(flow, execution1, map)
+            (flow, execution1) -> flowIO.readExecutionInputs(flow, execution1, map)
         );
 
         assertThat(execution.getTaskRunList(), hasSize(14));

--- a/core/src/test/java/io/kestra/core/runners/NoEncryptionConfiguredTest.java
+++ b/core/src/test/java/io/kestra/core/runners/NoEncryptionConfiguredTest.java
@@ -71,6 +71,6 @@ public class NoEncryptionConfiguredTest extends AbstractMemoryRunnerTest impleme
             .flowId(flow.getId())
             .build();
 
-        assertThrows(ConstraintViolationException.class, () -> flowIO.typedInputs(flow, execution, InputsTest.inputs));
+        assertThrows(ConstraintViolationException.class, () -> flowIO.readExecutionInputs(flow, execution, InputsTest.inputs));
     }
 }

--- a/core/src/test/java/io/kestra/core/runners/RunContextTest.java
+++ b/core/src/test/java/io/kestra/core/runners/RunContextTest.java
@@ -139,7 +139,7 @@ class RunContextTest extends AbstractMemoryRunnerTest {
             "io.kestra.tests",
             "inputs-large",
             null,
-            (flow, execution1) -> flowIO.typedInputs(flow, execution1, inputs)
+            (flow, execution1) -> flowIO.readExecutionInputs(flow, execution1, inputs)
         );
 
         assertThat(execution.getTaskRunList(), hasSize(10));

--- a/core/src/test/java/io/kestra/core/runners/TaskWithAllowFailureTest.java
+++ b/core/src/test/java/io/kestra/core/runners/TaskWithAllowFailureTest.java
@@ -17,7 +17,6 @@ import java.nio.file.Files;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeoutException;
-import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -52,7 +51,7 @@ public class TaskWithAllowFailureTest extends AbstractMemoryRunnerTest {
     void executableTask_ForEachItem() throws TimeoutException, QueueException, URISyntaxException, IOException {
         URI file = storageUpload();
         Map<String, Object> inputs = Map.of("file", file.toString());
-        Execution execution = runnerUtils.runOne(null, "io.kestra.tests", "task-allow-failure-executable-foreachitem", null, (flow, execution1) -> flowIO.typedInputs(flow, execution1, inputs));
+        Execution execution = runnerUtils.runOne(null, "io.kestra.tests", "task-allow-failure-executable-foreachitem", null, (flow, execution1) -> flowIO.readExecutionInputs(flow, execution1, inputs));
 
         assertThat(execution.getState().getCurrent(), is(State.Type.WARNING));
         assertThat(execution.getTaskRunList(), hasSize(4));

--- a/core/src/test/java/io/kestra/core/utils/MapUtilsTest.java
+++ b/core/src/test/java/io/kestra/core/utils/MapUtilsTest.java
@@ -103,4 +103,26 @@ class MapUtilsTest {
         assertThat(map, notNullValue());
         assertThat(map.size(), is(1));
     }
+
+    @Test
+    void shouldReturnMapWhenNestingMapGivenFlattenMap() {
+        Map<String, Object> results = MapUtils.flattenToNestedMap(Map.of(
+            "k1.k2.k3", "v1",
+            "k1.k2.k4", "v2"
+        ));
+        Assertions.assertEquals(
+            Map.of("k1", Map.of("k2", Map.of("k3", "v1", "k4", "v2"))),
+            results
+        );
+    }
+
+    @Test
+    void shouldThrowExceptionWhenNestingMapGivenFlattenMapWithConflicts() {
+        Assertions.assertThrows(IllegalArgumentException.class, () -> {
+            MapUtils.flattenToNestedMap(Map.of(
+                "k1.k2", "v1",
+                "k1.k2.k3", "v2"
+            ));
+        });
+    }
 }

--- a/core/src/test/java/io/kestra/plugin/core/flow/AllowFailureTest.java
+++ b/core/src/test/java/io/kestra/plugin/core/flow/AllowFailureTest.java
@@ -38,7 +38,7 @@ class AllowFailureTest extends AbstractMemoryRunnerTest {
             "io.kestra.tests",
             "allow-failure",
             null,
-            (f, e) -> flowIO.typedInputs(f, e, ImmutableMap.of("crash", "1"))
+            (f, e) -> flowIO.readExecutionInputs(f, e, ImmutableMap.of("crash", "1"))
         );
 
         assertThat(execution.getTaskRunList(), hasSize(10));

--- a/core/src/test/java/io/kestra/plugin/core/flow/ForEachItemCaseTest.java
+++ b/core/src/test/java/io/kestra/plugin/core/flow/ForEachItemCaseTest.java
@@ -76,7 +76,7 @@ public class ForEachItemCaseTest {
         URI file = storageUpload();
         Map<String, Object> inputs = Map.of("file", file.toString());
         Execution execution = runnerUtils.runOne(null, TEST_NAMESPACE, "for-each-item", null,
-            (flow, execution1) -> flowIO.typedInputs(flow, execution1, inputs),
+            (flow, execution1) -> flowIO.readExecutionInputs(flow, execution1, inputs),
             Duration.ofSeconds(30));
 
         // we should have triggered 26 subflows
@@ -107,7 +107,7 @@ public class ForEachItemCaseTest {
         URI file = emptyItems();
         Map<String, Object> inputs = Map.of("file", file.toString());
         Execution execution = runnerUtils.runOne(null, TEST_NAMESPACE, "for-each-item", null,
-            (flow, execution1) -> flowIO.typedInputs(flow, execution1, inputs),
+            (flow, execution1) -> flowIO.readExecutionInputs(flow, execution1, inputs),
             Duration.ofSeconds(30));
 
         // assert on the main flow execution
@@ -136,7 +136,7 @@ public class ForEachItemCaseTest {
         URI file = storageUpload();
         Map<String, Object> inputs = Map.of("file", file.toString());
         Execution execution = runnerUtils.runOne(null, TEST_NAMESPACE, "for-each-item-no-wait", null,
-            (flow, execution1) -> flowIO.typedInputs(flow, execution1, inputs),
+            (flow, execution1) -> flowIO.readExecutionInputs(flow, execution1, inputs),
             Duration.ofSeconds(30));
 
         // assert that not all subflows ran (depending on the speed of execution, there can be some)
@@ -183,7 +183,7 @@ public class ForEachItemCaseTest {
         URI file = storageUpload();
         Map<String, Object> inputs = Map.of("file", file.toString());
         Execution execution = runnerUtils.runOne(null, TEST_NAMESPACE, "for-each-item-failed", null,
-            (flow, execution1) -> flowIO.typedInputs(flow, execution1, inputs),
+            (flow, execution1) -> flowIO.readExecutionInputs(flow, execution1, inputs),
             Duration.ofSeconds(30));
 
         // we should have triggered 26 subflows
@@ -226,7 +226,7 @@ public class ForEachItemCaseTest {
         URI file = storageUpload();
         Map<String, Object> inputs = Map.of("file", file.toString());
         Execution execution = runnerUtils.runOne(null, TEST_NAMESPACE, "for-each-item-outputs", null,
-            (flow, execution1) -> flowIO.typedInputs(flow, execution1, inputs),
+            (flow, execution1) -> flowIO.readExecutionInputs(flow, execution1, inputs),
             Duration.ofSeconds(30));
 
         // we should have triggered 26 subflows

--- a/core/src/test/java/io/kestra/plugin/core/flow/TemplateTest.java
+++ b/core/src/test/java/io/kestra/plugin/core/flow/TemplateTest.java
@@ -71,7 +71,7 @@ public class TemplateTest extends AbstractMemoryRunnerTest {
             "io.kestra.tests",
             "with-template",
             null,
-            (flow, execution1) -> flowIO.typedInputs(flow, execution1, ImmutableMap.of(
+            (flow, execution1) -> flowIO.readExecutionInputs(flow, execution1, ImmutableMap.of(
                 "with-string", "myString",
                 "with-optional", "myOpt"
             )),

--- a/core/src/test/java/io/kestra/plugin/core/trigger/ScheduleTest.java
+++ b/core/src/test/java/io/kestra/plugin/core/trigger/ScheduleTest.java
@@ -334,6 +334,8 @@ class ScheduleTest {
             conditionContext(trigger),
             TriggerContext.builder()
                 .date(date)
+                .namespace("io.kestra.tests")
+                .flowId(IdUtils.create())
                 .build()
         );
 

--- a/jdbc/src/test/java/io/kestra/jdbc/runner/JdbcRunnerTest.java
+++ b/jdbc/src/test/java/io/kestra/jdbc/runner/JdbcRunnerTest.java
@@ -391,7 +391,7 @@ public abstract class JdbcRunnerTest {
             "io.kestra.tests",
             "inputs-large",
             null,
-            (flow, execution1) -> flowIO.typedInputs(flow, execution1, inputs),
+            (flow, execution1) -> flowIO.readExecutionInputs(flow, execution1, inputs),
             Duration.ofSeconds(120)
         );
 
@@ -415,7 +415,7 @@ public abstract class JdbcRunnerTest {
             "io.kestra.tests",
             "inputs-large",
             null,
-            (flow, execution1) -> flowIO.typedInputs(flow, execution1, inputs),
+            (flow, execution1) -> flowIO.readExecutionInputs(flow, execution1, inputs),
             Duration.ofSeconds(60)
         ));
 

--- a/ui/src/components/executions/Resume.vue
+++ b/ui/src/components/executions/Resume.vue
@@ -14,7 +14,7 @@
             <span v-html="$t('resumed title', {id: execution.id})" />
         </template>
         <el-form :model="inputs" label-position="top" ref="form" @submit.prevent="false">
-            <inputs-form :inputs-list="inputsList" v-model="inputs" />
+            <inputs-form :initial-inputs="inputsList" :execution="execution" v-model="inputs" />
         </el-form>
         <template #footer>
             <el-button :icon="PlayBox" type="primary" @click="resumeWithInputs($refs.form)" native-type="submit">
@@ -65,7 +65,6 @@
             click() {
                 if (this.needInputs) {
                     this.isDrawerOpen = true;
-
                     return;
                 }
 

--- a/ui/src/components/flows/FlowRun.vue
+++ b/ui/src/components/flows/FlowRun.vue
@@ -6,7 +6,7 @@
         </el-alert>
 
         <el-form label-position="top" :model="inputs" ref="form" @submit.prevent="false">
-            <inputs-form :inputs-list="flow.inputs" v-model="inputs" />
+            <inputs-form :initial-inputs="flow.inputs" :flow="flow" v-model="inputs" />
 
             <el-collapse class="mt-4" v-model="collapseName">
                 <el-collapse-item :title="$t('advanced configuration')" name="advanced">
@@ -140,7 +140,7 @@
                     .filter(input => nonEmptyInputNames.includes(input.id))
                     .forEach(input => {
                         let value = this.execution.inputs[input.id];
-                        this.inputs[input.id] =  Inputs.normalize(input.type, value);
+                        this.inputs[input.id] = Inputs.normalize(input.type, value);
                     });
             },
             purgeInputs(inputs){

--- a/ui/src/stores/executions.js
+++ b/ui/src/stores/executions.js
@@ -135,7 +135,14 @@ export default {
                 }
             });
         },
-
+        validateResume(_, options) {
+            return this.$http.post(`${apiUrl(this)}/executions/${options.id}/resume/validate`, options.formData, {
+                timeout: 60 * 60 * 1000,
+                headers: {
+                    "content-type": "multipart/form-data"
+                }
+            });
+        },
         loadExecution({commit}, options) {
             return this.$http.get(`${apiUrl(this)}/executions/${options.id}`).then(response => {
                 commit("setExecution", response.data)
@@ -151,6 +158,18 @@ export default {
                 }
 
                 return response.data
+            })
+        },
+        validateExecution(_, options) {
+            return this.$http.post(`${apiUrl(this)}/executions/${options.namespace}/${options.id}/validate`, options.formData, {
+                timeout: 60 * 60 * 1000,
+                headers: {
+                    "content-type": "multipart/form-data"
+                },
+                params: {
+                    labels: options.labels ?? [],
+                    scheduleDate: options.scheduleDate
+                }
             })
         },
         triggerExecution(_, options) {

--- a/ui/src/utils/submitTask.js
+++ b/ui/src/utils/submitTask.js
@@ -9,7 +9,6 @@ const cleanInputs = (inputsList, values) => {
     return inputs;
 }
 
-
 export const inputsToFormDate = (submitor, inputsList, values) => {
     values = cleanInputs(inputsList, values);
 

--- a/webserver/src/test/java/io/kestra/webserver/controllers/api/PluginControllerTest.java
+++ b/webserver/src/test/java/io/kestra/webserver/controllers/api/PluginControllerTest.java
@@ -229,7 +229,7 @@ class PluginControllerTest {
 
             assertThat(doc.getSchema().getProperties().size(), is(3));
             Map<String, Object> properties = (Map<String, Object>) doc.getSchema().getProperties().get("properties");
-            assertThat(properties.size(), is(6));
+            assertThat(properties.size(), is(7));
 //            assertThat(((Map<String, Object>) properties.get("name")).get("$deprecated"), is(true));
         });
     }


### PR DESCRIPTION
This commits adds:
- support for dependsOn field in flow's inputs
- support for expression on input of type SELECT, MULTISELECT
- new REST API to validate inputs for an execution
- some code cleanup, and method renaming

Fix: #3610