### PR TITLE
fix(docker): adapt postgres-data volume location to postgres 18+ 

### DIFF
--- a/docker-compose-dind.yml
+++ b/docker-compose-dind.yml
@@ -15,9 +15,9 @@ volumes:
 
 services:
   postgres:
-    image: postgres
+    image: postgres:18
     volumes:
-      - postgres-data:/var/lib/postgresql/data
+      - postgres-data:/var/lib/postgresql/18/docker
     environment:
       POSTGRES_DB: kestra
       POSTGRES_USER: kestra

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,9 +6,9 @@ volumes:
 
 services:
   postgres:
-    image: postgres
+    image: postgres:18
     volumes:
-      - postgres-data:/var/lib/postgresql/data
+      - postgres-data:/var/lib/postgresql/18/docker
     environment:
       POSTGRES_DB: kestra
       POSTGRES_USER: kestra


### PR DESCRIPTION
<!-- Thanks for submitting a Pull Request to Kestra. To help us review your contribution, please follow the guidelines below:

- Make sure that your commits follow the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) specification e.g. `feat(ui): add a new navigation menu item` or `fix(core): fix a bug in the core model` or `docs: update the README.md`. This will help us automatically generate the changelog.
- The title should briefly summarize the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share a flow example to help the reviewer understand and QA the change.
- Use "closes" to automatically close an issue. For example, `closes #1234` will close issue #1234. -->

### What changes are being made and why?
Running ` docker compose up` or `docker compose up postgres` give the following error:

```console
Attaching to postgres-1
postgres-1  | Error: in 18+, these Docker images are configured to store database data in a
postgres-1  |        format which is compatible with "pg_ctlcluster" (specifically, using
postgres-1  |        major-version-specific directory names).  This better reflects how
postgres-1  |        PostgreSQL itself works, and how upgrades are to be performed.
postgres-1  |
postgres-1  |        See also https://github.com/docker-library/postgres/pull/1259
postgres-1  |
postgres-1  |        Counter to that, there appears to be PostgreSQL data in:
postgres-1  |          /var/lib/postgresql/data (unused mount/volume)
postgres-1  |
postgres-1  |        This is usually the result of upgrading the Docker image without
postgres-1  |        upgrading the underlying database using "pg_upgrade" (which requires both
postgres-1  |        versions).
postgres-1  |
postgres-1  |        The suggested container configuration for 18+ is to place a single mount
postgres-1  |        at /var/lib/postgresql which will then place PostgreSQL data in a
postgres-1  |        subdirectory, allowing usage of "pg_upgrade --link" without mount point
postgres-1  |        boundary issues.
postgres-1  |
postgres-1  |        See https://github.com/docker-library/postgres/issues/37 for a (long)
postgres-1  |        discussion around this process, and suggestions for how to do so.
postgres-1 exited with code 1
```

due to breaking change in Postgres 18+ (release in september 25th): https://github.com/docker-library/postgres/pull/1259).

This PR updates the docker compose files to comply with the new postgres requirements.

<!-- Please include a brief summary of the changes included in this PR e.g. closes #1234. -->

---

### How the changes have been QAed?


After the update running `docker compose up postgres` now yield the expected output: 

```console
docker compose up postgres
[+] Running 1/1
 ✔ postgres Pulled                                                                                                                                                                                                                     1.3s
[+] Running 1/1
 ✔ Container kestra-postgres-1  Recreated                                                                                                                                                                                              0.1s
Attaching to postgres-1
postgres-1  | The files belonging to this database system will be owned by user "postgres".
postgres-1  | This user must also own the server process.
postgres-1  |
postgres-1  | The database cluster will be initialized with locale "en_US.utf8".
postgres-1  | The default database encoding has accordingly been set to "UTF8".
postgres-1  | The default text search configuration will be set to "english".
postgres-1  |
postgres-1  | Data page checksums are enabled.
postgres-1  |
postgres-1  | fixing permissions on existing directory /var/lib/postgresql/18/docker ... ok
postgres-1  | creating subdirectories ... ok
postgres-1  | selecting dynamic shared memory implementation ... posix
postgres-1  | selecting default "max_connections" ... 100
postgres-1  | selecting default "shared_buffers" ... 128MB
postgres-1  | selecting default time zone ... Etc/UTC
postgres-1  | creating configuration files ... ok
postgres-1  | running bootstrap script ... ok
postgres-1  | performing post-bootstrap initialization ... ok
postgres-1  | syncing data to disk ... ok
postgres-1  |
postgres-1  |
postgres-1  | Success. You can now start the database server using:
postgres-1  |
postgres-1  |     pg_ctl -D /var/lib/postgresql/18/docker -l logfile start
```
