### PR TITLE
docs(workingdirectory): add best practice for python venv caching

### DIFF
--- a/core/src/main/java/io/kestra/plugin/core/flow/WorkingDirectory.java
+++ b/core/src/main/java/io/kestra/plugin/core/flow/WorkingDirectory.java
@@ -171,7 +171,34 @@ import jakarta.validation.constraints.NotNull;
                           const colors = require("colors");
                           console.log(colors.red("Hello"));
                 """
-        )
+                           ),
+        @Example(
+            full = true,
+            title = "A working directory with a cache of the Python virtual environment.",
+            code = """
+                id: python_cached_dependencies
+                namespace: company.team
+
+                tasks:
+                  - id: working_dir
+                    type: io.kestra.plugin.core.flow.WorkingDirectory
+                    cache:
+                      patterns:
+                        - venv/**
+                      ttl: PT24H
+                    tasks:
+                      - id: python_script
+                        type: io.kestra.plugin.scripts.python.Commands
+                        taskRunner:
+                          type: io.kestra.plugin.core.runner.Process
+                        warningOnStdErr: false
+                        beforeCommands:
+                          - python -m venv venv
+                          - ./venv/bin/pip install pandas
+                        commands:
+                          - ./venv/bin/python -c "import pandas as pd; print(pd.__version__)"
+                """
+                           )
     },
     aliases = {"io.kestra.core.tasks.flows.WorkingDirectory", "io.kestra.core.tasks.flows.Worker"}
 )
@@ -185,6 +212,8 @@ public class WorkingDirectory extends Sequential implements NamespaceFilesInterf
         description = """
             When a cache is configured, an archive of the files denoted by the cache configuration is created at the end of the task run and saved in Kestra's internal storage.
             Then, at the beginning of the next task execution, the file archive is retrieved and the working directory is initialized with it.
+            
+            **Best Practice for Python Virtual Environments**: When caching Python virtual environments, use the full path to executables (e.g., `./venv/bin/pip` and `./venv/bin/python`) instead of attempting to activate the environment with `source` or `.` commands. This ensures compatibility across different shell environments and properly isolates dependencies within the cached venv.
             """
     )
     @PluginProperty


### PR DESCRIPTION

---

### ✨ Description

Adds a "Best Practice" documentation note to the WorkingDirectory task's cache property. This update guides users to use direct executable paths (e.g., ./venv/bin/python) when working with cached Python virtual environments, rather than relying on shell activation commands (like source or .) which are often unreliable in minimal container environments or non-interactive shells.

### 🔗 Related Issue

Closes [#8540](https://github.com/kestra-io/kestra/issues/8540)


### 🛠️ Backend Checklist

- [ ] Code compiles successfully and passes all checks
- [ ] All unit and integration tests pass

### 📝 Additional Notes

I have verified this change by running a local Kestra instance and executing a flow that creates, caches, and restores a Python virtual environment on Windows.

Verification Evidence: Please find the attached screenshot.
<img width="1517" height="335" alt="image" src="https://github.com/user-attachments/assets/313e1d8f-cc91-46be-a1a7-a1655c69f04b" />

