### PR TITLE
fix(logs): redesign logs indexes and use single-query fetchPage on MySQL

### DIFF
--- a/jdbc-h2/src/main/resources/migrations/h2/V1_54__logs_indexes.sql
+++ b/jdbc-h2/src/main/resources/migrations/h2/V1_54__logs_indexes.sql
@@ -1,0 +1,3 @@
+DROP INDEX IF EXISTS logs_namespace_flow;
+CREATE INDEX IF NOT EXISTS logs_tenant_timestamp ON logs ("tenant_id", "timestamp", "level");
+CREATE INDEX IF NOT EXISTS logs_tenant_namespace_timestamp ON logs ("tenant_id", "namespace", "timestamp", "level");

--- a/jdbc-mysql/src/main/resources/migrations/mysql/V1_55__logs_indexes.sql
+++ b/jdbc-mysql/src/main/resources/migrations/mysql/V1_55__logs_indexes.sql
@@ -1,0 +1,3 @@
+ALTER TABLE logs DROP INDEX ix_namespace_flow;
+ALTER TABLE logs ADD INDEX ix_tenant_timestamp (`tenant_id`, `timestamp`, `level`), ALGORITHM=INPLACE, LOCK=NONE;
+ALTER TABLE logs ADD INDEX ix_tenant_namespace_timestamp (`tenant_id`, `namespace`, `timestamp`, `level`), ALGORITHM=INPLACE, LOCK=NONE;

--- a/jdbc-postgres/src/main/resources/migrations/postgres/V1_55__logs_indexes.sql
+++ b/jdbc-postgres/src/main/resources/migrations/postgres/V1_55__logs_indexes.sql
@@ -1,0 +1,3 @@
+DROP INDEX CONCURRENTLY IF EXISTS logs_namespace_flow;
+CREATE INDEX CONCURRENTLY IF NOT EXISTS logs_tenant_timestamp ON logs ("tenant_id", "timestamp", "level");
+CREATE INDEX CONCURRENTLY IF NOT EXISTS logs_tenant_namespace_timestamp ON logs ("tenant_id", "namespace", "timestamp", "level");


### PR DESCRIPTION
Replace the inefficient ix_namespace_flow index where timestamp range made namespace unusable, with two proper indexes:
- ix_timestamp for general time-range queries
- ix_namespace_timestamp for namespace-scoped queries

Also align MySQL fetchPage (in MysqlRepository) with Postgres/H2 by using COUNT() OVER() window function in a single query instead of two separate queries (avoid multiple full-scans).