### PR TITLE
Update fullscreen button to use global $t helper

### DIFF
--- a/ui/src/components/Drawer.vue
+++ b/ui/src/components/Drawer.vue
@@ -14,7 +14,7 @@
                 <slot name="header" />
             </span>
             <el-button link class="full-screen">
-                <Fullscreen :title="t('toggle fullscreen')" @click="toggleFullScreen" />
+                <Fullscreen :title="$t('toggle fullscreen')" @click="toggleFullScreen" />
             </el-button>
         </template>
 
@@ -30,10 +30,7 @@
 
 <script setup lang="ts">
     import {ref} from "vue";
-    import {useI18n} from "vue-i18n";
     import Fullscreen from "vue-material-design-icons/Fullscreen.vue"
-
-    const {t} = useI18n();
 
     const props = defineProps({
         title: {


### PR DESCRIPTION
This pull request makes a minor update to the `Drawer.vue` component to improve internationalization handling.

* Replaced the use of the local `t` translation function with the global `$t` function for the fullscreen button label in the template.
* Removed the import of `useI18n`

Closes https://github.com/kestra-io/kestra/issues/12962