### PR TITLE
chore(build): add Postgres stat extension

### DIFF
--- a/docker-compose-ci.yml
+++ b/docker-compose-ci.yml
@@ -21,6 +21,8 @@ services:
       POSTGRES_PASSWORD: k3str4
     ports:
       - 5432:5432
+    # enable pg_state_statements to have statistics on query executions
+    command: postgres -c shared_preload_libraries=pg_stat_statements -c pg_stat_statements.track=all
     restart: on-failure
 
 #  jaeger-all-in-one:


### PR DESCRIPTION
To use it, first you have to create the extension:

```
CREATE EXTENSION pg_stat_statements;
```

Then you can query it for long queries, for ex:

```
select query, mean_exec_time from pg_stat_statements order by mean_exec_time desc;
```