### PR TITLE
fix(core): fix preconditions rendering for ExecutionOutputs (#10651)

### DIFF
--- a/core/src/main/java/io/kestra/core/models/property/Property.java
+++ b/core/src/main/java/io/kestra/core/models/property/Property.java
@@ -68,6 +68,19 @@ public class Property<T> {
     String getExpression() {
         return expression;
     }
+    
+    /**
+     * Returns a new {@link Property} with no cached rendered value,
+     * so that the next render will evaluate its original Pebble expression.
+     * <p>
+     * The returned property will still cache its rendered result.
+     * To re-evaluate on a subsequent render, call {@code skipCache()} again.
+     *
+     * @return a new {@link Property} without a pre-rendered value
+     */
+    public Property<T> skipCache() {
+        return Property.ofExpression(expression);
+    }
 
     /**
      * Build a new Property object with a value already set.<br>

--- a/core/src/main/java/io/kestra/plugin/core/condition/ExecutionOutputs.java
+++ b/core/src/main/java/io/kestra/plugin/core/condition/ExecutionOutputs.java
@@ -90,7 +90,7 @@ public class ExecutionOutputs extends Condition implements ScheduleCondition {
     private static final String OUTPUTS_VAR = "outputs";
 
     @NotNull
-    private Property<String> expression;
+    private Property<Boolean> expression;
 
     /** {@inheritDoc} **/
     @SuppressWarnings("unchecked")
@@ -105,9 +105,8 @@ public class ExecutionOutputs extends Condition implements ScheduleCondition {
             conditionContext.getVariables(),
             Map.of(TRIGGER_VAR, Map.of(OUTPUTS_VAR, conditionContext.getExecution().getOutputs()))
         );
-
-        String render = conditionContext.getRunContext().render(expression).as(String.class, variables).orElseThrow();
-        return !(render.isBlank() || render.trim().equals("false"));
+        
+        return conditionContext.getRunContext().render(expression).skipCache().as(Boolean.class, variables).orElseThrow();
     }
 
     private boolean hasNoOutputs(final Execution execution) {

--- a/core/src/test/java/io/kestra/core/runners/RunContextPropertyTest.java
+++ b/core/src/test/java/io/kestra/core/runners/RunContextPropertyTest.java
@@ -83,4 +83,24 @@ class RunContextPropertyTest {
         runContextProperty = new RunContextProperty<>(Property.<Map<String, String>>builder().expression("{ \"key\": \"{{ key }}\"}").build(), runContext);
         assertThat(runContextProperty.asMap(String.class, String.class, Map.of("key", "value"))).containsEntry("key", "value");
     }
+    
+    @Test
+    void asShouldReturnCachedRenderedProperty() throws IllegalVariableEvaluationException {
+        var runContext = runContextFactory.of();
+        
+        var runContextProperty = new RunContextProperty<>(Property.<String>builder().expression("{{ variable }}").build(), runContext);
+        
+        assertThat(runContextProperty.as(String.class, Map.of("variable", "value1"))).isEqualTo(Optional.of("value1"));
+        assertThat(runContextProperty.as(String.class, Map.of("variable", "value2"))).isEqualTo(Optional.of("value1"));
+    }
+    
+    @Test
+    void asShouldNotReturnCachedRenderedPropertyWithSkipCache() throws IllegalVariableEvaluationException {
+        var runContext = runContextFactory.of();
+        
+        var runContextProperty = new RunContextProperty<>(Property.<String>builder().expression("{{ variable }}").build(), runContext);
+        
+        assertThat(runContextProperty.as(String.class, Map.of("variable", "value1"))).isEqualTo(Optional.of("value1"));
+        assertThat(runContextProperty.skipCache().as(String.class, Map.of("variable", "value2"))).isEqualTo(Optional.of("value2"));
+    }
 }


### PR DESCRIPTION
Ensure that preconditions are always re-rendered for any new executions

Changes:
* add new fluent skipCache methods on RunContextProperty and Property classes

Fix: #10651

Backported needed for 0.23.x, 0.24.x