### PR TITLE
fix(ui) : Limit the width of the filter dropdown menu in Execution Tab

### DIFF
--- a/ui/src/components/filter/KestraFilter.vue
+++ b/ui/src/components/filter/KestraFilter.vue
@@ -360,6 +360,10 @@
 .filters {
     width: -webkit-fill-available;
 
+    & .el-select {
+        width: 300px;
+    }
+
     & .el-select__placeholder {
         color: var(--bs-gray-700);
     }


### PR DESCRIPTION
Fixes #5925 . Keep the width to a fixed 300px