### PR TITLE
feat!: add a new method "taskWithState"

### DIFF
--- a/core/src/main/java/io/kestra/core/runners/RunVariables.java
+++ b/core/src/main/java/io/kestra/core/runners/RunVariables.java
@@ -12,7 +12,6 @@ import io.kestra.core.models.flows.input.SecretInput;
 import io.kestra.core.models.tasks.Task;
 import io.kestra.core.models.triggers.AbstractTrigger;
 import io.kestra.core.utils.ListUtils;
-import io.kestra.core.utils.MapUtils;
 import lombok.AllArgsConstructor;
 import lombok.With;
 
@@ -78,7 +77,7 @@ public final class RunVariables {
     static Map<String, Object> of(final FlowInterface flow) {
         ImmutableMap.Builder<String, Object> builder = ImmutableMap.builder();
         builder.put("id", flow.getId())
-               .put("namespace", flow.getNamespace());
+            .put("namespace", flow.getNamespace());
 
         Optional.ofNullable(flow.getRevision())
             .ifPresent(revision ->  builder.put("revision", revision));

--- a/core/src/main/java/io/kestra/core/runners/pebble/Extension.java
+++ b/core/src/main/java/io/kestra/core/runners/pebble/Extension.java
@@ -161,6 +161,7 @@ public class Extension extends AbstractExtension {
         functions.put("randomPort", new RandomPortFunction());
         functions.put("fileExists", fileExistsFunction);
         functions.put("isFileEmpty", isFileEmptyFunction);
+        functions.put("tasksWithState", new TasksWithState());
         return functions;
     }
 

--- a/core/src/main/java/io/kestra/core/runners/pebble/functions/TasksWithState.java
+++ b/core/src/main/java/io/kestra/core/runners/pebble/functions/TasksWithState.java
@@ -1,0 +1,85 @@
+package io.kestra.core.runners.pebble.functions;
+
+import io.pebbletemplates.pebble.error.PebbleException;
+import io.pebbletemplates.pebble.extension.Function;
+import io.pebbletemplates.pebble.template.EvaluationContext;
+import io.pebbletemplates.pebble.template.EvaluationContextImpl;
+import io.pebbletemplates.pebble.template.PebbleTemplate;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class TasksWithState implements Function {
+    public List<String> getArgumentNames() {
+        return List.of("state");
+    }
+
+    @Override
+    public Object execute(Map<String, Object> args, PebbleTemplate self, EvaluationContext context, int lineNumber) {
+        if (!args.containsKey("state")) {
+            throw new PebbleException(null, "The 'tasksWithState' function expects an argument 'state'.", lineNumber, self.getName());
+        }
+        String stateToFilter = ((String) args.get("state")).toUpperCase();
+
+        EvaluationContextImpl evaluationContext = (EvaluationContextImpl) context;
+
+        Map<String, Object> globalTasksMap = (Map<String, Object>) evaluationContext.getScopeChain().getGlobalScopes().stream()
+            .flatMap(scope -> scope.getKeys().stream())
+            .distinct()
+            .filter(key -> "tasks".equals(key)) // Filter for the "tasks" key specifically
+            .collect(HashMap::new, (m, k) -> m.put(k, context.getVariable(k)), HashMap::putAll)
+            .get("tasks");
+
+        List<Map<String, Object>> filteredTasks = new ArrayList<>();
+
+        if (globalTasksMap != null) {
+            globalTasksMap.forEach((taskId, taskDetailsObj) -> {
+                if (taskDetailsObj instanceof Map) {
+                    Map<String, Object> taskDetailsMap = (Map<String, Object>) taskDetailsObj;
+                    taskDetailsMap.forEach((key, valueObj) -> {
+                        Map<String, Object> transformedTask = new HashMap<>();
+                        transformedTask.put("taskId", taskId);
+
+                        if ("state".equals(key)) {
+                            if (valueObj instanceof String) {
+                                String state = ((String) valueObj).toUpperCase();
+                                if (stateToFilter.equals(state)) {
+                                    transformedTask.put("state", state);
+                                    filteredTasks.add(transformedTask);
+                                }
+
+                            }
+                            else if (valueObj instanceof Map) {
+                                Map<String, Object> nestedMap = (Map<String, Object>) valueObj;
+                                Object stateFromNested = nestedMap.get("state");
+                                if (stateFromNested instanceof String) {
+                                    String state = ((String) stateFromNested).toUpperCase();
+                                    if (stateToFilter.equals(state)) {
+                                        transformedTask.put("state", state);
+                                        transformedTask.put("value", "state");
+                                        filteredTasks.add(transformedTask);
+                                    }
+                                }
+                            }
+                        } else if (valueObj instanceof Map) {
+                            Map<String, Object> nestedMap = (Map<String, Object>) valueObj;
+                            Object stateFromNested = nestedMap.get("state");
+                            if (stateFromNested instanceof String) {
+                                String state = ((String) stateFromNested).toUpperCase();
+                                if (stateToFilter.equals(state)) {
+                                    transformedTask.put("state", state);
+                                    transformedTask.put("value", key);
+                                    filteredTasks.add(transformedTask);
+                                }
+                            }
+                        }
+                    });
+                }
+            });
+        }
+
+        return filteredTasks;
+    }
+}

--- a/core/src/test/resources/flows/invalids/foreach-switch-failed.yaml
+++ b/core/src/test/resources/flows/invalids/foreach-switch-failed.yaml
@@ -1,0 +1,23 @@
+id: foreach-switch-failed
+namespace: io.kestra.tests
+
+tasks:
+  - id: foreach
+    type: io.kestra.plugin.core.flow.ForEach
+    values: [1,2]
+    tasks:
+      - id: switch
+        type: io.kestra.plugin.core.flow.Switch
+        value: "{{ taskrun.value  }}"
+        cases:
+          1:
+            - id: log
+              type: io.kestra.plugin.core.log.Log
+              message: "hello"
+          2:
+            - id: fail
+              type: io.kestra.plugin.core.execution.Fail
+    errors:
+      - id: errorforeach
+        type: io.kestra.plugin.core.debug.Return
+        format: "{{ tasksWithState('failed') }}"


### PR DESCRIPTION
I've then implemented a new method `taskWithState` that basically help to filter easily the task list and display it in a more readable format:

![image](https://github.com/user-attachments/assets/a8d32707-8aa1-4475-a4c7-a02f7bbbc69d)

This also handle when the value is "state"

close #5653 