### PR TITLE
fix(core): flaky test RunContextLoggerText.logs()

### DIFF
--- a/core/src/test/java/io/kestra/core/runners/RunContextLoggerTest.java
+++ b/core/src/test/java/io/kestra/core/runners/RunContextLoggerTest.java
@@ -30,7 +30,6 @@ class RunContextLoggerTest {
     @Test
     void logs() {
         List<LogEntry> logs = new CopyOnWriteArrayList<>();
-        List<LogEntry> matchingLog;
         Flux<LogEntry> receive = TestsUtils.receive(logQueue, either -> logs.add(either.getLeft()));
 
         Flow flow = TestsUtils.mockFlow();
@@ -50,7 +49,7 @@ class RunContextLoggerTest {
         logger.warn("warn");
         logger.error("error");
 
-        matchingLog = TestsUtils.awaitLogs(logs, 5);
+        List<LogEntry> matchingLog = TestsUtils.awaitLogs(logs, 5);
         receive.blockLast();
         assertThat(matchingLog.stream().filter(logEntry -> logEntry.getLevel().equals(Level.TRACE)).findFirst().orElseThrow().getMessage()).isEqualTo("trace");
         assertThat(matchingLog.stream().filter(logEntry -> logEntry.getLevel().equals(Level.DEBUG)).findFirst().orElseThrow().getMessage()).isEqualTo("debug");

--- a/tests/src/main/java/io/kestra/core/utils/TestsUtils.java
+++ b/tests/src/main/java/io/kestra/core/utils/TestsUtils.java
@@ -96,7 +96,7 @@ abstract public class TestsUtils {
 
                 int matchingLogsCount = matchingLogs.get().size();
                 return countMatcher.test(matchingLogsCount);
-            }, Duration.ofMillis(10), Duration.ofMillis(500));
+            }, Duration.ofMillis(10), Duration.ofMillis(1000));
         } catch (TimeoutException e) {}
 
         return matchingLogs.get();


### PR DESCRIPTION
Wait a little longuer by default for logs to avoid too much flakyness.
