### PR TITLE
refactor(ui): use global $t helper in ContextDocsSearch

### DIFF
--- a/ui/src/components/docs/ContextDocsSearch.vue
+++ b/ui/src/components/docs/ContextDocsSearch.vue
@@ -2,7 +2,7 @@
     <div class="search-container" ref="searchContainer">
         <el-input
             v-model="searchQuery"
-            :placeholder="t('search_docs')"
+            :placeholder="$t('search_docs')"
             class="search-input"
             @input="handleSearch"
             @keydown.enter.prevent="handleEnterKey"
@@ -15,7 +15,7 @@
             </template>
         </el-input>
         <div v-if="loading" class="loading-indicator">
-            {{ t('searching') }}
+            {{ $t('searching') }}
         </div>
         <div v-if="showResults" class="search-results">
             <template v-if="searchResults.length > 0">
@@ -38,7 +38,7 @@
                 </ContextDocsLink>
             </template>
             <div v-else class="no-results">
-                {{ t("no_results_found") }}
+                {{ $t("no_results_found") }}
             </div>
         </div>
     </div>
@@ -47,12 +47,10 @@
 <script setup lang="ts">
     import {ref, computed, onMounted, onUnmounted} from "vue";
     import {useDocStore} from "../../stores/doc";
-    import {useI18n} from "vue-i18n";
     import Magnify from "vue-material-design-icons/Magnify.vue";
     import ContextDocsLink from "./ContextDocsLink.vue";
     import {debounce} from "lodash-es";
 
-    const {t} = useI18n({useScope: "global"});
     const docStore = useDocStore();
 
     const searchQuery = ref("");


### PR DESCRIPTION
### ✨ Description

Refactors `ui/src/components/docs/ContextDocsSearch.vue` to remove the unnecessary manual import and usage of `useI18n`. Replaced the local `t()` function with the globally available `$t()` helper in the template, which simplifies the component logic and removes redundant code.

### 🔗 Related Issue

Closes #13201 

### 🎨 Frontend Checklist

- [x] Code builds without errors (`npm run build`)
- [x] All existing E2E tests pass (`npm run test:e2e`)

### 📝 Additional Notes

Screenshots not applicable as this is a pure refactor with no visual changes

