### PR TITLE
fix(ui): amend visiblity of labels

### DIFF
--- a/ui/src/components/layout/Labels.vue
+++ b/ui/src/components/layout/Labels.vue
@@ -64,6 +64,7 @@
 
 <style scoped lang="scss">
 .label {
+    background-color: var(--ks-tag-background-active);
     font-weight: normal;
 
     &:hover {


### PR DESCRIPTION
### What changes are being made and why?

Currently labels just blend with the table row's background. This makes selecting labels slightly unpleasant.

This change makes labels a bit more visible, but still not as much pronounced as in e.g. v0.20.