### PR TITLE
feat(flow): add support for optional flow outputs

### DIFF
--- a/core/src/main/java/io/kestra/core/models/flows/Output.java
+++ b/core/src/main/java/io/kestra/core/models/flows/Output.java
@@ -43,4 +43,11 @@ public class Output implements Data {
     Type type;
 
     String displayName;
+    
+    /**
+     * Specifies whether the output is required or not.
+     * <p>
+     * By default, an output is always required.
+     */
+    Boolean required;
 }

--- a/core/src/main/java/io/kestra/core/runners/ExecutorService.java
+++ b/core/src/main/java/io/kestra/core/runners/ExecutorService.java
@@ -380,11 +380,9 @@ public class ExecutorService {
 
         if (flow.getOutputs() != null) {
             RunContext runContext = runContextFactory.of(executor.getFlow(), executor.getExecution());
+            
             try {
-                Map<String, Object> outputs = flow.getOutputs()
-                    .stream()
-                    .collect(HashMap::new, (map, entry) -> map.put(entry.getId(), entry.getValue()), Map::putAll);
-                outputs = runContext.render(outputs);
+                Map<String, Object> outputs = FlowInputOutput.renderFlowOutputs(flow.getOutputs(), runContext);
                 outputs = flowInputOutput.typedOutputs(flow, executor.getExecution(), outputs);
                 newExecution = newExecution.withOutputs(outputs);
             } catch (Exception e) {

--- a/core/src/main/java/io/kestra/core/runners/FlowInputOutput.java
+++ b/core/src/main/java/io/kestra/core/runners/FlowInputOutput.java
@@ -2,7 +2,6 @@ package io.kestra.core.runners;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.collect.ImmutableMap;
 import io.kestra.core.encryption.EncryptionService;
 import io.kestra.core.exceptions.IllegalVariableEvaluationException;
 import io.kestra.core.exceptions.KestraRuntimeException;
@@ -12,6 +11,7 @@ import io.kestra.core.models.flows.DependsOn;
 import io.kestra.core.models.flows.Flow;
 import io.kestra.core.models.flows.FlowInterface;
 import io.kestra.core.models.flows.Input;
+import io.kestra.core.models.flows.Output;
 import io.kestra.core.models.flows.RenderableInput;
 import io.kestra.core.models.flows.Type;
 import io.kestra.core.models.flows.input.FileInput;
@@ -368,7 +368,7 @@ public class FlowInputOutput {
         final Map<String, Object> in
     ) {
         if (flow.getOutputs() == null) {
-            return ImmutableMap.of();
+            return Map.of();
         }
         Map<String, Object> results = flow
             .getOutputs()
@@ -376,6 +376,9 @@ public class FlowInputOutput {
             .map(output -> {
                 Object current = in == null ? null : in.get(output.getId());
                 try {
+                    if (current == null && Boolean.FALSE.equals(output.getRequired())) {
+                        return Optional.of(new AbstractMap.SimpleEntry<>(output.getId(), null));
+                    }
                     return parseData(execution, output, current)
                         .map(entry -> {
                             if (output.getType().equals(Type.SECRET)) {
@@ -406,7 +409,7 @@ public class FlowInputOutput {
         if (data.getType() == null) {
             return Optional.of(new AbstractMap.SimpleEntry<>(data.getId(), current));
         }
-
+        
         final Type elementType = data instanceof ItemTypeInterface itemTypeInterface ? itemTypeInterface.getItemType() : null;
 
         return Optional.of(new AbstractMap.SimpleEntry<>(
@@ -482,6 +485,28 @@ public class FlowInputOutput {
         } catch (Throwable e) {
             throw new Exception("Expected `" + type + "` but received `" + current + "` with errors:\n```\n" + e.getMessage() + "\n```");
         }
+    }
+    
+    public static Map<String, Object> renderFlowOutputs(List<Output> outputs, RunContext runContext) throws IllegalVariableEvaluationException {
+        // render required outputs
+        Map<String, Object> outputsById = outputs
+            .stream()
+            .filter(output -> output.getRequired() == null || output.getRequired())
+            .collect(HashMap::new, (map, entry) -> map.put(entry.getId(), entry.getValue()), Map::putAll);
+        outputsById = runContext.render(outputsById);
+        
+        // render optional outputs one by one to catch, log, and skip any error.
+        for (io.kestra.core.models.flows.Output output :outputs) {
+            if (Boolean.FALSE.equals(output.getRequired())) {
+                try {
+                    outputsById.putAll(runContext.render(Map.of(output.getId(), output.getValue())));
+                } catch (Exception e) {
+                    runContext.logger().warn("Failed to render optional subflow output '{}'. Output is ignored.", output.getId(), e);
+                    outputsById.put(output.getId(), null);
+                }
+            }
+        }
+        return outputsById;
     }
 
     /**

--- a/core/src/main/java/io/kestra/plugin/core/flow/ForEachItem.java
+++ b/core/src/main/java/io/kestra/plugin/core/flow/ForEachItem.java
@@ -535,19 +535,13 @@ public class ForEachItem extends Task implements FlowableTask<VoidOutput>, Child
 
             // We only resolve subflow outputs for an execution result when the execution is terminated.
             if (taskRun.getState().isTerminated() && flow.getOutputs() != null && waitForExecution()) {
-                final Map<String, Object> outputs = flow.getOutputs()
-                    .stream()
-                    .collect(Collectors.toMap(
-                        io.kestra.core.models.flows.Output::getId,
-                        io.kestra.core.models.flows.Output::getValue)
-                    );
                 final ForEachItem.Output.OutputBuilder builder = Output
                     .builder()
                     .iterations((Map<State.Type, Integer>) taskRun.getOutputs().get(ExecutableUtils.TASK_VARIABLE_ITERATIONS))
                     .numberOfBatches((Integer) taskRun.getOutputs().get(ExecutableUtils.TASK_VARIABLE_NUMBER_OF_BATCHES));
 
                 try (ByteArrayOutputStream bos = new ByteArrayOutputStream()) {
-                    FileSerde.write(bos, runContext.render(outputs));
+                    FileSerde.write(bos, FlowInputOutput.renderFlowOutputs(flow.getOutputs(), runContext));
                     URI uri = runContext.storage().putFile(
                         new ByteArrayInputStream(bos.toByteArray()),
                         URI.create((String) taskRun.getOutputs().get("uri"))

--- a/core/src/main/java/io/kestra/plugin/core/flow/Subflow.java
+++ b/core/src/main/java/io/kestra/plugin/core/flow/Subflow.java
@@ -8,18 +8,18 @@ import io.kestra.core.models.annotations.Example;
 import io.kestra.core.models.annotations.Plugin;
 import io.kestra.core.models.annotations.PluginProperty;
 import io.kestra.core.models.executions.Execution;
-import io.kestra.core.models.flows.FlowInterface;
-import io.kestra.core.models.property.Property;
 import io.kestra.core.models.executions.TaskRun;
 import io.kestra.core.models.executions.TaskRunAttempt;
 import io.kestra.core.models.executions.Variables;
+import io.kestra.core.models.flows.FlowInterface;
 import io.kestra.core.models.flows.State;
+import io.kestra.core.models.property.Property;
 import io.kestra.core.models.tasks.ExecutableTask;
 import io.kestra.core.models.tasks.Task;
-import io.kestra.core.runners.ExecutableUtils;
-import io.kestra.core.runners.FlowMetaStoreInterface;
-import io.kestra.core.runners.FlowInputOutput;
 import io.kestra.core.runners.DefaultRunContext;
+import io.kestra.core.runners.ExecutableUtils;
+import io.kestra.core.runners.FlowInputOutput;
+import io.kestra.core.runners.FlowMetaStoreInterface;
 import io.kestra.core.runners.RunContext;
 import io.kestra.core.runners.SubflowExecution;
 import io.kestra.core.runners.SubflowExecutionResult;
@@ -30,20 +30,22 @@ import io.kestra.core.storages.StorageContext;
 import io.kestra.core.validations.NoSystemLabelValidation;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Min;
-import lombok.experimental.SuperBuilder;
-
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
-
-import jakarta.validation.constraints.NotEmpty;
-import jakarta.validation.constraints.NotNull;
+import lombok.experimental.SuperBuilder;
+import org.slf4j.event.Level;
 
 import java.time.ZonedDateTime;
-import java.util.*;
-import java.util.stream.Collectors;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 
 @SuperBuilder
 @ToString
@@ -218,20 +220,26 @@ public class Subflow extends Task implements ExecutableTask<Subflow.Output>, Chi
                 .<Boolean>pluginConfiguration(PLUGIN_FLOW_OUTPUTS_ENABLED)
                 .orElse(true);
 
-            final Map<String, Object> subflowOutputs = Optional
-                .ofNullable(flow.getOutputs())
-                .map(outputs -> outputs
-                    .stream()
-                    .collect(Collectors.toMap(
-                        io.kestra.core.models.flows.Output::getId,
-                        io.kestra.core.models.flows.Output::getValue)
+            List<io.kestra.core.models.flows.Output> subflowOutputs = flow.getOutputs();
+            
+            // region [deprecated] Subflow outputs feature
+            if (subflowOutputs == null && isOutputsAllowed) {
+                subflowOutputs = this.getOutputs().entrySet().stream()
+                    .<io.kestra.core.models.flows.Output>map(entry -> io.kestra.core.models.flows.Output
+                        .builder()
+                        .id(entry.getKey())
+                        .value(entry.getValue())
+                        .required(true)
+                        .build()
                     )
-                )
-                .orElseGet(() -> isOutputsAllowed ? this.getOutputs() : null);
+                    .toList();
+            }
+            //endregion
 
-            if (subflowOutputs != null) {
+            if (subflowOutputs != null && !subflowOutputs.isEmpty()) {
                 try {
-                    Map<String, Object> outputs = runContext.render(subflowOutputs);
+                    Map<String, Object> outputs = FlowInputOutput.renderFlowOutputs(flow.getOutputs(), runContext);
+                    
                     FlowInputOutput flowInputOutput = ((DefaultRunContext)runContext).getApplicationContext().getBean(FlowInputOutput.class); // this is hacking
                     if (flow.getOutputs() != null && flowInputOutput != null) {
                         outputs = flowInputOutput.typedOutputs(flow, execution, outputs);

--- a/core/src/test/java/io/kestra/plugin/core/flow/FlowOutputTest.java
+++ b/core/src/test/java/io/kestra/plugin/core/flow/FlowOutputTest.java
@@ -19,6 +19,13 @@ class FlowOutputTest {
         assertThat(execution.getOutputs().get("key")).isEqualTo("{\"value\":\"flow-with-outputs\"}");
         assertThat(execution.getState().getCurrent()).isEqualTo(State.Type.SUCCESS);
     }
+    
+    @Test
+    @ExecuteFlow("flows/valids/flow-with-optional-outputs.yml")
+    void shouldGetSuccessExecutionForFlowWithOptionalOutputs(Execution execution) {
+        assertThat(execution.getOutputs()).isNull();
+        assertThat(execution.getState().getCurrent()).isEqualTo(State.Type.SUCCESS);
+    }
 
     @SuppressWarnings("unchecked")
     @Test

--- a/core/src/test/resources/flows/valids/flow-with-optional-outputs.yml
+++ b/core/src/test/resources/flows/valids/flow-with-optional-outputs.yml
@@ -1,0 +1,13 @@
+id: flow-with-optional-outputs
+namespace: io.kestra.tests
+
+tasks:
+- id: return
+  type: io.kestra.plugin.core.debug.Return
+  format: "{{ flow.id }}"
+
+outputs:
+- id: "optional"
+  value: "{{ outputs.invalid-task }}"
+  type: STRING
+  required: false


### PR DESCRIPTION
Add the new required property to the flow output model. By default, all flow's outputs are required

Fixes: kestra-io/kestra-ee#3969