### PR TITLE
fix: hide the triggers widget in the dashboard when no permission

### DIFF
--- a/ui/src/components/dashboard/Dashboard.vue
+++ b/ui/src/components/dashboard/Dashboard.vue
@@ -169,10 +169,11 @@
                     :total="stats.total"
                 />
                 <ExecutionsNextScheduled
-                    v-else
+                    v-else-if="isAllowedTriggers"
                     :flow="props.flowID"
                     :namespace="filters.namespace"
                 />
+                <ExecutionsEmptyNextScheduled v-else />
             </el-col>
         </el-row>
 
@@ -220,17 +221,21 @@
 
     import ExecutionsInProgress from "./components/tables/executions/InProgress.vue";
     import ExecutionsNextScheduled from "./components/tables/executions/NextScheduled.vue";
+    import ExecutionsEmptyNextScheduled from "./components/tables/executions/EmptyNextScheduled.vue"
 
     import CheckBold from "vue-material-design-icons/CheckBold.vue";
     import Alert from "vue-material-design-icons/Alert.vue";
     import LightningBolt from "vue-material-design-icons/LightningBolt.vue";
     import FileTree from "vue-material-design-icons/FileTree.vue";
     import BookOpenOutline from "vue-material-design-icons/BookOpenOutline.vue";
+    import permission from "../../models/permission.js";
+    import action from "../../models/action.js";
 
     const router = useRouter();
     const route = useRoute();
     const store = useStore();
     const {t} = useI18n({useScope: "global"});
+    const user = store.getters["auth/user"];
 
     const props = defineProps({
         embed: {
@@ -408,6 +413,12 @@
             console.error("All promises failed:", error);
         }
     };
+
+    const isAllowedTriggers = computed(() => {
+        return (
+            user && user.isAllowed(permission.FLOW, action.READ, filters.value.namespace)
+        );
+    });
 
     onBeforeMount(() => {
         filters.value.namespace = route.query.namespace ?? null;

--- a/ui/src/components/dashboard/components/tables/executions/EmptyNextScheduled.vue
+++ b/ui/src/components/dashboard/components/tables/executions/EmptyNextScheduled.vue
@@ -1,0 +1,19 @@
+<template>
+    <div class="p-4 h-100">
+        <span class="fs-6 fw-bold">
+            {{ t("dashboard.next_scheduled_executions") }}
+        </span>
+
+        <div class="pt-4">
+            <span class="align-middle">
+                {{ t("dashboard.not_auth") }}
+            </span>
+        </div>
+    </div>
+</template>
+
+<script setup>
+    import {useI18n} from "vue-i18n";
+
+    const {t} = useI18n({useScope: "global"});
+</script>

--- a/ui/src/translations/en.json
+++ b/ui/src/translations/en.json
@@ -863,7 +863,8 @@
       "id": "ID",
       "trigger_disabled": "This trigger can only be enabled through code.",
       "description": "Description",
-      "no_flow_description": "This flow has no description."
+      "no_flow_description": "This flow has no description.",
+      "not_auth": "You don't have the necessary permissions to view this widget."
     },
     "docs": "Docs",
     "active-slots": "Active slots",


### PR DESCRIPTION
Triggers can only be listed if a user has the FLOW READ permission