### PR TITLE
fix(core): make CRC32 for plugin JARs lazy

### DIFF
--- a/core/src/main/java/io/kestra/core/plugins/ExternalPlugin.java
+++ b/core/src/main/java/io/kestra/core/plugins/ExternalPlugin.java
@@ -6,6 +6,12 @@ import lombok.Getter;
 import lombok.ToString;
 
 import java.net.URL;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.Enumeration;
+import java.util.jar.JarEntry;
+import java.util.jar.JarFile;
+import java.util.zip.CRC32;
 
 @AllArgsConstructor
 @Getter
@@ -14,5 +20,59 @@ import java.net.URL;
 public class ExternalPlugin {
     private final URL location;
     private final URL[] resources;
-    private final long crc32;
+    private volatile Long crc32; // lazy-val
+    
+    public ExternalPlugin(URL location, URL[] resources) {
+        this.location = location;
+        this.resources = resources;
+    }
+    
+    public Long getCrc32() {
+        if (this.crc32 == null) {
+            synchronized (this) {
+                if (this.crc32 == null) {
+                    this.crc32 = computeJarCrc32(location);
+                }
+            }
+        }
+        return crc32;
+    }
+    
+    /**
+     * Compute a CRC32 of the JAR File without reading the whole file
+     *
+     * @param location of the JAR File.
+     * @return the CRC32 of {@code -1} if the checksum can't be computed.
+     */
+    private static long computeJarCrc32(final URL location) {
+        CRC32 crc = new CRC32();
+        try (JarFile jar = new JarFile(location.toURI().getPath(), false)) {
+            Enumeration<JarEntry> entries = jar.entries();
+            byte[] buffer = new byte[Long.BYTES]; // reusable buffer to avoid re-allocation
+            
+            while (entries.hasMoreElements()) {
+                JarEntry entry = entries.nextElement();
+                crc.update(entry.getName().getBytes(StandardCharsets.UTF_8));
+                updateCrc32WithLong(crc, buffer, entry.getSize());
+                updateCrc32WithLong(crc, buffer, entry.getCrc());
+            }
+            
+            return crc.getValue();
+        } catch (Exception e) {
+            return -1;
+        }
+    }
+    
+    private static void updateCrc32WithLong(CRC32 crc32, byte[] reusable, long val) {
+        // fast long -> byte conversion
+        reusable[0] = (byte) (val >>> 56);
+        reusable[1] = (byte) (val >>> 48);
+        reusable[2] = (byte) (val >>> 40);
+        reusable[3] = (byte) (val >>> 32);
+        reusable[4] = (byte) (val >>> 24);
+        reusable[5] = (byte) (val >>> 16);
+        reusable[6] = (byte) (val >>> 8);
+        reusable[7] = (byte) val;
+        crc32.update(reusable);;
+    }
 }

--- a/core/src/main/java/io/kestra/core/plugins/PluginResolver.java
+++ b/core/src/main/java/io/kestra/core/plugins/PluginResolver.java
@@ -51,8 +51,7 @@ public class PluginResolver {
                 final List<URL> resources = resolveUrlsForPluginPath(path);
                 plugins.add(new ExternalPlugin(
                     path.toUri().toURL(),
-                    resources.toArray(new URL[0]),
-                    computeJarCrc32(path)
+                    resources.toArray(new URL[0])
                 ));
             }
         } catch (final InvalidPathException | MalformedURLException e) {
@@ -124,33 +123,5 @@ public class PluginResolver {
 
         return urls;
     }
-    
-    
-    /**
-     * Compute a CRC32 of the JAR File without reading the whole file
-     *
-     * @param location of the JAR File.
-     * @return the CRC32 of {@code -1} if the checksum can't be computed.
-     */
-    private static long computeJarCrc32(final Path location) {
-        CRC32 crc = new CRC32();
-        try (JarFile jar = new JarFile(location.toFile(), false)) {
-            Enumeration<JarEntry> entries = jar.entries();
-            while (entries.hasMoreElements()) {
-                JarEntry entry = entries.nextElement();
-                crc.update(entry.getName().getBytes());
-                crc.update(longToBytes(entry.getSize()));
-                crc.update(longToBytes(entry.getCrc()));
-            }
-        } catch (Exception e) {
-            return -1;
-        }
-        return crc.getValue();
-    }
-    
-    private static byte[] longToBytes(long x) {
-        ByteBuffer buffer = ByteBuffer.allocate(Long.BYTES);
-        buffer.putLong(x);
-        return buffer.array();
-    }
+
 }


### PR DESCRIPTION
Make CRC32 calculation for lazy plugin JAR files
to avoid excessive startup time and performance impact.

Avoid byte buffer reallocation while computing CRC32.