### PR TITLE
fix(ui): add state filters when pressed on see all in progress executions button in the dashboard(#5529)

### DIFF
--- a/ui/src/components/dashboard/components/tables/executions/InProgress.vue
+++ b/ui/src/components/dashboard/components/tables/executions/InProgress.vue
@@ -4,7 +4,18 @@
             <span class="fs-6 fw-bold">
                 {{ t("dashboard.executions_in_progress") }}
             </span>
-            <RouterLink :to="{name: 'executions/list'}">
+            <RouterLink
+                :to="{name: 'executions/list',
+                      query:{state:[
+                          'RUNNING',
+                          'RESTARTED',
+                          'CREATED',
+                          'PAUSED',
+                          'RETRYING',
+                          'QUEUED',
+                          'KILLING'
+                      ]}}"
+            >
                 <el-button type="primary" size="small" text>
                     {{ t("dashboard.see_all") }}
                 </el-button>

--- a/ui/src/components/dashboard/components/tables/executions/InProgress.vue
+++ b/ui/src/components/dashboard/components/tables/executions/InProgress.vue
@@ -7,13 +7,13 @@
             <RouterLink
                 :to="{name: 'executions/list',
                       query:{state:[
-                          'RUNNING',
-                          'RESTARTED',
-                          'CREATED',
-                          'PAUSED',
-                          'RETRYING',
-                          'QUEUED',
-                          'KILLING'
+                          State.RUNNING,
+                          State.RESTARTED,
+                          State.CREATED,
+                          State.PAUSED,
+                          State.RETRYING,
+                          State.QUEUED,
+                          State.KILLING
                       ]}}"
             >
                 <el-button type="primary" size="small" text>
@@ -129,6 +129,8 @@
     import {useI18n} from "vue-i18n";
 
     import moment from "moment";
+
+    import State from "../../../../../utils/state.js"
 
     import Status from "../../../../Status.vue";
     import NoData from "../../../../layout/NoData.vue";


### PR DESCRIPTION
<!-- Thanks for submitting a Pull Request to Kestra. To help us review your contribution, please follow the guidelines below:

- Make sure that your commits follow the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) specification e.g. `feat(ui): add a new navigation menu item` or `fix(core): fix a bug in the core model` or `docs: update the README.md`. This will help us automatically generate the changelog.
- The title should briefly summarize the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share a flow example to help the reviewer understand and QA the change.
- Use "closes" to automatically close an issue. For example, `closes #1234` will close issue #1234. -->

### What changes are being made and why?

<!-- Please include a brief summary of the changes included in this PR e.g. closes #1234. -->
closes #5529
---
Added a query for the router such that It shows only the in progress executions and not all of them as per the ask in the issue. 

### How the changes have been QAed?


Tested the functinality as if you press on the see all button, it will navagate you to the excution page with the state filiters applied, see the image below. 

![Screenshot 2024-12-23 100752](https://github.com/user-attachments/assets/ff8561c1-c911-4882-8a06-e7803298f949)


---

### Setup Instructions
no further setup needed
