### PR TITLE
refactor(core): do not save search query with saved filters

### DIFF
--- a/ui/src/components/filter/components/KSFilter.vue
+++ b/ui/src/components/filter/components/KSFilter.vue
@@ -105,8 +105,6 @@
         savedFilter.filters.forEach((filter) => {
             addFilter(filter);
         });
-
-        searchQuery.value = savedFilter.searchQuery ?? "";
     };
 
     const refreshData = () => {

--- a/ui/src/components/filter/components/KSFilter.vue
+++ b/ui/src/components/filter/components/KSFilter.vue
@@ -1,6 +1,6 @@
 <template>
     <section class="filter">
-        <div class="top" :class="{'options': showOptions}">
+        <div class="top" :class="{options: showOptions}">
             <MainFilter />
             <RightFilter>
                 <template #extra>
@@ -8,65 +8,69 @@
                 </template>
             </RightFilter>
         </div>
+  
         <FilterOptions v-if="showOptions && buttons?.tableOptions?.shown !== false" />
     </section>
 </template>
-
-<script setup lang="ts">
+  
+  <script setup lang="ts">
     import {ref, computed, provide, onMounted, watch} from "vue";
     import {useFilters} from "../composables/useFilters";
     import {useSavedFilters} from "../composables/useSavedFilters";
     import {useDataOptions} from "../composables/useDataOptions";
-    
-    import {
+  
+    import type {
         SavedFilter,
         TableOptions,
         AppliedFilter,
         TableProperties,
         FilterConfiguration,
     } from "../utils/filterTypes";
-
+  
     import {FILTER_CONTEXT_INJECTION_KEY} from "../utils/filterInjectionKeys";
-
+  
     import MainFilter from "./MainFilter.vue";
     import RightFilter from "./RightFilter.vue";
     import FilterOptions from "./FilterOptions.vue";
-
-    const props = withDefaults(defineProps<{
-        configuration: FilterConfiguration;
-        buttons?: {
-            savedFilters?: {shown?: boolean}; 
-            tableOptions?: {shown?: boolean}
-        };
-        tableOptions?: TableOptions;
-        properties?: TableProperties;
-        prefix?: string;
-        showSearchInput?: boolean;
-        searchInputFullWidth?: boolean;
-        legacyQuery?: boolean;
-        readOnly?: boolean;
-        defaultScope?: boolean;
-        defaultTimeRange?: boolean;
-    }>(), {
-        buttons: () => ({}),
-        tableOptions: () => ({}),
-        properties: () => ({shown: false}),
-        prefix: "",
-        showSearchInput: true,
-        searchInputFullWidth: false,
-        legacyQuery: false,
-        readOnly: false,
-        defaultScope: undefined,
-        defaultTimeRange: undefined,
-    });
-
+  
+    const props = withDefaults(
+        defineProps<{
+            configuration: FilterConfiguration;
+            buttons?: {
+                savedFilters?: { shown?: boolean };
+                tableOptions?: { shown?: boolean };
+            };
+            tableOptions?: TableOptions;
+            properties?: TableProperties;
+            prefix?: string;
+            showSearchInput?: boolean;
+            searchInputFullWidth?: boolean;
+            legacyQuery?: boolean;
+            readOnly?: boolean;
+            defaultScope?: boolean;
+            defaultTimeRange?: boolean;
+        }>(),
+        {
+            buttons: () => ({}),
+            tableOptions: () => ({}),
+            properties: () => ({shown: false}),
+            prefix: "",
+            showSearchInput: true,
+            searchInputFullWidth: false,
+            legacyQuery: false,
+            readOnly: false,
+            defaultScope: undefined,
+            defaultTimeRange: undefined,
+        },
+    );
+  
     const emits = defineEmits<{
         refresh: [];
         search: [query: string];
         filter: [filters: AppliedFilter[]];
         updateProperties: [columns: string[]];
     }>();
-
+  
     const {
         appliedFilters,
         searchQuery,
@@ -75,7 +79,7 @@
         updateFilter,
         resetToPreApplied,
         hasPreApplied,
-        getPreApplied
+        getPreApplied,
     } = useFilters(
         props.configuration,
         props.showSearchInput,
@@ -83,37 +87,57 @@
         props.defaultScope,
         props.defaultTimeRange,
     );
-
-    const {savedFilters, saveFilter, updateSavedFilter, deleteSavedFilter} = useSavedFilters(
-        props.prefix
-    );
-
-    const {showOptions, chartVisible, toggleOptions, updateChart, refreshData: tableRefreshData} = useDataOptions(
-        props.tableOptions
-    );
-
+  
+    const {savedFilters, saveFilter, updateSavedFilter, deleteSavedFilter} =
+        useSavedFilters(props.prefix);
+  
+    const {
+        showOptions,
+        chartVisible,
+        toggleOptions,
+        updateChart,
+        refreshData: tableRefreshData,
+    } = useDataOptions(props.tableOptions);
+  
     const editingFilter = ref<SavedFilter | undefined>(undefined);
-
-    const hasFilterKeys = computed(() => props.configuration.keys?.length > 0);
-    const hasAppliedFilters = computed(() => appliedFilters.value?.length > 0);
-
-    const loadSavedFilter = (savedFilter: SavedFilter) => {
-        appliedFilters.value.forEach((filter) => {
-            removeFilter(filter.id);
-        });
-
-        savedFilter.filters.forEach((filter) => {
-            addFilter(filter);
-        });
-
-        searchQuery.value = savedFilter.searchQuery ?? "";
+  
+    const hasFilterKeys = computed(() => (props.configuration.keys?.length ?? 0) > 0);
+    const hasAppliedFilters = computed(() => (appliedFilters.value?.length ?? 0) > 0);
+  
+    /**
+     * Defensive: saved filters should never re-apply "search" state.
+     * Source of truth is useSavedFilters.ts (it strips search on save/deserialize),
+     * but we also guard here to protect against legacy/dirty saved filters.
+     *
+     * Intentionally does NOT touch router/URL. This keeps concerns separated.
+     */
+    const isSearchLikeKey = (raw: unknown) => {
+        const key = String(raw ?? "");
+        return key === "q" || key === "search" || key.startsWith("filters[q]");
     };
 
+    const loadSavedFilter = (savedFilter: SavedFilter) => {
+        // Clear current filters
+        for (const f of appliedFilters.value) {
+            removeFilter(f.id);
+        }
+
+        // Apply saved filters (excluding search-like keys)
+        for (const f of savedFilter.filters ?? []) {
+            if (!isSearchLikeKey(f.key)) {
+                addFilter(f);
+            }
+        }
+
+        // NOTE: Never mutate searchQuery here.
+        // If the user typed something, keep it. If empty, leave it empty.
+    };
+  
     const refreshData = () => {
         tableRefreshData();
         emits("refresh");
     };
-
+  
     provide(FILTER_CONTEXT_INJECTION_KEY, {
         configuration: computed(() => props.configuration),
         appliedFilters,
@@ -151,9 +175,9 @@
         },
         updateProperties: (columns: string[]) => {
             emits("updateProperties", columns);
-        }
+        },
     });
-
+  
     onMounted(() => {
         if (props.showSearchInput && searchQuery.value) {
             emits("search", searchQuery.value);
@@ -162,40 +186,44 @@
             emits("filter", appliedFilters.value);
         }
     });
-
+  
     watch(searchQuery, (newQuery) => {
         if (props.showSearchInput) {
             emits("search", newQuery);
         }
     });
-
-    watch(appliedFilters, (newFilters) => {
-        emits("filter", newFilters);
-    }, {deep: true});
-    
-</script>
-
-<style lang="scss" scoped>
-.filter {
+  
+    watch(
+        appliedFilters,
+        (newFilters) => {
+            emits("filter", newFilters);
+        },
+        {deep: true},
+    );
+  </script>
+  
+  <style lang="scss" scoped>
+  .filter {
     display: flex;
     flex-direction: column;
     margin-bottom: 1rem;
     width: 100%;
     border-radius: 0.5rem;
-    
+  
     .top {
-        display: flex;
-        align-items: flex-start;
-        flex-wrap: nowrap;
-        gap: 0.5rem;
-        
-        &.options {
-            padding-bottom: 1rem;
-        }
-
-        @media (max-width: 768px) {
-            flex-wrap: wrap;
-        }
+      display: flex;
+      align-items: flex-start;
+      flex-wrap: nowrap;
+      gap: 0.5rem;
+  
+      &.options {
+        padding-bottom: 1rem;
+      }
+  
+      @media (max-width: 768px) {
+        flex-wrap: wrap;
+      }
     }
-}
-</style>
+  }
+  </style>
+  

--- a/ui/src/components/filter/components/KSFilter.vue
+++ b/ui/src/components/filter/components/KSFilter.vue
@@ -106,7 +106,8 @@
             addFilter(filter);
         });
 
-        searchQuery.value = savedFilter.searchQuery ?? "";
+       // searchQuery.value = savedFilter.searchQuery ?? "";
+       searchQuery.value = "";
     };
 
     const refreshData = () => {

--- a/ui/src/components/filter/components/KSFilter.vue
+++ b/ui/src/components/filter/components/KSFilter.vue
@@ -1,6 +1,6 @@
 <template>
     <section class="filter">
-        <div class="top" :class="{options: showOptions}">
+        <div class="top" :class="{'options': showOptions}">
             <MainFilter />
             <RightFilter>
                 <template #extra>
@@ -8,69 +8,65 @@
                 </template>
             </RightFilter>
         </div>
-  
         <FilterOptions v-if="showOptions && buttons?.tableOptions?.shown !== false" />
     </section>
 </template>
-  
-  <script setup lang="ts">
+
+<script setup lang="ts">
     import {ref, computed, provide, onMounted, watch} from "vue";
     import {useFilters} from "../composables/useFilters";
     import {useSavedFilters} from "../composables/useSavedFilters";
     import {useDataOptions} from "../composables/useDataOptions";
-  
-    import type {
+    
+    import {
         SavedFilter,
         TableOptions,
         AppliedFilter,
         TableProperties,
         FilterConfiguration,
     } from "../utils/filterTypes";
-  
+
     import {FILTER_CONTEXT_INJECTION_KEY} from "../utils/filterInjectionKeys";
-  
+
     import MainFilter from "./MainFilter.vue";
     import RightFilter from "./RightFilter.vue";
     import FilterOptions from "./FilterOptions.vue";
-  
-    const props = withDefaults(
-        defineProps<{
-            configuration: FilterConfiguration;
-            buttons?: {
-                savedFilters?: { shown?: boolean };
-                tableOptions?: { shown?: boolean };
-            };
-            tableOptions?: TableOptions;
-            properties?: TableProperties;
-            prefix?: string;
-            showSearchInput?: boolean;
-            searchInputFullWidth?: boolean;
-            legacyQuery?: boolean;
-            readOnly?: boolean;
-            defaultScope?: boolean;
-            defaultTimeRange?: boolean;
-        }>(),
-        {
-            buttons: () => ({}),
-            tableOptions: () => ({}),
-            properties: () => ({shown: false}),
-            prefix: "",
-            showSearchInput: true,
-            searchInputFullWidth: false,
-            legacyQuery: false,
-            readOnly: false,
-            defaultScope: undefined,
-            defaultTimeRange: undefined,
-        },
-    );
-  
+
+    const props = withDefaults(defineProps<{
+        configuration: FilterConfiguration;
+        buttons?: {
+            savedFilters?: {shown?: boolean}; 
+            tableOptions?: {shown?: boolean}
+        };
+        tableOptions?: TableOptions;
+        properties?: TableProperties;
+        prefix?: string;
+        showSearchInput?: boolean;
+        searchInputFullWidth?: boolean;
+        legacyQuery?: boolean;
+        readOnly?: boolean;
+        defaultScope?: boolean;
+        defaultTimeRange?: boolean;
+    }>(), {
+        buttons: () => ({}),
+        tableOptions: () => ({}),
+        properties: () => ({shown: false}),
+        prefix: "",
+        showSearchInput: true,
+        searchInputFullWidth: false,
+        legacyQuery: false,
+        readOnly: false,
+        defaultScope: undefined,
+        defaultTimeRange: undefined,
+    });
+
     const emits = defineEmits<{
         refresh: [];
         search: [query: string];
         filter: [filters: AppliedFilter[]];
         updateProperties: [columns: string[]];
     }>();
-  
+
     const {
         appliedFilters,
         searchQuery,
@@ -79,7 +75,7 @@
         updateFilter,
         resetToPreApplied,
         hasPreApplied,
-        getPreApplied,
+        getPreApplied
     } = useFilters(
         props.configuration,
         props.showSearchInput,
@@ -87,57 +83,37 @@
         props.defaultScope,
         props.defaultTimeRange,
     );
-  
-    const {savedFilters, saveFilter, updateSavedFilter, deleteSavedFilter} =
-        useSavedFilters(props.prefix);
-  
-    const {
-        showOptions,
-        chartVisible,
-        toggleOptions,
-        updateChart,
-        refreshData: tableRefreshData,
-    } = useDataOptions(props.tableOptions);
-  
+
+    const {savedFilters, saveFilter, updateSavedFilter, deleteSavedFilter} = useSavedFilters(
+        props.prefix
+    );
+
+    const {showOptions, chartVisible, toggleOptions, updateChart, refreshData: tableRefreshData} = useDataOptions(
+        props.tableOptions
+    );
+
     const editingFilter = ref<SavedFilter | undefined>(undefined);
-  
-    const hasFilterKeys = computed(() => (props.configuration.keys?.length ?? 0) > 0);
-    const hasAppliedFilters = computed(() => (appliedFilters.value?.length ?? 0) > 0);
-  
-    /**
-     * Defensive: saved filters should never re-apply "search" state.
-     * Source of truth is useSavedFilters.ts (it strips search on save/deserialize),
-     * but we also guard here to protect against legacy/dirty saved filters.
-     *
-     * Intentionally does NOT touch router/URL. This keeps concerns separated.
-     */
-    const isSearchLikeKey = (raw: unknown) => {
-        const key = String(raw ?? "");
-        return key === "q" || key === "search" || key.startsWith("filters[q]");
-    };
+
+    const hasFilterKeys = computed(() => props.configuration.keys?.length > 0);
+    const hasAppliedFilters = computed(() => appliedFilters.value?.length > 0);
 
     const loadSavedFilter = (savedFilter: SavedFilter) => {
-        // Clear current filters
-        for (const f of appliedFilters.value) {
-            removeFilter(f.id);
-        }
+        appliedFilters.value.forEach((filter) => {
+            removeFilter(filter.id);
+        });
 
-        // Apply saved filters (excluding search-like keys)
-        for (const f of savedFilter.filters ?? []) {
-            if (!isSearchLikeKey(f.key)) {
-                addFilter(f);
-            }
-        }
+        savedFilter.filters.forEach((filter) => {
+            addFilter(filter);
+        });
 
-        // NOTE: Never mutate searchQuery here.
-        // If the user typed something, keep it. If empty, leave it empty.
+        searchQuery.value = savedFilter.searchQuery ?? "";
     };
-  
+
     const refreshData = () => {
         tableRefreshData();
         emits("refresh");
     };
-  
+
     provide(FILTER_CONTEXT_INJECTION_KEY, {
         configuration: computed(() => props.configuration),
         appliedFilters,
@@ -175,9 +151,9 @@
         },
         updateProperties: (columns: string[]) => {
             emits("updateProperties", columns);
-        },
+        }
     });
-  
+
     onMounted(() => {
         if (props.showSearchInput && searchQuery.value) {
             emits("search", searchQuery.value);
@@ -186,44 +162,40 @@
             emits("filter", appliedFilters.value);
         }
     });
-  
+
     watch(searchQuery, (newQuery) => {
         if (props.showSearchInput) {
             emits("search", newQuery);
         }
     });
-  
-    watch(
-        appliedFilters,
-        (newFilters) => {
-            emits("filter", newFilters);
-        },
-        {deep: true},
-    );
-  </script>
-  
-  <style lang="scss" scoped>
-  .filter {
+
+    watch(appliedFilters, (newFilters) => {
+        emits("filter", newFilters);
+    }, {deep: true});
+    
+</script>
+
+<style lang="scss" scoped>
+.filter {
     display: flex;
     flex-direction: column;
     margin-bottom: 1rem;
     width: 100%;
     border-radius: 0.5rem;
-  
+    
     .top {
-      display: flex;
-      align-items: flex-start;
-      flex-wrap: nowrap;
-      gap: 0.5rem;
-  
-      &.options {
-        padding-bottom: 1rem;
-      }
-  
-      @media (max-width: 768px) {
-        flex-wrap: wrap;
-      }
+        display: flex;
+        align-items: flex-start;
+        flex-wrap: nowrap;
+        gap: 0.5rem;
+        
+        &.options {
+            padding-bottom: 1rem;
+        }
+
+        @media (max-width: 768px) {
+            flex-wrap: wrap;
+        }
     }
-  }
-  </style>
-  
+}
+</style>

--- a/ui/src/components/filter/components/KSFilter.vue
+++ b/ui/src/components/filter/components/KSFilter.vue
@@ -106,8 +106,7 @@
             addFilter(filter);
         });
 
-       // searchQuery.value = savedFilter.searchQuery ?? "";
-       searchQuery.value = "";
+        searchQuery.value = savedFilter.searchQuery ?? "";
     };
 
     const refreshData = () => {

--- a/ui/src/components/filter/components/RightFilter.vue
+++ b/ui/src/components/filter/components/RightFilter.vue
@@ -93,8 +93,7 @@
         filter.saveFilter(
             name,
             description,
-            filter.appliedFilters.value,
-            filter.searchQuery.value
+            filter.appliedFilters.value
         );
     };
 

--- a/ui/src/components/filter/components/RightFilter.vue
+++ b/ui/src/components/filter/components/RightFilter.vue
@@ -93,8 +93,8 @@
         filter.saveFilter(
             name,
             description,
-            filter.appliedFilters.value
-          //  filter.searchQuery.value
+            filter.appliedFilters.value,
+            filter.searchQuery.value
         );
     };
 

--- a/ui/src/components/filter/components/RightFilter.vue
+++ b/ui/src/components/filter/components/RightFilter.vue
@@ -93,8 +93,8 @@
         filter.saveFilter(
             name,
             description,
-            filter.appliedFilters.value,
-            filter.searchQuery.value
+            filter.appliedFilters.value
+          //  filter.searchQuery.value
         );
     };
 

--- a/ui/src/components/filter/components/RightFilter.vue
+++ b/ui/src/components/filter/components/RightFilter.vue
@@ -93,7 +93,8 @@
         filter.saveFilter(
             name,
             description,
-            filter.appliedFilters.value
+            filter.appliedFilters.value,
+            filter.searchQuery.value
         );
     };
 

--- a/ui/src/components/filter/composables/useSavedFilters.ts
+++ b/ui/src/components/filter/composables/useSavedFilters.ts
@@ -35,13 +35,12 @@ export function useSavedFilters(prefix: string) {
         }
     });
 
-    const saveFilter = (name: string, description: string, filters: any[], searchQuery?: string) => {
+    const saveFilter = (name: string, description: string, filters: any[]) => {
         savedFilters.value = [...savedFilters.value, {
             id: `saved_${Date.now()}`,
             name,
             description,
             filters: [...filters],
-            searchQuery,
             createdAt: new Date(),
         }];
     };

--- a/ui/src/components/filter/composables/useSavedFilters.ts
+++ b/ui/src/components/filter/composables/useSavedFilters.ts
@@ -35,13 +35,14 @@ export function useSavedFilters(prefix: string) {
         }
     });
 
-    const saveFilter = (name: string, description: string, filters: any[], searchQuery?: string) => {
+    //const saveFilter = (name: string, description: string, filters: any[], searchQuery?: string) => {
+        const saveFilter = (name: string, description: string, filters: any[]) => {
         savedFilters.value = [...savedFilters.value, {
             id: `saved_${Date.now()}`,
             name,
             description,
             filters: [...filters],
-            searchQuery,
+          //  searchQuery,
             createdAt: new Date(),
         }];
     };

--- a/ui/src/components/filter/composables/useSavedFilters.ts
+++ b/ui/src/components/filter/composables/useSavedFilters.ts
@@ -5,80 +5,66 @@ import {SavedFilter} from "../utils/filterTypes";
 import {storageKeys} from "../../../utils/constants";
 
 const isDateString = (value: any) =>
-  typeof value === "string" && !isNaN(Date.parse(value)) && value.includes("T");
+    typeof value === "string" && !isNaN(Date.parse(value)) && value.includes("T");
 
-// Saved filters should not persist the free-text search ("q") to avoid ghost filters.
-const stripSearchFilters = (filters: any[] = []) =>
-  filters.filter((f: any) => {
-    const k = String(f?.key ?? "");
-    return !(k === "q" || k === "search" || k.startsWith("filters[q]"));
-  });
-
-const deserializeDates = (filter: SavedFilter): SavedFilter => {
-  const {searchQuery:_searchQuery, ...rest} = filter as any; // strip legacy field
-
-  return {
-    ...rest,
-    filters: stripSearchFilters(rest.filters ?? []).map((f: any) => ({
-      ...f,
-      value:
-        f.value?.startDate && f.value?.endDate
-          ? {startDate: new Date(f.value.startDate), endDate: new Date(f.value.endDate)}
-          : isDateString(f.value)
-            ? new Date(f.value)
-            : f.value
+const deserializeDates = (filter: SavedFilter): SavedFilter => ({
+    ...filter,
+    filters: filter.filters.map((f: any) => ({
+        ...f,
+        value: f.value?.startDate && f.value?.endDate
+            ? {startDate: new Date(f.value.startDate), endDate: new Date(f.value.endDate)}
+            : isDateString(f.value)
+                ? new Date(f.value)
+                : f.value
     })),
-    createdAt: new Date(rest.createdAt)
-  };
-};
+    createdAt: new Date(filter.createdAt)
+});
 
 export function useSavedFilters(prefix: string) {
-  const route = useRoute();
+    const route = useRoute();
+    
+    const storageKey = computed(() => {
+        const routeKey = String(route.name || route.path.replace(/\//g, "_").replace(/^_/, ""));
+        return `${storageKeys.SAVED_FILTERS_PREFIX}_${prefix}_${routeKey}`;
+    });
 
-  const storageKey = computed(() => {
-    const routeKey = String(route.name || route.path.replace(/\//g, "_").replace(/^_/, ""));
-    return `${storageKeys.SAVED_FILTERS_PREFIX}_${prefix}_${routeKey}`;
-  });
+    const savedFilters = useStorage<SavedFilter[]>(storageKey, [], localStorage, {
+        serializer: {
+            read: (v: string) => JSON.parse(v).map(deserializeDates),
+            write: (v: SavedFilter[]) => JSON.stringify(v)
+        }
+    });
 
-  const savedFilters = useStorage<SavedFilter[]>(storageKey, [], localStorage, {
-    serializer: {
-      read: (v: string) => JSON.parse(v).map(deserializeDates),
-      write: (v: SavedFilter[]) => JSON.stringify(v)
-    }
-  });
+    const saveFilter = (name: string, description: string, filters: any[], searchQuery?: string) => {
+        savedFilters.value = [...savedFilters.value, {
+            id: `saved_${Date.now()}`,
+            name,
+            description,
+            filters: [...filters],
+            searchQuery,
+            createdAt: new Date(),
+        }];
+    };
 
-  const saveFilter = (name: string, description: string, filters: any[]) => {
-    savedFilters.value = [
-      ...savedFilters.value,
-      {
-        id: `saved_${Date.now()}`,
-        name,
-        description,
-        filters: stripSearchFilters(filters),
-        createdAt: new Date()
-      }
-    ];
-  };
+    const updateSavedFilter = (id: string, name: string, description: string) => {
+        const index = savedFilters.value.findIndex((f) => f.id === id);
+        if (index !== -1) {
+            savedFilters.value[index] = {
+                ...savedFilters.value[index],
+                name,
+                description
+            };
+        }
+    };
 
-  const updateSavedFilter = (id: string, name: string, description: string) => {
-    const index = savedFilters.value.findIndex((f) => f.id === id);
-    if (index !== -1) {
-      savedFilters.value[index] = {
-        ...savedFilters.value[index],
-        name,
-        description
-      };
-    }
-  };
+    const deleteSavedFilter = (savedFilter: SavedFilter) => {
+        savedFilters.value = savedFilters.value.filter((f) => f.id !== savedFilter.id);
+    };
 
-  const deleteSavedFilter = (savedFilter: SavedFilter) => {
-    savedFilters.value = savedFilters.value.filter((f) => f.id !== savedFilter.id);
-  };
-
-  return {
-    savedFilters: computed(() => savedFilters.value),
-    saveFilter,
-    updateSavedFilter,
-    deleteSavedFilter
-  };
+    return {
+        savedFilters: computed(() => savedFilters.value),
+        saveFilter,
+        updateSavedFilter,
+        deleteSavedFilter,
+    };
 }

--- a/ui/src/components/filter/composables/useSavedFilters.ts
+++ b/ui/src/components/filter/composables/useSavedFilters.ts
@@ -35,14 +35,13 @@ export function useSavedFilters(prefix: string) {
         }
     });
 
-    //const saveFilter = (name: string, description: string, filters: any[], searchQuery?: string) => {
-        const saveFilter = (name: string, description: string, filters: any[]) => {
+    const saveFilter = (name: string, description: string, filters: any[], searchQuery?: string) => {
         savedFilters.value = [...savedFilters.value, {
             id: `saved_${Date.now()}`,
             name,
             description,
             filters: [...filters],
-          //  searchQuery,
+            searchQuery,
             createdAt: new Date(),
         }];
     };

--- a/ui/src/components/filter/composables/useSavedFilters.ts
+++ b/ui/src/components/filter/composables/useSavedFilters.ts
@@ -5,66 +5,80 @@ import {SavedFilter} from "../utils/filterTypes";
 import {storageKeys} from "../../../utils/constants";
 
 const isDateString = (value: any) =>
-    typeof value === "string" && !isNaN(Date.parse(value)) && value.includes("T");
+  typeof value === "string" && !isNaN(Date.parse(value)) && value.includes("T");
 
-const deserializeDates = (filter: SavedFilter): SavedFilter => ({
-    ...filter,
-    filters: filter.filters.map((f: any) => ({
-        ...f,
-        value: f.value?.startDate && f.value?.endDate
-            ? {startDate: new Date(f.value.startDate), endDate: new Date(f.value.endDate)}
-            : isDateString(f.value)
-                ? new Date(f.value)
-                : f.value
+// Saved filters should not persist the free-text search ("q") to avoid ghost filters.
+const stripSearchFilters = (filters: any[] = []) =>
+  filters.filter((f: any) => {
+    const k = String(f?.key ?? "");
+    return !(k === "q" || k === "search" || k.startsWith("filters[q]"));
+  });
+
+const deserializeDates = (filter: SavedFilter): SavedFilter => {
+  const {searchQuery:_searchQuery, ...rest} = filter as any; // strip legacy field
+
+  return {
+    ...rest,
+    filters: stripSearchFilters(rest.filters ?? []).map((f: any) => ({
+      ...f,
+      value:
+        f.value?.startDate && f.value?.endDate
+          ? {startDate: new Date(f.value.startDate), endDate: new Date(f.value.endDate)}
+          : isDateString(f.value)
+            ? new Date(f.value)
+            : f.value
     })),
-    createdAt: new Date(filter.createdAt)
-});
+    createdAt: new Date(rest.createdAt)
+  };
+};
 
 export function useSavedFilters(prefix: string) {
-    const route = useRoute();
-    
-    const storageKey = computed(() => {
-        const routeKey = String(route.name || route.path.replace(/\//g, "_").replace(/^_/, ""));
-        return `${storageKeys.SAVED_FILTERS_PREFIX}_${prefix}_${routeKey}`;
-    });
+  const route = useRoute();
 
-    const savedFilters = useStorage<SavedFilter[]>(storageKey, [], localStorage, {
-        serializer: {
-            read: (v: string) => JSON.parse(v).map(deserializeDates),
-            write: (v: SavedFilter[]) => JSON.stringify(v)
-        }
-    });
+  const storageKey = computed(() => {
+    const routeKey = String(route.name || route.path.replace(/\//g, "_").replace(/^_/, ""));
+    return `${storageKeys.SAVED_FILTERS_PREFIX}_${prefix}_${routeKey}`;
+  });
 
-    const saveFilter = (name: string, description: string, filters: any[], searchQuery?: string) => {
-        savedFilters.value = [...savedFilters.value, {
-            id: `saved_${Date.now()}`,
-            name,
-            description,
-            filters: [...filters],
-            searchQuery,
-            createdAt: new Date(),
-        }];
-    };
+  const savedFilters = useStorage<SavedFilter[]>(storageKey, [], localStorage, {
+    serializer: {
+      read: (v: string) => JSON.parse(v).map(deserializeDates),
+      write: (v: SavedFilter[]) => JSON.stringify(v)
+    }
+  });
 
-    const updateSavedFilter = (id: string, name: string, description: string) => {
-        const index = savedFilters.value.findIndex((f) => f.id === id);
-        if (index !== -1) {
-            savedFilters.value[index] = {
-                ...savedFilters.value[index],
-                name,
-                description
-            };
-        }
-    };
+  const saveFilter = (name: string, description: string, filters: any[]) => {
+    savedFilters.value = [
+      ...savedFilters.value,
+      {
+        id: `saved_${Date.now()}`,
+        name,
+        description,
+        filters: stripSearchFilters(filters),
+        createdAt: new Date()
+      }
+    ];
+  };
 
-    const deleteSavedFilter = (savedFilter: SavedFilter) => {
-        savedFilters.value = savedFilters.value.filter((f) => f.id !== savedFilter.id);
-    };
+  const updateSavedFilter = (id: string, name: string, description: string) => {
+    const index = savedFilters.value.findIndex((f) => f.id === id);
+    if (index !== -1) {
+      savedFilters.value[index] = {
+        ...savedFilters.value[index],
+        name,
+        description
+      };
+    }
+  };
 
-    return {
-        savedFilters: computed(() => savedFilters.value),
-        saveFilter,
-        updateSavedFilter,
-        deleteSavedFilter,
-    };
+  const deleteSavedFilter = (savedFilter: SavedFilter) => {
+    savedFilters.value = savedFilters.value.filter((f) => f.id !== savedFilter.id);
+  };
+
+  return {
+    savedFilters: computed(() => savedFilters.value),
+    saveFilter,
+    updateSavedFilter,
+    deleteSavedFilter
+  };
 }

--- a/ui/src/components/filter/utils/filterInjectionKeys.ts
+++ b/ui/src/components/filter/utils/filterInjectionKeys.ts
@@ -37,7 +37,7 @@ export interface FilterContext {
     hasPreApplied: (filterKey: string) => boolean;
     getPreApplied: (filterKey: string) => AppliedFilter | undefined;
     updateSavedFilter: (id: string, name: string, description: string) => void;
-    saveFilter: (name: string, description: string, filters: AppliedFilter[], searchQuery?: string) => void;
+    saveFilter: (name: string, description: string, filters: AppliedFilter[]) => void;
 }
 
 export const FILTER_CONTEXT_INJECTION_KEY = Symbol("filter-context-injection-key") as InjectionKey<FilterContext>;

--- a/ui/src/components/filter/utils/filterTypes.ts
+++ b/ui/src/components/filter/utils/filterTypes.ts
@@ -56,7 +56,6 @@ export interface SavedFilter {
     createdAt: Date;
     global?: boolean;
     description?: string;
-    searchQuery?: string;
     filters: AppliedFilter[];
 }
 

--- a/ui/src/composables/useRestoreUrl.ts
+++ b/ui/src/composables/useRestoreUrl.ts
@@ -2,9 +2,159 @@ import {computed, nextTick, onMounted, ref} from "vue";
 import {RouteLocation, useRoute, useRouter} from "vue-router";
 
 interface UseRestoreUrlOptions {
+  restoreUrl?: boolean;
+  isDefaultNamespaceAllow?: boolean;
+}
+
+type QueryLike = Record<string, unknown>;
+
+const stripSearchFromQuery = (query: QueryLike): QueryLike => {
+  const cleaned: QueryLike = {...query};
+
+  // legacy keys
+  delete cleaned.q;
+  delete cleaned.search;
+
+  // encoded filter keys
+  for (const k of Object.keys(cleaned)) {
+    if (k === "filters[q][EQUALS]" || k.startsWith("filters[q]")) {
+      delete cleaned[k];
+    }
+  }
+
+  return cleaned;
+};
+
+function getLocalStorageName(route: RouteLocation): string {
+  const tenant = route.params.tenant;
+  return `${route.name?.toString().replace("/", "_")}${route.params.tab ? "_" + route.params.tab : ""}${
+    tenant ? "_" + tenant : ""
+  }_restore_url`;
+}
+
+function getRestoredUrlValue(route: RouteLocation): QueryLike | null {
+  const localStorageName = getLocalStorageName(route);
+  const localStorageValue = window.sessionStorage.getItem(localStorageName);
+  return localStorageValue ? (JSON.parse(localStorageValue) as QueryLike) : null;
+}
+
+export function getRestoredQuery(route: RouteLocation) {
+  const localStorageValue = getRestoredUrlValue(route);
+
+  if (localStorageValue === null) {
+    return {
+      query: route.query,
+      change: false,
+      localStorageValue,
+    };
+  }
+
+  // NOTE: route.query is typically empty when restore runs, but keep this safe anyway.
+  const query: QueryLike = stripSearchFromQuery({...(route.query as QueryLike)});
+  const local: QueryLike = stripSearchFromQuery(localStorageValue);
+
+  let change = false;
+
+  for (const key in local) {
+    // only add keys that are missing from current query
+    if (query[key] == null && local[key] != null) {
+      // empty array breaks the application
+      if (Array.isArray(local[key]) && (local[key] as unknown[]).length === 0) continue;
+
+      query[key] = local[key];
+      change = true;
+    }
+  }
+
+  return {
+    query,
+    change,
+    localStorageValue,
+  };
+}
+
+export default function useRestoreUrl(options: UseRestoreUrlOptions = {}) {
+  const {restoreUrl = true} = options;
+
+  const route = useRoute();
+  const router = useRouter();
+
+  const loadInit = ref(true);
+
+  const localStorageName = computed(() => getLocalStorageName(route));
+
+  const localStorageValue = computed<QueryLike | null>(() => {
+    const raw = window.sessionStorage.getItem(localStorageName.value);
+    return raw ? (JSON.parse(raw) as QueryLike) : null;
+  });
+
+  const saveRestoreUrl = () => {
+    if (!restoreUrl) return;
+
+    const toPersist = stripSearchFromQuery(route.query as QueryLike);
+
+    if (Object.keys(toPersist).length === 0) {
+      window.sessionStorage.removeItem(localStorageName.value);
+    } else {
+      window.sessionStorage.setItem(localStorageName.value, JSON.stringify(toPersist));
+    }
+  };
+
+  const goToRestoreUrl = () => {
+    const {query, change} = getRestoredQuery(route);
+
+    if (change) {
+      nextTick(() => {
+        router.replace({query: query as any});
+      });
+    } else {
+      loadInit.value = true;
+    }
+  };
+
+  onMounted(() => {
+    if (restoreUrl && localStorageValue.value) {
+      if (!route.query || Object.keys(route.query).length === 0) {
+        loadInit.value = false;
+        goToRestoreUrl();
+      }
+    }
+  });
+
+  return {
+    loadInit,
+    localStorageName,
+    localStorageValue,
+    saveRestoreUrl,
+    goToRestoreUrl,
+  };
+}
+
+
+
+
+
+
+/*import {computed, nextTick, onMounted, ref} from "vue";
+import {RouteLocation, useRoute, useRouter} from "vue-router";
+
+interface UseRestoreUrlOptions {
     restoreUrl?: boolean;
     isDefaultNamespaceAllow?: boolean;
 }
+
+//new code
+const stripSearchFromQuery = (query: Record<string, any>) => {
+    const cleaned = { ...query };
+  
+    delete cleaned.q;
+  
+    Object.keys(cleaned).forEach((k) => {
+      if (k.startsWith("filters[q]")) delete cleaned[k];
+    });
+  
+    return cleaned;
+  };
 
 function getLocalStorageName(route: RouteLocation): string {
     const tenant = route.params.tenant;
@@ -30,10 +180,11 @@ export function getRestoredQuery(route: RouteLocation) {
             localStorageValue,
         };
     };
-    const query = {...route.query};
-    const local = {...localStorageValue};
-
-    let change = false;
+ 
+//new code
+      const query = stripSearchFromQuery({ ...route.query } as any);
+      const local = stripSearchFromQuery({ ...localStorageValue } as any);
+      let change = false;
 
     for (const key in local) {
         if (!query[key] && local[key]) {
@@ -77,22 +228,18 @@ export default function useRestoreUrl(options: UseRestoreUrlOptions = {}) {
         }
     });
 
+    //newest code
     const saveRestoreUrl = () => {
-        if (!restoreUrl) {
-            return;
-        }
-
-        if (Object.keys(route.query).length > 0 || (localStorageValue.value !== null && Object.keys(localStorageValue.value).length > 0)) {
-            if (Object.keys(route.query).length === 0) {
-                window.sessionStorage.removeItem(localStorageName.value);
-            } else {
-                window.sessionStorage.setItem(
-                    localStorageName.value,
-                    JSON.stringify(route.query)
-                );
-            }
-        }
-    };
+          if (!restoreUrl) return;
+        
+          const toPersist = stripSearchFromQuery(route.query as any);
+        
+          if (Object.keys(toPersist).length === 0) {
+            window.sessionStorage.removeItem(localStorageName.value);
+          } else {
+            window.sessionStorage.setItem(localStorageName.value, JSON.stringify(toPersist));
+          }
+        };
 
     const router = useRouter();
 
@@ -101,6 +248,7 @@ export default function useRestoreUrl(options: UseRestoreUrlOptions = {}) {
      * Only adds missing parameters to avoid overwriting user changes.
      * Updates route only when changes are made.
      */
+    /*
     const goToRestoreUrl = () => {
         const {query, change} = getRestoredQuery(route);
 
@@ -118,6 +266,7 @@ export default function useRestoreUrl(options: UseRestoreUrlOptions = {}) {
      * Automatically restores saved URL state from sessionStorage on mount.
      * Only triggers when restoreUrl is enabled and saved state exists.
      */
+    /*
     onMounted(() => {
         if (restoreUrl && localStorageValue.value){
             if(!route.query || Object.keys(route.query).length === 0) {
@@ -135,3 +284,4 @@ export default function useRestoreUrl(options: UseRestoreUrlOptions = {}) {
         goToRestoreUrl
     };
 }
+*/

--- a/ui/src/composables/useRestoreUrl.ts
+++ b/ui/src/composables/useRestoreUrl.ts
@@ -2,159 +2,9 @@ import {computed, nextTick, onMounted, ref} from "vue";
 import {RouteLocation, useRoute, useRouter} from "vue-router";
 
 interface UseRestoreUrlOptions {
-  restoreUrl?: boolean;
-  isDefaultNamespaceAllow?: boolean;
-}
-
-type QueryLike = Record<string, unknown>;
-
-const stripSearchFromQuery = (query: QueryLike): QueryLike => {
-  const cleaned: QueryLike = {...query};
-
-  // legacy keys
-  delete cleaned.q;
-  delete cleaned.search;
-
-  // encoded filter keys
-  for (const k of Object.keys(cleaned)) {
-    if (k === "filters[q][EQUALS]" || k.startsWith("filters[q]")) {
-      delete cleaned[k];
-    }
-  }
-
-  return cleaned;
-};
-
-function getLocalStorageName(route: RouteLocation): string {
-  const tenant = route.params.tenant;
-  return `${route.name?.toString().replace("/", "_")}${route.params.tab ? "_" + route.params.tab : ""}${
-    tenant ? "_" + tenant : ""
-  }_restore_url`;
-}
-
-function getRestoredUrlValue(route: RouteLocation): QueryLike | null {
-  const localStorageName = getLocalStorageName(route);
-  const localStorageValue = window.sessionStorage.getItem(localStorageName);
-  return localStorageValue ? (JSON.parse(localStorageValue) as QueryLike) : null;
-}
-
-export function getRestoredQuery(route: RouteLocation) {
-  const localStorageValue = getRestoredUrlValue(route);
-
-  if (localStorageValue === null) {
-    return {
-      query: route.query,
-      change: false,
-      localStorageValue,
-    };
-  }
-
-  // NOTE: route.query is typically empty when restore runs, but keep this safe anyway.
-  const query: QueryLike = stripSearchFromQuery({...(route.query as QueryLike)});
-  const local: QueryLike = stripSearchFromQuery(localStorageValue);
-
-  let change = false;
-
-  for (const key in local) {
-    // only add keys that are missing from current query
-    if (query[key] == null && local[key] != null) {
-      // empty array breaks the application
-      if (Array.isArray(local[key]) && (local[key] as unknown[]).length === 0) continue;
-
-      query[key] = local[key];
-      change = true;
-    }
-  }
-
-  return {
-    query,
-    change,
-    localStorageValue,
-  };
-}
-
-export default function useRestoreUrl(options: UseRestoreUrlOptions = {}) {
-  const {restoreUrl = true} = options;
-
-  const route = useRoute();
-  const router = useRouter();
-
-  const loadInit = ref(true);
-
-  const localStorageName = computed(() => getLocalStorageName(route));
-
-  const localStorageValue = computed<QueryLike | null>(() => {
-    const raw = window.sessionStorage.getItem(localStorageName.value);
-    return raw ? (JSON.parse(raw) as QueryLike) : null;
-  });
-
-  const saveRestoreUrl = () => {
-    if (!restoreUrl) return;
-
-    const toPersist = stripSearchFromQuery(route.query as QueryLike);
-
-    if (Object.keys(toPersist).length === 0) {
-      window.sessionStorage.removeItem(localStorageName.value);
-    } else {
-      window.sessionStorage.setItem(localStorageName.value, JSON.stringify(toPersist));
-    }
-  };
-
-  const goToRestoreUrl = () => {
-    const {query, change} = getRestoredQuery(route);
-
-    if (change) {
-      nextTick(() => {
-        router.replace({query: query as any});
-      });
-    } else {
-      loadInit.value = true;
-    }
-  };
-
-  onMounted(() => {
-    if (restoreUrl && localStorageValue.value) {
-      if (!route.query || Object.keys(route.query).length === 0) {
-        loadInit.value = false;
-        goToRestoreUrl();
-      }
-    }
-  });
-
-  return {
-    loadInit,
-    localStorageName,
-    localStorageValue,
-    saveRestoreUrl,
-    goToRestoreUrl,
-  };
-}
-
-
-
-
-
-
-/*import {computed, nextTick, onMounted, ref} from "vue";
-import {RouteLocation, useRoute, useRouter} from "vue-router";
-
-interface UseRestoreUrlOptions {
     restoreUrl?: boolean;
     isDefaultNamespaceAllow?: boolean;
 }
-
-//new code
-const stripSearchFromQuery = (query: Record<string, any>) => {
-    const cleaned = { ...query };
-  
-    delete cleaned.q;
-  
-    Object.keys(cleaned).forEach((k) => {
-      if (k.startsWith("filters[q]")) delete cleaned[k];
-    });
-  
-    return cleaned;
-  };
 
 function getLocalStorageName(route: RouteLocation): string {
     const tenant = route.params.tenant;
@@ -180,11 +30,10 @@ export function getRestoredQuery(route: RouteLocation) {
             localStorageValue,
         };
     };
- 
-//new code
-      const query = stripSearchFromQuery({ ...route.query } as any);
-      const local = stripSearchFromQuery({ ...localStorageValue } as any);
-      let change = false;
+    const query = {...route.query};
+    const local = {...localStorageValue};
+
+    let change = false;
 
     for (const key in local) {
         if (!query[key] && local[key]) {
@@ -228,18 +77,22 @@ export default function useRestoreUrl(options: UseRestoreUrlOptions = {}) {
         }
     });
 
-    //newest code
     const saveRestoreUrl = () => {
-          if (!restoreUrl) return;
-        
-          const toPersist = stripSearchFromQuery(route.query as any);
-        
-          if (Object.keys(toPersist).length === 0) {
-            window.sessionStorage.removeItem(localStorageName.value);
-          } else {
-            window.sessionStorage.setItem(localStorageName.value, JSON.stringify(toPersist));
-          }
-        };
+        if (!restoreUrl) {
+            return;
+        }
+
+        if (Object.keys(route.query).length > 0 || (localStorageValue.value !== null && Object.keys(localStorageValue.value).length > 0)) {
+            if (Object.keys(route.query).length === 0) {
+                window.sessionStorage.removeItem(localStorageName.value);
+            } else {
+                window.sessionStorage.setItem(
+                    localStorageName.value,
+                    JSON.stringify(route.query)
+                );
+            }
+        }
+    };
 
     const router = useRouter();
 
@@ -248,7 +101,6 @@ export default function useRestoreUrl(options: UseRestoreUrlOptions = {}) {
      * Only adds missing parameters to avoid overwriting user changes.
      * Updates route only when changes are made.
      */
-    /*
     const goToRestoreUrl = () => {
         const {query, change} = getRestoredQuery(route);
 
@@ -266,7 +118,6 @@ export default function useRestoreUrl(options: UseRestoreUrlOptions = {}) {
      * Automatically restores saved URL state from sessionStorage on mount.
      * Only triggers when restoreUrl is enabled and saved state exists.
      */
-    /*
     onMounted(() => {
         if (restoreUrl && localStorageValue.value){
             if(!route.query || Object.keys(route.query).length === 0) {
@@ -284,4 +135,3 @@ export default function useRestoreUrl(options: UseRestoreUrlOptions = {}) {
         goToRestoreUrl
     };
 }
-*/


### PR DESCRIPTION
### ✨ Description

Fixes an issue where saved filters and restored URLs could persist and re-apply the free-text search query (`q` / `filters[q][EQUALS]`), causing unexpected “ghost” searches.

The fix ensures that:
- Free-text search is not persisted when saving filters
- Search parameters are excluded from restore-URL session state
- Loading a saved filter applies only structured filters, not search

---

### 🔗 Related Issue

Closes https://github.com/kestra-io/kestra/issues/13938

---

### 🎨 Frontend Checklist

- [x] Code builds without errors (`npm run build`)
- [ ] All existing E2E tests pass (not run locally)
- [ ] Screenshots or video recordings attached  
  _Not required — no visual UI changes_

---

### 📝 Additional Notes

Behavior verified manually across saved filters, restored URLs, and live search interactions.