### PR TITLE
fix(core): prevent log lines from breaking too early in firefox

### DIFF
--- a/ui/src/components/logs/LogLine.vue
+++ b/ui/src/components/logs/LogLine.vue
@@ -205,8 +205,6 @@ div.line {
     .log-content {
         display: inline-block;
         vertical-align: middle;
-        /* prevent Firefox word breaks */
-        max-width: calc(100% - 6rem);
         overflow-wrap: anywhere;
         word-break: break-word;
         min-width: 0;


### PR DESCRIPTION
Closes https://github.com/kestra-io/kestra/issues/12736.

Related to https://github.com/kestra-io/kestra/pull/13130.