### PR TITLE
chore(system): don't manage Micrometer and Micronaut OpenAPI

### DIFF
--- a/platform/build.gradle
+++ b/platform/build.gradle
@@ -12,7 +12,7 @@ javaPlatform {
 dependencies {
     // versions for libraries with multiple module but no BOM
     def slf4jVersion = "2.0.17"
-    def protobufVersion = "3.25.5" // Orc still uses 3.25.5 see https://github.com/apache/orc/blob/main/java/pom.xml
+    def protobufVersion = "3.25.5" // Orc still uses 3 see https://github.com/apache/orc/blob/main/java/pom.xml
     def bouncycastleVersion = "1.82"
     def mavenResolverVersion = "2.0.10"
     def jollydayVersion = "1.5.6"
@@ -76,11 +76,6 @@ dependencies {
         api "org.apache.kafka:kafka-streams:$kafkaVersion"
         // AWS CRT is not included in the AWS BOM but needed for the S3 Transfer manager
         api 'software.amazon.awssdk.crt:aws-crt:0.39.3'
-
-        // we need at least 0.14, it could be removed when Micronaut contains a recent only version in their BOM
-        api "io.micrometer:micrometer-core:1.15.5"
-        // We need at least 6.17, it could be removed when Micronaut contains a recent only version in their BOM
-        api "io.micronaut.openapi:micronaut-openapi-bom:6.18.1"
 
         // Other libs
         api("org.projectlombok:lombok:1.18.42")


### PR DESCRIPTION
Their version from the Micronaut BOM is now recent enought for our usage.

Closes https://github.com/kestra-io/kestra/pull/12222
