### PR TITLE
fix: only run posthog in prod mode

### DIFF
--- a/ui/src/App.vue
+++ b/ui/src/App.vue
@@ -143,22 +143,26 @@
                     return;
                 }
 
-                posthog.init(
-                    apiConfig.posthog.token,
-                    {
-                        api_host: apiConfig.posthog.apiHost,
-                        ui_host: "https://eu.posthog.com",
-                        capture_pageview: false,
-                        capture_pageleave: true,
-                        autocapture: false,
+                // only run posthog in production
+                if (import.meta.env.MODE === "production") {
+                    posthog.init(
+                        apiConfig.posthog.token,
+                        {
+                            api_host: apiConfig.posthog.apiHost,
+                            ui_host: "https://eu.posthog.com",
+                            capture_pageview: false,
+                            capture_pageleave: true,
+                            autocapture: false,
+                        }
+                    )
+
+                    posthog.register_once(this.statsGlobalData(config, uid));
+
+                    if (!posthog.get_property("__alias")) {
+                        posthog.alias(apiConfig.id);
                     }
-                )
-
-                posthog.register_once(this.statsGlobalData(config, uid));
-
-                if (!posthog.get_property("__alias")) {
-                    posthog.alias(apiConfig.id);
                 }
+
 
                 // close survey on page change
                 let surveyVisible = false;


### PR DESCRIPTION
Posthog masks very useful errors coming from Vue in dev mode.

Since we only have a use for it in production. let's only run it in produciton.