### PR TITLE
fix(flows): properly coompute flow dependencies with preconditions

### DIFF
--- a/core/src/main/java/io/kestra/plugin/core/trigger/Flow.java
+++ b/core/src/main/java/io/kestra/plugin/core/trigger/Flow.java
@@ -202,7 +202,7 @@ import static io.kestra.core.utils.Rethrow.throwPredicate;
             code = """
                 id: sentry_execution_example
                 namespace: company.team
-                
+
                 tasks:
                 - id: send_alert
                   type: io.kestra.plugin.notifications.sentry.SentryExecution
@@ -221,7 +221,7 @@ import static io.kestra.core.utils.Rethrow.throwPredicate;
                         - WARNING
                     - type: io.kestra.plugin.core.condition.ExecutionNamespace
                         namespace: company.payroll
-                        prefix: false"""                                
+                        prefix: false"""
         )
 
     },
@@ -403,6 +403,28 @@ public class Flow extends AbstractTrigger implements TriggerOutput<Flow.Output> 
             conditions.putAll(flowsCondition);
             conditions.putAll(whereConditions);
             return conditions;
+        }
+
+        @JsonIgnore
+        public Map<String, Condition> getUpstreamFlowsConditions() {
+            AtomicInteger conditionId = new AtomicInteger();
+            return ListUtils.emptyOnNull(flows).stream()
+                .map(upstreamFlow -> Map.entry(
+                    "condition_" + conditionId.incrementAndGet(),
+                    new UpstreamFlowCondition(upstreamFlow)
+                ))
+                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+        }
+
+        @JsonIgnore
+        public Map<String, Condition> getWhereConditions() {
+            AtomicInteger conditionId = new AtomicInteger();
+            return ListUtils.emptyOnNull(where).stream()
+                .map(filter -> Map.entry(
+                    "condition_" + conditionId.incrementAndGet() + "_" + filter.getId(),
+                    new FilterCondition(filter)
+                ))
+                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
         }
 
         @Override

--- a/core/src/test/java/io/kestra/core/topologies/FlowTopologyServiceTest.java
+++ b/core/src/test/java/io/kestra/core/topologies/FlowTopologyServiceTest.java
@@ -204,6 +204,10 @@ class FlowTopologyServiceTest {
                             io.kestra.plugin.core.trigger.Flow.UpstreamFlow.builder().namespace("io.kestra.ee").flowId("parent").build(),
                             io.kestra.plugin.core.trigger.Flow.UpstreamFlow.builder().namespace("io.kestra.others").flowId("invalid").build()
                         ))
+                        // add an always true condition to validate that it's an AND between 'flows' and 'where'
+                        .where(List.of(io.kestra.plugin.core.trigger.Flow.ExecutionFilter.builder()
+                                .filters(List.of(io.kestra.plugin.core.trigger.Flow.Filter.builder().field(io.kestra.plugin.core.trigger.Flow.Field.EXPRESSION).type(io.kestra.plugin.core.trigger.Flow.Type.IS_NOT_NULL).value("something").build()))
+                            .build()))
                         .build()
                     )
                     .build()


### PR DESCRIPTION
When both upstream flows and where are set, it should be a AND between the two as dependencies must match the upstream flows.

Fixes #11164
