### PR TITLE
fix(core): flatten map should not throw an exception

### DIFF
--- a/core/src/main/java/io/kestra/core/models/Label.java
+++ b/core/src/main/java/io/kestra/core/models/Label.java
@@ -19,6 +19,7 @@ public record Label(@NotNull String key, @NotNull String value) {
     public static final String RESTARTED = SYSTEM_PREFIX + "restarted";
     public static final String REPLAY = SYSTEM_PREFIX + "replay";
     public static final String REPLAYED = SYSTEM_PREFIX + "replayed";
+    public static final String SIMULATED_EXECUTION = SYSTEM_PREFIX + "simulatedExecution";
 
     /**
      * Static helper method for converting a list of labels to a nested map.

--- a/core/src/main/java/io/kestra/core/topologies/FlowTopologyService.java
+++ b/core/src/main/java/io/kestra/core/topologies/FlowTopologyService.java
@@ -29,7 +29,7 @@ import java.util.stream.Stream;
 @Slf4j
 @Singleton
 public class FlowTopologyService {
-    public static final Label SIMULATED_EXECUTION = new Label(Label.SYSTEM_PREFIX + "simulatedExecution", "true");
+    public static final Label SIMULATED_EXECUTION = new Label(Label.SIMULATED_EXECUTION, "true");
 
     @Inject
     protected ConditionService conditionService;

--- a/core/src/main/java/io/kestra/core/utils/MapUtils.java
+++ b/core/src/main/java/io/kestra/core/utils/MapUtils.java
@@ -1,11 +1,15 @@
 package io.kestra.core.utils;
 
 import jakarta.validation.constraints.NotNull;
+import lombok.extern.slf4j.Slf4j;
 
 import java.util.*;
 
 @SuppressWarnings({"rawtypes", "unchecked"})
+@Slf4j
 public class MapUtils {
+    private static final String CONFLICT_AT_KEY_MSG = "Conflict at key: '{}', ignoring it. Map keys are: {}";
+
     public static Map<String, Object> merge(Map<String, Object> a, Map<String, Object> b) {
         if (a == null && b == null) {
             return null;
@@ -136,9 +140,9 @@ public class MapUtils {
     }
 
     /**
-     * Utility method nested a flatten map.
+     * Utility method nested a flattened map.
      *
-     * @param flatMap the flatten map.
+     * @param flatMap the flattened map.
      * @return the nested map.
      *
      * @throws IllegalArgumentException if the given map contains conflicting keys.
@@ -156,13 +160,13 @@ public class MapUtils {
                     currentMap.put(key, new HashMap<>());
                 } else if (!(currentMap.get(key) instanceof Map)) {
                     var invalidKey = String.join(",", Arrays.copyOfRange(keys, 0, i));
-                    throw new IllegalArgumentException("Conflict at key: '" + invalidKey + "'. Map keys are: " + flatMap.keySet());
+                    log.error(CONFLICT_AT_KEY_MSG, invalidKey, flatMap.keySet());
                 }
                 currentMap = (Map<String, Object>) currentMap.get(key);
             }
             String lastKey = keys[keys.length - 1];
             if (currentMap.containsKey(lastKey)) {
-                throw new IllegalArgumentException("Conflict at key: '" + lastKey + "', Map keys are: " + flatMap.keySet());
+                log.error("Conflict at key: '{}', ignoring it. Map keys are: {}", lastKey, flatMap.keySet());
             }
             currentMap.put(lastKey, entry.getValue());
         }

--- a/core/src/test/java/io/kestra/core/utils/MapUtilsTest.java
+++ b/core/src/test/java/io/kestra/core/utils/MapUtilsTest.java
@@ -125,12 +125,13 @@ class MapUtilsTest {
     }
 
     @Test
-    void shouldThrowExceptionWhenNestingMapGivenFlattenMapWithConflicts() {
-        Assertions.assertThrows(IllegalArgumentException.class, () -> {
-            MapUtils.flattenToNestedMap(Map.of(
-                "k1.k2", "v1",
-                "k1.k2.k3", "v2"
-            ));
-        });
+    void shouldReturnMapAndIgnoreConflicts() {
+        Map<String, Object> results = MapUtils.flattenToNestedMap(Map.of(
+            "k1.k2", "v1",
+            "k1.k2.k3", "v2"
+        ));
+
+        assertThat(results, aMapWithSize(1));
+        assertThat(results, hasEntry("k1", Map.of("k2", "v1")));
     }
 }


### PR DESCRIPTION
As it is called inside the Executor, it must be fail-safe.
