### PR TITLE
Added Sync with system theme option in settings

### DIFF
--- a/ui/src/components/settings/BasicSettings.vue
+++ b/ui/src/components/settings/BasicSettings.vue
@@ -310,6 +310,11 @@
                 this.theme = value;
                 this.$toast().saved(this.$t("settings.label"), undefined, {multiple: true});
             },
+            updateThemeBasedOnSystem() {
+                if (this.theme === "syncWithSystem") {
+                    Utils.switchTheme("syncWithSystem");
+                }
+            },
             onDateFormat(value) {
                 localStorage.setItem(DATE_FORMAT_STORAGE_KEY, value);
                 this.dateFormat = value;
@@ -386,6 +391,10 @@
                 this.$toast().saved(this.$t("settings.label"), undefined, {multiple: true});
             }
         },
+        mounted() {
+            const mediaQuery = window.matchMedia("(prefers-color-scheme: dark)");
+            mediaQuery.addEventListener("change", this.updateThemeBasedOnSystem);
+        },
         computed: {
             ...mapState("auth", ["user"]),
             ...mapGetters("misc", ["configs"]),
@@ -413,7 +422,8 @@
             themesOptions() {
                 return [
                     {value: "light", text: "Light"},
-                    {value: "dark", text: "Dark"}
+                    {value: "dark", text: "Dark"},
+                    {value: "syncWithSystem", text: "Sync With System"}
                 ]
             },
             editorThemesOptions() {

--- a/ui/src/utils/utils.js
+++ b/ui/src/utils/utils.js
@@ -183,13 +183,25 @@ export default class Utils {
         // class name
         let htmlClass = document.getElementsByTagName("html")[0].classList;
 
-        htmlClass.forEach((cls) => {
-            if (cls === "dark" || cls === "light") {
+        function removeClasses() 
+        {
+            htmlClass.forEach((cls) => {
+            if (cls === "dark" || cls === "light" || cls === "syncWithSystem") {
                 htmlClass.remove(cls);
             }
-        })
+            })
+        }
+        removeClasses();
 
-        htmlClass.add(theme);
+        if(theme === "syncWithSystem") {
+            removeClasses();
+            const systemTheme = window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
+            htmlClass.add(theme, systemTheme);
+        }
+        else {
+            removeClasses();
+            htmlClass.add(theme);
+        }
         localStorage.setItem("theme", theme);
     }
 


### PR DESCRIPTION
This PR helps in selecting the new "Sync with System" option to fetch system's theme and apply it to the overall app. Closes #1949 

### What changes are being made and why?

BasicSettings.vue: Added an event listener in Settings to detect system theme changes (light/dark mode) and apply the appropriate theme accordingly. (Note: This works dynamically only on Settings page, otherwise the corresponding page needs a refresh after changing one's system theme)
utils.js: Added functionality to modify the html class list, specifically adding or removing the syncWithSystem class based on system theme synchronization.

![image](https://github.com/user-attachments/assets/27b7130e-2230-427e-a237-007c5d9dd2a6)


### How the changes have been QAed?
1. Syncing with System Theme:
    - Code Path: In BasicSettings.vue, if the user selects the "sync with system" theme option, the updateThemeBasedOnSystem method listens for system theme changes (via window.matchMedia) and updates the UI accordingly. 
    - Test: Change the system theme from light to dark (and vice versa) while the app is running, and verify that the theme updates without a refresh on Settings page.
2. Manual Theme Selection:
    - Code Path: The Utils.switchTheme method allows users to manually select between light, dark, and system-synced modes. This method saves the preference in localStorage and applies the correct CSS classes (dark, light, or syncWithSystem) to the <html> element. 
    -  Test: Verify that the theme is saved in localStorage and is applied on page reload, and that the correct classes are added/removed from the html tag.

```
In the localStorage it should be displayed as
{theme: syncWithSystem}

In the index HTML classList, it should be either 
class="syncWithSystem dark" 
(or)
class="syncWithSystem light" 
```

