### PR TITLE
chore(core): move run context property validation to the run context

### DIFF
--- a/core/src/main/java/io/kestra/core/runners/RunContext.java
+++ b/core/src/main/java/io/kestra/core/runners/RunContext.java
@@ -75,6 +75,11 @@ public abstract class RunContext {
 
     public abstract Map<String, String> renderMap(Map<String, String> inline, Map<String, Object> variables) throws IllegalVariableEvaluationException;
 
+    /**
+     * Validate a bean using Jakarta Bean Validation.
+     */
+    public abstract <T> void validate(T bean);
+
     public abstract String decrypt(String encrypted) throws GeneralSecurityException;
 
     /**

--- a/core/src/main/java/io/kestra/core/runners/RunContextProperty.java
+++ b/core/src/main/java/io/kestra/core/runners/RunContextProperty.java
@@ -35,23 +35,11 @@ public class RunContextProperty<T> {
         this.trigger = ((DefaultRunContext) runContext).getTrigger();
     }
 
-    /**
-     * Validate a bean using Jakarta Bean Validation.
-     * TODO this seems useful as a general util so maybe move it to the RunContext
-     */
-    public <U> void validate(U bean) {
-        Validator validator = ((DefaultRunContext) runContext).getApplicationContext().getBean(Validator.class);
-        Set<ConstraintViolation<U>> violations = validator.validate(bean);
-        if (!violations.isEmpty()) {
-            throw new ConstraintViolationException(violations);
-        }
-    }
-
     private void validate() {
         if (task != null) {
-            validate(task);
+            runContext.validate(task);
         } else if (trigger != null) {
-            validate(trigger);
+            runContext.validate(trigger);
         } else if (log.isTraceEnabled()) {
             // this should never happen, but it happens a lot on unit test
             log.trace("Unable to do validation: no task or trigger found");

--- a/core/src/test/java/io/kestra/core/runners/RunContextTest.java
+++ b/core/src/test/java/io/kestra/core/runners/RunContextTest.java
@@ -35,6 +35,7 @@ import io.micronaut.context.annotation.Property;
 import io.micronaut.context.annotation.Value;
 import jakarta.inject.Inject;
 import jakarta.inject.Named;
+import jakarta.validation.ConstraintViolationException;
 import jakarta.validation.constraints.NotNull;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -62,6 +63,7 @@ import java.util.concurrent.TimeoutException;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @KestraTest(startRunner = true)
 @Property(name = "kestra.tasks.tmp-dir.path", value = "/tmp/sub/dir/tmp/")
@@ -321,6 +323,22 @@ class RunContextTest {
         assertThat(Objects.requireNonNull(matchingLog.stream().filter(logEntry -> logEntry.getLevel().equals(Level.INFO)).findFirst().orElse(null)).getMessage(), is("john ******** doe"));
     }
 
+    @Test
+    void shouldValidateABean() {
+        RunContext runContext = runContextInitializer.forExecutor((DefaultRunContext) runContextFactory.of());
+        TestBean testBean = new TestBean("someValue");
+
+        runContext.validate(testBean);
+    }
+
+    @Test
+    void shouldFailValidateABean() {
+        RunContext runContext = runContextInitializer.forExecutor((DefaultRunContext) runContextFactory.of());
+        TestBean testBean = new TestBean(null);
+
+        assertThrows(ConstraintViolationException.class, () -> runContext.validate(testBean));
+    }
+
     @SuperBuilder
     @ToString
     @EqualsAndHashCode
@@ -344,4 +362,6 @@ class RunContextTest {
             return null;
         }
     }
+
+    record TestBean(@NotNull String someValue) {}
 }


### PR DESCRIPTION
This would avoid loading the Validator from the application context each time we render a property