### PR TITLE
Fix/loop visualization back edge

### DIFF
--- a/core/src/main/java/io/kestra/core/models/hierarchies/FlowGraph.java
+++ b/core/src/main/java/io/kestra/core/models/hierarchies/FlowGraph.java
@@ -17,22 +17,54 @@ public class FlowGraph {
     List<String> flowables;
 
     public static FlowGraph of(GraphCluster graph) throws IllegalVariableEvaluationException {
-        return FlowGraph.builder()
-            .nodes(GraphUtils.nodes(graph))
-            .edges(GraphUtils.edges(graph))
-            .clusters(GraphUtils.clusters(graph, new ArrayList<>())
-                .stream()
-                .map(g -> new Cluster(g.getKey(), g.getKey().getGraph()
+        // Build base nodes, edges and clusters from the underlying graph
+        var nodes = GraphUtils.nodes(graph);
+        var edges = new ArrayList<Edge>(GraphUtils.edges(graph));
+
+        var clusters = GraphUtils.clusters(graph, new ArrayList<>())
+            .stream()
+            .map(g -> new Cluster(
+                g.getKey(),
+                g.getKey().getGraph()
                     .nodes()
                     .stream()
                     .map(AbstractGraph::getUid)
                     .toList(),
-                    g.getValue(),
-                    g.getKey().getRoot().getUid(),
-                    g.getKey().getEnd().getUid()
-                ))
-                .toList()
-            )
+                g.getValue(),
+                g.getKey().getRoot().getUid(),
+                g.getKey().getEnd().getUid()
+            ))
+            .toList();
+
+        // Visualization-only enhancement: for LoopUntil/WaitFor clusters, add a back-edge from end to start
+        // This makes cycles obvious in the UI without altering the runtime GraphCluster (avoids introducing cycles there).
+        clusters.forEach(c -> {
+            try {
+                if (c.getCluster() instanceof GraphCluster cluster && cluster.getTaskNode() instanceof AbstractGraphTask taskNode) {
+                    var task = taskNode.getTask();
+                    if (task != null) {
+                        String type = task.getType();
+                        // Match on canonical type name; alias "WaitFor" maps to LoopUntil but we include it defensively
+                        boolean isLoop = type != null && (type.endsWith(".LoopUntil") || type.endsWith(".WaitFor")
+                            || type.contains("io.kestra.plugin.core.flow.LoopUntil") || type.contains("io.kestra.plugin.core.flow.WaitFor"));
+                        if (isLoop && c.getStart() != null && c.getEnd() != null) {
+                            edges.add(new Edge(
+                                c.getEnd(),
+                                c.getStart(),
+                                new Relation(null, null) // no specific relation type; renderer will still show the arrow
+                            ));
+                        }
+                    }
+                }
+            } catch (Exception ignored) {
+                // Defensive: never break graph generation due to visualization-only enhancement
+            }
+        });
+
+        return FlowGraph.builder()
+            .nodes(nodes)
+            .edges(edges)
+            .clusters(clusters)
             .build();
     }
 

--- a/core/src/test/java/io/kestra/core/models/hierarchies/LoopUntilGraphBackEdgeTest.java
+++ b/core/src/test/java/io/kestra/core/models/hierarchies/LoopUntilGraphBackEdgeTest.java
@@ -1,0 +1,47 @@
+package io.kestra.core.models.hierarchies;
+
+import io.kestra.core.exceptions.IllegalVariableEvaluationException;
+import io.kestra.core.models.flows.FlowWithSource;
+import io.kestra.core.serializers.YamlParser;
+import io.kestra.core.utils.TestsUtils;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URL;
+import java.nio.file.Files;
+
+import static io.kestra.core.tenant.TenantService.MAIN_TENANT;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class LoopUntilGraphBackEdgeTest {
+
+    @Test
+    void waitFor_hasBackEdgeFromEndToStart() throws IOException, IllegalVariableEvaluationException {
+        FlowWithSource flow = parse("flows/valids/waitfor-no-success.yaml");
+
+        FlowGraph flowGraph = io.kestra.core.utils.GraphUtils.flowGraph(flow, null);
+
+        // look for an edge that goes from the LoopUntil/WaitFor cluster end to its start
+        boolean hasBackEdge = flowGraph.getEdges().stream().anyMatch(e ->
+            e.getSource().matches("root\\.waitfor\\.end-.*") &&
+                e.getTarget().matches("root\\.waitfor\\.root-.*")
+        );
+
+        assertThat(hasBackEdge)
+            .as("Expected an end->start back-edge for waitfor/LoopUntil cluster")
+            .isTrue();
+    }
+
+    private static FlowWithSource parse(String path) throws IOException {
+        URL resource = TestsUtils.class.getClassLoader().getResource(path);
+        assert resource != null;
+
+        File file = new File(resource.getFile());
+
+        return YamlParser.parse(file, FlowWithSource.class).toBuilder()
+            .tenantId(MAIN_TENANT)
+            .source(Files.readString(file.toPath()))
+            .build();
+    }
+}


### PR DESCRIPTION
### What changes are being made and why?

Modified the FlowGraph generation to add a visual back-edge for LoopUntil and WaitFor tasks in the topology view. Previously, these loop cycles were hard to see because there was no visual line showing the loop back to the start of the task.

The change detects LoopUntil/WaitFor clusters during graph generation and appends a visualization-only edge from the cluster end back to its start. This makes the loop cycle immediately visible in the topology without affecting runtime execution or scheduling logic.

Closes #12136

---

### How the changes have been QAed?

All existing FlowGraph tests pass, including 14 tests in FlowGraphTest. Added a new test `LoopUntilGraphBackEdgeTest` that verifies the back-edge is created for WaitFor/LoopUntil flows.

Example flow showing the loop visualization (uses existing test flow):

```yaml
id: waitfor-no-success
namespace: io.kestra.tests

tasks:
  - id: waitfor
    type: io.kestra.plugin.core.flow.WaitFor
    condition: "{{ outputs.output_values.values.count == '6'}}"
    checkFrequency:
      maxIterations: 5
      interval: PT0.2S
    tasks:
      - id: output_values
        type: io.kestra.plugin.core.output.OutputValues
        values:
          count: "{{ outputs.waitfor.iterationCount + 1 }}"

When viewing this flow in the topology view, you will now see a visual arrow from the end of the waitfor cluster back to its start, making the loop cycle obvious.

Build completed successfully with no errors. The change is backward compatible and purely additive to the graph data structure.

kindly add the following hacktoberfest2025, hacktoberfestaccepted, hacktoberfest labesls, thanks
