### PR TITLE
UI: Cleanup unnecessary useI18n usage in LowCodeEditorWrapper (Fix #13351)

### DIFF
--- a/ui/src/components/inputs/LowCodeEditorWrapper.vue
+++ b/ui/src/components/inputs/LowCodeEditorWrapper.vue
@@ -16,12 +16,12 @@
         />
         <div v-else-if="invalidGraph">
             <el-alert
-                :title="t('topology-graph.invalid')"
+                :title="$t('topology-graph.invalid')"
                 type="error"
                 class="invalid-graph"
                 :closable="false"
             >
-                {{ t('topology-graph.invalid_description') }}
+                {{ $t('topology-graph.invalid_description') }}
             </el-alert>
         </div>
     </div>
@@ -29,14 +29,11 @@
 
 <script setup lang="ts">
     import {computed, ref} from "vue";
-    import {useI18n} from "vue-i18n";
     import {Utils} from "@kestra-io/ui-libs";
     import LowCodeEditor from "./LowCodeEditor.vue";
     import {useFlowStore} from "../../stores/flow";
 
     const flowStore = useFlowStore();
-
-    const {t} = useI18n();
 
     const flowYaml = computed(() => flowStore.flowYaml);
     const flowGraph = computed(() => flowStore.flowGraph);


### PR DESCRIPTION
### ✨ Description

What does this PR change? 

This PR cleans up unnecessary usage of useI18n within LowCodeEditorWrapper.vue.
Since createI18n already exposes $t globally to Vue templates, explicit imports and destructured usage of useI18n are unnecessary in this component.

This change updates the template to use $t('...') and removes the unused import and destructure.
There are no behavioral changes — this is a straightforward UI cleanup.

### 🔗 Related Issue

Which issue does this PR resolve?

Closes https://github.com/kestra-io/kestra/issues/13351

### 🎨 Frontend Checklist

- [x] Code builds without errors (`npm run build`)
- [ ] All existing E2E tests pass (`npm run test:e2e`)
- [x] No visual regressions — UI renders identical before/after
- [x] Screenshots not required — template text-only change

### 📝 Additional Notes

This aligns the component with the preferred i18n pattern described in the issue and reduces unnecessary imports.
No logic, styling, or behavior is modified.

### 🤖 AI Authors
No thank you!