### PR TITLE
chore(core, jdbc): refactor Worker with more immutability

### DIFF
--- a/core/src/main/java/io/kestra/core/runners/DefaultRunContext.java
+++ b/core/src/main/java/io/kestra/core/runners/DefaultRunContext.java
@@ -171,6 +171,7 @@ public class DefaultRunContext extends RunContext {
         runContext.metrics = new ArrayList<>();
         runContext.storage = this.storage;
         runContext.pluginConfiguration = this.pluginConfiguration;
+        runContext.secretInputs = this.secretInputs;
         if (this.isInitialized.get()) {
             //Inject all services
             runContext.init(applicationContext);

--- a/core/src/main/java/io/kestra/core/runners/WorkerTask.java
+++ b/core/src/main/java/io/kestra/core/runners/WorkerTask.java
@@ -51,8 +51,8 @@ public class WorkerTask extends WorkerJob {
      *
      * @return this worker task, updated
      */
-    public WorkerTask fail() {
+    public TaskRun fail() {
         var state = this.task.isAllowFailure() ? State.Type.WARNING : State.Type.FAILED;
-        return this.withTaskRun(this.getTaskRun().withState(state));
+        return this.getTaskRun().withState(state);
     }
 }

--- a/core/src/main/java/io/kestra/core/runners/WorkerTaskResult.java
+++ b/core/src/main/java/io/kestra/core/runners/WorkerTaskResult.java
@@ -8,7 +8,7 @@ import lombok.Value;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Collectors;
+
 import jakarta.validation.constraints.NotNull;
 
 @Value
@@ -23,19 +23,6 @@ public class WorkerTaskResult implements HasUID {
     public WorkerTaskResult(TaskRun taskRun) {
         this.taskRun = taskRun;
         this.dynamicTaskRuns = new ArrayList<>();
-    }
-
-    public WorkerTaskResult(WorkerTask workerTask) {
-        this.taskRun = workerTask.getTaskRun();
-        this.dynamicTaskRuns = new ArrayList<>();
-    }
-
-    public WorkerTaskResult(WorkerTask workerTask, List<WorkerTaskResult> dynamicWorkerResults) {
-        this.taskRun = workerTask.getTaskRun();
-        this.dynamicTaskRuns = dynamicWorkerResults
-            .stream()
-            .map(WorkerTaskResult::getTaskRun)
-            .toList();
     }
 
     /**

--- a/jdbc/src/main/java/io/kestra/jdbc/runner/JdbcExecutor.java
+++ b/jdbc/src/main/java/io/kestra/jdbc/runner/JdbcExecutor.java
@@ -434,7 +434,7 @@ public class JdbcExecutor implements ExecutorInterface, Service {
                     workerTasksDedup
                         .stream()
                         .filter(workerTask -> workerTask.getTask().isFlowable())
-                        .map(workerTask -> new WorkerTaskResult(workerTask.withTaskRun(workerTask.getTaskRun().withState(State.Type.RUNNING))))
+                        .map(workerTask -> new WorkerTaskResult(workerTask.getTaskRun().withState(State.Type.RUNNING)))
                         .forEach(throwConsumer(workerTaskResult -> workerTaskResultQueue.emit(workerTaskResult)));
                 }
 


### PR DESCRIPTION
Avoid mutating the WorkerTask inside the worker, thanks to that we can avoid serialization/deserialization steps for cleanup transient that can eat up more than 15% of CPU time in the Worker on contrived benchmarks.
