### PR TITLE
fix(system)*: mitigate possible deadlock for execution delay and SLA

### DIFF
--- a/jdbc/src/main/java/io/kestra/jdbc/runner/AbstractJdbcExecutionDelayStorage.java
+++ b/jdbc/src/main/java/io/kestra/jdbc/runner/AbstractJdbcExecutionDelayStorage.java
@@ -24,13 +24,15 @@ public abstract class AbstractJdbcExecutionDelayStorage extends AbstractJdbcRepo
         this.jdbcRepository
             .getDslContextWrapper()
             .transaction(configuration -> {
-                SelectConditionStep<Record1<Object>> select = DSL
+                var select = DSL
                     .using(configuration)
                     .select(AbstractJdbcRepository.field("value"))
                     .from(this.jdbcRepository.getTable())
                     .where(
                         AbstractJdbcRepository.field("date").lessOrEqual(now.toOffsetDateTime())
-                    );
+                    )
+                    .forUpdate()
+                    .skipLocked();
 
                 this.jdbcRepository.fetch(select)
                     .forEach(executionDelay -> {

--- a/jdbc/src/main/java/io/kestra/jdbc/runner/AbstractJdbcSLAMonitorStorage.java
+++ b/jdbc/src/main/java/io/kestra/jdbc/runner/AbstractJdbcSLAMonitorStorage.java
@@ -49,7 +49,9 @@ public abstract class AbstractJdbcSLAMonitorStorage extends AbstractJdbcReposito
                 DSLContext context = DSL.using(configuration);
                 var select = context.select()
                     .from(this.jdbcRepository.getTable())
-                    .where(field("deadline").lt(date));
+                    .where(field("deadline").lt(date))
+                    .forUpdate()
+                    .skipLocked();
 
                 this.jdbcRepository.fetch(select)
                     .forEach(slaMonitor -> {


### PR DESCRIPTION
In case multiple instances of the executor are started, the execution delay loop and the monitoring SLA loop have a risk of duplicate execution resume or execution SLA violation computation. This could create some race conditions and duplicate execution update. But this may also risk to create some deadlocks as two instances of the executor may try to lock the same exection to restart it (or fail it due to SLA).
