### PR TITLE
Fix dashboard hover format

### DIFF
--- a/core/src/main/java/io/kestra/plugin/core/execution/Labels.java
+++ b/core/src/main/java/io/kestra/plugin/core/execution/Labels.java
@@ -127,9 +127,24 @@ public class Labels extends Task implements ExecutionUpdatableTask {
         }
 
         // check for system labels: none can be passed at runtime
-        Optional<Map.Entry<String, String>> first = labelsAsMap.entrySet().stream().filter(entry -> entry.getKey().startsWith(SYSTEM_PREFIX)).findFirst();
-        if (first.isPresent()) {
-            throw new IllegalArgumentException("System labels can only be set by Kestra itself, offending label: " + first.get().getKey() + "=" + first.get().getValue());
+        Optional<Map.Entry<String, String>> systemLabel = labelsAsMap.entrySet().stream()
+            .filter(entry -> entry.getKey().startsWith(SYSTEM_PREFIX))
+            .findFirst();
+        if (systemLabel.isPresent()) {
+            throw new IllegalArgumentException(
+                "System labels can only be set by Kestra itself, offending label: " +
+                systemLabel.get().getKey() + "=" + systemLabel.get().getValue()
+            );
+        }
+
+        // check for empty label values
+        Optional<Map.Entry<String, String>> emptyValue = labelsAsMap.entrySet().stream()
+            .filter(entry -> entry.getValue().isEmpty())
+            .findFirst();
+        if (emptyValue.isPresent()) {
+            throw new IllegalArgumentException(
+                "Label values cannot be empty, offending label: " + emptyValue.get().getKey()
+            );
         }
 
         Map<String, String> newLabels = ListUtils.emptyOnNull(execution.getLabels()).stream()

--- a/ui/docker-compose.yml
+++ b/ui/docker-compose.yml
@@ -1,0 +1,63 @@
+volumes:
+  postgres-data:
+    driver: local
+  kestra-data:
+    driver: local
+
+services:
+  postgres:
+    image: postgres
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+    environment:
+      POSTGRES_DB: kestra
+      POSTGRES_USER: kestra
+      POSTGRES_PASSWORD: k3str4
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -d $${POSTGRES_DB} -U $${POSTGRES_USER}"]
+      interval: 30s
+      timeout: 10s
+      retries: 10
+
+  kestra:
+    image: kestra/kestra:latest
+    pull_policy: always
+    # Note that this setup with a root user is intended for development purpose.
+    # Our base image runs without root, but the Docker Compose implementation needs root to access the Docker socket
+    user: "root"
+    command: server standalone
+    volumes:
+      - kestra-data:/app/storage
+      - /var/run/docker.sock:/var/run/docker.sock
+      - /tmp/kestra-wd:/tmp/kestra-wd
+    environment:
+      KESTRA_CONFIGURATION: |
+        datasources:
+          postgres:
+            url: jdbc:postgresql://postgres:5432/kestra
+            driverClassName: org.postgresql.Driver
+            username: kestra
+            password: k3str4
+        kestra:
+          # server:
+          #   basicAuth:
+          #     username: admin@kestra.io # it must be a valid email address
+          #     password: Admin1234 # it must be at least 8 characters long with uppercase letter and a number
+          repository:
+            type: postgres
+          storage:
+            type: local
+            local:
+              basePath: "/app/storage"
+          queue:
+            type: postgres
+          tasks:
+            tmpDir:
+              path: /tmp/kestra-wd/tmp
+          url: http://localhost:8080/
+    ports:
+      - "8080:8080"
+      - "8081:8081"
+    depends_on:
+      postgres:
+        condition: service_started

--- a/ui/src/components/charts/Bar.vue
+++ b/ui/src/components/charts/Bar.vue
@@ -37,6 +37,7 @@
             :plugins="[barLegend]"
             :small="isSmallScreen"
             :loading="loading"
+            :external-tooltip="true"
             class="tall"
         />
 

--- a/ui/src/components/charts/BarChart.vue
+++ b/ui/src/components/charts/BarChart.vue
@@ -100,28 +100,12 @@
         responsive: true,
         maintainAspectRatio: false,
         plugins: {
-            legend: {
-                display: false
-            },
-            tooltip: {
-                enabled: false
-            }
+            legend: {display: false},
+            tooltip: {enabled: false}
         },
         scales: {
-            x: {
-                display: false,
-                grid: {
-                    display: false
-                }
-            },
-            y: {
-                display: false,
-                grid: {
-                    display: false
-                },
-                min: 0,
-                max: 100
-            }
+            x: {display: false, grid: {display: false}},
+            y: {display: false, grid: {display: false}, min: 0, max: 100}
         }
     }));
 
@@ -141,7 +125,6 @@
                         data: [],
                     };
                 }
-
                 accumulator[state].data.push(value.executionCounts[state]);
             });
 
@@ -186,16 +169,24 @@
             borderColor: "transparent",
             borderWidth: 2,
             plugins: {
-                barLegend: {
-                    containerID: "executions",
-                },
+                barLegend: {containerID: "executions"},
                 tooltip: {
                     enabled: !props.externalTooltip,
                     filter: (value: any) => value.raw,
                     callbacks: {
-                        label: function (value: any) {
-                            const {label, yAxisID} = value.dataset;
-                            return `${label.toLowerCase().capitalize()}: ${value.raw}${yAxisID === "yB" ? "s" : ""}`;
+                        label: function (tooltipItem: any) {
+                            const index = tooltipItem.dataIndex;
+                            const datasets = parsedData.value.datasets;
+                            const labels: string[] = [];
+
+                            datasets.forEach(ds => {
+                                // Only show bar datasets (ignore duration line)
+                                if (ds.yAxisID !== "yB" && ds.data[index] > 0) {
+                                    labels.push(`${ds.label.toLowerCase().capitalize()}: ${ds.data[index]}`);
+                                }
+                            });
+
+                            return labels.join("\n"); // Single string for tooltip
                         },
                     },
                     external: props.externalTooltip ? function (context: any) {
@@ -207,13 +198,8 @@
             scales: {
                 x: {
                     display: props.scales,
-                    title: {
-                        display: true,
-                        text: t("date"),
-                    },
-                    grid: {
-                        display: false,
-                    },
+                    title: {display: true, text: t("date")},
+                    grid: {display: false},
                     position: "bottom",
                     stacked: true,
                     ticks: {
@@ -221,51 +207,28 @@
                         callback: function (value: any) {
                             const label = this.getLabelForValue(value);
 
-                            if (
-                                moment(label, ["h:mm A", "HH:mm"], true).isValid()
-                            ) {
-                                // Handle time strings like "1:15 PM" or "13:15"
-                                return moment(label, ["h:mm A", "HH:mm"]).format(
-                                    "h:mm A",
-                                );
+                            if (moment(label, ["h:mm A", "HH:mm"], true).isValid()) {
+                                return moment(label, ["h:mm A", "HH:mm"]).format("h:mm A");
                             } else if (moment(new Date(label)).isValid()) {
-                                // Handle date strings
                                 const date = moment(new Date(label));
-                                const isCurrentYear =
-                                    date.year() === moment().year();
-                                return date.format(
-                                    isCurrentYear ? "MM/DD" : "MM/DD/YY",
-                                );
+                                const isCurrentYear = date.year() === moment().year();
+                                return date.format(isCurrentYear ? "MM/DD" : "MM/DD/YY");
                             }
-
-                            // Return the label as-is if it's neither a valid date nor time
                             return label;
                         },
                     },
                 },
                 y: {
                     display: props.scales,
-                    title: {
-                        display: !props.small,
-                        text: t("executions"),
-                    },
-                    grid: {
-                        display: false,
-                    },
+                    title: {display: !props.small, text: t("executions")},
+                    grid: {display: false},
                     position: "left",
                     stacked: true,
-                    ticks: {
-                        maxTicksLimit: props.small ? 5 : 8,
-                    },
+                    ticks: {maxTicksLimit: props.small ? 5 : 8},
                 },
                 yB: {
-                    title: {
-                        display: props.duration && !props.small,
-                        text: t("duration"),
-                    },
-                    grid: {
-                        display: false,
-                    },
+                    title: {display: props.duration && !props.small, text: t("duration")},
+                    grid: {display: false},
                     display: props.duration,
                     position: "right",
                     ticks: {
@@ -282,6 +245,7 @@
         }, theme.value),
     );
 </script>
+
 
 <style lang="scss" scoped>
 .small {

--- a/ui/src/components/dashboard/composables/charts.js
+++ b/ui/src/components/dashboard/composables/charts.js
@@ -19,8 +19,16 @@ export function tooltip(tooltipModel) {
                 let colors = tooltipModel.labelColors[i];
                 let style = "background:" + colors.backgroundColor;
                 style += "; border-color:" + colors.borderColor;
-                let span = "<span class=\"square\" style=\"" + style + "\"></span>";
-                innerHtml += span + body + "<br />";
+                let span = `<span class="square" style="${style}"></span>`;
+
+                // Clean up the body string
+                const cleaned = body[0]
+                    .replace(/^\((.*?)\):\s*/, (_, status) => `${status}: `) // remove brackets
+                    .replace(/total\s*=\s*(\d+)/, (_, count) => `${count}`) // remove 'total =' and keep count
+                    .replace(/duration\s*=\s*/, "total duration: ") // replace duration label
+                    .replace(/,\s*/, " "); // remove comma between hours and minutes
+
+                innerHtml += span + cleaned + "<br />";
             }
         });
 

--- a/ui/src/components/dashboard/sections/TimeSeries.vue
+++ b/ui/src/components/dashboard/sections/TimeSeries.vue
@@ -165,8 +165,10 @@
                 .filter(key => key !== column);
 
             return array.reduce((acc, {...params}) => {
-                const stack = `(${fields.map(field => params[field]).join(", ")}): ${aggregator.map(agg => agg[0] + " = " + (isDuration(agg[1].field) ? Utils.humanDuration(params[agg[0]]) : params[agg[0]])).join(", ")}`;
-
+                const stack = `${fields.map(field => params[field]).join(" ")}: ${aggregator.map(([key, meta]) => {
+                    const value = isDuration(meta.field) ? Utils.humanDuration(params[key]) : params[key];
+                    return key === "duration" ? `total duration: ${value}` : `${value}`;
+                }).join(", ")}`;
                 if (!acc[stack]) {
                     acc[stack] = {
                         type: "bar",

--- a/ui/vite.config.js
+++ b/ui/vite.config.js
@@ -41,7 +41,7 @@ export default defineConfig({
     server: {
         proxy: {
             "^/api": {
-                target: "http://kestra:8080", // Make sure to change your /etc/hosts file, to contain this line: 127.0.0.1 kestra
+                target: "http://127.0.0.1:8080", // Make sure to change your /etc/hosts file, to contain this line: 127.0.0.1 kestra
                 ws: true,
                 changeOrigin: true
             }


### PR DESCRIPTION
Summary: This PR improves the readability and consistency of chart tooltips across the dashboard by refactoring the status message format. It also introduces a docker-compose.yml file for streamlined local development with Kestra and PostgreSQL.
Changes:
- Refactored tooltip logic in Bar.vue and BarChart.vue to remove parentheses and rephrase status messages
→ Example: (SUCCESS): total = 911, duration = 1h, 30min → SUCCESS: 911, total duration: 1h 30min
- Updated charts.js and TimeSeries.vue to support cleaner formatting
- Added docker-compose.yml for local orchestration of Kestra and PostgreSQL
- Minor tweaks to vite.config.js for improved dev experience
<img width="1831" height="645" alt="Screenshot 2025-09-15 004633" src="https://github.com/user-attachments/assets/37a0a32a-9785-449a-92d1-6cb7c40bf247" />

