### PR TITLE
fix(cli): prevent NPE on commands defaulting to help

### DIFF
--- a/cli/src/main/java/io/kestra/cli/AbstractCommand.java
+++ b/cli/src/main/java/io/kestra/cli/AbstractCommand.java
@@ -40,7 +40,7 @@ import picocli.CommandLine.Option;
 )
 @Slf4j
 @Introspected
-abstract public class AbstractCommand implements Callable<Integer> {
+public abstract class AbstractCommand implements Callable<Integer> {
     @Inject
     private ApplicationContext applicationContext;
 
@@ -93,7 +93,7 @@ abstract public class AbstractCommand implements Callable<Integer> {
             this.startupHook.start(this);
         }
 
-        if (this.pluginsPath != null && loadExternalPlugins()) {
+        if (pluginRegistryProvider != null && this.pluginsPath != null && loadExternalPlugins()) {
             pluginRegistry = pluginRegistryProvider.get();
             pluginRegistry.registerIfAbsent(pluginsPath);
 


### PR DESCRIPTION
### What changes are being made and why?

Prevent NPE on commands defaulting to help. For example, `./kestra server` used to fail with:

```text
java.lang.NullPointerException: Cannot invoke "jakarta.inject.Provider.get()" because "this.pluginRegistryProvider" is null
	at io.kestra.cli.AbstractCommand.call(AbstractCommand.java:101)
	at io.kestra.cli.commands.servers.ServerCommand.call(ServerCommand.java:29)
	at io.kestra.cli.commands.servers.ServerCommand.call(ServerCommand.java:10)
	at picocli.CommandLine.executeUserObject(CommandLine.java:2045)
	at picocli.CommandLine.access$1500(CommandLine.java:148)
	at picocli.CommandLine$RunLast.executeUserObjectOfLastSubcommandWithSameParent(CommandLine.java:2465)
	at picocli.CommandLine$RunLast.handle(CommandLine.java:2457)
	at picocli.CommandLine$RunLast.handle(CommandLine.java:2419)
	at picocli.CommandLine$AbstractParseResultHandler.execute(CommandLine.java:2277)
	at picocli.CommandLine$RunLast.execute(CommandLine.java:2421)
	at picocli.CommandLine.execute(CommandLine.java:2174)
	at io.kestra.cli.App.execute(App.java:70)
	at io.kestra.cli.App.main(App.java:52)
```

---

### How the changes have been QAed?

Sadly, I was unable to reproduce that NPE using unit tests - I tried a similar approach to `io.kestra.cli.AppTest`.
