### PR TITLE
fix(ui): Drop "Administration" from Instance and Tenant

### DIFF
--- a/ui/src/override/components/useLeftMenu.ts
+++ b/ui/src/override/components/useLeftMenu.ts
@@ -233,7 +233,7 @@ export function useLeftMenu() {
                 ],
             },
             {
-                title: t("tenant_administration"),
+                title: t("tenant.name"),
                 routes: [
                     "admin/stats",
                     "kv",
@@ -332,7 +332,7 @@ export function useLeftMenu() {
                 ],
             },
             {
-                title: t("instance_administration"),
+                title: t("instance"),
                 routes: routeStartWith("admin/instance"),
                 href: {
                     name: "admin/instance",

--- a/ui/src/translations/de.json
+++ b/ui/src/translations/de.json
@@ -1011,7 +1011,6 @@
     "input_custom_duration": "oder benutzerdefinierte Dauer eingeben:",
     "inputs": "Inputs",
     "instance": "Instanz",
-    "instance_administration": "Instanzverwaltung",
     "invalid bulk delete": "Ausführungen konnten nicht gelöscht werden",
     "invalid bulk force run": "Konnte Ausführungen nicht erzwingen",
     "invalid bulk kill": "Ausführungen konnten nicht beendet werden",
@@ -1747,7 +1746,6 @@
       "names": "Mandanten"
     },
     "tenantId": "Mandanten-ID",
-    "tenant_administration": "Mandantenverwaltung",
     "test-badge-text": "Test",
     "test-badge-tooltip": "Diese Ausführung wurde durch einen Test erstellt",
     "theme": "Modus",

--- a/ui/src/translations/en.json
+++ b/ui/src/translations/en.json
@@ -393,8 +393,6 @@
     "conditions": "Conditions",
     "triggerId": "Trigger ID",
     "tenantId": "Tenant ID",
-    "tenant_administration": "Tenant Administration",
-    "instance_administration": "Instance Administration",
     "codeDisabled": "Disabled in Flow",
     "paused": "Paused",
     "Fold auto": "Editor: automatic fold of multi-lines",

--- a/ui/src/translations/es.json
+++ b/ui/src/translations/es.json
@@ -1011,7 +1011,6 @@
     "input_custom_duration": "o ingrese duración personalizada:",
     "inputs": "Entradas",
     "instance": "Instancia",
-    "instance_administration": "Administración de Instancia",
     "invalid bulk delete": "No se pudieron eliminar las ejecuciones",
     "invalid bulk force run": "No se pudo forzar la ejecución de ejecuciones",
     "invalid bulk kill": "No se pudieron matar las ejecuciones",
@@ -1747,7 +1746,6 @@
       "names": "Arrendatarios"
     },
     "tenantId": "ID de Mandante",
-    "tenant_administration": "Administración de Mandantes",
     "test-badge-text": "Prueba",
     "test-badge-tooltip": "Esta ejecución fue creada por una prueba",
     "theme": "Tema",

--- a/ui/src/translations/fr.json
+++ b/ui/src/translations/fr.json
@@ -1011,7 +1011,6 @@
     "input_custom_duration": "ou saisir une durée personnalisée :",
     "inputs": "Entrées",
     "instance": "Instance",
-    "instance_administration": "Administration de l'Instance",
     "invalid bulk delete": "Impossible de supprimer les exécutions",
     "invalid bulk force run": "Impossible de forcer l'exécution des exécutions",
     "invalid bulk kill": "Impossible d'arrêter les exécutions",
@@ -1747,7 +1746,6 @@
       "names": "Mandants"
     },
     "tenantId": "ID du mandant",
-    "tenant_administration": "Administration des Mandants",
     "test-badge-text": "Test",
     "test-badge-tooltip": "Cette exécution a été créée par un Test",
     "theme": "Thème",

--- a/ui/src/translations/hi.json
+++ b/ui/src/translations/hi.json
@@ -1011,7 +1011,6 @@
     "input_custom_duration": "या कस्टम अवधि दर्ज करें:",
     "inputs": "इनपुट्स",
     "instance": "इंस्टेंस",
-    "instance_administration": "इंस्टेंस प्रशासन",
     "invalid bulk delete": "निष्पादन हटाने में असमर्थ",
     "invalid bulk force run": "निष्पादन को जबरन चलाने में असमर्थ",
     "invalid bulk kill": "निष्पादन kill करने में असमर्थ",
@@ -1747,7 +1746,6 @@
       "names": "मंडल"
     },
     "tenantId": "टेनेंट ID",
-    "tenant_administration": "किरायेदार प्रशासन",
     "test-badge-text": "परीक्षण",
     "test-badge-tooltip": "यह execution एक Test द्वारा बनाया गया था",
     "theme": "थीम",

--- a/ui/src/translations/it.json
+++ b/ui/src/translations/it.json
@@ -1011,7 +1011,6 @@
     "input_custom_duration": "oppure inserisci durata personalizzata:",
     "inputs": "Inputs",
     "instance": "Istanza",
-    "instance_administration": "Amministrazione dell'istanza",
     "invalid bulk delete": "Impossibile eliminare le esecuzioni",
     "invalid bulk force run": "Impossibile forzare l'esecuzione delle esecuzioni",
     "invalid bulk kill": "Impossibile kill le esecuzioni",
@@ -1747,7 +1746,6 @@
       "names": "Mandanti"
     },
     "tenantId": "ID del Mandante",
-    "tenant_administration": "Amministrazione del Mandante",
     "test-badge-text": "Test",
     "test-badge-tooltip": "Questa esecuzione è stata creata da un Test",
     "theme": "Tema",

--- a/ui/src/translations/ja.json
+++ b/ui/src/translations/ja.json
@@ -1011,7 +1011,6 @@
     "input_custom_duration": "またはカスタム期間を入力してください:",
     "inputs": "Inputs",
     "instance": "インスタンス",
-    "instance_administration": "インスタンス管理",
     "invalid bulk delete": "実行を削除できませんでした",
     "invalid bulk force run": "実行を強制的に開始できませんでした",
     "invalid bulk kill": "実行をkillできませんでした",
@@ -1747,7 +1746,6 @@
       "names": "テナント"
     },
     "tenantId": "テナントID",
-    "tenant_administration": "テナント管理",
     "test-badge-text": "テスト",
     "test-badge-tooltip": "この実行はテストによって作成されました",
     "theme": "テーマ",

--- a/ui/src/translations/ko.json
+++ b/ui/src/translations/ko.json
@@ -1011,7 +1011,6 @@
     "input_custom_duration": "또는 사용자 지정 기간 입력:",
     "inputs": "Inputs",
     "instance": "인스턴스",
-    "instance_administration": "인스턴스 관리",
     "invalid bulk delete": "실행을 삭제할 수 없습니다",
     "invalid bulk force run": "실행을 강제로 실행할 수 없습니다.",
     "invalid bulk kill": "실행을 강제 종료할 수 없습니다",
@@ -1747,7 +1746,6 @@
       "names": "테넌트"
     },
     "tenantId": "테넌트 ID",
-    "tenant_administration": "테넌트 관리",
     "test-badge-text": "테스트",
     "test-badge-tooltip": "이 실행은 테스트에 의해 생성되었습니다.",
     "theme": "테마",

--- a/ui/src/translations/pl.json
+++ b/ui/src/translations/pl.json
@@ -1011,7 +1011,6 @@
     "input_custom_duration": "lub wprowadź niestandardowy czas trwania:",
     "inputs": "Inputs",
     "instance": "Instancja",
-    "instance_administration": "Administracja Instancji",
     "invalid bulk delete": "Nie można usunąć wykonań",
     "invalid bulk force run": "Nie można wymusić uruchomienia wykonania",
     "invalid bulk kill": "Nie można zabić wykonań",
@@ -1747,7 +1746,6 @@
       "names": "Najemcy"
     },
     "tenantId": "Identyfikator Mandanta",
-    "tenant_administration": "Administracja Mandanta",
     "test-badge-text": "Test",
     "test-badge-tooltip": "To wykonanie zostało utworzone przez Test.",
     "theme": "Motyw",

--- a/ui/src/translations/pt.json
+++ b/ui/src/translations/pt.json
@@ -1011,7 +1011,6 @@
     "input_custom_duration": "ou insira uma duração personalizada:",
     "inputs": "Inputs",
     "instance": "Instância",
-    "instance_administration": "Administração da Instância",
     "invalid bulk delete": "Não foi possível deletar execuções",
     "invalid bulk force run": "Não foi possível forçar a execução das execuções",
     "invalid bulk kill": "Não foi possível matar execuções",
@@ -1747,7 +1746,6 @@
       "names": "Mandantes"
     },
     "tenantId": "ID do Mandante",
-    "tenant_administration": "Administração do Mandante",
     "test-badge-text": "Teste",
     "test-badge-tooltip": "Esta execução foi criada por um Teste",
     "theme": "Tema",

--- a/ui/src/translations/pt_BR.json
+++ b/ui/src/translations/pt_BR.json
@@ -1011,7 +1011,6 @@
     "input_custom_duration": "ou insira uma duração personalizada:",
     "inputs": "Inputs",
     "instance": "Instância",
-    "instance_administration": "Administração da Instância",
     "invalid bulk delete": "Não foi possível excluir execuções",
     "invalid bulk force run": "Não foi possível forçar a execução das execuções",
     "invalid bulk kill": "Não foi possível matar execuções",
@@ -1747,7 +1746,6 @@
       "names": "Clientes"
     },
     "tenantId": "ID do Cliente",
-    "tenant_administration": "Administração de Tenant",
     "test-badge-text": "Teste",
     "test-badge-tooltip": "Esta execução foi criada por um Teste",
     "theme": "Tema",

--- a/ui/src/translations/ru.json
+++ b/ui/src/translations/ru.json
@@ -1011,7 +1011,6 @@
     "input_custom_duration": "или введите пользовательскую продолжительность:",
     "inputs": "Входные данные",
     "instance": "Экземпляр",
-    "instance_administration": "Администрирование экземпляра",
     "invalid bulk delete": "Не удалось удалить выполнения",
     "invalid bulk force run": "Не удалось принудительно запустить executions",
     "invalid bulk kill": "Не удалось убить выполнения",
@@ -1747,7 +1746,6 @@
       "names": "Арендаторы"
     },
     "tenantId": "ID арендатора",
-    "tenant_administration": "Администрирование Манданта",
     "test-badge-text": "Тест",
     "test-badge-tooltip": "Это выполнение было создано тестом",
     "theme": "Тема",

--- a/ui/src/translations/zh_CN.json
+++ b/ui/src/translations/zh_CN.json
@@ -1011,7 +1011,6 @@
     "input_custom_duration": "或输入自定义持续时间：",
     "inputs": "输入",
     "instance": "实例",
-    "instance_administration": "实例管理",
     "invalid bulk delete": "无法删除执行",
     "invalid bulk force run": "无法强制运行执行",
     "invalid bulk kill": "无法终止执行",
@@ -1747,7 +1746,6 @@
       "names": "租户"
     },
     "tenantId": "租户 ID",
-    "tenant_administration": "租户管理",
     "test-badge-text": "测试",
     "test-badge-tooltip": "此执行由测试创建",
     "theme": "主题",


### PR DESCRIPTION
### ✨ Description

Discussed with @Ben8t 

Drop "Administration" as it overflows and just breaks with overall menu UX.
Also technically Namespaces would be classified as "Administration", as it behaves very similar to tenants.

EE fix: https://github.com/kestra-io/kestra-ee/pull/6233

### 🔗 Related Issue

relates to https://github.com/kestra-io/kestra-ee/issues/5415#issuecomment-3502465847

### 🎨 Frontend Checklist

_If this PR does not include any frontend changes, delete this entire section._

- [x] Code builds without errors (`npm run build`)
- [x] All existing E2E tests pass (`npm run test:e2e`)
- [x] Screenshots or video recordings attached showing the `UI` changes


<img width="253" height="578" alt="image" src="https://github.com/user-attachments/assets/bbd8b4cb-109b-4587-a5b1-ca4333085d25" />

