### PR TITLE
fix(core): os incompitibility file path problem

### DIFF
--- a/core/src/main/java/io/kestra/core/models/namespaces/files/NamespaceFileMetadata.java
+++ b/core/src/main/java/io/kestra/core/models/namespaces/files/NamespaceFileMetadata.java
@@ -94,7 +94,7 @@ public class NamespaceFileMetadata implements DeletedInterface, TenantInterface,
         return NamespaceFileMetadata.builder()
             .tenantId(tenantId)
             .namespace(namespaceFile.namespace())
-            .path(namespaceFile.path(true).toString())
+            .path(namespaceFile.filePath().toString())
             .version(namespaceFile.version())
             .build();
     }

--- a/core/src/main/java/io/kestra/core/models/namespaces/files/NamespaceFileMetadata.java
+++ b/core/src/main/java/io/kestra/core/models/namespaces/files/NamespaceFileMetadata.java
@@ -94,7 +94,7 @@ public class NamespaceFileMetadata implements DeletedInterface, TenantInterface,
         return NamespaceFileMetadata.builder()
             .tenantId(tenantId)
             .namespace(namespaceFile.namespace())
-            .path(namespaceFile.path().toString())
+            .path(namespaceFile.path(true).toString())
             .version(namespaceFile.version())
             .build();
     }

--- a/core/src/main/java/io/kestra/core/models/namespaces/files/NamespaceFileMetadata.java
+++ b/core/src/main/java/io/kestra/core/models/namespaces/files/NamespaceFileMetadata.java
@@ -94,7 +94,7 @@ public class NamespaceFileMetadata implements DeletedInterface, TenantInterface,
         return NamespaceFileMetadata.builder()
             .tenantId(tenantId)
             .namespace(namespaceFile.namespace())
-            .path(namespaceFile.path(true).toString())
+            .path(namespaceFile.path().toString())
             .version(namespaceFile.version())
             .build();
     }

--- a/core/src/main/java/io/kestra/core/runners/pebble/functions/FileExistsFunction.java
+++ b/core/src/main/java/io/kestra/core/runners/pebble/functions/FileExistsFunction.java
@@ -23,7 +23,7 @@ public class FileExistsFunction extends AbstractFileFunction {
             case LocalPath.FILE_SCHEME -> localPathFactory.createLocalPath().exists(path);
             case Namespace.NAMESPACE_FILE_SCHEME  -> {
                 Namespace namespaceStorage = namespaceFactory.of(tenantId, namespace, storageInterface);
-                yield namespaceStorage.exists(NamespaceFile.normalize(Path.of(path.getPath()), true));
+                yield namespaceStorage.exists(NamespaceFile.normalize(Path.of(path.getPath())));
             }
             default -> throw new IllegalArgumentException(SCHEME_NOT_SUPPORTED_ERROR.formatted(path));
         };

--- a/core/src/main/java/io/kestra/core/runners/pebble/functions/FileSizeFunction.java
+++ b/core/src/main/java/io/kestra/core/runners/pebble/functions/FileSizeFunction.java
@@ -31,7 +31,7 @@ public class FileSizeFunction extends AbstractFileFunction {
             case Namespace.NAMESPACE_FILE_SCHEME  -> {
                 FileAttributes fileAttributes = namespaceFactory
                     .of(tenantId, namespace, storageInterface)
-                    .getFileMetadata(NamespaceFile.normalize(Path.of(path.getPath()), true));
+                    .getFileMetadata(NamespaceFile.normalize(Path.of(path.getPath())));
                 yield fileAttributes.getSize();
             }
             default -> throw new IllegalArgumentException(SCHEME_NOT_SUPPORTED_ERROR.formatted(path));

--- a/core/src/main/java/io/kestra/core/runners/pebble/functions/IsFileEmptyFunction.java
+++ b/core/src/main/java/io/kestra/core/runners/pebble/functions/IsFileEmptyFunction.java
@@ -35,7 +35,7 @@ public class IsFileEmptyFunction extends AbstractFileFunction {
             case Namespace.NAMESPACE_FILE_SCHEME -> {
                 FileAttributes fileAttributes = namespaceFactory
                     .of(tenantId, namespace, storageInterface)
-                    .getFileMetadata(NamespaceFile.normalize(Path.of(path.getPath()), true));
+                    .getFileMetadata(NamespaceFile.normalize(Path.of(path.getPath())));
                 yield fileAttributes.getSize() <= 0;
             }
             default -> throw new IllegalArgumentException(SCHEME_NOT_SUPPORTED_ERROR.formatted(path));

--- a/core/src/main/java/io/kestra/core/runners/pebble/functions/ReadFileFunction.java
+++ b/core/src/main/java/io/kestra/core/runners/pebble/functions/ReadFileFunction.java
@@ -57,12 +57,12 @@ public class ReadFileFunction extends AbstractFileFunction {
 
         if (args.containsKey(VERSION)) {
             return namespaceStorage.getFileContent(
-                    NamespaceFile.normalize(Path.of(path.getPath()), true),
+                    NamespaceFile.normalize(Path.of(path.getPath())),
                     Integer.parseInt(args.get(VERSION).toString())
                 );
         }
 
-        return namespaceStorage.getFileContent(NamespaceFile.normalize(Path.of(path.getPath()), true));
+        return namespaceStorage.getFileContent(NamespaceFile.normalize(Path.of(path.getPath())));
     }
 
     @Override

--- a/core/src/main/java/io/kestra/core/storages/InternalNamespace.java
+++ b/core/src/main/java/io/kestra/core/storages/InternalNamespace.java
@@ -127,7 +127,7 @@ public class InternalNamespace implements Namespace {
      **/
     @Override
     public List<NamespaceFileMetadata> children(String parentPath, boolean recursive) throws IOException {
-        final String normalizedParentPath = NamespaceFile.normalize(Path.of(parentPath), true).toString();
+        final String normalizedParentPath = NamespaceFile.normalize(Path.of(parentPath)).toString();
 
         return namespaceFileMetadataRepository.find(Pageable.UNPAGED, tenant, List.of(
             QueryFilter.builder().field(QueryFilter.Field.NAMESPACE).operation(QueryFilter.Op.EQUALS).value(namespace).build(),
@@ -141,8 +141,8 @@ public class InternalNamespace implements Namespace {
 
     @Override
     public List<Pair<NamespaceFile, NamespaceFile>> move(Path source, Path target) throws Exception {
-        final Path normalizedSource = NamespaceFile.normalize(source, true);
-        final Path normalizedTarget = NamespaceFile.normalize(target, true);
+        final Path normalizedSource = NamespaceFile.normalize(source);
+        final Path normalizedTarget = NamespaceFile.normalize(target);
 
         if (findByPath(normalizedTarget).isPresent()) {
             throw new IOException(String.format(
@@ -191,7 +191,7 @@ public class InternalNamespace implements Namespace {
      **/
     @Override
     public NamespaceFile get(Path path) throws IOException {
-        final Path normalizedPath = NamespaceFile.normalize(path, true);
+        final Path normalizedPath = NamespaceFile.normalize(path);
 
         int version = findByPath(normalizedPath).map(NamespaceFileMetadata::getVersion).orElse(1);
 
@@ -217,7 +217,7 @@ public class InternalNamespace implements Namespace {
      **/
     @Override
     public InputStream getFileContent(Path path, @Nullable Integer version) throws IOException {
-        final Path normalizedPath = NamespaceFile.normalize(path, true);
+        final Path normalizedPath = NamespaceFile.normalize(path);
 
         // Throw if file not found OR if it's deleted
         NamespaceFileMetadata namespaceFileMetadata = findByPath(normalizedPath, version).orElseThrow(() -> fileNotFound(normalizedPath, version));
@@ -228,7 +228,7 @@ public class InternalNamespace implements Namespace {
 
     @Override
     public FileAttributes getFileMetadata(Path path) throws IOException {
-        final Path normalizedPath = NamespaceFile.normalize(path, true);
+        final Path normalizedPath = NamespaceFile.normalize(path);
 
         return findByPath(normalizedPath).map(NamespaceFileAttributes::new).orElseThrow(() -> fileNotFound(normalizedPath, null));
     }
@@ -238,7 +238,7 @@ public class InternalNamespace implements Namespace {
     }
 
     private Optional<NamespaceFileMetadata> findByPath(Path path, boolean allowDeleted, @Nullable Integer version) throws IOException {
-        final Path normalizedPath = NamespaceFile.normalize(path, true);
+        final Path normalizedPath = NamespaceFile.normalize(path);
 
         if (version != null) {
             return namespaceFileMetadataRepository.find(Pageable.from(1, 1), tenant, List.of(
@@ -265,7 +265,7 @@ public class InternalNamespace implements Namespace {
 
     @Override
     public boolean exists(Path path) throws IOException {
-        final Path normalizedPath = NamespaceFile.normalize(path, true);
+        final Path normalizedPath = NamespaceFile.normalize(path);
 
         return findByPath(normalizedPath).isPresent();
     }
@@ -275,7 +275,7 @@ public class InternalNamespace implements Namespace {
      **/
     @Override
     public List<NamespaceFile> putFile(final Path path, final InputStream content, final Conflicts onAlreadyExist) throws IOException, URISyntaxException {
-        final Path normalizedPath = NamespaceFile.normalize(path, true);
+        final Path normalizedPath = NamespaceFile.normalize(path);
 
         Optional<NamespaceFileMetadata> inRepository = findByPath(normalizedPath, true);
         int currentVersion = inRepository.map(NamespaceFileMetadata::getVersion).orElse(0);
@@ -373,7 +373,7 @@ public class InternalNamespace implements Namespace {
      **/
     @Override
     public NamespaceFile createDirectory(Path path) throws IOException {
-        final Path normalizedPath = NamespaceFile.normalize(path, true);
+        final Path normalizedPath = NamespaceFile.normalize(path);
 
         NamespaceFileMetadata nsFileMetadata = namespaceFileMetadataRepository.save(
             NamespaceFileMetadata.builder()
@@ -393,7 +393,7 @@ public class InternalNamespace implements Namespace {
      **/
     @Override
     public List<NamespaceFile> delete(Path path) throws IOException {
-        final Path normalizedPath = NamespaceFile.normalize(path, true);
+        final Path normalizedPath = NamespaceFile.normalize(path);
 
         Optional<NamespaceFileMetadata> maybeNamespaceFileMetadata = namespaceFileMetadataRepository.find(Pageable.from(1, 1), tenant, List.of(
             QueryFilter.builder().field(QueryFilter.Field.NAMESPACE).operation(QueryFilter.Op.EQUALS).value(namespace).build(),

--- a/core/src/main/java/io/kestra/core/storages/InternalNamespace.java
+++ b/core/src/main/java/io/kestra/core/storages/InternalNamespace.java
@@ -209,7 +209,7 @@ public class InternalNamespace implements Namespace {
      **/
     @Override
     public List<NamespaceFile> findAllFilesMatching(final Predicate<Path> predicate) throws IOException {
-        return all().stream().filter(it -> predicate.test(it.path(true))).toList();
+        return all().stream().filter(it -> predicate.test(it.filePath())).toList();
     }
 
     /**

--- a/core/src/main/java/io/kestra/core/storages/InternalStorage.java
+++ b/core/src/main/java/io/kestra/core/storages/InternalStorage.java
@@ -17,6 +17,8 @@ import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
 
+import static io.kestra.core.storages.NamespaceFile.toLogicalPath;
+
 /**
  * The default {@link Storage} implementation acting as a facade to the {@link StorageInterface}.
  */
@@ -154,7 +156,7 @@ public class InternalStorage implements Storage {
     @Override
     public URI putFile(InputStream inputStream, String name) throws IOException {
         URI uri = context.getContextStorageURI();
-        URI resolved = uri.resolve(uri.getPath() + PATH_SEPARATOR + name);
+        URI resolved = uri.resolve(uri.getPath() + PATH_SEPARATOR + toLogicalPath(name));
         return this.storage.put(context.getTenantId(), context.getNamespace(), resolved, new BufferedInputStream(inputStream));
     }
 

--- a/core/src/main/java/io/kestra/core/storages/NamespaceFile.java
+++ b/core/src/main/java/io/kestra/core/storages/NamespaceFile.java
@@ -152,7 +152,10 @@ public record NamespaceFile(
         if(path == null){
             return Path.of("/");
         }
-        String compatiblePath = WindowsUtils.windowsToUnixPath(path.toString());
+        String compatiblePath = toLogicalPath(path);
+        if(!compatiblePath.startsWith("/")){
+            compatiblePath = "/" + compatiblePath;
+        }
         return Path.of(compatiblePath);
     }
 

--- a/core/src/main/java/io/kestra/core/storages/NamespaceFile.java
+++ b/core/src/main/java/io/kestra/core/storages/NamespaceFile.java
@@ -150,7 +150,10 @@ public record NamespaceFile(
 
     public static Path normalize(Path path) {
 
-        String compatiblePath = WindowsUtils.windowsToUnixPath(path.toString());
+        String compatiblePath = path.toString().replace("\\", "/");
+        if(!compatiblePath.startsWith("/")) {
+            compatiblePath = "/" + compatiblePath;
+        }
         return Path.of(compatiblePath);
     }
 

--- a/core/src/main/java/io/kestra/core/storages/NamespaceFile.java
+++ b/core/src/main/java/io/kestra/core/storages/NamespaceFile.java
@@ -148,24 +148,10 @@ public record NamespaceFile(
         );
     }
 
-    public static Path normalize(String pathStr, boolean withLeadingSlash) {
-        return normalize(Path.of(pathStr), withLeadingSlash);
-    }
+    public static Path normalize(Path path) {
 
-    public static Path normalize(Path path, boolean withLeadingSlash) {
-        if (path == null) {
-            return Path.of("/");
-        }
-
-        if (withLeadingSlash && !path.toString().startsWith("/")) {
-            return Path.of("/" + path);
-        }
-
-        if (!withLeadingSlash && path.toString().startsWith("/")) {
-            return Path.of(path.toString().substring(1));
-        }
-
-        return path;
+        String compatiblePath = WindowsUtils.windowsToUnixPath(path.toString());
+        return Path.of(compatiblePath);
     }
 
     /**
@@ -181,7 +167,7 @@ public record NamespaceFile(
             strPath = matcher.group(1);
         }
 
-        return normalize(Path.of(strPath), withLeadingSlash);
+        return normalize(Path.of(strPath));
     }
 
     /**

--- a/core/src/main/java/io/kestra/core/storages/NamespaceFile.java
+++ b/core/src/main/java/io/kestra/core/storages/NamespaceFile.java
@@ -152,10 +152,7 @@ public record NamespaceFile(
         if(path == null){
             return Path.of("/");
         }
-        String compatiblePath = path.toString().replace("\\", "/");
-        if(!compatiblePath.startsWith("/")) {
-            compatiblePath = "/" + compatiblePath;
-        }
+        String compatiblePath = WindowsUtils.windowsToUnixPath(path.toString());
         return Path.of(compatiblePath);
     }
 

--- a/core/src/main/java/io/kestra/core/storages/NamespaceFile.java
+++ b/core/src/main/java/io/kestra/core/storages/NamespaceFile.java
@@ -149,7 +149,9 @@ public record NamespaceFile(
     }
 
     public static Path normalize(Path path) {
-
+        if(path == null){
+            return Path.of("/");
+        }
         String compatiblePath = path.toString().replace("\\", "/");
         if(!compatiblePath.startsWith("/")) {
             compatiblePath = "/" + compatiblePath;
@@ -159,11 +161,9 @@ public record NamespaceFile(
 
     /**
      * Returns the path of file relative to the namespace.
-     *
-     * @param withLeadingSlash specify whether to remove leading slash from the returned path.
      * @return The path.
      */
-    public Path path(boolean withLeadingSlash) {
+    public Path filePath() {
         String strPath = path;
         Matcher matcher = capturePathWithoutVersion.matcher(strPath);
         if (matcher.matches()) {

--- a/core/src/main/java/io/kestra/core/storages/NamespaceFile.java
+++ b/core/src/main/java/io/kestra/core/storages/NamespaceFile.java
@@ -202,4 +202,29 @@ public record NamespaceFile(
     public boolean isRootDirectory() {
         return equals(NamespaceFile.of(namespace));
     }
+
+    /**
+     * Converts a {@link Path} to a canonical **logical path** string.
+     * <p>
+     * Logical paths use forward slashes ('/') as separators regardless of the OS.
+     * This is useful for namespace storage, URI construction, or any cross-platform
+     * path handling where OS-dependent separators should be avoided.
+     *
+     * @param path the {@link Path} to convert
+     * @return a String representing the logical path with forward slashes
+     */
+    public static String toLogicalPath(Path path){ return toLogicalPath(path.toString());}
+
+    /**
+     * Converts a path string to a canonical **logical path**.
+     * <p>
+     * Replaces all backslashes ('\') with forward slashes ('/') to ensure
+     * cross-platform consistency.
+     *
+     * @param path the path string to convert
+     * @return a String representing the logical path with forward slashes
+     */
+    public static String toLogicalPath(String path) {
+        return path.replace("\\", "/");
+    }
 }

--- a/core/src/main/java/io/kestra/plugin/core/namespace/DownloadFiles.java
+++ b/core/src/main/java/io/kestra/plugin/core/namespace/DownloadFiles.java
@@ -118,7 +118,7 @@ public class DownloadFiles extends Task implements RunnableTask<DownloadFiles.Ou
                 try (InputStream is = runContext.storage().getFile(file.uri())) {
                     URI uri = runContext.storage().putFile(is, renderedDestination + file.path());
                     logger.debug(String.format("Downloaded %s", uri));
-                    return new AbstractMap.SimpleEntry<>(file.path(true).toString(), uri);
+                    return new AbstractMap.SimpleEntry<>(file.filePath().toString(), uri);
                 }
             }))
             .collect(Collectors.toMap(AbstractMap.SimpleEntry::getKey, AbstractMap.SimpleEntry::getValue));

--- a/core/src/main/java/io/kestra/plugin/core/namespace/DownloadFiles.java
+++ b/core/src/main/java/io/kestra/plugin/core/namespace/DownloadFiles.java
@@ -27,6 +27,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import static io.kestra.core.storages.NamespaceFile.toLogicalPath;
+
 @Slf4j
 @SuperBuilder
 @Getter
@@ -118,7 +120,7 @@ public class DownloadFiles extends Task implements RunnableTask<DownloadFiles.Ou
                 try (InputStream is = runContext.storage().getFile(file.uri())) {
                     URI uri = runContext.storage().putFile(is, renderedDestination + file.path());
                     logger.debug(String.format("Downloaded %s", uri));
-                    return new AbstractMap.SimpleEntry<>(file.filePath().toString(), uri);
+                    return new AbstractMap.SimpleEntry<>(toLogicalPath(file.filePath()), uri);
                 }
             }))
             .collect(Collectors.toMap(AbstractMap.SimpleEntry::getKey, AbstractMap.SimpleEntry::getValue));

--- a/core/src/test/java/io/kestra/core/storages/NamespaceFileTest.java
+++ b/core/src/test/java/io/kestra/core/storages/NamespaceFileTest.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.Test;
 import java.net.URI;
 import java.nio.file.Path;
 
+import static io.kestra.core.storages.NamespaceFile.toLogicalPath;
 import static org.assertj.core.api.Assertions.assertThat;
 
 class NamespaceFileTest {
@@ -140,7 +141,4 @@ class NamespaceFileTest {
         assertThat(toLogicalPath(unixPath2)).isEqualTo("/folder/file.txt");
     }
 
-    private static String toLogicalPath(Path path) {
-        return path.toString().replace("\\", "/");
-    }
 }

--- a/core/src/test/java/io/kestra/core/storages/NamespaceFileTest.java
+++ b/core/src/test/java/io/kestra/core/storages/NamespaceFileTest.java
@@ -6,6 +6,8 @@ import org.junit.jupiter.api.Test;
 import java.net.URI;
 import java.nio.file.Path;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 class NamespaceFileTest {
 
     private static final String NAMESPACE = "io.kestra.test";
@@ -123,5 +125,22 @@ class NamespaceFileTest {
             ), namespaceFile
         );
         Assertions.assertTrue(namespaceFile.isDirectory());
+    }
+
+    @Test
+    void shouldNormalizeNamespacePathIndependentlyOfOperatingSystem() {
+        Path windowsPath1 = NamespaceFile.normalize(Path.of("folder\\file.txt"));
+        Path windowsPath2 = NamespaceFile.normalize(Path.of("\\folder\\file.txt"));
+        Path unixPath1 = NamespaceFile.normalize(Path.of("folder/file.txt"));
+        Path unixPath2 = NamespaceFile.normalize(Path.of("/folder/file.txt"));
+
+        assertThat(toLogicalPath(windowsPath1)).isEqualTo("/folder/file.txt");
+        assertThat(toLogicalPath(windowsPath2)).isEqualTo("/folder/file.txt");
+        assertThat(toLogicalPath(unixPath1)).isEqualTo("/folder/file.txt");
+        assertThat(toLogicalPath(unixPath2)).isEqualTo("/folder/file.txt");
+    }
+
+    private static String toLogicalPath(Path path) {
+        return path.toString().replace("\\", "/");
     }
 }

--- a/core/src/test/java/io/kestra/plugin/core/namespace/PurgeFilesTest.java
+++ b/core/src/test/java/io/kestra/plugin/core/namespace/PurgeFilesTest.java
@@ -37,6 +37,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
+import static io.kestra.core.storages.NamespaceFile.toLogicalPath;
 import static io.kestra.core.tenant.TenantService.MAIN_TENANT;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -149,7 +150,7 @@ public class PurgeFilesTest {
         assertThat(output.getSize()).isEqualTo(2L);
         List<NamespaceFile> namespaceFiles = namespaceStorage.all();
         assertThat(namespaceFiles.size()).isEqualTo(1);
-        assertThat(namespaceFiles.getFirst().path()).isEqualTo("not/found.txt");
+        assertThat(toLogicalPath(namespaceFiles.getFirst().path())).isEqualTo("not/found.txt");
     }
 
     @Test

--- a/webserver/src/main/java/io/kestra/webserver/controllers/api/NamespaceFileController.java
+++ b/webserver/src/main/java/io/kestra/webserver/controllers/api/NamespaceFileController.java
@@ -71,7 +71,7 @@ public class NamespaceFileController {
         @Parameter(description = "The namespace id") @PathVariable String namespace,
         @Parameter(description = "The string the file path should contain") @QueryValue String q
     ) throws IOException {
-        return namespaceFactory.of(tenantService.resolveTenant(), namespace, storageInterface).all(q).stream().map(namespaceFile -> namespaceFile.path(true).toString()).toList();
+        return namespaceFactory.of(tenantService.resolveTenant(), namespace, storageInterface).all(q).stream().map(namespaceFile -> namespaceFile.filePath().toString()).toList();
     }
 
     @ExecuteOn(TaskExecutors.IO)


### PR DESCRIPTION
Closes https://github.com/kestra-io/kestra/issues/13740.

## Description
- UNC path problem occur during file path normalization because Path.of() is OS dependent for ex:
when passing Path.of("/file.txt") to normalize at windows it becomes "\file.txt" entering the second check as it will consider it not starting with "/" returning "/\file.txt" causing UNC problem as it expects a correct UNC  path not interpreted as file path
## Solution
- we must convert windows style to unix style before checks as checks assumes unix style
## Testing  
- added test for both unix and windows styles and assert on their logical paths to ensure they are working on all environments
- it tests normalization by simulating running on both by passing the formats produced from windows and unix styles and should normalize them correctly ( although that is sufficient, for more certainty it also passes locally on my windows machine and on CI (Linux) )
## Notes
 - now this fixes many of failing tests related to files if running on windows since all depends on normalize()
 - there is redundant checks ( third check ) at normalize() as always we consider leadingBackSlash is true so keeping these checks and flag adding complexity only, instead WindowsUtils.windowsToUnixPath(String path) handle the issue with adding leading back slash as it is always the case  
 - on the long term, it may be better to depend on unified logical path using String to avoid these OS issues because Path object depends on the OS which may make problems as the path format isn't unified 