### PR TITLE
fix: set title when favoriting a flow & clean URL parameters that change

### DIFF
--- a/ui/src/components/dashboard/Dashboard.vue
+++ b/ui/src/components/dashboard/Dashboard.vue
@@ -469,7 +469,7 @@
         }
 
 
-        updateParams();
+        updateParams(route.query);
     });
 </script>
 

--- a/ui/src/components/flows/FlowRootTopBar.vue
+++ b/ui/src/components/flows/FlowRootTopBar.vue
@@ -1,5 +1,5 @@
 <template>
-    <top-nav-bar :breadcrumb="routeInfo.breadcrumb">
+    <top-nav-bar :breadcrumb="routeInfo.breadcrumb" :title="routeInfo.title">
         <template #title>
             <template v-if="deleted">
                 <Alert class="text-warning me-2" />Deleted:&nbsp;

--- a/ui/src/components/layout/TopNavBar.vue
+++ b/ui/src/components/layout/TopNavBar.vue
@@ -100,6 +100,7 @@
         </div>
     </nav>
 </template>
+
 <script>
     import {mapState, mapGetters} from "vuex";
     import Auth from "override/components/auth/Auth.vue";
@@ -136,7 +137,7 @@
         props: {
             title: {
                 type: String,
-                default: ""
+                required: true
             },
             breadcrumb: {
                 type: Array,
@@ -171,7 +172,12 @@
                 // by mentionning the route in the computed properties
                 // we create a hook into vues reactivity system to update when it updates
                 if(this.$route) {
-                    return `${window.location.pathname}${window.location.search.replace(/&?page=[^&]*/i, "")}`
+                    return window.location.pathname
+                        + window.location.search
+                            // remove the parameters that are permanently changing
+                            .replace(/&?(page|startDate|endDate)=[^&]*/ig, "")
+                            // fix if this resulted in a "?&" url
+                            .replace(/\?&/, "?")
                 }
                 return ""
             }
@@ -196,6 +202,7 @@
                         path: this.currentFavURI
                     })
                 } else {
+                    console.log(this.title, this.breadcrumb)
                     this.$store.dispatch("starred/add", {
                         path: this.currentFavURI,
                         label: this.breadcrumb?.length ? `${this.breadcrumb[0].label}: ${this.title}` : this.title,
@@ -204,7 +211,8 @@
             }
         },
     };
-</script>,
+</script>
+
 <style lang="scss" scoped>
     nav {
         top: 0;

--- a/ui/src/components/layout/TopNavBar.vue
+++ b/ui/src/components/layout/TopNavBar.vue
@@ -175,7 +175,7 @@
                     return window.location.pathname
                         + window.location.search
                             // remove the parameters that are permanently changing
-                            .replace(/&?(page|startDate|endDate)=[^&]*/ig, "")
+                            .replace(/&?page=[^&]*/ig, "")
                             // fix if this resulted in a "?&" url
                             .replace(/\?&/, "?")
                 }


### PR DESCRIPTION
Ensure that favoriting a flow automatically includes its title and remove changing parameters from the URL of a fav.

**Opportunity fix:**
When accessing a dashboard filtered using the Url, the parameters were resetting to the current filter. In short, using the url to filter dates did not work. It was always rolling back to "now". Therefore when bookmarking an old dashboard or an old flow log (a dashboard) it was changing the dates and not remembering. 
Now it does.