### PR TITLE
fix(ui): auto expand first output in flow Overview

### DIFF
--- a/ui/src/components/executions/Overview.vue
+++ b/ui/src/components/executions/Overview.vue
@@ -152,7 +152,6 @@
         <div v-if="execution.trigger" class="my-5">
             <h5>{{ $t("trigger") }}</h5>
             <TriggerCascader
-                id="triggers"
                 :options="transform({
                     ...execution.trigger,
                     ...(execution.trigger.trigger ? execution.trigger.trigger : {})
@@ -165,7 +164,6 @@
         <div v-if="execution.inputs" class="my-5">
             <h5>{{ $t("inputs") }}</h5>
             <KestraCascader
-                id="inputs"
                 :options="transform(execution.inputs)"
                 :execution
                 class="overflow-auto"
@@ -175,7 +173,6 @@
         <div v-if="execution.variables" class="my-5">
             <h5>{{ $t("variables") }}</h5>
             <KestraCascader
-                id="variables"
                 :options="transform(execution.variables)"
                 :execution
                 class="overflow-auto"
@@ -185,7 +182,6 @@
         <div v-if="execution.outputs" class="my-5">
             <h5>{{ $t("flow_outputs") }}</h5>
             <KestraCascader
-                id="outputs"
                 :options="transform(execution.outputs)"
                 :execution
                 class="overflow-auto"

--- a/ui/src/components/executions/TriggerCascader.vue
+++ b/ui/src/components/executions/TriggerCascader.vue
@@ -129,7 +129,6 @@
     const props = defineProps<{
         options: CascaderOption[];
         execution: any;
-        id?: string;
     }>();
 
     const cascader = ref<any>(null);

--- a/ui/src/components/kestra/Cascader.vue
+++ b/ui/src/components/kestra/Cascader.vue
@@ -1,5 +1,5 @@
 <template>
-    <el-cascader-panel :options :id>
+    <el-cascader-panel ref="panelRef" :options="options" :id="id">
         <template #default="{data}">
             <div v-if="isFile(data.value)">
                 <VarValue :value="data.value" :execution="execution" />
@@ -25,11 +25,10 @@
 </template>
 
 <script setup lang="ts">
-    import {onMounted} from "vue";
-
+    import {ref, onMounted, toRefs} from "vue";
     import VarValue from "../executions/VarValue.vue";
-
     import {useI18n} from "vue-i18n";
+
     const {t} = useI18n({useScope: "global"});
 
     const isFile = (data: any) =>
@@ -41,13 +40,31 @@
         children?: Options[];
     }
 
-    const props = defineProps<{ options: Options; execution: any, id: string }>();
+    const props = defineProps<{ options: Options; execution: any; id: string }>();
+    const {options, execution, id} = toRefs(props);
+
+    const panelRef = ref<any>(null);
+    let hasAutoExpanded = false;
+
+    const expandOutputsPanel = () => {
+        if (hasAutoExpanded) return;
+        if (!id?.value || !id.value.includes("outputs")) return;
+
+        const panelElement = panelRef.value?.$el ?? panelRef.value;
+        if (!panelElement) return;
+
+        const menus = panelElement.querySelectorAll(".el-cascader-menu");
+        if (!menus || menus.length === 0) return;
+
+        const firstNode = menus[0].querySelector(".el-cascader-node");
+        if (!firstNode) return;
+
+        (firstNode as HTMLElement).click();
+        hasAutoExpanded = true;
+    };
 
     onMounted(() => {
-        const nodes = document.querySelectorAll(`#${props.id} .el-cascader-node`);
-        if(nodes.length > 0) {
-            (nodes[0] as HTMLElement).click();
-        }
+        expandOutputsPanel();
     });
 </script>
 

--- a/ui/src/components/kestra/Cascader.vue
+++ b/ui/src/components/kestra/Cascader.vue
@@ -1,5 +1,5 @@
 <template>
-    <el-cascader-panel ref="panelRef" :options="options" :id="id">
+    <el-cascader-panel ref="panelRef" :options>
         <template #default="{data}">
             <div v-if="isFile(data.value)">
                 <VarValue :value="data.value" :execution="execution" />
@@ -14,9 +14,7 @@
                 <div v-if="data.value && data.children">
                     <code>
                         {{ data.children.length }}
-                        {{
-                            data.children.length === 1 ? t("item") : t("items")
-                        }}
+                        {{ data.children.length === 1 ? t("item") : t("items") }}
                     </code>
                 </div>
             </div>
@@ -25,14 +23,14 @@
 </template>
 
 <script setup lang="ts">
-    import {ref, onMounted, toRefs} from "vue";
-    import VarValue from "../executions/VarValue.vue";
-    import {useI18n} from "vue-i18n";
+    import {onMounted, ref} from "vue";
 
+    import VarValue from "../executions/VarValue.vue";
+
+    import {useI18n} from "vue-i18n";
     const {t} = useI18n({useScope: "global"});
 
-    const isFile = (data: any) =>
-        typeof data === "string" && (data.startsWith("kestra:///") || data.startsWith("file://") || data.startsWith("nsfile://"));
+    const isFile = (data: any) => typeof data === "string" && (data.startsWith("kestra:///") || data.startsWith("file://") || data.startsWith("nsfile://"));
 
     interface Options {
         label: string;
@@ -40,31 +38,13 @@
         children?: Options[];
     }
 
-    const props = defineProps<{ options: Options; execution: any; id: string }>();
-    const {options, execution, id} = toRefs(props);
-
+    defineProps<{ options: Options; execution: any }>();
+        
     const panelRef = ref<any>(null);
-    let hasAutoExpanded = false;
-
-    const expandOutputsPanel = () => {
-        if (hasAutoExpanded) return;
-        if (!id?.value || !id.value.includes("outputs")) return;
-
-        const panelElement = panelRef.value?.$el ?? panelRef.value;
-        if (!panelElement) return;
-
-        const menus = panelElement.querySelectorAll(".el-cascader-menu");
-        if (!menus || menus.length === 0) return;
-
-        const firstNode = menus[0].querySelector(".el-cascader-node");
-        if (!firstNode) return;
-
-        (firstNode as HTMLElement).click();
-        hasAutoExpanded = true;
-    };
 
     onMounted(() => {
-        expandOutputsPanel();
+        const nodes =  panelRef.value.$el.querySelectorAll(".el-cascader-node");
+        if(nodes.length > 0) (nodes[0] as HTMLElement).click();
     });
 </script>
 


### PR DESCRIPTION
closes #11289 

### What changes are being made and why?
This PR introduces an improvement in the Flow Overview UI, where the first output is now automatically expanded when the component is mounted.
This change enhances the user experience by allowing users to immediately view the first output details without requiring manual interaction.

<img width="1609" height="913" alt="kestra-issue-1" src="https://github.com/user-attachments/assets/9627cca2-aacd-4880-941a-879671518e0c" />


### How the changes have been QAed?
The change was tested by creating and running a sample flow and verifying that, upon opening the Flow Overview, the first output is automatically expanded.

```yaml
id: getting_started_output
namespace: company.team2

inputs:
  - id: api_url
    type: STRING
    defaults: https://dummyjson.com/products

tasks:
  - id: api
    type: io.kestra.plugin.core.http.Request
    uri: "{{ inputs.api_url }}"

outputs:
  - id: file
    type: STRING
    value: "Test Output"
```
When navigating to the flow overview, the output section greeting is now auto-expanded by default.

### Setup Instructions
No additional setup is required for this change.

