### PR TITLE
refactor(ui): remove usage of unnecessary i18n composable in AITriggerButton.vue

### DIFF
--- a/ui/src/components/ai/AITriggerButton.vue
+++ b/ui/src/components/ai/AITriggerButton.vue
@@ -6,13 +6,12 @@
             :icon="AiIcon" 
             @click="handleClick"
         >
-            {{ t("ai.flow.title") }}
+            {{ $t("ai.flow.title") }}
         </el-button>
     </div>
 </template>
 
 <script setup lang="ts">
-    import {useI18n} from "vue-i18n";
     import AiIcon from "./AiIcon.vue";
 
     interface AITriggerButtonProps {
@@ -23,8 +22,6 @@
     interface AITriggerButtonEmits {
         (event: "click"): void;
     }
-
-    const {t} = useI18n();
 
     withDefaults(defineProps<AITriggerButtonProps>(), {
         show: false,


### PR DESCRIPTION
Fixes #12968 
Removes redundant useI18n setup in AITriggerButton.vue and switches to using the globally provided $t helper in the template.

🎨 Frontend Checklist
 Code builds without errors (npm run build)
 All existing E2E tests pass (npm run test:e2e)