### PR TITLE
fix(ci): Avoid retag latest docker image being `true` by default

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -7,7 +7,7 @@ on:
         description: 'Retag latest Docker images'
         required: true
         type: string
-        default: "true"
+        default: "false"
         options:
           - "true"
           - "false"


### PR DESCRIPTION
Companion PR : https://github.com/kestra-io/kestra-ee/pull/4309