### PR TITLE
feat(webserver): add endpoint to expose metrics for running workers.

### DIFF
--- a/webserver/src/main/java/io/kestra/webserver/controllers/api/ClusterController.java
+++ b/webserver/src/main/java/io/kestra/webserver/controllers/api/ClusterController.java
@@ -3,6 +3,7 @@ package io.kestra.webserver.controllers.api;
 import io.kestra.core.repositories.ServiceInstanceRepositoryInterface;
 import io.kestra.core.server.*;
 import io.micronaut.context.annotation.Requires;
+import io.micronaut.data.model.Pageable;
 import io.micronaut.http.HttpResponse;
 import io.micronaut.http.annotation.*;
 import io.micronaut.http.exceptions.HttpStatusException;
@@ -10,6 +11,10 @@ import io.micronaut.scheduling.TaskExecutors;
 import io.micronaut.scheduling.annotation.ExecuteOn;
 import io.swagger.v3.oas.annotations.Operation;
 import jakarta.inject.Inject;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 @Controller("/api/v1/{tenant}/cluster")
 @Requires(bean = ServiceInstanceRepositoryInterface.class)
@@ -29,5 +34,20 @@ public class ClusterController {
         return repository.findById(id)
             .map(HttpResponse::ok)
             .orElseGet(HttpResponse::notFound);
+    }
+
+    @ExecuteOn(TaskExecutors.IO)
+    @Get("/metrics")
+    @Operation(tags = {"Services"}, summary = "Get metrics for running workers")
+    public Map<String, Set<Metric>> metrics() {
+        return repository.find(
+                Pageable.unpaged(),
+                Service.ServiceState.allRunningStates(),
+                Set.of(ServiceType.WORKER)
+            ).stream()
+            .collect(Collectors.toMap(
+                ServiceInstance::uid,
+                ServiceInstance::metrics
+            ));
     }
 }

--- a/webserver/src/test/java/io/kestra/webserver/controllers/api/ClusterControllerTest.java
+++ b/webserver/src/test/java/io/kestra/webserver/controllers/api/ClusterControllerTest.java
@@ -1,14 +1,21 @@
 package io.kestra.webserver.controllers.api;
 
 import io.kestra.core.junit.annotations.KestraTest;
+import io.kestra.core.metrics.MetricRegistry;
+import io.kestra.core.server.Metric;
 import io.kestra.core.server.ServerInstance;
 import io.kestra.core.server.ServiceInstance;
 import io.kestra.worker.DefaultWorker;
+import io.micronaut.core.type.Argument;
 import io.micronaut.http.HttpRequest;
 import io.micronaut.http.client.annotation.Client;
 import io.micronaut.reactor.http.client.ReactorHttpClient;
 import jakarta.inject.Inject;
 import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -30,5 +37,27 @@ class ClusterControllerTest {
 
         assertThat(serviceInstance).isNotNull();
         assertThat(serviceInstance.server().type()).isEqualTo(ServerInstance.Type.STANDALONE);
+    }
+
+
+    @Test
+    void shouldGetWorkerMetrics() {
+        Map<String, Set<Metric>> metricsByWorkerId = client.toBlocking().retrieve(
+            HttpRequest.GET("/api/v1/main/cluster/metrics"),
+            Argument.mapOf(Argument.of(String.class), Argument.setOf(Metric.class))
+        );
+
+        assertThat(metricsByWorkerId).isNotNull();
+        assertThat(metricsByWorkerId).isNotEmpty();
+
+        Set<Metric> metrics = metricsByWorkerId.get(worker.getId());
+        assertThat(metrics).isNotNull();
+
+        Set<String> metricNames = metrics.stream().map(Metric::name).collect(Collectors.toSet());
+        assertThat(metricNames).isEqualTo(Set.of(
+            MetricRegistry.METRIC_WORKER_JOB_THREAD_COUNT,
+            MetricRegistry.METRIC_WORKER_JOB_PENDING_COUNT,
+            MetricRegistry.METRIC_WORKER_JOB_RUNNING_COUNT
+        ));
     }
 }


### PR DESCRIPTION
### ✨ Description

What does this PR change?  
Add endpoint to expose metric for running worker via the api. The following metrics will be exposed for each running worker:
- worker.job.thread
- worker.job.pending
- worker.job.running

### 🔗 Related Issue
refs #[424](https://github.com/kestra-io/kestra-ee/issues/424)


### 🛠️ Backend Checklist
- [x] Code compiles successfully and passes all checks
- [x] All unit and integration tests pass
