### PR TITLE
feat(ui): Make filters expand fully if we omit some of the non required buttons

### DIFF
--- a/ui/src/components/filter/KestraFilter.vue
+++ b/ui/src/components/filter/KestraFilter.vue
@@ -1,5 +1,5 @@
 <template>
-    <section :class="['d-inline-flex mb-3 filters', {'is-focused': isFocused}]">
+    <section :class="['d-inline-flex mb-3 filters', {focused: isFocused}]">
         <History :prefix @search="handleHistoryItems" />
 
         <el-select
@@ -97,7 +97,6 @@
 
 <script setup lang="ts">
     import {ref, computed} from "vue";
-    const isFocused = ref(false);
     import {ElSelect} from "element-plus";
 
     import {useI18n} from "vue-i18n";
@@ -195,13 +194,9 @@
         }
     };
 
-    const handleFocus = () => {
-        isFocused.value = true; // Set focus state to true
-    };
-
-    const handleBlur = () => {
-        isFocused.value = false; // Set focus state to false
-    };
+    const isFocused = ref(false);
+    const handleFocus = () => (isFocused.value = true);
+    const handleBlur = () => (isFocused.value = false);
 
     const filterCallback = (option) => {
         if (!option.value) {
@@ -499,9 +494,9 @@
     align-items: center;
     justify-content: space-between;
 
-    &.is-focused {
+    &.focused {
         border-radius: 5px;
-        border: solid 1.5px #8405FF;
+        border: solid 1.5px #8405ff;
         transition: border-color 0.5s;
     }
 
@@ -520,7 +515,7 @@
 
     .el-select__wrapper {
         border-radius: 0;
-        box-shadow: 
+        box-shadow:
             0 -1px 0 0 var(--el-border-color) inset,
             0 1px 0 0 var(--el-border-color) inset;
 

--- a/ui/src/components/filter/KestraFilter.vue
+++ b/ui/src/components/filter/KestraFilter.vue
@@ -1,5 +1,5 @@
 <template>
-    <section class="d-inline-flex pb-3 filters">
+    <section :class="['d-inline-flex mb-3 filters', {'is-focused': isFocused}]">
         <History :prefix @search="handleHistoryItems" />
 
         <el-select
@@ -20,6 +20,8 @@
             @keyup.enter="() => handleEnterKey(select?.hoverOption?.value)"
             @remove-tag="(item) => removeItem(item)"
             @visible-change="(visible) => dropdownClosedCallback(visible)"
+            @focus="handleFocus"
+            @blur="handleBlur"
         >
             <template #label="{value}">
                 <Label :option="value" />
@@ -95,6 +97,7 @@
 
 <script setup lang="ts">
     import {ref, computed} from "vue";
+    const isFocused = ref(false);
     import {ElSelect} from "element-plus";
 
     import {useI18n} from "vue-i18n";
@@ -190,6 +193,14 @@
         } else if (dropdowns.value.third.shown) {
             valueCallback(option);
         }
+    };
+
+    const handleFocus = () => {
+        isFocused.value = true; // Set focus state to true
+    };
+
+    const handleBlur = () => {
+        isFocused.value = false; // Set focus state to false
     };
 
     const filterCallback = (option) => {
@@ -479,55 +490,60 @@
 @mixin width-available {
     width: -moz-available;
     width: -webkit-fill-available;
-    // https://caniuse.com/?search=fill-available
     width: fill-available;
 }
 
 .filters {
     @include width-available;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
 
-    & .el-select {
-        max-width: calc(100% - 237px);
+    &.is-focused {
+        border-radius: 5px;
+        border: solid 1.5px #8405FF;
+        transition: border-color 0.5s;
+    }
 
-        &.settings {
-            max-width: calc(100% - 285px);
-        }
+    .el-select {
+        flex-grow: 1;
 
+        &.settings,
         &:not(.refresh) {
-            max-width: calc(100% - 189px);
+            max-width: 100%;
         }
     }
 
-    & .el-select__placeholder {
+    .el-select__placeholder {
         color: var(--bs-gray-700);
     }
 
-    & .el-select__wrapper {
+    .el-select__wrapper {
         border-radius: 0;
-        box-shadow:
+        box-shadow: 
             0 -1px 0 0 var(--el-border-color) inset,
             0 1px 0 0 var(--el-border-color) inset;
 
-        & .el-tag {
+        .el-tag {
             background: var(--bs-border-color) !important;
             color: var(--bs-gray-900);
 
-            & .el-tag__close {
+            .el-tag__close {
                 color: var(--bs-gray-900);
             }
         }
     }
 
-    & .el-select__selection {
+    .el-select__selection {
         flex-wrap: nowrap;
         overflow-x: auto;
 
         &::-webkit-scrollbar {
-            height: 0px;
+            height: 0;
         }
     }
 
-    & .el-button-group {
+    .el-button-group {
         .el-button {
             border-radius: 0;
         }
@@ -549,7 +565,7 @@
 }
 
 .filters-select {
-    & .el-select-dropdown {
+    .el-select-dropdown {
         width: 300px !important;
 
         &:has(.el-select-dropdown__empty) {
@@ -557,12 +573,12 @@
         }
     }
 
-    & .el-date-editor.el-input__wrapper {
+    .el-date-editor.el-input__wrapper {
         background-color: initial;
         box-shadow: none;
     }
 
-    & .el-select-dropdown__item .material-design-icon {
+    .el-select-dropdown__item .material-design-icon {
         bottom: -0.15rem;
     }
 }


### PR DESCRIPTION
> [!NOTE]
> **Closes Backlog Issue - #5912** - **_Make filters expand fully if we omit some of the non required buttons_**

**From Local:** I have commented the Refresh Button & still all good with width.

> ![image](https://github.com/user-attachments/assets/deb2f78e-8d33-4927-a93a-71a7cb593273) <br/>
> ![image](https://github.com/user-attachments/assets/2d6a9973-5b60-4ad3-8d16-35d813bdd1b8)

<hr>

> [!IMPORTANT]
> Additionally, I thought to add color on border of filter when `el-select` is focused for filtering, same as `SearchField`.
> I have pushed this in same commit, please check from your side if it can be a good implementation on UI part for Filter. <br/>
> **_You may always ask me to modify & remove that part if not needed._** <br/>
> _**How it looks ?**_
> ![image](https://github.com/user-attachments/assets/0fc8b3a3-fd6b-4729-bbc1-b2ad373e24f8)
> ![image](https://github.com/user-attachments/assets/be33cfcf-4b49-48d7-8f5f-29482a647325)


Closes https://github.com/kestra-io/kestra/issues/6261.