### PR TITLE
feat(executions): allow flow trigger on concurrency limit

### DIFF
--- a/core/src/test/java/io/kestra/core/repositories/AbstractFlowRepositoryTest.java
+++ b/core/src/test/java/io/kestra/core/repositories/AbstractFlowRepositoryTest.java
@@ -285,7 +285,7 @@ public abstract class AbstractFlowRepositoryTest {
     @Test
     void findByNamespace() {
         List<Flow> save = flowRepository.findByNamespace(MAIN_TENANT, "io.kestra.tests");
-        assertThat((long) save.size()).isEqualTo(Helpers.FLOWS_COUNT - 22);
+        assertThat((long) save.size()).isEqualTo(Helpers.FLOWS_COUNT - 24);
 
         save = flowRepository.findByNamespace(MAIN_TENANT, "io.kestra.tests2");
         assertThat((long) save.size()).isEqualTo(1L);
@@ -614,7 +614,7 @@ public abstract class AbstractFlowRepositoryTest {
     @Test
     void findDistinctNamespace() {
         List<String> distinctNamespace = flowRepository.findDistinctNamespace(MAIN_TENANT);
-        assertThat((long) distinctNamespace.size()).isEqualTo(8L);
+        assertThat((long) distinctNamespace.size()).isEqualTo(9L);
     }
 
     @Test

--- a/core/src/test/java/io/kestra/core/runners/AbstractRunnerTest.java
+++ b/core/src/test/java/io/kestra/core/runners/AbstractRunnerTest.java
@@ -214,6 +214,13 @@ public abstract class AbstractRunnerTest {
     }
 
     @Test
+    @LoadFlows({"flows/valids/trigger-flow-listener-with-concurrency-limit.yaml",
+        "flows/valids/trigger-flow-with-concurrency-limit.yaml"})
+    void flowTriggerWithConcurrencyLimit() throws Exception {
+        flowTriggerCaseTest.triggerWithConcurrencyLimit();
+    }
+
+    @Test
     @LoadFlows({"flows/valids/trigger-multiplecondition-listener.yaml",
         "flows/valids/trigger-multiplecondition-flow-a.yaml",
         "flows/valids/trigger-multiplecondition-flow-b.yaml"})

--- a/core/src/test/resources/flows/valids/trigger-flow-listener-with-concurrency-limit.yaml
+++ b/core/src/test/resources/flows/valids/trigger-flow-listener-with-concurrency-limit.yaml
@@ -1,0 +1,32 @@
+id: trigger-flow-listener-with-concurrency-limit
+namespace: io.kestra.tests.trigger.concurrency
+
+outputs:
+  - id: status
+    type: STRING
+    value: "{{trigger.state}}"
+  - id: executionId
+    type: STRING
+    value: "{{trigger.executionId}}"
+
+triggers:
+  - id: flow
+    type: io.kestra.plugin.core.trigger.Flow
+    states:
+      - QUEUED
+      - RUNNING
+      - SUCCESS
+    preconditions:
+      id: flows
+      flows:
+        - namespace: io.kestra.tests.trigger.concurrency
+          flowId: trigger-flow-with-concurrency-limit
+          states:
+            - QUEUED
+            - RUNNING
+            - SUCCESS
+
+tasks:
+  - id: hello
+    type: io.kestra.plugin.core.log.Log
+    message: Hello {{trigger.executionId}} you're in {{trigger.state}}

--- a/core/src/test/resources/flows/valids/trigger-flow-with-concurrency-limit.yaml
+++ b/core/src/test/resources/flows/valids/trigger-flow-with-concurrency-limit.yaml
@@ -1,0 +1,11 @@
+id: trigger-flow-with-concurrency-limit
+namespace: io.kestra.tests.trigger.concurrency
+
+concurrency:
+  limit: 1
+  behavior: QUEUE
+
+tasks:
+  - id: sleep
+    type: io.kestra.plugin.core.flow.Sleep
+    duration: PT0.5S

--- a/webserver/src/test/java/io/kestra/webserver/controllers/api/FlowControllerTest.java
+++ b/webserver/src/test/java/io/kestra/webserver/controllers/api/FlowControllerTest.java
@@ -499,7 +499,7 @@ class FlowControllerTest {
         List<String> namespaces = client.toBlocking().retrieve(
             HttpRequest.GET("/api/v1/main/flows/distinct-namespaces"), Argument.listOf(String.class));
 
-        assertThat(namespaces.size()).isEqualTo(8);
+        assertThat(namespaces.size()).isEqualTo(9);
     }
 
     @Test


### PR DESCRIPTION
Closes https://github.com/kestra-io/kestra-ee/issues/3270

This allow listening to the QUEUED state on the flow trigger. This also fixes an issue that when concurrency limit is setup, you would not listen to the RUNNING state.
