### PR TITLE
fix(build): Gradle space-assignment deprecation

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -74,7 +74,7 @@ dependencies {
  **********************************************************************************************************************/
 allprojects {
     if (it.name != 'platform') {
-        group "io.kestra"
+        group = "io.kestra"
 
         java {
             sourceCompatibility = targetJavaVersion


### PR DESCRIPTION
### What changes are being made and why?

Space-assignment is deprecated and removed in Gradle 10.