### PR TITLE
fix(core): improve exception handling at FlowInputOutput

### DIFF
--- a/core/src/main/java/io/kestra/core/exceptions/InputOutputValidationException.java
+++ b/core/src/main/java/io/kestra/core/exceptions/InputOutputValidationException.java
@@ -1,0 +1,37 @@
+package io.kestra.core.exceptions;
+
+import io.kestra.core.models.flows.Data;
+import io.kestra.core.models.flows.Input;
+import io.kestra.core.models.flows.Output;
+
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * Exception that can be thrown when Inputs/Outputs have validation problems.
+ */
+public class InputOutputValidationException extends KestraRuntimeException {
+    public InputOutputValidationException(String message) {
+        super(message);
+    }
+    public static InputOutputValidationException of( String message, Input<?> input){
+        String inputMessage = "Invalid value for input" + " `" + input.getId() + "`. Cause: " + message;
+        return new InputOutputValidationException(inputMessage);
+    }
+    public static InputOutputValidationException of( String message, Output output){
+        String outputMessage = "Invalid value for output" + " `" + output.getId() + "`. Cause: " + message;
+        return new InputOutputValidationException(outputMessage);
+    }
+    public static InputOutputValidationException of(String message){
+        return new InputOutputValidationException(message);
+    }
+
+    public static InputOutputValidationException merge(Set<InputOutputValidationException> exceptions){
+        String combinedMessage = exceptions.stream()
+                .map(InputOutputValidationException::getMessage)
+                .collect(Collectors.joining(System.lineSeparator()));
+        throw new InputOutputValidationException(combinedMessage);
+    }
+
+}

--- a/core/src/main/java/io/kestra/core/exceptions/KestraRuntimeException.java
+++ b/core/src/main/java/io/kestra/core/exceptions/KestraRuntimeException.java
@@ -1,6 +1,8 @@
 package io.kestra.core.exceptions;
 
 import java.io.Serial;
+import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * The top-level {@link KestraRuntimeException} for non-recoverable errors.

--- a/core/src/main/java/io/kestra/core/models/flows/Data.java
+++ b/core/src/main/java/io/kestra/core/models/flows/Data.java
@@ -1,7 +1,5 @@
 package io.kestra.core.models.flows;
 
-import io.kestra.core.models.validations.ManualConstraintViolation;
-import jakarta.validation.ConstraintViolationException;
 
 /**
  * Interface for defining an identifiable and typed data.
@@ -29,16 +27,4 @@ public interface Data {
      */
     String getDisplayName();
 
-    @SuppressWarnings("unchecked")
-    default ConstraintViolationException toConstraintViolationException(String message, Object value) {
-        Class<Data> cls = (Class<Data>) this.getClass();
-
-        return ManualConstraintViolation.toConstraintViolationException(
-            "Invalid " + (this instanceof Output ? "output" : "input") + " for `" + getId() + "`, " + message + ", but received `" + value + "`",
-            this,
-            cls,
-            this.getId(),
-            value
-        );
-    }
 }

--- a/core/src/main/java/io/kestra/core/models/flows/input/InputAndValue.java
+++ b/core/src/main/java/io/kestra/core/models/flows/input/InputAndValue.java
@@ -1,9 +1,11 @@
 package io.kestra.core.models.flows.input;
 
+import io.kestra.core.exceptions.InputOutputValidationException;
 import io.kestra.core.models.flows.Input;
 import jakarta.annotation.Nullable;
-import jakarta.validation.ConstraintViolationException;
 import jakarta.validation.constraints.NotNull;
+
+import java.util.Set;
 
 /**
  * Represents an input along with its associated value and validation state.
@@ -12,15 +14,15 @@ import jakarta.validation.constraints.NotNull;
  * @param value     The provided value for the input.
  * @param enabled   {@code true} if the input is enabled; {@code false} otherwise.
  * @param isDefault {@code true} if the provided value is the default; {@code false} otherwise.
- * @param exception The validation exception, if the input value is invalid; {@code null} otherwise.
+ * @param exceptions The validation exceptions, if the input value is invalid; {@code null} otherwise.
  */
 public record InputAndValue(
     Input<?> input,
     Object value,
     boolean enabled,
     boolean isDefault,
-    ConstraintViolationException exception) {
-    
+    Set<InputOutputValidationException> exceptions) {
+
     /**
      * Creates a new {@link InputAndValue} instance.
      *

--- a/core/src/main/java/io/kestra/core/models/flows/input/MultiselectInput.java
+++ b/core/src/main/java/io/kestra/core/models/flows/input/MultiselectInput.java
@@ -7,6 +7,7 @@ import io.kestra.core.models.property.Property;
 import io.kestra.core.models.validations.ManualConstraintViolation;
 import io.kestra.core.validations.Regex;
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.ConstraintViolation;
 import jakarta.validation.ConstraintViolationException;
 import jakarta.validation.constraints.NotNull;
 import lombok.Builder;
@@ -14,10 +15,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
 
-import java.util.Collection;
-import java.util.List;
-import java.util.Objects;
-import java.util.Optional;
+import java.util.*;
 import java.util.function.Function;
 
 @SuperBuilder
@@ -77,29 +75,34 @@ public class MultiselectInput extends Input<List<String>> implements ItemTypeInt
 
     @Override
     public void validate(List<String> inputs) throws ConstraintViolationException {
+        Set<ConstraintViolation<?>> violations = new HashSet<>();
+
         if (values != null && options != null) {
-            throw ManualConstraintViolation.toConstraintViolationException(
+            violations.add( ManualConstraintViolation.of(
                 "you can't define both `values` and `options`",
                 this,
                 MultiselectInput.class,
                 getId(),
                 ""
-            );
+            ));
         }
 
         if (!this.getAllowCustomValue()) {
             for (String input : inputs) {
                 List<@Regex String> finalValues = this.values != null ? this.values : this.options;
                 if (!finalValues.contains(input)) {
-                    throw ManualConstraintViolation.toConstraintViolationException(
-                        "it must match the values `" + finalValues + "`",
+                    violations.add(ManualConstraintViolation.of(
+                        "value `" + input + "` doesn't match the values `" + finalValues + "`",
                         this,
                         MultiselectInput.class,
                         getId(),
                         input
-                    );
+                    ));
                 }
             }
+        }
+        if (!violations.isEmpty()) {
+            throw ManualConstraintViolation.toConstraintViolationException(violations);
         }
     }
 
@@ -145,7 +148,7 @@ public class MultiselectInput extends Input<List<String>> implements ItemTypeInt
 
         String type = Optional.ofNullable(result).map(Object::getClass).map(Class::getSimpleName).orElse("<null>");
         throw ManualConstraintViolation.toConstraintViolationException(
-            "Invalid expression result. Expected a list of strings, but received " + type,
+            "Invalid expression result. Expected a list of strings",
             this,
             MultiselectInput.class,
             getId(),

--- a/core/src/main/java/io/kestra/core/models/flows/input/SelectInput.java
+++ b/core/src/main/java/io/kestra/core/models/flows/input/SelectInput.java
@@ -125,7 +125,7 @@ public class SelectInput extends Input<String> implements RenderableInput {
 
         String type = Optional.ofNullable(result).map(Object::getClass).map(Class::getSimpleName).orElse("<null>");
         throw ManualConstraintViolation.toConstraintViolationException(
-            "Invalid expression result. Expected a list of strings, but received " + type,
+            "Invalid expression result. Expected a list of strings",
             this,
             SelectInput.class,
             getId(),

--- a/core/src/main/java/io/kestra/core/models/validations/ManualConstraintViolation.java
+++ b/core/src/main/java/io/kestra/core/models/validations/ManualConstraintViolation.java
@@ -67,6 +67,11 @@ public class ManualConstraintViolation<T> implements ConstraintViolation<T> {
             invalidValue
         )));
     }
+    public static <T> ConstraintViolationException toConstraintViolationException(
+        Set<? extends ConstraintViolation<?>> constraintViolations
+    ) {
+        return new ConstraintViolationException(constraintViolations);
+    }
 
     public String getMessageTemplate() {
         return "{messageTemplate}";

--- a/core/src/main/java/io/kestra/core/runners/FlowInputOutput.java
+++ b/core/src/main/java/io/kestra/core/runners/FlowInputOutput.java
@@ -3,6 +3,8 @@ package io.kestra.core.runners;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.kestra.core.encryption.EncryptionService;
 import io.kestra.core.exceptions.IllegalVariableEvaluationException;
+
+import io.kestra.core.exceptions.InputOutputValidationException;
 import io.kestra.core.models.executions.Execution;
 import io.kestra.core.models.flows.Data;
 import io.kestra.core.models.flows.DependsOn;
@@ -17,7 +19,6 @@ import io.kestra.core.models.property.Property;
 import io.kestra.core.models.property.PropertyContext;
 import io.kestra.core.models.property.URIFetcher;
 import io.kestra.core.models.tasks.common.EncryptedString;
-import io.kestra.core.models.validations.ManualConstraintViolation;
 import io.kestra.core.serializers.JacksonMapper;
 import io.kestra.core.storages.StorageContext;
 import io.kestra.core.storages.StorageInterface;
@@ -207,8 +208,8 @@ public class FlowInputOutput {
             .filter(InputAndValue::enabled)
             .map(it -> {
                 //TODO check to return all exception at-once.
-                if (it.exception() != null) {
-                    throw it.exception();
+                if (it.exceptions() != null && !it.exceptions().isEmpty()) {
+                    throw  InputOutputValidationException.merge(it.exceptions());
                 }
                 return new AbstractMap.SimpleEntry<>(it.input().getId(), it.value());
             })
@@ -292,13 +293,9 @@ public class FlowInputOutput {
                 try {
                     isInputEnabled = Boolean.TRUE.equals(runContext.renderTyped(dependsOnCondition.get()));
                 } catch (IllegalVariableEvaluationException e) {
-                    resolvable.resolveWithError(ManualConstraintViolation.toConstraintViolationException(
-                        "Invalid condition: " + e.getMessage(),
-                        input,
-                        (Class<Input>)input.getClass(),
-                        input.getId(),
-                        this
-                    ));
+                    resolvable.resolveWithError(
+                        InputOutputValidationException.of("Invalid condition: " + e.getMessage())
+                    );
                     isInputEnabled = false;
                 }
             }
@@ -331,7 +328,7 @@ public class FlowInputOutput {
             // validate and parse input value
             if (value == null) {
                 if (input.getRequired()) {
-                    resolvable.resolveWithError(input.toConstraintViolationException("missing required input", null));
+                    resolvable.resolveWithError(InputOutputValidationException.of("Missing required input:"  + input.getId()));
                 } else {
                     resolvable.resolveWithValue(null);
                 }
@@ -341,17 +338,18 @@ public class FlowInputOutput {
                     parsedInput.ifPresent(parsed -> ((Input) resolvable.get().input()).validate(parsed.getValue()));
                     parsedInput.ifPresent(typed -> resolvable.resolveWithValue(typed.getValue()));
                 } catch (ConstraintViolationException e) {
-                    ConstraintViolationException exception = e.getConstraintViolations().size() == 1 ?
-                        input.toConstraintViolationException(List.copyOf(e.getConstraintViolations()).getFirst().getMessage(), value) :
-                        input.toConstraintViolationException(e.getMessage(), value);
-                    resolvable.resolveWithError(exception);
+                    Input<?> finalInput = input;
+                  Set<InputOutputValidationException> exceptions =  e.getConstraintViolations().stream()
+                      .map(c-> InputOutputValidationException.of(c.getMessage(), finalInput))
+                      .collect(Collectors.toSet());
+                    resolvable.resolveWithError(exceptions);
                 }
             }
-        } catch (ConstraintViolationException e) {
-            resolvable.resolveWithError(e);
-        } catch (Exception e) {
-            ConstraintViolationException exception = input.toConstraintViolationException(e instanceof IllegalArgumentException ? e.getMessage() : e.toString(), resolvable.get().value());
-            resolvable.resolveWithError(exception);
+        } catch (IllegalArgumentException e){
+            resolvable.resolveWithError(InputOutputValidationException.of(e.getMessage(), input));
+        }
+        catch (Exception e) {
+            resolvable.resolveWithError(InputOutputValidationException.of(e.getMessage()));
         }
 
         return resolvable.get();
@@ -439,8 +437,12 @@ public class FlowInputOutput {
                             }
                             return entry;
                         });
-                } catch (Exception e) {
-                    throw output.toConstraintViolationException(e.getMessage(), current);
+                }
+                catch (IllegalArgumentException e){
+                    throw InputOutputValidationException.of(e.getMessage(), output);
+                }
+                catch (Exception e) {
+                    throw InputOutputValidationException.of(e.getMessage());
                 }
             })
             .filter(Optional::isPresent)
@@ -503,7 +505,7 @@ public class FlowInputOutput {
                     if (matcher.matches()) {
                         yield current.toString();
                     } else {
-                        throw new IllegalArgumentException("Expected `URI` but received `" + current + "`");
+                        throw new IllegalArgumentException("Invalid URI format.");
                     }
                 }
                 case ARRAY, MULTISELECT -> {
@@ -533,7 +535,7 @@ public class FlowInputOutput {
         } catch (IllegalArgumentException e) {
             throw e;
         } catch (Throwable e) {
-            throw new Exception("Expected `" + type + "` but received `" + current + "` with errors:\n```\n" + e.getMessage() + "\n```");
+            throw new Exception(" errors:\n```\n" + e.getMessage() + "\n```");
         }
     }
 
@@ -565,26 +567,29 @@ public class FlowInputOutput {
         }
 
         public void isDefault(boolean isDefault) {
-            this.input = new InputAndValue(this.input.input(), this.input.value(), this.input.enabled(), isDefault, this.input.exception());
+            this.input = new InputAndValue(this.input.input(), this.input.value(), this.input.enabled(), isDefault, this.input.exceptions());
         }
 
         public void setInput(final Input<?> input) {
-            this.input = new InputAndValue(input, this.input.value(), this.input.enabled(), this.input.isDefault(), this.input.exception());
+            this.input = new InputAndValue(input, this.input.value(), this.input.enabled(), this.input.isDefault(), this.input.exceptions());
         }
 
         public void resolveWithEnabled(boolean enabled) {
-            this.input = new InputAndValue(this.input.input(), input.value(), enabled, this.input.isDefault(), this.input.exception());
+            this.input = new InputAndValue(this.input.input(), input.value(), enabled, this.input.isDefault(), this.input.exceptions());
             markAsResolved();
         }
 
         public void resolveWithValue(@Nullable Object value) {
-            this.input = new InputAndValue(this.input.input(), value,  this.input.enabled(), this.input.isDefault(), this.input.exception());
+            this.input = new InputAndValue(this.input.input(), value,  this.input.enabled(), this.input.isDefault(), this.input.exceptions());
             markAsResolved();
         }
 
-        public void resolveWithError(@Nullable ConstraintViolationException exception) {
+        public void resolveWithError(@Nullable Set<InputOutputValidationException> exception) {
             this.input = new InputAndValue(this.input.input(),  this.input.value(), this.input.enabled(), this.input.isDefault(), exception);
             markAsResolved();
+        }
+        private void resolveWithError(@Nullable InputOutputValidationException exception){
+            resolveWithError(Collections.singleton(exception));
         }
 
         private void markAsResolved() {

--- a/core/src/test/java/io/kestra/core/runners/FlowInputOutputTest.java
+++ b/core/src/test/java/io/kestra/core/runners/FlowInputOutputTest.java
@@ -239,7 +239,7 @@ class FlowInputOutputTest {
         // Then
         Assertions.assertEquals(2, values.size());
         Assertions.assertFalse(values.get(1).enabled());
-        Assertions.assertNotNull(values.get(1).exception());
+        Assertions.assertNotNull(values.get(1).exceptions());
     }
 
     @Test
@@ -257,7 +257,7 @@ class FlowInputOutputTest {
         List<InputAndValue> values = flowInputOutput.validateExecutionInputs(List.of(input), null, DEFAULT_TEST_EXECUTION, data).block();
 
         // Then
-        Assertions.assertNull(values.getFirst().exception());
+        Assertions.assertNull(values.getFirst().exceptions());
         Assertions.assertFalse(storageInterface.exists(MAIN_TENANT, null, URI.create(values.getFirst().value().toString())));
     }
 

--- a/core/src/test/java/io/kestra/core/runners/InputsTest.java
+++ b/core/src/test/java/io/kestra/core/runners/InputsTest.java
@@ -2,6 +2,7 @@ package io.kestra.core.runners;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.io.CharStreams;
+import io.kestra.core.exceptions.InputOutputValidationException;
 import io.kestra.core.junit.annotations.KestraTest;
 import io.kestra.core.junit.annotations.LoadFlows;
 import io.kestra.core.models.executions.Execution;
@@ -137,8 +138,8 @@ public class InputsTest {
     void missingRequired() {
         HashMap<String, Object> inputs = new HashMap<>(InputsTest.inputs);
         inputs.put("string", null);
-        ConstraintViolationException e = assertThrows(ConstraintViolationException.class, () -> typedInputs(inputs, MAIN_TENANT));
-        assertThat(e.getMessage()).contains("Invalid input for `string`, missing required input, but received `null`");
+        InputOutputValidationException e = assertThrows(InputOutputValidationException.class, () -> typedInputs(inputs, MAIN_TENANT));
+        assertThat(e.getMessage()).contains("Missing required input:string");
     }
 
     @Test
@@ -232,9 +233,9 @@ public class InputsTest {
         HashMap<String, Object> map = new HashMap<>(inputs);
         map.put("validatedString", "foo");
 
-        ConstraintViolationException e = assertThrows(ConstraintViolationException.class, () -> typedInputs(map, "tenant4"));
+        InputOutputValidationException e = assertThrows(InputOutputValidationException.class, () -> typedInputs(map, "tenant4"));
 
-        assertThat(e.getMessage()).contains("Invalid input for `validatedString`, it must match the pattern");
+        assertThat(e.getMessage()).contains(  "Invalid value for input `validatedString`. Cause: it must match the pattern");
     }
 
     @Test
@@ -242,15 +243,15 @@ public class InputsTest {
     void inputValidatedIntegerBadValue() {
         HashMap<String, Object> mapMin = new HashMap<>(inputs);
         mapMin.put("validatedInt", "9");
-        ConstraintViolationException e = assertThrows(ConstraintViolationException.class, () -> typedInputs(mapMin, "tenant5"));
-        assertThat(e.getMessage()).contains("Invalid input for `validatedInt`, it must be more than `10`, but received `9`");
+        InputOutputValidationException e = assertThrows(InputOutputValidationException.class, () -> typedInputs(mapMin, "tenant5"));
+        assertThat(e.getMessage()).contains("Invalid value for input `validatedInt`. Cause: it must be more than `10`");
 
         HashMap<String, Object> mapMax = new HashMap<>(inputs);
         mapMax.put("validatedInt", "21");
 
-        e = assertThrows(ConstraintViolationException.class, () -> typedInputs(mapMax, "tenant5"));
+        e = assertThrows(InputOutputValidationException.class, () -> typedInputs(mapMax, "tenant5"));
 
-        assertThat(e.getMessage()).contains("Invalid input for `validatedInt`, it must be less than `20`, but received `21`");
+        assertThat(e.getMessage()).contains("Invalid value for input `validatedInt`. Cause: it must be less than `20`");
     }
 
     @Test
@@ -258,15 +259,15 @@ public class InputsTest {
     void inputValidatedDateBadValue() {
         HashMap<String, Object> mapMin = new HashMap<>(inputs);
         mapMin.put("validatedDate", "2022-01-01");
-        ConstraintViolationException e = assertThrows(ConstraintViolationException.class, () -> typedInputs(mapMin, "tenant6"));
-        assertThat(e.getMessage()).contains("Invalid input for `validatedDate`, it must be after `2023-01-01`, but received `2022-01-01`");
+        InputOutputValidationException e = assertThrows(InputOutputValidationException.class, () -> typedInputs(mapMin, "tenant6"));
+        assertThat(e.getMessage()).contains("Invalid value for input `validatedDate`. Cause: it must be after `2023-01-01`");
 
         HashMap<String, Object> mapMax = new HashMap<>(inputs);
         mapMax.put("validatedDate", "2024-01-01");
 
-        e = assertThrows(ConstraintViolationException.class, () -> typedInputs(mapMax, "tenant6"));
+        e = assertThrows(InputOutputValidationException.class, () -> typedInputs(mapMax, "tenant6"));
 
-        assertThat(e.getMessage()).contains("Invalid input for `validatedDate`, it must be before `2023-12-31`, but received `2024-01-01`");
+        assertThat(e.getMessage()).contains("Invalid value for input `validatedDate`. Cause: it must be before `2023-12-31`");
     }
 
     @Test
@@ -274,15 +275,15 @@ public class InputsTest {
     void inputValidatedDateTimeBadValue() {
         HashMap<String, Object> mapMin = new HashMap<>(inputs);
         mapMin.put("validatedDateTime", "2022-01-01T00:00:00Z");
-        ConstraintViolationException e = assertThrows(ConstraintViolationException.class, () -> typedInputs(mapMin, "tenant7"));
-        assertThat(e.getMessage()).contains("Invalid input for `validatedDateTime`, it must be after `2023-01-01T00:00:00Z`, but received `2022-01-01T00:00:00Z`");
+        InputOutputValidationException e = assertThrows(InputOutputValidationException.class, () -> typedInputs(mapMin, "tenant7"));
+        assertThat(e.getMessage()).contains("Invalid value for input `validatedDateTime`. Cause: it must be after `2023-01-01T00:00:00Z`");
 
         HashMap<String, Object> mapMax = new HashMap<>(inputs);
         mapMax.put("validatedDateTime", "2024-01-01T00:00:00Z");
 
-        e = assertThrows(ConstraintViolationException.class, () -> typedInputs(mapMax, "tenant7"));
+        e = assertThrows(InputOutputValidationException.class, () -> typedInputs(mapMax, "tenant7"));
 
-        assertThat(e.getMessage()).contains("Invalid input for `validatedDateTime`, it must be before `2023-12-31T23:59:59Z`");
+        assertThat(e.getMessage()).contains("Invalid value for input `validatedDateTime`. Cause: it must be before `2023-12-31T23:59:59Z`");
     }
 
     @Test
@@ -290,15 +291,15 @@ public class InputsTest {
     void inputValidatedDurationBadValue() {
         HashMap<String, Object> mapMin = new HashMap<>(inputs);
         mapMin.put("validatedDuration", "PT1S");
-        ConstraintViolationException e = assertThrows(ConstraintViolationException.class, () -> typedInputs(mapMin, "tenant8"));
-        assertThat(e.getMessage()).contains("Invalid input for `validatedDuration`, It must be more than `PT10S`, but received `PT1S`");
+        InputOutputValidationException e = assertThrows(InputOutputValidationException.class, () -> typedInputs(mapMin, "tenant8"));
+        assertThat(e.getMessage()).contains("Invalid value for input `validatedDuration`. Cause: It must be more than `PT10S`");
 
         HashMap<String, Object> mapMax = new HashMap<>(inputs);
         mapMax.put("validatedDuration", "PT30S");
 
-        e = assertThrows(ConstraintViolationException.class, () -> typedInputs(mapMax, "tenant8"));
+        e = assertThrows(InputOutputValidationException.class, () -> typedInputs(mapMax, "tenant8"));
 
-        assertThat(e.getMessage()).contains("Invalid input for `validatedDuration`, It must be less than `PT20S`, but received `PT30S`");
+        assertThat(e.getMessage()).contains("Invalid value for input `validatedDuration`. Cause: It must be less than `PT20S`");
     }
 
     @Test
@@ -306,15 +307,15 @@ public class InputsTest {
     void inputValidatedFloatBadValue() {
         HashMap<String, Object> mapMin = new HashMap<>(inputs);
         mapMin.put("validatedFloat", "0.01");
-        ConstraintViolationException e = assertThrows(ConstraintViolationException.class, () -> typedInputs(mapMin, "tenant9"));
-        assertThat(e.getMessage()).contains("Invalid input for `validatedFloat`, it must be more than `0.1`, but received `0.01`");
+        InputOutputValidationException e = assertThrows(InputOutputValidationException.class, () -> typedInputs(mapMin, "tenant9"));
+        assertThat(e.getMessage()).contains("Invalid value for input `validatedFloat`. Cause: it must be more than `0.1`");
 
         HashMap<String, Object> mapMax = new HashMap<>(inputs);
         mapMax.put("validatedFloat", "1.01");
 
-        e = assertThrows(ConstraintViolationException.class, () -> typedInputs(mapMax, "tenant9"));
+        e = assertThrows(InputOutputValidationException.class, () -> typedInputs(mapMax, "tenant9"));
 
-        assertThat(e.getMessage()).contains("Invalid input for `validatedFloat`, it must be less than `0.5`, but received `1.01`");
+        assertThat(e.getMessage()).contains("Invalid value for input `validatedFloat`. Cause: it must be less than `0.5`");
     }
 
     @Test
@@ -322,15 +323,15 @@ public class InputsTest {
     void inputValidatedTimeBadValue() {
         HashMap<String, Object> mapMin = new HashMap<>(inputs);
         mapMin.put("validatedTime", "00:00:01");
-        ConstraintViolationException e = assertThrows(ConstraintViolationException.class, () -> typedInputs(mapMin, "tenant10"));
-        assertThat(e.getMessage()).contains("Invalid input for `validatedTime`, it must be after `01:00`, but received `00:00:01`");
+        InputOutputValidationException e = assertThrows(InputOutputValidationException.class, () -> typedInputs(mapMin, "tenant10"));
+        assertThat(e.getMessage()).contains(  "Invalid value for input `validatedTime`. Cause: it must be after `01:00`");
 
         HashMap<String, Object> mapMax = new HashMap<>(inputs);
         mapMax.put("validatedTime", "14:00:00");
 
-        e = assertThrows(ConstraintViolationException.class, () -> typedInputs(mapMax, "tenant10"));
+        e = assertThrows(InputOutputValidationException.class, () -> typedInputs(mapMax, "tenant10"));
 
-        assertThat(e.getMessage()).contains("Invalid input for `validatedTime`, it must be before `11:59:59`, but received `14:00:00`");
+        assertThat(e.getMessage()).contains("Invalid value for input `validatedTime`. Cause: it must be before `11:59:59`");
     }
 
     @Test
@@ -339,9 +340,9 @@ public class InputsTest {
         HashMap<String, Object> map = new HashMap<>(inputs);
         map.put("uri", "http:/bla");
 
-        ConstraintViolationException e = assertThrows(ConstraintViolationException.class, () -> typedInputs(map, "tenant11"));
+        InputOutputValidationException e = assertThrows(InputOutputValidationException.class, () -> typedInputs(map, "tenant11"));
 
-        assertThat(e.getMessage()).contains("Invalid input for `uri`, Expected `URI` but received `http:/bla`, but received `http:/bla`");
+        assertThat(e.getMessage()).contains(  "Invalid value for input `uri`. Cause: Invalid URI format." );
     }
 
     @Test
@@ -350,9 +351,9 @@ public class InputsTest {
         HashMap<String, Object> map = new HashMap<>(inputs);
         map.put("enum", "INVALID");
 
-        ConstraintViolationException e = assertThrows(ConstraintViolationException.class, () -> typedInputs(map, "tenant12"));
+        InputOutputValidationException e = assertThrows(InputOutputValidationException.class, () -> typedInputs(map, "tenant12"));
 
-        assertThat(e.getMessage()).isEqualTo("enum: Invalid input for `enum`, it must match the values `[ENUM_VALUE, OTHER_ONE]`, but received `INVALID`");
+        assertThat(e.getMessage()).isEqualTo("Invalid value for input `enum`. Cause: it must match the values `[ENUM_VALUE, OTHER_ONE]`");
     }
 
     @Test
@@ -361,9 +362,9 @@ public class InputsTest {
         HashMap<String, Object> map = new HashMap<>(inputs);
         map.put("array", "[\"s1\", \"s2\"]");
 
-        ConstraintViolationException e = assertThrows(ConstraintViolationException.class, () -> typedInputs(map, "tenant13"));
+        InputOutputValidationException e = assertThrows(InputOutputValidationException.class, () -> typedInputs(map, "tenant13"));
 
-        assertThat(e.getMessage()).contains("Invalid input for `array`, Unable to parse array element as `INT` on `s1`, but received `[\"s1\", \"s2\"]`");
+        assertThat(e.getMessage()).contains(  "Invalid value for input `array`. Cause: Unable to parse array element as `INT` on `s1`");
     }
 
     @Test
@@ -467,7 +468,20 @@ public class InputsTest {
         assertThat(execution.getState().getCurrent()).isEqualTo(State.Type.SUCCESS);
         assertThat((String) execution.findTaskRunsByTaskId("file").getFirst().getOutputs().get("value")).isEqualTo(file.toString());
     }
+    @Test
+    @LoadFlows(value = "flows/invalids/inputs-with-multiple-constraint-violations.yaml")
+    void multipleConstraintViolations()  {
+        InputOutputValidationException ex = assertThrows(InputOutputValidationException.class, ()-> runnerUtils.runOne(MAIN_TENANT, "io.kestra.tests", "inputs-with-multiple-constraint-violations", null,
+            (f, e) ->flowIO.readExecutionInputs(f, e , Map.of("multi", List.of("F", "H")) )));
 
+        List<String> messages = Arrays.asList(ex.getMessage().split(System.lineSeparator()));
+
+        assertThat(messages).containsExactlyInAnyOrder(
+            "Invalid value for input `multi`. Cause: you can't define both `values` and `options`",
+            "Invalid value for input `multi`. Cause: value `F` doesn't match the values `[A, B, C]`",
+            "Invalid value for input `multi`. Cause: value `H` doesn't match the values `[A, B, C]`"
+        );
+    }
     private URI createFile() throws IOException {
         File tempFile = File.createTempFile("file", ".txt");
         Files.write(tempFile.toPath(), "Hello World".getBytes());

--- a/core/src/test/java/io/kestra/core/runners/NoEncryptionConfiguredTest.java
+++ b/core/src/test/java/io/kestra/core/runners/NoEncryptionConfiguredTest.java
@@ -1,5 +1,6 @@
 package io.kestra.core.runners;
 
+import io.kestra.core.exceptions.InputOutputValidationException;
 import io.kestra.core.junit.annotations.ExecuteFlow;
 import io.kestra.core.junit.annotations.LoadFlows;
 import io.kestra.core.models.executions.Execution;
@@ -71,6 +72,6 @@ public class NoEncryptionConfiguredTest implements TestPropertyProvider {
             .flowId(flow.getId())
             .build();
 
-        assertThrows(ConstraintViolationException.class, () -> flowIO.readExecutionInputs(flow, execution, InputsTest.inputs));
+        assertThrows(InputOutputValidationException.class, () -> flowIO.readExecutionInputs(flow, execution, InputsTest.inputs));
     }
 }

--- a/core/src/test/java/io/kestra/plugin/core/flow/PauseTest.java
+++ b/core/src/test/java/io/kestra/plugin/core/flow/PauseTest.java
@@ -1,6 +1,7 @@
 package io.kestra.plugin.core.flow;
 
 import com.google.common.io.CharStreams;
+import io.kestra.core.exceptions.InputOutputValidationException;
 import io.kestra.core.junit.annotations.ExecuteFlow;
 import io.kestra.core.junit.annotations.FlakyTest;
 import io.kestra.core.junit.annotations.KestraTest;
@@ -328,12 +329,12 @@ public class PauseTest {
 
             assertThat(execution.getState().getCurrent()).isEqualTo(State.Type.PAUSED);
 
-            ConstraintViolationException e = assertThrows(
-                ConstraintViolationException.class,
+            InputOutputValidationException e = assertThrows(
+                InputOutputValidationException.class,
                 () -> executionService.resume(execution, flow, State.Type.RUNNING, Mono.empty(), Pause.Resumed.now()).block()
             );
 
-            assertThat(e.getMessage()).contains("Invalid input for `asked`, missing required input, but received `null`");
+            assertThat(e.getMessage()).contains(  "Missing required input:asked");
         }
 
         @SuppressWarnings("unchecked")

--- a/core/src/test/resources/flows/invalids/inputs-with-multiple-constraint-violations.yaml
+++ b/core/src/test/resources/flows/invalids/inputs-with-multiple-constraint-violations.yaml
@@ -1,0 +1,18 @@
+id: inputs-with-multiple-constraint-violations
+namespace: io.kestra.tests
+inputs:
+  - id: multi
+    type: MULTISELECT
+    values:
+      - A
+      - B
+      - C
+    options:
+      - X
+      - Y
+      - Z
+
+tasks:
+  - id: validMultiSelect
+    type: io.kestra.plugin.core.debug.Return
+    format: "{{inputs.multi}}"

--- a/webserver/src/main/java/io/kestra/webserver/controllers/ErrorController.java
+++ b/webserver/src/main/java/io/kestra/webserver/controllers/ErrorController.java
@@ -36,6 +36,10 @@ public class ErrorController {
     public HttpResponse<JsonError> error(HttpRequest<?> request, JsonParseException e) {
         return jsonError(request, e, HttpStatus.UNPROCESSABLE_ENTITY, "Invalid json");
     }
+    @Error(global = true)
+    public HttpResponse<JsonError> error(HttpRequest<?> request, InputOutputValidationException e) {
+        return jsonError(request, e, HttpStatus.UNPROCESSABLE_ENTITY, "Invalid entity");
+    }
 
     @Error(global = true)
     public HttpResponse<JsonError> error(HttpRequest<?> request, ConversionErrorException e) {

--- a/webserver/src/main/java/io/kestra/webserver/controllers/api/ExecutionController.java
+++ b/webserver/src/main/java/io/kestra/webserver/controllers/api/ExecutionController.java
@@ -2670,7 +2670,12 @@ public class ExecutionController {
         ) {
         }
 
-        public static ApiValidateExecutionInputsResponse of(String id, String namespace, List<Check> checks, List<InputAndValue> inputs) {
+        public static ApiValidateExecutionInputsResponse of(
+            String id,
+            String namespace,
+            List<Check> checks,
+            List<InputAndValue> inputs
+        ) {
             return new ApiValidateExecutionInputsResponse(
                 id,
                 namespace,
@@ -2679,14 +2684,21 @@ public class ExecutionController {
                     it.value(),
                     it.enabled(),
                     it.isDefault(),
-                    Optional.ofNullable(it.exception()).map(exception ->
-                        exception.getConstraintViolations()
-                            .stream()
-                            .map(cv -> new ApiInputError(cv.getMessage()))
+                    // Map the Set<InputOutputValidationException> to ApiInputError
+                    Optional.ofNullable(it.exceptions())
+                        .map(exSet -> exSet.stream()
+                            .map(e -> new ApiInputError(e.getMessage()))
                             .toList()
-                    ).orElse(List.of())
+                        )
+                        .orElse(List.of())
                 )).toList(),
-                checks.stream().map(check -> new ApiCheckFailure(check.getMessage(), check.getStyle(), check.getBehavior())).toList()
+                checks.stream()
+                    .map(check -> new ApiCheckFailure(
+                        check.getMessage(),
+                        check.getStyle(),
+                        check.getBehavior()
+                    ))
+                    .toList()
             );
         }
     }

--- a/webserver/src/test/java/io/kestra/webserver/controllers/api/ExecutionControllerRunnerTest.java
+++ b/webserver/src/test/java/io/kestra/webserver/controllers/api/ExecutionControllerRunnerTest.java
@@ -242,7 +242,7 @@ class ExecutionControllerRunnerTest {
         String response = e.getResponse().getBody(String.class).orElseThrow();
 
         assertThat(response).contains("Invalid entity");
-        assertThat(response).contains("Invalid input for `validatedString`");
+        assertThat(response).contains("Invalid value for input `validatedString`");
     }
 
     @Test
@@ -1071,7 +1071,7 @@ class ExecutionControllerRunnerTest {
                 .contentType(MediaType.MULTIPART_FORM_DATA_TYPE)
         ));
         assertThat(exception.getStatus().getCode()).isEqualTo(422);
-        assertThat(exception.getMessage()).isEqualTo("Invalid entity: asked: Invalid input for `asked`, missing required input, but received `null`");
+        assertThat(exception.getMessage()).isEqualTo("Invalid entity: Missing required input:asked");
     }
 
     @Test


### PR DESCRIPTION
closes #13577
## Description
- some parts used with generic exception with all situations in Data interface causing either confusion about the correct error  or even duplication
## Solution
- Added InputOutputValidationException to represent Inputs/Outputs
  validation issues and added handler to it in ErrorsController
- Added support for throwing multiple constraint violations for the same
  input
- Added support for throwing multiple constraints at MultiselectInput
- Refactored exception handling at FlowInputOutput
- Added merge() function to combine constraint violation messages and
  added test for it at InputsTest
- Fixed the failed tests

