### PR TITLE
docs: add {tenant} placeholder in webhook trigger URL description

### DIFF
--- a/core/src/main/java/io/kestra/plugin/core/trigger/Webhook.java
+++ b/core/src/main/java/io/kestra/plugin/core/trigger/Webhook.java
@@ -35,7 +35,7 @@ import jakarta.validation.constraints.Size;
     description = """
         Webhook trigger allows you to create a unique URL that you can use to trigger a Kestra flow execution based on events in another application such as GitHub or Amazon EventBridge. In order to use that URL, you have to add a secret key to secure your webhook URL.
 
-        The URL will then follow the following format: `https://{your_hostname}/api/v1/executions/webhook/{namespace}/{flowId}/{key}`. Replace the templated values according to your workflow setup.
+        The URL will then follow the following format: `https://{your_hostname}/api/v1/{tenant}/executions/webhook/{namespace}/{flowId}/{key}`. Replace the templated values according to your workflow setup.
 
         The webhook URL accepts `GET`, `POST`, and `PUT` requests.
 

--- a/core/src/main/java/io/kestra/plugin/core/trigger/Webhook.java
+++ b/core/src/main/java/io/kestra/plugin/core/trigger/Webhook.java
@@ -85,7 +85,7 @@ import jakarta.validation.constraints.Size;
 @Plugin(
     examples = {
         @Example(
-            title = "Add a webhook trigger to the current flow with the key `4wjtkzwVGBM9yKnjm3yv8r`; the webhook will be available at the URI `/api/v1/executions/webhook/{namespace}/{flowId}/4wjtkzwVGBM9yKnjm3yv8r`.",
+            title = "Add a webhook trigger to the current flow with the key `4wjtkzwVGBM9yKnjm3yv8r`; the webhook will be available at the URI `/api/v1/{tenant}/executions/webhook/{namespace}/{flowId}/4wjtkzwVGBM9yKnjm3yv8r`.",
             code = """
                 id: webhook_flow
                 namespace: company.team


### PR DESCRIPTION
<!-- Thanks for submitting a Pull Request to Kestra. To help us review your contribution, please follow the guidelines below:

- Make sure that your commits follow the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) specification e.g. `feat(ui): add a new navigation menu item` or `fix(core): fix a bug in the core model` or `docs: update the README.md`. This will help us automatically generate the changelog.
- The title should briefly summarize the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share a flow example to help the reviewer understand and QA the change.
- Use "closes" to automatically close an issue. For example, `closes #1234` will close issue #1234. -->

### What changes are being made and why?

The in-app documentation for the Webhook trigger had an incomplete example URL format. it was missing the {tenant} placeholder.

Before : 
https://{your_hostname}/api/v1/executions/webhook/{namespace}/{flowId}/{key}

After :
https://{your_hostname}/api/v1/{tenant}/executions/webhook/{namespace}/{flowId}/{key}


<!-- Please include a brief summary of the changes included in this PR e.g. closes #1234. -->

closes #11939

### How the changes have been QAed?

- Verified that the modified `@Schema` description correctly includes {tenant}.

- Compared the updated text against the [original issue 

- Ensured no functional logic changes, only documentation content was updated.


