### PR TITLE
Refactor DateAgo component to use moment directly

### DIFF
--- a/ui/src/components/layout/DateAgo.vue
+++ b/ui/src/components/layout/DateAgo.vue
@@ -17,8 +17,9 @@
     </span>
 </template>
 <script setup lang="ts">
-    import {computed, getCurrentInstance} from "vue";
+    import {computed} from "vue";
     import Utils from "../../utils/utils";
+    import moment from "moment";
 
     const props = defineProps({
         date: {
@@ -46,12 +47,11 @@
     function uid(key: string) {
         return key + "-" + Utils.uid();
     }
-    const {$moment, $filters} = getCurrentInstance()?.appContext.config.globalProperties || {} as any;
 
     const from = computed(() => {
-        return $moment(props.date).fromNow();
+        return moment(props.date).fromNow();
     })
     const full = computed(() => {
-        return $filters.date(props.date, props.format);
+        return moment(props.date).format(props.format);
     })
 </script>


### PR DESCRIPTION
## ✨ Description

This PR refactors the `DateAgo.vue` component to use a direct import of `moment` instead of accessing it through Vue's `getCurrentInstance()` API.

### Changes:
- Removed `getCurrentInstance` from Vue imports
- Added direct `import moment from "moment";`
- Replaced `$moment(props.date).fromNow()` with `moment(props.date).fromNow()`
- Replaced `$filters.date()` with `moment().format()` for date formatting

### 🔗 Related Issue

Closes https://github.com/kestra-io/kestra/issues/12956

## 🖥 Frontend Checklist

- [x] Code builds without errors (`npm run build`)
- [ ] All existing E2E tests pass (`npm run test:e2e`)
- [ ] Screenshots or video recordings attached showing the `UI` changes

## 📝 Additional Notes

This is a straightforward refactoring that improves code maintainability by using explicit imports rather than relying on Vue's internal instance API, which is consistent with the pattern used elsewhere in the project.