### PR TITLE
fix(core): flaky test ExecutionServiceTest.replayEachSeq or replayEac…

### DIFF
--- a/core/src/test/java/io/kestra/core/runners/ExecutionServiceTest.java
+++ b/core/src/test/java/io/kestra/core/runners/ExecutionServiceTest.java
@@ -232,9 +232,8 @@ class ExecutionServiceTest {
     }
 
     @Test
-    @LoadFlows({"flows/valids/each-sequential-nested.yaml"})
-    void replayEachSeq() throws Exception {
-        Execution execution = runnerUtils.runOne(null, "io.kestra.tests", "each-sequential-nested");
+    @ExecuteFlow("flows/valids/each-sequential-nested.yaml")
+    void replayEachSeq(Execution execution) throws Exception {
         assertThat(execution.getTaskRunList()).hasSize(23);
         assertThat(execution.getState().getCurrent()).isEqualTo(State.Type.SUCCESS);
 
@@ -252,9 +251,8 @@ class ExecutionServiceTest {
     }
 
     @Test
-    @LoadFlows({"flows/valids/each-sequential-nested.yaml"})
-    void replayEachSeq2() throws Exception {
-        Execution execution = runnerUtils.runOne(null, "io.kestra.tests", "each-sequential-nested");
+    @ExecuteFlow("flows/valids/each-sequential-nested.yaml")
+    void replayEachSeq2(Execution execution) throws Exception {
         assertThat(execution.getTaskRunList()).hasSize(23);
         assertThat(execution.getState().getCurrent()).isEqualTo(State.Type.SUCCESS);
 


### PR DESCRIPTION
…hSeq2

One of the two is failing pretty often, using @ExecuteFlow instead of @LoadFlow seems to make them non-flaky. We can also remove the second ad those are duplicated test but maybe the person that duplicate it has some reason...