### PR TITLE
fix(core): Dashboard end date should apply to the execution start date

### DIFF
--- a/core/src/main/java/io/kestra/core/models/dashboards/GlobalFilter.java
+++ b/core/src/main/java/io/kestra/core/models/dashboards/GlobalFilter.java
@@ -1,13 +1,11 @@
 package io.kestra.core.models.dashboards;
 
-import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.experimental.SuperBuilder;
 
 import java.time.ZonedDateTime;
-import java.util.List;
 import java.util.Map;
 
 @Getter

--- a/core/src/main/java/io/kestra/core/validations/validator/DataChartValidator.java
+++ b/core/src/main/java/io/kestra/core/validations/validator/DataChartValidator.java
@@ -4,6 +4,7 @@ import io.kestra.core.models.dashboards.AggregationType;
 import io.kestra.core.models.dashboards.ColumnDescriptor;
 import io.kestra.core.models.dashboards.OrderBy;
 import io.kestra.core.models.dashboards.charts.DataChart;
+import io.kestra.core.utils.MapUtils;
 import io.kestra.core.validations.DataChartValidation;
 import io.micronaut.core.annotation.AnnotationValue;
 import io.micronaut.core.annotation.Introspected;
@@ -33,7 +34,7 @@ public class DataChartValidator implements ConstraintValidator<DataChartValidati
 
         List<String> violations = new ArrayList<>();
 
-        Set<String> dataColumns = dataChart.getData().getColumns().keySet();
+        Set<String> dataColumns = MapUtils.emptyOnNull(dataChart.getData().getColumns()).keySet();
         if (dataChart.getChartOptions() != null) {
             List<String> neededColumns = dataChart.getChartOptions().neededColumns();
             neededColumns.forEach(column -> {

--- a/core/src/main/java/io/kestra/plugin/core/dashboard/data/Executions.java
+++ b/core/src/main/java/io/kestra/plugin/core/dashboard/data/Executions.java
@@ -46,13 +46,14 @@ public class Executions<C extends ColumnDescriptor<Executions.Fields>> extends D
             where.removeIf(f -> f.getField().equals(Fields.LABELS));
             where.add(Contains.<Executions.Fields>builder().field(Fields.LABELS).value(globalFilter.getLabels()).build());
         }
-        if (globalFilter.getStartDate() != null) {
+        if (globalFilter.getStartDate() != null || globalFilter.getEndDate() != null) {
             where.removeIf(f -> f.getField().equals(Fields.START_DATE));
-            where.add(GreaterThanOrEqualTo.<Executions.Fields>builder().field(Fields.START_DATE).value(globalFilter.getStartDate().toOffsetDateTime()).build());
-        }
-        if (globalFilter.getEndDate() != null) {
-            where.removeIf(f -> f.getField().equals(Fields.END_DATE));
-            where.add(LessThanOrEqualTo.<Executions.Fields>builder().field(Fields.END_DATE).value(globalFilter.getEndDate().toOffsetDateTime()).build());
+            if (globalFilter.getStartDate() != null) {
+                where.add(GreaterThanOrEqualTo.<Executions.Fields>builder().field(Fields.START_DATE).value(globalFilter.getStartDate().toOffsetDateTime()).build());
+            }
+            if (globalFilter.getEndDate() != null) {
+                where.add(LessThanOrEqualTo.<Executions.Fields>builder().field(Fields.START_DATE).value(globalFilter.getEndDate().toOffsetDateTime()).build());
+            }
         }
 
         this.setWhere(where);


### PR DESCRIPTION
Otherwise you would not be able to have running executions. It is aligned with what we do for the other dashboard / filter
