### PR TITLE
Improve performance for MapUtils

### DIFF
--- a/jmh-benchmarks/README.md
+++ b/jmh-benchmarks/README.md
@@ -1,0 +1,17 @@
+# JMH-Benchmarks module
+
+This module contains benchmarks written using JMH from OpenJDK.
+
+## Running Benchmarks
+
+**To run all benchmarks**
+
+```bash
+./gradlew jmh:jmh
+```
+
+**To run a specific benchmark**
+
+```bash
+./gradlew jmh:jmh -Pjmh.include=io.kestra.core.utils.MapUtilsBenchmark
+```

--- a/jmh-benchmarks/build.gradle
+++ b/jmh-benchmarks/build.gradle
@@ -1,0 +1,22 @@
+plugins {
+    id "me.champeau.jmh" version "0.7.2"
+}
+
+configurations {
+    tests
+    implementation.extendsFrom(micronaut)
+}
+
+tasks.register('copyGradleProperties', Copy) {
+    group = "build"
+    shouldRunAfter compileJava
+
+    from '../gradle.properties'
+    into 'src/main/resources'
+}
+
+processResources.dependsOn copyGradleProperties
+
+dependencies {
+    jmh project(':core')
+}

--- a/jmh-benchmarks/src/jmh/java/io/kestra/core/utils/MapUtilsBenchmark.java
+++ b/jmh-benchmarks/src/jmh/java/io/kestra/core/utils/MapUtilsBenchmark.java
@@ -1,0 +1,32 @@
+package io.kestra.core.utils;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import org.openjdk.jmh.annotations.*;
+
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@State(Scope.Thread)
+public class MapUtilsBenchmark {
+    private Map<String, Object> mapA;
+    private Map<String, Object> mapB;
+
+    @Setup(Level.Invocation)
+    public void setup() {
+        mapA = new HashMap<>();
+        mapB = new HashMap<>();
+        for (int i = 0; i < 100; i++) {
+            mapA.put("key" + i, "valueA" + i);
+            mapB.put("key" + i, "valueB" + i);
+        }
+        mapA.put("nested", Map.of("a", 1));
+        mapB.put("nested", Map.of("b", 2));
+    }
+
+    @Benchmark
+    public Map<String, Object> testMerge() {
+        return MapUtils.merge(mapA, mapB);
+    }
+}

--- a/jmh-benchmarks/src/jmh/java/io/kestra/core/utils/MapUtilsBenchmark.java
+++ b/jmh-benchmarks/src/jmh/java/io/kestra/core/utils/MapUtilsBenchmark.java
@@ -25,6 +25,9 @@ public class MapUtilsBenchmark {
         mapB.put("nested", Map.of("b", 2));
     }
 
+    /**
+     * @see <a href="https://github.com/kestra-io/kestra/pull/8914">KESTRA#8914</a>
+     */
     @Benchmark
     public Map<String, Object> testMerge() {
         return MapUtils.merge(mapA, mapB);

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,4 +1,4 @@
-rootProject.name="kestra"
+rootProject.name = "kestra"
 
 include 'platform'
 
@@ -24,3 +24,4 @@ include 'processor'
 include 'script'
 include 'e2e-tests'
 
+include 'jmh-benchmarks'


### PR DESCRIPTION
## Testing with JMH

Warmup: 5 iterations, 10 s each
Measurement: 5 iterations, 10 s each
Timeout: 10 min per iteration
Threads: 1 thread, will synchronize iteration

**Before**
(min, avg, max) = (26.135, 27.007, 27.619)

**After**
(min, avg, max) = (23.073, 23.427, 24.423)

~13% performance gain

## Testing with Flow (standalone instance):

```yaml
id: hummingbird_941521
namespace: company.team

tasks:

  - id: foreach
    type: io.kestra.plugin.core.flow.ForEach
    values: "{{range(1, 160)}}"
    concurrencyLimit: 0
    tasks:
      - id: log
        type: io.kestra.plugin.core.log.Log
        message: Some log
```
**Before**: Avg: 21.36
**After**: Avg: 16.96

~20% performance gain
