### PR TITLE
fix(Pause.vue): update translation method to use $t for consistency

### DIFF
--- a/ui/src/components/executions/overview/components/actions/Pause.vue
+++ b/ui/src/components/executions/overview/components/actions/Pause.vue
@@ -4,16 +4,16 @@
         :icon="Pause"
         @click="click"
     >
-        {{ t('pause') }}
+        {{ $t('pause') }}
     </el-button>
 
     <el-dialog v-if="isDrawerOpen" v-model="isDrawerOpen" destroyOnClose :appendToBody="true">
         <template #header>
-            <span v-html="t('pause title', {id: execution.id})" />
+            <span v-html="$t('pause title', {id: execution.id})" />
         </template>
         <template #footer>
             <el-button :icon="Pause" type="primary" @click="pause()" nativeType="submit">
-                {{ t('pause') }}
+                {{ $t('pause') }}
             </el-button>
         </template>
     </el-dialog>


### PR DESCRIPTION
Closes https://github.com/kestra-io/kestra/issues/13964.

### ✨ Description

What does this PR change?  
update translation method to use $t for consistency

### 🔗 Related Issue

Which issue does this PR resolve?
[Uniform Pause.vue translations by using $t in template section](https://github.com/kestra-io/kestra/issues/13964)

### 🎨 Frontend Checklist

_If this PR does not include any frontend changes, delete this entire section._

- [x] Code builds without errors (`npm run build`)
- [x] All existing E2E tests pass (`npm run test:e2e`)
- [] Screenshots or video recordings attached showing the `UI` changes

