### PR TITLE
fix: file-download-issue

### DIFF
--- a/core/src/main/java/io/kestra/plugin/core/http/Download.java
+++ b/core/src/main/java/io/kestra/plugin/core/http/Download.java
@@ -173,8 +173,8 @@ public class Download extends AbstractHttp implements RunnableTask<Download.Outp
         if (path.indexOf('/') != -1) {
             path = path.substring(path.lastIndexOf('/')); // keep the last segment
         }
-        if (path.indexOf('.') != -1) {
-            return path.substring(path.indexOf('.'));
+        if (path.lastIndexOf('.') != -1) {
+            return path.substring(path.lastIndexOf('.'));
         }
         return null;
     }

--- a/core/src/test/java/io/kestra/core/utils/FileUtilsTest.java
+++ b/core/src/test/java/io/kestra/core/utils/FileUtilsTest.java
@@ -12,5 +12,7 @@ class FileUtilsTest {
         assertThat(FileUtils.getExtension("")).isNull();
         assertThat(FileUtils.getExtension("/file/hello")).isNull();
         assertThat(FileUtils.getExtension("/file/hello.txt")).isEqualTo(".txt");
+        assertThat(FileUtils.getExtension("/file/hello.file with spaces.txt")).isEqualTo(".txt");
+        assertThat(FileUtils.getExtension("/file/hello.file.with.multiple.dots.txt")).isEqualTo(".txt");
     }
 }

--- a/core/src/test/java/io/kestra/plugin/core/http/DownloadTest.java
+++ b/core/src/test/java/io/kestra/plugin/core/http/DownloadTest.java
@@ -217,6 +217,25 @@ class DownloadTest {
         assertThat(output.getUri().toString()).endsWith("filename..jpg");
     }
 
+    @Test
+    void contentDispositionWithSpaceAfterDot() throws Exception {
+        EmbeddedServer embeddedServer = applicationContext.getBean(EmbeddedServer.class);
+        embeddedServer.start();
+
+        Download task = Download.builder()
+            .id(DownloadTest.class.getSimpleName())
+            .type(DownloadTest.class.getName())
+            .uri(Property.ofValue(embeddedServer.getURI() + "/content-disposition-space-after-dot"))
+            .build();
+
+        RunContext runContext = TestsUtils.mockRunContext(this.runContextFactory, task, ImmutableMap.of());
+
+        Download.Output output = task.run(runContext);
+
+        assertThat(output.getUri().toString()).doesNotContain("/secure-path/");
+        assertThat(output.getUri().toString()).endsWith("file.with spaces.txt");
+    }
+
     @Controller()
     public static class SlackWebController {
         @Get("500")
@@ -256,6 +275,12 @@ class DownloadTest {
         public HttpResponse<byte[]> contentDispositionWithDoubleDot() {
             return HttpResponse.ok("Hello World".getBytes())
                 .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=\"/secure-path/filename..jpg\"");
+        }
+
+        @Get("content-disposition-space-after-dot")
+        public HttpResponse<byte[]> contentDispositionWithSpaceAfterDot() {
+            return HttpResponse.ok("Hello World".getBytes())
+                .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=\"file.with spaces.txt\"");
         }
     }
 }

--- a/core/src/test/java/io/kestra/plugin/core/http/DownloadTest.java
+++ b/core/src/test/java/io/kestra/plugin/core/http/DownloadTest.java
@@ -233,7 +233,7 @@ class DownloadTest {
         Download.Output output = task.run(runContext);
 
         assertThat(output.getUri().toString()).doesNotContain("/secure-path/");
-        assertThat(output.getUri().toString()).endsWith("file.with spaces.txt");
+        assertThat(output.getUri().toString()).endsWith("file.with+spaces.txt");
     }
 
     @Controller()


### PR DESCRIPTION
closes: #11569

<!-- Thanks for submitting a Pull Request to Kestra. To help us review your contribution, please follow the guidelines below:

- Make sure that your commits follow the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) specification e.g. `feat(ui): add a new navigation menu item` or `fix(core): fix a bug in the core model` or `docs: update the README.md`. This will help us automatically generate the changelog.
- The title should briefly summarize the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share a flow example to help the reviewer understand and QA the change.
- Use "closes" to automatically close an issue. For example, `closes #1234` will close issue #1234. -->

### What changes are being made and why?

<!-- Please include a brief summary of the changes included in this PR e.g. closes #1234. -->

✅ Fixed file extension extraction in Download plugin to support filenames with spaces after dots.
✅ Updated test coverage to include filenames with spaces and multiple dots.

---

Fix:

Updated `filenameFromURI` in `Download.java` to use `lastIndexOf('.')` for correct extension extraction.
Added test in `DownloadTest.java` for filenames like `file.with spaces.txt`.
Added test in `FileUtilsTest.java` for extension extraction with spaces and multiple dots.