### PR TITLE
fix(system): access log configuration

### DIFF
--- a/cli/src/main/resources/application.yml
+++ b/cli/src/main/resources/application.yml
@@ -30,15 +30,15 @@ micronaut:
     read-idle-timeout: 60m
     write-idle-timeout: 60m
     idle-timeout: 60m
-    netty:
-      max-zstd-encode-size: 67108864 # increased to 64MB from the default of 32MB
-      max-chunk-size: 10MB
-      max-header-size: 32768 # increased from the default of 8k
     responses:
       file:
         cache-seconds: 86400
         cache-control:
           public: true
+    netty:
+      max-zstd-encode-size: 67108864 # increased to 64MB from the default of 32MB
+      max-chunk-size: 10MB
+      max-header-size: 32768 # increased from the default of 8k
 
       # Access log configuration, see https://docs.micronaut.io/latest/guide/index.html#accessLogger
       access-logger:

--- a/cli/src/test/java/io/kestra/cli/commands/configs/sys/NoConfigCommandTest.java
+++ b/cli/src/test/java/io/kestra/cli/commands/configs/sys/NoConfigCommandTest.java
@@ -68,7 +68,8 @@ class NoConfigCommandTest {
 
 
             assertThat(exitCode).isNotZero();
-            assertThat(out.toString()).isEmpty();
+            // check that the only log is an access log: this has the advantage to also check that access log is working!
+            assertThat(out.toString()).contains("POST /api/v1/main/flows HTTP/1.1 | status: 500");
             assertThat(err.toString()).contains("No bean of type [io.kestra.core.repositories.FlowRepositoryInterface] exists");
         }
     }


### PR DESCRIPTION
Due to a change in the configuration file, access log configuration was in the wrong sub-document.

Fixes https://github.com/kestra-io/kestra-ee/issues/5670
