### PR TITLE
fix(ui): prevent tab title change on cancelling unsaved changes confirmation

### DIFF
--- a/ui/src/components/Tabs.vue
+++ b/ui/src/components/Tabs.vue
@@ -138,6 +138,7 @@
             },
             to(tab) {
                 if (this.activeTab === tab) {
+                    this.setActiveName()
                     return this.$route;
                 } else {
                     return {


### PR DESCRIPTION
- This PR solves the issue #1571 

- The issue was that when we changed the tab with unsaved changes in the editor, we received an unsaved changes confirmation, and when we clicked 'Cancel,' the **activeName** value still updated, even though there was no route change.
-So, to handle this set the **activeName** when there is no route change.


https://github.com/user-attachments/assets/e3fe63dd-6b86-49ea-9309-04a04b012ccf

closes #1571 




