### PR TITLE
fix(pebble): correct return format of timestampMicro

### DIFF
--- a/core/src/main/java/io/kestra/core/runners/pebble/filters/TimestampMicroFilter.java
+++ b/core/src/main/java/io/kestra/core/runners/pebble/filters/TimestampMicroFilter.java
@@ -30,6 +30,6 @@ public class TimestampMicroFilter extends AbstractDate implements Filter {
         ZoneId zoneId = zoneId(timeZone);
         ZonedDateTime date = convert(input, zoneId, existingFormat);
 
-        return String.valueOf(TimeUnit.SECONDS.toNanos(date.toEpochSecond()) + TimeUnit.NANOSECONDS.toMicros(date.getNano()));
+        return String.valueOf(TimeUnit.SECONDS.toMicros(date.toEpochSecond()) + TimeUnit.NANOSECONDS.toMicros(date.getNano()));
     }
 }

--- a/core/src/test/java/io/kestra/core/runners/pebble/filters/DateFilterTest.java
+++ b/core/src/test/java/io/kestra/core/runners/pebble/filters/DateFilterTest.java
@@ -147,7 +147,7 @@ class DateFilterTest {
             )
         );
 
-        assertThat(render).isEqualTo("1378653552000123456");
+        assertThat(render).isEqualTo("1378653552123456");
     }
 
     @Test


### PR DESCRIPTION
<!-- Thanks for submitting a Pull Request to Kestra. To help us review your contribution, please follow the guidelines below:

- Make sure that your commits follow the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) specification e.g. `feat(ui): add a new navigation menu item` or `fix(core): fix a bug in the core model` or `docs: update the README.md`. This will help us automatically generate the changelog.
- The title should briefly summarize the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share a flow example to help the reviewer understand and QA the change.
- Use "closes" to automatically close an issue. For example, `closes #1234` will close issue #1234. -->

### What changes are being made and why?

The return value of the pebble expression `timestampMicro` is fixed to match the correct pattern (length).

Fixes #11545 
