### PR TITLE
refactor(core): replace deprecated Property(String) constructor with Property.ofValue / Property.ofExpression

### DIFF
--- a/core/src/test/java/io/kestra/core/test/AssertionTest.java
+++ b/core/src/test/java/io/kestra/core/test/AssertionTest.java
@@ -59,7 +59,8 @@ class AssertionTest {
     @Test
     void shouldBrokenAssert_returnError() {
         var assertion = Assertion.builder()
-            .value(new Property<>("{{ invalid-pebble-expression() }}"))
+            .value(Property.ofExpression("{{ invalid-pebble-expression() }}")
+            )
             .equalTo(Property.ofValue("value"))
             .build();
 
@@ -78,7 +79,7 @@ class AssertionTest {
     @Test
     void shouldRender_values_fromTaskOutputs() {
         var assertion = Assertion.builder()
-            .value(new Property<>("{{ outputs.my_task.res }}"))
+            .value(Property.ofExpression("{{ outputs.my_task.res }}"))
             .equalTo(Property.ofValue("value1"))
             .build();
         var runContext = runContextFactory.of(Map.of("outputs", Map.of("my_task", Map.of("res", "value1"))));
@@ -92,7 +93,7 @@ class AssertionTest {
     @Test
     void shouldRender_values_fromTaskOutputs_and_produce_defaultErrorMessage() {
         var assertion = Assertion.builder()
-            .value(new Property<>("{{ outputs.my_task.res }}"))
+            .value(Property.ofExpression("{{ outputs.my_task.res }}"))
             .equalTo(Property.ofValue("expectedValue2"))
             .build();
         var runContext = runContextFactory.of(Map.of("outputs", Map.of("my_task", Map.of("res", "actualValue1"))));

--- a/core/src/test/java/io/kestra/core/topologies/FlowTopologyServiceTest.java
+++ b/core/src/test/java/io/kestra/core/topologies/FlowTopologyServiceTest.java
@@ -160,7 +160,7 @@ class FlowTopologyServiceTest {
                                     .in(Property.ofValue(List.of(State.Type.SUCCESS)))
                                     .build(),
                                 "variables", Expression.builder()
-                                    .expression(new Property<>("{{ true }}"))
+                                    .expression(Property.ofExpression("{{ true }}"))
                                     .build()
                             ))
                             .build()

--- a/core/src/test/java/io/kestra/plugin/core/kv/SetTest.java
+++ b/core/src/test/java/io/kestra/plugin/core/kv/SetTest.java
@@ -194,8 +194,8 @@ class SetTest {
         KVStoreException exception = Assertions.assertThrows(KVStoreException.class, () -> Set.builder()
             .id(Set.class.getSimpleName())
             .type(Set.class.getName())
-            .key(new Property<>("{{ inputs.key }}"))
-            .value(new Property<>("{{ inputs.value }}"))
+            .key(Property.ofExpression("{{ inputs.key }}"))
+            .value(Property.ofExpression("{{ inputs.value }}"))
             .overwrite(Property.ofValue(false))
             .build().run(runContext));
         assertThat(exception.getMessage()).isEqualTo("Cannot set value for key '%s'. Key already exists and `overwrite` is set to `false`.".formatted(key));

--- a/scheduler/src/test/java/io/kestra/scheduler/SchedulerPollingTriggerTest.java
+++ b/scheduler/src/test/java/io/kestra/scheduler/SchedulerPollingTriggerTest.java
@@ -153,7 +153,7 @@ public class SchedulerPollingTriggerTest extends AbstractSchedulerTest {
                 List.of(
                     Expression.builder()
                         .type(Expression.class.getName())
-                        .expression(new Property<>("{{ trigger.date | date() < now() }}"))
+                        .expression(Property.ofExpression("{{ trigger.date | date() < now() }}"))
                         .build()
                 ))
             .build();

--- a/scheduler/src/test/java/io/kestra/scheduler/SchedulerScheduleTest.java
+++ b/scheduler/src/test/java/io/kestra/scheduler/SchedulerScheduleTest.java
@@ -499,7 +499,7 @@ public class SchedulerScheduleTest extends AbstractSchedulerTest {
                 List.of(
                     Expression.builder()
                         .type(Expression.class.getName())
-                        .expression(new Property<>("{{ trigger.date | date() < now() }}"))
+                        .expression(Property.ofExpression("{{ trigger.date | date() < now() }}"))
                         .build()
                 )
             )

--- a/scheduler/src/test/java/io/kestra/scheduler/SchedulerTriggerChangeTest.java
+++ b/scheduler/src/test/java/io/kestra/scheduler/SchedulerTriggerChangeTest.java
@@ -80,7 +80,7 @@ public class SchedulerTriggerChangeTest extends AbstractSchedulerTest {
             .tasks(Collections.singletonList(Return.builder()
                 .id("test")
                 .type(Return.class.getName())
-                .format(new Property<>("{{ inputs.testInputs }}"))
+                .format(Property.ofExpression("{{ inputs.testInputs }}"))
                 .build())
             )
             .build();

--- a/webserver/src/test/java/io/kestra/webserver/controllers/api/FlowControllerTest.java
+++ b/webserver/src/test/java/io/kestra/webserver/controllers/api/FlowControllerTest.java
@@ -1081,7 +1081,7 @@ class FlowControllerTest {
         return Return.builder()
             .id(id)
             .type(Return.class.getName())
-            .format(new Property<>(format))
+            .format(Property.ofValue(format))
             .build();
     }
 


### PR DESCRIPTION
### What changes are being made and why?

This PR refactors tests that used the deprecated `new Property<>(String)` constructor.  
They are now replaced with either:
- `Property.ofExpression()` for Pebble expressions.
- `Property.ofValue()` for literal values.

This removes usage of deprecated constructors and aligns the code with current API recommendations.

Closes #12098

---

### How the changes have been QAed?

All affected tests were successfully run locally to verify compatibility.  
No functional behavior was modified — only the constructor invocations were updated.


