### PR TITLE
fix(executions): killing queued exec. didn't respect concurrency limit

### DIFF
--- a/core/src/main/java/io/kestra/core/runners/ExecutionRunning.java
+++ b/core/src/main/java/io/kestra/core/runners/ExecutionRunning.java
@@ -32,5 +32,7 @@ public class ExecutionRunning implements HasUID {
         return IdUtils.fromPartsAndSeparator('|', this.tenantId, this.namespace, this.flowId, this.execution.getId());
     }
 
-    public enum ConcurrencyState { CREATED, RUNNING, QUEUED, CANCELLED, FAILED }
+    // Note: the KILLED state is only used in the Kafka implementation to difference between purging terminated running execution (null)
+    // and purging killed execution which need special treatment
+    public enum ConcurrencyState { CREATED, RUNNING, QUEUED, CANCELLED, FAILED, KILLED }
 }

--- a/core/src/test/java/io/kestra/core/runners/AbstractRunnerTest.java
+++ b/core/src/test/java/io/kestra/core/runners/AbstractRunnerTest.java
@@ -455,6 +455,12 @@ public abstract class AbstractRunnerTest {
     }
 
     @Test
+    @LoadFlows({"flows/valids/flow-concurrency-parallel-subflow-kill.yaml", "flows/valids/flow-concurrency-parallel-subflow-kill-child.yaml", "flows/valids/flow-concurrency-parallel-subflow-kill-grandchild.yaml"})
+    void flowConcurrencyParallelSubflowKill() throws Exception {
+        flowConcurrencyCaseTest.flowConcurrencyParallelSubflowKill();
+    }
+
+    @Test
     @ExecuteFlow("flows/valids/executable-fail.yml")
     void badExecutable(Execution execution) {
         assertThat(execution.getTaskRunList().size()).isEqualTo(1);

--- a/core/src/test/resources/flows/valids/flow-concurrency-parallel-subflow-kill-child.yaml
+++ b/core/src/test/resources/flows/valids/flow-concurrency-parallel-subflow-kill-child.yaml
@@ -1,0 +1,12 @@
+id: flow-concurrency-parallel-subflow-kill-child
+namespace: io.kestra.tests
+
+concurrency:
+  behavior: QUEUE
+  limit: 1
+
+tasks:
+  - id: flow1
+    type: io.kestra.plugin.core.flow.Subflow
+    flowId: flow-concurrency-parallel-subflow-kill-grandchild
+    namespace: io.kestra.tests

--- a/core/src/test/resources/flows/valids/flow-concurrency-parallel-subflow-kill-grandchild.yaml
+++ b/core/src/test/resources/flows/valids/flow-concurrency-parallel-subflow-kill-grandchild.yaml
@@ -1,0 +1,7 @@
+id: flow-concurrency-parallel-subflow-kill-grandchild
+namespace: io.kestra.tests
+
+tasks:
+  - id: sleep
+    type: io.kestra.plugin.core.flow.Sleep
+    duration: PT10S

--- a/core/src/test/resources/flows/valids/flow-concurrency-parallel-subflow-kill.yaml
+++ b/core/src/test/resources/flows/valids/flow-concurrency-parallel-subflow-kill.yaml
@@ -1,0 +1,16 @@
+id: flow-concurrency-parallel-subflow-kill
+namespace: io.kestra.tests
+
+tasks:
+  - id: parallel
+    type: io.kestra.plugin.core.flow.Parallel
+    tasks:
+      - id: flow1
+        type: io.kestra.plugin.core.flow.Subflow
+        flowId: flow-concurrency-parallel-subflow-kill-child
+        namespace: io.kestra.tests
+
+      - id: flow2
+        type: io.kestra.plugin.core.flow.Subflow
+        flowId: flow-concurrency-parallel-subflow-kill-child
+        namespace: io.kestra.tests


### PR DESCRIPTION
There was two issues here:
- When killing a queued execution, the associated ExecutionQueued record was not deleted
- When terminating a killed execution that has concurrency limit, we poped an execution even if the execution was not running (no associated ExecutionRunning record) which may exceed concurrency limit

Fixes #11574

I also fix the TestRunnerUtils that should test the predicate before returning the last execution not after.

@nkwiatkowski you may want to have a look at my changes on the `TestRunnerUtils`.
