### PR TITLE
feat(core)*: close code tab if file is deleted

### DIFF
--- a/ui/src/components/flows/useCodePanels.ts
+++ b/ui/src/components/flows/useCodePanels.ts
@@ -100,6 +100,14 @@ export function useCodePanels(panels: Ref<Panel[]>) {
     watch(codeEditorTabs, (newVal) => {
         const codeTabs = getPanelsFromCodeEditorTabs(newVal)
 
+        // Loop through tabs to see if any code tab should be removed due to file deletion
+        const openedTabs = new Set(codeTabs.tabs.map(tab => tab.value))
+        panels.value.forEach((panel) => {
+            panel.tabs = panel.tabs.filter(tab => {
+                return !tab.value.startsWith("code-") || openedTabs.has(tab.value)
+            })
+        })
+        
         // get all the tabs to add since they are not already part of the panels tabs
         const toAdd = codeTabs.tabs.filter(t => !panels.value.some(p => p.tabs.some(pt => t.value === pt.value)))
 

--- a/ui/src/stores/namespaces.js
+++ b/ui/src/stores/namespaces.js
@@ -152,7 +152,17 @@ export default {
             if (!payload.path) return;
 
             const URL = `${base.call(this, payload.namespace)}/files?path=${slashPrefix(safePath(payload.path))}`;
-            const request = await this.$http.get(URL, {transformResponse: response => response, responseType: "json"})
+            const request = await this.$http.get(URL, {
+                validateStatus: (status) => status === 200 || status === 404,
+                transformResponse: response => response, responseType: "json"
+            })
+
+            if(request.status === 404) {
+                const message = JSON.parse(request.data)?.message;
+                this.$toast.bind({$t: this.$i18n.t})().error(message ?? "File not found");
+
+                return [];
+            }
 
             return request.data ?? [];
         },


### PR DESCRIPTION
In the new multi panel view, if we have `code` tab opened and delete that file from `files` panel, we'll automatically close the opened tab for the file in question.

Closes https://github.com/kestra-io/kestra/issues/8271.