### PR TITLE
refactor(layout): convert DefaultLayout.vue to TypeScript using Composition API

### DIFF
--- a/ui/src/override/components/LeftMenu.vue
+++ b/ui/src/override/components/LeftMenu.vue
@@ -6,7 +6,7 @@
     </SideBar>
 </template>
 
-<script setup>
+<script lang="ts" setup>
     import {useLeftMenu} from "override/components/useLeftMenu";
     import SideBar from "../../components/layout/SideBar.vue";
     import Auth from "../../override/components/auth/Auth.vue";
@@ -15,7 +15,7 @@
 
     const $emit = defineEmits(["menu-collapse"])
 
-    function onCollapse(folded) {
+    function onCollapse(folded: boolean) {
         $emit("menu-collapse", folded);
     }
 

--- a/ui/src/override/components/layout/DefaultLayout.vue
+++ b/ui/src/override/components/layout/DefaultLayout.vue
@@ -17,7 +17,7 @@
     import Errors from "../../../components/errors/Errors.vue"
     import ContextInfoBar from "../../../components/ContextInfoBar.vue"
     import SurveyDialog from "../../../components/SurveyDialog.vue"
-    import {onMounted, ref, watch, type Ref} from "vue"
+    import {onMounted, ref, watch} from "vue"
     import {useSurveySkip} from "../../../composables/useSurveyData"
     import {useCoreStore} from "../../../stores/core"
     import {useMiscStore} from "override/stores/misc"
@@ -27,7 +27,7 @@
     const miscStore = useMiscStore()
     const layoutStore = useLayoutStore()
     const {markSurveyDialogShown} = useSurveySkip()
-    const showSurveyDialog: Ref<boolean> = ref(false)
+    const showSurveyDialog = ref(false)
 
     function onMenuCollapse(collapse: boolean) {
         layoutStore.setSideMenuCollapsed(collapse)

--- a/ui/src/override/components/layout/DefaultLayout.vue
+++ b/ui/src/override/components/layout/DefaultLayout.vue
@@ -12,12 +12,12 @@
     />
 </template>
 
-<script setup>
+<script setup lang="ts">
     import LeftMenu from "override/components/LeftMenu.vue"
     import Errors from "../../../components/errors/Errors.vue"
     import ContextInfoBar from "../../../components/ContextInfoBar.vue"
     import SurveyDialog from "../../../components/SurveyDialog.vue"
-    import {onMounted, ref, watch} from "vue"
+    import {onMounted, ref, watch, type Ref} from "vue"
     import {useSurveySkip} from "../../../composables/useSurveyData"
     import {useCoreStore} from "../../../stores/core"
     import {useMiscStore} from "override/stores/misc"
@@ -27,19 +27,19 @@
     const miscStore = useMiscStore()
     const layoutStore = useLayoutStore()
     const {markSurveyDialogShown} = useSurveySkip()
-    const showSurveyDialog = ref(false)
+    const showSurveyDialog: Ref<boolean> = ref(false)
 
-    const onMenuCollapse = (collapse) => {
+    function onMenuCollapse(collapse: boolean) {
         layoutStore.setSideMenuCollapsed(collapse)
     }
 
-    const handleSurveyDialogClose = () => {
+    function handleSurveyDialogClose() {
         showSurveyDialog.value = false
         markSurveyDialogShown()
         localStorage.removeItem("showSurveyDialogAfterLogin")
     }
 
-    const checkForSurveyDialog = () => {
+    function checkForSurveyDialog() {
         const shouldShow = localStorage.getItem("showSurveyDialogAfterLogin") === "true"
         if (shouldShow) {
             setTimeout(() => {
@@ -49,11 +49,15 @@
     }
 
     onMounted(() => {
-        onMenuCollapse(layoutStore.sideMenuCollapsed)
+        // ensure UI state is synchronized with store
+        onMenuCollapse(Boolean(layoutStore.sideMenuCollapsed))
         checkForSurveyDialog()
     })
 
-    watch(() => layoutStore.sideMenuCollapsed, (val) => {
-        onMenuCollapse(val)
-    })
+    watch(
+        () => layoutStore.sideMenuCollapsed,
+        (val: boolean) => {
+            onMenuCollapse(val)
+        },
+    )
 </script>

--- a/ui/src/shims-vue.d.ts
+++ b/ui/src/shims-vue.d.ts
@@ -1,0 +1,6 @@
+declare module "*.vue" {
+  import type {DefineComponent} from "vue"
+  // Use Record<string, unknown> instead of {} to satisfy lint rules
+  const component: DefineComponent<Record<string, unknown>, Record<string, unknown>, any>
+  export default component
+}

--- a/ui/src/shims-vue.d.ts
+++ b/ui/src/shims-vue.d.ts
@@ -1,6 +1,0 @@
-declare module "*.vue" {
-  import type {DefineComponent} from "vue"
-  // Use Record<string, unknown> instead of {} to satisfy lint rules
-  const component: DefineComponent<Record<string, unknown>, Record<string, unknown>, any>
-  export default component
-}


### PR DESCRIPTION
Refactor: convert DefaultLayout.vue to TypeScript (Composition API)

Converted DefaultLayout.vue to <script setup lang="ts"> using the Composition API.
Added shims-vue.d.ts to declare *.vue modules for TypeScript and avoid implicit any on SFC imports.

No behavior change is intended — this is a refactor to improve type safety and developer DX.

Closes: #12401