### PR TITLE
fix(secrets): NS update for a secret  should be disabled properly with correct prop

### DIFF
--- a/ui/src/components/secrets/SecretsTable.vue
+++ b/ui/src/components/secrets/SecretsTable.vue
@@ -148,7 +148,7 @@
                 >
                     <NamespaceSelect
                         v-model="secret.namespace"
-                        :readonly="secret.update"
+                        :readOnly="secret.update"
                         :includeSystemNamespace="true"
                         all
                     />


### PR DESCRIPTION
Closes https://github.com/kestra-io/kestra-ee/issues/5646

Note to self: Backport to `1.0` and `1.1`