### PR TITLE
fix(core): prevent cursor in code editor from jumping to top

### DIFF
--- a/ui/src/components/code/NoCodeWrapper.vue
+++ b/ui/src/components/code/NoCodeWrapper.vue
@@ -48,7 +48,7 @@
         (oldValue) => {
             try {
                 YAML_UTILS.parse(flowYaml.value);
-                return flowYaml.value;
+                return oldValue ?? flowYaml.value ?? "";
             } catch {
                 return oldValue ?? "";
             }


### PR DESCRIPTION
For the life of me, I could not solve this issue in any other way (this one proposed seems to be alright).

Problem here was that the `YAML_UTILS.parse(flowYaml.value);` was not failing if the object value is empty.

Used this flow for testing, and was playing around the `taskRunner` and its `cpus` property:

```yaml
id: docker_script_runner
namespace: company.team

tasks:
  - id: shell
    type: io.kestra.plugin.scripts.shell.Commands
    containerImage: centos
    taskRunner:
      type: io.kestra.plugin.scripts.runner.docker.Docker
      cpu:
        cpus: 1
    commands:
      - echo "Hello World!"
```

@elevatebart Could you validate that this is not breaking something I've missed, been looking at this for too long.

Closes https://github.com/kestra-io/kestra/issues/9013.