### PR TITLE
fix(ui): Prevent all doc-cards in a row from expanding

### DIFF
--- a/ui/src/components/layout/EnhancedMarkdown.vue
+++ b/ui/src/components/layout/EnhancedMarkdown.vue
@@ -741,6 +741,7 @@
         display: grid;
         gap: var(--spacer, 1rem);
         grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+        align-items: start;
     }
 
     :deep(.doc-card) {


### PR DESCRIPTION
### What changes are being made and why?

This PR fixes a visual bug in the `doc-card` component. Previously, when a user expanded a `doc-card`, all other cards in the same row would also expand vertically. This was due to the default alignment settings of the flexbox container.

This change applies `align-items: start` to the `.doc-cards` container in `ui/src/components/layout/EnhancedMarkdown.vue`, ensuring that only the selected card expands, while others in the same row maintain their original size.

fixes #11786

---

### How the changes have been QAed?

This is a general UI fix and can be tested on any page that uses the `doc-card` component.

**Screenshot of the fix:**

<img width="1537" height="860" alt="image" src="https://github.com/user-attachments/assets/ead546f9-f28e-4abc-bfab-637c9f491fb1" />


**To verify the fix:**
1. Navigate to the page with multiple `doc-card` components arranged in a row.
2. Click on one of the cards to expand it.
3. Confirm that only the clicked card expands and the others in the row are unaffected.

---
