### PR TITLE
fix(ui): correct duration toggle alignment in Bars.vue

### DIFF
--- a/ui/src/components/dashboard/components/charts/executions/Bar.vue
+++ b/ui/src/components/dashboard/components/charts/executions/Bar.vue
@@ -19,12 +19,12 @@
                 <div
                     class="d-flex justify-content-end align-items-center switch-content"
                 >
-                    <span class="pe-2 fw-light small">{{ t("duration") }}</span>
                     <el-switch
                         v-model="duration"
                         :active-icon="CheckIcon"
                         inline-prompt
                     />
+                    <span class="d-flex align-items-center ps-2 fw-light small">{{ t("duration") }}</span>
                 </div>
                 <div id="executions" />
             </div>
@@ -131,10 +131,6 @@ $height: 200px;
 
     .small {
         font-size: 0.75rem;
-    }
-
-    .pe-2 {
-        padding-right: 0.5rem;
     }
 }
 </style>


### PR DESCRIPTION
<!-- Thanks for submitting a Pull Request to Kestra. To help us review your contribution, please follow the guidelines below:

- Make sure that your commits follow the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) specification e.g. `feat(ui): add a new navigation menu item` or `fix(core): fix a bug in the core model` or `docs: update the README.md`. This will help us automatically generate the changelog.
- The title should briefly summarize the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share a flow example to help the reviewer understand and QA the change.
- Use "closes" to automatically close an issue. For example, `closes #1234` will close issue #1234. -->

### What changes are being made and why?

I have changed the css styling and ordering of the duration toggle to align it properly as describe in the issue image.
closes #7228 
<!-- Please include a brief summary of the changes included in this PR e.g. closes #1234. -->

---

### How the changes have been QAed?
Tested the changes locally. please check out the screenshot below.

<img width="1438" alt="Screenshot 2025-02-08 at 10 21 15 PM" src="https://github.com/user-attachments/assets/abda802e-600e-4d56-b38e-80e34ee0d68b" />