### PR TITLE
fix docker image not starting

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -19,7 +19,7 @@ on:
         default: "no input"
 jobs:
   check:
-    timeout-minutes: 10
+    timeout-minutes: 15
     runs-on: ubuntu-latest
     env:
       GOOGLE_SERVICE_ACCOUNT: ${{ secrets.GOOGLE_SERVICE_ACCOUNT }}

--- a/build-and-start-e2e-tests.sh
+++ b/build-and-start-e2e-tests.sh
@@ -7,7 +7,7 @@ set -e
 # run tests on this image
 
 
-LOCAL_IMAGE_VERSION="local-e2e"
+LOCAL_IMAGE_VERSION="local-e2e-$(date +%s)"
 
 echo "Running E2E"
 echo "Start time: $(date '+%Y-%m-%d %H:%M:%S')"
@@ -15,6 +15,7 @@ start_time=$(date +%s)
 
 echo ""
 echo "Building the image for this current repository"
+make clean
 make build-docker VERSION=$LOCAL_IMAGE_VERSION
 
 end_time=$(date +%s)
@@ -32,7 +33,7 @@ echo "npm i"
 npm i
 
 echo 'sh ./run-e2e-tests.sh --kestra-docker-image-to-test "kestra/kestra:$LOCAL_IMAGE_VERSION"'
-sh ./run-e2e-tests.sh --kestra-docker-image-to-test "kestra/kestra:$LOCAL_IMAGE_VERSION"
+./run-e2e-tests.sh --kestra-docker-image-to-test "kestra/kestra:$LOCAL_IMAGE_VERSION"
 
 end_time2=$(date +%s)
 elapsed2=$(( end_time2 - start_time2 ))

--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ plugins {
     id "java"
     id 'java-library'
     id "idea"
-    id "com.gradleup.shadow" version "9.0.1"
+    id "com.gradleup.shadow" version "8.3.9"
     id "application"
 
     // test

--- a/ui/tests/e2e/docker-compose-postgres.yml
+++ b/ui/tests/e2e/docker-compose-postgres.yml
@@ -42,6 +42,7 @@ services:
         condition: service_completed_successfully
 
   kestra:
+    container_name: kestra-e2e-backend
     image: "${KESTRA_DOCKER_IMAGE:-kestra/kestra:develop}"
     entrypoint:
       - bash

--- a/ui/tests/e2e/start-e2e-tests-backend.sh
+++ b/ui/tests/e2e/start-e2e-tests-backend.sh
@@ -42,6 +42,8 @@ while [ "$(curl -s -L -o /dev/null -w %{http_code} $KESTRA_BASE_URL)" != "200" ]
   ELAPSED_TIME=$((CURRENT_TIME - START_TIME))
   if [ $ELAPSED_TIME -ge $TIMEOUT_DURATION ]; then
     echo "Timeout reached: Exiting after 5 minutes."
+    echo "printing 'docker logs kestra-e2e-backend'"
+    docker logs kestra-e2e-backend
     exit 1
   fi
   sleep 2

--- a/ui/tests/e2e/start-e2e-tests-backend.sh
+++ b/ui/tests/e2e/start-e2e-tests-backend.sh
@@ -35,7 +35,7 @@ docker compose -f "docker-compose-postgres.yml" up -d
 # Wait for Kestra UI
 echo "Waiting for Kestra UI at $KESTRA_BASE_URL"
 START_TIME=$(date +%s)
-TIMEOUT_DURATION=$((5 * 60))
+TIMEOUT_DURATION=$((2 * 60))
 while [ "$(curl -s -L -o /dev/null -w %{http_code} $KESTRA_BASE_URL)" != "200" ]; do
   echo -e "$(date)\tKestra server HTTP state: $(curl -k -L -s -o /dev/null -w %{http_code} $KESTRA_BASE_URL) (waiting for 200)"
   CURRENT_TIME=$(date +%s)


### PR DESCRIPTION
- fixes https://github.com/kestra-io/kestra-ee/issues/4715

backend was not starting, so we waited 5minutes for it to start, but the github timeout was 10min, so it was wronglfully marked as canceled

example: a failing e2e run https://github.com/kestra-io/kestra/actions/runs/16955071358 wrongfully marked as Canceled by github