### PR TITLE
fix(core): make password requirement descriptive.

### DIFF
--- a/ui/src/components/basicauth/BasicAuthSetup.vue
+++ b/ui/src/components/basicauth/BasicAuthSetup.vue
@@ -87,7 +87,7 @@
                             </el-form-item>
                             <div class="password-requirements mb-4">
                                 <el-text>     
-                                    Password must be at least 8 Character long and include 1 Uppercase letter and 1 Number
+                                    {{ t('setup.form.password_requirements') }}
                                 </el-text>
                             </div>
                         </el-form>

--- a/ui/src/components/basicauth/BasicAuthSetup.vue
+++ b/ui/src/components/basicauth/BasicAuthSetup.vue
@@ -86,8 +86,8 @@
                                 </el-input>
                             </el-form-item>
                             <div class="password-requirements mb-4">
-                                <el-text>
-                                    8+ chars, 1 upper, 1 number
+                                <el-text>     
+                                    Password must be at least 8 Character long and include 1 Uppercase letter and 1 Number
                                 </el-text>
                             </div>
                         </el-form>

--- a/ui/src/components/basicauth/setup.scss
+++ b/ui/src/components/basicauth/setup.scss
@@ -101,7 +101,7 @@ $checkbox-checked-color: #8405FF;
 
   .el-text {
     color: var(--ks-content-tertiary);
-    font-size: 14px;
+    font-size: 12px;
   }
 }
 

--- a/ui/src/translations/en.json
+++ b/ui/src/translations/en.json
@@ -1477,7 +1477,8 @@
         "email": "Email",
         "firstName": "First Name",
         "lastName": "Last Name",
-        "password": "Password"
+        "password": "Password",
+        "password_requirements": "Password must be at least 8 characters long and include at least 1 uppercase letter and 1 number."
       },
       "validation": {
         "email_required": "Email is required",


### PR DESCRIPTION
Closes #13413 

Changes made are :
The text is changed from the current 8+ chars, 1 upper, 1 number to the suggested, more professional format: 
Password must be at least 8 Character long and include 1 Uppercase letter and 1 Number


Before:
<img width="990" height="752" alt="Screenshot 2025-12-05 at 10 51 15 PM" src="https://github.com/user-attachments/assets/f47d8c64-b946-4a02-8115-324fa372d787" />

After: 
<img width="1199" height="834" alt="Screenshot 2025-12-05 at 10 51 40 PM" src="https://github.com/user-attachments/assets/269f96d6-7602-4d06-ad70-38f173916fc8" />

