### PR TITLE
feat(http): add digest auth (RFC 7616)

### DIFF
--- a/core/src/main/java/io/kestra/core/http/client/HttpClient.java
+++ b/core/src/main/java/io/kestra/core/http/client/HttpClient.java
@@ -5,6 +5,7 @@ import io.kestra.core.exceptions.IllegalVariableEvaluationException;
 import io.kestra.core.http.HttpRequest;
 import io.kestra.core.http.HttpResponse;
 import io.kestra.core.http.client.apache.*;
+import io.kestra.core.http.client.configurations.DigestAuthConfiguration;
 import io.kestra.core.http.client.configurations.HttpConfiguration;
 import io.kestra.core.runners.DefaultRunContext;
 import io.kestra.core.runners.RunContext;
@@ -55,6 +56,7 @@ import javax.net.ssl.SSLHandshakeException;
 @Slf4j
 public class HttpClient implements Closeable {
     private transient CloseableHttpClient client;
+    private transient BasicCredentialsProvider defaultCredentialsProvider;
     private final RunContext runContext;
     private final HttpConfiguration configuration;
     private ObservationRegistry observationRegistry;
@@ -104,7 +106,7 @@ public class HttpClient implements Closeable {
         // Object dependencies
         PoolingHttpClientConnectionManagerBuilder connectionManagerBuilder = PoolingHttpClientConnectionManagerBuilder.create();
         ConnectionConfig.Builder connectionConfig = ConnectionConfig.custom();
-        BasicCredentialsProvider credentialsStore = new BasicCredentialsProvider();
+        this.defaultCredentialsProvider = new BasicCredentialsProvider();
 
         // Timeout
         if (this.configuration.getTimeout() != null) {
@@ -143,7 +145,7 @@ public class HttpClient implements Closeable {
                 if (this.configuration.getProxy().getUsername() != null && this.configuration.getProxy().getPassword() != null) {
                     builder.setProxyAuthenticationStrategy(new DefaultAuthenticationStrategy());
 
-                    credentialsStore.setCredentials(
+                    this.defaultCredentialsProvider.setCredentials(
                         new AuthScope(proxyAddress, port),
                         new UsernamePasswordCredentials(
                             runContext.render(this.configuration.getProxy().getUsername()).as(String.class).orElseThrow(),
@@ -171,24 +173,12 @@ public class HttpClient implements Closeable {
             builder.disableRedirectHandling();
         }
 
-        if (!runContext.render(this.configuration.getAllowFailed()).as(Boolean.class).orElseThrow()) {
-            builder.addResponseInterceptorLast(new FailedResponseInterceptor());
-        }
-
-        if (this.configuration.getAllowedResponseCodes() != null) {
-            List<Integer> list = runContext.render(this.configuration.getAllowedResponseCodes()).asList(Integer.class);
-
-            if (!list.isEmpty()) {
-                builder.addResponseInterceptorLast(new FailedResponseInterceptor(list));
-            }
-        }
-
         builder.addResponseInterceptorLast(new RunContextResponseInterceptor(this.runContext));
 
         // builder object
         connectionManagerBuilder.setDefaultConnectionConfig(connectionConfig.build());
         builder.setConnectionManager(connectionManagerBuilder.build());
-        builder.setDefaultCredentialsProvider(credentialsStore);
+        builder.setDefaultCredentialsProvider(this.defaultCredentialsProvider);
 
         this.client = builder.build();
 
@@ -217,9 +207,14 @@ public class HttpClient implements Closeable {
      * @return the response
      */
     public <T> HttpResponse<T> request(HttpRequest request, Class<T> cls) throws HttpClientException, IllegalVariableEvaluationException {
+        boolean allowFailed = runContext.render(this.configuration.getAllowFailed()).as(Boolean.class).orElseThrow();
+        List<Integer> allowedResponseCodes = this.configuration.getAllowedResponseCodes() != null ?
+            runContext.render(this.configuration.getAllowedResponseCodes()).asList(Integer.class) :
+            null;
         HttpClientContext httpClientContext = this.clientContext(request);
 
         return this.request(request, httpClientContext, r -> {
+            this.throwIfResponseNotAllowed(r, httpClientContext, allowFailed, allowedResponseCodes);
             T body = bodyHandler(cls, r.getEntity());
 
             return HttpResponse.from(r, body, request, httpClientContext);
@@ -234,9 +229,14 @@ public class HttpClient implements Closeable {
      * @return the response without the body
      */
     public HttpResponse<Void> request(HttpRequest request, Consumer<HttpResponse<InputStream>> consumer) throws HttpClientException, IllegalVariableEvaluationException {
+        boolean allowFailed = runContext.render(this.configuration.getAllowFailed()).as(Boolean.class).orElseThrow();
+        List<Integer> allowedResponseCodes = this.configuration.getAllowedResponseCodes() != null ?
+            runContext.render(this.configuration.getAllowedResponseCodes()).asList(Integer.class) :
+            null;
         HttpClientContext httpClientContext = this.clientContext(request);
 
         return this.request(request, httpClientContext, r -> {
+            this.throwIfResponseNotAllowed(r, httpClientContext, allowFailed, allowedResponseCodes);
             HttpResponse<InputStream> from = HttpResponse.from(
                 r,
                 r.getEntity() != null ? r.getEntity().getContent() : null,
@@ -258,19 +258,74 @@ public class HttpClient implements Closeable {
      * @return the response
      */
     public <T> HttpResponse<T> request(HttpRequest request) throws HttpClientException, IllegalVariableEvaluationException {
+        boolean allowFailed = runContext.render(this.configuration.getAllowFailed()).as(Boolean.class).orElseThrow();
+        List<Integer> allowedResponseCodes = this.configuration.getAllowedResponseCodes() != null ?
+            runContext.render(this.configuration.getAllowedResponseCodes()).asList(Integer.class) :
+            null;
         HttpClientContext httpClientContext = this.clientContext(request);
 
         return this.request(request, httpClientContext, response -> {
+            this.throwIfResponseNotAllowed(response, httpClientContext, allowFailed, allowedResponseCodes);
             T body = JacksonMapper.ofJson().readValue(response.getEntity().getContent(), new TypeReference<>() {});
 
             return HttpResponse.from(response, body, request, httpClientContext);
         });
     }
 
-    private HttpClientContext clientContext(HttpRequest request) {
-        ContextBuilder contextBuilder = ContextBuilder.create();
+    private HttpClientContext clientContext(HttpRequest request) throws IllegalVariableEvaluationException {
+        HttpClientContext httpClientContext = ContextBuilder.create().build();
 
-        return contextBuilder.build();
+        if (this.configuration.getAuth() instanceof DigestAuthConfiguration digestAuthConfiguration) {
+            String username = runContext.render(digestAuthConfiguration.getUsername()).as(String.class).orElse(null);
+            String password = runContext.render(digestAuthConfiguration.getPassword()).as(String.class).orElse(null);
+
+            if (StringUtils.isEmpty(username) || password == null) {
+                throw new IllegalArgumentException("Digest authentication requires both `username` and `password`.");
+            }
+
+            URI uri = request.getUri();
+            if (uri == null || uri.getHost() == null) {
+                throw new IllegalArgumentException("Digest authentication requires an absolute URI with a host.");
+            }
+
+            int port = uri.getPort() != -1 ? uri.getPort() : ("https".equalsIgnoreCase(uri.getScheme()) ? 443 : 80);
+            AuthScope digestScope = new AuthScope(uri.getHost(), port);
+            UsernamePasswordCredentials digestCredentials = new UsernamePasswordCredentials(username, password.toCharArray());
+
+            httpClientContext.setCredentialsProvider((authScope, context) -> {
+                if (digestScope.match(authScope) >= 0) {
+                    return digestCredentials;
+                }
+                return this.defaultCredentialsProvider.getCredentials(authScope, context);
+            });
+        }
+
+        return httpClientContext;
+    }
+
+    private void throwIfResponseNotAllowed(
+        org.apache.hc.core5.http.HttpResponse response,
+        HttpClientContext context,
+        boolean allowFailed,
+        List<Integer> allowedResponseCodes
+    ) throws IOException {
+        if (isAllowedStatusCode(response.getCode(), allowFailed, allowedResponseCodes)) {
+            return;
+        }
+
+        throw new IOException(HttpResponseFailure.exception(response, context));
+    }
+
+    private static boolean isAllowedStatusCode(int statusCode, boolean allowFailed, List<Integer> allowedResponseCodes) {
+        if (allowedResponseCodes != null && !allowedResponseCodes.isEmpty()) {
+            return allowedResponseCodes.contains(statusCode);
+        }
+
+        if (allowFailed) {
+            return true;
+        }
+
+        return statusCode < 400;
     }
 
     private <T> HttpResponse<T> request(

--- a/core/src/main/java/io/kestra/core/http/client/apache/FailedResponseInterceptor.java
+++ b/core/src/main/java/io/kestra/core/http/client/apache/FailedResponseInterceptor.java
@@ -1,16 +1,12 @@
 package io.kestra.core.http.client.apache;
 
-import io.kestra.core.http.HttpResponse;
-import io.kestra.core.http.HttpService;
 import io.kestra.core.http.client.HttpClientResponseException;
 import org.apache.hc.core5.http.EntityDetails;
-import org.apache.hc.core5.http.HttpEntityContainer;
 import org.apache.hc.core5.http.HttpException;
 import org.apache.hc.core5.http.HttpResponseInterceptor;
 import org.apache.hc.core5.http.protocol.HttpContext;
 
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import java.util.List;
 
 public class FailedResponseInterceptor implements HttpResponseInterceptor {
@@ -39,15 +35,6 @@ public class FailedResponseInterceptor implements HttpResponseInterceptor {
     }
 
     private void raiseError(org.apache.hc.core5.http.HttpResponse response, HttpContext context) throws IOException, HttpClientResponseException {
-        String error = "Failed http request with response code '" + response.getCode() + "'";
-
-        if (response instanceof HttpEntityContainer httpEntity && httpEntity.getEntity() != null) {
-            HttpService.HttpEntityCopy copy = HttpService.copy(httpEntity.getEntity());
-            httpEntity.setEntity(copy);
-
-            error += " and body:\n" + new String(copy.getBody(), StandardCharsets.UTF_8);
-        }
-
-        throw new HttpClientResponseException(error, HttpResponse.from(response, context));
+        throw HttpResponseFailure.exception(response, context);
     }
 }

--- a/core/src/main/java/io/kestra/core/http/client/apache/HttpResponseFailure.java
+++ b/core/src/main/java/io/kestra/core/http/client/apache/HttpResponseFailure.java
@@ -1,0 +1,29 @@
+package io.kestra.core.http.client.apache;
+
+import io.kestra.core.http.HttpResponse;
+import io.kestra.core.http.HttpService;
+import io.kestra.core.http.client.HttpClientResponseException;
+import org.apache.hc.core5.http.HttpEntityContainer;
+import org.apache.hc.core5.http.protocol.HttpContext;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+public final class HttpResponseFailure {
+    private HttpResponseFailure() {
+    }
+
+    public static HttpClientResponseException exception(org.apache.hc.core5.http.HttpResponse response, HttpContext context) throws IOException {
+        String error = "Failed http request with response code '" + response.getCode() + "'";
+
+        if (response instanceof HttpEntityContainer httpEntity && httpEntity.getEntity() != null) {
+            HttpService.HttpEntityCopy copy = HttpService.copy(httpEntity.getEntity());
+            httpEntity.setEntity(copy);
+
+            error += " and body:\n" + new String(copy.getBody(), StandardCharsets.UTF_8);
+        }
+
+        return new HttpClientResponseException(error, HttpResponse.from(response, context));
+    }
+}
+

--- a/core/src/main/java/io/kestra/core/http/client/configurations/AbstractAuthConfiguration.java
+++ b/core/src/main/java/io/kestra/core/http/client/configurations/AbstractAuthConfiguration.java
@@ -11,7 +11,8 @@ import org.apache.hc.client5.http.impl.classic.HttpClientBuilder;
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type", visible = true, include = JsonTypeInfo.As.EXISTING_PROPERTY)
 @JsonSubTypes({
     @JsonSubTypes.Type(value = BasicAuthConfiguration.class, name = "BASIC"),
-    @JsonSubTypes.Type(value = BearerAuthConfiguration.class, name = "BEARER")
+    @JsonSubTypes.Type(value = BearerAuthConfiguration.class, name = "BEARER"),
+    @JsonSubTypes.Type(value = DigestAuthConfiguration.class, name = "DIGEST")
 })
 @SuperBuilder(toBuilder = true)
 @NoArgsConstructor
@@ -22,6 +23,7 @@ public abstract class AbstractAuthConfiguration {
 
     public enum AuthType {
         BASIC,
-        BEARER
+        BEARER,
+        DIGEST
     }
 }

--- a/core/src/main/java/io/kestra/core/http/client/configurations/BasicAuthConfiguration.java
+++ b/core/src/main/java/io/kestra/core/http/client/configurations/BasicAuthConfiguration.java
@@ -22,6 +22,7 @@ public class BasicAuthConfiguration extends AbstractAuthConfiguration {
     @NotNull
     @JsonInclude
     @Builder.Default
+    @Getter(AccessLevel.NONE)
     protected AuthType type = AuthType.BASIC;
 
     @Schema(title = "The username for HTTP basic authentication.")
@@ -43,5 +44,10 @@ public class BasicAuthConfiguration extends AbstractAuthConfiguration {
                 HttpHeaders.AUTHORIZATION,
                 "Basic " + new String(encoded, StandardCharsets.UTF_8)
             )));
+    }
+
+    @Override
+    public AuthType getType() {
+        return this.type;
     }
 }

--- a/core/src/main/java/io/kestra/core/http/client/configurations/BearerAuthConfiguration.java
+++ b/core/src/main/java/io/kestra/core/http/client/configurations/BearerAuthConfiguration.java
@@ -6,6 +6,7 @@ import io.kestra.core.models.property.Property;
 import io.kestra.core.runners.RunContext;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
+import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -21,6 +22,7 @@ public class BearerAuthConfiguration extends AbstractAuthConfiguration {
     @NotNull
     @JsonInclude
     @Builder.Default
+    @Getter(AccessLevel.NONE)
     protected AuthType type = AuthType.BEARER;
 
     @Schema(title = "The token for bearer token authentication.")
@@ -34,5 +36,10 @@ public class BearerAuthConfiguration extends AbstractAuthConfiguration {
                 HttpHeaders.AUTHORIZATION,
                 "Bearer " + renderedToken
             )));
+    }
+
+    @Override
+    public AuthType getType() {
+        return this.type;
     }
 }

--- a/core/src/main/java/io/kestra/core/http/client/configurations/DigestAuthConfiguration.java
+++ b/core/src/main/java/io/kestra/core/http/client/configurations/DigestAuthConfiguration.java
@@ -1,0 +1,36 @@
+package io.kestra.core.http.client.configurations;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import io.kestra.core.exceptions.IllegalVariableEvaluationException;
+import io.kestra.core.models.property.Property;
+import io.kestra.core.runners.RunContext;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+import org.apache.hc.client5.http.impl.DefaultAuthenticationStrategy;
+import org.apache.hc.client5.http.impl.classic.HttpClientBuilder;
+
+@SuperBuilder(toBuilder = true)
+@Getter
+@NoArgsConstructor
+public class DigestAuthConfiguration extends AbstractAuthConfiguration {
+    @NotNull
+    @JsonInclude
+    @Builder.Default
+    protected AuthType type = AuthType.DIGEST;
+
+    @Schema(title = "The username for HTTP Digest authentication.")
+    private Property<String> username;
+
+    @Schema(title = "The password for HTTP Digest authentication.")
+    private Property<String> password;
+
+    @Override
+    public void configure(HttpClientBuilder builder, RunContext runContext) throws IllegalVariableEvaluationException {
+        builder.setTargetAuthenticationStrategy(new DefaultAuthenticationStrategy());
+    }
+}
+

--- a/core/src/main/java/io/kestra/core/http/client/configurations/DigestAuthConfiguration.java
+++ b/core/src/main/java/io/kestra/core/http/client/configurations/DigestAuthConfiguration.java
@@ -6,6 +6,7 @@ import io.kestra.core.models.property.Property;
 import io.kestra.core.runners.RunContext;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
+import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -20,6 +21,7 @@ public class DigestAuthConfiguration extends AbstractAuthConfiguration {
     @NotNull
     @JsonInclude
     @Builder.Default
+    @Getter(AccessLevel.NONE)
     protected AuthType type = AuthType.DIGEST;
 
     @Schema(title = "The username for HTTP Digest authentication.")
@@ -32,5 +34,9 @@ public class DigestAuthConfiguration extends AbstractAuthConfiguration {
     public void configure(HttpClientBuilder builder, RunContext runContext) throws IllegalVariableEvaluationException {
         builder.setTargetAuthenticationStrategy(new DefaultAuthenticationStrategy());
     }
-}
 
+    @Override
+    public AuthType getType() {
+        return this.type;
+    }
+}

--- a/core/src/main/java/io/kestra/plugin/core/http/Request.java
+++ b/core/src/main/java/io/kestra/plugin/core/http/Request.java
@@ -65,6 +65,25 @@ import java.util.OptionalInt;
                 """
         ),
         @Example(
+            title = "Make an HTTP request authenticated with Digest auth (RFC 7616).",
+            full = true,
+            code = """
+                id: digest_auth_call
+                namespace: company.team
+
+                tasks:
+                  - id: digest_auth_api
+                    type: io.kestra.plugin.core.http.Request
+                    uri: https://example.com/protected
+                    method: GET
+                    options:
+                      auth:
+                        type: DIGEST
+                        username: "{{ secret('API_USERNAME') }}"
+                        password: "{{ secret('API_PASSWORD') }}"
+                """
+        ),
+        @Example(
             title = "Execute a Kestra flow via an HTTP request authenticated with a Bearer auth token / JWT token.",
             full = true,
             code = """

--- a/core/src/test/java/io/kestra/plugin/core/http/RequestTest.java
+++ b/core/src/test/java/io/kestra/plugin/core/http/RequestTest.java
@@ -36,11 +36,14 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
 import java.time.Duration;
 import java.util.Base64;
+import java.util.HexFormat;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.TreeMap;
 
 import static io.kestra.core.tenant.TenantService.MAIN_TENANT;
 import static io.kestra.core.utils.Rethrow.throwFunction;
@@ -582,6 +585,91 @@ class RequestTest {
     }
 
     @Test
+    void allowedResponseCodesEnforcedForSuccessResponses() {
+        try (
+            ApplicationContext applicationContext = ApplicationContext.run();
+            EmbeddedServer server = applicationContext.getBean(EmbeddedServer.class).start();
+        ) {
+            Request task = Request.builder()
+                .id(RequestTest.class.getSimpleName())
+                .type(RequestTest.class.getName())
+                .uri(Property.ofValue(server.getURL().toString() + "/hello"))
+                .options(HttpConfiguration.builder()
+                    .allowedResponseCodes(Property.ofValue(List.of(201)))
+                    .build()
+                )
+                .build();
+
+            RunContext runContext = TestsUtils.mockRunContext(this.runContextFactory, task, Map.of());
+
+            HttpClientResponseException exception = assertThrows(
+                HttpClientResponseException.class,
+                () -> task.run(runContext)
+            );
+
+            assertThat(exception.getResponse().getStatus().getCode()).isEqualTo(200);
+        }
+    }
+
+    @Test
+    void digestAuthMd5() throws Exception {
+        try (
+            ApplicationContext applicationContext = ApplicationContext.run();
+            EmbeddedServer server = applicationContext.getBean(EmbeddedServer.class).start();
+        ) {
+            Request task = Request.builder()
+                .id(RequestTest.class.getSimpleName())
+                .type(RequestTest.class.getName())
+                .uri(Property.ofValue(server.getURL().toString() + "/auth/digest/md5"))
+                .options(HttpConfiguration.builder()
+                    .auth(DigestAuthConfiguration.builder()
+                        .username(Property.ofValue("John"))
+                        .password(Property.ofValue("p4ss"))
+                        .build()
+                    )
+                    .build()
+                )
+                .build();
+
+            RunContext runContext = TestsUtils.mockRunContext(this.runContextFactory, task, Map.of());
+
+            Request.Output output = task.run(runContext);
+
+            assertThat(output.getBody()).isEqualTo("{\"hello\":\"John\"}");
+            assertThat(output.getCode()).isEqualTo(200);
+        }
+    }
+
+    @Test
+    void digestAuthSha256() throws Exception {
+        try (
+            ApplicationContext applicationContext = ApplicationContext.run();
+            EmbeddedServer server = applicationContext.getBean(EmbeddedServer.class).start();
+        ) {
+            Request task = Request.builder()
+                .id(RequestTest.class.getSimpleName())
+                .type(RequestTest.class.getName())
+                .uri(Property.ofValue(server.getURL().toString() + "/auth/digest/sha256"))
+                .options(HttpConfiguration.builder()
+                    .auth(DigestAuthConfiguration.builder()
+                        .username(Property.ofValue("John"))
+                        .password(Property.ofValue("p4ss"))
+                        .build()
+                    )
+                    .build()
+                )
+                .build();
+
+            RunContext runContext = TestsUtils.mockRunContext(this.runContextFactory, task, Map.of());
+
+            Request.Output output = task.run(runContext);
+
+            assertThat(output.getBody()).isEqualTo("{\"hello\":\"John\"}");
+            assertThat(output.getCode()).isEqualTo(200);
+        }
+    }
+
+    @Test
     void specialContentType() throws Exception {
         try (
             ApplicationContext applicationContext = ApplicationContext.run();
@@ -634,6 +722,10 @@ class RequestTest {
 
         private static final int LARGE_BODY_SIZE = 20 * 1024 * 1024; // 20MB > 19MB safeguard
         private static final String LARGE_BODY = "a".repeat(LARGE_BODY_SIZE);
+        private static final String DIGEST_REALM = "kestra";
+        private static final String DIGEST_OPAQUE = "kestra-opaque";
+        private static final String DIGEST_NONCE_MD5 = "kestra-md5-nonce";
+        private static final String DIGEST_NONCE_SHA256 = "kestra-sha256-nonce";
 
         @Get("/hello")
         HttpResponse<String> hello() {
@@ -702,6 +794,16 @@ class RequestTest {
                 .orElseThrow();
         }
 
+        @Get("/auth/digest/md5")
+        HttpResponse<String> digestAuthMd5(HttpRequest<?> request) {
+            return handleDigestAuth(request, "MD5", DIGEST_NONCE_MD5);
+        }
+
+        @Get("/auth/digest/sha256")
+        HttpResponse<String> digestAuthSha256(HttpRequest<?> request) {
+            return handleDigestAuth(request, "SHA-256", DIGEST_NONCE_SHA256);
+        }
+
         @Post(uri = "/post/json")
         HttpResponse<Map<String, String>> postBody(@Body Map<String, String> body) {
             return HttpResponse.ok(body);
@@ -734,6 +836,140 @@ class RequestTest {
         @Get("/large")
         HttpResponse<String> large() {
             return HttpResponse.ok(LARGE_BODY);
+        }
+
+        private static HttpResponse<String> handleDigestAuth(HttpRequest<?> request, String algorithm, String nonce) {
+            var authorization = request.getHeaders().getAuthorization().orElse(null);
+            if (authorization == null || !authorization.startsWith("Digest ")) {
+                return digestChallenge(algorithm, nonce);
+            }
+
+            Map<String, String> directives = parseDigestAuthorization(authorization);
+            String username = directives.get("username");
+            String realm = directives.get("realm");
+            String requestNonce = directives.get("nonce");
+            String uri = directives.get("uri");
+            String response = directives.get("response");
+            String qop = directives.get("qop");
+            String nc = directives.get("nc");
+            String cnonce = directives.get("cnonce");
+
+            if (!"John".equals(username) ||
+                !DIGEST_REALM.equals(realm) ||
+                !nonce.equals(requestNonce) ||
+                response == null ||
+                !"auth".equals(qop) ||
+                nc == null ||
+                cnonce == null ||
+                uri == null
+            ) {
+                return digestChallenge(algorithm, nonce);
+            }
+
+            String method = request.getMethodName();
+            String expected = computeDigestResponse(
+                algorithm,
+                username,
+                realm,
+                "p4ss",
+                method,
+                uri,
+                requestNonce,
+                nc,
+                cnonce,
+                qop
+            );
+
+            if (!expected.equalsIgnoreCase(response)) {
+                return digestChallenge(algorithm, nonce);
+            }
+
+            return HttpResponse.ok("{\"hello\":\"John\"}");
+        }
+
+        private static HttpResponse<String> digestChallenge(String algorithm, String nonce) {
+            return HttpResponse.<String>status(HttpStatus.UNAUTHORIZED)
+                .header(
+                    "WWW-Authenticate",
+                    "Digest realm=\"" + DIGEST_REALM + "\", qop=\"auth\", nonce=\"" + nonce + "\", opaque=\"" + DIGEST_OPAQUE + "\", algorithm=" + algorithm
+                );
+        }
+
+        private static Map<String, String> parseDigestAuthorization(String header) {
+            String payload = header.substring("Digest ".length());
+            Map<String, String> directives = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
+
+            StringBuilder token = new StringBuilder();
+            boolean inQuotes = false;
+            for (int i = 0; i < payload.length(); i++) {
+                char c = payload.charAt(i);
+                if (c == '"') {
+                    inQuotes = !inQuotes;
+                    token.append(c);
+                } else if (c == ',' && !inQuotes) {
+                    putDigestDirective(directives, token.toString());
+                    token.setLength(0);
+                } else {
+                    token.append(c);
+                }
+            }
+            putDigestDirective(directives, token.toString());
+
+            return directives;
+        }
+
+        private static void putDigestDirective(Map<String, String> directives, String rawToken) {
+            String token = rawToken.trim();
+            if (token.isEmpty()) {
+                return;
+            }
+
+            int equalsIndex = token.indexOf('=');
+            if (equalsIndex == -1) {
+                return;
+            }
+
+            String key = token.substring(0, equalsIndex).trim();
+            String rawValue = token.substring(equalsIndex + 1).trim();
+            String value = rawValue;
+            if (value.length() >= 2 && value.startsWith("\"") && value.endsWith("\"")) {
+                value = value.substring(1, value.length() - 1);
+            }
+
+            directives.put(key, value);
+        }
+
+        private static String computeDigestResponse(
+            String algorithm,
+            String username,
+            String realm,
+            String password,
+            String method,
+            String digestUri,
+            String nonce,
+            String nc,
+            String cnonce,
+            String qop
+        ) {
+            String ha1 = hash(algorithm, username + ":" + realm + ":" + password);
+            String ha2 = hash(algorithm, method + ":" + digestUri);
+            return hash(algorithm, ha1 + ":" + nonce + ":" + nc + ":" + cnonce + ":" + qop + ":" + ha2);
+        }
+
+        private static String hash(String algorithm, String input) {
+            String javaAlgorithm = switch (algorithm) {
+                case "MD5" -> "MD5";
+                case "SHA-256" -> "SHA-256";
+                default -> throw new IllegalArgumentException("Unsupported digest algorithm: " + algorithm);
+            };
+
+            try {
+                MessageDigest digest = MessageDigest.getInstance(javaAlgorithm);
+                byte[] hashed = digest.digest(input.getBytes(StandardCharsets.ISO_8859_1));
+                return HexFormat.of().formatHex(hashed);
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
         }
     }
 


### PR DESCRIPTION
Resolves #14146 

Adds `options.auth.type: DIGEST` (username/password) for HTTP tasks (Request/Download/http()).

Digest requires an initial 401 challenge/response handshake, so failure handling runs after execution to avoid aborting negotiation.

Also preserves allowedResponseCodes semantics, scopes digest creds to per-request HttpClientContext, and centralizes error construction for readability.