### PR TITLE
feat(core): add support for single datetime as well in filter

### DIFF
--- a/ui/src/components/filter/components/layout/FilterDateTime.vue
+++ b/ui/src/components/filter/components/layout/FilterDateTime.vue
@@ -1,25 +1,21 @@
 <template>
-    <el-date-picker
-        v-model="dateModel"
-        type="datetime"
-        :placeholder="`Select ${label.toLowerCase()}`"
-    />
+    <div class="p-3">
+        <el-date-picker
+            :modelValue="dateValue"
+            type="datetime"
+            :placeholder="`Select ${label.toLowerCase()}`"
+            @update:model-value="$emit('update:dateValue', $event)"
+        />
+    </div>
 </template>
 
 <script setup lang="ts">
-    import {computed} from "vue";
-
-    const props = defineProps<{
+    defineProps<{
         label: string;
         dateValue: Date | null;
     }>();
 
-    const emits = defineEmits<{
+    defineEmits<{
         "update:dateValue": [value: Date | null];
     }>();
-
-    const dateModel = computed({
-        get: () => props.dateValue,
-        set: (value: Date | null) => emits("update:dateValue", value)
-    });
 </script>

--- a/ui/src/components/filter/components/layout/FilterEditPopper.vue
+++ b/ui/src/components/filter/components/layout/FilterEditPopper.vue
@@ -270,8 +270,8 @@
                         : "";
                 break;
             case "date":
-                filterValue = state.dateValue!;
-                valueLabel = state.dateValue!.toLocaleDateString();
+                filterValue = state.dateValue ?? "";
+                valueLabel = state.dateValue?.toLocaleDateString() ?? "";
                 break;
             case "radio":
                 if (state.radioValue === "ALL") {
@@ -343,7 +343,11 @@
                 state.multiSelectValue = Array.isArray(props.filter.value) ? props.filter.value : [];
                 break;
             case "date":
-                state.dateValue = props.filter.value instanceof Date ? props.filter.value : null;
+                state.dateValue = props.filter.value instanceof Date 
+                    ? props.filter.value 
+                    : typeof props.filter.value === "string" 
+                        ? new Date(props.filter.value) 
+                        : null;
                 break;
             case "radio":
                 state.radioValue = typeof props.filter.value === "string" ? props.filter.value : "ALL";

--- a/ui/src/components/filter/composables/useFilters.ts
+++ b/ui/src/components/filter/composables/useFilters.ts
@@ -269,8 +269,14 @@ export function useFilters(configuration: FilterConfiguration, showSearchInput =
             return {value: combinedValue, valueLabel: combinedValue.join(", ")};
         } else {
             const param = params[0];
-            const value = Array.isArray(param?.value) ? param.value[0] : param?.value as string;
-            return {value, valueLabel: value};
+            let value = Array.isArray(param?.value) ? param.value[0] : param?.value as string;
+            
+            if (config?.valueType === "date" && typeof value === "string") {
+                value = new Date(value);
+            }
+            
+            const valueLabel = value instanceof Date ? value.toLocaleDateString() : value;
+            return {value, valueLabel};
         }
     };
 

--- a/ui/src/components/filter/utils/helpers.ts
+++ b/ui/src/components/filter/utils/helpers.ts
@@ -77,7 +77,9 @@ export const encodeFiltersToQuery = (filters: Filter[], keyOfComparator: (compar
                     ? value.join(",")
                     : typeof value === "object" && "startDate" in value
                         ? `${value.startDate.toISOString()},${value.endDate.toISOString()}`
-                        : value;
+                        : value instanceof Date
+                            ? value.toISOString()
+                            : value;
                 query[`filters[${key}][${comparatorKey}]`] = processedValue?.toString() ?? "";
                 return query;
             }


### PR DESCRIPTION
We only have timeRange either with some predefined values or constructed with startDate - endDate key.

But **we should have a support for using all the Comparators with a single datetime picker as well, not range**

```
Comparators.GREATER_THAN_OR_EQUAL_TO,
Comparators.GREATER_THAN,
Comparators.LESS_THAN_OR_EQUAL_TO,
Comparators.LESS_THAN,
Comparators.EQUALS,
Comparators.NOT_EQUALS,
```

Since Brian has added a UPDATED key in his KV Metadata [work](https://github.com/kestra-io/kestra/pull/12342/files#diff-b9ebd2d964f01d0aacd53abf9223b84ab0c6af0bb0ed20441cd3ca472ed0fce4R112-R277) which only filters on single datetime picked. I am adding a support for it to unlock the situation to add in UI.

Here is how it should. work and How it will look. Tested on Brian's Branch.


https://github.com/user-attachments/assets/c7100a61-0228-4446-9026-78ed1ae0594d


