### PR TITLE
fix(executions): evaluate multiple conditions in a separate queue

### DIFF
--- a/core/src/main/java/io/kestra/core/queues/QueueFactoryInterface.java
+++ b/core/src/main/java/io/kestra/core/queues/QueueFactoryInterface.java
@@ -27,6 +27,7 @@ public interface QueueFactoryInterface {
     String CLUSTER_EVENT_NAMED = "clusterEventQueue";
     String SUBFLOWEXECUTIONEND_NAMED = "subflowExecutionEndQueue";
     String EXECUTION_RUNNING_NAMED = "executionRunningQueue";
+    String MULTIPLE_CONDITION_EVENT_NAMED = "multipleConditionEventQueue";
 
     QueueInterface<Execution> execution();
 
@@ -59,4 +60,6 @@ public interface QueueFactoryInterface {
     QueueInterface<SubflowExecutionEnd> subflowExecutionEnd();
 
     QueueInterface<ExecutionRunning> executionRunning();
+
+    QueueInterface<MultipleConditionEvent> multipleConditionEvent();
 }

--- a/core/src/main/java/io/kestra/core/runners/MultipleConditionEvent.java
+++ b/core/src/main/java/io/kestra/core/runners/MultipleConditionEvent.java
@@ -1,0 +1,13 @@
+package io.kestra.core.runners;
+
+import io.kestra.core.models.HasUID;
+import io.kestra.core.models.executions.Execution;
+import io.kestra.core.models.flows.Flow;
+import io.kestra.core.utils.IdUtils;
+
+public record MultipleConditionEvent(Flow flow, Execution execution) implements HasUID {
+    @Override
+    public String uid() {
+        return IdUtils.fromParts(flow.uidWithoutRevision(), execution.getId());
+    }
+}

--- a/core/src/test/java/io/kestra/core/runners/AbstractRunnerTest.java
+++ b/core/src/test/java/io/kestra/core/runners/AbstractRunnerTest.java
@@ -258,6 +258,12 @@ public abstract class AbstractRunnerTest {
     }
 
     @Test
+    @LoadFlows({"flows/valids/flow-trigger-for-each-item-parent.yaml", "flows/valids/flow-trigger-for-each-item-child.yaml", "flows/valids/flow-trigger-for-each-item-grandchild.yaml"})
+    void forEachItemWithFlowTrigger() throws Exception {
+        multipleConditionTriggerCaseTest.forEachItemWithFlowTrigger();
+    }
+
+    @Test
     @LoadFlows({"flows/valids/each-null.yaml"})
     void eachWithNull() throws Exception {
         EachSequentialTest.eachNullTest(runnerUtils, logsQueue);

--- a/core/src/test/resources/flows/valids/flow-trigger-for-each-item-child.yaml
+++ b/core/src/test/resources/flows/valids/flow-trigger-for-each-item-child.yaml
@@ -1,0 +1,13 @@
+id: flow-trigger-for-each-item-child
+namespace: io.kestra.tests.trigger.foreachitem
+
+tasks:
+  - id: write_file
+    type: io.kestra.plugin.core.storage.Write
+    content: Hello World
+    extension: .txt
+
+outputs:
+  - id: myFile
+    type: FILE
+    value: "{{ outputs.write_file.uri }}"

--- a/core/src/test/resources/flows/valids/flow-trigger-for-each-item-grandchild.yaml
+++ b/core/src/test/resources/flows/valids/flow-trigger-for-each-item-grandchild.yaml
@@ -1,0 +1,30 @@
+id: flow-trigger-for-each-item-grandchild
+namespace: io.kestra.tests.trigger.foreachitem
+
+inputs:
+  - id: testFile
+    type: FILE
+tasks:
+  - id: test_if_empty
+    type: io.kestra.plugin.core.flow.If
+    condition: "{{ isFileEmpty(inputs.testFile) }}"
+    then:
+      - id: empty_file
+        type: io.kestra.plugin.core.log.Log
+        message: "I am empty inside"
+    else:
+      - id: not_empty_file
+        type: io.kestra.plugin.core.log.Log
+        message: "{{ read(inputs.testFile) }}"
+
+triggers:
+  - id: 01_complete
+    type: io.kestra.plugin.core.trigger.Flow
+    inputs:
+      testFile: "{{ trigger.outputs.myFile }}"
+    preconditions:
+      id: output_01_success
+      flows:
+        - namespace: io.kestra.tests.trigger.foreachitem
+          flowId: flow-trigger-for-each-item-child
+          states: [SUCCESS]

--- a/core/src/test/resources/flows/valids/flow-trigger-for-each-item-parent.yaml
+++ b/core/src/test/resources/flows/valids/flow-trigger-for-each-item-parent.yaml
@@ -1,0 +1,18 @@
+id: flow-trigger-for-each-item-parent
+namespace: io.kestra.tests.trigger.foreachitem
+
+tasks:
+  - id: manifest
+    type: io.kestra.plugin.core.storage.Write
+    content: |-
+      0
+      1
+      2
+      3
+      4
+    extension: .txt
+  - id: forEachItem
+    type: io.kestra.plugin.core.flow.ForEachItem
+    items: "{{ outputs.manifest.uri }}"
+    namespace: io.kestra.tests.trigger.foreachitem
+    flowId: flow-trigger-for-each-item-child

--- a/executor/src/main/java/io/kestra/executor/FlowTriggerService.java
+++ b/executor/src/main/java/io/kestra/executor/FlowTriggerService.java
@@ -35,7 +35,6 @@ public class FlowTriggerService {
         this.flowService = flowService;
     }
 
-    // used in EE only
     public Stream<FlowWithFlowTrigger> withFlowTriggersOnly(Stream<FlowWithSource> allFlows) {
         return allFlows
             .filter(flow -> !flow.isDisabled())

--- a/jdbc-h2/src/main/java/io/kestra/runner/h2/H2QueueFactory.java
+++ b/jdbc-h2/src/main/java/io/kestra/runner/h2/H2QueueFactory.java
@@ -152,4 +152,12 @@ public class H2QueueFactory implements QueueFactoryInterface {
     public QueueInterface<ExecutionRunning> executionRunning() {
         return new H2Queue<>(ExecutionRunning.class, applicationContext);
     }
+
+    @Override
+    @Singleton
+    @Named(QueueFactoryInterface.MULTIPLE_CONDITION_EVENT_NAMED)
+    @Bean(preDestroy = "close")
+    public QueueInterface<MultipleConditionEvent> multipleConditionEvent() {
+        return new H2Queue<>(MultipleConditionEvent.class, applicationContext);
+    }
 }

--- a/jdbc-h2/src/main/resources/migrations/h2/V1_43__multiple_condition_event.sql
+++ b/jdbc-h2/src/main/resources/migrations/h2/V1_43__multiple_condition_event.sql
@@ -1,0 +1,20 @@
+ALTER TABLE queues ALTER COLUMN "type" ENUM(
+    'io.kestra.core.models.executions.Execution',
+    'io.kestra.core.models.templates.Template',
+    'io.kestra.core.models.executions.ExecutionKilled',
+    'io.kestra.core.runners.WorkerJob',
+    'io.kestra.core.runners.WorkerTaskResult',
+    'io.kestra.core.runners.WorkerInstance',
+    'io.kestra.core.runners.WorkerTaskRunning',
+    'io.kestra.core.models.executions.LogEntry',
+    'io.kestra.core.models.triggers.Trigger',
+    'io.kestra.ee.models.audits.AuditLog',
+    'io.kestra.core.models.executions.MetricEntry',
+    'io.kestra.core.runners.WorkerTriggerResult',
+    'io.kestra.core.runners.SubflowExecutionResult',
+    'io.kestra.core.server.ClusterEvent',
+    'io.kestra.core.runners.SubflowExecutionEnd',
+    'io.kestra.core.models.flows.FlowInterface',
+    'io.kestra.core.runners.ExecutionRunning',
+    'io.kestra.core.runners.MultipleConditionEvent'
+) NOT NULL

--- a/jdbc-mysql/src/main/java/io/kestra/runner/mysql/MysqlQueueFactory.java
+++ b/jdbc-mysql/src/main/java/io/kestra/runner/mysql/MysqlQueueFactory.java
@@ -152,4 +152,12 @@ public class MysqlQueueFactory implements QueueFactoryInterface {
     public QueueInterface<ExecutionRunning> executionRunning() {
         return new MysqlQueue<>(ExecutionRunning.class, applicationContext);
     }
+
+    @Override
+    @Singleton
+    @Named(QueueFactoryInterface.MULTIPLE_CONDITION_EVENT_NAMED)
+    @Bean(preDestroy = "close")
+    public QueueInterface<MultipleConditionEvent> multipleConditionEvent() {
+        return new MysqlQueue<>(MultipleConditionEvent.class, applicationContext);
+    }
 }

--- a/jdbc-mysql/src/main/resources/migrations/mysql/V1_43__multiple_condition_event.sql
+++ b/jdbc-mysql/src/main/resources/migrations/mysql/V1_43__multiple_condition_event.sql
@@ -1,0 +1,20 @@
+ALTER TABLE queues MODIFY COLUMN `type` ENUM(
+    'io.kestra.core.models.executions.Execution',
+    'io.kestra.core.models.templates.Template',
+    'io.kestra.core.models.executions.ExecutionKilled',
+    'io.kestra.core.runners.WorkerJob',
+    'io.kestra.core.runners.WorkerTaskResult',
+    'io.kestra.core.runners.WorkerInstance',
+    'io.kestra.core.runners.WorkerTaskRunning',
+    'io.kestra.core.models.executions.LogEntry',
+    'io.kestra.core.models.triggers.Trigger',
+    'io.kestra.ee.models.audits.AuditLog',
+    'io.kestra.core.models.executions.MetricEntry',
+    'io.kestra.core.runners.WorkerTriggerResult',
+    'io.kestra.core.runners.SubflowExecutionResult',
+    'io.kestra.core.server.ClusterEvent',
+    'io.kestra.core.runners.SubflowExecutionEnd',
+    'io.kestra.core.models.flows.FlowInterface',
+    'io.kestra.core.runners.ExecutionRunning',
+    'io.kestra.core.runners.MultipleConditionEvent'
+    ) NOT NULL;

--- a/jdbc-postgres/src/main/java/io/kestra/runner/postgres/PostgresQueueFactory.java
+++ b/jdbc-postgres/src/main/java/io/kestra/runner/postgres/PostgresQueueFactory.java
@@ -152,4 +152,12 @@ public class PostgresQueueFactory implements QueueFactoryInterface {
     public QueueInterface<ExecutionRunning> executionRunning() {
         return new PostgresQueue<>(ExecutionRunning.class, applicationContext);
     }
+
+    @Override
+    @Singleton
+    @Named(QueueFactoryInterface.MULTIPLE_CONDITION_EVENT_NAMED)
+    @Bean(preDestroy = "close")
+    public QueueInterface<MultipleConditionEvent> multipleConditionEvent() {
+        return new PostgresQueue<>(MultipleConditionEvent.class, applicationContext);
+    }
 }

--- a/jdbc-postgres/src/main/resources/migrations/postgres/V1_43__multiple_condition_event.sql
+++ b/jdbc-postgres/src/main/resources/migrations/postgres/V1_43__multiple_condition_event.sql
@@ -1,0 +1,1 @@
+ALTER TYPE queue_type ADD VALUE IF NOT EXISTS 'io.kestra.core.runners.MultipleConditionEvent';


### PR DESCRIPTION
By evaluating multiple condition in a separate queue, we serialize their evaluation which avoir races when we compute the outputs for flow triggers. This is because evaluation is a multi step process: first you get the existing condtion, then you evaluate, then you store the result. As this is not guarded by a lock you must not do it concurrently.

The race can still occurs if muiltiple executors run but this is less probable. A re-implementation would be needed probably in 2.0 for that.

Fixes https://github.com/kestra-io/kestra-ee/issues/4602