### PR TITLE
chore(ui): Make No-Code Add-Buttons default/secondary

### DIFF
--- a/ui/src/components/no-code/components/tasks/taskList/buttons/Creation.vue
+++ b/ui/src/components/no-code/components/tasks/taskList/buttons/Creation.vue
@@ -1,5 +1,5 @@
 <template>
-    <el-button @click.prevent.stop="handleClick()" type="primary" :icon="Plus">
+    <el-button @click.prevent.stop="handleClick()" type="default" :icon="Plus">
         {{ $t("add") }}
     </el-button>
 </template>


### PR DESCRIPTION


### ✨ Description

#### Before
<img width="350" height="559" alt="image" src="https://github.com/user-attachments/assets/0a2d02a3-7bee-4f9d-9236-8ef4d912c113" />

#### After
<img width="350" height="535" alt="image" src="https://github.com/user-attachments/assets/cda5d682-a079-40cb-ac19-2aa3f655f744" />


### 🎨 Frontend Checklist

_If this PR does not include any frontend changes, delete this entire section._

- [x] Code builds without errors (`npm run build`)
- [x] All existing E2E tests pass (`npm run test:e2e`)
- [x] Screenshots or video recordings attached showing the `UI` changes

