### PR TITLE
chore(system): log machine information at startup

### DIFF
--- a/cli/src/main/java/io/kestra/cli/commands/servers/AbstractServerCommand.java
+++ b/cli/src/main/java/io/kestra/cli/commands/servers/AbstractServerCommand.java
@@ -2,17 +2,25 @@ package io.kestra.cli.commands.servers;
 
 import io.kestra.cli.AbstractCommand;
 import io.kestra.core.contexts.KestraContext;
-import jakarta.annotation.PostConstruct;
+import lombok.extern.slf4j.Slf4j;
 import picocli.CommandLine;
 
-abstract public class AbstractServerCommand extends AbstractCommand implements ServerCommandInterface {
+@Slf4j
+public abstract class AbstractServerCommand extends AbstractCommand implements ServerCommandInterface {
     @CommandLine.Option(names = {"--port"}, description = "The port to bind")
     Integer serverPort;
 
     @Override
     public Integer call()  throws Exception {
+        log.info("Machine information: {} available cpu(s), {}MB max memory, Java version {}", Runtime.getRuntime().availableProcessors(), maxMemoryInMB(), Runtime.version());
+
         this.shutdownHook(true, () -> KestraContext.getContext().shutdown());
+
         return super.call();
+    }
+
+    private long maxMemoryInMB() {
+        return Runtime.getRuntime().maxMemory() / 1024 / 1024;
     }
 
     protected static int defaultWorkerThread() {


### PR DESCRIPTION
This will log this kind of line at startup, helping to understand possible infrastructure limitation by looking at the starting logs.

```
14:38:17.018 INFO  main         i.k.c.c.s.AbstractServerCommand Machine information: 16 available cpu(s), 2048MB max memory, Java version 21.0.5+11-LTS
```