### PR TITLE
chore(ui): Mark taskruns that have attemps in the Gantt view.

### DIFF
--- a/ui/src/components/executions/Gantt.vue
+++ b/ui/src/components/executions/Gantt.vue
@@ -39,6 +39,17 @@
                                         <small v-if="item.task && item.task.value"> {{ item.task.value }}</small>
                                     </span>
                                 </el-tooltip>
+                                <div>
+                                    <el-tooltip placement="right" :persistent="false" transition="" :hide-after="0" effect="light">
+                                        <template #content>
+                                            <span>This task has {{ item.attempts }} attempts.</span>
+                                        </template>
+                                        <Warning 
+                                            v-if="item.attempts > 1" 
+                                            class="attempt_warn me-3" 
+                                        />
+                                    </el-tooltip>
+                                </div>
                                 <div :style="'width: ' + (100 / (dates.length + 1)) * dates.length + '%'">
                                     <el-tooltip placement="top" :persistent="false" transition="" :hide-after="0" effect="light">
                                         <template #content>
@@ -92,11 +103,13 @@
     import {DynamicScroller, DynamicScrollerItem} from "vue-virtual-scroller";
     import ChevronRight from "vue-material-design-icons/ChevronRight.vue";
     import ChevronDown from "vue-material-design-icons/ChevronDown.vue";
+    import Warning from "vue-material-design-icons/Alert.vue"
+
 
     const ts = date => new Date(date).getTime();
     const TASKRUN_THRESHOLD = 50
     export default {
-        components: {DynamicScroller, DynamicScrollerItem, TaskRunDetails, Duration, ChevronRight, ChevronDown},
+        components: {DynamicScroller,Warning, DynamicScrollerItem, TaskRunDetails, Duration, ChevronRight, ChevronDown},
         data() {
             return {
                 colors: State.colorClass(),
@@ -287,7 +300,8 @@
                         task,
                         flowId: task.flowId,
                         namespace: task.namespace,
-                        executionId: task.outputs && task.outputs.executionId
+                        executionId: task.outputs && task.outputs.executionId,
+                        attempts: task.attempts ? task.attempts.length : 1
                     });
                 }
                 this.series = series;
@@ -395,6 +409,11 @@
                         font-size: var(--font-size-xs);
                         color: var(--ks-content-primary);
                     }
+                }
+                
+                .attempt_warn{
+                    color: var(--el-color-warning);
+                    vertical-align: middle;
                 }
 
                 .task-progress {

--- a/ui/src/components/executions/Gantt.vue
+++ b/ui/src/components/executions/Gantt.vue
@@ -40,7 +40,7 @@
                                     </span>
                                 </el-tooltip>
                                 <div>
-                                    <el-tooltip placement="right" :persistent="false" transition="" :hide-after="0" effect="light">
+                                    <el-tooltip placement="right" :persistent="false" :hide-after="0" effect="light">
                                         <template #content>
                                             <span>This task has {{ item.attempts }} attempts.</span>
                                         </template>


### PR DESCRIPTION
Closes #6653 

Implemented to show  when attempt > 1

Light:
![image](https://github.com/user-attachments/assets/b439b1b3-024d-4be4-b9b6-ab67fef61bf5)


Dark:
![image](https://github.com/user-attachments/assets/f78e2049-3b69-4268-b8ed-4f06761fd885)


Used the below flow to reproduce:

```id: airbyte-cloud-dbt-cloud
namespace: company.team

tasks:
  - id: data_ingestion
    type: io.kestra.plugin.core.flow.Parallel
    tasks:
      - id: salesforce
        type: io.kestra.plugin.airbyte.cloud.jobs.Sync
        connectionId: e3b1ce92-547c-436f-b1e8-23b6936c12ab

      - id: google_analytics
        type: io.kestra.plugin.airbyte.cloud.jobs.Sync
        connectionId: e3b1ce92-547c-436f-b1e8-23b6936c12cd

      - id: facebook_ads
        type: io.kestra.plugin.airbyte.cloud.jobs.Sync
        connectionId: e3b1ce92-547c-436f-b1e8-23b6936c12ef

  - id: dbt_cloud_job
    type: io.kestra.plugin.dbt.cloud.TriggerRun
    jobId: "396284"
    accountId: "{{ secret('DBT_CLOUD_ACCOUNT_ID') }}"
    token: "{{ secret('DBT_CLOUD_API_TOKEN') }}"
    wait: true

pluginDefaults:
  - type: io.kestra.plugin.airbyte.cloud.jobs.Sync
    values:
      token: "{{ secret('AIRBYTE_CLOUD_API_TOKEN') }}"
