### PR TITLE
fix(system)*: don't include yourself as def in the JSONSchema

### DIFF
--- a/core/src/main/java/io/kestra/core/docs/JsonSchemaGenerator.java
+++ b/core/src/main/java/io/kestra/core/docs/JsonSchemaGenerator.java
@@ -666,6 +666,7 @@ public class JsonSchemaGenerator {
                 .flatMap(registeredPlugin -> registeredPlugin.getAdditionalPlugins().stream())
                 // for additional plugins, we have one subtype by type of additional plugins (for ex: embedding store for Langchain4J), so we need to filter on the correct subtype
                 .filter(cls -> declaredType.getErasedType().isAssignableFrom(cls))
+                .filter(cls -> cls != declaredType.getErasedType())
                 .filter(Predicate.not(io.kestra.core.models.Plugin::isInternal))
                 .map(typeContext::resolve)
                 .toList();


### PR DESCRIPTION
For AdditionalPlugin, as we resolves subtypes using isAssignable, we will resolve ourself as a subtype which leads to infinite loop while parsing the schema.
