### PR TITLE
fix(executions): don't urlencode files as they would already be insid…

### DIFF
--- a/core/src/main/java/io/kestra/core/runners/FilesService.java
+++ b/core/src/main/java/io/kestra/core/runners/FilesService.java
@@ -82,8 +82,7 @@ public abstract class FilesService {
     }
 
     private static String resolveUniqueNameForFile(final Path path) {
-        String filename = path.getFileName().toString();
-        String encodedFilename = java.net.URLEncoder.encode(filename, java.nio.charset.StandardCharsets.UTF_8);
-        return IdUtils.from(path.toString()) + "-" + encodedFilename;
+        String filename = path.getFileName().toString().replace(' ', '+');
+        return IdUtils.from(path.toString()) + "-" + filename;
     }
 }

--- a/core/src/test/java/io/kestra/core/runners/FilesServiceTest.java
+++ b/core/src/test/java/io/kestra/core/runners/FilesServiceTest.java
@@ -106,28 +106,28 @@ class FilesServiceTest {
         var runContext = runContextFactory.of();
 
         Path fileWithSpace = tempDir.resolve("with space.txt");
-        Path fileWithUnicode = tempDir.resolve("สวัสดี.txt");
+        Path fileWithUnicode = tempDir.resolve("สวัสดี&.txt");
 
         Files.writeString(fileWithSpace, "content");
         Files.writeString(fileWithUnicode, "content");
 
         Path targetFileWithSpace = runContext.workingDir().path().resolve("with space.txt");
-        Path targetFileWithUnicode = runContext.workingDir().path().resolve("สวัสดี.txt");
+        Path targetFileWithUnicode = runContext.workingDir().path().resolve("สวัสดี&.txt");
 
         Files.copy(fileWithSpace, targetFileWithSpace);
         Files.copy(fileWithUnicode, targetFileWithUnicode);
 
         Map<String, URI> outputFiles = FilesService.outputFiles(
             runContext,
-            List.of("with space.txt", "สวัสดี.txt")
+            List.of("with space.txt", "สวัสดี&.txt")
         );
 
         assertThat(outputFiles).hasSize(2);
         assertThat(outputFiles).containsKey("with space.txt");
-        assertThat(outputFiles).containsKey("สวัสดี.txt");
+        assertThat(outputFiles).containsKey("สวัสดี&.txt");
 
         assertThat(runContext.storage().getFile(outputFiles.get("with space.txt"))).isNotNull();
-        assertThat(runContext.storage().getFile(outputFiles.get("สวัสดี.txt"))).isNotNull();
+        assertThat(runContext.storage().getFile(outputFiles.get("สวัสดี&.txt"))).isNotNull();
     }
 
     private URI createFile() throws IOException {


### PR DESCRIPTION
…e the storage

It reverts a mis-behaving fix for supporting files with special characters.
Tested with both the local storage and MinIO (which fail otherwise)
