### PR TITLE
fix(ui): disable AI copilot prompt input while generating

### DIFF
--- a/ui/src/components/ai/AiCopilot.vue
+++ b/ui/src/components/ai/AiCopilot.vue
@@ -35,6 +35,7 @@
                     v-if="configured"
                     v-model="prompt"
                     type="textarea"
+                    :disabled="waitingForReply"
                     :autosize="{minRows: 2, maxRows: 6}"
                     :placeholder="$t('ai.flow.prompt_placeholder')"
                     @keydown.exact.enter.prevent="submitPrompt"


### PR DESCRIPTION

### ✨ Description

This PR disables the AI Copilot prompt input field after the user submits a request. The input remains locked (`disabled`) until the generation process is complete and a response is received. This prevents users from editing the prompt while the AI is processing, avoiding potential confusion or state inconsistencies.

### 🔗 Related Issue

Closes #14497

### 🎨 Frontend Checklist

* [x] Code builds without errors (`npm run build`)
* [x] All existing E2E tests pass (`npm run test:e2e`)
* [x] Screenshots or video recordings attached showing the `UI` changes

Jam: https://jam.dev/c/fe5b744b-996a-4cda-afb6-9f83c23e41f8

