### PR TITLE
fix: unify label deserialization for numeric values in array form

### DIFF
--- a/core/src/main/java/io/kestra/core/serializers/ListOrMapOfLabelDeserializer.java
+++ b/core/src/main/java/io/kestra/core/serializers/ListOrMapOfLabelDeserializer.java
@@ -26,7 +26,14 @@ public class ListOrMapOfLabelDeserializer extends JsonDeserializer<List<Label>> 
         else if (p.hasToken(JsonToken.START_ARRAY)) {
             // deserialize as list
             List<Map<String, String>> ret = ctxt.readValue(p, List.class);
-            return ret.stream().map(map -> new Label(map.get("key"), map.get("value"))).toList();
+            return ret.stream().map(map -> {
+                Object value = map.get("value");
+                if (isAllowedType(value)) {
+                    return new Label(map.get("key"), String.valueOf(value));
+                } else {
+                    throw new IllegalArgumentException("Unsupported type for key: " + map.get("key") + ", value: " + value);
+                }
+            }).toList();
         }
         else if (p.hasToken(JsonToken.START_OBJECT)) {
             // deserialize as map

--- a/core/src/test/java/io/kestra/core/serializers/YamlParserTest.java
+++ b/core/src/test/java/io/kestra/core/serializers/YamlParserTest.java
@@ -3,6 +3,7 @@ package io.kestra.core.serializers;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.kestra.core.models.flows.Flow;
+import io.kestra.core.models.flows.FlowWithSource;
 import io.kestra.core.models.flows.Input;
 import io.kestra.core.models.flows.Type;
 import io.kestra.core.models.flows.input.StringInput;
@@ -32,6 +33,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 @KestraTest
 class YamlParserTest {
     private static final ObjectMapper MAPPER = JacksonMapper.ofJson();
+    private static final ObjectMapper OBJECT_MAPPER = JacksonMapper.ofYaml().copy();
 
     @Inject
     private ModelValidator modelValidator;
@@ -233,6 +235,29 @@ class YamlParserTest {
 
         assertThat(exception.getConstraintViolations().size()).isEqualTo(1);
         assertThat(new ArrayList<>(exception.getConstraintViolations()).getFirst().getMessage()).contains("Duplicate field 'variables.tf'");
+    }
+
+    @Test
+    void vaildLabelsParser() throws IOException {
+        Flow flow = parse("flows/valids/labels-deserialization.yaml");
+        // like change execution state api,Serialize flow to YAML/JSON string
+        String s = OBJECT_MAPPER.writeValueAsString(flow);
+        assertThat(s).isEqualTo("id: full\n" +
+            "namespace: io.kestra.tests\n" +
+            "disabled: false\n" +
+            "deleted: false\n" +
+            "labels:\n" +
+            "- key: key1\n" +
+            "  value: 123\n" +
+            "tasks:\n" +
+            "- id: t1\n" +
+            "  type: io.kestra.plugin.core.log.Log\n" +
+            "  message: \"{{ task.id }}\"\n");
+        Map<String, Object> mapFlow = OBJECT_MAPPER.readValue(s, JacksonMapper.MAP_TYPE_REFERENCE);
+        // Parse into FlowWithSource (simulates state update scenario)
+        FlowWithSource parse = YamlParser.parse(mapFlow, FlowWithSource.class, false);
+
+        assertThat(parse.getLabels().size()).isEqualTo(1);;
     }
 
     private Flow parse(String path) {

--- a/core/src/test/java/io/kestra/core/serializers/YamlParserTest.java
+++ b/core/src/test/java/io/kestra/core/serializers/YamlParserTest.java
@@ -242,7 +242,7 @@ class YamlParserTest {
         Flow flow = parse("flows/valids/labels-deserialization.yaml");
         // like change execution state api,Serialize flow to YAML/JSON string
         String s = OBJECT_MAPPER.writeValueAsString(flow);
-        assertThat(s).isEqualTo("id: full\n" +
+        assertThat(s).isEqualTo("id: labels-deserialization\n" +
             "namespace: io.kestra.tests\n" +
             "disabled: false\n" +
             "deleted: false\n" +

--- a/core/src/test/resources/flows/valids/labels-deserialization.yaml
+++ b/core/src/test/resources/flows/valids/labels-deserialization.yaml
@@ -1,0 +1,17 @@
+id: full
+namespace: io.kestra.tests
+labels:
+  key1: 123
+
+#triggers:
+#- type: schedule
+#  expression: 42 4 1 * *
+#  backfill:
+#    start: 2018-01-01
+#    depend-on-past: false
+#
+
+tasks:
+  - id: t1
+    type: io.kestra.plugin.core.log.Log
+    message: "{{ task.id }}"

--- a/core/src/test/resources/flows/valids/labels-deserialization.yaml
+++ b/core/src/test/resources/flows/valids/labels-deserialization.yaml
@@ -1,4 +1,4 @@
-id: full
+id: labels-deserialization
 namespace: io.kestra.tests
 labels:
   key1: 123


### PR DESCRIPTION
Closes https://github.com/kestra-io/kestra/issues/13359.

## 🐛 Background

When updating an `Execution` state, deserialization fails if a label contains a
numeric value (e.g. `"value": 123`):


This does not happen in normal flow loading, which is why the issue was tricky to locate.

---

## 🔍 Root Cause

Kestra deserializes labels from **two different sources**, and they behave inconsistently:

| Scenario | Serialization source | Serialized form | Deserialization branch | Type conversion |
|---------|----------------------|------------------|-------------------------|----------------|
| **Flow loading** | `flow.source`  | `Map<String, Object>` | `START_OBJECT` | ✔ converts allowed types (String/Number/Boolean → String) |
| **Execution state update** | Flow object → JSON string | `List<Map<String, String>>` | `START_ARRAY` | ❌ assumes all values are Strings |

When updating execution state, numeric values remain as `Integer`, but the `START_ARRAY` branch tries to treat them as `String`, causing a cast failure.

---

## 💡 What This PR Does

This PR **unifies both code paths** by adding the same allowed-type conversion logic
to the `START_ARRAY` branch as used in the `START_OBJECT` branch.

This ensures:

- consistent behavior regardless of how labels are serialized  
- numeric / boolean values no longer cause deserialization failures  
- safer handling of future cases where labels are serialized as a list

---

## ✔️ Verification

- Tested with numeric label values (`Integer`, `Long`, `Double`, `Boolean`)  
- Execution state update no longer throws deserialization errors  
- Existing behavior for flows loaded from `flow.source` remains unchanged

---

## 🙏 Request for Review

Please help confirm that this behavior is desired.  
It makes the two deserialization paths consistent and prevents real production failures in state updates.
