### PR TITLE
refactor(core): replace deprecated vue flow options parameter

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "dependencies": {
         "@js-joda/core": "^5.6.5",
-        "@kestra-io/ui-libs": "^0.0.168",
+        "@kestra-io/ui-libs": "^0.0.169",
         "@vue-flow/background": "^1.3.2",
         "@vue-flow/controls": "^1.1.2",
         "@vue-flow/core": "^1.42.5",
@@ -2676,9 +2676,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@kestra-io/ui-libs": {
-      "version": "0.0.168",
-      "resolved": "https://registry.npmjs.org/@kestra-io/ui-libs/-/ui-libs-0.0.168.tgz",
-      "integrity": "sha512-kkYgLaRIsM9+eoXQfns56okCcdmKebGgpzqidvhCQz9oamQL6XcexBGSR7xfGJIIQfuiTIg7uWSqTEj9udt4sA==",
+      "version": "0.0.169",
+      "resolved": "https://registry.npmjs.org/@kestra-io/ui-libs/-/ui-libs-0.0.169.tgz",
+      "integrity": "sha512-mmpq9Y3cbH7wXeiiZNGEtNwzl6Lb2X8lxFzCi4D4/k9U1/KvKh39mZmnppUB4PfBkZ5gSu+02XGOza6rUJFeMw==",
       "dependencies": {
         "@nuxtjs/mdc": "^0.12.1",
         "@popperjs/core": "^2.11.8",

--- a/ui/package.json
+++ b/ui/package.json
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "@js-joda/core": "^5.6.5",
-    "@kestra-io/ui-libs": "^0.0.168",
+    "@kestra-io/ui-libs": "^0.0.169",
     "@vue-flow/background": "^1.3.2",
     "@vue-flow/controls": "^1.1.2",
     "@vue-flow/core": "^1.42.5",

--- a/ui/src/components/inputs/LowCodeEditor.vue
+++ b/ui/src/components/inputs/LowCodeEditor.vue
@@ -131,8 +131,7 @@
     const router = useRouter();
 
     const vueflowId = ref(Math.random().toString());
-    // Vue flow methods to interact with Graph
-    const {fitView} = useVueFlow({id: vueflowId.value});
+    const {fitView} = useVueFlow(vueflowId.value);
 
     // props
     const props = defineProps({

--- a/ui/src/stores/flow.js
+++ b/ui/src/stores/flow.js
@@ -22,7 +22,6 @@ export default {
         total: 0,
         overallTotal: undefined,
         flowGraph: undefined,
-        flowGraphParam: undefined,
         revisions: undefined,
         flowValidation: undefined,
         taskError: undefined,
@@ -436,12 +435,6 @@ export default {
             }
             return this.$http.get(`${apiUrl(this)}/flows/${flow.namespace}/${flow.id}/graph`, {params}).then(response => {
                 commit("setFlowGraph", response.data)
-                commit("setFlowGraphParam", {
-                    namespace: flow.namespace,
-                    id: flow.id,
-                    revision: flow.revision
-                })
-
                 return response.data;
             })
         },
@@ -463,11 +456,6 @@ export default {
                     // prevent losing revision when loading graph from source
                     flow.revision = state.flow?.revision;
                     commit("setFlow", flow);
-                    commit("setFlowGraphParam", {
-                        namespace: flow.namespace ? flow.namespace : "default",
-                        id: flow.id ? flow.id : "default",
-                        revision: flow.revision
-                    })
 
                     return response;
                 }).catch(error => {
@@ -600,15 +588,6 @@ export default {
         setFlow(state, flow) {
             state.flow = flow;
             state.lastSaveFlow = flow;
-            // if (state.flowGraph !== undefined && state.flowGraphParam && flow) {
-            //     if (state.flowGraphParam.namespace !== flow.namespace || state.flowGraphParam.id !== flow.id) {
-            //         state.flowGraph = undefined
-            //     }
-            // }
-
-        },
-        setFlowGraphParam(state, flow) {
-            state.flowGraphParam = flow
         },
         setTask(state, task) {
             state.task = task;

--- a/ui/src/utils/vueFlow.js
+++ b/ui/src/utils/vueFlow.js
@@ -2,7 +2,7 @@ import {useVueFlow} from "@vue-flow/core"
 
 
 export const predecessorsEdge = (vueFlowId, nodeUid) => {
-    const {getEdges} = useVueFlow({id: vueFlowId});
+    const {getEdges} = useVueFlow(vueFlowId);
 
     let nodes = [];
 
@@ -20,7 +20,7 @@ export const predecessorsEdge = (vueFlowId, nodeUid) => {
 }
 
 export const successorsEdge = (vueFlowId, nodeUid) => {
-    const {getEdges} = useVueFlow({id: vueFlowId});
+    const {getEdges} = useVueFlow(vueFlowId);
 
     let nodes = [];
 
@@ -38,7 +38,7 @@ export const successorsEdge = (vueFlowId, nodeUid) => {
 }
 
 export const predecessorsNode = (vueFlowId, nodeUid) => {
-    const {getEdges, findNode} = useVueFlow({id: vueFlowId});
+    const {getEdges, findNode} = useVueFlow(vueFlowId);
 
     let nodes = [findNode(nodeUid)];
 
@@ -56,7 +56,7 @@ export const predecessorsNode = (vueFlowId, nodeUid) => {
 }
 
 export const successorsNode = (vueFlowId, nodeUid) => {
-    const {getEdges, findNode} = useVueFlow({id: vueFlowId});
+    const {getEdges, findNode} = useVueFlow(vueFlowId);
 
     let nodes = [findNode(nodeUid)];
 


### PR DESCRIPTION
Remove usage of the deprecated options object parameter with the id one, as per the latest API guidelines. This change ensures compatibility with future versions and removes the related console warning.

Related to https://github.com/kestra-io/kestra/issues/7804.