### PR TITLE
fix(12949): replace getCurrentInstance with useI18n in AiCopilot

### DIFF
--- a/ui/src/components/ai/AiCopilot.vue
+++ b/ui/src/components/ai/AiCopilot.vue
@@ -60,15 +60,16 @@
 </template>
 
 <script setup lang="ts">
-    import {computed, getCurrentInstance, onMounted, onUnmounted, ref, watch} from "vue";
+    import {computed, onMounted, onUnmounted, ref, watch} from "vue";
     import Close from "vue-material-design-icons/Close.vue";
     import KeyboardReturn from "vue-material-design-icons/KeyboardReturn.vue";
+    import {useI18n} from "vue-i18n";
     import AiIcon from "./AiIcon.vue";
     import {useAiStore} from "../../stores/ai";
     import Utils from "../../utils/utils";
     import {useMiscStore} from "override/stores/misc";
 
-    const t = getCurrentInstance()!.appContext.config.globalProperties.$t;
+    const {t} = useI18n();
     const aiStore = useAiStore();
     const emit = defineEmits<{
         close: [];

--- a/ui/src/components/ai/AiCopilot.vue
+++ b/ui/src/components/ai/AiCopilot.vue
@@ -3,7 +3,7 @@
         <template #header>
             <div class="d-flex justify-content-between">
                 <span class="d-inline-flex title align-items-center">
-                    <AiIcon /><span>{{ t("ai.flow.title") }}</span>
+                    <AiIcon /><span>{{ $t("ai.flow.title") }}</span>
                 </span>
                 <el-button 
                     class="border-0 ai-close-button" 
@@ -18,7 +18,7 @@
             ref="promptInput"
             v-if="configured"
             type="textarea"
-            :placeholder="t('ai.flow.prompt_placeholder')"
+            :placeholder="$t('ai.flow.prompt_placeholder')"
             v-model="prompt"
             @keydown.exact.ctrl.enter="$event.preventDefault(); prompt += '\n'"
             @keydown.exact.enter.prevent="submitPrompt"
@@ -26,15 +26,15 @@
         />
         <template v-else>
             <!-- eslint-disable-next-line vue/no-v-text-v-html-on-component -->
-            <el-text class="keep-whitespace" v-html="t('ai.flow.enable_instructions.header')" />
+            <el-text class="keep-whitespace" v-html="$t('ai.flow.enable_instructions.header')" />
             <div class="mt-2" v-html="highlightedAiConfiguration" />
             <!-- eslint-disable-next-line vue/no-v-text-v-html-on-component -->
-            <el-text class="keep-whitespace" v-html="t('ai.flow.enable_instructions.footer')" />
+            <el-text class="keep-whitespace" v-html="$t('ai.flow.enable_instructions.footer')" />
         </template>
         <template #footer>
             <div class="d-flex justify-content-between">
                 <el-text class="text-tertiary" size="small">
-                    (⌘) Ctrl + Alt (⌥) + Shift + K {{ t("to toggle") }}
+                    (⌘) Ctrl + Alt (⌥) + Shift + K {{ $t("to toggle") }}
                 </el-text>
                 <div v-if="configured" class="d-flex flex-column align-items-end gap-3">
                     <el-text v-if="error !== undefined" type="danger" size="default" class="me-auto">
@@ -42,7 +42,7 @@
                     </el-text>
                     <div v-if="waitingForReply" class="d-flex loading-text">
                         <div v-loading="true" />
-                        <span>{{ t('ai.flow.generating') }}</span>
+                        <span>{{ $t('ai.flow.generating') }}</span>
                     </div>
                     <el-button
                         v-else
@@ -51,7 +51,7 @@
                         :disabled="prompt.length === 0"
                         @click="submitPrompt"
                     >
-                        {{ t('submit') }}
+                        {{ $t('submit') }}
                     </el-button>
                 </div>
             </div>
@@ -67,10 +67,7 @@
     import {useAiStore} from "../../stores/ai";
     import Utils from "../../utils/utils";
     import {useMiscStore} from "override/stores/misc";
-    
-    import {useI18n} from "vue-i18n";
-    const {t} = useI18n({useScope: "global"});
-    
+
     const aiStore = useAiStore();
     const emit = defineEmits<{
         close: [];

--- a/ui/src/components/ai/AiCopilot.vue
+++ b/ui/src/components/ai/AiCopilot.vue
@@ -63,13 +63,14 @@
     import {computed, onMounted, onUnmounted, ref, watch} from "vue";
     import Close from "vue-material-design-icons/Close.vue";
     import KeyboardReturn from "vue-material-design-icons/KeyboardReturn.vue";
-    import {useI18n} from "vue-i18n";
     import AiIcon from "./AiIcon.vue";
     import {useAiStore} from "../../stores/ai";
     import Utils from "../../utils/utils";
     import {useMiscStore} from "override/stores/misc";
-
-    const {t} = useI18n();
+    
+    import {useI18n} from "vue-i18n";
+    const {t} = useI18n({useScope: "global"});
+    
     const aiStore = useAiStore();
     const emit = defineEmits<{
         close: [];


### PR DESCRIPTION
Closes https://github.com/kestra-io/kestra/issues/12949.

### Summary
This PR resolves **#12949** by replacing the usage of `getCurrentInstance` with
the `useI18n` composable inside `AiCopilot.vue`.

### Why this change?
The rest of the project already uses `useI18n` for localization.  
Using it here ensures:
- consistent localization approach across the codebase
- cleaner component structure
- removal of unnecessary instance access

### Changes
- Replaced `getCurrentInstance()` usage
- Introduced `useI18n()` composable
- Updated references accordingly

### Files updated
- `kestra/ui/src/components/ai/AiCopilot.vue`


