### PR TITLE
Simplify ValidationError.vue translations by using $t in template

### DIFF
--- a/ui/src/components/flows/ValidationError.vue
+++ b/ui/src/components/flows/ValidationError.vue
@@ -22,7 +22,7 @@
                     <el-header>
                         <AlertCircle class="align-middle text-danger" />
                         <span class="align-middle">
-                            {{ t("error detected") }}
+                            {{ $t("error detected") }}
                         </span>
                     </el-header>
                     <el-main v-for="error in errors" :key="error">{{ error }}</el-main>
@@ -50,7 +50,7 @@
                     <el-header>
                         <Alert class="align-middle text-warning" />
                         <span class="align-middle">
-                            {{ t("warning detected") }}
+                            {{ $t("warning detected") }}
                         </span>
                     </el-header>
                     <el-main>
@@ -86,7 +86,7 @@
                     <el-header>
                         <Alert class="align-middle text-info" />
                         <span class="align-middle">
-                            {{ t("informative notice") }}
+                            {{ $t("informative notice") }}
                         </span>
                     </el-header>
                     <el-main>{{ infos.join("<\n") }}</el-main>
@@ -94,7 +94,7 @@
             </template>
             <el-button v-bind="$attrs" :link="link" :size="size" type="default" class="info">
                 <Alert class="text-info" />
-                <span class="text-info label">{{ t("informative notice") }}</span>
+                <span class="text-info label">{{ $t("informative notice") }}</span>
             </el-button>
         </el-tooltip>
     </span>
@@ -105,9 +105,6 @@
     import CheckBoldIcon from "vue-material-design-icons/CheckBold.vue";
     import AlertCircle from "vue-material-design-icons/AlertCircle.vue";
     import Alert from "vue-material-design-icons/Alert.vue";
-    import {useI18n} from "vue-i18n";
-
-    const {t} = useI18n();
 
     defineOptions({
         inheritAttrs: false,


### PR DESCRIPTION
### ✨ Description

What does this PR change?  
This PR simplifies the translation implementation in ValidationError.vue by using $t() directly in the template section instead of extracting the t function from useI18n() in the script section. 
### 🔗 Related Issue
Closes https://github.com/kestra-io/kestra/issues/13258

### 🎨 Frontend Checklist

_If this PR does not include any frontend changes, delete this entire section._

- [ ] Code builds without errors (`npm run build`)
- [ ] All existing E2E tests pass (`npm run test:e2e`)
- [ ] Screenshots or video recordings attached showing the `UI` changes