### PR TITLE
feat(cli,webserver): hidden labels

### DIFF
--- a/cli/src/main/resources/application.yml
+++ b/cli/src/main/resources/application.yml
@@ -188,3 +188,8 @@ kestra:
     uri: https://api.kestra.io/v1/reports/usages
     initial-delay: 5m
     fixed-delay: 1h
+
+  hidden-labels:
+    prefixes:
+      - system_
+      - internal_

--- a/ui/src/components/executions/Executions.vue
+++ b/ui/src/components/executions/Executions.vue
@@ -143,7 +143,7 @@
             <template #table v-if="executions.length">
                 <select-table
                     ref="selectTable"
-                    :data="executions"
+                    :data="filteredExecutions"
                     :default-sort="{prop: 'state.startDate', order: 'descending'}"
                     stripe
                     table-layout="auto"
@@ -438,7 +438,7 @@
 </script>
 
 <script>
-    import {mapState} from "vuex";
+    import {mapState, mapGetters} from "vuex";
     import DataTable from "../layout/DataTable.vue";
     import TextSearch from "vue-material-design-icons/TextSearch.vue";
     import Status from "../Status.vue";
@@ -629,6 +629,19 @@
             ...mapState("stat", ["daily"]),
             ...mapState("auth", ["user"]),
             ...mapState("flow", ["flow"]),
+            ...mapGetters("misc", ["configs"]),
+            filteredExecutions() {
+                const toIgnore = this.configs.hiddenLabelsPrefixes || [];
+                // Extract only the keys from the route query labels
+                const allowedLabels = this.$route.query.labels ? this.$route.query.labels.map(label => label.split(":")[0]) : [];
+
+                return this.executions.filter(execution => {
+                    return !execution.labels?.some(label => {
+                        // Check if the label key matches any prefix, but allow if it's in the query
+                        return toIgnore.some(prefix => label.key.startsWith(prefix)) && !allowedLabels.includes(label.key);
+                    });
+                });
+            },
             routeInfo() {
                 return {
                     title: this.$t("executions")

--- a/webserver/src/main/java/io/kestra/webserver/controllers/api/ExecutionController.java
+++ b/webserver/src/main/java/io/kestra/webserver/controllers/api/ExecutionController.java
@@ -686,7 +686,7 @@ public class ExecutionController {
     }
 
     protected Pair<List<Label>, List<Label>> parseLabels(List<String> labels) {
-        // We allow passing the correlation id from the API but only this one, other system labels will go throught and fail at execution creation.
+        // We allow passing the correlation id from the API but only this one, other system labels will go through and fail at execution creation.
         List<Label> parsedLabels =  labels == null ? Collections.emptyList() : RequestUtils.toMap(labels).entrySet().stream()
             .map(entry -> new Label(entry.getKey(), entry.getValue()))
             .toList();

--- a/webserver/src/main/java/io/kestra/webserver/controllers/api/MiscController.java
+++ b/webserver/src/main/java/io/kestra/webserver/controllers/api/MiscController.java
@@ -23,6 +23,7 @@ import lombok.experimental.SuperBuilder;
 import lombok.extern.slf4j.Slf4j;
 
 import java.time.ZonedDateTime;
+import java.util.List;
 import java.util.Optional;
 
 @Slf4j
@@ -69,6 +70,9 @@ public class MiscController {
     @io.micronaut.context.annotation.Value("${kestra.server.preview.max-rows:5000}")
     private Integer maxPreviewRows;
 
+    @io.micronaut.context.annotation.Value("${kestra.hidden-labels.prefixes:}")
+    private List<String> hiddenLabelsPrefixes;
+
 
     @Get("{/tenant}/configs")
     @ExecuteOn(TaskExecutors.IO)
@@ -88,7 +92,8 @@ public class MiscController {
                 .max(this.maxPreviewRows)
                 .build()
             ).isBasicAuthEnabled(basicAuthService.isEnabled())
-            .systemNamespace(namespaceUtils.getSystemFlowNamespace());
+            .systemNamespace(namespaceUtils.getSystemFlowNamespace())
+            .hiddenLabelsPrefixes(hiddenLabelsPrefixes);
 
         if (this.environmentName != null || this.environmentColor != null) {
             builder.environment(
@@ -148,6 +153,8 @@ public class MiscController {
         Boolean isBasicAuthEnabled;
 
         String systemNamespace;
+
+        List<String> hiddenLabelsPrefixes;
     }
 
     @Value


### PR DESCRIPTION
Hide some labels by default to avoid having too many of them cluttering the UI.

We should hide them in lists but not in the execution overview page.

Part-of: https://github.com/kestra-io/kestra/issues/2059
