### PR TITLE
fix(ui): update shortcut modal to show correct autocomplete key for Mac

### DIFF
--- a/ui/src/components/inputs/KeyShortcuts.vue
+++ b/ui/src/components/inputs/KeyShortcuts.vue
@@ -52,7 +52,7 @@
 
     const commands = [
         {
-            keys: ["⌘ Cmd/Ctrl", "SPACE"],
+            keys: ["Ctrl", "SPACE"],
             description: "editor_shortcuts.trigger_autocompletion",
         },
         {


### PR DESCRIPTION
**What changes are being made and why?**

Replaces the misleading `Cmd/Ctrl + SPACE` shortcut with `Ctrl + SPACE` in the keyboard shortcut help dialog shown in the UI editor.

This avoids confusion for Mac users where `Cmd + SPACE` triggers Spotlight search, not autocomplete. The change improves accuracy and UX consistency across platforms.

---

**How have the changes been QAed?**

- Launched the editor in the web UI.
- Clicked on the keyboard icon (tooltip).
- Verified that the autocomplete shortcut now shows only `Ctrl + SPACE`.
- Confirmed all other shortcuts remain unchanged.

---

**Screenshot:**

[Updated Shortcut Dialog](https://drive.google.com/file/d/1r7V4vJjpCzKowIdXb-cM_cx2UkIJdjxs/view?usp=sharing)

---

Hi @MilosPaunovic,
Could you please review this change? The update ensures that the keyboard shortcut for autocomplete on Mac is Ctrl + SPACE, avoiding the conflict with Spotlight Search. Your feedback would be greatly appreciated!

Closes https://github.com/kestra-io/kestra/issues/8617.