### PR TITLE
feat(storage): Add guard for non-relative subpath Kestra URI

### DIFF
--- a/storage-local/src/main/java/io/kestra/storage/local/LocalStorage.java
+++ b/storage-local/src/main/java/io/kestra/storage/local/LocalStorage.java
@@ -232,12 +232,18 @@ public class LocalStorage implements StorageInterface {
                 .toList();
         }
     }
-
     private URI getKestraUri(String tenantId, Path path) {
         Path prefix = (tenantId == null) ?
-            basePath.toAbsolutePath() :
-            Path.of(basePath.toAbsolutePath().toString(), tenantId);
+            basePath.toAbsolutePath():
+            basePath.toAbsolutePath().resolve(tenantId);
+        subPathParentGuard(path, prefix);
         return URI.create("kestra:///" + prefix.relativize(path).toString().replace("\\", "/"));
+    }
+
+    private void subPathParentGuard(Path path, Path prefix) {
+        if (!path.toAbsolutePath().startsWith(prefix)) {
+            throw new IllegalArgumentException("The path must be a subpath of the base path with the tenant ID.");
+        }
     }
 
     private void parentTraversalGuard(URI uri) {


### PR DESCRIPTION
### What changes are being made and why?

When providing Kestra access URI, an exception handling logic was added to prevent the injected path from being a resource dependent on the base path.

### How the changes have been QAed?

```java
    private URI getKestraUri(String tenantId, Path path) {
        Path prefix = (tenantId == null) ?
            basePath.toAbsolutePath():
            basePath.toAbsolutePath().resolve(tenantId);
        subPathParentGuard(path, prefix);
        return URI.create("kestra:///" + prefix.relativize(path).toString().replace("\\", "/"));
    }

    private void subPathParentGuard(Path path, Path prefix) {
        if (!path.toAbsolutePath().startsWith(prefix)) {
            throw new IllegalArgumentException("The path must be a subpath of the base path with the tenant ID.");
        }
    }
```
---
Implemented for exception handling logic conventions within the same class.
In the basepath branch, the path return logic was unified to resolve to correct readability.
