### PR TITLE
fix(ui): fixes merge snafu and warning lastExecutionByFlowReady

### DIFF
--- a/ui/src/components/executions/Executions.vue
+++ b/ui/src/components/executions/Executions.vue
@@ -412,6 +412,7 @@
 
 <script>
     import {mapState, mapGetters} from "vuex";
+    import {mapStores} from "pinia";
     import DataTable from "../layout/DataTable.vue";
     import TextSearch from "vue-material-design-icons/TextSearch.vue";
     import Status from "../Status.vue";
@@ -423,6 +424,7 @@
     import Labels from "../layout/Labels.vue"
     import RestoreUrl from "../../mixins/restoreUrl";
     import {State} from "@kestra-io/ui-libs"
+    import {useStatStore} from "../../stores/stat";
     import Id from "../Id.vue";
     import _merge from "lodash/merge";
     import permission from "../../models/permission";
@@ -589,6 +591,7 @@
             ...mapState("execution", ["executions", "total"]),
             ...mapState("auth", ["user"]),
             ...mapState("flow", ["flow"]),
+            ...mapStores(useStatStore),
             ...mapGetters("misc", ["configs"]),
             routeInfo() {
                 return {
@@ -644,6 +647,11 @@
                         label: this.$t("mark as", {status: value})
                     };
                 });
+            },
+            executionsCount() {
+                return this.statStore.dailyData?.reduce((a, b) => {  
+                    return a + Object.values(b.executionCounts).reduce((a, b) => a + b, 0);  
+                }, 0) ?? 0; 
             },
             selectedNamespace(){
                 return this.namespace !== null && this.namespace !== undefined ? this.namespace : this.$route.query?.namespace;

--- a/ui/src/stores/stat.ts
+++ b/ui/src/stores/stat.ts
@@ -1,0 +1,49 @@
+import {defineStore} from "pinia";
+import {apiUrl} from "override/utils/route";
+
+type StatsPayload = Record<string, any>;
+type DailyStats = Record<string, any>;
+type TaskRunStats = Record<string, any>;
+type LastExecutionStats = Record<string, any>;
+
+interface State {
+    dailyGroupByFlowData: DailyStats | undefined;
+    dailyData: DailyStats | undefined;
+    taskRunDailyData: TaskRunStats | undefined;
+    lastExecutionsData: LastExecutionStats | undefined;
+}
+
+export const useStatStore = defineStore("stat", {
+    state: (): State => ({
+        dailyGroupByFlowData: undefined,
+        dailyData: undefined,
+        taskRunDailyData: undefined,
+        lastExecutionsData: undefined
+    }),
+
+    actions: {
+        async dailyGroupByFlow(payload: StatsPayload) {
+            const response = await this.$http.post(`${apiUrl(this.vuexStore)}/stats/executions/daily/group-by-flow`, payload);
+            this.dailyGroupByFlowData = response.data;
+            return response.data;
+        },
+
+        async daily(payload: StatsPayload) {
+            const response = await this.$http.post(`${apiUrl(this.vuexStore)}/stats/executions/daily`, payload);
+            this.dailyData = response.data;
+            return response.data;
+        },
+
+        async taskRunDaily(payload: StatsPayload) {
+            const response = await this.$http.post(`${apiUrl(this.vuexStore)}/stats/taskruns/daily`, payload);
+            this.taskRunDailyData = response.data;
+            return response.data;
+        },
+
+        async lastExecutions(payload: StatsPayload) {
+            const response = await this.$http.post(`${apiUrl(this.vuexStore)}/stats/executions/latest/group-by-flow`, payload);
+            this.lastExecutionsData = response.data;
+            return response.data;
+        }
+    }
+});


### PR DESCRIPTION
Fixes:  Warning
```
Property "lastExecutionByFlowReady" was accessed during render but is not defined on instance. Proxy(Object) {…} at <TableTdWrapper>
at <ElTableBody>
at <ElScrollbar>
at <ElTable>
at <SelectTable>
at <ElContainer>
at <DataTable>
at <Flows>
at <RouterView>
at <DefaultLayout>
at <ElConfigProvider>
at <App> (12) [{…}, {…}, {…}, {…}, {…}, {…}, {…}, {…}, {…}, {…}, {…}, {…}]
```

It was due to a merge snafu - Changes didn't appear after merge - https://github.com/kestra-io/kestra/pull/9750