### PR TITLE
fixed namespace-aware-logger-config

### DIFF
--- a/core/src/main/java/io/kestra/core/runners/RunContextLogger.java
+++ b/core/src/main/java/io/kestra/core/runners/RunContextLogger.java
@@ -55,11 +55,11 @@ public class RunContextLogger implements Supplier<org.slf4j.Logger> {
 
     public RunContextLogger(QueueInterface<LogEntry> logQueue, LogEntry logEntry, org.slf4j.event.Level loglevel, boolean logToFile) {
         if (logEntry.getTaskId() != null) {
-            this.loggerName = "flow." + logEntry.getFlowId() + "." + logEntry.getTaskId();
+            this.loggerName = logEntry.getNamespace() + "." + logEntry.getFlowId() + "." + logEntry.getTaskId();
         } else if (logEntry.getTriggerId() != null) {
-            this.loggerName = "flow." + logEntry.getFlowId() + "." + logEntry.getTriggerId();
+            this.loggerName = logEntry.getNamespace() + "." + logEntry.getFlowId() + "." + logEntry.getTriggerId();
         } else {
-            this.loggerName = "flow." + logEntry.getFlowId();
+            this.loggerName = logEntry.getNamespace() + "." + logEntry.getFlowId();
         }
 
         this.logQueue = logQueue;

--- a/core/src/main/java/io/kestra/core/services/LogService.java
+++ b/core/src/main/java/io/kestra/core/services/LogService.java
@@ -40,7 +40,7 @@ public class LogService {
     }
 
     /**
-     * Log an execution via the execution logger named: 'execution.{flowId}'.
+     * Log an execution via the execution logger named: '{namespace}.{flowId}'.
      */
     public void logExecution(Execution execution, Level level, String message, Object... args) {
         Logger logger = logger(execution);
@@ -54,7 +54,7 @@ public class LogService {
     }
 
     /**
-     * Log a trigger via the trigger logger named: 'trigger.{flowId}.{triggereId}'.
+     * Log a trigger via the trigger logger named: '{namespace}.{flowId}.{triggereId}'.
      */
     public void logTrigger(TriggerContext triggerContext, Level level, String message, Object... args) {
         Logger logger = logger(triggerContext);
@@ -68,7 +68,7 @@ public class LogService {
     }
 
     /**
-     * Log a taskRun via the taskRun logger named: 'task.{flowId}.{taskId}'.
+     * Log a taskRun via the taskRun logger named: '{namespace}.{flowId}.{taskId}'.
      */
     public void logTaskRun(TaskRun taskRun, Level level, String message, Object... args) {
         String prefix = TASKRUN_PREFIX_WITH_TENANT;
@@ -96,19 +96,19 @@ public class LogService {
 
     private Logger logger(TaskRun taskRun) {
         return LoggerFactory.getLogger(
-            "task." + taskRun.getFlowId() + "." + taskRun.getTaskId()
+            taskRun.getNamespace() + "." + taskRun.getFlowId() + "." + taskRun.getTaskId()
         );
     }
 
     private Logger logger(TriggerContext triggerContext) {
         return LoggerFactory.getLogger(
-            "trigger." + triggerContext.getFlowId() + "." + triggerContext.getTriggerId()
+            triggerContext.getNamespace() + "." + triggerContext.getFlowId() + "." + triggerContext.getTriggerId()
         );
     }
 
     private Logger logger(Execution execution) {
         return LoggerFactory.getLogger(
-            "execution." + execution.getFlowId()
+            execution.getNamespace() + "." + execution.getFlowId()
         );
     }
 }

--- a/core/src/main/resources/logback/base.xml
+++ b/core/src/main/resources/logback/base.xml
@@ -9,10 +9,13 @@
     <property name="pattern" value="%date{HH:mm:ss}.%ms %highlight(%-5.5level) %magenta(%-12.36thread) %cyan(%-12.36logger{36}) %msg%n" />
 
     <logger name="io.kestra" level="INFO" />
-    <logger name="flow" level="INFO" />
-    <logger name="task" level="INFO" />
-    <logger name="execution" level="INFO" />
-    <logger name="trigger" level="INFO" />
+    <!-- Logger levels for namespace-aware loggers: {namespace}.{flowId}.{taskId} -->
+    <!-- Example configurations:
+         <logger name="mynamespace.myflowId.mytaskId" level="OFF" />
+         <logger name="mynamespace.myflowId.mytriggerId" level="OFF" />
+         <logger name="mynamespace.myflowId" level="OFF" />
+         <logger name="mynamespace" level="OFF" />
+    -->
 
     <logger name="io.kestra.ee.runner.kafka.services.KafkaConsumerService" level="WARN" />
     <logger name="io.kestra.ee.runner.kafka.services.KafkaProducerService" level="WARN" />


### PR DESCRIPTION
fixes #11930 

### Problem

The current logger configuration does not include the namespace in the key path, causing ambiguity when multiple flows or tasks share the same IDs across namespaces.

### Solution

Introduced namespace-aware logger paths to make logging configuration explicit and easier to manage.

### Changes

* **`LogService.java`**: Updated logger factory methods to include the namespace in logger names.

  * Tasks: `{namespace}.{flowId}.{taskId}`
  * Triggers: `{namespace}.{flowId}.{triggerId}`
  * Executions: `{namespace}.{flowId}`
* **`RunContextLogger.java`**: Updated constructor to use namespace-aware logger names.
* **`base.xml`**:

  * Removed generic logger definitions.
  * Added examples and documentation for namespace-aware configuration.
* Updated JavaDoc comments and configuration documentation.



### Testing

* All existing tests pass.
* Logger names correctly include the namespace in all cases.
* Hierarchical logging configuration verified.


