### PR TITLE
chore(ui): Secret: Make Add tag button a default button

### DIFF
--- a/ui/src/components/secrets/SecretsTable.vue
+++ b/ui/src/components/secrets/SecretsTable.vue
@@ -199,7 +199,7 @@
                             />
                         </el-button-group>
                     </el-row>
-                    <el-button :icon="Plus" @click="addSecretTag" type="primary">
+                    <el-button :icon="Plus" @click="addSecretTag" type="default">
                         {{ $t('secret.addTag') }}
                     </el-button>
                 </el-form-item>


### PR DESCRIPTION
### ✨ Description

Secret: Make Add tag button a default button



### Before

<img width="764" height="328" alt="image" src="https://github.com/user-attachments/assets/94477d9b-5429-44d5-8584-9f70308a1678" />

### After

<img width="788" height="349" alt="image" src="https://github.com/user-attachments/assets/4b421177-433b-4d5a-935d-d23ae1070657" />





### 🎨 Frontend Checklist

_If this PR does not include any frontend changes, delete this entire section._

- [x] Code builds without errors (`npm run build`)
- [x] All existing E2E tests pass (`npm run test:e2e`)
- [x] Screenshots or video recordings attached showing the `UI` changes
