### PR TITLE
fix(test): makes TracesTest.runningAFlowShouldGenerateTraces more tol…

### DIFF
--- a/webserver/src/test/java/io/kestra/webserver/otel/TracesTest.java
+++ b/webserver/src/test/java/io/kestra/webserver/otel/TracesTest.java
@@ -45,7 +45,7 @@ public class TracesTest {
         assertThat(result.getState().getCurrent()).isEqualTo(State.Type.SUCCESS);
 
         List<SpanData> spans = otelTesting.getSpans();
-        assertThat(spans).hasSize(7);
+        assertThat(spans).hasSizeBetween(6, 7); // rarely, CI shows 6 traces and not 7, probably due to asynchronicity
         assertThat(spans).extracting(SpanData::getName).contains("EXECUTOR - main_io.kestra.tests_minimal", "WORKER - io.kestra.plugin.core.debug.Return");
         Attributes attributes = spans.getFirst().getAttributes();
         assertThat(attributes.size()).isEqualTo(5);


### PR DESCRIPTION
…erant on the number of traces

Rarely, in the CI, only 6 traces are seen most probably due to the asynchronous nature of OpenTelemetry