### PR TITLE
chore(deps): downgrade protobug

### DIFF
--- a/platform/build.gradle
+++ b/platform/build.gradle
@@ -13,7 +13,7 @@ javaPlatform {
 dependencies {
     // versions for libraries with multiple module but no BOM
     def slf4jVersion = "2.0.16"
-    def protobufVersion = "4.29.3"
+    def protobufVersion = "3.25.6"
     def bouncycastleVersion = "1.80"
     def aetherVersion = "1.1.0"
     def jollydayVersion = "0.32.0"


### PR DESCRIPTION
Orc uses an older version.
And probably also other libs that we're using are still in 3.x
