### PR TITLE
fix(core): show the proper origin in webhook curl command

### DIFF
--- a/ui/src/components/flows/WebhookCurl.vue
+++ b/ui/src/components/flows/WebhookCurl.vue
@@ -35,7 +35,7 @@
     import {useI18n} from "vue-i18n";
     import CopyToClipboard from "../layout/CopyToClipboard.vue";
     import Editor from "../inputs/Editor.vue";
-    import {apiUrlWithoutTenants} from "../../override/utils/route";
+    import {baseUrl, basePathWithoutTenant, apiUrlWithoutTenants} from "../../override/utils/route";
     import {useFlowStore} from "../../stores/flow";
 
     interface Flow {
@@ -73,7 +73,8 @@
     });
 
     const generateWebhookUrl = (trigger: Trigger): string => {
-        return `${apiUrlWithoutTenants()}/executions/webhook/${props.flow.namespace}/${props.flow.id}/${trigger.key}`;
+        const origin = baseUrl ? apiUrlWithoutTenants() : `${location.origin}${basePathWithoutTenant()}`;
+        return `${origin}/executions/webhook/${props.flow.namespace}/${props.flow.id}/${trigger.key}`;
     };
 
     const generateWebhookCurlCommand = (trigger: Trigger): string => {

--- a/ui/src/override/utils/route.ts
+++ b/ui/src/override/utils/route.ts
@@ -14,10 +14,11 @@ const createBaseUrl = (): string => {
 
 export const baseUrl = createBaseUrl().replace(/\/$/, "")
 export const basePath = () => "/api/v1/main"
+export const basePathWithoutTenant = () => "/api/v1"
 
 export const apiUrl = (_: Store<any>): string => {
     return `${baseUrl}${basePath()}`;
 }
 
 export const apiUrlWithTenant = (store: Store<any>, _: RouteLocationNormalizedLoaded): string => apiUrl(store);
-export const apiUrlWithoutTenants = (): string => `${baseUrl}/api/v1`
+export const apiUrlWithoutTenants = (): string => `${baseUrl}${basePathWithoutTenant()}`;


### PR DESCRIPTION
Before we don't have the say - `http://localhost:8080` in command which fails calling it.

Now we have this added.
<img width="3418" height="1908" alt="image" src="https://github.com/user-attachments/assets/b0d85f2c-9c77-40fb-b23f-6be34246014e" />


@aj-emerich , could you also update this image please in docs repo - `public/docs/workflow-components/triggers/webhook-trigger-test.png`

