### PR TITLE
fix(system): MySQL fulltext search didn't work for suffix

### DIFF
--- a/core/src/test/java/io/kestra/core/repositories/AbstractTriggerRepositoryTest.java
+++ b/core/src/test/java/io/kestra/core/repositories/AbstractTriggerRepositoryTest.java
@@ -2,9 +2,12 @@ package io.kestra.core.repositories;
 
 import io.kestra.core.exceptions.InvalidQueryFiltersException;
 import io.kestra.core.junit.annotations.KestraTest;
+import io.kestra.core.models.Label;
 import io.kestra.core.models.QueryFilter;
 import io.kestra.core.models.QueryFilter.Field;
 import io.kestra.core.models.QueryFilter.Op;
+import io.kestra.core.models.flows.FlowWithSource;
+import io.kestra.core.models.flows.GenericFlow;
 import io.kestra.core.models.flows.State;
 import io.kestra.core.models.triggers.Trigger;
 import io.kestra.core.repositories.ExecutionRepositoryInterface.ChildFilter;
@@ -26,6 +29,7 @@ import java.util.Optional;
 import java.util.stream.Stream;
 
 import static io.kestra.core.models.flows.FlowScope.USER;
+import static io.kestra.core.utils.NamespaceUtils.SYSTEM_FLOWS_DEFAULT_NAMESPACE;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -91,6 +95,45 @@ public abstract class AbstractTriggerRepositoryTest {
             QueryFilter.builder().field(Field.TRIGGER_ID).value("triggerId").operation(Op.EQUALS).build(),
             QueryFilter.builder().field(Field.WORKER_ID).value("workerId").operation(Op.EQUALS).build()
         );
+    }
+
+    @Test
+    void should_find_exact_prefix_suffix() {
+        String tenant = TestsUtils.randomTenant(this.getClass().getSimpleName());
+        Trigger trigger = generateDefaultTrigger(tenant).toBuilder().flowId("some_search_trigger").build();
+        triggerRepository.save(trigger);
+
+        // exact match
+        ArrayListTotal<Trigger> entries = triggerRepository.find(
+            Pageable.UNPAGED,
+            tenant,
+            List.of(QueryFilter.builder().field(Field.QUERY).value("some_search_trigger").operation(Op.EQUALS).build())
+        );
+        assertThat(entries).hasSize(1);
+
+        // prefix match
+        entries = triggerRepository.find(
+            Pageable.UNPAGED,
+            tenant,
+            List.of(QueryFilter.builder().field(Field.QUERY).value("some_search").operation(Op.EQUALS).build())
+        );
+        assertThat(entries).hasSize(1);
+
+        // suffix match
+        entries = triggerRepository.find(
+            Pageable.UNPAGED,
+            tenant,
+            List.of(QueryFilter.builder().field(Field.QUERY).value("search_trigger").operation(Op.EQUALS).build())
+        );
+        assertThat(entries).hasSize(1);
+
+        // no match
+        entries = triggerRepository.find(
+            Pageable.UNPAGED,
+            tenant,
+            List.of(QueryFilter.builder().field(Field.QUERY).value("nothing").operation(Op.EQUALS).build())
+        );
+        assertThat(entries).hasSize(0);
     }
 
     @ParameterizedTest
@@ -167,7 +210,7 @@ public abstract class AbstractTriggerRepositoryTest {
 
         // Full text search is on namespace, flowId, triggerId, executionId
         find = triggerRepository.find(Pageable.from(1, 100, Sort.UNSORTED), trigger.getNamespace(), tenant, null, null, null);
-        assertThat(find.size()).isEqualTo(1);
+        assertThat(find.size()).isGreaterThanOrEqualTo(1); // MySQL returns more results than the other for this test
         assertThat(find.getFirst().getTriggerId()).isEqualTo(trigger.getTriggerId());
         find = triggerRepository.find(Pageable.from(1, 100, Sort.UNSORTED), searchedTrigger.getFlowId(), tenant, null, null, null);
         assertThat(find.size()).isEqualTo(1);

--- a/jdbc-mysql/src/main/java/io/kestra/repository/mysql/MysqlRepository.java
+++ b/jdbc-mysql/src/main/java/io/kestra/repository/mysql/MysqlRepository.java
@@ -49,7 +49,7 @@ public class MysqlRepository<T> extends AbstractJdbcRepository<T> {
         String match = Arrays
             .stream(query.split("\\p{IsPunct}"))
             .filter(s -> s.length() >= 3)
-            .map(s -> "+" + s + "*")
+            .map(s -> "*" + s + "*")
             .collect(Collectors.joining(" "));
 
         if (match.isEmpty()) {
@@ -61,7 +61,7 @@ public class MysqlRepository<T> extends AbstractJdbcRepository<T> {
 
     @Override
     public <R extends Record, E> ArrayListTotal<E> fetchPage(DSLContext context, SelectConditionStep<R> select, Pageable pageable, RecordMapper<R, E> mapper) {
-        Integer rows = context.fetchCount(select);
+        int rows = context.fetchCount(select);
         Result<R> records = this.pageable(select, pageable).fetch();
         return new ArrayListTotal<>(records.map(mapper), rows);
     }


### PR DESCRIPTION
This was because the search term was changed to `+term*` which mandates  the term to be a prefix, it is now `*term*` which work for prefix also.

But it has the caveats that if multiple terms are used, the terms are no longuer mandatory so the result may be less accurate in this case, this is a tradeoff.