### PR TITLE
fix(webserver): server exceptions were not logged when no message

### DIFF
--- a/webserver/src/main/java/io/kestra/webserver/controllers/ErrorController.java
+++ b/webserver/src/main/java/io/kestra/webserver/controllers/ErrorController.java
@@ -220,9 +220,11 @@ public class ErrorController {
 
     public static HttpResponse<JsonError> jsonError(HttpRequest<?> request, Throwable e, HttpStatus status, String reason) {
         if (status == HttpStatus.INTERNAL_SERVER_ERROR) {
-            log.error(e.getMessage(), e);
+            var prefixMessage = "Server error: ";
+            log.error(prefixMessage + (e.getMessage() != null ? e.getMessage() : ""), e);
         } else {
-            log.trace(e.getMessage(), e);
+            var prefixMessage = "Client error: ";
+            log.trace(prefixMessage + (e.getMessage() != null ? e.getMessage() : ""), e);
         }
 
         JsonError error = new JsonError(reason + (e.getMessage() != null ? ": " + e.getMessage() : ""))

--- a/webserver/src/test/java/io/kestra/webserver/controllers/api/TestUtilsController.java
+++ b/webserver/src/test/java/io/kestra/webserver/controllers/api/TestUtilsController.java
@@ -1,0 +1,47 @@
+package io.kestra.webserver.controllers.api;
+
+import io.kestra.webserver.models.ai.FlowGenerationPrompt;
+import io.kestra.webserver.services.ai.AiServiceInterface;
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.http.HttpStatus;
+import io.micronaut.http.annotation.*;
+import io.micronaut.http.exceptions.HttpStatusException;
+import io.micronaut.scheduling.TaskExecutors;
+import io.micronaut.scheduling.annotation.ExecuteOn;
+import io.micronaut.validation.Validated;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import jakarta.inject.Inject;
+import lombok.extern.slf4j.Slf4j;
+import reactor.core.publisher.Mono;
+
+@Slf4j
+@Validated
+@Controller("/test-utils")
+public class TestUtilsController {
+
+    @ExecuteOn(TaskExecutors.IO)
+    @Get(uri = "/failing-with-400-client-error", produces = "application/json")
+    public String failingWith400ClientError() {
+        if(true){
+            throw new HttpStatusException(HttpStatus.BAD_REQUEST, "a client error message");
+        }
+        return "";
+    }
+    @ExecuteOn(TaskExecutors.IO)
+    @Get(uri = "/failing-with-500-server-error", produces = "application/json")
+    public String failingWith500ServerError() {
+        if(true){
+            throw new RuntimeException("an unhandled server error message");
+        }
+        return "";
+    }
+    @ExecuteOn(TaskExecutors.IO)
+    @Get(uri = "/failing-with-server-error-with-no-error-message", produces = "application/json")
+    public String failingWithServerErrorWithNoErrorMessage() {
+        if(true){
+            throw new NullPointerException();
+        }
+        return "";
+    }
+}


### PR DESCRIPTION
some libraries or even java code throw Exceptions with a 'null' message (but with a stacktrace), in this case our logger was not logging anything
