### PR TITLE
fix(core): update necessary node viewer in gradle build

### DIFF
--- a/ui/build.gradle
+++ b/ui/build.gradle
@@ -4,7 +4,7 @@ plugins {
 
 node {
     download = true
-    version = '22.11.0'
+    version = '22.12.0'
 }
 
 tasks.register('assembleFrontend', NpmTask) {


### PR DESCRIPTION
```
npm warn EBADENGINE Unsupported engine {
npm warn EBADENGINE   package: '@vitejs/plugin-vue@6.0.1',
npm warn EBADENGINE   required: { node: '^20.19.0 || >=22.12.0' },
npm warn EBADENGINE   current: { node: 'v22.11.0', npm: '10.9.0' }
npm warn EBADENGINE }
npm warn EBADENGINE Unsupported engine {
npm warn EBADENGINE   package: '@vitejs/plugin-vue-jsx@5.0.1',
npm warn EBADENGINE   required: { node: '^20.19.0 || >=22.12.0' },
npm warn EBADENGINE   current: { node: 'v22.11.0', npm: '10.9.0' }
npm warn EBADENGINE }
```