### PR TITLE
fix(no-code): allow specifying type for flow outputs (#11304)

### DIFF
--- a/ui/src/components/no-code/components/tasks/TaskObject.vue
+++ b/ui/src/components/no-code/components/tasks/TaskObject.vue
@@ -130,8 +130,13 @@
 
     const filteredProperties = computed<Entry[]>(() => {
         const propertiesProc = (props.properties ?? props.schema?.properties);
+        const isOutputsContext = props.root?.startsWith("outputs[") || false;
         return propertiesProc
-            ? (Object.entries(propertiesProc) as Entry[]).filter(([key, value]) => key !== "type" && !Array.isArray(value))
+            ? (Object.entries(propertiesProc) as Entry[]).filter(([key, value]) => {
+                // Allow "type" field for outputs context, filter it out for other contexts
+                const shouldFilterType = key === "type" && !isOutputsContext;
+                return !shouldFilterType && !Array.isArray(value);
+            })
             : [];
     });
 

--- a/ui/src/components/no-code/utils/useFlowFields.ts
+++ b/ui/src/components/no-code/utils/useFlowFields.ts
@@ -23,6 +23,7 @@ export const SECTIONS_IDS = [
     "finally",
     "afterExecution",
     "pluginDefaults",
+    "outputs",
 ]
 
 // once all those fields are displayed, the rest of the fields are displayed


### PR DESCRIPTION

**PR Description:**
closes #11304 

**Summary**

* Added missing **"type"** field for flow outputs in the no-code editor
* Made outputs section more accessible in the main no-code interface

**Problem**

Previously, when defining flow-level outputs in the no-code editor, there was no option to set the **"type"** (e.g., STRING, URI, BOOLEAN). Since type is a required property, this led to validation errors and incomplete configurations.

**Solution**

1. Updated **TaskObject** to display the "type" field when editing flow outputs (detected by checking if the field path starts with `outputs[`).
2. Added **"outputs"** to the primary no-code editor sections so outputs appear alongside tasks and triggers rather than hidden in alphabetical listings.

**Test Plan**

* Open a flow in the no-code editor
*  Add a new output under the outputs section
*  Confirm that the "type" field is visible and editable
*  Verify the outputs section appears in the main interface sections
*  Ensure task-level type fields remain correctly filtered