### PR TITLE
fix(executions): unqueing execution must remove the execution queued

### DIFF
--- a/jdbc/src/main/java/io/kestra/jdbc/services/JdbcConcurrencyLimitService.java
+++ b/jdbc/src/main/java/io/kestra/jdbc/services/JdbcConcurrencyLimitService.java
@@ -1,0 +1,29 @@
+package io.kestra.jdbc.services;
+
+import io.kestra.core.models.executions.Execution;
+import io.kestra.core.models.flows.State;
+import io.kestra.core.queues.QueueException;
+import io.kestra.core.services.ConcurrencyLimitService;
+import io.kestra.jdbc.runner.AbstractJdbcExecutionQueuedStorage;
+import io.micronaut.context.annotation.Replaces;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+
+@Singleton
+@Replaces(ConcurrencyLimitService.class)
+public class JdbcConcurrencyLimitService extends ConcurrencyLimitService {
+
+    @Inject
+    private AbstractJdbcExecutionQueuedStorage storage;
+
+    @Override
+    public Execution unqueue(Execution execution) throws QueueException {
+        if (execution.getState().getCurrent() != State.Type.QUEUED) {
+            throw new IllegalArgumentException("Only QUEUED execution can be unqueued");
+        }
+
+        storage.remove(execution);
+
+        return execution.withState(State.Type.RUNNING);
+    }
+}

--- a/webserver/src/test/java/io/kestra/webserver/controllers/api/ExecutionControllerRunnerTest.java
+++ b/webserver/src/test/java/io/kestra/webserver/controllers/api/ExecutionControllerRunnerTest.java
@@ -1352,6 +1352,14 @@ class ExecutionControllerRunnerTest {
         var response = client.toBlocking().exchange(HttpRequest.POST("/api/v1/executions/" + result.getId() + "/unqueue", null));
         assertThat(response.getStatus().getCode()).isEqualTo(HttpStatus.OK.getCode());
 
+        // waiting for the flow to complete successfully
+        runnerUtils.awaitExecution(
+            execution -> execution.getId().equals(result.getId()) && execution.getState().isSuccess(),
+            () -> {},
+            Duration.ofSeconds(10)
+        );
+
+
         var notFound = assertThrows(HttpClientResponseException.class, () -> client.toBlocking().exchange(HttpRequest.POST("/api/v1/executions/notfound/unqueue", null)));
         assertThat(notFound.getStatus().getCode()).isEqualTo(HttpStatus.NOT_FOUND.getCode());
 
@@ -1390,6 +1398,13 @@ class ExecutionControllerRunnerTest {
         Optional<Execution> forcedRun = executionRepositoryInterface.findById(null, result.getId());
         assertThat(forcedRun.isPresent()).isTrue();
         assertThat(forcedRun.get().getState().getCurrent()).isNotEqualTo(State.Type.QUEUED);
+
+        // waiting for the flow to complete successfully
+        runnerUtils.awaitExecution(
+            execution -> execution.getId().equals(result.getId()) && execution.getState().isSuccess(),
+            () -> {},
+            Duration.ofSeconds(10)
+        );
     }
 
     @Test


### PR DESCRIPTION
When an execution is queued in the JDBC backend, a record is inserted inside the execution_queued table, we must remove this record when we unqeue an execution.

Fixes #8448
