### PR TITLE
feat(runners): add `syncWorkingDirectory` property to remote task run…

### DIFF
--- a/core/src/main/java/io/kestra/core/models/tasks/runners/TaskCommands.java
+++ b/core/src/main/java/io/kestra/core/models/tasks/runners/TaskCommands.java
@@ -30,6 +30,10 @@ public interface TaskCommands {
 
     Map<String, Object> getAdditionalVars();
 
+    default String outputDirectoryName() {
+        return this.getWorkingDirectory().relativize(this.getOutputDirectory()).toString();
+    }
+
     Path getWorkingDirectory();
 
     Path getOutputDirectory();

--- a/tests/src/main/java/io/kestra/core/models/tasks/runners/AbstractTaskRunnerTest.java
+++ b/tests/src/main/java/io/kestra/core/models/tasks/runners/AbstractTaskRunnerTest.java
@@ -263,6 +263,7 @@ public abstract class AbstractTaskRunnerTest {
         var outputDirectory = workingDirectory.resolve(IdUtils.create());
         outputDirectory.toFile().mkdirs();
         Mockito.when(commands.getOutputDirectory()).thenReturn(outputDirectory);
+        Mockito.when(commands.outputDirectoryName()).thenCallRealMethod();
         Mockito.when(commands.getAdditionalVars()).thenReturn(Collections.emptyMap());
         Mockito.when(commands.getEnableOutputDirectory()).thenReturn(true);
         Mockito.when(commands.outputDirectoryEnabled()).thenReturn(true);


### PR DESCRIPTION
…ners

part of kestra-io/kestra-ee#4761
