### PR TITLE
fix(ui): amend Absolute date filter's looks

### DIFF
--- a/ui/src/components/filter/composables/useFilters.ts
+++ b/ui/src/components/filter/composables/useFilters.ts
@@ -37,7 +37,9 @@ export function useFilters(prefix: string, isDefaultDashboard: boolean) {
         IN: buildComparator(t(comparator("in")), "IN", true),
         NOT_IN: buildComparator(t(comparator("not_in")), "NOT_IN", true),
         GREATER_THAN: buildComparator(t(comparator("greater_than")), "GREATER_THAN"),
+        GREATER_THAN_OR_EQUAL_TO: buildComparator(t(comparator("greater_than_or_equal_to")), "GREATER_THAN_OR_EQUAL_TO"),
         LESS_THAN: buildComparator(t(comparator("less_than")), "LESS_THAN"),
+        LESS_THAN_OR_EQUAL_TO: buildComparator(t(comparator("less_than_or_equal_to")), "LESS_THAN_OR_EQUAL_TO"),
     };
 
     let OPTIONS: Option[] = [

--- a/ui/src/translations/en.json
+++ b/ui/src/translations/en.json
@@ -1110,7 +1110,9 @@
         "relative_date": "Relative date",
         "absolute_date": "Absolute date",
         "labels": "Labels",
-        "text": "text"
+        "text": "text",
+        "startDate": "Start date",
+        "endDate": "End date"
       },
       "comparators": {
         "is": "is",
@@ -1123,7 +1125,9 @@
         "between": "between",
         "starts_with": "starts with",
         "greater_than": "greater than",
+        "greater_than_or_equal_to": "greater than or equal to",
         "less_than": "less than",
+        "less_than_or_equal_to": "less than or equal to",
         "ends_with": "ends with"
       },
       "save": {


### PR DESCRIPTION
### What changes are being made and why?

The Absolute date filter was missing several pieces leading to missing translation strings.

---

### How the changes have been QAed?
![20250423-194720_snap](https://github.com/user-attachments/assets/457d16fa-50b2-4683-98a8-996beb82cc48)


