### PR TITLE
fix(secrets-page): adjust top margin for empty secrets block

### DIFF
--- a/ui/src/components/secrets/Secrets.vue
+++ b/ui/src/components/secrets/Secrets.vue
@@ -15,7 +15,7 @@
         :class="miscStore.configs?.secretsEnabled === undefined ? 'mt-0 p-0' : 'container'"
     >
         <EmptyTemplate v-if="miscStore.configs?.secretsEnabled === undefined" class="d-flex flex-column text-start m-0 p-0 mw-100">
-            <div class="no-secret-manager-block d-flex flex-column gap-6">
+            <div class="no-secret-manager-block d-flex flex-column gap-6 mt-3">
                 <div class="header-block d-flex align-items-center">
                     <div class="d-flex flex-column">
                         <div class="d-flex flex-row gap-2">


### PR DESCRIPTION
This PR fixes an issue where the secrets page of kestra at landing state have margin issue , which leads to the content starting just after navbar.

## Screenshots
### Before

<img width="1033" height="428" alt="image" src="https://github.com/user-attachments/assets/e0e4cc2a-d845-46a9-98ce-0d8ccdef5a2c" />

### After

<img width="1033" height="428" alt="image" src="https://github.com/user-attachments/assets/c322c406-6fcd-4248-8421-aed5f9b93906" />
