### PR TITLE
feat: re-enable 3 failing tests

### DIFF
--- a/core/src/test/java/io/kestra/core/runners/AbstractRunnerTest.java
+++ b/core/src/test/java/io/kestra/core/runners/AbstractRunnerTest.java
@@ -12,7 +12,6 @@ import io.kestra.core.queues.QueueInterface;
 import io.kestra.plugin.core.flow.*;
 import jakarta.inject.Inject;
 import jakarta.inject.Named;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 
@@ -242,7 +241,7 @@ public abstract class AbstractRunnerTest {
         multipleConditionTriggerCaseTest.flowTriggerPreconditions();
     }
 
-    @Disabled
+
     @Test
     @LoadFlows(value = {"flows/valids/flow-trigger-preconditions-flow-listen.yaml",
         "flows/valids/flow-trigger-preconditions-flow-a.yaml",

--- a/core/src/test/java/io/kestra/core/runners/ExecutionServiceTest.java
+++ b/core/src/test/java/io/kestra/core/runners/ExecutionServiceTest.java
@@ -20,7 +20,6 @@ import io.kestra.plugin.core.debug.Return;
 import io.kestra.plugin.core.flow.Pause;
 import jakarta.inject.Inject;
 import lombok.extern.slf4j.Slf4j;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junitpioneer.jupiter.RetryingTest;
 import org.slf4j.event.Level;
@@ -218,7 +217,7 @@ class ExecutionServiceTest {
         assertThat(restart.getLabels()).contains(new Label(Label.REPLAY, "true"));
     }
 
-    @Disabled
+
     @Test
     @LoadFlows({"flows/valids/parallel-nested.yaml"})
     void replayParallel() throws Exception {

--- a/core/src/test/java/io/kestra/core/tasks/test/SanityCheckTest.java
+++ b/core/src/test/java/io/kestra/core/tasks/test/SanityCheckTest.java
@@ -5,7 +5,6 @@ import io.kestra.core.junit.annotations.KestraTest;
 import io.kestra.core.models.executions.Execution;
 import io.kestra.core.models.executions.TaskRun;
 import io.kestra.core.models.flows.State;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -32,8 +31,7 @@ class SanityCheckTest {
         assertThat(execution.getTaskRunList()).hasSize(8);
         assertThat(execution.getState().getCurrent()).isEqualTo(State.Type.SUCCESS);
     }
-
-    @Disabled
+    
     @Test
     @ExecuteFlow("sanity-checks/kv.yaml")
     void qaKv(Execution execution) {


### PR DESCRIPTION
Closes https://github.com/kestra-io/kestra/issues/11269

I rehabilitated them.

core/src/test/java/io/kestra/core/runners/AbstractRunnerTest.java

forEachItemEmptyItems
flowConcurrencyWithForEachItem
concurrencyQueueRestarted
core/src/test/java/io/kestra/core/runners/ExecutionServiceTest.java

replayParallel
core/src/test/java/io/kestra/core/tasks/test/SanityCheckTest.java

qaKv