### PR TITLE
fix(executions): concurrency limit exceeded when restarting an execution

### DIFF
--- a/core/src/main/java/io/kestra/core/models/flows/State.java
+++ b/core/src/main/java/io/kestra/core/models/flows/State.java
@@ -116,7 +116,7 @@ public class State {
     }
 
     public Instant maxDate() {
-        if (this.histories.size() == 0) {
+        if (this.histories.isEmpty()) {
             return Instant.now();
         }
 
@@ -124,7 +124,7 @@ public class State {
     }
 
     public Instant minDate() {
-        if (this.histories.size() == 0) {
+        if (this.histories.isEmpty()) {
             return Instant.now();
         }
 
@@ -174,6 +174,11 @@ public class State {
     }
 
     @JsonIgnore
+    public boolean isQueued() {
+        return this.current.isQueued();
+    }
+
+    @JsonIgnore
     public boolean isRetrying() {
         return this.current.isRetrying();
     }
@@ -204,6 +209,14 @@ public class State {
             return false;
         }
         return this.histories.get(this.histories.size() - 2).state.isPaused();
+    }
+
+    /**
+     * Return true if the execution has failed, then was restarted.
+     * This is to disambiguate between a RESTARTED after PAUSED and RESTARTED after FAILED state.
+     */
+    public boolean failedThenRestarted() {
+       return this.current ==  Type.RESTARTED && this.histories.get(this.histories.size() - 2).state.isFailed();
     }
 
     @Introspected
@@ -262,6 +275,10 @@ public class State {
 
         public boolean isKilled(){
             return this == Type.KILLED;
+        }
+
+        public boolean isQueued(){
+            return this == Type.QUEUED;
         }
 
         /**

--- a/core/src/main/java/io/kestra/core/runners/Executor.java
+++ b/core/src/main/java/io/kestra/core/runners/Executor.java
@@ -86,7 +86,7 @@ public class Executor {
 
     public Boolean canBeProcessed() {
         return !(this.getException() != null || this.getFlow() == null || this.getFlow() instanceof FlowWithException || this.getFlow().getTasks() == null ||
-            this.getExecution().isDeleted() || this.getExecution().getState().isPaused() || this.getExecution().getState().isBreakpoint());
+            this.getExecution().isDeleted() || this.getExecution().getState().isPaused() || this.getExecution().getState().isBreakpoint() || this.getExecution().getState().isQueued());
     }
 
     public Executor withFlow(FlowWithSource flow) {

--- a/core/src/test/java/io/kestra/core/runners/AbstractRunnerTest.java
+++ b/core/src/test/java/io/kestra/core/runners/AbstractRunnerTest.java
@@ -424,6 +424,12 @@ public abstract class AbstractRunnerTest {
     }
 
     @Test
+    @LoadFlows({"flows/valids/flow-concurrency-queue-fail.yml"})
+    void concurrencyQueueRestarted() throws Exception {
+        flowConcurrencyCaseTest.flowConcurrencyQueueRestarted();
+    }
+
+    @Test
     @ExecuteFlow("flows/valids/executable-fail.yml")
     void badExecutable(Execution execution) {
         assertThat(execution.getTaskRunList().size()).isEqualTo(1);

--- a/core/src/test/resources/flows/valids/flow-concurrency-queue-fail.yml
+++ b/core/src/test/resources/flows/valids/flow-concurrency-queue-fail.yml
@@ -1,0 +1,13 @@
+id: flow-concurrency-queue-fail
+namespace: io.kestra.tests
+
+concurrency:
+  behavior: QUEUE
+  limit: 1
+
+tasks:
+  - id: sleep
+    type: io.kestra.plugin.core.flow.Sleep
+    duration: PT2S
+  - id: fail
+    type: io.kestra.plugin.core.execution.Fail

--- a/jdbc/src/main/java/io/kestra/jdbc/runner/AbstractJdbcExecutionRunningStorage.java
+++ b/jdbc/src/main/java/io/kestra/jdbc/runner/AbstractJdbcExecutionRunningStorage.java
@@ -20,6 +20,12 @@ public class AbstractJdbcExecutionRunningStorage extends AbstractJdbcRepository 
         this.jdbcRepository = jdbcRepository;
     }
 
+    public void save(ExecutionRunning executionRunning) {
+        jdbcRepository.getDslContextWrapper().transaction(
+            configuration -> save(DSL.using(configuration), executionRunning)
+        );
+    }
+
     public void save(DSLContext dslContext, ExecutionRunning executionRunning) {
         Map<Field<Object>, Object> fields = this.jdbcRepository.persistFields(executionRunning);
         this.jdbcRepository.persist(executionRunning, dslContext, fields);

--- a/jdbc/src/main/java/io/kestra/jdbc/runner/JdbcExecutor.java
+++ b/jdbc/src/main/java/io/kestra/jdbc/runner/JdbcExecutor.java
@@ -546,7 +546,7 @@ public class JdbcExecutor implements ExecutorInterface, Service {
                         }
 
                         // create an SLA monitor if needed
-                        if (execution.getState().getCurrent() == State.Type.CREATED && !ListUtils.isEmpty(flow.getSla())) {
+                        if ((execution.getState().getCurrent() == State.Type.CREATED || execution.getState().failedThenRestarted()) && !ListUtils.isEmpty(flow.getSla())) {
                             List<SLAMonitor> monitors = flow.getSla().stream()
                                 .filter(ExecutionMonitoringSLA.class::isInstance)
                                 .map(ExecutionMonitoringSLA.class::cast)


### PR DESCRIPTION
Fixes #7880

I created a method in the State to know when an execution has been restarted from a failure to disambiguate between restarted from the UI/API and restarted from a PAUSE.
This is unfortunate that both uses the same RESTARTED state.