### PR TITLE
feat(executions): Add workerId to each worker task attemps

### DIFF
--- a/core/src/main/java/io/kestra/core/models/executions/TaskRunAttempt.java
+++ b/core/src/main/java/io/kestra/core/models/executions/TaskRunAttempt.java
@@ -1,5 +1,6 @@
 package io.kestra.core.models.executions;
 
+import jakarta.annotation.Nullable;
 import lombok.Builder;
 import lombok.Value;
 import io.kestra.core.models.flows.State;
@@ -18,11 +19,13 @@ public class TaskRunAttempt {
      */
     @Deprecated
     public void setMetrics(List<AbstractMetricEntry<?>> metrics) {
-
     }
 
     @NotNull
     State state;
+
+    @Nullable
+    String workerId;
 
     @With
     URI logFile;
@@ -30,6 +33,7 @@ public class TaskRunAttempt {
     public TaskRunAttempt withState(State.Type state) {
         return new TaskRunAttempt(
             this.state.withState(state),
+            this.workerId,
             this.logFile
         );
     }

--- a/core/src/main/java/io/kestra/core/runners/Worker.java
+++ b/core/src/main/java/io/kestra/core/runners/Worker.java
@@ -773,7 +773,10 @@ public class Worker implements Service, Runnable, AutoCloseable {
         if (!(workerTask.getTask() instanceof RunnableTask<?> task)) {
             // This should never happen but better to deal with it than crashing the Worker
             var state = workerTask.getTask().isAllowFailure() ? workerTask.getTask().isAllowWarning() ? SUCCESS : WARNING : FAILED;
-            TaskRunAttempt attempt = TaskRunAttempt.builder().state(new io.kestra.core.models.flows.State().withState(state)).build();
+            TaskRunAttempt attempt = TaskRunAttempt.builder()
+                .state(new io.kestra.core.models.flows.State().withState(state))
+                .workerId(this.id)
+                .build();
             List<TaskRunAttempt> attempts = this.addAttempt(workerTask, attempt);
             TaskRun taskRun = workerTask.getTaskRun().withAttempts(attempts);
             logger.error("Unable to execute the task '" + workerTask.getTask().getId() +
@@ -782,7 +785,8 @@ public class Worker implements Service, Runnable, AutoCloseable {
         }
 
         TaskRunAttempt.TaskRunAttemptBuilder builder = TaskRunAttempt.builder()
-            .state(new io.kestra.core.models.flows.State().withState(RUNNING));
+            .state(new io.kestra.core.models.flows.State().withState(RUNNING))
+            .workerId(this.id);
 
         // emit the attempt so the execution knows that the task is in RUNNING
         this.workerTaskResultQueue.emit(new WorkerTaskResult(

--- a/ui/src/components/executions/ServiceInfo.vue
+++ b/ui/src/components/executions/ServiceInfo.vue
@@ -1,0 +1,46 @@
+<template>
+    <component
+        :is="component"
+        v-if="service != null"
+    >
+        <template #default>
+            <strong>{{ service.id }}</strong>: {{ $t("hostname") }}={{ service.server.hostname }}, {{ $t("version") }}={{ service.server.version }}, {{ $t("state") }}={{ service.state }}
+        </template>
+    </component>
+</template>
+
+<script>
+    export default {
+        props: {
+            component: {
+                type: String,
+                default: "b-button"
+            },
+            serviceId: {
+                type: String,
+                required: true
+            }
+        },
+        emits: ["follow"],
+        methods: {
+            load() {
+                this.$store.dispatch("service/findServiceById", {id: this.serviceId}).then(service => {
+                    this.service = service;
+                });
+            },
+        },
+        computed: {
+            uuid() {
+                return "serviceinfo-" + this.serviceId;
+            },
+        },
+        mounted() {
+            this.load();
+        },
+        data() {
+            return {
+                service: undefined,
+            };
+        },
+    };
+</script>

--- a/ui/src/components/executions/TaskRunLine.vue
+++ b/ui/src/components/executions/TaskRunLine.vue
@@ -126,6 +126,12 @@
                     >
                         {{ $t("delete logs") }}
                     </el-dropdown-item>
+                    <WorkerInfo
+                        component="el-dropdown-item"
+                        v-if="hasWorkerId(currentTaskRun) !== null"
+                        :task-run="currentTaskRun"
+                        @follow="forwardEvent('follow', $event)"
+                    />
                 </el-dropdown-menu>
             </template>
         </el-dropdown>
@@ -165,6 +171,7 @@
     import ChevronRight from "vue-material-design-icons/ChevronRight.vue";
     import ChevronDown from "vue-material-design-icons/ChevronDown.vue";
     import DotsVertical from "vue-material-design-icons/DotsVertical.vue";
+    import WorkerInfo from "./WorkerInfo.vue";
 </script>
 
 <script>
@@ -325,6 +332,9 @@
                     () => {}
                 )
 
+            },
+            hasWorkerId(currentTaskRun) {
+                return currentTaskRun.attempts?.find(attempt => attempt.workerId !== null) !== null;
             },
             forwardEvent(type, event) {
                 this.$emit(type, event);

--- a/ui/src/components/executions/WorkerInfo.vue
+++ b/ui/src/components/executions/WorkerInfo.vue
@@ -1,0 +1,63 @@
+<template>
+    <component
+        :is="component"
+        :icon="Server"
+        @click="visible = !visible"
+    >
+        <span v-if="component !== 'el-button'">{{ $t('worker information') }}</span>
+
+        <el-dialog v-if="visible" v-model="visible" :id="uuid" destroy-on-close :append-to-body="true">
+            <template #header>
+                <h5>{{ $t("worker information") }}</h5>
+            </template>
+
+            <template #default>
+                <ol>
+                    <li v-for="item in taskRun.attempts" :key="item.id">
+                        <ServiceInfo :service-id="item.workerId" />
+                    </li>
+                </ol>
+            </template>
+
+            <template #footer>
+                <el-button @click="visible = false">
+                    {{ $t('close') }}
+                </el-button>
+            </template>
+        </el-dialog>
+    </component>
+</template>
+
+<script setup>
+    import Server from "vue-material-design-icons/Server.vue";
+</script>
+
+<script>
+    import ServiceInfo from "./ServiceInfo.vue";
+
+    export default {
+        components: {ServiceInfo},
+        props: {
+            component: {
+                type: String,
+                default: "b-button"
+            },
+            taskRun: {
+                type: Object,
+                required: false,
+                default: undefined
+            }
+        },
+        emits: ["follow"],
+        computed: {
+            uuid() {
+                return "workerinfo-" + this.taskRun.id;
+            },
+        },
+        data() {
+            return {
+                visible: false,
+            };
+        },
+    };
+</script>

--- a/ui/src/stores/service.js
+++ b/ui/src/stores/service.js
@@ -1,0 +1,13 @@
+import {apiUrl} from "override/utils/route";
+
+export default {
+    namespaced: true,
+
+    actions: {
+        findServiceById(_, options) {
+            return this.$http.get(`${apiUrl(this)}/cluster/services/${options.id}`).then(response => {
+                return response.data;
+            })
+        },
+    }
+}

--- a/ui/src/stores/store.js
+++ b/ui/src/stores/store.js
@@ -19,6 +19,7 @@ import bookmarks from "./bookmarks";
 import dashboard from "./dashboard";
 import code from "./code";
 import blueprints from "./blueprints";
+import service from "./service"
 
 export default {
     modules: {
@@ -43,5 +44,6 @@ export default {
         dashboard,
         code,
         blueprints,
+        service,
     }
 }

--- a/ui/src/translations/en.json
+++ b/ui/src/translations/en.json
@@ -1314,6 +1314,7 @@
     },
     "search_docs": "Search",
     "no_results_found": "No results found",
-    "searching": "Searching..."
+    "searching": "Searching...",
+    "worker information": "Worker Information"
   }
 }

--- a/webserver/src/main/java/io/kestra/webserver/controllers/api/ClusterController.java
+++ b/webserver/src/main/java/io/kestra/webserver/controllers/api/ClusterController.java
@@ -1,0 +1,33 @@
+package io.kestra.webserver.controllers.api;
+
+import io.kestra.core.repositories.ServiceInstanceRepositoryInterface;
+import io.kestra.core.server.*;
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.http.HttpResponse;
+import io.micronaut.http.annotation.*;
+import io.micronaut.http.exceptions.HttpStatusException;
+import io.micronaut.scheduling.TaskExecutors;
+import io.micronaut.scheduling.annotation.ExecuteOn;
+import io.swagger.v3.oas.annotations.Operation;
+import jakarta.inject.Inject;
+
+@Controller("/api/v1/cluster")
+@Requires(bean = ServiceInstanceRepositoryInterface.class)
+public class ClusterController {
+
+    private final ServiceInstanceRepositoryInterface repository;
+
+    @Inject
+    public ClusterController(final ServiceInstanceRepositoryInterface repository) {
+        this.repository = repository;
+    }
+
+    @ExecuteOn(TaskExecutors.IO)
+    @Get("services/{id}")
+    @Operation(tags = {"Services"}, summary = "Get details about a service")
+    public HttpResponse<ServiceInstance> getService(@PathVariable("id") String id) throws HttpStatusException {
+        return repository.findById(id)
+            .map(HttpResponse::ok)
+            .orElseGet(HttpResponse::notFound);
+    }
+}

--- a/webserver/src/test/java/io/kestra/webserver/controllers/api/ClusterControllerTest.java
+++ b/webserver/src/test/java/io/kestra/webserver/controllers/api/ClusterControllerTest.java
@@ -1,0 +1,34 @@
+package io.kestra.webserver.controllers.api;
+
+import io.kestra.core.junit.annotations.KestraTest;
+import io.kestra.core.runners.Worker;
+import io.kestra.core.server.ServerInstance;
+import io.kestra.core.server.ServiceInstance;
+import io.micronaut.http.HttpRequest;
+import io.micronaut.http.client.annotation.Client;
+import io.micronaut.reactor.http.client.ReactorHttpClient;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@KestraTest(startRunner = true)
+class ClusterControllerTest {
+    @Inject
+    @Client("/")
+    ReactorHttpClient client;
+
+    @Inject
+    Worker worker;
+
+    @Test
+    void shouldGetServiceInfo() {
+        ServiceInstance serviceInstance = client.toBlocking().retrieve(
+            HttpRequest.GET("/api/v1/cluster/services/" + worker.getId()),
+            ServiceInstance.class
+        );
+
+        assertThat(serviceInstance).isNotNull();
+        assertThat(serviceInstance.server().type()).isEqualTo(ServerInstance.Type.STANDALONE);
+    }
+}


### PR DESCRIPTION
Closes #7799

Will display the following service information for each attempt:
![image](https://github.com/user-attachments/assets/9aa667fa-5ec0-4365-8054-6569411807c5)

More information are available, see the cluster tab in EE.
