### PR TITLE
fix(cli): print help on missing parameters

### DIFF
--- a/cli/src/main/java/io/kestra/cli/App.java
+++ b/cli/src/main/java/io/kestra/cli/App.java
@@ -88,11 +88,12 @@ public class App implements Callable<Integer> {
             .environments(Environment.CLI);
 
         CommandLine cmd = new CommandLine(mainClass, CommandLine.defaultFactory());
+        continueOnParsingErrors(cmd);
 
         CommandLine.ParseResult parseResult = cmd.parseArgs(args);
         List<CommandLine> parsedCommands = parseResult.asCommandLineList();
 
-        CommandLine commandLine = parsedCommands.get(parsedCommands.size() - 1);
+        CommandLine commandLine = parsedCommands.getLast();
         Class<?> cls = commandLine.getCommandSpec().userObject().getClass();
 
         if (AbstractCommand.class.isAssignableFrom(cls)) {
@@ -114,13 +115,15 @@ public class App implements Callable<Integer> {
                 .stream()
                 .filter(argSpec -> ((Field) argSpec.userObject()).getName().equals("serverPort"))
                 .findFirst()
-                .ifPresent(argSpec -> {
-                    properties.put("micronaut.server.port", argSpec.getValue());
-                });
+                .ifPresent(argSpec -> properties.put("micronaut.server.port", argSpec.getValue()));
 
             builder.properties(properties);
         }
         return builder.build();
+    }
+
+    private static void continueOnParsingErrors(CommandLine cmd) {
+        cmd.getCommandSpec().parser().collectErrors(true);
     }
 
     @SuppressWarnings("unchecked")

--- a/cli/src/test/java/io/kestra/cli/AppTest.java
+++ b/cli/src/test/java/io/kestra/cli/AppTest.java
@@ -45,4 +45,20 @@ class AppTest {
             assertThat(out.toString(), startsWith("Usage: kestra server " + serverType));
         }
     }
+
+    @Test
+    void missingRequiredParamsPrintHelpInsteadOfException() {
+        final ByteArrayOutputStream out = new ByteArrayOutputStream();
+        System.setErr(new PrintStream(out));
+
+        final String[] argsWithMissingParams = new String[]{"flow", "namespace", "update"};
+
+        try (ApplicationContext ctx = App.applicationContext(App.class, argsWithMissingParams)) {
+            new CommandLine(App.class, new MicronautFactory(ctx)).execute(argsWithMissingParams);
+
+            assertThat(out.toString(), startsWith("Missing required parameters: "));
+            assertThat(out.toString(), containsString("Usage: kestra flow namespace update "));
+            assertThat(out.toString(), not(containsString("MissingParameterException: ")));
+        }
+    }
 }


### PR DESCRIPTION
### What changes are being made and why?

Missing required positional parameters caused just a stacktrace print.

Now such cases print the error message accompanied by command's help.

---

### How the changes have been QAed?

Examples:

* `./kestra flow namespace update`
* `./kestra flow dot`