### PR TITLE
Fix: IllegalArgumentException

### DIFF
--- a/core/src/main/java/io/kestra/core/models/tasks/runners/PluginUtilsService.java
+++ b/core/src/main/java/io/kestra/core/models/tasks/runners/PluginUtilsService.java
@@ -67,9 +67,11 @@ abstract public class PluginUtilsService {
                     File tempFile;
 
                     if (isDir) {
-                        tempFile = Files.createTempDirectory(tempDirectory, s + "_").toFile();
+                        String safeDirName = s.replace(" ", "_");
+                        tempFile = Files.createTempDirectory(tempDirectory, safeDirName + "_").toFile();
                     } else {
-                        String prefix = StringUtils.leftPad(s + "_", 3, "_");
+                        String safePrefix = s.replace(" ", "_");
+                        String prefix = StringUtils.leftPad(safePrefix + "_", 3, "_");
                         tempFile = File.createTempFile(prefix, null, tempDirectory.toFile());
                     }
 


### PR DESCRIPTION
Fix: IllegalArgumentException in filenames with spaces

Issue: #10802 

I reviewed the code and confirmed that Unicode characters in the filename are not causing the error. The actual issue arises from spaces in the filename.

<img width="1789" height="903" alt="2025-08-21-195012_hyprshot" src="https://github.com/user-attachments/assets/5be68aeb-85be-4ec5-b594-a9d5d9ff80b6" />

