### PR TITLE
fix(core): wait for running executor for liveness executor

### DIFF
--- a/jdbc/src/main/java/io/kestra/jdbc/runner/JdbcServiceLivenessCoordinator.java
+++ b/jdbc/src/main/java/io/kestra/jdbc/runner/JdbcServiceLivenessCoordinator.java
@@ -6,6 +6,7 @@ import io.kestra.core.server.ServerConfig;
 import io.kestra.core.server.Service;
 import io.kestra.core.server.Service.ServiceState;
 import io.kestra.core.server.ServiceInstance;
+import io.kestra.core.server.ServiceRegistry;
 import io.kestra.core.server.WorkerTaskRestartStrategy;
 import io.kestra.jdbc.repository.AbstractJdbcServiceInstanceRepository;
 import io.micronaut.context.annotation.Requires;
@@ -44,8 +45,9 @@ public final class JdbcServiceLivenessCoordinator extends AbstractServiceLivenes
      */
     @Inject
     public JdbcServiceLivenessCoordinator(final AbstractJdbcServiceInstanceRepository serviceInstanceRepository,
+                                          final ServiceRegistry serviceRegistry,
                                           final ServerConfig serverConfig) {
-        super(serviceInstanceRepository, serverConfig);
+        super(serviceInstanceRepository, serviceRegistry, serverConfig);
         this.serviceInstanceRepository = serviceInstanceRepository;
     }
 


### PR DESCRIPTION
Changes:
To safely execute the liveness coordinator task without error we should wait for the executor to be fully running

part-of: kestra-io/kestra-ee#2492