### PR TITLE
feat(core): add new subkey arg to secret pebble function

### DIFF
--- a/core/src/main/java/io/kestra/core/runners/pebble/functions/SecretFunction.java
+++ b/core/src/main/java/io/kestra/core/runners/pebble/functions/SecretFunction.java
@@ -1,8 +1,13 @@
 package io.kestra.core.runners.pebble.functions;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.kestra.core.runners.RunVariables;
+import io.kestra.core.secret.SecretException;
 import io.kestra.core.secret.SecretNotFoundException;
 import io.kestra.core.secret.SecretService;
+import io.kestra.core.serializers.JacksonMapper;
 import io.kestra.core.services.FlowService;
 import io.pebbletemplates.pebble.error.PebbleException;
 import io.pebbletemplates.pebble.extension.Function;
@@ -20,6 +25,12 @@ import java.util.function.Consumer;
 @Slf4j
 @Singleton
 public class SecretFunction implements Function {
+
+    private static final ObjectMapper OBJECT_MAPPER = JacksonMapper.ofJson();
+    private static final String SUBKEY_ARG = "subkey";
+    private static final String NAMESPACE_ARG = "namespace";
+    private static final String KEY_ARG = "key";
+
     @Inject
     private SecretService secretService;
 
@@ -28,17 +39,17 @@ public class SecretFunction implements Function {
 
     @Override
     public List<String> getArgumentNames() {
-        return List.of("key", "namespace");
+        return List.of(KEY_ARG, NAMESPACE_ARG, SUBKEY_ARG);
     }
 
     @SuppressWarnings("unchecked")
     @Override
     public Object execute(Map<String, Object> args, PebbleTemplate self, EvaluationContext context, int lineNumber) {
         String key = getSecretKey(args, self, lineNumber);
-        String namespace = (String) args.get("namespace");
+        String namespace = (String) args.get(NAMESPACE_ARG);
 
         Map<String, String> flow = (Map<String, String>) context.getVariable("flow");
-        String flowNamespace = flow.get("namespace");
+        String flowNamespace = flow.get(NAMESPACE_ARG);
         String flowTenantId = flow.get("tenantId");
 
         if (namespace == null) {
@@ -50,6 +61,25 @@ public class SecretFunction implements Function {
         try {
             String secret = secretService.findSecret(flowTenantId, namespace, key);
 
+            final String subkey = (String) args.get(SUBKEY_ARG);
+            if (subkey != null && !subkey.isEmpty()) {
+                try {
+                    JsonNode subkeys = OBJECT_MAPPER.readTree(secret);
+                    if (!subkeys.has(subkey)) {
+                        throw new SecretNotFoundException("Cannot find secret sub-key '" + subkey + "' in secret '" + key + "'.");
+                    } else {
+                        JsonNode jsonNode = subkeys.get(subkey);
+                        secret = jsonNode.isValueNode() ? jsonNode.asText() : jsonNode.toString();
+                    }
+                } catch (JsonProcessingException e) {
+                    throw new SecretException(String.format(
+                        "Failed to read secret sub-key '%s' from secret '%s'. Ensure the secret contains valid JSON value.",
+                        subkey,
+                        key
+                    ));
+                }
+            }
+
             try {
                 Consumer<String> addSecretConsumer = (Consumer<String>) context.getVariable(RunVariables.SECRET_CONSUMER_VARIABLE_NAME);
                 addSecretConsumer.accept(secret);
@@ -58,16 +88,16 @@ public class SecretFunction implements Function {
             }
 
             return secret;
-        } catch (SecretNotFoundException | IOException e) {
+        } catch (SecretException | IOException e) {
             throw new PebbleException(e, e.getMessage(), lineNumber, self.getName());
         }
     }
 
     protected String getSecretKey(Map<String, Object> args, PebbleTemplate self, int lineNumber) {
-        if (!args.containsKey("key")) {
+        if (!args.containsKey(KEY_ARG)) {
             throw new PebbleException(null, "The 'secret' function expects an argument 'key'.", lineNumber, self.getName());
         }
 
-        return (String) args.get("key");
+        return (String) args.get(KEY_ARG);
     }
 }

--- a/core/src/main/java/io/kestra/core/secret/SecretException.java
+++ b/core/src/main/java/io/kestra/core/secret/SecretException.java
@@ -1,0 +1,18 @@
+package io.kestra.core.secret;
+
+import io.kestra.core.exceptions.KestraRuntimeException;
+
+import java.io.Serial;
+
+/**
+ * Top-level exception for Secrets.
+ */
+public class SecretException extends KestraRuntimeException {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
+
+    public SecretException(String message) {
+        super(message);
+    }
+}

--- a/core/src/main/java/io/kestra/core/secret/SecretNotFoundException.java
+++ b/core/src/main/java/io/kestra/core/secret/SecretNotFoundException.java
@@ -1,13 +1,11 @@
 package io.kestra.core.secret;
 
-import io.kestra.core.exceptions.KestraRuntimeException;
-
 import java.io.Serial;
 
 /**
  * Exception when a secret is not found.
  */
-public class SecretNotFoundException extends KestraRuntimeException {
+public class SecretNotFoundException extends SecretException {
 
     @Serial
     private static final long serialVersionUID = 1L;

--- a/core/src/test/java/io/kestra/core/secret/SecretFunctionTest.java
+++ b/core/src/test/java/io/kestra/core/secret/SecretFunctionTest.java
@@ -2,6 +2,7 @@ package io.kestra.core.secret;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 
+import io.kestra.core.exceptions.IllegalVariableEvaluationException;
 import io.kestra.core.junit.annotations.KestraTest;
 import io.kestra.core.junit.annotations.LoadFlows;
 import io.kestra.core.models.executions.Execution;
@@ -11,12 +12,20 @@ import io.kestra.core.queues.QueueException;
 import io.kestra.core.queues.QueueFactoryInterface;
 import io.kestra.core.queues.QueueInterface;
 import io.kestra.core.runners.RunnerUtils;
+import io.kestra.core.runners.VariableRenderer;
 import io.kestra.core.utils.TestsUtils;
+import io.micronaut.test.annotation.MockBean;
 import jakarta.inject.Inject;
 import jakarta.inject.Named;
+
+import java.io.IOException;
 import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.TimeoutException;
+
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 import reactor.core.publisher.Flux;
@@ -36,6 +45,9 @@ public class SecretFunctionTest {
 
     @Inject
     private SecretService secretService;
+
+    @Inject
+    VariableRenderer variableRenderer;
 
     @Test
     @LoadFlows({"flows/valids/secrets.yaml"})
@@ -57,9 +69,77 @@ public class SecretFunctionTest {
         assertThat(matchingLog.getMessage(), containsString("***"));
     }
 
+
+    @Test
+    void shouldGetSecretGivenExistingSubKey() throws IllegalVariableEvaluationException {
+        // Given
+        Map<String, Object> context = Map.of(
+            "flow", Map.of("namespace", "io.kestra.unittest")
+        );
+
+        // When / Then
+        assertThat(variableRenderer.render("{{ secret('json-secret', subkey='string') }}", context), is("value"));
+        assertThat(variableRenderer.render("{{ secret('json-secret', subkey='number') }}", context), is("42"));
+        assertThat(variableRenderer.render("{{ secret('json-secret', subkey='array') }}", context), is("[\"one\",\"two\",\"three\"]"));
+        assertThat(variableRenderer.render("{{ secret('json-secret', subkey='object') }}", context), is("{\"f1\":\"value1\",\"f2\":\"value2\"}"));
+        assertThat(variableRenderer.render("{{ secret('json-secret', subkey='boolean') }}", context), is("true"));
+    }
+
+    @Test
+    void shouldFailedGivenNonExistingSubKey() {
+        // Given
+        Map<String, Object> context = Map.of(
+            "flow", Map.of("namespace", "io.kestra.unittest")
+        );
+
+        // When / Then
+        Throwable cause = Assertions.assertThrows(IllegalVariableEvaluationException.class, () -> {
+            variableRenderer.render("{{ secret('json-secret', subkey='missing') }}", context);
+        }).getCause();
+        assertThat(cause.getMessage(), is("Cannot find secret sub-key 'missing' in secret 'json-secret'. ({{ secret('json-secret', subkey='missing') }}:1)"));
+    }
+
+    @Test
+    void shouldFailedGivenExistingButInvalidSubKey() {
+        // Given
+        Map<String, Object> context = Map.of(
+            "flow", Map.of("namespace", "io.kestra.unittest")
+        );
+
+        // When / Then
+        Throwable cause = Assertions.assertThrows(IllegalVariableEvaluationException.class, () -> {
+            variableRenderer.render("{{ secret('string-secret', subkey='???') }}", context);
+        }).getCause();
+        assertThat(cause.getMessage(), is("Failed to read secret sub-key '???' from secret 'string-secret'. Ensure the secret contains valid JSON value. ({{ secret('string-secret', subkey='???') }}:1)"));
+    }
+
     @Test
     void getUnknownSecret() {
         var exception = assertThrows(SecretNotFoundException.class, () -> secretService.findSecret(null, null, "unknown_secret_key"));
         assertThat(exception.getMessage(), is("Cannot find secret for key 'unknown_secret_key'."));
+    }
+
+    @MockBean(SecretService.class)
+    public static class TestSecretService extends SecretService {
+
+        private static final Map<String, String> SECRETS = Map.of(
+            "io.kestra.unittest.json-secret", """ 
+                {
+                "string": "value",
+                "number": 42,
+                "boolean": true,
+                "array": ["one", "two", "three"],
+                "object": {"f1": "value1", "f2": "value2"}
+                }
+                """,
+            "io.kestra.unittest.string-secret", "string-value"
+        );
+        public String findSecret(String tenantId, String namespace, String key) throws SecretNotFoundException, IOException {
+            Optional<String> optional = Optional.ofNullable(SECRETS.get(namespace + "." + key));
+            if (optional.isPresent()) {
+                return optional.get();
+            }
+            return super.findSecret(tenantId, namespace, key);
+        }
     }
 }


### PR DESCRIPTION
Add new `subkey` named argument to the pebble function `secret` to be able to select a specific field inside a secret containing a JSON value

close: kestra-io/kestra-ee#3200
