### PR TITLE
fix(executions): truncate the execution_running table as in 0.24 ther…

### DIFF
--- a/jdbc-h2/src/main/resources/migrations/h2/V1_42__purge_execution_running.sql
+++ b/jdbc-h2/src/main/resources/migrations/h2/V1_42__purge_execution_running.sql
@@ -1,0 +1,2 @@
+-- We must truncate the table as in 0.24 there was a bug that lead to records not purged in this table
+truncate table execution_running;

--- a/jdbc-mysql/src/main/resources/migrations/mysql/V1_42__purge_execution_running.sql
+++ b/jdbc-mysql/src/main/resources/migrations/mysql/V1_42__purge_execution_running.sql
@@ -1,0 +1,2 @@
+-- We must truncate the table as in 0.24 there was a bug that lead to records not purged in this table
+truncate table execution_running;

--- a/jdbc-postgres/src/main/resources/migrations/postgres/V1_42__purge_execution_running.sql
+++ b/jdbc-postgres/src/main/resources/migrations/postgres/V1_42__purge_execution_running.sql
@@ -1,0 +1,2 @@
+-- We must truncate the table as in 0.24 there was a bug that lead to records not purged in this table
+truncate table execution_running;


### PR DESCRIPTION
…e was an issue in the purge

This table contains executions for flows that have a concurrency that are currently running. It has been added in 0.24 but in that release there was a bug that may prevent some records to being correctly removed from this table. To fix that, we truncate it once.
