### PR TITLE
Revert "chore(sanitycheck): refactor `PurgeCurrentExecutionFiles` (#1…

### DIFF
--- a/core/src/test/java/io/kestra/core/tasks/test/SanityCheckTest.java
+++ b/core/src/test/java/io/kestra/core/tasks/test/SanityCheckTest.java
@@ -70,7 +70,7 @@ class SanityCheckTest {
     @Test
     @ExecuteFlow("sanity-checks/purge_current_execution_files.yaml")
     void qaPurgeExecutionFiles(Execution execution) {
-        assertThat(execution.getTaskRunList()).hasSize(4);
+        assertThat(execution.getTaskRunList()).hasSize(2);
         assertThat(execution.getState().getCurrent()).isEqualTo(State.Type.SUCCESS);
     }
 

--- a/core/src/test/resources/sanity-checks/purge_current_execution_files.yaml
+++ b/core/src/test/resources/sanity-checks/purge_current_execution_files.yaml
@@ -2,28 +2,9 @@ id: purge_current_execution_files
 namespace: sanitychecks.core
 
 tasks:
-  - id: download_file
+  - id: download
     type: io.kestra.plugin.core.http.Download
     uri: https://huggingface.co/datasets/kestra/datasets/raw/main/csv/orders.csv
-    
-  - id: purge_files
+
+  - id: purge
     type: io.kestra.plugin.core.storage.PurgeCurrentExecutionFiles
-
-  # Check if the first purged file URI contains "orders.csv"
-  - id: python_string_check
-    type: io.kestra.plugin.scripts.python.Script
-    env:
-      FILE_STRING: "{{ outputs.purge_files.uris['0'] }}"
-    script: |
-      import os
-      file_path = os.getenv("FILE_STRING", "")
-      print(f"The file string is: {file_path}")
-      if "orders.csv" in file_path:
-          print("It contains orders.csv")
-      else:
-          raise ValueError(f"The file string does not contain 'orders.csv': {file_path}")
-
-  - id: assert
-    type: io.kestra.plugin.core.execution.Assert
-    conditions:
-      - "{{ outputs.python_string_check.exitCode == 0}}"


### PR DESCRIPTION
…1115)"

This reverts commit fc690bf7cd96257829e0e4c323b6ebc7ad2904ab. Python task cannot be used here, it is not available. This commit was wrongly merged with a red CI

- reverts https://github.com/kestra-io/kestra/pull/11115