### PR TITLE
fix(ui): amend label filter after filter change

### DIFF
--- a/ui/src/components/filter/utils/helpers.ts
+++ b/ui/src/components/filter/utils/helpers.ts
@@ -1,5 +1,5 @@
 export const encodeParams = (route, filters, OPTIONS) => {
-    if(isSearchPath(route)) {return encodeSearchParams(filters, OPTIONS); }
+    if(isSearchPath(route)) { return encodeSearchParams(filters, OPTIONS); }
 
     const encode = (values, key) => {
         return values
@@ -109,14 +109,12 @@ export const encodeSearchParams = (filters, OPTIONS) => {
         return valuesArray.reduce((acc, v) => {
             if (key === "childFilter" && v === "ALL") return acc;
 
-            const encoded = encodeURIComponent(v);
-
             if (key === "labels") {
                 const [labelKey, labelValue] = v.split(":");
-                acc[`filters[${key}][${operation}][${labelKey}]`] = encodeURIComponent(labelValue);
+                acc[`filters[${key}][${operation}][${labelKey}]`] = labelValue;
             } else {
                 const paramKey = `filters[${key}][${operation}]`;
-                acc[paramKey] = acc[paramKey] ? `${acc[paramKey]},${encoded}` : encoded;
+                acc[paramKey] = acc[paramKey] ? `${acc[paramKey]},${v}` : v;
             }
             return acc;
         }, {});


### PR DESCRIPTION
### What changes are being made and why?

Prevent the value of labels filter from being explicitly URI-encoded.

The issue might be related to #7404.

#### Steps to reproduce the issue

1. Create the attached flow
2. Execute the flow at least once
3. Navigate to the _Executions_ view
4. Add the `namespace is company.team` filter
**Either:**
6. Click on the `amp&:amp&` label on the executions table
7. Remove the `namespace is company.team` filter
**Or:**
5. Add the `labels is amp&:amp&` filter manually

The flow execution(s) gets filtered out completely.  This is caused by the filter query getting URI-encoded to `amp%2526` instead of `amp%26`.

---

### How the changes have been QAed?

```yaml
id: rat_157618
namespace: company.team

labels:
  amp&: amp& # '&' should be handled correctly

tasks:
  - id: hello
    type: io.kestra.plugin.core.log.Log
    message: Hello World! 🚀
```
