### PR TITLE
feat(webserver): OpenAPI spec improvement

### DIFF
--- a/webserver/src/main/java/io/kestra/webserver/responses/PagedResults.java
+++ b/webserver/src/main/java/io/kestra/webserver/responses/PagedResults.java
@@ -7,11 +7,13 @@ import lombok.NoArgsConstructor;
 
 import jakarta.validation.constraints.NotNull;
 
+import java.util.List;
+
 @Getter
 @NoArgsConstructor
 public class PagedResults<T> {
     @NotNull
-    private ArrayListTotal<T> results;
+    private List<T> results;
 
     @JsonInclude
     @NotNull

--- a/webserver/src/test/java/io/kestra/webserver/controllers/api/BlueprintControllerTest.java
+++ b/webserver/src/test/java/io/kestra/webserver/controllers/api/BlueprintControllerTest.java
@@ -48,7 +48,7 @@ class BlueprintControllerTest {
         );
 
         assertThat(blueprintsWithTotal.getTotal(), is(2L));
-        ArrayListTotal<BlueprintController.BlueprintItem> blueprints = blueprintsWithTotal.getResults();
+        List<BlueprintController.BlueprintItem> blueprints = blueprintsWithTotal.getResults();
         assertThat(blueprints.size(), is(2));
         assertThat(blueprints.getFirst().getId(), is("1"));
         assertThat(blueprints.getFirst().getTitle(), is("GCS Trigger"));

--- a/webserver/src/test/java/io/kestra/webserver/controllers/api/NamespaceControllerTest.java
+++ b/webserver/src/test/java/io/kestra/webserver/controllers/api/NamespaceControllerTest.java
@@ -69,7 +69,7 @@ public class NamespaceControllerTest {
         assertThat(list.getTotal(), is(6L));
         assertThat(list.getResults().size(), is(6));
         assertThat(list.getResults(), everyItem(hasProperty("disabled", is(true))));
-        assertThat(list.getResults().map(NamespaceWithDisabled::getId), containsInAnyOrder(
+        assertThat(list.getResults().stream().map(NamespaceWithDisabled::getId).toList(), containsInAnyOrder(
             "my", "my.ns", "my.ns.flow",
             "another", "another.ns", "system"
         ));


### PR DESCRIPTION
Previously, PagedResult contains ArrayListTotal which is a list with a total in it. But due to that, ArrayListTotal is not recognized as an array for the OpenAPI spec so all the endpoints that use it generates incorrect specification. Switching to a list fixes the issue.
The serialized form is not impacted.

Before this change, the definition of PagedResult was as follow:

```yaml
    PagedResults_Flow_:
      required:
      - results
      - total
      type: object
      properties:
        results:
          $ref: "#/components/schemas/ArrayListTotal_Flow_"
        total:
          type: integer
          format: int64
          
     ArrayListTotal_Flow_:
      required:
      - total
      type: object
      allOf:
      - $ref: "#/components/schemas/ArrayList_Flow_"
      - $ref: "#/components/schemas/AbstractList_Flow_"
      - $ref: "#/components/schemas/AbstractCollection_Flow_"
      - properties:
          first:
            $ref: "#/components/schemas/Flow"
          last:
            $ref: "#/components/schemas/Flow"
          empty:
            type: boolean
          total:
            type: integer
            format: int64
```

With this change it is now only that (there are no more ArrayListTotal_*_ definitions)
```yaml
    PagedResults_Flow_:
      required:
      - results
      - total
      type: object
      properties:
        results:
          type: array
          items:
            $ref: "#/components/schemas/Flow"
        total:
          type: integer
          format: int64
```