### PR TITLE
fix(core): retry flaky test AbstractRunnerTest.restartFailedThenFailu…

### DIFF
--- a/core/src/test/java/io/kestra/core/runners/AbstractRunnerTest.java
+++ b/core/src/test/java/io/kestra/core/runners/AbstractRunnerTest.java
@@ -178,7 +178,7 @@ public abstract class AbstractRunnerTest {
         restartCaseTest.restartMultiple();
     }
 
-    @Test
+    @RetryingTest(5) // Flaky on CI but never locally even with 100 repetitions
     @LoadFlows({"flows/valids/restart_always_failed.yaml"})
     void restartFailedThenFailureWithGlobalErrors() throws Exception {
         restartCaseTest.restartFailedThenFailureWithGlobalErrors();


### PR DESCRIPTION
…reWithGlobalErrors

This test is flaky on CI but never locally even with 100 repetitions.
