### PR TITLE
fix(ui): Fixed selection of multiple filter values in version 0.22.x

### DIFF
--- a/ui/src/components/filter/composables/useFilters.ts
+++ b/ui/src/components/filter/composables/useFilters.ts
@@ -37,7 +37,9 @@ export function useFilters(prefix: string, isDefaultDashboard: boolean) {
         IN: buildComparator(t(comparator("in")), "IN", true),
         NOT_IN: buildComparator(t(comparator("not_in")), "NOT_IN", true),
         GREATER_THAN: buildComparator(t(comparator("greater_than")), "GREATER_THAN"),
+        GREATER_THAN_OR_EQUAL_TO: buildComparator(t(comparator("greater_than_or_equal_to")), "GREATER_THAN_OR_EQUAL_TO"),
         LESS_THAN: buildComparator(t(comparator("less_than")), "LESS_THAN"),
+        LESS_THAN_OR_EQUAL_TO: buildComparator(t(comparator("less_than_or_equal_to")), "LESS_THAN_OR_EQUAL_TO"),
     };
 
     let OPTIONS: Option[] = [

--- a/ui/src/components/filter/utils/helpers.ts
+++ b/ui/src/components/filter/utils/helpers.ts
@@ -161,7 +161,7 @@ export const decodeSearchParams = (query, include, OPTIONS) => {
             const label = field === "q" ? "text" : OPTIONS.find(o => o.key === field)?.value.label || field;
             const comparator = OPTIONS.find(o => o.key === field)?.comparators?.find(c => c.value === operation) || {value: operation};
 
-            return {field: label, value: decodeURIComponent(value), operation: comparator.value};
+            return {field: label, label: label, operation: comparator.value, comparator: comparator, value: decodeURIComponent(value).split(",")};
         })
         .filter(Boolean);
 

--- a/ui/src/components/flows/Flows.vue
+++ b/ui/src/components/flows/Flows.vue
@@ -86,7 +86,7 @@
 
                 <template #table>
                     <select-table
-                        v-if="flows.length"
+                        v-if="flows?.length"
                         ref="selectTable"
                         :data="flows"
                         :default-sort="{prop: 'id', order: 'ascending'}"

--- a/ui/src/translations/en.json
+++ b/ui/src/translations/en.json
@@ -1110,7 +1110,9 @@
         "relative_date": "Relative date",
         "absolute_date": "Absolute date",
         "labels": "Labels",
-        "text": "text"
+        "text": "text",
+        "startDate": "Start date",
+        "endDate": "End date"
       },
       "comparators": {
         "is": "is",
@@ -1123,7 +1125,9 @@
         "between": "between",
         "starts_with": "starts with",
         "greater_than": "greater than",
+        "greater_than_or_equal_to": "greater than or equal to",
         "less_than": "less than",
+        "less_than_or_equal_to": "less than or equal to",
         "ends_with": "ends with"
       },
       "save": {

--- a/ui/tests/unit/filter/utils/helpers.spec.ts
+++ b/ui/tests/unit/filter/utils/helpers.spec.ts
@@ -33,7 +33,7 @@ describe("Params Encoding & Decoding", () => {
 
         const decoded = decodeSearchParams(query, ["namespace"], OPTIONS);
         expect(decoded).toEqual([
-            {field: "namespace", value: "test-namespace", operation: "EQUALS"},
+            {field: "namespace", label: "namespace", value: ["test-namespace"], operation: "EQUALS", comparator: COMPARATORS.EQUALS},
         ]);
     });
 


### PR DESCRIPTION
<!-- Thanks for submitting a Pull Request to Kestra. To help us review your contribution, please follow the guidelines below:

- Make sure that your commits follow the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) specification e.g. `feat(ui): add a new navigation menu item` or `fix(core): fix a bug in the core model` or `docs: update the README.md`. This will help us automatically generate the changelog.
- The title should briefly summarize the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share a flow example to help the reviewer understand and QA the change.
- Use "closes" to automatically close an issue. For example, `closes #1234` will close issue #1234. -->

### What changes are being made and why?
Fixes #8486 

In this PR, I fixed the inability to filter execution states using multiple values with `in` and `not in` comparators. 
I modified the JSON structure returned by the `decodeSearchParams` function according to the UI requirements for filtering using multiple values in, for example, an `in` filter.

I tried to maintain backward compatibility, but it was necessary to change the return type of the `value` property from a string to an array of strings, as required by the UI filtering logic.

--
I also fixed missing translations and comparators for filtering using absolute dates. Currently, translations of new keys for languages other than English are missing because I am unable to provide these translations myself.

### Testing changes
I tested the changes and tried to verify that the changes I proposed did not affect other UI elements. I also modified the corresponding unit tests.

The result of the fix looks like this:

**Before:**
![image](https://github.com/user-attachments/assets/a30da124-d836-4def-877b-3d80f37fcb3a)
**After:**
![image](https://github.com/user-attachments/assets/155e4ce1-573f-4852-ab78-46e5d436c0f0)

--

**Before:**
![image](https://github.com/user-attachments/assets/a1ea4f74-be8f-49ba-adc3-9b11ddecb972)
**After:**
![image](https://github.com/user-attachments/assets/b1ead249-598e-4e9f-ab3f-9f511f5e0dd1)


Please let me know if there is anything else I can do.

<!-- Please include a brief summary of the changes included in this PR e.g. closes #1234. -->