### PR TITLE
fix(storage-local): path traversal guard should include File.separator

### DIFF
--- a/core/src/main/java/io/kestra/core/storages/StorageInterface.java
+++ b/core/src/main/java/io/kestra/core/storages/StorageInterface.java
@@ -100,4 +100,13 @@ public interface StorageInterface extends AutoCloseable, Plugin {
         URI uri = StorageContext.forInput(execution, input, file.getName()).getContextStorageURI();
         return this.put(execution.getTenantId(), execution.getNamespace(), uri, new BufferedInputStream(new FileInputStream(file)));
     }
+
+    /**
+     * Throws an IllegalArgumentException if the URI is not absolute: a.k.a., if it contains <code>".." + File.separator</code>.
+     */
+    default void parentTraversalGuard(URI uri) {
+        if (uri != null && uri.toString().contains(".." + File.separator)) {
+            throw new IllegalArgumentException("File should be accessed with their full path and not using relative '..' path.");
+        }
+    }
 }

--- a/core/src/test/java/io/kestra/plugin/core/http/DownloadTest.java
+++ b/core/src/test/java/io/kestra/plugin/core/http/DownloadTest.java
@@ -200,6 +200,25 @@ class DownloadTest {
         }
     }
 
+    @Test
+    void contentDispositionWithDoubleDot() throws Exception {
+        EmbeddedServer embeddedServer = applicationContext.getBean(EmbeddedServer.class);
+        embeddedServer.start();
+
+        Download task = Download.builder()
+            .id(DownloadTest.class.getSimpleName())
+            .type(DownloadTest.class.getName())
+            .uri(embeddedServer.getURI() + "/content-disposition-double-dot")
+            .build();
+
+        RunContext runContext = TestsUtils.mockRunContext(this.runContextFactory, task, ImmutableMap.of());
+
+        Download.Output output = task.run(runContext);
+
+        assertThat(output.getUri().toString(), not(containsString("/secure-path/")));
+        assertThat(output.getUri().toString(), endsWith("filename..jpg"));
+    }
+
     @Controller()
     public static class SlackWebController {
         @Get("500")
@@ -233,6 +252,12 @@ class DownloadTest {
         public HttpResponse<byte[]> contentDispositionWithPath() {
             return HttpResponse.ok("Hello World".getBytes())
                 .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=\"/secure-path/filename.jpg\"");
+        }
+
+        @Get("content-disposition-double-dot")
+        public HttpResponse<byte[]> contentDispositionWithDoubleDot() {
+            return HttpResponse.ok("Hello World".getBytes())
+                .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=\"/secure-path/filename..jpg\"");
         }
     }
 }

--- a/storage-local/src/main/java/io/kestra/storage/local/LocalStorage.java
+++ b/storage-local/src/main/java/io/kestra/storage/local/LocalStorage.java
@@ -233,6 +233,7 @@ public class LocalStorage implements StorageInterface {
                 .toList();
         }
     }
+
     private URI getKestraUri(String tenantId, Path path) {
         Path prefix = (tenantId == null) ?
             basePath.toAbsolutePath():
@@ -244,12 +245,6 @@ public class LocalStorage implements StorageInterface {
     private void subPathParentGuard(Path path, Path prefix) {
         if (!path.toAbsolutePath().startsWith(prefix)) {
             throw new IllegalArgumentException("The path must be a subpath of the base path with the tenant ID.");
-        }
-    }
-
-    private void parentTraversalGuard(URI uri) {
-        if (uri.toString().contains("..")) {
-            throw new IllegalArgumentException("File should be accessed with their full path and not using relative '..' path.");
         }
     }
 }


### PR DESCRIPTION
Today, we check that a file didn't contains '..' which is too aggressive, we should check that it didn't contains '../' or '..\' only.

Fixes #6629
Will be backported to 0.20, however it also needs the same fix on all storage implementation.
