### PR TITLE
fix(execution): parallel flowable may not ends all child flowable

### DIFF
--- a/core/src/main/java/io/kestra/core/models/executions/Execution.java
+++ b/core/src/main/java/io/kestra/core/models/executions/Execution.java
@@ -1040,6 +1040,16 @@ public class Execution implements DeletedInterface, TenantInterface {
         return result;
     }
 
+    /**
+     * Find all children of this {@link TaskRun}.
+     */
+    public List<TaskRun> findChildren(TaskRun parentTaskRun) {
+        return taskRunList.stream()
+            .filter(taskRun -> parentTaskRun.getId().equals(taskRun.getParentTaskRunId()))
+            .toList();
+    }
+
+
     public List<String> findParentsValues(TaskRun taskRun, boolean withCurrent) {
         return (withCurrent ?
             Stream.concat(findParents(taskRun).stream(), Stream.of(taskRun)) :

--- a/core/src/test/java/io/kestra/plugin/core/flow/ParallelTest.java
+++ b/core/src/test/java/io/kestra/plugin/core/flow/ParallelTest.java
@@ -58,4 +58,15 @@ class ParallelTest {
         assertThat(execution.findTaskRunsByTaskId("a2").getFirst().getState().getStartDate().isAfter(execution.findTaskRunsByTaskId("a1").getFirst().getState().getEndDate().orElseThrow())).isTrue();
         assertThat(execution.findTaskRunsByTaskId("e2").getFirst().getState().getStartDate().isAfter(execution.findTaskRunsByTaskId("e1").getFirst().getState().getEndDate().orElseThrow())).isTrue();
     }
+
+    @Test
+    @ExecuteFlow("flows/valids/parallel-fail-with-flowable.yaml")
+    void parallelFailWithFlowable(Execution execution) {
+        assertThat(execution.getState().getCurrent()).isEqualTo(State.Type.FAILED);
+        assertThat(execution.getTaskRunList()).hasSize(5);
+        // all tasks must be terminated except the Sleep that will ends later as everything is concurrent
+        execution.getTaskRunList().stream()
+            .filter(taskRun -> !"sleep".equals(taskRun.getTaskId()))
+            .forEach(run -> assertThat(run.getState().isTerminated()).isTrue());
+    }
 }

--- a/core/src/test/resources/flows/valids/parallel-fail-with-flowable.yaml
+++ b/core/src/test/resources/flows/valids/parallel-fail-with-flowable.yaml
@@ -1,0 +1,28 @@
+id: parallel-fail-with-flowable
+namespace: io.kestra.tests
+
+inputs:
+  - id: user
+    type: STRING
+    defaults: Rick Astley
+
+
+tasks:
+  - id: parallel
+    type: io.kestra.plugin.core.flow.Parallel
+    tasks:
+      - id: if-1
+        type: io.kestra.plugin.core.flow.If
+        condition: "{{ inputs.user == 'Rick Astley'}}"
+        then:
+          - id: sleep
+            type: io.kestra.plugin.core.flow.Sleep
+            duration: PT1S
+
+      - id: if-2
+        type: io.kestra.plugin.core.flow.If
+        condition: "{{ inputs.user == 'Rick Astley'}}"
+        then:
+          - id: fail_missing_variable
+            type: io.kestra.plugin.core.log.Log
+            message: "{{ vars.nonexistent_variable }}"

--- a/jdbc/src/main/java/io/kestra/jdbc/runner/JdbcExecutor.java
+++ b/jdbc/src/main/java/io/kestra/jdbc/runner/JdbcExecutor.java
@@ -1219,13 +1219,13 @@ public class JdbcExecutor implements ExecutorInterface, Service {
                 try {
                     // Handle paused tasks
                     if (executionDelay.getDelayType().equals(ExecutionDelay.DelayType.RESUME_FLOW) && !pair.getLeft().getState().isTerminated()) {
-                        FlowInterface flow = flowMetaStore.findByExecution(pair.getLeft()).orElseThrow();
                         if (executionDelay.getTaskRunId() == null) {
                             // if taskRunId is null, this means we restart a flow that was delayed at startup (scheduled on)
                             Execution markAsExecution = pair.getKey().withState(executionDelay.getState());
                             executor = executor.withExecution(markAsExecution, "pausedRestart");
                         } else {
                             // if there is a taskRun it means we restart a paused task
+                            FlowInterface flow = flowMetaStore.findByExecution(pair.getLeft()).orElseThrow();
                             Execution markAsExecution = executionService.markAs(
                                 pair.getKey(),
                                 flow,


### PR DESCRIPTION
Parallel flowable tasks like `Parallel`, `Dag` and `ForEach` are racy. When a task fail in a branch, other concurrent branches that have flowable may never ends. We make sure that all children are terminated when a flowable is itself terminated.

Fixes #6780
