### PR TITLE
feat(docs): improve `warningOnStdErr` info clarity

### DIFF
--- a/script/src/main/java/io/kestra/plugin/scripts/exec/AbstractExecScript.java
+++ b/script/src/main/java/io/kestra/plugin/scripts/exec/AbstractExecScript.java
@@ -67,7 +67,8 @@ public abstract class AbstractExecScript extends Task implements RunnableTask<Sc
 
     @Builder.Default
     @Schema(
-        title = "Whether to set the task state to `WARNING` if any `stdErr` is emitted."
+        title = "Whether to set the task state to `WARNING` when any `stdErr` output is detected.",
+        description = "Note that a script error will set the state to `FAILED` regardless."
     )
     @PluginProperty
     @NotNull


### PR DESCRIPTION
### What changes are being made and why?

The original description of the `warningOnStdErr` property might have suggested it affected even the `FAILED` state.