### PR TITLE
feat: namespace-prefix-filter

### DIFF
--- a/core/src/main/java/io/kestra/core/models/QueryFilter.java
+++ b/core/src/main/java/io/kestra/core/models/QueryFilter.java
@@ -68,7 +68,7 @@ public record QueryFilter(
             case ENDS_WITH -> EndsWith.<T>builder().field(field).value(value.toString()).build();
             case CONTAINS -> Contains.<T>builder().field(field).value(value.toString()).build();
             case REGEX -> Regex.<T>builder().field(field).value(value.toString()).build();
-            case PREFIX -> Regex.<T>builder().field(field).value("^" + value.toString().replace(".", "\\.") + "(?:\\..+)?$").build();
+            case PREFIX -> Prefix.<T>builder().field(field).value(value.toString()).build();
         };
     }
 

--- a/core/src/main/java/io/kestra/core/models/dashboards/filters/AbstractFilter.java
+++ b/core/src/main/java/io/kestra/core/models/dashboards/filters/AbstractFilter.java
@@ -29,6 +29,7 @@ import lombok.experimental.SuperBuilder;
     @JsonSubTypes.Type(value = Or.class, name = "OR"),
     @JsonSubTypes.Type(value = Regex.class, name = "REGEX"),
     @JsonSubTypes.Type(value = StartsWith.class, name = "STARTS_WITH"),
+    @JsonSubTypes.Type(value = Prefix.class, name = "PREFIX"),
 })
 @Getter
 @NoArgsConstructor
@@ -72,6 +73,7 @@ public abstract class AbstractFilter<F extends Enum<F>> {
         NOT_IN,
         OR,
         REGEX,
-        STARTS_WITH
+        STARTS_WITH,
+        PREFIX
     }
 }

--- a/core/src/main/java/io/kestra/core/models/dashboards/filters/Prefix.java
+++ b/core/src/main/java/io/kestra/core/models/dashboards/filters/Prefix.java
@@ -1,0 +1,25 @@
+package io.kestra.core.models.dashboards.filters;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+@SuperBuilder
+@Getter
+@NoArgsConstructor
+@EqualsAndHashCode
+@Schema(title = "PREFIX", description = "Matches namespace prefix (namespace.equals(value) or namespace.startsWith(value + '.'))")
+public class Prefix<F extends Enum<F>> extends AbstractFilter<F> {
+    @NotNull
+    @JsonInclude
+    @Builder.Default
+    protected FilterType type = FilterType.PREFIX;
+
+    @NotNull
+    private String value;
+}

--- a/core/src/main/java/io/kestra/core/services/AbstractFilterService.java
+++ b/core/src/main/java/io/kestra/core/services/AbstractFilterService.java
@@ -33,6 +33,7 @@ public abstract class AbstractFilterService<Q> {
                     case Or<F> f -> or(finalQuery.get(), fieldsMapping, f);
                     case Regex<F> f -> regex(finalQuery.get(), fieldsMapping.get(f.getField()), f);
                     case StartsWith<F> f -> startsWith(finalQuery.get(), fieldsMapping.get(f.getField()), f);
+                    case Prefix<F> f -> prefix(finalQuery.get(), fieldsMapping.get(f.getField()), f);
                     default ->
                         throw new UnsupportedOperationException(filter.getClass().getName() + " is not implemented.");
                 })
@@ -74,4 +75,6 @@ public abstract class AbstractFilterService<Q> {
     protected abstract <F extends Enum<F>> Q regex(Q query, String field, Regex<F> filter);
 
     protected abstract <F extends Enum<F>> Q startsWith(Q query, String field, StartsWith<F> filter);
+
+    protected abstract <F extends Enum<F>> Q prefix(Q query, String field, Prefix<F> filter);
 }

--- a/core/src/main/java/io/kestra/plugin/core/dashboard/data/IExecutions.java
+++ b/core/src/main/java/io/kestra/plugin/core/dashboard/data/IExecutions.java
@@ -5,6 +5,7 @@ import io.kestra.core.models.dashboards.filters.AbstractFilter;
 import io.kestra.core.models.dashboards.filters.Contains;
 import io.kestra.core.models.dashboards.filters.GreaterThanOrEqualTo;
 import io.kestra.core.models.dashboards.filters.LessThanOrEqualTo;
+import io.kestra.core.models.dashboards.filters.Prefix;
 
 import java.time.ZonedDateTime;
 import java.util.ArrayList;

--- a/core/src/main/java/io/kestra/plugin/core/dashboard/data/IMetrics.java
+++ b/core/src/main/java/io/kestra/plugin/core/dashboard/data/IMetrics.java
@@ -20,7 +20,7 @@ public interface IMetrics extends IData<IMetrics.Fields> {
         if (!namespaceFilters.isEmpty()) {
             updatedWhere.removeIf(filter -> filter.getField().equals(Fields.NAMESPACE));
             namespaceFilters.forEach(f -> {
-                updatedWhere.add(EqualTo.<Fields>builder().field(Fields.NAMESPACE).value(f.value()).build());
+                updatedWhere.add(f.toDashboardFilterBuilder(Fields.NAMESPACE, f.value()));
             });
         }
 

--- a/core/src/test/java/io/kestra/core/models/QueryFilterTest.java
+++ b/core/src/test/java/io/kestra/core/models/QueryFilterTest.java
@@ -4,6 +4,16 @@ import io.kestra.core.exceptions.InvalidQueryFiltersException;
 import io.kestra.core.models.QueryFilter.Field;
 import io.kestra.core.models.QueryFilter.Op;
 import io.kestra.core.models.QueryFilter.Resource;
+import io.kestra.core.models.dashboards.filters.AbstractFilter;
+import io.kestra.core.models.dashboards.filters.Prefix;
+import io.kestra.core.models.dashboards.filters.EqualTo;
+import io.kestra.core.models.dashboards.filters.StartsWith;
+import io.kestra.core.models.dashboards.filters.Regex;
+import io.kestra.core.models.dashboards.filters.Contains;
+import io.kestra.core.models.dashboards.filters.In;
+import java.util.List;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -360,6 +370,51 @@ public class QueryFilterTest {
                 )
             )
         ).flatMap(s -> s);
+    }
+
+    @Test
+    void toDashboardFilterBuilder_prefix_shouldReturnPrefixFilter() {
+        QueryFilter filter = QueryFilter.builder()
+            .field(Field.NAMESPACE)
+            .operation(Op.PREFIX)
+            .value("io.kestra.tests")
+            .build();
+
+        enum TestField { NAMESPACE }
+        AbstractFilter<TestField> result = filter.toDashboardFilterBuilder(TestField.NAMESPACE, filter.value());
+
+        assertThat(result).isInstanceOf(Prefix.class);
+        Prefix<TestField> prefix = (Prefix<TestField>) result;
+        assertThat(prefix.getValue()).isEqualTo("io.kestra.tests");
+        assertThat(prefix.getField()).isEqualTo(TestField.NAMESPACE);
+    }
+
+    @Test
+    void toDashboardFilterBuilder_equals_shouldReturnEqualToFilter() {
+        QueryFilter filter = QueryFilter.builder()
+            .field(Field.NAMESPACE)
+            .operation(Op.EQUALS)
+            .value("io.kestra.tests")
+            .build();
+
+        enum TestField { NAMESPACE }
+        AbstractFilter<TestField> result = filter.toDashboardFilterBuilder(TestField.NAMESPACE, filter.value());
+
+        assertThat(result).isInstanceOf(EqualTo.class);
+    }
+
+    @Test
+    void toDashboardFilterBuilder_startsWith_shouldReturnStartsWithFilter() {
+        QueryFilter filter = QueryFilter.builder()
+            .field(Field.NAMESPACE)
+            .operation(Op.STARTS_WITH)
+            .value("io.kestra")
+            .build();
+
+        enum TestField { NAMESPACE }
+        AbstractFilter<TestField> result = filter.toDashboardFilterBuilder(TestField.NAMESPACE, filter.value());
+
+        assertThat(result).isInstanceOf(StartsWith.class);
     }
 
     static Stream<Arguments> invalidOperationFilters() {

--- a/core/src/test/java/io/kestra/core/models/dashboards/filters/PrefixTest.java
+++ b/core/src/test/java/io/kestra/core/models/dashboards/filters/PrefixTest.java
@@ -1,0 +1,32 @@
+package io.kestra.core.models.dashboards.filters;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class PrefixTest {
+
+    enum TestField { NAMESPACE }
+
+    @Test
+    void shouldBuildWithCorrectType() {
+        Prefix<TestField> prefix = Prefix.<TestField>builder()
+            .field(TestField.NAMESPACE)
+            .value("io.kestra.tests")
+            .build();
+
+        assertThat(prefix.getType()).isEqualTo(AbstractFilter.FilterType.PREFIX);
+        assertThat(prefix.getField()).isEqualTo(TestField.NAMESPACE);
+        assertThat(prefix.getValue()).isEqualTo("io.kestra.tests");
+    }
+
+    @Test
+    void shouldHaveCorrectDefaults() {
+        Prefix<TestField> prefix = Prefix.<TestField>builder()
+            .field(TestField.NAMESPACE)
+            .value("test")
+            .build();
+
+        assertThat(prefix.getType()).isEqualTo(AbstractFilter.FilterType.PREFIX);
+    }
+}

--- a/core/src/test/java/io/kestra/core/services/FlowServiceTest.java
+++ b/core/src/test/java/io/kestra/core/services/FlowServiceTest.java
@@ -327,9 +327,24 @@ class FlowServiceTest {
 
     @Test
     void findByNamespacePrefix() {
-        FlowWithSource flow = create(null, "some.namespace","findByTest", "test", 1);
-        flowRepository.create(GenericFlow.of(flow));
-        assertThat(flowService.findByNamespacePrefix(null, "some.namespace").size()).isEqualTo(1);
+        FlowWithSource exactMatch = create(null, "prefix.namespace", "prefixExact", "test", 1);
+        flowRepository.create(GenericFlow.of(exactMatch));
+
+        FlowWithSource childMatch = create(null, "prefix.namespace.child", "prefixChild", "test", 1);
+        flowRepository.create(GenericFlow.of(childMatch));
+
+        FlowWithSource similarPrefix = create(null, "prefix.namespace2", "prefixSimilar", "test", 1);
+        flowRepository.create(GenericFlow.of(similarPrefix));
+
+        FlowWithSource differentNs = create(null, "other.namespace", "prefixOther", "test", 1);
+        flowRepository.create(GenericFlow.of(differentNs));
+
+        List<Flow> results = flowService.findByNamespacePrefix(null, "prefix.namespace");
+
+        assertThat(results)
+            .hasSize(2)
+            .extracting(Flow::getId)
+            .containsExactlyInAnyOrder("prefixExact", "prefixChild");
     }
 
     @Test

--- a/jdbc/src/main/java/io/kestra/jdbc/repository/AbstractJdbcExecutionRepository.java
+++ b/jdbc/src/main/java/io/kestra/jdbc/repository/AbstractJdbcExecutionRepository.java
@@ -530,7 +530,7 @@ public abstract class AbstractJdbcExecutionRepository extends AbstractJdbcCrudRe
             if (flowId != null) {
                 select = select.and(field("namespace").eq(namespace));
             } else {
-                select = select.and(DSL.or(field("namespace").eq(namespace), field("namespace").likeIgnoreCase(namespace + ".%")));
+                select = select.and(DSL.or(field("namespace").eq(namespace), field("namespace").startsWith(namespace + ".")));
             }
         }
 

--- a/jdbc/src/main/java/io/kestra/jdbc/repository/AbstractJdbcFlowRepository.java
+++ b/jdbc/src/main/java/io/kestra/jdbc/repository/AbstractJdbcFlowRepository.java
@@ -507,7 +507,7 @@ public abstract class AbstractJdbcFlowRepository extends AbstractJdbcRepository 
                 .using(configuration)
                 .select(field("value"), field("namespace"), field("tenant_id"))
                 .from(fromLastRevision(true))
-                .where(DSL.or(NAMESPACE_FIELD.eq(namespacePrefix), NAMESPACE_FIELD.likeIgnoreCase(namespacePrefix + ".%"))));
+                .where(NAMESPACE_FIELD.eq(namespacePrefix).or(NAMESPACE_FIELD.startsWith(namespacePrefix + "."))));
     }
 
     @Override

--- a/jdbc/src/main/java/io/kestra/jdbc/repository/AbstractJdbcFlowRepository.java
+++ b/jdbc/src/main/java/io/kestra/jdbc/repository/AbstractJdbcFlowRepository.java
@@ -548,7 +548,7 @@ public abstract class AbstractJdbcFlowRepository extends AbstractJdbcRepository 
                         TENANT_ID_FIELD
                     )
                     .from(fromLastRevision(true))
-                    .where(DSL.or(NAMESPACE_FIELD.eq(namespacePrefix), NAMESPACE_FIELD.likeIgnoreCase(namespacePrefix + ".%")))
+                    .where(DSL.or(NAMESPACE_FIELD.eq(namespacePrefix), NAMESPACE_FIELD.startsWith(namespacePrefix + ".")))
                     .and(this.defaultFilter(tenantId));
 
                 return select.fetch().map(record -> FlowWithSource.of(
@@ -662,7 +662,7 @@ public abstract class AbstractJdbcFlowRepository extends AbstractJdbcRepository 
                 }
 
                 if (namespace != null) {
-                    select.and(DSL.or(NAMESPACE_FIELD.eq(namespace), NAMESPACE_FIELD.likeIgnoreCase(namespace + ".%")));
+                    select.and(DSL.or(NAMESPACE_FIELD.eq(namespace), NAMESPACE_FIELD.startsWith(namespace + ".")));
                 }
 
                 return (ArrayListTotal) this.jdbcRepository.fetchPage(

--- a/jdbc/src/main/java/io/kestra/jdbc/repository/AbstractJdbcFlowTopologyRepository.java
+++ b/jdbc/src/main/java/io/kestra/jdbc/repository/AbstractJdbcFlowTopologyRepository.java
@@ -85,7 +85,7 @@ public abstract class AbstractJdbcFlowTopologyRepository extends AbstractJdbcRep
             .transactionResult(configuration -> {
                 // Match flows that originate from the namespace or its children
                 Condition sourceCondition = field("source_namespace").eq(namespacePrefix)
-                    .or(field("source_namespace").likeIgnoreCase(namespacePrefix + ".%"));
+                    .or(field("source_namespace").startsWith(namespacePrefix + "."));
 
                 Condition tenantSource = buildTenantCondition("source", tenantId);
                 Condition tenantDest = buildTenantCondition("destination", tenantId);

--- a/jdbc/src/main/java/io/kestra/jdbc/repository/AbstractJdbcRepository.java
+++ b/jdbc/src/main/java/io/kestra/jdbc/repository/AbstractJdbcRepository.java
@@ -369,8 +369,8 @@ public abstract class AbstractJdbcRepository {
             case ENDS_WITH -> DSL.field(columnName).like("%" + value);
             case CONTAINS -> DSL.field(columnName).like("%" + value + "%");
             case REGEX -> DSL.field(columnName).likeRegex((String) value);
-            case PREFIX -> DSL.field(columnName).like(value + ".%")
-                .or(DSL.field(columnName).eq(value));
+            case PREFIX -> DSL.field(columnName).eq(value)
+                .or(DSL.field(columnName).startsWith(value + "."));
             default -> throw new InvalidQueryFiltersException("Unsupported operation: " + operation);
         };
     }

--- a/jdbc/src/main/java/io/kestra/jdbc/repository/AbstractJdbcTemplateRepository.java
+++ b/jdbc/src/main/java/io/kestra/jdbc/repository/AbstractJdbcTemplateRepository.java
@@ -69,7 +69,7 @@ public abstract class AbstractJdbcTemplateRepository extends AbstractJdbcCrudRep
             condition = condition.and(this.findCondition(query));
         }
         if (namespace != null) {
-            condition = condition.and(DSL.or(field("namespace").eq(namespace), field("namespace").likeIgnoreCase(namespace + ".%")));
+            condition = condition.and(DSL.or(field("namespace").eq(namespace), field("namespace").startsWith(namespace + ".")));
         }
 
         return condition;

--- a/jdbc/src/main/java/io/kestra/jdbc/repository/AbstractJdbcTriggerRepository.java
+++ b/jdbc/src/main/java/io/kestra/jdbc/repository/AbstractJdbcTriggerRepository.java
@@ -207,7 +207,7 @@ public abstract class AbstractJdbcTriggerRepository extends AbstractJdbcCrudRepo
         var condition = this.fullTextCondition(query).and(this.defaultFilter());
 
         if (namespace != null) {
-            condition = condition.and(DSL.or(NAMESPACE_FIELD.eq(namespace), NAMESPACE_FIELD.likeIgnoreCase(namespace + ".%")));
+            condition = condition.and(DSL.or(NAMESPACE_FIELD.eq(namespace), NAMESPACE_FIELD.startsWith(namespace + ".")));
         }
 
         if (flowId != null) {

--- a/jdbc/src/main/java/io/kestra/jdbc/services/JdbcFilterService.java
+++ b/jdbc/src/main/java/io/kestra/jdbc/services/JdbcFilterService.java
@@ -55,6 +55,7 @@ public class JdbcFilterService extends AbstractFilterService<SelectConditionStep
             case OR -> orCondition(fieldsMapping, (Or<F>) filter);
             case REGEX -> regexCondition(fieldsMapping.get(filter.getField()), (Regex<F>) filter);
             case STARTS_WITH -> startsWithCondition(fieldsMapping.get(filter.getField()), (StartsWith<F>) filter);
+            case PREFIX -> prefixCondition(fieldsMapping.get(filter.getField()), (Prefix<F>) filter);
         };
     }
 
@@ -147,6 +148,11 @@ public class JdbcFilterService extends AbstractFilterService<SelectConditionStep
         return query.and(field(field).startsWith(filter.getValue()));
     }
 
+    @Override
+    protected <F extends Enum<F>> SelectConditionStep<Record> prefix(SelectConditionStep<Record> query, String field, Prefix<F> filter) {
+        return query.and(prefixCondition(field, filter));
+    }
+
     private <F extends Enum<F>> org.jooq.Condition containsCondition(String field, Contains<F> filter) {
         if (filter.getLabelKey() != null) {
             return executionRepositoryInterface.get().findLabelCondition(Either.left(Map.of(filter.getLabelKey(), filter.getValue())), QueryFilter.Op.EQUALS);
@@ -221,6 +227,11 @@ public class JdbcFilterService extends AbstractFilterService<SelectConditionStep
 
     private <F extends Enum<F>> org.jooq.Condition startsWithCondition(String field, StartsWith<F> filter) {
         return field(field).startsWith(filter.getValue());
+    }
+
+    private <F extends Enum<F>> org.jooq.Condition prefixCondition(String field, Prefix<F> filter) {
+        return field(field).eq(filter.getValue())
+            .or(field(field).startsWith(filter.getValue() + "."));
     }
 
 }

--- a/jdbc/src/test/java/io/kestra/jdbc/repository/AbstractJdbcRepositoryTest.java
+++ b/jdbc/src/test/java/io/kestra/jdbc/repository/AbstractJdbcRepositoryTest.java
@@ -69,8 +69,8 @@ public class AbstractJdbcRepositoryTest extends AbstractJdbcRepository {
                 DSL.field(columnName).likeRegex(assertValue)
             );
             assertThat(this.getConditionOnField(field, assertValue, QueryFilter.Op.PREFIX, null)).isEqualTo(
-                DSL.field(columnName).like(assertValue + ".%")
-                    .or(DSL.field(columnName).eq(assertValue))
+                DSL.field(columnName).eq(assertValue)
+                    .or(DSL.field(columnName).startsWith(assertValue + "."))
             );
         });
     }

--- a/ui/src/components/filter/utils/filterTypes.ts
+++ b/ui/src/components/filter/utils/filterTypes.ts
@@ -103,7 +103,7 @@ export const COMPARATOR_LABELS: Record<Comparators, string> = {
     [Comparators.ENDS_WITH]: "Ends With",
     [Comparators.CONTAINS]: "Contains",
     [Comparators.REGEX]: "Matches Pattern",
-    [Comparators.PREFIX]: "Hierarchy",
+    [Comparators.PREFIX]: "Namespace Prefix",
 };
 
 export const COMPARATOR_DESCRIPTIONS: Record<Comparators, string> = {


### PR DESCRIPTION
closes: #9171

### ✨ Description

What does this PR change?  

- Adds a first-class `Namespace Prefix` filter operation.
- Eliminates the requirement for regex.
- Provides consistent behavior for the JDBC repo.