### PR TITLE
bug(ui): chart fix with system theme mode (kestra-io#1949)

### DIFF
--- a/ui/src/components/settings/BasicSettings.vue
+++ b/ui/src/components/settings/BasicSettings.vue
@@ -278,7 +278,7 @@
             this.pendingSettings.lang = Utils.getLang();
             this.pendingSettings.theme = localStorage.getItem("theme") || "light";
             this.pendingSettings.editorTheme = localStorage.getItem("editorTheme") || "dark";
-            this.pendingSettings.chartColor = localStorage.getItem("scheme") || "default";
+            this.pendingSettings.chartColor = localStorage.getItem("scheme") || "classic";
             this.pendingSettings.dateFormat = localStorage.getItem(DATE_FORMAT_STORAGE_KEY) || "llll";
             this.pendingSettings.timezone = localStorage.getItem(TIMEZONE_STORAGE_KEY) || this.$moment.tz.guess();
             this.pendingSettings.autofoldTextEditor = localStorage.getItem("autofoldTextEditor") === "true";


### PR DESCRIPTION
This PR helps in resolving the issue faced with charts color scheme based on adding the new "Sync with System" option. Closes #1949 

## What changes are being made and why?
BasicSettings.vue: Modified the chartColor variable to default to "classic" if no value was set.


