### PR TITLE
fix(executions)*: restart with finally or afterExecution

### DIFF
--- a/core/src/main/java/io/kestra/core/models/flows/Flow.java
+++ b/core/src/main/java/io/kestra/core/models/flows/Flow.java
@@ -19,7 +19,6 @@ import io.kestra.core.models.tasks.retrys.AbstractRetry;
 import io.kestra.core.models.triggers.AbstractTrigger;
 import io.kestra.core.models.validations.ManualConstraintViolation;
 import io.kestra.core.serializers.JacksonMapper;
-import io.kestra.core.services.FlowService;
 import io.kestra.core.utils.ListUtils;
 import io.kestra.core.validations.FlowValidation;
 import io.micronaut.core.annotation.Introspected;
@@ -30,8 +29,6 @@ import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotEmpty;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.util.*;
 import java.util.stream.Collectors;
@@ -189,17 +186,30 @@ public class Flow extends AbstractFlow implements HasUID {
             .toList();
     }
 
-    public List<Task> allErrorsWithChilds() {
+    public List<Task> allErrorsWithChildrend() {
         var allErrors = allTasksWithChilds().stream()
             .filter(task -> task.isFlowable() && ((FlowableTask<?>) task).getErrors() != null)
             .flatMap(task -> ((FlowableTask<?>) task).getErrors().stream())
             .collect(Collectors.toCollection(ArrayList::new));
 
-        if (this.getErrors() != null && !this.getErrors().isEmpty()) {
+        if (!ListUtils.isEmpty(this.getErrors())) {
             allErrors.addAll(this.getErrors());
         }
 
         return allErrors;
+    }
+
+    public List<Task> allFinallyWithChildren() {
+        var allFinally = allTasksWithChilds().stream()
+            .filter(task -> task.isFlowable() && ((FlowableTask<?>) task).getFinally() != null)
+            .flatMap(task -> ((FlowableTask<?>) task).getFinally().stream())
+            .collect(Collectors.toCollection(ArrayList::new));
+
+        if (!ListUtils.isEmpty(this.getFinally())) {
+            allFinally.addAll(this.getFinally());
+        }
+
+        return allFinally;
     }
 
     public Task findParentTasksByTaskId(String taskId) {

--- a/core/src/test/java/io/kestra/core/runners/AbstractRunnerTest.java
+++ b/core/src/test/java/io/kestra/core/runners/AbstractRunnerTest.java
@@ -185,6 +185,18 @@ public abstract class AbstractRunnerTest {
         restartCaseTest.restartSubflow();
     }
 
+    @Test
+    @LoadFlows({"flows/valids/restart-with-finally.yaml"})
+    protected void restartFailedWithFinally() throws Exception {
+        restartCaseTest.restartFailedWithFinally();
+    }
+
+    @Test
+    @LoadFlows({"flows/valids/restart-with-after-execution.yaml"})
+    protected void restartFailedWithAfterExecution() throws Exception {
+        restartCaseTest.restartFailedWithAfterExecution();
+    }
+
     @RetryingTest(5)
     @LoadFlows({"flows/valids/trigger-flow-listener-no-inputs.yaml",
         "flows/valids/trigger-flow-listener.yaml",

--- a/core/src/test/resources/flows/valids/restart-with-after-execution.yaml
+++ b/core/src/test/resources/flows/valids/restart-with-after-execution.yaml
@@ -1,0 +1,21 @@
+id: restart-with-after-execution
+namespace: io.kestra.tests
+
+tasks:
+  - id: hello
+    type: io.kestra.plugin.core.log.Log
+    message: Hello World! 🚀
+
+  - id: fail_randomly
+    type: io.kestra.plugin.core.execution.Fail
+    runIf: "{{taskrun.attemptsCount == 0}}"
+    errorMessage: Bad value returned!
+
+  - id: log
+    type: io.kestra.plugin.core.log.Log
+    message: should finish here
+
+afterExecution:
+  - id: end
+    type: io.kestra.plugin.core.log.Log
+    message: after execution!

--- a/core/src/test/resources/flows/valids/restart-with-finally.yaml
+++ b/core/src/test/resources/flows/valids/restart-with-finally.yaml
@@ -1,0 +1,21 @@
+id: restart-with-finally
+namespace: io.kestra.tests
+
+tasks:
+  - id: hello
+    type: io.kestra.plugin.core.log.Log
+    message: Hello World! 🚀
+
+  - id: fail_randomly
+    type: io.kestra.plugin.core.execution.Fail
+    runIf: "{{taskrun.attemptsCount == 0}}"
+    errorMessage: Bad value returned!
+
+  - id: log
+    type: io.kestra.plugin.core.log.Log
+    message: should finish here
+
+finally:
+  - id: end
+    type: io.kestra.plugin.core.log.Log
+    message: finally!


### PR DESCRIPTION
When a flow fail and is restarted and contains either a finally or an afterExecution block, those are not resetted so the restart will skip all task and terminate the flow. The fix will reset the status of those tasks so they are restarted.

Fixes #10155
