### PR TITLE
feat(core): flow SLA

### DIFF
--- a/core/src/main/java/io/kestra/core/models/flows/Flow.java
+++ b/core/src/main/java/io/kestra/core/models/flows/Flow.java
@@ -13,6 +13,7 @@ import io.kestra.core.models.HasUID;
 import io.kestra.core.models.Label;
 import io.kestra.core.models.annotations.PluginProperty;
 import io.kestra.core.models.executions.Execution;
+import io.kestra.core.models.flows.sla.SLA;
 import io.kestra.core.models.listeners.Listener;
 import io.kestra.core.models.tasks.FlowableTask;
 import io.kestra.core.models.tasks.Task;
@@ -116,7 +117,10 @@ public class Flow extends AbstractFlow implements HasUID {
     List<Output> outputs;
 
     @Valid
-    protected AbstractRetry retry;
+    AbstractRetry retry;
+
+    List<SLA> sla;
+
 
     public Logger logger() {
         return LoggerFactory.getLogger("flow." + this.id);

--- a/core/src/main/java/io/kestra/core/models/flows/FlowWithSource.java
+++ b/core/src/main/java/io/kestra/core/models/flows/FlowWithSource.java
@@ -36,6 +36,7 @@ public class FlowWithSource extends Flow {
             .deleted(this.deleted)
             .concurrency(this.concurrency)
             .retry(this.retry)
+            .sla(this.sla)
             .build();
     }
 
@@ -89,6 +90,7 @@ public class FlowWithSource extends Flow {
             .source(source)
             .concurrency(flow.concurrency)
             .retry(flow.retry)
+            .sla(flow.sla)
             .build();
     }
 }

--- a/core/src/main/java/io/kestra/core/models/flows/sla/ExecutionChangedSLA.java
+++ b/core/src/main/java/io/kestra/core/models/flows/sla/ExecutionChangedSLA.java
@@ -1,0 +1,8 @@
+package io.kestra.core.models.flows.sla;
+
+/**
+ * Marker interface to denote an SLA as evaluating on execution change.
+ * ExecutionChangedSLA will be evaluated on each execution change, a.k.a. at the beginning of the processing of the execution queue.
+ */
+public interface ExecutionChangedSLA {
+}

--- a/core/src/main/java/io/kestra/core/models/flows/sla/ExecutionMonitoringSLA.java
+++ b/core/src/main/java/io/kestra/core/models/flows/sla/ExecutionMonitoringSLA.java
@@ -1,0 +1,12 @@
+package io.kestra.core.models.flows.sla;
+
+import java.time.Duration;
+
+/**
+ * Marker interface to denote an SLA as evaluating using an {@link SLAMonitor}.
+ * ExecutionMonitoringSLA will be evaluated on a deadline defined by the monitor;
+ * the monitor is created when the execution is created.
+ */
+public interface ExecutionMonitoringSLA {
+    Duration getDuration();
+}

--- a/core/src/main/java/io/kestra/core/models/flows/sla/SLA.java
+++ b/core/src/main/java/io/kestra/core/models/flows/sla/SLA.java
@@ -1,0 +1,57 @@
+package io.kestra.core.models.flows.sla;
+
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import io.kestra.core.exceptions.InternalException;
+import io.kestra.core.models.executions.Execution;
+import io.kestra.core.models.flows.sla.types.ExecutionConditionSLA;
+import io.kestra.core.models.flows.sla.types.MaxDurationSLA;
+import io.kestra.core.runners.RunContext;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+import java.util.Map;
+import java.util.Optional;
+
+@SuperBuilder
+@Getter
+@NoArgsConstructor
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type", visible = true, include = JsonTypeInfo.As.EXISTING_PROPERTY)
+@JsonSubTypes({
+    @JsonSubTypes.Type(value = MaxDurationSLA.class, name = "MAX_DURATION"),
+    @JsonSubTypes.Type(value = ExecutionConditionSLA.class, name = "EXECUTION_CONDITION"),
+})
+public abstract class SLA {
+    @NotNull
+    @NotEmpty
+    private String id;
+
+    @NotNull
+    private SLA.Type type;
+
+    @NotNull
+    private Behavior behavior;
+
+    // TODO prevent system labels
+    private Map<String, Object> labels;
+
+    /**
+     * Evaluate a flow SLA on an execution.
+     * In case the SLA is exceeded, a violation will be returned.
+     */
+    public abstract Optional<Violation> evaluate(RunContext runContext, Execution execution) throws InternalException;
+
+    public enum Type {
+        MAX_DURATION,
+        EXECUTION_CONDITION,
+    }
+
+    public enum Behavior {
+        FAIL,
+        CANCEL,
+        NONE
+    }
+}

--- a/core/src/main/java/io/kestra/core/models/flows/sla/SLAMonitor.java
+++ b/core/src/main/java/io/kestra/core/models/flows/sla/SLAMonitor.java
@@ -1,0 +1,21 @@
+package io.kestra.core.models.flows.sla;
+
+import io.kestra.core.models.HasUID;
+import io.kestra.core.utils.IdUtils;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.Instant;
+
+@Builder
+@Getter
+public class SLAMonitor implements HasUID {
+    String executionId;
+    String slaId;
+    Instant deadline;
+
+    @Override
+    public String uid() {
+        return IdUtils.fromParts(executionId, slaId);
+    }
+}

--- a/core/src/main/java/io/kestra/core/models/flows/sla/SLAMonitorStorage.java
+++ b/core/src/main/java/io/kestra/core/models/flows/sla/SLAMonitorStorage.java
@@ -1,0 +1,12 @@
+package io.kestra.core.models.flows.sla;
+
+import java.time.Instant;
+import java.util.function.Consumer;
+
+public interface SLAMonitorStorage {
+    void save(SLAMonitor slaMonitor);
+
+    void purge(String executionId);
+
+    void processExpired(Instant now, Consumer<SLAMonitor> consumer);
+}

--- a/core/src/main/java/io/kestra/core/models/flows/sla/Violation.java
+++ b/core/src/main/java/io/kestra/core/models/flows/sla/Violation.java
@@ -1,0 +1,6 @@
+package io.kestra.core.models.flows.sla;
+
+import java.util.Map;
+
+public record Violation(String slaId, SLA.Behavior behavior, Map<String, Object> labels, String reason) {
+}

--- a/core/src/main/java/io/kestra/core/models/flows/sla/types/ExecutionConditionSLA.java
+++ b/core/src/main/java/io/kestra/core/models/flows/sla/types/ExecutionConditionSLA.java
@@ -1,0 +1,36 @@
+package io.kestra.core.models.flows.sla.types;
+
+import io.kestra.core.exceptions.InternalException;
+import io.kestra.core.models.executions.Execution;
+import io.kestra.core.models.flows.sla.ExecutionChangedSLA;
+import io.kestra.core.models.flows.sla.SLA;
+import io.kestra.core.models.flows.sla.Violation;
+import io.kestra.core.runners.RunContext;
+import io.kestra.core.utils.TruthUtils;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+import java.util.Optional;
+
+@SuperBuilder
+@Getter
+@NoArgsConstructor
+public class ExecutionConditionSLA extends SLA implements ExecutionChangedSLA {
+    @NotNull
+    @NotEmpty
+    private String condition;
+
+    @Override
+    public Optional<Violation> evaluate(RunContext runContext, Execution execution) throws InternalException {
+        String result = runContext.render(this.getCondition());
+        if (TruthUtils.isTruthy(result)) {
+            String reason = "condition met: " + this.getCondition() + ".";
+            return Optional.of(new Violation(this.getId(), this.getBehavior(), this.getLabels(), reason));
+        }
+
+        return Optional.empty();
+    }
+}

--- a/core/src/main/java/io/kestra/core/models/flows/sla/types/MaxDurationSLA.java
+++ b/core/src/main/java/io/kestra/core/models/flows/sla/types/MaxDurationSLA.java
@@ -1,0 +1,36 @@
+package io.kestra.core.models.flows.sla.types;
+
+import io.kestra.core.exceptions.InternalException;
+import io.kestra.core.models.executions.Execution;
+import io.kestra.core.models.flows.sla.ExecutionMonitoringSLA;
+import io.kestra.core.models.flows.sla.SLA;
+import io.kestra.core.models.flows.sla.Violation;
+import io.kestra.core.runners.RunContext;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Optional;
+
+@SuperBuilder
+@Getter
+@NoArgsConstructor
+public class MaxDurationSLA extends SLA implements ExecutionMonitoringSLA {
+    @NotNull
+    private Duration duration;
+
+    @Override
+    public Optional<Violation> evaluate(RunContext runContext, Execution execution) throws InternalException {
+        Duration executionDuration = Duration.between(execution.getState().getStartDate(), Instant.now());
+        if (executionDuration.compareTo(this.getDuration()) > 0) {
+            String reason = "execution duration of " + executionDuration.truncatedTo(ChronoUnit.MILLIS) + " exceed the maximum duration of " + this.getDuration() + ".";
+            return Optional.of(new Violation(this.getId(), this.getBehavior(), this.getLabels(), reason));
+        }
+
+        return Optional.empty();
+    }
+}

--- a/core/src/main/java/io/kestra/core/services/SLAService.java
+++ b/core/src/main/java/io/kestra/core/services/SLAService.java
@@ -1,0 +1,54 @@
+package io.kestra.core.services;
+
+import io.kestra.core.models.executions.Execution;
+import io.kestra.core.models.flows.Flow;
+import io.kestra.core.models.flows.sla.ExecutionChangedSLA;
+import io.kestra.core.models.flows.sla.SLA;
+import io.kestra.core.models.flows.sla.Violation;
+import io.kestra.core.runners.RunContext;
+import io.kestra.core.utils.ListUtils;
+import jakarta.inject.Singleton;
+
+import java.util.List;
+import java.util.Optional;
+
+@Singleton
+public class SLAService {
+
+    /**
+     * Evaluate execution changed SLA of a flow for an execution.
+     * Each violated SLA will be logged.
+     */
+    public List<Violation> evaluateExecutionChangedSLA(RunContext runContext, Flow flow, Execution execution) {
+        return ListUtils.emptyOnNull(flow.getSla()).stream()
+            .filter(ExecutionChangedSLA.class::isInstance)
+            .map(
+                sla -> {
+                    try {
+                        return sla.evaluate(runContext, execution);
+                    } catch (Exception e) {
+                        runContext.logger().error("Ignoring SLA '{}' because of the error: {}", sla.getId(), e.getMessage(), e);
+                        return Optional.<Violation>empty();
+                    }
+                }
+            )
+            .flatMap(violation -> violation.stream())
+            .peek(violation -> runContext.logger().warn("SLA '{}' violated: {}", violation.slaId(), violation.reason()))
+            .toList();
+    }
+
+    /**
+     * Evaluate a single SLA for an execution.
+     * Each violated SLA will be logged.
+     */
+    public Optional<Violation> evaluateExecutionMonitoringSLA(RunContext runContext, Execution execution, SLA sla) {
+        try {
+            Optional<Violation> maybeViolation = sla.evaluate(runContext, execution);
+            maybeViolation.ifPresent(violation -> runContext.logger().warn("SLA '{}' violated: {}", violation.slaId(), violation.reason()));
+            return maybeViolation;
+        } catch (Exception e) {
+            runContext.logger().error("Ignoring SLA '{}' because of the error: {}", sla.getId(), e.getMessage(), e);
+            return Optional.empty();
+        }
+    }
+}

--- a/core/src/main/java/io/kestra/core/utils/MapUtils.java
+++ b/core/src/main/java/io/kestra/core/utils/MapUtils.java
@@ -142,6 +142,13 @@ public class MapUtils {
     }
 
     /**
+     * Utility method that returns true if the map is null or empty.
+     */
+    public static boolean isEmpty(Map<?, ?> map) {
+        return map == null || map.isEmpty();
+    }
+
+    /**
      * Creates a hash map that can hold <code>numMappings</code> entry.
      * This is a copy of the same methods available starting with Java 19.
      */

--- a/core/src/test/java/io/kestra/core/models/flows/sla/types/ExecutionConditionSLATest.java
+++ b/core/src/test/java/io/kestra/core/models/flows/sla/types/ExecutionConditionSLATest.java
@@ -1,0 +1,55 @@
+package io.kestra.core.models.flows.sla.types;
+
+import io.kestra.core.exceptions.InternalException;
+import io.kestra.core.junit.annotations.KestraTest;
+import io.kestra.core.models.flows.sla.Violation;
+import io.kestra.core.runners.RunContext;
+import io.kestra.core.runners.RunContextFactory;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+import java.util.Optional;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.jupiter.api.Assertions.*;
+
+@KestraTest
+class ExecutionConditionSLATest {
+    @Inject
+    private RunContextFactory runContextFactory;
+
+    @Test
+    void shouldEvaluateToAViolation() throws InternalException {
+        ExecutionConditionSLA sla = ExecutionConditionSLA.builder()
+            .condition("{{ condition == 'true'}}")
+            .build();
+        RunContext runContext = runContextFactory.of(Map.of("condition", "true"));
+
+        Optional<Violation> evaluate = sla.evaluate(runContext, null);
+        assertTrue(evaluate.isPresent());
+        assertThat(evaluate.get().reason(), is("condition met: {{ condition == 'true'}}."));
+    }
+
+    @Test
+    void shouldEvaluateToNoViolation() throws InternalException {
+        ExecutionConditionSLA sla = ExecutionConditionSLA.builder()
+            .condition("{{ condition == 'true'}}")
+            .build();
+        RunContext runContext = runContextFactory.of(Map.of("condition", "false"));
+
+        Optional<Violation> evaluate = sla.evaluate(runContext, null);
+        assertTrue(evaluate.isEmpty());
+    }
+
+    @Test
+    void shouldFailToEvaluate() throws InternalException {
+        ExecutionConditionSLA sla = ExecutionConditionSLA.builder()
+            .condition("{{ condition == 'true'}}")
+            .build();
+        RunContext runContext = runContextFactory.of();
+
+        assertThrows(InternalException.class, () -> sla.evaluate(runContext, null));
+    }
+}

--- a/core/src/test/java/io/kestra/core/models/flows/sla/types/MaxDurationSLATest.java
+++ b/core/src/test/java/io/kestra/core/models/flows/sla/types/MaxDurationSLATest.java
@@ -1,0 +1,48 @@
+package io.kestra.core.models.flows.sla.types;
+
+import io.kestra.core.exceptions.InternalException;
+import io.kestra.core.models.executions.Execution;
+import io.kestra.core.models.flows.State;
+import io.kestra.core.models.flows.sla.Violation;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.util.Optional;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.jupiter.api.Assertions.*;
+
+
+class MaxDurationSLATest {
+
+    @Test
+    void shouldEvaluateToAViolation() throws InternalException, InterruptedException {
+        MaxDurationSLA maxDurationSLA = MaxDurationSLA.builder()
+            .duration(Duration.ofMillis(50))
+            .build();
+        Execution execution = Execution.builder()
+            .state(new State().withState(State.Type.RUNNING))
+            .build();
+        Thread.sleep(100);
+
+        Optional<Violation> evaluate = maxDurationSLA.evaluate(null, execution);
+        assertTrue(evaluate.isPresent());
+        assertThat(evaluate.get().reason(), containsString("execution duration of"));
+        assertThat(evaluate.get().reason(), containsString("exceed the maximum duration of PT0.05S."));
+    }
+
+    @Test
+    void shouldEvaluateToNoViolation() throws InternalException {
+        MaxDurationSLA maxDurationSLA = MaxDurationSLA.builder()
+            .duration(Duration.ofSeconds(10))
+            .build();
+        Execution execution = Execution.builder()
+            .state(new State().withState(State.Type.RUNNING))
+            .build();
+
+        Optional<Violation> evaluate = maxDurationSLA.evaluate(null, execution);
+        assertTrue(evaluate.isEmpty());
+    }
+}

--- a/core/src/test/java/io/kestra/core/runners/SLATestCase.java
+++ b/core/src/test/java/io/kestra/core/runners/SLATestCase.java
@@ -1,0 +1,52 @@
+package io.kestra.core.runners;
+
+import io.kestra.core.models.Label;
+import io.kestra.core.models.executions.Execution;
+import io.kestra.core.models.flows.State;
+import io.kestra.core.queues.QueueException;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+
+import java.util.Map;
+import java.util.concurrent.TimeoutException;
+
+import static org.hamcrest.CoreMatchers.hasItem;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+@Singleton
+public class SLATestCase {
+    @Inject
+    private RunnerUtils runnerUtils;
+
+    public void maxDurationSLAShouldFail() throws QueueException, TimeoutException {
+        Execution execution = runnerUtils.runOne(null, "io.kestra.tests", "sla-max-duration-fail");
+
+        assertThat(execution.getState().getCurrent(), is(State.Type.FAILED));
+    }
+
+    public void maxDurationSLAShouldPass() throws QueueException, TimeoutException {
+        Execution execution = runnerUtils.runOne(null, "io.kestra.tests", "sla-max-duration-ok");
+
+        assertThat(execution.getState().getCurrent(), is(State.Type.SUCCESS));
+    }
+
+    public void executionConditionSLAShouldPass() throws QueueException, TimeoutException {
+        Execution execution = runnerUtils.runOne(null, "io.kestra.tests", "sla-execution-condition");
+
+        assertThat(execution.getState().getCurrent(), is(State.Type.SUCCESS));
+    }
+
+    public void executionConditionSLAShouldCancel() throws QueueException, TimeoutException {
+        Execution execution = runnerUtils.runOne(null, "io.kestra.tests", "sla-execution-condition", null, (f, e) -> Map.of("string", "CANCEL"));
+
+        assertThat(execution.getState().getCurrent(), is(State.Type.CANCELLED));
+    }
+
+    public void executionConditionSLAShouldLabel() throws QueueException, TimeoutException {
+        Execution execution = runnerUtils.runOne(null, "io.kestra.tests", "sla-execution-condition", null, (f, e) -> Map.of("string", "LABEL"));
+
+        assertThat(execution.getState().getCurrent(), is(State.Type.SUCCESS));
+        assertThat(execution.getLabels(), hasItem(new Label("system.sla", "violated")));
+    }
+}

--- a/core/src/test/java/io/kestra/core/utils/MapUtilsTest.java
+++ b/core/src/test/java/io/kestra/core/utils/MapUtilsTest.java
@@ -105,6 +105,14 @@ class MapUtilsTest {
     }
 
     @Test
+    void isEmpty() {
+        assertThat(MapUtils.isEmpty(null), is(true));
+        assertThat(MapUtils.isEmpty(Collections.emptyMap()), is(true));
+        assertThat(MapUtils.isEmpty(Map.of("key", "value")), is(false));
+    }
+
+
+    @Test
     void shouldReturnMapWhenNestingMapGivenFlattenMap() {
         Map<String, Object> results = MapUtils.flattenToNestedMap(Map.of(
             "k1.k2.k3", "v1",

--- a/core/src/test/resources/flows/valids/sla-execution-condition.yaml
+++ b/core/src/test/resources/flows/valids/sla-execution-condition.yaml
@@ -1,0 +1,28 @@
+id: sla-execution-condition
+namespace: io.kestra.tests
+
+inputs:
+  - id: string
+    type: SELECT
+    values:
+      - PASS
+      - CANCEL
+      - LABEL
+    defaults: PASS
+
+sla:
+  - id: condition
+    type: EXECUTION_CONDITION
+    behavior: CANCEL
+    condition: "{{inputs.string == 'CANCEL'}}"
+  - id: condition
+    type: EXECUTION_CONDITION
+    behavior: NONE
+    condition: "{{inputs.string == 'LABEL'}}"
+    labels:
+      system.sla: violated
+
+tasks:
+  - id: return
+    type: io.kestra.plugin.core.debug.Return
+    format: "true"

--- a/core/src/test/resources/flows/valids/sla-max-duration-fail.yaml
+++ b/core/src/test/resources/flows/valids/sla-max-duration-fail.yaml
@@ -1,0 +1,13 @@
+id: sla-max-duration-fail
+namespace: io.kestra.tests
+
+sla:
+  - id: maxDuration
+    type: MAX_DURATION
+    behavior: FAIL
+    duration: PT0.5S
+
+tasks:
+  - id: sleep
+    type: io.kestra.plugin.core.flow.Sleep
+    duration: PT2S

--- a/core/src/test/resources/flows/valids/sla-max-duration-ok.yaml
+++ b/core/src/test/resources/flows/valids/sla-max-duration-ok.yaml
@@ -1,0 +1,13 @@
+id: sla-max-duration-ok
+namespace: io.kestra.tests
+
+sla:
+  - id: maxDuration
+    type: MAX_DURATION
+    behavior: FAIL
+    duration: PT10S
+
+tasks:
+  - id: sleep
+    type: io.kestra.plugin.core.flow.Sleep
+    duration: PT0.5S

--- a/jdbc-h2/src/main/java/io/kestra/runner/h2/H2SLAMonitorStorage.java
+++ b/jdbc-h2/src/main/java/io/kestra/runner/h2/H2SLAMonitorStorage.java
@@ -1,0 +1,15 @@
+package io.kestra.runner.h2;
+
+import io.kestra.core.models.flows.sla.SLAMonitor;
+import io.kestra.jdbc.runner.AbstractJdbcSLAMonitorStorage;
+import io.kestra.repository.h2.H2Repository;
+import jakarta.inject.Named;
+import jakarta.inject.Singleton;
+
+@Singleton
+@H2QueueEnabled
+public class H2SLAMonitorStorage extends AbstractJdbcSLAMonitorStorage {
+    public H2SLAMonitorStorage(@Named("slamonitor") H2Repository<SLAMonitor> repository) {
+        super(repository);
+    }
+}

--- a/jdbc-h2/src/main/resources/migrations/h2/V1_24__sla_monitor.sql
+++ b/jdbc-h2/src/main/resources/migrations/h2/V1_24__sla_monitor.sql
@@ -1,0 +1,10 @@
+CREATE TABLE IF NOT EXISTS sla_monitor (
+    "key" VARCHAR(250) NOT NULL PRIMARY KEY,
+    "value" TEXT NOT NULL,
+    "execution_id" VARCHAR(150) NOT NULL GENERATED ALWAYS AS (JQ_STRING("value", '.executionId')),
+    "sla_id" VARCHAR(150) NOT NULL GENERATED ALWAYS AS (JQ_STRING("value", '.slaId')),
+    "deadline" TIMESTAMP NOT NULL GENERATED ALWAYS AS (PARSEDATETIME(JQ_STRING("value", '.deadline'), 'yyyy-MM-dd''T''HH:mm:ss.SSSXXX'))
+);
+
+CREATE INDEX IF NOT EXISTS sla_monitor__deadline ON sla_monitor ("deadline");
+CREATE INDEX IF NOT EXISTS sla_monitor__execution_id ON sla_monitor ("execution_id");

--- a/jdbc-mysql/src/main/java/io/kestra/runner/mysql/MysqlSLAMonitorStorage.java
+++ b/jdbc-mysql/src/main/java/io/kestra/runner/mysql/MysqlSLAMonitorStorage.java
@@ -1,0 +1,15 @@
+package io.kestra.runner.mysql;
+
+import io.kestra.core.models.flows.sla.SLAMonitor;
+import io.kestra.jdbc.runner.AbstractJdbcSLAMonitorStorage;
+import io.kestra.repository.mysql.MysqlRepository;
+import jakarta.inject.Named;
+import jakarta.inject.Singleton;
+
+@Singleton
+@MysqlQueueEnabled
+public class MysqlSLAMonitorStorage  extends AbstractJdbcSLAMonitorStorage {
+    public MysqlSLAMonitorStorage(@Named("slamonitor") MysqlRepository<SLAMonitor> repository) {
+        super(repository);
+    }
+}

--- a/jdbc-mysql/src/main/resources/migrations/mysql/V1_24__sla_monitor.sql
+++ b/jdbc-mysql/src/main/resources/migrations/mysql/V1_24__sla_monitor.sql
@@ -1,0 +1,9 @@
+CREATE TABLE IF NOT EXISTS sla_monitor (
+    `key` VARCHAR(250) NOT NULL PRIMARY KEY,
+    `value` JSON NOT NULL,
+    `execution_id` VARCHAR(150) GENERATED ALWAYS AS (value ->> '$.executionId') STORED NOT NULL,
+    `sla_id` VARCHAR(150) GENERATED ALWAYS AS (value ->> '$.slaId') STORED NOT NULL,
+    `deadline` DATETIME(6) GENERATED ALWAYS AS (STR_TO_DATE(value ->> '$.deadline' , '%Y-%m-%dT%H:%i:%s.%fZ')) STORED NOT NULL,
+    INDEX ix_deadline (deadline),
+    INDEX ix_execution_id (execution_id)
+);

--- a/jdbc-postgres/src/main/java/io/kestra/runner/postgres/PostgresSLAMonitorStorage.java
+++ b/jdbc-postgres/src/main/java/io/kestra/runner/postgres/PostgresSLAMonitorStorage.java
@@ -1,0 +1,15 @@
+package io.kestra.runner.postgres;
+
+import io.kestra.core.models.flows.sla.SLAMonitor;
+import io.kestra.jdbc.runner.AbstractJdbcSLAMonitorStorage;
+import io.kestra.repository.postgres.PostgresRepository;
+import jakarta.inject.Named;
+import jakarta.inject.Singleton;
+
+@Singleton
+@PostgresQueueEnabled
+public class PostgresSLAMonitorStorage  extends AbstractJdbcSLAMonitorStorage {
+    public PostgresSLAMonitorStorage(@Named("slamonitor") PostgresRepository<SLAMonitor> repository) {
+        super(repository);
+    }
+}

--- a/jdbc-postgres/src/main/resources/migrations/postgres/V1_24__sla_monitor.sql
+++ b/jdbc-postgres/src/main/resources/migrations/postgres/V1_24__sla_monitor.sql
@@ -1,0 +1,10 @@
+CREATE TABLE IF NOT EXISTS sla_monitor (
+    key VARCHAR(250) NOT NULL PRIMARY KEY,
+    value JSONB NOT NULL,
+    execution_id VARCHAR(150) NOT NULL GENERATED ALWAYS AS (value ->> 'executionId') STORED,
+    sla_id VARCHAR(150) NOT NULL GENERATED ALWAYS AS (value ->> 'slaId') STORED,
+    deadline TIMESTAMPTZ NOT NULL GENERATED ALWAYS AS (PARSE_ISO8601_DATETIME(value ->> 'deadline')) STORED
+);
+
+CREATE INDEX IF NOT EXISTS sla_monitor__deadline ON sla_monitor (deadline);
+CREATE INDEX IF NOT EXISTS sla_monitor__execution_id ON sla_monitor (execution_id);

--- a/jdbc/src/main/java/io/kestra/jdbc/JdbcTableConfigsFactory.java
+++ b/jdbc/src/main/java/io/kestra/jdbc/JdbcTableConfigsFactory.java
@@ -5,6 +5,7 @@ import io.kestra.core.models.executions.Execution;
 import io.kestra.core.models.executions.LogEntry;
 import io.kestra.core.models.executions.MetricEntry;
 import io.kestra.core.models.flows.Flow;
+import io.kestra.core.models.flows.sla.SLAMonitor;
 import io.kestra.core.models.templates.Template;
 import io.kestra.core.models.topologies.FlowTopology;
 import io.kestra.core.models.triggers.Trigger;
@@ -115,6 +116,12 @@ public class JdbcTableConfigsFactory {
     @Named("executionqueued")
     public InstantiableJdbcTableConfig executionQueued() {
         return new InstantiableJdbcTableConfig("executionqueued", ExecutionQueued.class, "execution_queued");
+    }
+
+    @Bean
+    @Named("slamonitor")
+    public InstantiableJdbcTableConfig slaMonitor() {
+        return new InstantiableJdbcTableConfig("slamonitor", SLAMonitor.class, "sla_monitor");
     }
 
     public static class InstantiableJdbcTableConfig extends JdbcTableConfig {

--- a/jdbc/src/main/java/io/kestra/jdbc/runner/AbstractJdbcSLAMonitorStorage.java
+++ b/jdbc/src/main/java/io/kestra/jdbc/runner/AbstractJdbcSLAMonitorStorage.java
@@ -1,0 +1,61 @@
+package io.kestra.jdbc.runner;
+
+import io.kestra.core.models.flows.sla.SLAMonitor;
+import io.kestra.core.models.flows.sla.SLAMonitorStorage;
+import io.kestra.jdbc.repository.AbstractJdbcRepository;
+import org.jooq.DSLContext;
+import org.jooq.Field;
+import org.jooq.impl.DSL;
+
+import java.time.Instant;
+import java.util.Map;
+import java.util.function.Consumer;
+
+public abstract class AbstractJdbcSLAMonitorStorage extends AbstractJdbcRepository implements SLAMonitorStorage {
+    protected io.kestra.jdbc.AbstractJdbcRepository<SLAMonitor> jdbcRepository;
+
+    protected AbstractJdbcSLAMonitorStorage(io.kestra.jdbc.AbstractJdbcRepository<SLAMonitor> jdbcRepository) {
+        this.jdbcRepository = jdbcRepository;
+    }
+
+    @Override
+    public void save(SLAMonitor slaMonitor) {
+        this.jdbcRepository
+            .getDslContextWrapper()
+            .transaction(configuration -> {
+                DSLContext context = DSL.using(configuration);
+                Map<Field<Object>, Object> fields = this.jdbcRepository.persistFields(slaMonitor);
+                this.jdbcRepository.persist(slaMonitor, context, fields);
+            });
+    }
+
+    @Override
+    public void purge(String executionId) {
+        this.jdbcRepository
+            .getDslContextWrapper()
+            .transaction(configuration -> {
+                DSLContext context = DSL.using(configuration);
+                context.delete(this.jdbcRepository.getTable())
+                    .where(field("execution_id").eq(executionId))
+                    .execute();
+            });
+    }
+
+    @Override
+    public void processExpired(Instant date, Consumer<SLAMonitor> consumer) {
+        this.jdbcRepository
+            .getDslContextWrapper()
+            .transaction(configuration -> {
+                DSLContext context = DSL.using(configuration);
+                var select = context.select()
+                    .from(this.jdbcRepository.getTable())
+                    .where(field("deadline").lt(date));
+
+                this.jdbcRepository.fetch(select)
+                    .forEach(slaMonitor -> {
+                        consumer.accept(slaMonitor);
+                        jdbcRepository.delete(slaMonitor);
+                    });
+            });
+    }
+}

--- a/jdbc/src/test/java/io/kestra/jdbc/runner/JdbcRunnerTest.java
+++ b/jdbc/src/test/java/io/kestra/jdbc/runner/JdbcRunnerTest.java
@@ -92,6 +92,9 @@ public abstract class JdbcRunnerTest {
     @Inject
     private FlowInputOutput flowIO;
 
+    @Inject
+    private SLATestCase slaTestCase;
+
     @BeforeAll
     void init() throws IOException, URISyntaxException {
         jdbcTestUtils.drop();
@@ -472,5 +475,30 @@ public abstract class JdbcRunnerTest {
     @Test
     void shouldScheduleOnDate() throws QueueException, InterruptedException {
         scheduleDateCaseTest.shouldScheduleOnDate();
+    }
+
+    @Test
+    void maxDurationSLAShouldFail() throws QueueException, TimeoutException {
+        slaTestCase.maxDurationSLAShouldFail();
+    }
+
+    @Test
+    void maxDurationSLAShouldPass() throws QueueException, TimeoutException {
+        slaTestCase.maxDurationSLAShouldPass();
+    }
+
+    @Test
+    void executionConditionSLAShouldPass() throws QueueException, TimeoutException {
+        slaTestCase.executionConditionSLAShouldPass();
+    }
+
+    @Test
+    void executionConditionSLAShouldCancel() throws QueueException, TimeoutException {
+        slaTestCase.executionConditionSLAShouldCancel();
+    }
+
+    @Test
+    void executionConditionSLAShouldLabel() throws QueueException, TimeoutException {
+        slaTestCase.executionConditionSLAShouldLabel();
     }
 }


### PR DESCRIPTION
Fixes #5857

First WIP draft prototype, still a lot of work to do.

Example flow:

```yaml
id: sla
namespace: company.team

inputs:
  - id: string
    type: SELECT
    values:
      - PASS
      - CANCEL
    defaults: PASS

# If input.string == CANCEL, the execution will be cancelled by the 'condition' SLA.
# If execution duration > 2s, the execution will have the label sla: violated
# If execution duration > 5s, the executon will fail
sla:
  - id: label
    type: MAX_DURATION
    behavior: NONE
    duration: PT2S
    labels:
      system.sla: violated
  - id: maxDuration
    type: MAX_DURATION
    behavior: FAIL
    duration: PT5S
  - id: condition
    type: EXECUTION_CONDITION
    behavior: CANCEL # NONE
    condition: "{{inputs.string == 'CANCEL'}}"

 
tasks:
  - id: sleep1
    type: io.kestra.plugin.core.flow.Sleep
    duration: PT2S
  - id: sleep2
    type: io.kestra.plugin.core.flow.Sleep
    duration: PT2S
  - id: sleep3
    type: io.kestra.plugin.core.flow.Sleep
    duration: PT2S
```