### PR TITLE
fix(cli): invalid static access via Child class

### DIFF
--- a/cli/src/main/java/io/kestra/cli/AbstractValidateCommand.java
+++ b/cli/src/main/java/io/kestra/cli/AbstractValidateCommand.java
@@ -95,13 +95,13 @@ public abstract class AbstractValidateCommand extends AbstractApiCommand {
                             warnings.forEach(warning -> stdOut("@|bold,yellow \u26A0|@ - " + warning));
                         } catch (ConstraintViolationException e) {
                             stdErr("@|red \u2718|@ - " + path);
-                            FlowValidateCommand.handleException(e, clsName);
+                            AbstractValidateCommand.handleException(e, clsName);
                             returnCode.set(1);
                         }
                     });
             }
         } else {
-            String body = FlowValidateCommand.buildYamlBody(directory);
+            String body = AbstractValidateCommand.buildYamlBody(directory);
 
             try(DefaultHttpClient client = client()) {
                 MutableHttpRequest<String> request = HttpRequest
@@ -118,12 +118,12 @@ public abstract class AbstractValidateCommand extends AbstractApiCommand {
                             stdOut("@|green \u2713|@ - " + validation.getIdentity());
                         } else {
                             stdErr("@|red \u2718|@ - " + validation.getIdentity(directory));
-                            FlowValidateCommand.handleValidateConstraintViolation(validation, clsName);
+                            AbstractValidateCommand.handleValidateConstraintViolation(validation, clsName);
                             returnCode.set(1);
                         }
                     }));
             } catch (HttpClientResponseException e){
-                FlowValidateCommand.handleHttpException(e, clsName);
+                AbstractValidateCommand.handleHttpException(e, clsName);
 
                 return 1;
             }

--- a/cli/src/main/java/io/kestra/cli/commands/flows/FlowExportCommand.java
+++ b/cli/src/main/java/io/kestra/cli/commands/flows/FlowExportCommand.java
@@ -1,6 +1,7 @@
 package io.kestra.cli.commands.flows;
 
 import io.kestra.cli.AbstractApiCommand;
+import io.kestra.cli.AbstractValidateCommand;
 import io.micronaut.context.ApplicationContext;
 import io.micronaut.http.HttpRequest;
 import io.micronaut.http.HttpResponse;
@@ -50,7 +51,7 @@ public class FlowExportCommand extends AbstractApiCommand {
 
             stdOut("Exporting flow(s) for namespace '" + namespace + "' successfully done !");
         } catch (HttpClientResponseException e) {
-            FlowValidateCommand.handleHttpException(e, "flow");
+            AbstractValidateCommand.handleHttpException(e, "flow");
             return 1;
         }
 

--- a/cli/src/main/java/io/kestra/cli/commands/flows/namespaces/FlowNamespaceUpdateCommand.java
+++ b/cli/src/main/java/io/kestra/cli/commands/flows/namespaces/FlowNamespaceUpdateCommand.java
@@ -1,5 +1,6 @@
 package io.kestra.cli.commands.flows.namespaces;
 
+import io.kestra.cli.AbstractValidateCommand;
 import io.kestra.cli.commands.AbstractServiceNamespaceUpdateCommand;
 import io.kestra.cli.commands.flows.FlowValidateCommand;
 import io.kestra.cli.commands.flows.IncludeHelperExpander;
@@ -66,11 +67,11 @@ public class FlowNamespaceUpdateCommand extends AbstractServiceNamespaceUpdateCo
                 stdOut(updated.size() + " flow(s) for namespace '" + namespace + "' successfully updated !");
                 updated.forEach(flow -> stdOut("- " + flow.getNamespace() + "."  + flow.getId()));
             } catch (HttpClientResponseException e){
-                FlowValidateCommand.handleHttpException(e, "flow");
+                AbstractValidateCommand.handleHttpException(e, "flow");
                 return 1;
             }
         } catch (ConstraintViolationException e) {
-            FlowValidateCommand.handleException(e, "flow");
+            AbstractValidateCommand.handleException(e, "flow");
 
             return 1;
         }

--- a/cli/src/main/java/io/kestra/cli/commands/templates/TemplateExportCommand.java
+++ b/cli/src/main/java/io/kestra/cli/commands/templates/TemplateExportCommand.java
@@ -1,6 +1,7 @@
 package io.kestra.cli.commands.templates;
 
 import io.kestra.cli.AbstractApiCommand;
+import io.kestra.cli.AbstractValidateCommand;
 import io.kestra.core.models.templates.TemplateEnabled;
 import io.micronaut.context.ApplicationContext;
 import io.micronaut.http.HttpRequest;
@@ -52,7 +53,7 @@ public class TemplateExportCommand extends AbstractApiCommand {
 
             stdOut("Exporting template(s) for namespace '" + namespace + "' successfully done !");
         } catch (HttpClientResponseException e) {
-            TemplateValidateCommand.handleHttpException(e, "template");
+            AbstractValidateCommand.handleHttpException(e, "template");
             return 1;
         }
 

--- a/cli/src/main/java/io/kestra/cli/commands/templates/namespaces/TemplateNamespaceUpdateCommand.java
+++ b/cli/src/main/java/io/kestra/cli/commands/templates/namespaces/TemplateNamespaceUpdateCommand.java
@@ -1,5 +1,6 @@
 package io.kestra.cli.commands.templates.namespaces;
 
+import io.kestra.cli.AbstractValidateCommand;
 import io.kestra.cli.commands.AbstractServiceNamespaceUpdateCommand;
 import io.kestra.cli.commands.templates.TemplateValidateCommand;
 import io.kestra.core.models.templates.Template;
@@ -57,12 +58,12 @@ public class TemplateNamespaceUpdateCommand extends AbstractServiceNamespaceUpda
                 stdOut(updated.size() + " template(s) for namespace '" + namespace + "' successfully updated !");
                 updated.forEach(template -> stdOut("- " + template.getNamespace() + "." + template.getId()));
             } catch (HttpClientResponseException e) {
-                TemplateValidateCommand.handleHttpException(e, "template");
+                AbstractValidateCommand.handleHttpException(e, "template");
 
                 return 1;
             }
         } catch (ConstraintViolationException e) {
-            TemplateValidateCommand.handleException(e, "template");
+            AbstractValidateCommand.handleException(e, "template");
 
             return 1;
         }


### PR DESCRIPTION
Static access must always be done on the class that contains the static method not a child
