### PR TITLE
fix(cli): retry flaky test FlowCreateOrUpdateCommandTest.runWithDelete.

### DIFF
--- a/cli/src/test/java/io/kestra/cli/commands/flows/FlowCreateOrUpdateCommandTest.java
+++ b/cli/src/test/java/io/kestra/cli/commands/flows/FlowCreateOrUpdateCommandTest.java
@@ -5,6 +5,7 @@ import io.micronaut.context.ApplicationContext;
 import io.micronaut.context.env.Environment;
 import io.micronaut.runtime.server.EmbeddedServer;
 import org.junit.jupiter.api.Test;
+import org.junitpioneer.jupiter.RetryingTest;
 
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
@@ -15,7 +16,7 @@ import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.StringContains.containsString;
 
 class FlowCreateOrUpdateCommandTest {
-    @Test
+    @RetryingTest(5) // flaky on CI but cannot be reproduced even with 100 repetitions
     void runWithDelete()  {
         URL directory = FlowCreateOrUpdateCommandTest.class.getClassLoader().getResource("flows");
         ByteArrayOutputStream out = new ByteArrayOutputStream();


### PR DESCRIPTION
Adding a retry because it cannot be reproduce to fail locally even with 100 repetitions.
