### PR TITLE
Fix/validate endpoint fix

### DIFF
--- a/core/src/main/java/io/kestra/core/models/triggers/AbstractTrigger.java
+++ b/core/src/main/java/io/kestra/core/models/triggers/AbstractTrigger.java
@@ -47,7 +47,6 @@ abstract public class AbstractTrigger implements TriggerInterface {
     @Valid
     protected List<@Valid @NotNull Condition> conditions;
 
-    @NotNull
     @Builder.Default
     @PluginProperty(hidden = true, group = PluginProperty.CORE_GROUP)
     @Schema(defaultValue = "false")

--- a/webserver/src/main/java/io/kestra/webserver/controllers/api/FlowController.java
+++ b/webserver/src/main/java/io/kestra/webserver/controllers/api/FlowController.java
@@ -618,12 +618,13 @@ public class FlowController {
     @Post(uri = "/validate/task", consumes = MediaType.APPLICATION_JSON)
     @Operation(tags = {"Flows"}, summary = "Validate task")
     public ValidateConstraintViolation validateTask(
-        @RequestBody(description = "The task") @Schema(implementation = Object.class) @Body Task task
+        @RequestBody(description = "The task") @Schema(implementation = Object.class) @Body String task
     ) {
         ValidateConstraintViolation.ValidateConstraintViolationBuilder<?, ?> validateConstraintViolationBuilder = ValidateConstraintViolation.builder();
 
         try {
-            modelValidator.validate(task);
+            var parsedTask = parseTaskTrigger(task, Task.class);
+            modelValidator.validate(parsedTask);
         } catch (ConstraintViolationException e) {
             validateConstraintViolationBuilder.constraints(e.getMessage());
         } catch (RuntimeException re) {
@@ -642,12 +643,13 @@ public class FlowController {
     @Post(uri = "/validate/trigger", consumes = MediaType.APPLICATION_JSON)
     @Operation(tags = {"Flows"}, summary = "Validate trigger")
     public ValidateConstraintViolation validateTrigger(
-        @RequestBody(description = "The trigger") @Schema(implementation = Object.class) @Body AbstractTrigger trigger
+        @RequestBody(description = "The trigger") @Schema(implementation = Object.class) @Body String trigger
     ) {
         ValidateConstraintViolation.ValidateConstraintViolationBuilder<?, ?> validateConstraintViolationBuilder = ValidateConstraintViolation.builder();
 
         try {
-            modelValidator.validate(trigger);
+            var parsedTrigger = parseTaskTrigger(trigger, AbstractTrigger.class);
+            modelValidator.validate(parsedTrigger);
         } catch (ConstraintViolationException e) {
             validateConstraintViolationBuilder.constraints(e.getMessage());
         } catch (RuntimeException re) {

--- a/webserver/src/main/java/io/kestra/webserver/controllers/api/FlowController.java
+++ b/webserver/src/main/java/io/kestra/webserver/controllers/api/FlowController.java
@@ -618,13 +618,12 @@ public class FlowController {
     @Post(uri = "/validate/task", consumes = MediaType.APPLICATION_JSON)
     @Operation(tags = {"Flows"}, summary = "Validate task")
     public ValidateConstraintViolation validateTask(
-        @RequestBody(description = "The task") @Body String task
+        @RequestBody(description = "The task") @Schema(implementation = Object.class) @Body Task task
     ) {
         ValidateConstraintViolation.ValidateConstraintViolationBuilder<?, ?> validateConstraintViolationBuilder = ValidateConstraintViolation.builder();
 
         try {
-            var taskParse = parseTaskTrigger(task, Task.class);
-            modelValidator.validate(taskParse);
+            modelValidator.validate(task);
         } catch (ConstraintViolationException e) {
             validateConstraintViolationBuilder.constraints(e.getMessage());
         } catch (RuntimeException re) {
@@ -643,13 +642,12 @@ public class FlowController {
     @Post(uri = "/validate/trigger", consumes = MediaType.APPLICATION_JSON)
     @Operation(tags = {"Flows"}, summary = "Validate trigger")
     public ValidateConstraintViolation validateTrigger(
-        @RequestBody(description = "The trigger") @Body String trigger
+        @RequestBody(description = "The trigger") @Schema(implementation = Object.class) @Body AbstractTrigger trigger
     ) {
         ValidateConstraintViolation.ValidateConstraintViolationBuilder<?, ?> validateConstraintViolationBuilder = ValidateConstraintViolation.builder();
 
         try {
-            var triggerParse = parseTaskTrigger(trigger, AbstractTrigger.class);
-            modelValidator.validate(triggerParse);
+            modelValidator.validate(trigger);
         } catch (ConstraintViolationException e) {
             validateConstraintViolationBuilder.constraints(e.getMessage());
         } catch (RuntimeException re) {


### PR DESCRIPTION
* Removed the @NotNull on the `disabled` property of the abstractTrigger as its a primitive it can not be null anyway and it was adding this property in the "required"

* In the validate method, we expect a string which is in fact a valid JSON that we will parsed. So I annotated that what has to be send is an object. However Python SDK was trying to send a String load as JSON.