### PR TITLE
Revert "chore(deps): upgrade Micronaut to 4.10.5"

### DIFF
--- a/platform/build.gradle
+++ b/platform/build.gradle
@@ -30,7 +30,7 @@ dependencies {
     // as Jackson is in the Micronaut BOM, to force its version we need to use enforcedPlatform but it didn't really work, see later :(
     api enforcedPlatform("com.fasterxml.jackson:jackson-bom:$jacksonVersion")
     api enforcedPlatform("org.slf4j:slf4j-api:$slf4jVersion")
-    api platform("io.micronaut.platform:micronaut-platform:4.10.5")
+    api platform("io.micronaut.platform:micronaut-platform:4.9.4")
     api platform("io.qameta.allure:allure-bom:2.32.0")
     // we define cloud bom here for GCP, Azure and AWS so they are aligned for all plugins that use them (secret, storage, oss and ee plugins)
     api platform('com.google.cloud:libraries-bom:26.73.0')
@@ -38,8 +38,6 @@ dependencies {
     api platform('software.amazon.awssdk:bom:2.40.10')
     api platform("dev.langchain4j:langchain4j-bom:$langchain4jVersion")
     api platform("dev.langchain4j:langchain4j-community-bom:$langchain4jCommunityVersion")
-    // Micronaut 4.10 brings a Jetty version no compatible with the one from Wiremock so we bump it here
-    api platform("org.eclipse.jetty.ee10:jetty-ee10-bom:12.1.2")
 
     constraints {
         // downgrade to proto 1.3.2-alpha as 1.5.0 needs protobuf 4

--- a/webserver/build.gradle
+++ b/webserver/build.gradle
@@ -19,10 +19,6 @@ dependencies {
     implementation "io.micronaut:micronaut-management"
     implementation "io.micronaut:micronaut-http-client"
     implementation "io.micronaut:micronaut-http-server-netty"
-    // See https://github.com/netty-contrib/codec-multipart/pull/25
-    // See https://github.com/kestra-io/kestra/issues/9743
-    // There is an issue on Netty multipart content decoding that is fixed in 5.x, this library will bring the same fix for 4.x
-    implementation("io.netty.contrib:netty-codec-multipart-vintage:1.0.0.Alpha1")
     implementation "io.micronaut.cache:micronaut-cache-core"
     implementation "io.micronaut.cache:micronaut-cache-caffeine"
 


### PR DESCRIPTION
- This reverts commits 167734e32a8452abb2278ada788637aa7d99c9e8. and 44d0c107132363f131c2e6363ce2578f4b7cac95
- from PR https://github.com/kestra-io/kestra/pull/13733

there is at least an issue on validation in test: ExecutionControllerRunnerTest.searchExecutions()