### PR TITLE
fix(core): do not allow empty labels

### DIFF
--- a/core/src/main/java/io/kestra/core/models/flows/AbstractFlow.java
+++ b/core/src/main/java/io/kestra/core/models/flows/AbstractFlow.java
@@ -62,6 +62,7 @@ public abstract class AbstractFlow implements FlowInterface {
     @JsonSerialize(using = ListOrMapOfLabelSerializer.class)
     @JsonDeserialize(using = ListOrMapOfLabelDeserializer.class)
     @Schema(implementation = Object.class, oneOf = {List.class, Map.class})
+    @Valid
     List<Label> labels;
 
     @Schema(additionalProperties = Schema.AdditionalPropertiesValue.TRUE)

--- a/core/src/main/java/io/kestra/plugin/core/execution/Labels.java
+++ b/core/src/main/java/io/kestra/plugin/core/execution/Labels.java
@@ -155,6 +155,7 @@ public class Labels extends Task implements ExecutionUpdatableTask {
         newLabels.putAll(labelsAsMap);
 
         return execution.withLabels(newLabels.entrySet().stream()
+            .filter(Label.getEntryNotEmptyPredicate())
             .map(entry -> new Label(
                 entry.getKey(),
                 entry.getValue()

--- a/core/src/test/java/io/kestra/core/models/LabelTest.java
+++ b/core/src/test/java/io/kestra/core/models/LabelTest.java
@@ -1,19 +1,32 @@
 package io.kestra.core.models;
 
+import io.kestra.core.junit.annotations.KestraTest;
+import io.kestra.core.models.validations.ModelValidator;
+import jakarta.inject.Inject;
+import jakarta.validation.ConstraintViolationException;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+@KestraTest
 class LabelTest {
+    @Inject
+    private ModelValidator modelValidator;
 
     @Test
     void shouldGetNestedMapGivenDistinctLabels() {
         Map<String, Object> result = Label.toNestedMap(List.of(
             new Label(Label.USERNAME, "test"),
-            new Label(Label.CORRELATION_ID, "id"))
+            new Label(Label.CORRELATION_ID, "id"),
+            new Label("", "bar"),
+            new Label(null, "bar"),
+            new Label("foo", ""),
+            new Label("baz", null)
+            )
         );
 
         assertThat(result).isEqualTo(
@@ -32,6 +45,18 @@ class LabelTest {
         assertThat(result).isEqualTo(
             Map.of("system", Map.of("username", "test2", "correlationId", "id"))
         );
+    }
+
+    @Test
+    void toNestedMapShouldIgnoreEmptyOrNull() {
+        Map<String, Object> result = Label.toNestedMap(List.of(
+            new Label("", "bar"),
+            new Label(null, "bar"),
+            new Label("foo", ""),
+            new Label("baz", null))
+        );
+
+        assertThat(result).isEmpty();
     }
 
     @Test
@@ -60,6 +85,18 @@ class LabelTest {
     }
 
     @Test
+    void toMapShouldIgnoreEmptyOrNull() {
+        Map<String, String> result = Label.toMap(List.of(
+            new Label("", "bar"),
+            new Label(null, "bar"),
+            new Label("foo", ""),
+            new Label("baz", null))
+        );
+
+        assertThat(result).isEmpty();
+    }
+
+    @Test
     void shouldDuplicateLabelsWithKeyOrderKept() {
         List<Label> result = Label.deduplicate(List.of(
             new Label(Label.USERNAME, "test1"),
@@ -72,5 +109,29 @@ class LabelTest {
             new Label(Label.USERNAME, "test3"),
             new Label(Label.CORRELATION_ID, "id")
         );
+    }
+
+    @Test
+    void deduplicateShouldIgnoreEmptyAndNull() {
+        List<Label> result = Label.deduplicate(List.of(
+            new Label("", "bar"),
+            new Label(null, "bar"),
+            new Label("foo", ""),
+            new Label("baz", null))
+        );
+
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    void shouldValidateEmpty() {
+        Optional<ConstraintViolationException> validLabelResult = modelValidator.isValid(new Label("foo", "bar"));
+        assertThat(validLabelResult.isPresent()).isFalse();
+
+        Optional<ConstraintViolationException> emptyValueLabelResult = modelValidator.isValid(new Label("foo", ""));
+        assertThat(emptyValueLabelResult.isPresent()).isTrue();
+
+        Optional<ConstraintViolationException> emptyKeyLabelResult = modelValidator.isValid(new Label("", "bar"));
+        assertThat(emptyKeyLabelResult.isPresent()).isTrue();
     }
 }

--- a/core/src/test/java/io/kestra/plugin/core/flow/RuntimeLabelsTest.java
+++ b/core/src/test/java/io/kestra/plugin/core/flow/RuntimeLabelsTest.java
@@ -174,8 +174,8 @@ class RuntimeLabelsTest {
             List.of()
         );
 
-        assertThat(execution.getTaskRunList()).hasSize(2);
-        assertThat(execution.getState().getCurrent()).isEqualTo(State.Type.SUCCESS);
+        assertThat(execution.getTaskRunList()).hasSize(1);
+        assertThat(execution.getState().getCurrent()).isEqualTo(State.Type.FAILED);
 
         assertThat(execution.getLabels()).containsExactly(
             new Label(Label.CORRELATION_ID, execution.getId())

--- a/core/src/test/java/io/kestra/plugin/core/flow/RuntimeLabelsTest.java
+++ b/core/src/test/java/io/kestra/plugin/core/flow/RuntimeLabelsTest.java
@@ -160,4 +160,25 @@ class RuntimeLabelsTest {
             new Label("fromListKey", "value2")
         );
     }
+
+    @Test
+    @LoadFlows({"flows/valids/labels-update-task-empty.yml"})
+    void updateIgnoresEmpty() throws TimeoutException, QueueException {
+        Execution execution = runnerUtils.runOne(
+            MAIN_TENANT,
+            "io.kestra.tests",
+            "labels-update-task-empty",
+            null,
+            (flow, createdExecution) -> Map.of(),
+            null,
+            List.of()
+        );
+
+        assertThat(execution.getTaskRunList()).hasSize(2);
+        assertThat(execution.getState().getCurrent()).isEqualTo(State.Type.SUCCESS);
+
+        assertThat(execution.getLabels()).containsExactly(
+            new Label(Label.CORRELATION_ID, execution.getId())
+        );
+    }
 }

--- a/core/src/test/java/io/kestra/plugin/core/trigger/FlowTest.java
+++ b/core/src/test/java/io/kestra/plugin/core/trigger/FlowTest.java
@@ -168,12 +168,12 @@ class FlowTest {
         Optional<Execution> evaluate = flowTrigger.evaluate(multipleConditionStorage, runContextFactory.of(), flow, execution);
 
         assertThat(evaluate.isPresent()).isTrue();
-        assertThat(evaluate.get().getLabels()).hasSize(6);
+        assertThat(evaluate.get().getLabels()).hasSize(5);
         assertThat(evaluate.get().getLabels()).contains(new Label("flow-label-1", "flow-label-1"));
         assertThat(evaluate.get().getLabels()).contains(new Label("flow-label-2", "flow-label-2"));
         assertThat(evaluate.get().getLabels()).contains(new Label("trigger-label-1", "trigger-label-1"));
         assertThat(evaluate.get().getLabels()).contains(new Label("trigger-label-2", "trigger-label-2"));
-        assertThat(evaluate.get().getLabels()).contains(new Label("trigger-label-3", ""));
+        assertThat(evaluate.get().getLabels()).doesNotContain(new Label("trigger-label-3", ""));
         assertThat(evaluate.get().getLabels()).contains(new Label(Label.CORRELATION_ID, "correlationId"));
         assertThat(evaluate.get().getTrigger()).extracting(ExecutionTrigger::getVariables).hasFieldOrProperty("executionLabels");
         assertThat(evaluate.get().getTrigger().getVariables().get("executionLabels")).isEqualTo(Map.of("execution-label", "execution"));

--- a/core/src/test/java/io/kestra/plugin/core/trigger/ScheduleTest.java
+++ b/core/src/test/java/io/kestra/plugin/core/trigger/ScheduleTest.java
@@ -169,7 +169,7 @@ class ScheduleTest {
         assertThat(evaluate.isPresent()).isTrue();
         assertThat(evaluate.get().getLabels()).contains(new Label("trigger-label-1", "trigger-label-1"));
         assertThat(evaluate.get().getLabels()).contains(new Label("trigger-label-2", "trigger-label-2"));
-        assertThat(evaluate.get().getLabels()).contains(new Label("trigger-label-3", ""));
+        assertThat(evaluate.get().getLabels()).doesNotContain(new Label("trigger-label-3", ""));
     }
 
     @Test

--- a/core/src/test/resources/flows/valids/labels-update-task-empty.yml
+++ b/core/src/test/resources/flows/valids/labels-update-task-empty.yml
@@ -1,0 +1,14 @@
+id: labels-update-task-empty
+namespace: io.kestra.tests
+
+tasks:
+  - id: from-string
+    type: io.kestra.plugin.core.execution.Labels
+    labels: "{ \"fromStringKey\": \"\", \"\": \"value2\" }"
+  - id: from-list
+    type: io.kestra.plugin.core.execution.Labels
+    labels:
+      - key: "fromListKey"
+        value: ""
+      - key: ""
+        value: "value2"

--- a/ui/src/components/executions/Executions.vue
+++ b/ui/src/components/executions/Executions.vue
@@ -504,7 +504,7 @@
     import YAML_CHART from "../dashboard/assets/executions_timeseries_chart.yaml?raw";
     import Utils from "../../utils/utils";
 
-    import {filterLabels} from "./utils"
+    import {filterValidLabels} from "./utils"
     import {useExecutionsStore} from "../../stores/executions";
     import {useAuthStore} from "override/stores/auth";
     import {useFlowStore} from "../../stores/flow";
@@ -1055,9 +1055,9 @@
                 );
             },
             setLabels() {
-                const filtered = filterLabels(this.executionLabels)
+                const filtered = filterValidLabels(this.executionLabels)
 
-                if(filtered.error) {
+                if (filtered.error) {
                     this.$toast().error(this.$t("wrong labels"))
                     return;
                 }

--- a/ui/src/components/executions/SetLabels.vue
+++ b/ui/src/components/executions/SetLabels.vue
@@ -55,7 +55,7 @@
     import LabelInput from "../../components/labels/LabelInput.vue";
     import {State} from "@kestra-io/ui-libs"
 
-    import {filterLabels} from "./utils"
+    import {filterValidLabels} from "./utils"
     import permission from "../../models/permission";
     import action from "../../models/action";
     import {useAuthStore} from "override/stores/auth"
@@ -78,10 +78,11 @@
         },
         methods: {
             setLabels() {
-                let filtered = filterLabels(this.executionLabels)
+                const filtered = filterValidLabels(this.executionLabels)
 
-                if(filtered.error) {
-                    filtered.labels = filtered.labels.filter(obj => !(obj.key === null && obj.value === null));
+                if (filtered.error) {
+                    this.$toast().error(this.$t("wrong labels"))
+                    return;
                 }
 
                 this.isOpen = false;

--- a/ui/src/components/executions/utils.ts
+++ b/ui/src/components/executions/utils.ts
@@ -8,7 +8,7 @@ interface FilterResult {
     error?: boolean;
 }
 
-export const filterLabels = (labels: Label[]): FilterResult => {
-    const invalid = labels.some(label => label.key === null || label.value === null || label.key === "" || label.value === "");
-    return invalid ? {labels, error: true} : {labels};
+export const filterValidLabels = (labels: Label[]): FilterResult => {
+    const validLabels = labels.filter(label => label.key !== null && label.value !== null && label.key !== "" && label.value !== "");
+    return validLabels.length === labels.length ? {labels} : {labels: validLabels, error: true};
 };


### PR DESCRIPTION
### What changes are being made and why?

* Filtered empty  entries on Labels task.
* Checking empty Flow labels via validation.
* Adjusted UI to disallow setting empty labels.

closes #11227

I feel like this PR still doesn't cover all possible ways of setting labels. Feel free to suggest more.

Related to https://github.com/kestra-io/kestra/pull/11273.