### PR TITLE
Refactor: Convert FlowCreate.vue to TypeScript and Composition API

### DIFF
--- a/ui/src/components/flows/FlowCreate.vue
+++ b/ui/src/components/flows/FlowCreate.vue
@@ -5,82 +5,78 @@
     </section>
 </template>
 
-<script>
-    import {mapStores} from "pinia";
+<script setup lang="ts">
+    import {computed, onMounted, onBeforeUnmount} from "vue";
+    import {useRoute, onBeforeRouteLeave} from "vue-router";
+    import {useI18n} from "vue-i18n";
     import * as YAML_UTILS from "@kestra-io/ui-libs/flow-yaml-utils";
-    import RouteContext from "../../mixins/routeContext";
     import TopNavBar from "../../components/layout/TopNavBar.vue";
     import MultiPanelFlowEditorView from "./MultiPanelFlowEditorView.vue";
     import {useBlueprintsStore} from "../../stores/blueprints";
     import {useCoreStore} from "../../stores/core";
     import {editorViewTypes} from "../../utils/constants";
-
     import {getRandomID} from "../../../scripts/id";
     import {useEditorStore} from "../../stores/editor";
     import {useFlowStore} from "../../stores/flow";
     import {defaultNamespace} from "../../composables/useNamespaces";
+    import {useTour} from "vue-tour";
 
-    export default {
-        mixins: [RouteContext],
-        components: {
-            MultiPanelFlowEditorView,
-            TopNavBar
-        },
+    const route = useRoute();
+    const {t} = useI18n();
+    const tour = useTour("guidedTour");
 
-        created() {
-            this.flowStore.isCreating = true;
-            if (this.$route.query.reset) {
-                localStorage.setItem("tourDoneOrSkip", undefined);
-                this.coreStore.guidedProperties = {...this.coreStore.guidedProperties, tourStarted: true};
-                this.$tours["guidedTour"]?.start();
-            }
-            this.setupFlow()
-            this.editorStore.closeAllTabs()
-        },
-        beforeUnmount() {
-            this.flowStore.flowValidation = undefined;
-        },
-        methods: {
-            async setupFlow() {
-                const blueprintId = this.$route.query.blueprintId;
-                const blueprintSource = this.$route.query.blueprintSource;
-                let flowYaml = ""
-                if (this.$route.query.copy && this.flowStore.flow){
-                    flowYaml = this.flowStore.flow.source;
-                } else if (blueprintId && blueprintSource) {
-                    flowYaml = await this.blueprintsStore.getBlueprintSource({type: blueprintSource, kind: "flow", id: blueprintId});
-                } else {
-                    const selectedNamespace = this.$route.query.namespace || defaultNamespace() || "company.team";
-                    flowYaml = `id: ${getRandomID()}
-namespace: ${selectedNamespace}
+    const blueprintsStore = useBlueprintsStore();
+    const coreStore = useCoreStore();
+    const editorStore = useEditorStore();
+    const flowStore = useFlowStore();
 
-tasks:
-  - id: hello
-    type: io.kestra.plugin.core.log.Log
-    message: Hello World! 🚀`;
-                }
+    const setupFlow = async () => {
+        const blueprintId = route.query.blueprintId as string;
+        const blueprintSource = route.query.blueprintSource as string;
+        let flowYaml = "";
 
-                this.flowStore.flowYaml = flowYaml;
-                this.flowStore.flowYamlBeforeAdd = flowYaml;
-
-                this.flowStore.flow = {...YAML_UTILS.parse(this.flowYaml), source: this.flowStore.flowYaml};
-                this.flowStore.initYamlSource({viewTypes: editorViewTypes.SOURCE_DOC});
-            }
-        },
-        computed: {
-            ...mapStores(useBlueprintsStore, useCoreStore, useEditorStore, useFlowStore),
-            routeInfo() {
-                return {
-                    title: this.$t("flows")
-                };
-            },
-            flowParsed() {
-                return YAML_UTILS.parse(this.source);
-            }
-        },
-        beforeRouteLeave(to, from, next) {
-            this.flowStore.flow = undefined;
-            next();
+        if (route.query.copy && flowStore.flow) {
+            flowYaml = flowStore.flow.source;
+        } else if (blueprintId && blueprintSource) {
+            flowYaml = await blueprintsStore.getBlueprintSource({
+                type: blueprintSource,
+                kind: "flow",
+                id: blueprintId
+            });
+        } else {
+            const selectedNamespace = (route.query.namespace as string) || defaultNamespace() || "company.team";
+            flowYaml = `id: ${getRandomID()}\nnamespace: ${selectedNamespace}\n\ntasks:\n  - id: hello\n    type: io.kestra.plugin.core.log.Log\n    message: Hello World! 🚀`;
         }
+
+        flowStore.flowYaml = flowYaml;
+        flowStore.flowYamlBeforeAdd = flowYaml;
+
+        flowStore.flow = {...YAML_UTILS.parse(flowStore.flowYaml), source: flowStore.flowYaml};
+        flowStore.initYamlSource({viewTypes: editorViewTypes.SOURCE_DOC});
     };
+
+    const routeInfo = computed(() => {
+        return {
+            title: t("flows")
+        };
+    });
+
+    onMounted(() => {
+        flowStore.isCreating = true;
+        if (route.query.reset) {
+            localStorage.setItem("tourDoneOrSkip", "");
+            coreStore.guidedProperties = {...coreStore.guidedProperties, tourStarted: true};
+            tour.start();
+        }
+        setupFlow();
+        editorStore.closeAllTabs();
+    });
+
+    onBeforeUnmount(() => {
+        flowStore.flowValidation = undefined;
+    });
+
+    onBeforeRouteLeave(() => {
+        flowStore.flow = undefined;
+    });
 </script>

--- a/ui/src/components/flows/FlowCreate.vue
+++ b/ui/src/components/flows/FlowCreate.vue
@@ -6,7 +6,7 @@
 </template>
 
 <script setup lang="ts">
-    import {computed, onMounted, onBeforeUnmount} from "vue";
+    import {computed, onBeforeUnmount} from "vue";
     import {useRoute, onBeforeRouteLeave} from "vue-router";
     import {useI18n} from "vue-i18n";
     import * as YAML_UTILS from "@kestra-io/ui-libs/flow-yaml-utils";
@@ -14,16 +14,16 @@
     import MultiPanelFlowEditorView from "./MultiPanelFlowEditorView.vue";
     import {useBlueprintsStore} from "../../stores/blueprints";
     import {useCoreStore} from "../../stores/core";
-    import {editorViewTypes} from "../../utils/constants";
     import {getRandomID} from "../../../scripts/id";
     import {useEditorStore} from "../../stores/editor";
     import {useFlowStore} from "../../stores/flow";
     import {defaultNamespace} from "../../composables/useNamespaces";
-    import {useTour} from "vue-tour";
+    import {useVueTour} from "../../composables/useVueTour";
 
     const route = useRoute();
     const {t} = useI18n();
-    const tour = useTour("guidedTour");
+
+    const tour = useVueTour("guidedTour");
 
     const blueprintsStore = useBlueprintsStore();
     const coreStore = useCoreStore();
@@ -34,6 +34,8 @@
         const blueprintId = route.query.blueprintId as string;
         const blueprintSource = route.query.blueprintSource as string;
         let flowYaml = "";
+        const id = getRandomID();
+        const selectedNamespace = (route.query.namespace as string) || defaultNamespace() || "company.team";
 
         if (route.query.copy && flowStore.flow) {
             flowYaml = flowStore.flow.source;
@@ -44,15 +46,24 @@
                 id: blueprintId
             });
         } else {
-            const selectedNamespace = (route.query.namespace as string) || defaultNamespace() || "company.team";
-            flowYaml = `id: ${getRandomID()}\nnamespace: ${selectedNamespace}\n\ntasks:\n  - id: hello\n    type: io.kestra.plugin.core.log.Log\n    message: Hello World! 🚀`;
+            flowYaml = `
+id: ${id}
+namespace: ${selectedNamespace}
+
+tasks:
+  - id: hello
+    type: io.kestra.plugin.core.log.Log
+    message: Hello World! 🚀`.trim();
         }
 
-        flowStore.flowYaml = flowYaml;
-        flowStore.flowYamlBeforeAdd = flowYaml;
+        flowStore.flow = {
+            id,
+            namespace: selectedNamespace,
+            ...YAML_UTILS.parse(flowYaml),
+            source: flowYaml,
+        };
 
-        flowStore.flow = {...YAML_UTILS.parse(flowStore.flowYaml), source: flowStore.flowYaml};
-        flowStore.initYamlSource({viewTypes: editorViewTypes.SOURCE_DOC});
+        flowStore.initYamlSource();
     };
 
     const routeInfo = computed(() => {
@@ -61,16 +72,17 @@
         };
     });
 
-    onMounted(() => {
-        flowStore.isCreating = true;
-        if (route.query.reset) {
-            localStorage.setItem("tourDoneOrSkip", "");
-            coreStore.guidedProperties = {...coreStore.guidedProperties, tourStarted: true};
-            tour.start();
-        }
-        setupFlow();
-        editorStore.closeAllTabs();
-    });
+    flowStore.isCreating = true;
+    if (route.query.reset) {
+        localStorage.setItem("tourDoneOrSkip", "");
+        coreStore.guidedProperties = {
+            ...coreStore.guidedProperties,
+            tourStarted: true,
+        };
+        tour.start();
+    }
+    setupFlow();
+    editorStore.closeAllTabs();
 
     onBeforeUnmount(() => {
         flowStore.flowValidation = undefined;

--- a/ui/src/components/flows/FlowRevisions.vue
+++ b/ui/src/components/flows/FlowRevisions.vue
@@ -196,7 +196,6 @@
                 .then((response:any) => {
                     toast.saved(response.id);
                     flowStore.flowYaml = response.source;
-                    flowStore.flowYamlBeforeAdd = response.source;
                     load()
                 })
                 .then(() => {

--- a/ui/src/composables/useVueTour.ts
+++ b/ui/src/composables/useVueTour.ts
@@ -1,0 +1,20 @@
+import {getCurrentInstance} from "vue"
+export function useVueTour(tourName: string) {
+    const instance = getCurrentInstance();
+    if (!instance) {
+        throw new Error("useVueTour must be called within a setup function");
+    }
+
+    const tours = instance.appContext.config.globalProperties.$tours;
+    if (!tours) {
+        throw new Error("VueTour is not properly installed.");
+    }
+
+    const start = () => {
+        tours[tourName].start();
+    };
+
+    return {
+        start
+    };
+}

--- a/ui/src/stores/flow.ts
+++ b/ui/src/stores/flow.ts
@@ -4,7 +4,6 @@ import permission from "../models/permission";
 import action from "../models/action";
 import * as YAML_UTILS from "@kestra-io/ui-libs/flow-yaml-utils";
 import Utils from "../utils/utils";
-import {editorViewTypes} from "../utils/constants";
 import {apiUrl} from "override/utils/route";
 import {useCoreStore} from "./core";
 import {useEditorStore} from "./editor";
@@ -63,7 +62,7 @@ interface Flow {
     labels?: Record<string, string | boolean>;
     triggers?: Trigger[];
     inputs?: Input[];
-    errors: { message: string; code?: string, id?: string }[];
+    errors?: { message: string; code?: string, id?: string }[];
 }
 
 export const useFlowStore = defineStore("flow", () => {
@@ -87,7 +86,6 @@ export const useFlowStore = defineStore("flow", () => {
     const isCreating = ref<boolean>(false)
     const flowYaml = ref<string>("")
     const flowYamlOrigin = ref<string>("")
-    const flowYamlBeforeAdd = ref<string>("")
     const confirmOutdatedSaveDialog = ref<boolean>(false)
     const haveChange = ref<boolean>(false)
     const expandedSubflows = ref<string[]>([])
@@ -336,22 +334,13 @@ export const useFlowStore = defineStore("flow", () => {
         });
     }
 
-    async function initYamlSource({viewType}: { viewType: string }) {
+    async function initYamlSource() {
         if (!flow.value) return;
         const {source} = flow.value;
         flowYaml.value = source;
         flowYamlOrigin.value = source;
         if (flowHaveTasks.value) {
-            if (
-                [
-                    editorViewTypes.TOPOLOGY,
-                    editorViewTypes.SOURCE_TOPOLOGY,
-                ].includes(viewType)
-            ) {
-                await fetchGraph();
-            } else {
-                fetchGraph();
-            }
+            fetchGraph();
         }
 
         // validate flow on first load
@@ -367,7 +356,7 @@ export const useFlowStore = defineStore("flow", () => {
             if (options.onlyTotal) {
                 return response.data.total;
             }
-            
+
             else {
                 flows.value = response.data.results
                 total.value = response.data.total
@@ -432,7 +421,6 @@ export const useFlowStore = defineStore("flow", () => {
                 flow.value = response.data;
                 flowYaml.value = response.data.source;
                 flowYamlOrigin.value = response.data.source;
-                flowYamlBeforeAdd.value = response.data.source;
                 overallTotal.value = 1;
 
                 return response.data;
@@ -468,7 +456,7 @@ export const useFlowStore = defineStore("flow", () => {
 
                     const editorStore = useEditorStore();
                     const currentTab = editorStore.current;
-                    
+
                     // The dirty flag for the flow tab was cleared using a hardcoded name,
                     // which failed if the tab's actual name and path was different.
                     // update the dirty flag clearing logic to target the actual current flow tab (using its real name and path), ensuring the Save button disables after a successful save.
@@ -909,7 +897,6 @@ function deleteFlowAndDependencies() {
         isCreating,
         flowYaml,
         flowYamlOrigin,
-        flowYamlBeforeAdd,
         confirmOutdatedSaveDialog,
         haveChange,
         expandedSubflows,


### PR DESCRIPTION
Closes https://github.com/kestra-io/kestra/issues/12081.

## Summary

This pull request refactors the `FlowCreate.vue` component to use TypeScript and the Composition API, improving its readability, maintainability, and type safety.

### Changes

- Converted the `<script>` section to `<script setup lang="ts">`.
- Replaced the Options API with the Composition API.
- Replaced the `RouteContext` mixin with the `useRoute` composable from `vue-router`.
- Replaced `mapStores` with individual `use...Store()` calls for better maintainability.
- Replaced the `created` lifecycle hook with `onMounted`.
- Replaced the `beforeUnmount` lifecycle hook with `onBeforeUnmount`.
- Used the `onBeforeRouteLeave` navigation guard instead of the in-component guard.
- Integrated the `useTour` composable to manage the guided tour feature.
