### PR TITLE
add checkboxes when enabling multi-selection mode

### DIFF
--- a/ui/src/components/inputs/EditorSidebar.vue
+++ b/ui/src/components/inputs/EditorSidebar.vue
@@ -108,6 +108,7 @@
             :load="loadNodes"
             :data="items"
             highlightCurrent
+            :showCheckbox="enableCheckboxes"
             :allowDrop="
                 (_, drop, dropType) => !drop.data?.leaf || dropType !== 'inner'
             "
@@ -116,6 +117,7 @@
             v-loading="items === undefined"
             :props="{class: nodeClass, isLeaf: 'leaf'}"
             class="mt-3"
+            @check="handleCheck"
             @node-drag-start="
                 nodeBeforeDrag = {
                     parent: $event.parent.data.id,
@@ -314,7 +316,22 @@
             width="500"
             @keydown.enter.prevent="removeItems()"
         >
-            <span class="py-3" v-html="confirmationLabels.message" />
+            <span class="py-3">
+                {{
+                    foldersCount > 0 && filesCount > 0
+                        ? $t("namespace files.dialog.mixed_deletion_description", {folders: foldersCount, files: filesCount})
+                        : foldersCount > 1
+                            ? $t("namespace files.dialog.folders_deletion_description", {count: foldersCount})
+                            : foldersCount === 1
+                                ? $t("namespace files.dialog.folder_deletion_description")
+                                : filesCount > 1
+                                    ? $t("namespace files.dialog.files_deletion_description", {count: filesCount})
+                                    : $t("namespace files.dialog.file_deletion_description")
+                }}
+
+
+            </span>
+
             <template #footer>
                 <div>
                     <el-button @click="confirmation.visible = false">
@@ -345,7 +362,7 @@
     </div>
 </template>
 
-<script>
+<script lang="ts">
     import {mapStores} from "pinia";
     import {useNamespacesStore} from "override/stores/namespaces";
     import {useEditorStore} from "../../stores/editor";
@@ -403,6 +420,7 @@
                 tree: {allExpanded: false},
                 currentFolder: undefined,
                 confirmation: {visible: false, data: {}},
+                enableCheckboxes: false,
                 items: undefined,
                 nodeBeforeDrag: undefined,
                 searchResults: [],
@@ -453,6 +471,12 @@
 
                 return labels;
             },
+            filesCount() {
+                return this.confirmation.nodes?.filter(n => n.type === "File").length ?? 0;
+            },
+            foldersCount() {
+                return this.confirmation.nodes?.filter(n => n.type === "Directory").length ?? 0;
+            },
         },
         methods: {
             nodeClass(data) {
@@ -461,6 +485,10 @@
                     return "node selected-tree-node";
                 }
                 return "node";
+            },
+            handleCheck(_node, {checkedNodes, checkedKeys}) {
+                this.selectedNodes = checkedKeys;
+                this.selectedFiles = checkedNodes.map(node => this.getPath(node.id));
             },
             pushToParentFolder(parentPath, newNode) {
                 const traverseAndInsert = (basePath = "", array) => {
@@ -482,6 +510,7 @@
 
                 traverseAndInsert("", this.items);
             },
+
             flattenTree(items, parentPath = "") {
                 const result = [];
 
@@ -504,32 +533,35 @@
                 const isCtrl = event && (event.ctrlKey || event.metaKey);
                 const isShift = event && event.shiftKey;
 
+                if (this.enableCheckboxes && data.leaf) {
+                    event.stopPropagation();
+                }
+
                 if (isShift && this.lastClickedIndex !== null) {
                     const start = Math.min(this.lastClickedIndex, currentIndex);
                     const end = Math.max(this.lastClickedIndex, currentIndex);
-
                     this.selectedFiles = flatList.slice(start, end + 1).map(item => item.path);
                     this.selectedNodes = flatList.slice(start, end + 1).map(item => item.id);
-
                 } else if (isCtrl) {
                     const isSelected = this.selectedNodes.includes(node.data.id);
-
                     if (isSelected) {
-                        // Remove from selection - force reactivity with new arrays
                         this.selectedFiles = [...this.selectedFiles.filter(file => file !== path)];
                         this.selectedNodes = [...this.selectedNodes.filter(id => id !== node.data.id)];
                     } else {
-                        // Add to selection
                         this.selectedFiles = [...this.selectedFiles, path];
                         this.selectedNodes = [...this.selectedNodes, node.data.id];
+                        if (this.enableCheckboxes) {
+                            this.$nextTick(() => {
+                                this.$refs.tree?.setCheckedKeys(this.selectedNodes);
+                            });
+                        }
                     }
                     this.lastClickedIndex = currentIndex;
-
                 } else {
-                    // Handle single-click selection
                     this.selectedFiles = [path];
                     this.selectedNodes = [node.data.id];
                     this.lastClickedIndex = currentIndex;
+
                     if (data.leaf) {
                         this.editorStore.openTab({
                             name: data.fileName,
@@ -540,12 +572,43 @@
                     }
                 }
             },
+            handleShiftDown(event) {
+                if (event.key === "Shift" && !event.repeat) {
+                    if (this.enableCheckboxes) {
+                        this.enableCheckboxes = false;
+                        this.$nextTick(() => {
+                            this.$refs.tree?.setCheckedKeys([]);
+                        });
+                    } else {
+                        this.enableCheckboxes = true;
+                        if (this.selectedNodes.length > 0) {
+                            this.$nextTick(() => {
+                                this.$refs.tree?.setCheckedKeys(this.selectedNodes);
+                            });
+                        }
+                    }
+                }
+            },
+
 
             async removeSelectedFiles() {
-                const nodes = this.selectedFiles.map((filePath) => {
-                    const node = this.findNodeByPath(filePath);
-                    return node;
-                });
+                let nodes = [];
+
+                if (this.enableCheckboxes) {
+                    const checkedNodes = this.$refs.tree.getCheckedNodes();
+
+                    this.selectedFiles = checkedNodes.map(node => this.getPath(node.id));
+                    this.selectedNodes = checkedNodes.map(node => node.id);
+
+                    nodes = checkedNodes;
+                } else {
+                    nodes = this.selectedFiles.map(filePath => this.findNodeByPath(filePath));
+                }
+
+                if (!nodes || nodes.length === 0) {
+                    this.$toast().warning(this.$t("namespace files.no_selection"));
+                    return;
+                }
 
                 this.confirmRemove(nodes);
             },
@@ -1150,9 +1213,13 @@
         },
         mounted() {
             document.addEventListener("click", this.clearSelection);
+            document.addEventListener("keydown", this.handleShiftDown);
+            document.addEventListener("keyup", this.handleShiftUp);
         },
         beforeUnmount() {
             document.removeEventListener("click", this.clearSelection);
+            document.removeEventListener("keydown", this.handleShiftDown);
+            document.removeEventListener("keyup", this.handleShiftUp);
         },
         watch: {
             "flowStore.flow": {
@@ -1169,6 +1236,7 @@
                 immediate: true,
                 deep: true,
             },
+            
             "editorStore.treeRefresh": {
                 async handler() {
                     if (this.$refs.tree) {

--- a/ui/src/components/namespaces/components/NamespaceFilesEditorView.vue
+++ b/ui/src/components/namespaces/components/NamespaceFilesEditorView.vue
@@ -1132,7 +1132,7 @@ ul.tabs-context {
 }
 </style>
 
-<style lang="scss">
+<style lang="scss" scoped>
     .tabs .el-scrollbar__bar.is-horizontal {
         height: 1px !important;
     }

--- a/ui/src/translations/en.json
+++ b/ui/src/translations/en.json
@@ -709,12 +709,14 @@
           "folder": "Folder name:"
         },
         "parent_folder": "Parent folder:",
+        "file_deletion_description": "Are you sure you want to delete the selected file?",
+        "files_deletion_description": "Are you sure you want to delete {count} files?",
+        "folder_deletion_description": "Are you sure you want to delete this folder and all of its contents?",
+        "folders_deletion_description": "Are you sure you want to delete {count} folders and all of its contents?",
+        "mixed_deletion_description": "Are you sure you want to delete {folders} folders and {files} files?",
+        "confirm": "Confirm",
         "deletion": {
-          "confirm": "Confirm",
-          "title": "Confirm deletion of content",
-          "files": "Are you sure you want to delete <code>{count}</code> file(s)?",
-          "folders": "Are you sure you want to delete <code>{count}</code> folder(s) and all of its contents?",
-          "mixed": "Are you sure you want to delete <code>{folders}</code> folder(s) and <code>{files}</code> file(s)?"
+          "confirm": "Confirm"
         }
       },
       "path": {
@@ -1420,7 +1422,8 @@
         "id readonly": "The property `id` cannot be changed — it's now set to its initial values. If you want to change it, you can create a new dashboard and remove the old one."
       },
       "deletion": {
-        "confirmation": "Are you sure you want to delete <code>{title}</code> dashboard?"
+        "confirmation": "Are you sure you want to delete <code>{title}</code> dashboard?",
+        "confirm": "Confirm"
       },
       "chart_preview": "Click on a chart source code to see its preview",
       "export": "Export to CSV"


### PR DESCRIPTION
Closes #8423 

This PR introduces the multi-selection feature using checkboxes.

How to Use:
Click Shift once (no need to hold it) to enable selection mode, the checkboxes will appear.
You can now select multiple files to perform batch actions, such as deleting them.
Click Shift again to disable selection mode.

UPGRADES!!!
Now the checkbox can only be checked by clicking inside the box, not on the item.
The first click opens the folder that is closed.

PS: I’d like to apologize for getting confused with my PRs. Many thanks to MilosPaunovic for following my case and for all the support during this little battle with GitHub XD. Lesson learned, I’ll always keep the original fork from now on. Thank you so much for your understanding and for being such an amazing professional.

https://github.com/user-attachments/assets/c44a95e8-07a1-4166-8f56-1817d76515e3


