### PR TITLE
fix(ui): Color is not the same between Gantt and Topology execution views 

### DIFF
--- a/ui/src/styles/layout/root-dark.scss
+++ b/ui/src/styles/layout/root-dark.scss
@@ -32,7 +32,7 @@ html.dark {
     #{--bs-link-color-rgb}: to-rgb($secondary);
     #{--bs-tertiary-color}: #C3BBE3;
 
-    $levels: info, running, danger, warning, success;
+    $levels: info, running, danger, warning;
     @each $level in $levels {
         .bg-#{$level} {
             #{--bs-bg-opacity}: 0.2;

--- a/ui/src/styles/layout/root.scss
+++ b/ui/src/styles/layout/root.scss
@@ -88,7 +88,7 @@
     $content-running: #7400df;
     $content-alert: #ab0009;
     $content-warning: #c15300;
-    $content-success: #017f5c;
+    $content-success: #03DABA;
     #{--background-failed}: #fed6d9;
     #{--background-success}: #e4f9f3;
     #{--content-information}: $content-information;


### PR DESCRIPTION
<!-- Thanks for submitting a Pull Request to Kestra. To help us review your contribution, please follow the guidelines below:

- Make sure that your commits follow the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) specification e.g. `feat(ui): add a new navigation menu item` or `fix(core): fix a bug in the core model` or `docs: update the README.md`. This will help us automatically generate the changelog.
- The title should briefly summarize the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share a flow example to help the reviewer understand and QA the change.
- Use "closes" to automatically close an issue. For example, `closes #1234` will close issue #1234. -->
closes #5238 
### What changes are being made and why?

Unified success task color between Gantt and Topology views.
Changed $content-success in root.scss to #03daba


---
