### PR TITLE
refactor(ui): replace useI18n with global  in ContextDocsMenu

### DIFF
--- a/ui/src/components/docs/ContextDocsMenu.vue
+++ b/ui/src/components/docs/ContextDocsMenu.vue
@@ -1,7 +1,7 @@
 <template>
     <div class="docsMenuWrapper">
         <el-button @click="menuOpen = !menuOpen" class="menuOpener">
-            {{ t("documentationMenu") }} <MenuDown class="expandIcon" />
+            {{ $t("documentationMenu") }} <MenuDown class="expandIcon" />
         </el-button>
         <ul v-if="menuOpen" class="docsMenu list-unstyled d-flex flex-column gap-3">
             <template v-if="rawStructure">
@@ -33,9 +33,6 @@
 <script setup lang="ts">
     import {ref, computed, watch} from "vue";
     import {useDocStore} from "../../stores/doc";
-    import {useI18n} from "vue-i18n";
-
-    const {t} = useI18n({useScope: "global"});
 
     import MenuDown from "vue-material-design-icons/MenuDown.vue";
 


### PR DESCRIPTION
### ✨ Description

Refactored ContextDocsMenu.vue to remove the explicit useI18n import and usage inside the <script> section. Since translations are only performed within the <template>, I replaced t() with the global $t() helper as per the issue requirements. 


### 🔗 Related Issue

Closes https://github.com/kestra-io/kestra/issues/13200

### 🎨 Frontend Checklist

_If this PR does not include any frontend changes, delete this entire section._

- [O] Code builds without errors (`npm run build`)
- [O] All existing E2E tests pass (`npm run test:e2e`)
- [O] Screenshots or video recordings attached showing the `UI` changes

### 📝 Additional Notes
I am in Windows and cannot run '.sh' scripts locally. I will rely on Github Actions to verify E2E tests.
This is a pure code refactor. No visual changes.