### PR TITLE
Read Only Flow

### DIFF
--- a/core/src/main/java/io/kestra/core/models/Label.java
+++ b/core/src/main/java/io/kestra/core/models/Label.java
@@ -9,4 +9,5 @@ public record Label(@NotNull String key, @NotNull String value) {
     public static final String CORRELATION_ID = SYSTEM_PREFIX + "correlationId";
     public static final String USERNAME = SYSTEM_PREFIX + "username";
     public static final String APP = SYSTEM_PREFIX + "app";
+    public static final String READ_ONLY = SYSTEM_PREFIX + "readOnly";
 }

--- a/core/src/main/java/io/kestra/core/models/executions/Execution.java
+++ b/core/src/main/java/io/kestra/core/models/executions/Execution.java
@@ -20,6 +20,7 @@ import io.kestra.core.runners.FlowableUtils;
 import io.kestra.core.runners.RunContextLogger;
 import io.kestra.core.serializers.ListOrMapOfLabelDeserializer;
 import io.kestra.core.serializers.ListOrMapOfLabelSerializer;
+import io.kestra.core.services.LabelService;
 import io.kestra.core.utils.IdUtils;
 import io.kestra.core.utils.MapUtils;
 import io.micronaut.core.annotation.Nullable;
@@ -38,8 +39,6 @@ import java.util.function.BiFunction;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import java.util.zip.CRC32;
-
-import static io.kestra.core.models.Label.SYSTEM_PREFIX;
 
 @Builder(toBuilder = true)
 @Slf4j
@@ -143,10 +142,7 @@ public class Execution implements DeletedInterface, TenantInterface {
             .scheduleDate(scheduleDate.map(ChronoZonedDateTime::toInstant).orElse(null))
             .build();
 
-        List<Label> executionLabels = new ArrayList<>();
-        if (flow.getLabels() != null) {
-            executionLabels.addAll(flow.getLabels());
-        }
+        List<Label> executionLabels = new ArrayList<>(LabelService.labelsExcludingSystem(flow));
 
         if (labels != null) {
             executionLabels.addAll(labels);
@@ -161,6 +157,8 @@ public class Execution implements DeletedInterface, TenantInterface {
 
         return execution;
     }
+
+
 
     public static class ExecutionBuilder {
         void prebuild() {
@@ -180,12 +178,6 @@ public class Execution implements DeletedInterface, TenantInterface {
         public Execution build() {
             this.prebuild();
             return super.build();
-        }
-
-        @Override
-        public ExecutionBuilder labels(List<Label> labels) {
-            checkForSystemLabels(labels);
-            return super.labels(labels);
         }
     }
 
@@ -212,12 +204,8 @@ public class Execution implements DeletedInterface, TenantInterface {
         );
     }
 
-    /**
-     * This method replaces labels with new ones.
-     * It refuses system labels as they must be passed via the withSystemLabels method.
-     */
     public Execution withLabels(List<Label> labels) {
-        checkForSystemLabels(labels);
+
 
         return new Execution(
             this.tenantId,
@@ -229,46 +217,6 @@ public class Execution implements DeletedInterface, TenantInterface {
             this.inputs,
             this.outputs,
             labels,
-            this.variables,
-            this.state,
-            this.parentId,
-            this.originalId,
-            this.trigger,
-            this.deleted,
-            this.metadata,
-            this.scheduleDate,
-            this.error
-        );
-    }
-
-    private static void checkForSystemLabels(List<Label> labels) {
-        if (labels != null) {
-            Optional<Label> first = labels.stream().filter(label -> label.key() != null && label.key().startsWith(SYSTEM_PREFIX)).findFirst();
-            if (first.isPresent()) {
-                throw new IllegalArgumentException("System labels can only be set by Kestra itself, offending label: " + first.get().key() + "=" + first.get().value());
-            }
-        }
-    }
-
-    /**
-     * This method in <b>only to be used</b> to add system labels to an execution.
-     * It will not replace exisiting labels but add new one (possibly duplicating).
-     */
-    public Execution withSystemLabels(List<Label> labels) {
-        List<Label> newLabels = this.labels == null ? new ArrayList<>() : this.labels;
-        if (labels != null) {
-            newLabels.addAll(labels);
-        }
-        return new Execution(
-            this.tenantId,
-            this.id,
-            this.namespace,
-            this.flowId,
-            this.flowRevision,
-            this.taskRunList,
-            this.inputs,
-            this.outputs,
-            newLabels,
             this.variables,
             this.state,
             this.parentId,

--- a/core/src/main/java/io/kestra/core/runners/Worker.java
+++ b/core/src/main/java/io/kestra/core/runners/Worker.java
@@ -19,6 +19,7 @@ import io.kestra.core.server.Metric;
 import io.kestra.core.server.ServerConfig;
 import io.kestra.core.server.Service;
 import io.kestra.core.server.ServiceStateChangeEvent;
+import io.kestra.core.services.LabelService;
 import io.kestra.core.services.LogService;
 import io.kestra.core.services.WorkerGroupService;
 import io.kestra.core.utils.Await;
@@ -361,11 +362,11 @@ public class Worker implements Service, Runnable, AutoCloseable {
             );
         }
 
-        var flowLabels = workerTrigger.getConditionContext().getFlow().getLabels();
-        if (flowLabels != null) {
+        var flow = workerTrigger.getConditionContext().getFlow();
+        if (flow.getLabels() != null) {
             evaluate = evaluate.map(execution -> {
                     List<Label> executionLabels = execution.getLabels() != null ? execution.getLabels() : new ArrayList<>();
-                    executionLabels.addAll(flowLabels);
+                    executionLabels.addAll(LabelService.labelsExcludingSystem(flow));
                     return execution.withLabels(executionLabels);
                 }
             );

--- a/core/src/main/java/io/kestra/core/schedulers/AbstractScheduler.java
+++ b/core/src/main/java/io/kestra/core/schedulers/AbstractScheduler.java
@@ -564,7 +564,7 @@ public abstract class AbstractScheduler implements Scheduler, Service {
                             .namespace(f.getTriggerContext().getNamespace())
                             .flowId(f.getTriggerContext().getFlowId())
                             .flowRevision(f.getFlow().getRevision())
-                            .labels(f.getFlow().getLabels())
+                            .labels(LabelService.labelsExcludingSystem(f.getFlow()))
                             .state(new State().withState(State.Type.FAILED))
                             .error(ExecutionError.from(ie))
                             .build();

--- a/core/src/main/java/io/kestra/core/services/LabelService.java
+++ b/core/src/main/java/io/kestra/core/services/LabelService.java
@@ -1,0 +1,56 @@
+package io.kestra.core.services;
+
+import io.kestra.core.exceptions.IllegalVariableEvaluationException;
+import io.kestra.core.models.Label;
+import io.kestra.core.models.flows.Flow;
+import io.kestra.core.models.triggers.AbstractTrigger;
+import io.kestra.core.runners.RunContext;
+import io.kestra.core.utils.ListUtils;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public final class LabelService {
+    private LabelService() {}
+
+    /**
+     * Return flow labels excluding system labels.
+     */
+    public static List<Label> labelsExcludingSystem(Flow flow) {
+        return ListUtils.emptyOnNull(flow.getLabels()).stream().filter(label -> !label.key().startsWith(Label.SYSTEM_PREFIX)).toList();
+    }
+
+    /**
+     * Return flow labels excluding system labels concatenated with trigger labels.
+     *
+     * Trigger labels will be rendered via the run context but not flow labels.
+     * In case rendering is not possible, the label will be omitted.
+     */
+    public static List<Label> fromTrigger(RunContext runContext, Flow flow, AbstractTrigger trigger) {
+        final List<Label> labels = new ArrayList<>();
+
+        if (flow.getLabels() != null) {
+            labels.addAll(LabelService.labelsExcludingSystem(flow)); // no need for rendering
+        }
+
+        if (trigger.getLabels() != null) {
+            for (Label label : trigger.getLabels()) {
+                final var value = renderLabelValue(runContext, label);
+                if (value != null) {
+                    labels.add(new Label(label.key(), value));
+                }
+            }
+        }
+
+        return labels;
+    }
+
+    private static String renderLabelValue(RunContext runContext, Label label) {
+        try {
+            return runContext.render(label.value());
+        } catch (IllegalVariableEvaluationException e) {
+            runContext.logger().warn("Failed to render label '{}', it will be omitted", label.key(), e);
+            return null;
+        }
+    }
+}

--- a/core/src/main/java/io/kestra/core/validations/validator/FlowValidator.java
+++ b/core/src/main/java/io/kestra/core/validations/validator/FlowValidator.java
@@ -24,6 +24,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
+import static io.kestra.core.models.Label.READ_ONLY;
 import static io.kestra.core.models.Label.SYSTEM_PREFIX;
 
 @Singleton
@@ -79,7 +80,7 @@ public class FlowValidator implements ConstraintValidator<FlowValidation, Flow> 
 
         // system labels
         ListUtils.emptyOnNull(value.getLabels()).stream()
-            .filter(label -> label.key() != null && label.key().startsWith(SYSTEM_PREFIX))
+            .filter(label -> label.key() != null && label.key().startsWith(SYSTEM_PREFIX) && !label.key().equals(READ_ONLY))
             .forEach(label -> violations.add("System labels can only be set by Kestra itself, offending label: " + label.key() + "=" + label.value()));
 
         if (!violations.isEmpty()) {

--- a/core/src/main/java/io/kestra/plugin/core/trigger/Schedule.java
+++ b/core/src/main/java/io/kestra/plugin/core/trigger/Schedule.java
@@ -20,6 +20,7 @@ import io.kestra.core.models.triggers.*;
 import io.kestra.core.runners.DefaultRunContext;
 import io.kestra.core.runners.RunContext;
 import io.kestra.core.services.ConditionService;
+import io.kestra.core.services.LabelService;
 import io.kestra.core.utils.ListUtils;
 import io.kestra.core.validations.ScheduleValidation;
 import io.kestra.core.validations.TimezoneId;
@@ -425,23 +426,10 @@ public class Schedule extends AbstractTrigger implements Schedulable, TriggerOut
     }
 
     private List<Label> generateLabels(RunContext runContext, ConditionContext conditionContext, Backfill backfill) throws IllegalVariableEvaluationException {
-        List<Label> labels = new ArrayList<>();
-
-        if (conditionContext.getFlow().getLabels() != null) {
-            labels.addAll(conditionContext.getFlow().getLabels()); // no need for rendering
-        }
+        List<Label> labels = LabelService.fromTrigger(runContext, conditionContext.getFlow(), this);
 
         if (backfill != null && backfill.getLabels() != null) {
             for (Label label : backfill.getLabels()) {
-                final var value = runContext.render(label.value());
-                if (value != null) {
-                    labels.add(new Label(label.key(), value));
-                }
-            }
-        }
-
-        if (this.getLabels() != null) {
-            for (Label label : this.getLabels()) {
                 final var value = runContext.render(label.value());
                 if (value != null) {
                     labels.add(new Label(label.key(), value));

--- a/core/src/main/java/io/kestra/plugin/core/trigger/ScheduleOnDates.java
+++ b/core/src/main/java/io/kestra/plugin/core/trigger/ScheduleOnDates.java
@@ -10,6 +10,7 @@ import io.kestra.core.models.property.Property;
 import io.kestra.core.models.tasks.VoidOutput;
 import io.kestra.core.models.triggers.*;
 import io.kestra.core.runners.RunContext;
+import io.kestra.core.services.LabelService;
 import io.kestra.core.validations.TimezoneId;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
@@ -83,7 +84,7 @@ public class ScheduleOnDates extends AbstractTrigger implements Schedulable, Tri
                 this,
                 conditionContext,
                 triggerContext,
-                generateLabels(runContext, conditionContext),
+                LabelService.fromTrigger(runContext, conditionContext.getFlow(), this),
                 this.inputs != null ? runContext.render(this.inputs) : Collections.emptyMap(),
                 Collections.emptyMap(),
                 nextDate
@@ -131,24 +132,5 @@ public class ScheduleOnDates extends AbstractTrigger implements Schedulable, Tri
             .map(throwFunction(date -> timezone == null ? date : date.withZoneSameInstant(ZoneId.of(runContext.render(timezone)))))
             .findFirst()
             .map(date -> date.truncatedTo(ChronoUnit.SECONDS));
-    }
-
-    private List<Label> generateLabels(RunContext runContext, ConditionContext conditionContext) throws IllegalVariableEvaluationException {
-        List<Label> labels = new ArrayList<>();
-
-        if (conditionContext.getFlow().getLabels() != null) {
-            labels.addAll(conditionContext.getFlow().getLabels()); // no need for rendering
-        }
-
-        if (this.getLabels() != null) {
-            for (Label label : this.getLabels()) {
-                final var value = runContext.render(label.value());
-                if (value != null) {
-                    labels.add(new Label(label.key(), value));
-                }
-            }
-        }
-
-        return labels;
     }
 }

--- a/core/src/test/java/io/kestra/core/serializers/YamlFlowParserTest.java
+++ b/core/src/test/java/io/kestra/core/serializers/YamlFlowParserTest.java
@@ -167,7 +167,7 @@ class YamlFlowParserTest {
         Flow flow = this.parse("flows/valids/minimal.yaml");
 
         String s = mapper.writeValueAsString(flow);
-        assertThat(s, is("{\"id\":\"minimal\",\"namespace\":\"io.kestra.tests\",\"revision\":2,\"disabled\":false,\"deleted\":false,\"tasks\":[{\"id\":\"date\",\"type\":\"io.kestra.plugin.core.debug.Return\",\"format\":\"{{taskrun.startDate}}\"}]}"));
+        assertThat(s, is("{\"id\":\"minimal\",\"namespace\":\"io.kestra.tests\",\"revision\":2,\"disabled\":false,\"deleted\":false,\"labels\":[{\"key\":\"system_readOnly\",\"value\":\"true\"}],\"tasks\":[{\"id\":\"date\",\"type\":\"io.kestra.plugin.core.debug.Return\",\"format\":\"{{taskrun.startDate}}\"}]}"));
     }
 
     @Test

--- a/core/src/test/java/io/kestra/core/services/LabelServiceTest.java
+++ b/core/src/test/java/io/kestra/core/services/LabelServiceTest.java
@@ -1,0 +1,68 @@
+package io.kestra.core.services;
+
+import io.kestra.core.junit.annotations.KestraTest;
+import io.kestra.core.models.Label;
+import io.kestra.core.models.flows.Flow;
+import io.kestra.core.models.triggers.AbstractTrigger;
+import io.kestra.core.runners.RunContext;
+import io.kestra.core.runners.RunContextFactory;
+import io.kestra.plugin.core.trigger.Schedule;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+
+@KestraTest
+class LabelServiceTest {
+
+    @Inject
+    private RunContextFactory runContextFactory;
+
+    @Test
+    void shouldFilterSystemLabels() {
+        Flow flow = Flow.builder()
+            .labels(List.of(new Label("key", "value"), new Label("system_Label", "systemValue")))
+            .build();
+
+        List<Label> labels = LabelService.labelsExcludingSystem(flow);
+
+        assertThat(labels, hasSize(1));
+        assertThat(labels.getFirst(), is(new Label("key", "value")));
+    }
+
+    @Test
+    void shouldReturnLabelsFromFlowAndTrigger() {
+        RunContext runContext = runContextFactory.of(Map.of("variable", "variableValue"));
+        Flow flow = Flow.builder()
+            .labels(List.of(new Label("key", "value"), new Label("system_Label", "systemValue")))
+            .build();
+        AbstractTrigger trigger = Schedule.builder()
+            .labels(List.of(new Label("scheduleLabel", "scheduleValue"), new Label("variable", "{{variable}}")))
+            .build();
+
+        List<Label> labels = LabelService.fromTrigger(runContext, flow, trigger);
+
+        assertThat(labels, hasSize(3));
+        assertThat(labels, hasItems(new Label("key", "value"), new Label("scheduleLabel", "scheduleValue"), new Label("variable", "variableValue")));
+    }
+
+    @Test
+    void shouldFilterNonRenderableLabels() {
+        RunContext runContext = runContextFactory.of();
+        Flow flow = Flow.builder()
+            .labels(List.of(new Label("key", "value"), new Label("system_Label", "systemValue")))
+            .build();
+        AbstractTrigger trigger = Schedule.builder()
+            .labels(List.of(new Label("scheduleLabel", "scheduleValue"), new Label("variable", "{{variable}}")))
+            .build();
+
+        List<Label> labels = LabelService.fromTrigger(runContext, flow, trigger);
+
+        assertThat(labels, hasSize(2));
+        assertThat(labels, hasItems(new Label("key", "value"), new Label("scheduleLabel", "scheduleValue")));
+    }
+}

--- a/core/src/test/java/io/kestra/core/validations/FlowValidationTest.java
+++ b/core/src/test/java/io/kestra/core/validations/FlowValidationTest.java
@@ -43,6 +43,14 @@ class FlowValidationTest {
         assertThat(validate.get().getMessage(), containsString("System labels can only be set by Kestra itself, offending label: system_id=id"));
     }
 
+    @Test
+    void validFlowShouldSucceed() {
+        Flow flow = this.parse("flows/valids/minimal.yaml");
+        Optional<ConstraintViolationException> validate = modelValidator.isValid(flow);
+
+        assertThat(validate.isPresent(), is(false));
+    }
+
     private Flow parse(String path) {
         URL resource = TestsUtils.class.getClassLoader().getResource(path);
         assert resource != null;

--- a/core/src/test/resources/flows/valids/minimal.yaml
+++ b/core/src/test/resources/flows/valids/minimal.yaml
@@ -2,6 +2,9 @@ id: minimal
 namespace: io.kestra.tests
 revision: 2
 
+labels:
+  system_readOnly: "true"
+
 tasks:
 - id: date
   type: io.kestra.plugin.core.debug.Return

--- a/jdbc/src/main/java/io/kestra/jdbc/runner/JdbcExecutor.java
+++ b/jdbc/src/main/java/io/kestra/jdbc/runner/JdbcExecutor.java
@@ -258,19 +258,24 @@ public class JdbcExecutor implements ExecutorInterface, Service {
                     flow = either.getLeft();
                 }
 
-                flowTopologyRepository.save(
-                    flow,
-                    (flow.isDeleted() ?
-                        Stream.<FlowTopology>empty() :
-                        flowTopologyService
-                            .topology(
-                                flow,
-                                this.allFlows
-                            )
-                    )
-                        .distinct()
-                        .toList()
-                );
+                try {
+                    flowTopologyRepository.save(
+                        flow,
+                        (flow.isDeleted() ?
+                            Stream.<FlowTopology>empty() :
+                            flowTopologyService
+                                .topology(
+                                    flow,
+                                    this.allFlows
+                                )
+                        )
+                            .distinct()
+                            .toList()
+                    );
+                } catch (Exception e) {
+                    log.error("Unable to save flow topology", e);
+                }
+
             }
         ));
         setState(ServiceState.RUNNING);

--- a/ui/src/components/flows/FlowRoot.vue
+++ b/ui/src/components/flows/FlowRoot.vue
@@ -167,7 +167,7 @@
                         containerClass: "full-container",
                         props: {
                             expandedSubflows: this.expandedSubflows,
-                            isReadOnly: this.deleted || !this.isAllowedEdit,
+                            isReadOnly: this.deleted || !this.isAllowedEdit || this.readOnlySystemLabel,
                         },
                     });
                 }
@@ -326,6 +326,13 @@
                     action.UPDATE,
                     this.flow.namespace,
                 );
+            },
+            readOnlySystemLabel() {
+                if (!this.flow) {
+                    return false;
+                }
+
+                return this.flow.labels?.system_readOnly === "true" ?? false;
             },
             routeFlowDependencies() {
                 return this.dependenciesCount > 0 ? FlowDependencies : FlowNoDependencies;

--- a/webserver/src/main/java/io/kestra/webserver/controllers/api/ExecutionController.java
+++ b/webserver/src/main/java/io/kestra/webserver/controllers/api/ExecutionController.java
@@ -29,10 +29,7 @@ import io.kestra.core.repositories.FlowRepositoryInterface;
 import io.kestra.core.runners.FlowInputOutput;
 import io.kestra.core.runners.RunContext;
 import io.kestra.core.runners.RunContextFactory;
-import io.kestra.core.services.ConditionService;
-import io.kestra.core.services.ExecutionService;
-import io.kestra.core.services.FlowService;
-import io.kestra.core.services.GraphService;
+import io.kestra.core.services.*;
 import io.kestra.core.storages.StorageContext;
 import io.kestra.core.storages.StorageInterface;
 import io.kestra.core.tenant.TenantService;
@@ -89,7 +86,6 @@ import lombok.experimental.SuperBuilder;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.lang3.exception.ExceptionUtils;
-import org.apache.commons.lang3.tuple.Pair;
 import org.reactivestreams.Publisher;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.FluxSink;
@@ -112,6 +108,8 @@ import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 
+import static io.kestra.core.models.Label.CORRELATION_ID;
+import static io.kestra.core.models.Label.SYSTEM_PREFIX;
 import static io.kestra.core.utils.DateUtils.validateTimeline;
 import static io.kestra.core.utils.Rethrow.throwConsumer;
 import static io.kestra.core.utils.Rethrow.throwFunction;
@@ -533,7 +531,7 @@ public class ExecutionController {
 
         var result = execution.get();
         if (flow.getLabels() != null) {
-            result = result.withLabels(flow.getLabels());
+            result = result.withLabels(LabelService.labelsExcludingSystem(flow));
         }
 
         // we check conditions here as it's easier as the execution is created we have the body and headers available for the runContext
@@ -583,8 +581,8 @@ public class ExecutionController {
         @Parameter(description = "The flow revision or latest if null") @QueryValue Optional<Integer> revision
     ) {
         Flow flow = flowService.getFlowIfExecutableOrThrow(tenantService.resolveTenant(), namespace, id, revision);
-        Pair<List<Label>, List<Label>> parsedLabels = parseLabels(labels);
-        Execution execution = Execution.newExecution(flow, parsedLabels.getLeft()).withSystemLabels(parsedLabels.getRight());
+        List<Label> parsedLabels = parseLabels(labels);
+        Execution execution = Execution.newExecution(flow, parsedLabels);
         return flowInputOutput
             .validateExecutionInputs(flow.getInputs(), execution, inputs)
             .map(values -> ApiValidateExecutionInputsResponse.of(id, namespace, values));
@@ -605,8 +603,8 @@ public class ExecutionController {
         @Parameter(description = "Schedule the flow on a specific date") @QueryValue Optional<ZonedDateTime> scheduleDate
     ) throws IOException {
         Flow flow = flowService.getFlowIfExecutableOrThrow(tenantService.resolveTenant(), namespace, id, revision);
-        Pair<List<Label>, List<Label>> parsedLabels = parseLabels(labels);
-        Execution current = Execution.newExecution(flow, null, parsedLabels.getLeft(), scheduleDate).withSystemLabels(parsedLabels.getRight());
+        List<Label> parsedLabels = parseLabels(labels);
+        Execution current = Execution.newExecution(flow, null, parsedLabels, scheduleDate);
         Mono<CompletableFuture<ExecutionResponse>> handle = flowInputOutput.readExecutionInputs(flow, current, inputs)
             .handle((executionInputs, sink) -> {
                 Execution executionWithInputs = current.withInputs(executionInputs);
@@ -685,14 +683,17 @@ public class ExecutionController {
         }
     }
 
-    protected Pair<List<Label>, List<Label>> parseLabels(List<String> labels) {
-        // We allow passing the correlation id from the API but only this one, other system labels will go through and fail at execution creation.
+    protected List<Label> parseLabels(List<String> labels) {
         List<Label> parsedLabels =  labels == null ? Collections.emptyList() : RequestUtils.toMap(labels).entrySet().stream()
             .map(entry -> new Label(entry.getKey(), entry.getValue()))
             .toList();
-        List<Label> standardLabels = parsedLabels.stream().filter(label -> !label.key().equals(Label.CORRELATION_ID)).toList();
-        List<Label> systemLabels = parsedLabels.stream().filter(label -> label.key().equals(Label.CORRELATION_ID)).toList();
-        return Pair.of(standardLabels, systemLabels);
+
+        // check for system labels: none can be passed at execution creation time except system_correlationId
+        Optional<Label> first = parsedLabels.stream().filter(label -> !label.key().equals(CORRELATION_ID) && label.key().startsWith(SYSTEM_PREFIX)).findFirst();
+        if (first.isPresent()) {
+            throw new IllegalArgumentException("System labels can only be set by Kestra itself, offending label: " + first.get().key() + "=" + first.get().value());
+        }
+        return parsedLabels;
     }
 
     protected <T> HttpResponse<T> validateFile(String executionId, URI path, String redirect) {
@@ -1699,6 +1700,12 @@ public class ExecutionController {
     }
 
     private Execution setLabels(Execution execution, List<Label> labels) {
+        // check for system labels: none can be passed at runtime
+        Optional<Label> first = labels.stream().filter(label -> label.key().startsWith(SYSTEM_PREFIX)).findFirst();
+        if (first.isPresent()) {
+            throw new IllegalArgumentException("System labels can only be set by Kestra itself, offending label: " + first.get().key() + "=" + first.get().value());
+        }
+
         Map<String, String> newLabels = labels.stream().collect(Collectors.toMap(Label::key, Label::value));
         if (execution.getLabels() != null) {
             execution.getLabels().forEach(

--- a/webserver/src/test/java/io/kestra/webserver/controllers/api/ExecutionControllerTest.java
+++ b/webserver/src/test/java/io/kestra/webserver/controllers/api/ExecutionControllerTest.java
@@ -1594,13 +1594,28 @@ class ExecutionControllerTest extends JdbcH2ControllerTest {
     }
 
     @Test
-    void shouldRefuseSystemLabels() {
+    void shouldRefuseSystemLabelsWhenCreatingAnExecution() {
         var error = assertThrows(HttpClientResponseException.class, () -> client.toBlocking().retrieve(
             HttpRequest
                 .POST("/api/v1/executions/io.kestra.tests/minimal?labels=system_label:system", null)
                 .contentType(MediaType.MULTIPART_FORM_DATA_TYPE),
             Execution.class
         ));
+
+        assertThat(error.getStatus(), is(HttpStatus.UNPROCESSABLE_ENTITY));
+    }
+
+    @Test
+    void shouldRefuseSystemLabelsWhenUpdatingLabels() throws QueueException, TimeoutException {
+        // update label on a terminated execution
+        Execution result = runnerUtils.runOne(null, "io.kestra.tests", "minimal");
+        assertThat(result.getState().getCurrent(), is(State.Type.SUCCESS));
+
+        var error = assertThrows(HttpClientResponseException.class, () -> client.toBlocking().retrieve(
+                HttpRequest.POST("/api/v1/executions/" + result.getId() + "/labels", List.of(new Label("system_label", "value"))),
+                Execution.class
+            )
+        );
 
         assertThat(error.getStatus(), is(HttpStatus.UNPROCESSABLE_ENTITY));
     }


### PR DESCRIPTION
Make the flow editor read only when a flow has the label `system_readOnly`.
Part-of: https://github.com/kestra-io/kestra-ee/issues/1867

Refator all the system label handling code, which fixes https://github.com/kestra-io/kestra-ee/issues/2001