### PR TITLE
Chore/upload file

### DIFF
--- a/core/src/test/java/io/kestra/core/runners/FlowInputOutputTest.java
+++ b/core/src/test/java/io/kestra/core/runners/FlowInputOutputTest.java
@@ -305,5 +305,9 @@ class FlowInputOutputTest {
         public boolean isComplete() {
             return true;
         }
+
+        @Override
+        public void discard() {
+        }
     }
 }

--- a/webserver/src/main/java/io/kestra/webserver/controllers/api/FlowController.java
+++ b/webserver/src/main/java/io/kestra/webserver/controllers/api/FlowController.java
@@ -858,6 +858,7 @@ public class FlowController {
                 }
             }
         } else {
+            fileUpload.discard();
             throw new IllegalArgumentException("Cannot import file of type " + fileName.substring(fileName.lastIndexOf('.')));
         }
 

--- a/webserver/src/main/java/io/kestra/webserver/controllers/api/NamespaceFileController.java
+++ b/webserver/src/main/java/io/kestra/webserver/controllers/api/NamespaceFileController.java
@@ -154,7 +154,7 @@ public class NamespaceFileController {
         @Part CompletedFileUpload fileContent
     ) throws IOException, URISyntaxException {
         String tenantId = tenantService.resolveTenant();
-        if(fileContent.getFilename().toLowerCase().endsWith(".zip")) {
+        if (fileContent.getFilename().toLowerCase().endsWith(".zip")) {
             try (ZipInputStream archive = new ZipInputStream(fileContent.getInputStream())) {
                 ZipEntry entry;
                 while ((entry = archive.getNextEntry()) != null) {
@@ -162,11 +162,13 @@ public class NamespaceFileController {
                         continue;
                     }
 
-                    putNamespaceFile(tenantId, namespace, URI.create("/" + entry.getName()), new BufferedInputStream(new ByteArrayInputStream(archive.readAllBytes())));
+                    try (BufferedInputStream inputStream = new BufferedInputStream(new ByteArrayInputStream(archive.readAllBytes()))) {
+                        putNamespaceFile(tenantId, namespace, URI.create("/" + entry.getName()), inputStream);
+                    }
                 }
             }
         } else {
-            try(BufferedInputStream inputStream = new BufferedInputStream(fileContent.getInputStream()) {
+            try (BufferedInputStream inputStream = new BufferedInputStream(fileContent.getInputStream()) {
                 // Done to bypass the wrong available() output of the CompletedFileUpload InputStream
                 @Override
                 public synchronized int available() {

--- a/webserver/src/main/java/io/kestra/webserver/controllers/api/TemplateController.java
+++ b/webserver/src/main/java/io/kestra/webserver/controllers/api/TemplateController.java
@@ -371,6 +371,7 @@ public class TemplateController {
                 }
             }
         } else {
+            fileUpload.discard();
             throw new IllegalArgumentException("Cannot import file of type " + fileName.substring(fileName.lastIndexOf('.')));
         }
 


### PR DESCRIPTION
- Ensure all input stream are closed
- Ensure all CompletedFileUpload are consumed by calling `discard()` if needed
- Switch input upload to the boundedElastic scheduler