### PR TITLE
feat(jdbc): Improve execution queued performance

### DIFF
--- a/jdbc-h2/src/main/resources/migrations/h2/V1_23__execution_queued_index.sql
+++ b/jdbc-h2/src/main/resources/migrations/h2/V1_23__execution_queued_index.sql
@@ -1,0 +1,2 @@
+DROP INDEX execution_queued__flow;
+CREATE INDEX IF NOT EXISTS execution_queued__flow_date ON execution_queued ("tenant_id", "namespace", "flow_id", "date" );

--- a/jdbc-mysql/src/main/resources/migrations/mysql/V1_23__execution_queued_index.sql
+++ b/jdbc-mysql/src/main/resources/migrations/mysql/V1_23__execution_queued_index.sql
@@ -1,0 +1,2 @@
+DROP INDEX ix_flow ON execution_queued;
+CREATE INDEX ix_flow_date ON execution_queued (`tenant_id`, `namespace`, `flow_id`, `date`);

--- a/jdbc-postgres/src/main/resources/migrations/postgres/V1_23__execution_queued_index.sql
+++ b/jdbc-postgres/src/main/resources/migrations/postgres/V1_23__execution_queued_index.sql
@@ -1,0 +1,2 @@
+DROP INDEX execution_queued__flow;
+CREATE INDEX IF NOT EXISTS execution_queued__flow_date ON execution_queued ("tenant_id", "namespace", "flow_id", "date" );

--- a/jdbc/src/main/java/io/kestra/jdbc/runner/AbstractJdbcExecutionQueuedStorage.java
+++ b/jdbc/src/main/java/io/kestra/jdbc/runner/AbstractJdbcExecutionQueuedStorage.java
@@ -36,7 +36,8 @@ public abstract class AbstractJdbcExecutionQueuedStorage extends AbstractJdbcRep
                     .and(field("flow_id").eq(flowId))
                     .orderBy(field("date").asc())
                     .limit(1)
-                    .forUpdate();
+                    .forUpdate()
+                    .skipLocked();
 
                 Optional<ExecutionQueued> maybeExecution = this.jdbcRepository.fetchOne(select);
                 if (maybeExecution.isPresent()) {


### PR DESCRIPTION
Add date inside the index to speed up order by in case there are a lot of execution queued. 
Skip locked records when selecting them as if there is a locked records it means you need to pop the next one.

Tested on 1k executions with a concurrency limit of 50 and it brings almost 50% improvements to tale execution duration.
Checked manually 10 exec, they are still in order so skip locked didn't cause any ordering issue.

Fixes https://github.com/kestra-io/kestra/issues/6024
