### PR TITLE
chore(ui): replace t() with $t() in Namespaces.vue template

### DIFF
--- a/ui/src/override/components/namespaces/Namespaces.vue
+++ b/ui/src/override/components/namespaces/Namespaces.vue
@@ -3,7 +3,7 @@
         <template #additional-right>
             <Action
                 v-if="!isOSS && canCreate"
-                :label="t('create')"
+                :label="$t('create')"
                 :to="{name: 'namespaces/create', params: {tab: 'edit'}}"
             />
         </template>
@@ -26,7 +26,7 @@
         />
 
         <el-col v-if="namespaces.length === 0" class="p-3 namespaces">
-            <span>{{ t("no_namespaces") }}</span>
+            <span>{{ $t("no_namespaces") }}</span>
         </el-col>
 
         <el-col
@@ -60,7 +60,7 @@
                             </span>
                             <slot name="description" :namespace="data" />
                             <span v-if="data.system" class="system">
-                                {{ t("system_namespace") }}
+                                {{ $t("system_namespace") }}
                             </span>
                         </div>
                         <el-button size="small">


### PR DESCRIPTION
### ✨ Description

This PR uniforms translation usage in the `Namespaces.vue` component by replacing all `t('...')` calls with `$t('...')` in the `<template>` section. This aligns with the project's i18n best practices, as `$t` is automatically exposed to Vue templates by the `createI18n` function.

### 🔗 Related Issue

Closes #14112

### 🎨 Frontend Checklist

- [x] Code builds without errors (`npm run build`)
- [ ] All existing E2E tests pass - _Not run locally; will be validated by CI_
- [ ] Screenshots or video recordings - _No visual changes; refactoring only_

### 🛠️ Backend Checklist

_This PR does not include any backend changes._

