### PR TITLE
fix(flows): refresh table on filter changes via guarded loader

### DIFF
--- a/ui/src/components/flows/Flows.vue
+++ b/ui/src/components/flows/Flows.vue
@@ -348,7 +348,11 @@
 
     const dataTableRef = useTemplateRef<typeof DataTable>("dataTable");
 
-    const {queryWithFilter, onPageChanged, onRowDoubleClick, onSort} = useDataTableActions({dblClickRouteName: "flows/update"});
+    const {queryWithFilter, onPageChanged, onRowDoubleClick, onSort, load} = useDataTableActions({
+        dblClickRouteName: "flows/update",
+        dataTableRef,
+        loadData,
+    });
     function selectionMapper(element: {id: string; namespace: string; disabled: boolean}): {id: string; namespace: string; enabled: boolean} {
         return {
             id: element.id,
@@ -360,7 +364,12 @@
         dataTableRef,
         selectionMapper
     });
-
+    // Guarded refresh on filter (query) changes to ensure table updates without duplicate loads
+    watch(() => route.query, () => {
+        if (!dataTableRef.value || !dataTableRef.value.isLoading) {
+            load();
+        }
+    }, {deep: true});
     const selectionIds = computed(() => selection.value.map((flow) => flow.id));
 
     interface ChartDefinition {
@@ -606,6 +615,7 @@
             }
         }
     }, {immediate: true, deep: true});
+
 
 </script>
 


### PR DESCRIPTION
### Summary

- Problem: Flows table didn’t update when filters changed unless manually refreshed.
- Approach: Delegate reloads to `useDataTableActions`:
  - Provide `dataTableRef` for `isLoading` handling and `loadData` for actual fetch.
  - Add a guarded `route.query` watcher that calls `load()` only when not already loading.
- Result: Table updates reliably on filter changes with no duplicate requests or UI flicker.

#### Demo

https://github.com/user-attachments/assets/2666d7a0-0caa-489e-9e87-2b9539527b6a


closes: [11442](https://github.com/kestra-io/kestra/issues/11442)