### PR TITLE
fix(core): concurrency limit on JDBC was decrementing when using FAIL…

### DIFF
--- a/core/src/main/java/io/kestra/core/models/flows/Concurrency.java
+++ b/core/src/main/java/io/kestra/core/models/flows/Concurrency.java
@@ -24,4 +24,8 @@ public class Concurrency {
     public enum Behavior {
         QUEUE, CANCEL, FAIL;
     }
+
+    public static boolean maybeConcurrencyLimited(State.Type type) {
+        return type.equals(State.Type.CANCELLED) || type.equals(State.Type.FAILED);
+    }
 }

--- a/core/src/main/java/io/kestra/core/models/flows/Concurrency.java
+++ b/core/src/main/java/io/kestra/core/models/flows/Concurrency.java
@@ -25,7 +25,7 @@ public class Concurrency {
         QUEUE, CANCEL, FAIL;
     }
 
-    public static boolean maybeConcurrencyLimited(State.Type type) {
+    public static boolean possibleTransitions(State.Type type) {
         return type.equals(State.Type.CANCELLED) || type.equals(State.Type.FAILED);
     }
 }

--- a/core/src/test/java/io/kestra/core/runners/FlowConcurrencyCaseTest.java
+++ b/core/src/test/java/io/kestra/core/runners/FlowConcurrencyCaseTest.java
@@ -25,7 +25,9 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.file.Files;
 import java.time.Duration;
-import java.util.*;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.TimeoutException;
 import java.util.stream.IntStream;
 
@@ -57,28 +59,32 @@ public class FlowConcurrencyCaseTest {
 
     public void flowConcurrencyCancel() throws TimeoutException, QueueException {
         Execution execution1 = runnerUtils.runOneUntilRunning(MAIN_TENANT, NAMESPACE, "flow-concurrency-cancel", null, null, Duration.ofSeconds(30));
-        List<Execution> shouldFailExecutions = List.of(
-            runnerUtils.runOne(MAIN_TENANT, NAMESPACE, "flow-concurrency-cancel"),
-            runnerUtils.runOne(MAIN_TENANT, NAMESPACE, "flow-concurrency-cancel")
-        );
-        assertThat(execution1.getState().isRunning()).isTrue();
+        try {
+            List<Execution> shouldFailExecutions = List.of(
+                runnerUtils.runOne(MAIN_TENANT, NAMESPACE, "flow-concurrency-cancel"),
+                runnerUtils.runOne(MAIN_TENANT, NAMESPACE, "flow-concurrency-cancel")
+            );
+            assertThat(execution1.getState().isRunning()).isTrue();
 
-        assertThat(shouldFailExecutions.stream().map(Execution::getState).map(State::getCurrent)).allMatch(Type.CANCELLED::equals);
-
-        runnerUtils.awaitExecution(e -> e.getState().getCurrent().equals(Type.SUCCESS), execution1);
+            assertThat(shouldFailExecutions.stream().map(Execution::getState).map(State::getCurrent)).allMatch(Type.CANCELLED::equals);
+        } finally {
+            runnerUtils.killExecution(execution1);
+        }
     }
 
     public void flowConcurrencyFail() throws TimeoutException, QueueException {
         Execution execution1 = runnerUtils.runOneUntilRunning(MAIN_TENANT, NAMESPACE, "flow-concurrency-fail", null, null, Duration.ofSeconds(30));
-        List<Execution> shouldFailExecutions = List.of(
-            runnerUtils.runOne(MAIN_TENANT, NAMESPACE, "flow-concurrency-fail"),
-            runnerUtils.runOne(MAIN_TENANT, NAMESPACE, "flow-concurrency-fail")
-        );
+        try {
+            List<Execution> shouldFailExecutions = List.of(
+                runnerUtils.runOne(MAIN_TENANT, NAMESPACE, "flow-concurrency-fail"),
+                runnerUtils.runOne(MAIN_TENANT, NAMESPACE, "flow-concurrency-fail")
+            );
 
-        assertThat(execution1.getState().isRunning()).isTrue();
-        assertThat(shouldFailExecutions.stream().map(Execution::getState).map(State::getCurrent)).allMatch(State.Type.FAILED::equals);
-
-        runnerUtils.awaitExecution(e -> e.getState().getCurrent().equals(Type.SUCCESS), execution1);
+            assertThat(execution1.getState().isRunning()).isTrue();
+            assertThat(shouldFailExecutions.stream().map(Execution::getState).map(State::getCurrent)).allMatch(State.Type.FAILED::equals);
+        } finally {
+            runnerUtils.killExecution(execution1);
+        }
     }
 
     public void flowConcurrencyQueue() throws QueueException {
@@ -141,11 +147,11 @@ public class FlowConcurrencyCaseTest {
         URI file = storageUpload(tenantId);
         Map<String, Object> inputs = Map.of("file", file.toString(), "batch", 4);
         Execution forEachItem = runnerUtils.runOneUntilRunning(tenantId, NAMESPACE, "flow-concurrency-for-each-item", null,
-        (flow, execution1) -> flowIO.readExecutionInputs(flow, execution1, inputs), Duration.ofSeconds(5));
+            (flow, execution1) -> flowIO.readExecutionInputs(flow, execution1, inputs), Duration.ofSeconds(5));
         assertThat(forEachItem.getState().getCurrent()).isEqualTo(Type.RUNNING);
 
 
-        Execution terminated = runnerUtils.awaitExecution(e -> e.getState().isTerminated(),forEachItem);
+        Execution terminated = runnerUtils.awaitExecution(e -> e.getState().isTerminated(), forEachItem);
         assertThat(terminated.getState().getCurrent()).isEqualTo(Type.SUCCESS);
 
         List<Execution> executions = runnerUtils.awaitFlowExecutionNumber(2, tenantId, NAMESPACE, "flow-concurrency-queue");

--- a/core/src/test/java/io/kestra/core/runners/FlowConcurrencyCaseTest.java
+++ b/core/src/test/java/io/kestra/core/runners/FlowConcurrencyCaseTest.java
@@ -57,20 +57,26 @@ public class FlowConcurrencyCaseTest {
 
     public void flowConcurrencyCancel() throws TimeoutException, QueueException {
         Execution execution1 = runnerUtils.runOneUntilRunning(MAIN_TENANT, NAMESPACE, "flow-concurrency-cancel", null, null, Duration.ofSeconds(30));
-        Execution execution2 = runnerUtils.runOne(MAIN_TENANT, NAMESPACE, "flow-concurrency-cancel");
-
+        List<Execution> shouldFailExecutions = List.of(
+            runnerUtils.runOne(MAIN_TENANT, NAMESPACE, "flow-concurrency-cancel"),
+            runnerUtils.runOne(MAIN_TENANT, NAMESPACE, "flow-concurrency-cancel")
+        );
         assertThat(execution1.getState().isRunning()).isTrue();
-        assertThat(execution2.getState().getCurrent()).isEqualTo(State.Type.CANCELLED);
+
+        assertThat(shouldFailExecutions.stream().map(Execution::getState).map(State::getCurrent)).allMatch(Type.CANCELLED::equals);
 
         runnerUtils.awaitExecution(e -> e.getState().getCurrent().equals(Type.SUCCESS), execution1);
     }
 
     public void flowConcurrencyFail() throws TimeoutException, QueueException {
         Execution execution1 = runnerUtils.runOneUntilRunning(MAIN_TENANT, NAMESPACE, "flow-concurrency-fail", null, null, Duration.ofSeconds(30));
-        Execution execution2 = runnerUtils.runOne(MAIN_TENANT, NAMESPACE, "flow-concurrency-fail");
+        List<Execution> shouldFailExecutions = List.of(
+            runnerUtils.runOne(MAIN_TENANT, NAMESPACE, "flow-concurrency-fail"),
+            runnerUtils.runOne(MAIN_TENANT, NAMESPACE, "flow-concurrency-fail")
+        );
 
         assertThat(execution1.getState().isRunning()).isTrue();
-        assertThat(execution2.getState().getCurrent()).isEqualTo(State.Type.FAILED);
+        assertThat(shouldFailExecutions.stream().map(Execution::getState).map(State::getCurrent)).allMatch(State.Type.FAILED::equals);
 
         runnerUtils.awaitExecution(e -> e.getState().getCurrent().equals(Type.SUCCESS), execution1);
     }

--- a/core/src/test/resources/flows/valids/flow-concurrency-cancel.yml
+++ b/core/src/test/resources/flows/valids/flow-concurrency-cancel.yml
@@ -8,4 +8,4 @@ concurrency:
 tasks:
   - id: sleep
     type: io.kestra.plugin.core.flow.Sleep
-    duration: PT2S
+    duration: PT5S

--- a/core/src/test/resources/flows/valids/flow-concurrency-cancel.yml
+++ b/core/src/test/resources/flows/valids/flow-concurrency-cancel.yml
@@ -8,4 +8,4 @@ concurrency:
 tasks:
   - id: sleep
     type: io.kestra.plugin.core.flow.Sleep
-    duration: PT5S
+    duration: PT10S

--- a/core/src/test/resources/flows/valids/flow-concurrency-fail.yml
+++ b/core/src/test/resources/flows/valids/flow-concurrency-fail.yml
@@ -8,4 +8,4 @@ concurrency:
 tasks:
   - id: sleep
     type: io.kestra.plugin.core.flow.Sleep
-    duration: PT2S
+    duration: PT5S

--- a/core/src/test/resources/flows/valids/flow-concurrency-fail.yml
+++ b/core/src/test/resources/flows/valids/flow-concurrency-fail.yml
@@ -8,4 +8,4 @@ concurrency:
 tasks:
   - id: sleep
     type: io.kestra.plugin.core.flow.Sleep
-    duration: PT5S
+    duration: PT10S

--- a/executor/src/main/java/io/kestra/executor/ExecutorService.java
+++ b/executor/src/main/java/io/kestra/executor/ExecutorService.java
@@ -125,7 +125,7 @@ public class ExecutorService {
                 case CANCEL ->
                     executionRunning
                         .withExecution(executionRunning.getExecution().withState(State.Type.CANCELLED))
-                        .withConcurrencyState(ExecutionRunning.ConcurrencyState.RUNNING);
+                        .withConcurrencyState(ExecutionRunning.ConcurrencyState.CANCELLED);
                 case FAIL -> {
                     var failedExecution = executionRunning.getExecution().failedExecutionFromExecutor(new IllegalStateException("Execution is FAILED due to concurrency limit exceeded"));
                     try {
@@ -135,7 +135,7 @@ public class ExecutorService {
                     }
                     yield executionRunning
                         .withExecution(failedExecution.getExecution())
-                        .withConcurrencyState(ExecutionRunning.ConcurrencyState.RUNNING);
+                        .withConcurrencyState(ExecutionRunning.ConcurrencyState.FAILED);
                 }
 
             };

--- a/jdbc/src/main/java/io/kestra/jdbc/runner/JdbcExecutor.java
+++ b/jdbc/src/main/java/io/kestra/jdbc/runner/JdbcExecutor.java
@@ -1171,7 +1171,7 @@ public class JdbcExecutor implements ExecutorInterface {
                     boolean queuedThenKilled = execution.getState().getCurrent() == State.Type.KILLED
                         && execution.getState().getHistories().stream().anyMatch(h -> h.getState().isQueued())
                         && execution.getState().getHistories().stream().noneMatch(h -> h.getState().isRunning());
-                    boolean concurrencyShortCircuitState = Concurrency.maybeConcurrencyLimited(execution.getState().getCurrent())
+                    boolean concurrencyShortCircuitState = Concurrency.possibleTransitions(execution.getState().getCurrent())
                         && execution.getState().getHistories().get(execution.getState().getHistories().size() - 2).getState().isCreated();
                     if (!queuedThenKilled && !concurrencyShortCircuitState) {
                         concurrencyLimitStorage.decrement(executor.getFlow());

--- a/jdbc/src/main/java/io/kestra/jdbc/runner/JdbcExecutor.java
+++ b/jdbc/src/main/java/io/kestra/jdbc/runner/JdbcExecutor.java
@@ -1171,7 +1171,9 @@ public class JdbcExecutor implements ExecutorInterface {
                     boolean queuedThenKilled = execution.getState().getCurrent() == State.Type.KILLED
                         && execution.getState().getHistories().stream().anyMatch(h -> h.getState().isQueued())
                         && execution.getState().getHistories().stream().noneMatch(h -> h.getState().isRunning());
-                    if (!queuedThenKilled) {
+                    boolean concurrencyShortCircuitState = Concurrency.maybeConcurrencyLimited(execution.getState().getCurrent())
+                        && execution.getState().getHistories().get(execution.getState().getHistories().size() - 2).getState().isCreated();
+                    if (!queuedThenKilled && !concurrencyShortCircuitState) {
                         concurrencyLimitStorage.decrement(executor.getFlow());
 
                         if (executor.getFlow().getConcurrency().getBehavior() == Concurrency.Behavior.QUEUE) {

--- a/tests/src/main/java/io/kestra/core/runners/TestRunnerUtils.java
+++ b/tests/src/main/java/io/kestra/core/runners/TestRunnerUtils.java
@@ -3,6 +3,8 @@ package io.kestra.core.runners;
 import com.google.common.annotations.VisibleForTesting;
 import io.kestra.core.models.Label;
 import io.kestra.core.models.executions.Execution;
+import io.kestra.core.models.executions.ExecutionKilled;
+import io.kestra.core.models.executions.ExecutionKilledExecution;
 import io.kestra.core.models.flows.Flow;
 import io.kestra.core.models.flows.FlowInterface;
 import io.kestra.core.models.flows.State;
@@ -37,6 +39,10 @@ public class TestRunnerUtils {
     @Inject
     @Named(QueueFactoryInterface.EXECUTION_NAMED)
     protected QueueInterface<Execution> executionQueue;
+
+    @Inject
+    @Named(QueueFactoryInterface.KILL_NAMED)
+    protected QueueInterface<ExecutionKilled> killQueue;
 
     @Inject
     private FlowRepositoryInterface flowRepository;
@@ -299,6 +305,22 @@ public class TestRunnerUtils {
         }
 
         return receive.get();
+    }
+
+    public Execution killExecution(Execution execution) throws QueueException {
+        killQueue.emit(ExecutionKilledExecution.builder()
+            .executionId(execution.getId())
+            .isOnKillCascade(true)
+            .state(ExecutionKilled.State.REQUESTED)
+            .tenantId(execution.getTenantId())
+            .build());
+
+        return awaitExecution(isTerminatedExecution(
+            execution,
+            flowRepository
+                .findById(execution.getTenantId(), execution.getNamespace(), execution.getFlowId(), Optional.ofNullable(execution.getFlowRevision()))
+                .orElse(null)
+        ), execution);
     }
 
     @VisibleForTesting


### PR DESCRIPTION
… or CANCEL behavior

closes https://github.com/kestra-io/kestra/issues/13141
