### PR TITLE
fix(build): fix Gradle task listing

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -507,8 +507,13 @@ subprojects {
     }
 
     tasks.register('testsJar', Jar) {
+        group = 'build'
+        description = 'Build the tests jar'
+
         archiveClassifier.set('tests')
-        from sourceSets.test.output
+        if (sourceSets.matching { it.name == 'test'}) {
+            from sourceSets.named('test').get().output
+        }
     }
 
     github {


### PR DESCRIPTION
### What changes are being made and why?

The `gradle tasks` command was broken by subprojects with no `test` source set.

---

### How the changes have been QAed?

```bash
./gradlew tasks
```