### PR TITLE
Fix: Replace deprecated setSerializationInclusion with setDefaultPropertyInclusion

### DIFF
--- a/core/src/main/java/io/kestra/core/models/flows/Flow.java
+++ b/core/src/main/java/io/kestra/core/models/flows/Flow.java
@@ -49,7 +49,7 @@ import java.util.stream.Stream;
 public class Flow extends AbstractFlow implements HasUID {
     private static final ObjectMapper NON_DEFAULT_OBJECT_MAPPER = JacksonMapper.ofYaml()
         .copy()
-        .setSerializationInclusion(JsonInclude.Include.NON_DEFAULT);
+        .setDefaultPropertyInclusion(JsonInclude.Include.NON_DEFAULT);
 
     private static final ObjectMapper WITHOUT_REVISION_OBJECT_MAPPER = NON_DEFAULT_OBJECT_MAPPER.copy()
         .configure(SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS, true)

--- a/core/src/main/java/io/kestra/core/models/flows/FlowInterface.java
+++ b/core/src/main/java/io/kestra/core/models/flows/FlowInterface.java
@@ -136,7 +136,7 @@ public interface FlowInterface extends FlowId, DeletedInterface, TenantInterface
     class SourceGenerator {
         private static final ObjectMapper NON_DEFAULT_OBJECT_MAPPER = JacksonMapper.ofJson()
             .copy()
-            .setSerializationInclusion(JsonInclude.Include.NON_DEFAULT);
+            .setDefaultPropertyInclusion(JsonInclude.Include.NON_DEFAULT);
 
         static String generate(final FlowInterface flow) {
             try {

--- a/core/src/main/java/io/kestra/core/models/templates/Template.java
+++ b/core/src/main/java/io/kestra/core/models/templates/Template.java
@@ -44,7 +44,7 @@ public class Template implements DeletedInterface, TenantInterface, HasUID {
                 return exclusions.contains(m.getName()) || super.hasIgnoreMarker(m);
             }
         })
-        .setSerializationInclusion(JsonInclude.Include.NON_DEFAULT);
+        .setDefaultPropertyInclusion(JsonInclude.Include.NON_DEFAULT);
 
     @Setter
     @Hidden

--- a/core/src/main/java/io/kestra/core/serializers/JacksonMapper.java
+++ b/core/src/main/java/io/kestra/core/serializers/JacksonMapper.java
@@ -140,7 +140,7 @@ public final class JacksonMapper {
 
         return mapper
             .configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false)
-            .setSerializationInclusion(JsonInclude.Include.NON_NULL)
+            .setDefaultPropertyInclusion(JsonInclude.Include.NON_NULL)
             .registerModule(new JavaTimeModule())
             .registerModule(new Jdk8Module())
             .registerModule(new ParameterNamesModule())
@@ -153,7 +153,7 @@ public final class JacksonMapper {
 
     private static ObjectMapper createIonObjectMapper() {
         return configure(new IonObjectMapper(new IonFactory(createIonSystem())))
-            .setSerializationInclusion(JsonInclude.Include.ALWAYS)
+            .setDefaultPropertyInclusion(JsonInclude.Include.ALWAYS)
             .registerModule(new IonModule());
     }
 
@@ -172,7 +172,7 @@ public final class JacksonMapper {
 
         return Pair.of(patch, revert);
     }
-    
+
     public static JsonNode applyPatchesOnJsonNode(JsonNode jsonObject, List<JsonNode> patches) {
         for (JsonNode patch : patches) {
             try {

--- a/core/src/main/java/io/kestra/core/services/PluginDefaultService.java
+++ b/core/src/main/java/io/kestra/core/services/PluginDefaultService.java
@@ -58,10 +58,10 @@ import java.util.stream.Stream;
 public class PluginDefaultService {
     private static final ObjectMapper NON_DEFAULT_OBJECT_MAPPER = JacksonMapper.ofYaml()
         .copy()
-        .setSerializationInclusion(JsonInclude.Include.NON_DEFAULT);
+        .setDefaultPropertyInclusion(JsonInclude.Include.NON_DEFAULT);
 
     private static final ObjectMapper OBJECT_MAPPER = JacksonMapper.ofYaml().copy()
-        .setSerializationInclusion(JsonInclude.Include.NON_NULL);
+        .setDefaultPropertyInclusion(JsonInclude.Include.NON_NULL);
     private static final String PLUGIN_DEFAULTS_FIELD = "pluginDefaults";
 
     private static final TypeReference<List<PluginDefault>> PLUGIN_DEFAULTS_TYPE_REF = new TypeReference<>() {

--- a/core/src/main/java/io/kestra/plugin/core/trigger/Webhook.java
+++ b/core/src/main/java/io/kestra/plugin/core/trigger/Webhook.java
@@ -131,7 +131,7 @@ import jakarta.validation.constraints.Size;
 @WebhookValidation
 public class Webhook extends AbstractTrigger implements TriggerOutput<Webhook.Output> {
     private static final ObjectMapper MAPPER = JacksonMapper.ofJson().copy()
-        .setSerializationInclusion(JsonInclude.Include.USE_DEFAULTS);
+        .setDefaultPropertyInclusion(JsonInclude.Include.USE_DEFAULTS);
 
     @Size(max = 256)
     @NotNull


### PR DESCRIPTION
This PR replaces all usages of the deprecated `ObjectMapper.setSerializationInclusion()` method with `ObjectMapper.setDefaultPropertyInclusion()` throughout the codebase.

Closes #12288 

## What changes are being made and why?

The `ObjectMapper.setSerializationInclusion()` method was deprecated in Jackson 2.7 and will be removed in Jackson 3.0. This PR replaces all usages with the recommended `setDefaultPropertyInclusion()` method.

This is a direct 1:1 replacement with **no behavioral changes** - the serialization logic (NON_NULL, NON_DEFAULT, etc.) remains identical.

## How the changes have been QAed?

**Verification:**
- ✅ Project-wide search confirms zero remaining usages of deprecated method (see screenshot)
- ✅ Code compiles successfully with no errors
- ✅ No functional changes - serialization behavior is identical

**Screenshot:**

<img width="694" height="685" alt="Screenshot 2025-10-23 at 7 14 34 PM" src="https://github.com/user-attachments/assets/7a928201-eb00-4c66-88fc-aee514e073de" />

*Verified all deprecated method calls have been replaced*