### PR TITLE
fix(labels): prevent system labels usage from schedule triggers

### DIFF
--- a/core/src/main/java/io/kestra/core/models/executions/Execution.java
+++ b/core/src/main/java/io/kestra/core/models/executions/Execution.java
@@ -194,7 +194,7 @@ public class Execution implements SoftDeletable<Execution>, TenantInterface, Has
             .kind(kind)
             .build();
 
-        List<Label> executionLabels = new ArrayList<>(LabelService.labelsExcludingSystem(flow));
+        List<Label> executionLabels = new ArrayList<>(LabelService.labelsExcludingSystem(flow.getLabels()));
         if (labels != null) {
             executionLabels.addAll(labels);
         }

--- a/core/src/main/java/io/kestra/core/services/LabelService.java
+++ b/core/src/main/java/io/kestra/core/services/LabelService.java
@@ -17,6 +17,7 @@ public final class LabelService {
     /**
      * Return labels after excluding system labels.
      * This method is used generally for any labels list
+     * When labels list is null it handles it implicitly to prevent unnecessary null checks at the callers
      */
     public static List<Label> labelsExcludingSystem(List<Label> labels) {
         return ListUtils.emptyOnNull(labels)

--- a/core/src/main/java/io/kestra/core/services/LabelService.java
+++ b/core/src/main/java/io/kestra/core/services/LabelService.java
@@ -15,13 +15,6 @@ public final class LabelService {
     private LabelService() {}
 
     /**
-     * Return flow labels excluding system labels.
-     */
-    public static List<Label> labelsExcludingSystem(FlowInterface flow) {
-        return ListUtils.emptyOnNull(flow.getLabels()).stream().filter(label -> !label.key().startsWith(Label.SYSTEM_PREFIX)).toList();
-    }
-
-    /**
      * Return labels after excluding system labels.
      * This method is used generally for any labels list
      */
@@ -39,14 +32,10 @@ public final class LabelService {
      * In case rendering is not possible, the label will be omitted.
      */
     public static List<Label> fromTrigger(RunContext runContext, FlowInterface flow, AbstractTrigger trigger) {
-        final List<Label> labels = new ArrayList<>();
 
-        if (flow.getLabels() != null) {
-            labels.addAll(labelsExcludingSystem(flow)); // no need for rendering
-        }
+        final List<Label> labels = new ArrayList<>(labelsExcludingSystem(flow.getLabels())); // no need for rendering
 
-        if (trigger.getLabels() != null) {
-            // It is better to remove system labels before rendering
+        // It is better to remove system labels before rendering
             List<Label> triggerLabels = labelsExcludingSystem(trigger.getLabels());
             for (Label label : triggerLabels) {
                 final var value = renderLabelValue(runContext, label);
@@ -54,7 +43,6 @@ public final class LabelService {
                     labels.add(new Label(label.key(), value));
                 }
             }
-        }
 
         return labels;
     }

--- a/core/src/main/java/io/kestra/core/services/LabelService.java
+++ b/core/src/main/java/io/kestra/core/services/LabelService.java
@@ -22,6 +22,17 @@ public final class LabelService {
     }
 
     /**
+     * Return labels after excluding system labels.
+     * This method is used generally for any labels list
+     */
+    public static List<Label> labelsExcludingSystem(List<Label> labels) {
+        return ListUtils.emptyOnNull(labels)
+                .stream()
+                .filter(label -> !label.key().startsWith(Label.SYSTEM_PREFIX))
+                .toList();
+    }
+
+    /**
      * Return flow labels excluding system labels concatenated with trigger labels.
      *
      * Trigger labels will be rendered via the run context but not flow labels.
@@ -31,11 +42,13 @@ public final class LabelService {
         final List<Label> labels = new ArrayList<>();
 
         if (flow.getLabels() != null) {
-            labels.addAll(LabelService.labelsExcludingSystem(flow)); // no need for rendering
+            labels.addAll(labelsExcludingSystem(flow)); // no need for rendering
         }
 
         if (trigger.getLabels() != null) {
-            for (Label label : trigger.getLabels()) {
+            // It is better to remove system labels before rendering
+            List<Label> triggerLabels = labelsExcludingSystem(trigger.getLabels());
+            for (Label label : triggerLabels) {
                 final var value = renderLabelValue(runContext, label);
                 if (value != null) {
                     labels.add(new Label(label.key(), value));

--- a/core/src/main/java/io/kestra/core/services/WebhookService.java
+++ b/core/src/main/java/io/kestra/core/services/WebhookService.java
@@ -108,9 +108,7 @@ public class WebhookService {
         // Add labels
         List<Label> labels = new ArrayList<>();
         labels.add(new Label(Label.FROM, "trigger"));
-        if (flow.getLabels() != null) {
-            labels.addAll(LabelService.labelsExcludingSystem(flow));
-        }
+        labels.addAll(LabelService.labelsExcludingSystem(flow.getLabels()));
         if (labels.stream().noneMatch(label -> label.key().equals(CORRELATION_ID))) {
             labels.add(new Label(CORRELATION_ID, execution.getId()));
         }

--- a/core/src/main/java/io/kestra/plugin/core/trigger/SchedulableExecutionFactory.java
+++ b/core/src/main/java/io/kestra/plugin/core/trigger/SchedulableExecutionFactory.java
@@ -94,7 +94,7 @@ final class SchedulableExecutionFactory {
     private static List<Label> getLabels(Schedulable trigger, RunContext runContext, Backfill backfill, FlowInterface flow) throws IllegalVariableEvaluationException {
         List<Label> labels = LabelService.fromTrigger(runContext, flow, (AbstractTrigger) trigger);
 
-        if (backfill != null && backfill.getLabels() != null) {
+        if (backfill != null) {
             // It is better to remove system labels before rendering
             List<Label> backfillLabels = LabelService.labelsExcludingSystem(backfill.getLabels());
             for (Label label : backfillLabels) {

--- a/core/src/main/java/io/kestra/plugin/core/trigger/SchedulableExecutionFactory.java
+++ b/core/src/main/java/io/kestra/plugin/core/trigger/SchedulableExecutionFactory.java
@@ -95,7 +95,9 @@ final class SchedulableExecutionFactory {
         List<Label> labels = LabelService.fromTrigger(runContext, flow, (AbstractTrigger) trigger);
 
         if (backfill != null && backfill.getLabels() != null) {
-            for (Label label : backfill.getLabels()) {
+            // It is better to remove system labels before rendering
+            List<Label> backfillLabels = LabelService.labelsExcludingSystem(backfill.getLabels());
+            for (Label label : backfillLabels) {
                 final var value = runContext.render(label.value());
                 if (value != null) {
                     labels.add(new Label(label.key(), value));

--- a/core/src/test/java/io/kestra/core/services/LabelServiceTest.java
+++ b/core/src/test/java/io/kestra/core/services/LabelServiceTest.java
@@ -35,7 +35,7 @@ class LabelServiceTest {
             .labels(List.of(new Label("key", "value"), new Label(Label.SYSTEM_PREFIX + "label", "systemValue")))
             .build();
 
-        List<Label> labels = LabelService.labelsExcludingSystem(flow);
+        List<Label> labels = LabelService.labelsExcludingSystem(flow.getLabels());
 
         assertThat(labels).hasSize(1);
         assertThat(labels.getFirst()).isEqualTo(new Label("key", "value"));

--- a/core/src/test/java/io/kestra/plugin/core/trigger/ScheduleTest.java
+++ b/core/src/test/java/io/kestra/plugin/core/trigger/ScheduleTest.java
@@ -159,7 +159,9 @@ class ScheduleTest {
             .labels(List.of(
                 new Label("trigger-label-1", "trigger-label-1"),
                 new Label("trigger-label-2", "{{ 'trigger-label-2' }}"),
-                new Label("trigger-label-3", "{{ null }}")
+                new Label("trigger-label-3", "{{ null }}"),
+                new Label("system.replay","replay"),
+                new Label("system.test", "test")
             ))
             .build();
         var conditionContext = conditionContext(scheduleTrigger);
@@ -176,6 +178,9 @@ class ScheduleTest {
 
         assertThat(evaluate.isPresent()).isTrue();
         assertThat(evaluate.get().getVariables()).containsEntry("custom_var", "VARIABLE VALUE");
+        assertThat(evaluate.get().getLabels()).hasSize(6);
+        assertThat(evaluate.get().getLabels()).doesNotContain(new Label("system.replay","replay"));
+        assertThat(evaluate.get().getLabels()).doesNotContain(new Label("system.test", "test"));
         assertThat(evaluate.get().getLabels()).contains(new Label("trigger-label-1", "trigger-label-1"));
         assertThat(evaluate.get().getLabels()).contains(new Label("trigger-label-2", "trigger-label-2"));
         assertThat(evaluate.get().getLabels()).doesNotContain(new Label("trigger-label-3", ""));

--- a/scheduler/src/main/java/io/kestra/scheduler/AbstractScheduler.java
+++ b/scheduler/src/main/java/io/kestra/scheduler/AbstractScheduler.java
@@ -776,7 +776,7 @@ public abstract class AbstractScheduler implements Scheduler {
                     if (abstractTrigger.isAllowConcurrent()) {
                         trigger = trigger.toBuilder().executionId(null).build();
                     }
-                
+
                     // Worker triggers result is evaluated in another thread with the workerTriggerResultQueue.
                     // We can then update the trigger directly.
                     this.saveLastTriggerAndEmitExecution(executionWithTrigger.getExecution(), trigger, triggerToSave -> this.triggerState.update(triggerToSave));
@@ -798,7 +798,7 @@ public abstract class AbstractScheduler implements Scheduler {
         if (result.getExecution().getState().getCurrent() == State.Type.FAILED) {
             trigger = trigger.resetExecution(State.Type.FAILED);
         }
-        
+
         // if the trigger is allowed to run concurrently we do not attached the executio-id to the trigger state
         // i.e., the trigger will not be locked
         if (((AbstractTrigger)schedule).isAllowConcurrent()) {
@@ -982,7 +982,7 @@ public abstract class AbstractScheduler implements Scheduler {
             .namespace(flowWithTrigger.getTriggerContext().getNamespace())
             .flowId(flowWithTrigger.getTriggerContext().getFlowId())
             .flowRevision(flowWithTrigger.getFlow().getRevision())
-            .labels(LabelService.labelsExcludingSystem(flowWithTrigger.getFlow()))
+            .labels(LabelService.labelsExcludingSystem(flowWithTrigger.getFlow().getLabels()))
             .state(new State().withState(State.Type.FAILED))
             .build();
         Logger logger = runContextFactory.of(flowWithTrigger.getFlow(), execution).logger();

--- a/webserver/src/main/java/io/kestra/webserver/controllers/api/ExecutionController.java
+++ b/webserver/src/main/java/io/kestra/webserver/controllers/api/ExecutionController.java
@@ -613,7 +613,7 @@ public class ExecutionController {
                 .namespace(flow.getNamespace())
                 .flowId(flow.getId())
                 .flowRevision(flow.getRevision())
-                .labels(LabelService.labelsExcludingSystem(flow))
+                .labels(LabelService.labelsExcludingSystem(flow.getLabels()))
                 .state(new State().withState(State.Type.FAILED))
                 .build();
 
@@ -711,8 +711,8 @@ public class ExecutionController {
                 if (Check.Behavior.BLOCK_EXECUTION.equals(behavior)) {
                     return Mono.error(new IllegalArgumentException(
                         "Flow execution blocked: one or more condition checks evaluated to false."
-                        + "\nFailed checks: " + failed.stream().map(Check::getMessage).collect(Collectors.joining(", ")
-                    )));
+                            + "\nFailed checks: " + failed.stream().map(Check::getMessage).collect(Collectors.joining(", ")
+                        )));
                 }
 
                 final Execution executionWithInputs = Optional.of(current.withInputs(executionInputs))

--- a/worker/src/main/java/io/kestra/worker/DefaultWorker.java
+++ b/worker/src/main/java/io/kestra/worker/DefaultWorker.java
@@ -466,14 +466,14 @@ public class DefaultWorker implements Worker {
         }
 
         var flow = workerTrigger.getConditionContext().getFlow();
-        if (flow.getLabels() != null) {
-            evaluate = evaluate.map(execution -> {
+
+        evaluate = evaluate.map(execution -> {
                     List<Label> executionLabels = execution.getLabels() != null ? execution.getLabels() : new ArrayList<>();
                     executionLabels.addAll(LabelService.labelsExcludingSystem(flow.getLabels()));
                     return execution.withLabels(executionLabels);
                 }
             );
-        }
+
 
         try {
             this.workerTriggerResultQueue.emit(

--- a/worker/src/main/java/io/kestra/worker/DefaultWorker.java
+++ b/worker/src/main/java/io/kestra/worker/DefaultWorker.java
@@ -469,7 +469,7 @@ public class DefaultWorker implements Worker {
         if (flow.getLabels() != null) {
             evaluate = evaluate.map(execution -> {
                     List<Label> executionLabels = execution.getLabels() != null ? execution.getLabels() : new ArrayList<>();
-                    executionLabels.addAll(LabelService.labelsExcludingSystem(flow));
+                    executionLabels.addAll(LabelService.labelsExcludingSystem(flow.getLabels()));
                     return execution.withLabels(executionLabels);
                 }
             );


### PR DESCRIPTION
- System labels defined on schedule triggers were not being excluded, which allowed them to appear in logs for scheduled executions if the flow bypassed earlier model validations and saved into the database which can happen in some cases (e.g. flow import, see #14446), system labels must be excluded from triggers and backfill just as flow labels when creating scheduled execution regardless of the earlier validation state to avoid inconsistencies and unintended exposure as there may be other ways to bypass validations rather than flow import.

- Refactor LabelService#labelsExcludingSystem() to handle labels uniformly across all contexts (flow, trigger, backfill, execution). The method is already null-safe, allowing removal of unnecessary null checks at call sites and resulting in cleaner, less verbose code.