### PR TITLE
chore: Replaced Microsoft Java with Temurin distribution

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -37,16 +37,16 @@ ARG OS_ARCHITECTURE
 RUN mkdir -p /usr/java
 RUN echo "Building on platform: $BUILDPLATFORM"
 RUN case "$BUILDPLATFORM" in \
-  "linux/amd64") OS_ARCHITECTURE="linux-x64" ;; \
-  "linux/arm64") OS_ARCHITECTURE="linux-aarch64" ;; \
-  "darwin/amd64") OS_ARCHITECTURE="macos-x64" ;; \
-  "darwin/arm64") OS_ARCHITECTURE="macos-aarch64" ;; \
+  "linux/amd64") OS_ARCHITECTURE="x64_linux" ;; \
+  "linux/arm64") OS_ARCHITECTURE="aarch64_linux" ;; \
+  "darwin/amd64") OS_ARCHITECTURE="x64_mac" ;; \
+  "darwin/arm64") OS_ARCHITECTURE="aarch64_mac" ;; \
   *) echo "Unsupported BUILDPLATFORM: $BUILDPLATFORM" && exit 1 ;; \
   esac && \
-  wget "https://aka.ms/download-jdk/microsoft-jdk-21.0.6-$OS_ARCHITECTURE.tar.gz" && \
-  mv "microsoft-jdk-21.0.6-$OS_ARCHITECTURE.tar.gz" microsoft-jdk-21.0.6.tar.gz
-RUN tar -xzvf microsoft-jdk-21.0.6.tar.gz && \
-  mv jdk-21.0.6+7 jdk-21 && \
+  wget "https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.7%2B6/OpenJDK21U-jdk_${OS_ARCHITECTURE}_hotspot_21.0.7_6.tar.gz" && \
+  mv OpenJDK21U-jdk_${OS_ARCHITECTURE}_hotspot_21.0.7_6.tar.gz openjdk-21.0.7.tar.gz
+RUN tar -xzvf openjdk-21.0.7.tar.gz && \
+  mv jdk-21.0.7+6 jdk-21 && \
   mv jdk-21 /usr/java/
 ENV JAVA_HOME=/usr/java/jdk-21
 ENV PATH="$PATH:$JAVA_HOME/bin"

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -39,7 +39,7 @@
         "yoavbls.pretty-ts-errors",
         "github.vscode-github-actions",
         "vscjava.vscode-java-pack",
-        "ms-azuretools.vscode-docker"
+        "docker.docker"
       ]
     }
   }


### PR DESCRIPTION
### What changes are being made and why?

- Replaced the Microsoft Java JDK with the Temurin JDK as recommended by @loicmathieu in the Kestra Plugin Template project. This makes Kestra projects aligned with the same setup and configuration.
- Also replaced a VSCode extension in devcontainer.json with the Docker DX extension as it is more relevant.

---

### How the changes have been QAed?

- Simply built the devcontainer and it opened up a container successfully

![image](https://github.com/user-attachments/assets/a096ad98-b13f-47b8-8f15-e37d6c5b9c81)