### PR TITLE
fix(jdbc): be resilient to DataException

### DIFF
--- a/jdbc-postgres/src/test/java/io/kestra/runner/postgres/PostgresQueueTest.java
+++ b/jdbc-postgres/src/test/java/io/kestra/runner/postgres/PostgresQueueTest.java
@@ -1,7 +1,38 @@
 package io.kestra.runner.postgres;
 
+import io.kestra.core.models.executions.TaskRun;
+import io.kestra.core.models.flows.State;
+import io.kestra.core.queues.QueueException;
+import io.kestra.core.runners.WorkerTaskResult;
+import io.kestra.core.utils.IdUtils;
 import io.kestra.jdbc.runner.JdbcQueueTest;
+import org.jooq.exception.DataException;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class PostgresQueueTest extends JdbcQueueTest {
+    @Test
+    void invalidWorkerTaskShouldThrowDataException() throws QueueException {
+        var workerTaskResult = WorkerTaskResult.builder()
+            .taskRun(TaskRun.builder()
+                .taskId("taskId")
+                .id(IdUtils.create())
+                .namespace("namespace")
+                .flowId("flowId")
+                .state(new State().withState(State.Type.SUCCESS))
+                .outputs(Map.of("value", "\u0000"))
+                .build()
+            )
+            .build();
 
+        var exception = assertThrows(QueueException.class, () -> workerTaskResultQueue.emit(workerTaskResult));
+        assertThat(exception.getMessage(), is("Unable to emit a message to the queue"));
+        assertThat(exception.getCause(), instanceOf(DataException.class));
+    }
 }

--- a/jdbc/src/test/java/io/kestra/jdbc/runner/JdbcQueueTest.java
+++ b/jdbc/src/test/java/io/kestra/jdbc/runner/JdbcQueueTest.java
@@ -6,6 +6,7 @@ import io.kestra.core.queues.QueueException;
 import io.kestra.core.queues.QueueFactoryInterface;
 import io.kestra.core.queues.QueueInterface;
 import io.kestra.core.runners.Indexer;
+import io.kestra.core.runners.WorkerTaskResult;
 import io.kestra.core.utils.TestsUtils;
 import io.kestra.plugin.core.debug.Return;
 import io.kestra.core.utils.IdUtils;
@@ -30,6 +31,10 @@ abstract public class JdbcQueueTest {
     @Inject
     @Named(QueueFactoryInterface.FLOW_NAMED)
     protected QueueInterface<FlowWithSource> flowQueue;
+
+    @Inject
+    @Named(QueueFactoryInterface.WORKERTASKRESULT_NAMED)
+    protected QueueInterface<WorkerTaskResult> workerTaskResultQueue;
 
     @Inject
     JdbcTestUtils jdbcTestUtils;


### PR DESCRIPTION
We usually fail fast, but when a DataException is thrown it means the JDBC driver throws an exception with error code 22: data exception. As the exception is from the data not the database or the network, there is no point of failfast, we throw a QueueException that may or may not be handled gracefully by the call site.

Fixes #7221
