### PR TITLE
fix: allow to enforce editor view when list is unreadable, also trunc…

### DIFF
--- a/ui/src/components/ListPreview.vue
+++ b/ui/src/components/ListPreview.vue
@@ -3,32 +3,35 @@
         <el-table-column v-for="(column, index) in generateTableColumns" :key="index" :prop="column" :label="column">
             <template #default="scope">
                 <template v-if="isComplex(scope.row[column])">
-                    <editor
-                        :full-height="false"
-                        :input="true"
-                        :navbar="false"
-                        :model-value="JSON.stringify(scope.row[column])"
-                        lang="json"
-                        read-only
+                    <el-input
+                        type="textarea"
+                        :model-value="truncate(JSON.stringify(scope.row[column], null, 2))"
+                        readonly
+                        :rows="3"
+                        autosize
+                        class="ks-editor"
+                        resize="none"
                     />
                 </template>
                 <template v-else>
-                    {{ scope.row[column] }}
+                    {{ truncate(scope.row[column]) }}
                 </template>
             </template>
         </el-table-column>
     </el-table>
 </template>
 <script>
-    import Editor from "./inputs/Editor.vue";
-
     export default {
         name: "ListPreview",
-        components: {Editor},
         props: {
             value: {
                 type: Array,
                 required: true
+            }
+        },
+        data() {
+            return {
+                maxColumnLength: 100
             }
         },
         computed: {
@@ -43,6 +46,12 @@
         methods: {
             isComplex(data) {
                 return data instanceof Array || data instanceof Object;
+            },
+            truncate(text) {
+                if (typeof text !== "string") return text;
+                return text.length > this.maxColumnLength
+                    ? text.slice(0, this.maxColumnLength) + "..."
+                    : text;
             }
         }
     }

--- a/ui/src/translations/en.json
+++ b/ui/src/translations/en.json
@@ -579,7 +579,6 @@
     "warning detected": "Warning(s) detected",
     "informative notice": "Note(s)",
     "cannot swap tasks": "Can't swap the tasks",
-    "preview": "Preview",
     "open": "Open",
     "dependency task": "Task {taskId} is a dependency of another task",
     "administration": "Administration",
@@ -1498,6 +1497,12 @@
         "placeholder": "Search by flow or namespace...",
         "no_results": "No results found for {term}"
       }
+    },
+    "preview": {
+      "label": "Preview",
+      "force-editor": "Enforce editor view",
+      "auto-view": "Auto view",
+      "view": "View"
     }
   }
 }


### PR DESCRIPTION
…ate too long column

Also remove editor for PreviewList as its too heavy when there is too much complex object (thousands of editors were init)

close https://github.com/kestra-io/plugin-kestra/issues/27