### PR TITLE
fix(ui): add missing text for change status in executions overview and logs

### DIFF
--- a/ui/src/components/executions/ChangeExecutionStatus.vue
+++ b/ui/src/components/executions/ChangeExecutionStatus.vue
@@ -4,7 +4,7 @@
         :persistent="false"
         transition=""
         :hide-after="0"
-        :content="$t('change status tooltip')"
+        :content="$t('change state tooltip')"
         raw-content
         :placement="tooltipPosition"
     >
@@ -15,7 +15,7 @@
             :disabled="!enabled"
             class="ms-0 me-1"
         >
-            {{ $t('change status') }}
+            {{ $t('change state') }}
         </component>
     </el-tooltip>
 
@@ -25,7 +25,7 @@
         </template>
 
         <template #default>
-            <p v-html="$t('change execution status confirm', {id: execution.id})" />
+            <p v-html="$t('change execution state confirm', {id: execution.id})" />
 
             <p>
                 Current status is : <status size="small" class="me-1" :status="execution.state.current" />

--- a/ui/src/components/executions/ChangeStatus.vue
+++ b/ui/src/components/executions/ChangeStatus.vue
@@ -13,7 +13,7 @@
             </template>
 
             <template #default>
-                <p v-html="$t('change status confirm', {id: execution.id, task: taskRun.taskId})" />
+                <p v-html="$t('change state confirm', {id: execution.id, task: taskRun.taskId})" />
 
                 <p>
                     Current status is : <status size="small" class="me-1" :status="taskRun.state.current" />

--- a/ui/src/components/executions/Executions.vue
+++ b/ui/src/components/executions/Executions.vue
@@ -857,7 +857,7 @@
                 );
             },
             changeStatusToast() {
-                return this.$t("bulk change execution status", {"executionCount": this.queryBulkAction ? this.total : this.selection.length});
+                return this.$t("bulk change state", {"executionCount": this.queryBulkAction ? this.total : this.selection.length});
             },
             deleteExecutions() {
                 const includeNonTerminated = ref(false);


### PR DESCRIPTION
- This PR solves the issue #5268

- added missing translation text for change state in main executions page, execution overview and executions logs.

https://github.com/user-attachments/assets/9b4b7f99-79f7-44ef-81ee-78881b39a1d5

closes #5268

