### PR TITLE
fix(ui): amend blueprint page translation key #12193

### DIFF
--- a/ui/src/override/components/flows/blueprints/BlueprintsBrowser.vue
+++ b/ui/src/override/components/flows/blueprints/BlueprintsBrowser.vue
@@ -23,7 +23,7 @@
                             <el-col :xs="24">
                                 <el-input
                                     v-model="searchText"
-                                    :placeholder="$t('search.blueprint')"
+                                    :placeholder="$t('search blueprint')"
                                     clearable
                                     @input="updateSearch"
                                 />

--- a/ui/src/override/components/flows/blueprints/BlueprintsBrowser.vue
+++ b/ui/src/override/components/flows/blueprints/BlueprintsBrowser.vue
@@ -23,7 +23,7 @@
                             <el-col :xs="24">
                                 <el-input
                                     v-model="searchText"
-                                    :placeholder="$t('Search or choose filters...')"
+                                    :placeholder="$t('search.blueprint')"
                                     clearable
                                     @input="updateSearch"
                                 />


### PR DESCRIPTION
### What changes are being made and why?

Closes #12193
This PR replaces the current placeholder text in the blueprint search bar with the correct, existing translation key `search.blueprint`, as requested in the issue.