### PR TITLE
docs(conditions): add deprecated note

### DIFF
--- a/core/src/main/java/io/kestra/plugin/core/condition/FlowCondition.java
+++ b/core/src/main/java/io/kestra/plugin/core/condition/FlowCondition.java
@@ -21,7 +21,8 @@ import jakarta.validation.constraints.NotNull;
 @Getter
 @NoArgsConstructor
 @Schema(
-    title = "Condition for a specific flow. Note that this condition is deprecated, use `io.kestra.plugin.core.condition.ExecutionFlow` instead."
+    title = "Condition for a specific flow. Note that this condition is deprecated, use `io.kestra.plugin.core.condition.ExecutionFlow` instead.",
+    description = "Note that this condition is deprecated, use `io.kestra.plugin.core.condition.ExecutionFlow` instead."
 )
 @Plugin(
     examples = {

--- a/core/src/main/java/io/kestra/plugin/core/condition/FlowNamespaceCondition.java
+++ b/core/src/main/java/io/kestra/plugin/core/condition/FlowNamespaceCondition.java
@@ -18,7 +18,7 @@ import jakarta.validation.constraints.NotNull;
 @Getter
 @NoArgsConstructor
 @Schema(
-    title = "Condition for a flow namespace.",
+    title = "Condition for a flow namespace. Use `io.kestra.plugin.core.condition.ExecutionNamespace` instead.",
     description = "Use `io.kestra.plugin.core.condition.ExecutionNamespace` instead."
 )
 @Plugin(

--- a/core/src/main/java/io/kestra/plugin/core/condition/FlowNamespaceCondition.java
+++ b/core/src/main/java/io/kestra/plugin/core/condition/FlowNamespaceCondition.java
@@ -18,8 +18,8 @@ import jakarta.validation.constraints.NotNull;
 @Getter
 @NoArgsConstructor
 @Schema(
-    title = "Condition for a flow namespace. Use `io.kestra.plugin.core.condition.ExecutionNamespace` instead.",
-    description = "Use `io.kestra.plugin.core.condition.ExecutionNamespace` instead."
+    title = "Condition for a flow namespace. Note that this condition is deprecated, use `io.kestra.plugin.core.condition.ExecutionNamespace` instead.",
+    description = "Note that this condition is deprecated,, use `io.kestra.plugin.core.condition.ExecutionNamespace` instead."
 )
 @Plugin(
     examples = {

--- a/core/src/main/java/io/kestra/plugin/core/condition/FlowNamespaceCondition.java
+++ b/core/src/main/java/io/kestra/plugin/core/condition/FlowNamespaceCondition.java
@@ -19,7 +19,7 @@ import jakarta.validation.constraints.NotNull;
 @NoArgsConstructor
 @Schema(
     title = "Condition for a flow namespace. Note that this condition is deprecated, use `io.kestra.plugin.core.condition.ExecutionNamespace` instead.",
-    description = "Note that this condition is deprecated,, use `io.kestra.plugin.core.condition.ExecutionNamespace` instead."
+    description = "Note that this condition is deprecated, use `io.kestra.plugin.core.condition.ExecutionNamespace` instead."
 )
 @Plugin(
     examples = {


### PR DESCRIPTION
Solves https://github.com/kestra-io/docs/issues/2230

Seems the description property doesn't work for Definitions. We should also hide these properties from the Definitions page or make it clearer they are deprecated like we do with tasks.

Few other notes:
- You can't seem to view the deprecated conditions on the website or in app under plugins. Not necessarily a problem. Helps to stop people using it but makes the description property somewhat useless for them as you couldn't see this deprecated note.
- Only examples seem to be viewable on the website for them.