### PR TITLE
fix(webserver): enforce pagination

### DIFF
--- a/webserver/src/main/java/io/kestra/webserver/controllers/api/BlueprintController.java
+++ b/webserver/src/main/java/io/kestra/webserver/controllers/api/BlueprintController.java
@@ -18,6 +18,7 @@ import io.micronaut.validation.Validated;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import jakarta.inject.Inject;
+import jakarta.validation.constraints.Min;
 import lombok.*;
 import lombok.experimental.FieldDefaults;
 import lombok.experimental.SuperBuilder;
@@ -44,8 +45,8 @@ public class BlueprintController {
         @Parameter(description = "A string filter") @Nullable @QueryValue(value = "q") Optional<String> q,
         @Parameter(description = "The sort of current page") @Nullable @QueryValue(value = "sort") Optional<String> sort,
         @Parameter(description = "A tags filter") @Nullable @QueryValue(value = "tags") Optional<List<String>> tags,
-        @Parameter(description = "The current page") @QueryValue(defaultValue = "1") Integer page,
-        @Parameter(description = "The current page size") @QueryValue(defaultValue = "1") Integer size,
+        @Parameter(description = "The current page") @QueryValue(defaultValue = "1") @Min(1) Integer page,
+        @Parameter(description = "The current page size") @QueryValue(defaultValue = "1") @Min(1) Integer size,
         HttpRequest<?> httpRequest
     ) throws URISyntaxException {
         return fastForwardToKestraApi(httpRequest, "/v1/blueprints", Map.of("ee", false), Argument.of(PagedResults.class, BlueprintItem.class));

--- a/webserver/src/main/java/io/kestra/webserver/controllers/api/ExecutionController.java
+++ b/webserver/src/main/java/io/kestra/webserver/controllers/api/ExecutionController.java
@@ -7,12 +7,7 @@ import io.kestra.core.exceptions.IllegalVariableEvaluationException;
 import io.kestra.core.exceptions.InternalException;
 import io.kestra.core.models.Label;
 import io.kestra.core.models.executions.*;
-import io.kestra.core.models.flows.Flow;
-import io.kestra.core.models.flows.FlowForExecution;
-import io.kestra.core.models.flows.FlowScope;
-import io.kestra.core.models.flows.FlowWithException;
-import io.kestra.core.models.flows.Input;
-import io.kestra.core.models.flows.State;
+import io.kestra.core.models.flows.*;
 import io.kestra.core.models.flows.input.InputAndValue;
 import io.kestra.core.models.hierarchies.FlowGraph;
 import io.kestra.core.models.storage.FileMetas;
@@ -49,20 +44,8 @@ import io.micronaut.core.annotation.Introspected;
 import io.micronaut.core.annotation.Nullable;
 import io.micronaut.core.async.annotation.SingleResult;
 import io.micronaut.core.convert.format.Format;
-import io.micronaut.data.model.Pageable;
-import io.micronaut.http.HttpRequest;
-import io.micronaut.http.HttpResponse;
-import io.micronaut.http.HttpStatus;
-import io.micronaut.http.MediaType;
-import io.micronaut.http.MutableHttpResponse;
-import io.micronaut.http.annotation.Body;
-import io.micronaut.http.annotation.Controller;
-import io.micronaut.http.annotation.Delete;
-import io.micronaut.http.annotation.Get;
-import io.micronaut.http.annotation.PathVariable;
-import io.micronaut.http.annotation.Post;
-import io.micronaut.http.annotation.Put;
-import io.micronaut.http.annotation.QueryValue;
+import io.micronaut.http.*;
+import io.micronaut.http.annotation.*;
 import io.micronaut.http.exceptions.HttpStatusException;
 import io.micronaut.http.server.multipart.MultipartBody;
 import io.micronaut.http.server.types.files.StreamedFile;
@@ -79,6 +62,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import jakarta.inject.Inject;
 import jakarta.inject.Named;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
@@ -101,22 +85,13 @@ import java.nio.charset.UnsupportedCharsetException;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.ZonedDateTime;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.NoSuchElementException;
-import java.util.Optional;
-import java.util.Set;
+import java.util.*;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 
 import static io.kestra.core.utils.DateUtils.validateTimeline;
-import static io.kestra.core.utils.Rethrow.throwBiFunction;
-import static io.kestra.core.utils.Rethrow.throwConsumer;
-import static io.kestra.core.utils.Rethrow.throwFunction;
+import static io.kestra.core.utils.Rethrow.*;
 
 @Slf4j
 @Validated
@@ -180,8 +155,8 @@ public class ExecutionController {
     @Get(uri = "/search")
     @Operation(tags = {"Executions"}, summary = "Search for executions")
     public PagedResults<Execution> find(
-        @Parameter(description = "The current page") @QueryValue(defaultValue = "1") int page,
-        @Parameter(description = "The current page size") @QueryValue(defaultValue = "10") int size,
+        @Parameter(description = "The current page") @QueryValue(defaultValue = "1") @Min(1) int page,
+        @Parameter(description = "The current page size") @QueryValue(defaultValue = "10") @Min(1) int size,
         @Parameter(description = "The sort of current page") @Nullable @QueryValue List<String> sort,
         @Parameter(description = "A string filter") @Nullable @QueryValue(value = "q") String query,
         @Parameter(description = "The scope of the executions to include") @Nullable @QueryValue(value = "scope") List<FlowScope> scope,
@@ -432,12 +407,12 @@ public class ExecutionController {
     public PagedResults<Execution> findByFlowId(
         @Parameter(description = "The flow namespace") @QueryValue String namespace,
         @Parameter(description = "The flow id") @QueryValue String flowId,
-        @Parameter(description = "The current page") @QueryValue(defaultValue = "1") int page,
-        @Parameter(description = "The current page size") @QueryValue(defaultValue = "10") int size
+        @Parameter(description = "The current page") @QueryValue(defaultValue = "1") @Min(1) int page,
+        @Parameter(description = "The current page size") @QueryValue(defaultValue = "10") @Min(1) int size
     ) {
         return PagedResults.of(
             executionRepository
-                .findByFlowId(tenantService.resolveTenant(), namespace, flowId, Pageable.from(page, size))
+                .findByFlowId(tenantService.resolveTenant(), namespace, flowId, PageableUtils.from(page, size))
         );
     }
 

--- a/webserver/src/main/java/io/kestra/webserver/controllers/api/FlowController.java
+++ b/webserver/src/main/java/io/kestra/webserver/controllers/api/FlowController.java
@@ -45,6 +45,7 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import jakarta.inject.Inject;
+import jakarta.validation.constraints.Min;
 import lombok.extern.slf4j.Slf4j;
 
 import jakarta.validation.ConstraintViolationException;
@@ -200,8 +201,8 @@ public class FlowController {
     @Get(uri = "/search")
     @Operation(tags = {"Flows"}, summary = "Search for flows")
     public PagedResults<Flow> find(
-        @Parameter(description = "The current page") @QueryValue(defaultValue = "1") int page,
-        @Parameter(description = "The current page size") @QueryValue(defaultValue = "10") int size,
+        @Parameter(description = "The current page") @QueryValue(defaultValue = "1") @Min(1) int page,
+        @Parameter(description = "The current page size") @QueryValue(defaultValue = "10") @Min(1) int size,
         @Parameter(description = "The sort of current page") @Nullable @QueryValue List<String> sort,
         @Parameter(description = "A string filter") @Nullable @QueryValue(value = "q") String query,
         @Parameter(description = "The scope of the flows to include") @Nullable @QueryValue List<FlowScope> scope,
@@ -232,8 +233,8 @@ public class FlowController {
     @Get(uri = "/source")
     @Operation(tags = {"Flows"}, summary = "Search for flows source code")
     public PagedResults<SearchResult<Flow>> source(
-        @Parameter(description = "The current page") @QueryValue(defaultValue = "1") int page,
-        @Parameter(description = "The current page size") @QueryValue(defaultValue = "10") int size,
+        @Parameter(description = "The current page") @QueryValue(defaultValue = "1") @Min(1) int page,
+        @Parameter(description = "The current page size") @QueryValue(defaultValue = "10") @Min(1) int size,
         @Parameter(description = "The sort of current page") @Nullable @QueryValue List<String> sort,
         @Parameter(description = "A string filter") @Nullable @QueryValue(value = "q") String query,
         @Parameter(description = "A namespace filter prefix") @Nullable @QueryValue String namespace

--- a/webserver/src/main/java/io/kestra/webserver/controllers/api/LogController.java
+++ b/webserver/src/main/java/io/kestra/webserver/controllers/api/LogController.java
@@ -21,6 +21,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import jakarta.inject.Inject;
 import jakarta.inject.Named;
+import jakarta.validation.constraints.Min;
 import org.slf4j.event.Level;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.FluxSink;
@@ -53,8 +54,8 @@ public class LogController {
     @Operation(tags = {"Logs"}, summary = "Search for logs")
     public PagedResults<LogEntry> find(
         @Parameter(description = "A string filter") @Nullable @QueryValue(value = "q") String query,
-        @Parameter(description = "The current page") @QueryValue(defaultValue = "1") int page,
-        @Parameter(description = "The current page size") @QueryValue(defaultValue = "10") int size,
+        @Parameter(description = "The current page") @QueryValue(defaultValue = "1") @Min(1) int page,
+        @Parameter(description = "The current page size") @QueryValue(defaultValue = "10") @Min(1) int size,
         @Parameter(description = "The sort of current page") @Nullable @QueryValue List<String> sort,
         @Parameter(description = "A namespace filter prefix") @Nullable @QueryValue String namespace,
         @Parameter(description = "A flow id filter") @Nullable @QueryValue String flowId,

--- a/webserver/src/main/java/io/kestra/webserver/controllers/api/MetricController.java
+++ b/webserver/src/main/java/io/kestra/webserver/controllers/api/MetricController.java
@@ -22,6 +22,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import jakarta.inject.Inject;
 import jakarta.inject.Named;
+import jakarta.validation.constraints.Min;
 
 import java.time.ZonedDateTime;
 import java.util.List;
@@ -46,8 +47,8 @@ public class MetricController {
     @Get(uri = "/{executionId}")
     @Operation(tags = {"Metrics"}, summary = "Get metrics for a specific execution")
     public PagedResults<MetricEntry> findByExecution(
-        @Parameter(description = "The current page") @QueryValue(defaultValue = "1") int page,
-        @Parameter(description = "The current page size") @QueryValue(defaultValue = "10") int size,
+        @Parameter(description = "The current page") @QueryValue(defaultValue = "1") @Min(1) int page,
+        @Parameter(description = "The current page size") @QueryValue(defaultValue = "10") @Min(1) int size,
         @Parameter(description = "The sort of current page") @Nullable @QueryValue List<String> sort,
         @Parameter(description = "The execution id") @PathVariable String executionId,
         @Parameter(description = "The taskrun id") @Nullable @QueryValue String taskRunId,

--- a/webserver/src/main/java/io/kestra/webserver/controllers/api/NamespaceController.java
+++ b/webserver/src/main/java/io/kestra/webserver/controllers/api/NamespaceController.java
@@ -21,6 +21,7 @@ import io.micronaut.validation.Validated;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import jakarta.inject.Inject;
+import jakarta.validation.constraints.Min;
 
 import java.util.*;
 import java.util.stream.Collectors;
@@ -51,8 +52,8 @@ public class NamespaceController implements NamespaceControllerInterface<Namespa
     @Operation(tags = {"Namespaces"}, summary = "Search for namespaces")
     public PagedResults<NamespaceWithDisabled> find(
         @Parameter(description = "A string filter") @Nullable @QueryValue(value = "q") String query,
-        @Parameter(description = "The current page") @QueryValue(defaultValue = "1") int page,
-        @Parameter(description = "The current page size") @QueryValue(defaultValue = "10") int size,
+        @Parameter(description = "The current page") @QueryValue(defaultValue = "1") @Min(1) int page,
+        @Parameter(description = "The current page size") @QueryValue(defaultValue = "10") @Min(1) int size,
         @Parameter(description = "The sort of current page") @Nullable @QueryValue List<String> sort,
         @Parameter(description = "Return only existing namespace") @Nullable @QueryValue(value = "existing", defaultValue = "false") Boolean existingOnly
     ) throws HttpStatusException {

--- a/webserver/src/main/java/io/kestra/webserver/controllers/api/NamespaceControllerInterface.java
+++ b/webserver/src/main/java/io/kestra/webserver/controllers/api/NamespaceControllerInterface.java
@@ -5,13 +5,14 @@ import io.kestra.core.models.topologies.FlowTopologyGraph;
 import io.kestra.webserver.models.namespaces.DisabledInterface;
 import io.kestra.webserver.responses.PagedResults;
 import io.micronaut.http.exceptions.HttpStatusException;
+import jakarta.validation.constraints.Min;
 
 import java.util.List;
 
 public interface NamespaceControllerInterface<N extends NamespaceInterface, D extends NamespaceInterface & DisabledInterface> {
     N index(String id);
 
-    PagedResults<D> find(String query, int page, int size, List<String> sort, Boolean existingOnly) throws HttpStatusException;
+    PagedResults<D> find(String query, @Min(1) int page, @Min(1) int size, List<String> sort, Boolean existingOnly) throws HttpStatusException;
 
     FlowTopologyGraph dependencies(String namespace, boolean destinationOnly);
 }

--- a/webserver/src/main/java/io/kestra/webserver/controllers/api/TaskRunController.java
+++ b/webserver/src/main/java/io/kestra/webserver/controllers/api/TaskRunController.java
@@ -19,6 +19,7 @@ import io.swagger.v3.oas.annotations.Hidden;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import jakarta.inject.Inject;
+import jakarta.validation.constraints.Min;
 
 import java.time.ZonedDateTime;
 import java.util.List;
@@ -38,8 +39,8 @@ public class TaskRunController {
     @Get(uri = "/search")
     @Operation(tags = {"Executions"}, summary = "Search for taskruns")
     public PagedResults<TaskRun> findTaskRun(
-        @Parameter(description = "The current page") @QueryValue(defaultValue = "1") int page,
-        @Parameter(description = "The current page size") @QueryValue(defaultValue = "10") int size,
+        @Parameter(description = "The current page") @QueryValue(defaultValue = "1") @Min(1) int page,
+        @Parameter(description = "The current page size") @QueryValue(defaultValue = "10") @Min(1) int size,
         @Parameter(description = "The sort of current page") @Nullable @QueryValue List<String> sort,
         @Parameter(description = "A string filter") @Nullable @QueryValue(value = "q") String query,
         @Parameter(description = "A namespace filter prefix") @Nullable @QueryValue String namespace,

--- a/webserver/src/main/java/io/kestra/webserver/controllers/api/TemplateController.java
+++ b/webserver/src/main/java/io/kestra/webserver/controllers/api/TemplateController.java
@@ -29,6 +29,8 @@ import jakarta.inject.Inject;
 
 import jakarta.validation.ConstraintViolationException;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Min;
+
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.util.*;
@@ -68,8 +70,8 @@ public class TemplateController {
     @Get(uri = "/search")
     @Operation(tags = {"Templates"}, summary = "Search for templates")
     public PagedResults<Template> find(
-        @Parameter(description = "The current page") @QueryValue(defaultValue = "1") int page,
-        @Parameter(description = "The current page size") @QueryValue(defaultValue = "10") int size,
+        @Parameter(description = "The current page") @QueryValue(defaultValue = "1") @Min(1) int page,
+        @Parameter(description = "The current page size") @QueryValue(defaultValue = "10") @Min(1) int size,
         @Parameter(description = "The sort of current page") @Nullable @QueryValue List<String> sort,
         @Parameter(description = "A string filter") @Nullable @QueryValue(value = "q") String query,
         @Parameter(description = "A namespace filter prefix") @Nullable @QueryValue String namespace

--- a/webserver/src/main/java/io/kestra/webserver/controllers/api/TriggerController.java
+++ b/webserver/src/main/java/io/kestra/webserver/controllers/api/TriggerController.java
@@ -28,6 +28,7 @@ import io.micronaut.scheduling.annotation.ExecuteOn;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import jakarta.inject.Inject;
+import jakarta.validation.constraints.Min;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
@@ -69,8 +70,8 @@ public class TriggerController {
     @Get(uri = "/search")
     @Operation(tags = {"Triggers"}, summary = "Search for triggers")
     public PagedResults<Triggers> search(
-        @Parameter(description = "The current page") @QueryValue(defaultValue = "1") int page,
-        @Parameter(description = "The current page size") @QueryValue(defaultValue = "10") int size,
+        @Parameter(description = "The current page") @QueryValue(defaultValue = "1") @Min(1) int page,
+        @Parameter(description = "The current page size") @QueryValue(defaultValue = "10") @Min(1) int size,
         @Parameter(description = "The sort of current page") @Nullable @QueryValue List<String> sort,
         @Parameter(description = "A string filter") @Nullable @QueryValue(value = "q") String query,
         @Parameter(description = "A namespace filter prefix") @Nullable @QueryValue String namespace,
@@ -212,8 +213,8 @@ public class TriggerController {
     @Get(uri = "/{namespace}/{flowId}")
     @Operation(tags = {"Triggers"}, summary = "Get all triggers for a flow")
     public PagedResults<Trigger> find(
-        @Parameter(description = "The current page") @QueryValue(defaultValue = "1") int page,
-        @Parameter(description = "The current page size") @QueryValue(defaultValue = "10") int size,
+        @Parameter(description = "The current page") @QueryValue(defaultValue = "1") @Min(1) int page,
+        @Parameter(description = "The current page size") @QueryValue(defaultValue = "10") @Min(1) int size,
         @Parameter(description = "The sort of current page") @Nullable @QueryValue List<String> sort,
         @Parameter(description = "A string filter") @Nullable @QueryValue(value = "q") String query,
         @Parameter(description = "A namespace filter prefix") @Nullable @QueryValue String namespace,

--- a/webserver/src/main/java/io/kestra/webserver/utils/PageableUtils.java
+++ b/webserver/src/main/java/io/kestra/webserver/utils/PageableUtils.java
@@ -7,23 +7,31 @@ import io.micronaut.http.exceptions.HttpStatusException;
 
 import java.util.List;
 import java.util.function.Function;
-import java.util.stream.Collectors;
 
 public class PageableUtils {
+    private PageableUtils() {
+    }
+
     public static Pageable from(int page, int size, List<String> sort, Function<String, String> sortMapper) throws HttpStatusException {
-        return Pageable.from(
+        final Pageable pageable = Pageable.from(
             page,
             size,
             sort(sort, sortMapper)
         );
+
+        if (pageable.isUnpaged()) {
+            throw new IllegalArgumentException("Unpaged data are not supported");
+        }
+
+        return pageable;
     }
 
     public static Pageable from(int page, int size, List<String> sort) throws HttpStatusException {
-        return Pageable.from(
-            page,
-            size,
-            sort(sort, null)
-        );
+        return from(page, size, sort, null);
+    }
+
+    public static Pageable from(int page, int size) throws HttpStatusException {
+        return from(page, size, null, null);
     }
 
     protected static Sort sort(List<String> sort, Function<String, String> sortMapper) {

--- a/webserver/src/test/java/io/kestra/webserver/controllers/api/ExecutionControllerTest.java
+++ b/webserver/src/test/java/io/kestra/webserver/controllers/api/ExecutionControllerTest.java
@@ -1166,6 +1166,20 @@ class ExecutionControllerTest extends JdbcH2ControllerTest {
         );
 
         assertThat(e.getStatus(), is(HttpStatus.UNPROCESSABLE_ENTITY));
+
+        e = assertThrows(
+            HttpClientResponseException.class,
+            () -> client.toBlocking().retrieve(GET("/api/v1/executions/search?page=1&size=-1"))
+        );
+
+        assertThat(e.getStatus(), is(HttpStatus.UNPROCESSABLE_ENTITY));
+
+        e = assertThrows(
+            HttpClientResponseException.class,
+            () -> client.toBlocking().retrieve(GET("/api/v1/executions/search?page=0"))
+        );
+
+        assertThat(e.getStatus(), is(HttpStatus.UNPROCESSABLE_ENTITY));
     }
 
     // This test is flaky on CI as the flow may be already SUCCESS when we kill it if CI is super slow

--- a/webserver/src/test/java/io/kestra/webserver/utils/PageableUtilsTest.java
+++ b/webserver/src/test/java/io/kestra/webserver/utils/PageableUtilsTest.java
@@ -1,0 +1,40 @@
+package io.kestra.webserver.utils;
+
+import io.micronaut.data.model.Pageable;
+import io.micronaut.data.model.Sort;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Locale;
+import java.util.function.Function;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.*;
+
+class PageableUtilsTest {
+
+    @Test
+    void testFrom() {
+        final Function<String, String> toUpper = (String key) -> key.toUpperCase(Locale.ROOT);
+
+        final Pageable pagedSortedMapped = PageableUtils.from(1, 42, List.of("key:asc"), toUpper);
+        final Pageable pagedSorted = PageableUtils.from(1, 42, List.of("key:asc"));
+        final Pageable paged = PageableUtils.from(1, 42);
+
+        assertFalse(pagedSortedMapped.isUnpaged());
+        assertTrue(pagedSortedMapped.isSorted());
+        assertThat(pagedSortedMapped.getSort().getOrderBy().getFirst(), is(Sort.Order.asc("KEY")));
+
+        assertFalse(pagedSorted.isUnpaged());
+        assertTrue(pagedSorted.isSorted());
+        assertThat(pagedSorted.getSort().getOrderBy().getFirst(), is(Sort.Order.asc("key")));
+
+        assertFalse(paged.isUnpaged());
+        assertFalse(paged.isSorted());
+
+        assertThrows(IllegalArgumentException.class, () -> PageableUtils.from(1, -1, List.of("key:asc"), toUpper));
+        assertThrows(IllegalArgumentException.class, () -> PageableUtils.from(1, -1, List.of("key:asc")));
+        assertThrows(IllegalArgumentException.class, () -> PageableUtils.from(1, -1));
+    }
+}


### PR DESCRIPTION
### What changes are being made and why?

* Added missing constraints at `page`/`size` query params.
* Enforced pagination via `PageableUtils`.

Taking the constraints route felt like the correct way - it is declarative & improves the OpenAPI definition.

closes #4977

---

### How the changes have been QAed?

[localhost:8080/ui/executions?page=-1](http://localhost:8080/ui/executions?page=-1)