### PR TITLE
fix(ai): avoid moving cursor twice after using AI Copilot

### DIFF
--- a/ui/src/components/inputs/Editor.vue
+++ b/ui/src/components/inputs/Editor.vue
@@ -1,6 +1,6 @@
 <template>
     <div class="ks-editor edit-flow-editor">
-        <nav v-if="original === undefined && navbar" class="top-nav">
+        <nav v-if="!isDiff && navbar" class="top-nav">
             <slot name="nav">
                 <div class="text-nowrap">
                     <el-button-group>
@@ -43,11 +43,12 @@
             <div ref="editorContainer" class="editor-wrapper position-relative">
                 <MonacoEditor
                     ref="monacoEditor"
+                    :key="isDiff.toString()"
                     :path="path"
                     :theme="themeComputed"
                     :value="modelValue"
                     :options="options"
-                    :diffEditor="original !== undefined"
+                    :diffEditor="isDiff"
                     :original="original"
                     :language="lang"
                     :extension="extension"
@@ -230,8 +231,8 @@
 
         } else {
             options.scrollbar = {
-                vertical: props.original !== undefined ? "hidden" : "auto",
-                verticalScrollbarSize: props.original !== undefined ? 0 : 10,
+                vertical: isDiff.value ? "hidden" : "auto",
+                verticalScrollbarSize: isDiff.value ? 0 : 10,
                 alwaysConsumeMouseWheel: false,
             };
             options.renderSideBySide = props.diffSideBySide;
@@ -281,6 +282,7 @@
     let lastTimeout: number | undefined = undefined
     let decorations: monaco.editor.IEditorDecorationsCollection | undefined = undefined
 
+    const isDiff = computed(() => props.original !== undefined);
 
     function isCodeEditor(editor?: monaco.editor.IStandaloneCodeEditor | monaco.editor.IStandaloneDiffEditor): editor is monaco.editor.IStandaloneCodeEditor{
         return editor?.getEditorType() === monacoEditor.value?.monaco.editor.EditorType.ICodeEditor
@@ -309,7 +311,7 @@
             return
         }
 
-        if (!props.original) {
+        if (!isDiff.value) {
             editor.onDidBlurEditorWidget?.(() => {
                 emit("focusout", isCodeEditor(editor)
                     ? editor.getValue()
@@ -395,7 +397,7 @@
             }
         }
 
-        if (props.original === undefined && props.navbar && props.fullHeight) {
+        if (!isDiff.value && props.navbar && props.fullHeight) {
             editor.addAction({
                 id: "fold-multiline",
                 label: t("fold_all_multi_lines"),
@@ -444,7 +446,7 @@
             });
         }
 
-        if (!props.original) {
+        if (!isDiff.value) {
             editor.onDidContentSizeChange((_) => {
                 highlightPebble();
             });

--- a/ui/src/components/inputs/EditorWrapper.vue
+++ b/ui/src/components/inputs/EditorWrapper.vue
@@ -4,7 +4,7 @@
             id="editorWrapper"
             ref="editorRefElement"
             class="flex-1"
-            :modelValue="draftSource === undefined ? source : draftSource"
+            :modelValue="hasDraft ? draftSource : source"
             :schemaType="isCurrentTabFlow ? 'flow': undefined"
             :lang="extension === undefined ? 'yaml' : undefined"
             :extension="extension"
@@ -19,7 +19,7 @@
             @execute="execute"
             @mouse-move="(e) => highlightHoveredTask(e.target?.position?.lineNumber)"
             @mouse-leave="() => highlightHoveredTask(-1)"
-            :original="draftSource === undefined ? undefined : source"
+            :original="hasDraft ? source : undefined"
             :diffSideBySide="false"
         >
             <template #absolute>
@@ -45,7 +45,7 @@
             />
         </Transition>
         <AcceptDecline
-            v-if="draftSource !== undefined"
+            v-if="hasDraft"
             @accept="acceptDraft"
             @reject="declineDraft"
         />
@@ -172,7 +172,7 @@
             return;
         }
         if (isCurrentTabFlow.value) {
-            if (draftSource.value !== undefined) {
+            if (hasDraft.value) {
                 draftSource.value = newValue;
             } else {
                 flowStore.flowYaml = newValue;
@@ -295,6 +295,8 @@
         draftSource.value = undefined;
         aiCopilotOpened.value = true;
     }
+
+    const hasDraft = computed(() => draftSource.value !== undefined);
 
     const {
         playgroundStore,


### PR DESCRIPTION
closes #11314

Essentially using a key will get rid of https://github.com/microsoft/monaco-editor/issues/4370, I believe it's occurring because of Monaco registering the arrow keybind once each time an editor is instantiated and since we were reusing the same editor when adding the AI draft diff it makes the cursor jump twice