### PR TITLE
fix: runcontext init for mock runcontext

### DIFF
--- a/tests/src/main/java/io/kestra/core/utils/TestsUtils.java
+++ b/tests/src/main/java/io/kestra/core/utils/TestsUtils.java
@@ -234,7 +234,11 @@ abstract public class TestsUtils {
         Execution execution = TestsUtils.mockExecution(flow, inputs, null);
         TaskRun taskRun = TestsUtils.mockTaskRun(execution, task);
 
-        return runContextFactory.of(flow, task, execution, taskRun);
+        RunContext runContext = runContextFactory.of(flow, task, execution, taskRun);
+
+        runContextFactory.initializer().forExecutor((DefaultRunContext) runContext);
+
+        return runContext;
     }
 
     public static <T> Flux<T> receive(QueueInterface<T> queue) {


### PR DESCRIPTION
After bumping `plugin-dbt` to 1.2

Error 1:
```
io.kestra.core.models.tasks.RunnableTaskException: Cannot invoke "java.util.Optional.isPresent()" because "this.secretKey" is null
```


Error 2:
```
Cannot invoke "io.kestra.core.runners.VariableRenderer.render(String, java.util.Map)" because "this.variableRenderer" is null
java.lang.NullPointerException: Cannot invoke "io.kestra.core.runners.VariableRenderer.render(String, java.util.Map)" because "this.variableRenderer" is null
```

