### PR TITLE
feat(core): create namespace file dir when uploading new files

### DIFF
--- a/webserver/src/main/java/io/kestra/webserver/controllers/api/NamespaceFileController.java
+++ b/webserver/src/main/java/io/kestra/webserver/controllers/api/NamespaceFileController.java
@@ -159,6 +159,10 @@ public class NamespaceFileController {
                 ZipEntry entry;
                 while ((entry = archive.getNextEntry()) != null) {
                     if (entry.isDirectory()) {
+                        String directory = entry.getName();
+                        if (forbiddenPathPatterns.stream().noneMatch(pattern -> pattern.matcher(directory).matches())) {
+                            createDirectory(namespace, directory);
+                        }
                         continue;
                     }
 
@@ -166,7 +170,14 @@ public class NamespaceFileController {
                 }
             }
         } else {
-            try(BufferedInputStream inputStream = new BufferedInputStream(fileContent.getInputStream()) {
+            if (path.lastIndexOf('/') > 0) {
+                String directory = path.substring(0, path.lastIndexOf('/'));
+                if (forbiddenPathPatterns.stream().noneMatch(pattern -> pattern.matcher(directory).matches())) {
+                    createDirectory(namespace, directory);
+                }
+            }
+
+            try (BufferedInputStream inputStream = new BufferedInputStream(fileContent.getInputStream()) {
                 // Done to bypass the wrong available() output of the CompletedFileUpload InputStream
                 @Override
                 public synchronized int available() {


### PR DESCRIPTION
This allows to avoid having to do it when we put the file.

On a contrived example, when using ForEachItem with 1000 subflows, which means 1000 files uploaded by the split, flow execution time for MinIO goes down from 5mn to 2mn y avoiding a call to create the directory if not exist which was done systematically before.

See the following PRs on the storage:
https://github.com/kestra-io/storage-s3/pull/114
https://github.com/kestra-io/storage-azure/pull/61
https://github.com/kestra-io/storage-gcs/pull/142
https://github.com/kestra-io/storage-minio/pull/93

Fixes https://github.com/kestra-io/kestra/issues/5354