### PR TITLE
feat(flows)!: evaluate flow trigger on PAUSED by default

### DIFF
--- a/core/src/main/java/io/kestra/plugin/core/trigger/Flow.java
+++ b/core/src/main/java/io/kestra/plugin/core/trigger/Flow.java
@@ -49,6 +49,7 @@ import java.util.stream.Stream;
 import io.micronaut.core.annotation.Nullable;
 import jakarta.validation.constraints.NotNull;
 
+import static io.kestra.core.models.flows.State.Type.PAUSED;
 import static io.kestra.core.topologies.FlowTopologyService.SIMULATED_EXECUTION;
 import static io.kestra.core.utils.Rethrow.throwPredicate;
 
@@ -218,14 +219,14 @@ public class Flow extends AbstractTrigger implements TriggerOutput<Flow.Output> 
     @Schema(
         title = "List of execution states that will be evaluated by the trigger",
         description = """
-            By default, only executions in a terminal state will be evaluated.
+            By default, only executions in a terminal state or in the PAUSED state will be evaluated.
             Any `ExecutionStatus`-type condition will be evaluated after the list of `states`. Note that a Flow trigger cannot react to the `CREATED` state because the Flow trigger reacts to state transitions. The `CREATED` state is the initial state of an execution and does not represent a state transition.
             ::alert{type="info"}
             The trigger will be evaluated for each state change of matching executions. If a flow has two `Pause` tasks, the execution will transition from PAUSED to a RUNNING state twice — one for each Pause task. In this case, a Flow trigger listening to a `PAUSED` state will be evaluated twice.
             ::"""
     )
     @Builder.Default
-    private List<State.Type> states = State.Type.terminatedTypes();
+    private List<State.Type> states = ListUtils.concat(State.Type.terminatedTypes(), List.of(PAUSED));
 
     @Valid
     @Schema(

--- a/core/src/test/java/io/kestra/core/repositories/AbstractFlowRepositoryTest.java
+++ b/core/src/test/java/io/kestra/core/repositories/AbstractFlowRepositoryTest.java
@@ -188,7 +188,7 @@ public abstract class AbstractFlowRepositoryTest {
     @Test
     void findByNamespace() {
         List<Flow> save = flowRepository.findByNamespace(null, "io.kestra.tests");
-        assertThat((long) save.size()).isEqualTo(Helpers.FLOWS_COUNT - 20);
+        assertThat((long) save.size()).isEqualTo(Helpers.FLOWS_COUNT - 22);
 
         save = flowRepository.findByNamespace(null, "io.kestra.tests2");
         assertThat((long) save.size()).isEqualTo(1L);
@@ -390,7 +390,7 @@ public abstract class AbstractFlowRepositoryTest {
     @Test
     void findDistinctNamespace() {
         List<String> distinctNamespace = flowRepository.findDistinctNamespace(null);
-        assertThat((long) distinctNamespace.size()).isEqualTo(7L);
+        assertThat((long) distinctNamespace.size()).isEqualTo(8L);
     }
 
     @SuppressWarnings("deprecation")

--- a/core/src/test/java/io/kestra/core/runners/AbstractRunnerTest.java
+++ b/core/src/test/java/io/kestra/core/runners/AbstractRunnerTest.java
@@ -232,6 +232,12 @@ public abstract class AbstractRunnerTest {
         multipleConditionTriggerCaseTest.flowTriggerPreconditionsMergeOutputs();
     }
 
+    @Test
+    @LoadFlows({"flows/valids/flow-trigger-paused-listen.yaml", "flows/valids/flow-trigger-paused-flow.yaml"})
+    void flowTriggerOnPaused() throws Exception {
+        multipleConditionTriggerCaseTest.flowTriggerOnPaused();
+    }
+
     @RetryingTest(5)
     @LoadFlows({"flows/valids/each-null.yaml"})
     void eachWithNull() throws Exception {

--- a/core/src/test/resources/flows/valids/flow-trigger-paused-flow.yaml
+++ b/core/src/test/resources/flows/valids/flow-trigger-paused-flow.yaml
@@ -1,0 +1,13 @@
+id: flow-trigger-paused-flow
+namespace: io.kestra.tests.trigger.paused
+
+labels:
+  some: label
+
+tasks:
+  - id: pause
+    type: io.kestra.plugin.core.flow.Pause
+    pauseDuration: PT0.5S
+  - id: only
+    type: io.kestra.plugin.core.debug.Return
+    format: "from parents: {{execution.id}}"

--- a/core/src/test/resources/flows/valids/flow-trigger-paused-listen.yaml
+++ b/core/src/test/resources/flows/valids/flow-trigger-paused-listen.yaml
@@ -1,0 +1,17 @@
+id: flow-trigger-paused-listen
+namespace: io.kestra.tests.trigger.paused
+
+triggers:
+  - id: flow
+    type: io.kestra.plugin.core.trigger.Flow
+    preconditions:
+      id: flow
+      flows:
+        - namespace: io.kestra.tests.trigger.paused
+          flowId: flow-trigger-paused-flow
+          states: [PAUSED]
+
+tasks:
+  - id: only
+    type: io.kestra.plugin.core.debug.Return
+    format: "It works"

--- a/webserver/src/test/java/io/kestra/webserver/controllers/api/FlowControllerTest.java
+++ b/webserver/src/test/java/io/kestra/webserver/controllers/api/FlowControllerTest.java
@@ -450,7 +450,7 @@ class FlowControllerTest {
         List<String> namespaces = client.toBlocking().retrieve(
             HttpRequest.GET("/api/v1/flows/distinct-namespaces"), Argument.listOf(String.class));
 
-        assertThat(namespaces.size()).isEqualTo(7);
+        assertThat(namespaces.size()).isEqualTo(8);
     }
 
     @Test


### PR DESCRIPTION
This is a breaking change as existing flow trigger wich didn't filter to any states on conditiosn or preconditions was before triggering executions only on terminal states and will now trigger executions on terminated and paused states.

Fixes https://github.com/kestra-io/kestra-ee/issues/3535
