### PR TITLE
bug(ui): Display download/preview button for file types in new Column…

### DIFF
--- a/ui/src/components/executions/Overview.vue
+++ b/ui/src/components/executions/Overview.vue
@@ -79,7 +79,11 @@
 
         <div v-if="execution.inputs" class="my-5">
             <h5>{{ $t("inputs") }}</h5>
-            <KestraCascader :options="transform(execution.inputs)" class="overflow-auto" />
+            <KestraCascader
+                :options="transform(execution.inputs)"
+                :execution="execution"
+                class="overflow-auto"
+            />
         </div>
 
         <div v-if="execution.variables" class="my-5">

--- a/ui/src/components/kestra/Cascader.vue
+++ b/ui/src/components/kestra/Cascader.vue
@@ -1,9 +1,29 @@
 <template>
-    <el-cascader-panel :options="options" />
+    <el-cascader-panel :options="options">
+        <template #default="{data}">
+            <div v-if="isFile(data.value)">
+                <VarValue :value="data.value" :execution="execution" />
+            </div>
+            <div v-else class="w-100 d-flex justify-content-between">
+                <div class="pe-5 d-flex task">
+                    <span>{{ trim(data.label) }}</span>
+                </div>
+                <div v-if="data.value && data.children">
+                    <code>
+                        {{ data.children.length }} times
+                    </code>
+                </div>
+            </div>
+        </template>
+    </el-cascader-panel>
 </template>
 
 <script setup lang="ts">
-    import type {PropType} from "vue";
+    import {type PropType} from "vue";
+    import VarValue from "../executions/VarValue.vue";
+
+    const isFile = (data) => typeof(data) === "string" && data.startsWith("kestra:///");
+    const trim = (value) => (typeof value !== "string" || value.length < 16) ? value : `${value.substring(0, 16)}...`;
 
     interface Options {
         label: string;
@@ -16,5 +36,10 @@
             type: Object as PropType<Options>,
             required: true,
         },
+        execution: {
+            type: Object,
+            required: false,
+            default: undefined
+        }
     });
 </script>


### PR DESCRIPTION
closes #5741

### How the changes have been QAed?
Create a flow with all possible input types and verify inputs are displayed as expected. Specifically for file types, download/preview button should be visible.

```yaml
id: repro
namespace: demo
inputs:
  - id: columns_to_keepjhbhjdbvchjdfhjbhjdbch
    type: ARRAY
    itemType: STRING
    defaults: 
      - brand
      - price
  - id: file
    type: FILE
  - id: file-1
    type: FILE
  - id: date
    type: DATE
  - id: boolean
    type: BOOLEAN
  - id: datetime
    type: DATETIME
  - id: enum
    type: ENUM
    values:
      - hi
      - hello
  - id: int
    type: INT
  - id: float
    type: FLOAT

tasks:
  - id: hello
    type: io.kestra.plugin.core.log.Log
    message: Hello 
```
