### PR TITLE
fix(system): the WatchService should not be null

### DIFF
--- a/cli/src/main/java/io/kestra/cli/services/FileChangedEventListener.java
+++ b/cli/src/main/java/io/kestra/cli/services/FileChangedEventListener.java
@@ -31,7 +31,6 @@ import java.util.Optional;
 public class FileChangedEventListener {
     @Nullable
     private final FileWatchConfiguration fileWatchConfiguration;
-    @Nullable
     private final WatchService watchService;
 
     @Inject
@@ -53,7 +52,7 @@ public class FileChangedEventListener {
     private boolean isStarted = false;
 
     @Inject
-    public FileChangedEventListener(@Nullable FileWatchConfiguration fileWatchConfiguration, @Nullable WatchService watchService) {
+    public FileChangedEventListener(@Nullable FileWatchConfiguration fileWatchConfiguration, WatchService watchService) {
         this.fileWatchConfiguration = fileWatchConfiguration;
         this.watchService = watchService;
     }


### PR DESCRIPTION
Using `@Nullable` here hides a configuration issue where watching is enabled but due to mis-configuration (ex: the directory to watch didn't exist) the WatchService cannot be created by Micronaut.

Part-of: https://github.com/kestra-io/kestra/issues/13700
