### PR TITLE
fix(jdbc) : fix issue where delayed instances bypass concurrency limit checks

### DIFF
--- a/jdbc/src/main/java/io/kestra/jdbc/runner/JdbcExecutor.java
+++ b/jdbc/src/main/java/io/kestra/jdbc/runner/JdbcExecutor.java
@@ -577,7 +577,7 @@ public class JdbcExecutor implements ExecutorInterface {
                             ExecutionDelay executionDelay = ExecutionDelay.builder()
                                 .executionId(executor.getExecution().getId())
                                 .date(execution.getScheduleDate())
-                                .state(State.Type.RUNNING)
+                                .state(State.Type.CREATED)
                                 .delayType(ExecutionDelay.DelayType.RESUME_FLOW)
                                 .build();
                             executionDelayStorage.save(executionDelay);

--- a/jdbc/src/test/java/io/kestra/jdbc/runner/JdbcConcurrencyRunnerTest.java
+++ b/jdbc/src/test/java/io/kestra/jdbc/runner/JdbcConcurrencyRunnerTest.java
@@ -61,4 +61,30 @@ public abstract class JdbcConcurrencyRunnerTest extends AbstractRunnerConcurrenc
         // we manually reset the concurrency count to avoid messing with any other tests
         concurrencyLimitStorage.update(concurrencyLimit.withRunning(concurrencyLimit.getRunning() - 1));
     }
+
+    @Test
+    @LoadFlows(value = {"flows/valids/flow-concurrency-queue.yml"}, tenantId = "flow-concurrency-scheduled")
+    void flowConcurrencyScheduled() throws QueueException, InterruptedException {
+        Execution execution1 = runnerUtils.runOneUntilRunning("flow-concurrency-scheduled", NAMESPACE, "flow-concurrency-queue", null, null, Duration.ofSeconds(30));
+        assertThat(execution1.getState().isRunning()).isTrue();
+
+        Flow flow = flowRepository
+            .findById("flow-concurrency-scheduled", NAMESPACE, "flow-concurrency-queue", Optional.empty())
+            .orElseThrow();
+
+        Execution scheduledExecution = Execution.newExecution(flow, null, null, Optional.empty())
+            .withScheduleDate(java.time.Instant.now().plusSeconds(1));
+
+        Execution execution2 = runnerUtils.emitAndAwaitExecution(
+            e -> e.getState().getCurrent().equals(State.Type.QUEUED) || e.getState().getCurrent().equals(State.Type.RUNNING),
+            scheduledExecution,
+            Duration.ofSeconds(10)
+        );
+
+        assertThat(execution2.getState().getCurrent()).isEqualTo(State.Type.QUEUED);
+
+        // cleanup
+        runnerUtils.awaitExecution(e -> e.getState().getCurrent().equals(State.Type.SUCCESS), execution1);
+        runnerUtils.awaitExecution(e -> e.getState().getCurrent().equals(State.Type.SUCCESS), execution2);
+    }
 }


### PR DESCRIPTION
All PRs submitted by external contributors that do not follow this template (including proper description, related issue, and checklist sections) **may be automatically closed**.

As a general practice, if you plan to work on a specific issue, comment on the issue first and wait to be assigned before starting any actual work. This avoids duplicated work and ensures a smooth contribution process - otherwise, the PR **may be automatically closed**.

---

### ✨ Description
Instances with a future scheduleDate are handled via delayed scheduling. If the workflow has concurrency limits, this process currently skips the concurrency check. Consequently, when triggered, the instance transitions directly from CREATED to RUNNING (skipping QUEUED ), which prevents the workflow from effectively enforcing concurrency limits.
<img width="1309" height="1906" alt="image" src="https://github.com/user-attachments/assets/e14219fd-2dd5-489e-852c-bca6ed20510b" />

What does this PR change?  

If a CREATED instance is persisted to ExecutionDelay because its scheduleDate is in the future, it retains the CREATED status. Once the scheduled time is reached, the instance is submitted to the executionQueue consumer—still as CREATED —ensuring that concurrency limit validation is performed.

### 🛠️ Backend Checklist

_If this PR does not include any backend changes, delete this entire section._

- [✅] Code compiles successfully and passes all checks
- [✅] All unit and integration tests pass
