### PR TITLE
refactor: unify management of anonymous routes

### DIFF
--- a/ui/src/App.vue
+++ b/ui/src/App.vue
@@ -5,7 +5,7 @@
         <component :is="route.meta.layout ?? DefaultLayout" v-if="loaded && shouldRenderApp">
             <router-view />
         </component>
-        <VueTour v-if="shouldRenderApp && route?.name && !isAnonymousRoute" />
+        <VueTour v-if="shouldRenderApp && route?.name && !route.meta?.anonymous" />
         <UnsavedChangesDialog />
     </el-config-provider>
 </template>
@@ -41,10 +41,6 @@
     const route = useRoute();
 
     const envName = computed(() => layoutStore.envName || miscStore.configs?.environment?.name);
-
-    const isLoginRoute = computed(() => route?.name?.toString().startsWith("login"));
-    const isSetupRoute = computed(() => route?.name === "setup");
-    const isAnonymousRoute = computed(() => isLoginRoute.value || isSetupRoute.value);
 
     const shouldRenderApp = computed(() => loaded.value);
 
@@ -91,7 +87,7 @@
     onMounted(async () => {
         setTitleEnvSuffix();
 
-        if (!isAnonymousRoute.value && BasicAuth.isLoggedIn()) {
+        if (!route?.meta?.anonymous && BasicAuth.isLoggedIn()) {
             try {
                 await loadGeneralResources();
             } catch (error) {

--- a/ui/src/composables/useTenant.ts
+++ b/ui/src/composables/useTenant.ts
@@ -25,7 +25,7 @@ export function setupTenantRouter(router: Router, app: App): void {
 
     router.beforeEach((to, from, next) => {
         // on login, prevent redirection to tenant
-        if (typeof to.name === "string" && ["login", "setup"].includes(to.name)) {
+        if (to.meta?.anonymous === true) {
             return next();
         }
         if (to.path !== "/" && !to.params.tenant) {

--- a/ui/src/main.js
+++ b/ui/src/main.js
@@ -25,7 +25,7 @@ const handleAuthError = (error, to) => {
 
 initApp(app, routes, null, en).then(({router, piniaStore}) => {
     router.beforeEach(async (to, from, next) => {
-        if (["login", "setup"].includes(to.name)) {
+        if (to.meta?.anonymous === true) {
             return next();
         }
 

--- a/ui/src/routes/routes.js
+++ b/ui/src/routes/routes.js
@@ -11,7 +11,7 @@ import {applyDefaultFilters} from "../components/filter/composables/useDefaultFi
 
 export default [
     //Initial
-    {name: "root", path: "/", redirect: {name: "home"}, meta: {layout: {template: "<div />"}}},
+    {name: "root", path: "/", redirect: {name: "home"}, meta: {layout: {template: "<div />"}, anonymous: true}},
     {name: "welcome", path: "/:tenant?/welcome", component: () => import("../components/onboarding/Welcome.vue")},
 
     //Dashboards
@@ -114,9 +114,9 @@ export default [
     {name: "admin/concurrency-limits", path: "/:tenant?/admin/concurrency-limits", component: () => import("../components/admin/ConcurrencyLimits.vue")},
 
     //Setup
-    {name: "setup", path: "/:tenant?/setup", component: () => import("../components/basicauth/BasicAuthSetup.vue"), meta: {layout: FullScreenLayout}},
+    {name: "setup", path: "/:tenant?/setup", component: () => import("../components/basicauth/BasicAuthSetup.vue"), meta: {layout: FullScreenLayout, anonymous: true}},
     //Login
-    {name: "login", path: "/:tenant?/login", component: () => import("../components/basicauth/BasicAuthLogin.vue"), meta: {layout: FullScreenLayout}},
+    {name: "login", path: "/:tenant?/login", component: () => import("../components/basicauth/BasicAuthLogin.vue"), meta: {layout: FullScreenLayout, anonymous: true}},
 
     //Errors
     {name: "errors/404-wildcard", path: "/:tenant?/:pathMatch(.*)", component: Errors, props: {code: 404}},


### PR DESCRIPTION
Set all routes that should be anonymous as anonymous in the routes.js file instead of in multiple places.

This will avoid mistakes like redirect loops at setup