### PR TITLE
refactor(core): use List.getLast() for lastAttempt()

### DIFF
--- a/core/src/main/java/io/kestra/core/models/executions/TaskRun.java
+++ b/core/src/main/java/io/kestra/core/models/executions/TaskRun.java
@@ -185,15 +185,11 @@ public class TaskRun implements TenantInterface {
     }
 
     public TaskRunAttempt lastAttempt() {
-        if (this.attempts == null) {
+        if (this.attempts == null || this.attempts.isEmpty()) {
             return null;
         }
 
-        return this
-            .attempts
-            .stream()
-            .reduce((a, b) -> b)
-            .orElse(null);
+        return this.attempts.getLast();
     }
 
     public TaskRun onRunningResend() {
@@ -264,8 +260,7 @@ public class TaskRun implements TenantInterface {
      * @return The next retry date, null if maxAttempt || maxDuration is reached
      */
     public Instant nextRetryDate(AbstractRetry retry, Execution execution) {
-        if (retry.getMaxAttempts() != null && execution.getMetadata().getAttemptNumber() >= retry.getMaxAttempts()) {
-
+        if (this.attempts == null || this.attempts.isEmpty() || retry.getMaxAttempts() != null && execution.getMetadata().getAttemptNumber() >= retry.getMaxAttempts()) {
             return null;
         }
         Instant base = this.lastAttempt().getState().maxDate();


### PR DESCRIPTION
## Description
- Replace stream-based reduction with Java 21 List.getLast() for clearer and more efficient access to the last attempt.
- This avoids unnecessary iteration by using constant-time access, which is beneficial when many retries are present.
- Add defensive check on attempts list before calling lastAttempt() in nextRetryDate() 
