### PR TITLE
fix(system): use isolation level READ_COMMITED

### DIFF
--- a/executor/src/main/java/io/kestra/executor/DefaultExecutor.java
+++ b/executor/src/main/java/io/kestra/executor/DefaultExecutor.java
@@ -320,7 +320,7 @@ public class DefaultExecutor extends AbstractService implements Executor {
             return;
         }
 
-        // TODO investigate moving the CREATED code here, or if it's too dangerous, calling the ExecutionEventMessageHandler here to avoid a loop inside the executor event queue
+        // TODO investigate calling the ExecutionEventMessageHandler here to avoid a loop inside the executor event queue
         Optional<ExecutorContext> maybeExecutor = executionMessageHandler.handle(message);
         maybeExecutor.ifPresent(this::toExecution);
     }

--- a/executor/src/main/java/io/kestra/executor/handler/ExecutionEventMessageHandler.java
+++ b/executor/src/main/java/io/kestra/executor/handler/ExecutionEventMessageHandler.java
@@ -184,7 +184,7 @@ public class ExecutionEventMessageHandler implements ExecutorMessageHandler<Exec
                                                 workerTaskResults.add(new WorkerTaskResult(taskRun));
                                             }
                                         }
-                                        /// flowable attempt state transition to running
+                                        // flowable attempt state transition to running
                                         if (workerTask.getTask().isFlowable()) {
                                             List<TaskRunAttempt> attempts = Optional.ofNullable(workerTask.getTaskRun().getAttempts())
                                                 .map(ArrayList::new)
@@ -235,7 +235,9 @@ public class ExecutionEventMessageHandler implements ExecutorMessageHandler<Exec
                     if (!executor.getSubflowExecutions().isEmpty()) {
                         executor.getSubflowExecutions().forEach(throwConsumer(subflowExecution -> {
                             Execution subExecution = subflowExecution.getExecution();
-                            String msg = String.format("Created new execution [[link execution=\"%s\" flowId=\"%s\" namespace=\"%s\"]]", subExecution.getId(), subExecution.getFlowId(), subExecution.getNamespace());
+                            String msg = subExecution.getState().getCurrent() == State.Type.RESTARTED ?
+                                String.format("Restarted execution [[link execution=\"%s\" flowId=\"%s\" namespace=\"%s\"]]", subExecution.getId(), subExecution.getFlowId(), subExecution.getNamespace()) :
+                                String.format("Created new execution [[link execution=\"%s\" flowId=\"%s\" namespace=\"%s\"]]", subExecution.getId(), subExecution.getFlowId(), subExecution.getNamespace());
 
                             log.info(msg);
 

--- a/executor/src/main/java/io/kestra/executor/handler/ExecutionMessageHandler.java
+++ b/executor/src/main/java/io/kestra/executor/handler/ExecutionMessageHandler.java
@@ -30,7 +30,8 @@ public class ExecutionMessageHandler implements ExecutorMessageHandler<Execution
     @Override
     public Optional<ExecutorContext> handle(Execution message) {
         try {
-            executionEventQueue.emit(new ExecutionEvent(message, ExecutionEventType.CREATED));
+            var eventType = message.getState().isCreated() ? ExecutionEventType.CREATED : ExecutionEventType.UPDATED;
+            executionEventQueue.emit(new ExecutionEvent(message, eventType));
             return Optional.empty();
         } catch (QueueException e) {
             // If we cannot send the execution event, we fail the execution

--- a/jdbc-mysql/src/test/java/io/kestra/runner/mysql/MysqlRunnerConcurrencyTest.java
+++ b/jdbc-mysql/src/test/java/io/kestra/runner/mysql/MysqlRunnerConcurrencyTest.java
@@ -1,8 +1,6 @@
 package io.kestra.runner.mysql;
 
 import io.kestra.core.runners.AbstractRunnerConcurrencyTest;
-import org.junit.jupiter.api.Disabled;
 
-@Disabled("Deadlock :(")
 public class MysqlRunnerConcurrencyTest extends AbstractRunnerConcurrencyTest {
 }

--- a/jdbc-mysql/src/test/java/io/kestra/runner/mysql/MysqlRunnerRetryTest.java
+++ b/jdbc-mysql/src/test/java/io/kestra/runner/mysql/MysqlRunnerRetryTest.java
@@ -1,11 +1,9 @@
 package io.kestra.runner.mysql;
 
 import io.kestra.jdbc.runner.JdbcRunnerRetryTest;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
 
-@Disabled("Deadlock :(")
 @TestInstance(Lifecycle.PER_CLASS)
 public class MysqlRunnerRetryTest extends JdbcRunnerRetryTest {
 

--- a/jdbc-mysql/src/test/java/io/kestra/runner/mysql/MysqlRunnerTest.java
+++ b/jdbc-mysql/src/test/java/io/kestra/runner/mysql/MysqlRunnerTest.java
@@ -1,9 +1,7 @@
 package io.kestra.runner.mysql;
 
 import io.kestra.jdbc.runner.JdbcRunnerTest;
-import org.junit.jupiter.api.Disabled;
 
-@Disabled("MySQL deadlock for now :(")
 public class MysqlRunnerTest extends JdbcRunnerTest {
 
 }

--- a/jdbc-mysql/src/test/resources/application-test.yml
+++ b/jdbc-mysql/src/test/resources/application-test.yml
@@ -10,6 +10,7 @@ datasources:
     connectionTimeout: 30000
     idleTimeout: 600000
     maxLifetime: 1800000
+    transactionIsolation: TRANSACTION_READ_COMMITTED
 
 flyway:
   datasources:

--- a/jdbc/src/main/java/io/kestra/jdbc/JooqExecuteListenerFactory.java
+++ b/jdbc/src/main/java/io/kestra/jdbc/JooqExecuteListenerFactory.java
@@ -7,9 +7,12 @@ import lombok.extern.slf4j.Slf4j;
 import org.jooq.ExecuteContext;
 import org.jooq.ExecuteListener;
 
+import java.sql.Connection;
+import java.sql.SQLException;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
 import javax.sql.DataSource;
 import jakarta.validation.constraints.NotNull;
 
@@ -22,11 +25,24 @@ public class JooqExecuteListenerFactory {
             @Override
             public @NotNull ExecuteListener provide() {
                 return new ExecuteListener() {
-                    Long startTime;
+                    private static final AtomicBoolean CONNECTION_CHECKED = new AtomicBoolean(false);
+                    private Long startTime;
 
                     @Override
                     public void executeStart(ExecuteContext ctx) {
                         startTime = System.currentTimeMillis();
+
+                        // check that isolation level is READ UNCOMMITED, it's the default for Postgres but not for MySQL,
+                        // our queue system didn't work correctly otherwise.
+                        if (!CONNECTION_CHECKED.getAndSet(true)) {
+                            try {
+                                if (ctx.connection().getTransactionIsolation() != Connection.TRANSACTION_READ_COMMITTED) {
+                                    throw new IllegalStateException("Isolation level must be READ COMMITTED");
+                                }
+                            } catch (SQLException e) {
+                                // silently ignore any exception here
+                            }
+                        }
                     }
 
                     @Override

--- a/jdbc/src/main/java/io/kestra/jdbc/runner/JdbcQueueConfiguration.java
+++ b/jdbc/src/main/java/io/kestra/jdbc/runner/JdbcQueueConfiguration.java
@@ -25,8 +25,12 @@ public record JdbcQueueConfiguration(
 ) {
 
     public List<Step> computeSteps() {
-        if (this.maxPollInterval.compareTo(this.minPollInterval) <= 0) {
-            throw new IllegalArgumentException("'maxPollInterval' (" + this.maxPollInterval + ") must be greater than 'minPollInterval' (" + this.minPollInterval + ")");
+        if (this.maxPollInterval.compareTo(this.minPollInterval) < 0) {
+            throw new IllegalArgumentException("'maxPollInterval' (" + this.maxPollInterval + ") must be greater than or equal to 'minPollInterval' (" + this.minPollInterval + ")");
+        }
+
+        if (this.maxPollInterval.equals(this.minPollInterval)) {
+            return List.of(new Step(this.minPollInterval, Duration.ZERO));
         }
 
         List<Step> steps = new ArrayList<>();

--- a/jdbc/src/test/java/io/kestra/jdbc/runner/JdbcQueueConfigurationTest.java
+++ b/jdbc/src/test/java/io/kestra/jdbc/runner/JdbcQueueConfigurationTest.java
@@ -12,8 +12,8 @@ public class JdbcQueueConfigurationTest {
     @Test
     void shouldFailWhenMaxPollLessThanMinPoll() {
         var configuration = new JdbcQueueConfiguration(
-            Duration.ofMillis(2),
-            Duration.ofMillis(1),
+            Duration.ofSeconds(2),
+            Duration.ofSeconds(1),
             Duration.ofSeconds(60),
             100,
             5,
@@ -75,8 +75,8 @@ public class JdbcQueueConfigurationTest {
     @Test
     void shouldComputeSingleStepWhenMinEqualsMax() {
         var configuration = new JdbcQueueConfiguration(
-            Duration.ofMillis(1),
-            Duration.ofMillis(1),
+            Duration.ofSeconds(1),
+            Duration.ofSeconds(1),
             Duration.ofSeconds(60),
             100,
             5,

--- a/queue/src/main/java/io/kestra/queue/AbstractSubscriber.java
+++ b/queue/src/main/java/io/kestra/queue/AbstractSubscriber.java
@@ -77,7 +77,7 @@ public abstract class AbstractSubscriber<T extends Event> implements QueueSubscr
             return true;
         }
 
-        throw new IllegalStateException(logPrefix + " illegal state change to " + newState + " from " + newState + ", current state is " + this.state.get());
+        throw new IllegalStateException(logPrefix + " illegal state change to " + newState + " from " + expected + ", current state is " + this.state.get());
     }
 
     protected void markReady() {
@@ -103,6 +103,10 @@ public abstract class AbstractSubscriber<T extends Event> implements QueueSubscr
 
     @Override
     public void resume() {
+        if (this.state.get() == State.STOPPED) {
+            return;
+        }
+
         if (log.isDebugEnabled()) {
             log.debug("{} resume received", logPrefix);
         }
@@ -135,6 +139,10 @@ public abstract class AbstractSubscriber<T extends Event> implements QueueSubscr
 
     @Override
     public void close() {
+        if (this.state.get() == State.STOPPED) {
+            return;
+        }
+
         if (log.isDebugEnabled()) {
             log.debug("{} close received", logPrefix);
         }

--- a/webserver/src/test/java/io/kestra/webserver/controllers/api/ExecutionControllerRunnerTest.java
+++ b/webserver/src/test/java/io/kestra/webserver/controllers/api/ExecutionControllerRunnerTest.java
@@ -521,10 +521,7 @@ class ExecutionControllerRunnerTest {
 
         assertThat(replay).isNotNull();
 
-        Execution finishedChildExecution = runnerUtils.awaitChildExecution(
-            flow.get(),
-            parentExecution,
-            Duration.ofSeconds(15));
+        Execution finishedChildExecution = awaitExecution(parentExecution.getId(), exec -> exec.getState().getCurrent().isSuccess());
 
         assertThat(finishedChildExecution).isNotNull();
         assertThat(finishedChildExecution.getParentId()).isEqualTo(parentExecution.getId());
@@ -568,6 +565,7 @@ class ExecutionControllerRunnerTest {
         );
 
         assertThat(replay).isNotNull();
+        awaitExecution(parentExecution.getId(), exec -> exec.getState().getCurrent().isSuccess());
 
         Execution finishedChildExecution = runnerUtils.awaitChildExecution(
             flow.get(),
@@ -1481,7 +1479,8 @@ class ExecutionControllerRunnerTest {
 
         assertThat(executions.getTotal()).isEqualTo(0L);
 
-        triggerExecutionInputsFlowExecution(tenantId, false);
+        Execution execution = triggerExecutionInputsFlowExecution(tenantId, false);
+        awaitExecution(execution.getId(), exec -> exec.getState().getCurrent().isSuccess());
 
         // + is there to simulate that a space was added (this can be the case from UI autocompletion for eg.)
         executions = client.toBlocking().retrieve(
@@ -1789,6 +1788,7 @@ class ExecutionControllerRunnerTest {
             ApiAsyncEvent.class
         );
         assertThat(response.getStatus().getCode()).isEqualTo(HttpStatus.OK.getCode());
+        awaitExecution(result.getId(), exec -> exec.getState().getCurrent() == State.Type.PAUSED);
 
         // resume it, it should then go to completion
         response = client.toBlocking().exchange(
@@ -1910,6 +1910,7 @@ class ExecutionControllerRunnerTest {
             HttpRequest.POST("/api/v1/" + tenantId + "/executions/" + result1.getId() + "/unqueue?state=CANCELLED", null)
         );
         assertThat(cancelResponse.getStatus().getCode()).isEqualTo(HttpStatus.OK.getCode());
+        awaitExecution(result1.getId(), exec -> exec.getState().getCurrent() == State.Type.CANCELLED);
 
         Optional<Execution> cancelledExecution = executionRepositoryInterface.findById(tenantId, result1.getId());
         assertThat(cancelledExecution.isPresent()).isTrue();
@@ -1945,6 +1946,8 @@ class ExecutionControllerRunnerTest {
 
         var response = client.toBlocking().exchange(HttpRequest.POST("/api/v1/" + tenantId + "/executions/" + result.getId() + "/force-run", null));
         assertThat(response.getStatus().getCode()).isEqualTo(HttpStatus.OK.getCode());
+        awaitExecution(result.getId(), exec -> exec.getState().getCurrent() != State.Type.QUEUED);
+
         Optional<Execution> forcedRun = executionRepositoryInterface.findById(tenantId, result.getId());
         assertThat(forcedRun.isPresent()).isTrue();
         assertThat(forcedRun.get().getState().getCurrent()).isNotEqualTo(State.Type.QUEUED);
@@ -1977,9 +1980,11 @@ class ExecutionControllerRunnerTest {
         String tenantId = "shouldforcerunexecutionacreatedflow";
         when(tenantService.resolveTenant()).thenReturn(tenantId);
         Execution result = this.createExecution(tenantId, TESTS_FLOW_NS, "minimal");
-        this.executionQueue.emit(result);
+        this.executionRepositoryInterface.save(result);
 
         var response = client.toBlocking().exchange(HttpRequest.POST("/api/v1/" + tenantId + "/executions/" + result.getId() + "/force-run", null));
+        awaitExecution(result.getId(), exec -> exec.getState().getCurrent() != Type.CREATED);
+
         assertThat(response.getStatus().getCode()).isEqualTo(HttpStatus.OK.getCode());
         Optional<Execution> forcedRun = executionRepositoryInterface.findById(tenantId, result.getId());
         assertThat(forcedRun.isPresent()).isTrue();


### PR DESCRIPTION
Check once that it is set on the connection.

This would align MySQL default isolation level with Postgres. This is mandatory for our queueing system to avoid potential deadlocks.
