### PR TITLE
chore(ui): simplify NamespaceSelect.vue translations by using

### DIFF
--- a/ui/src/components/namespaces/components/NamespaceSelect.vue
+++ b/ui/src/components/namespaces/components/NamespaceSelect.vue
@@ -11,7 +11,7 @@
         remote
         remoteShowSuffix
         :remoteMethod="onSearch"
-        :placeholder="t('namespaces')"
+        :placeholder="$t('namespaces')"
         :suffixIcon="readOnly ? Lock : undefined"
     >
         <template #tag>
@@ -37,13 +37,10 @@
 
 <script setup lang="ts">
     import {computed, onMounted} from "vue"
-    import {useI18n} from "vue-i18n"
     import {useNamespacesStore} from "override/stores/namespaces"
     import DotsSquare from "vue-material-design-icons/DotsSquare.vue"
     import Lock from "vue-material-design-icons/Lock.vue";
     import {defaultNamespace} from "../../../composables/useNamespaces";
-
-    const {t} = useI18n();
 
     withDefaults(defineProps<{
         multiple?: boolean,


### PR DESCRIPTION
### ✨ Description

This PR simplifies the translation usage in `NamespaceSelect.vue` by removing unnecessary `useI18n` imports and composable usage when translations occur only in the `<template>` section. The component now relies on the globally available `$t` helper, consistent with how `createI18n` exposes global properties in the UI.

### 🔗 Related Issue

Closes https://github.com/kestra-io/kestra/issues/13589

### 🎨 Frontend Checklist

- [x] Code builds without errors (`npm run build`)
- [x] All existing E2E tests pass (`npm run test:e2e`)
- [x] No UI changes introduced, so screenshots are not required

### 🛠️ Backend Checklist

_This PR does not include any backend changes._

### 📝 Additional Notes

No functional behavior changed; this is a cleanup for consistency and maintainability.

### 🤖 AI Authors

N/A
