### PR TITLE
feat(ui): Make filters expand fully if we omit some of the non required buttons.

### DIFF
--- a/ui/src/components/filter/KestraFilter.vue
+++ b/ui/src/components/filter/KestraFilter.vue
@@ -85,9 +85,9 @@
             <KestraIcon :tooltip="$t('search')" placement="bottom">
                 <el-button :icon="Magnify" @click="triggerSearch" />
             </KestraIcon>
-            <Save :disabled="!current.length" :prefix :current />
+            <!-- <Save :disabled="!current.length" :prefix :current />
             <Refresh v-if="refresh.shown" @refresh="refresh.callback" />
-            <Settings v-if="settings.shown" :settings />
+            <Settings v-if="settings.shown" :settings /> -->
         </el-button-group>
 
         <Dashboards
@@ -464,7 +464,8 @@
 .filters {
     @include width-available;
     & .el-select {
-        max-width: calc(100% - 237px);
+        flex: 1;
+        width: calc(100% - 237px);
         &.settings {
             max-width: calc(100% - 285px);
         }
@@ -498,6 +499,7 @@
     & .el-button-group {
         .el-button {
             border-radius: 0;
+            width: 47px;
         }
         span.kicon:last-child .el-button,
         > button.el-button:last-child {

--- a/ui/src/components/filter/KestraFilter.vue
+++ b/ui/src/components/filter/KestraFilter.vue
@@ -85,9 +85,9 @@
             <KestraIcon :tooltip="$t('search')" placement="bottom">
                 <el-button :icon="Magnify" @click="triggerSearch" />
             </KestraIcon>
-            <!-- <Save :disabled="!current.length" :prefix :current />
+            <Save :disabled="!current.length" :prefix :current />
             <Refresh v-if="refresh.shown" @refresh="refresh.callback" />
-            <Settings v-if="settings.shown" :settings /> -->
+            <Settings v-if="settings.shown" :settings />
         </el-button-group>
 
         <Dashboards

--- a/ui/src/components/filter/KestraFilter.vue
+++ b/ui/src/components/filter/KestraFilter.vue
@@ -499,7 +499,6 @@
     & .el-button-group {
         .el-button {
             border-radius: 0;
-            width: 47px;
         }
         span.kicon:last-child .el-button,
         > button.el-button:last-child {


### PR DESCRIPTION
Closes #5912 


Hey @MilosPaunovic ,

This is implemented for the issue reported like when we omit a button it should not give a blank space under `Section`.

But please be aware that whenever we will add a new means >4 button we will have to manually tweak the width of `el-select` to avoid overflow.
```
& .el-select {
        flex: 1;
        width: calc(100% - 237px);
```

I have tried using multiple filter. It looks fine to me. Would love to see any changes you suggest.
![image](https://github.com/user-attachments/assets/e1b82f74-8bf4-4f61-9ea0-4938293372fa)
![image](https://github.com/user-attachments/assets/7ef300ab-e759-4f49-ac28-6624032869e0)
