### PR TITLE
chore(deps): remove private npm package

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -122,7 +122,6 @@
                 "@esbuild/darwin-x64": "^0.27.2",
                 "@esbuild/linux-x64": "^0.27.2",
                 "@rolldown/binding-darwin-arm64": "^1.0.0-rc.3",
-                "@rolldown/binding-darwin-universal": "^1.0.0-rc.3",
                 "@rolldown/binding-darwin-x64": "^1.0.0-rc.3",
                 "@rolldown/binding-linux-x64-gnu": "^1.0.0-rc.3",
                 "@rollup/rollup-darwin-arm64": "^4.57.1",

--- a/ui/package.json
+++ b/ui/package.json
@@ -136,7 +136,6 @@
         "@esbuild/darwin-x64": "^0.27.2",
         "@esbuild/linux-x64": "^0.27.2",
         "@rolldown/binding-darwin-arm64": "^1.0.0-rc.3",
-        "@rolldown/binding-darwin-universal": "^1.0.0-rc.3",
         "@rolldown/binding-darwin-x64": "^1.0.0-rc.3",
         "@rolldown/binding-linux-x64-gnu": "^1.0.0-rc.3",
         "@rollup/rollup-darwin-arm64": "^4.57.1",


### PR DESCRIPTION
Remove `@rolldown/binding-darwin-universal` as it is in a private registry.