### PR TITLE
refactor(core): convert LogLevelSelector.vue to TypeScript and Composition API  

### DIFF
--- a/ui/src/components/logs/LogLevelSelector.vue
+++ b/ui/src/components/logs/LogLevelSelector.vue
@@ -16,34 +16,26 @@
         </el-option>
     </el-select>
 </template>
-<script>
-    export default {
-        emits: ["update:modelValue"],
-        data() {
-            return {
-                levelOptions: [
-                    "TRACE",
-                    "DEBUG",
-                    "INFO",
-                    "WARN",
-                    "ERROR",
-                ],
-            };
-        },
-        props: {
-            router: {
-                type: Boolean,
-                default: true
-            },
-            value: {
-                type: String,
-                default: "INFO"
-            }
-        },
-        methods: {
-            onInput(value) {
-                this.$emit("update:modelValue", value);
-            },
-        },
+<script setup lang="ts">
+    const emit = defineEmits<{(e: 'update:modelValue', value: string): void;}>()
+
+    withDefaults(defineProps<{
+        value?: string,
+        router?: boolean
+    }>(), {
+        value: "INFO",
+        router: true
+    })
+
+    const levelOptions = [
+        "TRACE",
+        "DEBUG",
+        "INFO",
+        "WARN",
+        "ERROR",
+    ];
+
+    const onInput = (value: string) => {
+        emit("update:modelValue", value);
     };
 </script>

--- a/ui/src/components/logs/LogLevelSelector.vue
+++ b/ui/src/components/logs/LogLevelSelector.vue
@@ -1,13 +1,13 @@
 <template>
     <el-select
         :modelValue="value"
-        @update:model-value="onInput"
+        @update:model-value="emit('update:modelValue', $event)"
         filterable
         :persistent="false"
         :placeholder="$t('revisions')"
     >
         <el-option
-            v-for="item in levelOptions"
+            v-for="item in LEVELS"
             :key="item"
             :label="item"
             :value="item"
@@ -17,7 +17,7 @@
     </el-select>
 </template>
 <script setup lang="ts">
-    const emit = defineEmits<{(e: 'update:modelValue', value: string): void;}>()
+    const emit = defineEmits<{(e: "update:modelValue", value: string): void;}>()
 
     withDefaults(defineProps<{
         value?: string,
@@ -27,15 +27,11 @@
         router: true
     })
 
-    const levelOptions = [
+    const LEVELS = [
         "TRACE",
         "DEBUG",
         "INFO",
         "WARN",
         "ERROR",
     ];
-
-    const onInput = (value: string) => {
-        emit("update:modelValue", value);
-    };
 </script>


### PR DESCRIPTION
Closes #12384 
### What changes are being made and why?

This pull request refactors the `ui/src/components/logs/LogLevelSelector.vue` component from using the Vue 2 Options API to the modern Composition API with TypeScript (`<script setup lang="ts">`).

This conversion is part of a broader initiative to enhance the Kestra UI by:
- Improving type safety and reducing runtime errors.
- Increasing code readability and maintainability.
- Aligning with modern Vue 3 best practices.

This change serves as an entry point for contributors looking to get involved with the Kestra UI codebase.

---

### How the changes have been QAed?

This is a UI component refactoring and does not alter functionality. The changes can be visually verified by running the application and ensuring the log level selector dropdown works as expected on pages that display logs. No specific flow is required to test this change.

---
