### PR TITLE
fixes #13282, the State History on the Execution- timeline

### DIFF
--- a/ui/src/components/executions/overview/components/sidebar/Timeline.vue
+++ b/ui/src/components/executions/overview/components/sidebar/Timeline.vue
@@ -79,6 +79,10 @@
         }
     }
 
+    & :deep(.el-timeline-item__content) {
+        color: var(--ks-content-primary);
+    }
+
     & :deep(.el-timeline-item__timestamp) {
         position: absolute;
         top: 0;
@@ -87,10 +91,6 @@
         margin-top: 0;
         text-align: right;
         color: var(--ks-content-tertiary);
-    }
-
-    & :deep(.el-timeline-item__content) {
-        color: var(--ks-content-primary);
     }
 
     & :deep(.el-timeline-item__tail) {

--- a/ui/src/components/executions/overview/components/sidebar/Timeline.vue
+++ b/ui/src/components/executions/overview/components/sidebar/Timeline.vue
@@ -23,7 +23,6 @@
     import type {Histories} from "../../../../../stores/executions";
 
     import {getSchemeValue} from "../../../../../utils/scheme";
-    import {storageKeys} from "../../../../../utils/constants";
 
     import moment from "moment";
 
@@ -31,8 +30,9 @@
 
     const props = defineProps<{ histories: Histories[] }>();
 
-    const F = localStorage.getItem(storageKeys.DATE_FORMAT_STORAGE_KEY) ?? "llll";
-    const formatDate = (date: string) => moment(date)?.format(F === "llll" ? "YYYY-MM-DD HH:mm:ss.SSS" : F) ?? date;
+    const formatDate = (date: string) => {
+        return moment(date)?.format("YYYY-MM-DD HH:mm:ss.SSS") ?? date;
+    };
 </script>
 
 <style scoped lang="scss">
@@ -67,74 +67,38 @@
 }
 
 .el-timeline {
-    padding-left: 200px;
+    padding-left: 50%;
     margin-top: $spacer;
 
     & :deep(.el-timeline-item) {
         padding-bottom: $spacer;
-        position: relative;
+
+        & * {
+            line-height: 1.5;
+            font-size: $font-size-sm;
+        }
     }
 
     & :deep(.el-timeline-item__timestamp) {
         position: absolute;
+        top: 0;
         left: -210px;
         width: 190px;
-        text-align: right;
-        top: -3px;
         margin-top: 0;
-        line-height: 1.5;
-        font-size: $font-size-sm;
+        text-align: right;
         color: var(--ks-content-tertiary);
-        white-space: nowrap;
-        overflow: hidden;
-        text-overflow: ellipsis;
     }
 
     & :deep(.el-timeline-item__content) {
-        font-size: $font-size-sm;
         color: var(--ks-content-primary);
-        line-height: 1.5;
-        top: -3px;
-        position: relative;
-        min-height: auto;
-
-        .timeline-state {
-            font-weight: bold;
-        }
-    }
-
-    & :deep(.el-timeline-item__node) {
-        position: absolute;
-        z-index: 2;
-        top: 2px;
-        left: -1px;
-        width: 10px;
-        height: 10px;
     }
 
     & :deep(.el-timeline-item__tail) {
-        position: absolute;
-        display: block !important;
-        z-index: 0;
-        left: 3px;
-        top: 0;
-        bottom: 0;
-        height: 100%;
-        width: 2px;
-        background-color: var(--ks-border-color, #5c5c5c);
-    }
-
-    & :deep(.el-timeline-item:first-child .el-timeline-item__tail) {
-        top: 7px;
-        height: calc(100% - 7px);
-    }
-
-    & :deep(.el-timeline-item:last-child .el-timeline-item__tail) {
-        display: none !important;
-    }
-
-    .el-collapse-item {
-        background-color: transparent;
+        height: inherit;
+        top: 40%;
+        bottom: 10%;
+        left: 4.5px;
+        border-left-width: 1px;
     }
 }
 </style>

--- a/ui/src/components/executions/overview/components/sidebar/Timeline.vue
+++ b/ui/src/components/executions/overview/components/sidebar/Timeline.vue
@@ -32,7 +32,7 @@
     const props = defineProps<{ histories: Histories[] }>();
 
     const F = localStorage.getItem(storageKeys.DATE_FORMAT_STORAGE_KEY) ?? "llll";
-    const formatDate = (date: string) => moment(date)?.format(F) ?? date;
+    const formatDate = (date: string) => moment(date)?.format(F === "llll" ? "YYYY-MM-DD HH:mm:ss.SSS" : F) ?? date;
 </script>
 
 <style scoped lang="scss">
@@ -67,25 +67,74 @@
 }
 
 .el-timeline {
+    padding-left: 200px;
+    margin-top: $spacer;
+
     & :deep(.el-timeline-item) {
         padding-bottom: $spacer;
+        position: relative;
+    }
+
+    & :deep(.el-timeline-item__timestamp) {
+        position: absolute;
+        left: -210px;
+        width: 190px;
+        text-align: right;
+        top: -3px;
+        margin-top: 0;
+        line-height: 1.5;
+        font-size: $font-size-sm;
+        color: var(--ks-content-tertiary);
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
     }
 
     & :deep(.el-timeline-item__content) {
         font-size: $font-size-sm;
         color: var(--ks-content-primary);
+        line-height: 1.5;
+        top: -3px;
+        position: relative;
+        min-height: auto;
+
+        .timeline-state {
+            font-weight: bold;
+        }
     }
 
-    & :deep(.el-timeline-item__timestamp) {
-        margin-top: calc($spacer / 4);
-        color: var(--ks-content-tertiary);
+    & :deep(.el-timeline-item__node) {
+        position: absolute;
+        z-index: 2;
+        top: 2px;
+        left: -1px;
+        width: 10px;
+        height: 10px;
     }
 
     & :deep(.el-timeline-item__tail) {
-        height: inherit;
-        top: 30%;
-        bottom: 10%;
-        border-left-width: 1px;
+        position: absolute;
+        display: block !important;
+        z-index: 0;
+        left: 3px;
+        top: 0;
+        bottom: 0;
+        height: 100%;
+        width: 2px;
+        background-color: var(--ks-border-color, #5c5c5c);
+    }
+
+    & :deep(.el-timeline-item:first-child .el-timeline-item__tail) {
+        top: 7px;
+        height: calc(100% - 7px);
+    }
+
+    & :deep(.el-timeline-item:last-child .el-timeline-item__tail) {
+        display: none !important;
+    }
+
+    .el-collapse-item {
+        background-color: transparent;
     }
 }
 </style>


### PR DESCRIPTION
Closes https://github.com/kestra-io/kestra/issues/13282.

This PR contains fixes for the issue [#13282](https://github.com/kestra-io/kestra/issues/13282).

According to the requirement, now the timeline on the overview tab is as expected and compliant to the design.
After changes:
<img width="466" height="449" alt="Screenshot from 2025-12-04 02-19-01" src="https://github.com/user-attachments/assets/2a0e5067-24a2-4c5f-af38-6870c8d8da4f" />

