### PR TITLE
Refactor: synced execution states with ui-libs and unified usage acro…

### DIFF
--- a/ui/src/components/dashboard/composables/charts.ts
+++ b/ui/src/components/dashboard/composables/charts.ts
@@ -1,6 +1,6 @@
 import _merge from "lodash/merge";
 import Utils from "../../../utils/utils";
-import {cssVariable, State} from "@kestra-io/ui-libs";
+import {cssVariable, State, STATE_NAMES as stateNames} from "@kestra-io/ui-libs";
 import {getSchemeValue} from "../../../utils/scheme";
 
 export function tooltip(tooltipModel: {
@@ -105,7 +105,6 @@ export function extractState(value: any) {
     if (!value || typeof value !== "string") return value;
 
     if (value.includes(",")) {
-        const stateNames = State.arrayAllStates().map(state => state.name);
         const matchedState = value.split(",")
             .map(part => part.trim())
             .find(part => stateNames.includes(part.toUpperCase()));

--- a/ui/src/components/filter/composables/useValues.ts
+++ b/ui/src/components/filter/composables/useValues.ts
@@ -2,7 +2,7 @@ import {useI18n} from "vue-i18n";
 
 import {Value} from "../utils/types";
 
-import {State} from "@kestra-io/ui-libs";
+import {STATE_NAMES as stateNames} from "@kestra-io/ui-libs";
 import {auditLogTypes} from "../../../models/auditLogTypes";
 import permission from "../../../models/permission";
 import action from "../../../models/action";
@@ -34,7 +34,7 @@ export function useValues(label: string | undefined, t?: ReturnType<typeof useI1
 
     const VALUES = {
         EXECUTION_STATES: buildFromArray(
-            State.arrayAllStates().map((state: { name: string }) => state.name),
+           [...stateNames],
         ),
         TRIGGER_STATES: buildFromArray(["ENABLED", "DISABLED"], true),
         SCOPES: [

--- a/ui/src/utils/scheme.ts
+++ b/ui/src/utils/scheme.ts
@@ -1,23 +1,6 @@
 import {computed} from "vue";
 import {useTheme} from "./utils"
-import {cssVariable} from "@kestra-io/ui-libs";
-
-const executionStates = [
-    "CANCELLED",
-    "CREATED",
-    "FAILED",
-    "KILLED",
-    "KILLING",
-    "PAUSED",
-    "QUEUED",
-    "RESTARTED",
-    "RETRIED",
-    "RETRYING",
-    "RUNNING",
-    "SKIPPED",
-    "SUCCESS",
-    "WARNING"
-] as const;
+import {cssVariable, STATE_NAMES as executionStates} from "@kestra-io/ui-libs";
 
 const logLevels = [
     "DEBUG",


### PR DESCRIPTION
@Piyush-r-bhaskar 

##  Description  
This PR syncs the execution state lists used in the UI with the canonical list defined in **`@kestra-io/ui-libs`**, ensuring consistency across both repositories.  

##  Related Work  
- **Issue:** [kestra-io/ui-libs#444](https://github.com/kestra-io/ui-libs/issues/444)  
- **PR:** [kestra-io/ui-libs#883](https://github.com/kestra-io/ui-libs/pull/883)  

##  Summary of Changes  
- Updated UI state lists to reference the unified `STATE_NAMES` from `ui-libs`.  
- Removed redundant local state arrays.  
- Ensured compatibility with existing components relying on execution states.  