### PR TITLE
fix(ui): prevent marking fields as error on login (Fix #12548)

### DIFF
--- a/ui/src/components/basicauth/BasicAuthLogin.vue
+++ b/ui/src/components/basicauth/BasicAuthLogin.vue
@@ -135,8 +135,8 @@
     };
 
     const rules = computed(() => ({
-        username: [{required: true, validator: validateEmail, trigger: "change"}],
-        password: [{required: true, validator: validatePassword, trigger: "change"}]
+        username: [{required: true, validator: validateEmail, trigger: "blur"}],
+        password: [{required: true, validator: validatePassword, trigger: "blur"}]
     }))
 
     const getFieldError = (fieldName: string) => {


### PR DESCRIPTION
Closes #12548 