### PR TITLE
refactor: replace getCurrentInstance with useToast composable

### DIFF
--- a/ui/src/components/inputs/EditorButtonsWrapper.vue
+++ b/ui/src/components/inputs/EditorButtonsWrapper.vue
@@ -41,7 +41,7 @@
 </script>
 
 <script setup lang="ts">
-    import {computed, getCurrentInstance, inject, InjectionKey} from "vue";
+    import {computed, inject, InjectionKey} from "vue";
     import {useRouter, useRoute} from "vue-router";
     import {useI18n} from "vue-i18n";
     import EditorButtons from "./EditorButtons.vue";
@@ -51,6 +51,7 @@
     import localUtils from "../../utils/utils";
     import {useFlowOutdatedErrors} from "./flowOutdatedErrors";
     import {useFlowStore} from "../../stores/flow";
+    import {useToast} from "../../utils/toast";
 
     defineProps<{
         haveChange: boolean;
@@ -82,7 +83,7 @@
     const flowHaveTasks = computed(() => flowStore.flowHaveTasks)
     const flowErrors = computed(() => flowStore.flowErrors?.map(translateError));
     const flowInfos = computed(() => flowStore.flowInfos)
-    const toast = getCurrentInstance()?.appContext.config.globalProperties.$toast();
+    const toast = useToast();
     const flowWarnings = computed(() => {
 
         const outdatedWarning =


### PR DESCRIPTION
### ✨ Description

Replace the deprecated `getCurrentInstance()?.appContext.config.globalProperties.$toast()` pattern with the `useToast()` composable from `utils/toast.ts` in the `EditorButtonsWrapper.vue` component for better maintainability and following Vue 3 best practices.

### 🔗 Related Issue

Closes #12951

### 🎨 Frontend Checklist

- [x] Code builds without errors (`npm run build`)
- [ ] All existing E2E tests pass (`npm run test:e2e`)
- [ ] Screenshots or video recordings attached showing the 'UI' changes

_Note: This is a refactoring change that does not modify the UI behavior._