### PR TITLE
feat(ui): Add sorting by last executed date in Flows tab

### DIFF
--- a/ui/src/components/flows/Flows.vue
+++ b/ui/src/components/flows/Flows.vue
@@ -142,6 +142,9 @@
                                 prop="state.startDate"
                                 :label="$t('last execution date')"
                                 v-if="user.hasAny(permission.EXECUTION)"
+                                sortable
+                                :sort-orders="['ascending', 'descending']"
+                                :sort-method="sortStartDate"
                             >
                                 <template #default="scope">
                                     <date-ago v-if="lastExecutionByFlowReady" :inverted="true" :date="getLastExecution(scope.row).startDate" />
@@ -568,8 +571,24 @@
             },
             rowClasses(row) {
                 return row && row.row && row.row.disabled ? "disabled" : "";
-            }
-        }
+            },
+            sortStartDate(a,b){
+                // In descending order, null values are displayed at the end
+                const startDateA = this.getLastExecution(a).startDate;
+                const startDateB = this.getLastExecution(b).startDate;
+                if (startDateA == null && startDateB == null) {
+                    return 0;
+                }
+                else if (startDateA == null) {
+                    return -1;
+                }
+                else if (startDateB == null) {
+                    return 1;
+                }
+  
+                return new Date(startDateA) - new Date(startDateB);
+
+            }}
     };
 </script>
 

--- a/ui/src/mixins/dataTableActions.js
+++ b/ui/src/mixins/dataTableActions.js
@@ -49,7 +49,13 @@ export default {
             }
         },
         onSort(sortItem) {
+            // derived columns will throw sql error if sorted as field is not present in db,instead sort them in Vue
+            const excludeSortColumns = ["state.startDate"];
+            if(excludeSortColumns.includes(sortItem.prop)){
+                this.internalSort = null;
+            }else{
             this.internalSort = this.sortString(sortItem);
+            }
 
             if (!this.embed && this.internalSort) {
                 const sort = this.internalSort;

--- a/ui/src/mixins/dataTableActions.js
+++ b/ui/src/mixins/dataTableActions.js
@@ -49,7 +49,7 @@ export default {
             }
         },
         onSort(sortItem) {
-            // derived columns will throw sql error if sorted as field is not present in db,instead sort them in Vue
+            // derived columns will throw sql error if column to be sorted is not present in db,instead sort them in Vue itself
             const excludeSortColumns = ["state.startDate"];
             if(excludeSortColumns.includes(sortItem.prop)){
                 this.internalSort = null;


### PR DESCRIPTION
This PR adds sorting functionality based on Last executed date.

### What changes are being made and why?



---

### How the changes have been QAed?
Before this change, Last Execution Date was not sortable.

On relying on backend Sorting via SQL, we encounter this error.
![image](https://github.com/user-attachments/assets/b9b2496d-b4b6-4442-a7ce-5259c5182d58)


So, We are relying on :sort-method functionality.
![image](https://github.com/user-attachments/assets/a2db302a-525b-4ae0-a3d3-f981521bcdea)

For ascending order,null values go on top(we might want a different behaviour,but that's upto the maintainers). 
![image](https://github.com/user-attachments/assets/6088718a-00e7-42d0-a1a7-96dd6b2385fd)

Closes #6774 
