### PR TITLE
feat: add support for deleting empty namespace parent folders

### DIFF
--- a/core/src/main/java/io/kestra/core/storages/Namespace.java
+++ b/core/src/main/java/io/kestra/core/storages/Namespace.java
@@ -118,6 +118,16 @@ public interface Namespace {
     }
 
     /**
+     * Deletes namespaces directories at the given path.
+     *
+     * @param file the {@link NamespaceFile} to be deleted.
+     * @throws IOException if an error happens while performing the delete operation.
+     */
+    default boolean deleteDirectory(NamespaceFile file) throws IOException {
+        return delete(Path.of(file.path()));
+    }
+
+    /**
      * Deletes any namespaces files at the given path.
      *
      * @param path the path to be deleted.
@@ -125,6 +135,21 @@ public interface Namespace {
      * @throws IOException if an error happens while performing the delete operation.
      */
     boolean delete(Path path) throws IOException;
+
+    /**
+     * Checks if a directory is empty.
+     *
+     * @param path the directory path to check
+     * @return true if the directory is empty or doesn't exist, false otherwise
+     * @throws IOException if an error occurs while checking the directory
+     */
+    default boolean isDirectoryEmpty(String path) throws IOException {
+        List<NamespaceFile> files = findAllFilesMatching(
+            List.of(path + "/**"),
+            List.of()
+        );
+        return files.isEmpty();
+    }
 
     enum Conflicts {
         OVERWRITE,

--- a/core/src/main/java/io/kestra/plugin/core/namespace/DeleteFiles.java
+++ b/core/src/main/java/io/kestra/plugin/core/namespace/DeleteFiles.java
@@ -22,8 +22,6 @@ import org.slf4j.Logger;
 
 import java.io.IOException;
 import java.net.URI;
-import java.util.Collections;
-import java.util.HashSet;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;

--- a/core/src/main/java/io/kestra/plugin/core/namespace/DeleteFiles.java
+++ b/core/src/main/java/io/kestra/plugin/core/namespace/DeleteFiles.java
@@ -95,6 +95,7 @@ public class DeleteFiles extends Task implements RunnableTask<Output> {
         defaultValue = "false"
     )
     @PluginProperty(dynamic = false)
+    @Builder.Default
     private Boolean deleteParentFolder = false;
 
     @SuppressWarnings("unchecked")

--- a/core/src/main/java/io/kestra/plugin/core/namespace/DeleteFiles.java
+++ b/core/src/main/java/io/kestra/plugin/core/namespace/DeleteFiles.java
@@ -11,6 +11,7 @@ import io.kestra.core.storages.Namespace;
 import io.kestra.core.storages.NamespaceFile;
 import io.kestra.core.utils.PathMatcherPredicate;
 import io.kestra.core.utils.Rethrow;
+import io.kestra.plugin.core.namespace.DeleteFiles.Output;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import lombok.Builder;
@@ -19,10 +20,15 @@ import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
 import org.slf4j.Logger;
 
+import java.io.IOException;
 import java.net.URI;
+import java.util.Collections;
+import java.util.HashSet;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.TreeSet;
 
 @SuperBuilder
 @Getter
@@ -66,7 +72,7 @@ import java.util.Map;
         )
     }
 )
-public class DeleteFiles extends Task implements RunnableTask<DeleteFiles.Output> {
+public class DeleteFiles extends Task implements RunnableTask<Output> {
     @NotNull
     @Schema(
         title = "The namespace from which the files should be deleted."
@@ -82,6 +88,14 @@ public class DeleteFiles extends Task implements RunnableTask<DeleteFiles.Output
     )
     @PluginProperty(dynamic = true)
     private Object files;
+
+    @Schema(
+        title = "Whether to delete empty parent folders after deleting files.",
+        description = "If true, parent folders that become empty after file deletion will also be removed.",
+        defaultValue = "false"
+    )
+    @PluginProperty(dynamic = false)
+    private Boolean deleteParentFolder = false;
 
     @SuppressWarnings("unchecked")
     @Override
@@ -101,11 +115,16 @@ public class DeleteFiles extends Task implements RunnableTask<DeleteFiles.Output
         }
 
         List<NamespaceFile> matched = namespace.findAllFilesMatching(PathMatcherPredicate.matches(renderedFiles));
+        Set<String> parentFolders = Boolean.TRUE.equals(deleteParentFolder) ? new TreeSet<>() : null;
         long count = matched
             .stream()
             .map(Rethrow.throwFunction(file -> {
                 if (namespace.delete(NamespaceFile.of(renderedNamespace, Path.of(file.path().replace("\\","/"))).storagePath())) {
                     logger.debug(String.format("Deleted %s", (file.path())));
+
+                    if (Boolean.TRUE.equals(deleteParentFolder)) {
+                        trackParentFolder(file, parentFolders);
+                    }
                     return true;
                 }
                 return false;
@@ -113,8 +132,45 @@ public class DeleteFiles extends Task implements RunnableTask<DeleteFiles.Output
             .filter(Boolean::booleanValue)
             .count();
 
+        // Handle folder deletion if enabled
+        if (parentFolders != null && !parentFolders.isEmpty()) {
+            deleteEmptyFolders(namespace, parentFolders, logger);
+        }
+
         runContext.metric(Counter.of("deleted", count));
         return Output.builder().build();
+    }
+
+    private void deleteEmptyFolders(Namespace namespace, Set<String> folders, Logger logger) {
+        folders.stream()
+            .sorted((a, b) -> b.split("/").length - a.split("/").length)
+            .forEach(folderPath -> {
+                try {
+                    if (namespace.isDirectoryEmpty(folderPath)) {
+                        // Create proper NamespaceFile for folder with trailing slash
+                        NamespaceFile folder = NamespaceFile.of(
+                            namespace.namespace(),
+                            URI.create(folderPath + "/")
+                        );
+
+                        if (namespace.deleteDirectory(folder)) {
+                            logger.debug("Deleted empty folder: {}", folderPath);
+                        }
+                    }
+                } catch (IOException e) {
+                    logger.warn("Failed to delete folder: " + folderPath, e);
+                }
+            });
+    }
+
+    private void trackParentFolder(NamespaceFile file, Set<String> parentFolders) {
+        String path = file.path();
+        int lastSlash = path.lastIndexOf('/');
+        while (lastSlash > 0) {
+            path = path.substring(0, lastSlash);
+            parentFolders.add(path);
+            lastSlash = path.lastIndexOf('/');
+        }
     }
 
     @Builder

--- a/core/src/test/java/io/kestra/plugin/core/namespace/DeleteFilesTest.java
+++ b/core/src/test/java/io/kestra/plugin/core/namespace/DeleteFilesTest.java
@@ -54,4 +54,89 @@ public class DeleteFilesTest {
         // Then
         assertThat(namespace.all("/a/b/", false).size(), is(1));
     }
+
+    @Test
+    void shouldDeleteParentFolder() throws Exception {
+        // Given
+        String namespaceId = "io.kestra." + IdUtils.create();
+
+        DeleteFiles deleteFiles = DeleteFiles.builder()
+            .id(DeleteFiles.class.getSimpleName())
+            .type(DeleteFiles.class.getName())
+            .files(List.of("**/file.txt"))
+            .namespace("{{ inputs.namespace }}")
+            .deleteParentFolder(true)
+            .build();
+
+        final RunContext runContext = TestsUtils.mockRunContext(this.runContextFactory, deleteFiles, Map.of("namespace", namespaceId));
+        final Namespace namespace = runContext.storage().namespace(namespaceId);
+
+        namespace.putFile(Path.of("/folder/file.txt"), new ByteArrayInputStream("content".getBytes(StandardCharsets.UTF_8)));
+
+        assertThat(namespace.all("/folder/", false).size(), is(1));
+
+        // When
+        assertThat(deleteFiles.run(runContext), notNullValue());
+
+        // Then
+        assertThat(namespace.all("/folder/", false).size(), is(0));
+        assertThat(namespace.all("/", false).size(), is(0));
+    }
+
+    @Test
+    void shouldNotDeleteParentFolderWhenFlagIsFalse() throws Exception {
+        // Given
+        String namespaceId = "io.kestra." + IdUtils.create();
+
+        DeleteFiles deleteFiles = DeleteFiles.builder()
+            .id(DeleteFiles.class.getSimpleName())
+            .type(DeleteFiles.class.getName())
+            .files(List.of("**/file.txt"))
+            .namespace("{{ inputs.namespace }}")
+            .deleteParentFolder(false)
+            .build();
+
+        final RunContext runContext = TestsUtils.mockRunContext(this.runContextFactory, deleteFiles, Map.of("namespace", namespaceId));
+        final Namespace namespace = runContext.storage().namespace(namespaceId);
+
+        namespace.putFile(Path.of("/folder/file.txt"), new ByteArrayInputStream("content".getBytes(StandardCharsets.UTF_8)));
+
+        assertThat(namespace.all("/folder/", false).size(), is(1));
+
+        // When
+        assertThat(deleteFiles.run(runContext), notNullValue());
+
+        // Then
+        assertThat(namespace.all("/folder/", false).size(), is(0));
+        assertThat(namespace.all("/", false).size(), is(1)); // Folder should still exist
+    }
+
+    @Test
+    void shouldNotDeleteParentFolderWhenMultipleFilesExist() throws Exception {
+        // Given
+        String namespaceId = "io.kestra." + IdUtils.create();
+
+        DeleteFiles deleteFiles = DeleteFiles.builder()
+            .id(DeleteFiles.class.getSimpleName())
+            .type(DeleteFiles.class.getName())
+            .files(List.of("**/file1.txt"))
+            .namespace("{{ inputs.namespace }}")
+            .deleteParentFolder(true)
+            .build();
+
+        final RunContext runContext = TestsUtils.mockRunContext(this.runContextFactory, deleteFiles, Map.of("namespace", namespaceId));
+        final Namespace namespace = runContext.storage().namespace(namespaceId);
+
+        namespace.putFile(Path.of("/folder/file1.txt"), new ByteArrayInputStream("content1".getBytes(StandardCharsets.UTF_8)));
+        namespace.putFile(Path.of("/folder/file2.txt"), new ByteArrayInputStream("content2".getBytes(StandardCharsets.UTF_8)));
+
+        assertThat(namespace.all("/folder/", false).size(), is(2));
+
+        // When
+        assertThat(deleteFiles.run(runContext), notNullValue());
+
+        // Then
+        assertThat(namespace.all("/folder/", false).size(), is(1)); // One file should still exist
+        assertThat(namespace.all("/", false).size(), is(1)); // Folder should still exist
+    }
 }

--- a/core/src/test/java/io/kestra/plugin/core/namespace/DeleteFilesTest.java
+++ b/core/src/test/java/io/kestra/plugin/core/namespace/DeleteFilesTest.java
@@ -1,12 +1,11 @@
 package io.kestra.plugin.core.namespace;
 
+import io.kestra.core.junit.annotations.KestraTest;
 import io.kestra.core.runners.RunContext;
 import io.kestra.core.runners.RunContextFactory;
 import io.kestra.core.storages.Namespace;
-import io.kestra.core.storages.StorageInterface;
 import io.kestra.core.utils.IdUtils;
 import io.kestra.core.utils.TestsUtils;
-import io.kestra.core.junit.annotations.KestraTest;
 import jakarta.inject.Inject;
 import org.junit.jupiter.api.Test;
 
@@ -22,9 +21,6 @@ import static org.hamcrest.Matchers.notNullValue;
 
 @KestraTest
 public class DeleteFilesTest {
-    @Inject
-    StorageInterface storageInterface;
-
     @Inject
     RunContextFactory runContextFactory;
 
@@ -108,7 +104,7 @@ public class DeleteFilesTest {
 
         // Then
         assertThat(namespace.all("/folder/", false).size(), is(0));
-        assertThat(namespace.all("/", false).size(), is(1)); // Folder should still exist
+        assertThat(namespace.all("/", true).size(), is(1)); // Folder should still exist
     }
 
     @Test


### PR DESCRIPTION
<!-- Thanks for submitting a Pull Request to Kestra. To help us review your contribution, please follow the guidelines below:

- Make sure that your commits follow the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) specification e.g. `feat(ui): add a new navigation menu item` or `fix(core): fix a bug in the core model` or `docs: update the README.md`. This will help us automatically generate the changelog.
- The title should briefly summarize the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share a flow example to help the reviewer understand and QA the change.
- Use "closes" to automatically close an issue. For example, `closes #1234` will close issue #1234. -->

### What changes are being made and why?
- Add deleteParentFolder flag to DeleteFiles task (default: false), when enabled, parent folders that become empty after file deletion are also removed.
Parent folders are deleted in reverse depth order to handle nested folders correctly.
This enhancement allows for cleaning up empty folder structures after file deletion.

closes #4807 
<!-- Please include a brief summary of the changes included in this PR e.g. closes #1234. -->

