### PR TITLE
fixsystem): always load netty from the app classloader

### DIFF
--- a/core/src/main/java/io/kestra/core/plugins/PluginClassLoader.java
+++ b/core/src/main/java/io/kestra/core/plugins/PluginClassLoader.java
@@ -46,6 +46,7 @@ public class PluginClassLoader extends URLClassLoader {
         + "|dev.failsafe"
         + "|reactor"
         + "|io.opentelemetry"
+        + "|io.netty"
         + ")\\..*$");
 
     private final ClassLoader parent;


### PR DESCRIPTION
As Netty is used in core and a lot of plugins, and we already load project reactor from the app classloader that depends in Netty.

Fixes https://github.com/kestra-io/kestra-ee/issues/5038
