### PR TITLE
fix(webserver): automatically handle trailing slash in delete endpoin…

### DIFF
--- a/webserver/src/main/java/io/kestra/webserver/controllers/api/NamespaceFileController.java
+++ b/webserver/src/main/java/io/kestra/webserver/controllers/api/NamespaceFileController.java
@@ -258,9 +258,11 @@ public class NamespaceFileController {
         @Parameter(description = "The internal storage uri of the file / directory to delete") @QueryValue String path
     ) throws IOException, URISyntaxException {
         URI encodedPath = null;
-        if (path != null) {
-            encodedPath = new URI(URLEncoder.encode(path, StandardCharsets.UTF_8));
+        if (!path.startsWith("/")) {
+            path = "/" + path;
         }
+        encodedPath = new URI(URLEncoder.encode(path, StandardCharsets.UTF_8));
+
         ensureWritableNamespaceFile(encodedPath);
 
         String pathWithoutScheme = encodedPath.getPath();


### PR DESCRIPTION
…t for namespace files

close #6118