### PR TITLE
feat(ui): allow searching read-only editor inputs

### DIFF
--- a/ui/src/components/inputs/Editor.vue
+++ b/ui/src/components/inputs/Editor.vue
@@ -284,9 +284,12 @@
                 })
 
                 if (this.input) {
-                    this.editor.addCommand(KeyMod.CtrlCmd | KeyCode.KeyF, () => {});
                     this.editor.addCommand(KeyMod.CtrlCmd | KeyCode.KeyH, () => {});
                     this.editor.addCommand(KeyCode.F1, () => {});
+
+                    if (!this.readOnly) {
+                        this.editor.addCommand(KeyMod.CtrlCmd | KeyCode.KeyF, () => { });
+                    }
                 }
 
                 if (this.original === undefined && this.navbar && this.fullHeight) {
@@ -332,7 +335,7 @@
 
                 if (!this.fullHeight) {
                     editor.onDidContentSizeChange(e => {
-                        if(!this.$refs.container) return;                    
+                        if(!this.$refs.container) return;
                         this.$refs.container.style.height = (e.contentHeight + this.customHeight) + "px";
                     });
                 }


### PR DESCRIPTION
### What changes are being made and why?

Enablement of searching read-only editor is intended mainly for the file preview (execution `FILE` inputs/outputs). This change allows users to easily search previewed files.

---

### How the changes have been QAed?

```yaml
id: myflow-with-file
namespace: dev

inputs:
  - id: file
    type: FILE
  - id: str
    type: STRING

tasks:
  - id: hello
    type: io.kestra.plugin.core.log.Log
    message: Hello World! 🚀
```


