### PR TITLE
fix(ui): disable sidebar version tooltip when no commitId or collapsed

### DIFF
--- a/ui/src/components/layout/SideBar.vue
+++ b/ui/src/components/layout/SideBar.vue
@@ -33,6 +33,7 @@
                     :persistent="false"
                     transition=""
                     :hide-after="0"
+                    :disabled="!configs.commitId"
                 >
                     <template #content>
                         <code>{{ configs.commitId }}</code> <DateAgo v-if="configs.commitDate" :inverted="true" :date="configs.commitDate" />
@@ -370,6 +371,7 @@
             span.version {
                 opacity: 0;
                 width: 0;
+                overflow: hidden;
             }
         }
 


### PR DESCRIPTION

<img width="1114" alt="Screenshot 2024-11-14 at 11 12 02" src="https://github.com/user-attachments/assets/534f57ba-358b-4e7b-b94e-9152ece8781c">
