### PR TITLE
fix(ui): Custom Dashboard name overflows.

### DIFF
--- a/ui/src/components/filter/KestraFilter.vue
+++ b/ui/src/components/filter/KestraFilter.vue
@@ -835,6 +835,7 @@ $dashboards: 52px;
         }
 
         &.dashboards {
+            min-width: $dashboards;
             max-width: calc(100% - $included - $dashboards);
         }
     }
@@ -872,6 +873,7 @@ $dashboards: 52px;
 .filters-select {
     & .el-select-dropdown {
         width: auto !important;
+        max-width: 300px;
 
         &:has(.el-select-dropdown__empty) {
             width: auto !important;

--- a/ui/src/components/filter/segments/Dashboards.vue
+++ b/ui/src/components/filter/segments/Dashboards.vue
@@ -1,8 +1,8 @@
 <template>
     <el-dropdown trigger="click" placement="bottom-end">
         <KestraIcon placement="bottom">
-            <el-button :icon="Menu">
-                {{ selectedDashboard ?? $t('default_dashboard') }}
+            <el-button :icon="Menu" class="main-button d-inline">
+                <span class="text-truncate">{{ selectedDashboard ?? $t('default_dashboard') }}</span>
             </el-button>
         </KestraIcon>
 
@@ -140,5 +140,13 @@
 
 .items {
     max-height: 160px !important; // 5 visible items
+}
+
+.main-button {
+    max-width: 300px;
+
+    span {
+        max-width: 250px;
+    }
 }
 </style>


### PR DESCRIPTION
Closes #7014 

**Additional**: Fixes the width which overflows the popper as in Video with `allow-create`.  `300px` will accommodate the width of create Dashboard popper too.


https://github.com/user-attachments/assets/e3068d8b-57a6-4935-b49a-66582776beda


https://github.com/user-attachments/assets/946cc8b4-d35e-4f58-a7c7-9ecd996f258f


https://github.com/user-attachments/assets/cc5a7fb2-d2cc-4855-9810-60e1b7fb0277

