### PR TITLE
docs(tests,flows): set loosely types fields like input and variable a…

### DIFF
--- a/core/src/main/java/io/kestra/core/models/flows/AbstractFlow.java
+++ b/core/src/main/java/io/kestra/core/models/flows/AbstractFlow.java
@@ -62,6 +62,7 @@ public abstract class AbstractFlow implements FlowInterface {
     @Schema(implementation = Object.class, oneOf = {List.class, Map.class})
     List<Label> labels;
 
+    @Schema(additionalProperties = Schema.AdditionalPropertiesValue.TRUE)
     Map<String, Object> variables;
 
     @Valid

--- a/core/src/main/java/io/kestra/core/models/flows/Flow.java
+++ b/core/src/main/java/io/kestra/core/models/flows/Flow.java
@@ -70,6 +70,8 @@ public class Flow extends AbstractFlow implements HasUID {
 
     @Valid
     @NotEmpty
+
+    @Schema(additionalProperties = Schema.AdditionalPropertiesValue.TRUE)
     List<Task> tasks;
 
     @Valid

--- a/core/src/main/java/io/kestra/core/test/flow/Fixtures.java
+++ b/core/src/main/java/io/kestra/core/test/flow/Fixtures.java
@@ -1,5 +1,6 @@
 package io.kestra.core.test.flow;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.Valid;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -14,6 +15,8 @@ import java.util.Map;
 @NoArgsConstructor
 @AllArgsConstructor
 public class Fixtures {
+
+    @Schema(additionalProperties = Schema.AdditionalPropertiesValue.TRUE)
     private Map<String, Object> inputs;
 
     private Map<String, String> files;


### PR DESCRIPTION
…s additional properties

this make the generated openapi spec match batter the existing API
combined with https://github.com/kestra-io/client-sdk/pull/13 the SDK should be available without any crash (at least in GO)
