### PR TITLE
Revert "Adjusted the CI to skip frontend and backend tests for commits/PRs containing the 'docs-only' text. #6729"

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -32,7 +32,7 @@ jobs:
   frontend:
     name: Frontend - Tests
     needs: [file-changes]
-    if: "needs.file-changes.outputs.ui == 'true' && !contains(github.event.title, 'docs-only')"
+    if: "needs.file-changes.outputs.ui == 'true'"
     uses: ./.github/workflows/workflow-frontend-test.yml
     secrets:
       GITHUB_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -41,7 +41,7 @@ jobs:
   backend:
     name: Backend - Tests
     needs: file-changes
-    if: "needs.file-changes.outputs.backend == 'true' && !contains(github.event.title, 'docs-only')"
+    if: "needs.file-changes.outputs.backend == 'true'"
     uses: ./.github/workflows/workflow-backend-test.yml
     secrets:
       GITHUB_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/workflow-test.yml
+++ b/.github/workflows/workflow-test.yml
@@ -43,7 +43,7 @@ jobs:
   frontend:
     name: Frontend - Tests
     needs: file-changes
-    if: "(needs.file-changes.outputs.ui == 'true' || startsWith(github.ref, 'refs/tags/v')) && !contains(github.event.head_commit.message, 'docs-only')"
+    if: "needs.file-changes.outputs.ui == 'true' || startsWith(github.ref, 'refs/tags/v')"
     uses: ./.github/workflows/workflow-frontend-test.yml
     secrets:
       GITHUB_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -53,7 +53,7 @@ jobs:
   backend:
     name: Backend - Tests
     needs: file-changes
-    if: "(needs.file-changes.outputs.backend == 'true' || startsWith(github.ref, 'refs/tags/v')) && !contains(github.event.head_commit.message, 'docs-only')"
+    if: "needs.file-changes.outputs.backend == 'true' || startsWith(github.ref, 'refs/tags/v')"
     uses: ./.github/workflows/workflow-backend-test.yml
     secrets:
       GITHUB_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Reverts kestra-io/kestra#7756 because we will follow this convention instead https://docs.github.com/en/actions/managing-workflow-runs-and-deployments/managing-workflow-runs/skipping-workflow-runs 