### PR TITLE
chore(core): tiny perf improvement in MapUtils.merge()

### DIFF
--- a/core/src/main/java/io/kestra/core/utils/MapUtils.java
+++ b/core/src/main/java/io/kestra/core/utils/MapUtils.java
@@ -18,11 +18,11 @@ public class MapUtils {
         }
 
         if (a == null || a.isEmpty()) {
-            return copyMap(b);
+            return b;
         }
 
         if (b == null || b.isEmpty()) {
-            return copyMap(a);
+            return a;
         }
 
         Map copy = copyMap(a);


### PR DESCRIPTION
MapUtils.merge() unnecessarily clone the map when there is only one map that is not null and not empty, which is not needed as the map is not modified but returned immediately.