### PR TITLE
use $t helper in AuditLogs template

### DIFF
--- a/ui/src/components/demo/AuditLogs.vue
+++ b/ui/src/components/demo/AuditLogs.vue
@@ -1,14 +1,14 @@
 <template>
     <TopNavBar :title="routeInfo.title" v-if="!isFullScreen() && !embed" />
     <Layout
-        :title="t('demos.audit-logs.title')"
-        :image="{source: sourceImg, alt: t('demos.audit-logs.title')}"
+        :title="$t('demos.audit-logs.title')"
+        :image="{source: sourceImg, alt: $t('demos.audit-logs.title')}"
         :video="{
             source: 'https://www.youtube.com/embed/Qz24gBPGZHs',
         }"
     >
         <template #message>
-            {{ t('demos.audit-logs.message') }}
+            {{ $t('demos.audit-logs.message') }}
         </template>
     </Layout>
 </template>


### PR DESCRIPTION
### ✨ Description

Replaces all t() expressions with $t() in the <template> section of the AuditLogs.vue.

### 🔗 Related Issue

Closes https://github.com/kestra-io/kestra/issues/13928

### 🎨 Frontend Checklist

- [x] Code builds without errors (`npm run build`)
- [ ] All existing E2E tests pass (`npm run test:e2e`)
- [ ] Screenshots or video recordings attached showing the `UI` changes
