### PR TITLE
fix(executions): Don't create outputs from the Subflow task when we d…

### DIFF
--- a/core/src/test/java/io/kestra/plugin/core/flow/SubflowRunnerTest.java
+++ b/core/src/test/java/io/kestra/plugin/core/flow/SubflowRunnerTest.java
@@ -4,16 +4,24 @@ import io.kestra.core.junit.annotations.KestraTest;
 import io.kestra.core.junit.annotations.LoadFlows;
 import io.kestra.core.models.Label;
 import io.kestra.core.models.executions.Execution;
+import io.kestra.core.models.flows.State;
 import io.kestra.core.queues.QueueException;
+import io.kestra.core.queues.QueueFactoryInterface;
+import io.kestra.core.queues.QueueInterface;
 import io.kestra.core.repositories.ExecutionRepositoryInterface;
 import io.kestra.core.runners.RunnerUtils;
 import jakarta.inject.Inject;
+import jakarta.inject.Named;
 import org.junit.jupiter.api.Test;
 
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static io.kestra.core.tenant.TenantService.MAIN_TENANT;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @KestraTest(startRunner = true)
 class SubflowRunnerTest {
@@ -23,6 +31,10 @@ class SubflowRunnerTest {
 
     @Inject
     private ExecutionRepositoryInterface executionRepository;
+
+    @Inject
+    @Named(QueueFactoryInterface.EXECUTION_NAMED)
+    protected QueueInterface<Execution> executionQueue;
 
     @Test
     @LoadFlows({"flows/valids/subflow-inherited-labels-child.yaml", "flows/valids/subflow-inherited-labels-parent.yaml"})
@@ -49,5 +61,30 @@ class SubflowRunnerTest {
             new Label("parentFlowLabel1", "launchBar"), // overridden by Subtask
             new Label("parentFlowLabel2", "value2") // inherited from the parent flow
         );
+    }
+
+    @Test
+    @LoadFlows({"flows/valids/subflow-parent-no-wait.yaml", "flows/valids/subflow-child-with-output.yaml"})
+    void subflowOutputWithoutWait() throws QueueException, TimeoutException, InterruptedException {
+        AtomicReference<Execution> childExecution = new AtomicReference<>();
+        CountDownLatch countDownLatch = new CountDownLatch(1);
+        Runnable closing = executionQueue.receive(either -> {
+            if (either.isLeft() && either.getLeft().getFlowId().equals("subflow-child-with-output") && either.getLeft().getState().isTerminated()) {
+                childExecution.set(either.getLeft());
+                countDownLatch.countDown();
+            }
+        });
+
+        Execution parentExecution = runnerUtils.runOne(MAIN_TENANT, "io.kestra.tests", "subflow-parent-no-wait");
+        String childExecutionId = (String) parentExecution.findTaskRunsByTaskId("subflow").getFirst().getOutputs().get("executionId");
+        assertThat(childExecutionId).isNotBlank();
+        assertThat(parentExecution.getState().getCurrent()).isEqualTo(State.Type.SUCCESS);
+        assertThat(parentExecution.getTaskRunList()).hasSize(1);
+
+        assertTrue(countDownLatch.await(10, TimeUnit.SECONDS));
+        assertThat(childExecution.get().getId()).isEqualTo(childExecutionId);
+        assertThat(childExecution.get().getState().getCurrent()).isEqualTo(State.Type.SUCCESS);
+        assertThat(childExecution.get().getTaskRunList()).hasSize(1);
+        closing.run();
     }
 }

--- a/core/src/test/resources/flows/valids/subflow-child-with-output.yaml
+++ b/core/src/test/resources/flows/valids/subflow-child-with-output.yaml
@@ -1,0 +1,12 @@
+id: subflow-child-with-output
+namespace: io.kestra.tests
+
+tasks:
+  - id: return
+    type: io.kestra.plugin.core.debug.Return
+    format: "Some value"
+
+outputs:
+  - id: flow_a_output
+    type: STRING
+    value: "{{ outputs.return.value }}"

--- a/core/src/test/resources/flows/valids/subflow-parent-no-wait.yaml
+++ b/core/src/test/resources/flows/valids/subflow-parent-no-wait.yaml
@@ -1,0 +1,9 @@
+id: subflow-parent-no-wait
+namespace: io.kestra.tests
+
+tasks:
+  - id: subflow
+    type: io.kestra.plugin.core.flow.Subflow
+    namespace: io.kestra.tests
+    flowId: subflow-child-with-output
+    wait: false


### PR DESCRIPTION
…idn't wait

As, well, if we didn't wait for the subflow execution, we cannot have access to its outputs.
