### PR TITLE
feat(execution): SDK auto auth for plugins

### DIFF
--- a/core/src/main/java/io/kestra/core/runners/DefaultRunContext.java
+++ b/core/src/main/java/io/kestra/core/runners/DefaultRunContext.java
@@ -61,6 +61,7 @@ public class DefaultRunContext extends RunContext {
     private WorkingDir workingDir;
     private Validator validator;
     private LocalPath localPath;
+    private SDK sdk;
 
     private Map<String, Object> variables;
     private List<AbstractMetricEntry<?>> metrics = new ArrayList<>();
@@ -167,6 +168,7 @@ public class DefaultRunContext extends RunContext {
             this.validator = applicationContext.getBean(Validator.class);
             this.localPath = applicationContext.getBean(LocalPathFactory.class).createLocalPath(this);
             this.assetManagerFactory = applicationContext.getBean(AssetManagerFactory.class);
+            this.sdk = applicationContext.getBean(RunContextSDKFactory.class).create(applicationContext, this);
         }
     }
 
@@ -638,6 +640,11 @@ public class DefaultRunContext extends RunContext {
     @Override
     public InputAndOutput inputAndOutput() {
         return new InputAndOutputImpl(this.applicationContext, this);
+    }
+
+    @Override
+    public SDK sdk() {
+        return this.sdk;
     }
 
     /**

--- a/core/src/main/java/io/kestra/core/runners/RunContext.java
+++ b/core/src/main/java/io/kestra/core/runners/RunContext.java
@@ -235,4 +235,9 @@ public abstract class RunContext implements PropertyContext {
      * @return an InputAndOutput that can be used to work with inputs and outputs.
      */
     public abstract InputAndOutput inputAndOutput();
+
+    /**
+     * Get access to the SDK handler which allows to interact easily with the Kestra API via the SDK.
+     */
+    public abstract SDK sdk();
 }

--- a/core/src/main/java/io/kestra/core/runners/RunContextSDKFactory.java
+++ b/core/src/main/java/io/kestra/core/runners/RunContextSDKFactory.java
@@ -1,0 +1,43 @@
+package io.kestra.core.runners;
+
+import io.micronaut.context.ApplicationContext;
+import jakarta.inject.Singleton;
+
+import java.util.Optional;
+
+@Singleton
+public class RunContextSDKFactory {
+    public SDK create(ApplicationContext applicationContext, RunContext runContext) {
+        return new SDKImpl(applicationContext);
+    }
+
+    static class SDKImpl implements SDK {
+        private static final String AUTH_PROP = "kestra.tasks.sdk.authentication";
+        private static final String API_TOKEN_PROP = AUTH_PROP + ".api-token";
+        private static final String USERNAME_PROP = AUTH_PROP + ".username";
+        private static final String PASSWORD_PROP = AUTH_PROP + ".password";
+
+        private final Auth sdkAuthentication;
+
+        SDKImpl(ApplicationContext applicationContext) {
+            this.sdkAuthentication = applicationContext.getProperty(API_TOKEN_PROP, String.class)
+                .map(it -> new SDK.Auth(Optional.of(it), Optional.empty(), Optional.empty()))
+                .orElseGet(() -> {
+                    Optional<String> maybeUserName = applicationContext.getProperty(USERNAME_PROP, String.class);
+                    Optional<String> maybePassword = applicationContext.getProperty(PASSWORD_PROP, String.class);
+                    if (maybePassword.isPresent() && maybeUserName.isPresent()) {
+                        return new SDK.Auth(Optional.empty(), maybeUserName, maybePassword);
+                    }
+                    if (maybeUserName.isPresent() || maybePassword.isPresent()) {
+                        throw new IllegalArgumentException("Both username and password must be provided if either is present: please configure both '" + USERNAME_PROP + "' and '" + PASSWORD_PROP + "' properties");
+                    }
+                    return null;
+                });
+        }
+
+        @Override
+        public Optional<Auth> defaultAuthentication() {
+            return Optional.ofNullable(this.sdkAuthentication);
+        }
+    }
+}

--- a/core/src/main/java/io/kestra/core/runners/SDK.java
+++ b/core/src/main/java/io/kestra/core/runners/SDK.java
@@ -1,0 +1,24 @@
+package io.kestra.core.runners;
+
+import io.micronaut.context.annotation.ConfigurationProperties;
+
+import java.util.Optional;
+
+/**
+ * Provides convenient methods to interact with the Kestra API via the SDK.
+ */
+public interface SDK {
+    /**
+     * @return the default authentication to the API for SDK interactions.
+     * On OSS: it returns an authentication configured inside the application configuration une the 'kestra.tasks.sdk.authentication' config properties.
+     * On EE: it tries first to locate a default authentication configured at the namespace level, then at the tenant level, then defaults to the application configuration provided one if any.
+     */
+    Optional<Auth> defaultAuthentication();
+
+    @ConfigurationProperties("kestra.tasks.sdk.authentication")
+    record Auth (
+        Optional<String> apiToken,
+        Optional<String> username,
+        Optional<String> password
+    ) {}
+}

--- a/core/src/test/java/io/kestra/core/runners/RunContextSDKTest.java
+++ b/core/src/test/java/io/kestra/core/runners/RunContextSDKTest.java
@@ -1,0 +1,50 @@
+package io.kestra.core.runners;
+
+import io.micronaut.context.annotation.Property;
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@MicronautTest(rebuildContext = true)
+class RunContextSDKTest {
+    @Inject
+    private RunContextFactory runContextFactory;
+
+    @Inject
+    private RunContextInitializer runContextInitializer;
+
+    @Test
+    void sdkAuthShouldReturnEmptyWhenNotSet() {
+        RunContext runContext = runContextInitializer.forExecutor((DefaultRunContext) runContextFactory.of());
+
+        assertThat(runContext.sdk().defaultAuthentication()).isEmpty();
+    }
+
+    @Test
+    @Property(name = "kestra.tasks.sdk.authentication.api-token", value = "test-key")
+    void sdkAuthShouldReturnApiKeyWhenSet() {
+        RunContext runContext = runContextInitializer.forExecutor((DefaultRunContext) runContextFactory.of());
+
+        assertThat(runContext.sdk().defaultAuthentication()).isPresent();
+        assertThat(runContext.sdk().defaultAuthentication().get().username()).isEmpty();
+        assertThat(runContext.sdk().defaultAuthentication().get().password()).isEmpty();
+        assertThat(runContext.sdk().defaultAuthentication().get().apiToken()).isPresent();
+        assertThat(runContext.sdk().defaultAuthentication().get().apiToken().get()).isEqualTo("test-key");
+    }
+
+    @Test
+    @Property(name = "kestra.tasks.sdk.authentication.username", value = "username")
+    @Property(name = "kestra.tasks.sdk.authentication.password", value = "password")
+    void sdkAuthShouldReturnUsernamePasswordKeyWhenSet() {
+        RunContext runContext = runContextInitializer.forExecutor((DefaultRunContext) runContextFactory.of());
+
+        assertThat(runContext.sdk().defaultAuthentication()).isPresent();
+        assertThat(runContext.sdk().defaultAuthentication().get().apiToken()).isEmpty();
+        assertThat(runContext.sdk().defaultAuthentication().get().username()).isPresent();
+        assertThat(runContext.sdk().defaultAuthentication().get().password()).isPresent();
+        assertThat(runContext.sdk().defaultAuthentication().get().username().get()).isEqualTo("username");
+        assertThat(runContext.sdk().defaultAuthentication().get().password().get()).isEqualTo("password");
+    }
+}


### PR DESCRIPTION
Part-of: https://github.com/kestra-io/kestra-ee/issues/5980

The following flow will work OOTB 
```yaml
id: kestra-list-ns
namespace: company.team

tasks:
  - id: hello
    type: io.kestra.plugin.kestra.namespaces.List
```

With the following configuration:
```yaml
  tasks:
    sdk:
      authentication:
        username: ${kestra.server.basic-auth.username}
        password: ${kestra.server.basic-auth.password}
```
