### PR TITLE
feat(ui): introduce shared IconButton for action icons

### DIFF
--- a/ui/src/components/IconButton.vue
+++ b/ui/src/components/IconButton.vue
@@ -1,0 +1,71 @@
+<template>
+    <el-tooltip
+        v-if="tooltip"
+        effect="light"
+        :content="tooltip"
+        :rawContent="true"
+        v-bind="placement ? {placement} : {}"
+        :persistent="false"
+        :enterable="false"
+        transition=""
+        :hideAfter="0"
+    >
+        <el-button
+            v-bind="buttonAttrs"
+            class="ks-icon-button"
+            :disabled="disabled"
+            :aria-label="ariaLabel || tooltip"
+            :tag="buttonTag"
+            :to="disabled ? undefined : to"
+            :replace="replace"
+            :nativeType="nativeType"
+        >
+            <slot />
+        </el-button>
+    </el-tooltip>
+    <el-button
+        v-else
+        v-bind="buttonAttrs"
+        class="ks-icon-button"
+        :disabled="disabled"
+        :aria-label="ariaLabel"
+        :tag="buttonTag"
+        :to="disabled ? undefined : to"
+        :replace="replace"
+        :nativeType="nativeType"
+    >
+        <slot />
+    </el-button>
+</template>
+
+<script setup lang="ts">
+    import {computed, useAttrs} from "vue";
+    import {type RouteLocationRaw} from "vue-router";
+
+    defineOptions({inheritAttrs: false});
+
+    const props = withDefaults(defineProps<{
+        tooltip?: string;
+        placement?: string;
+        ariaLabel?: string;
+        disabled?: boolean;
+        to?: RouteLocationRaw;
+        replace?: boolean;
+    }>(), {
+        tooltip: "",
+        placement: "left",
+        ariaLabel: "",
+        disabled: false,
+        to: undefined,
+        replace: false,
+    });
+
+    const attrs = useAttrs();
+    const buttonAttrs = computed(() => ({
+        ...attrs,
+        class: [attrs.class],
+    }));
+
+    const buttonTag = computed(() => (props.to ? "router-link" : undefined));
+    const nativeType = computed(() => (props.to ? undefined : "button"));
+</script>

--- a/ui/src/components/IconButton.vue
+++ b/ui/src/components/IconButton.vue
@@ -69,3 +69,33 @@
     const buttonTag = computed(() => (props.to ? "router-link" : undefined));
     const nativeType = computed(() => (props.to ? undefined : "button"));
 </script>
+
+<style scoped lang="scss">
+    .ks-icon-button {
+        color: var(--ks-content-primary);
+        width: 24px;
+        height: 24px;
+        min-width: 24px;
+        border-radius: var(--bs-border-radius);
+        text-align: center;
+        display: inline-flex;
+        justify-content: center;
+        align-items: center;
+        background-color: transparent;
+        border: none;
+        box-shadow: none;
+        padding: 0;
+        cursor: pointer;
+
+        &:hover {
+            color: var(--ks-content-primary);
+            background-color: var(--ks-tag-background);
+        }
+
+        :deep(.material-design-icon__svg) {
+            width: 16px;
+            height: 16px;
+            transform: translateY(1px) translateX(-0.5px);
+        }
+    }
+</style>

--- a/ui/src/components/admin/Triggers.vue
+++ b/ui/src/components/admin/Triggers.vue
@@ -205,24 +205,21 @@
                         >
                             <template #default="scope">
                                 <div class="action-container">
-                                    <el-button v-if="scope.row.executionId || scope.row.evaluateRunningDate">
-                                        <Kicon
-                                            :tooltip="$t(`unlock trigger.tooltip.${scope.row.executionId ? 'execution' : 'evaluation'}`)"
-                                            placement="left"
-                                            @click="triggerToUnlock = scope.row"
-                                        >
-                                            <LockOff />
-                                        </Kicon>
-                                    </el-button>
-                                    <el-button>
-                                        <Kicon
-                                            :tooltip="$t('delete trigger')"
-                                            placement="left"
-                                            @click="confirmDeleteTrigger(scope.row)"
-                                        >
-                                            <Delete />
-                                        </Kicon>
-                                    </el-button>
+                                    <IconButton
+                                        v-if="scope.row.executionId || scope.row.evaluateRunningDate"
+                                        :tooltip="$t(`unlock trigger.tooltip.${scope.row.executionId ? 'execution' : 'evaluation'}`)"
+                                        placement="left"
+                                        @click="triggerToUnlock = scope.row"
+                                    >
+                                        <LockOff />
+                                    </IconButton>
+                                    <IconButton
+                                        :tooltip="$t('delete trigger')"
+                                        placement="left"
+                                        @click="confirmDeleteTrigger(scope.row)"
+                                    >
+                                        <Delete />
+                                    </IconButton>
                                 </div>
                             </template>
                         </el-table-column>
@@ -372,7 +369,7 @@
     import Download from "vue-material-design-icons/Download.vue";
 
     import Id from "../Id.vue";
-    import Kicon from "../Kicon.vue";
+    import IconButton from "../IconButton.vue";
     //@ts-expect-error No declaration file
     import FlowRun from "../flows/FlowRun.vue";
     import DateAgo from "../layout/DateAgo.vue";

--- a/ui/src/components/executions/Executions.vue
+++ b/ui/src/components/executions/Executions.vue
@@ -281,13 +281,12 @@
                             :label="$t('actions')"
                         >
                             <template #default="scope">
-                                <router-link
+                                <IconButton
+                                    :tooltip="$t('details')"
                                     :to="{name: 'executions/update', params: {namespace: scope.row?.namespace, flowId: scope.row?.flowId, id: scope.row?.id}, query: {revision: scope.row?.flowRevision}}"
                                 >
-                                    <Kicon :tooltip="$t('details')" placement="left">
-                                        <TextSearch />
-                                    </Kicon>
-                                </router-link>
+                                    <TextSearch />
+                                </IconButton>
                             </template>
                         </el-table-column>
                     </template>
@@ -426,7 +425,7 @@
     import Download from "vue-material-design-icons/Download.vue";
 
     import Id from "../Id.vue";
-    import Kicon from "../Kicon.vue";
+    import IconButton from "../IconButton.vue";
     import {State, Status} from "@kestra-io/ui-libs";
     import Labels from "../layout/Labels.vue";
     import DateAgo from "../layout/DateAgo.vue";

--- a/ui/src/components/executions/Logs.vue
+++ b/ui/src/components/executions/Logs.vue
@@ -40,25 +40,19 @@
             <el-form-item>
                 <el-button-group class="ks-b-group">
                     <Restart v-if="executionsStore.execution" :execution="executionsStore.execution" class="ms-0" @follow="forwardEvent('follow', $event)" />
-                    <el-button @click="downloadContent()">
-                        <Kicon :tooltip="$t('download logs')">
-                            <Download />
-                        </Kicon>
-                    </el-button>
-                    <el-button @click="copyAllLogs()">
-                        <Kicon :tooltip="$t('copy logs')">
-                            <ContentCopy />
-                        </Kicon>
-                    </el-button>
+                    <IconButton :tooltip="$t('download logs')" @click="downloadContent()">
+                        <Download />
+                    </IconButton>
+                    <IconButton :tooltip="$t('copy logs')" @click="copyAllLogs()">
+                        <ContentCopy />
+                    </IconButton>
                 </el-button-group>
             </el-form-item>
             <el-form-item>
                 <el-button-group class="ks-b-group">
-                    <el-button @click="loadLogs()">
-                        <Kicon :tooltip="$t('refresh')">
-                            <Refresh />
-                        </Kicon>
-                    </el-button>
+                    <IconButton :tooltip="$t('refresh')" @click="loadLogs()">
+                        <Refresh />
+                    </IconButton>
                 </el-button-group>
             </el-form-item>
         </Collapse>
@@ -125,7 +119,7 @@
     import UnfoldLessHorizontal from "vue-material-design-icons/UnfoldLessHorizontal.vue";
     import ViewList from "vue-material-design-icons/ViewList.vue";
     import ViewGrid from "vue-material-design-icons/ViewGrid.vue";
-    import Kicon from "../Kicon.vue";
+    import IconButton from "../IconButton.vue";
     import LogLevelNavigator from "../logs/LogLevelNavigator.vue";
     import {DynamicScroller, DynamicScrollerItem} from "vue-virtual-scroller";
     import "vue-virtual-scroller/dist/vue-virtual-scroller.css"
@@ -146,7 +140,7 @@
             LogLine,
             TaskRunDetails,
             LogLevelNavigator,
-            Kicon,
+            IconButton,
             Download,
             ContentCopy,
             Collapse,

--- a/ui/src/components/flows/FlowTriggers.vue
+++ b/ui/src/components/flows/FlowTriggers.vue
@@ -93,24 +93,18 @@
                             />
                         </div>
                         <template v-if="!scope.row.backfill.paused">
-                            <el-button size="small" @click="pauseBackfill(scope.row)">
-                                <Kicon :tooltip="$t('pause backfill')">
-                                    <Pause />
-                                </Kicon>
-                            </el-button>
+                            <IconButton size="small" :tooltip="$t('pause backfill')" @click="pauseBackfill(scope.row)">
+                                <Pause />
+                            </IconButton>
                         </template>
                         <template v-else-if="userCan(action.UPDATE)">
-                            <el-button size="small" @click="unpauseBackfill(scope.row)">
-                                <Kicon :tooltip="$t('continue backfill')">
-                                    <Play />
-                                </Kicon>
-                            </el-button>
+                            <IconButton size="small" :tooltip="$t('continue backfill')" @click="unpauseBackfill(scope.row)">
+                                <Play />
+                            </IconButton>
 
-                            <el-button size="small" @click="deleteBackfill(scope.row)">
-                                <Kicon :tooltip="$t('delete backfill')">
-                                    <Delete />
-                                </Kicon>
-                            </el-button>
+                            <IconButton size="small" :tooltip="$t('delete backfill')" @click="deleteBackfill(scope.row)">
+                                <Delete />
+                            </IconButton>
                         </template>
                     </div>
                 </template>
@@ -140,21 +134,29 @@
 
         <el-table-column columnKey="restart" className="row-action" v-if="userCan(action.UPDATE)">
             <template #default="scope">
-                <el-button size="small" v-if="scope.row.evaluateRunningDate" @click="restart(scope.row)">
-                    <Kicon :tooltip="$t('restart trigger.button')">
-                        <Restart />
-                    </Kicon>
-                </el-button>
+                <IconButton
+                    v-if="scope.row.evaluateRunningDate"
+                    size="small"
+                    :tooltip="$t('restart trigger.button')"
+                    placement="left"
+                    @click="restart(scope.row)"
+                >
+                    <Restart />
+                </IconButton>
             </template>
         </el-table-column>
 
         <el-table-column columnKey="unlock" className="row-action" v-if="userCan(action.UPDATE)">
             <template #default="scope">
-                <el-button size="small" v-if="scope.row.executionId" @click="unlock(scope.row)">
-                    <Kicon :tooltip="$t('unlock trigger.button')">
-                        <LockOff />
-                    </Kicon>
-                </el-button>
+                <IconButton
+                    v-if="scope.row.executionId"
+                    size="small"
+                    :tooltip="$t('unlock trigger.button')"
+                    placement="left"
+                    @click="unlock(scope.row)"
+                >
+                    <LockOff />
+                </IconButton>
             </template>
         </el-table-column>
 
@@ -166,11 +168,9 @@
 
         <el-table-column columnKey="action" className="row-action">
             <template #default="scope">
-                <el-button size="small" @click="triggerId = scope.row.id; isOpen = true">
-                    <Kicon :tooltip="$t('details')" placement="left">
-                        <TextSearch />
-                    </Kicon>
-                </el-button>
+                <IconButton size="small" :tooltip="$t('details')" @click="triggerId = scope.row.id; isOpen = true">
+                    <TextSearch />
+                </IconButton>
             </template>
         </el-table-column>
     </el-table>
@@ -278,7 +278,7 @@
     import CalendarCollapseHorizontalOutline from "vue-material-design-icons/CalendarCollapseHorizontalOutline.vue";
 
     import Id from "../Id.vue";
-    import Kicon from "../Kicon.vue";
+    import IconButton from "../IconButton.vue";
     import Drawer from "../Drawer.vue";
     //@ts-expect-error no declared types
     import FlowRun from "./FlowRun.vue";

--- a/ui/src/components/flows/Flows.vue
+++ b/ui/src/components/flows/Flows.vue
@@ -252,10 +252,11 @@
                             <el-table-column columnKey="action" className="row-action" :label="$t('actions')">
                                 <template #default="scope">
                                     <div class="flow-actions-cell">
-                                        <Kicon :tooltip="t('execute')" placement="left" @click="openExecuteModal(scope.row)">
+                                        <IconButton :tooltip="t('execute')" @click="openExecuteModal(scope.row)">
                                             <Play />
-                                        </Kicon>
-                                        <router-link
+                                        </IconButton>
+                                        <IconButton
+                                            :tooltip="$t('details')"
                                             :to="{
                                                 name: 'flows/update',
                                                 params: {
@@ -264,10 +265,8 @@
                                                 },
                                             }"
                                         >
-                                            <Kicon :tooltip="$t('details')" placement="left">
-                                                <TextSearch />
-                                            </Kicon>
-                                        </router-link>
+                                            <TextSearch />
+                                        </IconButton>
                                     </div>
                                 </template>
                             </el-table-column>
@@ -315,7 +314,7 @@
     import FileDocumentRemoveOutline from "vue-material-design-icons/FileDocumentRemoveOutline.vue";
     import Play from "vue-material-design-icons/Play.vue";
 
-    import Kicon from "../Kicon.vue";
+    import IconButton from "../IconButton.vue";
     import {Status} from "@kestra-io/ui-libs";
     import Labels from "../layout/Labels.vue";
     import DateAgo from "../layout/DateAgo.vue";

--- a/ui/src/components/kv/KVTable.vue
+++ b/ui/src/components/kv/KVTable.vue
@@ -90,35 +90,40 @@
 
                 <el-table-column columnKey="copy" className="row-action">
                     <template #default="scope">
-                        <el-tooltip v-if="scope.row.key !== undefined" :content="$t('copy_to_clipboard')">
-                            <el-button
-                                :icon="ContentCopy"
-                                link
-                                @click="Utils.copy(`\{\{ kv('${scope.row.key}') \}\}`)"
-                            />
-                        </el-tooltip>
+                        <IconButton
+                            v-if="scope.row.key !== undefined"
+                            :tooltip="$t('copy_to_clipboard')"
+                            placement="left"
+                            @click="Utils.copy(`\{\{ kv('${scope.row.key}') \}\}`)"
+                        >
+                            <ContentCopy />
+                        </IconButton>
                     </template>
                 </el-table-column>
 
                 <el-table-column v-if="!paneView" columnKey="update" className="row-action">
                     <template #default="scope">
-                        <el-button
+                        <IconButton
                             v-if="canUpdate(scope.row)"
-                            :icon="FileDocumentEdit"
-                            link
+                            :tooltip="$t('update')"
+                            placement="left"
                             @click="updateKvModal(scope.row)"
-                        />
+                        >
+                            <FileDocumentEdit />
+                        </IconButton>
                     </template>
                 </el-table-column>
 
                 <el-table-column v-if="!paneView" columnKey="delete" className="row-action">
                     <template #default="scope">
-                        <el-button
+                        <IconButton
                             v-if="canDelete(scope.row)"
-                            :icon="Delete"
-                            link
+                            :tooltip="$t('delete')"
+                            placement="left"
                             @click="removeKv(scope.row.namespace, scope.row.key)"
-                        />
+                        >
+                            <Delete />
+                        </IconButton>
                     </template>
                 </el-table-column>
             </SelectTable>
@@ -244,6 +249,7 @@
     import FileDocumentEdit from "vue-material-design-icons/FileDocumentEdit.vue";
 
     import Id from "../Id.vue";
+    import IconButton from "../IconButton.vue";
     import Drawer from "../Drawer.vue";
     import Editor from "../inputs/Editor.vue";
     import InheritedKVs from "./InheritedKVs.vue";

--- a/ui/src/components/layout/SideBar.vue
+++ b/ui/src/components/layout/SideBar.vue
@@ -136,18 +136,12 @@
 <style scoped lang="scss">
 .collapseButton {
     position: absolute;
-    top: .5rem;
-    right: 0;
+    top: .75rem;
+    right: .5rem;
     z-index: 1;
 
     #side-menu & {
         border: none;
-        background: none;
-
-        &:hover {
-            background: none !important;
-            color: var(--ks-content-link) !important;
-        }
     }
 }
 

--- a/ui/src/components/layout/SidebarToggleButton.vue
+++ b/ui/src/components/layout/SidebarToggleButton.vue
@@ -1,7 +1,8 @@
 <template>
-    <el-button
+    <IconButton
         class="collapseButton sidebar-toggle"
         @click="$emit('toggle')"
+        aria-label="Toggle menu"
     >
         <svg 
             width="12" 
@@ -17,10 +18,12 @@
                 fill="currentColor" 
             />
         </svg>
-    </el-button>
+    </IconButton>
 </template>
 
 <script setup lang="ts">
+    import IconButton from "../IconButton.vue";
+
     defineEmits<{
         (e: "toggle"): void;
     }>();
@@ -31,10 +34,6 @@
     .sidebar-toggle {
         border: none;
         color: var(--ks-text-secondary);
-
-        &:hover {
-            color: var(--ks-content-link);
-        }
 
         html.dark & {
             color: var(--ks-text-secondary);

--- a/ui/src/components/secrets/SecretsTable.vue
+++ b/ui/src/components/secrets/SecretsTable.vue
@@ -91,13 +91,13 @@
 
                     <el-table-column columnKey="copy" className="row-action">
                         <template #default="scope">
-                            <el-tooltip :content="$t('copy_to_clipboard')">
-                                <el-button 
-                                    :icon="ContentCopy" 
-                                    link
-                                    @click="Utils.copy(`\{\{ secret('${scope.row?.key}') \}\}`)"
-                                />
-                            </el-tooltip>
+                            <IconButton
+                                :tooltip="$t('copy_to_clipboard')"
+                                placement="left"
+                                @click="Utils.copy(`\{\{ secret('${scope.row?.key}') \}\}`)"
+                            >
+                                <ContentCopy />
+                            </IconButton>
                         </template>
                     </el-table-column>
 
@@ -107,12 +107,14 @@
                         className="row-action"
                     >
                         <template #default="scope">
-                            <el-button 
+                            <IconButton
                                 v-if="canUpdate(scope.row)"
-                                :icon="FileDocumentEdit"
-                                link
+                                :tooltip="$t('update')"
+                                placement="left"
                                 @click="updateSecretModal(scope.row)"
-                            />
+                            >
+                                <FileDocumentEdit />
+                            </IconButton>
                         </template>
                     </el-table-column>
 
@@ -122,12 +124,14 @@
                         className="row-action"
                     >
                         <template #default="scope">
-                            <el-button 
+                            <IconButton
                                 v-if="canDelete(scope.row)"
-                                :icon="Delete"
-                                link
+                                :tooltip="$t('delete')"
+                                placement="left"
                                 @click="removeSecret(scope.row)"
-                            />
+                            >
+                                <Delete />
+                            </IconButton>
                         </template>
                     </el-table-column>
                 </SelectTable>
@@ -232,6 +236,7 @@
     import FileDocumentEdit from "vue-material-design-icons/FileDocumentEdit.vue";
 
     import Id from "../Id.vue";
+    import IconButton from "../IconButton.vue";
     import Drawer from "../Drawer.vue";
     import Labels from "../layout/Labels.vue";
     import KSFilter from "../filter/components/KSFilter.vue";

--- a/ui/src/components/templates/Templates.vue
+++ b/ui/src/components/templates/Templates.vue
@@ -111,13 +111,12 @@
 
                             <el-table-column columnKey="action" className="row-action">
                                 <template #default="scope">
-                                    <router-link
+                                    <IconButton
+                                        :tooltip="$t('details')"
                                         :to="{name: 'templates/update', params : {namespace: scope.row.namespace, id: scope.row.id}}"
                                     >
-                                        <Kicon :tooltip="$t('details')" placement="left">
-                                            <TextSearch />
-                                        </Kicon>
-                                    </router-link>
+                                        <TextSearch />
+                                    </IconButton>
                                 </template>
                             </el-table-column>
                         </template>
@@ -149,7 +148,7 @@
     import DataTableActions from "../../mixins/dataTableActions";
     import DataTable from "../layout/DataTable.vue";
     import SearchField from "../layout/SearchField.vue";
-    import Kicon from "../Kicon.vue"
+    import IconButton from "../IconButton.vue"
     import RestoreUrl from "../../mixins/restoreUrl";
     import _merge from "lodash/merge";
     import MarkdownTooltip from "../../components/layout/MarkdownTooltip.vue";
@@ -164,7 +163,7 @@
             DataTable,
             SearchField,
             NamespaceSelect,
-            Kicon,
+            IconButton,
             MarkdownTooltip,
             Upload,
             TopNavBar
@@ -281,4 +280,3 @@
         },
     };
 </script>
-

--- a/ui/src/styles/layout/element-plus-overload.scss
+++ b/ui/src/styles/layout/element-plus-overload.scss
@@ -98,6 +98,34 @@
     }
 }
 
+.ks-icon-button {
+    color: var(--ks-content-primary);
+    width: 24px;
+    height: 24px;
+    min-width: 24px;
+    border-radius: var(--bs-border-radius);
+    text-align: center;
+    display: inline-flex;
+    justify-content: center;
+    align-items: center;
+    background-color: transparent;
+    border: none;
+    box-shadow: none;
+    padding: 0;
+    cursor: pointer;
+
+    &:hover {
+        color: var(--ks-content-primary);
+        background-color: var(--ks-tag-background);
+    }
+
+    .material-design-icon__svg {
+        width: 16px;
+        height: 16px;
+        transform: translateY(1px) translateX(-0.5px);
+    }
+}
+
 .el-button--wrap {
   display: inline-block;
   max-width: 100%;

--- a/ui/src/styles/layout/element-plus-overload.scss
+++ b/ui/src/styles/layout/element-plus-overload.scss
@@ -98,34 +98,6 @@
     }
 }
 
-.ks-icon-button {
-    color: var(--ks-content-primary);
-    width: 24px;
-    height: 24px;
-    min-width: 24px;
-    border-radius: var(--bs-border-radius);
-    text-align: center;
-    display: inline-flex;
-    justify-content: center;
-    align-items: center;
-    background-color: transparent;
-    border: none;
-    box-shadow: none;
-    padding: 0;
-    cursor: pointer;
-
-    &:hover {
-        color: var(--ks-content-primary);
-        background-color: var(--ks-tag-background);
-    }
-
-    .material-design-icon__svg {
-        width: 16px;
-        height: 16px;
-        transform: translateY(1px) translateX(-0.5px);
-    }
-}
-
 .el-button--wrap {
   display: inline-block;
   max-width: 100%;


### PR DESCRIPTION
Add a reusable IconButton component that encapsulates tooltip behavior, consistent sizing, and optional router-link support. This reduces boilerplate across table action columns and ensures icon-only actions are accessible and visually consistent.

Migrate table action icons (flows, executions, templates, secrets, KV, triggers, logs, sidebar toggle) to use the new component and common styling.

Note: follow up in kestra-ee to align the remaining enterprise tables.

<img width="380" height="129" alt="image" src="https://github.com/user-attachments/assets/f4e14f11-6773-4072-a25a-8aa94df7d3b7" />

<img width="146" height="66" alt="image" src="https://github.com/user-attachments/assets/e4aaf5a4-0959-4db0-8496-49ecca7ce36a" />

cc: @Nico-Kestra 
