### PR TITLE
feat(core, jdbc): directly process WorkerTaskResult from flowable tasks

### DIFF
--- a/core/src/main/java/io/kestra/core/runners/Executor.java
+++ b/core/src/main/java/io/kestra/core/runners/Executor.java
@@ -23,7 +23,6 @@ public class Executor {
     private Flow flow;
     private final List<TaskRun> nexts = new ArrayList<>();
     private final List<WorkerTask> workerTasks = new ArrayList<>();
-    private final List<WorkerTaskResult> workerTaskResults = new ArrayList<>();
     private final List<ExecutionDelay> executionDelays = new ArrayList<>();
     private WorkerTaskResult joinedWorkerTaskResult;
     private final List<SubflowExecution<?>> subflowExecutions = new ArrayList<>();
@@ -126,13 +125,6 @@ public class Executor {
 
     public Executor withWorkerTriggers(List<WorkerTrigger> workerTriggers, String from) {
         this.workerTriggers.addAll(workerTriggers);
-        this.from.add(from);
-
-        return this;
-    }
-
-    public Executor withWorkerTaskResults(List<WorkerTaskResult> workerTaskResults, String from) {
-        this.workerTaskResults.addAll(workerTaskResults);
         this.from.add(from);
 
         return this;

--- a/core/src/test/java/io/kestra/plugin/core/execution/ExitTest.java
+++ b/core/src/test/java/io/kestra/plugin/core/execution/ExitTest.java
@@ -46,7 +46,7 @@ class ExitTest {
     @Test
     @LoadFlows("flows/valids/exit-killed.yaml")
     void shouldExitAndKillTheExecution() throws TimeoutException, QueueException, InterruptedException {
-        CountDownLatch countDownLatch = new CountDownLatch(3);// We need to wait for 3 execution modifications to be sure all tasks are passed to KILLED
+        CountDownLatch countDownLatch = new CountDownLatch(2);// We need to wait for 3 execution modifications to be sure all tasks are passed to KILLED
         AtomicReference<Execution> killedExecution = new AtomicReference<>();
         Flux<Execution> receive = TestsUtils.receive(executionQueue, either -> {
             Execution execution = either.getLeft();


### PR DESCRIPTION
And other places in the ExecutorService when we create them when processing the execution queue.

Fixes #5521
