### PR TITLE
feat(ui):Change arrow and colors tasks on Executions logs tab.

### DIFF
--- a/ui/src/components/executions/TaskRunLine.vue
+++ b/ui/src/components/executions/TaskRunLine.vue
@@ -1,5 +1,17 @@
 <template>
     <div class="attempt-header">
+        <div>
+            <el-icon
+                v-if="!taskRunId && shouldDisplayChevron(currentTaskRun)"
+                type="default"
+                @click.stop="() => forwardEvent('toggleShowAttempt',(attemptUid(currentTaskRun.id, selectedAttemptNumberByTaskRunId[currentTaskRun.id])))"
+            >
+                <ChevronDown
+                    v-if="shownAttemptsUid.includes(attemptUid(currentTaskRun.id, selectedAttemptNumberByTaskRunId[currentTaskRun.id]))"
+                />
+                <ChevronRight v-else />
+            </el-icon>
+        </div>
         <div class="task-icon d-none d-md-inline-block me-1">
             <task-icon
                 :cls="taskType(currentTaskRun)"
@@ -124,25 +136,11 @@
                 </el-dropdown-menu>
             </template>
         </el-dropdown>
-
-        <div>
-            <el-button
-                v-if="!taskRunId && shouldDisplayChevron(currentTaskRun)"
-                class="task-run-buttons"
-                type="default"
-                @click.stop="() => forwardEvent('toggleShowAttempt',(attemptUid(currentTaskRun.id, selectedAttemptNumberByTaskRunId[currentTaskRun.id])))"
-            >
-                <ChevronUp
-                    v-if="shownAttemptsUid.includes(attemptUid(currentTaskRun.id, selectedAttemptNumberByTaskRunId[currentTaskRun.id]))"
-                />
-                <ChevronDown v-else />
-            </el-button>
-        </div>
     </div>
 </template>
 <script>
     import Restart from "./Restart.vue";
-    import ChevronUp from "vue-material-design-icons/ChevronUp.vue";
+    import ChevronRight from "vue-material-design-icons/ChevronRight.vue";
     import Metrics from "./Metrics.vue";
     import Status from "../Status.vue";
     import ChangeStatus from "./ChangeStatus.vue";
@@ -177,7 +175,7 @@
             ChangeStatus,
             Status,
             Metrics,
-            ChevronUp,
+            ChevronRight,
             Restart,
             Duration
         },
@@ -354,7 +352,8 @@
             text-overflow: ellipsis;
 
             span span {
-                color: var(--bs-tertiary-color);
+                color: var(--el-text-color-regular);
+                font-size: 14px;
 
                 html:not(.dark) & {
                     color: $black;
@@ -366,6 +365,7 @@
             width: 36px;
             padding: 6px;
             border-radius: $border-radius-lg;
+            background-color: var(--bs-white);
         }
 
         small {
@@ -383,7 +383,7 @@
             padding: .5rem;
             height: 100%;
             border: 1px solid rgba($white, .05);
-            background-color: var(--bs-gray-400) !important;
+            background-color: var(--el-button-bg-color) !important;
             &:not(:hover) {
                 background: rgba($white, .10);
             }

--- a/ui/src/components/executions/TaskRunLine.vue
+++ b/ui/src/components/executions/TaskRunLine.vue
@@ -365,7 +365,6 @@
             width: 36px;
             padding: 6px;
             border-radius: $border-radius-lg;
-            background-color: var(--bs-white);
         }
 
         small {

--- a/ui/src/components/logs/LogLine.vue
+++ b/ui/src/components/logs/LogLine.vue
@@ -1,5 +1,8 @@
 <template>
     <div class="py-2 line font-monospace" :class="{['log-border-' + log.level.toLowerCase()]: cursor && log.level !== undefined}" v-if="filtered">
+        <el-icon v-if="cursor" class="icon_container" :style="{color: iconColor}" :size="25">
+            <MenuRight />
+        </el-icon>
         <span :class="levelClasses" class="border header-badge log-level el-tag noselect">{{ log.level }}</span>
         <div class="log-content d-inline-block">
             <span v-if="title" class="fw-bold">{{ (log.taskId ?? log.flowId ?? "") }}</span>
@@ -31,12 +34,15 @@
     import xss from "xss";
     import Markdown from "../../utils/markdown";
     import VRuntimeTemplate from "vue3-runtime-template";
+    import MenuRight from "vue-material-design-icons/MenuRight.vue";
+
 
     let convert = new Convert();
 
     export default {
         components:{
-            VRuntimeTemplate
+            VRuntimeTemplate,
+            MenuRight
         },
         props: {
             cursor: {
@@ -127,6 +133,10 @@
                     )
                 );
             },
+            iconColor() {
+                const logLevel = this.log.level?.toLowerCase();
+                return `var(--log-content-${logLevel}) !important`; // Use CSS variable for icon color
+            },
             message() {
                 let logMessage = !this.log.message ? "" : convert.toHtml(xss(this.log.message, {
                     allowList: {"span": ["style"]}
@@ -159,14 +169,17 @@
         white-space: pre-wrap;
         word-break: break-all;
         display: flex;
-        align-items: baseline;
+        align-items: center;
         gap: $spacer;
 
         border-left-width: 2px !important;
         border-left-style: solid;
         border-left-color: transparent;
 
-
+        .icon_container{
+            margin-left: -0.90rem;
+        }
+        
         .log-level {
             padding: calc(var(--spacer) / 4);
         }


### PR DESCRIPTION
Closes #6347

Please ignore the icon not showing it's just take time to load.
![image](https://github.com/user-attachments/assets/c99b8459-1b82-45a3-ada3-d9061e99ec52)
![image](https://github.com/user-attachments/assets/294de3a0-ddf4-458a-b18b-e443dee862a3)

Hey @MilosPaunovic 

I would require your guidance to change the color of icon like `csv` `log` to black on white bg.
I guess for icons this area requires some modification but I am not sure what need to be changed here because it's not a direct `svg`. it's using a Data URI to encodes the SVG content in Base64. I don't want to mess it globally.
![image](https://github.com/user-attachments/assets/2109d291-90b8-43b3-96a4-59614aef6d51)
