### PR TITLE
Add Gauge Metric to Kestra Metrics System

### DIFF
--- a/core/src/main/java/io/kestra/core/models/executions/MetricEntry.java
+++ b/core/src/main/java/io/kestra/core/models/executions/MetricEntry.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import io.kestra.core.models.DeletedInterface;
 import io.kestra.core.models.TenantInterface;
 import io.kestra.core.models.executions.metrics.Counter;
+import io.kestra.core.models.executions.metrics.Gauge;
 import io.kestra.core.models.executions.metrics.Timer;
 import io.swagger.v3.oas.annotations.Hidden;
 import jakarta.annotation.Nullable;
@@ -80,6 +81,10 @@ public class MetricEntry implements DeletedInterface, TenantInterface {
     private static Double computeValue(AbstractMetricEntry<?> metricEntry) {
         if (metricEntry instanceof Counter counter) {
             return counter.getValue();
+        }
+
+        if (metricEntry instanceof Gauge gauge) {
+            return gauge.getValue();
         }
 
         if (metricEntry instanceof Timer timer) {

--- a/core/src/main/java/io/kestra/core/models/executions/metrics/Gauge.java
+++ b/core/src/main/java/io/kestra/core/models/executions/metrics/Gauge.java
@@ -73,6 +73,6 @@ public class Gauge extends AbstractMetricEntry<Double> {
 
     @Override
     public void increment(Double value) {
-
+        this.value = value;
     }
 }

--- a/core/src/main/java/io/kestra/core/models/executions/metrics/Gauge.java
+++ b/core/src/main/java/io/kestra/core/models/executions/metrics/Gauge.java
@@ -1,0 +1,78 @@
+package io.kestra.core.models.executions.metrics;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import jakarta.annotation.Nullable;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+import io.kestra.core.metrics.MetricRegistry;
+import io.kestra.core.models.executions.AbstractMetricEntry;
+
+import jakarta.validation.constraints.NotNull;
+import java.util.Map;
+
+@ToString
+@EqualsAndHashCode
+@Getter
+@NoArgsConstructor
+public class Gauge extends AbstractMetricEntry<Double> {
+    public static final String TYPE = "gauge";
+
+    @NotNull
+    @JsonInclude
+    private final String type = TYPE;
+
+    @NotNull
+    @EqualsAndHashCode.Exclude
+    private Double value;
+
+    private Gauge(@NotNull String name, @Nullable String description, @NotNull Double value, String... tags) {
+        super(name, description, tags);
+
+        this.value = value;
+    }
+
+    public static Gauge of(@NotNull String name, @NotNull Double value, String... tags) {
+        return new Gauge(name, null, value, tags);
+    }
+
+    public static Gauge of(@NotNull String name, @Nullable String description, @NotNull Double value, String... tags) {
+        return new Gauge(name, description, value, tags);
+    }
+
+    public static Gauge of(@NotNull String name, @NotNull Integer value, String... tags) {
+        return new Gauge(name, null, (double) value, tags);
+    }
+
+    public static Gauge of(@NotNull String name, @Nullable String description, @NotNull Integer value, String... tags) {
+        return new Gauge(name, description, (double) value, tags);
+    }
+
+    public static Gauge of(@NotNull String name, @NotNull Long value, String... tags) {
+        return new Gauge(name, null, (double) value, tags);
+    }
+
+    public static Gauge of(@NotNull String name, @Nullable String description, @NotNull Long value, String... tags) {
+        return new Gauge(name, description, (double) value, tags);
+    }
+
+    public static Gauge of(@NotNull String name, @NotNull Float value, String... tags) {
+        return new Gauge(name, null, (double) value, tags);
+    }
+
+    public static Gauge of(@NotNull String name, @Nullable String description, @NotNull Float value, String... tags) {
+        return new Gauge(name, description, (double) value, tags);
+    }
+
+    @Override
+    public void register(MetricRegistry meterRegistry, String name, String description, Map<String, String> tags) {
+        meterRegistry
+                .gauge(this.metricName(name), description, this.value, this.tagsAsArray(tags));
+    }
+
+    @Override
+    public void increment(Double value) {
+
+    }
+}

--- a/core/src/main/java/io/kestra/core/models/tasks/metrics/AbstractMetric.java
+++ b/core/src/main/java/io/kestra/core/models/tasks/metrics/AbstractMetric.java
@@ -22,6 +22,7 @@ import java.util.Map;
 @JsonSubTypes({
     @JsonSubTypes.Type(value = CounterMetric.class, name = "counter"),
     @JsonSubTypes.Type(value = TimerMetric.class, name = "timer"),
+    @JsonSubTypes.Type(value = GaugeMetric.class, name = "gauge"),
 })
 @ToString
 @EqualsAndHashCode

--- a/core/src/main/java/io/kestra/core/models/tasks/metrics/GaugeMetric.java
+++ b/core/src/main/java/io/kestra/core/models/tasks/metrics/GaugeMetric.java
@@ -1,0 +1,44 @@
+package io.kestra.core.models.tasks.metrics;
+
+import io.kestra.core.exceptions.IllegalVariableEvaluationException;
+import io.kestra.core.models.executions.AbstractMetricEntry;
+import io.kestra.core.models.executions.metrics.Gauge;
+import io.kestra.core.models.property.Property;
+import io.kestra.core.runners.RunContext;
+import jakarta.validation.constraints.NotNull;
+import lombok.*;
+import lombok.experimental.SuperBuilder;
+
+import java.util.Map;
+import java.util.stream.Stream;
+
+@ToString
+@EqualsAndHashCode
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@SuperBuilder
+public class GaugeMetric extends AbstractMetric {
+    public static final String TYPE = "gauge";
+
+    @NotNull
+    @EqualsAndHashCode.Exclude
+    private Property<Double> value;
+
+    @Override
+    public AbstractMetricEntry<?> toMetric(RunContext runContext) throws IllegalVariableEvaluationException {
+        String name = runContext.render(this.name).as(String.class).orElseThrow();
+        Double value = runContext.render(this.value).as(Double.class).orElseThrow();
+        String description = runContext.render(this.description).as(String.class).orElse(null);
+        Map<String, String> tags = runContext.render(this.tags).asMap(String.class, String.class);
+        String[] tagsAsStrings = tags.entrySet().stream()
+                .flatMap(e -> Stream.of(e.getKey(), e.getValue()))
+                .toArray(String[]::new);
+
+        return Gauge.of(name, description, value, tagsAsStrings);
+    }
+
+    public String getType() {
+        return TYPE;
+    }
+}

--- a/core/src/test/java/io/kestra/plugin/core/metric/PublishTest.java
+++ b/core/src/test/java/io/kestra/plugin/core/metric/PublishTest.java
@@ -4,6 +4,7 @@ import io.kestra.core.context.TestRunContextFactory;
 import io.kestra.core.junit.annotations.KestraTest;
 import io.kestra.core.models.property.Property;
 import io.kestra.core.models.tasks.metrics.CounterMetric;
+import io.kestra.core.models.tasks.metrics.GaugeMetric;
 import io.kestra.core.models.tasks.metrics.TimerMetric;
 import io.kestra.core.runners.RunContext;
 import io.kestra.core.utils.TestsUtils;
@@ -35,6 +36,10 @@ public class PublishTest {
                     TimerMetric.builder()
                         .value(Property.ofValue(Duration.parse("PT5H")))
                         .name(Property.ofValue("timer"))
+                        .build(),
+                    GaugeMetric.builder()
+                        .value(Property.ofValue(1.0))
+                        .name(Property.ofValue("gauge"))
                         .build()
                 ))
             )
@@ -44,7 +49,7 @@ public class PublishTest {
 
         publish.run(runContext);
 
-        assertThat(runContext.metrics().size()).isEqualTo(2);
+        assertThat(runContext.metrics().size()).isEqualTo(3);
     }
 
 }


### PR DESCRIPTION
closes #9791 

### What changes are being made and why?

Add a gauge metric to kestra metrics system following the pattern of counter and timer metric.
---

### How the changes have been QAed?

```yaml
id: publish_metrics
namespace: company.team

tasks:
  - id: metric
    type: io.kestra.plugin.core.metric.Publish
    metrics:
      - type: timer
        name: duration
        value: PT10M # Represents 10 minutes, `timer` values are expressed in duration format
        tags:
          flow: "{{flow.id}}"
          project: kestra
      - type: counter
        name: number
        value: 42 # `counter` values are integers or doubles
        tags:
          flow: "{{flow.id}}"
          project: kestra
      - type: gauge
        name: tracker
        value: 11.8
        tags:
          flow: "{{flow.id}}"
          project: kestra
```

