### PR TITLE
fix(flow): flow trigger with both conditions and preconditions

### DIFF
--- a/core/src/test/java/io/kestra/core/runners/AbstractRunnerTest.java
+++ b/core/src/test/java/io/kestra/core/runners/AbstractRunnerTest.java
@@ -274,6 +274,12 @@ public abstract class AbstractRunnerTest {
     }
 
     @Test
+    @LoadFlows({"flows/valids/flow-trigger-mixed-conditions-flow-a.yaml", "flows/valids/flow-trigger-mixed-conditions-flow-listen.yaml"})
+    void flowTriggerMixedConditions() throws Exception {
+        multipleConditionTriggerCaseTest.flowTriggerMixedConditions();
+    }
+
+    @Test
     @LoadFlows({"flows/valids/each-null.yaml"})
     void eachWithNull() throws Exception {
         EachSequentialTest.eachNullTest(runnerUtils, logsQueue);

--- a/core/src/test/java/io/kestra/core/runners/MultipleConditionTriggerCaseTest.java
+++ b/core/src/test/java/io/kestra/core/runners/MultipleConditionTriggerCaseTest.java
@@ -232,4 +232,24 @@ public class MultipleConditionTriggerCaseTest {
             e -> e.getState().getCurrent().equals(Type.SUCCESS),
             MAIN_TENANT, "io.kestra.tests.trigger.multiple.conditions", "flow-trigger-multiple-conditions-flow-listen", Duration.ofSeconds(1)));
     }
+
+    public void flowTriggerMixedConditions() throws TimeoutException, QueueException {
+        Execution execution = runnerUtils.runOne(MAIN_TENANT, "io.kestra.tests.trigger.mixed.conditions",
+            "flow-trigger-mixed-conditions-flow-a");
+        assertThat(execution.getTaskRunList().size()).isEqualTo(1);
+        assertThat(execution.getState().getCurrent()).isEqualTo(State.Type.SUCCESS);
+
+        // trigger is done
+        Execution triggerExecution = runnerUtils.awaitFlowExecution(
+            e -> e.getState().getCurrent().equals(Type.SUCCESS),
+            MAIN_TENANT, "io.kestra.tests.trigger.mixed.conditions", "flow-trigger-mixed-conditions-flow-listen");
+        executionRepository.delete(triggerExecution);
+        assertThat(triggerExecution.getTaskRunList().size()).isEqualTo(1);
+        assertThat(triggerExecution.getState().getCurrent()).isEqualTo(State.Type.SUCCESS);
+
+        // we assert that we didn't have any other flow triggered
+        assertThrows(RuntimeException.class, () -> runnerUtils.awaitFlowExecution(
+            e -> e.getState().getCurrent().equals(Type.SUCCESS),
+            MAIN_TENANT, "io.kestra.tests.trigger.mixed.conditions", "flow-trigger-mixed-conditions-flow-listen", Duration.ofSeconds(1)));
+    }
 }

--- a/core/src/test/resources/flows/valids/flow-trigger-mixed-conditions-flow-a.yaml
+++ b/core/src/test/resources/flows/valids/flow-trigger-mixed-conditions-flow-a.yaml
@@ -1,0 +1,10 @@
+id: flow-trigger-mixed-conditions-flow-a
+namespace: io.kestra.tests.trigger.mixed.conditions
+
+labels:
+  some: label
+
+tasks:
+  - id: only
+    type: io.kestra.plugin.core.debug.Return
+    format: "from parents: {{execution.id}}"

--- a/core/src/test/resources/flows/valids/flow-trigger-mixed-conditions-flow-listen.yaml
+++ b/core/src/test/resources/flows/valids/flow-trigger-mixed-conditions-flow-listen.yaml
@@ -1,0 +1,25 @@
+id: flow-trigger-mixed-conditions-flow-listen
+namespace: io.kestra.tests.trigger.mixed.conditions
+
+triggers:
+  - id: on_completion
+    type: io.kestra.plugin.core.trigger.Flow
+    states: [ SUCCESS ]
+    conditions:
+      - type: io.kestra.plugin.core.condition.ExecutionFlow
+        namespace: io.kestra.tests.trigger.mixed.conditions
+        flowId: flow-trigger-mixed-conditions-flow-a
+  - id: on_failure
+    type: io.kestra.plugin.core.trigger.Flow
+    states: [ FAILED ]
+    preconditions:
+      id: flowsFailure
+      flows:
+        - namespace: io.kestra.tests.trigger.multiple.conditions
+          flowId: flow-trigger-multiple-conditions-flow-a
+          states: [FAILED]
+
+tasks:
+  - id: only
+    type: io.kestra.plugin.core.debug.Return
+    format: "It works"

--- a/executor/src/main/java/io/kestra/executor/FlowTriggerService.java
+++ b/executor/src/main/java/io/kestra/executor/FlowTriggerService.java
@@ -50,16 +50,147 @@ public class FlowTriggerService {
             .map(io.kestra.plugin.core.trigger.Flow.class::cast);
     }
 
-    public List<Execution> computeExecutionsFromFlowTriggers(Execution execution, List<? extends Flow> allFlows, Optional<MultipleConditionStorageInterface> multipleConditionStorage) {
-        List<FlowWithFlowTrigger> validTriggersBeforeMultipleConditionEval = allFlows.stream()
+    /**
+     * This method computes executions to trigger from flow triggers from a given execution.
+     * It only computes those depending on standard (non-multiple / non-preconditions) conditions, so it must be used
+     * in conjunction with {@link #computeExecutionsFromFlowTriggerPreconditions(Execution, Flow, MultipleConditionStorageInterface)}.
+     */
+    public List<Execution> computeExecutionsFromFlowTriggerConditions(Execution execution, Flow flow) {
+        List<FlowWithFlowTrigger> flowWithFlowTriggers = computeFlowTriggers(execution, flow)
+            .stream()
+            // we must filter on no multiple conditions and no preconditions to avoid evaluating two times triggers that have standard conditions and multiple conditions
+            .filter(it -> it.getTrigger().getPreconditions() == null && ListUtils.emptyOnNull(it.getTrigger().getConditions()).stream().noneMatch(MultipleCondition.class::isInstance))
+            .toList();
+
+        // short-circuit empty triggers to evaluate
+        if (flowWithFlowTriggers.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        // compute all executions to create from flow triggers without taken into account multiple conditions
+        return flowWithFlowTriggers.stream()
+            .map(f -> f.getTrigger().evaluate(
+                Optional.empty(),
+                runContextFactory.of(f.getFlow(), execution),
+                f.getFlow(),
+                execution
+            ))
+            .filter(Optional::isPresent)
+            .map(Optional::get)
+            .toList();
+    }
+
+    /**
+     * This method computes executions to trigger from flow triggers from a given execution.
+     * It only computes those depending on multiple conditions and preconditions, so it must be used
+     * in conjunction with {@link #computeExecutionsFromFlowTriggerConditions(Execution, Flow)}.
+     */
+    public List<Execution> computeExecutionsFromFlowTriggerPreconditions(Execution execution, Flow flow, MultipleConditionStorageInterface multipleConditionStorage) {
+        List<FlowWithFlowTrigger> flowWithFlowTriggers = computeFlowTriggers(execution, flow)
+            .stream()
+            // we must filter on multiple conditions or preconditions to avoid evaluating two times triggers that only have standard conditions
+            .filter(flowWithFlowTrigger -> flowWithFlowTrigger.getTrigger().getPreconditions() != null || ListUtils.emptyOnNull(flowWithFlowTrigger.getTrigger().getConditions()).stream().anyMatch(MultipleCondition.class::isInstance))
+            .toList();
+
+        // short-circuit empty triggers to evaluate
+        if (flowWithFlowTriggers.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        List<FlowWithFlowTriggerAndMultipleCondition> flowWithMultipleConditionsToEvaluate = flowWithFlowTriggers.stream()
+            .flatMap(flowWithFlowTrigger -> flowTriggerMultipleConditions(flowWithFlowTrigger)
+                .map(multipleCondition -> new FlowWithFlowTriggerAndMultipleCondition(
+                        flowWithFlowTrigger.getFlow(),
+                        multipleConditionStorage.getOrCreate(flowWithFlowTrigger.getFlow(), multipleCondition, execution.getOutputs()),
+                        flowWithFlowTrigger.getTrigger(),
+                        multipleCondition
+                    )
+                )
+            )
+            // avoid evaluating expired windows (for ex for daily time window or deadline)
+            .filter(flowWithFlowTriggerAndMultipleCondition -> flowWithFlowTriggerAndMultipleCondition.getMultipleConditionWindow().isValid(ZonedDateTime.now()))
+            .toList();
+
+        // evaluate multiple conditions
+        Map<FlowWithFlowTriggerAndMultipleCondition, MultipleConditionWindow> multipleConditionWindowsByFlow = flowWithMultipleConditionsToEvaluate.stream().map(f -> {
+                Map<String, Boolean> results = f.getMultipleCondition()
+                    .getConditions()
+                    .entrySet()
+                    .stream()
+                    .map(e -> new AbstractMap.SimpleEntry<>(
+                        e.getKey(),
+                        conditionService.isValid(e.getValue(), f.getFlow(), execution)
+                    ))
+                    .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+
+                return Map.entry(f, f.getMultipleConditionWindow().with(results));
+            })
+            .filter(e -> !e.getValue().getResults().isEmpty())
+            .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+
+        // persist results
+        multipleConditionStorage.save(new ArrayList<>(multipleConditionWindowsByFlow.values()));
+
+        // compute all executions to create from flow triggers now that multiple conditions storage is populated
+        List<Execution> executions = flowWithFlowTriggers.stream()
+            // will evaluate conditions
+            .filter(flowWithFlowTrigger ->
+                conditionService.isValid(
+                    flowWithFlowTrigger.getTrigger(),
+                    flowWithFlowTrigger.getFlow(),
+                    execution,
+                    multipleConditionStorage
+                )
+            )
+            // will evaluate preconditions
+            .filter(flowWithFlowTrigger ->
+                conditionService.isValid(
+                    flowWithFlowTrigger.getTrigger().getPreconditions(),
+                    flowWithFlowTrigger.getFlow(),
+                    execution,
+                    multipleConditionStorage
+                )
+            )
+            .map(f -> f.getTrigger().evaluate(
+                Optional.of(multipleConditionStorage),
+                runContextFactory.of(f.getFlow(), execution),
+                f.getFlow(),
+                execution
+            ))
+            .filter(Optional::isPresent)
+            .map(Optional::get)
+            .toList();
+
+        // purge fulfilled or expired multiple condition windows
+        Stream.concat(
+            multipleConditionWindowsByFlow.entrySet().stream()
+                .map(e -> Map.entry(
+                    e.getKey().getMultipleCondition(),
+                    e.getValue()
+                ))
+                .filter(e -> !Boolean.FALSE.equals(e.getKey().getResetOnSuccess()) &&
+                    e.getKey().getConditions().size() == Optional.ofNullable(e.getValue().getResults()).map(Map::size).orElse(0)
+                )
+                .map(Map.Entry::getValue),
+            multipleConditionStorage.expired(execution.getTenantId()).stream()
+        ).forEach(multipleConditionStorage::delete);
+
+        return executions;
+    }
+
+    private List<FlowWithFlowTrigger> computeFlowTriggers(Execution execution, Flow flow) {
+        if (
             // prevent recursive flow triggers
-            .filter(flow -> flowService.removeUnwanted(flow, execution))
-            // filter out Test Executions
-            .filter(flow -> execution.getKind() == null)
-            // ensure flow & triggers are enabled
-            .filter(flow -> !flow.isDisabled() && !(flow instanceof FlowWithException))
-            .filter(flow -> flow.getTriggers() != null && !flow.getTriggers().isEmpty())
-            .flatMap(flow -> flowTriggers(flow).map(trigger -> new FlowWithFlowTrigger(flow, trigger)))
+            !flowService.removeUnwanted(flow, execution) ||
+                // filter out Test Executions
+                execution.getKind() != null ||
+                // ensure flow & triggers are enabled
+                flow.isDisabled() || flow instanceof FlowWithException ||
+                flow.getTriggers() == null || flow.getTriggers().isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        return flowTriggers(flow).map(trigger -> new FlowWithFlowTrigger(flow, trigger))
             // filter on the execution state the flow listen to
             .filter(flowWithFlowTrigger -> flowWithFlowTrigger.getTrigger().getStates().contains(execution.getState().getCurrent()))
             // validate flow triggers conditions excluding multiple conditions
@@ -74,96 +205,6 @@ public class FlowTriggerService {
                     execution
                 )
             )).toList();
-
-        // short-circuit empty triggers to evaluate
-        if (validTriggersBeforeMultipleConditionEval.isEmpty()) {
-            return Collections.emptyList();
-        }
-
-        Map<FlowWithFlowTriggerAndMultipleCondition, MultipleConditionWindow> multipleConditionWindowsByFlow = null;
-        if (multipleConditionStorage.isPresent()) {
-            List<FlowWithFlowTriggerAndMultipleCondition> flowWithMultipleConditionsToEvaluate = validTriggersBeforeMultipleConditionEval.stream()
-                .flatMap(flowWithFlowTrigger -> flowTriggerMultipleConditions(flowWithFlowTrigger)
-                        .map(multipleCondition -> new FlowWithFlowTriggerAndMultipleCondition(
-                                flowWithFlowTrigger.getFlow(),
-                                multipleConditionStorage.get().getOrCreate(flowWithFlowTrigger.getFlow(), multipleCondition, execution.getOutputs()),
-                                flowWithFlowTrigger.getTrigger(),
-                                multipleCondition
-                            )
-                        )
-                )
-                // avoid evaluating expired windows (for ex for daily time window or deadline)
-                .filter(flowWithFlowTriggerAndMultipleCondition -> flowWithFlowTriggerAndMultipleCondition.getMultipleConditionWindow().isValid(ZonedDateTime.now()))
-                .toList();
-
-            // evaluate multiple conditions
-            multipleConditionWindowsByFlow = flowWithMultipleConditionsToEvaluate.stream().map(f -> {
-                    Map<String, Boolean> results = f.getMultipleCondition()
-                        .getConditions()
-                        .entrySet()
-                        .stream()
-                        .map(e -> new AbstractMap.SimpleEntry<>(
-                            e.getKey(),
-                            conditionService.isValid(e.getValue(), f.getFlow(), execution)
-                        ))
-                        .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
-
-                    return Map.entry(f, f.getMultipleConditionWindow().with(results));
-                })
-                .filter(e -> !e.getValue().getResults().isEmpty())
-                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
-
-            // persist results
-            multipleConditionStorage.get().save(new ArrayList<>(multipleConditionWindowsByFlow.values()));
-        }
-
-        // compute all executions to create from flow triggers now that multiple conditions storage is populated
-        List<Execution> executions = validTriggersBeforeMultipleConditionEval.stream()
-            // will evaluate conditions
-            .filter(flowWithFlowTrigger ->
-                conditionService.isValid(
-                    flowWithFlowTrigger.getTrigger(),
-                    flowWithFlowTrigger.getFlow(),
-                    execution,
-                    multipleConditionStorage.orElse(null)
-                )
-            )
-            // will evaluate preconditions
-            .filter(flowWithFlowTrigger ->
-                conditionService.isValid(
-                    flowWithFlowTrigger.getTrigger().getPreconditions(),
-                    flowWithFlowTrigger.getFlow(),
-                    execution,
-                    multipleConditionStorage.orElse(null)
-                )
-            )
-            .map(f -> f.getTrigger().evaluate(
-                multipleConditionStorage,
-                runContextFactory.of(f.getFlow(), execution),
-                f.getFlow(),
-                execution
-            ))
-            .filter(Optional::isPresent)
-            .map(Optional::get)
-            .toList();
-
-        if (multipleConditionStorage.isPresent()) {
-            // purge fulfilled or expired multiple condition windows
-            Stream.concat(
-                multipleConditionWindowsByFlow.entrySet().stream()
-                    .map(e -> Map.entry(
-                        e.getKey().getMultipleCondition(),
-                        e.getValue()
-                    ))
-                    .filter(e -> !Boolean.FALSE.equals(e.getKey().getResetOnSuccess()) &&
-                        e.getKey().getConditions().size() == Optional.ofNullable(e.getValue().getResults()).map(Map::size).orElse(0)
-                    )
-                    .map(Map.Entry::getValue),
-                multipleConditionStorage.get().expired(execution.getTenantId()).stream()
-            ).forEach(multipleConditionStorage.get()::delete);
-        }
-
-        return executions;
     }
 
     private Stream<MultipleCondition> flowTriggerMultipleConditions(FlowWithFlowTrigger flowWithFlowTrigger) {

--- a/executor/src/test/java/io/kestra/executor/FlowTriggerServiceTest.java
+++ b/executor/src/test/java/io/kestra/executor/FlowTriggerServiceTest.java
@@ -25,8 +25,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 @KestraTest
 class FlowTriggerServiceTest {
-    public static final List<Label> EMPTY_LABELS = List.of();
-    public static final Optional<MultipleConditionStorageInterface> EMPTY_MULTIPLE_CONDITION_STORAGE = Optional.empty();
+    private static final List<Label> EMPTY_LABELS = List.of();
 
     @Inject
     private TestRunContextFactory runContextFactory;
@@ -56,14 +55,27 @@ class FlowTriggerServiceTest {
 
         var simpleFlowExecution = Execution.newExecution(simpleFlow, EMPTY_LABELS).withState(State.Type.SUCCESS);
 
-        var resultingExecutionsToRun = flowTriggerService.computeExecutionsFromFlowTriggers(
+        var resultingExecutionsToRun = flowTriggerService.computeExecutionsFromFlowTriggerConditions(
             simpleFlowExecution,
-            List.of(simpleFlow, flowWithFlowTrigger),
-            EMPTY_MULTIPLE_CONDITION_STORAGE
+            flowWithFlowTrigger
         );
 
         assertThat(resultingExecutionsToRun).size().isEqualTo(1);
-        assertThat(resultingExecutionsToRun.get(0).getFlowId()).isEqualTo(flowWithFlowTrigger.getId());
+        assertThat(resultingExecutionsToRun.getFirst().getFlowId()).isEqualTo(flowWithFlowTrigger.getId());
+    }
+
+    @Test
+    void computeExecutionsFromFlowTriggers_none() {
+        var simpleFlow = aSimpleFlow();
+
+        var simpleFlowExecution = Execution.newExecution(simpleFlow, EMPTY_LABELS).withState(State.Type.SUCCESS);
+
+        var resultingExecutionsToRun = flowTriggerService.computeExecutionsFromFlowTriggerConditions(
+            simpleFlowExecution,
+            simpleFlow
+        );
+
+        assertThat(resultingExecutionsToRun).isEmpty();
     }
 
     @Test
@@ -81,10 +93,9 @@ class FlowTriggerServiceTest {
 
         var simpleFlowExecution = Execution.newExecution(simpleFlow, EMPTY_LABELS).withState(State.Type.CREATED);
 
-        var resultingExecutionsToRun = flowTriggerService.computeExecutionsFromFlowTriggers(
+        var resultingExecutionsToRun = flowTriggerService.computeExecutionsFromFlowTriggerConditions(
             simpleFlowExecution,
-            List.of(simpleFlow, flowWithFlowTrigger),
-            EMPTY_MULTIPLE_CONDITION_STORAGE
+            flowWithFlowTrigger
         );
 
         assertThat(resultingExecutionsToRun).size().isEqualTo(0);
@@ -109,10 +120,9 @@ class FlowTriggerServiceTest {
             .kind(ExecutionKind.TEST)
             .build();
 
-        var resultingExecutionsToRun = flowTriggerService.computeExecutionsFromFlowTriggers(
+        var resultingExecutionsToRun = flowTriggerService.computeExecutionsFromFlowTriggerConditions(
             simpleFlowExecutionComingFromATest,
-            List.of(simpleFlow, flowWithFlowTrigger),
-            EMPTY_MULTIPLE_CONDITION_STORAGE
+            flowWithFlowTrigger
         );
 
         assertThat(resultingExecutionsToRun).size().isEqualTo(0);

--- a/jdbc/src/main/java/io/kestra/jdbc/runner/JdbcExecutor.java
+++ b/jdbc/src/main/java/io/kestra/jdbc/runner/JdbcExecutor.java
@@ -424,7 +424,7 @@ public class JdbcExecutor implements ExecutorInterface {
 
         MultipleConditionEvent multipleConditionEvent = either.getLeft();
 
-        flowTriggerService.computeExecutionsFromFlowTriggers(multipleConditionEvent.execution(), List.of(multipleConditionEvent.flow()), Optional.of(multipleConditionStorage))
+        flowTriggerService.computeExecutionsFromFlowTriggerPreconditions(multipleConditionEvent.execution(), multipleConditionEvent.flow(), multipleConditionStorage)
             .forEach(exec -> {
                 try {
                     executionQueue.emit(exec);
@@ -1233,7 +1233,7 @@ public class JdbcExecutor implements ExecutorInterface {
             .filter(f -> ListUtils.emptyOnNull(f.getTrigger().getConditions()).stream().noneMatch(c -> c instanceof MultipleCondition) && f.getTrigger().getPreconditions() == null)
             .map(f -> f.getFlow())
             .distinct() // as computeExecutionsFromFlowTriggers is based on flow, we must map FlowWithFlowTrigger to a flow and distinct to avoid multiple execution for the same flow
-            .flatMap(f -> flowTriggerService.computeExecutionsFromFlowTriggers(execution, List.of(f), Optional.empty()).stream())
+            .flatMap(f -> flowTriggerService.computeExecutionsFromFlowTriggerConditions(execution, f).stream())
             .forEach(throwConsumer(exec -> executionQueue.emit(exec)));
 
         // send multiple conditions to the multiple condition queue for later processing

--- a/webserver/src/test/java/io/kestra/webserver/controllers/api/FlowControllerTest.java
+++ b/webserver/src/test/java/io/kestra/webserver/controllers/api/FlowControllerTest.java
@@ -531,7 +531,7 @@ class FlowControllerTest {
         List<String> namespaces = client.toBlocking().retrieve(
             HttpRequest.GET("/api/v1/main/flows/distinct-namespaces"), Argument.listOf(String.class));
 
-        assertThat(namespaces.size()).isEqualTo(12);
+        assertThat(namespaces.size()).isEqualTo(13);
     }
 
     @Test


### PR DESCRIPTION
When a flow have both a condition and a precondition, the condition was evaluated twice which lead to double execution triggered.

Fixes #12905