### PR TITLE
feat(core, ui, webserver): add replay system labels

### DIFF
--- a/core/src/main/java/io/kestra/core/models/Label.java
+++ b/core/src/main/java/io/kestra/core/models/Label.java
@@ -14,6 +14,8 @@ public record Label(@NotNull String key, @NotNull String value) {
     public static final String APP = SYSTEM_PREFIX + "app";
     public static final String READ_ONLY = SYSTEM_PREFIX + "readOnly";
     public static final String RESTARTED = SYSTEM_PREFIX + "restarted";
+    public static final String REPLAY = SYSTEM_PREFIX + "replay";
+    public static final String REPLAYED = SYSTEM_PREFIX + "replayed";
 
     /**
      * Static helper method for converting a map to a list of labels.

--- a/core/src/main/java/io/kestra/core/services/ExecutionService.java
+++ b/core/src/main/java/io/kestra/core/services/ExecutionService.java
@@ -297,7 +297,11 @@ public class ExecutionService {
             taskRunId == null ? new State() : execution.withState(State.Type.RESTARTED).getState()
         );
 
-        newExecution = newExecution.withMetadata(execution.getMetadata().nextAttempt());
+        List<Label> newLabels = new ArrayList<>(execution.getLabels());
+        if (!newLabels.contains(new Label(Label.REPLAY, "true"))) {
+            newLabels.add(new Label(Label.REPLAY, "true"));
+        }
+        newExecution = newExecution.withMetadata(execution.getMetadata().nextAttempt()).withLabels(newLabels);
 
         return revision != null ? newExecution.withFlowRevision(revision) : newExecution;
     }

--- a/core/src/test/java/io/kestra/core/runners/ExecutionServiceTest.java
+++ b/core/src/test/java/io/kestra/core/runners/ExecutionServiceTest.java
@@ -4,6 +4,7 @@ import com.google.common.collect.ImmutableMap;
 import io.kestra.core.junit.annotations.ExecuteFlow;
 import io.kestra.core.junit.annotations.KestraTest;
 import io.kestra.core.junit.annotations.LoadFlows;
+import io.kestra.core.models.Label;
 import io.kestra.core.models.executions.Execution;
 import io.kestra.core.models.flows.Flow;
 import io.kestra.core.models.flows.FlowWithSource;
@@ -62,9 +63,9 @@ class ExecutionServiceTest {
         assertThat(restart.getTaskRunList(), hasSize(3));
         assertThat(restart.getTaskRunList().get(2).getState().getCurrent(), is(State.Type.RESTARTED));
         assertThat(restart.getTaskRunList().get(2).getState().getHistories(), hasSize(4));
-
         assertThat(restart.getId(), is(execution.getId()));
         assertThat(restart.getTaskRunList().get(2).getId(), is(execution.getTaskRunList().get(2).getId()));
+        assertThat(restart.getLabels(), hasItem(new Label(Label.RESTARTED, "true")));
     }
 
     @Test
@@ -97,9 +98,9 @@ class ExecutionServiceTest {
         assertThat(restart.getTaskRunList(), hasSize(3));
         assertThat(restart.getTaskRunList().get(2).getState().getCurrent(), is(State.Type.RESTARTED));
         assertThat(restart.getTaskRunList().get(2).getState().getHistories(), hasSize(4));
-
         assertThat(restart.getId(), not(execution.getId()));
         assertThat(restart.getTaskRunList().get(2).getId(), not(execution.getTaskRunList().get(2).getId()));
+        assertThat(restart.getLabels(), hasItem(new Label(Label.RESTARTED, "true")));
     }
 
     @RetryingTest(5)
@@ -115,6 +116,7 @@ class ExecutionServiceTest {
         assertThat(restart.getTaskRunList().stream().filter(taskRun -> taskRun.getState().getCurrent() == State.Type.RESTARTED).count(), greaterThan(1L));
         assertThat(restart.getTaskRunList().stream().filter(taskRun -> taskRun.getState().getCurrent() == State.Type.RUNNING).count(), greaterThan(1L));
         assertThat(restart.getTaskRunList().getFirst().getId(), is(restart.getTaskRunList().getFirst().getId()));
+        assertThat(restart.getLabels(), hasItem(new Label(Label.RESTARTED, "true")));
     }
 
     @RetryingTest(5)
@@ -130,6 +132,7 @@ class ExecutionServiceTest {
         assertThat(restart.getTaskRunList().stream().filter(taskRun -> taskRun.getState().getCurrent() == State.Type.RESTARTED).count(), greaterThan(1L));
         assertThat(restart.getTaskRunList().stream().filter(taskRun -> taskRun.getState().getCurrent() == State.Type.RUNNING).count(), greaterThan(1L));
         assertThat(restart.getTaskRunList().getFirst().getId(), is(restart.getTaskRunList().getFirst().getId()));
+        assertThat(restart.getLabels(), hasItem(new Label(Label.RESTARTED, "true")));
     }
 
     @Test
@@ -145,6 +148,7 @@ class ExecutionServiceTest {
 
         assertThat(restart.getTaskRunList().getFirst().getState().getCurrent(), is(State.Type.RESTARTED));
         assertThat(restart.getTaskRunList().getFirst().getState().getHistories(), hasSize(4));
+        assertThat(restart.getLabels(), hasItem(new Label(Label.RESTARTED, "true")));
     }
 
     @Test
@@ -164,8 +168,8 @@ class ExecutionServiceTest {
         assertThat(restart.getState().getHistories(), hasSize(1));
         assertThat(restart.getState().getHistories().getFirst().getDate(), not(is(execution.getState().getStartDate())));
         assertThat(restart.getTaskRunList(), hasSize(0));
-
         assertThat(restart.getId(), not(execution.getId()));
+        assertThat(restart.getLabels(), hasItem(new Label(Label.REPLAY, "true")));
     }
 
     @Test
@@ -182,9 +186,9 @@ class ExecutionServiceTest {
         assertThat(restart.getTaskRunList(), hasSize(2));
         assertThat(restart.getTaskRunList().get(1).getState().getCurrent(), is(State.Type.RESTARTED));
         assertThat(restart.getTaskRunList().get(1).getState().getHistories(), hasSize(4));
-
         assertThat(restart.getId(), not(execution.getId()));
         assertThat(restart.getTaskRunList().get(1).getId(), not(execution.getTaskRunList().get(1).getId()));
+        assertThat(restart.getLabels(), hasItem(new Label(Label.REPLAY, "true")));
     }
 
     @Test
@@ -200,9 +204,9 @@ class ExecutionServiceTest {
         assertThat(restart.getState().getHistories(), hasSize(4));
         assertThat(restart.getTaskRunList(), hasSize(20));
         assertThat(restart.getTaskRunList().get(19).getState().getCurrent(), is(State.Type.RESTARTED));
-
         assertThat(restart.getId(), not(execution.getId()));
         assertThat(restart.getTaskRunList().get(1).getId(), not(execution.getTaskRunList().get(1).getId()));
+        assertThat(restart.getLabels(), hasItem(new Label(Label.REPLAY, "true")));
     }
 
     @Test
@@ -222,6 +226,7 @@ class ExecutionServiceTest {
 
         assertThat(restart.getId(), not(execution.getId()));
         assertThat(restart.getTaskRunList().get(1).getId(), not(execution.getTaskRunList().get(1).getId()));
+        assertThat(restart.getLabels(), hasItem(new Label(Label.REPLAY, "true")));
     }
 
     @Test
@@ -241,6 +246,7 @@ class ExecutionServiceTest {
 
         assertThat(restart.getId(), not(execution.getId()));
         assertThat(restart.getTaskRunList().get(1).getId(), not(execution.getTaskRunList().get(1).getId()));
+        assertThat(restart.getLabels(), hasItem(new Label(Label.REPLAY, "true")));
     }
 
     @Test
@@ -260,6 +266,7 @@ class ExecutionServiceTest {
 
         assertThat(restart.getId(), not(execution.getId()));
         assertThat(restart.getTaskRunList().get(1).getId(), not(execution.getTaskRunList().get(1).getId()));
+        assertThat(restart.getLabels(), hasItem(new Label(Label.REPLAY, "true")));
     }
 
     @Test
@@ -279,6 +286,7 @@ class ExecutionServiceTest {
 
         assertThat(restart.getId(), not(execution.getId()));
         assertThat(restart.getTaskRunList().get(1).getId(), not(execution.getTaskRunList().get(1).getId()));
+        assertThat(restart.getLabels(), hasItem(new Label(Label.REPLAY, "true")));
     }
 
     @Test
@@ -298,6 +306,7 @@ class ExecutionServiceTest {
 
         assertThat(restart.getId(), not(execution.getId()));
         assertThat(restart.getTaskRunList().get(1).getId(), not(execution.getTaskRunList().get(1).getId()));
+        assertThat(restart.getLabels(), hasItem(new Label(Label.REPLAY, "true")));
     }
 
     @Test

--- a/ui/src/components/executions/Overview.vue
+++ b/ui/src/components/executions/Overview.vue
@@ -39,6 +39,26 @@
             </el-alert>
         </div>
 
+        <div v-if="isReplayed()">
+            <el-alert type="info" :closable="false" class="mb-4 main-info">
+                <template #title>
+                    <div>
+                        {{ $t('execution replayed') }}
+                    </div>
+                </template>
+            </el-alert>
+        </div>
+
+        <div v-if="isReplay()">
+            <el-alert type="info" :closable="false" class="mb-4 main-info">
+                <template #title>
+                    <div>
+                        <span v-html="$t('execution replay', {originalId: execution?.originalId})" />
+                    </div>
+                </template>
+            </el-alert>
+        </div>
+
         <el-row class="mb-3">
             <el-col :span="12" class="crud-align">
                 <crud type="CREATE" permission="EXECUTION" :detail="{executionId: execution.id}" />
@@ -213,6 +233,12 @@
             },
             isRestarted() {
                 return this.execution.labels?.find( it => it.key === "system.restarted" && (it.value === "true" || it.value === true)) !== undefined;
+            },
+            isReplayed() {
+                return this.execution.labels?.find( it => it.key === "system.replayed" && (it.value === "true" || it.value === true)) !== undefined;
+            },
+            isReplay() {
+                return this.execution.labels?.find( it => it.key === "system.replay" && (it.value === "true" || it.value === true)) !== undefined;
             },
             load() {
                 this.$store

--- a/ui/src/translations/de.json
+++ b/ui/src/translations/de.json
@@ -1041,6 +1041,8 @@
     "execution restarted": "Diese Ausführung wurde {nbRestart} Mal neu gestartet.",
     "chart": "Diagramm",
     "source only": "Nur Quelle",
-    "chart preview": "Diagrammvorschau"
+    "chart preview": "Diagrammvorschau",
+    "execution replayed": "Diese Ausführung wurde erneut abgespielt.",
+    "execution replay": "Diese Ausführung ist eine Wiederholung von <code>{originalId}</code>."
   }
 }

--- a/ui/src/translations/en.json
+++ b/ui/src/translations/en.json
@@ -990,6 +990,8 @@
     "execution failed header": "Execution failed!",
     "execution failed message": "With last error: <code>{message}</code>",
     "execution restarted": "This execution has been restarted {nbRestart} time(s).",
+    "execution replay": "This execution is a replay of <code>{originalId}</code>.",
+    "execution replayed": "This execution has been replayed.",
     "task run id": "TaskRun ID",
     "active": "Active",
     "flows imported": "Flows imported",

--- a/ui/src/translations/es.json
+++ b/ui/src/translations/es.json
@@ -1041,6 +1041,8 @@
     "execution restarted": "Esta ejecución se ha reiniciado {nbRestart} vez/veces.",
     "chart": "Gráfico",
     "source only": "Solo fuente",
-    "chart preview": "Vista previa del gráfico"
+    "chart preview": "Vista previa del gráfico",
+    "execution replayed": "Esta ejecución ha sido reproducida.",
+    "execution replay": "Esta ejecución es una repetición de <code>{originalId}</code>."
   }
 }

--- a/ui/src/translations/fr.json
+++ b/ui/src/translations/fr.json
@@ -1041,6 +1041,8 @@
     "execution restarted": "Cette exécution a été redémarrée {nbRestart} fois.",
     "chart": "Graphique",
     "source only": "Source uniquement",
-    "chart preview": "Aperçu du graphique"
+    "chart preview": "Aperçu du graphique",
+    "execution replayed": "Cette exécution a été rejouée.",
+    "execution replay": "Cette exécution est une relecture de <code>{originalId}</code>."
   }
 }

--- a/ui/src/translations/hi.json
+++ b/ui/src/translations/hi.json
@@ -1041,6 +1041,8 @@
     "execution restarted": "इस execution को {nbRestart} बार पुनः प्रारंभ किया गया है।",
     "chart": "चार्ट",
     "source only": "केवल स्रोत",
-    "chart preview": "चार्ट पूर्वावलोकन"
+    "chart preview": "चार्ट पूर्वावलोकन",
+    "execution replayed": "इस execution को पुनः चलाया गया है।",
+    "execution replay": "यह execution <code>{originalId}</code> का पुनरावर्तन है।"
   }
 }

--- a/ui/src/translations/it.json
+++ b/ui/src/translations/it.json
@@ -1041,6 +1041,8 @@
     "execution restarted": "Questa esecuzione è stata riavviata {nbRestart} volta(e).",
     "chart": "Grafico",
     "source only": "Solo sorgente",
-    "chart preview": "Anteprima del grafico"
+    "chart preview": "Anteprima del grafico",
+    "execution replayed": "Questa esecuzione è stata ripetuta.",
+    "execution replay": "Questa esecuzione è una ripetizione di <code>{originalId}</code>."
   }
 }

--- a/ui/src/translations/ja.json
+++ b/ui/src/translations/ja.json
@@ -1041,6 +1041,8 @@
     "execution restarted": "この実行は{nbRestart}回再開されました。",
     "chart": "チャート",
     "source only": "ソースのみ",
-    "chart preview": "チャートプレビュー"
+    "chart preview": "チャートプレビュー",
+    "execution replayed": "この実行は再実行されました。",
+    "execution replay": "この実行は<code>{originalId}</code>のリプレイです。"
   }
 }

--- a/ui/src/translations/ko.json
+++ b/ui/src/translations/ko.json
@@ -1041,6 +1041,8 @@
     "execution restarted": "이 실행은 {nbRestart}번 다시 시작되었습니다.",
     "chart": "차트",
     "source only": "소스 전용",
-    "chart preview": "차트 미리보기"
+    "chart preview": "차트 미리보기",
+    "execution replayed": "이 실행은 재생되었습니다.",
+    "execution replay": "이 실행은 <code>{originalId}</code>의 재실행입니다."
   }
 }

--- a/ui/src/translations/pl.json
+++ b/ui/src/translations/pl.json
@@ -1041,6 +1041,8 @@
     "execution restarted": "Ta wykonanie zostało ponownie uruchomione {nbRestart} raz(y).",
     "chart": "Wykres",
     "source only": "Tylko źródło",
-    "chart preview": "Podgląd wykresu"
+    "chart preview": "Podgląd wykresu",
+    "execution replayed": "To wykonanie zostało odtworzone.",
+    "execution replay": "To wykonanie jest powtórką <code>{originalId}</code>."
   }
 }

--- a/ui/src/translations/pt.json
+++ b/ui/src/translations/pt.json
@@ -1041,6 +1041,8 @@
     "execution restarted": "Esta execução foi reiniciada {nbRestart} vez(es).",
     "chart": "Gráfico",
     "source only": "Somente fonte",
-    "chart preview": "Pré-visualização do gráfico"
+    "chart preview": "Pré-visualização do gráfico",
+    "execution replayed": "Esta execução foi reproduzida.",
+    "execution replay": "Esta execução é uma repetição de <code>{originalId}</code>."
   }
 }

--- a/ui/src/translations/ru.json
+++ b/ui/src/translations/ru.json
@@ -1041,6 +1041,8 @@
     "execution restarted": "Это выполнение было перезапущено {nbRestart} раз(а).",
     "chart": "Диаграмма",
     "source only": "Только источник",
-    "chart preview": "Предварительный просмотр диаграммы"
+    "chart preview": "Предварительный просмотр диаграммы",
+    "execution replayed": "Это выполнение было воспроизведено.",
+    "execution replay": "Это выполнение является повтором <code>{originalId}</code>."
   }
 }

--- a/ui/src/translations/zh_CN.json
+++ b/ui/src/translations/zh_CN.json
@@ -1041,6 +1041,8 @@
     "execution restarted": "此执行已重新启动{nbRestart}次。",
     "chart": "图表",
     "source only": "仅限来源",
-    "chart preview": "图表预览"
+    "chart preview": "图表预览",
+    "execution replayed": "此执行已被重放。",
+    "execution replay": "此执行是 <code>{originalId}</code> 的重放。"
   }
 }


### PR DESCRIPTION
- Add system.replay to executions that are a replay
- Add system.replayed to executions that have been replayed

Fixes #6682

New info block for executions that are a replay
![image](https://github.com/user-attachments/assets/100f0d5e-5833-43dd-844b-f29ff11edc77)

New warning block for executions that have been replayed
![image](https://github.com/user-attachments/assets/5fb4a2f9-d38d-4721-a9d1-23bdebdfc36d)

