### PR TITLE
fix(docs): open in a new window + light mode

### DIFF
--- a/ui/src/components/ContextInfoBar.vue
+++ b/ui/src/components/ContextInfoBar.vue
@@ -173,20 +173,26 @@
 
 .barWrapper .barButtonActive{
     background: var(--bs-primary);
-    color: var(--bs-primary-color);
     border-color: var(--bs-primary);
+    color: white;
+    html.dark & {
+        color: var(--bs-primary-color);
+    }
 }
 
 .newsDot{
     width: 10px;
     height: 10px;
     background: #FD7278;
-    border: 2px solid #2F3342;
+    border: 2px solid white;
     border-radius: 50%;
     display: block;
     position: absolute;
     bottom: -4px;
     right: -4px;
+    html.dark & {
+        border-color: #2F3342;
+    }
 }
 
 .buttonIcon{

--- a/ui/src/components/ContextInfoBar.vue
+++ b/ui/src/components/ContextInfoBar.vue
@@ -3,6 +3,7 @@
     import {useMouse, watchThrottled} from "@vueuse/core"
     import ContextDocs from "./docs/ContextDocs.vue"
     import ContextNews from "./layout/ContextNews.vue"
+    import DateAgo from "./layout/DateAgo.vue"
 
     import MessageOutline from "vue-material-design-icons/MessageOutline.vue"
     import FileDocument from "vue-material-design-icons/FileDocument.vue"
@@ -104,8 +105,20 @@
             <Calendar class="buttonIcon" />Get a demo<OpenInNew class="openIcon" />
         </a>
         <div style="flex:1" />
-        <span v-if="configs?.commitId" class="versionNumber">{{ configs?.commitId }}</span>
         <span class="versionNumber">{{ configs?.version }}</span>
+        <el-tooltip
+            v-if="configs?.commitId"
+            effect="light"
+            :persistent="false"
+            transition=""
+            :hide-after="0"
+            placement="left"
+        >
+            <template #content>
+                <DateAgo :inverted="true" :date="configs.commitDate" />
+            </template>
+            <span class="commitNumber">{{ configs?.commitId }}</span>
+        </el-tooltip>
     </div>
     <div ref="panel" class="panelWrapper" :class="{panelTabResizing: resizing}" :style="{width: activeTab?.length ? `${panelWidth}px` : 0}">
         <div :style="{overflow: 'hidden', width:`${panelWidth}px`}">
@@ -211,6 +224,12 @@
     font-size: 12px;
     color: var(--bs-tertiary-color);
     margin-top: var(--spacer);
+}
+
+.commitNumber{
+    font-size: 12px;
+    color: var(--bs-primary-color);
+    margin-top: calc(.5 * var(--spacer));
 }
 
 .panelWrapper{

--- a/ui/src/components/ContextInfoBar.vue
+++ b/ui/src/components/ContextInfoBar.vue
@@ -228,7 +228,7 @@
 
 .commitNumber{
     font-size: 12px;
-    color: var(--bs-primary-color);
+    color: var(--bs-primary);
     margin-top: calc(.5 * var(--spacer));
 }
 

--- a/ui/src/components/docs/ContextDocs.vue
+++ b/ui/src/components/docs/ContextDocs.vue
@@ -60,7 +60,17 @@
 <template>
     <div class="docWrapper">
         <h2 class="docTitle">
-            <a :href="`/docs${docPath ?? ''}`" target="_blank"><OpenInNew class="openInNew" /></a>
+            <router-link
+                :to="{
+                    name: 'docs/view',
+                    params:{
+                        path:docPath
+                    }
+                }"
+                target="_blank"
+            >
+                <OpenInNew class="openInNew" />
+            </router-link>
             {{ routeInfo.title }}
         </h2>
         <el-divider style="margin:0 var(--spacer);" />

--- a/ui/src/components/layout/DefaultLayout.vue
+++ b/ui/src/components/layout/DefaultLayout.vue
@@ -6,7 +6,7 @@
             Error: <errors :code="error" />
         </template>
     </main>
-    <context-info-bar />
+    <context-info-bar v-if="configs" />
 </template>
 
 <script setup>

--- a/ui/src/components/layout/SideBar.vue
+++ b/ui/src/components/layout/SideBar.vue
@@ -8,8 +8,13 @@
         width="268px"
         :collapsed="collapsed"
         link-component-name="LeftMenuLink"
+        hide-toggle
     >
         <template #header>
+            <el-button @click="collapsed = !collapsed" class="collapseButton" :size="collapsed ? 'small':undefined">
+                <chevron-right v-if="collapsed" />
+                <chevron-left v-else />
+            </el-button>
             <div class="logo">
                 <router-link :to="{name: 'home'}">
                     <span class="img" />
@@ -20,13 +25,6 @@
 
         <template #footer>
             <slot name="footer" />
-        </template>
-
-        <template #toggle-icon>
-            <el-button>
-                <chevron-double-right v-if="collapsed" />
-                <chevron-double-left v-else />
-            </el-button>
         </template>
     </sidebar-menu>
 </template>
@@ -46,8 +44,8 @@
 
     import {SidebarMenu} from "vue-sidebar-menu";
 
-    import ChevronDoubleLeft from "vue-material-design-icons/ChevronDoubleLeft.vue";
-    import ChevronDoubleRight from "vue-material-design-icons/ChevronDoubleRight.vue";
+    import ChevronLeft from "vue-material-design-icons/ChevronLeft.vue";
+    import ChevronRight from "vue-material-design-icons/ChevronRight.vue";
     import StarOutline from "vue-material-design-icons/StarOutline.vue";
 
     import Environment from "./Environment.vue";
@@ -170,6 +168,20 @@
 </script>
 
 <style lang="scss">
+    .collapseButton{
+        position: absolute;
+        top: var(--spacer);
+        right: var(--spacer);
+        z-index: 1;
+        #side-menu & {
+            border: none;
+        }
+
+        .vsm_collapsed & {
+            top: calc(var(--spacer) * .5);
+        }
+    }
+
     #side-menu {
         position: static;
         z-index: 1039;
@@ -178,7 +190,7 @@
         .logo {
             overflow: hidden;
             padding: 35px 0;
-            height: 113px;
+            height: 112px;
             position: relative;
 
             a {
@@ -204,6 +216,8 @@
                 }
             }
         }
+
+
 
 
         span.version {


### PR DESCRIPTION
closes https://github.com/kestra-io/kestra-ee/issues/2218
closes https://github.com/kestra-io/kestra-ee/issues/2219

- open docs in a new window sent to a 404
- in light mode, the fonts were black on purple impossible to read
- the border of the news button was black very aggressive
- the commit sha was not placed with todos instructions
- the collapse expand needed to match the designs