### PR TITLE
ui: use  instead of t in AITriggerButton template

### DIFF
--- a/ui/src/components/ai/AITriggerButton.vue
+++ b/ui/src/components/ai/AITriggerButton.vue
@@ -6,7 +6,7 @@
             :icon="AiIcon" 
             @click="handleClick"
         >
-            {{ t("ai.flow.title") }}
+            {{ $t("ai.flow.title") }}
         </el-button>
     </div>
 </template>

--- a/ui/src/components/ai/AITriggerButton.vue
+++ b/ui/src/components/ai/AITriggerButton.vue
@@ -12,7 +12,6 @@
 </template>
 
 <script setup lang="ts">
-    import {useI18n} from "vue-i18n";
     import AiIcon from "./AiIcon.vue";
 
     interface AITriggerButtonProps {
@@ -23,8 +22,6 @@
     interface AITriggerButtonEmits {
         (event: "click"): void;
     }
-
-    const {t} = useI18n();
 
     withDefaults(defineProps<AITriggerButtonProps>(), {
         show: false,


### PR DESCRIPTION
Uniforms the AITriggerButton.vue translations by using $t in the template section.
This ensures all button text is properly internationalized across supported languages and avoids hardcoded strings in the template.

Closes https://github.com/kestra-io/kestra/issues/12968.
Closes [#13892](https://github.com/kestra-io/kestra/issues/13892)

- [x]  Code builds without errors (npm run build)
- [x] All existing E2E tests pass (npm run test:e2e)

