### PR TITLE
refactor(ui): use $t in ContextNews.vue template to simplify translations

### DIFF
--- a/ui/src/components/layout/ContextNews.vue
+++ b/ui/src/components/layout/ContextNews.vue
@@ -1,5 +1,5 @@
 <template>
-    <ContextInfoContent ref="contextInfoRef" :title="t('feeds.title')">
+    <ContextInfoContent ref="contextInfoRef" :title="$t('feeds.title')">
         <div
             class="post"
             :class="{
@@ -26,11 +26,11 @@
                     @click="expanded[feed.id] = !expanded[feed.id]"
                 >
                     <MenuDown class="expandIcon" />
-                    {{ expanded[feed.id] ? t("showLess") : t("showMore") }}
+                    {{ expanded[feed.id] ? $t("showLess") : $t("showMore") }}
                 </el-button>
                 <el-button
                     v-if="feed.href"
-                    :title="t('open in new tab')"
+                    :title="$t('open in new tab')"
                     tag="a"
                     type="primary"
                     target="_blank"
@@ -47,7 +47,6 @@
 
 <script setup lang="ts">
     import {computed, onMounted, reactive, ref} from "vue";
-    import {useI18n} from "vue-i18n";
     import {useStorage} from "@vueuse/core"
     import {useScrollMemory} from "../../composables/useScrollMemory"
 
@@ -61,7 +60,6 @@
     import {useApiStore} from "../../stores/api";
 
     const apiStore = useApiStore();
-    const {t} = useI18n({useScope: "global"});
 
     const contextInfoRef = ref<InstanceType<typeof ContextInfoContent> | null>(null);
     const feeds = computed(() => apiStore.feeds);


### PR DESCRIPTION
### ✨ Description

This PR refactors ```ContextNews.vue``` to streamline translation handling.

- Removes the manual `useI18n` import and `t` extraction from the `<script>` block
- Uses the global `$t` helper in the `<template>` for translation calls

This reduces boilerplate and improves readability while preserving the exact same UI behavior.

### 🔗 Related Issue

Closes #13354

### 🎨 Frontend Checklist

_If this PR does not include any frontend changes, delete this entire section._

- [x] Code builds without errors (`npm run build`)
- [ ] All existing E2E tests pass (`npm run test:e2e`)
- [x] Screenshots or video recordings attached showing the `UI` changes

### 🖼️ Screenshot of the UI after the changes

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/904e1997-3b4e-4764-87f7-fb954f1e3371" />

