### PR TITLE
fix: Filter by 'not equals' in query 

### DIFF
--- a/core/src/test/java/io/kestra/core/repositories/AbstractFlowRepositoryTest.java
+++ b/core/src/test/java/io/kestra/core/repositories/AbstractFlowRepositoryTest.java
@@ -197,11 +197,6 @@ public abstract class AbstractFlowRepositoryTest {
             .labels(Label.from(Map.of("foo", "baz")))
             .build();
 
-        FlowWithSource flowWithDifferentLabel1 =builder(tenant)
-            .id("flow-with-different-label1")
-            .labels(Label.from(Map.of("foo", "baz")))
-            .build();
-
         try {
             flowWithLabel = flowRepository.create(GenericFlow.of(flowWithLabel));
             flowWithoutLabel = flowRepository.create(GenericFlow.of(flowWithoutLabel));

--- a/core/src/test/java/io/kestra/core/repositories/AbstractFlowRepositoryTest.java
+++ b/core/src/test/java/io/kestra/core/repositories/AbstractFlowRepositoryTest.java
@@ -180,6 +180,56 @@ public abstract class AbstractFlowRepositoryTest {
     }
 
     @Test
+    void shouldFilterFlowsWithNotEqualsLabelOperator() {
+        String tenant = TestsUtils.randomTenant(this.getClass().getSimpleName());
+
+        FlowWithSource flowWithLabel = builder(tenant)
+            .id("flow-with-label")
+            .labels(Label.from(Map.of("foo", "bar")))
+            .build();
+
+        FlowWithSource flowWithoutLabel = builder(tenant)
+            .id("flow-without-label")
+            .build();
+
+        FlowWithSource flowWithDifferentLabel =builder(tenant)
+            .id("flow-with-different-label")
+            .labels(Label.from(Map.of("foo", "baz")))
+            .build();
+
+        FlowWithSource flowWithDifferentLabel1 =builder(tenant)
+            .id("flow-with-different-label1")
+            .labels(Label.from(Map.of("foo", "baz")))
+            .build();
+
+        try {
+            flowWithLabel = flowRepository.create(GenericFlow.of(flowWithLabel));
+            flowWithoutLabel = flowRepository.create(GenericFlow.of(flowWithoutLabel));
+            flowWithDifferentLabel = flowRepository.create(GenericFlow.of(flowWithDifferentLabel));
+
+            // Filter: Labels NOT_EQUALS foo:bar
+            // Should return: flow-without-label and flow-with-different-label
+            QueryFilter filter = QueryFilter.builder()
+                .field(QueryFilter.Field.LABELS)
+                .operation(QueryFilter.Op.NOT_EQUALS)
+                .value(Map.of("foo", "bar"))
+                .build();
+
+            ArrayListTotal<Flow> results = flowRepository.find(Pageable.UNPAGED, tenant, List.of(filter));
+
+            assertThat(results).hasSize(2);
+            assertThat(results)
+                .extracting(Flow::getId)
+                .containsExactlyInAnyOrder("flow-without-label", "flow-with-different-label");
+
+        } finally {
+            deleteFlow(flowWithLabel);
+            deleteFlow(flowWithoutLabel);
+            deleteFlow(flowWithDifferentLabel);
+        }
+    }
+
+    @Test
     void findByIdWithoutAcl() {
         String tenant = TestsUtils.randomTenant(this.getClass().getSimpleName());
         FlowWithSource flow = builder(tenant)

--- a/jdbc-h2/src/main/java/io/kestra/repository/h2/H2FlowRepositoryService.java
+++ b/jdbc-h2/src/main/java/io/kestra/repository/h2/H2FlowRepositoryService.java
@@ -46,7 +46,7 @@ public abstract class H2FlowRepositoryService {
                 Field<String> valueField = DSL.field("JQ_STRING(\"value\", '.labels[]? | select(.key == \"" + key + "\") | .value')", String.class);
                 Condition condition = switch (operation) {
                     case EQUALS -> value == null ? valueField.isNull() : valueField.eq((String) value);
-                    case NOT_EQUALS -> value == null ? valueField.isNotNull() : valueField.ne((String) value);
+                    case NOT_EQUALS -> value == null ? valueField.isNotNull() : valueField.isNull().or(valueField.ne((String) value));
                     default -> throw new UnsupportedOperationException("Unsupported operation: " + operation);
                 };
 

--- a/jdbc-mysql/src/main/java/io/kestra/repository/mysql/MysqlFlowRepositoryService.java
+++ b/jdbc-mysql/src/main/java/io/kestra/repository/mysql/MysqlFlowRepositoryService.java
@@ -11,6 +11,7 @@ import org.jooq.impl.DSL;
 import java.util.*;
 
 import static io.kestra.core.models.QueryFilter.Op.EQUALS;
+import static io.kestra.core.models.QueryFilter.Op.NOT_EQUALS;
 
 public abstract class MysqlFlowRepositoryService {
     public static Condition findCondition(AbstractJdbcRepository<? extends FlowInterface> jdbcRepository, String query, Map<String, String> labels) {
@@ -42,7 +43,14 @@ public abstract class MysqlFlowRepositoryService {
                 Field<Boolean> valueField = DSL.field("JSON_CONTAINS(value, JSON_ARRAY(JSON_OBJECT('key', '" + key + "', 'value', '" + value + "')), '$.labels')", Boolean.class);
                if(operation.equals(EQUALS))
                 conditions.add(valueField.eq(value != null));
+               else if (operation.equals(NOT_EQUALS)) {
+                   // For NOT_EQUALS: match flows where the label key doesn't exist OR the label value is different
+                   String extractValueSqlTemplate = "JSON_UNQUOTE(JSON_EXTRACT(`value`, REPLACE(JSON_UNQUOTE(JSON_SEARCH(`value`, 'one', {0}, NULL, '$.labels[*].key')), '.key', '.value')))";
+                   Field<String> extractedValue = DSL.field(extractValueSqlTemplate, String.class, DSL.val(key));
 
+                   conditions.add(extractedValue.isNull().or(extractedValue.ne(DSL.val(value, String.class)))
+                   );
+               }
             });
         }
         return conditions.isEmpty() ? DSL.trueCondition() : DSL.and(conditions);

--- a/jdbc-postgres/src/main/java/io/kestra/repository/postgres/PostgresFlowRepositoryService.java
+++ b/jdbc-postgres/src/main/java/io/kestra/repository/postgres/PostgresFlowRepositoryService.java
@@ -4,6 +4,7 @@ import io.kestra.core.models.QueryFilter;
 import io.kestra.core.models.flows.FlowInterface;
 import io.kestra.jdbc.AbstractJdbcRepository;
 import org.jooq.Condition;
+import org.jooq.Field;
 import org.jooq.impl.DSL;
 
 import java.util.ArrayList;
@@ -44,8 +45,11 @@ public abstract class PostgresFlowRepositoryService {
                 String sql = "value -> 'labels' @> '[{\"key\":\"" + key + "\", \"value\":\"" + value + "\"}]'";
                 if (operation.equals(EQUALS)) {
                     conditions.add(DSL.condition(sql));
-                } else {
-                    conditions.add(DSL.not(DSL.condition(sql)));
+                } else if (operation.equals(QueryFilter.Op.NOT_EQUALS)) {
+                    // For NOT_EQUALS: match flows where the label key doesn't exist OR the label value is different
+                    String extractValueSql = "(SELECT jsonb_path_query_first(value, '$.labels[*] ? (@.key == \"" + key + "\").value')#>>'{}')";
+                    Field<String> extractedValue = DSL.field(extractValueSql, String.class);
+                    conditions.add(extractedValue.isNull().or(extractedValue.ne((String) value)));
                 }
             });
         }


### PR DESCRIPTION
---

### ✨ Description
Introduces support for the not_equals filter, which was previously unimplemented in the query logic. 

### 🔗 Related Issue
Fix: https://github.com/kestra-io/kestra/issues/13241

Screen Record:

https://github.com/user-attachments/assets/205c627f-c61a-4d45-993b-c8474743a18e


