### PR TITLE
fix(ui/sidebar): make nav item hovering snackbar darker for better visibility

### DIFF
--- a/ui/src/styles/components/sidebar-menu.scss
+++ b/ui/src/styles/components/sidebar-menu.scss
@@ -54,7 +54,7 @@
             }
 
             &:hover, body &_hover {
-                background-color: var(--ks-button-background-secondary-hover);
+                background-color: var(--ks-button-background-secondary-active);
             }
 
             .el-tooltip__trigger {


### PR DESCRIPTION
I noticed that sidebar navigation menu item snackbar not as visible as it should be while hovering. 

## Video
### Before

https://github.com/user-attachments/assets/3e8985e2-1552-4b8a-9e42-8f1ecc840357

### After

https://github.com/user-attachments/assets/7d04c5dd-0678-487b-9831-edce8172cc1e

