### PR TITLE
fix(ui): update storybook editor tests with provided keys

### DIFF
--- a/.github/workflows/workflow-frontend-test.yml
+++ b/.github/workflows/workflow-frontend-test.yml
@@ -22,8 +22,25 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Cache Node Modules
+        id: cache-node-modules
+        uses: actions/cache@v4
+        with:
+          path: |
+            ui/node_modules
+          key: modules-${{ hashFiles('ui/package-lock.json') }}
+
+      - name: Cache Playwright Binaries
+        id: cache-playwright
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/ms-playwright
+          key: playwright-${{ hashFiles('ui/package-lock.json') }}
+
       - name: Npm - install
         shell: bash
+        if: steps.cache-node-modules.outputs.cache-hit != 'true'
         working-directory: ui
         run: npm ci
 
@@ -44,6 +61,7 @@ jobs:
       - name: Storybook - Install Playwright
         shell: bash
         working-directory: ui
+        if: steps.cache-playwright.outputs.cache-hit != 'true'
         run: npx playwright install --with-deps
 
       - name: Run front-end unit tests

--- a/ui/tests/storybook/components/code/segments/Editor.stories.jsx
+++ b/ui/tests/storybook/components/code/segments/Editor.stories.jsx
@@ -1,5 +1,10 @@
 import Editor from "../../../../../src/components/code/segments/Editor.vue";
-import {ref} from "vue";
+import {
+    CREATING_INJECTION_KEY, FLOW_INJECTION_KEY,
+    POSITION_INJECTION_KEY, SAVEMODE_INJECTION_KEY,
+    SECTION_INJECTION_KEY, TASKID_INJECTION_KEY
+} from "../../../../../src/components/code/injectionKeys";
+import {provide, ref, computed} from "vue";
 import {useStore} from "vuex";
 import {vueRouter} from "storybook-vue3-router";
 
@@ -88,6 +93,13 @@ const Template = (args) => ({
     setup() {
         const store = useStore()
         const modelValue = ref(args.flow)
+
+        provide(FLOW_INJECTION_KEY, computed(() => args.flow));
+        provide(SECTION_INJECTION_KEY, ref("tasks"));
+        provide(TASKID_INJECTION_KEY, ref(""));
+        provide(POSITION_INJECTION_KEY, args.position);
+        provide(SAVEMODE_INJECTION_KEY, args.saveMode);
+        provide(CREATING_INJECTION_KEY, ref(args.creating));
 
         store.$http = {
             get(url) {

--- a/ui/vite.config.js
+++ b/ui/vite.config.js
@@ -87,6 +87,9 @@ export default defineConfig({
             "debug",
             "@braintree/sanitize-url",
             "monaco-yaml/yaml.worker",
+            "vue-axios",
+            "lodash-es",
+            "nprogress"
         ],
         exclude: [
             "* > @kestra-io/ui-libs"

--- a/ui/vite.config.js
+++ b/ui/vite.config.js
@@ -85,7 +85,8 @@ export default defineConfig({
             // without allowing interop in typescript
             "dayjs",
             "debug",
-            "@braintree/sanitize-url"
+            "@braintree/sanitize-url",
+            "monaco-yaml/yaml.worker",
         ],
         exclude: [
             "* > @kestra-io/ui-libs"

--- a/ui/vitest.config.js
+++ b/ui/vitest.config.js
@@ -37,10 +37,5 @@ export default defineConfig({
     },
     define: {
         "window.KESTRA_BASE_PATH": "/ui/",
-    },
-    optimizeDeps: {
-        include: [
-            "monaco-yaml/yaml.worker",
-        ],
-    },
+    }
 })

--- a/ui/vitest.config.js
+++ b/ui/vitest.config.js
@@ -37,5 +37,5 @@ export default defineConfig({
     },
     define: {
         "window.KESTRA_BASE_PATH": "/ui/",
-    }
+    },
 })

--- a/ui/vitest.config.js
+++ b/ui/vitest.config.js
@@ -38,4 +38,9 @@ export default defineConfig({
     define: {
         "window.KESTRA_BASE_PATH": "/ui/",
     },
+    optimizeDeps: {
+        include: [
+            "monaco-yaml/yaml.worker",
+        ],
+    },
 })


### PR DESCRIPTION
removes the following warning in UI tests

```log
[Vue warn]: injection "Symbol(creating-injection-key)" not found. 
  at <Editor creation=false metadata= {
  "concurrency": {},
  "description": "Example description",
  "disabled": false,
  "id": "example-id",
  "inputs": [],
  "labels": {},
  "namespace": "example-namespace",
  "outputs": "",
  "pluginDefaults": "",
  "retry": "",
  "variables": {},
} flow="id: flow1\nnamespace: namespace1\ntasks:\n  - id: task1\n    type: io.kestra.plugin.core.debug.Return\n    message: \"Hello world\"\n    values:\n      - one\n      - two\n      - three"  ... > 
  at <Anonymous> 
  at <Anonymous> 
  at <Story> 
  at <Anonymous> 
  at <App>
```

Also added a few dependencies to optimize explicitely so tests pass nicely.

Also added caching of dependencies so run can take 2 min instead of 5