### PR TITLE
refactor(ui): Replace usage of getCurrentInstance in LowCodeEditor.vue component

### DIFF
--- a/ui/src/components/inputs/AcceptDecline.vue
+++ b/ui/src/components/inputs/AcceptDecline.vue
@@ -1,22 +1,16 @@
 <template>
     <div class="wrapper">
         <el-button type="secondary" @click="emit('reject')">
-            {{ t('reject') }}
+            {{ $t("reject") }}
         </el-button>
         <el-button type="primary" @click="emit('accept')">
-            {{ t('accept') }}
+            {{ $t("accept") }}
         </el-button>
     </div>
 </template>
 
 <script setup lang="ts">
-    import {useI18n} from "vue-i18n";
-
-    const t = useI18n()!.appContext.config.globalProperties.$t;
-    const emit = defineEmits<{
-        accept: [];
-        reject: [];
-    }>();
+    const emit = defineEmits<{ accept: []; reject: [] }>();
 </script>
 
 <style scoped lang="scss">
@@ -26,13 +20,13 @@
     justify-content: end;
     align-items: center;
     gap: 10px;
-    background: #1E202AD9;
+    background: #1e202ad9;
     backdrop-filter: blur(10px);
     padding: 1rem;
-    border-top:1px solid var(--ks-border-primary);
+    border-top: 1px solid var(--ks-border-primary);
 
     html.light & {
-        background: #F8F9FA80;
+        background: #f8f9fa80;
     }
 
     &:deep(.el-button) {

--- a/ui/src/components/inputs/AcceptDecline.vue
+++ b/ui/src/components/inputs/AcceptDecline.vue
@@ -10,9 +10,9 @@
 </template>
 
 <script setup lang="ts">
-    import {getCurrentInstance} from "vue";
+    import {useI18n} from "vue-i18n";
 
-    const t = getCurrentInstance()!.appContext.config.globalProperties.$t;
+    const t = useI18n()!.appContext.config.globalProperties.$t;
     const emit = defineEmits<{
         accept: [];
         reject: [];


### PR DESCRIPTION
### ✨ Description

What does this PR change?  
This PR replaces the usage of the ```getCurrentInstance``` utility in ```kestra/ui/src/components/inputs/AcceptDecline.vue``` component with the use of ```useI18n``` composable used in the project. This standardizes the component with Kestra's standard UI patterns so that it matches the rest of the code.

### 🔗 Related Issue

Which issue does this PR resolve? Use [GitHub Keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue) to automatically link the pull request to the issue.  
Closes https://github.com/kestra-io/kestra/issues/12950.

### 🎨 Frontend Checklist

- [x] Code builds without errors (`npm run build`)
- [x] All existing E2E tests pass (`npm run test:e2e`)