### PR TITLE
fix(ui): simplify translations in ChartViewWrapper.vue by using global

### DIFF
--- a/ui/src/components/dashboard/components/ChartViewWrapper.vue
+++ b/ui/src/components/dashboard/components/ChartViewWrapper.vue
@@ -1,5 +1,7 @@
 <template>
-    <div class="chart-view">
+    <div
+        class="chart-view"
+    >
         <div v-if="dashboardStore.selectedChart" class="w-100">
             <Sections
                 :dashboard="{id: 'default', charts: [dashboardStore.selectedChart]}"

--- a/ui/src/components/dashboard/components/ChartViewWrapper.vue
+++ b/ui/src/components/dashboard/components/ChartViewWrapper.vue
@@ -1,7 +1,5 @@
 <template>
-    <div
-        class="chart-view"
-    >
+    <div class="chart-view">
         <div v-if="dashboardStore.selectedChart" class="w-100">
             <Sections
                 :dashboard="{id: 'default', charts: [dashboardStore.selectedChart]}"
@@ -16,7 +14,7 @@
             <el-empty :image="EmptyVisualDashboard" :imageSize="200">
                 <template #description>
                     <h5>
-                        {{ t("dashboards.chart_preview") }}
+                        {{ $t("dashboards.chart_preview") }}
                     </h5>
                 </template>
             </el-empty>
@@ -25,12 +23,9 @@
 </template>
 
 <script lang="ts" setup>
-    import {useI18n} from "vue-i18n";
     import Sections from "../sections/Sections.vue";
     import EmptyVisualDashboard from "../../../assets/empty_visuals/Visuals_empty_dashboard.svg";
     import {useDashboardStore} from "../../../stores/dashboard";
-
-    const {t} = useI18n();
 
     const dashboardStore = useDashboardStore();
 </script>


### PR DESCRIPTION
Closes https://github.com/kestra-io/kestra/issues/12970.

Simplify ChartViewWrapper.vue translations by using $t in template section #12970
✔ Removed useI18n import
✔ Removed const { t } = useI18n()
✔ Updated template translation to use $t("dashboards.chart_preview")
✔ Verified that component renders correctly

This aligns with Kestra’s i18n setup and improves code clarity and consistency.