### PR TITLE
Align the bulk and single execution actions for both Replay and Restart #8337

### DIFF
--- a/ui/src/components/executions/Executions.vue
+++ b/ui/src/components/executions/Executions.vue
@@ -90,7 +90,7 @@
                             <el-button v-if="canUpdate" :icon="StateMachine" @click="changeStatusDialogVisible = !changeStatusDialogVisible">
                                 {{ $t("change state") }}
                             </el-button>
-                            <el-button v-if="canUpdate" :icon="Restart" @click="restartExecutions()">
+                            <el-button v-if="canUpdate" :icon="Restart" @click="isOpenRestartModal = !isOpenRestartModal">
                                 {{ $t("restart") }}
                             </el-button>
                             <el-button v-if="canCreate" :icon="PlayBoxMultiple" @click="isOpenReplayModal = !isOpenReplayModal">
@@ -364,6 +364,21 @@
 
         <template #default>
             <p v-html="changeReplayToast()" />
+            <el-form v-if="canShowRevisionPicker && revisionsOptions && revisionsOptions.length > 1">
+                <p class="execution-description">
+                    {{ $t("restart change revision") }}
+                </p>
+                <ElFormItem :label="$t('revisions')">
+                    <el-select v-model="replayRevisionSelected">
+                        <el-option
+                            v-for="item in revisionsOptions"
+                            :key="item.value"
+                            :label="item.text"
+                            :value="item.value"
+                        />
+                    </el-select>
+                </ElFormItem>
+            </el-form>
         </template>
 
         <template #footer>
@@ -381,13 +396,53 @@
             </el-button>
         </template>
     </el-dialog>
+
+    <el-dialog v-if="isOpenRestartModal" v-model="isOpenRestartModal" :id="Utils.uid()" destroyOnClose :appendToBody="true" alignCenter>
+        <template #header>
+            <h5>{{ $t("confirmation") }}</h5>
+        </template>
+
+        <template #default>
+            <p v-html="changeRestartToast()" />
+            <el-form v-if="canShowRevisionPicker && revisionsOptions && revisionsOptions.length > 1">
+                <p class="execution-description">
+                    {{ $t("restart change revision") }}
+                </p>
+                <ElFormItem :label="$t('revisions')">
+                    <el-select v-model="restartRevisionSelected">
+                        <el-option
+                            v-for="item in revisionsOptions"
+                            :key="item.value"
+                            :label="item.text"
+                            :value="item.value"
+                        />
+                    </el-select>
+                </ElFormItem>
+            </el-form>
+        </template>
+
+        <template #footer>
+            <el-button @click="isOpenRestartModal = false">
+                {{ $t('cancel') }}
+            </el-button>
+            <el-button @click="restartExecutions(true)">
+                {{ $t('restart latest revision') }}
+            </el-button>
+            <el-button
+                type="primary"
+                @click="restartExecutions(false)"
+            >
+                {{ $t('ok') }}
+            </el-button>
+        </template>
+    </el-dialog>
 </template>
 
 <script setup lang="ts">
     import _merge from "lodash/merge";
     import {useI18n} from "vue-i18n";
     import {useRoute, useRouter} from "vue-router";
-    import {ref, computed, watch, h, useTemplateRef} from "vue";
+    import {ref, computed, watch, h, useTemplateRef, type Ref} from "vue";
     import * as YAML_UTILS from "@kestra-io/ui-libs/flow-yaml-utils";
     import {ElMessageBox, ElSwitch, ElFormItem, ElAlert, ElCheckbox} from "element-plus";
 
@@ -497,6 +552,7 @@
     const recomputeInterval = ref(false);
     const isOpenLabelsModal = ref(false);
     const isOpenReplayModal = ref(false);
+    const isOpenRestartModal = ref(false);
     const selectedStatus = ref(undefined);
     const lastRefreshDate = ref(new Date());
     const unqueueDialogVisible = ref(false);
@@ -705,6 +761,87 @@
         ];
     });
 
+    /**
+     * Gets the currently selected executions from table selection or query bulk action.
+     * @returns Array of selected execution objects
+     */
+    const getSelectedExecutions = () => {
+        if (queryBulkAction.value) {
+            return executionsStore.executions || [];
+        } else {
+            return (executionsStore.executions || []).filter((exec: any) => selection.value.includes(exec.id));
+        }
+    };
+
+    /**
+     * Checks if all selected executions belong to the same flow.
+     * @returns Flow info object if all same flow, null otherwise
+     */
+    const getCommonFlowInfo = () => {
+        const selectedExecs = getSelectedExecutions();
+        if (selectedExecs.length === 0) return null;
+
+        const firstExec = selectedExecs[0];
+        const allSameFlow = selectedExecs.every((exec: any) => 
+            exec.namespace === firstExec.namespace && exec.flowId === firstExec.flowId
+        );
+
+        if (allSameFlow) {
+            return {
+                namespace: firstExec.namespace,
+                flowId: firstExec.flowId,
+                executions: selectedExecs
+            };
+        }
+        return null;
+    };
+
+    const replayRevisionSelected = ref<number | undefined>(undefined);
+    const restartRevisionSelected = ref<number | undefined>(undefined);
+
+    const canShowRevisionPicker = computed(() => getCommonFlowInfo() !== null);
+
+    /**
+     * Generates revision options for the dropdown, marking current revision if all executions use the same one.
+     * @returns Array of revision option objects with value and text
+     */
+    const getRevisionsOptions = () => {
+        const commonFlow = getCommonFlowInfo();
+        if (!commonFlow || !flowStore.revisions) return [];
+
+        const selectedExecs = commonFlow.executions;
+        const allSameRevision = selectedExecs.every((exec: any) => exec.flowRevision === selectedExecs[0].flowRevision);
+
+        return flowStore.revisions
+            .map((revision) => ({
+                value: revision.revision,
+                text: revision.revision + (allSameRevision && revision.revision === selectedExecs[0].flowRevision ? ` (${t("current")})` : ""),
+            }))
+            .reverse();
+    };
+
+    const revisionsOptions = computed(() => getRevisionsOptions());
+
+    /**
+     * Loads revisions for the common flow and preselects current revision (if all same) or latest revision.
+     * @param revisionRef - The ref to update with the preselected revision value
+     */
+    const loadRevisions = async (revisionRef: Ref<number | undefined>) => {
+        const commonFlow = getCommonFlowInfo();
+        if (commonFlow) {
+            await flowStore.loadRevisions({
+                namespace: commonFlow.namespace,
+                id: commonFlow.flowId
+            });
+            if (flowStore.revisions && flowStore.revisions.length > 0) {
+                const selectedExecs = commonFlow.executions;
+                const allSameRevision = selectedExecs.every((exec: any) => exec.flowRevision === selectedExecs[0].flowRevision);
+                // Preselect current revision if all executions have same revision, otherwise latest
+                revisionRef.value = allSameRevision ? selectedExecs[0].flowRevision : flowStore.revisions[flowStore.revisions.length - 1].revision;
+            }
+        }
+    };
+
     const filteredLabels = (labels: any[]) => {
         const toIgnore = miscStore.configs?.hiddenLabelsPrefixes || [];
 
@@ -869,28 +1006,72 @@
         );
     };
 
-    const restartExecutions = () => {
-        genericConfirmAction(
-            "bulk restart",
+    /**
+     * Handles bulk restart execution with optional revision selection.
+     * If same revision selected, performs true restart (no revision param).
+     * @param useLatestRevision - Whether to use latest revision (from button click)
+     */
+    const restartExecutions = (useLatestRevision: boolean) => {
+        isOpenRestartModal.value = false;
+
+        let latestRevision: boolean | undefined = undefined;
+        let revision: number | undefined = undefined;
+
+        if (canShowRevisionPicker.value && !useLatestRevision && restartRevisionSelected.value !== undefined) {
+            const selectedExecs = getSelectedExecutions();
+            const allSameRevision = selectedExecs.length > 0 && selectedExecs.every((exec: any) => exec.flowRevision === selectedExecs[0].flowRevision);
+            
+            if (allSameRevision && restartRevisionSelected.value === selectedExecs[0].flowRevision) {
+                revision = undefined;
+            } else {
+                revision = restartRevisionSelected.value;
+            }
+        } else if (useLatestRevision) {
+            latestRevision = true;
+        }
+
+        genericConfirmCallback(
             "queryRestartExecution",
             "bulkRestartExecution",
-            "executions restarted"
+            "executions restarted",
+            revision !== undefined ? {revision} : latestRevision !== undefined ? {latestRevision} : {}
         );
     };
 
-    const replayExecutions = (latestRevision: boolean) => {
+    /**
+     * Handles bulk replay execution with optional revision selection.
+     * @param useLatestRevision - Whether to use latest revision (from button click)
+     */
+    const replayExecutions = (useLatestRevision: boolean) => {
         isOpenReplayModal.value = false;
+
+        let latestRevision: boolean | undefined = undefined;
+        let revision: number | undefined = undefined;
+
+        if (canShowRevisionPicker.value && !useLatestRevision && replayRevisionSelected.value !== undefined) {
+            revision = replayRevisionSelected.value;
+        } else if (useLatestRevision) {
+            latestRevision = true;
+        }
 
         genericConfirmCallback(
             "queryReplayExecution",
             "bulkReplayExecution",
             "executions replayed",
-            {latestRevision: latestRevision}
+            revision !== undefined ? {revision} : {latestRevision: latestRevision ?? false}
         );
     };
 
     const changeReplayToast = () => {
         return t("bulk replay", {"executionCount": queryBulkAction.value ? executionsStore.total : selection.value.length});
+    };
+
+    /**
+     * Returns the confirmation toast message for bulk restart action.
+     * @returns Formatted toast message with execution count
+     */
+    const changeRestartToast = () => {
+        return t("bulk restart", {"executionCount": queryBulkAction.value ? executionsStore.total : selection.value.length});
     };
 
     const changeStatus = () => {
@@ -1048,6 +1229,18 @@
         }
     });
 
+    watch(isOpenReplayModal, (opening) => {
+        if (opening) {
+            loadRevisions(replayRevisionSelected);
+        }
+    });
+
+    watch(isOpenRestartModal, (opening) => {
+        if (opening) {
+            loadRevisions(restartRevisionSelected);
+        }
+    });
+
     async function exportExecutionsAsStream() {
         await executionsStore.exportExecutionsAsCSV(
             route.query
@@ -1091,5 +1284,9 @@
 
 :deep(a.execution-id) code {
     color: var(--bs-code-color) !important;
+}
+
+.execution-description {
+    color: var(--ks-content-secondary);
 }
 </style>

--- a/ui/src/stores/executions.ts
+++ b/ui/src/stores/executions.ts
@@ -104,10 +104,12 @@ export const useExecutionsStore = defineStore("executions", () => {
             })
     }
 
-    const bulkRestartExecution = (options: { executionsId: string[] }) => {
+    const bulkRestartExecution = (options: { executionsId: string[] } & Record<string, any>) => {
+        const {executionsId, ...params} = options;
         return axios.post(
             `${apiUrl()}/executions/restart/by-ids`,
-            options.executionsId
+            executionsId,
+            {params: params}
         )
     }
 
@@ -135,10 +137,11 @@ export const useExecutionsStore = defineStore("executions", () => {
     }
 
     const bulkReplayExecution = (options: { executionsId: string[] } & Record<string, any>) => {
+        const {executionsId, ...params} = options;
         return axios.post(
             `${apiUrl()}/executions/replay/by-ids`,
-            options.executionsId,
-            {params: options}
+            executionsId,
+            {params: params}
         )
     }
 

--- a/webserver/src/main/java/io/kestra/webserver/controllers/api/ExecutionController.java
+++ b/webserver/src/main/java/io/kestra/webserver/controllers/api/ExecutionController.java
@@ -1030,7 +1030,9 @@ public class ExecutionController {
     @ApiResponse(responseCode = "200", description = "On success", content = {@Content(schema = @Schema(implementation = BulkResponse.class))})
     @ApiResponse(responseCode = "422", description = "Restarted with errors", content = {@Content(schema = @Schema(implementation = BulkErrorResponse.class))})
     public MutableHttpResponse<?> restartExecutionsByIds(
-        @RequestBody(description = "The list of executions id") @Body List<String> executionsId
+        @RequestBody(description = "The list of executions id") @Body List<String> executionsId,
+        @Parameter(description = "The flow revision to use for new execution") @Nullable @QueryValue Integer revision,
+        @Parameter(description = "If latest revision should be used") @Nullable @QueryValue(defaultValue = "false") Boolean latestRevision
     ) throws Exception {
         List<Execution> executions = new ArrayList<>();
         Set<ManualConstraintViolation<String>> invalids = new HashSet<>();
@@ -1067,7 +1069,9 @@ public class ExecutionController {
             );
         }
         for (Execution execution : executions) {
-            Execution restart = executionService.restart(execution, null);
+            Optional<Integer> revisionToUse = getRevisionToUse(execution, revision, latestRevision);
+            
+            Execution restart = executionService.restart(execution, revisionToUse.get());
             executionQueue.emit(restart);
             eventPublisher.publishEvent(new CrudEvent<>(restart, execution, CrudEventType.UPDATE));
         }
@@ -1094,7 +1098,10 @@ public class ExecutionController {
         @Deprecated @Parameter(description = "A state filter", deprecated = true) @Nullable @QueryValue List<State.Type> state,
         @Deprecated @Parameter(description = "A labels filter as a list of 'key:value'", deprecated = true) @Nullable @QueryValue @Format("MULTI") List<String> labels,
         @Deprecated @Parameter(description = "The trigger execution id", deprecated = true) @Nullable @QueryValue String triggerExecutionId,
-        @Deprecated @Parameter(description = "A execution child filter", deprecated = true) @Nullable @QueryValue ExecutionRepositoryInterface.ChildFilter childFilter
+        @Deprecated @Parameter(description = "A execution child filter", deprecated = true) @Nullable @QueryValue ExecutionRepositoryInterface.ChildFilter childFilter,
+
+        @Parameter(description = "The flow revision to use for new execution") @Nullable @QueryValue Integer revision,
+        @Parameter(description = "If latest revision should be used") @Nullable @QueryValue(defaultValue = "false") Boolean latestRevision
     ) throws Exception {
         filters = RequestUtils.getFiltersOrDefaultToLegacyMapping(
             filters,
@@ -1115,7 +1122,7 @@ public class ExecutionController {
         );
 
         var ids = getExecutionIds(filters);
-        return restartExecutionsByIds(ids);
+        return restartExecutionsByIds(ids, revision, latestRevision);
     }
 
     @ExecuteOn(TaskExecutors.IO)
@@ -1859,6 +1866,7 @@ public class ExecutionController {
         @Deprecated @Parameter(description = "The trigger execution id", deprecated = true) @Nullable @QueryValue String triggerExecutionId,
         @Deprecated @Parameter(description = "A execution child filter", deprecated = true) @Nullable @QueryValue ExecutionRepositoryInterface.ChildFilter childFilter,
 
+        @Parameter(description = "The flow revision to use for new execution") @Nullable @QueryValue Integer revision,
         @Parameter(description = "If latest revision should be used") @Nullable @QueryValue(defaultValue = "false") Boolean latestRevision
     ) throws Exception {
         filters = RequestUtils.getFiltersOrDefaultToLegacyMapping(
@@ -1881,7 +1889,7 @@ public class ExecutionController {
 
         var ids = getExecutionIds(filters);
 
-        return replayExecutionsByIds(ids, latestRevision);
+        return replayExecutionsByIds(ids, revision, latestRevision);
     }
 
     @ExecuteOn(TaskExecutors.IO)
@@ -1891,6 +1899,7 @@ public class ExecutionController {
     @ApiResponse(responseCode = "422", description = "Replayed with errors", content = {@Content(schema = @Schema(implementation = BulkErrorResponse.class))})
     public MutableHttpResponse<?> replayExecutionsByIds(
         @RequestBody(description = "The list of executions id") @Body List<String> executionsId,
+        @Parameter(description = "The flow revision to use for new execution") @Nullable @QueryValue Integer revision,
         @Parameter(description = "If latest revision should be used") @Nullable @QueryValue(defaultValue = "false") Boolean latestRevision
     ) throws Exception {
         List<Execution> executions = new ArrayList<>();
@@ -1921,12 +1930,9 @@ public class ExecutionController {
         }
 
         for (Execution execution : executions) {
-            if (latestRevision) {
-                Flow flow = flowRepository.findById(execution.getTenantId(), execution.getNamespace(), execution.getFlowId(), Optional.empty()).orElseThrow();
-                innerReplay(execution, null, flow.getRevision(), Optional.empty());
-            } else {
-                innerReplay(execution, null, null, Optional.empty());
-            }
+            Optional<Integer> revisionToUse = getRevisionToUse(execution, revision, latestRevision);
+            
+            innerReplay(execution, null, revisionToUse.get(), Optional.empty());
         }
         return HttpResponse.ok(BulkResponse.builder().count(executions.size()).build());
     }
@@ -2439,6 +2445,19 @@ public class ExecutionController {
         return forceRunByIds(ids);
     }
 
+    private Optional<Integer> getRevisionToUse(Execution execution, Integer revision, Boolean latestRevision) {
+        if (revision != null) {
+            // Validate and use specific revision
+            this.controlRevision(execution, revision);
+            return Optional.of(revision);
+        } else if (latestRevision != null && latestRevision) {
+            // Get latest revision for this flow
+            Flow flow = flowRepository.findById(execution.getTenantId(), execution.getNamespace(), execution.getFlowId(), Optional.empty()).orElseThrow();
+            return Optional.of(flow.getRevision());
+        }
+        return Optional.empty();
+    }
+    
     private List<String> getExecutionIds(List<QueryFilter> filters) {
         return executionRepository
             .find(

--- a/webserver/src/main/java/io/kestra/webserver/controllers/api/ExecutionController.java
+++ b/webserver/src/main/java/io/kestra/webserver/controllers/api/ExecutionController.java
@@ -1071,7 +1071,7 @@ public class ExecutionController {
         for (Execution execution : executions) {
             Optional<Integer> revisionToUse = getRevisionToUse(execution, revision, latestRevision);
             
-            Execution restart = executionService.restart(execution, revisionToUse.get());
+            Execution restart = executionService.restart(execution, revisionToUse.orElse(null));
             executionQueue.emit(restart);
             eventPublisher.publishEvent(new CrudEvent<>(restart, execution, CrudEventType.UPDATE));
         }
@@ -1932,7 +1932,7 @@ public class ExecutionController {
         for (Execution execution : executions) {
             Optional<Integer> revisionToUse = getRevisionToUse(execution, revision, latestRevision);
             
-            innerReplay(execution, null, revisionToUse.get(), Optional.empty());
+            innerReplay(execution, null, revisionToUse.orElse(null), Optional.empty());
         }
         return HttpResponse.ok(BulkResponse.builder().count(executions.size()).build());
     }
@@ -2452,8 +2452,12 @@ public class ExecutionController {
             return Optional.of(revision);
         } else if (latestRevision != null && latestRevision) {
             // Get latest revision for this flow
-            Flow flow = flowRepository.findById(execution.getTenantId(), execution.getNamespace(), execution.getFlowId(), Optional.empty()).orElseThrow();
-            return Optional.of(flow.getRevision());
+            Optional<Flow> flow = flowRepository.findById(execution.getTenantId(), execution.getNamespace(), execution.getFlowId(), Optional.empty());
+            if (flow.isPresent()) {
+                return Optional.of(flow.get().getRevision());
+            }
+            // If flow not found, return empty (will use original execution's revision)
+            return Optional.empty();
         }
         return Optional.empty();
     }


### PR DESCRIPTION
Fixes #8337

### Summary
Adds revision selection to bulk replay and restart actions, aligning them with single-execution behavior. Users can select a specific flow revision when replaying or restarting multiple executions.

### Changes

#### Frontend (`ui/src/components/executions/Executions.vue`)
- Added revision picker dropdown for bulk replay and restart modals
- Shows revision picker only when all selected executions belong to the same flow
- Preselects current revision if all executions share the same revision, otherwise latest
- Added "Replay latest revision" and "Restart latest revision" buttons (always visible)
- Added helper functions with documentation:
  - `getSelectedExecutions()` - Gets currently selected executions
  - `getCommonFlowInfo()` - Checks if all selected executions belong to the same flow
  - `getRevisionsOptions()` - Generates revision options for dropdown
  - `loadRevisions()` - Loads revisions and preselects appropriate revision
  - `replayExecutions()` - Handles bulk replay with revision selection
  - `restartExecutions()` - Handles bulk restart with revision selection
- Optimized code to reduce duplication by sharing computed properties and functions

#### Backend (`webserver/src/main/java/io/kestra/webserver/controllers/api/ExecutionController.java`)
- Updated `restartExecutionsByIds()` to accept `revision` and `latestRevision` query parameters
- Updated `restartExecutionsByQuery()` to pass through revision parameters
- Updated `replayExecutionsByIds()` to accept `revision` parameter (in addition to `latestRevision`)
- Updated `replayExecutionsByQuery()` to pass through revision parameters
- Logic prioritizes specific `revision` if provided, otherwise uses `latestRevision`, or falls back to original execution's revision

#### Backend (`core/src/main/java/io/kestra/core/services/ExecutionService.java`)
- Updated `restart()` method to handle different revision scenarios:
  - If different revision selected: creates new execution from scratch (similar to replay)
  - If same revision: performs true restart from failed/paused tasks
- Updated `replay()` method to load flow using provided revision when `taskRunId` is null

### Features
- Revision selection for bulk actions when all executions are from the same flow
- Current revision indicator: shows "(current)" label for the revision used by executions
- Smart preselection: preselects current revision if all executions share it, otherwise latest
- Latest revision button: always available for quick access
- Backend validation: automatically handles cases where restart isn't possible (e.g., successful executions without failed tasks)

### Behavior
- Single flow selection: Shows revision dropdown with all available revisions
- Multi-flow selection: Shows "Replay latest revision" / "Restart latest revision" buttons (no dropdown)
- Same revision restart: If selected revision matches current execution revision, performs true restart (no revision param)
- Different revision restart: If different revision selected, creates new execution with that revision

### Testing
- Test bulk replay with single flow selection and revision picker
- Test bulk restart with single flow selection and revision picker
- Test bulk actions with multi-flow selection (should show latest revision button only)
- Test restart with different revision for successful executions
- Test restart with same revision for failed executions
- Verify backend error handling for invalid scenarios
<img width="1402" height="696" alt="Screenshot 2026-01-03 at 7 43 06 PM" src="https://github.com/user-attachments/assets/8da421a2-e948-4eb3-8761-57f7c693ba95" />

