### PR TITLE
fix(ui): adjust error notification max height to prevent overflow

### DIFF
--- a/ui/src/components/ErrorToast.vue
+++ b/ui/src/components/ErrorToast.vue
@@ -91,6 +91,8 @@
 
 <style lang="scss">
     .error-notification {
+        max-height: 90svh;
+
         .el-notification__title {
             max-width: calc(100% - 15ch);
         }
@@ -100,6 +102,11 @@
             right: calc(15px + 2rem);
             transform: translateY(-50%);
             gap: .5rem;
+        }
+
+        .el-notification__content {
+            overflow-y: auto;
+            max-height: 100%;
         }
     }
 </style>


### PR DESCRIPTION
closes #8352 
The max height of the Elements Plus component used is not set, so it can overflow on the y-axis. The max height is added, and the content is set to scroll on overflow.