### PR TITLE
[Fix] highlight duplicate IDs in Flow code editor and remove leading colon

### DIFF
--- a/core/src/main/java/io/kestra/core/services/FlowService.java
+++ b/core/src/main/java/io/kestra/core/services/FlowService.java
@@ -97,6 +97,8 @@ public class FlowService {
         if (message.startsWith("Illegal flow source:")) {
             // Already formatted by YamlParser, return as-is
             return message;
+        } else if (message.startsWith(":")) {
+            message = message.substring(1);
         }
         // For other validation errors, provide context
         return "Validation error: " + message;

--- a/core/src/test/java/io/kestra/core/validations/FlowValidationTest.java
+++ b/core/src/test/java/io/kestra/core/validations/FlowValidationTest.java
@@ -141,7 +141,7 @@ class FlowValidationTest {
         Optional<ConstraintViolationException> validate = modelValidator.isValid(flow);
 
         assertThat(validate.isPresent()).isTrue();
-        assertThat(validate.get().getMessage()).contains(": Invalid Flow: Recursive call to flow [io.kestra.tests.recursive-flow]");
+        assertThat(validate.get().getMessage()).contains("Invalid Flow: Recursive call to flow [io.kestra.tests.recursive-flow]");
     }
 
     @Test

--- a/ui/src/components/inputs/Editor.vue
+++ b/ui/src/components/inputs/Editor.vue
@@ -96,7 +96,7 @@
     import MonacoEditor from "./MonacoEditor.vue";
     import type * as monaco from "monaco-editor/esm/vs/editor/editor.api";
     import {useScrollMemory} from "../../composables/useScrollMemory";
-
+    import {findDuplicateTaskIds} from "../../utils/yamlValidation.ts"
     const {t} = useI18n()
 
     const props = defineProps({
@@ -187,6 +187,34 @@
         }
     );
 
+    watch(
+        () => props.modelValue,
+        (newValue) => {
+            if (!editor || !isCodeEditor(editor) || !monacoEditor.value) return;
+
+            const model = editor.getModel();
+            if (!model) return;
+
+            // Only run for YAML files
+            if (props.lang !== "yaml") return;
+
+            const duplicateMarkers = findDuplicateTaskIds(newValue);
+
+            monacoEditor.value.monaco.editor.setModelMarkers(
+                model,
+                "duplicate-task-ids",
+                duplicateMarkers.map((m) => ({
+                    startLineNumber: m.startLineNumber,
+                    startColumn: m.startColumn,
+                    endLineNumber: m.endLineNumber,
+                    endColumn: m.endColumn,
+                    message: m.message,
+                    severity: monacoEditor.value!.monaco.MarkerSeverity.Error,
+                }))
+            );
+        },
+        {immediate: true}
+    );
 
     const themeComputed = computed(() => {
         return useMiscStore().theme;
@@ -276,7 +304,7 @@
         const settingsEditorFontSize = localStorage.getItem("editorFontSize")
 
         return {
-            
+
             tabSize: 2,
             fontFamily: localStorage.getItem("editorFontFamily")
                 ? localStorage.getItem("editorFontFamily")
@@ -335,25 +363,25 @@
         }
 
         const codeEditor = editor as monaco.editor.IStandaloneCodeEditor;
-        
-        
+
+
         if (props.scrollKey && scrollMemory) {
             const savedState = scrollMemory.loadData<monaco.editor.ICodeEditorViewState>("viewState");
             if (savedState) {
                 codeEditor.restoreViewState(savedState);
                 codeEditor.revealLineInCenterIfOutsideViewport?.(codeEditor.getPosition()?.lineNumber ?? 1);
             }
-            
+
             const top = scrollMemory.loadData<number>("scrollTop", 0);
             if (typeof top === "number") {
                 codeEditor.setScrollTop(top);
             }
-            
+
             const throttledSave = useThrottleFn(() => {
                 scrollMemory.saveData(codeEditor.saveViewState(), "viewState");
                 scrollMemory.saveData(codeEditor.getScrollTop(), "scrollTop");
             }, 100);
-            
+
             codeEditor.onDidScrollChange?.(throttledSave);
         }
 

--- a/ui/src/utils/yamlValidation.ts
+++ b/ui/src/utils/yamlValidation.ts
@@ -1,0 +1,98 @@
+import {parseDocument, isMap, isSeq, Scalar, YAMLMap} from "yaml";
+
+export interface EditorMarker {
+    taskId: string;
+    message: string;
+    startLineNumber: number;
+    startColumn: number;
+    endLineNumber: number;
+    endColumn: number;
+    severity: "error" | "warning" | "info";
+}
+
+/**
+ * Finds duplicate task IDs in a YAML flow source and returns markers for the duplicates.
+ */
+export function findDuplicateTaskIds(yamlSource: string): EditorMarker[] {
+    const markers: EditorMarker[] = [];
+
+    try {
+        const doc = parseDocument(yamlSource, {keepSourceTokens: true});
+        const seenIds = new Map<string, {line: number; col: number}>();
+
+        const processTasks = (tasks: unknown) => {
+            if (!isSeq(tasks)) return;
+
+            for (const task of tasks.items) {
+                if (!isMap(task)) continue;
+
+                const idPair = (task as YAMLMap).items.find(
+                    (pair) => (pair.key as Scalar)?.value === "id"
+                );
+
+                if (idPair && idPair.value) {
+                    const idNode = idPair.value as Scalar;
+                    const idValue = String(idNode.value);
+
+                    if (idValue && idNode.range) {
+                        const pos = getLineCol(yamlSource, idNode.range[0]);
+
+                        if (seenIds.has(idValue)) {
+                            // Found a duplicate - add marker
+                            const endPos = getLineCol(yamlSource, idNode.range[1]);
+                            markers.push({
+                                taskId: idValue,
+                                message: `Duplicate task id: "${idValue}"`,
+                                startLineNumber: pos.line,
+                                startColumn: pos.col,
+                                endLineNumber: endPos.line,
+                                endColumn: endPos.col,
+                                severity: "error"
+                            });
+                        } else {
+                            seenIds.set(idValue, pos);
+                        }
+                    }
+                }
+
+                // Recursively check nested tasks (Sequential, Parallel, etc.)
+                const taskMap = task as YAMLMap;
+                for (const pair of taskMap.items) {
+                    const key = (pair.key as Scalar)?.value;
+                    if (key === "tasks" || key === "errors" || key === "finally") {
+                        processTasks(pair.value);
+                    }
+                }
+            }
+        };
+
+        // Process top-level tasks, errors, and finally
+        const contents = doc.contents;
+        if (isMap(contents)) {
+            for (const pair of contents.items) {
+                const key = (pair.key as Scalar)?.value;
+                if (key === "tasks" || key === "errors" || key === "finally") {
+                    processTasks(pair.value);
+                }
+            }
+        }
+    } catch {
+        // If YAML parsing fails, return empty (other validators handle syntax errors)
+    }
+
+    return markers;
+}
+
+function getLineCol(source: string, offset: number): {line: number; col: number} {
+    let line = 1;
+    let col = 1;
+    for (let i = 0; i < offset && i < source.length; i++) {
+        if (source[i] === "\n") {
+            line++;
+            col = 1;
+        } else {
+            col++;
+        }
+    }
+    return {line, col};
+}


### PR DESCRIPTION
### ✨ Description
This PR removes the leading colon in the error notification box, and highlights duplicate IDs in real time in the flow code editor.

Before:  
<img width="1293" height="447" alt="image" src="https://github.com/user-attachments/assets/ebd09df2-b8c9-46c5-8592-481ce1608cf2" />


After"
<img width="1357" height="420" alt="image" src="https://github.com/user-attachments/assets/a70a0931-7c63-43bc-b94c-683ed7267974" />

### 🔗 Related Issue
Fixes #13644

### 🎨 Frontend Checklist

_If this PR does not include any frontend changes, delete this entire section._

- [x] Code builds without errors (`npm run build`)
- [ ] All existing E2E tests pass (`npm run test:e2e`)
- [x] Screenshots or video recordings attached showing the `UI` changes

### 🛠️ Backend Checklist

_If this PR does not include any backend changes, delete this entire section._

- [x] Code compiles successfully and passes all checks
- [ ] All unit and integration tests pass
