### PR TITLE
fix(core): adjust date property of PublicHoliday condition

### DIFF
--- a/core/src/main/java/io/kestra/core/runners/ExecutableUtils.java
+++ b/core/src/main/java/io/kestra/core/runners/ExecutableUtils.java
@@ -160,7 +160,8 @@ public final class ExecutableUtils {
             if (flow instanceof FlowWithException fwe) {
                 throw new IllegalStateException("Cannot execute an invalid flow: " + fwe.getException());
             }
-                List<Label> newLabels = inheritLabels ? new ArrayList<>(filterLabels(currentExecution.getLabels(), flow)) : new ArrayList<>(systemLabels(currentExecution));
+
+            List<Label> newLabels = inheritLabels ? new ArrayList<>(filterLabels(currentExecution.getLabels(), flow)) : new ArrayList<>(systemLabels(currentExecution));
             if (labels != null) {
                 labels.forEach(throwConsumer(label -> newLabels.add(new Label(runContext.render(label.key()), runContext.render(label.value())))));
             }

--- a/core/src/main/java/io/kestra/plugin/core/condition/PublicHoliday.java
+++ b/core/src/main/java/io/kestra/plugin/core/condition/PublicHoliday.java
@@ -82,7 +82,7 @@ public class PublicHoliday extends Condition implements ScheduleCondition {
     )
     @NotNull
     @Builder.Default
-    private Property<String> date = Property.ofExpression("{{ trigger.date }}");
+    private Property<String> date = Property.ofExpression("{{ trigger.date?? now()}}");
 
     @Schema(
         title = "[ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2) country code. If not set, it uses the country code from the default locale.",

--- a/core/src/main/java/io/kestra/plugin/core/condition/PublicHoliday.java
+++ b/core/src/main/java/io/kestra/plugin/core/condition/PublicHoliday.java
@@ -16,6 +16,7 @@ import lombok.*;
 import lombok.experimental.SuperBuilder;
 
 import java.time.LocalDate;
+import java.util.Map;
 
 @SuperBuilder
 @ToString
@@ -82,7 +83,7 @@ public class PublicHoliday extends Condition implements ScheduleCondition {
     )
     @NotNull
     @Builder.Default
-    private Property<String> date = Property.ofExpression("{{ trigger.date?? now()}}");
+    private Property<String> date = Property.ofExpression("{{ trigger.date}}");
 
     @Schema(
         title = "[ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2) country code. If not set, it uses the country code from the default locale.",
@@ -98,11 +99,12 @@ public class PublicHoliday extends Condition implements ScheduleCondition {
 
     @Override
     public boolean test(ConditionContext conditionContext) throws InternalException {
+        Map<String, Object> variables=conditionContext.getVariables();
         var renderedCountry = conditionContext.getRunContext().render(this.country).as(String.class).orElse(null);
         var renderedSubDivision = conditionContext.getRunContext().render(this.subDivision).as(String.class).orElse(null);
 
         HolidayManager holidayManager = renderedCountry != null ? HolidayManager.getInstance(ManagerParameters.create(renderedCountry)) : HolidayManager.getInstance();
-        LocalDate currentDate = DateUtils.parseLocalDate(conditionContext.getRunContext().render(date).as(String.class).orElseThrow());
+        LocalDate currentDate = DateUtils.parseLocalDate(conditionContext.getRunContext().render(date).as(String.class,variables).orElseThrow());
         return renderedSubDivision == null ? holidayManager.isHoliday(currentDate) : holidayManager.isHoliday(currentDate, renderedSubDivision);
     }
 }

--- a/core/src/test/java/io/kestra/plugin/core/condition/PublicHolidayTest.java
+++ b/core/src/test/java/io/kestra/plugin/core/condition/PublicHolidayTest.java
@@ -1,9 +1,11 @@
 package io.kestra.plugin.core.condition;
 
 import com.google.common.collect.ImmutableMap;
+import io.kestra.core.models.conditions.ConditionContext;
 import io.kestra.core.models.executions.Execution;
 import io.kestra.core.models.flows.Flow;
 import io.kestra.core.models.property.Property;
+import io.kestra.core.runners.RunContextFactory;
 import io.kestra.core.services.ConditionService;
 import io.kestra.core.utils.TestsUtils;
 import io.kestra.core.junit.annotations.KestraTest;
@@ -11,12 +13,17 @@ import jakarta.inject.Inject;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
+import java.util.Collections;
+import java.util.Map;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 @KestraTest
 class PublicHolidayTest {
     @Inject
     ConditionService conditionService;
+    @Inject
+    private RunContextFactory runContextFactory;
 
     @Test
     void valid() {
@@ -55,6 +62,44 @@ class PublicHolidayTest {
         assertThat(conditionService.isValid(publicHoliday, flow, execution)).isFalse();
     }
 
+    @Test
+    void validWithDynamicRender() {
+        Flow flow = TestsUtils.mockFlow();
+
+        Map<String, Object> variables = Map.of(
+            "trigger", Map.of("date", "2023-07-14")
+        );
+        Execution execution = TestsUtils.mockExecution(flow, ImmutableMap.of());
+        PublicHoliday publicHoliday = PublicHoliday.builder()
+            .country(Property.ofValue("FR"))
+            .build();
+       ConditionContext conditionContext= ConditionContext.builder()
+            .flow(flow)
+            .execution(execution)
+            .runContext(runContextFactory.of(flow,execution))
+            .variables(variables)
+            .build();
+        assertThat(conditionService.valid(flow, Collections.singletonList(publicHoliday), conditionContext)).isTrue();
+    }
+    @Test
+    void invalidWithDynamicRender() {
+        Flow flow = TestsUtils.mockFlow();
+
+        Map<String, Object> variables = Map.of(
+            "trigger", Map.of("date", "2023-01-02")
+        );
+        Execution execution = TestsUtils.mockExecution(flow, ImmutableMap.of());
+        PublicHoliday publicHoliday = PublicHoliday.builder()
+            .country(Property.ofValue("FR"))
+            .build();
+        ConditionContext conditionContext= ConditionContext.builder()
+            .flow(flow)
+            .execution(execution)
+            .runContext(runContextFactory.of(flow,execution))
+            .variables(variables)
+            .build();
+        assertThat(conditionService.valid(flow, Collections.singletonList(publicHoliday), conditionContext)).isFalse();
+    }
     @Test
     @Disabled("Locale is not deterministic on CI")
     void disabled() {


### PR DESCRIPTION
Closes: #11586

Description:

Problem:
the issue was caused by not passing the variables map when rendering trigger.date, I found that after investigating some similar condition classes.

Solution:
include  conditionContext.getVariables() in conditionContext.getRunContext().render(date)
