### PR TITLE
refactor: remove unnecessary useI18n import from Sections.vue

### DIFF
--- a/ui/src/components/dashboard/sections/Sections.vue
+++ b/ui/src/components/dashboard/sections/Sections.vue
@@ -27,7 +27,7 @@
                         <div id="charts_buttons">
                             <KestraIcon
                                 v-if="isTableChart(chart.type)"
-                                :tooltip="t('dashboards.export')"
+                                :tooltip="$t('dashboards.export')"
                             >
                                 <el-button
                                     @click="dashboardStore.export(dashboard, chart, {filters})"
@@ -39,7 +39,7 @@
 
                             <KestraIcon
                                 v-if="props.dashboard?.id !== 'default'"
-                                :tooltip="t('dashboards.edition.chart')"
+                                :tooltip="$t('dashboards.edition.chart')"
                             >
                                 <el-button
                                     tag="router-link"
@@ -81,9 +81,6 @@
 
     import {useDashboardStore} from "../../../stores/dashboard";
     const dashboardStore = useDashboardStore();
-
-    import {useI18n} from "vue-i18n";
-    const {t} = useI18n({useScope: "global"});
 
     import KestraIcon from "../../Kicon.vue";
 


### PR DESCRIPTION
### ✨ Description

Removes unnecessary `useI18n` composable import and usage from Sections.vue. Since `createI18n` in i18n.ts automatically exposes the global `$t` helper to all templates, there's no need to explicitly import and use `useI18n` when translations are only performed in the `<template>` section.

Changes:
- Removed `import {useI18n} from "vue-i18n";`
- Removed `const {t} = useI18n({useScope: "global"});`
- Replaced `t('dashboards.export')` with `$t('dashboards.export')`
- Replaced `t('dashboards.edition.chart')` with `$t('dashboards.edition.chart')`

### 🔗 Related Issue

Closes https://github.com/kestra-io/kestra/issues/13172

### 🎨 Frontend Checklist

- [x] Code builds without errors (`npm run build`)
- [x] All existing E2E tests pass (`npm run test:e2e`)
- [ ] Screenshots or video recordings attached showing the `UI` changes

### 📝 Additional Notes

This is a code cleanup PR as part of the effort to standardize i18n usage across the codebase. The `$t` global helper is preferred over `useI18n` when translations are only needed in templates.