### PR TITLE
fix(scheduler): preserve original trigger date in FlowWithWorkerTriggerNextDate

### DIFF
--- a/scheduler/src/main/java/io/kestra/scheduler/AbstractScheduler.java
+++ b/scheduler/src/main/java/io/kestra/scheduler/AbstractScheduler.java
@@ -1165,7 +1165,7 @@ public abstract class AbstractScheduler implements Scheduler {
                     .namespace(f.getTriggerContext().getNamespace())
                     .flowId(f.getTriggerContext().getFlowId())
                     .triggerId(f.getTriggerContext().getTriggerId())
-                    .date(f.getTriggerContext().getNextExecutionDate())
+                    .date(f.getTriggerContext().getDate())
                     .nextExecutionDate(f.getTriggerContext().getNextExecutionDate())
                     .backfill(f.getTriggerContext().getBackfill())
                     .stopAfter(f.getTriggerContext().getStopAfter())


### PR DESCRIPTION
In AbstractScheduler, FlowWithWorkerTriggerNextDate.of() method was incorrectly setting the trigger's `date` field to `nextExecutionDate` instead of preserving the original `date` value.

This caused a cascading bug when nextExecutionDate is invalid:
1. Schedule.evaluate() uses triggerContext.getDate() to compute execution time
2. With date=nextExecutionDate, the computed time is in the future
3. The "future check" fails, returning Optional.empty()
4. The else branch saves the trigger with date=nextExecutionDate
5. nextEvaluationDate() computes from this wrong date
6. Each evaluation cycle trigger dates drift into the future

Related-to: kestra-io/kestra-ee#6515

