### PR TITLE
fix(core): properly check next scheduled date for backfill execution (#6413)

### DIFF
--- a/core/src/main/java/io/kestra/plugin/core/trigger/Schedule.java
+++ b/core/src/main/java/io/kestra/plugin/core/trigger/Schedule.java
@@ -337,7 +337,8 @@ public class Schedule extends AbstractTrigger implements Schedulable, TriggerOut
         RunContext runContext = conditionContext.getRunContext();
         ExecutionTime executionTime = this.executionTime();
         ZonedDateTime currentDateTimeExecution = convertDateTime(triggerContext.getDate());
-        Backfill backfill = triggerContext.getBackfill();
+
+        final Backfill backfill = triggerContext.getBackfill();
 
         if (backfill != null) {
             if (backfill.getPaused()) {
@@ -352,7 +353,14 @@ public class Schedule extends AbstractTrigger implements Schedulable, TriggerOut
             return Optional.empty();
         }
 
-        ZonedDateTime next = scheduleDates.getDate();
+        final ZonedDateTime next = scheduleDates.getDate();
+
+        // If the trigger is evaluated for 'back-fill', we have to make sure
+        // that 'current-date' is strictly after the next execution date for an execution to be eligible.
+        if (backfill != null && currentDateTimeExecution.isBefore(next)) {
+            // Otherwise, skip the execution.
+            return Optional.empty();
+        }
 
         // we are in the future don't allow
         // No use case, just here for prevention but it should never happen


### PR DESCRIPTION
Changes:
When a trigger is evaluated for in a back-fill context, we have to make sure that current-date is strictly after the next execution date for an execution to be eligible.

fix: #6413