### PR TITLE
Fix: Ensure flowable Switch task executes children in parallel #11745

### DIFF
--- a/core/src/main/java/io/kestra/plugin/core/flow/Switch.java
+++ b/core/src/main/java/io/kestra/plugin/core/flow/Switch.java
@@ -191,12 +191,16 @@ public class Switch extends Task implements FlowableTask<Switch.Output> {
 
     @Override
     public List<NextTaskRun> resolveNexts(RunContext runContext, Execution execution, TaskRun parentTaskRun) throws IllegalVariableEvaluationException {
-        return FlowableUtils.resolveSequentialNexts(
+        List<ResolvedTask> childTasks = this.childTasks(runContext, parentTaskRun);
+        Integer concurrency = 0;
+
+        return FlowableUtils.resolveParallelNexts(
             execution,
-            this.childTasks(runContext, parentTaskRun),
+            childTasks,
             FlowableUtils.resolveTasks(this.errors, parentTaskRun),
             FlowableUtils.resolveTasks(this._finally, parentTaskRun),
-            parentTaskRun
+            parentTaskRun,
+            concurrency
         );
     }
 

--- a/core/src/test/java/io/kestra/plugin/core/flow/SwitchTest.java
+++ b/core/src/test/java/io/kestra/plugin/core/flow/SwitchTest.java
@@ -100,4 +100,22 @@ class SwitchTest {
 
         assertThat(execution.getState().getCurrent()).isEqualTo(State.Type.FAILED);
     }
+
+    @Test
+    @LoadFlows({"flows/valids/switch-flowable-parallel.yaml"})
+    void flowableSwitch_parallelExecution() throws TimeoutException, QueueException {
+        Execution execution = runnerUtils.runOne(
+            MAIN_TENANT,
+            "io.kestra.tests",
+            "switch-flowable-parallel"
+        );
+
+        assertThat(execution.getState().getCurrent()).isEqualTo(State.Type.SUCCESS);
+
+        assertThat(execution.findTaskRunsByTaskId("task_A")).hasSize(1);
+        assertThat(execution.findTaskRunsByTaskId("task_B")).hasSize(1);
+
+        assertThat(execution.getState().getDuration().toSeconds()).isLessThan(3);
+    }
+
 }

--- a/core/src/test/resources/flows/valids/switch-flowable-parallel.yaml
+++ b/core/src/test/resources/flows/valids/switch-flowable-parallel.yaml
@@ -1,0 +1,17 @@
+id: switch-flowable-parallel
+namespace: io.kestra.tests
+
+tasks:
+  - id: my_flowable_switch
+    type: io.kestra.plugin.core.flow.Switch
+    allowFailure: true
+    value: "A"
+    cases:
+      "A":
+        - id: task_A
+          type: io.kestra.plugin.core.flow.Sleep
+          duration: PT2S
+
+        - id: task_B
+          type: io.kestra.plugin.core.flow.Sleep
+          duration: PT2S


### PR DESCRIPTION
Closes #11745 

**Summary**

This PR addresses a runtime logic bug in the `flowable Switch` task. When a `Switch` task was made `flowable` (e.g., with `allowFailure: true`), it would incorrectly execute the list of tasks in the chosen `case` sequentially, one after another. This defeated the purpose of a flowable task, which is expected to handle child tasks as independent, parallel operations.

This behavior was often hidden by very fast tasks (like `Log`) but became obvious when using tasks with a duration (like `Sleep`), which would cause the total execution time to be the sum of all task durations instead of the duration of the longest task.

**Solution**

The root cause was in the `resolveNexts` method of `Switch.java`, which was incorrectly using the `FlowableUtils.resolveSequentialNexts` utility.

This has been changed to use `FlowableUtils.resolveParallelNexts`, which correctly schedules the child tasks as concurrent operations. A concurrency of `0` (unlimited) is used, as the Switch task itself doesn't impose a concurrency limit on its children.

**How to Test**

1.  Create and execute the following flow:
    ```yaml
    id: definitive_switch_fix_test
    namespace: dev
    
    tasks:
      - id: my_flowable_switch
        type: io.kestra.plugin.core.flow.Switch
        allowFailure: true 
        value: "A"
        cases:
          "A":
            - id: task_A
              type: io.kestra.plugin.core.flow.Sleep
              duration: PT5S
    
            - id: task_B
              type: io.kestra.plugin.core.flow.Sleep
              duration: PT5S
    ```
2.  Observe the **Gantt chart** for the execution. The two `Sleep` tasks will start at the same time and run in parallel. The total execution duration for the switch will be **\~5 seconds**, not \~10 seconds.

**Checklist**

  - [x] A new unit test, `flowableSwitch_parallelExecution`, has been added to `SwitchTest.java` to cover this specific case and prevent regressions. The test asserts that the total execution duration is less than the sum of the individual task durations, confirming parallel execution.


### Before
<img width="1920" height="1172" alt="Screenshot from 2025-10-04 19-23-51" src="https://github.com/user-attachments/assets/d0589436-3455-4cc5-8c5d-947565852922" />

### After
<img width="1920" height="1172" alt="Screenshot from 2025-10-04 22-53-11" src="https://github.com/user-attachments/assets/5167aa53-eabb-470a-9a12-72d70c1ef6ad" />
