### PR TITLE
chore(build): increase Gradle memory limits

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -197,7 +197,8 @@ subprojects {
         test {
             useJUnitPlatform()
 
-            maxHeapSize = "4048m"
+            // set Xmx for test workers
+            maxHeapSize = '4g'
 
             // configure en_US default locale for tests
             systemProperty 'user.language', 'en'

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,6 @@
 version=0.21.0-SNAPSHOT
 
+org.gradle.jvmargs=-Xmx2g -XX:MaxMetaspaceSize=512m -XX:+HeapDumpOnOutOfMemoryError
 org.gradle.parallel=true
 org.gradle.caching=true
 org.gradle.priority=low


### PR DESCRIPTION
### What changes are being made and why?

By default the daemon is limited to 512MiB heap. Increasing that to 2GiB shaved around 10sec off the full build.