### PR TITLE
chore(versions): ignore protobuf 4 versions as we still need 3

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,6 +14,10 @@ updates:
     open-pull-requests-limit: 50
     labels:
       - "dependency-upgrade"
+    ignore:
+      - dependency-name: "com.google.protobuf:*"
+        # Ignore versions of Protobuf that are equal to or greater than 4.0.0 as Orc still uses 3
+        versions: [ "[4,)" ]
 
   # Maintain dependencies for Gradle modules
   - package-ecosystem: "gradle"


### PR DESCRIPTION
I'm not 100% sure of the dependabot syntax with Maven groupid but the doc points into that direction.