### PR TITLE
fix(executions): breakpoint on ForEach

### DIFF
--- a/core/src/main/java/io/kestra/core/runners/ExecutorService.java
+++ b/core/src/main/java/io/kestra/core/runners/ExecutorService.java
@@ -948,7 +948,7 @@ public class ExecutorService {
 
     private boolean shouldSuspend(TaskRun taskRun, List<Breakpoint> breakpoints) {
         return taskRun.getState().getCurrent().isCreated() && breakpoints.stream()
-                .anyMatch(breakpoint -> taskRun.getTaskId().equals(breakpoint.getId()) && Objects.equals(taskRun.getValue(), breakpoint.getValue()));
+                .anyMatch(breakpoint -> taskRun.getTaskId().equals(breakpoint.getId()) && (breakpoint.getValue() == null || Objects.equals(taskRun.getValue(), breakpoint.getValue())));
     }
 
     private Executor handleExecutableTask(final Executor executor) {


### PR DESCRIPTION
We should be able to put a breakpoint without value, easier for the playground
