### PR TITLE
fix(plugins)*: don't cache the `condition` property inside the If task

### DIFF
--- a/core/src/main/java/io/kestra/plugin/core/flow/If.java
+++ b/core/src/main/java/io/kestra/plugin/core/flow/If.java
@@ -74,7 +74,11 @@ public class If extends Task implements FlowableTask<If.Output> {
         title = "The `If` condition which can be any expression that evaluates to a boolean value.",
         description = "Boolean coercion allows 0, -0, null and '' to evaluate to false, all other values will evaluate to true."
     )
-    private Property<String> condition;
+    // Note: we can't use Property<String> here because of the cache of the property evaluation which causes issue when using If in a ForEach with concurrencyLimit > 1!
+    // See https://github.com/kestra-io/kestra/issues/8697
+    // At some point, if we need it, we should allow bypassing (or clearing) the property evaluation cache
+    @PluginProperty(dynamic = true)
+    private String condition;
 
     @Valid
     @PluginProperty
@@ -205,7 +209,7 @@ public class If extends Task implements FlowableTask<If.Output> {
     }
 
     private Boolean isTrue(RunContext runContext) throws IllegalVariableEvaluationException {
-        String rendered = runContext.render(condition).as(String.class).orElse(null);
+        String rendered = runContext.render(condition);
         return TruthUtils.isTruthy(rendered);
     }
 

--- a/core/src/test/java/io/kestra/plugin/core/flow/IfTest.java
+++ b/core/src/test/java/io/kestra/plugin/core/flow/IfTest.java
@@ -116,4 +116,11 @@ class IfTest {
         assertThat(execution.findTaskRunsByTaskId("if").getFirst().getState().getCurrent()).isEqualTo(State.Type.SUCCESS);
         assertThat(execution.getState().getCurrent()).isEqualTo(State.Type.SUCCESS);
     }
+
+    @Test
+    @ExecuteFlow("flows/valids/if-in-parallel.yaml")
+    void ifOnParallelBranch(Execution execution) {
+        assertThat(execution.getTaskRunList()).hasSize(9);
+        assertThat(execution.getState().getCurrent()).isEqualTo(State.Type.SUCCESS);
+    }
 }

--- a/core/src/test/resources/flows/valids/if-in-parallel.yaml
+++ b/core/src/test/resources/flows/valids/if-in-parallel.yaml
@@ -1,0 +1,30 @@
+id: if-in-parallel
+namespace: io.kestra.tests
+
+tasks:
+  - id: for_each
+    type: io.kestra.plugin.core.flow.ForEach
+    concurrencyLimit: 1
+    values:
+      - 1
+      - 2
+      - 3
+    tasks:
+      - id: return
+        type: io.kestra.plugin.core.debug.Return
+        format: "{{taskrun.value}}"
+
+      - id: if
+        type: io.kestra.plugin.core.flow.If
+        condition: '{{ taskrun.value == "2" }}'
+        then:
+          - id: after_if
+            type: io.kestra.plugin.core.debug.Return
+            format: "After if {{ parent.taskrun.value }}"
+
+  - id: assert
+    type: io.kestra.plugin.core.execution.Assert
+    conditions:
+      - "{{ outputs.return['1'].value == '1' }}"
+      - "{{ outputs.return['3'].value == '3' }}"
+      - "{{ outputs.after_if['2'].value == 'After if 2' }}"


### PR DESCRIPTION
Doing that, causes an issue if the If task is used inside a ForEach with a concurrencyLimit > 1.

Fixes #8697
