### PR TITLE
Remove URL encoding from file names in FilesService and Download task

### DIFF
--- a/core/src/main/java/io/kestra/core/runners/FilesService.java
+++ b/core/src/main/java/io/kestra/core/runners/FilesService.java
@@ -83,7 +83,6 @@ public abstract class FilesService {
 
     private static String resolveUniqueNameForFile(final Path path) {
         String filename = path.getFileName().toString();
-        String encodedFilename = java.net.URLEncoder.encode(filename, java.nio.charset.StandardCharsets.UTF_8);
-        return IdUtils.from(path.toString()) + "-" + encodedFilename;
+        return IdUtils.from(path.toString()) + "-" + filename;
     }
 }

--- a/core/src/main/java/io/kestra/plugin/core/http/Download.java
+++ b/core/src/main/java/io/kestra/plugin/core/http/Download.java
@@ -116,10 +116,6 @@ public class Download extends AbstractHttp implements RunnableTask<Download.Outp
                 String contentDisposition = response.getHeaders().firstValue("Content-Disposition").orElseThrow();
                 filename = filenameFromHeader(runContext, contentDisposition);
             }
-            if (filename != null) {
-                filename = URLEncoder.encode(filename, StandardCharsets.UTF_8);
-            }
-
             logger.debug("File '{}' downloaded with size '{}'", from, size);
 
             return Output.builder()


### PR DESCRIPTION
## Overview
This PR removes URL encoding that was being applied to file names in both the `FilesService` and the `Download` task. The issue was causing file names to be encoded unnecessarily when handling file paths, which could lead to unexpected file names containing encoded characters.

## Checklist
- [ ] Code changes are complete
- [ ] Tests pass
- [ ] Documentation updated (if applicable)

## Proof that changes are correct
The changes involve removing calls to `URLEncoder.encode()` in both `FilesService.resolveUniqueNameForFile()` and `Download.run()`. By removing these calls, file names will now be preserved as-is, which is the expected behavior. The change is minimal and reduces complexity by removing unnecessary encoding that was likely introduced to handle special characters but ended up causing more issues than it solved. The fix ensures that file names are handled consistently without additional encoding.