### PR TITLE
refactor(core): prevent console warnings related to tooltip in filters

### DIFF
--- a/ui/src/components/filter/components/RightFilter.vue
+++ b/ui/src/components/filter/components/RightFilter.vue
@@ -62,9 +62,13 @@
             />
         </el-popover>
 
-        <el-tooltip :content="$t('filter.show data options tooltip')" placement="top" effect="light">
+        <el-tooltip
+            v-if="filter.buttons.value?.tableOptions?.shown !== false"
+            :content="$t('filter.show data options tooltip')"
+            placement="top"
+            effect="light"
+        >
             <el-button
-                v-if="filter.buttons.value?.tableOptions?.shown !== false"
                 type="default"
                 size="default"
                 @click="filter.toggleOptions"


### PR DESCRIPTION
Prevent console warning in `Namespaces` page:

<img width="1920" height="984" alt="image" src="https://github.com/user-attachments/assets/83e246f7-cb76-470b-8149-56b390bc3b2c" />