### PR TITLE
feat(core): allow dynamic properties for Split and ForEachItem

### DIFF
--- a/core/src/main/java/io/kestra/core/runners/DefaultRunContext.java
+++ b/core/src/main/java/io/kestra/core/runners/DefaultRunContext.java
@@ -7,6 +7,7 @@ import com.google.common.collect.ImmutableMap;
 import io.kestra.core.exceptions.IllegalVariableEvaluationException;
 import io.kestra.core.metrics.MetricRegistry;
 import io.kestra.core.models.executions.AbstractMetricEntry;
+import io.kestra.core.models.property.Property;
 import io.kestra.core.services.KVStoreService;
 import io.kestra.core.storages.Storage;
 import io.kestra.core.storages.StorageInterface;
@@ -202,6 +203,16 @@ public class DefaultRunContext extends RunContext {
     @SuppressWarnings("unchecked")
     public String render(String inline, Map<String, Object> variables) throws IllegalVariableEvaluationException {
         return variableRenderer.render(inline, mergeWithNullableValues(this.variables, variables));
+    }
+
+    @Override
+    public <T> T render(Property<T> inline, Class<T> clazz) throws IllegalVariableEvaluationException {
+        return inline == null ? null : inline.as(this, clazz);
+    }
+
+    @Override
+    public <T> T render(Property<T> inline, Class<T> clazz, Map<String, Object> variables) throws IllegalVariableEvaluationException {
+        return inline == null ? null : inline.as(this, clazz, variables);
     }
 
     /**

--- a/core/src/main/java/io/kestra/core/runners/RunContext.java
+++ b/core/src/main/java/io/kestra/core/runners/RunContext.java
@@ -6,6 +6,7 @@ import io.kestra.core.encryption.EncryptionService;
 import io.kestra.core.exceptions.IllegalVariableEvaluationException;
 import io.kestra.core.exceptions.ResourceExpiredException;
 import io.kestra.core.models.executions.AbstractMetricEntry;
+import io.kestra.core.models.property.Property;
 import io.kestra.core.storages.StateStore;
 import io.kestra.core.storages.Storage;
 import io.kestra.core.storages.kv.KVStore;
@@ -58,6 +59,10 @@ public abstract class RunContext {
     public abstract Object renderTyped(String inline) throws IllegalVariableEvaluationException;
 
     public abstract String render(String inline, Map<String, Object> variables) throws IllegalVariableEvaluationException;
+
+    public abstract <T> T render(Property<T> inline, Class<T> clazz) throws IllegalVariableEvaluationException;
+
+    public abstract <T> T  render(Property<T> inline, Class<T> clazz, Map<String, Object> variables) throws IllegalVariableEvaluationException;
 
     public abstract List<String> render(List<String> inline) throws IllegalVariableEvaluationException;
 

--- a/core/src/main/java/io/kestra/core/storages/StorageSplitInterface.java
+++ b/core/src/main/java/io/kestra/core/storages/StorageSplitInterface.java
@@ -1,32 +1,7 @@
 package io.kestra.core.storages;
 
-import com.google.common.base.Charsets;
-import com.google.common.hash.Hashing;
-import io.kestra.core.annotations.Retryable;
-import io.kestra.core.models.annotations.PluginProperty;
-import io.kestra.core.models.executions.Execution;
-import io.kestra.core.models.executions.TaskRun;
-import io.kestra.core.models.flows.Flow;
-import io.kestra.core.models.flows.Input;
-import io.kestra.core.models.tasks.Task;
-import io.kestra.core.models.triggers.AbstractTrigger;
-import io.kestra.core.models.triggers.TriggerContext;
-import io.kestra.core.utils.Slugify;
-import io.micronaut.core.annotation.Introspected;
-import io.micronaut.core.annotation.Nullable;
+import io.kestra.core.models.property.Property;
 import io.swagger.v3.oas.annotations.media.Schema;
-import lombok.Builder;
-
-import java.io.*;
-import java.net.URI;
-import java.net.URISyntaxException;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Optional;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 
 public interface StorageSplitInterface {
     @Schema(
@@ -34,25 +9,21 @@ public interface StorageSplitInterface {
         description = "Can be provided as a string in the format \"10MB\" or \"200KB\", or the number of bytes. " +
             "This allows you to process large files, slit them into smaller chunks by lines and process them in parallel. For example, MySQL by default limits the size of a query size to 16MB per query. Trying to use a bulk insert query with input data larger than 16MB will fail. Splitting the input data into smaller chunks is a common strategy to circumvent this limitation. By dividing a large data set into chunks smaller than the `max_allowed_packet` size (e.g., 10MB), you can insert the data in multiple smaller queries. This approach not only helps to avoid hitting the query size limit but can also be more efficient and manageable in terms of memory utilization, especially for very large datasets. In short, by splitting the file by bytes, you can bulk-insert smaller chunks of e.g. 10MB in parallel to avoid this limitation."
     )
-    @PluginProperty(dynamic = true)
-    String getBytes();
+    Property<String> getBytes();
 
     @Schema(
         title = "Split a file into a fixed number of partitioned files. For example, if you have a file with 1000 lines and you set `partitions` to 10, the file will be split into 10 files with 100 lines each."
     )
-    @PluginProperty(dynamic = true)
-    Integer getPartitions();
+    Property<Integer> getPartitions();
 
     @Schema(
         title = "A number of rows per batch. The file will then be split into chunks with that maximum number of rows."
     )
-    @PluginProperty(dynamic = true)
-    Integer getRows();
+    Property<Integer> getRows();
 
     @Schema(
         title = "The separator used to split a file into chunks. By default, it's a newline `\\n` character. If you are on Windows, you might want to use `\\r\\n` instead.",
         defaultValue = "\\n"
     )
-    @PluginProperty
-    String getSeparator();
+    Property<String> getSeparator();
 }

--- a/core/src/main/java/io/kestra/plugin/core/flow/ForEachItem.java
+++ b/core/src/main/java/io/kestra/plugin/core/flow/ForEachItem.java
@@ -622,15 +622,15 @@ public class ForEachItem extends Task implements FlowableTask<VoidOutput>, Child
     @Getter
     @NoArgsConstructor
     public static class Batch implements StorageSplitInterface {
-        private String bytes;
+        private Property<String> bytes;
 
-        private Integer partitions;
-
-        @Builder.Default
-        private Integer rows = 1;
+        private Property<Integer> partitions;
 
         @Builder.Default
-        private String separator = "\n";
+        private Property<Integer> rows = Property.of(1);
+
+        @Builder.Default
+        private Property<String> separator = Property.of("\n");
     }
 
     @Builder

--- a/core/src/main/java/io/kestra/plugin/core/storage/Split.java
+++ b/core/src/main/java/io/kestra/plugin/core/storage/Split.java
@@ -3,6 +3,7 @@ package io.kestra.plugin.core.storage;
 import io.kestra.core.models.annotations.Example;
 import io.kestra.core.models.annotations.Plugin;
 import io.kestra.core.models.annotations.PluginProperty;
+import io.kestra.core.models.property.Property;
 import io.kestra.core.models.tasks.RunnableTask;
 import io.kestra.core.models.tasks.Task;
 import io.kestra.core.runners.RunContext;
@@ -58,14 +59,14 @@ public class Split extends Task implements RunnableTask<Split.Output>, StorageSp
     @NotNull
     private String from;
 
-    private String bytes;
+    private Property<String> bytes;
 
-    private Integer partitions;
+    private Property<Integer> partitions;
 
-    private Integer rows;
+    private Property<Integer> rows;
 
     @Builder.Default
-    private String separator = "\n";
+    private Property<String> separator = Property.of("\n");
 
     @Override
     public Split.Output run(RunContext runContext) throws Exception {

--- a/core/src/test/java/io/kestra/plugin/core/flow/ForEachItemCaseTest.java
+++ b/core/src/test/java/io/kestra/plugin/core/flow/ForEachItemCaseTest.java
@@ -74,7 +74,7 @@ public class ForEachItemCaseTest {
         });
 
         URI file = storageUpload();
-        Map<String, Object> inputs = Map.of("file", file.toString());
+        Map<String, Object> inputs = Map.of("file", file.toString(), "batch", 4);
         Execution execution = runnerUtils.runOne(null, TEST_NAMESPACE, "for-each-item", null,
             (flow, execution1) -> flowIO.readExecutionInputs(flow, execution1, inputs),
             Duration.ofSeconds(30));
@@ -105,7 +105,7 @@ public class ForEachItemCaseTest {
 
     public void forEachItemEmptyItems() throws TimeoutException, URISyntaxException, IOException, QueueException {
         URI file = emptyItems();
-        Map<String, Object> inputs = Map.of("file", file.toString());
+        Map<String, Object> inputs = Map.of("file", file.toString(), "batch", 4);
         Execution execution = runnerUtils.runOne(null, TEST_NAMESPACE, "for-each-item", null,
             (flow, execution1) -> flowIO.readExecutionInputs(flow, execution1, inputs),
             Duration.ofSeconds(30));

--- a/core/src/test/java/io/kestra/plugin/core/storage/SplitTest.java
+++ b/core/src/test/java/io/kestra/plugin/core/storage/SplitTest.java
@@ -1,6 +1,7 @@
 package io.kestra.plugin.core.storage;
 
 import com.google.common.io.CharStreams;
+import io.kestra.core.models.property.Property;
 import io.kestra.core.runners.RunContext;
 import io.kestra.core.runners.RunContextFactory;
 import io.kestra.core.storages.StorageInterface;
@@ -40,7 +41,7 @@ class SplitTest {
 
         Split result = Split.builder()
             .from(put.toString())
-            .partitions(8)
+            .partitions(Property.of(8))
             .build();
 
         Split.Output run = result.run(runContext);
@@ -57,7 +58,7 @@ class SplitTest {
 
         Split result = Split.builder()
             .from(put.toString())
-            .rows(10)
+            .rows(Property.of(10))
             .build();
 
         Split.Output run = result.run(runContext);
@@ -73,7 +74,7 @@ class SplitTest {
 
         Split result = Split.builder()
             .from(put.toString())
-            .bytes("1KB")
+            .bytes(Property.of("1KB"))
             .build();
 
         Split.Output run = result.run(runContext);

--- a/core/src/test/resources/flows/valids/for-each-item.yaml
+++ b/core/src/test/resources/flows/valids/for-each-item.yaml
@@ -4,13 +4,15 @@ namespace: io.kestra.tests
 inputs:
   - id: file
     type: FILE
+  - id: batch
+    type: INT
 
 tasks:
   - id: each
     type: io.kestra.plugin.core.flow.ForEachItem
     items: "{{ inputs.file }}"
     batch:
-      rows: 4
+      rows: "{{inputs.batch}}"
     namespace: io.kestra.tests
     flowId: for-each-item-subflow
     wait: true


### PR DESCRIPTION
Fixes #5442

You can now define the following flow:

```yaml
id: for-each
namespace: company.team

inputs:
  - id: file
    type: FILE
  - id: batch 
    type: INT

tasks:
  - id: for-each
    type: io.kestra.plugin.core.flow.ForEachItem
    items: "{{inputs.file}}"
    batch:
      rows: "{{inputs.batch}}"
    namespace: company.team
    flowId: for-each-item
    inputs:
      file: "{{taskrun.items}}"
```
