### PR TITLE
fix(core): existing ns based on KV and not only flows

### DIFF
--- a/core/src/test/java/io/kestra/core/services/KVStoreServiceTest.java
+++ b/core/src/test/java/io/kestra/core/services/KVStoreServiceTest.java
@@ -2,12 +2,15 @@ package io.kestra.core.services;
 
 import io.kestra.core.junit.annotations.KestraTest;
 import io.kestra.core.repositories.FlowRepositoryInterface;
-import io.kestra.core.storages.kv.KVStoreException;
+import io.kestra.core.storages.StorageInterface;
+import io.kestra.core.storages.kv.*;
 import io.micronaut.test.annotation.MockBean;
 import jakarta.inject.Inject;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import java.io.IOException;
+import java.time.Duration;
 import java.util.Optional;
 
 @KestraTest
@@ -19,7 +22,7 @@ class KVStoreServiceTest {
     KVStoreService storeService;
 
     @Inject
-    FlowRepositoryInterface flowRepository;
+    StorageInterface storageInterface;
 
     @Test
     void shouldGetKVStoreForExistingNamespaceGivenFromNull() {
@@ -35,6 +38,13 @@ class KVStoreServiceTest {
     @Test
     void shouldGetKVStoreForAnyNamespaceWhenAccessingFromChildNamespace() {
         Assertions.assertNotNull(storeService.get(null, "io.kestra", TEST_EXISTING_NAMESPACE));
+    }
+
+    @Test
+    void shouldGetKVStoreFromNonExistingNamespaceWithAKV() throws IOException {
+        KVStore kvStore = new InternalKVStore(null, "system", storageInterface);
+        kvStore.put("key", new KVValueAndMetadata(new KVMetadata(Duration.ofHours(1)), "value"));
+        Assertions.assertNotNull(storeService.get(null, "system", null));
     }
 
     @MockBean(NamespaceService.class)

--- a/core/src/test/java/io/kestra/plugin/core/kv/SetTest.java
+++ b/core/src/test/java/io/kestra/plugin/core/kv/SetTest.java
@@ -130,7 +130,7 @@ public class SetTest {
             .type(Set.class.getName())
             .key("{{ inputs.key }}")
             .value("{{ inputs.value }}")
-            .namespace("???")
+            .namespace("not-found")
             .build();
 
         // When - Then


### PR DESCRIPTION
Lookup if there are existing KV to know if a ns exist from the kv function and not only if flows exist in the KV.

Fixes #6367 