### PR TITLE
docs(dashboard-data): fix indentations for dashboard data plugins

### DIFF
--- a/core/src/main/java/io/kestra/plugin/core/dashboard/data/Executions.java
+++ b/core/src/main/java/io/kestra/plugin/core/dashboard/data/Executions.java
@@ -30,7 +30,7 @@ import lombok.experimental.SuperBuilder;
         @Example(
             title = "Display a chart with a Executions per Namespace broken out by State.",
             full = true,
-            code = """
+            code = { """
             charts:                
               - id: executions_per_namespace_bars
                 type: io.kestra.plugin.core.dashboard.chart.Bar
@@ -50,7 +50,8 @@ import lombok.experimental.SuperBuilder;
                     total:
                       displayName: Executions
                       agg: COUNT
-            """                    
+            """
+          }                    
         )
     }
 )

--- a/core/src/main/java/io/kestra/plugin/core/dashboard/data/ExecutionsKPI.java
+++ b/core/src/main/java/io/kestra/plugin/core/dashboard/data/ExecutionsKPI.java
@@ -30,7 +30,7 @@ import lombok.experimental.SuperBuilder;
         @Example(
             title = "Display a chart with executions in success in a given namespace.",
             full = true,
-            code = """
+            code = { """
             charts:
               - id: kpi_success_ratio
                 type: io.kestra.plugin.core.dashboard.chart.KPI
@@ -49,6 +49,7 @@ import lombok.experimental.SuperBuilder;
                       values:
                         - SUCCESS
             """
+          }
         )
     }
 )

--- a/core/src/main/java/io/kestra/plugin/core/dashboard/data/Logs.java
+++ b/core/src/main/java/io/kestra/plugin/core/dashboard/data/Logs.java
@@ -29,7 +29,7 @@ import java.util.Set;
         @Example(
             title = "Display a chart with a count of Logs per date grouped by level.",
             full = true,
-            code = """
+            code = { """
             charts:
               - id: logs_timeseries
                 type: io.kestra.plugin.core.dashboard.chart.TimeSeries
@@ -53,6 +53,7 @@ import java.util.Set;
                       agg: COUNT
                       graphStyle: BARS
             """
+          }
         )
     }
 )

--- a/core/src/main/java/io/kestra/plugin/core/dashboard/data/LogsKPI.java
+++ b/core/src/main/java/io/kestra/plugin/core/dashboard/data/LogsKPI.java
@@ -29,7 +29,7 @@ import java.util.Set;
         @Example(
             title = "Display a chart with a count of Logs per date grouped by level.",
             full = true,
-            code = """
+            code = { """
             charts:
               - id: logs_timeseries
                 type: io.kestra.plugin.core.dashboard.chart.TimeSeries
@@ -52,7 +52,8 @@ import java.util.Set;
                       displayName: Total Executions
                       agg: COUNT
                       graphStyle: BARS
-            """                
+            """
+          }                
         )
     }
 )

--- a/core/src/main/java/io/kestra/plugin/core/dashboard/data/Metrics.java
+++ b/core/src/main/java/io/kestra/plugin/core/dashboard/data/Metrics.java
@@ -27,7 +27,7 @@ import lombok.experimental.SuperBuilder;
         @Example(
             title = "Display a chart with rows inserted by Namespace.",
             full = true,
-            code = """
+            code = { """
             charts:
               - id: table_metrics
                 type: io.kestra.plugin.core.dashboard.chart.Table
@@ -49,6 +49,7 @@ import lombok.experimental.SuperBuilder;
                     - column: inserted_rows
                       order: DESC
             """
+          }
         )
     }
 )

--- a/core/src/main/java/io/kestra/plugin/core/dashboard/data/MetricsKPI.java
+++ b/core/src/main/java/io/kestra/plugin/core/dashboard/data/MetricsKPI.java
@@ -27,7 +27,7 @@ import lombok.experimental.SuperBuilder;
         @Example(
             title = "Display a chart with rows inserted by Namespace.",
             full = true,
-            code = """
+            code = { """
             charts:
               - id: table_metrics
                 type: io.kestra.plugin.core.dashboard.chart.Table
@@ -49,6 +49,7 @@ import lombok.experimental.SuperBuilder;
                     - column: inserted_rows
                       order: DESC
             """
+          }
         )
     }
 )


### PR DESCRIPTION
Examples were indented weirdly. Should fix

<img width="1919" alt="Screenshot 2025-07-07 at 11 09 15" src="https://github.com/user-attachments/assets/13f35671-084d-456a-a214-915c0a00f846" />
