### PR TITLE
fix(flows): file watching flow should delete the flow when the file i…

### DIFF
--- a/cli/src/main/java/io/kestra/cli/services/FileChangedEventListener.java
+++ b/cli/src/main/java/io/kestra/cli/services/FileChangedEventListener.java
@@ -162,7 +162,15 @@ public class FileChangedEventListener {
                                     }
 
                                 } catch (NoSuchFileException e) {
-                                    log.error("File not found: {}", entry, e);
+                                    log.warn("File not found: {}, deleting it", entry, e);
+                                    // the file might have been deleted while reading so if not found we try to delete the flow
+                                    flows.stream()
+                                        .filter(flow -> flow.getPath().equals(filePath.toString()))
+                                        .findFirst()
+                                        .ifPresent(flowWithPath -> {
+                                            flowFilesManager.deleteFlow(flowWithPath.getTenantId(), flowWithPath.getNamespace(), flowWithPath.getId());
+                                            this.flows.removeIf(fwp -> fwp.uidWithoutRevision().equals(flowWithPath.uidWithoutRevision()));
+                                        });
                                 } catch (IOException e) {
                                     log.error("Error reading file: {}", entry, e);
                                 }


### PR DESCRIPTION
…s deleted while reading for update

When you use flow watching, a file can be updated then deleted, if it occurs quickly you could have a modified event, read the file then have a file not found exception as it has been deleted. We should delete the flow in this case.

This has been detected because the related tests are flaky, doing that reduce falkiness of the related tests
