### PR TITLE
fix(core): show inherited kv pairs button only on kv  tab

### DIFF
--- a/ui/src/override/components/namespaces/Actions.vue
+++ b/ui/src/override/components/namespaces/Actions.vue
@@ -6,6 +6,7 @@
     />
 
     <Action
+        v-if="tab === 'kv'"
         :label="t('kv.inherited')"
         :icon="FamilyTree"
         @click="namespacesStore.inheritedKVModalVisible = true"


### PR DESCRIPTION
Closes https://github.com/kestra-io/kestra/issues/11097