### PR TITLE
fix(flow): don't URLEncode the fileName inside the Download task

### DIFF
--- a/core/src/main/java/io/kestra/plugin/core/http/Download.java
+++ b/core/src/main/java/io/kestra/plugin/core/http/Download.java
@@ -20,8 +20,6 @@ import java.io.BufferedOutputStream;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.net.URI;
-import java.net.URLEncoder;
-import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
@@ -60,7 +58,15 @@ import static io.kestra.core.utils.Rethrow.throwConsumer;
 public class Download extends AbstractHttp implements RunnableTask<Download.Output> {
     @Schema(title = "Should the task fail when downloading an empty file.")
     @Builder.Default
-    private final Property<Boolean> failOnEmptyResponse = Property.ofValue(true);
+    private Property<Boolean> failOnEmptyResponse = Property.ofValue(true);
+
+    @Schema(
+        title = "Name of the file inside the output.",
+        description = """
+            If not provided, the filename will be extracted from the `Content-Disposition` header.
+            If no `Content-Disposition` header, a name would be generated."""
+    )
+    private Property<String> saveAs;
 
     public Output run(RunContext runContext) throws Exception {
         Logger logger = runContext.logger();
@@ -111,20 +117,22 @@ public class Download extends AbstractHttp implements RunnableTask<Download.Outp
                 }
             }
 
-            String filename = null;
-            if (response.getHeaders().firstValue("Content-Disposition").isPresent()) {
-                String contentDisposition = response.getHeaders().firstValue("Content-Disposition").orElseThrow();
-                filename = filenameFromHeader(runContext, contentDisposition);
-            }
-            if (filename != null) {
-                filename = URLEncoder.encode(filename, StandardCharsets.UTF_8);
+            String rFilename = runContext.render(this.saveAs).as(String.class).orElse(null);
+            if (rFilename == null) {
+                if (response.getHeaders().firstValue("Content-Disposition").isPresent()) {
+                    String contentDisposition = response.getHeaders().firstValue("Content-Disposition").orElseThrow();
+                    rFilename = filenameFromHeader(runContext, contentDisposition);
+                    if (rFilename != null) {
+                        rFilename = rFilename.replace(' ', '+');
+                    }
+                }
             }
 
             logger.debug("File '{}' downloaded with size '{}'", from, size);
 
             return Output.builder()
                 .code(response.getStatus().getCode())
-                .uri(runContext.storage().putFile(tempFile, filename))
+                .uri(runContext.storage().putFile(tempFile, rFilename))
                 .headers(response.getHeaders().map())
                 .length(size.get())
                 .build();

--- a/core/src/test/java/io/kestra/plugin/core/http/DownloadTest.java
+++ b/core/src/test/java/io/kestra/plugin/core/http/DownloadTest.java
@@ -156,6 +156,26 @@ class DownloadTest {
         assertThat(output.getUri().toString()).endsWith("filename.jpg");
     }
 
+
+    @Test
+    void fileNameShouldOverrideContentDisposition() throws Exception {
+        EmbeddedServer embeddedServer = applicationContext.getBean(EmbeddedServer.class);
+        embeddedServer.start();
+
+        Download task = Download.builder()
+            .id(DownloadTest.class.getSimpleName())
+            .type(DownloadTest.class.getName())
+            .uri(Property.ofValue(embeddedServer.getURI() + "/content-disposition"))
+            .saveAs(Property.ofValue("hardcoded-filename.jpg"))
+            .build();
+
+        RunContext runContext = TestsUtils.mockRunContext(this.runContextFactory, task, ImmutableMap.of());
+
+        Download.Output output = task.run(runContext);
+
+        assertThat(output.getUri().toString()).endsWith("hardcoded-filename.jpg");
+    }
+
     @Test
     void contentDispositionWithPath() throws Exception {
         EmbeddedServer embeddedServer = applicationContext.getBean(EmbeddedServer.class);


### PR DESCRIPTION
Also provide a `fileName` property that when set would override any filename from the content disposition in case it causes issues.
