### PR TITLE
chore: modernize Java source using OpenRewrite

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,6 +40,23 @@ plugins {
 
     // OWASP dependency check
     id "org.owasp.dependencycheck" version "12.1.1" apply false
+
+    // source modernizer
+    id "org.openrewrite.rewrite" version "7.6.1"
+}
+
+rewrite {
+    activeRecipe(
+        "io.kestra.java.UpgradeToJava21Custom",
+        "io.kestra.staticanalysis.General",
+        "io.kestra.testing.General",
+        "io.kestra.misc.General"
+    )
+    exclusion(
+        // handling of generics wildcard capture of Map needs to be fixed by OpenRewrite
+        "**/ExecutionControllerTest.java"
+    )
+    setExportDatatables(true)
 }
 
 idea {
@@ -67,6 +84,11 @@ java {
 dependencies {
     implementation project(":cli")
     testImplementation project(":cli")
+
+    rewrite(platform("org.openrewrite.recipe:rewrite-recipe-bom:latest.release"))
+    rewrite("org.openrewrite.recipe:rewrite-migrate-java")
+    rewrite("org.openrewrite.recipe:rewrite-static-analysis")
+    rewrite("org.openrewrite.recipe:rewrite-testing-frameworks")
 }
 
 /**********************************************************************************************************************\

--- a/cli/src/main/java/io/kestra/cli/AbstractApiCommand.java
+++ b/cli/src/main/java/io/kestra/cli/AbstractApiCommand.java
@@ -49,6 +49,7 @@ public abstract class AbstractApiCommand extends AbstractCommand {
     /**
      * {@inheritDoc}
      */
+    @Override
     protected boolean loadExternalPlugins() {
         return false;
     }

--- a/cli/src/main/java/io/kestra/cli/AbstractCommand.java
+++ b/cli/src/main/java/io/kestra/cli/AbstractCommand.java
@@ -40,7 +40,7 @@ import picocli.CommandLine.Option;
 )
 @Slf4j
 @Introspected
-abstract public class AbstractCommand implements Callable<Integer> {
+public abstract class AbstractCommand implements Callable<Integer> {
     @Inject
     private ApplicationContext applicationContext;
 
@@ -71,7 +71,7 @@ abstract public class AbstractCommand implements Callable<Integer> {
     private boolean internalLog = false;
 
     @Option(names = {"-c", "--config"}, description = "Path to a configuration file")
-    private Path config = Paths.get(System.getProperty("user.home"), ".kestra/config.yml");
+    private Path config = Path.of(System.getProperty("user.home"), ".kestra/config.yml");
 
     @Option(names = {"-p", "--plugins"}, description = "Path to plugins directory")
     protected Path pluginsPath = Optional.ofNullable(System.getenv("KESTRA_PLUGINS_PATH")).map(Paths::get).orElse(null);

--- a/cli/src/main/java/io/kestra/cli/VersionProvider.java
+++ b/cli/src/main/java/io/kestra/cli/VersionProvider.java
@@ -10,6 +10,7 @@ import jakarta.inject.Singleton;
 class VersionProvider implements CommandLine.IVersionProvider {
     private static io.kestra.core.utils.VersionProvider versionProvider;
 
+    @Override
     public String[] getVersion() {
         return new String[] { versionProvider.getVersion() };
     }

--- a/cli/src/main/java/io/kestra/cli/commands/plugins/PluginDocCommand.java
+++ b/cli/src/main/java/io/kestra/cli/commands/plugins/PluginDocCommand.java
@@ -14,7 +14,6 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.Base64;
 import java.util.List;
 
@@ -27,7 +26,7 @@ public class PluginDocCommand extends AbstractCommand {
     private ApplicationContext applicationContext;
 
     @CommandLine.Parameters(index = "0", description = "Path to write documentation files")
-    private Path output = Paths.get(System.getProperty("user.dir"), "docs");
+    private Path output = Path.of(System.getProperty("user.dir"), "docs");
 
     @CommandLine.Option(names = {"--core"}, description = "Also write core tasks docs files")
     private boolean core = false;
@@ -52,7 +51,7 @@ public class PluginDocCommand extends AbstractCommand {
                 documentationGenerator
                     .generate(registeredPlugin)
                     .forEach(s -> {
-                            File file = Paths.get(output.toAbsolutePath().toString(), s.getPath()).toFile();
+                            File file = Path.of(output.toAbsolutePath().toString(), s.getPath()).toFile();
 
                             if (!file.getParentFile().exists()) {
                                 //noinspection ResultOfMethodCallIgnored

--- a/cli/src/main/java/io/kestra/cli/commands/servers/AbstractServerCommand.java
+++ b/cli/src/main/java/io/kestra/cli/commands/servers/AbstractServerCommand.java
@@ -5,7 +5,7 @@ import io.kestra.core.contexts.KestraContext;
 import jakarta.annotation.PostConstruct;
 import picocli.CommandLine;
 
-abstract public class AbstractServerCommand extends AbstractCommand implements ServerCommandInterface {
+public abstract class AbstractServerCommand extends AbstractCommand implements ServerCommandInterface {
     @CommandLine.Option(names = {"--port"}, description = "The port to bind")
     Integer serverPort;
 

--- a/cli/src/main/java/io/kestra/cli/commands/servers/LocalCommand.java
+++ b/cli/src/main/java/io/kestra/cli/commands/servers/LocalCommand.java
@@ -7,7 +7,6 @@ import jakarta.inject.Inject;
 import picocli.CommandLine;
 
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.Map;
 
 @CommandLine.Command(
@@ -21,7 +20,7 @@ public class LocalCommand extends StandAloneCommand {
 
     @SuppressWarnings("unused")
     public static Map<String, Object> propertiesOverrides() {
-        Path data = Paths.get("").toAbsolutePath().resolve("data");
+        Path data = Path.of("").toAbsolutePath().resolve("data");
 
         //noinspection ResultOfMethodCallIgnored
         data.toFile().mkdirs();

--- a/cli/src/main/java/io/kestra/cli/services/FileChangedEventListener.java
+++ b/cli/src/main/java/io/kestra/cli/services/FileChangedEventListener.java
@@ -89,14 +89,14 @@ public class FileChangedEventListener {
                 if (current.isDeleted()) {
                     this.flows.stream().filter(flowWithPath -> flowWithPath.uidWithoutRevision().equals(current.uidWithoutRevision())).findFirst()
                         .ifPresent(flowWithPath -> {
-                            deleteFile(Paths.get(flowWithPath.getPath()));
+                            deleteFile(Path.of(flowWithPath.getPath()));
                         });
                     this.flows.removeIf(flowWithPath -> flowWithPath.uidWithoutRevision().equals(current.uidWithoutRevision()));
                 } else {
                     // if updated/created
                     Optional<FlowWithPath> flowWithPath = this.flows.stream().filter(fwp -> fwp.uidWithoutRevision().equals(current.uidWithoutRevision())).findFirst();
                     if (flowWithPath.isPresent()) {
-                        flowToFile(current, Paths.get(flowWithPath.get().getPath()));
+                        flowToFile(current, Path.of(flowWithPath.get().getPath()));
                     } else {
                         flows.add(FlowWithPath.of(current, this.buildPath(current).toString()));
                         flowToFile(current, null);

--- a/cli/src/main/java/io/kestra/cli/services/NoOpStartupHook.java
+++ b/cli/src/main/java/io/kestra/cli/services/NoOpStartupHook.java
@@ -5,7 +5,8 @@ import jakarta.inject.Singleton;
 
 @Singleton
 public class NoOpStartupHook implements StartupHookInterface {
-   public void start(AbstractCommand abstractCommand) {
+    @Override
+    public void start(AbstractCommand abstractCommand) {
 
    }
 }

--- a/cli/src/test/java/io/kestra/cli/commands/flows/FlowExpandCommandTest.java
+++ b/cli/src/test/java/io/kestra/cli/commands/flows/FlowExpandCommandTest.java
@@ -23,7 +23,7 @@ class FlowExpandCommandTest {
             Integer call = PicocliRunner.call(FlowExpandCommand.class, ctx, args);
 
             assertThat(call).isZero();
-            assertThat(out.toString()).isEqualTo("id: include\n" +
+            assertThat(out).hasToString("id: include\n" +
                 "namespace: io.kestra.cli\n" +
                 "\n" +
                 "# The list of tasks\n" +

--- a/cli/src/test/java/io/kestra/cli/commands/flows/FlowExportCommandTest.java
+++ b/cli/src/test/java/io/kestra/cli/commands/flows/FlowExportCommandTest.java
@@ -55,7 +55,7 @@ class FlowExportCommandTest {
             };
             PicocliRunner.call(FlowExportCommand.class, ctx, exportArgs);
             File file = new File("/tmp/flows.zip");
-            assertThat(file.exists()).isTrue();
+            assertThat(file).exists();
             ZipFile zipFile = new ZipFile(file);
 
             // When launching the test in a suite, there is 4 flows but when lauching individualy there is only 3

--- a/cli/src/test/java/io/kestra/cli/commands/namespaces/kv/KvUpdateCommandTest.java
+++ b/cli/src/test/java/io/kestra/cli/commands/namespaces/kv/KvUpdateCommandTest.java
@@ -42,8 +42,8 @@ class KvUpdateCommandTest {
             KVStoreService kvStoreService = ctx.getBean(KVStoreService.class);
             KVStore kvStore = kvStoreService.get(null, "io.kestra.cli", null);
 
-            assertThat(kvStore.getValue("string").get()).isEqualTo(new KVValue("stringValue"));
-            assertThat(((InternalKVStore) kvStore).getRawValue("string").get()).isEqualTo("\"stringValue\"");
+            assertThat(kvStore.getValue("string")).contains(new KVValue("stringValue"));
+            assertThat(((InternalKVStore) kvStore).getRawValue("string")).contains("\"stringValue\"");
         }
     }
 
@@ -70,8 +70,8 @@ class KvUpdateCommandTest {
             KVStoreService kvStoreService = ctx.getBean(KVStoreService.class);
             KVStore kvStore = kvStoreService.get(null, "io.kestra.cli", null);
 
-            assertThat(kvStore.getValue("int").get()).isEqualTo(new KVValue(1));
-            assertThat(((InternalKVStore) kvStore).getRawValue("int").get()).isEqualTo("1");
+            assertThat(kvStore.getValue("int")).contains(new KVValue(1));
+            assertThat(((InternalKVStore) kvStore).getRawValue("int")).contains("1");
         }
     }
 
@@ -100,8 +100,8 @@ class KvUpdateCommandTest {
             KVStoreService kvStoreService = ctx.getBean(KVStoreService.class);
             KVStore kvStore = kvStoreService.get(null, "io.kestra.cli", null);
 
-            assertThat(kvStore.getValue("intStr").get()).isEqualTo(new KVValue("1"));
-            assertThat(((InternalKVStore) kvStore).getRawValue("intStr").get()).isEqualTo("\"1\"");
+            assertThat(kvStore.getValue("intStr")).contains(new KVValue("1"));
+            assertThat(((InternalKVStore) kvStore).getRawValue("intStr")).contains("\"1\"");
         }
     }
 
@@ -128,8 +128,8 @@ class KvUpdateCommandTest {
             KVStoreService kvStoreService = ctx.getBean(KVStoreService.class);
             KVStore kvStore = kvStoreService.get(null, "io.kestra.cli", null);
 
-            assertThat(kvStore.getValue("object").get()).isEqualTo(new KVValue(Map.of("some", "json")));
-            assertThat(((InternalKVStore) kvStore).getRawValue("object").get()).isEqualTo("{some:\"json\"}");
+            assertThat(kvStore.getValue("object")).contains(new KVValue(Map.of("some", "json")));
+            assertThat(((InternalKVStore) kvStore).getRawValue("object")).contains("{some:\"json\"}");
         }
     }
 
@@ -158,8 +158,8 @@ class KvUpdateCommandTest {
             KVStoreService kvStoreService = ctx.getBean(KVStoreService.class);
             KVStore kvStore = kvStoreService.get(null, "io.kestra.cli", null);
 
-            assertThat(kvStore.getValue("objectStr").get()).isEqualTo(new KVValue("{\"some\":\"json\"}"));
-            assertThat(((InternalKVStore) kvStore).getRawValue("objectStr").get()).isEqualTo("\"{\\\"some\\\":\\\"json\\\"}\"");
+            assertThat(kvStore.getValue("objectStr")).contains(new KVValue("{\"some\":\"json\"}"));
+            assertThat(((InternalKVStore) kvStore).getRawValue("objectStr")).contains("\"{\\\"some\\\":\\\"json\\\"}\"");
         }
     }
 
@@ -192,8 +192,8 @@ class KvUpdateCommandTest {
             KVStoreService kvStoreService = ctx.getBean(KVStoreService.class);
             KVStore kvStore = kvStoreService.get(null, "io.kestra.cli", null);
 
-            assertThat(kvStore.getValue("objectFromFile").get()).isEqualTo(new KVValue(Map.of("some", "json", "from", "file")));
-            assertThat(((InternalKVStore) kvStore).getRawValue("objectFromFile").get()).isEqualTo("{some:\"json\",from:\"file\"}");
+            assertThat(kvStore.getValue("objectFromFile")).contains(new KVValue(Map.of("some", "json", "from", "file")));
+            assertThat(((InternalKVStore) kvStore).getRawValue("objectFromFile")).contains("{some:\"json\",from:\"file\"}");
         }
     }
 }

--- a/cli/src/test/java/io/kestra/cli/commands/plugins/PluginDocCommandTest.java
+++ b/cli/src/test/java/io/kestra/cli/commands/plugins/PluginDocCommandTest.java
@@ -43,10 +43,10 @@ class PluginDocCommandTest {
 
             List<Path> files = Files.list(docPath).toList();
 
-            assertThat(files.size()).isEqualTo(1);
-            assertThat(files.getFirst().getFileName().toString()).isEqualTo("plugin-template-test");
+            assertThat(files).hasSize(1);
+            assertThat(files.getFirst().getFileName()).hasToString("plugin-template-test");
             var directory = files.getFirst().toFile();
-            assertThat(directory.isDirectory()).isTrue();
+            assertThat(directory).isDirectory();
             assertThat(directory.listFiles().length).isEqualTo(3);
 
             var readme = directory.toPath().resolve("index.md");

--- a/cli/src/test/java/io/kestra/cli/commands/plugins/PluginInstallCommandTest.java
+++ b/cli/src/test/java/io/kestra/cli/commands/plugins/PluginInstallCommandTest.java
@@ -25,8 +25,8 @@ class PluginInstallCommandTest {
 
             List<Path> files = Files.list(pluginsPath).toList();
 
-            assertThat(files.size()).isEqualTo(1);
-            assertThat(files.getFirst().getFileName().toString()).isEqualTo("io_kestra_plugin__plugin-notifications__0_6_0.jar");
+            assertThat(files).hasSize(1);
+            assertThat(files.getFirst().getFileName()).hasToString("io_kestra_plugin__plugin-notifications__0_6_0.jar");
         }
     }
 
@@ -41,7 +41,7 @@ class PluginInstallCommandTest {
 
             List<Path> files = Files.list(pluginsPath).toList();
 
-            assertThat(files.size()).isEqualTo(1);
+            assertThat(files).hasSize(1);
             assertThat(files.getFirst().getFileName().toString()).startsWith("io_kestra_plugin__plugin-notifications__");
             assertThat(files.getFirst().getFileName().toString()).doesNotContain("LATEST");
         }
@@ -59,8 +59,8 @@ class PluginInstallCommandTest {
 
             List<Path> files = Files.list(pluginsPath).toList();
 
-            assertThat(files.size()).isEqualTo(1);
-            assertThat(files.getFirst().getFileName().toString()).isEqualTo("io_kestra_storage__storage-s3__0_12_1.jar");
+            assertThat(files).hasSize(1);
+            assertThat(files.getFirst().getFileName()).hasToString("io_kestra_storage__storage-s3__0_12_1.jar");
         }
     }
 }

--- a/cli/src/test/java/io/kestra/cli/commands/sys/statestore/StateStoreMigrateCommandTest.java
+++ b/cli/src/test/java/io/kestra/cli/commands/sys/statestore/StateStoreMigrateCommandTest.java
@@ -24,6 +24,7 @@ import java.io.PrintStream;
 import java.net.URI;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ThreadLocalRandom;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -39,7 +40,7 @@ class StateStoreMigrateCommandTest {
             Flow flow = Flow.builder()
                 .tenantId("my-tenant")
                 .id("a-flow")
-                .namespace("some.valid.namespace." + ((int) (Math.random() * 1000000)))
+                .namespace("some.valid.namespace." + ((int) (ThreadLocalRandom.current().nextDouble() * 1000000)))
                 .tasks(List.of(Log.builder().id("log").type(Log.class.getName()).message("logging").build()))
                 .build();
             flowRepository.create(GenericFlow.of(flow));

--- a/cli/src/test/java/io/kestra/cli/commands/templates/TemplateExportCommandTest.java
+++ b/cli/src/test/java/io/kestra/cli/commands/templates/TemplateExportCommandTest.java
@@ -54,7 +54,7 @@ class TemplateExportCommandTest {
             };
             PicocliRunner.call(TemplateExportCommand.class, ctx, exportArgs);
             File file = new File("/tmp/templates.zip");
-            assertThat(file.exists()).isTrue();
+            assertThat(file).exists();
             ZipFile zipFile = new ZipFile(file);
             assertThat(zipFile.stream().count()).isEqualTo(3L);
 

--- a/core/src/main/java/io/kestra/core/app/AppBlockInterface.java
+++ b/core/src/main/java/io/kestra/core/app/AppBlockInterface.java
@@ -17,7 +17,8 @@ public interface AppBlockInterface extends io.kestra.core.models.Plugin {
         title = "The type of the block."
     )
     @NotNull
+    @Override
     @NotBlank
-    @Pattern(regexp="\\p{javaJavaIdentifierStart}\\p{javaJavaIdentifierPart}*(\\.\\p{javaJavaIdentifierStart}\\p{javaJavaIdentifierPart}*)*")
+    @Pattern(regexp = "\\p{javaJavaIdentifierStart}\\p{javaJavaIdentifierPart}*(\\.\\p{javaJavaIdentifierStart}\\p{javaJavaIdentifierPart}*)*")
     String getType();
 }

--- a/core/src/main/java/io/kestra/core/app/AppPluginInterface.java
+++ b/core/src/main/java/io/kestra/core/app/AppPluginInterface.java
@@ -17,7 +17,8 @@ public interface AppPluginInterface extends io.kestra.core.models.Plugin {
         title = "The type of the app."
     )
     @NotNull
+    @Override
     @NotBlank
-    @Pattern(regexp="\\p{javaJavaIdentifierStart}\\p{javaJavaIdentifierPart}*(\\.\\p{javaJavaIdentifierStart}\\p{javaJavaIdentifierPart}*)*")
+    @Pattern(regexp = "\\p{javaJavaIdentifierStart}\\p{javaJavaIdentifierPart}*(\\.\\p{javaJavaIdentifierStart}\\p{javaJavaIdentifierPart}*)*")
     String getType();
 }

--- a/core/src/main/java/io/kestra/core/contexts/KestraBeansFactory.java
+++ b/core/src/main/java/io/kestra/core/contexts/KestraBeansFactory.java
@@ -55,9 +55,7 @@ public class KestraBeansFactory {
     }
 
     public String getStoragePluginId(StorageInterfaceFactory storageInterfaceFactory) {
-        return storageType.orElseThrow(() -> new KestraRuntimeException(String.format(
-            "No storage configured through the application property '%s'. Supported types are: %s"
-            , KESTRA_STORAGE_TYPE_CONFIG,
+        return storageType.orElseThrow(() -> new KestraRuntimeException("No storage configured through the application property '%s'. Supported types are: %s".formatted(KESTRA_STORAGE_TYPE_CONFIG,
             storageInterfaceFactory.getLoggableStorageIds()
         )));
     }

--- a/core/src/main/java/io/kestra/core/exceptions/InvalidException.java
+++ b/core/src/main/java/io/kestra/core/exceptions/InvalidException.java
@@ -1,12 +1,15 @@
 package io.kestra.core.exceptions;
 
+import java.io.Serial;
+
 /**
  * General exception that can be throws when a Kestra resource or entity is not valid.
  */
 public class InvalidException extends KestraRuntimeException {
+    @Serial
     private static final long serialVersionUID = 1L;
 
-    private transient final Object invalid;
+    private final transient Object invalid;
 
     /**
      * Creates a new {@link InvalidException} instance.

--- a/core/src/main/java/io/kestra/core/exceptions/ResourceExpiredException.java
+++ b/core/src/main/java/io/kestra/core/exceptions/ResourceExpiredException.java
@@ -1,6 +1,9 @@
 package io.kestra.core.exceptions;
 
+import java.io.Serial;
+
 public class ResourceExpiredException extends Exception {
+    @Serial
     private static final long serialVersionUID = 1L;
 
     public ResourceExpiredException(Throwable e) {

--- a/core/src/main/java/io/kestra/core/models/collectors/HostUsage.java
+++ b/core/src/main/java/io/kestra/core/models/collectors/HostUsage.java
@@ -86,7 +86,7 @@ public class HostUsage {
         )
             .filter(Objects::nonNull)
             .filter(s -> !s.equals("unknown"))
-            .map(s -> String.format("%08x", s.hashCode()))
+            .map(s -> "%08x".formatted(s.hashCode()))
             .collect(Collectors.joining("-"));
 
         return HostUsage.builder()

--- a/core/src/main/java/io/kestra/core/models/dashboards/filters/AbstractFilter.java
+++ b/core/src/main/java/io/kestra/core/models/dashboards/filters/AbstractFilter.java
@@ -35,8 +35,9 @@ public abstract class AbstractFilter<F extends Enum<F>> {
     private F field;
     private String labelKey;
 
-    abstract public FilterType getType();
+    public abstract FilterType getType();
 
+    @Override
     public boolean equals(Object o) {
         if (o == this) {
             return true;

--- a/core/src/main/java/io/kestra/core/models/executions/AbstractMetricEntry.java
+++ b/core/src/main/java/io/kestra/core/models/executions/AbstractMetricEntry.java
@@ -31,8 +31,8 @@ import jakarta.validation.constraints.NotNull;
 @Getter
 @NoArgsConstructor
 @Introspected
-abstract public class AbstractMetricEntry<T> {
-    abstract public String getType();
+public abstract class AbstractMetricEntry<T> {
+    public abstract String getType();
 
     @NotNull
     protected String name;
@@ -81,9 +81,9 @@ abstract public class AbstractMetricEntry<T> {
         return prefix == null ? this.name : prefix + "." + this.name;
     }
 
-    abstract public T getValue();
+    public abstract T getValue();
 
-    abstract public void register(MetricRegistry meterRegistry, String name, @Nullable String description, Map<String, String> tags);
+    public abstract void register(MetricRegistry meterRegistry, String name, @Nullable String description, Map<String, String> tags);
 
-    abstract public void increment(T value);
+    public abstract void increment(T value);
 }

--- a/core/src/main/java/io/kestra/core/models/executions/ExecutionKilled.java
+++ b/core/src/main/java/io/kestra/core/models/executions/ExecutionKilled.java
@@ -36,8 +36,8 @@ import lombok.experimental.SuperBuilder;
     @JsonSubTypes.Type(value = ExecutionKilledExecution.class, name = "execution"),
     @JsonSubTypes.Type(value = ExecutionKilledTrigger.class, name = "trigger"),
 })
-abstract public class ExecutionKilled implements TenantInterface, HasUID {
-    abstract public String getType();
+public abstract class ExecutionKilled implements TenantInterface, HasUID {
+    public abstract String getType();
 
     public enum State {
         REQUESTED,

--- a/core/src/main/java/io/kestra/core/models/executions/Variables.java
+++ b/core/src/main/java/io/kestra/core/models/executions/Variables.java
@@ -209,6 +209,7 @@ public sealed interface Variables extends Map<String, Object> {
     }
 
     class Serializer extends StdSerializer<Variables> {
+        private static final long serialVersionUID = 1L;
         protected Serializer() {
             super(Variables.class);
         }
@@ -238,6 +239,7 @@ public sealed interface Variables extends Map<String, Object> {
     }
 
     class Deserializer extends StdDeserializer<Variables> {
+        private static final long serialVersionUID = 1L;
         public Deserializer() {
             super(Variables.class);
         }

--- a/core/src/main/java/io/kestra/core/models/executions/statistics/DailyExecutionStatistics.java
+++ b/core/src/main/java/io/kestra/core/models/executions/statistics/DailyExecutionStatistics.java
@@ -42,7 +42,7 @@ public class DailyExecutionStatistics {
 
     @Value
     @Builder
-    static public class Duration {
+    public static class Duration {
         @NotNull
         java.time.Duration min;
 

--- a/core/src/main/java/io/kestra/core/models/flows/FlowInterface.java
+++ b/core/src/main/java/io/kestra/core/models/flows/FlowInterface.java
@@ -32,6 +32,7 @@ public interface FlowInterface extends FlowId, DeletedInterface, TenantInterface
 
     boolean isDisabled();
 
+    @Override
     boolean isDeleted();
 
     List<Label> getLabels();
@@ -174,7 +175,7 @@ public interface FlowInterface extends FlowId, DeletedInterface, TenantInterface
                         Map.Entry::getKey,
                         Map.Entry::getValue,
                         (u, v) -> {
-                            throw new IllegalStateException(String.format("Duplicate key %s", u));
+                            throw new IllegalStateException("Duplicate key %s".formatted(u));
                         },
                         LinkedHashMap::new
                     ));

--- a/core/src/main/java/io/kestra/core/models/flows/State.java
+++ b/core/src/main/java/io/kestra/core/models/flows/State.java
@@ -115,7 +115,7 @@ public class State {
     }
 
     public Instant maxDate() {
-        if (this.histories.size() == 0) {
+        if (this.histories.isEmpty()) {
             return Instant.now();
         }
 
@@ -123,7 +123,7 @@ public class State {
     }
 
     public Instant minDate() {
-        if (this.histories.size() == 0) {
+        if (this.histories.isEmpty()) {
             return Instant.now();
         }
 

--- a/core/src/main/java/io/kestra/core/models/tasks/Task.java
+++ b/core/src/main/java/io/kestra/core/models/tasks/Task.java
@@ -26,7 +26,7 @@ import static io.kestra.core.utils.Rethrow.throwFunction;
 @NoArgsConstructor
 @JsonInclude(JsonInclude.Include.NON_DEFAULT)
 @Plugin
-abstract public class Task implements TaskInterface {
+public abstract class Task implements TaskInterface {
     protected String id;
 
     protected String type;
@@ -69,8 +69,7 @@ abstract public class Task implements TaskInterface {
             Optional<Task> childs = ((FlowableTask<?>) this).allChildTasks()
                 .stream()
                 .map(t -> t.findById(id))
-                .filter(Optional::isPresent)
-                .map(Optional::get)
+                .flatMap(Optional::stream)
                 .findFirst();
 
             if (childs.isPresent()) {
@@ -90,8 +89,7 @@ abstract public class Task implements TaskInterface {
             Optional<Task> childs = ((FlowableTask<?>) this).childTasks(runContext, taskRun)
                 .stream()
                 .map(throwFunction(resolvedTask -> resolvedTask.getTask().findById(id, runContext, taskRun)))
-                .filter(Optional::isPresent)
-                .map(Optional::get)
+                .flatMap(Optional::stream)
                 .findFirst();
 
             if (childs.isPresent()) {
@@ -103,8 +101,7 @@ abstract public class Task implements TaskInterface {
             Optional<Task> errorChilds = ((FlowableTask<?>) this).getErrors()
                 .stream()
                 .map(throwFunction(task -> task.findById(id, runContext, taskRun)))
-                .filter(Optional::isPresent)
-                .map(Optional::get)
+                .flatMap(Optional::stream)
                 .findFirst();
 
             if (errorChilds.isPresent()) {

--- a/core/src/main/java/io/kestra/core/models/tasks/TaskInterface.java
+++ b/core/src/main/java/io/kestra/core/models/tasks/TaskInterface.java
@@ -16,8 +16,9 @@ public interface TaskInterface extends Plugin, PluginVersioning {
     String getId();
 
     @NotNull
+    @Override
     @NotBlank
-    @Pattern(regexp="\\p{javaJavaIdentifierStart}\\p{javaJavaIdentifierPart}*(\\.\\p{javaJavaIdentifierStart}\\p{javaJavaIdentifierPart}*)*")
+    @Pattern(regexp = "\\p{javaJavaIdentifierStart}\\p{javaJavaIdentifierPart}*(\\.\\p{javaJavaIdentifierStart}\\p{javaJavaIdentifierPart}*)*")
     @Schema(title = "The class name of this task.")
     String getType();
 }

--- a/core/src/main/java/io/kestra/core/models/tasks/metrics/AbstractMetric.java
+++ b/core/src/main/java/io/kestra/core/models/tasks/metrics/AbstractMetric.java
@@ -30,7 +30,7 @@ import java.util.Map;
 @AllArgsConstructor
 @SuperBuilder
 public abstract class AbstractMetric {
-    abstract public String getType();
+    public abstract String getType();
 
     @NotNull
     protected Property<String> name;

--- a/core/src/main/java/io/kestra/core/models/tasks/metrics/CounterMetric.java
+++ b/core/src/main/java/io/kestra/core/models/tasks/metrics/CounterMetric.java
@@ -38,6 +38,7 @@ public class CounterMetric extends AbstractMetric {
         return Counter.of(name, description, value, tagsAsStrings);
     }
 
+    @Override
     public String getType() {
         return TYPE;
     }

--- a/core/src/main/java/io/kestra/core/models/tasks/metrics/TimerMetric.java
+++ b/core/src/main/java/io/kestra/core/models/tasks/metrics/TimerMetric.java
@@ -39,6 +39,7 @@ public class TimerMetric extends AbstractMetric {
         return Timer.of(name, description, value, tagsAsStrings);
     }
 
+    @Override
     public String getType() {
         return TYPE;
     }

--- a/core/src/main/java/io/kestra/core/models/tasks/retrys/AbstractRetry.java
+++ b/core/src/main/java/io/kestra/core/models/tasks/retrys/AbstractRetry.java
@@ -25,7 +25,7 @@ import java.time.Instant;
 @SuperBuilder
 @Introspected
 public abstract class AbstractRetry {
-    abstract public String getType();
+    public abstract String getType();
 
     private Duration maxDuration;
 

--- a/core/src/main/java/io/kestra/core/models/tasks/runners/DefaultLogConsumer.java
+++ b/core/src/main/java/io/kestra/core/models/tasks/runners/DefaultLogConsumer.java
@@ -19,6 +19,7 @@ public class DefaultLogConsumer extends AbstractLogConsumer {
         this.accept(line, isStdErr, null);
     }
 
+    @Override
     public void accept(String line, Boolean isStdErr, Instant instant) {
         outputs.putAll(PluginUtilsService.parseOut(line, runContext.logger(), runContext, isStdErr, instant));
 

--- a/core/src/main/java/io/kestra/core/models/tasks/runners/PluginUtilsService.java
+++ b/core/src/main/java/io/kestra/core/models/tasks/runners/PluginUtilsService.java
@@ -24,7 +24,6 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -35,7 +34,7 @@ import java.util.Optional;
 
 import static io.kestra.core.utils.Rethrow.throwConsumer;
 
-abstract public class PluginUtilsService {
+public abstract class PluginUtilsService {
 
     private static final TypeReference<Map<String, String>> MAP_TYPE_REFERENCE = new TypeReference<>() {};
 
@@ -99,8 +98,8 @@ abstract public class PluginUtilsService {
 
     @SuppressWarnings("unchecked")
     public static Map<String, String> transformInputFiles(RunContext runContext, Map<String, Object> additionalVars, @NotNull Object inputFiles) throws IllegalVariableEvaluationException, JsonProcessingException {
-        if (inputFiles instanceof Map) {
-            Map<String, String> castedInputFiles = (Map<String, String>) ((Map<?, ?>) inputFiles);
+        if (inputFiles instanceof Map<?, ?> map) {
+            Map<String, String> castedInputFiles = (Map<String, String>) (map);
             Map<String, String> nullFilteredInputFiles = new HashMap<>();
             castedInputFiles.forEach((key, val) -> {
                 if (val != null) {
@@ -137,7 +136,7 @@ abstract public class PluginUtilsService {
 
                 // path with "/", create the subfolders
                 if (file.getParent() != null) {
-                    Path subFolder = Paths.get(
+                    Path subFolder = Path.of(
                         workingDirectory.toAbsolutePath().toString(),
                         new File(finalFileName).getParent()
                     );

--- a/core/src/main/java/io/kestra/core/models/triggers/AbstractTrigger.java
+++ b/core/src/main/java/io/kestra/core/models/triggers/AbstractTrigger.java
@@ -29,7 +29,7 @@ import java.util.Map;
 @Getter
 @NoArgsConstructor
 @JsonInclude(JsonInclude.Include.NON_DEFAULT)
-abstract public class AbstractTrigger implements TriggerInterface {
+public abstract class AbstractTrigger implements TriggerInterface {
     protected String id;
 
     protected String type;

--- a/core/src/main/java/io/kestra/core/models/triggers/TriggerInterface.java
+++ b/core/src/main/java/io/kestra/core/models/triggers/TriggerInterface.java
@@ -16,8 +16,9 @@ public interface TriggerInterface extends Plugin, PluginVersioning {
     String getId();
 
     @NotNull
+    @Override
     @NotBlank
-    @Pattern(regexp="\\p{javaJavaIdentifierStart}\\p{javaJavaIdentifierPart}*(\\.\\p{javaJavaIdentifierStart}\\p{javaJavaIdentifierPart}*)*")
+    @Pattern(regexp = "\\p{javaJavaIdentifierStart}\\p{javaJavaIdentifierPart}*(\\.\\p{javaJavaIdentifierStart}\\p{javaJavaIdentifierPart}*)*")
     @Schema(title = "The class name for this current trigger.")
     String getType();
 

--- a/core/src/main/java/io/kestra/core/models/validations/ManualConstraintViolation.java
+++ b/core/src/main/java/io/kestra/core/models/validations/ManualConstraintViolation.java
@@ -68,14 +68,17 @@ public class ManualConstraintViolation<T> implements ConstraintViolation<T> {
         )));
     }
 
+    @Override
     public String getMessageTemplate() {
         return "{messageTemplate}";
     }
 
+    @Override
     public Object[] getExecutableParameters() {
         return new Object[0];
     }
 
+    @Override
     public Object getExecutableReturnValue() {
         return null;
     }

--- a/core/src/main/java/io/kestra/core/models/validations/ModelValidator.java
+++ b/core/src/main/java/io/kestra/core/models/validations/ModelValidator.java
@@ -24,7 +24,7 @@ public class ModelValidator {
     public <T> Optional<ConstraintViolationException> isValid(T model) {
         Set<ConstraintViolation<T>> violations = validator.validate(model);
 
-        if (violations.size() > 0) {
+        if (!violations.isEmpty()) {
             return Optional.of(new KestraConstraintViolationException(violations));
         }
 

--- a/core/src/main/java/io/kestra/core/repositories/ExecutionRepositoryInterface.java
+++ b/core/src/main/java/io/kestra/core/repositories/ExecutionRepositoryInterface.java
@@ -170,6 +170,7 @@ public interface ExecutionRepositoryInterface extends SaveRepositoryInterface<Ex
         @Nullable ZonedDateTime endDate,
         @Nullable List<String> namespaces);
 
+    @Override
     Execution save(Execution execution);
 
     Execution update(Execution execution);

--- a/core/src/main/java/io/kestra/core/repositories/LocalFlowRepositoryLoader.java
+++ b/core/src/main/java/io/kestra/core/repositories/LocalFlowRepositoryLoader.java
@@ -25,7 +25,6 @@ import java.nio.file.FileSystem;
 import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.Collections;
 import java.util.Map;
 import java.util.function.Function;
@@ -73,7 +72,7 @@ public class LocalFlowRepositoryLoader {
                 this.load(tenantId, tempDirectory.toFile());
             }
         } else {
-            this.load(tenantId, Paths.get(uri).toFile());
+            this.load(tenantId, Path.of(uri).toFile());
         }
     }
 

--- a/core/src/main/java/io/kestra/core/repositories/LogRepositoryInterface.java
+++ b/core/src/main/java/io/kestra/core/repositories/LogRepositoryInterface.java
@@ -101,6 +101,7 @@ public interface LogRepositoryInterface extends SaveRepositoryInterface<LogEntry
         @Nullable DateUtils.GroupType groupBy
     );
 
+    @Override
     LogEntry save(LogEntry log);
 
     Integer purge(Execution execution);

--- a/core/src/main/java/io/kestra/core/runners/ExecutorService.java
+++ b/core/src/main/java/io/kestra/core/runners/ExecutorService.java
@@ -691,8 +691,7 @@ public class ExecutorService {
                 Optional.of(State.Type.KILLED),
                 t
             ))
-            .filter(Optional::isPresent)
-            .map(Optional::get)
+            .flatMap(Optional::stream)
             .toList();
 
         this.addWorkerTaskResults(executor, executor.getFlow(), workerTaskResults);

--- a/core/src/main/java/io/kestra/core/runners/FlowInputOutput.java
+++ b/core/src/main/java/io/kestra/core/runners/FlowInputOutput.java
@@ -378,8 +378,7 @@ public class FlowInputOutput {
                     throw output.toConstraintViolationException(e.getMessage(), current);
                 }
             })
-            .filter(Optional::isPresent)
-            .map(Optional::get)
+            .flatMap(Optional::stream)
             .collect(HashMap::new, (map, entry) -> map.put(entry.getKey(), entry.getValue()), Map::putAll);
 
         // Ensure outputs are compliant with tasks outputs.

--- a/core/src/main/java/io/kestra/core/runners/FlowableUtils.java
+++ b/core/src/main/java/io/kestra/core/runners/FlowableUtils.java
@@ -420,8 +420,8 @@ public class FlowableUtils {
         return Collections.emptyList();
     }
 
-    private final static TypeReference<List<Object>> TYPE_REFERENCE = new TypeReference<>() {};
-    private final static ObjectMapper MAPPER = JacksonMapper.ofJson();
+    private static final TypeReference<List<Object>> TYPE_REFERENCE = new TypeReference<>() {};
+    private static final ObjectMapper MAPPER = JacksonMapper.ofJson();
 
     @SuppressWarnings({"unchecked", "rawtypes"})
     public static List<ResolvedTask> resolveEachTasks(RunContext runContext, TaskRun parentTaskRun, List<Task> tasks, Object value) throws IllegalVariableEvaluationException {

--- a/core/src/main/java/io/kestra/core/runners/WorkerJob.java
+++ b/core/src/main/java/io/kestra/core/runners/WorkerJob.java
@@ -10,6 +10,6 @@ import io.kestra.core.models.HasUID;
     @JsonSubTypes.Type(value = WorkerTrigger.class, name = "trigger")
 })
 public abstract class WorkerJob implements HasUID {
-    abstract public String getType();
+    public abstract String getType();
 
 }

--- a/core/src/main/java/io/kestra/core/runners/WorkerJobRunning.java
+++ b/core/src/main/java/io/kestra/core/runners/WorkerJobRunning.java
@@ -24,6 +24,6 @@ public abstract class WorkerJobRunning implements HasUID {
     @NotNull
     private int partition;
 
-    abstract public String getType();
+    public abstract String getType();
 
 }

--- a/core/src/main/java/io/kestra/core/runners/pebble/AbstractIndent.java
+++ b/core/src/main/java/io/kestra/core/runners/pebble/AbstractIndent.java
@@ -48,12 +48,12 @@ public abstract class AbstractIndent {
         }
 
         if (!args.containsKey("amount")) {
-            throw new PebbleException(null, String.format("The '%s' filter expects an integer as argument 'amount'.", indentType), lineNumber, self.getName());
+            throw new PebbleException(null, "The '%s' filter expects an integer as argument 'amount'.".formatted(indentType), lineNumber, self.getName());
         }
 
         int amount = ((Long) args.get("amount")).intValue();
         if (!(amount >= 0)) {
-            throw new PebbleException(null, String.format("The '%s' filter expects a positive integer >=0 as argument 'amount'.", indentType), lineNumber, self.getName());
+            throw new PebbleException(null, "The '%s' filter expects a positive integer >=0 as argument 'amount'.".formatted(indentType), lineNumber, self.getName());
         }
 
         String prefix = prefix(args);
@@ -66,7 +66,7 @@ public abstract class AbstractIndent {
             // nindent filter adds a newline to the string and indents each line by defined amount of spaces
             return (newLine + input).replace(newLine, newLine + prefix.repeat(amount));
         }
-        throw new PebbleException(null, String.format("Unknow indent type '%s'.", indentType), lineNumber, self.getName());
+        throw new PebbleException(null, "Unknow indent type '%s'.".formatted(indentType), lineNumber, self.getName());
 
     }
 }

--- a/core/src/main/java/io/kestra/core/runners/pebble/expression/NullCoalescingExpression.java
+++ b/core/src/main/java/io/kestra/core/runners/pebble/expression/NullCoalescingExpression.java
@@ -30,7 +30,7 @@ public class NullCoalescingExpression extends BinaryExpression<Object> {
 
     @Override
     public String toString() {
-        return String.format("%s ?? %s", getLeftExpression(), getRightExpression());
+        return "%s ?? %s".formatted(getLeftExpression(), getRightExpression());
     }
 
 }

--- a/core/src/main/java/io/kestra/core/runners/pebble/expression/UndefinedCoalescingExpression.java
+++ b/core/src/main/java/io/kestra/core/runners/pebble/expression/UndefinedCoalescingExpression.java
@@ -25,7 +25,7 @@ public class UndefinedCoalescingExpression extends BinaryExpression<Object> {
 
     @Override
     public String toString() {
-        return String.format("%s ?? %s", getLeftExpression(), getRightExpression());
+        return "%s ?? %s".formatted(getLeftExpression(), getRightExpression());
     }
 
 }

--- a/core/src/main/java/io/kestra/core/runners/pebble/filters/DistinctFilter.java
+++ b/core/src/main/java/io/kestra/core/runners/pebble/filters/DistinctFilter.java
@@ -19,14 +19,13 @@ public class DistinctFilter implements Filter {
     @Override
     public Object apply(Object input, Map<String, Object> args, PebbleTemplate self, EvaluationContext context,
                         int lineNumber) throws PebbleException {
-								
+
 		if (input == null) {
             return "null";
-        }						
-							
+        }
+
         // Check if the input is a list
-        if (input instanceof List<?>) {
-            List<?> list = (List<?>) input;
+        if (input instanceof List<?> list) {
 
             // Deduplicate the list by using distinct stream operation
             return list.stream().distinct().collect(Collectors.toList());

--- a/core/src/main/java/io/kestra/core/runners/pebble/filters/EndsWithFilter.java
+++ b/core/src/main/java/io/kestra/core/runners/pebble/filters/EndsWithFilter.java
@@ -14,7 +14,7 @@ public class EndsWithFilter implements Filter {
 
     private static final String ARGUMENT_VALUE = "value";
 
-    private final static List<String> ARGS = List.of(ARGUMENT_VALUE);
+    private static final List<String> ARGS = List.of(ARGUMENT_VALUE);
 
     @Override
     public List<String> getArgumentNames() {

--- a/core/src/main/java/io/kestra/core/runners/pebble/filters/ReplaceFilter.java
+++ b/core/src/main/java/io/kestra/core/runners/pebble/filters/ReplaceFilter.java
@@ -18,7 +18,7 @@ public class ReplaceFilter implements Filter {
     private static final String ARGUMENT_PAIRS = "replace_pairs";
     private static final String ARGUMENT_REGEXP = "regexp";
 
-    private final static List<String> ARGS = List.of(ARGUMENT_PAIRS, ARGUMENT_REGEXP);
+    private static final List<String> ARGS = List.of(ARGUMENT_PAIRS, ARGUMENT_REGEXP);
 
     @Override
     public List<String> getArgumentNames() {

--- a/core/src/main/java/io/kestra/core/runners/pebble/filters/StartsWithFilter.java
+++ b/core/src/main/java/io/kestra/core/runners/pebble/filters/StartsWithFilter.java
@@ -14,7 +14,7 @@ public class StartsWithFilter implements Filter {
 
     private static final String ARGUMENT_VALUE = "value";
 
-    private final static List<String> ARGS = List.of(ARGUMENT_VALUE);
+    private static final List<String> ARGS = List.of(ARGUMENT_VALUE);
 
     @Override
     public List<String> getArgumentNames() {

--- a/core/src/main/java/io/kestra/core/runners/pebble/functions/FetchContextFunction.java
+++ b/core/src/main/java/io/kestra/core/runners/pebble/functions/FetchContextFunction.java
@@ -12,6 +12,7 @@ import java.util.Map;
 
 @Singleton
 public class FetchContextFunction implements Function {
+    @Override
     public List<String> getArgumentNames() {
         return List.of();
     }

--- a/core/src/main/java/io/kestra/core/runners/pebble/functions/FromIonFunction.java
+++ b/core/src/main/java/io/kestra/core/runners/pebble/functions/FromIonFunction.java
@@ -15,7 +15,8 @@ import java.util.Map;
 import java.util.stream.Stream;
 
 public class FromIonFunction implements Function {
-        public List<String> getArgumentNames() {
+    @Override
+    public List<String> getArgumentNames() {
             return List.of("ion", "allRows");
         }
 

--- a/core/src/main/java/io/kestra/core/runners/pebble/functions/FromJsonFunction.java
+++ b/core/src/main/java/io/kestra/core/runners/pebble/functions/FromJsonFunction.java
@@ -14,6 +14,7 @@ import java.util.Map;
 public class FromJsonFunction implements Function {
     private static final ObjectMapper MAPPER = JacksonMapper.ofJson();
 
+    @Override
     public List<String> getArgumentNames() {
         return List.of("json");
     }

--- a/core/src/main/java/io/kestra/core/runners/pebble/functions/RandomIntFunction.java
+++ b/core/src/main/java/io/kestra/core/runners/pebble/functions/RandomIntFunction.java
@@ -7,6 +7,7 @@ import io.pebbletemplates.pebble.template.PebbleTemplate;
 
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ThreadLocalRandom;
 
 public class RandomIntFunction implements Function {
 
@@ -22,7 +23,7 @@ public class RandomIntFunction implements Function {
             lineNumber,
             self.getName());
     }
-    return (int) (Math.floor(Math.random() * (upper - lower)) + lower);
+    return (int) (Math.floor(ThreadLocalRandom.current().nextDouble() * (upper - lower)) + lower);
   }
 
   @Override

--- a/core/src/main/java/io/kestra/core/runners/pebble/functions/RenderFunction.java
+++ b/core/src/main/java/io/kestra/core/runners/pebble/functions/RenderFunction.java
@@ -23,6 +23,7 @@ public class RenderFunction implements Function {
     @Inject
     private ApplicationContext applicationContext;
 
+    @Override
     public List<String> getArgumentNames() {
         return List.of("toRender", "recursive");
     }

--- a/core/src/main/java/io/kestra/core/runners/pebble/functions/RenderOnceFunction.java
+++ b/core/src/main/java/io/kestra/core/runners/pebble/functions/RenderOnceFunction.java
@@ -13,6 +13,7 @@ import java.util.Map;
 @Singleton
 @Requires(property = "kestra.variables.recursive-rendering", value = StringUtils.FALSE, defaultValue = StringUtils.FALSE)
 public class RenderOnceFunction extends RenderFunction {
+    @Override
     public List<String> getArgumentNames() {
         return List.of("toRender");
     }

--- a/core/src/main/java/io/kestra/core/runners/pebble/functions/SecretFunction.java
+++ b/core/src/main/java/io/kestra/core/runners/pebble/functions/SecretFunction.java
@@ -72,8 +72,7 @@ public class SecretFunction implements Function {
                         secret = jsonNode.isValueNode() ? jsonNode.asText() : jsonNode.toString();
                     }
                 } catch (JsonProcessingException e) {
-                    throw new SecretException(String.format(
-                        "Failed to read secret sub-key '%s' from secret '%s'. Ensure the secret contains valid JSON value.",
+                    throw new SecretException("Failed to read secret sub-key '%s' from secret '%s'. Ensure the secret contains valid JSON value.".formatted(
                         subkey,
                         key
                     ));

--- a/core/src/main/java/io/kestra/core/runners/pebble/functions/YamlFunction.java
+++ b/core/src/main/java/io/kestra/core/runners/pebble/functions/YamlFunction.java
@@ -15,11 +15,12 @@ import java.util.List;
 import java.util.Map;
 
 public class YamlFunction implements Function {
-    final static ObjectMapper MAPPER = new ObjectMapper(
+    static final ObjectMapper MAPPER = new ObjectMapper(
         new YAMLFactory()
     ).findAndRegisterModules();
     private static final TypeReference<Object> TYPE_REFERENCE = new TypeReference<>() {};
 
+    @Override
     public List<String> getArgumentNames() {
         return List.of("yaml");
     }

--- a/core/src/main/java/io/kestra/core/schedulers/AbstractScheduler.java
+++ b/core/src/main/java/io/kestra/core/schedulers/AbstractScheduler.java
@@ -492,7 +492,7 @@ public abstract class AbstractScheduler implements Scheduler, Service {
             .filter(Objects::nonNull).toList();
     }
 
-    abstract public void handleNext(List<FlowWithSource> flows, ZonedDateTime now, BiConsumer<List<Trigger>, ScheduleContextInterface> consumer);
+    public abstract void handleNext(List<FlowWithSource> flows, ZonedDateTime now, BiConsumer<List<Trigger>, ScheduleContextInterface> consumer);
 
     public List<FlowWithTriggers> schedulerTriggers() {
         Map<String, FlowWithSource> flows = getFlowsWithDefaults().stream()

--- a/core/src/main/java/io/kestra/core/server/AbstractServiceLivenessCoordinator.java
+++ b/core/src/main/java/io/kestra/core/server/AbstractServiceLivenessCoordinator.java
@@ -23,7 +23,7 @@ import static io.kestra.core.server.Service.ServiceState.*;
 @Slf4j
 public abstract class AbstractServiceLivenessCoordinator extends AbstractServiceLivenessTask {
 
-    private final static int DEFAULT_SCHEDULE_JITTER_MAX_MS = 500;
+    private static final int DEFAULT_SCHEDULE_JITTER_MAX_MS = 500;
 
     protected static String DEFAULT_REASON_FOR_DISCONNECTED =
         "The service was detected as non-responsive after the session timeout. " +

--- a/core/src/main/java/io/kestra/core/server/ServiceInstance.java
+++ b/core/src/main/java/io/kestra/core/server/ServiceInstance.java
@@ -180,7 +180,7 @@ public record ServiceInstance(
 
         // add a default reason if a state changed is detected.
         if (reason == null && !state.equals(newState)) {
-            reason = String.format("Service transitioned to the '%s' state.", newState);
+            reason = "Service transitioned to the '%s' state.".formatted(newState);
         }
 
         List<TimestampedEvent> events = Optional.ofNullable(this.events).orElse(new ArrayList<>());

--- a/core/src/main/java/io/kestra/core/services/FlowService.java
+++ b/core/src/main/java/io/kestra/core/services/FlowService.java
@@ -420,10 +420,10 @@ public class FlowService {
 
         Pattern p = Pattern.compile(regex, Pattern.MULTILINE);
         if (p.matcher(source).find()) {
-            return p.matcher(source).replaceAll(String.format("disabled: %s\n", disabled));
+            return p.matcher(source).replaceAll("disabled: %s\n".formatted(disabled));
         }
 
-        return source + String.format("\ndisabled: %s", disabled);
+        return source + "\ndisabled: %s".formatted(disabled);
     }
 
     // Used in Git plugin

--- a/core/src/main/java/io/kestra/core/services/FlowTriggerService.java
+++ b/core/src/main/java/io/kestra/core/services/FlowTriggerService.java
@@ -140,8 +140,7 @@ public class FlowTriggerService {
                 f.getFlow(),
                 execution
             ))
-            .filter(Optional::isPresent)
-            .map(Optional::get)
+            .flatMap(Optional::stream)
             .toList();
 
         if (multipleConditionStorage.isPresent()) {

--- a/core/src/main/java/io/kestra/core/services/KVStoreService.java
+++ b/core/src/main/java/io/kestra/core/services/KVStoreService.java
@@ -36,8 +36,7 @@ public class KVStoreService {
             try {
                 flowService.checkAllowedNamespace(tenant, namespace, tenant, fromNamespace);
             } catch (IllegalArgumentException e) {
-                throw new KVStoreException(String.format(
-                    "Cannot access the KV store. Access to '%s' namespace is not allowed from '%s'.", namespace, fromNamespace)
+                throw new KVStoreException("Cannot access the KV store. Access to '%s' namespace is not allowed from '%s'.".formatted(namespace, fromNamespace)
                 );
             }
         }
@@ -49,8 +48,7 @@ public class KVStoreService {
             KVStore kvStore = new InternalKVStore(tenant, namespace, storageInterface);
             try {
                 if (kvStore.list().isEmpty()) {
-                    throw new KVStoreException(String.format(
-                        "Cannot access the KV store. The namespace '%s' does not exist.",
+                    throw new KVStoreException("Cannot access the KV store. The namespace '%s' does not exist.".formatted(
                         namespace
                     ));
                 }

--- a/core/src/main/java/io/kestra/core/storages/InternalNamespace.java
+++ b/core/src/main/java/io/kestra/core/storages/InternalNamespace.java
@@ -142,14 +142,12 @@ public class InternalNamespace implements Namespace {
                 URI uri = storage.put(tenant, namespace, cleanUri, content);
                 NamespaceFile namespaceFile = new NamespaceFile(relativize(uri), uri, namespace);
                 if (exists) {
-                    logger.debug(String.format(
-                        "File '%s' overwritten into namespace '%s'.",
+                    logger.debug("File '%s' overwritten into namespace '%s'.".formatted(
                         path,
                         namespace
                     ));
                 } else {
-                    logger.debug(String.format(
-                        "File '%s' added to namespace '%s'.",
+                    logger.debug("File '%s' added to namespace '%s'.".formatted(
                         path,
                         namespace
                     ));
@@ -161,8 +159,7 @@ public class InternalNamespace implements Namespace {
                     URI uri = storage.put(tenant, namespace, namespaceFilesPrefix.toUri(), content);
                     yield new NamespaceFile(relativize(uri), uri, namespace);
                 } else {
-                    throw new IOException(String.format(
-                        "File '%s' already exists in namespace '%s' and conflict is set to %s",
+                    throw new IOException("File '%s' already exists in namespace '%s' and conflict is set to %s".formatted(
                         path,
                         namespace,
                         Conflicts.ERROR
@@ -173,15 +170,13 @@ public class InternalNamespace implements Namespace {
                 if (!exists) {
                     URI uri = storage.put(tenant, namespace, namespaceFilesPrefix.toUri(), content);
                     NamespaceFile namespaceFile = new NamespaceFile(relativize(uri), uri, namespace);
-                    logger.debug(String.format(
-                        "File '%s' added to namespace '%s'.",
+                    logger.debug("File '%s' added to namespace '%s'.".formatted(
                         path,
                         namespace
                     ));
                     yield namespaceFile;
                 } else {
-                    logger.debug(String.format(
-                        "File '%s' already exists in namespace '%s' and conflict is set to %s. Skipping.",
+                    logger.debug("File '%s' already exists in namespace '%s' and conflict is set to %s. Skipping.".formatted(
                         path,
                         namespace,
                         Conflicts.SKIP

--- a/core/src/main/java/io/kestra/core/storages/InternalStorage.java
+++ b/core/src/main/java/io/kestra/core/storages/InternalStorage.java
@@ -266,6 +266,7 @@ public class InternalStorage implements Storage {
         return this.storage.put(context.getTenantId(), context.getNamespace(), resolve, new BufferedInputStream(inputStream));
     }
 
+    @Override
     public Optional<StorageContext.Task> getTaskStorageContext() {
         return Optional.ofNullable((context instanceof StorageContext.Task task) ? task : null);
     }

--- a/core/src/main/java/io/kestra/core/storages/NamespaceFile.java
+++ b/core/src/main/java/io/kestra/core/storages/NamespaceFile.java
@@ -53,13 +53,11 @@ public record NamespaceFile(
         final NamespaceFile namespaceFile;
         if (uri.getScheme() != null) {
             if (!uri.getScheme().equalsIgnoreCase("kestra")) {
-                throw new IllegalArgumentException(String.format(
-                    "Invalid Kestra URI scheme. Expected 'kestra', but was '%s'.", uri
+                throw new IllegalArgumentException("Invalid Kestra URI scheme. Expected 'kestra', but was '%s'.".formatted(uri
                 ));
             }
             if (!uri.getPath().startsWith(StorageContext.namespaceFilePrefix(namespace))) {
-                throw new IllegalArgumentException(String.format(
-                    "Invalid Kestra URI. Expected prefix for namespace '%s', but was %s.", namespace, uri)
+                throw new IllegalArgumentException("Invalid Kestra URI. Expected prefix for namespace '%s', but was %s.".formatted(namespace, uri)
                 );
             }
             namespaceFile = of(namespace, Path.of(StorageContext.namespaceFilePrefix(namespace)).relativize(path));
@@ -119,7 +117,7 @@ public record NamespaceFile(
      * @return The path.
      */
     public Path path(boolean withLeadingSlash) {
-        final String strPath = path.toString();
+        final String strPath = path;
         if (!withLeadingSlash) {
             if (strPath.startsWith("/")) {
                 return Path.of(strPath.substring(1));

--- a/core/src/main/java/io/kestra/core/storages/StorageContext.java
+++ b/core/src/main/java/io/kestra/core/storages/StorageContext.java
@@ -174,16 +174,14 @@ public class StorageContext {
 
         final String prefix;
         if (objectId == null) {
-            prefix = String.format(
-                PREFIX_FORMAT_CACHE,
+            prefix = PREFIX_FORMAT_CACHE.formatted(
                 getNamespaceAsPath(),
                 Slugify.of(getFlowId()),
                 Slugify.of(cacheId)
             );
         } else {
             String hashedObjectId = Hashing.hashToString(objectId);
-            prefix = String.format(
-                PREFIX_FORMAT_CACHE_OBJECT,
+            prefix = PREFIX_FORMAT_CACHE_OBJECT.formatted(
                 getNamespaceAsPath(),
                 Slugify.of(getFlowId()),
                 Slugify.of(cacheId),
@@ -232,7 +230,7 @@ public class StorageContext {
      */
     public URI getFlowStorageURI() {
         try {
-            var prefix = String.format(PREFIX_FORMAT_FLOWS, getNamespaceAsPath(), Slugify.of(getFlowId()));
+            var prefix = PREFIX_FORMAT_FLOWS.formatted(getNamespaceAsPath(), Slugify.of(getFlowId()));
             return new URI("//" + prefix);
         } catch (URISyntaxException e) {
             throw new IllegalArgumentException(e);
@@ -260,7 +258,7 @@ public class StorageContext {
                 .map(s -> s.endsWith("://") ? s : s + "://")
                 .orElse("//");
 
-            var prefix = String.format(PREFIX_FORMAT_EXECUTIONS,
+            var prefix = PREFIX_FORMAT_EXECUTIONS.formatted(
                 getNamespaceAsPath(),
                 Slugify.of(flowId),
                 executionId
@@ -290,12 +288,12 @@ public class StorageContext {
 
 
     public static String namespaceFilePrefix(String namespace) {
-        return String.format(PREFIX_FORMAT_NAMESPACE_FILE, namespace.replace(".", "/"));
+        return PREFIX_FORMAT_NAMESPACE_FILE.formatted(namespace.replace(".", "/"));
     }
 
 
     public static String kvPrefix(String namespace) {
-        return String.format(PREFIX_FORMAT_KV, namespace.replace(".", "/"));
+        return PREFIX_FORMAT_KV.formatted(namespace.replace(".", "/"));
     }
 
     /**
@@ -327,8 +325,7 @@ public class StorageContext {
         @Override
         public URI getContextStorageURI() {
             try {
-                var prefix = String.format(
-                    PREFIX_FORMAT_TASK,
+                var prefix = PREFIX_FORMAT_TASK.formatted(
                     getNamespaceAsPath(),
                     Slugify.of(getFlowId()),
                     getExecutionId(),
@@ -374,7 +371,7 @@ public class StorageContext {
         @Override
         public URI getContextStorageURI() {
             try {
-                String prefix = String.format(PREFIX_FORMAT_TRIGGER,
+                String prefix = PREFIX_FORMAT_TRIGGER.formatted(
                     getNamespaceAsPath(),
                     Slugify.of(getFlowId()),
                     getExecutionId(),
@@ -421,8 +418,7 @@ public class StorageContext {
         @Override
         public URI getContextStorageURI() {
             try {
-                var prefix = String.format(
-                    PREFIX_FORMAT_INPUTS,
+                var prefix = PREFIX_FORMAT_INPUTS.formatted(
                     getNamespaceAsPath(),
                     Slugify.of(getFlowId()),
                     getExecutionId(),

--- a/core/src/main/java/io/kestra/core/storages/StorageInterfaceFactory.java
+++ b/core/src/main/java/io/kestra/core/storages/StorageInterfaceFactory.java
@@ -21,7 +21,7 @@ import java.util.stream.Stream;
  * Factor class for constructing {@link StorageInterface} objects.
  */
 public class StorageInterfaceFactory {
-    
+
     public static final String KESTRA_STORAGE_TYPE_CONFIG = "kestra.storage.type";
 
     private final PluginRegistry pluginRegistry;
@@ -50,8 +50,7 @@ public class StorageInterfaceFactory {
 
         if (optional.isEmpty()) {
             String storageIds = getLoggableStorageIds();
-            throw new KestraRuntimeException(String.format(
-                "No storage interface can be found for '%s=%s'. Supported types are: %s", KESTRA_STORAGE_TYPE_CONFIG, pluginId, storageIds
+            throw new KestraRuntimeException("No storage interface can be found for '%s=%s'. Supported types are: %s".formatted(KESTRA_STORAGE_TYPE_CONFIG, pluginId, storageIds
             ));
         }
 
@@ -64,8 +63,7 @@ public class StorageInterfaceFactory {
             Map<String, Object> nonEmptyConfig = Optional.ofNullable(pluginConfiguration).orElse(Map.of());
             plugin = JacksonMapper.toMap(nonEmptyConfig, pluginClass);
         } catch (Exception e) {
-            throw new KestraRuntimeException(String.format(
-                "Failed to create storage '%s'. Error: %s", pluginId, e.getMessage())
+            throw new KestraRuntimeException("Failed to create storage '%s'. Error: %s".formatted(pluginId, e.getMessage())
             );
         }
 
@@ -74,22 +72,19 @@ public class StorageInterfaceFactory {
         try {
             violations = validator.validate(plugin);
         } catch (ConstraintViolationException e) {
-            throw new KestraRuntimeException(String.format(
-                "Failed to validate configuration for storage '%s'. Error: %s", pluginId, e.getMessage())
+            throw new KestraRuntimeException("Failed to validate configuration for storage '%s'. Error: %s".formatted(pluginId, e.getMessage())
             );
         }
         if (!violations.isEmpty()) {
             ConstraintViolationException e = new ConstraintViolationException(violations);
-            throw new KestraRuntimeException(String.format(
-                "Invalid configuration for storage '%s'. Error: '%s'", pluginId, e.getMessage()), e
+            throw new KestraRuntimeException("Invalid configuration for storage '%s'. Error: '%s'".formatted(pluginId, e.getMessage()), e
             );
         }
 
         try {
             plugin = init(storageConfiguration, plugin);
         } catch (IOException e) {
-            throw new KestraRuntimeException(String.format(
-                "Failed to initialize storage '%s'. Error: %s", pluginId, e.getMessage()), e
+            throw new KestraRuntimeException("Failed to initialize storage '%s'. Error: %s".formatted(pluginId, e.getMessage()), e
             );
         }
         return plugin;

--- a/core/src/main/java/io/kestra/core/storages/kv/InternalKVStore.java
+++ b/core/src/main/java/io/kestra/core/storages/kv/InternalKVStore.java
@@ -61,8 +61,7 @@ public class InternalKVStore implements KVStore {
         KVStore.validateKey(key);
 
         if (!overwrite && exists(key)) {
-            throw new KVStoreException(String.format(
-                "Cannot set value for key '%s'. Key already exists and `overwrite` is set to `false`.", key));
+            throw new KVStoreException("Cannot set value for key '%s'. Key already exists and `overwrite` is set to `false`.".formatted(key));
         }
 
         byte[] serialized = JacksonMapper.ofIon().writeValueAsBytes(value.value());

--- a/core/src/main/java/io/kestra/core/utils/Await.java
+++ b/core/src/main/java/io/kestra/core/utils/Await.java
@@ -39,8 +39,7 @@ public class Await {
         long start = System.currentTimeMillis();
         while (!condition.getAsBoolean()) {
             if (System.currentTimeMillis() - start > timeout.toMillis()) {
-                throw new TimeoutException(String.format(
-                    "Await failed to terminate within %s.%s",
+                throw new TimeoutException("Await failed to terminate within %s.%s".formatted(
                     timeout,
                     errorMessageInCaseOfFailure == null ? "" : " " + errorMessageInCaseOfFailure.get()
                 ));

--- a/core/src/main/java/io/kestra/core/utils/DurationOrSizeTrigger.java
+++ b/core/src/main/java/io/kestra/core/utils/DurationOrSizeTrigger.java
@@ -27,7 +27,7 @@ public class DurationOrSizeTrigger<V> implements Predicate<Collection<V>> {
             return true;
         }
 
-        if (buffer.size() > 0 && this.next.isBefore(Instant.now())) {
+        if (!buffer.isEmpty() && this.next.isBefore(Instant.now())) {
             this.nextDate();
             return true;
         }

--- a/core/src/main/java/io/kestra/core/utils/Enums.java
+++ b/core/src/main/java/io/kestra/core/utils/Enums.java
@@ -77,13 +77,12 @@ public final class Enums {
             .filter(e -> e.name().equals(value.toUpperCase(Locale.ROOT)))
             .findFirst()
             .or(() -> Optional.ofNullable(fallbackMap.get(value.toUpperCase(Locale.ROOT))))
-            .orElseThrow(() -> new IllegalArgumentException(String.format(
-                "Unsupported enum value '%s'. Expected one of: %s",
-                value,
-                Arrays.stream(values)
-                    .map(Enum::name)
-                    .collect(Collectors.joining(", ", "[", "]"))
-            )));
+            .orElseThrow(() -> new IllegalArgumentException("Unsupported enum value '%s'. Expected one of: %s".formatted(
+            value,
+            Arrays.stream(values)
+                .map(Enum::name)
+                .collect(Collectors.joining(", ", "[", "]"))
+        )));
     }
 
     /**

--- a/core/src/main/java/io/kestra/core/utils/GraphUtils.java
+++ b/core/src/main/java/io/kestra/core/utils/GraphUtils.java
@@ -424,9 +424,9 @@ public class GraphUtils {
                 // link to next edge
                 AbstractGraph nextEdge = relationType ==  RelationType.AFTER_EXECUTION ? graph.getEnd() : (relationType == RelationType.FINALLY ? graph.getAfterExecution() : graph.getFinally());
                 if (GraphUtils.isAllLinkToEnd(relationType)) {
-                    if (currentGraph instanceof GraphCluster && ((GraphCluster) currentGraph).getEnd() != null) {
+                    if (currentGraph instanceof GraphCluster cluster && cluster.getEnd() != null) {
                         graph.addEdge(
-                            ((GraphCluster) currentGraph).getEnd(),
+                            cluster.getEnd(),
                             nextEdge,
                             new Relation()
                         );
@@ -443,7 +443,7 @@ public class GraphUtils {
 
                 if (!iterator.hasNext() && !isAllLinkToEnd(relationType)) {
                     graph.addEdge(
-                        currentGraph instanceof GraphCluster ? ((GraphCluster) currentGraph).getEnd() : currentGraph,
+                        currentGraph instanceof GraphCluster gc ? gc.getEnd() : currentGraph,
                         nextEdge,
                         new Relation()
                     );
@@ -453,7 +453,7 @@ public class GraphUtils {
     }
 
     private static AbstractGraph toEdgeTarget(AbstractGraph currentGraph) {
-        return currentGraph instanceof GraphCluster ? ((GraphCluster) currentGraph).getRoot() : currentGraph;
+        return currentGraph instanceof GraphCluster gc ? gc.getRoot() : currentGraph;
     }
 
     private static void fillGraphDag(
@@ -557,8 +557,8 @@ public class GraphUtils {
                         }
                     }
 
-                    if (currentGraph instanceof GraphTask) {
-                        nodeTaskCreated.add((GraphTask) currentGraph);
+                    if (currentGraph instanceof GraphTask task) {
+                        nodeTaskCreated.add(task);
                     }
                     nodeCreatedIds.add(currentTask.getTask().getId());
                 }

--- a/core/src/main/java/io/kestra/core/utils/IdUtils.java
+++ b/core/src/main/java/io/kestra/core/utils/IdUtils.java
@@ -11,7 +11,7 @@ import java.util.UUID;
 import java.util.stream.Collectors;
 
 @SuppressWarnings({"deprecation"})
-abstract public class IdUtils {
+public abstract class IdUtils {
     private static final HashFunction HASH_FUNCTION = Hashing.md5();
     private static final char ID_SEPARATOR = '_';
 

--- a/core/src/main/java/io/kestra/core/utils/TruthUtils.java
+++ b/core/src/main/java/io/kestra/core/utils/TruthUtils.java
@@ -2,7 +2,7 @@ package io.kestra.core.utils;
 
 import java.util.List;
 
-abstract public class TruthUtils {
+public abstract class TruthUtils {
     private static final List<String> FALSE_VALUES = List.of("false", "0", "-0", "");
 
     public static boolean isTruthy(String condition) {

--- a/core/src/main/java/io/kestra/core/utils/Version.java
+++ b/core/src/main/java/io/kestra/core/utils/Version.java
@@ -168,7 +168,7 @@ public class Version implements Comparable<Version> {
 
     private static int requirePositive(int version, final String message) {
         if (version < 0) {
-            throw new IllegalArgumentException(String.format("The '%s' version must super or equal to 0", message));
+            throw new IllegalArgumentException("The '%s' version must super or equal to 0".formatted(message));
         }
         return version;
     }

--- a/core/src/main/java/io/kestra/core/utils/VersionProvider.java
+++ b/core/src/main/java/io/kestra/core/utils/VersionProvider.java
@@ -60,8 +60,7 @@ public class VersionProvider {
                     )
             )
             .map(this::getVersion)
-            .filter(Optional::isPresent)
-            .map(Optional::get)
+            .flatMap(Optional::stream)
             .findFirst()
             .orElse(this.version);
     }

--- a/core/src/main/java/io/kestra/core/validations/validator/FlowValidator.java
+++ b/core/src/main/java/io/kestra/core/validations/validator/FlowValidator.java
@@ -183,12 +183,12 @@ public class FlowValidator implements ConstraintValidator<FlowValidation, Flow> 
             if (!dependencies.isEmpty()) {
                 dependencies.forEach(id -> {
                     if (graph.get(id) == null) {
-                        violations.add(String.format("Input with id '%s' depends on a non-existent input '%s'.", key, id));
+                        violations.add("Input with id '%s' depends on a non-existent input '%s'.".formatted(key, id));
                     }
                 });
             }
             CycleDependency.findCycle(key, graph).ifPresent(list -> {
-                violations.add(String.format("Cycle dependency detected for input with id '%s': %s", key, list));
+                violations.add("Cycle dependency detected for input with id '%s': %s".formatted(key, list));
             });
         });
 

--- a/core/src/main/java/io/kestra/plugin/core/flow/Dag.java
+++ b/core/src/main/java/io/kestra/plugin/core/flow/Dag.java
@@ -109,6 +109,7 @@ public class Dag extends Task implements FlowableTask<VoidOutput> {
     @Getter(AccessLevel.NONE)
     protected List<Task> _finally;
 
+    @Override
     public List<Task> getFinally() {
         return this._finally;
     }

--- a/core/src/main/java/io/kestra/plugin/core/flow/ForEachItem.java
+++ b/core/src/main/java/io/kestra/plugin/core/flow/ForEachItem.java
@@ -317,6 +317,7 @@ public class ForEachItem extends Task implements FlowableTask<VoidOutput>, Child
     @Getter(AccessLevel.NONE)
     protected List<Task> _finally;
 
+    @Override
     public List<Task> getFinally() {
         return this._finally;
     }
@@ -516,8 +517,7 @@ public class ForEachItem extends Task implements FlowableTask<VoidOutput>, Child
                                 );
                         }
                     ))
-                    .filter(Optional::isPresent)
-                    .<SubflowExecution<?>>map(Optional::get)
+                    .flatMap(Optional::stream)
                     .toList();
             } catch (IOException e) {
                 throw new InternalException(e);

--- a/core/src/main/java/io/kestra/plugin/core/flow/If.java
+++ b/core/src/main/java/io/kestra/plugin/core/flow/If.java
@@ -104,6 +104,7 @@ public class If extends Task implements FlowableTask<If.Output> {
     @Getter(AccessLevel.NONE)
     protected List<Task> _finally;
 
+    @Override
     public List<Task> getFinally() {
         return this._finally;
     }

--- a/core/src/main/java/io/kestra/plugin/core/flow/LoopUntil.java
+++ b/core/src/main/java/io/kestra/plugin/core/flow/LoopUntil.java
@@ -81,6 +81,7 @@ public class LoopUntil extends Task implements FlowableTask<LoopUntil.Output> {
     @Getter(AccessLevel.NONE)
     protected List<Task> _finally;
 
+    @Override
     public List<Task> getFinally() {
         return this._finally;
     }
@@ -177,7 +178,7 @@ public class LoopUntil extends Task implements FlowableTask<LoopUntil.Output> {
         Integer iterationCount = Optional.ofNullable(parentTaskRun.getOutputs())
             .map(outputs -> (Integer) outputs.get("iterationCount"))
             .orElse(0);
-        
+
         Optional<Integer> maxIterations = runContext.render(this.getCheckFrequency().getMaxIterations()).as(Integer.class);
         if (maxIterations.isPresent() && iterationCount != null && iterationCount > maxIterations.get()) {
             if (printLog) {logger.warn("Max iterations reached");}
@@ -186,8 +187,8 @@ public class LoopUntil extends Task implements FlowableTask<LoopUntil.Output> {
 
         Instant creationDate = parentTaskRun.getState().getHistories().getFirst().getDate();
         Optional<Duration> maxDuration = runContext.render(this.getCheckFrequency().getMaxDuration()).as(Duration.class);
-        if (maxDuration.isPresent() 
-            && creationDate != null 
+        if (maxDuration.isPresent()
+            && creationDate != null
             && creationDate.plus(maxDuration.get()).isBefore(Instant.now())) {
             if (printLog) {logger.warn("Max duration reached");}
 
@@ -204,8 +205,8 @@ public class LoopUntil extends Task implements FlowableTask<LoopUntil.Output> {
             return Optional.empty();
         }
 
-        if (childTaskExecuted 
-            && this.reachedMaximums(runContext, execution, parentTaskRun, true) 
+        if (childTaskExecuted
+            && this.reachedMaximums(runContext, execution, parentTaskRun, true)
             && Boolean.TRUE.equals(runContext.render(this.failOnMaxReached).as(Boolean.class).orElseThrow())
         ) {
             return Optional.of(State.Type.FAILED);

--- a/core/src/main/java/io/kestra/plugin/core/flow/Parallel.java
+++ b/core/src/main/java/io/kestra/plugin/core/flow/Parallel.java
@@ -127,6 +127,7 @@ public class Parallel extends Task implements FlowableTask<VoidOutput> {
     @Getter(AccessLevel.NONE)
     protected List<Task> _finally;
 
+    @Override
     public List<Task> getFinally() {
         return this._finally;
     }

--- a/core/src/main/java/io/kestra/plugin/core/flow/Pause.java
+++ b/core/src/main/java/io/kestra/plugin/core/flow/Pause.java
@@ -207,6 +207,7 @@ public class Pause extends Task implements FlowableTask<Pause.Output> {
     @Getter(AccessLevel.NONE)
     protected List<Task> _finally;
 
+    @Override
     public List<Task> getFinally() {
         return this._finally;
     }

--- a/core/src/main/java/io/kestra/plugin/core/flow/Sequential.java
+++ b/core/src/main/java/io/kestra/plugin/core/flow/Sequential.java
@@ -71,6 +71,7 @@ public class Sequential extends Task implements FlowableTask<VoidOutput> {
     @Getter(AccessLevel.NONE)
     protected List<Task> _finally;
 
+    @Override
     public List<Task> getFinally() {
         return this._finally;
     }
@@ -96,6 +97,7 @@ public class Sequential extends Task implements FlowableTask<VoidOutput> {
         return subGraph;
     }
 
+    @Override
     public List<Task> allChildTasks() {
         return Stream
             .concat(

--- a/core/src/main/java/io/kestra/plugin/core/flow/Sleep.java
+++ b/core/src/main/java/io/kestra/plugin/core/flow/Sleep.java
@@ -45,6 +45,7 @@ public class Sleep extends Task implements RunnableTask<VoidOutput> {
     @NotNull
     private Property<Duration> duration;
 
+    @Override
     public VoidOutput run(RunContext runContext) throws Exception {
         Duration durationRendered = runContext.render(this.duration).as(Duration.class).orElseThrow();
         runContext.logger().info("Waiting for {}", durationRendered);

--- a/core/src/main/java/io/kestra/plugin/core/flow/Switch.java
+++ b/core/src/main/java/io/kestra/plugin/core/flow/Switch.java
@@ -118,6 +118,7 @@ public class Switch extends Task implements FlowableTask<Switch.Output> {
     @Getter(AccessLevel.NONE)
     protected List<Task> _finally;
 
+    @Override
     public List<Task> getFinally() {
         return this._finally;
     }

--- a/core/src/main/java/io/kestra/plugin/core/flow/Template.java
+++ b/core/src/main/java/io/kestra/plugin/core/flow/Template.java
@@ -99,6 +99,7 @@ public class Template extends Task implements FlowableTask<Template.Output> {
     @Getter(AccessLevel.NONE)
     protected List<Task> _finally;
 
+    @Override
     public List<Task> getFinally() {
         return this._finally;
     }

--- a/core/src/main/java/io/kestra/plugin/core/http/Download.java
+++ b/core/src/main/java/io/kestra/plugin/core/http/Download.java
@@ -64,6 +64,7 @@ public class Download extends AbstractHttp implements RunnableTask<Download.Outp
     @Builder.Default
     private final Property<Boolean> failOnEmptyResponse = Property.of(true);
 
+    @Override
     public Output run(RunContext runContext) throws Exception {
         Logger logger = runContext.logger();
         URI from = new URI(runContext.render(this.uri).as(String.class).orElseThrow());

--- a/core/src/main/java/io/kestra/plugin/core/http/Request.java
+++ b/core/src/main/java/io/kestra/plugin/core/http/Request.java
@@ -318,6 +318,7 @@ public class Request extends AbstractHttp implements RunnableTask<Request.Output
     )
     private Property<Boolean> encryptBody = Property.of(false);
 
+    @Override
     public Output run(RunContext runContext) throws Exception {
         try (HttpClient client = this.client(runContext)) {
             HttpRequest request = this.request(runContext);

--- a/core/src/main/java/io/kestra/plugin/core/namespace/DeleteFiles.java
+++ b/core/src/main/java/io/kestra/plugin/core/namespace/DeleteFiles.java
@@ -120,7 +120,7 @@ public class DeleteFiles extends Task implements RunnableTask<Output> {
             .stream()
             .map(Rethrow.throwFunction(file -> {
                 if (namespace.delete(NamespaceFile.of(renderedNamespace, Path.of(file.path().replace("\\","/"))).storagePath())) {
-                    logger.debug(String.format("Deleted %s", (file.path())));
+                    logger.debug("Deleted %s".formatted((file.path())));
 
                     if (Boolean.TRUE.equals(deleteParent)) {
                         trackParentFolder(file, parentFolders);

--- a/core/src/main/java/io/kestra/plugin/core/namespace/DownloadFiles.java
+++ b/core/src/main/java/io/kestra/plugin/core/namespace/DownloadFiles.java
@@ -117,7 +117,7 @@ public class DownloadFiles extends Task implements RunnableTask<DownloadFiles.Ou
             .map(Rethrow.throwFunction(file -> {
                 try (InputStream is = runContext.storage().getFile(file.uri())) {
                     URI uri = runContext.storage().putFile(is, renderedDestination + file.path());
-                    logger.debug(String.format("Downloaded %s", uri));
+                    logger.debug("Downloaded %s".formatted(uri));
                     return new AbstractMap.SimpleEntry<>(file.path(true).toString(), uri);
                 }
             }))

--- a/core/src/main/java/io/kestra/plugin/core/namespace/UploadFiles.java
+++ b/core/src/main/java/io/kestra/plugin/core/namespace/UploadFiles.java
@@ -23,7 +23,6 @@ import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.List;
 import java.util.Map;
 
@@ -188,7 +187,7 @@ public class UploadFiles extends Task implements RunnableTask<UploadFiles.Output
 
         for (Path path : runContext.workingDir().findAllFilesMatching(files)) {
             File file = path.toFile();
-            Path resolve = Paths.get("/").resolve(runContext.workingDir().path().relativize(file.toPath()));
+            Path resolve = Path.of("/").resolve(runContext.workingDir().path().relativize(file.toPath()));
 
             Path targetFilePath = Path.of(destination, resolve.toString());
             storageNamespace.putFile(targetFilePath, new FileInputStream(file), runContext.render(conflict).as(Namespace.Conflicts.class).orElseThrow());

--- a/core/src/main/java/io/kestra/plugin/core/storage/FilterItems.java
+++ b/core/src/main/java/io/kestra/plugin/core/storage/FilterItems.java
@@ -122,8 +122,7 @@ public class FilterItems extends Task implements RunnableTask<FilterItems.Output
                             if (exception != null) {
                                 throw exception;
                             } else {
-                                throw new IllegalVariableEvaluationException(String.format(
-                                    "Expression `%s` return `null` on item `%s`",
+                                throw new IllegalVariableEvaluationException("Expression `%s` return `null` on item `%s`".formatted(
                                     filterCondition,
                                     item
                                 ));

--- a/core/src/test/java/io/kestra/core/cache/NoopCacheTest.java
+++ b/core/src/test/java/io/kestra/core/cache/NoopCacheTest.java
@@ -31,21 +31,21 @@ class NoopCacheTest {
     void getAllPresent() {
         cache.put("key", "value");
 
-        assertThat(cache.getAllPresent(List.of("key"))).hasSize(0);
+        assertThat(cache.getAllPresent(List.of("key"))).isEmpty();
     }
 
     @Test
     void getAll() {
         cache.put("key", "value");
 
-        assertThat(cache.getAll(List.of("key"), it -> Map.of("key", "value"))).hasSize(0);
+        assertThat(cache.getAll(List.of("key"), it -> Map.of("key", "value"))).isEmpty();
     }
 
     @Test
     void putAll() {
         cache.putAll(Map.of("key", "value"));
 
-        assertThat(cache.getAllPresent(List.of("key"))).hasSize(0);
+        assertThat(cache.getAllPresent(List.of("key"))).isEmpty();
     }
 
     @Test
@@ -82,7 +82,7 @@ class NoopCacheTest {
     void asMap() {
         cache.put("key", "value");
 
-        assertThat(cache.asMap()).hasSize(0);
+        assertThat(cache.asMap()).isEmpty();
     }
 
     @Test
@@ -90,7 +90,7 @@ class NoopCacheTest {
         cache.put("key", "value");
         cache.cleanUp();
 
-        assertThat(cache.getAllPresent(List.of("key"))).hasSize(0);
+        assertThat(cache.getAllPresent(List.of("key"))).isEmpty();
     }
 
     @Test

--- a/core/src/test/java/io/kestra/core/docs/ClassPluginDocumentationTest.java
+++ b/core/src/test/java/io/kestra/core/docs/ClassPluginDocumentationTest.java
@@ -14,7 +14,6 @@ import org.junit.jupiter.api.Test;
 
 import java.net.URISyntaxException;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -29,34 +28,34 @@ class ClassPluginDocumentationTest {
         Helpers.runApplicationContext(throwConsumer((applicationContext) -> {
             JsonSchemaGenerator jsonSchemaGenerator = applicationContext.getBean(JsonSchemaGenerator.class);
 
-            Path plugins = Paths.get(Objects.requireNonNull(ClassPluginDocumentationTest.class.getClassLoader().getResource("plugins")).toURI());
+            Path plugins = Path.of(Objects.requireNonNull(ClassPluginDocumentationTest.class.getClassLoader().getResource("plugins")).toURI());
 
             PluginScanner pluginScanner = new PluginScanner(ClassPluginDocumentationTest.class.getClassLoader());
             List<RegisteredPlugin> scan = pluginScanner.scan(plugins);
 
-            assertThat(scan.size()).isEqualTo(1);
-            assertThat(scan.getFirst().getTasks().size()).isEqualTo(1);
+            assertThat(scan).hasSize(1);
+            assertThat(scan.getFirst().getTasks()).hasSize(1);
 
             PluginClassAndMetadata<Task> metadata = PluginClassAndMetadata.create(scan.getFirst(), scan.getFirst().getTasks().getFirst(), Task.class, null);
             ClassPluginDocumentation<? extends Task> doc = ClassPluginDocumentation.of(jsonSchemaGenerator, metadata, false);
 
-            assertThat(doc.getDocExamples().size()).isEqualTo(2);
+            assertThat(doc.getDocExamples()).hasSize(2);
             assertThat(doc.getIcon()).isNotNull();
-            assertThat(doc.getInputs().size()).isEqualTo(5);
+            assertThat(doc.getInputs()).hasSize(5);
             assertThat(doc.getDocLicense()).isEqualTo("EE");
 
             // simple
-            assertThat(((Map<String, String>) doc.getInputs().get("format")).get("type")).isEqualTo("string");
-            assertThat(((Map<String, String>) doc.getInputs().get("format")).get("default")).isEqualTo("{}");
-            assertThat(((Map<String, String>) doc.getInputs().get("format")).get("pattern")).isEqualTo(".*");
+            assertThat(((Map<String, String>) doc.getInputs().get("format"))).containsEntry("type", "string");
+            assertThat(((Map<String, String>) doc.getInputs().get("format"))).containsEntry("default", "{}");
+            assertThat(((Map<String, String>) doc.getInputs().get("format"))).containsEntry("pattern", ".*");
             assertThat(((Map<String, String>) doc.getInputs().get("format")).get("description")).contains("of this input");
 
             // definitions
-            assertThat(doc.getDefs().size()).isEqualTo(5);
+            assertThat(doc.getDefs()).hasSize(5);
 
             // enum
             Map<String, Object> enumProperties = (Map<String, Object>) ((Map<String, Object>) ((Map<String, Object>) doc.getDefs().get("io.kestra.plugin.templates.ExampleTask-PropertyChildInput")).get("properties")).get("childEnum");
-            assertThat(((List<String>) enumProperties.get("enum")).size()).isEqualTo(2);
+            assertThat(((List<String>) enumProperties.get("enum"))).hasSize(2);
             assertThat(((List<String>) enumProperties.get("enum"))).containsExactlyInAnyOrder("VALUE_1", "VALUE_2");
 
             Map<String, Object> childInput = (Map<String, Object>) ((Map<String, Object>) doc.getDefs().get("io.kestra.plugin.templates.ExampleTask-PropertyChildInput")).get("properties");
@@ -66,28 +65,28 @@ class ClassPluginDocumentationTest {
             assertThat((String) (childInputList).get("type")).isEqualTo("array");
             assertThat((String) (childInputList).get("title")).isEqualTo("List of string");
             assertThat((Integer) (childInputList).get("minItems")).isEqualTo(1);
-            assertThat(((Map<String, String>) (childInputList).get("items")).get("type")).isEqualTo("string");
+            assertThat(((Map<String, String>) (childInputList).get("items"))).containsEntry("type", "string");
 
             // map
             Map<String, Object> childInputMap = (Map<String, Object>) childInput.get("map");
             assertThat((String) (childInputMap).get("type")).isEqualTo("object");
             assertThat((Boolean) (childInputMap).get("$dynamic")).isTrue();
-            assertThat(((Map<String, String>) (childInputMap).get("additionalProperties")).get("type")).isEqualTo("number");
+            assertThat(((Map<String, String>) (childInputMap).get("additionalProperties"))).containsEntry("type", "number");
 
             // output
             Map<String, Object> childOutput = (Map<String, Object>) ((Map<String, Object>) doc.getDefs().get("io.kestra.plugin.templates.AbstractTask-OutputChild")).get("properties");
-            assertThat(((Map<String, String>) childOutput.get("value")).get("type")).isEqualTo("string");
-            assertThat(((Map<String, Object>) childOutput.get("outputChildMap")).get("type")).isEqualTo("object");
+            assertThat(((Map<String, String>) childOutput.get("value"))).containsEntry("type", "string");
+            assertThat(((Map<String, Object>) childOutput.get("outputChildMap"))).containsEntry("type", "object");
             assertThat(((Map<String, String>) ((Map<String, Object>) childOutput.get("outputChildMap")).get("additionalProperties")).get("$ref")).contains("OutputMap");
 
             // required
             Map<String, Object> propertiesChild = (Map<String, Object>) doc.getDefs().get("io.kestra.plugin.templates.ExampleTask-PropertyChildInput");
-            assertThat(((List<String>) propertiesChild.get("required")).size()).isEqualTo(3);
+            assertThat(((List<String>) propertiesChild.get("required"))).hasSize(3);
 
             // output ref
             Map<String, Object> outputMap = ((Map<String, Object>) ((Map<String, Object>) doc.getDefs().get("io.kestra.plugin.templates.AbstractTask-OutputMap")).get("properties"));
-            assertThat(outputMap.size()).isEqualTo(2);
-            assertThat(((Map<String, Object>) outputMap.get("code")).get("type")).isEqualTo("integer");
+            assertThat(outputMap).hasSize(2);
+            assertThat(((Map<String, Object>) outputMap.get("code"))).containsEntry("type", "integer");
         }));
     }
 
@@ -103,11 +102,11 @@ class ClassPluginDocumentationTest {
             PluginClassAndMetadata<AbstractTrigger> metadata = PluginClassAndMetadata.create(scan, Schedule.class, AbstractTrigger.class, null);
             ClassPluginDocumentation<? extends AbstractTrigger> doc = ClassPluginDocumentation.of(jsonSchemaGenerator, metadata, true);
 
-            assertThat(doc.getDefs().size()).isEqualTo(1);
+            assertThat(doc.getDefs()).hasSize(1);
             assertThat(doc.getDocLicense()).isNull();
 
-            assertThat(((Map<String, Object>) doc.getDefs().get("io.kestra.core.models.tasks.WorkerGroup")).get("type")).isEqualTo("object");
-            assertThat(((Map<String, Object>) ((Map<String, Object>) doc.getDefs().get("io.kestra.core.models.tasks.WorkerGroup")).get("properties")).size()).isEqualTo(2);
+            assertThat(((Map<String, Object>) doc.getDefs().get("io.kestra.core.models.tasks.WorkerGroup"))).containsEntry("type", "object");
+            assertThat(((Map<String, Object>) ((Map<String, Object>) doc.getDefs().get("io.kestra.core.models.tasks.WorkerGroup")).get("properties"))).hasSize(2);
         }));
     }
 
@@ -124,7 +123,7 @@ class ClassPluginDocumentationTest {
 
             assertThat(((Map<?, ?>) doc.getPropertiesSchema().get("properties")).get("version")).isNotNull();
             assertThat(doc.getCls()).isEqualTo("io.kestra.plugin.core.runner.Process");
-            assertThat(doc.getPropertiesSchema().get("title")).isEqualTo("Task runner that executes a task as a subprocess on the Kestra host.");
+            assertThat(doc.getPropertiesSchema()).containsEntry("title", "Task runner that executes a task as a subprocess on the Kestra host.");
             assertThat(doc.getDefs()).isEmpty();
         }));
     }
@@ -150,18 +149,18 @@ class ClassPluginDocumentationTest {
             assertThat(number.get("anyOf")).isNotNull();
             List<Map<String, Object>> anyOf = (List<Map<String, Object>>) number.get("anyOf");
             assertThat(anyOf).hasSize(2);
-            assertThat(anyOf.getFirst().get("type")).isEqualTo("integer");
+            assertThat(anyOf.getFirst()).containsEntry("type", "integer");
             assertThat((Boolean) anyOf.getFirst().get("$dynamic")).isTrue();
-            assertThat(anyOf.get(1).get("type")).isEqualTo("string");
+            assertThat(anyOf.get(1)).containsEntry("type", "string");
 //            assertThat(anyOf.get(1).get("pattern"), is(".*{{.*}}.*"));
 
             Map<String, Object> withDefault = (Map<String, Object>) properties.get("withDefault");
-            assertThat(withDefault.get("type")).isEqualTo("string");
-            assertThat(withDefault.get("default")).isEqualTo("Default Value");
+            assertThat(withDefault).containsEntry("type", "string");
+            assertThat(withDefault).containsEntry("default", "Default Value");
             assertThat((Boolean) withDefault.get("$dynamic")).isTrue();
 
             Map<String, Object> internalStorageURI = (Map<String, Object>) properties.get("uri");
-            assertThat(internalStorageURI.get("type")).isEqualTo("string");
+            assertThat(internalStorageURI).containsEntry("type", "string");
             assertThat((Boolean) internalStorageURI.get("$internalStorageURI")).isTrue();
         }));
     }

--- a/core/src/test/java/io/kestra/core/docs/DocumentationGeneratorTest.java
+++ b/core/src/test/java/io/kestra/core/docs/DocumentationGeneratorTest.java
@@ -17,7 +17,6 @@ import org.junit.jupiter.api.Test;
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
@@ -34,12 +33,12 @@ class DocumentationGeneratorTest {
 
     @Test
     void tasks() throws URISyntaxException, IOException {
-        Path plugins = Paths.get(Objects.requireNonNull(ClassPluginDocumentationTest.class.getClassLoader().getResource("plugins")).toURI());
+        Path plugins = Path.of(Objects.requireNonNull(ClassPluginDocumentationTest.class.getClassLoader().getResource("plugins")).toURI());
 
         PluginScanner pluginScanner = new PluginScanner(ClassPluginDocumentationTest.class.getClassLoader());
         List<RegisteredPlugin> scan = pluginScanner.scan(plugins);
 
-        assertThat(scan.size()).isEqualTo(1);
+        assertThat(scan).hasSize(1);
         PluginClassAndMetadata<Task> metadata = PluginClassAndMetadata.create(scan.getFirst(), scan.getFirst().getTasks().getFirst(), Task.class, null);
         ClassPluginDocumentation<? extends Task> doc = ClassPluginDocumentation.of(jsonSchemaGenerator, metadata, false);
 
@@ -168,7 +167,7 @@ class DocumentationGeneratorTest {
 
     @Test
     void pluginEeDoc() throws Exception {
-        Path plugins = Paths.get(Objects.requireNonNull(ClassPluginDocumentationTest.class.getClassLoader().getResource("plugins")).toURI());
+        Path plugins = Path.of(Objects.requireNonNull(ClassPluginDocumentationTest.class.getClassLoader().getResource("plugins")).toURI());
 
         PluginScanner pluginScanner = new PluginScanner(ClassPluginDocumentationTest.class.getClassLoader());
         List<RegisteredPlugin> list = pluginScanner.scan(plugins);

--- a/core/src/test/java/io/kestra/core/docs/JsonSchemaGeneratorTest.java
+++ b/core/src/test/java/io/kestra/core/docs/JsonSchemaGeneratorTest.java
@@ -375,7 +375,7 @@ class JsonSchemaGeneratorTest {
     @EqualsAndHashCode
     @Getter
     @NoArgsConstructor
-    private static abstract class ParentClass extends Task {
+    private abstract static class ParentClass extends Task {
         @Builder.Default
         private Property<String> stringWithDefault = Property.of("default");
     }

--- a/core/src/test/java/io/kestra/core/encryption/EncryptionServiceTest.java
+++ b/core/src/test/java/io/kestra/core/encryption/EncryptionServiceTest.java
@@ -31,7 +31,7 @@ public class EncryptionServiceTest {
         assertThat(EncryptionService.decrypt(KEY, (String) null)).isNull();
         assertThat(EncryptionService.encrypt(KEY, (byte[]) null)).isNull();
         assertThat(EncryptionService.decrypt(KEY, (byte[]) null)).isNull();
-        assertThat(EncryptionService.encrypt(KEY, "")).isEqualTo("");
-        assertThat(EncryptionService.decrypt(KEY, "")).isEqualTo("");
+        assertThat(EncryptionService.encrypt(KEY, "")).isEmpty();
+        assertThat(EncryptionService.decrypt(KEY, "")).isEmpty();
     }
 }

--- a/core/src/test/java/io/kestra/core/http/client/HttpClientTest.java
+++ b/core/src/test/java/io/kestra/core/http/client/HttpClientTest.java
@@ -178,7 +178,7 @@ class HttpClientTest {
             );
 
             assertThat(response.getStatus().getCode()).isEqualTo(200);
-            assertThat(response.getBody().get("ping")).isEqualTo("pong");
+            assertThat(response.getBody()).containsEntry("ping", "pong");
             assertThat(response.getHeaders().firstValue(HttpHeaders.CONTENT_TYPE).orElseThrow()).isEqualTo(MediaType.APPLICATION_JSON);
         }
     }
@@ -238,7 +238,7 @@ class HttpClientTest {
             );
 
             assertThat(response.getStatus().getCode()).isEqualTo(200);
-            assertThat(response.getBody().get("ping")).isEqualTo(UUID);
+            assertThat(response.getBody()).containsEntry("ping", UUID);
             assertThat(response.getHeaders().firstValue(HttpHeaders.CONTENT_TYPE).orElseThrow()).isEqualTo(MediaType.APPLICATION_JSON);
         }
     }
@@ -282,8 +282,8 @@ class HttpClientTest {
             );
 
             assertThat(response.getStatus().getCode()).isEqualTo(200);
-            assertThat(response.getBody().get("ping")).isEqualTo("pong");
-            assertThat(response.getBody().get("int")).isEqualTo("1");
+            assertThat(response.getBody()).containsEntry("ping", "pong");
+            assertThat(response.getBody()).containsEntry("int", "1");
             assertThat((String) response.getBody().get("file")).contains("logback");
             // @FIXME: Request seems to be correct, but not returned by micronaut
             // assertThat((String) response.getBody().get("inputStream"), containsString("logback"));

--- a/core/src/test/java/io/kestra/core/models/executions/ExecutionTest.java
+++ b/core/src/test/java/io/kestra/core/models/executions/ExecutionTest.java
@@ -157,7 +157,7 @@ class ExecutionTest {
             .labels(List.of(new Label("test", "test-value")))
             .build();
 
-        assertThat(execution.getLabels().size()).isEqualTo(1);
+        assertThat(execution.getLabels()).hasSize(1);
         assertThat(execution.getLabels().getFirst()).isEqualTo(new Label("test", "test-value"));
     }
 }

--- a/core/src/test/java/io/kestra/core/models/executions/LogEntryTest.java
+++ b/core/src/test/java/io/kestra/core/models/executions/LogEntryTest.java
@@ -22,16 +22,16 @@ public class LogEntryTest {
             .message("message")
             .build();
         Map<String, Object> logMap = logEntry.toLogMap();
-        assertThat(logMap.get("tenantId")).isEqualTo("tenantId");
-        assertThat(logMap.get("namespace")).isEqualTo("namespace");
-        assertThat(logMap.get("flowId")).isEqualTo("flowId");
-        assertThat(logMap.get("taskId")).isEqualTo("taskId");
-        assertThat(logMap.get("executionId")).isEqualTo("executionId");
-        assertThat(logMap.get("taskRunId")).isEqualTo("taskRunId");
-        assertThat(logMap.get("attemptNumber")).isEqualTo(1);
-        assertThat(logMap.get("triggerId")).isEqualTo("triggerId");
-        assertThat(logMap.get("thread")).isEqualTo("thread");
-        assertThat(logMap.get("message")).isEqualTo("message");
+        assertThat(logMap).containsEntry("tenantId", "tenantId");
+        assertThat(logMap).containsEntry("namespace", "namespace");
+        assertThat(logMap).containsEntry("flowId", "flowId");
+        assertThat(logMap).containsEntry("taskId", "taskId");
+        assertThat(logMap).containsEntry("executionId", "executionId");
+        assertThat(logMap).containsEntry("taskRunId", "taskRunId");
+        assertThat(logMap).containsEntry("attemptNumber", 1);
+        assertThat(logMap).containsEntry("triggerId", "triggerId");
+        assertThat(logMap).containsEntry("thread", "thread");
+        assertThat(logMap).containsEntry("message", "message");
     }
 
 }

--- a/core/src/test/java/io/kestra/core/models/executions/TaskRunTest.java
+++ b/core/src/test/java/io/kestra/core/models/executions/TaskRunTest.java
@@ -15,7 +15,7 @@ class TaskRunTest {
             .build()
             .onRunningResend();
 
-        assertThat(taskRun.getAttempts().size()).isEqualTo(1);
+        assertThat(taskRun.getAttempts()).hasSize(1);
         assertThat(taskRun.getAttempts().getFirst().getState().getHistories().getFirst()).isEqualTo(taskRun.getState().getHistories().getFirst());
         assertThat(taskRun.getAttempts().getFirst().getState().getCurrent()).isEqualTo(State.Type.KILLED);
     }
@@ -31,7 +31,7 @@ class TaskRunTest {
             .build()
             .onRunningResend();
 
-        assertThat(taskRun.getAttempts().size()).isEqualTo(1);
+        assertThat(taskRun.getAttempts()).hasSize(1);
         assertThat(taskRun.getAttempts().getFirst().getState().getHistories().getFirst()).isNotEqualTo(taskRun.getState().getHistories().getFirst());
         assertThat(taskRun.getAttempts().getFirst().getState().getCurrent()).isEqualTo(State.Type.KILLED);
     }
@@ -47,7 +47,7 @@ class TaskRunTest {
             .build()
             .onRunningResend();
 
-        assertThat(taskRun.getAttempts().size()).isEqualTo(2);
+        assertThat(taskRun.getAttempts()).hasSize(2);
         assertThat(taskRun.getAttempts().get(1).getState().getHistories().getFirst()).isNotEqualTo(taskRun.getState().getHistories().getFirst());
         assertThat(taskRun.getAttempts().get(1).getState().getCurrent()).isEqualTo(State.Type.KILLED);
     }

--- a/core/src/test/java/io/kestra/core/models/executions/VariablesTest.java
+++ b/core/src/test/java/io/kestra/core/models/executions/VariablesTest.java
@@ -24,14 +24,14 @@ class VariablesTest {
         // simple
         Map<String, Object> outputs = Map.of("key", "value");
         var variables = Variables.inMemory(outputs);
-        assertThat(variables.get("key")).isEqualTo("value");
+        assertThat(variables).containsEntry("key", "value");
 
         // nested
         Map<String, Object> nest = Map.of("nest", "value");
         var nestVariables = Variables.inMemory(nest);
         Map<String, Object> host = Map.of("key", nestVariables);
         var hostVariables = Variables.inMemory(host);
-        assertThat(((Map<String, Object>) hostVariables.get("key")).get("nest")).isEqualTo("value");
+        assertThat(((Map<String, Object>) hostVariables.get("key"))).containsEntry("nest", "value");
     }
 
     @Test
@@ -44,23 +44,23 @@ class VariablesTest {
         // simple
         Map<String, Object> outputs = Map.of("key", "value");
         var variables = Variables.inStorage(internalStorage, outputs);
-        assertThat(variables.get("key")).isEqualTo("value");
+        assertThat(variables).containsEntry("key", "value");
 
         // re-read it from URI
         URI uri = ((Variables.InStorageVariables) variables).getStorageUri();
         variables = Variables.inStorage(variablesContext, uri);
-        assertThat(variables.get("key")).isEqualTo("value");
+        assertThat(variables).containsEntry("key", "value");
 
         // nested
         Map<String, Object> nest = Map.of("nest", "value");
         var nestVariables = Variables.inStorage(internalStorage, nest);
         Map<String, Object> host = Map.of("key", nestVariables);
         var hostVariables = Variables.inStorage(internalStorage, host);
-        assertThat(((Map<String, Object>) hostVariables.get("key")).get("nest")).isEqualTo("value");
+        assertThat(((Map<String, Object>) hostVariables.get("key"))).containsEntry("nest", "value");
 
         // re-read it from URI
         uri = ((Variables.InStorageVariables) hostVariables).getStorageUri();
         hostVariables = Variables.inStorage(variablesContext, uri);
-        assertThat(((Map<String, Object>) hostVariables.get("key")).get("nest")).isEqualTo("value");
+        assertThat(((Map<String, Object>) hostVariables.get("key"))).containsEntry("nest", "value");
     }
 }

--- a/core/src/test/java/io/kestra/core/models/flows/FlowTest.java
+++ b/core/src/test/java/io/kestra/core/models/flows/FlowTest.java
@@ -33,8 +33,8 @@ class FlowTest {
         Flow flow = this.parse("flows/invalids/duplicate.yaml");
         Optional<ConstraintViolationException> validate = modelValidator.isValid(flow);
 
-        assertThat(validate.isPresent()).isTrue();
-        assertThat(validate.get().getConstraintViolations().size()).isEqualTo(1);
+        assertThat(validate).isPresent();
+        assertThat(validate.get().getConstraintViolations()).hasSize(1);
 
         assertThat(validate.get().getMessage()).contains("Duplicate task id with name [date, listen]");
         assertThat(validate.get().getMessage()).contains("Duplicate trigger id with name [trigger]");
@@ -45,8 +45,8 @@ class FlowTest {
         Flow flow = this.parse("flows/invalids/duplicate-inputs.yaml");
         Optional<ConstraintViolationException> validate = modelValidator.isValid(flow);
 
-        assertThat(validate.isPresent()).isTrue();
-        assertThat(validate.get().getConstraintViolations().size()).isEqualTo(1);
+        assertThat(validate).isPresent();
+        assertThat(validate.get().getConstraintViolations()).hasSize(1);
 
         assertThat(validate.get().getMessage()).contains("Duplicate input with name [first_input]");
     }
@@ -56,8 +56,8 @@ class FlowTest {
         Flow flow = this.parse("flows/invalids/duplicate-parallel.yaml");
         Optional<ConstraintViolationException> validate = modelValidator.isValid(flow);
 
-        assertThat(validate.isPresent()).isTrue();
-        assertThat(validate.get().getConstraintViolations().size()).isEqualTo(1);
+        assertThat(validate).isPresent();
+        assertThat(validate.get().getConstraintViolations()).hasSize(1);
 
         assertThat(validate.get().getMessage()).contains("Duplicate task id with name [t3]");
     }
@@ -68,8 +68,8 @@ class FlowTest {
         Flow updated = this.parse("flows/invalids/duplicate.yaml");
         Optional<ConstraintViolationException> validate = flow.validateUpdate(updated);
 
-        assertThat(validate.isPresent()).isTrue();
-        assertThat(validate.get().getConstraintViolations().size()).isEqualTo(1);
+        assertThat(validate).isPresent();
+        assertThat(validate.get().getConstraintViolations()).hasSize(1);
 
         assertThat(validate.get().getMessage()).contains("Illegal flow id update");
     }
@@ -80,8 +80,8 @@ class FlowTest {
         Flow flow = this.parse("flows/invalids/switch-invalid.yaml");
         Optional<ConstraintViolationException> validate = modelValidator.isValid(flow);
 
-        assertThat(validate.isPresent()).isTrue();
-        assertThat(validate.get().getConstraintViolations().size()).isEqualTo(1);
+        assertThat(validate).isPresent();
+        assertThat(validate.get().getConstraintViolations()).hasSize(1);
 
         assertThat(validate.get().getMessage()).contains("impossible: No task defined, neither cases or default have any tasks");
     }
@@ -91,8 +91,8 @@ class FlowTest {
         Flow flow = this.parse("flows/invalids/workingdirectory-invalid.yaml");
         Optional<ConstraintViolationException> validate = modelValidator.isValid(flow);
 
-        assertThat(validate.isPresent()).isTrue();
-        assertThat(validate.get().getConstraintViolations().size()).isEqualTo(1);
+        assertThat(validate).isPresent();
+        assertThat(validate.get().getConstraintViolations()).hasSize(1);
 
         assertThat(validate.get().getMessage()).contains("impossible: Only runnable tasks are allowed as children of a WorkingDirectory task");
     }
@@ -102,8 +102,8 @@ class FlowTest {
         Flow flow = this.parse("flows/invalids/workingdirectory-no-tasks.yaml");
         Optional<ConstraintViolationException> validate = modelValidator.isValid(flow);
 
-        assertThat(validate.isPresent()).isTrue();
-        assertThat(validate.get().getConstraintViolations().size()).isEqualTo(2);
+        assertThat(validate).isPresent();
+        assertThat(validate.get().getConstraintViolations()).hasSize(2);
 
         assertThat(validate.get().getMessage()).contains("impossible: The 'tasks' property cannot be empty");
     }
@@ -129,8 +129,8 @@ class FlowTest {
         Flow flow = this.parse("flows/invalids/worker-group.yaml");
         Optional<ConstraintViolationException> validate = modelValidator.isValid(flow);
 
-        assertThat(validate.isPresent()).isTrue();
-        assertThat(validate.get().getConstraintViolations().size()).isEqualTo(1);
+        assertThat(validate).isPresent();
+        assertThat(validate.get().getConstraintViolations()).hasSize(1);
 
         assertThat(validate.get().getMessage()).isEqualTo("tasks[0].workerGroup: Worker Group is an Enterprise Edition functionality\n");
     }
@@ -140,7 +140,7 @@ class FlowTest {
         Flow flow = this.parse("flows/valids/trigger-flow-listener-no-inputs.yaml");
         List<String> all = flow.allTasksWithChildsAndTriggerIds();
 
-        assertThat(all.size()).isEqualTo(3);
+        assertThat(all).hasSize(3);
     }
 
     @Test
@@ -148,8 +148,8 @@ class FlowTest {
         Flow flow = this.parse("flows/invalids/inputs-validation.yaml");
         Optional<ConstraintViolationException> validate = modelValidator.isValid(flow);
 
-        assertThat(validate.isPresent()).isTrue();
-        assertThat(validate.get().getConstraintViolations().size()).isEqualTo(2);
+        assertThat(validate).isPresent();
+        assertThat(validate.get().getConstraintViolations()).hasSize(2);
 
         assertThat(validate.get().getMessage()).contains("file: no `defaults` can be set for inputs of type 'FILE'");
         assertThat(validate.get().getMessage()).contains("array: `itemType` cannot be `ARRAY");

--- a/core/src/test/java/io/kestra/core/models/hierarchies/FlowGraphTest.java
+++ b/core/src/test/java/io/kestra/core/models/hierarchies/FlowGraphTest.java
@@ -51,9 +51,9 @@ class FlowGraphTest {
         FlowWithSource flow = this.parse("flows/valids/return.yaml");
         FlowGraph flowGraph = GraphUtils.flowGraph(flow, null);
 
-        assertThat(flowGraph.getNodes().size()).isEqualTo(5);
-        assertThat(flowGraph.getEdges().size()).isEqualTo(4);
-        assertThat(flowGraph.getClusters().size()).isZero();
+        assertThat(flowGraph.getNodes()).hasSize(5);
+        assertThat(flowGraph.getEdges()).hasSize(4);
+        assertThat(flowGraph.getClusters()).isEmpty();
 
         assertThat(((AbstractGraphTask) flowGraph.getNodes().get(2)).getTask().getId()).isEqualTo("date");
         assertThat(((AbstractGraphTask) flowGraph.getNodes().get(2)).getRelationType()).isEqualTo(RelationType.SEQUENTIAL);
@@ -69,9 +69,9 @@ class FlowGraphTest {
         FlowWithSource flow = this.parse("flows/valids/sequential.yaml");
         FlowGraph flowGraph = GraphUtils.flowGraph(flow, null);
 
-        assertThat(flowGraph.getNodes().size()).isEqualTo(19);
-        assertThat(flowGraph.getEdges().size()).isEqualTo(18);
-        assertThat(flowGraph.getClusters().size()).isEqualTo(3);
+        assertThat(flowGraph.getNodes()).hasSize(19);
+        assertThat(flowGraph.getEdges()).hasSize(18);
+        assertThat(flowGraph.getClusters()).hasSize(3);
 
         assertThat(edge(flowGraph, ".*1-3-2-1").getTarget()).matches(".*1-3-2-2_end");
         assertThat(edge(flowGraph, ".*1-3-2-1").getRelation().getRelationType()).isEqualTo(RelationType.SEQUENTIAL);
@@ -85,9 +85,9 @@ class FlowGraphTest {
         FlowWithSource flow = this.parse("flows/valids/errors.yaml");
         FlowGraph flowGraph = GraphUtils.flowGraph(flow, null);
 
-        assertThat(flowGraph.getNodes().size()).isEqualTo(17);
-        assertThat(flowGraph.getEdges().size()).isEqualTo(17);
-        assertThat(flowGraph.getClusters().size()).isEqualTo(4);
+        assertThat(flowGraph.getNodes()).hasSize(17);
+        assertThat(flowGraph.getEdges()).hasSize(17);
+        assertThat(flowGraph.getClusters()).hasSize(4);
 
         assertThat(edge(flowGraph, cluster(flowGraph, "root").getStart(), ".*t2").getRelation().getRelationType()).isEqualTo(RelationType.ERROR);
         assertThat(edge(flowGraph, cluster(flowGraph, "root").getStart(), ".*failed").getRelation().getRelationType()).isNull();
@@ -98,9 +98,9 @@ class FlowGraphTest {
         FlowWithSource flow = this.parse("flows/valids/parallel.yaml");
         FlowGraph flowGraph = GraphUtils.flowGraph(flow, null);
 
-        assertThat(flowGraph.getNodes().size()).isEqualTo(12);
-        assertThat(flowGraph.getEdges().size()).isEqualTo(16);
-        assertThat(flowGraph.getClusters().size()).isEqualTo(1);
+        assertThat(flowGraph.getNodes()).hasSize(12);
+        assertThat(flowGraph.getEdges()).hasSize(16);
+        assertThat(flowGraph.getClusters()).hasSize(1);
 
         assertThat(edge(flowGraph, ".*parent", ".*t2").getRelation().getRelationType()).isEqualTo(RelationType.PARALLEL);
         assertThat(edge(flowGraph, ".*parent", ".*t6").getRelation().getRelationType()).isEqualTo(RelationType.PARALLEL);
@@ -115,9 +115,9 @@ class FlowGraphTest {
         FlowWithSource flow = this.parse("flows/valids/parallel-nested.yaml");
         FlowGraph flowGraph = GraphUtils.flowGraph(flow, null);
 
-        assertThat(flowGraph.getNodes().size()).isEqualTo(19);
-        assertThat(flowGraph.getEdges().size()).isEqualTo(23);
-        assertThat(flowGraph.getClusters().size()).isEqualTo(3);
+        assertThat(flowGraph.getNodes()).hasSize(19);
+        assertThat(flowGraph.getEdges()).hasSize(23);
+        assertThat(flowGraph.getClusters()).hasSize(3);
 
         assertThat(edge(flowGraph, ".*1_par", ".*1-4_end").getRelation().getRelationType()).isEqualTo(RelationType.PARALLEL);
         assertThat(edge(flowGraph, ".*1_par", cluster(flowGraph, ".*1-3_par").getStart()).getRelation().getRelationType()).isEqualTo(RelationType.PARALLEL);
@@ -129,9 +129,9 @@ class FlowGraphTest {
         FlowWithSource flow = this.parse("flows/valids/switch.yaml");
         FlowGraph flowGraph = GraphUtils.flowGraph(flow, null);
 
-        assertThat(flowGraph.getNodes().size()).isEqualTo(17);
-        assertThat(flowGraph.getEdges().size()).isEqualTo(20);
-        assertThat(flowGraph.getClusters().size()).isEqualTo(3);
+        assertThat(flowGraph.getNodes()).hasSize(17);
+        assertThat(flowGraph.getEdges()).hasSize(20);
+        assertThat(flowGraph.getClusters()).hasSize(3);
 
         assertThat(edge(flowGraph, ".*parent-seq", ".*parent-seq\\.[^.]*").getRelation().getRelationType()).isEqualTo(RelationType.CHOICE);
         assertThat(edge(flowGraph, ".*parent-seq", ".*parent-seq\\.t3\\.[^.]*").getRelation().getValue()).isEqualTo("THIRD");
@@ -147,9 +147,9 @@ class FlowGraphTest {
         FlowWithSource flow = this.parse("flows/valids/each-sequential-nested.yaml");
         FlowGraph flowGraph = GraphUtils.flowGraph(flow, null);
 
-        assertThat(flowGraph.getNodes().size()).isEqualTo(13);
-        assertThat(flowGraph.getEdges().size()).isEqualTo(12);
-        assertThat(flowGraph.getClusters().size()).isEqualTo(2);
+        assertThat(flowGraph.getNodes()).hasSize(13);
+        assertThat(flowGraph.getEdges()).hasSize(12);
+        assertThat(flowGraph.getClusters()).hasSize(2);
 
         assertThat(edge(flowGraph, ".*1-1_return", cluster(flowGraph, ".*1-2_each").getStart()).getRelation().getRelationType()).isEqualTo(RelationType.DYNAMIC);
         assertThat(edge(flowGraph, ".*1-2_each", ".*1-2-1_return").getRelation().getRelationType()).isEqualTo(RelationType.DYNAMIC);
@@ -160,12 +160,12 @@ class FlowGraphTest {
         FlowWithSource flow = this.parse("flows/valids/each-parallel-nested.yaml");
         FlowGraph flowGraph = GraphUtils.flowGraph(flow, null);
 
-        assertThat(flowGraph.getNodes().size()).isEqualTo(11);
-        assertThat(flowGraph.getEdges().size()).isEqualTo(10);
-        assertThat(flowGraph.getClusters().size()).isEqualTo(2);
+        assertThat(flowGraph.getNodes()).hasSize(11);
+        assertThat(flowGraph.getEdges()).hasSize(10);
+        assertThat(flowGraph.getClusters()).hasSize(2);
 
         assertThat(edge(flowGraph, ".*1_each", cluster(flowGraph, ".*2-1_seq").getStart()).getRelation().getRelationType()).isEqualTo(RelationType.DYNAMIC);
-        assertThat(flowGraph.getClusters().get(1).getNodes().size()).isEqualTo(5);
+        assertThat(flowGraph.getClusters().get(1).getNodes()).hasSize(5);
     }
 
     @Test
@@ -173,9 +173,9 @@ class FlowGraphTest {
         FlowWithSource flow = this.parse("flows/valids/all-flowable.yaml");
         FlowGraph flowGraph = GraphUtils.flowGraph(flow, null);
 
-        assertThat(flowGraph.getNodes().size()).isEqualTo(38);
-        assertThat(flowGraph.getEdges().size()).isEqualTo(42);
-        assertThat(flowGraph.getClusters().size()).isEqualTo(7);
+        assertThat(flowGraph.getNodes()).hasSize(38);
+        assertThat(flowGraph.getEdges()).hasSize(42);
+        assertThat(flowGraph.getClusters()).hasSize(7);
     }
 
     @Test
@@ -184,9 +184,9 @@ class FlowGraphTest {
         FlowWithSource flow = this.parse("flows/valids/parallel.yaml");
         FlowGraph flowGraph = GraphUtils.flowGraph(flow, execution);
 
-        assertThat(flowGraph.getNodes().size()).isEqualTo(12);
-        assertThat(flowGraph.getEdges().size()).isEqualTo(16);
-        assertThat(flowGraph.getClusters().size()).isEqualTo(1);
+        assertThat(flowGraph.getNodes()).hasSize(12);
+        assertThat(flowGraph.getEdges()).hasSize(16);
+        assertThat(flowGraph.getClusters()).hasSize(1);
 
         assertThat(edge(flowGraph, ".*parent", ".*t2").getRelation().getRelationType()).isEqualTo(RelationType.PARALLEL);
         assertThat(edge(flowGraph, ".*parent", ".*t6").getRelation().getRelationType()).isEqualTo(RelationType.PARALLEL);
@@ -204,9 +204,9 @@ class FlowGraphTest {
         FlowWithSource flow = this.parse("flows/valids/each-sequential.yaml");
         FlowGraph flowGraph = GraphUtils.flowGraph(flow, execution);
 
-        assertThat(flowGraph.getNodes().size()).isEqualTo(21);
-        assertThat(flowGraph.getEdges().size()).isEqualTo(22);
-        assertThat(flowGraph.getClusters().size()).isEqualTo(4);
+        assertThat(flowGraph.getNodes()).hasSize(21);
+        assertThat(flowGraph.getEdges()).hasSize(22);
+        assertThat(flowGraph.getClusters()).hasSize(4);
 
         assertThat(edge(flowGraph, ".*1-1_value 1", ".*1-1_value 2").getRelation().getValue()).isEqualTo("value 2");
         assertThat(edge(flowGraph, ".*1-1_value 2", ".*1-1_value 3").getRelation().getValue()).isEqualTo("value 3");
@@ -224,9 +224,9 @@ class FlowGraphTest {
 
         FlowGraph flowGraph = graphService.flowGraph(flow, null);
 
-        assertThat(flowGraph.getNodes().size()).isEqualTo(6);
-        assertThat(flowGraph.getEdges().size()).isEqualTo(5);
-        assertThat(flowGraph.getClusters().size()).isEqualTo(1);
+        assertThat(flowGraph.getNodes()).hasSize(6);
+        assertThat(flowGraph.getEdges()).hasSize(5);
+        assertThat(flowGraph.getClusters()).hasSize(1);
         AbstractGraph triggerGraph = flowGraph.getNodes().stream().filter(e -> e instanceof GraphTrigger).findFirst().orElseThrow();
         assertThat(((GraphTrigger) triggerGraph).getTrigger().getDisabled()).isTrue();
     }
@@ -236,9 +236,9 @@ class FlowGraphTest {
         FlowWithSource flow = this.parse("flows/valids/trigger-flow-listener-no-inputs.yaml");
         FlowGraph flowGraph = GraphUtils.flowGraph(flow, null);
 
-        assertThat(flowGraph.getNodes().size()).isEqualTo(7);
-        assertThat(flowGraph.getEdges().size()).isEqualTo(7);
-        assertThat(flowGraph.getClusters().size()).isEqualTo(1);
+        assertThat(flowGraph.getNodes()).hasSize(7);
+        assertThat(flowGraph.getEdges()).hasSize(7);
+        assertThat(flowGraph.getClusters()).hasSize(1);
     }
 
 
@@ -247,9 +247,9 @@ class FlowGraphTest {
         FlowWithSource flow = this.parse("flows/valids/dag.yaml");
         FlowGraph flowGraph = GraphUtils.flowGraph(flow, null);
 
-        assertThat(flowGraph.getNodes().size()).isEqualTo(11);
-        assertThat(flowGraph.getEdges().size()).isEqualTo(13);
-        assertThat(flowGraph.getClusters().size()).isEqualTo(1);
+        assertThat(flowGraph.getNodes()).hasSize(11);
+        assertThat(flowGraph.getEdges()).hasSize(13);
+        assertThat(flowGraph.getClusters()).hasSize(1);
 
         assertThat(edge(flowGraph, ".*root..*", ".*dag.root..*").getRelation().getRelationType()).isNull();
         assertThat(edge(flowGraph, ".*root.dag.*", ".*dag.task1.*").getRelation().getRelationType()).isEqualTo(RelationType.PARALLEL);
@@ -266,15 +266,15 @@ class FlowGraphTest {
         FlowWithSource flow = this.parse("flows/valids/task-flow.yaml");
         FlowGraph flowGraph = GraphUtils.flowGraph(flow, null);
 
-        assertThat(flowGraph.getNodes().size()).isEqualTo(6);
-        assertThat(flowGraph.getEdges().size()).isEqualTo(5);
-        assertThat(flowGraph.getClusters().size()).isEqualTo(1);
+        assertThat(flowGraph.getNodes()).hasSize(6);
+        assertThat(flowGraph.getEdges()).hasSize(5);
+        assertThat(flowGraph.getClusters()).hasSize(1);
 
         flowGraph = graphService.flowGraph(flow, Collections.singletonList("root.launch"));
 
-        assertThat(flowGraph.getNodes().size()).isEqualTo(23);
-        assertThat(flowGraph.getEdges().size()).isEqualTo(26);
-        assertThat(flowGraph.getClusters().size()).isEqualTo(5);
+        assertThat(flowGraph.getNodes()).hasSize(23);
+        assertThat(flowGraph.getEdges()).hasSize(26);
+        assertThat(flowGraph.getClusters()).hasSize(5);
 
         assertThat(((SubflowGraphTask) ((SubflowGraphCluster) cluster(flowGraph, "root\\.launch").getCluster()).getTaskNode()).executableTask().subflowId().flowId()).isEqualTo("switch");
         SubflowGraphTask subflowGraphTask = (SubflowGraphTask) nodeByUid(flowGraph, "root.launch");
@@ -306,9 +306,9 @@ class FlowGraphTest {
         ));
         FlowGraph flowGraph = graphService.flowGraph(flow, Collections.singletonList("root.launch"), execution);
 
-        assertThat(flowGraph.getNodes().size()).isEqualTo(20);
-        assertThat(flowGraph.getEdges().size()).isEqualTo(23);
-        assertThat(flowGraph.getClusters().size()).isEqualTo(4);
+        assertThat(flowGraph.getNodes()).hasSize(20);
+        assertThat(flowGraph.getEdges()).hasSize(23);
+        assertThat(flowGraph.getClusters()).hasSize(4);
     }
 
     @Test
@@ -316,9 +316,9 @@ class FlowGraphTest {
         FlowWithSource flow = this.parse("flows/valids/finally-sequential.yaml");
         FlowGraph flowGraph = GraphUtils.flowGraph(flow, null);
 
-        assertThat(flowGraph.getNodes().size()).isEqualTo(13);
-        assertThat(flowGraph.getEdges().size()).isEqualTo(13);
-        assertThat(flowGraph.getClusters().size()).isEqualTo(2);
+        assertThat(flowGraph.getNodes()).hasSize(13);
+        assertThat(flowGraph.getEdges()).hasSize(13);
+        assertThat(flowGraph.getClusters()).hasSize(2);
 
         assertThat(edge(flowGraph, ".*seq.finally.*", ".*seq.a1").getRelation().getRelationType()).isEqualTo(RelationType.SEQUENTIAL);
         assertThat(edge(flowGraph, ".*seq.a1", ".*seq.a2").getRelation().getRelationType()).isEqualTo(RelationType.FINALLY);
@@ -330,9 +330,9 @@ class FlowGraphTest {
         FlowWithSource flow = this.parse("flows/valids/finally-sequential-error.yaml");
         FlowGraph flowGraph = GraphUtils.flowGraph(flow, null);
 
-        assertThat(flowGraph.getNodes().size()).isEqualTo(15);
-        assertThat(flowGraph.getEdges().size()).isEqualTo(16);
-        assertThat(flowGraph.getClusters().size()).isEqualTo(2);
+        assertThat(flowGraph.getNodes()).hasSize(15);
+        assertThat(flowGraph.getEdges()).hasSize(16);
+        assertThat(flowGraph.getClusters()).hasSize(2);
 
         assertThat(edge(flowGraph, ".*seq.e1", ".*seq.e2").getRelation().getRelationType()).isEqualTo(RelationType.ERROR);
         assertThat(edge(flowGraph, ".*seq.e2", ".*seq.finally.*").getRelation().getRelationType()).isNull();
@@ -346,9 +346,9 @@ class FlowGraphTest {
         FlowWithSource flow = this.parse("flows/valids/finally-dag.yaml");
         FlowGraph flowGraph = GraphUtils.flowGraph(flow, null);
 
-        assertThat(flowGraph.getNodes().size()).isEqualTo(17);
-        assertThat(flowGraph.getEdges().size()).isEqualTo(18);
-        assertThat(flowGraph.getClusters().size()).isEqualTo(2);
+        assertThat(flowGraph.getNodes()).hasSize(17);
+        assertThat(flowGraph.getEdges()).hasSize(18);
+        assertThat(flowGraph.getClusters()).hasSize(2);
 
         assertThat(edge(flowGraph, ".*dag.e1", ".*dag.e2").getRelation().getRelationType()).isEqualTo(RelationType.ERROR);
         assertThat(edge(flowGraph, ".*dag.e2", ".*dag.finally.*").getRelation().getRelationType()).isNull();
@@ -363,8 +363,8 @@ class FlowGraphTest {
         FlowWithSource flow = this.parse("flows/valids/after-execution.yaml");
         FlowGraph flowGraph = GraphUtils.flowGraph(flow, null);
 
-        assertThat(flowGraph.getNodes().size()).isEqualTo(5);
-        assertThat(flowGraph.getEdges().size()).isEqualTo(4);
+        assertThat(flowGraph.getNodes()).hasSize(5);
+        assertThat(flowGraph.getEdges()).hasSize(4);
 
         assertThat(edge(flowGraph, "root.root.*", "root.hello.*")).isNotNull();
         assertThat(edge(flowGraph, "root.hello.*", "root.after-execution.*")).isNotNull();

--- a/core/src/test/java/io/kestra/core/models/property/DynamicPropertyExampleTask.java
+++ b/core/src/test/java/io/kestra/core/models/property/DynamicPropertyExampleTask.java
@@ -57,8 +57,7 @@ public class DynamicPropertyExampleTask extends Task implements RunnableTask<Dyn
 
     @Override
     public Output run(RunContext runContext) throws Exception {
-        String value = String.format(
-            "%s - %s - %s - %s",
+        String value = "%s - %s - %s - %s".formatted(
             runContext.render(string).as(String.class).orElse(null),
             runContext.render(number).as(Integer.class).orElse(null),
             runContext.render(withDefault).as(String.class).orElse(null),

--- a/core/src/test/java/io/kestra/core/models/property/PropertyTest.java
+++ b/core/src/test/java/io/kestra/core/models/property/PropertyTest.java
@@ -78,8 +78,8 @@ class PropertyTest {
         assertThat(output.getLevel()).isEqualTo(Level.INFO);
         assertThat(output.getList()).containsExactlyInAnyOrder("item1", "item2");
         assertThat(output.getMap()).hasSize(2);
-        assertThat(output.getMap().get("key1")).isEqualTo("value1");
-        assertThat(output.getMap().get("key2")).isEqualTo("value2");
+        assertThat(output.getMap()).containsEntry("key1", "value1");
+        assertThat(output.getMap()).containsEntry("key2", "value2");
         assertThat(output.getMessages()).hasSize(1);
         assertThat(output.getMessages().getFirst().getKey()).isEqualTo("mapKey");
         assertThat(output.getMessages().getFirst().getValue()).isEqualTo("mapValue");
@@ -136,8 +136,8 @@ class PropertyTest {
         assertThat(output.getLevel()).isEqualTo(Level.INFO);
         assertThat(output.getList()).containsExactlyInAnyOrder("item1", "item2");
         assertThat(output.getMap()).hasSize(2);
-        assertThat(output.getMap().get("key1")).isEqualTo("value1");
-        assertThat(output.getMap().get("key2")).isEqualTo("value2");
+        assertThat(output.getMap()).containsEntry("key1", "value1");
+        assertThat(output.getMap()).containsEntry("key2", "value2");
         assertThat(output.getMessages()).hasSize(2);
         assertThat(output.getMessages().getFirst().getKey()).isEqualTo("mapKey1");
         assertThat(output.getMessages().getFirst().getValue()).isEqualTo("mapValue1");
@@ -193,8 +193,8 @@ class PropertyTest {
         assertThat(output.getLevel()).isEqualTo(Level.INFO);
         assertThat(output.getList()).containsExactlyInAnyOrder("item1", "item2");
         assertThat(output.getMap()).hasSize(2);
-        assertThat(output.getMap().get("key1")).isEqualTo("value1");
-        assertThat(output.getMap().get("key2")).isEqualTo("value2");
+        assertThat(output.getMap()).containsEntry("key1", "value1");
+        assertThat(output.getMap()).containsEntry("key2", "value2");
         assertThat(output.getMessages()).hasSize(2);
         assertThat(output.getMessages().getFirst().getKey()).isEqualTo("key1");
         assertThat(output.getMessages().getFirst().getValue()).isEqualTo("value1");
@@ -264,7 +264,7 @@ class PropertyTest {
         ));
 
         var exception = assertThrows(ConstraintViolationException.class, () -> task.run(runContext));
-        assertThat(exception.getConstraintViolations().size()).isEqualTo(1);
+        assertThat(exception.getConstraintViolations()).hasSize(1);
         assertThat(exception.getMessage()).isEqualTo("number: must be greater than or equal to 0");
     }
 
@@ -293,8 +293,8 @@ class PropertyTest {
         assertThat(output).isNotNull();
         assertThat(output.getList()).containsExactlyInAnyOrder("arrayValue1", "arrayValue2");
         assertThat(output.getMap()).hasSize(2);
-        assertThat(output.getMap().get("mapKey1")).isEqualTo("mapValue1");
-        assertThat(output.getMap().get("mapKey2")).isEqualTo("mapValue2");
+        assertThat(output.getMap()).containsEntry("mapKey1", "mapValue1");
+        assertThat(output.getMap()).containsEntry("mapKey2", "mapValue2");
     }
 
     @Test

--- a/core/src/test/java/io/kestra/core/models/tasks/runners/ScriptServiceTest.java
+++ b/core/src/test/java/io/kestra/core/models/tasks/runners/ScriptServiceTest.java
@@ -34,7 +34,7 @@ class ScriptServiceTest {
     void replaceInternalStorage() throws IOException {
         var runContext = runContextFactory.of();
         var command  = ScriptService.replaceInternalStorage(runContext, null, false);
-        assertThat(command).isEqualTo("");
+        assertThat(command).isEmpty();
 
         command = ScriptService.replaceInternalStorage(runContext, "my command", false);
         assertThat(command).isEqualTo("my command");
@@ -53,14 +53,14 @@ class ScriptServiceTest {
             assertThat(matcher.matches()).isTrue();
             Path absoluteLocalFilePath = Path.of(matcher.group(1));
             localFile = absoluteLocalFilePath.toFile();
-            assertThat(localFile.exists()).isTrue();
+            assertThat(localFile).exists();
 
             command = ScriptService.replaceInternalStorage(runContext, "my command with an internal storage file: " + internalStorageUri, true);
             matcher = COMMAND_PATTERN_CAPTURE_LOCAL_PATH.matcher(command);
             assertThat(matcher.matches()).isTrue();
             String relativePath = matcher.group(1);
             assertThat(relativePath).doesNotStartWith("/");
-            assertThat(runContext.workingDir().resolve(Path.of(relativePath)).toFile().exists()).isTrue();
+            assertThat(runContext.workingDir().resolve(Path.of(relativePath)).toFile()).exists();
         } finally {
             localFile.delete();
             path.toFile().delete();
@@ -96,7 +96,7 @@ class ScriptServiceTest {
             Matcher matcher = COMMAND_PATTERN_CAPTURE_LOCAL_PATH.matcher(commands.getFirst());
             assertThat(matcher.matches()).isTrue();
             File file = Path.of(matcher.group(1)).toFile();
-            assertThat(file.exists()).isTrue();
+            assertThat(file).exists();
             filesToDelete.add(file);
 
             assertThat(commands.get(1)).isEqualTo("my command with some additional var usage: " + wdir);
@@ -105,7 +105,7 @@ class ScriptServiceTest {
             matcher = COMMAND_PATTERN_CAPTURE_LOCAL_PATH.matcher(commands.getFirst());
             assertThat(matcher.matches()).isTrue();
             file = runContext.workingDir().resolve(Path.of(matcher.group(1))).toFile();
-            assertThat(file.exists()).isTrue();
+            assertThat(file).exists();
             filesToDelete.add(file);
         } catch (IllegalVariableEvaluationException e) {
             throw new RuntimeException(e);
@@ -125,7 +125,7 @@ class ScriptServiceTest {
 
         var outputFiles = ScriptService.uploadOutputFiles(runContext, Path.of("/tmp/unittest"));
         assertThat(outputFiles, not(anEmptyMap()));
-        assertThat(outputFiles.get("file.txt")).isEqualTo(URI.create("kestra:///file.txt"));
+        assertThat(outputFiles).containsEntry("file.txt", URI.create("kestra:///file.txt"));
 
         path.toFile().delete();
     }
@@ -143,22 +143,22 @@ class ScriptServiceTest {
         var runContext = runContext(runContextFactory, "very.very.very.very.very.very.very.very.very.very.very.very.long.namespace");
 
         var labels = ScriptService.labels(runContext, "kestra.io/");
-        assertThat(labels.size()).isEqualTo(6);
-        assertThat(labels.get("kestra.io/namespace")).isEqualTo("very.very.very.very.very.very.very.very.very.very.very.very.lon");
-        assertThat(labels.get("kestra.io/flow-id")).isEqualTo("flowId");
-        assertThat(labels.get("kestra.io/task-id")).isEqualTo("task");
-        assertThat(labels.get("kestra.io/execution-id")).isEqualTo("executionId");
-        assertThat(labels.get("kestra.io/taskrun-id")).isEqualTo("taskrun");
-        assertThat(labels.get("kestra.io/taskrun-attempt")).isEqualTo("0");
+        assertThat(labels).hasSize(6);
+        assertThat(labels).containsEntry("kestra.io/namespace", "very.very.very.very.very.very.very.very.very.very.very.very.lon");
+        assertThat(labels).containsEntry("kestra.io/flow-id", "flowId");
+        assertThat(labels).containsEntry("kestra.io/task-id", "task");
+        assertThat(labels).containsEntry("kestra.io/execution-id", "executionId");
+        assertThat(labels).containsEntry("kestra.io/taskrun-id", "taskrun");
+        assertThat(labels).containsEntry("kestra.io/taskrun-attempt", "0");
 
         labels = ScriptService.labels(runContext, null, true, true);
-        assertThat(labels.size()).isEqualTo(6);
-        assertThat(labels.get("namespace")).isEqualTo("very.very.very.very.very.very.very.very.very.very.very.very.lon");
-        assertThat(labels.get("flow-id")).isEqualTo("flowid");
-        assertThat(labels.get("task-id")).isEqualTo("task");
-        assertThat(labels.get("execution-id")).isEqualTo("executionid");
-        assertThat(labels.get("taskrun-id")).isEqualTo("taskrun");
-        assertThat(labels.get("taskrun-attempt")).isEqualTo("0");
+        assertThat(labels).hasSize(6);
+        assertThat(labels).containsEntry("namespace", "very.very.very.very.very.very.very.very.very.very.very.very.lon");
+        assertThat(labels).containsEntry("flow-id", "flowid");
+        assertThat(labels).containsEntry("task-id", "task");
+        assertThat(labels).containsEntry("execution-id", "executionid");
+        assertThat(labels).containsEntry("taskrun-id", "taskrun");
+        assertThat(labels).containsEntry("taskrun-attempt", "0");
     }
 
     @Test
@@ -166,12 +166,12 @@ class ScriptServiceTest {
         var runContext = runContext(runContextFactory, "namespace");
         String jobName = ScriptService.jobName(runContext);
         assertThat(jobName).startsWith("namespace-flowid-task-");
-        assertThat(jobName.length()).isEqualTo(27);
+        assertThat(jobName).hasSize(27);
 
         runContext = runContext(runContextFactory, "very.very.very.very.very.very.very.very.very.very.very.very.long.namespace");
         jobName = ScriptService.jobName(runContext);
         assertThat(jobName).startsWith("veryveryveryveryveryveryveryveryveryveryveryverylongnames-");
-        assertThat(jobName.length()).isEqualTo(63);
+        assertThat(jobName).hasSize(63);
     }
 
     @Test

--- a/core/src/test/java/io/kestra/core/models/triggers/multipleflows/AbstractMultipleConditionStorageTest.java
+++ b/core/src/test/java/io/kestra/core/models/triggers/multipleflows/AbstractMultipleConditionStorageTest.java
@@ -26,9 +26,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 public abstract class AbstractMultipleConditionStorageTest {
     private static final String NAMESPACE = "io.kestra.unit";
 
-    abstract protected MultipleConditionStorageInterface multipleConditionStorage();
+    protected abstract MultipleConditionStorageInterface multipleConditionStorage();
 
-    abstract protected void save(MultipleConditionStorageInterface multipleConditionStorage, Flow flow, List<MultipleConditionWindow> multipleConditionWindows);
+    protected abstract void save(MultipleConditionStorageInterface multipleConditionStorage, Flow flow, List<MultipleConditionWindow> multipleConditionWindows);
 
     @Test
     void allDefault() {
@@ -147,12 +147,12 @@ public abstract class AbstractMultipleConditionStorageTest {
         assertThat(window.getResults().get("a")).isTrue();
 
         List<MultipleConditionWindow> expired = multipleConditionStorage.expired(null);
-        assertThat(expired.size()).isZero();
+        assertThat(expired).isEmpty();
 
         Thread.sleep(2005);
 
         expired = multipleConditionStorage.expired(null);
-        assertThat(expired.size()).isEqualTo(1);
+        assertThat(expired).hasSize(1);
     }
 
     @Test
@@ -169,12 +169,12 @@ public abstract class AbstractMultipleConditionStorageTest {
         assertThat(window.getResults().get("a")).isTrue();
 
         List<MultipleConditionWindow> expired = multipleConditionStorage.expired(null);
-        assertThat(expired.size()).isZero();
+        assertThat(expired).isEmpty();
 
         Thread.sleep(2005);
 
         expired = multipleConditionStorage.expired(null);
-        assertThat(expired.size()).isEqualTo(1);
+        assertThat(expired).hasSize(1);
     }
 
     @Test
@@ -191,7 +191,7 @@ public abstract class AbstractMultipleConditionStorageTest {
         assertThat(window.getResults()).isEmpty();
 
         List<MultipleConditionWindow> expired = multipleConditionStorage.expired(null);
-        assertThat(expired.size()).isEqualTo(1);
+        assertThat(expired).hasSize(1);
     }
 
     @Test
@@ -209,7 +209,7 @@ public abstract class AbstractMultipleConditionStorageTest {
         assertThat(window.getResults().get("a")).isTrue();
 
         List<MultipleConditionWindow> expired = multipleConditionStorage.expired(null);
-        assertThat(expired.size()).isZero();
+        assertThat(expired).isEmpty();
     }
 
     @Test
@@ -226,7 +226,7 @@ public abstract class AbstractMultipleConditionStorageTest {
         assertThat(window.getResults().get("a")).isTrue();
 
         List<MultipleConditionWindow> expired = multipleConditionStorage.expired(null);
-        assertThat(expired.size()).isZero();
+        assertThat(expired).isEmpty();
     }
 
     private static Pair<Flow, MultipleCondition> mockFlow(TimeWindow sla) {

--- a/core/src/test/java/io/kestra/core/plugins/AdditionalPluginTest.java
+++ b/core/src/test/java/io/kestra/core/plugins/AdditionalPluginTest.java
@@ -26,8 +26,8 @@ class AdditionalPluginTest {
         assertThat(execution).isNotNull();
         assertThat(execution.getState().isSuccess()).isTrue();
         assertThat(execution.getTaskRunList()).hasSize(2);
-        assertThat(execution.getTaskRunList().getFirst().getOutputs().get("output")).isEqualTo("1 -> Hello");
-        assertThat(execution.getTaskRunList().get(1).getOutputs().get("output")).isEqualTo("Hello World!");
+        assertThat(execution.getTaskRunList().getFirst().getOutputs()).containsEntry("output", "1 -> Hello");
+        assertThat(execution.getTaskRunList().get(1).getOutputs()).containsEntry("output", "Hello World!");
     }
 
     @SuperBuilder
@@ -61,7 +61,7 @@ class AdditionalPluginTest {
     // IMPORTANT: The abstract plugin base class must define using the PluginDeserializer,
     // AND concrete subclasses must be annotated by @JsonDeserialize() to avoid StackOverflow.
     @JsonDeserialize(using = PluginDeserializer.class)
-    public static abstract class BaseAdditionalPluginTest extends AdditionalPlugin {
+    public abstract static class BaseAdditionalPluginTest extends AdditionalPlugin {
         public abstract String sayHello();
     }
 

--- a/core/src/test/java/io/kestra/core/plugins/PluginScannerTest.java
+++ b/core/src/test/java/io/kestra/core/plugins/PluginScannerTest.java
@@ -4,7 +4,6 @@ import org.junit.jupiter.api.Test;
 
 import java.net.URISyntaxException;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.List;
 import java.util.Objects;
 
@@ -13,12 +12,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 class PluginScannerTest {
     @Test
     void scanPlugins() throws URISyntaxException {
-        Path plugins = Paths.get(Objects.requireNonNull(PluginScannerTest.class.getClassLoader().getResource("plugins")).toURI());
+        Path plugins = Path.of(Objects.requireNonNull(PluginScannerTest.class.getClassLoader().getResource("plugins")).toURI());
 
         PluginScanner pluginScanner = new PluginScanner(PluginScannerTest.class.getClassLoader());
         List<RegisteredPlugin> scan = pluginScanner.scan(plugins);
 
-        assertThat(scan.size()).isEqualTo(1);
+        assertThat(scan).hasSize(1);
         assertThat(scan.getFirst().getManifest().getMainAttributes().getValue("X-Kestra-Group")).isEqualTo("io.kestra.plugin.templates");
     }
 

--- a/core/src/test/java/io/kestra/core/repositories/AbstractExecutionRepositoryTest.java
+++ b/core/src/test/java/io/kestra/core/repositories/AbstractExecutionRepositoryTest.java
@@ -147,7 +147,7 @@ public abstract class AbstractExecutionRepositoryTest {
 
         ArrayListTotal<Execution> executions = executionRepository.find(Pageable.from(1, 10),  null, null);
         assertThat(executions.getTotal()).isEqualTo(28L);
-        assertThat(executions.size()).isEqualTo(10);
+        assertThat(executions).hasSize(10);
 
         List<QueryFilter> filters = List.of(QueryFilter.builder()
                 .field(QueryFilter.Field.STATE)
@@ -227,8 +227,8 @@ public abstract class AbstractExecutionRepositoryTest {
             .build());
         ArrayListTotal<Execution> executions = executionRepository.find(Pageable.from(1, 10), null, filters);
         assertThat(executions.getTotal()).isEqualTo(28L);
-        assertThat(executions.size()).isEqualTo(10);
-        assertThat(executions.getFirst().getTrigger().getVariables().get("executionId")).isEqualTo(executionTriggerId);
+        assertThat(executions).hasSize(10);
+        assertThat(executions.getFirst().getTrigger().getVariables()).containsEntry("executionId", executionTriggerId);
         filters = List.of(QueryFilter.builder()
             .field(QueryFilter.Field.CHILD_FILTER)
             .operation(QueryFilter.Op.EQUALS)
@@ -237,8 +237,8 @@ public abstract class AbstractExecutionRepositoryTest {
 
         executions = executionRepository.find(Pageable.from(1, 10),  null, filters);
         assertThat(executions.getTotal()).isEqualTo(28L);
-        assertThat(executions.size()).isEqualTo(10);
-        assertThat(executions.getFirst().getTrigger().getVariables().get("executionId")).isEqualTo(executionTriggerId);
+        assertThat(executions).hasSize(10);
+        assertThat(executions.getFirst().getTrigger().getVariables()).containsEntry("executionId", executionTriggerId);
 
         filters = List.of(QueryFilter.builder()
             .field(QueryFilter.Field.CHILD_FILTER)
@@ -248,7 +248,7 @@ public abstract class AbstractExecutionRepositoryTest {
 
         executions = executionRepository.find(Pageable.from(1, 10),  null, filters );
         assertThat(executions.getTotal()).isEqualTo(28L);
-        assertThat(executions.size()).isEqualTo(10);
+        assertThat(executions).hasSize(10);
         assertThat(executions.getFirst().getTrigger()).isNull();
 
         executions = executionRepository.find(Pageable.from(1, 10),  null,null);
@@ -261,7 +261,7 @@ public abstract class AbstractExecutionRepositoryTest {
 
         ArrayListTotal<Execution> executions = executionRepository.find(Pageable.from(1, 10, Sort.of(Sort.Order.desc("id"))),  null, null);
         assertThat(executions.getTotal()).isEqualTo(28L);
-        assertThat(executions.size()).isEqualTo(10);
+        assertThat(executions).hasSize(10);
 
         var filters = List.of(QueryFilter.builder()
             .field(QueryFilter.Field.STATE)
@@ -278,7 +278,7 @@ public abstract class AbstractExecutionRepositoryTest {
 
         ArrayListTotal<TaskRun> taskRuns = executionRepository.findTaskRun(Pageable.from(1, 10), null, null);
         assertThat(taskRuns.getTotal()).isEqualTo(71L);
-        assertThat(taskRuns.size()).isEqualTo(10);
+        assertThat(taskRuns).hasSize(10);
 
         var filters = List.of(QueryFilter.builder()
             .field(QueryFilter.Field.LABELS)
@@ -288,7 +288,7 @@ public abstract class AbstractExecutionRepositoryTest {
 
         taskRuns = executionRepository.findTaskRun(Pageable.from(1, 10), null, filters);
         assertThat(taskRuns.getTotal()).isEqualTo(1L);
-        assertThat(taskRuns.size()).isEqualTo(1);
+        assertThat(taskRuns).hasSize(1);
     }
 
 
@@ -297,7 +297,7 @@ public abstract class AbstractExecutionRepositoryTest {
         executionRepository.save(ExecutionFixture.EXECUTION_1);
 
         Optional<Execution> full = executionRepository.findById(null, ExecutionFixture.EXECUTION_1.getId());
-        assertThat(full.isPresent()).isTrue();
+        assertThat(full).isPresent();
 
         full.ifPresent(current -> {
             assertThat(full.get().getId()).isEqualTo(ExecutionFixture.EXECUTION_1.getId());
@@ -309,12 +309,12 @@ public abstract class AbstractExecutionRepositoryTest {
         executionRepository.save(ExecutionFixture.EXECUTION_1);
 
         Optional<Execution> full = executionRepository.findById(null, ExecutionFixture.EXECUTION_1.getId());
-        assertThat(full.isPresent()).isTrue();
+        assertThat(full).isPresent();
 
         executionRepository.purge(ExecutionFixture.EXECUTION_1);
 
         full = executionRepository.findById(null, ExecutionFixture.EXECUTION_1.getId());
-        assertThat(full.isPresent()).isFalse();
+        assertThat(full).isNotPresent();
     }
 
     @Test
@@ -322,12 +322,12 @@ public abstract class AbstractExecutionRepositoryTest {
         executionRepository.save(ExecutionFixture.EXECUTION_1);
 
         Optional<Execution> full = executionRepository.findById(null, ExecutionFixture.EXECUTION_1.getId());
-        assertThat(full.isPresent()).isTrue();
+        assertThat(full).isPresent();
 
         executionRepository.delete(ExecutionFixture.EXECUTION_1);
 
         full = executionRepository.findById(null, ExecutionFixture.EXECUTION_1.getId());
-        assertThat(full.isPresent()).isFalse();
+        assertThat(full).isNotPresent();
     }
 
     @Test
@@ -337,7 +337,7 @@ public abstract class AbstractExecutionRepositoryTest {
 
         ArrayListTotal<Execution> page1 = executionRepository.findByFlowId(null, NAMESPACE, FLOW, Pageable.from(1, 10));
 
-        assertThat(page1.size()).isEqualTo(2);
+        assertThat(page1).hasSize(2);
     }
 
     @Test
@@ -363,23 +363,23 @@ public abstract class AbstractExecutionRepositoryTest {
             false
         );
 
-        assertThat(result.size()).isEqualTo(1);
-        assertThat(result.get("io.kestra.unittest").size()).isEqualTo(2);
+        assertThat(result).hasSize(1);
+        assertThat(result.get("io.kestra.unittest")).hasSize(2);
 
         DailyExecutionStatistics full = result.get("io.kestra.unittest").get(FLOW).get(10);
         DailyExecutionStatistics second = result.get("io.kestra.unittest").get("second").get(10);
 
         assertThat(full.getDuration().getAvg().toMillis()).isGreaterThan(0L);
-        assertThat(full.getExecutionCounts().size()).isEqualTo(11);
-        assertThat(full.getExecutionCounts().get(State.Type.FAILED)).isEqualTo(3L);
-        assertThat(full.getExecutionCounts().get(State.Type.RUNNING)).isEqualTo(5L);
-        assertThat(full.getExecutionCounts().get(State.Type.SUCCESS)).isEqualTo(7L);
-        assertThat(full.getExecutionCounts().get(State.Type.CREATED)).isEqualTo(0L);
+        assertThat(full.getExecutionCounts()).hasSize(11);
+        assertThat(full.getExecutionCounts()).containsEntry(State.Type.FAILED, 3L);
+        assertThat(full.getExecutionCounts()).containsEntry(State.Type.RUNNING, 5L);
+        assertThat(full.getExecutionCounts()).containsEntry(State.Type.SUCCESS, 7L);
+        assertThat(full.getExecutionCounts()).containsEntry(State.Type.CREATED, 0L);
 
         assertThat(second.getDuration().getAvg().toMillis()).isGreaterThan(0L);
-        assertThat(second.getExecutionCounts().size()).isEqualTo(11);
-        assertThat(second.getExecutionCounts().get(State.Type.SUCCESS)).isEqualTo(13L);
-        assertThat(second.getExecutionCounts().get(State.Type.CREATED)).isEqualTo(0L);
+        assertThat(second.getExecutionCounts()).hasSize(11);
+        assertThat(second.getExecutionCounts()).containsEntry(State.Type.SUCCESS, 13L);
+        assertThat(second.getExecutionCounts()).containsEntry(State.Type.CREATED, 0L);
 
         result = executionRepository.dailyGroupByFlowStatistics(
             null,
@@ -392,15 +392,15 @@ public abstract class AbstractExecutionRepositoryTest {
             true
         );
 
-        assertThat(result.size()).isEqualTo(1);
-        assertThat(result.get("io.kestra.unittest").size()).isEqualTo(1);
+        assertThat(result).hasSize(1);
+        assertThat(result.get("io.kestra.unittest")).hasSize(1);
         full = result.get("io.kestra.unittest").get("*").get(10);
         assertThat(full.getDuration().getAvg().toMillis()).isGreaterThan(0L);
-        assertThat(full.getExecutionCounts().size()).isEqualTo(11);
-        assertThat(full.getExecutionCounts().get(State.Type.FAILED)).isEqualTo(3L);
-        assertThat(full.getExecutionCounts().get(State.Type.RUNNING)).isEqualTo(5L);
-        assertThat(full.getExecutionCounts().get(State.Type.SUCCESS)).isEqualTo(20L);
-        assertThat(full.getExecutionCounts().get(State.Type.CREATED)).isEqualTo(0L);
+        assertThat(full.getExecutionCounts()).hasSize(11);
+        assertThat(full.getExecutionCounts()).containsEntry(State.Type.FAILED, 3L);
+        assertThat(full.getExecutionCounts()).containsEntry(State.Type.RUNNING, 5L);
+        assertThat(full.getExecutionCounts()).containsEntry(State.Type.SUCCESS, 20L);
+        assertThat(full.getExecutionCounts()).containsEntry(State.Type.CREATED, 0L);
 
         result = executionRepository.dailyGroupByFlowStatistics(
             null,
@@ -413,9 +413,9 @@ public abstract class AbstractExecutionRepositoryTest {
             false
         );
 
-        assertThat(result.size()).isEqualTo(1);
-        assertThat(result.get("io.kestra.unittest").size()).isEqualTo(1);
-        assertThat(result.get("io.kestra.unittest").get(FLOW).size()).isEqualTo(11);
+        assertThat(result).hasSize(1);
+        assertThat(result.get("io.kestra.unittest")).hasSize(1);
+        assertThat(result.get("io.kestra.unittest").get(FLOW)).hasSize(11);
     }
 
     @Test
@@ -478,7 +478,7 @@ public abstract class AbstractExecutionRepositoryTest {
                 )
         );
 
-        assertThat(result.size()).isEqualTo(2);
+        assertThat(result).hasSize(2);
         assertThat(result)
             .extracting(
                 r -> r.getState().getCurrent(),
@@ -519,13 +519,13 @@ public abstract class AbstractExecutionRepositoryTest {
             null,
             false);
 
-        assertThat(result.size()).isEqualTo(11);
-        assertThat(result.get(10).getExecutionCounts().size()).isEqualTo(11);
+        assertThat(result).hasSize(11);
+        assertThat(result.get(10).getExecutionCounts()).hasSize(11);
         assertThat(result.get(10).getDuration().getAvg().toMillis()).isGreaterThan(0L);
 
-        assertThat(result.get(10).getExecutionCounts().get(State.Type.FAILED)).isEqualTo(3L);
-        assertThat(result.get(10).getExecutionCounts().get(State.Type.RUNNING)).isEqualTo(5L);
-        assertThat(result.get(10).getExecutionCounts().get(State.Type.SUCCESS)).isEqualTo(21L);
+        assertThat(result.get(10).getExecutionCounts()).containsEntry(State.Type.FAILED, 3L);
+        assertThat(result.get(10).getExecutionCounts()).containsEntry(State.Type.RUNNING, 5L);
+        assertThat(result.get(10).getExecutionCounts()).containsEntry(State.Type.SUCCESS, 21L);
 
         result = executionRepository.dailyStatistics(
             null,
@@ -539,8 +539,8 @@ public abstract class AbstractExecutionRepositoryTest {
             null,
             false);
 
-        assertThat(result.size()).isEqualTo(11);
-        assertThat(result.get(10).getExecutionCounts().get(State.Type.SUCCESS)).isEqualTo(21L);
+        assertThat(result).hasSize(11);
+        assertThat(result.get(10).getExecutionCounts()).containsEntry(State.Type.SUCCESS, 21L);
 
         result = executionRepository.dailyStatistics(
             null,
@@ -553,8 +553,8 @@ public abstract class AbstractExecutionRepositoryTest {
             null,
             null,
             false);
-        assertThat(result.size()).isEqualTo(11);
-        assertThat(result.get(10).getExecutionCounts().get(State.Type.SUCCESS)).isEqualTo(20L);
+        assertThat(result).hasSize(11);
+        assertThat(result.get(10).getExecutionCounts()).containsEntry(State.Type.SUCCESS, 20L);
 
         result = executionRepository.dailyStatistics(
             null,
@@ -567,8 +567,8 @@ public abstract class AbstractExecutionRepositoryTest {
             null,
             null,
             false);
-        assertThat(result.size()).isEqualTo(11);
-        assertThat(result.get(10).getExecutionCounts().get(State.Type.SUCCESS)).isEqualTo(1L);
+        assertThat(result).hasSize(11);
+        assertThat(result.get(10).getExecutionCounts()).containsEntry(State.Type.SUCCESS, 1L);
     }
 
     @Test
@@ -597,13 +597,13 @@ public abstract class AbstractExecutionRepositoryTest {
             null,
             true);
 
-        assertThat(result.size()).isEqualTo(11);
-        assertThat(result.get(10).getExecutionCounts().size()).isEqualTo(11);
+        assertThat(result).hasSize(11);
+        assertThat(result.get(10).getExecutionCounts()).hasSize(11);
         assertThat(result.get(10).getDuration().getAvg().toMillis()).isGreaterThan(0L);
 
-        assertThat(result.get(10).getExecutionCounts().get(State.Type.FAILED)).isEqualTo(3L * 2);
-        assertThat(result.get(10).getExecutionCounts().get(State.Type.RUNNING)).isEqualTo(5L * 2);
-        assertThat(result.get(10).getExecutionCounts().get(State.Type.SUCCESS)).isEqualTo(57L);
+        assertThat(result.get(10).getExecutionCounts()).containsEntry(State.Type.FAILED, 3L * 2);
+        assertThat(result.get(10).getExecutionCounts()).containsEntry(State.Type.RUNNING, 5L * 2);
+        assertThat(result.get(10).getExecutionCounts()).containsEntry(State.Type.SUCCESS, 57L);
 
         result = executionRepository.dailyStatistics(
             null,
@@ -617,8 +617,8 @@ public abstract class AbstractExecutionRepositoryTest {
             null,
             true);
 
-        assertThat(result.size()).isEqualTo(11);
-        assertThat(result.get(10).getExecutionCounts().get(State.Type.SUCCESS)).isEqualTo(57L);
+        assertThat(result).hasSize(11);
+        assertThat(result.get(10).getExecutionCounts()).containsEntry(State.Type.SUCCESS, 57L);
 
         result = executionRepository.dailyStatistics(
             null,
@@ -631,8 +631,8 @@ public abstract class AbstractExecutionRepositoryTest {
             null,
             null,
             true);
-        assertThat(result.size()).isEqualTo(11);
-        assertThat(result.get(10).getExecutionCounts().get(State.Type.SUCCESS)).isEqualTo(55L);
+        assertThat(result).hasSize(11);
+        assertThat(result.get(10).getExecutionCounts()).containsEntry(State.Type.SUCCESS, 55L);
 
         result = executionRepository.dailyStatistics(
             null,
@@ -645,8 +645,8 @@ public abstract class AbstractExecutionRepositoryTest {
             null,
             null,
             true);
-        assertThat(result.size()).isEqualTo(11);
-        assertThat(result.get(10).getExecutionCounts().get(State.Type.SUCCESS)).isEqualTo(2L);
+        assertThat(result).hasSize(11);
+        assertThat(result.get(10).getExecutionCounts()).containsEntry(State.Type.SUCCESS, 2L);
     }
 
     @SuppressWarnings("OptionalGetWithoutIsPresent")
@@ -675,7 +675,7 @@ public abstract class AbstractExecutionRepositoryTest {
             ZonedDateTime.now(),
             null
         );
-        assertThat(result.size()).isEqualTo(4);
+        assertThat(result).hasSize(4);
         assertThat(result.stream().filter(executionCount -> executionCount.getFlowId().equals("first")).findFirst().get().getCount()).isEqualTo(2L);
         assertThat(result.stream().filter(executionCount -> executionCount.getFlowId().equals("second")).findFirst().get().getCount()).isEqualTo(3L);
         assertThat(result.stream().filter(executionCount -> executionCount.getFlowId().equals("third")).findFirst().get().getCount()).isEqualTo(9L);
@@ -693,7 +693,7 @@ public abstract class AbstractExecutionRepositoryTest {
             null,
             null
         );
-        assertThat(result.size()).isEqualTo(3);
+        assertThat(result).hasSize(3);
         assertThat(result.stream().filter(executionCount -> executionCount.getFlowId().equals("first")).findFirst().get().getCount()).isEqualTo(2L);
         assertThat(result.stream().filter(executionCount -> executionCount.getFlowId().equals("second")).findFirst().get().getCount()).isEqualTo(3L);
         assertThat(result.stream().filter(executionCount -> executionCount.getFlowId().equals("third")).findFirst().get().getCount()).isEqualTo(9L);
@@ -706,7 +706,7 @@ public abstract class AbstractExecutionRepositoryTest {
             null,
             List.of(NAMESPACE)
         );
-        assertThat(result.size()).isEqualTo(1);
+        assertThat(result).hasSize(1);
         assertThat(result.stream().filter(executionCount -> executionCount.getNamespace().equals(NAMESPACE)).findFirst().get().getCount()).isEqualTo(14L);
     }
 
@@ -720,8 +720,8 @@ public abstract class AbstractExecutionRepositoryTest {
         executionRepository.update(updated);
 
         Optional<Execution> validation = executionRepository.findById(null, updated.getId());
-        assertThat(validation.isPresent()).isTrue();
-        assertThat(validation.get().getLabels().size()).isEqualTo(1);
+        assertThat(validation).isPresent();
+        assertThat(validation.get().getLabels()).hasSize(1);
         assertThat(validation.get().getLabels().getFirst()).isEqualTo(label);
     }
 
@@ -734,7 +734,7 @@ public abstract class AbstractExecutionRepositoryTest {
         executionRepository.save(latest);
 
         Optional<Execution> result = executionRepository.findLatestForStates(null, "io.kestra.unittest", "full", List.of(State.Type.CREATED));
-        assertThat(result.isPresent()).isTrue();
+        assertThat(result).isPresent();
         assertThat(result.get().getId()).isEqualTo(latest.getId());
     }
 
@@ -767,10 +767,10 @@ public abstract class AbstractExecutionRepositoryTest {
         );
 
         assertThat(data.getTotal()).isEqualTo(1L);
-        assertThat(data.get(0).get("count")).isEqualTo(1L);
-        assertThat(data.get(0).get("country")).isEqualTo("FR");
+        assertThat(data.getFirst()).containsEntry("count", 1L);
+        assertThat(data.getFirst()).containsEntry("country", "FR");
         Instant startDate = execution.getState().getStartDate();
-        assertThat(data.get(0).get("date")).isEqualTo(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSXXX").format(ZonedDateTime.ofInstant(startDate, ZoneId.systemDefault()).withSecond(0).withNano(0)));
+        assertThat(data.getFirst()).containsEntry("date", DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSXXX").format(ZonedDateTime.ofInstant(startDate, ZoneId.systemDefault()).withSecond(0).withNano(0)));
     }
 
     private static Execution buildWithCreatedDate(Instant instant) {

--- a/core/src/test/java/io/kestra/core/repositories/AbstractFlowRepositoryTest.java
+++ b/core/src/test/java/io/kestra/core/repositories/AbstractFlowRepositoryTest.java
@@ -82,11 +82,11 @@ public abstract class AbstractFlowRepositoryTest {
         flow = flowRepository.create(GenericFlow.of(flow));
         try {
             Optional<Flow> full = flowRepository.findById(null, flow.getNamespace(), flow.getId());
-            assertThat(full.isPresent()).isTrue();
+            assertThat(full).isPresent();
             assertThat(full.get().getRevision()).isEqualTo(1);
 
             full = flowRepository.findById(null, flow.getNamespace(), flow.getId(), Optional.empty());
-            assertThat(full.isPresent()).isTrue();
+            assertThat(full).isPresent();
         } finally {
             deleteFlow(flow);
         }
@@ -100,11 +100,11 @@ public abstract class AbstractFlowRepositoryTest {
         flow = flowRepository.create(GenericFlow.of(flow));
         try {
             Optional<Flow> full = flowRepository.findByIdWithoutAcl(null, flow.getNamespace(), flow.getId(), Optional.empty());
-            assertThat(full.isPresent()).isTrue();
+            assertThat(full).isPresent();
             assertThat(full.get().getRevision()).isEqualTo(1);
 
             full = flowRepository.findByIdWithoutAcl(null, flow.getNamespace(), flow.getId(), Optional.empty());
-            assertThat(full.isPresent()).isTrue();
+            assertThat(full).isPresent();
         } finally {
             deleteFlow(flow);
         }
@@ -120,7 +120,7 @@ public abstract class AbstractFlowRepositoryTest {
 
         try {
             Optional<FlowWithSource> full = flowRepository.findByIdWithSource(null, flow.getNamespace(), flow.getId());
-            assertThat(full.isPresent()).isTrue();
+            assertThat(full).isPresent();
 
             full.ifPresent(current -> {
                 assertThat(full.get().getRevision()).isEqualTo(1);
@@ -239,7 +239,7 @@ public abstract class AbstractFlowRepositoryTest {
         assertThat((long) save.size()).isEqualTo(1L);
 
         save = flowRepository.find(Pageable.from(1, 100, Sort.UNSORTED), null, null, null, null, Map.of("country", "FR"));
-        assertThat(save.size()).isEqualTo(1);
+        assertThat(save).hasSize(1);
 
         save = flowRepository.find(Pageable.from(1), null, null, null, "io.kestra.tests", Map.of("key2", "value2"));
         assertThat((long) save.size()).isEqualTo(1L);
@@ -273,7 +273,7 @@ public abstract class AbstractFlowRepositoryTest {
         FlowWithSource save = flowRepository.create(GenericFlow.of(flow));
 
         try {
-            assertThat(flowRepository.findById(null, save.getNamespace(), save.getId()).isPresent()).isTrue();
+            assertThat(flowRepository.findById(null, save.getNamespace(), save.getId())).isPresent();
         } catch (Throwable e) {
             deleteFlow(save);
             throw e;
@@ -281,8 +281,8 @@ public abstract class AbstractFlowRepositoryTest {
 
         Flow delete = flowRepository.delete(save);
 
-        assertThat(flowRepository.findById(null, flow.getNamespace(), flow.getId()).isPresent()).isFalse();
-        assertThat(flowRepository.findById(null, flow.getNamespace(), flow.getId(), Optional.of(save.getRevision())).isPresent()).isTrue();
+        assertThat(flowRepository.findById(null, flow.getNamespace(), flow.getId())).isNotPresent();
+        assertThat(flowRepository.findById(null, flow.getNamespace(), flow.getId(), Optional.of(save.getRevision()))).isPresent();
 
         List<FlowWithSource> revisions = flowRepository.findRevisions(null, flow.getNamespace(), flow.getId());
         assertThat(revisions.getLast().getRevision()).isEqualTo(delete.getRevision());
@@ -302,7 +302,7 @@ public abstract class AbstractFlowRepositoryTest {
         Flow save = flowRepository.create(GenericFlow.of(flow));
 
         try {
-            assertThat(flowRepository.findById(null, flow.getNamespace(), flow.getId()).isPresent()).isTrue();
+            assertThat(flowRepository.findById(null, flow.getNamespace(), flow.getId())).isPresent();
 
             Flow update = Flow.builder()
                 .id(IdUtils.create())
@@ -317,7 +317,7 @@ public abstract class AbstractFlowRepositoryTest {
                 () -> flowRepository.update(GenericFlow.of(update), flow)
             );
 
-            assertThat(e.getConstraintViolations().size()).isEqualTo(2);
+            assertThat(e.getConstraintViolations()).hasSize(2);
         } finally {
             deleteFlow(save);
         }
@@ -339,7 +339,7 @@ public abstract class AbstractFlowRepositoryTest {
 
         flow = flowRepository.create(GenericFlow.of(flow));
         try {
-            assertThat(flowRepository.findById(null, flow.getNamespace(), flow.getId()).isPresent()).isTrue();
+            assertThat(flowRepository.findById(null, flow.getNamespace(), flow.getId())).isPresent();
 
             Flow update = Flow.builder()
                 .id(flowId)
@@ -377,7 +377,7 @@ public abstract class AbstractFlowRepositoryTest {
 
         Flow save = flowRepository.create(GenericFlow.of(flow));
         try {
-            assertThat(flowRepository.findById(null, flow.getNamespace(), flow.getId()).isPresent()).isTrue();
+            assertThat(flowRepository.findById(null, flow.getNamespace(), flow.getId())).isPresent();
         } finally {
             deleteFlow(save);
         }
@@ -420,7 +420,7 @@ public abstract class AbstractFlowRepositoryTest {
         try {
             Optional<Flow> found = flowRepository.findById(null, flow.getNamespace(), flow.getId());
 
-            assertThat(found.isPresent()).isTrue();
+            assertThat(found).isPresent();
             assertThat(found.get() instanceof FlowWithException).isTrue();
             assertThat(((FlowWithException) found.get()).getException()).contains("Templates are disabled");
         } finally {
@@ -456,13 +456,13 @@ public abstract class AbstractFlowRepositoryTest {
         // Given
         final String flowId = IdUtils.create();
         FlowWithSource created = flowRepository.create(createTestingLogFlow(flowId, "first"));
-        assertThat(flowRepository.findRevisions(TEST_TENANT_ID, TEST_NAMESPACE, flowId).size()).isEqualTo(1);
+        assertThat(flowRepository.findRevisions(TEST_TENANT_ID, TEST_NAMESPACE, flowId)).hasSize(1);
 
         // When
         flowRepository.delete(created);
 
         // Then
-        assertThat(flowRepository.findRevisions(TEST_TENANT_ID, TEST_NAMESPACE, flowId).size()).isEqualTo(2);
+        assertThat(flowRepository.findRevisions(TEST_TENANT_ID, TEST_NAMESPACE, flowId)).hasSize(2);
     }
 
     @Test
@@ -480,7 +480,7 @@ public abstract class AbstractFlowRepositoryTest {
             toDelete.add(flowRepository.create(createTestingLogFlow(flowId, "second")));
 
             // Then
-            assertThat(flowRepository.findRevisions(TEST_TENANT_ID, TEST_NAMESPACE, flowId).size()).isEqualTo(3);
+            assertThat(flowRepository.findRevisions(TEST_TENANT_ID, TEST_NAMESPACE, flowId)).hasSize(3);
             assertThat(flowRepository.lastRevision(TEST_TENANT_ID, TEST_NAMESPACE, flowId)).isEqualTo(3);
         } finally {
             toDelete.forEach(this::deleteFlow);
@@ -529,7 +529,7 @@ public abstract class AbstractFlowRepositoryTest {
 
             // Then
             assertThat(flowRepository.findById(TEST_TENANT_ID, TEST_NAMESPACE, flowId, Optional.empty())).isEqualTo(Optional.empty());
-            assertThat(flowRepository.findRevisions(TEST_TENANT_ID, TEST_NAMESPACE, flowId).size()).isEqualTo(3);
+            assertThat(flowRepository.findRevisions(TEST_TENANT_ID, TEST_NAMESPACE, flowId)).hasSize(3);
         } finally {
             toDelete.forEach(this::deleteFlow);
         }
@@ -584,7 +584,7 @@ public abstract class AbstractFlowRepositoryTest {
     @Test
     void shouldReturnForFindGivenQueryWildcard() {
         ArrayListTotal<Flow> flows = flowRepository.find(Pageable.from(1, 10), "*", null, null, null, Map.of());
-        assertThat(flows.size()).isEqualTo(10);
+        assertThat(flows).hasSize(10);
         assertThat(flows.getTotal()).isEqualTo(Helpers.FLOWS_COUNT);
     }
 
@@ -594,7 +594,7 @@ public abstract class AbstractFlowRepositoryTest {
            QueryFilter.builder().field(QueryFilter.Field.QUERY).operation(QueryFilter.Op.EQUALS).value("*").build()
         );
         ArrayListTotal<Flow> flows = flowRepository.find(Pageable.from(1, 10), null, filters);
-        assertThat(flows.size()).isEqualTo(10);
+        assertThat(flows).hasSize(10);
         assertThat(flows.getTotal()).isEqualTo(Helpers.FLOWS_COUNT);
     }
 

--- a/core/src/test/java/io/kestra/core/repositories/AbstractFlowTopologyRepositoryTest.java
+++ b/core/src/test/java/io/kestra/core/repositories/AbstractFlowTopologyRepositoryTest.java
@@ -42,6 +42,6 @@ public abstract class AbstractFlowTopologyRepositoryTest {
 
         List<FlowTopology> list = flowTopologyRepository.findByFlow(null, "io.kestra.tests", "flow-a", false);
 
-        assertThat(list.size()).isEqualTo(1);
+        assertThat(list).hasSize(1);
     }
 }

--- a/core/src/test/java/io/kestra/core/repositories/AbstractLogRepositoryTest.java
+++ b/core/src/test/java/io/kestra/core/repositories/AbstractLogRepositoryTest.java
@@ -44,13 +44,13 @@ public abstract class AbstractLogRepositoryTest {
         LogEntry.LogEntryBuilder builder = logEntry(Level.INFO);
 
         ArrayListTotal<LogEntry> find = logRepository.find(Pageable.UNPAGED, null, null);
-        assertThat(find.size()).isZero();
+        assertThat(find).isEmpty();
 
 
         LogEntry save = logRepository.save(builder.build());
 
         find = logRepository.find(Pageable.UNPAGED, null, null);
-        assertThat(find.size()).isEqualTo(1);
+        assertThat(find).hasSize(1);
         assertThat(find.getFirst().getExecutionId()).isEqualTo(save.getExecutionId());
         var filters = List.of(QueryFilter.builder()
                 .field(QueryFilter.Field.MIN_LEVEL)
@@ -63,45 +63,45 @@ public abstract class AbstractLogRepositoryTest {
                 .value(Instant.now().minus(1, ChronoUnit.HOURS))
                 .build());
         find = logRepository.find(Pageable.UNPAGED,  "doe", filters);
-        assertThat(find.size()).isZero();
+        assertThat(find).isEmpty();
 
         find = logRepository.find(Pageable.UNPAGED, null, null);
-        assertThat(find.size()).isEqualTo(1);
+        assertThat(find).hasSize(1);
         assertThat(find.getFirst().getExecutionId()).isEqualTo(save.getExecutionId());
 
         logRepository.find(Pageable.UNPAGED, "kestra-io/kestra", null);
-        assertThat(find.size()).isEqualTo(1);
+        assertThat(find).hasSize(1);
         assertThat(find.getFirst().getExecutionId()).isEqualTo(save.getExecutionId());
 
         List<LogEntry> list = logRepository.findByExecutionId(null, save.getExecutionId(), null);
-        assertThat(list.size()).isEqualTo(1);
+        assertThat(list).hasSize(1);
         assertThat(list.getFirst().getExecutionId()).isEqualTo(save.getExecutionId());
 
         list = logRepository.findByExecutionId(null, "io.kestra.unittest", "flowId", save.getExecutionId(), null);
-        assertThat(list.size()).isEqualTo(1);
+        assertThat(list).hasSize(1);
         assertThat(list.getFirst().getExecutionId()).isEqualTo(save.getExecutionId());
 
         list = logRepository.findByExecutionIdAndTaskId(null, save.getExecutionId(), save.getTaskId(), null);
-        assertThat(list.size()).isEqualTo(1);
+        assertThat(list).hasSize(1);
         assertThat(list.getFirst().getExecutionId()).isEqualTo(save.getExecutionId());
 
         list = logRepository.findByExecutionIdAndTaskId(null, "io.kestra.unittest", "flowId", save.getExecutionId(), save.getTaskId(), null);
-        assertThat(list.size()).isEqualTo(1);
+        assertThat(list).hasSize(1);
         assertThat(list.getFirst().getExecutionId()).isEqualTo(save.getExecutionId());
 
         list = logRepository.findByExecutionIdAndTaskRunId(null, save.getExecutionId(), save.getTaskRunId(), null);
-        assertThat(list.size()).isEqualTo(1);
+        assertThat(list).hasSize(1);
         assertThat(list.getFirst().getExecutionId()).isEqualTo(save.getExecutionId());
 
         list = logRepository.findByExecutionIdAndTaskRunIdAndAttempt(null, save.getExecutionId(), save.getTaskRunId(), null, 0);
-        assertThat(list.size()).isEqualTo(1);
+        assertThat(list).hasSize(1);
         assertThat(list.getFirst().getExecutionId()).isEqualTo(save.getExecutionId());
 
         Integer countDeleted = logRepository.purge(Execution.builder().id(save.getExecutionId()).build());
         assertThat(countDeleted).isEqualTo(1);
 
         list = logRepository.findByExecutionIdAndTaskId(null, save.getExecutionId(), save.getTaskId(), null);
-        assertThat(list.size()).isZero();
+        assertThat(list).isEmpty();
     }
 
     @Test
@@ -122,32 +122,32 @@ public abstract class AbstractLogRepositoryTest {
 
         ArrayListTotal<LogEntry> find = logRepository.findByExecutionId(null, executionId, null, Pageable.from(1, 50));
 
-        assertThat(find.size()).isEqualTo(50);
+        assertThat(find).hasSize(50);
         assertThat(find.getTotal()).isEqualTo(101L);
 
         find = logRepository.findByExecutionId(null, executionId, null, Pageable.from(3, 50));
 
-        assertThat(find.size()).isEqualTo(1);
+        assertThat(find).hasSize(1);
         assertThat(find.getTotal()).isEqualTo(101L);
 
         find = logRepository.findByExecutionIdAndTaskId(null, executionId, logEntry2.getTaskId(), null, Pageable.from(1, 50));
 
-        assertThat(find.size()).isEqualTo(21);
+        assertThat(find).hasSize(21);
         assertThat(find.getTotal()).isEqualTo(21L);
 
         find = logRepository.findByExecutionIdAndTaskRunId(null, executionId, logEntry2.getTaskRunId(), null, Pageable.from(1, 10));
 
-        assertThat(find.size()).isEqualTo(10);
+        assertThat(find).hasSize(10);
         assertThat(find.getTotal()).isEqualTo(21L);
 
         find = logRepository.findByExecutionIdAndTaskRunIdAndAttempt(null, executionId, logEntry2.getTaskRunId(), null, 0, Pageable.from(1, 10));
 
-        assertThat(find.size()).isEqualTo(10);
+        assertThat(find).hasSize(10);
         assertThat(find.getTotal()).isEqualTo(21L);
 
         find = logRepository.findByExecutionIdAndTaskRunId(null, executionId, logEntry2.getTaskRunId(), null, Pageable.from(10, 10));
 
-        assertThat(find.size()).isZero();
+        assertThat(find).isEmpty();
     }
 
     @Test
@@ -158,14 +158,14 @@ public abstract class AbstractLogRepositoryTest {
         logRepository.deleteByQuery(null, log1.getExecutionId(), null, (String) null, null, null);
 
         ArrayListTotal<LogEntry> find = logRepository.findByExecutionId(null, log1.getExecutionId(), null, Pageable.from(1, 50));
-        assertThat(find.size()).isZero();
+        assertThat(find).isEmpty();
 
         logRepository.save(log1);
 
         logRepository.deleteByQuery(null, "io.kestra.unittest", "flowId", List.of(Level.TRACE, Level.DEBUG, Level.INFO), null, ZonedDateTime.now().plusMinutes(1));
 
         find = logRepository.findByExecutionId(null, log1.getExecutionId(), null, Pageable.from(1, 50));
-        assertThat(find.size()).isZero();
+        assertThat(find).isEmpty();
     }
 
     @Test
@@ -176,14 +176,14 @@ public abstract class AbstractLogRepositoryTest {
         logRepository.deleteByQuery(null, log1.getExecutionId(), null, (String) null, null, null);
 
         ArrayListTotal<LogEntry> find = logRepository.findByExecutionId(null, log1.getExecutionId(), null, Pageable.from(1, 50));
-        assertThat(find.size()).isZero();
+        assertThat(find).isEmpty();
 
         logRepository.save(log1);
 
         logRepository.deleteByQuery(null, "io.kestra.unittest", "flowId", null);
 
         find = logRepository.findByExecutionId(null, log1.getExecutionId(), null, Pageable.from(1, 50));
-        assertThat(find.size()).isZero();
+        assertThat(find).isEmpty();
     }
 
     @Test
@@ -200,13 +200,13 @@ public abstract class AbstractLogRepositoryTest {
         Thread.sleep(500);
 
         List<LogStatistics> list = logRepository.statistics(null, null, null, "first", null, null, null, null);
-        assertThat(list.size()).isEqualTo(31);
+        assertThat(list).hasSize(31);
         assertThat(list.stream().filter(logStatistics -> logStatistics.getCounts().get(Level.TRACE) == 5).count()).isEqualTo(1L);
         assertThat(list.stream().filter(logStatistics -> logStatistics.getCounts().get(Level.INFO) == 3).count()).isEqualTo(1L);
         assertThat(list.stream().filter(logStatistics -> logStatistics.getCounts().get(Level.ERROR) == 7).count()).isEqualTo(1L);
 
         list = logRepository.statistics(null, null, null, "second", null, null, null, null);
-        assertThat(list.size()).isEqualTo(31);
+        assertThat(list).hasSize(31);
         assertThat(list.stream().filter(logStatistics -> logStatistics.getCounts().get(Level.ERROR) == 13).count()).isEqualTo(1L);
     }
 
@@ -228,11 +228,11 @@ public abstract class AbstractLogRepositoryTest {
 
         find = logRepository.findAsync(null, "io.kestra.unused", Level.INFO, startDate);
         logEntries = find.collectList().block();
-        assertThat(logEntries).hasSize(0);
+        assertThat(logEntries).isEmpty();
 
         find = logRepository.findAsync(null, null, Level.INFO, startDate.plusSeconds(2));
         logEntries = find.collectList().block();
-        assertThat(logEntries).hasSize(0);
+        assertThat(logEntries).isEmpty();
     }
 
     @Test

--- a/core/src/test/java/io/kestra/core/repositories/AbstractMetricRepositoryTest.java
+++ b/core/src/test/java/io/kestra/core/repositories/AbstractMetricRepositoryTest.java
@@ -33,13 +33,13 @@ public abstract class AbstractMetricRepositoryTest {
         metricRepository.save(timer);
 
         List<MetricEntry> results = metricRepository.findByExecutionId(null, executionId, Pageable.from(1, 10));
-        assertThat(results.size()).isEqualTo(2);
+        assertThat(results).hasSize(2);
 
         results = metricRepository.findByExecutionIdAndTaskId(null, executionId, taskRun1.getTaskId(), Pageable.from(1, 10));
-        assertThat(results.size()).isEqualTo(2);
+        assertThat(results).hasSize(2);
 
         results = metricRepository.findByExecutionIdAndTaskRunId(null, executionId, taskRun1.getId(), Pageable.from(1, 10));
-        assertThat(results.size()).isEqualTo(1);
+        assertThat(results).hasSize(1);
 
         MetricAggregations aggregationResults = metricRepository.aggregateByFlowId(
             null,
@@ -52,7 +52,7 @@ public abstract class AbstractMetricRepositoryTest {
             "sum"
         );
 
-        assertThat(aggregationResults.getAggregations().size()).isEqualTo(31);
+        assertThat(aggregationResults.getAggregations()).hasSize(31);
         assertThat(aggregationResults.getGroupBy()).isEqualTo("day");
 
         aggregationResults = metricRepository.aggregateByFlowId(
@@ -66,7 +66,7 @@ public abstract class AbstractMetricRepositoryTest {
             "sum"
         );
 
-        assertThat(aggregationResults.getAggregations().size()).isEqualTo(27);
+        assertThat(aggregationResults.getAggregations()).hasSize(27);
         assertThat(aggregationResults.getGroupBy()).isEqualTo("week");
 
     }
@@ -88,9 +88,9 @@ public abstract class AbstractMetricRepositoryTest {
          List<String> taskMetricsNames = metricRepository.taskMetrics(null, "namespace", "flow", "task");
          List<String> tasksWithMetrics = metricRepository.tasksWithMetrics(null, "namespace", "flow");
 
-         assertThat(flowMetricsNames.size()).isEqualTo(2);
-         assertThat(taskMetricsNames.size()).isEqualTo(1);
-         assertThat(tasksWithMetrics.size()).isEqualTo(2);
+         assertThat(flowMetricsNames).hasSize(2);
+         assertThat(taskMetricsNames).hasSize(1);
+         assertThat(tasksWithMetrics).hasSize(2);
      }
 
     @Test

--- a/core/src/test/java/io/kestra/core/repositories/AbstractSettingRepositoryTest.java
+++ b/core/src/test/java/io/kestra/core/repositories/AbstractSettingRepositoryTest.java
@@ -24,26 +24,26 @@ public abstract class AbstractSettingRepositoryTest {
             .build();
 
         Optional<Setting> find = settingRepository.findByKey(setting.getKey());
-        assertThat(find.isPresent()).isFalse();
+        assertThat(find).isNotPresent();
 
         Setting save = settingRepository.save(setting);
 
         find = settingRepository.findByKey(save.getKey());
 
-        assertThat(find.isPresent()).isTrue();
+        assertThat(find).isPresent();
         assertThat(find.get().getValue()).isEqualTo(save.getValue());
 
         List<Setting> all = settingRepository.findAll();
-        assertThat(all.size()).isEqualTo(1);
+        assertThat(all).hasSize(1);
         assertThat(all.getFirst().getValue()).isEqualTo(setting.getValue());
 
         Setting delete = settingRepository.delete(setting);
         assertThat(delete.getValue()).isEqualTo(setting.getValue());
 
         all = settingRepository.findAll();
-        assertThat(all.size()).isZero();
+        assertThat(all).isEmpty();
 
         find = settingRepository.findByKey(setting.getKey());
-        assertThat(find.isPresent()).isFalse();
+        assertThat(find).isNotPresent();
     }
 }

--- a/core/src/test/java/io/kestra/core/repositories/AbstractTemplateRepositoryTest.java
+++ b/core/src/test/java/io/kestra/core/repositories/AbstractTemplateRepositoryTest.java
@@ -50,11 +50,11 @@ public abstract class AbstractTemplateRepositoryTest {
         templateRepository.create(template);
 
         Optional<Template> full = templateRepository.findById(null, template.getNamespace(), template.getId());
-        assertThat(full.isPresent()).isTrue();
+        assertThat(full).isPresent();
         assertThat(full.get().getId()).isEqualTo(template.getId());
 
         full = templateRepository.findById(null, template.getNamespace(), template.getId());
-        assertThat(full.isPresent()).isTrue();
+        assertThat(full).isPresent();
         assertThat(full.get().getId()).isEqualTo(template.getId());
     }
 
@@ -71,7 +71,7 @@ public abstract class AbstractTemplateRepositoryTest {
         List<Template> templates = templateRepository.findByNamespace(null, template1.getNamespace());
         assertThat(templates.size()).isGreaterThanOrEqualTo(1);
         templates = templateRepository.findByNamespace(null, template2.getNamespace());
-        assertThat(templates.size()).isEqualTo(1);
+        assertThat(templates).hasSize(1);
     }
 
     @Test
@@ -133,9 +133,9 @@ public abstract class AbstractTemplateRepositoryTest {
         Template save = templateRepository.create(template);
         templateRepository.delete(save);
 
-        assertThat(templateRepository.findById(null, template.getNamespace(), template.getId()).isPresent()).isFalse();
+        assertThat(templateRepository.findById(null, template.getNamespace(), template.getId())).isNotPresent();
 
-        assertThat(TemplateListener.getEmits().size()).isEqualTo(2);
+        assertThat(TemplateListener.getEmits()).hasSize(2);
         assertThat(TemplateListener.getEmits().stream().filter(r -> r.getType() == CrudEventType.CREATE).count()).isEqualTo(1L);
         assertThat(TemplateListener.getEmits().stream().filter(r -> r.getType() == CrudEventType.DELETE).count()).isEqualTo(1L);
     }

--- a/core/src/test/java/io/kestra/core/repositories/AbstractTriggerRepositoryTest.java
+++ b/core/src/test/java/io/kestra/core/repositories/AbstractTriggerRepositoryTest.java
@@ -35,20 +35,20 @@ public abstract class AbstractTriggerRepositoryTest {
         Trigger.TriggerBuilder<?, ?> builder = trigger();
 
         Optional<Trigger> findLast = triggerRepository.findLast(builder.build());
-        assertThat(findLast.isPresent()).isFalse();
+        assertThat(findLast).isNotPresent();
 
         Trigger save = triggerRepository.save(builder.build());
 
         findLast = triggerRepository.findLast(save);
 
-        assertThat(findLast.isPresent()).isTrue();
+        assertThat(findLast).isPresent();
         assertThat(findLast.get().getExecutionId()).isEqualTo(save.getExecutionId());
 
         save = triggerRepository.save(builder.executionId(IdUtils.create()).build());
 
         findLast = triggerRepository.findLast(save);
 
-        assertThat(findLast.isPresent()).isTrue();
+        assertThat(findLast).isPresent();
         assertThat(findLast.get().getExecutionId()).isEqualTo(save.getExecutionId());
 
 
@@ -59,11 +59,11 @@ public abstract class AbstractTriggerRepositoryTest {
 
         List<Trigger> all = triggerRepository.findAllForAllTenants();
 
-        assertThat(all.size()).isEqualTo(4);
+        assertThat(all).hasSize(4);
 
         all = triggerRepository.findAll(null);
 
-        assertThat(all.size()).isEqualTo(4);
+        assertThat(all).hasSize(4);
 
         String namespacePrefix = "io.kestra.another";
         String namespace = namespacePrefix + ".ns";
@@ -71,29 +71,29 @@ public abstract class AbstractTriggerRepositoryTest {
         triggerRepository.save(trigger);
 
         List<Trigger> find = triggerRepository.find(Pageable.from(1, 4, Sort.of(Sort.Order.asc("namespace"))), null, null, null, null, null);
-        assertThat(find.size()).isEqualTo(4);
+        assertThat(find).hasSize(4);
         assertThat(find.getFirst().getNamespace()).isEqualTo(namespace);
 
         find = triggerRepository.find(Pageable.from(1, 4, Sort.of(Sort.Order.asc("namespace"))), null, null, null, searchedTrigger.getFlowId(), null);
-        assertThat(find.size()).isEqualTo(1);
+        assertThat(find).hasSize(1);
         assertThat(find.getFirst().getFlowId()).isEqualTo(searchedTrigger.getFlowId());
 
         find = triggerRepository.find(Pageable.from(1, 100, Sort.of(Sort.Order.asc(triggerRepository.sortMapping().apply("triggerId")))), null, null, namespacePrefix, null, null);
-        assertThat(find.size()).isEqualTo(1);
+        assertThat(find).hasSize(1);
         assertThat(find.getFirst().getTriggerId()).isEqualTo(trigger.getTriggerId());
 
         // Full text search is on namespace, flowId, triggerId, executionId
         find = triggerRepository.find(Pageable.from(1, 100, Sort.UNSORTED), trigger.getNamespace(), null, null, null, null);
-        assertThat(find.size()).isEqualTo(1);
+        assertThat(find).hasSize(1);
         assertThat(find.getFirst().getTriggerId()).isEqualTo(trigger.getTriggerId());
         find = triggerRepository.find(Pageable.from(1, 100, Sort.UNSORTED), searchedTrigger.getFlowId(), null, null, null, null);
-        assertThat(find.size()).isEqualTo(1);
+        assertThat(find).hasSize(1);
         assertThat(find.getFirst().getTriggerId()).isEqualTo(searchedTrigger.getTriggerId());
         find = triggerRepository.find(Pageable.from(1, 100, Sort.UNSORTED), searchedTrigger.getTriggerId(), null, null, null, null);
-        assertThat(find.size()).isEqualTo(1);
+        assertThat(find).hasSize(1);
         assertThat(find.getFirst().getTriggerId()).isEqualTo(searchedTrigger.getTriggerId());
         find = triggerRepository.find(Pageable.from(1, 100, Sort.UNSORTED), searchedTrigger.getExecutionId(), null, null, null, null);
-        assertThat(find.size()).isEqualTo(1);
+        assertThat(find).hasSize(1);
         assertThat(find.getFirst().getTriggerId()).isEqualTo(searchedTrigger.getTriggerId());
     }
 

--- a/core/src/test/java/io/kestra/core/runners/AbstractRunnerTest.java
+++ b/core/src/test/java/io/kestra/core/runners/AbstractRunnerTest.java
@@ -407,7 +407,7 @@ public abstract class AbstractRunnerTest {
     @Test
     @ExecuteFlow("flows/valids/executable-fail.yml")
     void badExecutable(Execution execution) {
-        assertThat(execution.getTaskRunList().size()).isEqualTo(1);
+        assertThat(execution.getTaskRunList()).hasSize(1);
         assertThat(execution.getTaskRunList().getFirst().getState().getCurrent()).isEqualTo(State.Type.FAILED);
         assertThat(execution.getState().getCurrent()).isEqualTo(State.Type.FAILED);
     }
@@ -415,7 +415,7 @@ public abstract class AbstractRunnerTest {
     @Test
     @ExecuteFlow("flows/valids/dynamic-task.yaml")
     void dynamicTask(Execution execution) {
-        assertThat(execution.getTaskRunList().size()).isEqualTo(3);
+        assertThat(execution.getTaskRunList()).hasSize(3);
         assertThat(execution.getState().getCurrent()).isEqualTo(State.Type.SUCCESS);
     }
 

--- a/core/src/test/java/io/kestra/core/runners/AfterExecutionTestCase.java
+++ b/core/src/test/java/io/kestra/core/runners/AfterExecutionTestCase.java
@@ -28,7 +28,7 @@ public class AfterExecutionTestCase {
         assertThat(afterExecution.getState().getStartDate()).isAfterOrEqualTo(taskRun.getState().getEndDate().orElseThrow());
         assertThat(afterExecution.getState().getStartDate()).isAfterOrEqualTo(execution.getState().getEndDate().orElseThrow());
         Map<String, Object> outputs = (Map<String, Object> ) afterExecution.getOutputs().get("values");
-        assertThat(outputs.get("state")).isEqualTo("SUCCESS");
+        assertThat(outputs).containsEntry("state", "SUCCESS");
     }
 
     @SuppressWarnings("unchecked")
@@ -48,7 +48,7 @@ public class AfterExecutionTestCase {
         assertThat(afterExecution.getState().getStartDate()).isAfterOrEqualTo(finallyTaskRun.getState().getEndDate().orElseThrow());
         assertThat(afterExecution.getState().getStartDate()).isAfterOrEqualTo(execution.getState().getEndDate().orElseThrow());
         Map<String, Object> outputs = (Map<String, Object> ) afterExecution.getOutputs().get("values");
-        assertThat(outputs.get("state")).isEqualTo("SUCCESS");
+        assertThat(outputs).containsEntry("state", "SUCCESS");
     }
 
     @SuppressWarnings("unchecked")
@@ -68,7 +68,7 @@ public class AfterExecutionTestCase {
         assertThat(afterExecution.getState().getStartDate()).isAfterOrEqualTo(taskRun.getState().getEndDate().orElseThrow());
         assertThat(afterExecution.getState().getStartDate()).isAfterOrEqualTo(execution.getState().getEndDate().orElseThrow());
         Map<String, Object> outputs = (Map<String, Object> ) afterExecution.getOutputs().get("values");
-        assertThat(outputs.get("state")).isEqualTo("FAILED");
+        assertThat(outputs).containsEntry("state", "FAILED");
     }
 
     @SuppressWarnings("unchecked")
@@ -88,6 +88,6 @@ public class AfterExecutionTestCase {
         assertThat(afterExecution.getState().getStartDate()).isAfterOrEqualTo(listenerTaskRun.getState().getEndDate().orElseThrow());
         assertThat(afterExecution.getState().getStartDate()).isAfterOrEqualTo(execution.getState().getEndDate().orElseThrow());
         Map<String, Object> outputs = (Map<String, Object> ) afterExecution.getOutputs().get("values");
-        assertThat(outputs.get("state")).isEqualTo("SUCCESS");
+        assertThat(outputs).containsEntry("state", "SUCCESS");
     }
 }

--- a/core/src/test/java/io/kestra/core/runners/AliasTest.java
+++ b/core/src/test/java/io/kestra/core/runners/AliasTest.java
@@ -15,13 +15,13 @@ public class AliasTest {
     @ExecuteFlow("flows/valids/alias-task.yaml")
     void taskAlias(Execution execution) {
         assertThat(execution.getState().getCurrent()).isEqualTo(State.Type.SUCCESS);
-        assertThat(execution.getTaskRunList().size()).isEqualTo(2);
+        assertThat(execution.getTaskRunList()).hasSize(2);
     }
 
     @Test
     @ExecuteFlow("flows/valids/alias-trigger.yaml")
     void triggerAlias(Execution execution) {
         assertThat(execution.getState().getCurrent()).isEqualTo(State.Type.SUCCESS);
-        assertThat(execution.getTaskRunList().size()).isEqualTo(1);
+        assertThat(execution.getTaskRunList()).hasSize(1);
     }
 }

--- a/core/src/test/java/io/kestra/core/runners/DeserializationIssuesCaseTest.java
+++ b/core/src/test/java/io/kestra/core/runners/DeserializationIssuesCaseTest.java
@@ -244,7 +244,7 @@ public class DeserializationIssuesCaseTest {
             Duration.ofMinutes(1)
         );
         receive.blockLast();
-        assertThat(workerTaskResult.get().getTaskRun().getState().getHistories().size()).isEqualTo(2);
+        assertThat(workerTaskResult.get().getTaskRun().getState().getHistories()).hasSize(2);
         assertThat(workerTaskResult.get().getTaskRun().getState().getHistories().getFirst().getState()).isEqualTo(State.Type.CREATED);
         assertThat(workerTaskResult.get().getTaskRun().getState().getCurrent()).isEqualTo(State.Type.FAILED);
     }

--- a/core/src/test/java/io/kestra/core/runners/ExecutionServiceTest.java
+++ b/core/src/test/java/io/kestra/core/runners/ExecutionServiceTest.java
@@ -169,7 +169,7 @@ class ExecutionServiceTest {
         assertThat(restart.getState().getCurrent()).isEqualTo(State.Type.CREATED);
         assertThat(restart.getState().getHistories()).hasSize(1);
         assertThat(restart.getState().getHistories().getFirst().getDate(), not(is(execution.getState().getStartDate())));
-        assertThat(restart.getTaskRunList()).hasSize(0);
+        assertThat(restart.getTaskRunList()).isEmpty();
         assertThat(restart.getId()).isNotEqualTo(execution.getId());
         assertThat(restart.getLabels()).contains(new Label(Label.REPLAY, "true"));
     }

--- a/core/src/test/java/io/kestra/core/runners/FilesServiceTest.java
+++ b/core/src/test/java/io/kestra/core/runners/FilesServiceTest.java
@@ -31,14 +31,14 @@ class FilesServiceTest {
     void renderInputFile() throws Exception {
         RunContext runContext = runContextFactory.of(Map.of("filename", "file.txt", "content", "Hello World"));
         Map<String, String> content = FilesService.inputFiles(runContext, Map.of("{{filename}}", "{{content}}"));
-        assertThat(content.get("file.txt")).isEqualTo("Hello World");
+        assertThat(content).containsEntry("file.txt", "Hello World");
     }
 
     @Test
     void renderRawFile() throws Exception {
         RunContext runContext = runContextFactory.of(Map.of("filename", "file.txt", "content", "Hello World"));
         Map<String, String> content = FilesService.inputFiles(runContext, Map.of("{{filename}}", "{% raw %}{{content}}{% endraw %}"));
-        assertThat(content.get("file.txt")).isEqualTo("{{content}}");
+        assertThat(content).containsEntry("file.txt", "{{content}}");
     }
 
     @Test
@@ -47,7 +47,7 @@ class FilesServiceTest {
         Map<String, String> files = FilesService.inputFiles(runContext, Map.of("file.txt", "content"));
 
         Map<String, URI> outputs = FilesService.outputFiles(runContext, files.keySet().stream().toList());
-        assertThat(outputs.size()).isEqualTo(1);
+        assertThat(outputs).hasSize(1);
     }
 
     @Test
@@ -56,6 +56,6 @@ class FilesServiceTest {
         Map<String, String> files = FilesService.inputFiles(runContext, Map.of("file.txt", "content"));
 
         Map<String, URI> outputs = FilesService.outputFiles(runContext, List.of("*.{{extension}}"));
-        assertThat(outputs.size()).isEqualTo(1);
+        assertThat(outputs).hasSize(1);
     }
 }

--- a/core/src/test/java/io/kestra/core/runners/FlowListenersTest.java
+++ b/core/src/test/java/io/kestra/core/runners/FlowListenersTest.java
@@ -20,7 +20,7 @@ import jakarta.inject.Inject;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @KestraTest
-abstract public class FlowListenersTest {
+public abstract class FlowListenersTest {
     @Inject
     protected FlowRepositoryInterface flowRepository;
 
@@ -52,14 +52,14 @@ abstract public class FlowListenersTest {
         // initial state
         wait(ref, () -> {
             assertThat(count.get()).isZero();
-            assertThat(flowListenersService.flows().size()).isZero();
+            assertThat(flowListenersService.flows()).isEmpty();
         });
 
         // resend on startup done for kafka
         if (flowListenersService.getClass().getName().equals("io.kestra.ee.runner.kafka.KafkaFlowListeners")) {
             wait(ref, () -> {
                 assertThat(count.get()).isZero();
-                assertThat(flowListenersService.flows().size()).isZero();
+                assertThat(flowListenersService.flows()).isEmpty();
             });
         }
 
@@ -71,14 +71,14 @@ abstract public class FlowListenersTest {
         flowRepository.create(GenericFlow.of(first));
         wait(ref, () -> {
             assertThat(count.get()).isEqualTo(1);
-            assertThat(flowListenersService.flows().size()).isEqualTo(1);
+            assertThat(flowListenersService.flows()).hasSize(1);
         });
 
         // create the same id than first, no additional flows
         first = flowRepository.update(GenericFlow.of(firstUpdated), first);
         wait(ref, () -> {
             assertThat(count.get()).isEqualTo(1);
-            assertThat(flowListenersService.flows().size()).isEqualTo(1);
+            assertThat(flowListenersService.flows()).hasSize(1);
             //assertThat(flowListenersService.flows().getFirst().getFirst().getId(), is("test2"));
         });
 
@@ -87,28 +87,28 @@ abstract public class FlowListenersTest {
         flowRepository.create(GenericFlow.of(second));
         wait(ref, () -> {
             assertThat(count.get()).isEqualTo(2);
-            assertThat(flowListenersService.flows().size()).isEqualTo(2);
+            assertThat(flowListenersService.flows()).hasSize(2);
         });
 
         // delete first
         FlowWithSource deleted = flowRepository.delete(first);
         wait(ref, () -> {
             assertThat(count.get()).isEqualTo(1);
-            assertThat(flowListenersService.flows().size()).isEqualTo(1);
+            assertThat(flowListenersService.flows()).hasSize(1);
         });
 
         // restore must works
         flowRepository.create(GenericFlow.of(first));
         wait(ref, () -> {
             assertThat(count.get()).isEqualTo(2);
-            assertThat(flowListenersService.flows().size()).isEqualTo(2);
+            assertThat(flowListenersService.flows()).hasSize(2);
         });
 
         FlowWithSource withTenant = first.toBuilder().tenantId("some-tenant").build();
         flowRepository.create(GenericFlow.of(withTenant));
         wait(ref, () -> {
             assertThat(count.get()).isEqualTo(3);
-            assertThat(flowListenersService.flows().size()).isEqualTo(3);
+            assertThat(flowListenersService.flows()).hasSize(3);
         });
     }
 

--- a/core/src/test/java/io/kestra/core/runners/FlowTriggerCaseTest.java
+++ b/core/src/test/java/io/kestra/core/runners/FlowTriggerCaseTest.java
@@ -55,27 +55,27 @@ public class FlowTriggerCaseTest {
 
         Execution execution = runnerUtils.runOne(null, "io.kestra.tests.trigger", "trigger-flow");
 
-        assertThat(execution.getTaskRunList().size()).isEqualTo(1);
+        assertThat(execution.getTaskRunList()).hasSize(1);
         assertThat(execution.getState().getCurrent()).isEqualTo(State.Type.SUCCESS);
 
         assertTrue(countDownLatch.await(15, TimeUnit.SECONDS));
         receive.blockLast();
 
-        assertThat(flowListener.get().getTaskRunList().size()).isEqualTo(1);
+        assertThat(flowListener.get().getTaskRunList()).hasSize(1);
         assertThat(flowListener.get().getState().getCurrent()).isEqualTo(State.Type.SUCCESS);
-        assertThat(flowListener.get().getTaskRunList().getFirst().getOutputs().get("value")).isEqualTo("childs: from parents: " + execution.getId());
-        assertThat(flowListener.get().getTrigger().getVariables().get("executionId")).isEqualTo(execution.getId());
-        assertThat(flowListener.get().getTrigger().getVariables().get("namespace")).isEqualTo("io.kestra.tests.trigger");
-        assertThat(flowListener.get().getTrigger().getVariables().get("flowId")).isEqualTo("trigger-flow");
+        assertThat(flowListener.get().getTaskRunList().getFirst().getOutputs()).containsEntry("value", "childs: from parents: " + execution.getId());
+        assertThat(flowListener.get().getTrigger().getVariables()).containsEntry("executionId", execution.getId());
+        assertThat(flowListener.get().getTrigger().getVariables()).containsEntry("namespace", "io.kestra.tests.trigger");
+        assertThat(flowListener.get().getTrigger().getVariables()).containsEntry("flowId", "trigger-flow");
 
-        assertThat(flowListenerNoInput.get().getTaskRunList().size()).isEqualTo(1);
-        assertThat(flowListenerNoInput.get().getTrigger().getVariables().get("executionId")).isEqualTo(execution.getId());
-        assertThat(flowListenerNoInput.get().getTrigger().getVariables().get("namespace")).isEqualTo("io.kestra.tests.trigger");
-        assertThat(flowListenerNoInput.get().getTrigger().getVariables().get("flowId")).isEqualTo("trigger-flow");
+        assertThat(flowListenerNoInput.get().getTaskRunList()).hasSize(1);
+        assertThat(flowListenerNoInput.get().getTrigger().getVariables()).containsEntry("executionId", execution.getId());
+        assertThat(flowListenerNoInput.get().getTrigger().getVariables()).containsEntry("namespace", "io.kestra.tests.trigger");
+        assertThat(flowListenerNoInput.get().getTrigger().getVariables()).containsEntry("flowId", "trigger-flow");
         assertThat(flowListenerNoInput.get().getState().getCurrent()).isEqualTo(State.Type.SUCCESS);
 
-        assertThat(flowListenerNamespace.get().getTaskRunList().size()).isEqualTo(1);
-        assertThat(flowListenerNamespace.get().getTrigger().getVariables().get("namespace")).isEqualTo("io.kestra.tests.trigger");
+        assertThat(flowListenerNamespace.get().getTaskRunList()).hasSize(1);
+        assertThat(flowListenerNamespace.get().getTrigger().getVariables()).containsEntry("namespace", "io.kestra.tests.trigger");
         // it will be triggered for 'trigger-flow' or any of the 'trigger-flow-listener*', so we only assert that it's one of them
         assertThat(flowListenerNamespace.get().getTrigger().getVariables().get("flowId"))
             .satisfiesAnyOf(
@@ -99,16 +99,16 @@ public class FlowTriggerCaseTest {
 
         Execution execution = runnerUtils.runOne(null, "io.kestra.tests.trigger.pause", "trigger-flow-with-pause");
 
-        assertThat(execution.getTaskRunList().size()).isEqualTo(3);
+        assertThat(execution.getTaskRunList()).hasSize(3);
         assertThat(execution.getState().getCurrent()).isEqualTo(State.Type.SUCCESS);
 
         assertTrue(countDownLatch.await(15, TimeUnit.SECONDS));
         receive.blockLast();
 
-        assertThat(flowListeners.size()).isEqualTo(4);
-        assertThat(flowListeners.get(0).getOutputs().get("status")).isEqualTo("RUNNING");
-        assertThat(flowListeners.get(1).getOutputs().get("status")).isEqualTo("PAUSED");
-        assertThat(flowListeners.get(2).getOutputs().get("status")).isEqualTo("RUNNING");
-        assertThat(flowListeners.get(3).getOutputs().get("status")).isEqualTo("SUCCESS");
+        assertThat(flowListeners).hasSize(4);
+        assertThat(flowListeners.getFirst().getOutputs()).containsEntry("status", "RUNNING");
+        assertThat(flowListeners.get(1).getOutputs()).containsEntry("status", "PAUSED");
+        assertThat(flowListeners.get(2).getOutputs()).containsEntry("status", "RUNNING");
+        assertThat(flowListeners.get(3).getOutputs()).containsEntry("status", "SUCCESS");
     }
 }

--- a/core/src/test/java/io/kestra/core/runners/InputsTest.java
+++ b/core/src/test/java/io/kestra/core/runners/InputsTest.java
@@ -122,7 +122,7 @@ public class InputsTest {
         HashMap<String, Object> inputsWithMissingOptionalInput = new HashMap<>(inputs);
         inputsWithMissingOptionalInput.remove("bool");
 
-        assertThat(typedInputs(inputsWithMissingOptionalInput).containsKey("bool")).isTrue();
+        assertThat(typedInputs(inputsWithMissingOptionalInput)).containsKey("bool");
         assertThat(typedInputs(inputsWithMissingOptionalInput).get("bool")).isNull();
     }
 
@@ -132,34 +132,34 @@ public class InputsTest {
     void allValidInputs() throws URISyntaxException, IOException {
         Map<String, Object> typeds = typedInputs(inputs);
 
-        assertThat(typeds.get("string")).isEqualTo("myString");
-        assertThat(typeds.get("int")).isEqualTo(42);
-        assertThat(typeds.get("float")).isEqualTo(42.42F);
+        assertThat(typeds).containsEntry("string", "myString");
+        assertThat(typeds).containsEntry("int", 42);
+        assertThat(typeds).containsEntry("float", 42.42F);
         assertThat((Boolean) typeds.get("bool")).isFalse();
-        assertThat(typeds.get("instant")).isEqualTo(Instant.parse("2019-10-06T18:27:49Z"));
-        assertThat(typeds.get("instantDefaults")).isEqualTo(Instant.parse("2013-08-09T14:19:00Z"));
-        assertThat(typeds.get("date")).isEqualTo(LocalDate.parse("2019-10-06"));
-        assertThat(typeds.get("time")).isEqualTo(LocalTime.parse("18:27:49"));
-        assertThat(typeds.get("duration")).isEqualTo(Duration.parse("PT5M6S"));
+        assertThat(typeds).containsEntry("instant", Instant.parse("2019-10-06T18:27:49Z"));
+        assertThat(typeds).containsEntry("instantDefaults", Instant.parse("2013-08-09T14:19:00Z"));
+        assertThat(typeds).containsEntry("date", LocalDate.parse("2019-10-06"));
+        assertThat(typeds).containsEntry("time", LocalTime.parse("18:27:49"));
+        assertThat(typeds).containsEntry("duration", Duration.parse("PT5M6S"));
         assertThat((URI) typeds.get("file")).isEqualTo(new URI("kestra:///io/kestra/tests/inputs/executions/test/inputs/file/application-test.yml"));
         assertThat(CharStreams.toString(new InputStreamReader(storageInterface.get(null, null, (URI) typeds.get("file"))))).isEqualTo(CharStreams.toString(new InputStreamReader(new FileInputStream((String) inputs.get("file")))));
-        assertThat(typeds.get("json")).isEqualTo(Map.of("a", "b"));
-        assertThat(typeds.get("uri")).isEqualTo("https://www.google.com");
-        assertThat(((Map<String, Object>) typeds.get("nested")).get("string")).isEqualTo("a string");
+        assertThat(typeds).containsEntry("json", Map.of("a", "b"));
+        assertThat(typeds).containsEntry("uri", "https://www.google.com");
+        assertThat(((Map<String, Object>) typeds.get("nested"))).containsEntry("string", "a string");
         assertThat((Boolean) ((Map<String, Object>) typeds.get("nested")).get("bool")).isTrue();
-        assertThat(((Map<String, Object>) ((Map<String, Object>) typeds.get("nested")).get("more")).get("int")).isEqualTo(123);
-        assertThat(typeds.get("validatedString")).isEqualTo("A123");
-        assertThat(typeds.get("validatedInt")).isEqualTo(12);
-        assertThat(typeds.get("validatedDate")).isEqualTo(LocalDate.parse("2023-01-02"));
-        assertThat(typeds.get("validatedDateTime")).isEqualTo(Instant.parse("2023-01-01T00:00:10Z"));
-        assertThat(typeds.get("validatedDuration")).isEqualTo(Duration.parse("PT15S"));
-        assertThat(typeds.get("validatedFloat")).isEqualTo(0.42F);
-        assertThat(typeds.get("validatedTime")).isEqualTo(LocalTime.parse("11:27:49"));
+        assertThat(((Map<String, Object>) ((Map<String, Object>) typeds.get("nested")).get("more"))).containsEntry("int", 123);
+        assertThat(typeds).containsEntry("validatedString", "A123");
+        assertThat(typeds).containsEntry("validatedInt", 12);
+        assertThat(typeds).containsEntry("validatedDate", LocalDate.parse("2023-01-02"));
+        assertThat(typeds).containsEntry("validatedDateTime", Instant.parse("2023-01-01T00:00:10Z"));
+        assertThat(typeds).containsEntry("validatedDuration", Duration.parse("PT15S"));
+        assertThat(typeds).containsEntry("validatedFloat", 0.42F);
+        assertThat(typeds).containsEntry("validatedTime", LocalTime.parse("11:27:49"));
         assertThat(typeds.get("secret")).isNotEqualTo("secret"); // secret inputs are encrypted
         assertThat(typeds.get("array")).isInstanceOf(List.class);
         assertThat((List<Integer>) typeds.get("array")).hasSize(3);
         assertThat((List<Integer>) typeds.get("array")).isEqualTo(List.of(1, 2, 3));
-        assertThat(typeds.get("yaml")).isEqualTo(Map.of(
+        assertThat(typeds).containsEntry("yaml", Map.of(
             "some", "property",
             "alist", List.of("of", "values")));
     }
@@ -172,10 +172,10 @@ public class InputsTest {
         typeds.put("float", 42.42F);
         typeds.put("bool", false);
 
-        assertThat(typeds.get("string")).isEqualTo("myString");
-        assertThat(typeds.get("enum")).isEqualTo("ENUM_VALUE");
-        assertThat(typeds.get("int")).isEqualTo(42);
-        assertThat(typeds.get("float")).isEqualTo(42.42F);
+        assertThat(typeds).containsEntry("string", "myString");
+        assertThat(typeds).containsEntry("enum", "ENUM_VALUE");
+        assertThat(typeds).containsEntry("int", 42);
+        assertThat(typeds).containsEntry("float", 42.42F);
         assertThat((Boolean) typeds.get("bool")).isFalse();
     }
 

--- a/core/src/test/java/io/kestra/core/runners/ListenersTest.java
+++ b/core/src/test/java/io/kestra/core/runners/ListenersTest.java
@@ -46,7 +46,7 @@ class ListenersTest {
         );
 
         assertThat(execution.getTaskRunList().get(1).getTaskId()).isEqualTo("ok");
-        assertThat(execution.getTaskRunList().size()).isEqualTo(3);
+        assertThat(execution.getTaskRunList()).hasSize(3);
         assertThat((String) execution.getTaskRunList().get(2).getOutputs().get("value")).contains("flowId=listeners");
     }
 
@@ -61,7 +61,7 @@ class ListenersTest {
         );
 
         assertThat(execution.getTaskRunList().get(1).getTaskId()).isEqualTo("ko");
-        assertThat(execution.getTaskRunList().size()).isEqualTo(3);
+        assertThat(execution.getTaskRunList()).hasSize(3);
         assertThat(execution.getTaskRunList().get(2).getTaskId()).isEqualTo("execution-failed-listener");
     }
 
@@ -75,7 +75,7 @@ class ListenersTest {
             (f, e) -> ImmutableMap.of("string", "execution")
         );
 
-        assertThat(execution.getTaskRunList().size()).isEqualTo(3);
+        assertThat(execution.getTaskRunList()).hasSize(3);
         assertThat(execution.getTaskRunList().get(1).getTaskId()).isEqualTo("parent-seq");
         assertThat(execution.getTaskRunList().get(2).getTaskId()).isEqualTo("execution-success-listener");
         assertThat((String) execution.getTaskRunList().get(2).getOutputs().get("value")).contains(execution.getId());
@@ -89,7 +89,7 @@ class ListenersTest {
             "listeners-multiple"
         );
 
-        assertThat(execution.getTaskRunList().size()).isEqualTo(3);
+        assertThat(execution.getTaskRunList()).hasSize(3);
         assertThat(execution.getTaskRunList().get(1).getTaskId()).isEqualTo("l1");
         assertThat(execution.getTaskRunList().get(2).getTaskId()).isEqualTo("l2");
     }
@@ -103,7 +103,7 @@ class ListenersTest {
         );
 
         assertThat(execution.getState().getCurrent()).isEqualTo(State.Type.SUCCESS);
-        assertThat(execution.getTaskRunList().size()).isEqualTo(2);
+        assertThat(execution.getTaskRunList()).hasSize(2);
         assertThat(execution.getTaskRunList().get(1).getTaskId()).isEqualTo("ko");
         assertThat(execution.getTaskRunList().get(1).getState().getCurrent()).isEqualTo(State.Type.FAILED);
     }
@@ -117,7 +117,7 @@ class ListenersTest {
         );
 
         assertThat(execution.getState().getCurrent()).isEqualTo(State.Type.SUCCESS);
-        assertThat(execution.getTaskRunList().size()).isEqualTo(3);
+        assertThat(execution.getTaskRunList()).hasSize(3);
         assertThat(execution.getTaskRunList().get(1).getTaskId()).isEqualTo("ko");
         assertThat(execution.getTaskRunList().get(1).getState().getCurrent()).isEqualTo(State.Type.FAILED);
         assertThat(execution.getTaskRunList().get(2).getTaskId()).isEqualTo("l2");

--- a/core/src/test/java/io/kestra/core/runners/LocalWorkingDirTest.java
+++ b/core/src/test/java/io/kestra/core/runners/LocalWorkingDirTest.java
@@ -36,10 +36,10 @@ class LocalWorkingDirTest {
         LocalWorkingDir workingDirectory = new LocalWorkingDir(Path.of("/tmp"), IdUtils.create());
 
         Path path = workingDirectory.resolve(Path.of("file.txt"));
-        assertThat(path.toString()).isEqualTo(workingDirectory.path() + "/file.txt");
+        assertThat(path).hasToString(workingDirectory.path() + "/file.txt");
 
         path = workingDirectory.resolve(Path.of("subdir/file.txt"));
-        assertThat(path.toString()).isEqualTo(workingDirectory.path() + "/subdir/file.txt");
+        assertThat(path).hasToString(workingDirectory.path() + "/subdir/file.txt");
 
         assertThat(workingDirectory.resolve(null)).isEqualTo(workingDirectory.path());
         assertThrows(IllegalArgumentException.class, () -> workingDirectory.resolve(Path.of("/etc/passwd")));
@@ -52,8 +52,8 @@ class LocalWorkingDirTest {
         String workingDirId = IdUtils.create();
         TestWorkingDir workingDirectory = new TestWorkingDir(workingDirId, new LocalWorkingDir(Path.of("/tmp/sub/dir/tmp/"), workingDirId));
         Path tempFile = workingDirectory.createTempFile();
-        assertThat(tempFile.toFile().getAbsolutePath().startsWith("/tmp/sub/dir/tmp/")).isTrue();
-        assertThat(workingDirectory.getAllCreatedTempFiles().size()).isEqualTo(1);
+        assertThat(tempFile.toFile().getAbsolutePath()).startsWith("/tmp/sub/dir/tmp/");
+        assertThat(workingDirectory.getAllCreatedTempFiles()).hasSize(1);
     }
 
     @Test
@@ -62,9 +62,9 @@ class LocalWorkingDirTest {
         TestWorkingDir workingDirectory = new TestWorkingDir(workingDirId, new LocalWorkingDir(Path.of("/tmp/sub/dir/tmp/"), workingDirId));
         Path path = workingDirectory.createFile("folder/file.txt");
 
-        assertThat(path.toFile().getAbsolutePath().startsWith("/tmp/sub/dir/tmp/")).isTrue();
-        assertThat(path.toFile().getAbsolutePath().endsWith("/folder/file.txt")).isTrue();
-        assertThat(workingDirectory.getAllCreatedFiles().size()).isEqualTo(1);
+        assertThat(path.toFile().getAbsolutePath()).startsWith("/tmp/sub/dir/tmp/");
+        assertThat(path.toFile().getAbsolutePath()).endsWith("/folder/file.txt");
+        assertThat(workingDirectory.getAllCreatedFiles()).hasSize(1);
     }
 
     @Test
@@ -91,13 +91,13 @@ class LocalWorkingDirTest {
         // When - Then
 
         // glob
-        assertThat(workingDir.findAllFilesMatching(List.of("glob:**/*.*")).size()).isEqualTo(5);
+        assertThat(workingDir.findAllFilesMatching(List.of("glob:**/*.*"))).hasSize(5);
         // pattern
-        assertThat(workingDir.findAllFilesMatching(List.of("*.*", "**/*.*")).size()).isEqualTo(5);
+        assertThat(workingDir.findAllFilesMatching(List.of("*.*", "**/*.*"))).hasSize(5);
         // duplicate pattern
-        assertThat(workingDir.findAllFilesMatching(List.of("*.*", "**/*.*", "**/*.*")).size()).isEqualTo(5);
+        assertThat(workingDir.findAllFilesMatching(List.of("*.*", "**/*.*", "**/*.*"))).hasSize(5);
         // regex
-        assertThat(workingDir.findAllFilesMatching(List.of("regex:.*\\.tmp", "*.txt", "**/*.txt")).size()).isEqualTo(5);
+        assertThat(workingDir.findAllFilesMatching(List.of("regex:.*\\.tmp", "*.txt", "**/*.txt"))).hasSize(5);
     }
 
     @Test
@@ -117,7 +117,7 @@ class LocalWorkingDirTest {
         // When
         Path secondPath = workingDir.path(true);
         // Then
-        assertThat(secondPath.toFile().exists()).isTrue();
+        assertThat(secondPath.toFile()).exists();
         assertThat(firtPath).isEqualTo(secondPath);
     }
 

--- a/core/src/test/java/io/kestra/core/runners/LogToFileTest.java
+++ b/core/src/test/java/io/kestra/core/runners/LogToFileTest.java
@@ -35,7 +35,7 @@ public class LogToFileTest {
         InputStream inputStream = storage.get(null, "io.kestra.tests", attempt.getLogFile());
         List<String> strings = IOUtils.readLines(inputStream, StandardCharsets.UTF_8);
         assertThat(strings).isNotNull();
-        assertThat(strings.size()).isEqualTo(1);
+        assertThat(strings).hasSize(1);
         assertThat(strings.getFirst()).contains("INFO");
         assertThat(strings.getFirst()).contains("Hello World!");
     }

--- a/core/src/test/java/io/kestra/core/runners/MultipleConditionTriggerCaseTest.java
+++ b/core/src/test/java/io/kestra/core/runners/MultipleConditionTriggerCaseTest.java
@@ -62,23 +62,23 @@ public class MultipleConditionTriggerCaseTest {
         // first one
         Execution execution = runnerUtils.runOne(null, "io.kestra.tests.trigger",
             "trigger-multiplecondition-flow-a", Duration.ofSeconds(60));
-        assertThat(execution.getTaskRunList().size()).isEqualTo(1);
+        assertThat(execution.getTaskRunList()).hasSize(1);
         assertThat(execution.getState().getCurrent()).isEqualTo(State.Type.SUCCESS);
 
         // wait a little to be sure that the trigger is not launching execution
         Thread.sleep(1000);
-        assertThat(ended.size()).isEqualTo(1);
+        assertThat(ended).hasSize(1);
 
         // second one
         execution = runnerUtils.runOne(null, "io.kestra.tests.trigger",
             "trigger-multiplecondition-flow-b", Duration.ofSeconds(60));
-        assertThat(execution.getTaskRunList().size()).isEqualTo(1);
+        assertThat(execution.getTaskRunList()).hasSize(1);
         assertThat(execution.getState().getCurrent()).isEqualTo(State.Type.SUCCESS);
 
         // trigger is done
         assertTrue(countDownLatch.await(10, TimeUnit.SECONDS));
         receive.blockLast();
-        assertThat(ended.size()).isEqualTo(3);
+        assertThat(ended).hasSize(3);
 
         Flow flow = flowRepository.findById(null, "io.kestra.tests.trigger",
             "trigger-multiplecondition-listener").orElseThrow();
@@ -89,12 +89,12 @@ public class MultipleConditionTriggerCaseTest {
             .map(Map.Entry::getValue)
             .orElseThrow();
 
-        assertThat(triggerExecution.getTaskRunList().size()).isEqualTo(1);
+        assertThat(triggerExecution.getTaskRunList()).hasSize(1);
         assertThat(triggerExecution.getState().getCurrent()).isEqualTo(State.Type.SUCCESS);
 
-        assertThat(triggerExecution.getTrigger().getVariables().get("executionId")).isEqualTo(execution.getId());
-        assertThat(triggerExecution.getTrigger().getVariables().get("namespace")).isEqualTo("io.kestra.tests.trigger");
-        assertThat(triggerExecution.getTrigger().getVariables().get("flowId")).isEqualTo("trigger-multiplecondition-flow-b");
+        assertThat(triggerExecution.getTrigger().getVariables()).containsEntry("executionId", execution.getId());
+        assertThat(triggerExecution.getTrigger().getVariables()).containsEntry("namespace", "io.kestra.tests.trigger");
+        assertThat(triggerExecution.getTrigger().getVariables()).containsEntry("flowId", "trigger-multiplecondition-flow-b");
     }
 
     public void failed() throws InterruptedException, TimeoutException, QueueException {
@@ -112,7 +112,7 @@ public class MultipleConditionTriggerCaseTest {
         // first one
         Execution execution = runnerUtils.runOne(null, "io.kestra.tests.trigger",
             "trigger-multiplecondition-flow-c", Duration.ofSeconds(60));
-        assertThat(execution.getTaskRunList().size()).isEqualTo(1);
+        assertThat(execution.getTaskRunList()).hasSize(1);
         assertThat(execution.getState().getCurrent()).isEqualTo(State.Type.FAILED);
 
         // wait a little to be sure that the trigger is not launching execution
@@ -122,7 +122,7 @@ public class MultipleConditionTriggerCaseTest {
         // second one
         execution = runnerUtils.runOne(null, "io.kestra.tests.trigger",
             "trigger-multiplecondition-flow-d", Duration.ofSeconds(60));
-        assertThat(execution.getTaskRunList().size()).isEqualTo(1);
+        assertThat(execution.getTaskRunList()).hasSize(1);
         assertThat(execution.getState().getCurrent()).isEqualTo(State.Type.SUCCESS);
 
         // trigger was not done
@@ -149,17 +149,17 @@ public class MultipleConditionTriggerCaseTest {
         // flowA
         Execution execution = runnerUtils.runOne(null, "io.kestra.tests.trigger.preconditions",
             "flow-trigger-preconditions-flow-a", Duration.ofSeconds(60));
-        assertThat(execution.getTaskRunList().size()).isEqualTo(1);
+        assertThat(execution.getTaskRunList()).hasSize(1);
         assertThat(execution.getState().getCurrent()).isEqualTo(State.Type.SUCCESS);
 
         // flowB: we trigger it two times, as flow-trigger-flow-preconditions-flow-listen is configured with resetOnSuccess: false it should be triggered two times
         execution = runnerUtils.runOne(null, "io.kestra.tests.trigger.preconditions",
             "flow-trigger-preconditions-flow-a", Duration.ofSeconds(60));
-        assertThat(execution.getTaskRunList().size()).isEqualTo(1);
+        assertThat(execution.getTaskRunList()).hasSize(1);
         assertThat(execution.getState().getCurrent()).isEqualTo(State.Type.SUCCESS);
         execution = runnerUtils.runOne(null, "io.kestra.tests.trigger.preconditions",
             "flow-trigger-preconditions-flow-b", Duration.ofSeconds(60));
-        assertThat(execution.getTaskRunList().size()).isEqualTo(1);
+        assertThat(execution.getTaskRunList()).hasSize(1);
         assertThat(execution.getState().getCurrent()).isEqualTo(State.Type.SUCCESS);
 
         // trigger is done
@@ -168,7 +168,7 @@ public class MultipleConditionTriggerCaseTest {
         assertThat(flowTrigger.get()).isNotNull();
 
         Execution triggerExecution = flowTrigger.get();
-        assertThat(triggerExecution.getTaskRunList().size()).isEqualTo(1);
+        assertThat(triggerExecution.getTaskRunList()).hasSize(1);
         assertThat(triggerExecution.getState().getCurrent()).isEqualTo(State.Type.SUCCESS);
         assertThat(triggerExecution.getTrigger().getVariables().get("outputs")).isNotNull();
         assertThat((Map<String, Object>) triggerExecution.getTrigger().getVariables().get("outputs")).containsEntry("some", "value");
@@ -191,13 +191,13 @@ public class MultipleConditionTriggerCaseTest {
         // flowB
         Execution execution = runnerUtils.runOne(null, "io.kestra.tests.trigger.preconditions",
             "flow-trigger-preconditions-flow-b", Duration.ofSeconds(60));
-        assertThat(execution.getTaskRunList().size()).isEqualTo(1);
+        assertThat(execution.getTaskRunList()).hasSize(1);
         assertThat(execution.getState().getCurrent()).isEqualTo(State.Type.SUCCESS);
 
         // flowA
         execution = runnerUtils.runOne(null, "io.kestra.tests.trigger.preconditions",
             "flow-trigger-preconditions-flow-a", Duration.ofSeconds(60));
-        assertThat(execution.getTaskRunList().size()).isEqualTo(1);
+        assertThat(execution.getTaskRunList()).hasSize(1);
         assertThat(execution.getState().getCurrent()).isEqualTo(State.Type.SUCCESS);
 
         // trigger is done
@@ -206,7 +206,7 @@ public class MultipleConditionTriggerCaseTest {
         assertThat(flowTrigger.get()).isNotNull();
 
         Execution triggerExecution = flowTrigger.get();
-        assertThat(triggerExecution.getTaskRunList().size()).isEqualTo(1);
+        assertThat(triggerExecution.getTaskRunList()).hasSize(1);
         assertThat(triggerExecution.getState().getCurrent()).isEqualTo(State.Type.SUCCESS);
         assertThat(triggerExecution.getTrigger().getVariables().get("outputs")).isNotNull();
         assertThat((Map<String, Object>) triggerExecution.getTrigger().getVariables().get("outputs")).containsEntry("some", "value");
@@ -228,7 +228,7 @@ public class MultipleConditionTriggerCaseTest {
 
         Execution execution = runnerUtils.runOne(null, "io.kestra.tests.trigger.paused",
             "flow-trigger-paused-flow", Duration.ofSeconds(60));
-        assertThat(execution.getTaskRunList().size()).isEqualTo(2);
+        assertThat(execution.getTaskRunList()).hasSize(2);
         assertThat(execution.getState().getCurrent()).isEqualTo(State.Type.SUCCESS);
 
         // trigger is done
@@ -237,7 +237,7 @@ public class MultipleConditionTriggerCaseTest {
         assertThat(flowTrigger.get()).isNotNull();
 
         Execution triggerExecution = flowTrigger.get();
-        assertThat(triggerExecution.getTaskRunList().size()).isEqualTo(1);
+        assertThat(triggerExecution.getTaskRunList()).hasSize(1);
         assertThat(triggerExecution.getState().getCurrent()).isEqualTo(State.Type.SUCCESS);
     }
 }

--- a/core/src/test/java/io/kestra/core/runners/NoEncryptionConfiguredTest.java
+++ b/core/src/test/java/io/kestra/core/runners/NoEncryptionConfiguredTest.java
@@ -47,19 +47,19 @@ public class NoEncryptionConfiguredTest implements TestPropertyProvider {
         assertThat(execution.getTaskRunList()).hasSize(2);
         TaskRun hello = execution.findTaskRunsByTaskId("hello").getFirst();
         Map<String, String> valueOutput = (Map<String, String>) hello.getOutputs().get("value");
-        assertThat(valueOutput.size()).isEqualTo(2);
-        assertThat(valueOutput.get("type")).isEqualTo(EncryptedString.TYPE);
+        assertThat(valueOutput).hasSize(2);
+        assertThat(valueOutput).containsEntry("type", EncryptedString.TYPE);
         // the value is not encrypted as there is no encryption key
-        assertThat(valueOutput.get("value")).isEqualTo("Hello World");
+        assertThat(valueOutput).containsEntry("value", "Hello World");
         TaskRun returnTask = execution.findTaskRunsByTaskId("return").getFirst();
         // the output is automatically decrypted so the return has the decrypted value of the hello task output
-        assertThat(returnTask.getOutputs().get("value")).isEqualTo("Hello World");
+        assertThat(returnTask.getOutputs()).containsEntry("value", "Hello World");
     }
 
     @Test
     @LoadFlows({"flows/valids/inputs.yaml"})
     void secretInput() {
-        assertThat(flowRepository.findById(null, "io.kestra.tests", "inputs").isPresent()).isTrue();
+        assertThat(flowRepository.findById(null, "io.kestra.tests", "inputs")).isPresent();
 
         Flow flow = flowRepository.findById(null, "io.kestra.tests", "inputs").get();
         Execution execution = Execution.builder()

--- a/core/src/test/java/io/kestra/core/runners/NullOutputTest.java
+++ b/core/src/test/java/io/kestra/core/runners/NullOutputTest.java
@@ -39,6 +39,6 @@ public class NullOutputTest {
         assertThat(execution.getState().getCurrent()).isEqualTo(State.Type.SUCCESS);
         assertThat(execution.getTaskRunList()).hasSize(1);
         assertThat(execution.getTaskRunList().getFirst().getOutputs()).hasSize(1);
-        assertThat(execution.getTaskRunList().getFirst().getOutputs().containsKey("value")).isTrue();
+        assertThat(execution.getTaskRunList().getFirst().getOutputs()).containsKey("value");
     }
 }

--- a/core/src/test/java/io/kestra/core/runners/PluginDefaultsCaseTest.java
+++ b/core/src/test/java/io/kestra/core/runners/PluginDefaultsCaseTest.java
@@ -37,18 +37,18 @@ public class PluginDefaultsCaseTest {
         assertThat(execution.getTaskRunList()).hasSize(8);
 
         assertThat(execution.getTaskRunList().getFirst().getTaskId()).isEqualTo("first");
-        assertThat(execution.getTaskRunList().getFirst().getOutputs().get("def")).isEqualTo("1");
+        assertThat(execution.getTaskRunList().getFirst().getOutputs()).containsEntry("def", "1");
         assertThat(execution.getTaskRunList().get(1).getTaskId()).isEqualTo("second");
-        assertThat(execution.getTaskRunList().get(1).getOutputs().get("def")).isEqualTo("2");
+        assertThat(execution.getTaskRunList().get(1).getOutputs()).containsEntry("def", "2");
         assertThat(execution.getTaskRunList().get(2).getTaskId()).isEqualTo("third");
-        assertThat(execution.getTaskRunList().get(2).getOutputs().get("def")).isEqualTo("3");
+        assertThat(execution.getTaskRunList().get(2).getOutputs()).containsEntry("def", "3");
 
         assertThat(execution.getTaskRunList().get(4).getTaskId()).isEqualTo("err-first");
-        assertThat(execution.getTaskRunList().get(4).getOutputs().get("def")).isEqualTo("1");
+        assertThat(execution.getTaskRunList().get(4).getOutputs()).containsEntry("def", "1");
         assertThat(execution.getTaskRunList().get(5).getTaskId()).isEqualTo("err-second");
-        assertThat(execution.getTaskRunList().get(5).getOutputs().get("def")).isEqualTo("2");
+        assertThat(execution.getTaskRunList().get(5).getOutputs()).containsEntry("def", "2");
         assertThat(execution.getTaskRunList().get(6).getTaskId()).isEqualTo("err-third");
-        assertThat(execution.getTaskRunList().get(6).getOutputs().get("def")).isEqualTo("3");
+        assertThat(execution.getTaskRunList().get(6).getOutputs()).containsEntry("def", "3");
     }
 
     @SuperBuilder
@@ -65,6 +65,7 @@ public class PluginDefaultsCaseTest {
         @Getter(AccessLevel.NONE)
         protected List<Task> _finally;
 
+        @Override
         public List<Task> getFinally() {
             return this._finally;
         }

--- a/core/src/test/java/io/kestra/core/runners/RestartCaseTest.java
+++ b/core/src/test/java/io/kestra/core/runners/RestartCaseTest.java
@@ -59,7 +59,7 @@ public class RestartCaseTest {
                 assertThat(restartedExec).isNotNull();
                 assertThat(restartedExec.getId()).isEqualTo(firstExecution.getId());
                 assertThat(restartedExec.getParentId()).isNull();
-                assertThat(restartedExec.getTaskRunList().size()).isEqualTo(3);
+                assertThat(restartedExec.getTaskRunList()).hasSize(3);
                 assertThat(restartedExec.getState().getCurrent()).isEqualTo(State.Type.RESTARTED);
 
                 executionQueue.emit(restartedExec);
@@ -70,9 +70,9 @@ public class RestartCaseTest {
         assertThat(finishedRestartedExecution).isNotNull();
         assertThat(finishedRestartedExecution.getId()).isEqualTo(firstExecution.getId());
         assertThat(finishedRestartedExecution.getParentId()).isNull();
-        assertThat(finishedRestartedExecution.getTaskRunList().size()).isEqualTo(4);
+        assertThat(finishedRestartedExecution.getTaskRunList()).hasSize(4);
 
-        assertThat(finishedRestartedExecution.getTaskRunList().get(2).getAttempts().size()).isEqualTo(2);
+        assertThat(finishedRestartedExecution.getTaskRunList().get(2).getAttempts()).hasSize(2);
 
         finishedRestartedExecution
             .getTaskRunList()
@@ -100,7 +100,7 @@ public class RestartCaseTest {
                 assertThat(restartedExec).isNotNull();
                 assertThat(restartedExec.getId()).isEqualTo(firstExecution.getId());
                 assertThat(restartedExec.getParentId()).isNull();
-                assertThat(restartedExec.getTaskRunList().size()).isEqualTo(1);
+                assertThat(restartedExec.getTaskRunList()).hasSize(1);
                 assertThat(restartedExec.getState().getCurrent()).isEqualTo(State.Type.RESTARTED);
             }),
             Duration.ofSeconds(60)
@@ -109,9 +109,9 @@ public class RestartCaseTest {
         assertThat(finishedRestartedExecution).isNotNull();
         assertThat(finishedRestartedExecution.getId()).isEqualTo(firstExecution.getId());
         assertThat(finishedRestartedExecution.getParentId()).isNull();
-        assertThat(finishedRestartedExecution.getTaskRunList().size()).isEqualTo(2);
+        assertThat(finishedRestartedExecution.getTaskRunList()).hasSize(2);
 
-        assertThat(finishedRestartedExecution.getTaskRunList().getFirst().getAttempts().size()).isEqualTo(2);
+        assertThat(finishedRestartedExecution.getTaskRunList().getFirst().getAttempts()).hasSize(2);
 
         assertThat(finishedRestartedExecution.getState().getCurrent()).isEqualTo(State.Type.FAILED);
     }
@@ -135,7 +135,7 @@ public class RestartCaseTest {
                 assertThat(restartedExec).isNotNull();
                 assertThat(restartedExec.getId()).isEqualTo(firstExecution.getId());
                 assertThat(restartedExec.getParentId()).isNull();
-                assertThat(restartedExec.getTaskRunList().size()).isEqualTo(4);
+                assertThat(restartedExec.getTaskRunList()).hasSize(4);
                 assertThat(restartedExec.getState().getCurrent()).isEqualTo(State.Type.RESTARTED);
             }),
             Duration.ofSeconds(60)
@@ -144,11 +144,11 @@ public class RestartCaseTest {
         assertThat(finishedRestartedExecution).isNotNull();
         assertThat(finishedRestartedExecution.getId()).isEqualTo(firstExecution.getId());
         assertThat(finishedRestartedExecution.getParentId()).isNull();
-        assertThat(finishedRestartedExecution.getTaskRunList().size()).isEqualTo(5);
+        assertThat(finishedRestartedExecution.getTaskRunList()).hasSize(5);
 
         Optional<TaskRun> taskRun = finishedRestartedExecution.findTaskRunsByTaskId("failStep").stream().findFirst();
         assertTrue(taskRun.isPresent());
-        assertThat(taskRun.get().getAttempts().size()).isEqualTo(2);
+        assertThat(taskRun.get().getAttempts()).hasSize(2);
 
         assertThat(finishedRestartedExecution.getState().getCurrent()).isEqualTo(State.Type.FAILED);
     }

--- a/core/src/test/java/io/kestra/core/runners/RunContextPropertyTest.java
+++ b/core/src/test/java/io/kestra/core/runners/RunContextPropertyTest.java
@@ -44,10 +44,10 @@ class RunContextPropertyTest {
         var runContext = runContextFactory.of();
 
         var runContextProperty = new RunContextProperty<List<String>>(null, runContext);
-        assertThat(runContextProperty.asList(String.class)).hasSize(0);
+        assertThat(runContextProperty.asList(String.class)).isEmpty();
 
         runContextProperty = new RunContextProperty<>(null, runContext);
-        assertThat(runContextProperty.asList(String.class, Map.of("key", "value"))).hasSize(0);
+        assertThat(runContextProperty.asList(String.class, Map.of("key", "value"))).isEmpty();
     }
 
     @Test
@@ -66,10 +66,10 @@ class RunContextPropertyTest {
         var runContext = runContextFactory.of();
 
         var runContextProperty = new RunContextProperty<Map<String, String>>(null, runContext);
-        assertThat(runContextProperty.asMap(String.class, String.class)).hasSize(0);
+        assertThat(runContextProperty.asMap(String.class, String.class)).isEmpty();
 
         runContextProperty = new RunContextProperty<>(null, runContext);
-        assertThat(runContextProperty.asMap(String.class, String.class, Map.of("key", "value"))).hasSize(0);
+        assertThat(runContextProperty.asMap(String.class, String.class, Map.of("key", "value"))).isEmpty();
     }
 
     @Test

--- a/core/src/test/java/io/kestra/core/runners/RunContextTest.java
+++ b/core/src/test/java/io/kestra/core/runners/RunContextTest.java
@@ -173,8 +173,8 @@ class RunContextTest {
         assertThat(ZonedDateTime.parse((String) execution.getTaskRunList().getFirst().getOutputs().get("value")))
             .isCloseTo(ZonedDateTime.now(), within(10, ChronoUnit.SECONDS));
 
-        assertThat(execution.getTaskRunList().get(1).getOutputs().get("value")).isEqualTo("task-id");
-        assertThat(execution.getTaskRunList().get(2).getOutputs().get("value")).isEqualTo("return");
+        assertThat(execution.getTaskRunList().get(1).getOutputs()).containsEntry("value", "task-id");
+        assertThat(execution.getTaskRunList().get(2).getOutputs()).containsEntry("value", "return");
     }
 
     @Test
@@ -190,7 +190,7 @@ class RunContextTest {
 
         long size = 1024L * 1024 * 1024;
 
-        Process p = Runtime.getRuntime().exec(new String[] {"dd", "if=/dev/zero", String.format("of=%s", path), "bs=1", "count=1", String.format("seek=%s", size)});
+        Process p = Runtime.getRuntime().exec(new String[] {"dd", "if=/dev/zero", "of=%s".formatted(path), "bs=1", "count=1", "seek=%s".formatted(size)});
         p.waitFor();
         p.destroy();
 
@@ -219,10 +219,10 @@ class RunContextTest {
         assertThat(metricRegistry.timer("duration", null).totalTime(TimeUnit.SECONDS)).isEqualTo(42D);
 
         assertThat(runContext.metrics().get(2).getValue()).isEqualTo(123D);
-        assertThat(runContext.metrics().get(2).getTags().size()).isEqualTo(1);
+        assertThat(runContext.metrics().get(2).getTags()).hasSize(1);
 
         assertThat(runContext.metrics().get(3).getValue()).isEqualTo(Duration.ofSeconds(123));
-        assertThat(runContext.metrics().get(3).getTags().size()).isEqualTo(1);
+        assertThat(runContext.metrics().get(3).getTags()).hasSize(1);
     }
 
     @Test
@@ -246,13 +246,13 @@ class RunContextTest {
         assertThat(execution.getTaskRunList()).hasSize(2);
         TaskRun hello = execution.findTaskRunsByTaskId("hello").getFirst();
         Map<String, String> valueOutput = (Map<String, String>) hello.getOutputs().get("value");
-        assertThat(valueOutput.size()).isEqualTo(2);
-        assertThat(valueOutput.get("type")).isEqualTo(EncryptedString.TYPE);
+        assertThat(valueOutput).hasSize(2);
+        assertThat(valueOutput).containsEntry("type", EncryptedString.TYPE);
         // the value is encrypted so it's not the plaintext value of the task property
         assertThat(valueOutput.get("value")).isNotEqualTo("Hello World");
         TaskRun returnTask = execution.findTaskRunsByTaskId("return").getFirst();
         // the output is automatically decrypted so the return has the decrypted value of the hello task output
-        assertThat(returnTask.getOutputs().get("value")).isEqualTo("Hello World");
+        assertThat(returnTask.getOutputs()).containsEntry("value", "Hello World");
     }
 
     @Test
@@ -283,13 +283,13 @@ class RunContextTest {
         ));
 
         Map<String, String> rendered = runContext.renderMap(Map.of("{{key}}", "{{value}}"));
-        assertThat(rendered.get("default")).isEqualTo("default");
+        assertThat(rendered).containsEntry("default", "default");
 
         rendered = runContext.renderMap(Map.of("{{key}}", "{{value}}"), Map.of(
             "key", "key",
             "value", "value"
         ));
-        assertThat(rendered.get("key")).isEqualTo("value");
+        assertThat(rendered).containsEntry("key", "value");
     }
 
 

--- a/core/src/test/java/io/kestra/core/runners/RunVariablesTest.java
+++ b/core/src/test/java/io/kestra/core/runners/RunVariablesTest.java
@@ -17,7 +17,7 @@ class RunVariablesTest {
     @SuppressWarnings("unchecked")
     void shouldGetEmptyVariables() {
         Map<String, Object> variables = new RunVariables.DefaultBuilder().build(new RunContextLogger());
-        assertThat(variables.size()).isEqualTo(3);
+        assertThat(variables).hasSize(3);
         assertThat((Map<String, Object>) variables.get("envs")).isEqualTo(Map.of());
         assertThat((Map<String, Object>) variables.get("globals")).isEqualTo(Map.of());
         assertThat(variables.get("addSecretConsumer")).isNotNull();
@@ -103,10 +103,10 @@ class RunVariablesTest {
         Map<String, Object> variables = new RunVariables.DefaultBuilder()
             .withKestraConfiguration(new RunVariables.KestraConfiguration("test", "http://localhost:8080"))
             .build(new RunContextLogger());
-        assertThat(variables.size()).isEqualTo(4);
+        assertThat(variables).hasSize(4);
         Map<String, Object> kestra = (Map<String, Object>) variables.get("kestra");
         assertThat(kestra).hasSize(2);
-        assertThat(kestra.get("environment")).isEqualTo("test");
-        assertThat(kestra.get("url")).isEqualTo("http://localhost:8080");
+        assertThat(kestra).containsEntry("environment", "test");
+        assertThat(kestra).containsEntry("url", "http://localhost:8080");
     }
 }

--- a/core/src/test/java/io/kestra/core/runners/RunnableTaskExceptionTest.java
+++ b/core/src/test/java/io/kestra/core/runners/RunnableTaskExceptionTest.java
@@ -15,6 +15,6 @@ class RunnableTaskExceptionTest {
     void simple(Execution execution) {
         assertThat(execution.getState().getCurrent()).isEqualTo(State.Type.FAILED);
         assertThat(execution.getTaskRunList()).hasSize(1);
-        assertThat(execution.getTaskRunList().get(0).getOutputs().get("message")).isEqualTo("Oh no!");
+        assertThat(execution.getTaskRunList().getFirst().getOutputs()).containsEntry("message", "Oh no!");
     }
 }

--- a/core/src/test/java/io/kestra/core/runners/TaskWithAllowFailureTest.java
+++ b/core/src/test/java/io/kestra/core/runners/TaskWithAllowFailureTest.java
@@ -39,7 +39,7 @@ public class TaskWithAllowFailureTest {
     void runnableTask(Execution execution) {
         assertThat(execution.getState().getCurrent()).isEqualTo(State.Type.WARNING);
         assertThat(execution.getTaskRunList()).hasSize(2);
-        assertThat(execution.findTaskRunsByTaskId("fail").getFirst().getAttempts().size()).isEqualTo(3);
+        assertThat(execution.findTaskRunsByTaskId("fail").getFirst().getAttempts()).hasSize(3);
     }
 
     @Test

--- a/core/src/test/java/io/kestra/core/runners/TaskWithAllowWarningTest.java
+++ b/core/src/test/java/io/kestra/core/runners/TaskWithAllowWarningTest.java
@@ -40,7 +40,7 @@ public class TaskWithAllowWarningTest {
     void runnableTask(Execution execution) {
         assertThat(execution.getState().getCurrent()).isEqualTo(State.Type.SUCCESS);
         assertThat(execution.getTaskRunList()).hasSize(2);
-        assertThat(execution.findTaskRunsByTaskId("fail").getFirst().getAttempts().size()).isEqualTo(3);
+        assertThat(execution.findTaskRunsByTaskId("fail").getFirst().getAttempts()).hasSize(3);
     }
 
     @Test

--- a/core/src/test/java/io/kestra/core/runners/TestWorkingDir.java
+++ b/core/src/test/java/io/kestra/core/runners/TestWorkingDir.java
@@ -37,6 +37,7 @@ public final class TestWorkingDir implements WorkingDir {
         this.delegate = delegate;
     }
 
+    @Override
     public String id() {
         return id;
     }

--- a/core/src/test/java/io/kestra/core/runners/WorkerTest.java
+++ b/core/src/test/java/io/kestra/core/runners/WorkerTest.java
@@ -77,7 +77,7 @@ class WorkerTest {
         receive.blockLast();
         worker.shutdown();
 
-        assertThat(workerTaskResult.get().getTaskRun().getState().getHistories().size()).isEqualTo(3);
+        assertThat(workerTaskResult.get().getTaskRun().getState().getHistories()).hasSize(3);
     }
 
     @Test
@@ -136,7 +136,7 @@ class WorkerTest {
         receive.blockLast();
         worker.shutdown();
 
-        assertThat(workerTaskResult.get().getTaskRun().getState().getHistories().size()).isEqualTo(3);
+        assertThat(workerTaskResult.get().getTaskRun().getState().getHistories()).hasSize(3);
     }
 
     @Test
@@ -178,14 +178,14 @@ class WorkerTest {
             .filter(r -> r.getTaskRun().getState().getCurrent() == State.Type.KILLED)
             .findFirst()
             .orElseThrow();
-        assertThat(oneKilled.getTaskRun().getState().getHistories().size()).isEqualTo(3);
+        assertThat(oneKilled.getTaskRun().getState().getHistories()).hasSize(3);
         assertThat(oneKilled.getTaskRun().getState().getCurrent()).isEqualTo(State.Type.KILLED);
 
         WorkerTaskResult oneNotKilled = workerTaskResult.stream()
             .filter(r -> r.getTaskRun().getState().getCurrent() == State.Type.SUCCESS)
             .findFirst()
             .orElseThrow();
-        assertThat(oneNotKilled.getTaskRun().getState().getHistories().size()).isEqualTo(3);
+        assertThat(oneNotKilled.getTaskRun().getState().getHistories()).hasSize(3);
         assertThat(oneNotKilled.getTaskRun().getState().getCurrent()).isEqualTo(State.Type.SUCCESS);
 
         // child process is stopped and we never received 3 logs

--- a/core/src/test/java/io/kestra/core/runners/WorkingDirFactoryTest.java
+++ b/core/src/test/java/io/kestra/core/runners/WorkingDirFactoryTest.java
@@ -23,6 +23,6 @@ class WorkingDirFactoryTest {
         // When
         Path path = workingDirectory.path();
         // Then
-        assertThat(path.toFile().getAbsolutePath().startsWith("/tmp/sub/dir/tmp/")).isTrue();
+        assertThat(path.toFile().getAbsolutePath()).startsWith("/tmp/sub/dir/tmp/");
     }
 }

--- a/core/src/test/java/io/kestra/core/runners/pebble/PebbleVariableRendererTest.java
+++ b/core/src/test/java/io/kestra/core/runners/pebble/PebbleVariableRendererTest.java
@@ -58,12 +58,12 @@ class PebbleVariableRendererTest {
 
         Map<String, Object> render = variableRenderer.render(in, vars);
 
-        assertThat(render.get("string")).isEqualTo("string");
-        assertThat(render.get("int")).isEqualTo("1");
-        assertThat(render.get("float")).isEqualTo("1.123");
-        assertThat(render.get("list")).isEqualTo("[\"string\",1,1.123]");
-        assertThat(render.get("bool")).isEqualTo("true");
-        assertThat(render.get("date")).isEqualTo("2013-09-08T16:19+02:00");
+        assertThat(render).containsEntry("string", "string");
+        assertThat(render).containsEntry("int", "1");
+        assertThat(render).containsEntry("float", "1.123");
+        assertThat(render).containsEntry("list", "[\"string\",1,1.123]");
+        assertThat(render).containsEntry("bool", "true");
+        assertThat(render).containsEntry("date", "2013-09-08T16:19+02:00");
         assertThat((String) render.get("map")).contains("\"int\":1");
         assertThat((String) render.get("map")).contains("\"int\":1");
         assertThat((String) render.get("map")).contains("\"float\":1.123");
@@ -71,7 +71,7 @@ class PebbleVariableRendererTest {
         assertThat((String) render.get("map")).startsWith("{");
         assertThat((String) render.get("map")).endsWith("}");
         assertThat((String) render.get("escape")).contains("[\"string\",1,1.123] // {");
-        assertThat((String) render.get("empty")).isEqualTo("");
+        assertThat((String) render.get("empty")).isEmpty();
         assertThat((String) render.get("concat")).isEqualTo("applepearbanana");
     }
 
@@ -95,9 +95,9 @@ class PebbleVariableRendererTest {
 
         assertThat((String) render.get("map")).contains("\"a\":\"1\"");
         assertThat((String) render.get("map")).contains("\"b\":\"2\"");
-        assertThat(render.get("collection")).isEqualTo("[\"1\",\"2\",\"3\"]");
-        assertThat(render.get("array")).isEqualTo("[\"1\",\"2\",\"3\"]");
-        assertThat(render.get("inta")).isEqualTo("[1,2,3]");
+        assertThat(render).containsEntry("collection", "[\"1\",\"2\",\"3\"]");
+        assertThat(render).containsEntry("array", "[\"1\",\"2\",\"3\"]");
+        assertThat(render).containsEntry("inta", "[1,2,3]");
     }
 
     @Test
@@ -146,9 +146,9 @@ class PebbleVariableRendererTest {
 
         Map<String, Object> render = variableRenderer.render(in, vars);
 
-        assertThat(render.get("string")).isEqualTo("top");
+        assertThat(render).containsEntry("string", "top");
         assertThat((List<String>) render.get("list")).containsExactlyInAnyOrder("top", "awesome");
-        assertThat(render.get("int")).isEqualTo(1);
+        assertThat(render).containsEntry("int", 1);
     }
 
     @Test

--- a/core/src/test/java/io/kestra/core/runners/pebble/expression/UndefinedCoalescingExpressionTest.java
+++ b/core/src/test/java/io/kestra/core/runners/pebble/expression/UndefinedCoalescingExpressionTest.java
@@ -23,7 +23,7 @@ class UndefinedCoalescingExpressionTest {
 
         String render = variableRenderer.render("{{ null ??? 'IS NULL' }}", vars);
 
-        assertThat(render).isEqualTo("");
+        assertThat(render).isEmpty();
 
         render = variableRenderer.render("{{ undefined ??? 'IS UNDEFINED' }}", vars);
 

--- a/core/src/test/java/io/kestra/core/runners/pebble/filters/IndentFilterTest.java
+++ b/core/src/test/java/io/kestra/core/runners/pebble/filters/IndentFilterTest.java
@@ -24,7 +24,7 @@ class IndentFilterTest {
     @Test
     void indentEmpty() throws IllegalVariableEvaluationException {
         String render = variableRenderer.render("{{ '' | indent(2) }}", Map.of());
-        assertThat(render).isEqualTo("");
+        assertThat(render).isEmpty();
     }
 
     @Test

--- a/core/src/test/java/io/kestra/core/runners/pebble/filters/JqFilterTest.java
+++ b/core/src/test/java/io/kestra/core/runners/pebble/filters/JqFilterTest.java
@@ -125,7 +125,7 @@ class JqFilterTest {
         assertThat(variableRenderer.render("{{ vars | jq(\".int\") | first | className }}", vars)).isEqualTo("java.lang.Integer");
         assertThat(variableRenderer.render("{{ vars | jq(\".float\") | first | className }}", vars)).isEqualTo("java.lang.Float");
         assertThat(variableRenderer.render("{{ vars | jq(\".bool\") | first | className }}", vars)).isEqualTo("java.lang.Boolean");
-        assertThat(variableRenderer.render("{{ vars | jq(\".null\") | first | className }}", vars)).isEqualTo("");
+        assertThat(variableRenderer.render("{{ vars | jq(\".null\") | first | className }}", vars)).isEmpty();
     }
 
     @Test

--- a/core/src/test/java/io/kestra/core/runners/pebble/filters/NindentFilterTest.java
+++ b/core/src/test/java/io/kestra/core/runners/pebble/filters/NindentFilterTest.java
@@ -24,7 +24,7 @@ class NindentFilterTest {
     @Test
     void nindentEmpty() throws IllegalVariableEvaluationException {
         String render = variableRenderer.render("{{ '' | nindent(2) }}", Map.of());
-        assertThat(render).isEqualTo("");
+        assertThat(render).isEmpty();
     }
 
     @Test

--- a/core/src/test/java/io/kestra/core/runners/pebble/functions/FetchContextFunctionTest.java
+++ b/core/src/test/java/io/kestra/core/runners/pebble/functions/FetchContextFunctionTest.java
@@ -21,7 +21,7 @@ class FetchContextFunctionTest {
     @Test
     void fromString() throws IllegalVariableEvaluationException, JsonProcessingException {
         String render = variableRenderer.render("{{ printContext() }}", Map.of("test", "value", "array", List.of("a", "b", "c")));
-        assertThat(JacksonMapper.toMap(render).get("test")).isEqualTo("value");
-        assertThat(JacksonMapper.toMap(render).get("array")).isEqualTo(List.of("a", "b", "c"));
+        assertThat(JacksonMapper.toMap(render)).containsEntry("test", "value");
+        assertThat(JacksonMapper.toMap(render)).containsEntry("array", List.of("a", "b", "c"));
     }
 }

--- a/core/src/test/java/io/kestra/core/runners/pebble/functions/KvFunctionTest.java
+++ b/core/src/test/java/io/kestra/core/runners/pebble/functions/KvFunctionTest.java
@@ -139,7 +139,7 @@ public class KvFunctionTest {
         String rendered = variableRenderer.render("{{ kv('my-key', errorOnMissing=false) }}", variables);
 
         // Then
-        assertThat(rendered).isEqualTo("");
+        assertThat(rendered).isEmpty();
     }
 
     @Test

--- a/core/src/test/java/io/kestra/core/schedulers/AbstractSchedulerTest.java
+++ b/core/src/test/java/io/kestra/core/schedulers/AbstractSchedulerTest.java
@@ -34,7 +34,7 @@ import java.util.Map;
 import java.util.Optional;
 
 @KestraTest
-abstract public class AbstractSchedulerTest {
+public abstract class AbstractSchedulerTest {
     @Inject
     protected ApplicationContext applicationContext;
 
@@ -161,6 +161,7 @@ abstract public class AbstractSchedulerTest {
 
         private String defaultInjected;
 
+        @Override
         public Optional<Execution> evaluate(ConditionContext conditionContext, TriggerContext context) throws InterruptedException {
             COUNTER++;
 

--- a/core/src/test/java/io/kestra/core/schedulers/SchedulerScheduleOnDatesTest.java
+++ b/core/src/test/java/io/kestra/core/schedulers/SchedulerScheduleOnDatesTest.java
@@ -102,8 +102,8 @@ public class SchedulerScheduleOnDatesTest extends AbstractSchedulerTest {
             // wait for execution
             Flux<Execution> receiveExecutions = TestsUtils.receive(executionQueue, throwConsumer(either -> {
                 Execution execution = either.getLeft();
-                assertThat(execution.getInputs().get("testInputs")).isEqualTo("test-inputs");
-                assertThat(execution.getInputs().get("def")).isEqualTo("awesome");
+                assertThat(execution.getInputs()).containsEntry("testInputs", "test-inputs");
+                assertThat(execution.getInputs()).containsEntry("def", "awesome");
 
                 date.add((String) execution.getTrigger().getVariables().get("date"));
                 executionId.add(execution.getId());

--- a/core/src/test/java/io/kestra/core/schedulers/SchedulerScheduleTest.java
+++ b/core/src/test/java/io/kestra/core/schedulers/SchedulerScheduleTest.java
@@ -139,8 +139,8 @@ public class SchedulerScheduleTest extends AbstractSchedulerTest {
             // wait for execution
             Flux<Execution> receiveExecutions = TestsUtils.receive(executionQueue, throwConsumer(either -> {
                 Execution execution = either.getLeft();
-                assertThat(execution.getInputs().get("testInputs")).isEqualTo("test-inputs");
-                assertThat(execution.getInputs().get("def")).isEqualTo("awesome");
+                assertThat(execution.getInputs()).containsEntry("testInputs", "test-inputs");
+                assertThat(execution.getInputs()).containsEntry("def", "awesome");
 
                 date.add((String) execution.getTrigger().getVariables().get("date"));
                 executionId.add(execution.getId());
@@ -462,8 +462,8 @@ public class SchedulerScheduleTest extends AbstractSchedulerTest {
             // wait for execution
             Flux<Execution> receive = TestsUtils.receive(executionQueue, throwConsumer(either -> {
                 Execution execution = either.getLeft();
-                assertThat(execution.getInputs().get("testInputs")).isEqualTo("test-inputs");
-                assertThat(execution.getInputs().get("def")).isEqualTo("awesome");
+                assertThat(execution.getInputs()).containsEntry("testInputs", "test-inputs");
+                assertThat(execution.getInputs()).containsEntry("def", "awesome");
                 assertThat(execution.getFlowId()).isEqualTo(flow.getId());
 
                 if (execution.getState().getCurrent() == State.Type.CREATED) {

--- a/core/src/test/java/io/kestra/core/schedulers/SchedulerStreamingTest.java
+++ b/core/src/test/java/io/kestra/core/schedulers/SchedulerStreamingTest.java
@@ -143,6 +143,7 @@ public class SchedulerStreamingTest extends AbstractSchedulerTest {
         @Builder.Default
         private Boolean failed = false;
 
+        @Override
         public Publisher<Execution> evaluate(ConditionContext conditionContext, TriggerContext context) {
             startedEvaluate.compute(this.failed, (val, integer) -> integer == null ? 1 : integer + 1);
 

--- a/core/src/test/java/io/kestra/core/schedulers/SchedulerThreadTest.java
+++ b/core/src/test/java/io/kestra/core/schedulers/SchedulerThreadTest.java
@@ -84,8 +84,8 @@ public class SchedulerThreadTest extends AbstractSchedulerTest {
             Execution last = receive.blockLast();
 
             assertThat(last).as("Countdown latch returned " + sawSuccessExecution).isNotNull();
-            assertThat(last.getTrigger().getVariables().get("defaultInjected")).isEqualTo("done");
-            assertThat(last.getTrigger().getVariables().get("counter")).isEqualTo(3);
+            assertThat(last.getTrigger().getVariables()).containsEntry("defaultInjected", "done");
+            assertThat(last.getTrigger().getVariables()).containsEntry("counter", 3);
             assertThat(last.getLabels()).contains(new Label("flow-label-1", "flow-label-1"));
             assertThat(last.getLabels()).contains(new Label("flow-label-2", "flow-label-2"));
             AbstractSchedulerTest.COUNTER = 0;

--- a/core/src/test/java/io/kestra/core/schedulers/SchedulerTriggerChangeTest.java
+++ b/core/src/test/java/io/kestra/core/schedulers/SchedulerTriggerChangeTest.java
@@ -172,6 +172,7 @@ public class SchedulerTriggerChangeTest extends AbstractSchedulerTest {
         private String format;
         private Duration sleep;
 
+        @Override
         public Optional<Execution> evaluate(ConditionContext conditionContext, TriggerContext context) throws InterruptedException {
             STARTED_COUNT++;
 

--- a/core/src/test/java/io/kestra/core/schedulers/SchedulerTriggerStateInterfaceTest.java
+++ b/core/src/test/java/io/kestra/core/schedulers/SchedulerTriggerStateInterfaceTest.java
@@ -30,20 +30,20 @@ public abstract class SchedulerTriggerStateInterfaceTest {
         Trigger.TriggerBuilder<?, ?> builder = trigger();
 
         Optional<Trigger> find = triggerState.findLast(builder.build());
-        assertThat(find.isPresent()).isFalse();
+        assertThat(find).isNotPresent();
 
         Trigger save = triggerState.update(builder.build());
 
         find = triggerState.findLast(save);
 
-        assertThat(find.isPresent()).isTrue();
+        assertThat(find).isPresent();
         assertThat(find.get().getExecutionId()).isEqualTo(save.getExecutionId());
 
         save = triggerState.update(builder.executionId(IdUtils.create()).build());
 
         find = triggerState.findLast(save);
 
-        assertThat(find.isPresent()).isTrue();
+        assertThat(find).isPresent();
         assertThat(find.get().getExecutionId()).isEqualTo(save.getExecutionId());
     }
 }

--- a/core/src/test/java/io/kestra/core/secret/SecretFunctionTest.java
+++ b/core/src/test/java/io/kestra/core/secret/SecretFunctionTest.java
@@ -57,9 +57,9 @@ public class SecretFunctionTest {
         Flux<LogEntry> receive = TestsUtils.receive(logQueue, either -> logs.add(either.getLeft()));
 
         Execution execution = runnerUtils.runOne(null, "io.kestra.tests", "secrets");
-        assertThat(execution.getTaskRunList().getFirst().getOutputs().get("value")).isEqualTo("secretValue");
-        assertThat(execution.getTaskRunList().get(2).getOutputs().get("value")).isEqualTo("passwordveryveryveyrlongpasswordveryveryveyrlongpasswordveryveryveyrlongpasswordveryveryveyrlongpasswordveryveryveyrlong");
-        assertThat(execution.getTaskRunList().get(3).getOutputs().get("value")).isEqualTo("secretValue");
+        assertThat(execution.getTaskRunList().getFirst().getOutputs()).containsEntry("value", "secretValue");
+        assertThat(execution.getTaskRunList().get(2).getOutputs()).containsEntry("value", "passwordveryveryveyrlongpasswordveryveryveyrlongpasswordveryveryveyrlongpasswordveryveryveyrlongpasswordveryveryveyrlong");
+        assertThat(execution.getTaskRunList().get(3).getOutputs()).containsEntry("value", "secretValue");
         assertThat(execution.getTaskRunList().get(4).getOutputs()).isEmpty();
         assertThat(execution.getTaskRunList().get(4).getState().getCurrent()).isEqualTo(State.Type.WARNING);
 
@@ -122,7 +122,7 @@ public class SecretFunctionTest {
     public static class TestSecretService extends SecretService {
 
         private static final Map<String, String> SECRETS = Map.of(
-            "io.kestra.unittest.json-secret", """ 
+            "io.kestra.unittest.json-secret", """
                 {
                 "string": "value",
                 "number": 42,
@@ -133,6 +133,8 @@ public class SecretFunctionTest {
                 """,
             "io.kestra.unittest.string-secret", "string-value"
         );
+
+        @Override
         public String findSecret(String tenantId, String namespace, String key) throws SecretNotFoundException, IOException {
             Optional<String> optional = Optional.ofNullable(SECRETS.get(namespace + "." + key));
             if (optional.isPresent()) {

--- a/core/src/test/java/io/kestra/core/serializers/FileSerdeTest.java
+++ b/core/src/test/java/io/kestra/core/serializers/FileSerdeTest.java
@@ -65,7 +65,7 @@ class FileSerdeTest {
         } else if (value instanceof Collections) {
             assertThat((List) object.get("key")).containsExactlyInAnyOrder((List) result.get("key"));
         } else {
-            assertThat(result.get("key")).isEqualTo(resultValue != null ? resultValue : object.get("key"));
+            assertThat(result).containsEntry("key", resultValue != null ? resultValue : object.get("key"));
         }
     }
 
@@ -83,7 +83,7 @@ class FileSerdeTest {
         List<Object> list = new ArrayList<>();
         FileSerde.reader(inputStream, 2, row -> list.add(row));
 
-        assertThat(list.size()).isEqualTo(2);
+        assertThat(list).hasSize(2);
     }
 
     @Test

--- a/core/src/test/java/io/kestra/core/serializers/JacksonMapperTest.java
+++ b/core/src/test/java/io/kestra/core/serializers/JacksonMapperTest.java
@@ -62,14 +62,14 @@ class JacksonMapperTest {
 
         List<Object> integerList = JacksonMapper.toList(list);
 
-        assertThat(integerList.size()).isEqualTo(3);
+        assertThat(integerList).hasSize(3);
         assertThat(integerList).containsExactlyInAnyOrder(1, 2, 3);
     }
 
     void test(Pojo original, Pojo deserialize) {
         assertThat(deserialize.getString()).isEqualTo(original.getString());
         assertThat(deserialize.getInstant().toEpochMilli()).isEqualTo(original.getInstant().toEpochMilli());
-        assertThat(deserialize.getInstant().toString()).isEqualTo(original.getInstant().toString());
+        assertThat(deserialize.getInstant()).hasToString(original.getInstant().toString());
         assertThat(deserialize.getZonedDateTime().toEpochSecond()).isEqualTo(original.getZonedDateTime().toEpochSecond());
         assertThat(deserialize.getZonedDateTime().getOffset()).isEqualTo(original.getZonedDateTime().getOffset());
     }

--- a/core/src/test/java/io/kestra/core/serializers/YamlParserTest.java
+++ b/core/src/test/java/io/kestra/core/serializers/YamlParserTest.java
@@ -42,7 +42,7 @@ class YamlParserTest {
         Flow flow = parse("flows/valids/full.yaml");
 
         assertThat(flow.getId()).isEqualTo("full");
-        assertThat(flow.getTasks().size()).isEqualTo(5);
+        assertThat(flow.getTasks()).hasSize(5);
 
         // third with all optionals
         Task optionals = flow.getTasks().get(2);
@@ -58,7 +58,7 @@ class YamlParserTest {
         Flow flow = parseString("flows/valids/full.yaml");
 
         assertThat(flow.getId()).isEqualTo("full");
-        assertThat(flow.getTasks().size()).isEqualTo(5);
+        assertThat(flow.getTasks()).hasSize(5);
 
         // third with all optionals
         Task optionals = flow.getTasks().get(2);
@@ -73,7 +73,7 @@ class YamlParserTest {
         Flow flow = this.parse("flows/valids/all-flowable.yaml");
 
         assertThat(flow.getId()).isEqualTo("all-flowable");
-        assertThat(flow.getTasks().size()).isEqualTo(4);
+        assertThat(flow.getTasks()).hasSize(4);
     }
 
     @Test
@@ -85,7 +85,7 @@ class YamlParserTest {
         try {
             this.parse("flows/invalids/invalid.yaml");
         } catch (ConstraintViolationException e) {
-            assertThat(e.getConstraintViolations().size()).isEqualTo(4);
+            assertThat(e.getConstraintViolations()).hasSize(4);
         }
     }
 
@@ -96,7 +96,7 @@ class YamlParserTest {
             () -> modelValidator.validate(this.parse("flows/invalids/empty.yaml"))
         );
 
-        assertThat(exception.getConstraintViolations().size()).isEqualTo(1);
+        assertThat(exception.getConstraintViolations()).hasSize(1);
         assertThat(new ArrayList<>(exception.getConstraintViolations()).getFirst().getMessage()).isEqualTo("must not be empty");
     }
 
@@ -107,7 +107,7 @@ class YamlParserTest {
             () -> modelValidator.validate(this.parse("flows/invalids/inputs.yaml"))
         );
 
-        assertThat(exception.getConstraintViolations().size()).isEqualTo(2);
+        assertThat(exception.getConstraintViolations()).hasSize(2);
         exception.getConstraintViolations().forEach(
             c -> assertThat(c.getMessage())
                 .satisfiesAnyOf(
@@ -121,7 +121,7 @@ class YamlParserTest {
     void inputs() {
         Flow flow = this.parse("flows/valids/inputs.yaml");
 
-        assertThat(flow.getInputs().size()).isEqualTo(29);
+        assertThat(flow.getInputs()).hasSize(29);
         assertThat(flow.getInputs().stream().filter(Input::getRequired).count()).isEqualTo(11L);
         assertThat(flow.getInputs().stream().filter(r -> !r.getRequired()).count()).isEqualTo(18L);
         assertThat(flow.getInputs().stream().filter(r -> r.getDefaults() != null).count()).isEqualTo(3L);
@@ -133,7 +133,7 @@ class YamlParserTest {
     void inputsOld() {
         Flow flow = this.parse("flows/tests/inputs-old.yaml");
 
-        assertThat(flow.getInputs().size()).isEqualTo(1);
+        assertThat(flow.getInputs()).hasSize(1);
         assertThat(flow.getInputs().getFirst().getId()).isEqualTo("myInput");
         assertThat(flow.getInputs().getFirst().getType()).isEqualTo(Type.STRING);
     }
@@ -155,7 +155,7 @@ class YamlParserTest {
             () -> modelValidator.validate(this.parse("flows/invalids/listener.yaml"))
         );
 
-        assertThat(exception.getConstraintViolations().size()).isEqualTo(2);
+        assertThat(exception.getConstraintViolations()).hasSize(2);
         assertThat(new ArrayList<>(exception.getConstraintViolations()).getFirst().getMessage()).contains("must not be empty");
         assertThat(new ArrayList<>(exception.getConstraintViolations()).get(1).getMessage()).isEqualTo("must not be empty");
     }
@@ -184,7 +184,7 @@ class YamlParserTest {
             () -> this.parse("flows/invalids/invalid-task.yaml")
         );
 
-        assertThat(exception.getConstraintViolations().size()).isEqualTo(2);
+        assertThat(exception.getConstraintViolations()).hasSize(2);
         assertThat(exception.getConstraintViolations().stream().filter(e -> e.getMessage().contains("Invalid type")).findFirst().orElseThrow().getMessage()).contains("Invalid type: io.kestra.plugin.core.debug.MissingOne");
     }
 
@@ -196,7 +196,7 @@ class YamlParserTest {
         );
 
         assertThat(exception.getMessage()).isEqualTo("Unrecognized field \"invalid\" (class io.kestra.plugin.core.debug.Return), not marked as ignorable (14 known properties: \"logLevel\", \"timeout\", \"retry\", \"allowWarning\", \"format\", \"version\", \"type\", \"id\", \"description\", \"workerGroup\", \"runIf\", \"logToFile\", \"disabled\", \"allowFailure\"])");
-        assertThat(exception.getConstraintViolations().size()).isEqualTo(1);
+        assertThat(exception.getConstraintViolations()).hasSize(1);
         assertThat(exception.getConstraintViolations().iterator().next().getPropertyPath().toString()).isEqualTo("io.kestra.core.models.flows.Flow[\"tasks\"]->java.util.ArrayList[0]->io.kestra.plugin.core.debug.Return[\"invalid\"]");
     }
 
@@ -220,8 +220,8 @@ class YamlParserTest {
         Flow parse = this.parse("flows/invalids/invalid-parallel.yaml");
         Optional<ConstraintViolationException> valid = modelValidator.isValid(parse);
 
-        assertThat(valid.isPresent()).isTrue();
-        assertThat(valid.get().getConstraintViolations().size()).isEqualTo(10);
+        assertThat(valid).isPresent();
+        assertThat(valid.get().getConstraintViolations()).hasSize(10);
         assertThat(new ArrayList<>(valid.get().getConstraintViolations()).stream().filter(r -> r.getMessage().contains("must not be empty")).count()).isEqualTo(3L);
     }
 
@@ -232,7 +232,7 @@ class YamlParserTest {
             () -> this.parse("flows/invalids/duplicate-key.yaml")
         );
 
-        assertThat(exception.getConstraintViolations().size()).isEqualTo(1);
+        assertThat(exception.getConstraintViolations()).hasSize(1);
         assertThat(new ArrayList<>(exception.getConstraintViolations()).getFirst().getMessage()).contains("Duplicate field 'variables.tf'");
     }
 

--- a/core/src/test/java/io/kestra/core/services/FlowServiceTest.java
+++ b/core/src/test/java/io/kestra/core/services/FlowServiceTest.java
@@ -92,22 +92,22 @@ class FlowServiceTest {
         assertThat(importFlow.getId()).isEqualTo("import");
         assertThat(importFlow.getNamespace()).isEqualTo("some.namespace");
         assertThat(importFlow.getRevision()).isEqualTo(1);
-        assertThat(importFlow.getTasks().size()).isEqualTo(1);
+        assertThat(importFlow.getTasks()).hasSize(1);
         assertThat(importFlow.getTasks().getFirst().getId()).isEqualTo("task");
 
         Optional<FlowWithSource> fromDb = flowRepository.findByIdWithSource("my-tenant", "some.namespace", "import", Optional.empty());
-        assertThat(fromDb.isPresent()).isTrue();
+        assertThat(fromDb).isPresent();
         assertThat(fromDb.get().getRevision()).isEqualTo(1);
         assertThat(fromDb.get().getSource()).isEqualTo(source);
 
         source = source.replace("id: task", "id: replaced_task");
         importFlow = flowService.importFlow("my-tenant", source);
         assertThat(importFlow.getRevision()).isEqualTo(2);
-        assertThat(importFlow.getTasks().size()).isEqualTo(1);
+        assertThat(importFlow.getTasks()).hasSize(1);
         assertThat(importFlow.getTasks().getFirst().getId()).isEqualTo("replaced_task");
 
         fromDb = flowRepository.findByIdWithSource("my-tenant", "some.namespace", "import", Optional.empty());
-        assertThat(fromDb.isPresent()).isTrue();
+        assertThat(fromDb).isPresent();
         assertThat(fromDb.get().getRevision()).isEqualTo(2);
         assertThat(fromDb.get().getSource()).isEqualTo(source);
     }
@@ -126,22 +126,22 @@ class FlowServiceTest {
         assertThat(importFlow.getId()).isEqualTo("import_dry");
         assertThat(importFlow.getNamespace()).isEqualTo("some.namespace");
         assertThat(importFlow.getRevision()).isEqualTo(1);
-        assertThat(importFlow.getTasks().size()).isEqualTo(1);
+        assertThat(importFlow.getTasks()).hasSize(1);
         assertThat(importFlow.getTasks().getFirst().getId()).isEqualTo("task");
 
         Optional<FlowWithSource> fromDb = flowRepository.findByIdWithSource("my-tenant", "some.namespace", "import_dry", Optional.empty());
-        assertThat(fromDb.isPresent()).isTrue();
+        assertThat(fromDb).isPresent();
         assertThat(fromDb.get().getRevision()).isEqualTo(1);
         assertThat(fromDb.get().getSource()).isEqualTo(oldSource);
 
         String newSource = oldSource.replace("id: task", "id: replaced_task");
         importFlow = flowService.importFlow("my-tenant", newSource, true);
         assertThat(importFlow.getRevision()).isEqualTo(2);
-        assertThat(importFlow.getTasks().size()).isEqualTo(1);
+        assertThat(importFlow.getTasks()).hasSize(1);
         assertThat(importFlow.getTasks().getFirst().getId()).isEqualTo("replaced_task");
 
         fromDb = flowRepository.findByIdWithSource("my-tenant", "some.namespace", "import_dry", Optional.empty());
-        assertThat(fromDb.isPresent()).isTrue();
+        assertThat(fromDb).isPresent();
         assertThat(fromDb.get().getRevision()).isEqualTo(1);
         assertThat(fromDb.get().getSource()).isEqualTo(oldSource);
     }
@@ -157,7 +157,7 @@ class FlowServiceTest {
 
         List<FlowInterface> collect = flowService.keepLastVersion(stream).toList();
 
-        assertThat(collect.size()).isEqualTo(1);
+        assertThat(collect).hasSize(1);
         assertThat(collect.getFirst().isDeleted()).isFalse();
         assertThat(collect.getFirst().getRevision()).isEqualTo(4);
     }
@@ -175,7 +175,7 @@ class FlowServiceTest {
 
         List<FlowInterface> collect = flowService.keepLastVersion(stream).toList();
 
-        assertThat(collect.size()).isEqualTo(1);
+        assertThat(collect).hasSize(1);
         assertThat(collect.getFirst().isDeleted()).isFalse();
         assertThat(collect.getFirst().getId()).isEqualTo("test2");
     }
@@ -192,7 +192,7 @@ class FlowServiceTest {
 
         List<FlowInterface> collect = flowService.keepLastVersion(stream).toList();
 
-        assertThat(collect.size()).isEqualTo(1);
+        assertThat(collect).hasSize(1);
         assertThat(collect.getFirst().isDeleted()).isFalse();
         assertThat(collect.getFirst().getRevision()).isEqualTo(4);
     }
@@ -211,7 +211,7 @@ class FlowServiceTest {
 
         List<FlowInterface> collect = flowService.keepLastVersion(stream).toList();
 
-        assertThat(collect.size()).isEqualTo(3);
+        assertThat(collect).hasSize(3);
         assertThat(collect.stream().filter(flow -> flow.getId().equals("test")).findFirst().orElseThrow().getRevision()).isEqualTo(2);
         assertThat(collect.stream().filter(flow -> flow.getId().equals("test2")).findFirst().orElseThrow().getRevision()).isEqualTo(3);
         assertThat(collect.stream().filter(flow -> flow.getId().equals("test3")).findFirst().orElseThrow().getRevision()).isEqualTo(3);
@@ -231,7 +231,7 @@ class FlowServiceTest {
 
         List<String> warnings = flowService.warnings(flow, null);
 
-        assertThat(warnings.size()).isEqualTo(1);
+        assertThat(warnings).hasSize(1);
         assertThat(warnings).containsExactlyInAnyOrder("This flow will be triggered for EVERY execution of EVERY flow on your instance. We recommend adding the preconditions property to the Flow trigger 'flow-trigger'.");
     }
 
@@ -259,7 +259,7 @@ class FlowServiceTest {
                     type: io.kestra.core.runners.test.task.Alias
                     message: Hello, {{taskrun.value}}""");
 
-        assertThat(warnings.size()).isEqualTo(2);
+        assertThat(warnings).hasSize(2);
         assertThat(warnings.getFirst().from()).isEqualTo("io.kestra.core.runners.test.task.Alias");
         assertThat(warnings.getFirst().to()).isEqualTo("io.kestra.core.runners.test.TaskWithAlias");
     }
@@ -314,23 +314,23 @@ class FlowServiceTest {
     void delete() {
         FlowWithSource flow = create("deleteTest", "test", 1);
         FlowWithSource saved = flowRepository.create(GenericFlow.of(flow));
-        assertThat(flowRepository.findById(flow.getTenantId(), flow.getNamespace(), flow.getId()).isPresent()).isTrue();
+        assertThat(flowRepository.findById(flow.getTenantId(), flow.getNamespace(), flow.getId())).isPresent();
         flowService.delete(saved);
-        assertThat(flowRepository.findById(flow.getTenantId(), flow.getNamespace(), flow.getId()).isPresent()).isFalse();
+        assertThat(flowRepository.findById(flow.getTenantId(), flow.getNamespace(), flow.getId())).isNotPresent();
     }
 
     @Test
     void findByNamespacePrefix() {
         FlowWithSource flow = create(null, "some.namespace","findByTest", "test", 1);
         flowRepository.create(GenericFlow.of(flow));
-        assertThat(flowService.findByNamespacePrefix(null, "some.namespace").size()).isEqualTo(1);
+        assertThat(flowService.findByNamespacePrefix(null, "some.namespace")).hasSize(1);
     }
 
     @Test
     void findById() {
         FlowWithSource flow = create("findByIdTest", "test", 1);
         FlowWithSource saved = flowRepository.create(GenericFlow.of(flow));
-        assertThat(flowService.findById(null, saved.getNamespace(), saved.getId()).isPresent()).isTrue();
+        assertThat(flowService.findById(null, saved.getNamespace(), saved.getId())).isPresent();
     }
 
     @Test
@@ -348,8 +348,8 @@ class FlowServiceTest {
 
         List<String> exceptions = flowService.checkValidSubflows(flow, null);
 
-        assertThat(exceptions.size()).isEqualTo(1);
-        assertThat(exceptions.iterator().next()).isEqualTo("The subflow 'nonExistentSubflow' not found in namespace 'io.kestra.unittest'.");
+        assertThat(exceptions).hasSize(1);
+        assertThat(exceptions.getFirst()).isEqualTo("The subflow 'nonExistentSubflow' not found in namespace 'io.kestra.unittest'.");
     }
 
     @Test
@@ -370,6 +370,6 @@ class FlowServiceTest {
 
         List<String> exceptions = flowService.checkValidSubflows(flow, null);
 
-        assertThat(exceptions.size()).isZero();
+        assertThat(exceptions).isEmpty();
     }
 }

--- a/core/src/test/java/io/kestra/core/services/PluginDefaultServiceTest.java
+++ b/core/src/test/java/io/kestra/core/services/PluginDefaultServiceTest.java
@@ -179,7 +179,7 @@ class PluginDefaultServiceTest {
 
     @Test
     public void injectFlowAndGlobals() throws FlowProcessingException {
-        String source = String.format("""
+        String source = """
             id: default-test
             namespace: io.kestra.tests
 
@@ -193,7 +193,7 @@ class PluginDefaultServiceTest {
             - id: test
               type: io.kestra.core.services.PluginDefaultServiceTest$DefaultTester
               set: 666
-              
+
             pluginDefaults:
             - type: "%s"
               forced: false
@@ -209,7 +209,7 @@ class PluginDefaultServiceTest {
               forced: false
               values:
                 expression: "{{ test }}"
-                  """,
+                  """.formatted(
             DefaultTester.class.getName(),
             DefaultTriggerTester.class.getName(),
             Expression.class.getName()
@@ -236,12 +236,12 @@ class PluginDefaultServiceTest {
         String source = """
             id: default-test
             namespace: io.kestra.tests
-    
+
             tasks:
             - id: test
               type: io.kestra.core.services.PluginDefaultServiceTest$DefaultTester
               set: 1
-                  
+
             pluginDefaults:
             - type: io.kestra.core.services.PluginDefaultServiceTest$DefaultTester
               forced: true
@@ -283,7 +283,7 @@ class PluginDefaultServiceTest {
             - id: test
               type: io.kestra.core.services.PluginDefaultServiceTest$DefaultTester
               set: 666
-              
+
             pluginDefaults:
             - type: io.kestra.core.services.PluginDefaultServiceTest$DefaultTester
               values:
@@ -316,7 +316,7 @@ class PluginDefaultServiceTest {
               - id: test
                 type: io.kestra.core.services.PluginDefaultServiceTest$DefaultTester
                 set: 666
-                
+
               pluginDefaults:
                  - type: io.kestra.core.services.DefaultTesterAlias
                    values:
@@ -340,7 +340,7 @@ class PluginDefaultServiceTest {
                   - id: test
                     type: io.kestra.core.services.PluginDefaultServiceTest$DefaultTester
                     set: 666
-                    
+
                   pluginDefaults:
                      - type: io.kestra.core.services.PluginDefaultServiceTest$DefaultTester
                        values:
@@ -364,7 +364,7 @@ class PluginDefaultServiceTest {
               type: io.kestra.plugin.core.log.Log
               message: testing
               level: INFO
-              
+
             pluginDefaults:
              - type: io.kestra.core.services.PluginDefaultServiceTest$DefaultTester
                values:

--- a/core/src/test/java/io/kestra/core/storages/InternalKVStoreTest.java
+++ b/core/src/test/java/io/kestra/core/storages/InternalKVStoreTest.java
@@ -49,7 +49,7 @@ class InternalKVStoreTest {
         Instant before = Instant.now().minusMillis(100);
         InternalKVStore kv = kv();
 
-        assertThat(kv.list().size()).isZero();
+        assertThat(kv.list()).isEmpty();
 
         kv.put(TEST_KV_KEY, new KVValueAndMetadata(new KVMetadata(Duration.ofMinutes(5)), complexValue));
         kv.put("my-second-key", new KVValueAndMetadata(new KVMetadata(Duration.ofMinutes(10)), complexValue));
@@ -57,7 +57,7 @@ class InternalKVStoreTest {
         Instant after = Instant.now().plusMillis(100);
 
         List<KVEntry> list = kv.list();
-        assertThat(list.size()).isEqualTo(2);
+        assertThat(list).hasSize(2);
 
         list.forEach(kvEntry -> {
             assertThat(kvEntry.creationDate().isAfter(before) && kvEntry.creationDate().isBefore(after)).isTrue();
@@ -66,7 +66,7 @@ class InternalKVStoreTest {
 
         Map<String, KVEntry> map = list.stream().collect(Collectors.toMap(KVEntry::key, Function.identity()));
         // Check that we don't list expired keys
-        assertThat(map.size()).isEqualTo(2);
+        assertThat(map).hasSize(2);
 
         KVEntry myKeyValue = map.get(TEST_KV_KEY);
         assertThat(myKeyValue.creationDate().plus(Duration.ofMinutes(4)).isBefore(myKeyValue.expirationDate()) &&
@@ -127,7 +127,7 @@ class InternalKVStoreTest {
         Optional<KVValue> value = kv.getValue(TEST_KV_KEY);
 
         // Then
-        assertThat(value.get()).isEqualTo(new KVValue(complexValue));
+        assertThat(value).contains(new KVValue(complexValue));
     }
 
     @Test
@@ -139,7 +139,7 @@ class InternalKVStoreTest {
         Optional<KVValue> value = kv.getValue(TEST_KV_KEY);
 
         // Then
-        assertThat(value.isEmpty()).isTrue();
+        assertThat(value).isEmpty();
     }
 
     @Test

--- a/core/src/test/java/io/kestra/core/storages/InternalNamespaceTest.java
+++ b/core/src/test/java/io/kestra/core/storages/InternalNamespaceTest.java
@@ -159,11 +159,11 @@ class InternalNamespaceTest {
 
         // When - Then
         List<NamespaceFile> allTenant1 = namespaceTenant1.all();
-        assertThat(allTenant1.size()).isEqualTo(1);
+        assertThat(allTenant1).hasSize(1);
         assertThat(allTenant1).containsExactlyInAnyOrder(namespaceFile1);
 
         List<NamespaceFile> allTenant2 = namespaceTenant2.all();
-        assertThat(allTenant2.size()).isEqualTo(1);
+        assertThat(allTenant2).hasSize(1);
         assertThat(allTenant2).containsExactlyInAnyOrder(namespaceFile2);
     }
 
@@ -173,6 +173,6 @@ class InternalNamespaceTest {
         final String namespaceId = "io.kestra." + IdUtils.create();
         final InternalNamespace namespace = new InternalNamespace(logger, null, namespaceId, storageInterface);
         List<NamespaceFile> namespaceFiles = namespace.findAllFilesMatching((unused) -> true);
-        assertThat(namespaceFiles.size()).isZero();
+        assertThat(namespaceFiles).isEmpty();
     }
 }

--- a/core/src/test/java/io/kestra/core/storages/StateStoreTest.java
+++ b/core/src/test/java/io/kestra/core/storages/StateStoreTest.java
@@ -60,7 +60,7 @@ public class StateStoreTest {
         MigrationRequiredException migrationRequiredException = Assertions.assertThrows(MigrationRequiredException.class, () -> runContext.stateStore().getState(state, "some-name", "my-taskrun-value"));
         assertThat(migrationRequiredException.getMessage()).isEqualTo("It looks like the State Store migration hasn't been run, please run the `/app/kestra sys state-store migrate` command before.");
 
-        assertThat(runContext.namespaceKv(flowInfo.namespace()).getValue(key).isEmpty()).isTrue();
+        assertThat(runContext.namespaceKv(flowInfo.namespace()).getValue(key)).isEmpty();
     }
 
     @Test

--- a/core/src/test/java/io/kestra/core/tasks/FetchTest.java
+++ b/core/src/test/java/io/kestra/core/tasks/FetchTest.java
@@ -18,7 +18,7 @@ class FetchTest {
         assertThat(execution.getState().getCurrent()).isEqualTo(State.Type.SUCCESS);
         assertThat(execution.getTaskRunList()).hasSize(4);
         TaskRun fetch = execution.findTaskRunsByTaskId("get-log-task").getFirst();
-        assertThat(fetch.getOutputs().get("size")).isEqualTo(3);
+        assertThat(fetch.getOutputs()).containsEntry("size", 3);
     }
 
     @Test
@@ -27,7 +27,7 @@ class FetchTest {
         assertThat(execution.getState().getCurrent()).isEqualTo(State.Type.SUCCESS);
         assertThat(execution.getTaskRunList()).hasSize(4);
         TaskRun fetch = execution.findTaskRunsByTaskId("get-log-task").getFirst();
-        assertThat(fetch.getOutputs().get("size")).isEqualTo(1);
+        assertThat(fetch.getOutputs()).containsEntry("size", 1);
     }
 
     @Test
@@ -36,6 +36,6 @@ class FetchTest {
         assertThat(execution.getState().getCurrent()).isEqualTo(State.Type.SUCCESS);
         assertThat(execution.getTaskRunList()).hasSize(4);
         TaskRun fetch = execution.findTaskRunsByTaskId("get-log-task").getFirst();
-        assertThat(fetch.getOutputs().get("size")).isEqualTo(3);
+        assertThat(fetch.getOutputs()).containsEntry("size", 3);
     }
 }

--- a/core/src/test/java/io/kestra/core/tasks/OutputValuesTest.java
+++ b/core/src/test/java/io/kestra/core/tasks/OutputValuesTest.java
@@ -26,13 +26,13 @@ class OutputValuesTest {
         TaskRun outputValues = execution.getTaskRunList().getFirst();
         assertThat(outputValues.getOutputs()).isInstanceOf(Variables.InMemoryVariables.class);
         Map<String, Object> values = (Map<String, Object>) outputValues.getOutputs().get("values");
-        assertThat(values.get("output1")).isEqualTo("xyz");
-        assertThat(values.get("output2")).isEqualTo("abc");
+        assertThat(values).containsEntry("output1", "xyz");
+        assertThat(values).containsEntry("output2", "abc");
 
         outputValues = execution.getTaskRunList().getLast();
         assertThat(outputValues.getOutputs()).isInstanceOf(Variables.InMemoryVariables.class);
         values = (Map<String, Object>) outputValues.getOutputs().get("values");
-        assertThat(values.get("output1")).isEqualTo("xyz");
-        assertThat(values.get("output2")).isEqualTo("abc");
+        assertThat(values).containsEntry("output1", "xyz");
+        assertThat(values).containsEntry("output2", "abc");
     }
 }

--- a/core/src/test/java/io/kestra/core/tasks/test/Read.java
+++ b/core/src/test/java/io/kestra/core/tasks/test/Read.java
@@ -9,7 +9,8 @@ import lombok.*;
 import lombok.experimental.SuperBuilder;
 
 import java.nio.file.Files;
-import java.nio.file.Paths;
+import java.nio.file.Path;
+
 import jakarta.validation.constraints.NotNull;
 
 @SuperBuilder
@@ -25,7 +26,7 @@ public class Read extends Task implements RunnableTask<Read.Output> {
     @Override
     public Read.Output run(RunContext runContext) throws Exception {
         return Output.builder()
-            .value(Files.readString(Paths.get(runContext.workingDir().path().toString(), runContext.render(path))))
+            .value(Files.readString(Path.of(runContext.workingDir().path().toString(), runContext.render(path))))
             .build();
     }
 

--- a/core/src/test/java/io/kestra/core/tasks/test/SanityCheckTest.java
+++ b/core/src/test/java/io/kestra/core/tasks/test/SanityCheckTest.java
@@ -81,7 +81,7 @@ class SanityCheckTest {
         assertThat(execution.getState().getCurrent()).isEqualTo(State.Type.SUCCESS);
 
         TaskRun taskRun = execution.findTaskRunsByTaskId("return_value").getFirst();
-        assertThat(taskRun.getOutputs().get("value")).isEqualTo("some string with pebble test");
+        assertThat(taskRun.getOutputs()).containsEntry("value", "some string with pebble test");
     }
 
     @Test

--- a/core/src/test/java/io/kestra/core/utils/ListUtilsTest.java
+++ b/core/src/test/java/io/kestra/core/utils/ListUtilsTest.java
@@ -17,7 +17,7 @@ class ListUtilsTest {
 
         list = ListUtils.emptyOnNull(List.of("1"));
         assertThat(list).isNotNull();
-        assertThat(list.size()).isEqualTo(1);
+        assertThat(list).hasSize(1);
     }
 
     @Test

--- a/core/src/test/java/io/kestra/core/utils/MapUtilsTest.java
+++ b/core/src/test/java/io/kestra/core/utils/MapUtilsTest.java
@@ -37,11 +37,11 @@ class MapUtilsTest {
 
         Map<String, Object> merge = MapUtils.merge(a, b);
 
-        assertThat(((Map<String, Object>) merge.get("map")).size()).isEqualTo(4);
-        assertThat(((Map<String, Object>) merge.get("map")).get("map_c")).isEqualTo("e");
-        assertThat(merge.get("string")).isEqualTo("b");
-        assertThat(merge.get("int")).isEqualTo(1);
-        assertThat(merge.get("float")).isEqualTo(1F);
+        assertThat(((Map<String, Object>) merge.get("map"))).hasSize(4);
+        assertThat(((Map<String, Object>) merge.get("map"))).containsEntry("map_c", "e");
+        assertThat(merge).containsEntry("string", "b");
+        assertThat(merge).containsEntry("int", 1);
+        assertThat(merge).containsEntry("float", 1F);
         assertThat((List<?>) merge.get("lists")).hasSize(2);
     }
 
@@ -67,8 +67,8 @@ class MapUtilsTest {
 
         Map<String, Object> merge = MapUtils.merge(a, b);
 
-        assertThat(((Map<String, Object>) merge.get("map")).size()).isEqualTo(3);
-        assertThat(((Map<String, Object>) merge.get("map")).get("map_c")).isEqualTo("e");
+        assertThat(((Map<String, Object>) merge.get("map"))).hasSize(3);
+        assertThat(((Map<String, Object>) merge.get("map"))).containsEntry("map_c", "e");
         assertThat(((Map<String, Object>) ((Map<String, Object>) ((Map<String, Object>) merge.get("map")).get("map_a")).get("sub")).get("null")).isNull();
     }
 
@@ -100,7 +100,7 @@ class MapUtilsTest {
 
         map = MapUtils.emptyOnNull(Map.of("key", "value"));
         assertThat(map).isNotNull();
-        assertThat(map.size()).isEqualTo(1);
+        assertThat(map).hasSize(1);
     }
 
     @Test

--- a/core/src/test/java/io/kestra/core/validations/ConstantRetryValidationTest.java
+++ b/core/src/test/java/io/kestra/core/validations/ConstantRetryValidationTest.java
@@ -26,7 +26,7 @@ public class ConstantRetryValidationTest {
             .build();
 
         Optional<ConstraintViolationException> valid = modelValidator.isValid(retry);
-        assertThat(valid.isEmpty()).isTrue();
+        assertThat(valid).isEmpty();
     }
 
     @Test
@@ -38,7 +38,7 @@ public class ConstantRetryValidationTest {
             .build();
 
         Optional<ConstraintViolationException> valid = modelValidator.isValid(retry);
-        assertThat(valid.isEmpty()).isFalse();
+        assertThat(valid).isNotEmpty();
         assertThat(valid.get().getConstraintViolations()).hasSize(1);
         assertThat(valid.get().getMessage()).isEqualTo(": 'interval' must be less than 'maxDuration' but is PT10S\n");
     }

--- a/core/src/test/java/io/kestra/core/validations/DataValidationTest.java
+++ b/core/src/test/java/io/kestra/core/validations/DataValidationTest.java
@@ -21,13 +21,13 @@ public class DataValidationTest {
     @Test
     void valid() throws Exception {
         Data<?> data = Data.ofURI(URI.create("kestra:///uri"));
-        assertThat(modelValidator.isValid(data).isEmpty()).isTrue();
+        assertThat(modelValidator.isValid(data)).isEmpty();
 
         data = Data.ofMap(Map.of("key", "value"));
-        assertThat(modelValidator.isValid(data).isEmpty()).isTrue();
+        assertThat(modelValidator.isValid(data)).isEmpty();
 
         data = Data.ofList(List.of(Map.of("key1", "value11"), Map.of("key2", "value2")));
-        assertThat(modelValidator.isValid(data).isEmpty()).isTrue();
+        assertThat(modelValidator.isValid(data)).isEmpty();
     }
 
     @Test
@@ -37,7 +37,7 @@ public class DataValidationTest {
             .fromList(new Property<>())
             .build();
 
-        assertThat(modelValidator.isValid(data).isEmpty()).isFalse();
+        assertThat(modelValidator.isValid(data)).isNotEmpty();
         assertThat(modelValidator.isValid(data).get().getMessage()).contains("Only one of 'fromURI', 'fromMap' or 'fromList' can be set.");
     }
 }

--- a/core/src/test/java/io/kestra/core/validations/DateFormatTest.java
+++ b/core/src/test/java/io/kestra/core/validations/DateFormatTest.java
@@ -60,6 +60,6 @@ class DateFormatTest {
         Optional<ConstraintViolationException> valid = modelValidator.isValid(options);
 
         assertThat(valid.isPresent()).isEqualTo(present);
-        valid.ifPresent(e -> assertThat(e.getConstraintViolations().size()).isEqualTo(size));
+        valid.ifPresent(e -> assertThat(e.getConstraintViolations()).hasSize(size));
     }
 }

--- a/core/src/test/java/io/kestra/core/validations/ExponentialRetryValidationTest.java
+++ b/core/src/test/java/io/kestra/core/validations/ExponentialRetryValidationTest.java
@@ -27,7 +27,7 @@ public class ExponentialRetryValidationTest {
             .build();
 
         Optional<ConstraintViolationException> valid = modelValidator.isValid(retry);
-        assertThat(valid.isEmpty()).isTrue();
+        assertThat(valid).isEmpty();
     }
 
     @Test
@@ -40,7 +40,7 @@ public class ExponentialRetryValidationTest {
             .build();
 
         Optional<ConstraintViolationException> valid = modelValidator.isValid(retry);
-        assertThat(valid.isEmpty()).isFalse();
+        assertThat(valid).isNotEmpty();
         assertThat(valid.get().getConstraintViolations()).hasSize(1);
         assertThat(valid.get().getMessage()).isEqualTo(": 'interval' must be less than 'maxDuration' but is PT2S\n");
 
@@ -52,7 +52,7 @@ public class ExponentialRetryValidationTest {
             .build();
 
         valid = modelValidator.isValid(retry);
-        assertThat(valid.isEmpty()).isFalse();
+        assertThat(valid).isNotEmpty();
         assertThat(valid.get().getConstraintViolations()).hasSize(1);
         assertThat(valid.get().getMessage()).isEqualTo(": 'interval' must be less than 'maxInterval' but is PT3S\n");
     }

--- a/core/src/test/java/io/kestra/core/validations/FlowValidationTest.java
+++ b/core/src/test/java/io/kestra/core/validations/FlowValidationTest.java
@@ -26,7 +26,7 @@ class FlowValidationTest {
         Flow flow = this.parse("flows/invalids/recursive-flow.yaml");
         Optional<ConstraintViolationException> validate = modelValidator.isValid(flow);
 
-        assertThat(validate.isPresent()).isTrue();
+        assertThat(validate).isPresent();
         assertThat(validate.get().getMessage()).contains(": Invalid Flow: Recursive call to flow [io.kestra.tests.recursive-flow]");
     }
 
@@ -35,7 +35,7 @@ class FlowValidationTest {
         Flow flow = this.parse("flows/invalids/system-labels.yaml");
         Optional<ConstraintViolationException> validate = modelValidator.isValid(flow);
 
-        assertThat(validate.isPresent()).isTrue();
+        assertThat(validate).isPresent();
         assertThat(validate.get().getMessage()).contains("System labels can only be set by Kestra itself, offending label: system.label=system_key");
         assertThat(validate.get().getMessage()).contains("System labels can only be set by Kestra itself, offending label: system.id=id");
     }
@@ -64,7 +64,7 @@ class FlowValidationTest {
         Flow flow = this.parse("flows/valids/minimal.yaml");
         Optional<ConstraintViolationException> validate = modelValidator.isValid(flow);
 
-        assertThat(validate.isPresent()).isFalse();
+        assertThat(validate).isNotPresent();
     }
 
     private Flow parse(String path) {

--- a/core/src/test/java/io/kestra/core/validations/InputTest.java
+++ b/core/src/test/java/io/kestra/core/validations/InputTest.java
@@ -22,7 +22,7 @@ class InputTest {
             .validator("[A-Z]+")
             .build();
 
-        assertThat(modelValidator.isValid(validInput).isEmpty()).isTrue();
+        assertThat(modelValidator.isValid(validInput)).isEmpty();
     }
 
     @SuppressWarnings("deprecation")

--- a/core/src/test/java/io/kestra/core/validations/JsonStringTest.java
+++ b/core/src/test/java/io/kestra/core/validations/JsonStringTest.java
@@ -28,11 +28,11 @@ class JsonStringTest {
     void jsonString() throws Exception {
         JsonStringCls build = new JsonStringCls("{}");
 
-        assertThat(modelValidator.isValid(build).isEmpty()).isTrue();
+        assertThat(modelValidator.isValid(build)).isEmpty();
 
         build = new JsonStringCls("{\"invalid\"}");
 
-        assertThat(modelValidator.isValid(build).isPresent()).isTrue();
+        assertThat(modelValidator.isValid(build)).isPresent();
         assertThat(modelValidator.isValid(build).get().getMessage()).contains("invalid json");
     }
 }

--- a/core/src/test/java/io/kestra/core/validations/NoSystemLabelValidationTest.java
+++ b/core/src/test/java/io/kestra/core/validations/NoSystemLabelValidationTest.java
@@ -32,7 +32,7 @@ class NoSystemLabelValidationTest {
 
         Optional<ConstraintViolationException> valid = modelValidator.isValid(sla);
 
-        assertThat(valid.isPresent()).isTrue();
+        assertThat(valid).isPresent();
         assertThat(valid.get().getMessage()).isEqualTo("labels[0].<list element>: System labels can only be set by Kestra itself, offending label: system.sla=violated.\n");
     }
 
@@ -48,6 +48,6 @@ class NoSystemLabelValidationTest {
 
         Optional<ConstraintViolationException> valid = modelValidator.isValid(sla);
 
-        assertThat(valid.isEmpty()).isTrue();
+        assertThat(valid).isEmpty();
     }
 }

--- a/core/src/test/java/io/kestra/core/validations/PluginDefaultValidationTest.java
+++ b/core/src/test/java/io/kestra/core/validations/PluginDefaultValidationTest.java
@@ -26,7 +26,7 @@ class PluginDefaultValidationTest {
 
         Optional<ConstraintViolationException> validate = modelValidator.isValid(pluginDefault);
 
-        assertThat(validate.isPresent()).isTrue();
+        assertThat(validate).isPresent();
     }
 
     @Test
@@ -40,7 +40,7 @@ class PluginDefaultValidationTest {
 
         Optional<ConstraintViolationException> validate = modelValidator.isValid(pluginDefault);
 
-        assertThat(validate.isPresent()).isTrue();
+        assertThat(validate).isPresent();
     }
 
     @Test
@@ -52,7 +52,7 @@ class PluginDefaultValidationTest {
 
         Optional<ConstraintViolationException> validate = modelValidator.isValid(pluginDefault);
 
-        assertThat(validate.isPresent()).isTrue();
+        assertThat(validate).isPresent();
     }
 
     @Test
@@ -64,7 +64,7 @@ class PluginDefaultValidationTest {
 
         Optional<ConstraintViolationException> validate = modelValidator.isValid(pluginDefault);
 
-        assertThat(validate.isEmpty()).isTrue();
+        assertThat(validate).isEmpty();
     }
 
     @Test
@@ -76,7 +76,7 @@ class PluginDefaultValidationTest {
 
         Optional<ConstraintViolationException> validate = modelValidator.isValid(pluginDefault);
 
-        assertThat(validate.isEmpty()).isTrue();
+        assertThat(validate).isEmpty();
     }
 
 }

--- a/core/src/test/java/io/kestra/core/validations/PreconditionFilterValidationTest.java
+++ b/core/src/test/java/io/kestra/core/validations/PreconditionFilterValidationTest.java
@@ -28,7 +28,7 @@ class PreconditionFilterValidationTest {
             .build();
 
         Optional<ConstraintViolationException> valid = modelValidator.isValid(condition);
-        assertThat(valid.isEmpty()).isTrue();
+        assertThat(valid).isEmpty();
     }
 
     @ParameterizedTest
@@ -41,7 +41,7 @@ class PreconditionFilterValidationTest {
             .build();
 
         Optional<ConstraintViolationException> valid = modelValidator.isValid(condition);
-        assertThat(valid.isEmpty()).isFalse();
+        assertThat(valid).isNotEmpty();
         assertThat(valid.get().getConstraintViolations()).hasSize(1);
         assertThat(valid.get().getMessage()).isEqualTo(": `value` cannot be null for type " + type.name() + "\n");
     }
@@ -57,7 +57,7 @@ class PreconditionFilterValidationTest {
             .build();
 
         Optional<ConstraintViolationException> valid = modelValidator.isValid(condition);
-        assertThat(valid.isEmpty()).isFalse();
+        assertThat(valid).isNotEmpty();
         assertThat(valid.get().getConstraintViolations()).hasSize(1);
         assertThat(valid.get().getMessage()).isEqualTo(": `values` must be null for type " + type.name() + "\n");
     }
@@ -72,7 +72,7 @@ class PreconditionFilterValidationTest {
             .build();
 
         Optional<ConstraintViolationException> valid = modelValidator.isValid(condition);
-        assertThat(valid.isEmpty()).isTrue();
+        assertThat(valid).isEmpty();
     }
 
     @ParameterizedTest
@@ -85,7 +85,7 @@ class PreconditionFilterValidationTest {
             .build();
 
         Optional<ConstraintViolationException> valid = modelValidator.isValid(condition);
-        assertThat(valid.isEmpty()).isFalse();
+        assertThat(valid).isNotEmpty();
         assertThat(valid.get().getConstraintViolations()).hasSize(1);
         assertThat(valid.get().getMessage()).isEqualTo(": `value` must be null for type " + type.name() + "\n");
     }

--- a/core/src/test/java/io/kestra/core/validations/RandomRetryValidationTest.java
+++ b/core/src/test/java/io/kestra/core/validations/RandomRetryValidationTest.java
@@ -27,7 +27,7 @@ public class RandomRetryValidationTest {
             .build();
 
         Optional<ConstraintViolationException> valid = modelValidator.isValid(retry);
-        assertThat(valid.isEmpty()).isTrue();
+        assertThat(valid).isEmpty();
     }
 
     @Test
@@ -40,7 +40,7 @@ public class RandomRetryValidationTest {
             .build();
 
         Optional<ConstraintViolationException> valid = modelValidator.isValid(retry);
-        assertThat(valid.isEmpty()).isFalse();
+        assertThat(valid).isNotEmpty();
         assertThat(valid.get().getConstraintViolations()).hasSize(1);
         assertThat(valid.get().getMessage()).isEqualTo(": 'minInterval' must be less than 'maxDuration' but is PT2S\n");
 
@@ -52,7 +52,7 @@ public class RandomRetryValidationTest {
             .build();
 
         valid = modelValidator.isValid(retry);
-        assertThat(valid.isEmpty()).isFalse();
+        assertThat(valid).isNotEmpty();
         assertThat(valid.get().getConstraintViolations()).hasSize(1);
         assertThat(valid.get().getMessage()).isEqualTo(": 'minInterval' must be less than 'maxInterval' but is PT3S\n");
     }

--- a/core/src/test/java/io/kestra/core/validations/RegexTest.java
+++ b/core/src/test/java/io/kestra/core/validations/RegexTest.java
@@ -27,11 +27,11 @@ class RegexTest {
     void inputValidation() {
         final RegexCls validRegex = new RegexCls("[A-Z]+");
 
-        assertThat(modelValidator.isValid(validRegex).isEmpty()).isTrue();
+        assertThat(modelValidator.isValid(validRegex)).isEmpty();
 
         final RegexCls invalidRegex = new RegexCls("\\");
 
-        assertThat(modelValidator.isValid(invalidRegex).isPresent()).isTrue();
+        assertThat(modelValidator.isValid(invalidRegex)).isPresent();
         assertThat(modelValidator.isValid(invalidRegex).get().getMessage()).contains("invalid pattern");
     }
 }

--- a/core/src/test/java/io/kestra/core/validations/ScheduleValidationTest.java
+++ b/core/src/test/java/io/kestra/core/validations/ScheduleValidationTest.java
@@ -25,14 +25,14 @@ class ScheduleValidationTest {
             .cron("* * * * *")
             .build();
 
-        assertThat(modelValidator.isValid(build).isEmpty()).isTrue();
+        assertThat(modelValidator.isValid(build)).isEmpty();
 
         build = Schedule.builder()
             .type(Schedule.class.getName())
             .cron("$ome Inv@lid Cr0n")
             .build();
 
-        assertThat(modelValidator.isValid(build).isPresent()).isTrue();
+        assertThat(modelValidator.isValid(build)).isPresent();
         assertThat(modelValidator.isValid(build).get().getMessage()).contains("invalid cron expression");
     }
 
@@ -44,7 +44,7 @@ class ScheduleValidationTest {
             .cron("@hourly")
             .build();
 
-        assertThat(modelValidator.isValid(build).isEmpty()).isTrue();
+        assertThat(modelValidator.isValid(build)).isEmpty();
     }
 
     @Test
@@ -56,7 +56,7 @@ class ScheduleValidationTest {
             .cron("* * * * * *")
             .build();
 
-        assertThat(modelValidator.isValid(build).isEmpty()).isTrue();
+        assertThat(modelValidator.isValid(build)).isEmpty();
 
         build = Schedule.builder()
             .id(IdUtils.create())
@@ -64,7 +64,7 @@ class ScheduleValidationTest {
             .cron("* * * * * *")
             .build();
 
-        assertThat(modelValidator.isValid(build).isPresent()).isTrue();
+        assertThat(modelValidator.isValid(build)).isPresent();
         assertThat(modelValidator.isValid(build).get().getMessage()).contains("invalid cron expression");
     }
 
@@ -77,7 +77,7 @@ class ScheduleValidationTest {
             .lateMaximumDelay(Duration.ofSeconds(10))
             .build();
 
-        assertThat(modelValidator.isValid(build).isPresent()).isFalse();
+        assertThat(modelValidator.isValid(build)).isNotPresent();
     }
 
     @Test
@@ -90,7 +90,7 @@ class ScheduleValidationTest {
             .build();
 
 
-        assertThat(modelValidator.isValid(build).isPresent()).isTrue();
+        assertThat(modelValidator.isValid(build)).isPresent();
         assertThat(modelValidator.isValid(build).get().getMessage()).contains("interval: must be null");
 
     }

--- a/core/src/test/java/io/kestra/core/validations/TimeWindowValidationTest.java
+++ b/core/src/test/java/io/kestra/core/validations/TimeWindowValidationTest.java
@@ -24,7 +24,7 @@ class TimeWindowValidationTest {
         var sla = TimeWindow.builder().build();
 
         Optional<ConstraintViolationException> valid = modelValidator.isValid(sla);
-        assertThat(valid.isEmpty()).isTrue();
+        assertThat(valid).isEmpty();
     }
 
     @Test
@@ -32,7 +32,7 @@ class TimeWindowValidationTest {
         var sla = TimeWindow.builder().type(TimeWindow.Type.DAILY_TIME_DEADLINE).deadline(LocalTime.now()).build();
 
         Optional<ConstraintViolationException> valid = modelValidator.isValid(sla);
-        assertThat(valid.isEmpty()).isTrue();
+        assertThat(valid).isEmpty();
     }
 
     @Test
@@ -40,7 +40,7 @@ class TimeWindowValidationTest {
         var sla = TimeWindow.builder().type(TimeWindow.Type.DAILY_TIME_DEADLINE).build();
 
         Optional<ConstraintViolationException> valid = modelValidator.isValid(sla);
-        assertThat(valid.isEmpty()).isFalse();
+        assertThat(valid).isNotEmpty();
         assertThat(valid.get().getConstraintViolations()).hasSize(1);
         assertThat(valid.get().getMessage()).isEqualTo(": Time window of type `DAILY_TIME_DEADLINE` must have a deadline.\n");
     }
@@ -50,7 +50,7 @@ class TimeWindowValidationTest {
         var sla = TimeWindow.builder().type(TimeWindow.Type.DAILY_TIME_DEADLINE).deadline(LocalTime.now()).window(Duration.ofHours(1)).build();
 
         Optional<ConstraintViolationException> valid = modelValidator.isValid(sla);
-        assertThat(valid.isEmpty()).isFalse();
+        assertThat(valid).isNotEmpty();
         assertThat(valid.get().getConstraintViolations()).hasSize(1);
         assertThat(valid.get().getMessage()).isEqualTo(": Time window of type `DAILY_TIME_DEADLINE` cannot have a window.\n");
     }
@@ -60,7 +60,7 @@ class TimeWindowValidationTest {
         var sla = TimeWindow.builder().type(TimeWindow.Type.DAILY_TIME_WINDOW).startTime(LocalTime.now()).endTime(LocalTime.now()).build();
 
         Optional<ConstraintViolationException> valid = modelValidator.isValid(sla);
-        assertThat(valid.isEmpty()).isTrue();
+        assertThat(valid).isEmpty();
     }
 
     @Test
@@ -68,7 +68,7 @@ class TimeWindowValidationTest {
         var sla = TimeWindow.builder().type(TimeWindow.Type.DAILY_TIME_WINDOW).build();
 
         Optional<ConstraintViolationException> valid = modelValidator.isValid(sla);
-        assertThat(valid.isEmpty()).isFalse();
+        assertThat(valid).isNotEmpty();
         assertThat(valid.get().getConstraintViolations()).hasSize(2);
         assertThat(valid.get().getMessage()).contains(": Time window of type `DAILY_TIME_WINDOW` must have an end time.\n");
         assertThat(valid.get().getMessage()).contains(": Time window of type `DAILY_TIME_WINDOW` must have a start time.\n");
@@ -79,7 +79,7 @@ class TimeWindowValidationTest {
         var sla = TimeWindow.builder().type(TimeWindow.Type.DAILY_TIME_WINDOW).startTime(LocalTime.now()).endTime(LocalTime.now()).window(Duration.ofHours(1)).build();
 
         Optional<ConstraintViolationException> valid = modelValidator.isValid(sla);
-        assertThat(valid.isEmpty()).isFalse();
+        assertThat(valid).isNotEmpty();
         assertThat(valid.get().getConstraintViolations()).hasSize(2);
         assertThat(valid.get().getMessage()).contains(": Time window of type `DAILY_TIME_WINDOW` cannot have a window.\n");
         assertThat(valid.get().getMessage()).contains(": Time window of type `DAILY_TIME_WINDOW` cannot have a deadline.\n");
@@ -90,7 +90,7 @@ class TimeWindowValidationTest {
         var sla = TimeWindow.builder().type(TimeWindow.Type.DURATION_WINDOW).window(Duration.ofHours(1)).build();
 
         Optional<ConstraintViolationException> valid = modelValidator.isValid(sla);
-        assertThat(valid.isEmpty()).isTrue();
+        assertThat(valid).isEmpty();
     }
 
     @Test
@@ -98,7 +98,7 @@ class TimeWindowValidationTest {
         var sla = TimeWindow.builder().type(TimeWindow.Type.DURATION_WINDOW).deadline(LocalTime.now()).window(Duration.ofHours(1)).build();
 
         Optional<ConstraintViolationException> valid = modelValidator.isValid(sla);
-        assertThat(valid.isEmpty()).isFalse();
+        assertThat(valid).isNotEmpty();
         assertThat(valid.get().getConstraintViolations()).hasSize(1);
         assertThat(valid.get().getMessage()).isEqualTo(": Time window of type `DURATION_WINDOW` cannot have a deadline.\n");
     }
@@ -108,7 +108,7 @@ class TimeWindowValidationTest {
         var sla = TimeWindow.builder().type(TimeWindow.Type.SLIDING_WINDOW).window(Duration.ofHours(1)).build();
 
         Optional<ConstraintViolationException> valid = modelValidator.isValid(sla);
-        assertThat(valid.isEmpty()).isTrue();
+        assertThat(valid).isEmpty();
     }
 
     @Test
@@ -116,7 +116,7 @@ class TimeWindowValidationTest {
         var sla = TimeWindow.builder().type(TimeWindow.Type.SLIDING_WINDOW).deadline(LocalTime.now()).window(Duration.ofHours(1)).build();
 
         Optional<ConstraintViolationException> valid = modelValidator.isValid(sla);
-        assertThat(valid.isEmpty()).isFalse();
+        assertThat(valid).isNotEmpty();
         assertThat(valid.get().getConstraintViolations()).hasSize(1);
         assertThat(valid.get().getMessage()).isEqualTo(": Time window of type `SLIDING_WINDOW` cannot have a deadline.\n");
     }

--- a/core/src/test/java/io/kestra/core/validations/TimezoneIdTest.java
+++ b/core/src/test/java/io/kestra/core/validations/TimezoneIdTest.java
@@ -27,11 +27,11 @@ class TimezoneIdTest {
     void inputValidation() {
         final TimezoneIdCls existingTimezone = new TimezoneIdCls("Europe/Paris");
 
-        assertThat(modelValidator.isValid(existingTimezone).isEmpty()).isTrue();
+        assertThat(modelValidator.isValid(existingTimezone)).isEmpty();
 
         final TimezoneIdCls invalidTimezone = new TimezoneIdCls("Foo/Bar");
 
-        assertThat(modelValidator.isValid(invalidTimezone).isPresent()).isTrue();
+        assertThat(modelValidator.isValid(invalidTimezone)).isPresent();
         assertThat(modelValidator.isValid(invalidTimezone).get().getMessage())
             .satisfies(
                 arg -> assertThat(arg).startsWith("timezone"),

--- a/core/src/test/java/io/kestra/core/validations/WebhookTest.java
+++ b/core/src/test/java/io/kestra/core/validations/WebhookTest.java
@@ -29,7 +29,7 @@ public class WebhookTest {
             )
             .build();
 
-        assertThat(modelValidator.isValid(webhook).isPresent()).isTrue();
+        assertThat(modelValidator.isValid(webhook)).isPresent();
         assertThat(modelValidator.isValid(webhook).get().getMessage()).contains("invalid webhook: conditions of type MultipleCondition are not supported");
     }
 }

--- a/core/src/test/java/io/kestra/core/validations/WorkingDirectoryTest.java
+++ b/core/src/test/java/io/kestra/core/validations/WorkingDirectoryTest.java
@@ -35,7 +35,7 @@ public class WorkingDirectoryTest {
             )
             .build();
 
-        assertThat(modelValidator.isValid(workingDirectory).isPresent()).isFalse();
+        assertThat(modelValidator.isValid(workingDirectory)).isNotPresent();
     }
 
     @Test
@@ -46,7 +46,7 @@ public class WorkingDirectoryTest {
             .type(WorkingDirectory.class.getName())
             .build();
 
-        assertThat(modelValidator.isValid(workingDirectory).isPresent()).isTrue();
+        assertThat(modelValidator.isValid(workingDirectory)).isPresent();
         assertThat(modelValidator.isValid(workingDirectory).get().getMessage()).contains("The 'tasks' property cannot be empty");
 
         // flowable task
@@ -63,7 +63,7 @@ public class WorkingDirectoryTest {
             )
             .build();
 
-        assertThat(modelValidator.isValid(workingDirectory).isPresent()).isTrue();
+        assertThat(modelValidator.isValid(workingDirectory)).isPresent();
         assertThat(modelValidator.isValid(workingDirectory).get().getMessage()).contains("Only runnable tasks are allowed as children of a WorkingDirectory task");
 
         // worker group at the subtasks level
@@ -81,7 +81,7 @@ public class WorkingDirectoryTest {
             )
             .build();
 
-        assertThat(modelValidator.isValid(workingDirectory).isPresent()).isTrue();
+        assertThat(modelValidator.isValid(workingDirectory)).isPresent();
         assertThat(modelValidator.isValid(workingDirectory).get().getMessage()).contains("Cannot set a Worker Group in any WorkingDirectory sub-tasks, it is only supported at the WorkingDirectory level");
 
     }

--- a/core/src/test/java/io/kestra/core/validations/extractors/PropertyValueExtractorTest.java
+++ b/core/src/test/java/io/kestra/core/validations/extractors/PropertyValueExtractorTest.java
@@ -26,7 +26,7 @@ public class PropertyValueExtractorTest {
 
         dto = new DynamicPropertyDto(Property.of(5), Property.of("Test"));
         violations = validator.validate(dto);
-        assertThat(violations.size()).isEqualTo(1);
+        assertThat(violations).hasSize(1);
         ConstraintViolation<DynamicPropertyDto> violation = violations.stream().findFirst().get();
         assertThat(violation.getMessage()).isEqualTo("must be greater than or equal to 10");
     }

--- a/core/src/test/java/io/kestra/plugin/core/execution/CountTest.java
+++ b/core/src/test/java/io/kestra/plugin/core/execution/CountTest.java
@@ -52,7 +52,7 @@ class CountTest {
         RunContext runContext = TestsUtils.mockRunContext(runContextFactory, task, ImmutableMap.of("namespace", "io.kestra.unittest"));
         Count.Output run = task.run(runContext);
 
-        assertThat(run.getResults().size()).isEqualTo(2);
+        assertThat(run.getResults()).hasSize(2);
         assertThat(run.getResults().stream().filter(f -> f.getFlowId().equals("second")).count()).isEqualTo(1L);
         assertThat(run.getResults().stream().filter(f -> f.getFlowId().equals("second")).findFirst().get().getCount()).isEqualTo(6L);
         assertThat(run.getResults().stream().filter(f -> f.getFlowId().equals("third")).count()).isEqualTo(1L);
@@ -71,7 +71,7 @@ class CountTest {
             .build()
             .run(runContext);
 
-        assertThat(run.getResults().size()).isZero();
+        assertThat(run.getResults()).isEmpty();
 
         // non-matching entry
         run = Count.builder()
@@ -84,7 +84,7 @@ class CountTest {
             .build()
             .run(runContext);
 
-        assertThat(run.getResults().size()).isEqualTo(1);
+        assertThat(run.getResults()).hasSize(1);
         assertThat(run.getResults().stream().filter(f -> f.getFlowId().equals("missing")).count()).isEqualTo(1L);
         assertThat(run.getTotal()).isEqualTo(0L);
 

--- a/core/src/test/java/io/kestra/plugin/core/execution/ExitTest.java
+++ b/core/src/test/java/io/kestra/plugin/core/execution/ExitTest.java
@@ -37,7 +37,7 @@ class ExitTest {
     @ExecuteFlow("flows/valids/exit.yaml")
     void shouldExitTheExecution(Execution execution) {
         assertThat(execution.getState().getCurrent()).isEqualTo(State.Type.WARNING);
-        assertThat(execution.getTaskRunList().size()).isEqualTo(2);
+        assertThat(execution.getTaskRunList()).hasSize(2);
         assertThat(execution.getTaskRunList().getFirst().getState().getCurrent()).isEqualTo(State.Type.WARNING);
     }
 
@@ -62,7 +62,7 @@ class ExitTest {
         assertTrue(countDownLatch.await(1, TimeUnit.MINUTES));
         assertThat(killedExecution.get()).isNotNull();
         assertThat(killedExecution.get().getState().getCurrent()).isEqualTo(State.Type.KILLED);
-        assertThat(killedExecution.get().getTaskRunList().size()).isEqualTo(2);
+        assertThat(killedExecution.get().getTaskRunList()).hasSize(2);
         assertThat(killedExecution.get().getTaskRunList().getFirst().getState().getCurrent()).isEqualTo(State.Type.KILLED);
         assertThat(killedExecution.get().getTaskRunList().get(1).getState().getCurrent()).isEqualTo(State.Type.KILLED);
         receive.blockLast();

--- a/core/src/test/java/io/kestra/plugin/core/flow/AllowFailureTest.java
+++ b/core/src/test/java/io/kestra/plugin/core/flow/AllowFailureTest.java
@@ -28,7 +28,7 @@ class AllowFailureTest {
     void success(Execution execution) {
         assertThat(execution.getTaskRunList()).hasSize(9);
         control(execution);
-        assertThat(execution.findTaskRunsByTaskId("global-error").size()).isZero();
+        assertThat(execution.findTaskRunsByTaskId("global-error")).isEmpty();
         assertThat(execution.findTaskRunsByTaskId("last").getFirst().getState().getCurrent()).isEqualTo(State.Type.SUCCESS);
         assertThat(execution.getState().getCurrent()).isEqualTo(State.Type.WARNING);
     }

--- a/core/src/test/java/io/kestra/plugin/core/flow/BadExecutableTest.java
+++ b/core/src/test/java/io/kestra/plugin/core/flow/BadExecutableTest.java
@@ -14,7 +14,7 @@ public class BadExecutableTest {
     @Test
     @ExecuteFlow("flows/valids/executable-fail.yml")
     void badExecutable(Execution execution) {
-        assertThat(execution.getTaskRunList().size()).isEqualTo(1);
+        assertThat(execution.getTaskRunList()).hasSize(1);
         assertThat(execution.getTaskRunList().getFirst().getState().getCurrent()).isEqualTo(State.Type.FAILED);
         assertThat(execution.getState().getCurrent()).isEqualTo(State.Type.FAILED);
     }

--- a/core/src/test/java/io/kestra/plugin/core/flow/CorrelationIdTest.java
+++ b/core/src/test/java/io/kestra/plugin/core/flow/CorrelationIdTest.java
@@ -62,13 +62,13 @@ class CorrelationIdTest {
         assertThat(child.get()).isNotNull();
         assertThat(child.get().getState().getCurrent()).isEqualTo(State.Type.SUCCESS);
         Optional<Label> correlationId = child.get().getLabels().stream().filter(label -> label.key().equals(Label.CORRELATION_ID)).findAny();
-        assertThat(correlationId.isPresent()).isTrue();
+        assertThat(correlationId).isPresent();
         assertThat(correlationId.get().value()).isEqualTo(execution.getId());
 
         assertThat(grandChild.get()).isNotNull();
         assertThat(grandChild.get().getState().getCurrent()).isEqualTo(State.Type.SUCCESS);
         correlationId = grandChild.get().getLabels().stream().filter(label -> label.key().equals(Label.CORRELATION_ID)).findAny();
-        assertThat(correlationId.isPresent()).isTrue();
+        assertThat(correlationId).isPresent();
         assertThat(correlationId.get().value()).isEqualTo(execution.getId());
     }
 }

--- a/core/src/test/java/io/kestra/plugin/core/flow/CurrentEachOutputFunctionTest.java
+++ b/core/src/test/java/io/kestra/plugin/core/flow/CurrentEachOutputFunctionTest.java
@@ -17,21 +17,21 @@ public class CurrentEachOutputFunctionTest {
         var output1 = (Map<String, Object>) execution.outputs().get("1-1-1_return");
         var outputv11 = (Map<String, Object>) output1.get("v11");
         var outputv11v21 = (Map<String, Object>) outputv11.get("v21");
-        assertThat(((Map<String, Object>) outputv11v21.get("v31")).get("value")).isEqualTo("return-v11-v21-v31");
-        assertThat(((Map<String, Object>) outputv11v21.get("v32")).get("value")).isEqualTo("return-v11-v21-v32");
+        assertThat(((Map<String, Object>) outputv11v21.get("v31"))).containsEntry("value", "return-v11-v21-v31");
+        assertThat(((Map<String, Object>) outputv11v21.get("v32"))).containsEntry("value", "return-v11-v21-v32");
         var outputv11v22 = (Map<String, Object>) outputv11.get("v22");
-        assertThat(((Map<String, Object>) outputv11v22.get("v31")).get("value")).isEqualTo("return-v11-v22-v31");
-        assertThat(((Map<String, Object>) outputv11v22.get("v32")).get("value")).isEqualTo("return-v11-v22-v32");
+        assertThat(((Map<String, Object>) outputv11v22.get("v31"))).containsEntry("value", "return-v11-v22-v31");
+        assertThat(((Map<String, Object>) outputv11v22.get("v32"))).containsEntry("value", "return-v11-v22-v32");
         var outputv12 = (Map<String, Object>) output1.get("v12");
         var outputv12v21 = (Map<String, Object>) outputv12.get("v21");
-        assertThat(((Map<String, Object>) outputv12v21.get("v31")).get("value")).isEqualTo("return-v12-v21-v31");
-        assertThat(((Map<String, Object>) outputv12v21.get("v32")).get("value")).isEqualTo("return-v12-v21-v32");
+        assertThat(((Map<String, Object>) outputv12v21.get("v31"))).containsEntry("value", "return-v12-v21-v31");
+        assertThat(((Map<String, Object>) outputv12v21.get("v32"))).containsEntry("value", "return-v12-v21-v32");
         var outputv12v22 = (Map<String, Object>) outputv12.get("v22");
-        assertThat(((Map<String, Object>) outputv12v22.get("v31")).get("value")).isEqualTo("return-v12-v22-v31");
-        assertThat(((Map<String, Object>) outputv12v22.get("v32")).get("value")).isEqualTo("return-v12-v22-v32");
+        assertThat(((Map<String, Object>) outputv12v22.get("v31"))).containsEntry("value", "return-v12-v22-v31");
+        assertThat(((Map<String, Object>) outputv12v22.get("v32"))).containsEntry("value", "return-v12-v22-v32");
 
         var output2 = (Map<String, Object>) execution.outputs().get("2-1_return");
-        assertThat(((Map<String, Object>) output2.get("v41")).get("value")).isEqualTo("return-v41");
-        assertThat(((Map<String, Object>) output2.get("v42")).get("value")).isEqualTo("return-v42");
+        assertThat(((Map<String, Object>) output2.get("v41"))).containsEntry("value", "return-v41");
+        assertThat(((Map<String, Object>) output2.get("v42"))).containsEntry("value", "return-v42");
     }
 }

--- a/core/src/test/java/io/kestra/plugin/core/flow/DagTest.java
+++ b/core/src/test/java/io/kestra/plugin/core/flow/DagTest.java
@@ -41,7 +41,7 @@ public class DagTest {
     @ExecuteFlow("flows/valids/dag.yaml")
     void dag(Execution execution) {
         assertThat(execution.getState().getCurrent()).isEqualTo(State.Type.SUCCESS);
-        assertThat(execution.getTaskRunList().size()).isEqualTo(7);
+        assertThat(execution.getTaskRunList()).hasSize(7);
     }
 
     @Test
@@ -49,8 +49,8 @@ public class DagTest {
         Flow flow = this.parse("flows/invalids/dag-cyclicdependency.yaml");
         Optional<ConstraintViolationException> validate = modelValidator.isValid(flow);
 
-        assertThat(validate.isPresent()).isTrue();
-        assertThat(validate.get().getConstraintViolations().size()).isEqualTo(1);
+        assertThat(validate).isPresent();
+        assertThat(validate.get().getConstraintViolations()).hasSize(1);
 
         assertThat(validate.get().getMessage()).contains("dag: Cyclic dependency detected: task1, task2");
     }
@@ -60,8 +60,8 @@ public class DagTest {
         Flow flow = this.parse("flows/invalids/dag-notexist-task.yaml");
         Optional<ConstraintViolationException> validate = modelValidator.isValid(flow);
 
-        assertThat(validate.isPresent()).isTrue();
-        assertThat(validate.get().getConstraintViolations().size()).isEqualTo(1);
+        assertThat(validate).isPresent();
+        assertThat(validate.get().getConstraintViolations()).hasSize(1);
 
         assertThat(validate.get().getMessage()).contains("dag: Not existing task id in dependency: taskX");
     }

--- a/core/src/test/java/io/kestra/plugin/core/flow/FinallyTest.java
+++ b/core/src/test/java/io/kestra/plugin/core/flow/FinallyTest.java
@@ -84,7 +84,7 @@ class FinallyTest {
         assertThat(execution.getTaskRunList()).hasSize(3);
         assertThat(execution.getState().getCurrent()).isEqualTo(State.Type.FAILED);
         assertThat(execution.findTaskRunsByTaskId("ko").getFirst().getState().getCurrent()).isEqualTo(State.Type.FAILED);
-        assertThat(execution.findTaskRunsByTaskId("ok").isEmpty()).isTrue();
+        assertThat(execution.findTaskRunsByTaskId("ok")).isEmpty();
         assertThat(execution.findTaskRunsByTaskId("a1").getFirst().getState().getCurrent()).isEqualTo(State.Type.SUCCESS);
     }
 
@@ -365,7 +365,7 @@ class FinallyTest {
         assertThat(execution.getTaskRunList()).hasSize(2);
         assertThat(execution.getState().getCurrent()).isEqualTo(State.Type.FAILED);
         assertThat(execution.findTaskRunsByTaskId("ko").getFirst().getState().getCurrent()).isEqualTo(State.Type.FAILED);
-        assertThat(execution.findTaskRunsByTaskId("ok").isEmpty()).isTrue();
+        assertThat(execution.findTaskRunsByTaskId("ok")).isEmpty();
         assertThat(execution.findTaskRunsByTaskId("a1").getFirst().getState().getCurrent()).isEqualTo(State.Type.SUCCESS);
     }
 }

--- a/core/src/test/java/io/kestra/plugin/core/flow/FlowCaseTest.java
+++ b/core/src/test/java/io/kestra/plugin/core/flow/FlowCaseTest.java
@@ -71,11 +71,11 @@ public class FlowCaseTest {
 
         assertThat(execution.getTaskRunList()).hasSize(1);
         assertThat(execution.getState().getCurrent()).isEqualTo(State.Type.SUCCESS);
-        assertThat(execution.getTaskRunList().getFirst().getOutputs().get("executionId")).isEqualTo(triggered.get().getId());
+        assertThat(execution.getTaskRunList().getFirst().getOutputs()).containsEntry("executionId", triggered.get().getId());
         assertThat(triggered.get().getTrigger().getType()).isEqualTo("io.kestra.core.tasks.flows.Subflow");
-        assertThat(triggered.get().getTrigger().getVariables().get("executionId")).isEqualTo(execution.getId());
-        assertThat(triggered.get().getTrigger().getVariables().get("flowId")).isEqualTo(execution.getFlowId());
-        assertThat(triggered.get().getTrigger().getVariables().get("namespace")).isEqualTo(execution.getNamespace());
+        assertThat(triggered.get().getTrigger().getVariables()).containsEntry("executionId", execution.getId());
+        assertThat(triggered.get().getTrigger().getVariables()).containsEntry("flowId", execution.getFlowId());
+        assertThat(triggered.get().getTrigger().getVariables()).containsEntry("namespace", execution.getNamespace());
     }
 
     @SuppressWarnings({"ResultOfMethodCallIgnored", "unchecked"})
@@ -113,25 +113,25 @@ public class FlowCaseTest {
             assertThat(((Map<String, String>) execution.getTaskRunList().getFirst().getOutputs().get("outputs")).get("extracted")).contains(outputs);
         }
 
-        assertThat(execution.getTaskRunList().getFirst().getOutputs().get("executionId")).isEqualTo(triggered.get().getId());
+        assertThat(execution.getTaskRunList().getFirst().getOutputs()).containsEntry("executionId", triggered.get().getId());
 
         if (outputs != null) {
-            assertThat(execution.getTaskRunList().getFirst().getOutputs().get("state")).isEqualTo(triggered.get().getState().getCurrent().name());
+            assertThat(execution.getTaskRunList().getFirst().getOutputs()).containsEntry("state", triggered.get().getState().getCurrent().name());
         }
 
         assertThat(triggered.get().getTrigger().getType()).isEqualTo("io.kestra.plugin.core.flow.Subflow");
-        assertThat(triggered.get().getTrigger().getVariables().get("executionId")).isEqualTo(execution.getId());
-        assertThat(triggered.get().getTrigger().getVariables().get("flowId")).isEqualTo(execution.getFlowId());
-        assertThat(triggered.get().getTrigger().getVariables().get("namespace")).isEqualTo(execution.getNamespace());
+        assertThat(triggered.get().getTrigger().getVariables()).containsEntry("executionId", execution.getId());
+        assertThat(triggered.get().getTrigger().getVariables()).containsEntry("flowId", execution.getFlowId());
+        assertThat(triggered.get().getTrigger().getVariables()).containsEntry("namespace", execution.getNamespace());
 
         assertThat(triggered.get().getTaskRunList()).hasSize(count);
         assertThat(triggered.get().getState().getCurrent()).isEqualTo(triggerState);
 
         if (testInherited) {
-            assertThat(triggered.get().getLabels().size()).isEqualTo(6);
+            assertThat(triggered.get().getLabels()).hasSize(6);
             assertThat(triggered.get().getLabels()).contains(new Label(Label.CORRELATION_ID, execution.getId()), new Label("mainFlowExecutionLabel", "execFoo"), new Label("mainFlowLabel", "flowFoo"), new Label("launchTaskLabel", "launchFoo"), new Label("switchFlowLabel", "switchFoo"), new Label("overriding", "child"));
         } else {
-            assertThat(triggered.get().getLabels().size()).isEqualTo(4);
+            assertThat(triggered.get().getLabels()).hasSize(4);
             assertThat(triggered.get().getLabels()).contains(new Label(Label.CORRELATION_ID, execution.getId()), new Label("launchTaskLabel", "launchFoo"), new Label("switchFlowLabel", "switchFoo"), new Label("overriding", "child"));
             assertThat(triggered.get().getLabels()).doesNotContain(new Label("inherited", "label"));
         }

--- a/core/src/test/java/io/kestra/plugin/core/flow/FlowOutputTest.java
+++ b/core/src/test/java/io/kestra/plugin/core/flow/FlowOutputTest.java
@@ -16,7 +16,7 @@ class FlowOutputTest {
     @ExecuteFlow("flows/valids/flow-with-outputs.yml")
     void shouldGetSuccessExecutionForFlowWithOutputs(Execution execution) {
         assertThat(execution.getOutputs()).hasSize(1);
-        assertThat(execution.getOutputs().get("key")).isEqualTo("{\"value\":\"flow-with-outputs\"}");
+        assertThat(execution.getOutputs()).containsEntry("key", "{\"value\":\"flow-with-outputs\"}");
         assertThat(execution.getState().getCurrent()).isEqualTo(State.Type.SUCCESS);
     }
 

--- a/core/src/test/java/io/kestra/plugin/core/flow/ForEachItemCaseTest.java
+++ b/core/src/test/java/io/kestra/plugin/core/flow/ForEachItemCaseTest.java
@@ -92,12 +92,12 @@ public class ForEachItemCaseTest {
         assertThat(execution.getTaskRunList().get(2).getAttempts().getFirst().getState().getCurrent()).isEqualTo(State.Type.SUCCESS);
         assertThat(execution.getState().getCurrent()).isEqualTo(State.Type.SUCCESS);
         Map<String, Object> outputs = execution.getTaskRunList().get(2).getOutputs();
-        assertThat(outputs.get("numberOfBatches")).isEqualTo(26);
+        assertThat(outputs).containsEntry("numberOfBatches", 26);
         assertThat(outputs.get("iterations")).isNotNull();
         Map<String, Integer> iterations = (Map<String, Integer>) outputs.get("iterations");
         assertThat(iterations.get("CREATED")).isZero();
         assertThat(iterations.get("RUNNING")).isZero();
-        assertThat(iterations.get("SUCCESS")).isEqualTo(26);
+        assertThat(iterations).containsEntry("SUCCESS", 26);
 
         // assert on the last subflow execution
         assertThat(triggered.get().getState().getCurrent()).isEqualTo(State.Type.SUCCESS);
@@ -105,7 +105,7 @@ public class ForEachItemCaseTest {
         assertThat((String) triggered.get().getInputs().get("items")).matches("kestra:///io/kestra/tests/for-each-item/executions/.*/tasks/each-split/.*\\.txt");
         assertThat(triggered.get().getTaskRunList()).hasSize(1);
         Optional<Label> correlationId = triggered.get().getLabels().stream().filter(label -> label.key().equals(Label.CORRELATION_ID)).findAny();
-        assertThat(correlationId.isPresent()).isTrue();
+        assertThat(correlationId).isPresent();
         assertThat(correlationId.get().value()).isEqualTo(execution.getId());
     }
 
@@ -154,12 +154,12 @@ public class ForEachItemCaseTest {
         assertThat(execution.getTaskRunList().get(2).getAttempts().getFirst().getState().getCurrent()).isEqualTo(State.Type.SUCCESS);
         assertThat(execution.getState().getCurrent()).isEqualTo(State.Type.SUCCESS);
         Map<String, Object> outputs = execution.getTaskRunList().get(2).getOutputs();
-        assertThat(outputs.get("numberOfBatches")).isEqualTo(26);
+        assertThat(outputs).containsEntry("numberOfBatches", 26);
         assertThat(outputs.get("iterations")).isNotNull();
         Map<String, Integer> iterations = (Map<String, Integer>) outputs.get("iterations");
         assertThat(iterations.get("CREATED")).isNull(); // if we didn't wait we will only observe RUNNING and SUCCESS
         assertThat(iterations.get("RUNNING")).isZero();
-        assertThat(iterations.get("SUCCESS")).isEqualTo(26);
+        assertThat(iterations).containsEntry("SUCCESS", 26);
 
         // wait for the 26 flows to ends
         assertThat(countDownLatch.await(1, TimeUnit.MINUTES)).as("Remaining count was " + countDownLatch.getCount()).isTrue();
@@ -201,12 +201,12 @@ public class ForEachItemCaseTest {
         assertThat(execution.getTaskRunList().get(2).getAttempts().getFirst().getState().getCurrent()).isEqualTo(FAILED);
         assertThat(execution.getState().getCurrent()).isEqualTo(FAILED);
         Map<String, Object> outputs = execution.getTaskRunList().get(2).getOutputs();
-        assertThat(outputs.get("numberOfBatches")).isEqualTo(26);
+        assertThat(outputs).containsEntry("numberOfBatches", 26);
         assertThat(outputs.get("iterations")).isNotNull();
         Map<String, Integer> iterations = (Map<String, Integer>) outputs.get("iterations");
         assertThat(iterations.get("CREATED")).isZero();
         assertThat(iterations.get("RUNNING")).isZero();
-        assertThat(iterations.get("FAILED")).isEqualTo(26);
+        assertThat(iterations).containsEntry("FAILED", 26);
 
         // assert on the last subflow execution
         assertThat(triggered.get().getState().getCurrent()).isEqualTo(FAILED);
@@ -244,13 +244,13 @@ public class ForEachItemCaseTest {
         assertThat(execution.getTaskRunList().get(2).getAttempts().getFirst().getState().getCurrent()).isEqualTo(State.Type.SUCCESS);
         assertThat(execution.getState().getCurrent()).isEqualTo(State.Type.SUCCESS);
         Map<String, Object> outputs = execution.getTaskRunList().get(2).getOutputs();
-        assertThat(outputs.get("numberOfBatches")).isEqualTo(26);
+        assertThat(outputs).containsEntry("numberOfBatches", 26);
         assertThat(outputs.get("iterations")).isNotNull();
 
         Map<String, Integer> iterations = (Map<String, Integer>) outputs.get("iterations");
         assertThat(iterations.get("CREATED")).isZero();
         assertThat(iterations.get("RUNNING")).isZero();
-        assertThat(iterations.get("SUCCESS")).isEqualTo(26);
+        assertThat(iterations).containsEntry("SUCCESS", 26);
 
         // assert on the last subflow execution
         assertThat(triggered.get().getState().getCurrent()).isEqualTo(State.Type.SUCCESS);
@@ -338,12 +338,12 @@ public class ForEachItemCaseTest {
         assertThat(execution.getTaskRunList()).hasSize(5);
         assertThat(execution.getState().getCurrent()).isEqualTo(State.Type.SUCCESS);
         Map<String, Object> outputs = execution.getTaskRunList().get(3).getOutputs();
-        assertThat(outputs.get("numberOfBatches")).isEqualTo(26);
+        assertThat(outputs).containsEntry("numberOfBatches", 26);
         assertThat(outputs.get("iterations")).isNotNull();
         Map<String, Integer> iterations = (Map<String, Integer>) outputs.get("iterations");
         assertThat(iterations.get("CREATED")).isZero();
         assertThat(iterations.get("RUNNING")).isZero();
-        assertThat(iterations.get("SUCCESS")).isEqualTo(26);
+        assertThat(iterations).containsEntry("SUCCESS", 26);
 
         // assert on the last subflow execution
         assertThat(triggered.get().getState().getCurrent()).isEqualTo(State.Type.SUCCESS);
@@ -351,7 +351,7 @@ public class ForEachItemCaseTest {
         assertThat((String) triggered.get().getInputs().get("items")).matches("kestra:///io/kestra/tests/for-each-item-in-if/executions/.*/tasks/each-split/.*\\.txt");
         assertThat(triggered.get().getTaskRunList()).hasSize(1);
         Optional<Label> correlationId = triggered.get().getLabels().stream().filter(label -> label.key().equals(Label.CORRELATION_ID)).findAny();
-        assertThat(correlationId.isPresent()).isTrue();
+        assertThat(correlationId).isPresent();
         assertThat(correlationId.get().value()).isEqualTo(execution.getId());
     }
 

--- a/core/src/test/java/io/kestra/plugin/core/flow/IfTest.java
+++ b/core/src/test/java/io/kestra/plugin/core/flow/IfTest.java
@@ -94,7 +94,7 @@ class IfTest {
         execution = runnerUtils.runOne(null, "io.kestra.tests", "if-without-else", null,
             (f, e) -> Map.of("param", false) , Duration.ofSeconds(120));
         assertThat(execution.getTaskRunList()).hasSize(1);
-        assertThat(execution.findTaskRunsByTaskId("when-true").isEmpty()).isTrue();
+        assertThat(execution.findTaskRunsByTaskId("when-true")).isEmpty();
         assertThat(execution.getState().getCurrent()).isEqualTo(State.Type.SUCCESS);
     }
 

--- a/core/src/test/java/io/kestra/plugin/core/flow/PauseTest.java
+++ b/core/src/test/java/io/kestra/plugin/core/flow/PauseTest.java
@@ -291,7 +291,7 @@ public class PauseTest {
             assertThat(execution.getState().getCurrent()).isEqualTo(State.Type.SUCCESS);
 
             Map<String, Object> outputs = (Map<String, Object>) execution.findTaskRunsByTaskId("last").getFirst().getOutputs().get("values");
-            assertThat(outputs.get("asked")).isEqualTo("restarted");
+            assertThat(outputs).containsEntry("asked", "restarted");
             assertThat((String) outputs.get("data")).startsWith("kestra://");
             assertThat(CharStreams.toString(new InputStreamReader(storageInterface.get(null, null, URI.create((String) outputs.get("data")))))).isEqualTo(executionId);
         }
@@ -329,7 +329,7 @@ public class PauseTest {
             assertThat(execution.getState().getCurrent()).isEqualTo(State.Type.SUCCESS);
 
             Map<String, Object> outputs = (Map<String, Object>) execution.findTaskRunsByTaskId("last").getFirst().getOutputs().get("values");
-            assertThat(outputs.get("asked")).isEqualTo("MISSING");
+            assertThat(outputs).containsEntry("asked", "MISSING");
         }
 
         public void runDurationWithBehavior(RunnerUtils runnerUtils, Pause.Behavior behavior) throws Exception {

--- a/core/src/test/java/io/kestra/plugin/core/flow/RetryCaseTest.java
+++ b/core/src/test/java/io/kestra/plugin/core/flow/RetryCaseTest.java
@@ -207,7 +207,7 @@ public class RetryCaseTest {
 
     public void retrySubflow(Execution execution) {
         assertThat(execution.getState().getCurrent()).isEqualTo(State.Type.FAILED);
-        assertThat(execution.getTaskRunList().get(0).getAttempts().size()).isEqualTo(3);
+        assertThat(execution.getTaskRunList().getFirst().getAttempts()).hasSize(3);
     }
 
     public void retryFlowableChild(Execution execution) {

--- a/core/src/test/java/io/kestra/plugin/core/flow/RuntimeLabelsTest.java
+++ b/core/src/test/java/io/kestra/plugin/core/flow/RuntimeLabelsTest.java
@@ -45,7 +45,7 @@ class RuntimeLabelsTest {
             )
         );
 
-        assertThat(execution.getTaskRunList().size()).isEqualTo(4);
+        assertThat(execution.getTaskRunList()).hasSize(4);
         assertThat(execution.getState().getCurrent()).isEqualTo(State.Type.SUCCESS);
 
         String labelsOverriderTaskRunId = execution.findTaskRunsByTaskId("override-labels").getFirst().getId();
@@ -64,7 +64,7 @@ class RuntimeLabelsTest {
     @Test
     @ExecuteFlow("flows/valids/npe-labels-update-task.yml")
     void noNpeOnNullPreviousExecutionLabels(Execution execution) {
-        assertThat(execution.getTaskRunList().size()).isEqualTo(1);
+        assertThat(execution.getTaskRunList()).hasSize(1);
         assertThat(execution.getState().getCurrent()).isEqualTo(State.Type.SUCCESS);
 
         String labelsTaskRunId = execution.findTaskRunsByTaskId("labels").getFirst().getId();
@@ -90,7 +90,7 @@ class RuntimeLabelsTest {
             )
         );
 
-        assertThat(execution.getTaskRunList().size()).isEqualTo(1);
+        assertThat(execution.getTaskRunList()).hasSize(1);
         assertThat(execution.getState().getCurrent()).isEqualTo(State.Type.SUCCESS);
 
         String labelsTaskRunId = execution.findTaskRunsByTaskId("update-labels").getFirst().getId();

--- a/core/src/test/java/io/kestra/plugin/core/flow/StateTest.java
+++ b/core/src/test/java/io/kestra/plugin/core/flow/StateTest.java
@@ -32,12 +32,12 @@ class StateTest {
         Execution execution = runnerUtils.runOne(null, "io.kestra.tests", "state",  null, (f, e) -> ImmutableMap.of("state", stateName));
         assertThat(execution.getTaskRunList()).hasSize(5);
         assertThat(execution.getState().getCurrent()).isEqualTo(State.Type.SUCCESS);
-        assertThat(((Map<String, Integer>) execution.findTaskRunsByTaskId("createGet").getFirst().getOutputs().get("data")).get("value")).isEqualTo(1);
+        assertThat(((Map<String, Integer>) execution.findTaskRunsByTaskId("createGet").getFirst().getOutputs().get("data"))).containsEntry("value", 1);
 
         execution = runnerUtils.runOne(null, "io.kestra.tests", "state",  null, (f, e) -> ImmutableMap.of("state", stateName));
         assertThat(execution.getTaskRunList()).hasSize(5);
         assertThat(execution.getState().getCurrent()).isEqualTo(State.Type.SUCCESS);
-        assertThat(((Map<String, Object>) execution.findTaskRunsByTaskId("updateGet").getFirst().getOutputs().get("data")).get("value")).isEqualTo("2");
+        assertThat(((Map<String, Object>) execution.findTaskRunsByTaskId("updateGet").getFirst().getOutputs().get("data"))).containsEntry("value", "2");
 
         execution = runnerUtils.runOne(null, "io.kestra.tests", "state",  null, (f, e) -> ImmutableMap.of("state", stateName));
         assertThat(execution.getTaskRunList()).hasSize(5);
@@ -53,7 +53,7 @@ class StateTest {
         Execution execution = runnerUtils.runOne(null, "io.kestra.tests", "state",  null, (f, e) -> ImmutableMap.of("state", "each"));
         assertThat(execution.getTaskRunList()).hasSize(17);
         assertThat(execution.getState().getCurrent()).isEqualTo(State.Type.SUCCESS);
-        assertThat(((Map<String, String>) execution.findTaskRunByTaskIdAndValue("regetEach1", List.of("b")).getOutputs().get("data")).get("value")).isEqualTo("null-b");
-        assertThat(((Map<String, String>) execution.findTaskRunByTaskIdAndValue("regetEach2", List.of("b")).getOutputs().get("data")).get("value")).isEqualTo("null-a-b");
+        assertThat(((Map<String, String>) execution.findTaskRunByTaskIdAndValue("regetEach1", List.of("b")).getOutputs().get("data"))).containsEntry("value", "null-b");
+        assertThat(((Map<String, String>) execution.findTaskRunByTaskIdAndValue("regetEach2", List.of("b")).getOutputs().get("data"))).containsEntry("value", "null-a-b");
     }
 }

--- a/core/src/test/java/io/kestra/plugin/core/flow/SubflowTest.java
+++ b/core/src/test/java/io/kestra/plugin/core/flow/SubflowTest.java
@@ -142,7 +142,7 @@ class SubflowTest {
             .toMap();
         assertThat(result.get().getParentTaskRun().getOutputs()).containsAllEntriesOf(expected);
 
-        assertThat(result.get().getParentTaskRun().getAttempts().get(0).getState().getHistories())
+        assertThat(result.get().getParentTaskRun().getAttempts().getFirst().getState().getHistories())
             .extracting(History::getState)
             .containsExactly(
                 State.Type.CREATED,

--- a/core/src/test/java/io/kestra/plugin/core/flow/SwitchTest.java
+++ b/core/src/test/java/io/kestra/plugin/core/flow/SwitchTest.java
@@ -31,8 +31,8 @@ class SwitchTest {
         );
 
         assertThat(execution.getTaskRunList().get(1).getTaskId()).isEqualTo("t1");
-        assertThat(execution.findTaskRunsByTaskId("parent-seq").getFirst().getOutputs().get("value")).isEqualTo("FIRST");
-        assertThat((Boolean) execution.findTaskRunsByTaskId("parent-seq").getFirst().getOutputs().get("defaults")).isEqualTo(false);
+        assertThat(execution.findTaskRunsByTaskId("parent-seq").getFirst().getOutputs()).containsEntry("value", "FIRST");
+        assertThat((Boolean) execution.findTaskRunsByTaskId("parent-seq").getFirst().getOutputs().get("defaults")).isFalse();
     }
 
     @Test
@@ -47,7 +47,7 @@ class SwitchTest {
         );
 
         assertThat(execution.getTaskRunList().get(1).getTaskId()).isEqualTo("t2");
-        assertThat(execution.findTaskRunsByTaskId("parent-seq").getFirst().getOutputs().get("value")).isEqualTo("SECOND");
+        assertThat(execution.findTaskRunsByTaskId("parent-seq").getFirst().getOutputs()).containsEntry("value", "SECOND");
         assertThat((Boolean) execution.findTaskRunsByTaskId("parent-seq").getFirst().getOutputs().get("defaults")).isFalse();
         assertThat(execution.getTaskRunList().get(2).getTaskId()).isEqualTo("t2_sub");
     }
@@ -64,7 +64,7 @@ class SwitchTest {
         );
 
         assertThat(execution.getTaskRunList().get(1).getTaskId()).isEqualTo("t3");
-        assertThat(execution.findTaskRunsByTaskId("parent-seq").getFirst().getOutputs().get("value")).isEqualTo("THIRD");
+        assertThat(execution.findTaskRunsByTaskId("parent-seq").getFirst().getOutputs()).containsEntry("value", "THIRD");
         assertThat((Boolean) execution.findTaskRunsByTaskId("parent-seq").getFirst().getOutputs().get("defaults")).isFalse();
         assertThat(execution.getTaskRunList().get(2).getTaskId()).isEqualTo("failed");
         assertThat(execution.getTaskRunList().get(3).getTaskId()).isEqualTo("error-t1");
@@ -82,7 +82,7 @@ class SwitchTest {
         );
 
         assertThat(execution.getTaskRunList().get(1).getTaskId()).isEqualTo("default");
-        assertThat(execution.findTaskRunsByTaskId("parent-seq").getFirst().getOutputs().get("value")).isEqualTo("DEFAULT");
+        assertThat(execution.findTaskRunsByTaskId("parent-seq").getFirst().getOutputs()).containsEntry("value", "DEFAULT");
         assertThat((Boolean)execution.findTaskRunsByTaskId("parent-seq").getFirst().getOutputs().get("defaults")).isTrue();
     }
 

--- a/core/src/test/java/io/kestra/plugin/core/flow/TimeoutTest.java
+++ b/core/src/test/java/io/kestra/plugin/core/flow/TimeoutTest.java
@@ -63,6 +63,6 @@ class TimeoutTest {
         assertThat(execution.getState().getCurrent()).isEqualTo(State.Type.FAILED);
         List<LogEntry> matchingLogs = TestsUtils.awaitLogs(logs, logEntry -> logEntry.getMessage().contains("Timeout"), 2);
         receive.blockLast();
-        assertThat(matchingLogs.size()).isEqualTo(2);
+        assertThat(matchingLogs).hasSize(2);
     }
 }

--- a/core/src/test/java/io/kestra/plugin/core/flow/VariablesTest.java
+++ b/core/src/test/java/io/kestra/plugin/core/flow/VariablesTest.java
@@ -38,9 +38,9 @@ class VariablesTest {
     @EnabledIfEnvironmentVariable(named = "ENV_TEST2", matches = ".*")
     void recursiveVars(Execution execution) {
         assertThat(execution.getTaskRunList()).hasSize(3);
-        assertThat(execution.findTaskRunsByTaskId("variable").getFirst().getOutputs().get("value")).isEqualTo("1 > 2 > 3");
-        assertThat(execution.findTaskRunsByTaskId("env").getFirst().getOutputs().get("value")).isEqualTo("true Pass by env");
-        assertThat(execution.findTaskRunsByTaskId("global").getFirst().getOutputs().get("value")).isEqualTo("string 1 true 2");
+        assertThat(execution.findTaskRunsByTaskId("variable").getFirst().getOutputs()).containsEntry("value", "1 > 2 > 3");
+        assertThat(execution.findTaskRunsByTaskId("env").getFirst().getOutputs()).containsEntry("value", "true Pass by env");
+        assertThat(execution.findTaskRunsByTaskId("global").getFirst().getOutputs()).containsEntry("value", "string 1 true 2");
     }
 
     @Test

--- a/core/src/test/java/io/kestra/plugin/core/flow/WaitForCaseTest.java
+++ b/core/src/test/java/io/kestra/plugin/core/flow/WaitForCaseTest.java
@@ -58,7 +58,7 @@ public class WaitForCaseTest {
         assertThat(execution.getTaskRunList().getFirst().getOutputs()).isNotNull();
         assertThat((Integer) execution.getTaskRunList().getFirst().getOutputs().get("iterationCount")).isEqualTo(3);
         Map<String,Object> values = (Map<String, Object>) execution.getTaskRunList().getLast().getOutputs().get("values");
-        assertThat(values.get("count")).isEqualTo("4");
+        assertThat(values).containsEntry("count", "4");
     }
 
     public void waitforMultipleTasksFailed() throws TimeoutException, QueueException {

--- a/core/src/test/java/io/kestra/plugin/core/flow/WorkingDirectoryTest.java
+++ b/core/src/test/java/io/kestra/plugin/core/flow/WorkingDirectoryTest.java
@@ -234,8 +234,7 @@ public class WorkingDirectoryTest {
                 .filter(t -> t.getTaskId().equals("exists"))
                 .findFirst().get()
                 .getOutputs()
-                .get("uris"))
-                .containsKey("hello.txt")).isTrue();
+                .get("uris"))).containsKey("hello.txt");
             assertThat(execution.getState().getCurrent()).isEqualTo(State.Type.SUCCESS);
         }
 
@@ -266,9 +265,9 @@ public class WorkingDirectoryTest {
             assertThat(execution.getTaskRunList()).hasSize(6);
             assertThat(execution.getState().getCurrent()).isEqualTo(State.Type.WARNING);
             assertThat(execution.findTaskRunsByTaskId("t4").getFirst().getState().getCurrent()).isEqualTo(State.Type.FAILED);
-            assertThat(execution.findTaskRunsByTaskId("t1").getFirst().getOutputs().get("value")).isEqualTo("first");
-            assertThat(execution.findTaskRunsByTaskId("t2").getFirst().getOutputs().get("value")).isEqualTo("second");
-            assertThat(execution.findTaskRunsByTaskId("t3").getFirst().getOutputs().get("value")).isEqualTo("third");
+            assertThat(execution.findTaskRunsByTaskId("t1").getFirst().getOutputs()).containsEntry("value", "first");
+            assertThat(execution.findTaskRunsByTaskId("t2").getFirst().getOutputs()).containsEntry("value", "second");
+            assertThat(execution.findTaskRunsByTaskId("t3").getFirst().getOutputs()).containsEntry("value", "third");
         }
 
         public void namespaceFilesWithNamespaces(RunnerUtils runnerUtils) throws TimeoutException, IOException, QueueException {
@@ -290,9 +289,9 @@ public class WorkingDirectoryTest {
             assertThat(execution.getTaskRunList()).hasSize(6);
             assertThat(execution.getState().getCurrent()).isEqualTo(State.Type.WARNING);
             assertThat(execution.findTaskRunsByTaskId("t4").getFirst().getState().getCurrent()).isEqualTo(State.Type.FAILED);
-            assertThat(execution.findTaskRunsByTaskId("t1").getFirst().getOutputs().get("value")).isEqualTo("first in third namespace");
-            assertThat(execution.findTaskRunsByTaskId("t2").getFirst().getOutputs().get("value")).isEqualTo("second in second namespace");
-            assertThat(execution.findTaskRunsByTaskId("t3").getFirst().getOutputs().get("value")).isEqualTo("third in first namespace");
+            assertThat(execution.findTaskRunsByTaskId("t1").getFirst().getOutputs()).containsEntry("value", "first in third namespace");
+            assertThat(execution.findTaskRunsByTaskId("t2").getFirst().getOutputs()).containsEntry("value", "second in second namespace");
+            assertThat(execution.findTaskRunsByTaskId("t3").getFirst().getOutputs()).containsEntry("value", "third in first namespace");
         }
 
         @SuppressWarnings("unchecked")
@@ -301,11 +300,11 @@ public class WorkingDirectoryTest {
 
             assertThat(execution.getTaskRunList()).hasSize(3);
             Map<String, Object> encryptedString = (Map<String, Object>) execution.findTaskRunsByTaskId("encrypted").getFirst().getOutputs().get("value");
-            assertThat(encryptedString.get("type")).isEqualTo(EncryptedString.TYPE);
+            assertThat(encryptedString).containsEntry("type", EncryptedString.TYPE);
             String encryptedValue = (String) encryptedString.get("value");
             assertThat(encryptedValue).isNotEqualTo("Hello World");
             assertThat(runContextFactory.of().decrypt(encryptedValue)).isEqualTo("Hello World");
-            assertThat(execution.findTaskRunsByTaskId("decrypted").getFirst().getOutputs().get("value")).isEqualTo("Hello World");
+            assertThat(execution.findTaskRunsByTaskId("decrypted").getFirst().getOutputs()).containsEntry("value", "Hello World");
         }
 
         private void put(String path, String content) throws IOException {

--- a/core/src/test/java/io/kestra/plugin/core/http/DownloadTest.java
+++ b/core/src/test/java/io/kestra/plugin/core/http/DownloadTest.java
@@ -95,7 +95,7 @@ class DownloadTest {
         Download.Output output = assertDoesNotThrow(() -> task.run(runContext));
 
         assertThat(output.getLength()).isEqualTo(0L);
-        assertThat(IOUtils.toString(this.storageInterface.get(null, null, output.getUri()), StandardCharsets.UTF_8)).isEqualTo("");
+        assertThat(IOUtils.toString(this.storageInterface.get(null, null, output.getUri()), StandardCharsets.UTF_8)).isEmpty();
     }
 
     @Test
@@ -192,7 +192,7 @@ class DownloadTest {
 
             Download.Output output = task.run(runContext);
 
-            assertThat(output.getHeaders().get("content-type")).isEqualTo(List.of("application/json"));
+            assertThat(output.getHeaders()).containsEntry("content-type", List.of("application/json"));
             assertThat(output.getCode()).isEqualTo(417);
         }
     }

--- a/core/src/test/java/io/kestra/plugin/core/log/PurgeLogsTest.java
+++ b/core/src/test/java/io/kestra/plugin/core/log/PurgeLogsTest.java
@@ -62,7 +62,7 @@ class PurgeLogsTest {
         Execution execution = runnerUtils.runOne(null, "io.kestra.tests", "purge_logs_full_arguments");
 
         assertTrue(execution.getState().isSuccess());
-        assertThat(execution.getTaskRunList().size()).isEqualTo(1);
+        assertThat(execution.getTaskRunList()).hasSize(1);
         assertThat(execution.getTaskRunList().getFirst().getOutputs().get("count")).as(failingReason).isEqualTo(resultCount);
     }
 

--- a/core/src/test/java/io/kestra/plugin/core/metric/PublishTest.java
+++ b/core/src/test/java/io/kestra/plugin/core/metric/PublishTest.java
@@ -44,7 +44,7 @@ public class PublishTest {
 
         publish.run(runContext);
 
-        assertThat(runContext.metrics().size()).isEqualTo(2);
+        assertThat(runContext.metrics()).hasSize(2);
     }
 
 }

--- a/core/src/test/java/io/kestra/plugin/core/namespace/DeleteFilesTest.java
+++ b/core/src/test/java/io/kestra/plugin/core/namespace/DeleteFilesTest.java
@@ -41,13 +41,13 @@ class DeleteFilesTest {
         namespace.putFile(Path.of("/a/b/test1.txt"), new ByteArrayInputStream("1".getBytes(StandardCharsets.UTF_8)));
         namespace.putFile(Path.of("/a/b/test2.txt"), new ByteArrayInputStream("2".getBytes(StandardCharsets.UTF_8)));
 
-        assertThat(namespace.all("/a/b/", false).size()).isEqualTo(2);
+        assertThat(namespace.all("/a/b/", false)).hasSize(2);
 
         // When
         assertThat(deleteFiles.run(runContext)).isNotNull();
 
         // Then
-        assertThat(namespace.all("/a/b/", false).size()).isEqualTo(1);
+        assertThat(namespace.all("/a/b/", false)).hasSize(1);
     }
 
     @Test
@@ -68,14 +68,14 @@ class DeleteFilesTest {
 
         namespace.putFile(Path.of("/folder/file.txt"), new ByteArrayInputStream("content".getBytes(StandardCharsets.UTF_8)));
 
-        assertThat(namespace.all("/folder/", false).size()).isEqualTo(1);
+        assertThat(namespace.all("/folder/", false)).hasSize(1);
 
         // When
         assertThat(deleteFiles.run(runContext)).isNotNull();
 
         // Then
-        assertThat(namespace.all("/folder/", false).size()).isZero();
-        assertThat(namespace.all("/", false).size()).isZero();
+        assertThat(namespace.all("/folder/", false)).isEmpty();
+        assertThat(namespace.all("/", false)).isEmpty();
     }
 
     @Test
@@ -96,14 +96,14 @@ class DeleteFilesTest {
 
         namespace.putFile(Path.of("/folder/file.txt"), new ByteArrayInputStream("content".getBytes(StandardCharsets.UTF_8)));
 
-        assertThat(namespace.all("/folder/", false).size()).isEqualTo(1);
+        assertThat(namespace.all("/folder/", false)).hasSize(1);
 
         // When
         assertThat(deleteFiles.run(runContext)).isNotNull();
 
         // Then
-        assertThat(namespace.all("/folder/", false).size()).isZero();
-        assertThat(namespace.all("/", true).size()).isEqualTo(1); // Folder should still exist
+        assertThat(namespace.all("/folder/", false)).isEmpty();
+        assertThat(namespace.all("/", true)).hasSize(1); // Folder should still exist
     }
 
     @Test
@@ -125,13 +125,13 @@ class DeleteFilesTest {
         namespace.putFile(Path.of("/folder/file1.txt"), new ByteArrayInputStream("content1".getBytes(StandardCharsets.UTF_8)));
         namespace.putFile(Path.of("/folder/file2.txt"), new ByteArrayInputStream("content2".getBytes(StandardCharsets.UTF_8)));
 
-        assertThat(namespace.all("/folder/", false).size()).isEqualTo(2);
+        assertThat(namespace.all("/folder/", false)).hasSize(2);
 
         // When
         assertThat(deleteFiles.run(runContext)).isNotNull();
 
         // Then
-        assertThat(namespace.all("/folder/", false).size()).isEqualTo(1); // One file should still exist
-        assertThat(namespace.all("/", false).size()).isEqualTo(1); // Folder should still exist
+        assertThat(namespace.all("/folder/", false)).hasSize(1); // One file should still exist
+        assertThat(namespace.all("/", false)).hasSize(1); // Folder should still exist
     }
 }

--- a/core/src/test/java/io/kestra/plugin/core/namespace/DownloadFilesTest.java
+++ b/core/src/test/java/io/kestra/plugin/core/namespace/DownloadFilesTest.java
@@ -45,7 +45,7 @@ public class DownloadFilesTest {
 
         DownloadFiles.Output output = downloadFiles.run(runContext);
 
-        assertThat(output.getFiles().size()).isEqualTo(1);
+        assertThat(output.getFiles()).hasSize(1);
         assertThat(output.getFiles().get("/a/b/test1.txt")).isNotNull();
 
     }

--- a/core/src/test/java/io/kestra/plugin/core/namespace/UploadFilesTest.java
+++ b/core/src/test/java/io/kestra/plugin/core/namespace/UploadFilesTest.java
@@ -61,7 +61,7 @@ public class UploadFilesTest {
         RunContext runContext = TestsUtils.mockRunContext(this.runContextFactory, uploadFile, ImmutableMap.of());
         uploadFile.run(runContext);
 
-        assertThat(runContext.storage().namespace(namespace).all().size()).isEqualTo(1);
+        assertThat(runContext.storage().namespace(namespace).all()).hasSize(1);
         assertThrows(IOException.class, () -> uploadFile.run(runContext));
     }
 
@@ -84,7 +84,7 @@ public class UploadFilesTest {
 
         Namespace namespaceStorage = runContext.storage().namespace(namespace);
         List<NamespaceFile> namespaceFiles = namespaceStorage.all();
-        assertThat(namespaceFiles.size()).isEqualTo(1);
+        assertThat(namespaceFiles).hasSize(1);
 
         String previousFile = IOUtils.toString(namespaceStorage.getFileContent(Path.of(namespaceFiles.getFirst().path())), StandardCharsets.UTF_8);
 
@@ -96,7 +96,7 @@ public class UploadFilesTest {
         uploadFile.run(runContext);
 
         namespaceFiles = namespaceStorage.all();
-        assertThat(namespaceFiles.size()).isEqualTo(1);
+        assertThat(namespaceFiles).hasSize(1);
 
         String newFile = IOUtils.toString(namespaceStorage.getFileContent(Path.of(namespaceFiles.getFirst().path())), StandardCharsets.UTF_8);
 
@@ -123,7 +123,7 @@ public class UploadFilesTest {
 
         Namespace namespaceStorage = runContext.storage().namespace(namespace);
         List<NamespaceFile> namespaceFiles = namespaceStorage.all();
-        assertThat(namespaceFiles.size()).isEqualTo(1);
+        assertThat(namespaceFiles).hasSize(1);
 
         String previousFile = IOUtils.toString(namespaceStorage.getFileContent(Path.of(namespaceFiles.getFirst().path())), StandardCharsets.UTF_8);
 
@@ -135,11 +135,11 @@ public class UploadFilesTest {
         uploadFile.run(runContext);
 
         namespaceFiles = namespaceStorage.all();
-        assertThat(namespaceFiles.size()).isEqualTo(1);
+        assertThat(namespaceFiles).hasSize(1);
 
         String newFile = IOUtils.toString(namespaceStorage.getFileContent(Path.of(namespaceFiles.getFirst().path())), StandardCharsets.UTF_8);
 
-        assertThat(previousFile.equals(newFile)).isTrue();
+        assertThat(previousFile).isEqualTo(newFile);
     }
 
     @Test
@@ -162,7 +162,7 @@ public class UploadFilesTest {
 
         Namespace namespaceStorage = runContext.storage().namespace(namespace);
         List<NamespaceFile> namespaceFiles = namespaceStorage.all();
-        assertThat(namespaceFiles.size()).isEqualTo(1);
+        assertThat(namespaceFiles).hasSize(1);
     }
 
     private URI addToStorage(String fileToLoad) throws IOException, URISyntaxException {

--- a/core/src/test/java/io/kestra/plugin/core/state/StateNamespaceTest.java
+++ b/core/src/test/java/io/kestra/plugin/core/state/StateNamespaceTest.java
@@ -47,7 +47,7 @@ class StateNamespaceTest {
             .build();
         Get.Output getOutput = get.run(runContextFlow2(get));
         assertThat(getOutput.getCount()).isEqualTo(1);
-        assertThat(getOutput.getData().get("john")).isEqualTo("doe");
+        assertThat(getOutput.getData()).containsEntry("john", "doe");
 
         get = Get.builder()
             .id(IdUtils.create())

--- a/core/src/test/java/io/kestra/plugin/core/state/StateTest.java
+++ b/core/src/test/java/io/kestra/plugin/core/state/StateTest.java
@@ -51,7 +51,7 @@ class StateTest {
             .build();
         getOutput = get.run(runContext);
         assertThat(getOutput.getCount()).isEqualTo(1);
-        assertThat(getOutput.getData().get("test")).isEqualTo("1");
+        assertThat(getOutput.getData()).containsEntry("test", "1");
 
         set = Set.builder()
             .id(IdUtils.create())
@@ -73,8 +73,8 @@ class StateTest {
         getOutput = get.run(runContext);
 
         assertThat(getOutput.getCount()).isEqualTo(2);
-        assertThat(getOutput.getData().get("test")).isEqualTo("2");
-        assertThat(getOutput.getData().get("test2")).isEqualTo("3");
+        assertThat(getOutput.getData()).containsEntry("test", "2");
+        assertThat(getOutput.getData()).containsEntry("test2", "3");
 
         Delete delete = Delete.builder()
             .id(IdUtils.create())

--- a/core/src/test/java/io/kestra/plugin/core/storage/LocalFilesTest.java
+++ b/core/src/test/java/io/kestra/plugin/core/storage/LocalFilesTest.java
@@ -62,7 +62,7 @@ class LocalFilesTest {
 
         assertThat(outputs).isNotNull();
         assertThat(outputs.getUris()).isNotNull();
-        assertThat(outputs.getUris().size()).isEqualTo(1);
+        assertThat(outputs.getUris()).hasSize(1);
         assertThat(new String(storageInterface.get(null, null, outputs.getUris().get("hello-input.txt")).readAllBytes())).isEqualTo("Hello Input");
         assertThat(runContext.workingDir().path().toFile().list().length).isEqualTo(2);
         assertThat(Files.readString(runContext.workingDir().path().resolve("execution.txt"))).isEqualTo("tata");
@@ -90,7 +90,7 @@ class LocalFilesTest {
 
         assertThat(outputs).isNotNull();
         assertThat(outputs.getUris()).isNotNull();
-        assertThat(outputs.getUris().size()).isEqualTo(3);
+        assertThat(outputs.getUris()).hasSize(3);
         assertThat(new String(storageInterface.get(null, null, outputs.getUris().get("test/hello-input.txt")).readAllBytes())).isEqualTo("Hello Input");
         assertThat(new String(storageInterface.get(null, null, outputs.getUris().get("test/sub/dir/2/execution.txt"))
             .readAllBytes())).isEqualTo("tata");

--- a/core/src/test/java/io/kestra/plugin/core/storage/PurgeCurrentExecutionFilesTest.java
+++ b/core/src/test/java/io/kestra/plugin/core/storage/PurgeCurrentExecutionFilesTest.java
@@ -34,6 +34,6 @@ class PurgeCurrentExecutionFilesTest {
             .build();
         var output = purge.run(runContext);
 
-        assertThat(output.getUris().size()).isEqualTo(2);
+        assertThat(output.getUris()).hasSize(2);
     }
 }

--- a/core/src/test/java/io/kestra/plugin/core/storage/SplitTest.java
+++ b/core/src/test/java/io/kestra/plugin/core/storage/SplitTest.java
@@ -44,7 +44,7 @@ class SplitTest {
 
         Split.Output run = result.run(runContext);
 
-        assertThat(run.getUris().size()).isEqualTo(8);
+        assertThat(run.getUris()).hasSize(8);
         assertThat(run.getUris().getFirst().getPath()).endsWith(".yml");
         assertThat(StringUtils.countMatches(readAll(run.getUris()), "\n")).isEqualTo(1000);
     }
@@ -61,7 +61,7 @@ class SplitTest {
 
         Split.Output run = result.run(runContext);
 
-        assertThat(run.getUris().size()).isEqualTo(100);
+        assertThat(run.getUris()).hasSize(100);
         assertThat(readAll(run.getUris())).isEqualTo(String.join("\n", content(1000)) + "\n");
     }
 
@@ -77,7 +77,7 @@ class SplitTest {
 
         Split.Output run = result.run(runContext);
 
-        assertThat(run.getUris().size()).isEqualTo(251);
+        assertThat(run.getUris()).hasSize(251);
         assertThat(readAll(run.getUris())).isEqualTo(String.join("\n", content(12288)) + "\n");
     }
 

--- a/core/src/test/java/io/kestra/plugin/core/trigger/FlowTest.java
+++ b/core/src/test/java/io/kestra/plugin/core/trigger/FlowTest.java
@@ -68,7 +68,7 @@ class FlowTest {
             execution
         );
 
-        assertThat(evaluate.isPresent()).isTrue();
+        assertThat(evaluate).isPresent();
         assertThat(evaluate.get().getFlowId()).isEqualTo("flow-with-flow-trigger");
         assertThat(evaluate.get().getLabels()).hasSize(3);
         assertThat(evaluate.get().getLabels()).contains(new Label("flow-label-1", "flow-label-1"));
@@ -118,7 +118,7 @@ class FlowTest {
             execution
         );
 
-        assertThat(evaluate.isPresent()).isTrue();
+        assertThat(evaluate).isPresent();
         assertThat(evaluate.get().getFlowId()).isEqualTo("flow-with-flow-trigger");
         assertThat(evaluate.get().getTenantId()).isEqualTo("tenantId");
         assertThat(evaluate.get().getLabels()).hasSize(3);
@@ -167,7 +167,7 @@ class FlowTest {
 
         Optional<Execution> evaluate = flowTrigger.evaluate(multipleConditionStorage, runContextFactory.of(), flow, execution);
 
-        assertThat(evaluate.isPresent()).isTrue();
+        assertThat(evaluate).isPresent();
         assertThat(evaluate.get().getLabels()).hasSize(6);
         assertThat(evaluate.get().getLabels()).contains(new Label("flow-label-1", "flow-label-1"));
         assertThat(evaluate.get().getLabels()).contains(new Label("flow-label-2", "flow-label-2"));
@@ -176,6 +176,6 @@ class FlowTest {
         assertThat(evaluate.get().getLabels()).contains(new Label("trigger-label-3", ""));
         assertThat(evaluate.get().getLabels()).contains(new Label(Label.CORRELATION_ID, "correlationId"));
         assertThat(evaluate.get().getTrigger()).extracting(ExecutionTrigger::getVariables).hasFieldOrProperty("executionLabels");
-        assertThat(evaluate.get().getTrigger().getVariables().get("executionLabels")).isEqualTo(Map.of("execution-label", "execution"));
+        assertThat(evaluate.get().getTrigger().getVariables()).containsEntry("executionLabels", Map.of("execution-label", "execution"));
     }
 }

--- a/core/src/test/java/io/kestra/plugin/core/trigger/ScheduleTest.java
+++ b/core/src/test/java/io/kestra/plugin/core/trigger/ScheduleTest.java
@@ -58,7 +58,7 @@ class ScheduleTest {
                 .build()
         );
 
-        assertThat(evaluate.isPresent()).isFalse();
+        assertThat(evaluate).isNotPresent();
     }
 
     private static TriggerContext triggerContext(ZonedDateTime date, Schedule schedule) {
@@ -99,7 +99,7 @@ class ScheduleTest {
             triggerContext(date, trigger)
         );
 
-        assertThat(evaluate.isPresent()).isTrue();
+        assertThat(evaluate).isPresent();
         assertThat(evaluate.get().getLabels()).hasSize(3);
         assertTrue(evaluate.get().getLabels().stream().anyMatch(label -> label.key().equals(Label.CORRELATION_ID)));
 
@@ -111,9 +111,9 @@ class ScheduleTest {
         assertThat(dateFromVars(vars.get("previous"), date)).isEqualTo(date.minusMonths(1));
         assertThat(evaluate.get().getLabels()).contains(new Label("flow-label-1", "flow-label-1"));
         assertThat(evaluate.get().getLabels()).contains(new Label("flow-label-2", "flow-label-2"));
-        assertThat(inputs.size()).isEqualTo(2);
+        assertThat(inputs).hasSize(2);
         assertThat(inputs.get("input1")).isNull();
-        assertThat(inputs.get("input2")).isEqualTo("default");
+        assertThat(inputs).containsEntry("input2", "default");
     }
 
     @Test
@@ -133,15 +133,15 @@ class ScheduleTest {
             triggerContext(date, trigger)
         );
 
-        assertThat(evaluate.isPresent()).isTrue();
+        assertThat(evaluate).isPresent();
         assertThat(evaluate.get().getLabels()).hasSize(3);
         assertTrue(evaluate.get().getLabels().stream().anyMatch(label -> label.key().equals(Label.CORRELATION_ID)));
 
         var inputs = evaluate.get().getInputs();
 
-        assertThat(inputs.size()).isEqualTo(2);
-        assertThat(inputs.get("input1")).isEqualTo("input1");
-        assertThat(inputs.get("input2")).isEqualTo("default");
+        assertThat(inputs).hasSize(2);
+        assertThat(inputs).containsEntry("input1", "input1");
+        assertThat(inputs).containsEntry("input2", "default");
     }
 
     @Test
@@ -167,7 +167,7 @@ class ScheduleTest {
 
         Optional<Execution> evaluate = scheduleTrigger.evaluate(conditionContext, triggerContext);
 
-        assertThat(evaluate.isPresent()).isTrue();
+        assertThat(evaluate).isPresent();
         assertThat(evaluate.get().getLabels()).contains(new Label("trigger-label-1", "trigger-label-1"));
         assertThat(evaluate.get().getLabels()).contains(new Label("trigger-label-2", "trigger-label-2"));
         assertThat(evaluate.get().getLabels()).contains(new Label("trigger-label-3", ""));
@@ -189,7 +189,7 @@ class ScheduleTest {
             triggerContext(date, trigger)
         );
 
-        assertThat(evaluate.isPresent()).isTrue();
+        assertThat(evaluate).isPresent();
 
         var vars = (Map<String, String>) evaluate.get().getVariables().get("schedule");
 
@@ -213,7 +213,7 @@ class ScheduleTest {
             triggerContext(date, trigger)
         );
 
-        assertThat(evaluate.isPresent()).isTrue();
+        assertThat(evaluate).isPresent();
 
         var vars = (Map<String, String>) evaluate.get().getVariables().get("schedule");
 
@@ -239,7 +239,7 @@ class ScheduleTest {
         Optional<Execution> result = trigger.evaluate(conditionContext(trigger), triggerContext);
 
         // Then
-        assertThat(result.isEmpty()).isTrue();
+        assertThat(result).isEmpty();
     }
 
     @Test
@@ -260,7 +260,7 @@ class ScheduleTest {
         Optional<Execution> result = trigger.evaluate(conditionContext(trigger), triggerContext);
 
         // Then
-        assertThat(result.isPresent()).isTrue();
+        assertThat(result).isPresent();
     }
 
     @Test
@@ -301,7 +301,7 @@ class ScheduleTest {
             triggerContext(date, trigger)
         );
 
-        assertThat(evaluate.isPresent()).isTrue();
+        assertThat(evaluate).isPresent();
 
         var vars = (Map<String, String>) evaluate.get().getVariables().get("schedule");
         assertThat(dateFromVars(vars.get("date"), expexted)).isEqualTo(expexted);
@@ -336,7 +336,7 @@ class ScheduleTest {
             triggerContext(date, trigger)
         );
 
-        assertThat(evaluate.isPresent()).isTrue();
+        assertThat(evaluate).isPresent();
 
         var vars = (Map<String, String>) evaluate.get().getVariables().get("schedule");
         assertThat(dateFromVars(vars.get("date"), date)).isEqualTo(date);
@@ -369,7 +369,7 @@ class ScheduleTest {
             triggerContext(date, trigger)
         );
 
-        assertThat(evaluate.isPresent()).isTrue();
+        assertThat(evaluate).isPresent();
 
         var vars = (Map<String, String>) evaluate.get().getVariables().get("schedule");
         assertThat(dateFromVars(vars.get("date"), date)).isEqualTo(date);
@@ -421,7 +421,7 @@ class ScheduleTest {
                 .build()
         );
 
-        assertThat(evaluate.isPresent()).isTrue();
+        assertThat(evaluate).isPresent();
         var vars = (Map<String, String>) evaluate.get().getVariables().get("schedule");
         assertThat(dateFromVars(vars.get("date"), date)).isEqualTo(date);
     }
@@ -447,7 +447,7 @@ class ScheduleTest {
             triggerContext(date, trigger)
         );
 
-        assertThat(evaluate.isPresent()).isTrue();
+        assertThat(evaluate).isPresent();
 
         var vars = (Map<String, String>) evaluate.get().getVariables().get("schedule");
 
@@ -477,7 +477,7 @@ class ScheduleTest {
         Optional<Execution> result = trigger.evaluate(conditionContext(trigger), triggerContext);
 
         // Then
-        assertThat(result.isPresent()).isTrue();
+        assertThat(result).isPresent();
     }
 
 

--- a/jdbc-h2/src/main/java/io/kestra/repository/h2/H2Repository.java
+++ b/jdbc-h2/src/main/java/io/kestra/repository/h2/H2Repository.java
@@ -74,6 +74,7 @@ public class H2Repository<T> extends io.kestra.jdbc.AbstractJdbcRepository<T> {
         });
     }
 
+    @Override
     public Condition fullTextCondition(List<String> fields, String query) {
         if (query == null || query.equals("*")) {
             return DSL.trueCondition();
@@ -90,13 +91,14 @@ public class H2Repository<T> extends io.kestra.jdbc.AbstractJdbcRepository<T> {
             .map(s -> field.likeIgnoreCase("%" + s.toUpperCase(Locale.ROOT) + "%"))
             .toList();
 
-        if (match.size() == 0) {
+        if (match.isEmpty()) {
             return DSL.falseCondition();
         }
 
         return DSL.and(match);
     }
 
+    @Override
     @SuppressWarnings("unchecked")
     public <R extends Record, E> ArrayListTotal<E> fetchPage(DSLContext context, SelectConditionStep<R> select, Pageable pageable, RecordMapper<R, E> mapper) {
         Result<Record> results = this.limit(
@@ -110,7 +112,7 @@ public class H2Repository<T> extends io.kestra.jdbc.AbstractJdbcRepository<T> {
             )
             .fetch();
 
-        Integer totalCount = results.size() > 0 ? results.getFirst().get("total_count", Integer.class) : 0;
+        Integer totalCount = !results.isEmpty() ? results.getFirst().get("total_count", Integer.class) : 0;
 
         List<E> map = results
             .map((Record record) -> mapper.map((R) record));

--- a/jdbc-h2/src/test/java/io/kestra/runner/h2/H2JdbcTestUtils.java
+++ b/jdbc-h2/src/test/java/io/kestra/runner/h2/H2JdbcTestUtils.java
@@ -12,6 +12,7 @@ import static io.kestra.core.utils.Rethrow.throwPredicate;
 @Singleton
 @Replaces(JdbcTestUtils.class)
 public class H2JdbcTestUtils extends JdbcTestUtils {
+    @Override
     @SneakyThrows
     public void drop() {
 //        dslContextWrapper.transaction((configuration) -> {

--- a/jdbc-mysql/src/main/java/io/kestra/repository/mysql/MysqlRepository.java
+++ b/jdbc-mysql/src/main/java/io/kestra/repository/mysql/MysqlRepository.java
@@ -74,6 +74,7 @@ public class MysqlRepository<T> extends AbstractJdbcRepository<T> {
         return this.sort(select, Pageable.from(Sort.of(Order.asc(orderField))));
     }
 
+    @Override
     public Field<Integer> weekFromTimestamp(Field<Timestamp> timestampField) {
         // DAYOFWEEK > 5 means you have less than 3 days in the first week of the year so we choose mode 2 (see https://www.w3resource.com/mysql/date-and-time-functions/mysql-week-function.php)
         return DSL.when(

--- a/jdbc-postgres/src/main/java/io/kestra/repository/postgres/PostgresRepository.java
+++ b/jdbc-postgres/src/main/java/io/kestra/repository/postgres/PostgresRepository.java
@@ -111,7 +111,7 @@ public class PostgresRepository<T> extends io.kestra.jdbc.AbstractJdbcRepository
         )
             .fetch();
 
-        Integer totalCount = results.size() > 0 ? results.getFirst().get("total_count", Integer.class) : 0;
+        Integer totalCount = !results.isEmpty() ? results.getFirst().get("total_count", Integer.class) : 0;
 
         List<E> map = results
             .map((Record record) -> mapper.map((R) record));

--- a/jdbc/src/main/java/io/kestra/jdbc/AbstractJdbcRepository.java
+++ b/jdbc/src/main/java/io/kestra/jdbc/AbstractJdbcRepository.java
@@ -56,7 +56,7 @@ public abstract class AbstractJdbcRepository<T> {
         this.table = DSL.table(tableConfig.table());
     }
 
-    abstract public Condition fullTextCondition(List<String> fields, String query);
+    public abstract Condition fullTextCondition(List<String> fields, String query);
 
     public String key(T entity) {
         String key = queueService.key(entity);
@@ -200,7 +200,7 @@ public abstract class AbstractJdbcRepository<T> {
         return select.fetch().map(e -> this.mapMetricAggregation(e, groupByType));
     }
 
-    abstract public <R extends Record, E> ArrayListTotal<E> fetchPage(DSLContext context, SelectConditionStep<R> select, Pageable pageable, RecordMapper<R, E> mapper);
+    public abstract <R extends Record, E> ArrayListTotal<E> fetchPage(DSLContext context, SelectConditionStep<R> select, Pageable pageable, RecordMapper<R, E> mapper);
 
     public <R extends Record> ArrayListTotal<T> fetchPage(DSLContext context, SelectConditionStep<R> select, Pageable pageable) {
         return this.fetchPage(context, select, pageable, this::map);

--- a/jdbc/src/main/java/io/kestra/jdbc/JdbcWorkerTriggerResultQueueService.java
+++ b/jdbc/src/main/java/io/kestra/jdbc/JdbcWorkerTriggerResultQueueService.java
@@ -25,7 +25,7 @@ import java.util.function.Consumer;
 @Singleton
 @Slf4j
 public class JdbcWorkerTriggerResultQueueService implements Closeable {
-    private final static ObjectMapper MAPPER = JdbcMapper.of();
+    private static final ObjectMapper MAPPER = JdbcMapper.of();
 
     private final JdbcQueue<WorkerTriggerResult> workerTriggerResultQueue;
 

--- a/jdbc/src/main/java/io/kestra/jdbc/repository/AbstractJdbcDashboardRepository.java
+++ b/jdbc/src/main/java/io/kestra/jdbc/repository/AbstractJdbcDashboardRepository.java
@@ -60,7 +60,7 @@ public abstract class AbstractJdbcDashboardRepository extends AbstractJdbcReposi
             });
     }
 
-    abstract protected Condition findCondition(String query);
+    protected abstract Condition findCondition(String query);
 
     @Override
     public ArrayListTotal<Dashboard> list(Pageable pageable, String tenantId, String query) {

--- a/jdbc/src/main/java/io/kestra/jdbc/repository/AbstractJdbcExecutionRepository.java
+++ b/jdbc/src/main/java/io/kestra/jdbc/repository/AbstractJdbcExecutionRepository.java
@@ -116,6 +116,7 @@ public abstract class AbstractJdbcExecutionRepository extends AbstractJdbcReposi
         return this.executionQueue;
     }
 
+    @Override
     public Boolean isTaskRunEnabled() {
         return false;
     }
@@ -194,9 +195,10 @@ public abstract class AbstractJdbcExecutionRepository extends AbstractJdbcReposi
             });
     }
 
-    abstract protected Condition findCondition(String query, Map<String, String> labels);
-    abstract protected Condition findCondition(Map<?, ?> value, QueryFilter.Op operation);
+    protected abstract Condition findCondition(String query, Map<String, String> labels);
+    protected abstract Condition findCondition(Map<?, ?> value, QueryFilter.Op operation);
 
+    @Override
     protected Condition statesFilter(List<State.Type> state) {
         return field("state_current")
             .in(state.stream().map(Enum::name).toList());
@@ -988,6 +990,7 @@ public abstract class AbstractJdbcExecutionRepository extends AbstractJdbcReposi
         return counts;
     }
 
+    @Override
     public List<Execution> lastExecutions(
         @Nullable String tenantId,
         List<FlowFilter> flows
@@ -1272,7 +1275,7 @@ public abstract class AbstractJdbcExecutionRepository extends AbstractJdbcReposi
         }
     }
 
-    abstract protected Field<Date> formatDateField(String dateField, DateUtils.GroupType groupType);
+    protected abstract Field<Date> formatDateField(String dateField, DateUtils.GroupType groupType);
 
     protected <F extends Enum<F>> List<Field<Date>> generateDateFields(
         DataFilter<F, ? extends ColumnDescriptor<F>> descriptors,

--- a/jdbc/src/main/java/io/kestra/jdbc/repository/AbstractJdbcFlowRepository.java
+++ b/jdbc/src/main/java/io/kestra/jdbc/repository/AbstractJdbcFlowRepository.java
@@ -537,8 +537,8 @@ public abstract class AbstractJdbcFlowRepository extends AbstractJdbcRepository 
             .where(this.defaultFilter(tenantId));
     }
 
-    abstract protected Condition findCondition(String query, Map<String, String> labels);
-    abstract protected Condition findCondition(Object value, QueryFilter.Op operation);
+    protected abstract Condition findCondition(String query, Map<String, String> labels);
+    protected abstract Condition findCondition(Object value, QueryFilter.Op operation);
 
     @Override
     @SuppressWarnings({"unchecked", "rawtypes"})
@@ -637,7 +637,7 @@ public abstract class AbstractJdbcFlowRepository extends AbstractJdbcRepository 
     }
 
 
-    abstract protected Condition findSourceCodeCondition(String query);
+    protected abstract Condition findSourceCodeCondition(String query);
 
     @Override
     @SuppressWarnings({"unchecked", "rawtypes"})

--- a/jdbc/src/main/java/io/kestra/jdbc/repository/AbstractJdbcLogRepository.java
+++ b/jdbc/src/main/java/io/kestra/jdbc/repository/AbstractJdbcLogRepository.java
@@ -44,7 +44,7 @@ public abstract class AbstractJdbcLogRepository extends AbstractJdbcRepository i
         this.filterService = filterService;
     }
 
-    abstract protected Condition findCondition(String query);
+    protected abstract Condition findCondition(String query);
 
     @Getter
     private final JdbcFilterService filterService;
@@ -653,6 +653,7 @@ public abstract class AbstractJdbcLogRepository extends AbstractJdbcRepository i
         return levelsCondition(LogEntry.findLevelsByMin(minLevel));
     }
 
+    @Override
     protected Condition levelsCondition(List<Level> levels) {
         return field("level").in(levels.stream().map(level -> level.name()).toList());
     }
@@ -711,7 +712,7 @@ public abstract class AbstractJdbcLogRepository extends AbstractJdbcRepository i
             });
     }
 
-    abstract protected Field<Date> formatDateField(String dateField, DateUtils.GroupType groupType);
+    protected abstract Field<Date> formatDateField(String dateField, DateUtils.GroupType groupType);
 
     protected <F extends Enum<F>> List<Field<Date>> generateDateFields(
         DataFilter<F, ? extends ColumnDescriptor<F>> descriptors,

--- a/jdbc/src/main/java/io/kestra/jdbc/repository/AbstractJdbcMetricRepository.java
+++ b/jdbc/src/main/java/io/kestra/jdbc/repository/AbstractJdbcMetricRepository.java
@@ -423,7 +423,7 @@ public abstract class AbstractJdbcMetricRepository extends AbstractJdbcRepositor
             });
     }
 
-    abstract protected Field<Date> formatDateField(String dateField, DateUtils.GroupType groupType);
+    protected abstract Field<Date> formatDateField(String dateField, DateUtils.GroupType groupType);
 
     protected <F extends Enum<F>> List<Field<Date>> generateDateFields(
         DataFilter<F, ? extends ColumnDescriptor<F>> descriptors,

--- a/jdbc/src/main/java/io/kestra/jdbc/repository/AbstractJdbcRepository.java
+++ b/jdbc/src/main/java/io/kestra/jdbc/repository/AbstractJdbcRepository.java
@@ -283,8 +283,8 @@ public abstract class AbstractJdbcRepository {
 
         // Special handling for START_DATE and END_DATE
         if (field == QueryFilter.Field.START_DATE || field == QueryFilter.Field.END_DATE) {
-            OffsetDateTime dateTime = (value instanceof ZonedDateTime)
-                ? ((ZonedDateTime) value).toOffsetDateTime()
+            OffsetDateTime dateTime = (value instanceof ZonedDateTime zdt)
+                ? zdt.toOffsetDateTime()
                 : ZonedDateTime.parse(value.toString()).toOffsetDateTime();
             return applyDateCondition(select, dateTime, operation, dateColumn);
         }
@@ -306,15 +306,15 @@ public abstract class AbstractJdbcRepository {
             case GREATER_THAN -> select = select.and(DSL.field(columnName).greaterThan(value));
             case LESS_THAN -> select = select.and(DSL.field(columnName).lessThan(value));
             case IN -> {
-                if (value instanceof Collection<?>) {
-                    select = select.and(DSL.field(columnName).in((Collection<?>) value));
+                if (value instanceof Collection<?> collection) {
+                    select = select.and(DSL.field(columnName).in(collection));
                 } else {
                     throw new IllegalArgumentException("IN operation requires a collection as value");
                 }
             }
             case NOT_IN -> {
-                if (value instanceof Collection<?>) {
-                    select = select.and(DSL.field(columnName).notIn((Collection<?>) value));
+                if (value instanceof Collection<?> collection) {
+                    select = select.and(DSL.field(columnName).notIn(collection));
                 } else {
                     throw new IllegalArgumentException("NOT_IN operation requires a collection as value");
                 }
@@ -400,7 +400,7 @@ public abstract class AbstractJdbcRepository {
         Object value,
         QueryFilter.Op operation
     ) {
-        Level minLevel = value instanceof Level ? (Level) value : Level.valueOf((String) value);
+        Level minLevel = value instanceof Level l ? l : Level.valueOf((String) value);
 
         switch (operation) {
             case EQUALS -> select = select.and(minLevelCondition(minLevel));

--- a/jdbc/src/main/java/io/kestra/jdbc/repository/AbstractJdbcTemplateRepository.java
+++ b/jdbc/src/main/java/io/kestra/jdbc/repository/AbstractJdbcTemplateRepository.java
@@ -79,8 +79,9 @@ public abstract class AbstractJdbcTemplateRepository extends AbstractJdbcReposit
             });
     }
 
-    abstract protected Condition findCondition(String query);
+    protected abstract Condition findCondition(String query);
 
+    @Override
     public ArrayListTotal<Template> find(
         Pageable pageable,
         @Nullable String query,
@@ -170,6 +171,7 @@ public abstract class AbstractJdbcTemplateRepository extends AbstractJdbcReposit
     }
 
 
+    @Override
     public Template update(Template template, Template previous) throws ConstraintViolationException {
         this
             .findById(previous.getTenantId(), previous.getNamespace(), previous.getId())

--- a/jdbc/src/main/java/io/kestra/jdbc/repository/AbstractJdbcTriggerRepository.java
+++ b/jdbc/src/main/java/io/kestra/jdbc/repository/AbstractJdbcTriggerRepository.java
@@ -345,6 +345,7 @@ public abstract class AbstractJdbcTriggerRepository extends AbstractJdbcReposito
         return query == null ? DSL.trueCondition() : jdbcRepository.fullTextCondition(List.of("fulltext"), query);
     }
 
+    @Override
     protected Condition defaultFilter(String tenantId, boolean allowDeleted) {
         return buildTenantCondition(tenantId);
     }

--- a/jdbc/src/main/java/io/kestra/jdbc/repository/JdbcFlowRepositoryService.java
+++ b/jdbc/src/main/java/io/kestra/jdbc/repository/JdbcFlowRepositoryService.java
@@ -68,7 +68,7 @@ public abstract class JdbcFlowRepositoryService {
             });
         }
 
-        return conditions.size() == 0 ? DSL.trueCondition() : DSL.and(conditions);
+        return conditions.isEmpty() ? DSL.trueCondition() : DSL.and(conditions);
     }
 
     public static Condition findSourceCodeCondition(AbstractJdbcRepository<Flow> jdbcRepository, String query) {

--- a/jdbc/src/main/java/io/kestra/jdbc/runner/JdbcExecutor.java
+++ b/jdbc/src/main/java/io/kestra/jdbc/runner/JdbcExecutor.java
@@ -601,7 +601,7 @@ public class JdbcExecutor implements ExecutorInterface, Service {
                                     subflowExecutionDedup
                                         .forEach(throwConsumer(subflowExecution -> {
                                             Execution subExecution = subflowExecution.getExecution();
-                                            String log = String.format("Created new execution [[link execution=\"%s\" flowId=\"%s\" namespace=\"%s\"]]", subExecution.getId(), subExecution.getFlowId(), subExecution.getNamespace());
+                                            String log = "Created new execution [[link execution=\"%s\" flowId=\"%s\" namespace=\"%s\"]]".formatted(subExecution.getId(), subExecution.getFlowId(), subExecution.getNamespace());
 
                                             JdbcExecutor.log.info(log);
 

--- a/jdbc/src/main/java/io/kestra/jdbc/runner/JdbcQueue.java
+++ b/jdbc/src/main/java/io/kestra/jdbc/runner/JdbcQueue.java
@@ -244,9 +244,9 @@ public abstract class JdbcQueue<T> implements QueueInterface<T> {
         return this.receiveFetch(ctx, consumerGroup, queueType, true);
     }
 
-    abstract protected Result<Record> receiveFetch(DSLContext ctx, String consumerGroup, String queueType, boolean forUpdate);
+    protected abstract Result<Record> receiveFetch(DSLContext ctx, String consumerGroup, String queueType, boolean forUpdate);
 
-    abstract protected void updateGroupOffsets(DSLContext ctx, String consumerGroup, String queueType, List<Integer> offsets);
+    protected abstract void updateGroupOffsets(DSLContext ctx, String consumerGroup, String queueType, List<Integer> offsets);
 
     protected abstract Condition buildTypeCondition(String type);
 

--- a/jdbc/src/main/java/io/kestra/jdbc/runner/JdbcSchedulerTriggerState.java
+++ b/jdbc/src/main/java/io/kestra/jdbc/runner/JdbcSchedulerTriggerState.java
@@ -86,10 +86,12 @@ public class JdbcSchedulerTriggerState implements SchedulerTriggerStateInterface
         return this.triggerRepository.update(updated);
     }
 
+    @Override
     public Trigger update(Flow flow, AbstractTrigger abstractTrigger, ConditionContext conditionContext) {
         return this.triggerRepository.update(flow, abstractTrigger, conditionContext);
     }
 
+    @Override
     public void delete(Trigger trigger) throws QueueException {
         this.triggerRepository.delete(trigger);
     }

--- a/jdbc/src/main/java/io/kestra/jdbc/runner/JdbcServiceLivenessCoordinator.java
+++ b/jdbc/src/main/java/io/kestra/jdbc/runner/JdbcServiceLivenessCoordinator.java
@@ -35,7 +35,7 @@ import static io.kestra.core.server.Service.ServiceState.allRunningStates;
 @Requires(property = "kestra.server-type", pattern = "(EXECUTOR|STANDALONE)")
 public final class JdbcServiceLivenessCoordinator extends AbstractServiceLivenessCoordinator {
 
-    private final static Logger log = LoggerFactory.getLogger(JdbcServiceLivenessCoordinator.class);
+    private static final Logger log = LoggerFactory.getLogger(JdbcServiceLivenessCoordinator.class);
 
     private final AtomicReference<JdbcExecutor> executor = new AtomicReference<>();
     private final AbstractJdbcServiceInstanceRepository serviceInstanceRepository;

--- a/jdbc/src/test/java/io/kestra/jdbc/repository/AbstractJdbcFlowRepositoryTest.java
+++ b/jdbc/src/test/java/io/kestra/jdbc/repository/AbstractJdbcFlowRepositoryTest.java
@@ -75,7 +75,7 @@ public abstract class AbstractJdbcFlowRepositoryTest extends io.kestra.core.repo
         Optional<FlowWithSource> flow = flowRepository.findByIdWithSource(null, "io.kestra.unittest", "invalid");
 
         try {
-            assertThat(flow.isPresent()).isTrue();
+            assertThat(flow).isPresent();
             assertThat(flow.get()).isInstanceOf(FlowWithException.class);
             assertThat(((FlowWithException) flow.get()).getException()).contains("Cannot deserialize value of type `org.slf4j.event.Level`");
         } finally {

--- a/jdbc/src/test/java/io/kestra/jdbc/repository/AbstractJdbcFlowTopologyRepositoryTest.java
+++ b/jdbc/src/test/java/io/kestra/jdbc/repository/AbstractJdbcFlowTopologyRepositoryTest.java
@@ -36,7 +36,7 @@ public abstract class AbstractJdbcFlowTopologyRepositoryTest extends AbstractFlo
         );
 
         List<FlowTopology> list = flowTopologyRepository.findByFlow(null, "io.kestra.tests", "flow-a", false);
-        assertThat(list.size()).isEqualTo(1);
+        assertThat(list).hasSize(1);
 
         flowTopologyRepository.save(
             flow,
@@ -47,7 +47,7 @@ public abstract class AbstractJdbcFlowTopologyRepositoryTest extends AbstractFlo
 
         list = flowTopologyRepository.findByFlow(null, "io.kestra.tests", "flow-a", false);
 
-        assertThat(list.size()).isEqualTo(1);
+        assertThat(list).hasSize(1);
         assertThat(list.getFirst().getDestination().getId()).isEqualTo("flow-c");
 
         flowTopologyRepository.save(
@@ -60,7 +60,7 @@ public abstract class AbstractJdbcFlowTopologyRepositoryTest extends AbstractFlo
 
         list = flowTopologyRepository.findByNamespace(null, "io.kestra.tests");
 
-        assertThat(list.size()).isEqualTo(2);
+        assertThat(list).hasSize(2);
     }
 
 

--- a/jdbc/src/test/java/io/kestra/jdbc/repository/AbstractJdbcTemplateRepositoryTest.java
+++ b/jdbc/src/test/java/io/kestra/jdbc/repository/AbstractJdbcTemplateRepositoryTest.java
@@ -24,13 +24,13 @@ public abstract class AbstractJdbcTemplateRepositoryTest extends io.kestra.core.
         templateRepository.create(builder("com.kestra.test").build());
 
         List<Template> save = templateRepository.find(Pageable.from(1, 10, Sort.UNSORTED), null, null, null);
-        assertThat(save.size()).isEqualTo(2);
+        assertThat(save).hasSize(2);
 
         save = templateRepository.find(Pageable.from(1, 10, Sort.UNSORTED), "kestra", null, "com");
-        assertThat(save.size()).isEqualTo(1);
+        assertThat(save).hasSize(1);
 
         save = templateRepository.find(Pageable.from(1, 10, Sort.of(Sort.Order.asc("id"))), "kestra unit", null, null);
-        assertThat(save.size()).isEqualTo(1);
+        assertThat(save).hasSize(1);
     }
 
     @BeforeEach

--- a/jdbc/src/test/java/io/kestra/jdbc/runner/JdbcQueueConfigurationTest.java
+++ b/jdbc/src/test/java/io/kestra/jdbc/runner/JdbcQueueConfigurationTest.java
@@ -25,7 +25,7 @@ public class JdbcQueueConfigurationTest {
 
         // By default, we have 5 computed steps + the minPoll
         List<JdbcQueue.Configuration.Step> steps = configuration.computeSteps();
-        assertThat(steps.size()).isEqualTo(6);
+        assertThat(steps).hasSize(6);
         assertThat(steps).contains(
             new JdbcQueue.Configuration.Step(Duration.ofMillis(25), Duration.ofMillis(1875)),
             new JdbcQueue.Configuration.Step(Duration.ofMillis(31), Duration.ofMillis(3750)),
@@ -45,7 +45,7 @@ public class JdbcQueueConfigurationTest {
 
         // As configured, we should have 6 steps + the minPoll
         List<JdbcQueue.Configuration.Step> steps = configuration.computeSteps();
-        assertThat(steps.size()).isEqualTo(7);
+        assertThat(steps).hasSize(7);
         assertThat(steps).contains(
             new JdbcQueue.Configuration.Step(Duration.ofMillis(1000), Duration.ofMillis(937)),
             new JdbcQueue.Configuration.Step(Duration.ofMillis(1875), Duration.ofMillis(1875)),

--- a/jdbc/src/test/java/io/kestra/jdbc/runner/JdbcQueueTest.java
+++ b/jdbc/src/test/java/io/kestra/jdbc/runner/JdbcQueueTest.java
@@ -27,7 +27,7 @@ import static io.kestra.core.utils.Rethrow.throwConsumer;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @KestraTest
-abstract public class JdbcQueueTest {
+public abstract class JdbcQueueTest {
     @Inject
     @Named(QueueFactoryInterface.FLOW_NAMED)
     protected QueueInterface<FlowInterface> flowQueue;

--- a/jdbc/src/test/java/io/kestra/jdbc/runner/JdbcRunnerTest.java
+++ b/jdbc/src/test/java/io/kestra/jdbc/runner/JdbcRunnerTest.java
@@ -111,7 +111,7 @@ public abstract class JdbcRunnerTest extends AbstractRunnerTest {
         assertThat(matchingLog.getMessage()).contains("has exceeded the configured limit of 1048576");
 
         assertThat(execution.getState().getCurrent()).isEqualTo(State.Type.FAILED);
-        assertThat(execution.getTaskRunList().size()).isEqualTo(1);
+        assertThat(execution.getTaskRunList()).hasSize(1);
 
     }
 

--- a/rewrite.yml
+++ b/rewrite.yml
@@ -1,0 +1,138 @@
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: io.kestra.java.UpgradeToJava21Custom
+displayName: Upgrade to Java 21 (custom)
+description: >-
+  This recipe is based on the official org.openrewrite.java.migrate.UpgradeToJava21 with expanded
+  org.openrewrite.java.migrate.UpgradeToJava17, and org.openrewrite.java.migrate.Java8toJava11.
+  Customizations:
+   # breaks YAML blocks
+  - removed org.openrewrite.java.migrate.lang.UseTextBlocks
+   # N/A
+  - removed org.openrewrite.java.migrate.lombok.UpdateLombokToJava11
+   # N/A
+  - removed org.openrewrite.java.migrate.javax.AddCommonAnnotationsDependencies
+tags:
+  - java21
+recipeList:
+  # Java8toJava11
+  - org.openrewrite.java.migrate.UpgradeToJava8
+  - org.openrewrite.java.migrate.UseJavaUtilBase64
+  - org.openrewrite.java.migrate.CastArraysAsListToList
+  # Add an explicit JAXB/JAX-WS runtime and upgrade the dependencies to Jakarta EE 8
+  - org.openrewrite.java.migrate.javax.AddJaxbDependencies
+  - org.openrewrite.java.migrate.javax.AddJaxwsDependencies
+  - org.openrewrite.java.migrate.javax.AddInjectDependencies
+  # Remediate deprecations
+  - org.openrewrite.staticanalysis.BigDecimalRoundingConstantsToEnums
+  - org.openrewrite.staticanalysis.PrimitiveWrapperClassConstructorToValueOf
+  - org.openrewrite.java.migrate.concurrent.JavaConcurrentAPIs
+  - org.openrewrite.java.migrate.lang.JavaLangAPIs
+  - org.openrewrite.java.RemoveMethodInvocations:
+      methodPattern: java.lang.Runtime runFinalizersOnExit(boolean)
+  - org.openrewrite.java.RemoveMethodInvocations:
+      methodPattern: java.lang.System runFinalizersOnExit(boolean)
+  - org.openrewrite.java.migrate.logging.JavaLoggingAPIs
+  - org.openrewrite.java.migrate.net.JavaNetAPIs
+  - org.openrewrite.java.migrate.nio.file.PathsGetToPathOf
+  - org.openrewrite.java.migrate.sql.JavaSqlAPIs
+  - org.openrewrite.java.migrate.javax.JavaxLangModelUtil
+  - org.openrewrite.java.migrate.javax.JavaxManagementMonitorAPIs
+  - org.openrewrite.java.migrate.javax.JavaxXmlStreamAPIs
+  - org.openrewrite.java.migrate.cobertura.RemoveCoberturaMavenPlugin
+  - org.openrewrite.java.migrate.UpgradeBuildToJava11
+  - org.openrewrite.java.migrate.util.OptionalNotPresentToIsEmpty
+  - org.openrewrite.java.migrate.util.OptionalNotEmptyToIsPresent
+  - org.openrewrite.java.migrate.util.OptionalStreamRecipe
+  - org.openrewrite.java.migrate.InternalBindPackages
+  - org.openrewrite.java.migrate.RemovedSecurityManagerMethods
+  - org.openrewrite.java.migrate.UpgradePluginsForJava11
+  - org.openrewrite.java.migrate.RemovedPolicy
+  - org.openrewrite.java.migrate.ReferenceCloneMethod
+  - org.openrewrite.java.migrate.ThreadStopDestroy
+  - org.openrewrite.java.migrate.ReplaceAWTGetPeerMethod
+  - org.openrewrite.scala.migrate.UpgradeScala_2_12
+  - org.openrewrite.java.migrate.ReplaceComSunAWTUtilitiesMethods
+  - org.openrewrite.java.migrate.ReplaceLocalizedStreamMethods
+  - org.openrewrite.java.migrate.ArrayStoreExceptionToTypeNotPresentException
+  - org.openrewrite.java.migrate.IllegalArgumentExceptionToAlreadyConnectedException
+  - org.openrewrite.java.migrate.ChangeDefaultKeyStore
+  # UpgradeToJava17
+  - org.openrewrite.java.migrate.UpgradeBuildToJava17
+  - org.openrewrite.staticanalysis.InstanceOfPatternMatch
+  - org.openrewrite.staticanalysis.AddSerialAnnotationToSerialVersionUID
+  - org.openrewrite.java.migrate.RemovedRuntimeTraceMethods
+  - org.openrewrite.java.migrate.RemovedToolProviderConstructor
+  - org.openrewrite.java.migrate.RemovedModifierAndConstantBootstrapsConstructors
+  - org.openrewrite.java.migrate.lang.ExplicitRecordImport
+  - org.openrewrite.java.migrate.lang.StringFormatted:
+      addParentheses: false
+  - org.openrewrite.java.migrate.DeprecatedJavaxSecurityCert
+  - org.openrewrite.java.migrate.DeprecatedLogRecordThreadID
+  - org.openrewrite.java.migrate.RemovedLegacySunJSSEProviderName
+  - org.openrewrite.java.migrate.Jre17AgentMainPreMainPublic
+  - org.openrewrite.java.migrate.DeprecatedCountStackFramesMethod
+  - org.openrewrite.java.migrate.RemovedZipFinalizeMethods
+  - org.openrewrite.java.migrate.RemovedSSLSessionGetPeerCertificateChainMethodImpl
+  - org.openrewrite.java.migrate.SunNetSslPackageUnavailable
+  - org.openrewrite.java.migrate.RemovedRMIConnectorServerCredentialTypesConstant
+  - org.openrewrite.java.migrate.RemovedFileIOFinalizeMethods
+  - org.openrewrite.java.migrate.UpgradePluginsForJava17
+  - org.openrewrite.java.dependencies.UpgradeDependencyVersion:
+      groupId: com.google.inject
+      artifactId: guice
+      newVersion: 5.x
+  - org.openrewrite.java.dependencies.UpgradeDependencyVersion:
+      groupId: commons-codec
+      artifactId: commons-codec
+      newVersion: 1.17.x
+  - org.openrewrite.java.migrate.AddLombokMapstructBinding
+  # UpgradeToJava21
+  - org.openrewrite.java.migrate.UpgradeBuildToJava21
+  - org.openrewrite.java.migrate.RemoveIllegalSemicolons
+  - org.openrewrite.java.migrate.lang.ThreadStopUnsupported
+  - org.openrewrite.java.migrate.net.URLConstructorToURICreate
+  - org.openrewrite.java.migrate.util.SequencedCollection
+  - org.openrewrite.java.migrate.util.UseLocaleOf
+  - org.openrewrite.staticanalysis.ReplaceDeprecatedRuntimeExecMethods
+  - org.openrewrite.github.SetupJavaUpgradeJavaVersion
+  - org.openrewrite.java.migrate.UpgradePluginsForJava21
+  - org.openrewrite.java.migrate.DeleteDeprecatedFinalize
+  - org.openrewrite.java.migrate.RemovedSubjectMethods
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: io.kestra.staticanalysis.General
+displayName: Set of static analysis
+description: >-
+  This recipe defines a custom set of static analysis recipes.
+recipeList:
+  - org.openrewrite.staticanalysis.ModifierOrder
+  - org.openrewrite.staticanalysis.MissingOverrideAnnotation
+  - org.openrewrite.staticanalysis.IsEmptyCallOnCollections
+  - org.openrewrite.staticanalysis.NoToStringOnStringType
+  - org.openrewrite.staticanalysis.UseMapContainsKey
+  - org.openrewrite.staticanalysis.AddSerialVersionUidToSerializable:
+      uid: 1L
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: io.kestra.testing.General
+displayName: Set of testing
+description: >-
+  This recipe defines a custom set of testing-related recipes.
+tags:
+  - testing
+recipeList:
+  - org.openrewrite.java.testing.assertj.SimplifyAssertJAssertions
+  - org.openrewrite.java.testing.assertj.SimplifyChainedAssertJAssertions
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: io.kestra.misc.General
+displayName: Set of miscellaneous
+description: >-
+  This recipe defines a custom set of various types of recipes.
+recipeList:
+  - org.openrewrite.java.migrate.net.JavaNetAPIs
+  - org.openrewrite.java.migrate.lang.JavaLangAPIs
+  - org.openrewrite.java.migrate.io.ReplaceFileInOrOutputStreamFinalizeWithClose
+  - org.openrewrite.java.migrate.lang.StringRulesRecipes
+  - org.openrewrite.java.migrate.lang.UseStringIsEmptyRecipe

--- a/runner-memory/src/test/java/io/kestra/repository/memory/MemoryRepositoryTest.java
+++ b/runner-memory/src/test/java/io/kestra/repository/memory/MemoryRepositoryTest.java
@@ -16,7 +16,7 @@ public class MemoryRepositoryTest {
 
     @Test
     void verifyMemoryFallbacksToH2() {
-        assertThat(flowRepositoryInterface.findAll(null).size()).isZero();
+        assertThat(flowRepositoryInterface.findAll(null)).isEmpty();
 
         String flowSource = """
             id: some-flow
@@ -28,7 +28,7 @@ public class MemoryRepositoryTest {
          """;
         flowRepositoryInterface.create(GenericFlow.fromYaml(null, flowSource));
 
-        assertThat(flowRepositoryInterface.findAll(null).size()).isEqualTo(1);
+        assertThat(flowRepositoryInterface.findAll(null)).hasSize(1);
 
         assertThat(flowRepositoryInterface.findByIdWithSource(null, "some.namespace", "some-flow").get().getSource()).isEqualTo(flowSource);
     }

--- a/script/src/main/java/io/kestra/plugin/scripts/exec/scripts/runners/CommandsWrapper.java
+++ b/script/src/main/java/io/kestra/plugin/scripts/exec/scripts/runners/CommandsWrapper.java
@@ -233,6 +233,7 @@ public class CommandsWrapper implements TaskCommands {
         return (TaskRunner<T>) taskRunner;
     }
 
+    @Override
     public Boolean getEnableOutputDirectory() {
         if (this.enableOutputDirectory == null) {
             // For compatibility reasons, if legacy runnerType property is used, we enable the output directory
@@ -242,6 +243,7 @@ public class CommandsWrapper implements TaskCommands {
         return this.enableOutputDirectory;
     }
 
+    @Override
     public Path getOutputDirectory() {
         if (this.outputDirectory == null) {
             this.outputDirectory = this.workingDirectory.resolve(IdUtils.create());

--- a/script/src/test/java/io/kestra/plugin/scripts/runners/LogConsumerTest.java
+++ b/script/src/test/java/io/kestra/plugin/scripts/runners/LogConsumerTest.java
@@ -66,7 +66,7 @@ class LogConsumerTest {
         );
         Await.until(() -> run.getLogConsumer().getStdOutCount() == 2, null, Duration.ofSeconds(5));
         assertThat(run.getLogConsumer().getStdOutCount()).isEqualTo(2);
-        assertThat(run.getLogConsumer().getOutputs().get("someOutput")).isEqualTo(outputValue);
+        assertThat(run.getLogConsumer().getOutputs()).containsEntry("someOutput", outputValue);
     }
 
     @Test

--- a/storage-local/src/main/java/io/kestra/storage/local/LocalStorage.java
+++ b/storage-local/src/main/java/io/kestra/storage/local/LocalStorage.java
@@ -51,13 +51,13 @@ public class LocalStorage implements StorageInterface {
 
     private Path getPath(String tenantId, URI uri) {
         Path basePath = tenantId == null ? this.basePath.toAbsolutePath()
-            : Paths.get(this.basePath.toAbsolutePath().toString(), tenantId);
+            : Path.of(this.basePath.toAbsolutePath().toString(), tenantId);
         if(uri == null) {
             return basePath;
         }
 
         parentTraversalGuard(uri);
-        return Paths.get(basePath.toString(), windowsToUnixPath(uri.getPath()));
+        return Path.of(basePath.toString(), windowsToUnixPath(uri.getPath()));
     }
 
     @Override

--- a/tests/src/main/java/io/kestra/core/Helpers.java
+++ b/tests/src/main/java/io/kestra/core/Helpers.java
@@ -10,7 +10,6 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.net.URISyntaxException;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.Map;
 import java.util.Objects;
 import java.util.function.BiConsumer;
@@ -24,7 +23,7 @@ public final class Helpers {
 
     static {
         try {
-            plugins = Paths.get(Objects.requireNonNull(Helpers.class.getClassLoader().getResource("plugins")).toURI());
+            plugins = Path.of(Objects.requireNonNull(Helpers.class.getClassLoader().getResource("plugins")).toURI());
         } catch (URISyntaxException e) {
             throw new RuntimeException(e);
         }

--- a/tests/src/main/java/io/kestra/core/junit/extensions/FlowExecutorExtension.java
+++ b/tests/src/main/java/io/kestra/core/junit/extensions/FlowExecutorExtension.java
@@ -14,7 +14,7 @@ import io.kestra.core.utils.TestsUtils;
 import io.micronaut.context.ApplicationContext;
 import java.net.URISyntaxException;
 import java.net.URL;
-import java.nio.file.Paths;
+import java.nio.file.Path;
 import java.time.Duration;
 import java.util.Objects;
 import lombok.SneakyThrows;
@@ -58,7 +58,7 @@ public class FlowExecutorExtension implements AfterEachCallback, ParameterResolv
         LocalFlowRepositoryLoader repositoryLoader = context.getBean(LocalFlowRepositoryLoader.class);
         TestsUtils.loads(tenantId, repositoryLoader, Objects.requireNonNull(url));
 
-        Flow flow = YamlParser.parse(Paths.get(url.toURI()).toFile(), Flow.class);
+        Flow flow = YamlParser.parse(Path.of(url.toURI()).toFile(), Flow.class);
         RunnerUtils runnerUtils = context.getBean(RunnerUtils.class);
         return runnerUtils.runOne(tenantId, flow.getNamespace(), flow.getId(), Duration.parse(executeFlow.timeout()));
     }
@@ -70,7 +70,7 @@ public class FlowExecutorExtension implements AfterEachCallback, ParameterResolv
 
         String path = executeFlow.value();
         URL resource = loadFile(path);
-        Flow loadedFlow = YamlParser.parse(Paths.get(resource.toURI()).toFile(), Flow.class);
+        Flow loadedFlow = YamlParser.parse(Path.of(resource.toURI()).toFile(), Flow.class);
         flowRepository.findAllForAllTenants().stream()
             .filter(flow -> Objects.equals(flow.getId(), loadedFlow.getId()))
             .forEach(flow -> flowRepository.delete(FlowWithSource.of(flow, "unused")));

--- a/tests/src/main/java/io/kestra/core/junit/extensions/FlowLoaderExtension.java
+++ b/tests/src/main/java/io/kestra/core/junit/extensions/FlowLoaderExtension.java
@@ -13,7 +13,7 @@ import io.kestra.core.utils.TestsUtils;
 import io.micronaut.context.ApplicationContext;
 import java.net.URISyntaxException;
 import java.net.URL;
-import java.nio.file.Paths;
+import java.nio.file.Path;
 import java.util.HashSet;
 import java.util.Set;
 import org.junit.jupiter.api.extension.AfterEachCallback;
@@ -62,7 +62,7 @@ public class FlowLoaderExtension implements BeforeEachCallback, AfterEachCallbac
         Set<String> flowIds = new HashSet<>();
         for (String path : loadFlows.value()) {
             URL resource = loadFile(path);
-            Flow flow = YamlParser.parse(Paths.get(resource.toURI()).toFile(), Flow.class);
+            Flow flow = YamlParser.parse(Path.of(resource.toURI()).toFile(), Flow.class);
             flowIds.add(flow.getId());
         }
         flowRepository.findAllForAllTenants().stream()

--- a/tests/src/main/java/io/kestra/core/models/tasks/runners/AbstractTaskRunnerTest.java
+++ b/tests/src/main/java/io/kestra/core/models/tasks/runners/AbstractTaskRunnerTest.java
@@ -144,7 +144,7 @@ public abstract class AbstractTaskRunnerTest {
         assertThat(IOUtils.toString(storage.get(null, "unittest", outputFiles.get("file.txt")), StandardCharsets.UTF_8)).isEqualTo("file from output dir");
         assertThat(IOUtils.toString(storage.get(null, "unittest", outputFiles.get("nested/file.txt")), StandardCharsets.UTF_8)).isEqualTo("nested file from output dir");
 
-        assertThat(defaultLogConsumer.getOutputs().get("logOutput")).isEqualTo("Hello World");
+        assertThat(defaultLogConsumer.getOutputs()).containsEntry("logOutput", "Hello World");
     }
 
     @Test
@@ -159,7 +159,7 @@ public abstract class AbstractTaskRunnerTest {
 
         var taskRunner = taskRunner();
         TaskException taskException = assertThrows(TaskException.class, () -> taskRunner.run(runContext, commands, Collections.emptyList()));
-        assertThat(taskException.getLogConsumer().getOutputs().get("logOutput")).isEqualTo("Hello World");
+        assertThat(taskException.getLogConsumer().getOutputs()).containsEntry("logOutput", "Hello World");
     }
 
     protected RunContext runContext(RunContextFactory runContextFactory) {

--- a/tests/src/main/java/io/kestra/core/storage/StorageTestSuite.java
+++ b/tests/src/main/java/io/kestra/core/storage/StorageTestSuite.java
@@ -636,7 +636,7 @@ public abstract class StorageTestSuite {
             storageInterface.get(tenantId, prefix, new URI("/" + prefix + "/storage/put.yml"))
         );
 
-        assertThat(putFromAnother.toString()).isEqualTo(new URI("kestra:///" + prefix + "/storage/put_from_another.yml").toString());
+        assertThat(putFromAnother).hasToString(new URI("kestra:///" + prefix + "/storage/put_from_another.yml").toString());
         InputStream get = storageInterface.get(tenantId, prefix, new URI("/" + prefix + "/storage/put_from_another.yml"));
         assertThat(CharStreams.toString(new InputStreamReader(get))).isEqualTo(CONTENT_STRING);
     }
@@ -687,7 +687,7 @@ public abstract class StorageTestSuite {
         URI put = putFile(tenantId, "/" + prefix + "/storage/put.yml");
         InputStream get = storageInterface.get(tenantId, prefix, new URI("/" + prefix + "/storage/put.yml"));
 
-        assertThat(put.toString()).isEqualTo(new URI("kestra:///" + prefix + "/storage/put.yml").toString());
+        assertThat(put).hasToString(new URI("kestra:///" + prefix + "/storage/put.yml").toString());
         assertThat(CharStreams.toString(new InputStreamReader(get))).isEqualTo(CONTENT_STRING);
     }
     //endregion

--- a/tests/src/main/java/io/kestra/core/utils/TestsUtils.java
+++ b/tests/src/main/java/io/kestra/core/utils/TestsUtils.java
@@ -39,7 +39,7 @@ import java.util.function.Consumer;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
-abstract public class TestsUtils {
+public abstract class TestsUtils {
     private static final ObjectMapper mapper = JacksonMapper.ofYaml();
 
     public static <T> T map(String path, Class<T> cls) throws IOException {

--- a/webserver/src/main/java/io/kestra/webserver/controllers/api/BlueprintController.java
+++ b/webserver/src/main/java/io/kestra/webserver/controllers/api/BlueprintController.java
@@ -118,7 +118,7 @@ public class BlueprintController {
 
     private <T> T fastForwardToKestraApi(HttpRequest<?> originalRequest, String newPath, Map<String, Object> additionalQueryParams, Argument<T> returnType) throws URISyntaxException {
         UriBuilder uriBuilder = UriBuilder.of(originalRequest.getUri())
-            .replacePath(originalRequest.getUri().getPath().toString().replaceAll("^[^?]*", newPath));
+            .replacePath(originalRequest.getUri().getPath().replaceAll("^[^?]*", newPath));
 
         if (additionalQueryParams != null) {
             additionalQueryParams.forEach(uriBuilder::queryParam);

--- a/webserver/src/main/java/io/kestra/webserver/controllers/api/FlowController.java
+++ b/webserver/src/main/java/io/kestra/webserver/controllers/api/FlowController.java
@@ -397,7 +397,7 @@ public class FlowController {
                 .filter(flow ->
                     !flow.getNamespace().equals(namespace) && (!flow.getNamespace().startsWith(namespace) || !allowNamespaceChild))
                 .map(flow -> ManualConstraintViolation.of(
-                    String.format("%s - flow namespace is invalid", flow.uid()),
+                    "%s - flow namespace is invalid".formatted(flow.uid()),
                     flow,
                     GenericFlow.class,
                     "flow.namespace",

--- a/webserver/src/main/java/io/kestra/webserver/controllers/api/NamespaceController.java
+++ b/webserver/src/main/java/io/kestra/webserver/controllers/api/NamespaceController.java
@@ -49,6 +49,7 @@ public class NamespaceController implements NamespaceControllerInterface<Namespa
     @Get(uri = "{id}")
     @ExecuteOn(TaskExecutors.IO)
     @Operation(tags = {"Namespaces"}, summary = "Get a namespace")
+    @Override
     public Namespace getNamespace(
         @Parameter(description = "The namespace id") @PathVariable String id
     ) {
@@ -58,6 +59,7 @@ public class NamespaceController implements NamespaceControllerInterface<Namespa
     @Get(uri = "/search")
     @ExecuteOn(TaskExecutors.IO)
     @Operation(tags = {"Namespaces"}, summary = "Search for namespaces")
+    @Override
     public PagedResults<NamespaceWithDisabled> searchNamespaces(
         @Parameter(description = "A string filter") @Nullable @QueryValue(value = "q") String query,
         @Parameter(description = "The current page") @QueryValue(defaultValue = "1") @Min(1) int page,
@@ -125,6 +127,7 @@ public class NamespaceController implements NamespaceControllerInterface<Namespa
     @ExecuteOn(TaskExecutors.IO)
     @Get(uri = "{namespace}/dependencies")
     @Operation(tags = {"Flows"}, summary = "Get flow dependencies")
+    @Override
     public FlowTopologyGraph getFlowDependenciesFromNamespace(
         @Parameter(description = "The flow namespace") @PathVariable String namespace,
         @Parameter(description = "if true, list only destination dependencies, otherwise list also source dependencies") @QueryValue(defaultValue = "false") boolean destinationOnly

--- a/webserver/src/main/java/io/kestra/webserver/controllers/api/StaticFilter.java
+++ b/webserver/src/main/java/io/kestra/webserver/controllers/api/StaticFilter.java
@@ -60,8 +60,7 @@ public class StaticFilter implements HttpServerFilter {
                                     StandardCharsets.UTF_8
                                 )))
                         )
-                        .filter(Optional::isPresent)
-                        .map(Optional::get)
+                        .flatMap(Optional::stream)
                         .map(s -> {
                             String finalBody = replace(s);
 

--- a/webserver/src/main/java/io/kestra/webserver/controllers/api/TriggerController.java
+++ b/webserver/src/main/java/io/kestra/webserver/controllers/api/TriggerController.java
@@ -116,7 +116,7 @@ public class TriggerController {
             Optional<Flow> flow = flowRepository.findById(tc.getTenantId(), tc.getNamespace(), tc.getFlowId());
             if (flow.isEmpty()) {
                 // Warn instead of throwing to avoid blocking the trigger UI
-                log.warn(String.format("Flow %s not found for trigger %s", tc.getFlowId(), tc.getTriggerId()));
+                log.warn("Flow %s not found for trigger %s".formatted(tc.getFlowId(), tc.getTriggerId()));
 
                 return;
             }
@@ -129,7 +129,7 @@ public class TriggerController {
             AbstractTrigger abstractTrigger = flow.get().getTriggers().stream().filter(t -> t.getId().equals(tc.getTriggerId())).findFirst().orElse(null);
             if (abstractTrigger == null) {
                 // Warn instead of throwing to avoid blocking the trigger UI
-                log.warn(String.format("Flow %s has no trigger %s", tc.getFlowId(), tc.getTriggerId()));
+                log.warn("Flow %s has no trigger %s".formatted(tc.getFlowId(), tc.getTriggerId()));
             }
 
             triggers.add(Triggers.builder()
@@ -257,11 +257,11 @@ public class TriggerController {
 
         Optional<Flow> maybeFlow = this.flowRepository.findById(this.tenantService.resolveTenant(), newTrigger.getNamespace(), newTrigger.getFlowId());
         if (maybeFlow.isEmpty()) {
-            throw new HttpStatusException(HttpStatus.NOT_FOUND, String.format("Flow of trigger %s not found", newTrigger.getTriggerId()));
+            throw new HttpStatusException(HttpStatus.NOT_FOUND, "Flow of trigger %s not found".formatted(newTrigger.getTriggerId()));
         }
         AbstractTrigger abstractTrigger = maybeFlow.get().getTriggers().stream().filter(t -> t.getId().equals(newTrigger.getTriggerId())).findFirst().orElse(null);
         if (abstractTrigger == null) {
-            throw new HttpStatusException(HttpStatus.NOT_FOUND, String.format("Flow %s has no trigger %s", newTrigger.getFlowId(), newTrigger.getTriggerId()));
+            throw new HttpStatusException(HttpStatus.NOT_FOUND, "Flow %s has no trigger %s".formatted(newTrigger.getFlowId(), newTrigger.getTriggerId()));
         }
 
         Trigger updatedTrigger = this.triggerRepository.lock(newTrigger.uid(), throwFunction(current -> {

--- a/webserver/src/main/java/io/micronaut/web/router/resource/VueStaticResourceResolver.java
+++ b/webserver/src/main/java/io/micronaut/web/router/resource/VueStaticResourceResolver.java
@@ -30,6 +30,7 @@ public class VueStaticResourceResolver extends StaticResourceResolver {
         }
     }
 
+    @Override
     public Optional<URL> resolve(String resourcePath) {
         Optional<URL> resolve = super.resolve(resourcePath);
 

--- a/webserver/src/test/java/io/kestra/webserver/OpenapiTest.java
+++ b/webserver/src/test/java/io/kestra/webserver/OpenapiTest.java
@@ -14,6 +14,6 @@ class OpenapiTest {
     void generatedOpenapiSpecFile() {
         Optional<URL> openapiSpec = new ResourceResolver().getResource("classpath:META-INF/swagger/kestra.yml");
 
-        assertThat(openapiSpec.isPresent()).isTrue();
+        assertThat(openapiSpec).isPresent();
     }
 }

--- a/webserver/src/test/java/io/kestra/webserver/controllers/api/BlueprintControllerTest.java
+++ b/webserver/src/test/java/io/kestra/webserver/controllers/api/BlueprintControllerTest.java
@@ -63,17 +63,17 @@ class BlueprintControllerTest {
 
         assertThat(blueprintsWithTotal.getTotal()).isEqualTo(2L);
         List<BlueprintController.ApiBlueprintItem> blueprints = blueprintsWithTotal.getResults();
-        assertThat(blueprints.size()).isEqualTo(2);
+        assertThat(blueprints).hasSize(2);
         assertThat(blueprints.getFirst().getId()).isEqualTo("1");
         assertThat(blueprints.getFirst().getTitle()).isEqualTo("GCS Trigger");
         assertThat(blueprints.getFirst().getDescription()).isEqualTo("GCS trigger flow");
         assertThat(blueprints.getFirst().getPublishedAt()).isEqualTo(Instant.parse("2023-06-01T08:37:34.661Z"));
-        assertThat(blueprints.getFirst().getTags().size()).isEqualTo(2);
+        assertThat(blueprints.getFirst().getTags()).hasSize(2);
         assertThat(blueprints.getFirst().getTags()).containsExactly("3", "2");
         assertThat(blueprints.get(1).getId()).isEqualTo("2");
 
         WireMock wireMock = wmRuntimeInfo.getWireMock();
-        wireMock.verifyThat(getRequestedFor(urlEqualTo(String.format(API_BLUEPRINT_SEARCH_KIND_FLOW , KIND_FLOW, versionProvider.getVersion()) + "?page=1&size=5&q=someTitle&sort=title%3Aasc&tags=3&ee=false")));
+        wireMock.verifyThat(getRequestedFor(urlEqualTo(API_BLUEPRINT_SEARCH_KIND_FLOW.formatted(KIND_FLOW, versionProvider.getVersion()) + "?page=1&size=5&q=someTitle&sort=title%3Aasc&tags=3&ee=false")));
     }
 
     @Test
@@ -92,7 +92,7 @@ class BlueprintControllerTest {
         assertThat(blueprintFlow, not(emptyOrNullString()));
 
         WireMock wireMock = wmRuntimeInfo.getWireMock();
-        wireMock.verifyThat(getRequestedFor(urlEqualTo(String.format(API_BLUEPRINT_GET_SOURCE, KIND_FLOW,  "id_1", versionProvider.getVersion()))));
+        wireMock.verifyThat(getRequestedFor(urlEqualTo(API_BLUEPRINT_GET_SOURCE.formatted(KIND_FLOW, "id_1", versionProvider.getVersion()))));
     }
 
     @SuppressWarnings("unchecked")
@@ -112,13 +112,13 @@ class BlueprintControllerTest {
         List<Map<String, Object>> nodes = (List<Map<String, Object>>) graph.get("nodes");
         List<Map<String, Object>> edges = (List<Map<String, Object>>) graph.get("edges");
         List<Map<String, Object>> clusters = (List<Map<String, Object>>) graph.get("clusters");
-        assertThat(nodes.size()).isEqualTo(12);
+        assertThat(nodes).hasSize(12);
         assertThat(nodes.stream().filter(abstractGraph -> abstractGraph.get("uid").equals("3mTDtNoUxYIFaQtgjEg28_root")).count()).isEqualTo(1L);
-        assertThat(edges.size()).isEqualTo(16);
-        assertThat(clusters.size()).isEqualTo(1);
+        assertThat(edges).hasSize(16);
+        assertThat(clusters).hasSize(1);
 
         WireMock wireMock = wmRuntimeInfo.getWireMock();
-        wireMock.verifyThat(getRequestedFor(urlEqualTo(String.format(API_BLUEPRINT_GET_GRAPH, KIND_FLOW, "id_1", versionProvider.getVersion()))));
+        wireMock.verifyThat(getRequestedFor(urlEqualTo(API_BLUEPRINT_GET_GRAPH.formatted(KIND_FLOW, "id_1", versionProvider.getVersion()))));
     }
 
     @Test
@@ -139,11 +139,11 @@ class BlueprintControllerTest {
         assertThat(blueprint.getDescription()).isEqualTo("GCS trigger flow");
         assertThat(blueprint.getSource(), not(emptyOrNullString()));
         assertThat(blueprint.getPublishedAt()).isEqualTo(Instant.parse("2023-06-01T08:37:34.661Z"));
-        assertThat(blueprint.getTags().size()).isEqualTo(2);
+        assertThat(blueprint.getTags()).hasSize(2);
         assertThat(blueprint.getTags()).containsExactly("3", "2");
 
         WireMock wireMock = wmRuntimeInfo.getWireMock();
-        wireMock.verifyThat(getRequestedFor(urlEqualTo(String.format(API_BLUEPRINT_GET, KIND_FLOW, "id_1", versionProvider.getVersion()))));
+        wireMock.verifyThat(getRequestedFor(urlEqualTo(API_BLUEPRINT_GET.formatted(KIND_FLOW, "id_1", versionProvider.getVersion()))));
     }
 
     @SuppressWarnings("unchecked")
@@ -160,12 +160,12 @@ class BlueprintControllerTest {
             Argument.of(List.class, BlueprintController.ApiBlueprintTagItem.class)
         );
 
-        assertThat(blueprintTags.size()).isEqualTo(3);
+        assertThat(blueprintTags).hasSize(3);
         assertThat(blueprintTags.getFirst().getId()).isEqualTo("3");
         assertThat(blueprintTags.getFirst().getName()).isEqualTo("Cloud");
         assertThat(blueprintTags.getFirst().getPublishedAt()).isEqualTo(Instant.parse("2023-06-01T08:37:10.171Z"));
 
         WireMock wireMock = wmRuntimeInfo.getWireMock();
-        wireMock.verifyThat(getRequestedFor(urlEqualTo(String.format(API_BLUEPRINT_GET_TAGS, KIND_FLOW, versionProvider.getVersion(), "someQuery"))));
+        wireMock.verifyThat(getRequestedFor(urlEqualTo(API_BLUEPRINT_GET_TAGS.formatted(KIND_FLOW, versionProvider.getVersion(), "someQuery"))));
     }
 }

--- a/webserver/src/test/java/io/kestra/webserver/controllers/api/ExecutionControllerRunnerTest.java
+++ b/webserver/src/test/java/io/kestra/webserver/controllers/api/ExecutionControllerRunnerTest.java
@@ -151,12 +151,12 @@ class ExecutionControllerRunnerTest {
 
         assertThat(result.getState().getCurrent()).isEqualTo(State.Type.CREATED);
         assertThat(result.getFlowId()).isEqualTo("inputs");
-        assertThat(result.getInputs().get("float")).isEqualTo(42.42);
+        assertThat(result.getInputs()).containsEntry("float", 42.42);
         assertThat(result.getInputs().get("file").toString()).startsWith("kestra:///io/kestra/tests/inputs/executions/");
         assertThat(result.getInputs().get("file").toString()).startsWith("kestra:///io/kestra/tests/inputs/executions/");
-        assertThat(result.getInputs().containsKey("bool")).isTrue();
+        assertThat(result.getInputs()).containsKey("bool");
         assertThat(result.getInputs().get("bool")).isNull();
-        assertThat(result.getLabels().size()).isEqualTo(6);
+        assertThat(result.getLabels()).hasSize(6);
         assertThat(result.getLabels().getFirst()).isEqualTo(new Label("flow-label-1", "flow-label-1"));
         assertThat(result.getLabels().get(1)).isEqualTo(new Label("flow-label-2", "flow-label-2"));
         assertThat(result.getLabels().get(2)).isEqualTo(new Label("a", "label-1"));
@@ -213,7 +213,7 @@ class ExecutionControllerRunnerTest {
         Execution result = triggerExecutionInputsFlowExecution(true);
 
         assertThat(result.getState().getCurrent()).isEqualTo(State.Type.SUCCESS);
-        assertThat(result.getTaskRunList().size()).isEqualTo(14);
+        assertThat(result.getTaskRunList()).hasSize(14);
     }
 
     @Test
@@ -308,7 +308,7 @@ class ExecutionControllerRunnerTest {
         } catch (JsonProcessingException e) {
             throw new AssertionError("Evaluation result is not a map. Probably due to output decryption being performed while it shouldn't for such feature.");
         }
-        assertThat(resultMap.get("type")).isEqualTo("io.kestra.datatype:aes_encrypted");
+        assertThat(resultMap).containsEntry("type", "io.kestra.datatype:aes_encrypted");
         assertThat(resultMap.get("value")).isNotNull();
 
         execution = runnerUtils.runOne(null, "io.kestra.tests", "inputs", null, (flow, execution1) -> flowIO.readExecutionInputs(flow, execution1, inputs));
@@ -333,7 +333,7 @@ class ExecutionControllerRunnerTest {
         ));
 
         assertThat(e.getStatus().getCode()).isEqualTo(HttpStatus.UNPROCESSABLE_ENTITY.getCode());
-        assertThat(e.getResponse().getBody(String.class).isPresent()).isTrue();
+        assertThat(e.getResponse().getBody(String.class)).isPresent();
         assertThat(e.getResponse().getBody(String.class).get()).contains("No task found");
     }
 
@@ -352,7 +352,7 @@ class ExecutionControllerRunnerTest {
         ));
 
         assertThat(e.getStatus().getCode()).isEqualTo(HttpStatus.UNPROCESSABLE_ENTITY.getCode());
-        assertThat(e.getResponse().getBody(String.class).isPresent()).isTrue();
+        assertThat(e.getResponse().getBody(String.class)).isPresent();
         assertThat(e.getResponse().getBody(String.class).get()).contains("No task found to restart");
     }
 
@@ -367,7 +367,7 @@ class ExecutionControllerRunnerTest {
 
         Optional<Flow> flow = flowRepositoryInterface.findById(null, TESTS_FLOW_NS, flowId);
 
-        assertThat(flow.isPresent()).isTrue();
+        assertThat(flow).isPresent();
 
         // Run child execution starting from a specific task and wait until it finishes
         Execution finishedChildExecution = runnerUtils.awaitChildExecution(
@@ -383,7 +383,7 @@ class ExecutionControllerRunnerTest {
 
             assertThat(createdChidExec).isNotNull();
             assertThat(createdChidExec.getParentId()).isEqualTo(parentExecution.getId());
-            assertThat(createdChidExec.getTaskRunList().size()).isEqualTo(4);
+            assertThat(createdChidExec.getTaskRunList()).hasSize(4);
             assertThat(createdChidExec.getState().getCurrent()).isEqualTo(State.Type.RESTARTED);
 
                 IntStream
@@ -392,13 +392,13 @@ class ExecutionControllerRunnerTest {
                     .forEach(taskRun -> assertThat(taskRun.getState().getCurrent()).isEqualTo(State.Type.SUCCESS));
 
             assertThat(createdChidExec.getTaskRunList().get(3).getState().getCurrent()).isEqualTo(State.Type.RESTARTED);
-            assertThat(createdChidExec.getTaskRunList().get(3).getAttempts().size()).isEqualTo(1);
+            assertThat(createdChidExec.getTaskRunList().get(3).getAttempts()).hasSize(1);
             }),
             Duration.ofSeconds(15));
 
         assertThat(finishedChildExecution).isNotNull();
         assertThat(finishedChildExecution.getParentId()).isEqualTo(parentExecution.getId());
-        assertThat(finishedChildExecution.getTaskRunList().size()).isEqualTo(5);
+        assertThat(finishedChildExecution.getTaskRunList()).hasSize(5);
 
         finishedChildExecution
             .getTaskRunList()
@@ -418,7 +418,7 @@ class ExecutionControllerRunnerTest {
             (flow, execution1) -> flowIO.readExecutionInputs(flow, execution1, inputs));
 
         Optional<Flow> flow = flowRepositoryInterface.findById(null, TESTS_FLOW_NS, flowId);
-        assertThat(flow.isPresent()).isTrue();
+        assertThat(flow).isPresent();
 
         // Run child execution starting from a specific task and wait until it finishes
         runnerUtils.awaitChildExecution(
@@ -454,7 +454,7 @@ class ExecutionControllerRunnerTest {
 
         // Update task's command to make second execution successful
         Optional<Flow> flow = flowRepositoryInterface.findById(null, TESTS_FLOW_NS, flowId);
-        assertThat(flow.isPresent()).isTrue();
+        assertThat(flow).isPresent();
 
         // Restart execution and wait until it finishes
         Execution finishedRestartedExecution = runnerUtils.awaitExecution(
@@ -471,17 +471,17 @@ class ExecutionControllerRunnerTest {
                 assertThat(restartedExec).isNotNull();
                 assertThat(restartedExec.getId()).isEqualTo(firstExecution.getId());
                 assertThat(restartedExec.getParentId()).isNull();
-                assertThat(restartedExec.getTaskRunList().size()).isEqualTo(3);
+                assertThat(restartedExec.getTaskRunList()).hasSize(3);
                 assertThat(restartedExec.getState().getCurrent()).isEqualTo(State.Type.RESTARTED);
 
                 IntStream
                     .range(0, 2)
                     .mapToObj(value -> restartedExec.getTaskRunList().get(value)).forEach(taskRun -> {
                     assertThat(taskRun.getState().getCurrent()).isEqualTo(State.Type.SUCCESS);
-                    assertThat(taskRun.getAttempts().size()).isEqualTo(1);
+                    assertThat(taskRun.getAttempts()).hasSize(1);
 
                     assertThat(restartedExec.getTaskRunList().get(2).getState().getCurrent()).isEqualTo(State.Type.RESTARTED);
-                    assertThat(restartedExec.getTaskRunList().get(2).getAttempts().size()).isEqualTo(1);
+                    assertThat(restartedExec.getTaskRunList().get(2).getAttempts()).hasSize(1);
                     });
             },
             Duration.ofSeconds(15)
@@ -490,12 +490,12 @@ class ExecutionControllerRunnerTest {
         assertThat(finishedRestartedExecution).isNotNull();
         assertThat(finishedRestartedExecution.getId()).isEqualTo(firstExecution.getId());
         assertThat(finishedRestartedExecution.getParentId()).isNull();
-        assertThat(finishedRestartedExecution.getTaskRunList().size()).isEqualTo(4);
+        assertThat(finishedRestartedExecution.getTaskRunList()).hasSize(4);
 
-        assertThat(finishedRestartedExecution.getTaskRunList().getFirst().getAttempts().size()).isEqualTo(1);
-        assertThat(finishedRestartedExecution.getTaskRunList().get(1).getAttempts().size()).isEqualTo(1);
-        assertThat(finishedRestartedExecution.getTaskRunList().get(2).getAttempts().size()).isEqualTo(2);
-        assertThat(finishedRestartedExecution.getTaskRunList().get(3).getAttempts().size()).isEqualTo(1);
+        assertThat(finishedRestartedExecution.getTaskRunList().getFirst().getAttempts()).hasSize(1);
+        assertThat(finishedRestartedExecution.getTaskRunList().get(1).getAttempts()).hasSize(1);
+        assertThat(finishedRestartedExecution.getTaskRunList().get(2).getAttempts()).hasSize(2);
+        assertThat(finishedRestartedExecution.getTaskRunList().get(3).getAttempts()).hasSize(1);
 
         finishedRestartedExecution
             .getTaskRunList()
@@ -517,7 +517,7 @@ class ExecutionControllerRunnerTest {
 
         // Update task's command to make second execution successful
         Optional<Flow> flow = flowRepositoryInterface.findById(null, TESTS_FLOW_NS, flowId);
-        assertThat(flow.isPresent()).isTrue();
+        assertThat(flow).isPresent();
 
         // Restart execution and wait until it finishes
         Execution finishedRestartedExecution = runnerUtils.awaitExecution(
@@ -534,19 +534,19 @@ class ExecutionControllerRunnerTest {
                 assertThat(restartedExec).isNotNull();
                 assertThat(restartedExec.getId()).isEqualTo(firstExecution.getId());
                 assertThat(restartedExec.getParentId()).isNull();
-                assertThat(restartedExec.getTaskRunList().size()).isEqualTo(4);
+                assertThat(restartedExec.getTaskRunList()).hasSize(4);
                 assertThat(restartedExec.getState().getCurrent()).isEqualTo(State.Type.RESTARTED);
 
                 IntStream
                     .range(0, 2)
                     .mapToObj(value -> restartedExec.getTaskRunList().get(value)).forEach(taskRun -> {
                     assertThat(taskRun.getState().getCurrent()).isEqualTo(State.Type.SUCCESS);
-                    assertThat(taskRun.getAttempts().size()).isEqualTo(1);
+                    assertThat(taskRun.getAttempts()).hasSize(1);
 
                     assertThat(restartedExec.getTaskRunList().get(2).getState().getCurrent()).isEqualTo(State.Type.RUNNING);
                     assertThat(restartedExec.getTaskRunList().get(3).getState().getCurrent()).isEqualTo(State.Type.RESTARTED);
                     assertThat(restartedExec.getTaskRunList().get(2).getAttempts()).isNull();
-                    assertThat(restartedExec.getTaskRunList().get(3).getAttempts().size()).isEqualTo(1);
+                    assertThat(restartedExec.getTaskRunList().get(3).getAttempts()).hasSize(1);
                     });
             },
             Duration.ofSeconds(15)
@@ -555,14 +555,14 @@ class ExecutionControllerRunnerTest {
         assertThat(finishedRestartedExecution).isNotNull();
         assertThat(finishedRestartedExecution.getId()).isEqualTo(firstExecution.getId());
         assertThat(finishedRestartedExecution.getParentId()).isNull();
-        assertThat(finishedRestartedExecution.getTaskRunList().size()).isEqualTo(5);
+        assertThat(finishedRestartedExecution.getTaskRunList()).hasSize(5);
 
-        assertThat(finishedRestartedExecution.getTaskRunList().getFirst().getAttempts().size()).isEqualTo(1);
-        assertThat(finishedRestartedExecution.getTaskRunList().get(1).getAttempts().size()).isEqualTo(1);
+        assertThat(finishedRestartedExecution.getTaskRunList().getFirst().getAttempts()).hasSize(1);
+        assertThat(finishedRestartedExecution.getTaskRunList().get(1).getAttempts()).hasSize(1);
         assertThat(finishedRestartedExecution.getTaskRunList().get(2).getAttempts()).isNull();
         assertThat(finishedRestartedExecution.getTaskRunList().get(2).getState().getHistories().stream().filter(state -> state.getState() == State.Type.PAUSED).count()).isEqualTo(1L);
-        assertThat(finishedRestartedExecution.getTaskRunList().get(3).getAttempts().size()).isEqualTo(2);
-        assertThat(finishedRestartedExecution.getTaskRunList().get(4).getAttempts().size()).isEqualTo(1);
+        assertThat(finishedRestartedExecution.getTaskRunList().get(3).getAttempts()).hasSize(2);
+        assertThat(finishedRestartedExecution.getTaskRunList().get(4).getAttempts()).hasSize(1);
 
         finishedRestartedExecution
             .getTaskRunList()
@@ -675,9 +675,9 @@ class ExecutionControllerRunnerTest {
             Execution.class
         );
 
-        assertThat(((Map<String, Object>) execution.getTrigger().getVariables().get("body")).get("a")).isEqualTo(1);
+        assertThat(((Map<String, Object>) execution.getTrigger().getVariables().get("body"))).containsEntry("a", 1);
         assertThat((Boolean) ((Map<String, Object>) execution.getTrigger().getVariables().get("body")).get("b")).isTrue();
-        assertThat(((Map<String, Object>) execution.getTrigger().getVariables().get("parameters")).get("name")).isEqualTo(List.of("john"));
+        assertThat(((Map<String, Object>) execution.getTrigger().getVariables().get("parameters"))).containsEntry("name", List.of("john"));
         assertThat(((Map<String, List<String>>) execution.getTrigger().getVariables().get("parameters")).get("age")).containsExactlyInAnyOrder("12", "13");
         assertThat(execution.getLabels().getFirst()).isEqualTo(new Label("flow-label-1", "flow-label-1"));
         assertThat(execution.getLabels().get(1)).isEqualTo(new Label("flow-label-2", "flow-label-2"));
@@ -691,7 +691,7 @@ class ExecutionControllerRunnerTest {
             Execution.class
         );
 
-        assertThat(((List<Map<String, Object>>) execution.getTrigger().getVariables().get("body")).getFirst().get("a")).isEqualTo(1);
+        assertThat(((List<Map<String, Object>>) execution.getTrigger().getVariables().get("body")).getFirst()).containsEntry("a", 1);
         assertThat((Boolean) ((List<Map<String, Object>>) execution.getTrigger().getVariables().get("body")).getFirst().get("b")).isTrue();
 
         execution = client.toBlocking().retrieve(
@@ -703,7 +703,7 @@ class ExecutionControllerRunnerTest {
             Execution.class
         );
 
-        assertThat(execution.getTrigger().getVariables().get("body")).isEqualTo("bla");
+        assertThat(execution.getTrigger().getVariables()).containsEntry("body", "bla");
 
         execution = client.toBlocking().retrieve(
             GET("/api/v1/executions/webhook/" + TESTS_FLOW_NS + "/webhook/" + key),
@@ -719,7 +719,7 @@ class ExecutionControllerRunnerTest {
                 ),
             Execution.class
         );
-        assertThat(execution.getTrigger().getVariables().get("body")).isEqualTo("{\\\"a\\\":\\\"\\\",\\\"b\\\":{\\\"c\\\":{\\\"d\\\":{\\\"e\\\":\\\"\\\",\\\"f\\\":\\\"1\\\"}}}}");
+        assertThat(execution.getTrigger().getVariables()).containsEntry("body", "{\\\"a\\\":\\\"\\\",\\\"b\\\":{\\\"c\\\":{\\\"d\\\":{\\\"e\\\":\\\"\\\",\\\"f\\\":\\\"1\\\"}}}}");
 
     }
 
@@ -775,7 +775,7 @@ class ExecutionControllerRunnerTest {
         assertThat(execution.getState().isPaused()).isFalse();
 
         Map<String, Object> outputs = (Map<String, Object>) execution.findTaskRunsByTaskId("pause").getFirst().getOutputs().get("onResume");
-        assertThat(outputs.get("asked")).isEqualTo("myString");
+        assertThat(outputs).containsEntry("asked", "myString");
         assertThat((String) outputs.get("data")).startsWith("kestra://");
     }
 
@@ -1090,7 +1090,7 @@ class ExecutionControllerRunnerTest {
             GET("/api/v1/executions/" + runningExecution.getId()),
             Execution.class);
         assertThat(execution.getState().getCurrent()).isEqualTo(State.Type.KILLED);
-        assertThat(execution.getTaskRunList().size()).isEqualTo(1);
+        assertThat(execution.getTaskRunList()).hasSize(1);
         assertThat(execution.getTaskRunList().getFirst().getState().getCurrent()).isEqualTo(State.Type.KILLED);
     }
 
@@ -1124,7 +1124,7 @@ class ExecutionControllerRunnerTest {
         );
 
         assertThat(e.getStatus().getCode()).isEqualTo(HttpStatus.UNPROCESSABLE_ENTITY.getCode());
-        assertThat(e.getResponse().getBody(String.class).isPresent()).isTrue();
+        assertThat(e.getResponse().getBody(String.class)).isPresent();
         assertThat(e.getResponse().getBody(String.class).get()).contains("are mutually exclusive");
 
         executions = client.toBlocking().retrieve(
@@ -1404,7 +1404,7 @@ class ExecutionControllerRunnerTest {
         var response = client.toBlocking().exchange(HttpRequest.POST("/api/v1/executions/" + result.getId() + "/force-run", null));
         assertThat(response.getStatus().getCode()).isEqualTo(HttpStatus.OK.getCode());
         Optional<Execution> forcedRun = executionRepositoryInterface.findById(null, result.getId());
-        assertThat(forcedRun.isPresent()).isTrue();
+        assertThat(forcedRun).isPresent();
         assertThat(forcedRun.get().getState().getCurrent()).isNotEqualTo(State.Type.QUEUED);
 
         // waiting for the flow to complete successfully
@@ -1436,7 +1436,7 @@ class ExecutionControllerRunnerTest {
         var response = client.toBlocking().exchange(HttpRequest.POST("/api/v1/executions/" + result.getId() + "/force-run", null));
         assertThat(response.getStatus().getCode()).isEqualTo(HttpStatus.OK.getCode());
         Optional<Execution> forcedRun = executionRepositoryInterface.findById(null, result.getId());
-        assertThat(forcedRun.isPresent()).isTrue();
+        assertThat(forcedRun).isPresent();
         assertThat(forcedRun.get().getState().getCurrent()).isNotEqualTo(State.Type.CREATED);
     }
 
@@ -1449,7 +1449,7 @@ class ExecutionControllerRunnerTest {
         var response = client.toBlocking().exchange(HttpRequest.POST("/api/v1/executions/" + result.getId() + "/force-run", null));
         assertThat(response.getStatus().getCode()).isEqualTo(HttpStatus.OK.getCode());
         Optional<Execution> forcedRun = executionRepositoryInterface.findById(null, result.getId());
-        assertThat(forcedRun.isPresent()).isTrue();
+        assertThat(forcedRun).isPresent();
         assertThat(forcedRun.get().getState().getCurrent()).isNotEqualTo(State.Type.PAUSED);
     }
 
@@ -1463,7 +1463,7 @@ class ExecutionControllerRunnerTest {
         var response = client.toBlocking().exchange(HttpRequest.POST("/api/v1/executions/" + result.getId() + "/force-run", null));
         assertThat(response.getStatus().getCode()).isEqualTo(HttpStatus.OK.getCode());
         Optional<Execution> forcedRun = executionRepositoryInterface.findById(null, result.getId());
-        assertThat(forcedRun.isPresent()).isTrue();
+        assertThat(forcedRun).isPresent();
         assertThat(forcedRun.get().getState().getCurrent()).isNotEqualTo(State.Type.CREATED);
     }
 

--- a/webserver/src/test/java/io/kestra/webserver/controllers/api/FlowControllerTest.java
+++ b/webserver/src/test/java/io/kestra/webserver/controllers/api/FlowControllerTest.java
@@ -94,7 +94,7 @@ class FlowControllerTest {
         String result = client.toBlocking().retrieve(HttpRequest.GET("/api/v1/flows/io.kestra.tests/full"), String.class);
         Flow flow = YamlParser.parse(result, Flow.class);
         assertThat(flow.getId()).isEqualTo("full");
-        assertThat(flow.getTasks().size()).isEqualTo(5);
+        assertThat(flow.getTasks()).hasSize(5);
     }
 
     @Test
@@ -127,9 +127,9 @@ class FlowControllerTest {
     void graph() {
         FlowGraph result = client.toBlocking().retrieve(HttpRequest.GET("/api/v1/flows/io.kestra.tests/all-flowable/graph"), FlowGraph.class);
 
-        assertThat(result.getNodes().size()).isEqualTo(38);
-        assertThat(result.getEdges().size()).isEqualTo(42);
-        assertThat(result.getClusters().size()).isEqualTo(7);
+        assertThat(result.getNodes()).hasSize(38);
+        assertThat(result.getEdges()).hasSize(42);
+        assertThat(result.getClusters()).hasSize(7);
         assertThat(result.getClusters().stream().map(FlowGraph.Cluster::getCluster).toList(), Matchers.everyItem(
             Matchers.hasProperty("uid", Matchers.not(Matchers.startsWith("cluster_cluster_")))
         ));
@@ -167,7 +167,7 @@ class FlowControllerTest {
         TestsUtils.loads(null, repositoryLoader, FlowControllerTest.class.getClassLoader().getResource("flows/getflowsbynamespace"));
 
         List<Flow> flows = client.toBlocking().retrieve(HttpRequest.GET("/api/v1/flows/io.kestra.unittest.flowsbynamespace"), Argument.listOf(Flow.class));
-        assertThat(flows.size()).isEqualTo(2);
+        assertThat(flows).hasSize(2);
         assertThat(flows.stream().map(Flow::getId).toList()).containsExactlyInAnyOrder("getbynamespace-test-flow", "getbynamespace-test-flow2");
     }
 
@@ -182,7 +182,7 @@ class FlowControllerTest {
         );
 
         List<Flow> updated = client.toBlocking().retrieve(HttpRequest.POST("/api/v1/flows/io.kestra.updatenamespace", flows), Argument.listOf(Flow.class));
-        assertThat(updated.size()).isEqualTo(3);
+        assertThat(updated).hasSize(3);
 
         Flow retrieve = parseFlow(client.toBlocking().retrieve(GET("/api/v1/flows/io.kestra.updatenamespace/f1"), String.class));
         assertThat(retrieve.getId()).isEqualTo("f1");
@@ -195,7 +195,7 @@ class FlowControllerTest {
 
         // f3 & f4 must be updated
         updated = client.toBlocking().retrieve(HttpRequest.POST("/api/v1/flows/io.kestra.updatenamespace", flows), Argument.listOf(Flow.class));
-        assertThat(updated.size()).isEqualTo(4);
+        assertThat(updated).hasSize(4);
         assertThat(updated.get(2).getInputs().getFirst().getId()).isEqualTo("3-3");
         assertThat(updated.get(3).getInputs().getFirst().getId()).isEqualTo("4");
 
@@ -277,7 +277,7 @@ class FlowControllerTest {
                     .contentType(MediaType.APPLICATION_YAML),
                 Argument.listOf(FlowWithSource.class)
             );
-        assertThat(updated.size()).isEqualTo(3);
+        assertThat(updated).hasSize(3);
 
         client.toBlocking().exchange(DELETE("/api/v1/flows/io.kestra.updatenamespace/flow1"));
         client.toBlocking().exchange(DELETE("/api/v1/flows/io.kestra.updatenamespace/flow2"));
@@ -450,7 +450,7 @@ class FlowControllerTest {
         List<String> namespaces = client.toBlocking().retrieve(
             HttpRequest.GET("/api/v1/flows/distinct-namespaces"), Argument.listOf(String.class));
 
-        assertThat(namespaces.size()).isEqualTo(8);
+        assertThat(namespaces).hasSize(8);
     }
 
     @Test
@@ -732,13 +732,13 @@ class FlowControllerTest {
         HttpResponse<List<ValidateConstraintViolation>> response = client.toBlocking().exchange(POST("/api/v1/flows/validate", flow).contentType(MediaType.APPLICATION_YAML), Argument.listOf(ValidateConstraintViolation.class));
 
         List<ValidateConstraintViolation> body = response.body();
-        assertThat(body.size()).isEqualTo(2);
+        assertThat(body).hasSize(2);
         // We don't send any revision while the flow already exists so it's outdated
         assertThat(body.getFirst().isOutdated()).isTrue();
         assertThat(body.getFirst().getDeprecationPaths()).hasSize(3);
         assertThat(body.getFirst().getDeprecationPaths()).containsExactlyInAnyOrder("tasks[1]", "tasks[1].additionalProperty", "listeners");
-        assertThat(body.getFirst().getWarnings().size()).isZero();
-        assertThat(body.getFirst().getInfos().size()).isZero();
+        assertThat(body.getFirst().getWarnings()).isEmpty();
+        assertThat(body.getFirst().getInfos()).isEmpty();
         assertThat(body.get(1).isOutdated()).isFalse();
         assertThat(body.get(1).getDeprecationPaths()).containsExactlyInAnyOrder("tasks[0]", "tasks[1]");
         assertThat(body, everyItem(
@@ -751,7 +751,7 @@ class FlowControllerTest {
         response = client.toBlocking().exchange(POST("/api/v1/flows/validate", flow).contentType(MediaType.APPLICATION_YAML), Argument.listOf(ValidateConstraintViolation.class));
 
         body = response.body();
-        assertThat(body.size()).isEqualTo(2);
+        assertThat(body).hasSize(2);
         assertThat(body.getFirst().getConstraints()).contains("Unrecognized field \"unknownProp\"");
         assertThat(body.get(1).getConstraints()).contains("Invalid type: io.kestra.plugin.core.debug.UnknownTask");
     }
@@ -766,10 +766,10 @@ class FlowControllerTest {
         HttpResponse<List<ValidateConstraintViolation>> response = client.toBlocking().exchange(POST("/api/v1/flows/validate", source).contentType(MediaType.APPLICATION_YAML), Argument.listOf(ValidateConstraintViolation.class));
 
         List<ValidateConstraintViolation> body = response.body();
-        assertThat(body.size()).isEqualTo(1);
+        assertThat(body).hasSize(1);
         assertThat(body.getFirst().getDeprecationPaths()).hasSize(1);
         assertThat(body.getFirst().getDeprecationPaths().getFirst()).isEqualTo("tasks[0]");
-        assertThat(body.getFirst().getInfos().size()).isEqualTo(1);
+        assertThat(body.getFirst().getInfos()).hasSize(1);
         assertThat(body.getFirst().getInfos().getFirst()).isEqualTo("io.kestra.core.tasks.log.Log is replaced by io.kestra.plugin.core.log.Log");
     }
 
@@ -827,7 +827,7 @@ class FlowControllerTest {
         HttpResponse<List<ValidateConstraintViolation>> response = client.toBlocking().exchange(POST("/api/v1/flows/validate/task", task).contentType(MediaType.APPLICATION_JSON), Argument.listOf(ValidateConstraintViolation.class));
 
         List<ValidateConstraintViolation> body = response.body();
-        assertThat(body.size()).isEqualTo(1);
+        assertThat(body).hasSize(1);
         assertThat(body, everyItem(
             Matchers.hasProperty("constraints", nullValue())
         ));
@@ -839,8 +839,8 @@ class FlowControllerTest {
 
         body = response.body();
 
-        assertThat(body.size()).isEqualTo(1);
-        assertThat(body.get(0).getConstraints()).contains("Invalid type: io.kestra.plugin.core.debug.UnknownTask");
+        assertThat(body).hasSize(1);
+        assertThat(body.getFirst().getConstraints()).contains("Invalid type: io.kestra.plugin.core.debug.UnknownTask");
 
         resource = TestsUtils.class.getClassLoader().getResource("tasks/invalidTaskUnknownProp.json");
         task = Files.readString(Path.of(Objects.requireNonNull(resource).getPath()), Charset.defaultCharset());
@@ -849,8 +849,8 @@ class FlowControllerTest {
 
         body = response.body();
 
-        assertThat(body.size()).isEqualTo(1);
-        assertThat(body.get(0).getConstraints()).contains("Unrecognized field \"unknownProp\"");
+        assertThat(body).hasSize(1);
+        assertThat(body.getFirst().getConstraints()).contains("Unrecognized field \"unknownProp\"");
 
         resource = TestsUtils.class.getClassLoader().getResource("tasks/invalidTaskMissingProp.json");
         task = Files.readString(Path.of(Objects.requireNonNull(resource).getPath()), Charset.defaultCharset());
@@ -859,8 +859,8 @@ class FlowControllerTest {
 
         body = response.body();
 
-        assertThat(body.size()).isEqualTo(1);
-        assertThat(body.get(0).getConstraints()).contains("message: must not be null");
+        assertThat(body).hasSize(1);
+        assertThat(body.getFirst().getConstraints()).contains("message: must not be null");
     }
 
     @Test
@@ -872,7 +872,7 @@ class FlowControllerTest {
         HttpResponse<List<ValidateConstraintViolation>> response = client.toBlocking().exchange(POST("/api/v1/flows/validate/trigger", task).contentType(MediaType.APPLICATION_JSON), Argument.listOf(ValidateConstraintViolation.class));
 
         List<ValidateConstraintViolation> body = response.body();
-        assertThat(body.size()).isEqualTo(1);
+        assertThat(body).hasSize(1);
         assertThat(body, everyItem(
             Matchers.hasProperty("constraints", nullValue())
         ));
@@ -884,8 +884,8 @@ class FlowControllerTest {
 
         body = response.body();
 
-        assertThat(body.size()).isEqualTo(1);
-        assertThat(body.get(0).getConstraints()).contains("Invalid type: io.kestra.plugin.core.debug.UnknownTrigger");
+        assertThat(body).hasSize(1);
+        assertThat(body.getFirst().getConstraints()).contains("Invalid type: io.kestra.plugin.core.debug.UnknownTrigger");
 
         resource = TestsUtils.class.getClassLoader().getResource("triggers/invalidTriggerUnknownProp.json");
         task = Files.readString(Path.of(Objects.requireNonNull(resource).getPath()), Charset.defaultCharset());
@@ -894,8 +894,8 @@ class FlowControllerTest {
 
         body = response.body();
 
-        assertThat(body.size()).isEqualTo(1);
-        assertThat(body.get(0).getConstraints()).contains("Unrecognized field \"unknownProp\"");
+        assertThat(body).hasSize(1);
+        assertThat(body.getFirst().getConstraints()).contains("Unrecognized field \"unknownProp\"");
 
         resource = TestsUtils.class.getClassLoader().getResource("triggers/invalidTriggerMissingProp.json");
         task = Files.readString(Path.of(Objects.requireNonNull(resource).getPath()), Charset.defaultCharset());
@@ -904,8 +904,8 @@ class FlowControllerTest {
 
         body = response.body();
 
-        assertThat(body.size()).isEqualTo(1);
-        assertThat(body.get(0).getConstraints()).contains("cron: must not be null");
+        assertThat(body).hasSize(1);
+        assertThat(body.getFirst().getConstraints()).contains("cron: must not be null");
     }
 
     private Flow generateFlow(String namespace, String inputName) {

--- a/webserver/src/test/java/io/kestra/webserver/controllers/api/KVControllerTest.java
+++ b/webserver/src/test/java/io/kestra/webserver/controllers/api/KVControllerTest.java
@@ -158,8 +158,8 @@ class KVControllerTest {
         assertThat(expectedClass.isAssignableFrom(valueClazz)).as("Expected value to be a " + expectedClass + " but was " + valueClazz).isTrue();
 
         List<KVEntry> list = kvStore.list();
-        assertThat(list.size()).isEqualTo(1);
-        KVEntry kvEntry = list.get(0);
+        assertThat(list).hasSize(1);
+        KVEntry kvEntry = list.getFirst();
         assertThat(kvEntry.expirationDate().isAfter(Instant.now().plus(Duration.ofMinutes(4)))).isTrue();
         assertThat(kvEntry.expirationDate().isBefore(Instant.now().plus(Duration.ofMinutes(6)))).isTrue();
     }

--- a/webserver/src/test/java/io/kestra/webserver/controllers/api/LogControllerTest.java
+++ b/webserver/src/test/java/io/kestra/webserver/controllers/api/LogControllerTest.java
@@ -103,7 +103,7 @@ class LogControllerTest {
             GET("/api/v1/logs/" + log1.getExecutionId()),
             Argument.of(List.class, LogEntry.class)
         );
-        assertThat(logs.size()).isEqualTo(2);
+        assertThat(logs).hasSize(2);
         assertThat(logs.getFirst().getExecutionId()).isEqualTo(log1.getExecutionId());
         assertThat(logs.get(1).getExecutionId()).isEqualTo(log1.getExecutionId());
     }
@@ -144,7 +144,7 @@ class LogControllerTest {
             GET("/api/v1/logs/" + log1.getExecutionId()),
             Argument.of(List.class, LogEntry.class)
         );
-        assertThat(logs.size()).isZero();
+        assertThat(logs).isEmpty();
     }
 
     @Test
@@ -165,7 +165,7 @@ class LogControllerTest {
             GET("/api/v1/logs/" + log1.getExecutionId()),
             Argument.of(List.class, LogEntry.class)
         );
-        assertThat(logs.size()).isZero();
+        assertThat(logs).isEmpty();
     }
 
     private static LogEntry logEntry(Level level) {

--- a/webserver/src/test/java/io/kestra/webserver/controllers/api/NamespaceControllerTest.java
+++ b/webserver/src/test/java/io/kestra/webserver/controllers/api/NamespaceControllerTest.java
@@ -73,7 +73,7 @@ public class NamespaceControllerTest {
             Argument.of(PagedResults.class, NamespaceWithDisabled.class)
         );
         assertThat(list.getTotal()).isEqualTo(6L);
-        assertThat(list.getResults().size()).isEqualTo(6);
+        assertThat(list.getResults()).hasSize(6);
         assertThat(list.getResults(), everyItem(hasProperty("disabled", is(true))));
         assertThat(list.getResults().stream().map(NamespaceWithDisabled::getId).toList()).containsExactlyInAnyOrder("my", "my.ns", "my.ns.flow", "another", "another.ns", "system");
 
@@ -83,7 +83,7 @@ public class NamespaceControllerTest {
             Argument.of(PagedResults.class, NamespaceWithDisabled.class)
         );
         assertThat(list.getTotal()).isEqualTo(6L);
-        assertThat(list.getResults().size()).isEqualTo(2);
+        assertThat(list.getResults()).hasSize(2);
         assertThat(list.getResults().getFirst().getId()).isEqualTo("system");
         assertThat(list.getResults().get(1).getId()).isEqualTo("my.ns.flow");
 
@@ -92,7 +92,7 @@ public class NamespaceControllerTest {
             Argument.of(PagedResults.class, NamespaceWithDisabled.class)
         );
         assertThat(list.getTotal()).isEqualTo(6L);
-        assertThat(list.getResults().size()).isEqualTo(2);
+        assertThat(list.getResults()).hasSize(2);
         assertThat(list.getResults().getFirst().getId()).isEqualTo("my.ns");
         assertThat(list.getResults().get(1).getId()).isEqualTo("my");
 
@@ -101,7 +101,7 @@ public class NamespaceControllerTest {
             Argument.of(PagedResults.class, NamespaceWithDisabled.class)
         );
         assertThat(list.getTotal()).isEqualTo(3L);
-        assertThat(list.getResults().size()).isEqualTo(3);
+        assertThat(list.getResults()).hasSize(3);
 
         list = client.toBlocking().retrieve(
             HttpRequest.GET("/api/v1/namespaces/search?page=4&size=2&sort=id:desc"),
@@ -121,8 +121,8 @@ public class NamespaceControllerTest {
             Argument.of(FlowTopologyGraph.class)
         );
 
-        assertThat(retrieve.getNodes().size()).isEqualTo(3);
-        assertThat(retrieve.getEdges().size()).isEqualTo(2);
+        assertThat(retrieve.getNodes()).hasSize(3);
+        assertThat(retrieve.getEdges()).hasSize(2);
     }
 
     @Test
@@ -154,8 +154,8 @@ public class NamespaceControllerTest {
             HttpRequest.GET("/api/v1/namespaces/any.ns/inherited-secrets"),
             Argument.mapOf(Argument.of(String.class), Argument.setOf(String.class))
         );
-        assertThat(parentInheritedSecrets.size()).isEqualTo(1);
-        assertThat(parentInheritedSecrets.get("any.ns")).isEqualTo(Set.of("WEBHOOK_KEY", "PASSWORD", "NEW_LINE", "MY_SECRET"));
+        assertThat(parentInheritedSecrets).hasSize(1);
+        assertThat(parentInheritedSecrets).containsEntry("any.ns", Set.of("WEBHOOK_KEY", "PASSWORD", "NEW_LINE", "MY_SECRET"));
     }
 
     protected Flow flow(String namespace) {

--- a/webserver/src/test/java/io/kestra/webserver/controllers/api/NamespaceFileControllerTest.java
+++ b/webserver/src/test/java/io/kestra/webserver/controllers/api/NamespaceFileControllerTest.java
@@ -185,7 +185,7 @@ class NamespaceFileControllerTest {
         File temp = File.createTempFile("task-flow", ".yml");
         Files.write(temp.toPath(), flowSource.getBytes());
 
-        assertThat(flowRepository.findByIdWithSource(null, NAMESPACE, "task-flow").isEmpty()).isTrue();
+        assertThat(flowRepository.findByIdWithSource(null, NAMESPACE, "task-flow")).isEmpty();
 
         MultipartBody body = MultipartBody.builder()
             .addPart("fileContent", "task-flow.yml", temp)
@@ -215,7 +215,7 @@ class NamespaceFileControllerTest {
         File temp = File.createTempFile("files", ".zip");
         Files.write(temp.toPath(), zip);
 
-        assertThat(flowRepository.findById(null, NAMESPACE, "task-flow").isEmpty()).isTrue();
+        assertThat(flowRepository.findById(null, NAMESPACE, "task-flow")).isEmpty();
 
         MultipartBody body = MultipartBody.builder()
             .addPart("fileContent", "files.zip", temp)

--- a/webserver/src/test/java/io/kestra/webserver/controllers/api/PluginControllerTest.java
+++ b/webserver/src/test/java/io/kestra/webserver/controllers/api/PluginControllerTest.java
@@ -37,7 +37,7 @@ class PluginControllerTest {
                 Argument.listOf(Plugin.class)
             );
 
-            assertThat(list.size()).isEqualTo(2);
+            assertThat(list).hasSize(2);
 
             Plugin template = list.stream()
                 .filter(plugin -> plugin.getTitle().equals("plugin-template-test"))
@@ -48,10 +48,10 @@ class PluginControllerTest {
             assertThat(template.getGroup()).isEqualTo("io.kestra.plugin.templates");
             assertThat(template.getDescription()).isEqualTo("Plugin template for Kestra");
 
-            assertThat(template.getTasks().size()).isEqualTo(1);
+            assertThat(template.getTasks()).hasSize(1);
             assertThat(template.getTasks().getFirst()).isEqualTo("io.kestra.plugin.templates.ExampleTask");
 
-            assertThat(template.getGuides().size()).isEqualTo(2);
+            assertThat(template.getGuides()).hasSize(2);
             assertThat(template.getGuides().getFirst()).isEqualTo("authentication");
 
             Plugin core = list.stream()
@@ -67,7 +67,7 @@ class PluginControllerTest {
                 Argument.listOf(Plugin.class)
             );
 
-            assertThat(list.size()).isEqualTo(2);
+            assertThat(list).hasSize(2);
         });
     }
 
@@ -103,8 +103,8 @@ class PluginControllerTest {
             assertThat(doc.getMarkdown()).contains("Return a value for debugging purposes.");
             assertThat(doc.getMarkdown()).contains("The templated string to render");
             assertThat(doc.getMarkdown()).contains("The generated string");
-            assertThat(((Map<String, Object>) doc.getSchema().getProperties().get("properties")).size()).isEqualTo(1);
-            assertThat(((Map<String, Object>) doc.getSchema().getOutputs().get("properties")).size()).isEqualTo(1);
+            assertThat(((Map<String, Object>) doc.getSchema().getProperties().get("properties"))).hasSize(1);
+            assertThat(((Map<String, Object>) doc.getSchema().getOutputs().get("properties"))).hasSize(1);
         });
     }
 
@@ -120,8 +120,8 @@ class PluginControllerTest {
             );
 
             assertThat(doc.getMarkdown()).contains("io.kestra.plugin.templates.ExampleTask");
-            assertThat(((Map<String, Object>) doc.getSchema().getProperties().get("properties")).size()).isEqualTo(5);
-            assertThat(((Map<String, Object>) doc.getSchema().getOutputs().get("properties")).size()).isEqualTo(1);
+            assertThat(((Map<String, Object>) doc.getSchema().getProperties().get("properties"))).hasSize(5);
+            assertThat(((Map<String, Object>) doc.getSchema().getOutputs().get("properties"))).hasSize(1);
         });
     }
 
@@ -155,9 +155,9 @@ class PluginControllerTest {
             Map<String, Map<String, Object>> properties = (Map<String, Map<String, Object>>) doc.getSchema().getProperties().get("properties");
 
             assertThat(doc.getMarkdown()).contains("io.kestra.plugin.templates.ExampleTask");
-            assertThat(properties.size()).isEqualTo(17);
-            assertThat(properties.get("id").size()).isEqualTo(4);
-            assertThat(((Map<String, Object>) doc.getSchema().getOutputs().get("properties")).size()).isEqualTo(1);
+            assertThat(properties).hasSize(17);
+            assertThat(properties.get("id")).hasSize(4);
+            assertThat(((Map<String, Object>) doc.getSchema().getOutputs().get("properties"))).hasSize(1);
         });
     }
 
@@ -170,7 +170,7 @@ class PluginControllerTest {
                 Argument.mapOf(String.class, Object.class)
             );
 
-            assertThat(doc.get("$ref")).isEqualTo("#/definitions/io.kestra.core.models.flows.Flow");
+            assertThat(doc).containsEntry("$ref", "#/definitions/io.kestra.core.models.flows.Flow");
         });
     }
 
@@ -183,7 +183,7 @@ class PluginControllerTest {
                 Argument.mapOf(String.class, Object.class)
             );
 
-            assertThat(doc.get("$ref")).isEqualTo("#/definitions/io.kestra.core.models.templates.Template");
+            assertThat(doc).containsEntry("$ref", "#/definitions/io.kestra.core.models.templates.Template");
         });
     }
 
@@ -196,7 +196,7 @@ class PluginControllerTest {
                 Argument.mapOf(String.class, Object.class)
             );
 
-            assertThat(doc.get("$ref")).isEqualTo("#/definitions/io.kestra.core.models.tasks.Task");
+            assertThat(doc).containsEntry("$ref", "#/definitions/io.kestra.core.models.tasks.Task");
         });
     }
 
@@ -209,7 +209,7 @@ class PluginControllerTest {
                 Argument.listOf(InputType.class)
             );
 
-            assertThat(doc.size()).isEqualTo(19);
+            assertThat(doc).hasSize(19);
         });
     }
 
@@ -223,9 +223,9 @@ class PluginControllerTest {
                 DocumentationWithSchema.class
             );
 
-            assertThat(doc.getSchema().getProperties().size()).isEqualTo(3);
+            assertThat(doc.getSchema().getProperties()).hasSize(3);
             Map<String, Object> properties = (Map<String, Object>) doc.getSchema().getProperties().get("properties");
-            assertThat(properties.size()).isEqualTo(8);
+            assertThat(properties).hasSize(8);
 //            assertThat(((Map<String, Object>) properties.get("name")).get("$deprecated"), is(true));
         });
     }

--- a/webserver/src/test/java/io/kestra/webserver/controllers/api/TemplateControllerTest.java
+++ b/webserver/src/test/java/io/kestra/webserver/controllers/api/TemplateControllerTest.java
@@ -130,12 +130,12 @@ class TemplateControllerTest {
         Template template = createTemplate();
         client.toBlocking().retrieve(POST("/api/v1/templates", template), Template.class);
         Template createdTemplate = client.toBlocking().retrieve(HttpRequest.GET("/api/v1/templates/" + template.getNamespace() + "/" + template.getId()), Template.class);
-        assertThat(template.getTasks().size()).isEqualTo(2);
+        assertThat(template.getTasks()).hasSize(2);
         Task t3 = Return.builder().id("task-3").type(Return.class.getName()).format(io.kestra.core.models.property.Property.of("test")).build();
         Template updateTemplate = Template.builder().id(template.getId()).namespace(template.getNamespace()).description("My new template description").tasks(Arrays.asList(t3)).build();
         client.toBlocking().retrieve(PUT("/api/v1/templates/" + template.getNamespace() + "/" + template.getId(), updateTemplate), Template.class);
         Template updatedTemplate = client.toBlocking().retrieve(HttpRequest.GET("/api/v1/templates/" + template.getNamespace() + "/" + template.getId()), Template.class);
-        assertThat(updatedTemplate.getTasks().size()).isEqualTo(1);
+        assertThat(updatedTemplate.getTasks()).hasSize(1);
         assertThat(updatedTemplate.getTasks().getFirst().getId()).isEqualTo("task-3");
         assertThat(updatedTemplate.getDescription()).isEqualTo("My new template description");
     }
@@ -144,7 +144,7 @@ class TemplateControllerTest {
     void listDistinctNamespace() {
         List<String> namespaces = client.toBlocking().retrieve(
             HttpRequest.GET("/api/v1/templates/distinct-namespaces"), Argument.listOf(String.class));
-        assertThat(namespaces.size()).isZero();
+        assertThat(namespaces).isEmpty();
             Template t1 = Template.builder()
             .id(IdUtils.create())
             .namespace("kestra.template.custom")
@@ -156,7 +156,7 @@ class TemplateControllerTest {
         namespaces = client.toBlocking().retrieve(
             HttpRequest.GET("/api/v1/templates/distinct-namespaces"), Argument.listOf(String.class));
 
-        assertThat(namespaces.size()).isEqualTo(2);
+        assertThat(namespaces).hasSize(2);
     }
 
     @Test

--- a/webserver/src/test/java/io/kestra/webserver/services/BasicAuthServiceTest.java
+++ b/webserver/src/test/java/io/kestra/webserver/services/BasicAuthServiceTest.java
@@ -107,7 +107,7 @@ class BasicAuthServiceTest {
         assertThat(actualConfiguration).isEqualTo(applicationYamlConfiguration);
 
         Optional<Setting> maybeSetting = settingRepositoryInterface.findByKey(BasicAuthService.BASIC_AUTH_SETTINGS_KEY);
-        assertThat(maybeSetting.isPresent()).isTrue();
+        assertThat(maybeSetting).isPresent();
         assertThat(maybeSetting.get().getValue()).isEqualTo(JacksonMapper.toMap(applicationYamlConfiguration));
     }
 

--- a/webserver/src/test/java/io/kestra/webserver/utils/RequestUtilsTest.java
+++ b/webserver/src/test/java/io/kestra/webserver/utils/RequestUtilsTest.java
@@ -21,7 +21,7 @@ class RequestUtilsTest {
     void toMap() {
         final Map<String, String> resultMap = RequestUtils.toMap(List.of("timestamp:2023-12-18T14:32:14Z"));
 
-        assertThat(resultMap.get("timestamp")).isEqualTo("2023-12-18T14:32:14Z");
+        assertThat(resultMap).containsEntry("timestamp", "2023-12-18T14:32:14Z");
     }
 
 

--- a/webserver/src/test/java/io/kestra/webserver/utils/SearcheableTest.java
+++ b/webserver/src/test/java/io/kestra/webserver/utils/SearcheableTest.java
@@ -42,7 +42,7 @@ class SearcheableTest {
             .build();
 
         ArrayListTotal<TestEntity> result = searcheable.search(searched);
-        assertEquals(25, result.get(0).age());
+        assertEquals(25, result.getFirst().age());
         assertEquals(30, result.get(1).age());
         assertEquals(35, result.get(2).age());
         assertEquals(40, result.get(3).age());
@@ -56,7 +56,7 @@ class SearcheableTest {
             .build();
 
         ArrayListTotal<TestEntity> result = searcheable.search(searched);
-        assertEquals(40, result.get(0).age());
+        assertEquals(40, result.getFirst().age());
         assertEquals(35, result.get(1).age());
         assertEquals(30, result.get(2).age());
         assertEquals(25, result.get(3).age());
@@ -71,8 +71,8 @@ class SearcheableTest {
             .build();
 
         ArrayListTotal<TestEntity> result = searcheable.search(searched);
-        assertEquals("Alice", result.get(0).name());
-        assertEquals(30, result.get(0).age());
+        assertEquals("Alice", result.getFirst().name());
+        assertEquals(30, result.getFirst().age());
         assertEquals("Alice", result.get(1).name());
         assertEquals(40, result.get(1).age());
     }

--- a/webserver/src/test/java/io/kestra/webserver/utils/TimeLineSearchTest.java
+++ b/webserver/src/test/java/io/kestra/webserver/utils/TimeLineSearchTest.java
@@ -68,8 +68,8 @@ class TimeLineSearchTest {
         List<QueryFilter> updatedFilters = QueryFilterUtils.updateFilters(filters, newStartDate);
         // THEN
         assertEquals(1, updatedFilters.size()); // TIME_RANGE filter should be removed
-        assertEquals(QueryFilter.Field.START_DATE, updatedFilters.get(0).field());
-        assertEquals(newStartDate.toString(), updatedFilters.get(0).value());
+        assertEquals(QueryFilter.Field.START_DATE, updatedFilters.getFirst().field());
+        assertEquals(newStartDate.toString(), updatedFilters.getFirst().value());
     }
 
     @Test


### PR DESCRIPTION
### What changes are being made and why?

There have been leftover bits from the pre-Java 21 code style in the code base. Since I've been toying with [OpenRewrite](https://docs.openrewrite.org/) recently, it felt tempting to apply it here.

The activity consisted of:

1. enabling the `org.openrewrite.rewrite` Gradle plugin providing source scanning tasks
2. composing suitable rules to `rewrite.yml`
3. running the dry run task (note the runtime being ~10 mins)
4. checking the patch output for obvious mistakes

---

The main goal was to modernize the style to match Java 21, with also having the AsssertJ assertions a bit less chatty, and lastly applying a few low-risk _best practice_ style rules.

---

It is certainly possible to treat the modernization as a one-shot action - having the Gradle plugin and its config enabled just temporarily for the modification time.

There are many other rules which might eventually be enabled in the future.

---

Rules of the code style part are probably relevant (and might conflict with) to #8177.

### How the changes have been QAed?

It builds & unit tests are OK except two `ExecutionControllerRunner`'s.
