### PR TITLE
Fix sidebar visibility by enabling vertical scrolling

### DIFF
--- a/ui/src/components/ContextInfoBar.vue
+++ b/ui/src/components/ContextInfoBar.vue
@@ -207,6 +207,7 @@
         align-items: center;
         gap: 0.5rem;
         font-size: var(--font-size-sm);
+        overflow-y: auto;
 
         &.opened {
             border-right: 1px solid var(--ks-border-primary);


### PR DESCRIPTION
closes #9474 

### What changes are being made and why?
Fixed an issue where sidebar buttons could get cut off if they overflowed the viewport. 
Added `overflow-y: auto` to enable vertical scrolling, so all options stay accessible without affecting layout on standard screens.

## The fix

https://github.com/user-attachments/assets/eab3d089-15e9-438c-8e98-44870231b0f8

