### PR TITLE
feat(core): allow to specify Pause task resume behavior (#8242)

### DIFF
--- a/core/src/main/java/io/kestra/core/models/flows/State.java
+++ b/core/src/main/java/io/kestra/core/models/flows/State.java
@@ -69,7 +69,7 @@ public class State {
 
     public State withState(Type state) {
         if (this.current == state) {
-            log.warn("Can't change state, already " + current);
+            log.warn("Can't change state, already {}", current);
             return this;
         }
 

--- a/core/src/test/java/io/kestra/core/runners/AbstractRunnerTest.java
+++ b/core/src/test/java/io/kestra/core/runners/AbstractRunnerTest.java
@@ -305,9 +305,9 @@ public abstract class AbstractRunnerTest {
     }
 
     @Test
-    @LoadFlows({"flows/valids/pause-delay-from-input.yaml"})
-    public void pauseRunDelayFromInput() throws Exception {
-        pauseTest.runDelayFromInput(runnerUtils);
+    @LoadFlows({"flows/valids/pause-duration-from-input.yaml"})
+    public void pauseRunDurationFromInput() throws Exception {
+        pauseTest.runDurationFromInput(runnerUtils);
     }
 
     @Test

--- a/core/src/test/resources/flows/valids/pause-behavior.yaml
+++ b/core/src/test/resources/flows/valids/pause-behavior.yaml
@@ -1,0 +1,16 @@
+id: pause-behavior
+namespace: io.kestra.tests
+
+inputs:
+  - id: behavior
+    type: STRING
+    defaults: CONTINUE
+
+tasks:
+  - id: pause
+    type: io.kestra.plugin.core.flow.Pause
+    pauseDuration: PT1S
+    behavior: "{{inputs.behavior}}"
+  - id: last
+    type: io.kestra.plugin.core.debug.Return
+    format: "{{task.id}}"

--- a/core/src/test/resources/flows/valids/pause-duration-from-input.yaml
+++ b/core/src/test/resources/flows/valids/pause-duration-from-input.yaml
@@ -1,4 +1,4 @@
-id: pause-delay-from-input
+id: pause-duration-from-input
 namespace: io.kestra.tests
 
 inputs:
@@ -9,7 +9,7 @@ inputs:
 tasks:
   - id: pause
     type: io.kestra.plugin.core.flow.Pause
-    delay: "{{inputs.delay}}"
+    pauseDuration: "{{inputs.delay}}"
     tasks:
       - id: subtask
         type: io.kestra.plugin.core.log.Log


### PR DESCRIPTION
When a pause task is resumed either because it wait until the end of it's duration or is resumed manually, it can now use a behavior to describe what to do next: resume, warn, fail, or cancel the execution.

Fixes #8242