### PR TITLE
cleanup: simplified CustomColumns by using () for translation

### DIFF
--- a/ui/src/components/filter/segments/CustomColumns.vue
+++ b/ui/src/components/filter/segments/CustomColumns.vue
@@ -2,8 +2,8 @@
     <div class="customize-columns-panel">
         <div class="header">
             <div class="title">
-                <h6>{{ t("filter.customize columns") }}</h6>
-                <small>{{ t("filter.drag to reorder columns") }}</small>
+                <h6>{{ $t("filter.customize columns") }}</h6>
+                <small>{{ $t("filter.drag to reorder columns") }}</small>
             </div>
             <el-button link :icon="Close" @click="$emit('close')" size="small" class="close-icon" />
         </div>
@@ -25,12 +25,10 @@
 
 <script setup lang="ts">
     import {computed, ref} from "vue";
-    import {useI18n} from "vue-i18n";
     import {Close} from "../utils/icons";
     import type {ColumnConfig} from "../../../composables/useTableColumns";
     import DraggableTableColumns from "../../layout/DraggableTableColumns.vue";
 
-    const {t} = useI18n();
     
     const props = defineProps<{
         storageKey: string;

--- a/ui/src/components/filter/segments/CustomColumns.vue
+++ b/ui/src/components/filter/segments/CustomColumns.vue
@@ -29,7 +29,6 @@
     import type {ColumnConfig} from "../../../composables/useTableColumns";
     import DraggableTableColumns from "../../layout/DraggableTableColumns.vue";
 
-    
     const props = defineProps<{
         storageKey: string;
         columns: ColumnConfig[];


### PR DESCRIPTION


### ✨ Description

Fixes #13204 
This issue covers applying that cleanup to the `kestra/ui/src/components/filter/segments/CustomColumns.vue` file.


### 🎨 Frontend Checklist

_If this PR does not include any frontend changes, delete this entire section._

- [ ] Code builds without errors (`npm run build`)
- [ ] All existing E2E tests pass (`npm run test:e2e`)
- [ ] Screenshots or video recordings attached showing the `UI` changes


