### PR TITLE
chore(core): add retry block to no code editor

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "dependencies": {
         "@js-joda/core": "^5.6.5",
-        "@kestra-io/ui-libs": "^0.0.194",
+        "@kestra-io/ui-libs": "^0.0.196",
         "@vue-flow/background": "^1.3.2",
         "@vue-flow/controls": "^1.1.2",
         "@vue-flow/core": "^1.44.0",
@@ -2630,9 +2630,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@kestra-io/ui-libs": {
-      "version": "0.0.194",
-      "resolved": "https://registry.npmjs.org/@kestra-io/ui-libs/-/ui-libs-0.0.194.tgz",
-      "integrity": "sha512-sh57BdCNrzVrBtb1/RIqdXR8qrqWXRtR85KtkHyfbG1xzP+Z90r+gaQhTorn/VlY4epAUwS8AV/jwP0LoVhPxw==",
+      "version": "0.0.196",
+      "resolved": "https://registry.npmjs.org/@kestra-io/ui-libs/-/ui-libs-0.0.196.tgz",
+      "integrity": "sha512-wOKteJX4yNc/MRyCOupMZdZdYk45/wJKYoywqMWhBrkg3ulzQpH2ykBPpgXFafTqjo0kyBCAyP+MKHtH/mikaw==",
       "dependencies": {
         "@nuxtjs/mdc": "^0.16.1",
         "@popperjs/core": "^2.11.8",

--- a/ui/package.json
+++ b/ui/package.json
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "@js-joda/core": "^5.6.5",
-    "@kestra-io/ui-libs": "^0.0.194",
+    "@kestra-io/ui-libs": "^0.0.196",
     "@vue-flow/background": "^1.3.2",
     "@vue-flow/controls": "^1.1.2",
     "@vue-flow/core": "^1.44.0",

--- a/ui/src/components/code/segments/Editor.vue
+++ b/ui/src/components/code/segments/Editor.vue
@@ -63,6 +63,7 @@
 
     import Editor from "../../inputs/Editor.vue";
     import MetadataInputs from "../../flows/MetadataInputs.vue";
+    import MetadataRetry from "../../flows/MetadataRetry.vue";
     import TaskBasic from "../../flows/tasks/TaskBasic.vue";
 
     import {
@@ -149,15 +150,9 @@
                 label: t("no_code.fields.main.description"),
             },
             retry: {
-                component: Editor,
+                component: MetadataRetry,
                 value: props.metadata.retry,
-                label: t("no_code.fields.general.retry"),
-                navbar: false,
-                input: true,
-                lang: "yaml",
-                shouldFocus: false,
-                showScroll: true,
-                style: {height: "100px"},
+                label: t("no_code.fields.general.retry")
             },
             labels: {
                 component: InputPair,

--- a/ui/src/components/code/utils/types.ts
+++ b/ui/src/components/code/utils/types.ts
@@ -48,7 +48,7 @@ export type Fields = {
     id: Field;
     namespace: Field;
     description: Field;
-    retry: EditorField;
+    retry: Field;
     labels: PairField;
     inputs: InputField;
     outputs: EditorField;

--- a/ui/src/components/flows/MetadataRetry.vue
+++ b/ui/src/components/flows/MetadataRetry.vue
@@ -1,0 +1,156 @@
+<template>
+    <span class="label">{{ props.label }}</span>
+    <div class="mt-1 mb-2 wrapper">
+        <TaskAnyOf
+            :model-value="props.modelValue"
+            :schema
+            :definitions
+            @update:model-value="emits('update:modelValue', $event)"
+            @any-of-type="emits('update:modelValue', undefined)"
+            wrap
+        />
+    </div>
+</template>
+
+<script setup lang="ts">
+    import TaskAnyOf from "./tasks/TaskAnyOf.vue";
+
+    const emits = defineEmits(["update:modelValue"]);
+
+    const props = defineProps({
+        modelValue: {type: Object, default: () => ({})},
+        label: {type: String, required: true},
+    });
+
+    // FIXME: Properly fetch and parse the schema and definitions
+    const schema = {
+        anyOf: [
+            {
+                $ref: "#/definitions/io.kestra.core.models.tasks.retrys.Constant-2",
+            },
+            {
+                $ref: "#/definitions/io.kestra.core.models.tasks.retrys.Exponential-2",
+            },
+            {
+                $ref: "#/definitions/io.kestra.core.models.tasks.retrys.Random-2",
+            },
+        ],
+    };
+
+    const definitions = {
+        "io.kestra.core.models.tasks.retrys.Random-2": {
+            type: "object",
+            properties: {
+                behavior: {
+                    type: "string",
+                    enum: ["RETRY_FAILED_TASK", "CREATE_NEW_EXECUTION"],
+                    default: "RETRY_FAILED_TASK",
+                    markdownDescription: "Default value is : `RETRY_FAILED_TASK`",
+                },
+                maxAttempt: {
+                    type: "integer",
+                    minimum: 1,
+                },
+                maxDuration: {
+                    type: "string",
+                    format: "duration",
+                },
+                maxInterval: {
+                    type: "string",
+                    format: "duration",
+                },
+                minInterval: {
+                    type: "string",
+                    format: "duration",
+                },
+                type: {
+                    type: "string",
+                    enum: ["exponential"],
+                },
+                warningOnRetry: {
+                    type: "boolean",
+                    default: false,
+                    markdownDescription: "Default value is : `false`",
+                },
+            },
+            required: ["type", "maxInterval", "minInterval"],
+        },
+        "io.kestra.core.models.tasks.retrys.Exponential-2": {
+            type: "object",
+            properties: {
+                behavior: {
+                    type: "string",
+                    enum: ["RETRY_FAILED_TASK", "CREATE_NEW_EXECUTION"],
+                    default: "RETRY_FAILED_TASK",
+                    markdownDescription: "Default value is : `RETRY_FAILED_TASK`",
+                },
+                delayFactor: {
+                    type: "number",
+                },
+                interval: {
+                    type: "string",
+                    format: "duration",
+                },
+                maxAttempt: {
+                    type: "integer",
+                    minimum: 1,
+                },
+                maxDuration: {
+                    type: "string",
+                    format: "duration",
+                },
+                maxInterval: {
+                    type: "string",
+                    format: "duration",
+                },
+                type: {
+                    type: "string",
+                    enum: ["exponential"],
+                },
+                warningOnRetry: {
+                    type: "boolean",
+                    default: false,
+                    markdownDescription: "Default value is : `false`",
+                },
+            },
+            required: ["type", "interval", "maxInterval"],
+        },
+        "io.kestra.core.models.tasks.retrys.Constant-2": {
+            type: "object",
+            properties: {
+                behavior: {
+                    type: "string",
+                    enum: ["RETRY_FAILED_TASK", "CREATE_NEW_EXECUTION"],
+                    default: "RETRY_FAILED_TASK",
+                    markdownDescription: "Default value is : `RETRY_FAILED_TASK`",
+                },
+                interval: {
+                    type: "string",
+                    format: "duration",
+                },
+                maxAttempt: {
+                    type: "integer",
+                    minimum: 1,
+                },
+                maxDuration: {
+                    type: "string",
+                    format: "duration",
+                },
+                type: {
+                    type: "string",
+                    enum: ["constant"],
+                },
+                warningOnRetry: {
+                    type: "boolean",
+                    default: false,
+                    markdownDescription: "Default value is : `false`",
+                },
+            },
+            required: ["type", "interval"],
+        },
+    };
+</script>
+
+<style scoped lang="scss">
+@import "../code/styles/code.scss";
+</style>

--- a/ui/src/components/flows/tasks/TaskAnyOf.vue
+++ b/ui/src/components/flows/tasks/TaskAnyOf.vue
@@ -1,35 +1,72 @@
 <template>
-    <el-form-item class="radio-wrapper">
-        <el-radio-group v-model="selectedSchema" @change="onSelectType">
-            <el-radio
-                v-for="schema in schemaOptions"
-                :key="schema.label"
-                :value="schema.value"
-            >
-                {{ schema.label }}
-            </el-radio>
-        </el-radio-group>
-    </el-form-item>
-    <el-form label-position="top" v-if="selectedSchema">
-        <component
-            :is="`task-${currentSchemaType}`"
-            v-if="currentSchema"
-            :model-value="modelValue"
-            :schema="currentSchema"
-            :properties="currentSchema?.properties"
-            :definitions="definitions"
-            @update:model-value="onInput"
-        />
-    </el-form>
+    <TaskWrapper v-if="wrap">
+        <template #tasks>
+            <el-form-item class="radio-wrapper">
+                <el-radio-group v-model="selectedSchema" @change="onSelectType">
+                    <el-radio
+                        v-for="schema in schemaOptions"
+                        :key="schema.label"
+                        :value="schema.value"
+                    >
+                        {{ schema.label }}
+                    </el-radio>
+                </el-radio-group>
+            </el-form-item>
+            <el-form label-position="top" v-if="selectedSchema">
+                <component
+                    :is="`task-${currentSchemaType}`"
+                    v-if="currentSchema"
+                    :model-value="modelValue"
+                    :schema="currentSchema"
+                    :properties="currentSchema?.properties"
+                    :definitions="definitions"
+                    @update:model-value="onInput"
+                />
+            </el-form>
+        </template>
+    </TaskWrapper>
+
+    <template v-else>
+        <el-form-item class="radio-wrapper">
+            <el-radio-group v-model="selectedSchema" @change="onSelectType">
+                <el-radio
+                    v-for="schema in schemaOptions"
+                    :key="schema.label"
+                    :value="schema.value"
+                >
+                    {{ schema.label }}
+                </el-radio>
+            </el-radio-group>
+        </el-form-item>
+        <el-form label-position="top" v-if="selectedSchema">
+            <component
+                :is="`task-${currentSchemaType}`"
+                v-if="currentSchema"
+                :model-value="modelValue"
+                :schema="currentSchema"
+                :properties="currentSchema?.properties"
+                :definitions="definitions"
+                @update:model-value="onInput"
+            />
+        </el-form>
+    </template>
 </template>
 
 <script>
     import Task from "./Task";
+    import TaskWrapper from "./TaskWrapper.vue";
 
     export default {
         inheritAttrs: false,
         mixins: [Task],
-        emits: ["update:modelValue"],
+        emits: ["update:modelValue", "any-of-type"],
+        components: {TaskWrapper},
+        props: {
+            wrap: {
+                type: Boolean,
+                default: true,
+            },
+        },
         data() {
             return {
                 isOpen: false,
@@ -49,6 +86,7 @@
         },
         methods: {
             onSelectType(value) {
+                this.$emit("any-of-type", value);
                 this.selectedSchema = value;
                 // Set up default values
                 if (
@@ -109,7 +147,7 @@
                     );
 
                     return {
-                        label: lastPartOfValue.capitalize(),
+                        label: lastPartOfValue.split("-")[0].capitalize(),
                         value: schemaRef,
                         id: lastPartOfValue.toLowerCase(),
                     };

--- a/ui/src/translations/en.json
+++ b/ui/src/translations/en.json
@@ -1191,6 +1191,7 @@
         },
         "general": {
           "retry": "Retry",
+          "sla": "SLA",
           "labels": "Labels",
           "inputs": "Inputs",
           "outputs": "Outputs",


### PR DESCRIPTION
Far from ideal solution, but as we'll try to create flow properties from the fetched schema right after the release, add this as is.

Closes https://github.com/kestra-io/kestra/issues/7031.