### PR TITLE
fix: missing tenant id for flow creation in AbstractSchedulerTest

### DIFF
--- a/scheduler/src/test/java/io/kestra/scheduler/AbstractSchedulerTest.java
+++ b/scheduler/src/test/java/io/kestra/scheduler/AbstractSchedulerTest.java
@@ -36,6 +36,8 @@ import java.util.Optional;
 
 @KestraTest(rebuildContext = true)
 abstract public class AbstractSchedulerTest {
+    public final static String TENANT_ID = "main";
+
     @Inject
     protected ApplicationContext applicationContext;
 
@@ -74,7 +76,7 @@ abstract public class AbstractSchedulerTest {
      */
     @Deprecated
     protected static FlowWithSource createFlow(List<AbstractTrigger> triggers) {
-        return createFlow(null, triggers);
+        return createFlow(TENANT_ID, triggers);
     }
 
     protected static FlowWithSource createFlow(String tenantId, List<AbstractTrigger> triggers) {

--- a/scheduler/src/test/java/io/kestra/scheduler/SchedulerConditionTest.java
+++ b/scheduler/src/test/java/io/kestra/scheduler/SchedulerConditionTest.java
@@ -77,6 +77,7 @@ class SchedulerConditionTest extends AbstractSchedulerTest {
         flowRepository.create(GenericFlow.of(flow));
 
         Trigger trigger = Trigger.builder()
+            .tenantId(TENANT_ID)
             .namespace(flow.getNamespace())
             .flowId(flow.getId())
             .triggerId("hourly")

--- a/scheduler/src/test/java/io/kestra/scheduler/SchedulerScheduleOnDatesTest.java
+++ b/scheduler/src/test/java/io/kestra/scheduler/SchedulerScheduleOnDatesTest.java
@@ -90,6 +90,7 @@ public class SchedulerScheduleOnDatesTest extends AbstractSchedulerTest {
 
         Trigger trigger = Trigger
             .builder()
+            .tenantId(TENANT_ID)
             .triggerId("schedule")
             .flowId(flow.getId())
             .namespace(flow.getNamespace())
@@ -145,6 +146,7 @@ public class SchedulerScheduleOnDatesTest extends AbstractSchedulerTest {
         ZonedDateTime lastDate = ZonedDateTime.now().minusHours(3L);
         Trigger lastTrigger = Trigger
             .builder()
+            .tenantId(TENANT_ID)
             .triggerId("recoverALLMissing")
             .flowId(flow.getId())
             .namespace(flow.getNamespace())
@@ -196,6 +198,7 @@ public class SchedulerScheduleOnDatesTest extends AbstractSchedulerTest {
         ZonedDateTime lastDate = ZonedDateTime.now().minusHours(3L);
         Trigger lastTrigger = Trigger
             .builder()
+            .tenantId(TENANT_ID)
             .triggerId("recoverLASTMissing")
             .flowId(flow.getId())
             .namespace(flow.getNamespace())
@@ -248,6 +251,7 @@ public class SchedulerScheduleOnDatesTest extends AbstractSchedulerTest {
         ZonedDateTime lastDate = ZonedDateTime.now().minusHours(3L);
         Trigger lastTrigger = Trigger
             .builder()
+            .tenantId(TENANT_ID)
             .triggerId("recoverNONEMissing")
             .flowId(flow.getId())
             .namespace(flow.getNamespace())


### PR DESCRIPTION
Test `shouldErrorForAbsentWorkerGroup` is failing, and we can see in the log `Unable to find flow null/io.kestra.unittest/3Pjikm2TowhIOISA0kx0I`