### PR TITLE
chore(ui): uniform use of $t in template section for BookmarkLink.vue

### DIFF
--- a/ui/src/components/layout/BookmarkLink.vue
+++ b/ui/src/components/layout/BookmarkLink.vue
@@ -22,11 +22,11 @@
                 <div class="buttons">
                     <PencilOutline
                         @click.stop.prevent="startEditBookmark"
-                        :title="t('edit')"
+                        :title="$t('edit')"
                     />
                     <DeleteOutline
                         @click.prevent="deleteBookmark"
-                        :title="t('delete')"
+                        :title="$t('delete')"
                     />
                 </div>
             </a>


### PR DESCRIPTION
### ✨ Description

Replaces the use of t() with $t() inside of `BookmarkLink.vue` to ensure consistent use of $t() for translations.

### 🔗 Related Issue

Closes https://github.com/kestra-io/kestra/issues/14107

### 🎨 Frontend Checklist

_If this PR does not include any frontend changes, delete this entire section._

- [x] Code builds without errors (`npm run build`)
- [x] All existing E2E tests pass (`npm run test:e2e`)
- [x] Screenshots or video recordings attached showing the `UI` changes

<img width="273" height="262" alt="image" src="https://github.com/user-attachments/assets/3d510c9a-3b71-4269-b703-ac6f6cb4a05e" />

Edit tooltip (English)

<img width="319" height="336" alt="image" src="https://github.com/user-attachments/assets/4c4c3e90-8514-47a7-83a4-c91dc7549495" />

Edit tooltip (German)
