### PR TITLE
Plugin: Define the langchain4j ollama, openai & gemini plugins 

### DIFF
--- a/.plugins
+++ b/.plugins
@@ -99,6 +99,9 @@
 #plugin-weaviate:io.kestra.plugin:plugin-weaviate:LATEST
 #plugin-zendesk:io.kestra.plugin:plugin-zendesk:LATEST
 #plugin-typesense:io.kestra.plugin:plugin-typesense:LATEST
+#plugin-langchain4j:io.kestra.plugin:plugin-langchain4j-openai:LATEST
+#plugin-langchain4j:io.kestra.plugin:plugin-langchain4j-gemini:LATEST
+#plugin-langchain4j:io.kestra.plugin:plugin-langchain4j-ollama:LATEST
 #storage-azure:io.kestra.storage:storage-azure:LATEST
 #storage-gcs:io.kestra.storage:storage-gcs:LATEST
 #storage-minio:io.kestra.storage:storage-minio:LATEST


### PR DESCRIPTION
Define the list of available langchain4j plugins:

#plugin-langchain4j:io.kestra.plugin:plugin-langchain4j-openai:LATEST
#plugin-langchain4j:io.kestra.plugin:plugin-langchain4j-gemini:LATEST
#plugin-langchain4j:io.kestra.plugin:plugin-langchain4j-ollama:LATEST

