### PR TITLE
fix(ui): display ForEach iteration values in Outputs view

### DIFF
--- a/ui/src/components/executions/outputs/Wrapper.vue
+++ b/ui/src/components/executions/outputs/Wrapper.vue
@@ -34,8 +34,10 @@
                                         onlyIcon
                                     />
                                     <span :class="{'ms-3': data.icon}">
-                                        {{ data.label }}
-                                        <small v-if="data.iterationValue !== undefined && data.iterationValue !== null"> {{ data.iterationValue }}</small>
+                                        <span>{{ data.label }}</span>
+                                        <small v-if="data.iterationValue != null">
+                                            {{ data.iterationValue }}
+                                        </small>
                                     </span>
                                 </div>
                                 <code>
@@ -380,12 +382,11 @@
     };
     const outputs = computed(() => {
         const tasks = executionsStore?.execution?.taskRunList?.map((task) => {
-            // For ForEach tasks, store the iteration value separately to display like Gantt view
             return {
-                ...task,
                 label: task.taskId,
                 value: task.taskId,
-                iterationValue: task.value,
+                ...task,
+                iterationValue: task.value, // For ForEach tasks, store the iteration value separately to display like Gantt view
                 icon: true,
                 children: task?.outputs
                     ? transform(task.outputs, true, task.taskId)

--- a/ui/src/components/executions/outputs/Wrapper.vue
+++ b/ui/src/components/executions/outputs/Wrapper.vue
@@ -33,9 +33,10 @@
                                         :cls="icons[data.taskId]"
                                         onlyIcon
                                     />
-                                    <span :class="{'ms-3': data.icon}">{{
-                                        data.label
-                                    }}</span>
+                                    <span :class="{'ms-3': data.icon}">
+                                        {{ data.label }}
+                                        <small v-if="data.iterationValue !== undefined && data.iterationValue !== null"> {{ data.iterationValue }}</small>
+                                    </span>
                                 </div>
                                 <code>
                                     <span
@@ -379,10 +380,12 @@
     };
     const outputs = computed(() => {
         const tasks = executionsStore?.execution?.taskRunList?.map((task) => {
+            // For ForEach tasks, store the iteration value separately to display like Gantt view
             return {
+                ...task,
                 label: task.taskId,
                 value: task.taskId,
-                ...task,
+                iterationValue: task.value,
                 icon: true,
                 children: task?.outputs
                     ? transform(task.outputs, true, task.taskId)


### PR DESCRIPTION
###  Description

Adds iteration identifiers to ForEach task outputs in the Outputs view, making each iteration distinguishable. Previously, all ForEach iterations showed the same task ID, making navigation difficult.

##Changes:
- Modified `Wrapper.vue` to display iteration values in a `<small>` tag alongside task IDs
- Follows the same pattern as the existing Gantt view for UI consistency

### Related Issue

Closes #14071

### Frontend Checklist

- [x] Code builds without errors (`npm run build`)
- [x] Linting passes (`npm run lint`)
- [x] TypeScript compilation clean (`npm run check:types`)
- [x] Screenshots showing UI changes (see below)

### Visual Changes

Before: All ForEach iterations showed identical task IDs
After: Each iteration displays with its value

[
<img width="1440" height="858" alt="Screenshot 2026-01-12 at 11 16 30 pm" src="https://github.com/user-attachments/assets/38ae86ef-2a86-4ded-93ae-f95ac3c4e155" />
]


As shown in the screenshot, the Outputs view now displays:
- `output 0`
- `output 1`
- `output 2`
- etc.

Each iteration is clearly identifiable with its value displayed in smaller text, matching the Gantt view's behavior.

### Implementation Details

This implementation mirrors the existing Gantt view pattern:

Gantt View (existing):
```vue
<code>{{ item.name }}</code>
<small v-if="item.task && item.task.value"> {{ item.task.value }}</small>
Outputs View (this PR):
{{ data.label }}
<small v-if="data.iterationValue !== undefined && data.iterationValue !== null"> {{ data.iterationValue }}</small>
