### PR TITLE
fix: allow turning on no-code in legacy

### DIFF
--- a/ui/src/components/inputs/EditorView.vue
+++ b/ui/src/components/inputs/EditorView.vue
@@ -238,8 +238,8 @@
             <NoCode
                 v-else
                 :flow="flowYaml"
-                :section="route.query.section.toString()"
-                :task-id="route.query.identifier.toString()"
+                :section="route.query.section?.toString()"
+                :task-id="route.query.identifier?.toString()"
                 :creating="isCreating"
                 :position="route.query.position === 'before' ? 'before' : 'after'"
                 @update-metadata="(e) => onUpdateMetadata(e, true)"


### PR DESCRIPTION
While doing some refactoring preparing for multiple no-code tabs I moved the routing out of no-code.
I forgot that some routing parameters could be ommited and did not test it.

This fixes the problem.