### PR TITLE
chore(deps): revert to Jackson 2.17 as 2.18 fails a test

### DIFF
--- a/platform/build.gradle
+++ b/platform/build.gradle
@@ -24,7 +24,7 @@ dependencies {
     def flyingSaucerVersion = "9.9.4"
 
     // as Jackson is in the Micronaut BOM, to force it's version we need to use enforcedPlatform
-    api enforcedPlatform("com.fasterxml.jackson:jackson-bom:2.18.0")
+    api enforcedPlatform("com.fasterxml.jackson:jackson-bom:2.17.2")
     api platform("io.micronaut.platform:micronaut-platform:4.6.2")
     api platform("io.qameta.allure:allure-bom:2.29.0")
 


### PR DESCRIPTION
The test PluginDefaultServiceTest.injectFlowAndGlobals() didn't work with Jackson 2.18, plugin default from the configuration file seems to not be applied anymore.