### PR TITLE
Feat(ui): Change to location for the save button on settings page

### DIFF
--- a/ui/src/components/settings/BasicSettings.vue
+++ b/ui/src/components/settings/BasicSettings.vue
@@ -1,5 +1,11 @@
 <template>
-    <top-nav-bar :title="routeInfo.title" />
+    <top-nav-bar :title="routeInfo.title">
+        <template #additional-right>
+            <el-button @click="saveAllSettings()" type="primary">
+                {{ $t("settings.blocks.save.fields.name") }}
+            </el-button>
+        </template>
+    </top-nav-bar>
 
     <Wrapper>
         <Block :heading="$t('settings.blocks.configuration.label')">
@@ -178,18 +184,6 @@
                     <Column>
                         <el-button v-if="canReadTemplates" :icon="Download" @click="exportTemplates()" :hidden="!configs?.isTemplateEnabled" class="w-100">
                             {{ $t("settings.blocks.export.fields.templates") }}
-                        </el-button>
-                    </Column>
-                </Row>
-            </template>
-        </Block>
-
-        <Block last>
-            <template #content>
-                <Row>
-                    <Column>
-                        <el-button @click="saveAllSettings()" class="w-60" type="primary">
-                            {{ $t("settings.blocks.save.fields.name") }}
                         </el-button>
                     </Column>
                 </Row>


### PR DESCRIPTION
<!-- Thanks for submitting a Pull Request to Kestra. To help us review your contribution, please follow the guidelines below:

- Make sure that your commits follow the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) specification e.g. `feat(ui): add a new navigation menu item` or `fix(core): fix a bug in the core model` or `docs: update the README.md`. This will help us automatically generate the changelog.
- The title should briefly summarize the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share a flow example to help the reviewer understand and QA the change.
- Use "closes" to automatically close an issue. For example, `closes #1234` will close issue #1234. -->

### What changes are being made and why?

#### Fixes #5695 

On settings page the "Save" button has been moved to the navigation bar

![image](https://github.com/user-attachments/assets/229a0851-54e9-4c6b-abdc-be9f140be3e6)

<!-- Please include a brief summary of the changes included in this PR e.g. closes #1234. -->

---

### How the changes have been QAed?

Save button location is changed for settings page only

<!-- Include example code that shows how this PR has been QAed. The code should present a complete yet easily reproducible flow.

```yaml
# Your example flow code here
```

Note that this is not a replacement for unit tests but rather a way to demonstrate how the changes work in a real-life scenario, as the end-user would experience them.

Remove this section if this change applies to all flows or to the documentation only. -->

---

### Setup Instructions

NA
<!--If there are any setup requirements like API keys or trial accounts, kindly include brief bullet-points-description outlining the setup process below.

- [External System Documentation](URL)
- Steps to set up the necessary resources

If there are no setup requirements, you can remove this section.

Thank you for your contribution. ❤️  -->
