### PR TITLE
feat(core): custom log filter

### DIFF
--- a/core/src/main/java/io/kestra/core/log/KestraLogFilter.java
+++ b/core/src/main/java/io/kestra/core/log/KestraLogFilter.java
@@ -1,0 +1,17 @@
+package io.kestra.core.log;
+
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.boolex.EvaluationException;
+import ch.qos.logback.core.boolex.EventEvaluatorBase;
+
+public class KestraLogFilter extends EventEvaluatorBase<ILoggingEvent> {
+    @Override
+    public boolean evaluate(ILoggingEvent event) throws NullPointerException, EvaluationException {
+        var message = event.getMessage();
+        // as this filter is called very often, for perf,
+        // we use startWith and do all checks successfully instead of using a more elegant construct like Stream...
+        return message.startsWith("outOfOrder mode is active. Migration of schema") ||
+            message.startsWith("Version mismatch         : Database version is older than what dialect POSTGRES supports") ||
+            message.startsWith("Failed to bind as java.util.concurrent.Executors$AutoShutdownDelegatedExecutorService is unsupported.");
+    }
+}

--- a/core/src/main/resources/logback/ecs.xml
+++ b/core/src/main/resources/logback/ecs.xml
@@ -21,13 +21,7 @@
             <level>WARN</level>
         </filter>
         <filter class="ch.qos.logback.core.filter.EvaluatorFilter">
-            <evaluator>
-                <expression>
-                    return message.contains("outOfOrder mode is active. Migration of schema") ||
-                    message.contains("Database version is older than what dialect POSTGRES supports") ||
-                    message.contains("Failed to bind as java.util.concurrent.Executors$AutoShutdownDelegatedExecutorService is unsupported.");
-                </expression>
-            </evaluator>
+            <evaluator class="io.kestra.core.log.KestraLogFilter" />
             <OnMismatch>NEUTRAL</OnMismatch>
             <OnMatch>DENY</OnMatch>
         </filter>

--- a/core/src/main/resources/logback/gcp.xml
+++ b/core/src/main/resources/logback/gcp.xml
@@ -24,13 +24,7 @@
             <level>WARN</level>
         </filter>
         <filter class="ch.qos.logback.core.filter.EvaluatorFilter">
-            <evaluator>
-                <expression>
-                    return message.contains("outOfOrder mode is active. Migration of schema") ||
-                    message.contains("Database version is older than what dialect POSTGRES supports") ||
-                    message.contains("Failed to bind as java.util.concurrent.Executors$AutoShutdownDelegatedExecutorService is unsupported.");
-                </expression>
-            </evaluator>
+            <evaluator class="io.kestra.core.log.KestraLogFilter" />
             <OnMismatch>NEUTRAL</OnMismatch>
             <OnMatch>DENY</OnMatch>
         </filter>

--- a/core/src/main/resources/logback/text.xml
+++ b/core/src/main/resources/logback/text.xml
@@ -23,19 +23,7 @@
             <level>WARN</level>
         </filter>
         <filter class="ch.qos.logback.core.filter.EvaluatorFilter">
-            <evaluator>
-                <!--
-                    - Disabling Liquibase outOfOrder warning
-                    - Disabling JooQ POSTGRES version support warning, see https://github.com/kestra-io/kestra/issues/3321#issuecomment-2017665833
-                    - Disabling Micronaut / Micrometer executor binding warning
-                    Warning: this needs to also be done on gcp.xml and ecs.xml
-                -->
-                <expression>
-                    return message.contains("outOfOrder mode is active. Migration of schema") ||
-                        message.contains("Database version is older than what dialect POSTGRES supports") ||
-                        message.contains("Failed to bind as java.util.concurrent.Executors$AutoShutdownDelegatedExecutorService is unsupported.");
-                </expression>
-            </evaluator>
+            <evaluator class="io.kestra.core.log.KestraLogFilter" />
             <OnMismatch>NEUTRAL</OnMismatch>
             <OnMatch>DENY</OnMatch>
         </filter>


### PR DESCRIPTION
Since Logback 1.5.13, there is no more default implementation for the EvaluatorFilter so we need to supply our own. See https://logback.qos.ch/manual/filters.html#evaluatorFilter