### PR TITLE
feat(ui): add ability to replay executions with latest flow revision

### DIFF
--- a/ui/src/stores/executions.js
+++ b/ui/src/stores/executions.js
@@ -62,7 +62,8 @@ export default {
         bulkReplayExecution(_, options) {
             return this.$http.post(
                 `${apiUrl(this)}/executions/replay/by-ids`,
-                options.executionsId
+                options.executionsId,
+                {params: options}
             )
         },
         bulkChangeExecutionStatus(_, options) {

--- a/webserver/src/main/java/io/kestra/webserver/controllers/api/ExecutionController.java
+++ b/webserver/src/main/java/io/kestra/webserver/controllers/api/ExecutionController.java
@@ -28,7 +28,6 @@ import io.kestra.core.storages.StorageContext;
 import io.kestra.core.storages.StorageInterface;
 import io.kestra.core.tenant.TenantService;
 import io.kestra.core.trace.propagation.ExecutionTextMapSetter;
-import io.kestra.core.trace.propagation.RunContextTextMapSetter;
 import io.kestra.core.utils.Await;
 import io.kestra.core.utils.ListUtils;
 import io.kestra.plugin.core.trigger.Webhook;
@@ -187,16 +186,16 @@ public class ExecutionController {
         @Parameter(description = "Filters") @QueryFilterFormat List<QueryFilter> filters,
         //Deprecated params
         @Parameter(description = "A string filter", deprecated = true) @Nullable @QueryValue(value = "q") String query,
-        @Parameter(description = "The scope of the executions to include",deprecated = true) @Nullable @QueryValue(value = "scope") List<FlowScope> scope,
-        @Parameter(description = "A namespace filter prefix",deprecated = true) @Nullable @QueryValue String namespace,
-        @Parameter(description = "A flow id filter",deprecated = true) @Nullable @QueryValue String flowId,
-        @Parameter(description = "The start datetime",deprecated = true) @Nullable @Format("yyyy-MM-dd'T'HH:mm[:ss][.SSS][XXX]") @QueryValue ZonedDateTime startDate,
-        @Parameter(description = "The end datetime",deprecated = true) @Nullable @Format("yyyy-MM-dd'T'HH:mm[:ss][.SSS][XXX]") @QueryValue ZonedDateTime endDate,
-        @Parameter(description = "A time range filter relative to the current time",deprecated = true, examples = {
+        @Parameter(description = "The scope of the executions to include", deprecated = true) @Nullable @QueryValue(value = "scope") List<FlowScope> scope,
+        @Parameter(description = "A namespace filter prefix", deprecated = true) @Nullable @QueryValue String namespace,
+        @Parameter(description = "A flow id filter", deprecated = true) @Nullable @QueryValue String flowId,
+        @Parameter(description = "The start datetime", deprecated = true) @Nullable @Format("yyyy-MM-dd'T'HH:mm[:ss][.SSS][XXX]") @QueryValue ZonedDateTime startDate,
+        @Parameter(description = "The end datetime", deprecated = true) @Nullable @Format("yyyy-MM-dd'T'HH:mm[:ss][.SSS][XXX]") @QueryValue ZonedDateTime endDate,
+        @Parameter(description = "A time range filter relative to the current time", deprecated = true, examples = {
             @ExampleObject(name = "Filter last 5 minutes", value = "PT5M"),
             @ExampleObject(name = "Filter last 24 hours", value = "P1D")
         }) @Nullable @QueryValue Duration timeRange,
-        @Parameter(description = "A state filter",deprecated = true) @Nullable @QueryValue List<State.Type> state,
+        @Parameter(description = "A state filter", deprecated = true) @Nullable @QueryValue List<State.Type> state,
         @Parameter(description = "A labels filter as a list of 'key:value'", deprecated = true) @Nullable @QueryValue @Format("MULTI") List<String> labels,
         @Parameter(description = "The trigger execution id", deprecated = true) @Nullable @QueryValue String triggerExecutionId,
         @Parameter(description = "A execution child filter", deprecated = true) @Nullable @QueryValue ExecutionRepositoryInterface.ChildFilter childFilter
@@ -269,7 +268,7 @@ public class ExecutionController {
 
                 return flow
                     .map(throwFunction(value ->
-                        graphService.flowGraph(value, subflows,  execution).forExecution()
+                        graphService.flowGraph(value, subflows, execution).forExecution()
                     ))
                     .orElse(null);
             }))
@@ -349,8 +348,8 @@ public class ExecutionController {
     public HttpResponse<Void> delete(
         @Parameter(description = "The execution id") @PathVariable String executionId,
         @Parameter(description = "Whether to delete execution logs") @QueryValue(defaultValue = "true") Boolean deleteLogs,
-        @Parameter(description = "Whether to delete execution metrics") @QueryValue(defaultValue = "true")  Boolean  deleteMetrics,
-        @Parameter(description = "Whether to delete execution files in the internal storage") @QueryValue(defaultValue = "true")  Boolean deleteStorage
+        @Parameter(description = "Whether to delete execution metrics") @QueryValue(defaultValue = "true") Boolean deleteMetrics,
+        @Parameter(description = "Whether to delete execution files in the internal storage") @QueryValue(defaultValue = "true") Boolean deleteStorage
     ) throws IOException {
         Optional<Execution> execution = executionRepository.findById(tenantService.resolveTenant(), executionId);
         if (execution.isPresent()) {
@@ -370,8 +369,8 @@ public class ExecutionController {
         @Parameter(description = "The execution id") @Body List<String> executionsId,
         @Parameter(description = "Whether to delete non-terminated executions") @Nullable @QueryValue(defaultValue = "false") Boolean includeNonTerminated,
         @Parameter(description = "Whether to delete execution logs") @QueryValue(defaultValue = "true") Boolean deleteLogs,
-        @Parameter(description = "Whether to delete execution metrics") @QueryValue(defaultValue = "true")  Boolean  deleteMetrics,
-        @Parameter(description = "Whether to delete execution files in the internal storage") @QueryValue(defaultValue = "true")  Boolean deleteStorage
+        @Parameter(description = "Whether to delete execution metrics") @QueryValue(defaultValue = "true") Boolean deleteMetrics,
+        @Parameter(description = "Whether to delete execution files in the internal storage") @QueryValue(defaultValue = "true") Boolean deleteStorage
     ) throws IOException {
         List<Execution> executions = new ArrayList<>();
         Set<ManualConstraintViolation<String>> invalids = new HashSet<>();
@@ -426,8 +425,8 @@ public class ExecutionController {
         @Parameter(description = "A execution child filter") @Nullable @QueryValue ExecutionRepositoryInterface.ChildFilter childFilter,
         @Parameter(description = "Whether to delete non-terminated executions") @Nullable @QueryValue(defaultValue = "false") Boolean includeNonTerminated,
         @Parameter(description = "Whether to delete execution logs") @QueryValue(defaultValue = "true") Boolean deleteLogs,
-        @Parameter(description = "Whether to delete execution metrics") @QueryValue(defaultValue = "true")  Boolean  deleteMetrics,
-        @Parameter(description = "Whether to delete execution files in the internal storage") @QueryValue(defaultValue = "true")  Boolean deleteStorage
+        @Parameter(description = "Whether to delete execution metrics") @QueryValue(defaultValue = "true") Boolean deleteMetrics,
+        @Parameter(description = "Whether to delete execution files in the internal storage") @QueryValue(defaultValue = "true") Boolean deleteStorage
     ) throws IOException {
         validateTimeline(startDate, endDate);
 
@@ -583,7 +582,7 @@ public class ExecutionController {
     public Publisher<ExecutionResponse> trigger(
         @Parameter(description = "The flow namespace") @PathVariable String namespace,
         @Parameter(description = "The flow id") @Nullable @PathVariable String id,
-        @Parameter(description = "The inputs") @Nullable  @Body MultipartBody inputs,
+        @Parameter(description = "The inputs") @Nullable @Body MultipartBody inputs,
         @Parameter(description = "The labels as a list of 'key:value'") @Nullable @QueryValue @Format("MULTI") List<String> labels,
         @Parameter(description = "If the server will wait the end of the execution") @QueryValue(defaultValue = "false") Boolean wait,
         @Parameter(description = "The flow revision or latest if null") @QueryValue Optional<Integer> revision
@@ -673,7 +672,7 @@ public class ExecutionController {
 
     private URI executionUrl(Execution execution) {
         String baseUrl = kestraUrl.map(url -> url.endsWith("/") ? url.substring(0, url.length() - 1) : url).orElse("");
-        return URI.create(baseUrl + "/ui" + (execution.getTenantId() != null ? "/" + execution.getTenantId(): "")
+        return URI.create(baseUrl + "/ui" + (execution.getTenantId() != null ? "/" + execution.getTenantId() : "")
             + "/executions/"
             + execution.getNamespace() + "/"
             + execution.getFlowId() + "/"
@@ -718,7 +717,7 @@ public class ExecutionController {
     }
 
     protected List<Label> parseLabels(List<String> labels) {
-        List<Label> parsedLabels =  labels == null ? Collections.emptyList() : RequestUtils.toMap(labels).entrySet().stream()
+        List<Label> parsedLabels = labels == null ? Collections.emptyList() : RequestUtils.toMap(labels).entrySet().stream()
             .map(entry -> new Label(entry.getKey(), entry.getValue()))
             .toList();
 
@@ -1210,7 +1209,7 @@ public class ExecutionController {
     @ApiResponse(responseCode = "204", description = "On success")
     @ApiResponse(responseCode = "409", description = "if the executions is not paused")
     @SingleResult
-    public Publisher<ApiValidateExecutionInputsResponse>  validateInputsOnResume(
+    public Publisher<ApiValidateExecutionInputsResponse> validateInputsOnResume(
         @Parameter(description = "The execution id") @PathVariable String executionId,
         @Parameter(description = "The inputs") @Nullable @Body MultipartBody inputs
     ) {
@@ -1463,13 +1462,14 @@ public class ExecutionController {
         @Parameter(description = "A state filter") @Nullable @QueryValue List<State.Type> state,
         @Parameter(description = "A labels filter as a list of 'key:value'") @Nullable @QueryValue @Format("MULTI") List<String> labels,
         @Parameter(description = "The trigger execution id") @Nullable @QueryValue String triggerExecutionId,
-        @Parameter(description = "A execution child filter") @Nullable @QueryValue ExecutionRepositoryInterface.ChildFilter childFilter
+        @Parameter(description = "A execution child filter") @Nullable @QueryValue ExecutionRepositoryInterface.ChildFilter childFilter,
+        @Parameter(description = "If latest revision should be used") @Nullable @QueryValue(defaultValue = "false") Boolean latestRevision
     ) throws Exception {
         validateTimeline(startDate, endDate);
 
         var ids = getExecutionIds(query, scope, namespace, flowId, startDate, endDate, timeRange, state, labels, triggerExecutionId, childFilter);
 
-        return replayByIds(ids);
+        return replayByIds(ids, latestRevision);
     }
 
     @ExecuteOn(TaskExecutors.IO)
@@ -1478,7 +1478,8 @@ public class ExecutionController {
     @ApiResponse(responseCode = "200", description = "On success", content = {@Content(schema = @Schema(implementation = BulkResponse.class))})
     @ApiResponse(responseCode = "422", description = "Replayed with errors", content = {@Content(schema = @Schema(implementation = BulkErrorResponse.class))})
     public MutableHttpResponse<?> replayByIds(
-        @Parameter(description = "The execution id") @Body List<String> executionsId
+        @Parameter(description = "The execution id") @Body List<String> executionsId,
+        @Parameter(description = "If latest revision should be used") @Nullable @QueryValue(defaultValue = "false") Boolean latestRevision
     ) throws Exception {
         List<Execution> executions = new ArrayList<>();
         Set<ManualConstraintViolation<String>> invalids = new HashSet<>();
@@ -1508,9 +1509,13 @@ public class ExecutionController {
         }
 
         for (Execution execution : executions) {
-            innerReplay(execution, null, null);
+            if (latestRevision) {
+                Flow flow = flowRepository.findById(execution.getTenantId(), execution.getNamespace(), execution.getFlowId(), Optional.empty()).orElseThrow();
+                innerReplay(execution, null, flow.getRevision());
+            } else {
+                innerReplay(execution, null, null);
+            }
         }
-
         return HttpResponse.ok(BulkResponse.builder().count(executions.size()).build());
     }
 
@@ -1522,39 +1527,39 @@ public class ExecutionController {
     ) {
         String subscriberId = UUID.randomUUID().toString();
         return Flux.<Event<Execution>>create(emitter -> {
-            // Send initial event
-            emitter.next(Event.of(Execution.builder().id(executionId).build()).id("start"));
+                // Send initial event
+                emitter.next(Event.of(Execution.builder().id(executionId).build()).id("start"));
 
-            // Check if execution exists
-            try {
-                Execution execution = Await.until(
-                    () -> executionRepository.findById(tenantService.resolveTenant(), executionId).orElse(null),
-                    Duration.ofMillis(500),
-                    Duration.ofSeconds(10)
-                );
+                // Check if execution exists
+                try {
+                    Execution execution = Await.until(
+                        () -> executionRepository.findById(tenantService.resolveTenant(), executionId).orElse(null),
+                        Duration.ofMillis(500),
+                        Duration.ofSeconds(10)
+                    );
 
-                Flow flow = flowRepository.findByExecutionWithoutAcl(execution);
+                    Flow flow = flowRepository.findByExecutionWithoutAcl(execution);
 
-                // If execution is already complete, just send final state
-                if (streamingService.isStopFollow(flow, execution)) {
-                    emitter.next(Event.of(execution).id("end"));
-                    emitter.complete();
-                    return;
+                    // If execution is already complete, just send final state
+                    if (streamingService.isStopFollow(flow, execution)) {
+                        emitter.next(Event.of(execution).id("end"));
+                        emitter.complete();
+                        return;
+                    }
+
+                    // Send current state
+                    emitter.next(Event.of(execution).id("progress"));
+
+                    // Register for updates
+                    streamingService.registerSubscriber(executionId, subscriberId, emitter, flow);
+                } catch (TimeoutException e) {
+                    emitter.error(new HttpStatusException(HttpStatus.NOT_FOUND,
+                        "Unable to find execution " + executionId));
+                } catch (IllegalStateException e) {
+                    emitter.error(new HttpStatusException(HttpStatus.NOT_FOUND,
+                        "Unable to find flow for execution " + executionId));
                 }
-
-                // Send current state
-                emitter.next(Event.of(execution).id("progress"));
-
-                // Register for updates
-                streamingService.registerSubscriber(executionId, subscriberId, emitter, flow);
-            } catch (TimeoutException e) {
-                emitter.error(new HttpStatusException(HttpStatus.NOT_FOUND,
-                    "Unable to find execution " + executionId));
-            } catch (IllegalStateException e) {
-                emitter.error(new HttpStatusException(HttpStatus.NOT_FOUND,
-                    "Unable to find flow for execution " + executionId));
-            }
-        }, FluxSink.OverflowStrategy.BUFFER)
+            }, FluxSink.OverflowStrategy.BUFFER)
             .doFinally(ignored -> streamingService.unregisterSubscriber(executionId, subscriberId));
     }
 
@@ -1631,13 +1636,13 @@ public class ExecutionController {
 
         Map<String, String> newLabels = labels.stream().collect(Collectors.toMap(Label::key, Label::value));
         existingSystemLabels.forEach(
-                label -> {
-                    // only add system labels
-                    if (!newLabels.containsKey(label.key())) {
-                        newLabels.put(label.key(), label.value());
-                    }
+            label -> {
+                // only add system labels
+                if (!newLabels.containsKey(label.key())) {
+                    newLabels.put(label.key(), label.value());
                 }
-            );
+            }
+        );
 
         Execution newExecution = execution
             .withLabels(newLabels.entrySet().stream().map(entry -> new Label(entry.getKey(), entry.getValue())).filter(label -> !label.key().isEmpty() || !label.value().isEmpty()).toList());


### PR DESCRIPTION
## Add Option for "Replay Using Latest Revision" in Bulk Actions

## Closes: #5740

## Summary of Changes

This update introduces a new button, **"Replay Using Latest Revision,"** in the bulk actions section of Kestra. It allows users to replay multiple executions using the most recent version of each flow, instead of using the original revision initially used when the execution was triggered.

## Key Differences from Regular Replay

- **Regular Replay**: 
  - Replay executions using the original flow revisions.
  
- **Latest Revision Replay**:
  - Uses the most recent version of each flow.
  - Requires fetching the latest revision information for each flow before execution.
  - Ensures that multiple executions of the same flow use the same, latest revision.

This feature allows users to replay executions with up-to-date versions of the flows, regardless of the original revision used during the initial execution.

## QA Process

The following quality assurance steps have been completed to verify the feature:

1. Verified the placement and functionality of the "Replay Using Latest Revision" button in the bulk actions interface.
2. Tested that executions are replayed using the latest flow versions when the option is selected.
3. Confirmed that regular replay behavior uses the original flow revisions by default.

## Setup Instructions
 
1. Navigate to the Executions section select the bulk actions section and confirm the presence and functionality of the "Replay Using Latest Revision" button.
3. Test the new functionality to ensure executions are replayed using the most recent flow versions.
