### PR TITLE
fix(flow)*: properly handle tab closing by clicking the cross icon in the corner of the panel

### DIFF
--- a/ui/src/stores/editor.js
+++ b/ui/src/stores/editor.js
@@ -76,7 +76,8 @@ export default {
                         return tab.name === name;
                     });
 
-            if (state.current?.name === name) {
+            if(!name) this.current = this.tabs?.[0] ?? []; // Handle tab closing by clicking the cross icon in the corner of the panel
+            else if (this.current?.name === name) {
                 if(POSITION - 1 >= 0){
                     commit("setCurrentTab", state.tabs[POSITION - 1]);
                 }else{


### PR DESCRIPTION
Separate `PR` instead of the simple `cherry-pick` of https://github.com/kestra-io/kestra/pull/11086 as there was `JS` to `TS` transition between the two versions.

Relates to #10981.

_Note to self - once merged, this needs to be `cherry-picked` to `v0.23.x`._