### PR TITLE
fix(core): allow scalar-to-string concatenation in typed task property

### DIFF
--- a/core/src/main/java/io/kestra/core/runners/pebble/TypedObjectWriter.java
+++ b/core/src/main/java/io/kestra/core/runners/pebble/TypedObjectWriter.java
@@ -4,149 +4,93 @@ import io.pebbletemplates.pebble.extension.writer.SpecializedWriter;
 import lombok.SneakyThrows;
 
 import java.io.IOException;
-import java.io.Writer;
 import java.util.Arrays;
-import java.util.Collection;
-import java.util.Map;
-import java.util.stream.IntStream;
 
 public class TypedObjectWriter extends OutputWriter implements SpecializedWriter {
     private Object current;
 
     @Override
     public void writeSpecialized(int i) {
-        if (current == null) {
-            current = i;
-        } else {
-            Integer currentI = this.ofSameTypeOrThrow(current, Integer.class);
-            current = currentI + i;
-        }
+        concatSpecialized(i);
     }
 
     @Override
     public void writeSpecialized(long l) {
-        if (current == null) {
-            current = l;
-        } else {
-            Long currentL = this.ofSameTypeOrThrow(current, Long.class);
-            current = currentL + l;
-        }
+        concatSpecialized(l);
     }
 
     @Override
     public void writeSpecialized(double d) {
-        if (current == null) {
-            current = d;
-        } else {
-            Double currentD = this.ofSameTypeOrThrow(current, Double.class);
-            current = currentD + d;
-        }
+        concatSpecialized(d);
     }
 
     @Override
     public void writeSpecialized(float f) {
-        if (current == null) {
-            current = f;
-        } else {
-            Float currentF = this.ofSameTypeOrThrow(current, Float.class);
-            current = currentF + f;
-        }
+        concatSpecialized(f);
     }
 
     @Override
     public void writeSpecialized(short s) {
-        if (current == null) {
-            current = s;
-        } else {
-            Short currentS = null;
-            try {
-                currentS = this.ofSameTypeOrThrow(current, Short.class);
-            } catch (Exception e) {
-                try {
-                    current = this.ofSameTypeOrThrow(current, Integer.class) + s;
-                    return;
-                } catch (Exception ex) {
-                    throw e;
-                }
-            }
-            current = currentS + s;
-        }
+        concatSpecialized(s);
     }
 
     @Override
     public void writeSpecialized(byte b) {
-        if (current == null) {
-            current = b;
-        } else {
-            Byte currentB = null;
-            try {
-                currentB = this.ofSameTypeOrThrow(current, Byte.class);
-            } catch (Exception e) {
-                try {
-                    current = this.ofSameTypeOrThrow(current, Integer.class) + b;
-                    return;
-                } catch (Exception ex) {
-                    throw e;
-                }
-            }
-            current = currentB + b;
-        }
+        concatSpecialized(b);
     }
 
     @Override
     public void writeSpecialized(char c) {
-        if (current == null) {
-            current = c;
-        } else {
-            Character currentC;
-            try {
-                currentC = this.ofSameTypeOrThrow(current, Character.class);
-            } catch (Exception e) {
-                try {
-                    current = this.ofSameTypeOrThrow(current, String.class) + c;
-                    return;
-                } catch (Exception ex) {
-                    throw e;
-                }
-            }
-            current = "" + currentC + c;
-        }
+        concatSpecialized(c);
     }
 
     @Override
     public void writeSpecialized(String s) {
-        if (current == null) {
-            current = s;
-        } else {
-            String currentS = this.ofSameTypeOrThrow(current, String.class);
-            current = currentS + s;
+        concatSpecialized(s);
+    }
+
+    private void concatSpecialized(final Object o) {
+        if (o == null) {
+            return;
         }
+
+        if (current == null) {
+            current = o;
+            return;
+        }
+
+        if (isConcatenableScalar(current) && isConcatenableScalar(o)) {
+            current = current.toString() + o;
+            return;
+        }
+
+        throw new IllegalArgumentException(
+            "Cannot concat " + current.getClass().getName() + " with " + o.getClass().getName()
+        );
     }
 
     @SneakyThrows
     @Override
     public void write(Object o) {
+        if (o == null) {
+            return;
+        }
+
         if (current == null) {
             current = o;
+        } else if (isConcatenableScalar(o)) {
+            // do call the writeSpecialized method depending on the object type.
+            SpecializedWriter.super.write(o);
         } else {
-            throwIllegalAddition(current, o.getClass());
+            throw new IllegalArgumentException(
+                "Cannot concat " + current.getClass().getName() + " with " + o.getClass().getName()
+            );
         }
     }
 
     @Override
     public void write(char[] cbuf, int off, int len) throws IOException {
-        if (current == null) {
-            current = String.valueOf(Arrays.copyOfRange(cbuf, off, off + len));
-            return;
-        }
-
-        if (current instanceof String) {
-            current += String.valueOf(Arrays.copyOfRange(cbuf, off, off + len));
-        } else {
-            for (int idx = off; idx < off + len; idx++) {
-                this.writeSpecialized(cbuf[idx]);
-            }
-        }
+        writeSpecialized(String.valueOf(Arrays.copyOfRange(cbuf, off, off + len)));
     }
 
     @Override
@@ -159,21 +103,19 @@ public class TypedObjectWriter extends OutputWriter implements SpecializedWriter
         // no-op
     }
 
-    private <T> T ofSameTypeOrThrow(Object baseObject, Class<T> clazz) {
-        if (clazz.isAssignableFrom(baseObject.getClass())) {
-            return clazz.cast(baseObject);
-        } else {
-            throwIllegalAddition(baseObject, clazz);
-            return null;
-        }
-    }
-
-    private static <T> void throwIllegalAddition(Object baseObject, Class<T> clazz) {
-        throw new IllegalArgumentException("Tried to add " + clazz.getName() + " to " + baseObject.getClass().getName());
-    }
-
     @Override
     public Object output() {
         return this.current;
+    }
+
+    public static boolean isConcatenableScalar(final Object obj) {
+        if (obj == null) return false;
+
+        Class<?> clazz = obj.getClass();
+
+        return clazz == Boolean.class ||
+            clazz == Character.class ||
+            clazz == String.class ||
+            Number.class.isAssignableFrom(clazz);
     }
 }

--- a/core/src/test/java/io/kestra/core/runners/pebble/TypedObjectWriterTest.java
+++ b/core/src/test/java/io/kestra/core/runners/pebble/TypedObjectWriterTest.java
@@ -9,12 +9,12 @@ import java.util.Map;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class TypedObjectWriterTest {
+
     @Test
-    void invalidAddition() throws IOException {
+    void writeInt() throws IOException {
         try (TypedObjectWriter writer = new TypedObjectWriter()){
             writer.writeSpecialized(1);
-            IllegalArgumentException illegalArgumentException = Assertions.assertThrows(IllegalArgumentException.class, () -> writer.writeSpecialized('a'));
-            assertThat(illegalArgumentException.getMessage()).isEqualTo("Tried to add java.lang.Character to java.lang.Integer");
+            assertThat(writer.output()).isEqualTo(1);
         }
     }
 
@@ -24,7 +24,15 @@ public class TypedObjectWriterTest {
             writer.writeSpecialized(1);
             writer.writeSpecialized(2);
             writer.writeSpecialized(3);
-            assertThat(writer.output()).isEqualTo(6);
+            assertThat(writer.output()).isEqualTo("123");
+        }
+    }
+
+    @Test
+    void writeLong() throws IOException {
+        try (TypedObjectWriter writer = new TypedObjectWriter()){
+            writer.writeSpecialized(1L);
+            assertThat(writer.output()).isEqualTo(1L);
         }
     }
 
@@ -34,7 +42,15 @@ public class TypedObjectWriterTest {
             writer.writeSpecialized(1L);
             writer.writeSpecialized(2L);
             writer.writeSpecialized(3L);
-            assertThat(writer.output()).isEqualTo(6L);
+            assertThat(writer.output()).isEqualTo("123");
+        }
+    }
+
+    @Test
+    void writeDouble() throws IOException {
+        try (TypedObjectWriter writer = new TypedObjectWriter()){
+            writer.writeSpecialized(1.0);
+            assertThat(writer.output()).isEqualTo(1.0);
         }
     }
 
@@ -44,7 +60,15 @@ public class TypedObjectWriterTest {
             writer.writeSpecialized(1.0);
             writer.writeSpecialized(2.0);
             writer.writeSpecialized(3.0);
-            assertThat(writer.output()).isEqualTo(6.0);
+            assertThat(writer.output()).isEqualTo("1.02.03.0");
+        }
+    }
+
+    @Test
+    void writeFloat() throws IOException {
+        try (TypedObjectWriter writer = new TypedObjectWriter()){
+            writer.writeSpecialized(1.0f);
+            assertThat(writer.output()).isEqualTo(1.0f);
         }
     }
 
@@ -54,7 +78,15 @@ public class TypedObjectWriterTest {
             writer.writeSpecialized(1.0f);
             writer.writeSpecialized(2.0f);
             writer.writeSpecialized(3.0f);
-            assertThat(writer.output()).isEqualTo(6.0f);
+            assertThat(writer.output()).isEqualTo("1.02.03.0");
+        }
+    }
+
+    @Test
+    void writeShort() throws IOException {
+        try (TypedObjectWriter writer = new TypedObjectWriter()){
+            writer.writeSpecialized((short) 1);
+            assertThat(writer.output()).isEqualTo((short) 1);
         }
     }
 
@@ -64,7 +96,7 @@ public class TypedObjectWriterTest {
             writer.writeSpecialized((short) 1);
             writer.writeSpecialized((short) 2);
             writer.writeSpecialized((short) 3);
-            assertThat(writer.output()).isEqualTo(6);
+            assertThat(writer.output()).isEqualTo("123");
         }
     }
 
@@ -77,7 +109,7 @@ public class TypedObjectWriterTest {
             writer.writeSpecialized(bByte);
             byte cByte = "c".getBytes()[0];
             writer.writeSpecialized(cByte);
-            assertThat(writer.output()).isEqualTo((aByte + bByte) + cByte);
+            assertThat(writer.output()).isEqualTo("979899");
         }
     }
 
@@ -106,7 +138,7 @@ public class TypedObjectWriterTest {
         try (TypedObjectWriter writer = new TypedObjectWriter()){
             writer.write(Map.of("a", "b"));
             IllegalArgumentException illegalArgumentException = Assertions.assertThrows(IllegalArgumentException.class, () -> writer.write(Map.of("c", "d")));
-            assertThat(illegalArgumentException.getMessage()).isEqualTo("Tried to add java.util.ImmutableCollections$Map1 to java.util.ImmutableCollections$Map1");
+            assertThat(illegalArgumentException.getMessage()).isEqualTo("Cannot concat java.util.ImmutableCollections$Map1 with java.util.ImmutableCollections$Map1");
         }
     }
 }


### PR DESCRIPTION
Enable concatenation of arbitrary scalar values (e.g., numbers, booleans) into a string when setting a typed plugin property expecting a single value: e.g., the `value` property of the `io.kestra.plugin.core.kv.Set` task.

Fix: kestra-io/kestra-ee#3570

This will make this flow working:

```yaml
id: kv-concat-test
namespace: sandbox

inputs:
  - id: int1
    type: INT
    defaults: 3

  - id: int2
    type: INT
    defaults: 2
tasks:
  # OK
  - id: set_string_works
    type: io.kestra.plugin.core.kv.Set
    key: "mystring"
    kvType: STRING
    value: "{{kestra.url ~ '/api/v1/' ~ flow.namespace ~ '/namespaces'}}"

  # KO Failed with: Tried to add java.lang.String to java.lang.String
  - id: set_string_doesnt_work
    type: io.kestra.plugin.core.kv.Set
    key: "mystring"
    kvType: STRING
    value: "{{kestra.url}}/api/v1/{{flow.namespace}}"
    allowFailure: true

  # KO Failed with: Tried to add java.lang.Integer to java.lang.Integer
  - id: set_concat_int_doesnt_work
    type: io.kestra.plugin.core.kv.Set
    key: "myint"
    kvType: STRING
    value: "{{inputs.int1}}{{inputs.int2}}" 
    allowFailure: true
```