### PR TITLE
test(core): add test for including running executions in last executions retrieval

### DIFF
--- a/jdbc/src/main/java/io/kestra/jdbc/repository/AbstractJdbcExecutionRepository.java
+++ b/jdbc/src/main/java/io/kestra/jdbc/repository/AbstractJdbcExecutionRepository.java
@@ -859,13 +859,12 @@ public abstract class AbstractJdbcExecutionRepository extends AbstractJdbcReposi
                             DSL.partitionBy(
                                 field("namespace"),
                                 field("flow_id")
-                            ).orderBy(field("end_date").desc())
+                            ).orderBy(DSL.coalesce(field("end_date"), field("start_date")).desc())
                         ).as("row_num")
                     )
                     .from(this.jdbcRepository.getTable())
                     .where(this.defaultFilter(tenantId))
                     .and(NORMAL_KIND_CONDITION)
-                    .and(field("end_date").isNotNull())
                     .and(DSL.or(
                         ListUtils.emptyOnNull(flows).isEmpty() ?
                             DSL.trueCondition()


### PR DESCRIPTION
This commit introduces a new test to verify that the last executions retrieval correctly includes running executions. The test ensures that when both finished and running executions exist for the same flow, the running execution is prioritized in the results.

Changes:
- Added `shouldIncludeRunningExecutionsInLastExecutions` test in `AbstractExecutionRepositoryTest.java`.

<!-- Thanks for submitting a Pull Request to Kestra. To help us review your contribution, please follow the guidelines below:

- Make sure that your commits follow the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) specification e.g. `feat(ui): add a new navigation menu item` or `fix(core): fix a bug in the core model` or `docs: update the README.md`. This will help us automatically generate the changelog.
- The title should briefly summarize the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share a flow example to help the reviewer understand and QA the change.
- Use "closes" to automatically close an issue. For example, `closes #1234` will close issue #1234. -->

### What changes are being made and why?

Solves: https://github.com/kestra-io/kestra/issues/11668

---
Files updated:
core/src/test/java/io/kestra/core/repositories/AbstractExecutionRepositoryTest.java
jdbc/src/main/java/io/kestra/jdbc/repository/AbstractJdbcExecutionRepository.java