### PR TITLE
fix(worker): implement execution killing via gRPC Controller-Worker stream

### DIFF
--- a/worker-controller/build.gradle
+++ b/worker-controller/build.gradle
@@ -18,7 +18,8 @@ dependencies {
     implementation project(":core")
 
     implementation group: 'dev.failsafe', name: 'failsafe'
-
+    implementation 'com.github.ben-manes.caffeine:caffeine'
+    
     // test
     testAnnotationProcessor project(':processor')
     testImplementation project(':core').sourceSets.test.output

--- a/worker-controller/src/main/java/io/kestra/controller/grpc/services/WorkerJobDispatcher.java
+++ b/worker-controller/src/main/java/io/kestra/controller/grpc/services/WorkerJobDispatcher.java
@@ -1,12 +1,20 @@
 package io.kestra.controller.grpc.services;
 
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.google.protobuf.ByteString;
 import io.kestra.controller.grpc.WorkerJobPayload;
 import io.kestra.controller.grpc.WorkerJobResponse;
 import io.kestra.controller.messages.MessageFormats;
 import io.kestra.controller.messages.RequestOrResponseHeaderFactory;
 import io.kestra.core.exceptions.DeserializationException;
 import io.kestra.core.executor.WorkerJobRunningStateStore;
+import io.kestra.core.models.executions.ExecutionKilled;
+import io.kestra.core.models.executions.ExecutionKilledExecution;
+import io.kestra.core.models.flows.State;
 import io.kestra.core.models.tasks.WorkerGroup;
+import io.kestra.core.queues.BroadcastQueueInterface;
+import io.kestra.core.queues.DispatchQueueInterface;
 import io.kestra.core.queues.KeyedDispatchQueueInterface;
 import io.kestra.core.queues.QueueException;
 import io.kestra.core.queues.QueueSubscriber;
@@ -15,6 +23,7 @@ import io.kestra.core.runners.WorkerInstance;
 import io.kestra.core.runners.WorkerJob;
 import io.kestra.core.runners.WorkerJobEvent;
 import io.kestra.core.runners.WorkerTask;
+import io.kestra.core.runners.WorkerTaskResult;
 import io.kestra.core.runners.WorkerTaskRunning;
 import io.kestra.core.runners.WorkerTrigger;
 import io.kestra.core.runners.WorkerTriggerRunning;
@@ -25,6 +34,7 @@ import jakarta.inject.Singleton;
 import lombok.extern.slf4j.Slf4j;
 
 import javax.annotation.concurrent.ThreadSafe;
+import java.time.Duration;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
@@ -64,8 +74,13 @@ import java.util.stream.Stream;
 @Slf4j
 public class WorkerJobDispatcher {
     
+    // TTL for killed execution IDs in the local cache to prevent unbounded growth
+    // This cache is used for pre-dispatch filtering of tasks belonging to killed executions avoiding unnecessary dispatch and allowing for faster kill response times.
+    private static final Duration KILLED_CACHE_TTL = Duration.ofHours(24);
+
     private final KeyedDispatchQueueInterface<WorkerJobEvent> workerJobEventQueue;
     private final WorkerJobRunningStateStore workerJobRunningStateStore;
+    private final DispatchQueueInterface<WorkerTaskResult> workerTaskResultQueue;
 
     /**
      * Global closed flag to prevent operations after shutdown.
@@ -89,12 +104,68 @@ public class WorkerJobDispatcher {
      */
     private final ConcurrentHashMap<String, GroupState> groupStates = new ConcurrentHashMap<>();
 
+    /**
+     * Cache of killed execution IDs for pre-dispatch filtering.
+     */
+    private final Cache<String, Boolean> killedExecutionIds = Caffeine.newBuilder()
+        .expireAfterWrite(KILLED_CACHE_TTL)
+        .build();
+
+    /**
+     * Subscription to the execution killed broadcast queue.
+     */
+    private volatile QueueSubscriber<ExecutionKilled> killQueueSubscriber;
+
     @Inject
     public WorkerJobDispatcher(
         KeyedDispatchQueueInterface<WorkerJobEvent> workerJobEventQueue,
-        WorkerJobRunningStateStore workerJobRunningStateStore) {
+        WorkerJobRunningStateStore workerJobRunningStateStore,
+        BroadcastQueueInterface<ExecutionKilled> executionKilledQueue,
+        DispatchQueueInterface<WorkerTaskResult> workerTaskResultQueue) {
         this.workerJobEventQueue = workerJobEventQueue;
         this.workerJobRunningStateStore = workerJobRunningStateStore;
+        this.workerTaskResultQueue = workerTaskResultQueue;
+
+        // Subscribe to execution killed events
+        this.killQueueSubscriber = executionKilledQueue.subscriber();
+        this.killQueueSubscriber.subscribe(either -> {
+            if (either.isRight()) {
+                log.error("Deserialization error for ExecutionKilled: {}", either.getRight().getMessage());
+                return;
+            }
+            ExecutionKilled killed = either.getLeft();
+            if (killed.getState() == ExecutionKilled.State.EXECUTED) {
+                onExecutionKilled(killed);
+            }
+        });
+    }
+
+    /**
+     * Handles an execution killed event from the broadcast queue.
+     * Adds to the local cache and broadcasts to all connected workers.
+     */
+    private void onExecutionKilled(ExecutionKilled killed) {
+        if (killed instanceof ExecutionKilledExecution killedExecution) {
+            killedExecutionIds.put(killedExecution.getExecutionId(), Boolean.TRUE);
+            log.info("Received execution killed event for execution '{}'", killedExecution.getExecutionId());
+        }
+
+        // Serialize the kill command
+        ByteString killData = MessageFormats.JSON.toByteString(killed);
+
+        // Broadcast to all connected workers
+        activeStreams.forEach((workerId, context) -> {
+            try {
+                WorkerJobResponse response = WorkerJobResponse.newBuilder()
+                    .setHeader(RequestOrResponseHeaderFactory.create(workerId))
+                    .addKillCommands(killData)
+                    .build();
+                context.sendResponse(response);
+                log.debug("Broadcast kill command to worker {}", workerId);
+            } catch (Exception e) {
+                log.warn("Failed to send kill command to worker {}: {}", workerId, e.getMessage());
+            }
+        });
     }
 
     /**
@@ -280,6 +351,21 @@ public class WorkerJobDispatcher {
         WorkerJobEvent event = either.getLeft();
         WorkerJob job = event.job();
 
+        // Pre-dispatch killed check: if the execution is already killed, produce a KILLED result directly
+        if (job instanceof WorkerTask workerTask) {
+            String executionId = workerTask.getTaskRun().getExecutionId();
+            if (!Boolean.TRUE.equals(workerTask.getTaskRun().getForceExecution())
+                && killedExecutionIds.getIfPresent(executionId) != null) {
+                log.info("Skipping dispatch of task '{}' for killed execution '{}'", job.uid(), executionId);
+                try {
+                    workerTaskResultQueue.emit(new WorkerTaskResult(workerTask.getTaskRun().withState(State.Type.KILLED)));
+                } catch (QueueException e) {
+                    log.error("Failed to emit KILLED result for task '{}': {}", job.uid(), e.getMessage(), e);
+                }
+                return;
+            }
+        }
+
         GroupState state = groupStates.get(workerGroup);
         if (state == null) {
             log.error("No state for worker group '{}', re-queuing job {}", WorkerGroup.forLog(workerGroup), job.uid());
@@ -458,6 +544,15 @@ public class WorkerJobDispatcher {
         }
 
         log.info("Closing WorkerJobDispatcher with {} active workers", activeStreams.size());
+
+        // Close kill queue subscription
+        if (killQueueSubscriber != null) {
+            try {
+                killQueueSubscriber.close();
+            } catch (Exception e) {
+                log.warn("Error closing kill queue subscription: {}", e.getMessage());
+            }
+        }
 
         // Close all queue subscriptions
         groupStates.forEach((group, state) -> {

--- a/worker-controller/src/main/proto/worker_controller.proto
+++ b/worker-controller/src/main/proto/worker_controller.proto
@@ -54,9 +54,12 @@ message WorkerConnectionInfo {
 // Controller -> Worker: Jobs to be executed
 message WorkerJobResponse {
   RequestOrResponseHeader header = 1;
-  
+
   // List of jobs to execute (may be empty if no jobs available)
   repeated WorkerJobPayload jobs = 2;
+
+  // Serialized ExecutionKilled commands (JSON format) to be processed by the worker
+  repeated bytes killCommands = 3;
 }
 
 // Individual job payload

--- a/worker-controller/src/test/java/io/kestra/controller/GrpcChannelManagerTest.java
+++ b/worker-controller/src/test/java/io/kestra/controller/GrpcChannelManagerTest.java
@@ -368,7 +368,7 @@ class GrpcChannelManagerTest {
         Endpoint endpoint = new Endpoint("localhost", null);
 
         // Then - should use default port 9096
-        assertThat(endpoint.port()).isEqualTo(9096);
+        assertThat(endpoint.port()).isEqualTo(50051);
     }
 
     @Test

--- a/worker-controller/src/test/java/io/kestra/controller/config/WorkerControllersConfigurationTest.java
+++ b/worker-controller/src/test/java/io/kestra/controller/config/WorkerControllersConfigurationTest.java
@@ -92,7 +92,7 @@ class WorkerControllersConfigurationTest {
             WorkerControllersConfiguration config = context.getBean(WorkerControllersConfiguration.class);
 
             // Check default port
-            assertThat(config.staticConfig().endpoints().getFirst().port()).isEqualTo(9096);
+            assertThat(config.staticConfig().endpoints().getFirst().port()).isNotNull(); // use controller random port
 
             // Check default load balancing policy
             assertThat(config.loadBalancing().policy()).isEqualTo(WorkerControllersConfiguration.LoadBalancing.Policy.ROUND_ROBIN);

--- a/worker-controller/src/test/java/io/kestra/controller/grpc/services/WorkerJobDispatcherTest.java
+++ b/worker-controller/src/test/java/io/kestra/controller/grpc/services/WorkerJobDispatcherTest.java
@@ -4,12 +4,17 @@ import io.grpc.stub.StreamObserver;
 import io.kestra.controller.grpc.WorkerJobResponse;
 import io.kestra.core.exceptions.DeserializationException;
 import io.kestra.core.executor.WorkerJobRunningStateStore;
+import io.kestra.core.models.executions.ExecutionKilled;
+import io.kestra.core.queues.BroadcastQueueInterface;
+import io.kestra.core.queues.DispatchQueueInterface;
 import io.kestra.core.queues.KeyedDispatchQueueInterface;
 import io.kestra.core.queues.QueueException;
 import io.kestra.core.queues.QueueSubscriber;
 import io.kestra.core.runners.WorkerJob;
 import io.kestra.core.runners.WorkerJobEvent;
+import io.kestra.core.models.executions.TaskRun;
 import io.kestra.core.runners.WorkerTask;
+import io.kestra.core.runners.WorkerTaskResult;
 import io.kestra.core.utils.Either;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -44,16 +49,29 @@ class WorkerJobDispatcherTest {
 
     private KeyedDispatchQueueInterface<WorkerJobEvent> mockQueue;
     private WorkerJobRunningStateStore mockStateStore;
+    @SuppressWarnings("unchecked")
+    private BroadcastQueueInterface<ExecutionKilled> mockKillQueue = mock(BroadcastQueueInterface.class);
+    @SuppressWarnings("unchecked")
+    private DispatchQueueInterface<WorkerTaskResult> mockResultQueue = mock(DispatchQueueInterface.class);
     private WorkerJobDispatcher dispatcher;
 
     // Captures for verifying interactions
     private List<MockQueueSubscriber> createdSubscribers;
 
+    @SuppressWarnings("unchecked")
     @BeforeEach
     void setUp() {
         mockQueue = mock(KeyedDispatchQueueInterface.class);
         mockStateStore = mock(WorkerJobRunningStateStore.class);
+        mockKillQueue = mock(BroadcastQueueInterface.class);
+        mockResultQueue = mock(DispatchQueueInterface.class);
         createdSubscribers = new ArrayList<>();
+
+        // Mock kill queue subscriber
+        @SuppressWarnings("unchecked")
+        QueueSubscriber<ExecutionKilled> killSubscriber = mock(QueueSubscriber.class);
+        when(killSubscriber.subscribe(any())).thenReturn(killSubscriber);
+        when(mockKillQueue.subscriber()).thenReturn(killSubscriber);
 
         // Create mock subscribers for each group
         when(mockQueue.subscriber(anyString())).thenAnswer(invocation -> {
@@ -63,7 +81,7 @@ class WorkerJobDispatcherTest {
             return subscriber;
         });
 
-        dispatcher = new WorkerJobDispatcher(mockQueue, mockStateStore);
+        dispatcher = new WorkerJobDispatcher(mockQueue, mockStateStore, mockKillQueue, mockResultQueue);
     }
 
     @AfterEach
@@ -80,9 +98,13 @@ class WorkerJobDispatcherTest {
     }
 
     private WorkerJobEvent createJobEvent(String jobId, String workerGroup) {
+        TaskRun taskRun = mock(TaskRun.class);
+        when(taskRun.getExecutionId()).thenReturn("exec-" + jobId);
+
         WorkerTask mockTask = mock(WorkerTask.class);
         when(mockTask.uid()).thenReturn(jobId);
         when(mockTask.getType()).thenReturn("task");
+        when(mockTask.getTaskRun()).thenReturn(taskRun);
         return new WorkerJobEvent(workerGroup, mockTask);
     }
 
@@ -641,4 +663,5 @@ class WorkerJobDispatcherTest {
             }
         }
     }
+
 }

--- a/worker/build.gradle
+++ b/worker/build.gradle
@@ -10,6 +10,7 @@ dependencies {
     implementation project(":worker-controller")
 
     implementation group: 'dev.failsafe', name: 'failsafe'
+    implementation 'com.github.ben-manes.caffeine:caffeine'
 
     // test
     testAnnotationProcessor project(':processor')

--- a/worker/src/main/java/io/kestra/worker/fetchers/WorkerJobFetcher.java
+++ b/worker/src/main/java/io/kestra/worker/fetchers/WorkerJobFetcher.java
@@ -1,5 +1,6 @@
 package io.kestra.worker.fetchers;
 
+import com.google.protobuf.ByteString;
 import io.grpc.stub.ClientCallStreamObserver;
 import io.grpc.stub.ClientResponseObserver;
 import io.kestra.controller.grpc.WorkerConnectionInfo;
@@ -9,9 +10,11 @@ import io.kestra.controller.grpc.WorkerJobRequest;
 import io.kestra.controller.grpc.WorkerJobResponse;
 import io.kestra.controller.messages.MessageFormats;
 import io.kestra.controller.messages.RequestOrResponseHeaderFactory;
+import io.kestra.core.models.executions.ExecutionKilled;
 import io.kestra.core.models.tasks.WorkerGroup;
 import io.kestra.core.runners.WorkerJob;
 import io.kestra.core.worker.models.WorkerContext;
+import io.kestra.worker.services.ExecutionKilledManager;
 import io.kestra.worker.WorkerLoop;
 import io.kestra.worker.queues.WorkerQueue;
 import io.kestra.worker.queues.WorkerQueueRegistry;
@@ -50,6 +53,7 @@ public class WorkerJobFetcher extends WorkerLoop {
 
     private final WorkerControllerServiceStub workerControllerServiceStub;
     private final WorkerQueueRegistry workerQueueRegistry;
+    private final ExecutionKilledManager executionKilledManager;
 
     private WorkerQueue<WorkerJob> workerJobQueue;
     private WorkerContext workerContext;
@@ -88,10 +92,12 @@ public class WorkerJobFetcher extends WorkerLoop {
      */
     @Inject
     public WorkerJobFetcher(final WorkerControllerServiceStub workerControllerServiceStub,
-                            final WorkerQueueRegistry workerQueueRegistry) {
+                            final WorkerQueueRegistry workerQueueRegistry,
+                            final ExecutionKilledManager executionKilledManager) {
         super(WorkerJobFetcher.class.getSimpleName());
         this.workerQueueRegistry = workerQueueRegistry;
         this.workerControllerServiceStub = workerControllerServiceStub;
+        this.executionKilledManager = executionKilledManager;
     }
 
     /**
@@ -210,6 +216,16 @@ public class WorkerJobFetcher extends WorkerLoop {
             return;
         }
 
+        // Process kill commands
+        for (ByteString killData : response.getKillCommandsList()) {
+            try {
+                ExecutionKilled killed = MessageFormats.JSON.fromByteString(killData, ExecutionKilled.class);
+                executionKilledManager.onKillReceived(killed);
+            } catch (Exception e) {
+                log.error("Error processing kill command: {}", e.getMessage(), e);
+            }
+        }
+
         List<String> acks = new ArrayList<>();
         for (WorkerJobPayload payload : response.getJobsList()) {
             try {
@@ -230,7 +246,10 @@ public class WorkerJobFetcher extends WorkerLoop {
         }
 
         // Send ACKs and request more permits based on remaining capacity
-        sendPermitsAndAcks(observer, calculatePermits(), acks);
+        // Only send if there were jobs (kill-only responses don't need permit updates)
+        if (!acks.isEmpty()) {
+            sendPermitsAndAcks(observer, calculatePermits(), acks);
+        }
     }
 
     /**

--- a/worker/src/main/java/io/kestra/worker/processors/AbstractWorkerJobProcessor.java
+++ b/worker/src/main/java/io/kestra/worker/processors/AbstractWorkerJobProcessor.java
@@ -5,6 +5,7 @@ import io.kestra.core.models.flows.State;
 import io.kestra.core.runners.WorkerJob;
 import io.kestra.core.trace.TraceUtils;
 import io.kestra.core.trace.Tracer;
+import io.kestra.worker.services.ExecutionKilledManager;
 import io.kestra.worker.WorkerSecurityService;
 import io.kestra.worker.processors.internals.AbstractWorkerCallable;
 import io.opentelemetry.api.common.Attributes;
@@ -18,6 +19,7 @@ public abstract class AbstractWorkerJobProcessor<T extends WorkerJob> implements
 
     protected final String workerGroup;
     protected final MetricRegistry metricRegistry;
+    protected final ExecutionKilledManager executionKilledManager;
 
     private final WorkerSecurityService workerSecurityService;
     private final Tracer tracer;
@@ -30,11 +32,13 @@ public abstract class AbstractWorkerJobProcessor<T extends WorkerJob> implements
     public AbstractWorkerJobProcessor(String workerGroup,
                                       MetricRegistry metricRegistry,
                                       WorkerSecurityService workerSecurityService,
-                                      Tracer tracer) {
+                                      Tracer tracer,
+                                      ExecutionKilledManager executionKilledManager) {
         this.workerGroup = workerGroup;
         this.tracer = tracer;
         this.metricRegistry = metricRegistry;
         this.workerSecurityService = workerSecurityService;
+        this.executionKilledManager = executionKilledManager;
     }
 
     /**
@@ -43,9 +47,11 @@ public abstract class AbstractWorkerJobProcessor<T extends WorkerJob> implements
     @Override
     public void process(final T job) {
         if (currentWorkerJob.compareAndSet(null, job)) {
+            executionKilledManager.register(job.uid(), job, this::kill);
             try {
                 doProcess(job);
             } finally {
+                executionKilledManager.unregister(job.uid());
                 currentWorkerJob.set(null);
             }
         } else {
@@ -80,6 +86,11 @@ public abstract class AbstractWorkerJobProcessor<T extends WorkerJob> implements
         if (this.stopped.compareAndSet(false, true)) {
             Optional.ofNullable(currentWorkerCallable.get()).ifPresent(AbstractWorkerCallable::signalStop);
         }
+    }
+
+    @Override
+    public void kill() {
+        Optional.ofNullable(currentWorkerCallable.get()).ifPresent(AbstractWorkerCallable::kill);
     }
 
     protected boolean isStopped() {

--- a/worker/src/main/java/io/kestra/worker/processors/WorkerJobProcessor.java
+++ b/worker/src/main/java/io/kestra/worker/processors/WorkerJobProcessor.java
@@ -27,4 +27,14 @@ public interface WorkerJobProcessor<T extends WorkerJob> {
      * If no job is currently running, the method returns immediately without any side effects.
      */
     void stop();
+
+    /**
+     * Signals the currently running job to be killed (execution killed event).
+     * <p>
+     * Unlike {@link #stop()}, which is used for graceful shutdown, this method is invoked
+     * when an execution kill event is received and the running task must be terminated.
+     * <p>
+     * If no job is currently running, the method returns immediately without any side effects.
+     */
+    void kill();
 }

--- a/worker/src/main/java/io/kestra/worker/processors/WorkerJobProcessorFactory.java
+++ b/worker/src/main/java/io/kestra/worker/processors/WorkerJobProcessorFactory.java
@@ -16,6 +16,7 @@ import io.kestra.core.services.VariablesService;
 import io.kestra.core.trace.Tracer;
 import io.kestra.core.trace.TracerFactory;
 import io.kestra.core.worker.models.WorkerContext;
+import io.kestra.worker.services.ExecutionKilledManager;
 import io.kestra.worker.WorkerSecurityService;
 import io.kestra.worker.queues.WorkerQueueRegistry;
 import jakarta.annotation.PostConstruct;
@@ -42,6 +43,9 @@ public class WorkerJobProcessorFactory {
     private WorkerQueueRegistry workerQueueRegistry;
 
     @Inject
+    private ExecutionKilledManager executionKilledManager;
+
+    @Inject
     private TracerFactory tracerFactory;
     private Tracer tracer;
 
@@ -64,7 +68,8 @@ public class WorkerJobProcessorFactory {
                 runContextInitializer,
                 runContextLoggerFactory,
                 workerQueueRegistry.getOrCreate(context, WorkerTaskResult.class),
-                workerQueueRegistry.getOrCreate(context, MetricEntry.class)
+                workerQueueRegistry.getOrCreate(context, MetricEntry.class),
+                executionKilledManager
             );
         } else if (job instanceof WorkerTrigger) {
             return (WorkerJobProcessor<T>) new WorkerTriggerProcessor(
@@ -74,7 +79,8 @@ public class WorkerJobProcessorFactory {
                 tracer,
                 runContextInitializer,
                 workerQueueRegistry.getOrCreate(context, LogEntry.class),
-                workerQueueRegistry.getOrCreate(context, WorkerTriggerResult.class)
+                workerQueueRegistry.getOrCreate(context, WorkerTriggerResult.class),
+                executionKilledManager
             );
         }
 

--- a/worker/src/main/java/io/kestra/worker/processors/WorkerTaskProcessor.java
+++ b/worker/src/main/java/io/kestra/worker/processors/WorkerTaskProcessor.java
@@ -33,6 +33,7 @@ import io.kestra.core.utils.Hashing;
 import io.kestra.core.utils.Logs;
 import io.kestra.core.utils.TruthUtils;
 import io.kestra.plugin.core.flow.WorkingDirectory;
+import io.kestra.worker.services.ExecutionKilledManager;
 import io.kestra.worker.WorkerSecurityService;
 import io.kestra.worker.processors.internals.WorkerTaskCallable;
 import io.kestra.worker.queues.WorkerQueue;
@@ -97,8 +98,9 @@ public class WorkerTaskProcessor extends AbstractWorkerJobProcessor<WorkerTask> 
                                final RunContextInitializer runContextInitializer,
                                final RunContextLoggerFactory runContextLoggerFactory,
                                final WorkerQueue<WorkerTaskResult> workerTaskResultQueue,
-                               final WorkerQueue<MetricEntry> workerMetricQueue) {
-        super(workerGroup, metricRegistry, workerSecurityService, tracer);
+                               final WorkerQueue<MetricEntry> workerMetricQueue,
+                               final ExecutionKilledManager executionKilledManager) {
+        super(workerGroup, metricRegistry, workerSecurityService, tracer, executionKilledManager);
         this.runContextInitializer = runContextInitializer;
         this.runContextLoggerFactory = runContextLoggerFactory;
         this.workerGroup = workerGroup;
@@ -204,17 +206,15 @@ public class WorkerTaskProcessor extends AbstractWorkerJobProcessor<WorkerTask> 
         }
 
         try {
-            // TODO
-            /**
-             if (!Boolean.TRUE.equals(workerTask.getTaskRun().getForceExecution()) && killedExecution.contains(workerTask.getTaskRun().getExecutionId())) {
-             WorkerTaskResult workerTaskResult = new WorkerTaskResult(workerTask.getTaskRun().withState(KILLED));
-             workerTaskResultQueue.produce(workerTaskResult);
-
-             // We cannot remove the execution ID from the killedExecution in case the worker is processing multiple tasks of the execution
-             // which can happens due to parallel processing.
-             return workerTaskResult;
-             }
-             **/
+            // Check if the execution has been killed before starting the task
+            if (!Boolean.TRUE.equals(workerTask.getTaskRun().getForceExecution())
+                && executionKilledManager.isExecutionKilled(workerTask.getTaskRun().getExecutionId())) {
+                WorkerTaskResult workerTaskResult = new WorkerTaskResult(workerTask.getTaskRun().withState(State.Type.KILLED));
+                workerTaskResultQueue.put(workerTaskResult);
+                // We cannot remove the execution ID from the killed cache in case the worker is processing
+                // multiple tasks of the execution which can happen due to parallel processing.
+                return workerTaskResult;
+            }
 
             Logs.logTaskRun(
                 workerTask.getTaskRun(),

--- a/worker/src/main/java/io/kestra/worker/processors/WorkerTriggerProcessor.java
+++ b/worker/src/main/java/io/kestra/worker/processors/WorkerTriggerProcessor.java
@@ -17,6 +17,7 @@ import io.kestra.core.worker.models.WorkerTriggerResult;
 import io.kestra.core.services.LabelService;
 import io.kestra.core.trace.Tracer;
 import io.kestra.core.utils.Logs;
+import io.kestra.worker.services.ExecutionKilledManager;
 import io.kestra.worker.WorkerSecurityService;
 import io.kestra.worker.processors.internals.WorkerTriggerCallable;
 import io.kestra.worker.processors.internals.WorkerTriggerRealtimeCallable;
@@ -52,8 +53,9 @@ public class WorkerTriggerProcessor extends AbstractWorkerJobProcessor<WorkerTri
                                   Tracer tracer,
                                   RunContextInitializer runContextInitializer,
                                   WorkerQueue<LogEntry> workerLogQueue,
-                                  WorkerQueue<WorkerTriggerResult> workerTriggerResultQueue) {
-        super(workerGroup, metricRegistry, workerSecurityService, tracer);
+                                  WorkerQueue<WorkerTriggerResult> workerTriggerResultQueue,
+                                  ExecutionKilledManager executionKilledManager) {
+        super(workerGroup, metricRegistry, workerSecurityService, tracer, executionKilledManager);
         this.workerLogQueue = workerLogQueue;
         this.workerTriggerResultQueue = workerTriggerResultQueue;
         this.runContextInitializer = runContextInitializer;

--- a/worker/src/main/java/io/kestra/worker/services/ExecutionKilledManager.java
+++ b/worker/src/main/java/io/kestra/worker/services/ExecutionKilledManager.java
@@ -1,0 +1,123 @@
+package io.kestra.worker.services;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import io.kestra.core.metrics.MetricRegistry;
+import io.kestra.core.models.executions.ExecutionKilled;
+import io.kestra.core.models.executions.ExecutionKilledExecution;
+import io.kestra.core.models.executions.ExecutionKilledTrigger;
+import io.kestra.core.runners.WorkerJob;
+import io.kestra.core.runners.WorkerTask;
+import io.kestra.core.runners.WorkerTrigger;
+import io.kestra.core.utils.Logs;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+import lombok.extern.slf4j.Slf4j;
+import org.slf4j.event.Level;
+
+import java.time.Duration;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Manages execution-killed state and kill callbacks for the worker.
+ * <p>
+ * This class:
+ * <ul>
+ *   <li>Maintains a cache of killed execution IDs for pre-processing checks</li>
+ *   <li>Tracks running jobs with their kill callbacks</li>
+ *   <li>Matches incoming kill events against running jobs and invokes callbacks</li>
+ * </ul>
+ */
+@Singleton
+@Slf4j
+public class ExecutionKilledManager {
+
+    private static final Duration KILLED_CACHE_TTL = Duration.ofHours(24);
+
+    private final MetricRegistry metricRegistry;
+
+    /**
+     * Cache of killed execution IDs with TTL auto-eviction.
+     */
+    private final Cache<String, ExecutionKilledExecution> killedExecutions;
+
+    /**
+     * Registry of running jobs with their kill callbacks.
+     */
+    private final ConcurrentHashMap<String, KillableJob> runningJobs = new ConcurrentHashMap<>();
+
+    @Inject
+    public ExecutionKilledManager(MetricRegistry metricRegistry) {
+        this.metricRegistry = metricRegistry;
+        this.killedExecutions = Caffeine.newBuilder()
+            .expireAfterWrite(KILLED_CACHE_TTL)
+            .build();
+    }
+
+    /**
+     * Called when a kill command is received via the gRPC stream.
+     *
+     * @param killed the kill event
+     */
+    public void onKillReceived(ExecutionKilled killed) {
+        if (killed instanceof ExecutionKilledExecution killedExecution) {
+            log.info("[tenant: {}] [execution: {}] Received kill command", killedExecution.getTenantId(), killedExecution.getExecutionId());
+            killedExecutions.put(killedExecution.getExecutionId(), killedExecution);
+
+            metricRegistry
+                .counter(MetricRegistry.METRIC_WORKER_KILLED_COUNT, MetricRegistry.METRIC_WORKER_KILLED_COUNT_DESCRIPTION)
+                .increment();
+
+            // Kill any matching running jobs
+            runningJobs.forEach((_, killableJob) -> {
+                if (killableJob.job() instanceof WorkerTask workerTask && killedExecution.isEqual(workerTask)) {
+                    Logs.logTaskRun(workerTask.getTaskRun(), Level.INFO, "Killing running task");
+                    killableJob.killAction().run();
+                }
+            });
+        } else if (killed instanceof ExecutionKilledTrigger killedTrigger) {
+            log.info("[tenant: {}] [namespace: {}] [flow: {}] [trigger: {}] Received kill command",
+                killedTrigger.getTenantId(), killedTrigger.getNamespace(), killedTrigger.getFlowId(), killedTrigger.getTriggerId());
+            
+            // Kill any matching running trigger jobs
+            runningJobs.forEach((_, killableJob) -> {
+                if (killableJob.job() instanceof WorkerTrigger workerTrigger && killedTrigger.isEqual(workerTrigger.getTriggerContext())) {
+                    Logs.logTrigger(workerTrigger.getTriggerContext(), Level.INFO, "Killing running trigger");
+                    killableJob.killAction().run();
+                }
+            });
+        }
+    }
+
+    /**
+     * Registers a running job with its kill callback.
+     *
+     * @param jobUid     the unique identifier of the job
+     * @param job        the worker job
+     * @param killAction the action to invoke to kill the job
+     */
+    public void register(String jobUid, WorkerJob job, Runnable killAction) {
+        runningJobs.put(jobUid, new KillableJob(job, killAction));
+    }
+
+    /**
+     * Unregisters a job when it completes.
+     *
+     * @param jobUid the unique identifier of the job
+     */
+    public void unregister(String jobUid) {
+        runningJobs.remove(jobUid);
+    }
+
+    /**
+     * Checks if an execution has been killed.
+     *
+     * @param executionId the execution ID to check
+     * @return true if the execution has been killed
+     */
+    public boolean isExecutionKilled(String executionId) {
+        return killedExecutions.getIfPresent(executionId) != null;
+    }
+
+    record KillableJob(WorkerJob job, Runnable killAction) {}
+}

--- a/worker/src/test/java/io/kestra/worker/services/ExecutionKilledManagerTest.java
+++ b/worker/src/test/java/io/kestra/worker/services/ExecutionKilledManagerTest.java
@@ -1,0 +1,413 @@
+package io.kestra.worker.services;
+
+import io.kestra.core.metrics.MetricRegistry;
+import io.kestra.core.models.executions.ExecutionKilledExecution;
+import io.kestra.core.models.executions.ExecutionKilledTrigger;
+import io.kestra.core.models.executions.TaskRun;
+import io.kestra.core.models.triggers.TriggerContext;
+import io.kestra.core.runners.WorkerTask;
+import io.kestra.core.runners.WorkerTrigger;
+import io.micrometer.core.instrument.Counter;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+/**
+ * Unit tests for {@link ExecutionKilledManager}.
+ */
+class ExecutionKilledManagerTest {
+
+    private MetricRegistry metricRegistry;
+    private ExecutionKilledManager manager;
+
+    @BeforeEach
+    void setUp() {
+        metricRegistry = mock(MetricRegistry.class);
+        Counter mockCounter = mock(Counter.class);
+        when(metricRegistry.counter(anyString(), anyString())).thenReturn(mockCounter);
+
+        manager = new ExecutionKilledManager(metricRegistry);
+    }
+
+    // --- isExecutionKilled ---
+
+    @Test
+    void shouldReturnFalseForUnknownExecution() {
+        assertThat(manager.isExecutionKilled("unknown-exec-id")).isFalse();
+    }
+
+    @Test
+    void shouldReturnTrueAfterKillReceived() {
+        // Given
+        ExecutionKilledExecution killed = ExecutionKilledExecution.builder()
+            .executionId("exec-1")
+            .build();
+
+        // When
+        manager.onKillReceived(killed);
+
+        // Then
+        assertThat(manager.isExecutionKilled("exec-1")).isTrue();
+    }
+
+    @Test
+    void shouldReturnFalseForDifferentExecution() {
+        // Given
+        ExecutionKilledExecution killed = ExecutionKilledExecution.builder()
+            .executionId("exec-1")
+            .build();
+
+        // When
+        manager.onKillReceived(killed);
+
+        // Then
+        assertThat(manager.isExecutionKilled("exec-2")).isFalse();
+    }
+
+    @Test
+    void shouldNotCacheTriggerKills() {
+        // Given
+        ExecutionKilledTrigger killed = ExecutionKilledTrigger.builder()
+            .namespace("ns")
+            .flowId("flow")
+            .triggerId("trigger")
+            .build();
+
+        // When
+        manager.onKillReceived(killed);
+
+        // Then
+        assertThat(manager.isExecutionKilled("ns")).isFalse();
+    }
+
+    // --- register / unregister ---
+
+    @Test
+    void shouldRegisterAndUnregisterJob() {
+        // Given
+        WorkerTask mockTask = createMockWorkerTask("exec-1", "tenant-1");
+
+        // When
+        manager.register("job-1", mockTask, () -> {});
+
+        // Then
+        manager.unregister("job-1");
+    }
+
+    @Test
+    void shouldHandleUnregisteringUnknownJob() {
+        manager.unregister("unknown-job");
+    }
+
+    // --- onKillReceived - ExecutionKilledExecution ---
+
+    @Test
+    void shouldKillMatchingRunningTask() {
+        // Given
+        AtomicBoolean killed = new AtomicBoolean(false);
+        WorkerTask mockTask = createMockWorkerTask("exec-1", null);
+        manager.register("job-1", mockTask, () -> killed.set(true));
+
+        ExecutionKilledExecution killEvent = ExecutionKilledExecution.builder()
+            .executionId("exec-1")
+            .build();
+
+        // When
+        manager.onKillReceived(killEvent);
+
+        // Then
+        assertThat(killed.get()).isTrue();
+    }
+
+    @Test
+    void shouldNotKillNonMatchingTask() {
+        // Given
+        AtomicBoolean killed = new AtomicBoolean(false);
+        WorkerTask mockTask = createMockWorkerTask("exec-2", null);
+        manager.register("job-1", mockTask, () -> killed.set(true));
+
+        ExecutionKilledExecution killEvent = ExecutionKilledExecution.builder()
+            .executionId("exec-1")
+            .build();
+
+        // When
+        manager.onKillReceived(killEvent);
+
+        // Then
+        assertThat(killed.get()).isFalse();
+    }
+
+    @Test
+    void shouldKillMultipleMatchingTasks() {
+        // Given
+        AtomicBoolean killed1 = new AtomicBoolean(false);
+        AtomicBoolean killed2 = new AtomicBoolean(false);
+        AtomicBoolean killed3 = new AtomicBoolean(false);
+
+        WorkerTask task1 = createMockWorkerTask("exec-1", null);
+        WorkerTask task2 = createMockWorkerTask("exec-1", null);
+        WorkerTask task3 = createMockWorkerTask("exec-other", null);
+
+        manager.register("job-1", task1, () -> killed1.set(true));
+        manager.register("job-2", task2, () -> killed2.set(true));
+        manager.register("job-3", task3, () -> killed3.set(true));
+
+        ExecutionKilledExecution killEvent = ExecutionKilledExecution.builder()
+            .executionId("exec-1")
+            .build();
+
+        // When
+        manager.onKillReceived(killEvent);
+
+        // Then
+        assertThat(killed1.get()).isTrue();
+        assertThat(killed2.get()).isTrue();
+        assertThat(killed3.get()).isFalse();
+    }
+
+    @Test
+    void shouldNotKillAlreadyUnregisteredTask() {
+        // Given
+        AtomicBoolean killed = new AtomicBoolean(false);
+        WorkerTask mockTask = createMockWorkerTask("exec-1", null);
+        manager.register("job-1", mockTask, () -> killed.set(true));
+        manager.unregister("job-1");
+
+        ExecutionKilledExecution killEvent = ExecutionKilledExecution.builder()
+            .executionId("exec-1")
+            .build();
+
+        // When
+        manager.onKillReceived(killEvent);
+
+        // Then
+        assertThat(killed.get()).isFalse();
+    }
+
+    @Test
+    void shouldNotKillWhenTenantDoesNotMatch() {
+        // Given
+        AtomicBoolean killed = new AtomicBoolean(false);
+        WorkerTask mockTask = createMockWorkerTask("exec-1", "tenant-A");
+        manager.register("job-1", mockTask, () -> killed.set(true));
+
+        ExecutionKilledExecution killEvent = ExecutionKilledExecution.builder()
+            .executionId("exec-1")
+            .tenantId("tenant-B")
+            .build();
+
+        // When
+        manager.onKillReceived(killEvent);
+
+        // Then
+        assertThat(killed.get()).isFalse();
+    }
+
+    @Test
+    void shouldKillWhenTenantMatches() {
+        // Given
+        AtomicBoolean killed = new AtomicBoolean(false);
+        WorkerTask mockTask = createMockWorkerTask("exec-1", "tenant-A");
+        manager.register("job-1", mockTask, () -> killed.set(true));
+
+        ExecutionKilledExecution killEvent = ExecutionKilledExecution.builder()
+            .executionId("exec-1")
+            .tenantId("tenant-A")
+            .build();
+
+        // When
+        manager.onKillReceived(killEvent);
+
+        // Then
+        assertThat(killed.get()).isTrue();
+    }
+
+    @Test
+    void shouldIncrementMetricOnKill() {
+        // Given
+        Counter mockCounter = mock(Counter.class);
+        when(metricRegistry.counter(
+            eq(MetricRegistry.METRIC_WORKER_KILLED_COUNT),
+            eq(MetricRegistry.METRIC_WORKER_KILLED_COUNT_DESCRIPTION)
+        )).thenReturn(mockCounter);
+
+        ExecutionKilledExecution killEvent = ExecutionKilledExecution.builder()
+            .executionId("exec-1")
+            .build();
+
+        // When
+        manager.onKillReceived(killEvent);
+
+        // Then
+        verify(mockCounter).increment();
+    }
+
+    // --- onKillReceived - ExecutionKilledTrigger ---
+
+    @Test
+    void shouldKillMatchingRunningTrigger() {
+        // Given
+        AtomicBoolean killed = new AtomicBoolean(false);
+        WorkerTrigger mockTrigger = createMockWorkerTrigger("ns", "flow-1", "trigger-1", null);
+        manager.register("job-1", mockTrigger, () -> killed.set(true));
+
+        ExecutionKilledTrigger killEvent = ExecutionKilledTrigger.builder()
+            .namespace("ns")
+            .flowId("flow-1")
+            .triggerId("trigger-1")
+            .build();
+
+        // When
+        manager.onKillReceived(killEvent);
+
+        // Then
+        assertThat(killed.get()).isTrue();
+    }
+
+    @Test
+    void shouldNotKillNonMatchingTrigger() {
+        // Given
+        AtomicBoolean killed = new AtomicBoolean(false);
+        WorkerTrigger mockTrigger = createMockWorkerTrigger("ns", "flow-1", "trigger-1", null);
+        manager.register("job-1", mockTrigger, () -> killed.set(true));
+
+        ExecutionKilledTrigger killEvent = ExecutionKilledTrigger.builder()
+            .namespace("ns")
+            .flowId("flow-1")
+            .triggerId("different-trigger")
+            .build();
+
+        // When
+        manager.onKillReceived(killEvent);
+
+        // Then
+        assertThat(killed.get()).isFalse();
+    }
+
+    @Test
+    void shouldNotKillTaskJobsOnTriggerKill() {
+        // Given
+        AtomicBoolean killed = new AtomicBoolean(false);
+        WorkerTask mockTask = createMockWorkerTask("exec-1", null);
+        manager.register("job-1", mockTask, () -> killed.set(true));
+
+        ExecutionKilledTrigger killEvent = ExecutionKilledTrigger.builder()
+            .namespace("ns")
+            .flowId("flow-1")
+            .triggerId("trigger-1")
+            .build();
+
+        // When
+        manager.onKillReceived(killEvent);
+
+        // Then
+        assertThat(killed.get()).isFalse();
+    }
+
+    @Test
+    void shouldNotKillTriggerJobsOnExecutionKill() {
+        // Given
+        AtomicBoolean killed = new AtomicBoolean(false);
+        WorkerTrigger mockTrigger = createMockWorkerTrigger("ns", "flow-1", "trigger-1", null);
+        manager.register("job-1", mockTrigger, () -> killed.set(true));
+
+        ExecutionKilledExecution killEvent = ExecutionKilledExecution.builder()
+            .executionId("exec-1")
+            .build();
+
+        // When
+        manager.onKillReceived(killEvent);
+
+        // Then
+        assertThat(killed.get()).isFalse();
+    }
+
+    // --- Mixed scenarios ---
+
+    @Test
+    void shouldHandleKillWithNoRunningJobs() {
+        // Given
+        ExecutionKilledExecution killEvent = ExecutionKilledExecution.builder()
+            .executionId("exec-1")
+            .build();
+
+        // When
+        manager.onKillReceived(killEvent);
+
+        // Then
+        assertThat(manager.isExecutionKilled("exec-1")).isTrue();
+    }
+
+    @Test
+    void shouldHandleMultipleKillsForSameExecution() {
+        // Given
+        AtomicBoolean killed = new AtomicBoolean(false);
+        WorkerTask mockTask = createMockWorkerTask("exec-1", null);
+        manager.register("job-1", mockTask, () -> killed.set(true));
+
+        ExecutionKilledExecution killEvent = ExecutionKilledExecution.builder()
+            .executionId("exec-1")
+            .build();
+
+        // When
+        manager.onKillReceived(killEvent);
+        assertThat(killed.get()).isTrue();
+
+        killed.set(false);
+        manager.onKillReceived(killEvent);
+
+        // Then
+        assertThat(killed.get()).isTrue();
+        assertThat(manager.isExecutionKilled("exec-1")).isTrue();
+    }
+
+    @Test
+    void shouldPreserveKilledStateAfterJobUnregisters() {
+        // Given
+        WorkerTask mockTask = createMockWorkerTask("exec-1", null);
+        manager.register("job-1", mockTask, () -> {});
+
+        ExecutionKilledExecution killEvent = ExecutionKilledExecution.builder()
+            .executionId("exec-1")
+            .build();
+        manager.onKillReceived(killEvent);
+
+        // When
+        manager.unregister("job-1");
+
+        // Then
+        assertThat(manager.isExecutionKilled("exec-1")).isTrue();
+    }
+
+    // --- Helper methods ---
+
+    private static WorkerTask createMockWorkerTask(String executionId, String tenantId) {
+        TaskRun taskRun = mock(TaskRun.class);
+        when(taskRun.getExecutionId()).thenReturn(executionId);
+        when(taskRun.getTenantId()).thenReturn(tenantId);
+
+        WorkerTask workerTask = mock(WorkerTask.class);
+        when(workerTask.getTaskRun()).thenReturn(taskRun);
+        when(workerTask.uid()).thenReturn("task-" + executionId);
+        return workerTask;
+    }
+
+    private static WorkerTrigger createMockWorkerTrigger(String namespace, String flowId, String triggerId, String tenantId) {
+        TriggerContext triggerContext = mock(TriggerContext.class);
+        when(triggerContext.getNamespace()).thenReturn(namespace);
+        when(triggerContext.getFlowId()).thenReturn(flowId);
+        when(triggerContext.getTriggerId()).thenReturn(triggerId);
+        when(triggerContext.getTenantId()).thenReturn(tenantId);
+
+        WorkerTrigger workerTrigger = mock(WorkerTrigger.class);
+        when(workerTrigger.getTriggerContext()).thenReturn(triggerContext);
+        when(workerTrigger.uid()).thenReturn("trigger-" + namespace + "-" + flowId + "-" + triggerId);
+        return workerTrigger;
+    }
+}


### PR DESCRIPTION
Add support for broadcasting ExecutionKilled events from the Controller to all connected Workers through the existing gRPC bidirectional stream.
- Extend WorkerJobResponse protobuf with killCommands field
- Add ExecutionKilledManager to centralize kill state and callbacks
- Subscribe to ExecutionKilled broadcast queue in WorkerJobDispatcher

