### PR TITLE
chore(ui): prevent using 'this' in Vue templates

### DIFF
--- a/ui/.eslintrc.json
+++ b/ui/.eslintrc.json
@@ -20,6 +20,9 @@
     "queryParams": "readonly"
   },
   "rules": {
+    "vue/this-in-template": [
+      "error"
+    ],
     "vue/html-indent": [
       "error",
       4,

--- a/ui/src/components/ErrorToastContainer.vue
+++ b/ui/src/components/ErrorToastContainer.vue
@@ -7,9 +7,9 @@
         <Slack />
         <span>{{ $t("slack support") }}</span>
     </a>
-    <span v-html="markdownRenderer" v-if="this.items.length === 0" />
+    <span v-html="markdownRenderer" v-if="items.length === 0" />
     <ul>
-        <li v-for="(item, index) in this.items" :key="index" class="font-monospace">
+        <li v-for="(item, index) in items" :key="index" class="font-monospace">
             <template v-if="item.path">
                 At <code>{{ item.path }}</code>:
             </template>

--- a/ui/src/components/flows/FlowCreate.vue
+++ b/ui/src/components/flows/FlowCreate.vue
@@ -2,7 +2,7 @@
     <top-nav-bar :title="routeInfo.title" />
     <section class="full-container">
         <editor-view
-            v-if="this.source"
+            v-if="source"
             :flow-id="flowParsed?.id"
             :namespace="flowParsed?.namespace"
             :is-creating="true"

--- a/ui/src/components/inputs/DurationPicker.vue
+++ b/ui/src/components/inputs/DurationPicker.vue
@@ -70,8 +70,8 @@
         />
     </div>
     <div>
-        <el-text size="small" :type="this.durationIssue ? 'danger': ''">
-            {{ this.durationIssue ?? "or input custom duration:" }}
+        <el-text size="small" :type="durationIssue ? 'danger': ''">
+            {{ durationIssue ?? "or input custom duration:" }}
         </el-text>
         <el-input type="text" id="customDuration" v-model="customDuration" @input="parseDuration" placeholder="Custom duration" />
     </div>

--- a/ui/src/components/logs/TaskRunDetails.vue
+++ b/ui/src/components/logs/TaskRunDetails.vue
@@ -63,7 +63,7 @@
                                 <log-line
                                     @click="emitLogCursor(`${currentTaskRunIndex}/${index}`)"
                                     class="line"
-                                    :cursor="this.logCursor === `${currentTaskRunIndex}/${index}`"
+                                    :cursor="logCursor === `${currentTaskRunIndex}/${index}`"
                                     :class="{['log-bg-' + levelToHighlight?.toLowerCase()]: levelToHighlight === item.level, 'opacity-40': levelToHighlight && levelToHighlight !== item.level}"
                                     :key="index"
                                     :level="level"


### PR DESCRIPTION
### What changes are being made and why?

Sadly the `vue/this-in-template` ESLint rule is included only in the rather nice-to-have `plugin:vue/vue3-recommended` config.

closes #5181