### PR TITLE
modified docker command documentation for wsl

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ If you're on Windows and use WSL (Linux-based environment in Windows):
 ```bash
 docker run --pull=always --rm -it -p 8080:8080 --user=root \
     -v "/var/run/docker.sock:/var/run/docker.sock" \
-    -v "C:/Temp:/tmp" kestra/kestra:latest server local
+    -v "/mnt/c/Temp:/tmp" kestra/kestra:latest server local
 ```
 
 Check our [Installation Guide](https://kestra.io/docs/installation) for other deployment options (Docker Compose, Podman, Kubernetes, AWS, GCP, Azure, and more).


### PR DESCRIPTION
* closes #12151 
* documentation fix
*   docker run --pull=always --rm -it -p 8080:8080 --user=root     -v "/var/run/docker.sock:/var/run/docker.sock"     -v "/mnt/c/Temp:/tmp" kestra/kestra:latest server local

latest: Pulling from kestra/kestra
Digest: sha256:8e229847c87b0d7d77ee4050c3cc4c23db3be606c9b4e5921f29a88fddd6b013
Status: Image is up to date for kestra/kestra:latest.....