### PR TITLE
fix(system): change default config values for liveness

### DIFF
--- a/cli/src/main/resources/application.yml
+++ b/cli/src/main/resources/application.yml
@@ -195,11 +195,11 @@ kestra:
     liveness:
       enabled: true
       # The expected time between liveness probe.
-      interval: 5s
+      interval: 10s
       # The timeout used to detect service failures.
-      timeout: 45s
+      timeout: 1m
       # The time to wait before executing a liveness probe.
-      initialDelay: 45s
+      initialDelay: 1m
       # The expected time between service heartbeats.
       heartbeatInterval: 3s
   anonymous-usage-report:


### PR DESCRIPTION
Change kestra.server.liveness.interval from 5s to 10s to be a bit less agressive on liveness check. Align other default liveness value with kafka implementation.