### PR TITLE
fix(flow): enhance error handling when injecting plugin defaults

### DIFF
--- a/cli/src/main/java/io/kestra/cli/services/FileChangedEventListener.java
+++ b/cli/src/main/java/io/kestra/cli/services/FileChangedEventListener.java
@@ -1,6 +1,6 @@
 package io.kestra.cli.services;
 
-import io.kestra.core.exceptions.DeserializationException;
+import io.kestra.core.exceptions.FlowProcessingException;
 import io.kestra.core.models.flows.FlowInterface;
 import io.kestra.core.models.flows.FlowWithPath;
 import io.kestra.core.models.flows.FlowWithSource;
@@ -236,7 +236,7 @@ public class FileChangedEventListener {
             FlowWithSource flow = pluginDefaultService.parseFlowWithAllDefaults(tenantId, content, false);
             modelValidator.validate(flow);
             return Optional.of(flow);
-        } catch (DeserializationException | ConstraintViolationException e) {
+        } catch (ConstraintViolationException | FlowProcessingException e) {
             log.warn("Error while parsing flow: {}", entry, e);
         }
         return Optional.empty();

--- a/core/src/main/java/io/kestra/core/exceptions/FlowProcessingException.java
+++ b/core/src/main/java/io/kestra/core/exceptions/FlowProcessingException.java
@@ -1,0 +1,24 @@
+package io.kestra.core.exceptions;
+
+import java.io.Serial;
+
+/**
+ * Exception class for all problems encountered when processing (parsing, injecting defaults, validating) a flow.
+ */
+public class FlowProcessingException extends KestraException {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
+    
+    public FlowProcessingException(String message) {
+        super(message);
+    }
+
+    public FlowProcessingException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public FlowProcessingException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/core/src/main/java/io/kestra/core/exceptions/KestraException.java
+++ b/core/src/main/java/io/kestra/core/exceptions/KestraException.java
@@ -1,0 +1,27 @@
+package io.kestra.core.exceptions;
+
+import java.io.Serial;
+
+/**
+ * The top-level {@link KestraException}..
+ */
+public class KestraException extends Exception {
+    @Serial
+    private static final long serialVersionUID = 1L;
+
+    public KestraException() {
+    }
+
+    public KestraException(String message) {
+        super(message);
+    }
+
+    public KestraException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public KestraException(Throwable cause) {
+        super(cause);
+    }
+
+}

--- a/core/src/main/java/io/kestra/core/repositories/LocalFlowRepositoryLoader.java
+++ b/core/src/main/java/io/kestra/core/repositories/LocalFlowRepositoryLoader.java
@@ -1,5 +1,6 @@
 package io.kestra.core.repositories;
 
+import io.kestra.core.exceptions.FlowProcessingException;
 import io.kestra.core.models.flows.FlowId;
 import io.kestra.core.models.flows.FlowInterface;
 import io.kestra.core.models.flows.FlowWithSource;
@@ -95,7 +96,7 @@ public class LocalFlowRepositoryLoader {
                             flowRepository.update(parsed, existing);
                             log.trace("Updated flow {}.{}", parsed.getNamespace(), parsed.getId());
                         }
-                    } catch (ConstraintViolationException e) {
+                    } catch (FlowProcessingException | ConstraintViolationException e) {
                         log.warn("Unable to create flow {}", file, e);
                     }
                 }));

--- a/core/src/main/java/io/kestra/core/runners/FlowListeners.java
+++ b/core/src/main/java/io/kestra/core/runners/FlowListeners.java
@@ -1,5 +1,6 @@
 package io.kestra.core.runners;
 
+import io.kestra.core.exceptions.FlowProcessingException;
 import io.kestra.core.models.flows.FlowInterface;
 import io.kestra.core.models.flows.FlowWithException;
 import io.kestra.core.models.flows.FlowWithSource;
@@ -54,7 +55,12 @@ public class FlowListeners implements FlowListenersInterface {
                     if (either.isRight()) {
                         flow = FlowWithException.from(either.getRight().getRecord(), either.getRight(), log).orElse(null);
                     } else {
-                        flow = pluginDefaultService.injectVersionDefaults(either.getLeft(), true);
+                        try {
+                            flow = pluginDefaultService.injectVersionDefaults(either.getLeft(), true);
+                        } catch (FlowProcessingException ignore) {
+                            // should not occur, safe = true...
+                            flow = null;
+                        }
                     }
 
                     if (flow == null) {

--- a/core/src/main/java/io/kestra/core/services/GraphService.java
+++ b/core/src/main/java/io/kestra/core/services/GraphService.java
@@ -1,5 +1,6 @@
 package io.kestra.core.services;
 
+import io.kestra.core.exceptions.FlowProcessingException;
 import io.kestra.core.exceptions.IllegalVariableEvaluationException;
 import io.kestra.core.models.executions.Execution;
 import io.kestra.core.models.flows.FlowWithSource;
@@ -15,6 +16,7 @@ import io.kestra.core.utils.GraphUtils;
 import io.micronaut.data.model.Pageable;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
+import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 
 import java.util.*;
@@ -34,27 +36,28 @@ public class GraphService {
     @Inject
     private RunContextFactory runContextFactory;
 
-    public FlowGraph flowGraph(FlowWithSource flow, List<String> expandedSubflows) throws IllegalVariableEvaluationException {
+    public FlowGraph flowGraph(FlowWithSource flow, List<String> expandedSubflows) throws IllegalVariableEvaluationException, FlowProcessingException {
         return this.flowGraph(flow, expandedSubflows, null);
     }
 
-    public FlowGraph flowGraph(FlowWithSource flow, List<String> expandedSubflows, Execution execution) throws IllegalVariableEvaluationException {
+    public FlowGraph flowGraph(FlowWithSource flow, List<String> expandedSubflows, Execution execution) throws IllegalVariableEvaluationException, FlowProcessingException {
         return FlowGraph.of(this.of(flow, Optional.ofNullable(expandedSubflows).orElse(Collections.emptyList()), new HashMap<>(), execution));
     }
 
-    public FlowGraph executionGraph(FlowWithSource flow, List<String> expandedSubflows, Execution execution) throws IllegalVariableEvaluationException {
+    public FlowGraph executionGraph(FlowWithSource flow, List<String> expandedSubflows, Execution execution) throws IllegalVariableEvaluationException, FlowProcessingException {
         return FlowGraph.of(this.of(flow, Optional.ofNullable(expandedSubflows).orElse(Collections.emptyList()), new HashMap<>(), execution));
     }
 
-    public GraphCluster of(FlowWithSource flow, List<String> expandedSubflows, Map<String, FlowWithSource> flowByUid, Execution execution) throws IllegalVariableEvaluationException {
+    public GraphCluster of(FlowWithSource flow, List<String> expandedSubflows, Map<String, FlowWithSource> flowByUid, Execution execution) throws IllegalVariableEvaluationException, FlowProcessingException {
         return this.of(null, flow, expandedSubflows, flowByUid, execution);
     }
 
-    public GraphCluster of(GraphCluster baseGraph, FlowWithSource flow, List<String> expandedSubflows, Map<String, FlowWithSource> flowByUid) throws IllegalVariableEvaluationException {
+    public GraphCluster of(GraphCluster baseGraph, FlowWithSource flow, List<String> expandedSubflows, Map<String, FlowWithSource> flowByUid) throws IllegalVariableEvaluationException, FlowProcessingException {
         return this.of(baseGraph, flow, expandedSubflows, flowByUid, null);
     }
 
-    public GraphCluster of(GraphCluster baseGraph, FlowWithSource flow, List<String> expandedSubflows, Map<String, FlowWithSource> flowByUid, Execution execution) throws IllegalVariableEvaluationException {
+    @SneakyThrows
+    public GraphCluster of(GraphCluster baseGraph, FlowWithSource flow, List<String> expandedSubflows, Map<String, FlowWithSource> flowByUid, Execution execution) throws IllegalVariableEvaluationException, FlowProcessingException {
         String tenantId = flow.getTenantId();
         flow = pluginDefaultService.injectAllDefaults(flow, false);
         List<Trigger> triggers = null;

--- a/core/src/test/java/io/kestra/core/models/hierarchies/FlowGraphTest.java
+++ b/core/src/test/java/io/kestra/core/models/hierarchies/FlowGraphTest.java
@@ -1,5 +1,6 @@
 package io.kestra.core.models.hierarchies;
 
+import io.kestra.core.exceptions.FlowProcessingException;
 import io.kestra.core.exceptions.IllegalVariableEvaluationException;
 import io.kestra.core.exceptions.InternalException;
 import io.kestra.core.junit.annotations.ExecuteFlow;
@@ -215,7 +216,7 @@ class FlowGraphTest {
     }
 
     @Test
-    void trigger() throws IllegalVariableEvaluationException, IOException {
+    void trigger() throws IllegalVariableEvaluationException, IOException, FlowProcessingException {
         FlowWithSource flow = this.parse("flows/valids/trigger-flow-listener.yaml");
         triggerRepositoryInterface.save(
             Trigger.of(flow, flow.getTriggers().getFirst()).toBuilder().disabled(true).build()
@@ -261,7 +262,7 @@ class FlowGraphTest {
     @Test
     @LoadFlows({"flows/valids/task-flow.yaml",
         "flows/valids/switch.yaml"})
-    void subflow() throws IllegalVariableEvaluationException, IOException {
+    void subflow() throws IllegalVariableEvaluationException, IOException, FlowProcessingException {
         FlowWithSource flow = this.parse("flows/valids/task-flow.yaml");
         FlowGraph flowGraph = GraphUtils.flowGraph(flow, null);
 
@@ -293,7 +294,7 @@ class FlowGraphTest {
     @Test
     @LoadFlows({"flows/valids/task-flow-dynamic.yaml",
         "flows/valids/switch.yaml"})
-    void dynamicIdSubflow() throws IllegalVariableEvaluationException, TimeoutException, QueueException, IOException {
+    void dynamicIdSubflow() throws IllegalVariableEvaluationException, TimeoutException, QueueException, IOException, FlowProcessingException {
         FlowWithSource flow = this.parse("flows/valids/task-flow-dynamic.yaml").toBuilder().revision(1).build();
 
         IllegalArgumentException illegalArgumentException = Assertions.assertThrows(IllegalArgumentException.class, () -> graphService.flowGraph(flow, Collections.singletonList("root.launch")));

--- a/core/src/test/java/io/kestra/core/services/FlowServiceTest.java
+++ b/core/src/test/java/io/kestra/core/services/FlowServiceTest.java
@@ -1,5 +1,6 @@
 package io.kestra.core.services;
 
+import io.kestra.core.exceptions.FlowProcessingException;
 import io.kestra.core.junit.annotations.KestraTest;
 import io.kestra.core.models.flows.FlowInterface;
 import io.kestra.core.models.flows.FlowWithSource;
@@ -51,7 +52,7 @@ class FlowServiceTest {
     }
 
     @Test
-    void importFlow() {
+    void importFlow() throws FlowProcessingException {
         String source = """
             id: import
             namespace: some.namespace
@@ -85,7 +86,7 @@ class FlowServiceTest {
     }
 
     @Test
-    void importFlow_DryRun() {
+    void importFlow_DryRun() throws FlowProcessingException {
         String oldSource = """
             id: import_dry
             namespace: some.namespace

--- a/core/src/test/java/io/kestra/core/services/PluginDefaultServiceTest.java
+++ b/core/src/test/java/io/kestra/core/services/PluginDefaultServiceTest.java
@@ -1,6 +1,7 @@
 package io.kestra.core.services;
 
 import com.google.common.collect.ImmutableMap;
+import io.kestra.core.exceptions.FlowProcessingException;
 import io.kestra.core.junit.annotations.KestraTest;
 import io.kestra.core.models.annotations.Plugin;
 import io.kestra.core.models.conditions.ConditionContext;
@@ -67,7 +68,7 @@ class PluginDefaultServiceTest {
     private PluginDefaultService pluginDefaultService;
 
     @Test
-    void shouldInjectGivenFlowWithNullSource() {
+    void shouldInjectGivenFlowWithNullSource() throws FlowProcessingException {
         // Given
         FlowInterface flow = GenericFlow.fromYaml(null, TEST_LOG_FLOW_SOURCE);
 
@@ -131,7 +132,7 @@ class PluginDefaultServiceTest {
 
     @ParameterizedTest
     @MethodSource
-    void flowDefaultsOverrideGlobalDefaults(boolean flowDefaultForced, boolean globalDefaultForced, String fooValue, String barValue, String bazValue) {
+    void flowDefaultsOverrideGlobalDefaults(boolean flowDefaultForced, boolean globalDefaultForced, String fooValue, String barValue, String bazValue) throws FlowProcessingException {
         final DefaultPrecedenceTester task = DefaultPrecedenceTester.builder()
             .id("test")
             .type(DefaultPrecedenceTester.class.getName())
@@ -177,7 +178,7 @@ class PluginDefaultServiceTest {
     }
 
     @Test
-    public void injectFlowAndGlobals() {
+    public void injectFlowAndGlobals() throws FlowProcessingException {
         String source = String.format("""
             id: default-test
             namespace: io.kestra.tests
@@ -230,7 +231,7 @@ class PluginDefaultServiceTest {
     }
 
     @Test
-    public void shouldInjectForcedDefaultsGivenForcedTrue() {
+    public void shouldInjectForcedDefaultsGivenForcedTrue() throws FlowProcessingException {
         // Given
         String source = """
             id: default-test
@@ -266,7 +267,7 @@ class PluginDefaultServiceTest {
     }
 
     @Test
-    public void shouldInjectDefaultGivenPrefixType() {
+    public void shouldInjectDefaultGivenPrefixType() throws FlowProcessingException {
         // Given
         String source = """
             id: default-test
@@ -305,7 +306,7 @@ class PluginDefaultServiceTest {
     }
 
     @Test
-    void shouldInjectFlowDefaultsGivenAlias() {
+    void shouldInjectFlowDefaultsGivenAlias() throws FlowProcessingException {
         // Given
         GenericFlow flow = GenericFlow.fromYaml(null, """
               id: default-test
@@ -330,7 +331,7 @@ class PluginDefaultServiceTest {
     }
 
     @Test
-    void shouldInjectFlowDefaultsGivenType() {
+    void shouldInjectFlowDefaultsGivenType() throws FlowProcessingException {
         GenericFlow flow = GenericFlow.fromYaml(null, """
                   id: default-test
                   namespace: io.kestra.tests
@@ -352,7 +353,7 @@ class PluginDefaultServiceTest {
     }
 
     @Test
-    public void shouldNotInjectDefaultsGivenExistingTaskValue() {
+    public void shouldNotInjectDefaultsGivenExistingTaskValue() throws FlowProcessingException {
         // Given
         GenericFlow flow = GenericFlow.fromYaml(null, """
             id: default-test

--- a/webserver/src/main/java/io/kestra/webserver/controllers/api/ExecutionController.java
+++ b/webserver/src/main/java/io/kestra/webserver/controllers/api/ExecutionController.java
@@ -255,7 +255,7 @@ public class ExecutionController {
     public FlowGraph flowGraph(
         @Parameter(description = "The execution id") @PathVariable String executionId,
         @Parameter(description = "The subflow tasks to display") @Nullable @QueryValue List<String> subflows
-    ) throws IllegalVariableEvaluationException {
+    ) throws Exception {
         return executionRepository
             .findById(tenantService.resolveTenant(), executionId)
             .map(throwFunction(execution -> {

--- a/webserver/src/main/java/io/kestra/webserver/controllers/api/NamespaceFileController.java
+++ b/webserver/src/main/java/io/kestra/webserver/controllers/api/NamespaceFileController.java
@@ -1,12 +1,12 @@
 package io.kestra.webserver.controllers.api;
 
+import io.kestra.core.exceptions.FlowProcessingException;
 import io.kestra.core.services.FlowService;
 import io.kestra.core.storages.FileAttributes;
 import io.kestra.core.storages.NamespaceFile;
 import io.kestra.core.storages.StorageInterface;
 import io.kestra.core.tenant.TenantService;
 import io.kestra.core.utils.Rethrow;
-import io.kestra.core.utils.WindowsUtils;
 import io.micronaut.core.annotation.Nullable;
 import io.micronaut.http.HttpResponse;
 import io.micronaut.http.MediaType;
@@ -153,7 +153,7 @@ public class NamespaceFileController {
         @Parameter(description = "The namespace id") @PathVariable String namespace,
         @Parameter(description = "The internal storage uri") @QueryValue String path,
         @Part CompletedFileUpload fileContent
-    ) throws IOException, URISyntaxException {
+    ) throws Exception {
         String tenantId = tenantService.resolveTenant();
         if (fileContent.getFilename().toLowerCase().endsWith(".zip")) {
             try (ZipInputStream archive = new ZipInputStream(fileContent.getInputStream())) {
@@ -181,7 +181,7 @@ public class NamespaceFileController {
         }
     }
 
-    private void putNamespaceFile(String tenantId, String namespace, URI path, BufferedInputStream inputStream) throws IOException {
+    private void putNamespaceFile(String tenantId, String namespace, URI path, BufferedInputStream inputStream) throws Exception {
         String filePath = path.getPath();
         if(filePath.matches("/" + FLOWS_FOLDER + "/.*")) {
             if(filePath.split("/").length != 3) {
@@ -197,7 +197,7 @@ public class NamespaceFileController {
         storageInterface.put(tenantId, namespace, NamespaceFile.of(namespace, path).uri(), inputStream);
     }
 
-    protected void importFlow(String tenantId, String source) {
+    protected void importFlow(String tenantId, String source) throws FlowProcessingException {
         flowService.importFlow(tenantId, source);
     }
 


### PR DESCRIPTION
Add a new checked exception FlowProcessingException to enhance error handling when parsing, validating a flow, and injecting plugin defaults.

Related-to: #7894