### PR TITLE
chore(ui): default outline remove for Editor. minor fix  Related to ISSUE - 6182

### DIFF
--- a/ui/src/components/inputs/Editor.vue
+++ b/ui/src/components/inputs/Editor.vue
@@ -524,6 +524,7 @@
 
     .custom-dark-vs-theme {
         .monaco-editor, .monaco-editor-background {
+            outline: none;
             background-color: $input-bg;
             --vscode-editor-background: $input-bg;
             --vscode-breadcrumb-background: $input-bg;


### PR DESCRIPTION
**Related to fix for Issue #6182** 

After adding Padding, introduced visibility of outline. 

**Was not looking good**
![image](https://github.com/user-attachments/assets/f4256fea-624e-413c-af80-ef923884811d)
![image](https://github.com/user-attachments/assets/da8d1664-acf5-4eec-beda-e694f52f3324)


**Now it looks good**
![image](https://github.com/user-attachments/assets/009691c0-5b2b-4a50-989c-583e9f6a149e)
![image](https://github.com/user-attachments/assets/d0a4c1e5-8857-43c7-9626-df2d60102328)
