### PR TITLE
Corrected timezone in triggers

### DIFF
--- a/ui/src/components/admin/Triggers.vue
+++ b/ui/src/components/admin/Triggers.vue
@@ -150,7 +150,7 @@
                         </el-table-column>
                         <el-table-column :label="$t('cron')">
                             <template #default="scope">
-                                <Cron v-if="scope.row.cron" :cron-expression="scope.row?.cron" />
+                                <Cron v-if="scope.row.cron" :date="scope.row.nextExecutionDate" />
                             </template>
                         </el-table-column>
                         <el-table-column :label="$t('details')">

--- a/ui/src/components/layout/Cron.vue
+++ b/ui/src/components/layout/Cron.vue
@@ -5,20 +5,24 @@
 </template>
 
 <script>
-    import Utils from "../../utils/utils";
-    import cronstrue from "cronstrue";
     import "cronstrue/locales/fr";
 
     export default {
         props: {
-            cronExpression: {
-                type: String,
+            date:{
+                type:String,
                 default: undefined
             }
         },
         computed: {
             humanReadableCron() {
-                return cronstrue.toString(this.cronExpression, {locale: Utils.getLang()});
+                const newDate = new Date(this.date)
+                const timeString = newDate.toLocaleTimeString("en-US", {
+                    hour: "numeric",
+                    minute: "2-digit",
+                    hour12: true
+                });         
+                return timeString;
             }
         }
     }


### PR DESCRIPTION
Closes #8605 
Took the date string from the scope and fetched out localeTimeString. 
![Screenshot From 2025-05-07 00-43-50](https://github.com/user-attachments/assets/4dff2854-dec9-4ce7-962c-a3701e012c97)
