### PR TITLE
feat(ui): Improve mobile/tablet responsiveness for sidebar and top navigation 

### DIFF
--- a/ui/src/components/layout/SideBar.vue
+++ b/ui/src/components/layout/SideBar.vue
@@ -77,7 +77,6 @@
                     r.disabled = true;
                 }
 
-                // route hack is still needed for blueprints
                 if (r.href !== "/" && ($route.path.startsWith(r.href) || r.routes?.includes($route.name))) {
                     r.class = "vsm--link_active";
                 }
@@ -99,7 +98,6 @@
     }
 
     onUpdated(() => {
-        // Required here because in mounted() the menu is not yet rendered
         expandParentIfNeeded();
     })
 
@@ -114,8 +112,6 @@
                     class: "menu-icon",
                 },
                 child: [{
-                    // here we use only one component for all bookmarks
-                    // so when one edits the bookmark, it will be updated without closing the section
                     component: () => h(BookmarkLinkList, {pages: bookmarksStore.pages}),
                 }]
             }] : []),
@@ -149,6 +145,23 @@
     z-index: 1039;
     border-right: 1px solid var(--ks-border-primary);
     background-color: var(--ks-background-left-menu);
+
+    @media (max-width: 992px) {
+        position: fixed !important;
+        top: 0;
+        left: 0;
+        bottom: 0;
+        height: 100vh; 
+        width: 100% !important; 
+        z-index: 9999;
+
+        &.vsm--collapsed {
+            transform: translateX(-100%) !important;
+            transition: transform 0.3s ease-in-out !important;
+            visibility: hidden !important;
+            pointer-events: none; 
+        }
+    }
 
     .logo {
         overflow: hidden;

--- a/ui/src/components/layout/TopNavBar.vue
+++ b/ui/src/components/layout/TopNavBar.vue
@@ -6,7 +6,7 @@
                     v-if="layoutStore.sideMenuCollapsed"
                     @toggle="layoutStore.setSideMenuCollapsed(false)"
                 />
-                <div class="d-flex flex-column gap-2">
+                <div class="d-flex md:flex-column gap-2">
                     <el-breadcrumb v-if="breadcrumb">
                         <el-breadcrumb-item v-for="(item, x) in breadcrumb" :key="x" :class="{'pe-none': item.disabled}">
                             <a v-if="item.disabled || !item.link">
@@ -36,20 +36,33 @@
                 </div>
             </div>
         </div>
-        <div class="d-lg-flex side gap-2 flex-shrink-0 align-items-center mycontainer">
-            <div class="d-none d-lg-flex align-items-center">
-                <GlobalSearch class="trigger-flow-guided-step" />
-            </div>
-            <div class="d-flex side gap-2 flex-shrink-0 align-items-center">
-                <el-button v-if="shouldDisplayDeleteButton && logsStore.logs !== undefined && logsStore.logs.length > 0" @click="deleteLogs()">
-                    <TrashCan class="me-2" />
-                    <span>{{ $t("delete logs") }}</span>
-                </el-button>
-            </div>
+
+        <div class="d-none d-lg-flex side gap-2 flex-shrink-0 align-items-center">
+            <GlobalSearch class="trigger-flow-guided-step" />
+            <el-button v-if="shouldDisplayDeleteButton && logsStore.logs !== undefined && logsStore.logs.length > 0" @click="deleteLogs()">
+                <TrashCan class="me-2" />
+                <span>{{ $t("delete logs") }}</span>
+            </el-button>
             <slot name="additional-right" />
             <div class="d-flex fixed-buttons icons">
                 <Impersonating />
             </div>
+        </div>
+
+        <div class="d-flex d-lg-none side gap-2 flex-shrink-0 align-items-center">
+            <HamburgerDropdown>
+                <div class="d-flex flex-column gap-3 p-3">
+                    <GlobalSearch class="trigger-flow-guided-step" />
+                    <el-button v-if="shouldDisplayDeleteButton && logsStore.logs !== undefined && logsStore.logs.length > 0" @click="deleteLogs()">
+                        <TrashCan class="me-2" />
+                        <span>{{ $t("delete logs") }}</span>
+                    </el-button>
+                    <slot name="additional-right" />
+                    <div class="d-flex fixed-buttons icons">
+                        <Impersonating />
+                    </div>
+                </div>
+            </HamburgerDropdown>
         </div>
     </nav>
 </template>
@@ -71,6 +84,7 @@
     import {useFlowStore} from "../../stores/flow";
     import {useLayoutStore} from "../../stores/layout";
     import SidebarToggleButton from "./SidebarToggleButton.vue";
+    import HamburgerDropdown from "../HamburgerDropdown.vue"; // Ensure this is imported
 
     type RouterLinkTo = InstanceType<typeof RouterLink>["$props"]["to"];
 
@@ -210,29 +224,6 @@
                 margin: 0;
                 gap: .5rem;
                 align-items: center;
-            }
-        }
-        @media (max-width: 768px) {
-            .mycontainer {
-                display: grid;
-                grid-template-columns: repeat(3, minmax(0, auto));
-                grid-template-rows: repeat(2, auto);
-                gap: 10px;
-                overflow: hidden;
-            }
-            .icons {
-                grid-row: 2;
-                grid-column: 2;
-                display: contents;
-            }
-        }
-        @media (max-width: 664px) {
-            .mycontainer {
-                display: grid;
-                grid-template-columns: repeat(2, minmax(0, auto));
-                grid-template-rows: repeat(2, auto);
-                gap: 10px;
-                overflow: hidden;
             }
         }
     }


### PR DESCRIPTION
### What changes are being made and why?
These changes address responsive layout issues and improve the user experience on mobile and tablet viewports.

Responsive Sidebar (SideBar.vue):

The sidebar layout has been updated with CSS media queries to behave as a fixed overlay on screens narrower than 992px (mobile and tablet viewports).

When displayed as an overlay, it spans the full height of the viewport (100vh) and is positioned above the main content with a high z-index.

When collapsed on small screens, the sidebar now uses a transform: translateX(-100%) to move completely off-screen, ensuring a proper off-canvas menu experience. This prevents the sidebar from pushing the main content when open and is the correct modern mobile pattern.

Responsive Top Navigation Bar (TopNavBar.vue):

The secondary action buttons and components (like Global Search, Delete Logs, and Impersonating) were causing overlap issues with the new mobile sidebar toggle button on small screens.

The affected components are now wrapped in a <HamburgerDropdown> component and are only displayed on non-desktop viewports (d-lg-none).

This reorganizes the layout on mobile/tablet, grouping less critical actions into a single menu button, resolving the overlap, and maintaining functionality without cluttering the compact viewport.

How the changes have been QAed?
The responsiveness was verified by:

Manually resizing the browser window to break points below 992px (tablet/mobile).

Checking that the sidebar toggles open as an overlay and covers the page content.

Confirming that the elements previously overlapping the sidebar toggle button in the top navigation bar are now correctly hidden within the new hamburger dropdown menu on mobile screens.

### Setup Instructions
No special setup is required as these changes are limited to frontend (Vue.js/SCSS) component logic and styling.

Closes #11525 