### PR TITLE
Chore/perf improvements

### DIFF
--- a/core/src/main/java/io/kestra/core/models/executions/Execution.java
+++ b/core/src/main/java/io/kestra/core/models/executions/Execution.java
@@ -840,11 +840,11 @@ public class Execution implements DeletedInterface, TenantInterface {
             }
         }
 
-        Map<String, Object> result = MapUtils.newHashMap(1);
+        Map<String, Object> result = HashMap.newHashMap(1);
         Map<String, Object> current = result;
 
         for (TaskRun t : parents) {
-            HashMap<String, Object> item = MapUtils.newHashMap(1);
+            HashMap<String, Object> item = HashMap.newHashMap(1);
             current.put(t.getValue(), item);
             current = item;
         }

--- a/core/src/main/java/io/kestra/core/models/flows/Flow.java
+++ b/core/src/main/java/io/kestra/core/models/flows/Flow.java
@@ -204,9 +204,9 @@ public class Flow extends AbstractFlow implements HasUID {
 
     public Stream<Task> allTasks() {
         return Stream.of(
-                this.tasks != null ? this.tasks : new ArrayList<Task>(),
-                this.errors != null ? this.errors : new ArrayList<Task>(),
-                this._finally != null ? this._finally : new ArrayList<Task>(),
+                this.tasks != null ? this.tasks : Collections.<Task>emptyList(),
+                this.errors != null ? this.errors : Collections.<Task>emptyList(),
+                this._finally != null ? this._finally : Collections.<Task>emptyList(),
                 this.listenersTasks()
             )
             .flatMap(Collection::stream);
@@ -331,7 +331,7 @@ public class Flow extends AbstractFlow implements HasUID {
 
     private List<Task> listenersTasks() {
         if (this.getListeners() == null) {
-            return new ArrayList<>();
+            return Collections.emptyList();
         }
 
         return this.getListeners()

--- a/core/src/main/java/io/kestra/core/utils/MapUtils.java
+++ b/core/src/main/java/io/kestra/core/utils/MapUtils.java
@@ -25,7 +25,7 @@ public class MapUtils {
             .entrySet()
             .stream()
             .collect(
-                () -> newHashMap(copy.size()),
+                () -> HashMap.newHashMap(copy.size()),
                 (m, v) -> {
                     Object original = copy.get(v.getKey());
                     Object value = v.getValue();
@@ -66,7 +66,7 @@ public class MapUtils {
             .entrySet()
             .stream()
             .collect(
-                () -> newHashMap(original.size()),
+                () -> HashMap.newHashMap(original.size()),
                 (map, entry) -> {
                     Object value = entry.getValue();
                     Object found;
@@ -133,19 +133,6 @@ public class MapUtils {
      */
     public static boolean isEmpty(Map<?, ?> map) {
         return map == null || map.isEmpty();
-    }
-
-    /**
-     * Creates a hash map that can hold <code>numMappings</code> entry.
-     * This is a copy of the same methods available starting with Java 19.
-     */
-    public static <K, V> HashMap<K, V> newHashMap(int numMappings) {
-        if (numMappings < 0) {
-            throw new IllegalArgumentException("Negative number of mappings: " + numMappings);
-        }
-
-        int hashMapCapacity = (int) Math.ceil(numMappings / 0.75d);
-        return new HashMap<>(hashMapCapacity);
     }
 
     /**

--- a/jdbc-mysql/src/main/java/io/kestra/runner/mysql/MysqlQueue.java
+++ b/jdbc-mysql/src/main/java/io/kestra/runner/mysql/MysqlQueue.java
@@ -72,7 +72,7 @@ public class MysqlQueue<T> extends JdbcQueue<T> {
                 DSL.field("CONCAT_WS(',', consumers, ?)", String.class, queueType)
             )
             .set(AbstractJdbcRepository.field("updated"), LocalDateTime.now())
-            .where(AbstractJdbcRepository.field("offset").in(offsets.toArray(Integer[]::new)));
+            .where(AbstractJdbcRepository.field("offset").in(offsets));
 
         if (consumerGroup != null) {
             update = update.and(AbstractJdbcRepository.field("consumer_group").eq(consumerGroup));


### PR DESCRIPTION
Multiple small enhancements, one of the most impactful should be to replace merging all outputs for all taskrun but only merging outputs of the same taskId to lower the scope of the merge.

`MapUtils.merge()`is a costly operation that clone the Map. As this is called a lot of time for complex workflow, this has a non-negligible impact.

Using this flow (2.1k taskruns):
```yaml
id: outputs
namespace: company.team

tasks:
  - id: forEach1
    type: io.kestra.plugin.core.flow.ForEach
    values: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
    tasks:
    - id: forEach2
      type: io.kestra.plugin.core.flow.ForEach
      values: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
      tasks:
      - id: forEach3
        type: io.kestra.plugin.core.flow.ForEach
        values: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
        tasks:
        - id: output
          type: io.kestra.plugin.core.output.OutputValues
          values:
            attr: "{{parents[1].taskrun.value}}-{{parent.taskrun.value}}-{{taskrun.value}}"
        - id: log
          type: io.kestra.plugin.core.log.Log
          message: "{{currentEachOutput(outputs.output).values.attr}}"
```

The performance impact is hard to tell because profiling depends on when you do the profile (for simplicity I didn't profile the whole execution but only one minute). The following numbers are nothing more than a hint, don't take them too seriously.

Approx improvements:
- The CPU cost of `Execution.output()` goes from 15.3% of samples to 11.8%
- The allocation cost of `Execution.output()` goes from 44% of samples to 38%

See the following flamegraphs (zoomed on the execution queue) for more information.

**Before - CPU profile**
![image](https://github.com/user-attachments/assets/6a29a897-9ef8-477e-a6a6-b83b9533b966)

** After - CPU profile**
![image](https://github.com/user-attachments/assets/82788b03-fc06-4b5e-b236-76b8451cc17d)

**Before - Allocation profile**
![image](https://github.com/user-attachments/assets/c71694f2-b853-4ea3-b8f3-9c9d9f27eab2)

**After - Allocation profile**
![image](https://github.com/user-attachments/assets/41c73d30-bd08-4f66-826e-78e3a974e5ce)
