### PR TITLE
fix(ui): use $t helper in BasicAuthLogin template

### DIFF
--- a/ui/src/components/basicauth/BasicAuthLogin.vue
+++ b/ui/src/components/basicauth/BasicAuthLogin.vue
@@ -12,7 +12,7 @@
                     size="large"
                     id="input-username"
                     v-model="credentials.username"
-                    :placeholder="t('email')"
+                    :placeholder="$t('email')"
                     required
                 >
                     <template #prepend>
@@ -31,7 +31,7 @@
                     size="large"
                     name="password"
                     id="input-password"
-                    :placeholder="t('password')"
+                    :placeholder="$t('password')"
                     type="password"
                     showPassword
                     required
@@ -56,7 +56,7 @@
                     :disabled="isLoginDisabled"
                     :loading="isLoading"
                 >
-                    {{ t("setup.login") }}
+                    {{ $t("setup.login") }}
                 </el-button>
             </el-form-item>
             <el-form-item>
@@ -66,7 +66,7 @@
                     size="large"
                     @click="openTroubleshootingGuide"
                 >
-                    {{ t("setup.troubleshooting") }}
+                    {{ $t("setup.troubleshooting") }}
                 </el-button>
             </el-form-item>
         </el-form>


### PR DESCRIPTION
## What does this PR change?
Replaces template usages of `t()` with `$t()` in `BasicAuthLogin.vue` to align
with the global i18n helpers exposed by `createI18n`.

## 🔗 Related Issue
Closes https://github.com/kestra-io/kestra/issues/13893

## 🎨 Frontend Checklist
- [x] Code builds without errors
- [ ] Screenshots or video recordings attached (not applicable – no UI change)

## 📝 Additional Notes
This change is limited to the `<template>` section only.
No script logic or behavior was modified.
