### PR TITLE
fix(core): save the If evaluation condition in the output

### DIFF
--- a/core/src/main/java/io/kestra/core/runners/pebble/functions/CurrentEachOutputFunction.java
+++ b/core/src/main/java/io/kestra/core/runners/pebble/functions/CurrentEachOutputFunction.java
@@ -27,7 +27,10 @@ public class CurrentEachOutputFunction implements Function {
         if (parents != null && !parents.isEmpty()) {
             Collections.reverse(parents);
             for (Map<?, ?> parent : parents) {
-                outputs = (Map<?, ?>) outputs.get(((Map<?, ?>) parent.get("taskrun")).get("value"));
+                Map<?, ?> taskrun = (Map<?, ?>) parent.get("taskrun");
+                if (taskrun != null) {
+                    outputs = (Map<?, ?>) outputs.get(taskrun.get("value"));
+                }
             }
         }
         Map<?, ?> taskrun = (Map<?, ?>) context.getVariable("taskrun");

--- a/core/src/test/java/io/kestra/core/tasks/FetchTest.java
+++ b/core/src/test/java/io/kestra/core/tasks/FetchTest.java
@@ -3,9 +3,7 @@ package io.kestra.core.tasks;
 import io.kestra.core.models.executions.Execution;
 import io.kestra.core.models.executions.TaskRun;
 import io.kestra.core.models.flows.State;
-import io.kestra.core.repositories.FlowRepositoryInterface;
 import io.kestra.core.runners.AbstractMemoryRunnerTest;
-import jakarta.inject.Inject;
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -13,17 +11,14 @@ import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 
 public class FetchTest extends AbstractMemoryRunnerTest {
-    @Inject
-    FlowRepositoryInterface flowRepository;
-
     @Test
     void fetch() throws Exception {
         Execution execution = runnerUtils.runOne(null, "io.kestra.tests", "get-log");
 
         assertThat(execution.getState().getCurrent(), is(State.Type.SUCCESS));
-        assertThat(execution.getTaskRunList(), hasSize(3));
-        TaskRun fetch = execution.getTaskRunList().get(2);
-        assertThat(fetch.getOutputs().get("size"), is(2));
+        assertThat(execution.getTaskRunList(), hasSize(4));
+        TaskRun fetch = execution.findTaskRunsByTaskId("get-log-task").getFirst();
+        assertThat(fetch.getOutputs().get("size"), is(3));
     }
 
     @Test
@@ -31,8 +26,8 @@ public class FetchTest extends AbstractMemoryRunnerTest {
         Execution execution = runnerUtils.runOne(null, "io.kestra.tests", "get-log-taskid");
 
         assertThat(execution.getState().getCurrent(), is(State.Type.SUCCESS));
-        assertThat(execution.getTaskRunList(), hasSize(3));
-        TaskRun fetch = execution.getTaskRunList().get(2);
+        assertThat(execution.getTaskRunList(), hasSize(4));
+        TaskRun fetch = execution.findTaskRunsByTaskId("get-log-task").getFirst();
         assertThat(fetch.getOutputs().get("size"), is(1));
     }
 
@@ -41,8 +36,8 @@ public class FetchTest extends AbstractMemoryRunnerTest {
         Execution execution = runnerUtils.runOne(null, "io.kestra.tests", "get-log-executionid");
 
         assertThat(execution.getState().getCurrent(), is(State.Type.SUCCESS));
-        assertThat(execution.getTaskRunList(), hasSize(3));
-        TaskRun fetch = execution.getTaskRunList().get(2);
-        assertThat(fetch.getOutputs().get("size"), is(2));
+        assertThat(execution.getTaskRunList(), hasSize(4));
+        TaskRun fetch = execution.findTaskRunsByTaskId("get-log-task").getFirst();
+        assertThat(fetch.getOutputs().get("size"), is(3));
     }
 }

--- a/core/src/test/resources/flows/valids/get-log-executionid.yaml
+++ b/core/src/test/resources/flows/valids/get-log-executionid.yaml
@@ -7,6 +7,10 @@ tasks:
   - type: io.kestra.plugin.core.debug.Echo
     id: task-2
     format: task 2
+  # as logs are async, to get your own logs reliably on tasks that run quickly, you must sleep a little
+  - type: io.kestra.plugin.core.flow.Sleep
+    id: sleep
+    duration: PT0.1S
   - type: io.kestra.plugin.core.log.Fetch
     id: get-log-task
     executionId: "{{execution.id}}"

--- a/core/src/test/resources/flows/valids/get-log-taskid.yaml
+++ b/core/src/test/resources/flows/valids/get-log-taskid.yaml
@@ -7,6 +7,10 @@ tasks:
   - type: io.kestra.plugin.core.debug.Echo
     id: task-2
     format: task 2
+  # as logs are async, to get your own logs reliably on tasks that run quickly, you must sleep a little
+  - type: io.kestra.plugin.core.flow.Sleep
+    id: sleep
+    duration: PT0.1S
   - type: io.kestra.plugin.core.log.Fetch
     id: get-log-task
     tasksId:

--- a/core/src/test/resources/flows/valids/get-log.yaml
+++ b/core/src/test/resources/flows/valids/get-log.yaml
@@ -7,5 +7,9 @@ tasks:
   - type: io.kestra.plugin.core.debug.Echo
     id: task-2
     format: task 2
+  # as logs are async, to get your own logs reliably on tasks that run quickly, you must sleep a little
+  - type: io.kestra.plugin.core.flow.Sleep
+    id: sleep
+    duration: PT0.1S
   - type: io.kestra.plugin.core.log.Fetch
     id: get-log-task


### PR DESCRIPTION
This avoids re-evaluation on each child task run which can be an issue if the taskrun modify something that is part of the condition.

Fixes #5437