### PR TITLE
fix(filters): make restoreUrl work better

### DIFF
--- a/ui/src/components/filter/components/KSFilter.vue
+++ b/ui/src/components/filter/components/KSFilter.vue
@@ -31,7 +31,6 @@
     import MainFilter from "./MainFilter.vue";
     import RightFilter from "./RightFilter.vue";
     import FilterOptions from "./FilterOptions.vue";
-    import useRestoreUrl from "../../../composables/useRestoreUrl";
     import {useDefaultFilter} from "../composables/useDefaultFilter";
 
     const props = withDefaults(defineProps<{
@@ -168,8 +167,6 @@
     watch(appliedFilters, (newFilters) => {
         emits("filter", newFilters);
     }, {deep: true});
-
-    useRestoreUrl({restoreUrl: true});
 
     useDefaultFilter(
         props.configuration,

--- a/ui/src/components/filter/composables/useDefaultFilter.ts
+++ b/ui/src/components/filter/composables/useDefaultFilter.ts
@@ -1,4 +1,4 @@
-import {onMounted} from "vue";
+import {nextTick, onMounted} from "vue";
 import {LocationQuery, RouteLocation, useRoute, useRouter} from "vue-router";
 import {useMiscStore} from "override/stores/misc";
 import {defaultNamespace} from "../../../composables/useNamespaces";
@@ -19,7 +19,7 @@ const hasFilterKey = (query: LocationQuery, prefix: string): boolean =>
     Object.keys(query).some(key => key.startsWith(prefix));
 
 export function applyDefaultFilters(
-    currentQuery: LocationQuery, 
+    currentQuery?: LocationQuery, 
     {
         configuration, 
         route, 
@@ -30,7 +30,14 @@ export function applyDefaultFilters(
     }: DefaultFilterOptions & { 
         configuration?: FilterConfiguration; 
         route?: RouteLocation 
-    } = {}): { query: LocationQuery } {
+    } = {}): { query: LocationQuery, change: boolean } {
+
+    if(currentQuery && Object.keys(currentQuery).length > 0) {
+        return {
+            query: currentQuery,
+            change: false,
+        }
+    }
 
     const hasTimeRange = configuration && route 
         ? configuration.keys?.some((k: any) => k.key === "timeRange") ?? false
@@ -57,7 +64,7 @@ export function applyDefaultFilters(
         query[legacyQuery ? "timeRange" : `${TIME_RANGE_FILTER_PREFIX}[EQUALS]`] = defaultDuration;
     }
 
-    return {query};
+    return {query, change: true};
 }
 
 export function useDefaultFilter(
@@ -67,14 +74,15 @@ export function useDefaultFilter(
     const route = useRoute();
     const router = useRouter();
 
-    onMounted(() => {
-        // wait for the restore url process to end
-        // it has priority over default filters
-        setTimeout(() => {
-            const {query} = applyDefaultFilters(route.query, {configuration, route, legacyQuery})
-            if(!route.query || Object.keys(route.query).length === 0) {
-                router.replace({...route, query})
-            }
-        }, 100);
+    onMounted(async () => {
+        // wait for router to be ready
+        await nextTick()
+        // wait for the useRestoreUrl to apply its changes
+        await nextTick()
+        // finally add default filter if necessary
+        const {query, change} = applyDefaultFilters(route.query, {configuration, route, legacyQuery})
+        if(change) {
+            router.replace({...route, query})
+        }
     });
 }   

--- a/ui/src/components/inputs/MonacoEditor.vue
+++ b/ui/src/components/inputs/MonacoEditor.vue
@@ -987,8 +987,8 @@
 
     .monaco-editor {
         :deep(.monaco-scrollable-element) {
-            :deep(> .scrollbar) {
-                :deep(.slider) {
+            > .scrollbar {
+                .slider {
                     width: 13px !important;
                     background: var(--ks-border-primary) !important;
                     border-radius: 8px !important;
@@ -996,7 +996,7 @@
                 }
             }
 
-            :deep(.monaco-list-row[aria-label="_DATE_PICKER_"]) {
+            .monaco-list-row[aria-label="_DATE_PICKER_"] {
                 padding-right: 0 !important;
             }
         }

--- a/ui/src/composables/useRestoreUrl.ts
+++ b/ui/src/composables/useRestoreUrl.ts
@@ -120,20 +120,10 @@ export default function useRestoreUrl(options: UseRestoreUrlOptions = {}) {
      */
     onMounted(() => {
         if (restoreUrl && localStorageValue.value){
-            // FIXME: this is a hacky way to wait for the router to be ready.
-            // if we wanted to do it properly, we should use a router guard.
-            // To do that we would have to pass the config through the route 
-            // meta property instead of in a prop.
-            // When composables are run the component is already created, 
-            // way after routes have been resolved. All components are resolved 
-            // and rendered twice with this method.
-            // NOTE: once this is fixed, don't forget to add the fix to useDefaultFilter.ts
-            setTimeout(() => {
-                if(route.query && Object.keys(route.query).length === 0) {
-                    loadInit.value = false;
-                    goToRestoreUrl();
-                }
-            }, 50)
+            if(!route.query || Object.keys(route.query).length === 0) {
+                loadInit.value = false;
+                goToRestoreUrl();
+            }
         }
     });
 

--- a/ui/src/routes/routes.js
+++ b/ui/src/routes/routes.js
@@ -7,6 +7,7 @@ import DemoAuditLogs from "../components/demo/AuditLogs.vue"
 import DemoInstance from "../components/demo/Instance.vue"
 import DemoApps from "../components/demo/Apps.vue"
 import DemoTests from "../components/demo/Tests.vue"
+import {applyDefaultFilters} from "../components/filter/composables/useDefaultFilter";
 
 export default [
     //Initial
@@ -18,15 +19,31 @@ export default [
         name: "home",
         path: "/:tenant?/dashboards/:dashboard?",
         component: () => import("../components/dashboard/Dashboard.vue"),
-        beforeEnter: (to, from, next) => {
+        beforeEnter: (to, _from, next) => {
+            // This specific case is to avoid redirecting dashboards twice:
+            // - once here in beforeEnter
+            // - once in useDefaultFilter composable
+
+            // We analyzed other ways to fix this:
+            // - using nextTick in useDefaultFilter to delay the redirection
+            // - using a flag in route meta and a beforeEnter in KSFilter to apply default filters
+            // but both were more complex and fragile than this simple check.
+            const {query, change} = applyDefaultFilters(to.query, {includeTimeRange: true, route: to, legacyQuery: false})
             if (!to.params.dashboard) {
                 next({
-                    name: "home",
+                    ...to,
                     params: {
                         ...to.params,
                         dashboard: "default",
                     },
-                    query: to.query,
+                    query,
+                });
+                return;
+            }
+            if(change) {
+                next({
+                    ...to, 
+                    query,
                 });
                 return;
             }

--- a/ui/src/utils/init.js
+++ b/ui/src/utils/init.js
@@ -70,7 +70,8 @@ export default async (app, routes, _stores, translations, additionalTranslations
 
     // router
     const router = createRouter({
-        history: createWebHistory(window.KESTRA_UI_PATH),
+        // make e2e tests pass in dev mode
+        history: createWebHistory(import.meta.env.DEV ? "/ui" : window.KESTRA_UI_PATH),
         routes
     });
 


### PR DESCRIPTION
closes #13082

- fix redirection scheme: 
  - remove timeout for `restoreUrl`
  - remove use of the restoreUrl hook in filters since it is only saved in `useDataTableAction`
  - to keep the order intact (restore first, default second) we add 2 `nextTick()` in `useDefaultFilter()` one for router the other for restoreUrl.