### PR TITLE
feat(system): add uv to kestra docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,8 +16,9 @@ RUN apt-get update -y && \
     if [ -n "${APT_PACKAGES}" ]; then apt-get install -y --no-install-recommends ${APT_PACKAGES}; fi && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* /var/tmp/* /tmp/* && \
+    curl -LsSf https://astral.sh/uv/0.6.17/install.sh | sh && mv /root/.local/bin/uv /bin && mv /root/.local/bin/uvx /bin && \
     if [ -n "${KESTRA_PLUGINS}" ]; then /app/kestra plugins install ${KESTRA_PLUGINS} && rm -rf /tmp/*; fi && \
-    if [ -n "${PYTHON_LIBRARIES}" ]; then pip install ${PYTHON_LIBRARIES}; fi && \
+    if [ -n "${PYTHON_LIBRARIES}" ]; then uv pip install --system ${PYTHON_LIBRARIES}; fi && \
     chown -R kestra:kestra /app
 
 USER kestra


### PR DESCRIPTION
Use uv to install packages. UV is now required
to manage pythons dependencies for the plugin-script python.

Fix: kestra-io/kestra-ee#3527