### PR TITLE
fix(trigger): Expression and ExecutionOutputs should not be scheduled…

### DIFF
--- a/core/src/main/java/io/kestra/core/models/conditions/ScheduleCondition.java
+++ b/core/src/main/java/io/kestra/core/models/conditions/ScheduleCondition.java
@@ -2,7 +2,10 @@ package io.kestra.core.models.conditions;
 
 import io.kestra.core.exceptions.InternalException;
 
-
+/**
+ * A ScheduleCondition is a special type of condition that will be used by the Schedule trigger when computing its next date.
+ * Such condition must be a condition on a date or there is a risk of infinite evaluation of the trigger (each on sec).
+ */
 public interface ScheduleCondition {
     boolean test(ConditionContext conditionContext) throws InternalException;
 }

--- a/core/src/main/java/io/kestra/plugin/core/condition/ExecutionOutputs.java
+++ b/core/src/main/java/io/kestra/plugin/core/condition/ExecutionOutputs.java
@@ -3,14 +3,11 @@ package io.kestra.plugin.core.condition;
 import io.kestra.core.exceptions.InternalException;
 import io.kestra.core.models.annotations.Example;
 import io.kestra.core.models.annotations.Plugin;
-import io.kestra.core.models.annotations.PluginProperty;
 import io.kestra.core.models.conditions.Condition;
 import io.kestra.core.models.conditions.ConditionContext;
-import io.kestra.core.models.conditions.ScheduleCondition;
 import io.kestra.core.models.executions.Execution;
 import io.kestra.core.models.property.Property;
 import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -84,7 +81,7 @@ import static io.kestra.core.utils.MapUtils.mergeWithNullableValues;
     },
     aliases = {"io.kestra.core.models.conditions.types.ExecutionOutputsCondition", "io.kestra.plugin.core.condition.ExecutionOutputsCondition"}
 )
-public class ExecutionOutputs extends Condition implements ScheduleCondition {
+public class ExecutionOutputs extends Condition {
 
     private static final String TRIGGER_VAR = "trigger";
     private static final String OUTPUTS_VAR = "outputs";

--- a/core/src/main/java/io/kestra/plugin/core/condition/Expression.java
+++ b/core/src/main/java/io/kestra/plugin/core/condition/Expression.java
@@ -53,7 +53,7 @@ import jakarta.validation.constraints.NotNull;
     },
     aliases = {"io.kestra.core.models.conditions.types.VariableCondition", "io.kestra.plugin.core.condition.ExpressionCondition"}
 )
-public class Expression extends Condition implements ScheduleCondition {
+public class Expression extends Condition {
     @NotNull
     private Property<String> expression;
 

--- a/core/src/test/java/io/kestra/plugin/core/trigger/ScheduleTest.java
+++ b/core/src/test/java/io/kestra/plugin/core/trigger/ScheduleTest.java
@@ -17,6 +17,7 @@ import io.kestra.core.models.flows.input.MultiselectInput;
 import io.kestra.core.models.triggers.AbstractTrigger;
 import io.kestra.core.models.triggers.TriggerContext;
 import io.kestra.core.runners.RunContextFactory;
+import io.kestra.plugin.core.condition.Expression;
 import io.kestra.plugin.core.condition.TimeBetween;
 import io.kestra.plugin.core.debug.Return;
 import io.kestra.core.utils.IdUtils;
@@ -695,6 +696,32 @@ class ScheduleTest {
                 .type(TimeBetween.class.getName())
                 .before(Property.ofValue(before))
                 .after(Property.ofValue(after))
+                .build()
+            ))
+            .build();
+
+        TriggerContext triggerContext = triggerContext(now, trigger).toBuilder().build();
+
+        ConditionContext conditionContext = ConditionContext.builder()
+            .runContext(runContextInitializer.forScheduler((DefaultRunContext) runContextFactory.of(), triggerContext, trigger))
+            .build();
+
+        Optional<ZonedDateTime> result = trigger.truePreviousNextDateWithCondition(trigger.executionTime(), conditionContext, now, true);
+        assertThat(result).isNotEmpty();
+    }
+
+    @Test
+    void shouldGetNextExecutionDateEvenIfExpressionConditionIsFalse() throws InternalException {
+        ZonedDateTime now = ZonedDateTime.now().withZoneSameLocal(ZoneId.of("Europe/Paris"));
+
+        Schedule trigger = Schedule.builder()
+            .id("schedule").type(Schedule.class.getName())
+            .cron("*/30 * * * * *")
+            .withSeconds(true)
+            .timezone("Europe/Paris")
+            .conditions(List.of(Expression.builder()
+                .type(Expression.class.getName())
+                .expression(Property.ofValue("false"))
                 .build()
             ))
             .build();


### PR DESCRIPTION
… condition

ScheduledCondition are special types of conditions used when computing the Schedule trigger next date. If no next date can be computed, the Scheduler will try to compute again the next date after 1s. So ScheduleConditions must be conditions that only works on date to limit the number of date a trigger should be scheduled on.

Without that, it creates a kind of inifinte loop.
In my local machine, this uses 5% CPU whereas with the fix the CPU becomes idle. On resource restricted computers this can cost way more.

Fixes https://github.com/kestra-io/kestra-ee/issues/6444
