### PR TITLE
Fix/pause

### DIFF
--- a/core/src/main/java/io/kestra/core/services/FlowService.java
+++ b/core/src/main/java/io/kestra/core/services/FlowService.java
@@ -19,6 +19,7 @@ import io.kestra.core.repositories.FlowRepositoryInterface;
 import io.kestra.core.repositories.FlowTopologyRepositoryInterface;
 import io.kestra.core.serializers.JacksonMapper;
 import io.kestra.core.utils.ListUtils;
+import io.kestra.plugin.core.flow.Pause;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 import jakarta.validation.ConstraintViolationException;
@@ -250,7 +251,7 @@ public class FlowService {
         // add warning for runnable properties (timeout, workerGroup, taskCache) when used not in a runnable
         flow.allTasksWithChilds().forEach(task -> {
             if (!(task instanceof RunnableTask<?>)) {
-                if (task.getTimeout() != null) {
+                if (task.getTimeout() != null && !(task instanceof Pause)) {
                     warnings.add("The task '" + task.getId() + "' cannot use the 'timeout' property as it's only relevant for runnable tasks.");
                 }
                 if (task.getTaskCache() != null) {

--- a/core/src/test/java/io/kestra/core/serializers/JacksonMapperTest.java
+++ b/core/src/test/java/io/kestra/core/serializers/JacksonMapperTest.java
@@ -13,6 +13,7 @@ import java.io.IOException;
 import java.time.Instant;
 import java.time.ZonedDateTime;
 import java.util.List;
+import java.util.Map;
 import java.util.TimeZone;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -64,6 +65,18 @@ class JacksonMapperTest {
 
         assertThat(integerList.size()).isEqualTo(3);
         assertThat(integerList).containsExactlyInAnyOrder(1, 2, 3);
+    }
+
+    @Test
+    void toMap() throws JsonProcessingException {
+        assertThat(JacksonMapper.toMap("""
+            {
+                "some": "property",
+                "another": "property"
+            }""")).isEqualTo(Map.of(
+                "some", "property",
+            "another", "property"
+        ));
     }
 
     void test(Pojo original, Pojo deserialize) {

--- a/core/src/test/java/io/kestra/plugin/core/flow/PauseTest.java
+++ b/core/src/test/java/io/kestra/plugin/core/flow/PauseTest.java
@@ -139,6 +139,12 @@ public class PauseTest {
         suite.shouldExecuteOnPauseTask(execution);
     }
 
+    @Test
+    @ExecuteFlow("flows/valids/pause-errors-finally-after-execution.yaml")
+    void shouldExecuteErrorsFinallyAndAfterExecution(Execution execution) throws Exception {
+        suite.shouldExecuteErrorsFinallyAndAfterExecution(execution);
+    }
+
     @Singleton
     public static class Suite {
         @Inject
@@ -236,7 +242,7 @@ public class PauseTest {
             );
 
             assertThat(execution.getTaskRunList().getFirst().getState().getHistories().stream().filter(history -> history.getState() == State.Type.PAUSED).count()).as("Task runs were: " + execution.getTaskRunList().toString()).isEqualTo(1L);
-            assertThat(execution.getTaskRunList().getFirst().getState().getHistories().stream().filter(history -> history.getState() == State.Type.RUNNING).count()).isEqualTo(1L);
+            assertThat(execution.getTaskRunList().getFirst().getState().getHistories().stream().filter(history -> history.getState() == State.Type.RUNNING).count()).isEqualTo(2L);
             assertThat(execution.getTaskRunList().getFirst().getState().getHistories().stream().filter(history -> history.getState() == State.Type.FAILED).count()).isEqualTo(1L);
             assertThat(execution.getTaskRunList()).hasSize(1);
         }
@@ -255,9 +261,9 @@ public class PauseTest {
             );
 
             assertThat(execution.getTaskRunList().getFirst().getState().getHistories().stream().filter(history -> history.getState() == State.Type.PAUSED).count()).as("Task runs were: " + execution.getTaskRunList().toString()).isEqualTo(1L);
-            assertThat(execution.getTaskRunList().getFirst().getState().getHistories().stream().filter(history -> history.getState() == State.Type.RUNNING).count()).isEqualTo(1L);
+            assertThat(execution.getTaskRunList().getFirst().getState().getHistories().stream().filter(history -> history.getState() == State.Type.RUNNING).count()).isEqualTo(2L);
             assertThat(execution.getTaskRunList().getFirst().getState().getHistories().stream().filter(history -> history.getState() == State.Type.WARNING).count()).isEqualTo(1L);
-            assertThat(execution.getTaskRunList()).hasSize(2);
+            assertThat(execution.getTaskRunList()).hasSize(3);
         }
 
         public void runEmptyTasks(RunnerUtils runnerUtils) throws Exception {
@@ -384,6 +390,19 @@ public class PauseTest {
             assertThat(execution.getTaskRunList()).hasSize(2);
             assertThat(execution.getTaskRunList().getLast().getTaskId()).isEqualTo("hello");
             assertThat(execution.getTaskRunList().getLast().getState().getCurrent()).isEqualTo(State.Type.SUCCESS);
+        }
+
+        public void shouldExecuteErrorsFinallyAndAfterExecution(Execution execution) throws Exception {
+            assertThat(execution.getState().getCurrent()).isEqualTo(State.Type.FAILED);
+            assertThat(execution.getTaskRunList()).hasSize(4);
+            assertThat(execution.findTaskRunsByTaskId("pause")).hasSize(1);
+            assertThat(execution.findTaskRunsByTaskId("pause").getFirst().getState().getCurrent()).isEqualTo(State.Type.FAILED);
+            assertThat(execution.findTaskRunsByTaskId("logError")).hasSize(1);
+            assertThat(execution.findTaskRunsByTaskId("logError").getFirst().getState().getCurrent()).isEqualTo(State.Type.SUCCESS);
+            assertThat(execution.findTaskRunsByTaskId("logFinally")).hasSize(1);
+            assertThat(execution.findTaskRunsByTaskId("logFinally").getFirst().getState().getCurrent()).isEqualTo(State.Type.SUCCESS);
+            assertThat(execution.findTaskRunsByTaskId("logAfter")).hasSize(1);
+            assertThat(execution.findTaskRunsByTaskId("logAfter").getFirst().getState().getCurrent()).isEqualTo(State.Type.SUCCESS);
         }
     }
 }

--- a/core/src/test/resources/flows/valids/pause-behavior.yaml
+++ b/core/src/test/resources/flows/valids/pause-behavior.yaml
@@ -4,7 +4,7 @@ namespace: io.kestra.tests
 inputs:
   - id: behavior
     type: STRING
-    defaults: CONTINUE
+    defaults: RESUME
 
 tasks:
   - id: pause

--- a/core/src/test/resources/flows/valids/pause-errors-finally-after-execution.yaml
+++ b/core/src/test/resources/flows/valids/pause-errors-finally-after-execution.yaml
@@ -1,0 +1,23 @@
+id: pause-with-errors-finally-after-execution
+namespace: io.kestra.tests
+
+tasks:
+  - id: pause
+    type: io.kestra.plugin.core.flow.Pause
+    timeout: PT0.25S
+    errors:
+      - id: logError
+        type: io.kestra.plugin.core.log.Log
+        message: I'm in error
+    finally:
+      - id: logFinally
+        type: io.kestra.plugin.core.log.Log
+        message: I'm in finally
+  - id: log
+    type: io.kestra.plugin.core.log.Log
+    message: I'm after the pause
+
+afterExecution:
+  - id: logAfter
+    type: io.kestra.plugin.core.log.Log
+    message: I'm after the execution


### PR DESCRIPTION
The Pause task was previously immediatly termindated without taken into account any errors or finally block.
To allow processing those blocks, we need to store the terminated state in the output, then use it to resolve the final state.
