### PR TITLE
feat(core, jdbc): use an elastic thread pool

### DIFF
--- a/core/src/main/java/io/kestra/core/runners/Worker.java
+++ b/core/src/main/java/io/kestra/core/runners/Worker.java
@@ -171,7 +171,7 @@ public class Worker implements Service, Runnable, AutoCloseable {
         this.numThreads = numThreads;
         this.workerGroup = workerGroupService.resolveGroupFromKey(workerGroupKey);
         this.eventPublisher = eventPublisher;
-        this.executorService = executorsUtils.maxCachedThreadPool(numThreads, EXECUTOR_NAME);
+        this.executorService = executorsUtils.elasticCachedThreadPool(1, numThreads, EXECUTOR_NAME);
         this.setState(ServiceState.CREATED);
     }
 
@@ -272,6 +272,7 @@ public class Worker implements Service, Runnable, AutoCloseable {
         this.clusterEventQueue.ifPresent(clusterEventQueueInterface -> this.receiveCancellations.addFirst(clusterEventQueueInterface.receive(this::clusterEventQueue)));
 
         setState(ServiceState.RUNNING);
+        log.info("Worker started with {} thread(s)", numThreads);
     }
 
     private void clusterEventQueue(Either<ClusterEvent, DeserializationException> either) {

--- a/core/src/main/java/io/kestra/core/utils/ExecutorsUtils.java
+++ b/core/src/main/java/io/kestra/core/utils/ExecutorsUtils.java
@@ -25,6 +25,24 @@ public class ExecutorsUtils {
         );
     }
 
+    public ExecutorService elasticCachedThreadPool(int minThread, int maxThread, String name) {
+        ThreadPoolExecutor threadPoolExecutor = new ThreadPoolExecutor(
+            minThread,
+            maxThread,
+            60L,
+            TimeUnit.SECONDS,
+            new LinkedBlockingQueue<>(),
+            threadFactoryBuilder.build(name + "_%d")
+        );
+
+        threadPoolExecutor.allowCoreThreadTimeOut(true);
+
+        return this.wrap(
+            name,
+            threadPoolExecutor
+        );
+    }
+
     public ExecutorService maxCachedThreadPool(int maxThread, String name) {
         ThreadPoolExecutor threadPoolExecutor = new ThreadPoolExecutor(
             maxThread,

--- a/jdbc/src/main/java/io/kestra/jdbc/runner/JdbcQueue.java
+++ b/jdbc/src/main/java/io/kestra/jdbc/runner/JdbcQueue.java
@@ -74,7 +74,7 @@ public abstract class JdbcQueue<T> implements QueueInterface<T> {
     public JdbcQueue(Class<T> cls, ApplicationContext applicationContext) {
         ExecutorsUtils executorsUtils = applicationContext.getBean(ExecutorsUtils.class);
         this.poolExecutor = executorsUtils.cachedThreadPool("jdbc-queue-" + cls.getSimpleName());
-        this.asyncPoolExecutor = executorsUtils.maxCachedThreadPool(MAX_ASYNC_THREADS, "jdbc-queue-async-" + cls.getSimpleName());
+        this.asyncPoolExecutor = executorsUtils.elasticCachedThreadPool(1, MAX_ASYNC_THREADS, "jdbc-queue-async-" + cls.getSimpleName());
 
         this.queueService = applicationContext.getBean(QueueService.class);
         this.cls = cls;


### PR DESCRIPTION
To avoid using too many threads when it's not needed.