### PR TITLE
chore(ui): remove unnecessary useI18n from FlowPlaygroundToggle

### DIFF
--- a/ui/src/components/inputs/FlowPlaygroundToggle.vue
+++ b/ui/src/components/inputs/FlowPlaygroundToggle.vue
@@ -8,7 +8,6 @@
     import {usePlaygroundStore} from "../../stores/playground";
 
     const playgroundStore = usePlaygroundStore();
-
 </script>
 
 <style scoped lang="scss">

--- a/ui/src/components/inputs/FlowPlaygroundToggle.vue
+++ b/ui/src/components/inputs/FlowPlaygroundToggle.vue
@@ -1,14 +1,12 @@
 <template>
-    <el-tooltip placement="bottom" :content="t('playground.tooltip_persistence')">
-        <el-switch v-model="playgroundStore.enabled" :activeText="t('playground.toggle')" class="toggle" :class="{'is-active': playgroundStore.enabled}" />
+    <el-tooltip placement="bottom" :content="$t('playground.tooltip_persistence')">
+        <el-switch v-model="playgroundStore.enabled" :activeText="$t('playground.toggle')" class="toggle" :class="{'is-active': playgroundStore.enabled}" />
     </el-tooltip>
 </template>
 
 <script setup lang="ts">
-    import {useI18n} from "vue-i18n";
     import {usePlaygroundStore} from "../../stores/playground";
 
-    const {t} = useI18n();
     const playgroundStore = usePlaygroundStore();
 
 </script>


### PR DESCRIPTION
### ✨ Description

This PR cleans up unnecessary usage of the `useI18n` composable in the `FlowPlaygroundToggle.vue` component.  
Since translations in this component are only used within the `<template>` section, it now relies on the globally available `$t` helper provided by Kestra’s i18n setup.

This improves readability and aligns the component with the recommended i18n usage pattern.

---

### 🔗 Related Issue

Closes https://github.com/kestra-io/kestra/issues/13261.

---

### 🎨 Frontend Checklist

- [x] Code builds without errors (`npm run build`)
- [ ] All existing E2E tests pass (`npm run test:e2e`)  
  _(Not run locally — no behavior changes introduced)_
- [x] No visual UI changes (translation output remains unchanged)

---

### 📝 Additional Notes

This is my first contribution to the Kestra UI codebase.  
The change is intentionally scoped to a single component, as described in the issue, to keep the PR focused and easy to review.

---

### 🤖 AI Authors

Not applicable — this PR was written by a human contributor 🙂
