### PR TITLE
fix(core): inject local Worker envs into RunContext

### DIFF
--- a/core/src/main/java/io/kestra/core/runners/RunContext.java
+++ b/core/src/main/java/io/kestra/core/runners/RunContext.java
@@ -2,6 +2,7 @@ package io.kestra.core.runners;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import io.kestra.core.encryption.EncryptionService;
 import io.kestra.core.exceptions.IllegalVariableEvaluationException;
 import io.kestra.core.models.Plugin;
@@ -20,6 +21,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
+@JsonSerialize(using = RunContextSerializer.class)
 public abstract class RunContext implements PropertyContext {
 
     /**

--- a/core/src/main/java/io/kestra/core/runners/RunContextInitializer.java
+++ b/core/src/main/java/io/kestra/core/runners/RunContextInitializer.java
@@ -51,6 +51,9 @@ public class RunContextInitializer {
     @Value("${kestra.encryption.secret-key}")
     protected Optional<String> secretKey;
 
+    @Inject
+    protected RunContextCache runContextCache;
+
     /**
      * Initializes the given {@link RunContext} for the given {@link WorkerTask} for executor.
      *
@@ -105,6 +108,7 @@ public class RunContextInitializer {
         Map<String, Object> enrichedVariables = new HashMap<>(runContext.getVariables());
         enrichedVariables.put("taskrun", RunVariables.of(taskRun));
         enrichedVariables.put("task", RunVariables.of(task));
+        enrichedVariables.put("envs", runContextCache.getEnvVars()); // inject local worker env vars
 
         Map<String, Object> workerTaskRun = (Map<String, Object>) enrichedVariables.get("workerTaskrun");
         if (workerTaskRun != null && workerTaskRun.containsKey("value")) {
@@ -151,6 +155,7 @@ public class RunContextInitializer {
                                        final WorkerTaskResult workerTaskResult,
                                        final TaskRun parent) {
         Map<String, Object> variables = new HashMap<>(runContext.getVariables());
+        variables.put("envs", runContextCache.getEnvVars()); // inject local worker env vars
 
         Map<String, Object> outputs = variables.containsKey("outputs") ?
             new HashMap<>((Map<String, Object>) variables.get("outputs")) :

--- a/core/src/main/java/io/kestra/core/runners/RunContextSerializer.java
+++ b/core/src/main/java/io/kestra/core/runners/RunContextSerializer.java
@@ -1,0 +1,53 @@
+package io.kestra.core.runners;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.ser.std.StdSerializer;
+
+import java.io.IOException;
+import java.io.Serial;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Custom serializer for {@link RunContext}.
+ * <p>
+ * Filters out the "envs" key from the variables map during serialization ensuring that environment
+ * variables are not sent to workers.
+ */
+public class RunContextSerializer extends StdSerializer<RunContext> {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
+
+    protected RunContextSerializer() {
+        super(RunContext.class);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void serialize(RunContext value, JsonGenerator gen, SerializerProvider provider) throws IOException {
+        Map<String, Object> mutableVariables = new HashMap<>(value.getVariables());
+        mutableVariables.remove("envs");
+        gen.writeObject(new RunContextData(mutableVariables, value.getSecretInputs(), value.getTraceParent()));
+    }
+
+    /**
+     * Intermediate record used to preserve null values during serialization.
+     * <p>
+     * The {@code @JsonInclude} annotation (defaulting to {@code ALWAYS} for both value and content)
+     * overrides the mapper-level {@code NON_NULL} policy, matching the behavior of {@link RunContext}'s property annotations.
+     */
+    private record RunContextData(
+        @JsonInclude
+        Map<String, Object> variables,
+        @JsonInclude
+        List<String> secretInputs,
+        @JsonInclude
+        String traceParent
+    ) {}
+}

--- a/core/src/test/java/io/kestra/core/runners/RunContextSerializerTest.java
+++ b/core/src/test/java/io/kestra/core/runners/RunContextSerializerTest.java
@@ -1,0 +1,81 @@
+package io.kestra.core.runners;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.kestra.core.context.TestRunContextFactory;
+import io.kestra.core.serializers.JacksonMapper;
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@MicronautTest
+class RunContextSerializerTest {
+
+    private static final Map<String, Object> TEST_VARIABLES = Map.of(
+        "envs", Map.of("KEY", "VALUE"),
+        "globals", Map.of("GLOBAL_KEY", "GLOBAL_VALUE"),
+        "addSecretConsumer", "consumer"
+    );
+
+    @Inject
+    private TestRunContextFactory runContextFactory;
+
+    @Test
+    void shouldSerializeWithoutEnvs() throws JsonProcessingException {
+        // Given
+        RunContext runContext = runContextFactory.of(TEST_VARIABLES);
+        runContext.setTraceParent("trace-parent-value");
+
+        ObjectMapper mapper = JacksonMapper.ofJson();
+
+        // When
+        String json = mapper.writeValueAsString(runContext);
+        Map<String, Object> deserialized = mapper.readValue(json, Map.class);
+
+        // Then
+        assertThat(deserialized).containsKey("variables");
+        Map<String, Object> variables = (Map<String, Object>) deserialized.get("variables");
+
+        // Verify that envs is filtered out
+        assertThat(variables).doesNotContainKey("envs");
+
+        // Verify that other keys are still present
+        assertThat(deserialized).containsKey("traceParent");
+
+        // Verify that globals, addSecretConsumer, and other keys are still present
+        assertThat(variables).containsKey("globals");
+        assertThat(variables).containsKey("addSecretConsumer");
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void shouldPreserveNullValuesInNestedVariablesMap() throws JsonProcessingException {
+        // Given - top-level variables map is an ImmutableMap (no nulls), but nested maps can contain nulls
+        HashMap<String, Object> inputs = new HashMap<>();
+        inputs.put("input1", "value1");
+        inputs.put("input2", null);
+
+        Map<String, Object> variables = Map.of(
+            "inputs", inputs,
+            "globals", Map.of("GLOBAL_KEY", "GLOBAL_VALUE")
+        );
+
+        RunContext runContext = runContextFactory.of(variables);
+        ObjectMapper mapper = JacksonMapper.ofJson();
+
+        // When
+        String json = mapper.writeValueAsString(runContext);
+        Map<String, Object> deserialized = mapper.readValue(json, Map.class);
+
+        // Then
+        Map<String, Object> deserializedVars = (Map<String, Object>) deserialized.get("variables");
+        Map<String, Object> deserializedInputs = (Map<String, Object>) deserializedVars.get("inputs");
+        assertThat(deserializedInputs).containsEntry("input1", "value1");
+        assertThat(deserializedInputs).containsEntry("input2", null);
+    }
+}


### PR DESCRIPTION
- add dedicated RunContextSerializer to filter env variables
- re-inject local `envs` variables when building RunContext for workers

Related-to: kestra-io/kestra-ee#6622