### PR TITLE
chore(flows)*: hide horizontal scroll on editor based inputs

### DIFF
--- a/ui/src/components/inputs/InputsForm.vue
+++ b/ui/src/components/inputs/InputsForm.vue
@@ -517,6 +517,10 @@
 
     :deep(.editor-container){
         max-height: 200px;
+        
+        & .ks-monaco-editor {
+            overflow-x: hidden;
+        }
     }
 
     .el-input-file {


### PR DESCRIPTION
There was always a horizontal scrollbar present at editor compnent when used as input field, which was previously handled for the No Code editor in https://github.com/kestra-io/kestra/pull/8216.

Relates to https://github.com/kestra-io/kestra-ee/issues/3404.