### PR TITLE
fix(core): bulk deletion of executions

### DIFF
--- a/ui/src/components/executions/Executions.vue
+++ b/ui/src/components/executions/Executions.vue
@@ -70,7 +70,7 @@
                     @selection-change="handleSelectionChange"
                     :selectable="!hidden?.includes('selection') && canCheck"
                     :no-data-text="$t('no_results.executions')"
-                    :rowKey="(row: any) => `${row.namespace}-${row.id}`"
+                    :rowKey="(row: any) => row.id"
                 >
                     <template #select-actions>
                         <BulkSelect


### PR DESCRIPTION
Bug reproducer

- Go to `Executions` Page
- `Select all` of the Executions **and**  Try to `Delete` from Actions button
- Receive **success Toast** with **`0`** **executions** deleted