### PR TITLE
fix(core): pass viewTypes to initYamlSource

### DIFF
--- a/ui/src/components/flows/FlowCreate.vue
+++ b/ui/src/components/flows/FlowCreate.vue
@@ -15,6 +15,7 @@
     import {storageKeys} from "../../utils/constants";
     import {useBlueprintsStore} from "../../stores/blueprints";
     import {useCoreStore} from "../../stores/core";
+    import {editorViewTypes} from "../../utils/constants";
 
     import {getRandomFlowID} from "../../../scripts/product/flow";
     import {useEditorStore} from "../../stores/editor";
@@ -65,7 +66,7 @@ tasks:
                 this.flowStore.flowYamlBeforeAdd = flowYaml;
 
                 this.flowStore.flow = {...YAML_UTILS.parse(this.flowYaml), source: this.flowStore.flowYaml};
-                this.flowStore.initYamlSource();
+                this.flowStore.initYamlSource({viewTypes: editorViewTypes.SOURCE_DOC});
             }
         },
         computed: {


### PR DESCRIPTION
Fixes Console error:

```
flow.ts:337 Uncaught (in promise) TypeError: Cannot destructure property 'viewType' of 'undefined' as it is undefined.
    at Proxy.initYamlSource (flow.ts:337:36)
    at Proxy.setupFlow (FlowCreate.vue:68:32)
    at Proxy.created (FlowCreate.vue:37:18)

```

Empty Topology
<img width="2516" height="1856" alt="image" src="https://github.com/user-attachments/assets/3f2aa992-df08-4868-9451-e31a4c381d1c" />
