### PR TITLE
(Fix: UI) Fixed the line between dots

### DIFF
--- a/ui/src/components/layout/Timeline.vue
+++ b/ui/src/components/layout/Timeline.vue
@@ -147,7 +147,7 @@
                 top: 50%;
                 left: 50%;
                 transform: translateY(-50%);
-                width: calc(100% - 15px);
+                width: calc(100% - 6px);
                 height: 1px;
             }
         }


### PR DESCRIPTION
Closes [#12209](https://github.com/kestra-io/kestra/issues/12209)

### What does this PR do?

I have changed the scss code so that the stepper/progress bar component's line touches the dot of progress as mentioned in the issue. I noticed that the width is subtracted from 100% because the line was overflowing into the dots. But the subtraction was a bit too much and was not connecting the dots together. Hence I reduced it in the PR as shown below. 

I hope this gets merged and the UI bug gets solved.

I am attaching a screenshot for reference.
 
<img width="1292" height="166" alt="image" src="https://github.com/user-attachments/assets/c7b95343-24f4-4818-a2f6-cff64396f3f8" />
