### PR TITLE
fix(core): only display close all tabs when there is more than one tab

### DIFF
--- a/ui/src/components/MultiPanelTabs.vue
+++ b/ui/src/components/MultiPanelTabs.vue
@@ -100,7 +100,7 @@
                                             {{ t("multi_panel_editor.move_left") }}
                                         </span>
                                     </el-dropdown-item>
-                                    <el-dropdown-item :icon="Close" @click="closeAllTabs(panelIndex)">
+                                    <el-dropdown-item v-if="panel.tabs.length > 1" :icon="Close" @click="closeAllTabs(panelIndex)">
                                         <span class="small-text">
                                             {{ t("multi_panel_editor.close_all_tabs") }}
                                         </span>


### PR DESCRIPTION
It did not make sense to me and was also confusing to users, that this button would appear even when its effect would only touch th e tab we are on.