### PR TITLE
chore(ui): Add an artwork instead of disabling the tab when no Trigger is defined for a flow.

### DIFF
--- a/ui/src/components/flows/FlowRoot.vue
+++ b/ui/src/components/flows/FlowRoot.vue
@@ -202,11 +202,6 @@
                         name: "triggers",
                         component: FlowTriggers,
                         title: this.$t("triggers"),
-                        props: {
-                            showTooltip: !this.flow.triggers || this.flow.triggers.length === 0
-                        },
-                        disabled: !this.flow.triggers,
-                        hideTitle: !this.flow.triggers
                     });
                 }
 

--- a/ui/src/components/layout/EmptyState.vue
+++ b/ui/src/components/layout/EmptyState.vue
@@ -1,13 +1,13 @@
 <template>
     <div class="empty-state-container">
         <div class="empty-state-image">
-            <img :src="image" :alt="title">
+            <img :src="image" :alt="title" width="150px">
         </div>
         <div class="empty-state-content">
-            <h4 class="empty-state-title">
+            <h5 class="empty-state-title mt-3">
                 {{ title }}
-            </h4>
-            <div
+            </h5>
+            <p
                 class="empty-state-description"
                 :class="themeClass"
                 v-html="description"
@@ -53,12 +53,11 @@
 }
 
 .empty-state-image {
-    margin-top: 2rem;
+    margin-top: 4rem;
     margin-bottom: 2rem;
 }
 
 .empty-state-image img {
-    max-width: 200px;
     height: auto;
 }
 
@@ -68,11 +67,12 @@
 
 .empty-state-title {
     color: var(--el-text-color-regular);
+    font-weight: 700;
+    font-size: var(--el-font-size-large);
 }
 
 .empty-state-description {
-    font-size: var(--el-font-size);
-    margin-bottom: 16px;
+    font-size: var(--el-font-size-small);
     color: var(--el-text-color-regular);
 }
 

--- a/ui/src/translations/en.json
+++ b/ui/src/translations/en.json
@@ -960,15 +960,15 @@
     },
     "concurrency-view": {
       "title_no_limit": "No limits are set for this Flow.",
-      "desc_no_limit": "Read more about <a href=\"https://kestra.io/docs/workflow-components/concurrency\" target=\"_blank\">Concurrency Limits</a> in our documentation."
+      "desc_no_limit": "Read more about <strong><a href=\"https://kestra.io/docs/workflow-components/concurrency\" target=\"_blank\">Concurrency Limits</a></strong> in our documentation."
     },
     "dependency-view": {
       "title_no_deps": "No dependencies are set for this Flow.",
       "desc_no_deps": "Read more about <a href=\"https://kestra.io/docs/ui/flows#dependencies\" target=\"_blank\">Flow Dependencies</a> in our documentation."
     },
     "triggers-view": {
-      "title_no_triggers": "Your flow does't have any Triggers.",
-      "desc_no_triggers": "Read more about <a href=\"https://kestra.io/docs/workflow-components/triggers\" target=\"_blank\">Triggers</a> in our documentation."
+      "title_no_triggers": "Your flow doesn't have any Triggers.",
+      "desc_no_triggers": "Read more about <strong><a href=\"https://kestra.io/docs/workflow-components/triggers\" target=\"_blank\">Triggers</a></strong> in our documentation."
     },
     "open sidebar": "open sidebar",
     "close sidebar": "close sidebar",


### PR DESCRIPTION
Closes #5246 

https://github.com/user-attachments/assets/b23290d7-32fc-4e26-9c96-17b2fb47d151

Hi @anna-geller,

I checked & worked on it since it was unassigned given no updates since a month.