### PR TITLE
Reduced space when input has a long description

### DIFF
--- a/ui/src/components/layout/Markdown.vue
+++ b/ui/src/components/layout/Markdown.vue
@@ -185,13 +185,11 @@
             }
         }
     }
-    p {
-        line-height: 15px;
-    }
-
     .markdown-tooltip {
         *:last-child {
             margin-bottom: 0;
         }
+        line-height: 15px;
+        padding: 5px;
     }
 </style>

--- a/ui/src/components/layout/Markdown.vue
+++ b/ui/src/components/layout/Markdown.vue
@@ -185,6 +185,9 @@
             }
         }
     }
+    p {
+        line-height: 15px;
+    }
 
     .markdown-tooltip {
         *:last-child {


### PR DESCRIPTION
Reduced the space between the lines when the description is too long! #5336 
<img width="929" alt="Screenshot 2024-10-08 at 12 54 26 AM" src="https://github.com/user-attachments/assets/5a5ce941-8b02-4eef-a456-5415de42b1a7">


