### PR TITLE
chore(core): remove redundant Boolean.Type.equals checks on non-nullable values

### DIFF
--- a/core/src/main/java/io/kestra/plugin/core/condition/ExecutionNamespace.java
+++ b/core/src/main/java/io/kestra/plugin/core/condition/ExecutionNamespace.java
@@ -82,7 +82,7 @@ public class ExecutionNamespace extends Condition {
         var renderedNamespace = runContext.render(this.namespace).as(String.class).orElseThrow();
 
         return runContext.render(this.comparison).as(Comparison.class)
-            .orElse(Boolean.TRUE.equals(renderedPrefix) ? Comparison.PREFIX : Comparison.EQUALS)
+            .orElse(renderedPrefix ? Comparison.PREFIX : Comparison.EQUALS)
             .test(conditionContext.getExecution().getNamespace(), renderedNamespace);
     }
 

--- a/core/src/main/java/io/kestra/plugin/core/flow/LoopUntil.java
+++ b/core/src/main/java/io/kestra/plugin/core/flow/LoopUntil.java
@@ -205,7 +205,7 @@ public class LoopUntil extends Task implements FlowableTask<LoopUntil.Output> {
 
         if (childTaskExecuted
             && this.reachedMaximums(runContext, execution, parentTaskRun, true)
-            && Boolean.TRUE.equals(runContext.render(this.failOnMaxReached).as(Boolean.class).orElseThrow())
+            && runContext.render(this.failOnMaxReached).as(Boolean.class).orElseThrow()
         ) {
             return Optional.of(State.Type.FAILED);
         }

--- a/core/src/main/java/io/kestra/plugin/core/kv/Delete.java
+++ b/core/src/main/java/io/kestra/plugin/core/kv/Delete.java
@@ -68,7 +68,7 @@ public class Delete extends Task implements RunnableTask<Delete.Output> {
         String renderedKey = runContext.render(this.key).as(String.class).orElseThrow();
 
         boolean deleted = runContext.namespaceKv(renderedNamespace).delete(renderedKey);
-        if (Boolean.TRUE.equals(runContext.render(this.errorOnMissing).as(Boolean.class).orElseThrow()) && !deleted) {
+        if (runContext.render(this.errorOnMissing).as(Boolean.class).orElseThrow() && !deleted) {
             throw new NoSuchElementException("No value found for key '" + renderedKey + "' in namespace '" + renderedNamespace + "' and `errorOnMissing` is set to true");
         }
 

--- a/core/src/main/java/io/kestra/plugin/core/kv/Get.java
+++ b/core/src/main/java/io/kestra/plugin/core/kv/Get.java
@@ -83,7 +83,7 @@ public class Get extends Task implements RunnableTask<Get.Output> {
             value = runContext.namespaceKv(renderedNamespace).getValue(renderedKey);
         }
 
-        if (Boolean.TRUE.equals(runContext.render(this.errorOnMissing).as(Boolean.class).orElseThrow()) && value.isEmpty()) {
+        if (runContext.render(this.errorOnMissing).as(Boolean.class).orElseThrow() && value.isEmpty()) {
             throw new NoSuchElementException("No value found for key '" + renderedKey + "' in namespace '" + renderedNamespace + "' and `errorOnMissing` is set to true");
         }
 

--- a/core/src/main/java/io/kestra/plugin/core/namespace/DeleteFiles.java
+++ b/core/src/main/java/io/kestra/plugin/core/namespace/DeleteFiles.java
@@ -115,14 +115,14 @@ public class DeleteFiles extends Task implements RunnableTask<Output> {
         var deleteParent = runContext.render(this.deleteParentFolder).as(Boolean.class).orElseThrow();
 
         List<NamespaceFile> matched = namespace.findAllFilesMatching(PathMatcherPredicate.matches(renderedFiles));
-        Set<String> parentFolders = Boolean.TRUE.equals(deleteParent) ? new TreeSet<>() : null;
+        Set<String> parentFolders = deleteParent ? new TreeSet<>() : null;
         long count = matched
             .stream()
             .map(Rethrow.throwFunction(file -> {
                 if (!namespace.delete(Path.of(file.path().replace("\\", "/"))).isEmpty()) {
                     logger.debug(String.format("Deleted %s", (file.path())));
 
-                    if (Boolean.TRUE.equals(deleteParent)) {
+                    if (deleteParent) {
                         trackParentFolder(file, parentFolders);
                     }
                     return true;

--- a/core/src/main/java/io/kestra/plugin/core/state/AbstractState.java
+++ b/core/src/main/java/io/kestra/plugin/core/state/AbstractState.java
@@ -92,7 +92,7 @@ public abstract class AbstractState extends Task {
     }
 
     private String taskRunValue(RunContext runContext) throws IllegalVariableEvaluationException {
-        return Boolean.TRUE.equals(runContext.render(this.taskrunValue).as(Boolean.class).orElseThrow()) ?
+        return runContext.render(this.taskrunValue).as(Boolean.class).orElseThrow() ?
             runContext.storage().getTaskStorageContext().map(StorageContext.Task::getTaskRunValue).orElse(null) : null;
     }
 }

--- a/core/src/main/java/io/kestra/plugin/core/state/Delete.java
+++ b/core/src/main/java/io/kestra/plugin/core/state/Delete.java
@@ -54,7 +54,7 @@ public class Delete extends AbstractState implements RunnableTask<Delete.Output>
 
         boolean delete = this.delete(runContext);
 
-        if (Boolean.TRUE.equals(runContext.render(errorOnMissing).as(Boolean.class).orElseThrow()) && !delete) {
+        if (runContext.render(errorOnMissing).as(Boolean.class).orElseThrow() && !delete) {
             throw new FileNotFoundException("Unable to find the state file '" + runContext.render(this.name).as(String.class).orElseThrow() + "'");
         }
 

--- a/core/src/main/java/io/kestra/plugin/core/state/Get.java
+++ b/core/src/main/java/io/kestra/plugin/core/state/Get.java
@@ -57,7 +57,7 @@ public class Get extends AbstractState implements RunnableTask<Get.Output> {
         try {
             data = this.get(runContext);
         } catch (FileNotFoundException e) {
-            if (Boolean.TRUE.equals(runContext.render(this.errorOnMissing).as(Boolean.class).orElseThrow())) {
+            if (runContext.render(this.errorOnMissing).as(Boolean.class).orElseThrow()) {
                 throw e;
             }
 

--- a/script/src/main/java/io/kestra/plugin/scripts/runner/docker/Docker.java
+++ b/script/src/main/java/io/kestra/plugin/scripts/runner/docker/Docker.java
@@ -377,8 +377,7 @@ public class Docker extends TaskRunner<Docker.DockerTaskRunnerDetailResult> {
 
         try (DockerClient dockerClient = dockerClient(runContext, image, resolvedHost)) {
             // evaluate resume (task property overrides plugin configuration if set)
-            Boolean resumeProp = runContext.render(this.resume).as(Boolean.class).orElse(Boolean.FALSE);
-            boolean resumeEnabled = Boolean.TRUE.equals(resumeProp);
+            boolean resumeEnabled = runContext.render(this.resume).as(Boolean.class).orElse(Boolean.FALSE);
 
             String containerId = null;
 
@@ -513,7 +512,7 @@ public class Docker extends TaskRunner<Docker.DockerTaskRunnerDetailResult> {
 
             final String runContainerId = containerId;
 
-            if (!Boolean.TRUE.equals(runContext.render(wait).as(Boolean.class).orElseThrow())) {
+            if (!runContext.render(wait).as(Boolean.class).orElseThrow()) {
                 return TaskRunnerResult.<DockerTaskRunnerDetailResult>builder()
                     .exitCode(0)
                     .logConsumer(defaultLogConsumer)
@@ -614,7 +613,7 @@ public class Docker extends TaskRunner<Docker.DockerTaskRunnerDetailResult> {
                     // come to a normal end.
                     kill();
 
-                    if (Boolean.TRUE.equals(renderedDelete)) {
+                    if (renderedDelete) {
                         dockerClient.removeContainerCmd(runContainerId).exec();
                         if (logger.isTraceEnabled()) {
                             logger.trace("Container deleted: {}", runContainerId);


### PR DESCRIPTION
## Description
Boolean.TRUE.equals(...) is useful only when the value may be null.
Since orElseThrow() in render().as(...).orElseThrow() throws exception if value is null and otherwise return non-nullable value, so this check is redundant, does not affect behavior, and only adds unnecessary noise / IDE warnings.