### PR TITLE
Alert blocks don't render in the plugin documentation in the UI

### DIFF
--- a/ui/src/components/secrets/Secrets.vue
+++ b/ui/src/components/secrets/Secrets.vue
@@ -15,7 +15,7 @@
         :class="miscStore.configs?.secretsEnabled === undefined ? 'mt-0 p-0' : 'container'"
     >
         <EmptyTemplate v-if="miscStore.configs?.secretsEnabled === undefined" class="d-flex flex-column text-start m-0 p-0 mw-100">
-            <div class="no-secret-manager-block d-flex flex-column gap-6">
+            <div class="no-secret-manager-block d-flex flex-column gap-6 mt-3">
                 <div class="header-block d-flex align-items-center">
                     <div class="d-flex flex-column">
                         <div class="d-flex flex-row gap-2">

--- a/ui/src/utils/markdown.ts
+++ b/ui/src/utils/markdown.ts
@@ -28,6 +28,13 @@ interface RenderOptions {
 }
 
 export async function render(markdown: string, options: RenderOptions = {}) {
+    // Convert ::alert{type="..."} ... :: to ::: type ... :::
+    const markdownWithAlerts = typeof markdown === "string"
+        ? markdown.replace(
+            /(\n)?:\s*:\s*alert\{type="(.*?)"\}\s*\n([\s\S]*?)\n:\s*:(\n)?/g,
+            (_: string, newLine1: string, type: string, content: string, newLine2: string) => `${newLine1 ?? ""}::: ${type}\n${content}\n:::${newLine2 ?? ""}`
+        )
+        : markdown;
     const {createHighlighterCore, githubDark, githubLight, markdownIt, mark, meta, mila, anchor, container, fromHighlighter, linkTag, langs, onigurumaEngine} = await import( "./markdownDeps")
     const highlighter = await getHighlighter(createHighlighterCore as any, Object.values(langs), onigurumaEngine, githubDark, githubLight);
 
@@ -73,7 +80,7 @@ export async function render(markdown: string, options: RenderOptions = {}) {
         md.renderer.rules.table_open = () => "<table class=\"table\">\n";
     }
 
-    return md.render(markdown);
+    return md.render(markdownWithAlerts);
 }
 
 function applyEnhancedRenderers(md: any) {


### PR DESCRIPTION
Closes https://github.com/kestra-io/kestra/issues/12019.

This pr fixes an issue in which alert block not get rendere no matter type is warning, info etc

## ScreenShots
### Before

<img width="1033" height="428" alt="alert_unfixed_1" src="https://github.com/user-attachments/assets/d34ab2dc-ea6a-4564-8e6d-6d869038d54a" />
<img width="1033" height="428" alt="alert_unverified_2" src="https://github.com/user-attachments/assets/f6f3c6a8-2dd1-47c7-a121-8b2258932dfd" />

### After
<img width="1033" height="428" alt="image" src="https://github.com/user-attachments/assets/fdd263af-0ed4-4cbd-bd2e-6d02646b9a4a" />
<img width="1033" height="428" alt="image" src="https://github.com/user-attachments/assets/1fb2359d-4e41-480c-81de-e716a3a8bf48" />

## What was the issue?
- The UI was not converting our `::alert{type="..."} ... ::` syntax into the format the markdown renderer understands `(::: info|warning ... :::)`.</br >
- Some pages use `EnhancedMarkdown.vue`, which didn’t do this conversion, so alerts never showed up regardless of type.</br >
- The fix moves the conversion into the shared markdown renderer, so both Markdown and EnhancedMarkdown paths render alert blocks correctly.</br >

