### PR TITLE
fix(ui): hide pagination when no flows results data available

### DIFF
--- a/ui/src/components/flows/FlowsSearch.vue
+++ b/ui/src/components/flows/FlowsSearch.vue
@@ -115,6 +115,7 @@
                         })
                         .finally(callback)
                 } else {
+                    this.$store.commit("flow/setTotal", 0);
                     this.$store.commit("flow/setSearch", undefined);
                     callback();
                 }


### PR DESCRIPTION
- This PR solves the issue #4841 

- The issue was when we search and retrieve the flow data, then clear the search, the paginated items are still displayed.

https://github.com/user-attachments/assets/3868f296-923a-45df-8e02-fe02ee420260

closes #4841 

