### PR TITLE
fix(core): enable `runIf` property on flowable tasks

### DIFF
--- a/core/src/main/java/io/kestra/core/runners/ExecutorService.java
+++ b/core/src/main/java/io/kestra/core/runners/ExecutorService.java
@@ -15,6 +15,7 @@ import io.kestra.core.queues.QueueFactoryInterface;
 import io.kestra.core.queues.QueueInterface;
 import io.kestra.core.services.*;
 import io.kestra.core.utils.ListUtils;
+import io.kestra.core.utils.TruthUtils;
 import io.kestra.plugin.core.flow.Pause;
 import io.kestra.plugin.core.flow.Subflow;
 import io.kestra.plugin.core.flow.WaitFor;
@@ -831,6 +832,17 @@ public class ExecutorService {
                             .withTaskRun(executableTaskRun.withState(State.Type.RUNNING)),
                         "handleExecutableTaskRunning"
                     );
+
+                    // handle runIf
+                    if (!TruthUtils.isTruthy(workerTask.getRunContext().render(workerTask.getTask().getRunIf()))) {
+                        executor.withExecution(
+                            executor
+                                .getExecution()
+                                .withTaskRun(executableTaskRun.withState(State.Type.SKIPPED)),
+                            "handleExecutableTaskSkipped"
+                        );
+                        return false;
+                    }
 
                     RunContext runContext = runContextFactory.of(
                         executor.getFlow(),

--- a/core/src/test/java/io/kestra/core/runners/TaskWithRunIfTest.java
+++ b/core/src/test/java/io/kestra/core/runners/TaskWithRunIfTest.java
@@ -11,15 +11,16 @@ import io.kestra.core.models.flows.State;
 import org.junit.jupiter.api.Test;
 
 @KestraTest(startRunner = true)
-public class TaskWithRunIfTest {
+class TaskWithRunIfTest {
 
     @Test
     @ExecuteFlow("flows/valids/task-runif.yml")
     void runnableTask(Execution execution) {
         assertThat(execution.getState().getCurrent(), is(State.Type.FAILED));
-        assertThat(execution.getTaskRunList(), hasSize(4));
+        assertThat(execution.getTaskRunList(), hasSize(5));
         assertThat(execution.findTaskRunsByTaskId("executed").getFirst().getState().getCurrent(), is(State.Type.SUCCESS));
         assertThat(execution.findTaskRunsByTaskId("notexecuted").getFirst().getState().getCurrent(), is(State.Type.SKIPPED));
+        assertThat(execution.findTaskRunsByTaskId("notexecutedflowable").getFirst().getState().getCurrent(), is(State.Type.SKIPPED));
         assertThat(execution.findTaskRunsByTaskId("willfailedtheflow").getFirst().getState().getCurrent(), is(State.Type.FAILED));
     }
 

--- a/core/src/test/resources/flows/valids/task-runif.yml
+++ b/core/src/test/resources/flows/valids/task-runif.yml
@@ -15,6 +15,12 @@ tasks:
     runIf: "{{ outputs.output['values']['taskrun_data'] == 2 }}"
     message:
       - "should not be printed"
+  - id: notexecutedflowable
+    type: io.kestra.plugin.core.flow.Subflow
+    runIf: "false"
+    wait: true
+    flowId: dummy_flow
+    namespace: dummy_namespace
   - id: willfailedtheflow
     type: io.kestra.plugin.core.log.Log
     runIf: "{{ outputs.notexists == 2 }}"


### PR DESCRIPTION
### What changes are being made and why?

This PR attempts to enable the `runIf` functionality for every flowable task.

It seemed like an easy fix<sup>TM</sup> but it surely impacts the deep internals of the executor, so the taken approach might be very wrong 🙂

closes #6525