### PR TITLE
feat(flows): warn on runnable only properties on non-runnable tasks

### DIFF
--- a/webserver/src/main/java/io/kestra/webserver/controllers/api/FlowController.java
+++ b/webserver/src/main/java/io/kestra/webserver/controllers/api/FlowController.java
@@ -96,9 +96,6 @@ public class FlowController {
     @Inject
     private TenantService tenantService;
 
-    @Inject
-    private JsonSchemaGenerator jsonSchemaGenerator;
-
 
     @ExecuteOn(TaskExecutors.IO)
     @Get(uri = "{namespace}/{id}/graph")


### PR DESCRIPTION
Closes #9967
Closes #10500

On the same PR, I had an improvement to the FlowValidator that compute once `flow.allTaskWithChild()` because it can be costly for big flows, and use it everywhere (which will improve things as previously some validation only use allTask so was missing for flowable child tasks).