### PR TITLE
fix(executions): allow caching tasks that use the 'workingDir' variable

### DIFF
--- a/core/src/main/java/io/kestra/core/runners/Worker.java
+++ b/core/src/main/java/io/kestra/core/runners/Worker.java
@@ -818,7 +818,11 @@ public class Worker implements Service, Runnable, AutoCloseable {
     private Optional<String> hashTask(RunContext runContext, Task task) {
         try {
             var map = JacksonMapper.toMap(task);
-            var rMap = runContext.render(map);
+            // If there are task provided variables, rendering the task may fail.
+            // The best we can do is to add a fake 'workingDir' as it's an often added variables,
+            // and it should not be part of the task hash.
+            Map<String, Object> variables = Map.of("workingDir", "workingDir");
+            var rMap = runContext.render(map, variables);
             var json = JacksonMapper.ofJson().writeValueAsBytes(rMap);
             MessageDigest digest = MessageDigest.getInstance("SHA-256");
             digest.update(json);

--- a/core/src/test/java/io/kestra/core/runners/TaskCacheTest.java
+++ b/core/src/test/java/io/kestra/core/runners/TaskCacheTest.java
@@ -5,6 +5,7 @@ import io.kestra.core.junit.annotations.LoadFlows;
 import io.kestra.core.models.annotations.Plugin;
 import io.kestra.core.models.executions.Execution;
 import io.kestra.core.models.flows.State;
+import io.kestra.core.models.property.Property;
 import io.kestra.core.models.tasks.RunnableTask;
 import io.kestra.core.models.tasks.Task;
 import io.kestra.core.queues.QueueException;
@@ -18,6 +19,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
+import java.util.Map;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -77,8 +79,12 @@ public class TaskCacheTest {
     @Plugin
     public static class CounterTask extends Task implements RunnableTask<CounterTask.Output> {
 
+        private String workingDir;
+
         @Override
         public Output run(RunContext runContext) throws Exception {
+            Map<String, Object> variables = Map.of("workingDir", runContext.workingDir().path().toString());
+            runContext.render(this.workingDir, variables);
             return Output.builder()
                 .counter(COUNTER.incrementAndGet())
                 .build();

--- a/core/src/test/resources/flows/valids/cache.yaml
+++ b/core/src/test/resources/flows/valids/cache.yaml
@@ -4,6 +4,7 @@ namespace: io.kestra.tests
 tasks:
   - id: cache
     type: io.kestra.core.runners.TaskCacheTest$CounterTask
+    workingDir: "{{workingDir}}"
     taskCache:
       enabled: true
       ttl: PT1S


### PR DESCRIPTION
Fixes #10253
