### PR TITLE
fix(ui): amend flow concurrency overview

### DIFF
--- a/ui/src/components/flows/FlowConcurrency.vue
+++ b/ui/src/components/flows/FlowConcurrency.vue
@@ -1,17 +1,17 @@
 <template>
     <template v-if="flow.concurrency">
         <div v-if="runningCount > 0 || !runningCountSet" :class="{'d-none': !runningCountSet}">
-            <el-card class="mb-1">
+            <el-card class="mb-3">
                 <div class="row mb-3">
                     <span class="col d-flex align-items-center">
-                        <h5 class="m-3">RUNNING</h5> {{ runningCount }} / {{ flow.concurrency.limit }} {{ $t('active-slots') }}
+                        <h5 class="m-3">RUNNING</h5> {{ runningCount }}/{{ flow.concurrency.limit }} {{ $t('active-slots') }}
                     </span>
                     <span class="col d-flex justify-content-end align-items-center">
-                        {{ $t('behavior') }}: <status class="mx-2" :status="flow.concurrency.behavior" />
+                        {{ $t('behavior') }}: <status class="mx-2" :status="flow.concurrency.behavior" size="small" />
                     </span>
                 </div>
                 <div class="progressbar mb-3">
-                    <el-progress :stroke-width="40" color="#5BB8FF" :percentage="progress" :show-text="false" />
+                    <el-progress :stroke-width="16" color="#5BB8FF" :percentage="progress" :show-text="false" />
                 </div>
             </el-card>
             <el-card>
@@ -90,5 +90,15 @@
     .bg-purple {
         height: 100%;
         width: 100%;
+    }
+    h5 {
+        font-weight: bold;
+        margin-left: 0 !important;
+    }
+
+    :deep(.el-progress) {
+        .el-progress-bar, .el-progress-bar__outer, .el-progress-bar__inner {
+            border-radius: var(--bs-border-radius);
+        }
     }
 </style>

--- a/ui/src/components/flows/FlowConcurrency.vue
+++ b/ui/src/components/flows/FlowConcurrency.vue
@@ -1,37 +1,39 @@
 <template>
-    <div v-if="flow.concurrency && !runningCountSet" :class="{'d-none': !runningCountSet}">
-        <el-card class="mb-1">
-            <div class="row mb-3">
-                <span class="col d-flex align-items-center">
-                    <h5 class="m-3">RUNNING</h5> {{ runningCount }} / {{ flow.concurrency.limit }} {{ $t('active-slots') }}
-                </span>
-                <span class="col d-flex justify-content-end align-items-center">
-                    {{ $t('behavior') }}: <status class="mx-2" :status="flow.concurrency.behavior" />
-                </span>
-            </div>
-            <div class="progressbar mb-3">
-                <el-progress :stroke-width="40" color="#5BB8FF" :percentage="progress" :show-text="false" />
-            </div>
-        </el-card>
-        <el-card>
-            <executions
-                :restore-url="false"
-                :topbar="false"
-                :namespace="flow.namespace"
-                :flow-id="flow.id"
-                is-concurrency
-                :statuses="[State.QUEUED, State.RUNNING, State.PAUSED]"
-                @state-count="setRunningCount"
-                :filter="false"
-            />
-        </el-card>
-    </div>
-    <empty-state
-        v-else-if="runningCount === 0"
-        :title="$t('concurrency-view.title_no_executions')"
-        :description="$t('concurrency-view.desc_no_executions')"
-        :image="noConcurrencyImage"
-    />
+    <template v-if="flow.concurrency">
+        <div v-if="runningCount > 0 || !runningCountSet" :class="{'d-none': !runningCountSet}">
+            <el-card class="mb-1">
+                <div class="row mb-3">
+                    <span class="col d-flex align-items-center">
+                        <h5 class="m-3">RUNNING</h5> {{ runningCount }} / {{ flow.concurrency.limit }} {{ $t('active-slots') }}
+                    </span>
+                    <span class="col d-flex justify-content-end align-items-center">
+                        {{ $t('behavior') }}: <status class="mx-2" :status="flow.concurrency.behavior" />
+                    </span>
+                </div>
+                <div class="progressbar mb-3">
+                    <el-progress :stroke-width="40" color="#5BB8FF" :percentage="progress" :show-text="false" />
+                </div>
+            </el-card>
+            <el-card>
+                <executions
+                    :restore-url="false"
+                    :topbar="false"
+                    :namespace="flow.namespace"
+                    :flow-id="flow.id"
+                    is-concurrency
+                    :statuses="[State.QUEUED, State.RUNNING, State.PAUSED]"
+                    @state-count="setRunningCount"
+                    :filter="false"
+                />
+            </el-card>
+        </div>
+        <empty-state
+            v-else
+            :title="$t('concurrency-view.title_no_executions')"
+            :description="$t('concurrency-view.desc_no_executions')"
+            :image="noConcurrencyImage"
+        />
+    </template>
     <empty-state
         v-else
         :title="$t('concurrency-view.title_no_limit')"
@@ -49,11 +51,13 @@
     import noConcurrencyImage from "../../assets/no_concurrency.svg";
 
     export default {
+        inheritAttrs: false,
         components: {
-            Status, 
+            Status,
             Executions,
             EmptyState
         },
+        emits: ["expand-subflow"],
         data() {
             return {
                 runningCount: 0,


### PR DESCRIPTION
### What changes are being made and why?

Rather straightforward fix inconsistent behavior of the flow's concurrency overview.

closes #6811

---

### How the changes have been QAed?

```yaml
id: autotest
namespace: autotest

concurrency:
  limit: 2

tasks:
   - id: wait
     type: io.kestra.plugin.core.flow.Sleep
     duration: PT2M
```