### PR TITLE
feat(system)*: decrease defaut JDBC queue poll size

### DIFF
--- a/jdbc/src/main/java/io/kestra/jdbc/runner/JdbcQueue.java
+++ b/jdbc/src/main/java/io/kestra/jdbc/runner/JdbcQueue.java
@@ -465,6 +465,6 @@ public abstract class JdbcQueue<T> implements QueueInterface<T> {
         Duration minPollInterval = Duration.ofMillis(100);
         Duration maxPollInterval = Duration.ofMillis(500);
         Duration pollSwitchInterval = Duration.ofSeconds(30);
-        Integer pollSize = 100;
+        Integer pollSize = 50;
     }
 }


### PR DESCRIPTION
Decreasing it from 100 to 50 didn't show any performance hit but lower the memory consumption now that we process the queue concurrently in the executor.

I plan to do more test but I propose this as a quickwin to lower the memory consumption increase due to the new concurrency processing on the executor.

## With small messages
### BEFORE - pollSize=100
- 10 tx/s: 150ms
- 25 tx/s: 200ms
- 50 tx/s: 300ms
- 75 tx/s: 5.2s
- 100 tx/s: 15s

### AFTER - pollSize=50
- 10 tx/s: 150ms
- 25 tx/s: 200ms
- 50 tx/s: 300ms
- 75 tx/s: 4.8s
- 100 tx/s: 14s

## With big messages (150k)
The effect on memory consumption is visible

## Before (10 tx/s then 20 tx/s)
![image](https://github.com/user-attachments/assets/4f02c513-ecaa-47db-ac20-cb3bfa384bb1)


## After (10 tx/s then 20 tx/s)
![image](https://github.com/user-attachments/assets/63858499-f7c8-4d11-90bb-17c5b8aa6cbf)
