### PR TITLE
fix(executions): correctly fail the request when trying to resume an …

### DIFF
--- a/webserver/src/main/java/io/kestra/webserver/controllers/api/ExecutionController.java
+++ b/webserver/src/main/java/io/kestra/webserver/controllers/api/ExecutionController.java
@@ -1383,16 +1383,14 @@ public class ExecutionController {
         Pause.Resumed resumed = createResumed();
 
         return this.executionService.resume(execution, flow, State.Type.RUNNING, inputs, resumed)
-            .<HttpResponse<?>>handle((resumeExecution, sink) -> {
+            .handle((resumeExecution, sink) -> {
                 try {
                     this.executionQueue.emit(resumeExecution);
                     sink.next(HttpResponse.noContent());
                 } catch (QueueException e) {
                     sink.error(e);
                 }
-            })
-            // need to consume the inputs in case of error
-            .doOnError(t -> Flux.from(inputs).subscribeOn(Schedulers.boundedElastic()).blockLast());
+            });
     }
 
     protected Pause.Resumed createResumed() {


### PR DESCRIPTION
…execution with the wrong inputs

Fixes #9959
