### PR TITLE
Fix: YAML Input Serialization for Subflow Map/Collection Inputs

### DIFF
--- a/core/src/main/java/io/kestra/core/runners/VariableRenderer.java
+++ b/core/src/main/java/io/kestra/core/runners/VariableRenderer.java
@@ -1,7 +1,12 @@
 package io.kestra.core.runners;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import io.kestra.core.exceptions.IllegalVariableEvaluationException;
-import io.kestra.core.runners.pebble.*;
+import io.kestra.core.runners.pebble.JsonWriter;
+import io.kestra.core.runners.pebble.OutputWriter;
+import io.kestra.core.runners.pebble.PebbleEngineFactory;
+import io.kestra.core.runners.pebble.TypedObjectWriter;
+import io.kestra.core.serializers.JacksonMapper;
 import io.micronaut.context.ApplicationContext;
 import io.micronaut.context.annotation.ConfigurationProperties;
 import io.micronaut.core.annotation.Nullable;
@@ -30,16 +35,16 @@ public class VariableRenderer {
     public VariableRenderer(ApplicationContext applicationContext, @Nullable VariableConfiguration variableConfiguration) {
         this(applicationContext.getBean(PebbleEngineFactory.class), variableConfiguration);
     }
-    
+
     public VariableRenderer(PebbleEngineFactory pebbleEngineFactory, @Nullable VariableConfiguration variableConfiguration) {
         this.variableConfiguration = variableConfiguration != null ? variableConfiguration : new VariableConfiguration();
         this.pebbleEngine = pebbleEngineFactory.create();
     }
-    
+
     public void setPebbleEngine(final PebbleEngine pebbleEngine) {
         this.pebbleEngine = pebbleEngine;
     }
-    
+
     public static IllegalVariableEvaluationException properPebbleException(PebbleException initialExtension) {
         if (initialExtension instanceof AttributeNotFoundException current) {
             return new IllegalVariableEvaluationException(
@@ -176,10 +181,16 @@ public class VariableRenderer {
             String key = this.render(r.getKey(), variables);
             Object value = renderObject(r.getValue(), variables, recursive).orElse(r.getValue());
 
-            map.putIfAbsent(
-                key,
-                value
-            );
+            // If value is a Map or Collection, convert to JSON string
+            if (value instanceof Map || value instanceof Collection<?>) {
+                try {
+                    value = JacksonMapper.ofJson().writeValueAsString(value);
+                } catch (JsonProcessingException e) {
+                    throw new IllegalVariableEvaluationException("Failed to serialize value to JSON", e);
+                }
+            }
+
+            map.putIfAbsent(key, value);
         }
 
         return map;


### PR DESCRIPTION
This PR ensures that Maps and Collections passed as YAML inputs to subflows are properly serialized to JSON format instead of using Java's `toString()` method, which produces corrupted output.

closes #13007

### What changes are being made and why?

The `VariableRenderer.render()` method was passing Map and Collection objects directly to Pebble templates. When Pebble stringified these objects, it used Java's default `toString()` method, producing malformed output like `{first=John, last=Doe}` instead of proper JSON `{"first":"John","last":"Doe"}`.

The fix adds JSON serialization using Jackson's `ObjectMapper` for **both Maps and Collections** before they reach the Pebble rendering pipeline:


### How the changes have been QAed?

**Test Case 1: List of Maps** (Collection containing Maps)
```yaml
tasks:
  - id: hello
    type: io.kestra.plugin.core.flow.Subflow
    inputs:
      people: 
        - first: "John"
          last: "Doe"
        - first: "Jane"
          last: "Smith"
```

**Test Case 2: Single Map**
```yaml
tasks:
  - id: hello
    type: io.kestra.plugin.core.flow.Subflow
    inputs:
      person:
        first: "John"
        last: "Doe"
```

**Before**

Corrupted serialization: `[{"last=Doe":"","first=John":""}]` using `toString()`

**After**

<img width="950" height="545" alt="Screenshot 2025-11-18 at 1 55 44 PM" src="https://github.com/user-attachments/assets/066ce2b5-555a-4543-8cb3-05b3d79069b2" />

<img width="950" height="545" alt="Screenshot 2025-11-18 at 1 54 47 PM" src="https://github.com/user-attachments/assets/9d8e3dd8-7c88-49b5-8f64-2ceb33bb04ad" />


Proper JSON serialization: `[{"first":"John","last":"Doe"},{"first":"Jane","last":"Smith"}]`

**Verification:**
- ✅ Collections of Maps: Properly serialized to JSON (see screenshots)
- ✅ Single Maps: Properly serialized to JSON (see screenshots)
- ✅ Collections of primitives: Backward compatible - ForEach loops work correctly
- ✅ No regressions in existing flows