### PR TITLE
fix concurrency limit overload issue for jdbcexecutor

### DIFF
--- a/core/src/main/java/io/kestra/core/models/flows/State.java
+++ b/core/src/main/java/io/kestra/core/models/flows/State.java
@@ -267,6 +267,10 @@ public class State {
             return this == Type.RUNNING || this == Type.KILLING;
         }
 
+        public boolean onlyRunning() {
+            return this == Type.RUNNING;
+        }
+
         public boolean isFailed() {
             return this == Type.FAILED;
         }

--- a/core/src/test/java/io/kestra/core/runners/AbstractRunnerConcurrencyTest.java
+++ b/core/src/test/java/io/kestra/core/runners/AbstractRunnerConcurrencyTest.java
@@ -1,0 +1,91 @@
+package io.kestra.core.runners;
+
+import io.kestra.core.junit.annotations.FlakyTest;
+import io.kestra.core.junit.annotations.KestraTest;
+import io.kestra.core.junit.annotations.LoadFlows;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+
+@KestraTest(startRunner = true)
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public abstract class AbstractRunnerConcurrencyTest {
+    public static final String TENANT_1 = "tenant1";
+
+    @Inject
+    protected FlowConcurrencyCaseTest flowConcurrencyCaseTest;
+
+    @Test
+    @LoadFlows({"flows/valids/flow-concurrency-cancel.yml"})
+    void concurrencyCancel() throws Exception {
+        flowConcurrencyCaseTest.flowConcurrencyCancel();
+    }
+
+    @Test
+    @LoadFlows({"flows/valids/flow-concurrency-fail.yml"})
+    void concurrencyFail() throws Exception {
+        flowConcurrencyCaseTest.flowConcurrencyFail();
+    }
+
+    @Test
+    @LoadFlows({"flows/valids/flow-concurrency-queue.yml"})
+    void concurrencyQueue() throws Exception {
+        flowConcurrencyCaseTest.flowConcurrencyQueue();
+    }
+
+    @Test
+    @LoadFlows({"flows/valids/flow-concurrency-queue-pause.yml"})
+    protected void concurrencyQueuePause() throws Exception {
+        flowConcurrencyCaseTest.flowConcurrencyQueuePause();
+    }
+
+    @Test
+    @LoadFlows({"flows/valids/flow-concurrency-cancel-pause.yml"})
+    protected void concurrencyCancelPause() throws Exception {
+        flowConcurrencyCaseTest.flowConcurrencyCancelPause();
+    }
+
+    @Test
+    @LoadFlows(value = {"flows/valids/flow-concurrency-for-each-item.yaml", "flows/valids/flow-concurrency-queue.yml"}, tenantId = TENANT_1)
+    protected void flowConcurrencyWithForEachItem() throws Exception {
+        flowConcurrencyCaseTest.flowConcurrencyWithForEachItem(TENANT_1);
+    }
+
+    @Test
+    @LoadFlows({"flows/valids/flow-concurrency-queue-fail.yml"})
+    protected void concurrencyQueueRestarted() throws Exception {
+        flowConcurrencyCaseTest.flowConcurrencyQueueRestarted();
+    }
+
+    @Test
+    @LoadFlows({"flows/valids/flow-concurrency-queue-after-execution.yml"})
+    void concurrencyQueueAfterExecution() throws Exception {
+        flowConcurrencyCaseTest.flowConcurrencyQueueAfterExecution();
+    }
+
+    @Test
+    @LoadFlows(value = {"flows/valids/flow-concurrency-subflow.yml", "flows/valids/flow-concurrency-cancel.yml"}, tenantId = TENANT_1)
+    void flowConcurrencySubflow() throws Exception {
+        flowConcurrencyCaseTest.flowConcurrencySubflow(TENANT_1);
+    }
+
+    @Test
+    @FlakyTest(description = "Only flaky in CI")
+    @LoadFlows({"flows/valids/flow-concurrency-parallel-subflow-kill.yaml", "flows/valids/flow-concurrency-parallel-subflow-kill-child.yaml", "flows/valids/flow-concurrency-parallel-subflow-kill-grandchild.yaml"})
+    protected void flowConcurrencyParallelSubflowKill() throws Exception {
+        flowConcurrencyCaseTest.flowConcurrencyParallelSubflowKill();
+    }
+
+    @Test
+    @LoadFlows({"flows/valids/flow-concurrency-queue-killed.yml"})
+    void flowConcurrencyKilled() throws Exception {
+        flowConcurrencyCaseTest.flowConcurrencyKilled();
+    }
+
+    @Test
+    @FlakyTest(description = "Only flaky in CI")
+    @LoadFlows({"flows/valids/flow-concurrency-queue-killed.yml"})
+    void flowConcurrencyQueueKilled() throws Exception {
+        flowConcurrencyCaseTest.flowConcurrencyQueueKilled();
+    }
+}

--- a/core/src/test/java/io/kestra/core/runners/AbstractRunnerTest.java
+++ b/core/src/test/java/io/kestra/core/runners/AbstractRunnerTest.java
@@ -67,9 +67,6 @@ public abstract class AbstractRunnerTest {
     protected LoopUntilCaseTest loopUntilTestCaseTest;
 
     @Inject
-    protected FlowConcurrencyCaseTest flowConcurrencyCaseTest;
-
-    @Inject
     protected ScheduleDateCaseTest scheduleDateCaseTest;
 
     @Inject
@@ -420,78 +417,6 @@ public abstract class AbstractRunnerTest {
         "flows/valids/for-each-item-after-execution.yaml"})
     protected void forEachItemWithAfterExecution() throws Exception {
         forEachItemCaseTest.forEachItemWithAfterExecution();
-    }
-
-    @Test
-    @LoadFlows({"flows/valids/flow-concurrency-cancel.yml"})
-    void concurrencyCancel() throws Exception {
-        flowConcurrencyCaseTest.flowConcurrencyCancel();
-    }
-
-    @Test
-    @LoadFlows({"flows/valids/flow-concurrency-fail.yml"})
-    void concurrencyFail() throws Exception {
-        flowConcurrencyCaseTest.flowConcurrencyFail();
-    }
-
-    @Test
-    @LoadFlows({"flows/valids/flow-concurrency-queue.yml"})
-    void concurrencyQueue() throws Exception {
-        flowConcurrencyCaseTest.flowConcurrencyQueue();
-    }
-
-    @Test
-    @LoadFlows({"flows/valids/flow-concurrency-queue-pause.yml"})
-    protected void concurrencyQueuePause() throws Exception {
-        flowConcurrencyCaseTest.flowConcurrencyQueuePause();
-    }
-
-    @Test
-    @LoadFlows({"flows/valids/flow-concurrency-cancel-pause.yml"})
-    protected void concurrencyCancelPause() throws Exception {
-        flowConcurrencyCaseTest.flowConcurrencyCancelPause();
-    }
-
-    @Test
-    @LoadFlows(value = {"flows/valids/flow-concurrency-for-each-item.yaml", "flows/valids/flow-concurrency-queue.yml"}, tenantId = TENANT_1)
-    protected void flowConcurrencyWithForEachItem() throws Exception {
-        flowConcurrencyCaseTest.flowConcurrencyWithForEachItem(TENANT_1);
-    }
-
-    @Test
-    @LoadFlows({"flows/valids/flow-concurrency-queue-fail.yml"})
-    protected void concurrencyQueueRestarted() throws Exception {
-        flowConcurrencyCaseTest.flowConcurrencyQueueRestarted();
-    }
-
-    @Test
-    @LoadFlows({"flows/valids/flow-concurrency-queue-after-execution.yml"})
-    void concurrencyQueueAfterExecution() throws Exception {
-        flowConcurrencyCaseTest.flowConcurrencyQueueAfterExecution();
-    }
-
-    @Test
-    @LoadFlows(value = {"flows/valids/flow-concurrency-subflow.yml", "flows/valids/flow-concurrency-cancel.yml"}, tenantId = TENANT_1)
-    void flowConcurrencySubflow() throws Exception {
-        flowConcurrencyCaseTest.flowConcurrencySubflow(TENANT_1);
-    }
-
-    @Test
-    @LoadFlows({"flows/valids/flow-concurrency-parallel-subflow-kill.yaml", "flows/valids/flow-concurrency-parallel-subflow-kill-child.yaml", "flows/valids/flow-concurrency-parallel-subflow-kill-grandchild.yaml"})
-    void flowConcurrencyParallelSubflowKill() throws Exception {
-        flowConcurrencyCaseTest.flowConcurrencyParallelSubflowKill();
-    }
-
-    @Test
-    @LoadFlows({"flows/valids/flow-concurrency-queue-killed.yml"})
-    void flowConcurrencyKilled() throws Exception {
-        flowConcurrencyCaseTest.flowConcurrencyKilled();
-    }
-
-    @Test
-    @LoadFlows({"flows/valids/flow-concurrency-queue-killed.yml"})
-    void flowConcurrencyQueueKilled() throws Exception {
-        flowConcurrencyCaseTest.flowConcurrencyQueueKilled();
     }
 
     @Test

--- a/core/src/test/java/io/kestra/core/runners/AbstractRunnerTest.java
+++ b/core/src/test/java/io/kestra/core/runners/AbstractRunnerTest.java
@@ -483,6 +483,18 @@ public abstract class AbstractRunnerTest {
     }
 
     @Test
+    @LoadFlows({"flows/valids/flow-concurrency-queue-killed.yml"})
+    void flowConcurrencyKilled() throws Exception {
+        flowConcurrencyCaseTest.flowConcurrencyKilled();
+    }
+
+    @Test
+    @LoadFlows({"flows/valids/flow-concurrency-queue-killed.yml"})
+    void flowConcurrencyQueueKilled() throws Exception {
+        flowConcurrencyCaseTest.flowConcurrencyQueueKilled();
+    }
+
+    @Test
     @ExecuteFlow("flows/valids/executable-fail.yml")
     void badExecutable(Execution execution) {
         assertThat(execution.getTaskRunList().size()).isEqualTo(1);

--- a/core/src/test/java/io/kestra/core/runners/FlowConcurrencyCaseTest.java
+++ b/core/src/test/java/io/kestra/core/runners/FlowConcurrencyCaseTest.java
@@ -69,6 +69,7 @@ public class FlowConcurrencyCaseTest {
             assertThat(shouldFailExecutions.stream().map(Execution::getState).map(State::getCurrent)).allMatch(Type.CANCELLED::equals);
         } finally {
             runnerUtils.killExecution(execution1);
+            runnerUtils.awaitExecution(e -> e.getState().isTerminated(), execution1);
         }
     }
 
@@ -84,6 +85,7 @@ public class FlowConcurrencyCaseTest {
             assertThat(shouldFailExecutions.stream().map(Execution::getState).map(State::getCurrent)).allMatch(State.Type.FAILED::equals);
         } finally {
             runnerUtils.killExecution(execution1);
+            runnerUtils.awaitExecution(e -> e.getState().isTerminated(), execution1);
         }
     }
 
@@ -238,6 +240,94 @@ public class FlowConcurrencyCaseTest {
         assertThat(terminated.getState().getCurrent()).isEqualTo(State.Type.KILLED);
         assertThat(terminated.getState().getHistories().stream().noneMatch(h -> h.getState() == Type.RUNNING)).isTrue();
         assertThat(terminated.getTaskRunList()).isNull();
+    }
+
+    public void flowConcurrencyKilled() throws QueueException, InterruptedException {
+        Flow flow = flowRepository
+            .findById(MAIN_TENANT, NAMESPACE, "flow-concurrency-queue-killed", Optional.empty())
+            .orElseThrow();
+        Execution execution1 = runnerUtils.runOneUntilRunning(MAIN_TENANT, NAMESPACE, "flow-concurrency-queue-killed", null, null, Duration.ofSeconds(30));
+        Execution execution2 = runnerUtils.emitAndAwaitExecution(e -> e.getState().getCurrent().equals(Type.QUEUED), Execution.newExecution(flow, null, null, Optional.empty()));
+        Execution execution3 = runnerUtils.emitAndAwaitExecution(e -> e.getState().getCurrent().equals(Type.QUEUED), Execution.newExecution(flow, null, null, Optional.empty()));
+
+        try {
+            assertThat(execution1.getState().isRunning()).isTrue();
+            assertThat(execution2.getState().getCurrent()).isEqualTo(Type.QUEUED);
+            assertThat(execution3.getState().getCurrent()).isEqualTo(Type.QUEUED);
+
+            // we kill execution 1, execution 2 should run but not execution 3
+            killQueue.emit(ExecutionKilledExecution
+                .builder()
+                .state(ExecutionKilled.State.REQUESTED)
+                .executionId(execution1.getId())
+                .isOnKillCascade(true)
+                .tenantId(MAIN_TENANT)
+                .build()
+            );
+
+            Execution killed = runnerUtils.awaitExecution(e -> e.getState().getCurrent().equals(Type.KILLED), execution1);
+            assertThat(killed.getState().getCurrent()).isEqualTo(Type.KILLED);
+            assertThat(killed.getState().getHistories().stream().anyMatch(h -> h.getState() == Type.RUNNING)).isTrue();
+
+            // we now check that execution 2 is running
+            Execution running = runnerUtils.awaitExecution(e -> e.getState().getCurrent().equals(Type.RUNNING), execution2);
+            assertThat(running.getState().getCurrent()).isEqualTo(Type.RUNNING);
+
+            // we check that execution 3 is still queued
+            Thread.sleep(100); // wait a little to be 100% sure
+            Execution queued = runnerUtils.awaitExecution(e -> e.getState().isQueued(), execution3);
+            assertThat(queued.getState().getCurrent()).isEqualTo(Type.QUEUED);
+        } finally {
+            // kill everything to avoid dangling executions
+            runnerUtils.killExecution(execution1);
+            runnerUtils.killExecution(execution2);
+            runnerUtils.killExecution(execution3);
+
+            // await that they are all terminated, note that as KILLED is received twice, some messages would still be pending, but this is the best we can do
+            runnerUtils.awaitFlowExecutionNumber(3, MAIN_TENANT, NAMESPACE, "flow-concurrency-queue-killed");
+        }
+    }
+
+    public void flowConcurrencyQueueKilled() throws QueueException, InterruptedException {
+        Flow flow = flowRepository
+            .findById(MAIN_TENANT, NAMESPACE, "flow-concurrency-queue-killed", Optional.empty())
+            .orElseThrow();
+        Execution execution1 = runnerUtils.runOneUntilRunning(MAIN_TENANT, NAMESPACE, "flow-concurrency-queue-killed", null, null, Duration.ofSeconds(30));
+        Execution execution2 = runnerUtils.emitAndAwaitExecution(e -> e.getState().getCurrent().equals(Type.QUEUED), Execution.newExecution(flow, null, null, Optional.empty()));
+        Execution execution3 = runnerUtils.emitAndAwaitExecution(e -> e.getState().getCurrent().equals(Type.QUEUED), Execution.newExecution(flow, null, null, Optional.empty()));
+
+        try {
+            assertThat(execution1.getState().isRunning()).isTrue();
+            assertThat(execution2.getState().getCurrent()).isEqualTo(Type.QUEUED);
+            assertThat(execution3.getState().getCurrent()).isEqualTo(Type.QUEUED);
+
+            // we kill execution 2, execution 3 should not run
+            killQueue.emit(ExecutionKilledExecution
+                .builder()
+                .state(ExecutionKilled.State.REQUESTED)
+                .executionId(execution2.getId())
+                .isOnKillCascade(true)
+                .tenantId(MAIN_TENANT)
+                .build()
+            );
+
+            Execution killed = runnerUtils.awaitExecution(e -> e.getState().getCurrent().equals(Type.KILLED), execution2);
+            assertThat(killed.getState().getCurrent()).isEqualTo(Type.KILLED);
+            assertThat(killed.getState().getHistories().stream().noneMatch(h -> h.getState() == Type.RUNNING)).isTrue();
+
+            // we now check that execution 3 is still queued
+            Thread.sleep(100); // wait a little to be 100% sure
+            Execution queued = runnerUtils.awaitExecution(e -> e.getState().isQueued(), execution3);
+            assertThat(queued.getState().getCurrent()).isEqualTo(Type.QUEUED);
+        } finally {
+            // kill everything to avoid dangling executions
+            runnerUtils.killExecution(execution1);
+            runnerUtils.killExecution(execution2);
+            runnerUtils.killExecution(execution3);
+
+            // await that they are all terminated, note that as KILLED is received twice, some messages would still be pending, but this is the best we can do
+            runnerUtils.awaitFlowExecutionNumber(3, MAIN_TENANT, NAMESPACE, "flow-concurrency-queue-killed");
+        }
     }
 
     private URI storageUpload(String tenantId) throws URISyntaxException, IOException {

--- a/core/src/test/resources/flows/valids/flow-concurrency-queue-killed.yml
+++ b/core/src/test/resources/flows/valids/flow-concurrency-queue-killed.yml
@@ -1,0 +1,11 @@
+id: flow-concurrency-queue-killed
+namespace: io.kestra.tests
+
+concurrency:
+  behavior: QUEUE
+  limit: 1
+
+tasks:
+  - id: sleep
+    type: io.kestra.plugin.core.flow.Sleep
+    duration: PT1M

--- a/jdbc-h2/src/test/java/io/kestra/runner/h2/H2RunnerConcurrencyTest.java
+++ b/jdbc-h2/src/test/java/io/kestra/runner/h2/H2RunnerConcurrencyTest.java
@@ -1,0 +1,6 @@
+package io.kestra.runner.h2;
+
+import io.kestra.core.runners.AbstractRunnerConcurrencyTest;
+
+public class H2RunnerConcurrencyTest extends AbstractRunnerConcurrencyTest {
+}

--- a/jdbc-mysql/src/test/java/io/kestra/runner/mysql/MysqlRunnerConcurrencyTest.java
+++ b/jdbc-mysql/src/test/java/io/kestra/runner/mysql/MysqlRunnerConcurrencyTest.java
@@ -1,0 +1,6 @@
+package io.kestra.runner.mysql;
+
+import io.kestra.core.runners.AbstractRunnerConcurrencyTest;
+
+public class MysqlRunnerConcurrencyTest extends AbstractRunnerConcurrencyTest {
+}

--- a/jdbc-postgres/src/test/java/io/kestra/runner/postgres/PostgresRunnerConcurrencyTest.java
+++ b/jdbc-postgres/src/test/java/io/kestra/runner/postgres/PostgresRunnerConcurrencyTest.java
@@ -1,0 +1,6 @@
+package io.kestra.runner.postgres;
+
+import io.kestra.core.runners.AbstractRunnerConcurrencyTest;
+
+public class PostgresRunnerConcurrencyTest extends AbstractRunnerConcurrencyTest {
+}

--- a/jdbc/src/main/java/io/kestra/jdbc/runner/JdbcExecutor.java
+++ b/jdbc/src/main/java/io/kestra/jdbc/runner/JdbcExecutor.java
@@ -176,7 +176,7 @@ public class JdbcExecutor implements ExecutorInterface {
 
     @Inject
     private AbstractJdbcWorkerJobRunningRepository workerJobRunningRepository;
-    
+
     @Inject
     private SLAMonitorStorage slaMonitorStorage;
 
@@ -1205,16 +1205,17 @@ public class JdbcExecutor implements ExecutorInterface {
 
                 // check if there exist a queued execution and submit it to the execution queue
                 if (executor.getFlow().getConcurrency() != null) {
-
-                    // decrement execution concurrency limit
                     // if an execution was queued but never running, it would have never been counted inside the concurrency limit and should not lead to popping a new queued execution
-                    // this could only happen for KILLED execution.
                     boolean queuedThenKilled = execution.getState().getCurrent() == State.Type.KILLED
                         && execution.getState().getHistories().stream().anyMatch(h -> h.getState().isQueued())
-                        && execution.getState().getHistories().stream().noneMatch(h -> h.getState().isRunning());
+                        && execution.getState().getHistories().stream().noneMatch(h -> h.getState().onlyRunning());
+                    // if an execution was FAILED or CANCELLED due to concurrency limit exceeded, it would have never been counter inside the concurrency limit and should not lead to popping a new queued execution
                     boolean concurrencyShortCircuitState = Concurrency.possibleTransitions(execution.getState().getCurrent())
                         && execution.getState().getHistories().get(execution.getState().getHistories().size() - 2).getState().isCreated();
-                    if (!queuedThenKilled && !concurrencyShortCircuitState) {
+                    // as we may receive multiple time killed execution (one when we kill it, then one for each running worker task), we limit to the first we receive: when the state transitionned from KILLING to KILLED
+                    boolean killingThenKilled = execution.getState().getCurrent().isKilled() && executor.getOriginalState() == State.Type.KILLING;
+                    if (!queuedThenKilled && !concurrencyShortCircuitState && (!execution.getState().getCurrent().isKilled() || killingThenKilled)) {
+                        // decrement execution concurrency limit and pop a new queued execution if needed
                         concurrencyLimitStorage.decrement(executor.getFlow());
 
                         if (executor.getFlow().getConcurrency().getBehavior() == Concurrency.Behavior.QUEUE) {


### PR DESCRIPTION
### ✨ Description

Here are the three key updates to the toExecution method：

Regarding the judgment of the queueThenKilled state, the implementation of the h.getState().onlyRunning() method should only filter executions in the running state（exclude killing state）.
Concerning the concurrency limit, when processing execution instance in the queueThenKilled state, add logic to determine whether the execution's current state is killed and not​ triggered by a workerTaskResult message.
When checking the concurrency behavior, it is necessary to add a check for concurrency limit breaches (out-of-bounds judgment).

### 🔗 Related Issue

Closes https://github.com/kestra-io/kestra/issues/13211
