### PR TITLE
refactor(ui): convert HomePageHeader component to TypeScript

### DIFF
--- a/ui/src/components/content/HomePageHeader.vue
+++ b/ui/src/components/content/HomePageHeader.vue
@@ -1,16 +1,16 @@
 <template>
-  <div class="home-page-header">
-    <h2>{{ title }}</h2>
-    <slot />
-  </div>
+    <div class="home-page-header">
+        <h2>{{ title }}</h2>
+        <slot />
+    </div>
 </template>
 
 <script setup lang="ts">
-interface Props {
-  title?: string
-}
+    interface Props {
+        title?: string
+    }
 
-const props = defineProps<Props>()
+    defineProps<Props>()
 </script>
 
 <style lang="scss" scoped>

--- a/ui/src/components/content/HomePageHeader.vue
+++ b/ui/src/components/content/HomePageHeader.vue
@@ -1,37 +1,36 @@
 <template>
-    <div class="home-page-header">
-        <h2>{{ title }}</h2>
-        <slot />
-    </div>
+  <div class="home-page-header">
+    <h2>{{ title }}</h2>
+    <slot />
+  </div>
 </template>
 
-<script setup>
-    defineProps({
-        title: {
-            type: String,
-            default: ""
-        }
-    })
+<script setup lang="ts">
+interface Props {
+  title?: string
+}
+
+const props = defineProps<Props>()
 </script>
 
 <style lang="scss" scoped>
+$font-size-md: 1.5rem;
+$font-size-xs: .875rem;
 
-    $font-size-md: 1.5rem;
-    $font-size-xs: .875rem;
-    .home-page-header {
-        h2 {
-            padding-top: 0;
-            font-size: $font-size-md;
-            font-weight: 400;
-            margin-top: 2rem;
-            margin-bottom: .75rem;
-            border: none;
-        }
+.home-page-header {
+  h2 {
+    padding-top: 0;
+    font-size: $font-size-md;
+    font-weight: 400;
+    margin-top: 2rem;
+    margin-bottom: .75rem;
+    border: none;
+  }
 
-        :deep(p){
-            font-size: $font-size-xs;
-            line-height: 1.5em;
-            margin: .5rem 0;
-        }
-    }
+  :deep(p) {
+    font-size: $font-size-xs;
+    line-height: 1.5em;
+    margin: .5rem 0;
+  }
+}
 </style>


### PR DESCRIPTION
Closes #11716  

### What changes are being made and why?  
This PR refactors the `HomePageHeader.vue` component to use TypeScript with the Composition API, improving type safety and consistency across the codebase.  

**Changes:**  
- Converted `<script setup>` to TypeScript (`lang="ts`)  
- Defined a `Props` interface and migrated the `title` prop to TypeScript syntax  
- Kept `title` optional to preserve the original default behavior  
- Aligned the component with project-wide TypeScript migration standards  

This improves type safety, maintainability, and consistency with other components already migrated to TypeScript.  

---

### How the changes have been QAed?  
This is a refactoring change with no functional modifications. The component behavior remains identical:  

- The `title` is still rendered as a header  
- Slot content displays as expected  
- No changes to styles or layout  

**Manual testing confirmed:**  
- No linter errors  
- TypeScript compilation passes  
- Component renders correctly with proper typing  

---

### Setup Instructions  
No setup required. This is an internal refactoring with no user-facing changes or external dependencies.  
