### PR TITLE
feat(system): configure Docker Compose termination grace period to 6m

### DIFF
--- a/docker-compose-dind.yml
+++ b/docker-compose-dind.yml
@@ -44,6 +44,8 @@ services:
   kestra:
     image: kestra/kestra:latest
     pull_policy: always
+    # Kestra, by default, has a termination grace period of 5m. We need to wait a little more to be sure no active tasks are running.
+    stop_grace_period: 6m
     # Note that this is meant for development only. Refer to the documentation for production deployments of Kestra which runs without a root user.
     user: "root"
     command: server standalone

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,6 +22,8 @@ services:
   kestra:
     image: kestra/kestra:latest
     pull_policy: always
+    # Kestra, by default, has a termination grace period of 5m. We need to wait a little more to be sure no active tasks are running.
+    stop_grace_period: 6m
     # Note that this setup with a root user is intended for development purpose.
     # Our base image runs without root, but the Docker Compose implementation needs root to access the Docker socket
     user: "root"


### PR DESCRIPTION
By default, Kestra has a termination grace period of 5m. To be sure all tasks are terminated, we need to configure Docker Compose with a termination grace period of more than that: 6m.

Part-of: https://github.com/kestra-io/kestra-ee/issues/5556