### PR TITLE
fix(tests): lower termination grace period

### DIFF
--- a/cli/src/test/resources/application-test.yml
+++ b/cli/src/test/resources/application-test.yml
@@ -21,6 +21,7 @@ kestra:
   server:
     liveness:
       enabled: false
+    termination-grace-period: 5s
 micronaut:
   http:
     services:

--- a/core/src/test/resources/application-test.yml
+++ b/core/src/test/resources/application-test.yml
@@ -58,7 +58,8 @@ kestra:
       purge:
         initial-delay: 1h
         fixed-delay: 1d
-        retention: 30d
+        retention: 30dPeriod
+    termination-grace-period: 5s
 
   anonymous-usage-report:
     enabled: false

--- a/core/src/test/resources/flows/valids/sleep-long.yml
+++ b/core/src/test/resources/flows/valids/sleep-long.yml
@@ -4,7 +4,7 @@ namespace: io.kestra.tests
 tasks:
   - id: sleep-long
     type: io.kestra.plugin.core.flow.Sleep
-    duration: PT300S
+    duration: PT30S
 
 afterExecution:
   - id: output

--- a/executor/src/test/resources/application-test.yml
+++ b/executor/src/test/resources/application-test.yml
@@ -54,6 +54,7 @@ kestra:
         - "/api/v1/executions/webhook/"
     liveness:
       enabled: false
+    termination-grace-period: 5s
     service:
       purge:
         initial-delay: 1h

--- a/jdbc-h2/src/test/resources/application-test.yml
+++ b/jdbc-h2/src/test/resources/application-test.yml
@@ -19,6 +19,7 @@ kestra:
   server:
     liveness:
       enabled: false
+    termination-grace-period: 5s
     service:
       purge:
         initial-delay: 1h

--- a/jdbc-mysql/src/test/resources/application-test.yml
+++ b/jdbc-mysql/src/test/resources/application-test.yml
@@ -25,6 +25,7 @@ kestra:
   server:
     liveness:
       enabled: false
+    termination-grace-period: 5s
     service:
       purge:
         initial-delay: 1h

--- a/jdbc-postgres/src/test/resources/application-test.yml
+++ b/jdbc-postgres/src/test/resources/application-test.yml
@@ -40,6 +40,7 @@ kestra:
   server:
     liveness:
       enabled: false
+    termination-grace-period: 5s
     service:
       purge:
         initial-delay: 1h

--- a/repository-memory/src/test/resources/application-test.yml
+++ b/repository-memory/src/test/resources/application-test.yml
@@ -10,3 +10,4 @@ kestra:
   server:
     liveness:
       enabled: false
+    termination-grace-period: 5s

--- a/runner-memory/src/test/resources/application-test.yml
+++ b/runner-memory/src/test/resources/application-test.yml
@@ -14,3 +14,4 @@ kestra:
   server:
     liveness:
       enabled: false
+    termination-grace-period: 5s

--- a/scheduler/src/test/resources/application-test.yml
+++ b/scheduler/src/test/resources/application-test.yml
@@ -54,6 +54,7 @@ kestra:
         - "/api/v1/executions/webhook/"
     liveness:
       enabled: false
+    termination-grace-period: 5s
     service:
       purge:
         initial-delay: 1h

--- a/webserver/src/test/resources/application-test.yml
+++ b/webserver/src/test/resources/application-test.yml
@@ -172,6 +172,7 @@ kestra:
         - "/api/v1/main/executions/webhook/"
     liveness:
       enabled: false
+    termination-grace-period: 5s
     service:
       purge:
         initial-delay: 1h

--- a/worker/src/test/resources/application-test.yml
+++ b/worker/src/test/resources/application-test.yml
@@ -54,6 +54,7 @@ kestra:
         - "/api/v1/executions/webhook/"
     liveness:
       enabled: false
+    termination-grace-period: 5s
     service:
       purge:
         initial-delay: 1h


### PR DESCRIPTION
If a test mis-behave, for ex starting an execution but not terminating it, as the default termination grace period is 5mn it can take very long time to wait for post-test terminaison. Switching to a termination grace period of 5s may help.

I also detect that the ExecutionControllerRunner test when launching the test suite, would not properly kill the `sleep-long` flow so waiting for it to complete, or the termination grace period. When a test that use this flow is launched separatly it works properly. As a safety net I reduce the sleep from 5mn to 30s.