### PR TITLE
refactor(ui): convert ErrorToast.vue to TypeScript with Composition API

### DIFF
--- a/ui/src/components/ErrorToast.vue
+++ b/ui/src/components/ErrorToast.vue
@@ -1,123 +1,148 @@
-<script>
+<template>
+    <!-- root element required by vue/valid-template-root.
+       kept invisible because this component only shows ElementPlus notifications -->
+    <div style="display: none" aria-hidden="true" />
+</template>
+
+<script setup lang="ts">
+    import {ref, nextTick, watch, onBeforeUnmount} from "vue";
+    import {useRoute} from "vue-router";
     import {ElNotification} from "element-plus";
-    import {pageFromRoute} from "../utils/eventsRouter";
-    import {h} from "vue"
+    import {h} from "vue";
     import ErrorToastContainer from "./ErrorToastContainer.vue";
-    import {mapStores} from "pinia";
     import {useApiStore} from "../stores/api";
+    import {pageFromRoute} from "../utils/eventsRouter";
 
-    export default {
-        name: "ErrorToast",
-        props: {
-            message: {
-                type: Object,
-                required: true
-            },
-            noAutoHide: {
-                type: Boolean,
-                default: false
-            }
-        },
-        notifications: undefined,
-        watch: {
-            $route() {
-                this.close();
-            },
-        },
-        computed: {
-            ...mapStores(useApiStore),
-            title () {
-                if (this.message.title) {
-                    return this.message.title;
-                }
-
-                if (this.message.response.status === 503) {
-                    return "503 Service Unavailable";
-                }
-
-                if (this.message.content && this.message.content.message && this.message.content.message.indexOf(":") > 0) {
-                    return this.message.content.message.substring(0, this.message.content.message.indexOf(":"));
-                }
-
-                return "Error"
-            },
-            items() {
-                const messages = this.message.content && this.message.content._embedded && this.message.content._embedded.errors ? this.message.content._embedded.errors : []
-                return Array.isArray(messages) ? messages : [messages]
-            },
-        },
-        methods: {
-            close() {
-                if (this.notifications) {
-                    this.notifications.close();
-                }
-            },
-        },
-        render() {
-            this.$nextTick(async () => {
-                this.close();
-
-                const error =  {
-                    type: "ERROR",
-                    error: {
-                        message: this.title,
-                        errors: this.items,
-                    },
-                    page: pageFromRoute(this.$route)
-                };
-
-                if (this.message.response) {
-                    error.error.response = {};
-                    error.error.request = {};
-
-                    if (this.message.response.status) {
-                        error.error.response.status = this.message.response.status;
-                    }
-
-                    error.error.request.url = this.message.response.config.url;
-                    error.error.request.method = this.message.response.config.method;
-                }
-
-                this.apiStore.events(error);
-
-                this.notifications = ElNotification({
-                    title: this.title || "Error",
-                    message: h(ErrorToastContainer, {
-                        message: this.message,
-                        items: this.items,
-                        onClose: () => this.close()
-                    }),
-                    position: "bottom-right",
-                    type: this.message.variant,
-                    duration: 0,
-                    dangerouslyUseHTMLString: true,
-                    customClass: "error-notification large"
-                });
-            });
-
-            return "";
-        }
+    /** Minimal message typing — adjust if you want stricter types */
+    type ErrorMessage = {
+        title?: string;
+        response?: any;
+        content?: any;
+        variant?: "success" | "warning" | "info" | "error" | string;
     };
+
+    const props = defineProps<{
+        message: ErrorMessage | null;
+        noAutoHide?: boolean;
+    }>();
+
+    const apiStore = useApiStore();
+    const route = useRoute();
+    const notificationRef = ref<any | null>(null);
+
+    function closeNotification() {
+        if (notificationRef.value && typeof notificationRef.value.close === "function") {
+            try {
+                notificationRef.value.close();
+            } catch {
+                // ignore closing errors
+            }
+        }
+        notificationRef.value = null;
+    }
+
+    function deriveTitle(message: ErrorMessage | null): string {
+        if (!message) return "Error";
+        if (message.title) return message.title;
+        if (message.response && message.response.status === 503) {
+            return "503 Service Unavailable";
+        }
+        const contentMsg = message.content && (message.content.message ?? "");
+        if (typeof contentMsg === "string" && contentMsg.indexOf(":") > 0) {
+            return contentMsg.substring(0, contentMsg.indexOf(":"));
+        }
+        return "Error";
+    }
+
+    function deriveItems(message: ErrorMessage | null) {
+        const messages =
+            message?.content && message.content._embedded && message.content._embedded.errors
+                ? message.content._embedded.errors
+                : [];
+        return Array.isArray(messages) ? messages : [messages];
+    }
+
+    /* watch message -> create notification (mirrors original $nextTick render behaviour) */
+    watch(
+        () => props.message,
+        async (newMsg) => {
+            closeNotification();
+            if (!newMsg) return;
+
+            await nextTick();
+
+            const errorEvent: any = {
+                type: "ERROR",
+                error: {
+                    message: deriveTitle(newMsg),
+                    errors: deriveItems(newMsg),
+                },
+                page: pageFromRoute(route),
+            };
+
+            if (newMsg.response) {
+                errorEvent.error.response = {};
+                errorEvent.error.request = {};
+
+                if (newMsg.response.status) {
+                    errorEvent.error.response.status = newMsg.response.status;
+                }
+
+                const cfg = newMsg.response.config ?? {};
+                errorEvent.error.request.url = cfg.url;
+                errorEvent.error.request.method = cfg.method;
+            }
+
+            apiStore.events(errorEvent);
+
+            notificationRef.value = ElNotification({
+                title: deriveTitle(newMsg) || "Error",
+                message: h(ErrorToastContainer, {
+                    message: newMsg,
+                    items: deriveItems(newMsg),
+                    onClose: () => closeNotification(),
+                }),
+                position: "bottom-right",
+                type: newMsg.variant ?? "error",
+                duration: props.noAutoHide ? 0 : 0,
+                dangerouslyUseHTMLString: true,
+                customClass: "error-notification large",
+            });
+        },
+        {immediate: true}
+    );
+
+    /* close on route change */
+    watch(
+        () => route.fullPath,
+        () => {
+            closeNotification();
+        }
+    );
+
+    onBeforeUnmount(() => {
+        closeNotification();
+    });
 </script>
 
-<style lang="scss">
-    .error-notification {
-        max-height: 90svh;
+<style lang="scss" scoped>
+.error-notification {
+  max-height: 90svh;
 
-        .el-notification__title {
-            max-width: calc(100% - 15ch);
-        }
+  .el-notification__title {
+    max-width: calc(100% - 15ch);
+  }
 
-        .slack-on-error {
-            top: calc(18px + 0.5rem);
-            right: calc(15px + 2rem);
-            transform: translateY(-50%);
-            gap: .5rem;
-        }
+  .slack-on-error {
+    top: calc(18px + 0.5rem);
+    right: calc(15px + 2rem);
+    transform: translateY(-50%);
+    gap: 0.5rem;
+  }
 
-        .el-notification__content {
-            overflow-y: auto;
-            max-height: 100%;
-        }
-    }
+  .el-notification__content {
+    overflow-y: auto;
+    max-height: 100%;
+  }
+}
 </style>


### PR DESCRIPTION
### What changes are being made and why?

Closes #12395  

This PR converts the `ErrorToast.vue` component to **TypeScript** using the **Vue 3 Composition API** and `<script setup>` syntax.

### Key Changes
- Migrated from Options API to Composition API
- Added minimal TypeScript types for `message` prop
- Preserved original notification logic (Element Plus)
- Added required root `<div>` to satisfy `vue/valid-template-root`
- Scoped styles as per `vue/enforce-style-attribute`
- Removed unused catch variable (`@typescript-eslint/no-unused-vars`)
- Verified lint and build pass

### How the changes have been QAed?

The changes were tested locally by running the UI in dev mode:
<img width="1894" height="891" alt="image" src="https://github.com/user-attachments/assets/2da22e04-4c4e-4345-aace-83a45458b7e3" />



