### PR TITLE
fix(core): add warn log when emit logQueue failed

### DIFF
--- a/core/src/main/java/io/kestra/core/runners/RunContextLogger.java
+++ b/core/src/main/java/io/kestra/core/runners/RunContextLogger.java
@@ -312,6 +312,7 @@ public class RunContextLogger implements Supplier<org.slf4j.Logger> {
         }
     }
 
+    @Slf4j
     public static class ContextAppender extends BaseAppender {
         private final QueueInterface<LogEntry> logQueue;
         private final LogEntry logEntry;
@@ -327,11 +328,11 @@ public class RunContextLogger implements Supplier<org.slf4j.Logger> {
             e = this.transform(e);
 
             logEntries(e, logEntry)
-                .forEach(log -> {
+                .forEach(l -> {
                     try {
-                        logQueue.emitAsync(log);
+                        logQueue.emitAsync(l);
                     } catch (QueueException ex) {
-                        // silently do nothing
+                        log.warn("Unable to emit logQueue", ex);
                     }
                 });
         }


### PR DESCRIPTION
When the sending to the logQueue fails, record a warning log, so as to facilitate the detection of problems.