### PR TITLE
chore(ui): upgrade to Node 22 LTS

### DIFF
--- a/ui/build.gradle
+++ b/ui/build.gradle
@@ -7,7 +7,7 @@ plugins {
 publishSonatypePublicationPublicationToSonatypeRepository.enabled = false
 
 frontend {
-    nodeVersion = '18.18.0'
+    nodeVersion = '22.12.0'
     installScript = 'install'
     assembleScript = 'run build'
     checkScript = 'run test:unit'

--- a/ui/package.json
+++ b/ui/package.json
@@ -3,7 +3,7 @@
   "version": "0.20.0",
   "private": true,
   "type": "module",
-  "packageManager": "npm@9.9.3",
+  "packageManager": "npm@10.9.0",
   "scripts": {
     "dev": "vite --host",
     "build": "vite build --emptyOutDir",


### PR DESCRIPTION
### What changes are being made and why?

Node 22 entered to LTS in October.

At my machine build times are 10-15% shorter compared to Node 18.

---

### How the changes have been QAed?

```bash
 ./gradlew executableJar
```