### PR TITLE
feat(plugin): add a way to provide additional type of plugins

### DIFF
--- a/core/src/main/java/io/kestra/core/docs/DocumentationGenerator.java
+++ b/core/src/main/java/io/kestra/core/docs/DocumentationGenerator.java
@@ -7,6 +7,7 @@ import io.kestra.core.models.tasks.logs.LogExporter;
 import io.kestra.core.models.tasks.runners.TaskRunner;
 import io.kestra.core.models.tasks.Task;
 import io.kestra.core.models.triggers.AbstractTrigger;
+import io.kestra.core.plugins.AdditionalPlugin;
 import io.kestra.core.plugins.PluginClassAndMetadata;
 import io.kestra.core.plugins.RegisteredPlugin;
 import io.kestra.core.runners.pebble.Extension;
@@ -75,6 +76,7 @@ public class DocumentationGenerator {
         //noinspection unchecked
         result.addAll(this.generate(registeredPlugin, registeredPlugin.getTaskRunners(), (Class) TaskRunner.class, "task-runners"));
         result.addAll(this.generate(registeredPlugin, registeredPlugin.getLogExporters(), (Class) LogExporter.class, "log-exporters"));
+        result.addAll(this.generate(registeredPlugin, registeredPlugin.getAdditionalPlugins(), AdditionalPlugin.class, "additional-plugins"));
 
         result.addAll(guides(registeredPlugin));
 

--- a/core/src/main/java/io/kestra/core/docs/JsonSchemaGenerator.java
+++ b/core/src/main/java/io/kestra/core/docs/JsonSchemaGenerator.java
@@ -33,6 +33,7 @@ import io.kestra.core.models.tasks.common.EncryptedString;
 import io.kestra.core.models.tasks.logs.LogExporter;
 import io.kestra.core.models.tasks.runners.TaskRunner;
 import io.kestra.core.models.triggers.AbstractTrigger;
+import io.kestra.core.plugins.AdditionalPlugin;
 import io.kestra.core.plugins.PluginRegistry;
 import io.kestra.core.plugins.RegisteredPlugin;
 import io.kestra.core.serializers.JacksonMapper;
@@ -577,6 +578,13 @@ public class JsonSchemaGenerator {
             return getRegisteredPlugins()
                 .stream()
                 .flatMap(registeredPlugin -> registeredPlugin.getLogExporters().stream())
+                .filter(Predicate.not(io.kestra.core.models.Plugin::isInternal))
+                .map(typeContext::resolve)
+                .toList();
+        } else if (declaredType.getErasedType() == AdditionalPlugin.class) {
+            return getRegisteredPlugins()
+                .stream()
+                .flatMap(registeredPlugin -> registeredPlugin.getAdditionalPlugins().stream())
                 .filter(Predicate.not(io.kestra.core.models.Plugin::isInternal))
                 .map(typeContext::resolve)
                 .toList();

--- a/core/src/main/java/io/kestra/core/docs/Plugin.java
+++ b/core/src/main/java/io/kestra/core/docs/Plugin.java
@@ -37,6 +37,7 @@ public class Plugin {
     private List<String> charts;
     private List<String> dataFilters;
     private List<String> logExporters;
+    private List<String> additionalPlugins;
     private List<PluginSubGroup.PluginCategory> categories;
     private String subGroup;
 
@@ -89,17 +90,18 @@ public class Plugin {
         plugin.subGroup = subgroup;
 
         Predicate<Class<?>> packagePredicate = c -> subgroup == null || c.getPackageName().equals(subgroup);
-        plugin.tasks = filterAndGetClassName(registeredPlugin.getTasks(), includeDeprecated, packagePredicate).stream().toList();
-        plugin.triggers = filterAndGetClassName(registeredPlugin.getTriggers(), includeDeprecated, packagePredicate).stream().toList();
-        plugin.conditions = filterAndGetClassName(registeredPlugin.getConditions(), includeDeprecated, packagePredicate).stream().toList();
-        plugin.storages = filterAndGetClassName(registeredPlugin.getStorages(), includeDeprecated, packagePredicate).stream().toList();
-        plugin.secrets = filterAndGetClassName(registeredPlugin.getSecrets(), includeDeprecated, packagePredicate).stream().toList();
-        plugin.taskRunners = filterAndGetClassName(registeredPlugin.getTaskRunners(), includeDeprecated, packagePredicate).stream().toList();
-        plugin.apps = filterAndGetClassName(registeredPlugin.getApps(), includeDeprecated, packagePredicate).stream().toList();
-        plugin.appBlocks = filterAndGetClassName(registeredPlugin.getAppBlocks(), includeDeprecated, packagePredicate).stream().toList();
-        plugin.charts = filterAndGetClassName(registeredPlugin.getCharts(), includeDeprecated, packagePredicate).stream().toList();
-        plugin.dataFilters = filterAndGetClassName(registeredPlugin.getDataFilters(), includeDeprecated, packagePredicate).stream().toList();
-        plugin.logExporters = filterAndGetClassName(registeredPlugin.getLogExporters(), includeDeprecated, packagePredicate).stream().toList();
+        plugin.tasks = filterAndGetClassName(registeredPlugin.getTasks(), includeDeprecated, packagePredicate);
+        plugin.triggers = filterAndGetClassName(registeredPlugin.getTriggers(), includeDeprecated, packagePredicate);
+        plugin.conditions = filterAndGetClassName(registeredPlugin.getConditions(), includeDeprecated, packagePredicate);
+        plugin.storages = filterAndGetClassName(registeredPlugin.getStorages(), includeDeprecated, packagePredicate);
+        plugin.secrets = filterAndGetClassName(registeredPlugin.getSecrets(), includeDeprecated, packagePredicate);
+        plugin.taskRunners = filterAndGetClassName(registeredPlugin.getTaskRunners(), includeDeprecated, packagePredicate);
+        plugin.apps = filterAndGetClassName(registeredPlugin.getApps(), includeDeprecated, packagePredicate);
+        plugin.appBlocks = filterAndGetClassName(registeredPlugin.getAppBlocks(), includeDeprecated, packagePredicate);
+        plugin.charts = filterAndGetClassName(registeredPlugin.getCharts(), includeDeprecated, packagePredicate);
+        plugin.dataFilters = filterAndGetClassName(registeredPlugin.getDataFilters(), includeDeprecated, packagePredicate);
+        plugin.logExporters = filterAndGetClassName(registeredPlugin.getLogExporters(), includeDeprecated, packagePredicate);
+        plugin.additionalPlugins = filterAndGetClassName(registeredPlugin.getAdditionalPlugins(), includeDeprecated, packagePredicate);
 
         return plugin;
     }

--- a/core/src/main/java/io/kestra/core/plugins/AdditionalPlugin.java
+++ b/core/src/main/java/io/kestra/core/plugins/AdditionalPlugin.java
@@ -1,0 +1,20 @@
+package io.kestra.core.plugins;
+
+import io.kestra.core.models.Plugin;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+@io.kestra.core.models.annotations.Plugin
+@SuperBuilder(toBuilder = true)
+@Getter
+@NoArgsConstructor
+public abstract class AdditionalPlugin implements Plugin {
+    @NotNull
+    @NotBlank
+    @Pattern(regexp="\\p{javaJavaIdentifierStart}\\p{javaJavaIdentifierPart}*(\\.\\p{javaJavaIdentifierStart}\\p{javaJavaIdentifierPart}*)*")
+    protected String type;
+}

--- a/core/src/main/java/io/kestra/core/plugins/PluginScanner.java
+++ b/core/src/main/java/io/kestra/core/plugins/PluginScanner.java
@@ -110,6 +110,7 @@ public class PluginScanner {
         List<Class<? extends Chart<?>>> charts = new ArrayList<>();
         List<Class<? extends DataFilter<?, ?>>> dataFilters = new ArrayList<>();
         List<Class<? extends LogExporter<?>>> logExporter = new ArrayList<>();
+        List<Class<? extends AdditionalPlugin>> additionalPlugins = new ArrayList<>();
         List<String> guides = new ArrayList<>();
         Map<String, Class<?>> aliases = new HashMap<>();
 
@@ -172,6 +173,10 @@ public class PluginScanner {
                         log.debug("Loading LogExporter plugin: '{}'", plugin.getClass());
                         logExporter.add((Class<? extends LogExporter<?>>)  shipper.getClass());
                     }
+                    case AdditionalPlugin additionalPlugin -> {
+                        log.debug("Loading additional plugin: '{}'", plugin.getClass());
+                        additionalPlugins.add(additionalPlugin.getClass());
+                    }
                     default -> {
                     }
                 }
@@ -222,6 +227,7 @@ public class PluginScanner {
             .dataFilters(dataFilters)
             .guides(guides)
             .logExporters(logExporter)
+            .additionalPlugins(additionalPlugins)
             .aliases(aliases.entrySet().stream().collect(Collectors.toMap(
                 e -> e.getKey().toLowerCase(),
                 Function.identity()

--- a/core/src/main/java/io/kestra/core/plugins/RegisteredPlugin.java
+++ b/core/src/main/java/io/kestra/core/plugins/RegisteredPlugin.java
@@ -45,8 +45,9 @@ public class RegisteredPlugin {
     private final List<Class<? extends AppBlockInterface>> appBlocks;
     private final List<Class<? extends Chart<?>>> charts;
     private final List<Class<? extends DataFilter<?, ?>>> dataFilters;
-    private final List<String> guides;
     private final List<Class<? extends LogExporter<?>>> logExporters;
+    private final List<Class<? extends AdditionalPlugin>> additionalPlugins;
+    private final List<String> guides;
     // Map<lowercasealias, <Alias, Class>>
     private final Map<String, Map.Entry<String, Class<?>>> aliases;
 
@@ -61,7 +62,8 @@ public class RegisteredPlugin {
             !appBlocks.isEmpty() ||
             !charts.isEmpty() ||
             !dataFilters.isEmpty() ||
-            !logExporters.isEmpty()
+            !logExporters.isEmpty() ||
+            !additionalPlugins.isEmpty()
         ;
     }
 
@@ -126,6 +128,10 @@ public class RegisteredPlugin {
             return LogExporter.class;
         }
 
+        if (this.getAdditionalPlugins().stream().anyMatch(r -> r.getName().equals(cls))) {
+            return AdditionalPlugin.class;
+        }
+
         if (this.getAliases().containsKey(cls.toLowerCase())) {
             // This is a quick-win, but it may trigger an infinite loop ... or not ...
             return baseClass(this.getAliases().get(cls.toLowerCase()).getValue().getName());
@@ -158,13 +164,10 @@ public class RegisteredPlugin {
         result.put("charts", Arrays.asList(this.getCharts().toArray(Class[]::new)));
         result.put("data-filters", Arrays.asList(this.getDataFilters().toArray(Class[]::new)));
         result.put("log-exporters", Arrays.asList(this.getLogExporters().toArray(Class[]::new)));
+        result.put("additional-plugins", Arrays.asList(this.getAdditionalPlugins().toArray(Class[]::new)));
 
         return result;
     }
-
-//    public Map<String, Map<String,List<Class>>> allClassGroupedBySubGroup() {
-//
-//    }
 
     public Set<String> subGroupNames() {
         return allClass()
@@ -357,6 +360,12 @@ public class RegisteredPlugin {
         if (!this.getLogExporters().isEmpty()) {
             b.append("[Log Exporters: ");
             b.append(this.getLogExporters().stream().map(Class::getName).collect(Collectors.joining(", ")));
+            b.append("] ");
+        }
+
+        if (!this.getAdditionalPlugins().isEmpty()) {
+            b.append("[Additional Plugins: ");
+            b.append(this.getAdditionalPlugins().stream().map(Class::getName).collect(Collectors.joining(", ")));
             b.append("] ");
         }
 

--- a/core/src/test/java/io/kestra/core/plugins/AdditionalPluginTest.java
+++ b/core/src/test/java/io/kestra/core/plugins/AdditionalPluginTest.java
@@ -1,0 +1,95 @@
+package io.kestra.core.plugins;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import io.kestra.core.junit.annotations.ExecuteFlow;
+import io.kestra.core.junit.annotations.KestraTest;
+import io.kestra.core.models.annotations.Plugin;
+import io.kestra.core.models.executions.Execution;
+import io.kestra.core.models.property.Property;
+import io.kestra.core.models.tasks.RunnableTask;
+import io.kestra.core.models.tasks.Task;
+import io.kestra.core.plugins.serdes.PluginDeserializer;
+import io.kestra.core.runners.RunContext;
+import jakarta.validation.constraints.NotNull;
+import lombok.*;
+import lombok.experimental.SuperBuilder;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@KestraTest(startRunner = true)
+class AdditionalPluginTest {
+
+    @Test
+    @ExecuteFlow("flows/valids/additional-plugin.yaml")
+    void additionalPlugin(Execution execution) {
+        assertThat(execution).isNotNull();
+        assertThat(execution.getState().isSuccess()).isTrue();
+        assertThat(execution.getTaskRunList()).hasSize(2);
+        assertThat(execution.getTaskRunList().getFirst().getOutputs().get("output")).isEqualTo("1 -> Hello");
+        assertThat(execution.getTaskRunList().get(1).getOutputs().get("output")).isEqualTo("Hello World!");
+    }
+
+    @SuperBuilder
+    @ToString
+    @EqualsAndHashCode
+    @Getter
+    @NoArgsConstructor
+    @Plugin
+    public static class AdditionalPluginTestTask extends Task implements RunnableTask<AdditionalPluginTestTask.Output> {
+        @NotNull
+        private BaseAdditionalPluginTest additionalPlugin;
+
+        @Override
+        public AdditionalPluginTestTask.Output run(RunContext runContext) throws Exception {
+            return Output.builder()
+                .output(additionalPlugin.sayHello())
+                .build();
+        }
+
+        @Builder
+        @Getter
+        public static class Output implements io.kestra.core.models.tasks.Output {
+            private String output;
+        }
+    }
+
+    @Plugin
+    @SuperBuilder(toBuilder = true)
+    @Getter
+    @NoArgsConstructor
+    // IMPORTANT: The abstract plugin base class must define using the PluginDeserializer,
+    // AND concrete subclasses must be annotated by @JsonDeserialize() to avoid StackOverflow.
+    @JsonDeserialize(using = PluginDeserializer.class)
+    public static abstract class BaseAdditionalPluginTest extends AdditionalPlugin {
+        public abstract String sayHello();
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Plugin
+    @JsonDeserialize
+    public static class AdditionalPluginTest1 extends BaseAdditionalPluginTest {
+        @NotNull
+        private Property<String> baseMessage;
+
+        @Override
+        public String sayHello() {
+            return "1 -> " + baseMessage;
+        }
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @Plugin
+    @JsonDeserialize
+    public static class AdditionalPluginTest2 extends BaseAdditionalPluginTest {
+        @Override
+        public String sayHello() {
+            return "Hello World!";
+        }
+    }
+}

--- a/core/src/test/resources/flows/valids/additional-plugin.yaml
+++ b/core/src/test/resources/flows/valids/additional-plugin.yaml
@@ -1,0 +1,13 @@
+id: additional-plugin
+namespace: io.kestra.tests
+
+tasks:
+  - id: additional-plugin-1
+    type: io.kestra.core.plugins.AdditionalPluginTest$AdditionalPluginTestTask
+    additionalPlugin:
+      type: io.kestra.core.plugins.AdditionalPluginTest$AdditionalPluginTest1
+      baseMessage: Hello
+  - id: additional-plugin-2
+    type: io.kestra.core.plugins.AdditionalPluginTest$AdditionalPluginTestTask
+    additionalPlugin:
+      type: io.kestra.core.plugins.AdditionalPluginTest$AdditionalPluginTest2


### PR DESCRIPTION
Provide a way for plugins to define a new type of plugins. To do that, a plugin must provide both an abstract base class that extends AdditionalPlugin and a set of concrete classes. Both the abstract base class and the concrete classes mut be inside the same plugin. This is a limitation that we may work on later by providing, for example, an SPI to add base classes to the application classloader.

Example usage: https://github.com/kestra-io/plugin-langchain/pull/25

There are two gotchas:
- We need to add `@JsonDeserialize(using = PluginDeserializer.class)` to the base type and `@JsonDeserialize` to all concrete classes to avoid StackOverflow at deserialization time
- Inline documentation has not been updated, Brian said it should be possible so we may do that later. For now when editing an additional plugin you would stay on the "enclosing documentation".
