### PR TITLE
fix(executions): flow concurrency limit not honors when executions ar…

### DIFF
--- a/core/src/main/java/io/kestra/core/queues/QueueFactoryInterface.java
+++ b/core/src/main/java/io/kestra/core/queues/QueueFactoryInterface.java
@@ -28,6 +28,7 @@ public interface QueueFactoryInterface {
     String SUBFLOWEXECUTIONRESULT_NAMED = "subflowExecutionResultQueue";
     String CLUSTER_EVENT_NAMED = "clusterEventQueue";
     String SUBFLOWEXECUTIONEND_NAMED = "subflowExecutionEndQueue";
+    String EXECUTION_RUNNING_NAMED = "executionRunningQueue";
 
     QueueInterface<Execution> execution();
 
@@ -58,4 +59,6 @@ public interface QueueFactoryInterface {
     QueueInterface<SubflowExecutionResult> subflowExecutionResult();
 
     QueueInterface<SubflowExecutionEnd> subflowExecutionEnd();
+
+    QueueInterface<ExecutionRunning> executionRunning();
 }

--- a/core/src/main/java/io/kestra/core/queues/QueueService.java
+++ b/core/src/main/java/io/kestra/core/queues/QueueService.java
@@ -27,8 +27,6 @@ public class QueueService {
             return ((Executor) object).getExecution().getId();
         } else if (object.getClass() == MetricEntry.class) {
             return null;
-        } else if (object.getClass() == ExecutionRunning.class) {
-            return ((ExecutionRunning) object).getExecution().getId();
         } else if (object.getClass() == SubflowExecutionEnd.class) {
             return ((SubflowExecutionEnd) object).getParentExecutionId();
         } else {

--- a/core/src/main/java/io/kestra/core/runners/ExecutionRunning.java
+++ b/core/src/main/java/io/kestra/core/runners/ExecutionRunning.java
@@ -1,5 +1,6 @@
 package io.kestra.core.runners;
 
+import io.kestra.core.models.HasUID;
 import io.kestra.core.models.executions.Execution;
 import io.kestra.core.utils.IdUtils;
 import jakarta.validation.constraints.NotNull;
@@ -11,7 +12,7 @@ import lombok.With;
 @Value
 @AllArgsConstructor
 @Builder
-public class ExecutionRunning {
+public class ExecutionRunning implements HasUID {
     String tenantId;
 
     @NotNull
@@ -26,6 +27,7 @@ public class ExecutionRunning {
     @With
     ConcurrencyState concurrencyState;
 
+    @Override
     public String uid() {
         return IdUtils.fromPartsAndSeparator('|', this.tenantId, this.namespace, this.flowId, this.execution.getId());
     }

--- a/core/src/test/java/io/kestra/core/runners/AbstractRunnerTest.java
+++ b/core/src/test/java/io/kestra/core/runners/AbstractRunnerTest.java
@@ -418,6 +418,12 @@ public abstract class AbstractRunnerTest {
     }
 
     @Test
+    @LoadFlows({"flows/valids/flow-concurrency-for-each-item.yaml", "flows/valids/flow-concurrency-queue.yml"})
+    protected void flowConcurrencyWithForEachItem() throws Exception {
+        flowConcurrencyCaseTest.flowConcurrencyWithForEachItem();
+    }
+
+    @Test
     @ExecuteFlow("flows/valids/executable-fail.yml")
     void badExecutable(Execution execution) {
         assertThat(execution.getTaskRunList().size()).isEqualTo(1);

--- a/core/src/test/resources/flows/valids/flow-concurrency-for-each-item.yaml
+++ b/core/src/test/resources/flows/valids/flow-concurrency-for-each-item.yaml
@@ -1,0 +1,21 @@
+id: flow-concurrency-for-each-item
+namespace: io.kestra.tests
+
+inputs:
+  - id: file
+    type: FILE
+  - id: batch
+    type: INT
+
+tasks:
+  - id: each
+    type: io.kestra.plugin.core.flow.ForEachItem
+    items: "{{ inputs.file }}"
+    batch:
+      rows: "{{inputs.batch}}"
+    namespace: io.kestra.tests
+    flowId: flow-concurrency-queue
+    wait: true
+    transmitFailed: true
+    inputs:
+      items: "{{ taskrun.items }}"

--- a/jdbc-h2/src/main/java/io/kestra/runner/h2/H2ExecutionRunningStorage.java
+++ b/jdbc-h2/src/main/java/io/kestra/runner/h2/H2ExecutionRunningStorage.java
@@ -1,0 +1,15 @@
+package io.kestra.runner.h2;
+
+import io.kestra.core.runners.ExecutionRunning;
+import io.kestra.jdbc.runner.AbstractJdbcExecutionRunningStorage;
+import io.kestra.repository.h2.H2Repository;
+import jakarta.inject.Named;
+import jakarta.inject.Singleton;
+
+@Singleton
+@H2QueueEnabled
+public class H2ExecutionRunningStorage extends AbstractJdbcExecutionRunningStorage {
+    public H2ExecutionRunningStorage(@Named("executionrunning") H2Repository<ExecutionRunning> repository) {
+        super(repository);
+    }
+}

--- a/jdbc-h2/src/main/java/io/kestra/runner/h2/H2QueueFactory.java
+++ b/jdbc-h2/src/main/java/io/kestra/runner/h2/H2QueueFactory.java
@@ -144,4 +144,12 @@ public class H2QueueFactory implements QueueFactoryInterface {
     public QueueInterface<SubflowExecutionEnd> subflowExecutionEnd() {
         return new H2Queue<>(SubflowExecutionEnd.class, applicationContext);
     }
+
+    @Override
+    @Singleton
+    @Named(QueueFactoryInterface.EXECUTION_RUNNING_NAMED)
+    @Bean(preDestroy = "close")
+    public QueueInterface<ExecutionRunning> executionRunning() {
+        return new H2Queue<>(ExecutionRunning.class, applicationContext);
+    }
 }

--- a/jdbc-h2/src/main/resources/migrations/h2/V1_41__execution_running.sql
+++ b/jdbc-h2/src/main/resources/migrations/h2/V1_41__execution_running.sql
@@ -1,0 +1,29 @@
+CREATE TABLE IF NOT EXISTS execution_running (
+    "key" VARCHAR(250) NOT NULL PRIMARY KEY,
+    "value" TEXT NOT NULL,
+    "tenant_id" VARCHAR(250) GENERATED ALWAYS AS (JQ_STRING("value", '.tenantId')),
+    "namespace" VARCHAR(150) NOT NULL GENERATED ALWAYS AS (JQ_STRING("value", '.namespace')),
+    "flow_id" VARCHAR(150) NOT NULL GENERATED ALWAYS AS (JQ_STRING("value", '.flowId'))
+    );
+
+CREATE INDEX IF NOT EXISTS execution_running__flow ON execution_running ("tenant_id", "namespace", "flow_id");
+
+ALTER TABLE queues ALTER COLUMN "type" ENUM(
+    'io.kestra.core.models.executions.Execution',
+    'io.kestra.core.models.templates.Template',
+    'io.kestra.core.models.executions.ExecutionKilled',
+    'io.kestra.core.runners.WorkerJob',
+    'io.kestra.core.runners.WorkerTaskResult',
+    'io.kestra.core.runners.WorkerInstance',
+    'io.kestra.core.runners.WorkerTaskRunning',
+    'io.kestra.core.models.executions.LogEntry',
+    'io.kestra.core.models.triggers.Trigger',
+    'io.kestra.ee.models.audits.AuditLog',
+    'io.kestra.core.models.executions.MetricEntry',
+    'io.kestra.core.runners.WorkerTriggerResult',
+    'io.kestra.core.runners.SubflowExecutionResult',
+    'io.kestra.core.server.ClusterEvent',
+    'io.kestra.core.runners.SubflowExecutionEnd',
+    'io.kestra.core.models.flows.FlowInterface',
+    'io.kestra.core.runners.ExecutionRunning'
+) NOT NULL

--- a/jdbc-mysql/src/main/java/io/kestra/runner/mysql/MysqlExecutionRunningStorage.java
+++ b/jdbc-mysql/src/main/java/io/kestra/runner/mysql/MysqlExecutionRunningStorage.java
@@ -1,0 +1,15 @@
+package io.kestra.runner.mysql;
+
+import io.kestra.core.runners.ExecutionRunning;
+import io.kestra.jdbc.runner.AbstractJdbcExecutionRunningStorage;
+import io.kestra.repository.mysql.MysqlRepository;
+import jakarta.inject.Named;
+import jakarta.inject.Singleton;
+
+@Singleton
+@MysqlQueueEnabled
+public class MysqlExecutionRunningStorage extends AbstractJdbcExecutionRunningStorage {
+    public MysqlExecutionRunningStorage(@Named("executionrunning") MysqlRepository<ExecutionRunning> repository) {
+        super(repository);
+    }
+}

--- a/jdbc-mysql/src/main/java/io/kestra/runner/mysql/MysqlQueueFactory.java
+++ b/jdbc-mysql/src/main/java/io/kestra/runner/mysql/MysqlQueueFactory.java
@@ -144,4 +144,12 @@ public class MysqlQueueFactory implements QueueFactoryInterface {
     public QueueInterface<SubflowExecutionEnd> subflowExecutionEnd() {
         return new MysqlQueue<>(SubflowExecutionEnd.class, applicationContext);
     }
+
+    @Override
+    @Singleton
+    @Named(QueueFactoryInterface.EXECUTION_RUNNING_NAMED)
+    @Bean(preDestroy = "close")
+    public QueueInterface<ExecutionRunning> executionRunning() {
+        return new MysqlQueue<>(ExecutionRunning.class, applicationContext);
+    }
 }

--- a/jdbc-mysql/src/main/resources/migrations/mysql/V1_40__execution_running.sql
+++ b/jdbc-mysql/src/main/resources/migrations/mysql/V1_40__execution_running.sql
@@ -1,0 +1,28 @@
+CREATE TABLE IF NOT EXISTS execution_running (
+    `key` VARCHAR(250) NOT NULL PRIMARY KEY,
+    `value` JSON NOT NULL,
+    `tenant_id` VARCHAR(250) GENERATED ALWAYS AS (value ->> '$.tenantId') STORED,
+    `namespace` VARCHAR(150) GENERATED ALWAYS AS (value ->> '$.namespace') STORED NOT NULL,
+    `flow_id` VARCHAR(150) GENERATED ALWAYS AS (value ->> '$.flowId') STORED NOT NULL,
+    INDEX ix_flow (tenant_id, namespace, flow_id)
+);
+
+ALTER TABLE queues MODIFY COLUMN `type` ENUM(
+    'io.kestra.core.models.executions.Execution',
+    'io.kestra.core.models.templates.Template',
+    'io.kestra.core.models.executions.ExecutionKilled',
+    'io.kestra.core.runners.WorkerJob',
+    'io.kestra.core.runners.WorkerTaskResult',
+    'io.kestra.core.runners.WorkerInstance',
+    'io.kestra.core.runners.WorkerTaskRunning',
+    'io.kestra.core.models.executions.LogEntry',
+    'io.kestra.core.models.triggers.Trigger',
+    'io.kestra.ee.models.audits.AuditLog',
+    'io.kestra.core.models.executions.MetricEntry',
+    'io.kestra.core.runners.WorkerTriggerResult',
+    'io.kestra.core.runners.SubflowExecutionResult',
+    'io.kestra.core.server.ClusterEvent',
+    'io.kestra.core.runners.SubflowExecutionEnd',
+    'io.kestra.core.models.flows.FlowInterface',
+    'io.kestra.core.runners.ExecutionRunning'
+    ) NOT NULL;

--- a/jdbc-postgres/src/main/java/io/kestra/runner/postgres/PostgresExecutionRunningStorage.java
+++ b/jdbc-postgres/src/main/java/io/kestra/runner/postgres/PostgresExecutionRunningStorage.java
@@ -1,0 +1,15 @@
+package io.kestra.runner.postgres;
+
+import io.kestra.core.runners.ExecutionRunning;
+import io.kestra.jdbc.runner.AbstractJdbcExecutionRunningStorage;
+import io.kestra.repository.postgres.PostgresRepository;
+import jakarta.inject.Named;
+import jakarta.inject.Singleton;
+
+@Singleton
+@PostgresQueueEnabled
+public class PostgresExecutionRunningStorage extends AbstractJdbcExecutionRunningStorage {
+    public PostgresExecutionRunningStorage(@Named("executionrunning") PostgresRepository<ExecutionRunning> repository) {
+        super(repository);
+    }
+}

--- a/jdbc-postgres/src/main/java/io/kestra/runner/postgres/PostgresQueueFactory.java
+++ b/jdbc-postgres/src/main/java/io/kestra/runner/postgres/PostgresQueueFactory.java
@@ -144,4 +144,12 @@ public class PostgresQueueFactory implements QueueFactoryInterface {
     public QueueInterface<SubflowExecutionEnd> subflowExecutionEnd() {
         return new PostgresQueue<>(SubflowExecutionEnd.class, applicationContext);
     }
+
+    @Override
+    @Singleton
+    @Named(QueueFactoryInterface.EXECUTION_RUNNING_NAMED)
+    @Bean(preDestroy = "close")
+    public QueueInterface<ExecutionRunning> executionRunning() {
+        return new PostgresQueue<>(ExecutionRunning.class, applicationContext);
+    }
 }

--- a/jdbc-postgres/src/main/resources/migrations/postgres/V1_40__execution_running.sql
+++ b/jdbc-postgres/src/main/resources/migrations/postgres/V1_40__execution_running.sql
@@ -1,0 +1,11 @@
+CREATE TABLE IF NOT EXISTS execution_running (
+    key VARCHAR(250) NOT NULL PRIMARY KEY,
+    value JSONB NOT NULL,
+    tenant_id VARCHAR(250) GENERATED ALWAYS AS (value ->> 'tenantId') STORED,
+    namespace VARCHAR(150) NOT NULL GENERATED ALWAYS AS (value ->> 'namespace') STORED,
+    flow_id VARCHAR(150) NOT NULL GENERATED ALWAYS AS (value ->> 'flowId') STORED
+);
+
+CREATE INDEX IF NOT EXISTS execution_running__flow ON execution_running (tenant_id, namespace, flow_id);
+
+ALTER TYPE queue_type ADD VALUE IF NOT EXISTS 'io.kestra.core.runners.ExecutionRunning';

--- a/jdbc/src/main/java/io/kestra/jdbc/JdbcTableConfigsFactory.java
+++ b/jdbc/src/main/java/io/kestra/jdbc/JdbcTableConfigsFactory.java
@@ -125,6 +125,12 @@ public class JdbcTableConfigsFactory {
         return new InstantiableJdbcTableConfig("dashboards", Dashboard.class, "dashboards");
     }
 
+    @Bean
+    @Named("executionrunning")
+    public InstantiableJdbcTableConfig executionRunning() {
+        return new InstantiableJdbcTableConfig("executionrunning", ExecutionRunning.class, "execution_running");
+    }
+
     public static class InstantiableJdbcTableConfig extends JdbcTableConfig {
         public InstantiableJdbcTableConfig(String name, @Nullable Class<?> cls, String table) {
             super(name, cls, table);

--- a/jdbc/src/main/java/io/kestra/jdbc/runner/AbstractJdbcExecutionQueuedStorage.java
+++ b/jdbc/src/main/java/io/kestra/jdbc/runner/AbstractJdbcExecutionQueuedStorage.java
@@ -4,6 +4,7 @@ import io.kestra.core.models.executions.Execution;
 import io.kestra.core.runners.ExecutionQueued;
 import io.kestra.core.utils.IdUtils;
 import io.kestra.jdbc.repository.AbstractJdbcRepository;
+import org.jooq.DSLContext;
 import org.jooq.Field;
 import org.jooq.impl.DSL;
 
@@ -19,9 +20,9 @@ public abstract class AbstractJdbcExecutionQueuedStorage extends AbstractJdbcRep
         this.jdbcRepository = jdbcRepository;
     }
 
-    public void save(ExecutionQueued executionQueued) {
+    public void save(DSLContext dslContext, ExecutionQueued executionQueued) {
         Map<Field<Object>, Object> fields = this.jdbcRepository.persistFields(executionQueued);
-        this.jdbcRepository.persist(executionQueued, fields);
+        this.jdbcRepository.persist(executionQueued, dslContext, fields);
     }
 
     public void pop(String tenantId, String namespace, String flowId, Consumer<Execution> consumer) {

--- a/jdbc/src/main/java/io/kestra/jdbc/runner/AbstractJdbcExecutionRunningStorage.java
+++ b/jdbc/src/main/java/io/kestra/jdbc/runner/AbstractJdbcExecutionRunningStorage.java
@@ -1,0 +1,71 @@
+package io.kestra.jdbc.runner;
+
+import io.kestra.core.models.executions.Execution;
+import io.kestra.core.models.flows.FlowInterface;
+import io.kestra.core.runners.ExecutionRunning;
+import io.kestra.core.utils.IdUtils;
+import io.kestra.jdbc.repository.AbstractJdbcRepository;
+import org.jooq.DSLContext;
+import org.jooq.Field;
+import org.jooq.impl.DSL;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.*;
+
+public class AbstractJdbcExecutionRunningStorage extends AbstractJdbcRepository {
+    protected io.kestra.jdbc.AbstractJdbcRepository<ExecutionRunning> jdbcRepository;
+
+    public AbstractJdbcExecutionRunningStorage(io.kestra.jdbc.AbstractJdbcRepository<ExecutionRunning> jdbcRepository) {
+        this.jdbcRepository = jdbcRepository;
+    }
+
+    public void save(DSLContext dslContext, ExecutionRunning executionRunning) {
+        Map<Field<Object>, Object> fields = this.jdbcRepository.persistFields(executionRunning);
+        this.jdbcRepository.persist(executionRunning, dslContext, fields);
+    }
+
+    /**
+     * Count for running executions then process the count using the consumer function.
+     * It locked the raw and is wrapped in a transaction so the consumer should use the provided dslContext for any database access.
+     * <p>
+     * Note: when there is no execution running, there will be no database locks, so multiple calls will return 0.
+     * This is only potentially an issue with multiple executor instances when the concurrency limit is set to 1.
+     */
+    public ExecutionRunning countThenProcess(FlowInterface flow, BiFunction<DSLContext, Integer, ExecutionRunning> consumer) {
+        return this.jdbcRepository
+            .getDslContextWrapper()
+            .transactionResult(configuration -> {
+                var dslContext = DSL.using(configuration);
+                var select = dslContext
+                    .select(AbstractJdbcRepository.field("value"))
+                    .from(this.jdbcRepository.getTable())
+                    .where(this.buildTenantCondition(flow.getTenantId()))
+                    .and(field("namespace").eq(flow.getNamespace()))
+                    .and(field("flow_id").eq(flow.getId()));
+
+                Integer count = select.forUpdate().fetch().size();
+                return consumer.apply(dslContext, count);
+            });
+    }
+
+    /**
+     * Delete the execution running corresponding to the given execution.
+     */
+    public void remove(Execution execution) {
+        this.jdbcRepository
+            .getDslContextWrapper()
+            .transaction(configuration -> {
+                var select = DSL
+                    .using(configuration)
+                    .select(AbstractJdbcRepository.field("value"))
+                    .from(this.jdbcRepository.getTable())
+                    .where(buildTenantCondition(execution.getTenantId()))
+                    .and(field("key").eq(IdUtils.fromPartsAndSeparator('|', execution.getTenantId(), execution.getNamespace(), execution.getFlowId(), execution.getId())))
+                    .forUpdate();
+
+                Optional<ExecutionRunning> maybeExecution = this.jdbcRepository.fetchOne(select);
+                maybeExecution.ifPresent(executionRunning -> this.jdbcRepository.delete(executionRunning));
+            });
+    }
+}


### PR DESCRIPTION
…e created at a high rate

This is due to the fact that we now process the execution queue concurrently so there is a race when counting currently running executions. This can be seen easily using a ForEachItem as it could create tens or hundreds of executions almost instantly leading to almost all those executions started as they would all see 0 executions running...

Using a dedicated execution running queue, as done in EE, would serialize the messages and fix the issue.

However, if using multiple executor instances and concurrency limit = 1, there is a theoretical race as no locks will be done if no execution is running. A max surge of executions could be as high as the number of executor but this race is less probable to happen in real world scenario.

Fixes https://github.com/kestra-io/kestra/issues/10228
