### PR TITLE
fix(core): amend server start announcements

### DIFF
--- a/cli/src/main/java/io/kestra/cli/commands/servers/ExecutorCommand.java
+++ b/cli/src/main/java/io/kestra/cli/commands/servers/ExecutorCommand.java
@@ -8,7 +8,6 @@ import io.kestra.core.services.StartExecutorService;
 import io.kestra.core.utils.Await;
 import io.micronaut.context.ApplicationContext;
 import jakarta.inject.Inject;
-import lombok.extern.slf4j.Slf4j;
 import picocli.CommandLine;
 
 import java.util.Collections;
@@ -19,7 +18,6 @@ import java.util.Map;
     name = "executor",
     description = "Start the Kestra executor"
 )
-@Slf4j
 public class ExecutorCommand extends AbstractServerCommand {
     @Inject
     private ApplicationContext applicationContext;
@@ -68,8 +66,6 @@ public class ExecutorCommand extends AbstractServerCommand {
 
         ExecutorInterface executorService = applicationContext.getBean(ExecutorInterface.class);
         executorService.run();
-
-        log.info("Executor started");
 
         Await.until(() -> !this.applicationContext.isRunning());
 

--- a/cli/src/main/java/io/kestra/cli/commands/servers/IndexerCommand.java
+++ b/cli/src/main/java/io/kestra/cli/commands/servers/IndexerCommand.java
@@ -1,13 +1,11 @@
 package io.kestra.cli.commands.servers;
 
 import com.google.common.collect.ImmutableMap;
-import io.kestra.core.contexts.KestraContext;
 import io.kestra.core.models.ServerType;
 import io.kestra.core.runners.IndexerInterface;
 import io.kestra.core.utils.Await;
 import io.micronaut.context.ApplicationContext;
 import jakarta.inject.Inject;
-import lombok.extern.slf4j.Slf4j;
 import picocli.CommandLine;
 
 import java.util.Map;
@@ -16,7 +14,6 @@ import java.util.Map;
     name = "indexer",
     description = "Start the Kestra indexer"
 )
-@Slf4j
 public class IndexerCommand extends AbstractServerCommand {
     @Inject
     private ApplicationContext applicationContext;
@@ -35,7 +32,6 @@ public class IndexerCommand extends AbstractServerCommand {
         IndexerInterface indexer = applicationContext.getBean(IndexerInterface.class);
         indexer.run();
 
-        log.info("Indexer started");
         Await.until(() -> !this.applicationContext.isRunning());
 
         return 0;

--- a/cli/src/main/java/io/kestra/cli/commands/servers/SchedulerCommand.java
+++ b/cli/src/main/java/io/kestra/cli/commands/servers/SchedulerCommand.java
@@ -34,7 +34,6 @@ public class SchedulerCommand extends AbstractServerCommand {
         AbstractScheduler scheduler = applicationContext.getBean(AbstractScheduler.class);
         scheduler.run();
 
-        log.info("Scheduler started");
         Await.until(() -> !this.applicationContext.isRunning());
 
         return 0;

--- a/cli/src/main/java/io/kestra/cli/commands/servers/StandAloneCommand.java
+++ b/cli/src/main/java/io/kestra/cli/commands/servers/StandAloneCommand.java
@@ -11,7 +11,6 @@ import io.kestra.core.utils.Await;
 import io.micronaut.context.ApplicationContext;
 import jakarta.annotation.Nullable;
 import jakarta.inject.Inject;
-import lombok.extern.slf4j.Slf4j;
 import picocli.CommandLine;
 
 import java.io.File;
@@ -24,7 +23,6 @@ import java.util.Map;
     name = "standalone",
     description = "Start the standalone all-in-one server"
 )
-@Slf4j
 public class StandAloneCommand extends AbstractServerCommand {
     @CommandLine.Spec
     CommandLine.Model.CommandSpec spec;

--- a/cli/src/main/java/io/kestra/cli/commands/servers/WorkerCommand.java
+++ b/cli/src/main/java/io/kestra/cli/commands/servers/WorkerCommand.java
@@ -1,13 +1,11 @@
 package io.kestra.cli.commands.servers;
 
 import com.google.common.collect.ImmutableMap;
-import io.kestra.core.contexts.KestraContext;
 import io.kestra.core.models.ServerType;
 import io.kestra.core.runners.Worker;
 import io.kestra.core.utils.Await;
 import io.micronaut.context.ApplicationContext;
 import jakarta.inject.Inject;
-import lombok.extern.slf4j.Slf4j;
 import picocli.CommandLine;
 import picocli.CommandLine.Option;
 
@@ -18,7 +16,6 @@ import java.util.UUID;
     name = "worker",
     description = "Start the Kestra worker"
 )
-@Slf4j
 public class WorkerCommand extends AbstractServerCommand {
 
     @Inject
@@ -50,13 +47,6 @@ public class WorkerCommand extends AbstractServerCommand {
         applicationContext.registerSingleton(worker);
 
         worker.run();
-
-        if (this.workerGroupKey != null) {
-            log.info("Worker started with {} thread(s) in group '{}'", this.thread, this.workerGroupKey);
-        }
-        else {
-            log.info("Worker started with {} thread(s)", this.thread);
-        }
 
         Await.until(() -> !this.applicationContext.isRunning());
 

--- a/core/src/main/java/io/kestra/core/schedulers/AbstractScheduler.java
+++ b/core/src/main/java/io/kestra/core/schedulers/AbstractScheduler.java
@@ -260,6 +260,7 @@ public abstract class AbstractScheduler implements Scheduler, Service {
         this.clusterEventQueue.ifPresent(clusterEventQueueInterface -> this.receiveCancellations.addFirst(((QueueInterface<ClusterEvent>) clusterEventQueueInterface).receive(this::clusterEventQueue)));
 
         setState(ServiceState.RUNNING);
+        log.info("Scheduler started");
     }
 
     // Initialized local trigger state,

--- a/jdbc/src/main/java/io/kestra/jdbc/runner/JdbcIndexer.java
+++ b/jdbc/src/main/java/io/kestra/jdbc/runner/JdbcIndexer.java
@@ -74,6 +74,7 @@ public class JdbcIndexer implements IndexerInterface {
         log.debug("Starting the indexer");
         startQueues();
         setState(ServiceState.RUNNING);
+        log.info("Indexer started");
     }
 
     protected void startQueues() {


### PR DESCRIPTION
### What changes are being made and why?

Servers announced their start, even though their async startup process was still in progress.

This lead to confusing situations - server announced a successful start but, in fact, it failed after some time (EE executor loading state of Kafka Streams, etc.).

---

Note, the log message needs to be ported to EE server implementations.