### PR TITLE
fix(core): enable `runIf` at execution updating tasks

### DIFF
--- a/core/src/test/java/io/kestra/core/runners/TaskWithRunIfTest.java
+++ b/core/src/test/java/io/kestra/core/runners/TaskWithRunIfTest.java
@@ -6,6 +6,8 @@ import io.kestra.core.models.executions.Execution;
 import io.kestra.core.models.flows.State;
 import org.junit.jupiter.api.Test;
 
+import java.util.List;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 @KestraTest(startRunner = true)
@@ -31,4 +33,15 @@ class TaskWithRunIfTest {
         assertThat(execution.findTaskRunsByTaskId("log_test").getFirst().getState().getCurrent()).isEqualTo(State.Type.SKIPPED);
     }
 
+    @Test
+    @ExecuteFlow("flows/valids/task-runif-executionupdating.yml")
+    void executionUpdatingTask(Execution execution) {
+        assertThat(execution.getState().getCurrent()).isEqualTo(State.Type.SUCCESS);
+        assertThat(execution.getTaskRunList()).hasSize(5);
+        assertThat(execution.findTaskRunsByTaskId("skipSetVariables").getFirst().getState().getCurrent()).isEqualTo(State.Type.SKIPPED);
+        assertThat(execution.findTaskRunsByTaskId("skipUnsetVariables").getFirst().getState().getCurrent()).isEqualTo(State.Type.SKIPPED);
+        assertThat(execution.findTaskRunsByTaskId("unsetVariables").getFirst().getState().getCurrent()).isEqualTo(State.Type.SUCCESS);
+        assertThat(execution.findTaskRunsByTaskId("setVariables").getFirst().getState().getCurrent()).isEqualTo(State.Type.SUCCESS);
+        assertThat(execution.getVariables()).containsEntry("list", List.of(42));
+    }
 }

--- a/core/src/test/resources/flows/valids/task-runif-executionupdating.yml
+++ b/core/src/test/resources/flows/valids/task-runif-executionupdating.yml
@@ -1,0 +1,35 @@
+id: task-runif-executionupdating
+namespace: io.kestra.tests
+
+variables:
+  list: []
+
+tasks:
+  - id: output
+    type: io.kestra.plugin.core.output.OutputValues
+    values:
+      taskrun_data: 1
+
+  - id: unsetVariables
+    type: io.kestra.plugin.core.execution.UnsetVariables
+    runIf: "true"
+    variables:
+      - list
+
+  - id: setVariables
+    type: io.kestra.plugin.core.execution.SetVariables
+    runIf: "{{ outputs.output['values']['taskrun_data'] == 1 }}"
+    variables:
+      list: [42]
+
+  - id: skipSetVariables
+    type: io.kestra.plugin.core.execution.SetVariables
+    runIf: "false"
+    variables:
+      list: [1]
+
+  - id: skipUnsetVariables
+    type: io.kestra.plugin.core.execution.UnsetVariables
+    runIf: "{{ outputs.output['values']['taskrun_data'] == 2 }}"
+    variables:
+      - list

--- a/executor/src/main/java/io/kestra/executor/ExecutorService.java
+++ b/executor/src/main/java/io/kestra/executor/ExecutorService.java
@@ -1072,6 +1072,17 @@ public class ExecutorService {
                 var executionUpdatingTask = (ExecutionUpdatableTask) workerTask.getTask();
 
                 try {
+                    // handle runIf
+                    if (!TruthUtils.isTruthy(workerTask.getRunContext().render(workerTask.getTask().getRunIf()))) {
+                        executor.withExecution(
+                            executor
+                                .getExecution()
+                                .withTaskRun(workerTask.getTaskRun().withState(State.Type.SKIPPED)),
+                            "handleExecutionUpdatingTaskSkipped"
+                        );
+                        return false;
+                    }
+
                     executor.withExecution(
                         executionUpdatingTask.update(executor.getExecution(), workerTask.getRunContext())
                             .withTaskRun(workerTask.getTaskRun().withState(State.Type.RUNNING)),


### PR DESCRIPTION
### What changes are being made and why?

A group of tasks, such as `io.kestra.plugin.core.execution.SetVariables`, did not react on the value of the `runIf` property.

---

### How the changes have been QAed?


```yaml
id: task-runif-executionupdating
namespace: company.team

variables:
  list: []

tasks:
  - id: skipSetVariables
    type: io.kestra.plugin.core.execution.SetVariables
    runIf: "false" # skip the task
    variables:
      list: [111]
```