### PR TITLE
fix(core): obfuscate secrets used as default inputs (#11681)

### DIFF
--- a/ui/src/components/flows/FlowRun.vue
+++ b/ui/src/components/flows/FlowRun.vue
@@ -6,7 +6,7 @@
         </el-alert>
 
         <el-form labelPosition="top" :model="inputs" ref="form" @submit.prevent="false">
-            <InputsForm :initialInputs="flow.inputs" :selectedTrigger="selectedTrigger" :flow="flow" v-model="inputs" :executeClicked="executeClicked" @confirm="onSubmit($refs.form)" />
+            <InputsForm :initialInputs="flow.inputs" :selectedTrigger="selectedTrigger" :flow="flow" v-model="inputs" :executeClicked="executeClicked" @confirm="onSubmit($refs.form)" @update:model-value-no-default="values => inputsNoDefaults=values" />
 
             <el-collapse v-model="collapseName">
                 <el-collapse-item :title="$t('advanced configuration')" name="advanced">
@@ -105,6 +105,7 @@
         data() {
             return {
                 inputs: {},
+                inputsNoDefaults: {},
                 inputNewLabel: "",
                 executionLabels: [],
                 scheduleDate: undefined,
@@ -183,7 +184,7 @@
                                 formRef,
                                 id: this.flow.id,
                                 namespace: this.flow.namespace,
-                                inputs: this.inputs,
+                                inputs: this.inputsNoDefaults,
                                 labels: [...new Set(
                                     this.executionLabels
                                         .filter(label => label.key && label.value)
@@ -192,7 +193,7 @@
                                 scheduleDate: this.scheduleDate
                             });
                         } else {
-                            executeTask(this, this.flow, this.inputs, {
+                            executeTask(this, this.flow, this.inputsNoDefaults, {
                                 redirect: this.redirect,
                                 newTab: this.newTab,
                                 id: this.flow.id,

--- a/ui/src/components/inputs/InputsForm.vue
+++ b/ui/src/components/inputs/InputsForm.vue
@@ -339,7 +339,7 @@
                 editableItems: {},
             };
         },
-        emits: ["update:modelValue", "confirm", "validation"],
+        emits: ["update:modelValue", "update:modelValueNoDefault", "confirm", "validation"],
         created() {
             this.inputsMetaData = JSON.parse(JSON.stringify(this.initialInputs));
             this.debouncedValidation = debounce(this.validateInputs, 500)
@@ -356,6 +356,7 @@
                             // to avoid too many calls to the server
                             this.debouncedValidation();
                             this.$emit("update:modelValue", this.inputsValues);
+                            this.$emit("update:modelValueNoDefault", this.inputsValuesWithNoDefault());
                         }
                         this.previousInputsValues = JSON.parse(JSON.stringify(val))
                     },
@@ -441,6 +442,7 @@
                 }, 2000);
                 input.isDefault = false;
                 this.$emit("update:modelValue", this.inputsValues);
+                this.$emit("update:modelValueNoDefault", this.inputsValuesWithNoDefault());
             },
             onSubmit() {
                 this.$emit("confirm");
@@ -467,6 +469,12 @@
                 this.inputsValues[input.id] = e.target.value;
                 this.onChange(input);
             },
+            inputsValuesWithNoDefault() {
+                return this.inputsMetaData.reduce((acc, input) => {
+                    acc[input.id] = input.isDefault ? undefined : this.inputsValues[input.id];
+                    return acc;
+                }, {});
+            },
             numberHint(input){
                 const {min, max} = input;
 
@@ -484,10 +492,7 @@
                     return;
                 }
               
-                const inputsValuesWithNoDefault = this.inputsMetaData.reduce((acc, input) => {
-                    acc[input.id] = input.isDefault ? undefined : this.inputsValues[input.id];
-                    return acc;
-                }, {});
+                const inputsValuesWithNoDefault = this.inputsValuesWithNoDefault();
                 
                 const formData = inputsToFormData(this, this.inputsMetaData, inputsValuesWithNoDefault);
 

--- a/webserver/src/main/java/io/kestra/webserver/controllers/api/ExecutionController.java
+++ b/webserver/src/main/java/io/kestra/webserver/controllers/api/ExecutionController.java
@@ -170,7 +170,7 @@ public class ExecutionController {
 
     @Inject
     private ApplicationEventPublisher<CrudEvent<Execution>> eventPublisher;
-
+    
     @Inject
     private RunContextFactory runContextFactory;
 


### PR DESCRIPTION
Make sure values return from pebble function are obfuscate when return from the input validation endpoints.

Changes:
* UI: Don't send default input values when creating new execution

Fixes: #11681