### PR TITLE
Bug Fix: fixes toast width issue 12518

### DIFF
--- a/ui/src/styles/layout/element-plus-overload.scss
+++ b/ui/src/styles/layout/element-plus-overload.scss
@@ -1029,7 +1029,7 @@ form.ks-horizontal {
 
         @include res(lg) {
             width: 35%;
-           min-width: auto;
+            min-width: auto;
         }
     }
 }

--- a/ui/src/styles/layout/element-plus-overload.scss
+++ b/ui/src/styles/layout/element-plus-overload.scss
@@ -1029,7 +1029,7 @@ form.ks-horizontal {
 
         @include res(lg) {
             width: 35%;
-            min-width: 800px;
+           min-width: auto;
         }
     }
 }


### PR DESCRIPTION
<!-- Thanks for submitting a Pull Request to Kestra. To help us review your contribution, please follow the guidelines below:

- Make sure that your commits follow the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) specification e.g. `feat(ui): add a new navigation menu item` or `fix(core): fix a bug in the core model` or `docs: update the README.md`. This will help us automatically generate the changelog.
- The title should briefly summarize the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share a flow example to help the reviewer understand and QA the change.
- Use "closes" to automatically close an issue. For example, `closes #1234` will close issue #1234. -->

### What changes are being made and why?

<!-- Please include a brief summary of the changes included in this PR e.g. closes #1234. -->
closes #12518 Toast Notification width issue 
width was forced 800px earlier so it was appearing to be wide and overlapping so changed to auto
after fix:

<img width="1440" height="900" alt="Screenshot 2025-11-03 at 10 00 44 PM" src="https://github.com/user-attachments/assets/497eb8e8-2216-430a-a5c5-3c1cecd8d788" />



---


<!-- Include example code that shows how this PR has been QAed. The code should present a complete yet easily reproducible flow.

```yaml
# Your example flow code here
```

Note that this is not a replacement for unit tests but rather a way to demonstrate how the changes work in a real-life scenario, as the end-user would experience them.

Remove this section if this change applies to all flows or to the documentation only. -->

---

### Setup Instructions

<!--If there are any setup requirements like API keys or trial accounts, kindly include brief bullet-points-description outlining the setup process below.

- [External System Documentation](URL)
- Steps to set up the necessary resources

If there are no setup requirements, you can remove this section.

Thank you for your contribution. ❤️ Don't forget to give us a star! ⭐  -->
