### PR TITLE
fix(ui): improve padding and font sizes on Blueprints tab in Editor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,8 @@ yarn.lock
 ui/node_modules
 ui/.env.local
 ui/.env.*.local
+ui/package.json
+ui/package-lock.json
 webserver/src/main/resources/ui
 yarn.lock
 ui/coverage
@@ -59,3 +61,5 @@ core/src/main/resources/gradle.properties
 
 *storybook.log
 storybook-static
+
+dev-tools/*

--- a/.gitignore
+++ b/.gitignore
@@ -31,8 +31,6 @@ yarn.lock
 ui/node_modules
 ui/.env.local
 ui/.env.*.local
-ui/package.json
-ui/package-lock.json
 webserver/src/main/resources/ui
 yarn.lock
 ui/coverage
@@ -61,5 +59,3 @@ core/src/main/resources/gradle.properties
 
 *storybook.log
 storybook-static
-
-dev-tools/*

--- a/cli/src/main/resources/application.yml
+++ b/cli/src/main/resources/application.yml
@@ -16,12 +16,6 @@ micronaut:
         paths: classpath:static
         mapping: /static/**
   server:
-    cors:
-      enabled: true
-      configurations:
-        all:
-          allowOrigin:
-            - http://localhost:5173
     max-request-size: 10GB
     multipart:
       max-file-size: 10GB

--- a/cli/src/main/resources/application.yml
+++ b/cli/src/main/resources/application.yml
@@ -16,6 +16,12 @@ micronaut:
         paths: classpath:static
         mapping: /static/**
   server:
+    cors:
+      enabled: true
+      configurations:
+        all:
+          allowOrigin:
+            - http://localhost:5173
     max-request-size: 10GB
     multipart:
       max-file-size: 10GB

--- a/ui/src/components/flows/blueprints/BlueprintDetail.vue
+++ b/ui/src/components/flows/blueprints/BlueprintDetail.vue
@@ -270,7 +270,7 @@
 
         h4 {
             margin-top: calc($spacer * 2);
-            margin-bottom: 0;
+            //margin-bottom: 0; 
             font-weight: normal;
         }
 

--- a/ui/src/components/flows/blueprints/BlueprintDetail.vue
+++ b/ui/src/components/flows/blueprints/BlueprintDetail.vue
@@ -14,10 +14,12 @@
         <div class="header d-flex">
             <button class="back-button align-self-center">
                 <el-icon size="medium" @click="goBack">
-                    <ArrowLeft />
+                    <ChevronLeft />
                 </el-icon>
             </button>
-            {{ $t('Blueprints') }}
+            <span class="header-title align-self-center">
+                {{ $t('Blueprints') }}
+            </span>
         </div>
         <div>
             <h2 class="blueprint-title align-self-center">
@@ -83,8 +85,7 @@
 </template>
 <script setup>
     import {YamlUtils as YAML_UTILS} from "@kestra-io/ui-libs";
-
-    import ArrowLeft from "vue-material-design-icons/ArrowLeft.vue";
+    import ChevronLeft from "vue-material-design-icons/ChevronLeft.vue";
     import Editor from "../../inputs/Editor.vue";
     import LowCodeEditor from "../../inputs/LowCodeEditor.vue";
     import TaskIcon from  "@kestra-io/ui-libs/src/components/misc/TaskIcon.vue";
@@ -237,15 +238,27 @@
             }
 
             .back-button {
-                padding-left: 0;
-                padding-right: calc($spacer * 1.5);
+                margin-left: 0;
+                margin-right: calc($spacer);
                 cursor: pointer;
                 border: none;
-                background: none;
+                background: var(--ks-background-card);
                 display: flex;
                 align-items: center;
+                border-radius: var(--bs-border-radius); // 加圓角
+                padding: 8px;
                 :deep(.material-design-icon) {
-                    font-size: $h4-font-size;
+                    position: absolute;
+                    top: 50%;
+                    left: 50%;
+                    transform: translate(-50%, -50%);
+                }
+
+                :deep(.header-tittle) {
+                    font-size: 1.25rem;
+                    font-weight: 600;
+                    line-height: 1;
+                    margin: 0;
                 }
             }
 
@@ -270,7 +283,7 @@
 
         h4 {
             margin-top: calc($spacer * 2);
-            //margin-bottom: 0; 
+            //margin-bottom: 0;
             font-weight: normal;
         }
 

--- a/ui/src/components/flows/blueprints/BlueprintDetail.vue
+++ b/ui/src/components/flows/blueprints/BlueprintDetail.vue
@@ -17,6 +17,9 @@
                     <ArrowLeft />
                 </el-icon>
             </button>
+            {{ $t('Blueprints') }}
+        </div>
+        <div>
             <h2 class="blueprint-title align-self-center">
                 {{ blueprint.title }}
             </h2>
@@ -219,7 +222,8 @@
     @import "@kestra-io/ui-libs/src/scss/variables";
 
     .header-wrapper {
-        margin-bottom: calc($spacer * 2);
+        margin-top: calc($spacer * 2);    // 32px (assuming $spacer = 1rem = 16px)
+        margin-bottom: $spacer;
 
         .el-card & {
             margin-top: 2.5rem;
@@ -246,7 +250,9 @@
             }
 
             .blueprint-title {
-                font-weight: bold;
+                font-weight: 600;
+                font-size: 20px;
+                line-height: 30px;
                 text-overflow: ellipsis;
                 overflow: hidden;
             }
@@ -265,7 +271,7 @@
         h4 {
             margin-top: calc($spacer * 2);
             margin-bottom: 0;
-            font-weight: bold;
+            font-weight: normal;
         }
 
         .embedded-topology {

--- a/ui/src/components/inputs/Editor.vue
+++ b/ui/src/components/inputs/Editor.vue
@@ -620,14 +620,14 @@
     .monaco-editor,
     .monaco-editor-background {
         outline: none;
-        background-color: $input-bg;
-        --vscode-editor-background: $input-bg;
-        --vscode-breadcrumb-background: $input-bg;
-        --vscode-editorGutter-background: $input-bg;
+        background-color: var(--ks-background-input);
+        --vscode-editor-background: var(--ks-background-input);
+        --vscode-breadcrumb-background: var(--ks-background-input);
+        --vscode-editorGutter-background: var(--ks-background-input);
     }
 
     .monaco-editor .margin {
-        background-color: $input-bg;
+        background-color: var(--ks-background-input);
     }
 }
 

--- a/ui/src/components/inputs/Editor.vue
+++ b/ui/src/components/inputs/Editor.vue
@@ -557,7 +557,7 @@
             padding-top: 7px;
 
             &.custom-dark-vs-theme {
-                background-color: $input-bg;
+                background-color: var(--ks-background-input);
             }
 
             &.theme-light {

--- a/ui/src/override/components/flows/blueprints/BlueprintsBrowser.vue
+++ b/ui/src/override/components/flows/blueprints/BlueprintsBrowser.vue
@@ -53,8 +53,8 @@
                         >
                             <div class="left">
                                 <div class="blueprint">
-                                    <div 
-                                        class="ps-0 title" 
+                                    <div
+                                        class="ps-0 title"
                                         :class="{'embed-title': embed, 'text-truncate': embed}"
                                     >
                                         {{ blueprint.title ?? blueprint.id }}
@@ -425,7 +425,7 @@
                     min-width: 0;
                     .title {
                         width: 500px;
-                        font-weight: bold;
+                        font-weight: normal;
                         font-size: $small-font-size;
                         padding-left: 0;
                         margin-right: 15px;
@@ -440,7 +440,7 @@
                         white-space: nowrap;
                         overflow: hidden;
                         text-overflow: ellipsis;
-                        
+
                     }
 
                     .tags {

--- a/ui/src/styles/layout/element-plus-overload.scss
+++ b/ui/src/styles/layout/element-plus-overload.scss
@@ -628,7 +628,7 @@ form.ks-horizontal {
                     }
                 }
                 &.is-active a{
-                    background-color: var(--ks-background-body);
+                    background-color: var(--ks-background-input);
                     color: var(--ks-content-link);
                     position: relative;
                     z-index: 1;

--- a/ui/src/styles/layout/element-plus-overload.scss
+++ b/ui/src/styles/layout/element-plus-overload.scss
@@ -600,6 +600,7 @@ form.ks-horizontal {
     }
 
     &.el-tabs--card{
+        margin-top: 32px; // fix 8950 , Improve padding
         .el-tabs__nav-wrap{
             margin-bottom: 1px; // fix tabs overflowing over the bottom line
         }


### PR DESCRIPTION
### What changes are being made and why?

#### Blueprint Browser
1. Added top spacing at Blueprint browser page.
2. Backgound color already changed as `ks-backgorund-input` at `MultiPanelTabs.vue`
3. Change bold titte blueprint to regular

#### Blueprint Detail Page
1. Added spacing at Blueprint detail page. 
2. Changed arrow icon and added "blueprints" tittle
3. Changed font tittle 
4. Changed backgorund color as `ks-backgorund-input`
5. Changed editor backgorund color as `ks-backgorund-input`
---

### How the changes have been QAed?

![image](https://github.com/user-attachments/assets/ce7bc2da-3d0f-4796-9ee6-e5ed9c0c64d9)

![image](https://github.com/user-attachments/assets/0f9c18e3-8a3f-4637-83ae-86652a84628b)

---

Remarks: 
This PR related to #8950 