### PR TITLE
fix(core): prevent multiple tabs for adding tasks to create duplicate entries

### DIFF
--- a/ui/src/components/code/segments/Task.vue
+++ b/ui/src/components/code/segments/Task.vue
@@ -23,7 +23,7 @@
             :disabled="(errors?.length ?? 0) > 0"
             @click="() => {
                 saveTask();
-                exitTaskElement();
+                exitTask();
             }"
             :what="section"
             class="w-100 mt-3"
@@ -79,6 +79,16 @@
             component: breadcrumbs.value?.[index]?.component,
         };
     });
+
+    const exitTask = () => {
+        /*
+            Removing the created task from the store, so it would not overlap with other creation tabs.
+            See https://github.com/kestra-io/kestra/issues/8781 for more details.
+        */
+        store.commit("flow/removeCreatedTask", {section: section.value, index: taskCreationIndex.value - 1});
+
+        exitTaskElement();
+    };
 
     const yaml = taskCreationIndex.value ? computed({
         get() {

--- a/ui/src/stores/flow.js
+++ b/ui/src/stores/flow.js
@@ -685,6 +685,10 @@ export default {
                 state.createdTasks[section] = []
             }
             state.createdTasks[section][index] = rest
+        },
+        removeCreatedTask(state, payload) {
+            const {section, index} = payload;
+            state.createdTasks[section]?.splice(index, 1);
         }
     },
     getters: {


### PR DESCRIPTION
Steps to reproduce the problem:

- From the `No Code` editor click `Add Task` button. It will open the new tab.
- Return to main `No Code` tab and click same `Add Task` button again.
- Now select type and input `id` of the new task and click close after that.
- Switch over to other opened `Add Task` tab, and select type.
- It will add the first (already added) task again.

This change is preventing that from happening.

Closes https://github.com/kestra-io/kestra/issues/8781.
Closes https://github.com/kestra-io/kestra/issues/8926.