### PR TITLE
fix(flows): properly check average duration for dashboard graphs

### DIFF
--- a/ui/src/components/dashboard/components/charts/executions/BarChart.vue
+++ b/ui/src/components/dashboard/components/charts/executions/BarChart.vue
@@ -159,7 +159,7 @@
                         data: props.data.map((value) => {
                             return value.duration.avg === 0 || !value.duration.avg
                                 ? 0
-                                : Utils.duration(value.duration.avg.toString());
+                                : Utils.duration(value.duration?.avg?.toString());
                         }),
                     },
                     ...datasetsArray,


### PR DESCRIPTION
There was a problem on flows view with the main chart not showing proper data until user clicks on duration toggle.

Closes https://github.com/kestra-io/kestra-ee/issues/3499.