### PR TITLE
fix(executions): loop until restart and replay with max duration reached limit

### DIFF
--- a/core/src/main/java/io/kestra/core/models/executions/TaskRun.java
+++ b/core/src/main/java/io/kestra/core/models/executions/TaskRun.java
@@ -319,12 +319,12 @@ public class TaskRun implements TenantInterface {
     }
 
     public TaskRun resetAttempts() {
-        List<State.History> wantedHistories = this.state.getHistories()
+        List<State.History> creationHistories = this.state.getHistories()
             .stream()
             .filter(history -> history.getState().isCreated())
             .toList();
         return this.toBuilder()
-            .state(new State(wantedHistories.getLast().getState(), wantedHistories))
+            .state(new State(creationHistories.getLast().getState(), creationHistories))
             .attempts(null)
             .build();
     }

--- a/core/src/main/java/io/kestra/core/models/executions/TaskRun.java
+++ b/core/src/main/java/io/kestra/core/models/executions/TaskRun.java
@@ -319,8 +319,12 @@ public class TaskRun implements TenantInterface {
     }
 
     public TaskRun resetAttempts() {
+        List<State.History> wantedHistories = this.state.getHistories()
+            .stream()
+            .filter(history -> history.getState().isCreated())
+            .toList();
         return this.toBuilder()
-            .state(new State(State.Type.CREATED, List.of(this.state.getHistories().getFirst())))
+            .state(new State(wantedHistories.getLast().getState(), wantedHistories))
             .attempts(null)
             .build();
     }

--- a/core/src/main/java/io/kestra/core/models/executions/TaskRun.java
+++ b/core/src/main/java/io/kestra/core/models/executions/TaskRun.java
@@ -18,6 +18,7 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 @ToString
 @EqualsAndHashCode
@@ -319,12 +320,14 @@ public class TaskRun implements TenantInterface {
     }
 
     public TaskRun resetAttempts() {
-        List<State.History> creationHistories = this.state.getHistories()
+        State.Type lastCreationState = this.state.getHistories()
+            .reversed()
             .stream()
             .filter(history -> history.getState().isCreated())
-            .toList();
+            .findFirst().get()
+            .getState();
         return this.toBuilder()
-            .state(new State(creationHistories.getLast().getState(), creationHistories))
+            .state(new State(lastCreationState, this.state.getHistories()))
             .attempts(null)
             .build();
     }

--- a/core/src/main/java/io/kestra/core/services/ExecutionService.java
+++ b/core/src/main/java/io/kestra/core/services/ExecutionService.java
@@ -165,7 +165,7 @@ public class ExecutionService {
             .map(taskRun -> {
                 if (taskRun.getId().equals(flowableTaskRunId)) {
                     // Keep only CREATED/RESTARTED to avoid having large history
-                    // Keeping RESTARTED at history is useful for LoopUntil Task Restart case since we depend on it to check reached max duration
+                    // Keeping RESTARTED at history is useful for LoopUntil Task Restart/Replay case since we depend on it to check reached max duration
                     return taskRun.resetAttempts().incrementIteration();
                 }
 

--- a/core/src/main/java/io/kestra/core/services/ExecutionService.java
+++ b/core/src/main/java/io/kestra/core/services/ExecutionService.java
@@ -31,6 +31,7 @@ import io.kestra.core.storages.StorageInterface;
 import io.kestra.core.utils.GraphUtils;
 import io.kestra.core.utils.IdUtils;
 import io.kestra.core.utils.ListUtils;
+import io.kestra.plugin.core.flow.LoopUntil;
 import io.kestra.plugin.core.flow.Pause;
 import io.kestra.plugin.core.flow.WorkingDirectory;
 import io.micronaut.context.event.ApplicationEventPublisher;
@@ -163,8 +164,8 @@ public class ExecutionService {
             .stream()
             .map(taskRun -> {
                 if (taskRun.getId().equals(flowableTaskRunId)) {
-                    // Keep only CREATED/RUNNING
-                    // To avoid having large history
+                    // Keep only CREATED/RESTARTED to avoid having large history
+                    // Keeping RESTARTED at history is useful for LoopUntil Task Restart case since we depend on it to check reached max duration
                     return taskRun.resetAttempts().incrementIteration();
                 }
 
@@ -838,7 +839,7 @@ public class ExecutionService {
             alterState = originalTaskRun.withState(newStateType).getState();
         } else {
             Task task = flow.findTaskByTaskId(originalTaskRun.getTaskId());
-            if (!task.isFlowable() || task instanceof WorkingDirectory) {
+            if (!task.isFlowable() || task instanceof WorkingDirectory || task instanceof LoopUntil) {
                 // The current task run is the reference task run, its default state will be newState
                 alterState = originalTaskRun.withState(newStateType).getState();
             } else {

--- a/core/src/main/java/io/kestra/core/services/ExecutionService.java
+++ b/core/src/main/java/io/kestra/core/services/ExecutionService.java
@@ -164,8 +164,6 @@ public class ExecutionService {
             .stream()
             .map(taskRun -> {
                 if (taskRun.getId().equals(flowableTaskRunId)) {
-                    // Keep only CREATED/RESTARTED to avoid having large history
-                    // Keeping RESTARTED at history is useful for LoopUntil Task Restart/Replay case since we depend on it to check reached max duration
                     return taskRun.resetAttempts().incrementIteration();
                 }
 

--- a/core/src/main/java/io/kestra/plugin/core/flow/LoopUntil.java
+++ b/core/src/main/java/io/kestra/plugin/core/flow/LoopUntil.java
@@ -181,8 +181,13 @@ public class LoopUntil extends Task implements FlowableTask<LoopUntil.Output> {
             if (printLog) {logger.warn("Max iterations reached");}
             return true;
         }
-
-        Instant creationDate = parentTaskRun.getState().getHistories().getFirst().getDate();
+        Instant creationDate = parentTaskRun.getState()
+            .getHistories()
+            .reversed()
+            .stream()
+            .filter(history -> history.getState().isCreated())
+            .findFirst().get()
+            .getDate();
         Optional<Duration> maxDuration = runContext.render(this.getCheckFrequency().getMaxDuration()).as(Duration.class);
         if (maxDuration.isPresent()
             && creationDate != null

--- a/core/src/test/java/io/kestra/core/runners/AbstractRunnerTest.java
+++ b/core/src/test/java/io/kestra/core/runners/AbstractRunnerTest.java
@@ -192,6 +192,12 @@ public abstract class AbstractRunnerTest {
     }
 
     @Test
+    @LoadFlows({"flows/valids/loop-until-restart.yaml"})
+    protected void restartLoopUntil() throws Exception{
+        restartCaseTest.restartLoopUntil();
+    }
+
+    @Test
     @LoadFlows(value = {"flows/valids/trigger-flow-listener-no-inputs.yaml",
         "flows/valids/trigger-flow-listener.yaml",
         "flows/valids/trigger-flow-listener-namespace-condition.yaml",

--- a/core/src/test/java/io/kestra/core/runners/AbstractRunnerTest.java
+++ b/core/src/test/java/io/kestra/core/runners/AbstractRunnerTest.java
@@ -193,8 +193,8 @@ public abstract class AbstractRunnerTest {
 
     @Test
     @LoadFlows({"flows/valids/loop-until-restart.yaml"})
-    protected void restartLoopUntil() throws Exception{
-        restartCaseTest.restartLoopUntil();
+    protected void restartOrReplayLoopUntil() throws Exception{
+        restartCaseTest.restartOrReplayLoopUntil();
     }
 
     @Test

--- a/core/src/test/java/io/kestra/core/runners/RestartCaseTest.java
+++ b/core/src/test/java/io/kestra/core/runners/RestartCaseTest.java
@@ -9,6 +9,7 @@ import io.kestra.core.repositories.FlowRepositoryInterface;
 import io.kestra.core.services.ExecutionService;
 
 import java.time.Duration;
+import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.Optional;
 
@@ -283,4 +284,31 @@ public class RestartCaseTest {
             .map(TaskRun::getState)
             .forEach(state -> assertThat(state.getCurrent()).isIn(State.Type.SUCCESS, State.Type.SKIPPED));
     }
+
+
+    public void restartLoopUntil() throws Exception{
+        Flow flow = flowRepository.findById(MAIN_TENANT, "io.kestra.tests", "loop-until-restart").orElseThrow();
+
+        Execution firstExecution = runnerUtils.runOne(MAIN_TENANT, flow.getNamespace(), flow.getId(), Duration.ofSeconds(60));
+
+        assertThat(firstExecution.getState().getCurrent()).isEqualTo(Type.FAILED);
+
+        Execution restartedExecution = executionService.restart(firstExecution, null);
+        assertThat(restartedExecution).isNotNull();
+        assertThat(restartedExecution.getId()).isEqualTo(firstExecution.getId());
+        assertThat(restartedExecution.getState().getCurrent()).isEqualTo(Type.RESTARTED);
+
+        Execution finalRestartedExecution = runnerUtils.restartExecution( execution -> execution.getState().isFailed(), restartedExecution);
+        assertThat(finalRestartedExecution.getState().getCurrent()).isEqualTo(Type.FAILED);
+
+        Optional<TaskRun> parentTaskRun = finalRestartedExecution.findTaskRunsByTaskId("loop_test").stream().findFirst();
+        assertThat(parentTaskRun.isPresent());
+
+        State.History lastFailed = parentTaskRun.get().getState().getHistories().getLast();
+        State.History lastRestarted = parentTaskRun.get().getState().getHistories().reversed().stream()
+            .filter(history -> history.getState() == Type.RESTARTED).findFirst().get();
+        assertThat(lastRestarted).isNotNull();
+        assertThat(lastRestarted.getDate().plus(10, ChronoUnit.SECONDS).isBefore(lastFailed.getDate()));
+    }
+
 }

--- a/core/src/test/java/io/kestra/core/runners/RestartCaseTest.java
+++ b/core/src/test/java/io/kestra/core/runners/RestartCaseTest.java
@@ -286,13 +286,13 @@ public class RestartCaseTest {
     }
 
 
-    public void restartLoopUntil() throws Exception{
+    public void restartOrReplayLoopUntil() throws Exception{
         Flow flow = flowRepository.findById(MAIN_TENANT, "io.kestra.tests", "loop-until-restart").orElseThrow();
 
         Execution firstExecution = runnerUtils.runOne(MAIN_TENANT, flow.getNamespace(), flow.getId(), Duration.ofSeconds(60));
 
         assertThat(firstExecution.getState().getCurrent()).isEqualTo(Type.FAILED);
-
+         // restarting case
         Execution restartedExecution = executionService.restart(firstExecution, null);
         assertThat(restartedExecution).isNotNull();
         assertThat(restartedExecution.getId()).isEqualTo(firstExecution.getId());
@@ -301,14 +301,37 @@ public class RestartCaseTest {
         Execution finalRestartedExecution = runnerUtils.restartExecution( execution -> execution.getState().isFailed(), restartedExecution);
         assertThat(finalRestartedExecution.getState().getCurrent()).isEqualTo(Type.FAILED);
 
-        Optional<TaskRun> parentTaskRun = finalRestartedExecution.findTaskRunsByTaskId("loop_test").stream().findFirst();
-        assertThat(parentTaskRun.isPresent());
+        Optional<TaskRun> parentTaskRun1 = finalRestartedExecution.findTaskRunsByTaskId("loop_test").stream().findFirst();
+        assertThat(parentTaskRun1.isPresent());
 
-        State.History lastFailed = parentTaskRun.get().getState().getHistories().getLast();
-        State.History lastRestarted = parentTaskRun.get().getState().getHistories().reversed().stream()
+        State.History lastFailed1 = parentTaskRun1.get().getState().getHistories().getLast();
+        State.History lastRestarted1 = parentTaskRun1.get().getState().getHistories().reversed().stream()
             .filter(history -> history.getState() == Type.RESTARTED).findFirst().get();
-        assertThat(lastRestarted).isNotNull();
-        assertThat(lastRestarted.getDate().plus(10, ChronoUnit.SECONDS).isBefore(lastFailed.getDate()));
+        assertThat(lastRestarted1).isNotNull();
+        assertThat(lastRestarted1.getDate().plus(10, ChronoUnit.SECONDS).isBefore(lastFailed1.getDate()));
+
+        // replaying case
+        Execution replayedExecution = executionService.replay(firstExecution, firstExecution.findTaskRunByTaskIdAndValue("loop_test", List.of()).getId(), null);
+        assertThat(replayedExecution.getState().getCurrent()).isEqualTo(Type.RESTARTED);
+        assertThat(replayedExecution.getId()).isNotEqualTo(firstExecution.getId());
+
+        Execution finalReplayedExecution = runnerUtils.awaitChildExecution(
+            flow,
+            firstExecution,
+            replayedExecution,
+            Duration.ofSeconds(60)
+        );
+        assertThat(finalReplayedExecution.getState().getCurrent()).isEqualTo(Type.FAILED);
+
+        Optional<TaskRun> parentTaskRun2 = finalReplayedExecution.findTaskRunsByTaskId("loop_test").stream().findFirst();
+        assertThat(parentTaskRun2.isPresent());
+
+        State.History lastFailed2 = parentTaskRun2.get().getState().getHistories().getLast();
+        State.History lastRestarted2 = parentTaskRun2.get().getState().getHistories().reversed().stream()
+            .filter(history -> history.getState() == Type.RESTARTED).findFirst().get();
+        assertThat(lastRestarted2).isNotNull();
+        assertThat(lastRestarted2.getDate().plus(10, ChronoUnit.SECONDS).isBefore(lastFailed2.getDate()));
+
     }
 
 }

--- a/core/src/test/resources/flows/valids/loop-until-restart.yaml
+++ b/core/src/test/resources/flows/valids/loop-until-restart.yaml
@@ -8,7 +8,7 @@ tasks:
     failOnMaxReached: true
     checkFrequency:
       interval: PT1S
-      maxDuration: P10S
+      maxDuration: PT10S
     tasks:
       - id: return_test
         type: io.kestra.core.tasks.debugs.Return

--- a/core/src/test/resources/flows/valids/loop-until-restart.yaml
+++ b/core/src/test/resources/flows/valids/loop-until-restart.yaml
@@ -1,0 +1,15 @@
+id: loop-until-restart
+namespace: io.kestra.tests
+
+tasks:
+  - id: loop_test
+    type: io.kestra.plugin.core.flow.LoopUntil
+    condition: "{{ false }}"
+    failOnMaxReached: true
+    checkFrequency:
+      interval: PT1S
+      maxDuration: P10S
+    tasks:
+      - id: return_test
+        type: io.kestra.core.tasks.debugs.Return
+        format: "{{outputs.loop_test.iterationCount}}"


### PR DESCRIPTION
closes #14326
## Description 
1- The problem is the same for replay and restart and it happens at LoopUntil#reachedMaximums() when checking creationDate with maxDuration against current time, it always gets the first time the task is created adding maxDuration and compares against current time which is always passed since the last executed time that is why it is failing instantly after restart.
2- For now the state is changed to Running directly when restarting, keeping it difficult to track the first start time since Running states is cleaned from history between LoopUntil iterations.

## Solution
1- This can be done by adding Restart state for LoopUntil task before changing to Running to record time of restart and keeping it at the history as like Created to be easy to use it at comparison at LoopUntil#reachedMaximums() for subsequent iterations for the new restarted loop until execution.
2- Preserve Created and Restarted cases only for flowable task run history and get the recent to use it in checks (which is Restarted in our case)

## Testing
1- Added a LoopUntil restart and replay test which should assert that the final restarted or replayed execution is failed and we have restarted state for the LoopUntil task and ends with Failed state and the time elapsed between both is the same for max duration to make sure that the max duration period is respected after restart/replay of LoopUntil task

## Screen after fix
1- This screen shows the state history for replayed LoopUntil task with Max duration 3M and Interval 1M
2- A small note: the old history of running and failed doesn't appear between created and restarted after an iteration is done and starting a new one, since we are cleaning flowable task run history each time a new iteration start keeping only created and restarted for avoiding large history as stated but max duration is respected now as shown.

<img width="800" height="693" alt="replay" src="https://github.com/user-attachments/assets/ac8b79fb-c9ee-4aac-8644-b42f5e9a8cae" />
