### PR TITLE
fix(core): do not show release notes button for ee specific plugins

### DIFF
--- a/ui/src/utils/pluginUtils.ts
+++ b/ui/src/utils/pluginUtils.ts
@@ -3,5 +3,7 @@ export const getPluginReleaseUrl = (pluginClass?: string): string | null => {
     
     return !pluginType ? null 
         : pluginType === "core" ? "https://github.com/kestra-io/kestra/releases"
+        : pluginType === "ee" ? null
+        : pluginType === "secret" ? null
         : `https://github.com/kestra-io/${groupId === "storage" ? "storage" : "plugin"}-${pluginType}/releases`;
 };

--- a/ui/src/utils/pluginUtils.ts
+++ b/ui/src/utils/pluginUtils.ts
@@ -1,9 +1,14 @@
 export const getPluginReleaseUrl = (pluginClass?: string): string | null => {
     const [, , groupId, pluginType] = pluginClass?.split(".") ?? [];
     
-    return !pluginType ? null 
-        : pluginType === "core" ? "https://github.com/kestra-io/kestra/releases"
-        : pluginType === "ee" ? null
-        : pluginType === "secret" ? null
-        : `https://github.com/kestra-io/${groupId === "storage" ? "storage" : "plugin"}-${pluginType}/releases`;
+    if (!pluginType || pluginType === "ee" || pluginType === "secret") {
+        return null;
+    }
+
+    if (pluginType === "core") {
+        return "https://github.com/kestra-io/kestra/releases";
+    }
+
+    const repoPrefix = groupId === "storage" ? "storage" : "plugin";
+    return `https://github.com/kestra-io/${repoPrefix}-${pluginType}/releases`;
 };


### PR DESCRIPTION
Since user won't be able to access private repos release notes, I am hiding the button for EE specific plugins.

Closes https://github.com/kestra-io/kestra-ee/issues/4069