### PR TITLE
feat(autocomplete): complete auto suggestions when cursor is in pebble block

### DIFF
--- a/ui/src/components/inputs/MonacoEditor.vue
+++ b/ui/src/components/inputs/MonacoEditor.vue
@@ -402,6 +402,7 @@
                 label: label,
                 insertText: value,
                 insertTextRules: value.includes("${1:") ? monaco.languages.CompletionItemInsertTextRule.InsertAsSnippet : undefined,
+                sortText: value.includes("(") ? "b" + value : "a" + value,
                 range: {
                     startLineNumber: position.lineNumber,
                     endLineNumber: position.lineNumber,
@@ -431,69 +432,6 @@
                 };
             }
         }));
-
-        autoCompletionProviders.value.push(monaco.languages.registerCompletionItemProvider(["yaml", "plaintext"], {
-            triggerCharacters: ["{"],
-            async provideCompletionItems(model, position) {
-                if (!isInsidePebbleBlock(model, position)) {
-                    return {suggestions: []};
-                }
-
-                const lineContent = model.getLineContent(position.lineNumber);
-                const beforeCursor = lineContent.substring(0, position.column);
-                const afterCursor = lineContent.substring(position.column);
-
-                const lastOpen = beforeCursor.lastIndexOf("{{");
-                const nextClose = afterCursor.indexOf("}}");
-
-                const openIndex = lastOpen + 2;
-                const closeIndex = nextClose !== -1 ? position.column + nextClose : lineContent.length;
-                const fullContent = lineContent.substring(openIndex, closeIndex).trim();
-
-                const word = fullContent;
-
-                const suggestions = (await yamlAutoCompletionProvider.pebbleFunctionAutoCompletion())
-                    .filter(func => func.toLowerCase().includes(word.toLowerCase()))
-                    .map(func => ({
-                        kind: monaco.languages.CompletionItemKind.Function,
-                        label: func,
-                        insertText: func,
-                        documentation: "Pebble function",
-                        range: {
-                            startLineNumber: position.lineNumber,
-                            endLineNumber: position.lineNumber,
-                            startColumn: openIndex + 1,
-                            endColumn: closeIndex
-                        }
-                    }));
-
-                return {suggestions};
-            }
-        }));
-
-        const isInsidePebbleBlock = (model, position) => {
-            const lineContent = model.getLineContent(position.lineNumber);
-            const beforeCursor = lineContent.substring(0, position.column);
-            const afterCursor = lineContent.substring(position.column);
-
-            const lastOpen = beforeCursor.lastIndexOf("{{");
-            const nextClose = afterCursor.indexOf("}}");
-
-            return (
-                lastOpen !== -1 &&
-                (nextClose !== -1 || !afterCursor.includes("}}")) &&
-                position.column > lastOpen + 2
-            );
-        }
-
-        localEditor.onDidChangeCursorSelection((e) => {
-            const position = e.selection.getPosition();
-            const model = localEditor.getModel();
-
-            if (isInsidePebbleBlock(model, position)) {
-                localEditor.trigger("keyboard", "editor.action.triggerSuggest", {});
-            }
-        });
 
         autoCompletionProviders.value.push(monaco.languages.registerCompletionItemProvider(["yaml", "plaintext"], {
             triggerCharacters: ["("],

--- a/ui/src/components/inputs/MonacoEditor.vue
+++ b/ui/src/components/inputs/MonacoEditor.vue
@@ -89,7 +89,7 @@
         theme?: "light" | "dark",
         language?: string,
         extension?: string,
-        options?: monaco.editor.IStandaloneEditorConstructionOptions & {renderSideBySide?: boolean},
+        options?: monaco.editor.IStandaloneEditorConstructionOptions & { renderSideBySide?: boolean },
         schemaType?: string,
         diffEditor?: boolean,
         input?: boolean,
@@ -433,6 +433,69 @@
         }));
 
         autoCompletionProviders.value.push(monaco.languages.registerCompletionItemProvider(["yaml", "plaintext"], {
+            triggerCharacters: ["{"],
+            async provideCompletionItems(model, position) {
+                if (!isInsidePebbleBlock(model, position)) {
+                    return {suggestions: []};
+                }
+
+                const lineContent = model.getLineContent(position.lineNumber);
+                const beforeCursor = lineContent.substring(0, position.column);
+                const afterCursor = lineContent.substring(position.column);
+
+                const lastOpen = beforeCursor.lastIndexOf("{{");
+                const nextClose = afterCursor.indexOf("}}");
+
+                const openIndex = lastOpen + 2;
+                const closeIndex = nextClose !== -1 ? position.column + nextClose : lineContent.length;
+                const fullContent = lineContent.substring(openIndex, closeIndex).trim();
+
+                const word = fullContent;
+
+                const suggestions = (await yamlAutoCompletionProvider.pebbleFunctionAutoCompletion())
+                    .filter(func => func.toLowerCase().includes(word.toLowerCase()))
+                    .map(func => ({
+                        kind: monaco.languages.CompletionItemKind.Function,
+                        label: func,
+                        insertText: func,
+                        documentation: "Pebble function",
+                        range: {
+                            startLineNumber: position.lineNumber,
+                            endLineNumber: position.lineNumber,
+                            startColumn: openIndex + 1,
+                            endColumn: closeIndex
+                        }
+                    }));
+
+                return {suggestions};
+            }
+        }));
+
+        const isInsidePebbleBlock = (model, position) => {
+            const lineContent = model.getLineContent(position.lineNumber);
+            const beforeCursor = lineContent.substring(0, position.column);
+            const afterCursor = lineContent.substring(position.column);
+
+            const lastOpen = beforeCursor.lastIndexOf("{{");
+            const nextClose = afterCursor.indexOf("}}");
+
+            return (
+                lastOpen !== -1 &&
+                (nextClose !== -1 || !afterCursor.includes("}}")) &&
+                position.column > lastOpen + 2
+            );
+        }
+
+        localEditor.onDidChangeCursorSelection((e) => {
+            const position = e.selection.getPosition();
+            const model = localEditor.getModel();
+
+            if (isInsidePebbleBlock(model, position)) {
+                localEditor.trigger("keyboard", "editor.action.triggerSuggest", {});
+            }
+        });
+
+        autoCompletionProviders.value.push(monaco.languages.registerCompletionItemProvider(["yaml", "plaintext"], {
             triggerCharacters: ["("],
             async provideCompletionItems(model, position) {
                 const source = model.getValue();
@@ -590,12 +653,12 @@
         });
 
         const $el = editorRef.value
-        if($el !== null) {
+        if ($el !== null) {
             suggestWidgetResizeObserver.value.observe($el.querySelector(".overflowingContentWidgets")!, {childList: true})
         }
     }
 
-    async function initMonaco () {
+    async function initMonaco() {
         let options = {
             ...{
                 value: props.value,
@@ -610,7 +673,7 @@
         };
 
         if (props.diffEditor) {
-            if(editorRef.value){
+            if (editorRef.value) {
                 localDiffEditor = monaco.editor.createDiffEditor(editorRef.value, {
                     ...options,
                     ignoreTrimWhitespace: false
@@ -651,7 +714,7 @@
                 when: "editorFocus"
             });
 
-            if(editorRef.value){
+            if (editorRef.value) {
                 localEditor = monaco.editor.create(editorRef.value, options);
             }
 
@@ -731,7 +794,7 @@
     function destroy() {
         disposeObservers();
         autoCompletionProviders.value.forEach(provider => provider.dispose());
-        if(props.diffEditor) {
+        if (props.diffEditor) {
             localDiffEditor?.getModel()?.modified?.dispose();
             localDiffEditor?.getModel()?.original?.dispose();
             localDiffEditor?.dispose();
@@ -752,20 +815,20 @@
 </script>
 
 <style scoped lang="scss">
-.ks-monaco-editor {
-    position: absolute;
-    width: 100%;
-    height: 100%;
-    outline: none;
-}
+    .ks-monaco-editor {
+        position: absolute;
+        width: 100%;
+        height: 100%;
+        outline: none;
+    }
 
-.main-editor>#editorWrapper .monaco-editor {
-    padding: 1rem 0 0 1rem;
-}
+    .main-editor > #editorWrapper .monaco-editor {
+        padding: 1rem 0 0 1rem;
+    }
 </style>
 
 <style lang="scss">
-@import "../../styles/layout/root-dark";
+    @import "../../styles/layout/root-dark";
 
     .custom-dark-vs-theme .ks-monaco-editor .sticky-widget {
         background-color: $input-bg;

--- a/ui/src/override/services/flowAutoCompletionProvider.ts
+++ b/ui/src/override/services/flowAutoCompletionProvider.ts
@@ -216,4 +216,44 @@ export class FlowAutoCompletion extends YamlNoAutoCompletion {
         }
         return Promise.resolve([]);
     }
+
+    pebbleFunctionAutoCompletion(): Promise<string[]> {
+        return Promise.resolve([
+            // File-related functions
+            "fileExists",
+            "fileSize",
+            "isFileEmpty",
+            "read",
+            "fileURI",
+            
+            // Data format functions
+            "json",
+            "fromJson",
+            "yaml",
+            "fromIon",
+            
+            // Context and logging functions
+            "printContext",
+            "fetchContext",
+            "errorLogs",
+            "render",
+            "renderOnce",
+            "currentEachOutput",
+            
+            // Utility functions
+            "uuid",
+            "id",
+            "now",
+            
+            // Security functions
+            "secret",
+            "kv",
+            "encrypt",
+            "decrypt",
+            
+            // Random functions
+            "randomInt",
+            "randomPort"
+        ]);
+    }
 }

--- a/ui/src/override/services/flowAutoCompletionProvider.ts
+++ b/ui/src/override/services/flowAutoCompletionProvider.ts
@@ -1,6 +1,6 @@
 import type {Store} from "vuex";
 import type {JSONSchema} from "@kestra-io/ui-libs";
-import {YamlUtils as YAML_UTILS, YamlElement} from "@kestra-io/ui-libs";
+import {YamlElement, YamlUtils as YAML_UTILS} from "@kestra-io/ui-libs";
 import {QUOTE, YamlNoAutoCompletion} from "../../services/autoCompletionProvider";
 import RegexProvider from "../../utils/regex";
 
@@ -32,9 +32,29 @@ export class FlowAutoCompletion extends YamlNoAutoCompletion {
             "globals",
             "parents",
             "error",
+            "kestra",
             "secret(namespace=${1:flow.namespace}, key=" + QUOTE + "${2:MY_SECRET}" + QUOTE + ")",
             "kv(namespace=${1:flow.namespace}, key=" + QUOTE + "${2:my_key}" + QUOTE + ")",
-            "kestra"
+            "currentEachOutput(outputs=${1:outputs.forEach})",
+            "decrypt(key=${1:secret('encryption_key')}, encrypted=${2:outputs.request.encryptedBody})",
+            "encrypt(key=${1:secret('encryption_key')}, plaintext=${2:'value_to_encrypt'})",
+            "errorLogs()",
+            "fetchContext()",
+            "isFileEmpty(namespace=${1:flow.namespace}, path=${2:outputs.download.uri})",
+            "fileExists(namespace=${1:flow.namespace}, path=${2:outputs.download.uri})",
+            "fileSize(namespace=${1:flow.namespace}, path=${2:outputs.download.uri})",
+            "read(namespace=${1:flow.namespace}, path=${2:'a/namespace/file'})",
+            "render(toRender=${1:inputs.inputWithPebble}, recursive=${2:true})",
+            "renderOnce(toRender=${1:inputs.inputWithPebble})",
+            "fileURI(path=${1:'a/namespace/file'})",
+            "fromIon(ion=${1:read('ion/namespace/file')})",
+            "fromJson(json=${1:read('json/namespace/file')})",
+            "yaml(yaml=${1:inputs.yamlInput})",
+            "uuid()",
+            "id()",
+            "now()",
+            "randomInt(lower=${1:0}, upper=${2:10})",
+            "randomPort()"
         ]);
     }
 
@@ -215,45 +235,5 @@ export class FlowAutoCompletion extends YamlNoAutoCompletion {
             }
         }
         return Promise.resolve([]);
-    }
-
-    pebbleFunctionAutoCompletion(): Promise<string[]> {
-        return Promise.resolve([
-            // File-related functions
-            "fileExists",
-            "fileSize",
-            "isFileEmpty",
-            "read",
-            "fileURI",
-            
-            // Data format functions
-            "json",
-            "fromJson",
-            "yaml",
-            "fromIon",
-            
-            // Context and logging functions
-            "printContext",
-            "fetchContext",
-            "errorLogs",
-            "render",
-            "renderOnce",
-            "currentEachOutput",
-            
-            // Utility functions
-            "uuid",
-            "id",
-            "now",
-            
-            // Security functions
-            "secret",
-            "kv",
-            "encrypt",
-            "decrypt",
-            
-            // Random functions
-            "randomInt",
-            "randomPort"
-        ]);
     }
 }


### PR DESCRIPTION
<!-- Thanks for submitting a Pull Request to Kestra. To help us review your contribution, please follow the guidelines below:

- Make sure that your commits follow the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) specification e.g. `feat(ui): add a new navigation menu item` or `fix(core): fix a bug in the core model` or `docs: update the README.md`. This will help us automatically generate the changelog.
- The title should briefly summarize the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share a flow example to help the reviewer understand and QA the change.
- Use "closes" to automatically close an issue. For example, `closes #1234` will close issue #1234. -->

### What changes are being made and why?

<!-- Please include a brief summary of the changes included in this PR e.g. closes #1234. -->

closes #7733 
This PR enhances the Pebble block autocomplete experience in the code editor by:

- Triggering suggestions when the user clicks inside a `{{ ... }}` block (not just when typing).
- Matching the entire expression inside the block rather than just the characters before the cursor.
- Supporting partial matches — for example, typing `file` now correctly suggests `isFileExists`.

This improves usability and relevance of suggestions, especially for users navigating code via mouse or editing within larger expressions.

---

### How the changes have been QAed?

<!-- Include example code that shows how this PR has been QAed. The code should present a complete yet easily reproducible flow.

```yaml
# Your example flow code here
```

Note that this is not a replacement for unit tests but rather a way to demonstrate how the changes work in a real-life scenario, as the end-user would experience them.

Remove this section if this change applies to all flows or to the documentation only. -->

Autocomplete was manually tested inside the Monaco-based editor with various cursor positions and input patterns. Example:
<img width="720" alt="Screenshot 2025-04-06 at 12 53 42 AM" src="https://github.com/user-attachments/assets/aa70916a-a4e1-4310-bef4-ae3a0077e71a" />

<img width="732" alt="Screenshot 2025-04-06 at 12 54 09 AM" src="https://github.com/user-attachments/assets/2bdbb01d-10f2-4cab-beb5-3ce34070f468" />

<img width="686" alt="Screenshot 2025-04-06 at 12 49 55 AM" src="https://github.com/user-attachments/assets/855d9388-0bd8-450a-90c7-3bdcc139e857" />

---

### Setup Instructions

<!--If there are any setup requirements like API keys or trial accounts, kindly include brief bullet-points-description outlining the setup process below.

- [External System Documentation](URL)
- Steps to set up the necessary resources

If there are no setup requirements, you can remove this section.

Thank you for your contribution. ❤️  -->

No special setup is required. The functionality works as part of the existing Monaco editor integration.
