### PR TITLE
feat(jdbc): purge execution queue early

### DIFF
--- a/jdbc/src/main/java/io/kestra/jdbc/runner/JdbcExecutor.java
+++ b/jdbc/src/main/java/io/kestra/jdbc/runner/JdbcExecutor.java
@@ -940,6 +940,13 @@ public class JdbcExecutor implements ExecutorInterface, Service {
                 executorService.log(log, false, executor);
             }
 
+            // delete all previous execution messages
+            // we still send the last one so all consumers of terminated executions will be sure to have the latest status
+            // TODO we check 3 times if the exec is terminated, we may want to refactor all this
+            if (executorService.canBePurged(executor)) {
+                ((JdbcQueue<Execution>) executionQueue).deleteByKey(executor.getExecution().getId());
+            }
+
             // emit for other consumer than executor if no failure
             if (hasFailure) {
                 this.executionQueue.emit(executor.getExecution());

--- a/jdbc/src/main/java/io/kestra/jdbc/runner/JdbcQueue.java
+++ b/jdbc/src/main/java/io/kestra/jdbc/runner/JdbcQueue.java
@@ -163,6 +163,18 @@ public abstract class JdbcQueue<T> implements QueueInterface<T> {
         // and the queue has its own cleaner, which we better not mess with, as the 'queues' table is selected with a lock.
     }
 
+    public void deleteByKey(String key) throws QueueException {
+        dslContextWrapper.transaction(configuration -> {
+            int deleted = DSL
+                .using(configuration)
+                .delete(this.table)
+                .where(buildTypeCondition(this.cls.getName()))
+                .and(AbstractJdbcRepository.field("key").eq(key))
+                .execute();
+            log.debug("Cleaned {} records for key {}", deleted, key);
+        });
+    }
+
     protected Result<Record> receiveFetch(DSLContext ctx, String consumerGroup, Integer offset) {
         return this.receiveFetch(ctx, consumerGroup, offset, true);
     }

--- a/jdbc/src/main/java/io/kestra/jdbc/runner/JdbcQueue.java
+++ b/jdbc/src/main/java/io/kestra/jdbc/runner/JdbcQueue.java
@@ -175,6 +175,20 @@ public abstract class JdbcQueue<T> implements QueueInterface<T> {
         });
     }
 
+    public void deleteByKeys(List<String> keys) throws QueueException {
+        // TODO check that IN is not an issue with executions with a lot of taskuns
+        //  we may instead either split by 100/1000 or use a batch delete with equals
+        dslContextWrapper.transaction(configuration -> {
+            int deleted = DSL
+                .using(configuration)
+                .delete(this.table)
+                .where(buildTypeCondition(this.cls.getName()))
+                .and(AbstractJdbcRepository.field("key").in(keys))
+                .execute();
+            log.debug("Cleaned {} records for keys {}", deleted, keys);
+        });
+    }
+
     protected Result<Record> receiveFetch(DSLContext ctx, String consumerGroup, Integer offset) {
         return this.receiveFetch(ctx, consumerGroup, offset, true);
     }


### PR DESCRIPTION
Purge eagerly queue messages from the executor: execution, worker job, worker task result.

Other messages will be purged by the JdbcCleaner. 

Fixes #5055 