### PR TITLE
feat(ui): add syntax highlighting to NoCode editor

### DIFF
--- a/ui/src/components/flows/tasks/TaskString.vue
+++ b/ui/src/components/flows/tasks/TaskString.vue
@@ -37,7 +37,7 @@
             :full-height="false"
             :should-focus="false"
             schema-type="flow"
-            lang="plaintext"
+            :lang="'python'"
             input
             @update:model-value="onInput"
             :large-suggestions="false"

--- a/ui/src/components/inputs/MonacoEditor.vue
+++ b/ui/src/components/inputs/MonacoEditor.vue
@@ -35,6 +35,7 @@
     import "monaco-editor/esm/vs/editor/standalone/browser/quickAccess/standaloneCommandsQuickAccess.js";
     import "monaco-editor/esm/vs/language/json/monaco.contribution";
     import "monaco-editor/esm/vs/basic-languages/monaco.contribution";
+    import "monaco-editor/esm/vs/basic-languages/python/python.contribution";
     import * as monaco from "monaco-editor/esm/vs/editor/editor.api";
     import {editor} from "monaco-editor/esm/vs/editor/editor.api";
     import EditorWorker from "monaco-editor/esm/vs/editor/editor.worker?worker";


### PR DESCRIPTION
closes: #9647 
I’ve added the syntax highlighting feature to the NoCode editor, as shown in the screenshot below. Please let me know if any changes are needed.


<img width="531" alt="Screenshot 2025-06-23 at 1 11 12 PM" src="https://github.com/user-attachments/assets/35dcd138-04fb-4539-8e09-cedff259861e" />
