### PR TITLE
fix(logs): persist logs when navigating back to Logs page (#5469)

### DIFF
--- a/ui/src/components/logs/LogsWrapper.vue
+++ b/ui/src/components/logs/LogsWrapper.vue
@@ -245,7 +245,7 @@
             },
             load() {
                 this.isLoading = true
-
+                
                 // eslint-disable-next-line no-unused-vars
                 const data = {
                     page: this.filters ? this.internalPageNumber : this.$route.query.page || this.internalPageNumber,
@@ -270,7 +270,7 @@
                 this.$store
                     .dispatch("stat/logDaily", this.loadQuery({
                         startDate: this.$moment(this.startDate).toISOString(true),
-                        endDate: this.$moment(this.endDate).toISOString(true)
+                        endDate: this.$moment(this.endDate + 1).toISOString(true)
                     }, true))
                     .then(() => {
                         this.statsReady = true;


### PR DESCRIPTION
### What changes are being made and why?

This PR resolves issue #5469, where logs were disappearing when navigating back to the Logs page. The issue was caused by an error in the filtering logic, which excluded the current day from the logs.

**Fix:**
- The filtering logic was updated to ensure that the current day is included in the logs when navigating back to the Logs page.

**Closes #5469.**

---

### How have the changes been QAed?

The changes were manually tested by navigating between different pages and back to the Logs page to confirm that logs from the current day are now correctly displayed. A video demonstrating the fix is included below:

![Logs Persistence Demo](url-to-video)

https://github.com/user-attachments/assets/5a8497fe-3fa5-455f-a698-cc5037f44bb3

---

### Setup Instructions

No additional setup is required. The changes are universally applied across environments where the Logs page is used.
