### PR TITLE
using $t for template translations in Topology.vue

### DIFF
--- a/ui/src/components/flows/Topology.vue
+++ b/ui/src/components/flows/Topology.vue
@@ -13,18 +13,16 @@
                 @on-edit="(event) => emit('on-edit', event, true)"
             />
             <el-alert v-else type="warning" :closable="false">
-                {{ t("unable to generate graph") }}
+                {{ $t("unable to generate graph") }}
             </el-alert>
         </div>
     </el-card>
 </template>
 <script setup lang="ts">
     import {onBeforeUnmount} from "vue";
-    import {useI18n} from "vue-i18n";
     import {useFlowStore} from "../../stores/flow";
     import LowCodeEditor from "../inputs/LowCodeEditor.vue";
 
-    const {t} = useI18n();
     defineProps<{
         isReadOnly?: boolean;
         expandedSubflows?: any[];


### PR DESCRIPTION
All PRs submitted by external contributors that do not follow this template (including proper description, related issue, and checklist sections) **may be automatically closed**.

As a general practice, if you plan to work on a specific issue, comment on the issue first and wait to be assigned before starting any actual work. This avoids duplicated work and ensures a smooth contribution process - otherwise, the PR **may be automatically closed**.

---

### ✨ Description

What does this PR change?  
This PR simplifies translations in Topology.vue by using the globally available $t helper in the template section and removing unnecessary useI18n usage that was only required for template translations.

### 🔗 Related Issue

closes  #13257


### 🎨 Frontend Checklist

_If this PR does not include any frontend changes, delete this entire section._

- [ ] Code builds without errors (`npm run build`)
- [ ] All existing E2E tests pass (`npm run test:e2e`)
- [ ] Screenshots or video recordings attached showing the `UI` changes
- Not run locally (change is limited to template refactor) CI may validate

