### PR TITLE
fix(core): show plugin toc properly

### DIFF
--- a/ui/src/components/plugins/Toc.vue
+++ b/ui/src/components/plugins/Toc.vue
@@ -117,8 +117,7 @@
                                     .map(([elementType, elements]) => [
                                         elementType,
                                         elements.filter(({deprecated}) => !deprecated)
-                                            .map(({cls}) => cls)
-                                            .filter(element => element.toLowerCase().includes(this.searchInput.toLowerCase()))
+                                            .filter(({cls}) => cls.toLowerCase().includes(this.searchInput.toLowerCase()))
                                     ])
                             )
                         }

--- a/ui/src/styles/components/plugin-doc.scss
+++ b/ui/src/styles/components/plugin-doc.scss
@@ -13,7 +13,7 @@
     }
 
     .plugin-title {
-        min-width: 150px;
+        min-width: 50px;
     }
 
     .plugin-schema {


### PR DESCRIPTION
Closes https://github.com/kestra-io/kestra/issues/10066

Earlier, was prematurely converting element objects to strings using `.map(({cls}) => cls)`, which stripped  all object properties except the class name. This broke the rendering because it expected complete objects with properties like `cls, deprecated….`

**Solution**
Remove the premature string conversion and maintain the full object  throughout the filtering. Now the template receives complete element objects as expected.

- Minor tweak to fix the gap between the title and release notes button beside Editor.