### PR TITLE
fix(ui/sidebar): make plugin icon as outline to match icon harmony

### DIFF
--- a/ui/src/styles/components/sidebar-menu.scss
+++ b/ui/src/styles/components/sidebar-menu.scss
@@ -15,6 +15,13 @@
             }
         }
 
+        // Make Connection icon appear as outline
+        .vsm--link[href*="plugins"] .vsm--icon svg {
+            fill: none !important;
+            stroke: currentColor !important;
+            stroke-width: 1.5 !important;
+        }
+
         .vsm--item {
             padding: 0 30px;
             transition: padding 0.2s ease;

--- a/ui/src/styles/components/sidebar-menu.scss
+++ b/ui/src/styles/components/sidebar-menu.scss
@@ -15,7 +15,7 @@
             }
         }
 
-        // Make Connection icon appear as outline
+        // Make Plugins icon appear as outline
         .vsm--link[href*="plugins"] .vsm--icon svg {
             fill: none !important;
             stroke: currentColor !important;


### PR DESCRIPTION
In this pr, i make plugin icon as outline to match icon harmony.

# Why was solid before?
There is no outline version of plugin icon available by default on vue material icon library, so i think you guys choose solid version, which looks odd, it seems like it's a selected item of sidebar menu.

# Screenshots
## Before & After Side by side
<img width="291" height="758" alt="Screenshot from 2025-10-18 13-30-13" src="https://github.com/user-attachments/assets/bce691bc-3b45-4c58-abb6-75a4f655992e" />

<img width="291" height="758" alt="Screenshot from 2025-10-18 13-31-19" src="https://github.com/user-attachments/assets/02e3748c-cf08-4e3f-84d0-b57750600a52" />

# How i fixed it?
icons are eventually svg, so we can edit them like css.
