### PR TITLE
fix(ui): align delete icons with form fields in no-code array inputs

### DIFF
--- a/ui/src/components/no-code/components/inputs/InputPair.vue
+++ b/ui/src/components/no-code/components/inputs/InputPair.vue
@@ -140,4 +140,8 @@
 
 <style scoped lang="scss">
 @import "../../styles/code.scss";
+
+.delete {
+    min-height: 32px;
+}
 </style>

--- a/ui/src/components/no-code/components/tasks/TaskArray.vue
+++ b/ui/src/components/no-code/components/tasks/TaskArray.vue
@@ -5,7 +5,7 @@
         :gutter="10"
         class="w-100"
     >
-        <el-col :span="2" class="d-flex flex-column justify-content-center mt-1 mb-2 reorder" v-if="items.length > 1">
+        <el-col :span="2" class="d-flex flex-column justify-content-center align-items-center reorder" v-if="items.length > 1">
             <ChevronUp
                 @click.prevent.stop="moveItem(index, 'up')"
                 :class="{disabled: index === 0}"
@@ -143,5 +143,9 @@
     opacity: 0.5;
     pointer-events: none;
     cursor: not-allowed;
+}
+
+.reorder {
+    min-height: 32px;
 }
 </style>

--- a/ui/src/components/no-code/components/tasks/TaskArray.vue
+++ b/ui/src/components/no-code/components/tasks/TaskArray.vue
@@ -5,7 +5,7 @@
         :gutter="10"
         class="w-100"
     >
-        <el-col :span="2" class="d-flex flex-column justify-content-center mt-1 mb-2 reorder" v-if="items.length > 1">
+        <el-col :span="2" class="d-flex flex-column justify-content-center align-items-center reorder" v-if="items.length > 1">
             <ChevronUp
                 @click.prevent.stop="moveItem(index, 'up')"
                 :class="{disabled: index === 0}"
@@ -145,6 +145,7 @@
     cursor: not-allowed;
 }
 
+.reorder,
 .delete {
     min-height: 32px;
 }

--- a/ui/src/components/no-code/components/tasks/TaskArray.vue
+++ b/ui/src/components/no-code/components/tasks/TaskArray.vue
@@ -5,7 +5,7 @@
         :gutter="10"
         class="w-100"
     >
-        <el-col :span="2" class="d-flex flex-column justify-content-center align-items-center reorder" v-if="items.length > 1">
+        <el-col :span="2" class="d-flex flex-column justify-content-center mt-1 mb-2 reorder" v-if="items.length > 1">
             <ChevronUp
                 @click.prevent.stop="moveItem(index, 'up')"
                 :class="{disabled: index === 0}"
@@ -145,7 +145,7 @@
     cursor: not-allowed;
 }
 
-.reorder {
+.delete {
     min-height: 32px;
 }
 </style>

--- a/ui/src/components/no-code/components/tasks/TaskDict.vue
+++ b/ui/src/components/no-code/components/tasks/TaskDict.vue
@@ -154,4 +154,8 @@
 
 <style scoped lang="scss">
 @import "../../styles/code.scss";
+
+.delete {
+    min-height: 32px;
+}
 </style>


### PR DESCRIPTION
fixes #11422 

  ## Summary
  - Fixed vertical alignment of delete icons in array-type inputs (TaskArray, TaskDict, InputPair)
  - Added `min-height: 32px` to `.delete` class to ensure icons align properly with 32px input fields