### PR TITLE
fix(core): copy the list to avoid concurrent modification exception i…

### DIFF
--- a/core/src/test/java/io/kestra/core/runners/WorkerTest.java
+++ b/core/src/test/java/io/kestra/core/runners/WorkerTest.java
@@ -166,7 +166,11 @@ class WorkerTest {
         executionKilledQueue.emit(ExecutionKilledExecution.builder().executionId(workerTask.getTaskRun().getExecutionId()).build());
 
         Await.until(
-            () -> workerTaskResult.stream().filter(r -> r.getTaskRun().getState().isTerminated()).count() == 5,
+            () -> {
+                // copy the list to avoid concurrent modification exception if a WorkerTaskResult arrives in the queue
+                var copy = new ArrayList<>(workerTaskResult);
+                return copy.stream().filter(r -> r.getTaskRun().getState().isTerminated()).count() == 5;
+            },
             Duration.ofMillis(100),
             Duration.ofMinutes(1)
         );


### PR DESCRIPTION
…n count

This would avoid this test failure: https://github.com/kestra-io/kestra/pull/6264/checks?check_run_id=33916950881