### PR TITLE
fix(ui): Refreshing login page shows a brief dashboard flash

### DIFF
--- a/ui/src/App.vue
+++ b/ui/src/App.vue
@@ -2,7 +2,7 @@
     <DocIdDisplay />
     <el-config-provider>
         <ErrorToast v-if="coreStore.message" :noAutoHide="true" :message="coreStore.message" />
-        <component :is="route.meta.layout ?? DefaultLayout" v-if="loaded && shouldRenderApp">
+        <component :is="route.meta.layout ?? DefaultLayout" v-if="loaded && shouldRenderApp && route.name">
             <router-view />
         </component>
         <VueTour v-if="shouldRenderApp && route?.name && !route.meta?.anonymous" />


### PR DESCRIPTION
Refreshing the login page shows a brief flash of dashboard for milliseconds.

All PRs submitted by external contributors that do not follow this template (including proper description, related issue, and checklist sections) **may be automatically closed**.

As a general practice, if you plan to work on a specific issue, comment on the issue first and wait to be assigned before starting any actual work. This avoids duplicated work and ensures a smooth contribution process - otherwise, the PR **may be automatically closed**.

---

### ✨ Description

What does this PR change?  

Fixes the brief dashboard flash that appears when refreshing the login page.

### 🔗 Related Issue

Closes https://github.com/kestra-io/kestra/issues/13410

### 📝 Additional Notes

Root Cause:
On page refresh, the route object is temporarily empty. This caused the template to render DefaultLayout (dashboard) as a fallback since route.meta was undefined. Once the router fully initialized, it would navigate to /login, creating a visible flash.

The Fix:
Added a route.name check in App.vue to prevent rendering any layout until the router is fully initialized. This ensures the correct layout renders immediately without flashing the dashboard.
