### PR TITLE
fix(executions): set the execution to KILLING and not RESTARTED when …

### DIFF
--- a/core/src/main/java/io/kestra/core/services/ExecutionService.java
+++ b/core/src/main/java/io/kestra/core/services/ExecutionService.java
@@ -727,7 +727,7 @@ public class ExecutionService {
             // An edge case can exist where the execution is resumed automatically before we resume it with a killing.
             try {
                 newExecution = this.resume(execution, flow, State.Type.KILLING, null);
-                newExecution = newExecution.withState(afterKillState.orElse(newExecution.getState().getCurrent()));
+                newExecution = newExecution.withState(killingOrAfterKillState);
             } catch (Exception e) {
                 // if we cannot resume, we set it anyway to killing, so we don't throw
                 log.warn("Unable to resume a paused execution before killing it", e);
@@ -741,6 +741,7 @@ public class ExecutionService {
         // immediately without publishing a CrudEvent like it's done on pause/resume method.
         return newExecution;
     }
+
     public Execution kill(Execution execution, FlowInterface flow) {
         return this.kill(execution, flow, Optional.empty());
     }

--- a/core/src/test/java/io/kestra/core/runners/ExecutionServiceTest.java
+++ b/core/src/test/java/io/kestra/core/runners/ExecutionServiceTest.java
@@ -418,9 +418,9 @@ class ExecutionServiceTest {
 
         Execution killed = executionService.kill(execution, flow);
 
-        assertThat(killed.getState().getCurrent()).isEqualTo(State.Type.RESTARTED);
+        assertThat(killed.getState().getCurrent()).isEqualTo(State.Type.KILLING);
         assertThat(killed.findTaskRunsByTaskId("pause").getFirst().getState().getCurrent()).isEqualTo(State.Type.KILLED);
-        assertThat(killed.getState().getHistories()).hasSize(4);
+        assertThat(killed.getState().getHistories()).hasSize(5);
     }
 
     @Test

--- a/webserver/src/test/java/io/kestra/webserver/controllers/api/ExecutionControllerRunnerTest.java
+++ b/webserver/src/test/java/io/kestra/webserver/controllers/api/ExecutionControllerRunnerTest.java
@@ -1296,13 +1296,14 @@ class ExecutionControllerRunnerTest {
         Execution pausedExecution = runnerUtils.runOneUntilPaused(TENANT_ID, TESTS_FLOW_NS, "pause-test");
         assertThat(pausedExecution.getState().isPaused()).isTrue();
 
-        // resume the execution
-        HttpResponse<?> resumeResponse = client.toBlocking().exchange(
+        // kill the execution
+        HttpResponse<?> killResponse = client.toBlocking().exchange(
             HttpRequest.DELETE("/api/v1/main/executions/" + pausedExecution.getId() + "/kill"));
-        assertThat(resumeResponse.getStatus().getCode()).isEqualTo(HttpStatus.ACCEPTED.getCode());
+        assertThat(killResponse.getStatus().getCode()).isEqualTo(HttpStatus.ACCEPTED.getCode());
 
-        // check that the execution is no more paused
-        awaitExecution(pausedExecution.getId(), exec -> !exec.getState().isPaused());
+        // check that the execution is killed
+        Execution killedExecution = awaitExecution(pausedExecution.getId(), exec -> exec.getState().getCurrent().isKilled());
+        assertThat(killedExecution.getTaskRunList()).hasSize(1);
     }
 
     // This test is flaky on CI as the flow may be already SUCCESS when we kill it if CI is super slow


### PR DESCRIPTION
…killing a paused flow

Fixes https://github.com/kestra-io/kestra/issues/12417