### PR TITLE
feat(ui): highlight filter comparators

### DIFF
--- a/ui/src/components/filter/KestraFilter.vue
+++ b/ui/src/components/filter/KestraFilter.vue
@@ -80,9 +80,9 @@
     import Refresh from "../layout/RefreshButton.vue";
 
     import History from "./components/history/History.vue";
+    import Label from "./components/Label.vue";
     import Save from "./components/Save.vue";
     import Settings from "./components/Settings.vue";
-    import Label from "./components/Label.vue";
 
     import Magnify from "vue-material-design-icons/Magnify.vue";
 

--- a/ui/src/components/filter/KestraFilter.vue
+++ b/ui/src/components/filter/KestraFilter.vue
@@ -16,7 +16,7 @@
             @visible-change="(visible) => dropdownClosedCallback(visible)"
         >
             <template #label="{value}">
-                <span>{{ formatLabel(value) }} </span>
+                <Label :option="value" />
             </template>
             <template #empty>
                 <span v-if="!isDatePickerShown">{{ emptyLabel }}</span>
@@ -82,6 +82,7 @@
     import History from "./components/history/History.vue";
     import Save from "./components/Save.vue";
     import Settings from "./components/Settings.vue";
+    import Label from "./components/Label.vue";
 
     import Magnify from "vue-material-design-icons/Magnify.vue";
 
@@ -101,7 +102,7 @@
         },
     });
 
-    import {formatLabel, useFilters, compare} from "./useFilters.js";
+    import {useFilters, compare} from "./useFilters.js";
     const {getRecentItems, setRecentItems, OPTIONS, encodeParams, decodeParams} =
         useFilters(props.prefix);
 

--- a/ui/src/components/filter/components/Label.vue
+++ b/ui/src/components/filter/components/Label.vue
@@ -1,0 +1,38 @@
+<template>
+    <label>
+        {{ label }}<template v-if="comparator"><span>:{{ comparator }}:</span></template>
+        <template v-if="value">{{ value }}</template>
+    </label>
+</template>
+
+<script setup lang="ts">
+    import {computed} from "vue";
+
+    const props = defineProps({
+        option: {type: Object, required: true}
+    });
+
+    const DATE_FORMATS = {timeStyle: "short", dateStyle: "short"};
+    const formatter = new Intl.DateTimeFormat("en-US", DATE_FORMATS);
+
+    const getFilterValue = (value, label, comparator) => {
+        if (!value.length) {
+            return;
+        }
+        if (label !== "absolute_date" && comparator !== "between") {
+            return `${value.join(", ")}`;
+        }
+        const {startDate, endDate} = value[0];
+        return `${startDate ? formatter.format(new Date(startDate)) : "Unknown"}:and:${endDate ? formatter.format(new Date(endDate)) : "Unknown"}`;
+    };
+
+    const label = computed(() => props.option.label);
+    const comparator = computed(() => props.option?.comparator?.value);
+    const value = computed(() => getFilterValue(props.option?.value, label.value, comparator.value));
+</script>
+
+<style lang="scss" scoped>
+    span {
+        color: var(--bs-primary);
+    }
+</style>

--- a/ui/src/components/filter/components/Label.vue
+++ b/ui/src/components/filter/components/Label.vue
@@ -1,21 +1,22 @@
 <template>
-    <label>
-        {{ label }}<template v-if="comparator"><span>:{{ comparator }}:</span></template>
-        <template v-if="value">{{ value }}</template>
-    </label>
+    <span v-if="label">{{ label }}</span>
+    <span v-if="comparator" class="text-primary">:{{ comparator }}:</span>
+    <span v-if="value">{{ value }}</span>
 </template>
 
 <script setup lang="ts">
     import {computed} from "vue";
 
-    const props = defineProps({
-        option: {type: Object, required: true}
-    });
+    const props = defineProps({option: {type: Object, required: true}});
 
-    const DATE_FORMATS = {timeStyle: "short", dateStyle: "short"};
+    const DATE_FORMATS: Intl.DateTimeFormatOptions = {timeStyle: "short", dateStyle: "short"};
     const formatter = new Intl.DateTimeFormat("en-US", DATE_FORMATS);
 
-    const getFilterValue = (value, label, comparator) => {
+    const label = computed(() => props.option?.label);
+    const comparator = computed(() => props.option?.comparator?.value);
+    const value = computed(() => {
+        const {value, label, comparator} = props.option;
+
         if (!value.length) {
             return;
         }
@@ -23,16 +24,6 @@
             return `${value.join(", ")}`;
         }
         const {startDate, endDate} = value[0];
-        return `${startDate ? formatter.format(new Date(startDate)) : "Unknown"}:and:${endDate ? formatter.format(new Date(endDate)) : "Unknown"}`;
-    };
-
-    const label = computed(() => props.option.label);
-    const comparator = computed(() => props.option?.comparator?.value);
-    const value = computed(() => getFilterValue(props.option?.value, label.value, comparator.value));
+        return `${startDate ? formatter.format(new Date(startDate)) : "unknown"}:and:${endDate ? formatter.format(new Date(endDate)) : "unknown"}`;
+    });
 </script>
-
-<style lang="scss" scoped>
-    span {
-        color: var(--bs-primary);
-    }
-</style>

--- a/ui/src/components/filter/components/Label.vue
+++ b/ui/src/components/filter/components/Label.vue
@@ -1,7 +1,8 @@
 <template>
     <span v-if="label">{{ label }}</span>
     <span v-if="comparator" class="text-primary">:{{ comparator }}:</span>
-    <span v-if="value">{{ value }}</span>
+    <!-- TODO: Amend line below after merging issue: https://github.com/kestra-io/kestra/issues/5955 -->
+    <span v-if="value">{{ !comparator ? ":" : "" }}{{ value }}</span>
 </template>
 
 <script setup lang="ts">

--- a/ui/src/components/filter/components/Label.vue
+++ b/ui/src/components/filter/components/Label.vue
@@ -23,6 +23,7 @@
         if (label !== "absolute_date" && comparator !== "between") {
             return `${value.join(", ")}`;
         }
+
         const {startDate, endDate} = value[0];
         return `${startDate ? formatter.format(new Date(startDate)) : "unknown"}:and:${endDate ? formatter.format(new Date(endDate)) : "unknown"}`;
     });

--- a/ui/src/components/filter/components/Label.vue
+++ b/ui/src/components/filter/components/Label.vue
@@ -13,13 +13,12 @@
     const formatter = new Intl.DateTimeFormat("en-US", DATE_FORMATS);
 
     const label = computed(() => props.option?.label);
-    const comparator = computed(() => props.option?.comparator?.value);
+    const comparator = computed(() => props.option?.comparator?.label);
     const value = computed(() => {
         const {value, label, comparator} = props.option;
 
-        if (!value.length) {
-            return;
-        }
+        if (!value.length) return;
+
         if (label !== "absolute_date" && comparator !== "between") {
             return `${value.join(", ")}`;
         }

--- a/ui/src/components/filter/components/Save.vue
+++ b/ui/src/components/filter/components/Save.vue
@@ -26,7 +26,7 @@
         </section>
         <section class="current-tags">
             <el-tag v-for="(item, index) in current" :key="index" class="m-1">
-                {{ formatLabel(item) }}
+                <Label :option="item" />
             </el-tag>
         </section>
         <template #footer>
@@ -51,6 +51,8 @@
     import {useI18n} from "vue-i18n";
     const {t} = useI18n({useScope: "global"});
 
+    import Label from "./Label.vue";
+
     import Save from "vue-material-design-icons/ContentSaveOutline.vue";
 
     const props = defineProps({
@@ -59,7 +61,7 @@
         current: {type: Object, required: true},
     });
 
-    import {formatLabel, useFilters} from "../useFilters.js";
+    import {useFilters} from "../useFilters.js";
     const {getSavedItems, setSavedItems} = useFilters(props.prefix);
 
     const visible = ref(false);

--- a/ui/src/components/filter/components/history/HistoryItem.vue
+++ b/ui/src/components/filter/components/history/HistoryItem.vue
@@ -7,7 +7,9 @@
         <div class="col flex-grow-1 overflow-auto text-nowrap">
             <div class="me-3 overflow-x-auto scroller">
                 <el-tag v-for="value in item.value" :key="value" class="me-2">
-                    <span class="small">{{ formatLabel(value) }}</span>
+                    <span class="small">
+                        <Label :option="value" />
+                    </span>
                 </el-tag>
             </div>
         </div>
@@ -19,7 +21,7 @@
 </template>
 
 <script setup lang="ts">
-    import {formatLabel} from "../../useFilters.js";
+    import Label from "../Label.vue";
 
     defineProps({item: {type: Object, required: true}});
 </script>

--- a/ui/src/components/filter/useFilters.js
+++ b/ui/src/components/filter/useFilters.js
@@ -169,7 +169,7 @@ export function useFilters(prefix) {
         // Handle the date functionality by grouping startDate and endDate if they exist
         if (query.startDate && query.endDate) {
             params.push({
-                label: "absolute_date:between",
+                label: "absolute_date",
                 value: [{startDate: query.startDate, endDate: query.endDate}],
             });
         }

--- a/ui/src/components/filter/useFilters.js
+++ b/ui/src/components/filter/useFilters.js
@@ -13,24 +13,6 @@ const filterItems = (items, element) => {
     return items.filter((item) => compare(item, element));
 };
 
-const DATE_FORMATS = {timeStyle: "short", dateStyle: "short"};
-const formatter = new Intl.DateTimeFormat("en-US", DATE_FORMATS);
-export const formatLabel = (option) => {
-    let {label, comparator, value} = option;
-
-    if (comparator?.label) label += `:${comparator.label}`;
-
-    if (value.length) {
-        if (label !== "absolute_date:between") label += `:${value.join(", ")}`;
-        else {
-            const {startDate, endDate} = value[0];
-            label += `:${startDate ? formatter.format(new Date(startDate)) : "Unknown"}:and:${endDate ? formatter.format(new Date(endDate)) : "Unknown"}`;
-        }
-    }
-
-    return label;
-};
-
 export function useFilters(prefix) {
     const {t} = useI18n({useScope: "global"});
 


### PR DESCRIPTION
### What changes are being made and why?

Filter label was divided to separate parts using new `Label` component.

The component got reused.

closes #5926

![20241116-223436_snap](https://github.com/user-attachments/assets/513b01f0-4991-440f-897d-4452bf1e0fe5)
