### PR TITLE
fix(concurrency): make decrement and pop atomic to prevent stuck queued executions

### DIFF
--- a/jdbc/src/main/java/io/kestra/jdbc/runner/AbstractJdbcConcurrencyLimitStorage.java
+++ b/jdbc/src/main/java/io/kestra/jdbc/runner/AbstractJdbcConcurrencyLimitStorage.java
@@ -4,6 +4,7 @@ import io.kestra.core.models.flows.FlowInterface;
 import io.kestra.core.runners.ConcurrencyLimit;
 import io.kestra.core.runners.ExecutionRunning;
 import io.kestra.jdbc.repository.AbstractJdbcRepository;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.tuple.Pair;
 import org.jooq.*;
 import org.jooq.exception.DataAccessException;
@@ -12,8 +13,10 @@ import org.jooq.impl.DSL;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.function.BiConsumer;
 import java.util.function.BiFunction;
 
+@Slf4j
 public class AbstractJdbcConcurrencyLimitStorage extends AbstractJdbcRepository {
     protected io.kestra.jdbc.AbstractJdbcRepository<ConcurrencyLimit> jdbcRepository;
 
@@ -87,6 +90,50 @@ public class AbstractJdbcConcurrencyLimitStorage extends AbstractJdbcRepository 
                         return newLimit;
                     }
                 ).orElse(0);
+            });
+    }
+
+    /**
+     * Atomically decrement the concurrency limit counter and pop a queued execution if available.
+     * This ensures the decrement, limit check, and pop all happen within the same transaction,
+     * preventing race conditions that could leave executions stuck in queue indefinitely.
+     *
+     * @param flow the flow to decrement the counter for
+     * @param executionQueuedStorage the storage to pop from
+     * @param consumer the consumer to call with the popped execution (only called if pop succeeds and limit allows)
+     */
+    public void decrementAndPop(FlowInterface flow, AbstractJdbcExecutionQueuedStorage executionQueuedStorage,
+                                BiConsumer<DSLContext, io.kestra.core.models.executions.Execution> consumer) {
+        this.jdbcRepository
+            .getDslContextWrapper()
+            .transaction(configuration -> {
+                var dslContext = DSL.using(configuration);
+
+                // Decrement the counter
+                int newLimit = fetchOne(dslContext, flow).map(
+                    concurrencyLimit -> {
+                        int decremented = concurrencyLimit.getRunning() == 0 ? 0 : concurrencyLimit.getRunning() - 1;
+                        update(dslContext, concurrencyLimit.withRunning(decremented));
+                        return decremented;
+                    }
+                ).orElse(0);
+
+                // Only pop if we're below the limit
+                if (newLimit < flow.getConcurrency().getLimit()) {
+                    executionQueuedStorage.pop(
+                        dslContext,
+                        flow.getTenantId(),
+                        flow.getNamespace(),
+                        flow.getId(),
+                        (ctx, queued) -> {
+                            // Increment the counter for the newly running execution
+                            increment(ctx, flow);
+                            // Call the consumer
+                            consumer.accept(ctx, queued);
+                        }
+                    );
+                } else {
+                    log.error("Concurrency limit reached for flow {}.{} after decrementing the execution running count. No new executions will be dequeued.", flow.getNamespace(), flow.getId());                }
             });
     }
 

--- a/jdbc/src/main/java/io/kestra/jdbc/runner/AbstractJdbcExecutionQueuedStorage.java
+++ b/jdbc/src/main/java/io/kestra/jdbc/runner/AbstractJdbcExecutionQueuedStorage.java
@@ -1,6 +1,7 @@
 package io.kestra.jdbc.runner;
 
 import io.kestra.core.models.executions.Execution;
+import io.kestra.core.models.flows.FlowInterface;
 import io.kestra.core.runners.ExecutionQueued;
 import io.kestra.core.utils.IdUtils;
 import io.kestra.jdbc.repository.AbstractJdbcRepository;
@@ -25,28 +26,28 @@ public abstract class AbstractJdbcExecutionQueuedStorage extends AbstractJdbcRep
         this.jdbcRepository.persist(executionQueued, dslContext, fields);
     }
 
-    public void pop(String tenantId, String namespace, String flowId, BiConsumer<DSLContext, Execution> consumer) {
-        this.jdbcRepository
-            .getDslContextWrapper()
-            .transaction(configuration -> {
-                var dslContext = DSL.using(configuration);
-                var select = dslContext
-                    .select(VALUE_FIELD)
-                    .from(this.jdbcRepository.getTable())
-                    .where(buildTenantCondition(tenantId))
-                    .and(field("namespace").eq(namespace))
-                    .and(field("flow_id").eq(flowId))
-                    .orderBy(field("date").asc())
-                    .limit(1)
-                    .forUpdate()
-                    .skipLocked();
+    /**
+     * Pop the next queued execution.
+     * This method is intended to be part of a larger transaction,
+     * see {@link AbstractJdbcConcurrencyLimitStorage#decrementAndPop(FlowInterface, AbstractJdbcExecutionQueuedStorage, BiConsumer)}
+     */
+    public void pop(DSLContext dslContext, String tenantId, String namespace, String flowId, BiConsumer<DSLContext, Execution> consumer) {
+        var select = dslContext
+            .select(VALUE_FIELD)
+            .from(this.jdbcRepository.getTable())
+            .where(buildTenantCondition(tenantId))
+            .and(field("namespace").eq(namespace))
+            .and(field("flow_id").eq(flowId))
+            .orderBy(field("date").asc())
+            .limit(1)
+            .forUpdate()
+            .skipLocked();
 
-                Optional<ExecutionQueued> maybeExecution = this.jdbcRepository.fetchOne(select);
-                if (maybeExecution.isPresent()) {
-                    consumer.accept(dslContext, maybeExecution.get().getExecution());
-                    this.jdbcRepository.delete(maybeExecution.get());
-                }
-            });
+        Optional<ExecutionQueued> maybeExecution = this.jdbcRepository.fetchOne(select);
+        if (maybeExecution.isPresent()) {
+            consumer.accept(dslContext, maybeExecution.get().getExecution());
+            this.jdbcRepository.delete(maybeExecution.get());
+        }
     }
 
     /**

--- a/jdbc/src/main/java/io/kestra/jdbc/runner/JdbcExecutor.java
+++ b/jdbc/src/main/java/io/kestra/jdbc/runner/JdbcExecutor.java
@@ -1215,30 +1215,28 @@ public class JdbcExecutor implements ExecutorInterface {
                     // as we may receive multiple time killed execution (one when we kill it, then one for each running worker task), we limit to the first we receive: when the state transitioned from KILLING to KILLED
                     boolean killingThenKilled = execution.getState().getCurrent().isKilled() && executor.getOriginalState() == State.Type.KILLING;
                     if (!queuedThenKilled && !concurrencyShortCircuitState && (!execution.getState().getCurrent().isKilled() || killingThenKilled)) {
-                        int newLimit = concurrencyLimitStorage.decrement(executor.getFlow());
-
                         if (executor.getFlow().getConcurrency().getBehavior() == Concurrency.Behavior.QUEUE) {
                             var finalFlow = executor.getFlow();
 
-                            if (newLimit < finalFlow.getConcurrency().getLimit()) {
-                                executionQueuedStorage.pop(executor.getFlow().getTenantId(),
-                                    executor.getFlow().getNamespace(),
-                                    executor.getFlow().getId(),
-                                    throwBiConsumer((dslContext, queued) -> {
-                                        var newExecution = queued.withState(State.Type.RUNNING);
-                                        concurrencyLimitStorage.increment(dslContext, finalFlow);
-                                        executionQueue.emit(newExecution);
-                                        metricRegistry.counter(MetricRegistry.METRIC_EXECUTOR_EXECUTION_POPPED_COUNT, MetricRegistry.METRIC_EXECUTOR_EXECUTION_POPPED_COUNT_DESCRIPTION, metricRegistry.tags(newExecution)).increment();
+                            // Pop the next queued execution atomically with decrement/increment to avoid race conditions
+                            // that could leave executions stuck in the queue indefinitely (see issue #13785)
+                            concurrencyLimitStorage.decrementAndPop(
+                                finalFlow,
+                                executionQueuedStorage,
+                                throwBiConsumer((dslContext, queued) -> {
+                                    var newExecution = queued.withState(State.Type.RUNNING);
+                                    executionQueue.emit(newExecution);
+                                    metricRegistry.counter(MetricRegistry.METRIC_EXECUTOR_EXECUTION_POPPED_COUNT, MetricRegistry.METRIC_EXECUTOR_EXECUTION_POPPED_COUNT_DESCRIPTION, metricRegistry.tags(newExecution)).increment();
 
-                                        // process flow triggers to allow listening on RUNNING state after a QUEUED state
-                                        processFlowTriggers(newExecution);
-                                    })
-                                );
-                            } else {
-                                log.error("Concurrency limit reached for flow {}.{} after decrementing the execution running count due to the terminated execution {}. No new executions will be dequeued.", executor.getFlow().getNamespace(), executor.getFlow().getId(), executor.getExecution().getId());
+                                    // process flow triggers to allow listening on RUNNING state after a QUEUED state
+                                    processFlowTriggers(newExecution);
+                                })
+                            );
+                        } else {
+                            int newLimit = concurrencyLimitStorage.decrement(executor.getFlow());
+                            if (newLimit >= executor.getFlow().getConcurrency().getLimit()) {
+                                log.error("Concurrency limit reached for flow {}.{} after decrementing the execution running count due to the terminated execution {}. This should not happen.", executor.getFlow().getNamespace(), executor.getFlow().getId(), executor.getExecution().getId());
                             }
-                        } else if (newLimit >= executor.getFlow().getConcurrency().getLimit()) {
-                            log.error("Concurrency limit reached for flow {}.{} after decrementing the execution running count due to the terminated execution {}. This should not happen.", executor.getFlow().getNamespace(), executor.getFlow().getId(), executor.getExecution().getId());
                         }
                     }
                 }


### PR DESCRIPTION
## Summary
- Fixes race condition where executions with concurrency settings get stuck in QUEUED state indefinitely
- Makes the decrement and pop operations atomic within a single transaction

## Problem
The protection mechanism added in v1.1.10 (commit 71f605898f) has a race condition:

1. When an execution terminates, it decrements the concurrency counter (Transaction 1)
2. Between decrement and pop, another execution can start and increment the counter
3. The limit check `newLimit < limit` then fails because the counter was incremented by the new execution
4. The queued execution never gets popped and remains stuck indefinitely

## Solution
Introduce `decrementAndPop()` method that performs:
1. Decrement the counter
2. Check if newLimit < limit  
3. Pop the next queued execution and increment

All within the same database transaction, ensuring:
- The counter value read during limit check is consistent
- No race between decrement and new execution start
- Queued executions are always properly dequeued when capacity is available

## Changes
- `AbstractJdbcConcurrencyLimitStorage.java`: Add `decrementAndPop()` method for atomic operation
- `AbstractJdbcExecutionQueuedStorage.java`: Add `popWithContext()` method to use existing transaction
- `JdbcExecutor.java`: Use the new atomic `decrementAndPop()` for QUEUE behavior

## Test plan
- [ ] Existing concurrency tests should pass
- [ ] `flowConcurrencyQueuedProtection` test continues to work (protection still applies within atomic transaction)
- [ ] ForEachItem with subflow concurrency no longer gets stuck

Fixes #13785