### PR TITLE
chore(flows): make flow validation a bit less aggressive

### DIFF
--- a/ui/src/components/inputs/EditorWrapper.vue
+++ b/ui/src/components/inputs/EditorWrapper.vue
@@ -103,7 +103,7 @@
                 editorViewType: "YAML", // this is to be opposed to the no-code editor
                 topologyVisible: true,
             });
-        }, 500);
+        }, 2000);
     }
 
 


### PR DESCRIPTION
Flow was being validate with a throttle of `500ms`, which was too aggressive. Now it's increased to `2000ms`.

Closes https://github.com/kestra-io/kestra-ee/issues/3627.