### PR TITLE
  Replace "Ask any question via Slack" button with "Fix with AI" in error notifications

### DIFF
--- a/ui/src/components/ErrorToastContainer.vue
+++ b/ui/src/components/ErrorToastContainer.vue
@@ -1,12 +1,13 @@
 <template>
-    <a
-        href="https://kestra.io/slack?utm_source=app&utm_campaign=slack&utm_content=error"
-        class="position-absolute slack-on-error el-button el-button--small"
-        target="_blank"
+    <el-button
+        v-if="isFlowContext"
+        @click="fixWithAi"
+        class="position-absolute slack-on-error el-button--small"
+        size="small"
     >
-        <Slack />
-        <span>{{ $t("slack support") }}</span>
-    </a>
+        <AiIcon class="me-1" />
+        <span>{{ $t("fix_with_ai") }}</span>
+    </el-button>
     <span v-html="markdownRenderer" v-if="items.length === 0" />
     <ul>
         <li v-for="(item, index) in items" :key="index" class="font-monospace">
@@ -19,7 +20,7 @@
 </template>
 
 <script>
-    import Slack from "vue-material-design-icons/Slack.vue";
+    import AiIcon from "vue-material-design-icons/Creation.vue";
     import * as Markdown from "../utils/markdown";
 
     export default {
@@ -46,13 +47,38 @@
                 this.markdownRenderer = await this.renderMarkdown();
             }
         },
-        components: {Slack},
+        computed: {
+            isFlowContext() {
+                const routeName = this.$route?.name;
+                return routeName === "flows/update" || routeName === "flows/create";
+            }
+        },
+        components: {AiIcon},
         methods: {
             async renderMarkdown() {
                 if (this.message.response && this.message.response.status === 503) {
                     return await Markdown.render("Server is temporarily unavailable. Please try again later.", {html: true});
                 }
                 return await Markdown.render(this.message.message || this.message.content.message, {html: true});
+            },
+            fixWithAi() {
+                const errorMessage = this.message.message || this.message.content?.message || "";
+                const errorItems = this.items.map(item => {
+                    const path = item.path ? `At ${item.path}: ` : "";
+                    return path + item.message;
+                }).join("\n");
+
+                const fullErrorMessage = errorItems || errorMessage;
+                const prompt = `Fix the following error in the flow:\n${fullErrorMessage}`;
+
+                try {
+                    window.sessionStorage.setItem("kestra-ai-prompt", prompt);
+                } catch (err) {
+                    console.warn("AI prompt not persisted to sessionStorage:", err);
+                }
+
+                // Close the notification
+                this.$parent?.close?.();
             },
         },
     };

--- a/ui/src/components/ErrorToastContainer.vue
+++ b/ui/src/components/ErrorToastContainer.vue
@@ -68,7 +68,7 @@
                     return path + item.message;
                 }).join("\n");
 
-                const fullErrorMessage = errorItems || errorMessage;
+                const fullErrorMessage = [errorMessage, errorItems].filter(Boolean).join("\n\n");
                 const prompt = `Fix the following error in the flow:\n${fullErrorMessage}`;
 
                 try {


### PR DESCRIPTION
closes #11581  

## Summary
  When users encounter flow validation errors (like invalid YAML), they now see a helpful "Fix with AI" button instead of a link to Slack support. This makes it easier to get immediate help right where they're working.

  ## What changed?
  - The error notification toast now shows a "Fix with AI" button when you're editing or creating a flow
  - Clicking the button captures the error details and passes them to the AI editor to help you fix the issue
  - The button only appears in the flow editor context (not everywhere) to keep it relevant

  ## How it works
  When you click "Fix with AI":
  1. It grabs the error message and any specific validation issues
  2. Formats them into a helpful prompt for the AI
  3. Stores it in sessionStorage so the AI can access it
  4. Closes the error notification automatically

  This follows the same pattern we already use for the "Fix with AI" option in task execution errors, keeping the experience
  consistent.