### PR TITLE
fix: remove duplicate spacing in log lines

### DIFF
--- a/ui/src/components/logs/LogLine.vue
+++ b/ui/src/components/logs/LogLine.vue
@@ -214,10 +214,6 @@ div.line {
             align-items: center;
             gap: .5rem;
         }
-
-        .header > * + * {
-            margin-left: 1rem;
-        }
     }
 
     .el-tag {


### PR DESCRIPTION
## Description

Fixes the wrong spacing in log lines reported in #14287.

### Problem

The log line header (`.header` in `LogLine.vue`) had both:
- `gap: .5rem` (flexbox gap)
- `margin-left: 1rem` on sibling elements (`.header > * + *`)

These two spacing mechanisms stacked, causing inconsistent and excessive spacing between log header elements (level badge, timestamp, metadata).

### Fix

Removed the redundant `margin-left` rule. The flexbox `gap` property alone provides consistent spacing between all child elements.

Fixes #14287