### PR TITLE
fix(flows): playground need to use updated ui-libs

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -10,7 +10,7 @@
             "hasInstallScript": true,
             "dependencies": {
                 "@js-joda/core": "^5.6.5",
-                "@kestra-io/ui-libs": "^0.0.231",
+                "@kestra-io/ui-libs": "^0.0.232",
                 "@vue-flow/background": "^1.3.2",
                 "@vue-flow/controls": "^1.1.2",
                 "@vue-flow/core": "^1.45.0",
@@ -3133,9 +3133,9 @@
             "license": "BSD-3-Clause"
         },
         "node_modules/@kestra-io/ui-libs": {
-            "version": "0.0.231",
-            "resolved": "https://registry.npmjs.org/@kestra-io/ui-libs/-/ui-libs-0.0.231.tgz",
-            "integrity": "sha512-4nUsWqjKXc0zvlrYKwFvtoiOoThB3d/cJmLm0uBz2tppZOsqeMMRh25wG73c/GQN/VbaptfluM/uiLBllHIDeg==",
+            "version": "0.0.232",
+            "resolved": "https://registry.npmjs.org/@kestra-io/ui-libs/-/ui-libs-0.0.232.tgz",
+            "integrity": "sha512-4Z1DNxWEZSEEy2Tv63uNf2remxb/IqVUY01/qCaeYjLcp5axrS7Dn43N8DspA4EPdlhe4JFq2RhG13Pom+JDQA==",
             "dependencies": {
                 "@nuxtjs/mdc": "^0.16.1",
                 "@popperjs/core": "^2.11.8",

--- a/ui/package.json
+++ b/ui/package.json
@@ -24,7 +24,7 @@
     },
     "dependencies": {
         "@js-joda/core": "^5.6.5",
-        "@kestra-io/ui-libs": "^0.0.231",
+        "@kestra-io/ui-libs": "^0.0.232",
         "@vue-flow/background": "^1.3.2",
         "@vue-flow/controls": "^1.1.2",
         "@vue-flow/core": "^1.45.0",


### PR DESCRIPTION
closes #10505

this version of ui-libs correctly compares objects and arrays in tasks