### PR TITLE
Fix for file identification in flow validate CLI command

### DIFF
--- a/core/src/main/java/io/kestra/core/models/validations/ValidateConstraintViolation.java
+++ b/core/src/main/java/io/kestra/core/models/validations/ValidateConstraintViolation.java
@@ -1,6 +1,7 @@
 package io.kestra.core.models.validations;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import io.kestra.core.serializers.YamlParser;
 import io.micronaut.core.annotation.Introspected;
 import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
@@ -39,7 +40,7 @@ public class ValidateConstraintViolation {
     private List<String> infos;
 
     @JsonIgnore
-    public String getIdentity(){
+    public String getIdentity() {
         return flow != null && namespace != null ? getFlowId() : flow != null ? flow : String.valueOf(index);
     }
 
@@ -50,12 +51,17 @@ public class ValidateConstraintViolation {
 
     private String getPath(Path directory) throws IOException {
         try (var files = Files.walk(directory)) {
-            return String.valueOf(files.toList().get(index));
+            return String.valueOf(
+                files.filter(Files::isRegularFile)
+                    .filter(YamlParser::isValidExtension)
+                    .toList()
+                    .get(index)
+            );
         }
     }
 
     @JsonIgnore
-    public String getFlowId(){
-        return namespace+"."+flow;
+    public String getFlowId() {
+        return namespace + "." + flow;
     }
 }


### PR DESCRIPTION
### ✨ Description

The command for validating flows before deployment (`kestra flow validate`) incorrectly points to a file with a validation error.

Two possible scenarios could have occurred:
1) The error was in the "first flow file" (according to the `Files.walk()` method) and the validation command returned the path to the directory as the erroneous file instead of the path to the corresponding file.
```
===============================
kookabura_577848.yml => STRINGG
kookabura_577849.yml => OK
===============================

✘ - /tmp/flows-test
        Unable to parse flowwithsources due to the following error:
        - Validation error: Invalid type: STRINGG
✓ - company.team.kookabura_577849
``` 
2) The error was in the second - N file, but the file returned by the validation command did not correspond to the name of the file that actually contained the error.
```
===============================
kookabura_577849.yml => OK
kookabura_577848.yml => STRINGG
===============================

✓ - company.team.kookabura_577849
✘ - /tmp/flows-test/kookabura_577849.yml
        Unable to parse flowwithsources due to the following error:
        - Validation error: Invalid type: STRINGG
``` 

The reason was a discrepancy between the code that builds the POST request body for validation and the code that mapped the error index back to the file name in the CLI - this is used when the flow id and namespace values are `null` - i.e., in the case of a validation error.

This PR resolves this discrepancy and thus corrects the functionality of the validation command.

### 🔗 Related Issue

Relates to https://github.com/kestra-io/kestra/issues/7132
