### PR TITLE
feat(system): use available processor count number of executor threads

### DIFF
--- a/jdbc/src/main/java/io/kestra/jdbc/runner/JdbcExecutor.java
+++ b/jdbc/src/main/java/io/kestra/jdbc/runner/JdbcExecutor.java
@@ -237,10 +237,10 @@ public class JdbcExecutor implements ExecutorInterface, Service {
         this.eventPublisher = eventPublisher;
         this.tracer = tracerFactory.getTracer(JdbcExecutor.class, "EXECUTOR");
 
-        // By default, we start half-available processors count threads with a minimum of 4 by executor service
+        // By default, we start available processors count threads with a minimum of 4 by executor service
         // for the worker task result queue and the execution queue.
         // Other queues would not benefit from more consumers.
-        this.numberOfThreads = threadCount != 0 ? threadCount : Math.max(4, Runtime.getRuntime().availableProcessors() / 2);
+        this.numberOfThreads = threadCount != 0 ? threadCount : Math.max(4, Runtime.getRuntime().availableProcessors());
         this.workerTaskResultExecutorService = executorsUtils.maxCachedThreadPool(numberOfThreads, "jdbc-worker-task-result-executor");
         this.executionExecutorService = executorsUtils.maxCachedThreadPool(numberOfThreads, "jdbc-execution-executor");
     }


### PR DESCRIPTION
## Before
10 exec/s => 300ms
25 exec/s => 550ms
50 exec/s => 17s

## After
10 exec/s => 250ms
25 exec/s => 500ms
50 exec/s => 6s

## This PR with #9332
10 exec/s => 150ms
25 exec/s => 300ms
50 exec/s => 6s