### PR TITLE
feat(executions): Allow unqueuing to states other than RUNNING #5939

### DIFF
--- a/core/src/main/java/io/kestra/core/runners/ExecutionRunning.java
+++ b/core/src/main/java/io/kestra/core/runners/ExecutionRunning.java
@@ -30,5 +30,5 @@ public class ExecutionRunning {
         return IdUtils.fromPartsAndSeparator('|', this.tenantId, this.namespace, this.flowId, this.execution.getId());
     }
 
-    public enum ConcurrencyState { CREATED, RUNNING, QUEUED }
+    public enum ConcurrencyState { CREATED, RUNNING, QUEUED, CANCELLED, FAILED }
 }

--- a/core/src/main/java/io/kestra/core/services/ConcurrencyLimitService.java
+++ b/core/src/main/java/io/kestra/core/services/ConcurrencyLimitService.java
@@ -6,7 +6,6 @@ import io.kestra.core.queues.QueueException;
 import jakarta.inject.Singleton;
 
 import java.util.EnumSet;
-import java.util.Optional;
 import java.util.Set;
 
 @Singleton

--- a/core/src/main/java/io/kestra/core/services/ConcurrencyLimitService.java
+++ b/core/src/main/java/io/kestra/core/services/ConcurrencyLimitService.java
@@ -19,7 +19,7 @@ public class ConcurrencyLimitService {
      *
      * @throws IllegalArgumentException in case the execution is not queued.
      */
-    public Execution unqueue(Execution execution,State.Type state) throws QueueException {
+    public Execution unqueue(Execution execution, State.Type state) throws QueueException {
         if (execution.getState().getCurrent() != State.Type.QUEUED) {
             throw new IllegalArgumentException("Only QUEUED execution can be unqueued");
         }

--- a/core/src/main/java/io/kestra/core/services/ConcurrencyLimitService.java
+++ b/core/src/main/java/io/kestra/core/services/ConcurrencyLimitService.java
@@ -11,7 +11,7 @@ import java.util.Set;
 @Singleton
 public class ConcurrencyLimitService {
 
-    private static final Set<State.Type> VALID_TARGET_STATES =
+    protected static final Set<State.Type> VALID_TARGET_STATES =
         EnumSet.of(State.Type.RUNNING, State.Type.CANCELLED, State.Type.FAILED);
 
     /**

--- a/core/src/main/java/io/kestra/core/services/ConcurrencyLimitService.java
+++ b/core/src/main/java/io/kestra/core/services/ConcurrencyLimitService.java
@@ -5,18 +5,33 @@ import io.kestra.core.models.flows.State;
 import io.kestra.core.queues.QueueException;
 import jakarta.inject.Singleton;
 
+import java.util.EnumSet;
+import java.util.Optional;
+import java.util.Set;
+
 @Singleton
 public class ConcurrencyLimitService {
+
+    private static final Set<State.Type> VALID_TARGET_STATES =
+        EnumSet.of(State.Type.RUNNING, State.Type.CANCELLED, State.Type.FAILED);
 
     /**
      * Unqueue a queued execution.
      *
      * @throws IllegalArgumentException in case the execution is not queued.
      */
-    public Execution unqueue(Execution execution) throws QueueException {
+    public Execution unqueue(Execution execution,State.Type state) throws QueueException {
         if (execution.getState().getCurrent() != State.Type.QUEUED) {
             throw new IllegalArgumentException("Only QUEUED execution can be unqueued");
         }
-        return execution.withState(State.Type.RUNNING);
+
+        state = (state == null) ? State.Type.RUNNING : state;
+
+        // Validate the target state, throwing an exception if the state is invalid
+        if (!VALID_TARGET_STATES.contains(state)) {
+            throw new IllegalArgumentException("Invalid target state: " + state + ". Valid states are: " + VALID_TARGET_STATES);
+        }
+
+        return execution.withState(state);
     }
 }

--- a/core/src/main/java/io/kestra/core/services/ExecutionService.java
+++ b/core/src/main/java/io/kestra/core/services/ExecutionService.java
@@ -843,7 +843,7 @@ public class ExecutionService {
         }
 
         if (execution.getState().getCurrent() == State.Type.QUEUED) {
-            return concurrencyLimitService.unqueue(execution);
+            return concurrencyLimitService.unqueue(execution,State.Type.RUNNING);
         }
 
         if (execution.getState().getCurrent() == State.Type.PAUSED) {

--- a/jdbc/src/main/java/io/kestra/jdbc/services/JdbcConcurrencyLimitService.java
+++ b/jdbc/src/main/java/io/kestra/jdbc/services/JdbcConcurrencyLimitService.java
@@ -19,13 +19,20 @@ public class JdbcConcurrencyLimitService extends ConcurrencyLimitService {
     private AbstractJdbcExecutionQueuedStorage storage;
 
     @Override
-    public Execution unqueue(Execution execution) throws QueueException {
+    public Execution unqueue(Execution execution, State.Type state) throws QueueException {
         if (execution.getState().getCurrent() != State.Type.QUEUED) {
             throw new IllegalArgumentException("Only QUEUED execution can be unqueued");
         }
 
         storage.remove(execution);
 
-        return execution.withState(State.Type.RUNNING);
+        state = (state == null) ? State.Type.RUNNING : state;
+
+        // Validate the target state, throwing an exception if the state is invalid
+        if (!VALID_TARGET_STATES.contains(state)) {
+            throw new IllegalArgumentException("Invalid target state: " + state + ". Valid states are: " + VALID_TARGET_STATES);
+        }
+
+        return execution.withState(state);
     }
 }

--- a/ui/src/components/executions/Overview.vue
+++ b/ui/src/components/executions/Overview.vue
@@ -14,6 +14,9 @@
                             <chevron-up v-if="isExpanded" />
                             <chevron-down v-else />
                         </span>
+                        <span v-if="!errorLogs">
+                            {{ $t('error detected') }}
+                        </span>
                     </div>
                 </template>
                 <div v-if="isExpanded && errorLogs" class="error-stack">

--- a/ui/src/stores/executions.js
+++ b/ui/src/stores/executions.js
@@ -299,7 +299,9 @@ export default {
             return this.$http.post(`${apiUrl(this)}/executions/labels/by-ids`,  options)
         },
         unqueue(_, options) {
-            return this.$http.post(`${apiUrl(this)}/executions/${options.id}/unqueue`);
+            return this.$http.post(`${apiUrl(this)}/executions/${options.id}/unqueue`, {
+                state: options.state
+            });
         },
         bulkUnqueueExecution(_, options) {
             return this.$http.post(

--- a/ui/src/stores/executions.js
+++ b/ui/src/stores/executions.js
@@ -303,13 +303,13 @@ export default {
         },
         bulkUnqueueExecution(_, options) {
             return this.$http.post(
-                `${apiUrl(this)}/executions/unqueue/by-ids`,
+                `${apiUrl(this)}/executions/unqueue/by-ids?state=${options.newStatus}`,
                 options.executionsId
             )
         },
         queryUnqueueExecution(_, options) {
             return this.$http.post(
-                `${apiUrl(this)}/executions/unqueue/by-query`,
+                `${apiUrl(this)}/executions/unqueue/by-query?state=${options.newStatus}`,
                 {},
                 {params: options}
             )

--- a/ui/src/stores/executions.js
+++ b/ui/src/stores/executions.js
@@ -299,9 +299,7 @@ export default {
             return this.$http.post(`${apiUrl(this)}/executions/labels/by-ids`,  options)
         },
         unqueue(_, options) {
-            return this.$http.post(`${apiUrl(this)}/executions/${options.id}/unqueue`, {
-                state: options.state
-            });
+            return this.$http.post(`${apiUrl(this)}/executions/${options.id}/unqueue?state=${options.state}`);
         },
         bulkUnqueueExecution(_, options) {
             return this.$http.post(

--- a/ui/src/translations/en.json
+++ b/ui/src/translations/en.json
@@ -238,6 +238,7 @@
     "pause done": "Execution is paused",
     "unqueue": "Unqueue",
     "unqueue title": "Are you sure you want to Unqueue execution <code>{id}</code>?<br/><br/>Note that it will not obey the flow concurrency limit, so more executions could be running than the allowed limit.",
+    "unqueue title multiple": "Are you sure you want to Unqueue <code>{count}</code> executions?<br/><br/>Note that it will not obey the flow concurrency limit, so more executions could be running than the allowed limit.",
     "unqueue confirm": "Are you sure you want to unqueue execution <code>{id}</code>?",
     "unqueue done": "Execution is unqueued",
     "force run": "Force run",

--- a/ui/src/translations/en.json
+++ b/ui/src/translations/en.json
@@ -195,6 +195,7 @@
     "change state": "Change state",
     "change state done": "Task state has been updated",
     "change state confirm": "Are you sure you want to change the task run state for the <code>{task}</code> task in execution <code>{id}</code>?<br/>It will then restart the execution from the next task and restart the parent execution if any.",
+    "change queue confirm": "Are you sure you want to change the queue state for the execution <code>{id}</code>?<br/>",
     "change state current state": "Current status is:",
     "change state hint": {
       "WARNING": [
@@ -221,6 +222,7 @@
     "change execution state confirm": "Are you sure you want to change the state of the execution <code>{id}</code>?",
     "change execution state done": "Execution state updated",
     "mark as": "Mark as <code>{status}</code>",
+    "unqueue as": "Unqueue as <code>{status}</code>",
     "kill": "Kill",
     "kill parents and subflow": "Kill parents and subflows",
     "kill only parents": "Kill parents only",
@@ -235,7 +237,7 @@
     "pause confirm": "Are you sure you want to pause execution <code>{id}</code>?",
     "pause done": "Execution is paused",
     "unqueue": "Unqueue",
-    "unqueue title": "Unqueue execution <code>{id}</code>.<br/>Note that it will not obey the flow concurrency limit, so more executions could be running than the allowed limit.",
+    "unqueue title": "Are you sure you want to Unqueue execution <code>{id}</code>?<br/><br/>Note that it will not obey the flow concurrency limit, so more executions could be running than the allowed limit.",
     "unqueue confirm": "Are you sure you want to unqueue execution <code>{id}</code>?",
     "unqueue done": "Execution is unqueued",
     "force run": "Force run",

--- a/webserver/src/main/java/io/kestra/webserver/controllers/api/ExecutionController.java
+++ b/webserver/src/main/java/io/kestra/webserver/controllers/api/ExecutionController.java
@@ -1,7 +1,6 @@
 package io.kestra.webserver.controllers.api;
 
 import com.google.common.annotations.VisibleForTesting;
-import io.kestra.core.debug.Breakpoint;
 import io.kestra.core.events.CrudEvent;
 import io.kestra.core.events.CrudEventType;
 import io.kestra.core.exceptions.IllegalVariableEvaluationException;
@@ -1920,14 +1919,15 @@ public class ExecutionController {
     @Post(uri = "/{executionId}/unqueue")
     @Operation(tags = {"Executions"}, summary = "Unqueue an execution")
     public Execution unqueueExecution(
-        @Parameter(description = "The execution id") @PathVariable String executionId
+        @Parameter(description = "The execution id") @PathVariable String executionId,
+        @Parameter(description = "The new state of the execution") @Nullable @QueryValue State.Type state
     ) throws Exception {
         Optional<Execution> execution = executionRepository.findById(tenantService.resolveTenant(), executionId);
         if (execution.isEmpty()) {
             return null;
         }
 
-        Execution restart = concurrencyLimitService.unqueue(execution.get());
+        Execution restart = concurrencyLimitService.unqueue(execution.get(), state);
         executionQueue.emit(restart);
         eventPublisher.publishEvent(new CrudEvent<>(restart, execution.get(), CrudEventType.UPDATE));
 
@@ -1940,7 +1940,8 @@ public class ExecutionController {
     @ApiResponse(responseCode = "200", description = "On success", content = {@Content(schema = @Schema(implementation = BulkResponse.class))})
     @ApiResponse(responseCode = "422", description = "Unqueued with errors", content = {@Content(schema = @Schema(implementation = BulkErrorResponse.class))})
     public MutableHttpResponse<?> unqueueExecutionsByIds(
-        @RequestBody(description = "The list of executions id") @Body List<String> executionsId
+        @RequestBody(description = "The list of executions id") @Body List<String> executionsId,
+        @Parameter(description = "The new state of the unqueued executions") @Nullable @QueryValue State.Type state
     ) throws Exception {
         List<Execution> executions = new ArrayList<>();
         Set<ManualConstraintViolation<String>> invalids = new HashSet<>();
@@ -1977,7 +1978,7 @@ public class ExecutionController {
             );
         }
         for (Execution execution : executions) {
-            Execution restart = concurrencyLimitService.unqueue(execution);
+            Execution restart = concurrencyLimitService.unqueue(execution, state);
             executionQueue.emit(restart);
             eventPublisher.publishEvent(new CrudEvent<>(restart, execution, CrudEventType.UPDATE));
         }
@@ -2004,7 +2005,8 @@ public class ExecutionController {
         @Deprecated @Parameter(description = "A state filter") @Nullable @QueryValue List<State.Type> state,
         @Deprecated @Parameter(description = "A labels filter as a list of 'key:value'") @Nullable @QueryValue @Format("MULTI") List<String> labels,
         @Deprecated @Parameter(description = "The trigger execution id") @Nullable @QueryValue String triggerExecutionId,
-        @Deprecated @Parameter(description = "A execution child filter") @Nullable @QueryValue ExecutionRepositoryInterface.ChildFilter childFilter
+        @Deprecated @Parameter(description = "A execution child filter") @Nullable @QueryValue ExecutionRepositoryInterface.ChildFilter childFilter,
+        @Parameter(description = "The new state of the unqueued executions") @Nullable @QueryValue State.Type newState
     ) throws Exception {
         filters = RequestUtils.getFiltersOrDefaultToLegacyMapping(
             filters,
@@ -2026,7 +2028,7 @@ public class ExecutionController {
 
         var ids = getExecutionIds(filters);
 
-        return unqueueExecutionsByIds(ids);
+        return unqueueExecutionsByIds(ids, newState);
     }
 
     @ExecuteOn(TaskExecutors.IO)

--- a/webserver/src/main/java/io/kestra/webserver/controllers/api/ExecutionController.java
+++ b/webserver/src/main/java/io/kestra/webserver/controllers/api/ExecutionController.java
@@ -1,6 +1,7 @@
 package io.kestra.webserver.controllers.api;
 
 import com.google.common.annotations.VisibleForTesting;
+import io.kestra.core.debug.Breakpoint;
 import io.kestra.core.events.CrudEvent;
 import io.kestra.core.events.CrudEventType;
 import io.kestra.core.exceptions.IllegalVariableEvaluationException;

--- a/webserver/src/test/java/io/kestra/webserver/controllers/api/ExecutionControllerRunnerTest.java
+++ b/webserver/src/test/java/io/kestra/webserver/controllers/api/ExecutionControllerRunnerTest.java
@@ -1372,7 +1372,7 @@ class ExecutionControllerRunnerTest {
         );
         assertThat(cancelResponse.getStatus().getCode()).isEqualTo(HttpStatus.OK.getCode());
 
-        Optional<Execution> cancelledExecution = executionRepositoryInterface.findById(null, result1.getId());
+        Optional<Execution> cancelledExecution = executionRepositoryInterface.findById(TENANT_ID, result1.getId());
         assertThat(cancelledExecution.isPresent()).isTrue();
         assertThat(cancelledExecution.get().getState().getCurrent()).isEqualTo(State.Type.CANCELLED);
     }

--- a/webserver/src/test/java/io/kestra/webserver/controllers/api/ExecutionControllerRunnerTest.java
+++ b/webserver/src/test/java/io/kestra/webserver/controllers/api/ExecutionControllerRunnerTest.java
@@ -1360,6 +1360,24 @@ class ExecutionControllerRunnerTest {
     }
 
     @Test
+    @LoadFlows({"flows/valids/flow-concurrency-queue.yml",
+        "flows/valids/minimal.yaml"})
+    void shouldUnqueueAQueuedFlowToCancelledState() throws QueueException, TimeoutException {
+        // run a first flow so the second is queued
+        runnerUtils.runOneUntilRunning(null, "io.kestra.tests", "flow-concurrency-queue");
+        Execution result1 = runUntilQueued("io.kestra.tests", "flow-concurrency-queue");
+
+        var cancelResponse = client.toBlocking().exchange(
+            HttpRequest.POST("/api/v1/executions/" + result1.getId() + "/unqueue?state=CANCELLED", null)
+        );
+        assertThat(cancelResponse.getStatus().getCode()).isEqualTo(HttpStatus.OK.getCode());
+
+        Optional<Execution> cancelledExecution = executionRepositoryInterface.findById(null, result1.getId());
+        assertThat(cancelledExecution.isPresent()).isTrue();
+        assertThat(cancelledExecution.get().getState().getCurrent()).isEqualTo(State.Type.CANCELLED);
+    }
+
+    @Test
     @LoadFlows({"flows/valids/flow-concurrency-queue.yml"})
     void shouldUnqueueExecutionByIdsQueuedFlows() throws TimeoutException, QueueException {
         // run a first flow so the others are queued

--- a/webserver/src/test/java/io/kestra/webserver/controllers/api/ExecutionControllerRunnerTest.java
+++ b/webserver/src/test/java/io/kestra/webserver/controllers/api/ExecutionControllerRunnerTest.java
@@ -1364,7 +1364,7 @@ class ExecutionControllerRunnerTest {
         "flows/valids/minimal.yaml"})
     void shouldUnqueueAQueuedFlowToCancelledState() throws QueueException, TimeoutException {
         // run a first flow so the second is queued
-        runnerUtils.runOneUntilRunning(null, "io.kestra.tests", "flow-concurrency-queue");
+        runnerUtils.runOneUntilRunning(TENANT_ID, "io.kestra.tests", "flow-concurrency-queue");
         Execution result1 = runUntilQueued("io.kestra.tests", "flow-concurrency-queue");
 
         var cancelResponse = client.toBlocking().exchange(


### PR DESCRIPTION
<!-- Thanks for submitting a Pull Request to Kestra. To help us review your contribution, please follow the guidelines below:

- Make sure that your commits follow the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) specification e.g. `feat(ui): add a new navigation menu item` or `fix(core): fix a bug in the core model` or `docs: update the README.md`. This will help us automatically generate the changelog.
- The title should briefly summarize the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share a flow example to help the reviewer understand and QA the change.
- Use "closes" to automatically close an issue. For example, `closes #1234` will close issue #1234. -->

### What changes are being made and why?
Allows queued executions to be moved to RUNNING (default), CANCELLED, or FAILED states when unqueued.

closes #5939 
