### PR TITLE
fix(ui): make whole Gantt task rows active

### DIFF
--- a/ui/src/components/executions/Gantt.vue
+++ b/ui/src/components/executions/Gantt.vue
@@ -35,7 +35,7 @@
                                         <small v-if="item.task && item.task.value"> {{ item.task.value }}</small>
                                     </span>
                                 </el-tooltip>
-                                <div @click="onTaskSelect(item.task)" class="cursor-pointer" :style="'width: ' + (100 / (dates.length + 1)) * dates.length + '%'">
+                                <div @click="onTaskSelect(item.id)" class="cursor-pointer" :style="'width: ' + (100 / (dates.length + 1)) * dates.length + '%'">
                                     <el-tooltip placement="top" :persistent="false" transition="" :hide-after="0" effect="light">
                                         <template #content>
                                             <span style="white-space: pre-wrap;">
@@ -45,7 +45,6 @@
                                         <div
                                             :style="{left: item.start + '%', width: item.width + '%'}"
                                             class="task-progress"
-                                            @click="onTaskSelect(item.id)"
                                         >
                                             <div class="progress">
                                                 <div


### PR DESCRIPTION
### What changes are being made and why?

Being restricted to click at task progress bars led to weird UX in case the duration of tasks differed greatly.

---

### How the changes have been QAed?


```yaml
id: long-short
namespace: company.team

tasks:
  - id: short-task
    type: io.kestra.plugin.core.log.Log
    message: Hello World! 🚀
  - id: long-task
    type: io.kestra.plugin.core.flow.Pause
    delay: PT1M
```