### PR TITLE
Output drawer fix

### DIFF
--- a/ui/src/components/executions/outputs/Wrapper.vue
+++ b/ui/src/components/executions/outputs/Wrapper.vue
@@ -491,40 +491,6 @@
         background: var(--ks-background-card);
     }
 
-    .content-container {
-        height: calc(100vh - 0px);
-        overflow-y: auto !important;
-        overflow-x: hidden;
-        word-wrap: break-word;
-        word-break: break-word;
-    }
-
-    :deep(.el-collapse) {
-        .el-collapse-item__wrap {
-            overflow-y: auto !important;
-            max-height: none !important;
-        }
-        
-        .el-collapse-item__content {
-            overflow-y: auto !important;
-            word-wrap: break-word;
-            word-break: break-word;
-        }
-    }
-
-    :deep(.var-value) {
-        overflow-y: auto !important;
-        word-wrap: break-word;
-        word-break: break-word;
-    }
-
-    :deep(pre) {
-        white-space: pre-wrap !important;
-        word-wrap: break-word !important;
-        word-break: break-word !important;
-        overflow-wrap: break-word !important;
-    }
-
     .el-cascader-menu {
         min-width: 300px;
         max-width: 300px;
@@ -573,4 +539,39 @@
         }
     }
 }
+</style>
+<style lang="scss" scoped>
+    .content-container {
+        height: calc(100vh - 0px);
+        overflow-y: auto !important;
+        overflow-x: hidden;
+        word-wrap: break-word;
+        word-break: break-word;
+    }
+
+    :deep(.el-collapse) {
+        .el-collapse-item__wrap {
+            overflow-y: auto !important;
+            max-height: none !important;
+        }
+        
+        .el-collapse-item__content {
+            overflow-y: auto !important;
+            word-wrap: break-word;
+            word-break: break-word;
+        }
+    }
+
+    :deep(.var-value) {
+        overflow-y: auto !important;
+        word-wrap: break-word;
+        word-break: break-word;
+    }
+
+    :deep(pre) {
+        white-space: pre-wrap !important;
+        word-wrap: break-word !important;
+        word-break: break-word !important;
+        overflow-wrap: break-word !important;
+    }
 </style>

--- a/ui/src/components/executions/outputs/Wrapper.vue
+++ b/ui/src/components/executions/outputs/Wrapper.vue
@@ -189,6 +189,8 @@
         if (!task) return "";
 
         let path = expandedValue.value;
+        if (!path) return `{{ outputs${formatTask(task)} }}`;
+
         return `{{ outputs${formatPath(path)} }}`;
     });
 

--- a/ui/src/components/executions/outputs/Wrapper.vue
+++ b/ui/src/components/executions/outputs/Wrapper.vue
@@ -55,7 +55,7 @@
         <div class="right wrapper" :style="{width: 100 - leftWidth + '%', 'z-index': 999}">
             <div
                 v-if="multipleSelected || selectedValue"
-                class="w-100 overflow-auto p-3"
+                class="w-100 overflow-auto p-3 content-container"
             >
                 <div class="d-flex justify-content-between pe-none fs-5 values">
                     <code class="d-block">
@@ -189,8 +189,6 @@
         if (!task) return "";
 
         let path = expandedValue.value;
-        if (!path) return `{{ outputs${formatTask(task)} }}`;
-
         return `{{ outputs${formatPath(path)} }}`;
     });
 
@@ -463,6 +461,7 @@
     display: flex;
     width: 100%;
     height: 100vh;
+    overflow: hidden;
 
     .el-scrollbar.el-cascader-menu:nth-of-type(-n + 2) ul li:first-child,
     .values {
@@ -488,6 +487,40 @@
 
     .wrapper {
         background: var(--ks-background-card);
+    }
+
+    .content-container {
+        height: calc(100vh - 0px);
+        overflow-y: auto !important;
+        overflow-x: hidden;
+        word-wrap: break-word;
+        word-break: break-word;
+    }
+
+    :deep(.el-collapse) {
+        .el-collapse-item__wrap {
+            overflow-y: auto !important;
+            max-height: none !important;
+        }
+        
+        .el-collapse-item__content {
+            overflow-y: auto !important;
+            word-wrap: break-word;
+            word-break: break-word;
+        }
+    }
+
+    :deep(.var-value) {
+        overflow-y: auto !important;
+        word-wrap: break-word;
+        word-break: break-word;
+    }
+
+    :deep(pre) {
+        white-space: pre-wrap !important;
+        word-wrap: break-word !important;
+        word-break: break-word !important;
+        overflow-wrap: break-word !important;
     }
 
     .el-cascader-menu {

--- a/ui/src/components/flows/Flows.vue
+++ b/ui/src/components/flows/Flows.vue
@@ -772,6 +772,7 @@
             },
             mappedChart(id, namespace) {
                 let MAPPED_CHARTS = JSON.parse(JSON.stringify(CHART_DEFINITION));
+                
                 MAPPED_CHARTS.content = MAPPED_CHARTS.content.replace("${namespace}", namespace).replace("${flow_id}", id);
 
                 return MAPPED_CHARTS;

--- a/ui/src/components/flows/Flows.vue
+++ b/ui/src/components/flows/Flows.vue
@@ -772,7 +772,6 @@
             },
             mappedChart(id, namespace) {
                 let MAPPED_CHARTS = JSON.parse(JSON.stringify(CHART_DEFINITION));
-
                 MAPPED_CHARTS.content = MAPPED_CHARTS.content.replace("${namespace}", namespace).replace("${flow_id}", id);
 
                 return MAPPED_CHARTS;

--- a/ui/src/components/flows/Flows.vue
+++ b/ui/src/components/flows/Flows.vue
@@ -772,7 +772,7 @@
             },
             mappedChart(id, namespace) {
                 let MAPPED_CHARTS = JSON.parse(JSON.stringify(CHART_DEFINITION));
-                
+
                 MAPPED_CHARTS.content = MAPPED_CHARTS.content.replace("${namespace}", namespace).replace("${flow_id}", id);
 
                 return MAPPED_CHARTS;


### PR DESCRIPTION
closes #10532
Fixed drawer content overflow issue in the executions output panel where long content would extend outside the container instead of being scrollable.

Changes made:
Added proper word-wrapping for long text content
Ensured content containers have proper height constraints
This resolves the issue where users couldn't scroll through large outputs in the execution drawer, improving the user experience when viewing execution results.

