### PR TITLE
Fix: webhook tenant URL authentication issue

### DIFF
--- a/cli/src/main/resources/application.yml
+++ b/cli/src/main/resources/application.yml
@@ -167,6 +167,8 @@ kestra:
       open-urls:
         - "/ping"
         - "/api/v1/executions/webhook/"
+        - "/api/v1/main/executions/webhook/"
+        - "/api/v1/*/executions/webhook/"
 
     preview:
       initial-rows: 100

--- a/ui/src/components/flows/WebhookCurl.vue
+++ b/ui/src/components/flows/WebhookCurl.vue
@@ -35,7 +35,7 @@
     import {useI18n} from "vue-i18n";
     import CopyToClipboard from "../layout/CopyToClipboard.vue";
     import Editor from "../inputs/Editor.vue";
-    import {baseUrl, basePathWithoutTenant, apiUrlWithoutTenants} from "../../override/utils/route";
+    import {baseUrl, basePath, apiUrl, basePathWithoutTenant, apiUrlWithoutTenants} from "../../override/utils/route";
     import {useFlowStore} from "../../stores/flow";
 
     interface Flow {
@@ -73,7 +73,7 @@
     });
 
     const generateWebhookUrl = (trigger: Trigger): string => {
-        const origin = baseUrl ? apiUrlWithoutTenants() : `${location.origin}${basePathWithoutTenant()}`;
+        const origin = baseUrl ? apiUrl() : `${location.origin}${basePath()}`;
         return `${origin}/executions/webhook/${props.flow.namespace}/${props.flow.id}/${trigger.key}`;
     };
 


### PR DESCRIPTION
## Description
Fixes #11388 

### Issue with Webhook URL Generation (BUG1):
- The UI was incorrectly generating webhook URLs without tenant information, even when a tenant was configured.
- The function used `apiUrlWithoutTenants()` which did not include the tenant-specific part of the URL.
- This fix updates the URL generation to use `apiUrl()` instead of `apiUrlWithoutTenants()`, ensuring that the correct tenant path is included in the generated webhook URLs.

**File Updated:** `ui/src/components/flows/WebhookCurl.vue`
- Line 76-77: Modified the webhook URL generation logic to include the tenant path.

### Authentication Configuration Blocking Tenant Webhook URLs (BUG2):
- Webhook URLs with tenant information were being blocked by the authentication configuration.
- The authentication setup only allowed non-tenant paths (i.e., `/api/v1/executions/webhook/`) and did not account for tenant-specific URLs (i.e., `/api/v1/{tenant}/executions/webhook/`).
- The fix updates the authentication configuration to allow both non-tenant and tenant-specific webhook URLs by adding a pattern that covers tenant paths.

**File Updated:** `cli/src/main/resources/application.yml`
- Line 171: Added `/api/v1/*/executions/webhook/` to the open-urls list to allow tenant-specific webhook URLs.

## Summary of Changes:
- **Webhook URL Generation:** The UI now generates correct tenant-aware webhook URLs.
- **Authentication Configuration:** The authentication system now supports both non-tenant and tenant-specific webhook paths without causing unauthorized errors.

