### PR TITLE
fix(docs): center main container in DocsLayout

### DIFF
--- a/ui/src/components/docs/DocsLayout.vue
+++ b/ui/src/components/docs/DocsLayout.vue
@@ -14,7 +14,7 @@
                 <slot name="menu" />
             </div>
         </div>
-        <div class="container main-container mx-auto">
+        <div class="container main-container">
             <div class="content">
                 <slot name="content" />
             </div>
@@ -60,6 +60,10 @@
         > div > ul > li > span:first-child {
             font-size: 12px;
         }
+    }
+
+    .main-container {
+        max-width: 100%;
     }
 
     .content {

--- a/ui/src/components/docs/DocsLayout.vue
+++ b/ui/src/components/docs/DocsLayout.vue
@@ -14,7 +14,7 @@
                 <slot name="menu" />
             </div>
         </div>
-        <div class="container main-container">
+        <div class="container main-container mx-auto">
             <div class="content">
                 <slot name="content" />
             </div>


### PR DESCRIPTION
Closes https://github.com/kestra-io/kestra/issues/11077

<img width="1899" height="694" alt="Screenshot 2025-09-11 at 10 55 30" src="https://github.com/user-attachments/assets/111daefe-85bb-4b38-8b23-4053898c2c7c" />
<img width="1906" height="729" alt="Screenshot 2025-09-11 at 10 55 52" src="https://github.com/user-attachments/assets/daf9bf92-d7f5-45e8-8836-0a944b6b219a" />
<img width="1896" height="811" alt="Screenshot 2025-09-11 at 10 55 41" src="https://github.com/user-attachments/assets/41574f3a-bbb7-4881-8125-001c498750ab" />
