### PR TITLE
feat(flows): allow reading local files inside the file functions

### DIFF
--- a/core/src/main/java/io/kestra/core/runners/LocalPath.java
+++ b/core/src/main/java/io/kestra/core/runners/LocalPath.java
@@ -3,15 +3,23 @@ package io.kestra.core.runners;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
+import java.nio.file.attribute.BasicFileAttributes;
 
 /**
  * Get access to local paths of the host machine.
  * <p>
  * All methods of this class check allowed paths and protect against path traversal.
- * All paths must be allowed via the `kestra.plugins.allowed-paths` configuration property or via plugin configuration.
+ * All paths must be allowed via the {@link #ALLOWED_PATHS_CONFIG} configuration property or via plugin configuration.
  */
 public interface LocalPath {
     String FILE_SCHEME = "file";
+    String FILE_PROTOCOL = FILE_SCHEME + "://";
+
+    String LOCAL_FILES_CONFIG = "kestra.local-files";
+    String ALLOWED_PATHS_CONFIG = LocalPath.LOCAL_FILES_CONFIG + ".allowed-paths";
+    String ENABLE_FILE_FUNCTIONS_CONFIG = LocalPath.LOCAL_FILES_CONFIG + ".enable-file-functions";
+    String ENABLE_PREVIEW_CONFIG = LocalPath.LOCAL_FILES_CONFIG + ".enable-preview";
+
 
     /**
      * Get an InputStream of a local file denoted by this URI.
@@ -20,4 +28,20 @@ public interface LocalPath {
      * @throws SecurityException if the file is not allowed globally or specifically for this plugin.
      */
     InputStream get(URI uri) throws IOException;
+
+    /**
+     * Return true if the local file denoted by this URI exists.
+     *
+     * @param uri a file URI
+     * @throws SecurityException if the file is not allowed globally or specifically for this plugin.
+     */
+    boolean exists(URI uri) throws IOException;
+
+    /**
+     * Get a local file attributes.
+     *
+     * @param uri a file URI
+     * @throws SecurityException if the file is not allowed globally or specifically for this plugin.
+     */
+    BasicFileAttributes getAttributes(URI uri) throws IOException;
 }

--- a/core/src/main/java/io/kestra/core/runners/LocalPathFactory.java
+++ b/core/src/main/java/io/kestra/core/runners/LocalPathFactory.java
@@ -8,7 +8,9 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
+import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.attribute.BasicFileAttributes;
 import java.util.Collections;
 import java.util.List;
 
@@ -17,31 +19,83 @@ public class LocalPathFactory {
     private final List<String> globalAllowedPaths;
 
     @Inject
-    public LocalPathFactory(@Value("${kestra.plugins.allowed-paths:}") List<String> globalAllowedPaths) {
+    public LocalPathFactory(@Value("${" + LocalPath.ALLOWED_PATHS_CONFIG + ":}") List<String> globalAllowedPaths) {
         this.globalAllowedPaths = globalAllowedPaths;
     }
 
+    /**
+     * Create a LocalPath based on a RunContext, this is the preferred way as it would be allowed to check
+     * working directory and plugin configuration.
+     * If no RunContext is available {@link #createLocalPath()} can be used instead but this LocalPath would only be able to check
+     * paths globally allowed inside the Kestra configuration.
+     */
     public LocalPath createLocalPath(RunContext runContext) {
-        return new DefaultLocalPath(globalAllowedPaths, runContext);
+        return new RunContextLocalPath(globalAllowedPaths, runContext);
     }
 
-    static class DefaultLocalPath implements LocalPath {
+    /**
+     * Create a LocalPath.
+     * If a RunContext is available, this is preferable to use {@link #createLocalPath(RunContext)} as it would be possible to
+     * check for paths inside the working directory or allowed inside the plugin configuration.
+     */
+    public LocalPath createLocalPath() {
+        return new DefaultLocalPath(globalAllowedPaths);
+    }
+
+    abstract static class AbstractLocalPath implements LocalPath {
+        @Override
+        public InputStream get(URI uri) throws IOException {
+            if (!LocalPath.FILE_SCHEME.equals(uri.getScheme())) {
+                throw new IllegalArgumentException("The uri '" + uri + "' is not a valid file URI.");
+            }
+
+            Path path = checkPath(uri);
+            return new FileInputStream(path.toFile());
+        }
+
+        @Override
+        public boolean exists(URI uri) throws IOException {
+            if (!LocalPath.FILE_SCHEME.equals(uri.getScheme())) {
+                throw new IllegalArgumentException("The uri '" + uri + "' is not a valid file URI.");
+            }
+
+            Path path = checkPath(uri);
+            return Files.exists(path);
+        }
+
+        @Override
+        public BasicFileAttributes getAttributes(URI uri) throws IOException {
+            if (!LocalPath.FILE_SCHEME.equals(uri.getScheme())) {
+                throw new IllegalArgumentException("The uri '" + uri + "' is not a valid file URI.");
+            }
+
+            Path path = checkPath(uri);
+            return Files.readAttributes(path, BasicFileAttributes.class);
+        }
+
+        /**
+         * Check the URI then return it as a Path.
+         * Based on the available context, implementors should:
+         * - check if the file is inside the working directory
+         * - check globally allowed paths
+         * - check if plugin allowed paths
+         */
+        protected abstract Path checkPath(URI uri) throws IOException;
+    }
+
+    static class RunContextLocalPath extends AbstractLocalPath {
         private final List<String> globalAllowedPaths;
         private final RunContext runContext;
 
-        DefaultLocalPath(List<String> globalAllowedPaths, RunContext runContext) {
+        RunContextLocalPath(List<String> globalAllowedPaths, RunContext runContext) {
             this.globalAllowedPaths = globalAllowedPaths;
             this.runContext = runContext;
         }
 
         @Override
         @SuppressWarnings("unchecked")
-        public InputStream get(URI uri) throws IOException {
+        protected Path checkPath(URI uri) throws IOException {
             Path workingDirectory = runContext.workingDir().path(true);
-            if (!uri.getScheme().equals(LocalPath.FILE_SCHEME)) {
-                throw new IllegalArgumentException("The uri '" + uri + "' is not a valid file URI.");
-            }
-
             Path path = Path.of(uri).toRealPath(); // toRealPath() will protect about path traversal issues
             // We allow working directory or globally allowed path
             if (!path.startsWith(workingDirectory) && globalAllowedPaths.stream().noneMatch(path::startsWith)) {
@@ -49,12 +103,32 @@ public class LocalPathFactory {
                 List<String> pluginAllowedPaths = (List<String>) runContext.pluginConfiguration("allowed-paths").orElse(Collections.emptyList());
                 if (pluginAllowedPaths.stream().noneMatch(path::startsWith)) {
                     throw new SecurityException("The path " + path + " is not authorized. " +
-                        "Only files inside the working directory are allowed by default, other path must be allowed either globally inside the Kestra configuration using the `kestra.plugins.allowed-paths` property, " +
+                        "Only files inside the working directory are allowed by default, other path must be allowed either globally inside the Kestra configuration using the `" + LocalPath.ALLOWED_PATHS_CONFIG + "` property, " +
                         "or by plugin using the `allowed-paths` plugin configuration.");
                 }
             }
 
-            return new FileInputStream(path.toFile());
+            return path;
+        }
+    }
+
+    static class DefaultLocalPath extends AbstractLocalPath {
+        private final List<String> globalAllowedPaths;
+
+        DefaultLocalPath(List<String> globalAllowedPaths) {
+            this.globalAllowedPaths = globalAllowedPaths;
+        }
+
+        @Override
+        protected Path checkPath(URI uri) throws IOException {
+            Path path = Path.of(uri).toRealPath(); // toRealPath() will protect about path traversal issues
+            // we only allow globally allowed as we don't have a run context to get the working directory nor the plugin configuration
+            if (globalAllowedPaths.stream().noneMatch(path::startsWith)) {
+                throw new SecurityException("The path " + path + " is not authorized. " +
+                    "Path must be allowed either globally inside the Kestra configuration using the `" + LocalPath.ALLOWED_PATHS_CONFIG + "` property.");
+            }
+
+            return path;
         }
     }
 }

--- a/core/src/main/java/io/kestra/core/runners/pebble/functions/FileExistsFunction.java
+++ b/core/src/main/java/io/kestra/core/runners/pebble/functions/FileExistsFunction.java
@@ -1,17 +1,24 @@
 package io.kestra.core.runners.pebble.functions;
 
+import io.kestra.core.runners.LocalPath;
+import io.kestra.core.storages.StorageContext;
 import io.pebbletemplates.pebble.template.EvaluationContext;
 import jakarta.inject.Singleton;
+
+import java.io.IOException;
 import java.net.URI;
 
 @Singleton
 public class FileExistsFunction extends AbstractFileFunction {
     private static final String ERROR_MESSAGE = "The 'fileExists' function expects an argument 'path' that is a path to the internal storage URI.";
 
-    @SuppressWarnings("unchecked")
     @Override
-    protected Object fileFunction(EvaluationContext context, URI path, String namespace, String tenantId) {
-        return storageInterface.exists(tenantId, namespace, path);
+    protected Object fileFunction(EvaluationContext context, URI path, String namespace, String tenantId) throws IOException {
+        return switch (path.getScheme()) {
+            case StorageContext.KESTRA_SCHEME -> storageInterface.exists(tenantId, namespace, path);
+            case LocalPath.FILE_SCHEME -> localPathFactory.createLocalPath().exists(path);
+            default -> throw new IllegalArgumentException(SCHEME_NOT_SUPPORTED_ERROR.formatted(path));
+        };
     }
 
     @Override

--- a/core/src/main/java/io/kestra/core/runners/pebble/functions/FileSizeFunction.java
+++ b/core/src/main/java/io/kestra/core/runners/pebble/functions/FileSizeFunction.java
@@ -1,20 +1,31 @@
 package io.kestra.core.runners.pebble.functions;
 
+import io.kestra.core.runners.LocalPath;
 import io.kestra.core.storages.FileAttributes;
+import io.kestra.core.storages.StorageContext;
 import io.pebbletemplates.pebble.template.EvaluationContext;
 import jakarta.inject.Singleton;
 import java.io.IOException;
 import java.net.URI;
+import java.nio.file.attribute.BasicFileAttributes;
 
 @Singleton
 public class FileSizeFunction extends AbstractFileFunction {
     private static final String ERROR_MESSAGE = "The 'fileSize' function expects an argument 'path' that is a path to the internal storage URI.";
 
-    @SuppressWarnings("unchecked")
     @Override
     protected Object fileFunction(EvaluationContext context, URI path, String namespace, String tenantId) throws IOException {
-        FileAttributes fileAttributes = storageInterface.getAttributes(tenantId, namespace, path);
-        return fileAttributes.getSize();
+        return switch (path.getScheme()) {
+            case StorageContext.KESTRA_SCHEME -> {
+                FileAttributes fileAttributes = storageInterface.getAttributes(tenantId, namespace, path);
+                yield fileAttributes.getSize();
+            }
+            case LocalPath.FILE_SCHEME -> {
+                BasicFileAttributes fileAttributes = localPathFactory.createLocalPath().getAttributes(path);
+                yield fileAttributes.size();
+            }
+            default -> throw new IllegalArgumentException(SCHEME_NOT_SUPPORTED_ERROR.formatted(path));
+        };
     }
 
     @Override

--- a/core/src/main/java/io/kestra/core/runners/pebble/functions/IsFileEmptyFunction.java
+++ b/core/src/main/java/io/kestra/core/runners/pebble/functions/IsFileEmptyFunction.java
@@ -1,5 +1,7 @@
 package io.kestra.core.runners.pebble.functions;
 
+import io.kestra.core.runners.LocalPath;
+import io.kestra.core.storages.StorageContext;
 import io.pebbletemplates.pebble.template.EvaluationContext;
 import jakarta.inject.Singleton;
 import java.io.IOException;
@@ -10,13 +12,23 @@ import java.net.URI;
 public class IsFileEmptyFunction extends AbstractFileFunction {
     private static final String ERROR_MESSAGE = "The 'isFileEmpty' function expects an argument 'path' that is a path to a namespace file or an internal storage URI.";
 
-    @SuppressWarnings("unchecked")
     @Override
     protected Object fileFunction(EvaluationContext context, URI path, String namespace, String tenantId) throws IOException {
-        try (InputStream inputStream = storageInterface.get(tenantId, namespace, path)) {
-            byte[] buffer = new byte[1];
-            return inputStream.read(buffer, 0, 1) <= 0;
-        }
+        return switch (path.getScheme()) {
+            case StorageContext.KESTRA_SCHEME -> {
+                try (InputStream inputStream = storageInterface.get(tenantId, namespace, path)) {
+                    byte[] buffer = new byte[1];
+                    yield inputStream.read(buffer, 0, 1) <= 0;
+                }
+            }
+            case LocalPath.FILE_SCHEME -> {
+                try (InputStream inputStream = localPathFactory.createLocalPath().get(path)) {
+                    byte[] buffer = new byte[1];
+                    yield inputStream.read(buffer, 0, 1) <= 0;
+                }
+            }
+            default -> throw new IllegalArgumentException(SCHEME_NOT_SUPPORTED_ERROR.formatted(path));
+        };
     }
 
     @Override

--- a/core/src/test/java/io/kestra/core/runners/FilesServiceTest.java
+++ b/core/src/test/java/io/kestra/core/runners/FilesServiceTest.java
@@ -18,7 +18,7 @@ import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@KestraTest
+@KestraTest(rebuildContext = true)
 class FilesServiceTest {
     @Inject
     private TestRunContextFactory runContextFactory;
@@ -31,10 +31,10 @@ class FilesServiceTest {
         RunContext runContext = runContextFactory.of();
         FilesService.inputFiles(runContext, Map.of("file.txt", "content"));
 
-        FilesService.inputFiles(runContext, Map.of("file.txt", "overriden content"));
+        FilesService.inputFiles(runContext, Map.of("file.txt", "overridden content"));
 
         String fileContent = FileUtils.readFileToString(runContext.workingDir().path().resolve("file.txt").toFile(), "UTF-8");
-        assertThat(fileContent).isEqualTo("overriden content");
+        assertThat(fileContent).isEqualTo("overridden content");
     }
 
     @Test
@@ -52,7 +52,7 @@ class FilesServiceTest {
     }
 
     @Test
-    @Property(name = "kestra.plugins.allowed-paths", value = "/tmp")
+    @Property(name = LocalPath.ALLOWED_PATHS_CONFIG, value = "/tmp")
     void localFileAsInputFile() throws Exception {
         URI uri = createFile();
         RunContext runContext = runContextFactory.of();

--- a/core/src/test/java/io/kestra/core/runners/pebble/functions/FileExistsFunctionTest.java
+++ b/core/src/test/java/io/kestra/core/runners/pebble/functions/FileExistsFunctionTest.java
@@ -2,22 +2,27 @@ package io.kestra.core.runners.pebble.functions;
 
 import io.kestra.core.exceptions.IllegalVariableEvaluationException;
 import io.kestra.core.junit.annotations.KestraTest;
+import io.kestra.core.runners.LocalPath;
 import io.kestra.core.runners.VariableRenderer;
 import io.kestra.core.storages.StorageContext;
 import io.kestra.core.storages.StorageInterface;
 import io.kestra.core.utils.IdUtils;
+import io.micronaut.context.annotation.Property;
 import jakarta.inject.Inject;
 import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayInputStream;
+import java.io.File;
 import java.io.IOException;
 import java.net.URI;
+import java.nio.file.Files;
 import java.util.Map;
 
 import static io.kestra.core.tenant.TenantService.MAIN_TENANT;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 
-@KestraTest
+@KestraTest(rebuildContext = true)
 class FileExistsFunctionTest {
 
     private static final String NAMESPACE = "my.namespace";
@@ -84,5 +89,72 @@ class FileExistsFunctionTest {
         );
         boolean render = Boolean.parseBoolean(variableRenderer.render("{{ fileExists('" + internalStorageFile + "') }}", variables));
         assertFalse(render);
+    }
+
+    @Test
+    void shouldFailProcessingUnsupportedScheme() {
+        Map<String, Object> variables = Map.of(
+            "flow", Map.of(
+                "id", "notme",
+                "namespace", "notme",
+                "tenantId", MAIN_TENANT),
+            "execution", Map.of("id", "notme")
+        );
+
+        assertThrows(IllegalArgumentException.class, () -> variableRenderer.render("{{ fileExists('unsupported://path-to/file.txt') }}", variables));
+    }
+
+    @Test
+    void shouldFailProcessingNotAllowedPath() throws IOException {
+        URI file = createFile();
+        Map<String, Object> variables = Map.of(
+            "flow", Map.of(
+                "id", "notme",
+                "namespace", "notme",
+                "tenantId", MAIN_TENANT),
+            "execution", Map.of("id", "notme"),
+            "file", file.toString()
+        );
+
+        assertThrows(SecurityException.class, () -> variableRenderer.render("{{ fileExists(file) }}", variables));
+    }
+
+    @Test
+    @Property(name = LocalPath.ALLOWED_PATHS_CONFIG, value = "/tmp")
+    void shouldSucceedProcessingAllowedFile() throws IllegalVariableEvaluationException, IOException {
+        URI file = createFile();
+        Map<String, Object> variables = Map.of(
+            "flow", Map.of(
+                "id", "notme",
+                "namespace", "notme",
+                "tenantId", MAIN_TENANT),
+            "execution", Map.of("id", "notme"),
+            "file", file.toString()
+        );
+
+        assertThat(variableRenderer.render("{{ fileExists(file) }}", variables)).isEqualTo("true");
+    }
+
+    @Test
+    @Property(name = LocalPath.ALLOWED_PATHS_CONFIG, value = "/tmp")
+    @Property(name = LocalPath.ENABLE_FILE_FUNCTIONS_CONFIG, value = "false")
+    void shouldFailProcessingAllowedFileIfFileFunctionDisabled() throws IOException {
+        URI file = createFile();
+        Map<String, Object> variables = Map.of(
+            "flow", Map.of(
+                "id", "notme",
+                "namespace", "notme",
+                "tenantId", MAIN_TENANT),
+            "execution", Map.of("id", "notme"),
+            "file", file.toString()
+        );
+
+        assertThrows(SecurityException.class, () -> variableRenderer.render("{{ fileExists(file) }}", variables));
+    }
+
+    private URI createFile() throws IOException {
+        File tempFile = File.createTempFile("file", ".txt");
+        Files.write(tempFile.toPath(), "Hello World".getBytes());
+        return tempFile.toPath().toUri();
     }
 }

--- a/core/src/test/java/io/kestra/core/runners/pebble/functions/IsFileEmptyFunctionTest.java
+++ b/core/src/test/java/io/kestra/core/runners/pebble/functions/IsFileEmptyFunctionTest.java
@@ -2,22 +2,27 @@ package io.kestra.core.runners.pebble.functions;
 
 import io.kestra.core.exceptions.IllegalVariableEvaluationException;
 import io.kestra.core.junit.annotations.KestraTest;
+import io.kestra.core.runners.LocalPath;
 import io.kestra.core.runners.VariableRenderer;
 import io.kestra.core.storages.StorageContext;
 import io.kestra.core.storages.StorageInterface;
 import io.kestra.core.utils.IdUtils;
+import io.micronaut.context.annotation.Property;
 import jakarta.inject.Inject;
 import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayInputStream;
+import java.io.File;
 import java.io.IOException;
 import java.net.URI;
+import java.nio.file.Files;
 import java.util.Map;
 
 import static io.kestra.core.tenant.TenantService.MAIN_TENANT;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 
-@KestraTest
+@KestraTest(rebuildContext = true)
 class IsFileEmptyFunctionTest {
 
     private static final String NAMESPACE = "my.namespace";
@@ -84,5 +89,72 @@ class IsFileEmptyFunctionTest {
         );
         boolean render = Boolean.parseBoolean(variableRenderer.render("{{ isFileEmpty('" + internalStorageFile + "') }}", variables));
         assertTrue(render);
+    }
+
+    @Test
+    void shouldFailProcessingUnsupportedScheme() {
+        Map<String, Object> variables = Map.of(
+            "flow", Map.of(
+                "id", "notme",
+                "namespace", "notme",
+                "tenantId", MAIN_TENANT),
+            "execution", Map.of("id", "notme")
+        );
+
+        assertThrows(IllegalArgumentException.class, () -> variableRenderer.render("{{ isFileEmpty('unsupported://path-to/file.txt') }}", variables));
+    }
+
+    @Test
+    void shouldFailProcessingNotAllowedPath() throws IOException {
+        URI file = createFile();
+        Map<String, Object> variables = Map.of(
+            "flow", Map.of(
+                "id", "notme",
+                "namespace", "notme",
+                "tenantId", MAIN_TENANT),
+            "execution", Map.of("id", "notme"),
+            "file", file.toString()
+        );
+
+        assertThrows(SecurityException.class, () -> variableRenderer.render("{{ isFileEmpty(file) }}", variables));
+    }
+
+    @Test
+    @Property(name = LocalPath.ALLOWED_PATHS_CONFIG, value = "/tmp")
+    void shouldSucceedProcessingAllowedFile() throws IllegalVariableEvaluationException, IOException {
+        URI file = createFile();
+        Map<String, Object> variables = Map.of(
+            "flow", Map.of(
+                "id", "notme",
+                "namespace", "notme",
+                "tenantId", MAIN_TENANT),
+            "execution", Map.of("id", "notme"),
+            "file", file.toString()
+        );
+
+        assertThat(variableRenderer.render("{{ isFileEmpty(file) }}", variables)).isEqualTo("false");
+    }
+
+    @Test
+    @Property(name = LocalPath.ALLOWED_PATHS_CONFIG, value = "/tmp")
+    @Property(name = LocalPath.ENABLE_FILE_FUNCTIONS_CONFIG, value = "false")
+    void shouldFailProcessingAllowedFileIfFileFunctionDisabled() throws IOException {
+        URI file = createFile();
+        Map<String, Object> variables = Map.of(
+            "flow", Map.of(
+                "id", "notme",
+                "namespace", "notme",
+                "tenantId", MAIN_TENANT),
+            "execution", Map.of("id", "notme"),
+            "file", file.toString()
+        );
+
+        assertThrows(SecurityException.class, () -> variableRenderer.render("{{ isFileEmpty(file) }}", variables));
+    }
+
+    private URI createFile() throws IOException {
+        File tempFile = File.createTempFile("file", ".txt");
+        Files.write(tempFile.toPath(), "Hello World".getBytes());
+        return tempFile.toPath().toUri();
     }
 }


### PR DESCRIPTION
Supports the 'file://' protocol inside the read(), isFileEmpty(), fileExists() and fileSize() Pebble functions.

Closes #9739
