### PR TITLE
fix(ui): vertical align table items. remove element plus override

### DIFF
--- a/ui/src/styles/layout/element-plus-overload.scss
+++ b/ui/src/styles/layout/element-plus-overload.scss
@@ -397,9 +397,6 @@ form.ks-horizontal {
         font-weight: 400;
     }
 
-    .el-table__cell {
-        vertical-align: top;
-    }
 
 
     .el-table__inner-wrapper::before {


### PR DESCRIPTION
<!-- Thanks for submitting a Pull Request to Kestra. To help us review your contribution, please follow the guidelines below:

- Make sure that your commits follow the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) specification e.g. `feat(ui): add a new navigation menu item` or `fix(core): fix a bug in the core model` or `docs: update the README.md`. This will help us automatically generate the changelog.
- The title should briefly summarize the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share a flow example to help the reviewer understand and QA the change.
- Use "closes" to automatically close an issue. For example, `closes #1234` will close issue #1234. -->

### What changes are being made and why?

vertically align table items. removed element plus vertical-align override as default is middle.
closes #7018 
![Screenshot 2025-02-12 at 11 24 38 PM](https://github.com/user-attachments/assets/3a9ecb60-5adb-45df-a014-1af5dd091d32)

### How the changes have been QAed?

tested changes locally