### PR TITLE
fix(executions): clear errors/finally/afterExecution branches when ch…

### DIFF
--- a/core/src/test/resources/flows/valids/change-state-errors.yaml
+++ b/core/src/test/resources/flows/valids/change-state-errors.yaml
@@ -1,0 +1,18 @@
+id: change-state-errors
+namespace: io.kestra.tests
+
+errors:
+  - id: print_error_log
+    type: io.kestra.plugin.core.log.Log
+    message: "Failure alert for flow {{ flow.namespace }}.{{ flow.id }} with ID {{ execution.id }}"
+
+tasks:
+  - id: before_task
+    type: io.kestra.plugin.core.debug.Return
+    format: "this always works"
+  - id: make_error
+    type: io.kestra.plugin.core.debug.Return
+    format: "{{error}}"
+  - id: after-task
+    type: io.kestra.plugin.core.debug.Return
+    format: "after"

--- a/webserver/src/main/java/io/kestra/webserver/controllers/api/ExecutionController.java
+++ b/webserver/src/main/java/io/kestra/webserver/controllers/api/ExecutionController.java
@@ -1133,7 +1133,7 @@ public class ExecutionController {
 
         Flow flow = flowRepository.findByExecution(execution.get());
 
-        Execution replay = executionService.markAs(execution.get(), flow, stateRequest.getTaskRunId(), stateRequest.getState());
+        Execution replay = executionService.changeTaskRunState(execution.get(), flow, stateRequest.getTaskRunId(), stateRequest.getState());
         List<Label> newLabels = new ArrayList<>(replay.getLabels());
         if (!newLabels.contains(new Label(Label.RESTARTED, "true"))) {
             newLabels.add(new Label(Label.RESTARTED, "true"));


### PR DESCRIPTION
…anging the state of a taskrun

As changing the state of a taskrun will restart the flow, if we didn't clear those branches, the flow would not resart properly.

Fixes https://github.com/kestra-io/kestra-ee/issues/3211