### PR TITLE
fix(ui): simplify Actions.vue translations using  helper

### DIFF
--- a/ui/src/override/components/flows/Actions.vue
+++ b/ui/src/override/components/flows/Actions.vue
@@ -7,14 +7,14 @@
         v-if="deleted"
         type="default"
         :icon="BackupRestore"
-        :label="t('restore')"
+        :label="$t('restore')"
         @click="restoreFlow"
     />
     <Action
         v-if="canEdit && !deleted && tab !== 'edit'"
         type="default"
         :icon="Pencil"
-        :label="t('edit flow')"
+        :label="$t('edit flow')"
         @click="editFlow"
     />
     <TriggerFlow
@@ -28,7 +28,6 @@
 
 <script setup lang="ts">
     import {computed} from "vue";
-    import {useI18n} from "vue-i18n";
     import {useRoute, useRouter} from "vue-router";
     import {useFlowStore} from "../../../stores/flow";
     import * as YAML_UTILS from "@kestra-io/ui-libs/flow-yaml-utils";
@@ -43,8 +42,6 @@
     import action from "../../../models/action";
     import {useAuthStore} from "override/stores/auth";
     import {useUnsavedChangesStore} from "../../../stores/unsavedChanges";
-
-    const {t} = useI18n();
 
     const onSelectDashboard = (value: any) => {
         router.replace({


### PR DESCRIPTION
### ✨ Description

Simplified i18n translations in [Actions.vue](cci:7://file:///Users/suraj/Documents/Personal-work/open-source/kestra/ui/src/override/components/flows/Actions.vue:0:0-0:0) by using the globally exposed `$t` helper directly in the template instead of importing `useI18n` composable. This follows Vue I18n best practices when translations are only needed in the template section.

**Changes:**
- Removed `useI18n` import and composable usage
- Replaced [t()](cci:1://file:///Users/suraj/Documents/Personal-work/open-source/kestra/ui/src/override/components/flows/Actions.vue:70:4-80:6) with `$t()` in template bindings

### 🔗 Related Issue

Closes https://github.com/kestra-io/kestra/issues/13652

### 🎨 Frontend Checklist

- [x] Code builds without errors (`npm run build`)
- [ ] All existing E2E tests pass (`npm run test:e2e`)
- [ ] Screenshots or video recordings attached showing the `UI` changes

**Note:** No visual UI changes - only internal refactoring. Buttons display the same translated text as before.

### 🛠️ Backend Checklist

_This PR does not include any backend changes._

### 📝 Additional Notes

Automated verification completed:
- ✅ ESLint: No errors
- ✅ TypeScript: No type errors