### PR TITLE
fix(triggers): improve layout of action buttons in trigger table

### DIFF
--- a/ui/src/components/admin/Triggers.vue
+++ b/ui/src/components/admin/Triggers.vue
@@ -204,24 +204,26 @@
                             className="row-action"
                         >
                             <template #default="scope">
-                                <el-button v-if="scope.row.executionId || scope.row.evaluateRunningDate">
-                                    <Kicon
-                                        :tooltip="$t(`unlock trigger.tooltip.${scope.row.executionId ? 'execution' : 'evaluation'}`)"
-                                        placement="left"
-                                        @click="triggerToUnlock = scope.row"
-                                    >
-                                        <LockOff />
-                                    </Kicon>
-                                </el-button>
-                                <el-button>
-                                    <Kicon
-                                        :tooltip="$t('delete trigger')"
-                                        placement="left"
-                                        @click="confirmDeleteTrigger(scope.row)"
-                                    >
-                                        <Delete />
-                                    </Kicon>
-                                </el-button>
+                                <div style="display: flex; align-items: center; gap: 5px;">
+                                    <el-button v-if="scope.row.executionId || scope.row.evaluateRunningDate">
+                                        <Kicon
+                                            :tooltip="$t(`unlock trigger.tooltip.${scope.row.executionId ? 'execution' : 'evaluation'}`)"
+                                            placement="left"
+                                            @click="triggerToUnlock = scope.row"
+                                        >
+                                            <LockOff />
+                                        </Kicon>
+                                    </el-button>
+                                    <el-button>
+                                        <Kicon
+                                            :tooltip="$t('delete trigger')"
+                                            placement="left"
+                                            @click="confirmDeleteTrigger(scope.row)"
+                                        >
+                                            <Delete />
+                                        </Kicon>
+                                    </el-button>
+                                </div>
                             </template>
                         </el-table-column>
                         <el-table-column :label="$t('backfill')" columnKey="backfill">

--- a/ui/src/components/admin/Triggers.vue
+++ b/ui/src/components/admin/Triggers.vue
@@ -204,7 +204,7 @@
                             className="row-action"
                         >
                             <template #default="scope">
-                                <div style="display: flex; align-items: center; gap: 5px;">
+                                <div class="action-container">
                                     <el-button v-if="scope.row.executionId || scope.row.evaluateRunningDate">
                                         <Kicon
                                             :tooltip="$t(`unlock trigger.tooltip.${scope.row.executionId ? 'execution' : 'evaluation'}`)"
@@ -855,6 +855,12 @@
     .backfillContainer {
         display: flex;
         align-items: center;
+    }
+
+    .action-container {
+        display: flex;
+        align-items: center;
+        gap: 5px;
     }
 
     .statusIcon {


### PR DESCRIPTION
### ✨ Description

This PR fixes a visual bug in the **Administration -> Triggers** table where the action buttons (Unlock and Delete) were misaligned and wrapping onto multiple lines.

I have wrapped the action buttons in a flex container to ensure they remain aligned horizontally on the same row.

### 🔗 Related Issue

Closes #13642

### 🎨 Frontend Checklist

- [x] Code builds without errors (`npm run build`)
- [x] All existing E2E tests pass (`npm run test:e2e`)
- [x] Screenshots or video recordings attached showing the `UI` changes

#### Before
<img width="1680" height="1050" alt="Screenshot 2025-12-13 at 2 20 06 PM" src="https://github.com/user-attachments/assets/bbb9f24c-e4b3-41a5-8f8d-9765b97379f9" />

#### After
<img width="1680" height="1050" alt="Screenshot 2025-12-13 at 2 18 24 PM" src="https://github.com/user-attachments/assets/2e3b3489-2d87-4f2c-9a17-8000dee92b7d" />
