### PR TITLE
Add responsive auto-collapse behavior to sidebar with floating reopen button

### DIFF
--- a/ui/src/components/layout/SideBar.vue
+++ b/ui/src/components/layout/SideBar.vue
@@ -1,5 +1,9 @@
 <template>
+    <!-- Mobile opener moved to TopNavBar -->
+
+    <!-- Desktop / large screens: regular fixed sidebar -->
     <SidebarMenu
+        v-if="!isSmallScreen"
         ref="sideBarRef"
         id="side-menu"
         :menu
@@ -8,6 +12,8 @@
         :collapsed="collapsed"
         linkComponentName="LeftMenuLink"
         hideToggle
+        role="navigation"
+        :aria-hidden="false"
     >
         <template #header>
             <SidebarToggleButton
@@ -25,18 +31,48 @@
             <slot name="footer" />
         </template>
     </SidebarMenu>
-    <el-button
-        v-if="isSmallScreen && collapsed"
-        class="reopenSidebarBtn"
-        circle
-        @click="onToggleCollapse(false)"
-        aria-label="Open sidebar"
-        title="Open sidebar"
+
+    <!-- Mobile slide-in sidebar + overlay -->
+    <div
+        v-if="isSmallScreen"
+        class="sidebar-overlay"
+        :class="{open: isMobileSidebarOpen}"
+        @click="isMobileSidebarOpen = false"
+        aria-hidden="true"
+    />
+    <nav
+        v-if="isSmallScreen"
+        class="mobile-sidebar"
+        :class="{open: isMobileSidebarOpen}"
+        role="navigation"
+        :aria-hidden="!isMobileSidebarOpen"
     >
-        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-            <path d="M8 5L15 12L8 19" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
-        </svg>
-    </el-button>
+        <div class="mobile-sidebar__header">
+            <button class="icon-btn close-left" aria-label="Close menu" @click="isMobileSidebarOpen = false">
+                <CloseIcon />
+            </button>
+            <div class="logo">
+                <component :is="props.showLink ? 'router-link' : 'div'" :to="{name: 'home'}">
+                    <span class="img" />
+                </component>
+            </div>
+        </div>
+        <div class="mobile-sidebar__body">
+            <SidebarMenu
+                ref="sideBarRef"
+                id="side-menu"
+                :menu
+                width="268px"
+                :collapsed="false"
+                linkComponentName="LeftMenuLink"
+                hideToggle
+            >
+                <template #footer>
+                    <slot name="footer" />
+                </template>
+            </SidebarMenu>
+        </div>
+    </nav>
 </template>
 
 <script setup lang="ts">
@@ -45,7 +81,7 @@
         onMounted,
         onBeforeUnmount,
         ref,
-        computed, h
+        computed, h, watch
     } from "vue";
     import {useI18n} from "vue-i18n";
     import {useRoute} from "vue-router";
@@ -60,6 +96,7 @@
     import type {MenuItem} from "override/components/useLeftMenu";
     import {useLayoutStore} from "../../stores/layout";
     import SidebarToggleButton from "./SidebarToggleButton.vue";
+    import CloseIcon from "vue-material-design-icons/Close.vue";
 
 
     const props = withDefaults(defineProps<{
@@ -78,6 +115,7 @@
 
     const BREAKPOINT = 992; // px
     const isSmallScreen = ref(false);
+    const isMobileSidebarOpen = ref(false);
 
     function onToggleCollapse(folded: boolean) {
         collapsed.value = folded;
@@ -89,18 +127,10 @@
 
     function evaluateScreenSize() {
         const small = window.innerWidth < BREAKPOINT;
-        // If entering small screen, force collapse
-        if (small && !collapsed.value) {
-            onToggleCollapse(true);
-        }
-        // If leaving small screen, restore from stored preference
-        if (!small) {
-            const stored = localStorage.getItem("menuCollapsed") === "true";
-            if (stored !== collapsed.value) {
-                onToggleCollapse(stored);
-            }
-        }
         isSmallScreen.value = small;
+        if (!small) {
+            isMobileSidebarOpen.value = false;
+        }
     }
 
     onMounted(() => {
@@ -110,6 +140,16 @@
 
     onBeforeUnmount(() => {
         window.removeEventListener("resize", evaluateScreenSize);
+    });
+
+    // Keep collapsed state in sync with mobile sidebar visibility
+    watch(isMobileSidebarOpen, (open) => {
+        if (isSmallScreen.value) onToggleCollapse(!open);
+    });
+
+    // React to external layoutStore changes
+    watch(() => layoutStore.sideMenuCollapsed, (val) => {
+        if (isSmallScreen.value) isMobileSidebarOpen.value = !val;
     });
 
     function disabledCurrentRoute(items: MenuItem[]) {
@@ -222,17 +262,99 @@
     }
 }
 
-.reopenSidebarBtn {
-    position: fixed;
-    left: 8px;
-    top: 72px;
-    z-index: 2000;
-    background: var(--ks-surface-primary);
-    color: var(--ks-text-secondary);
-    border: 1px solid var(--ks-border-primary);
+/* Mobile slide-in */
+.mobile-sidebar {
+  position: fixed;
+  top: 0;
+  left: 0;
+  height: 100%;
+  width: 268px;
+  background-color: var(--ks-background-left-menu);
+  box-shadow: 2px 0 10px rgba(0,0,0,0.3);
+  transform: translateX(-100%);
+  transition: transform 0.3s ease-in-out;
+  z-index: 2000;
 
-    &:hover {
-        color: var(--ks-content-link);
-    }
+  &.open { transform: translateX(0); }
 }
+
+.mobile-sidebar__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 10px 12px;
+  border-bottom: 1px solid var(--ks-border-primary);
+}
+
+.mobile-sidebar__body {
+  height: calc(100% - 56px);
+  overflow: auto;
+}
+
+.icon-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 6px;
+  border-radius: 8px;
+  background: rgba(0,0,0,0.08);
+  border: 1px solid var(--ks-border-primary);
+  color: var(--ks-text-secondary);
+}
+
+.close-left { margin-right: 8px; }
+
+.sidebar-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.5);
+  z-index: 1999;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.3s ease-in-out;
+
+  &.open {
+    opacity: 1;
+    pointer-events: all;
+  }
+}
+
+/* Sidebar menu item styling */
+#side-menu :deep(.vsm--item) {
+    margin: 4px 8px;
+}
+
+#side-menu :deep(.vsm--link) {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 8px 10px;
+    border-radius: 10px;
+}
+
+#side-menu :deep(.vsm--link:hover) {
+    background: var(--ks-background-card);
+}
+
+/* Remove gray icon background and size icons similar to text */
+#side-menu :deep(.vsm--icon) {
+    background: transparent !important;
+    width: auto;
+    height: auto;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+}
+
+#side-menu :deep(.vsm--icon > svg),
+#side-menu :deep(.vsm--icon > span > svg) {
+    width: 18px;
+    height: 18px;
+}
+
+
+/* opener moved to TopNavBar */
 </style>

--- a/ui/src/components/layout/SideBar.vue
+++ b/ui/src/components/layout/SideBar.vue
@@ -25,11 +25,25 @@
             <slot name="footer" />
         </template>
     </SidebarMenu>
+    <el-button
+        v-if="isSmallScreen && collapsed"
+        class="reopenSidebarBtn"
+        circle
+        @click="onToggleCollapse(false)"
+        aria-label="Open sidebar"
+        title="Open sidebar"
+    >
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <path d="M8 5L15 12L8 19" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
+        </svg>
+    </el-button>
 </template>
 
 <script setup lang="ts">
     import {
         onUpdated,
+        onMounted,
+        onBeforeUnmount,
         ref,
         computed, h
     } from "vue";
@@ -62,6 +76,9 @@
 
     const layoutStore = useLayoutStore();
 
+    const BREAKPOINT = 992; // px
+    const isSmallScreen = ref(false);
+
     function onToggleCollapse(folded: boolean) {
         collapsed.value = folded;
         layoutStore.setSideMenuCollapsed(folded);
@@ -69,6 +86,31 @@
 
         return folded;
     }
+
+    function evaluateScreenSize() {
+        const small = window.innerWidth < BREAKPOINT;
+        // If entering small screen, force collapse
+        if (small && !collapsed.value) {
+            onToggleCollapse(true);
+        }
+        // If leaving small screen, restore from stored preference
+        if (!small) {
+            const stored = localStorage.getItem("menuCollapsed") === "true";
+            if (stored !== collapsed.value) {
+                onToggleCollapse(stored);
+            }
+        }
+        isSmallScreen.value = small;
+    }
+
+    onMounted(() => {
+        evaluateScreenSize();
+        window.addEventListener("resize", evaluateScreenSize);
+    });
+
+    onBeforeUnmount(() => {
+        window.removeEventListener("resize", evaluateScreenSize);
+    });
 
     function disabledCurrentRoute(items: MenuItem[]) {
         return items
@@ -177,6 +219,20 @@
                 }
             }
         }
+    }
+}
+
+.reopenSidebarBtn {
+    position: fixed;
+    left: 8px;
+    top: 72px;
+    z-index: 2000;
+    background: var(--ks-surface-primary);
+    color: var(--ks-text-secondary);
+    border: 1px solid var(--ks-border-primary);
+
+    &:hover {
+        color: var(--ks-content-link);
     }
 }
 </style>

--- a/ui/src/components/layout/TopNavBar.vue
+++ b/ui/src/components/layout/TopNavBar.vue
@@ -4,6 +4,7 @@
             <div class="d-flex align-items-end gap-2">
                 <SidebarToggleButton
                     v-if="layoutStore.sideMenuCollapsed"
+                    class="d-none d-lg-inline-flex"
                     @toggle="layoutStore.setSideMenuCollapsed(false)"
                 />
                 <!-- Mobile hamburger button -->

--- a/ui/src/components/layout/TopNavBar.vue
+++ b/ui/src/components/layout/TopNavBar.vue
@@ -6,6 +6,14 @@
                     v-if="layoutStore.sideMenuCollapsed"
                     @toggle="layoutStore.setSideMenuCollapsed(false)"
                 />
+                <!-- Mobile hamburger button -->
+                <button
+                    class="icon-btn d-lg-none"
+                    aria-label="Open menu"
+                    @click="layoutStore.setSideMenuCollapsed(false)"
+                >
+                    <MenuIcon />
+                </button>
                 <div class="d-flex flex-column gap-2">
                     <el-breadcrumb v-if="breadcrumb">
                         <el-breadcrumb-item v-for="(item, x) in breadcrumb" :key="x" :class="{'pe-none': item.disabled}">
@@ -64,6 +72,7 @@
     import StarOutlineIcon from "vue-material-design-icons/StarOutline.vue";
     import StarIcon from "vue-material-design-icons/Star.vue";
     import Information from "vue-material-design-icons/Information.vue";
+    import MenuIcon from "vue-material-design-icons/Menu.vue";
     import Badge from "../global/Badge.vue";
     import {useLogsStore} from "../../stores/logs";
     import {useBookmarksStore} from "../../stores/bookmarks";
@@ -204,6 +213,16 @@
                 gap: .5rem;
                 align-items: center;
             }
+        }
+        .icon-btn {
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            padding: 6px;
+            border-radius: 8px;
+            background: rgba(0,0,0,0.08);
+            border: 1px solid var(--ks-border-primary);
+            color: var(--ks-text-secondary);
         }
         @media (max-width: 768px) {
             .mycontainer {

--- a/ui/src/override/components/layout/DefaultLayout.vue
+++ b/ui/src/override/components/layout/DefaultLayout.vue
@@ -1,5 +1,5 @@
 <template>
-    <LeftMenu v-if="miscStore.configs && !layoutStore.sideMenuCollapsed" @menu-collapse="onMenuCollapse" />
+    <LeftMenu v-if="miscStore.configs" @menu-collapse="onMenuCollapse" />
     <main>
         <Errors v-if="coreStore.error" :code="coreStore.error" />
         <slot v-else />


### PR DESCRIPTION
Closes https://github.com/kestra-io/kestra/issues/1425:

# **Summary**

This PR enhances the sidebar experience by making it responsive and user-friendly on smaller screens.

**Changes**

* **DefaultLayout.vue**

    * Always renders ```LeftMenu``` to ensure sidebar remains mounted.

* **SideBar.vue**

    * Automatically collapses when window width **< 992px.**

    * Restores the user’s previous collapse preference when width **≥ 992px.**

    * Adds a `resize` listener with proper cleanup.

    * Keeps `layoutStore` and `localStorage` states in sync.

    * Introduces a subtle floating **“reopen” button** visible only on small screens when the sidebar is collapsed.

**Behavior**

* On **narrow screens,** the sidebar collapses automatically; a floating button appears to reopen it.

* On **wider screens,** the sidebar respects the user’s last collapse/expand preference.

* All changes hot-reload seamlessly via Vite.

Notes

If a different breakpoint or button placement/style is preferred, please share the target width or design details, the implementation can be easily adjusted.