### PR TITLE
Pre-fill namespace from current filter

### DIFF
--- a/ui/src/components/flows/FlowCreate.vue
+++ b/ui/src/components/flows/FlowCreate.vue
@@ -62,8 +62,9 @@
                 } else if (this.$route.query.blueprintId && this.$route.query.blueprintSource) {
                     this.source = await this.queryBlueprint(this.$route.query.blueprintId)
                 } else {
+                    const selectedNamespace = this.$route.query.namespace || "company.team";
                     this.source = `id: myflow
-namespace: company.team
+namespace: ${selectedNamespace}
 tasks:
   - id: hello
     type: io.kestra.plugin.core.log.Log

--- a/ui/src/components/flows/Flows.vue
+++ b/ui/src/components/flows/Flows.vue
@@ -27,7 +27,7 @@
                     </router-link>
                 </li>
                 <li>
-                    <router-link :to="{name: 'flows/create'}" v-if="canCreate">
+                    <router-link :to="{name: 'flows/create', query: {namespace: $route.query.namespace}}" v-if="canCreate">
                         <el-button :icon="Plus" type="primary">
                             {{ $t('create') }}
                         </el-button>


### PR DESCRIPTION
Pre-fill the namespace in the "Create Flow" page using the selected namespace from the Flow page's query parameters - closes #4863 

https://github.com/user-attachments/assets/bbbdb6c5-d5f9-4f8d-a213-391d1770e836

