### PR TITLE
chore(flows): remove unnecessary section about keyboard shortcuts from basic flow documentation

### DIFF
--- a/ui/src/assets/docs/basic.md
+++ b/ui/src/assets/docs/basic.md
@@ -1,11 +1,3 @@
-### Keyboard Shortcuts
-
-Use the shortcut `CTRL + SPACE` on Windows/Linux or `fn + control + SPACE` on Mac to trigger **autocompletion** listing available properties.
-
-If you want to **comment out** some part of your code, use the `CTRL or ⌘ + K + C` shortcut, and to uncomment it, use `CTRL or ⌘ + K + U`. To remember it, `C` stands for `comment` and `U` stands for `uncomment`.
-
-If you want to fold all nested properties, use `CTRL or ⌘ + K` and then `CTRL or ⌘ + 0` (note that it's zero, not `O`). To unfold again, use `CTRL or ⌘ + K` and then `CTRL or ⌘ + J`.
-
 ### Flow properties
 
 Kestra allows you to automate complex flows using a simple declarative interface.


### PR DESCRIPTION
Closes https://github.com/kestra-io/kestra/issues/7065.