### PR TITLE
fix(executions): make sure BulkErrorResponse violations are returned

### DIFF
--- a/webserver/src/main/java/io/kestra/webserver/responses/BulkErrorResponse.java
+++ b/webserver/src/main/java/io/kestra/webserver/responses/BulkErrorResponse.java
@@ -1,13 +1,30 @@
 package io.kestra.webserver.responses;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import io.kestra.core.models.validations.ManualConstraintViolation;
+import io.kestra.core.serializers.JacksonMapper;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.Set;
 
 @SuperBuilder
 @Getter
 @NoArgsConstructor
+@Slf4j
 public class BulkErrorResponse {
     String message;
-    Object invalids;
+    Set<ManualConstraintViolation<String>> invalids;
+
+    public String getMessage(){
+        var serializedViolations = "could not be serialized";
+        try {
+            serializedViolations = JacksonMapper.ofJson().writeValueAsString(invalids);
+        } catch (JsonProcessingException e) {
+            log.warn("could not serialize invalids field for BulkErrorResponse", e);
+        }
+        return this.message + ", violations: " + serializedViolations;
+    }
 }

--- a/webserver/src/test/java/io/kestra/webserver/controllers/api/ExecutionControllerRunnerTest.java
+++ b/webserver/src/test/java/io/kestra/webserver/controllers/api/ExecutionControllerRunnerTest.java
@@ -1862,7 +1862,7 @@ class ExecutionControllerRunnerTest {
         } catch (HttpClientResponseException e){
             long afterException = System.currentTimeMillis();
             String errorMessage = "Duration before executions -> %d <-> duration after the exception -> %d <-> Error while pausing execution, err: %s, response: %s";
-            String formatedError = String.format(errorMessage, afterExec - start, afterException - start, e.getMessage(), e.getResponse().getBody(BulkErrorResponse.class).map(BulkErrorResponse::getInvalids).orElse("errors"));
+            String formatedError = String.format(errorMessage, afterExec - start, afterException - start, e.getMessage(), e.getResponse().getBody(BulkErrorResponse.class).map(BulkErrorResponse::getInvalids).orElse(Set.of()));
             log.error("Error while pausing execution, err: {}, response: {}", e.getMessage(), e.getResponse().getBody(BulkErrorResponse.class).map(BulkErrorResponse::getInvalids), e);
             fail(formatedError);
         }


### PR DESCRIPTION
this will help to debug failing tests, otherwise we only have invalid bulk restart in the resulting http exception
