### PR TITLE
fix(kv): PurgeKV should also purge parent namespace

### DIFF
--- a/core/src/main/java/io/kestra/plugin/core/kv/PurgeKV.java
+++ b/core/src/main/java/io/kestra/plugin/core/kv/PurgeKV.java
@@ -1,19 +1,13 @@
 package io.kestra.plugin.core.kv;
 
-import com.cronutils.utils.VisibleForTesting;
-import io.kestra.core.exceptions.IllegalVariableEvaluationException;
-import io.kestra.core.exceptions.ValidationErrorException;
 import io.kestra.core.models.annotations.Example;
 import io.kestra.core.models.annotations.Plugin;
 import io.kestra.core.models.property.Property;
 import io.kestra.core.models.tasks.RunnableTask;
 import io.kestra.core.models.tasks.Task;
-import io.kestra.core.repositories.FlowRepositoryInterface;
-import io.kestra.core.runners.DefaultRunContext;
 import io.kestra.core.runners.RunContext;
 import io.kestra.core.storages.kv.KVEntry;
 import io.kestra.core.storages.kv.KVStore;
-import io.kestra.core.utils.ListUtils;
 import io.kestra.plugin.core.purge.PurgeTask;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.Valid;
@@ -22,10 +16,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.io.FilenameUtils;
-import org.apache.commons.lang3.StringUtils;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicLong;
 
@@ -103,8 +94,6 @@ public class PurgeKV extends Task implements PurgeTask<KVEntry>, RunnableTask<Pu
     @Override
     public Output run(RunContext runContext) throws Exception {
         List<String> kvNamespaces = findNamespaces(runContext);
-        String renderedKeyPattern = runContext.render(keyPattern).as(String.class).orElse(null);
-        boolean keyFiltering = StringUtils.isNotBlank(renderedKeyPattern);
         runContext.logger().info("purging {} namespaces: {}", kvNamespaces.size(), kvNamespaces);
         AtomicLong count = new AtomicLong();
         KvPurgeBehavior renderedBehavior;

--- a/core/src/main/java/io/kestra/plugin/core/purge/PurgeTask.java
+++ b/core/src/main/java/io/kestra/plugin/core/purge/PurgeTask.java
@@ -63,6 +63,10 @@ public interface PurgeTask<T> {
                         return false;
                     }).toList());
             }
+
+            // add the rendered namespace if not already present, this can happen it's a parent namespace with no flow
+            filesNamespaces.addAll(renderedNamespaces.stream().filter(ns -> !filesNamespaces.contains(ns)).toList());
+
         } else {
             filesNamespaces.addAll(distinctNamespaces);
         }

--- a/core/src/test/java/io/kestra/plugin/core/kv/PurgeKVTest.java
+++ b/core/src/test/java/io/kestra/plugin/core/kv/PurgeKVTest.java
@@ -99,7 +99,7 @@ public class PurgeKVTest {
             .build();
         List<String> namespaces = purgeKV.findNamespaces(runContextFactory.of(NAMESPACE));
 
-        assertThat(namespaces).containsExactlyInAnyOrder(PARENT_NAMESPACE);
+        assertThat(namespaces).containsExactlyInAnyOrder(PARENT_NAMESPACE, "ns1", "ns2");
     }
 
     @Test
@@ -109,6 +109,20 @@ public class PurgeKVTest {
         PurgeKV purgeKV = PurgeKV.builder()
             .type(PurgeKV.class.getName())
             .namespaces(Property.ofValue(List.of("ns1", "ns2", PARENT_NAMESPACE)))
+            .includeChildNamespaces(Property.ofValue(true))
+            .build();
+        List<String> namespaces = purgeKV.findNamespaces(runContextFactory.of(NAMESPACE));
+
+        assertThat(namespaces).containsExactlyInAnyOrder(PARENT_NAMESPACE, CHILD_NAMESPACE, "ns1", "ns2");
+    }
+
+    @Test
+    void should_find_parent_namespace_even_if_no_flows() throws IllegalVariableEvaluationException {
+        addNamespace(CHILD_NAMESPACE);
+
+        PurgeKV purgeKV = PurgeKV.builder()
+            .type(PurgeKV.class.getName())
+            .namespaces(Property.ofValue(List.of(PARENT_NAMESPACE)))
             .includeChildNamespaces(Property.ofValue(true))
             .build();
         List<String> namespaces = purgeKV.findNamespaces(runContextFactory.of(NAMESPACE));

--- a/core/src/test/java/io/kestra/plugin/core/namespace/PurgeFilesTest.java
+++ b/core/src/test/java/io/kestra/plugin/core/namespace/PurgeFilesTest.java
@@ -101,7 +101,7 @@ public class PurgeFilesTest {
             .build();
         List<String> namespaces = purgeFiles.findNamespaces(runContextFactory.of(NAMESPACE));
 
-        assertThat(namespaces).containsExactlyInAnyOrder(PARENT_NAMESPACE);
+        assertThat(namespaces).containsExactlyInAnyOrder(PARENT_NAMESPACE, "ns1", "ns2");
     }
 
     @Test
@@ -115,7 +115,7 @@ public class PurgeFilesTest {
             .build();
         List<String> namespaces = purgeFiles.findNamespaces(runContextFactory.of(NAMESPACE));
 
-        assertThat(namespaces).containsExactlyInAnyOrder(PARENT_NAMESPACE, CHILD_NAMESPACE);
+        assertThat(namespaces).containsExactlyInAnyOrder(PARENT_NAMESPACE, CHILD_NAMESPACE, "ns1", "ns2");
     }
 
     @Test


### PR DESCRIPTION
Even when the namespace has no flow.

Fixes https://github.com/kestra-io/kestra-ee/issues/5890
