### PR TITLE
fix(ui): prevent restart tooltip blocking clicks

### DIFF
--- a/ui/src/components/executions/overview/components/actions/Restart.vue
+++ b/ui/src/components/executions/overview/components/actions/Restart.vue
@@ -2,9 +2,11 @@
     <el-tooltip
         v-if="isReplay || enabled"
         :placement="tooltipPosition"
+        :enterable="false"
         :persistent="false"
         :hideAfter="0"
         :content="tooltip"
+        popperClass="ks-restart-tooltip--no-pointer"
         rawContent
         transition=""
         effect="light"
@@ -108,7 +110,7 @@
         execution: {type: Object, required: true},
         taskRun: {type: Object, required: false, default: undefined},
         attemptIndex: {type: Number, required: false, default: undefined},
-        tooltipPosition: {type: String, default: "bottom"}
+        tooltipPosition: {type: String, default: "bottom"},
     })
 
     const emit = defineEmits(["follow"])
@@ -237,6 +239,12 @@
 
     watch(isOpen, (newValue) => newValue && loadRevision())
 </script>
+
+<style lang="scss">
+    .ks-restart-tooltip--no-pointer {
+        pointer-events: none;
+    }
+</style>
 
 <style scoped lang="scss">
 .execution-description {


### PR DESCRIPTION
Prevent the restart/replay tooltip from covering resume or other actions.
This is especially annoying with the Resume buttons new location.


https://github.com/user-attachments/assets/4dc31d0f-7a10-4ca7-a16f-2fa794d6bfd5

