### PR TITLE
Plugin Property v2 validation

### DIFF
--- a/core/src/main/java/io/kestra/core/models/property/Property.java
+++ b/core/src/main/java/io/kestra/core/models/property/Property.java
@@ -12,10 +12,7 @@ import com.google.common.annotations.VisibleForTesting;
 import io.kestra.core.exceptions.IllegalVariableEvaluationException;
 import io.kestra.core.runners.RunContext;
 import io.kestra.core.serializers.JacksonMapper;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import java.io.IOException;
 import java.io.Serial;
@@ -43,11 +40,6 @@ public class Property<T> {
 
     private String expression;
     private T value;
-
-    //TODO: Temporary to make the ValueExtractor work, but it's not supposed to say here
-    public T getValue(){
-        return this.value;
-    }
 
     // used only by the deserializer and in tests
     @VisibleForTesting
@@ -353,6 +345,11 @@ public class Property<T> {
     // used only by the serializer
     String getExpression() {
         return this.expression;
+    }
+
+    // used only by the value extractor
+    T getValue() {
+        return value;
     }
 
     static class PropertyDeserializer extends StdDeserializer<Property<?>> {

--- a/core/src/main/java/io/kestra/core/models/property/Property.java
+++ b/core/src/main/java/io/kestra/core/models/property/Property.java
@@ -44,6 +44,11 @@ public class Property<T> {
     private String expression;
     private T value;
 
+    //TODO: Temporary to make the ValueExtractor work, but it's not supposed to say here
+    public T getValue(){
+        return this.value;
+    }
+
     // used only by the deserializer and in tests
     @VisibleForTesting
     public Property(String expression) {

--- a/core/src/main/java/io/kestra/core/models/property/PropertyValueExtractor.java
+++ b/core/src/main/java/io/kestra/core/models/property/PropertyValueExtractor.java
@@ -1,15 +1,20 @@
-package io.kestra.core.validations.extractors;
+package io.kestra.core.models.property;
 
-import io.kestra.core.models.property.Property;
 import io.micronaut.context.annotation.Context;
 import jakarta.validation.valueextraction.ExtractedValue;
 import jakarta.validation.valueextraction.ValueExtractor;
 
+/**
+ * Jakarta Bean Validation value extractor for a Property.<br>
+ *
+ * This is used by the @{@link io.kestra.core.validations.factory.CustomValidatorFactoryProvider}.
+ */
 @Context
 public class PropertyValueExtractor implements ValueExtractor<Property<@ExtractedValue ?>> {
 
     @Override
     public void extractValues(Property<?> originalValue, ValueReceiver receiver) {
+        // this will disable validation at save time but enable it at runtime when the value would be populated
         receiver.value( null, originalValue.getValue());
     }
 }

--- a/core/src/main/java/io/kestra/core/runners/DefaultRunContext.java
+++ b/core/src/main/java/io/kestra/core/runners/DefaultRunContext.java
@@ -8,6 +8,8 @@ import io.kestra.core.exceptions.IllegalVariableEvaluationException;
 import io.kestra.core.metrics.MetricRegistry;
 import io.kestra.core.models.executions.AbstractMetricEntry;
 import io.kestra.core.models.property.Property;
+import io.kestra.core.models.tasks.Task;
+import io.kestra.core.models.triggers.AbstractTrigger;
 import io.kestra.core.services.KVStoreService;
 import io.kestra.core.storages.Storage;
 import io.kestra.core.storages.StorageInterface;
@@ -59,6 +61,10 @@ public class DefaultRunContext extends RunContext {
     private Map<String, Object> pluginConfiguration;
     private List<String> secretInputs;
 
+    // those are only used to validate dynamic properties inside the RunContextProperty
+    private Task task;
+    private AbstractTrigger trigger;
+
     private final AtomicBoolean isInitialized = new AtomicBoolean(false);
 
 
@@ -100,6 +106,16 @@ public class DefaultRunContext extends RunContext {
     @JsonIgnore
     public ApplicationContext getApplicationContext() {
         return applicationContext;
+    }
+
+    @JsonIgnore
+    Task getTask() {
+        return task;
+    }
+
+    @JsonIgnore
+    AbstractTrigger getTrigger() {
+        return trigger;
     }
 
     void init(final ApplicationContext applicationContext) {
@@ -148,6 +164,14 @@ public class DefaultRunContext extends RunContext {
 
     void setTriggerExecutionId(final String triggerExecutionId) {
         this.triggerExecutionId = triggerExecutionId;
+    }
+
+    void setTask(final Task task) {
+        this.task = task;
+    }
+
+    void setTrigger(final AbstractTrigger trigger) {
+        this.trigger = trigger;
     }
 
     /**
@@ -521,6 +545,8 @@ public class DefaultRunContext extends RunContext {
         private RunContextLogger logger;
         private KVStoreService kvStoreService;
         private List<String> secretInputs;
+        private Task task;
+        private AbstractTrigger trigger;
 
         /**
          * Builds the new {@link DefaultRunContext} object.
@@ -541,6 +567,8 @@ public class DefaultRunContext extends RunContext {
             context.triggerExecutionId = triggerExecutionId;
             context.kvStoreService = kvStoreService;
             context.secretInputs = secretInputs;
+            context.task = task;
+            context.trigger = trigger;
             return context;
         }
     }

--- a/core/src/main/java/io/kestra/core/runners/RunContextFactory.java
+++ b/core/src/main/java/io/kestra/core/runners/RunContextFactory.java
@@ -114,6 +114,7 @@ public class RunContextFactory {
                 .build(runContextLogger))
             .withKvStoreService(kvStoreService)
             .withSecretInputs(secretInputsFromFlow(flow))
+            .withTask(task)
             .build();
     }
 
@@ -131,6 +132,7 @@ public class RunContextFactory {
                 .build(runContextLogger)
             )
             .withSecretInputs(secretInputsFromFlow(flow))
+            .withTrigger(trigger)
             .build();
     }
 
@@ -148,6 +150,11 @@ public class RunContextFactory {
 
     @VisibleForTesting
     public RunContext of(final Map<String, Object> variables) {
+        return of((Task) null, variables);
+    }
+
+    @VisibleForTesting
+    public RunContext of(final Task task, final Map<String, Object> variables) {
         RunContextLogger runContextLogger = new RunContextLogger();
         return newBuilder()
             .withLogger(runContextLogger)
@@ -177,6 +184,7 @@ public class RunContextFactory {
                 flowService
             ))
             .withVariables(variables)
+            .withTask(task)
             .build();
     }
 

--- a/core/src/main/java/io/kestra/core/runners/RunContextInitializer.java
+++ b/core/src/main/java/io/kestra/core/runners/RunContextInitializer.java
@@ -134,6 +134,7 @@ public class RunContextInitializer {
         runContext.setPluginConfiguration(pluginConfigurations.getConfigurationByPluginTypeOrAliases(task.getType(), task.getClass()));
         runContext.setStorage(new InternalStorage(runContextLogger.logger(), StorageContext.forTask(taskRun), storageInterface, flowService));
         runContext.setLogger(runContextLogger);
+        runContext.setTask(task);
 
         return runContext;
     }
@@ -226,6 +227,7 @@ public class RunContextInitializer {
         runContext.setStorage(storage);
         runContext.setPluginConfiguration(pluginConfigurations.getConfigurationByPluginTypeOrAliases(trigger.getType(), trigger.getClass()));
         runContext.setTriggerExecutionId(triggerExecutionId);
+        runContext.setTrigger(trigger);
 
         return runContext;
     }

--- a/core/src/main/java/io/kestra/core/runners/RunContextProperty.java
+++ b/core/src/main/java/io/kestra/core/runners/RunContextProperty.java
@@ -2,10 +2,17 @@ package io.kestra.core.runners;
 
 import io.kestra.core.exceptions.IllegalVariableEvaluationException;
 import io.kestra.core.models.property.Property;
+import io.kestra.core.models.tasks.Task;
+import io.kestra.core.models.triggers.AbstractTrigger;
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.ConstraintViolationException;
+import jakarta.validation.Validator;
+import lombok.extern.slf4j.Slf4j;
 
 import java.util.Collections;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 
 import static io.kestra.core.utils.Rethrow.throwFunction;
 
@@ -14,86 +21,148 @@ import static io.kestra.core.utils.Rethrow.throwFunction;
  *
  * @param <T>
  */
+@Slf4j
 public class RunContextProperty<T> {
     private final Property<T> property;
     private final RunContext runContext;
+    private final Task task;
+    private final AbstractTrigger trigger;
 
     RunContextProperty(Property<T> property, RunContext runContext) {
         this.property = property;
         this.runContext = runContext;
+        this.task = ((DefaultRunContext) runContext).getTask();
+        this.trigger = ((DefaultRunContext) runContext).getTrigger();
     }
 
     /**
-     * Render a property then convert it to its target type.<br>
+     * Validate a bean using Jakarta Bean Validation.
+     * TODO this seems useful as a general util so maybe move it to the RunContext
+     */
+    public <U> void validate(U bean) {
+        Validator validator = ((DefaultRunContext) runContext).getApplicationContext().getBean(Validator.class);
+        Set<ConstraintViolation<U>> violations = validator.validate(bean);
+        if (!violations.isEmpty()) {
+            throw new ConstraintViolationException(violations);
+        }
+    }
+
+    private void validate() {
+        if (task != null) {
+            validate(task);
+        } else if (trigger != null) {
+            validate(trigger);
+        } else {
+            // this should never happen, but if it happens, we may lower to debug
+            log.warn("Unable to do validation: no task or trigger found");
+        }
+    }
+
+    /**
+     * Render a property then convert it to its target type and validate it.<br>
+     *
+     * Validation will only occur if the runContext has been created with a Task or an AbstractTrigger.<br>
      *
      * This method is safe to be used as many times as you want as the rendering and conversion will be cached.
      * Warning, due to the caching mechanism, this method is not thread-safe.
      */
     public Optional<T> as(Class<T> clazz) throws IllegalVariableEvaluationException {
-        return Optional.ofNullable(this.property)
+        var as = Optional.ofNullable(this.property)
             .map(throwFunction(prop -> Property.as(prop, this.runContext, clazz)));
+
+        validate();
+        return as;
     }
 
     /**
-     * Render a property with additional variables, then convert it to its target type.<br>
+     * Render a property with additional variables, then convert it to its target type and validate it.<br>
+     *
+     * Validation will only occur if the runContext has been created with a Task or an AbstractTrigger.<br>
      *
      * This method is safe to be used as many times as you want as the rendering and conversion will be cached.
      * Warning, due to the caching mechanism, this method is not thread-safe.
      */
     public Optional<T> as(Class<T> clazz, Map<String, Object> variables) throws IllegalVariableEvaluationException {
-        return Optional.ofNullable(this.property)
+        var as = Optional.ofNullable(this.property)
             .map(throwFunction(prop -> Property.as(prop, this.runContext, clazz, variables)));
+
+        validate();
+        return as;
     }
 
     /**
-     * Render a property then convert it as a list of target type.
+     * Render a property then convert it as a list of target type and validate it.
      * Null properties will return an empty list.<br>
+     *
+     * Validation will only occur if the runContext has been created with a Task or an AbstractTrigger.<br>
      *
      * This method is safe to be used as many times as you want as the rendering and conversion will be cached.
      * Warning, due to the caching mechanism, this method is not thread-safe.
      */
+    @SuppressWarnings("unchecked")
     public <I> T asList(Class<I> itemClazz) throws IllegalVariableEvaluationException {
-        return Optional.ofNullable(this.property)
+        var as = Optional.ofNullable(this.property)
             .map(throwFunction(prop -> Property.asList(prop, this.runContext, itemClazz)))
             .orElse((T) Collections.emptyList());
+
+        validate();
+        return as;
     }
 
     /**
-     * Render a property with additional variables, then convert it as a list of target type.
+     * Render a property with additional variables, then convert it as a list of target type and validate it.
      * Null properties will return an empty list.<br>
      *
+     * Validation will only occur if the runContext has been created with a Task or an AbstractTrigger.<br>
+     *
      * This method is safe to be used as many times as you want as the rendering and conversion will be cached.
      * Warning, due to the caching mechanism, this method is not thread-safe.
      */
+    @SuppressWarnings("unchecked")
     public <I> T asList(Class<I> itemClazz, Map<String, Object> variables) throws IllegalVariableEvaluationException {
-        return Optional.ofNullable(this.property)
+        var as = Optional.ofNullable(this.property)
             .map(throwFunction(prop -> Property.asList(prop, this.runContext, itemClazz, variables)))
             .orElse((T) Collections.emptyList());
+
+        validate();
+        return as;
     }
 
     /**
-     * Render a property then convert it as a map of target types.
+     * Render a property then convert it as a map of target types and validate it.
      * Null properties will return an empty map.<br>
+     *
+     * Validation will only occur if the runContext has been created with a Task or an AbstractTrigger.<br>
      *
      * This method is safe to be used as many times as you want as the rendering and conversion will be cached.
      * Warning, due to the caching mechanism, this method is not thread-safe.
      */
+    @SuppressWarnings("unchecked")
     public <K,V> T asMap(Class<K> keyClass, Class<V> valueClass) throws IllegalVariableEvaluationException {
-        return Optional.ofNullable(this.property)
+        var as = Optional.ofNullable(this.property)
             .map(throwFunction(prop -> Property.asMap(prop, this.runContext, keyClass, valueClass)))
             .orElse((T) Collections.emptyMap());
+
+        validate();
+        return as;
     }
 
     /**
-     * Render a property with additional variables, then convert it as a map of target types.
+     * Render a property with additional variables, then convert it as a map of target types and validate it.
      * Null properties will return an empty map.<br>
+     *
+     * Validation will only occur if the runContext has been created with a Task or an AbstractTrigger.<br>
      *
      * This method is safe to be used as many times as you want as the rendering and conversion will be cached.
      * Warning, due to the caching mechanism, this method is not thread-safe.
      */
+    @SuppressWarnings("unchecked")
     public <K,V> T asMap(Class<K> keyClass, Class<V> valueClass, Map<String, Object> variables) throws IllegalVariableEvaluationException {
-        return Optional.ofNullable(this.property)
+        var as = Optional.ofNullable(this.property)
             .map(throwFunction(prop -> Property.asMap(prop, this.runContext, keyClass, valueClass, variables)))
             .orElse((T) Collections.emptyMap());
+
+        validate();
+        return as;
     }
 }

--- a/core/src/main/java/io/kestra/core/validations/extractors/PropertyValueExtractor.java
+++ b/core/src/main/java/io/kestra/core/validations/extractors/PropertyValueExtractor.java
@@ -1,0 +1,15 @@
+package io.kestra.core.validations.extractors;
+
+import io.kestra.core.models.property.Property;
+import io.micronaut.context.annotation.Context;
+import jakarta.validation.valueextraction.ExtractedValue;
+import jakarta.validation.valueextraction.ValueExtractor;
+
+@Context
+public class PropertyValueExtractor implements ValueExtractor<Property<@ExtractedValue ?>> {
+
+    @Override
+    public void extractValues(Property<?> originalValue, ValueReceiver receiver) {
+        receiver.value( null, originalValue.getValue());
+    }
+}

--- a/core/src/main/java/io/kestra/core/validations/factory/CustomValidatorFactoryProvider.java
+++ b/core/src/main/java/io/kestra/core/validations/factory/CustomValidatorFactoryProvider.java
@@ -1,0 +1,105 @@
+package io.kestra.core.validations.factory;
+
+import io.kestra.core.validations.extractors.PropertyValueExtractor;
+import io.micronaut.configuration.hibernate.validator.ValidatorFactoryProvider;
+import io.micronaut.context.annotation.Factory;
+import io.micronaut.context.annotation.Replaces;
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.context.annotation.Value;
+import io.micronaut.context.env.Environment;
+import io.micronaut.core.annotation.TypeHint;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+import jakarta.validation.Configuration;
+import jakarta.validation.ConstraintValidatorFactory;
+import jakarta.validation.MessageInterpolator;
+import jakarta.validation.ParameterNameProvider;
+import jakarta.validation.TraversableResolver;
+import jakarta.validation.Validation;
+import jakarta.validation.ValidatorFactory;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Properties;
+import org.hibernate.validator.HibernateValidator;
+import org.hibernate.validator.messageinterpolation.ParameterMessageInterpolator;
+
+/**
+ * Produce a Validator factory provider that replace {@link ValidatorFactoryProvider} from micronaut
+ * hibernate validator. This has to be done because of a conflict between micronaut validation and micronaut hibernate validation
+ * that prevent {@link jakarta.validation.valueextraction.ValueExtractor} to work
+ * <br>
+ * This provider allows to manually register the ValueExtractors. To do that, they have to be injected
+ * and set in the {@link CustomValidatorFactoryProvider#configureValueExtractor(Configuration)} method
+ */
+@Factory
+@Requires(classes = HibernateValidator.class)
+@TypeHint(HibernateValidator.class)
+@Replaces(ValidatorFactoryProvider.class)
+public class CustomValidatorFactoryProvider {
+
+    @Inject
+    protected Optional<MessageInterpolator> messageInterpolator = Optional.empty();
+
+    @Inject
+    protected Optional<TraversableResolver> traversableResolver = Optional.empty();
+
+    @Inject
+    protected Optional<ConstraintValidatorFactory> constraintValidatorFactory = Optional.empty();
+
+    @Inject
+    protected Optional<ParameterNameProvider> parameterNameProvider = Optional.empty();
+
+    @Inject
+    protected PropertyValueExtractor propertyValueExtractor;
+
+    @Value("${hibernate.validator.ignore-xml-configuration:true}")
+    protected boolean ignoreXmlConfiguration = true;
+
+    /**
+     * Produces a Validator factory class.
+     * @param environment optional param for environment
+     * @return validator factory
+     */
+    @Singleton
+    @Requires(classes = HibernateValidator.class)
+    @Replaces(ValidatorFactory.class)
+    ValidatorFactory validatorFactory(Optional<Environment> environment) {
+        Configuration<?> validatorConfiguration = Validation.byDefaultProvider()
+            .configure();
+
+        validatorConfiguration.messageInterpolator(messageInterpolator.orElseGet(ParameterMessageInterpolator::new));
+        messageInterpolator.ifPresent(validatorConfiguration::messageInterpolator);
+        traversableResolver.ifPresent(validatorConfiguration::traversableResolver);
+        constraintValidatorFactory.ifPresent(validatorConfiguration::constraintValidatorFactory);
+        parameterNameProvider.ifPresent(validatorConfiguration::parameterNameProvider);
+
+        if (ignoreXmlConfiguration) {
+            validatorConfiguration.ignoreXmlConfiguration();
+        }
+        environment.ifPresent(env -> {
+            Optional<Properties> config = env.getProperty("hibernate.validator", Properties.class);
+            config.ifPresent(properties -> {
+                for (Map.Entry<Object, Object> entry : properties.entrySet()) {
+                    Object value = entry.getValue();
+                    if (value != null) {
+                        validatorConfiguration.addProperty(
+                            "hibernate.validator." + entry.getKey(),
+                            value.toString()
+                        );
+                    }
+                }
+            });
+        });
+
+        configureValueExtractor(validatorConfiguration);
+
+        return validatorConfiguration.buildValidatorFactory();
+    }
+
+    /**
+     * The custom ValueExtractors has to be set here
+     */
+    protected void configureValueExtractor(Configuration<?> validatorConfiguration ){
+        validatorConfiguration.addValueExtractor(propertyValueExtractor);
+    }
+}

--- a/core/src/main/java/io/kestra/core/validations/factory/CustomValidatorFactoryProvider.java
+++ b/core/src/main/java/io/kestra/core/validations/factory/CustomValidatorFactoryProvider.java
@@ -1,6 +1,6 @@
 package io.kestra.core.validations.factory;
 
-import io.kestra.core.validations.extractors.PropertyValueExtractor;
+import io.kestra.core.models.property.PropertyValueExtractor;
 import io.micronaut.configuration.hibernate.validator.ValidatorFactoryProvider;
 import io.micronaut.context.annotation.Factory;
 import io.micronaut.context.annotation.Replaces;
@@ -10,16 +10,12 @@ import io.micronaut.context.env.Environment;
 import io.micronaut.core.annotation.TypeHint;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
-import jakarta.validation.Configuration;
-import jakarta.validation.ConstraintValidatorFactory;
-import jakarta.validation.MessageInterpolator;
-import jakarta.validation.ParameterNameProvider;
-import jakarta.validation.TraversableResolver;
-import jakarta.validation.Validation;
-import jakarta.validation.ValidatorFactory;
+import jakarta.validation.*;
+
 import java.util.Map;
 import java.util.Optional;
 import java.util.Properties;
+
 import org.hibernate.validator.HibernateValidator;
 import org.hibernate.validator.messageinterpolation.ParameterMessageInterpolator;
 

--- a/core/src/test/java/io/kestra/core/models/property/DynamicPropertyExampleTask.java
+++ b/core/src/test/java/io/kestra/core/models/property/DynamicPropertyExampleTask.java
@@ -4,6 +4,7 @@ import io.kestra.core.models.annotations.Plugin;
 import io.kestra.core.models.tasks.RunnableTask;
 import io.kestra.core.models.tasks.Task;
 import io.kestra.core.runners.RunContext;
+import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
@@ -21,7 +22,7 @@ import java.util.Map;
 @Plugin
 public class DynamicPropertyExampleTask extends Task implements RunnableTask<DynamicPropertyExampleTask.Output> {
     @NotNull
-    private Property<Integer> number;
+    private Property<@Min(0) Integer> number;
 
     @NotNull
     private Property<String> string;

--- a/core/src/test/java/io/kestra/core/validations/extractors/DynamicPropertyDto.java
+++ b/core/src/test/java/io/kestra/core/validations/extractors/DynamicPropertyDto.java
@@ -1,0 +1,19 @@
+package io.kestra.core.validations.extractors;
+
+import io.kestra.core.models.property.Property;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+
+public class DynamicPropertyDto {
+
+    @NotNull
+    private Property<@Min(10) Integer> number;
+
+    @NotNull
+    private Property<String> string;
+
+    public DynamicPropertyDto(Property<@Min(value = 10, message = "must be greater than or equal to {value}") Integer> number, Property<String> string) {
+        this.number = number;
+        this.string = string;
+    }
+}

--- a/core/src/test/java/io/kestra/core/validations/extractors/PropertyValueExtractorTest.java
+++ b/core/src/test/java/io/kestra/core/validations/extractors/PropertyValueExtractorTest.java
@@ -1,0 +1,35 @@
+package io.kestra.core.validations.extractors;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.kestra.core.models.property.Property;
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import io.micronaut.validation.validator.Validator;
+import jakarta.inject.Inject;
+import jakarta.validation.ConstraintViolation;
+import java.util.Optional;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+@MicronautTest
+public class PropertyValueExtractorTest {
+
+    @Inject
+    private Validator validator;
+
+    @Test
+    public void should_extract_and_validate_integer_value(){
+        DynamicPropertyDto dto = new DynamicPropertyDto(Property.of(20), Property.of("Test"));
+        Set<ConstraintViolation<DynamicPropertyDto>> violations = validator.validate(dto);
+        assertTrue(violations.isEmpty());
+
+        dto = new DynamicPropertyDto(Property.of(5), Property.of("Test"));
+        violations = validator.validate(dto);
+        assertThat(violations.size(), is(1));
+        ConstraintViolation<DynamicPropertyDto> violation = violations.stream().findFirst().get();
+        assertThat(violation.getMessage(), is("must be greater than or equal to 10"));
+    }
+
+}

--- a/core/src/test/java/io/kestra/plugin/core/trigger/ScheduleOnDatesTest.java
+++ b/core/src/test/java/io/kestra/plugin/core/trigger/ScheduleOnDatesTest.java
@@ -42,6 +42,7 @@ class ScheduleOnDatesTest {
         var later = now.plusMinutes(2).truncatedTo(ChronoUnit.SECONDS);
         var scheduleOnDates = ScheduleOnDates.builder()
             .id(IdUtils.create())
+            .type(ScheduleOnDates.class.getName())
             .interval(null)
             .dates(Property.of(List.of(before, after, later)))
             .build();
@@ -65,6 +66,7 @@ class ScheduleOnDatesTest {
         var later = now.plusMinutes(2).truncatedTo(ChronoUnit.SECONDS);
         var scheduleOnDates = ScheduleOnDates.builder()
             .id(IdUtils.create())
+            .type(ScheduleOnDates.class.getName())
             .interval(null)
             .dates(Property.of(List.of(before, after, later)))
             .build();
@@ -86,6 +88,7 @@ class ScheduleOnDatesTest {
         var next = now.plusMinutes(1).truncatedTo(ChronoUnit.SECONDS);
         var scheduleOnDates = ScheduleOnDates.builder()
             .id(IdUtils.create())
+            .type(ScheduleOnDates.class.getName())
             .interval(null)
             .dates(Property.of(List.of(first, before, next)))
             .build();


### PR DESCRIPTION
Allow validation of plugin property v2 at runtime by extracting the value of the property (after rendering) and automatically validate tasks and triggers when a property is rendered.

Fixes #5455