### PR TITLE
fix(ui): add missing editor shortcut

### DIFF
--- a/ui/src/components/inputs/KeyShortcuts.vue
+++ b/ui/src/components/inputs/KeyShortcuts.vue
@@ -64,6 +64,10 @@
             description: "editor_shortcuts.save_flow",
         },
         {
+            keys: ["⌘ Cmd/Ctrl", "e"],
+            description: "editor_shortcuts.execute_flow",
+        },
+        {
             keys: ["⌥ Option/Alt", "↑", "↓"],
             description: "editor_shortcuts.move_line",
         },

--- a/ui/src/translations/en.json
+++ b/ui/src/translations/en.json
@@ -1249,6 +1249,7 @@
       "trigger_autocompletion": "Trigger autocompletion",
       "command_palette": "Show command palette",
       "save_flow": "Save flow",
+      "execute_flow": "Execute flow",
       "move_line": "Move line",
       "duplicate_cursor": "Duplicate cursor",
       "fold_unfold": "Fold/Unfold code",


### PR DESCRIPTION
### What changes are being made and why?

A useful shortcut was missing from the list of editor shortcuts.

Closes https://github.com/kestra-io/kestra/issues/9317.