### PR TITLE
fix(flow editor): enhance behavior when switching file tabs

### DIFF
--- a/ui/src/components/inputs/Editor.vue
+++ b/ui/src/components/inputs/Editor.vue
@@ -50,6 +50,7 @@
                     :original="original"
                     @change="onInput"
                     @editor-did-mount="editorDidMount"
+                    @tab-loaded="$emit('tabLoaded', $event)"
                     :language="lang"
                     :extension="extension"
                     :schema-type="schemaType"
@@ -113,10 +114,11 @@
             "save",
             "execute",
             "focusout",
-            "tab",
+            "tabLoaded",
             "update:modelValue",
             "cursor",
             "confirm",
+            "tabLoaded",
         ],
         editor: undefined,
         data() {
@@ -268,11 +270,11 @@
                         this.focus = false;
                     });
 
-                    if(this.shouldFocus){                
+                    if(this.shouldFocus){
                         this.editor.onDidFocusEditorText?.(() => {
                             this.focus = true;
                         });
-                        
+
                         this.$refs.monacoEditor.focus();
                     }
                 }

--- a/ui/src/components/inputs/Editor.vue
+++ b/ui/src/components/inputs/Editor.vue
@@ -50,7 +50,7 @@
                     :original="original"
                     @change="onInput"
                     @editor-did-mount="editorDidMount"
-                    @tab-loaded="$emit('tabLoaded', $event)"
+                    @tab-loaded="(...args) => $emit('tabLoaded', ...args)"
                     :language="lang"
                     :extension="extension"
                     :schema-type="schemaType"

--- a/ui/src/components/inputs/EditorView.vue
+++ b/ui/src/components/inputs/EditorView.vue
@@ -147,6 +147,7 @@
                     @cursor="updatePluginDocumentation"
                     :creating="isCreating"
                     @restart-guided-tour="() => persistViewType(editorViewTypes.SOURCE)"
+                    @tab-loaded="onTabLoaded"
                     :read-only="isReadOnly"
                     :navbar="false"
                 >
@@ -1424,13 +1425,18 @@
         dragOverTabIndex.value = null;
     };
 
+    const dirtyBeforeLoad = ref(false);
+
     watch(currentTab, (current, previous) => {
+        // to avoid changing the dirty state of a tab
+        // when switching between tabs, we save the value
+        // before the tabs text is loaded from the model.
+        dirtyBeforeLoad.value = currentTab.value.dirty;
         const isCurrentFlow = current?.name === "Flow";
         const isPreviousFlow = previous?.name === "Flow";
 
         if(isPreviousFlow) persistViewType(viewType.value);
         updatedFromEditor.value = false;
-        haveChange.value = currentTab.value.dirty;
         switchViewType(isCurrentFlow ? loadViewType() : editorViewTypes.SOURCE, false)
 
         nextTick(() => {
@@ -1441,6 +1447,16 @@
             tabsScrollRef.value.setScrollLeft(rightMostCurrentTabPixel - tabsWrapper.clientWidth);
         });
     })
+
+    function onTabLoaded(tab){
+        clearTimeout(timer.value);
+
+        // once the tab is finished loading, restore the dirty state
+        if(tab.path === currentTab.value.path){
+            currentTab.value.dirty = dirtyBeforeLoad.value
+            haveChange.value = dirtyBeforeLoad.value
+        }
+    }
 
     const tabContextMenu = ref({
         visible: false,

--- a/ui/src/components/inputs/EditorView.vue
+++ b/ui/src/components/inputs/EditorView.vue
@@ -139,7 +139,7 @@
                     ref="editorDomElement"
                     @save="save"
                     @execute="execute"
-                    v-model="flowYaml"
+                    :model-value="flowYaml"
                     :schema-type="isCurrentTabFlow? 'flow': undefined"
                     :lang="currentTab?.extension === undefined ? 'yaml' : undefined"
                     :extension="currentTab?.extension"
@@ -1094,7 +1094,6 @@
         const currentIsFlow = isFlow();
 
         updatedFromEditor.value = true;
-        flowYaml.value = event;
 
         clearTimeout(timer.value);
         timer.value = setTimeout(() => onEdit(event, currentIsFlow), 500);
@@ -1202,6 +1201,7 @@
         if (flowErrors.value?.length || !haveChange.value && !props.isCreating) {
             return;
         }
+
         if (e) {
             if (e.type === "keydown") {
                 if (!(e.keyCode === 83 && e.ctrlKey)) {
@@ -1430,6 +1430,7 @@
 
         if(isPreviousFlow) persistViewType(viewType.value);
         updatedFromEditor.value = false;
+        haveChange.value = currentTab.value.dirty;
         switchViewType(isCurrentFlow ? loadViewType() : editorViewTypes.SOURCE, false)
 
         nextTick(() => {

--- a/ui/src/components/inputs/EditorView.vue
+++ b/ui/src/components/inputs/EditorView.vue
@@ -106,7 +106,7 @@
                 :is-read-only="props.isReadOnly"
                 :can-delete="canDelete()"
                 :is-allowed-edit="isAllowedEdit"
-                :have-change="flowYaml !== flowYamlOrigin"
+                :have-change="isFlow() ? flowYaml !== flowYamlOrigin : currentTab?.dirty"
                 :flow-have-tasks="flowHaveTasks()"
                 :errors="flowErrors"
                 :warnings="flowWarnings"
@@ -1448,11 +1448,13 @@
         });
     })
 
-    function onTabLoaded(tab){
+    function onTabLoaded(tab, source){
         clearTimeout(timer.value);
 
         // once the tab is finished loading, restore the dirty state
         if(tab.path === currentTab.value.path){
+            flowYaml.value = source;
+            onEdit(source, tab.flow);
             currentTab.value.dirty = dirtyBeforeLoad.value
             haveChange.value = dirtyBeforeLoad.value
         }

--- a/ui/src/components/inputs/EditorView.vue
+++ b/ui/src/components/inputs/EditorView.vue
@@ -901,44 +901,45 @@
     };
 
     const onEdit = (event, currentIsFlow = false) => {
-        flowYaml.value = event;
+        if(flowYaml.value !== event) {
+            flowYaml.value = event;
 
-        if (currentIsFlow) {
-            if (
-                flowParsed.value &&
-                !props.isCreating &&
-                (routeParams.id !== flowParsed.value.id ||
-                    routeParams.namespace !== flowParsed.value.namespace)
-            ) {
-                store.dispatch("core/showMessage", {
-                    variant: "error",
-                    title: t("readonly property"),
-                    message: t("namespace and id readonly"),
+            if (currentIsFlow) {
+                if (
+                    flowParsed.value &&
+                    !props.isCreating &&
+                    (routeParams.id !== flowParsed.value.id ||
+                        routeParams.namespace !== flowParsed.value.namespace)
+                ) {
+                    store.dispatch("core/showMessage", {
+                        variant: "error",
+                        title: t("readonly property"),
+                        message: t("namespace and id readonly"),
+                    });
+                    flowYaml.value = YamlUtils.replaceIdAndNamespace(
+                        flowYaml.value,
+                        routeParams.id,
+                        routeParams.namespace
+                    );
+                    return;
+                }
+            }
+
+            haveChange.value = true;
+            if(editorViewType.value === "YAML") store.dispatch("core/isUnsaved", true);
+
+            if(!props.isCreating){
+                store.commit("editor/changeOpenedTabs", {
+                    action: "dirty",
+                    ...currentTab.value,
+                    name: currentTab.value?.name ?? "Flow",
+                    path: currentTab.value?.path ?? "Flow.yaml",
+                    dirty: true
                 });
-                flowYaml.value = YamlUtils.replaceIdAndNamespace(
-                    flowYaml.value,
-                    routeParams.id,
-                    routeParams.namespace
-                );
-                return;
             }
         }
 
-        haveChange.value = true;
-        if(editorViewType.value === "YAML") store.dispatch("core/isUnsaved", true);
-        
-        if(!props.isCreating){
-            store.commit("editor/changeOpenedTabs", {
-                action: "dirty",
-                ...currentTab.value,
-                name: currentTab.value?.name ?? "Flow",
-                path: currentTab.value?.path ?? "Flow.yaml",
-                dirty: true
-            });
-        }
-
         clearTimeout(timer.value);
-
         if(!currentIsFlow) return;
 
         return store
@@ -1402,7 +1403,7 @@
 
     const draggedTabIndex = ref(null);
     const dragOverTabIndex = ref(null);
-    
+
     const onDragStart = (event, index) => {
         draggedTabIndex.value = index;
         event.dataTransfer.effectAllowed = "move";
@@ -1428,6 +1429,7 @@
         const isPreviousFlow = previous?.name === "Flow";
 
         if(isPreviousFlow) persistViewType(viewType.value);
+        updatedFromEditor.value = false;
         switchViewType(isCurrentFlow ? loadViewType() : editorViewTypes.SOURCE, false)
 
         nextTick(() => {
@@ -1540,10 +1542,10 @@
     });
     const dialogHandler = async () => {
         try {
-            const path = dialog.value.folder 
+            const path = dialog.value.folder
                 ? `${dialog.value.folder}/${dialog.value.name}`
                 : dialog.value.name;
-            
+
             if (dialog.value.type === "file") {
                 await store.dispatch("namespace/createFile", {
                     namespace: props.namespace ?? route.params.namespace,
@@ -1580,7 +1582,7 @@
                 reader.readAsArrayBuffer(file);
             });
             const path = file.webkitRelativePath || file.name;
-            
+
             await store.dispatch("namespace/importFileDirectory", {
                 namespace: props.namespace ?? route.params.namespace,
                 content,
@@ -1769,14 +1771,14 @@
             margin-top: 1rem;
             border: 1px solid var(--ks-border-primary);
             border-radius: 0.5rem;
-            
+
             iframe {
                 width: 100%;
                 min-height: 380px;
                 height: auto;
             }
         }
-        
+
         .hidden {
             display: none;
         }

--- a/ui/src/components/inputs/MonacoEditor.vue
+++ b/ui/src/components/inputs/MonacoEditor.vue
@@ -123,7 +123,7 @@
                 default: false
             }
         },
-        emits: ["editorDidMount", "change"],
+        emits: ["editorDidMount", "change", "tabLoaded"],
         model: {
             event: "change"
         },
@@ -159,6 +159,8 @@
                     model = await this.changeTab(newTabName, () => this.readFile(payload));
                 }
                 this.$emit("change", model.getValue());
+                console.log("Tab loaded", newTabName);
+                this.$emit("tabLoaded", newValue);
             },
             options: {
                 deep: true,

--- a/ui/src/components/inputs/MonacoEditor.vue
+++ b/ui/src/components/inputs/MonacoEditor.vue
@@ -147,16 +147,18 @@
                     return;
                 }
 
+                let model
                 if (newValue.persistent && this.flow?.source) {
-                    await this.changeTab("Flow", () => this.flow.source);
+                    model = await this.changeTab("Flow", () => this.flow.source);
                 } else {
                     const payload = {
                         namespace: this.$route.params.namespace || this.$route.params.id,
                         path: newValue.path ?? newValue.name,
                     };
 
-                    await this.changeTab(newTabName, () => this.readFile(payload));
+                    model = await this.changeTab(newTabName, () => this.readFile(payload));
                 }
+                this.$emit("change", model.getValue());
             },
             options: {
                 deep: true,
@@ -724,6 +726,8 @@
                     }
                 }
                 this.editor.setModel(model);
+
+                return model
             },
             getEditor: function () {
                 return this.editor;

--- a/ui/src/components/inputs/MonacoEditor.vue
+++ b/ui/src/components/inputs/MonacoEditor.vue
@@ -158,9 +158,9 @@
 
                     model = await this.changeTab(newTabName, () => this.readFile(payload));
                 }
-                this.$emit("change", model.getValue());
-                console.log("Tab loaded", newTabName);
-                this.$emit("tabLoaded", newValue);
+                const source = model.getValue()
+                this.$emit("change", source);
+                this.$emit("tabLoaded", newValue, source);
             },
             options: {
                 deep: true,

--- a/ui/src/stores/flow.js
+++ b/ui/src/stores/flow.js
@@ -1,4 +1,3 @@
-import axios from "axios";
 import YamlUtils from "../utils/yamlUtils";
 import Utils from "../utils/utils";
 import {apiUrl} from "override/utils/route";
@@ -171,7 +170,7 @@ export default {
             if (!flowParsed.id || !flowParsed.namespace) {
                 flowSource = YamlUtils.updateMetadata(flowSource, {id: "default", namespace: "default"})
             }
-            return axios.post(`${apiUrl(this)}/flows/graph`, flowSource, {...config, withCredentials: true})
+            return this.$http.post(`${apiUrl(this)}/flows/graph`, flowSource, {...config, withCredentials: true})
                 .then(response => {
                     commit("setFlowGraph", response.data)
 
@@ -257,14 +256,14 @@ export default {
             return this.$http.delete(`${apiUrl(this)}/flows/delete/by-query`, {params: options})
         },
         validateFlow({commit}, options) {
-            return axios.post(`${apiUrl(this)}/flows/validate`, options.flow, {...textYamlHeader, withCredentials: true})
+            return this.$http.post(`${apiUrl(this)}/flows/validate`, options.flow, {...textYamlHeader, withCredentials: true})
                 .then(response => {
                     commit("setFlowValidation", response.data[0])
                     return response.data[0]
                 })
         },
         validateTask({commit}, options) {
-            return axios.post(`${apiUrl(this)}/flows/validate/task`, options.task, {...textYamlHeader, withCredentials: true, params: {section: options.section}})
+            return this.$http.post(`${apiUrl(this)}/flows/validate/task`, options.task, {...textYamlHeader, withCredentials: true, params: {section: options.section}})
                 .then(response => {
                     commit("setTaskError", response.data.constraints)
                     return response.data

--- a/ui/tests/fixtures/flowgraphs/allow-failure-demo.json
+++ b/ui/tests/fixtures/flowgraphs/allow-failure-demo.json
@@ -1,0 +1,150 @@
+{
+    "nodes": [
+        {
+            "uid": "root.root-7c2PAMw6iAYKLlTs3NgAEo",
+            "type": "io.kestra.core.models.hierarchies.GraphClusterRoot"
+        },
+        {
+            "uid": "root.end-2ecn1da4JRgQ58RmR57kix",
+            "type": "io.kestra.core.models.hierarchies.GraphClusterEnd"
+        },
+        {
+            "uid": "root.allow_failure.root-3vCjH2f8MKMiVCkEHtZmpG",
+            "type": "io.kestra.core.models.hierarchies.GraphClusterRoot"
+        },
+        {
+            "uid": "root.allow_failure.end-4o3fsEolpoFu3xkrLw733R",
+            "type": "io.kestra.core.models.hierarchies.GraphClusterEnd"
+        },
+        {
+            "uid": "root.allow_failure",
+            "type": "io.kestra.core.models.hierarchies.GraphTask",
+            "task": {
+                "id": "allow_failure",
+                "type": "io.kestra.plugin.core.flow.AllowFailure",
+                "tasks": [
+                    {
+                        "id": "fail_silently",
+                        "type": "io.kestra.plugin.scripts.shell.Commands",
+                        "taskRunner": {
+                            "type": "io.kestra.plugin.core.runner.Process"
+                        },
+                        "commands": [
+                            "exit 1"
+                        ]
+                    }
+                ]
+            },
+            "relationType": "SEQUENTIAL"
+        },
+        {
+            "uid": "root.allow_failure.fail_silently",
+            "type": "io.kestra.core.models.hierarchies.GraphTask",
+            "task": {
+                "id": "fail_silently",
+                "type": "io.kestra.plugin.scripts.shell.Commands",
+                "taskRunner": {
+                    "type": "io.kestra.plugin.core.runner.Process"
+                },
+                "commands": [
+                    "exit 1"
+                ]
+            },
+            "relationType": "SEQUENTIAL"
+        },
+        {
+            "uid": "root.print_to_console",
+            "type": "io.kestra.core.models.hierarchies.GraphTask",
+            "task": {
+                "id": "print_to_console",
+                "type": "io.kestra.plugin.scripts.shell.Commands",
+                "taskRunner": {
+                    "type": "io.kestra.plugin.core.runner.Process"
+                },
+                "commands": [
+                    "echo \"this will run since previous failure was allowed ✅\""
+                ]
+            },
+            "relationType": "SEQUENTIAL"
+        }
+    ],
+    "edges": [
+        {
+            "source": "root.print_to_console",
+            "target": "root.end-2ecn1da4JRgQ58RmR57kix",
+            "relation": {}
+        },
+        {
+            "source": "root.root-7c2PAMw6iAYKLlTs3NgAEo",
+            "target": "root.allow_failure.root-3vCjH2f8MKMiVCkEHtZmpG",
+            "relation": {}
+        },
+        {
+            "source": "root.allow_failure.end-4o3fsEolpoFu3xkrLw733R",
+            "target": "root.print_to_console",
+            "relation": {
+                "relationType": "SEQUENTIAL"
+            }
+        },
+        {
+            "source": "root.allow_failure.fail_silently",
+            "target": "root.allow_failure.end-4o3fsEolpoFu3xkrLw733R",
+            "relation": {}
+        },
+        {
+            "source": "root.allow_failure.root-3vCjH2f8MKMiVCkEHtZmpG",
+            "target": "root.allow_failure",
+            "relation": {}
+        },
+        {
+            "source": "root.allow_failure",
+            "target": "root.allow_failure.fail_silently",
+            "relation": {
+                "relationType": "SEQUENTIAL"
+            }
+        }
+    ],
+    "clusters": [
+        {
+            "cluster": {
+                "uid": "cluster_root.allow_failure",
+                "type": "io.kestra.core.models.hierarchies.GraphCluster",
+                "relationType": "SEQUENTIAL",
+                "taskNode": {
+                    "uid": "root.allow_failure",
+                    "type": "io.kestra.core.models.hierarchies.GraphTask",
+                    "task": {
+                        "id": "allow_failure",
+                        "type": "io.kestra.plugin.core.flow.AllowFailure",
+                        "tasks": [
+                            {
+                                "id": "fail_silently",
+                                "type": "io.kestra.plugin.scripts.shell.Commands",
+                                "taskRunner": {
+                                    "type": "io.kestra.plugin.core.runner.Process"
+                                },
+                                "commands": [
+                                    "exit 1"
+                                ]
+                            }
+                        ]
+                    },
+                    "relationType": "SEQUENTIAL"
+                },
+                "finally": {
+                    "uid": "allow_failure.finally-3OW0HTfTWnwkSwrg1cBvxj",
+                    "type": "io.kestra.core.models.hierarchies.GraphClusterFinally"
+                }
+            },
+            "nodes": [
+                "root.allow_failure.root-3vCjH2f8MKMiVCkEHtZmpG",
+                "root.allow_failure.end-4o3fsEolpoFu3xkrLw733R",
+                "root.allow_failure",
+                "root.allow_failure.fail_silently"
+            ],
+            "parents": [],
+            "start": "root.allow_failure.root-3vCjH2f8MKMiVCkEHtZmpG",
+            "end": "root.allow_failure.end-4o3fsEolpoFu3xkrLw733R"
+        }
+    ]
+}

--- a/ui/tests/storybook/components/flows/FlowEditor.stories.jsx
+++ b/ui/tests/storybook/components/flows/FlowEditor.stories.jsx
@@ -2,6 +2,7 @@ import {useStore} from "vuex";
 import {vueRouter} from "storybook-vue3-router";
 import FlowEditor from "../../../../src/components/flows/FlowEditor.vue";
 import YamlUtils from "../../../../src/utils/yamlUtils";
+import allowFailureDemo from "../../../fixtures/flowgraphs/allow-failure-demo.json";
 
 
 export default {
@@ -28,12 +29,17 @@ const Template = (args) => ({
     const store = useStore()
     store.$http = {
         get: async (uri) => {
+            console.log("get request", uri)
             if(uri.endsWith("/plugins")) {
                 return {data: []}
             }
             return {data: {}}
         },
-        post: async () => {
+        post: async (uri) => {
+            console.log("post request", uri)
+            if(uri.endsWith("/graph")) {
+                return {data: allowFailureDemo}
+            }
             return {data: {}}
         }
     }
@@ -48,7 +54,10 @@ const Template = (args) => ({
         persistent:true,
     })
 
-    return () => <FlowEditor />;
+    return () =>
+        <div style="height: 100vh">
+            <FlowEditor />
+        </div>
   }
 });
 

--- a/ui/tests/storybook/components/flows/FlowEditor.stories.jsx
+++ b/ui/tests/storybook/components/flows/FlowEditor.stories.jsx
@@ -1,0 +1,122 @@
+import {useStore} from "vuex";
+import {vueRouter} from "storybook-vue3-router";
+import FlowEditor from "../../../../src/components/flows/FlowEditor.vue";
+import YamlUtils from "../../../../src/utils/yamlUtils";
+
+
+export default {
+  title: "Components/FlowEditor",
+  component: FlowEditor,
+  decorators: [
+    vueRouter([
+        {
+            path: "/",
+            name: "home",
+            component: {template: "div>home</div>"}
+        },
+        {
+            path: "/flows/edit/:namespace/",
+            name: "flows/edit",
+            component: {template: "<div>updateflows</div>"}
+        }
+    ])
+  ]
+};
+
+const Template = (args) => ({
+  setup() {
+    const store = useStore()
+    store.$http = {
+        get: async (uri) => {
+            if(uri.endsWith("/plugins")) {
+                return {data: []}
+            }
+            return {data: {}}
+        },
+        post: async () => {
+            return {data: {}}
+        }
+    }
+    const flow = YamlUtils.parse(args.flow)
+    flow.source = args.flow
+    store.commit("flow/setFlow", flow)
+    store.commit("editor/changeOpenedTabs", {
+        action:"open",
+        flow:true,
+        name:"Flow",
+        path :"Flow.yaml",
+        persistent:true,
+    })
+
+    return () => <FlowEditor />;
+  }
+});
+
+export const Default = Template.bind({});
+Default.args = {
+  flow: `
+id: allow-failure-demo
+namespace: sanitychecks.flows.blueprints
+tasks:
+  - id: allow_failure
+    type: io.kestra.plugin.core.flow.AllowFailure
+    tasks:
+      - id: fail_silently
+        type: io.kestra.plugin.scripts.shell.Commands
+        taskRunner:
+          type: io.kestra.plugin.core.runner.Process
+        commands:
+          - exit 1
+  - id: print_to_console
+    type: io.kestra.plugin.scripts.shell.Commands
+    taskRunner:
+      type: io.kestra.plugin.core.runner.Process
+    commands:
+      - echo "this will run since previous failure was allowed ✅"
+`.trim(),
+};
+
+export const EmptyFlow = Template.bind({});
+EmptyFlow.args = {
+  flow: `
+id: empty
+namespace: sanitychecks.flows.blueprints
+`.trim(),
+};
+
+export const ComplexFlow = Template.bind({});
+ComplexFlow.args = {
+  flow: `
+id: hello-world
+namespace: tutorial
+description: Hello World
+
+inputs:
+  - id: user
+    type: STRING
+    defaults: Rick Astley
+
+tasks:
+  - id: first_task
+    type: io.kestra.plugin.core.debug.Return
+    format: thrilled
+
+  - id: second_task
+    type: io.kestra.plugin.scripts.shell.Commands
+    commands:
+      - sleep 0.42
+      - echo '::{"outputs":{"returned_data":"mydata"}}::'
+
+  - id: hello_world
+    type: io.kestra.plugin.core.log.Log
+    message: |
+      Welcome to Kestra, {{ inputs.user }}!
+      We are {{ outputs.first_task.value}} to have You here!
+
+triggers:
+  - id: daily
+    type: io.kestra.plugin.core.trigger.Schedule
+    disabled: true
+    cron: 0 9 * * *
+`.trim(),
+};

--- a/ui/tests/storybook/components/inputs/InputsForm.stories.jsx
+++ b/ui/tests/storybook/components/inputs/InputsForm.stories.jsx
@@ -41,7 +41,7 @@ export const InputTypes = {
             // eslint-disable-next-line @typescript-eslint/no-unused-expressions
             expect(editor).to.exist;
             return editor;
-        }, {timeout: 500, interval: 100});
+        }, {timeout: 2000, interval: 100});
         // wait for the setup to finish
         await waitFor(() => expect(typeof MonacoEditor.__setValueInTests).toBe("function"));
         MonacoEditor.__setValueInTests("foo@example.com")


### PR DESCRIPTION
### Bug desciption

[BugFlowEditor.webm](https://github.com/user-attachments/assets/3bde4599-2df3-4f2a-9dc9-fb29f22f4fac)

### Changes

- When switching file tabs, signal the `EditorView.vue` that the value in monaco has changed so flowYaml get updated.
- On that update, avoid updating `dirty` or `haveChanged` since we have to consider it a new editor
- Since the flowYaml value is the engine of both the save and the lowcode flow, only update it on timeout `onEdit`
- Base activation of save button on the dirty flag for non-flow tabs