### PR TITLE
fix(cli): fix double shutdown warn messages

### DIFF
--- a/cli/src/main/java/io/kestra/cli/AbstractCommand.java
+++ b/cli/src/main/java/io/kestra/cli/AbstractCommand.java
@@ -230,10 +230,12 @@ abstract public class AbstractCommand implements Callable<Integer> {
         return false;
     }
 
-    protected void shutdownHook(Rethrow.RunnableChecked<Exception> run) {
+    protected void shutdownHook(boolean logShutdown, Rethrow.RunnableChecked<Exception> run) {
         Runtime.getRuntime().addShutdownHook(new Thread(
             () -> {
-                log.warn("Receiving shutdown ! Try to graceful exit");
+                if (logShutdown) {
+                    log.warn("Receiving shutdown ! Try to graceful exit");
+                }
                 try {
                     run.run();
                 } catch (Exception e) {

--- a/cli/src/main/java/io/kestra/cli/commands/servers/AbstractServerCommand.java
+++ b/cli/src/main/java/io/kestra/cli/commands/servers/AbstractServerCommand.java
@@ -1,11 +1,19 @@
 package io.kestra.cli.commands.servers;
 
 import io.kestra.cli.AbstractCommand;
+import io.kestra.core.contexts.KestraContext;
+import jakarta.annotation.PostConstruct;
 import picocli.CommandLine;
 
 abstract public class AbstractServerCommand extends AbstractCommand implements ServerCommandInterface {
     @CommandLine.Option(names = {"--port"}, description = "The port to bind")
     Integer serverPort;
+
+    @Override
+    public Integer call()  throws Exception {
+        this.shutdownHook(true, () -> KestraContext.getContext().shutdown());
+        return super.call();
+    }
 
     protected static int defaultWorkerThread() {
         return Runtime.getRuntime().availableProcessors() * 4;

--- a/cli/src/main/java/io/kestra/cli/commands/servers/ExecutorCommand.java
+++ b/cli/src/main/java/io/kestra/cli/commands/servers/ExecutorCommand.java
@@ -1,7 +1,6 @@
 package io.kestra.cli.commands.servers;
 
 import com.google.common.collect.ImmutableMap;
-import io.kestra.core.contexts.KestraContext;
 import io.kestra.core.models.ServerType;
 import io.kestra.core.runners.ExecutorInterface;
 import io.kestra.core.services.SkipExecutionService;
@@ -66,7 +65,6 @@ public class ExecutorCommand extends AbstractServerCommand {
         this.startExecutorService.applyOptions(startExecutors, notStartExecutors);
 
         super.call();
-        this.shutdownHook(() -> KestraContext.getContext().shutdown());
 
         ExecutorInterface executorService = applicationContext.getBean(ExecutorInterface.class);
         executorService.run();

--- a/cli/src/main/java/io/kestra/cli/commands/servers/IndexerCommand.java
+++ b/cli/src/main/java/io/kestra/cli/commands/servers/IndexerCommand.java
@@ -31,13 +31,11 @@ public class IndexerCommand extends AbstractServerCommand {
     @Override
     public Integer call() throws Exception {
         super.call();
-        this.shutdownHook(() -> KestraContext.getContext().shutdown());
 
         IndexerInterface indexer = applicationContext.getBean(IndexerInterface.class);
         indexer.run();
 
         log.info("Indexer started");
-
         Await.until(() -> !this.applicationContext.isRunning());
 
         return 0;

--- a/cli/src/main/java/io/kestra/cli/commands/servers/SchedulerCommand.java
+++ b/cli/src/main/java/io/kestra/cli/commands/servers/SchedulerCommand.java
@@ -1,7 +1,6 @@
 package io.kestra.cli.commands.servers;
 
 import com.google.common.collect.ImmutableMap;
-import io.kestra.core.contexts.KestraContext;
 import io.kestra.core.models.ServerType;
 import io.kestra.core.schedulers.AbstractScheduler;
 import io.kestra.core.utils.Await;
@@ -31,7 +30,6 @@ public class SchedulerCommand extends AbstractServerCommand {
     @Override
     public Integer call() throws Exception {
         super.call();
-        this.shutdownHook(() -> KestraContext.getContext().shutdown());
 
         AbstractScheduler scheduler = applicationContext.getBean(AbstractScheduler.class);
         scheduler.run();

--- a/cli/src/main/java/io/kestra/cli/commands/servers/StandAloneCommand.java
+++ b/cli/src/main/java/io/kestra/cli/commands/servers/StandAloneCommand.java
@@ -2,7 +2,6 @@ package io.kestra.cli.commands.servers;
 
 import com.google.common.collect.ImmutableMap;
 import io.kestra.cli.services.FileChangedEventListener;
-import io.kestra.core.contexts.KestraContext;
 import io.kestra.core.models.ServerType;
 import io.kestra.core.repositories.LocalFlowRepositoryLoader;
 import io.kestra.core.runners.StandAloneRunner;
@@ -95,7 +94,6 @@ public class StandAloneCommand extends AbstractServerCommand {
         this.startExecutorService.applyOptions(startExecutors, notStartExecutors);
 
         super.call();
-        this.shutdownHook(() -> KestraContext.getContext().shutdown());
 
         if (flowPath != null) {
             try {
@@ -123,8 +121,6 @@ public class StandAloneCommand extends AbstractServerCommand {
         if (fileWatcher != null) {
             fileWatcher.startListeningFromConfig();
         }
-
-        this.shutdownHook(standAloneRunner::close);
 
         Await.until(() -> !this.applicationContext.isRunning());
 

--- a/cli/src/main/java/io/kestra/cli/commands/servers/WebServerCommand.java
+++ b/cli/src/main/java/io/kestra/cli/commands/servers/WebServerCommand.java
@@ -1,9 +1,7 @@
 package io.kestra.cli.commands.servers;
 
 import com.google.common.collect.ImmutableMap;
-import io.kestra.core.contexts.KestraContext;
 import io.kestra.core.models.ServerType;
-import io.kestra.core.runners.ExecutorInterface;
 import io.kestra.core.runners.IndexerInterface;
 import io.kestra.core.utils.Await;
 import io.kestra.core.utils.ExecutorsUtils;
@@ -57,20 +55,11 @@ public class WebServerCommand extends AbstractServerCommand {
             log.info("Starting an embedded indexer, this can be disabled by using `--no-indexer`.");
             poolExecutor = executorsUtils.cachedThreadPool("webserver-indexer");
             poolExecutor.execute(applicationContext.getBean(IndexerInterface.class));
+            shutdownHook(false, () -> poolExecutor.shutdown());
         }
 
         log.info("Webserver started");
-        this.shutdownHook(() -> {
-            this.close();
-            KestraContext.getContext().shutdown();
-        });
         Await.until(() -> !this.applicationContext.isRunning());
         return 0;
-    }
-
-    private void close() {
-        if (this.poolExecutor != null) {
-            this.poolExecutor.shutdown();
-        }
     }
 }

--- a/cli/src/main/java/io/kestra/cli/commands/servers/WorkerCommand.java
+++ b/cli/src/main/java/io/kestra/cli/commands/servers/WorkerCommand.java
@@ -40,7 +40,6 @@ public class WorkerCommand extends AbstractServerCommand {
     @Override
     public Integer call() throws Exception {
         super.call();
-        this.shutdownHook(() -> KestraContext.getContext().shutdown());
         if (this.workerGroupKey != null && !this.workerGroupKey.matches("[a-zA-Z0-9_-]+")) {
             throw new IllegalArgumentException("The --worker-group option must match the [a-zA-Z0-9_-]+ pattern");
         }

--- a/core/src/main/java/io/kestra/core/runners/StandAloneRunner.java
+++ b/core/src/main/java/io/kestra/core/runners/StandAloneRunner.java
@@ -7,6 +7,7 @@ import io.kestra.core.utils.ExecutorsUtils;
 import io.micronaut.context.ApplicationContext;
 import io.micronaut.context.annotation.Requires;
 import io.micronaut.context.annotation.Value;
+import jakarta.annotation.PreDestroy;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 import lombok.Setter;
@@ -86,6 +87,7 @@ public class StandAloneRunner implements RunnerInterface, AutoCloseable {
         return this.running;
     }
 
+    @PreDestroy
     @Override
     public void close() throws Exception {
         this.poolExecutor.shutdown();


### PR DESCRIPTION
Changes:
- Avoid registering two shutdown-hooks that will both log the shutdown message - leading to some confusion
- Some code cleanup/refactoring