### PR TITLE
feat(flows): allow to pass a typed object in Data.from()

### DIFF
--- a/core/src/main/java/io/kestra/core/models/property/Data.java
+++ b/core/src/main/java/io/kestra/core/models/property/Data.java
@@ -82,7 +82,16 @@ public class Data {
             return Mono.just(map).flux().map(mapper);
         }
 
+        if (clazz.isAssignableFrom(from.getClass())) {
+            // it could be the case in tests so we handle it for dev experience
+            return Mono.just((T) from).flux();
+        }
+
         if (from instanceof List<?> fromList) {
+            if (!fromList.isEmpty() && clazz.isAssignableFrom(fromList.getFirst().getClass())){
+                // it could be the case in tests so we handle it for dev experience
+                return Flux.fromIterable((List<T>) fromList);
+            }
             Stream<Map<String, Object>> stream = fromList.stream().map(throwFunction(it -> runContext.render((Map<String, Object>) it)));
             return Flux.fromStream(stream).map(mapper);
         }


### PR DESCRIPTION
This would facilitate dev experience as he would be able to directly use a typed object not a Map. This will not be used inside a Kestra instance as deserialization would always deserialize to a Map as the `from` attribute is an Object.
