### PR TITLE
fix(ui): Make global notifications scrollable

### DIFF
--- a/ui/src/styles/layout/element-plus-overload.scss
+++ b/ui/src/styles/layout/element-plus-overload.scss
@@ -1010,7 +1010,7 @@ form.ks-horizontal {
 
     .el-notification__content {
         text-align: left;
-        max-height: 250px;
+        max-height: 200px;
         overflow-y: auto;
     }
 

--- a/ui/src/styles/layout/element-plus-overload.scss
+++ b/ui/src/styles/layout/element-plus-overload.scss
@@ -1010,6 +1010,8 @@ form.ks-horizontal {
 
     .el-notification__content {
         text-align: left;
+        max-height: 250px;
+        overflow-y: auto;
     }
 
     &.large {


### PR DESCRIPTION
This PR fixes an issue where notifications with a large amount of content would overflow the screen instead of becoming scrollable.

I've applied a global CSS rule to the notification component to enforce a `max-height` and add `overflow-y: auto`. This ensures that all notifications are now properly constrained and their content remains accessible.

Closes #11924 

### Screenshots

**Before (Overflowing Notification)**

<img width="1918" height="1083" alt="Screenshot from 2025-10-14 02-01-42" src="https://github.com/user-attachments/assets/a84eb950-7e11-40a3-8111-e57faf489734" />

**After (Scrollable Notification)**

<img width="1918" height="1083" alt="Screenshot from 2025-10-14 01-59-06" src="https://github.com/user-attachments/assets/89454455-210d-4b08-9548-ecc740147d7e" />
