### PR TITLE
fix(ui): do not use element.computedStyleMap()

### DIFF
--- a/ui/src/components/logs/TaskRunDetails.vue
+++ b/ui/src/components/logs/TaskRunDetails.vue
@@ -261,7 +261,8 @@
                         this.$nextTick(() => {
                             const parentScroller = this.$refs.taskRunScroller?.$el?.parentNode?.closest(".vue-recycle-scroller");
                             if (parentScroller) {
-                                this.$refs.taskRunScroller.$el.style.maxHeight = `${parentScroller.computedStyleMap().get("max-height").value - parentScroller.clientHeight}px`;
+                                const scrollerStyles = window.getComputedStyle(parentScroller);
+                                this.$refs.taskRunScroller.$el.style.maxHeight = `${scrollerStyles.getPropertyValue("max-height") - parentScroller.clientHeight}px`;
                             }
                         })
                     }


### PR DESCRIPTION
### What changes are being made and why?

The `element.computedStyleMap()` function is still not widely supported as per: https://developer.mozilla.org/en-US/docs/Web/API/Element/computedStyleMap

This PR attempts to hopefully prevent Firefox errors 🙂