### PR TITLE
fix(runner): support floating-point CPU values in Docker runner

### DIFF
--- a/script/src/main/java/io/kestra/plugin/scripts/runner/docker/Cpu.java
+++ b/script/src/main/java/io/kestra/plugin/scripts/runner/docker/Cpu.java
@@ -14,5 +14,5 @@ public class Cpu {
         title = "The maximum amount of CPU resources a container can use.",
         description = "Make sure to set that to a numeric value e.g. `cpus: \"1.5\"` or `cpus: \"4\"` or For instance, if the host machine has two CPUs and you set `cpus: \"1.5\"`, the container is guaranteed **at most** one and a half of the CPUs."
     )
-    private Property<Long> cpus;
+    private Property<Double> cpus;
 }

--- a/script/src/main/java/io/kestra/plugin/scripts/runner/docker/Docker.java
+++ b/script/src/main/java/io/kestra/plugin/scripts/runner/docker/Docker.java
@@ -765,7 +765,8 @@ public class Docker extends TaskRunner<Docker.DockerTaskRunnerDetailResult> {
         }
 
         if (this.getCpu() != null && this.getCpu().getCpus() != null) {
-            hostConfig.withCpuQuota(runContext.render(this.getCpu().getCpus()).as(Long.class).orElseThrow() * 10000L);
+            Double cpuValue = runContext.render(this.getCpu().getCpus()).as(Double.class).orElseThrow();
+            hostConfig.withNanoCPUs((long)(cpuValue * 1_000_000_000L));
         }
 
         if (this.getMemory() != null) {

--- a/script/src/test/java/io/kestra/plugin/scripts/runner/docker/DockerTest.java
+++ b/script/src/test/java/io/kestra/plugin/scripts/runner/docker/DockerTest.java
@@ -2,15 +2,18 @@ package io.kestra.plugin.scripts.runner.docker;
 
 import io.kestra.core.models.property.Property;
 import io.kestra.core.models.tasks.runners.AbstractTaskRunnerTest;
+import io.kestra.core.models.tasks.runners.TaskCommands;
 import io.kestra.core.models.tasks.runners.TaskRunner;
 import io.kestra.plugin.scripts.exec.scripts.runners.CommandsWrapper;
 import org.assertj.core.api.Assertions;
+import org.hamcrest.MatcherAssert;
 import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
 import java.util.List;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.hamcrest.Matchers.containsString;
 
 class DockerTest extends AbstractTaskRunnerTest {
     @Override
@@ -52,14 +55,15 @@ class DockerTest extends AbstractTaskRunnerTest {
             .build();
 
         var taskCommands = new CommandsWrapper(runContext).withCommands(Property.ofValue(List.of(
-            "/bin/sh", "-c",
-            "cat /sys/fs/cgroup/cpu.max || cat /sys/fs/cgroup/cpu/cpu.cfs_quota_us"
-        )));
-
+                "/bin/sh", "-c",
+                "CPU_LIMIT=$(cat /sys/fs/cgroup/cpu.max || cat /sys/fs/cgroup/cpu/cpu.cfs_quota_us) && " +
+                    "echo \"::{\\\"outputs\\\":{\\\"cpuLimit\\\":\\\"$CPU_LIMIT\\\"}}::\""
+            )));
         var result = docker.run(runContext, taskCommands, Collections.emptyList());
 
         assertThat(result).isNotNull();
         assertThat(result.getExitCode()).isZero();
-        Assertions.assertThat(result.getLogConsumer().getStdOutCount()).isEqualTo(1);
+        MatcherAssert.assertThat((String) result.getLogConsumer().getOutputs().get("cpuLimit"), containsString("150000"));
+        assertThat(result.getLogConsumer().getStdOutCount()).isEqualTo(1);
     }
 }

--- a/script/src/test/java/io/kestra/plugin/scripts/runner/docker/DockerTest.java
+++ b/script/src/test/java/io/kestra/plugin/scripts/runner/docker/DockerTest.java
@@ -37,4 +37,29 @@ class DockerTest extends AbstractTaskRunnerTest {
         assertThat(result.getExitCode()).isZero();
         Assertions.assertThat(result.getLogConsumer().getStdOutCount()).isEqualTo(1);
     }
+
+    @Test
+    void shouldSetCorrectCPULimitsInContainer() throws Exception {
+        var runContext = runContext(this.runContextFactory);
+
+        var cpuConfig = Cpu.builder()
+            .cpus(Property.ofValue(1.5))
+            .build();
+
+        var docker = Docker.builder()
+            .image("rockylinux:9.3-minimal")
+            .cpu(cpuConfig)
+            .build();
+
+        var taskCommands = new CommandsWrapper(runContext).withCommands(Property.ofValue(List.of(
+            "/bin/sh", "-c",
+            "cat /sys/fs/cgroup/cpu.max || cat /sys/fs/cgroup/cpu/cpu.cfs_quota_us"
+        )));
+
+        var result = docker.run(runContext, taskCommands, Collections.emptyList());
+
+        assertThat(result).isNotNull();
+        assertThat(result.getExitCode()).isZero();
+        Assertions.assertThat(result.getLogConsumer().getStdOutCount()).isEqualTo(1);
+    }
 }


### PR DESCRIPTION
fixes #8510
