### PR TITLE
Replace YAML string body with multipart in namespace update

### DIFF
--- a/cli/src/main/java/io/kestra/cli/commands/flows/namespaces/FlowNamespaceUpdateCommand.java
+++ b/cli/src/main/java/io/kestra/cli/commands/flows/namespaces/FlowNamespaceUpdateCommand.java
@@ -2,7 +2,6 @@ package io.kestra.cli.commands.flows.namespaces;
 
 import io.kestra.cli.AbstractValidateCommand;
 import io.kestra.cli.commands.AbstractServiceNamespaceUpdateCommand;
-import io.kestra.cli.commands.flows.IncludeHelperExpander;
 import io.kestra.cli.services.TenantIdSelectorService;
 import io.kestra.core.serializers.YamlParser;
 import io.micronaut.core.type.Argument;
@@ -10,16 +9,16 @@ import io.micronaut.http.HttpRequest;
 import io.micronaut.http.MediaType;
 import io.micronaut.http.MutableHttpRequest;
 import io.micronaut.http.client.exceptions.HttpClientResponseException;
+import io.micronaut.http.client.multipart.MultipartBody;
 import io.micronaut.http.client.netty.DefaultHttpClient;
 import jakarta.inject.Inject;
-import jakarta.validation.ConstraintViolationException;
 import lombok.extern.slf4j.Slf4j;
 import picocli.CommandLine;
 
-import java.io.IOException;
-import java.nio.charset.Charset;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.List;
+import java.util.stream.Stream;
 
 @CommandLine.Command(
     name = "update",
@@ -35,52 +34,44 @@ public class FlowNamespaceUpdateCommand extends AbstractServiceNamespaceUpdateCo
     @Inject
     private TenantIdSelectorService tenantService;
 
-    @SuppressWarnings("deprecation")
     @Override
     public Integer call() throws Exception {
         super.call();
 
-        try (var files = Files.walk(directory)) {
-            List<String> flows = files
+        try (Stream<Path> files = Files.walk(directory)) {
+            List<Path> flows = files
                 .filter(Files::isRegularFile)
                 .filter(YamlParser::isValidExtension)
-                .map(path -> {
-                    try {
-                        return IncludeHelperExpander.expand(Files.readString(path, Charset.defaultCharset()), path.getParent());
-                    } catch (IOException e) {
-                        throw new RuntimeException(e);
-                    }
-                })
                 .toList();
 
-            String body = "";
+            // At least one flow file is expected for update
             if (flows.isEmpty()) {
-                stdOut("No flow found on '{}'", directory.toFile().getAbsolutePath());
-            } else {
-                body = String.join("\n---\n", flows);
+                stdErr("No flow found in ''{0}''!", directory.toFile().getAbsolutePath());
+                return 1;
             }
-            if (override) {
-                body = body.replaceAll("(?m)^namespace:.+", "namespace: " + namespace);
-            }
-            try(DefaultHttpClient client = client()) {
-                MutableHttpRequest<String> request = HttpRequest
-                    .POST(apiUri("/flows/", tenantService.getTenantIdAndAllowEETenants(tenantId)) + namespace + "?delete=" + delete, body).contentType(MediaType.APPLICATION_YAML);
+
+            // Build multipart body with all available flow files
+            MultipartBody.Builder bodyBuilder = MultipartBody.builder();
+            flows.forEach(flow -> bodyBuilder.addPart("flows", flow.toFile().getName(), MediaType.APPLICATION_YAML_TYPE, flow.toFile()));
+
+            // Call update API
+            try (DefaultHttpClient client = client()) {
+                MutableHttpRequest<MultipartBody> request = HttpRequest.POST(
+                    String.format("%s/%s?override=%s&delete=%s", apiUri("/flows", tenantService.getTenantIdAndAllowEETenants(tenantId)), namespace, override, delete),
+                    bodyBuilder.build()
+                ).contentType(MediaType.MULTIPART_FORM_DATA);
 
                 List<UpdateResult> updated = client.toBlocking().retrieve(
                     this.requestOptions(request),
                     Argument.listOf(UpdateResult.class)
                 );
 
-                stdOut(updated.size() + " flow(s) for namespace '" + namespace + "' successfully updated !");
-                updated.forEach(flow -> stdOut("- " + flow.getNamespace() + "."  + flow.getId()));
-            } catch (HttpClientResponseException e){
+                stdOut("{0} flow(s) for namespace ''{1}'' successfully updated!", updated.size(), namespace);
+                updated.forEach(flow -> stdOut("- {0}.{1}", flow.getNamespace(), flow.getId()));
+            } catch (HttpClientResponseException e) {
                 AbstractValidateCommand.handleHttpException(e, "flow");
                 return 1;
             }
-        } catch (ConstraintViolationException e) {
-            AbstractValidateCommand.handleException(e, "flow");
-
-            return 1;
         }
 
         return 0;

--- a/webserver/src/main/java/io/kestra/webserver/controllers/api/FlowController.java
+++ b/webserver/src/main/java/io/kestra/webserver/controllers/api/FlowController.java
@@ -62,7 +62,6 @@ import org.reactivestreams.Publisher;
 import reactor.core.publisher.Flux;
 
 import java.io.IOException;
-import java.nio.charset.Charset;
 import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;

--- a/webserver/src/main/java/io/kestra/webserver/controllers/api/FlowController.java
+++ b/webserver/src/main/java/io/kestra/webserver/controllers/api/FlowController.java
@@ -58,9 +58,11 @@ import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotEmpty;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
+import org.reactivestreams.Publisher;
 import reactor.core.publisher.Flux;
 
 import java.io.IOException;
+import java.nio.charset.Charset;
 import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -325,6 +327,38 @@ public class FlowController {
             .stream()
             .map(source -> parseFlowSource(source.trim()))
             .toList();
+
+        return this.bulkUpdateOrCreate(namespace, genericFlows, delete, false);
+    }
+
+    @ExecuteOn(TaskExecutors.IO)
+    @Post(uri = "{namespace}", consumes = MediaType.MULTIPART_FORM_DATA)
+    @Operation(
+        tags = {"Flows"},
+        summary = "Update a complete namespace from yaml source",
+        description = "All flows will be created / updated for this namespace.\n" +
+            "Existing flows missing from `flows` will be deleted if the query delete is `true`"
+    )
+    public List<FlowInterface> updateFlowsInNamespace(
+        @Parameter(description = "The flow namespace") @PathVariable String namespace,
+        @RequestBody(description = "A list of flow files") @Part("flows") Publisher<CompletedFileUpload> flowsPublisher,
+        @Parameter(description = "If namespace of all provided flows should be overridden") @QueryValue(defaultValue = "false") Boolean override,
+        @Parameter(description = "If missing flows should be deleted") @QueryValue(defaultValue = "true") Boolean delete
+    ) throws ConstraintViolationException, IOException {
+        List<CompletedFileUpload> flows = Flux.from(flowsPublisher)
+            .collectList()
+            .blockOptional()
+            .orElse(Collections.emptyList());
+
+        List<GenericFlow> genericFlows = new ArrayList<>();
+        for (CompletedFileUpload flow : flows) {
+            String source = new String(flow.getBytes(), Charset.defaultCharset()).trim();
+            if (override) {
+                source = source.replaceFirst("(?m)^namespace:.+", "namespace: " + namespace);
+            }
+
+            genericFlows.add(parseFlowSource(source));
+        }
 
         return this.bulkUpdateOrCreate(namespace, genericFlows, delete, false);
     }

--- a/webserver/src/main/java/io/kestra/webserver/controllers/api/FlowController.java
+++ b/webserver/src/main/java/io/kestra/webserver/controllers/api/FlowController.java
@@ -352,7 +352,7 @@ public class FlowController {
 
         List<GenericFlow> genericFlows = new ArrayList<>();
         for (CompletedFileUpload flow : flows) {
-            String source = new String(flow.getBytes(), Charset.defaultCharset()).trim();
+            String source = new String(flow.getBytes()).trim();
             if (override) {
                 source = source.replaceFirst("(?m)^namespace:.+", "namespace: " + namespace);
             }

--- a/webserver/src/main/java/io/kestra/webserver/controllers/api/FlowController.java
+++ b/webserver/src/main/java/io/kestra/webserver/controllers/api/FlowController.java
@@ -344,14 +344,14 @@ public class FlowController {
         @Parameter(description = "If namespace of all provided flows should be overridden") @QueryValue(defaultValue = "false") Boolean override,
         @Parameter(description = "If missing flows should be deleted") @QueryValue(defaultValue = "true") Boolean delete
     ) throws ConstraintViolationException, IOException {
-        List<CompletedFileUpload> flows = Flux.from(flowsPublisher)
+        List<CompletedFileUpload> flowFiles = Flux.from(flowsPublisher)
             .collectList()
             .blockOptional()
             .orElse(Collections.emptyList());
 
         List<GenericFlow> genericFlows = new ArrayList<>();
-        for (CompletedFileUpload flow : flows) {
-            String source = new String(flow.getBytes()).trim();
+        for (CompletedFileUpload flowFile : flowFiles) {
+            String source = new String(flowFile.getBytes()).trim();
             if (override) {
                 source = source.replaceFirst("(?m)^namespace:.+", "namespace: " + namespace);
             }

--- a/webserver/src/test/java/io/kestra/webserver/controllers/api/FlowControllerTest.java
+++ b/webserver/src/test/java/io/kestra/webserver/controllers/api/FlowControllerTest.java
@@ -67,9 +67,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.everyItem;
 import static org.hamcrest.Matchers.nullValue;
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 @KestraTest
 class FlowControllerTest {
@@ -327,6 +325,106 @@ class FlowControllerTest {
                     .contentType(MediaType.APPLICATION_YAML),
                 Argument.listOf(FlowWithSource.class)
             );
+        assertThat(updated.size()).isEqualTo(3);
+
+        client.toBlocking().exchange(DELETE("/api/v1/main/flows/io.kestra.updatenamespace/flow1"));
+        client.toBlocking().exchange(DELETE("/api/v1/main/flows/io.kestra.updatenamespace/flow2"));
+        client.toBlocking().exchange(DELETE("/api/v1/main/flows/io.kestra.updatenamespace/flow3"));
+    }
+
+    @Test
+    void updateFlowInNamespaceUsingMultipart() throws IOException {
+        // Create one flow file
+        String flow = generateFlowAsString("flow1", "io.kestra.updatenamespace", "a");
+        File flowFile = File.createTempFile("flow1", ".yaml");
+        Files.writeString(flowFile.toPath(), flow);
+
+        // Construct request body
+        MultipartBody body = MultipartBody.builder()
+            .addPart("flows", flowFile.getName(), MediaType.APPLICATION_YAML_TYPE, flowFile)
+            .build();
+
+        // Send request
+        List<FlowWithSource> updated = client.toBlocking().retrieve(
+            HttpRequest.POST("/api/v1/main/flows/io.kestra.updatenamespace", body)
+                .contentType(MediaType.MULTIPART_FORM_DATA),
+            Argument.listOf(FlowWithSource.class)
+        );
+
+        assertThat(updated.size()).isEqualTo(1);
+
+        client.toBlocking().exchange(DELETE("/api/v1/main/flows/io.kestra.updatenamespace/flow1"));
+    }
+
+    @Test
+    void updateFlowsInNamespaceUsingMultipart() throws IOException {
+        // Create multiple flow files and add them to body
+        MultipartBody.Builder bodyBuilder = MultipartBody.builder();
+        for (int i = 1; i <= 3; i++) {
+            String flow = generateFlowAsString("flow" + i, "io.kestra.updatenamespace", "a");
+            File flowFile = File.createTempFile("flow" + i, ".yaml");
+            Files.writeString(flowFile.toPath(), flow);
+
+            bodyBuilder.addPart("flows", flowFile.getName(), MediaType.APPLICATION_YAML_TYPE, flowFile);
+        }
+
+        // Send request
+        List<FlowWithSource> updated = client.toBlocking().retrieve(
+            HttpRequest.POST("/api/v1/main/flows/io.kestra.updatenamespace", bodyBuilder.build())
+                .contentType(MediaType.MULTIPART_FORM_DATA),
+            Argument.listOf(FlowWithSource.class)
+        );
+
+        assertThat(updated.size()).isEqualTo(3);
+
+        client.toBlocking().exchange(DELETE("/api/v1/main/flows/io.kestra.updatenamespace/flow1"));
+        client.toBlocking().exchange(DELETE("/api/v1/main/flows/io.kestra.updatenamespace/flow2"));
+        client.toBlocking().exchange(DELETE("/api/v1/main/flows/io.kestra.updatenamespace/flow3"));
+    }
+
+    @Test
+    void updateFlowsInIncorrectNamespaceUsingMultipart() throws IOException {
+        // Create multiple flow files and add them to body
+        MultipartBody.Builder bodyBuilder = MultipartBody.builder();
+        for (int i = 1; i <= 3; i++) {
+            String flow = generateFlowAsString("flow" + i, "io.kestra.randomnamespace", "a");
+            File flowFile = File.createTempFile("flow" + i, ".yaml");
+            Files.writeString(flowFile.toPath(), flow);
+
+            bodyBuilder.addPart("flows", flowFile.getName(), MediaType.APPLICATION_YAML_TYPE, flowFile);
+        }
+
+        // Send request and catch exception
+        HttpClientResponseException exception = assertThrows(HttpClientResponseException.class, () ->
+            client.toBlocking().retrieve(
+                HttpRequest.POST("/api/v1/main/flows/io.kestra.updatenamespace", bodyBuilder.build())
+                    .contentType(MediaType.MULTIPART_FORM_DATA),
+                Argument.listOf(FlowWithSource.class)
+            )
+        );
+
+        assertTrue(exception.getMessage().contains("flow namespace is invalid"));
+    }
+
+    @Test
+    void updateFlowsInNamespaceWithOverrideUsingMultipart() throws IOException {
+        // Create multiple flow files and add them to body
+        MultipartBody.Builder bodyBuilder = MultipartBody.builder();
+        for (int i = 1; i <= 3; i++) {
+            String flow = generateFlowAsString("flow" + i, "io.kestra.randomnamespace", "a");
+            File flowFile = File.createTempFile("flow" + i, ".yaml");
+            Files.writeString(flowFile.toPath(), flow);
+
+            bodyBuilder.addPart("flows", flowFile.getName(), MediaType.APPLICATION_YAML_TYPE, flowFile);
+        }
+
+        // Send request
+        List<FlowWithSource> updated = client.toBlocking().retrieve(
+            HttpRequest.POST("/api/v1/main/flows/io.kestra.updatenamespace?override=true", bodyBuilder.build())
+                .contentType(MediaType.MULTIPART_FORM_DATA),
+            Argument.listOf(FlowWithSource.class)
+        );
+
         assertThat(updated.size()).isEqualTo(3);
 
         client.toBlocking().exchange(DELETE("/api/v1/main/flows/io.kestra.updatenamespace/flow1"));


### PR DESCRIPTION
### ✨ Description

Hey,

I took a look at the `flow namespace update` CLI command and would like to discuss possible improvements with you.
Previously it read all flow files, concatenated them into one big YAML multi-document string, and sent that as the request body.
It seemed to me that this wasn't exactly the ideal way to provide data to the backend from the CLI.

So, I moved most of the logic from CLI to the backend. Now the CLI just builds a multipart body and sends individual YAML files instead of the concatenated string. The backend has a new multipart endpoint that reads each file separately and can replace namespaces when the override query parameter is passed from CLI - this logic has also been moved from the CLI to the backend, as the CLI no longer manipulates YAML files in any way.
From my point of view, this is also better for cases where someone would like to use only the API without the CLI for their work - now all the logic happens on the backend, which seems like the right approach to me.

Everything else works basically the same, but this opens up possibilities for better validation and error reporting back to the CLI, which is something I'd like to work on next - it is kind of related to #7132.
This is kind of a "showcase PR" so I can discuss with you guys possibilities with this approach and show you how I'm thinking about it.

If you're cool with this approach, I'd like to use the same pattern for `flow validate` and other commands where it makes sense.
I would also like to use these changes as a basis for improving how validation or parsing errors are reported back to the CLI, thus enabling better observability.

**I mention this potential breaking change:**
CLI performed flows expansion using a long-deprecated function (`IncludeHelperExpander`) as one of its steps. I have now completely removed this step because, in my opinion, it is no longer relevant, but it can of course be implemented in the backend.

As for the API, the old YAML string endpoint still works btw.

What do you think about these changes? Do they make sense to you?

### 🔗 Related Issue

Kind of relates to #7132.

### 🛠️ Backend Checklist

- [x] Code compiles successfully and passes all checks
- [x] All unit and integration tests pass

### 📝 Additional Notes

I manually tested the changes and everything seems to be working. I simulated scenarios with both valid and invalid flows.
