### PR TITLE
chore(ui): No limit on environment name in Settings.

### DIFF
--- a/ui/src/components/executions/Overview.vue
+++ b/ui/src/components/executions/Overview.vue
@@ -468,7 +468,7 @@
         }
 
         .text-end {
-            border-top: 1px solid var(--bs-border-color);
+            border-top: 1px solid var(--log-background-error);
         }
     }
 }

--- a/ui/src/components/settings/BasicSettings.vue
+++ b/ui/src/components/settings/BasicSettings.vue
@@ -131,6 +131,8 @@
                             @change="onEnvNameChange"
                             :placeholder="$t('name')"
                             clearable
+                            show-word-limit
+                            maxlength="15"
                         />
                     </Column>
 
@@ -561,5 +563,13 @@
 <style>
     .el-input-number {
         max-width: 20vw;
+    }
+
+    .el-input__count {
+        color: var(--bs-white) !important;
+        
+        .el-input__count-inner {
+            background: none !important;
+        }
     }
 </style>

--- a/ui/src/components/settings/BasicSettings.vue
+++ b/ui/src/components/settings/BasicSettings.vue
@@ -132,7 +132,7 @@
                             :placeholder="$t('name')"
                             clearable
                             show-word-limit
-                            maxlength="15"
+                            maxlength="30"
                         />
                     </Column>
 


### PR DESCRIPTION
Closes #3979 

Added Word limit based on possible env Name :
- Development
- Testing
- Staging
- Production
- Integration
- Cloud

Please remove `show-word-limit` incase not required but it would be better for user information.

Changes in `Overview.vue` is for matching the line color with error level.