### PR TITLE
feat(system): don't deepClone maps inside MapUtils.merge

### DIFF
--- a/core/src/main/java/io/kestra/core/services/PluginDefaultService.java
+++ b/core/src/main/java/io/kestra/core/services/PluginDefaultService.java
@@ -568,9 +568,9 @@ public class PluginDefaultService {
 
         for (PluginDefault pluginDefault : matching) {
             if (pluginDefault.isForced()) {
-                result = MapUtils.merge(result, pluginDefault.getValues());
+                result = MapUtils.deepMerge(result, pluginDefault.getValues());
             } else {
-                result = MapUtils.merge(pluginDefault.getValues(), result);
+                result = MapUtils.deepMerge(pluginDefault.getValues(), result);
             }
         }
 

--- a/core/src/main/java/io/kestra/plugin/core/state/AbstractState.java
+++ b/core/src/main/java/io/kestra/plugin/core/state/AbstractState.java
@@ -69,7 +69,7 @@ public abstract class AbstractState extends Task {
             current = Map.of();
         }
 
-        Map<String, Object> merge = MapUtils.merge(current, runContext.render(map));
+        Map<String, Object> merge = MapUtils.deepMerge(current, runContext.render(map));
 
         String key = runContext.stateStore().putState(
             !runContext.render(this.namespace).as(Boolean.class).orElseThrow(),

--- a/core/src/main/java/io/kestra/plugin/core/trigger/Flow.java
+++ b/core/src/main/java/io/kestra/plugin/core/trigger/Flow.java
@@ -35,7 +35,6 @@ import io.kestra.core.models.executions.ExecutionTrigger;
 import io.kestra.core.models.flows.State;
 import io.kestra.core.models.triggers.AbstractTrigger;
 import io.kestra.core.models.triggers.TriggerOutput;
-import io.kestra.core.runners.RunContext;
 import io.kestra.core.utils.IdUtils;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.stream.Streams;
@@ -255,7 +254,7 @@ public class Flow extends AbstractTrigger implements TriggerOutput<Flow.Output> 
             for (String id : multipleConditionIds) {
                 Optional<MultipleConditionWindow> multipleConditionWindow = multipleConditionStorage.get().get(flow, id);
                 if (multipleConditionWindow.isPresent()) {
-                    outputs = MapUtils.merge(outputs, multipleConditionWindow.get().getOutputs());
+                    outputs = MapUtils.deepMerge(outputs, multipleConditionWindow.get().getOutputs());
                 }
             }
         }

--- a/core/src/test/java/io/kestra/core/utils/MapUtilsTest.java
+++ b/core/src/test/java/io/kestra/core/utils/MapUtilsTest.java
@@ -47,6 +47,40 @@ class MapUtilsTest {
 
     @SuppressWarnings("unchecked")
     @Test
+    void deepMerge() {
+        Map<String, Object> a = Map.of(
+            "map", Map.of(
+                "map_a", "a",
+                "map_b", "b",
+                "map_c", "c"
+            ),
+            "string", "a",
+            "int", 1,
+            "lists", Collections.singletonList(1)
+        );
+
+        Map<String, Object> b = Map.of(
+            "map", Map.of(
+                "map_c", "e",
+                "map_d", "d"
+            ),
+            "string", "b",
+            "float", 1F,
+            "lists", Collections.singletonList(2)
+        );
+
+        Map<String, Object> merge = MapUtils.deepMerge(a, b);
+
+        assertThat(((Map<String, Object>) merge.get("map")).size()).isEqualTo(4);
+        assertThat(((Map<String, Object>) merge.get("map")).get("map_c")).isEqualTo("e");
+        assertThat(merge.get("string")).isEqualTo("b");
+        assertThat(merge.get("int")).isEqualTo(1);
+        assertThat(merge.get("float")).isEqualTo(1F);
+        assertThat((List<?>) merge.get("lists")).hasSize(2);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
     void mergeWithNull() {
         var mapWithNull = new HashMap<String, String>();
         mapWithNull.put("null", null);
@@ -66,6 +100,33 @@ class MapUtilsTest {
         );
 
         Map<String, Object> merge = MapUtils.merge(a, b);
+
+        assertThat(((Map<String, Object>) merge.get("map")).size()).isEqualTo(3);
+        assertThat(((Map<String, Object>) merge.get("map")).get("map_c")).isEqualTo("e");
+        assertThat(((Map<String, Object>) ((Map<String, Object>) ((Map<String, Object>) merge.get("map")).get("map_a")).get("sub")).get("null")).isNull();
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    void deepMergeWithNull() {
+        var mapWithNull = new HashMap<String, String>();
+        mapWithNull.put("null", null);
+
+        Map<String, Object> a = Map.of(
+            "map", Map.of(
+                "map_a", Map.of("sub", mapWithNull),
+                "map_c", "c"
+            )
+        );
+
+        Map<String, Object> b = Map.of(
+            "map", Map.of(
+                "map_c", "e",
+                "map_d", "d"
+            )
+        );
+
+        Map<String, Object> merge = MapUtils.deepMerge(a, b);
 
         assertThat(((Map<String, Object>) merge.get("map")).size()).isEqualTo(3);
         assertThat(((Map<String, Object>) merge.get("map")).get("map_c")).isEqualTo("e");

--- a/jdbc/src/main/java/io/kestra/jdbc/runner/JdbcExecutor.java
+++ b/jdbc/src/main/java/io/kestra/jdbc/runner/JdbcExecutor.java
@@ -796,7 +796,7 @@ public class JdbcExecutor implements ExecutorInterface, Service {
                         // This is important to avoid races such as RUNNING that arrives after the first SUCCESS/FAILED.
                         RunContext runContext = runContextFactory.of(flow, task, current.getExecution(), message.getParentTaskRun());
                         taskRun = execution.findTaskRunByTaskRunId(message.getParentTaskRun().getId()).withState(message.getState());
-                        Map<String, Object> outputs = MapUtils.merge(taskRun.getOutputs(), message.getParentTaskRun().getOutputs());
+                        Map<String, Object> outputs = MapUtils.deepMerge(taskRun.getOutputs(), message.getParentTaskRun().getOutputs());
                         Variables variables = variablesService.of(StorageContext.forTask(taskRun), outputs);
                         taskRun = taskRun.withOutputs(variables);
                         taskRun = ExecutableUtils.manageIterations(

--- a/jmh-benchmarks/README.md
+++ b/jmh-benchmarks/README.md
@@ -7,11 +7,11 @@ This module contains benchmarks written using JMH from OpenJDK.
 **To run all benchmarks**
 
 ```bash
-./gradlew jmh:jmh
+./gradlew jmh
 ```
 
 **To run a specific benchmark**
 
 ```bash
-./gradlew jmh:jmh -Pjmh.include=io.kestra.core.utils.MapUtilsBenchmark
+./gradlew jmh -Pjmh.include=io.kestra.core.utils.MapUtilsBenchmark
 ```

--- a/jmh-benchmarks/src/jmh/java/io/kestra/core/utils/MapUtilsBenchmark.java
+++ b/jmh-benchmarks/src/jmh/java/io/kestra/core/utils/MapUtilsBenchmark.java
@@ -1,6 +1,7 @@
 package io.kestra.core.utils;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
@@ -21,12 +22,17 @@ public class MapUtilsBenchmark {
             mapA.put("key" + i, "valueA" + i);
             mapB.put("key" + i, "valueB" + i);
         }
-        mapA.put("nested", Map.of("a", 1));
-        mapB.put("nested", Map.of("b", 2));
+        for (int i = 0; i < 10; i++) {
+            mapA.put("nested" + i, Map.of("a", i));
+            mapB.put("nested" + i, Map.of("b", i));
+        }
+        mapA.put("deepNested", Map.of("deepNested", Map.of("deepNested", "deepNestedA", "collection", List.of("mapA"))));
+        mapB.put("deepNested", Map.of("deepNested", Map.of("deepNested", "deepNestedB", "collection", List.of("mapB"))));
     }
 
     /**
      * @see <a href="https://github.com/kestra-io/kestra/pull/8914">KESTRA#8914</a>
+     * @see <a href="https://github.com/kestra-io/kestra/pull/8917">KESTRA#8917</a>
      */
     @Benchmark
     public Map<String, Object> testMerge() {


### PR DESCRIPTION
removing deepClone brings vast improvements when there are a lot of taskRuns with outputs.

This PR must wait more analysis to understand if this deepClone is needed or if it was conservative programming that could be relaxed.