### PR TITLE
fix(execution): failed flowable should also have a failed attempt

### DIFF
--- a/core/src/test/java/io/kestra/core/runners/AbstractRunnerTest.java
+++ b/core/src/test/java/io/kestra/core/runners/AbstractRunnerTest.java
@@ -487,6 +487,7 @@ public abstract class AbstractRunnerTest {
     void badExecutable(Execution execution) {
         assertThat(execution.getTaskRunList().size()).isEqualTo(1);
         assertThat(execution.getTaskRunList().getFirst().getState().getCurrent()).isEqualTo(State.Type.FAILED);
+        assertThat(execution.getTaskRunList().getFirst().getAttempts().getFirst().getState().getCurrent()).isEqualTo(State.Type.FAILED);
         assertThat(execution.getState().getCurrent()).isEqualTo(State.Type.FAILED);
     }
 

--- a/core/src/test/java/io/kestra/plugin/core/flow/BadFlowableTest.java
+++ b/core/src/test/java/io/kestra/plugin/core/flow/BadFlowableTest.java
@@ -17,6 +17,8 @@ public class BadFlowableTest {
     void sequential(Execution execution) {
         assertThat(execution.getTaskRunList().size()).as("Task runs were: \n" + JacksonMapper.log(execution.getTaskRunList())).isGreaterThanOrEqualTo(2);
         assertThat(execution.getState().getCurrent()).isEqualTo(State.Type.FAILED);
+        assertThat(execution.getTaskRunList().getFirst().getState().getCurrent()).isEqualTo(State.Type.FAILED);
+        assertThat(execution.getTaskRunList().getFirst().getAttempts().getFirst().getState().getCurrent()).isEqualTo(State.Type.FAILED);
     }
 
     @Test

--- a/core/src/test/java/io/kestra/plugin/core/flow/IfTest.java
+++ b/core/src/test/java/io/kestra/plugin/core/flow/IfTest.java
@@ -132,4 +132,13 @@ class IfTest {
         assertThat(execution.getTaskRunList()).hasSize(9);
         assertThat(execution.getState().getCurrent()).isEqualTo(State.Type.SUCCESS);
     }
+
+    @Test
+    @ExecuteFlow("flows/valids/if-condition-fail.yaml")
+    void ifConditionFail(Execution execution) {
+        assertThat(execution.getTaskRunList()).hasSize(1);
+        assertThat(execution.getState().getCurrent()).isEqualTo(State.Type.FAILED);
+        assertThat(execution.getTaskRunList().getFirst().getState().getCurrent()).isEqualTo(State.Type.FAILED);
+        assertThat(execution.getTaskRunList().getFirst().getAttempts().getFirst().getState().getCurrent()).isEqualTo(State.Type.FAILED);
+    }
 }

--- a/core/src/test/resources/flows/valids/if-condition-fail.yaml
+++ b/core/src/test/resources/flows/valids/if-condition-fail.yaml
@@ -1,0 +1,11 @@
+id: if-condition-fail
+namespace: io.kestra.tests
+
+tasks:
+  - id: if
+    type: io.kestra.plugin.core.flow.If
+    condition: "{{ inputs.run }}"
+    then:
+      - id: hello
+        type: io.kestra.plugin.core.log.Log
+        message: Hello World! 🚀

--- a/executor/src/main/java/io/kestra/executor/ExecutorService.java
+++ b/executor/src/main/java/io/kestra/executor/ExecutorService.java
@@ -263,26 +263,30 @@ public class ExecutorService {
                 WorkerTaskResult workerTaskResult = endedTask.get();
                 // Compute outputs for the parent Flowable task if a terminated state was resolved
                 if (workerTaskResult.getTaskRun().getState().isTerminated()) {
+                    Variables variables;
                     try {
                         // as flowable tasks can save outputs during iterative execution, we must merge the maps here
                         Output outputs = flowableParent.outputs(runContext);
                         Map<String, Object> outputMap = MapUtils.merge(workerTaskResult.getTaskRun().getOutputs(), outputs == null ? null : outputs.toMap());
-                        Variables variables = variablesService.of(StorageContext.forTask(workerTaskResult.getTaskRun()), outputMap);
-                        // flowable attempt state transition to terminated
-                        List<TaskRunAttempt> attempts = Optional.ofNullable(parentTaskRun.getAttempts())
-                            .map(ArrayList::new)
-                            .orElseGet(ArrayList::new);
-                        State.Type endedState = endedTask.get().getTaskRun().getState().getCurrent();
-                        TaskRunAttempt updated = attempts.getLast().withState(endedState);
-                        attempts.set( attempts.size() - 1, updated);
-                        return Optional.of(new WorkerTaskResult(workerTaskResult
-                            .getTaskRun()
-                            .withOutputs(variables)
-                            .withAttempts(attempts)
-                        ));
+                        variables = variablesService.of(StorageContext.forTask(workerTaskResult.getTaskRun()), outputMap);
                     } catch (Exception e) {
                         runContext.logger().error("Unable to resolve outputs from the Flowable task: {}", e.getMessage(), e);
+                        variables = Variables.empty();
                     }
+
+                    // flowable attempt state transition to terminated
+                    List<TaskRunAttempt> attempts = Optional.ofNullable(parentTaskRun.getAttempts())
+                        .map(ArrayList::new)
+                        .orElseGet(ArrayList::new);
+                    State.Type endedState = endedTask.get().getTaskRun().getState().getCurrent();
+                    TaskRunAttempt updated = attempts.getLast().withState(endedState);
+                    attempts.set( attempts.size() - 1, updated);
+
+                    return Optional.of(new WorkerTaskResult(workerTaskResult
+                        .getTaskRun()
+                        .withOutputs(variables)
+                        .withAttempts(attempts)
+                    ));
                 }
                 return endedTask;
             }


### PR DESCRIPTION
When a flowable fail, it should also switch its attempts to FAILED.

Fixes #12614