### PR TITLE
feat: optimize queue usage for follow endpoints

### DIFF
--- a/webserver/src/main/java/io/kestra/webserver/controllers/api/ExecutionController.java
+++ b/webserver/src/main/java/io/kestra/webserver/controllers/api/ExecutionController.java
@@ -107,9 +107,7 @@ import java.time.Duration;
 import java.time.Instant;
 import java.time.ZonedDateTime;
 import java.util.*;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeoutException;
-import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 
 import static io.kestra.core.models.Label.CORRELATION_ID;
@@ -619,24 +617,23 @@ public class ExecutionController {
                         ));
                     }
 
+                    String subscriberId = UUID.randomUUID().toString();
                     // Use Flux to wait for completion using the streaming service
                     return Flux.<Event<Execution>>create(emitter -> {
                             streamingService.registerSubscriber(
                                 executionWithInputs.getId(),
-                                emitter
+                                subscriberId,
+                                emitter,
+                                flow
                             );
                         })
-                        .filter(event -> "end".equals(event.getId()))
+                        .last()
                         .map(Event::getData)
                         .map(execution -> ExecutionResponse.fromExecution(
                             execution,
                             executionUrl(execution)
                         ))
-                        .next()
-                        .doFinally(signalType -> {
-                            // This will be called in all completion scenarios (normal, error, or cancel)
-                            log.debug("SSE connection finished with signal: {}", signalType);
-                        });
+                        .doFinally(signalType -> streamingService.unregisterSubscriber(executionWithInputs.getId(), subscriberId));
                 } catch (QueueException e) {
                     return Mono.error(e);
                 }
@@ -1485,18 +1482,14 @@ public class ExecutionController {
         return HttpResponse.ok(BulkResponse.builder().count(executions.size()).build());
     }
 
-    private boolean isStopFollow(Flow flow, Execution execution) {
-        return conditionService.isTerminatedWithListeners(flow, execution) &&
-            execution.getState().getCurrent() != State.Type.PAUSED;
-    }
-
     @ExecuteOn(TaskExecutors.IO)
     @Get(uri = "/{executionId}/follow", produces = MediaType.TEXT_EVENT_STREAM)
     @Operation(tags = {"Executions"}, summary = "Follow an execution")
     public Flux<Event<Execution>> follow(
         @Parameter(description = "The execution id") @PathVariable String executionId
     ) {
-        return Flux.create(emitter -> {
+        String subscriberId = UUID.randomUUID().toString();
+        return Flux.<Event<Execution>>create(emitter -> {
             // Send initial event
             emitter.next(Event.of(Execution.builder().id(executionId).build()).id("start"));
 
@@ -1511,7 +1504,7 @@ public class ExecutionController {
                 Flow flow = flowRepository.findByExecutionWithoutAcl(execution);
 
                 // If execution is already complete, just send final state
-                if (isStopFollow(flow, execution)) {
+                if (streamingService.isStopFollow(flow, execution)) {
                     emitter.next(Event.of(execution).id("end"));
                     emitter.complete();
                     return;
@@ -1521,9 +1514,7 @@ public class ExecutionController {
                 emitter.next(Event.of(execution).id("progress"));
 
                 // Register for updates
-                streamingService.registerSubscriber(executionId, emitter);
-
-                Schedulers.boundedElastic().schedule(() -> {
+                streamingService.registerSubscriber(executionId, subscriberId, emitter, flow);
             } catch (TimeoutException e) {
                 emitter.error(new HttpStatusException(HttpStatus.NOT_FOUND,
                     "Unable to find execution " + executionId));
@@ -1531,7 +1522,8 @@ public class ExecutionController {
                 emitter.error(new HttpStatusException(HttpStatus.NOT_FOUND,
                     "Unable to find flow for execution " + executionId));
             }
-        }, FluxSink.OverflowStrategy.BUFFER);
+        }, FluxSink.OverflowStrategy.BUFFER)
+            .doFinally(ignored -> streamingService.unregisterSubscriber(executionId, subscriberId));
     }
 
     @ExecuteOn(TaskExecutors.IO)

--- a/webserver/src/main/java/io/kestra/webserver/controllers/api/ExecutionController.java
+++ b/webserver/src/main/java/io/kestra/webserver/controllers/api/ExecutionController.java
@@ -39,6 +39,7 @@ import io.kestra.plugin.core.trigger.Webhook;
 import io.kestra.webserver.responses.BulkErrorResponse;
 import io.kestra.webserver.responses.BulkResponse;
 import io.kestra.webserver.responses.PagedResults;
+import io.kestra.webserver.services.ExecutionStreamingService;
 import io.kestra.webserver.utils.PageableUtils;
 import io.kestra.webserver.utils.RequestUtils;
 import io.kestra.webserver.utils.filepreview.FileRender;
@@ -151,6 +152,9 @@ public class ExecutionController {
 
     @Inject
     private ConcurrencyLimitService concurrencyLimitService;
+
+    @Inject
+    private ExecutionStreamingService streamingService;
 
     @Inject
     @Named(QueueFactoryInterface.EXECUTION_NAMED)
@@ -597,9 +601,8 @@ public class ExecutionController {
         Flow flow = flowService.getFlowIfExecutableOrThrow(tenantService.resolveTenant(), namespace, id, revision);
         List<Label> parsedLabels = parseLabels(labels);
         Execution current = Execution.newExecution(flow, null, parsedLabels, scheduleDate);
-        final AtomicReference<Runnable> disposable = new AtomicReference<>();
-        Mono<CompletableFuture<ExecutionResponse>> handle = flowInputOutput.readExecutionInputs(flow, current, inputs)
-            .handle((executionInputs, sink) -> {
+        return flowInputOutput.readExecutionInputs(flow, current, inputs)
+            .flatMap(executionInputs -> {
                 Execution executionWithInputs = current.withInputs(executionInputs);
                 try {
                     // inject the traceparent into the execution
@@ -609,32 +612,35 @@ public class ExecutionController {
                     executionQueue.emit(executionWithInputs);
                     eventPublisher.publishEvent(new CrudEvent<>(executionWithInputs, CrudEventType.CREATE));
 
-                    CompletableFuture<ExecutionResponse> future = new CompletableFuture<>();
                     if (!wait) {
-                        future.complete(ExecutionResponse.fromExecution(executionWithInputs, executionUrl(executionWithInputs)));
-                    } else {
-                        disposable.set(this.executionQueue.receive(either -> {
-                            if (either.isRight()) {
-                                log.error("Unable to deserialize the execution: {}", either.getRight().getMessage());
-                                sink.complete();
-                            }
-
-                            Execution item = either.getLeft();
-                            if (item.getId().equals(executionWithInputs.getId()) && this.isStopFollow(flow, item)) {
-                                future.complete(ExecutionResponse.fromExecution(item, executionUrl(item)));
-                            }
-                        }));
+                        return Mono.just(ExecutionResponse.fromExecution(
+                            executionWithInputs,
+                            executionUrl(executionWithInputs)
+                        ));
                     }
-                    sink.next(future);
+
+                    // Use Flux to wait for completion using the streaming service
+                    return Flux.<Event<Execution>>create(emitter -> {
+                            streamingService.registerSubscriber(
+                                executionWithInputs.getId(),
+                                emitter
+                            );
+                        })
+                        .filter(event -> "end".equals(event.getId()))
+                        .map(Event::getData)
+                        .map(execution -> ExecutionResponse.fromExecution(
+                            execution,
+                            executionUrl(execution)
+                        ))
+                        .next()
+                        .doFinally(signalType -> {
+                            // This will be called in all completion scenarios (normal, error, or cancel)
+                            log.debug("SSE connection finished with signal: {}", signalType);
+                        });
                 } catch (QueueException e) {
-                    sink.error(e);
+                    return Mono.error(e);
                 }
             });
-        return handle.flatMap(Mono::fromFuture).doFinally(ignored -> {
-            if (disposable.get() != null) {
-                disposable.get().run();
-            }
-        });
     }
 
     private URI executionUrl(Execution execution) {
@@ -1490,71 +1496,42 @@ public class ExecutionController {
     public Flux<Event<Execution>> follow(
         @Parameter(description = "The execution id") @PathVariable String executionId
     ) {
-        AtomicReference<Runnable> cancel = new AtomicReference<>();
+        return Flux.create(emitter -> {
+            // Send initial event
+            emitter.next(Event.of(Execution.builder().id(executionId).build()).id("start"));
 
-        return Flux
-            .<Event<Execution>>create(emitter -> {
-                // send a first "empty" event so the SSE is correctly initialized in the frontend in case there are no logs
-                emitter.next(Event.of(Execution.builder().id(executionId).build()).id("start"));
+            // Check if execution exists
+            try {
+                Execution execution = Await.until(
+                    () -> executionRepository.findById(tenantService.resolveTenant(), executionId).orElse(null),
+                    Duration.ofMillis(500),
+                    Duration.ofSeconds(10)
+                );
 
-                // already finished execution
-                Execution execution;
-                try {
-                    execution = Await.until(
-                        () -> executionRepository.findById(tenantService.resolveTenant(), executionId).orElse(null),
-                        Duration.ofMillis(500),
-                        Duration.ofSeconds(10)
-                    );
-                } catch (TimeoutException e) {
-                    emitter.error(new HttpStatusException(HttpStatus.NOT_FOUND, "Unable to find the execution " + executionId));
-                    return;
-                }
+                Flow flow = flowRepository.findByExecutionWithoutAcl(execution);
 
-                Flow flow;
-                try {
-                    flow = flowRepository.findByExecutionWithoutAcl(execution);
-                } catch (IllegalStateException e)  {
-                    emitter.error(new HttpStatusException(HttpStatus.NOT_FOUND, "Unable to find the flow for the execution " + executionId));
-                    return;
-                }
-
-                if (this.isStopFollow(flow, execution)) {
+                // If execution is already complete, just send final state
+                if (isStopFollow(flow, execution)) {
                     emitter.next(Event.of(execution).id("end"));
                     emitter.complete();
                     return;
                 }
 
-                // emit the repository one first in order to wait the queue connections
+                // Send current state
                 emitter.next(Event.of(execution).id("progress"));
 
-                // consume new value
-                Runnable receive = this.executionQueue.receive(either -> {
-                    if (either.isRight()) {
-                        log.error("Unable to deserialize the execution: {}", either.getRight().getMessage());
-                        return;
-                    }
+                // Register for updates
+                streamingService.registerSubscriber(executionId, emitter);
 
-                    Execution current = either.getLeft();
-                    if (current.getId().equals(executionId)) {
-
-                        emitter.next(Event.of(current).id("progress"));
-
-                        if (this.isStopFollow(flow, current)) {
-                            emitter.next(Event.of(current).id("end"));
-                            emitter.complete();
-                        }
-                    }
-                });
-
-                cancel.set(receive);
-            }, FluxSink.OverflowStrategy.BUFFER)
-            .doFinally(ignored -> {
                 Schedulers.boundedElastic().schedule(() -> {
-                    if (cancel.get() != null) {
-                        cancel.get().run();
-                    }
-                });
-            });
+            } catch (TimeoutException e) {
+                emitter.error(new HttpStatusException(HttpStatus.NOT_FOUND,
+                    "Unable to find execution " + executionId));
+            } catch (IllegalStateException e) {
+                emitter.error(new HttpStatusException(HttpStatus.NOT_FOUND,
+                    "Unable to find flow for execution " + executionId));
+            }
+        }, FluxSink.OverflowStrategy.BUFFER);
     }
 
     @ExecuteOn(TaskExecutors.IO)

--- a/webserver/src/main/java/io/kestra/webserver/services/ExecutionStreamingService.java
+++ b/webserver/src/main/java/io/kestra/webserver/services/ExecutionStreamingService.java
@@ -5,7 +5,6 @@ import io.kestra.core.models.flows.Flow;
 import io.kestra.core.models.flows.State;
 import io.kestra.core.queues.QueueFactoryInterface;
 import io.kestra.core.queues.QueueInterface;
-import io.kestra.core.repositories.FlowRepositoryInterface;
 import io.kestra.core.services.ConditionService;
 import io.micronaut.http.sse.Event;
 import jakarta.annotation.PostConstruct;
@@ -14,35 +13,42 @@ import jakarta.inject.Inject;
 import jakarta.inject.Named;
 import jakarta.inject.Singleton;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.tuple.Pair;
 import reactor.core.publisher.FluxSink;
 
 import java.util.Map;
-import java.util.Set;
-import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * This service offers a fanout mechanism so a single consumer of the execution queue can dispatch execution
+ * messages to multiple consumers.
+ * It is designed to be used for 'follow' endpoints that using SSE to follow a flow execution.
+ * <p>
+ * Consumers need first to register themselves via {@link #registerSubscriber(String, String, FluxSink, Flow)},
+ * then unregister (ideally in a finally block to avoid any memory leak) via {@link #unregisterSubscriber(String, String)}.
+ */
 @Slf4j
 @Singleton
 public class ExecutionStreamingService {
-    private final Map<String, Map<String, FluxSink<Event<Execution>>>> subscribers = new ConcurrentHashMap<>();
+    private final Map<String, Map<String, Pair<FluxSink<Event<Execution>>, Flow>>> subscribers = new ConcurrentHashMap<>();
+    private final Object subscriberLock = new Object();
 
-    @Named(QueueFactoryInterface.EXECUTION_NAMED)
     private final QueueInterface<Execution> executionQueue;
-    private final FlowRepositoryInterface flowRepository;
     private final ConditionService conditionService;
+
     private Runnable queueConsumer;
+
     @Inject
     public ExecutionStreamingService(
-        QueueInterface<Execution> executionQueue,
-        FlowRepositoryInterface flowRepository,
+        @Named(QueueFactoryInterface.EXECUTION_NAMED) QueueInterface<Execution> executionQueue,
         ConditionService conditionService
     ) {
         this.executionQueue = executionQueue;
-        this.flowRepository = flowRepository;
         this.conditionService = conditionService;
     }
 
     @PostConstruct
-    private void startQueueConsumer() {
+    void startQueueConsumer() {
         // Single queue consumer
         this.queueConsumer = executionQueue.receive(either -> {
             if (either.isRight()) {
@@ -54,17 +60,18 @@ public class ExecutionStreamingService {
             String executionId = execution.getId();
 
             // Get all subscribers for this execution
-            Map<String, FluxSink<Event<Execution>>> executionSubscribers = subscribers.get(executionId);
+            Map<String, Pair<FluxSink<Event<Execution>>, Flow>> executionSubscribers = subscribers.get(executionId);
 
             if (executionSubscribers != null && !executionSubscribers.isEmpty()) {
-                executionSubscribers.values().forEach(sink -> {
+                executionSubscribers.values().forEach(pair -> {
+                    var sink = pair.getLeft();
+                    var flow = pair.getRight();
                     try {
-                        sink.next(Event.of(execution).id("progress"));
-
-                        Flow flow = flowRepository.findByExecutionWithoutAcl(execution);
                         if (isStopFollow(flow, execution)) {
                             sink.next(Event.of(execution).id("end"));
                             sink.complete();
+                        } else {
+                            sink.next(Event.of(execution).id("progress"));
                         }
                     } catch (Exception e) {
                         log.error("Error sending execution update", e);
@@ -75,27 +82,39 @@ public class ExecutionStreamingService {
         });
     }
 
-    public void registerSubscriber(String executionId, FluxSink<Event<Execution>> sink) {
-        String subscriberId = UUID.randomUUID().toString();
-
-        subscribers.computeIfAbsent(executionId, k -> new ConcurrentHashMap<>())
-            .put(subscriberId, sink);
-
-        // Cleanup when subscriber disconnects
-        sink.onCancel(() -> unregisterSubscriber(executionId, subscriberId));
+    /**
+     * Register a subscriber to an execution.
+     * All subscribers must ensure to call {@link #unregisterSubscriber(String, String)} to avoid any memory leak.
+     */
+    public void registerSubscriber(String executionId, String subscriberId, FluxSink<Event<Execution>> sink, Flow flow) {
+        // it needs to be synchronized as we get and remove if empty, so we must be sure that nobody else is adding a new one in-between
+        synchronized (subscriberLock) {
+            subscribers.computeIfAbsent(executionId, k -> new ConcurrentHashMap<>())
+                .put(subscriberId, Pair.of(sink, flow));
+        }
     }
 
+    /**
+     * Unregister a subscribers.
+     * This is advised to do it in a finally block to be sure to free resources.
+     */
     public void unregisterSubscriber(String executionId, String subscriberId) {
-        Map<String, FluxSink<Event<Execution>>> executionSubscribers = subscribers.get(executionId);
-        if (executionSubscribers != null) {
-            executionSubscribers.remove(subscriberId);
-            if (executionSubscribers.isEmpty()) {
-                subscribers.remove(executionId);
+        // it needs to be synchronized as we get and remove if empty, so we must be sure that nobody else is adding a new one in-between
+        synchronized (subscriberLock) {
+            Map<String, Pair<FluxSink<Event<Execution>>, Flow>> executionSubscribers = subscribers.get(executionId);
+            if (executionSubscribers != null) {
+                executionSubscribers.remove(subscriberId);
+                if (executionSubscribers.isEmpty()) {
+                    subscribers.remove(executionId);
+                }
             }
         }
     }
 
-    private boolean isStopFollow(Flow flow, Execution execution) {
+    /**
+     * Utility method to know if following an execution can be stopped.
+     */
+    public boolean isStopFollow(Flow flow, Execution execution) {
         return conditionService.isTerminatedWithListeners(flow, execution) &&
             execution.getState().getCurrent() != State.Type.PAUSED;
     }

--- a/webserver/src/main/java/io/kestra/webserver/services/ExecutionStreamingService.java
+++ b/webserver/src/main/java/io/kestra/webserver/services/ExecutionStreamingService.java
@@ -1,0 +1,109 @@
+package io.kestra.webserver.services;
+
+import io.kestra.core.models.executions.Execution;
+import io.kestra.core.models.flows.Flow;
+import io.kestra.core.models.flows.State;
+import io.kestra.core.queues.QueueFactoryInterface;
+import io.kestra.core.queues.QueueInterface;
+import io.kestra.core.repositories.FlowRepositoryInterface;
+import io.kestra.core.services.ConditionService;
+import io.micronaut.http.sse.Event;
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
+import jakarta.inject.Inject;
+import jakarta.inject.Named;
+import jakarta.inject.Singleton;
+import lombok.extern.slf4j.Slf4j;
+import reactor.core.publisher.FluxSink;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+@Slf4j
+@Singleton
+public class ExecutionStreamingService {
+    private final Map<String, Map<String, FluxSink<Event<Execution>>>> subscribers = new ConcurrentHashMap<>();
+
+    @Named(QueueFactoryInterface.EXECUTION_NAMED)
+    private final QueueInterface<Execution> executionQueue;
+    private final FlowRepositoryInterface flowRepository;
+    private final ConditionService conditionService;
+    private Runnable queueConsumer;
+    @Inject
+    public ExecutionStreamingService(
+        QueueInterface<Execution> executionQueue,
+        FlowRepositoryInterface flowRepository,
+        ConditionService conditionService
+    ) {
+        this.executionQueue = executionQueue;
+        this.flowRepository = flowRepository;
+        this.conditionService = conditionService;
+    }
+
+    @PostConstruct
+    private void startQueueConsumer() {
+        // Single queue consumer
+        this.queueConsumer = executionQueue.receive(either -> {
+            if (either.isRight()) {
+                log.error("Unable to deserialize execution: {}", either.getRight().getMessage());
+                return;
+            }
+
+            Execution execution = either.getLeft();
+            String executionId = execution.getId();
+
+            // Get all subscribers for this execution
+            Map<String, FluxSink<Event<Execution>>> executionSubscribers = subscribers.get(executionId);
+
+            if (executionSubscribers != null && !executionSubscribers.isEmpty()) {
+                executionSubscribers.values().forEach(sink -> {
+                    try {
+                        sink.next(Event.of(execution).id("progress"));
+
+                        Flow flow = flowRepository.findByExecutionWithoutAcl(execution);
+                        if (isStopFollow(flow, execution)) {
+                            sink.next(Event.of(execution).id("end"));
+                            sink.complete();
+                        }
+                    } catch (Exception e) {
+                        log.error("Error sending execution update", e);
+                        sink.error(e);
+                    }
+                });
+            }
+        });
+    }
+
+    public void registerSubscriber(String executionId, FluxSink<Event<Execution>> sink) {
+        String subscriberId = UUID.randomUUID().toString();
+
+        subscribers.computeIfAbsent(executionId, k -> new ConcurrentHashMap<>())
+            .put(subscriberId, sink);
+
+        // Cleanup when subscriber disconnects
+        sink.onCancel(() -> unregisterSubscriber(executionId, subscriberId));
+    }
+
+    public void unregisterSubscriber(String executionId, String subscriberId) {
+        Map<String, FluxSink<Event<Execution>>> executionSubscribers = subscribers.get(executionId);
+        if (executionSubscribers != null) {
+            executionSubscribers.remove(subscriberId);
+            if (executionSubscribers.isEmpty()) {
+                subscribers.remove(executionId);
+            }
+        }
+    }
+
+    private boolean isStopFollow(Flow flow, Execution execution) {
+        return conditionService.isTerminatedWithListeners(flow, execution) &&
+            execution.getState().getCurrent() != State.Type.PAUSED;
+    }
+
+    @PreDestroy
+    public void shutdown() {
+        if (queueConsumer != null) {
+            queueConsumer.run();
+        }
+    }
+}

--- a/webserver/src/test/java/io/kestra/webserver/controllers/api/ExecutionControllerTest.java
+++ b/webserver/src/test/java/io/kestra/webserver/controllers/api/ExecutionControllerTest.java
@@ -321,6 +321,8 @@ class ExecutionControllerTest {
         assertThat(results, is(notNullValue()));
         assertThat(results.size(), is(greaterThan(0)));
         assertThat(results.getLast().getData().getState().getCurrent(), is(State.Type.SUCCESS));
+        assertThat(results.getFirst().getId(), is("start"));
+        assertThat(results.getLast().getId(), is("end"));
     }
 
     private ExecutionController.EvalResult eval(Execution execution, String expression, int index) {


### PR DESCRIPTION
<!-- Thanks for submitting a Pull Request to Kestra. To help us review your contribution, please follow the guidelines below:

- Make sure that your commits follow the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) specification e.g. `feat(ui): add a new navigation menu item` or `fix(core): fix a bug in the core model` or `docs: update the README.md`. This will help us automatically generate the changelog.
- The title should briefly summarize the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share a flow example to help the reviewer understand and QA the change.
- Use "closes" to automatically close an issue. For example, `closes #1234` will close issue #1234. -->

### What changes are being made and why?
This PR introduces improvements to the follow endpoints for executions and logs in Kestra. It focuses on optimizing queue usage to enhance scalability and resource efficiency.

Key Changes:

Centralized Queue Management:

Implemented a singleton ExecutionStreamingService to manage a single queue consumer for all execution updates.
Reduces the creation of multiple queue consumers and threads for each connection.
Subscriber Pattern:

Introduced a subscription mechanism where clients (UI connections and wait=true executions) register as subscribers for specific execution IDs.
Updates are selectively broadcasted to relevant subscribers using a ConcurrentHashMap.

closes #6777  
<!--