### PR TITLE
fix(core): retry flaky runner test restartForEachItem as it's flaky o…

### DIFF
--- a/core/src/test/java/io/kestra/core/runners/AbstractRunnerTest.java
+++ b/core/src/test/java/io/kestra/core/runners/AbstractRunnerTest.java
@@ -362,7 +362,7 @@ public abstract class AbstractRunnerTest {
         forEachItemCaseTest.forEachItemWithSubflowOutputs();
     }
 
-    @Test
+    @RetryingTest(5) // flaky on CI but always pass locally even with 100 iterations
     @LoadFlows({"flows/valids/restart-for-each-item.yaml", "flows/valids/restart-child.yaml"})
     void restartForEachItem() throws Exception {
         forEachItemCaseTest.restartForEachItem();


### PR DESCRIPTION
…n CI but always pass locally
