### PR TITLE
fix(core): Add warning logs for mismatched (Parent-Subflow) inputs 

### DIFF
--- a/core/src/main/java/io/kestra/core/runners/ExecutableUtils.java
+++ b/core/src/main/java/io/kestra/core/runners/ExecutableUtils.java
@@ -164,17 +164,16 @@ public final class ExecutableUtils {
                 Set<String> declaredInputs = flow.getInputs().stream().map(Input::getId).collect(Collectors.toSet());
                 for (var inputKey : inputs.keySet()) {
                     if (!declaredInputs.contains(inputKey)) {
-                        String log = String.format(
-                            "Input %s was provided by parent execution %s for subflow %s.%s but isn't declared at the subflow inputs",
+                        runContext.logger().warn(
+                            "Input {} was provided by parent execution {} for subflow {}.{} but isn't declared at the subflow inputs",
                             inputKey,
                             currentExecution.getId(),
                             currentTask.subflowId().namespace(),
                             currentTask.subflowId().flowId()
                         );
-                        runContext.logger().warn(log);
                     }
                 }
-            List<Label> newLabels = inheritLabels ? new ArrayList<>(filterLabels(currentExecution.getLabels(), flow)) : new ArrayList<>(systemLabels(currentExecution));
+                List<Label> newLabels = inheritLabels ? new ArrayList<>(filterLabels(currentExecution.getLabels(), flow)) : new ArrayList<>(systemLabels(currentExecution));
             if (labels != null) {
                 labels.forEach(throwConsumer(label -> newLabels.add(new Label(runContext.render(label.key()), runContext.render(label.value())))));
             }

--- a/core/src/main/java/io/kestra/core/runners/ExecutableUtils.java
+++ b/core/src/main/java/io/kestra/core/runners/ExecutableUtils.java
@@ -160,19 +160,6 @@ public final class ExecutableUtils {
             if (flow instanceof FlowWithException fwe) {
                 throw new IllegalStateException("Cannot execute an invalid flow: " + fwe.getException());
             }
-
-                Set<String> declaredInputs = flow.getInputs().stream().map(Input::getId).collect(Collectors.toSet());
-                for (var inputKey : inputs.keySet()) {
-                    if (!declaredInputs.contains(inputKey)) {
-                        runContext.logger().warn(
-                            "Input {} was provided by parent execution {} for subflow {}.{} but isn't declared at the subflow inputs",
-                            inputKey,
-                            currentExecution.getId(),
-                            currentTask.subflowId().namespace(),
-                            currentTask.subflowId().flowId()
-                        );
-                    }
-                }
                 List<Label> newLabels = inheritLabels ? new ArrayList<>(filterLabels(currentExecution.getLabels(), flow)) : new ArrayList<>(systemLabels(currentExecution));
             if (labels != null) {
                 labels.forEach(throwConsumer(label -> newLabels.add(new Label(runContext.render(label.key()), runContext.render(label.value())))));
@@ -211,7 +198,20 @@ public final class ExecutableUtils {
                     .build()
                 )
                 .withScheduleDate(scheduleOnDate);
-
+                if(execution.getInputs().size()<inputs.size()) {
+                    Map<String,Object>resolvedInputs=execution.getInputs();
+                    for (var inputKey : inputs.keySet()) {
+                        if (!resolvedInputs.containsKey(inputKey)) {
+                            runContext.logger().warn(
+                                "Input {} was provided by parent execution {} for subflow {}.{} but isn't declared at the subflow inputs",
+                                inputKey,
+                                currentExecution.getId(),
+                                currentTask.subflowId().namespace(),
+                                currentTask.subflowId().flowId()
+                            );
+                        }
+                    }
+                }
             // inject the traceparent into the new execution
             propagator.ifPresent(pg -> pg.inject(Context.current(), execution, ExecutionTextMapSetter.INSTANCE));
 

--- a/core/src/main/java/io/kestra/core/runners/ExecutableUtils.java
+++ b/core/src/main/java/io/kestra/core/runners/ExecutableUtils.java
@@ -5,10 +5,7 @@ import io.kestra.core.exceptions.IllegalVariableEvaluationException;
 import io.kestra.core.exceptions.InternalException;
 import io.kestra.core.models.Label;
 import io.kestra.core.models.executions.*;
-import io.kestra.core.models.flows.Flow;
-import io.kestra.core.models.flows.FlowInterface;
-import io.kestra.core.models.flows.FlowWithException;
-import io.kestra.core.models.flows.State;
+import io.kestra.core.models.flows.*;
 import io.kestra.core.models.property.Property;
 import io.kestra.core.models.tasks.ExecutableTask;
 import io.kestra.core.models.tasks.Task;
@@ -29,6 +26,7 @@ import org.apache.commons.lang3.stream.Streams;
 import java.time.Instant;
 import java.time.ZonedDateTime;
 import java.util.*;
+import java.util.stream.Collectors;
 
 import static io.kestra.core.trace.Tracer.throwCallable;
 import static io.kestra.core.utils.Rethrow.throwConsumer;
@@ -163,6 +161,19 @@ public final class ExecutableUtils {
                 throw new IllegalStateException("Cannot execute an invalid flow: " + fwe.getException());
             }
 
+                Set<String> declaredInputs = flow.getInputs().stream().map(Input::getId).collect(Collectors.toSet());
+                for (var inputKey : inputs.keySet()) {
+                    if (!declaredInputs.contains(inputKey)) {
+                        String log = String.format(
+                            "Input %s was provided by parent execution %s for subflow %s.%s but isn't declared at the subflow inputs",
+                            inputKey,
+                            currentExecution.getId(),
+                            currentTask.subflowId().namespace(),
+                            currentTask.subflowId().flowId()
+                        );
+                        runContext.logger().warn(log);
+                    }
+                }
             List<Label> newLabels = inheritLabels ? new ArrayList<>(filterLabels(currentExecution.getLabels(), flow)) : new ArrayList<>(systemLabels(currentExecution));
             if (labels != null) {
                 labels.forEach(throwConsumer(label -> newLabels.add(new Label(runContext.render(label.key()), runContext.render(label.value())))));


### PR DESCRIPTION
Closes #11372

### Description
This PR adds warning logs when inputs are passed from a parent workflow but are not declared in the subflow.  
This ensures better visibility for users and improves the overall experience by making it clear which inputs are ignored by the subflow.
<img width="1402" height="378" alt="subflow" src="https://github.com/user-attachments/assets/1edb6cb4-ea4c-4d12-bc69-d909b6dda12f" />
