### PR TITLE
refactor(ui): convert Settings.vue to TS composition API

### DIFF
--- a/ui/src/override/components/settings/Settings.vue
+++ b/ui/src/override/components/settings/Settings.vue
@@ -2,10 +2,10 @@
     <BasicSettings />
 </template>
 
-<script>
+<script setup lang="ts">
     import BasicSettings from "../../../components/settings/BasicSettings.vue";
 
-    export default {
-        components: {BasicSettings}
-    }
+    defineOptions({
+        name: "Settings",
+    });
 </script>

--- a/ui/src/override/components/settings/Settings.vue
+++ b/ui/src/override/components/settings/Settings.vue
@@ -3,9 +3,6 @@
 </template>
 
 <script setup lang="ts">
+    // @ts-expect-error no types defined yet
     import BasicSettings from "../../../components/settings/BasicSettings.vue";
-
-    defineOptions({
-        name: "Settings",
-    });
 </script>

--- a/ui/src/vite.d.ts
+++ b/ui/src/vite.d.ts
@@ -1,1 +1,7 @@
 /// <reference types="vite/client" />
+
+declare module "*.vue" {
+	import type {DefineComponent} from "vue";
+	const component: DefineComponent;
+	export default component;
+}

--- a/ui/src/vite.d.ts
+++ b/ui/src/vite.d.ts
@@ -1,7 +1,1 @@
 /// <reference types="vite/client" />
-
-declare module "*.vue" {
-	import type {DefineComponent} from "vue";
-	const component: DefineComponent;
-	export default component;
-}


### PR DESCRIPTION
closes #12402 

**Summary**

- Switch override [Settings.vue] to `<script setup lang="ts"> (no behavior change)`
- Add explicit component name via defineOptions for devtools/trace
- Consolidate SFC typings: add declare module "*.vue" to [vite.d.ts]
