### PR TITLE
refactor(ui): Clean up unnecessary imports and usages of the useI18n

### DIFF
--- a/ui/src/components/layout/empty/Empty.vue
+++ b/ui/src/components/layout/empty/Empty.vue
@@ -16,9 +16,11 @@
 
 <script setup lang="ts">
     import {computed} from "vue";
-    import {images} from "./images";
     
+    import {images} from "./images";
+
     const props = defineProps({type: {type: String, required: true}});
+
     const src = computed((): string => images[props.type]);
 </script>
 

--- a/ui/src/components/layout/empty/Empty.vue
+++ b/ui/src/components/layout/empty/Empty.vue
@@ -4,8 +4,8 @@
             <div class="d-flex flex-column align-items-center gap-2 px-2">
                 <img :src>
 
-                <h2>{{ t(`empty.${props.type}.title`) }}</h2>
-                <p v-html="t(`empty.${props.type}.content`)" />
+                <h2>{{ $t(`empty.${props.type}.title`) }}</h2>
+                <p v-html="$t(`empty.${props.type}.content`)" />
 
                 <slot name="button" />
             </div>
@@ -16,13 +16,9 @@
 
 <script setup lang="ts">
     import {computed} from "vue";
-
-    const props = defineProps({type: {type: String, required: true}});
-
-    import {useI18n} from "vue-i18n";
-    const {t} = useI18n({useScope: "global"});
-
     import {images} from "./images";
+    
+    const props = defineProps({type: {type: String, required: true}});
     const src = computed((): string => images[props.type]);
 </script>
 


### PR DESCRIPTION
### ✨ Description

Fixes #13588 
Removes redundant `useI18n` setup in `Empty.vue `and switches to using the globally provided `$t` helper in the template.

### 🎨 Frontend Checklist

- [x] Code builds without errors (`npm run build`)
- [x] All existing E2E tests pass (`npm run test:e2e`)



