### PR TITLE
fix(core): set proper classes for tabs depending on locked status

### DIFF
--- a/ui/src/components/Tabs.vue
+++ b/ui/src/components/Tabs.vue
@@ -128,8 +128,8 @@
                 }
             },
             getTabClasses(tab) {
-                if(tab.locked) return ["px-0"];
-                return ["container", "mt-4"];
+                if(tab.locked) return {"px-0": true};
+                return {"container": true, "mt-4": true};
             }
         },
         computed: {


### PR DESCRIPTION
Related to https://github.com/kestra-io/kestra/pull/12295/files#r2495479880.

<img width="1767" height="787" alt="image" src="https://github.com/user-attachments/assets/83061ab9-4445-41e4-b8c0-4292d2802de4" />