### PR TITLE
feat(ui): update dependency badge style and disable tab if empty

### DIFF
--- a/ui/src/components/Tabs.vue
+++ b/ui/src/components/Tabs.vue
@@ -15,7 +15,7 @@
                     <EnterpriseBadge :enable="tab.locked">
                         <span class="tab-label-wrapper">
                             {{ tab.title }}
-                            <el-badge :type="tab.badgeType || (tab.count > 0 ? 'danger' : 'primary')" :value="tab.count" v-if="tab.count !== undefined" class="inline-badge" />
+                            <el-badge v-if="tab.count !== undefined" :value="tab.count" type="primary" class="inline-badge" />
                         </span>
                     </EnterpriseBadge>
                 </component>
@@ -58,7 +58,6 @@
         disabled?: boolean;
         props?: any;
         count?: number;
-        badgeType?: string;
         locked?: boolean;
         query?: any;
         component?: any;

--- a/ui/src/components/Tabs.vue
+++ b/ui/src/components/Tabs.vue
@@ -13,8 +13,10 @@
                         <span><strong>{{ tab.title }}</strong></span>
                     </el-tooltip>
                     <EnterpriseBadge :enable="tab.locked">
-                        {{ tab.title }}
-                        <el-badge :type="tab.badgeType || (tab.count > 0 ? 'danger' : 'primary')" :value="tab.count" v-if="tab.count !== undefined" />
+                        <span class="tab-label-wrapper">
+                            {{ tab.title }}
+                            <el-badge :type="tab.badgeType || (tab.count > 0 ? 'danger' : 'primary')" :value="tab.count" v-if="tab.count !== undefined" class="inline-badge" />
+                        </span>
                     </EnterpriseBadge>
                 </component>
             </template>
@@ -224,6 +226,22 @@ section.container.mt-4:has(> section.empty) {
 :deep(.el-tabs__nav-prev) {
     &.is-disabled {
         display: none;
+    }
+}
+
+.tab-label-wrapper {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+}
+
+.inline-badge {
+    :deep(.el-badge__content) {
+        transform: translateY(-1px);
+        position: static;
+        border: none;
+        margin-top: 0;
+        vertical-align: middle;
     }
 }
 </style>

--- a/ui/src/components/Tabs.vue
+++ b/ui/src/components/Tabs.vue
@@ -14,7 +14,7 @@
                     </el-tooltip>
                     <EnterpriseBadge :enable="tab.locked">
                         {{ tab.title }}
-                        <el-badge :type="tab.count > 0 ? 'danger' : 'primary'" :value="tab.count" v-if="tab.count !== undefined" />
+                        <el-badge :type="tab.badgeType || (tab.count > 0 ? 'danger' : 'primary')" :value="tab.count" v-if="tab.count !== undefined" />
                     </EnterpriseBadge>
                 </component>
             </template>
@@ -56,6 +56,7 @@
         disabled?: boolean;
         props?: any;
         count?: number;
+        badgeType?: string;
         locked?: boolean;
         query?: any;
         component?: any;

--- a/ui/src/components/executions/composables/useExecutionRoot.ts
+++ b/ui/src/components/executions/composables/useExecutionRoot.ts
@@ -111,9 +111,8 @@ export function useExecutionRoot() {
                 name: "dependencies",
                 component: Dependencies,
                 title: t("dependencies"),
-                count: (dependenciesCount.value && dependenciesCount.value > 0) ? dependenciesCount.value : undefined,
-                badgeType: (dependenciesCount.value && dependenciesCount.value > 0) ? "primary" : undefined,
-                disabled: !dependenciesCount.value || dependenciesCount.value == 0,
+                count: (dependenciesCount.value ?? 0) > 0 ? dependenciesCount.value : undefined,
+                disabled: !dependenciesCount.value,
                 maximized: true,
                 props: {
                     isReadOnly: true,

--- a/ui/src/components/executions/composables/useExecutionRoot.ts
+++ b/ui/src/components/executions/composables/useExecutionRoot.ts
@@ -111,7 +111,9 @@ export function useExecutionRoot() {
                 name: "dependencies",
                 component: Dependencies,
                 title: t("dependencies"),
-                count: dependenciesCount.value,
+                count: (dependenciesCount.value && dependenciesCount.value > 0) ? dependenciesCount.value : undefined,
+                badgeType: (dependenciesCount.value && dependenciesCount.value > 0) ? "primary" : undefined,
+                disabled: !dependenciesCount.value || dependenciesCount.value == 0,
                 maximized: true,
                 props: {
                     isReadOnly: true,

--- a/ui/src/components/flows/FlowRoot.vue
+++ b/ui/src/components/flows/FlowRoot.vue
@@ -277,18 +277,14 @@
                         this.flowStore.flow.namespace,
                     )
                 ) {
-                    const dependenciesTab = {
+                    tabs.push({
                         name: "dependencies",
                         component: Dependencies,
                         title: this.$t("dependencies"),
+                        count: this.dependenciesCount > 0 ? this.dependenciesCount : undefined,
+                        disabled: !this.dependenciesCount,
                         maximized: true
-                    };
-                    if (this.dependenciesCount > 0) {
-                        dependenciesTab.count = this.dependenciesCount;
-                        dependenciesTab.badgeType = "primary";
-                    } else
-                        dependenciesTab.disabled = true;
-                    tabs.push(dependenciesTab);
+                    });
                 }
 
                 tabs.push({

--- a/ui/src/components/flows/FlowRoot.vue
+++ b/ui/src/components/flows/FlowRoot.vue
@@ -281,7 +281,7 @@
                         name: "dependencies",
                         component: Dependencies,
                         title: this.$t("dependencies"),
-                        count: this.dependenciesCount > 0 ? this.dependenciesCount : undefined,
+                        count: (this.dependenciesCount ?? 0) > 0 ? this.dependenciesCount : undefined,
                         disabled: !this.dependenciesCount,
                         maximized: true
                     });

--- a/ui/src/components/flows/FlowRoot.vue
+++ b/ui/src/components/flows/FlowRoot.vue
@@ -277,13 +277,18 @@
                         this.flowStore.flow.namespace,
                     )
                 ) {
-                    tabs.push({
+                    const dependenciesTab = {
                         name: "dependencies",
                         component: Dependencies,
                         title: this.$t("dependencies"),
-                        count: this.dependenciesCount,
                         maximized: true
-                    });
+                    };
+                    if (this.dependenciesCount > 0) {
+                        dependenciesTab.count = this.dependenciesCount;
+                        dependenciesTab.badgeType = "primary";
+                    } else
+                        dependenciesTab.disabled = true;
+                    tabs.push(dependenciesTab);
                 }
 
                 tabs.push({


### PR DESCRIPTION
Fixes #14341 

### Proof of Implementation
I have recorded a demo showing both (the empty state and the active state).

### Empty State
https://github.com/user-attachments/assets/404346d7-1c5d-4768-903e-909e5c2c8475

### Active State

https://github.com/user-attachments/assets/7e33aefe-b76c-4c4c-8dd7-cef37c97f9af

### Note
The issue description mentioned applying this change to the **Assest Page** as well. I could not find those files because I guess since it is the part of their Enterprise Edition, the repo is not public.