### PR TITLE
chore(ui): show blueprint `id` field in case of missing title

### DIFF
--- a/ui/src/override/components/flows/blueprints/BlueprintsBrowser.vue
+++ b/ui/src/override/components/flows/blueprints/BlueprintsBrowser.vue
@@ -54,7 +54,7 @@
                             <div class="left">
                                 <div class="blueprint">
                                     <div class="ps-0 title">
-                                        {{ blueprint.title }}
+                                        {{ blueprint.title ?? blueprint.id }}
                                     </div>
                                     <div v-if="!system" class="tags text-uppercase">
                                         <div v-for="(tag, index) in blueprint.tags" :key="index" class="tag-box">


### PR DESCRIPTION
Relates to https://github.com/kestra-io/kestra-ee/issues/3310.