### PR TITLE
fix(executions): don't ends flowable if any subtasks should be retried

### DIFF
--- a/core/src/main/java/io/kestra/core/models/executions/Execution.java
+++ b/core/src/main/java/io/kestra/core/models/executions/Execution.java
@@ -658,18 +658,20 @@ public class Execution implements DeletedInterface, TenantInterface {
     public boolean hasFailedNoRetry(List<ResolvedTask> resolvedTasks, TaskRun parentTaskRun) {
         return this.findTaskRunByTasks(resolvedTasks, parentTaskRun)
             .stream()
-            .anyMatch(taskRun -> {
-                ResolvedTask resolvedTask = resolvedTasks.stream()
-                    .filter(t -> t.getTask().getId().equals(taskRun.getTaskId())).findFirst()
-                    .orElse(null);
-                if (resolvedTask == null) {
-                    log.warn("Can't find task for taskRun '{}' in parentTaskRun '{}'",
-                        taskRun.getId(), parentTaskRun.getId());
-                    return false;
-                }
-                return !taskRun.shouldBeRetried(resolvedTask.getTask().getRetry())
-                    && taskRun.getState().isFailed();
-            });
+            // NOTE: we check on isFailed first to avoid the costly shouldBeRetried() method
+            .anyMatch(taskRun -> taskRun.getState().isFailed() && shouldNotBeRetried(resolvedTasks, parentTaskRun, taskRun));
+    }
+
+    private static boolean shouldNotBeRetried(List<ResolvedTask> resolvedTasks, TaskRun parentTaskRun, TaskRun taskRun) {
+        ResolvedTask resolvedTask = resolvedTasks.stream()
+            .filter(t -> t.getTask().getId().equals(taskRun.getTaskId())).findFirst()
+            .orElse(null);
+        if (resolvedTask == null) {
+            log.warn("Can't find task for taskRun '{}' in parentTaskRun '{}'",
+                taskRun.getId(), parentTaskRun.getId());
+            return false;
+        }
+        return !taskRun.shouldBeRetried(resolvedTask.getTask().getRetry());
     }
 
     public boolean hasCreated() {

--- a/core/src/main/java/io/kestra/core/runners/FlowableUtils.java
+++ b/core/src/main/java/io/kestra/core/runners/FlowableUtils.java
@@ -218,7 +218,7 @@ public class FlowableUtils {
             }
         } else {
             // first call, the error flow is not ready, we need to notify the parent task that can be failed to init error flows
-            if (execution.hasFailed(tasks, parentTaskRun) || terminalState == State.Type.FAILED) {
+            if (execution.hasFailedNoRetry(tasks, parentTaskRun) || terminalState == State.Type.FAILED) {
                 return Optional.of(execution.guessFinalState(tasks, parentTaskRun, allowFailure, allowWarning, terminalState));
             }
         }

--- a/core/src/test/java/io/kestra/plugin/core/flow/SubflowRunnerTest.java
+++ b/core/src/test/java/io/kestra/plugin/core/flow/SubflowRunnerTest.java
@@ -14,6 +14,8 @@ import jakarta.inject.Inject;
 import jakarta.inject.Named;
 import org.junit.jupiter.api.Test;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
@@ -85,6 +87,30 @@ class SubflowRunnerTest {
         assertThat(childExecution.get().getId()).isEqualTo(childExecutionId);
         assertThat(childExecution.get().getState().getCurrent()).isEqualTo(State.Type.SUCCESS);
         assertThat(childExecution.get().getTaskRunList()).hasSize(1);
+        closing.run();
+    }
+
+    @Test
+    @LoadFlows({"flows/valids/subflow-parent-retry.yaml", "flows/valids/subflow-to-retry.yaml"})
+    void subflowOutputWithWait() throws QueueException, TimeoutException, InterruptedException {
+        List<Execution> childExecution = new ArrayList<>();
+        CountDownLatch countDownLatch = new CountDownLatch(4);
+        Runnable closing = executionQueue.receive(either -> {
+            if (either.isLeft() && either.getLeft().getFlowId().equals("subflow-to-retry") && either.getLeft().getState().isTerminated()) {
+                childExecution.add(either.getLeft());
+                countDownLatch.countDown();
+            }
+        });
+
+        Execution parentExecution = runnerUtils.runOne(MAIN_TENANT, "io.kestra.tests", "subflow-parent-retry");
+        assertThat(parentExecution.getState().getCurrent()).isEqualTo(State.Type.SUCCESS);
+        assertThat(parentExecution.getTaskRunList()).hasSize(5);
+
+        assertTrue(countDownLatch.await(10, TimeUnit.SECONDS));
+        // we should have 4 executions, two in SUCCESS and two in FAILED
+        assertThat(childExecution).hasSize(4);
+        assertThat(childExecution.stream().filter(e -> e.getState().getCurrent() == State.Type.SUCCESS).count()).isEqualTo(2);
+        assertThat(childExecution.stream().filter(e -> e.getState().getCurrent() == State.Type.FAILED).count()).isEqualTo(2);
         closing.run();
     }
 }

--- a/core/src/test/resources/flows/valids/subflow-parent-retry.yaml
+++ b/core/src/test/resources/flows/valids/subflow-parent-retry.yaml
@@ -1,0 +1,33 @@
+id: subflow-parent-retry
+namespace: io.kestra.tests
+
+tasks:
+  - id: parallel
+    type: io.kestra.plugin.core.flow.Parallel
+    tasks:
+      - id: seq1
+        type: io.kestra.plugin.core.flow.Sequential
+        tasks:
+        - id: subflow1
+          type: io.kestra.plugin.core.flow.Subflow
+          flowId: subflow-to-retry
+          namespace: io.kestra.tests
+          inputs:
+            counter: "{{ taskrun.attemptsCount }}"
+          retry:
+            type: constant
+            maxAttempts: 3
+            interval: PT1S
+      - id: seq2
+        type: io.kestra.plugin.core.flow.Sequential
+        tasks:
+        - id: subflow2
+          type: io.kestra.plugin.core.flow.Subflow
+          flowId: subflow-to-retry
+          namespace: io.kestra.tests
+          inputs:
+            counter: "{{ taskrun.attemptsCount }}"
+          retry:
+            type: constant
+            maxAttempts: 3
+            interval: PT1S

--- a/core/src/test/resources/flows/valids/subflow-to-retry.yaml
+++ b/core/src/test/resources/flows/valids/subflow-to-retry.yaml
@@ -1,0 +1,14 @@
+id: subflow-to-retry
+namespace: io.kestra.tests
+
+inputs:
+  - id: counter
+    type: INT
+
+tasks:
+  - id: fail
+    type: io.kestra.plugin.core.execution.Fail
+    runIf: "{{inputs.counter < 1}}"
+  - id: hello
+    type: io.kestra.plugin.core.log.Log
+    message: Hello World! 🚀


### PR DESCRIPTION
Fixes #11444

Flowables in flowables was finished in FAILED when a subflow task with configured retry was FAILING which should not have been the case.
We now correctly wait for the retry to happen
