### PR TITLE
fix(core, webserver): properly close the queue on Flux.onFinally

### DIFF
--- a/core/src/main/java/io/kestra/core/services/ExecutionLogService.java
+++ b/core/src/main/java/io/kestra/core/services/ExecutionLogService.java
@@ -61,12 +61,7 @@ public class ExecutionLogService {
                     }
                 }));
             }, FluxSink.OverflowStrategy.BUFFER)
-            .doOnCancel(() -> {
-                if (disposable.get() != null) {
-                    disposable.get().run();
-                }
-            })
-            .doOnComplete(() -> {
+            .doFinally(ignored -> {
                 if (disposable.get() != null) {
                     disposable.get().run();
                 }


### PR DESCRIPTION
Two fixes:
- close the queue onFinally and not onComplete and onCancel to take into accunt errors.
- close the queue onFinally in the execution creation as now it is only done on the success path and not even via a Flux lifecycle method

This may fix or improve some incosistent behavior reported by users on the webserver.
