### PR TITLE
feat(ui): No message when flow list is empty

### DIFF
--- a/ui/src/components/flows/Flows.vue
+++ b/ui/src/components/flows/Flows.vue
@@ -86,8 +86,9 @@
                     </el-card>
                 </template>
 
-                <template #table v-if="flows.length">
+                <template #table>
                     <select-table
+                        v-if="flows.length"
                         ref="selectTable"
                         :data="flows"
                         :default-sort="{prop: 'id', order: 'ascending'}"
@@ -216,9 +217,8 @@
                             </el-table-column>
                         </template>
                     </select-table>
-                </template>
-                <template #table v-else>
-                    <el-empty :description="$t('no_data')" />
+
+                    <el-empty v-else :description="$t('no_data')" />
                 </template>
             </data-table>
         </div>
@@ -560,6 +560,7 @@
                     .then(flows => {
                         this.dailyGroupByFlowReady = false;
                         this.lastExecutionByFlowReady = false;
+
                         if (flows.results && flows.results.length > 0) {
                             if (this.user && this.user.hasAny(permission.EXECUTION)) {
                                 this.$store

--- a/ui/src/components/flows/Flows.vue
+++ b/ui/src/components/flows/Flows.vue
@@ -550,7 +550,6 @@
             },
             loadData(callback) {
                 this.loadStats();
-                console.log("inside loadData");
 
                 this.$store
                     .dispatch("flow/findFlows", this.loadQuery({
@@ -561,7 +560,6 @@
                     .then(flows => {
                         this.dailyGroupByFlowReady = false;
                         this.lastExecutionByFlowReady = false;
-                        console.log("flows length", flows.results);
                         if (flows.results && flows.results.length > 0) {
                             if (this.user && this.user.hasAny(permission.EXECUTION)) {
                                 this.$store

--- a/ui/src/components/flows/Flows.vue
+++ b/ui/src/components/flows/Flows.vue
@@ -217,6 +217,9 @@
                         </template>
                     </select-table>
                 </template>
+                <template #table v-else>
+                    <el-empty :description="$t('no_data')" />
+                </template>
             </data-table>
         </div>
     </section>
@@ -547,6 +550,7 @@
             },
             loadData(callback) {
                 this.loadStats();
+                console.log("inside loadData");
 
                 this.$store
                     .dispatch("flow/findFlows", this.loadQuery({
@@ -557,7 +561,7 @@
                     .then(flows => {
                         this.dailyGroupByFlowReady = false;
                         this.lastExecutionByFlowReady = false;
-
+                        console.log("flows length", flows.results);
                         if (flows.results && flows.results.length > 0) {
                             if (this.user && this.user.hasAny(permission.EXECUTION)) {
                                 this.$store


### PR DESCRIPTION
<!-- Thanks for submitting a Pull Request to Kestra. To help us review your contribution, please follow the guidelines below:

- Make sure that your commits follow the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) specification e.g. `feat(ui): add a new navigation menu item` or `fix(core): fix a bug in the core model` or `docs: update the README.md`. This will help us automatically generate the changelog.
- The title should briefly summarize the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share a flow example to help the reviewer understand and QA the change.
- Use "closes" to automatically close an issue. For example, `closes #1234` will close issue #1234. -->

### What changes are being made and why?

<!-- Please include a brief summary of the changes included in this PR e.g. closes #1234. -->

---
Closes #5632
Made changes to flows.vue. 
Previously, when the list of flows was empty, no message was displayed. This has been fixed, and now a message stating "No Data Available" will be shown when there are no flows.

### Output

https://github.com/user-attachments/assets/1b38abe5-3638-4cad-843b-ef382388b93c



### Setup Instructions

<!--If there are any setup requirements like API keys or trial accounts, kindly include brief bullet-points-description outlining the setup process below.

- [External System Documentation](URL)
- Steps to set up the necessary resources
not needed
If there are no setup requirements, you can remove this section.

Thank you for your contribution. ❤️  -->
not needed
