### PR TITLE
fix(execution): concurrency limit didn't work with afterExecutions

### DIFF
--- a/core/src/test/java/io/kestra/core/runners/AbstractRunnerTest.java
+++ b/core/src/test/java/io/kestra/core/runners/AbstractRunnerTest.java
@@ -388,6 +388,13 @@ public abstract class AbstractRunnerTest {
     }
 
     @Test
+    @LoadFlows({"flows/valids/for-each-item-subflow-after-execution.yaml",
+        "flows/valids/for-each-item-after-execution.yaml"})
+    protected void forEachItemWithAfterExecution() throws Exception {
+        forEachItemCaseTest.forEachItemWithAfterExecution();
+    }
+
+    @Test
     @LoadFlows({"flows/valids/flow-concurrency-cancel.yml"})
     void concurrencyCancel() throws Exception {
         flowConcurrencyCaseTest.flowConcurrencyCancel();
@@ -427,6 +434,12 @@ public abstract class AbstractRunnerTest {
     @LoadFlows({"flows/valids/flow-concurrency-queue-fail.yml"})
     void concurrencyQueueRestarted() throws Exception {
         flowConcurrencyCaseTest.flowConcurrencyQueueRestarted();
+    }
+
+    @Test
+    @LoadFlows({"flows/valids/flow-concurrency-queue-after-execution.yml"})
+    void concurrencyQueueAfterExecution() throws Exception {
+        flowConcurrencyCaseTest.flowConcurrencyQueueAfterExecution();
     }
 
     @Test

--- a/core/src/test/resources/flows/valids/flow-concurrency-queue-after-execution.yml
+++ b/core/src/test/resources/flows/valids/flow-concurrency-queue-after-execution.yml
@@ -1,0 +1,17 @@
+id: flow-concurrency-queue-after-execution
+namespace: io.kestra.tests
+
+concurrency:
+  behavior: QUEUE
+  limit: 1
+
+tasks:
+  - id: sleep
+    type: io.kestra.plugin.core.flow.Sleep
+    duration: PT2S
+
+afterExecution:
+  - id: afterExecution
+    type: io.kestra.plugin.core.output.OutputValues
+    values:
+      some: value

--- a/core/src/test/resources/flows/valids/for-each-item-after-execution.yaml
+++ b/core/src/test/resources/flows/valids/for-each-item-after-execution.yaml
@@ -1,0 +1,26 @@
+id: for-each-item-after-execution
+namespace: io.kestra.tests
+
+inputs:
+  - id: file
+    type: FILE
+  - id: batch
+    type: INT
+
+tasks:
+  - id: each
+    type: io.kestra.plugin.core.flow.ForEachItem
+    items: "{{ inputs.file }}"
+    batch:
+      rows: "{{inputs.batch}}"
+    namespace: io.kestra.tests
+    flowId: for-each-item-subflow-after-execution
+    wait: true
+    transmitFailed: true
+    inputs:
+      items: "{{ taskrun.items }}"
+
+afterExecution:
+  - id: afterExecution
+    type: io.kestra.plugin.core.log.Log
+    message: Hello from afterExecution!

--- a/core/src/test/resources/flows/valids/for-each-item-subflow-after-execution.yaml
+++ b/core/src/test/resources/flows/valids/for-each-item-subflow-after-execution.yaml
@@ -1,0 +1,16 @@
+id: for-each-item-subflow-after-execution
+namespace: io.kestra.tests
+
+inputs:
+  - id: items
+    type: STRING
+
+tasks:
+  - id: per-item
+    type: io.kestra.plugin.core.log.Log
+    message: "{{ inputs.items }}"
+
+afterExecution:
+  - id: afterExecution
+    type: io.kestra.plugin.core.log.Log
+    message: Hello from afterExecution!

--- a/jdbc/src/main/java/io/kestra/jdbc/runner/JdbcExecutor.java
+++ b/jdbc/src/main/java/io/kestra/jdbc/runner/JdbcExecutor.java
@@ -1065,7 +1065,11 @@ public class JdbcExecutor implements ExecutorInterface, Service {
                 executorService.log(log, false, executor);
             }
 
-            // the terminated state can only come from the execution queue, in this case we always have a flow in the executor
+            // the terminated state can come from the execution queue, in this case we always have a flow in the executor
+            // or from a worker task in an afterExecution block, in this case we need to load the flow
+            if (executor.getFlow() == null && executor.getExecution().getState().isTerminated()) {
+                executor = executor.withFlow(findFlow(executor.getExecution()));
+            }
             boolean isTerminated = executor.getFlow() != null && executionService.isTerminated(executor.getFlow(), executor.getExecution());
 
             // purge the executionQueue


### PR DESCRIPTION
This is because the execution is never considered fully terminated so concurrency limit is not handled properly. This should also affect SLA, trigger lock, and other cleaning stuff.

The root issue is that, with a worker task from afterExecution, there are no other update on the execution itself (as it's already terminated) so no execution messages are again processed by the executor.

Because of that, the worker task result message from the afterExecution block is the last message, but unfortunatly as messages from the worker task result have no flow attached, the computation of the final termination is incorrect. The solution is to load the flow if null inside the executor and the execution is terminated which should only occurs inside afterExecution.

Fixes #10657
Fixes #8459
Fixes #8609