### PR TITLE
Fix code snippets overlaying main UI in execution outputs

### DIFF
--- a/ui/src/components/executions/outputs/Wrapper.vue
+++ b/ui/src/components/executions/outputs/Wrapper.vue
@@ -52,7 +52,7 @@
                 </div>
             </el-splitter-panel>
             <el-splitter-panel>
-                <div class="right wrapper" :style="{'z-index': 999}">
+                <div class="right wrapper">
                     <div
                         v-if="multipleSelected || selectedValue"
                         class="w-100 overflow-auto p-3 content-container"
@@ -478,6 +478,8 @@
 
 .wrapper {
     background: var(--ks-background-card);
+    position: relative;
+    z-index: 1;
 }
 
 :deep(.el-cascader-menu) {
@@ -533,6 +535,8 @@
     overflow-x: hidden;
     word-wrap: break-word;
     word-break: break-word;
+    position: relative;
+    z-index: 0;
 }
 
 :deep(.el-collapse) {
@@ -559,5 +563,13 @@
     word-wrap: break-word !important;
     word-break: break-word !important;
     overflow-wrap: break-word !important;
+}
+
+// Ensure Monaco editors and other code snippets don't overlay other UI elements
+:deep(.monaco-editor),
+:deep(.editor-container),
+:deep(.complex-value-editor) {
+    position: relative !important;
+    z-index: auto !important;
 }
 </style>

--- a/ui/src/components/executions/outputs/Wrapper.vue
+++ b/ui/src/components/executions/outputs/Wrapper.vue
@@ -565,7 +565,6 @@
     overflow-wrap: break-word !important;
 }
 
-// Ensure Monaco editors and other code snippets don't overlay other UI elements
 :deep(.monaco-editor),
 :deep(.editor-container),
 :deep(.complex-value-editor) {


### PR DESCRIPTION
## Summary

Fixed z-index layering issue where code snippets in execution outputs were overlaying the main UI when scrolling. Removed inline `z-index: 999` and added proper CSS positioning to keep Monaco editors contained within their panel boundaries.

Closes #12370
ref: #12370