### PR TITLE
-- DO NOT MERGE -- bug/dp fails tests

### DIFF
--- a/core/src/main/java/io/kestra/plugin/core/condition/DateTimeBetween.java
+++ b/core/src/main/java/io/kestra/plugin/core/condition/DateTimeBetween.java
@@ -8,6 +8,8 @@ import io.kestra.core.models.annotations.PluginProperty;
 import io.kestra.core.models.conditions.Condition;
 import io.kestra.core.models.conditions.ConditionContext;
 import io.kestra.core.models.conditions.ScheduleCondition;
+import io.kestra.core.models.property.Property;
+import io.kestra.core.runners.RunContext;
 import io.kestra.core.utils.DateUtils;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.*;

--- a/core/src/main/java/io/kestra/plugin/core/condition/DateTimeBetween.java
+++ b/core/src/main/java/io/kestra/plugin/core/condition/DateTimeBetween.java
@@ -4,18 +4,18 @@ import io.kestra.core.exceptions.IllegalConditionEvaluation;
 import io.kestra.core.exceptions.InternalException;
 import io.kestra.core.models.annotations.Example;
 import io.kestra.core.models.annotations.Plugin;
-import io.kestra.core.models.annotations.PluginProperty;
 import io.kestra.core.models.conditions.Condition;
 import io.kestra.core.models.conditions.ConditionContext;
 import io.kestra.core.models.conditions.ScheduleCondition;
 import io.kestra.core.models.property.Property;
-import io.kestra.core.runners.RunContext;
 import io.kestra.core.utils.DateUtils;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
 
 import java.time.ZonedDateTime;
+import java.util.Map;
+
 import jakarta.validation.constraints.NotNull;
 
 @SuperBuilder
@@ -89,30 +89,31 @@ public class DateTimeBetween extends Condition implements ScheduleCondition {
         title = "The date to test must be after this one.",
         description = "Must be a valid ISO 8601 datetime with the zone identifier (use 'Z' for the default zone identifier)."
     )
-    @PluginProperty
-    private ZonedDateTime after;
+    private Property<ZonedDateTime> after;
 
     @Schema(
         title = "The date to test must be before this one.",
         description = "Must be a valid ISO 8601 datetime with the zone identifier (use 'Z' for the default zone identifier)."
     )
-    @PluginProperty
-    private ZonedDateTime before;
+    private Property<ZonedDateTime> before;
 
     @Override
     public boolean test(ConditionContext conditionContext) throws InternalException {
-        String render = conditionContext.getRunContext().render(date).as(String.class, conditionContext.getVariables()).orElseThrow();
+        Map<String, Object> vars = conditionContext.getVariables();
+        String render = conditionContext.getRunContext().render(date).as(String.class, vars).orElseThrow();
         ZonedDateTime currentDate = DateUtils.parseZonedDateTime(render);
 
-        if (this.before != null && this.after != null) {
-            return currentDate.isAfter(after) && currentDate.isBefore(before);
-        } else if (this.before != null) {
-            return currentDate.isBefore(before);
-        } else if (this.after != null) {
-            return currentDate.isAfter(after);
+        ZonedDateTime afterRendered = conditionContext.getRunContext().render(this.after).as(ZonedDateTime.class, vars).orElse(null);
+        ZonedDateTime beforeRendered = conditionContext.getRunContext().render(this.before).as(ZonedDateTime.class, vars).orElse(null);
+
+        if (beforeRendered != null && afterRendered != null) {
+            return currentDate.isAfter(afterRendered) && currentDate.isBefore(beforeRendered);
+        } else if (beforeRendered != null) {
+            return currentDate.isBefore(beforeRendered);
+        } else if (afterRendered != null) {
+            return currentDate.isAfter(afterRendered);
         } else {
             throw new IllegalConditionEvaluation("Invalid condition with no before nor after");
         }
-
     }
 }

--- a/core/src/main/java/io/kestra/plugin/core/condition/DateTimeBetween.java
+++ b/core/src/main/java/io/kestra/plugin/core/condition/DateTimeBetween.java
@@ -4,6 +4,7 @@ import io.kestra.core.exceptions.IllegalConditionEvaluation;
 import io.kestra.core.exceptions.InternalException;
 import io.kestra.core.models.annotations.Example;
 import io.kestra.core.models.annotations.Plugin;
+import io.kestra.core.models.annotations.PluginProperty;
 import io.kestra.core.models.conditions.Condition;
 import io.kestra.core.models.conditions.ConditionContext;
 import io.kestra.core.models.conditions.ScheduleCondition;
@@ -83,7 +84,8 @@ public class DateTimeBetween extends Condition implements ScheduleCondition {
         description = "Can be any variable or any valid ISO 8601 datetime. By default, it will use the trigger date."
     )
     @Builder.Default
-    private final Property<String> date = new Property<>("{{ trigger.date }}");
+    @PluginProperty(dynamic = true)
+    private final String date = "{{ trigger.date }}";
 
     @Schema(
         title = "The date to test must be after this one.",
@@ -100,7 +102,7 @@ public class DateTimeBetween extends Condition implements ScheduleCondition {
     @Override
     public boolean test(ConditionContext conditionContext) throws InternalException {
         Map<String, Object> vars = conditionContext.getVariables();
-        String render = conditionContext.getRunContext().render(date).as(String.class, vars).orElseThrow();
+        String render = conditionContext.getRunContext().render(date, vars);
         ZonedDateTime currentDate = DateUtils.parseZonedDateTime(render);
 
         ZonedDateTime afterRendered = conditionContext.getRunContext().render(this.after).as(ZonedDateTime.class, vars).orElse(null);

--- a/core/src/main/java/io/kestra/plugin/core/condition/DateTimeBetween.java
+++ b/core/src/main/java/io/kestra/plugin/core/condition/DateTimeBetween.java
@@ -84,8 +84,7 @@ public class DateTimeBetween extends Condition implements ScheduleCondition {
         description = "Can be any variable or any valid ISO 8601 datetime. By default, it will use the trigger date."
     )
     @Builder.Default
-    @PluginProperty(dynamic = true)
-    private final String date = "{{ trigger.date }}";
+    private final Property<String> date = new Property<>("{{ trigger.date }}");
 
     @Schema(
         title = "The date to test must be after this one.",
@@ -102,7 +101,7 @@ public class DateTimeBetween extends Condition implements ScheduleCondition {
     @Override
     public boolean test(ConditionContext conditionContext) throws InternalException {
         Map<String, Object> vars = conditionContext.getVariables();
-        String render = conditionContext.getRunContext().render(date, vars);
+        String render = conditionContext.getRunContext().render(date).as(String.class, vars).orElse(null);
         ZonedDateTime currentDate = DateUtils.parseZonedDateTime(render);
 
         ZonedDateTime afterRendered = conditionContext.getRunContext().render(this.after).as(ZonedDateTime.class, vars).orElse(null);

--- a/core/src/main/java/io/kestra/plugin/core/condition/DateTimeBetween.java
+++ b/core/src/main/java/io/kestra/plugin/core/condition/DateTimeBetween.java
@@ -61,7 +61,7 @@ import jakarta.validation.constraints.NotNull;
                   - id: log_message
                     type: io.kestra.plugin.core.log.Log
                     message: "This flow will be executed once every 5 minutes between the before and after dates"
-                
+
                 triggers:
                   - id: schedule
                     type: io.kestra.plugin.core.trigger.Schedule
@@ -83,8 +83,7 @@ public class DateTimeBetween extends Condition implements ScheduleCondition {
         description = "Can be any variable or any valid ISO 8601 datetime. By default, it will use the trigger date."
     )
     @Builder.Default
-    @PluginProperty(dynamic = true)
-    private final String date = "{{ trigger.date }}";
+    private final Property<String> date = new Property<>("{{ trigger.date }}");
 
     @Schema(
         title = "The date to test must be after this one.",
@@ -102,7 +101,7 @@ public class DateTimeBetween extends Condition implements ScheduleCondition {
 
     @Override
     public boolean test(ConditionContext conditionContext) throws InternalException {
-        String render = conditionContext.getRunContext().render(date, conditionContext.getVariables());
+        String render = conditionContext.getRunContext().render(date).as(String.class, conditionContext.getVariables()).orElseThrow();
         ZonedDateTime currentDate = DateUtils.parseZonedDateTime(render);
 
         if (this.before != null && this.after != null) {

--- a/core/src/main/java/io/kestra/plugin/core/condition/DayWeek.java
+++ b/core/src/main/java/io/kestra/plugin/core/condition/DayWeek.java
@@ -3,10 +3,11 @@ package io.kestra.plugin.core.condition;
 import io.kestra.core.exceptions.InternalException;
 import io.kestra.core.models.annotations.Example;
 import io.kestra.core.models.annotations.Plugin;
-import io.kestra.core.models.annotations.PluginProperty;
 import io.kestra.core.models.conditions.Condition;
 import io.kestra.core.models.conditions.ConditionContext;
 import io.kestra.core.models.conditions.ScheduleCondition;
+import io.kestra.core.models.property.Property;
+import io.kestra.core.runners.RunContext;
 import io.kestra.core.utils.DateUtils;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.*;
@@ -57,19 +58,18 @@ public class DayWeek extends Condition implements ScheduleCondition {
         description = "Can be any variable or any valid ISO 8601 datetime. By default, it will use the trigger date."
     )
     @Builder.Default
-    @PluginProperty(dynamic = true)
-    private final String date = "{{ trigger.date }}";
+    private final Property<String> date = new Property<>("{{ trigger.date }}");
 
     @NotNull
     @Schema(title = "The day of week.")
-    @PluginProperty
-    private DayOfWeek dayOfWeek;
+    private Property<DayOfWeek> dayOfWeek;
 
     @Override
     public boolean test(ConditionContext conditionContext) throws InternalException {
-        String render = conditionContext.getRunContext().render(date, conditionContext.getVariables());
+        RunContext runContext = conditionContext.getRunContext();
+        String render = runContext.render(date).as(String.class, conditionContext.getVariables()).orElseThrow();
         LocalDate currentDate = DateUtils.parseLocalDate(render);
 
-        return currentDate.getDayOfWeek().equals(this.dayOfWeek);
+        return currentDate.getDayOfWeek().equals(runContext.render(dayOfWeek).as(DayOfWeek.class, conditionContext.getVariables()).orElseThrow());
     }
 }

--- a/core/src/main/java/io/kestra/plugin/core/condition/DayWeekInMonth.java
+++ b/core/src/main/java/io/kestra/plugin/core/condition/DayWeekInMonth.java
@@ -63,8 +63,7 @@ public class DayWeekInMonth extends Condition implements ScheduleCondition {
         description = "Can be any variable or any valid ISO 8601 datetime. By default, it will use the trigger date."
     )
     @Builder.Default
-    @PluginProperty(dynamic = true)
-    private final String date = "{{ trigger.date }}";
+    private final Property<String> date = new Property<>("{{ trigger.date }}");
 
     @NotNull
     @Schema(title = "The day of week.")
@@ -79,7 +78,7 @@ public class DayWeekInMonth extends Condition implements ScheduleCondition {
         Map<String, Object> vars = conditionContext.getVariables();
         RunContext runContext = conditionContext.getRunContext();
 
-        String render = runContext.render(date, vars);
+        String render = runContext.render(date).as(String.class, vars).orElse(null);
         LocalDate currentDate = DateUtils.parseLocalDate(render);
         LocalDate computed;
 

--- a/core/src/main/java/io/kestra/plugin/core/condition/ExecutionFlow.java
+++ b/core/src/main/java/io/kestra/plugin/core/condition/ExecutionFlow.java
@@ -2,7 +2,8 @@ package io.kestra.plugin.core.condition;
 
 import io.kestra.core.exceptions.IllegalConditionEvaluation;
 import io.kestra.core.exceptions.InternalException;
-import io.kestra.core.models.annotations.PluginProperty;
+import io.kestra.core.models.property.Property;
+import io.kestra.core.runners.RunContext;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -55,13 +56,11 @@ import jakarta.validation.constraints.NotNull;
 public class ExecutionFlow extends Condition {
     @NotNull
     @Schema(title = "The namespace of the flow.")
-    @PluginProperty
-    private String namespace;
+    private Property<String> namespace;
 
     @NotNull
     @Schema(title = "The flow id.")
-    @PluginProperty
-    private String flowId;
+    private Property<String> flowId;
 
     @Override
     public boolean test(ConditionContext conditionContext) throws InternalException {
@@ -69,6 +68,8 @@ public class ExecutionFlow extends Condition {
             throw new IllegalConditionEvaluation("Invalid condition with null execution");
         }
 
-        return conditionContext.getExecution().getNamespace().equals(this.namespace) && conditionContext.getExecution().getFlowId().equals(this.flowId);
+        RunContext runContext = conditionContext.getRunContext();
+        return conditionContext.getExecution().getNamespace().equals(runContext.render(this.namespace).as(String.class, conditionContext.getVariables()).orElseThrow())
+            && conditionContext.getExecution().getFlowId().equals(runContext.render(this.flowId).as(String.class, conditionContext.getVariables()).orElseThrow());
     }
 }

--- a/core/src/main/java/io/kestra/plugin/core/condition/ExecutionOutputs.java
+++ b/core/src/main/java/io/kestra/plugin/core/condition/ExecutionOutputs.java
@@ -8,6 +8,7 @@ import io.kestra.core.models.conditions.Condition;
 import io.kestra.core.models.conditions.ConditionContext;
 import io.kestra.core.models.conditions.ScheduleCondition;
 import io.kestra.core.models.executions.Execution;
+import io.kestra.core.models.property.Property;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
@@ -89,9 +90,7 @@ public class ExecutionOutputs extends Condition implements ScheduleCondition {
     private static final String OUTPUTS_VAR = "outputs";
 
     @NotNull
-    @NotEmpty
-    @PluginProperty
-    private String expression;
+    private Property<String> expression;
 
     /** {@inheritDoc} **/
     @SuppressWarnings("unchecked")
@@ -107,8 +106,8 @@ public class ExecutionOutputs extends Condition implements ScheduleCondition {
             Map.of(TRIGGER_VAR, Map.of(OUTPUTS_VAR, conditionContext.getExecution().getOutputs()))
         );
 
-        String render = conditionContext.getRunContext().render(expression, variables);
-        return !(render.isBlank() || render.isEmpty() || render.trim().equals("false"));
+        String render = conditionContext.getRunContext().render(expression).as(String.class, variables).orElseThrow();
+        return !(render.isBlank() || render.trim().equals("false"));
     }
 
     private boolean hasNoOutputs(final Execution execution) {

--- a/core/src/main/java/io/kestra/plugin/core/condition/Expression.java
+++ b/core/src/main/java/io/kestra/plugin/core/condition/Expression.java
@@ -7,6 +7,7 @@ import io.kestra.core.models.annotations.PluginProperty;
 import io.kestra.core.models.conditions.Condition;
 import io.kestra.core.models.conditions.ConditionContext;
 import io.kestra.core.models.conditions.ScheduleCondition;
+import io.kestra.core.models.property.Property;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -54,13 +55,11 @@ import jakarta.validation.constraints.NotNull;
 )
 public class Expression extends Condition implements ScheduleCondition {
     @NotNull
-    @NotEmpty
-    @PluginProperty
-    private String expression;
+    private Property<String> expression;
 
     @Override
     public boolean test(ConditionContext conditionContext) throws InternalException {
-        String render = conditionContext.getRunContext().render(expression, conditionContext.getVariables());
-        return !(render.isBlank() || render.isEmpty() || render.trim().equals("false"));
+        String render = conditionContext.getRunContext().render(expression).as(String.class, conditionContext.getVariables()).orElseThrow();
+        return !(render.isBlank() || render.trim().equals("false"));
     }
 }

--- a/core/src/main/java/io/kestra/plugin/core/condition/HasRetryAttempt.java
+++ b/core/src/main/java/io/kestra/plugin/core/condition/HasRetryAttempt.java
@@ -8,6 +8,8 @@ import io.kestra.core.models.annotations.PluginProperty;
 import io.kestra.core.models.conditions.Condition;
 import io.kestra.core.models.conditions.ConditionContext;
 import io.kestra.core.models.flows.State;
+import io.kestra.core.models.property.Property;
+import io.kestra.core.runners.RunContext;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -55,19 +57,21 @@ import jakarta.validation.Valid;
 public class HasRetryAttempt extends Condition {
     @Valid
     @Schema(title = "List of states that are authorized.")
-    @PluginProperty
-    private List<State.Type> in;
+    private Property<List<State.Type>> in;
 
     @Valid
     @Schema(title = "List of states that aren't authorized.")
-    @PluginProperty
-    private List<State.Type> notIn;
+    private Property<List<State.Type>> notIn;
 
     @Override
     public boolean test(ConditionContext conditionContext) throws InternalException {
         if (conditionContext.getExecution() == null) {
             throw new IllegalConditionEvaluation("Invalid condition with null execution");
         }
+
+        RunContext runContext = conditionContext.getRunContext();
+        var stateInRendered = runContext.render(this.in).asList(String.class, conditionContext.getVariables());
+        var stateNotInRendered = runContext.render(this.notIn).asList(String.class, conditionContext.getVariables());
 
         return conditionContext
             .getExecution()
@@ -78,11 +82,11 @@ public class HasRetryAttempt extends Condition {
             .anyMatch(taskRunAttempt -> {
                 boolean result = true;
 
-                if (this.in != null && !this.in.contains(taskRunAttempt.getState().getCurrent())) {
+                if (!stateInRendered.contains(taskRunAttempt.getState().getCurrent())) {
                     result = false;
                 }
 
-                if (this.notIn != null && this.notIn.contains(taskRunAttempt.getState().getCurrent())) {
+                if (stateNotInRendered.contains(taskRunAttempt.getState().getCurrent())) {
                     result = false;
                 }
 

--- a/core/src/main/java/io/kestra/plugin/core/condition/TimeBetween.java
+++ b/core/src/main/java/io/kestra/plugin/core/condition/TimeBetween.java
@@ -8,6 +8,7 @@ import io.kestra.core.models.annotations.PluginProperty;
 import io.kestra.core.models.conditions.Condition;
 import io.kestra.core.models.conditions.ConditionContext;
 import io.kestra.core.models.conditions.ScheduleCondition;
+import io.kestra.core.models.property.Property;
 import io.kestra.core.utils.DateUtils;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
@@ -58,8 +59,7 @@ public class TimeBetween extends Condition implements ScheduleCondition {
         description = "Can be any variable or any valid ISO 8601 time. By default, it will use the trigger date."
     )
     @Builder.Default
-    @PluginProperty(dynamic = true)
-    private final String date = "{{ trigger.date }}";
+    private final Property<String> date = new Property<>("{{ trigger.date }}");
 
     @Schema(
         title = "The time to test must be after this one.",
@@ -77,7 +77,7 @@ public class TimeBetween extends Condition implements ScheduleCondition {
 
     @Override
     public boolean test(ConditionContext conditionContext) throws InternalException {
-        String render = conditionContext.getRunContext().render(date, conditionContext.getVariables());
+        String render = conditionContext.getRunContext().render(date).as(String.class, conditionContext.getVariables()).orElseThrow();
         OffsetTime currentDate = DateUtils.parseZonedDateTime(render).toOffsetDateTime().toOffsetTime();
 
         if (this.before != null && this.after != null) {

--- a/core/src/main/java/io/kestra/plugin/core/condition/TimeBetween.java
+++ b/core/src/main/java/io/kestra/plugin/core/condition/TimeBetween.java
@@ -4,11 +4,11 @@ import io.kestra.core.exceptions.IllegalConditionEvaluation;
 import io.kestra.core.exceptions.InternalException;
 import io.kestra.core.models.annotations.Example;
 import io.kestra.core.models.annotations.Plugin;
-import io.kestra.core.models.annotations.PluginProperty;
 import io.kestra.core.models.conditions.Condition;
 import io.kestra.core.models.conditions.ConditionContext;
 import io.kestra.core.models.conditions.ScheduleCondition;
 import io.kestra.core.models.property.Property;
+import io.kestra.core.runners.RunContext;
 import io.kestra.core.utils.DateUtils;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
@@ -16,6 +16,7 @@ import lombok.*;
 import lombok.experimental.SuperBuilder;
 
 import java.time.OffsetTime;
+import java.util.Map;
 
 @SuperBuilder
 @ToString
@@ -65,27 +66,31 @@ public class TimeBetween extends Condition implements ScheduleCondition {
         title = "The time to test must be after this one.",
         description = "Must be a valid ISO 8601 time with offset."
     )
-    @PluginProperty
-    private OffsetTime after;
+    private Property<OffsetTime> after;
 
     @Schema(
         title = "The time to test must be before this one.",
         description = "Must be a valid ISO 8601 time with offset."
     )
-    @PluginProperty
-    private OffsetTime before;
+    private Property<OffsetTime> before;
 
     @Override
     public boolean test(ConditionContext conditionContext) throws InternalException {
-        String render = conditionContext.getRunContext().render(date).as(String.class, conditionContext.getVariables()).orElseThrow();
-        OffsetTime currentDate = DateUtils.parseZonedDateTime(render).toOffsetDateTime().toOffsetTime();
+        RunContext runContext = conditionContext.getRunContext();
+        Map<String, Object> variables = conditionContext.getVariables();
 
-        if (this.before != null && this.after != null) {
-            return currentDate.isAfter(after) && currentDate.isBefore(before);
-        } else if (this.before != null) {
-            return currentDate.isBefore(before);
-        } else if (this.after != null) {
-            return currentDate.isAfter(after);
+        String dateRendered = runContext.render(date).as(String.class, variables).orElseThrow();
+        OffsetTime currentDate = DateUtils.parseZonedDateTime(dateRendered).toOffsetDateTime().toOffsetTime();
+
+        OffsetTime beforeRendered = runContext.render(before).as(OffsetTime.class, variables).orElse(null);
+        OffsetTime afterRendered = runContext.render(after).as(OffsetTime.class, variables).orElse(null);
+
+        if (beforeRendered != null && afterRendered != null) {
+            return currentDate.isAfter(afterRendered) && currentDate.isBefore(beforeRendered);
+        } else if (beforeRendered != null) {
+            return currentDate.isBefore(beforeRendered);
+        } else if (afterRendered != null) {
+            return currentDate.isAfter(afterRendered);
         } else {
             throw new IllegalConditionEvaluation("Invalid condition with no before nor after");
         }

--- a/core/src/main/java/io/kestra/plugin/core/condition/Weekend.java
+++ b/core/src/main/java/io/kestra/plugin/core/condition/Weekend.java
@@ -7,6 +7,7 @@ import io.kestra.core.models.annotations.PluginProperty;
 import io.kestra.core.models.conditions.Condition;
 import io.kestra.core.models.conditions.ConditionContext;
 import io.kestra.core.models.conditions.ScheduleCondition;
+import io.kestra.core.models.property.Property;
 import io.kestra.core.utils.DateUtils;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.*;
@@ -56,12 +57,11 @@ public class Weekend extends Condition implements ScheduleCondition {
         description = "Can be any variable or any valid ISO 8601 datetime. By default, it will use the trigger date."
     )
     @Builder.Default
-    @PluginProperty(dynamic = true)
-    private final String date = "{{ trigger.date }}";
+    private final Property<String> date = new Property<>("{{ trigger.date }}");
 
     @Override
     public boolean test(ConditionContext conditionContext) throws InternalException {
-        String render = conditionContext.getRunContext().render(date, conditionContext.getVariables());
+        String render = conditionContext.getRunContext().render(date).as(String.class, conditionContext.getVariables()).orElseThrow();
         LocalDate currentDate = DateUtils.parseLocalDate(render);
 
         return currentDate.getDayOfWeek().equals(DayOfWeek.SATURDAY) ||

--- a/core/src/test/java/io/kestra/core/models/flows/FlowWithSourceTest.java
+++ b/core/src/test/java/io/kestra/core/models/flows/FlowWithSourceTest.java
@@ -110,7 +110,7 @@ class FlowWithSourceTest {
             ))
             .listeners(List.of(
                 Listener.builder()
-                    .conditions(List.of(Expression.builder().expression("true").build()))
+                    .conditions(List.of(Expression.builder().expression(Property.of("true")).build()))
                     .build()
             ))
             .triggers(List.of(

--- a/core/src/test/java/io/kestra/core/models/triggers/multipleflows/AbstractMultipleConditionStorageTest.java
+++ b/core/src/test/java/io/kestra/core/models/triggers/multipleflows/AbstractMultipleConditionStorageTest.java
@@ -2,6 +2,7 @@ package io.kestra.core.models.triggers.multipleflows;
 
 import com.google.common.collect.ImmutableMap;
 import io.kestra.core.junit.annotations.KestraTest;
+import io.kestra.core.models.property.Property;
 import org.apache.commons.lang3.tuple.Pair;
 import org.junit.jupiter.api.Test;
 import io.kestra.plugin.core.condition.ExecutionFlow;
@@ -237,12 +238,12 @@ public abstract class AbstractMultipleConditionStorageTest {
             .id("condition-multiple")
             .conditions(ImmutableMap.of(
                 "flow-a", ExecutionFlow.builder()
-                    .flowId("flow-a")
-                    .namespace(NAMESPACE)
+                    .flowId(Property.of("flow-a"))
+                    .namespace(Property.of(NAMESPACE))
                     .build(),
                 "flow-b", ExecutionFlow.builder()
-                    .flowId("flow-b")
-                    .namespace(NAMESPACE)
+                    .flowId(Property.of("flow-b"))
+                    .namespace(Property.of(NAMESPACE))
                     .build()
             ))
             .timeWindow(sla)

--- a/core/src/test/java/io/kestra/core/runners/ListenersTest.java
+++ b/core/src/test/java/io/kestra/core/runners/ListenersTest.java
@@ -20,7 +20,7 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
 
 @KestraTest(startRunner = true)
-public class ListenersTest {
+class ListenersTest {
 
     @Inject
     private RunnerUtils runnerUtils;

--- a/core/src/test/java/io/kestra/core/schedulers/SchedulerConditionTest.java
+++ b/core/src/test/java/io/kestra/core/schedulers/SchedulerConditionTest.java
@@ -3,6 +3,7 @@ package io.kestra.core.schedulers;
 import io.kestra.core.models.executions.Execution;
 import io.kestra.core.models.flows.Flow;
 import io.kestra.core.models.flows.State;
+import io.kestra.core.models.property.Property;
 import io.kestra.core.models.triggers.Trigger;
 import io.kestra.core.repositories.FlowRepositoryInterface;
 import io.kestra.core.runners.FlowListeners;
@@ -55,8 +56,8 @@ class SchedulerConditionTest extends AbstractSchedulerTest {
                 DayWeekInMonth.builder()
                     .type(DayWeekInMonth.class.getName())
                     .date("{{ trigger.date }}")
-                    .dayOfWeek(DayOfWeek.MONDAY)
-                    .dayInMonth(DayWeekInMonth.DayInMonth.FIRST)
+                    .dayOfWeek(Property.of(DayOfWeek.MONDAY))
+                    .dayInMonth(Property.of(DayWeekInMonth.DayInMonth.FIRST))
                     .build()
             ))
             .build();

--- a/core/src/test/java/io/kestra/core/schedulers/SchedulerConditionTest.java
+++ b/core/src/test/java/io/kestra/core/schedulers/SchedulerConditionTest.java
@@ -55,7 +55,7 @@ class SchedulerConditionTest extends AbstractSchedulerTest {
             .conditions(List.of(
                 DayWeekInMonth.builder()
                     .type(DayWeekInMonth.class.getName())
-                    .date("{{ trigger.date }}")
+                    .date(new Property<>("{{ trigger.date }}"))
                     .dayOfWeek(Property.of(DayOfWeek.MONDAY))
                     .dayInMonth(Property.of(DayWeekInMonth.DayInMonth.FIRST))
                     .build()

--- a/core/src/test/java/io/kestra/core/schedulers/SchedulerPollingTriggerTest.java
+++ b/core/src/test/java/io/kestra/core/schedulers/SchedulerPollingTriggerTest.java
@@ -1,6 +1,7 @@
 package io.kestra.core.schedulers;
 
 import io.kestra.core.models.Label;
+import io.kestra.core.models.property.Property;
 import io.kestra.core.repositories.FlowRepositoryInterface;
 import io.kestra.core.utils.TestsUtils;
 import io.kestra.jdbc.runner.JdbcScheduler;
@@ -145,7 +146,7 @@ public class SchedulerPollingTriggerTest extends AbstractSchedulerTest {
                 List.of(
                     Expression.builder()
                         .type(Expression.class.getName())
-                        .expression("{{ trigger.date | date() < now() }}")
+                        .expression(new Property<>("{{ trigger.date | date() < now() }}"))
                         .build()
                 ))
             .build();

--- a/core/src/test/java/io/kestra/core/schedulers/SchedulerScheduleTest.java
+++ b/core/src/test/java/io/kestra/core/schedulers/SchedulerScheduleTest.java
@@ -4,6 +4,7 @@ import com.devskiller.friendly_id.FriendlyId;
 import io.kestra.core.models.executions.TaskRun;
 import io.kestra.core.models.flows.FlowWithSource;
 import io.kestra.core.models.flows.PluginDefault;
+import io.kestra.core.models.property.Property;
 import io.kestra.core.repositories.FlowRepositoryInterface;
 import io.kestra.core.utils.TestsUtils;
 import io.kestra.jdbc.runner.JdbcScheduler;
@@ -480,7 +481,7 @@ public class SchedulerScheduleTest extends AbstractSchedulerTest {
                 List.of(
                     Expression.builder()
                         .type(Expression.class.getName())
-                        .expression("{{ trigger.date | date() < now() }}")
+                        .expression(new Property<>("{{ trigger.date | date() < now() }}"))
                         .build()
                 )
             )

--- a/core/src/test/java/io/kestra/core/services/ConditionServiceTest.java
+++ b/core/src/test/java/io/kestra/core/services/ConditionServiceTest.java
@@ -3,6 +3,7 @@ package io.kestra.core.services;
 import com.google.common.collect.ImmutableMap;
 import io.kestra.core.models.conditions.Condition;
 import io.kestra.core.models.conditions.ConditionContext;
+import io.kestra.core.models.property.Property;
 import io.kestra.core.runners.RunContext;
 import io.kestra.plugin.core.condition.ExecutionFlow;
 import io.kestra.plugin.core.condition.ExecutionNamespace;
@@ -51,11 +52,11 @@ class ConditionServiceTest {
 
         List<Condition> conditions = Arrays.asList(
             ExecutionFlow.builder()
-                .namespace(flow.getNamespace())
-                .flowId(flow.getId())
+                .namespace(Property.of(flow.getNamespace()))
+                .flowId(Property.of(flow.getId()))
                 .build(),
             ExecutionNamespace.builder()
-                .namespace(flow.getNamespace())
+                .namespace(Property.of(flow.getNamespace()))
                 .build()
         );
 
@@ -78,8 +79,8 @@ class ConditionServiceTest {
 
         List<Condition> conditions = Collections.singletonList(
             ExecutionFlow.builder()
-                .namespace(flow.getNamespace())
-                .flowId(flow.getId())
+                .namespace(Property.of(flow.getNamespace()))
+                .flowId(Property.of(flow.getId()))
                 .build()
         );
 

--- a/core/src/test/java/io/kestra/core/services/FlowTopologyServiceTest.java
+++ b/core/src/test/java/io/kestra/core/services/FlowTopologyServiceTest.java
@@ -109,11 +109,11 @@ class FlowTopologyServiceTest {
                 io.kestra.plugin.core.trigger.Flow.builder()
                     .conditions(List.of(
                         ExecutionFlow.builder()
-                            .namespace("io.kestra.ee")
-                            .flowId("parent")
+                            .namespace(Property.of("io.kestra.ee"))
+                            .flowId(Property.of("parent"))
                             .build(),
                         ExecutionStatus.builder()
-                            .in(List.of(State.Type.SUCCESS))
+                            .in(Property.of(List.of(State.Type.SUCCESS)))
                             .build()
                     ))
                     .build()
@@ -151,23 +151,23 @@ class FlowTopologyServiceTest {
                 io.kestra.plugin.core.trigger.Flow.builder()
                     .conditions(List.of(
                         ExecutionStatus.builder()
-                            .in(List.of(State.Type.SUCCESS))
+                            .in(Property.of(List.of(State.Type.SUCCESS)))
                             .build(),
                         MultipleCondition.builder()
                             .conditions(Map.of(
                                 "first", ExecutionFlow.builder()
-                                    .namespace("io.kestra.ee")
-                                    .flowId("parent")
+                                    .namespace(Property.of("io.kestra.ee"))
+                                    .flowId(Property.of("parent"))
                                     .build(),
                                 "second", ExecutionFlow.builder()
-                                    .namespace("io.kestra.others")
-                                    .flowId("invalid")
+                                    .namespace(Property.of("io.kestra.others"))
+                                    .flowId(Property.of("invalid"))
                                     .build(),
                                 "filtered", ExecutionStatus.builder()
-                                    .in(List.of(State.Type.SUCCESS))
+                                    .in(Property.of(List.of(State.Type.SUCCESS)))
                                     .build(),
                                 "variables", Expression.builder()
-                                    .expression("{{ true }}")
+                                    .expression(new Property<>("{{ true }}"))
                                     .build()
                             ))
                             .build()

--- a/core/src/test/java/io/kestra/core/services/PluginDefaultServiceTest.java
+++ b/core/src/test/java/io/kestra/core/services/PluginDefaultServiceTest.java
@@ -176,7 +176,7 @@ class PluginDefaultServiceTest {
     }
 
     @Test
-    public void injectFlowAndGlobals() {
+    void injectFlowAndGlobals() {
         String source = """
             id: default-test
             namespace: io.kestra.tests
@@ -222,7 +222,7 @@ class PluginDefaultServiceTest {
         assertThat(((DefaultTester) injected.getTasks().getFirst()).getProperty().getLists().getFirst().getVal().size(), is(1));
         assertThat(((DefaultTester) injected.getTasks().getFirst()).getProperty().getLists().getFirst().getVal().get("key"), is("test"));
         assertThat(((DefaultTriggerTester) injected.getTriggers().getFirst()).getSet(), is(123));
-        assertThat(((Expression) injected.getTriggers().getFirst().getConditions().getFirst()).getExpression(), is("{{ test }}"));
+        assertThat(((Expression) injected.getTriggers().getFirst().getConditions().getFirst()).getExpression().toString(), is("{{ test }}"));
     }
 
     @Test

--- a/core/src/test/java/io/kestra/plugin/core/condition/DateTimeBetweenTest.java
+++ b/core/src/test/java/io/kestra/plugin/core/condition/DateTimeBetweenTest.java
@@ -3,6 +3,7 @@ package io.kestra.plugin.core.condition;
 import com.google.common.collect.ImmutableMap;
 import io.kestra.core.models.executions.Execution;
 import io.kestra.core.models.flows.Flow;
+import io.kestra.core.models.property.Property;
 import io.kestra.core.services.ConditionService;
 import io.kestra.core.utils.TestsUtils;
 import io.kestra.core.junit.annotations.KestraTest;

--- a/core/src/test/java/io/kestra/plugin/core/condition/DateTimeBetweenTest.java
+++ b/core/src/test/java/io/kestra/plugin/core/condition/DateTimeBetweenTest.java
@@ -42,8 +42,8 @@ class DateTimeBetweenTest {
 
         DateTimeBetween build = DateTimeBetween.builder()
             .date(new Property<>(date))
-            .before(before)
-            .after(after)
+            .before(Property.of(before))
+            .after(Property.of(after))
             .build();
 
         boolean test = conditionService.isValid(build, flow, execution);

--- a/core/src/test/java/io/kestra/plugin/core/condition/DateTimeBetweenTest.java
+++ b/core/src/test/java/io/kestra/plugin/core/condition/DateTimeBetweenTest.java
@@ -41,7 +41,7 @@ class DateTimeBetweenTest {
         Execution execution = TestsUtils.mockExecution(flow, ImmutableMap.of());
 
         DateTimeBetween build = DateTimeBetween.builder()
-            .date(date)
+            .date(Property.of(date))
             .before(Property.of(before))
             .after(Property.of(after))
             .build();

--- a/core/src/test/java/io/kestra/plugin/core/condition/DateTimeBetweenTest.java
+++ b/core/src/test/java/io/kestra/plugin/core/condition/DateTimeBetweenTest.java
@@ -41,7 +41,7 @@ class DateTimeBetweenTest {
         Execution execution = TestsUtils.mockExecution(flow, ImmutableMap.of());
 
         DateTimeBetween build = DateTimeBetween.builder()
-            .date(new Property<>(date))
+            .date(date)
             .before(Property.of(before))
             .after(Property.of(after))
             .build();

--- a/core/src/test/java/io/kestra/plugin/core/condition/DateTimeBetweenTest.java
+++ b/core/src/test/java/io/kestra/plugin/core/condition/DateTimeBetweenTest.java
@@ -41,7 +41,7 @@ class DateTimeBetweenTest {
         Execution execution = TestsUtils.mockExecution(flow, ImmutableMap.of());
 
         DateTimeBetween build = DateTimeBetween.builder()
-            .date(date)
+            .date(new Property<>(date))
             .before(before)
             .after(after)
             .build();

--- a/core/src/test/java/io/kestra/plugin/core/condition/DayWeekInMonthTest.java
+++ b/core/src/test/java/io/kestra/plugin/core/condition/DayWeekInMonthTest.java
@@ -3,6 +3,7 @@ package io.kestra.plugin.core.condition;
 import com.google.common.collect.ImmutableMap;
 import io.kestra.core.models.executions.Execution;
 import io.kestra.core.models.flows.Flow;
+import io.kestra.core.models.property.Property;
 import io.kestra.core.services.ConditionService;
 import io.kestra.core.utils.TestsUtils;
 import io.kestra.core.junit.annotations.KestraTest;

--- a/core/src/test/java/io/kestra/plugin/core/condition/DayWeekInMonthTest.java
+++ b/core/src/test/java/io/kestra/plugin/core/condition/DayWeekInMonthTest.java
@@ -44,7 +44,7 @@ class DayWeekInMonthTest {
         Execution execution = TestsUtils.mockExecution(flow, ImmutableMap.of());
 
         DayWeekInMonth build = DayWeekInMonth.builder()
-            .date(date)
+            .date(Property.of(date))
             .dayOfWeek(Property.of(dayOfWeek))
             .dayInMonth(Property.of(dayInMonth))
             .build();

--- a/core/src/test/java/io/kestra/plugin/core/condition/DayWeekInMonthTest.java
+++ b/core/src/test/java/io/kestra/plugin/core/condition/DayWeekInMonthTest.java
@@ -45,8 +45,8 @@ class DayWeekInMonthTest {
 
         DayWeekInMonth build = DayWeekInMonth.builder()
             .date(date)
-            .dayOfWeek(dayOfWeek)
-            .dayInMonth(dayInMonth)
+            .dayOfWeek(Property.of(dayOfWeek))
+            .dayInMonth(Property.of(dayInMonth))
             .build();
 
         boolean test = conditionService.isValid(build, flow, execution);

--- a/core/src/test/java/io/kestra/plugin/core/condition/DayWeekTest.java
+++ b/core/src/test/java/io/kestra/plugin/core/condition/DayWeekTest.java
@@ -3,6 +3,7 @@ package io.kestra.plugin.core.condition;
 import com.google.common.collect.ImmutableMap;
 import io.kestra.core.models.executions.Execution;
 import io.kestra.core.models.flows.Flow;
+import io.kestra.core.models.property.Property;
 import io.kestra.core.services.ConditionService;
 import io.kestra.core.utils.TestsUtils;
 import io.kestra.core.junit.annotations.KestraTest;
@@ -37,8 +38,8 @@ class DayWeekTest {
         Execution execution = TestsUtils.mockExecution(flow, ImmutableMap.of());
 
         DayWeek build = DayWeek.builder()
-            .date(date)
-            .dayOfWeek(dayOfWeek)
+            .date(Property.of(date))
+            .dayOfWeek(Property.of(dayOfWeek))
             .build();
 
         boolean test = conditionService.isValid(build, flow, execution);

--- a/core/src/test/java/io/kestra/plugin/core/condition/ExecutionFlowTest.java
+++ b/core/src/test/java/io/kestra/plugin/core/condition/ExecutionFlowTest.java
@@ -2,6 +2,7 @@ package io.kestra.plugin.core.condition;
 
 import com.google.common.collect.ImmutableMap;
 import io.kestra.core.junit.annotations.KestraTest;
+import io.kestra.core.models.property.Property;
 import org.junit.jupiter.api.Test;
 import io.kestra.core.models.executions.Execution;
 import io.kestra.core.models.flows.Flow;
@@ -9,6 +10,8 @@ import io.kestra.core.services.ConditionService;
 import io.kestra.core.utils.TestsUtils;
 
 import jakarta.inject.Inject;
+
+import java.util.Map;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
@@ -24,8 +27,8 @@ class ExecutionFlowTest {
         Execution execution = TestsUtils.mockExecution(flow, ImmutableMap.of());
 
         ExecutionFlow build = ExecutionFlow.builder()
-            .namespace(flow.getNamespace())
-            .flowId(flow.getId())
+            .namespace(Property.of(flow.getNamespace()))
+            .flowId(Property.of(flow.getId()))
             .build();
 
         boolean test = conditionService.isValid(build, flow, execution);
@@ -39,8 +42,8 @@ class ExecutionFlowTest {
         Execution execution = TestsUtils.mockExecution(flow, ImmutableMap.of());
 
         ExecutionFlow build = ExecutionFlow.builder()
-            .namespace(flow.getNamespace() + "a")
-            .flowId(flow.getId())
+            .namespace(Property.of(flow.getNamespace() + "a"))
+            .flowId(Property.of(flow.getId()))
             .build();
 
         boolean test = conditionService.isValid(build, flow, execution);

--- a/core/src/test/java/io/kestra/plugin/core/condition/ExecutionNamespaceTest.java
+++ b/core/src/test/java/io/kestra/plugin/core/condition/ExecutionNamespaceTest.java
@@ -1,6 +1,7 @@
 package io.kestra.plugin.core.condition;
 
 import com.google.common.collect.ImmutableMap;
+import io.kestra.core.models.property.Property;
 import io.kestra.core.serializers.JacksonMapper;
 import io.kestra.core.junit.annotations.KestraTest;
 import org.junit.jupiter.api.Test;
@@ -27,7 +28,7 @@ class ExecutionNamespaceTest {
         Execution execution = TestsUtils.mockExecution(flow, ImmutableMap.of());
 
         ExecutionNamespace build = ExecutionNamespace.builder()
-            .namespace(flow.getNamespace())
+            .namespace(Property.of(flow.getNamespace()))
             .build();
 
         boolean test = conditionService.isValid(build, flow, execution);
@@ -36,8 +37,8 @@ class ExecutionNamespaceTest {
 
         // Explicit
         build = ExecutionNamespace.builder()
-            .namespace(flow.getNamespace())
-            .comparison(ExecutionNamespace.Comparison.EQUALS)
+            .namespace(Property.of(flow.getNamespace()))
+            .comparison(Property.of(ExecutionNamespace.Comparison.EQUALS))
             .build();
 
         test = conditionService.isValid(build, flow, execution);
@@ -50,7 +51,7 @@ class ExecutionNamespaceTest {
         Execution execution = TestsUtils.mockExecution(flow, ImmutableMap.of());
 
         ExecutionNamespace build = ExecutionNamespace.builder()
-            .namespace(flow.getNamespace() + "a")
+            .namespace(Property.of(flow.getNamespace() + "a"))
             .build();
 
         boolean test = conditionService.isValid(build, flow, execution);
@@ -73,16 +74,16 @@ class ExecutionNamespaceTest {
         assertThat(test, is(true));
 
         build = ExecutionNamespace.builder()
-            .namespace(flow.getNamespace().substring(0, 3))
-            .comparison(ExecutionNamespace.Comparison.PREFIX)
+            .namespace(Property.of(flow.getNamespace().substring(0, 3)))
+            .comparison(Property.of(ExecutionNamespace.Comparison.PREFIX))
             .build();
 
         test = conditionService.isValid(build, flow, execution);
         assertThat(test, is(true));
 
         build = ExecutionNamespace.builder()
-            .namespace(flow.getNamespace().substring(0, 3))
-            .prefix(true)
+            .namespace(Property.of(flow.getNamespace().substring(0, 3)))
+            .prefix(Property.of(true))
             .build();
 
         test = conditionService.isValid(build, flow, execution);
@@ -96,7 +97,7 @@ class ExecutionNamespaceTest {
 
         // Should use EQUALS if prefix is not set
         ExecutionNamespace build = ExecutionNamespace.builder()
-            .namespace(flow.getNamespace().substring(0, 3))
+            .namespace(Property.of(flow.getNamespace().substring(0, 3)))
             .build();
 
         boolean test = conditionService.isValid(build, flow, execution);
@@ -109,8 +110,8 @@ class ExecutionNamespaceTest {
         Execution execution = TestsUtils.mockExecution(flow, ImmutableMap.of());
 
         ExecutionNamespace build = ExecutionNamespace.builder()
-            .namespace(flow.getNamespace().substring(flow.getNamespace().length() - 4))
-            .comparison(ExecutionNamespace.Comparison.SUFFIX)
+            .namespace(Property.of(flow.getNamespace().substring(flow.getNamespace().length() - 4)))
+            .comparison(Property.of(ExecutionNamespace.Comparison.SUFFIX))
             .build();
 
         boolean test = conditionService.isValid(build, flow, execution);

--- a/core/src/test/java/io/kestra/plugin/core/condition/ExecutionOutputsTest.java
+++ b/core/src/test/java/io/kestra/plugin/core/condition/ExecutionOutputsTest.java
@@ -2,6 +2,7 @@ package io.kestra.plugin.core.condition;
 
 import io.kestra.core.models.executions.Execution;
 import io.kestra.core.models.flows.Flow;
+import io.kestra.core.models.property.Property;
 import io.kestra.core.services.ConditionService;
 import io.kestra.core.utils.TestsUtils;
 import io.kestra.core.junit.annotations.KestraTest;
@@ -27,7 +28,7 @@ class ExecutionOutputsTest {
             Map.of("test", "value"));
 
         ExecutionOutputs build = ExecutionOutputs.builder()
-            .expression("{{ trigger.outputs.test == 'value' }}")
+            .expression(new Property<>("{{ trigger.outputs.test == 'value' }}"))
             .build();
 
         boolean test = conditionService.isValid(build, flow, execution);
@@ -44,7 +45,7 @@ class ExecutionOutputsTest {
             Map.of("test", "value"));
 
         ExecutionOutputs build = ExecutionOutputs.builder()
-            .expression("{{ unknown is defined }}")
+            .expression(new Property<>("{{ unknown is defined }}"))
             .build();
 
         boolean test = conditionService.isValid(build, flow, execution);
@@ -58,7 +59,7 @@ class ExecutionOutputsTest {
         Execution execution = TestsUtils.mockExecution(flow, Map.of());
 
         ExecutionOutputs build = ExecutionOutputs.builder()
-            .expression("{{ not evaluated }}")
+            .expression(new Property<>("{{ not evaluated }}"))
             .build();
 
         boolean test = conditionService.isValid(build, flow, execution);

--- a/core/src/test/java/io/kestra/plugin/core/condition/ExecutionStatusTest.java
+++ b/core/src/test/java/io/kestra/plugin/core/condition/ExecutionStatusTest.java
@@ -2,6 +2,7 @@ package io.kestra.plugin.core.condition;
 
 import com.google.common.collect.ImmutableMap;
 import io.kestra.core.junit.annotations.KestraTest;
+import io.kestra.core.models.property.Property;
 import org.junit.jupiter.api.Test;
 import io.kestra.core.models.executions.Execution;
 import io.kestra.core.models.flows.Flow;
@@ -27,7 +28,7 @@ class ExecutionStatusTest {
         Execution execution = TestsUtils.mockExecution(flow, ImmutableMap.of());
 
         ExecutionStatus build = ExecutionStatus.builder()
-            .in(Collections.singletonList(State.Type.SUCCESS))
+            .in(Property.of(Collections.singletonList(State.Type.SUCCESS)))
             .build();
 
         boolean test = conditionService.isValid(build, flow, execution);
@@ -41,7 +42,7 @@ class ExecutionStatusTest {
         Execution execution = TestsUtils.mockExecution(flow, ImmutableMap.of());
 
         ExecutionStatus build = ExecutionStatus.builder()
-            .notIn(Collections.singletonList(State.Type.SUCCESS))
+            .notIn(Property.of(Collections.singletonList(State.Type.SUCCESS)))
             .build();
 
         boolean test = conditionService.isValid(build, flow, execution);
@@ -55,8 +56,8 @@ class ExecutionStatusTest {
         Execution execution = TestsUtils.mockExecution(flow, ImmutableMap.of());
 
         ExecutionStatus build = ExecutionStatus.builder()
-            .in(Collections.singletonList(State.Type.CREATED))
-            .notIn(Collections.singletonList(State.Type.SUCCESS))
+            .in(Property.of(Collections.singletonList(State.Type.CREATED)))
+            .notIn(Property.of(Collections.singletonList(State.Type.SUCCESS)))
             .build();
 
         boolean test = conditionService.isValid(build, flow, execution);

--- a/core/src/test/java/io/kestra/plugin/core/condition/ExpressionTest.java
+++ b/core/src/test/java/io/kestra/plugin/core/condition/ExpressionTest.java
@@ -2,6 +2,7 @@ package io.kestra.plugin.core.condition;
 
 import com.google.common.collect.ImmutableMap;
 import io.kestra.core.junit.annotations.KestraTest;
+import io.kestra.core.models.property.Property;
 import org.junit.jupiter.api.Test;
 import io.kestra.core.models.executions.Execution;
 import io.kestra.core.models.flows.Flow;
@@ -24,7 +25,7 @@ class ExpressionTest {
         Execution execution = TestsUtils.mockExecution(flow, ImmutableMap.of("test", "value"));
 
         Expression build = Expression.builder()
-            .expression("{{ flow.id }}")
+            .expression(new Property<>("{{ flow.id }}"))
             .build();
 
         boolean test = conditionService.isValid(build, flow, execution);
@@ -38,7 +39,7 @@ class ExpressionTest {
         Execution execution = TestsUtils.mockExecution(flow, ImmutableMap.of("test", "value"));
 
         Expression build = Expression.builder()
-            .expression("{{ unknown is defined }}")
+            .expression(new Property<>("{{ unknown is defined }}"))
             .build();
 
         boolean test = conditionService.isValid(build, flow, execution);

--- a/core/src/test/java/io/kestra/plugin/core/condition/HasRetryAttemptTest.java
+++ b/core/src/test/java/io/kestra/plugin/core/condition/HasRetryAttemptTest.java
@@ -6,6 +6,7 @@ import io.kestra.core.models.executions.TaskRun;
 import io.kestra.core.models.executions.TaskRunAttempt;
 import io.kestra.core.models.flows.Flow;
 import io.kestra.core.models.flows.State;
+import io.kestra.core.models.property.Property;
 import io.kestra.core.services.ConditionService;
 import io.kestra.core.utils.TestsUtils;
 import io.kestra.core.junit.annotations.KestraTest;
@@ -41,7 +42,7 @@ class HasRetryAttemptTest {
         ));
 
         HasRetryAttempt build = HasRetryAttempt.builder()
-            .in(Collections.singletonList(State.Type.KILLED))
+            .in(Property.of(Collections.singletonList(State.Type.KILLED)))
             .build();
 
         boolean test = conditionService.isValid(build, flow, execution);
@@ -49,7 +50,7 @@ class HasRetryAttemptTest {
         assertThat(test, is(true));
 
         build = HasRetryAttempt.builder()
-            .in(Collections.singletonList(State.Type.FAILED))
+            .in(Property.of(Collections.singletonList(State.Type.FAILED)))
             .build();
 
         test = conditionService.isValid(build, flow, execution);

--- a/core/src/test/java/io/kestra/plugin/core/condition/MultipleConditionTest.java
+++ b/core/src/test/java/io/kestra/plugin/core/condition/MultipleConditionTest.java
@@ -2,6 +2,7 @@ package io.kestra.plugin.core.condition;
 
 import com.google.common.collect.ImmutableMap;
 import io.kestra.core.models.conditions.Condition;
+import io.kestra.core.models.property.Property;
 import io.kestra.core.models.triggers.multipleflows.MultipleConditionStorageInterface;
 import io.kestra.core.junit.annotations.KestraTest;
 import org.junit.jupiter.api.Test;
@@ -33,10 +34,10 @@ class MultipleConditionTest {
             .conditions(
                 ImmutableMap.of(
                 "first", ExecutionStatus.builder()
-                    .in(Collections.singletonList(State.Type.SUCCESS))
+                    .in(Property.of(Collections.singletonList(State.Type.SUCCESS)))
                     .build(),
                 "second", Expression.builder()
-                    .expression("{{ flow.id }}")
+                    .expression(new Property<>("{{ flow.id }}"))
                     .build()
             ))
             .build();

--- a/core/src/test/java/io/kestra/plugin/core/condition/NotTest.java
+++ b/core/src/test/java/io/kestra/plugin/core/condition/NotTest.java
@@ -4,6 +4,7 @@ import com.google.common.collect.ImmutableMap;
 import io.kestra.core.models.conditions.Condition;
 import io.kestra.core.models.executions.Execution;
 import io.kestra.core.models.flows.Flow;
+import io.kestra.core.models.property.Property;
 import io.kestra.core.services.ConditionService;
 import io.kestra.core.utils.TestsUtils;
 import io.kestra.core.junit.annotations.KestraTest;
@@ -31,8 +32,8 @@ class NotTest {
             Arguments.of(
                 Collections.singletonList(
                     DayWeek.builder()
-                        .date("2013-09-08")
-                        .dayOfWeek(DayOfWeek.SUNDAY)
+                        .date(Property.of("2013-09-08"))
+                        .dayOfWeek(Property.of(DayOfWeek.SUNDAY))
                         .build()
                 ),
                 false
@@ -40,12 +41,12 @@ class NotTest {
             Arguments.of(
                 Arrays.asList(
                     DayWeek.builder()
-                        .date("2013-09-08")
-                        .dayOfWeek(DayOfWeek.SATURDAY)
+                        .date(Property.of("2013-09-08"))
+                        .dayOfWeek(Property.of(DayOfWeek.SATURDAY))
                         .build(),
                     DayWeek.builder()
-                        .date("2013-09-08")
-                        .dayOfWeek(DayOfWeek.MONDAY)
+                        .date(Property.of("2013-09-08"))
+                        .dayOfWeek(Property.of(DayOfWeek.MONDAY))
                         .build()
                 ),
                 true
@@ -53,12 +54,12 @@ class NotTest {
             Arguments.of(
                 Arrays.asList(
                     DayWeek.builder()
-                        .date("2013-09-08")
-                        .dayOfWeek(DayOfWeek.SUNDAY)
+                        .date(Property.of("2013-09-08"))
+                        .dayOfWeek(Property.of(DayOfWeek.SUNDAY))
                         .build(),
                     DayWeek.builder()
-                        .date("2013-09-08")
-                        .dayOfWeek(DayOfWeek.MONDAY)
+                        .date(Property.of("2013-09-08"))
+                        .dayOfWeek(Property.of(DayOfWeek.MONDAY))
                         .build()
                 ),
                 false

--- a/core/src/test/java/io/kestra/plugin/core/condition/OrTest.java
+++ b/core/src/test/java/io/kestra/plugin/core/condition/OrTest.java
@@ -4,6 +4,7 @@ import com.google.common.collect.ImmutableMap;
 import io.kestra.core.models.conditions.Condition;
 import io.kestra.core.models.executions.Execution;
 import io.kestra.core.models.flows.Flow;
+import io.kestra.core.models.property.Property;
 import io.kestra.core.services.ConditionService;
 import io.kestra.core.utils.TestsUtils;
 import io.kestra.core.junit.annotations.KestraTest;
@@ -31,8 +32,8 @@ class OrTest {
             Arguments.of(
                 Collections.singletonList(
                     DayWeek.builder()
-                        .date("2013-09-08")
-                        .dayOfWeek(DayOfWeek.SUNDAY)
+                        .date(Property.of("2013-09-08"))
+                        .dayOfWeek(Property.of(DayOfWeek.SUNDAY))
                         .build()
                 ),
                 true
@@ -40,12 +41,12 @@ class OrTest {
             Arguments.of(
                 Arrays.asList(
                     DayWeek.builder()
-                        .date("2013-09-08")
-                        .dayOfWeek(DayOfWeek.SATURDAY)
+                        .date(Property.of("2013-09-08"))
+                        .dayOfWeek(Property.of(DayOfWeek.SATURDAY))
                         .build(),
                     DayWeek.builder()
-                        .date("2013-09-08")
-                        .dayOfWeek(DayOfWeek.MONDAY)
+                        .date(Property.of("2013-09-08"))
+                        .dayOfWeek(Property.of(DayOfWeek.MONDAY))
                         .build()
                 ),
                 false
@@ -53,12 +54,12 @@ class OrTest {
             Arguments.of(
                 Arrays.asList(
                     DayWeek.builder()
-                        .date("2013-09-08")
-                        .dayOfWeek(DayOfWeek.SUNDAY)
+                        .date(Property.of("2013-09-08"))
+                        .dayOfWeek(Property.of(DayOfWeek.SUNDAY))
                         .build(),
                     DayWeek.builder()
-                        .date("2013-09-08")
-                        .dayOfWeek(DayOfWeek.MONDAY)
+                        .date(Property.of("2013-09-08"))
+                        .dayOfWeek(Property.of(DayOfWeek.MONDAY))
                         .build()
                 ),
                 true

--- a/core/src/test/java/io/kestra/plugin/core/condition/PublicHolidayTest.java
+++ b/core/src/test/java/io/kestra/plugin/core/condition/PublicHolidayTest.java
@@ -3,6 +3,7 @@ package io.kestra.plugin.core.condition;
 import com.google.common.collect.ImmutableMap;
 import io.kestra.core.models.executions.Execution;
 import io.kestra.core.models.flows.Flow;
+import io.kestra.core.models.property.Property;
 import io.kestra.core.services.ConditionService;
 import io.kestra.core.utils.TestsUtils;
 import io.kestra.core.junit.annotations.KestraTest;
@@ -23,20 +24,20 @@ class PublicHolidayTest {
         Execution execution = TestsUtils.mockExecution(flow, ImmutableMap.of());
 
         PublicHoliday publicHoliday = PublicHoliday.builder()
-            .date("2023-01-01")
+            .date(Property.of("2023-01-01"))
             .build();
         assertThat(conditionService.isValid(publicHoliday, flow, execution), is(true));
 
         publicHoliday = PublicHoliday.builder()
-            .date("2023-07-14")
-            .country("FR")
+            .date(Property.of("2023-07-14"))
+            .country(Property.of("FR"))
             .build();
         assertThat(conditionService.isValid(publicHoliday, flow, execution), is(true));
 
         publicHoliday = PublicHoliday.builder()
-            .date("2023-03-08")
-            .country("DE")
-            .subDivision("BE")
+            .date(Property.of("2023-03-08"))
+            .country(Property.of("DE"))
+            .subDivision(Property.of("BE"))
             .build();
         assertThat(conditionService.isValid(publicHoliday, flow, execution), is(true));
     }
@@ -47,14 +48,14 @@ class PublicHolidayTest {
         Execution execution = TestsUtils.mockExecution(flow, ImmutableMap.of());
 
         PublicHoliday publicHoliday = PublicHoliday.builder()
-            .date("2023-01-02")
-            .country("FR")
+            .date(Property.of("2023-01-02"))
+            .country(Property.of("FR"))
             .build();
         assertThat(conditionService.isValid(publicHoliday, flow, execution), is(false));
 
         publicHoliday = PublicHoliday.builder()
-            .date("2023-03-08")
-            .country("DE")
+            .date(Property.of("2023-03-08"))
+            .country(Property.of("DE"))
             .build();
         assertThat(conditionService.isValid(publicHoliday, flow, execution), is(false));
     }

--- a/core/src/test/java/io/kestra/plugin/core/condition/TimeBetweenTest.java
+++ b/core/src/test/java/io/kestra/plugin/core/condition/TimeBetweenTest.java
@@ -3,6 +3,7 @@ package io.kestra.plugin.core.condition;
 import com.google.common.collect.ImmutableMap;
 import io.kestra.core.models.executions.Execution;
 import io.kestra.core.models.flows.Flow;
+import io.kestra.core.models.property.Property;
 import io.kestra.core.services.ConditionService;
 import io.kestra.core.utils.TestsUtils;
 import io.kestra.core.junit.annotations.KestraTest;
@@ -40,7 +41,7 @@ class TimeBetweenTest {
         Execution execution = TestsUtils.mockExecution(flow, ImmutableMap.of());
 
         TimeBetween build = TimeBetween.builder()
-            .date(date)
+            .date(Property.of(date))
             .before(before)
             .after(after)
             .build();

--- a/core/src/test/java/io/kestra/plugin/core/condition/TimeBetweenTest.java
+++ b/core/src/test/java/io/kestra/plugin/core/condition/TimeBetweenTest.java
@@ -42,8 +42,8 @@ class TimeBetweenTest {
 
         TimeBetween build = TimeBetween.builder()
             .date(Property.of(date))
-            .before(before)
-            .after(after)
+            .before(Property.of(before))
+            .after(Property.of(after))
             .build();
 
         boolean test = conditionService.isValid(build, flow, execution);

--- a/core/src/test/java/io/kestra/plugin/core/condition/WeekendTest.java
+++ b/core/src/test/java/io/kestra/plugin/core/condition/WeekendTest.java
@@ -3,6 +3,7 @@ package io.kestra.plugin.core.condition;
 import com.google.common.collect.ImmutableMap;
 import io.kestra.core.models.executions.Execution;
 import io.kestra.core.models.flows.Flow;
+import io.kestra.core.models.property.Property;
 import io.kestra.core.services.ConditionService;
 import io.kestra.core.utils.TestsUtils;
 import io.kestra.core.junit.annotations.KestraTest;
@@ -38,7 +39,7 @@ class WeekendTest {
         Execution execution = TestsUtils.mockExecution(flow, ImmutableMap.of());
 
         Weekend build = Weekend.builder()
-            .date(date)
+            .date(new Property<>(date))
             .build();
 
         boolean test = conditionService.isValid(build, flow, execution);

--- a/core/src/test/java/io/kestra/plugin/core/trigger/ScheduleTest.java
+++ b/core/src/test/java/io/kestra/plugin/core/trigger/ScheduleTest.java
@@ -323,7 +323,7 @@ class ScheduleTest {
                     .type(DayWeekInMonth.class.getName())
                     .dayOfWeek(Property.of(DayOfWeek.MONDAY))
                     .dayInMonth(Property.of(DayWeekInMonth.DayInMonth.FIRST))
-                    .date("{{ trigger.date }}")
+                    .date(new Property<>("{{ trigger.date }}"))
                     .build()
             ))
             .build();
@@ -357,7 +357,7 @@ class ScheduleTest {
                 DateTimeBetween.builder()
                     .type(DateTimeBetween.class.getName())
                     .before(Property.of(ZonedDateTime.parse("2021-08-03T12:00:00+02:00")))
-                    .date("{{ trigger.date }}")
+                    .date(new Property<>("{{ trigger.date }}"))
                     .build()
             ))
             .build();

--- a/core/src/test/java/io/kestra/plugin/core/trigger/ScheduleTest.java
+++ b/core/src/test/java/io/kestra/plugin/core/trigger/ScheduleTest.java
@@ -315,6 +315,7 @@ class ScheduleTest {
     void conditions() throws Exception {
         Schedule trigger = Schedule.builder()
             .id("schedule")
+            .type(Schedule.class.getName())
             .cron("0 12 * * 1")
             .timezone("Europe/Paris")
             .conditions(List.of(
@@ -348,6 +349,7 @@ class ScheduleTest {
     void impossibleNextConditions() throws Exception {
         Schedule trigger = Schedule.builder()
             .id("schedule")
+            .type(Schedule.class.getName())
             .cron("0 12 * * 1")
             .timezone("Europe/Paris")
             .conditions(List.of(

--- a/core/src/test/java/io/kestra/plugin/core/trigger/ScheduleTest.java
+++ b/core/src/test/java/io/kestra/plugin/core/trigger/ScheduleTest.java
@@ -320,8 +320,9 @@ class ScheduleTest {
             .timezone("Europe/Paris")
             .conditions(List.of(
                 DayWeekInMonth.builder()
-                    .dayOfWeek(DayOfWeek.MONDAY)
-                    .dayInMonth(DayWeekInMonth.DayInMonth.FIRST)
+                    .type(DayWeekInMonth.class.getName())
+                    .dayOfWeek(Property.of(DayOfWeek.MONDAY))
+                    .dayInMonth(Property.of(DayWeekInMonth.DayInMonth.FIRST))
                     .date("{{ trigger.date }}")
                     .build()
             ))
@@ -356,7 +357,7 @@ class ScheduleTest {
                 DateTimeBetween.builder()
                     .type(DateTimeBetween.class.getName())
                     .before(Property.of(ZonedDateTime.parse("2021-08-03T12:00:00+02:00")))
-                    .date(new Property<>("{{ trigger.date }}"))
+                    .date("{{ trigger.date }}")
                     .build()
             ))
             .build();

--- a/core/src/test/java/io/kestra/plugin/core/trigger/ScheduleTest.java
+++ b/core/src/test/java/io/kestra/plugin/core/trigger/ScheduleTest.java
@@ -355,7 +355,7 @@ class ScheduleTest {
             .conditions(List.of(
                 DateTimeBetween.builder()
                     .type(DateTimeBetween.class.getName())
-                    .before(ZonedDateTime.parse("2021-08-03T12:00:00+02:00"))
+                    .before(Property.of(ZonedDateTime.parse("2021-08-03T12:00:00+02:00")))
                     .date(new Property<>("{{ trigger.date }}"))
                     .build()
             ))

--- a/core/src/test/java/io/kestra/plugin/core/trigger/ScheduleTest.java
+++ b/core/src/test/java/io/kestra/plugin/core/trigger/ScheduleTest.java
@@ -354,8 +354,9 @@ class ScheduleTest {
             .timezone("Europe/Paris")
             .conditions(List.of(
                 DateTimeBetween.builder()
+                    .type(DateTimeBetween.class.getName())
                     .before(ZonedDateTime.parse("2021-08-03T12:00:00+02:00"))
-                    .date("{{ trigger.date }}")
+                    .date(new Property<>("{{ trigger.date }}"))
                     .build()
             ))
             .build();

--- a/script/src/test/java/io/kestra/plugin/scripts/runners/LogConsumerTest.java
+++ b/script/src/test/java/io/kestra/plugin/scripts/runners/LogConsumerTest.java
@@ -121,6 +121,6 @@ class LogConsumerTest {
         assertThat(logs.stream().filter(m -> m.getLevel().equals(Level.INFO)).count(), is(1L));
         assertThat(logs.stream().filter(m -> m.getLevel().equals(Level.ERROR)).count(), is(1L));
         assertThat(logs.stream().filter(m -> m.getLevel().equals(Level.TRACE)).filter(m -> m.getMessage().contains("Trace 2")).count(), is(1L));
-        assertThat(logs.stream().filter(m -> m.getLevel().equals(Level.TRACE)).count(), greaterThanOrEqualTo(5L));
+        assertThat(logs.stream().filter(m -> m.getLevel().equals(Level.TRACE)).count(), greaterThanOrEqualTo(4L));
     }
 }


### PR DESCRIPTION
Issue when refactoring to Dynamic properties. 
As we can see some tests are failing when moving `String date` to `Property<String> date` for both classes `DayWeekInMonth` and `DateTimeBetween`. 

The render is done correctly but some tests fail : 

- test ScheduleTest.impossibleNextConditions() : for this assertion `assertThat(vars.containsKey("next"), is(false));`
- test ScheduleTest.conditions(): for this assertion `assertThat(dateFromVars(vars.get("next"), next), is(next));`

It seems to always fail with this `next` variable.

![image](https://github.com/user-attachments/assets/4a1ad617-d598-4210-9cee-f4b2b6e7b140)
