### PR TITLE
Fix(UI) : Remove overlapping line near category titles(#12041)

### DIFF
--- a/ui/src/components/layout/Markdown.vue
+++ b/ui/src/components/layout/Markdown.vue
@@ -157,7 +157,6 @@
                 }
             }
             padding: 5px ;
-            border-left: 4px solid var(--ks-border-primary);
         }
 
         strong > code,


### PR DESCRIPTION
Fixes #12041

I've removed the overlapping line near category titles by removing the CSS that was causing it.

**Removed CSS:**
```css
border-left: 4px solid var(--ks-border-primary);
```

**Before:**

<img width="775" height="683" alt="Before" src="https://github.com/user-attachments/assets/d47b9561-91db-4661-ac53-1896ea07060f" />

**After:**

<img width="879" height="812" alt="After" src="https://github.com/user-attachments/assets/3eed10cd-4bc2-447e-992e-b0030d3afe8d" />
