### PR TITLE
fix(ui): use  helper in dashboard selector template

### DIFF
--- a/ui/src/components/dashboard/components/selector/Selector.vue
+++ b/ui/src/components/dashboard/components/selector/Selector.vue
@@ -2,7 +2,7 @@
     <el-dropdown trigger="click" hideOnClick placement="bottom-end">
         <el-button :icon="ChartLineVariant" class="selected">
             <span v-if="!verticalLayout" class="text-truncate">
-                {{ selected ?? t("dashboards.default") }}
+                {{ selected ?? $t("dashboards.default") }}
             </span>
         </el-button>
 
@@ -15,13 +15,13 @@
                     :to="{name: 'dashboards/create', query}"
                     class="w-100"
                 >
-                    <small>{{ t("dashboards.creation.label") }}</small>
+                    <small>{{ $t("dashboards.creation.label") }}</small>
                 </el-button>
 
                 <Item
                     :dashboard="{
                         id: filtered.filter(d => d.title === selected)?.[0]?.id ?? 'default',
-                        title: selected ?? t('dashboards.default')
+                        title: selected ?? $t('dashboards.default')
                     }"
                     :edit="edit"
                     class="mt-3"
@@ -31,7 +31,7 @@
 
                 <el-input
                     v-model="search"
-                    :placeholder="t('search')"
+                    :placeholder="$t('search')"
                     :prefixIcon="Magnify"
                     clearable
                     class="my-1 mb-3 search"
@@ -47,7 +47,7 @@
                         @click="select(dashboard)"
                     />
                     <span v-if="!filtered.length" class="empty">
-                        {{ t("dashboards.empty") }}
+                        {{ $t("dashboards.empty") }}
                     </span>
                 </div>
             </el-dropdown-menu>


### PR DESCRIPTION
### ✨ Description
Replace all template usages of t('…') with $t('…') in Selector.vue to align with global i18n exposure and Kestra UI conventions.

### 🔗 Related Issue
Closes https://github.com/kestra-io/kestra/issues/13927

### 🎨 Frontend Checklist

- [x] Code builds without errors (`npm run build`)
- [ ] All existing E2E tests pass (`npm run test:e2e`)
- [ ] Screenshots or video recordings attached showing the `UI` changes

### 📝 Additional Notes
This is a small frontend-only fix with no impact outside the affected UI code.
