### PR TITLE
feat(system): purge empty service  instances

### DIFF
--- a/cli/src/main/resources/application.yml
+++ b/cli/src/main/resources/application.yml
@@ -202,6 +202,11 @@ kestra:
       initialDelay: 1m
       # The expected time between service heartbeats.
       heartbeatInterval: 3s
+    service:
+      purge:
+        initial-delay: 1h
+        fixed-delay: 1d
+        retention: 30d
   anonymous-usage-report:
     enabled: true
     uri: https://api.kestra.io/v1/reports/usages

--- a/core/src/main/java/io/kestra/core/repositories/ServiceInstanceRepositoryInterface.java
+++ b/core/src/main/java/io/kestra/core/repositories/ServiceInstanceRepositoryInterface.java
@@ -85,7 +85,14 @@ public interface ServiceInstanceRepositoryInterface {
                                                   final Instant to);
 
     /**
-     * Returns the function to be used for mapping column used to sort result.
+     * Purge all instances in the EMPTY state older than the until date.
+     *
+     * @return the number of purged instances
+     */
+    int purgeEmptyInstances(Instant until);
+
+    /**
+     * Returns the function to be used for mapping column used to sort results.
      *
      * @return the mapping function.
      */

--- a/jdbc-h2/src/test/resources/application-test.yml
+++ b/jdbc-h2/src/test/resources/application-test.yml
@@ -16,6 +16,14 @@ flyway:
 
 kestra:
   server-type: STANDALONE
+  server:
+    liveness:
+      enabled: false
+    service:
+      purge:
+        initial-delay: 1h
+        fixed-delay: 1d
+        retention: 30d
   queue:
     type: h2
   repository:

--- a/jdbc-mysql/src/test/resources/application-test.yml
+++ b/jdbc-mysql/src/test/resources/application-test.yml
@@ -17,6 +17,14 @@ flyway:
 
 kestra:
   server-type: STANDALONE
+  server:
+    liveness:
+      enabled: false
+    service:
+      purge:
+        initial-delay: 1h
+        fixed-delay: 1d
+        retention: 30d
   queue:
     type: mysql
   repository:

--- a/jdbc-postgres/src/test/resources/application-test.yml
+++ b/jdbc-postgres/src/test/resources/application-test.yml
@@ -40,3 +40,8 @@ kestra:
   server:
     liveness:
       enabled: false
+    service:
+      purge:
+        initial-delay: 1h
+        fixed-delay: 1d
+        retention: 30d

--- a/jdbc/src/main/java/io/kestra/jdbc/repository/AbstractJdbcServiceInstanceRepository.java
+++ b/jdbc/src/main/java/io/kestra/jdbc/repository/AbstractJdbcServiceInstanceRepository.java
@@ -182,6 +182,16 @@ public abstract class AbstractJdbcServiceInstanceRepository extends AbstractJdbc
             this.jdbcRepository.fetch(query);
     }
 
+    @Override
+    public int purgeEmptyInstances(Instant until) {
+        return jdbcRepository.getDslContextWrapper().transactionResult(
+            configuration -> using(configuration).delete(table())
+                .where(STATE.eq(Service.ServiceState.EMPTY.name()))
+                .and(UPDATED_AT.lessOrEqual(until))
+                .execute()
+        );
+    }
+
     public void transaction(final TransactionalRunnable runnable) {
         this.jdbcRepository
             .getDslContextWrapper()

--- a/jdbc/src/test/java/io/kestra/jdbc/repository/AbstractJdbcServiceInstanceRepositoryTest.java
+++ b/jdbc/src/test/java/io/kestra/jdbc/repository/AbstractJdbcServiceInstanceRepositoryTest.java
@@ -168,6 +168,21 @@ public abstract class AbstractJdbcServiceInstanceRepositoryTest {
         Assertions.assertEquals(new ServiceStateTransition.Response(FAILED, instance), response);
     }
 
+    @Test
+    void shouldPurgeServiceInstance() {
+        // Given
+        ServiceInstance instance = Fixtures.RunningServiceInstance;
+        repository.update(instance);
+        instance = Fixtures.EmptyServiceInstance;
+        repository.update(instance);
+
+        // When
+        int purged = repository.purgeEmptyInstances(Instant.now());
+
+        //Then
+        assertThat(purged).isEqualTo(1);
+    }
+
     public static final class Fixtures {
 
         public static List<ServiceInstance> all() {

--- a/webserver/src/test/resources/application-test.yml
+++ b/webserver/src/test/resources/application-test.yml
@@ -55,6 +55,11 @@ kestra:
         - "/api/v1/executions/webhook/"
     liveness:
       enabled: false
+    service:
+      purge:
+        initial-delay: 1h
+        fixed-delay: 1d
+        retention: 30d
   queue:
     type: h2
   repository:


### PR DESCRIPTION
Purge service instance in EMPTY state after a certain duration, 30 days by default, to avoid never ending groth on the service_instances table.

Fixes #8514