### PR TITLE
feat(triggers): add inputs property to webhook trigger

### DIFF
--- a/core/src/main/java/io/kestra/plugin/core/trigger/Webhook.java
+++ b/core/src/main/java/io/kestra/plugin/core/trigger/Webhook.java
@@ -156,6 +156,13 @@ public class Webhook extends AbstractTrigger implements TriggerOutput<Webhook.Ou
            """
     )
     private Boolean wait = false;
+    
+    
+    @Schema(
+        title = "The inputs to pass to the triggered flow"
+    )
+    @PluginProperty(dynamic = true)
+    private Map<String, Object> inputs;
 
     @PluginProperty
     @Builder.Default
@@ -174,6 +181,7 @@ public class Webhook extends AbstractTrigger implements TriggerOutput<Webhook.Ou
             .namespace(flow.getNamespace())
             .flowId(flow.getId())
             .flowRevision(flow.getRevision())
+            .inputs(inputs)
             .state(new State())
             .trigger(ExecutionTrigger.of(
                 this,

--- a/core/src/test/resources/flows/valids/webhook-inputs.yaml
+++ b/core/src/test/resources/flows/valids/webhook-inputs.yaml
@@ -1,0 +1,15 @@
+id: webhook-inputs
+namespace: io.kestra.tests
+inputs:
+  - id: body
+    type: STRING
+tasks:
+  - id: out
+    type: io.kestra.plugin.core.debug.Return
+    format: "{{ inputs.body }}"
+triggers:
+  - id: webhook
+    type: io.kestra.plugin.core.trigger.Webhook
+    key: webhookKey
+    inputs:
+      body: "{{ trigger.body }}"

--- a/webserver/src/test/java/io/kestra/webserver/controllers/api/ExecutionControllerTest.java
+++ b/webserver/src/test/java/io/kestra/webserver/controllers/api/ExecutionControllerTest.java
@@ -227,7 +227,24 @@ class ExecutionControllerTest {
         assertThat(response.getStatus().getCode()).isEqualTo(HttpStatus.NO_CONTENT.getCode());
         assertThat(response.body()).isNull();
     }
-
+    
+    @Test
+    void webhookWithInputs() {
+        record Hello(String hello) {}
+        
+        Execution execution = client.toBlocking().retrieve(
+            HttpRequest
+                .POST(
+                    "/api/v1/main/executions/webhook/" + TESTS_FLOW_NS + "/webhook-inputs/webhookKey",
+                    new Hello("world")
+                ),
+            Execution.class
+        );
+        
+        assertThat(execution).isNotNull();
+        assertThat(execution.getId()).isNotNull();
+    }
+    
     @Test
     void resolveAbsoluteDateTime() {
         final ZonedDateTime absoluteTimestamp = ZonedDateTime.of(2023, 2, 3, 4, 6,10, 0, ZoneId.systemDefault());


### PR DESCRIPTION
Add a new `inputs` property to the Webhook trigger, allowing input data to be passed to the triggered flow. If no inputs are defined on the trigger, the flow will not receive any inputs, even if some have default values. This behavior ensures backward compatibility with how the Webhook trigger currently works.

### Use case

Easily define a flow that can be triggered either manually or through a webhook with an expected payload.

### Example

```yaml
id: webhook
namespace: example
inputs:
  - id: first
    type: STRING

  - id: second
    type: STRING
    defaults: "World"

tasks:
  - id: hello
    type: io.kestra.plugin.core.log.Log
    message: "Hello {{ inputs.first }}, {{ inputs.second }}!"

triggers:
  - id: webhook
    type: io.kestra.plugin.core.trigger.Webhook
    key: my_secret_key
    inputs:
      # if the input failed to be resolved the flow is not triggered
      first: "{{ trigger.body.name }}"
```