### PR TITLE
Feat/system labels

### DIFF
--- a/core/src/main/java/io/kestra/core/models/Label.java
+++ b/core/src/main/java/io/kestra/core/models/Label.java
@@ -4,4 +4,9 @@ import jakarta.validation.constraints.NotNull;
 
 public record Label(@NotNull String key, @NotNull String value) {
     public static final String SYSTEM_PREFIX = "system_";
+
+    // system labels
+    public static final String CORRELATION_ID = SYSTEM_PREFIX + "correlationId";
+    public static final String USERNAME = SYSTEM_PREFIX + "username";
+    public static final String APP = SYSTEM_PREFIX + "app";
 }

--- a/core/src/main/java/io/kestra/core/models/Label.java
+++ b/core/src/main/java/io/kestra/core/models/Label.java
@@ -2,4 +2,6 @@ package io.kestra.core.models;
 
 import jakarta.validation.constraints.NotNull;
 
-public record Label(@NotNull String key, @NotNull String value) {}
+public record Label(@NotNull String key, @NotNull String value) {
+    public static final String SYSTEM_PREFIX = "system_";
+}

--- a/core/src/main/java/io/kestra/core/models/executions/Execution.java
+++ b/core/src/main/java/io/kestra/core/models/executions/Execution.java
@@ -212,6 +212,10 @@ public class Execution implements DeletedInterface, TenantInterface {
         );
     }
 
+    /**
+     * This method replaces labels with new ones.
+     * It refuses system labels as they must be passed via the withSystemLabels method.
+     */
     public Execution withLabels(List<Label> labels) {
         checkForSystemLabels(labels);
 
@@ -246,7 +250,15 @@ public class Execution implements DeletedInterface, TenantInterface {
         }
     }
 
+    /**
+     * This method in <b>only to be used</b> to add system labels to an execution.
+     * It will not replace exisiting labels but add new one (possibly duplicating).
+     */
     public Execution withSystemLabels(List<Label> labels) {
+        List<Label> newLabels = this.labels == null ? new ArrayList<>() : this.labels;
+        if (labels != null) {
+            newLabels.addAll(labels);
+        }
         return new Execution(
             this.tenantId,
             this.id,
@@ -256,7 +268,7 @@ public class Execution implements DeletedInterface, TenantInterface {
             this.taskRunList,
             this.inputs,
             this.outputs,
-            labels,
+            newLabels,
             this.variables,
             this.state,
             this.parentId,

--- a/core/src/main/java/io/kestra/core/validations/validator/FlowValidator.java
+++ b/core/src/main/java/io/kestra/core/validations/validator/FlowValidator.java
@@ -1,5 +1,6 @@
 package io.kestra.core.validations.validator;
 
+import io.kestra.core.models.Label;
 import io.kestra.core.models.flows.Data;
 import io.kestra.core.models.flows.Flow;
 import io.kestra.core.models.flows.Input;
@@ -23,6 +24,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+
+import static io.kestra.core.models.Label.SYSTEM_PREFIX;
 
 @Singleton
 @Introspected
@@ -81,6 +84,13 @@ public class FlowValidator implements ConstraintValidator<FlowValidation, Flow> 
             if (!duplicates.isEmpty()) {
                 violations.add("Duplicate output with name [" + String.join(", ", duplicates) + "]");
             }
+        }
+
+        // system labels
+        if (value.getLabels() != null) {
+            value.getLabels().stream()
+                .filter(label -> label.key() != null && label.key().startsWith(SYSTEM_PREFIX))
+                .forEach(label -> violations.add("System labels can only be set by Kestra itself, offending label: " + label.key() + "=" + label.value()));
         }
 
         if (!violations.isEmpty()) {

--- a/core/src/main/java/io/kestra/plugin/core/execution/Labels.java
+++ b/core/src/main/java/io/kestra/plugin/core/execution/Labels.java
@@ -131,14 +131,12 @@ public class Labels extends Task implements ExecutionUpdatableTask {
                 );
             }));
 
-            return execution.toBuilder()
-                .labels(newLabels.entrySet().stream()
+            return execution.withLabels(newLabels.entrySet().stream()
                     .map(throwFunction(entry -> new Label(
                         entry.getKey(),
                         entry.getValue()
                     )))
-                    .toList())
-                .build();
+                    .toList());
         } else {
             throw new IllegalVariableEvaluationException("Unknown value type: " + labels.getClass());
         }

--- a/core/src/test/java/io/kestra/core/validations/FlowValidationTest.java
+++ b/core/src/test/java/io/kestra/core/validations/FlowValidationTest.java
@@ -22,7 +22,7 @@ class FlowValidationTest {
     @Inject
     private ModelValidator modelValidator;
     @Inject
-    YamlFlowParser yamlFlowParser = new YamlFlowParser();
+    private YamlFlowParser yamlFlowParser = new YamlFlowParser();
 
     @Test
     void invalidRecursiveFlow() {
@@ -31,6 +31,16 @@ class FlowValidationTest {
 
         assertThat(validate.isPresent(), is(true));
         assertThat(validate.get().getMessage(), containsString(": Invalid Flow: Recursive call to flow [io.kestra.tests.recursive-flow]"));
+    }
+
+    @Test
+    void systemLabelShouldFailValidation() {
+        Flow flow = this.parse("flows/invalids/system-labels.yaml");
+        Optional<ConstraintViolationException> validate = modelValidator.isValid(flow);
+
+        assertThat(validate.isPresent(), is(true));
+        assertThat(validate.get().getMessage(), containsString("System labels can only be set by Kestra itself, offending label: system_label=system_key"));
+        assertThat(validate.get().getMessage(), containsString("System labels can only be set by Kestra itself, offending label: system_id=id"));
     }
 
     private Flow parse(String path) {

--- a/core/src/test/java/io/kestra/plugin/core/flow/CorrelationIdTest.java
+++ b/core/src/test/java/io/kestra/plugin/core/flow/CorrelationIdTest.java
@@ -1,0 +1,68 @@
+package io.kestra.plugin.core.flow;
+
+import io.kestra.core.models.Label;
+import io.kestra.core.models.executions.Execution;
+import io.kestra.core.models.flows.State;
+import io.kestra.core.queues.QueueException;
+import io.kestra.core.queues.QueueFactoryInterface;
+import io.kestra.core.queues.QueueInterface;
+import io.kestra.core.runners.AbstractMemoryRunnerTest;
+import io.kestra.core.utils.TestsUtils;
+import jakarta.inject.Inject;
+import jakarta.inject.Named;
+import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Flux;
+
+import java.util.Optional;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class CorrelationIdTest extends AbstractMemoryRunnerTest {
+    @Inject
+    @Named(QueueFactoryInterface.EXECUTION_NAMED)
+    private QueueInterface<Execution> executionQueue;
+
+    @Test
+    void shouldHaveCorrelationId() throws QueueException, TimeoutException, InterruptedException {
+        CountDownLatch countDownLatch = new CountDownLatch(2);
+        AtomicReference<Execution> child = new AtomicReference<>();
+        AtomicReference<Execution> grandChild = new AtomicReference<>();
+
+        Flux<Execution> receive = TestsUtils.receive(executionQueue, either -> {
+            Execution execution = either.getLeft();
+            if (execution.getFlowId().equals("subflow-child") && execution.getState().getCurrent().isTerminated()) {
+                countDownLatch.countDown();
+                child.set(execution);
+            }
+            if (execution.getFlowId().equals("subflow-grand-child") && execution.getState().getCurrent().isTerminated()) {
+                countDownLatch.countDown();
+                grandChild.set(execution);
+            }
+        });
+
+        Execution execution = runnerUtils.runOne(null, "io.kestra.tests", "subflow-parent");
+        assertThat(execution.getState().getCurrent(), is(State.Type.SUCCESS));
+
+        assertTrue(countDownLatch.await(1, TimeUnit.MINUTES));
+        receive.blockLast();
+
+        assertThat(child.get(), notNullValue());
+        assertThat(child.get().getState().getCurrent(), is(State.Type.SUCCESS));
+        Optional<Label> correlationId = child.get().getLabels().stream().filter(label -> label.key().equals(Label.CORRELATION_ID)).findAny();
+        assertThat(correlationId.isPresent(), is(true));
+        assertThat(correlationId.get().value(), is(execution.getId()));
+
+        assertThat(grandChild.get(), notNullValue());
+        assertThat(grandChild.get().getState().getCurrent(), is(State.Type.SUCCESS));
+        correlationId = grandChild.get().getLabels().stream().filter(label -> label.key().equals(Label.CORRELATION_ID)).findAny();
+        assertThat(correlationId.isPresent(), is(true));
+        assertThat(correlationId.get().value(), is(execution.getId()));
+    }
+}

--- a/core/src/test/java/io/kestra/plugin/core/flow/FlowCaseTest.java
+++ b/core/src/test/java/io/kestra/plugin/core/flow/FlowCaseTest.java
@@ -100,14 +100,16 @@ public class FlowCaseTest {
 
         if (testInherited) {
             assertThat(triggered.get().getLabels(), hasItems(
+                new Label(Label.CORRELATION_ID, execution.getId()),
                 new Label("mainFlowExecutionLabel", "execFoo"),
                 new Label("mainFlowLabel", "flowFoo"),
                 new Label("launchTaskLabel", "launchFoo"),
                 new Label("switchFlowLabel", "switchFoo")
             ));
         } else {
-            assertThat(triggered.get().getLabels().size(), is(2));
+            assertThat(triggered.get().getLabels().size(), is(3));
             assertThat(triggered.get().getLabels(), hasItems(
+                new Label(Label.CORRELATION_ID, execution.getId()),
                 new Label("launchTaskLabel", "launchFoo"),
                 new Label("switchFlowLabel", "switchFoo")
             ));

--- a/core/src/test/java/io/kestra/plugin/core/flow/ForEachItemCaseTest.java
+++ b/core/src/test/java/io/kestra/plugin/core/flow/ForEachItemCaseTest.java
@@ -1,5 +1,6 @@
 package io.kestra.plugin.core.flow;
 
+import io.kestra.core.models.Label;
 import io.kestra.core.models.executions.Execution;
 import io.kestra.core.models.flows.State;
 import io.kestra.core.queues.QueueException;
@@ -28,6 +29,7 @@ import java.nio.file.Files;
 import java.time.Duration;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
@@ -101,6 +103,9 @@ public class ForEachItemCaseTest {
         assertThat(triggered.get().getFlowId(), is("for-each-item-subflow"));
         assertThat((String) triggered.get().getInputs().get("items"), matchesRegex("kestra:///io/kestra/tests/for-each-item/executions/.*/tasks/each-split/.*\\.txt"));
         assertThat(triggered.get().getTaskRunList(), hasSize(1));
+        Optional<Label> correlationId = triggered.get().getLabels().stream().filter(label -> label.key().equals(Label.CORRELATION_ID)).findAny();
+        assertThat(correlationId.isPresent(), is(true));
+        assertThat(correlationId.get().value(), is(execution.getId()));
     }
 
     public void forEachItemEmptyItems() throws TimeoutException, URISyntaxException, IOException, QueueException {

--- a/core/src/test/resources/flows/invalids/system-labels.yaml
+++ b/core/src/test/resources/flows/invalids/system-labels.yaml
@@ -1,0 +1,11 @@
+id: system-labels
+namespace: io.kestra.tests
+
+labels:
+  system_label: system_key
+  system_id: id
+  another: label
+
+tasks:
+  - type: io.kestra.plugin.core.log.Log
+    message: "bla"

--- a/core/src/test/resources/flows/valids/subflow-child.yaml
+++ b/core/src/test/resources/flows/valids/subflow-child.yaml
@@ -1,0 +1,8 @@
+id: subflow-child
+namespace: io.kestra.tests
+
+tasks:
+  - id: subflow
+    type: io.kestra.plugin.core.flow.Subflow
+    namespace: io.kestra.tests
+    flowId: subflow-grand-child

--- a/core/src/test/resources/flows/valids/subflow-grand-child.yaml
+++ b/core/src/test/resources/flows/valids/subflow-grand-child.yaml
@@ -1,0 +1,7 @@
+id: subflow-grand-child
+namespace: io.kestra.tests
+
+tasks:
+  - id: firstLevel
+    type: io.kestra.plugin.core.log.Log
+    message: "My grandparent is {{labels.system_correlationId}}"

--- a/core/src/test/resources/flows/valids/subflow-parent.yaml
+++ b/core/src/test/resources/flows/valids/subflow-parent.yaml
@@ -1,0 +1,8 @@
+id: subflow-parent
+namespace: io.kestra.tests
+
+tasks:
+  - id: subflow
+    type: io.kestra.plugin.core.flow.Subflow
+    namespace: io.kestra.tests
+    flowId: subflow-child

--- a/webserver/src/test/java/io/kestra/webserver/controllers/api/ExecutionControllerTest.java
+++ b/webserver/src/test/java/io/kestra/webserver/controllers/api/ExecutionControllerTest.java
@@ -1592,4 +1592,16 @@ class ExecutionControllerTest extends JdbcH2ControllerTest {
         );
         assertThat(response.getCount(), is(3));
     }
+
+    @Test
+    void shouldRefuseSystemLabels() {
+        var error = assertThrows(HttpClientResponseException.class, () -> client.toBlocking().retrieve(
+            HttpRequest
+                .POST("/api/v1/executions/io.kestra.tests/minimal?labels=system_label:system", null)
+                .contentType(MediaType.MULTIPART_FORM_DATA_TYPE),
+            Execution.class
+        ));
+
+        assertThat(error.getStatus(), is(HttpStatus.UNPROCESSABLE_ENTITY));
+    }
 }


### PR DESCRIPTION
Part-of: #2059

Introduce **system labels** which are labels that start with `system_`  and can't be set by a user.

The first system label, that is also introduced by this PR, is `system_correlationId` which is set by default in any subflow created by an execution via the  Subflow or ForEachItem tasks.
The value of the `system_correlationId` label is the value of the parent `system_correlationId` label or the parent execution id if not set.
The Execution API will allow to pass this label at execution creation time but not at any execution modification time.