### PR TITLE
fix(executions): support Download content dispositions with brackets

### DIFF
--- a/core/src/main/java/io/kestra/plugin/core/http/Download.java
+++ b/core/src/main/java/io/kestra/plugin/core/http/Download.java
@@ -20,6 +20,8 @@ import java.io.BufferedOutputStream;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.net.URI;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
@@ -123,7 +125,11 @@ public class Download extends AbstractHttp implements RunnableTask<Download.Outp
                     String contentDisposition = response.getHeaders().firstValue("Content-Disposition").orElseThrow();
                     rFilename = filenameFromHeader(runContext, contentDisposition);
                     if (rFilename != null) {
+                        URLEncoder.encode(rFilename, StandardCharsets.UTF_8);
                         rFilename = rFilename.replace(' ', '+');
+                        // brackets are IPv6 reserved characters
+                        rFilename = rFilename.replace("[", "%5B");
+                        rFilename = rFilename.replace("]", "%5D");
                     }
                 }
             }

--- a/core/src/test/java/io/kestra/plugin/core/http/DownloadTest.java
+++ b/core/src/test/java/io/kestra/plugin/core/http/DownloadTest.java
@@ -252,8 +252,25 @@ class DownloadTest {
 
         Download.Output output = task.run(runContext);
 
-        assertThat(output.getUri().toString()).doesNotContain("/secure-path/");
         assertThat(output.getUri().toString()).endsWith("file.with+spaces.txt");
+    }
+
+    @Test
+    void contentDispositionWithBrackets() throws Exception {
+        EmbeddedServer embeddedServer = applicationContext.getBean(EmbeddedServer.class);
+        embeddedServer.start();
+
+        Download task = Download.builder()
+            .id(DownloadTest.class.getSimpleName())
+            .type(DownloadTest.class.getName())
+            .uri(Property.ofValue(embeddedServer.getURI() + "/content-disposition-with-brackets"))
+            .build();
+
+        RunContext runContext = TestsUtils.mockRunContext(this.runContextFactory, task, ImmutableMap.of());
+
+        Download.Output output = task.run(runContext);
+
+        assertThat(output.getUri().toString()).endsWith("file.with%5B%5Dbrackets.txt");
     }
 
     @Controller()
@@ -301,6 +318,11 @@ class DownloadTest {
         public HttpResponse<byte[]> contentDispositionWithSpaceAfterDot() {
             return HttpResponse.ok("Hello World".getBytes())
                 .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=\"file.with spaces.txt\"");
+        }
+        @Get("content-disposition-with-brackets")
+        public HttpResponse<byte[]> contentDispositionWithBrackets() {
+            return HttpResponse.ok("Hello World".getBytes())
+                .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=\"file.with[]brackets.txt\"");
         }
     }
 }


### PR DESCRIPTION
By escaping them with %5B and %5D.

Fixes #13299