### PR TITLE
tests(core): add a test to taskrunners to ensure it's working multiple times on the same working directory

### DIFF
--- a/tests/src/main/java/io/kestra/core/models/tasks/runners/AbstractTaskRunnerTest.java
+++ b/tests/src/main/java/io/kestra/core/models/tasks/runners/AbstractTaskRunnerTest.java
@@ -38,6 +38,10 @@ public abstract class AbstractTaskRunnerTest {
     @Test
     protected void run() throws Exception {
         var runContext = runContext(this.runContextFactory);
+        simpleRun(runContext);
+    }
+
+    private void simpleRun(RunContext runContext) throws Exception {
         var commands = initScriptCommands(runContext);
         Mockito.when(commands.getCommands()).thenReturn(
             Property.ofValue(ScriptService.scriptCommands(List.of("/bin/sh", "-c"), Collections.emptyList(), List.of("echo 'Hello World'")))
@@ -164,6 +168,13 @@ public abstract class AbstractTaskRunnerTest {
         var taskRunner = taskRunner();
         TaskException taskException = assertThrows(TaskException.class, () -> taskRunner.run(runContext, commands, Collections.emptyList()));
         assertThat(taskException.getLogConsumer().getOutputs().get("logOutput")).isEqualTo("Hello World");
+    }
+
+    @Test
+    protected void canWorkMultipleTimeInSameWdir() throws Exception {
+        var runContext = runContext(this.runContextFactory);
+        simpleRun(runContext);
+        simpleRun(runContext);
     }
 
     protected RunContext runContext(RunContextFactory runContextFactory) {


### PR DESCRIPTION
part of kestra-io/plugin-ee-kubernetes#45
