### PR TITLE
fix: treat undefined boolean as undefined instead of false

### DIFF
--- a/ui/src/components/inputs/InputsForm.vue
+++ b/ui/src/components/inputs/InputsForm.vue
@@ -282,11 +282,9 @@
                         if (input.type === "MULTISELECT") {
                             this.multiSelectInputs[input.id] = input.defaults;
                         }
-
                         this.inputs[input.id] = Inputs.normalize(input.type, input.defaults);
                     }
                 }
-                console.log("updateDefaults", JSON.stringify(this.inputs))
             },
             onChange() {
                 this.$emit("update:modelValue", this.inputs);
@@ -371,7 +369,6 @@
                         }
                     },
                 } : undefined
-
             }
         },
         watch: {

--- a/ui/src/components/inputs/InputsForm.vue
+++ b/ui/src/components/inputs/InputsForm.vue
@@ -1,5 +1,6 @@
 <template>
     <template v-if="inputsList">
+        <pre>{{ inputErrors }}</pre>
         <el-form-item
             v-for="input in inputsList || []"
             :key="input.id"
@@ -8,6 +9,7 @@
             :prop="input.id"
             :error="inputError(input.id)"
             :inline-message="true"
+            :rules="input.type === 'BOOLEAN' ? [requiredBooleanRule(input.required)] : undefined"
         >
             <editor
                 :full-height="false"
@@ -99,7 +101,7 @@
             >
                 <el-radio-button :label="$t('true')" :value="true" />
                 <el-radio-button :label="$t('false')" :value="false" />
-                <el-radio-button :label="$t('undefined')" :value="'undefined'" />
+                <el-radio-button :label="$t('undefined')" value="undefined" />
             </el-radio-group>
             <el-date-picker
                 :data-test-id="`input-form-${input.id}`"
@@ -359,6 +361,17 @@
                         }
                     });
                 }
+            },
+            requiredBooleanRule(required) {
+                return required ? {
+                    validator(_, val){
+                        console.log("requiredBooleanRule", val)
+                        if( val !== "undefined"){
+                            throw new Error("This field is required");
+                        }
+                    },
+                } : undefined
+
             }
         },
         watch: {

--- a/ui/src/components/inputs/InputsForm.vue
+++ b/ui/src/components/inputs/InputsForm.vue
@@ -99,7 +99,7 @@
             >
                 <el-radio-button :label="$t('true')" :value="true" />
                 <el-radio-button :label="$t('false')" :value="false" />
-                <el-radio-button :label="$t('undefined')" :value="undefined" />
+                <el-radio-button :label="$t('undefined')" :value="'undefined'" />
             </el-radio-group>
             <el-date-picker
                 :data-test-id="`input-form-${input.id}`"

--- a/ui/src/components/inputs/InputsForm.vue
+++ b/ui/src/components/inputs/InputsForm.vue
@@ -1,6 +1,5 @@
 <template>
     <template v-if="inputsList">
-        <pre>{{ inputErrors }}</pre>
         <el-form-item
             v-for="input in inputsList || []"
             :key="input.id"
@@ -283,9 +282,11 @@
                         if (input.type === "MULTISELECT") {
                             this.multiSelectInputs[input.id] = input.defaults;
                         }
+
                         this.inputs[input.id] = Inputs.normalize(input.type, input.defaults);
                     }
                 }
+                console.log("updateDefaults", JSON.stringify(this.inputs))
             },
             onChange() {
                 this.$emit("update:modelValue", this.inputs);
@@ -363,10 +364,9 @@
                 }
             },
             requiredBooleanRule(required) {
-                return required ? {
+                return required !== false ? {
                     validator(_, val){
-                        console.log("requiredBooleanRule", val)
-                        if( val !== "undefined"){
+                        if(val === "undefined"){
                             throw new Error("This field is required");
                         }
                     },

--- a/ui/src/utils/inputs.js
+++ b/ui/src/utils/inputs.js
@@ -5,7 +5,9 @@ export default class Inputs {
     static normalize(type, value) {
         let res = value;
 
-        if (value === null || value === undefined) {
+        if (type === "BOOLEAN" && value === undefined){
+            res = "undefined";
+        } else if (value === null || value === undefined) {
             res = undefined;
         } else if (type === "DATE" || type === "DATETIME") {
             res = moment(res).toISOString()
@@ -19,8 +21,6 @@ export default class Inputs {
             if(typeof res !== "string") {
                 res = YamlUtils.stringify(res).toString();
             }
-        } else if (type === "BOOLEAN" && type === undefined){
-            res = "undefined";
         } else if (type === "STRING" && Array.isArray(res)){
             res = res.toString();
         }


### PR DESCRIPTION
closes https://github.com/kestra-io/kestra-ee/issues/2110

When a boolean is displayed, it now has a "default" value of `undefined` if it is not set by a user.