### PR TITLE
fix: make settings menu proper links

### DIFF
--- a/ui/src/override/components/auth/Auth.vue
+++ b/ui/src/override/components/auth/Auth.vue
@@ -5,63 +5,55 @@
         :show-arrow="false"
         :suffix-icon="ChevronRight"
         :placeholder="$t('kestra')"
-        :popper-class="'user-select border border-0'"
+        popper-class="user-select border border-0"
     >
         <template #prefix>
             <img src="../../../assets/ks-logo-small.svg" width="40" alt="Kestra">
         </template>
         <template #header>
             <el-option :value="{}" class=" list-unstyled">
-                <div class="d-flex align-items-center gap-2">
+                <div class="menu-item">
                     <img src="../../../assets/ks-logo-small.svg" width="40" alt="Kestra">
                     {{ $t("kestra") }}
                 </div>
             </el-option>
         </template>
-        <el-option
-            v-for="item in menuItems"
-            :key="item.label"
-            :label="item.label"
-            :value="item.label"
-            @click="item.action"
-        >
-            <template #default>
-                <div class="d-flex align-items-center gap-2">
-                    <component :is="item.icon" class="fs-4 menu-icon" />
-                    {{ $t(item.label) }}
-                </div>
-            </template>
+        <el-option label="Settings" value="settings">
+            <RouterLink :to="{name: 'settings'}" class="menu-item">
+                <CogOutline class="menu-icon" />
+                {{ $t("settings.label") }}
+            </RouterLink>
+        </el-option>
+        <el-option label="slack" value="slack">
+            <a href="https://kestra.io/slack" target="_blank" class="menu-item">
+                <Slack class="menu-icon" />
+                {{ $t("join_slack") }}
+            </a>
         </el-option>
     </el-select>
 </template>
 
 <script setup>
-    import {computed} from "vue";
-    import {useRouter} from "vue-router";
+    import {RouterLink} from "vue-router";
 
     import CogOutline from "vue-material-design-icons/CogOutline.vue";
     import Slack from "vue-material-design-icons/Slack.vue";
     import ChevronRight from "vue-material-design-icons/ChevronRight.vue";
-
-    const router = useRouter();
-
-    const menuItems = computed(() => [
-        {
-            label: "settings.label",
-            icon: CogOutline,
-            action: () => {
-                router.push({name: "settings"});
-            },
-        },
-        {
-            label: "join_slack",
-            icon: Slack,
-            action: () => {
-                window.open("https://kestra.io/slack", "_blank");
-            },
-        },
-    ]);
 </script>
+
+<style lang="scss" scoped>
+.menu-item{
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+    color: var(--ks-content-primary);
+
+    .menu-icon {
+        color: var(--ks-content-tertiary);
+        font-size: 1.5rem;
+    }
+}
+</style>
 
 <style lang="scss">
 .user-select  {
@@ -80,10 +72,6 @@
             margin: 0;
             font-size: 14px;
             font-weight: 700;
-
-            .menu-icon {
-                color: var(--ks-content-tertiary);
-            }
         }
 
         .el-select-dropdown__header {

--- a/ui/src/override/components/auth/Auth.vue
+++ b/ui/src/override/components/auth/Auth.vue
@@ -78,6 +78,7 @@
             .el-select-dropdown__item {
                 padding: 0;
                 margin: 0;
+                background: none;
 
                 &.is-hovering {
                     background: none;


### PR DESCRIPTION
When clicking on settings one cannot open it in a new window. same for slack.

Links should always be links and we should avoid non-links for linked behavior as the pleague.


NOTE: this PR should not change designs. It has been regression tested both in dark and light mode 