### PR TITLE
feat(system): set the default number of worker threads to 8x availabl…

### DIFF
--- a/cli/src/main/java/io/kestra/cli/commands/servers/AbstractServerCommand.java
+++ b/cli/src/main/java/io/kestra/cli/commands/servers/AbstractServerCommand.java
@@ -16,6 +16,6 @@ abstract public class AbstractServerCommand extends AbstractCommand implements S
     }
 
     protected static int defaultWorkerThread() {
-        return Runtime.getRuntime().availableProcessors() * 4;
+        return Runtime.getRuntime().availableProcessors() * 8;
     }
 }

--- a/cli/src/main/java/io/kestra/cli/commands/servers/StandAloneCommand.java
+++ b/cli/src/main/java/io/kestra/cli/commands/servers/StandAloneCommand.java
@@ -48,7 +48,7 @@ public class StandAloneCommand extends AbstractServerCommand {
     @CommandLine.Option(names = "--tenant", description = "Tenant identifier, Required to load flows from path with the enterprise edition")
     private String tenantId;
 
-    @CommandLine.Option(names = {"--worker-thread"}, description = "the number of worker threads, defaults to four times the number of available processors. Set it to 0 to avoid starting a worker.")
+    @CommandLine.Option(names = {"--worker-thread"}, description = "the number of worker threads, defaults to eight times the number of available processors. Set it to 0 to avoid starting a worker.")
     private int workerThread = defaultWorkerThread();
 
     @CommandLine.Option(names = {"--skip-executions"}, split=",", description = "a list of execution identifiers to skip, separated by a coma; for troubleshooting purpose only")

--- a/cli/src/main/java/io/kestra/cli/commands/servers/WorkerCommand.java
+++ b/cli/src/main/java/io/kestra/cli/commands/servers/WorkerCommand.java
@@ -22,7 +22,7 @@ public class WorkerCommand extends AbstractServerCommand {
     @Inject
     private ApplicationContext applicationContext;
 
-    @Option(names = {"-t", "--thread"}, description = "The max number of worker threads, defaults to four times the number of available processors")
+    @Option(names = {"-t", "--thread"}, description = "The max number of worker threads, defaults to eight times the number of available processors")
     private int thread = defaultWorkerThread();
 
     @Option(names = {"-g", "--worker-group"}, description = "The worker group key, must match the regex [a-zA-Z0-9_-]+ (EE only)")


### PR DESCRIPTION
…e cpu cores

This is a better default for mixed workloads and provides better tail latency.
This is also what we advise to our customer.

## Performance - BEFORE

Strandard flow with 2 quick tasks
1000 exec/s => 284ms
1500 exec/s => 279ms
2000 exec/s => 307ms
2500 exec/s => 1.5s
3000 exec/s => 30s

A flow with only a Sleep task with a sleep of 5s
500 exec/s => 5.1s
1000 exec/s => 13s


## Performance - AFTER

Strandard flow with 2 quick tasks
1000 exec/s => 246ms
1500 exec/s => 265ms
2000 exec/s => 336ms
2500 exec/s => 635ms
3000 exec/s => 13s

**Tail latency is nicely improved (x2)**

A flow with only a Sleep task with a sleep of 5s
500 exec/s => 5.1s
1000 exec/s => 5.1s
1500 exec/s => 5.1s
2000 exec/s => 13s

**We can sustain up to 2000 exec/s whereas with the previous config no more than 1000 exec/s**