### PR TITLE
build: lower codecov default targets to make it more pertinent

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -70,7 +70,7 @@ flag_management:
     carryforward: true
     statuses:
       - type: project
-        target: 80%
+        target: 73% # current value as of 2025-06-25
         threshold: 1%
       - type: patch
-        target: 90%
+        target: 75%


### PR DESCRIPTION
lets try to keep improving the project coverage by making the codecev check more relevant to our context

FYI recent trend:

<img width="1565" alt="image" src="https://github.com/user-attachments/assets/72d3bbdf-2a9e-4867-9aab-48cd97b40a28" />
