### PR TITLE
fix(ui): amend log lines in Firefox

### DIFF
--- a/ui/src/components/logs/LogLine.vue
+++ b/ui/src/components/logs/LogLine.vue
@@ -218,6 +218,9 @@ div.line {
     }
 
     .log-content {
+        // prevent Firefox word breaks 
+        flex-grow: 1;
+
         .header > * + * {
             margin-left: 1rem;
         }


### PR DESCRIPTION
### What changes are being made and why?

Log line text was oddly wrapped in Firefox unlike in Chromium-based browsers.

For example, this is how the logged text `test` got wrapped:

![20250131-213329_snap](https://github.com/user-attachments/assets/5e20b883-8ac3-4ddd-baf8-ba230be5055f)
