### PR TITLE
refactor: convert FlowExecutions component to TypeScript with Composition API

### DIFF
--- a/ui/src/components/flows/FlowExecutions.vue
+++ b/ui/src/components/flows/FlowExecutions.vue
@@ -1,19 +1,22 @@
 <template>
-    <Executions :restoreUrl="false" filter :topbar="false" :namespace="flowStore.flow?.namespace" :flowId="flowStore.flow?.id" />
+    <Executions 
+        :restoreUrl="false" 
+        filter 
+        :topbar="false" 
+        :namespace="flowStore.flow?.namespace" 
+        :flowId="flowStore.flow?.id" 
+    />
 </template>
 
-<script>
-    import {mapStores} from "pinia";
+<script setup lang="ts">
     import Executions from "../executions/Executions.vue";
     import {useFlowStore} from "../../stores/flow";
 
-    export default {
-        inheritAttrs: false,
-        components: {
-            Executions,
-        },
-        computed: {
-            ...mapStores(useFlowStore)
-        }
-    };
+    // This will get the flowstore instance
+    const flowStore = useFlowStore();
+
+    // inheritAttrs
+    defineOptions({
+        inheritAttrs: false
+    });
 </script>

--- a/ui/src/components/flows/FlowExecutions.vue
+++ b/ui/src/components/flows/FlowExecutions.vue
@@ -1,22 +1,18 @@
 <template>
-    <Executions 
-        :restoreUrl="false" 
-        filter 
-        :topbar="false" 
-        :namespace="flowStore.flow?.namespace" 
-        :flowId="flowStore.flow?.id" 
+    <Executions
+        :namespace="flowStore.flow?.namespace"
+        :flowId="flowStore.flow?.id"
+        :topbar="false"
+        :restoreUrl="false"
+        filter
     />
 </template>
 
 <script setup lang="ts">
     import Executions from "../executions/Executions.vue";
-    import {useFlowStore} from "../../stores/flow";
 
-    // This will get the flowstore instance
+    import {useFlowStore} from "../../stores/flow";
     const flowStore = useFlowStore();
 
-    // inheritAttrs
-    defineOptions({
-        inheritAttrs: false
-    });
+    defineOptions({inheritAttrs: false});
 </script>


### PR DESCRIPTION
closes: https://github.com/kestra-io/kestra/issues/12084

# Summary
Converts `kestra/ui/src/components/flows/FlowExecutions.vue` from Options API with JavaScript to Composition API with TypeScript.
Changes

* Migrated from Options API to <script setup> (Composition API)
* Added TypeScript support (lang="ts")
* Replaced mapStores helper with direct useFlowStore() call
* Converted inheritAttrs: false to defineOptions()
* Maintained all existing functionality and template structure