### PR TITLE
feat(core): save individual namespace files from multi panel editor

### DIFF
--- a/ui/src/components/inputs/Editor.vue
+++ b/ui/src/components/inputs/Editor.vue
@@ -529,6 +529,8 @@
         top: 8px;
         right: 20px;
         z-index: 10;
+        color: var(--ks-content-secondary);
+        cursor: pointer;
     }
 
     .editor-absolute-container > * {

--- a/ui/src/components/inputs/EditorWrapper.vue
+++ b/ui/src/components/inputs/EditorWrapper.vue
@@ -16,6 +16,7 @@
     >
         <template #absolute>
             <KeyShortcuts v-if="isCurrentTabFlow" />
+            <ContentSave v-else @click="saveFileContent" />
         </template>
     </editor>
 </template>
@@ -25,6 +26,8 @@
     import {useStore} from "vuex";
     import Editor from "./Editor.vue";
     import KeyShortcuts from "./KeyShortcuts.vue";
+
+    import ContentSave from "vue-material-design-icons/ContentSave.vue";
 
     import {YamlUtils as YAML_UTILS} from "@kestra-io/ui-libs";
 
@@ -187,6 +190,18 @@
         return store.dispatch("flow/save", {
             content: editorDomElement.value.$refs.monacoEditor.value,
         })
+    }
+
+    const saveFileContent =  async ()=>{
+        await store.dispatch("namespace/createFile", {
+            namespace: namespace.value,
+            path: props.path,
+            content: editorDomElement.value.modelValue,
+        });
+        store.commit("editor/setTabDirty", {
+            path: props.path,
+            dirty: false
+        });
     }
 
     const execute = () => {

--- a/ui/src/components/inputs/KeyShortcuts.vue
+++ b/ui/src/components/inputs/KeyShortcuts.vue
@@ -6,7 +6,7 @@
         effect="light"
         placement="top"
     >
-        <Keyboard @click="isShown = true" class="keyboard" />
+        <Keyboard @click="isShown = true" />
     </el-tooltip>
 
     <el-dialog v-model="isShown" top="25vh" header-class="p-3" body-class="p-2">
@@ -103,11 +103,6 @@
 </script>
 
 <style scoped lang="scss">
-.keyboard {
-    color: var(--ks-content-secondary);
-    cursor: pointer;
-}
-
 .el-tag {
     background-color: var(--ks-tag-background);
     color: var(--ks-tag-content);

--- a/ui/src/stores/flow.js
+++ b/ui/src/stores/flow.js
@@ -82,7 +82,7 @@ export default {
                     return res
                 });
             } else {
-                if(!currentTab.dirty) return;
+                if(!currentTab?.dirty) return;
 
                 await dispatch("namespace/createFile", {
                     namespace: namespace ?? getters.namespace,


### PR DESCRIPTION
Closes https://github.com/kestra-io/kestra/issues/8923.

Each namespace file tab opened now will have a floating save button in the top right corner which will save only that file and nothing else.

![image](https://github.com/user-attachments/assets/532fd0b6-e034-43f0-acbb-e9134705cb85)