### PR TITLE
feat(system): save the edition in settings

### DIFF
--- a/core/src/main/java/io/kestra/core/models/Setting.java
+++ b/core/src/main/java/io/kestra/core/models/Setting.java
@@ -16,6 +16,7 @@ import jakarta.validation.constraints.NotNull;
 public class Setting {
     public static final String INSTANCE_UUID = "instance.uuid";
     public static final String INSTANCE_VERSION = "instance.version";
+    public static final String INSTANCE_EDITION = "instance.edition";
 
     @NotNull
     private String key;

--- a/core/src/main/java/io/kestra/core/utils/EditionProvider.java
+++ b/core/src/main/java/io/kestra/core/utils/EditionProvider.java
@@ -1,11 +1,37 @@
 package io.kestra.core.utils;
 
+import io.kestra.core.models.Setting;
+import io.kestra.core.repositories.SettingRepositoryInterface;
+import jakarta.annotation.PostConstruct;
+import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
+
+import java.util.Optional;
 
 @Singleton
 public class EditionProvider {
     public Edition get() {
         return Edition.OSS;
+    }
+
+    @Inject
+    private Optional<SettingRepositoryInterface> settingRepository; // repositories are not always there on unit tests
+
+    @PostConstruct
+    void start() {
+        // check the edition in the settings and update if needed, we didn't use it would allow us to detect incompatible update later if needed
+        settingRepository.ifPresent(settingRepositoryInterface -> persistEdition(settingRepositoryInterface, get()));
+    }
+
+    private void persistEdition(SettingRepositoryInterface settingRepositoryInterface, Edition edition) {
+        Optional<Setting> versionSetting = settingRepositoryInterface.findByKey(Setting.INSTANCE_EDITION);
+        if (versionSetting.isEmpty() || !versionSetting.get().getValue().equals(edition)) {
+            settingRepositoryInterface.save(Setting.builder()
+                .key(Setting.INSTANCE_EDITION)
+                .value(edition)
+                .build()
+            );
+        }
     }
 
     public enum Edition {

--- a/core/src/test/java/io/kestra/core/utils/EditionProviderTest.java
+++ b/core/src/test/java/io/kestra/core/utils/EditionProviderTest.java
@@ -1,14 +1,23 @@
 package io.kestra.core.utils;
 
-import io.kestra.core.junit.annotations.KestraTest;
+import io.kestra.core.models.Setting;
+import io.kestra.core.repositories.SettingRepositoryInterface;
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
 import jakarta.inject.Inject;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-@KestraTest
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@MicronautTest
 public class EditionProviderTest {
     @Inject
     private EditionProvider editionProvider;
+
+    @Inject
+    private SettingRepositoryInterface settingRepository;
 
     protected EditionProvider.Edition expectedEdition() {
         return EditionProvider.Edition.OSS;
@@ -17,5 +26,10 @@ public class EditionProviderTest {
     @Test
     void shouldReturnCurrentEdition() {
         Assertions.assertEquals(expectedEdition(), editionProvider.get());
+
+        // check that the edition is persisted in settings
+        Optional<Setting> editionSettings = settingRepository.findByKey(Setting.INSTANCE_EDITION);
+        assertThat(editionSettings).isPresent();
+        assertThat(editionSettings.get().getValue()).isEqualTo(expectedEdition().name());
     }
 }

--- a/core/src/test/java/io/kestra/core/utils/VersionProviderTest.java
+++ b/core/src/test/java/io/kestra/core/utils/VersionProviderTest.java
@@ -1,0 +1,30 @@
+package io.kestra.core.utils;
+
+import io.kestra.core.models.Setting;
+import io.kestra.core.repositories.SettingRepositoryInterface;
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@MicronautTest
+class VersionProviderTest {
+    @Inject
+    private VersionProvider versionProvider;
+
+    @Inject
+    private SettingRepositoryInterface settingRepository;
+
+    @Test
+    void shouldResolveVersion() {
+        assertThat(versionProvider.getVersion()).endsWith("-SNAPSHOT");
+
+        // check that the version is persisted in settings
+        Optional<Setting> versionSettings = settingRepository.findByKey(Setting.INSTANCE_VERSION);
+        assertThat(versionSettings).isPresent();
+        assertThat(versionSettings.get().getValue()).isEqualTo(versionProvider.getVersion());
+    }
+}


### PR DESCRIPTION
This would allow to detect OSS -> EE migration.

Closes https://github.com/kestra-io/kestra-ee/issues/5106
