### PR TITLE
fix(system): subflow validation can fail when typing

### DIFF
--- a/core/src/main/java/io/kestra/core/services/FlowService.java
+++ b/core/src/main/java/io/kestra/core/services/FlowService.java
@@ -274,7 +274,7 @@ public class FlowService {
             String regex = ".*\\{\\{.+}}.*"; // regex to check if string contains pebble
             String subflowId = subflow.getFlowId();
             String namespace = subflow.getNamespace();
-            if (subflowId.matches(regex) || namespace.matches(regex)) {
+            if ((subflowId != null && subflowId.matches(regex)) || (namespace != null && namespace.matches(regex))) {
                 return;
             }
             Optional<Flow> optional = findById(tenantId, subflow.getNamespace(), subflow.getFlowId());


### PR DESCRIPTION
The fix avoid NPE when editing a flow YAML due to subflow validation.

```
15:11:05.120 ERROR io-executor-thread-18 io.kestra.core.services.FlowService Unable to validate the flow
java.lang.NullPointerException: Cannot invoke "String.matches(String)" because "subflowId" is null
	at io.kestra.core.services.FlowService.lambda$checkValidSubflows$10(FlowService.java:277)
	at java.base/java.lang.Iterable.forEach(Iterable.java:75)
	at io.kestra.core.services.FlowService.checkValidSubflows(FlowService.java:273)
	at io.kestra.core.services.FlowService.warnings(FlowService.java:233)
	at io.kestra.core.services.FlowService.lambda$validate$2(FlowService.java:123)
	at java.base/java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:197)
	at java.base/java.util.Spliterators$ArraySpliterator.forEachRemaining(Spliterators.java:1024)
	at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:509)
```
