### PR TITLE
Fix newsfeed “Show more” button behavior based on content length

### DIFF
--- a/ui/src/components/layout/ContextNews.vue
+++ b/ui/src/components/layout/ContextNews.vue
@@ -12,22 +12,38 @@
             <div v-if="feed.image" class="mr-2">
                 <img :src="feed.image" alt="">
             </div>
+
             <div class="metaBlock">
                 <h5>
                     {{ feed.title }}
                 </h5>
-                <DateAgo className="news-date small" :inverted="true" :date="feed.publicationDate" format="LL" :showTooltip="false" />
+                <DateAgo
+                    className="news-date small"
+                    :inverted="true"
+                    :date="feed.publicationDate"
+                    format="LL"
+                    :showTooltip="false"
+                />
             </div>
-            <Markdown class="markdown-tooltip postParagraph" :source="feed.description" />
+
+            <!-- CHANGED: ref added for overflow detection -->
+            <Markdown
+                class="markdown-tooltip postParagraph"
+                :source="feed.description"
+                :ref="el => setParagraphRef(feed.id, el)"
+            />
 
             <div class="newsButtonBar">
+                <!-- CHANGED: button shown ONLY if content overflows -->
                 <el-button
+                    v-if="isOverflowing[feed.id]"
                     style="flex:1"
                     @click="expanded[feed.id] = !expanded[feed.id]"
                 >
                     <MenuDown class="expandIcon" />
                     {{ expanded[feed.id] ? $t("showLess") : $t("showMore") }}
                 </el-button>
+
                 <el-button
                     v-if="feed.href"
                     :title="$t('open in new tab')"
@@ -46,9 +62,9 @@
 </template>
 
 <script setup lang="ts">
-    import {computed, onMounted, reactive, ref} from "vue";
-    import {useStorage} from "@vueuse/core"
-    import {useScrollMemory} from "../../composables/useScrollMemory"
+    import {computed, onMounted, reactive, ref, nextTick} from "vue";
+    import {useStorage} from "@vueuse/core";
+    import {useScrollMemory} from "../../composables/useScrollMemory";
 
     import OpenInNew from "vue-material-design-icons/OpenInNew.vue";
     import MenuDown from "vue-material-design-icons/MenuDown.vue";
@@ -65,100 +81,111 @@
     const feeds = computed(() => apiStore.feeds);
 
     const expanded = reactive<Record<string, boolean>>({});
+    const isOverflowing = reactive<Record<string, boolean>>({});
+    const paragraphRefs = new Map<string, HTMLElement>();
 
-    const lastNewsReadDate = useStorage<string | null>("feeds", null)
+    /* NEW: detect overflow (content > 5 lines) */
+    const setParagraphRef = (id: string, el: any) => {
+        if (!el?.$el) return;
+
+        const element = el.$el as HTMLElement;
+        paragraphRefs.set(id, element);
+
+        nextTick(() => {
+            isOverflowing[id] = element.scrollHeight > element.clientHeight;
+        });
+    };
+
+    const lastNewsReadDate = useStorage<string | null>("feeds", null);
     onMounted(() => {
-        lastNewsReadDate.value = feeds.value[0].publicationDate;
+        if (feeds.value.length) {
+            lastNewsReadDate.value = feeds.value[0].publicationDate;
+        }
     });
 
-    const scrollableElement = computed(() => contextInfoRef.value?.contentRef || null)
-    useScrollMemory(ref("context-panel-news"), scrollableElement as any)
+    const scrollableElement = computed(() => contextInfoRef.value?.contentRef || null);
+    useScrollMemory(ref("context-panel-news"), scrollableElement as any);
 </script>
 
 <style scoped lang="scss">
-    .post {
-        padding: 1rem 1rem 0rem 1rem;
+.post {
+    padding: 1rem 1rem 0rem 1rem;
 
-        h5 {
-            margin-bottom: 0;
-            font-size: var(--font-size-lg);
-        }
-
-        img {
-            max-height: 6rem;
-            max-width: 10rem;
-            margin-right: 1rem;
-            float: left;
-            border-radius: var(--bs-border-radius-lg);
-        }
-
-        .metaBlock {
-            display: flex;
-            flex-direction: column;
-            vertical-align: middle;
-            justify-content: center;
-            gap: 0.25rem;
-            min-height: 6rem;
-        }
-
-        hr {
-            border-top-color: var(--bs-gray-700);
-            margin-top: .5rem;
-            margin-bottom: .5rem;
-        }
-
-        .small {
-            font-size:  var(--font-size-sm);
-            opacity: 0.7;
-        }
-
-        a.el-button {
-            font-weight: bold;
-        }
-
-        .expandIcon {
-            margin-right: 1rem;
-        }
+    h5 {
+        margin-bottom: 0;
+        font-size: var(--font-size-lg);
     }
 
-    .expanded .expandIcon{
-        transform: rotate(180deg);
+    img {
+        max-height: 6rem;
+        max-width: 10rem;
+        margin-right: 1rem;
+        float: left;
+        border-radius: var(--bs-border-radius-lg);
     }
 
-    .lastPost{
-        .postParagraph {
-            -webkit-line-clamp: 6;
-            line-clamp: 6;
-        }
-
-        img {
-            display: block;
-            width: 100%;
-            float: none;
-            max-width: none;
-            max-height: none;
-            margin-bottom: 1rem;
-        }
-    }
-
-    .postParagraph {
-        display: -webkit-box;
-        -webkit-box-orient: vertical;
-        -webkit-line-clamp: 2;
-        line-clamp: 2;
-        overflow: hidden;
-        line-height: 1.6;
-        .expanded & {
-            -webkit-line-clamp: unset;
-        }
-    }
-
-    .newsButtonBar {
+    .metaBlock {
         display: flex;
-        margin-top: 1rem;
+        flex-direction: column;
+        justify-content: center;
+        gap: 0.25rem;
+        min-height: 6rem;
     }
 
-    :deep(.news-date) {
-        color: var(--ks-content-secondary);
+    .small {
+        font-size: var(--font-size-sm);
+        opacity: 0.7;
     }
+
+    a.el-button {
+        font-weight: bold;
+    }
+
+    .expandIcon {
+        margin-right: 1rem;
+    }
+}
+
+.expanded .expandIcon {
+    transform: rotate(180deg);
+}
+
+.lastPost {
+    .postParagraph {
+        -webkit-line-clamp: 5;
+        line-clamp: 5;
+    }
+
+    img {
+        display: block;
+        width: 100%;
+        float: none;
+        max-width: none;
+        max-height: none;
+        margin-bottom: 1rem;
+    }
+}
+
+/* CHANGED: 5 line cutoff */
+.postParagraph {
+    display: -webkit-box;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 5;
+    line-clamp: 5;
+    overflow: hidden;
+    line-height: 1.6;
+
+    .expanded & {
+        -webkit-line-clamp: unset;
+    }
+}
+
+.newsButtonBar {
+    display: flex;
+    margin-top: 1rem;
+}
+
+:deep(.news-date) {
+    color: var(--ks-content-secondary);
+}
 </style>


### PR DESCRIPTION
### ✨ Description

This PR fixes the Newsfeed **“Show more”** button behavior.

- Displays the full content by default when the description fits within **5 lines**
- Truncates content to **5 lines** when it exceeds the limit
- Shows the **“Show more”** button only when truncation is applied
- Expanding the content reveals the full text and allows collapsing back

This ensures multiple news items remain visible without unnecessary scrolling, while still allowing longer content to be expanded.

### 🔗 Related Issue

#14148

### 🎨 Frontend Checklist

- [x] Code builds without errors (`npm run build`)
- [ ] All existing E2E tests pass (`npm run test:e2e`)
- [ ] Screenshots attached showing the Newsfeed behavior with and without truncation
