### PR TITLE
refactor(ui): simplify ClearButton translations using global $t

### DIFF
--- a/ui/src/components/no-code/components/tasks/ClearButton.vue
+++ b/ui/src/components/no-code/components/tasks/ClearButton.vue
@@ -4,14 +4,12 @@
         type="button"
         @click="emit('click')"
     >
-        <CloseIcon class="clear-icon" />{{ t("no_code.clearSelection") }}
+        <CloseIcon class="clear-icon" />{{ $t("no_code.clearSelection") }}
     </button>
 </template>
 
 <script setup lang="ts">
     import CloseIcon from "vue-material-design-icons/Close.vue";
-    import {useI18n} from "vue-i18n";
-    const {t} = useI18n();
     const emit = defineEmits(["click"]);
 </script>
 


### PR DESCRIPTION
### ✨ Description

This PR refactors `kestra/ui/src/components/no-code/components/tasks/ClearButton.vue` to simplify how translations are handled.
- Removed the unnecessary import and usage of `useI18n` from the `<script>` section.
- Updated the `<template>` to use the globally exposed `$t` helper for the "Clear Selection" text.

### 🔗 Related Issue

Closes #13639

### 🎨 Frontend Checklist

- [x] Code builds without errors (`npm run build`)
- [x] All existing E2E tests pass (`npm run test:e2e`)
- [ ] Screenshots or video recordings attached showing the `UI` changes

### 📝 Additional Notes

