### PR TITLE
chore(sanitycheck): add for `OutputValues`

### DIFF
--- a/core/src/test/java/io/kestra/core/tasks/test/SanityCheckTest.java
+++ b/core/src/test/java/io/kestra/core/tasks/test/SanityCheckTest.java
@@ -111,4 +111,11 @@ class SanityCheckTest {
         assertThat(execution.getTaskRunList()).hasSize(6);
         assertThat(execution.getState().getCurrent()).isEqualTo(State.Type.SUCCESS);
     }
+
+    @Test
+    @ExecuteFlow("sanity-checks/output_values.yaml")
+    void qaOutputValues(Execution execution) {
+        assertThat(execution.getTaskRunList()).hasSize(2);
+        assertThat(execution.getState().getCurrent()).isEqualTo(State.Type.SUCCESS);
+    }
 }

--- a/core/src/test/resources/sanity-checks/output_values.yaml
+++ b/core/src/test/resources/sanity-checks/output_values.yaml
@@ -1,0 +1,27 @@
+id: outputvalues_flow
+namespace: sanitychecks
+
+variables:
+  var1: "myvaribale"
+  var2: 25
+
+tasks:
+  - id: output_values
+    type: io.kestra.plugin.core.output.OutputValues
+    values:
+      string_value: "hello"
+      number_value: 42
+      nested_object:
+        key1: "value1"
+        key2: "value2"
+      text_var: "{{ vars.var1}}"
+      number_var: "the number value is: {{vars.var2}}"
+
+  - id: assert
+    type: io.kestra.plugin.core.execution.Assert
+    conditions:
+      - "{{ outputs.output_values.values.string_value == 'hello'}}"
+      - "{{ outputs.output_values.values.number_value == 42 }}"
+      - "{{ outputs.output_values.values.nested_object['key1'] == 'value1' }}"
+      - "{{ outputs.output_values.values.text_var == 'myvaribale' }}"
+      - "{{ outputs.output_values.values.number_var == 'the number value is: 25' }}"

--- a/core/src/test/resources/sanity-checks/output_values.yaml
+++ b/core/src/test/resources/sanity-checks/output_values.yaml
@@ -1,5 +1,5 @@
 id: output_values
-namespace: sanitychecks
+namespace: sanitychecks.core
 
 variables:
   var1: "myvaribale"

--- a/core/src/test/resources/sanity-checks/output_values.yaml
+++ b/core/src/test/resources/sanity-checks/output_values.yaml
@@ -1,4 +1,4 @@
-id: outputvalues_flow
+id: output_values
 namespace: sanitychecks
 
 variables:


### PR DESCRIPTION
### What changes are being made and why?

Add a sanity check for `io.kestra.plugin.core.output.OutputValues`

Closes #11159 


