### PR TITLE
chore(core): use annotation instead of logger field

### DIFF
--- a/core/src/main/java/io/kestra/core/contexts/KestraContext.java
+++ b/core/src/main/java/io/kestra/core/contexts/KestraContext.java
@@ -9,8 +9,8 @@ import io.micronaut.context.annotation.Context;
 import io.micronaut.context.annotation.Requires;
 import io.micronaut.context.env.Environment;
 import io.micronaut.context.env.PropertySource;
+import lombok.extern.slf4j.Slf4j;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -22,10 +22,9 @@ import java.util.concurrent.atomic.AtomicReference;
 /**
  * Utility class for retrieving common information about a Kestra Server at runtime.
  */
+@Slf4j
 @SuppressWarnings("this-escape")
 public abstract class KestraContext {
-
-    private static final Logger log = LoggerFactory.getLogger(KestraContext.class);
 
     private static final AtomicReference<KestraContext> INSTANCE = new AtomicReference<>();
 

--- a/core/src/main/java/io/kestra/core/plugins/DefaultPluginRegistry.java
+++ b/core/src/main/java/io/kestra/core/plugins/DefaultPluginRegistry.java
@@ -4,8 +4,8 @@ import io.kestra.core.models.Plugin;
 import io.kestra.core.models.assets.Asset;
 import jakarta.annotation.Nullable;
 import jakarta.validation.constraints.NotNull;
+import lombok.extern.slf4j.Slf4j;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.Closeable;
 import java.io.IOException;
@@ -36,9 +36,8 @@ import static java.util.Objects.requireNonNull;
  * @see io.kestra.core.plugins.serdes.PluginDeserializer
  * @see PluginScanner
  */
+@Slf4j
 public class DefaultPluginRegistry implements PluginRegistry {
-
-    private static final Logger log = LoggerFactory.getLogger(DefaultPluginRegistry.class);
 
     private static class LazyHolder {
         static final DefaultPluginRegistry INSTANCE = new DefaultPluginRegistry();

--- a/core/src/main/java/io/kestra/core/plugins/LocalPluginManager.java
+++ b/core/src/main/java/io/kestra/core/plugins/LocalPluginManager.java
@@ -7,8 +7,8 @@ import jakarta.annotation.Nullable;
 import jakarta.inject.Inject;
 import jakarta.inject.Provider;
 import jakarta.inject.Singleton;
+import lombok.extern.slf4j.Slf4j;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.IOException;
@@ -29,9 +29,8 @@ import static io.kestra.core.plugins.PluginManager.createLocalRepositoryIfNotExi
  * A {@link PluginManager} implementation managing plugin artifacts on local storage.
  */
 @Singleton
+@Slf4j
 public class LocalPluginManager implements PluginManager {
-
-    private static final Logger log = LoggerFactory.getLogger(LocalPluginManager.class);
 
     private final Provider<PluginRegistry> pluginRegistryProvider;
 

--- a/core/src/main/java/io/kestra/core/plugins/MavenPluginDownloader.java
+++ b/core/src/main/java/io/kestra/core/plugins/MavenPluginDownloader.java
@@ -8,6 +8,7 @@ import io.micronaut.core.annotation.Nullable;
 import jakarta.annotation.PreDestroy;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.io.FileUtils;
 import org.apache.maven.repository.internal.MavenRepositorySystemUtils;
 import org.eclipse.aether.DefaultRepositorySystemSession;
@@ -26,7 +27,6 @@ import org.eclipse.aether.resolution.VersionRangeResult;
 import org.eclipse.aether.supplier.RepositorySystemSupplier;
 import org.eclipse.aether.util.repository.AuthenticationBuilder;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.Closeable;
 import java.io.File;
@@ -40,9 +40,8 @@ import java.util.List;
  * Service for resolving plugins from a Maven repository.
  */
 @Singleton
+@Slf4j
 public class MavenPluginDownloader implements Closeable {
-
-    private static final Logger log = LoggerFactory.getLogger(MavenPluginDownloader.class);
     private static final String DEFAULT_LOCAL_REPOSITORY_PREFIX = "kestra-plugins-m2-repository";
     private static final String DEFAULT_REPOSITORY_TYPE = "default";
     public static final String LATEST = "latest";

--- a/core/src/main/java/io/kestra/core/plugins/PluginCatalogService.java
+++ b/core/src/main/java/io/kestra/core/plugins/PluginCatalogService.java
@@ -9,8 +9,8 @@ import io.micronaut.http.HttpRequest;
 import io.micronaut.http.HttpResponse;
 import io.micronaut.http.MutableHttpRequest;
 import io.micronaut.http.client.HttpClient;
+import lombok.extern.slf4j.Slf4j;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
@@ -29,9 +29,8 @@ import java.util.stream.Collectors;
 /**
  * Services for retrieving available plugin artifacts for Kestra.
  */
+@Slf4j
 public class PluginCatalogService {
-
-    private static final Logger log = LoggerFactory.getLogger(PluginCatalogService.class);
 
     private static final Duration MAX_CACHE_DURATION = Duration.ofHours(1);
 

--- a/core/src/main/java/io/kestra/core/plugins/serdes/PluginDeserializer.java
+++ b/core/src/main/java/io/kestra/core/plugins/serdes/PluginDeserializer.java
@@ -13,8 +13,8 @@ import io.kestra.core.plugins.DefaultPluginRegistry;
 import io.kestra.core.plugins.PluginRegistry;
 import io.kestra.core.serializers.JacksonMapper;
 import io.micronaut.context.exceptions.NoSuchBeanException;
+import lombok.extern.slf4j.Slf4j;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.lang.reflect.ParameterizedType;
@@ -29,9 +29,8 @@ import java.util.Optional;
  * The {@link PluginDeserializer} uses the {@link PluginRegistry} to found the plugin class corresponding to
  * a plugin type.
  */
+@Slf4j
 public class PluginDeserializer<T extends Plugin> extends JsonDeserializer<T> {
-
-    private static final Logger log = LoggerFactory.getLogger(PluginDeserializer.class);
 
     private static final String TYPE = "type";
     private static final String VERSION = "version";

--- a/core/src/main/java/io/kestra/core/server/ServiceLivenessManager.java
+++ b/core/src/main/java/io/kestra/core/server/ServiceLivenessManager.java
@@ -10,8 +10,8 @@ import io.micronaut.runtime.event.annotation.EventListener;
 import jakarta.annotation.Nullable;
 import jakarta.annotation.PreDestroy;
 import jakarta.inject.Inject;
+import lombok.extern.slf4j.Slf4j;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.time.Duration;
 import java.time.Instant;
@@ -27,9 +27,8 @@ import static io.kestra.core.server.ServiceLivenessManager.OnStateTransitionFail
  */
 @Context
 @Requires(beans = ServiceLivenessUpdater.class)
+@Slf4j
 public class ServiceLivenessManager extends AbstractServiceLivenessTask {
-
-    private static final Logger log = LoggerFactory.getLogger(ServiceLivenessManager.class);
 
     private static final String TASK_NAME = "service-liveness-manager-task";
     private final LocalServiceStateFactory localServiceStateFactory;

--- a/core/src/main/java/io/kestra/core/server/ServiceStateTransition.java
+++ b/core/src/main/java/io/kestra/core/server/ServiceStateTransition.java
@@ -2,16 +2,15 @@ package io.kestra.core.server;
 
 import jakarta.annotation.Nullable;
 import jakarta.validation.constraints.NotNull;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.time.Instant;
 import java.util.Optional;
 
+@Slf4j
 public final class ServiceStateTransition {
-
-    private static final Logger LOG = LoggerFactory.getLogger(ServiceStateTransition.class);
 
     /**
      * Static helper method for validating a state transition for an existing service instance.
@@ -58,7 +57,7 @@ public final class ServiceStateTransition {
                                                        @NotNull final Service.ServiceState newState,
                                                        @Nullable final ImmutablePair<ServiceInstance, ServiceInstance> result) {
         if (result == null) {
-            LOG.debug("Failed to transition service [id={}, type={}, hostname={}] to {}. Cause: {}",
+            log.debug("Failed to transition service [id={}, type={}, hostname={}] to {}. Cause: {}",
                 initial.uid(),
                 initial.type(),
                 initial.server().hostname(),
@@ -72,7 +71,7 @@ public final class ServiceStateTransition {
         final ServiceInstance newInstance = result.getRight();
 
         if (newInstance == null) {
-            LOG.warn("Failed to transition service [id={}, type={}, hostname={}] from {} to {}. Cause: {}.",
+            log.warn("Failed to transition service [id={}, type={}, hostname={}] from {} to {}. Cause: {}.",
                 initial.uid(),
                 initial.type(),
                 initial.server().hostname(),
@@ -85,8 +84,8 @@ public final class ServiceStateTransition {
 
         // Logs if the state was changed, otherwise this method called for heartbeat purpose.
         if (!oldInstance.state().equals(newInstance.state())) {
-            if (LOG.isDebugEnabled()) {
-                LOG.debug("Service [id={}, type={}, hostname={}] transition from {} to {}.",
+            if (log.isDebugEnabled()) {
+                log.debug("Service [id={}, type={}, hostname={}] transition from {} to {}.",
                     initial.uid(),
                     initial.type(),
                     initial.server().hostname(),

--- a/core/src/main/java/io/kestra/core/storages/InternalNamespace.java
+++ b/core/src/main/java/io/kestra/core/storages/InternalNamespace.java
@@ -7,9 +7,9 @@ import io.kestra.core.repositories.ArrayListTotal;
 import io.kestra.core.repositories.NamespaceFileMetadataRepositoryInterface;
 import io.micronaut.data.model.Pageable;
 import jakarta.annotation.Nullable;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.tuple.Pair;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.FileNotFoundException;
 import java.io.IOException;
@@ -30,9 +30,8 @@ import static io.kestra.core.utils.Rethrow.throwFunction;
  * @see Storage#namespace()
  * @see Storage#namespace(String)
  */
+@Slf4j
 public class InternalNamespace implements Namespace {
-
-    private static final Logger LOG = LoggerFactory.getLogger(InternalNamespace.class);
 
     private final String namespace;
     private final String tenant;
@@ -47,7 +46,7 @@ public class InternalNamespace implements Namespace {
      * @param storage   The storage.
      */
     public InternalNamespace(@Nullable final String tenant, final String namespace, final StorageInterface storage, final NamespaceFileMetadataRepositoryInterface namespaceFileMetadataRepository) {
-        this(LOG, tenant, namespace, storage, namespaceFileMetadataRepository);
+        this(log, tenant, namespace, storage, namespaceFileMetadataRepository);
     }
 
     /**
@@ -433,7 +432,7 @@ public class InternalNamespace implements Namespace {
             .count();
 
         if (actualDeletedEntries != purgedMetadataCount) {
-            LOG.warn("Namespace Files Metadata purge reported {} deleted entries, but {} values were actually deleted from storage", purgedMetadataCount, actualDeletedEntries);
+            log.warn("Namespace Files Metadata purge reported {} deleted entries, but {} values were actually deleted from storage", purgedMetadataCount, actualDeletedEntries);
         }
 
         return purgedMetadataCount;

--- a/core/src/main/java/io/kestra/core/storages/InternalStorage.java
+++ b/core/src/main/java/io/kestra/core/storages/InternalStorage.java
@@ -2,8 +2,8 @@ package io.kestra.core.storages;
 
 import io.kestra.core.services.NamespaceService;
 import jakarta.annotation.Nullable;
+import lombok.extern.slf4j.Slf4j;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.BufferedInputStream;
 import java.io.File;
@@ -20,9 +20,8 @@ import java.util.Optional;
 /**
  * The default {@link Storage} implementation acting as a facade to the {@link StorageInterface}.
  */
+@Slf4j
 public class InternalStorage implements Storage {
-
-    private static final Logger LOG = LoggerFactory.getLogger(InternalStorage.class);
 
     private static final String PATH_SEPARATOR = "/";
 
@@ -39,7 +38,7 @@ public class InternalStorage implements Storage {
      * @param storage The storage to delegate operations.
      */
     public InternalStorage(StorageContext context, StorageInterface storage, NamespaceFactory namespaceFactory) {
-        this(LOG, context, storage, null, namespaceFactory);
+        this(log, context, storage, null, namespaceFactory);
     }
 
     /**

--- a/core/src/main/java/io/micronaut/retry/intercept/OverrideRetryInterceptor.java
+++ b/core/src/main/java/io/micronaut/retry/intercept/OverrideRetryInterceptor.java
@@ -14,8 +14,8 @@ import io.micronaut.retry.RetryState;
 import io.micronaut.retry.annotation.DefaultRetryPredicate;
 import io.micronaut.retry.event.RetryEvent;
 import jakarta.inject.Singleton;
+import lombok.extern.slf4j.Slf4j;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.time.Duration;
 import java.util.Arrays;
@@ -27,8 +27,8 @@ import java.util.Optional;
  * Replace {@link DefaultRetryInterceptor} only to catch Throwable
  */
 @Singleton
+@Slf4j
 public class OverrideRetryInterceptor implements MethodInterceptor<Object, Object> {
-    private static final Logger LOG = LoggerFactory.getLogger(OverrideRetryInterceptor.class);
     private final ApplicationEventPublisher<RetryEvent> eventPublisher;
 
     public OverrideRetryInterceptor(ApplicationEventPublisher<RetryEvent> eventPublisher) {
@@ -97,8 +97,8 @@ public class OverrideRetryInterceptor implements MethodInterceptor<Object, Objec
                 return interceptedMethod.interceptResult(this);
             } catch (Throwable e) {
                 if (!retryState.canRetry(e)) {
-                    if (LOG.isDebugEnabled()) {
-                        LOG.debug("Cannot retry anymore. Rethrowing original exception for method: {}", context);
+                    if (log.isDebugEnabled()) {
+                        log.debug("Cannot retry anymore. Rethrowing original exception for method: {}", context);
                     }
                     retryState.close(e);
                     throw e;
@@ -109,11 +109,11 @@ public class OverrideRetryInterceptor implements MethodInterceptor<Object, Objec
                             try {
                                 eventPublisher.publishEvent(new RetryEvent(context, retryState, e));
                             } catch (Exception e1) {
-                                LOG.error("Error occurred publishing RetryEvent: " + e1.getMessage(), e1);
+                                log.error("Error occurred publishing RetryEvent: " + e1.getMessage(), e1);
                             }
                         }
-                        if (LOG.isDebugEnabled()) {
-                            LOG.debug("Retrying execution for method [{}] after delay of {}ms for exception: {}", context, delayMillis, e.getMessage());
+                        if (log.isDebugEnabled()) {
+                            log.debug("Retrying execution for method [{}] after delay of {}ms for exception: {}", context, delayMillis, e.getMessage());
                         }
                         Thread.sleep(delayMillis);
                     } catch (InterruptedException e1) {

--- a/core/src/test/java/io/kestra/core/repositories/AbstractTemplateRepositoryTest.java
+++ b/core/src/test/java/io/kestra/core/repositories/AbstractTemplateRepositoryTest.java
@@ -13,6 +13,8 @@ import io.micronaut.data.model.Pageable;
 import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
+import lombok.extern.slf4j.Slf4j;
+
 import java.time.Duration;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.TimeoutException;
@@ -25,11 +27,11 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 @MicronautTest
+@Slf4j
 public abstract class AbstractTemplateRepositoryTest {
     @Inject
     protected TemplateRepositoryInterface templateRepository;
@@ -138,8 +140,6 @@ public abstract class AbstractTemplateRepositoryTest {
         templateRepository.delete(template3);
     }
 
-    private static final Logger LOG = LoggerFactory.getLogger(AbstractTemplateRepositoryTest.class);
-
     @Test
     protected void delete() throws TimeoutException {
         String tenant = TestsUtils.randomTenant(this.getClass().getSimpleName());
@@ -151,7 +151,7 @@ public abstract class AbstractTemplateRepositoryTest {
         assertThat(templateRepository.findById(tenant, template.getNamespace(), template.getId()).isPresent()).isFalse();
 
         Await.until(() -> {
-            LOG.info("-------------> number of event: {}", TemplateListener.getEmits(tenant).size());
+            log.info("-------------> number of event: {}", TemplateListener.getEmits(tenant).size());
             return TemplateListener.getEmits(tenant).size() == 2;
 
         }, Duration.ofMillis(100), Duration.ofSeconds(5));

--- a/core/src/test/java/io/kestra/core/runners/FlowListenersTest.java
+++ b/core/src/test/java/io/kestra/core/runners/FlowListenersTest.java
@@ -17,12 +17,13 @@ import io.kestra.core.utils.IdUtils;
 import java.util.Collections;
 import java.util.concurrent.atomic.AtomicInteger;
 import jakarta.inject.Inject;
+import lombok.extern.slf4j.Slf4j;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 @KestraTest
+@Slf4j
 abstract public class FlowListenersTest {
     @Inject
     protected FlowRepositoryInterface flowRepository;
@@ -42,8 +43,6 @@ abstract public class FlowListenersTest {
         return flow.toBuilder().source(flow.sourceOrGenerateIfNull()).build();
     }
 
-    private static final Logger LOG = LoggerFactory.getLogger(FlowListenersTest.class);
-
     public void suite(FlowListenersInterface flowListenersService) throws TimeoutException {
         String tenant = TestsUtils.randomTenant(this.getClass().getSimpleName());
         flowListenersService.run();
@@ -53,19 +52,19 @@ abstract public class FlowListenersTest {
         flowListenersService.listen(flows -> count.set(getFlowsForTenant(flowListenersService, tenant).size()));
 
         // initial state
-        LOG.info("-----------> wait for zero");
+        log.info("-----------> wait for zero");
         Await.until(() -> count.get() == 0, Duration.ofMillis(10), Duration.ofSeconds(5));
         assertThat(getFlowsForTenant(flowListenersService, tenant).size()).isZero();
 
         // resend on startup done for kafka
-        LOG.info("-----------> wait for zero kafka");
+        log.info("-----------> wait for zero kafka");
         if (flowListenersService.getClass().getName().equals("io.kestra.ee.runner.kafka.KafkaFlowListeners")) {
             Await.until(() -> count.get() == 0, Duration.ofMillis(10), Duration.ofSeconds(5));
             assertThat(getFlowsForTenant(flowListenersService, tenant).size()).isZero();
         }
 
         // create first
-        LOG.info("-----------> create fist flow");
+        log.info("-----------> create fist flow");
         FlowWithSource first = create(tenant, "first_" + IdUtils.create(), "test");
         FlowWithSource firstUpdated = create(tenant, first.getId(), "test2");
 

--- a/core/src/test/java/io/kestra/core/storages/InternalNamespaceTest.java
+++ b/core/src/test/java/io/kestra/core/storages/InternalNamespaceTest.java
@@ -5,10 +5,10 @@ import io.kestra.core.utils.PathMatcherPredicate;
 import io.kestra.core.utils.TestsUtils;
 import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
 import jakarta.inject.Inject;
+import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -22,9 +22,8 @@ import static io.kestra.core.tenant.TenantService.MAIN_TENANT;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @MicronautTest
+@Slf4j
 class InternalNamespaceTest {
-
-    private static final Logger logger = LoggerFactory.getLogger(InternalNamespaceTest.class);
 
     @Inject
     private StorageInterface storageInterface;
@@ -36,7 +35,7 @@ class InternalNamespaceTest {
     void shouldGetAllNamespaceFiles() throws IOException, URISyntaxException {
         // Given
         final String namespaceId = TestsUtils.randomNamespace();
-        final InternalNamespace namespace = new InternalNamespace(logger, MAIN_TENANT, namespaceId, storageInterface, namespaceFileMetadataRepository);
+        final InternalNamespace namespace = new InternalNamespace(log, MAIN_TENANT, namespaceId, storageInterface, namespaceFileMetadataRepository);
 
         // When
         namespace.putFile(Path.of("/sub/dir/file1.txt"), new ByteArrayInputStream("1".getBytes()));
@@ -54,7 +53,7 @@ class InternalNamespaceTest {
     void shouldPutFileGivenNoTenant() throws IOException, URISyntaxException {
         // Given
         final String namespaceId = TestsUtils.randomNamespace();
-        final InternalNamespace namespace = new InternalNamespace(logger, MAIN_TENANT, namespaceId, storageInterface, namespaceFileMetadataRepository);
+        final InternalNamespace namespace = new InternalNamespace(log, MAIN_TENANT, namespaceId, storageInterface, namespaceFileMetadataRepository);
 
         // When
         List<NamespaceFile> namespaceFiles = namespace.putFile(Path.of("/sub/dir/file.txt"), new ByteArrayInputStream("1".getBytes()));
@@ -78,7 +77,7 @@ class InternalNamespaceTest {
     void shouldSucceedPutFileGivenExistingFileForConflictOverwrite() throws IOException, URISyntaxException {
         // Given
         final String namespaceId = TestsUtils.randomNamespace();
-        final InternalNamespace namespace = new InternalNamespace(logger, MAIN_TENANT, namespaceId, storageInterface, namespaceFileMetadataRepository);
+        final InternalNamespace namespace = new InternalNamespace(log, MAIN_TENANT, namespaceId, storageInterface, namespaceFileMetadataRepository);
 
         NamespaceFile namespaceFile = namespace.get(Path.of("/sub/dir/file.txt"));
 
@@ -97,7 +96,7 @@ class InternalNamespaceTest {
     void shouldFailPutFileGivenExistingFileForError() throws IOException, URISyntaxException {
         // Given
         final String namespaceId = TestsUtils.randomNamespace();
-        final InternalNamespace namespace = new InternalNamespace(logger, MAIN_TENANT, namespaceId, storageInterface, namespaceFileMetadataRepository);
+        final InternalNamespace namespace = new InternalNamespace(log, MAIN_TENANT, namespaceId, storageInterface, namespaceFileMetadataRepository);
 
         NamespaceFile namespaceFile = namespace.get(Path.of("/sub/dir/file.txt"));
 
@@ -114,7 +113,7 @@ class InternalNamespaceTest {
     void shouldIgnorePutFileGivenExistingFileForSkip() throws IOException, URISyntaxException {
         // Given
         final String namespaceId = TestsUtils.randomNamespace();
-        final InternalNamespace namespace = new InternalNamespace(logger, MAIN_TENANT, namespaceId, storageInterface, namespaceFileMetadataRepository);
+        final InternalNamespace namespace = new InternalNamespace(log, MAIN_TENANT, namespaceId, storageInterface, namespaceFileMetadataRepository);
 
         NamespaceFile namespaceFile = namespace.get(Path.of("/sub/dir/file.txt"));
 
@@ -133,7 +132,7 @@ class InternalNamespaceTest {
     void shouldFindAllMatchingGivenNoTenant() throws IOException, URISyntaxException {
         // Given
         final String namespaceId = TestsUtils.randomNamespace();
-        final InternalNamespace namespace = new InternalNamespace(logger, MAIN_TENANT, namespaceId, storageInterface, namespaceFileMetadataRepository);
+        final InternalNamespace namespace = new InternalNamespace(log, MAIN_TENANT, namespaceId, storageInterface, namespaceFileMetadataRepository);
 
         // When
         namespace.putFile(Path.of("/a/b/c/1.sql"), new ByteArrayInputStream("1".getBytes()));
@@ -156,12 +155,12 @@ class InternalNamespaceTest {
     void shouldFindAllGivenTenant() throws IOException, URISyntaxException {
         // Given
         final String namespaceId = TestsUtils.randomNamespace();
-        final InternalNamespace namespaceTenant1 = new InternalNamespace(logger, "tenant1", namespaceId, storageInterface, namespaceFileMetadataRepository);
+        final InternalNamespace namespaceTenant1 = new InternalNamespace(log, "tenant1", namespaceId, storageInterface, namespaceFileMetadataRepository);
         NamespaceFile namespaceFile1 = namespaceTenant1.putFile(Path.of("/a/b/c/test.txt"), new ByteArrayInputStream("1".getBytes())).stream()
             .filter(namespaceFile -> namespaceFile.path().endsWith("test.txt"))
             .findFirst().get();
 
-        final InternalNamespace namespaceTenant2 = new InternalNamespace(logger, "tenant2", namespaceId, storageInterface, namespaceFileMetadataRepository);
+        final InternalNamespace namespaceTenant2 = new InternalNamespace(log, "tenant2", namespaceId, storageInterface, namespaceFileMetadataRepository);
         NamespaceFile namespaceFile2 = namespaceTenant2.putFile(Path.of("/a/b/c/test.txt"), new ByteArrayInputStream("1".getBytes())).stream()
             .filter(namespaceFile -> namespaceFile.path().endsWith("test.txt"))
             .findFirst().get();
@@ -180,7 +179,7 @@ class InternalNamespaceTest {
     void shouldReturnNoNamespaceFileForEmptyNamespace() throws IOException {
         // Given
         final String namespaceId = TestsUtils.randomNamespace();
-        final InternalNamespace namespace = new InternalNamespace(logger, MAIN_TENANT, namespaceId, storageInterface, namespaceFileMetadataRepository);
+        final InternalNamespace namespace = new InternalNamespace(log, MAIN_TENANT, namespaceId, storageInterface, namespaceFileMetadataRepository);
         List<NamespaceFile> namespaceFiles = namespace.findAllFilesMatching((unused) -> true);
         assertThat(namespaceFiles.size()).isZero();
     }
@@ -189,7 +188,7 @@ class InternalNamespaceTest {
     void shouldCreateDirectory() throws IOException {
         // Given
         final String namespaceId = TestsUtils.randomNamespace();
-        final InternalNamespace namespace = new InternalNamespace(logger, MAIN_TENANT, namespaceId, storageInterface, namespaceFileMetadataRepository);
+        final InternalNamespace namespace = new InternalNamespace(log, MAIN_TENANT, namespaceId, storageInterface, namespaceFileMetadataRepository);
 
         // When
         NamespaceFile directory = namespace.createDirectory(Path.of("my-directory"));

--- a/core/src/test/java/io/kestra/plugin/core/flow/SubflowTest.java
+++ b/core/src/test/java/io/kestra/plugin/core/flow/SubflowTest.java
@@ -12,6 +12,7 @@ import io.kestra.core.runners.InputAndOutput;
 import io.kestra.core.runners.SubflowExecutionResult;
 import io.kestra.core.services.VariablesService;
 import io.micronaut.context.ApplicationContext;
+import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -21,7 +22,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.time.Instant;
 import java.util.Collections;
@@ -34,9 +34,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @ExtendWith(MockitoExtension.class)
 @MockitoSettings(strictness = Strictness.LENIENT)
+@Slf4j
 class SubflowTest {
-
-    private static final Logger LOG = LoggerFactory.getLogger(SubflowTest.class);
 
     private static final State DEFAULT_SUCCESS_STATE = State.of(State.Type.SUCCESS, List.of(new State.History(State.Type.CREATED, Instant.now()), new State.History(State.Type.RUNNING, Instant.now()), new State.History(State.Type.SUCCESS, Instant.now())));
     public static final String EXECUTION_ID = "executionId";
@@ -53,7 +52,7 @@ class SubflowTest {
     @BeforeEach
     void beforeEach() {
         Mockito.when(applicationContext.getBean(VariablesService.class)).thenReturn(new VariablesService());
-        Mockito.when(runContext.logger()).thenReturn(LOG);
+        Mockito.when(runContext.logger()).thenReturn(log);
         Mockito.when(runContext.getApplicationContext()).thenReturn(applicationContext);
         Mockito.when(runContext.inputAndOutput()).thenReturn(inputAndOutput);
     }

--- a/jdbc/src/main/java/io/kestra/jdbc/runner/JdbcServiceLivenessCoordinator.java
+++ b/jdbc/src/main/java/io/kestra/jdbc/runner/JdbcServiceLivenessCoordinator.java
@@ -14,8 +14,8 @@ import io.micronaut.context.annotation.Value;
 import io.micronaut.scheduling.annotation.Scheduled;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
+import lombok.extern.slf4j.Slf4j;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.time.Duration;
 import java.time.Instant;
@@ -31,11 +31,10 @@ import static io.kestra.core.server.Service.ServiceState.allRunningStates;
  * @see ServiceInstance
  */
 @Singleton
+@Slf4j
 @JdbcRunnerEnabled
 @Requires(property = "kestra.server-type", pattern = "(EXECUTOR|STANDALONE)")
 public final class JdbcServiceLivenessCoordinator extends AbstractServiceLivenessCoordinator {
-
-    private final static Logger log = LoggerFactory.getLogger(JdbcServiceLivenessCoordinator.class);
 
     private final AtomicReference<JdbcExecutor> executor = new AtomicReference<>();
     private final AbstractJdbcServiceInstanceRepository serviceInstanceRepository;

--- a/storage-local/src/main/java/io/kestra/storage/local/LocalStorage.java
+++ b/storage-local/src/main/java/io/kestra/storage/local/LocalStorage.java
@@ -11,9 +11,9 @@ import jakarta.annotation.Nullable;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.io.FileUtils;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.*;
 import java.net.URI;
@@ -33,9 +33,9 @@ import static io.kestra.core.utils.WindowsUtils.windowsToUnixPath;
 @Plugin.Id("local")
 @Getter
 @Setter
+@Slf4j
 @NoArgsConstructor
 public class LocalStorage implements StorageInterface {
-    private static final Logger log = LoggerFactory.getLogger(LocalStorage.class);
     private static final int MAX_OBJECT_NAME_LENGTH = 255;
 
     @PluginProperty

--- a/webserver/src/main/java/io/kestra/webserver/services/FlowAutoLoaderService.java
+++ b/webserver/src/main/java/io/kestra/webserver/services/FlowAutoLoaderService.java
@@ -16,8 +16,8 @@ import io.micronaut.http.client.HttpClient;
 import io.micronaut.http.client.annotation.Client;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
+import lombok.extern.slf4j.Slf4j;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import reactor.core.publisher.Mono;
 
 import java.util.Objects;
@@ -27,10 +27,10 @@ import java.util.function.Function;
  * Service for automatically loading initial flows from the community blueprints at server startup.
  */
 @Singleton
+@Slf4j
 @WebServerEnabled
 @Requires(property = "kestra.tutorial-flows.enabled", value = "true", defaultValue = "true")
 public class FlowAutoLoaderService {
-    private static final Logger log = LoggerFactory.getLogger(FlowAutoLoaderService.class);
 
     public static final String PURGE_SYSTEM_FLOW_BLUEPRINT_ID = "234";
 


### PR DESCRIPTION
### ✨ Description

Normalize `Slf4` logger initialization to the already used Lombok annotation.

### 🛠️ Backend Checklist

- [x] Code compiles successfully and passes all checks
- [x] All unit and integration tests pass