### PR TITLE
build(core): remove unused dependency

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -24,7 +24,6 @@
                 "cronstrue": "^3.9.0",
                 "cytoscape": "^3.33.0",
                 "dagre": "^0.8.5",
-                "el-table-infinite-scroll": "^3.0.8",
                 "element-plus": "2.11.8",
                 "humanize-duration": "^3.33.1",
                 "js-yaml": "^4.1.1",
@@ -10119,17 +10118,6 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/isaacs"
-            }
-        },
-        "node_modules/el-table-infinite-scroll": {
-            "version": "3.0.8",
-            "resolved": "https://registry.npmjs.org/el-table-infinite-scroll/-/el-table-infinite-scroll-3.0.8.tgz",
-            "integrity": "sha512-zveIGMsYfRFLuknOjfrCMRtyX0yFcb6BQsZS7E4A1AQYFiuBXHcU8Ag/hSKsdYvN1P28Ot/Bs0TUxwckOHt+JQ==",
-            "license": "MIT",
-            "dependencies": {
-                "core-js": "^3.x",
-                "element-plus": "^2.x",
-                "vue": "^3.x"
             }
         },
         "node_modules/electron-to-chromium": {

--- a/ui/package.json
+++ b/ui/package.json
@@ -38,7 +38,6 @@
         "cronstrue": "^3.9.0",
         "cytoscape": "^3.33.0",
         "dagre": "^0.8.5",
-        "el-table-infinite-scroll": "^3.0.8",
         "element-plus": "2.11.8",
         "humanize-duration": "^3.33.1",
         "js-yaml": "^4.1.1",
@@ -147,9 +146,6 @@
     "overrides": {
         "bootstrap": {
             "@popperjs/core": "npm:@sxzz/popperjs-es@^2.11.7"
-        },
-        "el-table-infinite-scroll": {
-            "vue": "^3.5.21"
         },
         "storybook": "$storybook",
         "vite": "npm:rolldown-vite@latest"


### PR DESCRIPTION
If I'm not missing anything, we're not using `el-table-infinite-scroll` anywhere in the code anymore.
https://www.npmjs.com/package/el-table-infinite-scroll

Can you double check please?