### PR TITLE
fix(tests): unwanted namespace binding was breaking filtering in Flow…

### DIFF
--- a/ui/src/components/Tabs.vue
+++ b/ui/src/components/Tabs.vue
@@ -48,8 +48,8 @@
             v-on="activeTab['v-on'] ?? {}"
             ref="tabContent"
             :is="activeTab.component"
+            :namespace="namespaceToForward"
             @go-to-detail="blueprintId => selectedBlueprintId = blueprintId"
-            :namespace
             :embed="activeTab.props && activeTab.props.embed !== undefined ? activeTab.props.embed : true"
         />
     </section>
@@ -204,6 +204,11 @@
                     Object.entries(this.$attrs)
                         .filter(([key]) => key !== "class")
                 );
+            },
+            namespaceToForward(){
+                return this.activeTab.props?.namespace ?? this.namespace;
+                // in the special case of Namespace creation on Namespaces page, the tabs are loaded before the namespace creation
+                // in this case this.props.namespace will be used
             }
         }
     };


### PR DESCRIPTION
… page

fixes https://github.com/kestra-io/kestra-ee/issues/4691

the namespace binding in Tabs was added in PR https://github.com/kestra-io/kestra/pull/10543, it breaks things and did not seem useful to fix the issue on Secret/KvStore
