### PR TITLE
fix: avoid nuking comments when changing top level

### DIFF
--- a/ui/src/components/no-code/NoCode.vue
+++ b/ui/src/components/no-code/NoCode.vue
@@ -81,13 +81,13 @@
             typeof val === "object" && !Array.isArray(val)
                 ? removeNullAndUndefined(val)
                 : val; // Handle null values
+        
 
-
-        const currentFlow = parsedFlow.value;
-
-        currentFlow[key] = realValue;
-
-        editorUpdate(YAML_UTILS.stringify(currentFlow));
+        editorUpdate(YAML_UTILS.replaceBlockWithPath({
+            source: flowStore.flowYaml ?? "",
+            path: key,
+            newContent: YAML_UTILS.stringify(realValue),
+        }));
     }
 
     const lastValidFlowYaml = computed<string>(
@@ -104,7 +104,6 @@
     const {
         fieldsFromSchemaTop,
         fieldsFromSchemaRest,
-        parsedFlow,
     } = useFlowFields(lastValidFlowYaml)
 
     useKeyboardSave()


### PR DESCRIPTION
See the bug here tested on https://postgres-oss.preview.dev.kestra.io/ui/main/flows/new

https://github.com/user-attachments/assets/196d9f57-6c80-4549-a933-4a86fa752f30

