### PR TITLE
fix(plugins): ForEach must be displayed as a sequential

### DIFF
--- a/core/src/main/java/io/kestra/core/runners/FlowableUtils.java
+++ b/core/src/main/java/io/kestra/core/runners/FlowableUtils.java
@@ -218,7 +218,7 @@ public class FlowableUtils {
 
     /**
      * resolveConcurrentNexts will resolve concurrent values
-     * For both concurrent vales and subtasks, see resolveParallelNexts()
+     * For both concurrent values and subtasks, see resolveParallelNexts()
      */
     public static List<NextTaskRun> resolveConcurrentNexts(
         Execution execution,

--- a/core/src/main/java/io/kestra/plugin/core/flow/ForEach.java
+++ b/core/src/main/java/io/kestra/plugin/core/flow/ForEach.java
@@ -224,25 +224,16 @@ public class ForEach extends Sequential implements FlowableTask<VoidOutput> {
     public GraphCluster tasksTree(Execution execution, TaskRun taskRun, List<String> parentValues) throws IllegalVariableEvaluationException {
         GraphCluster subGraph = new GraphCluster(this, taskRun, parentValues, RelationType.DYNAMIC);
 
-        if (concurrencyLimit == 1) {
-            GraphUtils.sequential(
-                subGraph,
-                this.getTasks(),
-                this.getErrors(),
-                this.getFinally(),
-                taskRun,
-                execution
-            );
-        } else {
-            GraphUtils.parallel(
-                subGraph,
-                this.getTasks(),
-                this.errors,
-                this._finally,
-                taskRun,
-                execution
-            );
-        }
+        // ForEach executes task groups concurrently, not the task inside the group concurrently,
+        // so the topology should display it as a sequential.
+        GraphUtils.sequential(
+            subGraph,
+            this.getTasks(),
+            this.getErrors(),
+            this.getFinally(),
+            taskRun,
+            execution
+        );
 
         return subGraph;
     }


### PR DESCRIPTION
As the tasks inside each task group are executed sequentially, groups are executed concurrently not tasks inside them.

Part-of: https://github.com/kestra-io/kestra-ee/issues/3722
