### PR TITLE
fix(ui/secrets): redesign secret page to align it's design style with other enterprise Edition Pages

### DIFF
--- a/ui/src/components/secrets/Secrets.vue
+++ b/ui/src/components/secrets/Secrets.vue
@@ -15,17 +15,20 @@
         :class="miscStore.configs?.secretsEnabled === undefined ? 'mt-0 p-0' : 'container'"
     >
         <EmptyTemplate v-if="miscStore.configs?.secretsEnabled === undefined" class="d-flex flex-column text-start m-0 p-0 mw-100">
-            <div class="no-secret-manager-block d-flex flex-column gap-6 mt-3">
+            <div class="no-secret-manager-block d-flex flex-column gap-6 mt-5">
                 <div class="header-block d-flex align-items-center">
                     <div class="d-flex flex-column">
-                        <div class="d-flex flex-row gap-2">
+                        <div class="d-flex flex-column gap-2">
                             <div class="d-flex flex-column align-items-start justify-content-center">
-                                <h5 class="fw-bold">
+                                <img :src="sourceImg" :alt="$t('demos.secrets.title')" class="img-wrapper">
+                                <div class="enterprise-tag">
+                                    <div class="flare" />
+                                    {{ $t('demos.enterprise_edition') }}
+                                </div>
+                                <h5 class="fw-bold mb-4 m-auto">
                                     {{ $t('demos.secrets.title') }}
                                 </h5>
-                                <p>{{ $t('demos.secrets.message') }}</p>
                             </div>
-                            <img :src="sourceImg" :alt="$t('demos.secrets.title')" class="img-wrapper">
                         </div>
                         <div>
                             <div v-if="isOnline" class="video-container">
@@ -33,7 +36,8 @@
                                     src="https://www.youtube.com/embed/u0yuOYG-qMI"
                                 />
                             </div>
-                            <DemoButtons />
+                            <p>{{ $t('demos.secrets.message') }}</p>
+                            <DemoButtons class="mb-3" />
                         </div>
                     </div>
                 </div>
@@ -110,8 +114,10 @@
 </script>
 
 <style scoped lang="scss">
+    @import "@kestra-io/ui-libs/src/scss/color-palette.scss";
+
     .no-secret-manager-block {
-        padding: 0 10.75rem;
+        padding: 0 7.75rem;
 
         *[style*="display: none"] { display: none !important }
 
@@ -123,11 +129,103 @@
             }
 
             .img-wrapper {
-                width: 350px;
-                height: 300px;
+                width: 250px;
+                height: 200px;
                 overflow: visible;
                 direction: rtl;
+                margin: 0 auto;
             }
+        }
+
+        .enterprise-tag::before,
+        .enterprise-tag::after{
+            content: "";
+            display: block;
+            position: absolute;
+            border-radius: 1rem;
+        }
+
+        .enterprise-tag::before{
+            z-index: -2;
+            background-image: linear-gradient(138.8deg, #CCE8FE 0%, #CDA0FF 27.03%, #8489F5 41.02%, #CDF1FF 68.68%, #B591E9 94%, #CCE8FE 100%);
+            background-size: 200% 200%;
+            top: 0px;
+            bottom: 0px;
+            left: 0px;
+            right: 0px;
+            animation: move-border 3s linear infinite;
+        }
+
+        .enterprise-tag::after{
+            z-index: -1;
+            background: $base-gray-100;
+            top: 1px;
+            left: 1px;
+            bottom: 1px;
+            right: 1px;
+            html.dark & {
+                background: $base-gray-400;
+            }
+        }
+
+        .enterprise-tag{
+            position: relative;
+            top: -1.5rem;
+            background: $base-gray-200;
+            padding: .125rem 1rem;
+            border-radius: 1rem;
+            display: inline-block;
+            z-index: 2;
+            margin: 0 auto;
+            html.dark &{
+                background: #FBFBFB26;
+            }
+            .flare{
+                display: none;
+                position: absolute;
+                content: "";
+                height: 2rem;
+                width: 2rem;
+                z-index: 12;
+                top: -1.1rem;
+                right: 0;
+                background-image:
+                    // vertical flare
+                    linear-gradient(0deg, rgba($base-gray-200, 0) 0%, $base-gray-200 50%, rgba($base-gray-200, 0) 100%),
+                    // horizontal flare
+                    linear-gradient(90deg, rgba($base-gray-200, 0) 0%, $base-gray-200 50%, rgba($base-gray-200, 0) 100%),
+                    // flare effect
+                    radial-gradient(circle, $base-gray-200 0%, rgba($base-gray-200, .1) 50%,rgba($base-gray-200, 0) 70%);
+                background-size:  1px 100%, 100% 1px, 40% 40%;
+                background-repeat: no-repeat;
+                background-position: center, center, center;
+                transform:rotate(-13deg);
+                &::before{
+                    content: "";
+                    display: block;
+                    position: absolute;
+                    height: 2rem;
+                    width: 2rem;
+                    background-image:
+                        // vertical flare
+                        linear-gradient(0deg, rgba($base-gray-200, 0) 0%, rgba($base-gray-200, .7) 50%, rgba($base-gray-200, 0) 100%),
+                        // horizontal flare
+                        linear-gradient(90deg, rgba($base-gray-200, 0) 0%, rgba($base-gray-200, .7) 50%, rgba($base-gray-200, 0) 100%);
+                    background-size:  1px 50%, 50% 1px;
+                    background-repeat: no-repeat;
+                    background-position: center, center, center;
+                    transform: rotate(45deg);
+                }
+                html.dark &{
+                    display: block;
+                }
+            }
+        }
+
+        @keyframes move-border {
+            0%{background-position: 0% 0%}
+            50%{background-position: 100% 100%}
+            100%{background-position: 0% 0%}
         }
 
         .text-secondary {


### PR DESCRIPTION
in this pr, i redesign secret page, which was looks very odd because it was not following design guideline of other enterprise locked pages.

## Screenshot 
### Before
<img width="1033" height="428" alt="Screenshot from 2025-10-15 15-50-59" src="https://github.com/user-attachments/assets/47e704eb-9c1d-4ba2-b406-0eee21d98773" />


### After
<img width="1366" height="768" alt="image" src="https://github.com/user-attachments/assets/a917a920-baf2-4d3c-b5bb-3bd6f239b3ee" />

### Other Enterprise Edition Page
<img width="1366" height="768" alt="image" src="https://github.com/user-attachments/assets/236896ce-6e19-48cb-8e67-3d7bd4d4da0c" />
