### PR TITLE
chore(analytics): revert app property flatten in posthog

### DIFF
--- a/ui/src/composables/usePosthog.ts
+++ b/ui/src/composables/usePosthog.ts
@@ -28,8 +28,10 @@ function statsGlobalData(config: Config, uid: string): any {
         from: "APP",
         iid: config.uuid,
         uid: uid,
-        app_version: config.version,
-        app_type: config.edition
+        app: {
+            version: config.version,
+            type: config.edition
+        }
     }
 }
 


### PR DESCRIPTION
for backward compatibility of metrics
Flattening happens in PostHog transformation instead
