### PR TITLE
chore(flow): deprecate core tasks that have replacements inside the K…

### DIFF
--- a/core/src/main/java/io/kestra/plugin/core/execution/Count.java
+++ b/core/src/main/java/io/kestra/plugin/core/execution/Count.java
@@ -31,7 +31,9 @@ import static io.kestra.core.utils.Rethrow.throwPredicate;
 @NoArgsConstructor
 @Schema(
     title = "List execution counts for a list of flows.",
-    description = "This can be used to send an alert if a condition is met about execution counts."
+    description = """
+        **This task is deprecated**, please use the `io.kestra.plugin.kestra.executions.Count` task instead.
+        This can be used to send an alert if a condition is met about execution counts."""
 )
 @Plugin(
     examples = {
@@ -75,6 +77,7 @@ import static io.kestra.core.utils.Rethrow.throwPredicate;
     },
     aliases = "io.kestra.core.tasks.executions.Counts"
 )
+@Deprecated(since = "1.2", forRemoval = true)
 public class Count extends Task implements RunnableTask<Count.Output> {
     @Schema(
         title = "A list of flows to be filtered",

--- a/core/src/main/java/io/kestra/plugin/core/execution/Resume.java
+++ b/core/src/main/java/io/kestra/plugin/core/execution/Resume.java
@@ -27,7 +27,6 @@ import lombok.NoArgsConstructor;
 import lombok.ToString;
 import lombok.experimental.SuperBuilder;
 
-import java.time.LocalDateTime;
 import java.util.Map;
 
 @SuperBuilder
@@ -37,7 +36,9 @@ import java.util.Map;
 @NoArgsConstructor
 @Schema(
     title = "Resume a paused execution.",
-    description = "By default, the task assumes that you want to resume the current `executionId`. If you want to programmatically resume an execution of another flow, make sure to define the `executionId`, `flowId`, and `namespace` properties explicitly. Using the `inputs` property, you can additionally pass custom `onResume` input values to the execution."
+    description = """
+        **This task is deprecated**, please use `io.kestra.plugin.kestra.executions.Resume` instead.
+        By default, the task assumes that you want to resume the current `executionId`. If you want to programmatically resume an execution of another flow, make sure to define the `executionId`, `flowId`, and `namespace` properties explicitly. Using the `inputs` property, you can additionally pass custom `onResume` input values to the execution."""
 )
 @Plugin(
     examples = {
@@ -48,6 +49,7 @@ import java.util.Map;
         )
     }
 )
+@Deprecated(since = "1.2", forRemoval = true)
 public class Resume  extends Task implements RunnableTask<VoidOutput> {
     @Schema(
         title = "Filter for a specific namespace in case `executionId` is set. In case you wonder why `executionId` is not enough — we require specifying the namespace to make permissions explicit. The Enterprise Edition of Kestra allows you to resume executions from another namespaces only if the permissions allow it. Check the [Allowed Namespaces](https://kestra.io/docs/enterprise/allowed-namespaces) documentation for more details."

--- a/core/src/main/java/io/kestra/plugin/core/trigger/Toggle.java
+++ b/core/src/main/java/io/kestra/plugin/core/trigger/Toggle.java
@@ -30,7 +30,8 @@ import java.util.Optional;
 @Getter
 @NoArgsConstructor
 @Schema(
-    title = "Toggle a trigger: enable or disable it."
+    title = "Toggle a trigger: enable or disable it.",
+    description = "**This task is deprecated**, please use the `io.kestra.plugin.kestra.triggers.Toggle` task instead."
 )
 @Plugin(
     examples = {
@@ -73,6 +74,7 @@ import java.util.Optional;
     },
     aliases = "io.kestra.core.tasks.trigger.Toggle"
 )
+@Deprecated(since = "1.2", forRemoval = true)
 public class Toggle extends Task implements RunnableTask<VoidOutput> {
     @Schema(
         title = "The flow identifier of the trigger to toggle",


### PR DESCRIPTION
…estra plugin

Part-of: https://github.com/kestra-io/kestra-ee/issues/4228

@Malaydewangan09 I think those 3 have been merged inside plugin-kestra and would be available in 1.2 so we can deprecate them here.
I don't think other would have the time to make it.
