### PR TITLE
feat(cli,core): allow disabling logging to the server logs

### DIFF
--- a/cli/src/main/java/io/kestra/cli/AbstractCommand.java
+++ b/cli/src/main/java/io/kestra/cli/AbstractCommand.java
@@ -180,7 +180,6 @@ abstract public class AbstractCommand implements Callable<Integer> {
                         logger.getName().startsWith("io.kestra") &&
                             !logger.getName().startsWith("io.kestra.ee.runner.kafka.services"))
                 )
-                    || logger.getName().startsWith("flow")
             )
             .forEach(
                 logger -> logger.setLevel(ch.qos.logback.classic.Level.valueOf(this.logLevel.name()))

--- a/core/src/main/java/io/kestra/core/models/flows/Flow.java
+++ b/core/src/main/java/io/kestra/core/models/flows/Flow.java
@@ -38,8 +38,6 @@ import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotEmpty;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.util.*;
 import java.util.stream.Collectors;
@@ -136,11 +134,6 @@ public class Flow extends AbstractFlow implements HasUID {
     @Valid
     @PluginProperty(beta = true)
     List<SLA> sla;
-
-
-    public Logger logger() {
-        return LoggerFactory.getLogger("flow." + this.id);
-    }
 
 
     /** {@inheritDoc **/

--- a/core/src/main/java/io/kestra/core/runners/RunContextLogger.java
+++ b/core/src/main/java/io/kestra/core/runners/RunContextLogger.java
@@ -20,7 +20,6 @@ import io.kestra.core.queues.QueueInterface;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.slf4j.LoggerFactory;
-import org.slf4j.MDC;
 
 import java.io.*;
 import java.time.Instant;
@@ -33,11 +32,13 @@ public class RunContextLogger implements Supplier<org.slf4j.Logger> {
 
     private final String loggerName;
     private volatile Logger logger; // must be volatile as it is built lazily via DCL
+
     private QueueInterface<LogEntry> logQueue;
     private LogEntry logEntry;
     private Level loglevel;
     private final List<String> useSecrets = new ArrayList<>();
     private final boolean logToFile;
+
     @Getter
     private File logFile;
     private OutputStream logFileOS;
@@ -54,6 +55,7 @@ public class RunContextLogger implements Supplier<org.slf4j.Logger> {
         } else {
             this.loggerName = "flow." + logEntry.getFlowId() + "." + logEntry.getTriggerId();
         }
+
         this.logQueue = logQueue;
         this.logEntry = logEntry;
         this.loglevel = loglevel == null ? Level.TRACE : Level.toLevel(loglevel.toString());
@@ -349,10 +351,12 @@ public class RunContextLogger implements Supplier<org.slf4j.Logger> {
     }
 
     public static class ForwardAppender extends BaseAppender {
-        private static final ch.qos.logback.classic.Logger LOGGER = (ch.qos.logback.classic.Logger) LoggerFactory.getLogger("flow");
+        private final ch.qos.logback.classic.Logger fowardLogger;
 
         protected ForwardAppender(RunContextLogger runContextLogger, Logger logger) {
             super(runContextLogger, logger);
+
+            fowardLogger = (ch.qos.logback.classic.Logger) LoggerFactory.getLogger(runContextLogger.loggerName);
         }
 
         @Override
@@ -369,8 +373,8 @@ public class RunContextLogger implements Supplier<org.slf4j.Logger> {
         protected void append(ILoggingEvent e) {
             e = this.transform(e);
 
-            if (LOGGER.isEnabledFor(e.getLevel())) {
-                LOGGER.callAppenders(e);
+            if (fowardLogger.isEnabledFor(e.getLevel())) {
+                fowardLogger.callAppenders(e);
             }
         }
     }

--- a/core/src/main/java/io/kestra/core/runners/Worker.java
+++ b/core/src/main/java/io/kestra/core/runners/Worker.java
@@ -419,7 +419,6 @@ public class Worker implements Service, Runnable, AutoCloseable {
         if (log.isDebugEnabled()) {
             logService.logTrigger(
                 workerTrigger.getTriggerContext(),
-                log,
                 Level.DEBUG,
                 "[type: {}] {}",
                 workerTrigger.getTrigger().getType(),
@@ -627,7 +626,6 @@ public class Worker implements Service, Runnable, AutoCloseable {
 
         logService.logTaskRun(
             workerTask.getTaskRun(),
-            workerTask.logger(),
             Level.INFO,
             "Type {} started",
             workerTask.getTask().getClass().getSimpleName()
@@ -724,7 +722,6 @@ public class Worker implements Service, Runnable, AutoCloseable {
 
         logService.logTaskRun(
             workerTask.getTaskRun(),
-            workerTask.logger(),
             Level.INFO,
             "Type {} with state {} completed in {}",
             workerTask.getTask().getClass().getSimpleName(),

--- a/core/src/main/java/io/kestra/core/runners/WorkerTask.java
+++ b/core/src/main/java/io/kestra/core/runners/WorkerTask.java
@@ -7,8 +7,6 @@ import io.kestra.core.models.tasks.Task;
 import lombok.Builder;
 import lombok.Data;
 import lombok.With;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import jakarta.validation.constraints.NotNull;
 
@@ -30,13 +28,6 @@ public class WorkerTask extends WorkerJob {
 
     @NotNull
     private RunContext runContext;
-
-    public Logger logger() {
-        return LoggerFactory.getLogger(
-            "flow." + this.getTaskRun().getFlowId() + "." +
-                this.getTask().getId()
-        );
-    }
 
     /**
      * {@inheritDoc}

--- a/core/src/main/java/io/kestra/core/schedulers/AbstractScheduler.java
+++ b/core/src/main/java/io/kestra/core/schedulers/AbstractScheduler.java
@@ -731,7 +731,6 @@ public abstract class AbstractScheduler implements Scheduler, Service {
             if (lastTrigger.getUpdatedDate() == null || lastTrigger.getUpdatedDate().plusSeconds(60).isBefore(Instant.now())) {
                 logService.logTrigger(
                     f.getTriggerContext(),
-                    log,
                     Level.WARN,
                     "Execution '{}' is not found, schedule is blocked since '{}'",
                     lastTrigger.getExecutionId(),
@@ -751,7 +750,6 @@ public abstract class AbstractScheduler implements Scheduler, Service {
         if (log.isDebugEnabled()) {
             logService.logTrigger(
                 f.getTriggerContext(),
-                log,
                 Level.DEBUG,
                 "Execution '{}' is still '{}', updated at '{}'",
                 lastTrigger.getExecutionId(),
@@ -791,7 +789,6 @@ public abstract class AbstractScheduler implements Scheduler, Service {
 
         logService.logTrigger(
             executionWithTrigger.getTriggerContext(),
-            log,
             Level.INFO,
             "Scheduled execution {} at '{}' started at '{}'",
             executionWithTrigger.getExecution().getId(),
@@ -827,7 +824,6 @@ public abstract class AbstractScheduler implements Scheduler, Service {
             if (log.isDebugEnabled()) {
                 logService.logTrigger(
                     flowWithWorkerTrigger.getTriggerContext(),
-                    log,
                     Level.DEBUG,
                     "[type: {}] {}",
                     flowWithWorkerTrigger.getAbstractTrigger().getType(),
@@ -869,7 +865,7 @@ public abstract class AbstractScheduler implements Scheduler, Service {
         trigger, Throwable e) {
         Logger logger = conditionContext.getRunContext().logger();
 
-        logService.logFlow(
+        logService.logExecution(
             flow,
             logger,
             Level.ERROR,
@@ -890,7 +886,6 @@ public abstract class AbstractScheduler implements Scheduler, Service {
         if (log.isDebugEnabled()) {
             logService.logTrigger(
                 flowWithTrigger.getTriggerContext(),
-                log,
                 Level.DEBUG,
                 "[date: {}] Scheduling evaluation to the worker",
                 flowWithTrigger.getTriggerContext().getDate()

--- a/core/src/main/java/io/kestra/core/services/LogService.java
+++ b/core/src/main/java/io/kestra/core/services/LogService.java
@@ -13,6 +13,7 @@ import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 import org.apache.commons.lang3.ArrayUtils;
 import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.slf4j.event.Level;
 
 import java.time.ZonedDateTime;
@@ -36,15 +37,23 @@ public class LogService {
     private boolean tenantEnabled;
 
     @Inject
-    LogRepositoryInterface logRepository;
+    private LogRepositoryInterface logRepository;
 
-    public void logFlow(Flow flow, Logger logger, Level level, String message, Object... args) {
+    public void logExecution(Flow flow, Logger logger, Level level, String message, Object... args) {
         String finalMsg = tenantEnabled ? FLOW_PREFIX_WITH_TENANT + message : FLOW_PREFIX_NO_TENANT + message;
         Object[] executionArgs = tenantEnabled ?
             new Object[] { flow.getTenantId(), flow.getNamespace(), flow.getId() } :
             new Object[] { flow.getNamespace(), flow.getId() };
         Object[] finalArgs = ArrayUtils.addAll(executionArgs, args);
         logger.atLevel(level).log(finalMsg, finalArgs);
+    }
+
+    /**
+     * Log an execution via the execution logger named: 'execution.{flowId}'.
+     */
+    public void logExecution(Execution execution, Level level, String message, Object... args) {
+        Logger logger = logger(execution);
+        logExecution(execution, logger, level, message, args);
     }
 
     public void logExecution(Execution execution, Logger logger, Level level, String message, Object... args) {
@@ -56,6 +65,14 @@ public class LogService {
         logger.atLevel(level).log(finalMsg, finalArgs);
     }
 
+    /**
+     * Log a trigger via the trigger logger named: 'trigger.{flowId}.{triggereId}'.
+     */
+    public void logTrigger(TriggerContext triggerContext, Level level, String message, Object... args) {
+        Logger logger = logger(triggerContext);
+        logTrigger(triggerContext, logger, level, message, args);
+    }
+
     public void logTrigger(TriggerContext triggerContext, Logger logger, Level level, String message, Object... args) {
         String finalMsg = tenantEnabled ? TRIGGER_PREFIX_WITH_TENANT + message : TRIGGER_PREFIX_NO_TENANT + message;
         Object[] executionArgs = tenantEnabled ?
@@ -65,7 +82,10 @@ public class LogService {
         logger.atLevel(level).log(finalMsg, finalArgs);
     }
 
-    public void logTaskRun(TaskRun taskRun, Logger logger, Level level, String message, Object... args) {
+    /**
+     * Log a taskRun via the taskRun logger named: 'task.{flowId}.{taskId}'.
+     */
+    public void logTaskRun(TaskRun taskRun, Level level, String message, Object... args) {
         String prefix = tenantEnabled ? TASKRUN_PREFIX_WITH_TENANT : TASKRUN_PREFIX_NO_TENANT;
         String finalMsg = taskRun.getValue() == null ? prefix + message : prefix + "[value: {}] " + message;
         Object[] executionArgs = tenantEnabled ?
@@ -75,6 +95,7 @@ public class LogService {
             executionArgs = ArrayUtils.add(executionArgs, taskRun.getValue());
         }
         Object[] finalArgs = ArrayUtils.addAll(executionArgs, args);
+        Logger logger = logger(taskRun);
         logger.atLevel(level).log(finalMsg, finalArgs);
     }
 
@@ -88,5 +109,23 @@ public class LogService {
      */
     public List<LogEntry> errorLogs(String tenantId, String executionId) {
         return logRepository.findByExecutionId(tenantId, executionId, Level.ERROR, Pageable.from(1, 25, Sort.of(Sort.Order.asc("timestamp"))));
+    }
+
+    private Logger logger(TaskRun taskRun) {
+        return LoggerFactory.getLogger(
+            "task." + taskRun.getFlowId() + "." + taskRun.getTaskId()
+        );
+    }
+
+    private Logger logger(TriggerContext triggerContext) {
+        return LoggerFactory.getLogger(
+            "trigger." + triggerContext.getFlowId() + "." + triggerContext.getTriggerId()
+        );
+    }
+
+    private Logger logger(Execution execution) {
+        return LoggerFactory.getLogger(
+            "execution." + execution.getFlowId()
+        );
     }
 }

--- a/core/src/main/resources/logback/base.xml
+++ b/core/src/main/resources/logback/base.xml
@@ -10,6 +10,9 @@
 
     <logger name="io.kestra" level="INFO" />
     <logger name="flow" level="INFO" />
+    <logger name="task" level="INFO" />
+    <logger name="execution" level="INFO" />
+    <logger name="trigger" level="INFO" />
 
     <logger name="io.kestra.ee.runner.kafka.services.KafkaConsumerService" level="WARN" />
     <logger name="io.kestra.ee.runner.kafka.services.KafkaProducerService" level="WARN" />

--- a/core/src/test/java/io/kestra/core/services/LogServiceTest.java
+++ b/core/src/test/java/io/kestra/core/services/LogServiceTest.java
@@ -19,9 +19,9 @@ class LogServiceTest {
     @Test
     void logFlow() {
         var flow = Flow.builder().namespace("namespace").id("flow").build();
-        logService.logFlow(flow, log, Level.INFO, "Some log");
-        logService.logFlow(flow, log, Level.INFO, "Some log with an {}", "attribute");
-        logService.logFlow(flow, log, Level.ERROR, "Some log with an {} and an error", "attribute", new RuntimeException("Test Exception"));
+        logService.logExecution(flow, log, Level.INFO, "Some log");
+        logService.logExecution(flow, log, Level.INFO, "Some log with an {}", "attribute");
+        logService.logExecution(flow, log, Level.ERROR, "Some log with an {} and an error", "attribute", new RuntimeException("Test Exception"));
     }
 
     @Test
@@ -29,6 +29,7 @@ class LogServiceTest {
         var execution = Execution.builder().namespace("namespace").flowId("flow").id("execution").build();
         logService.logExecution(execution, log, Level.INFO, "Some log");
         logService.logExecution(execution, log, Level.INFO, "Some log with an {}", "attribute");
+        logService.logExecution(execution, Level.INFO, "Some log");
     }
 
     @Test
@@ -36,16 +37,17 @@ class LogServiceTest {
         var trigger = TriggerContext.builder().namespace("namespace").flowId("flow").triggerId("trigger").build();
         logService.logTrigger(trigger, log, Level.INFO, "Some log");
         logService.logTrigger(trigger, log, Level.INFO, "Some log with an {}", "attribute");
+        logService.logTrigger(trigger, Level.INFO, "Some log");
     }
 
     @Test
     void logTaskRun() {
         var taskRun = TaskRun.builder().namespace("namespace").flowId("flow").executionId("execution").taskId("task").id("taskRun").build();
-        logService.logTaskRun(taskRun, log, Level.INFO, "Some log");
-        logService.logTaskRun(taskRun, log, Level.INFO, "Some log with an {}", "attribute");
+        logService.logTaskRun(taskRun, Level.INFO, "Some log");
+        logService.logTaskRun(taskRun, Level.INFO, "Some log with an {}", "attribute");
 
         taskRun = TaskRun.builder().namespace("namespace").flowId("flow").executionId("execution").taskId("task").id("taskRun").value("value").build();
-        logService.logTaskRun(taskRun, log, Level.INFO, "Some log");
-        logService.logTaskRun(taskRun, log, Level.INFO, "Some log with an {}", "attribute");
+        logService.logTaskRun(taskRun, Level.INFO, "Some log");
+        logService.logTaskRun(taskRun, Level.INFO, "Some log with an {}", "attribute");
     }
 }

--- a/jdbc/src/main/java/io/kestra/jdbc/runner/JdbcExecutor.java
+++ b/jdbc/src/main/java/io/kestra/jdbc/runner/JdbcExecutor.java
@@ -384,14 +384,12 @@ public class JdbcExecutor implements ExecutorInterface, Service {
                             );
                             logService.logTaskRun(
                                 workerTaskRunning.getTaskRun(),
-                                log,
                                 Level.WARN,
                                 "Re-emitting WorkerTask."
                             );
                         } catch (QueueException e) {
                             logService.logTaskRun(
                                 workerTaskRunning.getTaskRun(),
-                                log,
                                 Level.ERROR,
                                 "Unable to re-emit WorkerTask.",
                                 e
@@ -410,14 +408,12 @@ public class JdbcExecutor implements ExecutorInterface, Service {
                             .build());
                         logService.logTrigger(
                             workerTriggerRunning.getTriggerContext(),
-                            log,
                             Level.WARN,
                             "Re-emitting WorkerTrigger."
                         );
                     } catch (QueueException e) {
                         logService.logTrigger(
                             workerTriggerRunning.getTriggerContext(),
-                            log,
                             Level.ERROR,
                             "Unable to re-emit WorkerTrigger.",
                             e
@@ -524,7 +520,7 @@ public class JdbcExecutor implements ExecutorInterface, Service {
 
                         if (!executor.getNexts().isEmpty() && deduplicateNexts(execution, executorState, executor.getNexts())) {
                             executor.withExecution(
-                                executorService.onNexts(executor.getFlow(), executor.getExecution(), executor.getNexts()),
+                                executorService.onNexts(executor.getExecution(), executor.getNexts()),
                                 "onNexts"
                             );
                         }


### PR DESCRIPTION
```yaml
logger:
  levels:
    flow: 'OFF'
```

Will disable all flow execution logs to go to the server logs

```yaml
logger:
  levels:
    flow.hello-world: 'OFF'
```

Will disable execution logs for the `hello-world` flow to go to the server logs

Fixes #7753

It also introduces 3 new loggers that could then be disabled separately: execution, task and trigger which will be used to log executions, tasks and triggers start and end into the server log. They previously use the flow logger or the caller logger.

Those logs will now be shown as
```
2025-03-18 12:24:28,490 INFO  jdbc-queue-Execution_7 execution.hello-world [namespace: company.team] [flow: hello-world] [execution: 63b1IXxAirxJxjCRwJvaDP] Flow started
2025-03-18 12:24:29,468 INFO  worker_0     task.hello-world.hello [namespace: company.team] [flow: hello-world] [task: hello] [execution: 63b1IXxAirxJxjCRwJvaDP] [taskrun: dkkf9mQOrnT00rYF96JEy] Type Log started
2025-03-18 12:24:29,512 INFO  worker_0     f.h.6.dkkf9mQOrnT00rYF96JEy Hello World! 🚀
2025-03-18 12:24:29,520 INFO  worker_0     task.hello-world.hello [namespace: company.team] [flow: hello-world] [task: hello] [execution: 63b1IXxAirxJxjCRwJvaDP] [taskrun: dkkf9mQOrnT00rYF96JEy] Type Log with state SUCCESS completed in 00:00:01.039
2025-03-18 12:24:30,578 INFO  jdbc-queue-Execution_7 execution.hello-world [namespace: company.team] [flow: hello-world] [execution: 63b1IXxAirxJxjCRwJvaDP] Flow completed with state SUCCESS in 00:00:02.439
```