### PR TITLE
ui: use  in Auth dropdown template

### DIFF
--- a/ui/src/override/components/auth/Auth.vue
+++ b/ui/src/override/components/auth/Auth.vue
@@ -4,7 +4,7 @@
         :popperOffset="20"
         :showArrow="false"
         :suffixIcon="ChevronRight"
-        :placeholder="t('kestra')"
+        :placeholder="$t('kestra')"
         popperClass="user-select border border-0"
     >
         <template #prefix>
@@ -14,27 +14,27 @@
             <el-option :value="{}" class=" list-unstyled">
                 <div class="menu-item">
                     <img src="../../../assets/ks-logo-small.svg" width="40" alt="Kestra">
-                    {{ t("kestra") }}
+                    {{ $t("kestra") }}
                 </div>
             </el-option>
         </template>
         <el-option label="Settings" value="settings">
             <RouterLink :to="{name: 'settings'}" class="menu-item">
                 <CogOutline class="menu-icon" />
-                {{ t("settings.label") }}
+                {{ $t("settings.label") }}
             </RouterLink>
         </el-option>
         <el-option label="slack" value="slack">
             <a href="https://kestra.io/slack" target="_blank" class="menu-item">
                 <Slack class="menu-icon" />
-                {{ t("join_slack") }}
+                {{ $t("join_slack") }}
             </a>
         </el-option>
         <template #footer>
             <el-option class="list-unstyled" :value="'logout'" @click="logout">
                 <div class="menu-item">
                     <Logout class="menu-icon" />
-                    {{ t("setup.logout") }}
+                    {{ $t("setup.logout") }}
                 </div>
             </el-option>
         </template>
@@ -43,7 +43,6 @@
 
 <script setup lang="ts">
     import {RouterLink, useRouter} from "vue-router";
-    import {useI18n} from "vue-i18n";
 
     import CogOutline from "vue-material-design-icons/CogOutline.vue";
     import Slack from "vue-material-design-icons/Slack.vue";
@@ -55,7 +54,6 @@
 
     const router = useRouter();
     const axios = useAxios();
-    const {t} = useI18n();
 
     const logout = () => {
         BasicAuth.logout();


### PR DESCRIPTION
### ✨ Description

This PR removes unnecessary usage of the `useI18n` composable in [ui/src/override/components/auth/Auth.vue] and relies on the globally available `$t` helper for template-only translations (provided by `createI18n`).

Changes:
- Replace `t(...)` calls in the `<template>` with `$t(...)`
- Remove `useI18n` import and `const { t } = useI18n()` from `<script setup>`

### 🔗 Related Issue

Closes https://github.com/kestra-io/kestra/issues/13651

### 🎨 Frontend Checklist

- [x] Code builds without errors (`npm run build`)
- [ ] All existing E2E tests pass (`npm run test:e2e`)
- [ ] Screenshots or video recordings attached showing the UI changes

### 📝 Additional Notes

- Cleanup-only change limited to [ui/src/override/components/auth/Auth.vue](cci:7://file:///c:/Users/madha/OneDrive/Desktop/KestraOSS2/kestra/ui/src/override/components/auth/Auth.vue:0:0-0:0).
- While running `npm run dev`, the Vite proxy may show `/api/v1/configs` connection errors if the backend is not running; this PR does not change API behavior.
