### PR TITLE
chore(ui): respect default execution tab settings field when opening single execution

### DIFF
--- a/ui/src/components/executions/ExecutionRoot.vue
+++ b/ui/src/components/executions/ExecutionRoot.vue
@@ -59,6 +59,9 @@
             };
         },
         created() {
+            const tab = localStorage.getItem("executeDefaultTab") || undefined;
+            this.$router.replace({name: "executions/update", params: {...this.$route.params, tab}});
+
             this.follow();
             window.addEventListener("popstate", this.follow)
         },


### PR DESCRIPTION
Closes https://github.com/kestra-io/kestra/issues/7545.