### PR TITLE
tests: make storybook tests pass with less warnings

### DIFF
--- a/ui/src/components/dashboard/components/States.vue
+++ b/ui/src/components/dashboard/components/States.vue
@@ -9,7 +9,7 @@
 </template>
 
 <script setup>
-    import {useScheme} from "../../../utils/scheme.js";
+    import {useScheme} from "../../../utils/scheme";
 
     const scheme = useScheme();
 

--- a/ui/src/components/dashboard/components/charts/executions/Doughnut.vue
+++ b/ui/src/components/dashboard/components/charts/executions/Doughnut.vue
@@ -38,7 +38,7 @@
     import {totalsLegend} from "../legend.js";
     import {useTheme} from "../../../../../utils/utils";
     import {defaultConfig} from "../../../../../utils/charts.js";
-    import {useScheme} from "../../../../../utils/scheme.js";
+    import {useScheme} from "../../../../../utils/scheme";
 
     const router = useRouter();
     const scheme = useScheme();

--- a/ui/src/components/dashboard/components/charts/executions/Namespace.vue
+++ b/ui/src/components/dashboard/components/charts/executions/Namespace.vue
@@ -39,7 +39,7 @@
     import {barLegend} from "../legend.js";
 
     import {defaultConfig} from "../../../../../utils/charts.js";
-    import {useScheme} from "../../../../../utils/scheme.js";
+    import {useScheme} from "../../../../../utils/scheme";
     import {useTheme} from "../../../../../utils/utils";
 
     import NoData from "../../../../layout/NoData.vue";

--- a/ui/src/components/dashboard/components/charts/logs/Bar.vue
+++ b/ui/src/components/dashboard/components/charts/logs/Bar.vue
@@ -39,7 +39,7 @@
     import {barLegend} from "../legend.js";
 
     import {defaultConfig, getFormat} from "../../../../../utils/charts.js";
-    import {useScheme} from "../../../../../utils/scheme.js";
+    import {useScheme} from "../../../../../utils/scheme";
     import Logs from "../../../../../utils/logs.js";
 
     import LogsNoData from "./LogsNoData.vue";

--- a/ui/src/components/executions/Executions.vue
+++ b/ui/src/components/executions/Executions.vue
@@ -280,7 +280,9 @@
                                     <template #content>
                                         <pre class="mb-0">{{ JSON.stringify(scope.row.inputs, null, "\t") }}</pre>
                                     </template>
-                                    <Import v-if="scope.row.inputs" class="fs-5" />
+                                    <div>
+                                        <Import v-if="scope.row.inputs" class="fs-5" />
+                                    </div>
                                 </el-tooltip>
                             </template>
                         </el-table-column>

--- a/ui/src/components/filter/components/Label.vue
+++ b/ui/src/components/filter/components/Label.vue
@@ -19,7 +19,7 @@
     const props = defineProps<{ option: CurrentItem; prefix: string }>();
 
     import {useFilters} from "../composables/useFilters";
-    const {COMPARATORS} = useFilters(props.prefix);
+    const {COMPARATORS} = useFilters(props.prefix, false);
 
     import moment from "moment";
     const DATE_FORMAT = localStorage.getItem("dateFormat") || "llll";
@@ -66,7 +66,7 @@ span {
     .operation {
         background: var(--ks-tag-background);
     }
-    
+
     .operation {
         border-left: 4px solid $white;
         border-right: 4px solid $white;

--- a/ui/src/components/filter/utils/types.ts
+++ b/ui/src/components/filter/utils/types.ts
@@ -22,7 +22,8 @@ export type Buttons = {
 };
 
 export type CurrentItem = {
-    label: string;
+    label?: string;
+    field?: string;
     value: string[] | { startDate: Date; endDate: Date }[];
     operation?: string;
     comparator?: Comparator;

--- a/ui/src/components/inputs/EditorView.vue
+++ b/ui/src/components/inputs/EditorView.vue
@@ -586,7 +586,7 @@
         return undefined;
     });
     const flowInfos = computed(() => store.getters["flow/flowInfos"]);
-    const flowHaveTasks = computed(() => store.getters["flow/flowHaveTasks"]);
+    const flowHaveTasks = computed(() => Boolean(store.getters["flow/flowHaveTasks"]));
 
     const editorViewType = useStorage(storageKeys.EDITOR_VIEW_TYPE, "YAML");
 

--- a/ui/src/components/stats/StateChart.vue
+++ b/ui/src/components/stats/StateChart.vue
@@ -21,7 +21,7 @@
     import {useRoute, useRouter} from "vue-router"
     import {Bar} from "vue-chartjs";
     import Utils, {useTheme} from "../../utils/utils";
-    import {useScheme} from "../../utils/scheme.js";
+    import {useScheme} from "../../utils/scheme";
     import {defaultConfig, tooltip, chartClick, getFormat} from "../../utils/charts.js";
     import {useI18n} from "vue-i18n";
 

--- a/ui/src/utils/charts.js
+++ b/ui/src/utils/charts.js
@@ -1,7 +1,7 @@
 import _merge from "lodash/merge";
 import Utils from "./utils";
 import {cssVariable, State} from "@kestra-io/ui-libs";
-import {getScheme} from "./scheme.js";
+import {getScheme} from "./scheme";
 
 export function tooltip(tooltipModel) {
     const titleLines = tooltipModel.title || [];

--- a/ui/src/utils/scheme.ts
+++ b/ui/src/utils/scheme.ts
@@ -1,0 +1,63 @@
+import {computed} from "vue";
+import {useStorage} from "@vueuse/core";
+import {useTheme} from "./utils"
+import {cssVariable} from "@kestra-io/ui-libs";
+
+const SCHEME = "scheme";
+const EXECUTIONS = Object.freeze({
+    CANCELLED: cssVariable("--ks-chart-cancelled"),
+    CREATED: cssVariable("--ks-chart-created"),
+    FAILED: cssVariable("--ks-chart-failed"),
+    KILLED: cssVariable("--ks-chart-killed"),
+    KILLING: cssVariable("--ks-chart-killing"),
+    PAUSED: cssVariable("--ks-chart-paused"),
+    QUEUED: cssVariable("--ks-chart-queued"),
+    RESTARTED: cssVariable("--ks-chart-restarted"),
+    RETRIED: cssVariable("--ks-chart-retried"),
+    RETRYING: cssVariable("--ks-chart-retrying"),
+    RUNNING: cssVariable("--ks-chart-running"),
+    SKIPPED: cssVariable("--ks-chart-skipped"),
+    SUCCESS: cssVariable("--ks-chart-success"),
+    WARNING: cssVariable("--ks-chart-warning"),
+});
+const LOGS = Object.freeze({
+    DEBUG: cssVariable("--ks-chart-debug"),
+    ERROR: cssVariable("--ks-chart-error"),
+    INFO: cssVariable("--ks-chart-info"),
+    TRACE: cssVariable("--ks-chart-trace"),
+    WARN: cssVariable("--ks-chart-warn"),
+});
+const TYPES = Object.freeze({
+    executions: EXECUTIONS,
+    logs: LOGS,
+});
+/**
+ * Allows scheme/theme customization.
+ */
+const OPTIONS = Object.freeze({
+    classic: {
+        light: TYPES,
+        dark: TYPES,
+    },
+    kestra: {
+        light: TYPES,
+        dark: TYPES,
+    },
+});
+
+export const setScheme = (value: "classic" | "kestra") => {
+    localStorage.setItem(SCHEME, value);
+};
+
+export const getScheme = (theme: "light" | "dark", state: "string", type: "executions" | "logs" = "executions") => {
+    const scheme = localStorage.getItem(SCHEME) as  "classic" | "kestra" ?? "classic";
+
+    return (OPTIONS[scheme]?.[theme]?.[type] as Record<string, string>)?.[state];
+};
+
+export const useScheme = (type: "executions" | "logs" = "executions") => {
+    const scheme = useStorage<"classic" | "kestra">(SCHEME, "classic");
+    const theme = useTheme();
+
+    return computed(() => OPTIONS[scheme.value]?.[theme.value]?.[type]);
+}

--- a/ui/src/utils/utils.ts
+++ b/ui/src/utils/utils.ts
@@ -311,5 +311,5 @@ export default class Utils {
 
 export const useTheme = () => {
     const store = useStore();
-    return computed(() => store.getters["misc/theme"]);
+    return computed<"light" | "dark">(() => store.getters["misc/theme"]);
 }

--- a/ui/tests/storybook/components/dashboard/charts/executions/Bar.stories.jsx
+++ b/ui/tests/storybook/components/dashboard/charts/executions/Bar.stories.jsx
@@ -1,7 +1,15 @@
 import Bar from "../../../../../../src/components/dashboard/components/charts/executions/Bar.vue";
+import {vueRouter} from "storybook-vue3-router";
 
 export default {
     title: "Dashboard/Charts/Executions/Bar",
+    decorators: [vueRouter([
+        {
+            path: "/",
+            name: "home",
+            component: {template: "<div>home</div>"}
+        }
+    ])],
     component: Bar,
     parameters: {
         layout: "centered",
@@ -17,7 +25,7 @@ const generateSampleData = (days) => {
     for (let i = 0; i < days; i++) {
         const date = new Date(now);
         date.setDate(date.getDate() - i);
-        
+
         const executionCounts = {};
         states.forEach(state => {
             executionCounts[state] = Math.floor(Math.random() * 50); // Random count between 0-50
@@ -38,7 +46,6 @@ const generateSampleData = (days) => {
 
 // Template for all stories
 const Template = (args) => ({
-    components: {Bar},
     setup() {
         return () => {
             return <div style="width: 800px;"><Bar {...args} /></div>
@@ -94,7 +101,7 @@ HourlyData.args = {
         };
     }),
     total: 500,
-}; 
+};
 
 // Story with execution names as labels
 export const ExecutionNamesAsLabels = Template.bind({});

--- a/ui/tests/storybook/components/dashboard/charts/executions/BarChart.stories.jsx
+++ b/ui/tests/storybook/components/dashboard/charts/executions/BarChart.stories.jsx
@@ -1,8 +1,16 @@
 import BarChart from "../../../../../../src/components/dashboard/components/charts/executions/BarChart.vue";
+import {vueRouter} from "storybook-vue3-router";
 
 export default {
     title: "Dashboard/Charts/Executions/BarChart",
     component: BarChart,
+    decorators: [vueRouter([
+        {
+            path: "/",
+            name: "home",
+            component: {template: "<div>home</div>"}
+        }
+    ])],
     parameters: {
         layout: "centered",
     },
@@ -52,6 +60,7 @@ const Template = (args) => ({
 // Story with 30 days of data
 export const ThirtyDays = Template.bind({});
 ThirtyDays.args = {
+    plugins: [],
     data: generateSampleData(30),
     total: 1500,
 };
@@ -59,6 +68,7 @@ ThirtyDays.args = {
 // Story with no data
 export const NoData = Template.bind({});
 NoData.args = {
+    plugins: [],
     data: [],
     total: 0,
 };
@@ -66,6 +76,7 @@ NoData.args = {
 // Story with single day data
 export const SingleDay = Template.bind({});
 SingleDay.args = {
+    plugins: [],
     data: generateSampleData(1),
     total: 50,
 };

--- a/ui/tests/storybook/components/dashboard/charts/executions/Namespace.stories.jsx
+++ b/ui/tests/storybook/components/dashboard/charts/executions/Namespace.stories.jsx
@@ -1,8 +1,16 @@
 import Namespace from "../../../../../../src/components/dashboard/components/charts/executions/Namespace.vue";
+import {vueRouter} from "storybook-vue3-router";
 
 export default {
     title: "Dashboard/Charts/Executions/Namespace",
     component: Namespace,
+    decorators: [vueRouter([
+        {
+            path: "/",
+            name: "home",
+            component: {template: "<div>home</div>"}
+        }
+    ])],
     parameters: {
         layout: "centered",
     },
@@ -113,8 +121,8 @@ CustomNamespaces.args = {
 // Story with super long namespace names
 export const LongNamespaces = Template.bind({});
 const customDataLong = generateNamespaceData(25, "super-long-namespace-name-");
-   
+
 LongNamespaces.args = {
     data: customDataLong,
     total: calculateTotal(customDataLong)
-}; 
+};

--- a/ui/tests/storybook/components/dashboard/components/Card.stories.tsx
+++ b/ui/tests/storybook/components/dashboard/components/Card.stories.tsx
@@ -1,4 +1,6 @@
+import {markRaw} from "vue";
 import type {Meta, StoryObj} from "@storybook/vue3";
+import {vueRouter} from "storybook-vue3-router";
 import Card from "../../../../../src/components/dashboard/components/Card.vue";
 import AccountMultiple from "vue-material-design-icons/AccountMultiple.vue";
 import ChartTimelineVariant from "vue-material-design-icons/ChartTimelineVariant.vue";
@@ -7,7 +9,23 @@ import ChartTimelineVariant from "vue-material-design-icons/ChartTimelineVariant
 const meta = {
     title: "Components/Dashboard/Card",
     component: Card,
-    tags: ["autodocs"],
+    decorators: [vueRouter([
+        {
+            path: "/",
+            name: "home",
+            component: {template: "<div>home</div>"}
+        },
+        {
+            path: "/users",
+            name: "users",
+            component: {template: "<div>users</div>"}
+        },
+        {
+            path: "/flows",
+            name: "flows",
+            component: {template: "<div>flows</div>"}
+        },
+    ])],
     argTypes: {
         icon: {
             control: "text",
@@ -38,7 +56,7 @@ type Story = StoryObj<typeof meta>;
 // Basic story
 export const Default: Story = {
     args: {
-        icon: AccountMultiple,
+        icon: markRaw(AccountMultiple),
         label: "Total Users",
         value: "1,234",
         redirect: {name: "users"}
@@ -48,7 +66,7 @@ export const Default: Story = {
 // Story with tooltip
 export const WithTooltip: Story = {
     args: {
-        icon: ChartTimelineVariant,
+        icon: markRaw(ChartTimelineVariant),
         label: "Active Flows",
         tooltip: "Number of flows that have been executed in the last 24 hours",
         value: "42",
@@ -59,12 +77,12 @@ export const WithTooltip: Story = {
 // Story with number value
 export const NumericValue: Story = {
     args: {
-        icon: AccountMultiple,
+        icon: markRaw(AccountMultiple),
         label: "New Users",
         value: 567,
         redirect: {name: "users"}
     }
-}; 
+};
 
 export const ThreeCardsInRow = {
     render: () => ({

--- a/ui/tests/storybook/components/executions/ForEachStatus.stories.jsx
+++ b/ui/tests/storybook/components/executions/ForEachStatus.stories.jsx
@@ -1,8 +1,22 @@
 import ForEachStatus from "../../../../src/components/executions/ForEachStatus.vue";
+import {vueRouter} from "storybook-vue3-router";
 
 const meta = {
     title: "components/ForEachStatus",
     component: ForEachStatus,
+    decorators: [
+        vueRouter([
+            {
+                path: "/",
+                name: "home",
+                component: {template: "<div>home</div>"}
+            },
+            {
+                path: "/executions",
+                name:"executions/list",
+                component: {template: "<div>executions</div>"}
+            },
+        ])]
 }
 
 export default meta;

--- a/ui/tests/storybook/components/filter/components/Label.stories.tsx
+++ b/ui/tests/storybook/components/filter/components/Label.stories.tsx
@@ -2,19 +2,19 @@ import Label from "../../../../../src/components/filter/components/Label.vue";
 
 export default {title: "filter/components/label", component: Label};
 
-export const Default = () => <Label option={{
+export const Default = () => <Label prefix="ks-" option={{
     label: "namespace",
     value: ["engineering.kestra.io"],
-    comparator: {label: "starts with", value: "starts with"}
+    comparator: {label: "starts with", value: "starts with"},
 }} />;
 
-export const MultipleValue = () => <Label option={{
+export const MultipleValue = () => <Label prefix="ks-" option={{
     label: "state",
     value: ["SUCCESS", "RUNNING"],
     comparator: {label: "is one of", value: "is one of", multiple: true}
 }} />;
 
-export const DateValue = () => <Label option={{
+export const DateValue = () => <Label prefix="ks-" option={{
     label: "absolute_date",
     value: [{startDate: new Date(), endDate: new Date()}],
     comparator: {label: "between", value: "between"}

--- a/ui/tests/storybook/components/flows/FlowEditor.stories.jsx
+++ b/ui/tests/storybook/components/flows/FlowEditor.stories.jsx
@@ -29,17 +29,20 @@ const Template = (args) => ({
     const store = useStore()
     store.$http = {
         get: async (uri) => {
-            console.log("get request", uri)
             if(uri.endsWith("/plugins")) {
                 return {data: []}
             }
+            console.log("get request", uri)
             return {data: {}}
         },
         post: async (uri) => {
-            console.log("post request", uri)
             if(uri.endsWith("/graph")) {
                 return {data: allowFailureDemo}
             }
+            if(uri.endsWith("/validate")) {
+                return {data: {}}
+            }
+            console.log("post request", uri)
             return {data: {}}
         }
     }

--- a/ui/tests/storybook/components/inputs/LowCodeEditor.stories.jsx
+++ b/ui/tests/storybook/components/inputs/LowCodeEditor.stories.jsx
@@ -1,9 +1,17 @@
 import {useStore} from "vuex";
+import {vueRouter} from "storybook-vue3-router";
 import LowCodeEditor from "../../../../src/components/inputs/LowCodeEditor.vue";
 
 export default {
     title: "Components/Inputs/LowCodeEditor",
     component: LowCodeEditor,
+    decorators: [vueRouter([
+            {
+                path: "/",
+                name: "home",
+                component: {template: "<div>home</div>"}
+            },
+        ])]
 };
 
 const Template= (args) => ({
@@ -14,7 +22,7 @@ const Template= (args) => ({
                 return  Promise.resolve({data: {}})
             }
         }
-        return () => <LowCodeEditor {...args} />;
+        return () => <div style="width:600px; height:600px;"><LowCodeEditor {...args} /></div>;
     }
 });
 

--- a/ui/tests/storybook/components/logs/LogLine.stories.jsx
+++ b/ui/tests/storybook/components/logs/LogLine.stories.jsx
@@ -192,7 +192,7 @@ export const MultipleLogLinesWithAllLevels = () => {
 export const ShortLogWithoutContext = () => {
     return (
         <ElCard>
-            <LogLine log={{level: "INFO", message: "test"}} />
+            <LogLine log={{level: "INFO", message: "test"}} level="INFO" />
         </ElCard>
     );
 }

--- a/ui/tests/storybook/theme/ShowCase.vue
+++ b/ui/tests/storybook/theme/ShowCase.vue
@@ -4,8 +4,6 @@
             <el-button size="large" @click="toast">
                 El Message
             </el-button>
-
-            <MessageBoxDemo />
         </div>
 
         <div class="my-2 flex flex-wrap items-center justify-center text-center">


### PR DESCRIPTION
The lots of warning that w ecan see in FE unit tests make them flaky.
We should avoid pollution as much as possible so we can at least test.

Here is my attempt to do so.

@MilosPaunovic can you review and merge ASAP?

TYTY 