### PR TITLE
fix(core): properly encode filenames with spaces in URI

### DIFF
--- a/core/src/main/java/io/kestra/core/storages/InternalStorage.java
+++ b/core/src/main/java/io/kestra/core/storages/InternalStorage.java
@@ -16,10 +16,12 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
 import java.nio.file.Files;
+import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
+import java.net.URLEncoder;
 
 /**
  * The default {@link Storage} implementation acting as a facade to the {@link StorageInterface}.
@@ -175,11 +177,19 @@ public class InternalStorage implements Storage {
      **/
     @Override
     public URI putFile(File file, String name) throws IOException {
+        string rawName = name!=null ? name:file.getName();
+        //URL-encode the filename component
+        // URLEncoder.encode converts space ' ' to '+'. For URI path segments, 
+        // '+' is incorrect and must be '%20'. We replace it manually.
+        // This is a common and necessary pattern for encoding path components.
+        // Manually remove the " " --> "+" --> "%20"
+        String encodedName = URLEncoder.encode(rawName, StandardCharsets.UTF_8.toString())
+        .replace("+", "%20");
         URI uri = context.getContextStorageURI();
-        URI resolved = uri.resolve(uri.getPath() + PATH_SEPARATOR + (name != null ? name : file.getName()));
+        URI resolved = uri.resolve(uri.getPath() + PATH_SEPARATOR + encodedName);
         try (InputStream is = new FileInputStream(file)) {
-            return putFile(is, resolved);
-        } finally {
+        return putFile(is, resolved);
+    } finally {
             try {
                 Files.delete(file.toPath());
             } catch (IOException e) {

--- a/core/src/main/java/io/kestra/core/storages/InternalStorage.java
+++ b/core/src/main/java/io/kestra/core/storages/InternalStorage.java
@@ -151,9 +151,19 @@ public class InternalStorage implements Storage {
      **/
     @Override
     public URI putFile(InputStream inputStream, String name) throws IOException {
+        //Replace spaces using encoder which give "+" and then replace it with standard "%20"
+        String encodedName = URLEncoder.encode(name, StandardCharsets.UTF_8.toString())
+        .replace("+", "%20");
+
         URI uri = context.getContextStorageURI();
-        URI resolved = uri.resolve(uri.getPath() + PATH_SEPARATOR + name);
-        return this.storage.put(context.getTenantId(), context.getNamespace(), resolved, new BufferedInputStream(inputStream));
+        URI resolved = uri.resolve(uri.getPath() + PATH_SEPARATOR + encodedName);
+
+        return this.storage.put(
+            context.getTenantId(),
+            context.getNamespace(),
+            resolved,
+            new BufferedInputStream(inputStream)
+        );
     }
 
     /**
@@ -177,19 +187,10 @@ public class InternalStorage implements Storage {
      **/
     @Override
     public URI putFile(File file, String name) throws IOException {
-        string rawName = name!=null ? name:file.getName();
-        //URL-encode the filename component
-        // URLEncoder.encode converts space ' ' to '+'. For URI path segments, 
-        // '+' is incorrect and must be '%20'. We replace it manually.
-        // This is a common and necessary pattern for encoding path components.
-        // Manually remove the " " --> "+" --> "%20"
-        String encodedName = URLEncoder.encode(rawName, StandardCharsets.UTF_8.toString())
-        .replace("+", "%20");
-        URI uri = context.getContextStorageURI();
-        URI resolved = uri.resolve(uri.getPath() + PATH_SEPARATOR + encodedName);
         try (InputStream is = new FileInputStream(file)) {
-        return putFile(is, resolved);
-    } finally {
+            //Call putFile(InputStream input,String name) function from here
+        return putFile(is, name != null ? name : file.getName());
+        } finally {
             try {
                 Files.delete(file.toPath());
             } catch (IOException e) {
@@ -197,6 +198,8 @@ public class InternalStorage implements Storage {
             }
         }
     }
+
+
 
     /**
      * {@inheritDoc}

--- a/core/src/test/java/io/kestra/plugin/core/namespace/DownloadFilesTest.java
+++ b/core/src/test/java/io/kestra/plugin/core/namespace/DownloadFilesTest.java
@@ -63,10 +63,11 @@ public class DownloadFilesTest {
             Map.of("namespace", namespaceId));
         final Namespace namespace = runContext.storage().namespace(namespaceId);
         // Create a file with a space after a dot
-        String weirdFileName = "/a/b/sample.file with weird naming.txt";
+        Path weirdPath = Path.of("a", "b", "sample.file with weird naming.txt");
         namespace.putFile(
-            new ByteArrayInputStream("test content".getBytes(StandardCharsets.UTF_8)),
-            weirdFileName);
+            weirdPath,
+            new ByteArrayInputStream("test content".getBytes(StandardCharsets.UTF_8))
+        );
         // Run the task
         DownloadFiles.Output output = downloadFiles.run(runContext);
         // Verify the file was downloaded successfully

--- a/core/src/test/java/io/kestra/plugin/core/namespace/DownloadFilesTest.java
+++ b/core/src/test/java/io/kestra/plugin/core/namespace/DownloadFilesTest.java
@@ -31,55 +31,46 @@ public class DownloadFilesTest {
     void shouldDownloadNamespaceFile() throws Exception {
         String namespaceId = "io.kestra." + IdUtils.create();
         DownloadFiles downloadFiles = DownloadFiles.builder()
-                .id(DownloadFiles.class.getSimpleName())
-                .type(DownloadFiles.class.getName())
-                .files(List.of("**test1.txt"))
-                .namespace(new Property<>("{{ inputs.namespace }}"))
-                .build();
-
+            .id(DownloadFiles.class.getSimpleName())
+            .type(DownloadFiles.class.getName())
+            .files(List.of("**test1.txt"))
+            .namespace(new Property<>("{{ inputs.namespace }}"))
+            .build();
         final RunContext runContext = TestsUtils.mockRunContext(this.runContextFactory, downloadFiles,
-                Map.of("namespace", namespaceId));
+            Map.of("namespace", namespaceId));
         final Namespace namespace = runContext.storage().namespace(namespaceId);
-
-        namespace.putFile(Path.of("/a/b/test1.txt"), new ByteArrayInputStream("1".getBytes(StandardCharsets.UTF_8)));
-        namespace.putFile(Path.of("/a/b/test2.txt"), new ByteArrayInputStream("2".getBytes(StandardCharsets.UTF_8)));
-
-        DownloadFiles.Output output = downloadFiles.run(runContext);
-
-        assertThat(output.getFiles().size()).isEqualTo(1);
-        assertThat(output.getFiles().get("/a/b/test1.txt")).isNotNull();
-
+            namespace.putFile(Path.of("/a/b/test1.txt"),
+                new ByteArrayInputStream("1".getBytes(StandardCharsets.UTF_8)));
+            namespace.putFile(Path.of("/a/b/test2.txt"),
+                new ByteArrayInputStream("2".getBytes(StandardCharsets.UTF_8)));
+            DownloadFiles.Output output = downloadFiles.run(runContext);
+            assertThat(output.getFiles().size()).isEqualTo(1);
+            assertThat(output.getFiles().get("/a/b/test1.txt")).isNotNull();
     }
 
     @Test
     void shouldHandleFileWithSpacesAfterDot() throws Exception {
         String namespaceId = "io.kestra." + IdUtils.create();
         DownloadFiles downloadFiles = DownloadFiles.builder()
-                .id(DownloadFiles.class.getSimpleName())
-                .type(DownloadFiles.class.getName())
-                .files(List.of("**weird*"))
-                .namespace(new Property<>("{{ inputs.namespace }}"))
-                .build();
-
+            .id(DownloadFiles.class.getSimpleName())
+            .type(DownloadFiles.class.getName())
+            .files(List.of("**weird*"))
+            .namespace(new Property<>("{{ inputs.namespace }}"))
+            .build();
         final RunContext runContext = TestsUtils.mockRunContext(
-                this.runContextFactory,
-                downloadFiles,
-                Map.of("namespace", namespaceId));
-
+            this.runContextFactory,
+            downloadFiles,
+            Map.of("namespace", namespaceId));
         final Namespace namespace = runContext.storage().namespace(namespaceId);
-
         // Create a file with a space after a dot
         String weirdFileName = "/a/b/sample.file with weird naming.txt";
         namespace.putFile(
-                Path.of(weirdFileName),
-                new ByteArrayInputStream("test content".getBytes(StandardCharsets.UTF_8)));
-
+            Path.of(weirdFileName),
+            new ByteArrayInputStream("test content".getBytes(StandardCharsets.UTF_8)));
         // Run the task
         DownloadFiles.Output output = downloadFiles.run(runContext);
-
         // Verify the file was downloaded successfully
         assertThat(output.getFiles()).containsKey(weirdFileName);
         assertThat(output.getFiles().get(weirdFileName)).isNotNull();
     }
-
 }

--- a/core/src/test/java/io/kestra/plugin/core/namespace/DownloadFilesTest.java
+++ b/core/src/test/java/io/kestra/plugin/core/namespace/DownloadFilesTest.java
@@ -71,7 +71,7 @@ public class DownloadFilesTest {
         // Run the task
         DownloadFiles.Output output = downloadFiles.run(runContext);
         // Verify the file was downloaded successfully
-        assertThat(output.getFiles()).containsKey(weirdFileName);
-        assertThat(output.getFiles().get(weirdFileName)).isNotNull();
+        assertThat(output.getFiles()).containsKey("/a/b/sample.file with weird naming.txt");
+        assertThat(output.getFiles().get("/a/b/sample.file with weird naming.txt")).isNotNull();
     }
 }

--- a/core/src/test/java/io/kestra/plugin/core/namespace/DownloadFilesTest.java
+++ b/core/src/test/java/io/kestra/plugin/core/namespace/DownloadFilesTest.java
@@ -31,13 +31,14 @@ public class DownloadFilesTest {
     void shouldDownloadNamespaceFile() throws Exception {
         String namespaceId = "io.kestra." + IdUtils.create();
         DownloadFiles downloadFiles = DownloadFiles.builder()
-            .id(DownloadFiles.class.getSimpleName())
-            .type(DownloadFiles.class.getName())
-            .files(List.of("**test1.txt"))
-            .namespace(new Property<>("{{ inputs.namespace }}"))
-            .build();
+                .id(DownloadFiles.class.getSimpleName())
+                .type(DownloadFiles.class.getName())
+                .files(List.of("**test1.txt"))
+                .namespace(new Property<>("{{ inputs.namespace }}"))
+                .build();
 
-        final RunContext runContext = TestsUtils.mockRunContext(this.runContextFactory, downloadFiles, Map.of("namespace", namespaceId));
+        final RunContext runContext = TestsUtils.mockRunContext(this.runContextFactory, downloadFiles,
+                Map.of("namespace", namespaceId));
         final Namespace namespace = runContext.storage().namespace(namespaceId);
 
         namespace.putFile(Path.of("/a/b/test1.txt"), new ByteArrayInputStream("1".getBytes(StandardCharsets.UTF_8)));
@@ -49,4 +50,36 @@ public class DownloadFilesTest {
         assertThat(output.getFiles().get("/a/b/test1.txt")).isNotNull();
 
     }
+
+    @Test
+    void shouldHandleFileWithSpacesAfterDot() throws Exception {
+        String namespaceId = "io.kestra." + IdUtils.create();
+        DownloadFiles downloadFiles = DownloadFiles.builder()
+                .id(DownloadFiles.class.getSimpleName())
+                .type(DownloadFiles.class.getName())
+                .files(List.of("**weird*"))
+                .namespace(new Property<>("{{ inputs.namespace }}"))
+                .build();
+
+        final RunContext runContext = TestsUtils.mockRunContext(
+                this.runContextFactory,
+                downloadFiles,
+                Map.of("namespace", namespaceId));
+
+        final Namespace namespace = runContext.storage().namespace(namespaceId);
+
+        // Create a file with a space after a dot
+        String weirdFileName = "/a/b/sample.file with weird naming.txt";
+        namespace.putFile(
+                Path.of(weirdFileName),
+                new ByteArrayInputStream("test content".getBytes(StandardCharsets.UTF_8)));
+
+        // Run the task
+        DownloadFiles.Output output = downloadFiles.run(runContext);
+
+        // Verify the file was downloaded successfully
+        assertThat(output.getFiles()).containsKey(weirdFileName);
+        assertThat(output.getFiles().get(weirdFileName)).isNotNull();
+    }
+
 }

--- a/core/src/test/java/io/kestra/plugin/core/namespace/DownloadFilesTest.java
+++ b/core/src/test/java/io/kestra/plugin/core/namespace/DownloadFilesTest.java
@@ -39,13 +39,13 @@ public class DownloadFilesTest {
         final RunContext runContext = TestsUtils.mockRunContext(this.runContextFactory, downloadFiles,
             Map.of("namespace", namespaceId));
         final Namespace namespace = runContext.storage().namespace(namespaceId);
-            namespace.putFile(Path.of("/a/b/test1.txt"),
-                new ByteArrayInputStream("1".getBytes(StandardCharsets.UTF_8)));
-            namespace.putFile(Path.of("/a/b/test2.txt"),
-                new ByteArrayInputStream("2".getBytes(StandardCharsets.UTF_8)));
-            DownloadFiles.Output output = downloadFiles.run(runContext);
-            assertThat(output.getFiles().size()).isEqualTo(1);
-            assertThat(output.getFiles().get("/a/b/test1.txt")).isNotNull();
+        namespace.putFile(Path.of("/a/b/test1.txt"),
+            new ByteArrayInputStream("1".getBytes(StandardCharsets.UTF_8)));
+        namespace.putFile(Path.of("/a/b/test2.txt"),
+            new ByteArrayInputStream("2".getBytes(StandardCharsets.UTF_8)));
+        DownloadFiles.Output output = downloadFiles.run(runContext);
+        assertThat(output.getFiles().size()).isEqualTo(1);
+        assertThat(output.getFiles().get("/a/b/test1.txt")).isNotNull();
     }
 
     @Test
@@ -65,8 +65,8 @@ public class DownloadFilesTest {
         // Create a file with a space after a dot
         String weirdFileName = "/a/b/sample.file with weird naming.txt";
         namespace.putFile(
-            Path.of(weirdFileName),
-            new ByteArrayInputStream("test content".getBytes(StandardCharsets.UTF_8)));
+            new ByteArrayInputStream("test content".getBytes(StandardCharsets.UTF_8)),
+            weirdFileName);
         // Run the task
         DownloadFiles.Output output = downloadFiles.run(runContext);
         // Verify the file was downloaded successfully


### PR DESCRIPTION
### What changes are being made and why?

This PR fixes a bug where downloading files with spaces after a dot in their filename (e.g., `sample.file with weird naming.txt`) would fail with:

```
java.net.URISyntaxException: Illegal character in path ...
```

**Root cause**: the filename was concatenated into a `URI` without proper percent-encoding, leaving spaces as illegal characters.

**Change**:

* Encode filenames before resolving them into URIs with `URLEncoder.encode(...)`.
* Replace `"+"` with `"%20"` to ensure spaces are valid for path segments.

This ensures all filenames, including those containing spaces or other special characters, can be stored and downloaded without error.
Closes #11569

---

### How the changes have been QAed?

QA was done by reproducing the reported issue using a flow that downloads a file with a space after a dot in its name. With the fix applied, the file is successfully stored and downloaded without throwing a `URISyntaxException`.

```yaml
id: download-bug-test
namespace: dev

tasks:
  - id: downloadweirdfile
    type: io.kestra.plugin.core.http.Download
    uri: "https://raw.githubusercontent.com/PepperSniffer/kestra-download-bug/main/sample.file%20with%20weird%20naming.txt"
```

Before the fix:
❌ Task fails with `java.net.URISyntaxException`

After the fix:
✅ Task completes successfully, file is downloaded and processed.

---

### Setup Instructions

No additional setup required.
Run the provided flow on any Kestra instance (tested on v1.0.2) to verify the fix.
