### PR TITLE
feat(ui): enable variable filter refresh interval

### DIFF
--- a/ui/src/components/layout/RefreshButton.vue
+++ b/ui/src/components/layout/RefreshButton.vue
@@ -1,6 +1,6 @@
 <template>
     <el-button :disabled="!canAutoRefresh" :active="autoRefresh" @click="toggleAutoRefresh" data-test-id="toggle-aut-refresh-button">
-        <kicon :tooltip="$t('toggle periodic refresh each 10 seconds')" placement="bottom">
+        <kicon :tooltip="$t('toggle periodic refresh each x seconds', {interval: autoRefreshIntervalSec})" placement="bottom">
             <component :is="autoRefresh ? 'auto-renew' : 'auto-renew-off'" class="auto-refresh-icon" />
         </kicon>
     </el-button>
@@ -15,7 +15,8 @@
     import Refresh from "vue-material-design-icons/Refresh.vue";
     import AutoRenew from "vue-material-design-icons/Autorenew.vue";
     import AutoRenewOff from "vue-material-design-icons/AutorenewOff.vue";
-    import Kicon from "../Kicon.vue"
+    import Kicon from "../Kicon.vue";
+    import {storageKeys} from "../../utils/constants";
 
     export default {
         components: {Refresh, AutoRenew, AutoRenewOff, Kicon},
@@ -37,11 +38,13 @@
         data() {
             return {
                 autoRefresh: undefined,
-                refreshHandler: undefined
+                refreshHandler: undefined,
+                autoRefreshIntervalSec: undefined
             };
         },
         created() {
             this.autoRefresh = localStorage.getItem("autoRefresh") === "1";
+            this.autoRefreshIntervalSec = parseInt(localStorage.getItem(storageKeys.AUTO_REFRESH_INTERVAL)) || 10;
         },
         methods: {
             toggleAutoRefresh() {
@@ -70,7 +73,7 @@
             },
             autoRefresh(newValue, oldValue) {
                 if (newValue) {
-                    this.refreshHandler = setInterval(this.triggerRefresh, 10000);
+                    this.refreshHandler = setInterval(this.triggerRefresh, this.autoRefreshIntervalSec * 1000);
                     if (oldValue !== undefined) {
                         this.triggerRefresh();
                     }

--- a/ui/src/components/settings/BasicSettings.vue
+++ b/ui/src/components/settings/BasicSettings.vue
@@ -84,17 +84,16 @@
                     </Column>
                 </Row>
                 <Row>
-                    <Column :label="$t('settings.blocks.configuration.fields.auto_refresh_interval.label')">
+                    <Column :label="$t('settings.blocks.configuration.fields.auto_refresh_interval')">
                         <el-input-number
                             :model-value="pendingSettings.autoRefreshInterval"
                             @update:model-value="onAutoRefreshInterval"
                             controls-position="right"
                             :min="2"
                             :max="120"
-                            :step="5"
                         >
                             <template #suffix>
-                                <span>{{ $t('settings.blocks.configuration.fields.auto_refresh_interval.time_unit') }}</span>
+                                <small class="dimmed">{{ $t('seconds').toLowerCase() }}</small>
                             </template>
                         </el-input-number>
                     </Column>
@@ -765,10 +764,14 @@
         }
     };
 </script>
-<style>
-
+<style lang="scss">
     .settings-wrapper .el-input-number {
         max-width: 20vw;
+
+        & .el-input__suffix {
+            color: var(--ks-content-secondary);
+        }
+
     }
 
     .el-input__count {

--- a/ui/src/components/settings/BasicSettings.vue
+++ b/ui/src/components/settings/BasicSettings.vue
@@ -84,6 +84,22 @@
                     </Column>
                 </Row>
                 <Row>
+                    <Column :label="$t('settings.blocks.configuration.fields.auto_refresh_interval.label')">
+                        <el-input-number
+                            :model-value="pendingSettings.autoRefreshInterval"
+                            @update:model-value="onAutoRefreshInterval"
+                            controls-position="right"
+                            :min="2"
+                            :max="120"
+                            :step="5"
+                        >
+                            <template #suffix>
+                                <span>{{ $t('settings.blocks.configuration.fields.auto_refresh_interval.time_unit') }}</span>
+                            </template>
+                        </el-input-number>
+                    </Column>
+                </Row>
+                <Row>
                     <Column :label="$t('settings.blocks.configuration.fields.multi_panel_editor')">
                         <el-switch :aria-label="$t('settings.blocks.configuration.fields.multi_panel_editor')" :model-value="pendingSettings.multiPanelEditor" @update:model-value="onMultiPanelEditor" />
                     </Column>
@@ -301,6 +317,7 @@
                     envColor: undefined,
                     executeDefaultTab: undefined,
                     multiPanelEditor: undefined,
+                    autoRefreshInterval: undefined,
                     flowDefaultTab: undefined,
                     logsFontSize: undefined
                 },
@@ -350,6 +367,7 @@
             this.pendingSettings.envColor = store.getters["layout/envColor"] || this.configs?.environment?.color;
             this.pendingSettings.logsFontSize = parseInt(localStorage.getItem("logsFontSize")) || 12;
             this.pendingSettings.multiPanelEditor = localStorage.getItem("multiPanelEditor") === "true";
+            this.pendingSettings.autoRefreshInterval = parseInt(localStorage.getItem(storageKeys.AUTO_REFRESH_INTERVAL)) || 10;
             this.originalSettings = JSON.parse(JSON.stringify(this.pendingSettings));
         },
         methods: {
@@ -488,6 +506,10 @@
             },
             onMultiPanelEditor(value) {
                 this.pendingSettings.multiPanelEditor = value;
+                this.checkForChanges();
+            },
+            onAutoRefreshInterval(value) {
+                this.pendingSettings.autoRefreshInterval = value;
                 this.checkForChanges();
             },
             onFlowDefaultTabChange(value){

--- a/ui/src/translations/en.json
+++ b/ui/src/translations/en.json
@@ -771,10 +771,7 @@
             "execute_default_tab": "Default Execution Tab",
             "multi_panel_editor": "Multi Panel Editor",
             "flow_default_tab": "Default Flow Tab",
-            "auto_refresh_interval": {
-              "label": "Auto refresh interval",
-              "time_unit": "sec"
-            }
+            "auto_refresh_interval": "Auto Refresh Interval"            
           }
         },
         "theme": {

--- a/ui/src/translations/en.json
+++ b/ui/src/translations/en.json
@@ -261,7 +261,7 @@
     "parent execution": "Parent execution",
     "original execution": "Original execution",
     "automatic refresh": "Automatic refresh",
-    "toggle periodic refresh each 10 seconds": "Toggle periodic refresh every 10 seconds",
+    "toggle periodic refresh each x seconds": "Toggle periodic refresh every {interval} seconds",
     "trigger refresh": "Trigger refresh",
     "add-trigger-in-editor": "Add a Trigger to your Flow first",
     "refresh": "Refresh",
@@ -770,7 +770,11 @@
             "execute_flow": "Execute the Flow",
             "execute_default_tab": "Default Execution Tab",
             "multi_panel_editor": "Multi Panel Editor",
-            "flow_default_tab": "Default Flow Tab"
+            "flow_default_tab": "Default Flow Tab",
+            "auto_refresh_interval": {
+              "label": "Auto refresh interval",
+              "time_unit": "sec"
+            }
           }
         },
         "theme": {

--- a/ui/src/utils/constants.ts
+++ b/ui/src/utils/constants.ts
@@ -38,7 +38,8 @@ export const storageKeys = {
     PAGINATION_SIZE: "paginationSize",
     IMPERSONATE: "impersonate",
     EDITOR_VIEW_TYPE: "editorViewType",
-    DASHBORD_SELECTED: "dashboardSelected"
+    DASHBORD_SELECTED: "dashboardSelected",
+    AUTO_REFRESH_INTERVAL: "autoRefreshInterval"
 }
 
 export const executeFlowBehaviours = {


### PR DESCRIPTION
### What changes are being made and why?

Let users pick longer/shorter automatic refresh interval than the default 10 sec.

These new interval values have been selected rather arbitrary.