### PR TITLE
refactor(ui): convert GuidesChildCard.vue to TypeScript with Composit…

### DIFF
--- a/ui/src/components/content/GuidesChildCard.vue
+++ b/ui/src/components/content/GuidesChildCard.vue
@@ -2,16 +2,11 @@
     <ChildCard :pageUrl="pageUrl" />
 </template>
 
-<script>
+<script setup lang="ts">
+    import {defineProps} from "vue";
     import ChildCard from "./ChildCard.vue";
 
-    export default {
-        components: {ChildCard},
-        props: {
-            pageUrl: {
-                type: String,
-                default: undefined
-            }
-        }
-    }
+    defineProps<{
+        pageUrl?: string;
+    }>();
 </script>

--- a/ui/src/components/content/GuidesChildCard.vue
+++ b/ui/src/components/content/GuidesChildCard.vue
@@ -1,12 +1,9 @@
 <template>
-    <ChildCard :pageUrl="pageUrl" />
+    <ChildCard :pageUrl />
 </template>
 
 <script setup lang="ts">
-    import {defineProps} from "vue";
     import ChildCard from "./ChildCard.vue";
 
-    defineProps<{
-        pageUrl?: string;
-    }>();
+    defineProps<{ pageUrl?: string }>();
 </script>


### PR DESCRIPTION
closes #11714

This PR refactors the GuidesChildCard.vue component to use TypeScript and the Composition API.

### Changes
- Converted component to <script setup lang="ts">
- Added typed props definition (pageUrl?: string)
- Kept ChildCard.vue import as is

### Notes
When importing ChildCard.vue, TypeScript shows a TS7016 warning ("Could not find a declaration file for module ...").  
The proper fix would be to add a global type declaration (e.g. env.d.ts with `declare module "*.vue"`).  

For this PR, I kept the scope minimal and added a brief comment in the code to indicate the possible fix, following the issue’s request for a small and focused change.
