### PR TITLE
feat: allow defining custom topology nodes from tasks

### DIFF
--- a/core/src/main/java/io/kestra/core/models/hierarchies/CustomGraphCluster.java
+++ b/core/src/main/java/io/kestra/core/models/hierarchies/CustomGraphCluster.java
@@ -1,0 +1,34 @@
+package io.kestra.core.models.hierarchies;
+
+import lombok.Getter;
+
+import java.util.List;
+
+@SuppressWarnings("this-escape")
+@Getter
+public class CustomGraphCluster extends GraphCluster {
+    public CustomGraphCluster(String uid, GraphTask rootTask, List<CustomGraphNode> nodes) {
+        super(rootTask, uid, RelationType.SEQUENTIAL); // TODO should we add a custom relation type?
+
+        this.getGraph().addNode(rootTask);
+        this.addEdge(this.getRoot(), rootTask, new Relation());
+
+        this.getGraph().removeEdge(rootTask, this.getFinally());
+        this.getGraph().removeEdge(rootTask, this.getAfterExecution());
+        this.getGraph().removeNode(this.getFinally());
+        this.getGraph().removeNode(this.getAfterExecution());
+
+        nodes.forEach(node -> {
+            this.getGraph().addNode(node);
+            this.addEdge(rootTask, node, new Relation(RelationType.SEQUENTIAL, null));
+            this.addEdge(node, this.getEnd(), new Relation());
+        });
+    }
+
+    @Override
+    public void updateUidWithChildren(String uid) {
+        // as children are not "regular children with parent -> child relationship as with flowable task"
+        // we fall back to the existing UID.
+        this.uid = uid;
+    }
+}

--- a/core/src/main/java/io/kestra/core/models/hierarchies/CustomGraphNode.java
+++ b/core/src/main/java/io/kestra/core/models/hierarchies/CustomGraphNode.java
@@ -1,0 +1,24 @@
+package io.kestra.core.models.hierarchies;
+
+import io.kestra.core.models.Plugin;
+
+public class CustomGraphNode extends AbstractGraph {
+    private final String label;
+    private final Plugin plugin;
+
+    public CustomGraphNode(String uid, String label, Plugin plugin) {
+        super(uid);
+
+        this.label = label;
+        this.plugin = plugin;
+    }
+
+    @Override
+    public String getLabel() {
+        return label;
+    }
+
+    public Plugin getPlugin() {
+        return plugin;
+    }
+}

--- a/core/src/main/java/io/kestra/core/models/tasks/RunnableTask.java
+++ b/core/src/main/java/io/kestra/core/models/tasks/RunnableTask.java
@@ -2,7 +2,13 @@ package io.kestra.core.models.tasks;
 
 import io.kestra.core.models.Plugin;
 import io.kestra.core.models.WorkerJobLifecycle;
+import io.kestra.core.models.executions.TaskRun;
+import io.kestra.core.models.hierarchies.AbstractGraph;
+import io.kestra.core.models.hierarchies.GraphTask;
+import io.kestra.core.models.hierarchies.RelationType;
 import io.kestra.core.runners.RunContext;
+
+import java.util.List;
 
 /**
  * Interface for tasks that are run in the Worker.
@@ -12,4 +18,13 @@ public interface RunnableTask <T extends Output> extends Plugin, WorkerJobLifecy
      * This method is called inside the Worker to run (execute) the task.
      */
     T run(RunContext runContext) throws Exception;
+
+    /**
+     * Create the topology representation of a runnable task.
+     * <p>
+     * By default, it returns a single GraphTask, tasks may override it to provide a custom topology representation.
+     */
+    default AbstractGraph graph(TaskRun taskRun, List<String> values, RelationType relationType) {
+        return new GraphTask((Task) this, taskRun, values, relationType);
+    }
 }

--- a/core/src/main/java/io/kestra/core/utils/GraphUtils.java
+++ b/core/src/main/java/io/kestra/core/utils/GraphUtils.java
@@ -7,6 +7,7 @@ import io.kestra.core.models.flows.Flow;
 import io.kestra.core.models.hierarchies.*;
 import io.kestra.core.models.tasks.ExecutableTask;
 import io.kestra.core.models.tasks.FlowableTask;
+import io.kestra.core.models.tasks.RunnableTask;
 import io.kestra.core.models.tasks.Task;
 import io.kestra.core.models.triggers.AbstractTrigger;
 import io.kestra.core.models.triggers.Trigger;
@@ -391,6 +392,8 @@ public class GraphUtils {
                     currentGraph = flowableTask.tasksTree(execution, currentTaskRun, parentValues);
                 } else if (currentTask instanceof ExecutableTask<?> subflowTask) {
                     currentGraph = new SubflowGraphTask(subflowTask, currentTaskRun, parentValues, relationType);
+                } else if (currentTask instanceof RunnableTask<?> runnableTask) {
+                    currentGraph = runnableTask.graph(currentTaskRun, parentValues, relationType);
                 } else {
                     currentGraph = new GraphTask(currentTask, currentTaskRun, parentValues, relationType);
                 }

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -10,7 +10,7 @@
             "hasInstallScript": true,
             "dependencies": {
                 "@js-joda/core": "^5.6.5",
-                "@kestra-io/ui-libs": "^0.0.258",
+                "@kestra-io/ui-libs": "^0.0.259",
                 "@vue-flow/background": "^1.3.2",
                 "@vue-flow/controls": "^1.1.2",
                 "@vue-flow/core": "^1.47.0",
@@ -3296,9 +3296,9 @@
             "license": "BSD-3-Clause"
         },
         "node_modules/@kestra-io/ui-libs": {
-            "version": "0.0.258",
-            "resolved": "https://registry.npmjs.org/@kestra-io/ui-libs/-/ui-libs-0.0.258.tgz",
-            "integrity": "sha512-4Rujbf22LmuERY1R28H7Yd3IqKC+YpjtTnM/SJkSuSL0fieQZBblgvgMEwbbQJpVO1syYD3mOKGPvbKf8ARgqg==",
+            "version": "0.0.259",
+            "resolved": "https://registry.npmjs.org/@kestra-io/ui-libs/-/ui-libs-0.0.259.tgz",
+            "integrity": "sha512-qFhWt+JfjyWaaW5jDX7YCz1JdFZRXZJDKfvvZ51LGDFEVmwXis8jImw/p2KFu3alE6/bEc805fOee4rp8LB8sA==",
             "dependencies": {
                 "@nuxtjs/mdc": "^0.17.3",
                 "@popperjs/core": "^2.11.8",

--- a/ui/package.json
+++ b/ui/package.json
@@ -24,7 +24,7 @@
     },
     "dependencies": {
         "@js-joda/core": "^5.6.5",
-        "@kestra-io/ui-libs": "^0.0.258",
+        "@kestra-io/ui-libs": "^0.0.259",
         "@vue-flow/background": "^1.3.2",
         "@vue-flow/controls": "^1.1.2",
         "@vue-flow/core": "^1.47.0",


### PR DESCRIPTION
Part-of: https://github.com/kestra-io/kestra-ee/issues/4729

@kestra-io/frontend I would need help with the topology view part. I had a quick look inside the ui-lib, and I think it would need more work than I thought, as it would need to create a new type of Node inside the topology.

What this PR is doing is to add a new type of node `CustomGraphNode`, some plugins may, instead of returning a single GraphTask node, return a CustomGraphCluster with a list of CustomGraphNode inside them.
The topoplogy must be adapted to at minimum display correctly these new kind of nodes, add the icon and the type as tooltip.

Currently, the topology looks like this:
<img width="2527" height="1409" alt="image" src="https://github.com/user-attachments/assets/f983ce6a-a6f2-4397-bbd2-da2cb9898cad" />


To be able to test this, you would have to build the AI plugin from that branch: https://github.com/kestra-io/plugin-ai/pull/204

Example flow:
```yaml
id: ai-agent-calling-flows
namespace: tutorial
description: AI Agent

inputs:
  - id: use_case
    type: SELECT
    displayName: Select Your Orchestration Use Case
    defaults: Just Exploring
    values:
      - Business Automation
      - Business Processes
      - Data Engineering Pipeline
      - Data Warehouse and Analytics
      - Infrastructure Automation
      - Microservices and APIs
      - Just Exploring
tasks:
  - id: agent
    type: io.kestra.plugin.ai.agent.AIAgent
    prompt: |
      Execute a flow that best matches the {{inputs.use_case}} use case selected by the user. Use the following mapping of use cases to flow ids:
      - Business Automation: business-automation
      - Business Processes: business-processes
      - Data Engineering Pipeline: data-engineering-pipeline
      - Data Warehouse and Analytics: dwh-and-analytics
      - Infrastructure Automation: infrastructure-automation
      - Microservices and APIs: microservices-and-apis
      - Just Exploring: hello-world
      Remember that all those flows are in the tutorial namespace.
      Return only the Execution URI with no extra characters - the structure of URL is {{ kestra.url ?? 'http://localhost:8080/'}}ui/<tenantId>/executions/<namespace>/<flowId>/<id>
    provider:
      type: io.kestra.plugin.ai.provider.GoogleGemini
      modelName: gemini-2.5-flash
      apiKey: "{{ kv('GEMINI_API_KEY', errorOnMissing=false) }}"
    tools:
      - type: io.kestra.plugin.ai.tool.KestraFlow

  - id: uri
    type: io.kestra.plugin.core.debug.Return
    format: "{{ (kestra.url ?? 'http://localhost:8080/') ~ 'ui/' ~
      fromJson((outputs.agent.toolExecutions | first).result).tenantId ~
      '/executions/tutorial/' ~ fromJson((outputs.agent.toolExecutions |
      first).result).flowId ~ '/' ~ fromJson((outputs.agent.toolExecutions |
      first).result).id }}"

```
