### PR TITLE
fix(core, ui): send a "start" event to be sure the UI receive the SSE

### DIFF
--- a/core/src/main/java/io/kestra/core/services/ExecutionLogService.java
+++ b/core/src/main/java/io/kestra/core/services/ExecutionLogService.java
@@ -40,6 +40,9 @@ public class ExecutionLogService {
         final AtomicReference<Runnable> disposable = new AtomicReference<>();
 
         return Flux.<Event<LogEntry>>create(emitter -> {
+                // send a first "empty" event so the SSE is correctly initialized in the frontend in case there are no logs
+                emitter.next(Event.of(LogEntry.builder().build()).id("start"));
+
                 // fetch repository first
                 getExecutionLogs(tenantId, executionId, minLevel, List.of(), withAccessControl)
                     .forEach(logEntry -> emitter.next(Event.of(logEntry).id("progress")));

--- a/ui/src/components/logs/TaskRunDetails.vue
+++ b/ui/src/components/logs/TaskRunDetails.vue
@@ -502,7 +502,10 @@
                         this.logsSSE = sse;
 
                         this.logsSSE.onmessage = event => {
-                            this.logsBuffer = this.logsBuffer.concat(JSON.parse(event.data));
+                            // we are receiving a first "fake" event to force initializing the connection: ignoring it
+                            if (event.lastEventId !== "start") {
+                                this.logsBuffer = this.logsBuffer.concat(JSON.parse(event.data));
+                            }
 
                             clearTimeout(this.timeout);
                             this.timeout = setTimeout(() => {


### PR DESCRIPTION
The UI only store a reference to the logs SSE when receive the first event. In case a flow didn't emit any log, or the logs tab is closed before any logs is emitted, the UI will not have any reference to the SSE so the SSE connection would stay alive forever. Each SSE connection starts a thread via the logs queue, creating a thread leak.

Sending a first "start" event makes sure the UI has a reference to the SSE.

Closes kestra-io/kestra#6725

Validated manually: before the patch, threads keeps being created and not destroyed for the logQueue, after the patch threads are correctly destroyed.

May fix https://github.com/kestra-io/kestra-ee/issues/3083