### PR TITLE
fix(core): streamlining base URL creation

### DIFF
--- a/ui/src/override/utils/route.ts
+++ b/ui/src/override/utils/route.ts
@@ -1,4 +1,4 @@
-import type {Store} from "vuex"
+import {Store} from "vuex";
 
 declare global {
     interface Window {
@@ -6,26 +6,27 @@ declare global {
     }
 }
 
-const createBaseUrl = (): string => {
-    const root = (import.meta.env.VITE_APP_API_URL || "") + (window.KESTRA_BASE_PATH || "")
-    return root.trim() || window.location.origin
+let root = (import.meta.env.VITE_APP_API_URL || "") + window.KESTRA_BASE_PATH;
+if (root.endsWith("/")) {
+    root = root.substring(0, root.length - 1);
 }
 
-export const baseUrl = createBaseUrl().replace(/\/$/, "")
-export const basePath = "/api/v1/main"
+export const baseUrl = root;
 
-export const apiUrl = (_: Store<any>): string => {
-    const login = localStorage.getItem("basicAuthLogin")
-    const password = localStorage.getItem("basicAuthPassword")
-    
-    if (!login || !password) return `${baseUrl}${basePath}`
-    
+export const basePath = () => "/api/v1/main"
+
+export const apiUrl = (_: Store<any>) => {
+    const login = localStorage.getItem("basicAuthLogin");
+    const password = localStorage.getItem("basicAuthPassword");
+    if(!login || !password) {
+        return `${baseUrl}${basePath()}`
+    }
     try {
-        const {protocol, host} = new URL(baseUrl)
-        return `${protocol}//${login}:${password}@${host}${basePath}`
+        const {protocol, host} = new URL(baseUrl); // Validate baseUrl
+        return `${protocol}//${login}:${password}@${host}${basePath()}`
     } catch {
-        return `${baseUrl}${basePath}`
+        return `${baseUrl}${basePath()}`;
     }
 }
 
-export const apiUrlWithoutTenants = (): string => `${baseUrl}/api/v1`
+export const apiUrlWithoutTenants = () => `${baseUrl}/api/v1`

--- a/ui/src/override/utils/route.ts
+++ b/ui/src/override/utils/route.ts
@@ -1,4 +1,4 @@
-import {Store} from "vuex";
+import type {Store} from "vuex"
 
 declare global {
     interface Window {
@@ -6,23 +6,26 @@ declare global {
     }
 }
 
-let root = (import.meta.env.VITE_APP_API_URL || "") + window.KESTRA_BASE_PATH;
-if (root.endsWith("/")) {
-    root = root.substring(0, root.length - 1);
+const createBaseUrl = (): string => {
+    const root = (import.meta.env.VITE_APP_API_URL || "") + (window.KESTRA_BASE_PATH || "")
+    return root.trim() || window.location.origin
 }
 
-export const baseUrl = root;
+export const baseUrl = createBaseUrl().replace(/\/$/, "")
+export const basePath = "/api/v1/main"
 
-export const basePath = () => "/api/v1/main"
-
-export const apiUrl = (_: Store<any>) => {
-    const login = localStorage.getItem("basicAuthLogin");
-    const password = localStorage.getItem("basicAuthPassword");
-    if(!login || !password) {
-        return `${baseUrl}${basePath()}`
+export const apiUrl = (_: Store<any>): string => {
+    const login = localStorage.getItem("basicAuthLogin")
+    const password = localStorage.getItem("basicAuthPassword")
+    
+    if (!login || !password) return `${baseUrl}${basePath}`
+    
+    try {
+        const {protocol, host} = new URL(baseUrl)
+        return `${protocol}//${login}:${password}@${host}${basePath}`
+    } catch {
+        return `${baseUrl}${basePath}`
     }
-    const baseUrlParsed = new URL(baseUrl); // Validate baseUrl
-    return `${baseUrlParsed.protocol}//${login}:${password}@${baseUrlParsed.host}${basePath()}`
 }
 
-export const apiUrlWithoutTenants = () => `${baseUrl}/api/v1`
+export const apiUrlWithoutTenants = (): string => `${baseUrl}/api/v1`


### PR DESCRIPTION
While creating user at fist step,  `localhost:8080`
`Failed to create basic auth account: TypeError: Failed to construct 'URL': Invalid URL`

<img width="3420" height="1900" alt="image" src="https://github.com/user-attachments/assets/9ac4bb04-3ace-4ad7-9925-5ebbee053e94" />


