### PR TITLE
fix(core): add proxy so that origin is the same as request url for workers

### DIFF
--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -27,11 +27,6 @@ In the meantime, you can move onto the next step...
 
 - Create a `.env.development.local` file in the `ui` folder and paste the following:
 
-```bash
-# This lets the frontend know what the backend URL is but you are free to change this to your actual server URL e.g. hosted version of Kestra.
-VITE_APP_API_URL=http://localhost:8080
-```
-
 - Navigate into the `ui` folder and run `npm install` to install the dependencies for the frontend project.
 
 - Now go to the `cli/src/main/resources` folder and create a `application-override.yml` file.

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -80,7 +80,6 @@ python3 -m pip install virtualenv
 The frontend is made with [Vue.js](https://vuejs.org/) and located on the `/ui` folder.
 
 - `npm install`
-- create a file `ui/.env.development.local` with content `VITE_APP_API_URL=http://localhost:8080` (or your actual server url)
 - `npm run dev` will start the development server with hot reload.
 - The server start by default on port 5173 and is reachable on `http://localhost:5173`
 - You can run `npm run build` in order to build the front-end that will be delivered from the backend (without running the `npm run dev`) above.

--- a/ui/vite.config.js
+++ b/ui/vite.config.js
@@ -38,6 +38,15 @@ export default defineConfig({
             }
         }
     },
+    server: {
+        proxy: {
+            "^/api": {
+                target: "http://kestra:8080", // Make sure to change your /etc/hosts file, to contain this line: 127.0.0.1 kestra
+                ws: true,
+                changeOrigin: true
+            }
+        }
+    },
     resolve: {
         alias: {
             "override": path.resolve(__dirname, "src/override/"),


### PR DESCRIPTION
After this PR, we should remove any .env file that adds a VITE_APP_URL because the goal is to request against the same host when using npm run dev and let VITE act as a proxy so that webworkers properly send cookies that are then transmitted by the proxy to the backend