### PR TITLE
feat(cli): validate config URL

### DIFF
--- a/cli/src/main/java/io/kestra/cli/AbstractCommand.java
+++ b/cli/src/main/java/io/kestra/cli/AbstractCommand.java
@@ -4,6 +4,7 @@ import ch.qos.logback.classic.LoggerContext;
 import com.google.common.collect.ImmutableMap;
 import io.kestra.cli.commands.servers.ServerCommandInterface;
 import io.kestra.cli.services.StartupHookInterface;
+import io.kestra.cli.validators.AppConfigValidator;
 import io.kestra.core.plugins.PluginManager;
 import io.kestra.core.plugins.PluginRegistry;
 import io.kestra.webserver.services.FlowAutoLoaderService;
@@ -58,6 +59,9 @@ abstract public class AbstractCommand implements Callable<Integer> {
 
     @Inject
     protected Provider<PluginManager> pluginManagerProvider;
+
+    @Inject
+    protected AppConfigValidator appConfigValidator;
 
     private PluginRegistry pluginRegistry;
 

--- a/cli/src/main/java/io/kestra/cli/App.java
+++ b/cli/src/main/java/io/kestra/cli/App.java
@@ -62,16 +62,15 @@ public class App implements Callable<Integer> {
         SLF4JBridgeHandler.removeHandlersForRootLogger();
         SLF4JBridgeHandler.install();
 
+        int exitCode = 0;
+
         // Init ApplicationContext
-        ApplicationContext applicationContext = App.applicationContext(cls, args);
-
-        // Call Picocli command
-        int exitCode = new CommandLine(cls, new MicronautFactory(applicationContext)).execute(args);
-
-        applicationContext.close();
-
+        try (ApplicationContext applicationContext = App.applicationContext(cls, args)) {
+            // Call Picocli command
+            exitCode = new CommandLine(cls, new MicronautFactory(applicationContext)).execute(args);
+        }
         // exit code
-        System.exit(Objects.requireNonNullElse(exitCode, 0));
+        System.exit(exitCode);
     }
 
     /**

--- a/cli/src/main/java/io/kestra/cli/AppConfig.java
+++ b/cli/src/main/java/io/kestra/cli/AppConfig.java
@@ -1,0 +1,18 @@
+package io.kestra.cli;
+
+import io.kestra.core.validations.Url;
+import io.micronaut.context.annotation.ConfigurationProperties;
+
+/**
+ * Enforces various validation rules upon the application configuration preventing misconfiguration.
+ */
+@ConfigurationProperties("kestra")
+public class AppConfig {
+
+    @Url(
+        scheme = "(http|https)",
+        message = "invalid URL [{validatedValue}] - 'kestra.url' configuration property must be a valid HTTP(S) URL " +
+                " - e.g. https://your.company.com"
+    )
+    public String url;
+}

--- a/cli/src/main/java/io/kestra/cli/validators/AppConfigValidator.java
+++ b/cli/src/main/java/io/kestra/cli/validators/AppConfigValidator.java
@@ -1,0 +1,17 @@
+package io.kestra.cli.validators;
+
+import io.kestra.cli.AppConfig;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+import jakarta.validation.Valid;
+
+@Singleton
+public class AppConfigValidator {
+    @Valid
+    private final AppConfig config;
+
+    @Inject
+    public AppConfigValidator(AppConfig config) {
+        this.config = config;
+    }
+}

--- a/cli/src/main/java/io/kestra/cli/validators/ServerCommandValidator.java
+++ b/cli/src/main/java/io/kestra/cli/validators/ServerCommandValidator.java
@@ -1,4 +1,4 @@
-package io.kestra.cli;
+package io.kestra.cli.validators;
 
 import io.micronaut.context.annotation.Context;
 import io.micronaut.context.annotation.Requires;
@@ -31,7 +31,7 @@ public class ServerCommandValidator {
     @PostConstruct
     void validate() {
         final List<Map.Entry<String, String>> missingProperties = VALIDATED_PROPERTIES.entrySet().stream()
-            .filter((property) -> !environment.containsProperty(property.getKey()))
+            .filter(property -> !environment.containsProperty(property.getKey()))
             .toList();
 
         missingProperties.forEach(property -> log.error("""

--- a/cli/src/test/java/io/kestra/cli/validators/AppConfigValidatorTest.java
+++ b/cli/src/test/java/io/kestra/cli/validators/AppConfigValidatorTest.java
@@ -1,0 +1,40 @@
+package io.kestra.cli.validators;
+
+import io.kestra.cli.AppConfig;
+import io.kestra.core.models.validations.ModelValidator;
+import io.micronaut.context.ApplicationContext;
+import io.micronaut.context.env.Environment;
+import io.micronaut.context.exceptions.BeanInstantiationException;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class AppConfigValidatorTest {
+    @Test
+    void validConfig() {
+        final Map<String, Object> props = Map.of("kestra.url", "https://postgres-oss.preview.dev.kestra.io");
+
+        try (ApplicationContext context = ApplicationContext.builder(Environment.CLI, Environment.TEST).properties(props).start()) {
+            ModelValidator validator = context.getBean(ModelValidator.class);
+            AppConfig config = context.getBean(AppConfig.class);
+
+            assertThat(validator.isValid(config)).isEmpty();
+        }
+    }
+
+    @Test
+    void invalidConfig() {
+        final Map<String, Object> props = Map.of("kestra.url", "foo.bar");
+
+        try (ApplicationContext context = ApplicationContext.builder().deduceEnvironment(false).properties(props).start()) {
+            final Throwable exception = assertThrows(BeanInstantiationException.class, () ->
+                context.getBean(AppConfig.class)
+            );
+
+            assertThat(exception.getMessage()).contains("'kestra.url' configuration property must be a valid HTTP(S) URL");
+        }
+    }
+}

--- a/cli/src/test/java/io/kestra/cli/validators/ServerCommandValidatorTest.java
+++ b/cli/src/test/java/io/kestra/cli/validators/ServerCommandValidatorTest.java
@@ -1,4 +1,4 @@
-package io.kestra.cli;
+package io.kestra.cli.validators;
 
 import io.micronaut.context.ApplicationContext;
 import io.micronaut.context.exceptions.BeanInstantiationException;

--- a/core/src/main/java/io/kestra/core/validations/Url.java
+++ b/core/src/main/java/io/kestra/core/validations/Url.java
@@ -1,0 +1,28 @@
+package io.kestra.core.validations;
+
+import io.kestra.core.validations.validator.UrlValidator;
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.*;
+
+/**
+ * Validates the annotated string is a URL.
+ * Optionally, enforces the URL scheme as regex.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Constraint(validatedBy = UrlValidator.class)
+@Target({ METHOD, FIELD, ANNOTATION_TYPE, CONSTRUCTOR, PARAMETER, TYPE_USE })
+public @interface Url {
+    String message() default "invalid URL [{validatedValue}]";
+    /**
+     * @return the URL scheme pattern, e.g. <code>(http|https)</code>. Defaults to <code>.*</code>.
+     */
+    String scheme() default ".*";
+    Class<?>[] groups() default {};
+    Class<? extends Payload>[] payload() default {};
+}

--- a/core/src/main/java/io/kestra/core/validations/validator/UrlValidator.java
+++ b/core/src/main/java/io/kestra/core/validations/validator/UrlValidator.java
@@ -1,0 +1,67 @@
+package io.kestra.core.validations.validator;
+
+import io.kestra.core.validations.Url;
+import io.micronaut.core.annotation.AnnotationValue;
+import io.micronaut.core.annotation.Introspected;
+import io.micronaut.core.annotation.NonNull;
+import io.micronaut.core.annotation.Nullable;
+import io.micronaut.validation.validator.constraints.ConstraintValidator;
+import io.micronaut.validation.validator.constraints.ConstraintValidatorContext;
+import jakarta.inject.Singleton;
+
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URL;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+@Singleton
+@Introspected
+public class UrlValidator implements ConstraintValidator<Url, String> {
+    private Pattern scheme;
+    private String message;
+
+    @Override
+    public void initialize(Url constraint) {
+        scheme = Pattern.compile(constraint.scheme());
+        message = constraint.message();
+    }
+
+    @Override
+    public boolean isValid(
+        @Nullable String value,
+        @NonNull AnnotationValue<Url> annotationMetadata,
+        @NonNull ConstraintValidatorContext context) {
+        if (value == null) {
+            return true;
+        }
+
+        try {
+            final URL url = URI.create(value).toURL();
+
+            if (!isSchemeAllowed(url)) {
+                return setViolation(
+                    context,
+                    "URL scheme doesn't match '" + scheme.pattern() + "' [{validatedValue}] - " + message
+                );
+            }
+        } catch (IllegalArgumentException | MalformedURLException e) {
+            return setViolation(context, message);
+        }
+
+        return true;
+    }
+
+    private boolean setViolation(ConstraintValidatorContext context, String protocol) {
+        context.disableDefaultConstraintViolation();
+        context.buildConstraintViolationWithTemplate(
+            protocol
+        ).addConstraintViolation();
+        return false;
+    }
+
+    private boolean isSchemeAllowed(URL url) {
+        final Matcher matcher = scheme.matcher(url.getProtocol());
+        return matcher.matches();
+    }
+}

--- a/core/src/test/java/io/kestra/core/validations/UrlValidatorTest.java
+++ b/core/src/test/java/io/kestra/core/validations/UrlValidatorTest.java
@@ -1,0 +1,69 @@
+package io.kestra.core.validations;
+
+import io.kestra.core.junit.annotations.KestraTest;
+import io.kestra.core.models.validations.ModelValidator;
+import io.micronaut.core.annotation.Introspected;
+import jakarta.inject.Inject;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@KestraTest
+class UrlValidatorTest {
+    @Inject
+    private ModelValidator modelValidator;
+
+    @AllArgsConstructor
+    @Introspected
+    @Getter
+    public static class SimpleUrlCls {
+        @Url
+        String url;
+    }
+
+    @AllArgsConstructor
+    @Introspected
+    @Getter
+    public static class UrlWithHttpSchemeCls {
+        @Url(scheme = "(http|https)")
+        String url;
+    }
+
+    @Test
+    void noSchemeInputValidation() {
+        final SimpleUrlCls validUrl = new SimpleUrlCls("https://postgres-oss.preview.dev.kestra.io");
+
+        assertThat(modelValidator.isValid(validUrl)).isEmpty();
+
+        final SimpleUrlCls invalidUrl = new SimpleUrlCls("postgres-oss.preview.dev.kestra.io");
+
+        assertThat(modelValidator.isValid(invalidUrl))
+            .isPresent()
+            .hasValueSatisfying(throwable ->
+                assertThat(throwable)
+                    .hasMessageContaining("invalid URL")
+            );
+    }
+
+    @Test
+    void validSchemeInputValidation() {
+        final UrlWithHttpSchemeCls httpUrl = new UrlWithHttpSchemeCls("http://postgres-oss.preview.dev.kestra.io");
+
+        assertThat(modelValidator.isValid(httpUrl)).isEmpty();
+
+        final UrlWithHttpSchemeCls httpsUrl = new UrlWithHttpSchemeCls("https://postgres-oss.preview.dev.kestra.io");
+
+        assertThat(modelValidator.isValid(httpsUrl)).isEmpty();
+
+        final UrlWithHttpSchemeCls invalidSchemeUrl = new UrlWithHttpSchemeCls("ftp://postgres-oss.preview.dev.kestra.io");
+
+        assertThat(modelValidator.isValid(invalidSchemeUrl))
+            .isPresent()
+            .hasValueSatisfying(throwable ->
+                assertThat(throwable)
+                    .hasMessageContaining("URL scheme doesn't match")
+            );
+    }
+}


### PR DESCRIPTION
### What changes are being made and why?

* Added a custom Jakarta Validation-based URL validator.
* Created a generic app config validator.
* Validation is triggered at valid commands - not only at `server`.

Yet, there is probably a better place to invoke the validation than the `AbstractCommand` class.

closes #8314

BREAKING CHANGE: app won't start due invalid `kestra.url`