### PR TITLE
feat(core): restarting Subflow

### DIFF
--- a/core/src/main/java/io/kestra/core/models/Label.java
+++ b/core/src/main/java/io/kestra/core/models/Label.java
@@ -13,6 +13,7 @@ public record Label(@NotNull String key, @NotNull String value) {
     public static final String USERNAME = SYSTEM_PREFIX + "username";
     public static final String APP = SYSTEM_PREFIX + "app";
     public static final String READ_ONLY = SYSTEM_PREFIX + "readOnly";
+    public static final String RESTARTED = SYSTEM_PREFIX + "restarted";
 
     /**
      * Static helper method for converting a map to a list of labels.

--- a/core/src/main/java/io/kestra/core/models/hierarchies/SubflowGraphTask.java
+++ b/core/src/main/java/io/kestra/core/models/hierarchies/SubflowGraphTask.java
@@ -77,6 +77,11 @@ public class SubflowGraphTask extends AbstractGraphTask {
         }
 
         @Override
+        public RestartBehavior getRestartBehavior() {
+            return subflowTask.getRestartBehavior();
+        }
+
+        @Override
         public String getId() {
             return ((TaskInterface) subflowTask).getId();
         }

--- a/core/src/main/java/io/kestra/core/models/tasks/ExecutableTask.java
+++ b/core/src/main/java/io/kestra/core/models/tasks/ExecutableTask.java
@@ -43,6 +43,11 @@ public interface ExecutableTask<T extends Output>{
      */
     SubflowId subflowId();
 
+    /**
+     * Returns the restart behavior of subflow executions.
+     */
+    RestartBehavior getRestartBehavior();
+
     record SubflowId(String namespace, String flowId, Optional<Integer> revision) {
         public String flowUid() {
             // as the Flow task can only be used in the same tenant we can hardcode null here
@@ -53,5 +58,10 @@ public interface ExecutableTask<T extends Output>{
             // as the Flow task can only be used in the same tenant we can hardcode null here
             return Flow.uidWithoutRevision(null, this.namespace, this.flowId);
         }
+    }
+
+    enum RestartBehavior {
+        NEW_EXECUTION,
+        RETRY_FAILED
     }
 }

--- a/core/src/main/java/io/kestra/core/runners/ExecutableUtils.java
+++ b/core/src/main/java/io/kestra/core/runners/ExecutableUtils.java
@@ -11,7 +11,10 @@ import io.kestra.core.models.flows.State;
 import io.kestra.core.models.property.Property;
 import io.kestra.core.models.tasks.ExecutableTask;
 import io.kestra.core.models.tasks.Task;
+import io.kestra.core.repositories.ExecutionRepositoryInterface;
+import io.kestra.core.services.ExecutionService;
 import io.kestra.core.storages.Storage;
+import io.kestra.core.utils.MapUtils;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.stream.Streams;
 
@@ -53,7 +56,7 @@ public final class ExecutableUtils {
             .build();
     }
 
-    public static <T extends Task & ExecutableTask<?>> SubflowExecution<?> subflowExecution(
+    public static <T extends Task & ExecutableTask<?>> Optional<SubflowExecution<?>> subflowExecution(
         RunContext runContext,
         FlowExecutorInterface flowExecutorInterface,
         Execution currentExecution,
@@ -65,6 +68,50 @@ public final class ExecutableUtils {
         boolean inheritLabels,
         Property<ZonedDateTime> scheduleDate
     ) throws IllegalVariableEvaluationException {
+        // If we are in a flow that is restarted, we search for existing run of the task to restart them
+        if (currentExecution.getLabels().contains(new Label(Label.RESTARTED, "true")) && currentTask.getRestartBehavior() == ExecutableTask.RestartBehavior.RETRY_FAILED) {
+            ExecutionRepositoryInterface executionRepository = ((DefaultRunContext) runContext).getApplicationContext().getBean(ExecutionRepositoryInterface.class);
+
+            Optional<Execution> existingSubflowExecution = Optional.empty();
+            if (currentTaskRun.getOutputs() != null && currentTaskRun.getOutputs().containsKey("executionId")) {
+                // we know which execution to restart; this should be the case for Subflow tasks
+                existingSubflowExecution = executionRepository.findById(currentExecution.getTenantId(), (String) currentTaskRun.getOutputs().get("executionId"));
+            }
+
+            if (existingSubflowExecution.isEmpty()) {
+                // otherwise, we try to find the correct one; this should be the case for ForEachItem tasks
+                List<Execution> childExecutions = executionRepository.findAllByTriggerExecutionId(currentExecution.getTenantId(), currentExecution.getId())
+                    .filter(e -> e.getNamespace().equals(currentTask.subflowId().namespace()) && e.getFlowId().equals(currentTask.subflowId().flowId()) && e.getTrigger().getId().equals(currentTask.getId()))
+                    .filter(e -> Objects.equals(e.getTrigger().getVariables().get("taskRunId"), currentTaskRun.getId()) && Objects.equals(e.getTrigger().getVariables().get("taskRunValue"), currentTaskRun.getValue()) && Objects.equals(e.getTrigger().getVariables().get("taskRunIteration"), currentTaskRun.getIteration()))
+                    .collectList()
+                    .block();
+
+                if (childExecutions != null && childExecutions.size() == 1) {
+                    // if there are more than one, we ignore the results and create a new one
+                    existingSubflowExecution = Optional.of(childExecutions.getFirst());
+                }
+            }
+
+            if (existingSubflowExecution.isPresent()) {
+                Execution subflowExecution = existingSubflowExecution.get();
+                if (!subflowExecution.getState().isFailed()) {
+                    // don't restart it as it's terminated successfully
+                    return Optional.empty();
+                }
+                ExecutionService executionService = ((DefaultRunContext) runContext).getApplicationContext().getBean(ExecutionService.class);
+                try {
+                    Execution restarted = executionService.restart(subflowExecution, null);
+                    return Optional.of(SubflowExecution.builder()
+                        .parentTask(currentTask)
+                        .parentTaskRun(currentTaskRun.withState(State.Type.RUNNING))
+                        .execution(restarted)
+                        .build());
+                } catch (Exception e) {
+                    throw new RuntimeException(e);
+                }
+            }
+        }
+
         String subflowNamespace = runContext.render(currentTask.subflowId().namespace());
         String subflowId = runContext.render(currentTask.subflowId().flowId());
         Optional<Integer> subflowRevision = currentTask.subflowId().revision();
@@ -93,12 +140,19 @@ public final class ExecutableUtils {
             labels.forEach(throwConsumer(label -> newLabels.add(new Label(runContext.render(label.key()), runContext.render(label.value())))));
         }
 
-        Map<String, Object> variables = ImmutableMap.of(
+        var variables = ImmutableMap.<String, Object>builder().putAll(Map.of(
             "executionId", currentExecution.getId(),
             "namespace", currentFlow.getNamespace(),
             "flowId", currentFlow.getId(),
-            "flowRevision", currentFlow.getRevision()
-        );
+            "flowRevision", currentFlow.getRevision(),
+            "taskRunId", currentTaskRun.getId()
+        ));
+        if (currentTaskRun.getValue() != null) {
+            variables.put("taskRunValue", currentTaskRun.getValue());
+        }
+        if (currentTaskRun.getIteration() != null) {
+            variables.put("taskRunIteration", currentTaskRun.getIteration());
+        }
 
         FlowInputOutput flowInputOutput = ((DefaultRunContext)runContext).getApplicationContext().getBean(FlowInputOutput.class);
         Instant scheduleOnDate = runContext.render(scheduleDate).as(ZonedDateTime.class).map(date -> date.toInstant()).orElse(null);
@@ -111,15 +165,15 @@ public final class ExecutableUtils {
             .withTrigger(ExecutionTrigger.builder()
                 .id(currentTask.getId())
                 .type(currentTask.getType())
-                .variables(variables)
+                .variables(variables.build())
                 .build()
             )
             .withScheduleDate(scheduleOnDate);
-        return SubflowExecution.builder()
+        return Optional.of(SubflowExecution.builder()
             .parentTask(currentTask)
             .parentTaskRun(currentTaskRun.withState(State.Type.RUNNING))
             .execution(execution)
-            .build();
+            .build());
     }
 
     private static List<Label> systemLabels(Execution execution) {
@@ -142,7 +196,7 @@ public final class ExecutableUtils {
             Optional.empty();
 
         // search for the previous iterations, if not found, we init it with an empty map
-        Map<String, Integer> iterations = previousTaskRun.getOutputs() != null ?
+        Map<String, Integer> iterations = !MapUtils.isEmpty(previousTaskRun.getOutputs()) ?
             (Map<String, Integer>) previousTaskRun.getOutputs().get(TASK_VARIABLE_ITERATIONS) :
             new HashMap<>();
 
@@ -151,6 +205,11 @@ public final class ExecutableUtils {
         if (previousState.isPresent() && previousState.get() != currentState) {
             int previousStateIterations = iterations.getOrDefault(previousState.get().toString(), numberOfBatches);
             iterations.put(previousState.get().toString(), previousStateIterations - 1);
+
+            if (previousState.get() == State.Type.RESTARTED) {
+                // if we are in a restart, we need to reset the failed executions
+                iterations.put(State.Type.FAILED.toString(), 0);
+            }
         }
 
         // update the state to success if terminatedIterations == numberOfBatches

--- a/core/src/main/java/io/kestra/core/services/ExecutionService.java
+++ b/core/src/main/java/io/kestra/core/services/ExecutionService.java
@@ -3,6 +3,7 @@ package io.kestra.core.services;
 import io.kestra.core.events.CrudEvent;
 import io.kestra.core.events.CrudEventType;
 import io.kestra.core.exceptions.InternalException;
+import io.kestra.core.models.Label;
 import io.kestra.core.models.executions.Execution;
 import io.kestra.core.models.executions.ExecutionKilled;
 import io.kestra.core.models.executions.ExecutionKilledExecution;
@@ -213,7 +214,11 @@ public class ExecutionService {
                 execution.withState(State.Type.RESTARTED).getState()
             );
 
-        newExecution = newExecution.withMetadata(execution.getMetadata().nextAttempt());
+        List<Label> newLabels = new ArrayList<>(execution.getLabels());
+        if (!newLabels.contains(new Label(Label.RESTARTED, "true"))) {
+            newLabels.add(new Label(Label.RESTARTED, "true"));
+        }
+        newExecution = newExecution.withMetadata(execution.getMetadata().nextAttempt()).withLabels(newLabels);
 
         return revision != null ? newExecution.withFlowRevision(revision) : newExecution;
     }

--- a/core/src/test/java/io/kestra/core/runners/AbstractRunnerTest.java
+++ b/core/src/test/java/io/kestra/core/runners/AbstractRunnerTest.java
@@ -173,6 +173,12 @@ public abstract class AbstractRunnerTest {
         restartCaseTest.restartMultiple();
     }
 
+    @Test
+    @LoadFlows({"flows/valids/restart-parent.yaml", "flows/valids/restart-child.yaml"})
+    void restartSubflow() throws Exception {
+        restartCaseTest.restartSubflow();
+    }
+
     @RetryingTest(5)
     @LoadFlows({"flows/valids/trigger-flow-listener-no-inputs.yaml",
         "flows/valids/trigger-flow-listener.yaml",

--- a/core/src/test/java/io/kestra/core/runners/RestartTest.java
+++ b/core/src/test/java/io/kestra/core/runners/RestartTest.java
@@ -2,6 +2,7 @@ package io.kestra.core.runners;
 
 import io.kestra.core.junit.annotations.KestraTest;
 import io.kestra.core.junit.annotations.LoadFlows;
+import io.kestra.plugin.core.flow.ForEachItemCaseTest;
 import jakarta.inject.Inject;
 import org.junit.jupiter.api.Test;
 import org.junitpioneer.jupiter.RetryingTest;
@@ -10,6 +11,9 @@ import org.junitpioneer.jupiter.RetryingTest;
 public class RestartTest {
     @Inject
     private RestartCaseTest restartCaseTest;
+
+    @Inject
+    private ForEachItemCaseTest forEachItemCaseTest;
 
     @Test
     @LoadFlows({"flows/valids/restart_last_failed.yaml"})
@@ -33,5 +37,17 @@ public class RestartTest {
     @LoadFlows({"flows/valids/restart-each.yaml"})
     void replay() throws Exception {
         restartCaseTest.replay();
+    }
+
+    @Test
+    @LoadFlows({"flows/valids/restart-parent.yaml", "flows/valids/restart-child.yaml"})
+    void restartSubflow() throws Exception {
+        restartCaseTest.restartSubflow();
+    }
+
+    @Test
+    @LoadFlows({"flows/valids/restart-for-each-item.yaml", "flows/valids/restart-child.yaml"})
+    void restartForEachItem() throws Exception {
+        forEachItemCaseTest.restartForEachItem();
     }
 }

--- a/core/src/test/resources/flows/valids/restart-child.yaml
+++ b/core/src/test/resources/flows/valids/restart-child.yaml
@@ -1,0 +1,14 @@
+id: restart-child
+namespace: io.kestra.tests
+tasks:
+  - id: helloSubflow1
+    type: io.kestra.plugin.core.log.Log
+    message: Hello Subflow 1
+
+  - id: failFirstTime
+    type: io.kestra.plugin.core.log.Log
+    message: "{{ 1 / taskrun.attemptsCount }}"
+
+  - id: helloSubflow2
+    type: io.kestra.plugin.core.log.Log
+    message: Hello Subflow 2

--- a/core/src/test/resources/flows/valids/restart-for-each-item.yaml
+++ b/core/src/test/resources/flows/valids/restart-for-each-item.yaml
@@ -1,0 +1,21 @@
+id: restart-for-each-item
+namespace: io.kestra.tests
+
+inputs:
+  - id: file
+    type: FILE
+  - id: batch
+    type: INT
+
+tasks:
+  - id: each
+    type: io.kestra.plugin.core.flow.ForEachItem
+    items: "{{ inputs.file }}"
+    batch:
+      rows: "{{inputs.batch}}"
+    namespace: io.kestra.tests
+    flowId: restart-child
+    wait: true
+    transmitFailed: true
+    inputs:
+      items: "{{ taskrun.items }}"

--- a/core/src/test/resources/flows/valids/restart-parent.yaml
+++ b/core/src/test/resources/flows/valids/restart-parent.yaml
@@ -1,0 +1,22 @@
+id: restart-parent
+namespace: io.kestra.tests
+tasks:
+  - id: hello
+    type: io.kestra.plugin.core.log.Log
+    message: Hello Parent 1
+
+  - id: each
+    type: io.kestra.plugin.core.flow.ForEach
+    values: ["1", "2", "3"]
+    tasks:
+      - id: callSubflow
+        type: io.kestra.plugin.core.flow.Subflow
+        namespace: io.kestra.tests
+        flowId: restart-child
+        wait: true
+        transmitFailed: true
+        inheritLabels: true
+
+  - id: helloParent2
+    type: io.kestra.plugin.core.log.Log
+    message: Hello Parent 2


### PR DESCRIPTION
When restarting an execution, each `Subflow` and `ForEachItem` tasks will restart failing subflow executions instead of creating a new one. This behavior is manageable via the new `restartBehavior` property, configuring to `NEW_EXECUTION` will create new executions as before. If the subflow executions was in SUCCESS, it will not be restarted nor a new execution will be created, this is important for `ForEachItem`.

Fixes https://github.com/kestra-io/kestra-ee/issues/1399

Two changes:
- When restarting an execution, a system label is added so we know from the Subflow or ForEachItem task that we need to restart the child execution: `system.restarted: true`.
- Inside the subflow execution, the execution trigger variables have been enhanced with taskRun ID and taskRun value and taskRun iteration so we can find the correct execution to restart in case the Subflow is inside a ForEach
![image](https://github.com/user-attachments/assets/1cb8d05b-02fc-4611-8eb1-41fa011791e9)

