### PR TITLE
fix(core): make KVStore compatible with gRPC-based worker

### DIFF
--- a/cli/src/main/java/io/kestra/cli/commands/migrations/metadata/MetadataMigrationService.java
+++ b/cli/src/main/java/io/kestra/cli/commands/migrations/metadata/MetadataMigrationService.java
@@ -8,6 +8,7 @@ import io.kestra.core.models.namespaces.files.NamespaceFileMetadata;
 import io.kestra.core.repositories.FlowRepositoryInterface;
 import io.kestra.core.repositories.KvMetadataRepositoryInterface;
 import io.kestra.core.repositories.NamespaceFileMetadataRepositoryInterface;
+import io.kestra.core.runners.KVMetadataStateStore;
 import io.kestra.core.storages.FileAttributes;
 import io.kestra.core.storages.StorageContext;
 import io.kestra.core.storages.StorageInterface;
@@ -34,6 +35,7 @@ public class MetadataMigrationService {
     protected FlowRepositoryInterface flowRepository;
     protected TenantService tenantService;
     protected KvMetadataRepositoryInterface kvMetadataRepository;
+    protected KVMetadataStateStore kvMetadataStateStore;
     protected NamespaceFileMetadataRepositoryInterface namespaceFileMetadataRepository;
     protected StorageInterface storageInterface;
     protected KestraConfig kestraConfig;
@@ -41,13 +43,15 @@ public class MetadataMigrationService {
     @Singleton
     public MetadataMigrationService(FlowRepositoryInterface flowRepository, 
                                     TenantService tenantService,
-                                    KvMetadataRepositoryInterface kvMetadataRepository, 
+                                    KvMetadataRepositoryInterface kvMetadataRepository,
+                                    KVMetadataStateStore kvMetadataStateStore,
                                     NamespaceFileMetadataRepositoryInterface namespaceFileMetadataRepository, 
                                     StorageInterface storageInterface, 
                                     KestraConfig kestraConfig) {
         this.flowRepository = flowRepository;
         this.tenantService = tenantService;
         this.kvMetadataRepository = kvMetadataRepository;
+        this.kvMetadataStateStore = kvMetadataStateStore;
         this.namespaceFileMetadataRepository = namespaceFileMetadataRepository;
         this.storageInterface = storageInterface;
         this.kestraConfig = kestraConfig;
@@ -66,7 +70,7 @@ public class MetadataMigrationService {
         this.namespacesPerTenant().entrySet().stream()
             .flatMap(namespacesForTenant -> namespacesForTenant.getValue().stream().map(namespace -> Map.entry(namespacesForTenant.getKey(), namespace)))
             .flatMap(throwFunction(namespaceForTenant -> {
-                InternalKVStore kvStore = new InternalKVStore(namespaceForTenant.getKey(), namespaceForTenant.getValue(), storageInterface, kvMetadataRepository);
+                InternalKVStore kvStore = new InternalKVStore(namespaceForTenant.getKey(), namespaceForTenant.getValue(), storageInterface, kvMetadataStateStore);
                 List<FileAttributes> list = listAllFromStorage(storageInterface, StorageContext::kvPrefix, namespaceForTenant.getKey(), namespaceForTenant.getValue()).stream()
                     .map(PathAndAttributes::attributes)
                     .toList();

--- a/cli/src/test/java/io/kestra/cli/commands/migrations/metadata/KvMetadataMigrationCommandTest.java
+++ b/cli/src/test/java/io/kestra/cli/commands/migrations/metadata/KvMetadataMigrationCommandTest.java
@@ -7,6 +7,7 @@ import io.kestra.core.models.flows.GenericFlow;
 import io.kestra.core.models.kv.PersistedKvMetadata;
 import io.kestra.core.repositories.FlowRepositoryInterface;
 import io.kestra.core.repositories.KvMetadataRepositoryInterface;
+import io.kestra.core.runners.KVMetadataStateStore;
 import io.kestra.core.serializers.JacksonMapper;
 import io.kestra.core.storages.StorageContext;
 import io.kestra.core.storages.StorageInterface;
@@ -67,6 +68,7 @@ public class KvMetadataMigrationCommandTest {
             assertThat(storage.exists(tenantId, null, getKvStorageUri(namespace, expiredKey))).isTrue();
 
             KvMetadataRepositoryInterface kvMetadataRepository = ctx.getBean(KvMetadataRepositoryInterface.class);
+            KVMetadataStateStore kvMetadataStateStore = ctx.getBean(KVMetadataStateStore.class);
             assertThat(kvMetadataRepository.findByName(tenantId, namespace, key).isPresent()).isFalse();
 
             /* Expected outcome from the migration command:
@@ -105,7 +107,7 @@ public class KvMetadataMigrationCommandTest {
 
             assertThat(kvMetadataRepository.findByName(tenantId, anotherNamespace, anotherKey).isPresent()).isFalse();
 
-            KVStore kvStore = new InternalKVStore(tenantId, namespace, storage, kvMetadataRepository);
+            KVStore kvStore = new InternalKVStore(tenantId, namespace, storage, kvMetadataStateStore);
             Optional<KVEntry> actualKv = kvStore.get(key);
             assertThat(actualKv.isPresent()).isTrue();
             assertThat(actualKv.get().description()).isEqualTo(description);

--- a/cli/src/test/java/io/kestra/cli/commands/migrations/metadata/MetadataMigrationServiceTest.java
+++ b/cli/src/test/java/io/kestra/cli/commands/migrations/metadata/MetadataMigrationServiceTest.java
@@ -53,6 +53,6 @@ public class MetadataMigrationServiceTest<T extends MetadataMigrationService> {
             public String resolveTenant() {
                 return TENANT_ID;
             }
-        }, null, null, null, kestraConfig));
+        }, null, null, null, null, kestraConfig));
     }
 }

--- a/core/src/main/java/io/kestra/core/runners/DefaultKVMetadataStateStore.java
+++ b/core/src/main/java/io/kestra/core/runners/DefaultKVMetadataStateStore.java
@@ -1,0 +1,86 @@
+package io.kestra.core.runners;
+
+import io.kestra.core.models.QueryFilter;
+import io.kestra.core.models.kv.PersistedKvMetadata;
+import io.kestra.core.repositories.KvMetadataRepositoryInterface;
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.data.model.Pageable;
+import jakarta.annotation.Nullable;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Default implementation of {@link KVMetadataStateStore} that delegates
+ * directly to {@link KvMetadataRepositoryInterface}.
+ * <p>
+ * This implementation is active on controller, webserver, and standalone servers
+ * where the repository is available. Workers use a gRPC-based implementation instead.
+ */
+@Singleton
+@Requires(property = "kestra.server-type", notEquals = "WORKER")
+public class DefaultKVMetadataStateStore implements KVMetadataStateStore {
+
+    private final KvMetadataRepositoryInterface kvMetadataRepository;
+
+    @Inject
+    public DefaultKVMetadataStateStore(KvMetadataRepositoryInterface kvMetadataRepository) {
+        this.kvMetadataRepository = kvMetadataRepository;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public Optional<PersistedKvMetadata> findByName(String tenantId, String namespace, String name) throws IOException {
+        return kvMetadataRepository.findByName(tenantId, namespace, name);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public List<PersistedKvMetadata> find(String tenantId, @Nullable String namespace) {
+        List<QueryFilter> filters = namespace == null ? List.of() : List.of(
+            QueryFilter.builder()
+                .field(QueryFilter.Field.NAMESPACE)
+                .operation(QueryFilter.Op.EQUALS)
+                .value(namespace)
+                .build()
+        );
+        return kvMetadataRepository.find(
+            Pageable.UNPAGED,
+            tenantId,
+            filters,
+            false,
+            false
+        );
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public boolean existsByNamespace(String tenantId, String namespace) {
+        return !kvMetadataRepository.find(
+            Pageable.from(1, 1),
+            tenantId,
+            List.of(QueryFilter.builder()
+                .field(QueryFilter.Field.NAMESPACE)
+                .operation(QueryFilter.Op.EQUALS)
+                .value(namespace)
+                .build()),
+            false,
+            false
+        ).isEmpty();
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public PersistedKvMetadata save(PersistedKvMetadata item) {
+        return kvMetadataRepository.save(item);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public PersistedKvMetadata delete(PersistedKvMetadata persistedKvMetadata) throws IOException {
+        return kvMetadataRepository.delete(persistedKvMetadata);
+    }
+}

--- a/core/src/main/java/io/kestra/core/runners/KVMetadataStateStore.java
+++ b/core/src/main/java/io/kestra/core/runners/KVMetadataStateStore.java
@@ -1,0 +1,87 @@
+package io.kestra.core.runners;
+
+import io.kestra.core.models.kv.PersistedKvMetadata;
+import jakarta.annotation.Nullable;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Abstraction layer for KV metadata operations, used by {@link io.kestra.core.storages.kv.InternalKVStore}
+ * and {@link io.kestra.core.services.KVStoreService}.
+ * <p>
+ * On controller/webserver/standalone servers, the default implementation delegates directly to
+ * {@link io.kestra.core.repositories.KvMetadataRepositoryInterface}.
+ * On workers, a gRPC-based implementation communicates with the controller.
+ * <p>
+ * This interface only exposes worker-safe operations. Server-only operations (paginated listing,
+ * version-aware queries, purge) require direct access to
+ * {@link io.kestra.core.repositories.KvMetadataRepositoryInterface}.
+ */
+public interface KVMetadataStateStore {
+
+    /**
+     * Find a KV metadata entry by tenant, namespace, and name.
+     *
+     * @param tenantId  the tenant ID
+     * @param namespace the namespace
+     * @param name      the key name
+     * @return an optional KV metadata entry
+     * @throws IOException if an I/O error occurs
+     */
+    Optional<PersistedKvMetadata> findByName(String tenantId, String namespace, String name) throws IOException;
+
+    /**
+     * Find all non-deleted, non-expired KV metadata entries for a given tenant and namespace.
+     *
+     * @param tenantId  the tenant ID
+     * @param namespace the namespace (maybe {@code null})
+     * @return list of active KV metadata entries
+     */
+    List<PersistedKvMetadata> find(String tenantId, @Nullable String namespace);
+
+    /**
+     * Check whether any non-deleted, non-expired KV entries exist in the given namespace.
+     *
+     * @param tenantId  the tenant ID
+     * @param namespace the namespace
+     * @return {@code true} if at least one active KV entry exists
+     */
+    boolean existsByNamespace(String tenantId, String namespace);
+
+    /**
+     * Save a KV metadata entry.
+     *
+     * @param item the KV metadata entry to save
+     * @return the saved KV metadata entry
+     */
+    PersistedKvMetadata save(PersistedKvMetadata item);
+
+    /**
+     * Soft-delete a KV metadata entry.
+     *
+     * @param persistedKvMetadata the KV metadata entry to delete
+     * @return the deleted KV metadata entry
+     * @throws IOException if an I/O error occurs
+     */
+    default PersistedKvMetadata delete(PersistedKvMetadata persistedKvMetadata) throws IOException {
+        return this.save(persistedKvMetadata.toDeleted());
+    }
+
+    /**
+     * Soft-delete a KV metadata entry by tenant, namespace, and name.
+     *
+     * @param tenantId  the tenant ID
+     * @param namespace the namespace
+     * @param name      the key name
+     * @throws IOException if an I/O error occurs
+     */
+    default Optional<PersistedKvMetadata> deleteByName(String tenantId, String namespace, String name) throws IOException {
+        Optional<PersistedKvMetadata> existing = this.findByName(tenantId, namespace, name);
+        if (existing.isPresent()) {
+            return Optional.of(this.delete(existing.get()));
+        }
+        return Optional.empty();
+    }
+}

--- a/core/src/main/java/io/kestra/core/services/KVStoreService.java
+++ b/core/src/main/java/io/kestra/core/services/KVStoreService.java
@@ -1,28 +1,61 @@
 package io.kestra.core.services;
 
+import io.kestra.core.models.FetchVersion;
+import io.kestra.core.models.QueryFilter;
+import io.kestra.core.models.kv.PersistedKvMetadata;
+import io.kestra.core.repositories.ArrayListTotal;
 import io.kestra.core.repositories.KvMetadataRepositoryInterface;
+import io.kestra.core.runners.KVMetadataStateStore;
 import io.kestra.core.storages.StorageInterface;
 import io.kestra.core.storages.kv.InternalKVStore;
+import io.kestra.core.storages.kv.KVEntry;
 import io.kestra.core.storages.kv.KVStore;
 import io.kestra.core.storages.kv.KVStoreException;
 import io.micronaut.data.model.Pageable;
 import jakarta.annotation.Nullable;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
+import lombok.extern.slf4j.Slf4j;
 
 import java.io.IOException;
+import java.net.URI;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+import static io.kestra.core.utils.Rethrow.throwFunction;
 
 @Singleton
+@Slf4j
 public class KVStoreService {
     @Inject
-    private KvMetadataRepositoryInterface kvMetadataRepository;
+    private KVMetadataStateStore kvMetadataStateStore;
 
     @Inject
     private StorageInterface storageInterface;
 
     @Inject
     private NamespaceService namespaceService;
+    
+    @Inject
+    private StorageInterface storage;
+    
+    @Inject
+    private Optional<KvMetadataRepositoryInterface> kvMetadataRepository;
 
+    /**
+     * Gets access to the Key-Value store for the given namespace.
+     *
+     * @param tenant        The tenant ID.
+     * @param namespace     The namespace of the K/V store.
+     * @return The {@link KVStore}.
+     */
+    public KVStore get(String tenant, String namespace) {
+        checkAccessNamespaceIsAllowed(tenant, namespace, null);
+        return new InternalKVStore(tenant, namespace, storageInterface, kvMetadataStateStore);
+    }
+    
     /**
      * Gets access to the Key-Value store for the given namespace.
      *
@@ -32,6 +65,101 @@ public class KVStoreService {
      * @return The {@link KVStore}.
      */
     public KVStore get(String tenant, String namespace, @Nullable String fromNamespace) {
+        checkAccessNamespaceIsAllowed(tenant, namespace, fromNamespace);
+        return new InternalKVStore(tenant, namespace, storageInterface, kvMetadataStateStore);
+    }
+    
+    public ArrayListTotal<KVEntry> list(Pageable pageable, String tenant, String namespace) throws IOException {
+        return this.list(pageable, tenant, namespace, Collections.emptyList());
+    }
+
+    public ArrayListTotal<KVEntry> list(Pageable pageable, String tenant, String namespace, List<QueryFilter> queryFilters) throws IOException {
+        return this.list(pageable, tenant, namespace, queryFilters, false, false, FetchVersion.LATEST);
+    }
+
+    /**
+     * Lists K/V store entries with pagination, filtering, and version control.
+     *
+     * @param pageable       The pagination parameters.
+     * @param filters        The query filters.
+     * @param allowDeleted   Whether to include deleted entries.
+     * @param allowExpired   Whether to include expired entries.
+     * @param fetchBehavior  The version fetch behavior.
+     * @return The paginated list of {@link KVEntry}.
+     * @throws IOException if an error occurred while executing the operation on the K/V store.
+     */
+    public ArrayListTotal<KVEntry> list(Pageable pageable, String tenant, String namespace, List<QueryFilter> filters, boolean allowDeleted, boolean allowExpired, FetchVersion fetchBehavior) throws IOException {
+        if (namespace != null) {
+            filters = Stream.concat(
+                filters.stream(),
+                Stream.of(QueryFilter.builder().field(QueryFilter.Field.NAMESPACE).operation(QueryFilter.Op.EQUALS).value(namespace).build())
+            ).toList();
+        }
+
+        return getKvMetadataRepository().find(
+            pageable,
+            tenant,
+            filters,
+            allowDeleted,
+            allowExpired,
+            fetchBehavior
+        ).map(throwFunction(KVEntry::from));
+    }
+
+    private KvMetadataRepositoryInterface getKvMetadataRepository() {
+        return this.kvMetadataRepository.orElseThrow(() -> new KVStoreException("The K/V store metadata repository is not available. This operation cannot be performed."));
+    }
+
+    /**
+     * Lists all the K/V store entries, expired or not.
+     * @param tenant        The tenant ID.
+     * @param namespace     The namespace of the K/V store.
+     * @return The list of all {@link KVEntry}.
+     * @throws IOException if an error occurred while executing the operation on the K/V store.
+     */
+    public List<KVEntry> listAll(String tenant, String namespace) throws IOException {
+        return this.list(Pageable.UNPAGED, tenant, namespace, Collections.emptyList(), true, true, FetchVersion.ALL);
+    }
+
+    /**
+     * Purge the provided KV entries.
+     *
+     * @param kvEntries The entries to purge.
+     * @return The number of purged entries.
+     * @throws IOException if an error occurred while executing the operation on the K/V store.
+     */
+    public Integer purge(String tenant, String namespace, List<KVEntry> kvEntries) throws IOException {
+        Integer purgedMetadataCount = getKvMetadataRepository().purge(kvEntries.stream().map(kv -> PersistedKvMetadata.from(tenant, kv)).toList());
+
+        long actualDeletedEntries = kvEntries.stream()
+            .map(KVEntry::key)
+            .map(key -> KVStore.storageUri(key, namespace, 1))
+            .map(throwFunction(uri -> {
+                boolean deleted = this.storage.delete(tenant, namespace, uri);
+                URI metadataURI = URI.create(uri.getPath() + ".metadata");
+                if (this.storage.exists(tenant, namespace, metadataURI)) {
+                    this.storage.delete(tenant, namespace, metadataURI);
+                }
+
+                return deleted;
+            })).filter(Boolean::booleanValue)
+            .count();
+
+        if (actualDeletedEntries != purgedMetadataCount) {
+            log.warn("KV Metadata purge reported {} deleted entries, but {} values were actually deleted from storage", purgedMetadataCount, actualDeletedEntries);
+        }
+
+        return purgedMetadataCount;
+    }
+    
+    /**
+     * Checks if access to the given namespace is allowed from the specified namespace and if the namespace exists.
+     * 
+     * @param tenant        The tenant ID.
+     * @param namespace     The namespace of the K/V store.
+     * @param fromNamespace The namespace from which the K/V store is accessed.
+     */
+    public void checkAccessNamespaceIsAllowed(String tenant, String namespace, @Nullable String fromNamespace) {
         boolean isNotSameNamespace = fromNamespace != null && !namespace.equals(fromNamespace);
         if (isNotSameNamespace && isNotParentNamespace(namespace, fromNamespace)) {
             try {
@@ -47,21 +175,13 @@ public class KVStoreService {
         boolean checkIfNamespaceExists = fromNamespace == null || isNotParentNamespace(namespace, fromNamespace);
         if (checkIfNamespaceExists && !namespaceService.isNamespaceExists(tenant, namespace)) {
             // if it didn't exist, we still check if there are KV as you can add KV without creating a namespace in DB or having flows in it
-            KVStore kvStore = new InternalKVStore(tenant, namespace, storageInterface, kvMetadataRepository);
-            try {
-                if (kvStore.list(Pageable.from(1, 1)).isEmpty()) {
-                    throw new KVStoreException(String.format(
-                        "Cannot access the KV store. The namespace '%s' does not exist.",
-                        namespace
-                    ));
-                }
-            } catch (IOException e) {
-                throw new KVStoreException(e);
+            if (!kvMetadataStateStore.existsByNamespace(tenant, namespace)) {
+                throw new KVStoreException(String.format(
+                    "Cannot access the KV store. The namespace '%s' does not exist.",
+                    namespace
+                ));
             }
-            return kvStore;
         }
-
-        return new InternalKVStore(tenant, namespace, storageInterface, kvMetadataRepository);
     }
 
     private static boolean isNotParentNamespace(final String parentNamespace, final String childNamespace) {

--- a/core/src/main/java/io/kestra/core/storages/kv/InternalKVStore.java
+++ b/core/src/main/java/io/kestra/core/storages/kv/InternalKVStore.java
@@ -1,32 +1,22 @@
 package io.kestra.core.storages.kv;
 
 import io.kestra.core.exceptions.ResourceExpiredException;
-import io.kestra.core.models.FetchVersion;
-import io.kestra.core.models.QueryFilter;
 import io.kestra.core.models.kv.PersistedKvMetadata;
-import io.kestra.core.repositories.ArrayListTotal;
-import io.kestra.core.repositories.KvMetadataRepositoryInterface;
+import io.kestra.core.runners.KVMetadataStateStore;
 import io.kestra.core.serializers.JacksonMapper;
 import io.kestra.core.storages.StorageInterface;
 import io.kestra.core.storages.StorageObject;
-import io.kestra.core.utils.ListUtils;
-import io.micronaut.data.model.Pageable;
-import io.micronaut.data.model.Sort;
 import jakarta.annotation.Nullable;
 import lombok.extern.slf4j.Slf4j;
 
 import java.io.ByteArrayInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
-import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.*;
-import java.util.function.Function;
 import java.util.regex.Pattern;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import static io.kestra.core.utils.Rethrow.throwFunction;
 
@@ -42,20 +32,24 @@ public class InternalKVStore implements KVStore {
     private final String namespace;
     private final String tenant;
     private final StorageInterface storage;
-    private final KvMetadataRepositoryInterface kvMetadataRepository;
+    private final KVMetadataStateStore kvMetadataStateStore;
 
     /**
      * Creates a new {@link InternalKVStore} instance.
      *
-     * @param namespace The namespace
-     * @param tenant    The tenant.
-     * @param storage   The storage.
+     * @param tenant               The tenant.
+     * @param namespace            The namespace.
+     * @param storage              The storage.
+     * @param kvMetadataStateStore The KV metadata state store (used for worker-safe operations).
      */
-    public InternalKVStore(@Nullable final String tenant, @Nullable final String namespace, final StorageInterface storage, final KvMetadataRepositoryInterface kvMetadataRepository) {
+    public InternalKVStore(@Nullable final String tenant,
+                           @Nullable final String namespace,
+                           final StorageInterface storage,
+                           final KVMetadataStateStore kvMetadataStateStore) {
         this.namespace = namespace;
         this.storage = Objects.requireNonNull(storage, "storage cannot be null");
         this.tenant = tenant;
-        this.kvMetadataRepository = kvMetadataRepository;
+        this.kvMetadataStateStore = kvMetadataStateStore;
     }
 
     /**
@@ -81,7 +75,7 @@ public class InternalKVStore implements KVStore {
         Object actualValue = value.value();
         byte[] serialized = actualValue instanceof Duration ? actualValue.toString().getBytes(StandardCharsets.UTF_8) : JacksonMapper.ofIon().writeValueAsBytes(actualValue);
 
-        PersistedKvMetadata saved = this.kvMetadataRepository.save(PersistedKvMetadata.builder()
+        PersistedKvMetadata saved = this.kvMetadataStateStore.save(PersistedKvMetadata.builder()
             .tenantId(this.tenant)
             .namespace(this.namespace)
             .name(key)
@@ -112,7 +106,7 @@ public class InternalKVStore implements KVStore {
     public Optional<String> getRawValue(String key) throws IOException, ResourceExpiredException {
         KVStore.validateKey(key);
 
-        Optional<PersistedKvMetadata> maybeMetadata = this.kvMetadataRepository.findByName(this.tenant, this.namespace, key);
+        Optional<PersistedKvMetadata> maybeMetadata = this.kvMetadataStateStore.findByName(this.tenant, this.namespace, key);
 
         int version = maybeMetadata.map(PersistedKvMetadata::getVersion).orElse(1);
         if (maybeMetadata.isPresent()) {
@@ -144,41 +138,27 @@ public class InternalKVStore implements KVStore {
     @Override
     public boolean delete(String key) throws IOException {
         KVStore.validateKey(key);
-        Optional<PersistedKvMetadata> maybeMetadata = this.kvMetadataRepository.findByName(this.tenant, this.namespace, key);
+        Optional<PersistedKvMetadata> maybeMetadata = this.kvMetadataStateStore.findByName(this.tenant, this.namespace, key);
         if (maybeMetadata.map(PersistedKvMetadata::isDeleted).orElse(true)) {
             return false;
         }
 
-        this.kvMetadataRepository.delete(maybeMetadata.get());
+        this.kvMetadataStateStore.delete(maybeMetadata.get());
         return true;
 
     }
 
     /**
      * {@inheritDoc}
+     * <p>
+     * This implementation uses the {@link KVMetadataStateStore} and is safe to call from workers.
      */
     @Override
-    public List<KVEntry> listAll() throws IOException {
-        return this.list(Pageable.UNPAGED, Collections.emptyList(), true, true, FetchVersion.ALL);
-    }
-
-    @Override
-    public ArrayListTotal<KVEntry> list(Pageable pageable, List<QueryFilter> filters, boolean allowDeleted, boolean allowExpired, FetchVersion fetchBehavior) throws IOException {
-        if (this.namespace != null) {
-            filters = Stream.concat(
-                filters.stream(),
-                Stream.of(QueryFilter.builder().field(QueryFilter.Field.NAMESPACE).operation(QueryFilter.Op.EQUALS).value(this.namespace).build())
-            ).toList();
-        }
-
-        return this.kvMetadataRepository.find(
-            pageable,
-            this.tenant,
-            filters,
-            allowDeleted,
-            allowExpired,
-            fetchBehavior
-        ).map(throwFunction(KVEntry::from));
+    public List<KVEntry> list() throws IOException {
+        return this.kvMetadataStateStore.find(this.tenant, this.namespace)
+            .stream()
+            .map(throwFunction(KVEntry::from))
+            .toList();
     }
 
     /**
@@ -188,39 +168,11 @@ public class InternalKVStore implements KVStore {
     public Optional<KVEntry> get(final String key) throws IOException {
         KVStore.validateKey(key);
 
-        Optional<PersistedKvMetadata> maybeMetadata = this.kvMetadataRepository.findByName(this.tenant, this.namespace, key);
+        Optional<PersistedKvMetadata> maybeMetadata = this.kvMetadataStateStore.findByName(this.tenant, this.namespace, key);
         if (maybeMetadata.isEmpty() || maybeMetadata.get().isDeleted()) {
             return Optional.empty();
         }
 
         return Optional.of(KVEntry.from(maybeMetadata.get()));
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public Integer purge(List<KVEntry> kvEntries) throws IOException {
-        Integer purgedMetadataCount = this.kvMetadataRepository.purge(kvEntries.stream().map(kv -> PersistedKvMetadata.from(tenant, kv)).toList());
-
-        long actualDeletedEntries = kvEntries.stream()
-            .map(KVEntry::key)
-            .map(this::storageUri)
-            .map(throwFunction(uri -> {
-                boolean deleted = this.storage.delete(tenant, namespace, uri);
-                URI metadataURI = URI.create(uri.getPath() + ".metadata");
-                if (this.storage.exists(this.tenant, this.namespace, metadataURI)) {
-                    this.storage.delete(this.tenant, this.namespace, metadataURI);
-                }
-
-                return deleted;
-            })).filter(Boolean::booleanValue)
-            .count();
-
-        if (actualDeletedEntries != purgedMetadataCount) {
-            log.warn("KV Metadata purge reported {} deleted entries, but {} values were actually deleted from storage", purgedMetadataCount, actualDeletedEntries);
-        }
-
-        return purgedMetadataCount;
     }
 }

--- a/core/src/main/java/io/kestra/core/storages/kv/KVStore.java
+++ b/core/src/main/java/io/kestra/core/storages/kv/KVStore.java
@@ -1,16 +1,11 @@
 package io.kestra.core.storages.kv;
 
 import io.kestra.core.exceptions.ResourceExpiredException;
-import io.kestra.core.models.FetchVersion;
-import io.kestra.core.models.QueryFilter;
-import io.kestra.core.repositories.ArrayListTotal;
 import io.kestra.core.storages.StorageContext;
-import io.micronaut.data.model.Pageable;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.net.URI;
-import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.regex.Pattern;
@@ -18,6 +13,9 @@ import java.util.regex.Pattern;
 
 /**
  * Service interface for accessing the files attached to a namespace Key-Value store.
+ * <p>
+ * This interface exposes only worker-safe operations. For server-only operations
+ * (paginated listing, listing all entries, purging), see {@link io.kestra.core.kv.services.KVService}.
  */
 public interface KVStore {
 
@@ -33,10 +31,10 @@ public interface KVStore {
     }
 
     default URI storageUri(String key, int version) {
-        return this.storageUri(key, namespace(), version);
+        return KVStore.storageUri(key, namespace(), version);
     }
 
-    default URI storageUri(String key, String namespace, int version) {
+    static URI storageUri(String key, String namespace, int version) {
         String fileName = kvFileName(key, version);
         return URI.create(StorageContext.KESTRA_PROTOCOL + StorageContext.kvPrefix(namespace) + (fileName.isEmpty() ? fileName : ("/" + fileName)));
     }
@@ -85,37 +83,12 @@ public interface KVStore {
     boolean delete(String key) throws IOException;
 
     /**
-     * Purge the provided KV entries.
-     */
-    Integer purge(List<KVEntry> kvToDelete) throws IOException;
-
-    default ArrayListTotal<KVEntry> list() throws IOException {
-        return this.list(Pageable.UNPAGED);
-    }
-
-    default ArrayListTotal<KVEntry> list(Pageable pageable) throws IOException {
-        return this.list(pageable, Collections.emptyList());
-    }
-
-    default ArrayListTotal<KVEntry> list(Pageable pageable, List<QueryFilter> queryFilters) throws IOException {
-        return this.list(pageable, queryFilters, false, false, FetchVersion.LATEST);
-    }
-
-    /**
-     * Lists all the K/V store entries.
+     * Lists all non-expired, non-deleted K/V store entries.
      *
-     * @return  The list of {@link KVEntry}.
+     * @return The list of {@link KVEntry}.
      * @throws IOException if an error occurred while executing the operation on the K/V store.
      */
-    ArrayListTotal<KVEntry> list(Pageable pageable, List<QueryFilter> queryFilters, boolean allowDeleted, boolean allowExpired, FetchVersion fetchBehavior) throws IOException;
-
-    /**
-     * Lists all the K/V store entries, expired or not.
-     *
-     * @return  The list of all {@link KVEntry}.
-     * @throws IOException if an error occurred while executing the operation on the K/V store.
-     */
-    List<KVEntry> listAll() throws IOException;
+    List<KVEntry> list() throws IOException;
 
     /**
      * Finds the K/V store entry for the given key.

--- a/core/src/main/java/io/kestra/plugin/core/kv/Key.java
+++ b/core/src/main/java/io/kestra/plugin/core/kv/Key.java
@@ -1,8 +1,8 @@
 package io.kestra.plugin.core.kv;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import io.kestra.core.services.KVStoreService;
 import io.kestra.core.storages.kv.KVEntry;
-import io.kestra.core.storages.kv.KVStore;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import lombok.Builder;
@@ -31,7 +31,7 @@ public class Key extends KvPurgeBehavior {
     private boolean expiredOnly = true;
 
     @Override
-    protected List<KVEntry> entriesToPurge(KVStore kvStore) throws IOException {
-        return kvStore.listAll().stream().filter(kv -> !expiredOnly || (kv.expirationDate() != null && kv.expirationDate().isBefore(Instant.now()))).toList();
+    protected List<KVEntry> entriesToPurge(String tenant, String namespace, KVStoreService service) throws IOException {
+        return service.listAll(tenant, namespace).stream().filter(kv -> !expiredOnly || (kv.expirationDate() != null && kv.expirationDate().isBefore(Instant.now()))).toList();
     }
 }

--- a/core/src/main/java/io/kestra/plugin/core/kv/KvPurgeBehavior.java
+++ b/core/src/main/java/io/kestra/plugin/core/kv/KvPurgeBehavior.java
@@ -2,8 +2,8 @@ package io.kestra.plugin.core.kv;
 
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import io.kestra.core.services.KVStoreService;
 import io.kestra.core.storages.kv.KVEntry;
-import io.kestra.core.storages.kv.KVStore;
 import io.micronaut.core.annotation.Introspected;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -24,5 +24,5 @@ import java.util.List;
 public abstract class KvPurgeBehavior {
     abstract public String getType();
 
-    protected abstract List<KVEntry> entriesToPurge(KVStore kvStore) throws IOException;
+    protected abstract List<KVEntry> entriesToPurge(String tenant, String namespace, KVStoreService service) throws IOException;
 }

--- a/core/src/main/java/io/kestra/plugin/core/kv/PurgeKV.java
+++ b/core/src/main/java/io/kestra/plugin/core/kv/PurgeKV.java
@@ -1,19 +1,14 @@
 package io.kestra.plugin.core.kv;
 
-import com.cronutils.utils.VisibleForTesting;
-import io.kestra.core.exceptions.IllegalVariableEvaluationException;
-import io.kestra.core.exceptions.ValidationErrorException;
 import io.kestra.core.models.annotations.Example;
 import io.kestra.core.models.annotations.Plugin;
 import io.kestra.core.models.property.Property;
 import io.kestra.core.models.tasks.RunnableTask;
 import io.kestra.core.models.tasks.Task;
-import io.kestra.core.repositories.FlowRepositoryInterface;
 import io.kestra.core.runners.DefaultRunContext;
 import io.kestra.core.runners.RunContext;
+import io.kestra.core.services.KVStoreService;
 import io.kestra.core.storages.kv.KVEntry;
-import io.kestra.core.storages.kv.KVStore;
-import io.kestra.core.utils.ListUtils;
 import io.kestra.plugin.core.purge.PurgeTask;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.Valid;
@@ -22,10 +17,8 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.lang3.StringUtils;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicLong;
 
@@ -115,10 +108,14 @@ public class PurgeKV extends Task implements PurgeTask<KVEntry>, RunnableTask<Pu
         } else {
             renderedBehavior = runContext.render(behavior).as(KvPurgeBehavior.class).orElseThrow();
         }
-        for (String ns : kvNamespaces) {
-            KVStore kvStore = runContext.namespaceKv(ns);
-            List<KVEntry> toPurge = filterItems(runContext, renderedBehavior.entriesToPurge(kvStore));
-            count.addAndGet(kvStore.purge(toPurge));
+
+        String tenantId = runContext.flowInfo().tenantId();
+        String namespace = runContext.flowInfo().namespace();
+        for (String targetNamespace : kvNamespaces) {
+            KVStoreService kvStoreService = ((DefaultRunContext) runContext).services().additionalService(KVStoreService.class);
+            kvStoreService.checkAccessNamespaceIsAllowed(tenantId, targetNamespace, namespace);
+            List<KVEntry> toPurge = filterItems(runContext, renderedBehavior.entriesToPurge(tenantId, targetNamespace, kvStoreService));
+            count.addAndGet(kvStoreService.purge(tenantId, targetNamespace, toPurge));
         }
         runContext.logger().info("purged {} keys", count.get());
 

--- a/core/src/main/java/io/kestra/plugin/core/kv/Version.java
+++ b/core/src/main/java/io/kestra/plugin/core/kv/Version.java
@@ -3,8 +3,8 @@ package io.kestra.plugin.core.kv;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import io.kestra.core.models.FetchVersion;
 import io.kestra.core.models.QueryFilter;
+import io.kestra.core.services.KVStoreService;
 import io.kestra.core.storages.kv.KVEntry;
-import io.kestra.core.storages.kv.KVStore;
 import io.kestra.core.validations.KvVersionBehaviorValidation;
 import io.micronaut.data.model.Pageable;
 import io.micronaut.data.model.Sort;
@@ -44,9 +44,11 @@ public class Version extends KvPurgeBehavior {
     private Integer keepAmount;
 
     @Override
-    protected List<KVEntry> entriesToPurge(KVStore kvStore) throws IOException {
-        List<KVEntry> entries = kvStore.list(
+    protected List<KVEntry> entriesToPurge(String tenant, String namespace, KVStoreService service) throws IOException {
+        List<KVEntry> entries = service.list(
             Pageable.UNPAGED.withSort(Sort.of(Sort.Order.desc("version"))),
+            tenant,
+            namespace,
             before == null
                 ? Collections.emptyList()
                 : List.of(QueryFilter.builder().field(QueryFilter.Field.UPDATED).operation(QueryFilter.Op.LESS_THAN_OR_EQUAL_TO).value(ZonedDateTime.parse(before)).build()),

--- a/core/src/test/java/io/kestra/core/runners/FlowInputOutputTest.java
+++ b/core/src/test/java/io/kestra/core/runners/FlowInputOutputTest.java
@@ -1,6 +1,5 @@
 package io.kestra.core.runners;
 
-import io.kestra.core.junit.annotations.KestraTest;
 import io.kestra.core.models.executions.Execution;
 import io.kestra.core.models.flows.*;
 import io.kestra.core.models.flows.input.FileInput;
@@ -9,7 +8,6 @@ import io.kestra.core.models.flows.input.IntInput;
 import io.kestra.core.models.flows.input.MultiselectInput;
 import io.kestra.core.models.flows.input.StringInput;
 import io.kestra.core.models.property.Property;
-import io.kestra.core.repositories.KvMetadataRepositoryInterface;
 import io.kestra.core.secret.SecretNotFoundException;
 import io.kestra.core.secret.SecretService;
 import io.kestra.core.services.KVStoreService;
@@ -63,7 +61,7 @@ class FlowInputOutputTest {
     StorageInterface storageInterface;
 
     @Inject
-    KvMetadataRepositoryInterface kvMetadataRepository;
+    KVMetadataStateStore kvMetadataStateStore;
 
     @MockBean(SecretService.class)
     SecretService testSecretService() {
@@ -80,7 +78,7 @@ class FlowInputOutputTest {
         return new KVStoreService() {
             @Override
             public KVStore get(String tenant, String namespace, @Nullable String fromNamespace) {
-                return new InternalKVStore(tenant, namespace, storageInterface, kvMetadataRepository) {
+                return new InternalKVStore(tenant, namespace, storageInterface, kvMetadataStateStore) {
                     @Override
                     public Optional<KVValue> getValue(String key) {
                         return Optional.of(new KVValue(TEST_KV_VALUE));

--- a/core/src/test/java/io/kestra/core/runners/RunVariablesTest.java
+++ b/core/src/test/java/io/kestra/core/runners/RunVariablesTest.java
@@ -11,7 +11,6 @@ import io.kestra.core.models.property.Property;
 import io.kestra.core.models.property.PropertyContext;
 import io.kestra.core.models.tasks.Task;
 import io.kestra.core.models.triggers.AbstractTrigger;
-import io.kestra.core.repositories.KvMetadataRepositoryInterface;
 import io.kestra.core.runners.pebble.PebbleEngineFactory;
 import io.kestra.core.services.KVStoreService;
 import io.kestra.core.storages.StorageInterface;
@@ -46,14 +45,14 @@ class RunVariablesTest {
     StorageInterface storageInterface;
 
     @Inject
-    KvMetadataRepositoryInterface kvMetadataRepository;
+    KVMetadataStateStore kvMetadataStateStore;
 
     @MockBean(KVStoreService.class)
     KVStoreService testKVStoreService() {
         return new KVStoreService() {
             @Override
             public KVStore get(String tenant, String namespace, @Nullable String fromNamespace) {
-                return new InternalKVStore(tenant, namespace, storageInterface, kvMetadataRepository) {
+                return new InternalKVStore(tenant, namespace, storageInterface, kvMetadataStateStore) {
                     @Override
                     public Optional<KVValue> getValue(String key) {
                         return Optional.of(new KVValue("value"));

--- a/core/src/test/java/io/kestra/core/runners/pebble/functions/KvFunctionTest.java
+++ b/core/src/test/java/io/kestra/core/runners/pebble/functions/KvFunctionTest.java
@@ -2,7 +2,7 @@ package io.kestra.core.runners.pebble.functions;
 
 import io.kestra.core.exceptions.IllegalVariableEvaluationException;
 import io.kestra.core.junit.annotations.KestraTest;
-import io.kestra.core.repositories.KvMetadataRepositoryInterface;
+import io.kestra.core.runners.KVMetadataStateStore;
 import io.kestra.core.runners.VariableRenderer;
 import io.kestra.core.storages.StorageInterface;
 import io.kestra.core.storages.kv.InternalKVStore;
@@ -25,7 +25,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 @KestraTest(startRunner = true)
 public class KvFunctionTest {
     @Inject
-    private KvMetadataRepositoryInterface kvMetadataRepository;
+    private KVMetadataStateStore kvMetadataStateStore;
 
     @Inject
     private StorageInterface storageInterface;
@@ -37,7 +37,7 @@ public class KvFunctionTest {
     void shouldGetValueFromKVGivenExistingKey() throws IllegalVariableEvaluationException, IOException {
         // Given
         String tenant = TestsUtils.randomTenant(this.getClass().getSimpleName());
-        KVStore kv = new InternalKVStore(tenant, "io.kestra.tests", storageInterface, kvMetadataRepository);
+        KVStore kv = new InternalKVStore(tenant, "io.kestra.tests", storageInterface, kvMetadataStateStore);
         kv.put("my-key", new KVValueAndMetadata(null, Map.of("field", "value")));
 
         Map<String, Object> variables = getVariables(tenant, "io.kestra.tests");
@@ -53,10 +53,10 @@ public class KvFunctionTest {
     void shouldGetValueFromKVGivenExistingKeyWithInheritance() throws IllegalVariableEvaluationException, IOException {
         // Given
         String tenant = TestsUtils.randomTenant(this.getClass().getSimpleName());
-        KVStore kv = new InternalKVStore(tenant, "my.company", storageInterface, kvMetadataRepository);
+        KVStore kv = new InternalKVStore(tenant, "my.company", storageInterface, kvMetadataStateStore);
         kv.put("my-key", new KVValueAndMetadata(null, Map.of("field", "value")));
 
-        KVStore firstKv = new InternalKVStore(tenant, "my", storageInterface, kvMetadataRepository);
+        KVStore firstKv = new InternalKVStore(tenant, "my", storageInterface, kvMetadataStateStore);
         firstKv.put("my-key", new KVValueAndMetadata(null, Map.of("field", "firstValue")));
 
         Map<String, Object> variables = getVariables(tenant, "my.company.team");
@@ -72,7 +72,7 @@ public class KvFunctionTest {
     void shouldNotGetValueFromKVWithGivenNamespaceAndInheritance() throws IOException {
         // Given
         String tenant = TestsUtils.randomTenant(this.getClass().getSimpleName());
-        KVStore kv = new InternalKVStore(tenant, "kv", storageInterface, kvMetadataRepository);
+        KVStore kv = new InternalKVStore(tenant, "kv", storageInterface, kvMetadataStateStore);
         kv.put("my-key", new KVValueAndMetadata(null, Map.of("field", "value")));
 
         Map<String, Object> variables = getVariables(tenant, "my.company.team");
@@ -86,7 +86,7 @@ public class KvFunctionTest {
     void shouldGetValueFromKVGivenExistingAndNamespace() throws IllegalVariableEvaluationException, IOException {
         // Given
         String tenant = TestsUtils.randomTenant(this.getClass().getSimpleName());
-        KVStore kv = new InternalKVStore(tenant, "kv", storageInterface, kvMetadataRepository);
+        KVStore kv = new InternalKVStore(tenant, "kv", storageInterface, kvMetadataStateStore);
         kv.put("my-key", new KVValueAndMetadata(null, Map.of("field", "value")));
 
         Map<String, Object> variables = getVariables(tenant, "io.kestra.tests");
@@ -117,7 +117,7 @@ public class KvFunctionTest {
         String namespace = TestsUtils.randomNamespace();
         Map<String, Object> variables = getVariables(tenant, namespace);
 
-        KVStore kv = new InternalKVStore(tenant, namespace, storageInterface, kvMetadataRepository);
+        KVStore kv = new InternalKVStore(tenant, namespace, storageInterface, kvMetadataStateStore);
         kv.put("my-expired-key", new KVValueAndMetadata(new KVMetadata(null, Instant.now().minus(1, ChronoUnit.HOURS)), "anyValue"));
 
         String rendered = variableRenderer.render("{{ kv('my-expired-key', errorOnMissing=false) }}", variables);

--- a/core/src/test/java/io/kestra/core/services/KVStoreServiceTest.java
+++ b/core/src/test/java/io/kestra/core/services/KVStoreServiceTest.java
@@ -3,7 +3,7 @@ package io.kestra.core.services;
 import static io.kestra.core.tenant.TenantService.MAIN_TENANT;
 
 import io.kestra.core.junit.annotations.KestraTest;
-import io.kestra.core.repositories.KvMetadataRepositoryInterface;
+import io.kestra.core.runners.KVMetadataStateStore;
 import io.kestra.core.storages.StorageInterface;
 import io.kestra.core.storages.kv.*;
 import io.micronaut.test.annotation.MockBean;
@@ -13,14 +13,13 @@ import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.time.Duration;
-import java.util.Optional;
 
 @KestraTest
 class KVStoreServiceTest {
     private static final String TEST_EXISTING_NAMESPACE = "io.kestra.unittest";
 
     @Inject
-    KvMetadataRepositoryInterface kvMetadataRepository;
+    KVMetadataStateStore kvMetadataStateStore;
 
     @Inject
     KVStoreService storeService;
@@ -46,7 +45,7 @@ class KVStoreServiceTest {
 
     @Test
     void shouldGetKVStoreFromNonExistingNamespaceWithAKV() throws IOException {
-        KVStore kvStore = new InternalKVStore(MAIN_TENANT, "system", storageInterface, kvMetadataRepository);
+        KVStore kvStore = new InternalKVStore(MAIN_TENANT, "system", storageInterface, kvMetadataStateStore);
         kvStore.put("key", new KVValueAndMetadata(new KVMetadata("myDescription", Duration.ofHours(1)), "value"));
         Assertions.assertNotNull(storeService.get(MAIN_TENANT, "system", null));
     }

--- a/core/src/test/java/io/kestra/core/storages/InternalKVStoreTest.java
+++ b/core/src/test/java/io/kestra/core/storages/InternalKVStoreTest.java
@@ -1,7 +1,7 @@
 package io.kestra.core.storages;
 
 import io.kestra.core.exceptions.ResourceExpiredException;
-import io.kestra.core.repositories.KvMetadataRepositoryInterface;
+import io.kestra.core.runners.KVMetadataStateStore;
 import io.kestra.core.serializers.JacksonMapper;
 import io.kestra.core.storages.kv.InternalKVStore;
 import io.kestra.core.storages.kv.KVEntry;
@@ -43,7 +43,7 @@ class InternalKVStoreTest {
     private StorageInterface storageInterface;
 
     @Inject
-    private KvMetadataRepositoryInterface kvMetadataRepository;
+    private KVMetadataStateStore kvMetadataStateStore;
 
     @Test
     void list() throws IOException, InterruptedException {
@@ -78,30 +78,6 @@ class InternalKVStoreTest {
         assertThat(mySecondKeyValue.creationDate().plus(Duration.ofMinutes(9)).isBefore(mySecondKeyValue.expirationDate()) &&
             mySecondKeyValue.creationDate().plus(Duration.ofMinutes(11)).isAfter(mySecondKeyValue.expirationDate())).isTrue();
         assertThat(mySecondKeyValue.description()).isNull();
-    }
-
-    @Test
-    void listAll() throws IOException {
-        Instant now = Instant.now();
-        InternalKVStore kv = kv();
-
-        assertThat(kv.list().size()).isZero();
-
-        String description = "myDescription";
-        kv.put(TEST_KV_KEY, new KVValueAndMetadata(new KVMetadata(description, Duration.ofMinutes(5)), complexValue));
-        kv.put("key-without-expiration", new KVValueAndMetadata(new KVMetadata(null, (Duration) null), complexValue));
-        kv.put("expired-key", new KVValueAndMetadata(new KVMetadata(null, Duration.ofMillis(1)), complexValue));
-
-        List<KVEntry> list = kv.listAll();
-        assertThat(list.size()).isEqualTo(3);
-
-        list.forEach(kvEntry -> {
-            assertThat(kvEntry.creationDate()).isCloseTo(now, within(1, ChronoUnit. SECONDS));
-            assertThat(kvEntry.updateDate()).isCloseTo(now, within(1, ChronoUnit. SECONDS));
-        });
-
-        List<String> keys = list.stream().map(KVEntry::key).toList();
-        assertThat(keys).containsExactlyInAnyOrder(TEST_KV_KEY, "key-without-expiration", "expired-key");
     }
 
     @Test
@@ -269,6 +245,6 @@ class InternalKVStoreTest {
 
     private InternalKVStore kv() {
         final String namespaceId = "io.kestra." + IdUtils.create();
-        return new InternalKVStore(MAIN_TENANT, namespaceId, storageInterface, kvMetadataRepository);
+        return new InternalKVStore(MAIN_TENANT, namespaceId, storageInterface, kvMetadataStateStore);
     }
 }

--- a/core/src/test/java/io/kestra/plugin/core/kv/PurgeKVTest.java
+++ b/core/src/test/java/io/kestra/plugin/core/kv/PurgeKVTest.java
@@ -11,6 +11,7 @@ import io.kestra.core.models.property.Property;
 import io.kestra.core.models.validations.ModelValidator;
 import io.kestra.core.repositories.FlowRepositoryInterface;
 import io.kestra.core.runners.RunContext;
+import io.kestra.core.services.KVStoreService;
 import io.kestra.core.storages.kv.KVEntry;
 import io.kestra.core.storages.kv.KVMetadata;
 import io.kestra.core.storages.kv.KVStore;
@@ -53,6 +54,9 @@ public class PurgeKVTest {
 
     @Inject
     FlowRepositoryInterface flowRepositoryInterface;
+    
+    @Inject
+    KVStoreService kvStoreService;
 
     @Inject
     ModelValidator modelValidator;
@@ -228,7 +232,7 @@ public class PurgeKVTest {
         Output output = purgeKV.run(runContext);
 
         assertThat(output.getSize()).isEqualTo(2L);
-        List<KVEntry> kvEntries = kvStore1.listAll();
+        List<KVEntry> kvEntries = kvStoreService.listAll(MAIN_TENANT, namespace);
         assertThat(kvEntries.size()).isEqualTo(1);
         assertThat(kvEntries.getFirst().key()).isEqualTo("not_found");
     }
@@ -246,7 +250,7 @@ public class PurgeKVTest {
         String changedDescription = "Another description";
         kvStore.put("my-key", new KVValueAndMetadata(new KVMetadata(changedDescription, Instant.now().plus(Duration.ofMinutes(5))), "some value"));
 
-        List<KVEntry> kvs = kvStore.list(Pageable.UNPAGED, Collections.emptyList(), true, true, FetchVersion.ALL);
+        List<KVEntry> kvs = kvStoreService.list(Pageable.UNPAGED, MAIN_TENANT, namespace, Collections.emptyList(), true, true, FetchVersion.ALL);
         assertThat(kvs.size()).isEqualTo(2);
 
         PurgeKV purgeKV = PurgeKV.builder()
@@ -257,7 +261,7 @@ public class PurgeKVTest {
 
         assertThat(run.getSize()).isEqualTo(1L);
 
-        kvs = kvStore.list(Pageable.UNPAGED, Collections.emptyList(), true, true, FetchVersion.ALL);
+        kvs = kvStoreService.list(Pageable.UNPAGED, MAIN_TENANT, namespace, Collections.emptyList(), true, true, FetchVersion.ALL);
         assertThat(kvs.size()).isEqualTo(1);
         assertThat(kvs.getFirst().description()).isEqualTo(changedDescription);
     }
@@ -276,7 +280,7 @@ public class PurgeKVTest {
         String thirdDescription = "Yet another description";
         kvStore.put("my-key", new KVValueAndMetadata(new KVMetadata(thirdDescription, Instant.now().plus(Duration.ofMinutes(5))), "some value"));
 
-        List<KVEntry> kvs = kvStore.list(Pageable.UNPAGED, Collections.emptyList(), true, true, FetchVersion.ALL);
+        List<KVEntry> kvs = kvStoreService.list(Pageable.UNPAGED, MAIN_TENANT, namespace, Collections.emptyList(), true, true, FetchVersion.ALL);
         assertThat(kvs.size()).isEqualTo(3);
 
         PurgeKV purgeKV = PurgeKV.builder()
@@ -287,7 +291,7 @@ public class PurgeKVTest {
 
         assertThat(run.getSize()).isEqualTo(1L);
 
-        kvs = kvStore.list(Pageable.UNPAGED, Collections.emptyList(), true, true, FetchVersion.ALL);
+        kvs = kvStoreService.list(Pageable.UNPAGED, MAIN_TENANT, namespace,Collections.emptyList(), true, true, FetchVersion.ALL);
         assertThat(kvs.size()).isEqualTo(2);
         assertThat(kvs.stream().map(KVEntry::description)).containsExactlyInAnyOrder(secondDescription, thirdDescription);
     }

--- a/webserver/src/main/java/io/kestra/webserver/controllers/api/KVController.java
+++ b/webserver/src/main/java/io/kestra/webserver/controllers/api/KVController.java
@@ -6,9 +6,8 @@ import io.kestra.core.exceptions.ResourceExpiredException;
 import io.kestra.core.models.QueryFilter;
 import io.kestra.core.models.kv.KVType;
 import io.kestra.core.models.namespaces.NamespaceInterface;
-import io.kestra.core.repositories.KvMetadataRepositoryInterface;
 import io.kestra.core.serializers.JacksonMapper;
-import io.kestra.core.storages.StorageInterface;
+import io.kestra.core.services.KVStoreService;
 import io.kestra.core.storages.kv.*;
 import io.kestra.core.tenant.TenantService;
 import io.kestra.webserver.converters.QueryFilterFormat;
@@ -37,11 +36,9 @@ import java.util.*;
 @Validated
 @Controller("/api/v1/{tenant}")
 public class KVController {
-    @Inject
-    private KvMetadataRepositoryInterface kvMetadataRepository;
 
     @Inject
-    private StorageInterface storageInterface;
+    private KVStoreService kvStoreService;
 
     @Inject
     protected TenantService tenantService;
@@ -62,7 +59,7 @@ public class KVController {
         @Parameter(description = "The sort of current page") @Nullable @QueryValue(value = "sort") List<String> sort,
         @Parameter(description = "Filters") @QueryFilterFormat List<QueryFilter> filters
         ) throws IOException {
-        return PagedResults.of(globalKvStore().list(PageableUtils.from(page, size, sort, this::sortMapper), filters));
+        return PagedResults.of(kvStoreService.list(PageableUtils.from(page, size, sort, this::sortMapper), tenantService.resolveTenant(), null, filters));
     }
 
     @ExecuteOn(TaskExecutors.IO)
@@ -84,17 +81,17 @@ public class KVController {
         List<String> namespaces = NamespaceInterface.asTree(namespace).stream()
             .filter(ns -> !ns.equals(namespace))
             .toList();
-        return getKvEntriesWithInheritance(namespaces);
+        return getKvEntriesWithInheritance(tenantService.resolveTenant(), namespaces);
     }
 
-    protected List<KVEntry> getKvEntriesWithInheritance(List<String> namespaces) throws IOException {
+    protected List<KVEntry> getKvEntriesWithInheritance(String tenant, List<String> namespaces) throws IOException {
         List<KVEntry> kvEntries = new ArrayList<>();
         Set<String> keys = new HashSet<>();
         List<String> sortedNamespaces = namespaces.stream()
             .sorted(Comparator.comparingInt(String::length).reversed())
             .toList();
         for (String ns : sortedNamespaces) {
-            List<KVEntry> entries = kvStore(ns).list(Pageable.UNPAGED);
+            List<KVEntry> entries = kvStoreService.list(Pageable.UNPAGED, tenant, ns);
             entries.forEach(key -> {
                 if (!keys.contains(key.key())) {
                     keys.add(key.key());
@@ -183,6 +180,10 @@ public class KVController {
         return HttpResponse.ok(new ApiDeleteBulkResponse(deletedKeys));
     }
 
+    protected KVStore kvStore(String namespace) {
+        return kvStoreService.get(tenantService.resolveTenant(), namespace);
+    }
+    
     /**
      * API Response for the bulk-delete operation.
      *
@@ -212,20 +213,6 @@ public class KVController {
         public List<String> keys() {
             return Optional.ofNullable(keys).orElse(List.of());
         }
-    }
-
-    protected KVStore globalKvStore() {
-        return new InternalKVStore(tenantService.resolveTenant(), null, storageInterface, kvMetadataRepository);
-    }
-
-    /**
-     * Create a new {@link KVStore} facade for the given namespace.
-     *
-     * @param namespace the namespace of the KV Store.
-     * @return a new {@link KVStore}.
-     */
-    protected KVStore kvStore(final String namespace) {
-        return new InternalKVStore(tenantService.resolveTenant(), namespace, storageInterface, kvMetadataRepository);
     }
 
     public record KvDetail(

--- a/webserver/src/test/java/io/kestra/webserver/controllers/api/KVControllerTest.java
+++ b/webserver/src/test/java/io/kestra/webserver/controllers/api/KVControllerTest.java
@@ -5,6 +5,7 @@ import io.kestra.core.junit.annotations.KestraTest;
 import io.kestra.core.models.kv.KVType;
 import io.kestra.core.models.kv.PersistedKvMetadata;
 import io.kestra.core.repositories.KvMetadataRepositoryInterface;
+import io.kestra.core.runners.KVMetadataStateStore;
 import io.kestra.core.storages.StorageInterface;
 import io.kestra.core.storages.kv.*;
 import io.kestra.core.utils.TestsUtils;
@@ -62,6 +63,9 @@ class KVControllerTest {
     @Inject
     private KvMetadataRepositoryInterface kvMetadataRepository;
 
+    @Inject
+    private KVMetadataStateStore kvMetadataStateStore;
+
     @BeforeEach
     public void init() throws IOException {
         storageInterface.delete(MAIN_TENANT, NAMESPACE, toKVUri(NAMESPACE, null));
@@ -73,9 +77,9 @@ class KVControllerTest {
     @Test
     void listAllKeys() throws IOException {
         String namespace = TestsUtils.randomNamespace();
-        KVStore kvStore = new InternalKVStore(MAIN_TENANT, namespace, storageInterface, kvMetadataRepository);
+        KVStore kvStore = new InternalKVStore(MAIN_TENANT, namespace, storageInterface, kvMetadataStateStore);
         String secondNamespace = TestsUtils.randomNamespace();
-        KVStore secondKvStore = new InternalKVStore(MAIN_TENANT, secondNamespace, storageInterface, kvMetadataRepository);
+        KVStore secondKvStore = new InternalKVStore(MAIN_TENANT, secondNamespace, storageInterface, kvMetadataStateStore);
 
         // Should come first in key:desc order
         String namespaceKey = "namespace-key";
@@ -256,7 +260,7 @@ class KVControllerTest {
     }
 
     private InternalKVStore kvStore(String namespace) {
-        return new InternalKVStore(MAIN_TENANT, namespace, storageInterface, kvMetadataRepository);
+        return new InternalKVStore(MAIN_TENANT, namespace, storageInterface, kvMetadataStateStore);
     }
 
     @Test

--- a/worker-controller/src/main/java/io/kestra/controller/grpc/services/GrpcKVMetadataControllerService.java
+++ b/worker-controller/src/main/java/io/kestra/controller/grpc/services/GrpcKVMetadataControllerService.java
@@ -1,0 +1,153 @@
+package io.kestra.controller.grpc.services;
+
+import io.grpc.stub.StreamObserver;
+import io.kestra.controller.grpc.BooleanResponse;
+import io.kestra.controller.grpc.KVMetadataRequest;
+import io.kestra.controller.grpc.KVMetadataServiceGrpc;
+import io.kestra.controller.grpc.NamespaceRequest;
+import io.kestra.controller.grpc.OpaqueData;
+import io.kestra.controller.grpc.WorkerControllerService;
+import io.kestra.controller.messages.MessageFormat;
+import io.kestra.controller.messages.MessageFormats;
+import io.kestra.controller.messages.RequestOrResponseHeaderFactory;
+import io.kestra.core.models.kv.PersistedKvMetadata;
+import io.kestra.core.runners.KVMetadataStateStore;
+import io.kestra.core.worker.models.WorkerInfo;
+import io.micronaut.context.annotation.Requires;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * gRPC service implementation for KV metadata operations.
+ * Provides worker-safe KV metadata read/write to workers via gRPC.
+ */
+@Singleton
+@Requires(property = "kestra.server-type", pattern = "(CONTROLLER|STANDALONE)")
+public class GrpcKVMetadataControllerService extends KVMetadataServiceGrpc.KVMetadataServiceImplBase implements WorkerControllerService {
+
+    private static final Logger log = LoggerFactory.getLogger(GrpcKVMetadataControllerService.class);
+    private static final MessageFormat MESSAGE_FORMAT = MessageFormats.JSON;
+
+    private final KVMetadataStateStore kvMetadataStateStore;
+    private final WorkerInfo workerInfo;
+
+    @Inject
+    public GrpcKVMetadataControllerService(final KVMetadataStateStore kvMetadataStateStore,
+                                           final WorkerInfo workerInfo) {
+        this.kvMetadataStateStore = kvMetadataStateStore;
+        this.workerInfo = workerInfo;
+    }
+
+    @Override
+    public void findByName(KVMetadataRequest request, StreamObserver<OpaqueData> responseObserver) {
+        try {
+            log.trace("Received findByName request: tenantId={}, namespace={}, name={}",
+                request.getTenantId(), request.getNamespace(), request.getName());
+
+            Optional<PersistedKvMetadata> result = kvMetadataStateStore.findByName(
+                request.getTenantId(), request.getNamespace(), request.getName());
+
+            OpaqueData response = OpaqueData.newBuilder()
+                .setHeader(RequestOrResponseHeaderFactory.create(workerInfo.getWorkerId()))
+                .setMessage(MESSAGE_FORMAT.toByteString(result.orElse(null)))
+                .build();
+
+            responseObserver.onNext(response);
+            responseObserver.onCompleted();
+        } catch (Exception e) {
+            log.error("Error during findByName", e);
+            responseObserver.onError(e);
+        }
+    }
+
+    @Override
+    public void find(NamespaceRequest request, StreamObserver<OpaqueData> responseObserver) {
+        try {
+            String tenantId = request.getTenantId();
+            String namespace = request.getNamespace();
+
+            log.trace("Received find request: tenantId={}, namespace={}", tenantId, namespace);
+
+            List<PersistedKvMetadata> result = kvMetadataStateStore.find(tenantId, namespace);
+
+            OpaqueData response = OpaqueData.newBuilder()
+                .setHeader(RequestOrResponseHeaderFactory.create(workerInfo.getWorkerId()))
+                .setMessage(MESSAGE_FORMAT.toByteString(result))
+                .build();
+
+            responseObserver.onNext(response);
+            responseObserver.onCompleted();
+        } catch (Exception e) {
+            log.error("Error during find", e);
+            responseObserver.onError(e);
+        }
+    }
+
+    @Override
+    public void existsByNamespace(NamespaceRequest request, StreamObserver<BooleanResponse> responseObserver) {
+        try {
+            log.trace("Received existsByNamespace request: tenantId={}, namespace={}",
+                request.getTenantId(), request.getNamespace());
+
+            boolean exists = kvMetadataStateStore.existsByNamespace(request.getTenantId(), request.getNamespace());
+
+            BooleanResponse response = BooleanResponse.newBuilder()
+                .setHeader(RequestOrResponseHeaderFactory.create(workerInfo.getWorkerId()))
+                .setValue(exists)
+                .build();
+
+            responseObserver.onNext(response);
+            responseObserver.onCompleted();
+        } catch (Exception e) {
+            log.error("Error during existsByNamespace", e);
+            responseObserver.onError(e);
+        }
+    }
+
+    @Override
+    public void save(OpaqueData request, StreamObserver<OpaqueData> responseObserver) {
+        try {
+            log.trace("Received save request");
+
+            PersistedKvMetadata item = MESSAGE_FORMAT.fromByteString(request.getMessage(), PersistedKvMetadata.class);
+
+            PersistedKvMetadata result = kvMetadataStateStore.save(item);
+
+            OpaqueData response = OpaqueData.newBuilder()
+                .setHeader(RequestOrResponseHeaderFactory.create(workerInfo.getWorkerId()))
+                .setMessage(MESSAGE_FORMAT.toByteString(result))
+                .build();
+
+            responseObserver.onNext(response);
+            responseObserver.onCompleted();
+        } catch (Exception e) {
+            log.error("Error during save", e);
+            responseObserver.onError(e);
+        }
+    }
+
+    @Override
+    public void deleteByName(KVMetadataRequest request, StreamObserver<OpaqueData> responseObserver) {
+        try {
+            log.trace("Received delete request");
+
+            Optional<PersistedKvMetadata> result = kvMetadataStateStore.deleteByName(request.getTenantId(), request.getNamespace(), request.getName());
+
+            OpaqueData response = OpaqueData.newBuilder()
+                .setHeader(RequestOrResponseHeaderFactory.create(workerInfo.getWorkerId()))
+                .setMessage(MESSAGE_FORMAT.toByteString(result.orElse(null)))
+                .build();
+
+            responseObserver.onNext(response);
+            responseObserver.onCompleted();
+        } catch (Exception e) {
+            log.error("Error during delete", e);
+            responseObserver.onError(e);
+        }
+    }
+}

--- a/worker-controller/src/main/proto/metastore.proto
+++ b/worker-controller/src/main/proto/metastore.proto
@@ -10,13 +10,33 @@ service WorkerFlowMetaStoreService {
   rpc IsNamespaceExists(NamespaceRequest) returns (BooleanResponse);
 }
 
+// Service for KV metadata operations - provides KV metadata read/write to workers.
+// Only exposes worker-safe operations. Server-only operations (paginated listing,
+// version-aware queries, purge) require direct repository access.
+service KVMetadataService {
+  // Find a KV metadata entry by tenant, namespace, and name
+  rpc findByName(KVMetadataRequest) returns (OpaqueData);
+
+  // Find all non-deleted, non-expired KV metadata entries for a tenant and namespace
+  rpc find(NamespaceRequest) returns (OpaqueData);
+
+  // Check whether any non-deleted, non-expired KV entries exist in a namespace
+  rpc existsByNamespace(NamespaceRequest) returns (BooleanResponse);
+
+  // Save a KV metadata entry
+  rpc save(OpaqueData) returns (OpaqueData);
+
+  // Soft-delete a KV metadata entry
+  rpc deleteByName(KVMetadataRequest) returns (OpaqueData);
+}
+
 // Request to check if a namespace exists
 message NamespaceRequest {
   RequestOrResponseHeader header = 1;
   // The tenant ID
   string tenant_id = 2;
   // The namespace name
-  string namespace = 3;
+  optional string namespace = 3;
 }
 
 // Request to check if a namespace exists
@@ -24,4 +44,15 @@ message TenantRequest {
   RequestOrResponseHeader header = 1;
   // The tenant ID
   string tenant_id = 2;
+}
+
+// Request to find a KV metadata entry by name
+message KVMetadataRequest {
+  RequestOrResponseHeader header = 1;
+  // The tenant ID
+  string tenant_id = 2;
+  // The namespace name
+  string namespace = 3;
+  // The KV metadata entry name
+  string name = 4;
 }

--- a/worker/src/main/java/io/kestra/worker/GrpcStubFactory.java
+++ b/worker/src/main/java/io/kestra/worker/GrpcStubFactory.java
@@ -3,6 +3,8 @@ package io.kestra.worker;
 import io.kestra.controller.GrpcChannelManager;
 import io.kestra.controller.grpc.ConnectControllerServiceGrpc;
 import io.kestra.controller.grpc.ConnectControllerServiceGrpc.ConnectControllerServiceBlockingStub;
+import io.kestra.controller.grpc.KVMetadataServiceGrpc;
+import io.kestra.controller.grpc.KVMetadataServiceGrpc.KVMetadataServiceBlockingStub;
 import io.kestra.controller.grpc.LivenessControllerServiceGrpc;
 import io.kestra.controller.grpc.LivenessControllerServiceGrpc.LivenessControllerServiceBlockingStub;
 import io.kestra.controller.grpc.WorkerControllerServiceGrpc;
@@ -52,5 +54,11 @@ public class GrpcStubFactory {
     @Singleton
     public WorkerFlowMetaStoreServiceBlockingStub workerFlowMetaStoreServiceBlockingStub() {
         return WorkerFlowMetaStoreServiceGrpc.newBlockingStub(grpcChannelManager.getDefaultChannel());
+    }
+
+    @Bean
+    @Singleton
+    public KVMetadataServiceBlockingStub kvMetadataServiceBlockingStub() {
+        return KVMetadataServiceGrpc.newBlockingStub(grpcChannelManager.getDefaultChannel());
     }
 }

--- a/worker/src/main/java/io/kestra/worker/stores/GrpcWorkerKVMetadataStateStore.java
+++ b/worker/src/main/java/io/kestra/worker/stores/GrpcWorkerKVMetadataStateStore.java
@@ -1,0 +1,133 @@
+package io.kestra.worker.stores;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import io.kestra.controller.grpc.BooleanResponse;
+import io.kestra.controller.grpc.KVMetadataRequest;
+import io.kestra.controller.grpc.KVMetadataServiceGrpc;
+import io.kestra.controller.grpc.NamespaceRequest;
+import io.kestra.controller.grpc.OpaqueData;
+import io.kestra.controller.messages.MessageFormat;
+import io.kestra.controller.messages.MessageFormats;
+import io.kestra.controller.messages.RequestOrResponseHeaderFactory;
+import io.kestra.core.models.kv.PersistedKvMetadata;
+import io.kestra.core.runners.DefaultKVMetadataStateStore;
+import io.kestra.core.runners.KVMetadataStateStore;
+import io.kestra.core.worker.models.WorkerInfo;
+import io.micronaut.context.annotation.Replaces;
+import io.micronaut.context.annotation.Requires;
+import jakarta.annotation.Nullable;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+import lombok.extern.slf4j.Slf4j;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Worker-side implementation of {@link KVMetadataStateStore} that communicates
+ * with the controller via gRPC.
+ * <p>
+ * This implementation is used only by workers and replaces the default implementation
+ * that uses repositories (which are not available to workers).
+ * Only exposes worker-safe operations.
+ */
+@Singleton
+@Slf4j
+@Requires(property = "kestra.server-type", value = "WORKER")
+@Replaces(DefaultKVMetadataStateStore.class)
+public class GrpcWorkerKVMetadataStateStore implements KVMetadataStateStore {
+
+    private static final MessageFormat MESSAGE_FORMAT = MessageFormats.JSON;
+    private static final TypeReference<List<PersistedKvMetadata>> LIST_TYPE = new TypeReference<>() {};
+
+    private final KVMetadataServiceGrpc.KVMetadataServiceBlockingStub kvMetadataStub;
+    private final WorkerInfo workerInfo;
+
+    @Inject
+    public GrpcWorkerKVMetadataStateStore(final KVMetadataServiceGrpc.KVMetadataServiceBlockingStub kvMetadataStub,
+                                          final WorkerInfo workerInfo) {
+        this.kvMetadataStub = kvMetadataStub;
+        this.workerInfo = workerInfo;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public Optional<PersistedKvMetadata> findByName(String tenantId, String namespace, String name) {
+        log.trace("Fetching KV metadata by name via gRPC: tenantId={}, namespace={}, name={}", tenantId, namespace, name);
+
+        KVMetadataRequest request = KVMetadataRequest.newBuilder()
+            .setHeader(RequestOrResponseHeaderFactory.create(workerInfo.getWorkerId()))
+            .setTenantId(tenantId)
+            .setNamespace(namespace)
+            .setName(name)
+            .build();
+
+        OpaqueData response = kvMetadataStub.findByName(request);
+
+        return Optional.ofNullable(MESSAGE_FORMAT.fromByteString(response.getMessage(), PersistedKvMetadata.class));
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public List<PersistedKvMetadata> find(String tenantId, @Nullable String namespace) {
+        log.trace("Fetching KV metadata via gRPC find: tenantId={}, namespace={}", tenantId, namespace);
+
+        NamespaceRequest request = NamespaceRequest.newBuilder()
+            .setHeader(RequestOrResponseHeaderFactory.create(workerInfo.getWorkerId()))
+            .setTenantId(tenantId)
+            .setNamespace(namespace)
+            .build();
+
+        OpaqueData response = kvMetadataStub.find(request);
+
+        return MESSAGE_FORMAT.fromByteString(response.getMessage(), LIST_TYPE);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public boolean existsByNamespace(String tenantId, String namespace) {
+        log.trace("Checking KV existence by namespace via gRPC: tenantId={}, namespace={}", tenantId, namespace);
+
+        NamespaceRequest request = NamespaceRequest.newBuilder()
+            .setHeader(RequestOrResponseHeaderFactory.create(workerInfo.getWorkerId()))
+            .setTenantId(tenantId)
+            .setNamespace(namespace)
+            .build();
+
+        BooleanResponse response = kvMetadataStub.existsByNamespace(request);
+
+        return response.getValue();
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public PersistedKvMetadata save(PersistedKvMetadata item) {
+        log.trace("Saving KV metadata via gRPC: namespace={}, name={}", item.getNamespace(), item.getName());
+
+        OpaqueData request = OpaqueData.newBuilder()
+            .setHeader(RequestOrResponseHeaderFactory.create(workerInfo.getWorkerId()))
+            .setMessage(MESSAGE_FORMAT.toByteString(item))
+            .build();
+
+        OpaqueData response = kvMetadataStub.save(request);
+
+        return MESSAGE_FORMAT.fromByteString(response.getMessage(), PersistedKvMetadata.class);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public PersistedKvMetadata delete(PersistedKvMetadata item) throws IOException {
+        log.trace("Deleting KV metadata via gRPC: namespace={}, name={}", item.getNamespace(), item.getName());
+
+        KVMetadataRequest request = KVMetadataRequest.newBuilder()
+            .setHeader(RequestOrResponseHeaderFactory.create(workerInfo.getWorkerId()))
+            .setTenantId(item.getTenantId())
+            .setNamespace(item.getNamespace())
+            .setName(item.getName())
+            .build();
+        OpaqueData response = kvMetadataStub.deleteByName(request);
+
+        return MESSAGE_FORMAT.fromByteString(response.getMessage(), PersistedKvMetadata.class);
+    }
+}


### PR DESCRIPTION
- Add new gRPC service to manage KVMetadata
- Add new KVMetadataStateStore abstraction with repository and gRPC-based implementation
- Remove server-side methods from KVStore interface to exposes only worker-safe operations.
- Extract ExtendedKVStore interface to expose server-side methods
- Refactor KV core tasks

