### PR TITLE
fix(core): showing properties of any-of type tasks

### DIFF
--- a/ui/src/components/flows/tasks/AnyOfContent.vue
+++ b/ui/src/components/flows/tasks/AnyOfContent.vue
@@ -17,6 +17,7 @@
             @update:model-value="onInput"
             :schema="currentSchema"
             :definitions="definitions"
+            :properties="currentSchema.properties"
         />
     </el-form>
 </template>


### PR DESCRIPTION
There was an error noticed with retry property of tasks where upon initial selection no properties would show up.