### PR TITLE
feat(core): enable label-based metrics

### DIFF
--- a/core/src/main/java/io/kestra/core/metrics/MetricConfig.java
+++ b/core/src/main/java/io/kestra/core/metrics/MetricConfig.java
@@ -4,6 +4,7 @@ import io.micronaut.context.annotation.ConfigurationProperties;
 import io.micronaut.core.convert.format.MapFormat;
 import lombok.Getter;
 
+import java.util.List;
 import java.util.Map;
 
 @ConfigurationProperties("kestra.metrics")
@@ -13,5 +14,10 @@ public class MetricConfig {
 
     @MapFormat(transformation = MapFormat.MapTransformation.FLAT)
     Map<String, String> tags;
+
+    /**
+     * {@link io.kestra.core.models.Label} keys included to metrics.
+     */
+    List<String> labels;
 }
 

--- a/core/src/main/java/io/kestra/core/metrics/MetricRegistry.java
+++ b/core/src/main/java/io/kestra/core/metrics/MetricRegistry.java
@@ -1,5 +1,6 @@
 package io.kestra.core.metrics;
 
+import io.kestra.core.models.Label;
 import io.kestra.core.models.executions.Execution;
 import io.kestra.core.models.executions.ExecutionKilled;
 import io.kestra.core.models.tasks.Task;
@@ -13,6 +14,11 @@ import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.ArrayUtils;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+
+import java.util.List;
+import java.util.stream.Stream;
 
 @Singleton
 @Slf4j
@@ -145,6 +151,8 @@ public class MetricRegistry {
     public static final String TAG_QUEUE_CONSUMER = "consumer";
     public static final String TAG_QUEUE_CONSUMER_GROUP = "consumer_group";
     public static final String TAG_QUEUE_TYPE = "queue_type";
+    public static final String TAG_LABEL_PREFIX = "label";
+    public static final String TAG_LABEL_PLACEHOLDER = "__none__";
 
     @Inject
     private MeterRegistry meterRegistry;
@@ -360,9 +368,11 @@ public class MetricRegistry {
      * @return tags to apply to metrics
      */
     public String[] tags(AbstractTrigger trigger) {
-        return new String[]{
+        var baseTags = new String[]{
             TAG_TRIGGER_TYPE, trigger.getType(),
         };
+        var labelTags = getLabelTags(trigger.getLabels());
+        return ArrayUtils.addAll(baseTags, labelTags);
     }
 
     /**
@@ -377,7 +387,9 @@ public class MetricRegistry {
             TAG_NAMESPACE_ID, execution.getNamespace(),
             TAG_STATE, execution.getState().getCurrent().name(),
         };
-        return execution.getTenantId() == null ? baseTags : ArrayUtils.addAll(baseTags, TAG_TENANT_ID, execution.getTenantId());
+        var labelTags = getLabelTags(execution.getLabels());
+        var tenantTag = getTenantTag(execution.getTenantId());
+        return ArrayUtils.addAll(ArrayUtils.addAll(baseTags, labelTags), tenantTag);
     }
 
     /**
@@ -428,6 +440,25 @@ public class MetricRegistry {
         } catch (Exception e) {
             log.warn("Error on metrics", e);
         }
+    }
+
+    private String[] getTenantTag(@Nullable String tenantId) {
+        return tenantId == null ? null : new String[]{TAG_TENANT_ID, tenantId};
+    }
+
+    private String[] getLabelTags(@NonNull List<Label> labels) {
+        return metricConfig.getLabels() == null ? null :
+            metricConfig.getLabels().stream()
+                .flatMap(labelKey -> Stream.of(
+                        "%s_%s".formatted(TAG_LABEL_PREFIX, labelKey),
+                        labels.stream()
+                            .filter(label -> labelKey.equals(label.key()))
+                            .map(Label::value)
+                            .findFirst()
+                            .orElse(TAG_LABEL_PLACEHOLDER)
+                    )
+                )
+                .toArray(String[]::new);
     }
 }
 

--- a/core/src/main/java/io/kestra/core/metrics/MetricRegistry.java
+++ b/core/src/main/java/io/kestra/core/metrics/MetricRegistry.java
@@ -152,6 +152,13 @@ public class MetricRegistry {
     public static final String TAG_QUEUE_CONSUMER_GROUP = "consumer_group";
     public static final String TAG_QUEUE_TYPE = "queue_type";
     public static final String TAG_LABEL_PREFIX = "label";
+    /**
+     * Sentinel value representing logical absence of label.
+     * <br />
+     * <a href="https://docs.micrometer.io/micrometer/reference/implementations/prometheus.html?utm_source=chatgpt.com#_limitation_on_same_name_with_different_set_of_tag_keys">
+     *     Micrometer - Limitation on same name with different set of tag keys
+     * </a>
+     */
     public static final String TAG_LABEL_PLACEHOLDER = "__none__";
 
     @Inject
@@ -446,19 +453,34 @@ public class MetricRegistry {
         return tenantId == null ? null : new String[]{TAG_TENANT_ID, tenantId};
     }
 
+    /**
+     * Speed-optimized version of {@link Label}s to tags conversion.
+     * @param labels The labels to evaluate against configured keys
+     * @return tags based on matching label keys
+     */
     private String[] getLabelTags(@NonNull List<Label> labels) {
-        return metricConfig.getLabels() == null ? null :
-            metricConfig.getLabels().stream()
-                .flatMap(labelKey -> Stream.of(
-                        "%s_%s".formatted(TAG_LABEL_PREFIX, labelKey),
-                        labels.stream()
-                            .filter(label -> labelKey.equals(label.key()))
-                            .map(Label::value)
-                            .findFirst()
-                            .orElse(TAG_LABEL_PLACEHOLDER)
-                    )
-                )
-                .toArray(String[]::new);
+        final List<String> configuredKeys = metricConfig.getLabels();
+        if (configuredKeys == null) return null;
+
+        int size = configuredKeys.size() * 2;
+        String[] tags = new String[size];
+        int i = 0;
+
+        for(String labelKey : configuredKeys) {
+            tags[i++] = TAG_LABEL_PREFIX + "_" + labelKey;
+            String labelValue = TAG_LABEL_PLACEHOLDER;
+
+            for (Label label : labels) {
+                if (labelKey.equals(label.key())) {
+                    labelValue = label.value();
+                    break;
+                }
+            }
+
+            tags[i++] = labelValue;
+        }
+
+        return tags;
     }
 }
 

--- a/core/src/test/java/io/kestra/core/metrics/MetricRegistryTest.java
+++ b/core/src/test/java/io/kestra/core/metrics/MetricRegistryTest.java
@@ -1,0 +1,105 @@
+package io.kestra.core.metrics;
+
+import io.kestra.core.models.Label;
+import io.kestra.core.models.executions.Execution;
+import io.kestra.core.models.flows.State;
+import io.kestra.core.utils.IdUtils;
+import io.micronaut.test.annotation.MockBean;
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.List;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@MicronautTest
+class MetricRegistryTest {
+    @Inject
+    private MetricRegistry metricRegistry;
+
+    @Inject
+    private MetricConfig mockConfig;
+
+    @MockBean(MetricConfig.class)
+    MetricConfig mockMetricConfig() {
+        return mock(MetricConfig.class);
+    }
+
+    @Test
+    void executionTagsNoLabelsConfigured() {
+        when(mockConfig.getLabels()).thenReturn(
+            List.of()
+        );
+
+        var execution = Execution.builder()
+            .id(IdUtils.create())
+            .namespace("io.kestra.unittest")
+            .flowId("flow")
+            .flowRevision(1)
+            .state(State.of(State.Type.SUCCESS, Collections.emptyList()))
+            .labels(List.of(
+                new Label("execution-label-foo", "bar"),
+                new Label(Label.CORRELATION_ID, "correlationId")
+            ))
+            .build();
+        var tags = metricRegistry.tags(execution);
+
+        assertThat(tags).containsExactly(
+            "flow_id", "flow",
+            "namespace_id", "io.kestra.unittest",
+            "state", "SUCCESS"
+        );
+    }
+
+    @Test
+    void executionTagsLabelsConfigured() {
+        when(mockConfig.getLabels()).thenReturn(
+            List.of("execution-label-foo")
+        );
+
+        var executionContainingConfiguredLabel = Execution.builder()
+            .id(IdUtils.create())
+            .namespace("io.kestra.unittest")
+            .flowId("flow")
+            .flowRevision(1)
+            .state(State.of(State.Type.SUCCESS, Collections.emptyList()))
+            .labels(List.of(
+                new Label("execution-label-foo", "test1"),
+                new Label("execution-label-bar", "test2"),
+                new Label(Label.CORRELATION_ID, "correlationId")
+            ))
+            .build();
+
+        assertThat(metricRegistry.tags(executionContainingConfiguredLabel)).containsExactly(
+            "flow_id", "flow",
+            "namespace_id", "io.kestra.unittest",
+            "state", "SUCCESS",
+            "label_execution-label-foo",
+            "test1"
+        );
+
+        var executionNotContainingConfiguredLabel = Execution.builder()
+            .id(IdUtils.create())
+            .namespace("io.kestra.unittest")
+            .flowId("flow")
+            .flowRevision(1)
+            .state(State.of(State.Type.SUCCESS, Collections.emptyList()))
+            .labels(List.of(
+                new Label("execution-label-bar", "test2"),
+                new Label(Label.CORRELATION_ID, "correlationId")
+            ))
+            .build();
+
+        assertThat(metricRegistry.tags(executionNotContainingConfiguredLabel)).containsExactly(
+            "flow_id", "flow",
+            "namespace_id", "io.kestra.unittest",
+            "state", "SUCCESS",
+            "label_execution-label-foo",
+            "__none__"
+        );
+    }
+}


### PR DESCRIPTION
### ✨ Description

This PR is more like a PoC/RFC - does such approach make sense, is possible cardinality explosion a problem, etc.

It attempts to solve the problem of monitoring executions of flow which executes data in different contexts conveyed by labels - e.g. `country: Germany`, `country: Italy`.

Therefore users could list label keys which they want to monitor. Execution-related metrics would become tagged by those labels.

### 🛠️ Backend Checklist

Tests including a PAUSED task seems to hang on my machine with both this branch and develop...

- [ ] Code compiles successfully and passes all checks
- [ ] All unit and integration tests pass