### PR TITLE
feat(executions): use the uploaded file name for inputs of type FILE

### DIFF
--- a/core/src/main/java/io/kestra/core/models/flows/input/FileInput.java
+++ b/core/src/main/java/io/kestra/core/models/flows/input/FileInput.java
@@ -21,6 +21,7 @@ public class FileInput extends Input<URI> {
     private static final String DEFAULT_EXTENSION = ".upl";
 
     @Builder.Default
+    @Deprecated(since = "0.24", forRemoval = true)
     public String extension = DEFAULT_EXTENSION;
 
     @Override

--- a/core/src/main/java/io/kestra/core/storages/StorageInterface.java
+++ b/core/src/main/java/io/kestra/core/storages/StorageInterface.java
@@ -97,8 +97,8 @@ public interface StorageInterface extends AutoCloseable, Plugin {
     List<URI> deleteByPrefix(String tenantId, @Nullable String namespace, URI storagePrefix) throws IOException;
 
     @Retryable(includes = {IOException.class})
-    default URI from(Execution execution, String input, File file) throws IOException {
-        URI uri = StorageContext.forInput(execution, input, file.getName()).getContextStorageURI();
+    default URI from(Execution execution, String input, String fileName, File file) throws IOException {
+        URI uri = StorageContext.forInput(execution, input, fileName).getContextStorageURI();
         return this.put(execution.getTenantId(), execution.getNamespace(), uri, new BufferedInputStream(new FileInputStream(file)));
     }
 

--- a/ui/src/components/flows/Curl.vue
+++ b/ui/src/components/flows/Curl.vue
@@ -93,7 +93,7 @@
                     command.push("-F");
 
                     if (input.type === "FILE") {
-                        command.push(`'files=@${inputValue};filename=${input.id}'`);
+                        command.push(`'${input.id}=@${inputValue};filename=${inputValue}'`);
                     } else {
                         command.push(`'${input.id}=${inputValue}'`);
                     }

--- a/ui/src/utils/submitTask.js
+++ b/ui/src/utils/submitTask.js
@@ -31,12 +31,6 @@ export const inputsToFormDate = (submitor, inputsList, values) => {
                 formData.append(inputName, submitor.$moment(inputValue).format("YYYY-MM-DD"));
             } else if (input.type === "TIME") {
                 formData.append(inputName, submitor.$moment(inputValue).format("hh:mm:ss"));
-            } else if (input.type === "FILE") {
-                if (typeof (inputValue) === "string") {
-                    formData.append(inputName, inputValue);
-                } else if (inputValue !== null) {
-                    formData.append("files", inputValue, inputName);
-                }
             } else {
                 formData.append(inputName, inputValue);
             }


### PR DESCRIPTION
Use the part name for the input ID, this is a BC.
Use the filename attribute of the part for creating the file inside the internal storage. Detect previous usage of part name and filename and emit a deprecation warning.

Closes #5987
