### PR TITLE
fix(execution): parent flow never ends when subflow fail due to SLA

### DIFF
--- a/core/src/test/java/io/kestra/core/runners/AbstractRunnerTest.java
+++ b/core/src/test/java/io/kestra/core/runners/AbstractRunnerTest.java
@@ -493,6 +493,12 @@ public abstract class AbstractRunnerTest {
     }
 
     @Test
+    @LoadFlows({"flows/valids/sla-parent-flow.yaml", "flows/valids/sla-subflow.yaml"})
+    void executionConditionSLAShouldLaslaViolationOnSubflowMayEndTheParentFlowbel() throws Exception {
+        slaTestCase.slaViolationOnSubflowMayEndTheParentFlow();
+    }
+
+    @Test
     @LoadFlows({"flows/valids/if.yaml"})
     void multipleIf() throws TimeoutException, QueueException {
         Execution execution = runnerUtils.runOne(MAIN_TENANT, "io.kestra.tests", "if", null,

--- a/core/src/test/java/io/kestra/core/runners/SLATestCase.java
+++ b/core/src/test/java/io/kestra/core/runners/SLATestCase.java
@@ -48,4 +48,10 @@ public class SLATestCase {
         assertThat(execution.getState().getCurrent()).isEqualTo(State.Type.SUCCESS);
         assertThat(execution.getLabels()).contains(new Label("sla", "violated"));
     }
+
+    public void slaViolationOnSubflowMayEndTheParentFlow() throws QueueException, TimeoutException {
+        Execution execution = runnerUtils.runOne(MAIN_TENANT, "io.kestra.tests", "sla-parent-flow");
+
+        assertThat(execution.getState().getCurrent()).isEqualTo(State.Type.FAILED);
+    }
 }

--- a/core/src/test/resources/flows/valids/sla-parent-flow.yaml
+++ b/core/src/test/resources/flows/valids/sla-parent-flow.yaml
@@ -1,0 +1,8 @@
+id: sla-parent-flow
+namespace: io.kestra.tests
+
+tasks:
+  - id: subflow
+    type: io.kestra.plugin.core.flow.Subflow
+    namespace: io.kestra.tests
+    flowId: sla-subflow

--- a/core/src/test/resources/flows/valids/sla-subflow.yaml
+++ b/core/src/test/resources/flows/valids/sla-subflow.yaml
@@ -1,0 +1,13 @@
+id: sla-subflow
+namespace: io.kestra.tests
+
+sla:
+  - id: maxDuration
+    type: MAX_DURATION
+    duration: PT10S
+    behavior: FAIL
+
+tasks:
+  - id: sleep
+    type: io.kestra.plugin.core.flow.Sleep
+    duration: PT60S

--- a/jdbc/src/main/java/io/kestra/jdbc/runner/JdbcExecutor.java
+++ b/jdbc/src/main/java/io/kestra/jdbc/runner/JdbcExecutor.java
@@ -1208,8 +1208,8 @@ public class JdbcExecutor implements ExecutorInterface, Service {
 
         slaMonitorStorage.processExpired(Instant.now(), slaMonitor -> {
             Executor result = executionRepository.lock(slaMonitor.getExecutionId(), pair -> {
-                Executor executor = new Executor(pair.getLeft(), null);
-                FlowInterface flow = flowMetaStore.findByExecution(pair.getLeft()).orElseThrow();
+                FlowWithSource flow = findFlow(pair.getLeft());
+                Executor executor = new Executor(pair.getLeft(), null).withFlow(flow);
                 Optional<SLA> sla = flow.getSla().stream().filter(s -> s.getId().equals(slaMonitor.getSlaId())).findFirst();
                 if (sla.isEmpty()) {
                     // this can happen in case the flow has been updated and the SLA removed


### PR DESCRIPTION
This is because the executor didn't have the flow inside it so the execution is not correctly terminated. It may fix other issues (like flow triggers, purge, ...)

Fixes #9618
