### PR TITLE
fix/ui/error-toast-width - resolve issue: #12518

### DIFF
--- a/ui/src/components/ErrorToast.vue
+++ b/ui/src/components/ErrorToast.vue
@@ -91,7 +91,8 @@
                     type: this.message.variant,
                     duration: 0,
                     dangerouslyUseHTMLString: true,
-                    customClass: "error-notification large"
+                    // remove the generic "large" class which forces wide notifications
+                    customClass: "error-notification"
                 });
             });
 
@@ -103,6 +104,10 @@
 <style lang="scss">
     .error-notification {
         max-height: 90svh;
+        /* constrain width locally so removing the global "large" class is safe */
+        max-width: 720px;
+        width: auto;
+        box-sizing: border-box;
 
         .el-notification__title {
             max-width: calc(100% - 15ch);


### PR DESCRIPTION
Closes https://github.com/kestra-io/kestra/issues/12518.

Summary
This PR fixes a UI bug where error notification toasts (shown by [ErrorToast.vue](vscode-file://vscode-app/c:/Users/subra/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)) stretch across the screen and overlap other elements (for example the "Confirm" button on the setup page). The root cause was a global .large style applied to .el-notification in [element-plus-overload.scss](vscode-file://vscode-app/c:/Users/subra/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) that forced very large widths (70% / min-width: 800px). Error toasts were created with the large class via customClass: "error-notification large". This change removes the large class from error notifications and adds a local max-width constraint and width: auto on the error-notification class to keep toasts at a sane size while preserving the existing error-notification styling.

What I changed
Updated [ErrorToast.vue](vscode-file://vscode-app/c:/Users/subra/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
Removed the "large" addition from customClass passed to ElNotification. Notifications now use customClass: "error-notification".
Added local CSS to the .error-notification rule:
max-width: 720px;
width: auto;
box-sizing: border-box;
Left other behavior intact (position: bottom-right, duration: 0, etc.)
No other files modified.
<img width="1919" height="1020" alt="Screenshot 2025-10-31 165602" src="https://github.com/user-attachments/assets/c1e9699b-8e03-41d7-ad4d-2b6ccb083c6e" />
