### PR TITLE
refactor(jdbc): avoid unnecessary JDBC executions.

### DIFF
--- a/jdbc-h2/src/main/java/io/kestra/runner/h2/H2Queue.java
+++ b/jdbc-h2/src/main/java/io/kestra/runner/h2/H2Queue.java
@@ -55,7 +55,7 @@ public class H2Queue<T> extends JdbcQueue<T> {
     }
 
     @Override
-    protected void updateGroupOffsets(DSLContext ctx, String consumerGroup, String queueType, List<Integer> offsets) {
+    protected void doUpdateGroupOffsets(DSLContext ctx, String consumerGroup, String queueType, List<Integer> offsets) {
         var update = ctx.update(DSL.table(table.getName()))
             .set(
                 AbstractJdbcRepository.field("consumers"),

--- a/jdbc-mysql/src/main/java/io/kestra/runner/mysql/MysqlQueue.java
+++ b/jdbc-mysql/src/main/java/io/kestra/runner/mysql/MysqlQueue.java
@@ -64,7 +64,7 @@ public class MysqlQueue<T> extends JdbcQueue<T> {
     }
 
     @Override
-    protected void updateGroupOffsets(DSLContext ctx, String consumerGroup, String queueType, List<Integer> offsets) {
+    protected void doUpdateGroupOffsets(DSLContext ctx, String consumerGroup, String queueType, List<Integer> offsets) {
         var update = ctx
             .update(DSL.table(table.getName()))
             .set(

--- a/jdbc-postgres/src/main/java/io/kestra/runner/postgres/PostgresQueue.java
+++ b/jdbc-postgres/src/main/java/io/kestra/runner/postgres/PostgresQueue.java
@@ -83,7 +83,7 @@ public class PostgresQueue<T> extends JdbcQueue<T> {
     }
 
     @Override
-    protected void updateGroupOffsets(DSLContext ctx, String consumerGroup, String queueType, List<Integer> offsets) {
+    protected void doUpdateGroupOffsets(DSLContext ctx, String consumerGroup, String queueType, List<Integer> offsets) {
         var update = ctx.update(DSL.table(table.getName()))
             .set(AbstractJdbcRepository.field("consumer_" + queueType), true)
             .set(AbstractJdbcRepository.field("updated"), LocalDateTime.now())

--- a/jdbc/src/main/java/io/kestra/jdbc/runner/JdbcQueue.java
+++ b/jdbc/src/main/java/io/kestra/jdbc/runner/JdbcQueue.java
@@ -11,6 +11,7 @@ import io.kestra.core.queues.*;
 import io.kestra.core.utils.Either;
 import io.kestra.core.utils.ExecutorsUtils;
 import io.kestra.core.utils.IdUtils;
+import io.kestra.core.utils.ListUtils;
 import io.kestra.jdbc.JdbcTableConfigs;
 import io.kestra.jdbc.JdbcMapper;
 import io.kestra.jdbc.JooqDSLContextWrapper;
@@ -264,9 +265,15 @@ public abstract class JdbcQueue<T> implements QueueInterface<T> {
         return this.receiveFetch(ctx, consumerGroup, queueType, true);
     }
 
+    protected void updateGroupOffsets(DSLContext ctx, String consumerGroup, String queueType, List<Integer> offsets) {
+        if (!ListUtils.isEmpty(offsets)) {
+            doUpdateGroupOffsets(ctx, consumerGroup, queueType, offsets);
+        }
+    }
+
     abstract protected Result<Record> receiveFetch(DSLContext ctx, String consumerGroup, String queueType, boolean forUpdate);
 
-    abstract protected void updateGroupOffsets(DSLContext ctx, String consumerGroup, String queueType, List<Integer> offsets);
+    abstract protected void doUpdateGroupOffsets(DSLContext ctx, String consumerGroup, String queueType, List<Integer> offsets);
 
     protected abstract Condition buildTypeCondition(String type);
 


### PR DESCRIPTION
avoid unnecessary JDBC executions.

### ✨ Description

To avoid unnecessary JDBC executions, which may result in empty offsets in some cases (e.g., executor, flow_topology, indexer).

### 🔗 Related Issue

chore

### 🛠️ Backend Checklist

- [√] Code compiles successfully and passes all checks
- [√ ] All unit and integration tests pass

### 📝 Additional Notes

none

