### PR TITLE
feat: add displayName to inputs (#4470)

### DIFF
--- a/core/src/main/java/io/kestra/core/models/flows/Input.java
+++ b/core/src/main/java/io/kestra/core/models/flows/Input.java
@@ -6,11 +6,13 @@ import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import io.kestra.core.models.flows.input.*;
 import io.micronaut.core.annotation.Introspected;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.ConstraintViolationException;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -62,6 +64,12 @@ public abstract class Input<T> implements Data {
     Boolean required = true;
 
     Object defaults;
+
+    @Schema(
+        title = "The display name of the input."
+    )
+    @Size(max = 64)
+    String displayName;
 
     public abstract void validate(T input) throws ConstraintViolationException;
 

--- a/core/src/main/java/io/kestra/core/models/flows/input/MultiselectInput.java
+++ b/core/src/main/java/io/kestra/core/models/flows/input/MultiselectInput.java
@@ -97,6 +97,7 @@ public class MultiselectInput extends Input<List<String>> implements ItemTypeInt
                 .description(getDescription())
                 .dependsOn(getDependsOn())
                 .itemType(getItemType())
+                .displayName(getDisplayName())
                 .build();
         }
         return this;

--- a/core/src/main/java/io/kestra/core/models/flows/input/SelectInput.java
+++ b/core/src/main/java/io/kestra/core/models/flows/input/SelectInput.java
@@ -66,6 +66,7 @@ public class SelectInput extends Input<String> implements RenderableInput {
                 .defaults(getDefaults())
                 .description(getDescription())
                 .dependsOn(getDependsOn())
+                .displayName(getDisplayName())
                 .build();
         }
         return this;

--- a/ui/src/components/inputs/InputsForm.vue
+++ b/ui/src/components/inputs/InputsForm.vue
@@ -3,7 +3,7 @@
         <el-form-item
             v-for="input in inputsList || []"
             :key="input.id"
-            :label="input.id"
+            :label="input.displayName ? input.displayName : input.id"
             :required="input.required !== false"
             :prop="input.id"
         >

--- a/webserver/src/test/java/io/kestra/webserver/controllers/api/PluginControllerTest.java
+++ b/webserver/src/test/java/io/kestra/webserver/controllers/api/PluginControllerTest.java
@@ -229,7 +229,7 @@ class PluginControllerTest {
 
             assertThat(doc.getSchema().getProperties().size(), is(3));
             Map<String, Object> properties = (Map<String, Object>) doc.getSchema().getProperties().get("properties");
-            assertThat(properties.size(), is(7));
+            assertThat(properties.size(), is(8));
 //            assertThat(((Map<String, Object>) properties.get("name")).get("$deprecated"), is(true));
         });
     }


### PR DESCRIPTION
Fix: #4470

Example:

```yaml
id: example
namespace: io.kestra
inputs:
  - id: "cloud_providers"
    displayName: "Cloud Providers"
    type: SELECT
    values:
       - AWS
       - GCP
       - AZURE

  - id: "cloud-credential"
    displayName: "Credentials"
    type: STRING
```