### PR TITLE
fix webhook requiring basicauth

### DIFF
--- a/webserver/src/main/java/io/kestra/webserver/controllers/api/MiscController.java
+++ b/webserver/src/main/java/io/kestra/webserver/controllers/api/MiscController.java
@@ -14,6 +14,7 @@ import io.kestra.core.services.InstanceService;
 import io.kestra.core.utils.EditionProvider;
 import io.kestra.core.utils.NamespaceUtils;
 import io.kestra.core.utils.VersionProvider;
+import io.kestra.webserver.services.BasicAuthCredentials;
 import io.kestra.webserver.services.BasicAuthService;
 import io.micronaut.context.ApplicationContext;
 import io.micronaut.core.annotation.Nullable;
@@ -27,7 +28,10 @@ import io.micronaut.scheduling.annotation.ExecuteOn;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.parameters.RequestBody;
 import jakarta.inject.Inject;
-import lombok.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Value;
 import lombok.experimental.SuperBuilder;
 import lombok.extern.slf4j.Slf4j;
 
@@ -156,7 +160,7 @@ public class MiscController {
     public HttpResponse<Void> createBasicAuth(
         @RequestBody @Body BasicAuthCredentials basicAuthCredentials
     ) {
-        basicAuthService.createBasicAuthCredentials(basicAuthCredentials);
+        basicAuthService.save(basicAuthCredentials);
 
         return HttpResponse.noContent();
     }
@@ -224,14 +228,6 @@ public class MiscController {
     public static class Preview {
         Integer initial;
         Integer max;
-    }
-
-    @Getter
-    @AllArgsConstructor
-    public static class BasicAuthCredentials {
-        private String uid;
-        private String username;
-        private String password;
     }
 
     @SuperBuilder(toBuilder = true)

--- a/webserver/src/main/java/io/kestra/webserver/controllers/api/MiscController.java
+++ b/webserver/src/main/java/io/kestra/webserver/controllers/api/MiscController.java
@@ -2,7 +2,6 @@ package io.kestra.webserver.controllers.api;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.core.JsonProcessingException;
-import io.kestra.core.models.QueryFilter;
 import io.kestra.core.models.collectors.ExecutionUsage;
 import io.kestra.core.models.collectors.FlowUsage;
 import io.kestra.core.plugins.PluginRegistry;
@@ -157,7 +156,7 @@ public class MiscController {
     public HttpResponse<Void> createBasicAuth(
         @RequestBody @Body BasicAuthCredentials basicAuthCredentials
     ) {
-        basicAuthService.save(basicAuthCredentials.getUid(), new BasicAuthService.BasicAuthConfiguration(basicAuthCredentials.getUsername(), basicAuthCredentials.getPassword()));
+        basicAuthService.createBasicAuthCredentials(basicAuthCredentials);
 
         return HttpResponse.noContent();
     }

--- a/webserver/src/main/java/io/kestra/webserver/services/BasicAuthCredentials.java
+++ b/webserver/src/main/java/io/kestra/webserver/services/BasicAuthCredentials.java
@@ -1,0 +1,20 @@
+package io.kestra.webserver.services;
+
+
+public record BasicAuthCredentials(
+    String uid,
+    String username,
+    String password
+) {
+    public String getUsername() {
+        return username;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public String getUid() {
+        return uid;
+    }
+}

--- a/webserver/src/main/java/io/kestra/webserver/services/BasicAuthService.java
+++ b/webserver/src/main/java/io/kestra/webserver/services/BasicAuthService.java
@@ -23,10 +23,7 @@ import lombok.NoArgsConstructor;
 import org.apache.commons.lang3.StringUtils;
 
 import java.time.Instant;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.Optional;
+import java.util.*;
 import java.util.regex.Pattern;
 
 @Context
@@ -198,6 +195,9 @@ public class BasicAuthService {
         protected String password;
 
         public SaltedBasicAuthCredentials(String salt, String username, String password) {
+            Objects.requireNonNull(salt);
+            Objects.requireNonNull(username);
+            Objects.requireNonNull(password);
             this.salt = salt;
             this.username = username;
             this.password = password;

--- a/webserver/src/main/java/io/kestra/webserver/services/BasicAuthService.java
+++ b/webserver/src/main/java/io/kestra/webserver/services/BasicAuthService.java
@@ -7,6 +7,7 @@ import io.kestra.core.repositories.SettingRepositoryInterface;
 import io.kestra.core.serializers.JacksonMapper;
 import io.kestra.core.services.InstanceService;
 import io.kestra.core.utils.AuthUtils;
+import io.kestra.webserver.controllers.api.MiscController;
 import io.kestra.webserver.models.events.OssAuthEvent;
 import io.micronaut.context.annotation.ConfigurationInject;
 import io.micronaut.context.annotation.ConfigurationProperties;
@@ -68,6 +69,13 @@ public class BasicAuthService {
                 .value(e.getInvalids())
                 .build());
         }
+    }
+
+    public void createBasicAuthCredentials(MiscController.BasicAuthCredentials basicAuthCredentials){
+        save(
+            basicAuthCredentials.getUid(),
+            basicAuthConfiguration.updateWithUsernamePassword(basicAuthCredentials.getUsername(), basicAuthCredentials.getPassword())
+        );
     }
 
     public void save(BasicAuthConfiguration basicAuthConfiguration) {
@@ -195,7 +203,7 @@ public class BasicAuthService {
         }
 
         @VisibleForTesting
-        BasicAuthConfiguration withUsernamePassword(String username, String password) {
+        BasicAuthConfiguration updateWithUsernamePassword(String username, String password) {
             return new BasicAuthConfiguration(
                 username,
                 password,

--- a/webserver/src/main/java/io/kestra/webserver/services/BasicAuthService.java
+++ b/webserver/src/main/java/io/kestra/webserver/services/BasicAuthService.java
@@ -7,26 +7,27 @@ import io.kestra.core.repositories.SettingRepositoryInterface;
 import io.kestra.core.serializers.JacksonMapper;
 import io.kestra.core.services.InstanceService;
 import io.kestra.core.utils.AuthUtils;
-import io.kestra.webserver.controllers.api.MiscController;
 import io.kestra.webserver.models.events.OssAuthEvent;
 import io.micronaut.context.annotation.ConfigurationInject;
 import io.micronaut.context.annotation.ConfigurationProperties;
 import io.micronaut.context.annotation.Context;
 import io.micronaut.context.annotation.Requires;
 import io.micronaut.context.event.ApplicationEventPublisher;
+import jakarta.annotation.Nullable;
 import jakarta.annotation.PostConstruct;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
-import java.util.ArrayList;
-import lombok.*;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.apache.commons.lang3.StringUtils;
 
-import jakarta.annotation.Nullable;
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.regex.Pattern;
-import org.apache.commons.lang3.StringUtils;
 
 @Context
 @Singleton
@@ -52,14 +53,18 @@ public class BasicAuthService {
 
     public BasicAuthService() {}
 
+    @VisibleForTesting
     @PostConstruct
-    protected void init() {
+    public void init() {
         if (basicAuthConfiguration == null ||
             (StringUtils.isBlank(basicAuthConfiguration.getUsername()) && StringUtils.isBlank(basicAuthConfiguration.getPassword()))){
             return;
         }
         try {
-            save(basicAuthConfiguration);
+            // save configured default credentials
+            save(
+                new BasicAuthCredentials(null, basicAuthConfiguration.getUsername(), basicAuthConfiguration.getPassword())
+            );
             if (settingRepository.findByKey(BASIC_AUTH_ERROR_CONFIG).isPresent()) {
                 settingRepository.delete(Setting.builder().key(BASIC_AUTH_ERROR_CONFIG).build());
             }
@@ -71,38 +76,27 @@ public class BasicAuthService {
         }
     }
 
-    public void createBasicAuthCredentials(MiscController.BasicAuthCredentials basicAuthCredentials){
-        save(
-            basicAuthCredentials.getUid(),
-            basicAuthConfiguration.updateWithUsernamePassword(basicAuthCredentials.getUsername(), basicAuthCredentials.getPassword())
-        );
-    }
-
-    public void save(BasicAuthConfiguration basicAuthConfiguration) {
-        save(null, basicAuthConfiguration);
-    }
-
-    public void save(String uid, BasicAuthConfiguration basicAuthConfiguration) {
+    public void save(BasicAuthCredentials basicAuthCredentials) {
         List<String> validationErrors = new ArrayList<>();
 
-        if (basicAuthConfiguration.getUsername() != null && !EMAIL_PATTERN.matcher(basicAuthConfiguration.getUsername()).matches()) {
+        if (basicAuthCredentials.getUsername() != null && !EMAIL_PATTERN.matcher(basicAuthCredentials.getUsername()).matches()) {
             validationErrors.add("Invalid username for Basic Authentication. Please provide a valid email address.");
         }
 
-        if (basicAuthConfiguration.getUsername() == null) {
+        if (basicAuthCredentials.getUsername() == null) {
             validationErrors.add("No user name set for Basic Authentication. Please provide a user name.");
         }
 
-        if (basicAuthConfiguration.getPassword() == null) {
+        if (basicAuthCredentials.getPassword() == null) {
             validationErrors.add("No password set for Basic Authentication. Please provide a password.");
         }
 
-        if (basicAuthConfiguration.getPassword() != null && !PASSWORD_PATTERN.matcher(basicAuthConfiguration.getPassword()).matches()) {
+        if (basicAuthCredentials.getPassword() != null && !PASSWORD_PATTERN.matcher(basicAuthCredentials.getPassword()).matches()) {
             validationErrors.add("Invalid password for Basic Authentication. The password must have 8 chars, one upper, one lower and one number");
         }
 
-        if ((basicAuthConfiguration.getUsername() != null && basicAuthConfiguration.getUsername().length() > EMAIL_PASSWORD_MAX_LEN) ||
-            (basicAuthConfiguration.getPassword() != null && basicAuthConfiguration.getPassword().length() > EMAIL_PASSWORD_MAX_LEN)) {
+        if ((basicAuthCredentials.getUsername() != null && basicAuthCredentials.getUsername().length() > EMAIL_PASSWORD_MAX_LEN) ||
+            (basicAuthCredentials.getPassword() != null && basicAuthCredentials.getPassword().length() > EMAIL_PASSWORD_MAX_LEN)) {
             validationErrors.add("The length of email or password should not exceed 256 characters.");
         }
 
@@ -110,15 +104,16 @@ public class BasicAuthService {
             throw new ValidationErrorException(validationErrors);
         }
 
-        SaltedBasicAuthConfiguration previousConfiguration = this.configuration();
-        String salt = previousConfiguration == null
+        var previousConfiguredCredentials = this.configuration().credentials();
+        String salt = previousConfiguredCredentials == null
             ? null
-            : previousConfiguration.getSalt();
-        SaltedBasicAuthConfiguration saltedNewConfiguration = new SaltedBasicAuthConfiguration(
+            : previousConfiguredCredentials.getSalt();
+        SaltedBasicAuthCredentials saltedNewConfiguration = new SaltedBasicAuthCredentials(
             salt,
-            basicAuthConfiguration
+            basicAuthCredentials.getUsername(),
+            basicAuthCredentials.getPassword()
         );
-        if (!saltedNewConfiguration.equals(previousConfiguration)) {
+        if (!saltedNewConfiguration.equals(previousConfiguredCredentials)) {
             settingRepository.save(
                 Setting.builder()
                     .key(BASIC_AUTH_SETTINGS_KEY)
@@ -128,11 +123,11 @@ public class BasicAuthService {
 
             ossAuthEventPublisher.publishEventAsync(
                 OssAuthEvent.builder()
-                    .uid(uid)
+                    .uid(basicAuthCredentials.getUid())
                     .iid(instanceService.fetch())
                     .date(Instant.now())
                     .ossAuth(OssAuthEvent.OssAuth.builder()
-                        .email(basicAuthConfiguration.getUsername())
+                        .email(basicAuthCredentials.getUsername())
                         .build()
                     ).build()
             );
@@ -146,26 +141,27 @@ public class BasicAuthService {
             .orElse(List.of());
     }
 
-    public SaltedBasicAuthConfiguration configuration() {
-        return settingRepository.findByKey(BASIC_AUTH_SETTINGS_KEY)
+    public ConfiguredBasicAuth configuration() {
+        var credentials = settingRepository.findByKey(BASIC_AUTH_SETTINGS_KEY)
             .map(Setting::getValue)
-            .map(value -> JacksonMapper.ofJson(false).convertValue(value, SaltedBasicAuthConfiguration.class))
+            .map(value -> JacksonMapper.ofJson(false).convertValue(value, SaltedBasicAuthCredentials.class))
             .orElse(null);
+        return new ConfiguredBasicAuth(this.basicAuthConfiguration != null ? this.basicAuthConfiguration.realm : null, this.basicAuthConfiguration != null ? this.basicAuthConfiguration.openUrls : null, credentials);
     }
 
     public boolean isBasicAuthInitialized(){
+        var configuration = configuration();
 
-        SaltedBasicAuthConfiguration configuration = configuration();
-
-        return configuration != null &&
-               !StringUtils.isBlank(configuration.getUsername()) &&
-               !StringUtils.isBlank(configuration.getPassword());
+        return configuration.credentials() != null &&
+            !StringUtils.isBlank(configuration.credentials().getUsername()) &&
+            !StringUtils.isBlank(configuration.credentials().getPassword());
     }
 
     @Getter
     @NoArgsConstructor
     @EqualsAndHashCode
     @ConfigurationProperties("kestra.server.basic-auth")
+    @VisibleForTesting
     public static class BasicAuthConfiguration {
         private String username;
         protected String password;
@@ -185,50 +181,28 @@ public class BasicAuthService {
             this.realm = Optional.ofNullable(realm).orElse("Kestra");
             this.openUrls = Optional.ofNullable(openUrls).orElse(Collections.emptyList());
         }
+    }
 
-        public BasicAuthConfiguration(
-            String username,
-            String password
-        ) {
-            this(username, password, null, null);
-        }
-
-        public BasicAuthConfiguration(BasicAuthConfiguration basicAuthConfiguration) {
-            if (basicAuthConfiguration != null) {
-                this.username = basicAuthConfiguration.getUsername();
-                this.password = basicAuthConfiguration.getPassword();
-                this.realm = basicAuthConfiguration.getRealm();
-                this.openUrls = basicAuthConfiguration.getOpenUrls();
-            }
-        }
-
-        @VisibleForTesting
-        BasicAuthConfiguration updateWithUsernamePassword(String username, String password) {
-            return new BasicAuthConfiguration(
-                username,
-                password,
-                this.realm,
-                this.openUrls
-            );
-        }
+    public record ConfiguredBasicAuth(
+        String realm,
+        List<String> openUrls,
+        SaltedBasicAuthCredentials credentials
+    ) {
     }
 
     @Getter
-    @AllArgsConstructor
-    @EqualsAndHashCode(callSuper = true)
-    public static class SaltedBasicAuthConfiguration extends BasicAuthConfiguration {
+    @EqualsAndHashCode
+    public static class SaltedBasicAuthCredentials {
         private String salt;
+        private String username;
+        protected String password;
 
-        public SaltedBasicAuthConfiguration(String salt, BasicAuthConfiguration basicAuthConfiguration) {
-            super(basicAuthConfiguration);
+        public SaltedBasicAuthCredentials(String salt, String username, String password) {
             this.salt = salt == null
                 ? AuthUtils.generateSalt()
                 : salt;
-            this.password = AuthUtils.encodePassword(this.salt, basicAuthConfiguration.getPassword());
-        }
-
-        public SaltedBasicAuthConfiguration() {
-            super();
+            this.username = username;
+            this.password = AuthUtils.encodePassword(this.salt, password);
         }
     }
 }

--- a/webserver/src/main/java/io/kestra/webserver/services/BasicAuthService.java
+++ b/webserver/src/main/java/io/kestra/webserver/services/BasicAuthService.java
@@ -108,7 +108,7 @@ public class BasicAuthService {
         String salt = previousConfiguredCredentials == null
             ? null
             : previousConfiguredCredentials.getSalt();
-        SaltedBasicAuthCredentials saltedNewConfiguration = new SaltedBasicAuthCredentials(
+        SaltedBasicAuthCredentials saltedNewConfiguration = SaltedBasicAuthCredentials.salt(
             salt,
             basicAuthCredentials.getUsername(),
             basicAuthCredentials.getPassword()
@@ -198,11 +198,20 @@ public class BasicAuthService {
         protected String password;
 
         public SaltedBasicAuthCredentials(String salt, String username, String password) {
-            this.salt = salt == null
+            this.salt = salt;
+            this.username = username;
+            this.password = password;
+        }
+
+        public static SaltedBasicAuthCredentials salt(String salt, String username, String password) {
+            var salt1 = salt == null
                 ? AuthUtils.generateSalt()
                 : salt;
-            this.username = username;
-            this.password = AuthUtils.encodePassword(this.salt, password);
+            return new SaltedBasicAuthCredentials(
+                salt1,
+                username,
+                AuthUtils.encodePassword(salt1, password)
+            );
         }
     }
 }

--- a/webserver/src/test/java/io/kestra/webserver/controllers/api/MiscControllerTest.java
+++ b/webserver/src/test/java/io/kestra/webserver/controllers/api/MiscControllerTest.java
@@ -6,7 +6,7 @@ import io.kestra.core.models.flows.FlowWithSource;
 import io.kestra.core.repositories.FlowRepositoryInterface;
 import io.kestra.core.repositories.SettingRepositoryInterface;
 import io.kestra.core.utils.IdUtils;
-import io.kestra.webserver.controllers.api.MiscController.BasicAuthCredentials;
+import io.kestra.webserver.services.BasicAuthCredentials;
 import io.kestra.webserver.services.BasicAuthService;
 import io.kestra.webserver.services.BasicAuthService.BasicAuthConfiguration;
 import io.micronaut.context.annotation.Property;
@@ -106,7 +106,7 @@ class MiscControllerTest {
         String uid = "someUid";
         String username = "my.email@kestra.io";
         String password = "myPassword1";
-        client.toBlocking().exchange(HttpRequest.POST("/api/v1/main/basicAuth", new MiscController.BasicAuthCredentials(uid, username, password)));
+        client.toBlocking().exchange(HttpRequest.POST("/api/v1/main/basicAuth", new BasicAuthCredentials(uid, username, password)));
         try {
             assertThatThrownBy(
                 () -> client.toBlocking().retrieve("/api/v1/main/dashboards", MiscController.Configuration.class)
@@ -134,7 +134,7 @@ class MiscControllerTest {
             ).as("expect success GET /api/v1/main/dashboards with good password")
                 .doesNotThrowAnyException();
         } finally {
-            basicAuthService.save(basicAuthConfiguration);
+            basicAuthService.save(new BasicAuthCredentials(null, basicAuthConfiguration.getUsername(), basicAuthConfiguration.getPassword()));
         }
     }
 
@@ -143,7 +143,7 @@ class MiscControllerTest {
         String uid = "someUid2";
         String username = "my.email2@kestra.io";
         String password = "myPassword2";
-        client.toBlocking().exchange(HttpRequest.POST("/api/v1/main/basicAuth", new MiscController.BasicAuthCredentials(uid, username, password)));
+        client.toBlocking().exchange(HttpRequest.POST("/api/v1/main/basicAuth", new BasicAuthCredentials(uid, username, password)));
 
         try {
             var namespace = "namespace1";
@@ -180,7 +180,7 @@ class MiscControllerTest {
             ).as("can trigger this Flow webhook when not authenticated")
                 .doesNotThrowAnyException();
         } finally {
-            basicAuthService.save(basicAuthConfiguration);
+            basicAuthService.save(new BasicAuthCredentials(null, basicAuthConfiguration.getUsername(), basicAuthConfiguration.getPassword()));
         }
     }
 }

--- a/webserver/src/test/java/io/kestra/webserver/controllers/api/MiscControllerTest.java
+++ b/webserver/src/test/java/io/kestra/webserver/controllers/api/MiscControllerTest.java
@@ -1,9 +1,5 @@
 package io.kestra.webserver.controllers.api;
 
-import static io.kestra.webserver.services.BasicAuthService.BASIC_AUTH_ERROR_CONFIG;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-
 import io.kestra.core.junit.annotations.KestraTest;
 import io.kestra.core.models.Setting;
 import io.kestra.core.repositories.SettingRepositoryInterface;
@@ -19,9 +15,13 @@ import io.micronaut.http.client.exceptions.HttpClientResponseException;
 import io.micronaut.http.hateoas.JsonError;
 import io.micronaut.reactor.http.client.ReactorHttpClient;
 import jakarta.inject.Inject;
-import java.util.List;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static io.kestra.webserver.services.BasicAuthService.BASIC_AUTH_ERROR_CONFIG;
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @KestraTest
 @Property(name = "kestra.system-flows.namespace", value = "some.system.ns")
@@ -92,30 +92,38 @@ class MiscControllerTest {
 
     @Test
     void basicAuth() {
-        Assertions.assertDoesNotThrow(() -> client.toBlocking().retrieve("/api/v1/configs", MiscController.Configuration.class));
+        assertThatCode(() -> client.toBlocking().retrieve("/api/v1/configs", MiscController.Configuration.class)).doesNotThrowAnyException();
 
         String uid = "someUid";
         String username = "my.email@kestra.io";
         String password = "myPassword1";
         client.toBlocking().exchange(HttpRequest.POST("/api/v1/main/basicAuth", new MiscController.BasicAuthCredentials(uid, username, password)));
         try {
-            assertThrows(
-                HttpClientResponseException.class,
+            assertThatThrownBy(
                 () -> client.toBlocking().retrieve("/api/v1/main/dashboards", MiscController.Configuration.class)
-            );
-            assertThrows(
-                HttpClientResponseException.class,
+            )
+                .as("expect 401 for unauthenticated GET /api/v1/main/dashboards")
+                .isInstanceOfSatisfying(HttpClientResponseException.class, ex ->
+                    assertThat((CharSequence) ex.getStatus()).isEqualTo(HttpStatus.UNAUTHORIZED)
+                );
+
+            assertThatThrownBy(
                 () -> client.toBlocking().retrieve(
                     HttpRequest.GET("/api/v1/main/dashboards")
                         .basicAuth("bad.user@kestra.io", "badPassword"),
                     MiscController.Configuration.class
                 )
-            );
-            Assertions.assertDoesNotThrow(() -> client.toBlocking().retrieve(
+            ).as("expect 401 for GET /api/v1/main/dashboards with wrong password")
+                .isInstanceOfSatisfying(HttpClientResponseException.class, ex ->
+                    assertThat((CharSequence) ex.getStatus()).isEqualTo(HttpStatus.UNAUTHORIZED)
+                );
+
+            assertThatCode(() -> client.toBlocking().retrieve(
                 HttpRequest.GET("/api/v1/main/dashboards")
                     .basicAuth(username, password),
                 MiscController.Configuration.class)
-            );
+            ).as("expect success GET /api/v1/main/dashboards with good password")
+                .doesNotThrowAnyException();
         } finally {
             basicAuthService.save(basicAuthConfiguration);
         }

--- a/webserver/src/test/java/io/kestra/webserver/controllers/api/MiscControllerTest.java
+++ b/webserver/src/test/java/io/kestra/webserver/controllers/api/MiscControllerTest.java
@@ -2,7 +2,10 @@ package io.kestra.webserver.controllers.api;
 
 import io.kestra.core.junit.annotations.KestraTest;
 import io.kestra.core.models.Setting;
+import io.kestra.core.models.flows.FlowWithSource;
+import io.kestra.core.repositories.FlowRepositoryInterface;
 import io.kestra.core.repositories.SettingRepositoryInterface;
+import io.kestra.core.utils.IdUtils;
 import io.kestra.webserver.controllers.api.MiscController.BasicAuthCredentials;
 import io.kestra.webserver.services.BasicAuthService;
 import io.kestra.webserver.services.BasicAuthService.BasicAuthConfiguration;
@@ -10,6 +13,7 @@ import io.micronaut.context.annotation.Property;
 import io.micronaut.core.type.Argument;
 import io.micronaut.http.HttpRequest;
 import io.micronaut.http.HttpStatus;
+import io.micronaut.http.MediaType;
 import io.micronaut.http.client.annotation.Client;
 import io.micronaut.http.client.exceptions.HttpClientResponseException;
 import io.micronaut.http.hateoas.JsonError;
@@ -20,6 +24,8 @@ import org.junit.jupiter.api.Test;
 import java.util.List;
 
 import static io.kestra.webserver.services.BasicAuthService.BASIC_AUTH_ERROR_CONFIG;
+import static io.micronaut.http.HttpRequest.GET;
+import static io.micronaut.http.HttpRequest.POST;
 import static org.assertj.core.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -38,6 +44,9 @@ class MiscControllerTest {
 
     @Inject
     private SettingRepositoryInterface settingRepository;
+
+    @Inject
+    private FlowRepositoryInterface flowRepository;
 
     @Test
     void ping() {
@@ -59,7 +68,7 @@ class MiscControllerTest {
 
     @Test
     void getEmptyValidationErrors() {
-        List<String> response = client.toBlocking().retrieve(HttpRequest.GET("/api/v1/basicAuthValidationErrors"), Argument.LIST_OF_STRING);
+        List<String> response = client.toBlocking().retrieve(GET("/api/v1/basicAuthValidationErrors"), Argument.LIST_OF_STRING);
 
         assertThat(response).isNotNull();
     }
@@ -68,7 +77,7 @@ class MiscControllerTest {
     void getValidationErrors() {
         settingRepository.save(Setting.builder().key(BASIC_AUTH_ERROR_CONFIG).value(List.of("error1", "error2")).build());
         try {
-            List<String> response = client.toBlocking().retrieve(HttpRequest.GET("/api/v1/basicAuthValidationErrors"), Argument.LIST_OF_STRING);
+            List<String> response = client.toBlocking().retrieve(GET("/api/v1/basicAuthValidationErrors"), Argument.LIST_OF_STRING);
 
             assertThat(response).containsExactly("error1", "error2");
         } finally {
@@ -109,7 +118,7 @@ class MiscControllerTest {
 
             assertThatThrownBy(
                 () -> client.toBlocking().retrieve(
-                    HttpRequest.GET("/api/v1/main/dashboards")
+                    GET("/api/v1/main/dashboards")
                         .basicAuth("bad.user@kestra.io", "badPassword"),
                     MiscController.Configuration.class
                 )
@@ -119,10 +128,56 @@ class MiscControllerTest {
                 );
 
             assertThatCode(() -> client.toBlocking().retrieve(
-                HttpRequest.GET("/api/v1/main/dashboards")
+                GET("/api/v1/main/dashboards")
                     .basicAuth(username, password),
                 MiscController.Configuration.class)
             ).as("expect success GET /api/v1/main/dashboards with good password")
+                .doesNotThrowAnyException();
+        } finally {
+            basicAuthService.save(basicAuthConfiguration);
+        }
+    }
+
+    @Test
+    void canTriggerAWebhookWithoutBasicAuth() {
+        String uid = "someUid2";
+        String username = "my.email2@kestra.io";
+        String password = "myPassword2";
+        client.toBlocking().exchange(HttpRequest.POST("/api/v1/main/basicAuth", new MiscController.BasicAuthCredentials(uid, username, password)));
+
+        try {
+            var namespace = "namespace1";
+            var flowId = "flowWithWebhook" + IdUtils.create();
+            var key = "1KERKzRQZSMtLdMdNI7Nkr";
+            var flowWithWebhook = """
+                id: %s
+                namespace: %s
+                tasks:
+                  - id: out
+                    type: io.kestra.plugin.core.debug.Return
+                    format: "output1"
+                triggers:
+                  - id: webhook_trigger
+                    type: io.kestra.plugin.core.trigger.Webhook
+                    key: %s
+                disabled: false
+                deleted: false
+                """.formatted(flowId, namespace, key);
+
+            assertThatCode(() -> client.toBlocking().retrieve(
+                POST("/api/v1/main/flows", flowWithWebhook)
+                    .contentType(MediaType.APPLICATION_YAML)
+                    .basicAuth(username, password),
+                FlowWithSource.class)
+            ).as("can create a Flow with webhook when authenticated")
+                .doesNotThrowAnyException();
+
+            assertThatCode(() -> client.toBlocking().retrieve(POST("/api/v1/main/executions/webhook/{namespace}/{flowId}/{key}"
+                    .replace("{namespace}", namespace)
+                    .replace("{flowId}", flowId)
+                    .replace("{key}", key)
+                , flowWithWebhook), FlowWithSource.class)
+            ).as("can trigger this Flow webhook when not authenticated")
                 .doesNotThrowAnyException();
         } finally {
             basicAuthService.save(basicAuthConfiguration);

--- a/webserver/src/test/java/io/kestra/webserver/filter/AuthenticationFilterTest.java
+++ b/webserver/src/test/java/io/kestra/webserver/filter/AuthenticationFilterTest.java
@@ -4,7 +4,7 @@ import io.kestra.core.junit.annotations.KestraTest;
 import io.kestra.core.models.Setting;
 import io.kestra.core.repositories.SettingRepositoryInterface;
 import io.kestra.core.utils.IdUtils;
-import io.kestra.webserver.controllers.api.MiscController;
+import io.kestra.webserver.services.BasicAuthCredentials;
 import io.kestra.webserver.services.BasicAuthService;
 import io.micronaut.http.HttpRequest;
 import io.micronaut.http.HttpResponse;
@@ -55,7 +55,7 @@ class AuthenticationFilterTest {
         assertThat(httpClientResponseException.getStatus().getCode()).isEqualTo(HttpStatus.UNAUTHORIZED.getCode());
 
         httpClientResponseException = assertThrows(HttpClientResponseException.class, () -> client.toBlocking()
-            .exchange(HttpRequest.POST("/api/v1/basicAuth", new MiscController.BasicAuthCredentials(
+            .exchange(HttpRequest.POST("/api/v1/basicAuth", new BasicAuthCredentials(
                 IdUtils.create(),
                 "anonymous",
                 "hacker"
@@ -63,7 +63,7 @@ class AuthenticationFilterTest {
         assertThat(httpClientResponseException.getStatus().getCode()).isEqualTo(HttpStatus.UNAUTHORIZED.getCode());
 
         HttpResponse<?> response = client.toBlocking()
-            .exchange(HttpRequest.POST("/api/v1/basicAuth", new MiscController.BasicAuthCredentials(
+            .exchange(HttpRequest.POST("/api/v1/basicAuth", new BasicAuthCredentials(
                 IdUtils.create(),
                 "anonymous@hacker",
                 "hackerPassword1"
@@ -88,7 +88,7 @@ class AuthenticationFilterTest {
         assertThat(response.getStatus().getCode()).isEqualTo(HttpStatus.OK.getCode());
 
         response = client.toBlocking()
-            .exchange(HttpRequest.POST("/api/v1/basicAuth",  new MiscController.BasicAuthCredentials(
+            .exchange(HttpRequest.POST("/api/v1/basicAuth", new BasicAuthCredentials(
                 IdUtils.create(),
                 basicAuthConfiguration.getUsername(),
                 basicAuthConfiguration.getPassword()

--- a/webserver/src/test/java/io/kestra/webserver/filter/TestAuthFilter.java
+++ b/webserver/src/test/java/io/kestra/webserver/filter/TestAuthFilter.java
@@ -1,7 +1,6 @@
 package io.kestra.webserver.filter;
 
 import io.kestra.webserver.services.BasicAuthService;
-import io.kestra.webserver.services.BasicAuthService.BasicAuthConfiguration;
 import io.micronaut.context.annotation.Requires;
 import io.micronaut.context.env.Environment;
 import io.micronaut.http.HttpHeaders;
@@ -12,16 +11,14 @@ import io.micronaut.http.filter.ClientFilterChain;
 import io.micronaut.http.filter.HttpClientFilter;
 import io.micronaut.http.filter.ServerFilterPhase;
 import jakarta.inject.Inject;
-import java.util.Base64;
 import org.reactivestreams.Publisher;
+
+import java.util.Base64;
 
 @Filter("/**")
 @Requires(env = Environment.TEST)
 public class TestAuthFilter implements HttpClientFilter {
     public static boolean ENABLED = true;
-
-    @Inject
-    private BasicAuthConfiguration basicAuthConfiguration;
 
     @Inject
     private BasicAuthService basicAuthService;
@@ -32,13 +29,13 @@ public class TestAuthFilter implements HttpClientFilter {
         if (ENABLED) {
             //Basic auth may be removed from the database by jdbcTestUtils.drop(); / jdbcTestUtils.migrate();
             //We need it back to be able to run the tests and avoid NPE while checking the basic authorization
-            if (basicAuthService.configuration() == null) {
-                basicAuthService.save(basicAuthConfiguration);
+            if (basicAuthService.configuration().credentials() == null) {
+                basicAuthService.init();
             }
             //Add basic authorization header if no header are present in the query
             if (request.getHeaders().getAuthorization().isEmpty()) {
                 String token = "Basic " + Base64.getEncoder().encodeToString(
-                    (basicAuthConfiguration.getUsername() + ":" + basicAuthConfiguration.getPassword()).getBytes());
+                    (basicAuthService.configuration().credentials() + ":" + basicAuthService.configuration().credentials()).getBytes());
                 request.getHeaders().add(HttpHeaders.AUTHORIZATION, token);
             }
         }

--- a/webserver/src/test/java/io/kestra/webserver/filter/TestAuthFilter.java
+++ b/webserver/src/test/java/io/kestra/webserver/filter/TestAuthFilter.java
@@ -35,7 +35,7 @@ public class TestAuthFilter implements HttpClientFilter {
             //Add basic authorization header if no header are present in the query
             if (request.getHeaders().getAuthorization().isEmpty()) {
                 String token = "Basic " + Base64.getEncoder().encodeToString(
-                    (basicAuthService.configuration().credentials() + ":" + basicAuthService.configuration().credentials()).getBytes());
+                    (basicAuthService.configuration().credentials().getUsername() + ":" + basicAuthService.configuration().credentials().getPassword()).getBytes());
                 request.getHeaders().add(HttpHeaders.AUTHORIZATION, token);
             }
         }

--- a/webserver/src/test/java/io/kestra/webserver/filter/TestAuthFilter.java
+++ b/webserver/src/test/java/io/kestra/webserver/filter/TestAuthFilter.java
@@ -23,6 +23,9 @@ public class TestAuthFilter implements HttpClientFilter {
     @Inject
     private BasicAuthService basicAuthService;
 
+    @Inject
+    private BasicAuthService.BasicAuthConfiguration basicAuthConfiguration;
+
     @Override
     public Publisher<? extends HttpResponse<?>> doFilter(MutableHttpRequest<?> request,
         ClientFilterChain chain) {
@@ -35,7 +38,7 @@ public class TestAuthFilter implements HttpClientFilter {
             //Add basic authorization header if no header are present in the query
             if (request.getHeaders().getAuthorization().isEmpty()) {
                 String token = "Basic " + Base64.getEncoder().encodeToString(
-                    (basicAuthService.configuration().credentials().getUsername() + ":" + basicAuthService.configuration().credentials().getPassword()).getBytes());
+                    (basicAuthConfiguration.getUsername() + ":" + basicAuthConfiguration.getPassword()).getBytes());
                 request.getHeaders().add(HttpHeaders.AUTHORIZATION, token);
             }
         }

--- a/webserver/src/test/java/io/kestra/webserver/services/BasicAuthServiceTest.java
+++ b/webserver/src/test/java/io/kestra/webserver/services/BasicAuthServiceTest.java
@@ -132,7 +132,7 @@ class BasicAuthServiceTest {
         basicAuthService.basicAuthConfiguration = defaultConfigWithoutBasicAuthCreds.config;
         settingRepositoryInterface.save(Setting.builder()
             .key(BASIC_AUTH_SETTINGS_KEY)
-            .value(new BasicAuthService.SaltedBasicAuthCredentials(null, "username1@example.com", "Password1"))
+            .value(BasicAuthService.SaltedBasicAuthCredentials.salt(null, "username1@example.com", "Password1"))
             .build());
         assertTrue(basicAuthService.isBasicAuthInitialized());
         basicAuthService.init();

--- a/webserver/src/test/java/io/kestra/webserver/services/BasicAuthServiceTest.java
+++ b/webserver/src/test/java/io/kestra/webserver/services/BasicAuthServiceTest.java
@@ -280,7 +280,7 @@ class BasicAuthServiceTest {
 
     private void assertConfigurationMatchesApplicationYaml() {
         var actualConfiguration = basicAuthService.configuration().credentials();
-        var applicationYamlConfiguration = new BasicAuthService.SaltedBasicAuthCredentials(
+        var applicationYamlConfiguration = BasicAuthService.SaltedBasicAuthCredentials.salt(
             actualConfiguration.getSalt(),
             basicAuthService.basicAuthConfiguration.getUsername(),
             basicAuthService.basicAuthConfiguration.getPassword()

--- a/webserver/src/test/java/io/kestra/webserver/services/BasicAuthServiceTest.java
+++ b/webserver/src/test/java/io/kestra/webserver/services/BasicAuthServiceTest.java
@@ -7,12 +7,16 @@ import io.kestra.core.models.Setting;
 import io.kestra.core.repositories.SettingRepositoryInterface;
 import io.kestra.core.serializers.JacksonMapper;
 import io.kestra.core.services.InstanceService;
+import io.kestra.core.utils.AuthUtils;
 import io.kestra.core.utils.Await;
 import io.kestra.webserver.controllers.api.MiscController;
 import io.kestra.webserver.models.events.Event;
 import io.kestra.webserver.services.BasicAuthService.BasicAuthConfiguration;
 import io.micronaut.context.env.Environment;
 import jakarta.inject.Inject;
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -61,25 +65,26 @@ class BasicAuthServiceTest {
 
     @Test
     void isBasicAuthInitialized(){
-        settingRepositoryInterface.save(Setting.builder()
-            .key(BASIC_AUTH_SETTINGS_KEY)
-            .value(new BasicAuthConfiguration("username", "password", null, null))
-            .build());
+        deleteSetting();
+        basicAuthService.basicAuthConfiguration = new ConfigWrapper(
+            new BasicAuthConfiguration(USER_NAME, PASSWORD, null, null)
+        ).config;
+        basicAuthService.init();
         assertTrue(basicAuthService.isBasicAuthInitialized());
 
         deleteSetting();
         assertFalse(basicAuthService.isBasicAuthInitialized());
 
-        settingRepositoryInterface.save(Setting.builder()
-            .key(BASIC_AUTH_SETTINGS_KEY)
-            .value(new BasicAuthConfiguration("username", null, null, null))
-            .build());
+        basicAuthService.basicAuthConfiguration = new ConfigWrapper(
+            new BasicAuthConfiguration(USER_NAME, null, null, null)
+        ).config;
+        basicAuthService.init();
         assertFalse(basicAuthService.isBasicAuthInitialized());
 
-        settingRepositoryInterface.save(Setting.builder()
-            .key(BASIC_AUTH_SETTINGS_KEY)
-            .value(new BasicAuthConfiguration(null, null, null, null))
-            .build());
+        basicAuthService.basicAuthConfiguration = new ConfigWrapper(
+            new BasicAuthConfiguration(null, null, null, null)
+        ).config;
+        basicAuthService.init();
         assertFalse(basicAuthService.isBasicAuthInitialized());
     }
 
@@ -98,8 +103,8 @@ class BasicAuthServiceTest {
          * simulate basic auth UI onboarding (createBasicAuth)
          * {@link io.kestra.webserver.controllers.api.MiscController#createBasicAuth(MiscController.BasicAuthCredentials)}
          */
-        basicAuthService.createBasicAuthCredentials(
-            new MiscController.BasicAuthCredentials(
+        basicAuthService.save(
+            new BasicAuthCredentials(
                 BASIC_AUTH_SETTINGS_KEY,
                 "username1@example.com",
                 "Password1"
@@ -110,11 +115,95 @@ class BasicAuthServiceTest {
         assertThat(basicAuthService.configuration())
             .as("Default configured realm and openUrls should not have been discarded after creating the basic auth user")
             .satisfies(configuration -> {
-                assertThat(configuration.getUsername()).isEqualTo("username1@example.com");
-                assertThat(configuration.getPassword()).isNotBlank();
-                assertThat(configuration.getRealm()).isEqualTo("Kestra2");
-                assertThat(configuration.getOpenUrls()).isEqualTo(List.of("/api/v1/main/executions/webhook/"));
-        });
+                assertThat(configuration.credentials().getUsername()).isEqualTo("username1@example.com");
+                assertThat(configuration.credentials().getPassword()).isNotBlank();
+                assertThat(configuration.realm()).isEqualTo("Kestra2");
+                assertThat(configuration.openUrls()).isEqualTo(List.of("/api/v1/main/executions/webhook/"));
+            });
+    }
+
+    @Test
+    void basicAuthAPICreation_shouldNot_discardYamlConfiguration_andBeBackwardCompatible_noDefaultCredentials() {
+        // simulate starting Kestra for the first time
+        deleteSetting();
+        var defaultConfigWithoutBasicAuthCreds = new ConfigWrapper(
+            new BasicAuthConfiguration(null, null, "Kestra2", List.of("/api/v1/main/executions/webhook/"))
+        );
+        basicAuthService.basicAuthConfiguration = defaultConfigWithoutBasicAuthCreds.config;
+        settingRepositoryInterface.save(Setting.builder()
+            .key(BASIC_AUTH_SETTINGS_KEY)
+            .value(new BasicAuthService.SaltedBasicAuthCredentials(null, "username1@example.com", "Password1"))
+            .build());
+        assertTrue(basicAuthService.isBasicAuthInitialized());
+        basicAuthService.init();
+        assertTrue(basicAuthService.isBasicAuthInitialized());
+
+        assertThat(basicAuthService.configuration())
+            .as("Default configured realm and openUrls should not have been discarded after creating the basic auth user")
+            .satisfies(configuration -> {
+                assertThat(configuration.credentials().getUsername()).isEqualTo("username1@example.com");
+                assertThat(configuration.credentials().getPassword()).isNotBlank();
+                assertThat(configuration.realm()).isEqualTo("Kestra2");
+                assertThat(configuration.openUrls()).isEqualTo(List.of("/api/v1/main/executions/webhook/"));
+            });
+    }
+
+    @Test
+    void basicAuthAPICreation_shouldNot_discardYamlConfiguration_andBeBackwardCompatible_withDefaultCredentials() {
+        // simulate starting Kestra for the first time
+        deleteSetting();
+        var defaultConfigWithoutBasicAuthCreds = new ConfigWrapper(
+            new BasicAuthConfiguration("username1@example.com", "Password1", "Kestra2", List.of("/api/v1/main/executions/webhook/"))
+        );
+        basicAuthService.basicAuthConfiguration = defaultConfigWithoutBasicAuthCreds.config;
+        basicAuthService.init();
+        assertTrue(basicAuthService.isBasicAuthInitialized());
+
+        assertThat(basicAuthService.configuration())
+            .as("Default configured realm and openUrls should not have been discarded after creating the basic auth user")
+            .satisfies(configuration -> {
+                assertThat(configuration.credentials().getUsername()).isEqualTo("username1@example.com");
+                assertThat(configuration.credentials().getPassword()).isNotBlank();
+                assertThat(configuration.realm()).isEqualTo("Kestra2");
+                assertThat(configuration.openUrls()).isEqualTo(List.of("/api/v1/main/executions/webhook/"));
+            });
+    }
+
+    @Getter
+    @AllArgsConstructor
+    @EqualsAndHashCode
+    public static class LegacySaltedBasicAuthConfiguration {
+        private String salt;
+        private String username;
+        protected String password;
+        private String realm;
+        private List<String> openUrls;
+    }
+
+    @Test
+    void basicAuthAPICreation_shouldStillWork_withLegacyPersistedConfiguration() {
+        // given an old configuration containing legacy persisted fields 'realm' and 'openUrls'
+        var salt = AuthUtils.generateSalt();
+        settingRepositoryInterface.save(Setting.builder()
+            .key(BASIC_AUTH_SETTINGS_KEY)
+            .value(new LegacySaltedBasicAuthConfiguration(salt, "username1@example.com", AuthUtils.encodePassword(salt, "Password1"), "OldPersistedRealm", List.of("old-persisted-open-url")))
+            .build());
+        deleteSetting();
+
+        basicAuthService.basicAuthConfiguration = new ConfigWrapper(
+            new BasicAuthConfiguration("username1@example.com", "Password1", "NewRealmFromConf", List.of("NewOpenurl-fromConf"))
+        ).config;
+        basicAuthService.init();
+
+        // then
+        assertThat(basicAuthService.configuration())
+            .as("should be able to fetch deserialize legacy configuration that contained 'realm' and 'openUrls', we do not persist these fields anymore")
+            .satisfies(configuration -> {
+                assertThat(configuration.credentials().getUsername()).isEqualTo("username1@example.com");
+                assertThat(configuration.credentials().getPassword()).isNotBlank();
+                assertThat(configuration.realm()).isEqualTo("NewRealmFromConf");
+                assertThat(configuration.openUrls()).isEqualTo(List.of("NewOpenurl-fromConf"));
+            });
     }
 
     @Test
@@ -132,29 +221,29 @@ class BasicAuthServiceTest {
         deleteSetting();
         basicAuthService.basicAuthConfiguration = configWrapper.config;
         basicAuthService.init();
-        assertThat(basicAuthService.configuration()).isNull();
+        assertThat(basicAuthService.configuration().credentials()).isNull();
     }
 
     static Stream<ConfigWrapper> getConfigs() {
         return Stream.of(
             new ConfigWrapper(null),
-            new ConfigWrapper(new BasicAuthConfiguration(null, null)),
-            new ConfigWrapper(new BasicAuthConfiguration(null, PASSWORD)),
-            new ConfigWrapper(new BasicAuthConfiguration("", PASSWORD)),
-            new ConfigWrapper(new BasicAuthConfiguration(USER_NAME, null)),
-            new ConfigWrapper(new BasicAuthConfiguration(USER_NAME, ""))
+            new ConfigWrapper(new BasicAuthConfiguration(null, null, null, null)),
+            new ConfigWrapper(new BasicAuthConfiguration(null, PASSWORD, null, null)),
+            new ConfigWrapper(new BasicAuthConfiguration("", PASSWORD, null, null)),
+            new ConfigWrapper(new BasicAuthConfiguration(USER_NAME, null, null, null)),
+            new ConfigWrapper(new BasicAuthConfiguration(USER_NAME, "", null, null))
         );
     }
 
     @Test
     void saveValidAuthConfig() throws TimeoutException {
-        basicAuthService.save(new BasicAuthConfiguration(USER_NAME, PASSWORD));
+        basicAuthService.save(new BasicAuthCredentials(null, USER_NAME, PASSWORD));
         awaitOssAuthEventApiCall(USER_NAME);
     }
 
     @Test
     void should_throw_exception_when_saving_invalid_config() {
-        assertThrows(ValidationErrorException.class, () -> basicAuthService.save(new BasicAuthConfiguration(null, null)));
+        assertThrows(ValidationErrorException.class, () -> basicAuthService.save(new BasicAuthCredentials(null, null, null)));
     }
 
     @MethodSource("invalidConfigs")
@@ -169,12 +258,12 @@ class BasicAuthServiceTest {
 
     static Stream<Arguments> invalidConfigs() {
         return Stream.of(
-            Arguments.of(new ConfigWrapper(new BasicAuthConfiguration("username", PASSWORD)), "Invalid username for Basic Authentication. Please provide a valid email address."),
-            Arguments.of(new ConfigWrapper(new BasicAuthConfiguration(null, PASSWORD)), "No user name set for Basic Authentication. Please provide a user name."),
-            Arguments.of(new ConfigWrapper(new BasicAuthConfiguration(USER_NAME + "a".repeat(244), PASSWORD)), "The length of email or password should not exceed 256 characters."),
-            Arguments.of(new ConfigWrapper(new BasicAuthConfiguration(USER_NAME, "pas")), "Invalid password for Basic Authentication. The password must have 8 chars, one upper, one lower and one number"),
-            Arguments.of(new ConfigWrapper(new BasicAuthConfiguration(USER_NAME, null)), "No password set for Basic Authentication. Please provide a password."),
-            Arguments.of(new ConfigWrapper(new BasicAuthConfiguration(USER_NAME, PASSWORD + "a".repeat(246))), "The length of email or password should not exceed 256 characters.")
+            Arguments.of(new ConfigWrapper(new BasicAuthConfiguration("username", PASSWORD, null, null)), "Invalid username for Basic Authentication. Please provide a valid email address."),
+            Arguments.of(new ConfigWrapper(new BasicAuthConfiguration(null, PASSWORD, null, null)), "No user name set for Basic Authentication. Please provide a user name."),
+            Arguments.of(new ConfigWrapper(new BasicAuthConfiguration(USER_NAME + "a".repeat(244), PASSWORD, null, null)), "The length of email or password should not exceed 256 characters."),
+            Arguments.of(new ConfigWrapper(new BasicAuthConfiguration(USER_NAME, "pas", null, null)), "Invalid password for Basic Authentication. The password must have 8 chars, one upper, one lower and one number"),
+            Arguments.of(new ConfigWrapper(new BasicAuthConfiguration(USER_NAME, null, null, null)), "No password set for Basic Authentication. Please provide a password."),
+            Arguments.of(new ConfigWrapper(new BasicAuthConfiguration(USER_NAME, PASSWORD + "a".repeat(246), null, null)), "The length of email or password should not exceed 256 characters.")
 
         );
     }
@@ -190,10 +279,11 @@ class BasicAuthServiceTest {
     }
 
     private void assertConfigurationMatchesApplicationYaml() {
-        BasicAuthService.SaltedBasicAuthConfiguration actualConfiguration = basicAuthService.configuration();
-        BasicAuthService.SaltedBasicAuthConfiguration applicationYamlConfiguration = new BasicAuthService.SaltedBasicAuthConfiguration(
+        var actualConfiguration = basicAuthService.configuration().credentials();
+        var applicationYamlConfiguration = new BasicAuthService.SaltedBasicAuthCredentials(
             actualConfiguration.getSalt(),
-            basicAuthService.basicAuthConfiguration
+            basicAuthService.basicAuthConfiguration.getUsername(),
+            basicAuthService.basicAuthConfiguration.getPassword()
         );
         assertThat(actualConfiguration).isEqualTo(applicationYamlConfiguration);
 

--- a/webserver/src/test/java/io/kestra/webserver/services/BasicAuthServiceTest.java
+++ b/webserver/src/test/java/io/kestra/webserver/services/BasicAuthServiceTest.java
@@ -1,21 +1,5 @@
 package io.kestra.webserver.services;
 
-import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
-import static com.github.tomakehurst.wiremock.client.WireMock.and;
-import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
-import static com.github.tomakehurst.wiremock.client.WireMock.matchingJsonPath;
-import static com.github.tomakehurst.wiremock.client.WireMock.post;
-import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
-import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
-import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
-import static com.github.tomakehurst.wiremock.client.WireMock.verify;
-import static io.kestra.webserver.services.BasicAuthService.BASIC_AUTH_ERROR_CONFIG;
-import static io.kestra.webserver.services.BasicAuthService.BASIC_AUTH_SETTINGS_KEY;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
 import com.github.tomakehurst.wiremock.junit5.WireMockTest;
 import io.kestra.core.exceptions.ValidationErrorException;
 import io.kestra.core.junit.annotations.KestraTest;
@@ -24,20 +8,28 @@ import io.kestra.core.repositories.SettingRepositoryInterface;
 import io.kestra.core.serializers.JacksonMapper;
 import io.kestra.core.services.InstanceService;
 import io.kestra.core.utils.Await;
+import io.kestra.webserver.controllers.api.MiscController;
 import io.kestra.webserver.models.events.Event;
 import io.kestra.webserver.services.BasicAuthService.BasicAuthConfiguration;
 import io.micronaut.context.env.Environment;
 import jakarta.inject.Inject;
-import java.time.Duration;
-import java.util.List;
-import java.util.Optional;
-import java.util.concurrent.TimeoutException;
-import java.util.stream.Stream;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.TimeoutException;
+import java.util.stream.Stream;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static io.kestra.webserver.services.BasicAuthService.BASIC_AUTH_ERROR_CONFIG;
+import static io.kestra.webserver.services.BasicAuthService.BASIC_AUTH_SETTINGS_KEY;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
 
 @WireMockTest(httpPort = 28181)
 @KestraTest(environments = Environment.TEST)
@@ -89,6 +81,40 @@ class BasicAuthServiceTest {
             .value(new BasicAuthConfiguration(null, null, null, null))
             .build());
         assertFalse(basicAuthService.isBasicAuthInitialized());
+    }
+
+    @Test
+    void basicAuthAPICreation_shouldNot_discardYamlConfiguration(){
+        // simulate starting Kestra for the first time
+        deleteSetting();
+        var defaultConfigWithoutBasicAuthCreds = new ConfigWrapper(
+            new BasicAuthConfiguration(null, null, "Kestra2", List.of("/api/v1/main/executions/webhook/"))
+        );
+        basicAuthService.basicAuthConfiguration = defaultConfigWithoutBasicAuthCreds.config;
+        basicAuthService.init();
+        assertFalse(basicAuthService.isBasicAuthInitialized());
+
+        /**
+         * simulate basic auth UI onboarding (createBasicAuth)
+         * {@link io.kestra.webserver.controllers.api.MiscController#createBasicAuth(MiscController.BasicAuthCredentials)}
+         */
+        basicAuthService.createBasicAuthCredentials(
+            new MiscController.BasicAuthCredentials(
+                BASIC_AUTH_SETTINGS_KEY,
+                "username1@example.com",
+                "Password1"
+            )
+        );
+        assertTrue(basicAuthService.isBasicAuthInitialized());
+
+        assertThat(basicAuthService.configuration())
+            .as("Default configured realm and openUrls should not have been discarded after creating the basic auth user")
+            .satisfies(configuration -> {
+                assertThat(configuration.getUsername()).isEqualTo("username1@example.com");
+                assertThat(configuration.getPassword()).isNotBlank();
+                assertThat(configuration.getRealm()).isEqualTo("Kestra2");
+                assertThat(configuration.getOpenUrls()).isEqualTo(List.of("/api/v1/main/executions/webhook/"));
+        });
     }
 
     @Test

--- a/webserver/src/test/resources/application-test.yml
+++ b/webserver/src/test/resources/application-test.yml
@@ -169,6 +169,7 @@ kestra:
       open-urls:
         - "/ping"
         - "/api/v1/executions/webhook/"
+        - "/api/v1/main/executions/webhook/"
     liveness:
       enabled: false
     service:


### PR DESCRIPTION
- fix https://github.com/kestra-io/kestra-ee/issues/5416

The issue was that BasicAuthConfiguration.openUrls was discarded by mistake after a basic auth creds creation.

What has been done:
- make BasicAuthConfiguration a POJO representing the yaml configuration
- dont persist BasicAuthConfiguration
- when fetching the configured Basic auth setup, fetch Credentials from DB and additional configuration from BasicAuthConfiguration
