### PR TITLE
feat(ui) namespace logo change.

### DIFF
--- a/ui/src/components/namespace/Namespaces.vue
+++ b/ui/src/components/namespace/Namespaces.vue
@@ -31,7 +31,7 @@
                 <template #default="{data}">
                     <router-link :to="{name: 'namespaces/update', params: {id: data.id, tab: data.system ? 'blueprints': ''}}" tag="div" class="node">
                         <div class="d-flex">
-                            <VectorIntersection class="me-2 icon" />
+                            <DotsSquare class="me-2 icon" />
                             <span class="pe-3">{{ namespaceLabel(data.label) }}</span>
                             <span v-if="data.system" class="system">{{ $t("system_namespace") }}</span>
                         </div>
@@ -60,7 +60,7 @@
 
     import Plus from "vue-material-design-icons/Plus.vue";
     import Magnify from "vue-material-design-icons/Magnify.vue";
-    import VectorIntersection from "vue-material-design-icons/VectorIntersection.vue";
+    import DotsSquare from "vue-material-design-icons/DotsSquare.vue";
     import TextSearch from "vue-material-design-icons/TextSearch.vue";
 
     const store = useStore();

--- a/ui/src/override/components/LeftMenu.vue
+++ b/ui/src/override/components/LeftMenu.vue
@@ -20,7 +20,7 @@
     import TimerCogOutline from "vue-material-design-icons/TimerCogOutline.vue";
     import ChartBoxOutline from "vue-material-design-icons/ChartBoxOutline.vue";
     import Connection from "vue-material-design-icons/Connection.vue";
-    import VectorIntersection from "vue-material-design-icons/VectorIntersection.vue";
+    import DotsSquare from "vue-material-design-icons/DotsSquare.vue";
     import AccountOutline from "vue-material-design-icons/AccountOutline.vue";
     import ShieldCheckOutline from "vue-material-design-icons/ShieldCheckOutline.vue";
     import ServerOutline from "vue-material-design-icons/ServerOutline.vue";
@@ -105,7 +105,7 @@
                 routes: routeStartWith("namespaces"),
                 title: t("namespaces"),
                 icon: {
-                    element: shallowRef(VectorIntersection),
+                    element: shallowRef(DotsSquare),
                     class: "menu-icon"
                 }
             },


### PR DESCRIPTION
Added vue-material-design-icons/DotsSquare.vue as suggested by @anna-geller 

![image](https://github.com/user-attachments/assets/1a264f39-0954-43b2-9ce6-cccbfad2bc6f)

Color being used:
$active: #A396FF;
$system: #5BB8FF;

Closes: https://github.com/kestra-io/kestra/issues/5824

Please feel free to suggest any changes if required. Thanks @MilosPaunovic  for the assignment 😊