### PR TITLE
feat: pebble-filter-autocomplete

### DIFF
--- a/core/src/main/java/io/kestra/core/runners/pebble/PebbleExpressionService.java
+++ b/core/src/main/java/io/kestra/core/runners/pebble/PebbleExpressionService.java
@@ -1,0 +1,49 @@
+package io.kestra.core.runners.pebble;
+
+import io.micronaut.context.ApplicationContext;
+import io.pebbletemplates.pebble.extension.Extension;
+import io.pebbletemplates.pebble.extension.Filter;
+import io.pebbletemplates.pebble.extension.Function;
+import io.pebbletemplates.pebble.extension.core.CoreExtension;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Singleton
+public class PebbleExpressionService {
+
+    private final List<String> filters;
+    private final List<String> functions;
+
+    @Inject
+    public PebbleExpressionService(ApplicationContext applicationContext) {
+        // Start with the core Pebble extension, after customization (same as PebbleEngineFactory)
+        ExtensionCustomizer customizedCore = new ExtensionCustomizer(new CoreExtension());
+        Map<String, Filter> allFilters = new HashMap<>(customizedCore.getFilters());
+        Map<String, Function> allFunctions = new HashMap<>(customizedCore.getFunctions());
+
+        // Merge all registered Extension beans (includes Kestra's Extension + any plugin extensions)
+        for (Extension ext : applicationContext.getBeansOfType(Extension.class)) {
+            if (ext.getFilters() != null) {
+                allFilters.putAll(ext.getFilters());
+            }
+            if (ext.getFunctions() != null) {
+                allFunctions.putAll(ext.getFunctions());
+            }
+        }
+
+        this.filters = allFilters.keySet().stream().sorted().toList();
+        this.functions = allFunctions.keySet().stream().sorted().toList();
+    }
+
+    public List<String> filters() {
+        return filters;
+    }
+
+    public List<String> functions() {
+        return functions;
+    }
+}

--- a/openapi.yml
+++ b/openapi.yml
@@ -110,6 +110,36 @@ paths:
                 type: array
                 items:
                   $ref: "#/components/schemas/AiController.AiProviderResponse"
+  /api/v1/pebble/filters:
+    get:
+      tags:
+      - Misc
+      summary: Retrieve the list of available Pebble expression filters.
+      operationId: getExpressionFilters
+      responses:
+        "200":
+          description: getExpressionFilters 200 response
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: string
+  /api/v1/pebble/functions:
+    get:
+      tags:
+      - Misc
+      summary: Retrieve the list of available Pebble expression functions.
+      operationId: getExpressionFunctions
+      responses:
+        "200":
+          description: getExpressionFunctions 200 response
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: string
   /api/v1/plugins:
     get:
       tags:

--- a/ui/src/composables/monaco/languages/pebbleLanguageConfigurator.ts
+++ b/ui/src/composables/monaco/languages/pebbleLanguageConfigurator.ts
@@ -157,6 +157,40 @@ export function registerNestedValueAutoCompletion(
     }));
 }
 
+export function registerFilterAutoCompletion(
+    autoCompletionProviders: IDisposable[],
+    autoCompletion: PebbleAutoCompletion,
+    languages: string[]
+) {
+    autoCompletionProviders.push(monaco.languages.registerCompletionItemProvider(languages, {
+        triggerCharacters: ["|"],
+        async provideCompletionItems(model, position) {
+            const lineContent = model.getLineContent(position.lineNumber);
+            const textBeforeCursor = lineContent.substring(0, position.column - 1);
+
+            const openBraces = (textBeforeCursor.match(/\{\{/g) || []).length;
+            const closeBraces = (textBeforeCursor.match(/\}\}/g) || []).length;
+
+            if (openBraces <= closeBraces) {
+                return NO_SUGGESTIONS;
+            }
+
+            const match = /\|\s*(\w*)$/.exec(textBeforeCursor);
+            const startOfWordColumn = match ? position.column - match[1].length : position.column;
+            const endColumn = position.column;
+
+            return {
+                suggestions: (await autoCompletion.filterAutoCompletion())
+                    .map(s => propertySuggestion(s, {
+                        lineNumber: position.lineNumber,
+                        startColumn: startOfWordColumn,
+                        endColumn: endColumn
+                    }, monaco.languages.CompletionItemKind.Function))
+            };
+        }
+    }));
+}
+
 const registeredLanguages = new Set<string>();
 
 function registerPebbleLanguage(language: string) {
@@ -240,6 +274,8 @@ export class PebbleLanguageConfigurator extends AbstractLanguageConfigurator {
         registerFunctionParametersAutoCompletion(autoCompletionProviders, autoCompletion, [this.language]);
 
         registerNestedValueAutoCompletion(autoCompletionProviders, autoCompletion, [this.language], completionSource);
+
+        registerFilterAutoCompletion(autoCompletionProviders, autoCompletion, [this.language]);
 
         return autoCompletionProviders;
     }

--- a/ui/src/services/autoCompletionProvider.ts
+++ b/ui/src/services/autoCompletionProvider.ts
@@ -1,7 +1,45 @@
 import {YamlElement} from "@kestra-io/ui-libs";
+import {apiUrlWithoutTenants} from "../override/utils/route";
+import {useAxios} from "../utils/axios";
 
 export const QUOTE = "'";
 
+let cachedFilters: string[] | null = null;
+let cachedFunctions: string[] | null = null;
+
+export function resetExpressionCache() {
+    cachedFilters = null;
+    cachedFunctions = null;
+}
+
+export function fillExpressionCache(filters: string[], functions: string[]) {
+    cachedFilters = filters;
+    cachedFunctions = functions;
+}
+
+async function fetchExpressionFilters(): Promise<string[]> {
+    if (cachedFilters === null) {
+        try {
+            const axios = useAxios();
+            cachedFilters = (await axios.get<string[]>(`${apiUrlWithoutTenants()}/pebble/filters`)).data;
+        } catch {
+            return [];
+        }
+    }
+    return cachedFilters;
+}
+
+async function fetchExpressionFunctions(): Promise<string[]> {
+    if (cachedFunctions === null) {
+        try {
+            const axios = useAxios();
+            cachedFunctions = (await axios.get<string[]>(`${apiUrlWithoutTenants()}/pebble/functions`)).data;
+        } catch {
+            return [];
+        }
+    }
+    return cachedFunctions;
+}
 
 export class PebbleAutoCompletion {
     rootFieldAutoCompletion(): Promise<string[]> {
@@ -14,6 +52,14 @@ export class PebbleAutoCompletion {
 
     functionAutoCompletion(_parsed: any | undefined, _functionName: string, _args: Record<string, string>): Promise<string[]> {
         return Promise.resolve([]);
+    }
+
+    filterAutoCompletion(): Promise<string[]> {
+        return fetchExpressionFilters();
+    }
+
+    functionNames(): Promise<string[]> {
+        return fetchExpressionFunctions();
     }
 }
 

--- a/ui/tests/storybook/components/inputs/Editor.stories.tsx
+++ b/ui/tests/storybook/components/inputs/Editor.stories.tsx
@@ -1,0 +1,203 @@
+import {ref} from "vue";
+import {expect} from "storybook/test";
+import type {Meta, StoryObj} from "@storybook/vue3-vite";
+import * as monaco from "monaco-editor/esm/vs/editor/editor.api";
+import Editor from "../../../../src/components/inputs/Editor.vue";
+import {fillExpressionCache} from "../../../../src/services/autoCompletionProvider";
+
+const MOCK_FILTERS = ["upper", "lower", "capitalize", "trim", "date", "number"];
+const MOCK_FUNCTIONS = ["now", "chunk", "max", "min", "range"];
+
+const meta: Meta<typeof Editor> = {
+    title: "Components/Inputs/Editor",
+    component: Editor,
+}
+
+export default meta;
+
+type Story = StoryObj<typeof Editor>;
+
+function getMonacoEditor(canvasElement: HTMLElement): monaco.editor.ICodeEditor | undefined {
+    const editorEl = canvasElement.querySelector(".monaco-editor") as HTMLElement | null;
+    if (!editorEl) return undefined;
+    return monaco.editor.getEditors().find(e => editorEl.contains(e.getDomNode()!));
+}
+
+function suggestionLabels(editorEl: HTMLElement): string[] {
+    const suggestWidget = editorEl.querySelector(".suggest-widget");
+    if (!suggestWidget) return [];
+    return Array.from(suggestWidget.querySelectorAll(".monaco-list-row .label-name"))
+        .map(el => el.textContent?.trim() ?? "");
+}
+
+export const Default: Story = {
+    render: () => ({
+        setup() {
+            const value = ref("");
+
+            return () => (
+                <div style="height: 500px; width: 100%;">
+                    <Editor
+                        modelValue={value.value}
+                        onUpdate:modelValue={(v: string) => value.value = v}
+                        lang="yaml-pebble"
+                        navbar={false}
+                        fullHeight={true}
+                    />
+                </div>
+            );
+        },
+    }),
+};
+
+export const PebbleFilterAutocomplete: Story = {
+    render: () => ({
+        setup() {
+            const value = ref("{{ 'hello' ");
+
+            return () => (
+                <div style="height: 500px; width: 100%;">
+                    <Editor
+                        modelValue={value.value}
+                        onUpdate:modelValue={(v: string) => value.value = v}
+                        lang="yaml-pebble"
+                        navbar={false}
+                        fullHeight={true}
+                    />
+                </div>
+            );
+        },
+    }),
+    play: async ({canvasElement}) => {
+        fillExpressionCache(MOCK_FILTERS, MOCK_FUNCTIONS);
+
+        // Wait for Monaco editor to mount
+        await new Promise(resolve => setTimeout(resolve, 1000));
+
+        const editorEl = canvasElement.querySelector(".monaco-editor") as HTMLElement;
+        expect(editorEl).toBeTruthy();
+
+        const codeEditor = getMonacoEditor(canvasElement);
+        expect(codeEditor).toBeTruthy();
+
+        codeEditor!.focus();
+        // Set value with pipe at end inside pebble expression, then type "|" to trigger filter completion
+        const model = codeEditor!.getModel()!;
+        const endPos = model.getPositionAt(model.getValueLength());
+        codeEditor!.setPosition(endPos);
+
+        // Type a pipe character via the editor API to trigger the completion provider
+        codeEditor!.trigger("test", "type", {text: "|"});
+        // Also explicitly trigger suggest in case the trigger character didn't fire
+        codeEditor!.trigger("test", "editor.action.triggerSuggest", {});
+
+        await new Promise(resolve => setTimeout(resolve, 2000));
+
+        // The suggest widget should appear with filter suggestions
+        const suggestWidget = editorEl.querySelector(".suggest-widget");
+        expect(suggestWidget).toBeTruthy();
+
+        // Assert at least one known filter is present
+        const labels = suggestionLabels(editorEl);
+        expect(labels.some(l => l.includes("upper"))).toBeTruthy();
+    },
+};
+
+export const PebbleRootFieldAutocomplete: Story = {
+    render: () => ({
+        setup() {
+            const value = ref("{{ out");
+
+            return () => (
+                <div style="height: 500px; width: 100%;">
+                    <Editor
+                        modelValue={value.value}
+                        onUpdate:modelValue={(v: string) => value.value = v}
+                        lang="yaml-pebble"
+                        navbar={false}
+                        fullHeight={true}
+                    />
+                </div>
+            );
+        },
+    }),
+    play: async ({canvasElement}) => {
+        fillExpressionCache(MOCK_FILTERS, MOCK_FUNCTIONS);
+
+        // Wait for Monaco editor to mount
+        await new Promise(resolve => setTimeout(resolve, 1000));
+
+        const editorEl = canvasElement.querySelector(".monaco-editor") as HTMLElement;
+        expect(editorEl).toBeTruthy();
+
+        const codeEditor = getMonacoEditor(canvasElement);
+        expect(codeEditor).toBeTruthy();
+
+        codeEditor!.focus();
+        // Content is "{{ out" — place cursor at end and trigger suggest
+        const model = codeEditor!.getModel()!;
+        const endPos = model.getPositionAt(model.getValueLength());
+        codeEditor!.setPosition(endPos);
+
+        codeEditor!.trigger("test", "editor.action.triggerSuggest", {});
+
+        await new Promise(resolve => setTimeout(resolve, 2000));
+
+        // The suggest widget should appear with root fields and function suggestions
+        const suggestWidget = editorEl.querySelector(".suggest-widget");
+        expect(suggestWidget).toBeTruthy();
+
+        // Assert at least one root variable is present
+        const labels = suggestionLabels(editorEl);
+        expect(labels.some(l => l.includes("outputs"))).toBeTruthy();
+    },
+};
+
+export const PebbleFilterAutocompleteOutsideExpression: Story = {
+    render: () => ({
+        setup() {
+            const value = ref("hello");
+
+            return () => (
+                <div style="height: 500px; width: 100%;">
+                    <Editor
+                        modelValue={value.value}
+                        onUpdate:modelValue={(v: string) => value.value = v}
+                        lang="yaml-pebble"
+                        navbar={false}
+                        fullHeight={true}
+                    />
+                </div>
+            );
+        },
+    }),
+    play: async ({canvasElement}) => {
+        fillExpressionCache(MOCK_FILTERS, MOCK_FUNCTIONS);
+
+        await new Promise(resolve => setTimeout(resolve, 1000));
+
+        const editorEl = canvasElement.querySelector(".monaco-editor") as HTMLElement;
+        expect(editorEl).toBeTruthy();
+
+        const codeEditor = getMonacoEditor(canvasElement);
+        expect(codeEditor).toBeTruthy();
+
+        // Dismiss any leftover suggest widget from previous tests
+        codeEditor!.trigger("test", "hideSuggestWidget", {});
+
+        codeEditor!.focus();
+        const model = codeEditor!.getModel()!;
+        const endPos = model.getPositionAt(model.getValueLength());
+        codeEditor!.setPosition(endPos);
+
+        // Type pipe outside of {{ }} — should NOT show filter suggestions
+        codeEditor!.trigger("test", "type", {text: "|"});
+
+        await new Promise(resolve => setTimeout(resolve, 2000));
+
+        // The suggest widget should NOT be visible (no .visible class, or no filter labels)
+        const labels = suggestionLabels(editorEl);
+        const hasFilterSuggestions = labels.some(l => MOCK_FILTERS.includes(l));
+        expect(hasFilterSuggestions).toBeFalsy();
+    },
+};

--- a/ui/tests/unit/services/pebbleAutoCompletionProvider.spec.ts
+++ b/ui/tests/unit/services/pebbleAutoCompletionProvider.spec.ts
@@ -1,0 +1,61 @@
+import {describe, expect, it, vi, beforeEach} from "vitest"
+import {PebbleAutoCompletion, resetExpressionCache} from "../../../src/services/autoCompletionProvider";
+
+const axiosGet = vi.fn();
+
+vi.mock("../../../src/utils/axios", () => ({
+    useAxios: () => ({
+        get: axiosGet,
+    }),
+}));
+
+vi.mock("../../../src/override/utils/route", () => ({
+    apiUrlWithoutTenants: () => "http://localhost/api/v1",
+}));
+
+describe("PebbleAutoCompletion", () => {
+    beforeEach(() => {
+        axiosGet.mockReset();
+        resetExpressionCache();
+    });
+
+    it("filterAutoCompletion fetches filters from API", async () => {
+        const filters = ["abs", "capitalize", "jq", "toJson", "upper", "yaml"];
+        axiosGet.mockResolvedValue({data: filters});
+
+        const provider = new PebbleAutoCompletion();
+        const result = await provider.filterAutoCompletion();
+
+        expect(axiosGet).toHaveBeenCalledWith("http://localhost/api/v1/pebble/filters");
+        expect(result).toEqual(filters);
+    });
+
+    it("functionNames fetches functions from API", async () => {
+        const functions = ["json", "kv", "max", "min", "now", "secret", "uuid"];
+        axiosGet.mockResolvedValue({data: functions});
+
+        const provider = new PebbleAutoCompletion();
+        const result = await provider.functionNames();
+
+        expect(axiosGet).toHaveBeenCalledWith("http://localhost/api/v1/pebble/functions");
+        expect(result).toEqual(functions);
+    });
+
+    it("filterAutoCompletion returns empty array on API error", async () => {
+        axiosGet.mockRejectedValue(new Error("Network error"));
+
+        const provider = new PebbleAutoCompletion();
+        const result = await provider.filterAutoCompletion();
+
+        expect(result).toEqual([]);
+    });
+
+    it("functionNames returns empty array on API error", async () => {
+        axiosGet.mockRejectedValue(new Error("Network error"));
+
+        const provider = new PebbleAutoCompletion();
+        const result = await provider.functionNames();
+
+        expect(result).toEqual([]);
+    });
+});

--- a/webserver/src/main/java/io/kestra/webserver/controllers/api/MiscController.java
+++ b/webserver/src/main/java/io/kestra/webserver/controllers/api/MiscController.java
@@ -8,6 +8,7 @@ import io.kestra.core.models.collectors.FlowUsage;
 import io.kestra.core.plugins.PluginRegistry;
 import io.kestra.core.reporter.Reportable;
 import io.kestra.core.reporter.reports.FeatureUsageReport;
+import io.kestra.core.runners.pebble.PebbleExpressionService;
 import io.kestra.core.repositories.DashboardRepositoryInterface;
 import io.kestra.core.repositories.ExecutionRepositoryInterface;
 import io.kestra.core.repositories.TemplateRepositoryInterface;
@@ -110,6 +111,9 @@ private String chartDefaultDuration;
     @Inject
     protected EditionProvider editionProvider;
 
+    @Inject
+    PebbleExpressionService pebbleExpressionService;
+
 
     @Get("/configs")
     @ExecuteOn(TaskExecutors.IO)
@@ -185,6 +189,20 @@ private String chartDefaultDuration;
         return basicAuthService
             .orElseThrow(() -> new IllegalStateException("basicAuthService bean is required in OSS"))
             .validationErrors();
+    }
+
+    @Get("/pebble/filters")
+    @ExecuteOn(TaskExecutors.IO)
+    @Operation(tags = {"Misc"}, summary = "Retrieve the list of available Pebble expression filters.")
+    public List<String> getExpressionFilters() {
+        return pebbleExpressionService.filters();
+    }
+
+    @Get("/pebble/functions")
+    @ExecuteOn(TaskExecutors.IO)
+    @Operation(tags = {"Misc"}, summary = "Retrieve the list of available Pebble expression functions.")
+    public List<String> getExpressionFunctions() {
+        return pebbleExpressionService.functions();
     }
 
     @Getter

--- a/webserver/src/test/java/io/kestra/webserver/controllers/api/MiscControllerTest.java
+++ b/webserver/src/test/java/io/kestra/webserver/controllers/api/MiscControllerTest.java
@@ -49,6 +49,34 @@ class MiscControllerTest {
     private FlowRepositoryInterface flowRepository;
 
     @Test
+    void getExpressionFilters() {
+        List<String> response = client.toBlocking().retrieve(GET("/api/v1/pebble/filters"), Argument.LIST_OF_STRING);
+
+        assertThat(response).isNotNull();
+        assertThat(response).isNotEmpty();
+        // Kestra custom filters
+        assertThat(response).contains("jq", "toJson", "yaml", "slugify", "chunk", "flatten");
+        // Pebble core filters
+        assertThat(response).contains("capitalize", "upper", "lower", "trim", "first", "last");
+        // Should be sorted
+        assertThat(response).isSorted();
+    }
+
+    @Test
+    void getExpressionFunctions() {
+        List<String> response = client.toBlocking().retrieve(GET("/api/v1/pebble/functions"), Argument.LIST_OF_STRING);
+
+        assertThat(response).isNotNull();
+        assertThat(response).isNotEmpty();
+        // Kestra custom functions
+        assertThat(response).contains("now", "secret", "kv", "uuid", "json", "yaml");
+        // Pebble core functions
+        assertThat(response).contains("max", "min", "range");
+        // Should be sorted
+        assertThat(response).isSorted();
+    }
+
+    @Test
     void ping() {
         var response = client.toBlocking().retrieve("/ping", String.class);
 


### PR DESCRIPTION
closes: #7734

### ✨ Description

What does this PR change?  

This PR adds autocompletion support for Pebble filters when typing the pipe (|) character inside Pebble expressions.

- Prevents suggestions outside Pebble expressions.
- Integrates cleanly with existing Pebble autocompletion logic.