### PR TITLE
fix(core): foreach duplicate values should be preserved

### DIFF
--- a/core/src/main/java/io/kestra/core/runners/FlowableUtils.java
+++ b/core/src/main/java/io/kestra/core/runners/FlowableUtils.java
@@ -523,12 +523,7 @@ public class FlowableUtils {
             throw new IllegalVariableEvaluationException("Unknown value type: " + value.getClass());
         }
 
-        List<Object> distinctValue = values
-            .stream()
-            .distinct()
-            .toList();
-
-        long nullCount = distinctValue
+        long nullCount = values
             .stream()
             .filter(Objects::isNull)
             .count();
@@ -542,7 +537,7 @@ public class FlowableUtils {
         ArrayList<ResolvedTask> result = new ArrayList<>();
 
         int iteration = 0;
-        for (Object current : distinctValue) {
+        for (Object current : values) {
             try {
                 String resolvedValue = current instanceof String stringValue ? stringValue : MAPPER.writeValueAsString(current);
                 for (Task task : tasks) {

--- a/core/src/test/java/io/kestra/plugin/core/flow/ForEachTest.java
+++ b/core/src/test/java/io/kestra/plugin/core/flow/ForEachTest.java
@@ -73,4 +73,18 @@ class ForEachTest {
         assertThat(seconds.get(0).getIteration()).isEqualTo(0);
         assertThat(seconds.get(1).getIteration()).isEqualTo(1);
     }
+    @Test
+    @ExecuteFlow("flows/valids/foreach-duplication.yaml")
+    void duplication(Execution execution){
+        List<TaskRun> allTasks = execution.findTaskRunsByTaskId("log_task");
+        assertThat(allTasks).hasSize(7);
+        assertThat(allTasks.getFirst().getValue()).isEqualTo("1");
+        assertThat(allTasks.get(1).getValue()).isEqualTo("2");
+        assertThat(allTasks.get(2).getValue()).isEqualTo("1");
+        assertThat(allTasks.get(3).getValue()).isEqualTo("2");
+        assertThat(allTasks.get(4).getValue()).isEqualTo("5");
+        assertThat(allTasks.get(5).getValue()).isEqualTo("5");
+        assertThat(allTasks.getLast().getValue()).isEqualTo("5");
+    }
+
 }

--- a/core/src/test/resources/flows/valids/foreach-duplication.yaml
+++ b/core/src/test/resources/flows/valids/foreach-duplication.yaml
@@ -1,0 +1,11 @@
+id: foreach-duplication
+namespace: io.kestra.tests
+
+tasks:
+  - id: foreach
+    type: io.kestra.plugin.core.flow.ForEach
+    values:  [1,2,1,2,5,5,5]
+    tasks:
+      - id: log_task
+        type: io.kestra.plugin.core.log.Log
+        message: "{{taskrun.value}}"


### PR DESCRIPTION
Related to https://github.com/kestra-io/kestra/issues/13837.

## Description
this PR preserves duplicates for foreach values