### PR TITLE
feat(runners): add `syncWorkingDirectory` property to remote task run…

### DIFF
--- a/core/src/main/java/io/kestra/core/models/tasks/runners/RemoteRunnerInterface.java
+++ b/core/src/main/java/io/kestra/core/models/tasks/runners/RemoteRunnerInterface.java
@@ -1,3 +1,11 @@
 package io.kestra.core.models.tasks.runners;
 
-public interface RemoteRunnerInterface {}
+import io.kestra.core.models.property.Property;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public interface RemoteRunnerInterface {
+    @Schema(
+        title = "Whether to synchronize working directory from remote runner back to local one after run."
+    )
+    Property<Boolean> getSyncWorkingDirectory();
+}


### PR DESCRIPTION
…ners

part of kestra-io/kestra-ee#4761
