### PR TITLE
fix:removed unused i18 imports in PlaygroundRunTaskButton component  

### DIFF
--- a/ui/src/components/inputs/PlaygroundRunTaskButton.vue
+++ b/ui/src/components/inputs/PlaygroundRunTaskButton.vue
@@ -7,27 +7,24 @@
         :disabled="!playgroundStore.readyToStart"
     >
         <el-icon><Play /></el-icon>
-        <span>{{ t('playground.run_task') }}</span>
+        <span>{{ $t('playground.run_task') }}</span>
         <template #dropdown>
             <el-dropdown-menu>
                 <el-dropdown-item :icon="Play" @click="playgroundStore.runUntilTask(taskId)">
-                    {{ t('playground.run_this_task') }}
+                    {{ $t('playground.run_this_task') }}
                 </el-dropdown-item>
                 <el-dropdown-item :icon="PlayBoxMultiple" @click="playgroundStore.runUntilTask(taskId, true)">
-                    {{ t('playground.run_task_and_downstream') }}
+                    {{ $t('playground.run_task_and_downstream') }}
                 </el-dropdown-item>
             </el-dropdown-menu>
         </template>
     </el-dropdown>
 </template>
 
-<script setup lang="ts">
-    import {useI18n} from "vue-i18n";
+<script setup lang="ts">;
     import {usePlaygroundStore} from "../../stores/playground";
     import Play from "vue-material-design-icons/Play.vue";
     import PlayBoxMultiple from "vue-material-design-icons/PlayBoxMultiple.vue";
-
-    const {t} = useI18n();
     const playgroundStore = usePlaygroundStore();
 
     defineProps<{

--- a/ui/src/components/inputs/PlaygroundRunTaskButton.vue
+++ b/ui/src/components/inputs/PlaygroundRunTaskButton.vue
@@ -21,7 +21,7 @@
     </el-dropdown>
 </template>
 
-<script setup lang="ts">;
+<script setup lang="ts">
     import {usePlaygroundStore} from "../../stores/playground";
     import Play from "vue-material-design-icons/Play.vue";
     import PlayBoxMultiple from "vue-material-design-icons/PlayBoxMultiple.vue";

--- a/ui/src/components/inputs/PlaygroundRunTaskButton.vue
+++ b/ui/src/components/inputs/PlaygroundRunTaskButton.vue
@@ -25,6 +25,7 @@
     import {usePlaygroundStore} from "../../stores/playground";
     import Play from "vue-material-design-icons/Play.vue";
     import PlayBoxMultiple from "vue-material-design-icons/PlayBoxMultiple.vue";
+
     const playgroundStore = usePlaygroundStore();
 
     defineProps<{


### PR DESCRIPTION

### ✨ Description

What does this PR change?  
Removed the  unnecessary imports and usages of the useI18n composable from vue-i18n when translations are performed only in the <template> section.

This PR applies that cleanup to PlaygroundRunTaskButton.vue

### 🔗 Related Issue

 Closes https://github.com/kestra-io/kestra/issues/13352

### 🎨 Frontend Checklist

_If this PR does not include any frontend changes, delete this entire section._

- [x] Code builds without errors (`npm run build`)
- [x] All existing E2E tests pass (`npm run test:e2e`)



