### PR TITLE
fix(ui): re-enable shortcut to launch execution

### DIFF
--- a/ui/src/components/flows/FlowRun.vue
+++ b/ui/src/components/flows/FlowRun.vue
@@ -6,7 +6,7 @@
         </el-alert>
 
         <el-form label-position="top" :model="inputs" ref="form" @submit.prevent="false">
-            <inputs-form :initial-inputs="flow.inputs" :flow="flow" v-model="inputs" :execute-clicked="executeClicked" />
+            <inputs-form :initial-inputs="flow.inputs" :flow="flow" v-model="inputs" :execute-clicked="executeClicked" @confirm="onSubmit($refs.form)" />
 
             <el-collapse class="mt-4" v-model="collapseName">
                 <el-collapse-item :title="$t('advanced configuration')" name="advanced">
@@ -50,7 +50,7 @@
                             @click="onSubmit($refs.form); executeClicked = true;"
                             type="primary"
                             native-type="submit"
-                            :disabled="flow.disabled || haveBadLabels"
+                            :disabled="!flowCanBeExecuted"
                         >
                             {{ $t('launch execution') }}
                         </el-button>
@@ -111,6 +111,9 @@
             haveBadLabels() {
                 return this.executionLabels.some(label => (label.key && !label.value) || (!label.key && label.value));
             },
+            flowCanBeExecuted() {
+                return this.flow && !this.flow.disabled && !this.haveBadLabels;
+            }
         },
         methods: {
             getExecutionLabels() {
@@ -152,7 +155,7 @@
                 return inputs;
             },
             onSubmit(formRef) {
-                if (formRef) {
+                if (formRef && this.flowCanBeExecuted) {
                     formRef.validate((valid) => {
                         if (!valid) {
                             return false;
@@ -175,7 +178,6 @@
                     });
                 }
             },
-
             state(input) {
                 const required = input.required === undefined ? true : input.required;
 

--- a/ui/src/components/inputs/InputsForm.vue
+++ b/ui/src/components/inputs/InputsForm.vue
@@ -14,6 +14,7 @@
                 v-if="input.type === 'STRING' || input.type === 'URI'"
                 v-model="inputs[input.id]"
                 @update:model-value="onChange"
+                @confirm="onSubmit"
             />
             <el-select
                 :full-height="false"
@@ -209,7 +210,7 @@
                 multiSelectInputs: {},
             };
         },
-        emits: ["update:modelValue"],
+        emits: ["update:modelValue", "confirm"],
         created() {
             this.inputsList.push(...(this.initialInputs ?? []));
             this.validateInputs();
@@ -223,9 +224,10 @@
             }, 500)
 
             this._keyListener = function(e) {
-                if (e.keyCode === 13 && (e.ctrlKey || e.metaKey))  {
+                // Ctrl/Control + Enter
+                if (e.key === "Enter" && (e.ctrlKey || e.metaKey))  {
                     e.preventDefault();
-                    this.onSubmit(this.$refs.form);
+                    this.onSubmit();
                 }
             };
 
@@ -247,6 +249,9 @@
             },
             onChange() {
                 this.$emit("update:modelValue", this.inputs);
+            },
+            onSubmit() {
+                this.$emit("confirm");
             },
             onMultiSelectChange(input, e) {
                 this.inputs[input] = JSON.stringify(e).toString();


### PR DESCRIPTION
### What changes are being made and why?

Ctrl/Control + Enter confirms the "execute flow" modal.