### PR TITLE
fix(ui): make table labels filter active again

### DIFF
--- a/ui/src/components/filter/KestraFilter.vue
+++ b/ui/src/components/filter/KestraFilter.vue
@@ -668,7 +668,7 @@
     };
 
     // Include parameters from URL directly to filter
-    onMounted(() => {
+    watch(route, () => {
         if (props.decode) {
             const decodedParams = decodeParams(route.path, route.query, props.include, OPTIONS);
             currentFilters.value = decodedParams.map((item: any) => {
@@ -741,9 +741,9 @@
                     comparator: COMPARATORS.EQUALS,
                     persistent: true,
                 });
-            }            
+            }
         }
-    });
+    }, {immediate: true});
 
     watch(
         () => select.value?.dropdownMenuVisible,

--- a/ui/src/components/filter/utils/helpers.ts
+++ b/ui/src/components/filter/utils/helpers.ts
@@ -151,7 +151,7 @@ export const decodeSearchParams = (query, include, OPTIONS) => {
             const [, field, operation, subKey] = match;
 
             if (field === "labels" && subKey) {
-                return {label: field, value: `${subKey}:${decodeURIComponent(value)}`, operation};
+                return {label: field, value: [`${subKey}:${decodeURIComponent(value)}`], operation};
             }
 
             const label = field === "q" ? "text" : OPTIONS.find(o => o.key === field)?.value.label || field;
@@ -176,4 +176,7 @@ export const decodeSearchParams = (query, include, OPTIONS) => {
     return params;
 };
 
-export const isSearchPath = (path: string) =>["/admin/triggers","/dashboards/default", "/flows", "/executions", "/logs", "/dashboard"].includes(path);
+export const isSearchPath = (path: string) => {
+    return ["/admin/triggers","/dashboards/default", "/flows", "/logs", "/dashboard"].includes(path) ||
+        path.endsWith("/executions");
+};

--- a/ui/src/components/layout/Labels.vue
+++ b/ui/src/components/layout/Labels.vue
@@ -14,6 +14,9 @@
 </template>
 
 <script>
+    import {decodeParams, encodeParams} from "../filter/utils/helpers";
+    import {useFilters} from "../filter/composables/useFilters";
+
     export default {
         props: {
             labels: {
@@ -35,21 +38,25 @@
                     return this.labels;
                 }
             },
+            filterUtils() {
+                return useFilters(this.$route.name);
+            },
+            currentFilters() {
+                return decodeParams(this.$route.path, this.$route.query, this.$props.include, this.filterUtils.OPTIONS);
+            },
             labelsFromQuery() {
                 const labels = new Map();
-                (this.$route.query.labels !== undefined ?
-                    (typeof(this.$route.query.labels) === "string" ? [this.$route.query.labels] : this.$route.query.labels)  :
-                    []
-                )
-                    .forEach(label => {
-                        const separatorIndex = label.indexOf(":");
+                const queryLabels = this.currentFilters.filter(item => item.label === "labels");
 
-                        if (separatorIndex === -1) {
-                            return;
-                        }
+                queryLabels.map(item => item.value[0]).forEach(label => {
+                    const separatorIndex = label.indexOf(":");
 
-                        labels.set(label.slice(0, separatorIndex), label.slice(separatorIndex + 1));
-                    })
+                    if (separatorIndex === -1) {
+                        return;
+                    }
+
+                    labels.set(label.slice(0, separatorIndex), label.slice(separatorIndex + 1));
+                });
 
                 return labels;
             }
@@ -58,21 +65,20 @@
             checked(key, value) {
                 return this.labelsFromQuery.has(key) && this.labelsFromQuery.get(key) === value;
             },
+            removeLabelFromFilters(key, value) {
+                return this.currentFilters.filter(item => !(item.label === "labels" && item.value[0] === `${key}:${value}`))
+            },
+            appendLabelToFilters(key, value) {
+                const labelValue = `${key}:${value}`;
+                const label = {label: "labels", value: [labelValue], comparator: this.filterUtils.COMPARATORS.EQUALS};
+
+                return this.currentFilters.concat([label]);
+            },
             link(key, value) {
-                const labels = this.labelsFromQuery;
-
-                if (labels.has(key)) {
-                    labels.delete(key);
-                } else {
-                    labels.set(key, value);
-                }
-
-                const qs = {
-                    ...this.$route.query,
-                    ...{"labels": Array.from(labels.keys()).map((key) => key + ":" + labels.get(key))}
-                };
-
-                delete qs.page;
+                const modifiedFilters = this.labelsFromQuery.has(key) ?
+                    this.removeLabelFromFilters(key, value) :
+                    this.appendLabelToFilters(key, value);
+                const qs =  encodeParams(this.$route.path, modifiedFilters, this.filterUtils.OPTIONS);
 
                 return {name: this.$route.name, params: this.$route.params, query: qs};
             }


### PR DESCRIPTION
### What changes are being made and why?

* Amended recently broken clickable labels.
* Made `KestraFilter` listen on route changes.
* Encoded filters also at `/flows/edit/<ns>/<flow>/executions`.