### PR TITLE
chore(executions): show all available date options for the chart on the overview page

### DIFF
--- a/ui/src/components/executions/overview/Overview.vue
+++ b/ui/src/components/executions/overview/Overview.vue
@@ -431,7 +431,7 @@
         },
     ];
 
-    const options = useValues("executions").VALUES.RELATIVE_DATE.slice(0, -1); // Remove last 365 days option
+    const options = useValues("executions").VALUES.RELATIVE_DATE;
     const timerange = ref<string>("PT168H"); // Default to last 7 days
 
     const chartRef = ref<InstanceType<typeof TimeSeries> | null>(null);


### PR DESCRIPTION
Related to https://github.com/kestra-io/kestra/issues/13361.

After the issue mentioned above got amended, the option for `365 days` does not return an error anymore on fetch, so I've introduced it again in the date selector for chart on the `Execution Overview` page.