### PR TITLE
fix #7217: position of refresh button

### DIFF
--- a/ui/src/components/layout/RefreshButton.vue
+++ b/ui/src/components/layout/RefreshButton.vue
@@ -1,10 +1,10 @@
 <template>
-    <el-button :disabled="!canAutoRefresh" :active="autoRefresh" @click="toggleAutoRefresh" data-test-id="toggle-aut-refresh-button">
+    <el-button :disabled="!canAutoRefresh" :active="autoRefresh" @click="toggleAutoRefresh" data-test-id="toggle-aut-refresh-button" class="refresh-button">
         <kicon :tooltip="$t('toggle periodic refresh each 10 seconds')" placement="bottom">
             <component :is="autoRefresh ? 'auto-renew' : 'auto-renew-off'" class="auto-refresh-icon" />
         </kicon>
     </el-button>
-    <el-button @click="triggerRefresh" data-test-id="trigger-refresh-button">
+    <el-button @click="triggerRefresh" data-test-id="trigger-refresh-button" class="refresh-button">
         <kicon :tooltip="$t('trigger refresh')" placement="bottom">
             <refresh />
         </kicon>
@@ -93,4 +93,7 @@
             rotate: 360deg;
         }
     }
+    .refresh-button {
+    margin-left: 5px; 
+    }    
 </style>


### PR DESCRIPTION
### What Changes You do and Why?

I changed the `RefreshButton.vue` file, added a `refreshbutton` class and gave a margin of `10px` so that it looks good.

Earlier the buttons look like this:
![Screenshot 2025-02-07 at 5 28 26 PM](https://github.com/user-attachments/assets/5c2b788a-44b1-4d2d-80c0-a969e415d9d7)

After modification, it looks something like this:
![Screenshot 2025-02-07 at 5 22 20 PM](https://github.com/user-attachments/assets/9b4dba36-39f3-4cd9-9b96-243ac2a25d78)

I think we should have some gap between the buttons because the screenshot shared by @Nico-Kestra was of the table with search filter but in trigger table, we have separate columns, so it would look weird if we join the two buttons. 

It closes #7217 issue

if you desire to change the gap between button, add the following in the `style block` of `RefreshButton.vue` file:

```
.refresh-button + .refresh-button {
    margin-left: 1px;  // Adjust the gap by changing this value.
    }
```