### PR TITLE
fix(flow): handle parsing error when reading flows from repository

### DIFF
--- a/core/src/main/java/io/kestra/core/runners/FlowListeners.java
+++ b/core/src/main/java/io/kestra/core/runners/FlowListeners.java
@@ -53,14 +53,15 @@ public class FlowListeners implements FlowListenersInterface {
                     FlowWithSource flow;
                     if (either.isRight()) {
                         flow = FlowWithException.from(either.getRight().getRecord(), either.getRight(), log).orElse(null);
-                        if (flow == null) {
-                            return;
-                        }
                     } else {
                         flow = pluginDefaultService.injectVersionDefaults(either.getLeft(), true);
                     }
 
-                    Optional<FlowWithSource> previous = this.previous(flow);
+                    if (flow == null) {
+                        return;
+                    }
+
+                    final FlowWithSource previous = this.previous(flow).orElse(null);
 
                     if (flow.isDeleted()) {
                         this.remove(flow);
@@ -77,7 +78,7 @@ public class FlowListeners implements FlowListenersInterface {
                         );
                     }
 
-                    this.notifyConsumersEach(flow, previous.orElse(null));
+                    this.notifyConsumersEach(flow, previous);
                     this.notifyConsumers();
                 });
 
@@ -109,7 +110,6 @@ public class FlowListeners implements FlowListenersInterface {
     private void upsert(FlowWithSource flow) {
         synchronized (this) {
             this.remove(flow);
-
             this.flows.add(flow);
         }
     }

--- a/core/src/main/java/io/kestra/core/services/PluginDefaultService.java
+++ b/core/src/main/java/io/kestra/core/services/PluginDefaultService.java
@@ -290,9 +290,9 @@ public class PluginDefaultService {
         }
 
         FlowWithSource result;
-        String source = flow.getSource();
-        try {
 
+        try {
+            String source = flow.getSource();
             if (source == null) {
                 source = OBJECT_MAPPER.writeValueAsString(flow);
             }

--- a/jdbc/src/main/java/io/kestra/jdbc/runner/JdbcExecutor.java
+++ b/jdbc/src/main/java/io/kestra/jdbc/runner/JdbcExecutor.java
@@ -240,9 +240,7 @@ public class JdbcExecutor implements ExecutorInterface, Service {
             serviceLivenessCoordinator.setExecutor(this);
         }
         flowListeners.run();
-        flowListeners.listen(flows -> {
-            this.allFlows = flows.stream().map(flow -> pluginDefaultService.injectVersionDefaults(flow, true)).toList();
-        });
+        flowListeners.listen(flows -> this.allFlows = flows);
 
         Await.until(() -> this.allFlows != null, Duration.ofMillis(100), Duration.ofMinutes(5));
 


### PR DESCRIPTION
This commit fixes NPE in JdbcExecutor which may occurred when reading invalid flow, and enahcen parsing error handler in JDBC flow repository.

Related-to: #7894