### PR TITLE
feat(system): deprecate RunContext method that must not be used anymore

### DIFF
--- a/core/src/main/java/io/kestra/core/runners/DefaultRunContext.java
+++ b/core/src/main/java/io/kestra/core/runners/DefaultRunContext.java
@@ -123,7 +123,12 @@ public class DefaultRunContext extends RunContext {
         this.traceParent = traceParent;
     }
 
+    /**
+     * @deprecated Plugin should not use the ApplicationContext anymore, and neither should they cast to this implementation.
+     *             Plugin should instead rely on supported API only.
+     */
     @JsonIgnore
+    @Deprecated(since = "1.2.0", forRemoval = true)
     public ApplicationContext getApplicationContext() {
         return applicationContext;
     }

--- a/core/src/main/java/io/kestra/core/runners/RunContext.java
+++ b/core/src/main/java/io/kestra/core/runners/RunContext.java
@@ -192,5 +192,9 @@ public abstract class RunContext implements PropertyContext {
     public record FlowInfo(String tenantId, String namespace, String id, Integer revision) {
     }
 
+    /**
+     * @deprecated there is no legitimate use case of this method outside the run context internal self-usage, so it should not be part of the interface
+     */
+    @Deprecated(since = "1.2.0", forRemoval = true)
     public abstract boolean isInitialized();
 }


### PR DESCRIPTION
- `isInitialized()` is not used by plugin so should not be part of the interface
- `getApplicationContext` should not be used anymore, all tasks that uses it would be refactored to avoid its usage

Part-of: https://github.com/kestra-io/kestra-ee/issues/4228
