### PR TITLE
fix(ui): hide download/preview button for invalid file in execution/Outputs

### DIFF
--- a/ui/src/components/executions/VarValue.vue
+++ b/ui/src/components/executions/VarValue.vue
@@ -1,5 +1,5 @@
 <template>
-    <el-button-group v-if="isFile(value)">
+    <el-button-group v-if="isFileValid(value)">
         <a class="el-button el-button--small el-button--primary" :href="itemUrl(value)" target="_blank">
             <Download />
             {{ $t('download') }}
@@ -44,6 +44,9 @@
         methods: {
             isFile(value) {
                 return typeof(value) === "string" && value.startsWith("kestra:///")
+            },
+            isFileValid(value) {
+                return this.isFile(value) && this.humanSize && this.humanSize !== "0B"
             },
             isURI(value) {
                 try {

--- a/ui/src/components/executions/VarValue.vue
+++ b/ui/src/components/executions/VarValue.vue
@@ -46,6 +46,7 @@
                 return typeof(value) === "string" && value.startsWith("kestra:///")
             },
             isFileValid(value) {
+                // we don't want to display the file if it's not a file or if the size is 0
                 return this.isFile(value) && this.humanSize && this.humanSize !== "0B"
             },
             isURI(value) {


### PR DESCRIPTION
fixes #6514.


for a valid file - 
![image](https://github.com/user-attachments/assets/27afdf0b-d20c-463d-95a8-aa4b3a307d15)

when file is purged - 
![image](https://github.com/user-attachments/assets/2f5ccaa9-9c1c-45b5-83a1-cbecccd453fb)

