### PR TITLE
refactor(namespaces): remove the unused `maximize` property

### DIFF
--- a/ui/src/components/namespaces/utils/useHelpers.ts
+++ b/ui/src/components/namespaces/utils/useHelpers.ts
@@ -11,11 +11,11 @@ import EditorView from "../../../components/inputs/EditorView.vue";
 
 export interface Tab {
     locked?: boolean;
+    maximized?: boolean;
 
     name: string;
     title: string;
     component: Component;
-    maximized?: boolean;
 
     props?: Record<string, any>;
 }
@@ -103,10 +103,10 @@ export function useHelpers() {
             props: {namespace, type: "dependencies"},
         },
         {
+            maximized: true,
             name: "files",
             title: t("files"),
             component: EditorView,
-            maximized: true,
             props: {namespace, isNamespace: true, isReadOnly: false},
         },
     ];

--- a/ui/src/override/components/namespaces/useTabs.ts
+++ b/ui/src/override/components/namespaces/useTabs.ts
@@ -14,7 +14,7 @@ import KVTable from "../../../components/kv/KVTable.vue";
 const lockedProps = (tab: string) => ({
     locked: true,
     component: DemoNamespace,
-    props: {tab, maximize: true},
+    props: {tab},
 });
 
 export function useTabs() {


### PR DESCRIPTION
There is no more need for `maximize` property to be passed for locked tabs, and therefore it's removed in this commit.