### PR TITLE
fix(plugins): fix registration of a same plugins and doc reload

### DIFF
--- a/core/src/main/java/io/kestra/core/plugins/DefaultPluginRegistry.java
+++ b/core/src/main/java/io/kestra/core/plugins/DefaultPluginRegistry.java
@@ -195,14 +195,17 @@ public class DefaultPluginRegistry implements PluginRegistry {
      */
     public void register(final RegisteredPlugin plugin) {
         final PluginBundleIdentifier identifier = PluginBundleIdentifier.of(plugin);
-
-        // Skip registration if plugin-bundle already exists in the registry.
-        if (containsPluginBundle(identifier)) {
-            return;
+        // Skip registration if the same plugin already exists in the registry.
+        final RegisteredPlugin existing = plugins.get(identifier);
+        if (existing != null && existing.crc32() == plugin.crc32()) {
+            return; // same plugin already registered
         }
-
+        
         lock.lock();
         try {
+            if (existing != null) {
+                unregister(List.of(existing));
+            }
             plugins.put(PluginBundleIdentifier.of(plugin), plugin);
             registerAll(getPluginClassesByIdentifier(plugin));
         } finally {

--- a/core/src/main/java/io/kestra/core/plugins/ExternalPlugin.java
+++ b/core/src/main/java/io/kestra/core/plugins/ExternalPlugin.java
@@ -14,4 +14,5 @@ import java.net.URL;
 public class ExternalPlugin {
     private final URL location;
     private final URL[] resources;
+    private final long crc32;
 }

--- a/core/src/main/java/io/kestra/core/plugins/PluginRegistry.java
+++ b/core/src/main/java/io/kestra/core/plugins/PluginRegistry.java
@@ -3,6 +3,7 @@ package io.kestra.core.plugins;
 import io.kestra.core.models.Plugin;
 
 import java.net.URL;
+import java.nio.ByteBuffer;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Optional;
@@ -138,10 +139,9 @@ public interface PluginRegistry {
         
         for (RegisteredPlugin plugin : plugins()) {
             Optional.ofNullable(plugin.getExternalPlugin())
-                .map(ExternalPlugin::getLocation)
-                .map(URL::getPath)
-                .ifPresent(path -> {
-                    byte[] bytes = plugin.path().getBytes();
+                .map(ExternalPlugin::getCrc32)
+                .ifPresent(checksum -> {
+                    byte[] bytes = ByteBuffer.allocate(Long.BYTES).putLong(checksum).array();
                     crc32.update(bytes, 0, bytes.length);
                 });
         }

--- a/core/src/main/java/io/kestra/core/plugins/RegisteredPlugin.java
+++ b/core/src/main/java/io/kestra/core/plugins/RegisteredPlugin.java
@@ -308,6 +308,10 @@ public class RegisteredPlugin {
         }
         return null;
     }
+    
+    public long crc32() {
+        return Optional.ofNullable(externalPlugin).map(ExternalPlugin::getCrc32).orElse(-1L);
+    }
 
     @Override
     public String toString() {


### PR DESCRIPTION
Compute a quick CRC32 of each plugin based on the Central Directory of the JarFile to ensure change detection - allowing re-upload of a same plugin version (EE)

Fix: kestra-io/kestra-ee#4925
Fix: kestra-io/kestra-ee#4882
