### PR TITLE
refactor(ui): use $t() in dashboard Header template

### DIFF
--- a/ui/src/components/dashboard/components/Header.vue
+++ b/ui/src/components/dashboard/components/Header.vue
@@ -1,7 +1,7 @@
 <template>
     <TopNavBar
         :title="routeInfo.title"
-        :breadcrumb="[{label: t('dashboards.labels.singular'), link: undefined}]"
+        :breadcrumb="[{label: $t('dashboards.labels.singular'), link: undefined}]"
         :description="props.dashboard?.description"
     >
         <template v-if="isAllowed" #additional-right>
@@ -21,14 +21,14 @@
                         :to="{name: 'dashboards/update', params: {id: props.dashboard?.id}}"
                     >
                         <el-button :icon="Pencil">
-                            {{ t("dashboards.edition.label") }}
+                            {{ $t("dashboards.edition.label") }}
                         </el-button>
                     </router-link>
                 </li>
                 <li>
                     <router-link :to="{name: 'flows/create'}">
                         <el-button :icon="Plus" type="primary">
-                            {{ t("create_flow") }}
+                            {{ $t("create_flow") }}
                         </el-button>
                     </router-link>
                 </li>


### PR DESCRIPTION
Closes: https://github.com/kestra-io/kestra/issues/13896

### Description

This PR uniformizes the translation usage in the dashboard Header component by replacing all `t('...')` calls with `$t('...')` in the `<template>` section. Since `createI18n` automatically exposes the `$t` helper to templates, this change ensures consistency across the codebase.