### PR TITLE
feat(*): OpenTelemetry traces

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -123,6 +123,7 @@ allprojects {
             micronaut "io.micronaut.micrometer:micronaut-micrometer-registry-prometheus"
             micronaut "io.micronaut:micronaut-http-client"
             micronaut "io.micronaut.reactor:micronaut-reactor-http-client"
+            micronaut "io.micronaut.tracing:micronaut-tracing-opentelemetry-http"
 
             // logs
             implementation "org.slf4j:slf4j-api"
@@ -132,6 +133,9 @@ allprojects {
             implementation group: 'org.slf4j', name: 'jul-to-slf4j'
             implementation group: 'org.slf4j', name: 'jcl-over-slf4j'
             implementation group: 'org.fusesource.jansi', name: 'jansi'
+
+            // OTEL
+            implementation "io.opentelemetry:opentelemetry-exporter-otlp"
 
             // jackson
             implementation group: 'com.fasterxml.jackson.core', name: 'jackson-core'

--- a/cli/src/main/resources/application.yml
+++ b/cli/src/main/resources/application.yml
@@ -160,6 +160,9 @@ kestra:
   metrics:
     prefix: kestra
 
+  traces:
+    root: DISABLED
+
   server:
     basic-auth:
       enabled: false
@@ -194,3 +197,12 @@ kestra:
     prefixes:
       - system.
       - internal.
+
+otel:
+  exclusions:
+    - /ping
+    - /metrics
+    - /health
+    - /env
+    - /prometheus
+  propagators: tracecontext, baggage

--- a/core/src/main/java/io/kestra/core/http/HttpRequest.java
+++ b/core/src/main/java/io/kestra/core/http/HttpRequest.java
@@ -1,6 +1,7 @@
 package io.kestra.core.http;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import io.kestra.core.runners.RunContext;
 import io.kestra.core.serializers.JacksonMapper;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
@@ -93,7 +94,7 @@ public class HttpRequest {
             .build();
     }
 
-    public HttpUriRequest to() throws IOException {
+    public HttpUriRequest to(RunContext runContext) throws IOException {
         HttpUriRequestBase builder = new HttpUriRequestBase(this.method, this.uri);
 
         // headers
@@ -102,6 +103,10 @@ public class HttpRequest {
                 .forEach((key, value) -> value
                     .forEach(headerValue -> builder.addHeader(key, headerValue))
                 );
+        }
+
+        if (runContext.getTraceParent() != null) {
+            builder.addHeader("traceparent", runContext.getTraceParent());
         }
 
         // body

--- a/core/src/main/java/io/kestra/core/http/client/HttpClient.java
+++ b/core/src/main/java/io/kestra/core/http/client/HttpClient.java
@@ -248,7 +248,7 @@ public class HttpClient implements Closeable {
         HttpClientResponseHandler<HttpResponse<T>> responseHandler
     ) throws HttpClientException {
         try {
-            return this.client.execute(request.to(), httpClientContext, responseHandler);
+            return this.client.execute(request.to(runContext), httpClientContext, responseHandler);
         } catch (SocketException e) {
             throw new HttpClientRequestException(e.getMessage(), request, e);
         } catch (IOException e) {

--- a/core/src/main/java/io/kestra/core/models/executions/Execution.java
+++ b/core/src/main/java/io/kestra/core/models/executions/Execution.java
@@ -29,6 +29,7 @@ import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
 import lombok.*;
 import lombok.experimental.FieldDefaults;
+import lombok.experimental.NonFinal;
 import lombok.extern.slf4j.Slf4j;
 
 import java.time.Instant;
@@ -105,6 +106,10 @@ public class Execution implements DeletedInterface, TenantInterface {
     @With
     @Nullable
     Instant scheduleDate;
+
+    @NonFinal
+    @Setter
+    String traceParent;
 
     /**
      * Factory method for constructing a new {@link Execution} object for the given {@link Flow}.
@@ -199,7 +204,8 @@ public class Execution implements DeletedInterface, TenantInterface {
             this.trigger,
             this.deleted,
             this.metadata,
-            this.scheduleDate
+            this.scheduleDate,
+            this.traceParent
         );
     }
 
@@ -222,7 +228,8 @@ public class Execution implements DeletedInterface, TenantInterface {
             this.trigger,
             this.deleted,
             this.metadata,
-            this.scheduleDate
+            this.scheduleDate,
+            this.traceParent
         );
     }
 
@@ -258,7 +265,8 @@ public class Execution implements DeletedInterface, TenantInterface {
             this.trigger,
             this.deleted,
             this.metadata,
-            this.scheduleDate
+            this.scheduleDate,
+            this.traceParent
         );
     }
 
@@ -281,7 +289,8 @@ public class Execution implements DeletedInterface, TenantInterface {
             this.trigger,
             this.deleted,
             this.metadata,
-            this.scheduleDate
+            this.scheduleDate,
+            this.traceParent
         );
     }
 

--- a/core/src/main/java/io/kestra/core/runners/AbstractWorkerTriggerCallable.java
+++ b/core/src/main/java/io/kestra/core/runners/AbstractWorkerTriggerCallable.java
@@ -13,7 +13,7 @@ abstract class AbstractWorkerTriggerCallable extends AbstractWorkerCallable {
     WorkerTrigger workerTrigger;
 
     AbstractWorkerTriggerCallable(RunContext runContext, String type, WorkerTrigger workerTrigger) {
-        super(runContext, type, workerTrigger.getTrigger().getClass().getClassLoader());
+        super(runContext, type, workerTrigger.uid(), workerTrigger.getTrigger().getClass().getClassLoader());
         this.workerTrigger = workerTrigger;
     }
 

--- a/core/src/main/java/io/kestra/core/runners/DefaultRunContext.java
+++ b/core/src/main/java/io/kestra/core/runners/DefaultRunContext.java
@@ -60,6 +60,7 @@ public class DefaultRunContext extends RunContext {
     private Storage storage;
     private Map<String, Object> pluginConfiguration;
     private List<String> secretInputs;
+    private String traceParent;
 
     // those are only used to validate dynamic properties inside the RunContextProperty
     private Task task;
@@ -101,6 +102,20 @@ public class DefaultRunContext extends RunContext {
     @JsonInclude
     public List<String> getSecretInputs() {
         return secretInputs;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    @JsonInclude
+    public String getTraceParent() {
+        return traceParent;
+    }
+
+    @Override
+    public void setTraceParent(String traceParent) {
+        this.traceParent = traceParent;
     }
 
     @JsonIgnore

--- a/core/src/main/java/io/kestra/core/runners/ExecutableUtils.java
+++ b/core/src/main/java/io/kestra/core/runners/ExecutableUtils.java
@@ -14,7 +14,11 @@ import io.kestra.core.models.tasks.Task;
 import io.kestra.core.repositories.ExecutionRepositoryInterface;
 import io.kestra.core.services.ExecutionService;
 import io.kestra.core.storages.Storage;
+import io.kestra.core.trace.TracerFactory;
 import io.kestra.core.utils.MapUtils;
+import io.kestra.core.trace.propagation.ExecutionTextMapSetter;
+import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.context.Context;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.stream.Streams;
 
@@ -22,6 +26,7 @@ import java.time.Instant;
 import java.time.ZonedDateTime;
 import java.util.*;
 
+import static io.kestra.core.trace.Tracer.throwCallable;
 import static io.kestra.core.utils.Rethrow.throwConsumer;
 
 @Slf4j
@@ -68,113 +73,128 @@ public final class ExecutableUtils {
         boolean inheritLabels,
         Property<ZonedDateTime> scheduleDate
     ) throws IllegalVariableEvaluationException {
-        // If we are in a flow that is restarted, we search for existing run of the task to restart them
-        if (currentExecution.getLabels() != null && currentExecution.getLabels().contains(new Label(Label.RESTARTED, "true"))
-            && currentTask.getRestartBehavior() == ExecutableTask.RestartBehavior.RETRY_FAILED) {
-            ExecutionRepositoryInterface executionRepository = ((DefaultRunContext) runContext).getApplicationContext().getBean(ExecutionRepositoryInterface.class);
+        // extract a trace context for propagation
+        var openTelemetry = ((DefaultRunContext) runContext).getApplicationContext().getBean(OpenTelemetry.class);
+        var propagator = openTelemetry.getPropagators().getTextMapPropagator();
+        var tracerFactory = ((DefaultRunContext) runContext).getApplicationContext().getBean(TracerFactory.class);
+        var tracer = tracerFactory.getTracer(currentTask.getClass(), "EXECUTOR");
 
-            Optional<Execution> existingSubflowExecution = Optional.empty();
-            if (currentTaskRun.getOutputs() != null && currentTaskRun.getOutputs().containsKey("executionId")) {
-                // we know which execution to restart; this should be the case for Subflow tasks
-                existingSubflowExecution = executionRepository.findById(currentExecution.getTenantId(), (String) currentTaskRun.getOutputs().get("executionId"));
-            }
+        return tracer.inNewContext(
+            currentExecution,
+            currentTask.getType(),
+            throwCallable(() -> {
+            // If we are in a flow that is restarted, we search for existing run of the task to restart them
+            if (currentExecution.getLabels() != null && currentExecution.getLabels().contains(new Label(Label.RESTARTED, "true"))
+                && currentTask.getRestartBehavior() == ExecutableTask.RestartBehavior.RETRY_FAILED) {
+                ExecutionRepositoryInterface executionRepository = ((DefaultRunContext) runContext).getApplicationContext().getBean(ExecutionRepositoryInterface.class);
 
-            if (existingSubflowExecution.isEmpty()) {
-                // otherwise, we try to find the correct one; this should be the case for ForEachItem tasks
-                List<Execution> childExecutions = executionRepository.findAllByTriggerExecutionId(currentExecution.getTenantId(), currentExecution.getId())
-                    .filter(e -> e.getNamespace().equals(currentTask.subflowId().namespace()) && e.getFlowId().equals(currentTask.subflowId().flowId()) && e.getTrigger().getId().equals(currentTask.getId()))
-                    .filter(e -> Objects.equals(e.getTrigger().getVariables().get("taskRunId"), currentTaskRun.getId()) && Objects.equals(e.getTrigger().getVariables().get("taskRunValue"), currentTaskRun.getValue()) && Objects.equals(e.getTrigger().getVariables().get("taskRunIteration"), currentTaskRun.getIteration()))
-                    .collectList()
-                    .block();
+                Optional<Execution> existingSubflowExecution = Optional.empty();
+                if (currentTaskRun.getOutputs() != null && currentTaskRun.getOutputs().containsKey("executionId")) {
+                    // we know which execution to restart; this should be the case for Subflow tasks
+                    existingSubflowExecution = executionRepository.findById(currentExecution.getTenantId(), (String) currentTaskRun.getOutputs().get("executionId"));
+                }
 
-                if (childExecutions != null && childExecutions.size() == 1) {
-                    // if there are more than one, we ignore the results and create a new one
-                    existingSubflowExecution = Optional.of(childExecutions.getFirst());
+                if (existingSubflowExecution.isEmpty()) {
+                    // otherwise, we try to find the correct one; this should be the case for ForEachItem tasks
+                    List<Execution> childExecutions = executionRepository.findAllByTriggerExecutionId(currentExecution.getTenantId(), currentExecution.getId())
+                        .filter(e -> e.getNamespace().equals(currentTask.subflowId().namespace()) && e.getFlowId().equals(currentTask.subflowId().flowId()) && e.getTrigger().getId().equals(currentTask.getId()))
+                        .filter(e -> Objects.equals(e.getTrigger().getVariables().get("taskRunId"), currentTaskRun.getId()) && Objects.equals(e.getTrigger().getVariables().get("taskRunValue"), currentTaskRun.getValue()) && Objects.equals(e.getTrigger().getVariables().get("taskRunIteration"), currentTaskRun.getIteration()))
+                        .collectList()
+                        .block();
+
+                    if (childExecutions != null && childExecutions.size() == 1) {
+                        // if there are more than one, we ignore the results and create a new one
+                        existingSubflowExecution = Optional.of(childExecutions.getFirst());
+                    }
+                }
+
+                if (existingSubflowExecution.isPresent()) {
+                    Execution subflowExecution = existingSubflowExecution.get();
+                    if (!subflowExecution.getState().isFailed()) {
+                        // don't restart it as it's terminated successfully
+                        return Optional.empty();
+                    }
+                    ExecutionService executionService = ((DefaultRunContext) runContext).getApplicationContext().getBean(ExecutionService.class);
+                    try {
+                        Execution restarted = executionService.restart(subflowExecution, null);
+                        // inject the traceparent into the new execution
+                        propagator.inject(Context.current(), restarted, ExecutionTextMapSetter.INSTANCE);
+                        return Optional.of(SubflowExecution.builder()
+                            .parentTask(currentTask)
+                            .parentTaskRun(currentTaskRun.withState(State.Type.RUNNING))
+                            .execution(restarted)
+                            .build());
+                    } catch (Exception e) {
+                        throw new RuntimeException(e);
+                    }
                 }
             }
 
-            if (existingSubflowExecution.isPresent()) {
-                Execution subflowExecution = existingSubflowExecution.get();
-                if (!subflowExecution.getState().isFailed()) {
-                    // don't restart it as it's terminated successfully
-                    return Optional.empty();
-                }
-                ExecutionService executionService = ((DefaultRunContext) runContext).getApplicationContext().getBean(ExecutionService.class);
-                try {
-                    Execution restarted = executionService.restart(subflowExecution, null);
-                    return Optional.of(SubflowExecution.builder()
-                        .parentTask(currentTask)
-                        .parentTaskRun(currentTaskRun.withState(State.Type.RUNNING))
-                        .execution(restarted)
-                        .build());
-                } catch (Exception e) {
-                    throw new RuntimeException(e);
-                }
+            String subflowNamespace = runContext.render(currentTask.subflowId().namespace());
+            String subflowId = runContext.render(currentTask.subflowId().flowId());
+            Optional<Integer> subflowRevision = currentTask.subflowId().revision();
+
+            Flow flow = flowExecutorInterface.findByIdFromTask(
+                    currentExecution.getTenantId(),
+                    subflowNamespace,
+                    subflowId,
+                    subflowRevision,
+                    currentExecution.getTenantId(),
+                    currentFlow.getNamespace(),
+                    currentFlow.getId()
+                )
+                .orElseThrow(() -> new IllegalStateException("Unable to find flow '" + subflowNamespace + "'.'" + subflowId + "' with revision '" + subflowRevision.orElse(0) + "'"));
+
+            if (flow.isDisabled()) {
+                throw new IllegalStateException("Cannot execute a flow which is disabled");
             }
-        }
 
-        String subflowNamespace = runContext.render(currentTask.subflowId().namespace());
-        String subflowId = runContext.render(currentTask.subflowId().flowId());
-        Optional<Integer> subflowRevision = currentTask.subflowId().revision();
+            if (flow instanceof FlowWithException fwe) {
+                throw new IllegalStateException("Cannot execute an invalid flow: " + fwe.getException());
+            }
 
-        io.kestra.core.models.flows.Flow flow = flowExecutorInterface.findByIdFromTask(
-                currentExecution.getTenantId(),
-                subflowNamespace,
-                subflowId,
-                subflowRevision,
-                currentExecution.getTenantId(),
-                currentFlow.getNamespace(),
-                currentFlow.getId()
-            )
-            .orElseThrow(() -> new IllegalStateException("Unable to find flow '" + subflowNamespace + "'.'" + subflowId + "' with revision '" + subflowRevision.orElse(0) + "'"));
+            List<Label> newLabels = inheritLabels ? new ArrayList<>(currentExecution.getLabels()) : new ArrayList<>(systemLabels(currentExecution));
+            if (labels != null) {
+                labels.forEach(throwConsumer(label -> newLabels.add(new Label(runContext.render(label.key()), runContext.render(label.value())))));
+            }
 
-        if (flow.isDisabled()) {
-            throw new IllegalStateException("Cannot execute a flow which is disabled");
-        }
+            var variables = ImmutableMap.<String, Object>builder().putAll(Map.of(
+                "executionId", currentExecution.getId(),
+                "namespace", currentFlow.getNamespace(),
+                "flowId", currentFlow.getId(),
+                "flowRevision", currentFlow.getRevision(),
+                "taskRunId", currentTaskRun.getId()
+            ));
+            if (currentTaskRun.getValue() != null) {
+                variables.put("taskRunValue", currentTaskRun.getValue());
+            }
+            if (currentTaskRun.getIteration() != null) {
+                variables.put("taskRunIteration", currentTaskRun.getIteration());
+            }
 
-        if (flow instanceof FlowWithException fwe) {
-            throw new IllegalStateException("Cannot execute an invalid flow: " + fwe.getException());
-        }
-
-        List<Label> newLabels = inheritLabels ? new ArrayList<>(currentExecution.getLabels()) : new ArrayList<>(systemLabels(currentExecution));
-        if (labels != null) {
-            labels.forEach(throwConsumer(label -> newLabels.add(new Label(runContext.render(label.key()), runContext.render(label.value())))));
-        }
-
-        var variables = ImmutableMap.<String, Object>builder().putAll(Map.of(
-            "executionId", currentExecution.getId(),
-            "namespace", currentFlow.getNamespace(),
-            "flowId", currentFlow.getId(),
-            "flowRevision", currentFlow.getRevision(),
-            "taskRunId", currentTaskRun.getId()
-        ));
-        if (currentTaskRun.getValue() != null) {
-            variables.put("taskRunValue", currentTaskRun.getValue());
-        }
-        if (currentTaskRun.getIteration() != null) {
-            variables.put("taskRunIteration", currentTaskRun.getIteration());
-        }
-
-        FlowInputOutput flowInputOutput = ((DefaultRunContext)runContext).getApplicationContext().getBean(FlowInputOutput.class);
-        Instant scheduleOnDate = runContext.render(scheduleDate).as(ZonedDateTime.class).map(date -> date.toInstant()).orElse(null);
-        Execution execution = Execution
-            .newExecution(
-                flow,
-                (f, e) -> flowInputOutput.readExecutionInputs(f, e, inputs),
-                newLabels,
-                Optional.empty())
-            .withTrigger(ExecutionTrigger.builder()
-                .id(currentTask.getId())
-                .type(currentTask.getType())
-                .variables(variables.build())
-                .build()
-            )
-            .withScheduleDate(scheduleOnDate);
-        return Optional.of(SubflowExecution.builder()
-            .parentTask(currentTask)
-            .parentTaskRun(currentTaskRun.withState(State.Type.RUNNING))
-            .execution(execution)
-            .build());
+            FlowInputOutput flowInputOutput = ((DefaultRunContext)runContext).getApplicationContext().getBean(FlowInputOutput.class);
+            Instant scheduleOnDate = runContext.render(scheduleDate).as(ZonedDateTime.class).map(date -> date.toInstant()).orElse(null);
+            Execution execution = Execution
+                .newExecution(
+                    flow,
+                    (f, e) -> flowInputOutput.readExecutionInputs(f, e, inputs),
+                    newLabels,
+                    Optional.empty())
+                .withTrigger(ExecutionTrigger.builder()
+                    .id(currentTask.getId())
+                    .type(currentTask.getType())
+                    .variables(variables.build())
+                    .build()
+                )
+                .withScheduleDate(scheduleOnDate);
+            // inject the traceparent into the new execution
+            propagator.inject(Context.current(), execution, ExecutionTextMapSetter.INSTANCE);
+            return Optional.of(SubflowExecution.builder()
+                .parentTask(currentTask)
+                .parentTaskRun(currentTaskRun.withState(State.Type.RUNNING))
+                .execution(execution)
+                .build());
+        }));
     }
 
     private static List<Label> systemLabels(Execution execution) {

--- a/core/src/main/java/io/kestra/core/runners/ExecutorService.java
+++ b/core/src/main/java/io/kestra/core/runners/ExecutorService.java
@@ -14,6 +14,7 @@ import io.kestra.core.queues.QueueException;
 import io.kestra.core.queues.QueueFactoryInterface;
 import io.kestra.core.queues.QueueInterface;
 import io.kestra.core.services.*;
+import io.kestra.core.trace.propagation.RunContextTextMapSetter;
 import io.kestra.core.utils.ListUtils;
 import io.kestra.core.utils.TruthUtils;
 import io.kestra.plugin.core.flow.Pause;
@@ -21,6 +22,8 @@ import io.kestra.plugin.core.flow.Subflow;
 import io.kestra.plugin.core.flow.WaitFor;
 import io.kestra.plugin.core.flow.WorkingDirectory;
 import io.micronaut.context.ApplicationContext;
+import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.context.Context;
 import jakarta.inject.Inject;
 import jakarta.inject.Named;
 import jakarta.inject.Singleton;
@@ -69,6 +72,9 @@ public class ExecutorService {
 
     @Inject
     private SLAService slaService;
+
+    @Inject
+    private OpenTelemetry openTelemetry;
 
     @Inject
     @Named(QueueFactoryInterface.KILL_NAMED)
@@ -733,6 +739,8 @@ public class ExecutorService {
             return executor;
         }
 
+        var propagator = openTelemetry.getPropagators().getTextMapPropagator();
+
         // submit TaskRun when receiving created, must be done after the state execution store
         Map<Boolean, List<WorkerTask>> workerTasks = executor.getExecution()
             .getTaskRunList()
@@ -741,6 +749,7 @@ public class ExecutorService {
             .map(throwFunction(taskRun -> {
                     Task task = executor.getFlow().findTaskByTaskId(taskRun.getTaskId());
                     RunContext runContext = runContextFactory.of(executor.getFlow(), task, executor.getExecution(), taskRun);
+                    propagator.inject(Context.current(), runContext, RunContextTextMapSetter.INSTANCE); // inject the traceparent into the run context
                     WorkerTask workerTask = WorkerTask.builder()
                         .runContext(runContext)
                         .taskRun(taskRun)

--- a/core/src/main/java/io/kestra/core/runners/RunContext.java
+++ b/core/src/main/java/io/kestra/core/runners/RunContext.java
@@ -43,6 +43,14 @@ public abstract class RunContext {
     @JsonInclude
     public abstract List<String> getSecretInputs();
 
+    /**
+     * OpenTelemetry trace parent
+     */
+    @JsonInclude
+    public abstract String getTraceParent();
+
+    public abstract void setTraceParent(String traceParent);
+
     public abstract String render(String inline) throws IllegalVariableEvaluationException;
 
     public abstract Object renderTyped(String inline) throws IllegalVariableEvaluationException;

--- a/core/src/main/java/io/kestra/core/runners/WorkerTaskCallable.java
+++ b/core/src/main/java/io/kestra/core/runners/WorkerTaskCallable.java
@@ -25,7 +25,7 @@ public class WorkerTaskCallable extends AbstractWorkerCallable {
     Output taskOutput;
 
     WorkerTaskCallable(WorkerTask workerTask, RunnableTask<?> task, RunContext runContext, MetricRegistry metricRegistry) {
-        super(runContext, task.getClass().getName(), task.getClass().getClassLoader());
+        super(runContext, task.getClass().getName(), workerTask.uid(), task.getClass().getClassLoader());
         this.workerTask = workerTask;
         this.task = task;
         this.metricRegistry = metricRegistry;

--- a/core/src/main/java/io/kestra/core/trace/DefaultTracer.java
+++ b/core/src/main/java/io/kestra/core/trace/DefaultTracer.java
@@ -1,0 +1,116 @@
+package io.kestra.core.trace;
+
+import io.kestra.core.models.executions.Execution;
+import io.kestra.core.runners.RunContext;
+import io.kestra.core.trace.propagation.ExecutionTextMapGetter;
+import io.kestra.core.trace.propagation.RunContextTextMapGetter;
+import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.trace.StatusCode;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.context.Scope;
+
+class DefaultTracer implements Tracer {
+    private final OpenTelemetry openTelemetry;
+    private final io.opentelemetry.api.trace.Tracer tracer;
+    private final String spanNamePrefix;
+    private final TraceLevel level; // FIXME useless for now as we didn't handle FINE level
+    private final Attributes baseAttributes;
+
+    DefaultTracer(OpenTelemetry openTelemetry, io.opentelemetry.api.trace.Tracer tracer, String spanNamePrefix, TraceLevel level, Attributes baseAttributes) {
+        this.openTelemetry = openTelemetry;
+        this.tracer = tracer;
+        this.spanNamePrefix = spanNamePrefix;
+        this.level = level;
+        this.baseAttributes = baseAttributes;
+    }
+
+    @Override
+    public <V> V inCurrentContext(RunContext runContext, String spanName, Callable<V> callable) {
+        return inCurrentContext(runContext, spanName, null, callable);
+    }
+
+    @Override
+    public <V> V inCurrentContext(RunContext runContext, String spanName, Attributes additionalAttributes, Callable<V> callable) {
+        // extract the traceparent from the run context to allow trace propagation
+        var propagator = openTelemetry.getPropagators().getTextMapPropagator();
+        var extractedContext = propagator.extract(Context.current(), runContext, RunContextTextMapGetter.INSTANCE);
+
+        var attributesBuilder = Attributes.builder()
+            .putAll(baseAttributes)
+            .putAll(TraceUtils.attributesFrom(runContext));
+        if (additionalAttributes != null) {
+            attributesBuilder.putAll(additionalAttributes);
+        }
+
+        return inCurrentContext(extractedContext, spanName, attributesBuilder.build(), callable);
+    }
+
+    @Override
+    public <V> V inCurrentContext(Execution execution, String spanName, Callable<V> callable) {
+        return inCurrentContext(execution, spanName, null, callable);
+    }
+
+    @Override
+    public <V> V inCurrentContext(Execution execution, String spanName, Attributes additionalAttributes, Callable<V> callable) {
+        // extract the traceparent from the execution to allow trace propagation
+        var propagator = openTelemetry.getPropagators().getTextMapPropagator();
+        var extractedContext = propagator.extract(Context.current(), execution, ExecutionTextMapGetter.INSTANCE);
+
+        var attributesBuilder = Attributes.builder()
+            .putAll(baseAttributes)
+            .putAll(TraceUtils.attributesFrom(execution));
+        if (additionalAttributes != null) {
+            attributesBuilder.putAll(additionalAttributes);
+        }
+
+        return inCurrentContext(extractedContext, spanName, attributesBuilder.build(), callable);
+    }
+
+    @Override
+    public <V> V inNewContext(Execution execution, String spanName, Callable<V> callable) {
+        return inNewContext(execution, spanName, null, callable);
+    }
+
+    @Override
+    public <V> V inNewContext(Execution execution, String spanName, Attributes additionalAttributes, Callable<V> callable) {
+        var attributesBuilder = Attributes.builder()
+            .putAll(baseAttributes)
+            .putAll(TraceUtils.attributesFrom(execution));
+        if (additionalAttributes != null) {
+            attributesBuilder.putAll(additionalAttributes);
+        }
+
+        return inNewContext(spanName, attributesBuilder.build(), callable);
+    }
+
+    private <V> V inCurrentContext(Context context, String spanName, Attributes attributes, Callable<V> callable) {
+        try (Scope ignored = context.makeCurrent()) {
+            var span = tracer.spanBuilder(spanNamePrefix + " - " + spanName)
+                .setAllAttributes(attributes)
+                .startSpan();
+            try {
+                return callable.call();
+            } catch(Exception e) {
+                span.setStatus(StatusCode.ERROR, e.getMessage());
+                throw e;
+            } finally {
+                span.end();
+            }
+        }
+    }
+
+    private <V> V inNewContext(String spanName, Attributes attributes, Callable<V> callable) {
+        var span = tracer.spanBuilder(spanNamePrefix + " - " + spanName)
+            .setAllAttributes(attributes)
+            .startSpan();
+        try (Scope ignored = span.makeCurrent()) {
+            return callable.call();
+        } catch(Exception e) {
+            span.setStatus(StatusCode.ERROR, e.getMessage());
+            throw e;
+        } finally {
+            span.end();
+        }
+    }
+}

--- a/core/src/main/java/io/kestra/core/trace/NoopTracer.java
+++ b/core/src/main/java/io/kestra/core/trace/NoopTracer.java
@@ -1,0 +1,37 @@
+package io.kestra.core.trace;
+
+import io.kestra.core.models.executions.Execution;
+import io.kestra.core.runners.RunContext;
+import io.opentelemetry.api.common.Attributes;
+
+class NoopTracer implements Tracer {
+    @Override
+    public <V> V inCurrentContext(RunContext runContext, String spanName, Callable<V> callable) {
+        return callable.call();
+    }
+
+    @Override
+    public <V> V inCurrentContext(RunContext runContext, String spanName, Attributes additionalAttributes, Callable<V> callable) {
+        return callable.call();
+    }
+
+    @Override
+    public <V> V inCurrentContext(Execution execution, String spanName, Callable<V> callable) {
+        return callable.call();
+    }
+
+    @Override
+    public <V> V inCurrentContext(Execution execution, String spanName, Attributes additionalAttributes, Callable<V> callable) {
+        return callable.call();
+    }
+
+    @Override
+    public <V> V inNewContext(Execution execution, String spanName, Callable<V> callable) {
+        return callable.call();
+    }
+
+    @Override
+    public <V> V inNewContext(Execution execution, String spanName, Attributes additionalAttributes, Callable<V> callable) {
+        return callable.call();
+    }
+}

--- a/core/src/main/java/io/kestra/core/trace/TraceLevel.java
+++ b/core/src/main/java/io/kestra/core/trace/TraceLevel.java
@@ -1,0 +1,5 @@
+package io.kestra.core.trace;
+
+public enum TraceLevel {
+    DISABLED, DEFAULT, FINE
+}

--- a/core/src/main/java/io/kestra/core/trace/TraceUtils.java
+++ b/core/src/main/java/io/kestra/core/trace/TraceUtils.java
@@ -1,0 +1,56 @@
+package io.kestra.core.trace;
+
+import io.kestra.core.models.executions.Execution;
+import io.kestra.core.runners.RunContext;
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.common.Attributes;
+
+import java.util.Map;
+
+public final class TraceUtils {
+    public static final AttributeKey<String> ATTR_UID = AttributeKey.stringKey("kestra.uid");
+
+    private static final AttributeKey<String> ATTR_TENANT_ID = AttributeKey.stringKey("kestra.tenantId");
+    private static final AttributeKey<String> ATTR_NAMESPACE = AttributeKey.stringKey("kestra.namespace");
+    private static final AttributeKey<String> ATTR_FLOW_ID = AttributeKey.stringKey("kestra.flowId");
+    private static final AttributeKey<String> ATTR_EXECUTION_ID = AttributeKey.stringKey("kestra.executionId");
+
+    public static final AttributeKey<String> ATTR_SOURCE = AttributeKey.stringKey("kestra.source");
+
+    private TraceUtils() {}
+
+    public static Attributes attributesFrom(Execution execution) {
+        var builder = Attributes.builder()
+            .put(ATTR_NAMESPACE, execution.getNamespace())
+            .put(ATTR_FLOW_ID, execution.getFlowId())
+            .put(ATTR_EXECUTION_ID, execution.getId());
+
+        if (execution.getTenantId() != null) {
+            builder.put(ATTR_TENANT_ID, execution.getTenantId());
+        }
+
+        return builder.build();
+    }
+
+    @SuppressWarnings("unchecked")
+    public static Attributes attributesFrom(RunContext runContext) {
+        var flowInfo = runContext.flowInfo();
+        var execution = (Map<String, Object>) runContext.getVariables().get("execution");
+        var executionId = (String) execution.get("id");
+
+        var builder = Attributes.builder()
+            .put(ATTR_NAMESPACE, flowInfo.namespace())
+            .put(ATTR_FLOW_ID, flowInfo.id())
+            .put(ATTR_EXECUTION_ID, executionId);
+
+        if (flowInfo.tenantId() != null) {
+            builder.put(ATTR_TENANT_ID, flowInfo.tenantId());
+        }
+
+        return builder.build();
+    }
+
+    public static Attributes attributesFrom(Class<?> clazz) {
+        return Attributes.builder().put(ATTR_SOURCE, clazz.getName()).build();
+    }
+}

--- a/core/src/main/java/io/kestra/core/trace/Tracer.java
+++ b/core/src/main/java/io/kestra/core/trace/Tracer.java
@@ -1,0 +1,90 @@
+package io.kestra.core.trace;
+
+import io.kestra.core.models.executions.Execution;
+import io.kestra.core.runners.RunContext;
+import io.kestra.core.utils.Rethrow;
+import io.opentelemetry.api.common.Attributes;
+
+/**
+ * A <code>Tracer</code> allow to instrument a block of code with OpenTelemetry traces.
+ */
+public interface Tracer {
+    /**
+     * Instrument a block of code with a trace context extracted from the run context.
+     *
+     * @see #inCurrentContext(RunContext, String, Attributes, Callable)
+     */
+    <V> V inCurrentContext(RunContext runContext, String spanName, Callable<V> callable);
+
+    /**
+     * Instrument a block of code with a trace context extracted from the run context.
+     * Default span attributes will be added derived from the run context.
+     *
+     * @param runContext the run context
+     * @param spanName the name of the span
+     * @param additionalAttributes additional span attributes
+     * @param callable the bock of code
+     */
+    <V> V inCurrentContext(RunContext runContext, String spanName, Attributes additionalAttributes, Callable<V> callable);
+
+    /**
+     * Instrument a block of code with a trace context extracted from the execution.
+     *
+     * @see #inCurrentContext(Execution, String, Attributes, Callable)
+     */
+    <V> V inCurrentContext(Execution execution, String spanName, Callable<V> callable);
+
+    /**
+     * Instrument a block of code with a trace context extracted from the execution.
+     * Default span attributes will be added derived from the execution.
+     *
+     * @param execution the execution
+     * @param spanName the name of the span
+     * @param additionalAttributes additional span attributes
+     * @param callable the bock of code
+     */
+    <V> V inCurrentContext(Execution execution, String spanName, Attributes additionalAttributes, Callable<V> callable);
+
+    /**
+     * Instrument a block of code with a new trace context from a parent context extracted from the execution.
+     *
+     * @see #inNewContext(Execution, String, Attributes, Callable)
+     */
+    <V> V inNewContext(Execution execution, String spanName, Callable<V> callable);
+
+    /**
+     * Instrument a block of code with a new trace context from a parent context extracted from the execution.
+     * Default span attributes will be added derived from the execution.
+     *
+     * @param execution the execution
+     * @param spanName the name of the span
+     * @param additionalAttributes additional span attributes
+     * @param callable the bock of code
+     */
+    <V> V inNewContext(Execution execution, String spanName, Attributes additionalAttributes, Callable<V> callable);
+
+    @FunctionalInterface
+    interface Callable<V> {
+        V call();
+    }
+
+    @FunctionalInterface
+    interface CallableChecked<R, E extends Exception> {
+        R call() throws E;
+    }
+
+    static <R, E extends Exception> Callable<R> throwCallable(Rethrow.CallableChecked<R, E> runnable) throws E {
+        return () -> {
+            try {
+                return runnable.call();
+            } catch (Exception exception) {
+                return throwException(exception);
+            }
+        };
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <E extends Exception, R> R throwException(Exception exception) throws E {
+        throw (E) exception;
+    }
+}

--- a/core/src/main/java/io/kestra/core/trace/TracerFactory.java
+++ b/core/src/main/java/io/kestra/core/trace/TracerFactory.java
@@ -1,0 +1,46 @@
+package io.kestra.core.trace;
+
+import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.api.common.Attributes;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+
+/**
+ * Creates <code>Trace</code> instances.
+ *
+ * @see Tracer
+ */
+@Singleton
+public class TracerFactory {
+    @Inject
+    private OpenTelemetry openTelemetry;
+
+    @Inject
+    private io.opentelemetry.api.trace.Tracer tracer;
+
+    @Inject
+    private TracesConfiguration tracesConfiguration;
+
+    /**
+     * Get a tracer for a class with a given prefix for the span names.
+     */
+    public Tracer getTracer(Class<?> clazz, String spanNamePrefix) {
+        TraceLevel level = levelFromConfiguration(clazz.getName());
+        Attributes attributes = TraceUtils.attributesFrom(clazz);
+        return level == TraceLevel.DISABLED ? new NoopTracer() : new DefaultTracer(openTelemetry, tracer, spanNamePrefix, level, attributes);
+    }
+
+    private TraceLevel levelFromConfiguration(String name) {
+        if (name == null) {
+            return tracesConfiguration.root();
+        } else if(tracesConfiguration.categories().containsKey(name)) {
+            return tracesConfiguration.categories().get(name);
+        } else {
+            if (name.contains(".")) {
+                return levelFromConfiguration(name.substring(0, name.lastIndexOf('.')));
+            } else {
+                return tracesConfiguration.root();
+            }
+        }
+    }
+}

--- a/core/src/main/java/io/kestra/core/trace/TracesConfiguration.java
+++ b/core/src/main/java/io/kestra/core/trace/TracesConfiguration.java
@@ -1,0 +1,19 @@
+package io.kestra.core.trace;
+
+import io.micronaut.context.annotation.ConfigurationProperties;
+import io.micronaut.core.bind.annotation.Bindable;
+import io.micronaut.core.convert.format.MapFormat;
+import jakarta.validation.constraints.NotNull;
+
+import java.util.Map;
+
+@ConfigurationProperties("kestra.traces")
+public record TracesConfiguration (
+    @NotNull @Bindable(defaultValue = "DISABLED")
+    TraceLevel root,
+
+    @NotNull @Bindable(defaultValue = "{}")
+    @MapFormat(transformation = MapFormat.MapTransformation.FLAT)
+    Map<String, TraceLevel> categories
+) {
+}

--- a/core/src/main/java/io/kestra/core/trace/propagation/ExecutionTextMapGetter.java
+++ b/core/src/main/java/io/kestra/core/trace/propagation/ExecutionTextMapGetter.java
@@ -1,0 +1,29 @@
+package io.kestra.core.trace.propagation;
+
+import io.kestra.core.models.executions.Execution;
+import io.opentelemetry.context.propagation.TextMapGetter;
+
+import javax.annotation.Nullable;
+import java.util.List;
+
+public class ExecutionTextMapGetter implements TextMapGetter<Execution> {
+    public static final ExecutionTextMapGetter INSTANCE = new ExecutionTextMapGetter();
+
+    @Override
+    public Iterable<String> keys(Execution carrier) {
+        return List.of("traceparent");
+    }
+
+    @Nullable
+    @Override
+    public String get(@Nullable Execution carrier, String key) {
+        if (carrier == null) {
+            return null;
+        }
+
+        return switch(key) {
+            case "traceparent" -> carrier.getTraceParent();
+            default -> null;
+        };
+    }
+}

--- a/core/src/main/java/io/kestra/core/trace/propagation/ExecutionTextMapSetter.java
+++ b/core/src/main/java/io/kestra/core/trace/propagation/ExecutionTextMapSetter.java
@@ -1,0 +1,21 @@
+package io.kestra.core.trace.propagation;
+
+import io.kestra.core.models.executions.Execution;
+import io.opentelemetry.context.propagation.TextMapSetter;
+
+import javax.annotation.Nullable;
+
+public class ExecutionTextMapSetter implements TextMapSetter<Execution> {
+    public static final ExecutionTextMapSetter INSTANCE = new ExecutionTextMapSetter();
+
+    @Override
+    public void set(@Nullable Execution carrier, String key, String value) {
+        if (carrier != null) {
+            switch (key) {
+                case "traceparent" -> carrier.setTraceParent(value);
+                default -> {
+                }
+            }
+        }
+    }
+}

--- a/core/src/main/java/io/kestra/core/trace/propagation/RunContextTextMapGetter.java
+++ b/core/src/main/java/io/kestra/core/trace/propagation/RunContextTextMapGetter.java
@@ -1,0 +1,29 @@
+package io.kestra.core.trace.propagation;
+
+import io.kestra.core.runners.RunContext;
+import io.opentelemetry.context.propagation.TextMapGetter;
+
+import javax.annotation.Nullable;
+import java.util.List;
+
+public class RunContextTextMapGetter implements TextMapGetter<RunContext> {
+    public static final RunContextTextMapGetter INSTANCE = new RunContextTextMapGetter();
+
+    @Override
+    public Iterable<String> keys(RunContext carrier) {
+        return List.of("traceparent");
+    }
+
+    @Nullable
+    @Override
+    public String get(@Nullable RunContext carrier, String key) {
+        if (carrier == null) {
+            return null;
+        }
+
+        return switch(key) {
+            case "traceparent" -> carrier.getTraceParent();
+            default -> null;
+        };
+    }
+}

--- a/core/src/main/java/io/kestra/core/trace/propagation/RunContextTextMapSetter.java
+++ b/core/src/main/java/io/kestra/core/trace/propagation/RunContextTextMapSetter.java
@@ -1,0 +1,21 @@
+package io.kestra.core.trace.propagation;
+
+import io.kestra.core.runners.RunContext;
+import io.opentelemetry.context.propagation.TextMapSetter;
+
+import javax.annotation.Nullable;
+
+public class RunContextTextMapSetter implements TextMapSetter<RunContext> {
+    public static final RunContextTextMapSetter INSTANCE = new RunContextTextMapSetter();
+
+    @Override
+    public void set(@Nullable RunContext carrier, String key, String value) {
+        if (carrier != null) {
+            switch (key) {
+                case "traceparent" -> carrier.setTraceParent(value);
+                default -> {
+                }
+            }
+        }
+    }
+}

--- a/core/src/main/java/io/kestra/core/utils/Rethrow.java
+++ b/core/src/main/java/io/kestra/core/utils/Rethrow.java
@@ -1,6 +1,5 @@
 package io.kestra.core.utils;
 
-import java.util.concurrent.Callable;
 import java.util.function.*;
 
 public final class Rethrow {
@@ -110,16 +109,6 @@ public final class Rethrow {
                 runnable.run();
             } catch (Exception exception) {
                 throwException(exception);
-            }
-        };
-    }
-
-    public static <R, E extends Exception> Callable<R> throwCallable(CallableChecked<R, E> runnable) throws E {
-        return () -> {
-            try {
-                return runnable.call();
-            } catch (Exception exception) {
-                return throwException(exception);
             }
         };
     }

--- a/docker-compose-ci.yml
+++ b/docker-compose-ci.yml
@@ -22,3 +22,14 @@ services:
     ports:
       - 5432:5432
     restart: on-failure
+
+#  jaeger-all-in-one:
+#    image: jaegertracing/all-in-one:latest
+#    ports:
+#      - "16686:16686" # Jaeger UI
+#      - "14268:14268" # Receive legacy OpenTracing traces, optional
+#      - "4317:4317"   # OTLP gRPC receiver
+#      - "4318:4318"   # OTLP HTTP receiver
+#      - "14250:14250" # Receive from external otel-collector, optional
+#    environment:
+#      - COLLECTOR_OTLP_ENABLED=true


### PR DESCRIPTION
Fixes #6149

Experimental support for OpenTelemetry traces.
Creates spans in:
- The API
- The Executor execution queue
- The Worker for each runnable task execution

It propagates the traces from:
- the API to the Executor
- the Executor to the Worker
- Any HTTP request done by any task that uses our common HttpClient

It is disabled by default, with a way to disable traces for each component individually.

See screenshots of what it does when use with Jaeger.

![Capture d’écran du 2024-12-11 13-29-07](https://github.com/user-attachments/assets/dac75e3f-840d-444f-8700-1e9d8350821a)


![Capture d’écran du 2024-12-11 13-28-41](https://github.com/user-attachments/assets/d53fd95d-8d7f-4b4f-b84e-4bfa09672736)

