### PR TITLE
docs: clarify Java version requirement (17 or 21, not 24+)

### DIFF
--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -25,7 +25,7 @@ In the meantime, you can move onto the next step...
 
 ### Requirements
 
-- Java 17 or Java 21 (LTS versions).
+- Java 21 (LTS versions).
   > ⚠️ Java 24 and above are not supported yet and will fail with `invalid source release: 21`.
 - Gradle (comes with wrapper `./gradlew`)
 - Docker (optional, for running Kestra in containers)

--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -23,7 +23,15 @@ In the meantime, you can move onto the next step...
 
 ---
 
+### Requirements
+
+- Java 17 or Java 21 (LTS versions).
+  > ⚠️ Java 24 and above are not supported yet and will fail with `invalid source release: 21`.
+- Gradle (comes with wrapper `./gradlew`)
+- Docker (optional, for running Kestra in containers)
+
 ### Development:
+
 - (Optional) By default, your dev server will target `localhost:8080`. If your backend is running elsewhere, you can create `.env.development.local` under `ui` folder with this content:
 ```
 VITE_APP_API_URL={myApiUrl}


### PR DESCRIPTION
## What changes are being made and why?

This PR updates the documentation to clarify the required Java versions.

Kestra currently requires Java 21(LTS), and versions like Java 24+ are not supported. This note will help contributors avoid runtime errors when setting up the project.

## How the changes have been QAed?

**Testing performed:**
- Verified locally by switching between Java 17, 21, and 24
- Build runs successfully on Java 21
- Errors appear on Java 24, confirming the need for this clarification

## Setup Instructions

No setup changes required. Documentation only.