### PR TITLE
chore(core): add sla block to no code editor

### DIFF
--- a/ui/src/components/code/segments/Editor.vue
+++ b/ui/src/components/code/segments/Editor.vue
@@ -64,6 +64,7 @@
     import Editor from "../../inputs/Editor.vue";
     import MetadataInputs from "../../flows/MetadataInputs.vue";
     import MetadataRetry from "../../flows/MetadataRetry.vue";
+    import MetadataSLA from "../../flows/MetadataSLA.vue";
     import TaskBasic from "../../flows/tasks/TaskBasic.vue";
 
     import {
@@ -189,6 +190,11 @@
                 label: t("no_code.fields.general.concurrency"),
                 schema: schema.value?.definitions?.["io.kestra.core.models.flows.Concurrency"] ?? {},
                 root: "concurrency",
+            },
+            sla: {
+                component: MetadataSLA,
+                value: props.metadata.sla ?? [],
+                label: t("no_code.fields.general.sla")
             },
             disabled: {
                 component: InputSwitch,

--- a/ui/src/components/code/utils/types.ts
+++ b/ui/src/components/code/utils/types.ts
@@ -54,6 +54,7 @@ export type Fields = {
     outputs: EditorField;
     variables: PairField;
     concurrency: ConcurrencyField;
+    sla: Field;
     disabled: Field;
 };
 

--- a/ui/src/components/flows/MetadataRetry.vue
+++ b/ui/src/components/flows/MetadataRetry.vue
@@ -2,17 +2,19 @@
     <span class="label">{{ props.label }}</span>
     <div class="mt-1 mb-2 wrapper">
         <TaskAnyOf
-            :model-value="props.modelValue"
+            :model-value="value"
             :schema
             :definitions
             @update:model-value="emits('update:modelValue', $event)"
-            @any-of-type="emits('update:modelValue', undefined)"
+            @any-of-type="changeType"
             wrap
         />
     </div>
 </template>
 
 <script setup lang="ts">
+    import {computed} from "vue";
+
     import TaskAnyOf from "./tasks/TaskAnyOf.vue";
 
     const emits = defineEmits(["update:modelValue"]);
@@ -20,6 +22,18 @@
     const props = defineProps({
         modelValue: {type: Object, default: () => ({})},
         label: {type: String, required: true},
+    });
+
+    const changeType = (v: any) => {
+        if (!v) return;
+
+        const type = definitions[v].properties.type.enum[0];
+        value.value = type ? {type} : {};
+    };
+
+    const value = computed({
+        get: () => props.modelValue,
+        set: (v) => emits("update:modelValue", v),
     });
 
     // FIXME: Properly fetch and parse the schema and definitions

--- a/ui/src/components/flows/MetadataSLA.vue
+++ b/ui/src/components/flows/MetadataSLA.vue
@@ -1,0 +1,123 @@
+<template>
+    <span class="label">{{ props.label }}</span>
+    <div class="mt-1 mb-2 wrapper">
+        <TaskAnyOf
+            :model-value="value"
+            :schema
+            :definitions
+            @update:model-value="emits('update:modelValue', [$event])"
+            @any-of-type="changeType"
+            wrap
+        />
+    </div>
+</template>
+
+<script setup lang="ts">
+    import {computed} from "vue";
+
+    import TaskAnyOf from "./tasks/TaskAnyOf.vue";
+
+    const emits = defineEmits(["update:modelValue"]);
+
+    const props = defineProps({
+        modelValue: {type: Array, default: () => []},
+        label: {type: String, required: true},
+    });
+
+    const changeType = (v: any) => {
+        if (!v) return;
+
+        const type = definitions[v].properties.type.enum[0];
+        value.value = type ? {type} : {};
+    };
+
+    const value = computed({
+        get: () => (props.modelValue.length > 0 ? props.modelValue[0] : {}),
+        set: (v) => emits("update:modelValue", [v]),
+    });
+
+    // FIXME: Properly fetch and parse the schema and definitions
+    const schema = {
+        anyOf: [
+            {
+                $ref: "#/definitions/io.kestra.core.models.flows.sla.types.ExecutionAssertionSLA-1",
+            },
+            {
+                $ref: "#/definitions/io.kestra.core.models.flows.sla.types.MaxDurationSLA-1",
+            },
+        ],
+    };
+
+    const definitions = {
+        "io.kestra.core.models.flows.sla.types.ExecutionAssertionSLA-1": {
+            type: "object",
+            properties: {
+                type: {
+                    type: "string",
+                    enum: ["EXECUTION_ASSERTION"],
+                },
+                id: {
+                    type: "string",
+                    minLength: 1,
+                },
+                assert: {
+                    type: "string",
+                    minLength: 1,
+                },
+                behavior: {
+                    type: "string",
+                    enum: ["FAIL", "CANCEL", "NONE"],
+                },
+                labels: {
+                    anyOf: [
+                        {
+                            type: "array",
+                            items: {},
+                        },
+                        {
+                            type: "object",
+                        },
+                    ],
+                },
+            },
+            required: ["type", "id,", "assert", "behavior"],
+        },
+        "io.kestra.core.models.flows.sla.types.MaxDurationSLA-1": {
+            type: "object",
+            properties: {
+                id: {
+                    type: "string",
+                    minLength: 1,
+                },
+                type: {
+                    type: "string",
+                    enum: ["MAX_DURATION"],
+                },
+                behavior: {
+                    type: "string",
+                    enum: ["FAIL", "CANCEL", "NONE"],
+                },
+                duration: {
+                    type: "string",
+                    format: "duration",
+                },
+                labels: {
+                    anyOf: [
+                        {
+                            type: "array",
+                            items: {},
+                        },
+                        {
+                            type: "object",
+                        },
+                    ],
+                },
+            },
+            required: ["id", "type", "behavior", "duration"],
+        },
+    };
+</script>
+
+<style scoped lang="scss">
+@import "../code/styles/code.scss";
+</style>

--- a/ui/src/components/flows/tasks/TaskAnyOf.vue
+++ b/ui/src/components/flows/tasks/TaskAnyOf.vue
@@ -86,7 +86,7 @@
         },
         methods: {
             onSelectType(value) {
-                this.$emit("any-of-type", value);
+                if(this.selectedSchema) this.$emit("any-of-type", value);
                 this.selectedSchema = value;
                 // Set up default values
                 if (


### PR DESCRIPTION
Far from ideal solution, but as we'll try to create flow properties from the fetched schema right after the release, add this as is.

Closes https://github.com/kestra-io/kestra/issues/7081.