### PR TITLE
fix(cli): enforce server command validator

### DIFF
--- a/core/src/main/java/io/kestra/core/validations/ServerCommandValidator.java
+++ b/core/src/main/java/io/kestra/core/validations/ServerCommandValidator.java
@@ -1,4 +1,4 @@
-package io.kestra.cli;
+package io.kestra.core.validations;
 
 import io.micronaut.context.annotation.Context;
 import io.micronaut.context.annotation.Requires;

--- a/core/src/test/java/io/kestra/core/validations/ServerCommandValidatorTest.java
+++ b/core/src/test/java/io/kestra/core/validations/ServerCommandValidatorTest.java
@@ -1,4 +1,4 @@
-package io.kestra.cli;
+package io.kestra.core.validations;
 
 import io.micronaut.context.ApplicationContext;
 import io.micronaut.context.exceptions.BeanInstantiationException;

--- a/webserver/src/main/java/io/kestra/webserver/services/BasicAuthService.java
+++ b/webserver/src/main/java/io/kestra/webserver/services/BasicAuthService.java
@@ -6,6 +6,7 @@ import io.kestra.core.repositories.SettingRepositoryInterface;
 import io.kestra.core.serializers.JacksonMapper;
 import io.kestra.core.services.InstanceService;
 import io.kestra.core.utils.AuthUtils;
+import io.kestra.core.validations.ServerCommandValidator;
 import io.kestra.webserver.models.events.OssAuthEvent;
 import io.micronaut.context.annotation.ConfigurationInject;
 import io.micronaut.context.annotation.ConfigurationProperties;
@@ -44,6 +45,8 @@ public class BasicAuthService {
 
     @Inject
     private ApplicationEventPublisher<OssAuthEvent> ossAuthEventPublisher;
+
+    public BasicAuthService(ServerCommandValidator serverCommandValidator) {}
 
     @PostConstruct
     private void init() {


### PR DESCRIPTION
### What changes are being made and why?

With addition of the eagerly initialized [BasicAuth](https://github.com/kestra-io/kestra/blob/develop/webserver/src/main/java/io/kestra/webserver/services/BasicAuthService.java) bean the validator's order needed to be enforced.

### How the changes have been QAed?

```bash
./build/executable/kestra-0.22.0-SNAPSHOT server standalone
```