### PR TITLE
chore(system): extract queue consumers processing into message handlers

### DIFF
--- a/core/src/main/java/io/kestra/core/runners/DefaultFlowMetaStore.java
+++ b/core/src/main/java/io/kestra/core/runners/DefaultFlowMetaStore.java
@@ -1,9 +1,11 @@
 package io.kestra.core.runners;
 
+import io.kestra.core.models.executions.Execution;
 import io.kestra.core.models.flows.FlowInterface;
 import io.kestra.core.models.flows.FlowWithSource;
 import io.kestra.core.repositories.FlowRepositoryInterface;
 import io.kestra.core.services.FlowListenersInterface;
+import io.kestra.core.services.PluginDefaultService;
 import jakarta.inject.Singleton;
 import java.util.Objects;
 import lombok.Setter;
@@ -15,12 +17,14 @@ import java.util.Optional;
 @Singleton
 public class DefaultFlowMetaStore implements FlowMetaStoreInterface {
     private final FlowRepositoryInterface flowRepository;
+    private final PluginDefaultService pluginDefaultService;
 
     @Setter
     private List<FlowWithSource> allFlows;
 
-    public DefaultFlowMetaStore(FlowListenersInterface flowListeners, FlowRepositoryInterface flowRepository) {
+    public DefaultFlowMetaStore(FlowListenersInterface flowListeners, FlowRepositoryInterface flowRepository, PluginDefaultService pluginDefaultService) {
         this.flowRepository = flowRepository;
+        this.pluginDefaultService = pluginDefaultService;
         flowListeners.listen(flows -> allFlows = flows);
     }
 
@@ -52,5 +56,10 @@ public class DefaultFlowMetaStore implements FlowMetaStoreInterface {
     @Override
     public Boolean isReady() {
         return true;
+    }
+
+    @Override
+    public Optional<FlowWithSource> findByExecutionThenInjectDefaults(Execution execution) {
+        return findByExecution(execution).map(it -> pluginDefaultService.injectDefaults(it, execution));
     }
 }

--- a/core/src/main/java/io/kestra/core/runners/FlowMetaStoreInterface.java
+++ b/core/src/main/java/io/kestra/core/runners/FlowMetaStoreInterface.java
@@ -49,4 +49,6 @@ public interface FlowMetaStoreInterface {
             Optional.of(execution.getFlowRevision())
         );
     }
+
+    Optional<FlowWithSource> findByExecutionThenInjectDefaults(Execution execution);
 }

--- a/executor/src/main/java/io/kestra/executor/DefaultExecutor.java
+++ b/executor/src/main/java/io/kestra/executor/DefaultExecutor.java
@@ -2,20 +2,14 @@ package io.kestra.executor;
 
 import io.kestra.core.contexts.KestraContext;
 import io.kestra.core.exceptions.DeserializationException;
-import io.kestra.core.exceptions.InternalException;
 import io.kestra.core.metrics.MetricRegistry;
 import io.kestra.core.models.executions.*;
 import io.kestra.core.models.flows.*;
 import io.kestra.core.models.flows.sla.ExecutionMonitoringSLA;
 import io.kestra.core.models.flows.sla.SLA;
-import io.kestra.core.models.flows.sla.SLAMonitor;
 import io.kestra.core.models.flows.sla.Violation;
-import io.kestra.core.models.tasks.ExecutableTask;
-import io.kestra.core.models.tasks.Task;
-import io.kestra.core.models.tasks.WorkerGroup;
 import io.kestra.core.models.triggers.TriggerId;
 import io.kestra.core.models.triggers.multipleflows.MultipleCondition;
-import io.kestra.core.models.triggers.multipleflows.MultipleConditionStorageInterface;
 import io.kestra.core.queues.QueueException;
 import io.kestra.core.queues.QueueFactoryInterface;
 import io.kestra.core.queues.QueueInterface;
@@ -27,25 +21,18 @@ import io.kestra.core.server.ServiceStateChangeEvent;
 import io.kestra.core.server.ServiceType;
 import io.kestra.core.services.*;
 import io.kestra.core.storages.StorageContext;
-import io.kestra.core.trace.Tracer;
-import io.kestra.core.trace.TracerFactory;
 import io.kestra.core.utils.*;
-import io.kestra.plugin.core.flow.ForEachItem;
-import io.kestra.plugin.core.flow.WorkingDirectory;
+import io.kestra.executor.handler.*;
 import io.kestra.scheduler.TriggerEventQueue;
 import io.kestra.scheduler.events.TriggerExecutionTerminated;
 import io.micronaut.context.annotation.Value;
 import io.micronaut.context.event.ApplicationEventPublisher;
-import io.opentelemetry.api.trace.Span;
-import io.opentelemetry.api.trace.StatusCode;
 import jakarta.annotation.PostConstruct;
 import jakarta.annotation.PreDestroy;
 import jakarta.inject.Inject;
 import jakarta.inject.Named;
 import jakarta.inject.Singleton;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.lang3.tuple.Pair;
-import org.slf4j.event.Level;
 
 import java.time.Duration;
 import java.time.Instant;
@@ -80,9 +67,6 @@ public class DefaultExecutor implements Executor {
     @Named(QueueFactoryInterface.WORKERTASKRESULT_NAMED)
     private QueueInterface<WorkerTaskResult> workerTaskResultQueue;
     @Inject
-    @Named(QueueFactoryInterface.WORKERTASKLOG_NAMED)
-    private QueueInterface<LogEntry> logQueue;
-    @Inject
     @Named(QueueFactoryInterface.KILL_NAMED)
     private QueueInterface<ExecutionKilled> killQueue;
     @Inject
@@ -101,11 +85,7 @@ public class DefaultExecutor implements Executor {
     @Inject
     private SkipExecutionService skipExecutionService;
     @Inject
-    private PluginDefaultService pluginDefaultService;
-    @Inject
     private ExecutorService executorService;
-    @Inject
-    private WorkerGroupService workerGroupService;
     @Inject
     private ExecutionService executionService;
     @Inject
@@ -125,8 +105,6 @@ public class DefaultExecutor implements Executor {
     @Inject
     private ExecutionQueuedStateStore executionQueuedStateStore;
     @Inject
-    private MultipleConditionStorageInterface multipleConditionStorage;
-    @Inject
     private ExecutionDelayStateStore executionDelayStateStore;
     @Inject
     private SLAMonitorStateStore  slaMonitorStateStore;
@@ -143,6 +121,21 @@ public class DefaultExecutor implements Executor {
 
     @Inject
     private FlowListenersInterface flowListeners;
+
+    @Inject
+    private ExecutionMessageHandler executionMessageHandler;
+    @Inject
+    private ExecutionEventMessageHandler executionEventMessageHandler;
+    @Inject
+    private WorkerTaskResultMessageHandler workerTaskResultMessageHandler;
+    @Inject
+    private ExecutionKilledExecutionMessageHandler executionKilledExecutionMessageHandler;
+    @Inject
+    private SubflowExecutionResultMessageHandler subflowExecutionResultMessageHandler;
+    @Inject
+    private SubflowExecutionEndMessageHandler subflowExecutionEndMessageHandler;
+    @Inject
+    private MultipleConditionEventMessageHandler multipleConditionEventMessageHandler;
 
     @Value("${kestra.executor.clean.execution-queue:true}")
     private boolean cleanExecutionQueue;
@@ -161,16 +154,13 @@ public class DefaultExecutor implements Executor {
 
     private List<FlowWithSource> allFlows;
 
-    private final Tracer tracer;
     private final java.util.concurrent.ExecutorService workerTaskResultExecutorService;
     private final java.util.concurrent.ExecutorService executionExecutorService;
     private final int numberOfThreads;
 
 
     @Inject
-    public DefaultExecutor(TracerFactory tracerFactory, ExecutorsUtils executorsUtils, @Value("${kestra.executor.thread-count:0}") int threadCount) {
-        this.tracer = tracerFactory.getTracer(DefaultExecutor.class, "EXECUTOR");
-
+    public DefaultExecutor(ExecutorsUtils executorsUtils, @Value("${kestra.executor.thread-count:0}") int threadCount) {
         // By default, we start available processors count threads with a minimum of 4 by executor service
         // for the worker task result queue and the execution queue.
         // Other queues would not benefit from more consumers.
@@ -321,22 +311,8 @@ public class DefaultExecutor implements Executor {
             return;
         }
 
-        try {
-            executionEventQueue.emit(new ExecutionEvent(message, ExecutionEventType.CREATED));
-        } catch (QueueException e) {
-            // If we cannot send the execution event, we fail the execution
-            executionStateStore.lock(message.getId(), execution -> {
-                try {
-                    Execution failed = execution.failedExecutionFromExecutor(e).getExecution().withState(State.Type.FAILED);
-                    ExecutionEvent event = new ExecutionEvent(failed, ExecutionEventType.TERMINATED);
-                    this.executionEventQueue.emit(event);
-                    return new ExecutorContext(failed);
-                } catch (QueueException ex) {
-                    log.error("Unable to emit the execution {}", execution.getId(), ex);
-                }
-                return null;
-            });
-        }
+        Optional<ExecutorContext> maybeExecutor = executionMessageHandler.handle(message);
+        maybeExecutor.ifPresent(this::toExecution);
     }
 
     private void executionEventQueue(Either<ExecutionEvent, DeserializationException> either) {
@@ -351,190 +327,8 @@ public class DefaultExecutor implements Executor {
             return;
         }
 
-        ExecutorContext result = executionStateStore.lock(message.executionId(), execution -> tracer.inCurrentContext(
-            execution,
-            FlowId.uidWithoutRevision(execution),
-            () -> {
-                try {
-                    final FlowWithSource flow = findFlow(execution);
-                    ExecutorContext executor = new ExecutorContext(execution, flow);
-
-                    // schedule it for later if needed
-                    if (execution.getState().getCurrent() == State.Type.CREATED && execution.getScheduleDate() != null && execution.getScheduleDate().isAfter(Instant.now())) {
-                        ExecutionDelay executionDelay = ExecutionDelay.builder()
-                            .executionId(executor.getExecution().getId())
-                            .date(execution.getScheduleDate())
-                            .state(State.Type.RUNNING)
-                            .delayType(ExecutionDelay.DelayType.RESUME_FLOW)
-                            .build();
-                        executionDelayStateStore.save(executionDelay);
-                        return executor;
-                    }
-
-                    // create an SLA monitor if needed
-                    if ((execution.getState().getCurrent() == State.Type.CREATED || execution.getState().failedThenRestarted()) && !ListUtils.isEmpty(flow.getSla())) {
-                        List<SLAMonitor> monitors = flow.getSla().stream()
-                            .filter(ExecutionMonitoringSLA.class::isInstance)
-                            .map(ExecutionMonitoringSLA.class::cast)
-                            .map(sla -> SLAMonitor.builder()
-                                .executionId(execution.getId())
-                                .slaId(((SLA) sla).getId())
-                                .deadline(execution.getState().getStartDate().plus(sla.getDuration()))
-                                .build()
-                            )
-                            .toList();
-                        monitors.forEach(monitor -> slaMonitorStateStore.save(monitor));
-                    }
-
-                    // handle concurrency limit, we need to use a different queue to be sure that execution running
-                    // are processed sequentially so inside a queue with no parallelism
-                    if ((execution.getState().getCurrent() == State.Type.CREATED || execution.getState().failedThenRestarted()) && flow.getConcurrency() != null) {
-                        ExecutionRunning executionRunning = ExecutionRunning.builder()
-                            .tenantId(executor.getFlow().getTenantId())
-                            .namespace(executor.getFlow().getNamespace())
-                            .flowId(executor.getFlow().getId())
-                            .execution(executor.getExecution())
-                            .concurrencyState(ExecutionRunning.ConcurrencyState.CREATED)
-                            .build();
-
-                        ExecutionRunning processed = concurrencyLimitStateStore.countThenProcess(flow, (txContext, concurrencyLimit) -> {
-                            ExecutionRunning computed = executorService.processExecutionRunning(flow, concurrencyLimit.getRunning(), executionRunning.withExecution(execution)); // be sure that the execution running contains the latest value of the execution
-                            if (computed.getConcurrencyState() == ExecutionRunning.ConcurrencyState.RUNNING && !computed.getExecution().getState().isTerminated()) {
-                                return Pair.of(computed, concurrencyLimit.withRunning(concurrencyLimit.getRunning() + 1));
-                            } else if (computed.getConcurrencyState() == ExecutionRunning.ConcurrencyState.QUEUED) {
-                                executionQueuedStateStore.save(txContext, ExecutionQueued.fromExecutionRunning(computed));
-                            }
-                            return Pair.of(computed, concurrencyLimit);
-                        });
-
-                        // if the execution is queued or terminated due to concurrency limit, we stop here
-                        if (processed.getExecution().getState().isTerminated() || processed.getConcurrencyState() == ExecutionRunning.ConcurrencyState.QUEUED) {
-                            return executor.withExecution(processed.getExecution(), "handleConcurrencyLimit");
-                        }
-                    }
-
-                    // handle execution changed SLA
-                    executor = executorService.handleExecutionChangedSLA(executor);
-
-                    // process the execution
-                    if (log.isDebugEnabled()) {
-                        executorService.log(log, true, executor);
-                    }
-                    executor = executorService.process(executor);
-
-                    if (!executor.getNexts().isEmpty()) {
-                        executor.withExecution(
-                            executorService.onNexts(executor.getExecution(), executor.getNexts()),
-                            "onNexts"
-                        );
-                    }
-
-                    // worker task
-                    if (!executor.getWorkerTasks().isEmpty()) {
-                        List<WorkerTaskResult> workerTaskResults = new ArrayList<>();
-                        executor
-                            .getWorkerTasks()
-                            .forEach(throwConsumer(workerTask -> {
-                                try {
-                                    if (!TruthUtils.isTruthy(workerTask.getRunContext().render(workerTask.getTask().getRunIf()))) {
-                                        workerTaskResults.add(new WorkerTaskResult(workerTask.getTaskRun().withState(State.Type.SKIPPED)));
-                                    } else {
-                                        if (workerTask.getTask().isSendToWorkerTask()) {
-                                            Optional<WorkerGroup> maybeWorkerGroup = workerGroupService.resolveGroupFromJob(flow, workerTask);
-                                            String workerGroupKey = maybeWorkerGroup.map(throwFunction(workerGroup -> workerTask.getRunContext().render(workerGroup.getKey())))
-                                                .orElse(null);
-                                            if (workerTask.getTask() instanceof WorkingDirectory) {
-                                                // WorkingDirectory is a flowable so it will be moved to RUNNING a few lines under
-                                                workerJobQueue.emit(workerGroupKey, workerTask);
-                                            } else {
-                                                TaskRun taskRun = workerTask.getTaskRun().withState(State.Type.SUBMITTED);
-                                                workerJobQueue.emit(workerGroupKey, workerTask.withTaskRun(taskRun));
-                                                workerTaskResults.add(new WorkerTaskResult(taskRun));
-                                            }
-                                        }
-                                        /// flowable attempt state transition to running
-                                        if (workerTask.getTask().isFlowable()) {
-                                            List<TaskRunAttempt> attempts = Optional.ofNullable(workerTask.getTaskRun().getAttempts())
-                                                .map(ArrayList::new)
-                                                .orElseGet(ArrayList::new);
-
-
-                                            attempts.add(
-                                                TaskRunAttempt.builder()
-                                                    .state(new State().withState(State.Type.RUNNING))
-                                                    .build()
-                                            );
-
-                                            TaskRun updatedTaskRun = workerTask.getTaskRun()
-                                                .withAttempts(attempts)
-                                                .withState(State.Type.RUNNING);
-
-                                            workerTaskResults.add(new WorkerTaskResult(updatedTaskRun));
-                                        }
-                                    }
-                                } catch (Exception e) {
-                                    workerTaskResults.add(new WorkerTaskResult(workerTask.getTaskRun().withState(State.Type.FAILED)));
-                                    workerTask.getRunContext().logger().error("Failed to evaluate the runIf condition for task {}. Cause: {}", workerTask.getTask().getId(), e.getMessage(), e);
-                                }
-                            }));
-
-                        try {
-                            executorService.addWorkerTaskResults(executor, workerTaskResults);
-                        } catch (InternalException e) {
-                            log.error("Unable to add a worker task result to the execution", e);
-                        }
-                    }
-
-                    // subflow execution results
-                    if (!executor.getSubflowExecutionResults().isEmpty()) {
-                        executor.getSubflowExecutionResults()
-                            .forEach(throwConsumer(subflowExecutionResult -> subflowExecutionResultQueue.emit(subflowExecutionResult)));
-                    }
-
-                    // schedulerDelay
-                    if (!executor.getExecutionDelays().isEmpty()) {
-                        executor.getExecutionDelays()
-                            .forEach(executionDelay -> executionDelayStateStore.save(executionDelay));
-                    }
-
-                    // subflow executions
-                    if (!executor.getSubflowExecutions().isEmpty()) {
-                        executor.getSubflowExecutions().forEach(throwConsumer(subflowExecution -> {
-                            Execution subExecution = subflowExecution.getExecution();
-                            String msg = String.format("Created new execution [[link execution=\"%s\" flowId=\"%s\" namespace=\"%s\"]]", subExecution.getId(), subExecution.getFlowId(), subExecution.getNamespace());
-
-                            log.info(msg);
-
-                            logQueue.emit(LogEntry.of(subflowExecution.getParentTaskRun(), subflowExecution.getExecution().getKind()).toBuilder()
-                                .level(Level.INFO)
-                                .message(msg)
-                                .timestamp(subflowExecution.getParentTaskRun().getState().getStartDate())
-                                .thread(Thread.currentThread().getName())
-                                .build()
-                            );
-
-                            executionQueue.emit(subflowExecution.getExecution());
-                        }));
-                    }
-
-                    return executor;
-                } catch (QueueException e) {
-                    try {
-                        Execution failedExecution = fail(execution, e);
-                        this.executionQueue.emit(failedExecution);
-                    } catch (QueueException ex) {
-                        log.error("Unable to emit the execution {}", execution.getId(), ex);
-                    }
-                    Span.current().recordException(e).setStatus(StatusCode.ERROR);
-
-                    return null;
-                }
-            }
-        ));
-
-        if (result != null) {
-            this.toExecution(result);
-        }
+        Optional<ExecutorContext> maybeExecutor = executionEventMessageHandler.handle(message);
+        maybeExecutor.ifPresent(this::toExecution);
     }
 
     private void workerTaskResultQueue(Either<WorkerTaskResult, DeserializationException> either) {
@@ -549,30 +343,8 @@ public class DefaultExecutor implements Executor {
             return;
         }
 
-        if (log.isDebugEnabled()) {
-            executorService.log(log, true, message);
-        }
-
-        ExecutorContext executor = executionStateStore.lock(message.getTaskRun().getExecutionId(), execution -> {
-            ExecutorContext current = new ExecutorContext(execution);
-
-            if (execution.hasTaskRunJoinable(message.getTaskRun())) {
-                try {
-                    // process worker task result
-                    executorService.addWorkerTaskResult(current, () -> findFlow(execution), message);
-                    // join worker result
-                    return current;
-                } catch (InternalException e) {
-                    return handleFailedExecutionFromExecutor(current, e);
-                }
-            }
-
-            return null;
-        });
-
-        if (executor != null) {
-            this.toExecution(executor);
-        }
+        Optional<ExecutorContext> maybeExecutor = workerTaskResultMessageHandler.handle(message);
+        maybeExecutor.ifPresent(this::toExecution);
     }
 
     private void killQueue(Either<ExecutionKilled, DeserializationException> either) {
@@ -598,54 +370,12 @@ public class DefaultExecutor implements Executor {
             return;
         }
 
-        metricRegistry
-            .counter(MetricRegistry.METRIC_EXECUTOR_KILLED_COUNT, MetricRegistry.METRIC_EXECUTOR_KILLED_COUNT_DESCRIPTION, metricRegistry.tags(killedExecution))
-            .increment();
+        Optional<ExecutorContext> maybeExecutor = executionKilledExecutionMessageHandler.handle(killedExecution);
 
-        if (log.isDebugEnabled()) {
-            executorService.log(log, true, killedExecution);
-        }
-
-        // Immediately fire the event in EXECUTED state to notify the Workers to kill
-        // any remaining tasks for that executing regardless of if the execution exist or not.
-        // Note, that this event will be a noop if all tasks for that execution are already killed or completed.
-        try {
-            killQueue.emit(ExecutionKilledExecution
-                .builder()
-                .executionId(killedExecution.getExecutionId())
-                .isOnKillCascade(false)
-                .state(ExecutionKilled.State.EXECUTED)
-                .tenantId(killedExecution.getTenantId())
-                .build()
-            );
-        } catch (QueueException e) {
-            log.error("Unable to kill the execution {}", killedExecution.getExecutionId(), e);
-        }
-
-        ExecutorContext executor = killingOrAfterKillState(killedExecution.getExecutionId(), Optional.ofNullable(killedExecution.getExecutionState()));
-
-        // Check whether kill event should be propagated to downstream executions.
-        // By default, always propagate the ExecutionKill to sub-flows (for backward compatibility).
-        Boolean isOnKillCascade = Optional.ofNullable(killedExecution.getIsOnKillCascade()).orElse(true);
-        if (isOnKillCascade) {
-            executionService
-                .killSubflowExecutions(event.getTenantId(), killedExecution.getExecutionId())
-                .doOnNext(executionKilled -> {
-                    try {
-                        killQueue.emit(executionKilled);
-                    } catch (QueueException e) {
-                        log.error("Unable to kill the execution {}", executionKilled.getExecutionId(), e);
-                    }
-                })
-                .blockLast();
-        }
-
-        if (executor != null) {
-            // Transmit the new execution state. Note that the execution
-            // will eventually transition to KILLED state before sub-flow executions are actually killed.
-            // This behavior is acceptable due to the fire-and-forget nature of the killing event.
-            this.toExecution(executor, true);
-        }
+        // Transmit the new execution state. Note that the execution
+        // will eventually transition to KILLED state before sub-flow executions are actually killed.
+        // This behavior is acceptable due to the fire-and-forget nature of the killing event.
+        maybeExecutor.ifPresent(executor -> this.toExecution(executor, true));
     }
 
     private void subflowExecutionResultQueue(Either<SubflowExecutionResult, DeserializationException> either) {
@@ -664,80 +394,8 @@ public class DefaultExecutor implements Executor {
             return;
         }
 
-        if (log.isDebugEnabled()) {
-            executorService.log(log, true, message);
-        }
-
-        ExecutorContext executor = executionStateStore.lock(message.getParentTaskRun().getExecutionId(), execution -> {
-            ExecutorContext current = new ExecutorContext(execution);
-
-            if (execution.hasTaskRunJoinable(message.getParentTaskRun())) { // TODO if we remove this check, we can avoid adding 'iteration' on the 'isSame()' method
-                try {
-                    FlowWithSource flow = findFlow(execution);
-                    Task task = flow.findTaskByTaskId(message.getParentTaskRun().getTaskId());
-                    TaskRun taskRun;
-
-                    // iterative tasks
-                    if (task instanceof ForEachItem.ForEachItemExecutable forEachItem) {
-                        // For iterative tasks, we need to get the taskRun from the execution,
-                        // move it to the state of the child flow, and merge the outputs.
-                        // This is important to avoid races such as RUNNING that arrives after the first SUCCESS/FAILED.
-                        RunContext runContext = runContextFactory.of(flow, task, current.getExecution(), message.getParentTaskRun());
-                        taskRun = execution.findTaskRunByTaskRunId(message.getParentTaskRun().getId());
-                        if (taskRun.getState().getCurrent() != message.getState()) {
-                            taskRun = taskRun.withState(message.getState());
-                        }
-                        Map<String, Object> outputs = MapUtils.deepMerge(taskRun.getOutputs(), message.getParentTaskRun().getOutputs());
-                        Variables variables = variablesService.of(StorageContext.forTask(taskRun), outputs);
-                        taskRun = taskRun.withOutputs(variables);
-                        taskRun = ExecutableUtils.manageIterations(
-                            runContext.storage(),
-                            taskRun,
-                            current.getExecution(),
-                            forEachItem.getTransmitFailed(),
-                            forEachItem.isAllowFailure(),
-                            forEachItem.isAllowWarning()
-                        );
-                    } else {
-                        taskRun = message.getParentTaskRun();
-                    }
-
-                    Execution newExecution = current.getExecution().withTaskRun(taskRun);
-
-                    // If the worker task result is killed, we must check if it has a parents to also kill them if not already done.
-                    // Running flowable tasks that have child tasks running in the worker will be killed thanks to that.
-                    if (taskRun.getState().getCurrent() == State.Type.KILLED && taskRun.getParentTaskRunId() != null) {
-                        newExecution = executionService.killParentTaskruns(taskRun, newExecution);
-                    }
-
-                    current = current.withExecution(newExecution, "joinSubflowExecutionResult");
-
-                    // send metrics on parent taskRun terminated
-                    if (taskRun.getState().isTerminated()) {
-                        metricRegistry
-                            .counter(MetricRegistry.METRIC_EXECUTOR_TASKRUN_ENDED_COUNT, MetricRegistry.METRIC_EXECUTOR_TASKRUN_ENDED_COUNT_DESCRIPTION, metricRegistry.tags(message))
-                            .increment();
-
-                        metricRegistry
-                            .timer(MetricRegistry.METRIC_EXECUTOR_TASKRUN_ENDED_DURATION, MetricRegistry.METRIC_EXECUTOR_TASKRUN_ENDED_DURATION_DESCRIPTION, metricRegistry.tags(message))
-                            .record(taskRun.getState().getDuration());
-
-                        log.trace("TaskRun terminated: {}", taskRun);
-                    }
-
-                    // join worker result
-                    return current;
-                } catch (InternalException e) {
-                    return handleFailedExecutionFromExecutor(current, e);
-                }
-            }
-
-            return null;
-        });
-
-        if (executor != null) {
-            this.toExecution(executor);
-        }
+        Optional<ExecutorContext> maybeExecutor = subflowExecutionResultMessageHandler.handle(message);
+        maybeExecutor.ifPresent(this::toExecution);
     }
 
     private void subflowExecutionEndQueue(Either<SubflowExecutionEnd, DeserializationException> either) {
@@ -756,44 +414,7 @@ public class DefaultExecutor implements Executor {
             return;
         }
 
-        if (log.isDebugEnabled()) {
-            executorService.log(log, true, message);
-        }
-
-        executionStateStore.lock(message.getParentExecutionId(), execution -> {
-            if (execution == null) {
-                throw new IllegalStateException("Execution state don't exist for " + message.getParentExecutionId() + ", receive " + message);
-            }
-
-            FlowWithSource flow = findFlow(execution);
-            try {
-                ExecutableTask<?> executableTask = (ExecutableTask<?>) flow.findTaskByTaskId(message.getTaskId());
-                if (!executableTask.waitForExecution()) {
-                    return null;
-                }
-
-                TaskRun taskRun = execution.findTaskRunByTaskRunId(message.getTaskRunId()).withState(message.getState()).withOutputs(message.getOutputs());
-                FlowInterface childFlow = flowMetaStore.findByExecution(message.getChildExecution()).orElseThrow();
-                RunContext runContext = runContextFactory.of(
-                    childFlow,
-                    (Task) executableTask,
-                    message.getChildExecution(),
-                    taskRun
-                );
-
-                SubflowExecutionResult subflowExecutionResult = ExecutableUtils.subflowExecutionResultFromChildExecution(runContext, childFlow, message.getChildExecution(), executableTask, taskRun);
-                if (subflowExecutionResult != null) {
-                    try {
-                        this.subflowExecutionResultQueue.emit(subflowExecutionResult);
-                    } catch (QueueException ex) {
-                        log.error("Unable to emit the subflow execution result", ex);
-                    }
-                }
-            } catch (InternalException e) {
-                log.error("Unable to process the subflow execution end", e);
-            }
-            return null;
-        });
+        subflowExecutionEndMessageHandler.handle(message);
     }
 
     private void multipleConditionEventQueue(Either<MultipleConditionEvent, DeserializationException> either) {
@@ -804,14 +425,7 @@ public class DefaultExecutor implements Executor {
 
         MultipleConditionEvent multipleConditionEvent = either.getLeft();
 
-        flowTriggerService.computeExecutionsFromFlowTriggerPreconditions(multipleConditionEvent.execution(), multipleConditionEvent.flow(), multipleConditionStorage)
-            .forEach(exec -> {
-                try {
-                    executionQueue.emit(exec);
-                } catch (QueueException e) {
-                    log.error("Unable to emit the execution {}", exec.getId(), e);
-                }
-            });
+        multipleConditionEventMessageHandler.handle(multipleConditionEvent);
     }
 
     private void clusterEventQueue(Either<ClusterEvent, DeserializationException> either) {
@@ -841,7 +455,7 @@ public class DefaultExecutor implements Executor {
         }
 
         executionDelayStateStore.processExpired(Instant.now(), executionDelay -> {
-            ExecutorContext result = executionStateStore.lock(executionDelay.getExecutionId(), execution -> {
+            Optional<ExecutorContext> maybeExecutor = executionStateStore.lock(executionDelay.getExecutionId(), execution -> {
                 ExecutorContext executor = new ExecutorContext(execution);
 
                 metricRegistry
@@ -870,7 +484,7 @@ public class DefaultExecutor implements Executor {
                     }
                     // Handle failed task retries
                     else if (executionDelay.getDelayType().equals(ExecutionDelay.DelayType.RESTART_FAILED_TASK)) {
-                        FlowWithSource flow = findFlow(execution);
+                        FlowWithSource flow = flowMetaStore.findByExecutionThenInjectDefaults(execution).orElseThrow();
                         Execution newAttempt = executionService.retryTask(
                             execution,
                             flow,
@@ -889,15 +503,13 @@ public class DefaultExecutor implements Executor {
                         executor = executor.withExecution(newExecution, "continueLoop");
                     }
                 } catch (Exception e) {
-                    executor = handleFailedExecutionFromExecutor(executor, e);
+                    executor = executorService.handleFailedExecutionFromExecutor(executor, e);
                 }
 
                 return executor;
             });
 
-            if (result != null) {
-                this.toExecution(result);
-            }
+            maybeExecutor.ifPresent(this::toExecution);
         });
     }
 
@@ -907,8 +519,8 @@ public class DefaultExecutor implements Executor {
         }
 
         slaMonitorStateStore.processExpired(Instant.now(), slaMonitor -> {
-            ExecutorContext result = executionStateStore.lock(slaMonitor.getExecutionId(), execution -> {
-                FlowWithSource flow = findFlow(execution);
+            Optional<ExecutorContext> maybeExecutor = executionStateStore.lock(slaMonitor.getExecutionId(), execution -> {
+                FlowWithSource flow = flowMetaStore.findByExecutionThenInjectDefaults(execution).orElseThrow();
                 Optional<SLA> sla = flow.getSla().stream().filter(s -> s.getId().equals(slaMonitor.getSlaId())).findFirst();
                 if (sla.isEmpty()) {
                     // this can happen in case the flow has been updated and the SLA removed
@@ -939,15 +551,13 @@ public class DefaultExecutor implements Executor {
                             .increment();
                     }
                 } catch (Exception e) {
-                    executor = handleFailedExecutionFromExecutor(executor, e);
+                    executor = executorService.handleFailedExecutionFromExecutor(executor, e);
                 }
 
                 return executor;
             });
 
-            if (result != null) {
-                this.toExecution(result);
-            }
+            maybeExecutor.ifPresent(this::toExecution);
         });
     }
 
@@ -971,31 +581,6 @@ public class DefaultExecutor implements Executor {
         this.setState(ServiceState.RUNNING);
     }
 
-    private Execution fail(Execution message, Exception e) {
-        var failedExecution = message.failedExecutionFromExecutor(e);
-        try {
-            logQueue.emitAsync(failedExecution.getLogs());
-        } catch (QueueException ex) {
-            // fail silently
-        }
-        return failedExecution.getExecution().getState().isFailed() ? failedExecution.getExecution() :  failedExecution.getExecution().withState(State.Type.FAILED);
-    }
-
-    private ExecutorContext killingOrAfterKillState(final String executionId, Optional<State.Type> afterKillState) {
-        return executionStateStore.lock(executionId, execution -> {
-            FlowInterface flow = flowMetaStore.findByExecution(execution).orElseThrow();
-
-            // remove it from the queued store if it was queued so it would not be restarted
-            if (execution.getState().isQueued()) {
-                executionQueuedStateStore.remove(execution);
-            }
-
-            Execution killing = executionService.kill(execution, flow, afterKillState);
-            return new ExecutorContext(execution)
-                .withExecution(killing, "joinKillingExecution");
-        });
-    }
-
     private void toExecution(ExecutorContext executor) {
         toExecution(executor, false);
     }
@@ -1005,7 +590,7 @@ public class DefaultExecutor implements Executor {
             boolean shouldSend = false;
 
             if (executor.getException() != null) {
-                executor = handleFailedExecutionFromExecutor(executor, executor.getException());
+                executor = executorService.handleFailedExecutionFromExecutor(executor, executor.getException());
                 shouldSend = true;
             } else if (executor.isExecutionUpdated()) {
                 shouldSend = true;
@@ -1032,7 +617,8 @@ public class DefaultExecutor implements Executor {
             // the terminated state can come from the execution queue, in this case we always have a flow in the executor
             // or from a worker task in an afterExecution block, in this case we need to load the flow
             if (executor.getFlow() == null && executor.getExecution().getState().isTerminated()) {
-                executor = executor.withFlow(findFlow(executor.getExecution()));
+                FlowWithSource flow = flowMetaStore.findByExecutionThenInjectDefaults(executor.getExecution()).orElseThrow();
+                executor = executor.withFlow(flow);
             }
             boolean isTerminated = executor.getFlow() != null && executionService.isTerminated(executor.getFlow(), executor.getExecution());
 
@@ -1156,23 +742,6 @@ public class DefaultExecutor implements Executor {
             .map(f -> new MultipleConditionEvent(f.getFlow(), execution))
             .distinct() // we can have multiple MultipleConditionEvent if a flow contains multiple triggers as it would lead to multiple FlowWithFlowTrigger
             .forEach(throwConsumer(multipleCondition -> multipleConditionEventQueue.emit(multipleCondition)));
-    }
-
-    private FlowWithSource findFlow(Execution execution) {
-        FlowInterface flow = flowMetaStore.findByExecution(execution).orElseThrow();
-        return  pluginDefaultService.injectDefaults(flow, execution);
-    }
-
-    private ExecutorContext handleFailedExecutionFromExecutor(ExecutorContext executor, Exception e) {
-        Execution.FailedExecutionWithLog failedExecutionWithLog = executor.getExecution().failedExecutionFromExecutor(e);
-
-        try {
-            logQueue.emitAsync(failedExecutionWithLog.getLogs());
-        } catch (QueueException ex) {
-            // fail silently
-        }
-
-        return executor.withExecution(failedExecutionWithLog.getExecution(), "exception");
     }
 
     @Override

--- a/executor/src/main/java/io/kestra/executor/ExecutionStateStore.java
+++ b/executor/src/main/java/io/kestra/executor/ExecutionStateStore.java
@@ -2,6 +2,7 @@ package io.kestra.executor;
 
 import io.kestra.core.models.executions.Execution;
 
+import java.util.Optional;
 import java.util.function.Function;
 
 /**
@@ -11,5 +12,5 @@ public interface ExecutionStateStore {
     /**
      * Lock an execution for processing using the provided function.
      */
-    ExecutorContext lock(String executionId, Function<Execution, ExecutorContext> function);
+    Optional<ExecutorContext> lock(String executionId, Function<Execution, ExecutorContext> function);
 }

--- a/executor/src/main/java/io/kestra/executor/ExecutorMessageHandler.java
+++ b/executor/src/main/java/io/kestra/executor/ExecutorMessageHandler.java
@@ -1,0 +1,19 @@
+package io.kestra.executor;
+
+import java.util.Optional;
+
+/**
+ * Executor queue message handler that may return an {@link ExecutorContext} for updating the current execution.
+ *
+ * @see MessageHandler
+ *
+ * @param <T> the message type, this message should be tied to execution processing.
+ */
+public interface ExecutorMessageHandler<T> {
+    /**
+     * Handle a message then return an {@link ExecutorContext} if the current execution must be updated.
+     *
+     * @implNote implementors usually start by locking the current execution ,then process the message to avoid any concurrency issue.
+     */
+    Optional<ExecutorContext> handle(T message);
+}

--- a/executor/src/main/java/io/kestra/executor/ExecutorService.java
+++ b/executor/src/main/java/io/kestra/executor/ExecutorService.java
@@ -59,9 +59,6 @@ public class ExecutorService {
     private MetricRegistry metricRegistry;
 
     @Inject
-    private ConditionService conditionService;
-
-    @Inject
     private LogService logService;
 
     @Inject
@@ -98,7 +95,7 @@ public class ExecutorService {
     @Named(QueueFactoryInterface.WORKERTASKLOG_NAMED)
     private QueueInterface<LogEntry> logQueue;
 
-    protected FlowMetaStoreInterface flowExecutorInterface() {
+    private FlowMetaStoreInterface flowExecutorInterface() {
         // bean is injected late, so we need to wait
         if (this.flowExecutorInterface == null) {
             this.flowExecutorInterface = applicationContext.getBean(FlowMetaStoreInterface.class);
@@ -235,6 +232,18 @@ public class ExecutorService {
         }
 
         return newExecution;
+    }
+
+    public ExecutorContext handleFailedExecutionFromExecutor(ExecutorContext executor, Exception e) {
+        Execution.FailedExecutionWithLog failedExecutionWithLog = executor.getExecution().failedExecutionFromExecutor(e);
+
+        try {
+            logQueue.emitAsync(failedExecutionWithLog.getLogs());
+        } catch (QueueException ex) {
+            // fail silently
+        }
+
+        return executor.withExecution(failedExecutionWithLog.getExecution(), "exception");
     }
 
     private Optional<WorkerTaskResult> childWorkerTaskResult(FlowWithSource flow, Execution execution, TaskRun parentTaskRun) throws InternalException {

--- a/executor/src/main/java/io/kestra/executor/MessageHandler.java
+++ b/executor/src/main/java/io/kestra/executor/MessageHandler.java
@@ -1,0 +1,15 @@
+package io.kestra.executor;
+
+/**
+ * Executor queue message handler.
+ *
+ * @see ExecutorMessageHandler
+ *
+ * @param <T> the message type, this message should not be tied to execution processing.
+ */
+public interface MessageHandler<T> {
+    /**
+     * Handle a message.
+     */
+    void handle(T message);
+}

--- a/executor/src/main/java/io/kestra/executor/handler/ExecutionEventMessageHandler.java
+++ b/executor/src/main/java/io/kestra/executor/handler/ExecutionEventMessageHandler.java
@@ -1,0 +1,278 @@
+package io.kestra.executor.handler;
+
+import io.kestra.core.exceptions.InternalException;
+import io.kestra.core.models.executions.Execution;
+import io.kestra.core.models.executions.LogEntry;
+import io.kestra.core.models.executions.TaskRun;
+import io.kestra.core.models.executions.TaskRunAttempt;
+import io.kestra.core.models.flows.FlowId;
+import io.kestra.core.models.flows.FlowWithSource;
+import io.kestra.core.models.flows.State;
+import io.kestra.core.models.flows.sla.ExecutionMonitoringSLA;
+import io.kestra.core.models.flows.sla.SLA;
+import io.kestra.core.models.flows.sla.SLAMonitor;
+import io.kestra.core.models.tasks.WorkerGroup;
+import io.kestra.core.queues.QueueException;
+import io.kestra.core.queues.QueueFactoryInterface;
+import io.kestra.core.queues.QueueInterface;
+import io.kestra.core.runners.*;
+import io.kestra.core.services.WorkerGroupService;
+import io.kestra.core.trace.Tracer;
+import io.kestra.core.trace.TracerFactory;
+import io.kestra.core.utils.ListUtils;
+import io.kestra.core.utils.TruthUtils;
+import io.kestra.executor.*;
+import io.kestra.plugin.core.flow.WorkingDirectory;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.StatusCode;
+import jakarta.inject.Inject;
+import jakarta.inject.Named;
+import jakarta.inject.Singleton;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.tuple.Pair;
+import org.slf4j.event.Level;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import static io.kestra.core.utils.Rethrow.throwConsumer;
+import static io.kestra.core.utils.Rethrow.throwFunction;
+
+@Singleton
+@Slf4j
+public class ExecutionEventMessageHandler implements ExecutorMessageHandler<ExecutionEvent> {
+    @Inject
+    private ExecutionStateStore executionStateStore;
+    @Inject
+    private ExecutionQueuedStateStore executionQueuedStateStore;
+    @Inject
+    private ExecutionDelayStateStore executionDelayStateStore;
+    @Inject
+    private SLAMonitorStateStore  slaMonitorStateStore;
+    @Inject
+    private ConcurrencyLimitStateStore concurrencyLimitStateStore;
+
+    @Inject
+    private ExecutorService executorService;
+    @Inject
+    private WorkerGroupService workerGroupService;
+
+    @Inject
+    private FlowMetaStoreInterface flowMetaStore;
+
+    @Inject
+    @Named(QueueFactoryInterface.WORKERJOB_NAMED)
+    private QueueInterface<WorkerJob> workerJobQueue;
+    @Inject
+    @Named(QueueFactoryInterface.SUBFLOWEXECUTIONRESULT_NAMED)
+    private QueueInterface<SubflowExecutionResult> subflowExecutionResultQueue;
+    @Inject
+    @Named(QueueFactoryInterface.EXECUTION_NAMED)
+    private QueueInterface<Execution> executionQueue;
+    @Inject
+    @Named(QueueFactoryInterface.WORKERTASKLOG_NAMED)
+    private QueueInterface<LogEntry> logQueue;
+
+    private final Tracer tracer;
+
+    @Inject
+    public ExecutionEventMessageHandler(TracerFactory tracerFactory) {
+        this.tracer = tracerFactory.getTracer(DefaultExecutor.class, "EXECUTOR");
+    }
+
+    @Override
+    public Optional<ExecutorContext> handle(ExecutionEvent message) {
+        return executionStateStore.lock(message.executionId(), execution -> tracer.inCurrentContext(
+            execution,
+            FlowId.uidWithoutRevision(execution),
+            () -> {
+                try {
+                    final FlowWithSource flow = flowMetaStore.findByExecutionThenInjectDefaults(execution).orElseThrow();
+                    ExecutorContext executor = new ExecutorContext(execution, flow);
+
+                    // schedule it for later if needed
+                    if (execution.getState().getCurrent() == State.Type.CREATED && execution.getScheduleDate() != null && execution.getScheduleDate().isAfter(Instant.now())) {
+                        ExecutionDelay executionDelay = ExecutionDelay.builder()
+                            .executionId(executor.getExecution().getId())
+                            .date(execution.getScheduleDate())
+                            .state(State.Type.RUNNING)
+                            .delayType(ExecutionDelay.DelayType.RESUME_FLOW)
+                            .build();
+                        executionDelayStateStore.save(executionDelay);
+                        return executor;
+                    }
+
+                    // create an SLA monitor if needed
+                    if ((execution.getState().getCurrent() == State.Type.CREATED || execution.getState().failedThenRestarted()) && !ListUtils.isEmpty(flow.getSla())) {
+                        List<SLAMonitor> monitors = flow.getSla().stream()
+                            .filter(ExecutionMonitoringSLA.class::isInstance)
+                            .map(ExecutionMonitoringSLA.class::cast)
+                            .map(sla -> SLAMonitor.builder()
+                                .executionId(execution.getId())
+                                .slaId(((SLA) sla).getId())
+                                .deadline(execution.getState().getStartDate().plus(sla.getDuration()))
+                                .build()
+                            )
+                            .toList();
+                        monitors.forEach(monitor -> slaMonitorStateStore.save(monitor));
+                    }
+
+                    // handle concurrency limit, we need to use a different queue to be sure that execution running
+                    // are processed sequentially so inside a queue with no parallelism
+                    if ((execution.getState().getCurrent() == State.Type.CREATED || execution.getState().failedThenRestarted()) && flow.getConcurrency() != null) {
+                        ExecutionRunning executionRunning = ExecutionRunning.builder()
+                            .tenantId(executor.getFlow().getTenantId())
+                            .namespace(executor.getFlow().getNamespace())
+                            .flowId(executor.getFlow().getId())
+                            .execution(executor.getExecution())
+                            .concurrencyState(ExecutionRunning.ConcurrencyState.CREATED)
+                            .build();
+
+                        ExecutionRunning processed = concurrencyLimitStateStore.countThenProcess(flow, (txContext, concurrencyLimit) -> {
+                            ExecutionRunning computed = executorService.processExecutionRunning(flow, concurrencyLimit.getRunning(), executionRunning.withExecution(execution)); // be sure that the execution running contains the latest value of the execution
+                            if (computed.getConcurrencyState() == ExecutionRunning.ConcurrencyState.RUNNING && !computed.getExecution().getState().isTerminated()) {
+                                return Pair.of(computed, concurrencyLimit.withRunning(concurrencyLimit.getRunning() + 1));
+                            } else if (computed.getConcurrencyState() == ExecutionRunning.ConcurrencyState.QUEUED) {
+                                executionQueuedStateStore.save(txContext, ExecutionQueued.fromExecutionRunning(computed));
+                            }
+                            return Pair.of(computed, concurrencyLimit);
+                        });
+
+                        // if the execution is queued or terminated due to concurrency limit, we stop here
+                        if (processed.getExecution().getState().isTerminated() || processed.getConcurrencyState() == ExecutionRunning.ConcurrencyState.QUEUED) {
+                            return executor.withExecution(processed.getExecution(), "handleConcurrencyLimit");
+                        }
+                    }
+
+                    // handle execution changed SLA
+                    executor = executorService.handleExecutionChangedSLA(executor);
+
+                    // process the execution
+                    if (log.isDebugEnabled()) {
+                        executorService.log(log, true, executor);
+                    }
+                    executor = executorService.process(executor);
+
+                    if (!executor.getNexts().isEmpty()) {
+                        executor.withExecution(
+                            executorService.onNexts(executor.getExecution(), executor.getNexts()),
+                            "onNexts"
+                        );
+                    }
+
+                    // worker task
+                    if (!executor.getWorkerTasks().isEmpty()) {
+                        List<WorkerTaskResult> workerTaskResults = new ArrayList<>();
+                        executor
+                            .getWorkerTasks()
+                            .forEach(throwConsumer(workerTask -> {
+                                try {
+                                    if (!TruthUtils.isTruthy(workerTask.getRunContext().render(workerTask.getTask().getRunIf()))) {
+                                        workerTaskResults.add(new WorkerTaskResult(workerTask.getTaskRun().withState(State.Type.SKIPPED)));
+                                    } else {
+                                        if (workerTask.getTask().isSendToWorkerTask()) {
+                                            Optional<WorkerGroup> maybeWorkerGroup = workerGroupService.resolveGroupFromJob(flow, workerTask);
+                                            String workerGroupKey = maybeWorkerGroup.map(throwFunction(workerGroup -> workerTask.getRunContext().render(workerGroup.getKey())))
+                                                .orElse(null);
+                                            if (workerTask.getTask() instanceof WorkingDirectory) {
+                                                // WorkingDirectory is a flowable so it will be moved to RUNNING a few lines under
+                                                workerJobQueue.emit(workerGroupKey, workerTask);
+                                            } else {
+                                                TaskRun taskRun = workerTask.getTaskRun().withState(State.Type.SUBMITTED);
+                                                workerJobQueue.emit(workerGroupKey, workerTask.withTaskRun(taskRun));
+                                                workerTaskResults.add(new WorkerTaskResult(taskRun));
+                                            }
+                                        }
+                                        /// flowable attempt state transition to running
+                                        if (workerTask.getTask().isFlowable()) {
+                                            List<TaskRunAttempt> attempts = Optional.ofNullable(workerTask.getTaskRun().getAttempts())
+                                                .map(ArrayList::new)
+                                                .orElseGet(ArrayList::new);
+
+
+                                            attempts.add(
+                                                TaskRunAttempt.builder()
+                                                    .state(new State().withState(State.Type.RUNNING))
+                                                    .build()
+                                            );
+
+                                            TaskRun updatedTaskRun = workerTask.getTaskRun()
+                                                .withAttempts(attempts)
+                                                .withState(State.Type.RUNNING);
+
+                                            workerTaskResults.add(new WorkerTaskResult(updatedTaskRun));
+                                        }
+                                    }
+                                } catch (Exception e) {
+                                    workerTaskResults.add(new WorkerTaskResult(workerTask.getTaskRun().withState(State.Type.FAILED)));
+                                    workerTask.getRunContext().logger().error("Failed to evaluate the runIf condition for task {}. Cause: {}", workerTask.getTask().getId(), e.getMessage(), e);
+                                }
+                            }));
+
+                        try {
+                            executorService.addWorkerTaskResults(executor, workerTaskResults);
+                        } catch (InternalException e) {
+                            log.error("Unable to add a worker task result to the execution", e);
+                        }
+                    }
+
+                    // subflow execution results
+                    if (!executor.getSubflowExecutionResults().isEmpty()) {
+                        executor.getSubflowExecutionResults()
+                            .forEach(throwConsumer(subflowExecutionResult -> subflowExecutionResultQueue.emit(subflowExecutionResult)));
+                    }
+
+                    // schedulerDelay
+                    if (!executor.getExecutionDelays().isEmpty()) {
+                        executor.getExecutionDelays()
+                            .forEach(executionDelay -> executionDelayStateStore.save(executionDelay));
+                    }
+
+                    // subflow executions
+                    if (!executor.getSubflowExecutions().isEmpty()) {
+                        executor.getSubflowExecutions().forEach(throwConsumer(subflowExecution -> {
+                            Execution subExecution = subflowExecution.getExecution();
+                            String msg = String.format("Created new execution [[link execution=\"%s\" flowId=\"%s\" namespace=\"%s\"]]", subExecution.getId(), subExecution.getFlowId(), subExecution.getNamespace());
+
+                            log.info(msg);
+
+                            logQueue.emit(LogEntry.of(subflowExecution.getParentTaskRun(), subflowExecution.getExecution().getKind()).toBuilder()
+                                .level(Level.INFO)
+                                .message(msg)
+                                .timestamp(subflowExecution.getParentTaskRun().getState().getStartDate())
+                                .thread(Thread.currentThread().getName())
+                                .build()
+                            );
+
+                            executionQueue.emit(subflowExecution.getExecution());
+                        }));
+                    }
+
+                    return executor;
+                } catch (QueueException e) {
+                    try {
+                        Execution failedExecution = fail(execution, e);
+                        this.executionQueue.emit(failedExecution);
+                    } catch (QueueException ex) {
+                        log.error("Unable to emit the execution {}", execution.getId(), ex);
+                    }
+                    Span.current().recordException(e).setStatus(StatusCode.ERROR);
+
+                    return null;
+                }
+            }
+        ));
+    }
+
+    private Execution fail(Execution message, Exception e) {
+        var failedExecution = message.failedExecutionFromExecutor(e);
+        try {
+            logQueue.emitAsync(failedExecution.getLogs());
+        } catch (QueueException ex) {
+            // fail silently
+        }
+        return failedExecution.getExecution().getState().isFailed() ? failedExecution.getExecution() :  failedExecution.getExecution().withState(State.Type.FAILED);
+    }
+}

--- a/executor/src/main/java/io/kestra/executor/handler/ExecutionKilledExecutionMessageHandler.java
+++ b/executor/src/main/java/io/kestra/executor/handler/ExecutionKilledExecutionMessageHandler.java
@@ -1,0 +1,110 @@
+package io.kestra.executor.handler;
+
+import io.kestra.core.metrics.MetricRegistry;
+import io.kestra.core.models.executions.Execution;
+import io.kestra.core.models.executions.ExecutionKilled;
+import io.kestra.core.models.executions.ExecutionKilledExecution;
+import io.kestra.core.models.flows.FlowInterface;
+import io.kestra.core.models.flows.State;
+import io.kestra.core.queues.QueueException;
+import io.kestra.core.queues.QueueFactoryInterface;
+import io.kestra.core.queues.QueueInterface;
+import io.kestra.core.runners.ExecutionQueuedStateStore;
+import io.kestra.core.runners.FlowMetaStoreInterface;
+import io.kestra.core.services.ExecutionService;
+import io.kestra.executor.ExecutionStateStore;
+import io.kestra.executor.ExecutorContext;
+import io.kestra.executor.ExecutorService;
+import io.kestra.executor.ExecutorMessageHandler;
+import jakarta.inject.Inject;
+import jakarta.inject.Named;
+import jakarta.inject.Singleton;
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.Optional;
+
+@Singleton
+@Slf4j
+public class ExecutionKilledExecutionMessageHandler implements ExecutorMessageHandler<ExecutionKilledExecution> {
+    @Inject
+    private ExecutorService executorService;
+    @Inject
+    private ExecutionService executionService;
+
+    @Inject
+    private ExecutionStateStore executionStateStore;
+    @Inject
+    private ExecutionQueuedStateStore executionQueuedStateStore;
+
+    @Inject
+    private MetricRegistry metricRegistry;
+
+    @Inject
+    private FlowMetaStoreInterface flowMetaStore;
+
+    @Inject
+    @Named(QueueFactoryInterface.KILL_NAMED)
+    private QueueInterface<ExecutionKilled> killQueue;
+
+    @Override
+    public Optional<ExecutorContext> handle(ExecutionKilledExecution message) {
+        metricRegistry
+            .counter(MetricRegistry.METRIC_EXECUTOR_KILLED_COUNT, MetricRegistry.METRIC_EXECUTOR_KILLED_COUNT_DESCRIPTION, metricRegistry.tags(message))
+            .increment();
+
+        if (log.isDebugEnabled()) {
+            executorService.log(log, true, message);
+        }
+
+        // Immediately fire the event in EXECUTED state to notify the Workers to kill
+        // any remaining tasks for that executing regardless of if the execution exist or not.
+        // Note, that this event will be a noop if all tasks for that execution are already killed or completed.
+        try {
+            killQueue.emit(ExecutionKilledExecution
+                .builder()
+                .executionId(message.getExecutionId())
+                .isOnKillCascade(false)
+                .state(ExecutionKilled.State.EXECUTED)
+                .tenantId(message.getTenantId())
+                .build()
+            );
+        } catch (QueueException e) {
+            log.error("Unable to kill the execution {}", message.getExecutionId(), e);
+        }
+
+        Optional<ExecutorContext> maybeExecutor = killingOrAfterKillState(message.getExecutionId(), Optional.ofNullable(message.getExecutionState()));
+
+        // Check whether kill event should be propagated to downstream executions.
+        // By default, always propagate the ExecutionKill to sub-flows (for backward compatibility).
+        Boolean isOnKillCascade = Optional.ofNullable(message.getIsOnKillCascade()).orElse(true);
+        if (isOnKillCascade) {
+            executionService
+                .killSubflowExecutions(message.getTenantId(), message.getExecutionId())
+                .doOnNext(executionKilled -> {
+                    try {
+                        killQueue.emit(executionKilled);
+                    } catch (QueueException e) {
+                        log.error("Unable to kill the execution {}", executionKilled.getExecutionId(), e);
+                    }
+                })
+                .blockLast();
+        }
+
+        return maybeExecutor;
+    }
+
+    private Optional<ExecutorContext> killingOrAfterKillState(final String executionId, Optional<State.Type> afterKillState) {
+        return executionStateStore.lock(executionId, execution -> {
+            FlowInterface flow = flowMetaStore.findByExecution(execution).orElseThrow();
+
+            // remove it from the queued store if it was queued so it would not be restarted
+            if (execution.getState().isQueued()) {
+                executionQueuedStateStore.remove(execution);
+            }
+
+            Execution killing = executionService.kill(execution, flow, afterKillState);
+            return new ExecutorContext(execution)
+                .withExecution(killing, "joinKillingExecution");
+        });
+    }
+}

--- a/executor/src/main/java/io/kestra/executor/handler/ExecutionMessageHandler.java
+++ b/executor/src/main/java/io/kestra/executor/handler/ExecutionMessageHandler.java
@@ -1,0 +1,50 @@
+package io.kestra.executor.handler;
+
+import io.kestra.core.models.executions.Execution;
+import io.kestra.core.models.flows.State;
+import io.kestra.core.queues.QueueException;
+import io.kestra.core.queues.QueueFactoryInterface;
+import io.kestra.core.queues.QueueInterface;
+import io.kestra.core.runners.ExecutionEvent;
+import io.kestra.core.runners.ExecutionEventType;
+import io.kestra.executor.ExecutionStateStore;
+import io.kestra.executor.ExecutorContext;
+import io.kestra.executor.ExecutorMessageHandler;
+import jakarta.inject.Inject;
+import jakarta.inject.Named;
+import jakarta.inject.Singleton;
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.Optional;
+
+@Singleton
+@Slf4j
+public class ExecutionMessageHandler implements ExecutorMessageHandler<Execution> {
+    @Inject
+    @Named(QueueFactoryInterface.EXECUTION_EVENT_NAMED)
+    private QueueInterface<ExecutionEvent> executionEventQueue;
+
+    @Inject
+    private ExecutionStateStore executionStateStore;
+
+    @Override
+    public Optional<ExecutorContext> handle(Execution message) {
+        try {
+            executionEventQueue.emit(new ExecutionEvent(message, ExecutionEventType.CREATED));
+            return Optional.empty();
+        } catch (QueueException e) {
+            // If we cannot send the execution event, we fail the execution
+            return executionStateStore.lock(message.getId(), execution -> {
+                try {
+                    Execution failed = execution.failedExecutionFromExecutor(e).getExecution().withState(State.Type.FAILED);
+                    ExecutionEvent event = new ExecutionEvent(failed, ExecutionEventType.TERMINATED);
+                    this.executionEventQueue.emit(event);
+                    return new ExecutorContext(failed);
+                } catch (QueueException ex) {
+                    log.error("Unable to emit the execution {}", execution.getId(), ex);
+                }
+                return null;
+            });
+        }
+    }
+}

--- a/executor/src/main/java/io/kestra/executor/handler/MultipleConditionEventMessageHandler.java
+++ b/executor/src/main/java/io/kestra/executor/handler/MultipleConditionEventMessageHandler.java
@@ -1,0 +1,40 @@
+package io.kestra.executor.handler;
+
+import io.kestra.core.models.executions.Execution;
+import io.kestra.core.models.triggers.multipleflows.MultipleConditionStorageInterface;
+import io.kestra.core.queues.QueueException;
+import io.kestra.core.queues.QueueFactoryInterface;
+import io.kestra.core.queues.QueueInterface;
+import io.kestra.core.runners.MultipleConditionEvent;
+import io.kestra.executor.FlowTriggerService;
+import io.kestra.executor.MessageHandler;
+import jakarta.inject.Inject;
+import jakarta.inject.Named;
+import jakarta.inject.Singleton;
+import lombok.extern.slf4j.Slf4j;
+
+@Singleton
+@Slf4j
+public class MultipleConditionEventMessageHandler implements MessageHandler<MultipleConditionEvent> {
+    @Inject
+    private FlowTriggerService flowTriggerService;
+
+    @Inject
+    private MultipleConditionStorageInterface multipleConditionStorage;
+
+    @Inject
+    @Named(QueueFactoryInterface.EXECUTION_NAMED)
+    private QueueInterface<Execution> executionQueue;
+
+    @Override
+    public void handle(MultipleConditionEvent message) {
+        flowTriggerService.computeExecutionsFromFlowTriggerPreconditions(message.execution(), message.flow(), multipleConditionStorage)
+            .forEach(exec -> {
+                try {
+                    executionQueue.emit(exec);
+                } catch (QueueException e) {
+                    log.error("Unable to emit the execution {}", exec.getId(), e);
+                }
+            });
+    }
+}

--- a/executor/src/main/java/io/kestra/executor/handler/SubflowExecutionEndMessageHandler.java
+++ b/executor/src/main/java/io/kestra/executor/handler/SubflowExecutionEndMessageHandler.java
@@ -1,0 +1,75 @@
+package io.kestra.executor.handler;
+
+import io.kestra.core.exceptions.InternalException;
+import io.kestra.core.models.executions.TaskRun;
+import io.kestra.core.models.flows.FlowInterface;
+import io.kestra.core.models.flows.FlowWithSource;
+import io.kestra.core.models.tasks.ExecutableTask;
+import io.kestra.core.models.tasks.Task;
+import io.kestra.core.queues.QueueException;
+import io.kestra.core.queues.QueueFactoryInterface;
+import io.kestra.core.queues.QueueInterface;
+import io.kestra.core.runners.*;
+import io.kestra.executor.*;
+import jakarta.inject.Inject;
+import jakarta.inject.Named;
+import jakarta.inject.Singleton;
+import lombok.extern.slf4j.Slf4j;
+
+@Singleton
+@Slf4j
+public class SubflowExecutionEndMessageHandler implements MessageHandler<SubflowExecutionEnd> {
+    @Inject
+    private ExecutorService executorService;
+
+    @Inject
+    private ExecutionStateStore executionStateStore;
+
+    @Inject
+    private FlowMetaStoreInterface flowMetaStore;
+
+    @Inject
+    private RunContextFactory runContextFactory;
+
+    @Inject
+    @Named(QueueFactoryInterface.SUBFLOWEXECUTIONRESULT_NAMED)
+    private QueueInterface<SubflowExecutionResult> subflowExecutionResultQueue;
+
+    @Override
+    public void handle(SubflowExecutionEnd message) {
+        if (log.isDebugEnabled()) {
+            executorService.log(log, true, message);
+        }
+
+        executionStateStore.lock(message.getParentExecutionId(), execution -> {
+            FlowWithSource flow = flowMetaStore.findByExecutionThenInjectDefaults(execution).orElseThrow();
+            try {
+                ExecutableTask<?> executableTask = (ExecutableTask<?>) flow.findTaskByTaskId(message.getTaskId());
+                if (!executableTask.waitForExecution()) {
+                    return null;
+                }
+
+                TaskRun taskRun = execution.findTaskRunByTaskRunId(message.getTaskRunId()).withState(message.getState()).withOutputs(message.getOutputs());
+                FlowInterface childFlow = flowMetaStore.findByExecution(message.getChildExecution()).orElseThrow();
+                RunContext runContext = runContextFactory.of(
+                    childFlow,
+                    (Task) executableTask,
+                    message.getChildExecution(),
+                    taskRun
+                );
+
+                SubflowExecutionResult subflowExecutionResult = ExecutableUtils.subflowExecutionResultFromChildExecution(runContext, childFlow, message.getChildExecution(), executableTask, taskRun);
+                if (subflowExecutionResult != null) {
+                    try {
+                        this.subflowExecutionResultQueue.emit(subflowExecutionResult);
+                    } catch (QueueException ex) {
+                        log.error("Unable to emit the subflow execution result", ex);
+                    }
+                }
+            } catch (InternalException e) {
+                log.error("Unable to process the subflow execution end", e);
+            }
+            return null;
+        });
+    }
+}

--- a/executor/src/main/java/io/kestra/executor/handler/SubflowExecutionResultMessageHandler.java
+++ b/executor/src/main/java/io/kestra/executor/handler/SubflowExecutionResultMessageHandler.java
@@ -1,0 +1,121 @@
+package io.kestra.executor.handler;
+
+import io.kestra.core.exceptions.InternalException;
+import io.kestra.core.metrics.MetricRegistry;
+import io.kestra.core.models.executions.Execution;
+import io.kestra.core.models.executions.TaskRun;
+import io.kestra.core.models.executions.Variables;
+import io.kestra.core.models.flows.FlowWithSource;
+import io.kestra.core.models.flows.State;
+import io.kestra.core.models.tasks.Task;
+import io.kestra.core.runners.*;
+import io.kestra.core.services.ExecutionService;
+import io.kestra.core.services.VariablesService;
+import io.kestra.core.storages.StorageContext;
+import io.kestra.core.utils.MapUtils;
+import io.kestra.executor.ExecutionStateStore;
+import io.kestra.executor.ExecutorContext;
+import io.kestra.executor.ExecutorService;
+import io.kestra.executor.ExecutorMessageHandler;
+import io.kestra.plugin.core.flow.ForEachItem;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.Map;
+import java.util.Optional;
+
+@Singleton
+@Slf4j
+public class SubflowExecutionResultMessageHandler implements ExecutorMessageHandler<SubflowExecutionResult> {
+    @Inject
+    private ExecutorService executorService;
+    @Inject
+    private RunContextFactory runContextFactory;
+    @Inject
+    private MetricRegistry metricRegistry;
+    @Inject
+    private VariablesService variablesService;
+    @Inject
+    private ExecutionService executionService;
+
+    @Inject
+    private FlowMetaStoreInterface flowMetaStore;
+
+    @Inject
+    private ExecutionStateStore executionStateStore;
+
+    @Override
+    public Optional<ExecutorContext> handle(SubflowExecutionResult message) {
+        if (log.isDebugEnabled()) {
+            executorService.log(log, true, message);
+        }
+
+        return executionStateStore.lock(message.getParentTaskRun().getExecutionId(), execution -> {
+            ExecutorContext current = new ExecutorContext(execution);
+
+            if (execution.hasTaskRunJoinable(message.getParentTaskRun())) { // TODO if we remove this check, we can avoid adding 'iteration' on the 'isSame()' method
+                try {
+                    FlowWithSource flow = flowMetaStore.findByExecutionThenInjectDefaults(execution).orElseThrow();
+                    Task task = flow.findTaskByTaskId(message.getParentTaskRun().getTaskId());
+                    TaskRun taskRun;
+
+                    // iterative tasks
+                    if (task instanceof ForEachItem.ForEachItemExecutable forEachItem) {
+                        // For iterative tasks, we need to get the taskRun from the execution,
+                        // move it to the state of the child flow, and merge the outputs.
+                        // This is important to avoid races such as RUNNING that arrives after the first SUCCESS/FAILED.
+                        RunContext runContext = runContextFactory.of(flow, task, current.getExecution(), message.getParentTaskRun());
+                        taskRun = execution.findTaskRunByTaskRunId(message.getParentTaskRun().getId());
+                        if (taskRun.getState().getCurrent() != message.getState()) {
+                            taskRun = taskRun.withState(message.getState());
+                        }
+                        Map<String, Object> outputs = MapUtils.deepMerge(taskRun.getOutputs(), message.getParentTaskRun().getOutputs());
+                        Variables variables = variablesService.of(StorageContext.forTask(taskRun), outputs);
+                        taskRun = taskRun.withOutputs(variables);
+                        taskRun = ExecutableUtils.manageIterations(
+                            runContext.storage(),
+                            taskRun,
+                            current.getExecution(),
+                            forEachItem.getTransmitFailed(),
+                            forEachItem.isAllowFailure(),
+                            forEachItem.isAllowWarning()
+                        );
+                    } else {
+                        taskRun = message.getParentTaskRun();
+                    }
+
+                    Execution newExecution = current.getExecution().withTaskRun(taskRun);
+
+                    // If the worker task result is killed, we must check if it has a parents to also kill them if not already done.
+                    // Running flowable tasks that have child tasks running in the worker will be killed thanks to that.
+                    if (taskRun.getState().getCurrent() == State.Type.KILLED && taskRun.getParentTaskRunId() != null) {
+                        newExecution = executionService.killParentTaskruns(taskRun, newExecution);
+                    }
+
+                    current = current.withExecution(newExecution, "joinSubflowExecutionResult");
+
+                    // send metrics on parent taskRun terminated
+                    if (taskRun.getState().isTerminated()) {
+                        metricRegistry
+                            .counter(MetricRegistry.METRIC_EXECUTOR_TASKRUN_ENDED_COUNT, MetricRegistry.METRIC_EXECUTOR_TASKRUN_ENDED_COUNT_DESCRIPTION, metricRegistry.tags(message))
+                            .increment();
+
+                        metricRegistry
+                            .timer(MetricRegistry.METRIC_EXECUTOR_TASKRUN_ENDED_DURATION, MetricRegistry.METRIC_EXECUTOR_TASKRUN_ENDED_DURATION_DESCRIPTION, metricRegistry.tags(message))
+                            .record(taskRun.getState().getDuration());
+
+                        log.trace("TaskRun terminated: {}", taskRun);
+                    }
+
+                    // join worker result
+                    return current;
+                } catch (InternalException e) {
+                    return executorService.handleFailedExecutionFromExecutor(current, e);
+                }
+            }
+
+            return null;
+        });
+    }
+}

--- a/executor/src/main/java/io/kestra/executor/handler/WorkerTaskResultMessageHandler.java
+++ b/executor/src/main/java/io/kestra/executor/handler/WorkerTaskResultMessageHandler.java
@@ -1,0 +1,51 @@
+package io.kestra.executor.handler;
+
+import io.kestra.core.exceptions.InternalException;
+import io.kestra.core.runners.FlowMetaStoreInterface;
+import io.kestra.core.runners.WorkerTaskResult;
+import io.kestra.executor.ExecutionStateStore;
+import io.kestra.executor.ExecutorContext;
+import io.kestra.executor.ExecutorService;
+import io.kestra.executor.ExecutorMessageHandler;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.Optional;
+
+@Singleton
+@Slf4j
+public class WorkerTaskResultMessageHandler implements ExecutorMessageHandler<WorkerTaskResult> {
+    @Inject
+    private ExecutionStateStore executionStateStore;
+
+    @Inject
+    private ExecutorService executorService;
+
+    @Inject
+    private FlowMetaStoreInterface flowMetaStore;
+
+    @Override
+    public Optional<ExecutorContext> handle(WorkerTaskResult message) {
+        if (log.isDebugEnabled()) {
+            executorService.log(log, true, message);
+        }
+
+        return executionStateStore.lock(message.getTaskRun().getExecutionId(), execution -> {
+            ExecutorContext current = new ExecutorContext(execution);
+
+            if (execution.hasTaskRunJoinable(message.getTaskRun())) {
+                try {
+                    // process worker task result
+                    executorService.addWorkerTaskResult(current, () -> flowMetaStore.findByExecutionThenInjectDefaults(execution).orElseThrow(), message);
+                    // join worker result
+                    return current;
+                } catch (InternalException e) {
+                    return executorService.handleFailedExecutionFromExecutor(current, e);
+                }
+            }
+
+            return null;
+        });
+    }
+}

--- a/executor/src/test/java/io/kestra/executor/handler/ExecutionEventMessageHandlerTest.java
+++ b/executor/src/test/java/io/kestra/executor/handler/ExecutionEventMessageHandlerTest.java
@@ -1,0 +1,53 @@
+package io.kestra.executor.handler;
+
+import io.kestra.core.junit.annotations.KestraTest;
+import io.kestra.core.models.executions.Execution;
+import io.kestra.core.models.flows.GenericFlow;
+import io.kestra.core.models.flows.State;
+import io.kestra.core.repositories.ExecutionRepositoryInterface;
+import io.kestra.core.repositories.FlowRepositoryInterface;
+import io.kestra.core.runners.ExecutionEvent;
+import io.kestra.core.runners.ExecutionEventType;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.util.Collections;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@KestraTest
+class ExecutionEventMessageHandlerTest {
+    @Inject
+    private ExecutionEventMessageHandler executionEventMessageHandler;
+
+    @Inject
+    private ExecutionRepositoryInterface executionRepository;
+
+    @Inject
+    private FlowRepositoryInterface flowRepository;
+
+    @Test
+    void shouldReturnEmptyForNonExistingExecution() {
+        var executionEvent = new ExecutionEvent("tenant", "namespace", "flow", "execution", Instant.now(), ExecutionEventType.CREATED);
+
+        var maybeExecutor = executionEventMessageHandler.handle(executionEvent);
+
+        assertThat(maybeExecutor).isEmpty();
+    }
+
+    @Test
+    void shouldReturnAnExecutorForExistingExecution() {
+        var flow = Fixtures.flow();
+        flowRepository.create(GenericFlow.of(flow));
+        var execution = Execution.newExecution(flow, Collections.emptyList());
+        executionRepository.save(execution);
+        var executionEvent = new ExecutionEvent(execution, ExecutionEventType.CREATED);
+
+        var maybeExecutor = executionEventMessageHandler.handle(executionEvent);
+
+        assertThat(maybeExecutor).isPresent();
+        assertThat(maybeExecutor.get().getExecution().getState().getCurrent()).isEqualTo(State.Type.RUNNING);
+        assertThat(maybeExecutor.get().getExecution().getTaskRunList()).hasSize(1);
+    }
+}

--- a/executor/src/test/java/io/kestra/executor/handler/ExecutionKilledExecutionMessageHandlerTest.java
+++ b/executor/src/test/java/io/kestra/executor/handler/ExecutionKilledExecutionMessageHandlerTest.java
@@ -1,0 +1,62 @@
+package io.kestra.executor.handler;
+
+import io.kestra.core.junit.annotations.KestraTest;
+import io.kestra.core.models.executions.Execution;
+import io.kestra.core.models.executions.ExecutionKilled;
+import io.kestra.core.models.executions.ExecutionKilledExecution;
+import io.kestra.core.models.flows.GenericFlow;
+import io.kestra.core.models.flows.State;
+import io.kestra.core.repositories.ExecutionRepositoryInterface;
+import io.kestra.core.repositories.FlowRepositoryInterface;
+import io.kestra.core.runners.ExecutionEvent;
+import io.kestra.core.runners.ExecutionEventType;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+@KestraTest
+class ExecutionKilledExecutionMessageHandlerTest {
+    @Inject
+    private ExecutionKilledExecutionMessageHandler executionKilledExecutionMessageHandler;
+
+    @Inject
+    private ExecutionRepositoryInterface executionRepository;
+
+    @Inject
+    private FlowRepositoryInterface flowRepository;
+
+    @Test
+    void shouldReturnEmptyForNonExistingExecution() {
+        var executionKilled = ExecutionKilledExecution.builder()
+            .tenantId("tenant")
+            .executionId("execution")
+            .executionState(State.Type.FAILED)
+            .build();
+
+        var maybeExecutor = executionKilledExecutionMessageHandler.handle(executionKilled);
+
+        assertTrue(maybeExecutor.isEmpty());
+    }
+
+    @Test
+    void shouldReturnAnExecutorForExistingExecution() {
+        var flow = Fixtures.flow();
+        flowRepository.create(GenericFlow.of(flow));
+        var execution = Execution.newExecution(flow, Collections.emptyList());
+        executionRepository.save(execution);
+        var executionKilledExecution = ExecutionKilledExecution.builder()
+            .tenantId(execution.getTenantId())
+            .executionId(execution.getId())
+            .executionState(State.Type.KILLED)
+            .build();
+
+        var maybeExecutor = executionKilledExecutionMessageHandler.handle(executionKilledExecution);
+
+        assertThat(maybeExecutor).isPresent();
+        assertThat(maybeExecutor.get().getExecution().getState().getCurrent()).isEqualTo(State.Type.KILLED);
+    }
+}

--- a/executor/src/test/java/io/kestra/executor/handler/ExecutionMessageHandlerTest.java
+++ b/executor/src/test/java/io/kestra/executor/handler/ExecutionMessageHandlerTest.java
@@ -1,0 +1,26 @@
+package io.kestra.executor.handler;
+
+import io.kestra.core.junit.annotations.KestraTest;
+import io.kestra.core.models.executions.Execution;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@KestraTest
+class ExecutionMessageHandlerTest {
+    @Inject
+    private ExecutionMessageHandler executionMessageHandler;
+
+    @Test
+    void shouldReturnNoExecutor() {
+        var flow = Fixtures.flow();
+        var execution = Execution.newExecution(flow, Collections.emptyList());
+
+        var maybeExecutor = executionMessageHandler.handle(execution);
+
+        assertThat(maybeExecutor.isEmpty()).isTrue();
+    }
+}

--- a/executor/src/test/java/io/kestra/executor/handler/Fixtures.java
+++ b/executor/src/test/java/io/kestra/executor/handler/Fixtures.java
@@ -1,0 +1,22 @@
+package io.kestra.executor.handler;
+
+import io.kestra.core.models.flows.Flow;
+import io.kestra.plugin.core.log.Log;
+
+import java.util.List;
+
+final class Fixtures {
+    private Fixtures() {
+        // utility class pattern
+    }
+
+    static Flow flow() {
+        return Flow.builder()
+            .tenantId("tenant")
+            .namespace("namespace")
+            .id("flow")
+            .revision(1)
+            .tasks(List.of(Log.builder().id("log").type(Log.class.getName()).message("Hello World").build()))
+            .build();
+    }
+}

--- a/executor/src/test/java/io/kestra/executor/handler/MultipleConditionEventMessageHandlerTest.java
+++ b/executor/src/test/java/io/kestra/executor/handler/MultipleConditionEventMessageHandlerTest.java
@@ -1,0 +1,35 @@
+package io.kestra.executor.handler;
+
+import io.kestra.core.junit.annotations.KestraTest;
+import io.kestra.core.models.executions.Execution;
+import io.kestra.core.models.flows.GenericFlow;
+import io.kestra.core.repositories.ExecutionRepositoryInterface;
+import io.kestra.core.repositories.FlowRepositoryInterface;
+import io.kestra.core.runners.MultipleConditionEvent;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+
+@KestraTest
+class MultipleConditionEventMessageHandlerTest {
+    @Inject
+    private MultipleConditionEventMessageHandler multipleConditionEventMessageHandler;
+
+    @Inject
+    private ExecutionRepositoryInterface executionRepository;
+
+    @Inject
+    private FlowRepositoryInterface flowRepository;
+
+    @Test
+    void shouldHandleAMessage() {
+        var flow = Fixtures.flow();
+        flowRepository.create(GenericFlow.of(flow));
+        var execution = Execution.newExecution(flow, Collections.emptyList());
+        executionRepository.save(execution);
+        var multipleConditionEvent = new MultipleConditionEvent(flow, execution);
+
+        multipleConditionEventMessageHandler.handle(multipleConditionEvent);
+    }
+}

--- a/executor/src/test/java/io/kestra/executor/handler/SubflowExecutionEndMessageHandlerTest.java
+++ b/executor/src/test/java/io/kestra/executor/handler/SubflowExecutionEndMessageHandlerTest.java
@@ -1,0 +1,46 @@
+package io.kestra.executor.handler;
+
+import io.kestra.core.junit.annotations.KestraTest;
+import io.kestra.core.models.executions.Execution;
+import io.kestra.core.models.flows.GenericFlow;
+import io.kestra.core.models.flows.State;
+import io.kestra.core.repositories.ExecutionRepositoryInterface;
+import io.kestra.core.repositories.FlowRepositoryInterface;
+import io.kestra.core.runners.SubflowExecutionEnd;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+
+@KestraTest
+class SubflowExecutionEndMessageHandlerTest {
+    @Inject
+    private SubflowExecutionEndMessageHandler subflowExecutionEndMessageHandler;
+
+    @Inject
+    private ExecutionRepositoryInterface executionRepository;
+
+    @Inject
+    private FlowRepositoryInterface flowRepository;
+
+    @Test
+    void shouldHandleAMessage() {
+        var flow = Fixtures.flow();
+        flowRepository.create(GenericFlow.of(flow));
+        var parentExecution = Execution.newExecution(flow, Collections.emptyList());
+        executionRepository.save(parentExecution);
+        var execution = Execution.newExecution(flow, Collections.emptyList());
+        executionRepository.save(execution);
+
+        var subflowExecutionEnd = SubflowExecutionEnd
+            .builder()
+            .childExecution(execution)
+            .parentExecutionId(parentExecution.getId())
+            .state(State.Type.SUCCESS)
+            .taskId("task")
+            .taskRunId("taskRun")
+            .build();
+
+        subflowExecutionEndMessageHandler.handle(subflowExecutionEnd);
+    }
+}

--- a/executor/src/test/java/io/kestra/executor/handler/SubflowExecutionResultMessageHandlerTest.java
+++ b/executor/src/test/java/io/kestra/executor/handler/SubflowExecutionResultMessageHandlerTest.java
@@ -1,0 +1,70 @@
+package io.kestra.executor.handler;
+
+import io.kestra.core.junit.annotations.KestraTest;
+import io.kestra.core.models.executions.Execution;
+import io.kestra.core.models.executions.TaskRun;
+import io.kestra.core.models.flows.GenericFlow;
+import io.kestra.core.models.flows.State;
+import io.kestra.core.repositories.ExecutionRepositoryInterface;
+import io.kestra.core.repositories.FlowRepositoryInterface;
+import io.kestra.core.runners.SubflowExecutionResult;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@KestraTest
+class SubflowExecutionResultMessageHandlerTest {
+    @Inject
+    private SubflowExecutionResultMessageHandler subflowExecutionResultMessageHandler;
+
+    @Inject
+    private ExecutionRepositoryInterface executionRepository;
+
+    @Inject
+    private FlowRepositoryInterface flowRepository;
+
+    @Test
+    void shouldReturnEmptyForNonExistingExecution() {
+        var subflowExecutionResult = SubflowExecutionResult.builder()
+            .executionId("execution")
+            .state(State.Type.SUCCESS)
+            .parentTaskRun(TaskRun.builder()
+                .id("parent")
+                .flowId("flow")
+                .namespace("namespace")
+                .executionId("execution")
+                .build())
+            .build();
+
+        var maybeExecutor = subflowExecutionResultMessageHandler.handle(subflowExecutionResult);
+
+        assertThat(maybeExecutor).isEmpty();
+    }
+
+    @Test
+    void shouldReturnAnExecutorForExistingExecution() {
+        var flow = Fixtures.flow();
+        flowRepository.create(GenericFlow.of(flow));
+        var parentExecution = Execution.newExecution(flow, Collections.emptyList());
+        executionRepository.save(parentExecution);
+        var execution = Execution.newExecution(flow, Collections.emptyList());
+        executionRepository.save(execution);
+        var subflowExecutionResult = SubflowExecutionResult.builder()
+            .executionId(execution.getId())
+            .state(State.Type.SUCCESS)
+            .parentTaskRun(TaskRun.builder()
+                .id("parent")
+                .flowId(parentExecution.getFlowId())
+                .namespace(parentExecution.getNamespace())
+                .executionId(parentExecution.getId())
+                .build())
+            .build();
+
+        var maybeExecutor = subflowExecutionResultMessageHandler.handle(subflowExecutionResult);
+
+        assertThat(maybeExecutor).isPresent();
+    }
+}

--- a/executor/src/test/java/io/kestra/executor/handler/WorkerTaskResultMessageHandlerTest.java
+++ b/executor/src/test/java/io/kestra/executor/handler/WorkerTaskResultMessageHandlerTest.java
@@ -1,0 +1,87 @@
+package io.kestra.executor.handler;
+
+import io.kestra.core.junit.annotations.KestraTest;
+import io.kestra.core.models.executions.Execution;
+import io.kestra.core.models.executions.TaskRun;
+import io.kestra.core.models.flows.GenericFlow;
+import io.kestra.core.models.flows.State;
+import io.kestra.core.repositories.ExecutionRepositoryInterface;
+import io.kestra.core.repositories.FlowRepositoryInterface;
+import io.kestra.core.runners.WorkerTaskResult;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@KestraTest
+class WorkerTaskResultMessageHandlerTest {
+    @Inject
+    private WorkerTaskResultMessageHandler workerTaskResultMessageHandler;
+
+    @Inject
+    private ExecutionRepositoryInterface executionRepository;
+
+    @Inject
+    private FlowRepositoryInterface flowRepository;
+
+    @Test
+    void shouldReturnEmptyForNonExistingExecution() {
+        var workerTaskResult = WorkerTaskResult.builder()
+            .taskRun(TaskRun.builder()
+                .executionId("execution")
+                .id("taskrun")
+                .taskId("task")
+                .build())
+            .build();
+
+        var maybeExecutor = workerTaskResultMessageHandler.handle(workerTaskResult);
+
+        assertThat(maybeExecutor).isEmpty();
+    }
+
+    @Test
+    void shouldReturnAnExecutorForExistingExecution() {
+        var flow = Fixtures.flow();
+        flowRepository.create(GenericFlow.of(flow));
+        var execution = Execution.newExecution(flow, Collections.emptyList());
+        var taskRun = TaskRun.builder()
+            .executionId(execution.getId())
+            .namespace(execution.getNamespace())
+            .flowId(execution.getFlowId())
+            .id("taskrun")
+            .taskId(flow.getTasks().getFirst().getId())
+            .state(new State().withState(State.Type.SUBMITTED))
+            .build();
+        executionRepository.save(execution.withTaskRunList(Collections.singletonList(taskRun)));
+        var workerTaskResult = WorkerTaskResult.builder()
+            .taskRun(taskRun.withState(State.Type.SUCCESS))
+            .build();
+
+        var maybeExecutor = workerTaskResultMessageHandler.handle(workerTaskResult);
+
+        assertThat(maybeExecutor).isPresent();
+        assertThat(maybeExecutor.get().getExecution().getTaskRunList().getFirst().getState().getCurrent()).isEqualTo(State.Type.SUCCESS);
+    }
+
+    @Test
+    void shouldFailTheExecutionForMissingTask() {
+        var flow = Fixtures.flow();
+        flowRepository.create(GenericFlow.of(flow));
+        var execution = Execution.newExecution(flow, Collections.emptyList());
+        executionRepository.save(execution);
+        var workerTaskResult = WorkerTaskResult.builder()
+            .taskRun(TaskRun.builder()
+                .executionId(execution.getId())
+                .id("taskrun")
+                .taskId("task")
+                .build())
+            .build();
+
+        var maybeExecutor = workerTaskResultMessageHandler.handle(workerTaskResult);
+
+        assertThat(maybeExecutor).isPresent();
+        assertThat(maybeExecutor.get().getExecution().getState().getCurrent()).isEqualTo(State.Type.FAILED);
+    }
+}

--- a/jdbc/src/main/java/io/kestra/jdbc/repository/AbstractJdbcExecutionRepository.java
+++ b/jdbc/src/main/java/io/kestra/jdbc/repository/AbstractJdbcExecutionRepository.java
@@ -868,7 +868,7 @@ public abstract class AbstractJdbcExecutionRepository extends AbstractJdbcCrudRe
     }
 
     @Override
-    public ExecutorContext lock(String executionId, Function<Execution, ExecutorContext> function) {
+    public Optional<ExecutorContext> lock(String executionId, Function<Execution, ExecutorContext> function) {
         return this.jdbcRepository
             .getDslContextWrapper()
             .transactionResult(configuration -> {
@@ -885,17 +885,17 @@ public abstract class AbstractJdbcExecutionRepository extends AbstractJdbcCrudRe
 
                 // not ready for now, skip and wait for a first state
                 if (execution.isEmpty()) {
-                    return null;
+                    return Optional.empty();
                 }
 
                 ExecutorContext executor = function.apply(execution.get());
 
                 if (executor != null) {
                     this.jdbcRepository.persist(executor.getExecution(), context, null);
-                    return executor;
+                    return Optional.of(executor);
                 }
 
-                return null;
+                return Optional.empty();
             });
     }
 


### PR DESCRIPTION
Split the Executor into multiple pieces, each queue consumer is now implemented in a separate message handler.