### PR TITLE
Fix: Added non-breaking space for button spacing in VarValue

### DIFF
--- a/ui/src/components/executions/VarValue.vue
+++ b/ui/src/components/executions/VarValue.vue
@@ -12,9 +12,9 @@
 
     <el-button-group v-else-if="isURI(value)">
         <a class="el-button el-button--small el-button--primary" :href="value" target="_blank">
-            <OpenInNew />
+            <OpenInNew /> &nbsp;
             {{ $t('open') }}
-        </a>        
+        </a>
     </el-button-group>
 
     <span v-else-if="value === null">


### PR DESCRIPTION
<!-- Thanks for submitting a Pull Request to Kestra. To help us review your contribution, please follow the guidelines below:

- Make sure that your commits follow the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) specification e.g. `feat(ui): add a new navigation menu item` or `fix(core): fix a bug in the core model` or `docs: update the README.md`. This will help us automatically generate the changelog.
- The title should briefly summarize the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share a flow example to help the reviewer understand and QA the change.
- Use "closes" to automatically close an issue. For example, `closes #1234` will close issue #1234. -->

### What changes are being made and why?

<!-- Please include a brief summary of the changes included in this PR e.g. closes #1234. -->

This PR adds a non-breaking space (&nbsp;) between the “Open” button’s icon (<OpenInNew />) and the text {{ $t('open') }} in the  kestra/ui/src/components/executions/VarValue.vue file. This change ensures better spacing between the icon and the text when rendering URLs.

Closes #5493

### How the changes have been QAed?
I verified this change locally by running the Kestra project and observing the updated spacing between the icon and text in the UI when the button is rendered for URLs.

<!-- Include example code that shows how this PR has been QAed. The code should present a complete yet easily reproducible flow.

```yaml
# Your example flow code here
```

Note that this is not a replacement for unit tests but rather a way to demonstrate how the changes work in a real-life scenario, as the end-user would experience them.

Remove this section if this change applies to all flows or to the documentation only. -->

---

### Setup Instructions

<!--If there are any setup requirements like API keys or trial accounts, kindly include brief bullet-points-description outlining the setup process below.

- [External System Documentation](URL)
- Steps to set up the necessary resources

If there are no setup requirements, you can remove this section.

Thank you for your contribution. ❤️  -->
