### PR TITLE
chore(namespaces): add disabled attribute to typescript interface for namespace tabs

### DIFF
--- a/ui/src/components/namespaces/utils/useHelpers.ts
+++ b/ui/src/components/namespaces/utils/useHelpers.ts
@@ -11,6 +11,7 @@ import NamespaceFilesEditorView from "../../../components/namespaces/components/
 
 export interface Tab {
     locked?: boolean;
+    disabled?: boolean;
     maximized?: boolean;
 
     name: string;


### PR DESCRIPTION
Related to https://github.com/kestra-io/kestra-ee/issues/4726.