### PR TITLE
fix: use global $t in Bar.vue and remove useI18n

### DIFF
--- a/ui/src/components/charts/Bar.vue
+++ b/ui/src/components/charts/Bar.vue
@@ -5,7 +5,7 @@
         >
             <div class="info-block">
                 <p class="m-0 fs-6">
-                    <span class="fw-bold">{{ t("total_executions") }}</span>
+                    <span class="fw-bold">{{ $t("total_executions") }}</span>
                 </p>
                 <p class="m-0 fs-2">
                     <el-skeleton v-if="loading" :rows="0" />
@@ -23,7 +23,7 @@
                         inlinePrompt
                         :disabled="loading"
                     />
-                    <span class="d-flex align-items-center ps-2 fw-light small">{{ t("duration") }}</span>
+                    <span class="d-flex align-items-center ps-2 fw-light small">{{ $t("duration") }}</span>
                 </div>
                 <div id="executions" class="w-100" />
             </div>
@@ -46,7 +46,7 @@
 
 <script setup>
     import {ref} from "vue";
-    import {useI18n} from "vue-i18n";
+
     import CheckIcon from "vue-material-design-icons/Check.vue";
 
     import {useMediaQuery} from "@vueuse/core";
@@ -57,7 +57,6 @@
 
     import BarChart from "./BarChart.vue";
 
-    const {t} = useI18n({useScope: "global"});
     const duration = ref(true);
 
     const isSmallScreen = useMediaQuery("(max-width: 610px)");


### PR DESCRIPTION
**Description**

Removes unnecessary usage of **useI18n** inside **Bar.vue** and switches the component to use the globally available **$t** helper instead

**Changes**

- Removed the **useI18n** import and composable usage from the <script setup> block 
- Replaced all **t("…")** calls with **$t("…")** in the <template>
- No functional behavior was changed

closes #12969 