### PR TITLE
fix(UI): Fix folder highlight bug when selecting a file

### DIFF
--- a/ui/src/components/inputs/EditorSidebar.vue
+++ b/ui/src/components/inputs/EditorSidebar.vue
@@ -114,7 +114,7 @@
             draggable
             node-key="id"
             v-loading="items === undefined"
-            :props="{class: 'node', isLeaf: 'leaf'}"
+            :props="{class: 'nodeClass', isLeaf: 'leaf'}"
             class="mt-3"
             @node-click="handleNodeClick"
             @node-drag-start="
@@ -149,7 +149,6 @@
                     <el-row
                         justify="space-between"
                         class="w-100"
-                        :class="{'selected-node': selectedNodes.includes(data.id)}"
                         @click="(event) => handleNodeClick(data, node)"
                     >
                         <el-col class="w-100">
@@ -490,7 +489,12 @@
                 "importFileDirectory",
                 "exportFileDirectory",
             ]),
-
+            nodeClass(data) {
+                if (this.selectedNodes.includes(data.id)) {
+                    return "node selected-tree-node";
+                }
+                return "node";
+            },
             flattenTree(items, parentPath = "") {
                 const result = [];
 
@@ -1305,6 +1309,7 @@
             }
 
             &:hover{
+                background-color: var(--ks-button-background-primary);
                 border: 1px solid var(--ks-border-active);
             }
         }
@@ -1321,7 +1326,7 @@
             min-width: fit-content;
             border: 1px solid var(--ks-border-active)
         }
-        .el-tree-node:has(.selected-node) > .el-tree-node__content {
+        .el-tree-node.selected-tree-node > .el-tree-node__content {
             background-color: var(--ks-button-background-primary);
             min-width: fit-content;
         }


### PR DESCRIPTION
<!-- Thanks for submitting a Pull Request to Kestra. To help us review your contribution, please follow the guidelines below:
This PR fixes a UI bug where selecting a file in the namespace file explorer would also incorrectly highlight its parent folder.


- Make sure that your commits follow the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) specification e.g. `feat(ui): add a new navigation menu item` or `fix(core): fix a bug in the core model` or `docs: update the README.md`. This will help us automatically generate the changelog.
- The title should briefly summarize the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share a flow example to help the reviewer understand and QA the change.
- Use "closes" to automatically close an issue. For example, `closes #1234` will close issue #1234. 

### What changes are being made and why?
-->
### Description
This PR fixes a UI bug where selecting a file in the namespace file explorer would also incorrectly highlight its parent folder.
<img width="1917" height="961" alt="image" src="https://github.com/user-attachments/assets/d386912e-75b8-49b8-a074-205ae82f8133" />

Closes #10360
