### PR TITLE
fix(dashboards): load home dashboard and guard refresh

### DIFF
--- a/ui/src/components/dashboard/Dashboard.vue
+++ b/ui/src/components/dashboard/Dashboard.vue
@@ -113,6 +113,8 @@
             load(ID, processFlowYaml(YAML_FLOW, route.params.namespace as string, route.params.id as string));
         } else if (props.isNamespace) {
             load(ID, YAML_NAMESPACE);
+        } else {
+            load(ID, YAML_MAIN);
         }
     });
 

--- a/ui/src/components/dashboard/sections/Sections.vue
+++ b/ui/src/components/dashboard/sections/Sections.vue
@@ -91,9 +91,7 @@
     const chartsComponents = ref<{refresh(): void}[]>();
 
     function refreshCharts() {
-        chartsComponents.value!.forEach((component) => {
-            component.refresh();
-        });
+        (chartsComponents.value ?? []).forEach((component) => component.refresh());
     }
 
     defineExpose({


### PR DESCRIPTION
In EE, users with namespace-scoped roles (e.g. Developer on company.team) do not pass the UI check for global FLOW CREATE, so the dashboard selector in the header is hidden. For the home route this meant no component ever invoked the dashboard 'load()' function, so charts never mounted and the preview endpoint (/api/v1/{tenant}/dashboards/charts/preview) was never called.

Load the default (main) dashboard YAML on mount for the home dashboard route so charts render and data requests are issued regardless of global permissions.

Also make dashboard refresh resilient when charts are not mounted: the v-for template ref can be undefined when charts fail to render (e.g. forbidden/empty), which previously caused a TypeError on refresh. Now refresh is a no-op in that case.

closes https://github.com/kestra-io/kestra-ee/issues/6059


https://github.com/user-attachments/assets/4edf98e5-a4d1-47f0-b964-b87ab916fa90


