### PR TITLE
feat(core): validate in editor if subflow with namespace present

### DIFF
--- a/core/src/test/java/io/kestra/core/services/FlowServiceTest.java
+++ b/core/src/test/java/io/kestra/core/services/FlowServiceTest.java
@@ -8,8 +8,8 @@ import io.kestra.core.models.flows.input.StringInput;
 import io.kestra.core.repositories.FlowRepositoryInterface;
 import io.kestra.plugin.core.debug.Echo;
 import io.kestra.plugin.core.debug.Return;
-import io.kestra.plugin.core.log.Log;
 import jakarta.inject.Inject;
+import jakarta.validation.ConstraintViolationException;
 import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
@@ -20,6 +20,7 @@ import java.util.stream.Stream;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @KestraTest
@@ -309,5 +310,33 @@ class FlowServiceTest {
         Flow flow = create("findByTest", "test", 1).toBuilder().namespace("some.namespace").build();
         flowRepository.create(flow, flow.generateSource(), flow);
         assertThat(flowService.findByNamespacePrefix(null, "some.namespace").size(), is(1));
+    }
+
+    @Test
+    void findById() {
+        Flow flow = create("findByIdTest", "test", 1);
+        FlowWithSource saved = flowRepository.create(flow, flow.generateSource(), flow);
+        assertThat(flowService.findById(null, saved.getNamespace(), saved.getId()).isPresent(), is(true));
+    }
+
+    @Test
+    void checkValidSubflowsNotFound() {
+        Flow flow = create("mainFlow", "task", 1).toBuilder()
+            .tasks(List.of(
+                io.kestra.plugin.core.flow.Subflow.builder()
+                    .id("subflowTask")
+                    .type(io.kestra.plugin.core.flow.Subflow.class.getName())
+                    .namespace("io.kestra.unittest")
+                    .flowId("nonExistentSubflow")
+                    .build()
+            ))
+            .build();
+
+        ConstraintViolationException exception = assertThrows(ConstraintViolationException.class, () -> {
+            flowService.checkValidSubflows(flow);
+        });
+
+        assertThat(exception.getConstraintViolations().size(), is(1));
+        assertThat(exception.getConstraintViolations().iterator().next().getMessage(), is("The subflow 'nonExistentSubflow' not found in namespace 'io.kestra.unittest'."));
     }
 }

--- a/webserver/src/main/java/io/kestra/webserver/controllers/api/FlowController.java
+++ b/webserver/src/main/java/io/kestra/webserver/controllers/api/FlowController.java
@@ -425,7 +425,7 @@ public class FlowController {
             return HttpResponse.status(HttpStatus.NOT_FOUND);
         }
         Flow flowParsed = yamlParser.parse(flow, Flow.class);
-
+        flowService.checkValidSubflows(flowParsed);
         return HttpResponse.ok(update(flowParsed, existingFlow.get(), flow));
     }
 
@@ -588,6 +588,7 @@ public class FlowController {
                     validateConstraintViolationBuilder.namespace(flowParse.getNamespace());
 
                     modelValidator.validate(pluginDefaultService.injectDefaults(flowParse.withSource(flow)));
+                    flowService.checkValidSubflows(flowParse);
                 } catch (ConstraintViolationException e) {
                     validateConstraintViolationBuilder.constraints(e.getMessage());
                 } catch (RuntimeException re) {


### PR DESCRIPTION
<!-- Thanks for submitting a Pull Request to Kestra. To help us review your contribution, please follow the guidelines below:

- Make sure that your commits follow the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) specification e.g. `feat(ui): add a new navigation menu item` or `fix(core): fix a bug in the core model` or `docs: update the README.md`. This will help us automatically generate the changelog.
- The title should briefly summarize the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share a flow example to help the reviewer understand and QA the change.
- Use "closes" to automatically close an issue. For example, `closes #1234` will close issue #1234. -->

### What changes are being made and why?

- added validation for subflows in task are present with the mentioned namespace.
- validation runs when saving the file and making any changes in editor.

closes #2087 

<!-- Please include a brief summary of the changes included in this PR e.g. closes #1234. -->

---

### How the changes have been QAed?

Tested changes locally on a standalone server. please screen recording below.


https://github.com/user-attachments/assets/b98eb776-893c-4e86-a48b-8f70688fbcde




<!-- Include example code that shows how this PR has been QAed. The code should present a complete yet easily reproducible flow.

```yaml
# Your example flow code here
```

Note that this is not a replacement for unit tests but rather a way to demonstrate how the changes work in a real-life scenario, as the end-user would experience them.

Remove this section if this change applies to all flows or to the documentation only. -->

---