### PR TITLE
feat(ui/admin): add backfill execution to Admin Triggers

### DIFF
--- a/ui/src/components/admin/Triggers.vue
+++ b/ui/src/components/admin/Triggers.vue
@@ -195,27 +195,21 @@
                         </el-table-column>
                         <el-table-column :label="$t('backfill')" columnKey="backfill">
                             <template #default="scope">
-                                <div class="backfillContainer items-center gap-2">
-                                    <span v-if="scope.row.backfill" class="statusIcon">
-                                        <el-tooltip v-if="!scope.row.backfill.paused" :content="$t('backfill running')" effect="light">
-                                            <PlayBox font />
-                                        </el-tooltip>
-                                        <el-tooltip v-else :content="$t('backfill paused')">
-                                            <PauseBox />
-                                        </el-tooltip>
-                                    </span>
-
-                                    <el-button
-                                        :icon="CalendarCollapseHorizontalOutline"
-                                        v-if="authStore.user.hasAnyAction(permission.EXECUTION, action.UPDATE)"
-                                        @click="restart(scope.row)"
-                                        size="small"
-                                        type="primary"
-                                        :disabled="scope.row.disabled || scope.row.codeDisabled"
-                                    >
-                                        {{ $t("backfill executions") }}
-                                    </el-button>
-                                </div>
+                                <BackfillCell
+                                    :trigger="scope.row"
+                                    :canCreate="authStore.user.hasAnyAction(permission.EXECUTION, action.CREATE)"
+                                    :canUpdate="authStore.user.hasAnyAction(permission.EXECUTION, action.UPDATE)"
+                                    @open-backfill="openBackfill(scope.row)"
+                                    @updated="(newTrigger) => { 
+                                        $toast().saved(newTrigger.id);
+                                        triggers = triggers.map(t => {
+                                            return t.id === newTrigger.id 
+                                                ? {abstractTrigger: t.abstractTrigger, triggerContext: newTrigger}
+                                                : t;
+                                        });
+                                        triggerLoadDataAfterBulkEditAction();
+                                    }"
+                                />
                             </template>
                         </el-table-column>
 
@@ -245,6 +239,25 @@
                 </template>
             </DataTable>
 
+            <BackfillDialog
+                v-model="isBackfillOpen"
+                v-if="selectedTrigger"
+                :namespace="selectedTrigger.namespace"
+                :flowId="selectedTrigger.flowId"
+                :trigger="selectedTrigger"
+                :backfillRouteName="null"
+                @updated="(newTrigger) => { 
+                    triggers = triggers.map(t => {
+                        return t.id === newTrigger.id 
+                            ? {abstractTrigger: t.abstractTrigger, triggerContext: newTrigger}
+                            : t;
+                    });
+                    isBackfillOpen = false; 
+                    selectedTrigger = null; 
+                    triggerLoadDataAfterBulkEditAction();
+                }"
+            />
+
             <el-dialog v-model="triggerToUnlock" destroyOnClose :appendToBody="true">
                 <template #header>
                     <span v-html="$t('unlock trigger.confirmation')" />
@@ -259,10 +272,8 @@
         </div>
     </section>
 </template>
-<script setup>
+<script lang="ts" setup>
     import LockOff from "vue-material-design-icons/LockOff.vue";
-    import PlayBox from "vue-material-design-icons/PlayBox.vue";
-    import PauseBox from "vue-material-design-icons/PauseBox.vue";
     import Kicon from "../Kicon.vue";
     import permission from "../../models/permission";
     import action from "../../models/action";
@@ -271,10 +282,11 @@
     import SelectTable from "../layout/SelectTable.vue";
     import BulkSelect from "../layout/BulkSelect.vue";
     import TriggerAvatar from "../flows/TriggerAvatar.vue";
-    import CalendarCollapseHorizontalOutline from "vue-material-design-icons/CalendarCollapseHorizontalOutline.vue";
     import TriggerFilterLanguage from "../../composables/monaco/languages/filters/impl/triggerFilterLanguage";
+    import BackfillCell from "../flows/BackfillCell.vue";
+    import BackfillDialog from "../flows/BackfillDialog.vue";
 </script>
-<script>
+<script lang="ts">
     import RouteContext from "../../mixins/routeContext";
     import RestoreUrl from "../../mixins/restoreUrl";
     import DataTable from "../layout/DataTable.vue";
@@ -299,13 +311,17 @@
             DataTable,
             DateAgo,
             Id,
-            LogsWrapper
+            LogsWrapper,
+            BackfillCell,
+            BackfillDialog
         },
         data() {
             return {
                 triggers: undefined,
                 total: undefined,
                 triggerToUnlock: undefined,
+                isBackfillOpen: false,
+                selectedTrigger: null,
                 states: [
                     {label: this.$t("triggers_state.options.enabled"), value: "ENABLED"},
                     {label: this.$t("triggers_state.options.disabled"), value: "DISABLED"}
@@ -314,6 +330,10 @@
             };
         },
         methods: {
+            openBackfill(trigger) {
+                this.selectedTrigger = trigger;
+                this.isBackfillOpen = true;
+            },
             hasLogsContent(row) {
                 return row.logs && row.logs.length > 0;
             },
@@ -609,7 +629,7 @@
         }
     }
 </style>
-<style lang="scss">
+<style lang="scss" scoped>
 .wide-tooltip {
     max-width: 400px;
     white-space: normal;

--- a/ui/src/components/flows/BackfillCell.vue
+++ b/ui/src/components/flows/BackfillCell.vue
@@ -1,0 +1,98 @@
+<template>
+    <div class="backfill-cell">
+        <el-button
+            :icon="CalendarCollapseHorizontalOutline"
+            v-if="isSchedule(trigger.type) && !trigger.backfill && canCreate"
+            @click="$emit('open-backfill', trigger)"
+            :disabled="trigger.disabled || trigger.sourceDisabled || trigger.codeDisabled"
+            size="small"
+            type="primary"
+        >
+            {{ $t("backfill executions") }}
+        </el-button>
+
+        <template v-else-if="isSchedule(trigger.type) && canUpdate && trigger.backfill">
+            <div class="progress-cell">
+                <el-progress
+                    :percentage="backfillProgression(trigger.backfill)"
+                    :status="trigger.backfill.paused ? 'warning' : ''"
+                    :stroke-width="12"
+                    :showText="!trigger.backfill.paused"
+                    :striped="!trigger.backfill.paused"
+                    stripedFlow
+                />
+            </div>
+            <template v-if="!trigger.backfill.paused">
+                <el-button size="small" @click="pauseBackfill(trigger)">
+                    <Kicon :tooltip="$t('pause backfill')">
+                        <Pause />
+                    </Kicon>
+                </el-button>
+            </template>
+            <template v-else>
+                <el-button size="small" @click="unpauseBackfill(trigger)">
+                    <Kicon :tooltip="$t('continue backfill')">
+                        <Play />
+                    </Kicon>
+                </el-button>
+                <el-button size="small" @click="deleteBackfill(trigger)">
+                    <Kicon :tooltip="$t('delete backfill')">
+                        <Delete />
+                    </Kicon>
+                </el-button>
+            </template>
+        </template>
+    </div>
+</template>
+
+<script lang="ts" setup>
+    import Pause from "vue-material-design-icons/Pause.vue";
+    import Play from "vue-material-design-icons/Play.vue";
+    import Delete from "vue-material-design-icons/Delete.vue";
+    import CalendarCollapseHorizontalOutline from "vue-material-design-icons/CalendarCollapseHorizontalOutline.vue";
+    import Kicon from "../Kicon.vue";
+    import moment from "moment";
+    import {useTriggerStore} from "../../stores/trigger";
+
+    type Backfill = { start: string; end: string; currentDate: string; paused?: boolean } | any;
+
+    defineProps<{
+        trigger: any,
+        canCreate?: boolean,
+        canUpdate?: boolean
+    }>();
+
+    const emit = defineEmits(["open-backfill", "updated"]);
+
+    const triggerStore = useTriggerStore();
+
+    function backfillProgression(backfill: Backfill) {
+        const startMoment = moment(backfill.start);
+        const endMoment = moment(backfill.end);
+        const currentMoment = moment(backfill.currentDate);
+        const totalDuration = endMoment.diff(startMoment);
+        const elapsedDuration = currentMoment.diff(startMoment);
+        return Math.round((elapsedDuration / totalDuration) * 100);
+    }
+
+    function isSchedule(type: string) {
+        return type === "io.kestra.plugin.core.trigger.Schedule" || type === "io.kestra.core.models.triggers.types.Schedule";
+    }
+
+    function pauseBackfill(trigger: any) {
+        triggerStore.pauseBackfill(trigger).then(newTrigger => emit("updated", newTrigger));
+    }
+
+    function unpauseBackfill(trigger: any) {
+        triggerStore.unpauseBackfill(trigger).then(newTrigger => emit("updated", newTrigger));
+    }
+
+    function deleteBackfill(trigger: any) {
+        triggerStore.deleteBackfill(trigger).then(newTrigger => emit("updated", newTrigger));
+    }
+</script>
+
+<style scoped>
+    .backfill-cell { display: flex; align-items: center; }
+    .progress-cell { width: 200px; margin-right: 1em; }
+</style>

--- a/ui/src/components/flows/BackfillDialog.vue
+++ b/ui/src/components/flows/BackfillDialog.vue
@@ -1,0 +1,161 @@
+<template>
+    <el-dialog v-model="internalOpen" destroyOnClose :appendToBody="true">
+        <template #header>
+            <span v-html="$t('backfill executions')" />
+        </template>
+        <el-form :model="backfill" labelPosition="top">
+            <div class="pickers">
+                <div class="small-picker">
+                    <el-form-item label="Start">
+                        <el-date-picker
+                            v-model="backfill.start"
+                            type="datetime"
+                            placeholder="Start"
+                            :disabledDate="time => new Date() < time || backfill.end ? time > backfill.end : false"
+                        />
+                    </el-form-item>
+                </div>
+                <div class="small-picker">
+                    <el-form-item label="End">
+                        <el-date-picker
+                            v-model="backfill.end"
+                            type="datetime"
+                            placeholder="End"
+                            :disabledDate="time => new Date() < time || backfill?.start > time"
+                        />
+                    </el-form-item>
+                </div>
+            </div>
+        </el-form>
+        <FlowRun
+            @update-inputs="backfill.inputs = $event"
+            @update-labels="backfill.labels = $event"
+            :selectedTrigger="trigger"
+            :redirect="false"
+            :embed="true"
+        />
+        <template #footer>
+            <router-link
+                v-if="isSchedule(trigger.type) && backfillRouteName"
+                :to="{name: backfillRouteName, query:{namespace, flowId, q: trigger.triggerId}}"
+            >
+                <el-button class="me-2">
+                    {{ $t('backfill') }}
+                </el-button>
+            </router-link>
+            <el-button
+                type="primary"
+                @click="postBackfill()"
+                :disabled="checkBackfill"
+            >
+                {{ $t("execute backfill") }}
+            </el-button>
+        </template>
+    </el-dialog>
+</template>
+
+<script setup lang="ts">
+    import FlowRun from "./FlowRun.vue";
+</script>
+
+<script lang="ts">
+    import {mapStores} from "pinia";
+    import {useExecutionsStore} from "../../stores/executions";
+    import {useTriggerStore} from "../../stores/trigger";
+
+    export default {
+        name: "BackfillDialog",
+        props: {
+            modelValue: {type: Boolean, default: false},
+            namespace: {type: String, required: true},
+            flowId: {type: String, required: true},
+            trigger: {type: Object, required: true},
+            backfillRouteName: {type: String, default: "admin/triggers"}
+        },
+        emits: ["update:modelValue", "updated"],
+        data() {
+            return {
+                backfill: {start: null, end: null, inputs: null, labels: []},
+                internalOpen: this.modelValue
+            }
+        },
+        computed: {
+            ...mapStores(useExecutionsStore, useTriggerStore),
+            checkBackfill() {
+                if (!this.backfill.start) return true;
+                if (this.backfill.end && this.backfill.start > this.backfill.end) return true;
+                const flow = this.executionsStore.flow;
+                if (flow?.inputs?.length) {
+                    const requiredInputs = flow.inputs.map(input => input.required !== false ? input.id : null).filter(i => i !== null);
+                    if (requiredInputs.length > 0) {
+                        if (!this.backfill.inputs) return true;
+                        const fillInputs = Object.keys(this.backfill.inputs).filter(i => this.backfill.inputs[i] !== null && this.backfill.inputs[i] !== undefined);
+                        if (requiredInputs.sort().join(",") !== fillInputs.sort().join(",")) return true;
+                    }
+                }
+                if (this.backfill.labels.length > 0) {
+                    for (let label of this.backfill.labels) {
+                        if ((label.key && !label.value) || (!label.key && label.value)) return true;
+                    }
+                }
+                return false;
+            }
+        },
+        watch: {
+            modelValue: {
+                immediate: true,
+                handler(val) {
+                    this.internalOpen = val;
+                    if (val) this.ensureFlowLoaded();
+                }
+            },
+            internalOpen(val) {
+                this.$emit("update:modelValue", val);
+            },
+            namespace() {
+                if (this.internalOpen) this.ensureFlowLoaded();
+            },
+            flowId() {
+                if (this.internalOpen) this.ensureFlowLoaded();
+            },
+            "executionsStore.flow": {handler() {}, deep: false}
+        },
+        methods: {
+            async ensureFlowLoaded() {
+                await this.executionsStore.loadFlowForExecution({
+                    namespace: this.namespace,
+                    flowId: this.flowId,
+                    store: true
+                });
+            },
+            isSchedule(type) {
+                return type === "io.kestra.plugin.core.trigger.Schedule" || type === "io.kestra.core.models.triggers.types.Schedule";
+            },
+            async postBackfill() {
+                const cleanBackfill = {
+                    ...this.backfill,
+                    labels: this.backfill.labels.filter(label => label.key && label.value)
+                };
+                const updated = await this.triggerStore.update({
+                    ...this.trigger,
+                    backfill: cleanBackfill
+                });
+                this.$toast().saved(updated.id);
+                this.$emit("updated", updated);
+                this.internalOpen = false;
+                this.backfill = {start: null, end: null, inputs: null, labels: []};
+            }
+        }
+    }
+</script>
+
+<style scoped>
+    .pickers {
+        display: flex;
+        justify-content: space-between;
+
+        .small-picker { width: 49%; }
+    }
+</style>
+
+

--- a/ui/src/components/flows/FlowTriggers.vue
+++ b/ui/src/components/flows/FlowTriggers.vue
@@ -52,50 +52,13 @@
                 {{ $t("backfill") }}
             </template>
             <template #default="scope">
-                <el-button
-                    :icon="CalendarCollapseHorizontalOutline"
-                    v-if="isSchedule(scope.row.type) && !scope.row.backfill && userCan(action.CREATE)"
-                    @click="setBackfillModal(scope.row, true)"
-                    :disabled="scope.row.disabled || scope.row.sourceDisabled"
-                    size="small"
-                    type="primary"
-                >
-                    {{ $t("backfill executions") }}
-                </el-button>
-                <template v-else-if="isSchedule(scope.row.type) && userCan(action.UPDATE)">
-                    <div class="backfill-cell">
-                        <div class="progress-cell">
-                            <el-progress
-                                :percentage="backfillProgression(scope.row.backfill)"
-                                :status="scope.row.backfill.paused ? 'warning' : ''"
-                                :stroke-width="12"
-                                :showText="!scope.row.backfill.paused"
-                                :striped="!scope.row.backfill.paused"
-                                stripedFlow
-                            />
-                        </div>
-                        <template v-if="!scope.row.backfill.paused">
-                            <el-button size="small" @click="pauseBackfill(scope.row)">
-                                <Kicon :tooltip="$t('pause backfill')">
-                                    <Pause />
-                                </Kicon>
-                            </el-button>
-                        </template>
-                        <template v-else-if="userCan(action.UPDATE)">
-                            <el-button size="small" @click="unpauseBackfill(scope.row)">
-                                <Kicon :tooltip="$t('continue backfill')">
-                                    <Play />
-                                </Kicon>
-                            </el-button>
-
-                            <el-button size="small" @click="deleteBackfill(scope.row)">
-                                <Kicon :tooltip="$t('delete backfill')">
-                                    <Delete />
-                                </Kicon>
-                            </el-button>
-                        </template>
-                    </div>
-                </template>
+                <BackfillCell
+                    :trigger="scope.row"
+                    :canCreate="userCan(action.CREATE)"
+                    :canUpdate="userCan(action.UPDATE)"
+                    @open-backfill="openBackfill(scope.row)"
+                    @updated="(newTrigger) => { $toast().saved(newTrigger.id); triggers = triggers.map(t => t.id === newTrigger.id ? newTrigger : t) }"
+                />
             </template>
         </el-table-column>
 
@@ -176,66 +139,14 @@
         </template>
     </Empty>
 
-    <el-dialog v-model="isBackfillOpen" destroyOnClose :appendToBody="true">
-        <template #header>
-            <span v-html="$t('backfill executions')" />
-        </template>
-        <el-form :model="backfill" labelPosition="top">
-            <div class="pickers">
-                <div class="small-picker">
-                    <el-form-item label="Start">
-                        <el-date-picker
-                            v-model="backfill.start"
-                            type="datetime"
-                            placeholder="Start"
-                            :disabledDate="time => new Date() < time || backfill.end ? time > backfill.end : false"
-                        />
-                    </el-form-item>
-                </div>
-                <div class="small-picker">
-                    <el-form-item label="End">
-                        <el-date-picker
-                            v-model="backfill.end"
-                            type="datetime"
-                            placeholder="End"
-                            :disabledDate="time => new Date() < time || backfill?.start > time"
-                        />
-                    </el-form-item>
-                </div>
-            </div>
-        </el-form>
-        <FlowRun
-            @update-inputs="backfill.inputs = $event"
-            @update-labels="backfill.labels = $event"
-            :selectedTrigger="selectedTrigger"
-            :redirect="false"
-            :embed="true"
-        />
-        <template #footer>
-            <router-link
-                v-if="isSchedule(selectedTrigger.type)"
-                :to="{
-                    name: 'admin/triggers',
-                    query: {
-                        namespace: selectedTrigger.namespace,
-                        flowId: selectedTrigger.flowId,
-                        q: selectedTrigger.triggerId
-                    }
-                }"
-            >
-                <el-button class="me-2">
-                    {{ $t("backfill") }}
-                </el-button>
-            </router-link>
-            <el-button
-                type="primary"
-                @click="postBackfill()"
-                :disabled="checkBackfill"
-            >
-                {{ $t("execute backfill") }}
-            </el-button>
-        </template>
-    </el-dialog>
+    <BackfillDialog
+        v-model="isBackfillOpen"
+        v-if="selectedTrigger"
+        :namespace="flowStore.flow.namespace"
+        :flowId="flowStore.flow.id"
+        :trigger="selectedTrigger"
+        @updated="(newTrigger) => { $toast().saved(newTrigger.id); triggers = triggers.map(t => t.id === newTrigger.id ? newTrigger : t) }"
+    />
 
     <Drawer
         v-if="isOpen"
@@ -250,17 +161,12 @@
     </Drawer>
 </template>
 
-<script setup>
+<script lang="ts" setup>
     import TextSearch from "vue-material-design-icons/TextSearch.vue";
-    import Pause from "vue-material-design-icons/Pause.vue";
-    import Play from "vue-material-design-icons/Play.vue";
-    import Delete from "vue-material-design-icons/Delete.vue";
     import LockOff from "vue-material-design-icons/LockOff.vue";
     import Check from "vue-material-design-icons/Check.vue";
     import Restart from "vue-material-design-icons/Restart.vue";
-    import CalendarCollapseHorizontalOutline from "vue-material-design-icons/CalendarCollapseHorizontalOutline.vue"
     import Plus from "vue-material-design-icons/Plus.vue";
-    import FlowRun from "./FlowRun.vue";
     import Id from "../Id.vue";
     import TriggerAvatar from "./TriggerAvatar.vue";
 
@@ -271,12 +177,13 @@
     import DateAgo from "../layout/DateAgo.vue";
     import Vars from "../executions/Vars.vue";
     import Drawer from "../Drawer.vue";
+    import BackfillCell from "./BackfillCell.vue";
+    import BackfillDialog from "./BackfillDialog.vue";
 </script>
 
-<script>
+<script lang="ts">
     import permission from "../../models/permission";
     import action from "../../models/action";
-    import moment from "moment";
     import LogsWrapper from "../logs/LogsWrapper.vue";
     import _isEqual from "lodash/isEqual";
     import {storageKeys} from "../../utils/constants";
@@ -291,7 +198,8 @@
             embed: {
                 type: Boolean,
                 default: false
-            }
+            },
+            backfillRouteName: {type: String, default: "admin/triggers"}
         },
         data() {
             return {
@@ -300,12 +208,6 @@
                 isBackfillOpen: false,
                 triggers: [],
                 selectedTrigger: null,
-                backfill: {
-                    start: null,
-                    end: null,
-                    inputs: null,
-                    labels: []
-                }
             }
         },
         created() {
@@ -354,38 +256,6 @@
                 }
                 return this.triggers
             },
-            cleanBackfill() {
-                return {...this.backfill, labels: this.backfill.labels.filter(label => label.key && label.value)}
-            },
-            checkBackfill() {
-                if (!this.backfill.start) {
-                    return true
-                }
-                if (this.backfill.end && this.backfill.start > this.backfill.end) {
-                    return true
-                }
-                if (this.flowStore.flow.inputs) {
-                    const requiredInputs = this.flowStore.flow.inputs.map(input => input.required !== false ? input.id : null).filter(i => i !== null)
-
-                    if (requiredInputs.length > 0) {
-                        if (!this.backfill.inputs) {
-                            return true
-                        }
-                        const fillInputs = Object.keys(this.backfill.inputs).filter(i => this.backfill.inputs[i] !== null && this.backfill.inputs[i] !== undefined);
-                        if (requiredInputs.sort().join(",") !== fillInputs.sort().join(",")) {
-                            return true
-                        }
-                    }
-                }
-                if (this.backfill.labels.length > 0) {
-                    for (let label of this.backfill.labels) {
-                        if ((label.key && !label.value) || (!label.key && label.value)) {
-                            return true
-                        }
-                    }
-                }
-                return false
-            },
             editorViewType() {
                 return localStorage.getItem(storageKeys.EDITOR_VIEW_TYPE) === "NO_CODE";
             },
@@ -404,32 +274,9 @@
                     .find({namespace: this.flowStore.flow.namespace, flowId: this.flowStore.flow.id, size: this.triggersWithType.length, q: this.query})
                     .then(triggers => this.triggers = triggers.results);
             },
-            setBackfillModal(trigger, bool) {
-                this.isBackfillOpen = bool
-                this.selectedTrigger = trigger
-            },
-            postBackfill() {
-                this.triggerStore.update({
-                    ...this.selectedTrigger,
-                    backfill: this.cleanBackfill
-                })
-                    .then(newTrigger => {
-                        this.$toast().saved(newTrigger.id);
-                        this.triggers = this.triggers.map(t => {
-                            if (t.id === newTrigger.id) {
-                                return newTrigger
-                            }
-                            return t
-                        })
-                        this.setBackfillModal(null, false);
-                        this.backfill = {
-                            start: null,
-                            end: null,
-                            inputs: null,
-                            labels: []
-                        }
-                    })
-
+            openBackfill(trigger) {
+                this.selectedTrigger = trigger;
+                this.isBackfillOpen = true;
             },
             pauseBackfill(trigger) {
                 this.triggerStore.pauseBackfill(trigger)
@@ -508,18 +355,6 @@
                         return t
                     })
                 })
-            },
-            backfillProgression(backfill) {
-                const startMoment = moment(backfill.start);
-                const endMoment = moment(backfill.end);
-                const currentMoment = moment(backfill.currentDate);
-
-                const totalDuration = endMoment.diff(startMoment);
-                const elapsedDuration = currentMoment.diff(startMoment);
-                return Math.round((elapsedDuration / totalDuration) * 100);
-            },
-            isSchedule(type) {
-                return type === "io.kestra.plugin.core.trigger.Schedule" || type === "io.kestra.core.models.triggers.types.Schedule";
             },
             canBeDisabled(trigger) {
                 return this.triggers.map(trigg => trigg.triggerId).includes(trigger.id)


### PR DESCRIPTION
### Summary
closes [#11433](https://github.com/kestra-io/kestra/issues/11433): In Administration > Triggers, clicking “Backfill executions” incorrectly restarted the trigger instead of opening a Backfill form. This PR introduces a reusable Backfill UX and wires it in both Admin and Flow pages.

#### Demo

https://github.com/user-attachments/assets/cb333831-100c-47d4-b296-394d56fbcdf2

### What changes are being made and why?

- feat(ui/admin): add backfill execution modal to Administration > Triggers
- refactor(ui): unify Backfill UX across Admin and Flow pages using reusable `BackfillDialog.vue` and `BackfillCell.vue`
- fix(ui): correct Admin “Backfill executions” button to open a Backfill form (not restart); ensure flow is loaded before rendering `FlowRun`
- cleanup(ui): remove duplicated backfill logic from `FlowTriggers.vue`; standardize emits and handlers; remove debug logs
---

### How the changes have been QAed?

- Manual QA steps
  - Admin > Triggers: for a schedule trigger without existing backfill
    - Click “Backfill executions” → dialog opens with Start/End pickers, “Other properties” (labels), cURL, and `FlowRun` inputs.
    - Fill required inputs and dates; click “Execute backfill” → success toast; row updates to show progression bar.
  - Admin > Triggers: for a trigger with active backfill
    - Use pause/unpause/delete controls in the Backfill cell → success toast and row updates.
  - Flow > Triggers
    - Same checks as Admin; verified identical behavior via shared components.

- Example flow snippet for QA
```yaml
id: variables
namespace: company.team
description: a trigger that logs the trigger time hourly
tasks:
  - id: hello
    type: io.kestra.plugin.core.log.Log
    message: Hello World on {{ trigger.date }}! 🚀
triggers:
  - id: schedule
    type: io.kestra.plugin.core.trigger.Schedule
    cron: "@hourly"
```
- Expected:
  - Admin > Triggers → click “Backfill executions”, set a past Start/End, execute, and observe progress.