### PR TITLE
chore(core): remove console warning

### DIFF
--- a/ui/src/components/ContextInfoBar.vue
+++ b/ui/src/components/ContextInfoBar.vue
@@ -43,7 +43,9 @@
             <KeepAlive>
                 <ContextDocs v-if="activeTab === 'docs'" />
                 <ContextNews v-else-if="activeTab === 'news'" />
-                <component v-else :is="activeTab" />
+                <template v-else>
+                    {{ activeTab }}
+                </template>
             </KeepAlive>
         </div>
     </div>


### PR DESCRIPTION
```
extend.iife.js:146 Invalid vnode type when creating vnode: . Proxy(Object) {_pStores: {…}, …} at <ContextInfoBar>
at <DefaultLayout>
at <ElConfigProvider>
at <App> (4) [{…}, {…}, {…}, {…}]
```