### PR TITLE
fix: clicking on a plugin should access the plugin page

### DIFF
--- a/ui/src/components/plugins/Plugin.vue
+++ b/ui/src/components/plugins/Plugin.vue
@@ -153,7 +153,7 @@
             version.value = route.params.version as string;
         }
 
-        const clsParam = route.params.version as string | undefined;
+        const clsParam = route.params.cls as string | undefined;
         if (!clsParam) {
             return;
         }


### PR DESCRIPTION
follow-up to https://github.com/kestra-io/kestra/pull/13571