### PR TITLE
fix(flows): no-code - when changing type message avoid warning

### DIFF
--- a/ui/src/components/flows/tasks/TaskArray.vue
+++ b/ui/src/components/flows/tasks/TaskArray.vue
@@ -95,7 +95,7 @@
     );
 
     const handleInput = (value: string, index: number) => {
-        emits("update:modelValue", items.value.toSpliced(index, 1, value));
+        emits("update:modelValue", [...items.value].splice(index, 1, value));
     };
 
     const newEmptyValue = computed(() => {
@@ -114,7 +114,7 @@
             emits("update:modelValue", undefined);
             return;
         }
-        emits("update:modelValue", items.value.toSpliced(index, 1));
+        emits("update:modelValue", [...items.value].splice(index, 1));
     };
 
     const moveItem = (index: number, direction: "up" | "down") => {


### PR DESCRIPTION
When going from array to string in log message, the value is only changed one way not the other.

With this update, it's now both ways.

It also removes 2 props type warnings.