### PR TITLE
fix: [#8282] - Fixed issue with Devcontainer not running on arm64 architecture

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:24.04
 
+ARG BUILDPLATFORM
 ARG DEBIAN_FRONTEND=noninteractive
-ARG TARGETPLATFORM
 
 USER root
 WORKDIR /root
@@ -32,18 +32,23 @@ ENV SHELL=/bin/zsh
 # --------------------------------------
 # Java
 # --------------------------------------
-ARG PLATFORM_ARCHITECTURE
-RUN case "$TARGETPLATFORM" in \
-  "linux/amd64") PLATFORM_ARCHITECTURE="linux-x64" ;; \
-  "linux/arm64") PLATFORM_ARCHITECTURE="linux-aarch64" ;; \
-  "darwin/arm64") PLATFORM_ARCHITECTURE="macos-aarch64" ;; \
-  *) echo "Unsupported TARGETPLATFORM: $TARGETPLATFORM" && exit 1 ;; \
+ARG OS_ARCHITECTURE
+
+RUN mkdir -p /usr/java
+RUN echo "Building on platform: $BUILDPLATFORM"
+RUN case "$BUILDPLATFORM" in \
+  "linux/amd64") OS_ARCHITECTURE="linux-x64" ;; \
+  "linux/arm64") OS_ARCHITECTURE="linux-aarch64" ;; \
+  "darwin/amd64") OS_ARCHITECTURE="macos-x64" ;; \
+  "darwin/arm64") OS_ARCHITECTURE="macos-aarch64" ;; \
+  *) echo "Unsupported BUILDPLATFORM: $BUILDPLATFORM" && exit 1 ;; \
   esac && \
-  wget https://download.java.net/java/GA/jdk21.0.2/f2283984656d49d69e91c558476027ac/13/GPL/openjdk-21.0.2_${PLATFORM_ARCHITECTURE}_bin.tar.gz && \
-  mv openjdk-21.0.2_${PLATFORM_ARCHITECTURE}_bin.tar.gz openjdk-21.0.2_bin.tar.gz \
-  tar -xzvf openjdk-21.0.2_bin.tar.gz \
-  mv jdk-21.0.2 /usr/java/jdk-21.0.2
-ENV JAVA_HOME=/usr/java/jdk-21.0.2
+  wget "https://aka.ms/download-jdk/microsoft-jdk-21.0.6-$OS_ARCHITECTURE.tar.gz" && \
+  mv "microsoft-jdk-21.0.6-$OS_ARCHITECTURE.tar.gz" microsoft-jdk-21.0.6.tar.gz
+RUN tar -xzvf microsoft-jdk-21.0.6.tar.gz && \
+  mv jdk-21.0.6+7 jdk-21 && \
+  mv jdk-21 /usr/java/
+ENV JAVA_HOME=/usr/java/jdk-21
 ENV PATH="$PATH:$JAVA_HOME/bin"
 # Will load a custom configuration file for Micronaut
 ENV MICRONAUT_ENVIRONMENTS=local,override

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,6 +1,7 @@
 FROM ubuntu:24.04
 
 ARG DEBIAN_FRONTEND=noninteractive
+ARG TARGETPLATFORM
 
 USER root
 WORKDIR /root
@@ -31,9 +32,18 @@ ENV SHELL=/bin/zsh
 # --------------------------------------
 # Java
 # --------------------------------------
-RUN wget https://download.oracle.com/java/21/latest/jdk-21_linux-x64_bin.deb
-RUN dpkg -i ./jdk-21_linux-x64_bin.deb
-ENV JAVA_HOME=/usr/java/jdk-21-oracle-x64
+ARG PLATFORM_ARCHITECTURE
+RUN case "$TARGETPLATFORM" in \
+  "linux/amd64") PLATFORM_ARCHITECTURE="linux-x64" ;; \
+  "linux/arm64") PLATFORM_ARCHITECTURE="linux-aarch64" ;; \
+  "darwin/arm64") PLATFORM_ARCHITECTURE="macos-aarch64" ;; \
+  *) echo "Unsupported TARGETPLATFORM: $TARGETPLATFORM" && exit 1 ;; \
+  esac && \
+  wget https://download.java.net/java/GA/jdk21.0.2/f2283984656d49d69e91c558476027ac/13/GPL/openjdk-21.0.2_${PLATFORM_ARCHITECTURE}_bin.tar.gz && \
+  mv openjdk-21.0.2_${PLATFORM_ARCHITECTURE}_bin.tar.gz openjdk-21.0.2_bin.tar.gz \
+  tar -xzvf openjdk-21.0.2_bin.tar.gz \
+  mv jdk-21.0.2 /usr/java/jdk-21.0.2
+ENV JAVA_HOME=/usr/java/jdk-21.0.2
 ENV PATH="$PATH:$JAVA_HOME/bin"
 # Will load a custom configuration file for Micronaut
 ENV MICRONAUT_ENVIRONMENTS=local,override


### PR DESCRIPTION
### What changes are being made and why?

- Replaced Oracle's version of Java with Microsoft's build of JDK as it has a more permissive license.
- Fixed issue with Devcontainer not working for ARM architectures as the amd64 version of the Java JDK was being installed within the Devcontainer. So now the platform architecture is being used to dynamically detect the appropriate JDK to install in the devcontainer so it's supported by the environment it's running on.

---

### How the changes have been QAed?

- Tested locally on a WSL machine which uses the linux-x64 architecture.

---

closes #8282
