### PR TITLE
feat(filters): add default visible filters for state and level

### DIFF
--- a/ui/src/components/admin/Triggers.vue
+++ b/ui/src/components/admin/Triggers.vue
@@ -2,7 +2,7 @@
     <TopNavBar :title="routeInfo.title">
         <template #additional-right>
             <el-button :icon="Download" @click="exportTriggersAsStream()">
-                {{ t('auditlog.export_csv') }}
+                {{ t('export_csv') }}
             </el-button>
         </template>
     </TopNavBar>

--- a/ui/src/components/executions/Executions.vue
+++ b/ui/src/components/executions/Executions.vue
@@ -5,7 +5,7 @@
                 <template v-if="$route.name === 'executions/list'">
                     <li>
                         <el-button :icon="Download" @click="exportExecutionsAsStream()">
-                            {{ t('auditlog.export_csv') }}
+                            {{ t('export_csv') }}
                         </el-button>
                     </li>
                     <li>

--- a/ui/src/components/filter/composables/useFilters.ts
+++ b/ui/src/components/filter/composables/useFilters.ts
@@ -335,7 +335,29 @@ export function useFilters(
             markAsPreApplied(parsedFilters);
         }
 
-        appliedFilters.value = parsedFilters;
+        /**
+         * Initialize default visible filters. These filters are marked with visibleByDefault: true
+         * and are automatically added to the filter list when the page loads, even if no value
+         * are present to filter. Users can remove them, but they will reappear on page refresh.
+         */
+        const parsedFilterKeys = new Set(parsedFilters.map(f => f.key));
+        const defaultVisibleFilters = configuration.keys
+            ?.filter(key => key.visibleByDefault && !parsedFilterKeys.has(key.key))
+            .map(key => {
+                const comparator = (key.comparators?.[0] as Comparators) ?? Comparators.EQUALS;
+                return {
+                    id: `${key.key}-default-${Date.now()}`,
+                    key: key.key,
+                    keyLabel: key.label,
+                    comparator,
+                    comparatorLabel: COMPARATOR_LABELS[comparator],
+                    value: key.valueType === "multi-select" ? [] : "",
+                    valueLabel: "",
+                    isDefaultVisible: true
+                } as AppliedFilter;
+            }) ?? [];
+
+        appliedFilters.value = [...parsedFilters, ...defaultVisibleFilters];
     };
 
     watch(() => route.query, initializeFromRoute, {deep: true, immediate: false});

--- a/ui/src/components/filter/configurations/executionFilter.ts
+++ b/ui/src/components/filter/configurations/executionFilter.ts
@@ -85,7 +85,8 @@ export const useExecutionFilter = (): ComputedRef<FilterConfiguration> => {
                         return VALUES.EXECUTION_STATES;
                     },
                     showComparatorSelection: true,
-                    searchable: true
+                    searchable: true,
+                    visibleByDefault: true
                 },
                 {
                     key: "scope",

--- a/ui/src/components/filter/configurations/flowExecutionFilter.ts
+++ b/ui/src/components/filter/configurations/flowExecutionFilter.ts
@@ -20,7 +20,8 @@ export const useFlowExecutionFilter = (): ComputedRef<FilterConfiguration> => {
                     valueProvider: async () => {
                         const {VALUES} = useValues("executions");
                         return VALUES.EXECUTION_STATES;
-                    }
+                    },
+                    visibleByDefault: true
                 },
                 {
                     key: "scope",

--- a/ui/src/components/filter/configurations/logExecutionsFilter.ts
+++ b/ui/src/components/filter/configurations/logExecutionsFilter.ts
@@ -21,6 +21,7 @@ export const useLogExecutionsFilter = (): ComputedRef<FilterConfiguration> => {
                         const {VALUES} = useValues("logs");
                         return VALUES.LEVELS;
                     },
+                    visibleByDefault: true
                 }
             ]
         };

--- a/ui/src/components/filter/configurations/logFilter.ts
+++ b/ui/src/components/filter/configurations/logFilter.ts
@@ -60,7 +60,8 @@ export const useLogFilter = (): ComputedRef<FilterConfiguration> => {
                         const {VALUES} = useValues("logs");
                         return VALUES.LEVELS;
                     },
-                    showComparatorSelection: true
+                    showComparatorSelection: true,
+                    visibleByDefault: true
                 },
                 {
                     key: "timeRange",

--- a/ui/src/components/filter/utils/filterTypes.ts
+++ b/ui/src/components/filter/utils/filterTypes.ts
@@ -30,6 +30,7 @@ export interface FilterKeyConfig {
     showComparatorSelection?: boolean;
     valueProvider?: () => Promise<FilterValue[]>;
     valueType: "text" | "select" | "date" | "multi-select" | "key-value" | "radio";
+    visibleByDefault?: boolean;
 }
 
 export interface FilterValue {
@@ -43,7 +44,7 @@ export interface AppliedFilter {
     key: string;
     keyLabel: string;
     valueLabel: string;
-    persistent?: boolean;
+    isDefaultVisible?: boolean;
     comparator: Comparators;
     comparatorLabel: string;
     value: string | string[] | Date | {startDate: Date; endDate: Date};

--- a/ui/src/components/flows/Flows.vue
+++ b/ui/src/components/flows/Flows.vue
@@ -4,7 +4,7 @@
             <ul class="header-actions-list">
                 <li>
                     <el-button v-if="canRead" :icon="Download" @click="exportFlowsAsStream()">
-                        {{ t('auditlog.export_csv') }}
+                        {{ t('export_csv') }}
                     </el-button>
                 </li>
                 <li>

--- a/ui/src/translations/de.json
+++ b/ui/src/translations/de.json
@@ -595,6 +595,7 @@
     "export": "Exportieren",
     "export all flows": "Alle Flows exportieren",
     "export all templates": "Alle Vorlagen exportieren",
+    "export_csv": "Als CSV exportieren",
     "exports": "Exporte",
     "failed to render pdf": "PDF-Vorschau konnte nicht gerendert werden",
     "false": "Falsch",

--- a/ui/src/translations/en.json
+++ b/ui/src/translations/en.json
@@ -491,6 +491,7 @@
     "seeing old revision": "You are seeing an old revision: {revision}",
     "export": "Export",
     "exports": "Exports",
+    "export_csv": "Export as CSV",
     "template export": "Are you sure you want to export <code>{templateCount}</code> template(s)?",
     "templates exported": "Templates exported",
     "export all templates": "Export all templates",

--- a/ui/src/translations/es.json
+++ b/ui/src/translations/es.json
@@ -595,6 +595,7 @@
     "export": "Exportar",
     "export all flows": "Exportar todos los flows",
     "export all templates": "Exportar todas las plantillas",
+    "export_csv": "Exportar como CSV",
     "exports": "Exportaciones",
     "failed to render pdf": "Error al renderizar la vista previa del PDF",
     "false": "Falso",

--- a/ui/src/translations/fr.json
+++ b/ui/src/translations/fr.json
@@ -595,6 +595,7 @@
     "export": "Exporter",
     "export all flows": "Exporter tous les flows",
     "export all templates": "Exporter tous les templates",
+    "export_csv": "Exporter en CSV",
     "exports": "Exporter",
     "failed to render pdf": "Impossible de rendre l'aperçu PDF",
     "false": "Faux",

--- a/ui/src/translations/hi.json
+++ b/ui/src/translations/hi.json
@@ -595,6 +595,7 @@
     "export": "निर्यात करें",
     "export all flows": "सभी Flows निर्यात करें",
     "export all templates": "सभी templates निर्यात करें",
+    "export_csv": "CSV के रूप में निर्यात करें",
     "exports": "निर्यात",
     "failed to render pdf": "PDF प्रस्तुत करने में विफल",
     "false": "असत्य",

--- a/ui/src/translations/it.json
+++ b/ui/src/translations/it.json
@@ -595,6 +595,7 @@
     "export": "Esporta",
     "export all flows": "Esporta tutti i flows",
     "export all templates": "Esporta tutti i template",
+    "export_csv": "Esporta come CSV",
     "exports": "Esportazioni",
     "failed to render pdf": "Impossibile visualizzare l'anteprima PDF",
     "false": "Falso",

--- a/ui/src/translations/ja.json
+++ b/ui/src/translations/ja.json
@@ -595,6 +595,7 @@
     "export": "エクスポート",
     "export all flows": "すべてのflowをエクスポート",
     "export all templates": "すべてのテンプレートをエクスポート",
+    "export_csv": "CSVとしてエクスポート",
     "exports": "エクスポート",
     "failed to render pdf": "PDFプレビューのレンダリングに失敗しました",
     "false": "False",

--- a/ui/src/translations/ko.json
+++ b/ui/src/translations/ko.json
@@ -595,6 +595,7 @@
     "export": "내보내기",
     "export all flows": "모든 flow 내보내기",
     "export all templates": "모든 템플릿 내보내기",
+    "export_csv": "CSV로 내보내기",
     "exports": "내보내기 목록",
     "failed to render pdf": "PDF 미리보기를 렌더링하지 못했습니다",
     "false": "False",

--- a/ui/src/translations/pl.json
+++ b/ui/src/translations/pl.json
@@ -595,6 +595,7 @@
     "export": "Eksportuj",
     "export all flows": "Eksportuj wszystkie flows",
     "export all templates": "Eksportuj wszystkie szablony",
+    "export_csv": "Eksportuj jako CSV",
     "exports": "Eksporty",
     "failed to render pdf": "Nie udało się wygenerować podglądu PDF",
     "false": "Fałsz",

--- a/ui/src/translations/pt.json
+++ b/ui/src/translations/pt.json
@@ -595,6 +595,7 @@
     "export": "Exportar",
     "export all flows": "Exportar todos os flows",
     "export all templates": "Exportar todos os templates",
+    "export_csv": "Exportar como CSV",
     "exports": "Exportações",
     "failed to render pdf": "Falha ao renderizar a pré-visualização do PDF",
     "false": "Falso",

--- a/ui/src/translations/pt_BR.json
+++ b/ui/src/translations/pt_BR.json
@@ -595,6 +595,7 @@
     "export": "Exportar",
     "export all flows": "Exportar todos os flows",
     "export all templates": "Exportar todos os templates",
+    "export_csv": "Exportar como CSV",
     "exports": "Exportações",
     "failed to render pdf": "Falha ao renderizar a pré-visualização do PDF",
     "false": "Falso",

--- a/ui/src/translations/ru.json
+++ b/ui/src/translations/ru.json
@@ -595,6 +595,7 @@
     "export": "Экспорт",
     "export all flows": "Экспортировать все flows",
     "export all templates": "Экспортировать все шаблоны",
+    "export_csv": "Экспортировать как CSV",
     "exports": "Экспорты",
     "failed to render pdf": "Не удалось отобразить предварительный просмотр PDF",
     "false": "Ложь",

--- a/ui/src/translations/zh_CN.json
+++ b/ui/src/translations/zh_CN.json
@@ -595,6 +595,7 @@
     "export": "导出",
     "export all flows": "导出所有流程",
     "export all templates": "导出所有模板",
+    "export_csv": "导出为CSV",
     "exports": "导出",
     "failed to render pdf": "渲染PDF预览失败",
     "false": "假",


### PR DESCRIPTION
Closes https://github.com/kestra-io/kestra-ee/issues/5976

We now have a new prop `visibleByDefault` which if added with in any key in configurations file , will automatically add that filter to the filter list when the page loads as kinda `level in any`, even if no value to filter. Users can remove them, but they will reappear on page refresh.

https://github.com/user-attachments/assets/ef337411-1f8c-41cf-8793-e1a0cea8269a

