### PR TITLE
chore(deps): upgrade to Jackson 2.20.0

### DIFF
--- a/core/src/main/java/io/kestra/core/serializers/FileSerde.java
+++ b/core/src/main/java/io/kestra/core/serializers/FileSerde.java
@@ -180,23 +180,13 @@ public final class FileSerde {
     }
 
     private static <T> MappingIterator<T> createMappingIterator(ObjectMapper objectMapper, Reader reader, TypeReference<T> type) throws IOException {
-        // See https://github.com/FasterXML/jackson-dataformats-binary/issues/493
-        // There is a limitation with the MappingIterator that cannot differentiate between an array of things (of whatever shape)
-        // and a sequence/stream of things (of Array shape).
-        // To work around that, we need to create a JsonParser and advance to the first token.
         try (var parser = objectMapper.createParser(reader)) {
-            parser.nextToken();
             return objectMapper.readerFor(type).readValues(parser);
         }
     }
 
     private static <T> MappingIterator<T> createMappingIterator(ObjectMapper objectMapper, Reader reader, Class<T> type) throws IOException {
-        // See https://github.com/FasterXML/jackson-dataformats-binary/issues/493
-        // There is a limitation with the MappingIterator that cannot differentiate between an array of things (of whatever shape)
-        // and a sequence/stream of things (of Array shape).
-        // To work around that, we need to create a JsonParser and advance to the first token.
         try (var parser = objectMapper.createParser(reader)) {
-            parser.nextToken();
             return objectMapper.readerFor(type).readValues(parser);
         }
     }

--- a/platform/build.gradle
+++ b/platform/build.gradle
@@ -21,7 +21,8 @@ dependencies {
     def opensearchVersion = "3.2.0"
     def opensearchRestVersion = "3.2.0"
     def flyingSaucerVersion = "9.13.3"
-    def jacksonVersion = "2.19.2"
+    def jacksonVersion = "2.20.0"
+    def jacksonAnnotationsVersion = "2.20"
     def jugVersion = "5.1.0"
     def langchain4jVersion = "1.4.0"
     def langchain4jCommunityVersion = "1.4.0-beta10"
@@ -51,7 +52,7 @@ dependencies {
         // ugly hack for jackson: as enforcing platform didn't work (it didn't enforce everywhere, not in plugins), we had to force all jackson libs individually.
         api("com.fasterxml.jackson.core:jackson-core:$jacksonVersion")
         api("com.fasterxml.jackson.core:jackson-databind:$jacksonVersion")
-        api("com.fasterxml.jackson.core:jackson-annotations:$jacksonVersion")
+        api("com.fasterxml.jackson.core:jackson-annotations:$jacksonAnnotationsVersion")
         api("com.fasterxml.jackson.module:jackson-module-parameter-names:$jacksonVersion")
         api("com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:$jacksonVersion")
         api("com.fasterxml.jackson.dataformat:jackson-dataformat-smile:$jacksonVersion")


### PR DESCRIPTION
Jackson annotation now uses a version scheme without micro version so it has been updated to 2.20.

Closes #11069
