### PR TITLE
fix(executions): remove errors and finally tasks when restarting

### DIFF
--- a/core/src/main/java/io/kestra/core/services/ExecutionService.java
+++ b/core/src/main/java/io/kestra/core/services/ExecutionService.java
@@ -14,6 +14,7 @@ import io.kestra.core.models.flows.State;
 import io.kestra.core.models.flows.input.InputAndValue;
 import io.kestra.core.models.hierarchies.AbstractGraphTask;
 import io.kestra.core.models.hierarchies.GraphCluster;
+import io.kestra.core.models.tasks.FlowableTask;
 import io.kestra.core.models.tasks.ResolvedTask;
 import io.kestra.core.models.tasks.Task;
 import io.kestra.core.models.tasks.retrys.AbstractRetry;
@@ -121,21 +122,38 @@ public class ExecutionService {
      * Retry set the given taskRun in created state
      * and return the execution in running state
      **/
-    public Execution retryTask(Execution execution, String taskRunId) {
-        List<TaskRun> newTaskRuns = execution
-            .getTaskRunList()
-            .stream()
-            .map(taskRun -> {
-                if (taskRun.getId().equals(taskRunId)) {
-                    return taskRun
-                        .withState(State.Type.CREATED);
+    public Execution retryTask(Execution execution, Flow flow, String taskRunId) throws InternalException {
+        TaskRun taskRun = execution.findTaskRunByTaskRunId(taskRunId).withState(State.Type.CREATED);
+        List<TaskRun> taskRunList = execution.getTaskRunList();
+
+        if (taskRun.getParentTaskRunId() != null) {
+            // we need to find the parent to remove any errors or finally tasks already executed
+            TaskRun parentTaskRun = execution.findTaskRunByTaskRunId(taskRun.getParentTaskRunId());
+            Task parentTask = flow.findTaskByTaskId(parentTaskRun.getTaskId());
+            if (parentTask instanceof FlowableTask<?> flowableTask) {
+                if (flowableTask.getErrors() != null) {
+                    List<Task> allErrors = Stream.concat(flowableTask.getErrors().stream()
+                                .filter(task -> task.isFlowable() && ((FlowableTask<?>) task).getErrors() != null)
+                                .flatMap(task -> ((FlowableTask<?>) task).getErrors().stream()),
+                            flowableTask.getErrors().stream())
+                        .toList();
+                    allErrors.forEach(error -> taskRunList.removeIf(t -> t.getTaskId().equals(error.getId())));
                 }
 
-                return taskRun;
-            })
-            .toList();
+                if (flowableTask.getFinally() != null) {
+                    List<Task> allFinally = Stream.concat(flowableTask.getFinally().stream()
+                                .filter(task -> task.isFlowable() && ((FlowableTask<?>) task).getFinally() != null)
+                                .flatMap(task -> ((FlowableTask<?>) task).getFinally().stream()),
+                            flowableTask.getFinally().stream())
+                        .toList();
+                    allFinally.forEach(error -> taskRunList.removeIf(t -> t.getTaskId().equals(error.getId())));
+                }
+            }
 
-        return execution.withTaskRunList(newTaskRuns).withState(State.Type.RUNNING);
+            return execution.withTaskRunList(taskRunList).withTaskRun(taskRun).withState(State.Type.RUNNING);
+        }
+
+        return execution.withTaskRun(taskRun).withState(State.Type.RUNNING);
     }
 
     public Execution retryWaitFor(Execution execution, String flowableTaskRunId) {

--- a/core/src/test/java/io/kestra/plugin/core/flow/RetryCaseTest.java
+++ b/core/src/test/java/io/kestra/plugin/core/flow/RetryCaseTest.java
@@ -162,4 +162,9 @@ public class RetryCaseTest {
         assertThat(execution.getState().getCurrent()).isEqualTo(State.Type.FAILED);
     }
 
+    public void retryWithFlowableErrors(Execution execution) {
+        assertThat(execution.getState().getCurrent()).isEqualTo(State.Type.SUCCESS);
+        assertThat(execution.getTaskRunList()).hasSize(3);
+        assertThat(execution.getTaskRunList().get(2).attemptNumber()).isEqualTo(2);
+    }
 }

--- a/core/src/test/resources/flows/valids/retry-with-flowable-errors.yaml
+++ b/core/src/test/resources/flows/valids/retry-with-flowable-errors.yaml
@@ -1,0 +1,29 @@
+id: retry-with-flowable-errors
+namespace: io.kestra.tests
+
+tasks:
+  - id: set_kv
+    type: io.kestra.plugin.core.kv.Set
+    key: "retry_counter_1"
+    value: "1"
+    kvType: NUMBER
+    overwrite: true
+
+  - id: retry_block
+    type: io.kestra.plugin.core.flow.AllowFailure
+    tasks:
+      - id: run_script
+        type: io.kestra.plugin.core.log.Log
+        message: "{{kv(namespace=flow.namespace, key='retry_counter_1') < 2 ? ko : 'It works'}}"
+    errors:
+      - id: incr_counter
+        type: io.kestra.plugin.core.kv.Set
+        key: retry_counter_1
+        value: "{{ kv(namespace=flow.namespace, key='retry_counter_1') + 1 }}"
+        overwrite: true
+    retry:
+      type: constant
+      behavior: RETRY_FAILED_TASK
+      maxAttempts: 3
+      interval: PT0.5S
+      warningOnRetry: true

--- a/jdbc/src/main/java/io/kestra/jdbc/runner/JdbcExecutor.java
+++ b/jdbc/src/main/java/io/kestra/jdbc/runner/JdbcExecutor.java
@@ -1304,6 +1304,7 @@ public class JdbcExecutor implements ExecutorInterface {
                     else if (executionDelay.getDelayType().equals(ExecutionDelay.DelayType.RESTART_FAILED_TASK)) {
                         Execution newAttempt = executionService.retryTask(
                             pair.getKey(),
+                            findFlow(pair.getKey()),
                             executionDelay.getTaskRunId()
                         );
                         executor = executor.withExecution(newAttempt, "retryFailedTask");

--- a/jdbc/src/test/java/io/kestra/jdbc/runner/JdbcRunnerRetryTest.java
+++ b/jdbc/src/test/java/io/kestra/jdbc/runner/JdbcRunnerRetryTest.java
@@ -137,4 +137,10 @@ public abstract class JdbcRunnerRetryTest {
     void retryDynamicTask(Execution execution){
         retryCaseTest.retryDynamicTask(execution);
     }
+
+    @Test
+    @ExecuteFlow("flows/valids/retry-with-flowable-errors.yaml")
+    void retryWithFlowableErrors(Execution execution){
+        retryCaseTest.retryWithFlowableErrors(execution);
+    }
 }


### PR DESCRIPTION
Otherwize we would detect that an error or a finally branch is processing and the flowable state would not be correctly taken.

Moreover, it prevent this branch to be taken again after a restart.

Fixes #11731