### PR TITLE
fix(ui): correct CSS variable usage for --bs-code-color

### DIFF
--- a/ui/src/styles/layout/root.scss
+++ b/ui/src/styles/layout/root.scss
@@ -39,7 +39,7 @@
         #{--el-color-alert-#{$type}}: var(--ks-content-#{$type});
     }
 
-    --bs-code-color: $base-purple-600;
+    #{--bs-code-color}: $base-purple-600;
 
     #{--card-bg}: var(--ks-background-card);
     #{--input-bg}: var(--ks-background-input);


### PR DESCRIPTION
closes #11682

This PR fixes the CSS variable declaration for `--bs-code-color` in `root.scss`.

Previously, it was declared as a plain CSS variable, which caused issues with SCSS compilation. 
Now it uses SCSS interpolation (`#{--bs-code-color}`), ensuring that the variable is parsed and applied correctly.

### Changes
- Updated `root.scss` to correctly define the `--bs-code-color` variable.
- Verified the UI to ensure the updated variable is applied as expected.

### Screenshots
<img width="348" height="139" alt="print-1" src="https://github.com/user-attachments/assets/1fc96945-3dfb-4839-8987-fa852afc84ec" />
