### PR TITLE
ui: remove unnecessary useI18n usage in Curl.vue

### DIFF
--- a/ui/src/components/flows/Curl.vue
+++ b/ui/src/components/flows/Curl.vue
@@ -29,7 +29,6 @@
         verbose: true
     });
 
-
     const exampleFileName = ref("kestra.json");
 
     const exampleFileInputUrl = computed(() =>

--- a/ui/src/components/flows/Curl.vue
+++ b/ui/src/components/flows/Curl.vue
@@ -5,7 +5,7 @@
         <CopyToClipboard :text="curlCommand" />
 
         <el-alert class="mt-3" type="info" showIcon :closable="false">
-            {{ t('curl.note') }}
+            {{ $t('curl.note') }}
         </el-alert>
     </div>
 </template>
@@ -14,7 +14,6 @@
     import {computed, ref} from "vue";
     import {baseUrl, basePath, apiUrl} from "override/utils/route";
     import CopyToClipboard from "../layout/CopyToClipboard.vue";
-    import {useI18n} from "vue-i18n";
     import moment from "moment";
     import {Flow} from "../../stores/flow";
     import {Label} from "../../stores/executions";
@@ -30,7 +29,6 @@
         verbose: true
     });
 
-    const {t} = useI18n();
 
     const exampleFileName = ref("kestra.json");
 


### PR DESCRIPTION
### ✨ Description

This PR removes unnecessary usage of the useI18n composable from Curl.vue and switches to the globally available $t helper for template-only translations.

This aligns the component with Kestra’s global i18n setup and reduces redundant imports.
### 🔗 Related Issue

Closes https://github.com/kestra-io/kestra/issues/13225
Closes https://github.com/kestra-io/kestra/issues/13987

### 🎨 Frontend Checklist

_If this PR does not include any frontend changes, delete this entire section._

- [ ] Code builds without errors (`npm run build`)
- [ ] All existing E2E tests pass (`npm run test:e2e`)
- [ ] Screenshots or video recordings attached showing the `UI` changes

### 🛠️ Backend Checklist

_If this PR does not include any backend changes, delete this entire section._

- [ ] Code compiles successfully and passes all checks
- [ ] All unit and integration tests pass

### 📝 Additional Notes

This change does not alter UI behavior and only simplifies translation usage in the template.