### PR TITLE
fix: correct the description for DayWeek condition

### DIFF
--- a/core/src/main/java/io/kestra/plugin/core/condition/DayWeek.java
+++ b/core/src/main/java/io/kestra/plugin/core/condition/DayWeek.java
@@ -22,7 +22,7 @@ import jakarta.validation.constraints.NotNull;
 @Getter
 @NoArgsConstructor
 @Schema(
-    title = "Condition to allow events on weekdays."
+    title = "Condition to allow events on a particular day of the week."
 )
 @Plugin(
     examples = {


### PR DESCRIPTION
The existing condition was misleading as it appeared to state weekdays implying Monday-Friday.