### PR TITLE
fix(flows): when user select nocode as default editor, add buttons need to work

### DIFF
--- a/ui/src/components/flows/MultiPanelFlowEditorView.vue
+++ b/ui/src/components/flows/MultiPanelFlowEditorView.vue
@@ -206,11 +206,7 @@
                         return panels
                             .filter((p) => p.tabs.length)
                             .map((p): Panel => {
-                                const tabs: Tab[] = p.tabs.map((tab) =>
-                                    setupInitialCodeTab(tab)
-                                    ?? setupInitialNoCodeTabIfExists(RawNoCode, tab, t, noCodeHandlers, flowStore.flowYaml ?? "")
-                                    ?? EDITOR_ELEMENTS.find(e => e.value === tab)
-                                )
+                                const tabs = p.tabs.map(getTabFromValue)
                                     // filter out any tab that may have disappeared
                                     .filter(t => t !== undefined);
                                 const activeTab = tabs.find(t => cleanupNoCodeTabKey(t.value) === p.activeTab) ?? tabs[0];

--- a/ui/src/components/flows/MultiPanelFlowEditorView.vue
+++ b/ui/src/components/flows/MultiPanelFlowEditorView.vue
@@ -127,8 +127,15 @@
         return staticGetPanelFromValue(value, tab, dirtyFlow)
     }
 
+    function getTabFromValue(value: string): Tab {
+        return setupInitialNoCodeTabIfExists(RawNoCode, value, t, noCodeHandlers, flowStore.flowYaml ?? "")
+            ?? setupInitialCodeTab(value)
+            ?? EDITOR_ELEMENTS.find(e => e.value === value)
+            ?? EDITOR_ELEMENTS[0]
+    }
+
     function staticGetPanelFromValue(value: string, tab?: Tab, dirtyFlow = false): {prepend: boolean, panel: Omit<Panel, "size">}{
-        const element: Tab = tab ?? EDITOR_ELEMENTS.find(e => e.value === value) ?? EDITOR_ELEMENTS[0]
+        const element: Tab = tab ?? getTabFromValue(value)
 
         if(isTabFlowRelated(element)){
             element.dirty = dirtyFlow


### PR DESCRIPTION
To reproduce:
- Go to personal settings
- Default Editor Type > to no code
- create a new flow
- try and add a new task/input/error
- nothing happens