### PR TITLE
simplify Creation.vue translations

### DIFF
--- a/ui/src/components/no-code/components/tasks/taskList/buttons/Creation.vue
+++ b/ui/src/components/no-code/components/tasks/taskList/buttons/Creation.vue
@@ -11,7 +11,6 @@
     } from "../../../../injectionKeys";
     import {Plus} from "../../../../utils/icons";
 
-
     const props = defineProps<{
         parentPathComplete: string;
         blockSchemaPath: string;

--- a/ui/src/components/no-code/components/tasks/taskList/buttons/Creation.vue
+++ b/ui/src/components/no-code/components/tasks/taskList/buttons/Creation.vue
@@ -1,6 +1,6 @@
 <template>
     <el-button @click.prevent.stop="handleClick()" type="primary" :icon="Plus">
-        {{ t("add") }}
+        {{ $t("add") }}
     </el-button>
 </template>
 
@@ -11,9 +11,6 @@
     } from "../../../../injectionKeys";
     import {Plus} from "../../../../utils/icons";
 
-
-    import {useI18n} from "vue-i18n";
-    const {t} = useI18n({useScope: "global"});
 
     const props = defineProps<{
         parentPathComplete: string;


### PR DESCRIPTION
### ✨ Description

What does this PR change?  

- Removed unnecessary useI18n usage from Creation.vue
- Switched to global $t helper in template
- No functional changes, translations remain unchanged


### 🔗 Related Issue

Which issue does this PR resolve? 

Closes https://github.com/kestra-io/kestra/issues/13650

### 🎨 Frontend Checklist

_If this PR does not include any frontend changes, delete this entire section._

- [x] Code builds without errors (`npm run build`)
- [ ] All existing E2E tests pass (`npm run test:e2e`)
