### PR TITLE
fix(editor): check isFlow when displaying NoCode in legacy editor

### DIFF
--- a/ui/src/components/flows/MultiPanelEditorView.vue
+++ b/ui/src/components/flows/MultiPanelEditorView.vue
@@ -21,7 +21,7 @@
 </template>
 
 <script setup lang="ts">
-    import {computed, Ref, watch} from "vue";
+    import {computed, onMounted, Ref, watch} from "vue";
     import {useStorage} from "@vueuse/core";
     import {useStore} from "vuex";
     import {useI18n} from "vue-i18n";
@@ -40,6 +40,10 @@
 
     const store = useStore()
     const flow = computed(() => store.state.flow.flow)
+
+    onMounted(() => {
+        store.state.editor.explorerVisible = false
+    })
 
     /**
      * Focus or activate a tab from it's value

--- a/ui/src/components/inputs/EditorView.vue
+++ b/ui/src/components/inputs/EditorView.vue
@@ -236,7 +236,7 @@
                 </div>
             </template>
             <NoCode
-                v-else
+                v-else-if="isFlow"
                 :flow="flowYaml"
                 :section="route.query.section?.toString()"
                 :task-id="route.query.identifier?.toString()"


### PR DESCRIPTION
closes kestra-io/kestra-ee#3567