### PR TITLE
feat: purge-current-execution-files-scope

### DIFF
--- a/core/src/main/java/io/kestra/plugin/core/storage/PurgeCurrentExecutionFiles.java
+++ b/core/src/main/java/io/kestra/plugin/core/storage/PurgeCurrentExecutionFiles.java
@@ -2,6 +2,7 @@ package io.kestra.plugin.core.storage;
 
 import io.kestra.core.models.annotations.Example;
 import io.kestra.core.models.annotations.Plugin;
+import io.kestra.core.models.property.Property;
 import io.kestra.core.models.tasks.RunnableTask;
 import io.kestra.core.models.tasks.Task;
 import io.kestra.core.runners.RunContext;
@@ -28,29 +29,42 @@ import java.util.List;
 @Plugin(
     examples = {
         @Example(
-            title = "Purge all files created by this execution.",
-            full = true,
-            code = """
-                id: purge_execution_files
-                namespace: company.team
-
-                tasks:
-                  - id: download
-                    type: io.kestra.plugin.core.http.Download
-                    uri: https://huggingface.co/datasets/kestra/datasets/raw/main/json/user_events.json
-
-                  - id: purge
-                    type: io.kestra.plugin.core.storage.PurgeCurrentExecutionFiles
-            """
+            title = "Purge all files for the current execution",
+            code = {
+            }
+        ),
+        @Example(
+            title = "Purge files including child executions and state files",
+            code = {
+                "includeChildExecutions: true",
+                "includeStates: true"
+            }
         )
     },
     aliases = {"io.kestra.core.tasks.storages.PurgeExecution", "io.kestra.plugin.core.storage.PurgeExecution"}
 )
 public class PurgeCurrentExecutionFiles extends Task implements RunnableTask<PurgeCurrentExecutionFiles.Output> {
+    @Schema(
+        title = "Whether to purge files from child executions (subflows)",
+        description = "When set to true, this will also purge files from all child executions triggered by subflow tasks."
+    )
+    @Builder.Default
+    private Property<Boolean> includeChildExecutions = Property.ofValue(false);
+
+    @Schema(
+        title = "Whether to purge state files created by Set tasks",
+        description = "When set to true, this will also purge state files created by io.kestra.plugin.core.state.Set tasks."
+    )
+    @Builder.Default
+    private Property<Boolean> includeStates = Property.ofValue(false);
+
     @Override
     public PurgeCurrentExecutionFiles.Output run(RunContext runContext) throws Exception {
+        boolean purgeChildExecutions = runContext.render(includeChildExecutions).as(Boolean.class).orElse(false);
+        boolean purgeStates = runContext.render(includeStates).as(Boolean.class).orElse(false);
+        
         return Output.builder()
-            .uris(runContext.storage().deleteExecutionFiles())
+            .uris(runContext.storage().deleteExecutionFiles(purgeChildExecutions, purgeStates))
             .build();
     }
 

--- a/core/src/test/java/io/kestra/core/tasks/test/SanityCheckTest.java
+++ b/core/src/test/java/io/kestra/core/tasks/test/SanityCheckTest.java
@@ -77,6 +77,13 @@ class SanityCheckTest {
     }
 
     @Test
+    @ExecuteFlow("sanity-checks/purge_current_execution_files_with_children.yaml")
+    void qaPurgeExecutionFilesWithChildren(Execution execution) {
+        assertThat(execution.getTaskRunList()).hasSize(2);
+        assertThat(execution.getState().getCurrent()).isEqualTo(State.Type.SUCCESS);
+    }
+
+    @Test
     @ExecuteFlow("sanity-checks/return.yaml")
     void qaReturn(Execution execution) {
         assertThat(execution.getTaskRunList()).hasSize(2);

--- a/core/src/test/java/io/kestra/plugin/core/storage/PurgeCurrentExecutionFilesTest.java
+++ b/core/src/test/java/io/kestra/plugin/core/storage/PurgeCurrentExecutionFilesTest.java
@@ -3,6 +3,7 @@ package io.kestra.plugin.core.storage;
 import io.kestra.core.context.TestRunContextFactory;
 import io.kestra.core.junit.annotations.KestraTest;
 import io.kestra.core.models.flows.Flow;
+import io.kestra.core.models.property.Property;
 import jakarta.inject.Inject;
 import org.junit.jupiter.api.Test;
 
@@ -37,5 +38,29 @@ class PurgeCurrentExecutionFilesTest {
         var output = purge.run(runContext);
 
         assertThat(output.getUris().size()).isEqualTo(2);
+    }
+
+    @Test
+    void shouldPurgeIncludingChildExecutionsAndStates() throws Exception {
+        var flow  = Flow.builder()
+            .namespace("namespace")
+            .id("flowId")
+            .tenantId(MAIN_TENANT)
+            .build();
+        var runContext = runContextFactory.of(flow, Map.of(
+            "execution", Map.of("id", "executionId"),
+            "task", Map.of("id", "taskId"),
+            "taskrun", Map.of("id", "taskRunId")
+        ));
+        var file = runContext.workingDir().createFile("test.txt", "Hello World".getBytes());
+        runContext.storage().putFile(file.toFile());
+
+        var purge = PurgeCurrentExecutionFiles.builder()
+            .includeChildExecutions(Property.ofValue(true))
+            .includeStates(Property.ofValue(true))
+            .build();
+        var output = purge.run(runContext);
+
+        assertThat(output.getUris())
     }
 }


### PR DESCRIPTION
closes: #7985

### ✨ Description

What does this PR change?  

- This PR extends the `PurgeCurrentExecutionFiles` task to give users explicit control over what execution data is purged, while keeping the current behavior safe by default.

- The existing behavior makes it difficult to safely purge execution files during runtime without risking premature cleanup of subflows or leaving residual execution traces.
 
- This change addresses that limitation while preserving backward compatibility.