### PR TITLE
fix(ui): match chart colors

### DIFF
--- a/ui/src/utils/scheme.js
+++ b/ui/src/utils/scheme.js
@@ -1,108 +1,47 @@
 import {computed} from "vue";
 import {useLocalStorage} from "@vueuse/core";
 import {useTheme} from "./utils"
+import {cssVariable} from "@kestra-io/ui-libs";
 
 const SCHEME = "scheme";
+const EXECUTIONS = Object.freeze({
+    CANCELLED: cssVariable("--ks-chart-cancelled"),
+    CREATED: cssVariable("--ks-chart-created"),
+    FAILED: cssVariable("--ks-chart-failed"),
+    KILLED: cssVariable("--ks-chart-killed"),
+    KILLING: cssVariable("--ks-chart-killing"),
+    PAUSED: cssVariable("--ks-chart-paused"),
+    QUEUED: cssVariable("--ks-chart-queued"),
+    RESTARTED: cssVariable("--ks-chart-restarted"),
+    RETRIED: cssVariable("--ks-chart-retried"),
+    RETRYING: cssVariable("--ks-chart-retrying"),
+    RUNNING: cssVariable("--ks-chart-running"),
+    SKIPPED: cssVariable("--ks-chart-skipped"),
+    SUCCESS: cssVariable("--ks-chart-success"),
+    WARNING: cssVariable("--ks-chart-warning"),
+});
+const LOGS = Object.freeze({
+    DEBUG: cssVariable("--ks-chart-debug"),
+    ERROR: cssVariable("--ks-chart-error"),
+    INFO: cssVariable("--ks-chart-info"),
+    TRACE: cssVariable("--ks-chart-trace"),
+    WARN: cssVariable("--ks-chart-warn"),
+});
+const TYPES = Object.freeze({
+    executions: EXECUTIONS,
+    logs: LOGS,
+});
+/**
+ * Allows scheme/theme customization.
+ */
 const OPTIONS = Object.freeze({
     classic: {
-        light: {
-            executions: {
-                CANCELLED: "#d1cfe9",
-                CREATED: "#fec9cb",
-                FAILED: "#fd7278",
-                KILLED: "#e5e4f7",
-                KILLING: "#d1cfe9",
-                PAUSED: "#fce07c",
-                QUEUED: "#fdedb3",
-                RESTARTED: "#c7f0ff",
-                RETRIED: "#a2cdff",
-                RETRYING: "#7fbbff",
-                RUNNING: "#5bb8ff",
-                SUCCESS: "#02be8a",
-                WARNING: "#e9985b",
-            },
-            logs: {
-                DEBUG: "#7fbbff",
-                ERROR: "#fd7278",
-                INFO: "#21ce9c",
-                TRACE: "#d1cfe9",
-                WARN: "#eeae7e",
-            },
-        },
-        dark: {
-            executions: {
-                CANCELLED: "#9a8eb4",
-                CREATED: "#fd9297",
-                FAILED: "#fd7278",
-                KILLED: "#7e719f",
-                KILLING: "#a6a4ca",
-                PAUSED: "#fde89d",
-                QUEUED: "#bda85d",
-                RESTARTED: "#c7f0ff",
-                RETRIED: "#a2cdff",
-                RETRYING: "#7fbbff",
-                RUNNING: "#5bb8ff",
-                SUCCESS: "#21ce9c",
-                WARNING: "#eeae7e",
-            },
-            logs: {
-                DEBUG: "#3991ff",
-                ERROR: "#fd7278",
-                INFO: "#21ce9c",
-                TRACE: "#9a8eb4",
-                WARN: "#f3c4a1",
-            },
-        },
+        light: TYPES,
+        dark: TYPES,
     },
     kestra: {
-        light: {
-            executions: {
-                CANCELLED: "#d1cfe9",
-                CREATED: "#fec9f5",
-                FAILED: "#ff41b9",
-                KILLED: "#e5e4f7",
-                KILLING: "#d1cfe9",
-                PAUSED: "#fce07c",
-                QUEUED: "#fdedb3",
-                RESTARTED: "#c7f0ff",
-                RETRIED: "#a2cdff",
-                RETRYING: "#7fbbff",
-                RUNNING: "#5bb8ff",
-                SUCCESS: "#9470ff",
-                WARNING: "#e9985b",
-            },
-            logs: {
-                DEBUG: "#7fbbff",
-                ERROR: "#ff41b9",
-                INFO: "#9470ff",
-                TRACE: "#d1cfe9",
-                WARN: "#eeae7e",
-            },
-        },
-        dark: {
-            executions: {
-                CANCELLED: "#a6a4ca",
-                CREATED: "#fec9cb",
-                FAILED: "#ff4bbd",
-                KILLED: "#9a8eb4",
-                KILLING: "#a6a4ca",
-                PAUSED: "#fde89d",
-                QUEUED: "#bda85d",
-                RESTARTED: "#c7f0ff",
-                RETRIED: "#a2cdff",
-                RETRYING: "#7fbbff",
-                RUNNING: "#5bb8ff",
-                SUCCESS: "#8c4bff",
-                WARNING: "#eeae7e",
-            },
-            logs: {
-                DEBUG: "#3991ff",
-                ERROR: "#ff4bbd",
-                INFO: "#8c4bff",
-                TRACE: "#a6a4ca",
-                WARN: "#f3c4a1",
-            },
-        },
+        light: TYPES,
+        dark: TYPES,
     },
 });
 


### PR DESCRIPTION
### What changes are being made and why?

Provide up-to-date colors for the charts as discussed at kestra-io/ui-libs/pull/217.

closes #7200