### PR TITLE
Add displayName to flow level outputs

### DIFF
--- a/core/src/main/java/io/kestra/core/models/flows/Data.java
+++ b/core/src/main/java/io/kestra/core/models/flows/Data.java
@@ -22,6 +22,13 @@ public interface Data {
      */
     Type getType();
 
+    /**
+     * The Display Name for this data.
+     *
+     * @return a string displayName.
+     */
+    String getDisplayName();
+
     @SuppressWarnings("unchecked")
     default ConstraintViolationException toConstraintViolationException(String message, Object value) {
         Class<Data> cls = (Class<Data>) this.getClass();

--- a/core/src/main/java/io/kestra/core/models/flows/Output.java
+++ b/core/src/main/java/io/kestra/core/models/flows/Output.java
@@ -41,4 +41,6 @@ public class Output implements Data {
     @NotNull
     @Valid
     Type type;
+
+    String displayName;
 }

--- a/core/src/main/java/io/kestra/core/runners/ExecutorService.java
+++ b/core/src/main/java/io/kestra/core/runners/ExecutorService.java
@@ -1,5 +1,7 @@
 package io.kestra.core.runners;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableMap;
 import io.kestra.core.exceptions.InternalException;
 import io.kestra.core.metrics.MetricRegistry;
@@ -383,7 +385,13 @@ public class ExecutorService {
             try {
                 Map<String, Object> outputs = flow.getOutputs()
                     .stream()
-                    .collect(HashMap::new, (map, entry) -> map.put(entry.getId(), entry.getValue()), Map::putAll);
+                    .collect(HashMap::new, (map, entry) -> {
+                        final ObjectMapper mapper = new ObjectMapper();
+                        final HashMap<String, Object> entryInfo = new HashMap<>();
+                        entryInfo.put("value", entry.getValue());
+                        entryInfo.put("displayName", Optional.ofNullable(entry.getDisplayName()).orElse(entry.getId()));
+                        map.put(entry.getId(), entryInfo);
+                    }, Map::putAll);
                 outputs = runContext.render(outputs);
                 outputs = flowInputOutput.typedOutputs(flow, executor.getExecution(), outputs);
                 newExecution = newExecution.withOutputs(outputs);

--- a/core/src/test/java/io/kestra/plugin/core/flow/FlowOutputTest.java
+++ b/core/src/test/java/io/kestra/plugin/core/flow/FlowOutputTest.java
@@ -39,4 +39,13 @@ class FlowOutputTest extends AbstractMemoryRunnerTest {
         assertThat(execution.getOutputs(), nullValue());
         assertThat(execution.getState().getCurrent(), is(State.Type.FAILED));
     }
+
+    @Test
+    void shouldGetSuccessExecutionForFlowWithOutputsDisplayName() throws TimeoutException, QueueException {
+        Execution execution = runnerUtils.runOne(null, NAMESPACE, "flow-with-outputs-display-name", null, null);
+        assertThat(execution.getOutputs(), aMapWithSize(1));
+        assertThat(execution.getOutputs().get("key"), nullValue());
+        assertThat(execution.getOutputs().get("Sample Output"), is("{\"value\":\"flow-with-outputs-display-name\"}"));
+        assertThat(execution.getState().getCurrent(), is(State.Type.SUCCESS));
+    }
 }

--- a/core/src/test/resources/flows/valids/flow-with-outputs-display-name.yml
+++ b/core/src/test/resources/flows/valids/flow-with-outputs-display-name.yml
@@ -1,0 +1,13 @@
+id: flow-with-outputs-display-name
+namespace: io.kestra.tests
+
+tasks:
+- id: return
+  type: io.kestra.plugin.core.debug.Return
+  format: "{{ flow.id }}"
+
+outputs:
+- id: "key"
+  value: "{{ outputs.return }}"
+  type: STRING
+  displayName: Sample Output


### PR DESCRIPTION
<!-- Thanks for submitting a Pull Request to Kestra. To help us review your contribution, please follow the guidelines below:

- Make sure that your commits follow the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) specification e.g. `feat(ui): add a new navigation menu item` or `fix(core): fix a bug in the core model` or `docs: update the README.md`. This will help us automatically generate the changelog.
- The title should briefly summarize the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share a flow example to help the reviewer understand and QA the change.
- Use "closes" to automatically close an issue. For example, `closes #1234` will close issue #1234. -->

### What changes are being made and why?

<!-- Please include a brief summary of the changes included in this PR e.g. closes #1234. -->

Related to #5476, One attribute **_"displayName"_** has been added to the flow level outputs in backend, while it is not decided how to show this attribute yet.
---

### How the changes have been QAed?

Sample config:

```yaml
id: stars
namespace: blueprints

inputs:
  - id: resource_type
    displayName: Select the resource type
    type: SELECT
    required: true
    values:
      - Access permissions
      - SaaS application
      - Development tool
      - Cloud VM
  - id: resource_type_2
    displayName: Select the resource type
    type: SELECT
    required: true
    values:
      - Another option
      - Another  option_2

tasks:
  - id: getdata
    type: io.kestra.plugin.core.debug.Return
    format: requested {{ inputs.resource_type }}
  - id: getdata_2
    type: io.kestra.plugin.core.debug.Return
    format: requested {{ inputs.resource_type_2 }}  


outputs:
  - id: myoutput
    type: STRING
    value: "{{ outputs.getdata.value }}"
    displayName: Final returned value
  - id: myoutput_2
    type: STRING
    value: "{{ outputs.getdata_2.value }}"
    displayName: Final returned value 2
```

---

### Setup Instructions

<!--If there are any setup requirements like API keys or trial accounts, kindly include brief bullet-points-description outlining the setup process below.

- [External System Documentation](URL)
- Steps to set up the necessary resources

If there are no setup requirements, you can remove this section.

Thank you for your contribution. ❤️  -->
