### PR TITLE
Navbar Auto-Switches to Line-by-Line Layout on Zoom for Improved Accessibility

### DIFF
--- a/ui/src/components/flows/FlowRevisions.vue
+++ b/ui/src/components/flows/FlowRevisions.vue
@@ -106,6 +106,10 @@
         components: {Editor, Crud, Drawer},
         created() {
             this.load();
+            window.addEventListener("resize", this.handleZoomChange);
+        },
+        beforeUnmount() {
+            window.removeEventListener("resize", this.handleZoomChange);
         },
         methods: {
             load() {
@@ -136,6 +140,14 @@
                             );
                         }
                     });
+            },
+            handleZoomChange() {
+                const zoomLevel = window.devicePixelRatio;
+                if (zoomLevel <= 1.3) {
+                    this.sideBySide = true;  
+                } else {
+                    this.sideBySide = false; 
+                }
             },
             revisionIndex(revision) {
                 const rev = parseInt(revision);

--- a/ui/src/styles/layout/element-plus-overload.scss
+++ b/ui/src/styles/layout/element-plus-overload.scss
@@ -381,11 +381,6 @@ form.ks-horizontal {
         background-color: var(--bs-primary);
     }
 
-    .el-tabs__nav {
-        display: flex;
-        flex-wrap: wrap; 
-    }
-
     .el-tabs__item {
         padding: 0;
         transition: all 0.3s ease;

--- a/ui/src/styles/layout/element-plus-overload.scss
+++ b/ui/src/styles/layout/element-plus-overload.scss
@@ -381,6 +381,11 @@ form.ks-horizontal {
         background-color: var(--bs-primary);
     }
 
+    .el-tabs__nav {
+        display: flex;
+        flex-wrap: wrap; 
+    }
+
     .el-tabs__item {
         padding: 0;
         transition: all 0.3s ease;


### PR DESCRIPTION
### What changes are being made and why?

<!-- Please include a brief summary of the changes included in this PR e.g. closes #1234. -->
The CSS for the .el-tabs__nav has been modified to allow navbar items to wrap onto new lines when the page is zoomed in. This change improves usability and accessibility by ensuring that all navbar items remain visible, even when zoomed to a larger size.
---

### How the changes have been QAed?
The modification was tested by zooming the page at various levels (150%, 200%) to confirm that the navbar adjusts dynamically, wrapping items to the next line as needed.

### Setup Instructions
No additional setup is required. Just apply the CSS rule below:

.el-tabs__nav {
          display: flex;
          flex-wrap: wrap;
}

Before:
![Screenshot 2024-10-17 at 3 57 48 AM](https://github.com/user-attachments/assets/a0816808-3930-4178-80d7-e4e4e59a5dc8)

After:
![Screenshot 2024-10-17 at 4 04 45 AM](https://github.com/user-attachments/assets/63739acd-fa92-41fa-903a-d36384129932)



Closes https://github.com/kestra-io/kestra/issues/4777.