### PR TITLE
fix(core): Fix Pause property annotation, exclude Input subtypes from definitions

### DIFF
--- a/core/src/main/java/io/kestra/core/docs/AbstractClassDocumentation.java
+++ b/core/src/main/java/io/kestra/core/docs/AbstractClassDocumentation.java
@@ -54,8 +54,8 @@ public abstract class AbstractClassDocumentation<T> {
             // Remove the Task entry as it only contains a reference that is filtered in the doc template,
             // which prevent the Definitions section to be empty if no other def exist.
             .filter(entry -> !entry.getKey().equals("io.kestra.core.models.tasks.Task"))
-            // Remove definitions of all Input subtypes
-            .filter(entry -> !entry.getKey().startsWith("io.kestra.core.models.flows.input."))
+            // Remove definitions of all Input subtypes if base class is null
+            .filter(entry -> (baseCls == null) || !entry.getKey().startsWith("io.kestra.core.models.flows.input."))
             .map(entry -> {
                 Map<String, Object> value = (Map<String, Object>) entry.getValue();
                 value.put("properties", flatten(properties(value), required(value), isTypeToKeep(entry.getKey())));

--- a/core/src/main/java/io/kestra/core/docs/AbstractClassDocumentation.java
+++ b/core/src/main/java/io/kestra/core/docs/AbstractClassDocumentation.java
@@ -54,6 +54,8 @@ public abstract class AbstractClassDocumentation<T> {
             // Remove the Task entry as it only contains a reference that is filtered in the doc template,
             // which prevent the Definitions section to be empty if no other def exist.
             .filter(entry -> !entry.getKey().equals("io.kestra.core.models.tasks.Task"))
+            // Remove definitions of all Input subtypes
+            .filter(entry -> !entry.getKey().startsWith("io.kestra.core.models.flows.input."))
             .map(entry -> {
                 Map<String, Object> value = (Map<String, Object>) entry.getValue();
                 value.put("properties", flatten(properties(value), required(value), isTypeToKeep(entry.getKey())));

--- a/core/src/main/java/io/kestra/plugin/core/flow/Pause.java
+++ b/core/src/main/java/io/kestra/plugin/core/flow/Pause.java
@@ -134,13 +134,15 @@ import java.util.stream.Stream;
 public class Pause extends Task implements FlowableTask<Pause.Output> {
     @Schema(
         title = "Duration of the pause — useful if you want to pause the execution for a fixed amount of time.",
-        description = "The delay is a string in the [ISO 8601 Duration](https://en.wikipedia.org/wiki/ISO_8601#Durations) format, e.g. `PT1H` for 1 hour, `PT30M` for 30 minutes, `PT10S` for 10 seconds, `P1D` for 1 day, etc. If no delay and no timeout are configured, the execution will never end until it's manually resumed from the UI or API."
+        description = "The delay is a string in the [ISO 8601 Duration](https://en.wikipedia.org/wiki/ISO_8601#Durations) format, e.g. `PT1H` for 1 hour, `PT30M` for 30 minutes, `PT10S` for 10 seconds, `P1D` for 1 day, etc. If no delay and no timeout are configured, the execution will never end until it's manually resumed from the UI or API.",
+        implementation = Duration.class
     )
     private Property<Duration> delay;
 
     @Schema(
         title = "Timeout of the pause — useful to avoid never-ending workflows in a human-in-the-loop scenario. For example, if you want to pause the execution until a human validates some data generated in a previous task, you can set a timeout of e.g. 24 hours. If no manual approval happens within 24 hours, the execution will automatically resume without a prior data validation.",
-        description = "If no delay and no timeout are configured, the execution will never end until it's manually resumed from the UI or API."
+        description = "If no delay and no timeout are configured, the execution will never end until it's manually resumed from the UI or API.",
+        implementation = Duration.class
     )
     private Property<Duration> timeout;
 


### PR DESCRIPTION
<!-- Thanks for submitting a Pull Request to Kestra. To help us review your contribution, please follow the guidelines below:

- Make sure that your commits follow the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) specification e.g. `feat(ui): add a new navigation menu item` or `fix(core): fix a bug in the core model` or `docs: update the README.md`. This will help us automatically generate the changelog.
- The title should briefly summarize the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share a flow example to help the reviewer understand and QA the change.
- Use "closes" to automatically close an issue. For example, `closes #1234` will close issue #1234. -->
### What changes are being made and why?
- closes #5538 
- Several properties in Pause task have unrecognizable type and causing difficulties/confusion when trying to fill the values through the UI
- Pause task documentation contains long definitions of Input subtypes. This PR will exclude all Input subtypes in the definitions

---

### How the changes have been QAed?
- Tested locally
Documentation
![image](https://github.com/user-attachments/assets/7d98025d-ecef-457d-90c5-40b5ebc2da8d)

Form
![image](https://github.com/user-attachments/assets/05bc6f42-5b55-4d3d-959a-41e9022b6406)


<!-- Include example code that shows how this PR has been QAed. The code should present a complete yet easily reproducible flow.

```yaml
# Your example flow code here
```

Note that this is not a replacement for unit tests but rather a way to demonstrate how the changes work in a real-life scenario, as the end-user would experience them.

Remove this section if this change applies to all flows or to the documentation only. -->

---
