### PR TITLE
fix: failing sanity checks

### DIFF
--- a/core/src/test/resources/sanity-checks/all_core.yaml
+++ b/core/src/test/resources/sanity-checks/all_core.yaml
@@ -16,7 +16,7 @@ tasks:
       - log
       - namespace_files
       - parallel
-      - pause
+      - pause-test
       - purge_current_execution_files
       - request-basicauth-deprecated
       - request-basicauth


### PR DESCRIPTION
### What changes are being made and why?

The ID has changed from `pause` to `pause-test` (https://github.com/kestra-io/kestra/blob/develop/core/src/test/resources/sanity-checks/pause-test.yaml), making the sanity check fail. So fixing the id for the subflow
