### PR TITLE
fix(core): pass flow variables on trigger execution

### DIFF
--- a/core/src/main/java/io/kestra/core/models/triggers/TriggerService.java
+++ b/core/src/main/java/io/kestra/core/models/triggers/TriggerService.java
@@ -11,7 +11,6 @@ import io.kestra.core.runners.FlowInputOutput;
 import io.kestra.core.runners.RunContext;
 import io.kestra.core.utils.IdUtils;
 import io.kestra.core.utils.ListUtils;
-
 import java.time.ZonedDateTime;
 import java.util.*;
 
@@ -25,7 +24,7 @@ public abstract class TriggerService {
         RunContext runContext = conditionContext.getRunContext();
         ExecutionTrigger executionTrigger = ExecutionTrigger.of(trigger, variables, runContext.logFileURI());
 
-        return generateExecution(runContext.getTriggerExecutionId(), trigger, context, executionTrigger, conditionContext.getFlow().getRevision());
+        return generateExecution(runContext.getTriggerExecutionId(), trigger, context, executionTrigger, conditionContext);
     }
 
     public static Execution generateExecution(
@@ -37,7 +36,7 @@ public abstract class TriggerService {
         RunContext runContext = conditionContext.getRunContext();
         ExecutionTrigger executionTrigger = ExecutionTrigger.of(trigger, output, runContext.logFileURI());
 
-        return generateExecution(runContext.getTriggerExecutionId(), trigger, context, executionTrigger, conditionContext.getFlow().getRevision());
+        return generateExecution(runContext.getTriggerExecutionId(), trigger, context, executionTrigger, conditionContext);
     }
 
     public static Execution generateRealtimeExecution(
@@ -49,7 +48,7 @@ public abstract class TriggerService {
         RunContext runContext = conditionContext.getRunContext();
         ExecutionTrigger executionTrigger = ExecutionTrigger.of(trigger, output, runContext.logFileURI());
 
-        return generateExecution(IdUtils.create(), trigger, context, executionTrigger, conditionContext.getFlow().getRevision());
+        return generateExecution(IdUtils.create(), trigger, context, executionTrigger, conditionContext);
     }
 
     public static Execution generateScheduledExecution(
@@ -75,6 +74,7 @@ public abstract class TriggerService {
             .namespace(context.getNamespace())
             .flowId(context.getFlowId())
             .flowRevision(conditionContext.getFlow().getRevision())
+            .variables(conditionContext.getFlow().getVariables())
             .labels(executionLabels)
             .state(new State())
             .trigger(executionTrigger)
@@ -108,7 +108,7 @@ public abstract class TriggerService {
         AbstractTrigger trigger,
         TriggerContext context,
         ExecutionTrigger executionTrigger,
-        Integer flowRevision
+        ConditionContext conditionContext
     ) {
         List<Label> executionLabels = new ArrayList<>(ListUtils.emptyOnNull(trigger.getLabels()));
         if (executionLabels.stream().noneMatch(label -> Label.CORRELATION_ID.equals(label.key()))) {
@@ -120,7 +120,8 @@ public abstract class TriggerService {
             .namespace(context.getNamespace())
             .flowId(context.getFlowId())
             .tenantId(context.getTenantId())
-            .flowRevision(flowRevision)
+            .flowRevision(conditionContext.getFlow().getRevision())
+            .variables(conditionContext.getFlow().getVariables())
             .state(new State())
             .trigger(executionTrigger)
             .labels(executionLabels)

--- a/core/src/test/java/io/kestra/plugin/core/trigger/PollingTest.java
+++ b/core/src/test/java/io/kestra/plugin/core/trigger/PollingTest.java
@@ -22,6 +22,7 @@ class PollingTest {
         assertThat(optionalExecution).isPresent();
         Execution execution = optionalExecution.get();
         assertThat(execution.getFlowId()).isEqualTo("polling-flow");
+        assertThat(execution.getVariables()).containsEntry("custom_var", "VARIABLE VALUE");
         assertTrue(execution.getState().getCurrent().isCreated());
     }
 }

--- a/core/src/test/java/io/kestra/plugin/core/trigger/ScheduleTest.java
+++ b/core/src/test/java/io/kestra/plugin/core/trigger/ScheduleTest.java
@@ -66,6 +66,7 @@ class ScheduleTest {
             .id(IdUtils.create())
             .namespace("io.kestra.unittest")
             .revision(1)
+            .variables(Map.of("custom_var", "VARIABLE VALUE"))
             .tasks(Collections.singletonList(Return.builder()
                 .id("test")
                 .type(Return.class.getName())
@@ -101,7 +102,7 @@ class ScheduleTest {
         assertThat(evaluate.isPresent()).isTrue();
         assertThat(evaluate.get().getLabels()).hasSize(3);
         assertTrue(evaluate.get().getLabels().stream().anyMatch(label -> label.key().equals(Label.CORRELATION_ID)));
-
+        assertThat(evaluate.get().getVariables()).containsEntry("custom_var", "VARIABLE VALUE");
         var vars = evaluate.get().getTrigger().getVariables();
         var inputs = evaluate.get().getInputs();
 
@@ -135,7 +136,7 @@ class ScheduleTest {
         assertThat(evaluate.isPresent()).isTrue();
         assertThat(evaluate.get().getLabels()).hasSize(3);
         assertTrue(evaluate.get().getLabels().stream().anyMatch(label -> label.key().equals(Label.CORRELATION_ID)));
-
+        assertThat(evaluate.get().getVariables()).containsEntry("custom_var", "VARIABLE VALUE");
         var inputs = evaluate.get().getInputs();
 
         assertThat(inputs.size()).isEqualTo(2);
@@ -167,6 +168,7 @@ class ScheduleTest {
         Optional<Execution> evaluate = scheduleTrigger.evaluate(conditionContext, triggerContext);
 
         assertThat(evaluate.isPresent()).isTrue();
+        assertThat(evaluate.get().getVariables()).containsEntry("custom_var", "VARIABLE VALUE");
         assertThat(evaluate.get().getLabels()).contains(new Label("trigger-label-1", "trigger-label-1"));
         assertThat(evaluate.get().getLabels()).contains(new Label("trigger-label-2", "trigger-label-2"));
         assertThat(evaluate.get().getLabels()).doesNotContain(new Label("trigger-label-3", ""));
@@ -188,8 +190,8 @@ class ScheduleTest {
         );
 
         assertThat(evaluate.isPresent()).isTrue();
-
-        var vars = evaluate.get().getTrigger().getVariables();;
+        assertThat(evaluate.get().getVariables()).containsEntry("custom_var", "VARIABLE VALUE");
+        var vars = evaluate.get().getTrigger().getVariables();
 
         assertThat(dateFromVars((String) vars.get("date"), date)).isEqualTo(date);
         assertThat(dateFromVars((String) vars.get("next"), date)).isEqualTo(date.plus(Duration.ofMinutes(1)));
@@ -210,8 +212,8 @@ class ScheduleTest {
         );
 
         assertThat(evaluate.isPresent()).isTrue();
-
-        var vars = evaluate.get().getTrigger().getVariables();;
+        assertThat(evaluate.get().getVariables()).containsEntry("custom_var", "VARIABLE VALUE");
+        var vars = evaluate.get().getTrigger().getVariables();
 
         assertThat(dateFromVars((String) vars.get("date"), date)).isEqualTo(date);
         assertThat(dateFromVars((String) vars.get("next"), date)).isEqualTo(date.plus(Duration.ofSeconds(1)));
@@ -232,7 +234,6 @@ class ScheduleTest {
             ).build();
         // When
         Optional<Execution> result = trigger.evaluate(conditionContext(trigger), triggerContext);
-
         // Then
         assertThat(result.isEmpty()).isTrue();
     }
@@ -296,8 +297,8 @@ class ScheduleTest {
         );
 
         assertThat(evaluate.isPresent()).isTrue();
-
-        var vars = evaluate.get().getTrigger().getVariables();;
+        assertThat(evaluate.get().getVariables()).containsEntry("custom_var", "VARIABLE VALUE");
+        var vars = evaluate.get().getTrigger().getVariables();
         assertThat(dateFromVars((String) vars.get("date"), expexted)).isEqualTo(expexted);
         assertThat(dateFromVars((String) vars.get("next"), expexted)).isEqualTo(expexted.plusMonths(1));
         assertThat(dateFromVars((String) vars.get("previous"), expexted)).isEqualTo(expexted.minusMonths(1));
@@ -330,8 +331,8 @@ class ScheduleTest {
         );
 
         assertThat(evaluate.isPresent()).isTrue();
-
-        var vars = evaluate.get().getTrigger().getVariables();;
+        assertThat(evaluate.get().getVariables()).containsEntry("custom_var", "VARIABLE VALUE");
+        var vars = evaluate.get().getTrigger().getVariables();
         assertThat(dateFromVars((String) vars.get("date"), date)).isEqualTo(date);
         assertThat(dateFromVars((String) vars.get("next"), next)).isEqualTo(next);
         assertThat(dateFromVars((String) vars.get("previous"), previous)).isEqualTo(previous);
@@ -362,8 +363,8 @@ class ScheduleTest {
         );
 
         assertThat(evaluate.isPresent()).isTrue();
-
-        var vars = evaluate.get().getTrigger().getVariables();;
+        assertThat(evaluate.get().getVariables()).containsEntry("custom_var", "VARIABLE VALUE");
+        var vars = evaluate.get().getTrigger().getVariables();
         assertThat(dateFromVars((String) vars.get("date"), date)).isEqualTo(date);
         assertThat(dateFromVars((String) vars.get("previous"), previous)).isEqualTo(previous);
         assertThat(vars.containsKey("next")).isFalse();
@@ -412,7 +413,8 @@ class ScheduleTest {
         );
 
         assertThat(evaluate.isPresent()).isTrue();
-        var vars = evaluate.get().getTrigger().getVariables();;
+        assertThat(evaluate.get().getVariables()).containsEntry("custom_var", "VARIABLE VALUE");
+        var vars = evaluate.get().getTrigger().getVariables();
         assertThat(dateFromVars((String) vars.get("date"), date)).isEqualTo(date);
     }
 
@@ -437,8 +439,8 @@ class ScheduleTest {
         );
 
         assertThat(evaluate.isPresent()).isTrue();
-
-        var vars = evaluate.get().getTrigger().getVariables();;
+        assertThat(evaluate.get().getVariables()).containsEntry("custom_var", "VARIABLE VALUE");
+        var vars = evaluate.get().getTrigger().getVariables();
 
         assertThat(dateFromVars((String) vars.get("date"), date)).isEqualTo(date);
         assertThat(ZonedDateTime.parse((String) vars.get("date")).getZone().getId()).isEqualTo("-04:00");
@@ -467,6 +469,7 @@ class ScheduleTest {
 
         // Then
         assertThat(result.isPresent()).isTrue();
+        assertThat(result.get().getVariables()).containsEntry("custom_var", "VARIABLE VALUE");
     }
 
     private ConditionContext conditionContext(AbstractTrigger trigger) {
@@ -479,6 +482,7 @@ class ScheduleTest {
                     new Label("flow-label-2", "flow-label-2")
                 )
             )
+            .variables(Map.of("custom_var", "VARIABLE VALUE"))
             .inputs(List.of(
                 StringInput.builder().id("input1").type(Type.STRING).required(false).build(),
                 StringInput.builder().id("input2").type(Type.STRING).defaults(Property.ofValue("default")).build()

--- a/core/src/test/resources/flows/tests/trigger-polling.yaml
+++ b/core/src/test/resources/flows/tests/trigger-polling.yaml
@@ -1,5 +1,9 @@
 id: polling-flow
 namespace: io.kestra.tests
+
+variables:
+  custom_var: VARIABLE VALUE
+
 triggers:
   - id: polling-trigger-1
     type: io.kestra.core.tasks.test.PollingTrigger


### PR DESCRIPTION
closes #11891

<!-- Thanks for submitting a Pull Request to Kestra. To help us review your contribution, please follow the guidelines below:

- Make sure that your commits follow the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) specification e.g. `feat(ui): add a new navigation menu item` or `fix(core): fix a bug in the core model` or `docs: update the README.md`. This will help us automatically generate the changelog.
- The title should briefly summarize the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share a flow example to help the reviewer understand and QA the change.
- Use "closes" to automatically close an issue. For example, `closes #1234` will close issue #1234. -->

### What changes are being made and why?

When running the flow manually, `execution.getVariables()` from the `update` method of `SetVariables` has this value:
```
{custom_var=VARIABLE VALUE}
```
When the flow is ran with the trigger, the value of `execution.getVariables()` is `null`.

The proposed fix is to pass the variables to the execution from the `TriggerService`
```
return Execution.builder()
    ...
    .variables(conditionContext.getFlow().getVariables())
    ...
```


<!-- Please include a brief summary of the changes included in this PR e.g. closes #1234. -->

---

### How the changes have been QAed?

Create the following flow and run it manually, then the trigger will also run it after 1 minute. Both executions work as expected.
```yaml
id: flow_issue_setvar
namespace: company.team

variables:
  custom_var: "VARIABLE VALUE"

tasks:
  - id: log
    type: io.kestra.plugin.core.log.Log
    message: "{{ vars.custom_var }}"

  - id: set_vars
    type: io.kestra.plugin.core.execution.SetVariables
    variables:
      random_var: "ok"

  - id: log2
    type: io.kestra.plugin.core.log.Log
    message: "{{ vars.custom_var }}"

triggers:
  - id: test
    type: io.kestra.plugin.core.trigger.Schedule
    cron: "*/1 * * * *"
```
<!-- Include example code that shows how this PR has been QAed. The code should present a complete yet easily reproducible flow.

```yaml
# Your example flow code here
```

Note that this is not a replacement for unit tests but rather a way to demonstrate how the changes work in a real-life scenario, as the end-user would experience them.

Remove this section if this change applies to all flows or to the documentation only. -->

