### PR TITLE
refactor(ui): Convert LeftMenuLink.vue to TypeScript

### DIFF
--- a/ui/src/components/LeftMenuLink.vue
+++ b/ui/src/components/LeftMenuLink.vue
@@ -1,9 +1,9 @@
 <template>
-    <a v-if="isHyperLink" v-bind="$attrs">
+    <a v-if="isHyperLink" v-bind="$attrs" ref="slotContainer">
         <slot />
     </a>
-    <router-link v-else :to="$attrs.href" custom v-slot="{href:linkHref, navigate}">
-        <a v-bind="$attrs" :href="linkHref" @click="navigate">
+    <router-link v-else :to="$attrs.href as string" custom v-slot="{href:linkHref, navigate}">
+        <a v-bind="$attrs" :href="linkHref" @click="navigate" ref="slotContainer">
             <EnterpriseBadge :enable="isLocked">
                 <slot />
             </EnterpriseBadge>
@@ -11,7 +11,7 @@
     </router-link>
 </template>
 
-<script setup>
+<script setup lang="ts">
     import {computed, ref, onMounted} from "vue"
     import {useRouter} from "vue-router";
     import EnterpriseBadge from "./EnterpriseBadge.vue";
@@ -21,25 +21,30 @@
         inheritAttrs: false,
     })
 
-    const props = defineProps({
-        item: {
-            type: Object,
-            required: true,
-        },
-    })
+    interface MenuItem{
+        href?: string;
+        external?: boolean;
+        attributes?: {
+            locked?: boolean;
+        };
+    }
+
+    const props = defineProps<{
+        item: MenuItem;
+    }>()
 
     const router = useRouter()
 
-    const isHyperLink = computed(() => {
+    const isHyperLink = computed<boolean>(() => {
         return !!(!props.item.href || props.item.external || !router)
     })
 
-    const isLocked = computed(() => {
+    const isLocked = computed<boolean>(() => {
         return props.item?.attributes?.locked || false;
     })
 
-    const slotContainer = ref(null)
-    const term = ref()
+    const slotContainer = ref<HTMLAnchorElement | null>(null)
+    const term = ref<string>()
 
     onMounted(() => {
         if (slotContainer?.value?.innerText) {


### PR DESCRIPTION
### What changes are being made and why?

This pull request converts the `LeftMenuLink.vue` component from JavaScript to TypeScript, using the Composition API.

This refactor introduces type safety for the component's props (via a new `MenuItem` interface) and its internal `ref` and `computed` properties. This improves code quality and maintainability without altering any component functionality.

Closes #12398
