### PR TITLE
feat(execution): allow to wait for execution completion into a Webhook

### DIFF
--- a/core/src/test/resources/flows/valids/webhook-wait.yaml
+++ b/core/src/test/resources/flows/valids/webhook-wait.yaml
@@ -1,0 +1,19 @@
+id: webhook-wait
+namespace: io.kestra.tests
+
+triggers:
+  - id: webhook
+    type: io.kestra.plugin.core.trigger.Webhook
+    key: webhook
+    wait: true
+
+outputs:
+  - id: output
+    type: STRING
+    value: "{{outputs.hello.values.some}}"
+
+tasks:
+  - id: hello
+    type: io.kestra.plugin.core.output.OutputValues
+    values:
+      some: output


### PR DESCRIPTION
Webhook can now wait for an execution termination and return it.
It will only return execution outputs, not the full list of taskrun with outputs to avoid any security leak as webhook are always anonymous so a flow developer must define which outputs could be accessible by setting them in the flow outputs. 

It can be used with the following flow:
```yaml
id: hello-webhook
namespace: company.team

triggers:
  - id: webhook
    type: io.kestra.plugin.core.trigger.Webhook
    key: webhook
    wait: true

outputs:
  - id: output
    type: STRING
    value: "{{outputs.hello.values.some}}"

tasks:
  - id: hello
    type: io.kestra.plugin.core.output.OutputValues
    values:
      some: output
```

Example usage from `cURL` and `jq` to extract the execution outputs.

```shell
curl http://localhost:8080/api/v1/executions/webhook/company.team/hello-webhook/webhook | jq ".outputs"
```

Closes #10147