### PR TITLE
Feat/realtime trigger thread

### DIFF
--- a/cli/src/main/java/io/kestra/cli/commands/servers/AbstractServerCommand.java
+++ b/cli/src/main/java/io/kestra/cli/commands/servers/AbstractServerCommand.java
@@ -7,7 +7,11 @@ abstract public class AbstractServerCommand extends AbstractCommand implements S
     @CommandLine.Option(names = {"--port"}, description = "the port to bind")
     Integer serverPort;
 
-    protected static int defaultWorkerThread() {
+    protected static int defaultWorkerThreads() {
         return Runtime.getRuntime().availableProcessors() * 4;
+    }
+
+    protected String displayRealtimeTriggerThreads(int threads) {
+        return threads > 0 ? String.valueOf(threads) : "unlimited";
     }
 }

--- a/cli/src/main/java/io/kestra/cli/commands/servers/StandAloneCommand.java
+++ b/cli/src/main/java/io/kestra/cli/commands/servers/StandAloneCommand.java
@@ -40,8 +40,11 @@ public class StandAloneCommand extends AbstractServerCommand {
     @CommandLine.Option(names = {"-f", "--flow-path"}, description = "the flow path containing flow to inject at startup (when running with a memory flow repository)")
     private File flowPath;
 
-    @CommandLine.Option(names = {"--worker-thread"}, description = "the number of worker threads, defaults to two times the number of available processors. Set it to 0 to avoid starting a worker.")
-    private int workerThread = defaultWorkerThread();
+    @CommandLine.Option(names = {"--worker-thread", "--worker-threads"}, description = "the number of worker threads, defaults to two times the number of available processors. Set it to 0 to avoid starting a worker.")
+    private int workerThreads = defaultWorkerThreads();
+
+    @CommandLine.Option(names = {"--worker-realtime-trigger-threads"}, description = "the max number of realtime trigger worker threads, defaults to -1 meaning unlimited")
+    private int workerRealtimeTriggerThreads = -1;
 
     @CommandLine.Option(names = {"--skip-executions"}, split=",", description = "a list of execution identifiers to skip, separated by a coma; for troubleshooting purpose only")
     private List<String> skipExecutions = Collections.emptyList();
@@ -99,10 +102,11 @@ public class StandAloneCommand extends AbstractServerCommand {
 
         StandAloneRunner standAloneRunner = applicationContext.getBean(StandAloneRunner.class);
 
-        if (this.workerThread == 0) {
+        if (this.workerThreads == 0) {
             standAloneRunner.setWorkerEnabled(false);
         } else {
-            standAloneRunner.setWorkerThread(this.workerThread);
+            standAloneRunner.setWorkerThreads(this.workerThreads);
+            standAloneRunner.setWorkerRealtimeTriggerThreads(workerRealtimeTriggerThreads);
         }
 
         standAloneRunner.run();

--- a/cli/src/main/java/io/kestra/cli/commands/servers/WorkerCommand.java
+++ b/cli/src/main/java/io/kestra/cli/commands/servers/WorkerCommand.java
@@ -24,8 +24,11 @@ public class WorkerCommand extends AbstractServerCommand {
     @Inject
     private ApplicationContext applicationContext;
 
-    @Option(names = {"-t", "--thread"}, description = "the max number of worker threads, defaults to two times the number of available processors")
-    private int thread = defaultWorkerThread();
+    @Option(names = {"-t", "--thread", "--threads"}, description = "the max number of worker threads, defaults to two times the number of available processors")
+    private int threads = defaultWorkerThreads();
+
+    @Option(names = {"-r", "--realtime-trigger-threads"}, description = "the max number of realtime trigger worker threads, defaults to -1 meaning unlimited")
+    private int realtimeTriggerThreads = -1;
 
     @Option(names = {"-g", "--worker-group"}, description = "the worker group key, must match the regex [a-zA-Z0-9_-]+ (EE only)")
     private String workerGroupKey = null;
@@ -45,18 +48,18 @@ public class WorkerCommand extends AbstractServerCommand {
             throw new IllegalArgumentException("The --worker-group option must match the [a-zA-Z0-9_-]+ pattern");
         }
 
-        // FIXME: For backward-compatibility with Kestra 0.15.x and earliest we still used UUID for Worker ID instead of IdUtils
+        // FIXME: For backward-compatibility with Kestra 0.15.x and earliest we still use UUID for Worker ID instead of IdUtils
         String workerID = UUID.randomUUID().toString();
-        Worker worker = applicationContext.createBean(Worker.class, workerID, this.thread, this.workerGroupKey);
+        Worker worker = applicationContext.createBean(Worker.class, workerID, this.threads, this.realtimeTriggerThreads, this.workerGroupKey);
         applicationContext.registerSingleton(worker);
 
         worker.run();
 
         if (this.workerGroupKey != null) {
-            log.info("Worker started with {} thread(s) in group '{}'", this.thread, this.workerGroupKey);
+            log.info("Worker started with {} thread(s) and {} realtime trigger thread(s) in group '{}'", this.threads, displayRealtimeTriggerThreads(realtimeTriggerThreads), this.workerGroupKey);
         }
         else {
-            log.info("Worker started with {} thread(s)", this.thread);
+            log.info("Worker started with {} thread(s) and {} realtime trigger thread(s)", displayRealtimeTriggerThreads(realtimeTriggerThreads), this.threads);
         }
 
         Await.until(() -> !this.applicationContext.isRunning());

--- a/core/src/main/java/io/kestra/core/metrics/MetricRegistry.java
+++ b/core/src/main/java/io/kestra/core/metrics/MetricRegistry.java
@@ -22,6 +22,8 @@ public class MetricRegistry {
     public final static String METRIC_WORKER_JOB_PENDING_COUNT = "worker.job.pending";
     public final static String METRIC_WORKER_JOB_RUNNING_COUNT = "worker.job.running";
     public final static String METRIC_WORKER_JOB_THREAD_COUNT = "worker.job.thread";
+    public final static String METRIC_WORKER_REALTIME_TRIGGER_THREAD_COUNT = "worker.realtimetrigger.thread";
+    public final static String METRIC_WORKER_REALTIME_TRIGGER_RUNNING_COUNT = "worker.realtimetrigger.running";
     public final static String METRIC_WORKER_RUNNING_COUNT = "worker.running.count";
     public final static String METRIC_WORKER_QUEUED_DURATION = "worker.queued.duration";
     public final static String METRIC_WORKER_STARTED_COUNT = "worker.started.count";

--- a/core/src/main/java/io/kestra/core/runners/RealtimeTriggerWorkerThreadPool.java
+++ b/core/src/main/java/io/kestra/core/runners/RealtimeTriggerWorkerThreadPool.java
@@ -1,0 +1,61 @@
+package io.kestra.core.runners;
+
+import io.kestra.core.metrics.MetricRegistry;
+import io.kestra.core.utils.ExecutorsUtils;
+
+import java.io.Serial;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * A thread pool based on virtual threads but with a limit on the number of threads used.
+ */
+class RealtimeTriggerWorkerThreadPool {
+    private final int maxThreads;
+    private final AtomicInteger count = new AtomicInteger();
+    private final ExecutorService executorService;
+
+    /**
+     * Create the virtual thread pool with the given ExecutorsUtils and maxThreads.
+     * If maxThreads is 0 or less, the pool will be unbounded.
+     */
+    RealtimeTriggerWorkerThreadPool(ExecutorsUtils executorUtils, int maxThreads) {
+        this.maxThreads = maxThreads;
+        this.executorService = executorUtils.newThreadPerTaskExecutor("worker-realtime-trigger");
+    }
+
+    void initMetrics(MetricRegistry metricRegistry, String[] tags) {
+        // create metrics to store thread count, pending jobs and running jobs, so we can have autoscaling easily
+        metricRegistry.gauge(MetricRegistry.METRIC_WORKER_REALTIME_TRIGGER_THREAD_COUNT, maxThreads, tags);
+        metricRegistry.gauge(MetricRegistry.METRIC_WORKER_REALTIME_TRIGGER_RUNNING_COUNT, count, tags);
+    }
+
+    /**
+     * Starts and forget a virtual thread with the runnable.
+     * It will maintain a count of running threads.
+     */
+    void startAndForget(Runnable runnable) throws ThreadPoolExcedeedException {
+        int actualTheadCount = count.incrementAndGet();
+        if (maxThreads > 0  && actualTheadCount > maxThreads) {
+            count.decrementAndGet();
+            throw new ThreadPoolExcedeedException("Unable to create a new worker thread for a realtime trigger: pool size exceeded (" + maxThreads + ")");
+        }
+
+        CompletableFuture.runAsync(runnable, executorService)
+            .whenComplete((ignored, exception) -> count.decrementAndGet());
+    }
+
+    void shutdown() {
+        this.executorService.shutdown();
+    }
+
+    static class ThreadPoolExcedeedException extends Exception {
+        @Serial
+        private static final long serialVersionUID = 1L;
+
+        public ThreadPoolExcedeedException(String message) {
+            super(message);
+        }
+    }
+}

--- a/core/src/main/java/io/kestra/core/runners/StandAloneRunner.java
+++ b/core/src/main/java/io/kestra/core/runners/StandAloneRunner.java
@@ -26,7 +26,8 @@ import java.util.concurrent.TimeoutException;
 @Requires(missingBeans = RunnerInterface.class)
 public class StandAloneRunner implements RunnerInterface, AutoCloseable {
     private ExecutorService poolExecutor;
-    @Setter protected int workerThread = Math.max(3, Runtime.getRuntime().availableProcessors());
+    @Setter protected int workerThreads = Math.max(3, Runtime.getRuntime().availableProcessors());
+    @Setter protected int workerRealtimeTriggerThreads = -1;
     @Setter protected boolean schedulerEnabled = true;
     @Setter protected boolean workerEnabled = true;
 
@@ -51,9 +52,9 @@ public class StandAloneRunner implements RunnerInterface, AutoCloseable {
         poolExecutor.execute(applicationContext.getBean(ExecutorInterface.class));
 
         if (workerEnabled) {
-            // FIXME: For backward-compatibility with Kestra 0.15.x and earliest we still used UUID for Worker ID instead of IdUtils
+            // FIXME: For backward-compatibility with Kestra 0.15.x and earliest we still use UUID for Worker ID instead of IdUtils
             String workerID = UUID.randomUUID().toString();
-            Worker worker = applicationContext.createBean(Worker.class, workerID, workerThread, null);
+            Worker worker = applicationContext.createBean(Worker.class, workerID, workerThreads, workerRealtimeTriggerThreads, null);
             applicationContext.registerSingleton(worker); //
             poolExecutor.execute(worker);
             servers.add(worker);

--- a/core/src/main/java/io/kestra/core/utils/ExecutorsUtils.java
+++ b/core/src/main/java/io/kestra/core/utils/ExecutorsUtils.java
@@ -71,6 +71,13 @@ public class ExecutorsUtils {
         );
     }
 
+    public ExecutorService newThreadPerTaskExecutor(String name) {
+        // TODO we cannot wrap it inside the ExecutorServiceMetrics.monitor as it is not supported yet.
+        return Executors.newThreadPerTaskExecutor(
+            threadFactoryBuilder.build(name + "_%d")
+        );
+    }
+
     private ExecutorService wrap(String name, ExecutorService executorService) {
         return ExecutorServiceMetrics.monitor(
             meterRegistry,

--- a/core/src/test/java/io/kestra/core/runners/TestMethodScopedWorker.java
+++ b/core/src/test/java/io/kestra/core/runners/TestMethodScopedWorker.java
@@ -24,7 +24,7 @@ public class TestMethodScopedWorker extends Worker {
                                   WorkerGroupService workerGroupService,
                                   ExecutorsUtils executorsUtils
     ) {
-        super(workerId, numThreads, workerGroupKey, eventPublisher, workerGroupService, executorsUtils);
+        super(workerId, numThreads, -1, workerGroupKey, eventPublisher, workerGroupService, executorsUtils);
     }
 
     /**

--- a/jdbc-postgres/src/main/java/io/kestra/runner/postgres/PostgresQueue.java
+++ b/jdbc-postgres/src/main/java/io/kestra/runner/postgres/PostgresQueue.java
@@ -134,7 +134,7 @@ public class PostgresQueue<T> extends JdbcQueue<T> {
                 try {
                     return Either.left(MAPPER.readValue(record.get("value", JSONB.class).data(), cls));
                 } catch (JsonProcessingException e) {
-                    return Either.right(new DeserializationException(e, record.get("value", String.class)));
+                    return Either.right(new DeserializationException(e, record.get("value", JSONB.class).data()));
                 }
             });
     }


### PR DESCRIPTION
This PR will dispatch the evaluation of realtime triggers to a virtual thread pool.
To protect against too many triggers running, it can be limited when launching the Worker via `--realtime-trigger-thread`, when the pool is exhausted the realtime trigger fail. By default the pool is unbounded.

For monitoring purpose, 2 new metrics has been created:
- worker.realtimetrigger.thread: the number of max threads to start for realtime triggers
- worker.realtimetrigger.running: the number of realtime triggers running in this worker