### PR TITLE
Topology view modification overwrites the flow without Saving it

### DIFF
--- a/ui/src/stores/flow.js
+++ b/ui/src/stores/flow.js
@@ -25,7 +25,8 @@ export default {
         metrics: [],
         aggregatedMetrics: undefined,
         tasksWithMetrics: [],
-        executeFlow: false
+        executeFlow: false,
+        lastSaveFlow: undefined
     },
 
     actions: {
@@ -313,6 +314,7 @@ export default {
         },
         setFlow(state, flow) {
             state.flow = flow;
+            state.lastSaveFlow = flow;
             // if (state.flowGraph !== undefined && state.flowGraphParam && flow) {
             //     if (state.flowGraphParam.namespace !== flow.namespace || state.flowGraphParam.id !== flow.id) {
             //         state.flowGraph = undefined
@@ -389,6 +391,11 @@ export default {
         }
     },
     getters: {
+        lastSaveFlow(state){
+            if(state.lastSavedFlow){
+                return state.lastSavedFlow;
+            }
+        },
         flow(state) {
             if (state.flow) {
                 return state.flow;

--- a/ui/src/utils/unsavedChange.js
+++ b/ui/src/utils/unsavedChange.js
@@ -11,6 +11,13 @@ export default (app, store, router) => {
     router.beforeEach(async () => {
         if (store.getters["core/unsavedChange"]) {
             if (confirm(confirmationMessage)) {
+                 store.commit("editor/changeOpenedTabs", {
+                     action: "dirty",
+                     name: "Flow",
+                     path: "Flow.yaml",
+                     dirty: false,
+                });
+                store.commit("flow/setFlow", store.getters["flow/lastSavedFlow"]);
                 store.commit("core/setUnsavedChange", false);
             } else {
                 return false;


### PR DESCRIPTION
- This PR fixes issue of unsaved flow overwrite while editing in `Sourcecode` and `Topology` view during tab change.

### What changes are being made and why?

- Added `lastSavedFlow` in `flow.js` so we can keep track of last saved flow.
- Added code in `unsavedChanges.js` to set flow value to last saved flow if changes are not saved.

outcome:
https://github.com/user-attachments/assets/04d9e6e9-3492-4627-b46a-2c56f76473e9

Relates to #5137.

