### PR TITLE
ci: try out new CI that optionally split tests phases if they exist

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -41,7 +41,7 @@ jobs:
     name: Backend - Tests
     needs: file-changes
     if: "needs.file-changes.outputs.backend == 'true'"
-    uses: kestra-io/actions/.github/workflows/kestra-oss-backend-tests.yml@main
+    uses: kestra-io/actions/.github/workflows/kestra-oss-backend-tests.yml@split-oss-backend-tests
     secrets:
       GITHUB_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/core/src/main/java/io/kestra/core/converters/PluginDefaultConverter.java
+++ b/core/src/main/java/io/kestra/core/converters/PluginDefaultConverter.java
@@ -12,6 +12,7 @@ import java.util.Optional;
 @SuppressWarnings({"rawtypes", "unchecked"})
 @Prototype
 public class PluginDefaultConverter implements TypeConverter<Map, PluginDefault> {
+    // trigger
     @Override
     public Optional<PluginDefault> convert(Map map, Class<PluginDefault> targetType, ConversionContext context) {
         return Optional.of(PluginDefault.builder()


### PR DESCRIPTION
nothing should change for this kestra version, both unitTest and flakyTest step should be skipped
