### PR TITLE
feat: add label rendering when an execution is triggered (flow and schedule only)

### DIFF
--- a/core/src/main/java/io/kestra/plugin/core/trigger/Flow.java
+++ b/core/src/main/java/io/kestra/plugin/core/trigger/Flow.java
@@ -153,14 +153,12 @@ public class Flow extends AbstractTrigger implements TriggerOutput<Flow.Output> 
     }
 
     private String renderLabelValue(RunContext runContext, Label label) {
-        String value;
         try {
-            value = runContext.render(label.value());
+            return runContext.render(label.value());
         } catch (IllegalVariableEvaluationException e) {
-            runContext.logger().warn("Unable to render the value of label '{}', using the raw value instead", label.key(), e);
-            value = label.value();
+            runContext.logger().warn("Failed to render label '{}', it will be omitted", label.key(), e);
+            return null;
         }
-        return value;
     }
 
     @Builder

--- a/core/src/test/java/io/kestra/plugin/core/trigger/FlowTest.java
+++ b/core/src/test/java/io/kestra/plugin/core/trigger/FlowTest.java
@@ -16,6 +16,7 @@ import java.util.Optional;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 
 @KestraTest
@@ -139,14 +140,15 @@ class FlowTest {
             .labels(List.of(
                 new Label("trigger-label-1", "trigger-label-1"),
                 new Label("trigger-label-2", "{{ 'trigger-label-2' }}"),
-                new Label("trigger-label-3", "{{ null }}")
+                new Label("trigger-label-3", "{{ null }}"), // should return an empty string
+                new Label("trigger-label-4", "{{ foobar }}") // should fail
             ))
             .build();
 
         Optional<Execution> evaluate = flowTrigger.evaluate(runContextFactory.of(), flow, execution);
 
         assertThat(evaluate.isPresent(), is(true));
-        assertThat(evaluate.get().getFlowId(), is("flow-with-flow-trigger"));
+        assertThat(evaluate.get().getLabels(), hasSize(5));
         assertThat(evaluate.get().getLabels(), hasItem(new Label("flow-label-1", "flow-label-1")));
         assertThat(evaluate.get().getLabels(), hasItem(new Label("flow-label-2", "flow-label-2")));
         assertThat(evaluate.get().getLabels(), hasItem(new Label("trigger-label-1", "trigger-label-1")));


### PR DESCRIPTION
When a new execution is triggered, it is possible to define labels via the trigger definition. Unfortunately, they are never rendered, preventing the use of dynamic values, and in other cases, they are ignored.

This commit introduces the handling and rendering of trigger labels in `Flow` and `Schedule` triggers, ensuring dynamic values are processed, and all labels are used.

**Note**: `Webhook` and `Toggle` triggers have not been modified and currently don't propagate labels to the created execution, despite inheriting the `labels` property from `AbstractTrigger`. Further work may be needed to address this.