### PR TITLE
fix(security): do not load OSS BasicAuthService in EE

### DIFF
--- a/webserver/src/main/java/io/kestra/webserver/services/BasicAuthService.java
+++ b/webserver/src/main/java/io/kestra/webserver/services/BasicAuthService.java
@@ -29,6 +29,7 @@ import java.util.regex.Pattern;
 @Context
 @Singleton
 @Requires(property = "kestra.server-type", pattern = "(WEBSERVER|STANDALONE)")
+@Requires(property = "micronaut.security.enabled", notEquals = "true") // don't load this in EE
 public class BasicAuthService {
     public static final String BASIC_AUTH_SETTINGS_KEY = "kestra.server.basic-auth";
     public static final String BASIC_AUTH_ERROR_CONFIG = "kestra.server.authentication-configuration-error";


### PR DESCRIPTION
BasicAuthService was loaded by mistake in EE, and it was changed recently in OSS to persist different data