### PR TITLE
chore(test): resolve Mockito JDK21 warning

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -185,6 +185,7 @@ subprojects {subProj ->
                 canBeResolved = true
                 canBeConsumed = true
             }
+            mockitoAgent
         }
 
         dependencies {
@@ -205,6 +206,9 @@ subprojects {subProj ->
             testImplementation "org.junit.jupiter:junit-jupiter-params"
             testImplementation "org.junit-pioneer:junit-pioneer"
             testImplementation 'org.mockito:mockito-junit-jupiter'
+            mockitoAgent("org.mockito:mockito-core:5.21.0") {
+                transitive = false // just the core
+            }
 
             // hamcrest
             testImplementation 'org.hamcrest:hamcrest'
@@ -329,7 +333,10 @@ subprojects {subProj ->
                 junitXml.outputLocation = layout.buildDirectory.dir("test-results/test")
             }
             commonTestConfig(t)
-            jvmArgs = ["-javaagent:${configurations.agent.singleFile}"]
+            jvmArgs = [
+                "-javaagent:${configurations.agent.singleFile}",
+                "-javaagent:${configurations.mockitoAgent.singleFile}"
+            ]
         }
 
         tasks.named('check') {


### PR DESCRIPTION
### ✨ Description

What does this PR change?  

This is an attempt to resolve the following Mockito warning:

> Mockito is currently self-attaching to enable the inline-mock-maker. This will no longer work in future releases of the JDK.

https://javadoc.io/doc/org.mockito/mockito-core/latest/org.mockito/org/mockito/Mockito.html#0.3


### 🛠️ Backend Checklist

_If this PR does not include any backend changes, delete this entire section._

- [x] Code compiles successfully and passes all checks
- [ ] All unit and integration tests pass
