### PR TITLE
fix(system): avoid catching JVM fatal error on Worker

### DIFF
--- a/core/src/main/java/io/kestra/core/runners/AbstractWorkerCallable.java
+++ b/core/src/main/java/io/kestra/core/runners/AbstractWorkerCallable.java
@@ -2,6 +2,7 @@ package io.kestra.core.runners;
 
 import io.kestra.core.models.WorkerJobLifecycle;
 import io.kestra.core.models.flows.State;
+import io.kestra.core.utils.Exceptions;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.StatusCode;
 import lombok.Getter;
@@ -61,6 +62,7 @@ public abstract class AbstractWorkerCallable implements Callable<State.Type> {
         try {
             return doCall();
         } catch (Throwable e) {
+            Exceptions.throwIfFatal(e);
             // Catching Throwable is usually a bad idea.
             // However, here, we want to be sure that the task fails whatever happens,
             // and some plugins may throw errors, for example, for dependency issues or worst,

--- a/core/src/main/java/io/kestra/core/utils/Exceptions.java
+++ b/core/src/main/java/io/kestra/core/utils/Exceptions.java
@@ -22,4 +22,18 @@ public interface Exceptions {
 
         return limitedStackTrace.toString();
     }
+
+    /**
+     * Throws a {@code Throwable} only if it is considered as "fatal" error.
+     *
+     * @param t the exception to evaluate.
+     */
+    static void throwIfFatal(Throwable t) {
+        if (t == null) {
+            return;
+        }
+        if (t instanceof VirtualMachineError error) {
+            throw error;
+        }
+    }
 }


### PR DESCRIPTION
Re-throw VirtualMachineError when an exception is catched from a worker task ensuring, for example, that OOM are correctly propagated.