### PR TITLE
chore(webserver): exclude metrics from access log

### DIFF
--- a/cli/src/main/resources/application.yml
+++ b/cli/src/main/resources/application.yml
@@ -49,6 +49,8 @@ micronaut:
           - /ui/.+
           - /health
           - /health/.+
+          - /metrics
+          - /metrics/.+
           - /prometheus
     http-version: HTTP_1_1
   caches:


### PR DESCRIPTION
### What changes are being made and why?

Do not log metrics requests, such as:

> 2025-10-08 10:16:09,649 INFO  default-nioEventLoopGroup-1-4 io.kestra.webserver.access 2025-10-08T10:16:09.642Z | GET /metrics/jvm.memory.used?tag=area:heap HTTP/1.1 | status: 200 | ip: x.x.x.x | length: 238