### PR TITLE
test(core): add regression test for illegal namespace updates

### DIFF
--- a/core/src/test/java/io/kestra/core/models/flows/FlowTest.java
+++ b/core/src/test/java/io/kestra/core/models/flows/FlowTest.java
@@ -185,4 +185,21 @@ class FlowTest {
 
         return YamlParser.parse(file, Flow.class);
     }
+    @Test
+    void illegalNamespaceUpdate() {
+        Flow original = Flow.builder()
+            .id("my-flow")
+            .namespace("io.kestra.prod")
+            .tasks(List.of(Log.builder().id("log").type(Log.class.getName()).message("hello").build()))
+            .build();
+
+        Flow updated = original.toBuilder()
+            .namespace("io.kestra.dev")
+            .build();
+
+        Optional<ConstraintViolationException> validate = original.validateUpdate(updated);
+
+        assertThat(validate.isPresent()).isTrue();
+        assertThat(validate.get().getMessage()).contains("Illegal namespace update");
+    }
 }


### PR DESCRIPTION
### ✨ Description

This PR improves the test coverage for the `Flow` model validation logic.

While `Flow.java` contains logic to prevent illegal updates to a Flow's `namespace` (in the `validateUpdate` method), there was no unit test enforcing this check.

I added a specific regression test `illegalNamespaceUpdate` in `FlowTest.java`. This ensures that any future refactoring does not accidentally remove this safety check, preserving data integrity.

### 🔗 Related Issue

N/A - Improvement to existing test coverage.

### 🎨 Frontend Checklist

_Not applicable._

### 🛠️ Backend Checklist

- [x] Code compiles successfully and passes all checks
- [x] All unit and integration tests pass (Verified locally with `./gradlew :core:test`)

### 📝 Additional Notes

I verified the fix locally by running the specific test case:
`./gradlew :core:test --tests "io.kestra.core.models.flows.FlowTest.illegalNamespaceUpdate"`