### PR TITLE
feat(ui): refine table action buttons

### DIFF
--- a/ui/src/components/Kicon.vue
+++ b/ui/src/components/Kicon.vue
@@ -1,18 +1,21 @@
 <template>
-    <span class="kicon">
-        <el-tooltip
-            effect="light"
-            v-if="tooltip"
-            :content="tooltip"
-            :rawContent="true"
-            v-bind="placement ? {placement} : {}"
-            :persistent="false"
-            transition=""
-            :hideAfter="0"
-        >
+    <el-tooltip
+        effect="light"
+        v-if="tooltip"
+        :content="tooltip"
+        :rawContent="true"
+        v-bind="placement ? {placement} : {}"
+        :persistent="false"
+        :enterable="false"
+        transition=""
+        :hideAfter="0"
+    >
+        <span class="kicon">
             <slot />
-        </el-tooltip>
-        <slot v-else />
+        </span>
+    </el-tooltip>
+    <span v-else class="kicon">
+        <slot />
     </span>
 </template>
 <script setup lang="ts">

--- a/ui/src/components/flows/Flows.vue
+++ b/ui/src/components/flows/Flows.vue
@@ -767,10 +767,6 @@
 .flow-actions-cell {
     display: flex;
     align-items: center;
-    gap: 0.5rem;
-
-    & :deep(.kicon) {
-        cursor: pointer;
-    }
+    gap: 0.25rem;
 }
 </style>

--- a/ui/src/styles/layout/element-plus-overload.scss
+++ b/ui/src/styles/layout/element-plus-overload.scss
@@ -454,25 +454,36 @@ form.ks-horizontal {
             white-space: nowrap;
         }
 
-        a, button {
+        a, button, .kicon, .el-button {
             color: var(--ks-content-primary);
-            width: 28px;
+            width: 24px;
+            height: 24px;
             border-radius: var(--bs-border-radius);
             text-align: center;
             display: flex;
             justify-content: center;
             align-items: center;
+            background-color: transparent;
+            border: none;
+            box-shadow: none;
+            padding: 0;
+            cursor: pointer;
 
-            .material-design-icon__svg {
-                bottom: -0.125rem;
-            }
-        }
-
-        button {
             .material-design-icon__svg {
                 bottom: 0;
+                width: 16px;
+                height: 16px;
+                transform: translateY(1px) translateX(-0.5px);
             }
         }
+
+        a:hover,
+        button:hover,
+        .kicon:hover,
+        .el-button:hover {
+            background-color: var(--ks-tag-background);
+        }
+
     }
 
     th.shrink {


### PR DESCRIPTION
  - Updated table action buttons to use a consistent icon-only style with hover highlight and pointer cursor.
  - Restored Flows action column to use existing Kicon tooltips while keeping global table action styling consistent.
  - Made tooltips on Kicon non-enterable so they close when cursor leaves the icon.

https://github.com/user-attachments/assets/d04a03ce-041d-4857-b737-f97dfbcf61f3

