### PR TITLE
fix: add validation for use of inputs with - in the name

### DIFF
--- a/core/src/test/java/io/kestra/core/validations/FlowValidationTest.java
+++ b/core/src/test/java/io/kestra/core/validations/FlowValidationTest.java
@@ -9,6 +9,7 @@ import jakarta.inject.Inject;
 import org.junit.jupiter.api.Test;
 
 import jakarta.validation.ConstraintViolationException;
+
 import java.io.File;
 import java.net.URL;
 import java.util.Optional;
@@ -37,6 +38,25 @@ class FlowValidationTest {
         assertThat(validate.isPresent()).isTrue();
         assertThat(validate.get().getMessage()).contains("System labels can only be set by Kestra itself, offending label: system.label=system_key");
         assertThat(validate.get().getMessage()).contains("System labels can only be set by Kestra itself, offending label: system.id=id");
+    }
+
+    @Test
+    void inputUsageWithSubtractionSymbolFailValidation() {
+        Flow flow = this.parse("flows/invalids/inputs-key-with-subtraction-symbol-validation.yaml");
+        Optional<ConstraintViolationException> validate = modelValidator.isValid(flow);
+
+        assertThat(validate.isPresent()).isEqualTo(true);
+        assertThat(validate.get().getMessage()).contains("Invalid input reference: use inputs[key-name] instead of inputs.key-name — keys with dashes require bracket notation, offending tasks: [hello]");
+    }
+
+    @Test
+    void outputUsageWithSubtractionSymbolFailValidation() {
+        Flow flow = this.parse("flows/invalids/outputs-key-with-subtraction-symbol-validation.yaml");
+        Optional<ConstraintViolationException> validate = modelValidator.isValid(flow);
+
+        assertThat(validate.isPresent()).isEqualTo(true);
+        assertThat(validate.get().getMessage()).contains("Invalid output reference: use outputs[key-name] instead of outputs.key-name — keys with dashes require bracket notation, offending tasks: [use_output]");
+        assertThat(validate.get().getMessage()).contains("Invalid output reference: use outputs[key-name] instead of outputs.key-name — keys with dashes require bracket notation, offending outputs: [final]");
     }
 
     @Test

--- a/core/src/test/resources/flows/invalids/inputs-key-with-subtraction-symbol-validation.yaml
+++ b/core/src/test/resources/flows/invalids/inputs-key-with-subtraction-symbol-validation.yaml
@@ -1,0 +1,12 @@
+id: inputs-key-with-subtraction-symbol-validation
+namespace: io.kestra.tests
+
+inputs:
+  - id: server-fqn
+    type: STRING
+    defaults: 'animal'
+
+tasks:
+  - id: hello
+    type: io.kestra.plugin.core.log.Log
+    message: "{{inputs.server-fqn}}"

--- a/core/src/test/resources/flows/invalids/outputs-key-with-subtraction-symbol-validation.yaml
+++ b/core/src/test/resources/flows/invalids/outputs-key-with-subtraction-symbol-validation.yaml
@@ -1,0 +1,16 @@
+id: task_outputs_example
+namespace: company.team
+
+tasks:
+  - id: produce-output
+    type: io.kestra.plugin.core.debug.Return
+    format: my output {{ execution.id }}
+
+  - id: use_output
+    type: io.kestra.plugin.core.log.Log
+    message: The previous task output is {{ outputs.produce-output.value }}
+
+outputs:
+  - id: final
+    type: STRING
+    value: "{{ outputs.produce-output.value }}"


### PR DESCRIPTION
<!-- Thanks for submitting a Pull Request to Kestra. To help us review your contribution, please follow the guidelines below:

- Make sure that your commits follow the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) specification e.g. `feat(ui): add a new navigation menu item` or `fix(core): fix a bug in the core model` or `docs: update the README.md`. This will help us automatically generate the changelog.
- The title should briefly summarize the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share a flow example to help the reviewer understand and QA the change.
- Use "closes" to automatically close an issue. For example, `closes #1234` will close issue #1234. -->

### What changes are being made and why?

<!-- Please include a brief summary of the changes included in this PR e.g. closes #1234. -->

[#4090](https://github.com/kestra-io/kestra/issues/4090)
added validation for usage of inputs with minus due to workflow failing 
---

### How the changes have been QAed?

<!-- Include example code that shows how this PR has been QAed. The code should present a complete yet easily reproducible flow.

```yaml
# Your example flow code here
```
id: backup-homelab-applications
namespace: hl443
description: Backs up the applications on a server

Note that this is not a replacement for unit tests but rather a way to demonstrate how the changes work in a real-life scenario, as the end-user would experience them.

Remove this section if this change applies to all flows or to the documentation only. -->

inputs:
  - id: server-fqn
    type: STRING
    defaults: 'animal'
    
  - id: server-user
    type: STRING
    defaults: 'root'

tasks:
  - id: hello
    type: io.kestra.plugin.core.log.Log
    message: "{{inputs.server-fqn}}"
---


