### PR TITLE
fix(executions): allow reading from subflow even if we have a parent

### DIFF
--- a/core/src/main/java/io/kestra/core/runners/pebble/functions/AbstractFileFunction.java
+++ b/core/src/main/java/io/kestra/core/runners/pebble/functions/AbstractFileFunction.java
@@ -151,10 +151,7 @@ abstract class AbstractFileFunction implements Function {
             // if there is a trigger of type execution, we also allow accessing a file from the parent execution
             Map<String, String> trigger = (Map<String, String>) context.getVariable(TRIGGER);
 
-            if (!isFileUriValid(trigger.get(NAMESPACE), trigger.get("flowId"), trigger.get("executionId"), path)) {
-                throw new IllegalArgumentException("Unable to read the file '" + path + "' as it didn't belong to the parent execution");
-            }
-            return true;
+            return isFileUriValid(trigger.get(NAMESPACE), trigger.get("flowId"), trigger.get("executionId"), path);
         }
         return false;
     }

--- a/core/src/test/java/io/kestra/core/runners/pebble/functions/FileSizeFunctionTest.java
+++ b/core/src/test/java/io/kestra/core/runners/pebble/functions/FileSizeFunctionTest.java
@@ -113,33 +113,6 @@ public class FileSizeFunctionTest {
     }
 
     @Test
-    void shouldThrowIllegalArgumentException_givenTrigger_andParentExecution_andMissingNamespace() throws IOException {
-        String executionId = IdUtils.create();
-        URI internalStorageURI = getInternalStorageURI(executionId);
-        URI internalStorageFile = getInternalStorageFile(internalStorageURI);
-
-        Map<String, Object> variables = Map.of(
-            "flow", Map.of(
-                "id", "subflow",
-                "namespace", NAMESPACE,
-                "tenantId", MAIN_TENANT),
-            "execution", Map.of("id", IdUtils.create()),
-            "trigger", Map.of(
-                "flowId", FLOW,
-                "executionId", executionId,
-                "tenantId", MAIN_TENANT
-            )
-        );
-
-        Exception ex = assertThrows(
-            IllegalArgumentException.class,
-            () -> variableRenderer.render("{{ fileSize('" + internalStorageFile + "') }}", variables)
-        );
-
-        assertTrue(ex.getMessage().startsWith("Unable to read the file"), "Exception message doesn't match expected one");
-    }
-
-    @Test
     void returnsCorrectSize_givenUri_andCurrentExecution() throws IOException, IllegalVariableEvaluationException {
         String executionId = IdUtils.create();
         URI internalStorageURI = getInternalStorageURI(executionId);

--- a/core/src/test/java/io/kestra/core/runners/pebble/functions/ReadFileFunctionTest.java
+++ b/core/src/test/java/io/kestra/core/runners/pebble/functions/ReadFileFunctionTest.java
@@ -259,6 +259,27 @@ class ReadFileFunctionTest {
         assertThat(variableRenderer.render("{{ read(nsfile) }}", variables)).isEqualTo("Hello World");
     }
 
+    @Test
+    void shouldReadChildFileEvenIfTrigger() throws IOException, IllegalVariableEvaluationException {
+        String namespace = "my.namespace";
+        String flowId = "flow";
+        String executionId = IdUtils.create();
+        URI internalStorageURI = URI.create("/" + namespace.replace(".", "/") + "/" + flowId + "/executions/" + executionId + "/tasks/task/" + IdUtils.create() + "/123456.ion");
+        URI internalStorageFile = storageInterface.put(MAIN_TENANT, namespace, internalStorageURI, new ByteArrayInputStream("Hello from a task output".getBytes()));
+
+        Map<String, Object> variables = Map.of(
+            "flow", Map.of(
+                "id", "flow",
+                "namespace", "notme",
+                "tenantId", MAIN_TENANT),
+            "execution", Map.of("id", "notme"),
+            "trigger", Map.of("namespace", "notme", "flowId", "parent", "executionId", "parent")
+        );
+
+        String render = variableRenderer.render("{{ read('" + internalStorageFile + "') }}", variables);
+        assertThat(render).isEqualTo("Hello from a task output");
+    }
+
     private URI createFile() throws IOException {
         File tempFile = File.createTempFile("file", ".txt");
         Files.write(tempFile.toPath(), "Hello World".getBytes());


### PR DESCRIPTION
This fixes an issue where you cannot read from a Subflow file if the execution has iteself be triggered by another Subflow task. It was caused by the trigger check beeing too aggressive, if it didn't pass the check it fail instead of return false so the other check would not be processed.

Fixes #12629