### PR TITLE
fix(ui): improve multi-select behavior and directory detection (closes #8423)

### DIFF
--- a/ui/src/components/inputs/EditorSidebar.vue
+++ b/ui/src/components/inputs/EditorSidebar.vue
@@ -315,19 +315,7 @@
             @keydown.enter.prevent="removeItems()"
         >
             <span class="py-3">
-                {{
-                    foldersCount > 0 && filesCount > 0
-                        ? $t("namespace files.dialog.mixed_deletion_description", {folders: foldersCount, files: filesCount})
-                        : foldersCount > 1
-                            ? $t("namespace files.dialog.folders_deletion_description", {count: foldersCount})
-                            : foldersCount === 1
-                                ? $t("namespace files.dialog.folder_deletion_description")
-                                : filesCount > 1
-                                    ? $t("namespace files.dialog.files_deletion_description", {count: filesCount})
-                                    : $t("namespace files.dialog.file_deletion_description")
-                }}
-
-
+                {{ confirmationMessage }}                
             </span>
             <template #footer>
                 <div>
@@ -359,7 +347,7 @@
     </div>
 </template>
 
-<script lang="ts">
+<script>
     import {mapStores} from "pinia";
     import {useNamespacesStore} from "override/stores/namespaces";
     import {useEditorStore} from "../../stores/editor";
@@ -471,11 +459,17 @@
                     ? this.$t("namespace files.dialog.folder_deletion")
                     : this.$t("namespace files.dialog.file_deletion");
             },
-            filesCount() {
-                return this.confirmation.nodes?.filter(n => n.type === "File").length ?? 0;
-            },
-            foldersCount() {
-                return this.confirmation.nodes?.filter(n => n.type === "Directory").length ?? 0;
+            confirmationMessage() {
+                const files = this.confirmation.nodes?.filter(n => n.type === "File").length ?? 0;
+                const folders = this.confirmation.nodes?.filter(n => n.type === "Directory").length ?? 0;
+
+                if (folders > 0 && files > 0) {
+                    return this.$t("namespace files.dialog.mixed_deletion_description", {folders, files});
+                } else if (folders > 0) {
+                    return this.$t("namespace files.dialog.folders_deletion_description", {count: folders});
+                } else {
+                    return this.$t("namespace files.dialog.files_deletion_description", {count: files});
+                }
             },
         },
         methods: {

--- a/ui/src/components/inputs/EditorSidebar.vue
+++ b/ui/src/components/inputs/EditorSidebar.vue
@@ -310,20 +310,18 @@
 
         <el-dialog
             v-model="confirmation.visible"
-            :title="confirmationTitle"
+            :title="confirmationLabels.title"
             width="500"
             @keydown.enter.prevent="removeItems()"
         >
-            <span class="py-3">
-                {{ confirmationMessage }}                
-            </span>
+            <span class="py-3" v-html="confirmationLabels.message" />
             <template #footer>
                 <div>
                     <el-button @click="confirmation.visible = false">
                         {{ $t("cancel") }}
                     </el-button>
                     <el-button type="primary" @click="removeItems()">
-                        {{ $t("namespace files.dialog.confirm") }}
+                        {{ $t("namespace files.dialog.deletion.confirm") }}
                     </el-button>
                 </div>
             </template>
@@ -443,33 +441,17 @@
 
                 return extractPaths(undefined, this.items);
             },
-            confirmationTitle() {
-                if (!this.confirmation.nodes || this.confirmation.nodes.length === 0) {
-                    return ""; // Return an empty string if no nodes are selected
-                }
-
-                if (this.confirmation.nodes.length > 1) {
-                    // Bulk deletion title
-                    return this.$t("namespace files.dialog.file_deletion");
-                }
-
-                // Single node deletion title
-                const node = this.confirmation.nodes[0];
-                return node.type === "Directory"
-                    ? this.$t("namespace files.dialog.folder_deletion")
-                    : this.$t("namespace files.dialog.file_deletion");
-            },
-            confirmationMessage() {
+            confirmationLabels() {
                 const files = this.confirmation.nodes?.filter(n => n.type === "File").length ?? 0;
                 const folders = this.confirmation.nodes?.filter(n => n.type === "Directory").length ?? 0;
 
-                if (folders > 0 && files > 0) {
-                    return this.$t("namespace files.dialog.mixed_deletion_description", {folders, files});
-                } else if (folders > 0) {
-                    return this.$t("namespace files.dialog.folders_deletion_description", {count: folders});
-                } else {
-                    return this.$t("namespace files.dialog.files_deletion_description", {count: files});
-                }
+                const labels = {title: this.$t("namespace files.dialog.deletion.title"), message: ""};
+
+                if (folders > 0 && files > 0) labels.message = this.$t("namespace files.dialog.deletion.mixed", {folders, files});
+                else if (folders > 0) labels.message = this.$t("namespace files.dialog.deletion.folders", {count: folders});
+                else labels.message = this.$t("namespace files.dialog.deletion.files", {count: files});
+
+                return labels;
             },
         },
         methods: {

--- a/ui/src/components/inputs/EditorSidebar.vue
+++ b/ui/src/components/inputs/EditorSidebar.vue
@@ -316,12 +316,18 @@
         >
             <span class="py-3">
                 {{
-                    confirmation.nodes.length > 1
-                        ? $t("namespace files.dialog.file_deletion_description")
-                        : confirmation.nodes[0]?.type === "Directory"
-                            ? $t("namespace files.dialog.folder_deletion_description")
-                            : $t("namespace files.dialog.file_deletion_description")
+                    foldersCount > 0 && filesCount > 0
+                        ? $t("namespace files.dialog.mixed_deletion_description", {folders: foldersCount, files: filesCount})
+                        : foldersCount > 1
+                            ? $t("namespace files.dialog.folders_deletion_description", {count: foldersCount})
+                            : foldersCount === 1
+                                ? $t("namespace files.dialog.folder_deletion_description")
+                                : filesCount > 1
+                                    ? $t("namespace files.dialog.files_deletion_description", {count: filesCount})
+                                    : $t("namespace files.dialog.file_deletion_description")
                 }}
+
+
             </span>
             <template #footer>
                 <div>
@@ -353,7 +359,7 @@
     </div>
 </template>
 
-<script>
+<script lang="ts">
     import {mapStores} from "pinia";
     import {useNamespacesStore} from "override/stores/namespaces";
     import {useEditorStore} from "../../stores/editor";
@@ -464,6 +470,12 @@
                 return node.type === "Directory"
                     ? this.$t("namespace files.dialog.folder_deletion")
                     : this.$t("namespace files.dialog.file_deletion");
+            },
+            filesCount() {
+                return this.confirmation.nodes?.filter(n => n.type === "File").length ?? 0;
+            },
+            foldersCount() {
+                return this.confirmation.nodes?.filter(n => n.type === "Directory").length ?? 0;
             },
         },
         methods: {

--- a/ui/src/components/namespaces/components/NamespaceFilesEditorView.vue
+++ b/ui/src/components/namespaces/components/NamespaceFilesEditorView.vue
@@ -1132,7 +1132,7 @@ ul.tabs-context {
 }
 </style>
 
-<style lang="scss" scoped>
+<style lang="scss">
     .tabs .el-scrollbar__bar.is-horizontal {
         height: 1px !important;
     }

--- a/ui/src/components/namespaces/components/NamespaceFilesEditorView.vue
+++ b/ui/src/components/namespaces/components/NamespaceFilesEditorView.vue
@@ -1132,7 +1132,7 @@ ul.tabs-context {
 }
 </style>
 
-<style lang="scss">
+<style lang="scss" scoped>
     .tabs .el-scrollbar__bar.is-horizontal {
         height: 1px !important;
     }

--- a/ui/src/translations/en.json
+++ b/ui/src/translations/en.json
@@ -708,12 +708,10 @@
           "folder": "Folder name:"
         },
         "parent_folder": "Parent folder:",
-        "file_deletion_description": "Are you sure you want to delete the selected file?",
-        "files_deletion_description": "Are you sure you want to delete {count} files?",
-        "folder_deletion_description": "Are you sure you want to delete this folder and all of its contents?",
-        "folders_deletion_description": "Are you sure you want to delete {count} folders and all of its contents?",
-        "mixed_deletion_description": "Are you sure you want to delete {folders} folders and {files} files?",
-        "confirm": "Confirm"
+        "confirm": "Confirm",
+        "files_deletion_description": "Are you sure you want to delete {count} file(s)?",
+        "folders_deletion_description": "Are you sure you want to delete {count} folder(s) and all of its contents?",
+        "mixed_deletion_description": "Are you sure you want to delete {folders} folder(s) and {files} file(s)?"
       },
       "path": {
         "copy": "Copy path",

--- a/ui/src/translations/en.json
+++ b/ui/src/translations/en.json
@@ -708,10 +708,13 @@
           "folder": "Folder name:"
         },
         "parent_folder": "Parent folder:",
-        "confirm": "Confirm",
-        "files_deletion_description": "Are you sure you want to delete {count} file(s)?",
-        "folders_deletion_description": "Are you sure you want to delete {count} folder(s) and all of its contents?",
-        "mixed_deletion_description": "Are you sure you want to delete {folders} folder(s) and {files} file(s)?"
+        "deletion": {
+          "confirm": "Confirm",
+          "title": "Confirm deletion of content",
+          "files": "Are you sure you want to delete <code>{count}</code> file(s)?",
+          "folders": "Are you sure you want to delete <code>{count}</code> folder(s) and all of its contents?",
+          "mixed": "Are you sure you want to delete <code>{folders}</code> folder(s) and <code>{files}</code> file(s)?"
+        }
       },
       "path": {
         "copy": "Copy path",

--- a/ui/src/translations/en.json
+++ b/ui/src/translations/en.json
@@ -708,10 +708,11 @@
           "folder": "Folder name:"
         },
         "parent_folder": "Parent folder:",
-        "file_deletion": "Confirm file deletion",
-        "folder_deletion": "Confirm folder deletion",
         "file_deletion_description": "Are you sure you want to delete the selected file(s)?",
+        "files_deletion_description": "Are you sure you want to delete {count} files?",
         "folder_deletion_description": "Are you sure you want to delete this folder and all of its contents?",
+        "folders_deletion_description": "Are you sure you want to delete {count} folders?",
+        "mixed_deletion_description": "Are you sure you want to delete {folders} folders and {files} files?",
         "confirm": "Confirm"
       },
       "path": {

--- a/ui/src/translations/en.json
+++ b/ui/src/translations/en.json
@@ -708,10 +708,10 @@
           "folder": "Folder name:"
         },
         "parent_folder": "Parent folder:",
-        "file_deletion_description": "Are you sure you want to delete the selected file(s)?",
+        "file_deletion_description": "Are you sure you want to delete the selected file?",
         "files_deletion_description": "Are you sure you want to delete {count} files?",
         "folder_deletion_description": "Are you sure you want to delete this folder and all of its contents?",
-        "folders_deletion_description": "Are you sure you want to delete {count} folders?",
+        "folders_deletion_description": "Are you sure you want to delete {count} folders and all of its contents?",
         "mixed_deletion_description": "Are you sure you want to delete {folders} folders and {files} files?",
         "confirm": "Confirm"
       },


### PR DESCRIPTION
Relates to https://github.com/kestra-io/kestra/issues/8423.

**This PR implements a small fix to improve the messages displayed when deleting files and folders.**

Previously, a single generic message was shown for any type of deletion.
Now, the messages are customized according to the type and number of items being deleted:

✅ **Specific message for deleting 1 file**
<img width="1615" height="634" alt="image" src="https://github.com/user-attachments/assets/f1d25e81-e1c8-453e-9f4f-990af9f9b2ff" />


**✅ Specific message for deleting 2 or more files**
<img width="1598" height="566" alt="image" src="https://github.com/user-attachments/assets/3597b66b-7f76-40cf-b940-d225793346be" />


✅ **Specific message for deleting 1 folder**
<img width="1569" height="613" alt="image" src="https://github.com/user-attachments/assets/9ad1bcc3-5560-45f2-9cbb-f8516d82f081" />


**✅ Specific message for deleting 2 or more folders**
<img width="1286" height="686" alt="image" src="https://github.com/user-attachments/assets/472811d1-c936-406b-8726-f06148e64165" />


**✅ Specific message for deleting both files and folders at the same time**
<img width="1492" height="605" alt="image" src="https://github.com/user-attachments/assets/652900f5-a57a-450d-b540-67667f1c1e57" />

Thank you for the opportunity to contribute to this project. I’m honored to be part of it. 