### PR TITLE
feat(tests): introduce JUnit test support for triggers

### DIFF
--- a/core/src/main/java/io/kestra/core/runners/ExecutableUtils.java
+++ b/core/src/main/java/io/kestra/core/runners/ExecutableUtils.java
@@ -160,7 +160,8 @@ public final class ExecutableUtils {
             if (flow instanceof FlowWithException fwe) {
                 throw new IllegalStateException("Cannot execute an invalid flow: " + fwe.getException());
             }
-                List<Label> newLabels = inheritLabels ? new ArrayList<>(filterLabels(currentExecution.getLabels(), flow)) : new ArrayList<>(systemLabels(currentExecution));
+
+            List<Label> newLabels = inheritLabels ? new ArrayList<>(filterLabels(currentExecution.getLabels(), flow)) : new ArrayList<>(systemLabels(currentExecution));
             if (labels != null) {
                 labels.forEach(throwConsumer(label -> newLabels.add(new Label(runContext.render(label.key()), runContext.render(label.value())))));
             }

--- a/core/src/test/java/io/kestra/plugin/core/trigger/PollingTest.java
+++ b/core/src/test/java/io/kestra/plugin/core/trigger/PollingTest.java
@@ -1,0 +1,26 @@
+package io.kestra.plugin.core.trigger;
+
+import io.kestra.core.junit.annotations.EvaluateTrigger;
+import io.kestra.core.junit.annotations.KestraTest;
+import io.kestra.core.models.executions.Execution;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@KestraTest
+class PollingTest {
+
+    @Test
+    @EvaluateTrigger(
+            flow = "flows/tests/trigger-polling.yaml",
+            triggerId = "polling-trigger-1"
+    )
+    void testPollingTrigger(Optional<Execution> executionOptional) {
+        assertThat(executionOptional).isPresent();
+        Execution execution = executionOptional.get();
+        assertThat(execution.getFlowId()).isEqualTo("polling-flow");
+        assertThat(execution.getState().getCurrent()).isNotNull();
+    }
+}

--- a/core/src/test/java/io/kestra/plugin/core/trigger/PollingTest.java
+++ b/core/src/test/java/io/kestra/plugin/core/trigger/PollingTest.java
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.Test;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @KestraTest
 class PollingTest {
@@ -17,10 +18,10 @@ class PollingTest {
             flow = "flows/tests/trigger-polling.yaml",
             triggerId = "polling-trigger-1"
     )
-    void testPollingTrigger(Optional<Execution> executionOptional) {
-        assertThat(executionOptional).isPresent();
-        Execution execution = executionOptional.get();
+    void pollingTriggerSuccess(Optional<Execution> optionalExecution) {
+        assertThat(optionalExecution).isPresent();
+        Execution execution = optionalExecution.get();
         assertThat(execution.getFlowId()).isEqualTo("polling-flow");
-        assertThat(execution.getState().getCurrent()).isNotNull();
+        assertTrue(execution.getState().getCurrent().isCreated());
     }
 }

--- a/core/src/test/resources/flows/tests/trigger-polling.yaml
+++ b/core/src/test/resources/flows/tests/trigger-polling.yaml
@@ -1,0 +1,5 @@
+id: polling-flow
+namespace: io.kestra.tests
+triggers:
+  - id: polling-trigger-1
+    type: io.kestra.core.tasks.test.PollingTrigger

--- a/tests/src/main/java/io/kestra/core/junit/annotations/EvaluateTrigger.java
+++ b/tests/src/main/java/io/kestra/core/junit/annotations/EvaluateTrigger.java
@@ -1,0 +1,18 @@
+package io.kestra.core.junit.annotations;
+
+import io.kestra.core.junit.extensions.TriggerEvaluationExtension;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+@ExtendWith(TriggerEvaluationExtension.class)
+public @interface EvaluateTrigger {
+    String flow();
+
+    String triggerId();
+}

--- a/tests/src/main/java/io/kestra/core/junit/extensions/TriggerEvaluationExtension.java
+++ b/tests/src/main/java/io/kestra/core/junit/extensions/TriggerEvaluationExtension.java
@@ -1,0 +1,117 @@
+package io.kestra.core.junit.extensions;
+
+import io.kestra.core.junit.annotations.EvaluateTrigger;
+import io.kestra.core.models.conditions.ConditionContext;
+import io.kestra.core.models.executions.Execution;
+import io.kestra.core.models.flows.Flow;
+import io.kestra.core.models.triggers.AbstractTrigger;
+import io.kestra.core.models.triggers.PollingTriggerInterface;
+import io.kestra.core.models.triggers.TriggerContext;
+import io.kestra.core.runners.DefaultRunContext;
+import io.kestra.core.runners.RunContextInitializer;
+import io.kestra.core.runners.RunContextFactory;
+import io.kestra.core.serializers.YamlParser;
+import io.micronaut.context.ApplicationContext;
+import lombok.SneakyThrows;
+import org.junit.jupiter.api.extension.*;
+
+import java.net.URL;
+import java.nio.file.Paths;
+import java.time.ZonedDateTime;
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * JUnit 5 extension to evaluate triggers and inject its Optional<Execution>.
+ */
+public class TriggerEvaluationExtension implements ParameterResolver {
+    private static final ExtensionContext.Namespace NAMESPACE =
+        ExtensionContext.Namespace.create(KestraTestExtension.class);
+
+    ApplicationContext context;
+
+
+    RunContextFactory runContextFactory;
+
+
+    RunContextInitializer runContextInitializer;
+
+    @Override
+    public boolean supportsParameter(ParameterContext parameterContext, ExtensionContext extensionContext) {
+        return parameterContext.getParameter().getType() == Optional.class;
+    }
+
+    @SneakyThrows
+    @Override
+    public Object resolveParameter(ParameterContext parameterContext, ExtensionContext extensionContext) {
+        ensureContext(extensionContext);
+
+        EvaluateTrigger evaluateTrigger = extensionContext.getRequiredTestMethod()
+            .getAnnotation(EvaluateTrigger.class);
+
+        String path = evaluateTrigger.flow();
+        URL url = getClass().getClassLoader().getResource(path);
+        if (url == null) {
+            throw new IllegalArgumentException("Unable to load flow: " + path);
+        }
+
+        Flow flow = YamlParser.parse(Paths.get(url.toURI()).toFile(), Flow.class);
+
+
+        AbstractTrigger trigger =  flow.getTriggers().stream()
+            .filter(t -> t.getId().equals(evaluateTrigger.triggerId()))
+            .findFirst()
+            .orElseThrow(() -> new IllegalArgumentException("Trigger not found: " + evaluateTrigger.triggerId()));
+
+
+    return evaluateTrigger(trigger,flow);
+    }
+
+    private void ensureContext(ExtensionContext extensionContext) {
+        if (context == null) {
+            context = extensionContext.getRoot()
+                .getStore(NAMESPACE)
+                .get(ApplicationContext.class, ApplicationContext.class);
+
+            if (context == null) {
+                throw new IllegalStateException("No ApplicationContext found. Add @KestraTest to the test class.");
+            }
+            runContextFactory = context.getBean(RunContextFactory.class);
+            runContextInitializer = context.getBean(RunContextInitializer.class);
+        }
+    }
+    private Optional<Execution> evaluateTrigger(AbstractTrigger trigger,Flow flow) throws Exception {
+
+        if(trigger instanceof PollingTriggerInterface pollingTrigger){
+            TriggerContext triggerContext = triggerContext(trigger, flow);
+            ConditionContext conditionContext = conditionContext(trigger, flow);
+
+            return pollingTrigger.evaluate(conditionContext, triggerContext);
+        }
+        else {
+            throw new IllegalArgumentException("Unsupported trigger type: " + trigger.getClass());
+        }
+    }
+    private ConditionContext conditionContext(AbstractTrigger trigger, Flow flow) {
+
+        TriggerContext triggerContext=triggerContext(trigger,flow);
+
+        return ConditionContext.builder()
+            .runContext(runContextInitializer.forScheduler(
+                (DefaultRunContext) runContextFactory.of(), triggerContext, trigger
+            ))
+            .flow(flow)
+            .build();
+    }
+    private TriggerContext triggerContext(AbstractTrigger trigger,Flow flow)
+    {
+        return TriggerContext.builder()
+            .namespace(flow.getNamespace())
+            .flowId(flow.getId())
+            .triggerId(trigger.getId())
+            .date(ZonedDateTime.now())
+            .build();
+    }
+
+
+}


### PR DESCRIPTION
close #11087
### Description

- Added a new annotation: `@EvaluateTrigger` and the corresponding `TriggerEvaluationExtension` to support trigger evaluation in unit tests.
- Supports **Polling Triggers**.
- Added a unit test to verify the functionality of the new annotation.
