### PR TITLE
fix(jdbc): possible deadlock on service instance

### DIFF
--- a/jdbc/src/main/java/io/kestra/jdbc/repository/AbstractJdbcServiceInstanceRepository.java
+++ b/jdbc/src/main/java/io/kestra/jdbc/repository/AbstractJdbcServiceInstanceRepository.java
@@ -122,7 +122,7 @@ public abstract class AbstractJdbcServiceInstanceRepository extends AbstractJdbc
             .where(STATE.in(states.stream().map(Enum::name).toList()));
 
         return isForUpdate ?
-            this.jdbcRepository.fetch(query.forUpdate()) :
+            this.jdbcRepository.fetch(query.forUpdate().skipLocked()) :
             this.jdbcRepository.fetch(query);
     }
 
@@ -150,7 +150,7 @@ public abstract class AbstractJdbcServiceInstanceRepository extends AbstractJdbc
             .where(STATE.notIn(Service.ServiceState.CREATED.name(), Service.ServiceState.RUNNING.name()));
 
         return isForUpdate ?
-            this.jdbcRepository.fetch(query.forUpdate()) :
+            this.jdbcRepository.fetch(query.forUpdate().skipLocked()) :
             this.jdbcRepository.fetch(query);
     }
 
@@ -178,7 +178,7 @@ public abstract class AbstractJdbcServiceInstanceRepository extends AbstractJdbc
             .where(STATE.eq(Service.ServiceState.NOT_RUNNING.name()));
 
         return isForUpdate ?
-            this.jdbcRepository.fetch(query.forUpdate()) :
+            this.jdbcRepository.fetch(query.forUpdate().skipLocked()) :
             this.jdbcRepository.fetch(query);
     }
 


### PR DESCRIPTION
If multiple Executors restart at the same time and there was a not of worker task to resubmit, there was a possible deadlock as the service instance table is selected for update so it can block other executors. Using skipped lock avoid that and is still correct as other executors can skip the dead instance handling as it was already in process by the first executor.

findById was not changed in this commit as it's not part of the worker task resubmission process.
