### PR TITLE
ci: add develocity buildScanUri to a tmp file

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -86,7 +86,7 @@ jobs:
     name: Backend - Tests
     needs: file-changes
     if: "needs.file-changes.outputs.backend == 'true'"
-    uses: kestra-io/actions/.github/workflows/kestra-oss-backend-tests.yml@main
+    uses: kestra-io/actions/.github/workflows/kestra-oss-backend-tests.yml@debug-report
     secrets:
       GITHUB_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -86,7 +86,7 @@ jobs:
     name: Backend - Tests
     needs: file-changes
     if: "needs.file-changes.outputs.backend == 'true'"
-    uses: kestra-io/actions/.github/workflows/kestra-oss-backend-tests.yml@debug-report
+    uses: kestra-io/actions/.github/workflows/kestra-oss-backend-tests.yml@main
     secrets:
       GITHUB_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/settings.gradle
+++ b/settings.gradle
@@ -10,6 +10,17 @@ develocity {
         publishing.onlyIf {
             it.authenticated
         }
+        buildScanPublished { scan ->
+            if (isCI) {
+                def payload = [
+                    timestamp: new Date().toString(),
+                    taskNames: gradle.startParameter.taskNames,
+                    buildScanId: scan.buildScanId,
+                    buildScanUri: scan.buildScanUri
+                ]
+                file("develocity-scan-output.ndjson") << groovy.json.JsonOutput.toJson(payload) + System.lineSeparator()
+            }
+        }
     }
 }
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -18,7 +18,8 @@ develocity {
                     buildScanId: scan.buildScanId,
                     buildScanUri: scan.buildScanUri
                 ]
-                file("develocity-scan-output.ndjson") << groovy.json.JsonOutput.toJson(payload) + System.lineSeparator()
+                def f = file("develocity-scan-output.ndjson") << groovy.json.JsonOutput.toJson(payload) + System.lineSeparator()
+                logger.warn("develocity-scan-output.ndjson path: ${f.getAbsolutePath()}")
             }
         }
     }

--- a/settings.gradle
+++ b/settings.gradle
@@ -16,10 +16,9 @@ develocity {
                     timestamp: new Date().toString(),
                     taskNames: gradle.startParameter.taskNames,
                     buildScanId: scan.buildScanId,
-                    buildScanUri: scan.buildScanUri
+                    buildScanUri: scan.buildScanUri.toString()
                 ]
-                def f = file("develocity-scan-output.ndjson") << groovy.json.JsonOutput.toJson(payload) + System.lineSeparator()
-                logger.warn("develocity-scan-output.ndjson path: ${f.getAbsolutePath()}")
+                file("develocity-scan-output.ndjson") << groovy.json.JsonOutput.toJson(payload) + System.lineSeparator()
             }
         }
     }


### PR DESCRIPTION
so we can use it later in CI to add it to the test report, and more
