### PR TITLE
fix(webserver): fix reason in ErrorController

### DIFF
--- a/webserver/src/main/java/io/kestra/webserver/controllers/ErrorController.java
+++ b/webserver/src/main/java/io/kestra/webserver/controllers/ErrorController.java
@@ -147,12 +147,12 @@ public class ErrorController {
 
     @Error(global = true)
     public HttpResponse<JsonError> error(HttpRequest<?> request, NotFoundException e) {
-        return jsonError(request, e, HttpStatus.NOT_FOUND, Optional.ofNullable(e.getMessage()).orElse(HttpStatus.NOT_FOUND.getReason()));
+        return jsonError(request, e, HttpStatus.NOT_FOUND, HttpStatus.NOT_FOUND.getReason());
     }
 
     @Error(global = true)
     public HttpResponse<JsonError> error(HttpRequest<?> request, ConflictException e) {
-        return jsonError(request, e, HttpStatus.CONFLICT, Optional.ofNullable(e.getMessage()).orElse(HttpStatus.CONFLICT.getReason()));
+        return jsonError(request, e, HttpStatus.CONFLICT, HttpStatus.CONFLICT.getReason());
     }
 
     @Error(global = true)


### PR DESCRIPTION
The exception message is already included in the payload returned from the response, so we don't have to include it in the HTTP Reason phrase. This leads to a wrong error message format in the UI which is in the form {Reason}: {Error Message}. With the current code Reason=Error Message