### PR TITLE
perf(utils): replace TreeMap with HashMap in MapUtils

### DIFF
--- a/core/src/main/java/io/kestra/core/utils/MapUtils.java
+++ b/core/src/main/java/io/kestra/core/utils/MapUtils.java
@@ -190,7 +190,7 @@ public class MapUtils {
      * @throws IllegalArgumentException if the given map contains conflicting keys.
      */
     public static Map<String, Object> flattenToNestedMap(@NotNull Map<String, ?> flatMap) {
-        Map<String, Object> result = new TreeMap<>();
+        Map<String, Object> result = new HashMap<>();
 
         for (Map.Entry<String, ?> entry : flatMap.entrySet()) {
             String[] keys = entry.getKey().split("\\.");
@@ -224,7 +224,7 @@ public class MapUtils {
      * @return the flattened map.
      */
     public static Map<String, Object> nestedToFlattenMap(@NotNull Map<String, Object> nestedMap) {
-        Map<String, Object> result = new TreeMap<>();
+        Map<String, Object> result = new HashMap<>();
 
         for (Map.Entry<String, Object> entry : nestedMap.entrySet()) {
             if (entry.getValue() instanceof Map<?, ?> map) {
@@ -238,7 +238,7 @@ public class MapUtils {
     }
 
     private static Map<String, Object> flattenEntry(String key, Map<String, Object> value) {
-        Map<String, Object> result = new TreeMap<>();
+        Map<String, Object> result = new HashMap<>();
 
         for (Map.Entry<String, Object> entry : value.entrySet()) {
             String newKey = key + "." + entry.getKey();


### PR DESCRIPTION
## Description
- TreeMap provides no functional benefit here and only adds sorting overhead.
flattenToNestedMap() is on a critical path and is invoked at least twice per execution, even when no inputs, outputs, or labels are defined, and may also be triggered indirectly from other paths( like each time creating a new run context by adding execution labels), so for a non trivial executions it is called many times per execution.
- With thousands of executions with defined inputs/outputs/labels, this introduces unnecessary slight overhead. 
- Using HashMap aligns better with the existing model and avoids this cost.