### PR TITLE
fix(cli): return exit 0 in CLI plugins cmd

### DIFF
--- a/cli/src/main/java/io/kestra/cli/commands/plugins/PluginInstallCommand.java
+++ b/cli/src/main/java/io/kestra/cli/commands/plugins/PluginInstallCommand.java
@@ -91,7 +91,7 @@ public class PluginInstallCommand extends AbstractCommand {
 
         if (dependencies.isEmpty()) {
             stdErr("Error: No plugin to install.");
-            return CommandLine.ExitCode.SOFTWARE;
+            return CommandLine.ExitCode.OK;
         }
 
         final List<PluginArtifact> pluginArtifacts;


### PR DESCRIPTION
The CLI plugins install command must return exit code 0 even when no plugin are installed