### PR TITLE
fix(flows): route to flow page

### DIFF
--- a/ui/src/components/flows/Flows.vue
+++ b/ui/src/components/flows/Flows.vue
@@ -413,7 +413,8 @@
                 file: undefined,
                 loading: false,
                 lastExecutionByFlowReady: false,
-                latestExecutions: []
+                latestExecutions: [],
+                dblClickRouteName: "flows/update"
             };
         },
         computed: {


### PR DESCRIPTION
Closes https://github.com/kestra-io/kestra-ee/issues/4562

This is done to behave similar to how route works when we click in table opened from Sidebar `Flows` Menu