### PR TITLE
feat(flows): Allow to define an onPause task on the Pause task

### DIFF
--- a/core/src/main/java/io/kestra/core/utils/ListUtils.java
+++ b/core/src/main/java/io/kestra/core/utils/ListUtils.java
@@ -31,4 +31,28 @@ public class ListUtils {
         newList.addAll(list2);
         return newList;
     }
+
+    /**
+     * Concat multiple lists into a single list.
+     */
+    @SafeVarargs
+    public static <T> List<T> concat(List<T> list1, List<T> list2, List<T>... lists) {
+        List<T> newList = new ArrayList<>();
+        if (!isEmpty(list1)) {
+            newList.addAll(list1);
+        }
+        if (!isEmpty(list2)) {
+            newList.addAll(list2);
+        }
+
+        if (lists != null) {
+            for (List<T> list : lists) {
+                if (!isEmpty(list)) {
+                    newList.addAll(list);
+                }
+            }
+        }
+
+        return newList;
+    }
 }

--- a/core/src/test/java/io/kestra/plugin/core/flow/PauseTest.java
+++ b/core/src/test/java/io/kestra/plugin/core/flow/PauseTest.java
@@ -1,6 +1,7 @@
 package io.kestra.plugin.core.flow;
 
 import com.google.common.io.CharStreams;
+import io.kestra.core.junit.annotations.ExecuteFlow;
 import io.kestra.core.junit.annotations.KestraTest;
 import io.kestra.core.junit.annotations.LoadFlows;
 import io.kestra.core.models.executions.Execution;
@@ -123,6 +124,12 @@ public class PauseTest {
     @LoadFlows({"flows/valids/pause-behavior.yaml"})
     void runDurationWithCANCELBehavior() throws Exception {
         suite.runDurationWithBehavior(runnerUtils, Pause.Behavior.CANCEL);
+    }
+
+    @Test
+    @ExecuteFlow("flows/valids/pause_on_pause.yaml")
+    void shouldExecuteOnPauseTask(Execution execution) throws Exception {
+        suite.shouldExecuteOnPauseTask(execution);
     }
 
     @Singleton
@@ -343,6 +350,13 @@ public class PauseTest {
             assertThat(execution.getTaskRunList()).hasSize(terminateAfterPause ? 1 : 2);
             assertThat(execution.getTaskRunList().getFirst().getState().getCurrent()).isEqualTo(finalState);
             assertThat(execution.getState().getCurrent()).isEqualTo(finalState);
+        }
+
+        public void shouldExecuteOnPauseTask(Execution execution) throws Exception {
+            assertThat(execution.getState().getCurrent()).isEqualTo(State.Type.SUCCESS);
+            assertThat(execution.getTaskRunList()).hasSize(2);
+            assertThat(execution.getTaskRunList().getLast().getTaskId()).isEqualTo("hello");
+            assertThat(execution.getTaskRunList().getLast().getState().getCurrent()).isEqualTo(State.Type.SUCCESS);
         }
     }
 }

--- a/core/src/test/resources/flows/valids/pause_on_pause.yaml
+++ b/core/src/test/resources/flows/valids/pause_on_pause.yaml
@@ -1,0 +1,11 @@
+id: pause_on_pause
+namespace: io.kestra.tests
+
+tasks:
+  - id: pause
+    type: io.kestra.plugin.core.flow.Pause
+    pauseDuration: PT0.5S
+    onPause:
+      id: hello
+      type: io.kestra.plugin.core.log.Log
+      message: Hello World! 🚀


### PR DESCRIPTION
The onPause task will be executed immediatly when the execution is paused. Part-of: #3601