### PR TITLE
fix(executor): delete WorkerJobRunning for any terminated task (#9493)

### DIFF
--- a/core/src/main/java/io/kestra/core/runners/WorkerJobRunningStateStore.java
+++ b/core/src/main/java/io/kestra/core/runners/WorkerJobRunningStateStore.java
@@ -1,0 +1,20 @@
+package io.kestra.core.runners;
+
+/**
+ * State store containing all workers' jobs in RUNNING state.
+ *
+ * @see WorkerJob
+ */
+public interface WorkerJobRunningStateStore {
+
+    /**
+     * Deletes a running worker job for the given key.
+     *
+     * <p>
+     *     A key can be a {@link WorkerTask} Task Run ID.
+     * </p>
+     *
+     * @param key the key of the worker job to be deleted.
+     */
+    void deleteByKey(String key);
+}

--- a/jdbc/src/main/java/io/kestra/jdbc/runner/JdbcExecutor.java
+++ b/jdbc/src/main/java/io/kestra/jdbc/runner/JdbcExecutor.java
@@ -718,22 +718,6 @@ public class JdbcExecutor implements ExecutorInterface, Service {
                 try {
                     // process worker task result
                     executorService.addWorkerTaskResult(current, () -> findFlow(execution), message);
-
-                    // send metrics on terminated
-                    TaskRun taskRun = message.getTaskRun();
-                    if (taskRun.getState().isTerminated()) {
-                        metricRegistry
-                            .counter(MetricRegistry.METRIC_EXECUTOR_TASKRUN_ENDED_COUNT, MetricRegistry.METRIC_EXECUTOR_TASKRUN_ENDED_COUNT_DESCRIPTION, metricRegistry.tags(message))
-                            .increment();
-
-                        metricRegistry
-                            .timer(MetricRegistry.METRIC_EXECUTOR_TASKRUN_ENDED_DURATION, MetricRegistry.METRIC_EXECUTOR_TASKRUN_ENDED_DURATION_DESCRIPTION, metricRegistry.tags(message))
-                            .record(taskRun.getState().getDuration());
-
-                        log.trace("TaskRun terminated: {}", taskRun);
-                        workerJobRunningRepository.deleteByKey(taskRun.getId());
-                    }
-
                     // join worker result
                     return Pair.of(
                         current,


### PR DESCRIPTION
Make ExecutorService responsible for deleting WorkerJobRunning when a terminated TaskRun is added to an execution.

Changes:
 - Remove unecessary read before delete on WorkerJobRunning table.

Close: #9493