### PR TITLE
chore: disable tests that are too flaky

### DIFF
--- a/core/src/test/java/io/kestra/core/schedulers/SchedulerScheduleTest.java
+++ b/core/src/test/java/io/kestra/core/schedulers/SchedulerScheduleTest.java
@@ -21,6 +21,7 @@ import io.kestra.core.runners.FlowListeners;
 import io.kestra.core.utils.Await;
 import jakarta.inject.Inject;
 import jakarta.inject.Named;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import reactor.core.publisher.Flux;
 
@@ -525,6 +526,7 @@ public class SchedulerScheduleTest extends AbstractSchedulerTest {
     }
 
     @Test
+    @Disabled("too flaky on CI")
     void recoverLASTLongRunningExecution() throws Exception {
         // mock flow listeners
         FlowListeners flowListenersServiceSpy = spy(this.flowListenersService);
@@ -596,6 +598,7 @@ public class SchedulerScheduleTest extends AbstractSchedulerTest {
     }
 
     @Test
+    @Disabled("too flaky on CI")
     void recoverNONELongRunningExecution() throws Exception {
         // mock flow listeners
         FlowListeners flowListenersServiceSpy = spy(this.flowListenersService);


### PR DESCRIPTION
An issue will be open to track them and re-enabled them later.
