### PR TITLE
fix(system): load OpenTelemetry lib in the app classloader

### DIFF
--- a/core/src/main/java/io/kestra/core/plugins/PluginClassLoader.java
+++ b/core/src/main/java/io/kestra/core/plugins/PluginClassLoader.java
@@ -45,6 +45,7 @@ public class PluginClassLoader extends URLClassLoader {
         + "|org.reactivestreams"
         + "|dev.failsafe"
         + "|reactor"
+        + "|io.opentelemetry"
         + ")\\..*$");
 
     private final ClassLoader parent;


### PR DESCRIPTION
Without that, as we have it here, plugins may have class loading issue if they use OpenTelemetry internally (like in the Elasticsearch client).
