### PR TITLE
Fix(Webserver) #6225 Added check in file creation path for _flows*

### DIFF
--- a/webserver/src/main/java/io/kestra/webserver/controllers/api/NamespaceFileController.java
+++ b/webserver/src/main/java/io/kestra/webserver/controllers/api/NamespaceFileController.java
@@ -186,7 +186,7 @@ public class NamespaceFileController {
         }
         String[] filePaths = filePath.split(DELIMITER_SLASH);
         if (filePaths.length != 0 && filePaths[0].startsWith(FLOWS_FOLDER)) {
-            if(filePaths.length != 3) {
+            if(filePaths.length != 2) {
                 throw new IllegalArgumentException("Invalid flow file path: " + filePath);
             }
 

--- a/webserver/src/main/java/io/kestra/webserver/controllers/api/NamespaceFileController.java
+++ b/webserver/src/main/java/io/kestra/webserver/controllers/api/NamespaceFileController.java
@@ -193,7 +193,10 @@ public class NamespaceFileController {
             this.importFlow(tenantId, flowSource);
             return;
         }
-
+        //Creation of file with name _flows*
+        if(filePath.matches(".*/" + FLOWS_FOLDER + "(?!/).*")) {
+            throw new IllegalArgumentException("Can't name file " + filePath + " because it contains the keyword _flows");
+        }
         storageInterface.put(tenantId, namespace, NamespaceFile.of(namespace, path).uri(), inputStream);
     }
 

--- a/webserver/src/main/java/io/kestra/webserver/controllers/api/NamespaceFileController.java
+++ b/webserver/src/main/java/io/kestra/webserver/controllers/api/NamespaceFileController.java
@@ -48,9 +48,7 @@ public class NamespaceFileController {
     @Inject
     private FlowService flowService;
 
-    private final List<Pattern> forbiddenPathPatterns = List.of(
-        Pattern.compile("/" + FLOWS_FOLDER + ".*")
-    );
+    private static final String DELIMITER_SLASH = "/";
 
 
     @ExecuteOn(TaskExecutors.IO)
@@ -183,8 +181,12 @@ public class NamespaceFileController {
 
     private void putNamespaceFile(String tenantId, String namespace, URI path, BufferedInputStream inputStream) throws IOException {
         String filePath = path.getPath();
-        if(filePath.matches("/" + FLOWS_FOLDER + "/.*")) {
-            if(filePath.split("/").length != 3) {
+        if (filePath.startsWith(DELIMITER_SLASH)) {
+            filePath = filePath.substring(1);
+        }
+        String[] filePaths = filePath.split(DELIMITER_SLASH);
+        if (filePaths.length != 0 && filePaths[0].startsWith(FLOWS_FOLDER)) {
+            if(filePaths.length != 3) {
                 throw new IllegalArgumentException("Invalid flow file path: " + filePath);
             }
 
@@ -192,10 +194,6 @@ public class NamespaceFileController {
             flowSource = flowSource.replaceFirst("(?m)^namespace: .*$", "namespace: " + namespace);
             this.importFlow(tenantId, flowSource);
             return;
-        }
-        //Creation of file with name _flows* check
-        if(filePath.matches(".*/" + FLOWS_FOLDER + "(?!/).*")) {
-            throw new IllegalArgumentException("Can't name file " + filePath + " because it contains the keyword _flows");
         }
         storageInterface.put(tenantId, namespace, NamespaceFile.of(namespace, path).uri(), inputStream);
     }
@@ -300,8 +298,15 @@ public class NamespaceFileController {
         if (path == null) {
             return;
         }
-
-        if (forbiddenPathPatterns.stream().anyMatch(pattern -> pattern.matcher(path.getPath()).matches())) {
+        String filePath = path.getPath();
+        if (filePath.startsWith(DELIMITER_SLASH)) {
+            filePath = filePath.substring(1);
+        }
+        String[] splitPath = filePath.split(DELIMITER_SLASH);
+        if(splitPath.length == 0) {
+            return;
+        }
+        if (splitPath[0].startsWith(FLOWS_FOLDER)) {
             throw new IllegalArgumentException("Forbidden path: " + path.getPath());
         }
     }

--- a/webserver/src/main/java/io/kestra/webserver/controllers/api/NamespaceFileController.java
+++ b/webserver/src/main/java/io/kestra/webserver/controllers/api/NamespaceFileController.java
@@ -258,9 +258,10 @@ public class NamespaceFileController {
         @Parameter(description = "The internal storage uri of the file / directory to delete") @QueryValue String path
     ) throws IOException, URISyntaxException {
         URI encodedPath = null;
-        if (path != null) {
-            encodedPath = new URI(URLEncoder.encode(path, StandardCharsets.UTF_8));
+        if (!path.startsWith("/")) {
+            path = "/" + path;
         }
+        encodedPath = new URI(URLEncoder.encode(path, StandardCharsets.UTF_8));
         ensureWritableNamespaceFile(encodedPath);
 
         String pathWithoutScheme = encodedPath.getPath();

--- a/webserver/src/main/java/io/kestra/webserver/controllers/api/NamespaceFileController.java
+++ b/webserver/src/main/java/io/kestra/webserver/controllers/api/NamespaceFileController.java
@@ -185,9 +185,9 @@ public class NamespaceFileController {
             filePath = filePath.substring(1);
         }
         String[] filePaths = filePath.split(DELIMITER_SLASH);
-        if (filePaths.length != 0 && filePaths[0].startsWith(FLOWS_FOLDER)) {
+        if (filePaths.length != 0 && filePaths[0].equals(FLOWS_FOLDER)) {
             if(filePaths.length != 2) {
-                throw new IllegalArgumentException("Invalid flow file path: " + filePath);
+                throw new IllegalArgumentException("Invalid flow file path: " + filePath +". To import a flow, the file path should follow this template: /" + FLOWS_FOLDER + "/{flowId}.yml");
             }
 
             String flowSource = new String(inputStream.readAllBytes());
@@ -306,7 +306,7 @@ public class NamespaceFileController {
         if(splitPath.length == 0) {
             return;
         }
-        if (splitPath[0].startsWith(FLOWS_FOLDER)) {
+        if (splitPath[0].equals(FLOWS_FOLDER)) {
             throw new IllegalArgumentException("Forbidden path: " + path.getPath());
         }
     }

--- a/webserver/src/main/java/io/kestra/webserver/controllers/api/NamespaceFileController.java
+++ b/webserver/src/main/java/io/kestra/webserver/controllers/api/NamespaceFileController.java
@@ -193,7 +193,7 @@ public class NamespaceFileController {
             this.importFlow(tenantId, flowSource);
             return;
         }
-        //Creation of file with name _flows*
+        //Creation of file with name _flows* check
         if(filePath.matches(".*/" + FLOWS_FOLDER + "(?!/).*")) {
             throw new IllegalArgumentException("Can't name file " + filePath + " because it contains the keyword _flows");
         }

--- a/webserver/src/test/java/io/kestra/webserver/controllers/api/NamespaceFileControllerTest.java
+++ b/webserver/src/test/java/io/kestra/webserver/controllers/api/NamespaceFileControllerTest.java
@@ -151,15 +151,15 @@ class NamespaceFileControllerTest {
         MultipartBody body = MultipartBody.builder()
             .addPart("fileContent", "_flows", "Hello".getBytes())
             .build();
-        assertThrows(IllegalArgumentException.class, () -> client.toBlocking().exchange(
+        assertThrows(HttpClientResponseException.class, () -> client.toBlocking().exchange(
             HttpRequest.POST("/api/v1/namespaces/" + NAMESPACE + "/files?path=/_flows", body)
                 .contentType(MediaType.MULTIPART_FORM_DATA_TYPE)
         ));
-        assertThrows(IllegalArgumentException.class, () -> client.toBlocking().exchange(
+        assertThrows(HttpClientResponseException.class, () -> client.toBlocking().exchange(
             HttpRequest.POST("/api/v1/namespaces/" + NAMESPACE + "/files?path=/_flows2", body)
                 .contentType(MediaType.MULTIPART_FORM_DATA_TYPE)
         ));
-        assertThrows(IllegalArgumentException.class, () -> client.toBlocking().exchange(
+        assertThrows(HttpClientResponseException.class, () -> client.toBlocking().exchange(
             HttpRequest.POST("/api/v1/namespaces/" + NAMESPACE + "/files?path=/abc/_flows2/_flows", body)
                 .contentType(MediaType.MULTIPART_FORM_DATA_TYPE)
         ));

--- a/webserver/src/test/java/io/kestra/webserver/controllers/api/NamespaceFileControllerTest.java
+++ b/webserver/src/test/java/io/kestra/webserver/controllers/api/NamespaceFileControllerTest.java
@@ -129,9 +129,13 @@ class NamespaceFileControllerTest {
     @Test
     void createDirectory() throws IOException {
         client.toBlocking().exchange(HttpRequest.POST("/api/v1/namespaces/" + NAMESPACE + "/files/directory?path=/test", null));
+        client.toBlocking().exchange(HttpRequest.POST("/api/v1/namespaces/" + NAMESPACE + "/files/directory?path=/_flows2", null));
         FileAttributes res = storageInterface.getAttributes(null, NAMESPACE, toNamespacedStorageUri(NAMESPACE, URI.create("/test")));
         assertThat(res.getFileName(), is("test"));
         assertThat(res.getType(), is(FileAttributes.FileType.Directory));
+        FileAttributes flows = storageInterface.getAttributes(null, NAMESPACE, toNamespacedStorageUri(NAMESPACE, URI.create("/_flows2")));
+        assertThat(flows.getFileName(), is("_flows2"));
+        assertThat(flows.getType(), is(FileAttributes.FileType.Directory));
     }
 
     @Test
@@ -145,15 +149,6 @@ class NamespaceFileControllerTest {
                     HttpRequest.POST(
                         "/api/v1/namespaces/" + NAMESPACE + "/files/directory?path=/_flows",
                         null)));
-    assertThrows(
-        HttpClientResponseException.class,
-        () ->
-            client
-                .toBlocking()
-                .exchange(
-                    HttpRequest.POST(
-                        "/api/v1/namespaces/" + NAMESPACE + "/files/directory?path=/_flows2",
-                        null)));
     }
 
     @Test
@@ -166,6 +161,14 @@ class NamespaceFileControllerTest {
                 .contentType(MediaType.MULTIPART_FORM_DATA_TYPE)
         );
         assertNamespaceFileContent(URI.create("/test.txt"), "Hello");
+        MultipartBody flowBody = MultipartBody.builder()
+            .addPart("fileContent", "_flowsFile", "Hello".getBytes())
+            .build();
+        client.toBlocking().exchange(
+            HttpRequest.POST("/api/v1/namespaces/" + NAMESPACE + "/files?path=/_flowsFile", flowBody)
+                .contentType(MediaType.MULTIPART_FORM_DATA_TYPE)
+        );
+        assertNamespaceFileContent(URI.create("/_flowsFile"), "Hello");
     }
 
     @Test
@@ -175,13 +178,6 @@ class NamespaceFileControllerTest {
             .build();
         assertThrows(HttpClientResponseException.class, () -> client.toBlocking().exchange(
             HttpRequest.POST("/api/v1/namespaces/" + NAMESPACE + "/files?path=/_flows", body)
-                .contentType(MediaType.MULTIPART_FORM_DATA_TYPE)
-        ));
-        MultipartBody body2 = MultipartBody.builder()
-            .addPart("fileContent", "_flows2", "Hello".getBytes())
-            .build();
-        assertThrows(HttpClientResponseException.class, () -> client.toBlocking().exchange(
-            HttpRequest.POST("/api/v1/namespaces/" + NAMESPACE + "/files?path=/_flows2", body2)
                 .contentType(MediaType.MULTIPART_FORM_DATA_TYPE)
         ));
     }

--- a/webserver/src/test/java/io/kestra/webserver/controllers/api/NamespaceFileControllerTest.java
+++ b/webserver/src/test/java/io/kestra/webserver/controllers/api/NamespaceFileControllerTest.java
@@ -4,6 +4,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.startsWith;
 import static org.hamcrest.core.Is.is;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import io.kestra.core.junit.annotations.KestraTest;
 import io.kestra.core.junit.annotations.LoadFlows;
@@ -143,6 +144,25 @@ class NamespaceFileControllerTest {
                 .contentType(MediaType.MULTIPART_FORM_DATA_TYPE)
         );
         assertNamespaceFileContent(URI.create("/test.txt"), "Hello");
+    }
+
+    @Test
+    void createFileFlowException() {
+        MultipartBody body = MultipartBody.builder()
+            .addPart("fileContent", "_flows", "Hello".getBytes())
+            .build();
+        assertThrows(IllegalArgumentException.class, () -> client.toBlocking().exchange(
+            HttpRequest.POST("/api/v1/namespaces/" + NAMESPACE + "/files?path=/_flows", body)
+                .contentType(MediaType.MULTIPART_FORM_DATA_TYPE)
+        ));
+        assertThrows(IllegalArgumentException.class, () -> client.toBlocking().exchange(
+            HttpRequest.POST("/api/v1/namespaces/" + NAMESPACE + "/files?path=/_flows2", body)
+                .contentType(MediaType.MULTIPART_FORM_DATA_TYPE)
+        ));
+        assertThrows(IllegalArgumentException.class, () -> client.toBlocking().exchange(
+            HttpRequest.POST("/api/v1/namespaces/" + NAMESPACE + "/files?path=/abc/_flows2/_flows", body)
+                .contentType(MediaType.MULTIPART_FORM_DATA_TYPE)
+        ));
     }
 
     @Test

--- a/webserver/src/test/java/io/kestra/webserver/controllers/api/NamespaceFileControllerTest.java
+++ b/webserver/src/test/java/io/kestra/webserver/controllers/api/NamespaceFileControllerTest.java
@@ -135,6 +135,28 @@ class NamespaceFileControllerTest {
     }
 
     @Test
+    void createDirectoryException() {
+    assertThrows(
+        HttpClientResponseException.class,
+        () ->
+            client
+                .toBlocking()
+                .exchange(
+                    HttpRequest.POST(
+                        "/api/v1/namespaces/" + NAMESPACE + "/files/directory?path=/_flows",
+                        null)));
+    assertThrows(
+        HttpClientResponseException.class,
+        () ->
+            client
+                .toBlocking()
+                .exchange(
+                    HttpRequest.POST(
+                        "/api/v1/namespaces/" + NAMESPACE + "/files/directory?path=/_flows2",
+                        null)));
+    }
+
+    @Test
     void createFile() throws IOException {
         MultipartBody body = MultipartBody.builder()
             .addPart("fileContent", "test.txt", "Hello".getBytes())
@@ -155,12 +177,11 @@ class NamespaceFileControllerTest {
             HttpRequest.POST("/api/v1/namespaces/" + NAMESPACE + "/files?path=/_flows", body)
                 .contentType(MediaType.MULTIPART_FORM_DATA_TYPE)
         ));
+        MultipartBody body2 = MultipartBody.builder()
+            .addPart("fileContent", "_flows2", "Hello".getBytes())
+            .build();
         assertThrows(HttpClientResponseException.class, () -> client.toBlocking().exchange(
-            HttpRequest.POST("/api/v1/namespaces/" + NAMESPACE + "/files?path=/_flows2", body)
-                .contentType(MediaType.MULTIPART_FORM_DATA_TYPE)
-        ));
-        assertThrows(HttpClientResponseException.class, () -> client.toBlocking().exchange(
-            HttpRequest.POST("/api/v1/namespaces/" + NAMESPACE + "/files?path=/abc/_flows2/_flows", body)
+            HttpRequest.POST("/api/v1/namespaces/" + NAMESPACE + "/files?path=/_flows2", body2)
                 .contentType(MediaType.MULTIPART_FORM_DATA_TYPE)
         ));
     }


### PR DESCRIPTION
### What changes are being made and why?

Kestra allows the creation of files and directories with names starting with _flows*, despite the system's default restrictions intended to prevent such creations. Additionally, it fails to block the creation of folders starting with _flows*. 

### How the changes have been QAed?

I manually tested these examples:
Invalid Files and directories test cases:
![image](https://github.com/user-attachments/assets/b1503260-29ef-4c5c-ba7a-0f52bcd251b3)
![image](https://github.com/user-attachments/assets/feff7c5c-a41a-4a1a-8d76-a544dee99707)
![image](https://github.com/user-attachments/assets/2ffbf17a-45d3-4cf3-be18-4aa1bf7ce19c)

Subfolder _flows* check:
![image](https://github.com/user-attachments/assets/0d3b3d35-f114-4ad9-b592-754146779d31)

Positive Test case
![image](https://github.com/user-attachments/assets/0f942bf5-ee93-452f-a709-65bacc2ab547)

Note that this is not a replacement for unit tests but rather a way to demonstrate how the changes work in a real-life scenario, as the end-user would experience them.


closes #6225