### PR TITLE
fix(scheduler): mysql convert 'now' to UTC to avoid any offset error on next_execution_date

### DIFF
--- a/jdbc-mysql/src/main/java/io/kestra/repository/mysql/MysqlTriggerRepository.java
+++ b/jdbc-mysql/src/main/java/io/kestra/repository/mysql/MysqlTriggerRepository.java
@@ -1,8 +1,10 @@
 package io.kestra.repository.mysql;
 
 import io.kestra.core.models.triggers.Trigger;
+import io.kestra.core.runners.ScheduleContextInterface;
 import io.kestra.core.utils.DateUtils;
 import io.kestra.jdbc.repository.AbstractJdbcTriggerRepository;
+import io.kestra.jdbc.runner.JdbcSchedulerContext;
 import io.kestra.jdbc.services.JdbcFilterService;
 import jakarta.inject.Inject;
 import jakarta.inject.Named;
@@ -11,6 +13,10 @@ import org.jooq.Condition;
 import org.jooq.Field;
 import org.jooq.impl.DSL;
 
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.time.temporal.Temporal;
 import java.util.Date;
 import java.util.List;
 
@@ -31,5 +37,12 @@ public class MysqlTriggerRepository extends AbstractJdbcTriggerRepository {
     @Override
     protected Field<Date> formatDateField(String dateField, DateUtils.GroupType groupType) {
         return MysqlRepositoryUtils.formatDateField(dateField, groupType);
+    }
+
+    @Override
+    protected Temporal toNextExecutionTime(ZonedDateTime now) {
+        // next_execution_date in the table is stored in UTC
+        // convert 'now' to UTC LocalDateTime to avoid any timezone/offset interpretation by the database.
+        return now.withZoneSameInstant(ZoneOffset.UTC).toLocalDateTime();
     }
 }

--- a/jdbc/src/main/java/io/kestra/jdbc/repository/AbstractJdbcTriggerRepository.java
+++ b/jdbc/src/main/java/io/kestra/jdbc/repository/AbstractJdbcTriggerRepository.java
@@ -31,9 +31,8 @@ import org.jooq.impl.DSL;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.FluxSink;
 
-import java.time.LocalDateTime;
-import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
+import java.time.temporal.Temporal;
 import java.util.*;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -148,16 +147,12 @@ public abstract class AbstractJdbcTriggerRepository extends AbstractJdbcReposito
 
     public List<Trigger> findByNextExecutionDateReadyForAllTenants(ZonedDateTime now, ScheduleContextInterface scheduleContextInterface) {
         JdbcSchedulerContext jdbcSchedulerContext = (JdbcSchedulerContext) scheduleContextInterface;
-
-        // next_execution_date in the table is stored in UTC
-        // convert 'now' to UTC LocalDateTime to avoid any timezone/offset interpretation by the database.
-        LocalDateTime nowUtc = now.withZoneSameInstant(ZoneOffset.UTC).toLocalDateTime();
         
         return jdbcSchedulerContext.getContext()
             .select(field("value"))
             .from(this.jdbcRepository.getTable())
             .where(
-                (field("next_execution_date").lessThan(nowUtc)
+                (field("next_execution_date").lessThan(toNextExecutionTime(now))
                     // we check for null for backwards compatibility
                     .or(field("next_execution_date").isNull()))
                     .and(field("execution_id").isNull())
@@ -168,19 +163,15 @@ public abstract class AbstractJdbcTriggerRepository extends AbstractJdbcReposito
             .fetch()
             .map(r -> this.jdbcRepository.deserialize(r.get("value", String.class)));
     }
-
+    
     public List<Trigger> findByNextExecutionDateReadyButLockedTriggers(ZonedDateTime now) {
-        
-        // next_execution_date in the table is stored in UTC
-        // convert 'now' to UTC LocalDateTime to avoid any timezone/offset interpretation by the database.
-        LocalDateTime nowUtc = now.withZoneSameInstant(ZoneOffset.UTC).toLocalDateTime();
         
         return this.jdbcRepository.getDslContextWrapper()
             .transactionResult(configuration -> DSL.using(configuration)
                 .select(field("value"))
                 .from(this.jdbcRepository.getTable())
                 .where(
-                    (field("next_execution_date").lessThan(nowUtc)
+                    (field("next_execution_date").lessThan(toNextExecutionTime(now))
                         // we check for null for backwards compatibility
                         .or(field("next_execution_date").isNull()))
                         .and(field("execution_id").isNotNull())
@@ -188,6 +179,10 @@ public abstract class AbstractJdbcTriggerRepository extends AbstractJdbcReposito
                 .orderBy(field("next_execution_date").asc())
                 .fetch()
                 .map(r -> this.jdbcRepository.deserialize(r.get("value", String.class))));
+    }
+    
+    protected Temporal toNextExecutionTime(ZonedDateTime now) {
+        return now.toOffsetDateTime();
     }
 
     public Trigger save(Trigger trigger, ScheduleContextInterface scheduleContextInterface) {


### PR DESCRIPTION
Fixed a previous commit to only apply the change for MySQL

Related-to: kestra-io/kestra-ee#5611

