### PR TITLE
Replace usage of getCurrentInstance in MonacoEditor.vue component

### DIFF
--- a/ui/src/components/inputs/MonacoEditor.vue
+++ b/ui/src/components/inputs/MonacoEditor.vue
@@ -125,7 +125,7 @@
     import uniqBy from "lodash/uniqBy";
     import {useI18n} from "vue-i18n";
     import {ElDatePicker} from "element-plus";
-    import {Moment} from "moment";
+    import moment from "moment";
     import PlaceholderContentWidget from "../../composables/monaco/PlaceholderContentWidget";
     import Utils from "../../utils/utils";
     import {hashCode} from "../../utils/global";
@@ -369,7 +369,7 @@
         }
     }, {deep: true});
 
-    const nowMoment: Moment = moment().startOf("day");
+    const nowMoment = moment().startOf("day");
     function addedSuggestRows(mutations: MutationRecord[]) {
         return mutations.flatMap(({addedNodes}) => {
             const nodes = [...addedNodes];

--- a/ui/src/components/inputs/MonacoEditor.vue
+++ b/ui/src/components/inputs/MonacoEditor.vue
@@ -97,7 +97,6 @@
 <script setup lang="ts">
     import {
         computed,
-        getCurrentInstance,
         h,
         inject,
         onBeforeUnmount,
@@ -137,7 +136,6 @@
     import EditorType = editor.EditorType;
     import {useRoute} from "vue-router";
 
-    const currentInstance = getCurrentInstance()!;
     const {t} = useI18n();
 
     const textAreaValue = computed({
@@ -371,8 +369,7 @@
         }
     }, {deep: true});
 
-    const nowMoment: Moment = currentInstance.appContext.config.globalProperties.$moment().startOf("day");
-
+    const nowMoment: Moment = moment().startOf("day");
     function addedSuggestRows(mutations: MutationRecord[]) {
         return mutations.flatMap(({addedNodes}) => {
             const nodes = [...addedNodes];
@@ -461,7 +458,7 @@
                     endColumn: wordAtPosition?.endColumn ?? position?.column
                 },
                 // We don't use the selectedDate directly because if user modifies the input value directly it doesn't work otherwise
-                text: `${currentInstance.appContext.config.globalProperties.$moment(
+                text: `${moment(
                     datePicker.value!.$el.nextElementSibling.querySelector("input").value
                 ).toISOString(true)} `,
                 forceMoveMarkers: true

--- a/ui/src/components/inputs/MonacoEditor.vue
+++ b/ui/src/components/inputs/MonacoEditor.vue
@@ -125,7 +125,7 @@
     import uniqBy from "lodash/uniqBy";
     import {useI18n} from "vue-i18n";
     import {ElDatePicker} from "element-plus";
-    import moment from "moment";
+    import moment, {Moment} from "moment";
     import PlaceholderContentWidget from "../../composables/monaco/PlaceholderContentWidget";
     import Utils from "../../utils/utils";
     import {hashCode} from "../../utils/global";
@@ -369,7 +369,7 @@
         }
     }, {deep: true});
 
-    const nowMoment = moment().startOf("day");
+    const nowMoment: Moment = moment().startOf("day");
     function addedSuggestRows(mutations: MutationRecord[]) {
         return mutations.flatMap(({addedNodes}) => {
             const nodes = [...addedNodes];


### PR DESCRIPTION


### ✨ Description

This PR replaces the usage of `getCurrentInstance` utility from Vue to access `$moment` with a direct import of `moment` in the `ui/src/components/inputs/MonacoEditor.vue` component. This change aligns with the pattern used elsewhere in the project and removes unnecessary Vue instance access. 

### 🔗 Related Issue

Closes https://github.com/kestra-io/kestra/issues/12953

### 🎨 Frontend Checklist

Note: Since this is a refactoring change with no visible UI changes, screenshots are not applicable. The functionality remains identical.



### 📝 Additional Notes

This is a refactoring change that improves code consistency.  The `moment` library is now imported directly instead of being accessed through Vue's global properties via `getCurrentInstance()`. No functional changes to the MonacoEditor component behavior. 


