### PR TITLE
Fixed Topology buttons functionality

### DIFF
--- a/ui/src/components/flows/ValidationError.vue
+++ b/ui/src/components/flows/ValidationError.vue
@@ -25,7 +25,7 @@
                             {{ $t("error detected") }}
                         </span>
                     </el-header>
-                    <el-main>{{ errors }}</el-main>
+                    <el-main v-for="error in errors" :key="error">{{ error }}</el-main>
                 </el-container>
             </template>
             <el-button v-bind="$attrs" :link="link" :size="size" type="default" class="error">

--- a/ui/src/components/flows/ValidationError.vue
+++ b/ui/src/components/flows/ValidationError.vue
@@ -25,7 +25,7 @@
                             {{ $t("error detected") }}
                         </span>
                     </el-header>
-                    <el-main v-for="error in errors" :key="error">{{ error }}</el-main>
+                    <el-main>{{ errors }}</el-main>
                 </el-container>
             </template>
             <el-button v-bind="$attrs" :link="link" :size="size" type="default" class="error">

--- a/ui/src/components/inputs/EditorView.vue
+++ b/ui/src/components/inputs/EditorView.vue
@@ -498,6 +498,9 @@
     const editorViewType = ref("YAML");
    
     const handleTopologyEditClick = (params) => {
+        if (viewType.value === editorViewTypes.TOPOLOGY) {
+            switchViewType(editorViewTypes.SOURCE_TOPOLOGY);
+        }
         editorViewType.value = "NO_CODE";
         nextTick(() => router.replace({query: {...route.query, ...params}}))
     }


### PR DESCRIPTION
Closes #6949 

### What changes are being made and why?

1. Added if statement to treat `TOPOLOGY` as `SOURCE_TOPOLOGY` in function `handleTopologyEditClick` while editing
2. In Validation.vue the string was treated as array 
