### PR TITLE
Adjusted the CI to skip frontend and backend tests for commits/PRs containing the 'docs-only' text. #6729

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -32,7 +32,7 @@ jobs:
   frontend:
     name: Frontend - Tests
     needs: [file-changes]
-    if: "needs.file-changes.outputs.ui == 'true'"
+    if: "needs.file-changes.outputs.ui == 'true' && !contains(github.event.title, 'docs-only') && !contains(github.event.body, 'docs-only') && !contains(github.event.labels.*.name, 'docs-only')"
     uses: ./.github/workflows/workflow-frontend-test.yml
     secrets:
       GITHUB_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -41,7 +41,7 @@ jobs:
   backend:
     name: Backend - Tests
     needs: file-changes
-    if: "needs.file-changes.outputs.backend == 'true'"
+    if: "needs.file-changes.outputs.backend == 'true' && !contains(github.event.title, 'docs-only') && !contains(github.event.body, 'docs-only') && !contains(github.event.labels.*.name, 'docs-only')"
     uses: ./.github/workflows/workflow-backend-test.yml
     secrets:
       GITHUB_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -32,7 +32,7 @@ jobs:
   frontend:
     name: Frontend - Tests
     needs: [file-changes]
-    if: "needs.file-changes.outputs.ui == 'true' && !contains(github.event.title, 'docs-only') && !contains(github.event.body, 'docs-only') && !contains(github.event.labels.*.name, 'docs-only')"
+    if: "needs.file-changes.outputs.ui == 'true' && !contains(github.event.title, 'docs-only')"
     uses: ./.github/workflows/workflow-frontend-test.yml
     secrets:
       GITHUB_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -41,7 +41,7 @@ jobs:
   backend:
     name: Backend - Tests
     needs: file-changes
-    if: "needs.file-changes.outputs.backend == 'true' && !contains(github.event.title, 'docs-only') && !contains(github.event.body, 'docs-only') && !contains(github.event.labels.*.name, 'docs-only')"
+    if: "needs.file-changes.outputs.backend == 'true' && !contains(github.event.title, 'docs-only')"
     uses: ./.github/workflows/workflow-backend-test.yml
     secrets:
       GITHUB_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/workflow-test.yml
+++ b/.github/workflows/workflow-test.yml
@@ -43,7 +43,7 @@ jobs:
   frontend:
     name: Frontend - Tests
     needs: file-changes
-    if: "needs.file-changes.outputs.ui == 'true' || startsWith(github.ref, 'refs/tags/v')"
+    if: "(needs.file-changes.outputs.ui == 'true' || startsWith(github.ref, 'refs/tags/v')) && !contains(github.event.head_commit.message, 'docs-only')"
     uses: ./.github/workflows/workflow-frontend-test.yml
     secrets:
       GITHUB_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -53,7 +53,7 @@ jobs:
   backend:
     name: Backend - Tests
     needs: file-changes
-    if: "needs.file-changes.outputs.backend == 'true' || startsWith(github.ref, 'refs/tags/v')"
+    if: "(needs.file-changes.outputs.backend == 'true' || startsWith(github.ref, 'refs/tags/v')) && !contains(github.event.head_commit.message, 'docs-only')"
     uses: ./.github/workflows/workflow-backend-test.yml
     secrets:
       GITHUB_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Changes made:

workflow-test.yml:
Extended the if condition to ensure that the frontend and backend jobs will only run if the most recent commit message does not contain the text 'docs-only' when a push is made.

pull-request.yml:
Updated the if condition to ensure that the frontend and backend jobs will only run if the PR title, body, and labels do not contain 'docs-only'.

I would really appreciate any feedback or suggestions.

Closes https://github.com/kestra-io/kestra/issues/6729.