### PR TITLE
Change validation trigger from 'change' to 'blur' #12548

### DIFF
--- a/ui/src/components/basicauth/BasicAuthLogin.vue
+++ b/ui/src/components/basicauth/BasicAuthLogin.vue
@@ -135,8 +135,8 @@
     };
 
     const rules = computed(() => ({
-        username: [{required: true, validator: validateEmail, trigger: "change"}],
-        password: [{required: true, validator: validatePassword, trigger: "change"}]
+        username: [{required: true, validator: validateEmail, trigger: "blur"}],
+        password: [{required: true, validator: validatePassword, trigger: "blur"}]
     }))
 
     const getFieldError = (fieldName: string) => {
@@ -206,6 +206,9 @@
         try {
             coreStore.error = undefined;
             if (!form.value || isLoading.value) return
+
+            // Clear any existing validation states before submitting
+            form.value.clearValidate()
 
             if (!(await form.value.validate().catch(() => false))) return
 


### PR DESCRIPTION
This PR Prevent marking fields as error on login  #12548

**Changes:**
- Changed form validation trigger from `"change"` to `"blur"` in the validation rules
- Added `form.value.clearValidate()` call before form submission to clear any lingering validation states
- This ensures validation only runs when users leave an input field, not during form submission
- 
<img width="631" height="566" alt="image" src="https://github.com/user-attachments/assets/3a9d90ee-4ad4-47d2-8676-2addd51ea0b0" />
