### PR TITLE
fix(ui): include parameters into request for plugin schema fetching

### DIFF
--- a/ui/src/components/flows/tasks/Task.js
+++ b/ui/src/components/flows/tasks/Task.js
@@ -33,7 +33,7 @@ export default {
             return this.root ? this.root + "." + addKey : addKey;
         },
         isRequired(key) {
-            return key === "id" || this.schema.required && this.schema.required.includes(key);
+            return this.schema.required && this.schema.required.includes(key);
         },
         getType(property, key) {
             if (property.enum !== undefined) {

--- a/ui/src/components/flows/tasks/TaskObject.vue
+++ b/ui/src/components/flows/tasks/TaskObject.vue
@@ -150,12 +150,6 @@
                         {},
                     );
 
-                    if (requiredFields && !properties.id) {
-                        properties = {
-                            ...properties,
-                            id: {type: "string", $required: true},
-                        };
-                    }
                     return this.sortProperties(properties);
                 }
 

--- a/ui/src/stores/plugins.js
+++ b/ui/src/stores/plugins.js
@@ -47,7 +47,7 @@ export default {
                 `${apiUrl(this)}/plugins/${options.cls}/versions/${options.version}` :
                 `${apiUrl(this)}/plugins/${options.cls}`;
 
-            return this.$http.get(url).then(response => {
+            return this.$http.get(url, {params: options}).then(response => {
                 if (options.commit !== false) {
                     if (options.all === true) {
                         commit("setPluginAllProps", response.data);


### PR DESCRIPTION
Closes https://github.com/kestra-io/kestra/issues/7939.

Reverting changes introduced [here](https://github.com/kestra-io/kestra/pull/7848/files) because of missing `id` parameters.