### PR TITLE
refactor(*): unify instanceof usage to pattern matching style

### DIFF
--- a/core/src/main/java/io/kestra/core/docs/AbstractClassDocumentation.java
+++ b/core/src/main/java/io/kestra/core/docs/AbstractClassDocumentation.java
@@ -126,8 +126,8 @@ public abstract class AbstractClassDocumentation<T> {
             }
 
             result.put(flattenKey(current.getKey(), parentName), finalValue);
-            if (current.getValue() instanceof Map) {
-                Map<String, Object> value = (Map<String, Object>) current.getValue();
+            if (current.getValue() instanceof Map<?, ?> mapValue) {
+                Map<String, Object> value = (Map<String, Object>) mapValue;
 
                 if (value.containsKey("properties")) {
                     result.putAll(flatten(properties(value), required(value), current.getKey()));

--- a/core/src/main/java/io/kestra/core/endpoints/BasicAuthEndpointsFilter.java
+++ b/core/src/main/java/io/kestra/core/endpoints/BasicAuthEndpointsFilter.java
@@ -31,8 +31,8 @@ public class BasicAuthEndpointsFilter implements HttpServerFilter {
     @Override
     public Publisher<MutableHttpResponse<?>> doFilter(HttpRequest<?> request, ServerFilterChain chain) {
         Optional<RouteMatch> routeMatch = RouteMatchUtils.findRouteMatch(request);
-        if (routeMatch.isPresent() && routeMatch.get() instanceof MethodBasedRouteMatch) {
-            ExecutableMethod<?, ?> method = ((MethodBasedRouteMatch<?, ?>) routeMatch.get()).getExecutableMethod();
+        if (routeMatch.isPresent() && routeMatch.get() instanceof MethodBasedRouteMatch<?, ?> methodBasedRouteMatch) {
+            ExecutableMethod<?, ?> method = methodBasedRouteMatch.getExecutableMethod();
             if (method.getAnnotation(Endpoint.class) != null) {
                 if (!validateUser(request)) {
                     return Publishers.just(HttpResponse.status(HttpStatus.UNAUTHORIZED));

--- a/core/src/main/java/io/kestra/core/endpoints/WorkerEndpoint.java
+++ b/core/src/main/java/io/kestra/core/endpoints/WorkerEndpoint.java
@@ -37,9 +37,9 @@ public class WorkerEndpoint {
                     .stream()
                     .map(workerTask -> new WorkerEndpointWorkerTask(
                         workerTask.getType(),
-                        (workerTask instanceof WorkerTask) ? ((WorkerTask) workerTask).getTaskRun() : null,
-                        (workerTask instanceof WorkerTask) ? ((WorkerTask) workerTask).getTask() : null,
-                        (workerTask instanceof WorkerTrigger) ? ((WorkerTrigger) workerTask).getTrigger() : null
+                        workerTask instanceof WorkerTask wt ? wt.getTaskRun() : null,
+                        workerTask instanceof WorkerTask wt ? wt.getTask() : null,
+                        workerTask instanceof WorkerTrigger wt ? wt.getTrigger() : null
                     ))
                     .toList()
             )

--- a/core/src/main/java/io/kestra/core/models/executions/MetricEntry.java
+++ b/core/src/main/java/io/kestra/core/models/executions/MetricEntry.java
@@ -74,12 +74,12 @@ public class MetricEntry implements DeletedInterface, TenantInterface {
     }
 
     private static Double computeValue(AbstractMetricEntry<?> metricEntry) {
-        if (metricEntry instanceof Counter) {
-            return ((Counter) metricEntry).getValue();
+        if (metricEntry instanceof Counter counter) {
+            return counter.getValue();
         }
 
-        if (metricEntry instanceof Timer) {
-            return (double) ((Timer) metricEntry).getValue().toMillis();
+        if (metricEntry instanceof Timer timer) {
+            return (double) timer.getValue().toMillis();
         }
 
         throw new IllegalArgumentException("Unknown metric type: " + metricEntry.getClass());

--- a/core/src/main/java/io/kestra/core/models/flows/Flow.java
+++ b/core/src/main/java/io/kestra/core/models/flows/Flow.java
@@ -264,7 +264,7 @@ public class Flow extends AbstractFlow implements HasUID {
 
     public Flow updateTask(String taskId, Task newValue) throws InternalException {
         Task task = this.findTaskByTaskId(taskId);
-        Flow flow = this instanceof FlowWithSource ? ((FlowWithSource) this).toFlow() : this;
+        Flow flow = this instanceof FlowWithSource flowWithSource ? flowWithSource.toFlow() : this;
 
         Map<String, Object> map = NON_DEFAULT_OBJECT_MAPPER.convertValue(flow, JacksonMapper.MAP_TYPE_REFERENCE);
 
@@ -275,8 +275,7 @@ public class Flow extends AbstractFlow implements HasUID {
     }
 
     private static Object recursiveUpdate(Object object, Task previous, Task newValue) {
-        if (object instanceof Map) {
-            Map<?, ?> value = (Map<?, ?>) object;
+        if (object instanceof Map<?, ?> value) {
             if (value.containsKey("id") && value.get("id").equals(previous.getId()) &&
                 value.containsKey("type") && value.get("type").equals(previous.getType())
             ) {
@@ -291,8 +290,7 @@ public class Flow extends AbstractFlow implements HasUID {
                     ))
                     .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
             }
-        } else if (object instanceof Collection) {
-            Collection<?> value = (Collection<?>) object;
+        } else if (object instanceof Collection<?> value) {
             return value
                 .stream()
                 .map(r -> recursiveUpdate(r, previous, newValue))

--- a/core/src/main/java/io/kestra/core/models/hierarchies/SubflowGraphTask.java
+++ b/core/src/main/java/io/kestra/core/models/hierarchies/SubflowGraphTask.java
@@ -27,8 +27,8 @@ public class SubflowGraphTask extends AbstractGraphTask {
 
     public ExecutableTask<?> executableTask() {
         TaskInterface task = super.getTask();
-        if (task instanceof ExecutableTask) {
-            return (ExecutableTask<?>) task;
+        if (task instanceof ExecutableTask<?> executableTask) {
+            return executableTask;
         } else {
             return null;
         }

--- a/core/src/main/java/io/kestra/core/models/tasks/runners/PluginUtilsService.java
+++ b/core/src/main/java/io/kestra/core/models/tasks/runners/PluginUtilsService.java
@@ -104,11 +104,11 @@ abstract public class PluginUtilsService {
                 }
             });
             return runContext.renderMap(nullFilteredInputFiles, additionalVars);
-        } else if (inputFiles instanceof String) {
+        } else if (inputFiles instanceof String inputFileString) {
 
 
             return JacksonMapper.ofJson(false).readValue(
-                runContext.render((String) inputFiles, additionalVars),
+                runContext.render(inputFileString, additionalVars),
                 MAP_TYPE_REFERENCE
             );
         } else {

--- a/core/src/main/java/io/kestra/core/models/validations/KestraConstraintViolationException.java
+++ b/core/src/main/java/io/kestra/core/models/validations/KestraConstraintViolationException.java
@@ -21,11 +21,11 @@ public class KestraConstraintViolationException extends ConstraintViolationExcep
         for (ConstraintViolation<?> violation : getConstraintViolations()) {
             String errorMessage = violation.getPropertyPath() + ": " + violation.getMessage();
             try {
-                if (violation.getLeafBean() instanceof Task) {
-                    errorMessage = replaceId("tasks", violation.getPropertyPath().toString(), ((Task) violation.getLeafBean()).getId()) + ": " + violation.getMessage();
+                if (violation.getLeafBean() instanceof Task task) {
+                    errorMessage = replaceId("tasks", violation.getPropertyPath().toString(), task.getId()) + ": " + violation.getMessage();
                 }
-                if (violation.getLeafBean() instanceof Input) {
-                    errorMessage = replaceId("inputs", violation.getPropertyPath().toString(), ((Input) violation.getLeafBean()).getId()) + ": " + violation.getMessage();
+                if (violation.getLeafBean() instanceof Input input) {
+                    errorMessage = replaceId("inputs", violation.getPropertyPath().toString(), input.getId()) + ": " + violation.getMessage();
 
                 }
             } catch (Exception e) {

--- a/core/src/main/java/io/kestra/core/runners/FlowableUtils.java
+++ b/core/src/main/java/io/kestra/core/runners/FlowableUtils.java
@@ -386,25 +386,25 @@ public class FlowableUtils {
     public static List<ResolvedTask> resolveEachTasks(RunContext runContext, TaskRun parentTaskRun, List<Task> tasks, Object value) throws IllegalVariableEvaluationException {
         List<Object> values;
 
-        if (value instanceof String) {
-            String renderValue = runContext.render((String) value);
+        if (value instanceof String stringValue) {
+            String renderValue = runContext.render(stringValue);
             try {
                 values = MAPPER.readValue(renderValue, TYPE_REFERENCE);
             } catch (JsonProcessingException e) {
                 throw new IllegalVariableEvaluationException(e);
             }
-        } else if (value instanceof List) {
-            values = new ArrayList<>(((List<?>) value).size());
+        } else if (value instanceof List<?> listValue) {
+            values = new ArrayList<>(listValue.size());
             for (Object obj : (List<Object>) value) {
-                if (obj instanceof String) {
-                    values.add(runContext.render((String) obj));
+                if (obj instanceof String stringObj) {
+                    values.add(runContext.render(stringObj));
                 }
                 else if (obj instanceof Integer) {
                     values.add(runContext.render(obj.toString()));
                 }
-                else if(obj instanceof Map<?, ?>) {
+                else if(obj instanceof Map mapObj) {
                     //JSON or YAML map
-                    values.add(runContext.render((Map) obj));
+                    values.add(runContext.render(mapObj));
                 } else {
                     throw new IllegalVariableEvaluationException("Unknown value element type: " + obj.getClass());
                 }
@@ -434,7 +434,7 @@ public class FlowableUtils {
         for (Object current : distinctValue) {
             for (Task task : tasks) {
                 try {
-                    String resolvedValue = current instanceof String ? (String) current : MAPPER.writeValueAsString(current);
+                    String resolvedValue = current instanceof String stringValue ? stringValue : MAPPER.writeValueAsString(current);
 
                     result.add(ResolvedTask.builder()
                         .task(task)

--- a/core/src/main/java/io/kestra/core/runners/RunContextLogger.java
+++ b/core/src/main/java/io/kestra/core/runners/RunContextLogger.java
@@ -129,8 +129,8 @@ public class RunContextLogger implements Supplier<org.slf4j.Logger> {
         Throwable result = null;
         IThrowableProxy throwableProxy = event.getThrowableProxy();
         if (null != throwableProxy) {
-            if (throwableProxy instanceof ThrowableProxy) {
-                result = ((ThrowableProxy) throwableProxy).getThrowable();
+            if (throwableProxy instanceof ThrowableProxy proxyThrowable) {
+                result = proxyThrowable.getThrowable();
             }
         }
         return result;
@@ -270,7 +270,7 @@ public class RunContextLogger implements Supplier<org.slf4j.Logger> {
                     this.logger,
                     event.getLevel(),
                     message,
-                    event.getThrowableProxy() instanceof ThrowableProxy ? ((ThrowableProxy) event.getThrowableProxy()).getThrowable() : null,
+                    event.getThrowableProxy() instanceof ThrowableProxy throwableProxy ? throwableProxy.getThrowable() : null,
                     argumentArray
                 );
             } catch (Throwable e) {

--- a/core/src/main/java/io/kestra/core/runners/VariableRenderer.java
+++ b/core/src/main/java/io/kestra/core/runners/VariableRenderer.java
@@ -116,8 +116,8 @@ public class VariableRenderer {
         } catch (IOException | PebbleException e) {
             String alternativeRender = this.alternativeRender(e, (String) inline, variables);
             if (alternativeRender == null) {
-                if (e instanceof PebbleException) {
-                    throw properPebbleException((PebbleException) e);
+                if (e instanceof PebbleException pebbleException) {
+                    throw properPebbleException(pebbleException);
                 }
                 throw new IllegalVariableEvaluationException(e);
             } else {
@@ -125,9 +125,9 @@ public class VariableRenderer {
             }
         }
 
-        if (result instanceof String && replacers != null) {
+        if (result instanceof String stringValue && replacers != null) {
             // post-process raw tags
-            result = putBackRawTags(replacers, (String) result);
+            result = putBackRawTags(replacers, stringValue);
         }
 
         return result;

--- a/core/src/main/java/io/kestra/core/runners/pebble/AbstractDate.java
+++ b/core/src/main/java/io/kestra/core/runners/pebble/AbstractDate.java
@@ -79,28 +79,28 @@ public abstract class AbstractDate {
     }
 
     protected static ZonedDateTime convert(Object value, ZoneId zoneId, String existingFormat) {
-        if (value instanceof Date) {
-            return ZonedDateTime.ofInstant(((Date) value).toInstant(), zoneId);
+        if (value instanceof Date dateValue) {
+            return ZonedDateTime.ofInstant(dateValue.toInstant(), zoneId);
         }
 
-        if (value instanceof Instant) {
-            return ((Instant) value).atZone(zoneId);
+        if (value instanceof Instant instantValue) {
+            return instantValue.atZone(zoneId);
         }
 
-        if (value instanceof LocalDateTime) {
-            return ZonedDateTime.of((LocalDateTime) value, zoneId);
+        if (value instanceof LocalDateTime localDateTimeValue) {
+            return ZonedDateTime.of(localDateTimeValue, zoneId);
         }
 
-        if (value instanceof LocalDate) {
-            return ZonedDateTime.of((LocalDate) value, LocalTime.NOON, zoneId);
+        if (value instanceof LocalDate localDateValue) {
+            return ZonedDateTime.of(localDateValue, LocalTime.NOON, zoneId);
         }
 
-        if (value instanceof ZonedDateTime) {
-            return (ZonedDateTime) value;
+        if (value instanceof ZonedDateTime zonedDateTimeValue) {
+            return zonedDateTimeValue;
         }
 
-        if (value instanceof Long) {
-            return Instant.ofEpochSecond((Long) value).atZone(zoneId);
+        if (value instanceof Long longValue) {
+            return Instant.ofEpochSecond(longValue).atZone(zoneId);
         }
 
         try {

--- a/core/src/main/java/io/kestra/core/runners/pebble/filters/EscapeCharFilter.java
+++ b/core/src/main/java/io/kestra/core/runners/pebble/filters/EscapeCharFilter.java
@@ -46,8 +46,8 @@ public class EscapeCharFilter implements Filter {
         Map<String, Object> resultMap = new HashMap<>();
         for (Map.Entry<String, Object> entry : inputMap.entrySet()) {
             Object value = entry.getValue();
-            if (value instanceof String) {
-                resultMap.put(entry.getKey(), escapeString((String) value, args, self, lineNumber));
+            if (value instanceof String stringValue) {
+                resultMap.put(entry.getKey(), escapeString(stringValue, args, self, lineNumber));
             } else if (value instanceof Map) {
                 resultMap.put(entry.getKey(), processMap((Map<String, Object>) value, args, self, lineNumber));
             } else if (value instanceof List<?>) {
@@ -63,8 +63,8 @@ public class EscapeCharFilter implements Filter {
     private Object processList(List<Object> inputList, Map<String, Object> args, PebbleTemplate self, int lineNumber) {
         List<Object> resultList = new ArrayList<>();
         for (Object item : inputList) {
-            if (item instanceof String) {
-                resultList.add(escapeString((String) item, args, self, lineNumber));
+            if (item instanceof String stringValue) {
+                resultList.add(escapeString(stringValue, args, self, lineNumber));
             } else if (item instanceof Map) {
                 resultList.add(processMap((Map<String, Object>) item, args, self, lineNumber));
             } else if (item instanceof List<?>) {

--- a/core/src/main/java/io/kestra/core/runners/pebble/filters/FlattenFilter.java
+++ b/core/src/main/java/io/kestra/core/runners/pebble/filters/FlattenFilter.java
@@ -33,7 +33,7 @@ public class FlattenFilter implements Filter {
         try {
             List<?> list = (List<?>) input;
             List<Object> flattened = list.stream()
-                .flatMap(o -> o instanceof List ? ((List<?>) o).stream() : Stream.of(o))
+                .flatMap(o -> o instanceof List<?> listValue ? listValue.stream() : Stream.of(o))
                 .toList();
             return flattened;
         } catch (Exception e) {

--- a/core/src/main/java/io/kestra/core/runners/pebble/filters/JqFilter.java
+++ b/core/src/main/java/io/kestra/core/runners/pebble/filters/JqFilter.java
@@ -50,8 +50,8 @@ public class JqFilter implements Filter {
             JsonQuery q = JsonQuery.compile(pattern, Versions.JQ_1_6);
 
             JsonNode in;
-            if (input instanceof String) {
-                in = JacksonMapper.ofJson().readTree((String) input);
+            if (input instanceof String stringValue) {
+                in = JacksonMapper.ofJson().readTree(stringValue);
             } else {
                 in = JacksonMapper.ofJson().valueToTree(input);
             }

--- a/core/src/main/java/io/kestra/core/runners/pebble/filters/KeysFilter.java
+++ b/core/src/main/java/io/kestra/core/runners/pebble/filters/KeysFilter.java
@@ -27,13 +27,11 @@ public class KeysFilter implements Filter {
             return null;
         }
 
-        if (input instanceof Map) {
-            Map inputMap = (Map) input;
+        if (input instanceof Map inputMap) {
             return inputMap.keySet();
         }
 
-        if (input instanceof List) {
-            List inputList = (List) input;
+        if (input instanceof List inputList) {
             return IntStream
                 .rangeClosed(0, inputList.size() - 1)
                 .boxed()

--- a/core/src/main/java/io/kestra/core/runners/pebble/filters/ReplaceFilter.java
+++ b/core/src/main/java/io/kestra/core/runners/pebble/filters/ReplaceFilter.java
@@ -56,8 +56,8 @@ public class ReplaceFilter implements Filter {
         Map<String, Object> resultMap = new HashMap<>();
         for (Map.Entry<String, Object> entry : inputMap.entrySet()) {
             Object value = entry.getValue();
-            if (value instanceof String) {
-                resultMap.put(entry.getKey(), processString((String) value, replacePair, regexp));
+            if (value instanceof String stringValue) {
+                resultMap.put(entry.getKey(), processString(stringValue, replacePair, regexp));
             } else if (value instanceof Map) {
                 resultMap.put(entry.getKey(), processMap((Map<String, Object>) value, replacePair, regexp));
             } else if (value instanceof List<?>) {
@@ -73,8 +73,8 @@ public class ReplaceFilter implements Filter {
     private Object processList(List<Object> inputList, Map<?, ?> replacePair, boolean regexp) {
         List<Object> resultList = new ArrayList<>();
         for (Object item : inputList) {
-            if (item instanceof String) {
-                resultList.add(processString((String) item, replacePair, regexp));
+            if (item instanceof String stringValue) {
+                resultList.add(processString(stringValue, replacePair, regexp));
             } else if (item instanceof Map) {
                 resultList.add(processMap((Map<String, Object>) item, replacePair, regexp));
             } else if (item instanceof List<?>) {

--- a/core/src/main/java/io/kestra/core/runners/pebble/filters/ValuesFilter.java
+++ b/core/src/main/java/io/kestra/core/runners/pebble/filters/ValuesFilter.java
@@ -24,8 +24,7 @@ public class ValuesFilter implements Filter {
             return null;
         }
 
-        if (input instanceof Map) {
-            Map inputMap = (Map) input;
+        if (input instanceof Map inputMap) {
             return inputMap.values();
         }
 

--- a/core/src/main/java/io/kestra/core/services/FlowService.java
+++ b/core/src/main/java/io/kestra/core/services/FlowService.java
@@ -347,8 +347,8 @@ public class FlowService {
      * @return the modified object
      */
     private static Object fixSnakeYaml(Object object) {
-        if (object instanceof Map) {
-            return ((Map<?, ?>) object)
+        if (object instanceof Map<?, ?> mapValue) {
+            return mapValue
                 .entrySet()
                 .stream()
                 .map(entry -> new AbstractMap.SimpleEntry<>(
@@ -364,14 +364,12 @@ public class FlowService {
                     },
                     LinkedHashMap::new
                 ));
-        } else if (object instanceof Collection) {
-            return ((Collection<?>) object)
+        } else if (object instanceof Collection<?> collectionValue) {
+            return collectionValue
                 .stream()
                 .map(FlowService::fixSnakeYaml)
                 .toList();
-        } else if (object instanceof String) {
-            String item = (String) object;
-
+        } else if (object instanceof String item) {
             if (item.contains("\n")) {
                 return item.replaceAll("\\s+\\n", "\\\n");
             }

--- a/core/src/main/java/io/kestra/core/services/Graph2DotService.java
+++ b/core/src/main/java/io/kestra/core/services/Graph2DotService.java
@@ -33,9 +33,7 @@ public class Graph2DotService {
         StringBuilder sb = new StringBuilder();
 
         for(AbstractGraph node : graph.nodes()) {
-            if (node instanceof GraphCluster) {
-                GraphCluster subGraph = (GraphCluster) node;
-
+            if (node instanceof GraphCluster subGraph) {
                 if (uid == null || !uid.equals(subGraph.getUid())) {
                     sb.append(subgraph(subGraph, level + 1));
                 }

--- a/core/src/main/java/io/kestra/core/utils/Debug.java
+++ b/core/src/main/java/io/kestra/core/utils/Debug.java
@@ -23,10 +23,10 @@ public class Debug {
     public static <T> String toJson(T arg) {
         String output;
 
-        if (arg instanceof String) {
-            output = (String) arg;
-        } else if (arg instanceof byte[]) {
-            output = new String((byte[]) arg);
+        if (arg instanceof String stringValue) {
+            output = stringValue;
+        } else if (arg instanceof byte[] bytesValue) {
+            output = new String(bytesValue);
         } else {
             try {
                 output = MAPPER.writerWithDefaultPrettyPrinter().writeValueAsString(arg);

--- a/core/src/main/java/io/kestra/core/utils/GraphUtils.java
+++ b/core/src/main/java/io/kestra/core/utils/GraphUtils.java
@@ -84,7 +84,7 @@ public class GraphUtils {
     public static List<AbstractGraph> nodes(GraphCluster graphCluster) {
         return graphCluster.getGraph().nodes()
             .stream()
-            .flatMap(t -> t instanceof GraphCluster ? nodes((GraphCluster) t).stream() : Stream.of(t))
+            .flatMap(t -> t instanceof GraphCluster cluster ? nodes(cluster).stream() : Stream.of(t))
             .distinct()
             .toList();
     }
@@ -96,7 +96,7 @@ public class GraphUtils {
                     .map(r -> Triple.of(r.getSource(), r.getTarget(), r.getValue())),
                 graphCluster.getGraph().nodes()
                     .stream()
-                    .flatMap(t -> t instanceof GraphCluster ? rawEdges((GraphCluster) t).stream() : Stream.of())
+                    .flatMap(t -> t instanceof GraphCluster cluster ? rawEdges(cluster).stream() : Stream.of())
             )
             .toList();
     }
@@ -113,13 +113,13 @@ public class GraphUtils {
             .stream()
             .flatMap(t -> {
 
-                if (t instanceof GraphCluster) {
+                if (t instanceof GraphCluster cluster) {
                     ArrayList<String> currentParents = new ArrayList<>(parents);
-                    currentParents.add(t.getUid());
+                    currentParents.add(cluster.getUid());
 
                     return Stream.concat(
-                        Stream.of(Pair.of((GraphCluster) t, parents)),
-                        clusters((GraphCluster) t, currentParents).stream()
+                        Stream.of(Pair.of(cluster, parents)),
+                        clusters(cluster, currentParents).stream()
                     );
                 }
 
@@ -134,7 +134,7 @@ public class GraphUtils {
 
         List<AbstractGraph> selectedTaskRuns = nodes
             .stream()
-            .filter(task -> task instanceof AbstractGraphTask)
+            .filter(AbstractGraphTask.class::isInstance)
             .filter(task -> ((AbstractGraphTask) task).getTaskRun() != null && taskRunIds.contains(((AbstractGraphTask) task).getTaskRun().getId()))
             .toList();
 

--- a/core/src/main/java/io/kestra/core/utils/MapUtils.java
+++ b/core/src/main/java/io/kestra/core/utils/MapUtils.java
@@ -43,15 +43,15 @@ public class MapUtils {
                         found = original;
                     } else if (original == null) {
                         found = value;
-                    } else if (value instanceof Map && original instanceof Map) {
-                        found = merge((Map) original, (Map) value);
-                    } else if (value instanceof Collection
-                        && original instanceof Collection) {
+                    } else if (value instanceof Map mapValue && original instanceof Map mapOriginal) {
+                        found = merge(mapOriginal, mapValue);
+                    } else if (value instanceof Collection collectionValue
+                        && original instanceof Collection collectionOriginal) {
                         try {
                             found = Lists
                                 .newArrayList(
-                                    (Collection) original,
-                                    (Collection) value
+                                    collectionOriginal,
+                                    collectionValue
                                 )
                                 .stream()
                                 .flatMap(Collection::stream)
@@ -84,10 +84,10 @@ public class MapUtils {
                     Object value = entry.getValue();
                     Object found;
 
-                    if (value instanceof Map) {
-                        found = cloneMap((Map) value);
-                    } else if (value instanceof Collection) {
-                        found = cloneCollection((Collection) value);
+                    if (value instanceof Map mapValue) {
+                        found = cloneMap(mapValue);
+                    } else if (value instanceof Collection collectionValue) {
+                        found = cloneCollection(collectionValue);
                     } else {
                         found = value;
                     }

--- a/core/src/main/java/io/kestra/plugin/core/http/AbstractHttp.java
+++ b/core/src/main/java/io/kestra/plugin/core/http/AbstractHttp.java
@@ -166,8 +166,8 @@ abstract public class AbstractHttp extends Task implements HttpInterface {
                 for (Map.Entry<String, Object> e : this.formData.entrySet()) {
                     String key = runContext.render(e.getKey());
 
-                    if (e.getValue() instanceof String) {
-                        String render = runContext.render((String) e.getValue());
+                    if (e.getValue() instanceof String stringValue) {
+                        String render = runContext.render(stringValue);
 
                         if (render.startsWith("kestra://")) {
                             File tempFile = runContext.workingDir().createTempFile().toFile();
@@ -180,9 +180,9 @@ abstract public class AbstractHttp extends Task implements HttpInterface {
                         } else {
                             builder.addPart(key, render);
                         }
-                    } else if (e.getValue() instanceof Map && ((Map<String, String>) e.getValue()).containsKey("name") && ((Map<String, String>) e.getValue()).containsKey("content")) {
-                        String name = runContext.render(((Map<String, String>) e.getValue()).get("name"));
-                        String content = runContext.render(((Map<String, String>) e.getValue()).get("content"));
+                    } else if (e.getValue() instanceof Map mapValue && ((Map<String, String>) mapValue).containsKey("name") && ((Map<String, String>) mapValue).containsKey("content")) {
+                        String name = runContext.render(((Map<String, String>) mapValue).get("name"));
+                        String content = runContext.render(((Map<String, String>) mapValue).get("content"));
 
                         File tempFile = runContext.workingDir().createTempFile().toFile();
                         File renamedFile = new File(Files.move(tempFile.toPath(), tempFile.toPath().resolveSibling(name)).toUri());

--- a/core/src/main/java/io/kestra/plugin/core/log/Log.java
+++ b/core/src/main/java/io/kestra/plugin/core/log/Log.java
@@ -76,11 +76,11 @@ public class Log extends Task implements RunnableTask<VoidOutput> {
     public VoidOutput run(RunContext runContext) throws Exception {
         Logger logger = runContext.logger();
 
-        if(this.message instanceof String) {
-            String render = runContext.render((String) this.message);
+        if(this.message instanceof String stringValue) {
+            String render = runContext.render(stringValue);
             this.log(logger, this.level, render);
-        } else if (this.message instanceof Collection) {
-            Collection<String> messages = (Collection<String>) this.message;
+        } else if (this.message instanceof Collection<?> collectionValue) {
+            Collection<String> messages = (Collection<String>) collectionValue;
             messages.forEach(throwConsumer(message -> {
                 String render;
                 render = runContext.render(message);

--- a/core/src/main/java/io/kestra/plugin/core/namespace/UploadFiles.java
+++ b/core/src/main/java/io/kestra/plugin/core/namespace/UploadFiles.java
@@ -172,8 +172,8 @@ public class UploadFiles extends Task implements RunnableTask<UploadFiles.Output
 
         if (filesMap != null) {
             Map<String, Object> readFilesMap;
-            if (filesMap instanceof String) {
-                String renderedFilesMap = runContext.render((String) filesMap);
+            if (filesMap instanceof String stringValue) {
+                String renderedFilesMap = runContext.render(stringValue);
                 readFilesMap = JacksonMapper.ofJson().readValue(renderedFilesMap, Map.class);
             } else {
                 readFilesMap = (Map<String, Object>) filesMap;

--- a/core/src/main/java/io/kestra/plugin/core/storage/Concat.java
+++ b/core/src/main/java/io/kestra/plugin/core/storage/Concat.java
@@ -116,13 +116,13 @@ public class Concat extends Task implements RunnableTask<Concat.Output> {
         File tempFile = runContext.workingDir().createTempFile(extension).toFile();
         try (FileOutputStream fileOutputStream = new FileOutputStream(tempFile)) {
             List<String> finalFiles;
-            if (this.files instanceof List) {
-                finalFiles = (List<String>) this.files;
-            } else if (this.files instanceof String) {
+            if (this.files instanceof List<?> listValue) {
+                finalFiles = (List<String>) listValue;
+            } else if (this.files instanceof String stringValue) {
                 final TypeReference<List<String>> reference = new TypeReference<>() {};
 
                 finalFiles = JacksonMapper.ofJson(false).readValue(
-                    runContext.render((String) this.files),
+                    runContext.render(stringValue),
                     reference
                 );
             } else {

--- a/core/src/test/java/io/kestra/core/serializers/YamlParserTest.java
+++ b/core/src/test/java/io/kestra/core/serializers/YamlParserTest.java
@@ -127,7 +127,7 @@ class YamlParserTest {
         assertThat(flow.getInputs().stream().filter(Input::getRequired).count(), is(11L));
         assertThat(flow.getInputs().stream().filter(r -> !r.getRequired()).count(), is(18L));
         assertThat(flow.getInputs().stream().filter(r -> r.getDefaults() != null).count(), is(3L));
-        assertThat(flow.getInputs().stream().filter(r -> r instanceof StringInput && ((StringInput)r).getValidator() != null).count(), is(1L));
+        assertThat(flow.getInputs().stream().filter(r -> r instanceof StringInput stringInput && stringInput.getValidator() != null).count(), is(1L));
     }
 
 

--- a/jdbc/src/main/java/io/kestra/jdbc/repository/AbstractJdbcFlowRepository.java
+++ b/jdbc/src/main/java/io/kestra/jdbc/repository/AbstractJdbcFlowRepository.java
@@ -618,8 +618,8 @@ public abstract class AbstractJdbcFlowRepository extends AbstractJdbcRepository 
 
     @SneakyThrows
     private FlowWithSource save(Flow flow, CrudEventType crudEventType, String flowSource) throws ConstraintViolationException {
-        if (flow instanceof FlowWithSource) {
-            flow = ((FlowWithSource) flow).toFlow();
+        if (flow instanceof FlowWithSource flowWithSource) {
+            flow = flowWithSource.toFlow();
         }
 
         // flow exists, return it

--- a/script/src/main/java/io/kestra/plugin/scripts/runner/docker/DockerService.java
+++ b/script/src/main/java/io/kestra/plugin/scripts/runner/docker/DockerService.java
@@ -55,8 +55,8 @@ public class DockerService {
         Map<String, Object> finalConfig = new HashMap<>();
 
         if (config != null) {
-            if (config instanceof String) {
-                finalConfig = JacksonMapper.toMap(runContext.render(config.toString()));
+            if (config instanceof String configString) {
+                finalConfig = JacksonMapper.toMap(runContext.render(configString));
             } else {
                 finalConfig = runContext.render((Map<String, Object>) config);
             }

--- a/webserver/src/main/java/io/kestra/webserver/controllers/ErrorController.java
+++ b/webserver/src/main/java/io/kestra/webserver/controllers/ErrorController.java
@@ -41,10 +41,8 @@ public class ErrorController {
 
     @Error(global = true)
     public HttpResponse<JsonError> error(HttpRequest<?> request, ConversionErrorException e) {
-        if (e.getConversionError().getCause() instanceof InvalidTypeIdException) {
+        if (e.getConversionError().getCause() instanceof InvalidTypeIdException invalidTypeIdException) {
             try {
-                InvalidTypeIdException invalidTypeIdException = ((InvalidTypeIdException) e.getConversionError().getCause());
-
                 String path = path(invalidTypeIdException);
 
                 Field typeField = InvalidTypeIdException.class.getDeclaredField("_typeId");
@@ -66,10 +64,8 @@ public class ErrorController {
                 return jsonError(error, HttpStatus.UNPROCESSABLE_ENTITY, "Invalid entity");
             } catch (Exception ignored) {
             }
-        } else if (e.getConversionError().getCause() instanceof JsonMappingException) {
+        } else if (e.getConversionError().getCause() instanceof JsonMappingException jsonMappingException) {
             try {
-                JsonMappingException jsonMappingException = ((JsonMappingException) e.getConversionError().getCause());
-
                 String path = path(jsonMappingException);
 
                 JsonError error = new JsonError("Invalid json mapping")

--- a/webserver/src/main/java/io/kestra/webserver/controllers/api/KVController.java
+++ b/webserver/src/main/java/io/kestra/webserver/controllers/api/KVController.java
@@ -56,8 +56,8 @@ public class KVController {
             .getValue(key)
             .orElseThrow(() -> new NoSuchElementException("No value found for key '" + key + "' in namespace '" + namespace + "'"));
         Object value = wrapper.value();
-        if (value instanceof byte[]) {
-            value = new String((byte[]) value);
+        if (value instanceof byte[] bytesValue) {
+            value = new String(bytesValue);
         }
         return new TypedValue(KVType.from(value), value);
     }

--- a/webserver/src/main/java/io/kestra/webserver/controllers/api/TriggerController.java
+++ b/webserver/src/main/java/io/kestra/webserver/controllers/api/TriggerController.java
@@ -257,8 +257,8 @@ public class TriggerController {
                 ConditionContext conditionContext = conditionService.conditionContext(runContext, maybeFlow.get(), null);
                 // We must set up the backfill before the update to calculate the next execution date
                 updated = current.initBackfill(newTrigger);
-                if (abstractTrigger instanceof PollingTriggerInterface) {
-                    nextExecutionDate = ((PollingTriggerInterface) abstractTrigger).nextEvaluationDate(conditionContext, Optional.of(updated));
+                if (abstractTrigger instanceof PollingTriggerInterface pollingTriggerInterface) {
+                    nextExecutionDate = pollingTriggerInterface.nextEvaluationDate(conditionContext, Optional.of(updated));
                 }
                 updated = Trigger.update(current, newTrigger, nextExecutionDate);
             } catch (Exception e) {

--- a/webserver/src/test/java/io/kestra/webserver/controllers/api/ExecutionControllerTest.java
+++ b/webserver/src/test/java/io/kestra/webserver/controllers/api/ExecutionControllerTest.java
@@ -200,7 +200,7 @@ class ExecutionControllerTest extends JdbcH2ControllerTest {
     void invalidInputs() {
         MultipartBody.Builder builder = MultipartBody.builder()
             .addPart("validatedString", "B-failed");
-        inputs.forEach((s, o) -> builder.addPart(s, o instanceof String ? (String) o : null));
+        inputs.forEach((s, o) -> builder.addPart(s, o instanceof String str ? str : null));
 
         HttpClientResponseException e = assertThrows(
             HttpClientResponseException.class,


### PR DESCRIPTION
### What changes are being made and why?
The usage of instanceof has been standardized across the codebase.
This PR replaces traditional instanceof checks with pattern matching.
It improves code readability, removes redundant casts, and ensures consistent coding style.

---

### How the changes have been QAed?
The changes have been QAed by running all existing unit tests to ensure no regressions.
Example scenario:

``` java
Object input = "example";
if (input instanceof String str) {
    System.out.println("Length: " + str.length());
}
```

This scenario was verified in cases where instanceof with pattern matching is used to ensure compatibility.

---

### Setup Instructions
No special setup is required.

closes #6064 