### PR TITLE
fix(core): amend misc label-related issues

### DIFF
--- a/core/src/main/java/io/kestra/core/models/Label.java
+++ b/core/src/main/java/io/kestra/core/models/Label.java
@@ -1,11 +1,10 @@
 package io.kestra.core.models;
 
 import io.kestra.core.utils.MapUtils;
+import jakarta.annotation.Nullable;
 import jakarta.validation.constraints.NotNull;
 
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.stream.Collectors;
 
 public record Label(@NotNull String key, @NotNull String value) {
@@ -29,11 +28,36 @@ public record Label(@NotNull String key, @NotNull String value) {
      * @return the nested {@link Map}.
      */
     public static Map<String, Object> toNestedMap(List<Label> labels) {
-        Map<String, Object> asMap = labels.stream()
+        return MapUtils.flattenToNestedMap(toMap(labels));
+    }
+
+    /**
+     * Static helper method for converting a list of labels to a flat map.
+     * Key order is kept.
+     *
+     * @param labels The list of {@link Label} to be converted.
+     * @return the flat {@link Map}.
+     */
+    public static Map<String, String> toMap(@Nullable List<Label> labels) {
+        if (labels == null || labels.isEmpty()) return Map.of();
+        return labels.stream()
             .filter(label -> label.value() != null && label.key() != null)
-            // using an accumulator in case labels with the same key exists: the first is kept
-            .collect(Collectors.toMap(Label::key, Label::value, (first, second) -> first));
-        return MapUtils.flattenToNestedMap(asMap);
+            // using an accumulator in case labels with the same key exists: the second is kept
+            .collect(Collectors.toMap(Label::key, Label::value, (first, second) -> second, LinkedHashMap::new));
+    }
+
+    /**
+     * Static helper method for deduplicating a list of labels by their key.
+     * Value of the last key occurrence is kept.
+     *
+     * @param labels The list of {@link Label} to be deduplicated.
+     * @return the deduplicated {@link List}.
+     */
+    public static List<Label> deduplicate(@Nullable List<Label> labels) {
+        if (labels == null || labels.isEmpty()) return new ArrayList<>();
+        return toMap(labels).entrySet().stream()
+            .map(entry -> new Label(entry.getKey(), entry.getValue()))
+            .collect(Collectors.toCollection(ArrayList::new));
     }
 
     /**

--- a/core/src/main/java/io/kestra/core/models/Label.java
+++ b/core/src/main/java/io/kestra/core/models/Label.java
@@ -39,7 +39,7 @@ public record Label(@NotNull String key, @NotNull String value) {
      * @return the flat {@link Map}.
      */
     public static Map<String, String> toMap(@Nullable List<Label> labels) {
-        if (labels == null || labels.isEmpty()) return Map.of();
+        if (labels == null || labels.isEmpty()) return Collections.emptyMap();
         return labels.stream()
             .filter(label -> label.value() != null && label.key() != null)
             // using an accumulator in case labels with the same key exists: the second is kept
@@ -54,7 +54,7 @@ public record Label(@NotNull String key, @NotNull String value) {
      * @return the deduplicated {@link List}.
      */
     public static List<Label> deduplicate(@Nullable List<Label> labels) {
-        if (labels == null || labels.isEmpty()) return new ArrayList<>();
+        if (labels == null || labels.isEmpty()) return Collections.emptyList();
         return toMap(labels).entrySet().stream()
             .map(entry -> new Label(entry.getKey(), entry.getValue()))
             .collect(Collectors.toCollection(ArrayList::new));

--- a/core/src/main/java/io/kestra/core/models/executions/Execution.java
+++ b/core/src/main/java/io/kestra/core/models/executions/Execution.java
@@ -229,7 +229,7 @@ public class Execution implements DeletedInterface, TenantInterface {
             this.taskRunList,
             this.inputs,
             this.outputs,
-            Label.deduplicate(labels),
+            this.labels,
             this.variables,
             this.state.withState(state),
             this.parentId,
@@ -246,7 +246,6 @@ public class Execution implements DeletedInterface, TenantInterface {
     }
 
     public Execution withLabels(List<Label> labels) {
-
         return new Execution(
             this.tenantId,
             this.id,
@@ -296,7 +295,7 @@ public class Execution implements DeletedInterface, TenantInterface {
             newTaskRunList,
             this.inputs,
             this.outputs,
-            Label.deduplicate(labels),
+            this.labels,
             this.variables,
             this.state,
             this.parentId,
@@ -322,7 +321,7 @@ public class Execution implements DeletedInterface, TenantInterface {
             this.taskRunList,
             this.inputs,
             this.outputs,
-            Label.deduplicate(labels),
+            this.labels,
             this.variables,
             this.state,
             this.parentId,
@@ -349,7 +348,7 @@ public class Execution implements DeletedInterface, TenantInterface {
             taskRunList,
             this.inputs,
             this.outputs,
-            Label.deduplicate(labels),
+            this.labels,
             this.variables,
             state,
             childExecutionId != null ? this.getId() : null,

--- a/core/src/main/java/io/kestra/core/models/executions/Execution.java
+++ b/core/src/main/java/io/kestra/core/models/executions/Execution.java
@@ -25,6 +25,7 @@ import io.kestra.core.serializers.ListOrMapOfLabelSerializer;
 import io.kestra.core.services.LabelService;
 import io.kestra.core.test.flow.TaskFixture;
 import io.kestra.core.utils.IdUtils;
+import io.kestra.core.utils.ListUtils;
 import io.kestra.core.utils.MapUtils;
 import io.swagger.v3.oas.annotations.Hidden;
 import jakarta.annotation.Nullable;
@@ -136,7 +137,7 @@ public class Execution implements DeletedInterface, TenantInterface {
     }
 
     public List<Label> getLabels() {
-        return Label.deduplicate(this.labels);
+        return ListUtils.emptyOnNull(this.labels);
     }
 
     /**
@@ -181,7 +182,21 @@ public class Execution implements DeletedInterface, TenantInterface {
     }
 
 
+    /**
+     * Customization of Lombok-generated builder.
+     */
     public static class ExecutionBuilder {
+
+        /**
+         * Enforce unique values of {@link Label} when using the builder.
+         *
+         * @param labels The labels.
+         * @return Deduplicated labels.
+         */
+        public ExecutionBuilder labels(List<Label> labels) {
+            this.labels = Label.deduplicate(labels);
+            return this;
+        }
 
         void prebuild() {
             this.originalId = this.id;
@@ -214,7 +229,7 @@ public class Execution implements DeletedInterface, TenantInterface {
             this.taskRunList,
             this.inputs,
             this.outputs,
-            this.labels,
+            Label.deduplicate(labels),
             this.variables,
             this.state.withState(state),
             this.parentId,
@@ -241,7 +256,7 @@ public class Execution implements DeletedInterface, TenantInterface {
             this.taskRunList,
             this.inputs,
             this.outputs,
-            labels,
+            Label.deduplicate(labels),
             this.variables,
             this.state,
             this.parentId,
@@ -281,7 +296,7 @@ public class Execution implements DeletedInterface, TenantInterface {
             newTaskRunList,
             this.inputs,
             this.outputs,
-            this.labels,
+            Label.deduplicate(labels),
             this.variables,
             this.state,
             this.parentId,
@@ -307,7 +322,7 @@ public class Execution implements DeletedInterface, TenantInterface {
             this.taskRunList,
             this.inputs,
             this.outputs,
-            this.labels,
+            Label.deduplicate(labels),
             this.variables,
             this.state,
             this.parentId,
@@ -334,7 +349,7 @@ public class Execution implements DeletedInterface, TenantInterface {
             taskRunList,
             this.inputs,
             this.outputs,
-            this.labels,
+            Label.deduplicate(labels),
             this.variables,
             state,
             childExecutionId != null ? this.getId() : null,

--- a/core/src/main/java/io/kestra/core/models/executions/Execution.java
+++ b/core/src/main/java/io/kestra/core/models/executions/Execution.java
@@ -136,7 +136,7 @@ public class Execution implements DeletedInterface, TenantInterface {
     }
 
     public List<Label> getLabels() {
-        return Optional.ofNullable(this.labels).orElse(new ArrayList<>());
+        return Label.deduplicate(this.labels);
     }
 
     /**
@@ -400,7 +400,7 @@ public class Execution implements DeletedInterface, TenantInterface {
      *
      * @param resolvedTasks normal tasks
      * @param resolvedErrors errors tasks
-     * @param resolvedErrors finally tasks
+     * @param resolvedFinally finally tasks
      * @return the flow we need to follow
      */
     public List<ResolvedTask> findTaskDependingFlowState(

--- a/core/src/main/java/io/kestra/core/runners/Worker.java
+++ b/core/src/main/java/io/kestra/core/runners/Worker.java
@@ -478,9 +478,10 @@ public class Worker implements Service, Runnable, AutoCloseable {
         var flow = workerTrigger.getConditionContext().getFlow();
         if (flow.getLabels() != null) {
             evaluate = evaluate.map(execution -> {
-                    List<Label> executionLabels = execution.getLabels();
-                    executionLabels.addAll(LabelService.labelsExcludingSystem(flow));
-                    return execution.withLabels(executionLabels);
+                    List<Label> tmpLabels = new ArrayList<>(execution.getLabels());
+                    tmpLabels.addAll(LabelService.labelsExcludingSystem(flow));
+
+                    return execution.withLabels(tmpLabels);
                 }
             );
         }

--- a/core/src/main/java/io/kestra/core/runners/Worker.java
+++ b/core/src/main/java/io/kestra/core/runners/Worker.java
@@ -478,10 +478,9 @@ public class Worker implements Service, Runnable, AutoCloseable {
         var flow = workerTrigger.getConditionContext().getFlow();
         if (flow.getLabels() != null) {
             evaluate = evaluate.map(execution -> {
-                    List<Label> tmpLabels = new ArrayList<>(execution.getLabels());
-                    tmpLabels.addAll(LabelService.labelsExcludingSystem(flow));
-
-                    return execution.withLabels(tmpLabels);
+                    List<Label> executionLabels = execution.getLabels() != null ? execution.getLabels() : new ArrayList<>();
+                    executionLabels.addAll(LabelService.labelsExcludingSystem(flow));
+                    return execution.withLabels(executionLabels);
                 }
             );
         }

--- a/core/src/main/java/io/kestra/core/runners/Worker.java
+++ b/core/src/main/java/io/kestra/core/runners/Worker.java
@@ -478,7 +478,7 @@ public class Worker implements Service, Runnable, AutoCloseable {
         var flow = workerTrigger.getConditionContext().getFlow();
         if (flow.getLabels() != null) {
             evaluate = evaluate.map(execution -> {
-                    List<Label> executionLabels = execution.getLabels() != null ? execution.getLabels() : new ArrayList<>();
+                    List<Label> executionLabels = execution.getLabels();
                     executionLabels.addAll(LabelService.labelsExcludingSystem(flow));
                     return execution.withLabels(executionLabels);
                 }

--- a/core/src/main/java/io/kestra/plugin/core/execution/Labels.java
+++ b/core/src/main/java/io/kestra/plugin/core/execution/Labels.java
@@ -111,8 +111,9 @@ public class Labels extends Task implements ExecutionUpdatableTask {
                     })
                 ).collect(Collectors.toMap(
                     Map.Entry::getKey,
-                    Map.Entry::getValue
-                ));
+                    Map.Entry::getValue,
+                    (first, second) -> second)
+                );
         } else if (labels instanceof Map<?, ?> map) {
             labelsAsMap = map.entrySet()
                 .stream()

--- a/core/src/test/java/io/kestra/core/models/LabelTest.java
+++ b/core/src/test/java/io/kestra/core/models/LabelTest.java
@@ -1,10 +1,11 @@
 package io.kestra.core.models;
 
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
 import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 class LabelTest {
 
@@ -15,9 +16,8 @@ class LabelTest {
             new Label(Label.CORRELATION_ID, "id"))
         );
 
-        Assertions.assertEquals(
-            Map.of("system", Map.of("username", "test", "correlationId", "id")),
-            result
+        assertThat(result).isEqualTo(
+            Map.of("system", Map.of("username", "test", "correlationId", "id"))
         );
     }
 
@@ -29,9 +29,48 @@ class LabelTest {
             new Label(Label.CORRELATION_ID, "id"))
         );
 
-        Assertions.assertEquals(
-            Map.of("system", Map.of("username", "test1", "correlationId", "id")),
-            result
+        assertThat(result).isEqualTo(
+            Map.of("system", Map.of("username", "test2", "correlationId", "id"))
+        );
+    }
+
+    @Test
+    void shouldGetMapGivenDistinctLabels() {
+        Map<String, String> result = Label.toMap(List.of(
+            new Label(Label.USERNAME, "test"),
+            new Label(Label.CORRELATION_ID, "id"))
+        );
+
+        assertThat(result).isEqualTo(
+            Map.of(Label.USERNAME, "test", Label.CORRELATION_ID, "id")
+        );
+    }
+
+    @Test
+    void shouldGetMapGivenDuplicateLabels() {
+        Map<String, String> result = Label.toMap(List.of(
+            new Label(Label.USERNAME, "test1"),
+            new Label(Label.USERNAME, "test2"),
+            new Label(Label.CORRELATION_ID, "id"))
+        );
+
+        assertThat(result).isEqualTo(
+            Map.of(Label.USERNAME, "test2", Label.CORRELATION_ID, "id")
+        );
+    }
+
+    @Test
+    void shouldDuplicateLabelsWithKeyOrderKept() {
+        List<Label> result = Label.deduplicate(List.of(
+            new Label(Label.USERNAME, "test1"),
+            new Label(Label.USERNAME, "test2"),
+            new Label(Label.CORRELATION_ID, "id"),
+            new Label(Label.USERNAME, "test3"))
+        );
+
+        assertThat(result).containsExactly(
+            new Label(Label.USERNAME, "test3"),
+            new Label(Label.CORRELATION_ID, "id")
         );
     }
 }

--- a/core/src/test/java/io/kestra/core/models/executions/ExecutionTest.java
+++ b/core/src/test/java/io/kestra/core/models/executions/ExecutionTest.java
@@ -7,7 +7,6 @@ import io.kestra.core.models.flows.State;
 
 import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -157,7 +156,19 @@ class ExecutionTest {
             .labels(List.of(new Label("test", "test-value")))
             .build();
 
-        assertThat(execution.getLabels().size()).isEqualTo(1);
-        assertThat(execution.getLabels().getFirst()).isEqualTo(new Label("test", "test-value"));
+        assertThat(execution.getLabels()).containsExactly(new Label("test", "test-value"));
+    }
+
+    @Test
+    void labelsGetDeduplicated() {
+        final List<Label> duplicatedLabels = List.of(
+            new Label("test", "value1"),
+            new Label("test", "value2")
+        );
+        final Execution execution = Execution.builder()
+            .labels(duplicatedLabels)
+            .build();
+
+        assertThat(execution.getLabels()).containsExactly(new Label("test", "value2"));
     }
 }

--- a/core/src/test/java/io/kestra/core/models/executions/ExecutionTest.java
+++ b/core/src/test/java/io/kestra/core/models/executions/ExecutionTest.java
@@ -2,11 +2,13 @@ package io.kestra.core.models.executions;
 
 import io.kestra.core.models.Label;
 import io.kestra.core.utils.IdUtils;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import io.kestra.core.models.flows.State;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -165,10 +167,49 @@ class ExecutionTest {
             new Label("test", "value1"),
             new Label("test", "value2")
         );
-        final Execution execution = Execution.builder()
+
+        final Execution executionWithLabels = Execution.builder()
+            .build()
+            .withLabels(duplicatedLabels);
+        assertThat(executionWithLabels.getLabels()).containsExactly(new Label("test", "value2"));
+
+        final Execution executionBuilder = Execution.builder()
             .labels(duplicatedLabels)
             .build();
+        assertThat(executionBuilder.getLabels()).containsExactly(new Label("test", "value2"));
+    }
 
-        assertThat(execution.getLabels()).containsExactly(new Label("test", "value2"));
+    @Test
+    @Disabled("Solve label deduplication on instantization")
+    void labelsGetDeduplicatedOnNewInstance() {
+        final List<Label> duplicatedLabels = List.of(
+            new Label("test", "value1"),
+            new Label("test", "value2")
+        );
+
+        final Execution executionNew = new Execution(
+            "foo",
+            "id",
+            "namespace",
+            "flowId",
+            1,
+            Collections.emptyList(),
+            Map.of(),
+            Map.of(),
+            duplicatedLabels,
+            Map.of(),
+            State.of(State.Type.SUCCESS, Collections.emptyList()),
+            "parentId",
+            "originalId",
+            null,
+            false,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null
+        );
+        assertThat(executionNew.getLabels()).containsExactly(new Label("test", "value2"));
     }
 }

--- a/core/src/test/java/io/kestra/plugin/core/flow/RuntimeLabelsTest.java
+++ b/core/src/test/java/io/kestra/plugin/core/flow/RuntimeLabelsTest.java
@@ -104,4 +104,38 @@ class RuntimeLabelsTest {
             new Label("taskRunId", labelsTaskRunId),
             new Label("existingLabel", "someValue"));
     }
+
+    @Test
+    @LoadFlows({"flows/valids/primitive-labels-flow.yml"})
+    void primitiveTypeLabelsOverrideExistingLabels() throws TimeoutException, QueueException {
+        Execution execution = runnerUtils.runOne(
+            MAIN_TENANT,
+            "io.kestra.tests",
+            "primitive-labels-flow",
+            null,
+            (flow, createdExecution) -> Map.of(
+                "intLabel", 42,
+                "boolLabel", true,
+                "floatLabel", 3.14f
+            ),
+            null,
+            List.of(
+                new Label("intValue", "1"),
+                new Label("boolValue", "false"),
+                new Label("floatValue", "4.2f")
+            )
+        );
+
+        assertThat(execution.getTaskRunList()).hasSize(1);
+        assertThat(execution.getState().getCurrent()).isEqualTo(State.Type.SUCCESS);
+
+        String labelsTaskRunId = execution.findTaskRunsByTaskId("update-labels").getFirst().getId();
+
+        assertThat(execution.getLabels()).containsExactlyInAnyOrder(
+            new Label(Label.CORRELATION_ID, execution.getId()),
+            new Label("intValue", "42"),
+            new Label("boolValue", "true"),
+            new Label("floatValue", "3.14"),
+            new Label("taskRunId", labelsTaskRunId));
+    }
 }

--- a/core/src/test/java/io/kestra/plugin/core/flow/RuntimeLabelsTest.java
+++ b/core/src/test/java/io/kestra/plugin/core/flow/RuntimeLabelsTest.java
@@ -2,7 +2,6 @@ package io.kestra.plugin.core.flow;
 
 import static io.kestra.core.tenant.TenantService.MAIN_TENANT;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.hamcrest.Matchers.is;
 
 import io.kestra.core.junit.annotations.ExecuteFlow;
 import io.kestra.core.junit.annotations.KestraTest;
@@ -137,5 +136,28 @@ class RuntimeLabelsTest {
             new Label("boolValue", "true"),
             new Label("floatValue", "3.14"),
             new Label("taskRunId", labelsTaskRunId));
+    }
+
+    @Test
+    @LoadFlows({"flows/valids/labels-update-task-deduplicate.yml"})
+    void updateGetsDeduplicated() throws TimeoutException, QueueException {
+        Execution execution = runnerUtils.runOne(
+            MAIN_TENANT,
+            "io.kestra.tests",
+            "labels-update-task-deduplicate",
+            null,
+            (flow, createdExecution) -> Map.of(),
+            null,
+            List.of()
+        );
+
+        assertThat(execution.getTaskRunList()).hasSize(2);
+        assertThat(execution.getState().getCurrent()).isEqualTo(State.Type.SUCCESS);
+
+        assertThat(execution.getLabels()).containsExactlyInAnyOrder(
+            new Label(Label.CORRELATION_ID, execution.getId()),
+            new Label("fromStringKey", "value2"),
+            new Label("fromListKey", "value2")
+        );
     }
 }

--- a/core/src/test/java/io/kestra/plugin/core/flow/SubflowRunnerTest.java
+++ b/core/src/test/java/io/kestra/plugin/core/flow/SubflowRunnerTest.java
@@ -1,0 +1,53 @@
+package io.kestra.plugin.core.flow;
+
+import io.kestra.core.junit.annotations.KestraTest;
+import io.kestra.core.junit.annotations.LoadFlows;
+import io.kestra.core.models.Label;
+import io.kestra.core.models.executions.Execution;
+import io.kestra.core.queues.QueueException;
+import io.kestra.core.repositories.ExecutionRepositoryInterface;
+import io.kestra.core.runners.RunnerUtils;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.TimeoutException;
+
+import static io.kestra.core.tenant.TenantService.MAIN_TENANT;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@KestraTest(startRunner = true)
+class SubflowRunnerTest {
+
+    @Inject
+    private RunnerUtils runnerUtils;
+
+    @Inject
+    private ExecutionRepositoryInterface executionRepository;
+
+    @Test
+    @LoadFlows({"flows/valids/subflow-inherited-labels-child.yaml", "flows/valids/subflow-inherited-labels-parent.yaml"})
+    void inheritedLabelsAreOverridden() throws QueueException, TimeoutException {
+        Execution parentExecution = runnerUtils.runOne(MAIN_TENANT, "io.kestra.tests", "subflow-inherited-labels-parent");
+
+        assertThat(parentExecution.getLabels()).containsExactlyInAnyOrder(
+            new Label(Label.CORRELATION_ID, parentExecution.getId()),
+            new Label("parentFlowLabel1", "value1"),
+            new Label("parentFlowLabel2", "value2")
+        );
+
+        String childExecutionId = (String) parentExecution.findTaskRunsByTaskId("launch").getFirst().getOutputs().get("executionId");
+
+        assertThat(childExecutionId).isNotBlank();
+
+        Execution childExecution = executionRepository.findById(MAIN_TENANT, childExecutionId).orElseThrow();
+
+        assertThat(childExecution.getLabels()).containsExactlyInAnyOrder(
+            new Label(Label.CORRELATION_ID, parentExecution.getId()), // parent's correlation ID
+            new Label("childFlowLabel1", "value1"), // defined by the subtask flow
+            new Label("childFlowLabel2", "value2"), // defined by the subtask flow
+            new Label("launchTaskLabel", "launchFoo"), // added by Subtask
+            new Label("parentFlowLabel1", "launchBar"), // overridden by Subtask
+            new Label("parentFlowLabel2", "value2") // inherited from the parent flow
+        );
+    }
+}

--- a/core/src/test/resources/flows/valids/labels-update-task-deduplicate.yml
+++ b/core/src/test/resources/flows/valids/labels-update-task-deduplicate.yml
@@ -1,0 +1,14 @@
+id: labels-update-task-deduplicate
+namespace: io.kestra.tests
+
+tasks:
+  - id: from-string
+    type: io.kestra.plugin.core.execution.Labels
+    labels: "{ \"fromStringKey\": \"value1\", \"fromStringKey\": \"value2\" }"
+  - id: from-list
+    type: io.kestra.plugin.core.execution.Labels
+    labels:
+      - key: "fromListKey"
+        value: "value1"
+      - key: "fromListKey"
+        value: "value2"

--- a/core/src/test/resources/flows/valids/subflow-inherited-labels-child.yaml
+++ b/core/src/test/resources/flows/valids/subflow-inherited-labels-child.yaml
@@ -1,0 +1,11 @@
+id: subflow-inherited-labels-child
+namespace: io.kestra.tests
+
+labels:
+  childFlowLabel1: value1
+  childFlowLabel2: value2
+
+tasks:
+  - id: return
+    type: io.kestra.plugin.core.log.Log
+    message: "{{ execution.id }}"

--- a/core/src/test/resources/flows/valids/subflow-inherited-labels-parent.yaml
+++ b/core/src/test/resources/flows/valids/subflow-inherited-labels-parent.yaml
@@ -1,0 +1,18 @@
+id: subflow-inherited-labels-parent
+namespace: io.kestra.tests
+
+labels:
+  parentFlowLabel1: value1
+  parentFlowLabel2: value2
+
+tasks:
+  - id: launch
+    type: io.kestra.plugin.core.flow.Subflow
+    namespace: io.kestra.tests
+    flowId: subflow-inherited-labels-child
+    wait: true
+    transmitFailed: true
+    inheritLabels: true
+    labels:
+      launchTaskLabel: launchFoo
+      parentFlowLabel1: launchBar

--- a/webserver/src/main/java/io/kestra/webserver/controllers/api/ExecutionController.java
+++ b/webserver/src/main/java/io/kestra/webserver/controllers/api/ExecutionController.java
@@ -1958,7 +1958,10 @@ public class ExecutionController {
             );
         }
 
-        executions.forEach(execution -> setLabelsOnTerminatedExecution(execution, ListUtils.concat(execution.getLabels(), setLabelsByIds.executionLabels())));
+        executions.forEach(execution -> setLabelsOnTerminatedExecution(
+                execution,
+                Label.deduplicate(ListUtils.concat(execution.getLabels(), setLabelsByIds.executionLabels())))
+        );
         return HttpResponse.ok(BulkResponse.builder().count(executions.size()).build());
     }
 

--- a/webserver/src/main/java/io/kestra/webserver/utils/RequestUtils.java
+++ b/webserver/src/main/java/io/kestra/webserver/utils/RequestUtils.java
@@ -13,23 +13,48 @@ import java.time.Duration;
 import java.time.ZonedDateTime;
 import java.util.*;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 public class RequestUtils {
+    private static final String QUERY_STRING_SEPARATOR = ":";
+
+    /**
+     * Transform colon-separated items to a {@link Map}.
+     *
+     * @param queryString the list of {@code key:value} parameters
+     * @return the map of split pairs
+     * @throws HttpStatusException when items can't be reliably split by the separator or there are duplicate keys
+     */
     public static Map<String, String> toMap(List<String> queryString) {
-        return queryString == null ? null : queryString
+        if (queryString == null) return Map.of();
+
+        Stream<AbstractMap.SimpleEntry<String, String>> entryStream = queryString
             .stream()
             .map(s -> {
-                String[] split = s.split("[: ]+");
+                String[] split = s.split(QUERY_STRING_SEPARATOR, 2);
                 if (split.length < 2 || split[0] == null || split[0].isEmpty()) {
-                    throw new HttpStatusException(HttpStatus.UNPROCESSABLE_ENTITY, "Invalid queryString parameter");
+                    throw new HttpStatusException(HttpStatus.UNPROCESSABLE_ENTITY, "Can't split the queryString parameter by ':'");
                 }
 
-                return new AbstractMap.SimpleEntry<>(
-                    split[0],
-                    s.substring(s.indexOf(":") + 1).trim()
-                );
-            })
-            .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+                final String key = split[0].trim();
+                final String value = s.substring(s.indexOf(QUERY_STRING_SEPARATOR) + 1).trim();
+
+                if (key.isEmpty() || value.isEmpty()) {
+                    throw new HttpStatusException(HttpStatus.UNPROCESSABLE_ENTITY, "Can't have an empty part of queryString");
+                }
+
+                if (key.matches(".*\\s.*")) {
+                    throw new HttpStatusException(HttpStatus.UNPROCESSABLE_ENTITY, "Key of queryString can't contain a whitespace character");
+                }
+
+                return new AbstractMap.SimpleEntry<>(key, value);
+            });
+
+        try {
+            return entryStream.collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+        } catch (IllegalStateException e) {
+            throw new HttpStatusException(HttpStatus.UNPROCESSABLE_ENTITY, "The queryString parameter keys contains duplicities: " + e.getMessage());
+        }
     }
 
     /**

--- a/webserver/src/main/java/io/kestra/webserver/utils/RequestUtils.java
+++ b/webserver/src/main/java/io/kestra/webserver/utils/RequestUtils.java
@@ -37,7 +37,7 @@ public class RequestUtils {
                 }
 
                 final String key = split[0].trim();
-                final String value = s.substring(s.indexOf(QUERY_STRING_SEPARATOR) + 1).trim();
+                final String value = split[1].trim();
 
                 if (key.isEmpty() || value.isEmpty()) {
                     throw new HttpStatusException(HttpStatus.UNPROCESSABLE_ENTITY, "Can't have an empty part of queryString");

--- a/webserver/src/test/java/io/kestra/webserver/controllers/api/ExecutionControllerTest.java
+++ b/webserver/src/test/java/io/kestra/webserver/controllers/api/ExecutionControllerTest.java
@@ -257,6 +257,17 @@ class ExecutionControllerTest {
         assertThrows(HttpClientResponseException.class, () -> client.toBlocking().retrieve(requestNullValue, Execution.class));
     }
 
+    @Test
+    void duplicatedLabels() {
+        MultipartBody requestBody = createExecutionInputsFlowBody();
+
+        // duplicated keys are forbidden
+        MutableHttpRequest<MultipartBody> requestNullKey = HttpRequest
+            .POST("/api/v1/main/executions/" + TESTS_FLOW_NS + "/inputs?labels=key:value1&labels=key:value2", requestBody)
+            .contentType(MediaType.MULTIPART_FORM_DATA_TYPE);
+        assertThrows(HttpClientResponseException.class, () -> client.toBlocking().retrieve(requestNullKey, Execution.class));
+    }
+
     @SuppressWarnings("DataFlowIssue")
     @Test
     void getExecutionFlowForExecution() {


### PR DESCRIPTION
### What changes are being made and why?

First of all, definition of labels' behavior has been a bit murky and that's been causing some troubles. The main "source of truth" is the [docs article](https://kestra.io/docs/workflow-components/labels) defining labels as _key-value pairs_. To me this reads as an entity holding a set of keys each with a specified value.

There have been several issues related to labels (e.g. partially remedied by #9941) mainly regarding to their behavior. For example:

1. running an execution with labels attached could lead to label duplication when the flow itself defined the same label key
2. it wasn't possible to update an existing value via the bulk Set labels action
3. launching an execution with labels having duplicated keys was rejected with a rather strange error
4. it was possible to launch an execution with a label key's value containing a space character leading to part of the key being thrown away silently

Mainly, I added tests covering those weird cases and also I tried to fix most of them, although **I didn't change the fundamental parts**.

#### Further work/Refactoring

1. Is the list of `Label` records really the best structure for key-value pairs (as the definition dictates)? AFAIK labels are not always validated via Jakarta validation directly, there is a need for validating their values via setters/builder. The list structure also brings the need for dedup.
2. Ordering of each "label merging" case should be defined in documentation (?) - execution can override flow's labels; child execution can override inherited labels, `upateLabels`, triggers vs flows, etc.
3. The `RequestUtils`'s `toMap` method does a lot of heavy lifting which would be more fitting for the `Label` or similar class. This is related to `1.`

WDYT?

#### Changes

* re-enabled bulk update of label value
* re-enabled merging flow-execution labels by key
* made duplicated keys rejection readable
* forced multiple validations within `RequestUtils`
* ensured existing labels can be overridden
* added multiple tests validating complex scenarios

BREAKING CHANGE: switched from first to last label value override
BREAKING CHANGE: preventing empty key/value labels
BREAKING CHANGE: preventing whitespace in key

---

### How the changes have been QAed?

* Performed a bulk label update setting a new value to an existing label key.
* Launched execution having two or more duplicated label keys.
* Launched an execution with a label "overriding" a flow label value.