### PR TITLE
chore: exclude liveness/readiness health checks from access logs

### DIFF
--- a/cli/src/main/resources/application.yml
+++ b/cli/src/main/resources/application.yml
@@ -37,6 +37,7 @@ micronaut:
         exclusions:
           - /ui/.+
           - /health
+          - /health/.+
           - /prometheus
     http-version: HTTP_1_1
   caches:


### PR DESCRIPTION
Following https://github.com/kestra-io/helm-charts/pull/62, health check endpoints (`/health/liveness` and `/health/readiness`) appear in access logs, creating unnecessary noise.

This PR configures access logger exclusions to filter out these endpoints.