### PR TITLE
feat(ui): "see all" options to executions in progress #5200

### DIFF
--- a/ui/src/components/dashboard/components/tables/executions/InProgress.vue
+++ b/ui/src/components/dashboard/components/tables/executions/InProgress.vue
@@ -1,15 +1,11 @@
 <template>
     <div class="p-4">
-        <!-- <span class="fs-6 fw-bold">
-            {{ t("dashboard.executions_in_progress") }}
-        </span> -->
-        
         <div class="d-flex justify-content-between align-items-center">
             <span class="fs-6 fw-bold">
                 {{ t("dashboard.executions_in_progress") }}
             </span>
             <RouterLink :to="{name: 'executions/list'}">
-                <el-button type="primary" size="small" class="seeall" text>
+                <el-button type="primary" size="small" text>
                     {{ t("dashboard.see_all") }}
                 </el-button>
             </RouterLink>
@@ -180,7 +176,4 @@ code {
     background: var(--bs-body-bg);
 }
 
-.seeall {
-    color: var(--el-color-primary);
-}
 </style>

--- a/ui/src/components/dashboard/components/tables/executions/InProgress.vue
+++ b/ui/src/components/dashboard/components/tables/executions/InProgress.vue
@@ -1,8 +1,19 @@
 <template>
     <div class="p-4">
-        <span class="fs-6 fw-bold">
+        <!-- <span class="fs-6 fw-bold">
             {{ t("dashboard.executions_in_progress") }}
-        </span>
+        </span> -->
+        
+        <div class="d-flex justify-content-between align-items-center">
+            <span class="fs-6 fw-bold">
+                {{ t("dashboard.executions_in_progress") }}
+            </span>
+            <RouterLink :to="{name: 'executions/list'}">
+                <el-button type="primary" size="small" class="seeall" text>
+                    {{ t("dashboard.see_all") }}
+                </el-button>
+            </RouterLink>
+        </div>
 
         <div class="pt-4">
             <el-table
@@ -167,5 +178,9 @@ code {
 .inprogress {
     --el-table-tr-bg-color: var(--bs-body-bg) !important;
     background: var(--bs-body-bg);
+}
+
+.seeall {
+    color: var(--el-color-primary);
 }
 </style>

--- a/ui/src/components/dashboard/components/tables/executions/NextScheduled.vue
+++ b/ui/src/components/dashboard/components/tables/executions/NextScheduled.vue
@@ -1,8 +1,18 @@
 <template>
     <div class="p-4">
-        <span class="fs-6 fw-bold">
+        <!-- <span class="fs-6 fw-bold">
             {{ t("dashboard.next_scheduled_executions") }}
-        </span>
+        </span> -->
+        <div class="d-flex justify-content-between align-items-center">
+            <span class="fs-6 fw-bold">
+                {{ t("dashboard.next_scheduled_executions") }}
+            </span>
+            <RouterLink :to="{name: 'executions/list'}">
+                <el-button type="primary" size="small" class="seeall" text>
+                    {{ t("dashboard.see_all") }}
+                </el-button>
+            </RouterLink>
+        </div>
 
         <div class="pt-4">
             <el-table
@@ -218,5 +228,9 @@ code {
 
 .next-toggle {
     padding: 8px 0 0 0 !important;
+}
+
+.seeall {
+    color: var(--el-color-primary);
 }
 </style>

--- a/ui/src/components/dashboard/components/tables/executions/NextScheduled.vue
+++ b/ui/src/components/dashboard/components/tables/executions/NextScheduled.vue
@@ -1,14 +1,11 @@
 <template>
     <div class="p-4">
-        <!-- <span class="fs-6 fw-bold">
-            {{ t("dashboard.next_scheduled_executions") }}
-        </span> -->
         <div class="d-flex justify-content-between align-items-center">
             <span class="fs-6 fw-bold">
                 {{ t("dashboard.next_scheduled_executions") }}
             </span>
-            <RouterLink :to="{name: 'executions/list'}">
-                <el-button type="primary" size="small" class="seeall" text>
+            <RouterLink :to="{name: 'admin/triggers'}">
+                <el-button type="primary" size="small" text>
                     {{ t("dashboard.see_all") }}
                 </el-button>
             </RouterLink>
@@ -228,9 +225,5 @@ code {
 
 .next-toggle {
     padding: 8px 0 0 0 !important;
-}
-
-.seeall {
-    color: var(--el-color-primary);
 }
 </style>

--- a/ui/src/translations/en.json
+++ b/ui/src/translations/en.json
@@ -859,6 +859,7 @@
       "per_namespace": " (per namespace)",
       "total_executions": "Total Executions",
       "executions_in_progress": "Executions In Progress",
+      "see_all":"See all",
       "next_scheduled_executions": "Next Scheduled Executions",
       "next_execution_date": "Next Execution Date",
       "id": "ID",


### PR DESCRIPTION
### What changes are being made and why?
Made changes to inProgress.vue, NextScheduled.vue and translations/en_json
el-button component in routerLink with link to executions/list

### How the changes have been QAed?
inProgress.vue
```
        <div class="d-flex justify-content-between align-items-center">
            <span class="fs-6 fw-bold">
                {{ t("dashboard.executions_in_progress") }}
            </span>
            <RouterLink :to="{name: 'executions/list'}">
                <el-button type="primary" size="small" class="seeall" text>
                    {{ t("dashboard.see_all") }}
                </el-button>
            </RouterLink>
        </div>

```
nextScheduled.vue
```
        <div class="d-flex justify-content-between align-items-center">
            <span class="fs-6 fw-bold">
                {{ t("dashboard.next_scheduled_executions") }}
            </span>
            <RouterLink :to="{name: 'executions/list'}">
                <el-button type="primary" size="small" class="seeall" text>
                    {{ t("dashboard.see_all") }}
                </el-button>
            </RouterLink>
        </div>
```
and .seeall class in <style>, to change color of text
```
.seeall {
    color: var(--el-color-primary);
}
```