### PR TITLE
feat(core):  503 Service Unavailable status in error messages.

### DIFF
--- a/ui/src/components/ErrorToast.vue
+++ b/ui/src/components/ErrorToast.vue
@@ -28,6 +28,10 @@
                     return this.message.title;
                 }
 
+                if (this.message.response.status === 503) {
+                    return "503 Service Unavailable";
+                }
+
                 if (this.message.content && this.message.content.message && this.message.content.message.indexOf(":") > 0) {
                     return this.message.content.message.substring(0, this.message.content.message.indexOf(":"));
                 }
@@ -53,7 +57,7 @@
                 const error =  {
                     type: "ERROR",
                     error: {
-                        message: this.text,
+                        message: this.title,
                         errors: this.items,
                     },
                     page: pageFromRoute(this.$route)

--- a/ui/src/components/ErrorToastContainer.vue
+++ b/ui/src/components/ErrorToastContainer.vue
@@ -49,6 +49,9 @@
         components: {Slack},
         methods: {
             async renderMarkdown() {
+                if (this.message.response && this.message.response.status === 503) {
+                    return await Markdown.render("Server is temporarily unavailable. Please try again later.", {html: true});
+                }
                 return await Markdown.render(this.message.message || this.message.content.message, {html: true});
             },
         },


### PR DESCRIPTION
Closes #9107 

Reproduced the 503 response using `https://app.requestly.io/rules`.
When we will have `503` from server we will see something like this in UI

![image](https://github.com/user-attachments/assets/2ad5109a-731a-4d03-9e1f-dfbf1d85e022)
