### PR TITLE
fix: Ensure strict typing for input defaults to prevent runtime errors

### DIFF
--- a/core/src/main/java/io/kestra/core/models/flows/Input.java
+++ b/core/src/main/java/io/kestra/core/models/flows/Input.java
@@ -78,7 +78,7 @@ public abstract class Input<T> implements Data {
     @Schema(
         title = "The default value to use if no value is specified."
     )
-    Object defaults;
+    T defaults;
 
     @Schema(
         title = "The display name of the input."

--- a/core/src/main/java/io/kestra/core/runners/FlowInputOutput.java
+++ b/core/src/main/java/io/kestra/core/runners/FlowInputOutput.java
@@ -405,8 +405,8 @@ public class FlowInputOutput {
                 case FLOAT -> current instanceof Float ? current : Float.valueOf(current.toString());
                 case BOOLEAN -> current instanceof Boolean ? current : Boolean.valueOf((String) current);
                 case DATETIME -> Instant.parse(((String) current));
-                case DATE -> LocalDate.parse(((String) current));
-                case TIME -> LocalTime.parse(((String) current));
+                case DATE -> current instanceof LocalDate ? current : LocalDate.parse(((String) current));
+                case TIME -> current instanceof LocalTime ? current : LocalTime.parse(((String) current));
                 case DURATION -> Duration.parse(((String) current));
                 case FILE -> {
                     URI uri = URI.create(((String) current).replace(File.separator, "/"));

--- a/core/src/main/java/io/kestra/core/runners/FlowInputOutput.java
+++ b/core/src/main/java/io/kestra/core/runners/FlowInputOutput.java
@@ -404,10 +404,10 @@ public class FlowInputOutput {
                 // Assuming that after the render we must have a double/int, so we can safely use its toString representation
                 case FLOAT -> current instanceof Float ? current : Float.valueOf(current.toString());
                 case BOOLEAN -> current instanceof Boolean ? current : Boolean.valueOf((String) current);
-                case DATETIME -> Instant.parse(((String) current));
+                case DATETIME -> current instanceof Instant ? current : Instant.parse(((String) current));
                 case DATE -> current instanceof LocalDate ? current : LocalDate.parse(((String) current));
                 case TIME -> current instanceof LocalTime ? current : LocalTime.parse(((String) current));
-                case DURATION -> Duration.parse(((String) current));
+                case DURATION -> current instanceof Duration ? current : Duration.parse(((String) current));
                 case FILE -> {
                     URI uri = URI.create(((String) current).replace(File.separator, "/"));
 

--- a/core/src/test/java/io/kestra/core/runners/FlowInputOutputTest.java
+++ b/core/src/test/java/io/kestra/core/runners/FlowInputOutputTest.java
@@ -244,7 +244,7 @@ class FlowInputOutputTest {
         Assertions.assertEquals(
             List.of(
                 new InputAndValue(input1, "0", true, null),
-                new InputAndValue(input2, "0", true, null)),
+                new InputAndValue(input2, 0, true, null)),
             values
         );
     }

--- a/core/src/test/java/io/kestra/core/runners/FlowInputOutputTest.java
+++ b/core/src/test/java/io/kestra/core/runners/FlowInputOutputTest.java
@@ -7,6 +7,7 @@ import io.kestra.core.models.flows.Input;
 import io.kestra.core.models.flows.Type;
 import io.kestra.core.models.flows.input.FileInput;
 import io.kestra.core.models.flows.input.InputAndValue;
+import io.kestra.core.models.flows.input.IntInput;
 import io.kestra.core.models.flows.input.StringInput;
 import io.kestra.core.storages.StorageInterface;
 import io.kestra.core.utils.IdUtils;
@@ -215,6 +216,37 @@ class FlowInputOutputTest {
         // Then
         Assertions.assertNull(values.getFirst().exception());
         Assertions.assertFalse(storageInterface.exists(null, URI.create(values.getFirst().value().toString())));
+    }
+
+    @Test
+    void resolveInputsWithStrictDefaultTyping() {
+        // Given
+        StringInput input1 = StringInput.builder()
+            .id("input1")
+            .validator("\\d")
+            .defaults("0")
+            .required(false)
+            .build();
+        IntInput input2 = IntInput.builder()
+            .id("input2")
+            .defaults(0)
+            .required(false)
+            .build();
+
+        List<Input<?>> inputs = List.of(input1, input2);
+
+        Map<String, Object> data = Map.of("input42", "foo");
+
+        // When
+        List<InputAndValue> values = flowInputOutput.resolveInputs(inputs, DEFAULT_TEST_EXECUTION, data);
+
+        // Then
+        Assertions.assertEquals(
+            List.of(
+                new InputAndValue(input1, "0", true, null),
+                new InputAndValue(input2, "0", true, null)),
+            values
+        );
     }
 
     private static final class MemoryCompletedFileUpload implements CompletedFileUpload {


### PR DESCRIPTION
<!-- Thanks for submitting a Pull Request to Kestra. To help us review your contribution, please follow the guidelines below:

- Make sure that your commits follow the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) specification e.g. `feat(ui): add a new navigation menu item` or `fix(core): fix a bug in the core model` or `docs: update the README.md`. This will help us automatically generate the changelog.
- The title should briefly summarize the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share a flow example to help the reviewer understand and QA the change.
- Use "closes" to automatically close an issue. For example, `closes #1234` will close issue #1234. -->

### What changes are being made and why?
This PR addresses the issue (#5590) where untyped input defaults could lead to runtime errors. By switching to a strongly typed generic parameter for inputs, we ensure that defaults are properly validated during schema generation, thereby reducing unexpected behaviors at execution time.

closes #5590 

<!-- Please include a brief summary of the changes included in this PR e.g. closes #1234. -->

