### PR TITLE
chore(deps): ignore @eslint/js major updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -109,8 +109,12 @@ updates:
           ]
 
     ignore:
-      # Ignore ESLint major updates (eslint@10 currently conflicts with typescript-eslint + eslint-plugin-vue)
+      # Ignore eslint major updates (eslint@10 currently conflicts with typescript-eslint + eslint-plugin-vue)
       - dependency-name: "eslint"
+        update-types: ["version-update:semver-major"]
+
+      # Ignore @eslint/js major updates (v10 requires eslint ^10 but project is on eslint ^9)
+      - dependency-name: "@eslint/js"
         update-types: ["version-update:semver-major"]
 
       # Ignore vue-router major updates (v5 conflicts with @kestra-io/ui-libs peer requirement ^4.5.0)


### PR DESCRIPTION
`v10` requires `eslint ^10` but project uses `eslint ^9`.