### PR TITLE
Replace YAML string body with multipart in flows validate

### DIFF
--- a/cli/src/main/java/io/kestra/cli/AbstractValidateCommand.java
+++ b/cli/src/main/java/io/kestra/cli/AbstractValidateCommand.java
@@ -9,34 +9,34 @@ import io.micronaut.http.HttpRequest;
 import io.micronaut.http.MediaType;
 import io.micronaut.http.MutableHttpRequest;
 import io.micronaut.http.client.exceptions.HttpClientResponseException;
+import io.micronaut.http.client.multipart.MultipartBody;
 import io.micronaut.http.client.netty.DefaultHttpClient;
 import jakarta.inject.Inject;
+import jakarta.validation.ConstraintViolationException;
 import picocli.CommandLine;
 
-import java.io.IOException;
-import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
-import java.util.stream.Collectors;
-import jakarta.validation.ConstraintViolationException;
+import java.util.stream.Stream;
 
 import static io.kestra.core.utils.Rethrow.throwConsumer;
-import static io.kestra.core.utils.Rethrow.throwFunction;
 
 public abstract class AbstractValidateCommand extends AbstractApiCommand {
-    @CommandLine.Option(names = {"--local"}, description = "If validation should be done locally or using a remote server", defaultValue = "false")
-    protected boolean local;
-
-    @CommandLine.Parameters(index = "0", description = "the directory containing files to check")
+    @CommandLine.Parameters(index = "0", description = "The directory containing files to check")
     protected Path directory;
+
+    @CommandLine.Option(names = {"--local"}, description = "Whether validation should be done locally or using a remote server", defaultValue = "false")
+    protected boolean local;
 
     @Inject
     private TenantIdSelectorService tenantService;
 
-    /** {@inheritDoc} **/
+    /**
+     * {@inheritDoc}
+     **/
     @Override
     protected boolean loadExternalPlugins() {
         return local;
@@ -48,7 +48,7 @@ public abstract class AbstractValidateCommand extends AbstractApiCommand {
             .forEach(constraintViolation -> {
                 stdErr(
                     "\t- @|bold,yellow {0} : {1} |@",
-                    constraintViolation.getMessage().replace("\n"," - "),
+                    constraintViolation.getMessage().replace("\n", " - "),
                     constraintViolation.getPropertyPath()
                 );
             });
@@ -62,21 +62,12 @@ public abstract class AbstractValidateCommand extends AbstractApiCommand {
         );
     }
 
-    public static void handleValidateConstraintViolation(ValidateConstraintViolation validateConstraintViolation, String resource){
+    public static void handleValidateConstraintViolation(ValidateConstraintViolation validateConstraintViolation, String resource) {
         stdErr("\t@|fg(red) Unable to parse {0}s due to the following error:|@", resource);
         stdErr(
             "\t- @|bold,yellow {0}|@",
             validateConstraintViolation.getConstraints()
         );
-    }
-
-    public static String buildYamlBody(Path directory) throws IOException {
-        try(var files = Files.walk(directory)) {
-            return files.filter(Files::isRegularFile)
-                .filter(YamlParser::isValidExtension)
-                .map(throwFunction(path -> Files.readString(path, Charset.defaultCharset())))
-                .collect(Collectors.joining("\n---\n"));
-        }
     }
 
     // bug in micronaut, we can't inject ModelValidator, so we inject from implementation
@@ -92,52 +83,68 @@ public abstract class AbstractValidateCommand extends AbstractApiCommand {
         AtomicInteger returnCode = new AtomicInteger(0);
         String clsName = cls.getSimpleName().toLowerCase();
 
-        if(this.local) {
-            try(var files = Files.walk(directory)) {
-                files.filter(Files::isRegularFile)
-                    .filter(YamlParser::isValidExtension)
-                    .forEach(path -> {
-                        try {
-                            Object parse = YamlParser.parse(path.toFile(), cls);
-                            modelValidator.validate(parse);
-                            stdOut("@|green \u2713|@ - " + identity.apply(parse));
-                            List<String> warnings = warningsFunction.apply(parse);
-                            warnings.forEach(warning -> stdOut("@|bold,yellow \u26A0|@ - " + warning));
-                            List<String> infos = infosFunction.apply(parse);
-                            infos.forEach(info -> stdOut("@|bold,blue \u2139|@ - " + info));
-                        } catch (ConstraintViolationException e) {
-                            stdErr("@|red \u2718|@ - " + path);
-                            AbstractValidateCommand.handleException(e, clsName);
-                            returnCode.set(1);
-                        }
-                    });
+        try (Stream<Path> files = Files.walk(directory)) {
+            List<Path> flows = files
+                .filter(Files::isRegularFile)
+                .filter(YamlParser::isValidExtension)
+                .toList();
+
+            // At least one flow file is expected for update
+            if (flows.isEmpty()) {
+                stdErr("No flow found in ''{0}''!", directory.toFile().getAbsolutePath());
+                return 1;
             }
-        } else {
-            String body = AbstractValidateCommand.buildYamlBody(directory);
 
-            try(DefaultHttpClient client = client()) {
-                MutableHttpRequest<String> request = HttpRequest
-                    .POST(apiUri("/flows/validate", tenantService.getTenantIdAndAllowEETenants(tenantId)), body).contentType(MediaType.APPLICATION_YAML);
+            if (this.local) {
+                // Perform local validation
+                flows.forEach(flow -> {
+                    try {
+                        Object parse = YamlParser.parse(flow.toFile(), cls);
+                        modelValidator.validate(parse);
 
-                List<ValidateConstraintViolation> validations = client.toBlocking().retrieve(
-                    this.requestOptions(request),
-                    Argument.listOf(ValidateConstraintViolation.class)
-                );
+                        stdOut("@|green \u2713|@ - {0}", identity.apply(parse));
 
-                validations
-                    .forEach(throwConsumer(validation -> {
+                        List<String> warnings = warningsFunction.apply(parse);
+                        warnings.forEach(warning -> stdOut("@|bold,yellow \u26A0|@ - {0}", warning));
+
+                        List<String> infos = infosFunction.apply(parse);
+                        infos.forEach(info -> stdOut("@|bold,blue \u2139|@ - {0}", info));
+                    } catch (ConstraintViolationException e) {
+                        stdErr("@|red \u2718|@ - {0}", flow);
+                        AbstractValidateCommand.handleException(e, clsName);
+                        returnCode.set(1);
+                    }
+                });
+            } else {
+                // Build multipart body with all available flow files
+                MultipartBody.Builder bodyBuilder = MultipartBody.builder();
+                flows.forEach(flow -> bodyBuilder.addPart("flows", flow.toFile().getName(), MediaType.APPLICATION_YAML_TYPE, flow.toFile()));
+
+                // Call validate API
+                try (DefaultHttpClient client = client()) {
+                    MutableHttpRequest<MultipartBody> request = HttpRequest.POST(
+                        apiUri("/flows/validate", tenantService.getTenantIdAndAllowEETenants(tenantId)),
+                        bodyBuilder.build()
+                    ).contentType(MediaType.MULTIPART_FORM_DATA);
+
+                    List<ValidateConstraintViolation> validations = client.toBlocking().retrieve(
+                        this.requestOptions(request),
+                        Argument.listOf(ValidateConstraintViolation.class)
+                    );
+
+                    validations.forEach(throwConsumer(validation -> {
                         if (validation.getConstraints() == null) {
-                            stdOut("@|green \u2713|@ - " + validation.getIdentity());
+                            stdOut("@|green \u2713|@ - {0}", validation.getIdentity());
                         } else {
-                            stdErr("@|red \u2718|@ - " + validation.getIdentity(directory));
+                            stdErr("@|red \u2718|@ - {0}", validation.getIdentity());
                             AbstractValidateCommand.handleValidateConstraintViolation(validation, clsName);
                             returnCode.set(1);
                         }
                     }));
-            } catch (HttpClientResponseException e){
-                AbstractValidateCommand.handleHttpException(e, clsName);
-
-                return 1;
+                } catch (HttpClientResponseException e) {
+                    AbstractValidateCommand.handleHttpException(e, clsName);
+                    return 1;
+                }
             }
         }
 

--- a/cli/src/main/java/io/kestra/cli/commands/flows/FlowValidateCommand.java
+++ b/cli/src/main/java/io/kestra/cli/commands/flows/FlowValidateCommand.java
@@ -16,7 +16,6 @@ import java.util.List;
     description = "Validate a flow"
 )
 public class FlowValidateCommand extends AbstractValidateCommand {
-
     @Inject
     private ModelValidator modelValidator;
 
@@ -26,7 +25,6 @@ public class FlowValidateCommand extends AbstractValidateCommand {
     @Inject
     private TenantIdSelectorService tenantIdSelectorService;
 
-
     @Override
     public Integer call() throws Exception {
         return this.call(
@@ -34,7 +32,7 @@ public class FlowValidateCommand extends AbstractValidateCommand {
             modelValidator,
             (Object object) -> {
                 FlowWithSource flow = (FlowWithSource) object;
-                return flow.getNamespace() + " / " + flow.getId();
+                return flow.getNamespace() + "." + flow.getId();
             },
             (Object object) -> {
                 FlowWithSource flow = (FlowWithSource) object;

--- a/cli/src/test/java/io/kestra/cli/commands/flows/FlowValidateCommandTest.java
+++ b/cli/src/test/java/io/kestra/cli/commands/flows/FlowValidateCommandTest.java
@@ -23,7 +23,7 @@ class FlowValidateCommandTest {
             Integer call = PicocliRunner.call(FlowValidateCommand.class, ctx, args);
 
             assertThat(call).isZero();
-            assertThat(out.toString()).contains("✓ - io.kestra.cli / include");
+            assertThat(out.toString()).contains("✓ - io.kestra.cli.include");
         }
     }
 
@@ -43,7 +43,7 @@ class FlowValidateCommandTest {
             Integer call = PicocliRunner.call(FlowValidateCommand.class, ctx, args);
 
             assertThat(call).isZero();
-            assertThat(out.toString()).contains("✓ - io.kestra.cli / include");
+            assertThat(out.toString()).contains("✓ - io.kestra.cli.include");
         }
     }
 
@@ -60,7 +60,7 @@ class FlowValidateCommandTest {
             Integer call = PicocliRunner.call(FlowValidateCommand.class, ctx, args);
 
             assertThat(call).isZero();
-            assertThat(out.toString()).contains("✓ - system / warning");
+            assertThat(out.toString()).contains("✓ - system.warning");
             assertThat(out.toString()).contains("⚠ - tasks[0] is deprecated");
             assertThat(out.toString()).contains("ℹ - io.kestra.core.tasks.log.Log is replaced by io.kestra.plugin.core.log.Log");
         }

--- a/core/src/main/java/io/kestra/core/models/flows/FlowSource.java
+++ b/core/src/main/java/io/kestra/core/models/flows/FlowSource.java
@@ -1,0 +1,17 @@
+package io.kestra.core.models.flows;
+
+import jakarta.annotation.Nullable;
+
+/**
+ * Represents a flow source code with an optional filename.
+ * Used for flow validation where the source can come from a single YAML string
+ * (potentially containing multiple documents separated by ---) or from uploaded files.
+ *
+ * @param filename Optional filename, null when validating raw YAML strings
+ * @param content  The flow source code in YAML format
+ */
+public record FlowSource(
+    @Nullable String filename,
+    String content
+) {
+}

--- a/core/src/main/java/io/kestra/core/models/validations/ValidateConstraintViolation.java
+++ b/core/src/main/java/io/kestra/core/models/validations/ValidateConstraintViolation.java
@@ -2,18 +2,11 @@ package io.kestra.core.models.validations;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.micronaut.core.annotation.Introspected;
-import lombok.AllArgsConstructor;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.ToString;
+import jakarta.validation.constraints.NotNull;
+import lombok.*;
 import lombok.experimental.SuperBuilder;
 import lombok.extern.slf4j.Slf4j;
 
-import jakarta.validation.constraints.NotNull;
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
 import java.util.List;
 
 @SuperBuilder(toBuilder = true)
@@ -25,12 +18,12 @@ import java.util.List;
 @Slf4j
 @EqualsAndHashCode
 public class ValidateConstraintViolation {
-    private String flow;
-
-    private String namespace;
-
     @NotNull
     private int index;
+    private String filename;
+
+    private String namespace;
+    private String flow;
 
     private String constraints;
     private boolean outdated;
@@ -39,23 +32,12 @@ public class ValidateConstraintViolation {
     private List<String> infos;
 
     @JsonIgnore
-    public String getIdentity(){
-        return flow != null && namespace != null ? getFlowId() : flow != null ? flow : String.valueOf(index);
+    public String getIdentity() {
+        return (namespace != null && flow != null) ? getFlowId() : (flow != null) ? flow : (filename != null) ? filename : String.valueOf(index);
     }
 
     @JsonIgnore
-    public String getIdentity(Path directory) throws IOException {
-        return flow != null && namespace != null ? getFlowId() : flow != null ? flow : getPath(directory);
-    }
-
-    private String getPath(Path directory) throws IOException {
-        try (var files = Files.walk(directory)) {
-            return String.valueOf(files.toList().get(index));
-        }
-    }
-
-    @JsonIgnore
-    public String getFlowId(){
-        return namespace+"."+flow;
+    public String getFlowId() {
+        return namespace + "." + flow;
     }
 }

--- a/core/src/main/java/io/kestra/core/services/FlowService.java
+++ b/core/src/main/java/io/kestra/core/services/FlowService.java
@@ -19,7 +19,6 @@ import io.kestra.core.runners.RunContextFactory;
 import io.kestra.core.serializers.JacksonMapper;
 import io.kestra.core.utils.ListUtils;
 import io.kestra.plugin.core.flow.Pause;
-import io.micronaut.http.multipart.CompletedFileUpload;
 import jakarta.inject.Inject;
 import jakarta.inject.Provider;
 import jakarta.inject.Singleton;
@@ -28,7 +27,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.ClassUtils;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 
-import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
@@ -149,81 +147,22 @@ public class FlowService {
     }
 
     /**
-     * Validates the given flow source.
-     * <p>
-     * the YAML source can contain one or many objects.
+     * Validates the given flow sources.
      *
-     * @param tenantId The tenant identifier.
-     * @param flows    The YAML source.
-     * @return The list validation constraint violations.
-     */
-    public List<ValidateConstraintViolation> validate(final String tenantId, final String flows) {
-        AtomicInteger index = new AtomicInteger(0);
-        return Stream
-            .of(flows.split("\\n+---\\n*?"))
-            .map(source -> {
-                ValidateConstraintViolation.ValidateConstraintViolationBuilder<?, ?> validateConstraintViolationBuilder = ValidateConstraintViolation.builder();
-                validateConstraintViolationBuilder.index(index.getAndIncrement());
-
-                try {
-                    FlowWithSource flow = pluginDefaultService.parseFlowWithVersionDefaults(tenantId, source, true);
-                    Integer sentRevision = flow.getRevision();
-                    if (sentRevision != null) {
-                        Integer lastRevision = Optional.ofNullable(repository().lastRevision(tenantId, flow.getNamespace(), flow.getId()))
-                            .orElse(0);
-                        validateConstraintViolationBuilder.outdated(!sentRevision.equals(lastRevision + 1));
-                    }
-
-                    validateConstraintViolationBuilder.deprecationPaths(deprecationPaths(flow));
-                    validateConstraintViolationBuilder.warnings(warnings(flow, tenantId));
-                    validateConstraintViolationBuilder.infos(relocations(source).stream().map(relocation -> relocation.from() + " is replaced by " + relocation.to()).toList());
-                    validateConstraintViolationBuilder.flow(flow.getId());
-                    validateConstraintViolationBuilder.namespace(flow.getNamespace());
-
-                    // Do not perform a strict parsing validation to ignore unknown
-                    // properties that might be injecting through default values.
-                    modelValidator.validate(pluginDefaultService.injectAllDefaults(flow, false));
-
-                } catch (ConstraintViolationException e) {
-                    String friendlyMessage = formatValidationError(e.getMessage());
-                    validateConstraintViolationBuilder.constraints(friendlyMessage);
-                } catch (FlowProcessingException e) {
-                    if (e.getCause() instanceof ConstraintViolationException cve) {
-                        String friendlyMessage = formatValidationError(cve.getMessage());
-                        validateConstraintViolationBuilder.constraints(friendlyMessage);
-                    } else {
-                        Throwable cause = e.getCause() != null ? e.getCause() : e;
-                        validateConstraintViolationBuilder.constraints("Unable to validate the flow: " + cause.getMessage());
-                    }
-                } catch (RuntimeException re) {
-                    // In case of any error, we add a validation violation so the error is displayed in the UI.
-                    // We may change that by throwing an internal error and handle it in the UI, but this should not occur except for rare cases
-                    // in dev like incompatible plugin versions.
-                    log.error("Unable to validate the flow", re);
-                    validateConstraintViolationBuilder.constraints("Unable to validate the flow: " + re.getMessage());
-                }
-                return validateConstraintViolationBuilder.build();
-            })
-            .collect(Collectors.toList());
-    }
-
-    /**
-     * Validates the given flow files.
-     *
-     * @param tenantId  The tenant identifier.
-     * @param flowFiles The YAML files to validate.
+     * @param tenantId    The tenant identifier.
+     * @param flowSources The flow sources to validate.
      * @return The list of validation constraint violations.
      */
-    public List<ValidateConstraintViolation> validate(final String tenantId, final List<CompletedFileUpload> flowFiles) {
+    public List<ValidateConstraintViolation> validate(final String tenantId, final List<FlowSource> flowSources) {
         AtomicInteger index = new AtomicInteger(0);
         List<ValidateConstraintViolation> constraints = new ArrayList<>();
-        flowFiles.forEach(flowFile -> {
+        flowSources.forEach(flowSource -> {
             ValidateConstraintViolation.ValidateConstraintViolationBuilder<?, ?> constraintsBuilder = ValidateConstraintViolation.builder();
             constraintsBuilder.index(index.getAndIncrement());
-            constraintsBuilder.filename(flowFile.getFilename());
+            constraintsBuilder.filename(flowSource.filename());
 
             try {
-                String source = new String(flowFile.getBytes()).trim();
+                String source = flowSource.content();
                 FlowWithSource flow = pluginDefaultService.parseFlowWithVersionDefaults(tenantId, source, true);
 
                 Integer sentRevision = flow.getRevision();
@@ -252,8 +191,6 @@ public class FlowService {
                     Throwable cause = e.getCause() != null ? e.getCause() : e;
                     constraintsBuilder.constraints("Unable to validate the flow: " + cause.getMessage());
                 }
-            } catch (IOException e) {
-                throw new RuntimeException(e);
             } catch (RuntimeException e) {
                 // In case of any error, we add a validation violation so the error is displayed in the UI.
                 // We may change that by throwing an internal error and handle it in the UI, but this should not occur except for rare cases

--- a/core/src/main/java/io/kestra/core/services/FlowService.java
+++ b/core/src/main/java/io/kestra/core/services/FlowService.java
@@ -19,6 +19,7 @@ import io.kestra.core.runners.RunContextFactory;
 import io.kestra.core.serializers.JacksonMapper;
 import io.kestra.core.utils.ListUtils;
 import io.kestra.plugin.core.flow.Pause;
+import io.micronaut.http.multipart.CompletedFileUpload;
 import jakarta.inject.Inject;
 import jakarta.inject.Provider;
 import jakarta.inject.Singleton;
@@ -27,6 +28,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.ClassUtils;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 
+import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
@@ -92,6 +94,7 @@ public class FlowService {
         return flowRepository
             .orElseThrow(() -> new IllegalStateException("Cannot perform operation on flow. Cause: No FlowRepository"));
     }
+
     private static String formatValidationError(String message) {
         if (message.startsWith("Illegal flow source:")) {
             // Already formatted by YamlParser, return as-is
@@ -100,6 +103,7 @@ public class FlowService {
         // For other validation errors, provide context
         return "Validation error: " + message;
     }
+
     /**
      * Evaluates all checks defined in the given flow using the provided inputs.
      * <p>
@@ -132,9 +136,9 @@ public class FlowService {
                     );
                     falseConditions.add(Check
                         .builder()
-                            .message("Failed to evaluate check condition. Cause: " + e.getMessage())
-                            .behavior(Check.Behavior.BLOCK_EXECUTION)
-                            .style(Check.Style.ERROR)
+                        .message("Failed to evaluate check condition. Cause: " + e.getMessage())
+                        .behavior(Check.Behavior.BLOCK_EXECUTION)
+                        .style(Check.Style.ERROR)
                         .build()
                     );
                 }
@@ -149,9 +153,9 @@ public class FlowService {
      * <p>
      * the YAML source can contain one or many objects.
      *
-     * @param tenantId  The tenant identifier.
-     * @param flows     The YAML source.
-     * @return  The list validation constraint violations.
+     * @param tenantId The tenant identifier.
+     * @param flows    The YAML source.
+     * @return The list validation constraint violations.
      */
     public List<ValidateConstraintViolation> validate(final String tenantId, final String flows) {
         AtomicInteger index = new AtomicInteger(0);
@@ -201,6 +205,67 @@ public class FlowService {
                 return validateConstraintViolationBuilder.build();
             })
             .collect(Collectors.toList());
+    }
+
+    /**
+     * Validates the given flow files.
+     *
+     * @param tenantId  The tenant identifier.
+     * @param flowFiles The YAML files to validate.
+     * @return The list of validation constraint violations.
+     */
+    public List<ValidateConstraintViolation> validate(final String tenantId, final List<CompletedFileUpload> flowFiles) {
+        AtomicInteger index = new AtomicInteger(0);
+        List<ValidateConstraintViolation> constraints = new ArrayList<>();
+        flowFiles.forEach(flowFile -> {
+            ValidateConstraintViolation.ValidateConstraintViolationBuilder<?, ?> constraintsBuilder = ValidateConstraintViolation.builder();
+            constraintsBuilder.index(index.getAndIncrement());
+            constraintsBuilder.filename(flowFile.getFilename());
+
+            try {
+                String source = new String(flowFile.getBytes()).trim();
+                FlowWithSource flow = pluginDefaultService.parseFlowWithVersionDefaults(tenantId, source, true);
+
+                Integer sentRevision = flow.getRevision();
+                if (sentRevision != null) {
+                    Integer lastRevision = Optional.ofNullable(repository().lastRevision(tenantId, flow.getNamespace(), flow.getId())).orElse(0);
+                    constraintsBuilder.outdated(!sentRevision.equals(lastRevision + 1));
+                }
+
+                constraintsBuilder.deprecationPaths(deprecationPaths(flow));
+                constraintsBuilder.warnings(warnings(flow, tenantId));
+                constraintsBuilder.infos(relocations(source).stream().map(relocation -> relocation.from() + " is replaced by " + relocation.to()).toList());
+                constraintsBuilder.flow(flow.getId());
+                constraintsBuilder.namespace(flow.getNamespace());
+
+                // Do not perform a strict parsing validation to ignore unknown
+                // properties that might be injecting through default values.
+                modelValidator.validate(pluginDefaultService.injectAllDefaults(flow, false));
+            } catch (ConstraintViolationException e) {
+                String friendlyMessage = formatValidationError(e.getMessage());
+                constraintsBuilder.constraints(friendlyMessage);
+            } catch (FlowProcessingException e) {
+                if (e.getCause() instanceof ConstraintViolationException cve) {
+                    String friendlyMessage = formatValidationError(cve.getMessage());
+                    constraintsBuilder.constraints(friendlyMessage);
+                } else {
+                    Throwable cause = e.getCause() != null ? e.getCause() : e;
+                    constraintsBuilder.constraints("Unable to validate the flow: " + cause.getMessage());
+                }
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            } catch (RuntimeException e) {
+                // In case of any error, we add a validation violation so the error is displayed in the UI.
+                // We may change that by throwing an internal error and handle it in the UI, but this should not occur except for rare cases
+                // in dev like incompatible plugin versions.
+                log.error("Unable to validate the flow", e);
+                constraintsBuilder.constraints("Unable to validate the flow: " + e.getMessage());
+            }
+
+            constraints.add(constraintsBuilder.build());
+        });
+
+        return constraints;
     }
 
     public FlowWithSource importFlow(String tenantId, String source) throws FlowProcessingException {
@@ -544,7 +609,7 @@ public class FlowService {
             throw new IllegalStateException("Requested Flow is disabled.");
         }
 
-        if (flow instanceof FlowWithException fwe ) {
+        if (flow instanceof FlowWithException fwe) {
             throw new IllegalStateException("Requested Flow is not valid. Error: " + fwe.getException());
         }
         return flow;

--- a/core/src/test/java/io/kestra/core/services/FlowServiceTest.java
+++ b/core/src/test/java/io/kestra/core/services/FlowServiceTest.java
@@ -2,11 +2,7 @@ package io.kestra.core.services;
 
 import io.kestra.core.exceptions.FlowProcessingException;
 import io.kestra.core.junit.annotations.KestraTest;
-import io.kestra.core.models.flows.Flow;
-import io.kestra.core.models.flows.FlowInterface;
-import io.kestra.core.models.flows.FlowWithSource;
-import io.kestra.core.models.flows.GenericFlow;
-import io.kestra.core.models.flows.Type;
+import io.kestra.core.models.flows.*;
 import io.kestra.core.models.flows.check.Check;
 import io.kestra.core.models.flows.input.StringInput;
 import io.kestra.core.models.property.Property;
@@ -75,7 +71,7 @@ class FlowServiceTest {
                   uri: https://kestra.io
             """;
         // When
-        List<ValidateConstraintViolation> results = flowService.validate("my-tenant", source);
+        List<ValidateConstraintViolation> results = flowService.validate("my-tenant", List.of(new FlowSource(null, source)));
 
         // Then
         assertThat(results).hasSize(1);
@@ -385,7 +381,7 @@ class FlowServiceTest {
             """;
 
         // When
-        List<ValidateConstraintViolation> results = flowService.validate("my-tenant", source);
+        List<ValidateConstraintViolation> results = flowService.validate("my-tenant", List.of(new FlowSource(null, source)));
 
         // Then
         assertThat(results).hasSize(1);
@@ -401,15 +397,15 @@ class FlowServiceTest {
     void shouldReturnValidationErrorForReservedFlowId() {
         // Given
         String source = """
-        id: pause
-        namespace: io.kestra.unittest
-        tasks:
-          - id: task
-            type: io.kestra.plugin.core.log.Log
-            message: Reserved id test
-        """;
+            id: pause
+            namespace: io.kestra.unittest
+            tasks:
+              - id: task
+                type: io.kestra.plugin.core.log.Log
+                message: Reserved id test
+            """;
         // When
-        List<ValidateConstraintViolation> results = flowService.validate("my-tenant", source);
+        List<ValidateConstraintViolation> results = flowService.validate("my-tenant", List.of(new FlowSource(null, source)));
 
         // Then
         assertThat(results).hasSize(1);

--- a/core/src/test/java/io/kestra/core/services/FlowServiceTest.java
+++ b/core/src/test/java/io/kestra/core/services/FlowServiceTest.java
@@ -79,6 +79,32 @@ class FlowServiceTest {
     }
 
     @Test
+    void shouldReturnTrueWhenValidatingFlowWithFilenameGivenDefaults() {
+        // Given
+        String source = """
+            id: test
+            namespace: io.kestra.unittest
+            tasks:
+              - id: download
+                type: io.kestra.plugin.core.http.Download
+              - id: log
+                type: io.kestra.plugin.core.log.Log
+                message: This is a message
+            pluginDefaults:
+              - type: io.kestra.plugin.core
+                values:
+                  level: WARN
+                  uri: https://kestra.io
+            """;
+        // When
+        List<ValidateConstraintViolation> results = flowService.validate("my-tenant", List.of(new FlowSource("flow.yaml", source)));
+
+        // Then
+        assertThat(results).hasSize(1);
+        assertThat(results.getFirst()).isEqualTo(new ValidateConstraintViolation(0, "flow.yaml", "io.kestra.unittest", "test", null, false, List.of(), List.of(), List.of()));
+    }
+
+    @Test
     void importFlow() throws FlowProcessingException {
         String source = """
             id: import

--- a/core/src/test/java/io/kestra/core/services/FlowServiceTest.java
+++ b/core/src/test/java/io/kestra/core/services/FlowServiceTest.java
@@ -79,7 +79,7 @@ class FlowServiceTest {
 
         // Then
         assertThat(results).hasSize(1);
-        assertThat(results.getFirst()).isEqualTo(new ValidateConstraintViolation("test", "io.kestra.unittest", 0, null, false, List.of(), List.of(), List.of()));
+        assertThat(results.getFirst()).isEqualTo(new ValidateConstraintViolation(0, null, "io.kestra.unittest", "test", null, false, List.of(), List.of(), List.of()));
     }
 
     @Test

--- a/core/src/test/java/io/kestra/core/validations/FlowValidationTest.java
+++ b/core/src/test/java/io/kestra/core/validations/FlowValidationTest.java
@@ -3,6 +3,7 @@ package io.kestra.core.validations;
 import io.kestra.core.models.assets.AssetIdentifier;
 import io.kestra.core.models.assets.AssetsDeclaration;
 import io.kestra.core.models.flows.Flow;
+import io.kestra.core.models.flows.FlowSource;
 import io.kestra.core.models.flows.GenericFlow;
 import io.kestra.core.models.validations.ModelValidator;
 import io.kestra.core.serializers.YamlParser;
@@ -111,10 +112,10 @@ class FlowValidationTest {
                 message: {{ abc }}
 
             """;
-            List<ValidateConstraintViolation> results = flowService.validate("my-tenant", invalidYaml);
+        List<ValidateConstraintViolation> results = flowService.validate("my-tenant", List.of(new FlowSource(null, invalidYaml)));
 
-            assertThat(results).hasSize(1);
-            assertThat(results.getFirst().getConstraints()).contains("YAML parsing error").contains("at line");
+        assertThat(results).hasSize(1);
+        assertThat(results.getFirst().getConstraints()).contains("YAML parsing error").contains("at line");
     }
 
     @Test
@@ -128,7 +129,7 @@ class FlowValidationTest {
                 message: {{ undefinedVar }}
             """;
 
-        List<ValidateConstraintViolation> results = flowService.validate("my-tenant", yamlWithUndefinedVar);
+        List<ValidateConstraintViolation> results = flowService.validate("my-tenant", List.of(new FlowSource(null, yamlWithUndefinedVar)));
 
         assertThat(results).hasSize(1);
         assertThat(results.getFirst().getConstraints()).contains("Validation error");

--- a/webserver/src/main/java/io/kestra/webserver/controllers/api/FlowController.java
+++ b/webserver/src/main/java/io/kestra/webserver/controllers/api/FlowController.java
@@ -58,6 +58,7 @@ import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotEmpty;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
+import org.reactivestreams.Publisher;
 import reactor.core.publisher.Flux;
 
 import java.io.IOException;
@@ -634,6 +635,20 @@ public class FlowController {
         @RequestBody(description = "A list of flows source code in a single string") @Body String flows
     ) {
         return flowService.validate(tenantService.resolveTenant(), flows);
+    }
+
+    @ExecuteOn(TaskExecutors.IO)
+    @Post(uri = "validate", consumes = MediaType.MULTIPART_FORM_DATA)
+    @Operation(tags = {"Flows"}, summary = "Validate a list of flows")
+    public List<ValidateConstraintViolation> validateFlows(
+        @RequestBody(description = "A list of flow files") @Part("flows") Publisher<CompletedFileUpload> flowsPublisher
+    ) {
+        List<CompletedFileUpload> flowFiles = Flux.from(flowsPublisher)
+            .collectList()
+            .blockOptional()
+            .orElse(Collections.emptyList());
+
+        return flowService.validate(tenantService.resolveTenant(), flowFiles);
     }
 
     // This endpoint is not used by the Kestra UI nor our CLI but is provided for the API users for convenience

--- a/webserver/src/main/java/io/kestra/webserver/controllers/api/FlowController.java
+++ b/webserver/src/main/java/io/kestra/webserver/controllers/api/FlowController.java
@@ -634,7 +634,11 @@ public class FlowController {
     public List<ValidateConstraintViolation> validateFlows(
         @RequestBody(description = "A list of flows source code in a single string") @Body String flows
     ) {
-        return flowService.validate(tenantService.resolveTenant(), flows);
+        List<FlowSource> flowSources = Arrays.stream(flows.split("\\n+---\\n*?"))
+            .map(flow -> new FlowSource(null, flow))
+            .toList();
+
+        return flowService.validate(tenantService.resolveTenant(), flowSources);
     }
 
     @ExecuteOn(TaskExecutors.IO)
@@ -642,13 +646,20 @@ public class FlowController {
     @Operation(tags = {"Flows"}, summary = "Validate a list of flows")
     public List<ValidateConstraintViolation> validateFlows(
         @RequestBody(description = "A list of flow files") @Part("flows") Publisher<CompletedFileUpload> flowsPublisher
-    ) {
+    ) throws IOException {
         List<CompletedFileUpload> flowFiles = Flux.from(flowsPublisher)
             .collectList()
             .blockOptional()
             .orElse(Collections.emptyList());
 
-        return flowService.validate(tenantService.resolveTenant(), flowFiles);
+        List<FlowSource> flowSources = new ArrayList<>();
+        for (CompletedFileUpload flowFile : flowFiles) {
+            String source = new String(flowFile.getBytes()).trim();
+
+            flowSources.add(new FlowSource(flowFile.getFilename(), source));
+        }
+
+        return flowService.validate(tenantService.resolveTenant(), flowSources);
     }
 
     // This endpoint is not used by the Kestra UI nor our CLI but is provided for the API users for convenience

--- a/webserver/src/test/java/io/kestra/webserver/controllers/api/FlowControllerTest.java
+++ b/webserver/src/test/java/io/kestra/webserver/controllers/api/FlowControllerTest.java
@@ -67,9 +67,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.everyItem;
 import static org.hamcrest.Matchers.nullValue;
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 @KestraTest
 class FlowControllerTest {
@@ -966,6 +964,178 @@ class FlowControllerTest {
         assertThat(body.getFirst().getDeprecationPaths().getFirst()).isEqualTo("tasks[0]");
         assertThat(body.getFirst().getInfos().size()).isEqualTo(1);
         assertThat(body.getFirst().getInfos().getFirst()).isEqualTo("io.kestra.core.tasks.log.Log is replaced by io.kestra.plugin.core.log.Log");
+    }
+
+    @Test
+    void validateFlowsUsingMultipart() throws URISyntaxException, IOException {
+        // Load first valid flow file
+        URL validResource1 = TestsUtils.class.getClassLoader().getResource("flows/validate/validFlow1.yaml");
+        File validFlowFile1 = new File(Objects.requireNonNull(validResource1).toURI());
+
+        // Save first flow to check outdated status
+        jdbcFlowRepository.create(GenericFlow.fromYaml("main", Files.readString(validFlowFile1.toPath())));
+
+        // Load second valid flow file
+        URL validResource2 = TestsUtils.class.getClassLoader().getResource("flows/validate/validFlow2.yaml");
+        File validFlowFile2 = new File(Objects.requireNonNull(validResource2).toURI());
+
+        // Construct request body
+        MultipartBody body = MultipartBody.builder()
+            .addPart("flows", validFlowFile1.getName(), MediaType.APPLICATION_YAML_TYPE, validFlowFile1)
+            .addPart("flows", validFlowFile2.getName(), MediaType.APPLICATION_YAML_TYPE, validFlowFile2)
+            .build();
+
+        // Send request
+        HttpResponse<List<ValidateConstraintViolation>> response = client.toBlocking().exchange(
+            POST("/api/v1/main/flows/validate", body)
+                .contentType(MediaType.MULTIPART_FORM_DATA),
+            Argument.listOf(ValidateConstraintViolation.class)
+        );
+
+        List<ValidateConstraintViolation> violations = response.body();
+        assertEquals(2, violations.size());
+
+        // Validate first valid flow
+        assertEquals("validFlow1.yaml", violations.getFirst().getFilename());
+        // We don't send any revision while the flow already exists so it's outdated
+        assertTrue(violations.getFirst().isOutdated());
+        assertEquals(3, violations.getFirst().getDeprecationPaths().size());
+        assertThat(violations.getFirst().getDeprecationPaths()).containsExactlyInAnyOrder("tasks[1]", "tasks[1].additionalProperty", "listeners");
+        assertTrue(violations.getFirst().getWarnings().isEmpty());
+        assertTrue(violations.getFirst().getInfos().isEmpty());
+
+        // Validate second valid flow
+        assertEquals("validFlow2.yaml", violations.get(1).getFilename());
+        assertFalse(violations.get(1).isOutdated());
+        assertEquals(2, violations.get(1).getDeprecationPaths().size());
+        assertThat(violations.get(1).getDeprecationPaths()).containsExactlyInAnyOrder("tasks[0]", "tasks[1]");
+        assertTrue(violations.get(1).getWarnings().isEmpty());
+        assertTrue(violations.get(1).getInfos().isEmpty());
+
+        assertThat(violations).extracting("constraints").containsOnlyNulls();
+    }
+
+    @Test
+    void validateFlowsWithInvalidUsingMultipart() throws URISyntaxException, IOException {
+        // Load valid flow file
+        URL validResource = TestsUtils.class.getClassLoader().getResource("flows/validate/validFlow1.yaml");
+        File validFlowFile = new File(Objects.requireNonNull(validResource).toURI());
+
+        // Save first flow to check outdated status
+        jdbcFlowRepository.create(GenericFlow.fromYaml("main", Files.readString(validFlowFile.toPath())));
+
+        // Load invalid flow file
+        URL invalidResource = TestsUtils.class.getClassLoader().getResource("flows/validate/invalidFlow1.yaml");
+        File invalidFlowFile = new File(Objects.requireNonNull(invalidResource).toURI());
+
+        // Construct request body
+        MultipartBody body = MultipartBody.builder()
+            .addPart("flows", validFlowFile.getName(), MediaType.APPLICATION_YAML_TYPE, validFlowFile)
+            .addPart("flows", invalidFlowFile.getName(), MediaType.APPLICATION_YAML_TYPE, invalidFlowFile)
+            .build();
+
+        // Send request
+        HttpResponse<List<ValidateConstraintViolation>> response = client.toBlocking().exchange(
+            POST("/api/v1/main/flows/validate", body)
+                .contentType(MediaType.MULTIPART_FORM_DATA),
+            Argument.listOf(ValidateConstraintViolation.class)
+        );
+
+        List<ValidateConstraintViolation> violations = response.body();
+        assertEquals(2, violations.size());
+
+        // Validate first valid flow
+        assertEquals("validFlow1.yaml", violations.getFirst().getFilename());
+        // We don't send any revision while the flow already exists so it's outdated
+        assertTrue(violations.getFirst().isOutdated());
+        assertEquals(3, violations.getFirst().getDeprecationPaths().size());
+        assertThat(violations.getFirst().getDeprecationPaths()).containsExactlyInAnyOrder("tasks[1]", "tasks[1].additionalProperty", "listeners");
+        assertTrue(violations.getFirst().getWarnings().isEmpty());
+        assertTrue(violations.getFirst().getInfos().isEmpty());
+
+        // Second flow is invalid, so most properties should be null or have default values
+        assertEquals("invalidFlow1.yaml", violations.get(1).getFilename());
+        assertFalse(violations.get(1).isOutdated());
+        assertNull(violations.get(1).getDeprecationPaths());
+        assertNull(violations.get(1).getWarnings());
+        assertNull(violations.get(1).getInfos());
+
+        assertNull(violations.getFirst().getConstraints());
+        assertThat(violations.get(1).getConstraints()).contains("Unrecognized field \"unknownProp\"");
+    }
+
+    @Test
+    void validateInvalidFlowsUsingMultipart() throws URISyntaxException, IOException {
+        // Load first invalid flow file
+        URL invalidResource1 = TestsUtils.class.getClassLoader().getResource("flows/validate/invalidFlow1.yaml");
+        File invalidFlowFile1 = new File(Objects.requireNonNull(invalidResource1).toURI());
+
+        // Save first flow to check outdated status
+        jdbcFlowRepository.create(GenericFlow.fromYaml("main", Files.readString(invalidFlowFile1.toPath())));
+
+        // Load second invalid flow file
+        URL invalidResource2 = TestsUtils.class.getClassLoader().getResource("flows/validate/invalidFlow2.yaml");
+        File invalidFlowFile2 = new File(Objects.requireNonNull(invalidResource2).toURI());
+
+        // Construct request body
+        MultipartBody body = MultipartBody.builder()
+            .addPart("flows", invalidFlowFile1.getName(), MediaType.APPLICATION_YAML_TYPE, invalidFlowFile1)
+            .addPart("flows", invalidFlowFile2.getName(), MediaType.APPLICATION_YAML_TYPE, invalidFlowFile2)
+            .build();
+
+        // Send request
+        HttpResponse<List<ValidateConstraintViolation>> response = client.toBlocking().exchange(
+            POST("/api/v1/main/flows/validate", body)
+                .contentType(MediaType.MULTIPART_FORM_DATA),
+            Argument.listOf(ValidateConstraintViolation.class)
+        );
+
+        List<ValidateConstraintViolation> violations = response.body();
+        assertEquals(2, violations.size());
+
+        // First flow is invalid, so most properties should be null or have default values
+        assertEquals("invalidFlow1.yaml", violations.getFirst().getFilename());
+        assertFalse(violations.getFirst().isOutdated());
+        assertNull(violations.getFirst().getDeprecationPaths());
+        assertNull(violations.getFirst().getWarnings());
+        assertNull(violations.getFirst().getInfos());
+
+        // Second flow is also invalid, so most properties should be null or have default values
+        assertEquals("invalidFlow2.yaml", violations.get(1).getFilename());
+        assertFalse(violations.get(1).isOutdated());
+        assertNull(violations.get(1).getDeprecationPaths());
+        assertNull(violations.get(1).getWarnings());
+        assertNull(violations.get(1).getInfos());
+
+        assertThat(violations.getFirst().getConstraints()).contains("Unrecognized field \"unknownProp\"");
+        assertThat(violations.get(1).getConstraints()).contains("Invalid type: io.kestra.plugin.core.debug.UnknownTask");
+    }
+
+    @Test
+    void shouldValidateFlowWithWarningsAndInfosUsingMultipart() throws URISyntaxException {
+        // Load flow file
+        URL resource = TestsUtils.class.getClassLoader().getResource("flows/warningsAndInfos.yaml");
+        File flowFile = new File(Objects.requireNonNull(resource).toURI());
+
+        // Construct request body
+        MultipartBody body = MultipartBody.builder()
+            .addPart("flows", flowFile.getName(), MediaType.APPLICATION_YAML_TYPE, flowFile)
+            .build();
+
+        // Send request
+        HttpResponse<List<ValidateConstraintViolation>> response = client.toBlocking().exchange(
+            POST("/api/v1/main/flows/validate", body)
+                .contentType(MediaType.MULTIPART_FORM_DATA),
+            Argument.listOf(ValidateConstraintViolation.class)
+        );
+
+        List<ValidateConstraintViolation> violations = response.body();
+        assertEquals(1, violations.size());
+        assertEquals("warningsAndInfos.yaml", violations.getFirst().getFilename());
+        assertEquals(1, violations.getFirst().getDeprecationPaths().size());
+        assertEquals("tasks[0]", violations.getFirst().getDeprecationPaths().getFirst());
+        assertEquals(1, violations.getFirst().getInfos().size());
+        assertEquals("io.kestra.core.tasks.log.Log is replaced by io.kestra.plugin.core.log.Log", violations.getFirst().getInfos().getFirst());
     }
 
     @Test

--- a/webserver/src/test/resources/flows/validate/invalidFlow1.yaml
+++ b/webserver/src/test/resources/flows/validate/invalidFlow1.yaml
@@ -1,0 +1,7 @@
+id: "first_flow"
+namespace: "validation"
+tasks:
+  - id: task_one
+    type: io.kestra.plugin.core.log.Log
+    message: "strange---string"
+    unknownProp: unknownValue

--- a/webserver/src/test/resources/flows/validate/invalidFlow2.yaml
+++ b/webserver/src/test/resources/flows/validate/invalidFlow2.yaml
@@ -1,0 +1,8 @@
+id: "second_flow"
+namespace: "validation"
+tasks:
+  - id: task-two
+    type: io.kestra.plugin.core.debug.UnknownTask
+  - id: task-three
+    type: io.kestra.plugin.core.debug.Return
+    format: strangestring---

--- a/webserver/src/test/resources/flows/validate/validFlow1.yaml
+++ b/webserver/src/test/resources/flows/validate/validFlow1.yaml
@@ -1,0 +1,15 @@
+id: "first_flow"
+namespace: "system"
+revision: 1
+tasks:
+  - id: task_one
+    type: io.kestra.plugin.core.log.Log
+    message: "strange---string"
+  - id: deprecated_task
+    type: io.kestra.core.plugins.test.DeprecatedTask
+    additionalProperty: "value"
+listeners:
+  - tasks:
+      - id: log
+        type: io.kestra.plugin.core.log.Log
+        message: logging

--- a/webserver/src/test/resources/flows/validate/validFlow2.yaml
+++ b/webserver/src/test/resources/flows/validate/validFlow2.yaml
@@ -1,0 +1,9 @@
+id: "second_flow"
+namespace: "validation"
+tasks:
+  - id: task-two
+    type: io.kestra.plugin.core.debug.Echo
+    format: strangestring---
+  - id: task-three
+    type: io.kestra.plugin.core.debug.Echo
+    format: ---strangestring


### PR DESCRIPTION
### ✨ Description

_I am opening this as a follow-up to PR #14078._

In this PR, an endpoint was added for validating flows using multipart body instead of one large YAML string multidocument.
The CLI has been rewritten to use this endpoint. Thanks to these changes, invalid flows are no longer mapped to the file name using the index number, but instead use the file name information from the multipart body.

The presence of the index has been retained for now, until the same approach is used for templates. After that, it can be completely removed.
Since I think a better approach is to use multiple smaller PRs, a follow-up will be opened.

### 🛠️ Backend Checklist

- [x] Code compiles successfully and passes all checks
- [x] All unit and integration tests pass

### 📝 Additional Notes

The validation endpoint using YAML body is used to validate flows from the UI. Therefore cannot be deprecated.

Closes #14022.
