### PR TITLE
feat: Abstract the implementation of the emitOnly method into the interface as well

### DIFF
--- a/core/src/main/java/io/kestra/core/queues/QueueInterface.java
+++ b/core/src/main/java/io/kestra/core/queues/QueueInterface.java
@@ -27,6 +27,13 @@ public interface QueueInterface<T> extends Closeable, Pauseable {
         emitAsync(null, messages);
     }
 
+    default void emitOnly(T message) throws QueueException {
+        emitOnly(null, message);
+    }
+
+    void emitOnly(String consumerGroup, T message) throws QueueException;
+
+
     void emitAsync(String consumerGroup, List<T> messages) throws QueueException;
 
     default void delete(T message) throws QueueException {

--- a/core/src/main/java/io/kestra/core/queues/QueueInterface.java
+++ b/core/src/main/java/io/kestra/core/queues/QueueInterface.java
@@ -31,7 +31,9 @@ public interface QueueInterface<T> extends Closeable, Pauseable {
         emitOnly(null, message);
     }
 
-    void emitOnly(String consumerGroup, T message) throws QueueException;
+    default void emitOnly(String consumerGroup, T message) throws QueueException {
+        throw new UnsupportedOperationException();
+    }
 
 
     void emitAsync(String consumerGroup, List<T> messages) throws QueueException;

--- a/jdbc/src/main/java/io/kestra/jdbc/runner/JdbcExecutor.java
+++ b/jdbc/src/main/java/io/kestra/jdbc/runner/JdbcExecutor.java
@@ -1174,7 +1174,7 @@ public class JdbcExecutor implements ExecutorInterface {
             if (hasFailure) {
                 this.executionQueue.emit(executor.getExecution());
             } else {
-                ((JdbcQueue<Execution>) this.executionQueue).emitOnly(null, executor.getExecution());
+                this.executionQueue.emitOnly(null, executor.getExecution());
             }
 
             Execution execution = executor.getExecution();

--- a/jdbc/src/main/java/io/kestra/jdbc/runner/JdbcQueue.java
+++ b/jdbc/src/main/java/io/kestra/jdbc/runner/JdbcQueue.java
@@ -170,6 +170,7 @@ public abstract class JdbcQueue<T> implements QueueInterface<T> {
             .increment();
     }
 
+    @Override
     public void emitOnly(String consumerGroup, T message) throws QueueException{
         this.produce(consumerGroup, queueService.key(message), message, true);
     }

--- a/worker/src/main/java/io/kestra/worker/DefaultWorker.java
+++ b/worker/src/main/java/io/kestra/worker/DefaultWorker.java
@@ -352,7 +352,7 @@ public class DefaultWorker implements Worker {
                 if ("task".equals(type)) {
                     // try to deserialize the taskRun to fail it
                     var taskRun = MAPPER.treeToValue(json.get("taskRun"), TaskRun.class);
-                    this.workerTaskResultQueue.emitOnly(new WorkerTaskResult(taskRun.fail()));
+                    this.workerTaskResultQueue.emit(new WorkerTaskResult(taskRun.fail()));
                 } else if ("trigger".equals(type)) {
                     // try to deserialize the triggerContext to fail it
                     var triggerContext = MAPPER.treeToValue(json.get("triggerContext"), TriggerContext.class);
@@ -382,7 +382,7 @@ public class DefaultWorker implements Worker {
                     workingDirectoryRunContext.logger().error("Failed preExecuteTasks on WorkingDirectory: {}", e.getMessage(), e);
                     WorkerTask failed = workerTask.withTaskRun(workerTask.fail());
                     try {
-                        this.workerTaskResultQueue.emitOnly(new WorkerTaskResult(failed.getTaskRun()));
+                        this.workerTaskResultQueue.emit(new WorkerTaskResult(failed.getTaskRun()));
                     } catch (QueueException ex) {
                         log.error("Unable to emit the worker task result for task {} taskrun {}", failed.getTask().getId(), failed.getTaskRun().getId(), e);
                     }
@@ -406,7 +406,7 @@ public class DefaultWorker implements Worker {
                     try {
                         if (!TruthUtils.isTruthy(runContext.render(currentWorkerTask.getTask().getRunIf()))) {
                             workerTaskResult = new WorkerTaskResult(currentWorkerTask.getTaskRun().withState(SKIPPED).addAttempt(TaskRunAttempt.builder().workerId(this.id).state(new State().withState(SKIPPED)).build()));
-                            this.workerTaskResultQueue.emitOnly(workerTaskResult);
+                            this.workerTaskResultQueue.emit(workerTaskResult);
                         } else {
                             workerTaskResult = this.run(currentWorkerTask, false);
                         }
@@ -414,7 +414,7 @@ public class DefaultWorker implements Worker {
                         RunContextLogger contextLogger = runContextLoggerFactory.create(currentWorkerTask);
                         contextLogger.logger().error("Failed evaluating runIf: {}", e.getMessage(), e);
                         try {
-                            this.workerTaskResultQueue.emitOnly(new WorkerTaskResult(workerTask.fail()));
+                            this.workerTaskResultQueue.emit(new WorkerTaskResult(workerTask.fail()));
                         } catch (QueueException ex) {
                             log.error("Unable to emit the worker task result for task {} taskrun {}", currentWorkerTask.getTask().getId(), currentWorkerTask.getTaskRun().getId(), e);
                         }
@@ -436,7 +436,7 @@ public class DefaultWorker implements Worker {
                 } catch (Exception e) {
                     workingDirectoryRunContext.logger().error("Failed postExecuteTasks on WorkingDirectory: {}", e.getMessage(), e);
                     try {
-                        this.workerTaskResultQueue.emitOnly(new WorkerTaskResult(workerTask.fail()));
+                        this.workerTaskResultQueue.emit(new WorkerTaskResult(workerTask.fail()));
                     } catch (QueueException ex) {
                         log.error("Unable to emit the worker task result for task {} taskrun {}", workerTask.getTask().getId(), workerTask.getTaskRun().getId(), e);
                     }
@@ -658,7 +658,7 @@ public class DefaultWorker implements Worker {
         if (! Boolean.TRUE.equals(workerTask.getTaskRun().getForceExecution()) && killedExecution.contains(workerTask.getTaskRun().getExecutionId())) {
             WorkerTaskResult workerTaskResult = new WorkerTaskResult(workerTask.getTaskRun().withState(KILLED));
             try {
-                this.workerTaskResultQueue.emitOnly(workerTaskResult);
+                this.workerTaskResultQueue.emit(workerTaskResult);
             } catch (QueueException ex) {
                 log.error("Unable to emit the worker task result for task {} taskrun {}", workerTask.getTask().getId(), workerTask.getTaskRun().getId(), ex);
             }
@@ -703,7 +703,7 @@ public class DefaultWorker implements Worker {
                                 List<TaskRunAttempt> attempts = this.addAttempt(workerTask, attempt);
                                 TaskRun taskRun = workerTask.getTaskRun().withAttempts(attempts).withOutputs(variables).withState(SUCCESS);
                                 WorkerTaskResult workerTaskResult = new WorkerTaskResult(taskRun);
-                                this.workerTaskResultQueue.emitOnly(workerTaskResult);
+                                this.workerTaskResultQueue.emit(workerTaskResult);
                                 return workerTaskResult;
                             }
                         }
@@ -760,7 +760,7 @@ public class DefaultWorker implements Worker {
 
             WorkerTaskResult workerTaskResult = new WorkerTaskResult(workerTask.getTaskRun(), dynamicTaskRuns);
 
-            this.workerTaskResultQueue.emitOnly(workerTaskResult);
+            this.workerTaskResultQueue.emit(workerTaskResult);
 
             // upload the cache file, hash may not be present if we didn't succeed in computing it
             if (workerTask.getTask().getTaskCache() != null && workerTask.getTask().getTaskCache().getEnabled() && hash.isPresent() &&
@@ -800,7 +800,7 @@ public class DefaultWorker implements Worker {
             RunContextLogger contextLogger = runContextLoggerFactory.create(workerTask);
             contextLogger.logger().error("Unable to emit the worker task result to the queue: {}", e.getMessage(), e);
             try {
-                this.workerTaskResultQueue.emitOnly(workerTaskResult);
+                this.workerTaskResultQueue.emit(workerTaskResult);
             } catch (QueueException ex) {
                 log.error("Unable to emit the worker task result for task {} taskrun {}", workerTask.getTask().getId(), workerTask.getTaskRun().getId(), e);
             }
@@ -912,7 +912,7 @@ public class DefaultWorker implements Worker {
             .workerId(this.id);
 
         // emit the attempt so the execution knows that the task is in RUNNING
-        this.workerTaskResultQueue.emitOnly(new WorkerTaskResult(
+        this.workerTaskResultQueue.emit(new WorkerTaskResult(
                 workerTask.getTaskRun()
                     .withAttempts(this.addAttempt(workerTask, builder.build()))
             )

--- a/worker/src/main/java/io/kestra/worker/DefaultWorker.java
+++ b/worker/src/main/java/io/kestra/worker/DefaultWorker.java
@@ -352,7 +352,7 @@ public class DefaultWorker implements Worker {
                 if ("task".equals(type)) {
                     // try to deserialize the taskRun to fail it
                     var taskRun = MAPPER.treeToValue(json.get("taskRun"), TaskRun.class);
-                    this.workerTaskResultQueue.emit(new WorkerTaskResult(taskRun.fail()));
+                    this.workerTaskResultQueue.emitOnly(new WorkerTaskResult(taskRun.fail()));
                 } else if ("trigger".equals(type)) {
                     // try to deserialize the triggerContext to fail it
                     var triggerContext = MAPPER.treeToValue(json.get("triggerContext"), TriggerContext.class);
@@ -382,7 +382,7 @@ public class DefaultWorker implements Worker {
                     workingDirectoryRunContext.logger().error("Failed preExecuteTasks on WorkingDirectory: {}", e.getMessage(), e);
                     WorkerTask failed = workerTask.withTaskRun(workerTask.fail());
                     try {
-                        this.workerTaskResultQueue.emit(new WorkerTaskResult(failed.getTaskRun()));
+                        this.workerTaskResultQueue.emitOnly(new WorkerTaskResult(failed.getTaskRun()));
                     } catch (QueueException ex) {
                         log.error("Unable to emit the worker task result for task {} taskrun {}", failed.getTask().getId(), failed.getTaskRun().getId(), e);
                     }
@@ -406,7 +406,7 @@ public class DefaultWorker implements Worker {
                     try {
                         if (!TruthUtils.isTruthy(runContext.render(currentWorkerTask.getTask().getRunIf()))) {
                             workerTaskResult = new WorkerTaskResult(currentWorkerTask.getTaskRun().withState(SKIPPED).addAttempt(TaskRunAttempt.builder().workerId(this.id).state(new State().withState(SKIPPED)).build()));
-                            this.workerTaskResultQueue.emit(workerTaskResult);
+                            this.workerTaskResultQueue.emitOnly(workerTaskResult);
                         } else {
                             workerTaskResult = this.run(currentWorkerTask, false);
                         }
@@ -414,7 +414,7 @@ public class DefaultWorker implements Worker {
                         RunContextLogger contextLogger = runContextLoggerFactory.create(currentWorkerTask);
                         contextLogger.logger().error("Failed evaluating runIf: {}", e.getMessage(), e);
                         try {
-                            this.workerTaskResultQueue.emit(new WorkerTaskResult(workerTask.fail()));
+                            this.workerTaskResultQueue.emitOnly(new WorkerTaskResult(workerTask.fail()));
                         } catch (QueueException ex) {
                             log.error("Unable to emit the worker task result for task {} taskrun {}", currentWorkerTask.getTask().getId(), currentWorkerTask.getTaskRun().getId(), e);
                         }
@@ -436,7 +436,7 @@ public class DefaultWorker implements Worker {
                 } catch (Exception e) {
                     workingDirectoryRunContext.logger().error("Failed postExecuteTasks on WorkingDirectory: {}", e.getMessage(), e);
                     try {
-                        this.workerTaskResultQueue.emit(new WorkerTaskResult(workerTask.fail()));
+                        this.workerTaskResultQueue.emitOnly(new WorkerTaskResult(workerTask.fail()));
                     } catch (QueueException ex) {
                         log.error("Unable to emit the worker task result for task {} taskrun {}", workerTask.getTask().getId(), workerTask.getTaskRun().getId(), e);
                     }
@@ -658,7 +658,7 @@ public class DefaultWorker implements Worker {
         if (! Boolean.TRUE.equals(workerTask.getTaskRun().getForceExecution()) && killedExecution.contains(workerTask.getTaskRun().getExecutionId())) {
             WorkerTaskResult workerTaskResult = new WorkerTaskResult(workerTask.getTaskRun().withState(KILLED));
             try {
-                this.workerTaskResultQueue.emit(workerTaskResult);
+                this.workerTaskResultQueue.emitOnly(workerTaskResult);
             } catch (QueueException ex) {
                 log.error("Unable to emit the worker task result for task {} taskrun {}", workerTask.getTask().getId(), workerTask.getTaskRun().getId(), ex);
             }
@@ -703,7 +703,7 @@ public class DefaultWorker implements Worker {
                                 List<TaskRunAttempt> attempts = this.addAttempt(workerTask, attempt);
                                 TaskRun taskRun = workerTask.getTaskRun().withAttempts(attempts).withOutputs(variables).withState(SUCCESS);
                                 WorkerTaskResult workerTaskResult = new WorkerTaskResult(taskRun);
-                                this.workerTaskResultQueue.emit(workerTaskResult);
+                                this.workerTaskResultQueue.emitOnly(workerTaskResult);
                                 return workerTaskResult;
                             }
                         }
@@ -760,7 +760,7 @@ public class DefaultWorker implements Worker {
 
             WorkerTaskResult workerTaskResult = new WorkerTaskResult(workerTask.getTaskRun(), dynamicTaskRuns);
 
-            this.workerTaskResultQueue.emit(workerTaskResult);
+            this.workerTaskResultQueue.emitOnly(workerTaskResult);
 
             // upload the cache file, hash may not be present if we didn't succeed in computing it
             if (workerTask.getTask().getTaskCache() != null && workerTask.getTask().getTaskCache().getEnabled() && hash.isPresent() &&
@@ -800,7 +800,7 @@ public class DefaultWorker implements Worker {
             RunContextLogger contextLogger = runContextLoggerFactory.create(workerTask);
             contextLogger.logger().error("Unable to emit the worker task result to the queue: {}", e.getMessage(), e);
             try {
-                this.workerTaskResultQueue.emit(workerTaskResult);
+                this.workerTaskResultQueue.emitOnly(workerTaskResult);
             } catch (QueueException ex) {
                 log.error("Unable to emit the worker task result for task {} taskrun {}", workerTask.getTask().getId(), workerTask.getTaskRun().getId(), e);
             }
@@ -912,7 +912,7 @@ public class DefaultWorker implements Worker {
             .workerId(this.id);
 
         // emit the attempt so the execution knows that the task is in RUNNING
-        this.workerTaskResultQueue.emit(new WorkerTaskResult(
+        this.workerTaskResultQueue.emitOnly(new WorkerTaskResult(
                 workerTask.getTaskRun()
                     .withAttempts(this.addAttempt(workerTask, builder.build()))
             )


### PR DESCRIPTION
---

### ✨ Description

Abstract the emitOnly method into the interface.

Benefits:

1. Avoid type casting: It enables queues like executionQueue to use the emitOnly method directly without requiring explicit type casting.
<img width="2306" height="1138" alt="image" src="https://github.com/user-attachments/assets/bcd45b52-6df3-45cc-baf5-883c33826eeb" />
2. Bypass persistence for non-critical messages: It allows using emitOnly instead of emit for messages (such as workerTaskResultQueue ) that do not require persistence via jdbcIndexerInterface.save .

3. Optimize custom Queue implementations (e.g., RocketMQ): In scenarios where the Queue implementation is replaced (e.g., with RocketMQ), using emitOnly directly prevents the worker from initiating redundant MySQL transactions before sending workerTaskResultQueue messages. This avoids potential failures caused by attempting to acquire a JDBC connection when the pool is busy, even though the transaction would execute no actual logic.


### 🛠️ Backend Checklist

_If this PR does not include any backend changes, delete this entire section._

- [✅] Code compiles successfully and passes all checks
- [✅] All unit and integration tests pass

### 📝 Additional Notes

Add any extra context or details reviewers should be aware of.

