### PR TITLE
fix(build): amend Node Gradle to reflect changes

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -62,7 +62,7 @@ jobs:
 
     - name: Build with Gradle
       if: ${{ matrix.language == 'java' }}
-      run: ./gradlew testClasses -x :ui:installFrontend -x :ui:assembleFrontend
+      run: ./gradlew testClasses -x :ui:assembleFrontend
 
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)

--- a/ui/build.gradle
+++ b/ui/build.gradle
@@ -7,15 +7,16 @@ node {
     version = '22.11.0'
 }
 
-
-tasks.register('installFrontend', NpmTask) {
-    description = 'Installs dependencies'
-    args = ['install']
-}
-
 tasks.register('assembleFrontend', NpmTask) {
-    dependsOn installFrontend
+    dependsOn npmInstall
     description = 'Builds the frontend'
+
+    inputs.files(fileTree('node_modules'))
+    inputs.files(fileTree('src'))
+    inputs.file('index.html')
+    inputs.file('package.json')
+    inputs.file('vite.config.js')
+
     args = ['run', 'build']
     outputs.dir('../webserver/src/main/resources/ui')
 }


### PR DESCRIPTION
### What changes are being made and why?

Since the migration from `org.siouan.frontend-jdk21` to `com.github.node-gradle.node` by 549da52a the UI build task was unaware of its inputs.

This caused following issues:

* The task started every single time even when no changes done to the UI subproject -> slower feedback
* The UI build didn't contain latest changes -> unexpected behavior

---

Details:

https://github.com/node-gradle/gradle-node-plugin/blob/main/docs/faq.md#how-to-avoid-nodenpmyarn-task-execution-if-no-changes-in-web-files

---

### How the changes have been QAed?

```bash
./gradlew runLocal
```