### PR TITLE
fix(core): Exit task was not setting the parent taskrun attempt state

### DIFF
--- a/core/src/main/java/io/kestra/plugin/core/execution/Exit.java
+++ b/core/src/main/java/io/kestra/plugin/core/execution/Exit.java
@@ -105,7 +105,7 @@ public class Exit extends Task implements ExecutionUpdatableTask {
                     Execution newExecution = execution.withTaskRun(newTaskRun);
                     // ends all parents
                     while (newTaskRun.getParentTaskRunId() != null) {
-                        newTaskRun = newExecution.findTaskRunByTaskRunId(newTaskRun.getParentTaskRunId()).withState(exitState);
+                        newTaskRun = newExecution.findTaskRunByTaskRunId(newTaskRun.getParentTaskRunId()).withStateAndAttempt(exitState);
                         newExecution = newExecution.withTaskRun(newTaskRun);
                     }
                     return newExecution;

--- a/core/src/test/java/io/kestra/plugin/core/execution/ExitTest.java
+++ b/core/src/test/java/io/kestra/plugin/core/execution/ExitTest.java
@@ -35,7 +35,9 @@ class ExitTest {
         assertThat(execution.getState().getCurrent()).isEqualTo(State.Type.FAILED);
         assertThat(execution.getTaskRunList()).hasSize(4);
         assertThat(execution.findTaskRunsByTaskId("if_some_bool").getFirst().getState().getCurrent()).isEqualTo(State.Type.FAILED);
+        assertThat(execution.findTaskRunsByTaskId("if_some_bool").getFirst().getAttempts().getFirst().getState().getCurrent()).isEqualTo(State.Type.FAILED);
         assertThat(execution.findTaskRunsByTaskId("nested_bool_check").getFirst().getState().getCurrent()).isEqualTo(State.Type.FAILED);
+        assertThat(execution.findTaskRunsByTaskId("nested_bool_check").getFirst().getAttempts().getFirst().getState().getCurrent()).isEqualTo(State.Type.FAILED);
         assertThat(execution.findTaskRunsByTaskId("nested_was_false").getFirst().getState().getCurrent()).isEqualTo(State.Type.FAILED);
     }
 }


### PR DESCRIPTION
closes https://github.com/kestra-io/kestra/issues/14309
