### PR TITLE
chore(build): trigger docker build on pull requests to releases/* branches

### DIFF
--- a/.github/workflows/workflow-pullrequest-publish-docker.yml
+++ b/.github/workflows/workflow-pullrequest-publish-docker.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches:
       - develop
+      - releases/*
 
 jobs:
   build-artifacts:


### PR DESCRIPTION
Updated the workflow so it runs automatically when a pull request targets any `releases/*` branch.