### PR TITLE
fix(system): flow graph fail to be created while editting a flow

### DIFF
--- a/core/src/main/java/io/kestra/core/utils/GraphUtils.java
+++ b/core/src/main/java/io/kestra/core/utils/GraphUtils.java
@@ -73,7 +73,7 @@ public class GraphUtils {
             )))
             .orElse(Collections.emptyMap());
 
-        triggersDeclarations.forEach(trigger -> {
+        triggersDeclarations.stream().filter(trigger -> trigger != null).forEach(trigger -> {
             GraphTrigger triggerNode = new GraphTrigger(trigger, triggersById.get(trigger.getId()));
             triggerCluster.addNode(triggerNode);
             triggerCluster.addEdge(triggerCluster.getRoot(), triggerNode, new Relation());


### PR DESCRIPTION
Fixes #9551

It is not the validation per se that fail, it's the graph dependency computation that is also done while editing a flow that fail.