### PR TITLE
fix: resolve icon offset issue in Triggers UI when locked trigger present

### DIFF
--- a/ui/src/components/admin/Triggers.vue
+++ b/ui/src/components/admin/Triggers.vue
@@ -200,7 +200,7 @@
 
                         <el-table-column
                             v-if="authStore.user.hasAnyAction(permission.EXECUTION, action.UPDATE)"
-                            columnKey="action"
+                            columnKey="unlock"
                             className="row-action"
                         >
                             <template #default="scope">
@@ -213,6 +213,14 @@
                                         <LockOff />
                                     </Kicon>
                                 </el-button>
+                            </template>
+                        </el-table-column>
+                        <el-table-column
+                            v-if="authStore.user.hasAnyAction(permission.EXECUTION, action.UPDATE)"
+                            columnKey="delete"
+                            className="row-action"
+                        >
+                            <template #default="scope">
                                 <el-button>
                                     <Kicon
                                         :tooltip="$t('delete trigger')"


### PR DESCRIPTION
## Summary
This PR fixes the icon offset issue in the Triggers Administration UI when a locked trigger is present.

## Changes
- Split the action column into two separate columns: one for the unlock button and one for the delete button
- This prevents icon misalignment by ensuring each button has its own properly sized column
- Follows the same pattern used in `FlowTriggers.vue` for similar action buttons

## Root Cause
The issue was caused by placing both buttons (unlock and delete) in a single column with a fixed width of 24px. Each button requires 28px, so when both were present (locked trigger), they overflowed and caused misalignment.

## Test Plan
- [x] Tested with triggers that have `executionId` or `evaluateRunningDate` (locked triggers)
- [x] Tested with triggers that don't have these fields (unlocked triggers)
- [x] Verified icons are now properly aligned in both cases

Fixes #13642

🤖 Generated with [Claude Code](https://claude.com/claude-code)