### PR TITLE
feat(cli,core): change KESTRA_ env prefix by ENV_

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -216,8 +216,8 @@ subprojects {
             environment 'SECRET_WEBHOOK_KEY', "secretKey".bytes.encodeBase64().toString()
             environment 'SECRET_NON_B64_SECRET', "some secret value"
             environment 'SECRET_PASSWORD', "cGFzc3dvcmQ="
-            environment 'KESTRA_TEST1', "true"
-            environment 'KESTRA_TEST2', "Pass by env"
+            environment 'ENV_TEST1', "true"
+            environment 'ENV_TEST2', "Pass by env"
         }
 
         testlogger {

--- a/cli/src/main/resources/application.yml
+++ b/cli/src/main/resources/application.yml
@@ -168,7 +168,7 @@ kestra:
         values:
           recoverMissedSchedules: ALL
   variables:
-    env-vars-prefix: KESTRA_
+    env-vars-prefix: ENV_
     cache-enabled: true
     cache-size: 1000
 

--- a/core/src/main/java/io/kestra/core/runners/RunContextCache.java
+++ b/core/src/main/java/io/kestra/core/runners/RunContextCache.java
@@ -30,7 +30,7 @@ public class RunContextCache {
 
     @PostConstruct
     void init() {
-        String envPrefix = applicationContext.getProperty("kestra.variables.env-vars-prefix", String.class, "KESTRA_");
+        String envPrefix = applicationContext.getProperty("kestra.variables.env-vars-prefix", String.class, "ENV_");
         envVars = this.envVariables(envPrefix);
 
         globalVars = applicationContext

--- a/core/src/test/java/io/kestra/plugin/core/flow/VariablesTest.java
+++ b/core/src/test/java/io/kestra/plugin/core/flow/VariablesTest.java
@@ -34,8 +34,8 @@ class VariablesTest {
 
     @Test
     @ExecuteFlow("flows/valids/variables.yaml")
-    @EnabledIfEnvironmentVariable(named = "KESTRA_TEST1", matches = ".*")
-    @EnabledIfEnvironmentVariable(named = "KESTRA_TEST2", matches = ".*")
+    @EnabledIfEnvironmentVariable(named = "ENV_TEST1", matches = ".*")
+    @EnabledIfEnvironmentVariable(named = "ENV_TEST2", matches = ".*")
     void recursiveVars(Execution execution) {
         assertThat(execution.getTaskRunList()).hasSize(3);
         assertThat(execution.findTaskRunsByTaskId("variable").getFirst().getOutputs().get("value")).isEqualTo("1 > 2 > 3");


### PR DESCRIPTION
This avoid possible security issue as you can use env var to override Kestra configuration properties and Kestra related configuration properties starts with `kestra`.

Fixes https://github.com/kestra-io/kestra-ee/issues/3131
