### PR TITLE
fix: use filters query instead of deprecated prop to filter by trigge…

### DIFF
--- a/ui/src/components/executions/ForEachStatus.vue
+++ b/ui/src/components/executions/ForEachStatus.vue
@@ -88,9 +88,9 @@
                 }
             },
             goToExecutionsList(state) {
-                const queries = {
-                    triggerExecutionId: this.executionId,
-                }
+                const queries = {}
+
+                queries["filters[triggerExecutionId][EQUALS]"] = this.executionId;
 
                 if (state) {
                     queries["filters[state][EQUALS]"] = state;


### PR DESCRIPTION
…rExecutionId when clicking on failed execution of a ForEachItem

Closes https://github.com/kestra-io/kestra/issues/11691.
