### PR TITLE
fix: Ensure normalize method reliably strips all trailing special chars

### DIFF
--- a/core/src/main/java/io/kestra/core/models/tasks/runners/ScriptService.java
+++ b/core/src/main/java/io/kestra/core/models/tasks/runners/ScriptService.java
@@ -226,9 +226,7 @@ public final class ScriptService {
             string = string.substring(0, 63);
         }
 
-        string = StringUtils.stripEnd(string, "-");
-        string = StringUtils.stripEnd(string, ".");
-        string = StringUtils.stripEnd(string, "_");
+        string = StringUtils.stripEnd(string, "-._");
 
         return string;
     }

--- a/core/src/test/java/io/kestra/core/models/tasks/runners/ScriptServiceTest.java
+++ b/core/src/test/java/io/kestra/core/models/tasks/runners/ScriptServiceTest.java
@@ -195,9 +195,19 @@ class ScriptServiceTest {
 
     @Test
     void normalize() {
+        // existing tests
         assertThat(ScriptService.normalize(null)).isNull();
         assertThat(ScriptService.normalize("a-normal-string")).isEqualTo("a-normal-string");
-        assertThat(ScriptService.normalize("very.very.very.very.very.very.very.very.very.very.very.very.long.namespace")).isEqualTo("very.very.very.very.very.very.very.very.very.very.very.very.lon");
+        assertThat(ScriptService.normalize("very.very.very.very.very.very.very.very.very.very.very.very.long.namespace"))
+            .isEqualTo("very.very.very.very.very.very.very.very.very.very.very.very.lon");
+
+        // new tests for the fix
+        assertThat(ScriptService.normalize("abc-_")).isEqualTo("abc");
+        assertThat(ScriptService.normalize("abc.-")).isEqualTo("abc");
+        assertThat(ScriptService.normalize("abc_-")).isEqualTo("abc");
+        assertThat(ScriptService.normalize("abc-._")).isEqualTo("abc");
+        assertThat(ScriptService.normalize("abc---")).isEqualTo("abc");
+        assertThat(ScriptService.normalize("a-b-c-")).isEqualTo("a-b-c");
     }
 
     private RunContext runContext(RunContextFactory runContextFactory, String namespace) {

--- a/core/src/test/java/io/kestra/core/models/tasks/runners/ScriptServiceTest.java
+++ b/core/src/test/java/io/kestra/core/models/tasks/runners/ScriptServiceTest.java
@@ -195,7 +195,6 @@ class ScriptServiceTest {
 
     @Test
     void normalize() {
-        // existing tests
         assertThat(ScriptService.normalize(null)).isNull();
         assertThat(ScriptService.normalize("a-normal-string")).isEqualTo("a-normal-string");
         assertThat(ScriptService.normalize("very.very.very.very.very.very.very.very.very.very.very.very.long.namespace"))


### PR DESCRIPTION
✨ Description
This PR fixes a bug in the ScriptService.normalize() method where it failed to reliably strip all invalid trailing characters (-, ., _).

The previous implementation used three separate, sequential calls to StringUtils.stripEnd(). This created a bug where a string ending in a combination of these characters, like "my-string-_", would be incorrectly processed. The final result would be "my-string-", which violates the RFC 1123 naming conventions that this method is intended to enforce.

The fix consolidates the three calls into a single, robust call: StringUtils.stripEnd(string, "-._"). This ensures that any combination of these invalid characters is correctly stripped from the end of the string.

The corresponding unit test for the normalize method has also been expanded to include assertions for these specific edge cases, verifying the fix and preventing future regressions.

🔗 Related Issue
N/A

🛠️ Backend Checklist
Code compiles successfully and passes all checks
All unit and integration tests pass

📝 Additional Notes
This is a correctness fix for a subtle bug in a core utility method.

🤖 AI Authors
What do you call a cat that gets everything it wants? Purr-suasive. 🐱