### PR TITLE
fix(core): skip login screen after initial setup and send to welcome

### DIFF
--- a/ui/src/components/basicauth/BasicAuthSetup.vue
+++ b/ui/src/components/basicauth/BasicAuthSetup.vue
@@ -502,9 +502,7 @@
         localStorage.removeItem("basicAuthUserCreated")
         localStorage.setItem("basicAuthSetupCompletedAt", new Date().toISOString())
 
-        sessionStorage.setItem("sessionActive", "true")
-
-        router.push({name: "home"})
+        router.push({name: "welcome"})
     }
 </script>
 

--- a/ui/src/components/basicauth/BasicAuthSetup.vue
+++ b/ui/src/components/basicauth/BasicAuthSetup.vue
@@ -502,7 +502,9 @@
         localStorage.removeItem("basicAuthUserCreated")
         localStorage.setItem("basicAuthSetupCompletedAt", new Date().toISOString())
 
-        router.push({name: "login"})
+        sessionStorage.setItem("sessionActive", "true")
+
+        router.push({name: "home"})
     }
 </script>
 


### PR DESCRIPTION
### ✨ Description
This PR improves the onboarding experience for new Kestra instances.

**Changes:**
- Implemented logic to automatically log the user in after they complete the initial setup (admin account creation).
- Users are now redirected directly to the dashboard instead of being sent to the login screen to re-enter the credentials they just created.


### 🔗 Related Issue
Closes #13400

### 🎨 Frontend Checklist

- [x] Code builds without errors (`npm run build`)
- [x] All existing E2E tests pass (`npm run test:e2e`)
- [x] Screenshots or video recordings attached showing the `UI` changes

### Demo Video:

https://github.com/user-attachments/assets/05b791bd-3451-489f-a8b9-92d7b1be8809


