### PR TITLE
Add in/not in to flow ids in execution filter

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -11,7 +11,6 @@
             "dependencies": {
                 "@js-joda/core": "^5.6.5",
                 "@kestra-io/ui-libs": "^0.0.269",
-                "@swc/core-linux-x64-gnu": "1.15.8",
                 "@vue-flow/background": "^1.3.2",
                 "@vue-flow/controls": "^1.1.2",
                 "@vue-flow/core": "^1.48.1",

--- a/ui/src/components/filter/configurations/executionFilter.ts
+++ b/ui/src/components/filter/configurations/executionFilter.ts
@@ -7,6 +7,8 @@ import {useAuthStore} from "override/stores/auth";
 import {useValues} from "../composables/useValues";
 import {useI18n} from "vue-i18n";
 import {useRoute} from "vue-router";
+import {useFlowStore} from "../../../stores/flow";
+
 
 export const useExecutionFilter = (): ComputedRef<FilterConfiguration> => {
     const {t} = useI18n();
@@ -60,8 +62,23 @@ export const useExecutionFilter = (): ComputedRef<FilterConfiguration> => {
                         Comparators.CONTAINS,
                         Comparators.STARTS_WITH,
                         Comparators.ENDS_WITH,
+                        Comparators.IN,
+                        Comparators.NOT_IN,
                     ],
-                    valueType: "text",
+                    valueType: "multi-select" as const,
+                    searchable: true,
+                    valueProvider: async (query?: string) => {
+                            const user = useAuthStore().user;
+                            if (user && user.hasAnyAction(permission.FLOW, action.READ)) {
+                                const flowStore = useFlowStore();
+                                const response = await flowStore.loadFlowAutoComplete(query || "");
+                                return response.map((flow: any) => ({
+                                    label: flow.id,
+                                    value: flow.id
+                                }));
+                            }
+                            return [];
+                        }
                 }] : []) as any,
                 {
                     key: "kind",

--- a/ui/src/stores/flow.ts
+++ b/ui/src/stores/flow.ts
@@ -96,6 +96,7 @@ export const useFlowStore = defineStore("flow", () => {
     const expandedSubflows = ref<string[]>([])
     const metadata = ref<Record<string, any>>()
     const creationId = ref<string>();
+    const autoCompleteFlows = ref<Flow[]>([])
 
     const axios = useAxios();
 
@@ -321,6 +322,23 @@ export const useFlowStore = defineStore("flow", () => {
             }
         })
     }
+
+    async function loadFlowAutoComplete() {
+        let page = 1;
+        const size = 50;
+        let hasMoreFlows = true;
+        while(hasMoreFlows){
+            const response = await findFlows({
+                page:page, 
+                size:size
+            });
+           autoCompleteFlows.value.push(...response.results);
+           hasMoreFlows = autoCompleteFlows.value.length === size;
+           page+=1;
+        }
+        return autoCompleteFlows.value;  
+    }
+
     function searchFlows(options: { [key: string]: any }) {
         const sortString = options.sort ? `?sort=${options.sort}` : ""
         delete options.sort
@@ -921,5 +939,6 @@ function deleteFlowAndDependencies() {
         loadTaskAggregatedMetrics,
         loadTasksWithMetrics,
         getNamespace,
+        loadFlowAutoComplete,
     }
 })


### PR DESCRIPTION
✨ Description
This PR adds multi-select options for IN/NOT IN filtration of flow-ids in Executions.

🔗 Related Issue
Closes [#13882](https://github.com/kestra-io/kestra/issues/13882)

 🎨 Frontend Checklist
 
https://jam.dev/c/8e757ea3-91ac-4d65-8a6b-2e223a814fff

- [ ] Code builds without errors (`npm run build`)
- [ ] All existing E2E tests pass (`npm run test:e2e`)
- [ ] Screenshots or video recordings attached showing the `UI` changes

### 🛠️ Backend Checklist

- [ ] Code compiles successfully and passes all checks
- [ ] All unit and integration tests pass

 📝 Additional Notes
While investigating how dynamic filter values are handled, I looked into Namespaces to get any design idea of how Flow-ID filtration should work.
However, after careful inspection by creating 50+ flows , I could see
-> NameSpace results in filters is capped to 50.
-> The search input does local filtering on already fetched namespaces.
-> As a result, if a namespace exists but is not a part of initial 50 results, typing its name shows - No Options.

Kindly check this jam for better understanding,
https://jam.dev/c/8ab3a677-5a06-4016-ac20-1e890a31b9fb

Based on this, I have implemented flow ID fetching slightly differently. An async function calls findFlows function which fetches 50 flow-ids at a time until all flow-ids are collected.
This fetches all flow-ids and local filtering doesn't miss any flow-id.

I understand this can be heavier from API calls perspective and I'm open to capping the results at a constant value similar to namespaces if that is preferred.

