### PR TITLE
feat(script): Resume of container for the Docker task runner

### DIFF
--- a/script/src/main/java/io/kestra/plugin/scripts/exec/scripts/models/DockerOptions.java
+++ b/script/src/main/java/io/kestra/plugin/scripts/exec/scripts/models/DockerOptions.java
@@ -118,6 +118,13 @@ public class DockerOptions {
     )
     private Property<Boolean> privileged;
 
+    @Schema(
+        title = "Whether to resume an existing matching container on restart.",
+        description = "If enabled, the runner will search for an existing container labeled with the current execution/task identifiers and reattach to it instead of creating a new container."
+    )
+    @PluginProperty
+    private Property<Boolean> resume;
+
     @Deprecated
     public void setDockerHost(String host) {
         this.host = host;

--- a/script/src/main/java/io/kestra/plugin/scripts/exec/scripts/models/DockerOptions.java
+++ b/script/src/main/java/io/kestra/plugin/scripts/exec/scripts/models/DockerOptions.java
@@ -118,13 +118,6 @@ public class DockerOptions {
     )
     private Property<Boolean> privileged;
 
-    @Schema(
-        title = "Whether to resume an existing matching container on restart.",
-        description = "If enabled, the runner will search for an existing container labeled with the current execution/task identifiers and reattach to it instead of creating a new container."
-    )
-    @PluginProperty
-    private Property<Boolean> resume;
-
     @Deprecated
     public void setDockerHost(String host) {
         this.host = host;

--- a/script/src/main/java/io/kestra/plugin/scripts/runner/docker/Docker.java
+++ b/script/src/main/java/io/kestra/plugin/scripts/runner/docker/Docker.java
@@ -390,7 +390,7 @@ public class Docker extends TaskRunner<Docker.DockerTaskRunnerDetailResult> {
 
                 if (!existing.isEmpty()) {
                     containerId = existing.get(0).getId();
-                    logger.info("Resuming existing container {}", containerId);
+                    logger.debug("Resuming existing container: {}", containerId);
                 }
             }
 
@@ -505,7 +505,7 @@ public class Docker extends TaskRunner<Docker.DockerTaskRunnerDetailResult> {
                     } else {
                         var volume = volumes.getVolumes().get(0);
                         filesVolumeName = volume.getName();
-                        logger.info("Volume found with name {} for resumed container {}", filesVolumeName, containerId);
+                        logger.debug("Volume found with name {} for resumed container {}", filesVolumeName, containerId);
                     }
                 }
                 

--- a/script/src/main/java/io/kestra/plugin/scripts/runner/docker/Docker.java
+++ b/script/src/main/java/io/kestra/plugin/scripts/runner/docker/Docker.java
@@ -373,6 +373,8 @@ public class Docker extends TaskRunner<Docker.DockerTaskRunnerDetailResult> {
         String image = runContext.render(this.image, additionalVars);
 
         String resolvedHost = DockerService.findHost(runContext, this.host);
+        Map<String, String> labels = ScriptService.labels(runContext, "kestra.io/");
+
         try (DockerClient dockerClient = dockerClient(runContext, image, resolvedHost)) {
             // evaluate resume (task property overrides plugin configuration if set)
             Boolean resumeProp = runContext.render(this.resume).as(Boolean.class).orElse(Boolean.FALSE);
@@ -381,7 +383,6 @@ public class Docker extends TaskRunner<Docker.DockerTaskRunnerDetailResult> {
             String containerId = null;
 
             if (resumeEnabled) {
-                Map<String, String> labels = ScriptService.labels(runContext, "kestra.io/");
                 List<Container> existing = dockerClient.listContainersCmd()
                     .withShowAll(true)
                     .withLabelFilter(labels)
@@ -419,7 +420,7 @@ public class Docker extends TaskRunner<Docker.DockerTaskRunnerDetailResult> {
                 // create a volume if we need to handle files
                 if (needVolume && FileHandlingStrategy.VOLUME.equals(strategy)) {
                     CreateVolumeCmd files = dockerClient.createVolumeCmd()
-                        .withLabels(ScriptService.labels(runContext, "kestra.io/"));
+                        .withLabels(labels);
                     filesVolumeName = files.exec().getName();
                     if (logger.isTraceEnabled()) {
                         logger.trace("Volume created: {}", filesVolumeName);
@@ -492,14 +493,19 @@ public class Docker extends TaskRunner<Docker.DockerTaskRunnerDetailResult> {
                     logger.debug("Attaching to logs of container {}", containerId);
                 }
                 if (needVolume && FileHandlingStrategy.VOLUME.equals(strategy)) {
-                    var inspectResult = dockerClient.inspectContainerCmd(containerId).exec();
-                    if (inspectResult.getMounts().isEmpty()) {
+                    List<String> labelsList = labels.entrySet()
+                        .stream()
+                        .map(entry -> String.join("=", entry.getKey(), entry.getValue()))
+                        .toList();
+                    var volumes = dockerClient.listVolumesCmd()
+                        .withFilter("label", labelsList).exec();
+                    if (volumes.getVolumes() == null || volumes.getVolumes().isEmpty()) {
                         logger.error("No volume found for resumed container {}", containerId);
                         throw new TaskException(1, defaultLogConsumer);
                     } else {
-                        var mount = inspectResult.getMounts().get(0);
-                        filesVolumeName = mount.getName();
-                        logger.info("Volume {} found for resumed container {}", filesVolumeName, containerId);
+                        var volume = volumes.getVolumes().get(0);
+                        filesVolumeName = volume.getName();
+                        logger.info("Volume found with name {} for resumed container {}", filesVolumeName, containerId);
                     }
                 }
                 

--- a/script/src/main/java/io/kestra/plugin/scripts/runner/docker/Docker.java
+++ b/script/src/main/java/io/kestra/plugin/scripts/runner/docker/Docker.java
@@ -50,6 +50,7 @@ import java.util.*;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Stream;
 
 import static io.kestra.core.utils.Rethrow.throwConsumer;
 import static io.kestra.core.utils.Rethrow.throwFunction;
@@ -151,7 +152,6 @@ public class Docker extends TaskRunner<Docker.DockerTaskRunnerDetailResult> {
 
     private static final String LEGACY_VOLUME_ENABLED_CONFIG = "kestra.tasks.scripts.docker.volume-enabled";
     private static final String VOLUME_ENABLED_CONFIG = "volume-enabled";
-    private static final String RESUME_ENABLED_CONFIG = "resume";
 
     @Schema(
         title = "Docker API URI."
@@ -314,12 +314,13 @@ public class Docker extends TaskRunner<Docker.DockerTaskRunnerDetailResult> {
     )
     private Duration killGracePeriod = Duration.ZERO;
 
+    @Builder.Default
     @Schema(
         title = "Whether to resume an existing matching container on restart.",
         description = "If enabled, the runner will search for an existing container labeled with the current execution/task identifiers and reattach to it instead of creating a new container."
     )
     @PluginProperty
-    private Property<Boolean> resume;
+    private Property<Boolean> resume = Property.ofValue(false);
 
     /**
      * Convenient default instance to be used as task default value for a 'taskRunner' property.
@@ -350,7 +351,6 @@ public class Docker extends TaskRunner<Docker.DockerTaskRunnerDetailResult> {
             .memory(dockerOptions.getMemory())
             .shmSize(dockerOptions.getShmSize())
             .privileged(dockerOptions.getPrivileged())
-            .resume(dockerOptions.getResume())
             .build();
     }
 
@@ -375,9 +375,8 @@ public class Docker extends TaskRunner<Docker.DockerTaskRunnerDetailResult> {
         String resolvedHost = DockerService.findHost(runContext, this.host);
         try (DockerClient dockerClient = dockerClient(runContext, image, resolvedHost)) {
             // evaluate resume (task property overrides plugin configuration if set)
-            Boolean resumeProp = runContext.render(this.resume).as(Boolean.class).orElse(null);
-            Optional<Boolean> resumeConfig = runContext.pluginConfiguration(RESUME_ENABLED_CONFIG);
-            boolean resumeEnabled = resumeProp != null ? resumeProp : resumeConfig.orElse(Boolean.FALSE);
+            Boolean resumeProp = runContext.render(this.resume).as(Boolean.class).orElse(Boolean.FALSE);
+            boolean resumeEnabled = Boolean.TRUE.equals(resumeProp);
 
             String containerId = null;
 
@@ -390,9 +389,7 @@ public class Docker extends TaskRunner<Docker.DockerTaskRunnerDetailResult> {
 
                 if (!existing.isEmpty()) {
                     containerId = existing.get(0).getId();
-                    if (logger.isDebugEnabled()) {
-                        logger.debug("Resuming existing container {}", containerId);
-                    }
+                    logger.info("Resuming existing container {}", containerId);
                 }
             }
 
@@ -494,6 +491,18 @@ public class Docker extends TaskRunner<Docker.DockerTaskRunnerDetailResult> {
                 if (logger.isDebugEnabled()) {
                     logger.debug("Attaching to logs of container {}", containerId);
                 }
+                if (needVolume && FileHandlingStrategy.VOLUME.equals(strategy)) {
+                    var inspectResult = dockerClient.inspectContainerCmd(containerId).exec();
+                    if (inspectResult.getMounts().isEmpty()) {
+                        logger.error("No volume found for resumed container {}", containerId);
+                        throw new TaskException(1, defaultLogConsumer);
+                    } else {
+                        var mount = inspectResult.getMounts().get(0);
+                        filesVolumeName = mount.getName();
+                        logger.info("Volume {} found for resumed container {}", filesVolumeName, containerId);
+                    }
+                }
+                
             }
 
             final String runContainerId = containerId;
@@ -574,7 +583,7 @@ public class Docker extends TaskRunner<Docker.DockerTaskRunnerDetailResult> {
                 Await.until(ended::get);
 
                 if (exitCode != 0) {
-                    if (needVolume && FileHandlingStrategy.VOLUME.equals(strategy)) {
+                    if (needVolume && FileHandlingStrategy.VOLUME.equals(strategy) && filesVolumeName != null) {
                         // On failure, still attempt to download outputs if VOLUME strategy is used
                         downloadOutputFiles(runContainerId, dockerClient, runContext, taskCommands);
                     }
@@ -585,11 +594,7 @@ public class Docker extends TaskRunner<Docker.DockerTaskRunnerDetailResult> {
                 }
 
                 if (needVolume && FileHandlingStrategy.VOLUME.equals(strategy) && filesVolumeName != null) {
-                    // For newly created containers, original condition holds; for resumed ones, filesVolumeName is null
-                    // but we still want to retrieve outputs from the container working directory.
-                    if (filesVolumeName != null || resumeEnabled) {
-                        downloadOutputFiles(runContainerId, dockerClient, runContext, taskCommands);
-                    }
+                    downloadOutputFiles(runContainerId, dockerClient, runContext, taskCommands);
                 }
 
                 return TaskRunnerResult.<DockerTaskRunnerDetailResult>builder()

--- a/script/src/main/java/io/kestra/plugin/scripts/runner/docker/Docker.java
+++ b/script/src/main/java/io/kestra/plugin/scripts/runner/docker/Docker.java
@@ -151,6 +151,7 @@ public class Docker extends TaskRunner<Docker.DockerTaskRunnerDetailResult> {
 
     private static final String LEGACY_VOLUME_ENABLED_CONFIG = "kestra.tasks.scripts.docker.volume-enabled";
     private static final String VOLUME_ENABLED_CONFIG = "volume-enabled";
+    private static final String RESUME_ENABLED_CONFIG = "resume";
 
     @Schema(
         title = "Docker API URI."
@@ -313,6 +314,13 @@ public class Docker extends TaskRunner<Docker.DockerTaskRunnerDetailResult> {
     )
     private Duration killGracePeriod = Duration.ZERO;
 
+    @Schema(
+        title = "Whether to resume an existing matching container on restart.",
+        description = "If enabled, the runner will search for an existing container labeled with the current execution/task identifiers and reattach to it instead of creating a new container."
+    )
+    @PluginProperty
+    private Property<Boolean> resume;
+
     /**
      * Convenient default instance to be used as task default value for a 'taskRunner' property.
      **/
@@ -342,6 +350,7 @@ public class Docker extends TaskRunner<Docker.DockerTaskRunnerDetailResult> {
             .memory(dockerOptions.getMemory())
             .shmSize(dockerOptions.getShmSize())
             .privileged(dockerOptions.getPrivileged())
+            .resume(dockerOptions.getResume())
             .build();
     }
 
@@ -365,17 +374,26 @@ public class Docker extends TaskRunner<Docker.DockerTaskRunnerDetailResult> {
 
         String resolvedHost = DockerService.findHost(runContext, this.host);
         try (DockerClient dockerClient = dockerClient(runContext, image, resolvedHost)) {
-            // pull image
-            var renderedPolicy = runContext.render(this.getPullPolicy()).as(PullPolicy.class).orElseThrow();
-            if (!PullPolicy.NEVER.equals(renderedPolicy)) {
-                pullImage(dockerClient, image, renderedPolicy, logger);
-            }
+            // evaluate resume (task property overrides plugin configuration if set)
+            Boolean resumeProp = runContext.render(this.resume).as(Boolean.class).orElse(null);
+            Optional<Boolean> resumeConfig = runContext.pluginConfiguration(RESUME_ENABLED_CONFIG);
+            boolean resumeEnabled = resumeProp != null ? resumeProp : resumeConfig.orElse(Boolean.FALSE);
 
-            // create container
-            CreateContainerCmd container = configure(taskCommands, dockerClient, runContext, additionalVars);
-            CreateContainerResponse exec = container.exec();
-            if (logger.isTraceEnabled()) {
-                logger.trace("Container created: {}", exec.getId());
+            String containerId = null;
+
+            if (resumeEnabled) {
+                Map<String, String> labels = ScriptService.labels(runContext, "kestra.io/");
+                List<Container> existing = dockerClient.listContainersCmd()
+                    .withShowAll(true)
+                    .withLabelFilter(labels)
+                    .exec();
+
+                if (!existing.isEmpty()) {
+                    containerId = existing.get(0).getId();
+                    if (logger.isDebugEnabled()) {
+                        logger.debug("Resuming existing container {}", containerId);
+                    }
+                }
             }
 
             List<Path> relativeWorkingDirectoryFilesPaths = taskCommands.relativeWorkingDirectoryFilesPaths(true);
@@ -384,94 +402,117 @@ public class Docker extends TaskRunner<Docker.DockerTaskRunnerDetailResult> {
             boolean outputDirectoryEnabled = taskCommands.outputDirectoryEnabled();
             boolean needVolume = hasFilesToDownload || hasFilesToUpload || outputDirectoryEnabled;
             String filesVolumeName = null;
-
-            // create a volume if we need to handle files
             var strategy = runContext.render(this.fileHandlingStrategy).as(FileHandlingStrategy.class).orElse(null);
-            if (needVolume && FileHandlingStrategy.VOLUME.equals(strategy)) {
-                CreateVolumeCmd files = dockerClient.createVolumeCmd()
-                    .withLabels(ScriptService.labels(runContext, "kestra.io/"));
-                filesVolumeName = files.exec().getName();
+
+            // pull image only if we will create a new container
+            if (containerId == null) {
+                var renderedPolicy = runContext.render(this.getPullPolicy()).as(PullPolicy.class).orElseThrow();
+                if (!PullPolicy.NEVER.equals(renderedPolicy)) {
+                    pullImage(dockerClient, image, renderedPolicy, logger);
+                }
+
+                // create container
+                CreateContainerCmd container = configure(taskCommands, dockerClient, runContext, additionalVars);
+                CreateContainerResponse exec = container.exec();
+                containerId = exec.getId();
                 if (logger.isTraceEnabled()) {
-                    logger.trace("Volume created: {}", filesVolumeName);
+                    logger.trace("Container created: {}", containerId);
                 }
 
-                String remotePath = windowsToUnixPath(taskCommands.getWorkingDirectory().toString());
-
-                // first, create an archive
-                Path fileArchive = runContext.workingDir().createFile("inputFiles.tar");
-                try (FileOutputStream fos = new FileOutputStream(fileArchive.toString());
-                     TarArchiveOutputStream out = new TarArchiveOutputStream(fos)) {
-                    out.setLongFileMode(TarArchiveOutputStream.LONGFILE_POSIX); // allow long file name
-                    out.setBigNumberMode(TarArchiveOutputStream.BIGNUMBER_POSIX); // allow large archive name
-
-                    for (Path file: relativeWorkingDirectoryFilesPaths) {
-                        Path resolvedFile = runContext.workingDir().resolve(file);
-                        TarArchiveEntry entry = out.createArchiveEntry(resolvedFile.toFile(), file.toString());
-                        // Preserve POSIX permissions if supported
-                        try {
-                            Set<PosixFilePermission> perms = Files.getPosixFilePermissions(resolvedFile);
-                            entry.setMode(UnixModeToPosixFilePermissions.fromPosixFilePermissions(perms));
-                        } catch (UnsupportedOperationException | IOException ignore) {
-                            // Skipping unix file permission
-                        }
-                        out.putArchiveEntry(entry);
-                        if (!Files.isDirectory(resolvedFile)) {
-                            try (InputStream fis = Files.newInputStream(resolvedFile)) {
-                                IOUtils.copy(fis, out);
-                            }
-                        }
-                        out.closeArchiveEntry();
+                // create a volume if we need to handle files
+                if (needVolume && FileHandlingStrategy.VOLUME.equals(strategy)) {
+                    CreateVolumeCmd files = dockerClient.createVolumeCmd()
+                        .withLabels(ScriptService.labels(runContext, "kestra.io/"));
+                    filesVolumeName = files.exec().getName();
+                    if (logger.isTraceEnabled()) {
+                        logger.trace("Volume created: {}", filesVolumeName);
                     }
-                    out.finish();
+
+                    String remotePath = windowsToUnixPath(taskCommands.getWorkingDirectory().toString());
+
+                    // first, create an archive
+                    Path fileArchive = runContext.workingDir().createFile("inputFiles.tar");
+                    try (FileOutputStream fos = new FileOutputStream(fileArchive.toString());
+                         TarArchiveOutputStream out = new TarArchiveOutputStream(fos)) {
+                        out.setLongFileMode(TarArchiveOutputStream.LONGFILE_POSIX); // allow long file name
+                        out.setBigNumberMode(TarArchiveOutputStream.BIGNUMBER_POSIX); // allow large archive name
+
+                        for (Path file: relativeWorkingDirectoryFilesPaths) {
+                            Path resolvedFile = runContext.workingDir().resolve(file);
+                            TarArchiveEntry entry = out.createArchiveEntry(resolvedFile.toFile(), file.toString());
+                            // Preserve POSIX permissions if supported
+                            try {
+                                Set<PosixFilePermission> perms = Files.getPosixFilePermissions(resolvedFile);
+                                entry.setMode(UnixModeToPosixFilePermissions.fromPosixFilePermissions(perms));
+                            } catch (UnsupportedOperationException | IOException ignore) {
+                                // Skipping unix file permission
+                            }
+                            out.putArchiveEntry(entry);
+                            if (!Files.isDirectory(resolvedFile)) {
+                                try (InputStream fis = Files.newInputStream(resolvedFile)) {
+                                    IOUtils.copy(fis, out);
+                                }
+                            }
+                            out.closeArchiveEntry();
+                        }
+                        out.finish();
+                    }
+
+                    // then send it to the container
+                    try (InputStream is = new FileInputStream(fileArchive.toString())) {
+                        CopyArchiveToContainerCmd copyArchiveToContainerCmd = dockerClient.copyArchiveToContainerCmd(containerId)
+                            .withTarInputStream(is)
+                            .withRemotePath(remotePath);
+                        copyArchiveToContainerCmd.exec();
+                    }
+
+                    Files.delete(fileArchive);
+
+                    // create the outputDir if needed
+                    if (taskCommands.outputDirectoryEnabled()) {
+                        CopyArchiveToContainerCmd copyArchiveToContainerCmd = dockerClient.copyArchiveToContainerCmd(containerId)
+                            .withHostResource(taskCommands.getOutputDirectory().toString())
+                            .withRemotePath(remotePath);
+                        copyArchiveToContainerCmd.exec();
+                    }
                 }
 
-                // then send it to the container
-                try (InputStream is = new FileInputStream(fileArchive.toString())) {
-                    CopyArchiveToContainerCmd copyArchiveToContainerCmd = dockerClient.copyArchiveToContainerCmd(exec.getId())
-                        .withTarInputStream(is)
-                        .withRemotePath(remotePath);
-                    copyArchiveToContainerCmd.exec();
+                // start container
+                dockerClient.startContainerCmd(containerId).exec();
+
+                List<String> renderedCommands = runContext.render(taskCommands.getCommands()).asList(String.class);
+
+                if (logger.isDebugEnabled()) {
+                    logger.debug(
+                        "Starting command with container id {} [{}]",
+                        containerId,
+                        String.join(" ", renderedCommands)
+                    );
                 }
-
-                Files.delete(fileArchive);
-
-                // create the outputDir if needed
-                if (taskCommands.outputDirectoryEnabled()) {
-                    CopyArchiveToContainerCmd copyArchiveToContainerCmd = dockerClient.copyArchiveToContainerCmd(exec.getId())
-                        .withHostResource(taskCommands.getOutputDirectory().toString())
-                        .withRemotePath(remotePath);
-                    copyArchiveToContainerCmd.exec();
+            } else {
+                // resumed path: do not re-create or start the container, just attach and wait
+                if (logger.isDebugEnabled()) {
+                    logger.debug("Attaching to logs of container {}", containerId);
                 }
             }
 
-            // start container
-            dockerClient.startContainerCmd(exec.getId()).exec();
-
-            List<String> renderedCommands = runContext.render(taskCommands.getCommands()).asList(String.class);
-
-            if (logger.isDebugEnabled()) {
-                logger.debug(
-                    "Starting command with container id {} [{}]",
-                    exec.getId(),
-                    String.join(" ", renderedCommands)
-                );
-            }
+            final String runContainerId = containerId;
 
             if (!Boolean.TRUE.equals(runContext.render(wait).as(Boolean.class).orElseThrow())) {
                 return TaskRunnerResult.<DockerTaskRunnerDetailResult>builder()
                     .exitCode(0)
                     .logConsumer(defaultLogConsumer)
-                    .details(DockerTaskRunnerDetailResult.builder().containerId(exec.getId()).build())
+                    .details(DockerTaskRunnerDetailResult.builder().containerId(runContainerId).build())
                     .build();
             }
 
             // register the runnable to be used for killing the container.
-            onKill(() -> kill(dockerClient, exec.getId(), logger));
+            onKill(() -> kill(dockerClient, runContainerId, logger));
 
             AtomicBoolean ended = new AtomicBoolean(false);
 
             try {
-                dockerClient.logContainerCmd(exec.getId())
+                dockerClient.logContainerCmd(runContainerId)
                     .withFollowStream(true)
                     .withStdErr(true)
                     .withStdOut(true)
@@ -527,14 +568,15 @@ public class Docker extends TaskRunner<Docker.DockerTaskRunnerDetailResult> {
                         }
                     });
 
-                WaitContainerResultCallback result = dockerClient.waitContainerCmd(exec.getId()).start();
+                WaitContainerResultCallback result = dockerClient.waitContainerCmd(runContainerId).start();
 
                 Integer exitCode = result.awaitStatusCode();
                 Await.until(ended::get);
 
                 if (exitCode != 0) {
-                    if (needVolume && FileHandlingStrategy.VOLUME.equals(strategy)  && filesVolumeName != null) {
-                        downloadOutputFiles(exec.getId(), dockerClient, runContext, taskCommands);
+                    if (needVolume && FileHandlingStrategy.VOLUME.equals(strategy)) {
+                        // On failure, still attempt to download outputs if VOLUME strategy is used
+                        downloadOutputFiles(runContainerId, dockerClient, runContext, taskCommands);
                     }
 
                     throw new TaskException(exitCode, defaultLogConsumer);
@@ -542,14 +584,18 @@ public class Docker extends TaskRunner<Docker.DockerTaskRunnerDetailResult> {
                     logger.debug("Command succeed with exit code {}", exitCode);
                 }
 
-                if (needVolume && FileHandlingStrategy.VOLUME.equals(strategy)  && filesVolumeName != null) {
-                    downloadOutputFiles(exec.getId(), dockerClient, runContext, taskCommands);
+                if (needVolume && FileHandlingStrategy.VOLUME.equals(strategy) && filesVolumeName != null) {
+                    // For newly created containers, original condition holds; for resumed ones, filesVolumeName is null
+                    // but we still want to retrieve outputs from the container working directory.
+                    if (filesVolumeName != null || resumeEnabled) {
+                        downloadOutputFiles(runContainerId, dockerClient, runContext, taskCommands);
+                    }
                 }
 
                 return TaskRunnerResult.<DockerTaskRunnerDetailResult>builder()
                     .exitCode(exitCode)
                     .logConsumer(defaultLogConsumer)
-                    .details(DockerTaskRunnerDetailResult.builder().containerId(exec.getId()).build())
+                    .details(DockerTaskRunnerDetailResult.builder().containerId(runContainerId).build())
                     .build();
             } finally {
                 try {
@@ -558,12 +604,12 @@ public class Docker extends TaskRunner<Docker.DockerTaskRunnerDetailResult> {
                     kill();
 
                     if (Boolean.TRUE.equals(renderedDelete)) {
-                        dockerClient.removeContainerCmd(exec.getId()).exec();
+                        dockerClient.removeContainerCmd(runContainerId).exec();
                         if (logger.isTraceEnabled()) {
-                            logger.trace("Container deleted: {}", exec.getId());
+                            logger.trace("Container deleted: {}", runContainerId);
                         }
 
-                        if (needVolume && FileHandlingStrategy.VOLUME.equals(strategy)  && filesVolumeName != null) {
+                        if (needVolume && FileHandlingStrategy.VOLUME.equals(strategy) && filesVolumeName != null) {
                             dockerClient.removeVolumeCmd(filesVolumeName).exec();
 
                             if (logger.isTraceEnabled()) {

--- a/script/src/main/java/io/kestra/plugin/scripts/runner/docker/Docker.java
+++ b/script/src/main/java/io/kestra/plugin/scripts/runner/docker/Docker.java
@@ -320,7 +320,7 @@ public class Docker extends TaskRunner<Docker.DockerTaskRunnerDetailResult> {
         description = "If enabled, the runner will search for an existing container labeled with the current execution/task identifiers and reattach to it instead of creating a new container."
     )
     @PluginProperty
-    private Property<Boolean> resume = Property.ofValue(false);
+    private Property<Boolean> resume = Property.ofValue(true);
 
     /**
      * Convenient default instance to be used as task default value for a 'taskRunner' property.

--- a/script/src/test/java/io/kestra/plugin/scripts/runner/docker/DockerTest.java
+++ b/script/src/test/java/io/kestra/plugin/scripts/runner/docker/DockerTest.java
@@ -10,6 +10,7 @@ import io.kestra.core.queues.QueueFactoryInterface;
 import io.kestra.core.queues.QueueInterface;
 import io.kestra.core.runners.RunContext;
 import io.kestra.core.utils.Await;
+import io.kestra.core.utils.IdUtils;
 import io.kestra.core.utils.TestsUtils;
 import io.kestra.plugin.scripts.exec.scripts.runners.CommandsWrapper;
 import jakarta.inject.Inject;
@@ -18,6 +19,7 @@ import org.assertj.core.api.Assertions;
 import org.hamcrest.MatcherAssert;
 import org.junit.jupiter.api.Test;
 import reactor.core.publisher.Flux;
+import java.lang.reflect.Method;
 import java.time.Duration;
 import java.util.*;
 import java.util.concurrent.CopyOnWriteArrayList;
@@ -87,16 +89,27 @@ class DockerTest extends AbstractTaskRunnerTest {
         assertThat(result.getLogConsumer().getStdOutCount()).isEqualTo(1);
     }
 
+    public static void callOnKill(TaskRunner<?> taskRunner, Runnable runnable) throws Exception {
+        Method method = TaskRunner.class.getDeclaredMethod("onKill", Runnable.class);
+        method.setAccessible(true);
+        method.invoke(taskRunner, runnable);
+    }
+
     @Test
     void killAfterResume() throws Exception {
-        var runContext = runContext(this.runContextFactory);
+        var taskRunId = IdUtils.create();
+
+        // Create a new RunContext with a specific taskRunId
+        var runContext = runContext(this.runContextFactory, null, taskRunId);
         var commands = initScriptCommands(runContext);
 
 
         // Setup log queue consumer
         List<LogEntry> logs = new CopyOnWriteArrayList<>();
         Flux<LogEntry> receive = TestsUtils.receive(workerTaskLogQueue, (logEntry) -> {
-            logs.add(logEntry.getLeft());
+            if (logEntry.isLeft()) {
+                logs.add(logEntry.getLeft());
+            }
         });
 
         var commandsList = ScriptService.scriptCommands(List.of("/bin/sh", "-c"), Collections.emptyList(),
@@ -120,13 +133,16 @@ class DockerTest extends AbstractTaskRunnerTest {
                     .withLabelFilter(labels)
                     .exec();
                 return !existingContainers.isEmpty() && existingContainers.get(0).getState().equals("running");
+            }, Duration.ofMillis(100), Duration.ofMillis(1000)); // Add timeout to avoid waiting forever for container to be created
+
+            callOnKill(taskRunner, () -> {
+                // override the kill method to not kill the container
             });
             initialContainerThread.interrupt();
 
-            // Create a new RunContext with the same taskrun variables to maintain labels
-            @SuppressWarnings("unchecked")
-            Map<String, Object> taskRunProps = new HashMap<>((Map<String, Object>) runContext.getVariables().get("taskrun"));
-            RunContext anotherRunContext = runContext(this.runContextFactory, Map.of("taskrun", taskRunProps));
+            // Create a new RunContext with the same taskRunId to maintain labels AND the same method to get a similar context
+            RunContext anotherRunContext = runContext(this.runContextFactory, null, taskRunId);
+
             var anotherTaskRunner = ((Docker) taskRunner())
                 .toBuilder()
                 .delete(Property.ofValue(false))
@@ -139,12 +155,17 @@ class DockerTest extends AbstractTaskRunnerTest {
             Mockito.when(resumeCommands.getCommands()).thenReturn(Property.ofValue(commandsList));
             Thread resumeContainerThread = new Thread(throwRunnable(() -> anotherTaskRunner.run(anotherRunContext, resumeCommands, Collections.emptyList())));
             resumeContainerThread.start();
-            // Wait for the log message indicating resume
-            LogEntry awaitLog = TestsUtils.awaitLog(logs, logEntry -> logEntry.getMessage().contains("Resuming existing container"));
-            // assertThat(awaitLog).isNotNull().withFailMessage("await log should not be null");
-            // assertThat(awaitLog.getMessage()).contains("Resuming existing container");
 
-            receive.blockLast();
+            // Add timeout to avoid waiting forever for logs
+            var timeout = Duration.ofSeconds(1);
+            receive.blockLast(timeout);
+            // Wait for the log message indicating resume
+            LogEntry awaitLog = TestsUtils
+                .awaitLog(logs, logEntry -> logEntry.getMessage().contains("Resuming existing container"));
+
+            // Assert that the log message is present
+            assertThat(awaitLog).isNotNull().withFailMessage("await log should not be null");
+            assertThat(awaitLog.getMessage()).contains("Resuming existing container");
 
             // Kill the container and verify cleanup
             anotherTaskRunner.kill();

--- a/script/src/test/java/io/kestra/plugin/scripts/runner/docker/DockerTest.java
+++ b/script/src/test/java/io/kestra/plugin/scripts/runner/docker/DockerTest.java
@@ -122,7 +122,7 @@ class DockerTest extends AbstractTaskRunnerTest {
             .delete(Property.ofValue(false))
             .build();
         // Assert that the resume property is set to true by default
-        Boolean resume =runContext.render(taskRunner.getResume()).as(Boolean.class).orElseThrow();
+        Boolean resume = runContext.render(taskRunner.getResume()).as(Boolean.class).orElseThrow();
         assertThat(resume).isEqualTo(Boolean.TRUE);
 
         Thread initialContainerThread = new Thread(throwRunnable(() -> taskRunner.run(runContext, commands, Collections.emptyList())));

--- a/script/src/test/java/io/kestra/plugin/scripts/runner/docker/DockerTest.java
+++ b/script/src/test/java/io/kestra/plugin/scripts/runner/docker/DockerTest.java
@@ -2,18 +2,19 @@ package io.kestra.plugin.scripts.runner.docker;
 
 import io.kestra.core.models.property.Property;
 import io.kestra.core.models.tasks.runners.AbstractTaskRunnerTest;
-import io.kestra.core.models.tasks.runners.TaskCommands;
 import io.kestra.core.models.tasks.runners.TaskRunner;
 import io.kestra.plugin.scripts.exec.scripts.runners.CommandsWrapper;
 import org.assertj.core.api.Assertions;
 import org.hamcrest.MatcherAssert;
 import org.junit.jupiter.api.Test;
-
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.hamcrest.Matchers.containsString;
+
+ 
 
 class DockerTest extends AbstractTaskRunnerTest {
     @Override
@@ -66,4 +67,116 @@ class DockerTest extends AbstractTaskRunnerTest {
         MatcherAssert.assertThat((String) result.getLogConsumer().getOutputs().get("cpuLimit"), containsString("150000"));
         assertThat(result.getLogConsumer().getStdOutCount()).isEqualTo(1);
     }
+    
+
+    @Test
+    void shouldResumeExistingContainer() throws Exception {
+        // resume = true
+        var runContext = runContext(this.runContextFactory);
+
+        // first run: create a container and do not wait for it to finish immediately
+        var dockerCreate = Docker.builder()
+            .image("rockylinux:9.3-minimal")
+            .wait(Property.ofValue(false))
+            .resume(Property.ofValue(true))
+            .build();
+
+        var createCommands = new CommandsWrapper(runContext).withCommands(Property.ofValue(List.of(
+            "/bin/sh", "-c",
+            "echo \"::{\\\"outputs\\\":{\\\"msg\\\":\\\"Token\\\"}}::\" && sleep 1"
+        )));
+
+        var first = dockerCreate.run(runContext, createCommands, Collections.emptyList());
+        var firstContainerId = first.getDetails().getContainerId();
+
+        // second run: resume and wait, reusing the same labels context (same runContext)
+        var dockerResume = Docker.builder()
+            .image("rockylinux:9.3-minimal")
+            .wait(Property.ofValue(true))
+            .resume(Property.ofValue(true))
+            .build();
+
+        var resumeCommands = new CommandsWrapper(runContext).withCommands(Property.ofValue(List.of(
+            "/bin/sh", "-c",
+            "echo \"::{\\\"outputs\\\":{\\\"msg\\\":\\\"Token\\\"}}::\" && sleep 1"
+        )));
+
+        var resumeResult = dockerResume.run(runContext, resumeCommands, Collections.emptyList());
+        var resumedContainerId = resumeResult.getDetails().getContainerId();
+
+        assertThat(resumeResult).isNotNull();
+        assertThat(resumeResult.getExitCode()).isZero();
+        assertThat(resumedContainerId).isEqualTo(firstContainerId);
+        assertThat(resumeResult.getLogConsumer().getStdOutCount()).isEqualTo(1);
+    }
+
+    @Test
+    void shouldCreateNewContainerIfNoneToResume() throws Exception {
+        var runContext = runContext(this.runContextFactory);
+
+        var docker = Docker.builder()
+            .image("rockylinux:9.3-minimal")
+            .resume(Property.ofValue(true))
+            .build();
+
+        var commands = new CommandsWrapper(runContext).withCommands(Property.ofValue(List.of(
+            "/bin/sh", "-c",
+            "echo \"::{\\\"outputs\\\":{\\\"msg\\\":\\\"NewContainer\\\"}}::\""
+        )));
+
+        var result = docker.run(runContext, commands, Collections.emptyList());
+
+        assertThat(result).isNotNull();
+        assertThat(result.getExitCode()).isZero();
+        String msg = (String) result.getLogConsumer().getOutputs().get("msg");
+        MatcherAssert.assertThat(msg, containsString("NewContainer"));
+        assertThat(result.getLogConsumer().getStdOutCount()).isEqualTo(1);
+    }
+
+    @Test
+    void shouldCreateTwoContainersWhenResumeDisabled() throws Exception {
+        // resume = false
+        var runContext = runContext(this.runContextFactory);
+
+        var dockerCreate = Docker.builder()
+            .image("rockylinux:9.3-minimal")
+            .wait(Property.ofValue(false))
+            .delete(Property.ofValue(false))
+            .build();
+
+        var commandProps = Property.ofValue(List.of(
+            "/bin/sh", "-c",
+            "echo 'Token' && sleep 1"
+        ));
+        var commands1 = new CommandsWrapper(runContext).withCommands(commandProps);
+        var commands2 = new CommandsWrapper(runContext).withCommands(commandProps);
+
+        var first = dockerCreate.run(runContext, commands1, Collections.emptyList());
+        var firstContainerId = first.getDetails().getContainerId();
+
+        var dockerSecond = Docker.builder()
+            .image("rockylinux:9.3-minimal")
+            .wait(Property.ofValue(false))
+            .delete(Property.ofValue(false))
+            .build();
+
+        var second = dockerSecond.run(runContext, commands2, Collections.emptyList());
+        var secondContainerId = second.getDetails().getContainerId();
+
+        assertThat(firstContainerId).isNotNull();
+        assertThat(secondContainerId).isNotNull();
+        assertThat(secondContainerId).isNotEqualTo(firstContainerId);
+
+
+        try (var client = DockerService.client(runContext, null, null, null, "rockylinux:9.3-minimal")) {
+            // wait concurrently
+            var f1 = CompletableFuture.supplyAsync(() -> client.waitContainerCmd(firstContainerId).start().awaitStatusCode());
+            var f2 = CompletableFuture.supplyAsync(() -> client.waitContainerCmd(secondContainerId).start().awaitStatusCode());
+            
+            CompletableFuture.allOf(f1, f2).join();
+            assertThat(f1.get()).isZero();
+            assertThat(f2.get()).isZero();
+        }
+    }
+    
 }

--- a/script/src/test/java/io/kestra/plugin/scripts/runner/docker/DockerTest.java
+++ b/script/src/test/java/io/kestra/plugin/scripts/runner/docker/DockerTest.java
@@ -18,7 +18,7 @@ import org.assertj.core.api.Assertions;
 import org.hamcrest.MatcherAssert;
 import org.junit.jupiter.api.Test;
 import reactor.core.publisher.Flux;
-
+import java.time.Duration;
 import java.util.*;
 import java.util.concurrent.CopyOnWriteArrayList;
 
@@ -35,6 +35,7 @@ class DockerTest extends AbstractTaskRunnerTest {
     @Inject
     @Named(QueueFactoryInterface.WORKERTASKLOG_NAMED)
     QueueInterface<LogEntry> workerTaskLogQueue;
+
     @Override
     protected TaskRunner<?> taskRunner() {
         return Docker.builder().image("rockylinux:9.3-minimal").build();
@@ -91,10 +92,21 @@ class DockerTest extends AbstractTaskRunnerTest {
         var runContext = runContext(this.runContextFactory);
         var commands = initScriptCommands(runContext);
 
-        var commandsList = ScriptService.scriptCommands(List.of("/bin/sh", "-c"), Collections.emptyList(), List.of("sleep 50"));
+
+        // Setup log queue consumer
+        List<LogEntry> logs = new CopyOnWriteArrayList<>();
+        Flux<LogEntry> receive = TestsUtils.receive(workerTaskLogQueue, (logEntry) -> {
+            logs.add(logEntry.getLeft());
+        });
+
+        var commandsList = ScriptService.scriptCommands(List.of("/bin/sh", "-c"), Collections.emptyList(),
+            List.of("echo 'sleeping for 50 seconds' && sleep 50"));
         Mockito.when(commands.getCommands()).thenReturn(Property.ofValue(commandsList));
 
-        var taskRunner = ((Docker) taskRunner()).toBuilder().resume(Property.ofValue(true)).build();
+        var taskRunner = ((Docker) taskRunner())
+            .toBuilder()
+            .delete(Property.ofValue(false))
+            .resume(Property.ofValue(true)).build();
         Thread initialContainerThread = new Thread(throwRunnable(() -> taskRunner.run(runContext, commands, Collections.emptyList())));
         initialContainerThread.start();
 
@@ -115,13 +127,11 @@ class DockerTest extends AbstractTaskRunnerTest {
             @SuppressWarnings("unchecked")
             Map<String, Object> taskRunProps = new HashMap<>((Map<String, Object>) runContext.getVariables().get("taskrun"));
             RunContext anotherRunContext = runContext(this.runContextFactory, Map.of("taskrun", taskRunProps));
-            var anotherTaskRunner = ((Docker) taskRunner()).toBuilder().resume(Property.ofValue(true)).build();
-
-            // Setup log queue consumer
-            List<LogEntry> logs = new CopyOnWriteArrayList<>();
-            Flux<LogEntry> receive = TestsUtils.receive(workerTaskLogQueue, (logEntry) -> {
-                logs.add(logEntry.getLeft());
-            });
+            var anotherTaskRunner = ((Docker) taskRunner())
+                .toBuilder()
+                .delete(Property.ofValue(false))
+                .resume(Property.ofValue(true))
+                .build();
 
             // Start resume in a new thread
             var resumeCommands = initScriptCommands(anotherRunContext);
@@ -129,9 +139,11 @@ class DockerTest extends AbstractTaskRunnerTest {
             Mockito.when(resumeCommands.getCommands()).thenReturn(Property.ofValue(commandsList));
             Thread resumeContainerThread = new Thread(throwRunnable(() -> anotherTaskRunner.run(anotherRunContext, resumeCommands, Collections.emptyList())));
             resumeContainerThread.start();
-            
             // Wait for the log message indicating resume
-            TestsUtils.awaitLog(logs, logEntry -> logEntry.getMessage().contains("Resuming existing container"));
+            LogEntry awaitLog = TestsUtils.awaitLog(logs, logEntry -> logEntry.getMessage().contains("Resuming existing container"));
+            // assertThat(awaitLog).isNotNull().withFailMessage("await log should not be null");
+            // assertThat(awaitLog.getMessage()).contains("Resuming existing container");
+
             receive.blockLast();
 
             // Kill the container and verify cleanup
@@ -139,7 +151,6 @@ class DockerTest extends AbstractTaskRunnerTest {
             resumeContainerThread.interrupt();
 
             List<Container> existingContainers = client.listContainersCmd()
-                .withShowAll(true)
                 .withLabelFilter(labels)
                 .exec();
             MatcherAssert.assertThat(existingContainers.isEmpty(), is(true));

--- a/script/src/test/java/io/kestra/plugin/scripts/runner/docker/DockerTest.java
+++ b/script/src/test/java/io/kestra/plugin/scripts/runner/docker/DockerTest.java
@@ -23,7 +23,8 @@ import java.lang.reflect.Method;
 import java.time.Duration;
 import java.util.*;
 import java.util.concurrent.CopyOnWriteArrayList;
-
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import org.mockito.Mockito;
 
 import static io.kestra.core.utils.Rethrow.throwRunnable;
@@ -126,6 +127,7 @@ class DockerTest extends AbstractTaskRunnerTest {
         try (var client = DockerService.client(runContext, null, null, null, "rockylinux:9.3-minimal")) {
             Map<String, String> labels = ScriptService.labels(runContext, "kestra.io/");
 
+            var timeout = Duration.ofSeconds(30);
             // Wait for the container to be created
             Await.until(() -> {
                 List<Container> existingContainers = client.listContainersCmd()
@@ -133,7 +135,7 @@ class DockerTest extends AbstractTaskRunnerTest {
                     .withLabelFilter(labels)
                     .exec();
                 return !existingContainers.isEmpty() && existingContainers.get(0).getState().equals("running");
-            }, Duration.ofMillis(100), Duration.ofMillis(1000)); // Add timeout to avoid waiting forever for container to be created
+            }, Duration.ofMillis(100), timeout); // Add timeout to avoid waiting forever for container to be created
 
             callOnKill(taskRunner, () -> {
                 // override the kill method to not kill the container
@@ -156,16 +158,40 @@ class DockerTest extends AbstractTaskRunnerTest {
             Thread resumeContainerThread = new Thread(throwRunnable(() -> anotherTaskRunner.run(anotherRunContext, resumeCommands, Collections.emptyList())));
             resumeContainerThread.start();
 
-            // Add timeout to avoid waiting forever for logs
-            var timeout = Duration.ofSeconds(1);
-            receive.blockLast(timeout);
             // Wait for the log message indicating resume
             LogEntry awaitLog = TestsUtils
-                .awaitLog(logs, logEntry -> logEntry.getMessage().contains("Resuming existing container"));
+                .awaitLog(logs, logEntry -> logEntry.getMessage().contains("Resuming existing container:"));
+            LogEntry createContainerLog = TestsUtils
+                .awaitLog(logs, logEntry -> logEntry.getMessage().contains("Container created:"));
 
-            // Assert that the log message is present
+            receive.blockLast(timeout);
+            // Assert that the log messages are present
+            assertThat(createContainerLog).isNotNull().withFailMessage("create container log should not be null");
+            assertThat(createContainerLog.getMessage()).contains("Container created:");
             assertThat(awaitLog).isNotNull().withFailMessage("await log should not be null");
-            assertThat(awaitLog.getMessage()).contains("Resuming existing container");
+            assertThat(awaitLog.getMessage()).contains("Resuming existing container:");
+
+            // Get container id from the logs using regex
+
+            String createContainerId = null;
+            String resumeContainerId = null;
+            Matcher createContainerMatcher =
+                Pattern.compile("Container created: ([\\w]+)").matcher(createContainerLog.getMessage());
+            if (createContainerMatcher.find()) {
+                createContainerId = createContainerMatcher.group(1);
+            }
+
+            assertThat(createContainerId)
+                .withFailMessage("Could not extract container id from create container log: %s", createContainerLog.getMessage())
+                .isNotNull();
+            Matcher resumeContainerMatcher =
+                Pattern.compile("Resuming existing container: ([\\w]+)").matcher(awaitLog.getMessage());
+            if (resumeContainerMatcher.find()) {
+                resumeContainerId = resumeContainerMatcher.group(1);
+            }
+
+            // Assert that the container id is the same
+            assertThat(resumeContainerId).isEqualTo(createContainerId);
 
             // Kill the container and verify cleanup
             anotherTaskRunner.kill();

--- a/script/src/test/java/io/kestra/plugin/scripts/runner/docker/DockerTest.java
+++ b/script/src/test/java/io/kestra/plugin/scripts/runner/docker/DockerTest.java
@@ -141,13 +141,14 @@ class DockerTest extends AbstractTaskRunnerTest {
                 // override the kill method to not kill the container
             });
             initialContainerThread.interrupt();
+            initialContainerThread.join();
 
             // Create a new RunContext with the same taskRunId to maintain labels AND the same method to get a similar context
             RunContext anotherRunContext = runContext(this.runContextFactory, null, taskRunId);
 
             var anotherTaskRunner = ((Docker) taskRunner())
                 .toBuilder()
-                .delete(Property.ofValue(false))
+                .delete(Property.ofValue(true)) // Delete the container after the second run
                 .resume(Property.ofValue(true))
                 .build();
 
@@ -194,10 +195,11 @@ class DockerTest extends AbstractTaskRunnerTest {
             assertThat(resumeContainerId).isEqualTo(createContainerId);
 
             // Kill the container and verify cleanup
-            anotherTaskRunner.kill();
             resumeContainerThread.interrupt();
+            resumeContainerThread.join();
 
             List<Container> existingContainers = client.listContainersCmd()
+                .withShowAll(true)
                 .withLabelFilter(labels)
                 .exec();
             MatcherAssert.assertThat(existingContainers.isEmpty(), is(true));

--- a/script/src/test/java/io/kestra/plugin/scripts/runner/docker/DockerTest.java
+++ b/script/src/test/java/io/kestra/plugin/scripts/runner/docker/DockerTest.java
@@ -1,22 +1,40 @@
 package io.kestra.plugin.scripts.runner.docker;
 
+import com.github.dockerjava.api.model.Container;
+import io.kestra.core.models.executions.LogEntry;
 import io.kestra.core.models.property.Property;
 import io.kestra.core.models.tasks.runners.AbstractTaskRunnerTest;
+import io.kestra.core.models.tasks.runners.ScriptService;
 import io.kestra.core.models.tasks.runners.TaskRunner;
+import io.kestra.core.queues.QueueFactoryInterface;
+import io.kestra.core.queues.QueueInterface;
+import io.kestra.core.runners.RunContext;
+import io.kestra.core.utils.Await;
+import io.kestra.core.utils.TestsUtils;
 import io.kestra.plugin.scripts.exec.scripts.runners.CommandsWrapper;
+import jakarta.inject.Inject;
+import jakarta.inject.Named;
 import org.assertj.core.api.Assertions;
 import org.hamcrest.MatcherAssert;
 import org.junit.jupiter.api.Test;
-import java.util.Collections;
-import java.util.List;
-import java.util.concurrent.CompletableFuture;
+import reactor.core.publisher.Flux;
 
+import java.util.*;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+import org.mockito.Mockito;
+
+import static io.kestra.core.utils.Rethrow.throwRunnable;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
 
  
 
 class DockerTest extends AbstractTaskRunnerTest {
+    @Inject
+    @Named(QueueFactoryInterface.WORKERTASKLOG_NAMED)
+    QueueInterface<LogEntry> workerTaskLogQueue;
     @Override
     protected TaskRunner<?> taskRunner() {
         return Docker.builder().image("rockylinux:9.3-minimal").build();
@@ -67,116 +85,64 @@ class DockerTest extends AbstractTaskRunnerTest {
         MatcherAssert.assertThat((String) result.getLogConsumer().getOutputs().get("cpuLimit"), containsString("150000"));
         assertThat(result.getLogConsumer().getStdOutCount()).isEqualTo(1);
     }
-    
 
     @Test
-    void shouldResumeExistingContainer() throws Exception {
-        // resume = true
+    void killAfterResume() throws Exception {
         var runContext = runContext(this.runContextFactory);
+        var commands = initScriptCommands(runContext);
 
-        // first run: create a container and do not wait for it to finish immediately
-        var dockerCreate = Docker.builder()
-            .image("rockylinux:9.3-minimal")
-            .wait(Property.ofValue(false))
-            .resume(Property.ofValue(true))
-            .build();
+        var commandsList = ScriptService.scriptCommands(List.of("/bin/sh", "-c"), Collections.emptyList(), List.of("sleep 50"));
+        Mockito.when(commands.getCommands()).thenReturn(Property.ofValue(commandsList));
 
-        var createCommands = new CommandsWrapper(runContext).withCommands(Property.ofValue(List.of(
-            "/bin/sh", "-c",
-            "echo \"::{\\\"outputs\\\":{\\\"msg\\\":\\\"Token\\\"}}::\" && sleep 1"
-        )));
-
-        var first = dockerCreate.run(runContext, createCommands, Collections.emptyList());
-        var firstContainerId = first.getDetails().getContainerId();
-
-        // second run: resume and wait, reusing the same labels context (same runContext)
-        var dockerResume = Docker.builder()
-            .image("rockylinux:9.3-minimal")
-            .wait(Property.ofValue(true))
-            .resume(Property.ofValue(true))
-            .build();
-
-        var resumeCommands = new CommandsWrapper(runContext).withCommands(Property.ofValue(List.of(
-            "/bin/sh", "-c",
-            "echo \"::{\\\"outputs\\\":{\\\"msg\\\":\\\"Token\\\"}}::\" && sleep 1"
-        )));
-
-        var resumeResult = dockerResume.run(runContext, resumeCommands, Collections.emptyList());
-        var resumedContainerId = resumeResult.getDetails().getContainerId();
-
-        assertThat(resumeResult).isNotNull();
-        assertThat(resumeResult.getExitCode()).isZero();
-        assertThat(resumedContainerId).isEqualTo(firstContainerId);
-        assertThat(resumeResult.getLogConsumer().getStdOutCount()).isEqualTo(1);
-    }
-
-    @Test
-    void shouldCreateNewContainerIfNoneToResume() throws Exception {
-        var runContext = runContext(this.runContextFactory);
-
-        var docker = Docker.builder()
-            .image("rockylinux:9.3-minimal")
-            .resume(Property.ofValue(true))
-            .build();
-
-        var commands = new CommandsWrapper(runContext).withCommands(Property.ofValue(List.of(
-            "/bin/sh", "-c",
-            "echo \"::{\\\"outputs\\\":{\\\"msg\\\":\\\"NewContainer\\\"}}::\""
-        )));
-
-        var result = docker.run(runContext, commands, Collections.emptyList());
-
-        assertThat(result).isNotNull();
-        assertThat(result.getExitCode()).isZero();
-        String msg = (String) result.getLogConsumer().getOutputs().get("msg");
-        MatcherAssert.assertThat(msg, containsString("NewContainer"));
-        assertThat(result.getLogConsumer().getStdOutCount()).isEqualTo(1);
-    }
-
-    @Test
-    void shouldCreateTwoContainersWhenResumeDisabled() throws Exception {
-        // resume = false
-        var runContext = runContext(this.runContextFactory);
-
-        var dockerCreate = Docker.builder()
-            .image("rockylinux:9.3-minimal")
-            .wait(Property.ofValue(false))
-            .delete(Property.ofValue(false))
-            .build();
-
-        var commandProps = Property.ofValue(List.of(
-            "/bin/sh", "-c",
-            "echo 'Token' && sleep 1"
-        ));
-        var commands1 = new CommandsWrapper(runContext).withCommands(commandProps);
-        var commands2 = new CommandsWrapper(runContext).withCommands(commandProps);
-
-        var first = dockerCreate.run(runContext, commands1, Collections.emptyList());
-        var firstContainerId = first.getDetails().getContainerId();
-
-        var dockerSecond = Docker.builder()
-            .image("rockylinux:9.3-minimal")
-            .wait(Property.ofValue(false))
-            .delete(Property.ofValue(false))
-            .build();
-
-        var second = dockerSecond.run(runContext, commands2, Collections.emptyList());
-        var secondContainerId = second.getDetails().getContainerId();
-
-        assertThat(firstContainerId).isNotNull();
-        assertThat(secondContainerId).isNotNull();
-        assertThat(secondContainerId).isNotEqualTo(firstContainerId);
-
+        var taskRunner = ((Docker) taskRunner()).toBuilder().resume(Property.ofValue(true)).build();
+        Thread initialContainerThread = new Thread(throwRunnable(() -> taskRunner.run(runContext, commands, Collections.emptyList())));
+        initialContainerThread.start();
 
         try (var client = DockerService.client(runContext, null, null, null, "rockylinux:9.3-minimal")) {
-            // wait concurrently
-            var f1 = CompletableFuture.supplyAsync(() -> client.waitContainerCmd(firstContainerId).start().awaitStatusCode());
-            var f2 = CompletableFuture.supplyAsync(() -> client.waitContainerCmd(secondContainerId).start().awaitStatusCode());
+            Map<String, String> labels = ScriptService.labels(runContext, "kestra.io/");
+
+            // Wait for the container to be created
+            Await.until(() -> {
+                List<Container> existingContainers = client.listContainersCmd()
+                    .withShowAll(true)
+                    .withLabelFilter(labels)
+                    .exec();
+                return !existingContainers.isEmpty() && existingContainers.get(0).getState().equals("running");
+            });
+            initialContainerThread.interrupt();
+
+            // Create a new RunContext with the same taskrun variables to maintain labels
+            @SuppressWarnings("unchecked")
+            Map<String, Object> taskRunProps = new HashMap<>((Map<String, Object>) runContext.getVariables().get("taskrun"));
+            RunContext anotherRunContext = runContext(this.runContextFactory, Map.of("taskrun", taskRunProps));
+            var anotherTaskRunner = ((Docker) taskRunner()).toBuilder().resume(Property.ofValue(true)).build();
+
+            // Setup log queue consumer
+            List<LogEntry> logs = new CopyOnWriteArrayList<>();
+            Flux<LogEntry> receive = TestsUtils.receive(workerTaskLogQueue, (logEntry) -> {
+                logs.add(logEntry.getLeft());
+            });
+
+            // Start resume in a new thread
+            var resumeCommands = initScriptCommands(anotherRunContext);
+
+            Mockito.when(resumeCommands.getCommands()).thenReturn(Property.ofValue(commandsList));
+            Thread resumeContainerThread = new Thread(throwRunnable(() -> anotherTaskRunner.run(anotherRunContext, resumeCommands, Collections.emptyList())));
+            resumeContainerThread.start();
             
-            CompletableFuture.allOf(f1, f2).join();
-            assertThat(f1.get()).isZero();
-            assertThat(f2.get()).isZero();
+            // Wait for the log message indicating resume
+            TestsUtils.awaitLog(logs, logEntry -> logEntry.getMessage().contains("Resuming existing container"));
+            receive.blockLast();
+
+            // Kill the container and verify cleanup
+            anotherTaskRunner.kill();
+            resumeContainerThread.interrupt();
+
+            List<Container> existingContainers = client.listContainersCmd()
+                .withShowAll(true)
+                .withLabelFilter(labels)
+                .exec();
+            MatcherAssert.assertThat(existingContainers.isEmpty(), is(true));
         }
     }
-    
 }

--- a/script/src/test/java/io/kestra/plugin/scripts/runner/docker/DockerTest.java
+++ b/script/src/test/java/io/kestra/plugin/scripts/runner/docker/DockerTest.java
@@ -120,7 +120,11 @@ class DockerTest extends AbstractTaskRunnerTest {
         var taskRunner = ((Docker) taskRunner())
             .toBuilder()
             .delete(Property.ofValue(false))
-            .resume(Property.ofValue(true)).build();
+            .build();
+        // Assert that the resume property is set to true by default
+        Boolean resume =runContext.render(taskRunner.getResume()).as(Boolean.class).orElseThrow();
+        assertThat(resume).isEqualTo(Boolean.TRUE);
+
         Thread initialContainerThread = new Thread(throwRunnable(() -> taskRunner.run(runContext, commands, Collections.emptyList())));
         initialContainerThread.start();
 
@@ -149,7 +153,6 @@ class DockerTest extends AbstractTaskRunnerTest {
             var anotherTaskRunner = ((Docker) taskRunner())
                 .toBuilder()
                 .delete(Property.ofValue(true)) // Delete the container after the second run
-                .resume(Property.ofValue(true))
                 .build();
 
             // Start resume in a new thread

--- a/tests/src/main/java/io/kestra/core/models/tasks/runners/AbstractTaskRunnerTest.java
+++ b/tests/src/main/java/io/kestra/core/models/tasks/runners/AbstractTaskRunnerTest.java
@@ -211,6 +211,10 @@ public abstract class AbstractTaskRunnerTest {
     }
 
     protected RunContext runContext(RunContextFactory runContextFactory, Map<String, Object> additionalVars) {
+        return this.runContext(runContextFactory, additionalVars, IdUtils.create());
+    }
+
+    protected RunContext runContext(RunContextFactory runContextFactory, Map<String, Object> additionalVars, String taskRunId) {
         // create a fake flow and execution
         Task task = new Task() {
             @Override
@@ -223,7 +227,7 @@ public abstract class AbstractTaskRunnerTest {
                 return "Task";
             }
         };
-        TaskRun taskRun = TaskRun.builder().id(IdUtils.create()).taskId("task").flowId("flow").namespace("namespace").executionId("execution")
+        TaskRun taskRun = TaskRun.builder().id(taskRunId).taskId("task").flowId("flow").namespace("namespace").executionId("execution")
             .state(new State().withState(State.Type.RUNNING))
             .build();
         Flow flow = Flow.builder().id("flow").namespace("namespace").revision(1)


### PR DESCRIPTION
<!-- Thanks for submitting a Pull Request to Kestra. To help us review your contribution, please follow the guidelines below:

- Make sure that your commits follow the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) specification e.g. `feat(ui): add a new navigation menu item` or `fix(core): fix a bug in the core model` or `docs: update the README.md`. This will help us automatically generate the changelog.
- The title should briefly summarize the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share a flow example to help the reviewer understand and QA the change.
- Use "closes" to automatically close an issue. For example, `closes #1234` will close issue #1234. -->

### What changes are being made and why?
closes #4129

<!-- Please include a brief summary of the changes included in this PR e.g. closes #1234. -->

---

### How the changes have been QAed?

<!-- Include example code that shows how this PR has been QAed. The code should present a complete yet easily reproducible flow.

Note that this is not a replacement for unit tests but rather a way to demonstrate how the changes work in a real-life scenario, as the end-user would experience them.

Remove this section if this change applies to all flows or to the documentation only. -->

Steps to reproduce:

1. Open a terminal at the path of the docker-compose file
2. Execute docker compose up
3. In the Browser navigate to the kestra instance and create a new Flow with the content below
4. Execute the flow and observe its logs
5. If you see the message starting with Starting Job go to your terminal with the running kestra instance and press CTRL + c to shut it down.
6. Start Kestra again and observe the execution you triggered before shutting down

Alternative with devcontainers:
1. Run kestra with `./gradlew runLocal`
2. In the Browser navigate to the kestra instance and create a new Flow with the content below
3. Execute the flow and observe its logs
4. If you see the message starting with Starting Job go to your terminal, find the container started by devcontainer and do `docker kill <devcontainerid>`
5. Go back to your IDE, reload the window and start kestra again `./gradlew runLocal`
7. Observe the execution you triggered before shutting down


```yaml
id: selfupdate
namespace: dev
description: Update Kestra itself with docker-compose

labels:
  env: dev

tasks:
  - id: pull_images
    type: io.kestra.plugin.scripts.shell.Commands
    taskRunner:
      type: io.kestra.plugin.scripts.runner.docker.Docker
      resume: true
    commands:
      - export EXECUTION_DATE=$(date) # keep the date constant, so we can track if the first or the second start finished
      - echo Starting Job $EXECUTION_DATE
      - sleep 30
      - echo Finished Job $EXECUTION_DATE
```
