### PR TITLE
chore(ui): properly sanitize markdown content before rendering

### DIFF
--- a/ui/src/components/ErrorToastContainer.vue
+++ b/ui/src/components/ErrorToastContainer.vue
@@ -49,7 +49,7 @@
         components: {Slack},
         methods: {
             async renderMarkdown() {
-                return await Markdown.render(this.message.message || this.message.content.message);
+                return await Markdown.render(this.message.message || this.message.content.message, {html: true});
             },
         },
     };

--- a/ui/src/components/dashboard/Dashboard.vue
+++ b/ui/src/components/dashboard/Dashboard.vue
@@ -158,12 +158,13 @@
                 >
                     <Markdown
                         :source="description"
+                        :html="false"
                         class="p-4 description"
                     />
                 </el-dialog>
             </span>
 
-            <Markdown :source="description" class="p-4 description" />
+            <Markdown :source="description" :html="false" class="p-4 description" />
         </div>
         <ExecutionsInProgress
             v-else

--- a/ui/src/components/layout/Markdown.vue
+++ b/ui/src/components/layout/Markdown.vue
@@ -20,6 +20,10 @@
             fontSizeVar: {
                 type: String,
                 default: "font-size-sm"
+            },
+            html: {
+                type: Boolean,
+                default: true
             }
         },
         data() {
@@ -39,6 +43,7 @@
             async renderMarkdown() {
                 return await Markdown.render(this.sourceWithReplacedAlerts, {
                     permalink: this.permalink,
+                    html: this.html
                 });
             },
         },

--- a/ui/src/components/logs/LogLine.vue
+++ b/ui/src/components/logs/LogLine.vue
@@ -85,7 +85,7 @@
             };
         },
         async created() {
-            this.renderedMarkdown = await Markdown.render(this.message, {onlyLink: true});
+            this.renderedMarkdown = await Markdown.render(this.message, {onlyLink: true, html: true});
         },
         computed: {
             logLineStyle() {

--- a/ui/src/utils/markdown.js
+++ b/ui/src/utils/markdown.js
@@ -37,7 +37,7 @@ export async function render(markdown, options = {}) {
         .use(linkTag);
 
     md.set({
-        html: false,
+        html: options.html,
         xhtmlOut: true,
         breaks: true,
         linkify: true,


### PR DESCRIPTION
https://kestra-io.slack.com/archives/C052XEFFC90/p1741266643612739?thread_ts=1741265258.776069&cid=C052XEFFC90

> for posterity: Milos will make a change so that:
the UI issues I reported in the original post will be solved
the security issue of flow description will be solved
the raw markdown in flow description will still render fine, just <html> tags in that flow description won't be rendered, but that's fine :+1:

Relates to https://github.com/kestra-io/kestra-ee/issues/2973.