### PR TITLE
fix(core): render errors as tasks in outputs correctly. add errors to…

### DIFF
--- a/core/src/main/java/io/kestra/core/models/flows/FlowForExecution.java
+++ b/core/src/main/java/io/kestra/core/models/flows/FlowForExecution.java
@@ -22,6 +22,9 @@ public class FlowForExecution extends AbstractFlow {
     List<TaskForExecution> tasks;
 
     @Valid
+    List<TaskForExecution> errors;
+
+    @Valid
     List<AbstractTriggerForExecution> triggers;
 
     public static FlowForExecution of(Flow flow) {
@@ -32,6 +35,7 @@ public class FlowForExecution extends AbstractFlow {
             .revision(flow.getRevision())
             .inputs(flow.getInputs())
             .tasks(flow.getTasks().stream().map(TaskForExecution::of).toList())
+            .errors(flow.getErrors().stream().map(TaskForExecution::of).toList())
             .triggers(ListUtils.emptyOnNull(flow.getTriggers()).stream().map(AbstractTriggerForExecution::of).toList())
             .disabled(flow.isDisabled())
             .deleted(flow.isDeleted())

--- a/core/src/main/java/io/kestra/core/models/flows/FlowForExecution.java
+++ b/core/src/main/java/io/kestra/core/models/flows/FlowForExecution.java
@@ -35,7 +35,7 @@ public class FlowForExecution extends AbstractFlow {
             .revision(flow.getRevision())
             .inputs(flow.getInputs())
             .tasks(flow.getTasks().stream().map(TaskForExecution::of).toList())
-            .errors(flow.getErrors().stream().map(TaskForExecution::of).toList())
+            .errors(ListUtils.emptyOnNull(flow.getErrors()).stream().map(TaskForExecution::of).toList())
             .triggers(ListUtils.emptyOnNull(flow.getTriggers()).stream().map(AbstractTriggerForExecution::of).toList())
             .disabled(flow.isDisabled())
             .deleted(flow.isDeleted())

--- a/ui/src/components/executions/outputs/Wrapper.vue
+++ b/ui/src/components/executions/outputs/Wrapper.vue
@@ -417,6 +417,7 @@
         const mapped = {};
 
         getTaskIcons(store.state.execution?.flow?.tasks || [], mapped);
+        getTaskIcons(store.state.execution?.flow?.errors || [], mapped);
 
         return mapped;
     });


### PR DESCRIPTION
… server response data

<!-- Thanks for submitting a Pull Request to Kestra. To help us review your contribution, please follow the guidelines below:

- Make sure that your commits follow the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) specification e.g. `feat(ui): add a new navigation menu item` or `fix(core): fix a bug in the core model` or `docs: update the README.md`. This will help us automatically generate the changelog.
- The title should briefly summarize the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share a flow example to help the reviewer understand and QA the change.
- Use "closes" to automatically close an issue. For example, `closes #1234` will close issue #1234. -->

### What changes are being made and why?

I have add `errors` to be sent in response for execution flows.
so that cls can be populated in TaskIcon correctly with the task.type. As for errors it was coming undefined earlier it was not able to find the icon in all icons.

This PR closes #5643.
<!-- Please include a brief summary of the changes included in this PR e.g. closes #1234. -->

---

### How the changes have been QAed?
tested the changes locally. please check out the image below.

<img width="1437" alt="Screenshot 2025-01-07 at 5 04 23 PM" src="https://github.com/user-attachments/assets/0068d68e-ad9e-469a-8619-dec33c991a8c" />

<!-- Include example code that shows how this PR has been QAed. The code should present a complete yet easily reproducible flow.

```yaml
# Your example flow code here
```

Note that this is not a replacement for unit tests but rather a way to demonstrate how the changes work in a real-life scenario, as the end-user would experience them. 

Remove this section if this change applies to all flows or to the documentation only. -->

---
