### PR TITLE
fix(core): update regex to correctly render the alert for embedded docs.

### DIFF
--- a/ui/src/components/layout/Markdown.vue
+++ b/ui/src/components/layout/Markdown.vue
@@ -24,7 +24,7 @@
 
     const sourceWithReplacedAlerts = computed(() => {
         return props.source.replace(
-            /(\n)?::alert\{type="(.*)"}\n([\s\S]*?)\n::(\n)?/g,
+            /(\n)?:\s*:\s*alert\{type="(.*?)"\}\s*\n([\s\S]*?)\n:\s*:(\n)?/g,
             (_, newLine1, type, content, newLine2) => `${newLine1 ?? ""}::: ${type}\n${content}\n:::${newLine2 ?? ""}`
         );
     })


### PR DESCRIPTION
Closes #8975

Review example: `/main/plugins/io.kestra.plugin.core.state.Set`