### PR TITLE
fix(core): do not validate subflow if namespace or id is pebble

### DIFF
--- a/core/src/main/java/io/kestra/core/services/FlowService.java
+++ b/core/src/main/java/io/kestra/core/services/FlowService.java
@@ -170,6 +170,12 @@ public class FlowService {
         Set<ConstraintViolation<?>> violations = new HashSet<>();
 
         subFlows.forEach(subflow -> {
+            String regex = ".*\\{\\{.+}}.*"; // regex to check if string contains pebble
+            String subflowId = subflow.getFlowId();
+            String namespace = subflow.getNamespace();
+            if (subflowId.matches(regex) || namespace.matches(regex)) {
+                return;
+            }
             Optional<Flow> optional = findById(flow.getTenantId(), subflow.getNamespace(), subflow.getFlowId());
 
             if (optional.isEmpty()) {


### PR DESCRIPTION
close #7271