### PR TITLE
refactor: Replace BallotOutlineIcon with ShapePlusOutline for the Blu…

### DIFF
--- a/ui/src/override/components/flows/panelDefinition.ts
+++ b/ui/src/override/components/flows/panelDefinition.ts
@@ -6,7 +6,7 @@ import DotsSquareIcon from "vue-material-design-icons/DotsSquare.vue";
 import FileDocumentIcon from "vue-material-design-icons/FileDocument.vue";
 import MouseRightClickIcon from "vue-material-design-icons/MouseRightClick.vue";
 import FileTreeOutlineIcon from "vue-material-design-icons/FileTreeOutline.vue";
-import BallotOutlineIcon from "vue-material-design-icons/BallotOutline.vue";
+import ShapePlusOutline from "vue-material-design-icons/ShapePlusOutline.vue";
 
 import NoCode from "../../../components/no-code/NoCode.vue";
 import EditorWrapper from "../../../components/inputs/EditorWrapper.vue";
@@ -49,7 +49,7 @@ export const EDITOR_ELEMENTS: EditorElement[] = [
         uid: "topology",
         component: markRaw(LowCodeEditorWrapper),
     },
-        {
+    {
         button: {
             icon: markRaw(FileDocumentIcon),
             label: "Documentation"
@@ -68,7 +68,7 @@ export const EDITOR_ELEMENTS: EditorElement[] = [
     },
     {
         button: {
-            icon: markRaw(BallotOutlineIcon),
+            icon: markRaw(ShapePlusOutline),
             label: "Blueprints"
         },
         uid: "blueprints",
@@ -77,7 +77,7 @@ export const EDITOR_ELEMENTS: EditorElement[] = [
 ].map((e): EditorElement => ({
     // add a default deserializer
     deserialize: (value: string) => {
-        if(e.uid === value){
+        if (e.uid === value) {
             return e;
         }
         return undefined;

--- a/ui/tests/storybook/components/MultiPanelTabs.stories.tsx
+++ b/ui/tests/storybook/components/MultiPanelTabs.stories.tsx
@@ -6,7 +6,7 @@ import MouseRightClickIcon from "vue-material-design-icons/MouseRightClick.vue";
 import FileTreeOutlineIcon from "vue-material-design-icons/FileTreeOutline.vue";
 import FileDocumentIcon from "vue-material-design-icons/FileDocument.vue";
 import DotsSquareIcon from "vue-material-design-icons/DotsSquare.vue";
-import BallotOutlineIcon from "vue-material-design-icons/BallotOutline.vue";
+import ShapePlusOutline from "vue-material-design-icons/ShapePlusOutline.vue";
 
 import MultiPanelTabs from "../../../src/components/MultiPanelTabs.vue";
 import {Panel} from "../../../src/utils/multiPanelTypes";
@@ -118,7 +118,7 @@ const argGenerator = (index?: number) => {
                         component: () => <PlaceholderComponent tabId="5" />,
                     },
                     {
-                        button: {icon: markRaw(BallotOutlineIcon), label: "Tab 6"},
+                        button: {icon: markRaw(ShapePlusOutline), label: "Tab 6"},
                         uid: "tab6",
                         component: () => <PlaceholderComponent tabId="6" />,
                     },


### PR DESCRIPTION
### ✨ Description

Replaced the updated `BallotOutline` icon with the new `ShapePlusOutline` icon for the Blueprints panel in the Flow Editor. This aligns the UI with the recent menu revamp.

### 🔗 Related Issue

Closes #13881

### 🎨 Frontend Checklist

- [x] Checked Manually 
- [ x] Before: It used a "Ballot" icon (box with check lines).
- [ x] Now: It should use the ShapePlus icon (shapes with a plus sign).
<img width="764" height="109" alt="Screenshot_2025-12-30_16-57-01" src="https://github.com/user-attachments/assets/cc4a5239-1684-4c28-9d77-cfda4ddccf0e" />


### 📝 Additional Notes

I verified this by checking the Blueprints button in the Flow Editor panel.