### PR TITLE
refactor(ui): Simplify Add.vue translations by using $t in template section

### DIFF
--- a/ui/src/components/no-code/components/Add.vue
+++ b/ui/src/components/no-code/components/Add.vue
@@ -2,16 +2,13 @@
     <button @click="emit('add', what)" class="py-2 adding" type="button">
         {{
             what
-                ? t("no_code.adding", {what})
-                : t("no_code.adding_default")
+                ? $t("no_code.adding", {what})
+                : $t("no_code.adding_default")
         }}
     </button>
 </template>
 
 <script setup lang="ts">
-    import {useI18n} from "vue-i18n";
-    const {t} = useI18n({useScope: "global"});
-
     const emit = defineEmits<{
         (e: "add", what: string | undefined): void;
     }>();


### PR DESCRIPTION
### ✨ Description

Removes unnecessary `useI18n` composable import and usage from `Add.vue`, replacing `t()` calls with the globally available `$t` helper in the template section.

### 🔗 Related Issue

Closes https://github.com/kestra-io/kestra/issues/13590

### 🎨 Frontend Checklist

- [x] Code builds without errors (`npm run build`)
- [ ] All existing E2E tests pass (`npm run test:e2e`)
- [ ] Screenshots or video recordings attached showing the `UI` changes

### 📝 Additional Notes

This is a simple refactoring with no visual or functional changes - the $t helper works identically to the t function from useI18n when used in templates, so E2E tests and screenshots are not applicable.