### PR TITLE
Add namespace KV JSON Type validation

### DIFF
--- a/ui/src/components/namespace/NamespaceKV.vue
+++ b/ui/src/components/namespace/NamespaceKV.vue
@@ -224,7 +224,6 @@
                     callback(new Error(this.$t("Invalid input: Expected a JSON formatted string")));
                 }
             },
-
             durationValidator(rule, value, callback) {
                 if (value !== undefined && !value.match(/^P(?=[^T]|T.)(?:\d*D)?(?:T(?=.)(?:\d*H)?(?:\d*M)?(?:\d*S)?)?$/)) {
                     callback(new Error(this.$t("datepicker.error")));

--- a/ui/src/components/namespace/NamespaceKV.vue
+++ b/ui/src/components/namespace/NamespaceKV.vue
@@ -214,8 +214,12 @@
         methods: {
             jsonValidator(rule, value, callback) {
                 try {
-                    JSON.parse(value)
-                    callback();
+                    const parsed = JSON.parse(value);
+                    if (typeof parsed !== "object" || parsed === null) {
+                        callback(new Error(this.$t("Invalid input: Expected a JSON object or array")));
+                    } else {
+                        callback();
+                    }
                 } catch (error) {
                     callback(new Error(this.$t("Invalid input: Expected a JSON formatted string")));
                 }

--- a/ui/src/components/namespace/NamespaceKV.vue
+++ b/ui/src/components/namespace/NamespaceKV.vue
@@ -164,7 +164,7 @@
                             validator: (rule, value, callback) => {
                                 if (this.kv.type === "DURATION") {
                                     this.durationValidator(rule, value, callback);
-                                } 
+                                }
                                 else if (this.kv.type === "JSON") {
                                     this.jsonValidator(rule, value, callback)
                                 }
@@ -224,6 +224,7 @@
                     callback(new Error(this.$t("Invalid input: Expected a JSON formatted string")));
                 }
             },
+
             durationValidator(rule, value, callback) {
                 if (value !== undefined && !value.match(/^P(?=[^T]|T.)(?:\d*D)?(?:T(?=.)(?:\d*H)?(?:\d*M)?(?:\d*S)?)?$/)) {
                     callback(new Error(this.$t("datepicker.error")));
@@ -272,7 +273,7 @@
 
                     const type = this.kv.type;
                     let value = this.kv.value;
-                    
+
                     if (["STRING", "DURATION"].includes(type)) {
                         value = JSON.stringify(value);
                     } else if (type === "DATETIME") {

--- a/ui/src/components/namespace/NamespaceKV.vue
+++ b/ui/src/components/namespace/NamespaceKV.vue
@@ -164,7 +164,11 @@
                             validator: (rule, value, callback) => {
                                 if (this.kv.type === "DURATION") {
                                     this.durationValidator(rule, value, callback);
-                                } else {
+                                } 
+                                else if (this.kv.type === "JSON") {
+                                    this.jsonValidator(rule, value, callback)
+                                }
+                                else {
                                     callback();
                                 }
                             },
@@ -208,6 +212,14 @@
             this.loadKvs();
         },
         methods: {
+            jsonValidator(rule, value, callback) {
+                try {
+                    JSON.parse(value)
+                    callback();
+                } catch (error) {
+                    callback(new Error(this.$t("Invalid input: Expected a JSON formatted string")));
+                }
+            },
             durationValidator(rule, value, callback) {
                 if (value !== undefined && !value.match(/^P(?=[^T]|T.)(?:\d*D)?(?:T(?=.)(?:\d*H)?(?:\d*M)?(?:\d*S)?)?$/)) {
                     callback(new Error(this.$t("datepicker.error")));


### PR DESCRIPTION
issue #4720

## summary

On the namespace page, when saving key-value data, even if the type is specified as JSON, the value can be saved even if the input data is not in JSON format.

I determined that a validation process to check whether the data is in the correct JSON format is necessary.

The method I created is as follows:

---
### NamespaceKV.vue
```js
jsonValidator(rule, value, callback) {
    try {
        const parsed = JSON.parse(value);
        if (typeof parsed !== "object" || parsed === null) {
            callback(new Error(this.$t("Invalid input: Expected a JSON object or array")));
        } else {
            callback();
        }
    } catch (error) {
        callback(new Error(this.$t("Invalid input: Expected a JSON formatted string")));
    }
},
```

```js
{
    validator: (rule, value, callback) => {
        if (this.kv.type === "DURATION") {
            this.durationValidator(rule, value, callback);
        }
        else if (this.kv.type === "JSON") {
            this.jsonValidator(rule, value, callback)
        }
        else {
            callback();
        }
    },
    trigger: "change"
}
```

## Result

https://github.com/user-attachments/assets/900aca77-3f2f-4017-8824-dc5fb3f3d4c3

