### PR TITLE
fix(ui): adjust padding and add gradient for cleaner layout

### DIFF
--- a/ui/src/components/layout/TopNavBar.vue
+++ b/ui/src/components/layout/TopNavBar.vue
@@ -161,6 +161,21 @@
             overflow: hidden;
         }
 
+        .top-title {
+            position: relative;
+
+        &::after {
+            content: "";
+            position: absolute;
+            top: 0;
+            right: 0;
+            width: 40px;
+            height: 100%;
+            background: linear-gradient(to left, var(--ks-background-card), transparent);
+            pointer-events: none;
+            }
+        }
+
         h1 {
             line-height: 1.6;
             display: flex !important;
@@ -212,7 +227,14 @@
                 align-items: center;
             }
         }
+
+        @media (max-width: 992px) {
+            padding: 0.75rem 1.5rem;
+        }
+
         @media (max-width: 768px) {
+            padding: 0.4rem 0.75rem;
+
             .mycontainer {
                 display: grid;
                 grid-template-columns: repeat(3, minmax(0, auto));
@@ -227,6 +249,8 @@
             }
         }
         @media (max-width: 664px) {
+            padding: 0.3rem 0.5rem;
+            
             .mycontainer {
                 display: grid;
                 grid-template-columns: repeat(2, minmax(0, auto));


### PR DESCRIPTION
What changes are being made and why?

     Updated the TopNavBar component:

     Reduced padding for smaller screens to improve mobile layout.

     Added a light right-side gradient on the title for a cleaner look.

Closes #12727

How the changes have been tested?

     Tested manually by running the UI locally and resizing the browser window.

     Padding adjusts correctly on small screens.

     Gradient appears on the right side of the title.

     Layout looks clean with no text cutoff or icon overlap.
