### PR TITLE
fix(executions): avoid to stop following execution too early leading to UI display shifting from actual state

### DIFF
--- a/core/src/test/resources/flows/valids/sleep.yml
+++ b/core/src/test/resources/flows/valids/sleep.yml
@@ -4,4 +4,4 @@ namespace: io.kestra.tests
 tasks:
   - id: sleep
     type: io.kestra.plugin.core.flow.Sleep
-    duration: PT1S
+    duration: PT5S

--- a/webserver/src/main/java/io/kestra/webserver/services/ExecutionStreamingService.java
+++ b/webserver/src/main/java/io/kestra/webserver/services/ExecutionStreamingService.java
@@ -116,7 +116,8 @@ public class ExecutionStreamingService {
      */
     public boolean isStopFollow(Flow flow, Execution execution) {
         return executionService.isTerminated(flow, execution) &&
-            execution.getState().getCurrent() != State.Type.PAUSED;
+            execution.getState().getCurrent() != State.Type.PAUSED &&
+            execution.getTaskRunList().stream().allMatch(taskRun -> taskRun.getState().isTerminated());
     }
 
     @PreDestroy


### PR DESCRIPTION
Looks like a scary change that could lead to deadlock but otherwise since the WorkerJobResult are not synchronously sent before updating execution final state, we end up with some tasks displayed as running indefinitely because the follow was stopped due to the execution shifting to a final state before.

part of kestra-io/kestra-ee#3526

```
id: some-flow
namespace: some.namespace


concurrency:
  behavior: QUEUE # QUEUE, CANCEL or FAIL
  limit: 3 # can be any integer >= 1


tasks:
  - id: forEach
    type: io.kestra.plugin.core.flow.ForEach
    values:
      - 1
      - 2
      - 3
      - 4
    concurrencyLimit: 8
    tasks:
    - id: parallel
      type: io.kestra.plugin.core.flow.Parallel
      tasks:
        - id: sleep
          type: io.kestra.plugin.scripts.python.Script
          taskRunner: 
            type: io.kestra.plugin.ee.kubernetes.runner.Kubernetes
            resume: true
          retry:
            type: constant
            maxAttempt: 3
            interval: PT30S
          namespaceFiles:
            enabled: true
          script: |
            from time import sleep
            print("starting the sleep")
            sleep(30)
            print("finished the sleep")

retry:
  maxAttempt: 3
  behavior: RETRY_FAILED_TASK
  type: constant
  interval: PT5M

sla:
  - id: maxDuration
    type: MAX_DURATION
    duration: PT10S
    behavior: FAIL
    labels:
      sla: miss
      reason: durationExceeded
```