### PR TITLE
perf(executions): optimize find last running task lookup at Execution

### DIFF
--- a/core/src/main/java/io/kestra/core/models/executions/Execution.java
+++ b/core/src/main/java/io/kestra/core/models/executions/Execution.java
@@ -576,6 +576,17 @@ public class Execution implements SoftDeletable<Execution>, TenantInterface, Has
             .findFirst();
     }
 
+    public Optional<TaskRun> findFirstRunning() {
+        if (this.taskRunList == null) {
+            return Optional.empty();
+        }
+
+        return this.taskRunList
+            .stream()
+            .filter(t -> t.getState().isRunning())
+            .findFirst();
+    }
+
     public Optional<TaskRun> findLastNotTerminated() {
         if (this.taskRunList == null) {
             return Optional.empty();

--- a/core/src/main/java/io/kestra/core/models/executions/Execution.java
+++ b/core/src/main/java/io/kestra/core/models/executions/Execution.java
@@ -8,7 +8,6 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Streams;
 import io.kestra.core.debug.Breakpoint;
 import io.kestra.core.exceptions.InternalException;
 import io.kestra.core.models.SoftDeletable;
@@ -587,6 +586,14 @@ public class Execution implements SoftDeletable<Execution>, TenantInterface, Has
             .findFirst();
     }
 
+    /**
+     * Using reversed().findFirst() is intended for better performance,
+     * as these methods are used heavily.
+     * Do not replace it with Streams.findLast() in these methods,
+     * as Streams.findLast() performs worse.
+     *
+     * See: @see <a href="https://github.com/kestra-io/kestra/pull/14385">KESTRA#14385</a>
+     */
     public Optional<TaskRun> findLastNotTerminated() {
         if (this.taskRunList == null) {
             return Optional.empty();
@@ -598,6 +605,7 @@ public class Execution implements SoftDeletable<Execution>, TenantInterface, Has
             .filter(t -> !t.getState().isTerminated() || !t.getState().isPaused())
             .findFirst();
     }
+
 
     public Optional<TaskRun> findLastByState(List<TaskRun> taskRuns, State.Type state) {
         return taskRuns

--- a/core/src/main/java/io/kestra/core/models/executions/Execution.java
+++ b/core/src/main/java/io/kestra/core/models/executions/Execution.java
@@ -576,61 +576,56 @@ public class Execution implements SoftDeletable<Execution>, TenantInterface, Has
             .findFirst();
     }
 
-    public Optional<TaskRun> findFirstRunning() {
-        if (this.taskRunList == null) {
-            return Optional.empty();
-        }
-
-        return this.taskRunList
-            .stream()
-            .filter(t -> t.getState().isRunning())
-            .findFirst();
-    }
-
     public Optional<TaskRun> findLastNotTerminated() {
         if (this.taskRunList == null) {
             return Optional.empty();
         }
 
-        return Streams.findLast(this.taskRunList
+        return this.taskRunList
+            .reversed()
             .stream()
             .filter(t -> !t.getState().isTerminated() || !t.getState().isPaused())
-        );
+            .findFirst();
     }
 
     public Optional<TaskRun> findLastByState(List<TaskRun> taskRuns, State.Type state) {
-        return Streams.findLast(taskRuns
+        return taskRuns
+            .reversed()
             .stream()
             .filter(t -> t.getState().getCurrent() == state)
-        );
+            .findFirst();
     }
 
     public Optional<TaskRun> findLastCreated(List<TaskRun> taskRuns) {
-        return Streams.findLast(taskRuns
+        return taskRuns
+            .reversed()
             .stream()
             .filter(t -> t.getState().isCreated())
-        );
+            .findFirst();
     }
 
     public Optional<TaskRun> findLastSubmitted(List<TaskRun> taskRuns) {
-        return Streams.findLast(taskRuns
+        return taskRuns
+            .reversed()
             .stream()
             .filter(t -> t.getState().getCurrent() == State.Type.SUBMITTED)
-        );
+            .findFirst();
     }
 
     public Optional<TaskRun> findLastRunning(List<TaskRun> taskRuns) {
-        return Streams.findLast(taskRuns
+        return taskRuns
+            .reversed()
             .stream()
             .filter(t -> t.getState().isRunning())
-        );
+            .findFirst();
     }
 
     public Optional<TaskRun> findLastTerminated(List<TaskRun> taskRuns) {
-        return Streams.findLast(taskRuns
+        return taskRuns
+            .reversed()
             .stream()
             .filter(t -> t.getState().isTerminated())
-        );
+            .findFirst();
     }
 
     public boolean isTerminated(List<ResolvedTask> resolvedTasks) {

--- a/core/src/main/java/io/kestra/core/models/executions/Execution.java
+++ b/core/src/main/java/io/kestra/core/models/executions/Execution.java
@@ -586,7 +586,7 @@ public class Execution implements SoftDeletable<Execution>, TenantInterface, Has
             .findFirst();
     }
 
-    /**
+    /*
      * Using reversed().findFirst() is intended for better performance,
      * as these methods are used heavily.
      * Do not replace it with Streams.findLast() in these methods,

--- a/jmh-benchmarks/src/jmh/java/io/kestra/core/executions/ExecutionsBenchmark.java
+++ b/jmh-benchmarks/src/jmh/java/io/kestra/core/executions/ExecutionsBenchmark.java
@@ -25,7 +25,9 @@ public class ExecutionsBenchmark {
             taskRuns.add(taskRunSetUp(state));
         }
     }
-
+    /**
+     * @see <a href="https://github.com/kestra-io/kestra/pull/14385">KESTRA#14385</a>
+     */
     @Benchmark
     public Optional<TaskRun> oldFindLastCreatedTaskRun(){
         return Streams.findLast(

--- a/jmh-benchmarks/src/jmh/java/io/kestra/core/executions/ExecutionsBenchmark.java
+++ b/jmh-benchmarks/src/jmh/java/io/kestra/core/executions/ExecutionsBenchmark.java
@@ -1,0 +1,59 @@
+package io.kestra.core.executions;
+
+import java.util.ArrayList;
+
+import com.google.common.collect.Streams;
+import io.kestra.core.models.flows.State;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+import io.kestra.core.models.executions.TaskRun;
+import io.kestra.core.utils.IdUtils;
+import org.openjdk.jmh.annotations.*;
+
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@org.openjdk.jmh.annotations.State(Scope.Thread)
+public class ExecutionsBenchmark {
+    List<TaskRun> taskRuns;
+
+    @Setup(Level.Invocation)
+    public void setup(){
+        taskRuns = new ArrayList<>();
+        State state = new State(State.Type.CREATED);
+        for(int i = 0; i < 100; i++){
+            taskRuns.add(taskRunSetUp(state));
+        }
+    }
+
+    @Benchmark
+    public Optional<TaskRun> oldFindLastCreatedTaskRun(){
+        return Streams.findLast(
+             taskRuns
+            .stream()
+            .filter(t -> t.getState().isCreated())
+        );
+    }
+    @Benchmark
+    public Optional<TaskRun> newFindLastCreatedTaskRun(){
+         return taskRuns
+            .reversed()
+            .stream()
+            .filter(t -> t.getState().isCreated())
+            .findFirst();
+    }
+     TaskRun taskRunSetUp(State state){
+       return TaskRun.builder()
+            .tenantId(IdUtils.create())
+            .id(IdUtils.create())
+            .executionId(IdUtils.create())
+            .namespace(IdUtils.create())
+            .flowId(IdUtils.create())
+            .taskId(IdUtils.create())
+            .parentTaskRunId(IdUtils.create())
+            .value(IdUtils.create())
+            .iteration(1)
+            .state(state)
+            .build();
+    }
+}


### PR DESCRIPTION
## Description
- Streams.findLast() is equivalent to reduce((a, b) -> b) with O(n) time complexity, 
always scanning the entire list even when the target is near the end.
- While Streams.findLast() is appropriate for generic streams since we have no indexing, using it with 
Lists is inefficient since we have random access.
- The current implementation is inefficient, it filters all matching a condition then iterates over them again to get the last

Use reversed().findFirst() instead:
- reversed() creates a view in O(1) time (no copying)
- findFirst() short-circuits, stopping at the first match
- Overall complexity: O(k) where k = elements from end to first match

- This can make difference for iterative tasks (ForEach, LoopUntil) that can generate 
hundreds of task runs.

## JMH Benchmark Tests

Warmup: 5 iterations, 10 s each
Measurement: 5 iterations, 10 s each
Timeout: 10 min per iteration
Threads: 1 thread, will synchronize iteration
Units: Microseconds
## Results

- for 10 task run

Before: "io.kestra.core.executions.ExecutionsBenchmark.oldFindLastCreatedTaskRun":
  (min, avg, max) = (0.304, 0.364, 0.460)

After: "io.kestra.core.executions.ExecutionsBenchmark.newFindLastCreatedTaskRun":
  (min, avg, max) = (0.201, 0.252, 0.340)

Performance gain: 30.8%
1.44× faster than old one

- for 100 task run

Before: "io.kestra.core.executions.ExecutionsBenchmark.oldFindLastCreatedTaskRun":
  (min, avg, max) = (8.782, 11.471, 15.608)
  
After: "io.kestra.core.executions.ExecutionsBenchmark.newFindLastCreatedTaskRun":
  (min, avg, max) = (2.890, 3.885, 6.431)

Performance gain: 66.1%
2.95× faster than old one

- for 300 task run 

Before: "io.kestra.core.executions.ExecutionsBenchmark.oldFindLastCreatedTaskRun": 
(min, avg, max) = (24.755, 29.618, 46.953)

After: "io.kestra.core.executions.ExecutionsBenchmark.newFindLastCreatedTaskRun":
(min, avg, max) = (4.062, 4.551, 5.095)

Performance gain: 84.6%
6.51× faster than old one

## Observations
- The results show a significant performance gain between the two approaches.
- Even for only 10 task runs, the new approach is nearly 1.5 faster , and the improvement grows with more task runs.
- The new approach scales better because it leverages backward traversal to find the last matching element without iterating the entire list unnecessarily, which is crucial for thousands of executions since it is on a critical execution path.

