### PR TITLE
chore(system): tiny improvements

### DIFF
--- a/core/src/main/java/io/kestra/core/models/executions/Execution.java
+++ b/core/src/main/java/io/kestra/core/models/executions/Execution.java
@@ -296,7 +296,7 @@ public class Execution implements DeletedInterface, TenantInterface {
     }
 
     public Execution withTaskRun(TaskRun taskRun) throws InternalException {
-        ArrayList<TaskRun> newTaskRunList = this.taskRunList == null ? new ArrayList<>() : new ArrayList<>(this.taskRunList);
+        List<TaskRun> newTaskRunList = this.taskRunList == null ? new ArrayList<>() : new ArrayList<>(this.taskRunList);
 
         boolean b = Collections.replaceAll(
             newTaskRunList,
@@ -528,12 +528,9 @@ public class Execution implements DeletedInterface, TenantInterface {
         return resolvedTasks;
     }
 
-    public List<ResolvedTask> findTaskDependingFlowState(List<ResolvedTask> resolvedTasks) {
-        resolvedTasks = removeDisabled(resolvedTasks);
-
-        return resolvedTasks;
-    }
-
+    /**
+     * Remove disabled tasks from the list of resolved tasks.
+     */
     public List<ResolvedTask> removeDisabled(List<ResolvedTask> tasks) {
         if (tasks == null) {
             return null;
@@ -1029,7 +1026,7 @@ public class Execution implements DeletedInterface, TenantInterface {
         Collections.reverse(parents);
 
         for (TaskRun childTaskRun : parents) {
-            HashMap<String, Object> current = new HashMap<>();
+            Map<String, Object> current = HashMap.newHashMap(2);
 
             if (childTaskRun.getValue() != null) {
                 current.put("taskrun", Map.of("value", childTaskRun.getValue()));
@@ -1060,7 +1057,7 @@ public class Execution implements DeletedInterface, TenantInterface {
             return Collections.emptyList();
         }
 
-        ArrayList<TaskRun> result = new ArrayList<>();
+        List<TaskRun> result = new ArrayList<>();
         boolean ended = false;
         while (!ended) {
             final TaskRun finalTaskRun = taskRun;
@@ -1092,7 +1089,7 @@ public class Execution implements DeletedInterface, TenantInterface {
             return Collections.emptyList();
         }
 
-        ArrayList<TaskRun> result = new ArrayList<>();
+        List<TaskRun> result = new ArrayList<>();
         boolean ended = false;
         while (!ended) {
             final TaskRun finalTaskRun = taskRun;

--- a/core/src/main/java/io/kestra/core/runners/FlowableUtils.java
+++ b/core/src/main/java/io/kestra/core/runners/FlowableUtils.java
@@ -24,7 +24,7 @@ public class FlowableUtils {
         Execution execution,
         List<ResolvedTask> tasks
     ) {
-        List<ResolvedTask> currentTasks = execution.findTaskDependingFlowState(tasks);
+        List<ResolvedTask> currentTasks = execution.removeDisabled(tasks);
 
         return FlowableUtils.innerResolveSequentialNexts(execution, currentTasks, null);
     }

--- a/core/src/main/java/io/kestra/core/services/ExecutionService.java
+++ b/core/src/main/java/io/kestra/core/services/ExecutionService.java
@@ -300,7 +300,7 @@ public class ExecutionService {
             );
 
             // remove all child for replay task id
-            Set<String> taskRunToRemove = GraphUtils.successors(graphCluster, List.of(taskRunId))
+            Set<String> taskRunToRemove = GraphUtils.successors(graphCluster, Set.of(taskRunId))
                 .stream()
                 .filter(task -> task instanceof AbstractGraphTask)
                 .map(task -> ((AbstractGraphTask) task))
@@ -408,7 +408,7 @@ public class ExecutionService {
 
 
                 if (originalTaskRun.getAttempts() != null && !originalTaskRun.getAttempts().isEmpty()) {
-                    ArrayList<TaskRunAttempt> attempts = new ArrayList<>(originalTaskRun.getAttempts());
+                    List<TaskRunAttempt> attempts = new ArrayList<>(originalTaskRun.getAttempts());
                     attempts.set(attempts.size() - 1, attempts.getLast().withState(targetState));
                     newTaskRun = newTaskRun.withAttempts(attempts);
                 }
@@ -790,7 +790,7 @@ public class ExecutionService {
 
         GraphCluster graphCluster = GraphUtils.of(flow, execution);
 
-        return GraphUtils.successors(graphCluster, new ArrayList<>(workerTaskRunId))
+        return GraphUtils.successors(graphCluster, workerTaskRunId)
             .stream()
             .filter(task -> task instanceof AbstractGraphTask)
             .map(task -> (AbstractGraphTask) task)

--- a/core/src/main/java/io/kestra/core/utils/GraphUtils.java
+++ b/core/src/main/java/io/kestra/core/utils/GraphUtils.java
@@ -133,7 +133,7 @@ public class GraphUtils {
             .toList();
     }
 
-    public static Set<AbstractGraph> successors(GraphCluster graphCluster, List<String> taskRunIds) {
+    public static Set<AbstractGraph> successors(GraphCluster graphCluster, Set<String> taskRunIds) {
         List<FlowGraph.Edge> edges = GraphUtils.edges(graphCluster);
         List<AbstractGraph> nodes = GraphUtils.nodes(graphCluster);
 

--- a/executor/src/main/java/io/kestra/executor/ExecutorService.java
+++ b/executor/src/main/java/io/kestra/executor/ExecutorService.java
@@ -485,7 +485,7 @@ public class ExecutorService {
             .toList();
 
         // Remove functional style to avoid (class io.kestra.core.exceptions.IllegalVariableEvaluationException cannot be cast to class java.lang.RuntimeException'
-        ArrayList<TaskRun> result = new ArrayList<>();
+        List<TaskRun> result = new ArrayList<>();
 
         for (TaskRun taskRun : running) {
             result.addAll(this.childNextsTaskRun(executor, taskRun));
@@ -1248,7 +1248,7 @@ public class ExecutorService {
 
     // Note: as the flow is only used in an error branch and it can take time to load, we pass it thought a Supplier
     private Execution addDynamicTaskRun(Execution execution, Supplier<FlowWithSource> flow, WorkerTaskResult workerTaskResult) throws InternalException {
-        ArrayList<TaskRun> taskRuns = new ArrayList<>(ListUtils.emptyOnNull(execution.getTaskRunList()));
+        List<TaskRun> taskRuns = new ArrayList<>(ListUtils.emptyOnNull(execution.getTaskRunList()));
 
         // declared dynamic tasks
         if (!ListUtils.isEmpty(workerTaskResult.getDynamicTaskRuns())) {

--- a/tests/src/main/java/io/kestra/core/runners/TestRunnerUtils.java
+++ b/tests/src/main/java/io/kestra/core/runners/TestRunnerUtils.java
@@ -82,7 +82,7 @@ public class TestRunnerUtils {
         return this.runOne(
             flowRepository
                 .findById(tenantId, namespace, flowId, revision != null ? Optional.of(revision) : Optional.empty())
-                .orElseThrow(() -> new IllegalArgumentException("Unable to find flow '" + flowId + "'")),
+                .orElseThrow(() -> new IllegalArgumentException("Unable to find flow '" + namespace + "." + flowId + "'")),
             inputs,
             duration,
             labels);
@@ -124,7 +124,7 @@ public class TestRunnerUtils {
         return this.runOneUntilPaused(
             flowRepository
                 .findById(tenantId, namespace, flowId, revision != null ? Optional.of(revision) : Optional.empty())
-                .orElseThrow(() -> new IllegalArgumentException("Unable to find flow '" + flowId + "'")),
+                .orElseThrow(() -> new IllegalArgumentException("Unable to find flow '" + namespace + "." + flowId + "'")),
             inputs,
             duration
         );
@@ -151,7 +151,7 @@ public class TestRunnerUtils {
         return this.runOneUntilRunning(
             flowRepository
                 .findById(tenantId, namespace, flowId, revision != null ? Optional.of(revision) : Optional.empty())
-                .orElseThrow(() -> new IllegalArgumentException("Unable to find flow '" + flowId + "'")),
+                .orElseThrow(() -> new IllegalArgumentException("Unable to find flow '" + namespace + "." + flowId + "'")),
             inputs,
             duration
         );
@@ -178,7 +178,7 @@ public class TestRunnerUtils {
         return this.runOneUntil(
             flowRepository
                 .findById(tenantId, namespace, flowId, revision != null ? Optional.of(revision) : Optional.empty())
-                .orElseThrow(() -> new IllegalArgumentException("Unable to find flow '" + flowId + "'")),
+                .orElseThrow(() -> new IllegalArgumentException("Unable to find flow '" + namespace + "." + flowId + "'")),
             inputs,
             duration,
             predicate
@@ -303,7 +303,7 @@ public class TestRunnerUtils {
         Flow flow = flowRepository
             .findById(tenantId, namespace, flowId, Optional.empty())
             .orElseThrow(
-                () -> new IllegalArgumentException("Unable to find flow '" + flowId + "'"));
+                () -> new IllegalArgumentException("Unable to find flow '" + namespace + "." + flowId + "'"));
         try {
             if (duration == null){
                 duration = Duration.ofSeconds(20);


### PR DESCRIPTION
- Make `Execution.removeDisabled(List<ResolvedTask>)` public and use it instread of the passthrought `Execution.findTaskDependingFlowState(List<ResolvedTask>)` method and delete the later.
- Add namespace to the error log inside the `TestRunnerUtils`.
- Code against interfaces
- Init hashmap with the right size when possible
- Avoid cloning collections when possible