### PR TITLE
fix(flows): properly load blueprints in multi panel view

### DIFF
--- a/ui/src/components/flows/blueprints/BlueprintsWrapper.vue
+++ b/ui/src/components/flows/blueprints/BlueprintsWrapper.vue
@@ -1,5 +1,5 @@
 <template>
-    <Blueprints embed kind="flow" />
+    <Blueprints embed kind="flow" combined-view />
 </template>
 
 <script lang="ts" setup>


### PR DESCRIPTION
While using the new Multi Panel view blueprints were not loading properly due to wrong paramtere being sent to action. now that's sorted.

Closes https://github.com/kestra-io/kestra/issues/8523.