### PR TITLE
refactor(core): prevent inheriting unused attributes in components

### DIFF
--- a/ui/src/components/flows/tasks/TaskRoot.vue
+++ b/ui/src/components/flows/tasks/TaskRoot.vue
@@ -12,6 +12,7 @@
     import TaskObject from "./TaskObject.vue";
 
     export default {
+        inheritAttrs: false,
         components: {
             TaskObject,
         },

--- a/ui/src/components/flows/tasks/TaskTask.vue
+++ b/ui/src/components/flows/tasks/TaskTask.vue
@@ -42,6 +42,7 @@
     import {SECTIONS as SECTION} from "../../../utils/constants";
 
     export default {
+        inheritAttrs: false,
         mixins: [Task],
         components: {TaskEditor, Drawer},
         emits: ["update:modelValue"],


### PR DESCRIPTION
Remove default inheriting of attributes in Vue components, which are not used. This pollutes the console with warnings and it's not necessary, so this PR is solving the problem.