### PR TITLE
chore(system): mask Caffeine metrics log

### DIFF
--- a/core/src/main/java/io/kestra/core/log/KestraLogFilter.java
+++ b/core/src/main/java/io/kestra/core/log/KestraLogFilter.java
@@ -12,6 +12,7 @@ public class KestraLogFilter extends EventEvaluatorBase<ILoggingEvent> {
         // we use startWith and do all checks successfully instead of using a more elegant construct like Stream...
         return message.startsWith("outOfOrder mode is active. Migration of schema") ||
             message.startsWith("Version mismatch         : Database version is older than what dialect POSTGRES supports") ||
-            message.startsWith("Failed to bind as java.util.concurrent.Executors$AutoShutdownDelegatedExecutorService is unsupported.");
+            message.startsWith("Failed to bind as java.util.concurrent.Executors$AutoShutdownDelegatedExecutorService is unsupported.") ||
+            message.startsWith("The cache 'default' is not recording statistics.");
     }
 }


### PR DESCRIPTION
As it's not an error and we cannot do anything if we don't want metrics (which cost) but want to hide that log.
