### PR TITLE
fix(plugins): finish pinia migration of plugins store

### DIFF
--- a/ui/src/components/plugins/Plugin.vue
+++ b/ui/src/components/plugins/Plugin.vue
@@ -53,7 +53,7 @@
                     <schema-to-html
                         class="plugin-schema"
                         :dark-mode="theme === 'dark'"
-                        :schema="plugin.schema"
+                        :schema="pluginsStore.plugin.schema"
                         :props-initially-expanded="true"
                         :plugin-type="pluginType"
                     >

--- a/ui/src/components/plugins/Toc.vue
+++ b/ui/src/components/plugins/Toc.vue
@@ -7,7 +7,7 @@
             clearable
         />
         <el-collapse accordion v-model="activeNames">
-            <template :key="plugin.title" v-for="(plugin) in sortedPlugins(pluginsList)">
+            <template v-for="(plugin) in sortedPlugins(pluginsList)" :key="plugin.title">
                 <el-collapse-item
                     v-if="isVisible(plugin)"
                     :name="plugin.group"
@@ -31,7 +31,7 @@
                                                     <task-icon
                                                         :only-icon="true"
                                                         :cls="namespace + '.' + cls"
-                                                        :icons="icons"
+                                                        :icons="pluginsStore.icons"
                                                     />
                                                 </div>
                                                 <span
@@ -54,7 +54,8 @@
 
 <script>
     import {isEntryAPluginElementPredicate, TaskIcon} from "@kestra-io/ui-libs";
-    import {mapState} from "vuex";
+    import {mapStores} from "pinia";
+    import {usePluginsStore} from "../../stores/plugins";
 
     export default {
         emits: ["routerChange"],
@@ -89,7 +90,7 @@
             }
         },
         computed: {
-            ...mapState("plugin", ["plugin", "icons"]),
+            ...mapStores(usePluginsStore),
             countPlugin() {
                 return this.plugins.flatMap(plugin => this.pluginElements(plugin)).length
             },


### PR DESCRIPTION
closes kestra-io/kestra-ee#4194

When opeing a plugins documentation, the app was erroring