### PR TITLE
feat: plugin-filter-kestra-core

### DIFF
--- a/ui/src/components/plugins/PluginHome.vue
+++ b/ui/src/components/plugins/PluginHome.vue
@@ -10,7 +10,7 @@
             <KSFilter
                 :configuration="pluginFilter"
                 :buttons="{
-                    savedFilters: {shown: false}, 
+                    savedFilters: {shown: false},
                     tableOptions: {shown: false}
                 }"
                 :searchInputFullWidth="true"
@@ -65,6 +65,7 @@
     import {ref, computed, onBeforeMount, watch} from "vue";
     import {useRoute, useRouter} from "vue-router";
     import {isEntryAPluginElementPredicate, TaskIcon} from "@kestra-io/ui-libs";
+    import {isPluginMatched} from "../../utils/pluginUtils";
     import DottedLayout from "../layout/DottedLayout.vue";
     import KSFilter from "../filter/components/KSFilter.vue";
     import {usePluginFilter} from "../filter/configurations";
@@ -76,7 +77,7 @@
     const route = useRoute();
     const router = useRouter();
     const pluginsStore = usePluginsStore();
-    
+
     const pluginFilter = usePluginFilter();
 
     const props = withDefaults(defineProps<{
@@ -123,10 +124,7 @@
             .filter((plugin, index, self) =>
                 index === self.findIndex(t => t.title === plugin.title && t.group === plugin.group)
             )
-            .filter(plugin =>
-                plugin.title.toLowerCase().includes(searchInput.value) ||
-                allElements(plugin).some(e => e.toLowerCase().includes(searchInput.value))
-            )
+            .filter(plugin => isPluginMatched(plugin, searchInput.value))
             .filter(plugin => isVisible(plugin))
             .sort((a, b) => {
                 const nameA = a.manifest["X-Kestra-Title"].toLowerCase();
@@ -247,3 +245,4 @@
         width: 2em;
     }
 </style>
+

--- a/ui/src/components/plugins/PluginList.vue
+++ b/ui/src/components/plugins/PluginList.vue
@@ -73,6 +73,7 @@
 <script setup lang="ts">
     import {ref, computed, onMounted, watch} from "vue";
     import {TaskIcon, isEntryAPluginElementPredicate} from "@kestra-io/ui-libs";
+    import {isPluginMatched} from "../../utils/pluginUtils";
     import ChevronRight from "vue-material-design-icons/ChevronRight.vue";
     import ChevronLeft from "vue-material-design-icons/ChevronLeft.vue";
     import PluginUnified from "./PluginUnified.vue";
@@ -173,16 +174,7 @@
 
     const sortedPlugins = computed(() => {
         if (!searchQuery.value) return basePlugins.value;
-        const query = searchQuery.value.toLowerCase();
-        return basePlugins.value.filter(plugin =>
-            (getPluginDisplayName(plugin) ?? "").toLowerCase().includes(query) ||
-            (plugin.title ?? "").toLowerCase().includes(query) ||
-            getPluginElements(plugin).some(element => element.toLowerCase().includes(query)) ||
-            (plugin.name ?? "").toLowerCase().includes(query) ||
-            (plugin.group ?? "").toLowerCase().includes(query) ||
-            (plugin.artifactId ?? "").toLowerCase().includes(query) ||
-            (plugin.manifest?.["X-Kestra-Title"] ?? "").toLowerCase().includes(query)
-        );
+        return basePlugins.value.filter(plugin => isPluginMatched(plugin, searchQuery.value));
     });
 
     const loadPluginIcons = async () => {

--- a/ui/src/components/plugins/PluginList.vue
+++ b/ui/src/components/plugins/PluginList.vue
@@ -177,7 +177,11 @@
         return basePlugins.value.filter(plugin =>
             (getPluginDisplayName(plugin) ?? "").toLowerCase().includes(query) ||
             (plugin.title ?? "").toLowerCase().includes(query) ||
-            getPluginElements(plugin).some(element => element.toLowerCase().includes(query))
+            getPluginElements(plugin).some(element => element.toLowerCase().includes(query)) ||
+            (plugin.name ?? "").toLowerCase().includes(query) ||
+            (plugin.group ?? "").toLowerCase().includes(query) ||
+            (plugin.artifactId ?? "").toLowerCase().includes(query) ||
+            (plugin.manifest?.["X-Kestra-Title"] ?? "").toLowerCase().includes(query)
         );
     });
 

--- a/ui/src/components/plugins/Toc.vue
+++ b/ui/src/components/plugins/Toc.vue
@@ -13,7 +13,7 @@
                     :name="plugin.group"
                     :title="plugin.title?.capitalize()"
                     :key="plugin.group"
-                    :ref="(el: any) => pluginRefs[plugin.group] = el"                
+                    :ref="(el: any) => pluginRefs[plugin.group] = el"
                 >
                     <ul class="toc-h3">
                         <li v-for="(types, namespace) in group(plugin)" :key="namespace">
@@ -191,17 +191,17 @@
     .plugins-list {
         display: flex;
         flex-direction: column;
-        
+
         .search {
             flex-shrink: 0;
             background-color: var(--ks-background-panel);
             padding-bottom: 0.5rem;
         }
-        
+
         .el-collapse {
             flex: 1;
         }
-        
+
         &.enhance-readability {
             padding: 1.5rem;
             background-color: var(--bs-gray-100);
@@ -255,7 +255,7 @@
     .selected {
         color: var(--ks-content-link);
     }
-    
+
     @media (max-width: 991px) {
         .plugins-list {
             .search {
@@ -263,7 +263,7 @@
                 top: 0;
                 z-index: 10;
             }
-            
+
             .el-collapse {
                 overflow-y: auto;
             }

--- a/ui/src/utils/pluginUtils.ts
+++ b/ui/src/utils/pluginUtils.ts
@@ -1,6 +1,20 @@
+import {extractPluginElements, type Plugin} from "@kestra-io/ui-libs";
+
+export function isPluginMatched(plugin: Plugin, search: string): boolean {
+    if (!search) return true;
+    const q = search.toLowerCase();
+    return [
+        plugin.title,
+        plugin.name,
+        plugin.group,
+        plugin.manifest?.["X-Kestra-Title"],
+    ].some(field => field?.toLowerCase().includes(q)) ||
+        Object.values(extractPluginElements(plugin)).flat().some(cls => cls.toLowerCase().includes(q));
+}
+
 export const getPluginReleaseUrl = (pluginClass?: string): string | null => {
     const [, , groupId, pluginType] = pluginClass?.split(".") ?? [];
-    
+
     if (!pluginType || pluginType === "ee" || pluginType === "secret") {
         return null;
     }
@@ -12,3 +26,4 @@ export const getPluginReleaseUrl = (pluginClass?: string): string | null => {
     const repoPrefix = groupId === "storage" ? "storage" : "plugin";
     return `https://github.com/kestra-io/${repoPrefix}-${pluginType}/releases`;
 };
+


### PR DESCRIPTION
closes: #10408

---

### ✨ Description

What does this PR change?  

**Fix:**
Extended plugin filtering logic in:

- PluginHome.vue
- PluginList.vue
- Toc.vue

Search now also includes:

- artifactId
- manifest["X-Kestra-Title"]

This ensures that core plugins like plugin-kestra are properly matched.