### PR TITLE
fix(core): remove tenantId substring check on file path

### DIFF
--- a/core/src/main/java/io/kestra/core/runners/pebble/functions/AbstractFileFunction.java
+++ b/core/src/main/java/io/kestra/core/runners/pebble/functions/AbstractFileFunction.java
@@ -1,5 +1,6 @@
 package io.kestra.core.runners.pebble.functions;
 
+import com.cronutils.utils.VisibleForTesting;
 import io.kestra.core.runners.LocalPath;
 import io.kestra.core.runners.LocalPathFactory;
 import io.kestra.core.services.NamespaceService;
@@ -155,26 +156,11 @@ abstract class AbstractFileFunction implements Function {
     }
 
     private String checkIfFileFromAllowedNamespaceAndReturnIt(URI path, String tenantId, String fromNamespace) {
-        // Extract namespace from the path, it should be of the form: kestra:///{namespace}/{flowId}/executions/{executionId}/tasks/{taskId}/{taskRunId}/{fileName}'
-        // To extract the namespace, we must do it step by step as namespace and taskId can contain the words 'executions' and 'tasks'
-        String namespace = path.toString().substring(KESTRA_SCHEME.length());
-        if (!EXECUTION_FILE.matcher(namespace).matches()) {
-            throw new IllegalArgumentException("Unable to read the file '" + path + "' as it is not an execution file");
-        }
-        // 1. remove everything after tasks
-        namespace = namespace.substring(0, namespace.lastIndexOf("/tasks/"));
-        // 2. remove everything after executions
-        namespace = namespace.substring(0, namespace.lastIndexOf("/executions/"));
-        // 3. remove the flowId
-        namespace = namespace.substring(0, namespace.lastIndexOf('/'));
-        // 4. replace '/' with '.'
-        namespace = namespace.replace("/", ".");
 
+        String namespace = extractNamespace(path);
         namespaceService.checkAllowedNamespace(tenantId, namespace, tenantId, fromNamespace);
-
         return namespace;
     }
-
     private String checkEnabledLocalFileAndReturnNamespace(Map<String, Object> args, Map<String, String> flow) {
         if (!enableFileProtocol) {
             throw new SecurityException("The file:// protocol has been disabled inside the Kestra configuration.");
@@ -194,5 +180,25 @@ abstract class AbstractFileFunction implements Function {
             namespaceService.checkAllowedNamespace(tenantId, customNs, tenantId, flow.get(NAMESPACE));
         }
         return Optional.ofNullable(customNs).orElse(flow.get(NAMESPACE));
+    }
+
+    @VisibleForTesting
+    String extractNamespace( URI path){
+        // Extract namespace from the path, it should be of the form: kestra:///{namespace}/{flowId}/executions/{executionId}/tasks/{taskId}/{taskRunId}/{fileName}'
+        // To extract the namespace, we must do it step by step as namespace and taskId can contain the words 'executions' and 'tasks'
+        String namespace = path.toString().substring(KESTRA_SCHEME.length());
+        if (!EXECUTION_FILE.matcher(namespace).matches()) {
+            throw new IllegalArgumentException("Unable to read the file '" + path + "' as it is not an execution file");
+        }
+        // 1. remove everything after tasks
+        namespace = namespace.substring(0, namespace.lastIndexOf("/tasks/"));
+        // 2. remove everything after executions
+        namespace = namespace.substring(0, namespace.lastIndexOf("/executions/"));
+        // 3. remove the flowId
+        namespace = namespace.substring(0, namespace.lastIndexOf('/'));
+        // 4. replace '/' with '.'
+        namespace = namespace.replace("/", ".");
+
+        return namespace;
     }
 }

--- a/core/src/main/java/io/kestra/core/runners/pebble/functions/AbstractFileFunction.java
+++ b/core/src/main/java/io/kestra/core/runners/pebble/functions/AbstractFileFunction.java
@@ -155,24 +155,19 @@ abstract class AbstractFileFunction implements Function {
     }
 
     private String checkIfFileFromAllowedNamespaceAndReturnIt(URI path, String tenantId, String fromNamespace) {
-        // Extract namespace from the path, it should be of the form: kestra:///({tenantId}/){namespace}/{flowId}/executions/{executionId}/tasks/{taskId}/{taskRunId}/{fileName}'
-        // To extract the namespace, we must do it step by step as tenantId, namespace and taskId can contain the words 'executions' and 'tasks'
+        // Extract namespace from the path, it should be of the form: kestra:///{namespace}/{flowId}/executions/{executionId}/tasks/{taskId}/{taskRunId}/{fileName}'
+        // To extract the namespace, we must do it step by step as namespace and taskId can contain the words 'executions' and 'tasks'
         String namespace = path.toString().substring(KESTRA_SCHEME.length());
         if (!EXECUTION_FILE.matcher(namespace).matches()) {
             throw new IllegalArgumentException("Unable to read the file '" + path + "' as it is not an execution file");
         }
-
-        // 1. remove the tenantId if existing
-        if (tenantId != null) {
-            namespace = namespace.substring(tenantId.length() + 1);
-        }
-        // 2. remove everything after tasks
+        // 1. remove everything after tasks
         namespace = namespace.substring(0, namespace.lastIndexOf("/tasks/"));
-        // 3. remove everything after executions
+        // 2. remove everything after executions
         namespace = namespace.substring(0, namespace.lastIndexOf("/executions/"));
-        // 4. remove the flowId
+        // 3. remove the flowId
         namespace = namespace.substring(0, namespace.lastIndexOf('/'));
-        // 5. replace '/' with '.'
+        // 4. replace '/' with '.'
         namespace = namespace.replace("/", ".");
 
         namespaceService.checkAllowedNamespace(tenantId, namespace, tenantId, fromNamespace);

--- a/core/src/test/java/io/kestra/core/runners/pebble/functions/AbstractFileFunctionTest.java
+++ b/core/src/test/java/io/kestra/core/runners/pebble/functions/AbstractFileFunctionTest.java
@@ -15,12 +15,7 @@ public class AbstractFileFunctionTest {
 
     @Test
     void namespaceFromURI(){
-
     String namespace = readFileFunction.extractNamespace(URI.create("kestra:///demo/simple-write-oss/executions/4Tnd2zrWGoHGrufwyt738j/tasks/write/2FOeylkRr5tktwIQqFh56w/18316959863401460785.txt"));
     assertThat(namespace).isEqualTo("demo");
-    }
-    @Test
-    void dno(){
-
     }
 }

--- a/core/src/test/java/io/kestra/core/runners/pebble/functions/AbstractFileFunctionTest.java
+++ b/core/src/test/java/io/kestra/core/runners/pebble/functions/AbstractFileFunctionTest.java
@@ -1,0 +1,26 @@
+package io.kestra.core.runners.pebble.functions;
+
+import io.kestra.core.junit.annotations.KestraTest;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.Test;
+import java.net.URI;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+@KestraTest
+public class AbstractFileFunctionTest {
+
+    @Inject
+    ReadFileFunction readFileFunction;
+
+    @Test
+    void namespaceFromURI(){
+
+    String namespace = readFileFunction.extractNamespace(URI.create("kestra:///demo/simple-write-oss/executions/4Tnd2zrWGoHGrufwyt738j/tasks/write/2FOeylkRr5tktwIQqFh56w/18316959863401460785.txt"));
+    assertThat(namespace).isEqualTo("demo");
+    }
+    @Test
+    void dno(){
+
+    }
+}

--- a/core/src/test/java/io/kestra/core/runners/pebble/functions/AbstractFileFunctionTest.java
+++ b/core/src/test/java/io/kestra/core/runners/pebble/functions/AbstractFileFunctionTest.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.Test;
 import java.net.URI;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @KestraTest
 public class AbstractFileFunctionTest {
@@ -15,7 +16,13 @@ public class AbstractFileFunctionTest {
 
     @Test
     void namespaceFromURI(){
-    String namespace = readFileFunction.extractNamespace(URI.create("kestra:///demo/simple-write-oss/executions/4Tnd2zrWGoHGrufwyt738j/tasks/write/2FOeylkRr5tktwIQqFh56w/18316959863401460785.txt"));
-    assertThat(namespace).isEqualTo("demo");
+    String namespace1 = readFileFunction.extractNamespace(URI.create("kestra:///demo/simple-write-oss/executions/4Tnd2zrWGoHGrufwyt738j/tasks/write/2FOeylkRr5tktwIQqFh56w/18316959863401460785.txt"));
+    assertThat(namespace1).isEqualTo("demo");
+
+    String namespace2 = readFileFunction.extractNamespace(URI.create("kestra:///io/kestra/tests/simple-write-oss/executions/4Tnd2zrWGoHGrufwyt738j/tasks/write/2FOeylkRr5tktwIQqFh56w/18316959863401460785.txt"));
+    assertThat(namespace2).isEqualTo("io.kestra.tests");
+
+    assertThrows(IllegalArgumentException.class, () ->readFileFunction.extractNamespace(URI.create("kestra:///simple-write-oss/executions/4Tnd2zrWGoHGrufwyt738j/tasks/write/2FOeylkRr5tktwIQqFh56w/18316959863401460785.txt")));
+    assertThrows(IllegalArgumentException.class, () ->readFileFunction.extractNamespace(URI.create("kestra:///executions/4Tnd2zrWGoHGrufwyt738j/tasks/write/2FOeylkRr5tktwIQqFh56w/18316959863401460785.txt")));
     }
 }


### PR DESCRIPTION
closes #13745
## Description
- splitting file path assumes that it starts with tenantId not namepace  and file path reaching there not containing tenantId but since tenantId parameter is not null so it always removes the namespace instead of tenantId causing StringIndexOutOfBounds exception when trying to remove flowId 
## Solution
- From my investigation I see that always the correct storage uri formula is kestra:///{namespace}/{flowId}/......
so I removed redundant tenantId splitting 
## Testing
- Since I can't assert on namespace using the public method since it returns the file content, it is mandatory to isolate it and make it package-private for testing purposes