### PR TITLE
feat(core): implement backend validation for login for configs and also fixes PH event

### DIFF
--- a/ui/src/components/basicauth/BasicAuthLogin.vue
+++ b/ui/src/components/basicauth/BasicAuthLogin.vue
@@ -66,7 +66,7 @@
 </template>
 
 <script setup lang="ts">
-    import {ref, computed, onMounted} from "vue"
+    import {ref, computed} from "vue"
     import {useRouter, useRoute} from "vue-router"
     import {useStore} from "vuex"
     import {useI18n} from "vue-i18n"
@@ -139,7 +139,7 @@
             (!error.response && error.message.includes("Network Error"))
     }
 
-    const loadAuthConfigErrors = async () => {
+    const loadAuthConfigErrors = async (showIncorrectCredsMessage = true) => {
         try {
             const errors = await miscStore.loadBasicAuthValidationErrors()
             if (errors && errors.length > 0) {
@@ -150,7 +150,7 @@
                         showClose: false
                     })
                 })
-            } else {
+            } else if (showIncorrectCredsMessage) {
                 ElMessage.error(t("setup.validation.incorrect_creds"))
             }
         } catch (error) {
@@ -217,19 +217,6 @@
     const openTroubleshootingGuide = () => {
         window.open("https://kestra.io/docs/administrator-guide/basic-auth-troubleshooting", "_blank")
     }
-
-    onMounted(async () => {
-        try {
-            const isInitialized = await checkServerInitialization()
-            if (!isInitialized) {
-                router.push({name: "setup"})
-            }
-        } catch (error: any) {
-            if (handleNetworkError(error) || error?.response?.status === 404) {
-                router.push({name: "setup"})
-            }
-        }
-    })
 </script>
 
 <style lang="scss" scoped>

--- a/ui/src/components/basicauth/BasicAuthLogin.vue
+++ b/ui/src/components/basicauth/BasicAuthLogin.vue
@@ -79,6 +79,7 @@
     import Logo from "../home/Logo.vue"
 
     import {useCoreStore} from "../../stores/core"
+    import {useMiscStore} from "../../stores/misc"
     import {useSurveySkip} from "../../composables/useSurveyData"
     import {apiUrlWithoutTenants, apiUrl} from "override/utils/route"
     import * as BasicAuth from "../../utils/basicAuth";
@@ -93,6 +94,7 @@
     const store = useStore()
     const {t} = useI18n()
     const coreStore = useCoreStore()
+    const miscStore = useMiscStore()
     const {shouldShowHelloDialog} = useSurveySkip()
 
     const form = ref<FormInstance>()
@@ -135,6 +137,25 @@
         return error.code === "ERR_NETWORK" ||
             error.code === "ECONNREFUSED" ||
             (!error.response && error.message.includes("Network Error"))
+    }
+
+    const loadAuthConfigErrors = async () => {
+        try {
+            const errors = await miscStore.loadBasicAuthValidationErrors()
+            if (errors && errors.length > 0) {
+                errors.forEach((error: string) => {
+                    ElMessage.error({
+                        message: `${error}. ${t("setup.validation.config_message")}`,
+                        duration: 5000,
+                        showClose: false
+                    })
+                })
+            } else {
+                ElMessage.error(t("setup.validation.incorrect_creds"))
+            }
+        } catch (error) {
+            console.error("Failed to load auth config errors:", error)
+        }
     }
 
     const handleSubmit = async (event: Event) => {
@@ -182,7 +203,7 @@
             }
 
             if (error?.response?.status === 401) {
-                ElMessage.error("Invalid credentials")
+                await loadAuthConfigErrors()
             } else if (error?.response?.status === 404) {
                 router.push({name: "setup"})
             } else {

--- a/ui/src/components/basicauth/BasicAuthSetup.vue
+++ b/ui/src/components/basicauth/BasicAuthSetup.vue
@@ -304,7 +304,7 @@
         try {
             const config = await miscStore.loadConfigs()
 
-            if (config && config.isBasicAuthInitialized) {
+            if (config?.isBasicAuthInitialized) {
                 localStorage.removeItem("basicAuthSetupInProgress")
                 localStorage.removeItem("setupStartTime")
                 router.push({name: "login"})

--- a/ui/src/components/basicauth/BasicAuthSetup.vue
+++ b/ui/src/components/basicauth/BasicAuthSetup.vue
@@ -207,8 +207,8 @@
     import {useI18n} from "vue-i18n"
     import MailChecker from "mailchecker"
     import {useMiscStore} from "../../stores/misc"
-    import {useApiStore} from "../../stores/api"
     import {useSurveySkip} from "../../composables/useSurveyData"
+    import {initPostHogForSetup, trackSetupEvent} from "../../utils/setupPosthog"
 
     import Cogs from "vue-material-design-icons/Cogs.vue"
     import AccountPlus from "vue-material-design-icons/AccountPlus.vue"
@@ -251,7 +251,6 @@
     }
 
     const miscStore = useMiscStore()
-    const apiStore = useApiStore()
     const router = useRouter()
     const {t} = useI18n()
     const {storeSurveySkipData} = useSurveySkip()
@@ -278,28 +277,6 @@
     const formData = computed(() => userFormData.value)
     const setupConfiguration = computed(() => usageData.value?.configurations ?? {})
 
-    const trackSetupEvent = (eventName: string, additionalData: Record<string, any> = {}) => {
-        const configs = miscStore.configs
-        const uid = localStorage.getItem("uid")
-
-        if (!configs || !uid || configs.isAnonymousUsageEnabled === false) return
-
-        const userInfo = activeStep.value >= 1 ? {
-            user_firstname: userFormData.value.firstName || undefined,
-            user_lastname: userFormData.value.lastName || undefined,
-            user_email: userFormData.value.username || undefined
-        } : {}
-
-        apiStore.posthogEvents({
-            type: eventName,
-            setup_step_current: activeStep.value,
-            instance_id: configs.uuid,
-            user_id: uid,
-            ...userInfo,
-            ...additionalData
-        })
-    }
-
     const initializeSetup = async () => {
         try {
             const config = await miscStore.loadConfigs()
@@ -311,11 +288,12 @@
                 return
             }
 
+            await initPostHogForSetup(config)
+
             localStorage.setItem("basicAuthSetupInProgress", "true")
             localStorage.setItem("setupStartTime", Date.now().toString())
 
             usageData.value = await miscStore.loadAllUsages()
-            trackSetupEvent("setup_flow:started", {step_number: 1})
         } catch {
             /* Silently handle usage data loading errors */
         } finally {
@@ -410,15 +388,11 @@
     }
 
     const nextStep = () => {
-        const currentStep = activeStep.value
         activeStep.value++
-        trackSetupEvent("setup_flow:step_advanced", {from_step_number: currentStep, to_step_number: activeStep.value})
     }
 
     const previousStep = () => {
-        const currentStep = activeStep.value
         activeStep.value--
-        trackSetupEvent("setup_flow:step_back", {from_step_number: currentStep, to_step_number: activeStep.value})
     }
 
     const handleUserFormSubmit = async () => {
@@ -444,9 +418,8 @@
                 user_firstname: userFormData.value.firstName,
                 user_lastname: userFormData.value.lastName,
                 user_email: userFormData.value.username
-            })
+            }, userFormData.value)
 
-            trackSetupEvent("setup_flow:user_form_submitted", {is_form_valid: isUserStepValid.value})
             
             localStorage.setItem("basicAuthUserCreated", "true")
             
@@ -454,7 +427,7 @@
         } catch (error: any) {
             trackSetupEvent("setup_flow:account_creation_failed", {
                 error_message: error.message || "Unknown error"
-            })
+            }, userFormData.value)
             console.error("Failed to create basic auth account:", error)
         }
     }
@@ -481,9 +454,8 @@
         }
 
         trackSetupEvent("setup_flow:marketing_survey_submitted", {
-            step_number: 3,
             ...surveySelections
-        })
+        }, userFormData.value)
 
         nextStep()
     }
@@ -500,14 +472,12 @@
         }
 
         storeSurveySkipData({
-            step_number: 3,
             ...surveySelections
         })
 
         trackSetupEvent("setup_flow:marketing_survey_skipped", {
-            step_number: 3,
             ...surveySelections
-        })
+        }, userFormData.value)
 
         nextStep()
     }
@@ -521,7 +491,7 @@
             user_lastname: userFormData.value.lastName,
             user_email: userFormData.value.username,
             ...surveySelections
-        })
+        }, userFormData.value)
 
         localStorage.setItem("basicAuthSetupCompleted", "true")
         localStorage.removeItem("basicAuthSetupInProgress")

--- a/ui/src/components/basicauth/BasicAuthSetup.vue
+++ b/ui/src/components/basicauth/BasicAuthSetup.vue
@@ -304,14 +304,10 @@
         try {
             const config = await miscStore.loadConfigs()
 
-            const setupCompleted = localStorage.getItem("basicAuthSetupCompleted") === "true"
-            
-            // If setup is marked as completed
-            // OR if basic auth is initialized, redirect to welcome
-            if (setupCompleted || (config && config.isBasicAuthInitialized)) {
+            if (config && config.isBasicAuthInitialized) {
                 localStorage.removeItem("basicAuthSetupInProgress")
                 localStorage.removeItem("setupStartTime")
-                router.push({name: "welcome"})
+                router.push({name: "login"})
                 return
             }
 

--- a/ui/src/stores/misc.ts
+++ b/ui/src/stores/misc.ts
@@ -25,6 +25,11 @@ export const useMiscStore = defineStore("misc", {
             return response.data;
         },
 
+        async loadBasicAuthValidationErrors() {
+            const response = await this.$http.get(`${apiUrlWithoutTenants()}/basicAuthValidationErrors`);
+            return response.data;
+        },
+
         async loadAllUsages() {
             if(this.configs.isBasicAuthInitialized && BasicAuth.isLoggedIn()){
                 const response = await this.$http.get(`${apiUrl(this.vuexStore)}/usages/all`);

--- a/ui/src/translations/en.json
+++ b/ui/src/translations/en.json
@@ -1396,7 +1396,9 @@
         "email_temporary_not_allowed": "Temporary or disposable email addresses are not allowed",
         "firstName_required": "First name required",
         "lastName_required": "Last name required",
-        "password_invalid": "Invalid password"
+        "password_invalid": "Invalid password",
+        "incorrect_creds": "Invalid username or password. Make sure your credentials are correct.",
+        "config_message": "Make sure to update your configuration to fix this error message"
       },
       "config": {
         "repository": "Database",

--- a/ui/src/utils/setupPosthog.ts
+++ b/ui/src/utils/setupPosthog.ts
@@ -1,0 +1,80 @@
+import {useApiStore} from "../stores/api"
+import {useMiscStore} from "../stores/misc"
+
+export interface SetupEventData {
+    type: string
+    instance_id?: string
+    user_id?: string
+    [key: string]: unknown
+}
+
+interface UserFormData {
+    firstName?: string
+    lastName?: string
+    username?: string
+}
+
+interface Config {
+    isAnonymousUsageEnabled?: boolean
+    uuid?: string
+    version?: string
+}
+
+export async function initPostHogForSetup(config: Config): Promise<void> {
+    try {
+        if (!config?.isAnonymousUsageEnabled) return
+
+        const apiStore = useApiStore()
+        const apiConfig = await apiStore.loadConfig()
+        
+        if (!apiConfig?.posthog?.token || (window as any).posthog?.__loaded) return
+
+        const uid = getUID()
+        if (!uid) return
+
+        const {default: posthog} = await import("posthog-js")
+
+        posthog.init(apiConfig.posthog.token, {
+            api_host: apiConfig.posthog.apiHost,
+            ui_host: "https://eu.posthog.com",
+            capture_pageview: false,
+            capture_pageleave: true,
+            autocapture: false,
+        })
+
+        if (!posthog.get_property("__alias")) {
+            posthog.alias(apiConfig.id)
+        }
+    } catch (error) {
+        console.error("Failed to initialize PostHog:", error)
+    }
+}
+
+export function trackSetupEvent(
+    eventName: string, 
+    additionalData: Record<string, any>, 
+    userFormData: UserFormData
+): void {
+    const miscStore = useMiscStore()
+    const uid = getUID()
+    
+    if (!miscStore.configs?.isAnonymousUsageEnabled || !uid) return
+
+    const userInfo = userFormData.firstName ? {
+        user_firstname: userFormData.firstName,
+        user_lastname: userFormData.lastName,
+        user_email: userFormData.username
+    } : {}
+
+    const eventData: SetupEventData = {
+        type: eventName,
+        instance_id: miscStore.configs.uuid,
+        user_id: uid,
+        ...userInfo,
+        ...additionalData
+    }
+
+    useApiStore().posthogEvents(eventData)
+}
+
+const getUID = (): string | null => localStorage.getItem("uid")

--- a/webserver/src/main/java/io/kestra/webserver/rooting/TenantAliasingRooter.java
+++ b/webserver/src/main/java/io/kestra/webserver/rooting/TenantAliasingRooter.java
@@ -22,7 +22,8 @@ public class TenantAliasingRooter extends DefaultRouter {
 
     protected static final List<Pattern> EXCLUDED_ROUTES = List.of(
         Pattern.compile("/api/v1/main/.*"),
-        Pattern.compile("/api/v1/configs")
+        Pattern.compile("/api/v1/configs"),
+        Pattern.compile("/api/v1/basicAuthValidationErrors")
     );
 
     @Inject

--- a/webserver/src/main/java/io/kestra/webserver/rooting/TenantAliasingRooter.java
+++ b/webserver/src/main/java/io/kestra/webserver/rooting/TenantAliasingRooter.java
@@ -22,8 +22,7 @@ public class TenantAliasingRooter extends DefaultRouter {
 
     protected static final List<Pattern> EXCLUDED_ROUTES = List.of(
         Pattern.compile("/api/v1/main/.*"),
-        Pattern.compile("/api/v1/configs"),
-        Pattern.compile("/api/v1/basicAuthValidationErrors")
+        Pattern.compile("/api/v1/configs")
     );
 
     @Inject

--- a/webserver/src/main/java/io/kestra/webserver/services/BasicAuthService.java
+++ b/webserver/src/main/java/io/kestra/webserver/services/BasicAuthService.java
@@ -150,13 +150,9 @@ public class BasicAuthService {
 
         SaltedBasicAuthConfiguration configuration = configuration();
 
-        if (configuration != null && configuration.getUsername() != null && configuration.getPassword() != null) {
-            return true;
-        }
-        
-        return basicAuthConfiguration != null && 
-               !StringUtils.isBlank(basicAuthConfiguration.getUsername()) && 
-               !StringUtils.isBlank(basicAuthConfiguration.getPassword());
+        return configuration != null && 
+               !StringUtils.isBlank(configuration.getUsername()) && 
+               !StringUtils.isBlank(configuration.getPassword());
     }
 
     @Getter

--- a/webserver/src/main/java/io/kestra/webserver/services/BasicAuthService.java
+++ b/webserver/src/main/java/io/kestra/webserver/services/BasicAuthService.java
@@ -147,8 +147,16 @@ public class BasicAuthService {
     }
 
     public boolean isBasicAuthInitialized(){
+
         SaltedBasicAuthConfiguration configuration = configuration();
-        return configuration != null && configuration.getUsername() != null && configuration.getPassword() != null;
+
+        if (configuration != null && configuration.getUsername() != null && configuration.getPassword() != null) {
+            return true;
+        }
+        
+        return basicAuthConfiguration != null && 
+               !StringUtils.isBlank(basicAuthConfiguration.getUsername()) && 
+               !StringUtils.isBlank(basicAuthConfiguration.getPassword());
     }
 
     @Getter


### PR DESCRIPTION
Closes https://github.com/kestra-io/kestra/issues/10180

@nkwiatkowski - Could you please review for small BE changes- you may push the test required in this same branch.

Earlier, when we used to have invalid creds in config file, I was being routed to `/setup` but expectation is to go to `login` and then validation error will inform about invalid creds in config.

Now : 
- No creds in config - `setup`
- Invalid creds in config - `login` (now BE validation will show it's magic)
- valid creds in config - `login` page to use those.

**Note**: Valid/ Invalid means the BE regex respect being done or not.

Also, I had to remove `/api/v1/basicAuthValidationErrors` from tenant routing system otherwise it was not giving the messages.


**Additional**: Posthog events for Setup process was not working - I separated initialization because setup happens before authentication, And `App.vue` PostHog only initializes after authentication So, i kept it as it is..