### PR TITLE
chore(system): skip sleep in the JdbcQueue when at max poll size

### DIFF
--- a/jdbc/src/main/java/io/kestra/jdbc/runner/JdbcQueue.java
+++ b/jdbc/src/main/java/io/kestra/jdbc/runner/JdbcQueue.java
@@ -398,6 +398,14 @@ public abstract class JdbcQueue<T> implements QueueInterface<T> {
                         if (count > 0) {
                             lastPoll = ZonedDateTime.now();
                             sleep = configuration.minPollInterval;
+                            if (count.equals(configuration.pollSize)) {
+                                // Note: this provides better latency on high throughput: when Kestra is a top capacity,
+                                // it will not do a sleep and immediately poll again.
+                                // We can even have better latency at even higher latency by continuing for positive count,
+                                // but at higher database cost.
+                                // Current impl balance database cost with latency.
+                                continue;
+                            }
                         } else {
                             ZonedDateTime finalLastPoll = lastPoll;
                             // get all poll steps which duration is less than the duration between last poll and now


### PR DESCRIPTION
When a queue is at max poll size, this means that it is at full capacity. In this case skip the sleep and process immediatly the next batch of message. This improve latency at high thoughput without adding too much load to the database.

We can even go further by skipping sleep each time the poll returns messages but this would imply database cost so for now we balance performance and database cost by only skipping sleep when at max capacity.
