### PR TITLE
feat(system): use the FlowMetaStore instead of the FlowRepository ins…

### DIFF
--- a/core/src/main/java/io/kestra/core/services/ExecutionService.java
+++ b/core/src/main/java/io/kestra/core/services/ExecutionService.java
@@ -315,7 +315,7 @@ public class ExecutionService {
         return revision != null ? newExecution.withFlowRevision(revision) : newExecution;
     }
 
-    public Execution markAs(final Execution execution, Flow flow, String taskRunId, State.Type newState) throws Exception {
+    public Execution markAs(final Execution execution, FlowInterface flow, String taskRunId, State.Type newState) throws Exception {
         return this.markAs(execution, flow, taskRunId, newState, null);
     }
 


### PR DESCRIPTION
…ide the Executor

This will be on par with EE that uses the KafkaFlowMetaStore.

This has two advantages:
- Performance as it uses the flow "in cache" from the flow listener (with a fallback on the flow repository if needed)
- Plugin default are now always computed which was not the case before
