### PR TITLE
chore(ui): Change filter color border - rework

### DIFF
--- a/ui/src/components/filter/KestraFilter.vue
+++ b/ui/src/components/filter/KestraFilter.vue
@@ -1,6 +1,6 @@
 <template>
     <section :class="['d-inline-flex mb-3 filters', {focused: isFocused}]">
-        <History :prefix @search="handleHistoryItems" />
+        <History :prefix @search="handleHistoryItems" class="brd" />
 
         <el-select
             ref="select"
@@ -487,15 +487,51 @@
     width: fill-available;
 }
 .filters {
+    border-radius: var(--bs-border-radius);
+    &.focused {
+	border-color: var(--bs-primary);
+	transition: border-color 0.5s;
+	border: 1px solid var(--bs-primary);
+
+	& .brd .el-button {
+		border: 0;
+		outline: none !important;
+		border-right: 1px solid var(--bs-border-color);
+
+		&:hover {
+			border-color: #8008f6 !important;
+		}
+	}
+
+	& .el-select__wrapper {
+		box-shadow:
+			0 0 0 0 var(--el-border-color),
+			0 0 0 0 var(--el-border-color);
+	}
+
+	& .el-button-group .el-button {
+		border: none;
+		border-left: 1px solid var(--el-border-color) !important;
+
+		&:hover {
+			border-left: 1px solid #8008f6 !important;
+			border-right: 1px solid #8008f6 !important;
+		}
+
+		&:last-child:hover {
+			border-right: 0 !important;
+		}
+	}
+}
     @include width-available;
     & .el-select {
         flex: 1;
         width: calc(100% - 237px);
         &.settings {
-            max-width: calc(100% - 285px);
+            width: calc(100% - 285px);
         }
         &:not(.refresh) {
-            max-width: calc(100% - 189px);
+            width: calc(100% - 189px);
         }
     }
     & .el-select__placeholder {


### PR DESCRIPTION
Will close #6261 

**Little more improvement for width of FilterBar on omitting button leaving no blank space - not overflowing with more filter too.**

**I think with changes being made here & with this issue being solved https://github.com/kestra-io/kestra/issues/6260 - Changes from this Pull doesn't seem relevant for now. We will have to make some changes too  particularly with new changes in `KestraFilter`**

![image](https://github.com/user-attachments/assets/44f917f8-bb36-4f7c-8b2d-92b4fa2af270)
![image](https://github.com/user-attachments/assets/8dc728aa-e269-4f27-9925-40c940a13ac3)
![image](https://github.com/user-attachments/assets/a51d9632-6a4a-44d3-8974-5098047f4022)
![image](https://github.com/user-attachments/assets/903e0939-5d16-4b1b-990f-ee09b37d0fe0)

