### PR TITLE
fix(run): add LD_PRELOAD to handle duckdb/rocksdb libc conflict

### DIFF
--- a/gradle/jar/selfrun.sh
+++ b/gradle/jar/selfrun.sh
@@ -23,6 +23,13 @@ esac
 # Opens java.lang due to https://github.com/kestra-io/kestra/issues/1755, see https://github.com/micronaut-projects/micronaut-core/issues/9573
 JAVA_ADD_OPENS="--add-opens java.base/java.nio=ALL-UNNAMED --add-opens java.base/java.util=ALL-UNNAMED --add-opens java.base/java.lang=ALL-UNNAMED"
 
+# Fix required to use new DucksDB versions along side RocksDB
+# https://github.com/kestra-io/plugin-jdbc/issues/165
+LIBSTDC="/lib/x86_64-linux-gnu/libstdc++.so.6"
+if [ "${LD_PRELOAD_ENABLED:-true}" = "true" ] && [ -z "$LD_PRELOAD" ] && [ -f "$LIBSTDC" ]; then
+  export LD_PRELOAD="$LIBSTDC"
+fi
+
 # Exec
 exec java ${JAVA_OPTS} ${JAVA_ADD_OPENS} -Djava.security.manager=allow -jar "$0" "$@"
 exit 127


### PR DESCRIPTION
related-to: kestra-io/plugin-jdbc#165