### PR TITLE
fix(flows): improved save logic, updated the dirty flag to target actual current flow tab.

### DIFF
--- a/ui/src/stores/flow.ts
+++ b/ui/src/stores/flow.ts
@@ -465,8 +465,16 @@ export const useFlowStore = defineStore("flow", () => {
                     return Promise.reject(new Error("Server error on flow save"))
                 } else {
                     flow.value = response.data;
-                    useEditorStore().setTabDirty({
-                        name: "Flow",
+
+                    const editorStore = useEditorStore();
+                    const currentTab = editorStore.current;
+                    
+                    // The dirty flag for the flow tab was cleared using a hardcoded name,
+                    // which failed if the tab's actual name and path was different.
+                    // update the dirty flag clearing logic to target the actual current flow tab (using its real name and path), ensuring the Save button disables after a successful save.
+                    editorStore.setTabDirty({
+                        name: currentTab?.name ?? "Flow",
+                        path: currentTab?.path ?? "Flow.yaml",
                         dirty: false,
                     });
 


### PR DESCRIPTION
**Closes #11982. Fixes the issue where the save button appears even when the file is already saved.**

**Before:**
<video src="https://github-production-user-asset-6210df.s3.amazonaws.com/108854849/501638848-0c2c9b26-9e24-4308-8999-0fa905c6e349.webm?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAVCODYLSA53PQK4ZA%2F20251015%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20251015T173144Z&X-Amz-Expires=300&X-Amz-Signature=1953a3928d4a42388ae54c5cd8c31cf2b72350cbd7abb45a2a9f6050033a374a&X-Amz-SignedHeaders=host" controls width="500"></video>

**After:**
<video src="https://github.com/user-attachments/assets/34358b1b-c735-4b84-a45c-1de088bcae58" controls width="500"></video>


