### PR TITLE
Fix ExecutionUpdatableTask attempt state tracking to record proper duration

### DIFF
--- a/core/src/test/java/io/kestra/plugin/core/flow/RuntimeLabelsTest.java
+++ b/core/src/test/java/io/kestra/plugin/core/flow/RuntimeLabelsTest.java
@@ -8,6 +8,8 @@ import io.kestra.core.junit.annotations.KestraTest;
 import io.kestra.core.junit.annotations.LoadFlows;
 import io.kestra.core.models.Label;
 import io.kestra.core.models.executions.Execution;
+import io.kestra.core.models.executions.TaskRun;
+import io.kestra.core.models.executions.TaskRunAttempt;
 import io.kestra.core.models.flows.State;
 import io.kestra.core.queues.QueueException;
 import io.kestra.core.runners.TestRunnerUtils;
@@ -58,6 +60,14 @@ class RuntimeLabelsTest {
             new Label("keyFromList", "valueFromList"),
             new Label("keyFromExecution", "valueFromExecution"),
             new Label("overriddenExecutionLabelKey", labelsOverriderTaskRunId));
+
+        TaskRun labelTaskRun = execution.findTaskRunsByTaskId("override-labels").getFirst();
+        TaskRunAttempt labelRunAttempt = labelTaskRun.lastAttempt();
+
+        assertThat(labelRunAttempt.getState().getCurrent()).isEqualTo(State.Type.SUCCESS);
+        assertThat(labelRunAttempt.getState().getHistories().size()).isEqualTo(3);
+        assertThat(labelRunAttempt.getState().getHistories()).extracting(State.History::getState)
+            .containsExactly(State.Type.CREATED, State.Type.RUNNING, State.Type.SUCCESS);
     }
 
 
@@ -69,6 +79,15 @@ class RuntimeLabelsTest {
 
         String labelsTaskRunId = execution.findTaskRunsByTaskId("labels").getFirst().getId();
         assertThat(execution.getLabels()).contains(new Label("someLabel", labelsTaskRunId));
+
+        TaskRun labelTaskRun = execution.findTaskRunsByTaskId("labels").getFirst();
+        TaskRunAttempt labelRunAttempt = labelTaskRun.lastAttempt();
+
+        assertThat(labelRunAttempt.getState().getCurrent()).isEqualTo(State.Type.SUCCESS);
+        assertThat(labelRunAttempt.getState().getHistories().size()).isEqualTo(3);
+        assertThat(labelRunAttempt.getState().getHistories()).extracting(State.History::getState)
+            .containsExactly(State.Type.CREATED, State.Type.RUNNING, State.Type.SUCCESS);
+
     }
 
     @Test
@@ -102,6 +121,15 @@ class RuntimeLabelsTest {
             new Label("floatValue", "3.14"),
             new Label("taskRunId", labelsTaskRunId),
             new Label("existingLabel", "someValue"));
+
+        TaskRun labelTaskRun = execution.findTaskRunsByTaskId("update-labels").getFirst();
+        TaskRunAttempt labelRunAttempt = labelTaskRun.lastAttempt();
+
+        assertThat(labelRunAttempt.getState().getCurrent()).isEqualTo(State.Type.SUCCESS);
+        assertThat(labelRunAttempt.getState().getHistories().size()).isEqualTo(3);
+        assertThat(labelRunAttempt.getState().getHistories()).extracting(State.History::getState)
+            .containsExactly(State.Type.CREATED, State.Type.RUNNING, State.Type.SUCCESS);
+
     }
 
     @Test
@@ -136,6 +164,14 @@ class RuntimeLabelsTest {
             new Label("boolValue", "true"),
             new Label("floatValue", "3.14"),
             new Label("taskRunId", labelsTaskRunId));
+
+        TaskRun labelTaskRun = execution.findTaskRunsByTaskId("update-labels").getFirst();
+        TaskRunAttempt labelRunAttempt = labelTaskRun.lastAttempt();
+
+        assertThat(labelRunAttempt.getState().getCurrent()).isEqualTo(State.Type.SUCCESS);
+        assertThat(labelRunAttempt.getState().getHistories().size()).isEqualTo(3);
+        assertThat(labelRunAttempt.getState().getHistories()).extracting(State.History::getState)
+            .containsExactly(State.Type.CREATED, State.Type.RUNNING, State.Type.SUCCESS);
     }
 
     @Test
@@ -159,6 +195,14 @@ class RuntimeLabelsTest {
             new Label("fromStringKey", "value2"),
             new Label("fromListKey", "value2")
         );
+
+        TaskRun labelTaskRun = execution.findTaskRunsByTaskId("from-string").getFirst();
+        TaskRunAttempt labelRunAttempt = labelTaskRun.lastAttempt();
+
+        assertThat(labelRunAttempt.getState().getCurrent()).isEqualTo(State.Type.SUCCESS);
+        assertThat(labelRunAttempt.getState().getHistories().size()).isEqualTo(3);
+        assertThat(labelRunAttempt.getState().getHistories()).extracting(State.History::getState)
+            .containsExactly(State.Type.CREATED, State.Type.RUNNING, State.Type.SUCCESS);
     }
 
     @Test
@@ -180,5 +224,11 @@ class RuntimeLabelsTest {
         assertThat(execution.getLabels()).containsExactly(
             new Label(Label.CORRELATION_ID, execution.getId())
         );
+
+        TaskRun labelTaskRun = execution.findTaskRunsByTaskId("from-string").getFirst();
+        TaskRunAttempt labelRunAttempt = labelTaskRun.lastAttempt();
+
+        assertThat(labelRunAttempt.getState().getCurrent()).isEqualTo(State.Type.FAILED);
+        assertThat(labelRunAttempt.getState().getHistories().size()).isEqualTo(1);
     }
 }

--- a/executor/src/main/java/io/kestra/executor/ExecutorService.java
+++ b/executor/src/main/java/io/kestra/executor/ExecutorService.java
@@ -1081,22 +1081,9 @@ public class ExecutorService {
                         return false;
                     }
 
-                    List<TaskRunAttempt> attempts = workerTask.getTaskRun().getAttempts();
-                    if (attempts == null || attempts.isEmpty()) {
-                        attempts = new ArrayList<>();
-                        attempts.add(TaskRunAttempt.builder().state(new State()).build());
-                    } else {
-                        attempts = new ArrayList<>(attempts);
-                    }
-
-                    // Update attempt to RUNNING before task execution
-                    int lastIndex = attempts.size() - 1;
-                    TaskRunAttempt runningAttempt = attempts.getLast().withState(State.Type.RUNNING);
-                    attempts.set(lastIndex, runningAttempt);
-
                     TaskRun runningTaskRun = workerTask
                         .getTaskRun()
-                        .withAttempts(attempts)
+                        .withAttempts(List.of(TaskRunAttempt.builder().state(new State().withState(State.Type.RUNNING)).build()))
                         .withState(State.Type.RUNNING);
 
                     executor.withExecution(
@@ -1109,14 +1096,12 @@ public class ExecutorService {
                         .resolveState(workerTask.getRunContext(), executor.getExecution())
                         .orElse(State.Type.SUCCESS);
 
-                    lastIndex = attempts.size() - 1;
-                    TaskRunAttempt terminalAttempt = attempts.getLast().withState(terminalState);
-                    attempts.set(lastIndex, terminalAttempt);
+                    TaskRunAttempt terminalAttempt = runningTaskRun.lastAttempt().withState(terminalState);
 
                     workerTaskResults.add(
                         WorkerTaskResult.builder()
                             .taskRun(runningTaskRun
-                                .withAttempts(attempts)
+                                .withAttempts(List.of(terminalAttempt))
                                 .withState(terminalState)
                             )
                             .build()

--- a/executor/src/main/java/io/kestra/executor/ExecutorService.java
+++ b/executor/src/main/java/io/kestra/executor/ExecutorService.java
@@ -1065,14 +1065,12 @@ public class ExecutorService {
 
         executor.getWorkerTasks()
             .removeIf(workerTask -> {
-                if (!(workerTask.getTask() instanceof ExecutionUpdatableTask)) {
+                if (!(workerTask.getTask() instanceof ExecutionUpdatableTask executionUpdatingTask)) {
                     return false;
                 }
 
-                var executionUpdatingTask = (ExecutionUpdatableTask) workerTask.getTask();
-
                 try {
-                    // handle runIf
+                    // Skip task if runIf condition is false
                     if (!TruthUtils.isTruthy(workerTask.getRunContext().render(workerTask.getTask().getRunIf()))) {
                         executor.withExecution(
                             executor
@@ -1083,19 +1081,43 @@ public class ExecutorService {
                         return false;
                     }
 
+                    List<TaskRunAttempt> attempts = workerTask.getTaskRun().getAttempts();
+                    if (attempts == null || attempts.isEmpty()) {
+                        attempts = new ArrayList<>();
+                        attempts.add(TaskRunAttempt.builder().state(new State()).build());
+                    } else {
+                        attempts = new ArrayList<>(attempts);
+                    }
+
+                    // Update attempt to RUNNING before task execution
+                    int lastIndex = attempts.size() - 1;
+                    TaskRunAttempt runningAttempt = attempts.getLast().withState(State.Type.RUNNING);
+                    attempts.set(lastIndex, runningAttempt);
+
+                    TaskRun runningTaskRun = workerTask
+                        .getTaskRun()
+                        .withAttempts(attempts)
+                        .withState(State.Type.RUNNING);
+
                     executor.withExecution(
                         executionUpdatingTask.update(executor.getExecution(), workerTask.getRunContext())
-                            .withTaskRun(workerTask.getTaskRun().withState(State.Type.RUNNING)),
+                            .withTaskRun(runningTaskRun),
                         "handleExecutionUpdatingTask.updateExecution"
                     );
 
-                    var taskState = executionUpdatingTask.resolveState(workerTask.getRunContext(), executor.getExecution()).orElse(State.Type.SUCCESS);
+                    var terminalState = executionUpdatingTask
+                        .resolveState(workerTask.getRunContext(), executor.getExecution())
+                        .orElse(State.Type.SUCCESS);
+
+                    lastIndex = attempts.size() - 1;
+                    TaskRunAttempt terminalAttempt = attempts.getLast().withState(terminalState);
+                    attempts.set(lastIndex, terminalAttempt);
+
                     workerTaskResults.add(
                         WorkerTaskResult.builder()
-                            .taskRun(workerTask.getTaskRun().withAttempts(
-                                        Collections.singletonList(TaskRunAttempt.builder().state(new State().withState(taskState)).build())
-                                    )
-                                    .withState(taskState)
+                            .taskRun(runningTaskRun
+                                .withAttempts(attempts)
+                                .withState(terminalState)
                             )
                             .build()
                     );


### PR DESCRIPTION
This PR ensures that ExecutionUpdatableTask attempts properly record state transitions (**CREATED → RUNNING → SUCCESS**) with accurate timestamps, enabling correct duration tracking and complete attempt history visibility in the UI.

closes #12177 

## What changes are being made and why?

The `handleExecutionUpdatingTask` method was creating attempt records with only the CREATED and terminal states, skipping the RUNNING state transition. This caused the **RUNNING state to be missing** from attempt history, resulting in incomplete execution timeline in UI.

The fix updates the same attempt object through complete state transitions:

1. Before task execution: transition attempt from **CREATED → RUNNING**
2. After task execution: transition attempt from **RUNNING → terminal state**

## How the changes have been QAed?

**Before** 

<img width="1217" height="704" alt="Screenshot 2025-10-21 at 6 15 11 PM" src="https://github.com/user-attachments/assets/f71bc81d-3dfd-4d86-8ff6-81e4f156a226" />

*Missing RUNNING state: Only CREATED and SUCCESS states visible*

**After**

<img width="1217" height="704" alt="Screenshot 2025-10-21 at 6 13 04 PM" src="https://github.com/user-attachments/assets/847f5eae-94fb-4f55-9003-7d1bd4c8ca87" />

*Complete state progression: CREATED → RUNNING → SUCCESS with distinct timestamps*

**Verification:**

- Complete state progression: CREATED → RUNNING → terminal
- UI displays proper attempt timeline
- No regression for skipped tasks (CREATED → SKIPPED)