### PR TITLE
fix: long chart titles no longer overflow in dashboard (closes #9192)

### DIFF
--- a/ui/src/components/dashboard/components/ChartsSection.vue
+++ b/ui/src/components/dashboard/components/ChartsSection.vue
@@ -10,7 +10,7 @@
             >
                 <div class="d-flex flex-column">
                     <p v-if="chart.type !== 'io.kestra.plugin.core.dashboard.chart.KPI'">
-                        <span class="fs-6 fw-bold">{{ labels(chart).title }}</span>
+                        <span class="fs-6 fw-bold chart-title">{{ labels(chart).title }}</span>
                         <template v-if="labels(chart)?.description">
                             <br>
                             <small class="fw-light">
@@ -125,5 +125,12 @@ section#charts {
 
 .charts-padding {
     padding: 0 2rem 1rem;
+}
+
+.chart-title {
+    word-break: break-word;
+    white-space: normal;
+    max-width: 100%;
+    display: inline-block;
 }
 </style>


### PR DESCRIPTION
 ## Summary

This PR fixes issue #9192 by making long chart titles in the dashboard wrap properly instead of overflowing outside the container. This improves readability and prevents the need to zoom out to view full class names.

## What was changed

- Added a `.chart-title` CSS class to `ChartsSection.vue` with `word-break: break-word` and `white-space: normal` to wrap long strings.
- Applied the class to the `<span>` that displays chart titles.
- Verified the fix by running the app locally and confirming that long titles no longer overflow.

## Why this fix is important

Previously, titles like `io.kestra.plugin.core.dashboard.chart.kpis.KpiOption` were overflowing out of their containers, making the dashboard difficult to read. This small CSS improvement keeps the UI clean and user-friendly.

## Screenshot

<img width="1273" alt="Screenshot 2025-06-14 at 1 55 17 AM" src="https://github.com/user-attachments/assets/a502d759-55ba-46c4-b332-da52020bef1a" />

## Closes

Closes #9192