### PR TITLE
[fix-13637]: Prevent rendering of dependent inputs until dependencies are satisfied

### DIFF
--- a/core/src/main/java/io/kestra/core/runners/FlowInputOutput.java
+++ b/core/src/main/java/io/kestra/core/runners/FlowInputOutput.java
@@ -311,14 +311,20 @@ public class FlowInputOutput {
                 return resolvable.get();
             }
 
+            boolean isRenderEnabled = (dependencies.isEmpty() ||
+                dependencies.values().stream().allMatch(item -> (item.input() != null) &&
+                    (!item.input().getRequired() || item.value() != null)));
+
             // render input
-            input = RenderableInput.mayRenderInput(input, expression -> {
-                try {
-                    return runContext.renderTyped(expression);
-                } catch (IllegalVariableEvaluationException e) {
-                    throw new RuntimeException(e.getMessage(), e);
-                }
-            });
+            if (isRenderEnabled) {
+                input = RenderableInput.mayRenderInput(input, expression -> {
+                    try {
+                        return runContext.renderTyped(expression);
+                    } catch (IllegalVariableEvaluationException e) {
+                        throw new RuntimeException(e.getMessage(), e);
+                    }
+                });
+            }
             resolvable.setInput(input);
 
             Object value = resolvable.get().value();

--- a/core/src/test/java/io/kestra/core/runners/FlowInputOutputTest.java
+++ b/core/src/test/java/io/kestra/core/runners/FlowInputOutputTest.java
@@ -7,6 +7,7 @@ import io.kestra.core.models.flows.input.FileInput;
 import io.kestra.core.models.flows.input.InputAndValue;
 import io.kestra.core.models.flows.input.IntInput;
 import io.kestra.core.models.flows.input.MultiselectInput;
+import io.kestra.core.models.flows.input.SelectInput;
 import io.kestra.core.models.flows.input.StringInput;
 import io.kestra.core.models.property.Property;
 import io.kestra.core.repositories.KvMetadataRepositoryInterface;
@@ -359,6 +360,56 @@ class FlowInputOutputTest {
 
         // Then
         Assertions.assertEquals(TEST_SECRET_VALUE, ((MultiselectInput)results.getFirst().input()).getValues().getFirst());
+    }
+
+    private InputAndValue setupRenderSelectInputTest(Map<String, Object> data) {
+        StringInput valueInput = StringInput.builder()
+            .id("value")
+            .type(Type.STRING)
+            .required(true)
+            .build();
+
+        SelectInput selectInput = SelectInput.builder()
+            .id("select")
+            .type(Type.SELECT)
+            .dependsOn(new DependsOn(
+                List.of("value"), null))
+            .expression("{{ [inputs.value] }}")
+            .required(true)
+            .build();
+
+        List<Input<?>> inputs = List.of(valueInput, selectInput);
+        List<InputAndValue> values = flowInputOutput.resolveInputs(inputs, null, DEFAULT_TEST_EXECUTION, data);
+
+        return values.stream()
+            .filter(r -> r.input().getId().equals("select"))
+            .findFirst()
+            .orElseThrow();
+    }
+
+    @Test
+    void shouldNotRenderSelectInputWhenDependenciesHaveNoValues() {
+        // Given
+        Map<String, Object> data = Map.of();
+
+        // When
+        InputAndValue selectInputResult = setupRenderSelectInputTest(data);
+
+        // Then
+        assertThat(((SelectInput) selectInputResult.input()).getValues()).isNull();
+    }
+
+    @Test
+    void shouldRenderSelectInputWhenDependenciesHaveValues() {
+        // Given
+        Map<String, Object> data = Map.of("value", "value1");
+
+        // When
+        InputAndValue selectInputResult = setupRenderSelectInputTest(data);
+
+        // Then
+        assertThat(((SelectInput) selectInputResult.input()).getValues()).isEqualTo(
+            List.of("value1"));
     }
 
     @Test


### PR DESCRIPTION
### Problem

Dynamic inputs with `dependsOn` are evaluated eagerly, even when one or more dependent inputs are unset. This causes expressions (e.g. `http()`) to be evaluated with `null` values, leading to invalid requests such as `/null`.

This happens despite `dependsOn` being defined and required inputs not yet having a value.

### Solution

This PR introduces a lazy-rendering guard for dynamic inputs.

An input is now rendered (and its expression evaluated) only if:
- it has no dependencies, **or**
- all dependent inputs are present, and
- for each dependency, either:
  - the input is not required, or
  - the input value is not `null`

This prevents expression evaluation until all required dependencies are satisfied, avoiding unintended side effects such as premature HTTP calls.

### Implementation details

The render condition is now gated by the following logic:

```java
boolean isRenderEnabled = dependencies.isEmpty() ||
    dependencies.values().stream().allMatch(item ->
        item.input() != null &&
        (!item.input().getRequired() || item.value() != null)
    );
```

### Tests

This PR adds two unit tests covering the new behavior:

1. Verifies that a dependent SELECT input is **not rendered / evaluated**
   when its required dependency has no value (result remains `null`).
2. Verifies that the SELECT input is correctly rendered and populated
   once the dependent input has a value.

### Related issue

Closes https://github.com/kestra-io/kestra/issues/13637

### 🛠️ Backend Checklist

- [x] Code compiles successfully and passes all checks
- [ ] All unit and integration tests pass

