### PR TITLE
 feat(ui): improve PostHog setup

### DIFF
--- a/ui/src/App.vue
+++ b/ui/src/App.vue
@@ -20,7 +20,7 @@
     import {useMiscStore} from "override/stores/misc";
     import Utils from "./utils/utils";
     import * as BasicAuth from "./utils/basicAuth";
-    import {initPostHogForSetup} from "./composables/usePosthog";
+    import {initPosthogIfEnabled} from "./utils/posthog";
     import ErrorToast from "./components/ErrorToast.vue";
     import VueTour from "./components/onboarding/VueTour.vue";
     import DefaultLayout from "override/components/layout/DefaultLayout.vue";
@@ -74,7 +74,7 @@
             uid: uid,
         });
 
-        void initPostHogForSetup(config);
+        void initPosthogIfEnabled(config);
 
         return config;
     }

--- a/ui/src/components/basicauth/BasicAuthLogin.vue
+++ b/ui/src/components/basicauth/BasicAuthLogin.vue
@@ -93,6 +93,7 @@
     import {apiUrlWithoutTenants, apiUrl} from "override/utils/route"
     import * as BasicAuth from "../../utils/basicAuth";
     import {shouldShowWelcome} from "../../utils/welcomeGuard";
+    import {identifyPosthogUser} from "../../utils/posthog";
 
     interface Credentials {
         username: string
@@ -236,6 +237,9 @@
             BasicAuth.signIn(trimmedUsername, password)
             localStorage.removeItem("basicAuthSetupInProgress")
             sessionStorage.setItem("sessionActive", "true")
+
+            const configs = await miscStore.loadConfigs()
+            await identifyPosthogUser(configs, {email: trimmedUsername})
 
             credentials.value = {username: "", password: ""}
 

--- a/ui/src/components/basicauth/BasicAuthSetup.vue
+++ b/ui/src/components/basicauth/BasicAuthSetup.vue
@@ -164,7 +164,8 @@
     import {useI18n} from "vue-i18n"
     import {useMiscStore} from "override/stores/misc"
     import {useSurveySkip} from "../../composables/useSurveyData"
-    import {initPostHogForSetup, trackSetupEvent} from "../../composables/usePosthog"
+    import {trackSetupEvent} from "../../composables/usePosthog"
+    import {identifyPosthogUser, initPosthogIfEnabled} from "../../utils/posthog"
 
     import AccountPlus from "vue-material-design-icons/AccountPlus.vue"
     import LightningBolt from "vue-material-design-icons/LightningBolt.vue"
@@ -228,7 +229,11 @@
                 return
             }
 
-            await initPostHogForSetup(config)
+            await initPosthogIfEnabled(config)
+
+            trackSetupEvent("setup_flow:started", {
+                setup_step: "account_creation"
+            }, userFormData.value)
 
             localStorage.setItem("basicAuthSetupInProgress", "true")
             localStorage.setItem("setupStartTime", Date.now().toString())
@@ -319,7 +324,13 @@
 
             BasicAuth.signIn(userFormData.value.username, userFormData.value.password)
 
-            await miscStore.loadConfigs()
+            const configs = await miscStore.loadConfigs()
+
+            await identifyPosthogUser(configs, {
+                email: userFormData.value.username.trim(),
+                first_name: userFormData.value.firstName,
+                last_name: userFormData.value.lastName
+            })
 
             trackSetupEvent("setup_flow:account_created", {
                 user_firstname: userFormData.value.firstName,

--- a/ui/src/composables/usePosthog.ts
+++ b/ui/src/composables/usePosthog.ts
@@ -28,10 +28,8 @@ function statsGlobalData(config: Config, uid: string): any {
         from: "APP",
         iid: config.uuid,
         uid: uid,
-        app: {
-            version: config.version,
-            type: config.edition
-        }
+        app_version: config.version,
+        app_type: config.edition
     }
 }
 
@@ -60,8 +58,6 @@ function installSurveyHooksOnce() {
 
 export async function initPostHogForSetup(config: Config): Promise<void> {
     try {
-        if (!config.isUiAnonymousUsageEnabled || import.meta.env.MODE === "development") return
-
         const uid = ensureUid()
 
         const {default: posthog} = await import("posthog-js")
@@ -86,7 +82,7 @@ export async function initPostHogForSetup(config: Config): Promise<void> {
             autocapture: false,
         })
 
-        posthog.register_once(statsGlobalData(config, uid));
+        posthog.register(statsGlobalData(config, uid));
 
         if (!posthog.get_property("__alias")) {
             posthog.alias(apiConfig.id)

--- a/ui/src/override/stores/misc.ts
+++ b/ui/src/override/stores/misc.ts
@@ -4,7 +4,7 @@ import {useApiStore} from "../../stores/api";
 import * as BasicAuth from "../../utils/basicAuth"
 import {ref} from "vue";
 import {useAxios} from "../../utils/axios";
-import {initPostHogForSetup} from "../../composables/usePosthog";
+import {initPosthogIfEnabled} from "../../utils/posthog";
 import {ensureUid} from "../../utils/uid";
 
 
@@ -52,7 +52,7 @@ export const useMiscStore = defineStore("misc", () => {
         localStorage.setItem("firstName", options.firstName);
         localStorage.setItem("lastName", options.lastName);
         if (analyticsEnabled) {
-            void initPostHogForSetup(configs.value)
+            void initPosthogIfEnabled(configs.value)
         }
 
         await axios.post(`${apiUrl()}/basicAuth`, {

--- a/ui/src/utils/posthog.ts
+++ b/ui/src/utils/posthog.ts
@@ -1,3 +1,5 @@
+import {ensureUid} from "./uid";
+
 type PosthogCapturePayload = {
     event: string;
     properties: Record<string, any>;
@@ -11,6 +13,14 @@ let posthogInitPromise: Promise<void> | undefined;
 let posthogQueue: PosthogCapturePayload[] = [];
 let posthogClient: any | undefined;
 let posthogLoadPromise: Promise<any> | undefined;
+
+function isPosthogDisabled(configs: Record<string, any> | undefined) {
+    return configs?.isUiAnonymousUsageEnabled === false || import.meta.env.MODE === "development";
+}
+
+export function isPosthogEnabled(configs: Record<string, any> | undefined) {
+    return !isPosthogDisabled(configs);
+}
 
 async function loadPosthogClient() {
     if (posthogClient) return posthogClient;
@@ -59,36 +69,34 @@ function flushQueue() {
     }
 }
 
-function maybeInit(configs: Record<string, any> | undefined) {
-    if (isLoaded()) {
-        flushQueue();
-        return;
-    }
-
-    // If configs are not loaded yet, we can't decide whether PostHog is enabled.
-    if (configs === undefined) {
-        return;
-    }
-
-    if (configs.isUiAnonymousUsageEnabled === false) {
+async function ensurePosthogClient(configs: Record<string, any> | undefined) {
+    if (isLoaded()) return posthogClient;
+    if (configs === undefined) return undefined;
+    if (isPosthogDisabled(configs)) {
         posthogQueue = [];
-        return;
+        return undefined;
     }
 
-    if (posthogInitPromise) return;
+    if (!posthogInitPromise) {
+        posthogInitPromise = import("../composables/usePosthog")
+            .then(({initPostHogForSetup}) => initPostHogForSetup(configs))
+            .then(() => loadPosthogClient())
+            .then(() => {
+                flushQueue();
+            })
+            .catch(() => undefined)
+            .finally(() => {
+                posthogInitPromise = undefined;
+            });
+    }
 
-    posthogInitPromise = import("../composables/usePosthog")
-        .then(({initPostHogForSetup}) => initPostHogForSetup(configs))
-        .then(() => loadPosthogClient())
-        .then(() => {
-            flushQueue();
-        })
-        .catch(() => {
-            // swallow
-        })
-        .finally(() => {
-            posthogInitPromise = undefined;
-        });
+    try {
+        await posthogInitPromise;
+    } catch {
+        return undefined;
+    }
+
+    return isLoaded() ? posthogClient : undefined;
 }
 
 export function disablePosthog() {
@@ -111,7 +119,7 @@ export function capturePosthogEvent(
     eventName: string,
     properties: Record<string, any>
 ) {
-    if (configs?.isUiAnonymousUsageEnabled === false) {
+    if (isPosthogDisabled(configs)) {
         disablePosthog();
         return;
     }
@@ -119,7 +127,7 @@ export function capturePosthogEvent(
     pruneQueue();
 
     if (!isLoaded()) {
-        maybeInit(configs);
+        void ensurePosthogClient(configs);
 
         if (posthogQueue.length >= POSTHOG_QUEUE_MAX) {
             posthogQueue.shift();
@@ -141,4 +149,34 @@ export function capturePosthogEvent(
     }
 
     flushQueue();
+}
+
+export async function identifyPosthogUser(
+    configs: Record<string, any> | undefined,
+    properties: Record<string, any>
+) {
+    if (isPosthogDisabled(configs)) {
+        disablePosthog();
+        return;
+    }
+
+    if (!properties || Object.keys(properties).length === 0) return;
+
+    const client = await ensurePosthogClient(configs);
+    if (!client?.identify) return;
+
+    try {
+        client.identify(ensureUid(), properties);
+    } catch {
+        // swallow
+    }
+}
+
+export async function initPosthogIfEnabled(configs: Record<string, any> | undefined) {
+    if (isPosthogDisabled(configs)) {
+        disablePosthog();
+        return;
+    }
+
+    await ensurePosthogClient(configs);
 }


### PR DESCRIPTION
- Register top-level app_version/app_type and avoid register_once so version updates correctly.
- Identify PostHog users by uid and set email/name person properties on setup/login.
- Add setup_flow:started event when the account creation page loads.