### PR TITLE
feat(jdbc): add index to commonly queried fields in the WHERE conditions of the triggers table

### DIFF
--- a/core/src/main/java/io/kestra/core/metrics/MetricRegistry.java
+++ b/core/src/main/java/io/kestra/core/metrics/MetricRegistry.java
@@ -85,6 +85,8 @@ public class MetricRegistry {
     public static final String METRIC_SCHEDULER_TRIGGER_COUNT_DESCRIPTION = "Total number of executions triggered by the Scheduler";
     public static final String METRIC_SCHEDULER_TRIGGER_DELAY_DURATION = "scheduler.trigger.delay.duration";
     public static final String METRIC_SCHEDULER_TRIGGER_DELAY_DURATION_DESCRIPTION = "Trigger delay duration inside the Scheduler";
+    public static final String METRIC_SCHEDULER_TRIGGER_FIND_BATCH_DURATION = "scheduler.trigger.find.batch.duration";
+    public static final String METRIC_SCHEDULER_TRIGGER_FIND_BATCH_DURATION_DESCRIPTION = "Trigger select method duration inside the Scheduler";
     public static final String METRIC_SCHEDULER_EVALUATE_COUNT = "scheduler.evaluate.count";
     public static final String METRIC_SCHEDULER_EVALUATE_COUNT_DESCRIPTION = "Total number of triggers evaluated by the Scheduler";
     public static final String METRIC_SCHEDULER_EXECUTION_LOCK_DURATION = "scheduler.execution.lock.duration";

--- a/core/src/main/java/io/kestra/core/metrics/MetricRegistry.java
+++ b/core/src/main/java/io/kestra/core/metrics/MetricRegistry.java
@@ -85,14 +85,14 @@ public class MetricRegistry {
     public static final String METRIC_SCHEDULER_TRIGGER_COUNT_DESCRIPTION = "Total number of executions triggered by the Scheduler";
     public static final String METRIC_SCHEDULER_TRIGGER_DELAY_DURATION = "scheduler.trigger.delay.duration";
     public static final String METRIC_SCHEDULER_TRIGGER_DELAY_DURATION_DESCRIPTION = "Trigger delay duration inside the Scheduler";
-    public static final String METRIC_SCHEDULER_TRIGGER_FIND_BATCH_DURATION = "scheduler.trigger.find.batch.duration";
-    public static final String METRIC_SCHEDULER_TRIGGER_FIND_BATCH_DURATION_DESCRIPTION = "Trigger select method duration inside the Scheduler";
     public static final String METRIC_SCHEDULER_EVALUATE_COUNT = "scheduler.evaluate.count";
     public static final String METRIC_SCHEDULER_EVALUATE_COUNT_DESCRIPTION = "Total number of triggers evaluated by the Scheduler";
     public static final String METRIC_SCHEDULER_EXECUTION_LOCK_DURATION = "scheduler.execution.lock.duration";
     public static final String METRIC_SCHEDULER_EXECUTION_LOCK_DURATION_DESCRIPTION = "Trigger lock duration waiting for an execution to be terminated";
     public static final String METRIC_SCHEDULER_EXECUTION_MISSING_DURATION = "scheduler.execution.missing.duration";
     public static final String METRIC_SCHEDULER_EXECUTION_MISSING_DURATION_DESCRIPTION = "Missing execution duration inside the Scheduler. A missing execution is an execution that was triggered by the Scheduler but not yet started by the Executor";
+    public static final String METRIC_SCHEDULER_HANDLE_DURATION = "scheduler.handler.duration";
+    public static final String METRIC_SCHEDULER_HANDLE_DURATION_DESCRIPTION = "handler execution duration inside the Scheduler";
 
     public static final String METRIC_STREAMS_STATE_COUNT = "stream.state.count";
     public static final String METRIC_STREAMS_STATE_COUNT_DESCRIPTION = "Number of Kafka Stream applications by state";

--- a/core/src/main/java/io/kestra/core/schedulers/AbstractScheduler.java
+++ b/core/src/main/java/io/kestra/core/schedulers/AbstractScheduler.java
@@ -78,7 +78,7 @@ public abstract class AbstractScheduler implements Scheduler, Service {
     protected final FlowListenersInterface flowListeners;
     private final RunContextFactory runContextFactory;
     private final RunContextInitializer runContextInitializer;
-    private final MetricRegistry metricRegistry;
+    protected final MetricRegistry metricRegistry;
     private final ConditionService conditionService;
     private final PluginDefaultService pluginDefaultService;
     private final WorkerGroupService workerGroupService;

--- a/core/src/main/java/io/kestra/core/schedulers/AbstractScheduler.java
+++ b/core/src/main/java/io/kestra/core/schedulers/AbstractScheduler.java
@@ -3,7 +3,6 @@ package io.kestra.core.schedulers;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Lists;
 import io.kestra.core.events.CrudEvent;
 import io.kestra.core.events.CrudEventType;
 import io.kestra.core.exceptions.DeserializationException;
@@ -79,7 +78,7 @@ public abstract class AbstractScheduler implements Scheduler, Service {
     protected final FlowListenersInterface flowListeners;
     private final RunContextFactory runContextFactory;
     private final RunContextInitializer runContextInitializer;
-    protected final MetricRegistry metricRegistry;
+    private final MetricRegistry metricRegistry;
     private final ConditionService conditionService;
     private final PluginDefaultService pluginDefaultService;
     private final WorkerGroupService workerGroupService;
@@ -518,7 +517,7 @@ public abstract class AbstractScheduler implements Scheduler, Service {
         if (this.isPaused.get()) {
             return;
         }
-        Instant startInstant = Instant.now();
+        ZonedDateTime startTime = ZonedDateTime.now();
         ZonedDateTime now = now();
 
         final List<FlowWithSource> flowWithDefaults = getFlowsWithDefaults();
@@ -662,8 +661,8 @@ public abstract class AbstractScheduler implements Scheduler, Service {
                 });
         });
         metricRegistry
-            .timer(MetricRegistry.METRIC_SCHEDULER_HANDLE_DURATION, MetricRegistry.METRIC_SCHEDULER_HANDLE_DURATION_DESCRIPTION, Lists.newArrayList().toArray(new String[0]))
-            .record(Duration.between(startInstant, Instant.now()));
+            .timer(MetricRegistry.METRIC_SCHEDULER_HANDLE_DURATION, MetricRegistry.METRIC_SCHEDULER_HANDLE_DURATION_DESCRIPTION)
+            .record(Duration.between(startTime, Instant.now()));
     }
 
     private List<FlowWithSource> getFlowsWithDefaults() {

--- a/core/src/main/java/io/kestra/core/schedulers/AbstractScheduler.java
+++ b/core/src/main/java/io/kestra/core/schedulers/AbstractScheduler.java
@@ -662,7 +662,7 @@ public abstract class AbstractScheduler implements Scheduler, Service {
         });
         metricRegistry
             .timer(MetricRegistry.METRIC_SCHEDULER_HANDLE_DURATION, MetricRegistry.METRIC_SCHEDULER_HANDLE_DURATION_DESCRIPTION)
-            .record(Duration.between(startTime, Instant.now()));
+            .record(Duration.between(startTime, ZonedDateTime.now()));
     }
 
     private List<FlowWithSource> getFlowsWithDefaults() {

--- a/core/src/main/java/io/kestra/core/schedulers/AbstractScheduler.java
+++ b/core/src/main/java/io/kestra/core/schedulers/AbstractScheduler.java
@@ -3,6 +3,7 @@ package io.kestra.core.schedulers;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Lists;
 import io.kestra.core.events.CrudEvent;
 import io.kestra.core.events.CrudEventType;
 import io.kestra.core.exceptions.DeserializationException;
@@ -517,7 +518,7 @@ public abstract class AbstractScheduler implements Scheduler, Service {
         if (this.isPaused.get()) {
             return;
         }
-
+        Instant startInstant = Instant.now();
         ZonedDateTime now = now();
 
         final List<FlowWithSource> flowWithDefaults = getFlowsWithDefaults();
@@ -660,6 +661,9 @@ public abstract class AbstractScheduler implements Scheduler, Service {
                     }
                 });
         });
+        metricRegistry
+            .timer(MetricRegistry.METRIC_SCHEDULER_HANDLE_DURATION, MetricRegistry.METRIC_SCHEDULER_HANDLE_DURATION_DESCRIPTION, Lists.newArrayList().toArray(new String[0]))
+            .record(Duration.between(startInstant, Instant.now()));
     }
 
     private List<FlowWithSource> getFlowsWithDefaults() {

--- a/jdbc-h2/src/main/resources/migrations/h2/V1_36__triggers_index_on_next_execution_date.sql
+++ b/jdbc-h2/src/main/resources/migrations/h2/V1_36__triggers_index_on_next_execution_date.sql
@@ -1,0 +1,1 @@
+CREATE INDEX IF NOT EXISTS ix_next_execution_date ON triggers ("ix_next_execution_date");

--- a/jdbc-h2/src/main/resources/migrations/h2/V1_36__triggers_index_on_next_execution_date.sql
+++ b/jdbc-h2/src/main/resources/migrations/h2/V1_36__triggers_index_on_next_execution_date.sql
@@ -1,1 +1,1 @@
-CREATE INDEX IF NOT EXISTS ix_next_execution_date ON triggers ("ix_next_execution_date");
+CREATE INDEX IF NOT EXISTS ix_next_execution_date ON triggers ("next_execution_date");

--- a/jdbc-mysql/src/main/resources/migrations/mysql/V1_35__triggers_index_on_next_execution_date.sql
+++ b/jdbc-mysql/src/main/resources/migrations/mysql/V1_35__triggers_index_on_next_execution_date.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `triggers` ADD INDEX idx_next_execution_date(`next_execution_date`);

--- a/jdbc-mysql/src/main/resources/migrations/mysql/V1_35__triggers_index_on_next_execution_date.sql
+++ b/jdbc-mysql/src/main/resources/migrations/mysql/V1_35__triggers_index_on_next_execution_date.sql
@@ -1,1 +1,1 @@
-ALTER TABLE `triggers` ADD INDEX idx_next_execution_date(`next_execution_date`);
+CREATE INDEX ix_next_execution_date ON `triggers` (`next_execution_date`);

--- a/jdbc-postgres/src/main/resources/migrations/postgres/V1_35__triggers_index_on_next_execution_date.sql
+++ b/jdbc-postgres/src/main/resources/migrations/postgres/V1_35__triggers_index_on_next_execution_date.sql
@@ -1,0 +1,1 @@
+CREATE INDEX IF NOT EXISTS triggers_next_execution_date ON triggers (next_execution_date);

--- a/jdbc/src/main/java/io/kestra/jdbc/runner/JdbcScheduler.java
+++ b/jdbc/src/main/java/io/kestra/jdbc/runner/JdbcScheduler.java
@@ -1,7 +1,5 @@
 package io.kestra.jdbc.runner;
 
-import com.google.common.collect.Lists;
-import io.kestra.core.metrics.MetricRegistry;
 import io.kestra.core.models.flows.FlowWithSource;
 import io.kestra.core.models.triggers.Trigger;
 import io.kestra.core.repositories.TriggerRepositoryInterface;
@@ -17,8 +15,6 @@ import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 import lombok.extern.slf4j.Slf4j;
 
-import java.time.Duration;
-import java.time.Instant;
 import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.function.BiConsumer;
@@ -67,11 +63,7 @@ public class JdbcScheduler extends AbstractScheduler {
         JdbcSchedulerContext schedulerContext = new JdbcSchedulerContext(this.dslContextWrapper);
 
         schedulerContext.doInTransaction(scheduleContextInterface -> {
-            Instant startInstant = Instant.now();
             List<Trigger> triggers = this.triggerState.findByNextExecutionDateReadyForAllTenants(now, scheduleContextInterface);
-            metricRegistry
-                .timer(MetricRegistry.METRIC_SCHEDULER_TRIGGER_FIND_BATCH_DURATION, MetricRegistry.METRIC_SCHEDULER_TRIGGER_FIND_BATCH_DURATION_DESCRIPTION, Lists.newArrayList().toArray(new String[0]))
-                .record(Duration.between(startInstant, Instant.now()));
             consumer.accept(triggers, scheduleContextInterface);
         });
     }

--- a/jdbc/src/main/java/io/kestra/jdbc/runner/JdbcScheduler.java
+++ b/jdbc/src/main/java/io/kestra/jdbc/runner/JdbcScheduler.java
@@ -1,5 +1,7 @@
 package io.kestra.jdbc.runner;
 
+import com.google.common.collect.Lists;
+import io.kestra.core.metrics.MetricRegistry;
 import io.kestra.core.models.flows.FlowWithSource;
 import io.kestra.core.models.triggers.Trigger;
 import io.kestra.core.repositories.TriggerRepositoryInterface;
@@ -15,6 +17,8 @@ import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 import lombok.extern.slf4j.Slf4j;
 
+import java.time.Duration;
+import java.time.Instant;
 import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.function.BiConsumer;
@@ -63,8 +67,11 @@ public class JdbcScheduler extends AbstractScheduler {
         JdbcSchedulerContext schedulerContext = new JdbcSchedulerContext(this.dslContextWrapper);
 
         schedulerContext.doInTransaction(scheduleContextInterface -> {
+            Instant startInstant = Instant.now();
             List<Trigger> triggers = this.triggerState.findByNextExecutionDateReadyForAllTenants(now, scheduleContextInterface);
-
+            metricRegistry
+                .timer(MetricRegistry.METRIC_SCHEDULER_TRIGGER_FIND_BATCH_DURATION, MetricRegistry.METRIC_SCHEDULER_TRIGGER_FIND_BATCH_DURATION_DESCRIPTION, Lists.newArrayList().toArray(new String[0]))
+                .record(Duration.between(startInstant, Instant.now()));
             consumer.accept(triggers, scheduleContextInterface);
         });
     }


### PR DESCRIPTION
<!-- Thanks for submitting a Pull Request to Kestra. To help us review your contribution, please follow the guidelines below:

- Make sure that your commits follow the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) specification e.g. `feat(ui): add a new navigation menu item` or `fix(core): fix a bug in the core model` or `docs: update the README.md`. This will help us automatically generate the changelog.
- The title should briefly summarize the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share a flow example to help the reviewer understand and QA the change.
- Use "closes" to automatically close an issue. For example, `closes #1234` will close issue #1234. -->

### What changes are being made and why?

Changes: 
1. Add an index to the next_execution_date field in the triggers table
2. Add performance time metrics

Reason: 
* The next_execution_date field, which is frequently used in WHERE conditions of common SQL queries on the triggers table, does not have an index. Under high load conditions, an index needs to be added to improve query performance and the performance of the core handler() method

<!-- Please include a brief summary of the changes included in this PR e.g. closes #1234. -->

---

### How the changes have been QAed?
![image](https://github.com/user-attachments/assets/2f8c424c-c522-4d62-b14e-dcca5bad853e)
<!-- Include example code that shows how this PR has been QAed. The code should present a complete yet easily reproducible flow.

```yaml
# Your example flow code here
```

Note that this is not a replacement for unit tests but rather a way to demonstrate how the changes work in a real-life scenario, as the end-user would experience them.

Remove this section if this change applies to all flows or to the documentation only. -->
