### PR TITLE
Fix for Comparison between inconvertible types

### DIFF
--- a/ui/src/composables/useRestoreUrl.ts
+++ b/ui/src/composables/useRestoreUrl.ts
@@ -31,7 +31,7 @@ export function getRestoredQuery(route: RouteLocation) {
         };
     };
     const query = {...route.query};
-    const local = localStorageValue === null ? {} : {...localStorageValue};
+    const local = { ...localStorageValue };
 
     let change = false;
 

--- a/ui/src/composables/useRestoreUrl.ts
+++ b/ui/src/composables/useRestoreUrl.ts
@@ -31,7 +31,7 @@ export function getRestoredQuery(route: RouteLocation) {
         };
     };
     const query = {...route.query};
-    const local = { ...localStorageValue };
+    const local = {...localStorageValue};
 
     let change = false;
 


### PR DESCRIPTION
In general, to fix this kind of issue you remove or refactor comparisons where, due to prior control flow, the variable cannot actually be the compared-to type/value. That means avoiding unnecessary `== null` / `=== null` checks after you’ve already guarded or narrowed the type.

Specifically here, inside `getRestoredQuery`, once you’ve handled the `localStorageValue === null` case with an early `return`, the subsequent ternary on line 34 should no longer check for `null`. At that point, `localStorageValue` is non-null (and assumed to be an object). We can safely spread it directly. So replace:

```ts
const local = localStorageValue === null ? {} : {...localStorageValue};
```

with:

```ts
const local = { ...localStorageValue };
```

This keeps the runtime behavior identical (since the `=== null` branch was unreachable) and removes the meaningless comparison that CodeQL is complaining about. No additional imports or helpers are needed, and no other lines must change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._