### PR TITLE
fix(core): ensure defaults can be injected in flows (#3206)

### DIFF
--- a/core/src/test/java/io/kestra/core/services/PluginDefaultServiceTest.java
+++ b/core/src/test/java/io/kestra/core/services/PluginDefaultServiceTest.java
@@ -51,12 +51,32 @@ class PluginDefaultServiceTest {
             Map.of("id", "my-task", "type", "io.kestra.test")
         )
     );
+    public static final String TEST_LOG_FLOW_SOURCE = """
+            id: test
+            namespace: io.kestra.unittest
+            tasks:
+             - id: log
+               type: io.kestra.plugin.core.log.Log
+        """;
 
     @Inject
     private PluginDefaultService pluginDefaultService;
 
     @Inject
     private YamlParser yamlParser;
+
+    @Test
+    void shouldInjectGivenFlowWithNullSource() {
+        // Given
+        FlowWithSource flow = yamlParser.parse(TEST_LOG_FLOW_SOURCE, FlowWithSource.class);
+
+        // When
+        FlowWithSource result = pluginDefaultService.injectDefaults(flow);
+
+        // Then
+        Log task = (Log) result.getTasks().getFirst();
+        assertThat(task.getMessage(), is("This is a default message"));
+    }
 
     @Test
     void shouldInjectGivenDefaultsIncludingType() {

--- a/core/src/test/resources/application-test.yml
+++ b/core/src/test/resources/application-test.yml
@@ -60,6 +60,9 @@ kestra:
           prop0: value0
 
     defaults:
+      - type: io.kestra.plugin.core.log
+        values:
+          message: This is a default message
       - type: io.kestra.core.services.PluginDefaultServiceTest$DefaultTester
         values:
           doubleValue: 19


### PR DESCRIPTION
Flow revisions create from older Kestra versions may not be linked to their original source. In such cases, fall back to the generated source approach to enable plugin default injection.

close: #3206
