### PR TITLE
chore(system): improve performance of IdUtils.fromParts()

### DIFF
--- a/core/src/main/java/io/kestra/core/utils/IdUtils.java
+++ b/core/src/main/java/io/kestra/core/utils/IdUtils.java
@@ -5,10 +5,8 @@ import com.google.common.hash.HashFunction;
 import com.google.common.hash.Hashing;
 import java.nio.charset.StandardCharsets;
 
-import java.util.Arrays;
-import java.util.Objects;
+import java.util.StringJoiner;
 import java.util.UUID;
-import java.util.stream.Collectors;
 
 @SuppressWarnings({"deprecation"})
 abstract public class IdUtils {
@@ -32,8 +30,12 @@ abstract public class IdUtils {
     }
 
     public static String fromPartsAndSeparator(char separator, String... parts) {
-        return Arrays.stream(parts)
-            .filter(Objects::nonNull)
-            .collect(Collectors.joining(String.valueOf(separator)));
+        StringJoiner sj = new StringJoiner(String.valueOf(separator));
+        for (String str : parts) {
+            if (str != null) {
+                sj.add(str);
+            }
+        }
+        return sj.toString();
     }
 }


### PR DESCRIPTION
Surprisingly, this method appear in some CPU and allocation profile as having a high cost, especially on the scheduler. Switching to using a StringJoiner brings 4x perf improvements in method execution time (great improvement also on allocation but didn't have a measurement).
