### PR TITLE
fix: redirect to edit when saving new flow

### DIFF
--- a/ui/src/stores/flow.js
+++ b/ui/src/stores/flow.js
@@ -195,6 +195,7 @@ export default {
                 }
             }
 
+            const {isCreating} = state;
             if (state.isCreating && !overrideFlow) {
                 await dispatch("createFlow", {flow: flowYaml})
                     .then((response) => {
@@ -210,13 +211,13 @@ export default {
                     });
             }
 
-            if (state.isCreating || overrideFlow) {
+            if (isCreating || overrideFlow) {
                 return "redirect_to_update";
             }
 
             commit("setHaveChange", false);
             await dispatch("validateFlow", {
-                flow: state.isCreating ? flowYaml : getters.yamlWithNextRevision
+                flow: isCreating ? flowYaml : getters.yamlWithNextRevision
             });
         },
         fetchGraph({state, dispatch}) {


### PR DESCRIPTION
closes #8530
Closes https://github.com/kestra-io/kestra/issues/8566.

The `state.isCreating` value was used as it was modified. Using a copy of its value to pursue the process was necessary.