### PR TITLE
fix(core): Choose File button and hover on btn text in light theme

### DIFF
--- a/ui/src/styles/layout/element-plus-overload.scss
+++ b/ui/src/styles/layout/element-plus-overload.scss
@@ -8,8 +8,6 @@
 
 // button
 .el-button {
-    // overflow: hidden;
-    // white-space: nowrap;
 
     &:not(.el-button--primary):not(.el-button--success):not(.el-button--warning):not(.el-button--danger):not(.el-button--error):not(.el-button--info):not(.el-button--playground), &--default {
         --el-button-hover-text-color: var(--ks-content-primary);
@@ -21,6 +19,7 @@
 
     &.el-button--primary {
         --el-button-text-color: var(--ks-button-content-primary);
+        --el-button-hover-text-color: var(--ks-button-content-primary);
         --el-button-bg-color: var(--ks-button-background-primary);
         --el-button-border-color: var(--ks-button-background-primary);
         --el-button-hover-bg-color: var(--ks-button-background-primary-hover);
@@ -294,6 +293,7 @@
 
     .el-input__inner::file-selector-button {
         background: var(--ks-button-background-primary);
+        color: var(--ks-button-content-primary);
         border: 0;
         margin: 2px 10px 0 4px;
         border-radius: var(--el-border-radius-base);


### PR DESCRIPTION
fix 

button text color in light mode

<img width="1110" height="530" alt="image" src="https://github.com/user-attachments/assets/3565cb04-cb45-407f-8829-e0cfdd88e9e2" />


and text color on primary btn on hovering

<img width="1110" height="530" alt="image" src="https://github.com/user-attachments/assets/c633f59a-d72d-4166-b4db-ec347c41bed1" />
