### PR TITLE
feat: synchronize task edition with editor

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "dependencies": {
         "@js-joda/core": "^5.6.5",
-        "@kestra-io/ui-libs": "^0.0.168",
+        "@kestra-io/ui-libs": "^0.0.170",
         "@vue-flow/background": "^1.3.2",
         "@vue-flow/controls": "^1.1.2",
         "@vue-flow/core": "^1.42.5",
@@ -2676,9 +2676,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@kestra-io/ui-libs": {
-      "version": "0.0.168",
-      "resolved": "https://registry.npmjs.org/@kestra-io/ui-libs/-/ui-libs-0.0.168.tgz",
-      "integrity": "sha512-kkYgLaRIsM9+eoXQfns56okCcdmKebGgpzqidvhCQz9oamQL6XcexBGSR7xfGJIIQfuiTIg7uWSqTEj9udt4sA==",
+      "version": "0.0.170",
+      "resolved": "https://registry.npmjs.org/@kestra-io/ui-libs/-/ui-libs-0.0.170.tgz",
+      "integrity": "sha512-vCTstZtmpQN/bN8f6wdjL7+g4zsJgXNFD0UNo55LOLgmnG7KYIJaFRKL7GSYp8RCy4A7vwcH23rmt6NRID1M8w==",
       "dependencies": {
         "@nuxtjs/mdc": "^0.12.1",
         "@popperjs/core": "^2.11.8",

--- a/ui/package.json
+++ b/ui/package.json
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "@js-joda/core": "^5.6.5",
-    "@kestra-io/ui-libs": "^0.0.168",
+    "@kestra-io/ui-libs": "^0.0.170",
     "@vue-flow/background": "^1.3.2",
     "@vue-flow/controls": "^1.1.2",
     "@vue-flow/core": "^1.42.5",

--- a/ui/src/components/MultiPanelTabs.vue
+++ b/ui/src/components/MultiPanelTabs.vue
@@ -1,9 +1,9 @@
 <template>
     <Splitpanes class="default-theme" @resize="onResize">
-        <Pane 
-            v-for="(panel, panelIndex) in panels" 
-            min-size="10" 
-            :key="panelIndex" 
+        <Pane
+            v-for="(panel, panelIndex) in panels"
+            min-size="10"
+            :key="panelIndex"
             :size="panel.size"
             @dragover.prevent="(e) => panelDragOver(e, panelIndex)"
             @dragleave.prevent="panelDragLeave"
@@ -11,12 +11,12 @@
             :class="{'d-block': true, 'panel-dragover': panel.dragover}"
         >
             <div class="editor-tabs-container">
-                <el-button 
-                    :icon="DragVertical" 
-                    link 
-                    class="tab-icon drag-handle" 
+                <el-button
+                    :icon="DragVertical"
+                    link
+                    class="tab-icon drag-handle"
                     draggable="true"
-                    @dragstart="(e) => panelDragStart(e, panelIndex)"
+                    @dragstart="(e:DragEvent) => panelDragStart(e, panelIndex)"
                 />
                 <div
                     class="editor-tabs"
@@ -73,13 +73,13 @@
                         />
                     </svg>
                 </button>
-                
+
                 <el-dropdown trigger="click" placement="bottom-end">
                     <el-button :icon="DotsVertical" link class="me-2 tab-icon" />
                     <template #dropdown>
                         <el-dropdown-menu class="m-2">
-                            <el-dropdown-item 
-                                :icon="DockRight" 
+                            <el-dropdown-item
+                                :icon="DockRight"
                                 :disabled="panelIndex === panels.length - 1"
                                 @click="movePanel(panelIndex, 'right')"
                             >
@@ -87,8 +87,8 @@
                                     {{ t("multi_panel_editor.move_right") }}
                                 </span>
                             </el-dropdown-item>
-                            <el-dropdown-item 
-                                :icon="DockLeft" 
+                            <el-dropdown-item
+                                :icon="DockLeft"
                                 :disabled="panelIndex === 0"
                                 @click="movePanel(panelIndex, 'left')"
                             >
@@ -419,7 +419,7 @@
 
     function panelDragOver(e: DragEvent, panelIndex: number) {
         if (draggingPanel.value === null || draggingPanel.value === panelIndex) return;
-        
+
         panels.value.forEach(panel => panel.dragover = false);
         panels.value[panelIndex].dragover = true;
     }
@@ -434,9 +434,9 @@
         const panelsCopy = [...panels.value];
         const [movedPanel] = panelsCopy.splice(draggingPanel.value, 1);
         panelsCopy.splice(targetPanelIndex, 0, movedPanel);
-        
+
         panels.value = panelsCopy;
-        
+
         draggingPanel.value = null;
         panelDragLeave();
     }

--- a/ui/src/components/code/NoCode.vue
+++ b/ui/src/components/code/NoCode.vue
@@ -15,8 +15,7 @@
 </template>
 
 <script setup lang="ts">
-    import {onBeforeMount, computed, provide, ref} from "vue";
-    import {useRouter, useRoute} from "vue-router";
+    import {computed, provide, ref} from "vue";
     import {YamlUtils as YAML_UTILS} from "@kestra-io/ui-libs";
 
     import {CREATING_INJECTION_KEY, FLOW_INJECTION_KEY, POSITION_INJECTION_KEY, SAVEMODE_INJECTION_KEY, SECTION_INJECTION_KEY, TASKID_INJECTION_KEY} from "./injectionKeys";
@@ -34,37 +33,28 @@
         defineProps<{
             flow: string;
             saveMode?: "button" | "auto";
+            creating?: boolean;
+            position?: "before" | "after";
         }>(), {
             saveMode: "button",
+            creating: false,
+            position: "after",
         });
 
-    const flowBreadcrumbs = computed(() => YAML_UTILS.parse(props.flow) as Record<string, string>)
+    const flowBreadcrumbs = computed(() => YAML_UTILS.parse<{id:string}>(props.flow) ?? {id: ""});
     const metadata = computed(() => YAML_UTILS.getMetadata(props.flow));
 
-
-    const router = useRouter();
-    const route = useRoute();
 
     const section = ref<string>("")
     const taskId = ref<string>("")
 
-    const position = computed(() => {
-        return route.query.position as "before" | "after";
-    });
 
     provide(FLOW_INJECTION_KEY, props.flow);
     provide(SECTION_INJECTION_KEY, section);
     provide(TASKID_INJECTION_KEY, taskId);
-    provide(POSITION_INJECTION_KEY, position);
+    provide(POSITION_INJECTION_KEY, props.position);
     provide(SAVEMODE_INJECTION_KEY, props.saveMode);
-    provide(CREATING_INJECTION_KEY, route.query.identifier === "new" ||
-        route.name === "flows/create");
-
-    onBeforeMount(async () => {
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
-        const {section, identifier, type, ...rest} = route.query;
-        router.replace({query: {...rest}});
-    });
+    provide(CREATING_INJECTION_KEY, taskId.value === "new" || props.creating);
 </script>
 
 <style scoped lang="scss">

--- a/ui/src/components/code/NoCode.vue
+++ b/ui/src/components/code/NoCode.vue
@@ -15,11 +15,11 @@
 </template>
 
 <script setup lang="ts">
-    import {onBeforeMount, computed, provide} from "vue";
+    import {onBeforeMount, computed, provide, ref} from "vue";
     import {useRouter, useRoute} from "vue-router";
     import {YamlUtils as YAML_UTILS} from "@kestra-io/ui-libs";
 
-    import {CREATING_INJECTION_KEY, FLOW_INJECTION_KEY, SAVEMODE_INJECTION_KEY} from "./injectionKeys";
+    import {CREATING_INJECTION_KEY, FLOW_INJECTION_KEY, POSITION_INJECTION_KEY, SAVEMODE_INJECTION_KEY, SECTION_INJECTION_KEY, TASKID_INJECTION_KEY} from "./injectionKeys";
     import Breadcrumbs from "./components/Breadcrumbs.vue";
     import Editor from "./segments/Editor.vue";
 
@@ -45,7 +45,17 @@
     const router = useRouter();
     const route = useRoute();
 
+    const section = ref<string>("")
+    const taskId = ref<string>("")
+
+    const position = computed(() => {
+        return route.query.position as "before" | "after";
+    });
+
     provide(FLOW_INJECTION_KEY, props.flow);
+    provide(SECTION_INJECTION_KEY, section);
+    provide(TASKID_INJECTION_KEY, taskId);
+    provide(POSITION_INJECTION_KEY, position);
     provide(SAVEMODE_INJECTION_KEY, props.saveMode);
     provide(CREATING_INJECTION_KEY, route.query.identifier === "new" ||
         route.name === "flows/create");

--- a/ui/src/components/code/NoCode.vue
+++ b/ui/src/components/code/NoCode.vue
@@ -61,7 +61,7 @@
     const injectedTaskId = ref<string>(props.taskId)
 
 
-    provide(FLOW_INJECTION_KEY, props.flow);
+    provide(FLOW_INJECTION_KEY, computed(() => props.flow));
     provide(SECTION_INJECTION_KEY, injectedSection);
     provide(TASKID_INJECTION_KEY, injectedTaskId);
     provide(POSITION_INJECTION_KEY, props.position);

--- a/ui/src/components/code/NoCode.vue
+++ b/ui/src/components/code/NoCode.vue
@@ -33,28 +33,40 @@
         defineProps<{
             flow: string;
             saveMode?: "button" | "auto";
+            /**
+             * Initial section name when opening
+             * a no-code panel from topology
+             */
+            section?: string;
+            /**
+             * Initial task id when opening
+             * a no-code panel from topology
+             */
+            taskId?: string;
             creating?: boolean;
             position?: "before" | "after";
         }>(), {
             saveMode: "button",
             creating: false,
             position: "after",
+            section: "",
+            taskId: "",
         });
 
     const flowBreadcrumbs = computed(() => YAML_UTILS.parse<{id:string}>(props.flow) ?? {id: ""});
     const metadata = computed(() => YAML_UTILS.getMetadata(props.flow));
 
 
-    const section = ref<string>("")
-    const taskId = ref<string>("")
+    const injectedSection = ref<string>(props.section)
+    const injectedTaskId = ref<string>(props.taskId)
 
 
     provide(FLOW_INJECTION_KEY, props.flow);
-    provide(SECTION_INJECTION_KEY, section);
-    provide(TASKID_INJECTION_KEY, taskId);
+    provide(SECTION_INJECTION_KEY, injectedSection);
+    provide(TASKID_INJECTION_KEY, injectedTaskId);
     provide(POSITION_INJECTION_KEY, props.position);
     provide(SAVEMODE_INJECTION_KEY, props.saveMode);
-    provide(CREATING_INJECTION_KEY, taskId.value === "new" || props.creating);
+    provide(CREATING_INJECTION_KEY, computed(() => injectedTaskId.value === "new" || props.creating));
 </script>
 
 <style scoped lang="scss">

--- a/ui/src/components/code/NoCode.vue
+++ b/ui/src/components/code/NoCode.vue
@@ -20,10 +20,11 @@
 </template>
 
 <script setup lang="ts">
-    import {onBeforeMount, computed} from "vue";
-
+    import {onBeforeMount, computed, provide} from "vue";
+    import {useRouter, useRoute} from "vue-router";
     import {YamlUtils as YAML_UTILS} from "@kestra-io/ui-libs";
 
+    import {CREATING_INJECTION_KEY, FLOW_INJECTION_KEY, SAVEMODE_INJECTION_KEY} from "./injectionKeys";
     import Breadcrumbs from "./components/Breadcrumbs.vue";
     import Editor from "./segments/Editor.vue";
 
@@ -34,16 +35,25 @@
         "reorder",
     ]);
 
-    const props = defineProps<{
-        flow: string;
-    }>();
+    const props = withDefaults(
+        defineProps<{
+            flow: string;
+            saveMode?: "button" | "auto";
+        }>(), {
+            saveMode: "button",
+        });
 
     const flowBreadcrumbs = computed(() => YAML_UTILS.parse(props.flow) as Record<string, string>)
     const metadata = computed(() => YAML_UTILS.getMetadata(props.flow));
 
-    import {useRouter, useRoute} from "vue-router";
+
     const router = useRouter();
     const route = useRoute();
+
+    provide(FLOW_INJECTION_KEY, props.flow);
+    provide(SAVEMODE_INJECTION_KEY, props.saveMode);
+    provide(CREATING_INJECTION_KEY, route.query.identifier === "new" ||
+        route.name === "flows/create");
 
     onBeforeMount(async () => {
         // eslint-disable-next-line @typescript-eslint/no-unused-vars

--- a/ui/src/components/code/NoCode.vue
+++ b/ui/src/components/code/NoCode.vue
@@ -66,7 +66,7 @@
     provide(TASKID_INJECTION_KEY, injectedTaskId);
     provide(POSITION_INJECTION_KEY, props.position);
     provide(SAVEMODE_INJECTION_KEY, props.saveMode);
-    provide(CREATING_INJECTION_KEY, computed(() => props.creating));
+    provide(CREATING_INJECTION_KEY, ref(props.creating));
 </script>
 
 <style scoped lang="scss">

--- a/ui/src/components/code/NoCode.vue
+++ b/ui/src/components/code/NoCode.vue
@@ -5,11 +5,6 @@
         <hr class="m-0">
 
         <Editor
-            :creation="
-                route.query.identifier === 'new' ||
-                    route.name === 'flows/create'
-            "
-            :flow
             :metadata
             @update-metadata="(k, v) => emits('updateMetadata', {[k]: v})"
             @update-task="(yaml) => emits('updateTask', yaml)"

--- a/ui/src/components/code/NoCodeWrapper.vue
+++ b/ui/src/components/code/NoCodeWrapper.vue
@@ -2,7 +2,7 @@
     <NoCode
         :flow="lastValidFlowYaml"
         save-mode="auto"
-        @update-metadata="(e) => onUpdateMetadata(e, true)"
+        @update-metadata="(e) => onUpdateMetadata(e)"
         @update-task="(e) => editorUpdate(e)"
         @reorder="(yaml) => handleReorder(yaml)"
         @update-documentation="(task) => updatePluginDocumentation(undefined, task)"
@@ -29,18 +29,27 @@
         }
     }, {immediate: true});
 
-    const onUpdateMetadata = (metadata: any, shouldSave: boolean) => {
-        if(shouldSave) {
-            store.commit("flow/setMetadata", {...metadata.value, ...(metadata.concurrency?.limit === 0 ? {concurrency: null} : metadata)});
-            store.dispatch("flow/onSaveMetadata");
-            store.dispatch("flow/validateFlow", {flow: flowYaml.value});
-        } else {
-            store.commit("flow/setMetadata", metadata.concurrency?.limit === 0 ?  {concurrency: null} : metadata);
-        }
+    const onUpdateMetadata = (metadata: any) => {
+        store.commit("flow/setMetadata", {
+            ...metadata.value,
+            ...((metadata.concurrency?.limit ?? -1) === 0 ? {
+                concurrency: null
+            } : metadata)});
+        store.dispatch("flow/onSaveMetadata");
+        store.dispatch("flow/validateFlow", {flow: flowYaml.value});
+        store.commit("editor/setTabDirty", {
+            name: "Flow",
+            dirty: true
+        });
     };
 
     const editorUpdate = (source: string) => {
         store.commit("flow/setFlowYaml", source);
+        store.commit("flow/setHaveChange", true);
+        store.commit("editor/setTabDirty", {
+            name: "Flow",
+            dirty: true
+        });
     };
 
     const handleReorder = (source: string) => {
@@ -50,6 +59,6 @@
     };
 
     const updatePluginDocumentation = (event: string | undefined, task: any) => {
-        store.dispatch("plugin/updateDocumentation", {event,task});
+        store.dispatch("plugin/updateDocumentation", {event, task});
     };
 </script>

--- a/ui/src/components/code/NoCodeWrapper.vue
+++ b/ui/src/components/code/NoCodeWrapper.vue
@@ -2,6 +2,8 @@
     <NoCode
         :flow="lastValidFlowYaml"
         save-mode="auto"
+        :creating="creating"
+        :position="route.query.position === 'before' ? 'before' : 'after'"
         @update-metadata="(e) => onUpdateMetadata(e)"
         @update-task="(e) => editorUpdate(e)"
         @reorder="(yaml) => handleReorder(yaml)"
@@ -10,24 +12,28 @@
 </template>
 
 <script setup lang="ts">
-    import {computed, ref, watch} from "vue";
+    import {computed} from "vue";
     import {useStore} from "vuex";
+    import {useRoute} from "vue-router"
     import {YamlUtils as YAML_UTILS} from "@kestra-io/ui-libs";
     import NoCode from "./NoCode.vue";
 
     const store = useStore();
     const flowYaml = computed(() => store.getters["flow/flowYaml"]);
+    const creating = computed(() => store.getters["flow/isCreating"]);
 
-    const lastValidFlowYaml = ref("");
+    const route = useRoute();
 
-    watch(flowYaml, (newVal) => {
-        try {
-            YAML_UTILS.parse(flowYaml.value);
-            lastValidFlowYaml.value = newVal;
-        } catch {
-            // do nothing
+    const lastValidFlowYaml = computed<string>(
+        (oldValue) => {
+            try {
+                YAML_UTILS.parse(flowYaml.value);
+                return flowYaml.value;
+            } catch {
+                return oldValue ?? "";
+            }
         }
-    }, {immediate: true});
+    );
 
     const onUpdateMetadata = (metadata: any) => {
         store.commit("flow/setMetadata", {

--- a/ui/src/components/code/NoCodeWrapper.vue
+++ b/ui/src/components/code/NoCodeWrapper.vue
@@ -1,6 +1,7 @@
 <template>
     <NoCode
         :flow="lastValidFlowYaml"
+        save-mode="auto"
         @update-metadata="(e) => onUpdateMetadata(e, true)"
         @update-task="(e) => editorUpdate(e)"
         @reorder="(yaml) => handleReorder(yaml)"

--- a/ui/src/components/code/components/Breadcrumbs.vue
+++ b/ui/src/components/code/components/Breadcrumbs.vue
@@ -6,70 +6,73 @@
             class="item"
             @click="
                 (store.commit('code/removeBreadcrumb', {position: index}),
-                 store.commit('code/unsetPanel', false))
+                 store.commit('code/unsetPanel', false),
+                 clickBreadCrumb(index)
+                )
             "
         >
-            <router-link :to="breadcrumb.to">
-                {{ breadcrumb.label }}
-            </router-link>
+            {{ breadcrumb.label }}
         </el-breadcrumb-item>
     </el-breadcrumb>
 </template>
 
 <script setup lang="ts">
-    import {computed, onMounted, watch} from "vue";
-
-    import {useRoute} from "vue-router";
-    const route = useRoute();
+    import {computed, inject, onMounted, ref, watch} from "vue";
 
     import {useStore} from "vuex";
     const store = useStore();
 
     import {useI18n} from "vue-i18n";
+    import {SECTION_INJECTION_KEY, TASKID_INJECTION_KEY} from "../injectionKeys";
     const {t} = useI18n({useScope: "global"});
 
-    const props = defineProps({flow: {type: Object, required: true}});
+    const props = defineProps<{
+        flow: {
+            id: string;
+        };
+    }>();
 
     store.commit("code/clearBreadcrumbs");
 
     const breadcrumbs = computed(() => store.state.code.breadcrumbs);
-
-    const params = {
-        namespace: route.params.namespace,
-        id: props.flow.id ?? "new",
-        tab: "edit",
-    };
+    const taskId = inject(TASKID_INJECTION_KEY, ref(""));
+    const taskSection = inject(SECTION_INJECTION_KEY, ref(""));
 
     onMounted(() => {
         store.commit("code/addBreadcrumbs", {
             breadcrumb: {
                 label:
-                    route.name === "flows/create"
+                    taskId.value === "new"
                         ? t("create_flow")
                         : props.flow.id,
-                to: {name: route.name, params, query: {}},
             },
             position: 0,
         });
     });
 
     watch(
-        () => route.query.identifier,
+        taskId,
         (value) => {
             if (!value) return;
 
             store.commit("code/addBreadcrumbs", {
                 breadcrumb: {
                     label:
-                        route.query.identifier === "new"
-                            ? t(`no_code.creation.${route.query.section}`)
-                            : route.query.identifier,
-                    to: {name: route.name, params, query: route.query},
+                        value === "new"
+                            ? t(`no_code.creation.${taskSection.value}`)
+                            : value,
                 },
                 position: 1,
             });
         },
     );
+
+    function clickBreadCrumb(index: number){
+        if (index === 0 && taskId.value.length > 0) {
+            taskId.value = "";
+            taskSection.value = "";
+        }
+    }
 </script>
 
 <style scoped lang="scss">

--- a/ui/src/components/code/components/Breadcrumbs.vue
+++ b/ui/src/components/code/components/Breadcrumbs.vue
@@ -78,6 +78,10 @@
 <style scoped lang="scss">
 @import "../styles/code.scss";
 
+.item{
+    cursor: pointer;
+}
+
 .item:last-child > .el-breadcrumb__inner > a {
     color: $code-primary !important;
 }

--- a/ui/src/components/code/components/Save.vue
+++ b/ui/src/components/code/components/Save.vue
@@ -1,14 +1,27 @@
 <template>
     <el-button type="primary" :icon="ContentSave">
-        {{ t(`no_code.save.${props.what}`) }}
+        {{ t(`no_code.${saveOrClose}.${props.what}`) }}
     </el-button>
 </template>
 
 <script setup lang="ts">
+    import {computed, inject} from "vue";
     import {ContentSave} from "../utils/icons";
+    import {SAVEMODE_INJECTION_KEY} from "../injectionKeys";
 
     const props = defineProps({
         what: {type: String, required: true, default: "tasks"},
+    });
+
+    const saveMode = inject(SAVEMODE_INJECTION_KEY, "button");
+
+    const saveOrClose = computed(() => {
+        if (saveMode === "button") {
+            return "save";
+        } else if (saveMode === "auto") {
+            return "close";
+        }
+        return "save";
     });
 
     import {useI18n} from "vue-i18n";

--- a/ui/src/components/code/components/collapse/Collapse.vue
+++ b/ui/src/components/code/components/collapse/Collapse.vue
@@ -5,9 +5,8 @@
             :key="index"
             :name="item.title"
             :title="`${item.title}${item.elements ? ` (${item.elements.length})` : ''}`"
-            :class="{creation}"
         >
-            <template v-if="creation" #icon>
+            <template #icon>
                 <Creation :section="item.title" />
             </template>
 
@@ -40,12 +39,11 @@
 
     import Creation from "./buttons/Creation.vue";
     import Element from "./Element.vue";
-    import {CREATING_INJECTION_KEY, FLOW_INJECTION_KEY} from "../../injectionKeys";
+    import {FLOW_INJECTION_KEY} from "../../injectionKeys";
 
     const emits = defineEmits(["remove", "reorder"]);
 
     const flow = inject(FLOW_INJECTION_KEY, "");
-    const creation = inject(CREATING_INJECTION_KEY, false);
 
     const props = defineProps({
         items: {
@@ -55,11 +53,11 @@
     });
     const expanded = ref<CollapseItem["title"][]>([]);
 
-    if (creation) {
-        props.items.forEach((item) => {
-            if (item.elements?.length) expanded.value.push(item.title);
-        });
-    }
+
+    props.items.forEach((item) => {
+        if (item.elements?.length) expanded.value.push(item.title);
+    });
+
 
     const removeElement = (title: string, index: number) => {
         props.items.forEach((item) => {

--- a/ui/src/components/code/components/collapse/Collapse.vue
+++ b/ui/src/components/code/components/collapse/Collapse.vue
@@ -43,7 +43,7 @@
 
     const emits = defineEmits(["remove", "reorder"]);
 
-    const flow = inject(FLOW_INJECTION_KEY, "");
+    const flow = inject(FLOW_INJECTION_KEY, ref(""));
 
     const props = defineProps({
         items: {
@@ -69,7 +69,7 @@
                     if(ID){
                         emits(
                             "remove",
-                            YAML_UTILS.deleteTask(flow, ID, title.toUpperCase()),
+                            YAML_UTILS.deleteTask(flow.value, ID, title.toUpperCase()),
                         );
                     }
                     expanded.value = expanded.value.filter((v) => v !== title);
@@ -94,7 +94,7 @@
         const newIndex = direction === "up" ? index - 1 : index + 1;
         emits(
             "reorder",
-            YAML_UTILS.swapTasks(flow, elementID, items[newIndex].id),
+            YAML_UTILS.swapTasks(flow.value, elementID, items[newIndex].id),
         );
     };
 </script>

--- a/ui/src/components/code/components/collapse/Collapse.vue
+++ b/ui/src/components/code/components/collapse/Collapse.vue
@@ -5,7 +5,7 @@
             :key="index"
             :name="item.title"
             :title="`${item.title}${item.elements ? ` (${item.elements.length})` : ''}`"
-            :class="{creation: props.creation}"
+            :class="{creation}"
         >
             <template v-if="creation" #icon>
                 <Creation :section="item.title" />
@@ -32,7 +32,7 @@
 </template>
 
 <script setup lang="ts">
-    import {nextTick, PropType, ref} from "vue";
+    import {inject, nextTick, PropType, ref} from "vue";
 
     import {YamlUtils as YAML_UTILS} from "@kestra-io/ui-libs";
 
@@ -40,20 +40,22 @@
 
     import Creation from "./buttons/Creation.vue";
     import Element from "./Element.vue";
+    import {CREATING_INJECTION_KEY, FLOW_INJECTION_KEY} from "../../injectionKeys";
 
     const emits = defineEmits(["remove", "reorder"]);
+
+    const flow = inject(FLOW_INJECTION_KEY, "");
+    const creation = inject(CREATING_INJECTION_KEY, false);
 
     const props = defineProps({
         items: {
             type: Array as PropType<CollapseItem[]>,
             required: true,
-        },
-        flow: {type: String, default: undefined},
-        creation: {type: Boolean, default: false},
+        }
     });
     const expanded = ref<CollapseItem["title"][]>([]);
 
-    if (props.creation) {
+    if (creation) {
         props.items.forEach((item) => {
             if (item.elements?.length) expanded.value.push(item.title);
         });
@@ -66,10 +68,12 @@
                     const ID = item.elements?.[index].id;
 
                     item.elements?.splice(index, 1);
-                    emits(
-                        "remove",
-                        YAML_UTILS.deleteTask(props.flow, ID, title.toUpperCase()),
-                    );
+                    if(ID){
+                        emits(
+                            "remove",
+                            YAML_UTILS.deleteTask(flow, ID, title.toUpperCase()),
+                        );
+                    }
                     expanded.value = expanded.value.filter((v) => v !== title);
                 });
             }
@@ -82,7 +86,7 @@
         index: number,
         direction: "up" | "down",
     ) => {
-        if (!items || !props.flow) return;
+        if (!items || !flow) return;
         if (
             (direction === "up" && index === 0) ||
             (direction === "down" && index === items.length - 1)
@@ -92,7 +96,7 @@
         const newIndex = direction === "up" ? index - 1 : index + 1;
         emits(
             "reorder",
-            YAML_UTILS.swapTasks(props.flow, elementID, items[newIndex].id),
+            YAML_UTILS.swapTasks(flow, elementID, items[newIndex].id),
         );
     };
 </script>

--- a/ui/src/components/code/components/collapse/Element.vue
+++ b/ui/src/components/code/components/collapse/Element.vue
@@ -22,9 +22,10 @@
 </template>
 
 <script setup lang="ts">
-    import {computed} from "vue";
+    import {computed, inject, ref} from "vue";
 
     import {DeleteOutline, ChevronUp, ChevronDown} from "../../utils/icons";
+    import {SECTION_INJECTION_KEY, TASKID_INJECTION_KEY} from "../../injectionKeys";
 
     import TaskIcon from "@kestra-io/ui-libs/src/components/misc/TaskIcon.vue";
 
@@ -43,19 +44,12 @@
 
     const icons = computed(() => store.state.plugin.icons);
 
-    import {useRouter, useRoute} from "vue-router";
-    const router = useRouter();
-    const route = useRoute();
+    const sectionInjected = inject(SECTION_INJECTION_KEY, ref(""));
+    const taskId = inject(TASKID_INJECTION_KEY, ref(""));
 
     const handleClick = () => {
-        router.replace({
-            query: {
-                ...route.query,
-                section: props.section.toLowerCase(),
-                identifier: props.element.id,
-                type: props.element.type,
-            },
-        });
+        sectionInjected.value = props.section.toLowerCase();
+        taskId.value = props.element.id;
     };
 </script>
 

--- a/ui/src/components/code/components/collapse/buttons/Creation.vue
+++ b/ui/src/components/code/components/collapse/buttons/Creation.vue
@@ -5,24 +5,20 @@
 </template>
 
 <script setup lang="ts">
+    import {inject, ref} from "vue";
+    import {SECTION_INJECTION_KEY, TASKID_INJECTION_KEY} from "../../../injectionKeys";
     import {Plus} from "../../../utils/icons";
-
-    import {useRouter, useRoute} from "vue-router";
-    const router = useRouter();
-    const route = useRoute();
 
     import {useI18n} from "vue-i18n";
     const {t} = useI18n({useScope: "global"});
 
     const props = defineProps({section: {type: String, required: true}});
 
+    const sectionInjected = inject(SECTION_INJECTION_KEY, ref(""));
+    const taskId = inject(TASKID_INJECTION_KEY, ref(""));
+
     const handleClick = () => {
-        router.replace({
-            query: {
-                ...route.query,
-                section: props.section.toLowerCase(),
-                identifier: "new",
-            },
-        });
+        sectionInjected.value = props.section.toLowerCase();
+        taskId.value = "new";
     };
 </script>

--- a/ui/src/components/code/injectionKeys.ts
+++ b/ui/src/components/code/injectionKeys.ts
@@ -1,8 +1,8 @@
-import {InjectionKey, Ref} from "vue"
+import type {InjectionKey, Ref, ComputedRef} from "vue"
 
 export const FLOW_INJECTION_KEY = Symbol("flow-injection-key") as InjectionKey<string>
 export const SECTION_INJECTION_KEY = Symbol("section-injection-key") as InjectionKey<Ref<string>>
 export const TASKID_INJECTION_KEY = Symbol("taskid-injection-key") as InjectionKey<Ref<string>>
 export const POSITION_INJECTION_KEY = Symbol("position-injection-key") as InjectionKey<"after" | "before">
-export const CREATING_INJECTION_KEY = Symbol("creating-injection-key") as InjectionKey<boolean>
+export const CREATING_INJECTION_KEY = Symbol("creating-injection-key") as InjectionKey<ComputedRef<boolean>>
 export const SAVEMODE_INJECTION_KEY = Symbol("flow-id-injection-key") as InjectionKey<"button" | "auto">

--- a/ui/src/components/code/injectionKeys.ts
+++ b/ui/src/components/code/injectionKeys.ts
@@ -1,0 +1,5 @@
+import {InjectionKey} from "vue"
+
+export const FLOW_INJECTION_KEY = Symbol("flow-injection-key") as InjectionKey<string>
+export const CREATING_INJECTION_KEY = Symbol("creating-injection-key") as InjectionKey<boolean>
+export const SAVEMODE_INJECTION_KEY = Symbol("flow-id-injection-key") as InjectionKey<"button" | "auto">

--- a/ui/src/components/code/injectionKeys.ts
+++ b/ui/src/components/code/injectionKeys.ts
@@ -1,6 +1,6 @@
-import type {InjectionKey, Ref} from "vue"
+import type {ComputedRef, InjectionKey, Ref} from "vue"
 
-export const FLOW_INJECTION_KEY = Symbol("flow-injection-key") as InjectionKey<string>
+export const FLOW_INJECTION_KEY = Symbol("flow-injection-key") as InjectionKey<ComputedRef<string>>
 export const SECTION_INJECTION_KEY = Symbol("section-injection-key") as InjectionKey<Ref<string>>
 export const TASKID_INJECTION_KEY = Symbol("taskid-injection-key") as InjectionKey<Ref<string>>
 export const POSITION_INJECTION_KEY = Symbol("position-injection-key") as InjectionKey<"after" | "before">

--- a/ui/src/components/code/injectionKeys.ts
+++ b/ui/src/components/code/injectionKeys.ts
@@ -1,8 +1,8 @@
-import type {InjectionKey, Ref, ComputedRef} from "vue"
+import type {InjectionKey, Ref} from "vue"
 
 export const FLOW_INJECTION_KEY = Symbol("flow-injection-key") as InjectionKey<string>
 export const SECTION_INJECTION_KEY = Symbol("section-injection-key") as InjectionKey<Ref<string>>
 export const TASKID_INJECTION_KEY = Symbol("taskid-injection-key") as InjectionKey<Ref<string>>
 export const POSITION_INJECTION_KEY = Symbol("position-injection-key") as InjectionKey<"after" | "before">
-export const CREATING_INJECTION_KEY = Symbol("creating-injection-key") as InjectionKey<ComputedRef<boolean>>
+export const CREATING_INJECTION_KEY = Symbol("creating-injection-key") as InjectionKey<Ref<boolean>>
 export const SAVEMODE_INJECTION_KEY = Symbol("flow-id-injection-key") as InjectionKey<"button" | "auto">

--- a/ui/src/components/code/injectionKeys.ts
+++ b/ui/src/components/code/injectionKeys.ts
@@ -1,5 +1,8 @@
-import {InjectionKey} from "vue"
+import {InjectionKey, Ref} from "vue"
 
 export const FLOW_INJECTION_KEY = Symbol("flow-injection-key") as InjectionKey<string>
+export const SECTION_INJECTION_KEY = Symbol("section-injection-key") as InjectionKey<Ref<string>>
+export const TASKID_INJECTION_KEY = Symbol("taskid-injection-key") as InjectionKey<Ref<string>>
+export const POSITION_INJECTION_KEY = Symbol("position-injection-key") as InjectionKey<Ref<"after" | "before">>
 export const CREATING_INJECTION_KEY = Symbol("creating-injection-key") as InjectionKey<boolean>
 export const SAVEMODE_INJECTION_KEY = Symbol("flow-id-injection-key") as InjectionKey<"button" | "auto">

--- a/ui/src/components/code/injectionKeys.ts
+++ b/ui/src/components/code/injectionKeys.ts
@@ -3,6 +3,6 @@ import {InjectionKey, Ref} from "vue"
 export const FLOW_INJECTION_KEY = Symbol("flow-injection-key") as InjectionKey<string>
 export const SECTION_INJECTION_KEY = Symbol("section-injection-key") as InjectionKey<Ref<string>>
 export const TASKID_INJECTION_KEY = Symbol("taskid-injection-key") as InjectionKey<Ref<string>>
-export const POSITION_INJECTION_KEY = Symbol("position-injection-key") as InjectionKey<Ref<"after" | "before">>
+export const POSITION_INJECTION_KEY = Symbol("position-injection-key") as InjectionKey<"after" | "before">
 export const CREATING_INJECTION_KEY = Symbol("creating-injection-key") as InjectionKey<boolean>
 export const SAVEMODE_INJECTION_KEY = Symbol("flow-id-injection-key") as InjectionKey<"button" | "auto">

--- a/ui/src/components/code/segments/Editor.vue
+++ b/ui/src/components/code/segments/Editor.vue
@@ -49,6 +49,7 @@
             :identifier="taskIdentifier"
             :section="taskSection"
             :position="taskPosition"
+            @exit-task="exitTask"
             @update-task="onTaskUpdate"
             @update-documentation="(task) => emits('updateDocumentation', task)"
         />
@@ -59,7 +60,7 @@
     import {watch, computed, inject} from "vue";
     import {YamlUtils as YAML_UTILS} from "@kestra-io/ui-libs";
 
-    import {Field, Fields, CollapseItem} from "../utils/types";
+    import {Field, Fields, CollapseItem, NoCodeElement} from "../utils/types";
 
     import Collapse from "../components/collapse/Collapse.vue";
     import InputText from "../components/inputs/InputText.vue";
@@ -70,7 +71,7 @@
     import MetadataInputs from "../../flows/MetadataInputs.vue";
     import TaskBasic from "../../flows/tasks/TaskBasic.vue";
 
-    import {CREATING_INJECTION_KEY, FLOW_INJECTION_KEY} from "../injectionKeys";
+    import {CREATING_INJECTION_KEY, FLOW_INJECTION_KEY, SAVEMODE_INJECTION_KEY} from "../injectionKeys";
 
     import Task from "./Task.vue";
 
@@ -126,6 +127,7 @@
 
     const creation = inject(CREATING_INJECTION_KEY);
     const flow = inject(FLOW_INJECTION_KEY, "");
+    const saveMode = inject(SAVEMODE_INJECTION_KEY, "button");
 
     const props = defineProps({
         metadata: {type: Object, required: true},
@@ -138,11 +140,18 @@
         return rest;
     };
 
-    function onTaskUpdate(yaml: string) {
-        emits("updateTask", yaml)
+    function exitTask() {
         // eslint-disable-next-line @typescript-eslint/no-unused-vars
         const {section, identifier, type, ...rest} = route.query;
         router.replace({query: {...rest}});
+    }
+
+    function onTaskUpdate(yaml: string) {
+        emits("updateTask", yaml)
+
+        if(saveMode === "button") {
+            exitTask()
+        }
     }
 
     const fields = computed<Fields>(() => {
@@ -259,18 +268,18 @@
     })
 
 
-    const getSectionTitle = (label: string, elements: Record<string, any>[] = []) => {
+    const getSectionTitle = (label: string, elements: NoCodeElement[] = []) => {
         const title = t(`no_code.sections.${label}`);
         return {title, elements};
     };
     const sections = computed((): CollapseItem[] => {
-        const parsedFlow:{
-            tasks: Record<string, any>[];
-            triggers: Record<string, any>[];
-            errors: Record<string, any>[];
-            finally: Record<string, any>[];
-            afterExecution: Record<string, any>[];
-        } = YAML_UTILS.parse(flow) as any;
+        const parsedFlow = YAML_UTILS.parse<{
+            tasks: NoCodeElement[];
+            triggers: NoCodeElement[];
+            errors: NoCodeElement[];
+            finally: NoCodeElement[];
+            afterExecution: NoCodeElement[];
+        }>(flow);
         return [
             getSectionTitle("tasks", parsedFlow?.tasks ?? []),
             getSectionTitle("triggers", parsedFlow?.triggers ?? []),

--- a/ui/src/components/code/segments/Editor.vue
+++ b/ui/src/components/code/segments/Editor.vue
@@ -26,8 +26,6 @@
 
                 <Collapse
                     :items="sections"
-                    creation
-                    :flow
                     @remove="(yaml) => emits('updateTask', yaml)"
                     @reorder="(yaml) => emits('reorder', yaml)"
                 />
@@ -49,16 +47,17 @@
             v-else
             :key="taskIdentifier"
             :identifier="taskIdentifier"
-            :flow
-            :creation
-            @update-task="(yaml) => emits('updateTask', yaml)"
+            :section="taskSection"
+            :position="taskPosition"
+            @update-task="onTaskUpdate"
             @update-documentation="(task) => emits('updateDocumentation', task)"
         />
     </div>
 </template>
 
 <script setup lang="ts">
-    import {watch, computed} from "vue";
+    import {watch, computed, inject} from "vue";
+    import {YamlUtils as YAML_UTILS} from "@kestra-io/ui-libs";
 
     import {Field, Fields, CollapseItem} from "../utils/types";
 
@@ -71,10 +70,13 @@
     import MetadataInputs from "../../flows/MetadataInputs.vue";
     import TaskBasic from "../../flows/tasks/TaskBasic.vue";
 
+    import {CREATING_INJECTION_KEY, FLOW_INJECTION_KEY} from "../injectionKeys";
+
     import Task from "./Task.vue";
 
-    import {useRoute} from "vue-router";
+    import {useRoute, useRouter} from "vue-router";
     const route = useRoute();
+    const router = useRouter();
 
     const taskIdentifier = computed(
         () => route.query.identifier?.toString() ?? "new",
@@ -89,6 +91,13 @@
         },
         {deep: true},
     );
+
+    const taskSection = computed(() => {
+        return (route.query.section ?? "TASKS").toString() as "tasks" | "triggers"
+    });
+    const taskPosition = computed(() => {
+        return route.query.position?.toString() as "after" | "before" | undefined;
+    });
 
     import {useI18n} from "vue-i18n";
     const {t} = useI18n({useScope: "global"});
@@ -115,9 +124,10 @@
 
     document.addEventListener("keydown", saveEvent);
 
+    const creation = inject(CREATING_INJECTION_KEY);
+    const flow = inject(FLOW_INJECTION_KEY, "");
+
     const props = defineProps({
-        creation: {type: Boolean, default: false},
-        flow: {type: String, required: true},
         metadata: {type: Object, required: true},
     });
 
@@ -128,6 +138,13 @@
         return rest;
     };
 
+    function onTaskUpdate(yaml: string) {
+        emits("updateTask", yaml)
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        const {section, identifier, type, ...rest} = route.query;
+        router.replace({query: {...rest}});
+    }
+
     const fields = computed<Fields>(() => {
         return {
             id: {
@@ -135,14 +152,14 @@
                 value: props.metadata.id,
                 label: t("no_code.fields.main.flow_id"),
                 required: true,
-                disabled: !props.creation,
+                disabled: !creation,
             },
             namespace: {
                 component: InputText,
                 value: props.metadata.namespace,
                 label: t("no_code.fields.main.namespace"),
                 required: true,
-                disabled: !props.creation,
+                disabled: !creation,
             },
             description: {
                 component: InputText,
@@ -241,30 +258,30 @@
         return rest;
     })
 
-    import {YamlUtils as YAML_UTILS} from "@kestra-io/ui-libs";
+
     const getSectionTitle = (label: string, elements: Record<string, any>[] = []) => {
         const title = t(`no_code.sections.${label}`);
         return {title, elements};
     };
     const sections = computed((): CollapseItem[] => {
-        const flow:{
+        const parsedFlow:{
             tasks: Record<string, any>[];
             triggers: Record<string, any>[];
             errors: Record<string, any>[];
             finally: Record<string, any>[];
             afterExecution: Record<string, any>[];
-        } = YAML_UTILS.parse(props.flow) as any;
+        } = YAML_UTILS.parse(flow) as any;
         return [
-            getSectionTitle("tasks", flow?.tasks ?? []),
-            getSectionTitle("triggers", flow?.triggers ?? []),
+            getSectionTitle("tasks", parsedFlow?.tasks ?? []),
+            getSectionTitle("triggers", parsedFlow?.triggers ?? []),
             getSectionTitle(
                 "error_handlers",
-                flow?.errors ?? [],
+                parsedFlow?.errors ?? [],
             ),
-            getSectionTitle("finally", flow?.finally ?? []),
+            getSectionTitle("finally", parsedFlow?.finally ?? []),
             getSectionTitle(
                 "after_execution",
-                flow?.afterExecution ?? [],
+                parsedFlow?.afterExecution ?? [],
             ),
         ];
     });

--- a/ui/src/components/code/segments/Editor.vue
+++ b/ui/src/components/code/segments/Editor.vue
@@ -75,27 +75,25 @@
 
     import Task from "./Task.vue";
 
-    import {useRoute, useRouter} from "vue-router";
-    const route = useRoute();
-    const router = useRouter();
 
     const taskIdentifier = computed(
         () => taskId.value?.toString() ?? "new",
     );
 
-    watch(
-        () => route.query,
-        async (newQuery) => {
-            if (!newQuery?.section && !newQuery?.identifier) {
-                emits("updateDocumentation", null);
-            }
-        },
-        {deep: true},
-    );
+
 
     const sectionInjected = inject(SECTION_INJECTION_KEY, ref(""));
     const taskId = inject(TASKID_INJECTION_KEY, ref(""));
-    const taskPosition = inject(POSITION_INJECTION_KEY, ref<"after" | "before">("after"));
+    const taskPosition = inject(POSITION_INJECTION_KEY, "after");
+
+    watch(
+        [sectionInjected, taskId],
+        ([section, id]) => {
+            if (section && id) {
+                emits("updateDocumentation", null);
+            }
+        },
+    );
 
     const taskSection = computed(() => {
         return (sectionInjected.value ?? "TASKS").toString() as "tasks" | "triggers"
@@ -142,9 +140,8 @@
     };
 
     function exitTask() {
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
-        const {section, identifier, type, ...rest} = route.query;
-        router.replace({query: {...rest}});
+        sectionInjected.value = "";
+        taskId.value = "";
     }
 
     function onTaskUpdate(yaml: string) {

--- a/ui/src/components/code/segments/Editor.vue
+++ b/ui/src/components/code/segments/Editor.vue
@@ -1,6 +1,6 @@
 <template>
     <div class="p-4">
-        <template v-if="!route.query.section && !route.query.identifier">
+        <template v-if="!taskSection && !taskIdentifier">
             <template v-if="panel">
                 <component
                     :is="panel.type"
@@ -57,7 +57,7 @@
 </template>
 
 <script setup lang="ts">
-    import {watch, computed, inject} from "vue";
+    import {watch, computed, inject, ref} from "vue";
     import {YamlUtils as YAML_UTILS} from "@kestra-io/ui-libs";
 
     import {Field, Fields, CollapseItem, NoCodeElement} from "../utils/types";
@@ -71,7 +71,7 @@
     import MetadataInputs from "../../flows/MetadataInputs.vue";
     import TaskBasic from "../../flows/tasks/TaskBasic.vue";
 
-    import {CREATING_INJECTION_KEY, FLOW_INJECTION_KEY, SAVEMODE_INJECTION_KEY} from "../injectionKeys";
+    import {CREATING_INJECTION_KEY, FLOW_INJECTION_KEY, POSITION_INJECTION_KEY, SAVEMODE_INJECTION_KEY, SECTION_INJECTION_KEY, TASKID_INJECTION_KEY} from "../injectionKeys";
 
     import Task from "./Task.vue";
 
@@ -80,7 +80,7 @@
     const router = useRouter();
 
     const taskIdentifier = computed(
-        () => route.query.identifier?.toString() ?? "new",
+        () => taskId.value?.toString() ?? "new",
     );
 
     watch(
@@ -93,11 +93,12 @@
         {deep: true},
     );
 
+    const sectionInjected = inject(SECTION_INJECTION_KEY, ref(""));
+    const taskId = inject(TASKID_INJECTION_KEY, ref(""));
+    const taskPosition = inject(POSITION_INJECTION_KEY, ref<"after" | "before">("after"));
+
     const taskSection = computed(() => {
-        return (route.query.section ?? "TASKS").toString() as "tasks" | "triggers"
-    });
-    const taskPosition = computed(() => {
-        return route.query.position?.toString() as "after" | "before" | undefined;
+        return (sectionInjected.value ?? "TASKS").toString() as "tasks" | "triggers"
     });
 
     import {useI18n} from "vue-i18n";

--- a/ui/src/components/code/segments/Editor.vue
+++ b/ui/src/components/code/segments/Editor.vue
@@ -46,9 +46,6 @@
         <Task
             v-else
             :key="taskIdentifier"
-            :identifier="taskIdentifier"
-            :section="taskSection"
-            :position="taskPosition"
             @exit-task="exitTask"
             @update-task="onTaskUpdate"
             @update-documentation="(task) => emits('updateDocumentation', task)"
@@ -71,7 +68,7 @@
     import MetadataInputs from "../../flows/MetadataInputs.vue";
     import TaskBasic from "../../flows/tasks/TaskBasic.vue";
 
-    import {CREATING_INJECTION_KEY, FLOW_INJECTION_KEY, POSITION_INJECTION_KEY, SAVEMODE_INJECTION_KEY, SECTION_INJECTION_KEY, TASKID_INJECTION_KEY} from "../injectionKeys";
+    import {CREATING_INJECTION_KEY, FLOW_INJECTION_KEY, SAVEMODE_INJECTION_KEY, SECTION_INJECTION_KEY, TASKID_INJECTION_KEY} from "../injectionKeys";
 
     import Task from "./Task.vue";
 
@@ -84,7 +81,6 @@
 
     const sectionInjected = inject(SECTION_INJECTION_KEY, ref(""));
     const taskId = inject(TASKID_INJECTION_KEY, ref(""));
-    const taskPosition = inject(POSITION_INJECTION_KEY, "after");
 
     watch(
         [sectionInjected, taskId],

--- a/ui/src/components/code/segments/Editor.vue
+++ b/ui/src/components/code/segments/Editor.vue
@@ -121,7 +121,7 @@
     document.addEventListener("keydown", saveEvent);
 
     const creation = inject(CREATING_INJECTION_KEY);
-    const flow = inject(FLOW_INJECTION_KEY, "");
+    const flow = inject(FLOW_INJECTION_KEY, ref(""));
     const saveMode = inject(SAVEMODE_INJECTION_KEY, "button");
 
     const props = defineProps({
@@ -273,7 +273,7 @@
             errors: NoCodeElement[];
             finally: NoCodeElement[];
             afterExecution: NoCodeElement[];
-        }>(flow);
+        }>(flow.value);
         return [
             getSectionTitle("tasks", parsedFlow?.tasks ?? []),
             getSectionTitle("triggers", parsedFlow?.triggers ?? []),

--- a/ui/src/components/code/segments/Task.vue
+++ b/ui/src/components/code/segments/Task.vue
@@ -19,34 +19,40 @@
         <ValidationError v-if="false" :errors link />
 
         <Save
-            @click="saveTask"
-            :what="route.query.section?.toString()"
+            :disabled="errors.length > 0"
+            @click="() => {
+                saveTask();
+                exitTaskElement();
+            }"
+            :what="section"
             class="w-100 mt-3"
         />
     </template>
 </template>
 
 <script setup lang="ts">
-    import {onBeforeMount, ref, watch, computed} from "vue";
+    import {onBeforeMount, ref, watch, computed, inject} from "vue";
+    import {useStore} from "vuex";
+    import {YamlUtils as YAML_UTILS} from "@kestra-io/ui-libs";
+    import {SECTIONS} from "../../../utils/constants";
+    import {CREATING_INJECTION_KEY, FLOW_INJECTION_KEY, SAVEMODE_INJECTION_KEY} from "../injectionKeys";
+    import TaskEditor from "../../../components/flows/TaskEditor.vue";
+    import ValidationError from "../../../components/flows/ValidationError.vue";
+    import Save from "../components/Save.vue";
 
     const emits = defineEmits(["updateTask", "updateDocumentation"]);
-    const props = defineProps({
-        identifier: {type: String, required: true},
-        flow: {type: String, required: true},
-        creation: {type: Boolean, default: false},
+    const props = withDefaults(defineProps<{
+        section: "tasks" | "triggers" | "error handlers" | "finally" | "after execution";
+        identifier: string;
+        position?: "before" | "after";
+    }>(), {
+        position: "after"
     });
 
-    import {useRouter, useRoute} from "vue-router";
-    const router = useRouter();
-    const route = useRoute();
+    const flow = inject(FLOW_INJECTION_KEY, "");
+    const creation = inject(CREATING_INJECTION_KEY);
+    const saveMode = inject(SAVEMODE_INJECTION_KEY, "button");
 
-    import {SECTIONS} from ".././../../utils/constants";
-    const section = ref(SECTIONS.TASKS);
-
-    import TaskEditor from "../../../components/flows/TaskEditor.vue";
-    import {YamlUtils as YAML_UTILS} from "@kestra-io/ui-libs";
-
-    import {useStore} from "vuex";
     const store = useStore();
 
     const breadcrumbs = computed(() => store.state.code.breadcrumbs);
@@ -61,7 +67,7 @@
     });
 
     const yaml = ref(
-        YAML_UTILS.extractTask(props.flow, props.identifier)?.toString() || "",
+        YAML_UTILS.extractTask(flow, props.identifier)?.toString() || "",
     );
 
     onBeforeMount(() => {
@@ -69,13 +75,9 @@
         emits("updateDocumentation", type);
     });
 
-    watch(
-        () => route.query.section,
-        (value) => {
-            section.value = SECTIONS[value === "triggers" ? "TRIGGERS" : "TASKS"];
-        },
-        {immediate: true},
-    );
+    const validationSection = computed(() =>
+        SECTIONS[props.section === "triggers" ? "TRIGGERS" : "TASKS"]
+    )
 
     watch(
         () => props.identifier,
@@ -84,16 +86,26 @@
                 yaml.value = "";
             } else {
                 yaml.value =
-                    YAML_UTILS.extractTask(props.flow, value)?.toString() || "";
+                    YAML_UTILS.extractTask(flow, value)?.toString() || "";
             }
         },
         {immediate: true},
     );
 
-    import ValidationError from "../../../components/flows/ValidationError.vue";
+    watch(
+        yaml,
+        (value) => {
+            if(saveMode === "auto") {
+                store.dispatch("flow/validateTask", {task: value, section: validationSection.value});
+                saveTask();
+            }
+        },
+    );
 
-    const CURRENT = ref(null);
-    const validateTask = (task) => {
+
+
+    const CURRENT = ref<string|null>(null);
+    const validateTask = (task: string) => {
         let temp = YAML_UTILS.parse(yaml.value);
 
         if (lastBreadcrumb.value.shown) {
@@ -104,7 +116,7 @@
         temp = YAML_UTILS.stringify(temp);
 
         store
-            .dispatch("flow/validateTask", {task: temp, section: section.value})
+            .dispatch("flow/validateTask", {task: temp, section: validationSection.value})
             .then(() => (yaml.value = temp));
 
         CURRENT.value = temp;
@@ -112,30 +124,31 @@
 
     const errors = computed(() => store.getters["flow/taskError"]);
 
-    import Save from "../components/Save.vue";
+    function exitTaskElement(){
+        store.commit("code/removeBreadcrumb", {last: true});
+    }
+
+
     const saveTask = () => {
-        if (lastBreadcrumb.value.shown) {
-            store.commit("code/removeBreadcrumb", {last: true});
+        if (lastBreadcrumb.value.shown && saveMode === "button") {
+            exitTaskElement();
             return;
         }
-
-        const source = props.flow;
 
         const task = YAML_UTILS.extractTask(
             yaml.value,
             YAML_UTILS.parse(yaml.value).id,
         );
 
-        const currentSection = route.query.section;
         const isCreation =
-            props.creation && (!props.identifier || props.identifier === "new");
+            creation && (!props.identifier || props.identifier === "new");
 
         let result;
 
         if (isCreation) {
-            if (currentSection === "tasks") {
+            if (props.section === "tasks" && CURRENT.value) {
                 const existing = YAML_UTILS.checkTaskAlreadyExist(
-                    source,
+                    flow,
                     CURRENT.value,
                 );
 
@@ -143,39 +156,40 @@
                     store.dispatch("core/showMessage", {
                         variant: "error",
                         title: "Task with same ID already exist",
-                        message: `Task in ${route.query.section} block  with ID: ${existing} already exist in the flow.`,
+                        message: `Task in ${props.section} block  with ID: ${existing} already exist in the flow.`,
                     });
                     return;
                 }
 
+                const taskId = props.identifier
+
+
                 result = YAML_UTILS.insertTask(
-                    source,
-                    route.query.target ?? YAML_UTILS.getLastTask(source),
-                    task,
-                    route.query.position ?? "after",
+                    flow,
+                    taskId,
+                    task!,
+                    props.position,
                 );
-            } else if (currentSection === "triggers") {
-                result = YAML_UTILS.insertSection("triggers", source, CURRENT.value);
-            } else if (currentSection === "error handlers") {
-                result = YAML_UTILS.insertSection("errors", source, CURRENT.value);
-            } else if (currentSection === "finally") {
-                result = YAML_UTILS.insertSection("finally", source, CURRENT.value);
-            } else if (currentSection === "after execution") {
-                result = YAML_UTILS.insertSection("afterExecution", source, CURRENT.value);
+            } else if (props.section === "triggers") {
+                result = YAML_UTILS.insertSection("triggers", flow, CURRENT.value);
+            } else if (props.section === "error handlers") {
+                result = YAML_UTILS.insertSection("errors", flow, CURRENT.value);
+            } else if (props.section === "finally") {
+                result = YAML_UTILS.insertSection("finally", flow, CURRENT.value);
+            } else if (props.section === "after execution") {
+                result = YAML_UTILS.insertSection("afterExecution", flow, CURRENT.value);
             }
         } else {
             result = YAML_UTILS.replaceTaskInDocument(
-                source,
+                flow,
                 props.identifier,
-                task,
+                task!,
             );
         }
 
         emits("updateTask", result);
-        store.commit("code/removeBreadcrumb", {last: true});
-
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
-        const {section, identifier, type, ...rest} = route.query;
-        router.replace({query: {...rest}});
+        if(saveMode === "button") {
+            store.commit("code/removeBreadcrumb", {last: true});
+        }
     };
 </script>

--- a/ui/src/components/code/segments/Task.vue
+++ b/ui/src/components/code/segments/Task.vue
@@ -42,7 +42,7 @@
 
     const emits = defineEmits(["updateTask", "exitTask", "updateDocumentation"]);
 
-    const flow = inject(FLOW_INJECTION_KEY, "");
+    const flow = inject(FLOW_INJECTION_KEY, ref(""));
     const creation = inject(CREATING_INJECTION_KEY, ref(false));
     const saveMode = inject(SAVEMODE_INJECTION_KEY, "button");
     const section = inject(SECTION_INJECTION_KEY, ref("tasks"));
@@ -63,8 +63,10 @@
     });
 
     const yaml = ref(
-        YAML_UTILS.extractTask(flow, taskId.value)?.toString() || "",
+        YAML_UTILS.extractTask(flow.value, taskId.value)?.toString() || "",
     );
+
+    const flowBeforeAdd = ref(flow.value);
 
     onBeforeMount(() => {
         const type = YAML_UTILS.parse(yaml.value)?.type ?? null;
@@ -79,7 +81,7 @@
         taskId,
         (value) => {
             yaml.value =
-                YAML_UTILS.extractTask(flow, value)?.toString() || "";
+                YAML_UTILS.extractTask(flow.value, value)?.toString() || "";
         },
         {immediate: true},
     );
@@ -160,7 +162,7 @@
         if (creation.value) {
             if (currentSection === "tasks" && task) {
                 const existing = YAML_UTILS.checkTaskAlreadyExist(
-                    flow,
+                    flowBeforeAdd.value,
                     task,
                 );
 
@@ -173,27 +175,22 @@
                     return;
                 }
 
-
-
                 result = YAML_UTILS.insertTask(
-                    flow,
-                    taskId.value ?? YAML_UTILS.getLastTask(flow), // target task id (the one before of after the task will be inserted)
+                    flowBeforeAdd.value,
+                    taskId.value.length ? taskId.value : YAML_UTILS.getLastTask(flowBeforeAdd.value) ?? "", // target task id (the one before of after the task will be inserted)
                     task,
                     position,
                 );
             } else if (currentSection && SECTIONS_MAP[currentSection.toString()]) {
                 result = YAML_UTILS.insertSection(
                     SECTIONS_MAP[currentSection.toString()],
-                    flow,
+                    flowBeforeAdd.value,
                     task
                 );
             }
-            const newTaskId = YAML_UTILS.parse(yaml.value).id
-            taskId.value = newTaskId;
-            creation.value = false;
         } else if(task){
             result = YAML_UTILS.replaceTaskInDocument(
-                flow,
+                flow.value,
                 taskId.value,
                 task,
             );

--- a/ui/src/components/code/segments/Task.vue
+++ b/ui/src/components/code/segments/Task.vue
@@ -35,24 +35,19 @@
     import {useStore} from "vuex";
     import {YamlUtils as YAML_UTILS} from "@kestra-io/ui-libs";
     import {SECTIONS} from "../../../utils/constants";
-    import {CREATING_INJECTION_KEY, FLOW_INJECTION_KEY, SAVEMODE_INJECTION_KEY, SECTION_INJECTION_KEY} from "../injectionKeys";
+    import {CREATING_INJECTION_KEY, FLOW_INJECTION_KEY, POSITION_INJECTION_KEY, SAVEMODE_INJECTION_KEY, SECTION_INJECTION_KEY, TASKID_INJECTION_KEY} from "../injectionKeys";
     import TaskEditor from "../../../components/flows/TaskEditor.vue";
     import ValidationError from "../../../components/flows/ValidationError.vue";
     import Save from "../components/Save.vue";
 
     const emits = defineEmits(["updateTask", "exitTask", "updateDocumentation"]);
-    const props = withDefaults(defineProps<{
-        section: "tasks" | "triggers" | "error handlers" | "finally" | "after execution";
-        identifier: string;
-        position?: "before" | "after";
-    }>(), {
-        position: "after"
-    });
 
     const flow = inject(FLOW_INJECTION_KEY, "");
     const creation = inject(CREATING_INJECTION_KEY, ref(false));
     const saveMode = inject(SAVEMODE_INJECTION_KEY, "button");
-    const injectedSectionId = inject(SECTION_INJECTION_KEY, "button");
+    const section = inject(SECTION_INJECTION_KEY, ref("tasks"));
+    const taskId = inject(TASKID_INJECTION_KEY, ref(""));
+    const position = inject(POSITION_INJECTION_KEY, "after");
 
     const store = useStore();
 
@@ -68,7 +63,7 @@
     });
 
     const yaml = ref(
-        YAML_UTILS.extractTask(flow, props.identifier)?.toString() || "",
+        YAML_UTILS.extractTask(flow, taskId.value)?.toString() || "",
     );
 
     onBeforeMount(() => {
@@ -77,18 +72,14 @@
     });
 
     const validationSection = computed(() =>
-        SECTIONS[props.section === "triggers" ? "TRIGGERS" : "TASKS"]
+        SECTIONS[section.value === "triggers" ? "TRIGGERS" : "TASKS"]
     )
 
     watch(
-        () => props.identifier,
+        taskId,
         (value) => {
-            if (value === "new") {
-                yaml.value = "";
-            } else {
-                yaml.value =
-                    YAML_UTILS.extractTask(flow, value)?.toString() || "";
-            }
+            yaml.value =
+                YAML_UTILS.extractTask(flow, value)?.toString() || "";
         },
         {immediate: true},
     );
@@ -102,8 +93,6 @@
             }
         },
     );
-
-
 
     const CURRENT = ref<string|null>(null);
     const validateTask = (task: string) => {
@@ -164,50 +153,46 @@
             YAML_UTILS.parse(yaml.value).id,
         );
 
-        const isCreation =
-            creation && (!props.identifier || props.identifier === "new");
+        let result: string = "";
 
-        let result;
+        const currentSection = section.value;
 
-        const currentSection = injectedSectionId.value;
-
-        if (isCreation) {
-            if (currentSection === "tasks" && CURRENT.value) {
+        if (creation.value) {
+            if (currentSection === "tasks" && task) {
                 const existing = YAML_UTILS.checkTaskAlreadyExist(
                     flow,
-                    CURRENT.value,
+                    task,
                 );
 
                 if (existing) {
                     store.dispatch("core/showMessage", {
                         variant: "error",
                         title: "Task with same ID already exist",
-                        message: `Task in ${props.section} block  with ID: ${existing} already exist in the flow.`,
+                        message: `Task in ${section} block  with ID: ${existing} already exist in the flow.`,
                     });
                     return;
                 }
 
-                const taskId = props.identifier
-
+                const taskId = YAML_UTILS.parse(yaml.value).id
 
                 result = YAML_UTILS.insertTask(
                     flow,
                     taskId,
-                    task!,
-                    props.position,
+                    task,
+                    position,
                 );
             } else if (currentSection && SECTIONS_MAP[currentSection.toString()]) {
                 result = YAML_UTILS.insertSection(
                     SECTIONS_MAP[currentSection.toString()],
                     flow,
-                    CURRENT.value
+                    task
                 );
             }
-        } else {
+        } else if(task){
             result = YAML_UTILS.replaceTaskInDocument(
                 flow,
-                props.identifier,
-                task!,
+                taskId.value,
+                task,
             );
         }
 

--- a/ui/src/components/code/segments/Task.vue
+++ b/ui/src/components/code/segments/Task.vue
@@ -140,6 +140,7 @@
             store.commit("code/removeBreadcrumb", {last: true});
         } else {
             emits("exitTask");
+            creation.value = false;
         }
     }
 
@@ -172,7 +173,10 @@
                         title: "Task with same ID already exist",
                         message: `Task in ${section} block  with ID: ${existing} already exist in the flow.`,
                     });
-                    return;
+
+                    if(saveMode === "button"){
+                        return;
+                    }
                 }
 
                 result = YAML_UTILS.insertTask(

--- a/ui/src/components/code/segments/Task.vue
+++ b/ui/src/components/code/segments/Task.vue
@@ -50,7 +50,7 @@
     });
 
     const flow = inject(FLOW_INJECTION_KEY, "");
-    const creation = inject(CREATING_INJECTION_KEY);
+    const creation = inject(CREATING_INJECTION_KEY, ref(false));
     const saveMode = inject(SAVEMODE_INJECTION_KEY, "button");
 
     const store = useStore();

--- a/ui/src/components/code/segments/Task.vue
+++ b/ui/src/components/code/segments/Task.vue
@@ -177,7 +177,7 @@
 
                 result = YAML_UTILS.insertTask(
                     flow,
-                    taskId.value, // target task id (the one before of after the task will be inserted)
+                    taskId.value ?? YAML_UTILS.getLastTask(flow), // target task id (the one before of after the task will be inserted)
                     task,
                     position,
                 );

--- a/ui/src/components/code/segments/Task.vue
+++ b/ui/src/components/code/segments/Task.vue
@@ -127,10 +127,10 @@
                 lastValidatedValue.value = temp;
                 store.dispatch("flow/validateTask", {task: temp, section: validationSection.value});
             }
-        }, 500);
+        }, 500) as any;
     };
 
-    const timer = ref(null);
+    const timer = ref<number>();
     const lastValidatedValue = ref(null);
 
     const errors = computed(() => store.getters["flow/taskError"]);

--- a/ui/src/components/code/segments/Task.vue
+++ b/ui/src/components/code/segments/Task.vue
@@ -173,11 +173,11 @@
                     return;
                 }
 
-                const taskId = YAML_UTILS.parse(yaml.value).id
+
 
                 result = YAML_UTILS.insertTask(
                     flow,
-                    taskId,
+                    taskId.value, // target task id (the one before of after the task will be inserted)
                     task,
                     position,
                 );
@@ -188,6 +188,9 @@
                     task
                 );
             }
+            const newTaskId = YAML_UTILS.parse(yaml.value).id
+            taskId.value = newTaskId;
+            creation.value = false;
         } else if(task){
             result = YAML_UTILS.replaceTaskInDocument(
                 flow,

--- a/ui/src/components/code/segments/Task.vue
+++ b/ui/src/components/code/segments/Task.vue
@@ -150,10 +150,10 @@
             return;
         }
 
-        const task = YAML_UTILS.extractTask(
-            yaml.value,
-            YAML_UTILS.parse(yaml.value).id,
-        );
+        const taskObject = YAML_UTILS.parse(yaml.value);
+        taskObject.id = taskObject.id?.length ? taskObject.id : undefined;
+
+        const task = YAML_UTILS.stringify(taskObject);
 
         let result: string = "";
 

--- a/ui/src/components/code/segments/Task.vue
+++ b/ui/src/components/code/segments/Task.vue
@@ -19,7 +19,7 @@
         <ValidationError v-if="false" :errors link />
 
         <Save
-            :disabled="errors.length > 0"
+            :disabled="(errors?.length ?? 0) > 0"
             @click="() => {
                 saveTask();
                 exitTaskElement();
@@ -40,7 +40,7 @@
     import ValidationError from "../../../components/flows/ValidationError.vue";
     import Save from "../components/Save.vue";
 
-    const emits = defineEmits(["updateTask", "updateDocumentation"]);
+    const emits = defineEmits(["updateTask", "exitTask", "updateDocumentation"]);
     const props = withDefaults(defineProps<{
         section: "tasks" | "triggers" | "error handlers" | "finally" | "after execution";
         identifier: string;
@@ -125,7 +125,11 @@
     const errors = computed(() => store.getters["flow/taskError"]);
 
     function exitTaskElement(){
-        store.commit("code/removeBreadcrumb", {last: true});
+        if (lastBreadcrumb.value.shown){
+            store.commit("code/removeBreadcrumb", {last: true});
+        } else {
+            emits("exitTask");
+        }
     }
 
 
@@ -190,6 +194,7 @@
         emits("updateTask", result);
         if(saveMode === "button") {
             store.commit("code/removeBreadcrumb", {last: true});
+            emits("exitTask");
         }
     };
 </script>

--- a/ui/src/components/code/utils/types.ts
+++ b/ui/src/components/code/utils/types.ts
@@ -57,7 +57,11 @@ export type Fields = {
 
 export type CollapseItem = {
     title: string;
-    elements?: Record<string, any>[];
+    elements?: {
+        id: string;
+        type: string;
+        [key:string]: any;
+    }[];
 };
 
 export type Breadcrumb = {

--- a/ui/src/components/code/utils/types.ts
+++ b/ui/src/components/code/utils/types.ts
@@ -55,13 +55,15 @@ export type Fields = {
     disabled: Field;
 };
 
+export interface NoCodeElement {
+    id: string;
+    type: string;
+    [key:string]: any;
+}
+
 export type CollapseItem = {
     title: string;
-    elements?: {
-        id: string;
-        type: string;
-        [key:string]: any;
-    }[];
+    elements?: NoCodeElement[];
 };
 
 export type Breadcrumb = {

--- a/ui/src/components/dashboard/components/charts/executions/BarChart.vue
+++ b/ui/src/components/dashboard/components/charts/executions/BarChart.vue
@@ -157,7 +157,7 @@
                         borderColor: "#A2CDFF",
                         yAxisID: "yB",
                         data: props.data.map((value) => {
-                            return value.duration.avg === 0
+                            return value.duration.avg === 0 || !value.duration.avg
                                 ? 0
                                 : Utils.duration(value.duration.avg.toString());
                         }),

--- a/ui/src/components/flows/ValidationError.vue
+++ b/ui/src/components/flows/ValidationError.vue
@@ -60,7 +60,7 @@
                         </span>
                         <br v-if="infos && infos.length > 0">
                         <span v-for="(info, index) in infos" :key="index">
-                            {{ info }}<br v-if="index < infos.length - 1">
+                            {{ info }}<br v-if="index < (infos?.length ?? 0) - 1">
                         </span>
                     </el-main>
                 </el-container>
@@ -102,57 +102,24 @@
     </span>
 </template>
 
-<script>
+<script setup lang="ts">
     import CheckCircle from "vue-material-design-icons/CheckCircle.vue";
     import AlertCircle from "vue-material-design-icons/AlertCircle.vue";
     import Alert from "vue-material-design-icons/Alert.vue";
 
-    export default {
+    defineOptions({
         inheritAttrs: false,
-        components: {
-            CheckCircle,
-            AlertCircle,
-            Alert
-        },
-        props: {
-            errors: {
-                type: Array,
-                default: undefined
-            },
-            warnings: {
-                type: Array,
-                default: undefined
-            },
-            infos: {
-                type: Array,
-                default: undefined
-            },
-            link: {
-                type: Boolean,
-                default: false
-            },
-            size: {
-                type: String,
-                default: "default"
-            },
-            tooltipPlacement: {
-                type: String,
-                default: undefined
-            }
-        },
-        methods: {
-            onResize(maxWidth) {
-                const buttonLabels = this.$el.querySelectorAll(".el-button span.label");
+    })
 
-                buttonLabels.forEach(el => el.classList.remove("d-none"))
-                this.$nextTick(() => {
-                    if(this.$el.offsetLeft + this.$el.offsetWidth > maxWidth) {
-                        buttonLabels.forEach(el => el.classList.add("d-none"))
-                    }
-                });
-            }
-        }
-    };
+    defineProps<{
+        errors?: string[] | undefined;
+        warnings?: string[] | undefined;
+        infos?: string[] | undefined;
+        link?: boolean;
+        size?: "default" | "small";
+        tooltipPlacement?: string;
+    }>()
+
 </script>
 
 <style scoped lang="scss">

--- a/ui/src/components/flows/ValidationError.vue
+++ b/ui/src/components/flows/ValidationError.vue
@@ -1,5 +1,5 @@
 <template>
-    <span>
+    <span ref="rootContainer">
         <!-- Valid -->
         <el-button v-if="!errors && !warnings &&!infos" v-bind="$attrs" :link="link" :size="size" type="default" class="success">
             <check-circle class="text-success" />
@@ -103,6 +103,7 @@
 </template>
 
 <script setup lang="ts">
+    import {nextTick, ref} from "vue";
     import CheckCircle from "vue-material-design-icons/CheckCircle.vue";
     import AlertCircle from "vue-material-design-icons/AlertCircle.vue";
     import Alert from "vue-material-design-icons/Alert.vue";
@@ -119,6 +120,26 @@
         size?: "default" | "small";
         tooltipPlacement?: string;
     }>()
+
+    const rootContainer = ref<HTMLSpanElement>()
+
+    function onResize(maxWidth: number) {
+        if(rootContainer.value === undefined) {
+            return;
+        }
+        const buttonLabels = rootContainer.value.querySelectorAll(".el-button span.label");
+
+        buttonLabels.forEach(el => el.classList.remove("d-none"))
+        nextTick(() => {
+            if(rootContainer.value && rootContainer.value.offsetLeft + rootContainer.value.offsetWidth > maxWidth) {
+                buttonLabels.forEach(el => el.classList.add("d-none"))
+            }
+        });
+    }
+
+    defineExpose({
+        onResize
+    })
 
 </script>
 

--- a/ui/src/components/inputs/EditorView.vue
+++ b/ui/src/components/inputs/EditorView.vue
@@ -238,6 +238,8 @@
             <NoCode
                 v-else
                 :flow="flowYaml"
+                :section="route.query.section.toString()"
+                :task-id="route.query.identifier.toString()"
                 :creating="isCreating"
                 :position="route.query.position === 'before' ? 'before' : 'after'"
                 @update-metadata="(e) => onUpdateMetadata(e, true)"

--- a/ui/src/components/inputs/EditorView.vue
+++ b/ui/src/components/inputs/EditorView.vue
@@ -238,6 +238,8 @@
             <NoCode
                 v-else
                 :flow="flowYaml"
+                :creating="isCreating"
+                :position="route.query.position === 'before' ? 'before' : 'after'"
                 @update-metadata="(e) => onUpdateMetadata(e, true)"
                 @update-task="(e) => editorUpdate(e)"
                 @reorder="(yaml) => handleReorder(yaml)"

--- a/ui/src/stores/editor.js
+++ b/ui/src/stores/editor.js
@@ -10,7 +10,7 @@ export default {
         treeData: [],
     },
     actions: {
-        saveAllTabs({dispatch, state}, {namespace}) {
+        saveAllTabs({dispatch, commit, state}, {namespace}) {
             return Promise.all(
                 state.tabs.map(async (tab) => {
                     if(tab.flow) return;
@@ -19,7 +19,11 @@ export default {
                         path: tab.path ?? tab.name,
                         content: tab.content,
                     }, {root: true});
-                    tab.dirty = false;
+                    commit("setTabDirty", {
+                        name: tab.name,
+                        path: tab.path,
+                        dirty: false
+                    });
                 })
             );
         },

--- a/ui/src/stores/flow.js
+++ b/ui/src/stores/flow.js
@@ -341,6 +341,10 @@ export default {
                         return Promise.reject(new Error("Server error on flow save"))
                     } else {
                         commit("setFlow", response.data);
+                        commit("editor/setTabDirty", {
+                            name: "Flow",
+                            dirty: false,
+                        }, {root: true});
 
                         return response.data;
                     }

--- a/ui/src/translations/en.json
+++ b/ui/src/translations/en.json
@@ -1197,6 +1197,14 @@
         "finally": "Save task",
         "after execution": "Save task",
         "input": "Save input"
+      },
+      "close": {
+        "tasks": "Close task",
+        "triggers": "Close trigger",
+        "error handlers": "Close error handler",
+        "finally": "Close task",
+        "after execution": "Close task",
+        "input": "Close input"
       }
     },
     "properties": {


### PR DESCRIPTION
After this change, there is no more need to hit the save button when we change Task in No-Code.

This is step 1/4

- [x] refactor no-code to stop relying on route for task creation edition + remove need for clicking save in multipanel
- [ ] refactor multipanel edition to allow for more than one nocode panel open at once
- [ ] fix the wiring of topology to open a new nocode when adding a new step
  - [ ] inject `noCodeCreateTask(taskId, section, position)` and `noCodeEditTask(taskId, section)` on 
  - [ ] use the injected functions in `LowCodeWrapper.vue`
- [ ] when opening a task from nocode, instead of navigating to the new task in the same nocode, open a new nocode with the task open.