### PR TITLE
feat: add ts and js workers to monaco editor

### DIFF
--- a/ui/src/components/inputs/MonacoEditor.vue
+++ b/ui/src/components/inputs/MonacoEditor.vue
@@ -179,7 +179,7 @@
     };
 
     // avoid using browser libs in ts worker added by default
-    monaco.languages.typescript.typescriptDefaults.setCompilerOptions({
+    monaco.languages.typescript?.typescriptDefaults.setCompilerOptions({
         target: monaco.languages.typescript.ScriptTarget.ES2020,
         lib: ["es2020"], // Exclude 'dom' to remove browser types
         allowNonTsExtensions: true
@@ -715,7 +715,7 @@
 
                         modifiedBackspaceTimeout = window.setTimeout(() => {
                             modifiedEditor.trigger("keyboard", "editor.action.triggerSuggest", {});
-                        }, 250); 
+                        }, 250);
                     }
                 });
             }
@@ -754,7 +754,7 @@
                     fixedOverflowWidgets: true // Helps suggestion widget render above other elements
                 });
                 let localBackspaceTimeout: number | null = null;
-                
+
                 localEditor.value.onKeyDown((e) => {
                     if (e.keyCode === monaco.KeyCode.Backspace) {
                         if (localBackspaceTimeout) clearTimeout(localBackspaceTimeout);

--- a/ui/src/components/inputs/MonacoEditor.vue
+++ b/ui/src/components/inputs/MonacoEditor.vue
@@ -50,6 +50,7 @@
     import {editor} from "monaco-editor/esm/vs/editor/editor.api";
     import EditorWorker from "monaco-editor/esm/vs/editor/editor.worker?worker";
     import JsonWorker from "monaco-editor/esm/vs/language/json/json.worker?worker";
+    import TypeScriptWorker from "monaco-editor/esm/vs/language/typescript/ts.worker?worker";
     import configureLanguage from "../../composables/monaco/languages/languagesConfigurator";
 
     import {EDITOR_HIGHLIGHT_INJECTION_KEY, EDITOR_WRAPPER_INJECTION_KEY} from "../no-code/injectionKeys";
@@ -83,6 +84,9 @@
                 return new YamlWorker();
             case "json":
                 return new JsonWorker();
+            case "javascript":
+            case "typescript":
+                return new TypeScriptWorker();
             default:
                 throw new Error(`Unknown label ${label}`);
             }
@@ -173,6 +177,13 @@
             }
         }
     };
+
+    // avoid using browser libs in ts worker added by default
+    monaco.languages.typescript.typescriptDefaults.setCompilerOptions({
+        target: monaco.languages.typescript.ScriptTarget.ES2020,
+        lib: ["es2020"], // Exclude 'dom' to remove browser types
+        allowNonTsExtensions: true
+    });
 
     export type EditorOptions = monaco.editor.IStandaloneEditorConstructionOptions & { renderSideBySide?: boolean };
     const props = withDefaults(defineProps<{


### PR DESCRIPTION
When opening a JS or TS namespace file, we get some weird errors about an unknown label. 
That is becuase those workers are not registered.