### PR TITLE
feat(ui): make PostHog tracking reliable and non-blocking

### DIFF
--- a/ui/src/App.vue
+++ b/ui/src/App.vue
@@ -74,7 +74,7 @@
             uid: uid,
         });
 
-        await initPostHogForSetup(config);
+        void initPostHogForSetup(config);
 
         return config;
     }

--- a/ui/src/composables/usePosthog.ts
+++ b/ui/src/composables/usePosthog.ts
@@ -1,5 +1,6 @@
 import {useApiStore} from "../stores/api"
 import {useMiscStore} from "override/stores/misc"
+import {ensureUid, getUid} from "../utils/uid"
 
 export interface SetupEventData {
     type: string
@@ -34,19 +35,48 @@ function statsGlobalData(config: Config, uid: string): any {
     }
 }
 
+const SURVEY_HOOKS_FLAG = "__kestra_posthog_survey_hooks_installed"
+
+function installSurveyHooksOnce() {
+    if ((window as any)[SURVEY_HOOKS_FLAG]) return
+    (window as any)[SURVEY_HOOKS_FLAG] = true
+
+    let surveyVisible = false
+    window.addEventListener("PHSurveyShown", () => {
+        surveyVisible = true
+    })
+
+    window.addEventListener("PHSurveyClosed", () => {
+        surveyVisible = false
+    })
+
+    window.addEventListener("KestraRouterAfterEach", () => {
+        if (surveyVisible) {
+            window.dispatchEvent(new Event("PHSurveyClosed"))
+            surveyVisible = false
+        }
+    })
+}
+
 export async function initPostHogForSetup(config: Config): Promise<void> {
     try {
         if (!config.isUiAnonymousUsageEnabled || import.meta.env.MODE === "development") return
 
+        const uid = ensureUid()
+
+        const {default: posthog} = await import("posthog-js")
+
+        // PostHog can already be initialized (e.g. user logs out then logs back in without a full page refresh).
+        // In that case we don't need to init again.
+        if ((posthog as any)?.__loaded) {
+            installSurveyHooksOnce()
+            return
+        }
+
         const apiStore = useApiStore()
         const apiConfig = await apiStore.loadConfig()
 
-        if (!apiConfig?.posthog?.token || (window as any).posthog?.__loaded) return
-
-        const uid = getUID()
-        if (!uid) return
-
-        const {default: posthog} = await import("posthog-js")
+        if (!apiConfig?.posthog?.token) return
 
         posthog.init(apiConfig.posthog.token, {
             api_host: apiConfig.posthog.apiHost,
@@ -62,21 +92,7 @@ export async function initPostHogForSetup(config: Config): Promise<void> {
             posthog.alias(apiConfig.id)
         }
 
-        let surveyVisible = false;
-        window.addEventListener("PHSurveyShown", () => {
-            surveyVisible = true;
-        });
-
-        window.addEventListener("PHSurveyClosed", () => {
-            surveyVisible = false;
-        })
-
-        window.addEventListener("KestraRouterAfterEach", () => {
-            if (surveyVisible) {
-                window.dispatchEvent(new Event("PHSurveyClosed"))
-                surveyVisible = false;
-            }
-        })
+        installSurveyHooksOnce()
     } catch (error) {
         console.error("Failed to initialize PostHog:", error)
     }
@@ -88,7 +104,7 @@ export function trackSetupEvent(
     userFormData: UserFormData
 ): void {
     const miscStore = useMiscStore()
-    const uid = getUID()
+    const uid = getUid()
 
     if (!miscStore.configs?.isAnonymousUsageEnabled || !uid) return
 
@@ -108,5 +124,3 @@ export function trackSetupEvent(
 
     useApiStore().posthogEvents(eventData)
 }
-
-const getUID = (): string | null => localStorage.getItem("uid")

--- a/ui/src/override/stores/misc.ts
+++ b/ui/src/override/stores/misc.ts
@@ -4,6 +4,8 @@ import {useApiStore} from "../../stores/api";
 import * as BasicAuth from "../../utils/basicAuth"
 import {ref} from "vue";
 import {useAxios} from "../../utils/axios";
+import {initPostHogForSetup} from "../../composables/usePosthog";
+import {ensureUid} from "../../utils/uid";
 
 
 
@@ -19,6 +21,8 @@ export const useMiscStore = defineStore("misc", () => {
     async function loadConfigs() {
         const response = await axios.get(`${apiUrlWithoutTenants()}/configs`);
         configs.value = response.data;
+        // Best-effort: flush any queued analytics events once configs are known.
+        void useApiStore().flushQueuedEvents()
         return response.data;
     }
 
@@ -42,12 +46,17 @@ export const useMiscStore = defineStore("misc", () => {
         password: string;
     }) {
         const email = options.username;
+        const analyticsEnabled = configs.value?.isUiAnonymousUsageEnabled === true;
+        const uid = ensureUid();
 
         localStorage.setItem("firstName", options.firstName);
         localStorage.setItem("lastName", options.lastName);
+        if (analyticsEnabled) {
+            void initPostHogForSetup(configs.value)
+        }
 
         await axios.post(`${apiUrl()}/basicAuth`, {
-            uid: localStorage.getItem("uid"),
+            uid,
             username: email,
             password: options.password,
         });
@@ -57,7 +66,7 @@ export const useMiscStore = defineStore("misc", () => {
         return apiStore.posthogEvents({
             type: "ossauth",
             iid: configs.value?.uuid,
-            uid: localStorage.getItem("uid"),
+            uid,
             date: new Date().toISOString(),
             counter: 0,
             email: email

--- a/ui/src/stores/api.ts
+++ b/ui/src/stores/api.ts
@@ -1,8 +1,10 @@
 import axios from "axios";
-import posthog from "posthog-js";
 import cloneDeep from "lodash/cloneDeep";
 import {defineStore} from "pinia";
 import {useMiscStore} from "override/stores/misc";
+import {capturePosthogEvent, disablePosthog} from "../utils/posthog";
+import {ensureUid} from "../utils/uid";
+import {PendingEventsBuffer} from "../utils/analytics/pendingEvents";
 
 export const API_URL = "https://api.kestra.io";
 
@@ -27,10 +29,17 @@ interface EventData {
     page?: {
         origin?: string;
         path?: string;
+        fullPath?: string;
         [key: string]: any;
     };
     [key: string]: any;
 }
+
+interface EventsOptions {
+    posthog?: boolean;
+}
+
+type Configs = Record<string, any>;
 
 interface State {
     feeds: Feed[];
@@ -39,6 +48,40 @@ interface State {
 }
 
 let counter = 0;
+
+const pendingEvents = new PendingEventsBuffer<EventData, EventsOptions>({
+    maxItems: 50,
+    maxAgeMs: 2 * 60 * 1000, // 2 minutes
+});
+
+function analyticsDisabled(configs: Configs): boolean {
+    return configs["isAnonymousUsageEnabled"] === false;
+}
+
+function buildEventPayload(data: EventData, configs: Configs, uid: string) {
+    const additionalData = {
+        iid: configs.uuid,
+        uid,
+        date: new Date().toISOString(),
+        counter: counter++,
+    };
+
+    const mergeData = {
+        ...data,
+        ...additionalData
+    };
+
+    const backendData: Partial<EventData> = cloneDeep(mergeData);
+    if (backendData.page) {
+        delete backendData.page.origin;
+        delete backendData.page.path;
+        delete backendData.page.fullPath;
+    }
+    delete (backendData as any).$referrer;
+    delete (backendData as any).$referring_domain;
+
+    return {mergeData, backendData};
+}
 
 export const useApiStore = defineStore("api", {
     state: (): State => ({
@@ -73,35 +116,77 @@ export const useApiStore = defineStore("api", {
             return response.data;
         },
 
-        async events(data: EventData) {
+        async flushQueuedEvents() {
             const miscStore = useMiscStore();
             const configs = miscStore.configs;
-            const uid = localStorage.getItem("uid");
 
-            if (configs === undefined || uid === null || configs["isAnonymousUsageEnabled"] === false) {
+            // Can't decide yet.
+            if (configs === undefined) return;
+
+            // Analytics disabled: drop queued events.
+            if (analyticsDisabled(configs)) {
+                pendingEvents.clear();
                 return;
             }
 
-            const additionalData = {
-                iid: configs.uuid,
-                uid,
-                date: new Date().toISOString(),
-                counter: counter++,
-            };
+            // Ensure uid exists now that we know analytics is enabled.
+            const uid = ensureUid();
 
-            const mergeData = {
-                ...data,
-                ...additionalData
-            };
+            const toFlush = pendingEvents.drain();
+            for (const item of toFlush) {
+                try {
+                    await this.sendEventNow(item.data, item.options, configs, uid);
+                } catch {
+                    // Best-effort flush: keep draining even if a send fails.
+                }
+            }
+        },
 
-            this.posthogEvents(mergeData);
+        async events(data: EventData, options: EventsOptions = {}) {
+            const miscStore = useMiscStore();
+            const configs = miscStore.configs;
 
-            return axios.post(`${API_URL}/v1/reports/events`, mergeData, {
+            // If configs aren't ready yet, buffer and replay later.
+            if (configs === undefined) {
+                pendingEvents.enqueue(data, options);
+                return;
+            }
+
+            if (analyticsDisabled(configs)) {
+                pendingEvents.clear();
+                return;
+            }
+
+            const uid = ensureUid();
+
+            return this.sendEventNow(data, options, configs, uid);
+        },
+
+        async sendEventNow(data: EventData, options: EventsOptions, configs: Configs, uid: string) {
+            const {mergeData, backendData} = buildEventPayload(data, configs, uid);
+
+            if (options.posthog !== false) {
+                this.posthogEvents(mergeData);
+            }
+
+            // Configs are loaded: flush any buffered events best-effort.
+            if (pendingEvents.length > 0) {
+                void this.flushQueuedEvents();
+            }
+
+            return axios.post(`${API_URL}/v1/reports/events`, backendData, {
                 withCredentials: true
             });
         },
 
         posthogEvents(data: EventData & { date?: string; counter?: number }) {
+            const miscStore = useMiscStore();
+            const configs = miscStore.configs;
+            if (configs?.isUiAnonymousUsageEnabled === false) {
+                disablePosthog();
+                return;
+            }
+
             const type = data.type;
             const finalData: Partial<EventData> = cloneDeep(data);
 
@@ -109,16 +194,28 @@ export const useApiStore = defineStore("api", {
             delete finalData.date;
             delete finalData.counter;
 
-            if (data.page) {
-                delete data.page.origin;
-                delete data.page.path;
-            }
+            const eventName = type === "PAGE" ? "$pageview" : data.type.toLowerCase();
 
             if (type === "PAGE") {
-                posthog.capture("$pageview", finalData);
-            } else {
-                posthog.capture(data.type.toLowerCase(), finalData);
+                const origin = data.page?.origin ?? window.location.origin;
+                const path = data.page?.path ?? window.location.pathname;
+                const host = (() => {
+                    try {
+                        return new URL(origin).host;
+                    } catch {
+                        return window.location.host;
+                    }
+                })();
+                const fullPath = data.page?.fullPath;
+                const currentUrl = fullPath ? `${origin}${fullPath}` : `${origin}${path}`;
+
+                (finalData as any).$current_url = currentUrl;
+                (finalData as any).$pathname = path;
+                (finalData as any).$host = host;
+                (finalData as any).$title = document.title;
             }
+
+            capturePosthogEvent(configs, eventName, finalData as Record<string, any>);
         },
 
         async pluginIcons() {

--- a/ui/src/utils/analytics/pendingEvents.ts
+++ b/ui/src/utils/analytics/pendingEvents.ts
@@ -1,0 +1,46 @@
+export type PendingItem<TData, TOptions> = {
+    data: TData;
+    options: TOptions;
+    enqueuedAt: number;
+};
+
+export class PendingEventsBuffer<TData, TOptions> {
+    private readonly maxItems: number;
+    private readonly maxAgeMs: number;
+    private items: PendingItem<TData, TOptions>[] = [];
+
+    constructor(options: {maxItems: number; maxAgeMs: number}) {
+        this.maxItems = options.maxItems;
+        this.maxAgeMs = options.maxAgeMs;
+    }
+
+    get length(): number {
+        return this.items.length;
+    }
+
+    clear() {
+        this.items = [];
+    }
+
+    prune(now = Date.now()) {
+        if (this.items.length === 0) return;
+        const cutoff = now - this.maxAgeMs;
+        this.items = this.items.filter((item) => item.enqueuedAt >= cutoff);
+    }
+
+    enqueue(data: TData, options: TOptions, now = Date.now()) {
+        this.prune(now);
+        if (this.items.length >= this.maxItems) {
+            this.items.shift();
+        }
+        this.items.push({data, options, enqueuedAt: now});
+    }
+
+    drain(now = Date.now()): PendingItem<TData, TOptions>[] {
+        this.prune(now);
+        const drained = this.items;
+        this.items = [];
+        return drained;
+    }
+}
+

--- a/ui/src/utils/eventsRouter.ts
+++ b/ui/src/utils/eventsRouter.ts
@@ -6,6 +6,7 @@ import {useApiStore} from "../stores/api"
 interface PageInfo {
     origin: string
     path: string
+    fullPath: string
     params: { key: string, value: string }[]
     queries: { key: string, values: string[] }[]
     name: string | undefined
@@ -16,6 +17,7 @@ export const pageFromRoute = (route: RouteLocationNormalized): PageInfo => {
     return {
         origin: window.location.origin,
         path: route.path,
+        fullPath: route.fullPath,
         params: Object.keys(route.params)
             .map((key) => ({key, value: route.params[key] as string})),
         queries: Object.keys(route.query)
@@ -34,9 +36,25 @@ export default (_app: any, router: any) => {
             if (_isEqual(from, to)) {
                 return
             }
+            const currentOrigin = window.location.origin
+            const isInitialNavigation = (from.matched?.length ?? 0) === 0
+            const referrerUrl = isInitialNavigation
+                ? (document.referrer || undefined)
+                : `${currentOrigin}${from.fullPath}`
+            const referringDomain = (() => {
+                if (!referrerUrl) return undefined
+                try {
+                    return new URL(referrerUrl).host
+                } catch {
+                    return undefined
+                }
+            })()
+
             apiStore.events({
                 type: "PAGE",
-                page: pageFromRoute(to)
+                page: pageFromRoute(to),
+                $referrer: referrerUrl,
+                $referring_domain: referringDomain,
             })
         })
     })

--- a/ui/src/utils/posthog.ts
+++ b/ui/src/utils/posthog.ts
@@ -1,0 +1,144 @@
+type PosthogCapturePayload = {
+    event: string;
+    properties: Record<string, any>;
+    enqueuedAt: number;
+};
+
+const POSTHOG_QUEUE_MAX = 100;
+const POSTHOG_QUEUE_MAX_AGE_MS = 5 * 60 * 1000; // 5 minutes
+
+let posthogInitPromise: Promise<void> | undefined;
+let posthogQueue: PosthogCapturePayload[] = [];
+let posthogClient: any | undefined;
+let posthogLoadPromise: Promise<any> | undefined;
+
+async function loadPosthogClient() {
+    if (posthogClient) return posthogClient;
+    if (posthogLoadPromise) return posthogLoadPromise;
+
+    posthogLoadPromise = import("posthog-js")
+        .then((mod) => mod.default ?? mod)
+        .then((client) => {
+            posthogClient = client;
+            return client;
+        })
+        .catch(() => undefined)
+        .finally(() => {
+            posthogLoadPromise = undefined;
+        });
+
+    return posthogLoadPromise;
+}
+
+function pruneQueue(now = Date.now()) {
+    const cutoff = now - POSTHOG_QUEUE_MAX_AGE_MS;
+    if (posthogQueue.length === 0) return;
+
+    posthogQueue = posthogQueue.filter((item) => item.enqueuedAt >= cutoff);
+}
+
+function isLoaded(): boolean {
+    return Boolean(posthogClient?.__loaded);
+}
+
+function flushQueue() {
+    if (!isLoaded() || posthogQueue.length === 0) return;
+
+    pruneQueue();
+    if (posthogQueue.length === 0) return;
+
+    const queued = posthogQueue;
+    posthogQueue = [];
+
+    for (const item of queued) {
+        try {
+            posthogClient.capture(item.event, item.properties);
+        } catch {
+            // swallow
+        }
+    }
+}
+
+function maybeInit(configs: Record<string, any> | undefined) {
+    if (isLoaded()) {
+        flushQueue();
+        return;
+    }
+
+    // If configs are not loaded yet, we can't decide whether PostHog is enabled.
+    if (configs === undefined) {
+        return;
+    }
+
+    if (configs.isUiAnonymousUsageEnabled === false) {
+        posthogQueue = [];
+        return;
+    }
+
+    if (posthogInitPromise) return;
+
+    posthogInitPromise = import("../composables/usePosthog")
+        .then(({initPostHogForSetup}) => initPostHogForSetup(configs))
+        .then(() => loadPosthogClient())
+        .then(() => {
+            flushQueue();
+        })
+        .catch(() => {
+            // swallow
+        })
+        .finally(() => {
+            posthogInitPromise = undefined;
+        });
+}
+
+export function disablePosthog() {
+    posthogQueue = [];
+    if (!posthogClient) return;
+    try {
+        posthogClient.opt_out_capturing?.();
+    } catch {
+        // swallow
+    }
+    try {
+        posthogClient.reset?.();
+    } catch {
+        // swallow
+    }
+}
+
+export function capturePosthogEvent(
+    configs: Record<string, any> | undefined,
+    eventName: string,
+    properties: Record<string, any>
+) {
+    if (configs?.isUiAnonymousUsageEnabled === false) {
+        disablePosthog();
+        return;
+    }
+
+    pruneQueue();
+
+    if (!isLoaded()) {
+        maybeInit(configs);
+
+        if (posthogQueue.length >= POSTHOG_QUEUE_MAX) {
+            posthogQueue.shift();
+        }
+
+        posthogQueue.push({
+            event: eventName,
+            properties,
+            enqueuedAt: Date.now(),
+        });
+
+        return;
+    }
+
+    try {
+        posthogClient.capture(eventName, properties);
+    } catch {
+        // swallow
+    }
+
+    flushQueue();
+}

--- a/ui/src/utils/tabTracking.ts
+++ b/ui/src/utils/tabTracking.ts
@@ -115,7 +115,7 @@ function sendTrackingEvent(eventData: any) {
         delete backendData.tab_type;
         delete backendData.metadata;
 
-        apiStore.events(backendData);
+        apiStore.events(backendData, {posthog: false});
 
         // Send to PostHog via API store (handles PostHog initialization internally)
         const posthogData = {

--- a/ui/src/utils/uid.ts
+++ b/ui/src/utils/uid.ts
@@ -1,0 +1,15 @@
+import Utils from "./utils";
+
+export function getUid(): string | null {
+    return localStorage.getItem("uid");
+}
+
+export function ensureUid(): string {
+    const existing = getUid();
+    if (existing) return existing;
+
+    const uid = Utils.uid();
+    localStorage.setItem("uid", uid);
+    return uid;
+}
+

--- a/ui/tests/unit/stores/api.spec.ts
+++ b/ui/tests/unit/stores/api.spec.ts
@@ -1,0 +1,126 @@
+import {describe, it, expect, vi, beforeEach} from "vitest";
+import {setActivePinia, createPinia} from "pinia";
+
+const axiosPost = vi.fn().mockResolvedValue({data: {}});
+
+vi.mock("nprogress", () => ({
+    start: vi.fn(),
+    done: vi.fn(),
+    set: vi.fn(),
+    inc: vi.fn(),
+}));
+
+vi.mock("vue-router", () => ({
+    useRouter: () => ({
+        beforeEach: vi.fn(),
+        afterEach: vi.fn(),
+        replace: vi.fn(),
+        push: vi.fn(),
+    }),
+}));
+
+vi.mock("axios", () => ({
+    default: {
+        post: axiosPost,
+        get: vi.fn(),
+    },
+}));
+
+const capturePosthogEvent = vi.fn();
+const disablePosthog = vi.fn();
+
+vi.mock("../../../src/utils/posthog", () => ({
+    capturePosthogEvent,
+    disablePosthog,
+}));
+
+vi.mock("../../../src/utils/uid", () => ({
+    ensureUid: vi.fn(() => "uid-123"),
+    getUid: vi.fn(() => "uid-123"),
+}));
+
+vi.mock("../../../src/utils/axios", () => ({
+    useAxios: () => ({
+        get: vi.fn(),
+        post: vi.fn(),
+    }),
+}));
+
+describe("api store events", () => {
+    beforeEach(() => {
+        vi.resetModules();
+        axiosPost.mockClear();
+        capturePosthogEvent.mockClear();
+        disablePosthog.mockClear();
+        setActivePinia(createPinia());
+        localStorage.clear();
+    });
+
+    it("buffers events until configs are available and flushes", async () => {
+        const {useApiStore} = await import("../../../src/stores/api");
+        const {useMiscStore} = await import("override/stores/misc");
+
+        const apiStore = useApiStore();
+        const miscStore = useMiscStore();
+
+        await apiStore.events({
+            type: "PAGE",
+            page: {
+                origin: "http://example.test",
+                path: "/foo",
+                fullPath: "/foo?bar=baz",
+            },
+            $referrer: "http://example.test/prev",
+            $referring_domain: "example.test",
+        });
+
+        expect(axiosPost).not.toHaveBeenCalled();
+        expect(capturePosthogEvent).not.toHaveBeenCalled();
+
+        miscStore.configs = {
+            uuid: "iid-1",
+            isAnonymousUsageEnabled: true,
+            isUiAnonymousUsageEnabled: true,
+        };
+
+        await apiStore.flushQueuedEvents();
+
+        expect(axiosPost).toHaveBeenCalledTimes(1);
+        const payload = axiosPost.mock.calls[0][1];
+        expect(payload.iid).toBe("iid-1");
+        expect(payload.uid).toBe("uid-123");
+        expect(payload.page?.origin).toBeUndefined();
+        expect(payload.page?.path).toBeUndefined();
+        expect(payload.page?.fullPath).toBeUndefined();
+        expect(payload.$referrer).toBeUndefined();
+        expect(payload.$referring_domain).toBeUndefined();
+        expect(capturePosthogEvent).toHaveBeenCalledTimes(1);
+    });
+
+    it("drops events when analytics is disabled", async () => {
+        const {useApiStore} = await import("../../../src/stores/api");
+        const {useMiscStore} = await import("override/stores/misc");
+
+        const apiStore = useApiStore();
+        const miscStore = useMiscStore();
+
+        miscStore.configs = {
+            uuid: "iid-2",
+            isAnonymousUsageEnabled: false,
+            isUiAnonymousUsageEnabled: false,
+        };
+
+        await apiStore.events({
+            type: "PAGE",
+            page: {
+                origin: "http://example.test",
+                path: "/foo",
+                fullPath: "/foo",
+            },
+        });
+
+        expect(axiosPost).not.toHaveBeenCalled();
+        expect(capturePosthogEvent).not.toHaveBeenCalled();
+        expect(disablePosthog).not.toHaveBeenCalled();
+    });
+});

--- a/ui/tests/unit/utils/pendingEvents.spec.ts
+++ b/ui/tests/unit/utils/pendingEvents.spec.ts
@@ -1,0 +1,34 @@
+import {describe, it, expect} from "vitest";
+import {PendingEventsBuffer} from "../../../src/utils/analytics/pendingEvents";
+
+describe("PendingEventsBuffer", () => {
+    it("prunes by age and respects max size", () => {
+        const buffer = new PendingEventsBuffer<string, Record<string, any>>({
+            maxItems: 2,
+            maxAgeMs: 1000,
+        });
+
+        buffer.enqueue("a", {}, 0);
+        buffer.enqueue("b", {}, 100);
+        buffer.enqueue("c", {}, 200);
+
+        expect(buffer.length).toBe(2);
+
+        const drained = buffer.drain(1200);
+        expect(drained.map((item) => item.data)).toEqual(["c"]);
+        expect(buffer.length).toBe(0);
+    });
+
+    it("clears items", () => {
+        const buffer = new PendingEventsBuffer<number, Record<string, any>>({
+            maxItems: 3,
+            maxAgeMs: 1000,
+        });
+
+        buffer.enqueue(1, {}, 0);
+        buffer.enqueue(2, {}, 10);
+        buffer.clear();
+
+        expect(buffer.length).toBe(0);
+    });
+});

--- a/ui/tests/unit/utils/posthog.spec.ts
+++ b/ui/tests/unit/utils/posthog.spec.ts
@@ -1,0 +1,70 @@
+import {describe, it, expect, vi, beforeEach} from "vitest";
+
+const posthogMock = {
+    __loaded: false,
+    capture: vi.fn(),
+    opt_out_capturing: vi.fn(),
+    reset: vi.fn(),
+};
+
+vi.mock("posthog-js", () => ({
+    default: posthogMock,
+}));
+
+vi.mock("../../../src/composables/usePosthog", () => ({
+    initPostHogForSetup: vi.fn(async () => {
+        posthogMock.__loaded = true;
+    }),
+}));
+
+const flushPromises = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+describe("posthog queue", () => {
+    beforeEach(() => {
+        posthogMock.__loaded = false;
+        posthogMock.capture.mockClear();
+        posthogMock.opt_out_capturing.mockClear();
+        posthogMock.reset.mockClear();
+        vi.resetModules();
+    });
+
+    it("queues events until initialized and flushes after init", async () => {
+        const {capturePosthogEvent} = await import("../../../src/utils/posthog");
+
+        capturePosthogEvent(
+            {isUiAnonymousUsageEnabled: true},
+            "test_event",
+            {foo: "bar"}
+        );
+
+        expect(posthogMock.capture).not.toHaveBeenCalled();
+
+        await flushPromises();
+        await flushPromises();
+
+        expect(posthogMock.capture).toHaveBeenCalledTimes(1);
+        expect(posthogMock.capture).toHaveBeenCalledWith("test_event", {foo: "bar"});
+    });
+
+    it("opts out and resets when disabled after init", async () => {
+        const {capturePosthogEvent} = await import("../../../src/utils/posthog");
+
+        capturePosthogEvent(
+            {isUiAnonymousUsageEnabled: true},
+            "test_event",
+            {foo: "bar"}
+        );
+
+        await flushPromises();
+        await flushPromises();
+
+        capturePosthogEvent(
+            {isUiAnonymousUsageEnabled: false},
+            "test_event_2",
+            {foo: "baz"}
+        );
+
+        expect(posthogMock.opt_out_capturing).toHaveBeenCalled();
+        expect(posthogMock.reset).toHaveBeenCalled();
+    });
+});


### PR DESCRIPTION
Why:
- Early UI events were dropped before configs/PostHog were ready
- PostHog init could block critical flows and pageviews were inconsistent
- Backend analytics payloads should remain unchanged

What:
- Buffer API events until configs load and drain safely
- Queue PostHog captures until posthog-js initializes; drop stale items
- Improve pageview fields for PostHog only and avoid editor tab pageview pollution
- Reset/opt-out PostHog when analytics are disabled
- Add unit tests for buffering, PostHog queueing, and API flush
