### PR TITLE
chore: bump com.gradleup.shadow from 8.3.9 to 9.0.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ plugins {
     id "java"
     id 'java-library'
     id "idea"
-    id "com.gradleup.shadow" version "8.3.9"
+    id "com.gradleup.shadow" version "9.0.1"
     id "application"
 
     // test


### PR DESCRIPTION
- BLOCKED> Kestra container is not starting, E2E test is failing, this is due to: https://github.com/kestra-io/kestra/issues/10767
- duplicate of https://github.com/kestra-io/kestra/pull/11059 but keeping it for doc