### PR TITLE
fix(core) : Ensure that a label key cannot contain spaces, special characters or encoded values (e.g. emojis)

### DIFF
--- a/core/src/main/java/io/kestra/core/models/Label.java
+++ b/core/src/main/java/io/kestra/core/models/Label.java
@@ -4,13 +4,16 @@ import io.kestra.core.utils.MapUtils;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.annotation.Nullable;
 import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.Pattern;
 
 import java.util.*;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 @Schema(description = "A key/value pair that can be attached to a Flow or Execution. Labels are often used to organize and categorize objects.")
-public record Label(@NotEmpty String key, @NotEmpty String value) {
+public record Label(
+        @NotEmpty @Pattern(regexp = "^[\\p{Ll}][\\p{L}0-9._-]*$", message = "Invalid label key. A valid key contains only lowercase letters numbers hyphens (-) underscores (_) or periods (.) and must begin with a lowercase letter.") String key,
+        @NotEmpty String value) {
     public static final String SYSTEM_PREFIX = "system.";
 
     // system labels

--- a/core/src/test/java/io/kestra/core/models/LabelTest.java
+++ b/core/src/test/java/io/kestra/core/models/LabelTest.java
@@ -134,4 +134,47 @@ class LabelTest {
         Optional<ConstraintViolationException> emptyKeyLabelResult = modelValidator.isValid(new Label("", "bar"));
         assertThat(emptyKeyLabelResult.isPresent()).isTrue();
     }
+
+    @Test
+    void shouldValidateValidLabelKeys() {
+        // Valid keys: start with lowercase; may contain letters, numbers, hyphens, underscores, periods
+        assertThat(modelValidator.isValid(new Label("foo", "bar")).isPresent()).isFalse();
+        assertThat(modelValidator.isValid(new Label("foo-bar", "value")).isPresent()).isFalse();
+        assertThat(modelValidator.isValid(new Label("foo_bar", "value")).isPresent()).isFalse();
+        assertThat(modelValidator.isValid(new Label("foo123", "value")).isPresent()).isFalse();
+        assertThat(modelValidator.isValid(new Label("foo-bar_baz123", "value")).isPresent()).isFalse();
+        assertThat(modelValidator.isValid(new Label("a", "value")).isPresent()).isFalse();
+        assertThat(modelValidator.isValid(new Label("foo.bar", "value")).isPresent()).isFalse(); // dot is allowed
+    }
+
+    @Test
+    void shouldRejectInvalidLabelKeys() {
+
+        Optional<ConstraintViolationException> spaceResult = modelValidator.isValid(new Label("foo bar", "value"));
+        assertThat(spaceResult.isPresent()).isTrue();
+
+        Optional<ConstraintViolationException> uppercaseResult = modelValidator.isValid(new Label("Foo", "value"));
+        assertThat(uppercaseResult.isPresent()).isTrue();
+
+        Optional<ConstraintViolationException> emojiResult = modelValidator.isValid(new Label("💩", "value"));
+        assertThat(emojiResult.isPresent()).isTrue();
+
+        Optional<ConstraintViolationException> atSignResult = modelValidator.isValid(new Label("foo@bar", "value"));
+        assertThat(atSignResult.isPresent()).isTrue();
+
+        Optional<ConstraintViolationException> colonResult = modelValidator.isValid(new Label("foo:bar", "value"));
+        assertThat(colonResult.isPresent()).isTrue();
+
+        Optional<ConstraintViolationException> hyphenStartResult = modelValidator.isValid(new Label("-foo", "value"));
+        assertThat(hyphenStartResult.isPresent()).isTrue();
+
+        Optional<ConstraintViolationException> underscoreStartResult = modelValidator.isValid(new Label("_foo", "value"));
+        assertThat(underscoreStartResult.isPresent()).isTrue();
+
+        Optional<ConstraintViolationException> zeroResult = modelValidator.isValid(new Label("0", "value"));
+        assertThat(zeroResult.isPresent()).isTrue();
+
+        Optional<ConstraintViolationException> digitStartResult = modelValidator.isValid(new Label("9test", "value"));
+        assertThat(digitStartResult.isPresent()).isTrue();
+    }
 }


### PR DESCRIPTION
Closes https://github.com/kestra-io/kestra/issues/11229.

### ✨ Description

What does this PR change?  

This PR adds validation to label keys to enforce the same naming pattern as flow IDs. Label keys must now start with a lowercase character and can only contain lowercase letters, numbers, hyphens (-), and underscores (_).

## Validation Rules

### ✅ Valid Label Keys
- `environment` - lowercase letters
- `app-name` - lowercase with hyphens
- `user_id` - lowercase with underscores
- `version2` - lowercase with numbers
- `foo.bar` - contains dot (.)
- `a` - single character
### ❌ Invalid Label Keys (Now Rejected)
- `My Label` - contains space
- `Foo` - starts with uppercase letter
- `💩` - emoji/special character
- `0test` - starts with number
- `foo@bar` - contains at sign (@)
- `foo:bar` - contains colon (:)
- `-foo` - starts with hyphen
- `_foo` - starts with underscore

### 🔗 Related Issue

Closes
- #11229

### 📝What I fixed
<img width="1920" height="916" alt="Screenshot (21)" src="https://github.com/user-attachments/assets/f53514a2-1c0b-4b36-8fbc-6c1ffb0eb8af" />

<img width="1887" height="893" alt="Screenshot 2025-12-07 231033" src="https://github.com/user-attachments/assets/7b3b75b8-1b7c-4ce6-ac96-c372b99ab309" />

