### PR TITLE
fix(core)*: allow horizontal scrolling of tabs in multi panel view

### DIFF
--- a/ui/src/components/MultiPanelTabs.vue
+++ b/ui/src/components/MultiPanelTabs.vue
@@ -8,7 +8,7 @@
             @dragover.prevent="(e) => panelDragOver(e, panelIndex)"
             @dragleave.prevent="panelDragLeave"
             @drop.prevent="(e) => panelDrop(e, panelIndex)"
-            :class="{'panel-dragover': panel.dragover}"
+            :class="{'d-block': true, 'panel-dragover': panel.dragover}"
         >
             <div class="editor-tabs-container">
                 <el-button 


### PR DESCRIPTION
If there are multiple tabs opened in a single panel of the new multi panel view,  there was no ability to scroll and see the overflowing ones. With changes in this PR, users can now do just that.

Closes https://github.com/kestra-io/kestra/issues/8270.