### PR TITLE
changes in Local Repo Loader

### DIFF
--- a/core/src/main/java/io/kestra/core/repositories/LocalFlowRepositoryLoader.java
+++ b/core/src/main/java/io/kestra/core/repositories/LocalFlowRepositoryLoader.java
@@ -27,6 +27,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -88,6 +89,8 @@ public class LocalFlowRepositoryLoader {
             .filter(flow -> tenantId.equals(flow.getTenantId()))
             .collect(Collectors.toMap(FlowId::uidWithoutRevision, Function.identity()));
 
+        Map<String, FlowInterface> processedInSameRun = new HashMap<>();    
+
         try (Stream<Path> pathStream = Files.walk(basePath.toPath())) {
             pathStream.filter(YamlParser::isValidExtension)
                 .forEach(Rethrow.throwConsumer(file -> {
@@ -97,7 +100,13 @@ public class LocalFlowRepositoryLoader {
 
                         FlowWithSource flowWithSource = pluginDefaultService.injectAllDefaults(parsed, false);
                         modelValidator.validate(flowWithSource);
-
+                        
+                        String flowUid = flowWithSource.uidWithoutRevision();
+                        if (processedInSameRun.containsKey(flowUid)) {
+                            log.trace("already processed in this execution", 
+                                    parsed.getNamespace(), parsed.getId());
+                            return; 
+                        }
                         FlowInterface existing = flowByUidInRepository.get(flowWithSource.uidWithoutRevision());
 
                         if (existing == null) {
@@ -107,6 +116,8 @@ public class LocalFlowRepositoryLoader {
                             flowRepository.update(parsed, existing);
                             log.trace("Updated flow {}.{}", parsed.getNamespace(), parsed.getId());
                         }
+
+                        processedInSameRun.put(flowUid, parsed);
                     } catch (FlowProcessingException | ConstraintViolationException e) {
                         log.warn("Unable to create flow {}", file, e);
                     }


### PR DESCRIPTION
Closes https://github.com/kestra-io/kestra/issues/12120.

### What changes are being made and why?
when using the default test lifecycle @TestInstance(TestInstance.Lifecycle.PER_METHOD) every method in the testing class uses a new instance of the tested class so there is no dependency between any of these methods , when using @LoadFlows or @ExecuteFlow @TestInstance(TestInstance.Lifecycle.PER_CLASS) we use the same instance for the methods in the testing class and if i add a flow with the same id at two methods it gives me exception (This is the issue) , so adding a tracking mechanism using a HashMap to detect and skip flows that have already been processed during the current load execution. This prevents duplicate flow insertion while maintaining the existing create/update logic for flows already in the database. 

### Changes :
Added processedInSameRun HashMap to track flows processed in current execution .
Added duplicate detection to skip already-processed flows .
Maintained existing create/update logic for database flows .

### Result : 
Multiple test methods can now use the same flow definitions without conflicts, eliminating the need for the @TestInstance(Lifecycle.PER_CLASS) workaround.
