### PR TITLE
chore: attempt to fix flaky tests

### DIFF
--- a/cli/src/test/java/io/kestra/cli/commands/flows/SingleFlowCommandsTest.java
+++ b/cli/src/test/java/io/kestra/cli/commands/flows/SingleFlowCommandsTest.java
@@ -12,12 +12,11 @@ import java.net.URL;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class SingleFlowCommandsTest {
-
+class SingleFlowCommandsTest {
 
     @Test
     void all() {
-        URL flow = SingleFlowCommandsTest.class.getClassLoader().getResource("flows/quattro.yml");
+        URL flow = SingleFlowCommandsTest.class.getClassLoader().getResource("crudFlow/date.yml");
         ByteArrayOutputStream out = new ByteArrayOutputStream();
         System.setOut(new PrintStream(out));
 
@@ -25,19 +24,6 @@ public class SingleFlowCommandsTest {
 
             EmbeddedServer embeddedServer = ctx.getBean(EmbeddedServer.class);
             embeddedServer.start();
-
-            String[] deleteArgs = {
-                "--server",
-                embeddedServer.getURL().toString(),
-                "--user",
-                "myuser:pass:word",
-                "io.kestra.outsider",
-                "quattro"
-            };
-            PicocliRunner.call(FlowDeleteCommand.class, ctx, deleteArgs);
-
-            assertThat(out.toString()).contains("Flow successfully deleted !");
-            out.reset();
 
             String[] createArgs = {
                 "--server",
@@ -50,21 +36,34 @@ public class SingleFlowCommandsTest {
 
             assertThat(out.toString()).contains("Flow successfully created !");
 
+            out.reset();
 
-            out.reset();String[] updateArgs = {
+            String[] updateArgs = {
                 "--server",
                 embeddedServer.getURL().toString(),
                 "--user",
                 "myuser:pass:word",
                 flow.getPath(),
-                "io.kestra.outsider",
-                "quattro"
+                "io.kestra.cli",
+                "date"
             };
             PicocliRunner.call(FlowUpdateCommand.class, ctx, updateArgs);
 
             assertThat(out.toString()).contains("Flow successfully updated !");
+
             out.reset();
+
+            String[] deleteArgs = {
+                "--server",
+                embeddedServer.getURL().toString(),
+                "--user",
+                "myuser:pass:word",
+                "io.kestra.cli",
+                "date"
+            };
+            PicocliRunner.call(FlowDeleteCommand.class, ctx, deleteArgs);
+
+            assertThat(out.toString()).contains("Flow successfully deleted !");
         }
     }
-
 }

--- a/cli/src/test/resources/crudFlow/date.yml
+++ b/cli/src/test/resources/crudFlow/date.yml
@@ -1,0 +1,7 @@
+id: date
+namespace: io.kestra.cli
+
+tasks:
+  - id: date
+    type: io.kestra.plugin.core.debug.Return
+    format: "{{taskrun.startDate}}"

--- a/core/src/test/java/io/kestra/plugin/core/log/PurgeLogsTest.java
+++ b/core/src/test/java/io/kestra/plugin/core/log/PurgeLogsTest.java
@@ -48,8 +48,8 @@ class PurgeLogsTest {
         Execution execution = runnerUtils.runOne(null, "io.kestra.tests", "purge_logs_no_arguments");
 
         assertTrue(execution.getState().isSuccess());
-        assertThat(execution.getTaskRunList().size()).isEqualTo(1);
-        assertThat(execution.getTaskRunList().getFirst().getOutputs().get("count")).isEqualTo(1);
+        assertThat(execution.getTaskRunList()).hasSize(1);
+        assertThat((int) execution.getTaskRunList().getFirst().getOutputs().get("count")).isPositive();
     }
 
 


### PR DESCRIPTION
# What changes are being made and why?

These strangely behaving tests were discovered by #7418.

## SingleFlowCommandsTest

The flow Delete -> Create -> Update sequence is weird - delete got HTTP 404. Reworked to Create -> Update -> Delete sequence.

## PurgeLogsTest

The log repository contained the prepared single entry but also might contain additional entries from previously logged messages.

