### PR TITLE
fix(ui): render level badge and header inline with message

### DIFF
--- a/ui/src/components/logs/LogLine.vue
+++ b/ui/src/components/logs/LogLine.vue
@@ -207,7 +207,6 @@ div.line {
         vertical-align: middle;
         /* prevent Firefox word breaks */
         max-width: calc(100% - 6rem);
-        /* allow breaking long words anywhere and avoid overflow across browsers */
         overflow-wrap: anywhere;
         word-break: break-word;
         min-width: 0;

--- a/ui/src/components/logs/LogLine.vue
+++ b/ui/src/components/logs/LogLine.vue
@@ -8,13 +8,13 @@
         <el-icon v-if="cursor" class="icon_container" :style="{color: iconColor}" :size="28">
             <MenuRight />
         </el-icon>
-        <span :style="levelStyle" class="el-tag log-level">{{ log.level }}</span>
         <div class="log-content d-inline-block">
             <span v-if="title" class="fw-bold">{{ log.taskId ?? log.flowId ?? "" }}</span>
             <div
                 class="header"
                 :class="{'d-inline-block': metaWithValue.length === 0, 'me-3': metaWithValue.length === 0}"
             >
+                <span :style="levelStyle" class="el-tag log-level">{{ log.level }}</span>
                 <span class="header-badge text-secondary">
                     {{ Filters.date(log.timestamp, "iso") }}
                 </span>
@@ -174,9 +174,7 @@ div.line {
     cursor: text;
     white-space: pre-wrap;
     word-break: break-all;
-    display: flex;
-    align-items: flex-start;
-    gap: 1rem;
+    display: block;
 
     border-left-width: 2px !important;
     border-left-style: solid;
@@ -199,13 +197,26 @@ div.line {
 
     .log-level {
         padding: .25rem;
-        margin-top: 0.25rem;
-        align-self: center;
+        margin-top: 0;
+        display: inline-flex;
+        vertical-align: middle;
     }
 
     .log-content {
-        // prevent Firefox word breaks
-        flex-grow: 1;
+        display: inline-block;
+        vertical-align: middle;
+        /* prevent Firefox word breaks */
+        max-width: calc(100% - 6rem);
+        /* allow breaking long words anywhere and avoid overflow across browsers */
+        overflow-wrap: anywhere;
+        word-break: break-word;
+        min-width: 0;
+
+        .header {
+            display: inline-flex;
+            align-items: center;
+            gap: .5rem;
+        }
 
         .header > * + * {
             margin-left: 1rem;
@@ -221,7 +232,8 @@ div.line {
         text-align: center;
         white-space: nowrap;
         vertical-align: baseline;
-        width: 40px;
+        width: auto;
+        min-width: 40px;
 
         span:first-child {
             margin-right: 6px;


### PR DESCRIPTION
closes #12736 

Summary: 
Rendered the log level badge, timestamp, and metadata inline with the message in the Execution > Logs view for a more compact and readable layout.

Changes made:

- Moved the log level tag `[.log-level]` into the `[.header]` markup so the level badge is part of the timestamp/meta group.
- Reworked layout from display: flex to inline-level layout for the badge and content:
  [.log-content] -> display: inline-block, vertical-align: middle
  [.log-level] -> display: inline-flex, removed top margin
  [.header] -> display: inline-flex, align-items: center
 

Improved cross-browser wrapping by adding:
  - overflow-wrap: anywhere; (better because it avoids splitting words in odd places).
  - word-break: break-word; (keeps older browser behavior as fallback)
  - min-width: 0; (prevents overflow in flex contexts when the element is allowed to shrink.)
  
  
<img width="764" height="216" alt="image" src="https://github.com/user-attachments/assets/6ac12098-9f51-4519-b2c1-c9d590c2e819" />


<img width="500" height="226" alt="image" src="https://github.com/user-attachments/assets/645cfd87-7803-4132-8d8c-3d8d504bb83e" />

  