### PR TITLE
Fix ZIP download so that file extension remains .yaml

### DIFF
--- a/webserver/src/main/java/io/kestra/webserver/controllers/api/FlowController.java
+++ b/webserver/src/main/java/io/kestra/webserver/controllers/api/FlowController.java
@@ -734,7 +734,7 @@ public class FlowController {
         var flows = ids.stream()
             .map(id -> flowRepository.findByIdWithSource(tenantService.resolveTenant(), id.getNamespace(), id.getId()).orElseThrow())
             .toList();
-        var bytes = HasSource.asZipFile(flows, flow -> flow.getNamespace() + "." + flow.getId() + ".yml");
+        var bytes = HasSource.asZipFile(flows, flow -> flow.getNamespace() + "." + flow.getId() + ".yaml");
         return HttpResponse.ok(bytes).header("Content-Disposition", "attachment; filename=\"flows.zip\"");
     }
 


### PR DESCRIPTION
✨ Description

Changed the file extension from .yml to .yaml for FlowControllers.
Path of the file changed -> kestra/webserver/src/main/java/kestra/controllers/api/FlowController.java
Changes
🪄 Removed '.yml' from exportFlowsByIds.
🪄 Replaced the said '.yml' with '.yaml'

🔗 Related Issue

Closes #13221

📸Relevant Screenshots ->

[
<img width="1435" height="441" alt="Screenshot 2025-12-01 at 10 25 23 PM" src="https://github.com/user-attachments/assets/22813c05-a72e-42bd-966c-e95b3ca65f3b" />
](url)

<img width="1435" height="415" alt="Screenshot 2025-12-01 at 10 24 39 PM" src="https://github.com/user-attachments/assets/a4ce8e73-4dfe-424a-bb1d-0a04de4bdd73" />


