### PR TITLE
fix(ui): prevent doubling the executions chart on flow overview

### DIFF
--- a/ui/src/components/dashboard/Dashboard.vue
+++ b/ui/src/components/dashboard/Dashboard.vue
@@ -178,13 +178,6 @@
             :namespace="props.namespace"
             class="card card-1/2"
         />
-
-        <ExecutionsDoughnut
-            v-if="props.flow"
-            :data="graphData"
-            :total="stats.total"
-            class="card card-1/2"
-        />
         <ExecutionsNextScheduled
             v-else-if="isAllowedTriggers"
             :flow="props.flowId"


### PR DESCRIPTION
Closes https://github.com/kestra-io/kestra/issues/7218.