### PR TITLE
refactor: use composition api and ts on revision component

### DIFF
--- a/ui/src/components/Drawer.vue
+++ b/ui/src/components/Drawer.vue
@@ -1,8 +1,7 @@
 <template>
     <el-drawer
         data-component="FILENAME_PLACEHOLDER"
-        :model-value="props.modelValue"
-        @update:model-value="emit('update:modelValue', $event)"
+        v-model="modelValue"
         destroy-on-close
         lock-scroll
         size=""
@@ -16,7 +15,7 @@
                 <slot name="header" />
             </span>
             <el-button link class="full-screen">
-                <Fullscreen :title="$t('toggle fullscreen')" @click="toggleFullScreen" />
+                <Fullscreen :title="t('toggle fullscreen')" @click="toggleFullScreen" />
             </el-button>
         </template>
 
@@ -30,28 +29,28 @@
     </el-drawer>
 </template>
 
-<script setup>
+<script lang="ts" setup>
     import {ref} from "vue";
+    import {useI18n} from "vue-i18n";
     import Fullscreen from "vue-material-design-icons/Fullscreen.vue"
 
+    const {t} = useI18n();
+
     const props = defineProps({
-        modelValue: {
-            type: Boolean,
-            required: true
-        },
         title: {
             type: String,
-            required: false,
             default: undefined
         },
         fullScreen: {
             type: Boolean,
-            required: false,
             default: false
         }
     });
 
-    const emit = defineEmits(["update:modelValue"])
+    const modelValue = defineModel({
+        type: Boolean,
+        required: true
+    });
 
     const fullScreen = ref(props.fullScreen);
 

--- a/ui/src/components/flows/FlowRevisions.vue
+++ b/ui/src/components/flows/FlowRevisions.vue
@@ -23,7 +23,7 @@
                         <el-button :icon="FileCode" @click="seeRevision(revisionLeftIndex, revisionLeftText)">
                             <span class="d-none d-lg-inline-block">&nbsp;{{ t('see full revision') }}</span>
                         </el-button>
-                        <el-button :icon="Restore" :disabled="revisionNumber(revisionLeftIndex) === flow.revision" @click="restoreRevision(revisionLeftIndex)">
+                        <el-button :icon="Restore" :disabled="revisionNumber(revisionLeftIndex) === flow.revision" @click="restoreRevision(revisionLeftIndex, revisionLeftText)">
                             <span class="d-none d-lg-inline-block">&nbsp;{{ t('restore') }}</span>
                         </el-button>
                     </el-button-group>
@@ -45,7 +45,7 @@
                         <el-button :icon="FileCode" @click="seeRevision(revisionRightIndex, revisionRightText)">
                             <span class="d-none d-lg-inline-block">&nbsp;{{ t('see full revision') }}</span>
                         </el-button>
-                        <el-button :icon="Restore" :disabled="revisionNumber(revisionRightIndex) === flow.revision" @click="restoreRevision(revisionRightIndex)">
+                        <el-button :icon="Restore" :disabled="revisionNumber(revisionRightIndex) === flow.revision" @click="restoreRevision(revisionRightIndex, revisionRightText)">
                             <span class="d-none d-lg-inline-block">&nbsp;{{ t('restore') }}</span>
                         </el-button>
                     </el-button-group>
@@ -105,9 +105,6 @@
     }
 
     const {t} = useI18n();
-
-    load();
-
     const store = useStore();
     const route = useRoute();
     const router = useRouter();
@@ -173,6 +170,7 @@
 
         return revisionInt - 1;
     }
+
     function revisionNumber(index: number) {
         return index + 1;
     }
@@ -184,9 +182,12 @@
         isModalOpen.value = true;
     }
 
-    function restoreRevision(index: number) {
+    function restoreRevision(index: number, revisionSource: string) {
         toast.confirm(t("restore confirm", {revision: revisionNumber(index)}), () => {
-            return saveFlowTemplate({$store: store}, revision, "flow")
+            return saveFlowTemplate({
+                $store: store,
+                $toast: () => toast,
+            }, revisionSource, "flow")
                 .then((response:any) => {
                     store.commit("flow/setFlowYaml", response.source);
                     store.commit("flow/setFlowYamlOrigin", response.source);
@@ -195,7 +196,7 @@
                 .then(() => {
                     router.push({query: {}});
                 });
-        });
+        })
     }
 
     function addQuery() {
@@ -222,6 +223,7 @@
 
         return revisionFetched;
     }
+
     function options(excludeRevisionIndex: number | undefined) {
         return revisions.value
             .filter((_, index) => index !== excludeRevisionIndex)
@@ -288,6 +290,8 @@
           },
           {deep: true}
     )
+
+    load();
 </script>
 
 <style scoped lang="scss">

--- a/ui/src/components/flows/FlowRevisions.vue
+++ b/ui/src/components/flows/FlowRevisions.vue
@@ -21,15 +21,15 @@
                     </el-select>
                     <el-button-group>
                         <el-button :icon="FileCode" @click="seeRevision(revisionLeftIndex, revisionLeftText)">
-                            <span class="d-none d-lg-inline-block">&nbsp;{{ $t('see full revision') }}</span>
+                            <span class="d-none d-lg-inline-block">&nbsp;{{ t('see full revision') }}</span>
                         </el-button>
-                        <el-button :icon="Restore" :disabled="revisionNumber(revisionLeftIndex) === flow.revision" @click="restoreRevision(revisionLeftIndex, revisionLeftText)">
-                            <span class="d-none d-lg-inline-block">&nbsp;{{ $t('restore') }}</span>
+                        <el-button :icon="Restore" :disabled="revisionNumber(revisionLeftIndex) === flow.revision" @click="restoreRevision(revisionLeftIndex)">
+                            <span class="d-none d-lg-inline-block">&nbsp;{{ t('restore') }}</span>
                         </el-button>
                     </el-button-group>
                 </div>
 
-                <crud class="mt-3" permission="FLOW" :detail="{namespace: $route.params.namespace, flowId: $route.params.id, revision: revisionNumber(revisionLeftIndex)}" />
+                <crud class="mt-3" permission="FLOW" :detail="{namespace: route.params.namespace, flowId: route.params.id, revision: revisionNumber(revisionLeftIndex)}" />
             </el-col>
             <el-col :span="12" v-if="revisionRightIndex !== undefined">
                 <div class="revision-select mb-3">
@@ -43,15 +43,15 @@
                     </el-select>
                     <el-button-group>
                         <el-button :icon="FileCode" @click="seeRevision(revisionRightIndex, revisionRightText)">
-                            <span class="d-none d-lg-inline-block">&nbsp;{{ $t('see full revision') }}</span>
+                            <span class="d-none d-lg-inline-block">&nbsp;{{ t('see full revision') }}</span>
                         </el-button>
-                        <el-button :icon="Restore" :disabled="revisionNumber(revisionRightIndex) === flow.revision" @click="restoreRevision(revisionRightIndex, revisionRightText)">
-                            <span class="d-none d-lg-inline-block">&nbsp;{{ $t('restore') }}</span>
+                        <el-button :icon="Restore" :disabled="revisionNumber(revisionRightIndex) === flow.revision" @click="restoreRevision(revisionRightIndex)">
+                            <span class="d-none d-lg-inline-block">&nbsp;{{ t('restore') }}</span>
                         </el-button>
                     </el-button-group>
                 </div>
 
-                <crud class="mt-3" permission="FLOW" :detail="{namespace: $route.params.namespace, flowId: $route.params.id, revision: revisionNumber(revisionRightIndex)}" />
+                <crud class="mt-3" permission="FLOW" :detail="{namespace: route.params.namespace, flowId: route.params.id, revision: revisionNumber(revisionRightIndex)}" />
             </el-col>
         </el-row>
 
@@ -72,7 +72,7 @@
 
         <drawer v-if="isModalOpen" v-model="isModalOpen">
             <template #header>
-                <h5>{{ $t("revision") + `: ` + revision }}</h5>
+                <h5>{{ t("revision") + `: ` + revision }}</h5>
             </template>
 
             <editor v-model="revisionYaml" lang="yaml" :full-height="false" :input="true" :navbar="false" :read-only="true" />
@@ -80,212 +80,214 @@
     </div>
     <div v-else>
         <el-alert class="mb-0" show-icon :closable="false">
-            {{ $t('no revisions found') }}
+            {{ t('no revisions found') }}
         </el-alert>
     </div>
 </template>
 
-<script setup>
+<script lang="ts" setup>
+    import {ref, computed, watch} from "vue";
+    import {useStore} from "vuex";
+    import {useI18n} from "vue-i18n";
+    import {useRoute, useRouter} from "vue-router";
     import FileCode from "vue-material-design-icons/FileCode.vue";
     import Restore from "vue-material-design-icons/Restore.vue";
-</script>
-
-<script>
-    import {mapState} from "vuex";
     import Editor from "../../components/inputs/Editor.vue";
     import Crud from "override/components/auth/Crud.vue";
     import Drawer from "../Drawer.vue";
+
     import {saveFlowTemplate} from "../../utils/flowTemplate";
+    import {useToast} from "../../utils/toast";
 
-    export default {
-        components: {Editor, Crud, Drawer},
-        created() {
-            this.load();
-        },
-        methods: {
-            load() {
-                const currentRevision = this.flow.revision;
+    interface Revision {
+        revision: number;
+        source?: string;
+    }
 
-                this.revisions = [...Array(currentRevision).keys()].map(((k, i) => {
-                    if (currentRevision === this.revisionNumber(i)) {
-                        return this.flow;
-                    }
-                    return {revision: i + 1};
-                }));
+    const {t} = useI18n();
 
-                if (this.$route.query.revisionRight) {
-                    this.revisionRightIndex = this.revisionIndex(
-                        this.$route.query.revisionRight
-                    );
-                    if (
-                        !this.$route.query.revisionLeft &&
-                        this.revisionRightIndex > 0
-                    ) {
-                        this.revisionLeftIndex = this.revisionRightIndex - 1;
-                    }
-                } else if (currentRevision > 0) {
-                    this.revisionRightIndex = currentRevision - 1;
-                }
+    load();
 
-                if (this.$route.query.revisionLeft) {
-                    this.revisionLeftIndex = this.revisionIndex(
-                        this.$route.query.revisionLeft
-                    );
-                } else if (currentRevision > 1) {
-                    this.revisionLeftIndex = currentRevision - 2;
-                }
-            },
-            revisionIndex(revision) {
-                const revisionInt = parseInt(revision);
+    const store = useStore();
+    const route = useRoute();
+    const router = useRouter();
+    const toast = useToast();
 
-                if (revisionInt < 1 || revisionInt > this.revisions.length) {
-                    return undefined;
-                }
+    const revisionLeftIndex = ref();
+    const revisionRightIndex = ref();
+    const revisionLeftText = ref();
+    const revisionRightText = ref();
+    const revision = ref();
+    const revisions = ref<(Revision)[]>([]);
+    const revisionId = ref();
+    const revisionYaml = ref();
+    const sideBySide = ref(true);
+    const isLoadingRevisions = ref(false);
+    const displayTypes = [
+        {value: true, text: t("side-by-side")},
+        {value: false, text:  t("line-by-line")},
+    ];
+    const isModalOpen = ref(false);
 
-                return revisionInt - 1;
-            },
-            revisionNumber(index) {
-                return index + 1;
-            },
-            seeRevision(index, revision) {
-                this.revisionId = index
-                this.revisionYaml = revision
-                this.revision = this.revisionNumber(index)
-                this.isModalOpen = true;
-            },
-            restoreRevision(index, revision) {
-                this.$toast()
-                    .confirm(this.$t("restore confirm", {revision: this.revisionNumber(index)}), () => {
-                        return saveFlowTemplate(this, revision, "flow")
-                            .then(response => {
-                                this.$store.commit("flow/setFlowYaml", response.source);
-                                this.$store.commit("flow/setFlowYamlOrigin", response.source);
-                                this.load()
-                            })
-                            .then(() => {
-                                this.$router.push({query: {}});
-                            });
-                    });
-            },
-            addQuery() {
-                if (this.isLoadingRevisions) {
-                    return;
-                }
-                
-                this.$router.push({query: {
-                    ...this.$route.query,
-                    ...{revisionLeft: this.revisionLeftIndex + 1, revisionRight: this.revisionRightIndex + 1}
-                }});
-            },
-            async fetchRevision(revision) {
-                const revisionFetched = await this.$store.dispatch("flow/loadFlow", {
-                    namespace: this.flow.namespace,
-                    id: this.flow.id,
-                    revision,
-                    allowDeleted: true,
-                    store: false
+    const flow = computed(() => store.state.flow.flow);
+
+    function load() {
+        const currentRevision = flow.value.revision;
+
+        revisions.value = [...Array(currentRevision).keys()].map(((k, i) => {
+            if (currentRevision === revisionNumber(i)) {
+                return flow.value;
+            }
+            return {revision: i + 1};
+        }));
+
+        if (route.query.revisionRight) {
+            revisionRightIndex.value = revisionIndex(
+                route.query.revisionRight.toString()
+            );
+            if (
+                !route.query.revisionLeft &&
+                revisionRightIndex.value > 0
+            ) {
+                revisionLeftIndex.value = revisionRightIndex.value - 1;
+            }
+        } else if (currentRevision > 0) {
+            revisionRightIndex.value = currentRevision - 1;
+        }
+
+        if (route.query.revisionLeft) {
+            revisionLeftIndex.value = revisionIndex(
+                route.query.revisionLeft.toString()
+            );
+        } else if (currentRevision > 1) {
+            revisionLeftIndex.value = currentRevision - 2;
+        }
+    }
+
+    function revisionIndex(revision: string) {
+        const revisionInt = parseInt(revision);
+
+        if (revisionInt < 1 || revisionInt > revisions.value?.length) {
+            return -1;
+        }
+
+        return revisionInt - 1;
+    }
+    function revisionNumber(index: number) {
+        return index + 1;
+    }
+
+    function seeRevision(index: number, revisionParam: Revision) {
+        revisionId.value = index
+        revisionYaml.value = revisionParam
+        revision.value = revisionNumber(index)
+        isModalOpen.value = true;
+    }
+
+    function restoreRevision(index: number) {
+        toast.confirm(t("restore confirm", {revision: revisionNumber(index)}), () => {
+            return saveFlowTemplate({$store: store}, revision, "flow")
+                .then((response:any) => {
+                    store.commit("flow/setFlowYaml", response.source);
+                    store.commit("flow/setFlowYamlOrigin", response.source);
+                    load()
+                })
+                .then(() => {
+                    router.push({query: {}});
                 });
-                this.revisions[this.revisionIndex(revision)] = revisionFetched;
+        });
+    }
 
-                return revisionFetched;
-            },
-            options(excludeRevisionIndex) {
-                return this.revisions
-                    .filter((_, index) => index !== excludeRevisionIndex)
-                    .map(({revision}) => ({value: this.revisionIndex(revision), text: revision}));
-            },
-            async loadRevisionContent(index, side) {
-                if (index === undefined) {
-                    if (side === "left") {
-                        this.revisionLeftText = undefined;
-                    } else {
-                        this.revisionRightText = undefined;
-                    }
-                    return;
-                }
+    function addQuery() {
+        if (isLoadingRevisions.value) {
+            return;
+        }
 
-                const revision = this.revisions[index];
-                let source = revision.source;
-                
-                if (!source) {
-                    source = (await this.fetchRevision(revision.revision)).source;
-                }
+        router.push({query: {
+            ...route.query,
+            revisionLeft: revisionLeftIndex.value + 1,
+            revisionRight: revisionRightIndex.value + 1
+        }});
+    }
 
-                if (side === "left") {
-                    this.revisionLeftText = source;
-                } else {
-                    this.revisionRightText = source;
-                }
+    async function fetchRevision(revision: string) {
+        const revisionFetched = await store.dispatch("flow/loadFlow", {
+            namespace: flow.value.namespace,
+            id: flow.value.id,
+            revision,
+            allowDeleted: true,
+            store: false
+        });
+        revisions.value[revisionIndex(revision)] = revisionFetched;
+
+        return revisionFetched;
+    }
+    function options(excludeRevisionIndex: number | undefined) {
+        return revisions.value
+            .filter((_, index) => index !== excludeRevisionIndex)
+            .map(({revision}) => ({value: revisionIndex(revision.toString()), text: revision}));
+    }
+
+    async function loadRevisionContent(index: number | undefined, side: "left" | "right") {
+        if (index === undefined) {
+            if (side === "left") {
+                revisionLeftText.value = undefined;
+            } else {
+                revisionRightText.value = undefined;
             }
-        },
-        computed: {
-            ...mapState("flow", ["flow"])
-        },
-        watch: {
-            "$route.query": {
-                handler(newQuery, oldQuery) {
-                    if (newQuery.revisionLeft !== oldQuery.revisionLeft && newQuery.revisionLeft) {
-                        const newLeftIndex = this.revisionIndex(parseInt(newQuery.revisionLeft));
-                        if (newLeftIndex !== this.revisionLeftIndex) {
-                            this.revisionLeftIndex = newLeftIndex;
-                        }
-                    }
-                    
-                    if (newQuery.revisionRight !== oldQuery.revisionRight && newQuery.revisionRight) {
-                        const newRightIndex = this.revisionIndex(parseInt(newQuery.revisionRight));
-                        if (newRightIndex !== this.revisionRightIndex) {
-                            this.revisionRightIndex = newRightIndex;
-                        }
-                    }
-                },
-                deep: true
-            },
-            
-            revisionLeftIndex: async function (newValue, oldValue) {
-                if (newValue === oldValue) {
-                    return;
-                }
+            return;
+        }
 
-                this.isLoadingRevisions = true;
-                try {
-                    await this.loadRevisionContent(newValue, "left");
-                } finally {
-                    this.isLoadingRevisions = false;
-                }
-            },
-            revisionRightIndex: async function (newValue, oldValue) {
-                if (newValue === oldValue) {
-                    return;
-                }
+        const revisionObject = revisions.value[index];
+        let source = revisionObject.source;
 
-                this.isLoadingRevisions = true;
-                try {
-                    await this.loadRevisionContent(newValue, "right");
-                } finally {
-                    this.isLoadingRevisions = false;
-                }
-            }
-        },
-        data() {
-            return {
-                revisionLeftIndex: undefined,
-                revisionRightIndex: undefined,
-                revisionLeftText: undefined,
-                revisionRightText: undefined,
-                revision: undefined,
-                revisions: [],
-                revisionId: undefined,
-                revisionYaml: undefined,
-                sideBySide: true,
-                isLoadingRevisions: false,
-                displayTypes: [
-                    {value: true, text: this.$t("side-by-side")},
-                    {value: false, text:  this.$t("line-by-line")},
-                ],
-                isModalOpen: false
-            };
-        },
-    };
+        if (!source) {
+            source = (await fetchRevision(revisionObject.revision.toString())).source;
+        }
+
+        if (side === "left") {
+            revisionLeftText.value = source;
+        } else {
+            revisionRightText.value = source;
+        }
+    }
+
+    watch(revisionLeftIndex, async (newValue) => {
+        isLoadingRevisions.value = true;
+        try {
+            await loadRevisionContent(newValue, "left");
+        } finally {
+            isLoadingRevisions.value = false;
+        }
+    });
+
+    watch(revisionRightIndex, async (newValue) => {
+        isLoadingRevisions.value = true;
+        try {
+            await loadRevisionContent(newValue, "right");
+        } finally {
+            isLoadingRevisions.value = false;
+        }
+    });
+
+    watch(() => route.query,
+          (newQuery, oldQuery) => {
+              if (newQuery.revisionLeft !== oldQuery.revisionLeft && newQuery.revisionLeft) {
+                  const newLeftIndex = revisionIndex(newQuery.revisionLeft.toString());
+                  if (newLeftIndex !== revisionLeftIndex.value) {
+                      revisionLeftIndex.value = newLeftIndex;
+                  }
+              }
+
+              if (newQuery.revisionRight !== oldQuery.revisionRight && newQuery.revisionRight) {
+                  const newRightIndex = revisionIndex(newQuery.revisionRight.toString());
+                  if (newRightIndex !== revisionRightIndex.value) {
+                      revisionRightIndex.value = newRightIndex;
+                  }
+              }
+          },
+          {deep: true}
+    )
 </script>
 
 <style scoped lang="scss">

--- a/ui/src/components/flows/FlowRevisions.vue
+++ b/ui/src/components/flows/FlowRevisions.vue
@@ -136,6 +136,10 @@
                 return flow.value;
             }
 
+            if(revisions.value[i] && revisions.value[i].revision === i + 1) {
+                return revisions.value[i];
+            }
+
             return {revision: i + 1};
         }));
 

--- a/ui/src/components/flows/FlowRevisions.vue
+++ b/ui/src/components/flows/FlowRevisions.vue
@@ -135,6 +135,7 @@
             if (currentRevision === revisionNumber(i)) {
                 return flow.value;
             }
+
             return {revision: i + 1};
         }));
 
@@ -230,14 +231,9 @@
             .map(({revision}) => ({value: revisionIndex(revision.toString()), text: revision}));
     }
 
-    async function loadRevisionContent(index: number | undefined, side: "left" | "right") {
+    async function loadRevisionContent(index: number | undefined) {
         if (index === undefined) {
-            if (side === "left") {
-                revisionLeftText.value = undefined;
-            } else {
-                revisionRightText.value = undefined;
-            }
-            return;
+            return undefined;
         }
 
         const revisionObject = revisions.value[index];
@@ -247,17 +243,13 @@
             source = (await fetchRevision(revisionObject.revision.toString())).source;
         }
 
-        if (side === "left") {
-            revisionLeftText.value = source;
-        } else {
-            revisionRightText.value = source;
-        }
+        return source;
     }
 
     watch(revisionLeftIndex, async (newValue) => {
         isLoadingRevisions.value = true;
         try {
-            await loadRevisionContent(newValue, "left");
+            revisionLeftText.value = await loadRevisionContent(newValue);
         } finally {
             isLoadingRevisions.value = false;
         }
@@ -266,7 +258,7 @@
     watch(revisionRightIndex, async (newValue) => {
         isLoadingRevisions.value = true;
         try {
-            await loadRevisionContent(newValue, "right");
+            revisionRightText.value = await loadRevisionContent(newValue);
         } finally {
             isLoadingRevisions.value = false;
         }

--- a/ui/src/components/flows/FlowRevisions.vue
+++ b/ui/src/components/flows/FlowRevisions.vue
@@ -131,7 +131,7 @@
     function load() {
         const currentRevision = flow.value.revision;
 
-        revisions.value = [...Array(currentRevision).keys()].map(((k, i) => {
+        revisions.value = [...Array(currentRevision).keys()].map(((_, i) => {
             if (currentRevision === revisionNumber(i)) {
                 return flow.value;
             }

--- a/ui/src/override/components/auth/Crud.vue
+++ b/ui/src/override/components/auth/Crud.vue
@@ -1,21 +1,19 @@
 <template>
     <span />
 </template>
-<script>
-    export default {
-        props: {
-            permission: {
-                type: String,
-                required: true
-            },
-            type: {
-                type: String,
-                default: undefined
-            },
-            detail: {
-                type: Object,
-                required: true
-            },
-        }
-    };
+<script lang="ts" setup>
+    defineProps({
+        permission: {
+            type: String,
+            required: true
+        },
+        type: {
+            type: String,
+            default: undefined
+        },
+        detail: {
+            type: Object,
+            required: true
+        },
+    });
 </script>

--- a/ui/src/routes/routes.js
+++ b/ui/src/routes/routes.js
@@ -92,7 +92,7 @@ export default [
     {name: "login", path: "/:tenant?/login", component: () => import("../components/basicauth/BasicAuthLogin.vue"), meta: {layout: FullScreenLayout}},
 
     //Errors
-    {name: "errors/404-wildcard", path: "/:pathMatch(.*)", component: Errors, props: {code: 404}},
+    {name: "errors/404-wildcard", path: "/:tenant?/:pathMatch(.*)", component: Errors, props: {code: 404}},
 
     //Demo Pages
     {name: "apps/list", path: "/:tenant?/apps", component: DemoApps},

--- a/ui/src/utils/flowTemplate.ts
+++ b/ui/src/utils/flowTemplate.ts
@@ -1,12 +1,12 @@
 import action from "../models/action";
 import permission from "../models/permission";
 
-export function canSaveFlowTemplate(isEdit, user, item, dataType) {
+export function canSaveFlowTemplate(isEdit: boolean, user: any, item: any, dataType: string) {
     if (item === undefined) {
         return  true;
     }
 
-    const typedPermission = permission[dataType.toUpperCase()]
+    const typedPermission = permission[dataType.toUpperCase() as keyof typeof permission]
 
     return (
         isEdit && user &&
@@ -17,10 +17,13 @@ export function canSaveFlowTemplate(isEdit, user, item, dataType) {
     );
 }
 
-export function saveFlowTemplate(self, file, dataType) {
+export function saveFlowTemplate(self: {
+    $store: any,
+    $toast: () => any,
+}, file: string, dataType: string) {
     return self.$store
         .dispatch(`${dataType}/save${dataType.capitalize()}`, {[dataType]: file})
-        .then((response) => {
+        .then((response: { id: string }) => {
             self.$toast().saved(response.id);
 
             return response

--- a/ui/src/utils/toast.ts
+++ b/ui/src/utils/toast.ts
@@ -30,9 +30,12 @@ const makeToast = (t: (t:string, options?: Record<string, string>) => string) =>
         return h(Markdown, {source: message})
     },
     confirm: function(message:string, callback: () => Promise<any>, type = "warning" as const, showCancelButton = true) {
-        ElMessageBox
+        return ElMessageBox
             .confirm(typeof message === "string" ? this._MarkdownWrap(message || t("toast confirm")) : h(message), t("confirmation"), {type, showCancelButton})
             .then(() => callback())
+            .catch(() => {
+                // User cancelled
+            });
     },
     saved: function(name:string, title?:string, options?: Record<string, any>) {
         ElNotification.closeAll();


### PR DESCRIPTION
closes #10450

also 
- remove promise warning when cancelling a toast
- avoid redirection loop when going from dev ee to dev oss