### PR TITLE
feat: parse docs in 2 steps to avoid user waiting with no content

### DIFF
--- a/ui/src/components/docs/ContextDocs.vue
+++ b/ui/src/components/docs/ContextDocs.vue
@@ -90,8 +90,15 @@
         if (!("canShare" in navigator)) {
             content = content.replaceAll(/\s*web-share\s*/g, "");
         }
-        const parse = await getMDCParser()
-        ast.value = await parse(content);
+        const parse = await getMDCParser();
+        // this hack alleviates a little the parsing load of the first render on big docs
+        // by only rendering the first 50 lines of the doc on opening
+        // since they are the only ones visible in the beginning
+        const firstLinesOfContent = content.split("---\n")[2].split("\n").slice(0, 50).join("\n") + "\nLoading the rest...\n";
+        ast.value = await parse(firstLinesOfContent);
+        setTimeout(async () => {
+            ast.value = await parse(content);
+        }, 50);
     }
 
     watch(docPath, async (val) => {


### PR DESCRIPTION
The Nuxt content parser of Nuxt CONtent 2 is really slow on big pages.
It sometimes hang for 5 seconds with content there to display any values.

I initially thought it was a bug and was worried.

Here I only take the first 50 lines of content and render it before rendering the rest in the background.

It allows for a better experience overall.