### PR TITLE
fix Executions duration on 1.1

### DIFF
--- a/core/src/main/java/io/kestra/core/models/flows/State.java
+++ b/core/src/main/java/io/kestra/core/models/flows/State.java
@@ -86,10 +86,12 @@ public class State {
 
     @JsonProperty(access = JsonProperty.Access.READ_ONLY)
     public Duration getDuration() {
-        return Duration.between(
-            this.histories.getFirst().getDate(),
-            this.histories.size() > 1 ? this.histories.get(this.histories.size() - 1).getDate() : Instant.now()
-        );
+        if (this.getEndDate().isPresent()) {
+            return Duration.between(this.getStartDate(), this.getEndDate().get());
+        } else {
+//            return Duration.between(this.getStartDate(), Instant.now()); TODO improve
+            return null;
+        }
     }
 
     @JsonProperty(access = JsonProperty.Access.READ_ONLY)

--- a/core/src/main/java/io/kestra/core/models/flows/State.java
+++ b/core/src/main/java/io/kestra/core/models/flows/State.java
@@ -84,14 +84,24 @@ public class State {
         );
     }
 
+    /**
+     * non-terminated execution duration is hard to provide in SQL, so we set it to null when endDate is empty
+     */
     @JsonProperty(access = JsonProperty.Access.READ_ONLY)
-    public Duration getDuration() {
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    public Optional<Duration> getDuration() {
         if (this.getEndDate().isPresent()) {
-            return Duration.between(this.getStartDate(), this.getEndDate().get());
+            return Optional.of(Duration.between(this.getStartDate(), this.getEndDate().get()));
         } else {
-//            return Duration.between(this.getStartDate(), Instant.now()); TODO improve
-            return null;
+            return Optional.empty();
         }
+    }
+
+    /**
+     * @return either the Duration persisted in database, or calculate it on the fly for non-terminated executions
+     */
+    public Duration getDurationOrComputeIt() {
+        return this.getDuration().orElseGet(() -> Duration.between(this.getStartDate(), Instant.now()));
     }
 
     @JsonProperty(access = JsonProperty.Access.READ_ONLY)
@@ -111,7 +121,7 @@ public class State {
 
     public String humanDuration() {
         try {
-            return DurationFormatUtils.formatDurationHMS(getDuration().toMillis());
+            return DurationFormatUtils.formatDurationHMS(getDurationOrComputeIt().toMillis());
         } catch (Throwable e) {
             return getDuration().toString();
         }

--- a/core/src/test/java/io/kestra/core/models/executions/StateDurationTest.java
+++ b/core/src/test/java/io/kestra/core/models/executions/StateDurationTest.java
@@ -1,0 +1,55 @@
+package io.kestra.core.models.executions;
+
+import io.kestra.core.models.flows.State;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class StateDurationTest {
+
+
+    private static final Instant NOW = Instant.now();
+    private static final Instant ONE = NOW.minus(Duration.ofDays(1000));
+    private static final Instant TWO = ONE.plus(Duration.ofHours(11));
+    private static final Instant THREE = TWO.plus(Duration.ofHours(222));
+
+    @Test
+    void justCreated() {
+        var state = State.of(
+            State.Type.CREATED,
+            List.of(
+                new State.History(State.Type.CREATED, ONE)
+            )
+        );
+        assertThat(state.getDuration()).isCloseTo(Duration.between(ONE, NOW), Duration.ofMinutes(10));
+    }
+
+    @Test
+    void success() {
+        var state = State.of(
+            State.Type.SUCCESS,
+            List.of(
+                new State.History(State.Type.CREATED, ONE),
+                new State.History(State.Type.RUNNING, TWO),
+                new State.History(State.Type.SUCCESS, THREE)
+            )
+        );
+        assertThat(state.getDuration()).isEqualTo(Duration.between(ONE, THREE));
+    }
+
+    @Test
+    void isRunning() {
+        var state = State.of(
+            State.Type.RUNNING,
+            List.of(
+                new State.History(State.Type.CREATED, ONE),
+                new State.History(State.Type.RUNNING, TWO)
+            )
+        );
+        assertThat(state.getDuration()).isCloseTo(Duration.between(ONE, NOW), Duration.ofMinutes(10));
+    }
+}

--- a/core/src/test/java/io/kestra/core/models/executions/StateDurationTest.java
+++ b/core/src/test/java/io/kestra/core/models/executions/StateDurationTest.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.Test;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.List;
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -25,7 +26,7 @@ public class StateDurationTest {
                 new State.History(State.Type.CREATED, ONE)
             )
         );
-        assertThat(state.getDuration()).isCloseTo(Duration.between(ONE, NOW), Duration.ofMinutes(10));
+        assertThat(state.getDuration()).isEmpty();
     }
 
     @Test
@@ -38,7 +39,7 @@ public class StateDurationTest {
                 new State.History(State.Type.SUCCESS, THREE)
             )
         );
-        assertThat(state.getDuration()).isEqualTo(Duration.between(ONE, THREE));
+        assertThat(state.getDuration()).isEqualTo(Optional.of(Duration.between(ONE, THREE)));
     }
 
     @Test
@@ -50,6 +51,6 @@ public class StateDurationTest {
                 new State.History(State.Type.RUNNING, TWO)
             )
         );
-        assertThat(state.getDuration()).isCloseTo(Duration.between(ONE, NOW), Duration.ofMinutes(10));
+        assertThat(state.getDuration()).isEmpty();
     }
 }

--- a/core/src/test/java/io/kestra/core/repositories/AbstractExecutionRepositoryTest.java
+++ b/core/src/test/java/io/kestra/core/repositories/AbstractExecutionRepositoryTest.java
@@ -32,6 +32,8 @@ import io.kestra.plugin.core.dashboard.data.Executions;
 import io.kestra.plugin.core.debug.Return;
 import io.micronaut.data.model.Pageable;
 import io.micronaut.data.model.Sort;
+import io.micronaut.http.HttpStatus;
+import io.micronaut.http.exceptions.HttpStatusException;
 import jakarta.inject.Inject;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -46,6 +48,7 @@ import java.time.format.DateTimeFormatter;
 import java.time.temporal.ChronoUnit;
 import java.util.*;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -648,7 +651,8 @@ public abstract class AbstractExecutionRepositoryTest {
         );
 
         assertThat(data.getTotal()).isEqualTo(1L);
-        assertThat(data).first().hasFieldOrPropertyWithValue("count", 1);
+        assertThat(data).first().hasFieldOrProperty("count");
+        assertThat(data).first().extracting("count").hasToString("1");
         assertThat(data).first().hasFieldOrPropertyWithValue("id", execution.getId());
     }
 
@@ -831,12 +835,7 @@ inject(tenant);
                         )
                     )
                 ).build();
-            try {
-                var res= JacksonMapper.ofJson().writeValueAsString(successExecution);
-                System.out.println(res);
-            } catch (JsonProcessingException e) {
-                throw new RuntimeException(e);
-            }
+
             assertThat(successExecution.getState().getDuration().get()).isCloseTo(Duration.ofSeconds(20), Duration.ofMillis(3));
             executionRepository.save(successExecution);
 
@@ -888,7 +887,7 @@ inject(tenant);
 
         // when
         List<QueryFilter> emptyFilters = null;
-        var sort = Sort.of(Sort.Order.asc("state_duration"));
+        var sort = createSortLikeInControllers(List.of("state.duration:asc"), executionRepository.sortMapping());
         var sortedByShortestDuration = executionRepository.find(Pageable.from(sort), tenant, emptyFilters);
 
         // then
@@ -916,7 +915,7 @@ inject(tenant);
 
         // when
         List<QueryFilter> emptyFilters = null;
-        var sort = Sort.of(Sort.Order.desc("state_duration"));
+        var sort = createSortLikeInControllers(List.of("state.duration:desc"), executionRepository.sortMapping());
         var sortedByLongestDuration = executionRepository.find(Pageable.from(sort), tenant, emptyFilters);
 
         // then
@@ -945,7 +944,7 @@ inject(tenant);
 
         // when
         List<QueryFilter> emptyFilters = null;
-        var sort = Sort.of(Sort.Order.asc("start_date"));
+        var sort = createSortLikeInControllers(List.of("state.startDate:asc"), executionRepository.sortMapping());
         var page = Pageable.from(1, 1, sort);
         var findByMoreRecentStartDate = executionRepository.find(
             page,
@@ -968,7 +967,7 @@ inject(tenant);
 
         // when
         List<QueryFilter> emptyFilters = null;
-        var sort = Sort.of(Sort.Order.desc("start_date"));
+        var sort = createSortLikeInControllers(List.of("state.startDate:desc"), executionRepository.sortMapping());
         var page = Pageable.from(1, 1, sort);
         var findByMoreRecentStartDate = executionRepository.find(
             page,
@@ -981,6 +980,28 @@ inject(tenant);
             .as("assert order when finding by last start date")
             .map(Execution::getId)
             .containsExactly(testData.failedExecution().getId());
+    }
+
+    // duplicated from PageableUtils, because mapping is different between PG and ES
+    private Sort createSortLikeInControllers(List<String> sort, Function<String, String> sortMapper) {
+        return sort == null ? null :
+            Sort.of(sort
+                .stream()
+                .map(s -> {
+                    String[] split = s.split(":");
+                    if (split.length != 2) {
+                        throw new HttpStatusException(HttpStatus.UNPROCESSABLE_ENTITY, "Invalid sort parameter");
+                    }
+                    String col = split[0];
+
+                    if (sortMapper != null) {
+                        col = sortMapper.apply(col);
+                    }
+
+                    return split[1].equals("asc") ? Sort.Order.asc(col) : Sort.Order.desc(col);
+                })
+                .toList()
+            );
     }
 
     @Test

--- a/core/src/test/java/io/kestra/core/repositories/AbstractExecutionRepositoryTest.java
+++ b/core/src/test/java/io/kestra/core/repositories/AbstractExecutionRepositoryTest.java
@@ -1,6 +1,7 @@
 package io.kestra.core.repositories;
 
 import com.devskiller.friendly_id.FriendlyId;
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.google.common.collect.ImmutableMap;
 import io.kestra.core.exceptions.InvalidQueryFiltersException;
 import io.kestra.core.junit.annotations.KestraTest;
@@ -23,6 +24,7 @@ import io.kestra.core.models.flows.State.Type;
 import io.kestra.core.models.property.Property;
 import io.kestra.core.models.tasks.ResolvedTask;
 import io.kestra.core.repositories.ExecutionRepositoryInterface.ChildFilter;
+import io.kestra.core.serializers.JacksonMapper;
 import io.kestra.core.utils.IdUtils;
 import io.kestra.core.utils.NamespaceUtils;
 import io.kestra.core.utils.TestsUtils;
@@ -38,17 +40,18 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.slf4j.event.Level;
 
 import java.io.IOException;
-import java.time.Duration;
-import java.time.Instant;
-import java.time.ZoneId;
-import java.time.ZonedDateTime;
+import java.sql.Timestamp;
+import java.time.*;
 import java.time.format.DateTimeFormatter;
 import java.time.temporal.ChronoUnit;
 import java.util.*;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static io.kestra.core.models.flows.FlowScope.USER;
+import static java.time.temporal.ChronoUnit.MINUTES;
+import static java.time.temporal.ChronoUnit.SECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.doReturn;
@@ -119,7 +122,7 @@ public abstract class AbstractExecutionRepositoryTest {
         );
 
         Random rand = new Random();
-        doReturn(Duration.ofSeconds(rand.nextInt(150)))
+        doReturn(Optional.of(Duration.ofSeconds(rand.nextInt(150))))
             .when(finalState)
             .getDuration();
 
@@ -612,8 +615,10 @@ public abstract class AbstractExecutionRepositoryTest {
     }
 
     @Test
-    protected void fetchData() throws IOException {
-        String tenantId = "data-tenant";
+    protected void dashboard_fetchData() throws IOException {
+        var tenantId = TestsUtils.randomTenant(this.getClass().getSimpleName());
+        var executionDuration = Duration.ofMinutes(220);
+        var executionCreateDate = Instant.now();
         Execution execution = Execution.builder()
             .tenantId(tenantId)
             .id(IdUtils.create())
@@ -621,29 +626,30 @@ public abstract class AbstractExecutionRepositoryTest {
             .flowId("some-execution")
             .flowRevision(1)
             .labels(Label.from(Map.of("country", "FR")))
-            .state(new State(State.Type.CREATED, List.of(new State.History(State.Type.CREATED, Instant.now()))))
+            .state(new State(Type.SUCCESS,
+                List.of(new State.History(State.Type.CREATED, executionCreateDate), new State.History(Type.SUCCESS, executionCreateDate.plus(executionDuration)))))
             .taskRunList(List.of())
             .build();
 
         execution = executionRepository.save(execution);
 
+        var now = ZonedDateTime.now();
         ArrayListTotal<Map<String, Object>> data = executionRepository.fetchData(tenantId, Executions.builder()
                 .type(Executions.class.getName())
                 .columns(Map.of(
                     "count", ColumnDescriptor.<Executions.Fields>builder().field(Executions.Fields.ID).agg(AggregationType.COUNT).build(),
-                    "country", ColumnDescriptor.<Executions.Fields>builder().field(Executions.Fields.LABELS).labelKey("country").build(),
-                    "date", ColumnDescriptor.<Executions.Fields>builder().field(Executions.Fields.START_DATE).build()
+                    "id", ColumnDescriptor.<Executions.Fields>builder().field(Executions.Fields.ID).build(),
+                    "date", ColumnDescriptor.<Executions.Fields>builder().field(Executions.Fields.START_DATE).build(),
+                    "duration", ColumnDescriptor.<Executions.Fields>builder().field(Executions.Fields.DURATION).build()
                 )).build(),
-            ZonedDateTime.now().minus(1, ChronoUnit.HOURS),
-            ZonedDateTime.now(),
+            now.minusHours(1),
+            now,
             null
         );
 
         assertThat(data.getTotal()).isEqualTo(1L);
-        assertThat(data.get(0).get("count")).isEqualTo(1L);
-        assertThat(data.get(0).get("country")).isEqualTo("FR");
-        Instant startDate = execution.getState().getStartDate();
-        assertThat(data.get(0).get("date")).isEqualTo(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSXXX").format(ZonedDateTime.ofInstant(startDate, ZoneId.systemDefault()).withSecond(0).withNano(0)));
+        assertThat(data).first().hasFieldOrPropertyWithValue("count", 1);
+        assertThat(data).first().hasFieldOrPropertyWithValue("id", execution.getId());
     }
 
     private static Execution buildWithCreatedDate(String tenant, Instant instant) {
@@ -784,6 +790,197 @@ inject(tenant);
             .as("find execution CONTAINS LABELS key")
             .usingRecursiveFieldByFieldElementComparatorOnFields("id")
             .containsOnly(exec1);
+    }
+
+    record ExecutionSortTestData(Execution createdExecution, Execution successExecution, Execution runningExecution, Execution failedExecution){
+        static ExecutionSortTestData insertExecutionsTestData(String tenant, ExecutionRepositoryInterface executionRepository) {
+            final Instant clock = Instant.now();
+            final AtomicInteger passedTime = new AtomicInteger();
+            var ten = 10;
+
+            var createdExecution = Execution.builder()
+                .id("createdExecution__" + FriendlyId.createFriendlyId())
+                .namespace(NAMESPACE)
+                .tenantId(tenant)
+                .flowId(FLOW)
+                .flowRevision(1)
+                .state(
+                    State.of(
+                        State.Type.CREATED,
+                        List.of(
+                            new State.History(State.Type.CREATED, clock)
+                        )
+                    )
+                ).build();
+            executionRepository.save(createdExecution);
+
+            var successExecution = Execution.builder()
+                .id("successExecution__" + FriendlyId.createFriendlyId())
+                .namespace(NAMESPACE)
+                .tenantId(tenant)
+                .flowId(FLOW)
+                .flowRevision(1)
+                .state(
+                    State.of(
+                        State.Type.SUCCESS,
+                        List.of(
+                            new State.History(State.Type.CREATED, clock.plus(passedTime.addAndGet(ten), SECONDS)),
+                            new State.History(Type.QUEUED, clock.plus(passedTime.get(), SECONDS)),
+                            new State.History(State.Type.RUNNING, clock.plus(passedTime.addAndGet(ten), SECONDS)),
+                            new State.History(State.Type.SUCCESS, clock.plus(passedTime.addAndGet(ten), SECONDS))
+                        )
+                    )
+                ).build();
+            try {
+                var res= JacksonMapper.ofJson().writeValueAsString(successExecution);
+                System.out.println(res);
+            } catch (JsonProcessingException e) {
+                throw new RuntimeException(e);
+            }
+            assertThat(successExecution.getState().getDuration().get()).isCloseTo(Duration.ofSeconds(20), Duration.ofMillis(3));
+            executionRepository.save(successExecution);
+
+            var runningExecution = Execution.builder()
+                .id("runningExecution__" + FriendlyId.createFriendlyId())
+                .namespace(NAMESPACE)
+                .tenantId(tenant)
+                .flowId(FLOW)
+                .flowRevision(1)
+                .state(
+                    State.of(
+                        State.Type.RUNNING,
+                        List.of(
+                            new State.History(State.Type.CREATED, clock.plus(passedTime.addAndGet(ten), SECONDS)),
+                            new State.History(State.Type.RUNNING, clock.plus(passedTime.addAndGet(ten), SECONDS))
+                        )
+                    )
+                ).build();
+            assertThat(runningExecution.getState().getDuration()).isEmpty();
+            executionRepository.save(runningExecution);
+
+            var failedExecution = Execution.builder()
+                .id("failedExecution__" + FriendlyId.createFriendlyId())
+                .namespace(NAMESPACE)
+                .tenantId(tenant)
+                .flowId(FLOW)
+                .flowRevision(1)
+                .state(
+                    State.of(
+                        Type.FAILED,
+                        List.of(
+                            new State.History(State.Type.CREATED, clock.plus(passedTime.addAndGet(ten), SECONDS)),
+                            new State.History(Type.FAILED, clock.plus(passedTime.addAndGet(ten), SECONDS))
+                        )
+                    )
+                ).build();
+            assertThat(failedExecution.getState().getDuration().get()).isCloseTo(Duration.ofSeconds(10), Duration.ofMillis(3));
+            executionRepository.save(failedExecution);
+
+            return new ExecutionSortTestData(createdExecution, successExecution, runningExecution, failedExecution);
+        }
+    }
+
+    @Test
+    protected void findShouldSortCorrectlyOnDurationAsc() {
+        // given
+        var tenant = TestsUtils.randomTenant(this.getClass().getSimpleName());
+        var testData = ExecutionSortTestData.insertExecutionsTestData(tenant, executionRepository);
+
+        // when
+        List<QueryFilter> emptyFilters = null;
+        var sort = Sort.of(Sort.Order.asc("state_duration"));
+        var sortedByShortestDuration = executionRepository.find(Pageable.from(sort), tenant, emptyFilters);
+
+        // then
+        assertThat(sortedByShortestDuration.stream())
+            .as("assert non-terminated are at the top (list position 0 and 1)")
+            .map(Execution::getId)
+            .elements(0, 1).containsExactlyInAnyOrder(
+                testData.runningExecution().getId(),
+                testData.createdExecution().getId()
+            );
+        assertThat(sortedByShortestDuration.stream())
+            .as("assert terminated are at the bot and sorted")
+            .map(Execution::getId)
+            .elements(2, 3).containsExactly(
+                testData.failedExecution().getId(),
+                testData.successExecution().getId()
+            );
+    }
+
+    @Test
+    protected void findShouldSortCorrectlyOnDurationDesc() {
+        // given
+        var tenant = TestsUtils.randomTenant(this.getClass().getSimpleName());
+        var testData = ExecutionSortTestData.insertExecutionsTestData(tenant, executionRepository);
+
+        // when
+        List<QueryFilter> emptyFilters = null;
+        var sort = Sort.of(Sort.Order.desc("state_duration"));
+        var sortedByLongestDuration = executionRepository.find(Pageable.from(sort), tenant, emptyFilters);
+
+        // then
+        assertThat(sortedByLongestDuration.stream())
+            .as("assert terminated are at the top and sorted")
+            .map(Execution::getId)
+            .elements(0, 1).containsExactly(
+                testData.successExecution().getId(),
+                testData.failedExecution().getId()
+            );
+
+        assertThat(sortedByLongestDuration.stream())
+            .as("assert non-terminated are at the bottom (list position 2 and 3)")
+            .map(Execution::getId)
+            .elements(2, 3).containsExactlyInAnyOrder(
+                testData.runningExecution().getId(),
+                testData.createdExecution().getId()
+            );
+    }
+
+    @Test
+    protected void findShouldOrderByStartDateAsc() {
+        // given
+        var tenant = TestsUtils.randomTenant(this.getClass().getSimpleName());
+        var testData = ExecutionSortTestData.insertExecutionsTestData(tenant, executionRepository);
+
+        // when
+        List<QueryFilter> emptyFilters = null;
+        var sort = Sort.of(Sort.Order.asc("start_date"));
+        var page = Pageable.from(1, 1, sort);
+        var findByMoreRecentStartDate = executionRepository.find(
+            page,
+            tenant,
+            emptyFilters
+        );
+
+        // then
+        assertThat(findByMoreRecentStartDate.stream())
+            .as("assert order when finding by first start date")
+            .map(Execution::getId)
+            .containsExactly(testData.createdExecution().getId());
+    }
+
+    @Test
+    protected void findShouldOrderByStartDateDesc() {
+        // given
+        var tenant = TestsUtils.randomTenant(this.getClass().getSimpleName());
+        var testData = ExecutionSortTestData.insertExecutionsTestData(tenant, executionRepository);
+
+        // when
+        List<QueryFilter> emptyFilters = null;
+        var sort = Sort.of(Sort.Order.desc("start_date"));
+        var page = Pageable.from(1, 1, sort);
+        var findByMoreRecentStartDate = executionRepository.find(
+            page,
+            tenant,
+            emptyFilters
+        );
+
+        // then
+        assertThat(findByMoreRecentStartDate.stream())
+            .as("assert order when finding by last start date")
+            .map(Execution::getId)
+            .containsExactly(testData.failedExecution().getId());
     }
 
     @Test

--- a/executor/src/main/java/io/kestra/executor/ExecutorService.java
+++ b/executor/src/main/java/io/kestra/executor/ExecutorService.java
@@ -435,7 +435,7 @@ public class ExecutorService {
 
         metricRegistry
             .timer(MetricRegistry.METRIC_EXECUTOR_EXECUTION_DURATION, MetricRegistry.METRIC_EXECUTOR_EXECUTION_DURATION_DESCRIPTION, metricRegistry.tags(newExecution))
-            .record(newExecution.getState().getDuration());
+            .record(newExecution.getState().getDurationOrComputeIt());
 
         return executor.withExecution(newExecution, "onEnd");
     }
@@ -1170,7 +1170,7 @@ public class ExecutorService {
                     MetricRegistry.METRIC_EXECUTOR_TASKRUN_ENDED_DURATION_DESCRIPTION,
                     metricRegistry.tags(workerTaskResult)
                 )
-                .record(taskRun.getState().getDuration());
+                .record(taskRun.getState().getDurationOrComputeIt());
         }
     }
 

--- a/jdbc-h2/src/main/resources/migrations/h2/V1_48__executions_state_duration_nullable.sql
+++ b/jdbc-h2/src/main/resources/migrations/h2/V1_48__executions_state_duration_nullable.sql
@@ -1,0 +1,2 @@
+-- make state_duration nullable
+ALTER TABLE executions ALTER COLUMN "state_duration" DROP NOT NULL;

--- a/jdbc-mysql/src/main/resources/migrations/mysql/V1_49__executions_state_duration_nullable.sql
+++ b/jdbc-mysql/src/main/resources/migrations/mysql/V1_49__executions_state_duration_nullable.sql
@@ -1,0 +1,3 @@
+-- make state_duration nullable
+ALTER TABLE executions MODIFY COLUMN
+    `state_duration` BIGINT GENERATED ALWAYS AS (value ->> '$.state.duration' * 1000) STORED;

--- a/jdbc-postgres/src/main/resources/migrations/postgres/V1_48__executions_state_duration_nullable.sql
+++ b/jdbc-postgres/src/main/resources/migrations/postgres/V1_48__executions_state_duration_nullable.sql
@@ -1,0 +1,2 @@
+-- make state_duration nullable
+ALTER TABLE executions ALTER COLUMN "state_duration" DROP NOT NULL;

--- a/jdbc/src/main/java/io/kestra/jdbc/AbstractJdbcRepository.java
+++ b/jdbc/src/main/java/io/kestra/jdbc/AbstractJdbcRepository.java
@@ -74,7 +74,7 @@ public abstract class AbstractJdbcRepository<T> {
             .of(io.kestra.jdbc.repository.AbstractJdbcRepository.field("value"), MAPPER.writeValueAsString(entity))
         );
     }
-    
+
     public int count(Condition condition) {
         return getDslContextWrapper()
             .transactionResult(configuration -> DSL
@@ -85,7 +85,7 @@ public abstract class AbstractJdbcRepository<T> {
                 .fetchOne(0, Integer.class)
             );
     }
-    
+
     public void persist(T entity) {
         this.persist(entity, null);
     }
@@ -264,7 +264,7 @@ public abstract class AbstractJdbcRepository<T> {
                 .forEach(order -> {
                     Field<Object> field = io.kestra.jdbc.repository.AbstractJdbcRepository.field(order.getProperty());
 
-                    select.orderBy(order.getDirection() == Sort.Order.Direction.ASC ? field.asc() : field.desc());
+                    select.orderBy(order.getDirection() == Sort.Order.Direction.ASC ? field.asc().nullsFirst() : field.desc().nullsLast());
                 });
         }
 

--- a/jdbc/src/main/java/io/kestra/jdbc/repository/AbstractJdbcExecutionRepository.java
+++ b/jdbc/src/main/java/io/kestra/jdbc/repository/AbstractJdbcExecutionRepository.java
@@ -713,7 +713,7 @@ public abstract class AbstractJdbcExecutionRepository extends AbstractJdbcReposi
     }
 
     private DailyExecutionStatistics dailyExecutionStatisticsMap(Instant date, List<ExecutionStatistics> result, String groupByType) {
-        long durationSum = result.stream().map(ExecutionStatistics::getDurationSum).mapToLong(value -> value).sum();
+        long durationSum = result.stream().map(ExecutionStatistics::getDurationSum).mapToLong(value -> value != null ? value : 0).sum();
         long count = result.stream().map(ExecutionStatistics::getCount).mapToLong(value -> value).sum();
 
         DailyExecutionStatistics build = DailyExecutionStatistics.builder()
@@ -721,8 +721,8 @@ public abstract class AbstractJdbcExecutionRepository extends AbstractJdbcReposi
             .groupBy(groupByType)
             .duration(DailyExecutionStatistics.Duration.builder()
                 .avg(Duration.ofMillis(durationSum / count))
-                .min(result.stream().map(ExecutionStatistics::getDurationMin).min(Long::compare).map(Duration::ofMillis).orElse(null))
-                .max(result.stream().map(ExecutionStatistics::getDurationMax).max(Long::compare).map(Duration::ofMillis).orElse(null))
+                .min(result.stream().map(ExecutionStatistics::getDurationMin).map(x -> x != null ? x : 0).min(Long::compare).map(Duration::ofMillis).orElse(null))
+                .max(result.stream().map(ExecutionStatistics::getDurationMax).map(x -> x != null ? x : 0).max(Long::compare).map(Duration::ofMillis).orElse(null))
                 .sum(Duration.ofMillis(durationSum))
                 .count(count)
                 .build()

--- a/jdbc/src/main/java/io/kestra/jdbc/runner/JdbcExecutor.java
+++ b/jdbc/src/main/java/io/kestra/jdbc/runner/JdbcExecutor.java
@@ -917,7 +917,7 @@ public class JdbcExecutor implements ExecutorInterface {
 
                         metricRegistry
                             .timer(MetricRegistry.METRIC_EXECUTOR_TASKRUN_ENDED_DURATION, MetricRegistry.METRIC_EXECUTOR_TASKRUN_ENDED_DURATION_DESCRIPTION, metricRegistry.tags(message))
-                            .record(taskRun.getState().getDuration());
+                            .record(taskRun.getState().getDurationOrComputeIt());
 
                         log.trace("TaskRun terminated: {}", taskRun);
                     }

--- a/jdbc/src/test/java/io/kestra/jdbc/repository/AbstractJdbcExecutionRepositoryTest.java
+++ b/jdbc/src/test/java/io/kestra/jdbc/repository/AbstractJdbcExecutionRepositoryTest.java
@@ -1,8 +1,4 @@
 package io.kestra.jdbc.repository;
 
 public abstract class AbstractJdbcExecutionRepositoryTest extends io.kestra.core.repositories.AbstractExecutionRepositoryTest {
-    @Override
-    protected void fetchData() {
-        // TODO Remove the override once JDBC implementation has the QueryBuilder working
-    }
 }

--- a/ui/src/components/dashboard/components/PreviewDashboardWrapper.vue
+++ b/ui/src/components/dashboard/components/PreviewDashboardWrapper.vue
@@ -12,7 +12,7 @@
 <script lang="ts" setup>
     import {ref, watch} from "vue";
     import Sections from "../sections/Sections.vue";
-    import {Chart} from "../composables/useDashboards";
+    import {Chart} from "../types.ts";
     import {useDashboardStore} from "../../../stores/dashboard";
     import * as YAML_UTILS from "@kestra-io/ui-libs/flow-yaml-utils";
     import throttle from "lodash/throttle";
@@ -44,7 +44,7 @@
         , {immediate: true}
     );
 
-    
+
 
     async function loadChart(chart: any) {
         const yamlChart = YAML_UTILS.stringify(chart);

--- a/ui/src/components/dashboard/composables/useDashboards.ts
+++ b/ui/src/components/dashboard/composables/useDashboards.ts
@@ -9,62 +9,6 @@ import {useI18n} from "vue-i18n";
 
 import {decodeSearchParams} from "../../filter/utils/helpers";
 
-export type Dashboard = {
-    id: string;
-    charts: Chart[];
-    title?: string;
-    sourceCode?: string;
-    [key: string]: unknown;
-};
-
-export type Chart = {
-    id: string;
-    type: string;
-    chartOptions?: {
-        displayName?: string;
-        description?: string;
-        width?: number;
-        pagination?: {
-            enabled?: boolean;
-            [key: string]: unknown;
-        };
-        legend?:{
-            enabled?: boolean;
-        };
-        column: string;
-        [key: string]: unknown;
-    };
-    data?: {
-        columns?: {
-            [key: string]: Record<string, any>;
-        };
-        [key: string]: unknown;
-    };
-    content?: string;
-    source?: {
-        type?: string;
-        content?: string;
-        [key: string]: unknown;
-    };
-
-    [key: string]: unknown;
-};
-
-export type Request = {
-    chart: Chart["content"];
-    globalFilter?: Parameters;
-};
-
-export type Parameters = {
-    pageNumber?: number;
-    pageSize?: number;
-    startDate?: Date;
-    endDate?: Date;
-    namespace?: string;
-    labels?: Record<string, string>;
-    filters?: Record<string, any>;
-};
-
 export const ALLOWED_CREATION_ROUTES = ["home", "flows/update", "namespaces/update"];
 
 export const STORAGE_KEYS = (params: RouteParams) => {
@@ -95,22 +39,11 @@ export function getDashboard(route: RouteLocation, type: "key" | "id"): string |
     return type === "key" ? storageKey : localStorage.getItem(storageKey) || "default";
 };
 
-import Bar from "../sections/Bar.vue";
-import KPI from "../sections/KPI.vue";
-import Markdown from "../sections/Markdown.vue";
-import Pie from "../sections/Pie.vue";
-import Table from "../sections/Table.vue";
-import TimeSeries from "../sections/TimeSeries.vue";
-import {FilterObject} from "../../../utils/filters";
 
-export const TYPES: Record<string, any> = {
-    "io.kestra.plugin.core.dashboard.chart.Bar": Bar,
-    "io.kestra.plugin.core.dashboard.chart.KPI": KPI,
-    "io.kestra.plugin.core.dashboard.chart.Markdown": Markdown,
-    "io.kestra.plugin.core.dashboard.chart.Pie": Pie,
-    "io.kestra.plugin.core.dashboard.chart.Table": Table,
-    "io.kestra.plugin.core.dashboard.chart.TimeSeries": TimeSeries,
-};
+import {FilterObject} from "../../../utils/filters";
+import {Chart, Parameters, Request} from "../types.ts";
+
+
 
 export const isKPIChart = (type: string): boolean => type === "io.kestra.plugin.core.dashboard.chart.KPI";
 
@@ -159,3 +92,5 @@ export function useChartGenerator(props: {chart: Chart; filters: FilterObject[];
 
     return {percentageShown, EMPTY_TEXT, data, generate};
 }
+
+export * from "../types";

--- a/ui/src/components/dashboard/dashboard-types.ts
+++ b/ui/src/components/dashboard/dashboard-types.ts
@@ -1,0 +1,15 @@
+import Bar from "./sections/Bar.vue";
+import KPI from "./sections/KPI.vue";
+import Markdown from "./sections/Markdown.vue";
+import Pie from "./sections/Pie.vue";
+import Table from "./sections/Table.vue";
+import TimeSeries from "./sections/TimeSeries.vue";
+
+export const TYPES: Record<string, any> = {
+    "io.kestra.plugin.core.dashboard.chart.Bar": Bar,
+    "io.kestra.plugin.core.dashboard.chart.KPI": KPI,
+    "io.kestra.plugin.core.dashboard.chart.Markdown": Markdown,
+    "io.kestra.plugin.core.dashboard.chart.Pie": Pie,
+    "io.kestra.plugin.core.dashboard.chart.Table": Table,
+    "io.kestra.plugin.core.dashboard.chart.TimeSeries": TimeSeries,
+};

--- a/ui/src/components/dashboard/sections/Sections.vue
+++ b/ui/src/components/dashboard/sections/Sections.vue
@@ -74,7 +74,8 @@
     import {ref, computed} from "vue";
 
     import type {Dashboard, Chart} from "../composables/useDashboards";
-    import {TYPES, isKPIChart, isTableChart, getChartTitle} from "../composables/useDashboards";
+    import {isKPIChart, isTableChart, getChartTitle} from "../composables/useDashboards";
+    import {TYPES} from "../dashboard-types";
 
     import {useRoute} from "vue-router";
     const route = useRoute();
@@ -113,11 +114,11 @@
         title: getChartTitle(chart),
         description: chart?.chartOptions?.description,
     });
-    
+
     // Make the overview of flows/dashboard/namespace specific
     const filters = computed(() => {
         const baseFilters: { field: string; operation: string; value: string | string[] }[] = [];
-        
+
         if (route.name === "flows/update") {
             baseFilters.push({field: "namespace", operation: "EQUALS", value: route.params.namespace as string});
             baseFilters.push({field: "flowId", operation: "EQUALS", value: route.params.id as string});
@@ -174,7 +175,7 @@ section#charts {
             opacity: 1;
         }
     }
-    
+
     .dash-width-3, .dash-width-6, .dash-width-9, .dash-width-12  {
         grid-column: span 3;
     }

--- a/ui/src/components/dashboard/sections/Table.vue
+++ b/ui/src/components/dashboard/sections/Table.vue
@@ -1,5 +1,5 @@
 <template>
-    <section v-if="data" id="table">
+    <section v-if="data?.results?.length" id="table">
         <el-table
             :id="containerID"
             :data="data.results"
@@ -39,7 +39,7 @@
 
     import type {RouteLocation} from "vue-router";
 
-    import type {Chart} from "../composables/useDashboards";
+    import type {Chart} from "../types.ts";
     import {getDashboard, isPaginationEnabled, useChartGenerator} from "../composables/useDashboards";
 
     import Date from "./table/columns/Date.vue";
@@ -87,9 +87,12 @@
         case "NAMESPACE":
             return {field: row[key]};
         case "STATE":
-            return {size: "small", status: row[key]};
+            return {
+                size: "small",
+                status: row[key].toString(),
+            };
         case "DURATION":
-            return {field: row[key]};
+            return {field: row[key], startDate: row["start_date"]};
         default:
             if (field.toLowerCase().includes("date")) {
                 return {field: row[key]};

--- a/ui/src/components/dashboard/sections/table/columns/Date.vue
+++ b/ui/src/components/dashboard/sections/table/columns/Date.vue
@@ -14,7 +14,8 @@
         },
     });
 
-    const format = localStorage.getItem(storageKeys.DATE_FORMAT_STORAGE_KEY) ?? "llll";
+    const momentLongDateFormat = "llll";
+    const format = localStorage.getItem(storageKeys.DATE_FORMAT_STORAGE_KEY) ?? momentLongDateFormat;
     const formatDateIfPresent = (rawDate: string|undefined) => {
         if(rawDate){
             // moment(date) always return a Moment, if the date is undefined, it will return current date, we don't want that here

--- a/ui/src/components/dashboard/sections/table/columns/Date.vue
+++ b/ui/src/components/dashboard/sections/table/columns/Date.vue
@@ -15,5 +15,13 @@
     });
 
     const format = localStorage.getItem(storageKeys.DATE_FORMAT_STORAGE_KEY) ?? "llll";
-    const date = computed(() => moment(props.field)?.format(format) ?? props.field);
+    const formatDateIfPresent = (rawDate: string|undefined) => {
+        if(rawDate){
+            // moment(date) always return a Moment, if the date is undefined, it will return current date, we don't want that here
+            return moment(rawDate).format(format) ?? props.field;
+        } else {
+            return undefined;
+        }
+    }
+    const date = computed(() => formatDateIfPresent(props.field));
 </script>

--- a/ui/src/components/dashboard/sections/table/columns/Duration.vue
+++ b/ui/src/components/dashboard/sections/table/columns/Duration.vue
@@ -1,14 +1,17 @@
 <template>
-    <span>{{ Utils.humanDuration(props.field) }}</span>
+    <span v-if="field">{{ Utils.humanDuration(calculatedField) }}</span>
+    <em v-else>{{ Utils.humanDuration(calculatedField) }}</em>
 </template>
 
 <script setup lang="ts">
     import {Utils} from "@kestra-io/ui-libs";
+    import {computed} from "vue";
 
-    const props = defineProps({
-        field: {
-            type: Number,
-            required: true,
-        },
-    });
+    const props = defineProps<{
+        field: number | undefined,
+        startDate?: string
+    }>();
+
+    // handle case where execution is non-terminated, then there is no duration, we calculate it live to display it to the user
+    const calculatedField = computed(() => props.field === undefined && props.startDate ? ((+new Date() - new Date(props.startDate).getTime()) / 1000 ) : props.field ?? 0);
 </script>

--- a/ui/src/components/dashboard/types.ts
+++ b/ui/src/components/dashboard/types.ts
@@ -1,0 +1,55 @@
+export type Dashboard = {
+    id: string;
+    charts: Chart[];
+    title?: string;
+    sourceCode?: string;
+    [key: string]: unknown;
+};
+
+export type Chart = {
+    id: string;
+    type: string;
+    chartOptions?: {
+        displayName?: string;
+        description?: string;
+        width?: number;
+        pagination?: {
+            enabled?: boolean;
+            [key: string]: unknown;
+        };
+        legend?:{
+            enabled?: boolean;
+        };
+        column: string;
+        [key: string]: unknown;
+    };
+    data?: {
+        columns?: {
+            [key: string]: Record<string, any>;
+        };
+        [key: string]: unknown;
+    };
+    content?: string;
+    source?: {
+        type?: string;
+        content?: string;
+        [key: string]: unknown;
+    };
+
+    [key: string]: unknown;
+};
+
+export type Request = {
+    chart: Chart["content"];
+    globalFilter?: Parameters;
+};
+
+export type Parameters = {
+    pageNumber?: number;
+    pageSize?: number;
+    startDate?: Date;
+    endDate?: Date;
+    namespace?: string;
+    labels?: Record<string, string>;
+    filters?: Record<string, any>;
+};

--- a/ui/src/components/executions/Executions.vue
+++ b/ui/src/components/executions/Executions.vue
@@ -193,10 +193,7 @@
                                     <DateAgo :inverted="true" :date="scope.row?.state?.endDate" />
                                 </template>
                                 <template v-else-if="col.prop === 'state.duration'">
-                                    <span v-if="isRunning(scope.row)">{{
-                                        humanizeDuration(durationFrom(scope.row).toString())
-                                    }}</span>
-                                    <span v-else>{{ humanizeDuration(scope.row?.state?.duration) }}</span>
+                                    <Duration :field="scope.row?.state?.duration" :startDate="scope.row?.state?.startDate" />
                                 </template>
                                 <template v-else-if="col.prop === 'namespace' && $route.name !== 'flows/update'">
                                     <span :title="invisibleSpace(scope.row?.namespace)">{{ invisibleSpace(scope.row?.namespace) }}</span>
@@ -421,8 +418,9 @@
     import {filterValidLabels} from "./utils";
     import {useToast} from "../../utils/toast";
     import {storageKeys} from "../../utils/constants";
-    import {humanizeDuration, invisibleSpace} from "../../utils/filters";
+    import {invisibleSpace} from "../../utils/filters";
     import Utils from "../../utils/utils";
+    import Duration from "../../components/dashboard/sections/table/columns/Duration.vue";
 
     import action from "../../models/action";
     import permission from "../../models/permission";
@@ -729,10 +727,6 @@
         load(onDataLoaded);
     };
 
-    const isRunning = (item: any) => {
-        return State.isRunning(item?.state?.current);
-    };
-
     const loadQuery = (base: any) => {
         let queryFilter = queryWithFilter();
 
@@ -750,10 +744,6 @@
         }
 
         return _merge(base, queryFilter);
-    };
-
-    const durationFrom = (item: any) => {
-        return +new Date() - new Date(item?.state?.startDate).getTime();
     };
 
     const genericConfirmAction = (message: string, queryAction: string, byIdAction: string, success: string, showCancelButton = true) => {

--- a/ui/src/components/executions/Executions.vue
+++ b/ui/src/components/executions/Executions.vue
@@ -753,7 +753,7 @@
     };
 
     const durationFrom = (item: any) => {
-        return (+new Date() - new Date(item?.state?.startDate).getTime()) / 1000;
+        return +new Date() - new Date(item?.state?.startDate).getTime();
     };
 
     const genericConfirmAction = (message: string, queryAction: string, byIdAction: string, success: string, showCancelButton = true) => {

--- a/ui/tests/storybook/components/dashboard/sections/Table.stories.tsx
+++ b/ui/tests/storybook/components/dashboard/sections/Table.stories.tsx
@@ -1,0 +1,133 @@
+import Table from "../../../../../src/components/dashboard/sections/Table.vue";
+import type {Chart} from "../../../../../src/components/dashboard/types.ts";
+import type {Meta, StoryObj} from "@storybook/vue3-vite";
+import {vueRouter} from "storybook-vue3-router";
+import {useAxios} from "../../../../../src/utils/axios.ts";
+import {expect, within} from "storybook/test";
+
+const meta: Meta<typeof Table> = {
+    title: "Dashboard/Sections/Table",
+    component: Table,
+    decorators: [
+        vueRouter([
+            {
+                path: "/",
+                component: () => <div></div>
+            },
+            {
+                path: "/flows/update",
+                name: "flows/update",
+                component: () => <div></div>
+            },
+            {
+                path: "/executions/update",
+                name: "executions/update",
+                component: () => <div></div>
+            },
+            {
+                path: "/namespaces/update",
+                name: "namespaces/update",
+                component: () => <div></div>
+            },
+        ])
+    ]
+}
+
+export default meta;
+
+export const SimpleExecutionsCase: StoryObj<typeof Table> = {
+    render: () => ({
+        setup() {
+            const store = useAxios() as any;
+            store.post = async function (uri: string) {
+                console.log("post request", uri)
+
+                if (uri.includes("charts/executions_finished")) {
+                    console.log("match charts/executions_finished", uri)
+
+                    return {
+                        data: {
+                            results: [
+                                {
+                                    "namespace": "company.team",
+                                    "id": "2wJlDoXRsMc7jXJfQUWTE7",
+                                    "state": "RUNNING",
+                                    "flow": "sleep",
+                                    "start_date": "2025-11-25T09:28:00.000+00:00",
+                                },
+                                {
+                                    "namespace": "company.team",
+                                    "id": "2yiYHSqLwNbocm9FB8qK5L",
+                                    "state": "RUNNING",
+                                    "flow": "sleep",
+                                    "start_date": "2025-11-25T09:28:00.000+00:00"
+                                },
+                                {
+                                    "duration": 6,
+                                    "namespace": "company.team",
+                                    "id": "2Iq5tjur4bB9fRYYazstV4",
+                                    "state": "SUCCESS",
+                                    "flow": "sleep",
+                                    "end_date": "2025-11-25T09:27:00.000+00:00",
+                                    "start_date": "2025-11-25T09:27:00.000+00:00",
+                                },
+                                {
+                                    "namespace": "company.team",
+                                    "id": "69d95APmpdw94OkaMduCep",
+                                    "state": "RUNNING",
+                                    "flow": "sleep",
+                                    "start_date": "2025-11-25T09:27:00.000+00:00"
+                                }
+                            ],
+                            total: 4
+                        }
+                    }
+                }
+                return {results: []}
+            }
+
+            const chart: Chart = {
+                "id": "executions_finished",
+                "type": "io.kestra.plugin.core.dashboard.chart.Table",
+                "chartOptions": {
+
+                            "displayName": "Executions Finished",
+                            "width": 12,
+                            "header": {"enabled": true},
+                            "pagination": {"enabled": true}
+                },
+                "data": {
+                    "columns": {
+                        "id": {"field": "ID", "displayName": "Execution ID", "columnAlignment": "LEFT"},
+                        "flow": {"field": "FLOW_ID", "displayName": "Flow", "columnAlignment": "LEFT"},
+                        "state": {"field": "STATE", "displayName": "State", "columnAlignment": "LEFT"},
+                        "duration": {"field": "DURATION", "displayName": "Duration", "columnAlignment": "LEFT"},
+                        "end_date": {"field": "END_DATE", "displayName": "End date", "columnAlignment": "LEFT"},
+                        "namespace": {
+                            "field": "NAMESPACE",
+                            "displayName": "Namespace",
+                            "columnAlignment": "LEFT"
+                        },
+                        "start_date": {
+                            "field": "START_DATE",
+                            "displayName": "Start date",
+                            "columnAlignment": "LEFT"
+                        }
+                    }
+                },
+            } as any;
+            return () => (
+                <div style="padding: 20px; background: #f5f5f5; border-radius: 8px;">
+                    <Table chart={chart}/>
+                </div>
+            );
+        }
+    }),
+    async play({canvasElement}) {
+        const canvas = within(canvasElement);
+        await expect(await canvas.findByText("2wJlDoXR")).toBeVisible();
+        await expect(await canvas.findByText("2yiYHSqL")).toBeVisible();
+        await expect(await canvas.findByText("2Iq5tjur")).toBeVisible();
+        await expect(await canvas.findByText("69d95APm")).toBeVisible();
+    }
+}

--- a/worker/src/main/java/io/kestra/worker/DefaultWorker.java
+++ b/worker/src/main/java/io/kestra/worker/DefaultWorker.java
@@ -858,7 +858,7 @@ public class DefaultWorker implements Worker {
 
         metricRegistry
             .timer(MetricRegistry.METRIC_WORKER_ENDED_DURATION, MetricRegistry.METRIC_WORKER_ENDED_DURATION_DESCRIPTION, metricRegistry.tags(workerTask, workerGroup))
-            .record(workerTask.getTaskRun().getState().getDuration());
+            .record(workerTask.getTaskRun().getState().getDurationOrComputeIt());
 
         logService.logTaskRun(
             workerTask.getTaskRun(),


### PR DESCRIPTION
- backport of PR https://github.com/kestra-io/kestra/pull/13132
- make non-terminated Executions not persist duration in database
- when sorting by Duration, either put it at the beginning of the list, or the end depending on asc/desc
- calculate it on the fly by Frontend both in Dashboards and Executions list page
- fix various Frontend issues about Executions EndDate, misscaculated Durations...
- to fix https://github.com/kestra-io/kestra-ee/issues/5420
- and https://github.com/kestra-io/kestra/issues/11593
- companion PR https://github.com/kestra-io/kestra-ee/pull/5989