### PR TITLE
chore: avoid global constants (use window instead)

### DIFF
--- a/ui/index.html
+++ b/ui/index.html
@@ -12,10 +12,10 @@
     <link rel="stylesheet" href="/loader.css" />
     <meta name="html-head" content="replace">
     <script>
-        const KESTRA_GOOGLE_ANALYTICS = null;
-        const KESTRA_UI_PATH = "./";
-        const KESTRA_BASE_PATH = function () {
-            const split = KESTRA_UI_PATH.split('/');
+        window.KESTRA_GOOGLE_ANALYTICS = null;
+        window.KESTRA_UI_PATH = "./";
+        window.KESTRA_BASE_PATH = function () {
+            const split = window.KESTRA_UI_PATH.split('/');
             split.pop();
             split.pop();
             return split.join('/') + "/";

--- a/ui/src/override/utils/route.js
+++ b/ui/src/override/utils/route.js
@@ -1,5 +1,5 @@
-// eslint-disable-next-line no-undef
-let root = (import.meta.env.VITE_APP_API_URL || "") + KESTRA_BASE_PATH;
+
+let root = (import.meta.env.VITE_APP_API_URL || "") + window.KESTRA_BASE_PATH;
 if (root.endsWith("/")) {
     root = root.substring(0, root.length - 1);
 }

--- a/ui/src/utils/init.js
+++ b/ui/src/utils/init.js
@@ -87,10 +87,10 @@ export default (app, routes, stores, translations) => {
     let store = createStore(stores);
     app.use(store);
 
-    /* eslint-disable no-undef */
+
     // router
     let router = createRouter({
-        history: createWebHistory(KESTRA_UI_PATH),
+        history: createWebHistory(window.KESTRA_UI_PATH),
         routes
     });
 
@@ -120,16 +120,16 @@ export default (app, routes, stores, translations) => {
     app.use(router)
 
     // Google Analytics
-    if (KESTRA_GOOGLE_ANALYTICS !== null) {
+    if (window.KESTRA_GOOGLE_ANALYTICS !== null) {
         app.use(
             VueGtag,
             {
-                config: {id: KESTRA_GOOGLE_ANALYTICS}
+                config: {id: window.KESTRA_GOOGLE_ANALYTICS}
             },
             router
         );
     }
-    /* eslint-enable no-undef */
+
 
 
     // l18n

--- a/ui/vitest.config.js
+++ b/ui/vitest.config.js
@@ -15,6 +15,6 @@ export default defineConfig({
         environment: "jsdom"
     },
     define: {
-        KESTRA_BASE_PATH: "/ui/",
+        "window.KESTRA_BASE_PATH": "/ui/",
     },
 })


### PR DESCRIPTION
Since we are to adopt storybook or another FE tools, we need to make its integration simpler.

Global variables are unfortunately too ambiguous. Precising their scope is always a good idea. 

In this case, I use `window.variable` we can replace it later by `globalThis.variable`