### PR TITLE
fix(core): trim expressions in select & multiselect to be able to use '|' instead of '>-'

### DIFF
--- a/core/src/main/java/io/kestra/core/models/flows/input/MultiselectInput.java
+++ b/core/src/main/java/io/kestra/core/models/flows/input/MultiselectInput.java
@@ -108,7 +108,7 @@ public class MultiselectInput extends Input<List<String>> implements ItemTypeInt
     private List<String> renderExpressionValues(final Function<String, Object> renderer) {
         Object result;
         try {
-            result = renderer.apply(expression);
+            result = renderer.apply(expression.trim());
         } catch (Exception e) {
             throw ManualConstraintViolation.toConstraintViolationException(
                 "Cannot render 'expression'. Cause: " + e.getMessage(),

--- a/core/src/main/java/io/kestra/core/models/flows/input/SelectInput.java
+++ b/core/src/main/java/io/kestra/core/models/flows/input/SelectInput.java
@@ -86,7 +86,7 @@ public class SelectInput extends Input<String> implements RenderableInput {
     private List<String> renderExpressionValues(final Function<String, Object> renderer) {
         Object result;
         try {
-            result = renderer.apply(expression);
+            result = renderer.apply(expression.trim());
         } catch (Exception e) {
             throw ManualConstraintViolation.toConstraintViolationException(
                 "Cannot render 'expression'. Cause: " + e.getMessage(),

--- a/core/src/test/java/io/kestra/core/models/flows/input/MultiselectInputTest.java
+++ b/core/src/test/java/io/kestra/core/models/flows/input/MultiselectInputTest.java
@@ -26,7 +26,7 @@ class MultiselectInputTest {
         MultiselectInput input = MultiselectInput
             .builder()
             .id("id")
-            .expression("{{ values }}")
+            .expression("{{ values }}\n")
             .build();
         // When
         Input<?> renderInput = RenderableInput.mayRenderInput(input, s -> {

--- a/core/src/test/java/io/kestra/core/models/flows/input/SelectInputTest.java
+++ b/core/src/test/java/io/kestra/core/models/flows/input/SelectInputTest.java
@@ -26,7 +26,7 @@ class SelectInputTest {
         SelectInput input = SelectInput
             .builder()
             .id("id")
-            .expression("{{ values }}")
+            .expression("{{ values }}\n")
             .build();
         // When
         Input<?> renderInput = RenderableInput.mayRenderInput(input, s -> {


### PR DESCRIPTION
closes #10016
