### PR TITLE
feat(core): add support for execution kind filter

### DIFF
--- a/core/src/main/java/io/kestra/core/models/QueryFilter.java
+++ b/core/src/main/java/io/kestra/core/models/QueryFilter.java
@@ -91,6 +91,12 @@ public record QueryFilter(
                 return List.of(Op.EQUALS, Op.NOT_EQUALS, Op.CONTAINS, Op.STARTS_WITH, Op.ENDS_WITH, Op.REGEX, Op.IN, Op.NOT_IN, Op.PREFIX);
             }
         },
+        KIND("kind") {
+            @Override
+            public List<Op> supportedOp() {
+                return List.of(Op.EQUALS,Op.NOT_EQUALS);
+            }
+        },
         LABELS("labels") {
             @Override
             public List<Op> supportedOp() {
@@ -211,7 +217,7 @@ public record QueryFilter(
                 return List.of(
                     Field.QUERY, Field.SCOPE, Field.FLOW_ID, Field.START_DATE, Field.END_DATE,
                     Field.STATE, Field.LABELS, Field.TRIGGER_EXECUTION_ID, Field.CHILD_FILTER,
-                    Field.NAMESPACE
+                    Field.NAMESPACE,Field.KIND
                 );
             }
         },
@@ -254,7 +260,7 @@ public record QueryFilter(
          *
          * @return List of {@code ResourceField} with resource names, fields, and operations.
          */
-        
+
         private static FieldOp toFieldInfo(Field field) {
             List<Operation> operations = field.supportedOp().stream()
                 .map(Resource::toOperation)

--- a/jdbc/src/main/java/io/kestra/jdbc/repository/AbstractJdbcExecutionRepository.java
+++ b/jdbc/src/main/java/io/kestra/jdbc/repository/AbstractJdbcExecutionRepository.java
@@ -54,6 +54,8 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import static io.kestra.core.models.QueryFilter.Field.KIND;
+
 public abstract class AbstractJdbcExecutionRepository extends AbstractJdbcRepository implements ExecutionRepositoryInterface, JdbcQueueIndexerInterface<Execution> {
     private static final int FETCH_SIZE = 100;
     private static final Field<String> STATE_CURRENT_FIELD = field("state_current", String.class);
@@ -299,7 +301,7 @@ public abstract class AbstractJdbcExecutionRepository extends AbstractJdbcReposi
             .where(this.defaultFilter(tenantId, false));
 
         boolean hasKindFilter = filters != null && filters.stream()
-            .anyMatch(f -> "kind".equalsIgnoreCase(f.field().name()) );
+            .anyMatch(f -> KIND.value().equalsIgnoreCase(f.field().name()) );
         if (!hasKindFilter) {
             select = select.and(NORMAL_KIND_CONDITION);
         }

--- a/jdbc/src/main/java/io/kestra/jdbc/repository/AbstractJdbcExecutionRepository.java
+++ b/jdbc/src/main/java/io/kestra/jdbc/repository/AbstractJdbcExecutionRepository.java
@@ -296,9 +296,13 @@ public abstract class AbstractJdbcExecutionRepository extends AbstractJdbcReposi
                 field("value")
             )
             .from(this.jdbcRepository.getTable())
-            .where(this.defaultFilter(tenantId, false))
-            .and(NORMAL_KIND_CONDITION);
+            .where(this.defaultFilter(tenantId, false));
 
+        boolean hasKindFilter = filters != null && filters.stream()
+            .anyMatch(f -> "kind".equalsIgnoreCase(f.field().name()) );
+        if (!hasKindFilter) {
+            select = select.and(NORMAL_KIND_CONDITION);
+        }
         select = select.and(this.filter(filters, "start_date", Resource.EXECUTION));
 
         return select;

--- a/jdbc/src/main/java/io/kestra/jdbc/repository/AbstractJdbcRepository.java
+++ b/jdbc/src/main/java/io/kestra/jdbc/repository/AbstractJdbcRepository.java
@@ -43,7 +43,7 @@ public abstract class AbstractJdbcRepository {
     private String systemFlowNamespace;
 
     private static final Field<String> NAMESPACE_FIELD = field("namespace", String.class);
-    
+
     protected Condition defaultFilter() {
         return field("deleted", Boolean.class).eq(false);
     }
@@ -309,6 +309,9 @@ public abstract class AbstractJdbcRepository {
                 throw new InvalidQueryFiltersException("Label field value must but instance of Map");
             }
         }
+        if(field==QueryFilter.Field.KIND){
+            return applyKindCondition(value,operation);
+        }
 
         // Convert the field name to lowercase and quote it
         Name columnName = DSL.quotedName(field.name().toLowerCase());
@@ -429,6 +432,14 @@ public abstract class AbstractJdbcRepository {
             case EQUALS -> FlowScope.USER.equals(scope) ? field("namespace").ne(systemNamespace) : field("namespace").eq(systemNamespace);
             case NOT_EQUALS -> FlowScope.USER.equals(scope) ? field("namespace").eq(systemNamespace) : field("namespace").ne(systemNamespace);
             default -> throw new InvalidQueryFiltersException("Unsupported operation for SCOPE: " + operation);
+        };
+    }
+    private Condition applyKindCondition(Object value, QueryFilter.Op operation) {
+        String kind =  value.toString();
+        return switch (operation) {
+            case EQUALS -> field("kind").eq(kind);
+            case NOT_EQUALS -> field("kind").ne(kind);
+            default -> throw new InvalidQueryFiltersException("Unsupported operation for KIND: " + operation);
         };
     }
 

--- a/jdbc/src/main/java/io/kestra/jdbc/repository/AbstractJdbcRepository.java
+++ b/jdbc/src/main/java/io/kestra/jdbc/repository/AbstractJdbcRepository.java
@@ -309,7 +309,7 @@ public abstract class AbstractJdbcRepository {
                 throw new InvalidQueryFiltersException("Label field value must but instance of Map");
             }
         }
-        if(field==QueryFilter.Field.KIND){
+        if (field == QueryFilter.Field.KIND) {
             return applyKindCondition(value,operation);
         }
 

--- a/ui/src/composables/monaco/languages/filters/impl/executionFilterLanguage.ts
+++ b/ui/src/composables/monaco/languages/filters/impl/executionFilterLanguage.ts
@@ -72,6 +72,11 @@ const executionFilterKeys: Record<string, FilterKeyCompletions> = {
         [Comparators.EQUALS, Comparators.NOT_EQUALS, Comparators.CONTAINS, Comparators.STARTS_WITH, Comparators.ENDS_WITH],
         undefined,
         true
+    ),
+      kind: new FilterKeyCompletions(
+        [Comparators.EQUALS,Comparators.NOT_EQUALS],
+        undefined,
+        true
     )
 }
 


### PR DESCRIPTION
closes : #10658
### Description
- added new Kind filter provides more flexibility at execution filtration based on kind 
- the filter supports EQUAL and NOT_EQUAL operations

https://github.com/user-attachments/assets/f272e48d-44ec-4a39-a437-89f95e0a09f5

