### PR TITLE
feat: allow to send output from a failed task

### DIFF
--- a/core/src/main/java/io/kestra/core/models/tasks/RunnableTaskException.java
+++ b/core/src/main/java/io/kestra/core/models/tasks/RunnableTaskException.java
@@ -1,0 +1,42 @@
+package io.kestra.core.models.tasks;
+
+import lombok.Getter;
+
+/**
+ * Exception that a {@link RunnableTask} can use to notice failure to the worker.
+ * This exception can convey an Output that will be set inside the WorkerTaskResult.
+ */
+@Getter
+public class RunnableTaskException extends Exception {
+    private final Output output;
+
+    public RunnableTaskException(Exception cause) {
+        super(cause);
+        this.output = null;
+    }
+
+    public RunnableTaskException(Exception cause, Output output) {
+        super(cause);
+        this.output = output;
+    }
+
+    public RunnableTaskException(String message) {
+        super(message);
+        this.output = null;
+    }
+
+    public RunnableTaskException(String message, Output output) {
+        super(message);
+        this.output = output;
+    }
+
+    public RunnableTaskException(String message, Throwable cause) {
+        super(message, cause);
+        this.output = null;
+    }
+
+    public RunnableTaskException(String message, Throwable cause, Output output) {
+        super(message, cause);
+        this.output = output;
+    }
+}

--- a/core/src/main/java/io/kestra/core/models/tasks/runners/TaskException.java
+++ b/core/src/main/java/io/kestra/core/models/tasks/runners/TaskException.java
@@ -1,28 +1,50 @@
 package io.kestra.core.models.tasks.runners;
 
-import lombok.Builder;
 import lombok.Getter;
 
 import java.io.Serial;
 
 @Getter
-@Builder
 public class TaskException extends Exception {
     @Serial
     private static final long serialVersionUID = 1L;
 
     private final int exitCode;
-    private final int stdOutSize;
-    private final int stdErrSize;
+    private final int stdOutCount;
+    private final int stdErrCount;
 
-    public TaskException(int exitCode, int stdOutSize, int stdErrSize) {
-        this("Command failed with code " + exitCode, exitCode, stdOutSize, stdErrSize);
+    private transient AbstractLogConsumer logConsumer;
+
+    /**
+     * This constructor will certainly be removed in 0.21 as we keep it only because all task runners must be impacted.
+     * @deprecated use {@link #TaskException(int, AbstractLogConsumer)} instead.
+     */
+    @Deprecated(forRemoval = true, since = "0.20.0")
+    public TaskException(int exitCode, int stdOutCount, int stdErrCount) {
+        this("Command failed with exit code " + exitCode, exitCode, stdOutCount, stdErrCount);
     }
 
-    public TaskException(String message, int exitCode, int stdOutSize, int stdErrSize) {
+    public TaskException(int exitCode, AbstractLogConsumer logConsumer) {
+        this("Command failed with exit code " + exitCode, exitCode, logConsumer);
+    }
+
+    /**
+     * This constructor will certainly be removed in 0.21 as we keep it only because all task runners must be impacted.
+     * @deprecated use {@link #TaskException(String, int, AbstractLogConsumer)} instead.
+     */
+    @Deprecated(forRemoval = true, since = "0.20.0")
+    public TaskException(String message, int exitCode, int stdOutCount, int stdErrCount) {
         super(message);
         this.exitCode = exitCode;
-        this.stdOutSize = stdOutSize;
-        this.stdErrSize = stdErrSize;
+        this.stdOutCount = stdOutCount;
+        this.stdErrCount = stdErrCount;
+    }
+
+    public TaskException(String message, int exitCode, AbstractLogConsumer logConsumer) {
+        super(message);
+        this.exitCode = exitCode;
+        this.stdOutCount = logConsumer.getStdOutCount();
+        this.stdErrCount = logConsumer.getStdErrCount();
+        this.logConsumer = logConsumer;
     }
 }

--- a/core/src/main/java/io/kestra/core/runners/WorkerTaskThread.java
+++ b/core/src/main/java/io/kestra/core/runners/WorkerTaskThread.java
@@ -6,6 +6,7 @@ import io.kestra.core.exceptions.TimeoutExceededException;
 import io.kestra.core.metrics.MetricRegistry;
 import io.kestra.core.models.tasks.Output;
 import io.kestra.core.models.tasks.RunnableTask;
+import io.kestra.core.models.tasks.RunnableTaskException;
 import lombok.Getter;
 
 import java.time.Duration;
@@ -82,6 +83,9 @@ public class WorkerTaskThread extends AbstractWorkerThread {
         } catch (dev.failsafe.TimeoutExceededException e) {
             kill(false);
             this.exceptionHandler(this, new TimeoutExceededException(workerTaskTimeout));
+        } catch (RunnableTaskException e) {
+            taskOutput = e.getOutput();
+            this.exceptionHandler(this, e);
         }
     }
 }

--- a/core/src/main/java/io/kestra/plugin/core/runner/Process.java
+++ b/core/src/main/java/io/kestra/plugin/core/runner/Process.java
@@ -152,9 +152,9 @@ public class Process extends TaskRunner {
             stdErr.join();
 
             if (exitCode != 0) {
-                throw new TaskException(exitCode, defaultLogConsumer.getStdOutCount(), defaultLogConsumer.getStdErrCount());
+                throw new TaskException(exitCode, defaultLogConsumer);
             } else {
-                logger.debug("Command succeed with code {}", exitCode);
+                logger.debug("Command succeed with exit code {}", exitCode);
             }
 
             return new RunnerResult(exitCode, defaultLogConsumer);

--- a/core/src/test/java/io/kestra/core/runners/RunnableTaskExceptionTest.java
+++ b/core/src/test/java/io/kestra/core/runners/RunnableTaskExceptionTest.java
@@ -1,0 +1,25 @@
+package io.kestra.core.runners;
+
+import io.kestra.core.junit.annotations.KestraTest;
+import io.kestra.core.models.executions.Execution;
+import io.kestra.core.models.flows.State;
+import io.kestra.core.queues.QueueException;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.TimeoutException;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+
+@KestraTest
+class RunnableTaskExceptionTest extends AbstractMemoryRunnerTest {
+    @Test
+    void simple() throws TimeoutException, QueueException {
+        Execution execution = runnerUtils.runOne(null, "io.kestra.tests", "exception-with-output");
+
+        assertThat(execution.getState().getCurrent(), is(State.Type.FAILED));
+        assertThat(execution.getTaskRunList(), hasSize(1));
+        assertThat(execution.getTaskRunList().get(0).getOutputs().get("message"), is("Oh no!"));
+    }
+}

--- a/core/src/test/java/io/kestra/core/runners/test/TaskThatFail.java
+++ b/core/src/test/java/io/kestra/core/runners/test/TaskThatFail.java
@@ -1,0 +1,34 @@
+package io.kestra.core.runners.test;
+
+import io.kestra.core.models.annotations.Plugin;
+import io.kestra.core.models.annotations.PluginProperty;
+import io.kestra.core.models.tasks.*;
+import io.kestra.core.runners.RunContext;
+import jakarta.validation.constraints.NotNull;
+import lombok.*;
+import lombok.experimental.SuperBuilder;
+
+@SuperBuilder
+@ToString
+@EqualsAndHashCode
+@Getter
+@NoArgsConstructor
+@Plugin
+public class TaskThatFail extends Task implements RunnableTask<TaskThatFail.Output> {
+    @NotNull
+    @PluginProperty(dynamic = true)
+    private String message;
+
+
+    @Override
+    public TaskThatFail.Output run(RunContext runContext) throws Exception {
+        var output = Output.builder().message(this.message).build();
+        throw new RunnableTaskException("An exception occurs", output);
+    }
+
+    @Builder
+    @Getter
+    public static class Output implements io.kestra.core.models.tasks.Output {
+        private String message;
+    }
+}

--- a/core/src/test/resources/flows/valids/exception-with-output.yaml
+++ b/core/src/test/resources/flows/valids/exception-with-output.yaml
@@ -1,0 +1,7 @@
+id: exception-with-output
+namespace: io.kestra.tests
+
+tasks:
+  - id: exception
+    type: io.kestra.core.runners.test.TaskThatFail
+    message: Oh no!


### PR DESCRIPTION
Fixes #4020

The following flow will have the first task fail in WARNING but still with outputs and output file available:

```yaml
id: shell
namespace: company.team

tasks: 
  - id: task1 
    type: io.kestra.plugin.scripts.shell.Commands
    outputFiles:
      - first.txt
    commands:  
      - echo "1" >> first.txt
      - echo '::{"outputs":{"test":"value"}}::'
      - exit 1
    allowFailure: true

  - id: task2 
    type: io.kestra.plugin.core.debug.Return 
    format: "{{ outputs.task1.exitCode }}"
```

Other task runner must be impacted to correctly build the TaskException, I'll submit followup PRs for them.
