### PR TITLE
refactor(ui): simplify EditorButtons translations using $t

### DIFF
--- a/ui/src/components/inputs/EditorButtons.vue
+++ b/ui/src/components/inputs/EditorButtons.vue
@@ -3,7 +3,7 @@
         <el-dropdown>
             <el-button type="default" :disabled="isReadOnly">
                 <DotsVertical title="" />
-                {{ t("actions") }}
+                {{ $t("actions") }}
             </el-button>
             <template #dropdown>
                 <el-dropdown-menu class="m-dropdown-menu">
@@ -13,7 +13,7 @@
                         size="large"
                         @click="forwardEvent('export')"
                     >
-                        {{ t("flow_export") }}
+                        {{ $t("flow_export") }}
                     </el-dropdown-item>
                     <el-dropdown-item
                         v-if="!isCreating && canDelete"
@@ -21,7 +21,7 @@
                         size="large"
                         @click="forwardEvent('delete-flow', $event)"
                     >
-                        {{ t("delete") }}
+                        {{ $t("delete") }}
                     </el-dropdown-item>
 
                     <el-dropdown-item
@@ -30,12 +30,13 @@
                         size="large"
                         @click="forwardEvent('copy', $event)"
                     >
-                        {{ t("copy") }}
+                        {{ $t("copy") }}
                     </el-dropdown-item>
                 </el-dropdown-menu>
             </template>
         </el-dropdown>
     </div>
+
     <div>
         <el-button
             v-if="isNamespace || isAllowedEdit"
@@ -46,14 +47,15 @@
             :disabled="hasErrors || !canSave"
             class="edit-flow-save-button"
         >
-            {{ t("save") }}
+            {{ $t("save") }}
         </el-button>
     </div>
 </template>
+
 <script setup lang="ts">
+
     import {computed} from "vue";
 
-    import {useI18n} from "vue-i18n";
     import DotsVertical from "vue-material-design-icons/DotsVertical.vue";
 
     import Delete from "vue-material-design-icons/Delete.vue";
@@ -63,8 +65,6 @@
     import {usePlaygroundStore} from "../../stores/playground";
 
     const playgroundStore = usePlaygroundStore();
-
-    const {t} = useI18n();
 
     const props = defineProps<{
         isCreating: boolean;

--- a/ui/src/components/inputs/EditorButtons.vue
+++ b/ui/src/components/inputs/EditorButtons.vue
@@ -36,7 +36,6 @@
             </template>
         </el-dropdown>
     </div>
-
     <div>
         <el-button
             v-if="isNamespace || isAllowedEdit"
@@ -51,9 +50,7 @@
         </el-button>
     </div>
 </template>
-
 <script setup lang="ts">
-
     import {computed} from "vue";
 
     import DotsVertical from "vue-material-design-icons/DotsVertical.vue";


### PR DESCRIPTION
### ✨ Description

This PR refactors `EditorButtons.vue` to simplify how translations are handled.
- Removed the manual import and usage of `useI18n` from the `<script>` section.
- Updated the `<template>` to use the global `$t` helper for translations instead of the local `t` variable.

This cleans up unnecessary code while maintaining the exact same UI functionality.

### UI after changes:
<img width="1710" height="985" alt="Issue_#13260" src="https://github.com/user-attachments/assets/ebe3e3a2-a012-4fd0-92a9-8c49b41e75c2" />

### 🔗 Related Issue

Closes #13260

### 🎨 Frontend Checklist

- [x] Code builds without errors (`npm run build`)
- [ ] All existing E2E tests pass (`npm run test:e2e`)
- [x] Screenshots or video recordings attached showing the `UI` changes
