### PR TITLE
test: ignore unhandled canceled promises in storybook

### DIFF
--- a/ui/.storybook/preview.jsx
+++ b/ui/.storybook/preview.jsx
@@ -37,4 +37,11 @@ setup((app) => {
   initApp(app, [], stores, en);
 });
 
+
+window.addEventListener("unhandledrejection", (evt) => {
+    if (evt?.reason?.stack?.includes?.("/monaco/esm/vs") || evt?.reason?.stack?.includes?.("/monaco/min/vs")) {
+        evt.stopImmediatePropagation()
+    }
+})
+
 export default preview;


### PR DESCRIPTION
This is to make FE tests finally pass even with the cancelled Promise from monaco