### PR TITLE
fix(core): prevent follow endpoint from sending events for invalid executionId

### DIFF
--- a/webserver/src/main/java/io/kestra/webserver/controllers/api/ExecutionController.java
+++ b/webserver/src/main/java/io/kestra/webserver/controllers/api/ExecutionController.java
@@ -121,7 +121,7 @@ public class ExecutionController {
     @Nullable
     @Value("${micronaut.server.context-path}")
     protected String basePath;
-    
+
     @Inject
     private FlowRepositoryInterface flowRepository;
 
@@ -168,7 +168,7 @@ public class ExecutionController {
 
     @Inject
     private ApplicationEventPublisher<CrudEvent<Execution>> eventPublisher;
-    
+
     @Inject
     private RunContextFactory runContextFactory;
 
@@ -1816,8 +1816,6 @@ public class ExecutionController {
     ) {
         String subscriberId = UUID.randomUUID().toString();
         return Flux.<Event<Execution>>create(emitter -> {
-                // Send initial event
-                emitter.next(Event.of(Execution.builder().id(executionId).build()).id("start"));
 
                 // Check if execution exists
                 try {
@@ -1826,6 +1824,9 @@ public class ExecutionController {
                         Duration.ofMillis(500),
                         Duration.ofSeconds(10)
                     );
+
+                    // Send initial event only if executionId exists
+                    emitter.next(Event.of(Execution.builder().id(executionId).build()).id("start"));
 
                     Flow flow = flowRepository.findByExecutionWithoutAcl(execution);
 


### PR DESCRIPTION
This PR ensures that the /follow SSE endpoint sends the **start event only when the execution id exists**, and returns an appropriate error otherwise.
This prevents invalid execution IDs from triggering partial or hanging responses.

closes kestra-io/kestra-ee#5461

**What changes are being made and why?**

The followExecution endpoint was sending a **start event even when the provided executionId did not exist**, which caused confusing behaviour:

	•	Browser kept loading with no visible error
	•	Curl showed partial data and then terminated with

`curl: (18) transfer closed with outstanding read data remaining`


This happened because the start event was emitted **before** checking if the execution actually existed.
The change moves the start event emission **after** the existence check to ensure a proper error response when the execution is invalid.

⸻

**How the changes have been QAed?**

**Before (Invalid Execution ID):**

```
curl -N -u <USERNAME>:<PASSWORD> http://localhost:8080/api/v1/main/executions/InvalidExecutionId/follow
id: start
data: {"id":"InvalidExecutionId","labels":[],"originalId":"InvalidExecutionId", ...}
curl: (18) transfer closed with outstanding read data remaining

```
**After (Invalid Execution ID):**

```
curl -N -u <USERNAME>:<PASSWORD> http://localhost:8080/api/v1/main/executions/InvalidExecutionId/follow
Unable to find execution InvalidExecutionId

```
**Valid Execution ID (unchanged):**

```
curl -N -u <USERNAME>:<PASSWORD> http://localhost:8080/api/v1/main/executions/<valid-id>/follow
id: start
data: {...}
id: end
data: {...}

```
Now, invalid execution IDs return proper error messages, and SSE behaviour remains consistent for valid executions.
