### PR TITLE
fix(ui): dashboard overflow

### DIFF
--- a/ui/src/components/MultiPanelTabs.vue
+++ b/ui/src/components/MultiPanelTabs.vue
@@ -834,6 +834,7 @@
         position: relative;
         height: 100%;
         overflow: auto;
+        container-type: inline-size;
     }
 
     .el-splitter-panel{

--- a/ui/src/components/dashboard/assets/default_main_definition.yaml
+++ b/ui/src/components/dashboard/assets/default_main_definition.yaml
@@ -11,7 +11,7 @@ charts:
     chartOptions:
       displayName: Success Ratio
       numberType: PERCENTAGE
-      width: 3
+      width: 6
     data:
       type: io.kestra.plugin.core.dashboard.data.ExecutionsKPI
       columns:
@@ -28,7 +28,7 @@ charts:
     chartOptions:
       displayName: Failed Ratio
       numberType: PERCENTAGE
-      width: 3
+      width: 6
     data:
       type: io.kestra.plugin.core.dashboard.data.ExecutionsKPI
       columns:
@@ -45,7 +45,7 @@ charts:
     chartOptions:
       displayName: Running Ratio
       numberType: PERCENTAGE
-      width: 3
+      width: 6
     data:
       type: io.kestra.plugin.core.dashboard.data.ExecutionsKPI
       columns:
@@ -66,7 +66,7 @@ charts:
     chartOptions:
       displayName: Pending Ratio
       numberType: PERCENTAGE
-      width: 3
+      width: 6
     data:
       type: io.kestra.plugin.core.dashboard.data.ExecutionsKPI
       columns:

--- a/ui/src/components/dashboard/assets/default_main_definition.yaml
+++ b/ui/src/components/dashboard/assets/default_main_definition.yaml
@@ -113,7 +113,7 @@ charts:
       displayName: Total Executions
       graphStyle: DONUT
       tooltip: ALL
-      width: 3
+      width: 6
     data:
       type: io.kestra.plugin.core.dashboard.data.Executions
       columns:

--- a/ui/src/components/dashboard/sections/Sections.vue
+++ b/ui/src/components/dashboard/sections/Sections.vue
@@ -5,8 +5,9 @@
                 v-for="chart in props.charts"
                 :key="`chart__${chart.id}`"
                 :xs="24"
-                :sm="(chart.chartOptions?.width || 6) * 4"
-                :md="(chart.chartOptions?.width || 6) * 2"
+                :sm="12"
+                :md="(chart.chartOptions?.width || 6)"
+                :lg="(chart.chartOptions?.width || 6)"
             >
                 <div class="d-flex flex-column">
                     <div class="d-flex justify-content-between">

--- a/ui/src/components/dashboard/sections/Sections.vue
+++ b/ui/src/components/dashboard/sections/Sections.vue
@@ -139,8 +139,18 @@ section#charts {
         padding: 0 2rem 1rem;
     }
 
+    
+    & .el-row {
+        display: flex;
+        flex-wrap: wrap;
+        width: 100%;
+        min-width: 0;
+    }
+    
+
     & .el-row .el-col {
         margin-bottom: 1rem;
+        min-width: 0;
 
         & > div {
             height: 100%;
@@ -159,6 +169,13 @@ section#charts {
         &:hover #charts_buttons {
             opacity: 1;
         }
+    }
+}
+@container (max-width: 800px){
+    .el-row .el-col {
+    width: 100% !important;
+    flex: 0 0 100%;
+    max-width: 100%;
     }
 }
 </style>


### PR DESCRIPTION
Fixes #12404 

This PR fixes the dashboard overflow bug, which occurred in two separate places:
1.  On the main, full-screen dashboard page.
2.  In the narrow "Preview" panel on the "Create Dashboard" editor page.

### 1. Main Dashboard Fix (Configuration)

The initial problem on the main dashboard page was caused by incorrect width configurations in the default YAML. The KPI cards and Pie chart were assigned `width: 3` (3/24 columns), which was too small.

* **Modified:** `ui/src/components/dashboard/assets/default_main_definition.yaml`
* **Change:** Changed `chartOptions.width` from 3 to 6 for the four KPI cards (`kpi_success_ratio`, etc.) and the `total_executions_pie` chart.

### 2. Editor Preview Panel Fix (Responsive Components)

After the YAML fix, the layout was *still* broken in the editor's preview panel. This was because the layout (`Sections.vue`) was reacting to the *full browser window width* (Media Queries) instead of its parent panel's width.


To solve this, I implemented a 3-part responsive fix:

* `MultiPanelTabs.vue` 
    * Added `container-type: inline-size` to the `.content-panel` style. This defines the preview panel as a "container" that its children can query.

* `Sections.vue` 
    * Added an `@container (max-width: 800px)` query to the CSS. When the preview panel (the container) is narrow, this rule now forces all dashboard columns (`.el-col`) to stack vertically (`width: 100%`), fixing the overlap.

These changes combined ensure the dashboard layout is robust and responsive on both the main page and within the editor's preview panel.

### Verification
Verified locally by running Kestra (backend via Docker, frontend via `npm run dev`). Resizing the main browser window *and* resizing the editor's preview panel now both result in a clean, stacking layout with no overflow.


https://github.com/user-attachments/assets/5720b13f-4497-413a-86b4-c801a4f40d82

