### PR TITLE
Additional YAML Test Coverage for ConfigPropertiesCommandTest

### DIFF
--- a/cli/src/test/java/io/kestra/cli/commands/configs/sys/ConfigPropertiesCommandTest.java
+++ b/cli/src/test/java/io/kestra/cli/commands/configs/sys/ConfigPropertiesCommandTest.java
@@ -4,11 +4,14 @@ import io.micronaut.configuration.picocli.PicocliRunner;
 import io.micronaut.context.ApplicationContext;
 import io.micronaut.context.env.Environment;
 import org.junit.jupiter.api.Test;
+import org.yaml.snakeyaml.Yaml;
 
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
+import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.catchThrowable;
 
 class ConfigPropertiesCommandTest {
     @Test
@@ -21,6 +24,50 @@ class ConfigPropertiesCommandTest {
 
             assertThat(out.toString()).contains("activeEnvironments:");
             assertThat(out.toString()).contains("- test");
+        }
+    }
+
+    @Test
+    void shouldOutputCustomEnvironment() {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        System.setOut(new PrintStream(out));
+
+        try (ApplicationContext ctx = ApplicationContext.run(Environment.CLI, "custom-env")) {
+            PicocliRunner.call(ConfigPropertiesCommand.class, ctx);
+
+            assertThat(out.toString()).contains("activeEnvironments:");
+            assertThat(out.toString()).contains("- custom-env");
+        }
+    }
+
+    @Test
+    void shouldReturnZeroOnSuccess() throws Exception {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        System.setOut(new PrintStream(out));
+
+        try (ApplicationContext ctx = ApplicationContext.run(Environment.CLI, Environment.TEST)) {
+            ConfigPropertiesCommand cmd = ctx.createBean(ConfigPropertiesCommand.class);
+            int result = cmd.call();
+
+            assertThat(result).isZero();
+        }
+    }
+
+    @Test
+    void shouldOutputValidYaml() {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        System.setOut(new PrintStream(out));
+
+        try (ApplicationContext ctx = ApplicationContext.run(Environment.CLI, Environment.TEST)) {
+            PicocliRunner.call(ConfigPropertiesCommand.class, ctx);
+
+            String output = out.toString();
+            Yaml yaml = new Yaml();
+            Throwable thrown = catchThrowable(() -> {
+                Map<?, ?> parsed = yaml.load(output);
+                assertThat(parsed).isInstanceOf(Map.class);
+            });
+            assertThat(thrown).isNull();
         }
     }
 }


### PR DESCRIPTION
### What changes are being made and why?

- **Added two new test cases** to `ConfigPropertiesCommandTest` to improve CLI coverage:
  1. **`shouldReturnZeroOnSuccess`**  
     Verifies that invoking `cmd.call()` on a `ConfigPropertiesCommand` bean returns exit code `0` on success.  
  2. **`shouldOutputValidYaml`**  
     Parses the command’s stdout with SnakeYAML and asserts that the output deserializes into a `Map<?,?>`, ensuring the CLI always emits well-formed YAML.

These assertions guarantee that the CLI command not only completes successfully but also produces machine-readable configuration output.

### How have the changes been QAed?

- Ran the full test suite via **IntelliJ IDEA’s “Run with Coverage”**: both new tests pass, and coverage metrics for `ConfigPropertiesCommand` have increased.  
- Executed `./gradlew test` on the command line to confirm no regressions.  
