### PR TITLE
fix(executions): purge executions by 100 by default

### DIFF
--- a/core/src/main/java/io/kestra/plugin/core/execution/PurgeExecutions.java
+++ b/core/src/main/java/io/kestra/plugin/core/execution/PurgeExecutions.java
@@ -104,11 +104,11 @@ public class PurgeExecutions extends Task implements RunnableTask<PurgeExecution
 
     @Schema(
         title = "The size of the bulk delete",
-        description = "For performance, deletion is made by batch of by default 500 executions/logs/metrics."
+        description = "For performance, deletion is made by batch of by default 100 executions/logs/metrics."
     )
     @Builder.Default
     @NotNull
-    private Property<Integer> batchSize = Property.ofValue(500);
+    private Property<Integer> batchSize = Property.ofValue(100);
 
     @Override
     public PurgeExecutions.Output run(RunContext runContext) throws Exception {


### PR DESCRIPTION
As 500 may be too much if executions are huge as the batch will be loaded in memory.
