### PR TITLE
fix: avoid file being displayed as diff in namespace file editor

### DIFF
--- a/ui/src/components/inputs/EditorView.vue
+++ b/ui/src/components/inputs/EditorView.vue
@@ -152,7 +152,7 @@
                         @tab-loaded="onTabLoaded"
                         :read-only="isReadOnly"
                         :navbar="false"
-                        :original="flowYaml"
+                        :original="isNamespace ? undefined : flowYaml"
                         :diff-side-by-side="false"
                     />
                 </template>


### PR DESCRIPTION
close #10744
