### PR TITLE
fix(timeline): connect timeline dots by setting width to 100% (#12209)

### DIFF
--- a/ui/src/components/layout/Timeline.vue
+++ b/ui/src/components/layout/Timeline.vue
@@ -147,7 +147,7 @@
                 top: 50%;
                 left: 50%;
                 transform: translateY(-50%);
-                width: calc(100% - 15px);
+                width: 100%;
                 height: 1px;
             }
         }


### PR DESCRIPTION
### Summary
Fixes a small visual gap between timeline dots in the UI.

Previously, the connector line used:
width: calc(100% - 15px);

This caused a visible break between items.
Updated to:
width: 100%;

to ensure continuous alignment between dots.

### Fixes
Closes #12209 

### Type of Change
- 🐛 Bug fix (non-breaking UI fix)

### Verification
- Visually tested on multiple breakpoints
- Confirmed no overflow or layout regressions
