### PR TITLE
feat(executions): improve performance of PurgeExecutions by batch del…

### DIFF
--- a/core/src/main/java/io/kestra/core/repositories/ExecutionRepositoryInterface.java
+++ b/core/src/main/java/io/kestra/core/repositories/ExecutionRepositoryInterface.java
@@ -98,6 +98,8 @@ public interface ExecutionRepositoryInterface extends SaveRepositoryInterface<Ex
 
     Integer purge(Execution execution);
 
+    Integer purge(List<Execution> executions);
+
     List<DailyExecutionStatistics> dailyStatisticsForAllTenants(
         @Nullable String query,
         @Nullable String namespace,

--- a/core/src/main/java/io/kestra/core/repositories/LogRepositoryInterface.java
+++ b/core/src/main/java/io/kestra/core/repositories/LogRepositoryInterface.java
@@ -90,6 +90,8 @@ public interface LogRepositoryInterface extends SaveRepositoryInterface<LogEntry
 
     Integer purge(Execution execution);
 
+    Integer purge(List<Execution> executions);
+
     void deleteByQuery(String tenantId, String executionId, String taskId, String taskRunId, Level minLevel, Integer attempt);
 
     void deleteByQuery(String tenantId, String namespace, String flowId, String triggerId);

--- a/core/src/main/java/io/kestra/core/repositories/MetricRepositoryInterface.java
+++ b/core/src/main/java/io/kestra/core/repositories/MetricRepositoryInterface.java
@@ -29,6 +29,8 @@ public interface MetricRepositoryInterface extends SaveRepositoryInterface<Metri
 
     Integer purge(Execution execution);
 
+    Integer purge(List<Execution> executions);
+
     Flux<MetricEntry> findAllAsync(@Nullable String tenantId);
 
     default Function<String, String> sortMapping() throws IllegalArgumentException {

--- a/core/src/test/java/io/kestra/core/repositories/AbstractExecutionRepositoryTest.java
+++ b/core/src/test/java/io/kestra/core/repositories/AbstractExecutionRepositoryTest.java
@@ -388,6 +388,21 @@ public abstract class AbstractExecutionRepositoryTest {
     }
 
     @Test
+    protected void purgeExecutions() {
+        var tenant = TestsUtils.randomTenant(this.getClass().getSimpleName());
+        var execution1 = ExecutionFixture.EXECUTION_1(tenant);
+        executionRepository.save(execution1);
+        var execution2 = ExecutionFixture.EXECUTION_2(tenant);
+        executionRepository.save(execution2);
+
+        var results = executionRepository.purge(List.of(execution1, execution2));
+        assertThat(results).isEqualTo(2);
+
+        assertThat(executionRepository.findById(tenant, execution1.getId())).isEmpty();
+        assertThat(executionRepository.findById(tenant, execution2.getId())).isEmpty();
+    }
+
+    @Test
     protected void delete() {
         var tenant = TestsUtils.randomTenant(this.getClass().getSimpleName());
         var execution1 = ExecutionFixture.EXECUTION_1(tenant);

--- a/core/src/test/java/io/kestra/core/repositories/AbstractExecutionServiceTest.java
+++ b/core/src/test/java/io/kestra/core/repositories/AbstractExecutionServiceTest.java
@@ -114,7 +114,8 @@ public abstract class AbstractExecutionServiceTest {
             flow.getId(),
             null,
             ZonedDateTime.now(),
-            null
+            null,
+            100
         );
 
         assertThat(purge.getExecutionsCount()).isEqualTo(1);
@@ -132,7 +133,8 @@ public abstract class AbstractExecutionServiceTest {
             flow.getId(),
             null,
             ZonedDateTime.now(),
-            null
+            null,
+            100
         );
 
         assertThat(purge.getExecutionsCount()).isZero();

--- a/core/src/test/java/io/kestra/core/repositories/AbstractLogRepositoryTest.java
+++ b/core/src/test/java/io/kestra/core/repositories/AbstractLogRepositoryTest.java
@@ -14,6 +14,7 @@ import io.kestra.core.models.flows.State;
 import io.kestra.core.repositories.ExecutionRepositoryInterface.ChildFilter;
 import io.kestra.core.utils.IdUtils;
 import io.kestra.core.utils.TestsUtils;
+import io.kestra.plugin.core.dashboard.data.Executions;
 import io.kestra.plugin.core.dashboard.data.Logs;
 import io.micronaut.data.model.Pageable;
 import jakarta.inject.Inject;
@@ -358,5 +359,17 @@ public abstract class AbstractLogRepositoryTest {
             null);
 
         assertThat(results).hasSize(1);
+    }
+
+    @Test
+    void purge() {
+        String tenant = TestsUtils.randomTenant(this.getClass().getSimpleName());
+        logRepository.save(logEntry(tenant, Level.INFO, "execution1").build());
+        logRepository.save(logEntry(tenant, Level.INFO, "execution1").build());
+        logRepository.save(logEntry(tenant, Level.INFO, "execution2").build());
+        logRepository.save(logEntry(tenant, Level.INFO, "execution2").build());
+
+        var result = logRepository.purge(List.of(Execution.builder().id("execution1").build(), Execution.builder().id("execution2").build()));
+        assertThat(result).isEqualTo(4);
     }
 }

--- a/jdbc/src/main/java/io/kestra/jdbc/repository/AbstractJdbcMetricRepository.java
+++ b/jdbc/src/main/java/io/kestra/jdbc/repository/AbstractJdbcMetricRepository.java
@@ -218,6 +218,7 @@ public abstract class AbstractJdbcMetricRepository extends AbstractJdbcRepositor
     @Override
     public Integer purge(Execution execution) {
         return this.jdbcRepository
+
             .getDslContextWrapper()
             .transactionResult(configuration -> {
                 DSLContext context = DSL.using(configuration);
@@ -227,6 +228,22 @@ public abstract class AbstractJdbcMetricRepository extends AbstractJdbcRepositor
                     // We add it here to be sure to use the correct index.
                     .where(field("deleted", Boolean.class).eq(false))
                     .and(field("execution_id", String.class).eq(execution.getId()))
+                    .execute();
+            });
+    }
+
+    @Override
+    public Integer purge(List<Execution> executions) {
+        return this.jdbcRepository
+            .getDslContextWrapper()
+            .transactionResult(configuration -> {
+                DSLContext context = DSL.using(configuration);
+
+                return context.delete(this.jdbcRepository.getTable())
+                    // The deleted field is not used, so ti will always be false.
+                    // We add it here to be sure to use the correct index.
+                    .where(field("deleted", Boolean.class).eq(false))
+                    .and(field("execution_id", String.class).in(executions.stream().map(Execution::getId).toList()))
                     .execute();
             });
     }


### PR DESCRIPTION
…eting executions, logs and metrics

Closes #11680

Purging 10k flows with 20k logs and 20k metrics shows an improvement of approx 2.5x (3.2s -> 1.2s) with the default batch size.
