### PR TITLE
fix: loop until avoid taskrun duplication +  handle submitted status

### DIFF
--- a/core/src/main/java/io/kestra/core/runners/FlowableUtils.java
+++ b/core/src/main/java/io/kestra/core/runners/FlowableUtils.java
@@ -157,8 +157,6 @@ public class FlowableUtils {
 
             if (currentTasks.size() > lastIndex + 1) {
                 return Collections.singletonList(currentTasks.get(lastIndex + 1).toNextTaskRunIncrementIteration(execution, parentTaskRun.getIteration()));
-            } else {
-                return Collections.singletonList(currentTasks.getFirst().toNextTaskRunIncrementIteration(execution, parentTaskRun.getIteration()));
             }
         }
 

--- a/core/src/main/java/io/kestra/core/runners/FlowableUtils.java
+++ b/core/src/main/java/io/kestra/core/runners/FlowableUtils.java
@@ -143,6 +143,13 @@ public class FlowableUtils {
             return Collections.emptyList();
         }
 
+        // have submitted, leave
+        Optional<TaskRun> lastSubmitted = execution.findLastSubmitted(taskRuns);
+        if (lastSubmitted.isPresent()) {
+            return Collections.emptyList();
+        }
+
+
         // last success, find next
         Optional<TaskRun> lastTerminated = execution.findLastTerminated(taskRuns);
         if (lastTerminated.isPresent()) {

--- a/executor/src/main/java/io/kestra/executor/ExecutorService.java
+++ b/executor/src/main/java/io/kestra/executor/ExecutorService.java
@@ -571,9 +571,7 @@ public class ExecutorService {
                     RunContext runContext = runContextFactory.of(executor.getFlow(), task, executor.getExecution().withTaskRun(updatedTaskRun), updatedTaskRun);
                     List<NextTaskRun> next = ((FlowableTask<?>) task).resolveNexts(runContext, executor.getExecution(), updatedTaskRun);
                     Instant nextDate = waitFor.nextExecutionDate(runContext, executor.getExecution(), updatedTaskRun);
-                    if (next.isEmpty()) {
-                        return executor;
-                    } else if (nextDate != null) {
+                     if (nextDate != null) {
                         executionDelays.add(ExecutionDelay.builder()
                             .taskRunId(taskRun.getId())
                             .executionId(executor.getExecution().getId())


### PR DESCRIPTION
As we currently can not handle a huge amount of taskrun, LoopUntil clean every taskrun on each loop and play again its task. 

Two errors were done : 
* In the `resolveWaitForNext`, if all tasks had been executed, we were sending again the first one, but this is unnecessary as said above when a new loop start again, we clean all previous taskrun so we always restart from the first one.

*  In the `handleChildWorkerTaskResult` from the ExecutorService, we add a case if LoopUntil had still some next taskrun, but we could only enter the if condition if all task of a loop were executed, so its was impossible to enter it, except if we had duplicated tasks.


close #12615 