### PR TITLE
fix(ui): fix refresh data overlap and create button overflow on flows page

### DIFF
--- a/ui/src/components/filter/components/KSFilter.vue
+++ b/ui/src/components/filter/components/KSFilter.vue
@@ -187,6 +187,7 @@
         display: flex;
         align-items: flex-start;
         flex-wrap: nowrap;
+        gap: 0.5rem;
         
         &.options {
             padding-bottom: 1rem;

--- a/ui/src/components/filter/components/RightFilter.vue
+++ b/ui/src/components/filter/components/RightFilter.vue
@@ -3,17 +3,16 @@
         class="filter-container"
         :class="{'filter-shrink': filter.searchInputFullWidth.value}"
     >
-        <el-tooltip :content="$t('filter.refresh')" placement="top" effect="light">
-            <el-button
-                v-if="filter.tableOptions.value?.refresh?.shown"
-                @click="filter.refreshData"
-                :icon="Refresh"
-                :size="'default'"
-                class="refresh-button"
-            >
-                <span class="d-none">{{ $t("filter.refresh") }}</span>
-            </el-button>
-        </el-tooltip>
+        <el-button
+            v-if="filter.tableOptions.value?.refresh?.shown"
+            @click="filter.refreshData"
+            :icon="Refresh"
+            :size="'default'"
+            class="refresh-button"
+        >
+            <span class="refresh-text">{{ $t("filter.refresh") }}</span>
+        </el-button>
+
         <SaveFilters
             v-if="!filter.searchInputFullWidth.value"
             :disabled="
@@ -159,20 +158,38 @@
     }
 
     .refresh-button {
+        cursor: pointer;
         background-color: transparent;
         border: none;
         box-shadow: none;
-        margin-left: 0.5rem;
+        margin: 0;
         padding: 0.25rem 0.5rem;
-        
+        font-size: 12px;
+
         :deep(svg) {
             color: var(--ks-content-tertiary);
-            font-size: 18px; 
-            vertical-align: middle;
+            
+            width: 1.1rem; 
+            height: 1.1rem;
+
+            @media (min-width: 768px) {
+                width: 1em;
+                height: 1em;
+            }
         }
 
         &:hover {
             background-color: var(--ks-tag-background);
+        }
+
+        .refresh-text {
+            display: none;
+
+            @media (min-width: 768px) {
+                display: inline;
+                margin-left: 0.25rem;
+                white-space: nowrap;
+            }
         }
     }
 }

--- a/ui/src/components/filter/components/RightFilter.vue
+++ b/ui/src/components/filter/components/RightFilter.vue
@@ -3,16 +3,17 @@
         class="filter-container"
         :class="{'filter-shrink': filter.searchInputFullWidth.value}"
     >
-        <el-button
-            v-if="filter.tableOptions.value?.refresh?.shown"
-            @click="filter.refreshData"
-            :icon="Refresh"
-            :size="'default'"
-            class="refresh-button"
-        >
-            {{ $t("filter.refresh") }}
-        </el-button>
-
+        <el-tooltip :content="$t('filter.refresh')" placement="top" effect="light">
+            <el-button
+                v-if="filter.tableOptions.value?.refresh?.shown"
+                @click="filter.refreshData"
+                :icon="Refresh"
+                :size="'default'"
+                class="refresh-button"
+            >
+                <span class="d-none">{{ $t("filter.refresh") }}</span>
+            </el-button>
+        </el-tooltip>
         <SaveFilters
             v-if="!filter.searchInputFullWidth.value"
             :disabled="
@@ -161,12 +162,13 @@
         background-color: transparent;
         border: none;
         box-shadow: none;
-        margin: 0;
+        margin-left: 0.5rem;
         padding: 0.25rem 0.5rem;
-        font-size: 12px;
-
+        
         :deep(svg) {
             color: var(--ks-content-tertiary);
+            font-size: 18px; 
+            vertical-align: middle;
         }
 
         &:hover {

--- a/ui/src/components/flows/Flows.vue
+++ b/ui/src/components/flows/Flows.vue
@@ -3,23 +3,32 @@
         <template #additional-right>
             <ul class="header-actions-list">
                 <li>
-                    <el-button v-if="canRead" :icon="Download" @click="exportFlowsAsStream()">
-                        {{ t('export_csv') }}
-                    </el-button>
+                    <el-tooltip :content="t('export_csv')" :disabled="isLargeScreen" placement="bottom" effect="light">
+                        <el-button v-if="canRead" :icon="Download" @click="exportFlowsAsStream()">
+                            <span class="d-none d-xl-inline">{{ t('export_csv') }}</span>
+                        </el-button>
+                    </el-tooltip>
                 </li>
+
                 <li>
-                    <el-button :icon="Upload" @click="file?.click()">
-                        {{ t("import") }}
-                    </el-button>
+                    <el-tooltip :content="t('import')" :disabled="isLargeScreen" placement="bottom" effect="light">
+                        <el-button :icon="Upload" @click="file?.click()">
+                            <span class="d-none d-xl-inline">{{ t("import") }}</span>
+                        </el-button>
+                    </el-tooltip>
                     <input ref="file" type="file" accept=".zip, .yml, .yaml" @change="importFlows()" class="d-none">
                 </li>
+
                 <li>
                     <router-link :to="{name: 'flows/search'}">
-                        <el-button :icon="TextBoxSearch">
-                            {{ t("source search") }}
-                        </el-button>
+                        <el-tooltip :content="t('source search')" :disabled="isLargeScreen" placement="bottom" effect="light">
+                            <el-button :icon="TextBoxSearch">
+                                <span class="d-none d-xl-inline">{{ t("source search") }}</span>
+                            </el-button>
+                        </el-tooltip>
                     </router-link>
                 </li>
+
                 <li>
                     <router-link
                         :to="{
@@ -257,6 +266,7 @@
 <script setup lang="ts">
     import {ref, computed, useTemplateRef} from "vue";
     import {useRoute} from "vue-router";
+    import {useBreakpoints} from "@vueuse/core";
     import {useI18n} from "vue-i18n";
     import _merge from "lodash/merge";
     import * as FILTERS from "../../utils/filters";
@@ -319,6 +329,9 @@
 
     const {t} = useI18n();
     const toast = useToast()
+
+    const breakpoints = useBreakpoints({xl: 1200});
+    const isLargeScreen = breakpoints.greaterOrEqual("xl");
 
     const flowFilter = useFlowFilter();
 
@@ -690,3 +703,4 @@
     }
 }
 </style>
+


### PR DESCRIPTION
### ✨ Description

This PR addresses two UI responsiveness issues on the Flows page to improve layout stability on smaller screens while maintaining full functionality on larger monitors.

**Changes:**
1.  **Fix "Refresh data" Overlap (Issue #13406):**
    * Resolved the overlap between the "Refresh data" label and the "Add filters" button.
    * Implemented responsive visibility: The text label is now hidden on standard laptop screens (showing only the icon) and reappears on extra-large screens (`d-xxl-inline`).
    * Added a Tooltip that displays "Refresh data" on hover.
    * Increased the Refresh icon size (18px) for better accessibility when the text is hidden.
    * Added proper spacing (margins/gaps) to the filter bar components.

2.  **Fix Top Toolbar Overflow (Issue #13418):**
    * Prevented the "Create" button from being pushed out of the container.
    * Applied responsive text hiding to secondary actions (Export, Import, Source Search) using `d-xl-inline`.
    * **Smart Tooltips:** Integrated `useBreakpoints` from `@vueuse/core`. Tooltips for these buttons are now logically controlled: they are **enabled** on small screens (when text is hidden) and **disabled** on large screens (when text is visible), preventing redundant UX.
    * The "Create" button text remains always visible as a primary action.

### 🔗 Related Issue

Closes #13406
Closes #13418

### 🎨 Frontend Checklist

- [x] Code builds without errors (`npm run build`)
- [ ] All existing E2E tests pass (`npm run test:e2e`)
- [x] Screenshots or video recordings attached showing the `UI` changes

### 📸 Visuals

| State | Before | After |
| :--- | :--- | :--- |
| **Refresh Button Overlap** | <img width="400" alt="overlapping_Issue" src="https://github.com/user-attachments/assets/f14d2e9b-8549-4858-9850-0a5779ddbe29" /> | <img width="400" alt="overlapping_Issue_after" src="https://github.com/user-attachments/assets/726642c0-b3ce-418f-b766-2baa7c969a0b" /> |
| **Toolbar Overflow** | <img width="400" alt="Create_button_overflows" src="https://github.com/user-attachments/assets/15552392-0e56-4d59-8bd8-c42131a2376e" /> | <img width="400" alt="Create_button_overflows_after" src="https://github.com/user-attachments/assets/5efa7782-a1d4-49f0-abd1-a7c7b189a613" /> |

**Video Demo:**

https://github.com/user-attachments/assets/6436bfb6-65cf-4b11-b26a-1cdc72ddafb0

