### PR TITLE
fix(flows): wrong warning in FILE input

### DIFF
--- a/core/src/main/java/io/kestra/core/models/flows/input/FileInput.java
+++ b/core/src/main/java/io/kestra/core/models/flows/input/FileInput.java
@@ -20,9 +20,8 @@ public class FileInput extends Input<URI> {
 
     private static final String DEFAULT_EXTENSION = ".upl";
 
-    @Builder.Default
     @Deprecated(since = "0.24", forRemoval = true)
-    public String extension = DEFAULT_EXTENSION;
+    public String extension;
 
     @Override
     public void validate(URI input) throws ConstraintViolationException {
@@ -33,6 +32,7 @@ public class FileInput extends Input<URI> {
         String res = inputs.stream()
             .filter(in -> in instanceof FileInput)
             .filter(in -> in.getId().equals(fileName))
+            .filter(flowInput -> ((FileInput) flowInput).getExtension() != null)
             .map(flowInput -> ((FileInput) flowInput).getExtension())
             .findFirst()
             .orElse(FileInput.DEFAULT_EXTENSION);


### PR DESCRIPTION
As we deprecate the `extension` property but still have a default for it, the warning is always disaply. Removing the default and applying only when needed fixes the issue.

Fixes #10361
