### PR TITLE
fix(execution): use jdbcRepository.findOne to be tolerant of multiple…

### DIFF
--- a/jdbc/src/main/java/io/kestra/jdbc/runner/AbstractJdbcConcurrencyLimitStorage.java
+++ b/jdbc/src/main/java/io/kestra/jdbc/runner/AbstractJdbcConcurrencyLimitStorage.java
@@ -22,10 +22,10 @@ public class AbstractJdbcConcurrencyLimitStorage extends AbstractJdbcRepository 
     }
 
     /**
-     * Fetch the concurrency limit counter then process the count using the consumer function.
-     * It locked the raw and is wrapped in a transaction so the consumer should use the provided dslContext for any database access.
+     * Fetch the concurrency limit counter, then process the count using the consumer function.
+     * It locked the raw and is wrapped in a transaction, so the consumer should use the provided dslContext for any database access.
      * <p>
-     * Note that to avoid a race when no concurrency limit counter exists, it first always try to insert a 0 counter.
+     * Note that to avoid a race when no concurrency limit counter exists, it first always tries to insert a 0 counter.
      */
     public ExecutionRunning countThenProcess(FlowInterface flow, BiFunction<DSLContext, ConcurrencyLimit, Pair<ExecutionRunning, ConcurrencyLimit>> consumer) {
         return this.jdbcRepository
@@ -97,7 +97,7 @@ public class AbstractJdbcConcurrencyLimitStorage extends AbstractJdbcRepository 
     }
 
     /**
-     * Returns all concurrency limit from the database
+     * Returns all concurrency limits from the database
      */
     public List<ConcurrencyLimit> find(String tenantId) {
         return this.jdbcRepository
@@ -132,8 +132,7 @@ public class AbstractJdbcConcurrencyLimitStorage extends AbstractJdbcRepository 
             .and(field("namespace").eq(flow.getNamespace()))
             .and(field("flow_id").eq(flow.getId()));
 
-        return Optional.ofNullable(select.forUpdate().fetchOne())
-            .map(record -> this.jdbcRepository.map(record));
+        return this.jdbcRepository.fetchOne(select.forUpdate());
     }
 
     private void update(DSLContext dslContext, ConcurrencyLimit concurrencyLimit) {


### PR DESCRIPTION
… results

It uses findAny() under the cover which does not throw if more than one result is returned.

Fixes #12943