### PR TITLE
fix(executions): subflow restart should reflect parent flow changes

### DIFF
--- a/core/src/main/java/io/kestra/core/runners/ExecutableUtils.java
+++ b/core/src/main/java/io/kestra/core/runners/ExecutableUtils.java
@@ -93,7 +93,13 @@ public final class ExecutableUtils {
                 Optional<Execution> existingSubflowExecution = Optional.empty();
                 if (currentTaskRun.getOutputs() != null && currentTaskRun.getOutputs().containsKey("executionId")) {
                     // we know which execution to restart; this should be the case for Subflow tasks
-                    existingSubflowExecution = executionRepository.findById(currentExecution.getTenantId(), (String) currentTaskRun.getOutputs().get("executionId"));
+                    Optional<Execution> subflowExecution = executionRepository.findById(currentExecution.getTenantId(), (String) currentTaskRun.getOutputs().get("executionId"));
+                    if(subflowExecution.isPresent()
+                        && currentTask.subflowId().flowId().equals(subflowExecution.get().getFlowId())
+                        && currentTask.subflowId().namespace().equals(subflowExecution.get().getNamespace())){
+                        existingSubflowExecution = subflowExecution;
+                    }
+
                 }
 
                 if (existingSubflowExecution.isEmpty()) {

--- a/core/src/main/java/io/kestra/core/services/ExecutionService.java
+++ b/core/src/main/java/io/kestra/core/services/ExecutionService.java
@@ -186,7 +186,10 @@ public class ExecutionService {
         return execution.withTaskRun(updateFlowableTaskRun.withState(State.Type.PAUSED)).withState(State.Type.PAUSED);
     }
 
-    public Execution restart(final Execution execution, @Nullable Integer revision) throws Exception {
+    public Execution restart(final Execution givenExecution, @Nullable Integer revision) throws Exception {
+
+        Execution execution = revision != null ? givenExecution.withFlowRevision(revision) : givenExecution;
+
         if (!execution.getState().canBeRestarted()) {
             throw new IllegalStateException("Execution must be terminated to be restarted, " +
                 "current state is '" + execution.getState().getCurrent() + "' !"
@@ -248,7 +251,7 @@ public class ExecutionService {
         }
         newExecution = newExecution.withMetadata(execution.getMetadata().nextAttempt()).withLabels(newLabels);
 
-        return revision != null ? newExecution.withFlowRevision(revision) : newExecution;
+        return newExecution;
     }
 
     private Set<String> taskRunToRestart(Execution execution, Predicate<TaskRun> predicate) {


### PR DESCRIPTION
closes #13641
## Description
- There is assumption that always restarting parent execution should restart last executed subflow execution, which is causing trigger for last executed subflow even if there is change in flowId or namespace in subflow task that refers to the child flow in parent execution which shows why even after changing subflow flowId referance it still gets failed state (which is the last state for subflow execution) not giving succeed as we changed the child flow id reference.
- And since the followed execution has revision for subflow task different from the executed one, a running state for the task appears even it is finished and in failed state (the version of the tracked is different than the versio of the executed one)
## Solution
- We should check that current subflow task has the same flow id and namespace for the last executed subflow to confirm they are the same, otherwise we should create a new subflow execution as we detected a change in parent revision.
- Flow revision should be attached to restarted execution before getting flow from repository to get the right flow revision.