### PR TITLE
Make Enter confirm and trigger's refresh filter, Shift+Enter adds a new line

### DIFF
--- a/ui/src/components/filter/KestraFilter.vue
+++ b/ui/src/components/filter/KestraFilter.vue
@@ -465,30 +465,38 @@
                 e.contentHeight + "px";
         });
 
-        mountedEditor.addCommand(monaco.KeyCode.Enter, () => {
-            const model = mountedEditor.getModel();
-            if (!model) return;
-            const currentValue = model.getValue();
-            if (currentValue.trim().length > 0) {
-                const position = mountedEditor.getPosition();
-                const endPosition = model.getPositionAt(currentValue.length);
-                if (
-                    position &&
-                    position.lineNumber === endPosition.lineNumber &&
-                    position.column === endPosition.column &&
-                    !currentValue.endsWith(" ")
-                ) {
-                    mountedEditor.executeEdits("", [
-                        {
-                            range: new monaco.Range(position.lineNumber, position.column, position.lineNumber, position.column),
-                            text: " ",
-                            forceMoveMarkers: true
-                        }
-                    ]);
+        mountedEditor.addAction({
+            id: "accept_kestra_filter",
+            label: "Accept Kestra Filter",
+            keybindingContext: "!suggestWidgetVisible",
+            keybindings: [monaco.KeyCode.Enter],
+            run: () => {
+                const model = mountedEditor.getModel();
+                if (!model) return;
+                const currentValue = model.getValue();
+                if (currentValue.trim().length > 0) {
+                    const position = mountedEditor.getPosition();
+                    const endPosition = model.getPositionAt(currentValue.length);
+                    if (
+                        position &&
+                        position.lineNumber === endPosition.lineNumber &&
+                        position.column === endPosition.column &&
+                        !currentValue.endsWith(" ")
+                    ) {
+                        mountedEditor.executeEdits("", [
+                            {
+                                range: new monaco.Range(position.lineNumber, position.column, position.lineNumber, position.column),
+                                text: " ",
+                                forceMoveMarkers: true
+                            }
+                        ]);
+
+                        mountedEditor.trigger("enterPressed", "editor.action.triggerSuggest", {});
+                    }
                 }
                 updateQuery();
             }
-        },"!suggestWidgetVisible");
+        });
 
         mountedEditor.onDidChangeModelContent(e => {
             if (e.changes.length === 1 && (e.changes[0].text === " " || e.changes[0].text === "\n")) {
@@ -509,7 +517,7 @@
         });
     };
 
-    watchDebounced(filterQueryString,updateQuery, {immediate: true, debounce: 1000});
+    watchDebounced(filterQueryString, updateQuery, {immediate: true, debounce: 1000});
 </script>
 
 <style lang="scss" scoped>
@@ -523,7 +531,7 @@
         border-bottom-right-radius: var(--el-border-radius-base);
         min-width: 0;
 
-        .mtk25, .mtk28{
+        .mtk25, .mtk28 {
             background-color: var(--ks-badge-background);
             padding: 2px 6px;
             border-radius: var(--el-border-radius-base);

--- a/ui/src/components/filter/KestraFilter.vue
+++ b/ui/src/components/filter/KestraFilter.vue
@@ -72,7 +72,7 @@
     import {computed, getCurrentInstance, ref, Ref, watch} from "vue";
     import Utils, {useTheme} from "../../utils/utils";
     import {Buttons, Property, Shown} from "./utils/types";
-    import {editor, KeyCode} from "monaco-editor/esm/vs/editor/editor.api";
+    import * as monaco from "monaco-editor";
     import Items from "./segments/Items.vue";
     import {cssVariable} from "@kestra-io/ui-libs";
     import {LocationQuery, useRoute, useRouter} from "vue-router";
@@ -370,7 +370,7 @@
     };
 
     const theme = useTheme();
-    const themeComputed: Ref<Omit<Partial<editor.IStandaloneThemeData>, "base"> & { base: ThemeBase }> = ref({
+    const themeComputed: Ref<Omit<Partial<monaco.editor.IStandaloneThemeData>, "base"> & { base: ThemeBase }> = ref({
         base: Utils.getTheme()!,
         colors: {
             "editor.background": cssVariable("--ks-background-input")!
@@ -392,7 +392,7 @@
 
     }, {immediate: true});
 
-    const options: editor.IStandaloneEditorConstructionOptions = {
+    const options: monaco.editor.IStandaloneEditorConstructionOptions = {
         lineNumbers: "off",
         folding: false,
         renderLineHighlight: "none",
@@ -436,7 +436,27 @@
 
     const monacoEditor = ref<typeof MonacoEditor>();
 
-    const editorDidMount = (mountedEditor: editor.IStandaloneCodeEditor) => {
+    const updateQuery = () => {
+        const newQuery = {
+            ...Object.fromEntries(queryParamsToKeep.value.map(key => {
+                return [
+                    key, 
+                    route.query[key]
+                ]
+            })),
+            ...filterQueryString.value
+        };
+        if (_isEqual(route.query, newQuery)) {
+            props.buttons.refresh?.callback?.();
+            return; // Skip if the query hasn't changed
+        }
+        skipRouteWatcherOnce.value = true;
+        router.push({ 
+            query: newQuery 
+        });
+    };
+
+    const editorDidMount = (mountedEditor: monaco.editor.IStandaloneCodeEditor) => {
         mountedEditor.onDidContentSizeChange((e) => {
             if (monacoEditor.value === undefined) {
                 return;
@@ -445,22 +465,34 @@
                 e.contentHeight + "px";
         });
 
-        mountedEditor.onKeyDown((e) => {
-            if (e.keyCode === KeyCode.Enter) {
-                const suggestController = mountedEditor.getContribution("editor.contrib.suggestController") as any;
-                
-                if (suggestController && suggestController.widget) {
-                    return;
+        mountedEditor.addCommand(monaco.KeyCode.Enter, () => {
+            const model = mountedEditor.getModel();
+            if (!model) return;
+            const currentValue = model.getValue();
+            if (currentValue.trim().length > 0) {
+                const position = mountedEditor.getPosition();
+                const endPosition = model.getPositionAt(currentValue.length);
+                if (
+                    position &&
+                    position.lineNumber === endPosition.lineNumber &&
+                    position.column === endPosition.column &&
+                    !currentValue.endsWith(" ")
+                ) {
+                    mountedEditor.executeEdits("", [
+                        {
+                            range: new monaco.Range(position.lineNumber, position.column, position.lineNumber, position.column),
+                            text: " ",
+                            forceMoveMarkers: true
+                        }
+                    ]);
                 }
-                e.preventDefault();
-                e.stopPropagation();
+                updateQuery();
             }
-        });
+        },"!suggestWidgetVisible");
 
         mountedEditor.onDidChangeModelContent(e => {
-            if (e.changes.length === 1 && e.changes[0].text === " ") {
-                const model = mountedEditor.getModel();
-                if (model && model.getValue().charAt(e.changes[0].rangeOffset - 1) === ",") {
+            if (e.changes.length === 1 && (e.changes[0].text === " " || e.changes[0].text === "\n")) {
+                if (mountedEditor.getModel()?.getValue().charAt(e.changes[0].rangeOffset - 1) === ",") {
                     mountedEditor.executeEdits("", [
                         {
                             range: {
@@ -474,39 +506,10 @@
                     ]);
                 }
             }
-
-            // Remove any newlines (e.g., with paste)
-            if (e.changes.some(change => change.text.includes("\n"))) {
-                const model = mountedEditor.getModel();
-                if (model) {
-                    const currentValue = model.getValue();
-                    if (currentValue.includes("\n")) {
-                        const newValue = currentValue.replace(/\n/g, " ");
-                        model.setValue(newValue);
-                    }
-                }
-            }
         });
     };
 
-    watchDebounced(filterQueryString, () => {
-        const newQuery = {
-            ...Object.fromEntries(queryParamsToKeep.value.map(key => {
-                return [
-                    key,
-                    route.query[key]
-                ];
-            })),
-            ...filterQueryString.value
-        };
-        if (_isEqual(route.query, newQuery)) {
-            return; // Skip if the query hasn't changed
-        }
-        skipRouteWatcherOnce.value = true;
-        router.push({
-            query: newQuery
-        });
-    }, {immediate: true, debounce: 1000});
+    watchDebounced(filterQueryString,updateQuery, {immediate: true, debounce: 1000});
 </script>
 
 <style lang="scss" scoped>

--- a/ui/src/components/inputs/Editor.vue
+++ b/ui/src/components/inputs/Editor.vue
@@ -372,14 +372,27 @@
         });
 
         if (props.input) {
-            editor.addCommand(KeyMod.CtrlCmd | KeyCode.KeyH, () => {});
-            editor.addCommand(KeyCode.F1, () => {});
+            editor.addAction({
+                id: "prevent-ctrl-h",
+                label: "Prevent CTRL + H",
+                keybindings: [KeyMod.CtrlCmd | KeyCode.KeyH],
+                run: () => {}
+            });
+
+            editor.addAction({
+                id: "prevent-f1",
+                label: "Prevent F1",
+                keybindings: [KeyCode.F1],
+                run: () => {}
+            });
 
             if (!props.readOnly) {
-                editor.addCommand(
-                    KeyMod.CtrlCmd | KeyCode.KeyF,
-                    () => {},
-                );
+                editor.addAction({
+                    id: "prevent-ctrl-f",
+                    label: "Prevent CTRL + F",
+                    keybindings: [KeyMod.CtrlCmd | KeyCode.KeyF],
+                    run: () => {}
+                });
             }
         }
 


### PR DESCRIPTION
closes #9471 

### What changes are being made and why?

- **Changes**:  
  - Added a custom `Enter` key command in `editorDidMount` to append a space and update the query.  
  - Implemented `onDidChangeModelContent` to handle special cases like removing commas before spaces or new lines.  

- **Why**:  
  - These changes address the layout overflow issue by ensuring the Monaco Editor handles input (e.g., **Enter** key) consistently, appending spaces for autocompletion and maintaining query updates.  
  - The dynamic height adjustment allows the editor to grow with content, avoiding manual height constraints while ensuring the UI remains functional without "screen bleeding" when new lines are added (e.g., via **Shift + Enter**), assuming the parent container or external CSS manages overflow.
  
  Demo:
  https://jam.dev/c/3a76d99d-e414-4b0b-9718-d68569c0310f
