### PR TITLE
fix(core): use proper option after P30D in misc

### DIFF
--- a/ui/src/components/filter/composables/useValues.ts
+++ b/ui/src/components/filter/composables/useValues.ts
@@ -43,7 +43,7 @@ export function useValues(label: string | undefined, t?: ReturnType<typeof useI1
         {label: t("datepicker.last24hours"), value: "PT24H"},
         {label: t("datepicker.last48hours"), value: "PT48H"},
         {label: t("datepicker.last7days"), value: "PT168H"},
-        {label: t("datepicker.last30days"), value: "PT720H"},
+        {label: t("datepicker.last30days"), value: "P30D"},
         {label: t("datepicker.last365days"), value: "PT8760H"},
     ];
 


### PR DESCRIPTION
bug screenshot

<img width="2252" height="1426" alt="image" src="https://github.com/user-attachments/assets/e4abace2-0b51-41a7-bca7-d2ca203b9d09" />
