### PR TITLE
fix(ui): remove duplicate empty state message on Logs and Triggers pages

### DIFF
--- a/ui/src/components/logs/LogsWrapper.vue
+++ b/ui/src/components/logs/LogsWrapper.vue
@@ -13,7 +13,7 @@
                         }"
                         :defaultScope="false"
                     />
-                </template>xx
+                </template>
 
                 <template v-if="showStatChart()" #top>
                     <Sections ref="dashboard" :charts :dashboard="{id: 'default', charts: []}" showDefault class="mb-4" />
@@ -31,10 +31,6 @@
                                 :log="log"
                                 :class="{'log-0': i === 0}"
                             />
-                        </div>
-
-                        <div v-else-if="!isLoading">
-                            <NoData :text="$t('no_logs_data_description')" />
                         </div>
                     </div>
                 </template>
@@ -55,7 +51,7 @@
     import DataTable from "../../components/layout/DataTable.vue";
     import TopNavBar from "../../components/layout/TopNavBar.vue";
     import LogLine from "../logs/LogLine.vue";
-    import NoData from "../layout/NoData.vue";
+    // NoData import is technically unused now, but safe to leave or remove 
     import {storageKeys} from "../../utils/constants";
     import {decodeSearchParams} from "../filter/utils/helpers";
     import * as YAML_UTILS from "@kestra-io/ui-libs/flow-yaml-utils";


### PR DESCRIPTION
✨ Description
This PR fixes a UI bug where the empty state message ("Looks like there’s nothing here... yet!") was appearing twice on the Logs page.

The duplicate occurred because LogsWrapper.vue was manually rendering a <NoData /> component, while the underlying DataTable component was also rendering its own empty state. I removed the manual instance to leave only the standard one.

🔗 Related Issue
Closes #13856

🎨 Frontend Checklist
[x] Code builds without errors (npm run build)

[ ] All existing E2E tests pass (npm run test:e2e)

[x] Screenshots or video recordings attached showing the UI changes

🛠️ Backend Checklist
Deleted (No backend changes)

📝 Additional Notes
None
<img width="1919" height="876" alt="Screenshot 2025-12-30 023951" src="https://github.com/user-attachments/assets/933a778c-2b6e-4042-bb6a-1a3919a8cfe4" />
<img width="1919" height="864" alt="Screenshot 2025-12-30 024001" src="https://github.com/user-attachments/assets/64393c2f-de22-4fb5-a326-bf38f3ece283" />

