### PR TITLE
fix: inputs for apps and select with expressions

### DIFF
--- a/ui/src/components/Status.vue
+++ b/ui/src/components/Status.vue
@@ -1,5 +1,5 @@
 <template>
-    <el-button data-component="FILENAME_PLACEHOLDER" data-test-id="execution-status" @click="$emit('click', $event)" class="status" :size="size" :class="cls" :style="style">
+    <el-button data-component="FILENAME_PLACEHOLDER" data-test-id="execution-status" @click="$emit('click', $event)" class="status" :size="size" :style="style">
         <template v-if="label">
             {{ title || $filters.cap(status) }}
         </template>

--- a/ui/src/components/executions/ForceRun.vue
+++ b/ui/src/components/executions/ForceRun.vue
@@ -32,7 +32,7 @@
 </template>
 
 <script setup>
-    // import RunFast from "vue-material-design-icons/RunFast.vue";
+    import RunFast from "vue-material-design-icons/RunFast.vue";
 </script>
 
 <script>

--- a/ui/src/components/executions/ForceRun.vue
+++ b/ui/src/components/executions/ForceRun.vue
@@ -5,13 +5,14 @@
         transition=""
         :hide-after="0"
         :content="$t('force run tooltip')"
+        v-if="enabled"
         raw-content
     >
         <component
             :is="component"
             :icon="RunFast"
             @click="click"
-            v-if="enabled"
+
             class="ms-0 me-1"
         >
             {{ $t('force run') }}
@@ -31,7 +32,7 @@
 </template>
 
 <script setup>
-    import RunFast from "vue-material-design-icons/RunFast.vue";
+    // import RunFast from "vue-material-design-icons/RunFast.vue";
 </script>
 
 <script>

--- a/ui/src/components/executions/Overview.vue
+++ b/ui/src/components/executions/Overview.vue
@@ -34,8 +34,8 @@
             </el-col>
             <el-col :span="12" class="d-flex gap-2 justify-content-end">
                 <set-labels :execution="execution" />
-                <restart is-replay :execution="execution" class="ms-0" @follow="forwardEvent('follow', $event)" />
-                <restart :execution="execution" class="ms-0" @follow="forwardEvent('follow', $event)" />
+                <restart is-replay :execution="execution" @follow="forwardEvent('follow', $event)" />
+                <restart :execution="execution" @follow="forwardEvent('follow', $event)" />
                 <change-execution-status :execution="execution" @follow="forwardEvent('follow', $event)" />
                 <resume :execution="execution" />
                 <pause :execution="execution" />

--- a/ui/src/components/flows/TriggerFlow.vue
+++ b/ui/src/components/flows/TriggerFlow.vue
@@ -110,19 +110,26 @@
                         },
                         page: pageFromRoute(this.$router.currentRoute.value)
                     });
-                    this.isOpen = !this.isOpen;
+                    this.toggleModal()
                     return;
                 }
                 else if (this.checkForTrigger) {
-                    this.$toast().confirm(h(FlowWarningDialog), () => (this.isOpen = !this.isOpen), true, null);
+                    this.$toast().confirm(h(FlowWarningDialog), () => (this.toggleModal()), true, null);
                 }
                 else if (this.computedNamespace !== undefined && this.computedFlowId !== undefined) {
-                    this.isOpen = !this.isOpen;
+                    this.toggleModal()
                 }
                 else {
                     this.$store.dispatch("execution/loadNamespaces");
                     this.isSelectFlowOpen = !this.isSelectFlowOpen;
                 }
+            },
+            async toggleModal() {
+                if (!this.isOpen && this.flowId && this.namespace) {
+                    // wait for flow to be set before opening the dialog
+                    await this.loadDefinition();
+                }
+                this.isOpen = !this.isOpen;
             },
             closeModal() {
                 this.isOpen = false;
@@ -130,8 +137,8 @@
             isDisabled() {
                 return this.disabled || this.flow?.deleted;
             },
-            loadDefinition() {
-                this.$store.dispatch("execution/loadFlowForExecution", {
+            async loadDefinition() {
+                await this.$store.dispatch("execution/loadFlowForExecution", {
                     flowId: this.flowId,
                     namespace: this.namespace
                 });
@@ -214,13 +221,6 @@
                     this.$store.commit("execution/setFlow", this.localFlow);
                 },
                 immediate: true
-            },
-            isOpen: {
-                handler() {
-                    if (this.isOpen && this.flowId && this.namespace) {
-                        this.loadDefinition();
-                    }
-                }
             }
         }
     };

--- a/ui/src/components/inputs/InputsForm.vue
+++ b/ui/src/components/inputs/InputsForm.vue
@@ -204,7 +204,7 @@
             },
             inputErrors() {
                 // we only keep errors that don't target an input directly
-                const keepErrors = this.inputsMetaData.filter(it => it.inputId === undefined);
+                const keepErrors = this.inputsMetaData.filter(it => it.id === undefined);
 
                 return keepErrors.filter(it => it.errors && it.errors.length > 0).length > 0 ?
                     keepErrors.filter(it => it.errors && it.errors.length > 0).flatMap(it => it.errors?.flatMap(err => err.message)) :
@@ -306,7 +306,7 @@
 
                 const errors = this.inputsMetaData
                     .filter((it) => {
-                        return it.id === id && errors && errors.length > 0;
+                        return it.id === id && it.errors && it.errors.length > 0;
                     })
                     .map(it => it.errors.map(err => err.message).join("\n"))
 
@@ -378,6 +378,7 @@
                         if(it.enabled){
                             acc.push({...it.input, errors: it.errors});
                         }
+                        return acc;
                     }, [])
                     this.updateDefaults();
                 }

--- a/ui/src/components/inputs/InputsForm.vue
+++ b/ui/src/components/inputs/InputsForm.vue
@@ -254,25 +254,19 @@
             this.inputsMetaData = JSON.parse(JSON.stringify(this.initialInputs));
 
             this.validateInputs().then(() => {
-                // wait for vuex to set the flow or execution
-                // before watching for changes
-                setTimeout(() => {
-                    this.$watch("flow", this.validateInputs);
-                    this.$watch("execution", this.validateInputs);
-                    this.$watch("inputsValues", {
-                        handler(val) {
-                            // only revalidate if values have changed
-                            if(JSON.stringify(val) !== JSON.stringify(this.previousInputsValues)){
-                                // only revalidate if values are stable for more than 200ms
-                                // to avoid too many useless calls to the server
-                                debounce(this.validateInputs, 200)();
-                                this.$emit("update:modelValue", this.inputsValues);
-                            }
-                            this.previousInputsValues = JSON.parse(JSON.stringify(val))
-                        },
-                        deep: true
-                    });
-                }, 10)
+                this.$watch("inputsValues", {
+                    handler(val) {
+                        // only revalidate if values have changed
+                        if(JSON.stringify(val) !== JSON.stringify(this.previousInputsValues)){
+                            // only revalidate if values are stable for more than 200ms
+                            // to avoid too many useless calls to the server
+                            debounce(this.validateInputs, 200)();
+                            this.$emit("update:modelValue", this.inputsValues);
+                        }
+                        this.previousInputsValues = JSON.parse(JSON.stringify(val))
+                    },
+                    deep: true
+                });
             });
         },
         mounted() {
@@ -412,6 +406,15 @@
                         callback()
                     },
                 } : undefined
+            }
+        },
+        watch: {
+            flow () {
+                this.validateInputs();
+
+            },
+            execution () {
+                this.validateInputs();
             }
         }
     };

--- a/ui/src/components/inputs/InputsForm.vue
+++ b/ui/src/components/inputs/InputsForm.vue
@@ -258,9 +258,9 @@
                     handler(val) {
                         // only revalidate if values have changed
                         if(JSON.stringify(val) !== JSON.stringify(this.previousInputsValues)){
-                            // only revalidate if values are stable for more than 200ms
-                            // to avoid too many useless calls to the server
-                            debounce(this.validateInputs, 200)();
+                            // only revalidate if values are stable for more than 500ms
+                            // to avoid too many calls to the server
+                            debounce(this.validateInputs, 500)();
                             this.$emit("update:modelValue", this.inputsValues);
                         }
                         this.previousInputsValues = JSON.parse(JSON.stringify(val))
@@ -368,6 +368,7 @@
                 const formData = inputsToFormDate(this, this.inputsMetaData, this.inputsValues);
 
                 const metadataCallback = (response) => {
+                    console.log("metadataCallback", response.inputs);
                     this.inputsMetaData = response.inputs.reduce((acc,it) => {
                         if(it.enabled){
                             acc.push({...it.input, errors: it.errors});


### PR DESCRIPTION
closes https://github.com/kestra-io/kestra-ee/issues/2312

- When opening an execution form, retrieve flow before opening
- Results of the Validate API contains also field definitions and custom values so rollback the overuse of the initialInputs
- Make watchers simpler to find