### PR TITLE
test(processor): Add edge-case tests for ServicesFiles utility

### DIFF
--- a/processor/src/test/java/io/kestra/core/plugins/processor/ServicesFilesTest.java
+++ b/processor/src/test/java/io/kestra/core/plugins/processor/ServicesFilesTest.java
@@ -5,8 +5,11 @@ import org.junit.jupiter.api.Test;
 
 import javax.annotation.processing.Processor;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.Set;
 
 class ServicesFilesTest {
@@ -17,5 +20,65 @@ class ServicesFilesTest {
         InputStream inputStream = ServicesFilesTest.class.getClassLoader().getResourceAsStream(path);
         Set<String> providers = ServicesFiles.readServiceFile(inputStream);
         Assertions.assertEquals(Set.of(PluginProcessor.class.getCanonicalName()), providers);
+    }
+
+    @Test
+    void testWriteAndReadServiceFileRoundTrip() throws IOException {
+        Set<String> services = Set.of("com.example.ServiceA", "com.example.ServiceB");
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        ServicesFiles.writeServiceFile(services, out);
+
+        ByteArrayInputStream in = new ByteArrayInputStream(out.toByteArray());
+        Set<String> read = ServicesFiles.readServiceFile(in);
+
+        Assertions.assertEquals(services, read);
+    }
+
+    @Test
+    void testReadServiceFileWithCommentsAndWhitespace() throws IOException {
+        String content = """
+        # comment
+        com.example.ServiceA
+
+        com.example.ServiceB   # inline comment
+        """;
+        ByteArrayInputStream in = new ByteArrayInputStream(content.getBytes(StandardCharsets.UTF_8));
+        Set<String> read = ServicesFiles.readServiceFile(in);
+
+        Assertions.assertEquals(Set.of("com.example.ServiceA", "com.example.ServiceB"), read);
+    }
+    @Test
+    void testReadServiceFileWithDuplicates() throws IOException {
+        String content = """
+        com.example.ServiceA
+        com.example.ServiceA
+        com.example.ServiceB
+        """;
+        ByteArrayInputStream in = new ByteArrayInputStream(content.getBytes(StandardCharsets.UTF_8));
+        Set<String> read = ServicesFiles.readServiceFile(in);
+
+        Assertions.assertEquals(Set.of("com.example.ServiceA", "com.example.ServiceB"), read);
+    }
+
+    @Test
+    void testWriteEmptyServiceFile() throws IOException {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        ServicesFiles.writeServiceFile(Set.of(), out);
+        Assertions.assertEquals("", out.toString(StandardCharsets.UTF_8));
+    }
+
+    @Test
+    void testReadEmptyServiceFile() throws IOException {
+        ByteArrayInputStream in = new ByteArrayInputStream(new byte[0]);
+        Set<String> read = ServicesFiles.readServiceFile(in);
+        Assertions.assertTrue(read.isEmpty());
+    }
+
+    @Test
+    void testReadMalformedServiceFile() throws IOException {
+        String content = "# only a comment\n\n";
+        ByteArrayInputStream in = new ByteArrayInputStream(content.getBytes(StandardCharsets.UTF_8));
+        Set<String> read = ServicesFiles.readServiceFile(in);
+        Assertions.assertTrue(read.isEmpty());
     }
 }


### PR DESCRIPTION
### What changes are being made and why?

- **Added six new test cases** to `ServicesFilesTest` to cover more scenarios in service-file parsing and writing:
  1. **`testWriteAndReadServiceFileRoundTrip`**  
     Verifies that writing a set of service names to an output stream and then reading them back returns the original set.
  2. **`testReadServiceFileWithCommentsAndWhitespace`**  
     Ensures that lines starting with `#`, blank lines, and inline comments are ignored when reading service files.
  3. **`testReadServiceFileWithDuplicates`**  
     Checks that duplicate entries in the service file are collapsed into a unique set.
  4. **`testWriteEmptyServiceFile`**  
     Asserts that writing an empty set produces an empty output string.
  5. **`testReadEmptyServiceFile`**  
     Confirms that reading from an empty input yields an empty set.
  6. **`testReadMalformedServiceFile`**  
     Validates that a file containing only comments and whitespace yields an empty set rather than throwing.

These additions improve confidence in `ServicesFiles.readServiceFile` and `ServicesFiles.writeServiceFile` by asserting correct behavior across common edge cases.

---

### How have the changes been QAed?
 
- Executed IntelliJ's testing features to ensure all test cases pass and provide additional overall coverage.
