### PR TITLE
Fix/logger mdc

### DIFF
--- a/core/src/main/java/io/kestra/core/runners/DefaultRunContext.java
+++ b/core/src/main/java/io/kestra/core/runners/DefaultRunContext.java
@@ -474,6 +474,8 @@ public class DefaultRunContext extends RunContext {
         } catch (IOException ex) {
             logger().warn("Unable to cleanup worker task", ex);
         }
+
+        logger.resetMDC();
     }
 
     /**

--- a/core/src/main/java/io/kestra/core/runners/ExecutorService.java
+++ b/core/src/main/java/io/kestra/core/runners/ExecutorService.java
@@ -407,7 +407,7 @@ public class ExecutorService {
 
         logService.logExecution(
             newExecution,
-            flow.logger(),
+            logger,
             Level.INFO,
             "Flow completed with state {} in {}",
             newExecution.getState().getCurrent(),

--- a/core/src/main/java/io/kestra/core/runners/RunContext.java
+++ b/core/src/main/java/io/kestra/core/runners/RunContext.java
@@ -126,6 +126,7 @@ public abstract class RunContext {
 
     /**
      * Cleanup any temporary resources, files created through this context.
+     * Also reset logs MDC so the logger should not be used after this point.
      */
     public abstract void cleanup();
 

--- a/core/src/main/java/io/kestra/core/runners/RunContextLogger.java
+++ b/core/src/main/java/io/kestra/core/runners/RunContextLogger.java
@@ -145,52 +145,8 @@ public class RunContextLogger implements Supplier<org.slf4j.Logger> {
     public org.slf4j.Logger logger() {
         if (this.logger == null) {
             synchronized (this) {
-                if (this.logger == null) { // Double Checked Locking (DCL) idiom
-                    LoggerContext loggerContext = new LoggerContext();
-                    LogbackMDCAdapter mdcAdapter = new LogbackMDCAdapter();
-
-                    loggerContext.setMDCAdapter(mdcAdapter);
-                    loggerContext.start();
-
-                    Logger logger = loggerContext.getLogger(this.loggerName);
-
-                    if (this.logEntry != null) {
-                        MDC.setContextMap(this.logEntry.toMap());
-                    }
-
-                    // unit tests don't always have the log queue as we construct a logger directly without it
-                    if (this.logQueue != null && !this.logToFile) {
-                        ContextAppender contextAppender = new ContextAppender(this, logger, this.logQueue, this.logEntry);
-                        contextAppender.setContext(loggerContext);
-                        contextAppender.start();
-
-                        logger.addAppender(contextAppender);
-                    }
-
-                    if (this.logToFile) {
-                        try {
-                            this.logFile = File.createTempFile("log", ".txt");
-                            this.logFileOS = new BufferedOutputStream(new FileOutputStream(logFile));
-                        } catch (IOException e) {
-                            throw new UncheckedIOException(e);
-                        }
-                        FileAppender fileAppender = new FileAppender(this, logger, this.logFileOS);
-                        fileAppender.setContext(loggerContext);
-                        fileAppender.start();
-
-                        logger.addAppender(fileAppender);
-                    }
-
-                    // forward flow logs to the server log
-                    ForwardAppender forwardAppender = new ForwardAppender(this, logger);
-                    forwardAppender.setContext(loggerContext);
-                    forwardAppender.start();
-                    logger.addAppender(forwardAppender);
-
-                    logger.setLevel(this.loglevel);
-                    logger.setAdditive(true);
-
-                    this.logger = logger;
+                if (this.logger == null) { // Double-Checked Locking (DCL) idiom
+                    this.logger = initializeLogger();
                 }
             }
         }
@@ -198,8 +154,55 @@ public class RunContextLogger implements Supplier<org.slf4j.Logger> {
         return this.logger;
     }
 
+    private Logger initializeLogger() {
+        LoggerContext loggerContext = new LoggerContext();
+        LogbackMDCAdapter mdcAdapter = new LogbackMDCAdapter();
+
+        loggerContext.setMDCAdapter(mdcAdapter);
+        loggerContext.start();
+
+        Logger newLogger = loggerContext.getLogger(this.loggerName);
+
+        if (this.logEntry != null) {
+            loggerContext.getMDCAdapter().setContextMap(this.logEntry.toMap());
+        }
+
+        // unit tests don't always have the log queue as we construct a logger directly without it
+        if (this.logQueue != null && !this.logToFile) {
+            ContextAppender contextAppender = new ContextAppender(this, newLogger, this.logQueue, this.logEntry);
+            contextAppender.setContext(loggerContext);
+            contextAppender.start();
+
+            newLogger.addAppender(contextAppender);
+        }
+
+        if (this.logToFile) {
+            try {
+                this.logFile = File.createTempFile("log", ".txt");
+                this.logFileOS = new BufferedOutputStream(new FileOutputStream(logFile));
+            } catch (IOException e) {
+                throw new UncheckedIOException(e);
+            }
+            FileAppender fileAppender = new FileAppender(this, newLogger, this.logFileOS);
+            fileAppender.setContext(loggerContext);
+            fileAppender.start();
+
+            newLogger.addAppender(fileAppender);
+        }
+
+        // forward flow logs to the server log
+        ForwardAppender forwardAppender = new ForwardAppender(this, newLogger);
+        forwardAppender.setContext(loggerContext);
+        forwardAppender.start();
+        newLogger.addAppender(forwardAppender);
+
+        newLogger.setLevel(this.loglevel);
+        newLogger.setAdditive(true);
+        return newLogger;
+    }
+
     public void resetMDC() {
-        MDC.clear();
+        this.logger.getLoggerContext().getMDCAdapter().clear();
     }
 
     @Override

--- a/core/src/main/java/io/kestra/core/runners/RunContextLogger.java
+++ b/core/src/main/java/io/kestra/core/runners/RunContextLogger.java
@@ -192,6 +192,10 @@ public class RunContextLogger implements Supplier<org.slf4j.Logger> {
         return this.logger;
     }
 
+    public void resetMDC() {
+        MDC.clear();
+    }
+
     @Override
     public org.slf4j.Logger get() {
         return logger();

--- a/core/src/main/java/io/kestra/core/runners/Worker.java
+++ b/core/src/main/java/io/kestra/core/runners/Worker.java
@@ -398,8 +398,8 @@ public class Worker implements Service, Runnable, AutoCloseable {
                     }
                 }
             } finally {
-                runContext.cleanup();
                 this.logTerminated(workerTask);
+                runContext.cleanup();
             }
         } else {
             throw new RuntimeException("Unable to process the task '" + workerTask.getTask().getId() + "' as it's not a runnable task");
@@ -570,8 +570,6 @@ public class Worker implements Service, Runnable, AutoCloseable {
                     } catch (Exception e) {
                         this.handleTriggerError(workerTrigger, e);
                     } finally {
-                        workerTrigger.getConditionContext().getRunContext().cleanup();
-
                         logService.logTrigger(
                             workerTrigger.getTriggerContext(),
                             runContext.logger(),
@@ -580,6 +578,8 @@ public class Worker implements Service, Runnable, AutoCloseable {
                             workerTrigger.getTrigger().getType(),
                             DurationFormatUtils.formatDurationHMS(stopWatch.getTime(TimeUnit.MILLISECONDS))
                         );
+
+                        workerTrigger.getConditionContext().getRunContext().cleanup();
                     }
 
                     this.evaluateTriggerRunningCount.get(workerTrigger.getTriggerContext().uid()).addAndGet(-1);
@@ -691,12 +691,12 @@ public class Worker implements Service, Runnable, AutoCloseable {
             }
             return workerTaskResult;
         } finally {
+            this.logTerminated(workerTask);
+
             // remove tmp directory
             if (cleanUp) {
                 workerTask.getRunContext().cleanup();
             }
-
-            this.logTerminated(workerTask);
         }
     }
 


### PR DESCRIPTION
- Reset MDC when we cleanup the run context
- Use DCL to initialize the logger to avoid half backed initialization

Fixes https://github.com/kestra-io/kestra-ee/issues/1260
