### PR TITLE
fix: sync "Select all" state with item selection (#11654)

### DIFF
--- a/ui/src/composables/useSelectTableActions.ts
+++ b/ui/src/composables/useSelectTableActions.ts
@@ -16,6 +16,7 @@ export function useSelectTableActions({
 
     const handleSelectionChange = (value: any[]) => {
         selection.value = value.map(selectionMapper)
+        queryBulkAction.value = value.length > 0 && value.length === elTable.value?.data?.length
     }
 
     const toggleAllUnselected = () => {

--- a/ui/src/composables/useSelectTableActions.ts
+++ b/ui/src/composables/useSelectTableActions.ts
@@ -16,7 +16,6 @@ export function useSelectTableActions({
 
     const handleSelectionChange = (value: any[]) => {
         selection.value = value.map(selectionMapper)
-        queryBulkAction.value = value.length > 0 && value.length === elTable.value?.data?.length
     }
 
     const toggleAllUnselected = () => {

--- a/ui/src/mixins/selectTableActions.ts
+++ b/ui/src/mixins/selectTableActions.ts
@@ -10,6 +10,10 @@ export default defineComponent({
     methods: {
         handleSelectionChange(value: any[]) {
             this.selection = value.map(this.selectionMapper);
+
+            if (this.queryBulkAction && this.elTable && value?.length < this.elTable.data?.length) {
+                this.queryBulkAction = false
+            }
         },
         toggleAllUnselected() {
             this.elTable.clearSelection()


### PR DESCRIPTION
## Fixes #11654

### Problem
When using "Select all", unchecking an item did not update the counter/state; batch actions (e.g., Delete/Replay) still considered all items selected.

### Solution
Updated `handleSelectionChange` in `useSelectTableActions.ts`:
- Changed condition to: `queryBulkAction = value.length === elTable.value?.data?.length`
- Ensures "Select all" state only becomes `true` when all items are actually selected
- Prevents premature `true` state when table is not ready or has no data


### Testing
1. Click "Select all" → counter shows total items
2. Uncheck one item → counter decreases; batch actions affect only selected items
3. Check all items again → counter returns to total; batch actions consider all items
<video src="https://github.com/user-attachments/assets/d2e913df-8bdf-4cd7-aadb-9a51db9df6ba" controls width="100%"></video>
---

**Hacktoberfest 2025 contribution** 