### PR TITLE
fix(ui): Overflow of Flow labels in flow editor page

### DIFF
--- a/ui/src/components/inputs/EditorButtonsWrapper.vue
+++ b/ui/src/components/inputs/EditorButtonsWrapper.vue
@@ -163,4 +163,10 @@
         margin: .5rem;
         gap: .5rem;
     }
+    @media screen and (max-width: 768px) {
+        .button-wrapper {
+            flex-wrap: wrap;
+            justify-content: space-evenly;
+        }
+    }
 </style>


### PR DESCRIPTION
### ✨ Description
Fixes the overflow issue of labels in Flow Editor for better user mobile experience.

### 🔗 Related Issue
Closes #12728 

### 🎨 Frontend Checklist
- [x] Screenshots or video recordings attached showing the `UI` changes

<img width="777" height="647" alt="image" src="https://github.com/user-attachments/assets/c31aa7df-98ed-4707-a474-274867f97ad8" />


<img width="996" height="644" alt="image" src="https://github.com/user-attachments/assets/02a0bafa-d061-43cd-a3d7-597fa81f8b34" />

