### PR TITLE
feat(flows): supports the nsfile:// protocol

### DIFF
--- a/core/src/main/java/io/kestra/core/models/property/Data.java
+++ b/core/src/main/java/io/kestra/core/models/property/Data.java
@@ -136,7 +136,7 @@ public class Data {
                 Structured data items can be defined in the following ways:
                 - A single item as a map (a document).
                 - A list of items as a list of maps (a list of documents).
-                - A URI, supported schemes are `kestra` for internal storage files, and `file` for host local files.
+                - A URI, supported schemes are `kestra` for internal storage files, `file` for host local files, and `nsfile` for namespace files.
                 - A JSON String that will then be serialized either as a single item or a list of items.""";
 
         @Schema(

--- a/core/src/main/java/io/kestra/core/models/tasks/InputFilesInterface.java
+++ b/core/src/main/java/io/kestra/core/models/tasks/InputFilesInterface.java
@@ -11,7 +11,7 @@ public interface InputFilesInterface {
         description = """
             Each file can be defined:
             - Inline with its content
-            - As a URI, supported schemes are `kestra` for internal storage files, and `file` for host local files.
+            - As a URI, supported schemes are `kestra` for internal storage files, `file` for host local files, and `nsfile` for namespace files.
             """,
         oneOf = {Map.class, String.class}
     )

--- a/core/src/main/java/io/kestra/core/storages/InternalNamespace.java
+++ b/core/src/main/java/io/kestra/core/storages/InternalNamespace.java
@@ -23,7 +23,7 @@ import java.util.function.Predicate;
  */
 public class InternalNamespace implements Namespace {
 
-    private static final Logger log = LoggerFactory.getLogger(InternalNamespace.class);
+    private static final Logger LOG = LoggerFactory.getLogger(InternalNamespace.class);
 
     private final String namespace;
     private final String tenant;
@@ -36,8 +36,8 @@ public class InternalNamespace implements Namespace {
      * @param namespace The namespace
      * @param storage   The storage.
      */
-    public InternalNamespace(final String namespace, final StorageInterface storage) {
-        this(log, null, namespace, storage);
+    public InternalNamespace(@Nullable final String tenant, final String namespace, final StorageInterface storage) {
+        this(LOG, tenant, namespace, storage);
     }
 
     /**

--- a/core/src/main/java/io/kestra/core/storages/Namespace.java
+++ b/core/src/main/java/io/kestra/core/storages/Namespace.java
@@ -14,6 +14,7 @@ import java.util.function.Predicate;
  * Service interface for accessing the files attached to a namespace (a.k.a., Namespace Files).
  */
 public interface Namespace {
+    String NAMESPACE_FILE_SCHEME = "nsfile";
 
     /**
      * Gets the current namespace.

--- a/core/src/main/java/io/kestra/core/validations/validator/FileInputValidator.java
+++ b/core/src/main/java/io/kestra/core/validations/validator/FileInputValidator.java
@@ -2,6 +2,7 @@ package io.kestra.core.validations.validator;
 
 import io.kestra.core.models.flows.input.FileInput;
 import io.kestra.core.runners.LocalPath;
+import io.kestra.core.storages.Namespace;
 import io.kestra.core.validations.FileInputValidation;
 import io.micronaut.core.annotation.AnnotationValue;
 import io.micronaut.core.annotation.Introspected;
@@ -20,9 +21,9 @@ public class FileInputValidator implements ConstraintValidator<FileInputValidati
             return true; // nulls are allowed according to spec
         }
 
-        if (value.getDefaults() != null && !LocalPath.FILE_SCHEME.equals(value.getDefaults().getScheme())) {
+        if (value.getDefaults() != null && !LocalPath.FILE_SCHEME.equals(value.getDefaults().getScheme()) && !Namespace.NAMESPACE_FILE_SCHEME.equals(value.getDefaults().getScheme())) {
             context.disableDefaultConstraintViolation();
-            context.buildConstraintViolationWithTemplate("inputs of type 'FILE' only support `defaults` as local files using a file URI")
+            context.buildConstraintViolationWithTemplate("inputs of type 'FILE' only support `defaults` as local files using a file URI or as namespace files using a nsfile URI")
                 .addConstraintViolation();
             return false;
         }

--- a/core/src/test/java/io/kestra/core/runners/pebble/functions/FileSizeFunctionTest.java
+++ b/core/src/test/java/io/kestra/core/runners/pebble/functions/FileSizeFunctionTest.java
@@ -242,6 +242,45 @@ public class FileSizeFunctionTest {
         assertThrows(SecurityException.class, () -> variableRenderer.render("{{ fileSize(file) }}", variables));
     }
 
+
+    @Test
+    void shouldProcessNamespaceFile() throws IOException, IllegalVariableEvaluationException {
+        URI file = createNsFile(false);
+        Map<String, Object> variables = Map.of(
+            "flow", Map.of(
+                "id", "flow",
+                "namespace", "io.kestra.tests",
+                "tenantId", MAIN_TENANT),
+            "execution", Map.of("id", "execution"),
+            "nsfile", file.toString()
+        );
+
+        assertThat(variableRenderer.render("{{ fileSize(nsfile) }}", variables)).isEqualTo("11");
+    }
+
+    @Test
+    void shouldProcessNamespaceFileFromAnotherNamespace() throws IOException, IllegalVariableEvaluationException {
+        URI file = createNsFile(true);
+        Map<String, Object> variables = Map.of(
+            "flow", Map.of(
+                "id", "flow",
+                "namespace", "notme",
+                "tenantId", MAIN_TENANT),
+            "execution", Map.of("id", "execution"),
+            "nsfile", file.toString()
+        );
+
+        assertThat(variableRenderer.render("{{ fileSize(nsfile) }}", variables)).isEqualTo("11");
+    }
+
+    private URI createNsFile(boolean nsInAuthority) throws IOException {
+        String namespace = "io.kestra.tests";
+        String filePath = "file.txt";
+        storageInterface.createDirectory(MAIN_TENANT, namespace, URI.create(StorageContext.namespaceFilePrefix(namespace)));
+        storageInterface.put(MAIN_TENANT, namespace, URI.create(StorageContext.namespaceFilePrefix(namespace) + "/" + filePath), new ByteArrayInputStream("Hello World".getBytes()));
+        return URI.create("nsfile://" + (nsInAuthority ? namespace : "") + "/" + filePath);
+    }
+
     private URI createFile() throws IOException {
         File tempFile = File.createTempFile("file", ".txt");
         Files.write(tempFile.toPath(), "Hello World".getBytes());

--- a/core/src/test/java/io/kestra/core/runners/pebble/functions/ReadFileFunctionTest.java
+++ b/core/src/test/java/io/kestra/core/runners/pebble/functions/ReadFileFunctionTest.java
@@ -250,9 +250,47 @@ class ReadFileFunctionTest {
         assertThrows(SecurityException.class, () -> variableRenderer.render("{{ read(file) }}", variables));
     }
 
+    @Test
+    void shouldProcessNamespaceFile() throws IOException, IllegalVariableEvaluationException {
+        URI file = createNsFile(false);
+        Map<String, Object> variables = Map.of(
+            "flow", Map.of(
+                "id", "flow",
+                "namespace", "io.kestra.tests",
+                "tenantId", MAIN_TENANT),
+            "execution", Map.of("id", "execution"),
+            "nsfile", file.toString()
+        );
+
+        assertThat(variableRenderer.render("{{ read(nsfile) }}", variables)).isEqualTo("Hello World");
+    }
+
+    @Test
+    void shouldProcessNamespaceFileFromAnotherNamespace() throws IOException, IllegalVariableEvaluationException {
+        URI file = createNsFile(true);
+        Map<String, Object> variables = Map.of(
+            "flow", Map.of(
+                "id", "flow",
+                "namespace", "notme",
+                "tenantId", MAIN_TENANT),
+            "execution", Map.of("id", "execution"),
+            "nsfile", file.toString()
+        );
+
+        assertThat(variableRenderer.render("{{ read(nsfile) }}", variables)).isEqualTo("Hello World");
+    }
+
     private URI createFile() throws IOException {
         File tempFile = File.createTempFile("file", ".txt");
         Files.write(tempFile.toPath(), "Hello World".getBytes());
         return tempFile.toPath().toUri();
+    }
+
+    private URI createNsFile(boolean nsInAuthority) throws IOException {
+        String namespace = "io.kestra.tests";
+        String filePath = "file.txt";
+        storageInterface.createDirectory(MAIN_TENANT, namespace, URI.create(StorageContext.namespaceFilePrefix(namespace)));
+        storageInterface.put(MAIN_TENANT, namespace, URI.create(StorageContext.namespaceFilePrefix(namespace) + "/" + filePath), new ByteArrayInputStream("Hello World".getBytes()));
+        return URI.create("nsfile://" + (nsInAuthority ? namespace : "") + "/" + filePath);
     }
 }


### PR DESCRIPTION
Automatically fetch namespace files from URI with the 'nsfile' scheme. The authority allow to fetch file from another namespace.

The following has been done:
- Supports using nsfile inside `from`
- Supports using nsfile inside input files
- Supports using nsfile as a FILE input defaults
- Supports using nsfile inside the Pebble files functions

Closes: #9741