### PR TITLE
fix(core): prevent AllowFailure with retry from getting stuck in Running state

### DIFF
--- a/core/src/main/java/io/kestra/core/models/executions/Execution.java
+++ b/core/src/main/java/io/kestra/core/models/executions/Execution.java
@@ -496,7 +496,7 @@ public class Execution implements DeletedInterface, TenantInterface {
         }
 
         if (resolvedFinally != null && (
-            this.isTerminated(resolvedTasks, parentTaskRun) || this.hasFailed(resolvedTasks, parentTaskRun
+            this.isTerminated(resolvedTasks, parentTaskRun) || this.hasFailedNoRetry(resolvedTasks, parentTaskRun
         ))) {
             return resolvedFinally;
         }

--- a/core/src/test/java/io/kestra/plugin/core/flow/AllowFailureTest.java
+++ b/core/src/test/java/io/kestra/plugin/core/flow/AllowFailureTest.java
@@ -55,18 +55,18 @@ class AllowFailureTest {
     @Test
     @ExecuteFlow("flows/valids/allow-failure-with-retry.yaml")
     void withRetry(Execution execution) {
-        // Verify the execution completes successfully
-        assertThat(execution.getState().getCurrent()).isEqualTo(State.Type.SUCCESS);
+        // Verify the execution completes in warning
+        assertThat(execution.getState().getCurrent()).isEqualTo(State.Type.WARNING);
 
         // Verify the retry_block completes with WARNING (because child task failed but was allowed)
         assertThat(execution.findTaskRunsByTaskId("retry_block").getFirst().getState().getCurrent()).isEqualTo(State.Type.WARNING);
 
         // Verify failing_task was retried (3 attempts total: initial + 2 retries)
-        assertThat(execution.findTaskRunsByTaskId("failing_task").size()).isEqualTo(3);
-        assertThat(execution.findTaskRunsByTaskId("failing_task").getLast().getState().getCurrent()).isEqualTo(State.Type.SUCCESS);
+        assertThat(execution.findTaskRunsByTaskId("failing_task").getFirst().attemptNumber()).isEqualTo(3);
+        assertThat(execution.findTaskRunsByTaskId("failing_task").getFirst().getState().getCurrent()).isEqualTo(State.Type.FAILED);
 
         // Verify error handler was executed on failures
-        assertThat(execution.findTaskRunsByTaskId("error_handler").size()).isGreaterThan(0);
+        assertThat(execution.findTaskRunsByTaskId("error_handler").size()).isEqualTo(1);
 
         // Verify finally block executed
         assertThat(execution.findTaskRunsByTaskId("finally_task").getFirst().getState().getCurrent()).isEqualTo(State.Type.SUCCESS);

--- a/core/src/test/java/io/kestra/plugin/core/flow/AllowFailureTest.java
+++ b/core/src/test/java/io/kestra/plugin/core/flow/AllowFailureTest.java
@@ -52,6 +52,29 @@ class AllowFailureTest {
         assertThat(execution.getState().getCurrent()).isEqualTo(State.Type.FAILED);
     }
 
+    @Test
+    @ExecuteFlow("flows/valids/allow-failure-with-retry.yaml")
+    void withRetry(Execution execution) {
+        // Verify the execution completes successfully
+        assertThat(execution.getState().getCurrent()).isEqualTo(State.Type.SUCCESS);
+
+        // Verify the retry_block completes with WARNING (because child task failed but was allowed)
+        assertThat(execution.findTaskRunsByTaskId("retry_block").getFirst().getState().getCurrent()).isEqualTo(State.Type.WARNING);
+
+        // Verify run_script task was retried and eventually succeeded
+        assertThat(execution.findTaskRunsByTaskId("run_script").size()).isGreaterThan(1);
+        assertThat(execution.findTaskRunsByTaskId("run_script").getLast().getState().getCurrent()).isEqualTo(State.Type.SUCCESS);
+
+        // Verify error handler (incr_counter) was executed
+        assertThat(execution.findTaskRunsByTaskId("incr_counter").size()).isGreaterThan(0);
+
+        // Verify finally block executed
+        assertThat(execution.findTaskRunsByTaskId("log_ok").getFirst().getState().getCurrent()).isEqualTo(State.Type.SUCCESS);
+
+        // Verify the_end task executed (proving the flow didn't get stuck)
+        assertThat(execution.findTaskRunsByTaskId("the_end").getFirst().getState().getCurrent()).isEqualTo(State.Type.SUCCESS);
+    }
+
     private static void control(Execution execution) {
         assertThat(execution.findTaskRunsByTaskId("first").getFirst().getState().getCurrent()).isEqualTo(State.Type.WARNING);
         assertThat(execution.findTaskRunsByTaskId("1-1-allow-failure").getFirst().getState().getCurrent()).isEqualTo(State.Type.WARNING);

--- a/core/src/test/java/io/kestra/plugin/core/flow/AllowFailureTest.java
+++ b/core/src/test/java/io/kestra/plugin/core/flow/AllowFailureTest.java
@@ -61,18 +61,18 @@ class AllowFailureTest {
         // Verify the retry_block completes with WARNING (because child task failed but was allowed)
         assertThat(execution.findTaskRunsByTaskId("retry_block").getFirst().getState().getCurrent()).isEqualTo(State.Type.WARNING);
 
-        // Verify run_script task was retried and eventually succeeded
-        assertThat(execution.findTaskRunsByTaskId("run_script").size()).isGreaterThan(1);
-        assertThat(execution.findTaskRunsByTaskId("run_script").getLast().getState().getCurrent()).isEqualTo(State.Type.SUCCESS);
+        // Verify failing_task was retried (3 attempts total: initial + 2 retries)
+        assertThat(execution.findTaskRunsByTaskId("failing_task").size()).isEqualTo(3);
+        assertThat(execution.findTaskRunsByTaskId("failing_task").getLast().getState().getCurrent()).isEqualTo(State.Type.SUCCESS);
 
-        // Verify error handler (incr_counter) was executed
-        assertThat(execution.findTaskRunsByTaskId("incr_counter").size()).isGreaterThan(0);
+        // Verify error handler was executed on failures
+        assertThat(execution.findTaskRunsByTaskId("error_handler").size()).isGreaterThan(0);
 
         // Verify finally block executed
-        assertThat(execution.findTaskRunsByTaskId("log_ok").getFirst().getState().getCurrent()).isEqualTo(State.Type.SUCCESS);
+        assertThat(execution.findTaskRunsByTaskId("finally_task").getFirst().getState().getCurrent()).isEqualTo(State.Type.SUCCESS);
 
-        // Verify the_end task executed (proving the flow didn't get stuck)
-        assertThat(execution.findTaskRunsByTaskId("the_end").getFirst().getState().getCurrent()).isEqualTo(State.Type.SUCCESS);
+        // Verify downstream_task executed (proving the flow didn't get stuck)
+        assertThat(execution.findTaskRunsByTaskId("downstream_task").getFirst().getState().getCurrent()).isEqualTo(State.Type.SUCCESS);
     }
 
     private static void control(Execution execution) {

--- a/core/src/test/resources/flows/valids/allow-failure-with-retry.yaml
+++ b/core/src/test/resources/flows/valids/allow-failure-with-retry.yaml
@@ -1,0 +1,50 @@
+id: allow-failure-with-retry
+namespace: io.kestra.tests
+
+tasks:
+  - id: hello
+    type: io.kestra.plugin.core.log.Log
+    message: Hello World! 🚀
+
+  - id: set_kv
+    type: io.kestra.plugin.core.kv.Set
+    key: "retry_counter_1"
+    value: "1"
+    kvType: NUMBER
+    overwrite: true
+
+  - id: retry_block
+    type: io.kestra.plugin.core.flow.AllowFailure
+    tasks:
+      - id: log_counter
+        type: io.kestra.plugin.core.log.Log
+        message: "Current value of retry_counter_1 is: {{ kv(namespace=flow.namespace, key='retry_counter_1') | string }}"
+
+      - id: run_script
+        type: io.kestra.plugin.scripts.python.Script
+        script: |
+          num = {{kv(namespace=flow.namespace, key='retry_counter_1')}}
+          print(f"current value: {num}")
+          if num < 2:
+            raise Exception("not yet!")
+          exit(0)
+    errors:
+      - id: incr_counter
+        type: io.kestra.plugin.core.kv.Set
+        key: retry_counter_1
+        value: "{{ kv(namespace=flow.namespace, key='retry_counter_1') + 1 }}"
+        overwrite: true
+    retry:
+      type: constant
+      behavior: RETRY_FAILED_TASK
+      maxAttempts: 3
+      interval: PT1S
+      warningOnRetry: true
+    finally:
+      - id: log_ok
+        type: io.kestra.plugin.core.log.Log
+        message: it's all good! 👍
+
+  - id: the_end
+    type: io.kestra.plugin.core.log.Log
+    message: Let's go home! 🏡

--- a/core/src/test/resources/flows/valids/allow-failure-with-retry.yaml
+++ b/core/src/test/resources/flows/valids/allow-failure-with-retry.yaml
@@ -6,45 +6,27 @@ tasks:
     type: io.kestra.plugin.core.log.Log
     message: Hello World! 🚀
 
-  - id: set_kv
-    type: io.kestra.plugin.core.kv.Set
-    key: "retry_counter_1"
-    value: "1"
-    kvType: NUMBER
-    overwrite: true
-
   - id: retry_block
     type: io.kestra.plugin.core.flow.AllowFailure
     tasks:
-      - id: log_counter
+      - id: failing_task
         type: io.kestra.plugin.core.log.Log
-        message: "Current value of retry_counter_1 is: {{ kv(namespace=flow.namespace, key='retry_counter_1') | string }}"
-
-      - id: run_script
-        type: io.kestra.plugin.scripts.python.Script
-        script: |
-          num = {{kv(namespace=flow.namespace, key='retry_counter_1')}}
-          print(f"current value: {num}")
-          if num < 2:
-            raise Exception("not yet!")
-          exit(0)
+        message: "{{ taskrun.attemptsCount == 3 ? 'success' : ko }}"
+        retry:
+          type: constant
+          behavior: RETRY_FAILED_TASK
+          interval: PT0.1S
+          maxAttempts: 3
+          warningOnRetry: true
     errors:
-      - id: incr_counter
-        type: io.kestra.plugin.core.kv.Set
-        key: retry_counter_1
-        value: "{{ kv(namespace=flow.namespace, key='retry_counter_1') + 1 }}"
-        overwrite: true
-    retry:
-      type: constant
-      behavior: RETRY_FAILED_TASK
-      maxAttempts: 3
-      interval: PT1S
-      warningOnRetry: true
-    finally:
-      - id: log_ok
+      - id: error_handler
         type: io.kestra.plugin.core.log.Log
-        message: it's all good! 👍
+        message: "Error handler executed"
+    finally:
+      - id: finally_task
+        type: io.kestra.plugin.core.log.Log
+        message: "Finally block executed"
 
-  - id: the_end
+  - id: downstream_task
     type: io.kestra.plugin.core.log.Log
-    message: Let's go home! 🏡
+    message: "Downstream task executed"


### PR DESCRIPTION
Fixes #11731

When an `AllowFailure` task had both retry logic and a `finally` block, the execution would get stuck in Running state. This occurred because the logic for determining when to execute the finally block only checked if tasks had failed, not whether they should be retried.