### PR TITLE
fix(dashboards): change default dashboard yaml to include filtering in progress states

### DIFF
--- a/ui/src/assets/dashboard/default_flow_definition.yaml
+++ b/ui/src/assets/dashboard/default_flow_definition.yaml
@@ -160,6 +160,17 @@ charts:
         state:
           field: STATE
           displayName: State
+      where:
+        - type: IN
+          field: STATE
+          values:
+            - CREATED
+            - RESTARTED
+            - QUEUED
+            - RUNNING
+            - PAUSED
+            - RETRYING
+            - KILLING
 
   - id: next_executions
     type: io.kestra.plugin.core.dashboard.chart.Table

--- a/ui/src/assets/dashboard/default_main_definition.yaml
+++ b/ui/src/assets/dashboard/default_main_definition.yaml
@@ -150,6 +150,17 @@ charts:
         state:
           displayName: State
           field: STATE
+      where:
+        - type: IN
+          field: STATE
+          values:
+            - CREATED
+            - RESTARTED
+            - QUEUED
+            - RUNNING
+            - PAUSED
+            - RETRYING
+            - KILLING
 
   - id: next_executions
     type: io.kestra.plugin.core.dashboard.chart.Table

--- a/ui/src/assets/dashboard/default_namespace_definition.yaml
+++ b/ui/src/assets/dashboard/default_namespace_definition.yaml
@@ -150,6 +150,17 @@ charts:
         state:
           displayName: State
           field: STATE
+      where:
+        - type: IN
+          field: STATE
+          values:
+            - CREATED
+            - RESTARTED
+            - QUEUED
+            - RUNNING
+            - PAUSED
+            - RETRYING
+            - KILLING
 
   - id: next_executions
     type: io.kestra.plugin.core.dashboard.chart.Table


### PR DESCRIPTION
Those states will now be filtered for the `In Progress` table:

- `CREATED`
- `RESTARTED`
- `QUEUED`
- `RUNNING`
- `PAUSED`
- `RETRYING`
- `KILLING`

Closes https://github.com/kestra-io/kestra/issues/9125.