### PR TITLE
Add maxObjectNameLength default method to StorageInterface

### DIFF
--- a/core/src/main/java/io/kestra/core/storages/StorageInterface.java
+++ b/core/src/main/java/io/kestra/core/storages/StorageInterface.java
@@ -360,4 +360,14 @@ public interface StorageInterface extends AutoCloseable, Plugin {
 
         return path;
     }
+
+    /**
+     * Returns the maximum allowed length for an object name in this storage.
+     *
+     * @return the maximum object name length, default is unlimited
+     */
+    default int maxObjectNameLength() {
+        return Integer.MAX_VALUE;
+    }
+
 }


### PR DESCRIPTION
This adds a new default method maxObjectNameLength() to StorageInterface to define the maximum allowed length for object names. The default implementation returns Integer.MAX_VALUE for unlimited length.

This method is needed to support object name length protection in the S3 storage plugin, as implemented in [storage-s3 PR #172](https://github.com/kestra-io/storage-s3/pull/172)
.

Adding this default method ensures that all storage implementations can optionally enforce object name length limits in a consistent way without breaking existing implementations.