### PR TITLE
fix(ui): pass with credentials as true to follow endpoints

### DIFF
--- a/ui/src/stores/executions.js
+++ b/ui/src/stores/executions.js
@@ -215,10 +215,10 @@ export default {
             return this.$http.delete(`${apiUrl(this)}/executions/by-query`, {params: options})
         },
         followExecution(_, options) {
-            return new EventSource(`${apiUrl(this)}/executions/${options.id}/follow`);
+            return new EventSource(`${apiUrl(this)}/executions/${options.id}/follow`, {withCredentials: true});
         },
         followLogs(_, options) {
-            return new EventSource(`${apiUrl(this)}/logs/${options.id}/follow`);
+            return new EventSource(`${apiUrl(this)}/logs/${options.id}/follow`, {withCredentials: true});
         },
         loadLogs({commit}, options) {
             return this.$http.get(`${apiUrl(this)}/logs/${options.executionId}`, {


### PR DESCRIPTION
Endpoints for `follow` Executions and Logs were returning 401 status without this parameter passed.