### PR TITLE
fix(core): make Namespace (files storage) compatible with gRPC-based worker

### DIFF
--- a/core/src/main/java/io/kestra/core/namespace/DefaultNamespaceFileMetadataStateStore.java
+++ b/core/src/main/java/io/kestra/core/namespace/DefaultNamespaceFileMetadataStateStore.java
@@ -1,0 +1,133 @@
+package io.kestra.core.namespace;
+
+import io.kestra.core.models.FetchVersion;
+import io.kestra.core.models.QueryFilter;
+import io.kestra.core.models.namespaces.files.NamespaceFileMetadata;
+import io.kestra.core.repositories.NamespaceFileMetadataRepositoryInterface;
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.data.model.Pageable;
+import jakarta.annotation.Nullable;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+/**
+ * Default implementation of {@link NamespaceFileMetadataStateStore} that delegates
+ * directly to {@link NamespaceFileMetadataRepositoryInterface}.
+ * <p>
+ * This implementation is active on controller, webserver, and standalone servers
+ * where the repository is available. Workers use a gRPC-based implementation instead.
+ */
+@Singleton
+@Requires(property = "kestra.server-type", notEquals = "WORKER")
+public class DefaultNamespaceFileMetadataStateStore implements NamespaceFileMetadataStateStore {
+
+    private final NamespaceFileMetadataRepositoryInterface repository;
+
+    @Inject
+    public DefaultNamespaceFileMetadataStateStore(NamespaceFileMetadataRepositoryInterface repository) {
+        this.repository = repository;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public Optional<NamespaceFileMetadata> findByPath(String tenantId, String namespace, String path, @Nullable Integer version, boolean allowDeleted) throws IOException {
+        if (version != null) {
+            return repository.find(Pageable.from(1, 1), tenantId, List.of(
+                QueryFilter.builder().field(QueryFilter.Field.NAMESPACE).operation(QueryFilter.Op.EQUALS).value(namespace).build(),
+                QueryFilter.builder().field(QueryFilter.Field.PATH).operation(QueryFilter.Op.EQUALS).value(path).build(),
+                QueryFilter.builder().field(QueryFilter.Field.VERSION).operation(QueryFilter.Op.EQUALS).value(version).build()
+            ), allowDeleted, FetchVersion.ALL).stream().findFirst();
+        }
+
+        return repository.findByPath(tenantId, namespace, path).filter(m -> allowDeleted || !m.isDeleted());
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public List<NamespaceFileMetadata> findChildren(String tenantId, String namespace, @Nullable String parentPath, boolean recursive) {
+        String normalizedParentPath = parentPath;
+        if (normalizedParentPath != null && !normalizedParentPath.endsWith("/")) {
+            normalizedParentPath = normalizedParentPath + "/";
+        }
+
+        List<QueryFilter> filters = new java.util.ArrayList<>(List.of(
+            QueryFilter.builder().field(QueryFilter.Field.NAMESPACE).operation(QueryFilter.Op.EQUALS).value(namespace).build()
+        ));
+
+        if (normalizedParentPath != null) {
+            filters.add(QueryFilter.builder()
+                .field(QueryFilter.Field.PARENT_PATH)
+                .operation(recursive ? QueryFilter.Op.STARTS_WITH : QueryFilter.Op.EQUALS)
+                .value(normalizedParentPath)
+                .build());
+        }
+
+        return repository.find(Pageable.UNPAGED, tenantId, filters, false);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public List<NamespaceFileMetadata> findAll(String tenantId, String namespace, @Nullable String containing) {
+        List<QueryFilter> filters = Stream.concat(
+            Stream.of(QueryFilter.builder().field(QueryFilter.Field.NAMESPACE).operation(QueryFilter.Op.EQUALS).value(namespace).build()),
+            Optional.ofNullable(containing).flatMap(p -> {
+                if (p.equals("/")) {
+                    return Optional.empty();
+                }
+                return Optional.of(QueryFilter.builder().field(QueryFilter.Field.QUERY).operation(QueryFilter.Op.EQUALS).value(p).build());
+            }).stream()
+        ).toList();
+
+        return repository.find(Pageable.UNPAGED, tenantId, filters, false);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public List<NamespaceFileMetadata> findByPaths(String tenantId, String namespace, List<String> paths, boolean allowDeleted) {
+        return repository.find(Pageable.UNPAGED, tenantId, List.of(
+            QueryFilter.builder().field(QueryFilter.Field.NAMESPACE).operation(QueryFilter.Op.EQUALS).value(namespace).build(),
+            QueryFilter.builder().field(QueryFilter.Field.PATH).operation(QueryFilter.Op.IN).value(paths).build()
+        ), allowDeleted);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public List<NamespaceFileMetadata> findAllVersionsByPaths(String tenantId, String namespace, List<String> paths) {
+        return repository.find(Pageable.UNPAGED, tenantId, List.of(
+            QueryFilter.builder().field(QueryFilter.Field.NAMESPACE).operation(QueryFilter.Op.EQUALS).value(namespace).build(),
+            QueryFilter.builder().field(QueryFilter.Field.PATH).operation(QueryFilter.Op.IN).value(paths).build()
+        ), true, FetchVersion.ALL);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public boolean existsByNamespace(String tenantId, String namespace) {
+        return !repository.find(
+            Pageable.from(1, 1),
+            tenantId,
+            List.of(QueryFilter.builder()
+                .field(QueryFilter.Field.NAMESPACE)
+                .operation(QueryFilter.Op.EQUALS)
+                .value(namespace)
+                .build()),
+            false
+        ).isEmpty();
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public NamespaceFileMetadata save(NamespaceFileMetadata item) {
+        return repository.save(item);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public NamespaceFileMetadata delete(NamespaceFileMetadata item) throws IOException {
+        return repository.delete(item);
+    }
+}

--- a/core/src/main/java/io/kestra/core/namespace/NamespaceFileMetadataStateStore.java
+++ b/core/src/main/java/io/kestra/core/namespace/NamespaceFileMetadataStateStore.java
@@ -1,0 +1,110 @@
+package io.kestra.core.namespace;
+
+import io.kestra.core.models.namespaces.files.NamespaceFileMetadata;
+import jakarta.annotation.Nullable;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Abstraction layer for namespace file metadata operations, used by {@link io.kestra.core.storages.InternalNamespace}.
+ * <p>
+ * On controller/webserver/standalone servers, the default implementation delegates directly to
+ * {@link io.kestra.core.repositories.NamespaceFileMetadataRepositoryInterface}.
+ * On workers, a gRPC-based implementation communicates with the controller.
+ * <p>
+ * This interface only exposes worker-safe operations. Server-only operations (paginated listing with
+ * advanced filters, version-aware queries, purge) require direct access to
+ * {@link io.kestra.core.repositories.NamespaceFileMetadataRepositoryInterface}.
+ */
+public interface NamespaceFileMetadataStateStore {
+
+    /**
+     * Find a namespace file metadata entry by tenant, namespace, and path.
+     * Optionally filter by a specific version and/or include deleted entries.
+     *
+     * @param tenantId     the tenant ID
+     * @param namespace    the namespace
+     * @param path         the file path
+     * @param version      optional version number (if {@code null}, returns the latest non-deleted entry)
+     * @param allowDeleted whether to include deleted entries
+     * @return an optional namespace file metadata entry
+     * @throws IOException if an I/O error occurs
+     */
+    Optional<NamespaceFileMetadata> findByPath(String tenantId, String namespace, String path, @Nullable Integer version, boolean allowDeleted) throws IOException;
+
+    /**
+     * Find all non-deleted namespace file metadata entries for a given tenant and namespace,
+     * optionally filtered by path prefix and containing text.
+     *
+     * @param tenantId  the tenant ID
+     * @param namespace the namespace
+     * @param parentPath optional parent path prefix filter (for children queries)
+     * @param recursive  whether to search recursively under parentPath
+     * @return list of active namespace file metadata entries
+     */
+    List<NamespaceFileMetadata> findChildren(String tenantId, String namespace, @Nullable String parentPath, boolean recursive);
+
+    /**
+     * Find all non-deleted namespace file metadata entries for a given tenant and namespace,
+     * optionally filtered by a containing substring.
+     *
+     * @param tenantId   the tenant ID
+     * @param namespace  the namespace
+     * @param containing optional path substring filter (can be {@code null})
+     * @return list of active namespace file metadata entries
+     */
+    List<NamespaceFileMetadata> findAll(String tenantId, String namespace, @Nullable String containing);
+
+    /**
+     * Find namespace file metadata entries by tenant, namespace, and a list of paths.
+     * Used for move and delete operations.
+     *
+     * @param tenantId     the tenant ID
+     * @param namespace    the namespace
+     * @param paths        the list of paths to search for
+     * @param allowDeleted whether to include deleted entries
+     * @return list of matching namespace file metadata entries
+     */
+    List<NamespaceFileMetadata> findByPaths(String tenantId, String namespace, List<String> paths, boolean allowDeleted);
+
+    /**
+     * Find all versions of namespace file metadata entries by tenant, namespace, and a list of paths.
+     * Used for move operations that need to access version history.
+     *
+     * @param tenantId     the tenant ID
+     * @param namespace    the namespace
+     * @param paths        the list of paths to search for
+     * @return list of all versions of matching namespace file metadata entries
+     */
+    List<NamespaceFileMetadata> findAllVersionsByPaths(String tenantId, String namespace, List<String> paths);
+
+    /**
+     * Check whether any non-deleted namespace file entries exist in the given namespace.
+     *
+     * @param tenantId  the tenant ID
+     * @param namespace the namespace
+     * @return {@code true} if at least one active namespace file entry exists
+     */
+    boolean existsByNamespace(String tenantId, String namespace);
+
+    /**
+     * Save a namespace file metadata entry.
+     *
+     * @param item the namespace file metadata entry to save
+     * @return the saved namespace file metadata entry
+     */
+    NamespaceFileMetadata save(NamespaceFileMetadata item);
+
+    /**
+     * Soft-delete a namespace file metadata entry.
+     *
+     * @param item the namespace file metadata entry to delete
+     * @return the deleted namespace file metadata entry
+     * @throws IOException if an I/O error occurs
+     */
+    default NamespaceFileMetadata delete(NamespaceFileMetadata item) throws IOException {
+        return this.save(item.toDeleted());
+    }
+}

--- a/core/src/main/java/io/kestra/core/namespace/NamespaceFileService.java
+++ b/core/src/main/java/io/kestra/core/namespace/NamespaceFileService.java
@@ -1,0 +1,155 @@
+package io.kestra.core.namespace;
+
+import io.kestra.core.models.FetchVersion;
+import io.kestra.core.models.QueryFilter;
+import io.kestra.core.models.namespaces.files.NamespaceFileMetadata;
+import io.kestra.core.repositories.ArrayListTotal;
+import io.kestra.core.repositories.NamespaceFileMetadataRepositoryInterface;
+import io.kestra.core.storages.NamespaceFile;
+import io.kestra.core.storages.StorageInterface;
+import io.micronaut.data.model.Pageable;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+import lombok.extern.slf4j.Slf4j;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+import static io.kestra.core.utils.Rethrow.throwFunction;
+
+/**
+ * Server-side service for namespace file operations that require direct repository access.
+ * <p>
+ * This includes paginated listing with advanced filters, version-aware queries, and purge operations.
+ * These operations cannot run on workers (which don't have access to repositories) and must be
+ * accessed via {@code DefaultRunContext.services().additionalService(NamespaceFileService.class)}.
+ *
+ * @see io.kestra.core.storages.Namespace for worker-safe operations
+ */
+@Singleton
+@Slf4j
+public class NamespaceFileService {
+
+    private final StorageInterface storage;
+
+    private final Optional<NamespaceFileMetadataRepositoryInterface> namespaceFileMetadataRepository;
+
+    @Inject
+    public NamespaceFileService(StorageInterface storage, 
+                                Optional<NamespaceFileMetadataRepositoryInterface> namespaceFileMetadataRepository) {
+        this.storage = storage;
+        this.namespaceFileMetadataRepository = namespaceFileMetadataRepository;
+    }
+
+    /**
+     * Lists namespace file entries with pagination, filtering, and version control.
+     *
+     * @param pageable      the pagination parameters.
+     * @param tenantId      the tenant ID.
+     * @param namespace     the namespace.
+     * @param filters       the query filters.
+     * @param allowDeleted  whether to include deleted entries.
+     * @param fetchBehavior the version fetch behavior.
+     * @return the paginated list of {@link NamespaceFile}.
+     */
+    public ArrayListTotal<NamespaceFile> find(Pageable pageable, String tenantId, String namespace, List<QueryFilter> filters, boolean allowDeleted, FetchVersion fetchBehavior) {
+        List<QueryFilter> allFilters = Stream.concat(
+            Stream.of(QueryFilter.builder().field(QueryFilter.Field.NAMESPACE).operation(QueryFilter.Op.EQUALS).value(namespace).build()),
+            filters.stream()
+        ).toList();
+
+        return getRepository().find(
+            pageable,
+            tenantId,
+            allFilters,
+            allowDeleted,
+            fetchBehavior
+        ).map(NamespaceFile::fromMetadata);
+    }
+
+    /**
+     * Lists all namespace file entries, including deleted ones, across all versions.
+     *
+     * @param tenantId  the tenant ID.
+     * @param namespace the namespace.
+     * @return the list of all {@link NamespaceFile}.
+     */
+    public List<NamespaceFile> listAll(String tenantId, String namespace) {
+        return this.find(Pageable.UNPAGED, tenantId, namespace, Collections.emptyList(), true, FetchVersion.ALL);
+    }
+
+    /**
+     * Purge (hard-delete) the provided namespace files. Removes both metadata and storage data.
+     *
+     * @param tenantId       the tenant ID.
+     * @param namespace      the namespace.
+     * @param namespaceFiles the files to purge.
+     * @return the number of purged files.
+     * @throws IOException if an error occurred while executing the purge operation.
+     */
+    public Integer purge(String tenantId, String namespace, List<NamespaceFile> namespaceFiles) throws IOException {
+        Integer purgedMetadataCount = getRepository().purge(
+            namespaceFiles.stream()
+                .map(nsFile -> NamespaceFileMetadata.builder()
+                    .tenantId(tenantId)
+                    .namespace(namespace)
+                    .path(nsFile.path())
+                    .version(nsFile.version())
+                    .build())
+                .toList()
+        );
+
+        long actualDeletedEntries = namespaceFiles.stream()
+            .map(nsFile -> nsFile.storagePath().toUri())
+            .map(throwFunction(uri -> storage.delete(tenantId, namespace, uri)))
+            .filter(Boolean::booleanValue)
+            .count();
+
+        if (actualDeletedEntries != purgedMetadataCount) {
+            log.warn(
+                "Namespace file metadata purge reported {} deleted entries, but {} values were actually deleted from storage",
+                purgedMetadataCount, actualDeletedEntries
+            );
+        }
+
+        return purgedMetadataCount;
+    }
+
+    /**
+     * Gets the namespace file revisions for a specific file path.
+     *
+     * @param tenantId  the tenant ID.
+     * @param namespace the namespace.
+     * @param path      the file path.
+     * @return the list of namespace file metadata for all versions.
+     */
+    public ArrayListTotal<NamespaceFileMetadata> findRevisions(String tenantId, String namespace, String path) {
+        return getRepository().find(Pageable.UNPAGED, tenantId, List.of(
+            QueryFilter.builder().field(QueryFilter.Field.NAMESPACE).operation(QueryFilter.Op.EQUALS).value(namespace).build(),
+            QueryFilter.builder().field(QueryFilter.Field.PATH).operation(QueryFilter.Op.EQUALS).value(path).build()
+        ), true, FetchVersion.ALL);
+    }
+
+    /**
+     * Finds namespace file metadata entries with pagination and filters.
+     * Used by the controller for deletion zombie-awareness checks.
+     *
+     * @param pageable     the pagination parameters.
+     * @param tenantId     the tenant ID.
+     * @param filters      the query filters.
+     * @param allowDeleted whether to include deleted entries.
+     * @return the paginated list of {@link NamespaceFileMetadata}.
+     */
+    public ArrayListTotal<NamespaceFileMetadata> findMetadata(Pageable pageable, String tenantId, List<QueryFilter> filters, boolean allowDeleted) {
+        return getRepository().find(pageable, tenantId, filters, allowDeleted);
+    }
+
+    private NamespaceFileMetadataRepositoryInterface getRepository() {
+        return this.namespaceFileMetadataRepository.orElseThrow(() ->
+            new IllegalStateException("The namespace file metadata repository is not available. This operation cannot be performed on a worker.")
+        );
+    }
+}

--- a/core/src/main/java/io/kestra/core/storages/InternalNamespace.java
+++ b/core/src/main/java/io/kestra/core/storages/InternalNamespace.java
@@ -1,11 +1,7 @@
 package io.kestra.core.storages;
 
-import io.kestra.core.models.FetchVersion;
-import io.kestra.core.models.QueryFilter;
 import io.kestra.core.models.namespaces.files.NamespaceFileMetadata;
-import io.kestra.core.repositories.ArrayListTotal;
-import io.kestra.core.repositories.NamespaceFileMetadataRepositoryInterface;
-import io.micronaut.data.model.Pageable;
+import io.kestra.core.namespace.NamespaceFileMetadataStateStore;
 import jakarta.annotation.Nullable;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.tuple.Pair;
@@ -19,13 +15,14 @@ import java.net.URISyntaxException;
 import java.nio.file.Path;
 import java.util.*;
 import java.util.function.Predicate;
-import java.util.stream.Stream;
 
 import static io.kestra.core.utils.Rethrow.throwFunction;
 
 /**
  * The default {@link Namespace} implementation.
  * This class acts as a facade to the {@link StorageInterface} for manipulating namespace files.
+ * <p>
+ * This implementation uses {@link NamespaceFileMetadataStateStore} and is safe to call from workers.
  *
  * @see Storage#namespace()
  * @see Storage#namespace(String)
@@ -36,46 +33,43 @@ public class InternalNamespace implements Namespace {
     private final String namespace;
     private final String tenant;
     private final StorageInterface storage;
-    private final NamespaceFileMetadataRepositoryInterface namespaceFileMetadataRepository;
+    private final NamespaceFileMetadataStateStore stateStore;
     private final Logger logger;
 
     /**
      * Creates a new {@link InternalNamespace} instance.
      *
-     * @param namespace The namespace
-     * @param storage   The storage.
+     * @param tenant     The tenant.
+     * @param namespace  The namespace.
+     * @param storage    The storage.
+     * @param stateStore The namespace file metadata state store (used for worker-safe operations).
      */
-    public InternalNamespace(@Nullable final String tenant, final String namespace, final StorageInterface storage, final NamespaceFileMetadataRepositoryInterface namespaceFileMetadataRepository) {
-        this(log, tenant, namespace, storage, namespaceFileMetadataRepository);
+    public InternalNamespace(final String tenant,
+                             final String namespace,
+                             final StorageInterface storage,
+                             final NamespaceFileMetadataStateStore stateStore) {
+        this(log, tenant, namespace, storage, stateStore);
     }
 
     /**
      * Creates a new {@link InternalNamespace} instance.
      *
-     * @param logger    The logger to be used by this class.
-     * @param namespace The namespace
-     * @param tenant    The tenant.
-     * @param storage   The storage.
+     * @param logger     The logger to be used by this class.
+     * @param tenant     The tenant.
+     * @param namespace  The namespace.
+     * @param storage    The storage.
+     * @param stateStore The namespace file metadata state store (used for worker-safe operations).
      */
-    public InternalNamespace(final Logger logger, @Nullable final String tenant, final String namespace, final StorageInterface storage, final NamespaceFileMetadataRepositoryInterface namespaceFileMetadataRepositoryInterface) {
+    public InternalNamespace(final Logger logger,
+                             final String tenant,
+                             final String namespace,
+                             final StorageInterface storage,
+                             final NamespaceFileMetadataStateStore stateStore) {
         this.logger = Objects.requireNonNull(logger, "logger cannot be null");
         this.namespace = Objects.requireNonNull(namespace, "namespace cannot be null");
         this.storage = Objects.requireNonNull(storage, "storage cannot be null");
-        this.namespaceFileMetadataRepository = Objects.requireNonNull(namespaceFileMetadataRepositoryInterface, "namespaceFileMetadataRepository cannot be null");
+        this.stateStore = Objects.requireNonNull(stateStore, "stateStore cannot be null");
         this.tenant = tenant;
-    }
-
-    @Override
-    public ArrayListTotal<NamespaceFile> find(Pageable pageable, List<QueryFilter> filters, boolean allowDeleted, FetchVersion fetchVersion) {
-        return namespaceFileMetadataRepository.find(
-            pageable,
-            tenant,
-            Stream.concat(filters.stream(), Stream.of(
-                QueryFilter.builder().field(QueryFilter.Field.NAMESPACE).operation(QueryFilter.Op.EQUALS).value(namespace).build()
-            )).toList(),
-            allowDeleted,
-            fetchVersion
-        ).map(throwFunction(NamespaceFile::fromMetadata));
     }
 
     /**
@@ -104,22 +98,16 @@ public class InternalNamespace implements Namespace {
      **/
     @Override
     public List<NamespaceFile> all(final String containing, boolean includeDirectories) throws IOException {
-        List<NamespaceFileMetadata> namespaceFilesMetadata = namespaceFileMetadataRepository.find(Pageable.UNPAGED, tenant, Stream.concat(
-            Stream.of(QueryFilter.builder().field(QueryFilter.Field.NAMESPACE).operation(QueryFilter.Op.EQUALS).value(namespace).build()),
-            Optional.ofNullable(containing).flatMap(p -> {
-                if (p.equals("/")) {
-                    return Optional.empty();
-                }
-
-                return Optional.of(QueryFilter.builder().field(QueryFilter.Field.QUERY).operation(QueryFilter.Op.EQUALS).value(p).build());
-            }).stream()
-        ).toList(), false);
+        List<NamespaceFileMetadata> namespaceFilesMetadata = stateStore.findAll(tenant, namespace, containing);
 
         if (!includeDirectories) {
             namespaceFilesMetadata = namespaceFilesMetadata.stream().filter(nsFileMetadata -> !nsFileMetadata.isDirectory()).toList();
         }
 
-        return namespaceFilesMetadata.stream().filter(nsFileMetadata -> !nsFileMetadata.getPath().equals("/")).map(nsFileMetadata -> NamespaceFile.of(namespace, Path.of(nsFileMetadata.getPath()), nsFileMetadata.getVersion())).toList();
+        return namespaceFilesMetadata.stream()
+            .filter(nsFileMetadata -> !nsFileMetadata.getPath().equals("/"))
+            .map(nsFileMetadata -> NamespaceFile.of(namespace, Path.of(nsFileMetadata.getPath()), nsFileMetadata.getVersion()))
+            .toList();
     }
 
     /**
@@ -129,16 +117,12 @@ public class InternalNamespace implements Namespace {
     public List<NamespaceFileMetadata> children(String parentPath, boolean recursive) throws IOException {
         final String normalizedParentPath = NamespaceFile.normalize(Path.of(parentPath)).toString();
 
-        return namespaceFileMetadataRepository.find(Pageable.UNPAGED, tenant, List.of(
-            QueryFilter.builder().field(QueryFilter.Field.NAMESPACE).operation(QueryFilter.Op.EQUALS).value(namespace).build(),
-            QueryFilter.builder()
-                .field(QueryFilter.Field.PARENT_PATH)
-                .operation(recursive ? QueryFilter.Op.STARTS_WITH : QueryFilter.Op.EQUALS)
-                .value(normalizedParentPath.endsWith("/") ? normalizedParentPath : normalizedParentPath + "/")
-                .build()
-        ), false);
+        return stateStore.findChildren(tenant, namespace, normalizedParentPath, recursive);
     }
 
+    /**
+     * {@inheritDoc}
+     **/
     @Override
     public List<Pair<NamespaceFile, NamespaceFile>> move(Path source, Path target) throws Exception {
         final Path normalizedSource = NamespaceFile.normalize(source);
@@ -152,12 +136,13 @@ public class InternalNamespace implements Namespace {
             ));
         }
 
-        ArrayListTotal<NamespaceFileMetadata> beforeRename = namespaceFileMetadataRepository.find(Pageable.UNPAGED, tenant, List.of(
-            QueryFilter.builder().field(QueryFilter.Field.NAMESPACE).operation(QueryFilter.Op.EQUALS).value(namespace).build(),
-            QueryFilter.builder().field(QueryFilter.Field.PATH).operation(QueryFilter.Op.IN).value(List.of(normalizedSource.toString(), normalizedSource + "/")).build()
-        ), true, FetchVersion.ALL);
+        List<NamespaceFileMetadata> beforeRename = stateStore.findAllVersionsByPaths(
+            tenant, namespace,
+            List.of(normalizedSource.toString(), normalizedSource + "/")
+        );
         beforeRename.sort(Comparator.comparing(NamespaceFileMetadata::getVersion));
-        ArrayListTotal<NamespaceFileMetadata> afterRename = beforeRename
+
+        List<NamespaceFileMetadata> afterRename = beforeRename.stream()
             .map(nsFileMetadata -> {
                 String newPath;
                 if (nsFileMetadata.isDirectory()) {
@@ -165,11 +150,11 @@ public class InternalNamespace implements Namespace {
                 } else {
                     newPath = normalizedTarget.toString();
                 }
-
                 return nsFileMetadata.toBuilder().path(newPath).build();
-            });
+            })
+            .toList();
 
-        return afterRename.map(throwFunction(nsFileMetadata -> {
+        return afterRename.stream().map(throwFunction(nsFileMetadata -> {
             NamespaceFile beforeNamespaceFile = NamespaceFile.of(namespace, normalizedSource, nsFileMetadata.getVersion());
             Path namespaceFilePath = beforeNamespaceFile.storagePath();
             NamespaceFile afterNamespaceFile;
@@ -181,9 +166,12 @@ public class InternalNamespace implements Namespace {
                 }
             }
 
-            this.purge(NamespaceFile.of(namespace, normalizedSource, nsFileMetadata.getVersion()));
+            // Hard-delete the old entry via storage
+            storage.delete(tenant, namespace, beforeNamespaceFile.storagePath().toUri());
+            // Purge the old metadata entry
+            stateStore.save(NamespaceFileMetadata.of(tenant, beforeNamespaceFile).toBuilder().deleted(true).build());
             return Pair.of(beforeNamespaceFile, afterNamespaceFile);
-        }));
+        })).toList();
     }
 
     /**
@@ -226,6 +214,9 @@ public class InternalNamespace implements Namespace {
         return storage.get(tenant, namespace, namespaceFilePath.toUri());
     }
 
+    /**
+     * {@inheritDoc}
+     **/
     @Override
     public FileAttributes getFileMetadata(Path path) throws IOException {
         final Path normalizedPath = NamespaceFile.normalize(path);
@@ -240,15 +231,7 @@ public class InternalNamespace implements Namespace {
     private Optional<NamespaceFileMetadata> findByPath(Path path, boolean allowDeleted, @Nullable Integer version) throws IOException {
         final Path normalizedPath = NamespaceFile.normalize(path);
 
-        if (version != null) {
-            return namespaceFileMetadataRepository.find(Pageable.from(1, 1), tenant, List.of(
-                QueryFilter.builder().field(QueryFilter.Field.NAMESPACE).operation(QueryFilter.Op.EQUALS).value(namespace).build(),
-                QueryFilter.builder().field(QueryFilter.Field.PATH).operation(QueryFilter.Op.EQUALS).value(normalizedPath.toString()).build(),
-                QueryFilter.builder().field(QueryFilter.Field.VERSION).operation(QueryFilter.Op.EQUALS).value(version).build()
-            ), allowDeleted, FetchVersion.ALL).stream().findFirst();
-        }
-        return namespaceFileMetadataRepository.findByPath(tenant, namespace, normalizedPath.toString())
-            .filter(namespaceFileMetadata -> allowDeleted || !namespaceFileMetadata.isDeleted());
+        return stateStore.findByPath(tenant, namespace, normalizedPath.toString(), version, allowDeleted);
     }
 
     private Optional<NamespaceFileMetadata> findByPath(Path path, boolean allowDeleted) throws IOException {
@@ -263,10 +246,12 @@ public class InternalNamespace implements Namespace {
         return findByPath(path, null);
     }
 
+    /**
+     * {@inheritDoc}
+     **/
     @Override
     public boolean exists(Path path) throws IOException {
         final Path normalizedPath = NamespaceFile.normalize(path);
-
         return findByPath(normalizedPath).isPresent();
     }
 
@@ -290,7 +275,7 @@ public class InternalNamespace implements Namespace {
 
             createdFiles.addAll(mkDirs(normalizedPath.toString()));
 
-            namespaceFileMetadataRepository.save(
+            stateStore.save(
                 NamespaceFileMetadata.builder()
                     .tenantId(tenant)
                     .namespace(namespace)
@@ -311,22 +296,14 @@ public class InternalNamespace implements Namespace {
 
             createdFiles.addAll(mkDirs(normalizedPath.toString()));
 
-            namespaceFileMetadataRepository.save(
+            stateStore.save(
                 inRepository.get().toBuilder().size(storage.getAttributes(tenant, namespace, cleanUri).getSize()).deleted(false).build()
             );
 
             if (inRepository.get().isDeleted()) {
-                logger.debug(String.format(
-                    "File '%s' added to namespace '%s'.",
-                    normalizedPath,
-                    namespace
-                ));
+                logger.debug("File '{}' added to namespace '{}'.", normalizedPath, namespace);
             } else {
-                logger.debug(String.format(
-                    "File '%s' overwritten into namespace '%s'.",
-                    normalizedPath,
-                    namespace
-                ));
+                logger.debug("File '{}' overwritten into namespace '{}'.", normalizedPath, namespace);
             }
 
             createdFiles.add(namespaceFile);
@@ -339,12 +316,7 @@ public class InternalNamespace implements Namespace {
                     namespace,
                     Conflicts.ERROR
                 ));
-                case SKIP -> logger.debug(String.format(
-                    "File '%s' already exists in namespace '%s' and conflict is set to %s. Skipping.",
-                    normalizedPath,
-                    namespace,
-                    Conflicts.SKIP
-                ));
+                case SKIP -> logger.debug("File '{}' already exists in namespace '{}' and conflict is set to {}. Skipping.", normalizedPath, namespace, Conflicts.SKIP);
             }
         }
 
@@ -375,7 +347,7 @@ public class InternalNamespace implements Namespace {
     public NamespaceFile createDirectory(Path path) throws IOException {
         final Path normalizedPath = NamespaceFile.normalize(path);
 
-        NamespaceFileMetadata nsFileMetadata = namespaceFileMetadataRepository.save(
+        NamespaceFileMetadata nsFileMetadata = stateStore.save(
             NamespaceFileMetadata.builder()
                 .tenantId(tenant)
                 .namespace(namespace)
@@ -395,46 +367,19 @@ public class InternalNamespace implements Namespace {
     public List<NamespaceFile> delete(Path path) throws IOException {
         final Path normalizedPath = NamespaceFile.normalize(path);
 
-        Optional<NamespaceFileMetadata> maybeNamespaceFileMetadata = namespaceFileMetadataRepository.find(Pageable.from(1, 1), tenant, List.of(
-            QueryFilter.builder().field(QueryFilter.Field.NAMESPACE).operation(QueryFilter.Op.EQUALS).value(namespace).build(),
-            QueryFilter.builder().field(QueryFilter.Field.PATH).operation(QueryFilter.Op.IN).value(List.of(normalizedPath.toString(), normalizedPath + "/")).build()
-        ), false).stream().findFirst();
+        List<NamespaceFileMetadata> matchingFiles = stateStore.findByPaths(
+            tenant, namespace,
+            List.of(normalizedPath.toString(), normalizedPath + "/"),
+            false
+        );
+        Optional<NamespaceFileMetadata> maybeNamespaceFileMetadata = matchingFiles.stream().findFirst();
 
-        List<NamespaceFileMetadata> toDelete = Stream.concat(
-            this.children(normalizedPath.toString(), true).stream().map(NamespaceFileMetadata::toDeleted),
-            maybeNamespaceFileMetadata.map(NamespaceFileMetadata::toDeleted).stream()
-        ).toList();
+        List<NamespaceFileMetadata> toDelete = new ArrayList<>();
+        toDelete.addAll(this.children(normalizedPath.toString(), true).stream().map(NamespaceFileMetadata::toDeleted).toList());
+        maybeNamespaceFileMetadata.map(NamespaceFileMetadata::toDeleted).ifPresent(toDelete::add);
 
-        toDelete.forEach(namespaceFileMetadataRepository::save);
+        toDelete.forEach(stateStore::save);
 
         return toDelete.stream().map(NamespaceFile::fromMetadata).toList();
-    }
-
-    @Override
-    public boolean purge(NamespaceFile namespaceFile) throws IOException {
-        storage.delete(tenant, namespace, namespaceFile.storagePath().toUri());
-        namespaceFileMetadataRepository.purge(List.of(NamespaceFileMetadata.of(tenant, namespaceFile)));
-        return true;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public Integer purge(List<NamespaceFile> namespaceFiles) throws IOException {
-        Integer purgedMetadataCount = this.namespaceFileMetadataRepository.purge(namespaceFiles.stream().map(namespaceFile -> NamespaceFileMetadata.of(tenant, namespaceFile)).toList());
-
-        long actualDeletedEntries = namespaceFiles.stream()
-            .map(NamespaceFile::storagePath)
-            .map(Path::toUri)
-            .map(throwFunction(uri -> this.storage.delete(tenant, namespace, uri)))
-            .filter(Boolean::booleanValue)
-            .count();
-
-        if (actualDeletedEntries != purgedMetadataCount) {
-            log.warn("Namespace Files Metadata purge reported {} deleted entries, but {} values were actually deleted from storage", purgedMetadataCount, actualDeletedEntries);
-        }
-
-        return purgedMetadataCount;
     }
 }

--- a/core/src/main/java/io/kestra/core/storages/Namespace.java
+++ b/core/src/main/java/io/kestra/core/storages/Namespace.java
@@ -1,12 +1,8 @@
 package io.kestra.core.storages;
 
-import io.kestra.core.models.FetchVersion;
-import io.kestra.core.models.QueryFilter;
 import io.kestra.core.models.namespaces.files.NamespaceFileMetadata;
-import io.kestra.core.repositories.ArrayListTotal;
+import io.kestra.core.namespace.NamespaceFileService;
 import io.kestra.core.utils.PathMatcherPredicate;
-import io.micronaut.data.model.Pageable;
-import io.micronaut.data.model.Sort;
 import jakarta.annotation.Nullable;
 import org.apache.commons.lang3.tuple.Pair;
 
@@ -15,18 +11,18 @@ import java.io.InputStream;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.file.Path;
-import java.time.ZonedDateTime;
-import java.util.Collections;
 import java.util.List;
 import java.util.function.Predicate;
 
 /**
  * Service interface for accessing the files attached to a namespace (a.k.a., Namespace Files).
+ * <p>
+ * This interface exposes only worker-safe operations. For server-only operations
+ * (paginated listing with advanced filters, version-aware queries, purge), see
+ * {@link NamespaceFileService}.
  */
 public interface Namespace {
     String NAMESPACE_FILE_SCHEME = "nsfile";
-
-    ArrayListTotal<NamespaceFile> find(Pageable pageable, List<QueryFilter> filters, boolean allowDeleted, FetchVersion fetchVersion);
 
     /**
      * Gets the current namespace.
@@ -169,24 +165,6 @@ public interface Namespace {
      * @throws IOException if an error happens while performing the delete operation.
      */
     List<NamespaceFile> delete(Path path) throws IOException;
-
-    /**
-     * Hard-deletes any namespaces files.
-     *
-     * @param namespaceFile the namespace file to be purged.
-     * @return {@code true} if the file was purged by this method; {@code false} if the file could not be deleted because it did not exist
-     * @throws IOException if an error happens while performing the delete operation.
-     */
-    boolean purge(NamespaceFile namespaceFile) throws IOException;
-
-    /**
-     * Hard-deletes all provided namespaces files.
-     *
-     * @param namespaceFiles the namespace files to be purged.
-     * @return the amount of files that were purged.
-     * @throws IOException if an error happens while performing the delete operation.
-     */
-    Integer purge(List<NamespaceFile> namespaceFiles) throws IOException;
 
     /**
      * Checks if a directory is empty.

--- a/core/src/main/java/io/kestra/core/storages/NamespaceFactory.java
+++ b/core/src/main/java/io/kestra/core/storages/NamespaceFactory.java
@@ -1,20 +1,28 @@
 package io.kestra.core.storages;
 
-import io.kestra.core.repositories.NamespaceFileMetadataRepositoryInterface;
+import io.kestra.core.namespace.NamespaceFileMetadataStateStore;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 import org.slf4j.Logger;
 
+/**
+ * Factory for creating {@link Namespace} instances.
+ */
 @Singleton
 public class NamespaceFactory {
+
+    private final NamespaceFileMetadataStateStore namespaceFileMetadataStateStore;
+
     @Inject
-    private NamespaceFileMetadataRepositoryInterface namespaceFileMetadataRepositoryInterface;
+    public NamespaceFactory(NamespaceFileMetadataStateStore namespaceFileMetadataStateStore) {
+        this.namespaceFileMetadataStateStore = namespaceFileMetadataStateStore;
+    }
 
     public Namespace of(String tenantId, String namespace, StorageInterface storageInterface) {
-        return new InternalNamespace(tenantId, namespace, storageInterface, namespaceFileMetadataRepositoryInterface);
+        return new InternalNamespace(tenantId, namespace, storageInterface, namespaceFileMetadataStateStore);
     }
 
     public Namespace of(Logger logger, String tenantId, String namespace, StorageInterface storageInterface) {
-        return new InternalNamespace(logger, tenantId, namespace, storageInterface, namespaceFileMetadataRepositoryInterface);
+        return new InternalNamespace(logger, tenantId, namespace, storageInterface, namespaceFileMetadataStateStore);
     }
 }

--- a/core/src/main/java/io/kestra/plugin/core/namespace/FilesPurgeBehavior.java
+++ b/core/src/main/java/io/kestra/plugin/core/namespace/FilesPurgeBehavior.java
@@ -2,7 +2,7 @@ package io.kestra.plugin.core.namespace;
 
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
-import io.kestra.core.storages.Namespace;
+import io.kestra.core.namespace.NamespaceFileService;
 import io.kestra.core.storages.NamespaceFile;
 import io.micronaut.core.annotation.Introspected;
 import lombok.Getter;
@@ -23,5 +23,5 @@ import java.util.List;
 public abstract class FilesPurgeBehavior {
     abstract public String getType();
 
-    protected abstract List<NamespaceFile> entriesToPurge(String tenantId, Namespace namespaceStorage) throws IOException;
+    protected abstract List<NamespaceFile> entriesToPurge(String tenantId, String namespace, NamespaceFileService namespaceFileService) throws IOException;
 }

--- a/core/src/main/java/io/kestra/plugin/core/namespace/PurgeFiles.java
+++ b/core/src/main/java/io/kestra/plugin/core/namespace/PurgeFiles.java
@@ -6,8 +6,9 @@ import io.kestra.core.models.annotations.Plugin;
 import io.kestra.core.models.property.Property;
 import io.kestra.core.models.tasks.RunnableTask;
 import io.kestra.core.models.tasks.Task;
+import io.kestra.core.runners.DefaultRunContext;
 import io.kestra.core.runners.RunContext;
-import io.kestra.core.storages.Namespace;
+import io.kestra.core.namespace.NamespaceFileService;
 import io.kestra.core.storages.NamespaceFile;
 import io.kestra.plugin.core.purge.PurgeTask;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -95,10 +96,11 @@ public class PurgeFiles extends Task implements PurgeTask<NamespaceFile>, Runnab
         runContext.logger().info("purging {} namespaces: {}", filesNamespaces.size(), filesNamespaces);
         AtomicLong count = new AtomicLong();
         FilesPurgeBehavior renderedBehavior = runContext.render(behavior).as(FilesPurgeBehavior.class).orElseThrow();
+        String tenantId = runContext.flowInfo().tenantId();
+        NamespaceFileService namespaceFileService = ((DefaultRunContext) runContext).services().additionalService(NamespaceFileService.class);
         for (String ns : filesNamespaces) {
-            Namespace namespaceStorage = runContext.storage().namespace(ns);
-            List<NamespaceFile> toPurge = filterItems(runContext, renderedBehavior.entriesToPurge(runContext.flowInfo().tenantId(), namespaceStorage));
-            count.addAndGet(namespaceStorage.purge(toPurge));
+            List<NamespaceFile> toPurge = filterItems(runContext, renderedBehavior.entriesToPurge(tenantId, ns, namespaceFileService));
+            count.addAndGet(namespaceFileService.purge(tenantId, ns, toPurge));
         }
         runContext.logger().info("purged {} files", count.get());
 

--- a/core/src/main/java/io/kestra/plugin/core/namespace/Version.java
+++ b/core/src/main/java/io/kestra/plugin/core/namespace/Version.java
@@ -3,12 +3,8 @@ package io.kestra.plugin.core.namespace;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import io.kestra.core.models.FetchVersion;
 import io.kestra.core.models.QueryFilter;
-import io.kestra.core.models.namespaces.files.NamespaceFileMetadata;
-import io.kestra.core.repositories.NamespaceFileMetadataRepositoryInterface;
-import io.kestra.core.storages.Namespace;
+import io.kestra.core.namespace.NamespaceFileService;
 import io.kestra.core.storages.NamespaceFile;
-import io.kestra.core.storages.kv.KVEntry;
-import io.kestra.core.storages.kv.KVStore;
 import io.kestra.core.validations.FilesVersionBehaviorValidation;
 import io.micronaut.data.model.Pageable;
 import io.micronaut.data.model.Sort;
@@ -19,7 +15,6 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
 
-import java.io.IOException;
 import java.time.ZonedDateTime;
 import java.util.Collections;
 import java.util.List;
@@ -48,9 +43,11 @@ public class Version extends FilesPurgeBehavior {
     private Integer keepAmount;
 
     @Override
-    protected List<NamespaceFile> entriesToPurge(String tenantId, Namespace namespaceStorage) {
-        List<NamespaceFile> entries = namespaceStorage.find(
+    protected List<NamespaceFile> entriesToPurge(String tenantId, String namespace, NamespaceFileService namespaceFileService) {
+        List<NamespaceFile> entries = namespaceFileService.find(
             Pageable.UNPAGED.withSort(Sort.of(Sort.Order.desc("version"))),
+            tenantId,
+            namespace,
             before == null
                 ? Collections.emptyList()
                 : List.of(QueryFilter.builder().field(QueryFilter.Field.UPDATED).operation(QueryFilter.Op.LESS_THAN_OR_EQUAL_TO).value(ZonedDateTime.parse(before)).build()),

--- a/core/src/test/java/io/kestra/core/namespace/AbstractDefaultNamespaceFileMetadataStateStoreTest.java
+++ b/core/src/test/java/io/kestra/core/namespace/AbstractDefaultNamespaceFileMetadataStateStoreTest.java
@@ -1,0 +1,461 @@
+package io.kestra.core.namespace;
+
+import io.kestra.core.models.namespaces.files.NamespaceFileMetadata;
+import io.kestra.core.utils.TestsUtils;
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@MicronautTest(transactional = false)
+public abstract class AbstractDefaultNamespaceFileMetadataStateStoreTest {
+    @Inject
+    protected NamespaceFileMetadataStateStore stateStore;
+
+    @Test
+    void shouldReturnLatestVersionWhenFindByPathGivenMultipleVersions() throws IOException {
+        // Given
+        String tenantId = TestsUtils.randomTenant();
+        String namespace = TestsUtils.randomNamespace();
+        String path = "/test/file.txt";
+
+        stateStore.save(NamespaceFileMetadata.builder()
+            .tenantId(tenantId)
+            .namespace(namespace)
+            .path(path)
+            .size(10L)
+            .build());
+        stateStore.save(NamespaceFileMetadata.builder()
+            .tenantId(tenantId)
+            .namespace(namespace)
+            .path(path)
+            .size(20L)
+            .build());
+
+        // When
+        Optional<NamespaceFileMetadata> result = stateStore.findByPath(tenantId, namespace, path, null, false);
+
+        // Then
+        assertThat(result).isPresent();
+        assertThat(result.get().getVersion()).isEqualTo(2);
+        assertThat(result.get().isLast()).isTrue();
+        assertThat(result.get().isDeleted()).isFalse();
+    }
+
+    @Test
+    void shouldReturnSpecificVersionWhenFindByPathGivenVersionNumber() throws IOException {
+        // Given
+        String tenantId = TestsUtils.randomTenant();
+        String namespace = TestsUtils.randomNamespace();
+        String path = "/test/versioned.txt";
+
+        stateStore.save(NamespaceFileMetadata.builder()
+            .tenantId(tenantId)
+            .namespace(namespace)
+            .path(path)
+            .size(10L)
+            .build());
+        stateStore.save(NamespaceFileMetadata.builder()
+            .tenantId(tenantId)
+            .namespace(namespace)
+            .path(path)
+            .size(20L)
+            .build());
+
+        // When
+        Optional<NamespaceFileMetadata> result = stateStore.findByPath(tenantId, namespace, path, 1, false);
+
+        // Then
+        assertThat(result).isPresent();
+        assertThat(result.get().getVersion()).isEqualTo(1);
+        assertThat(result.get().isLast()).isFalse();
+    }
+
+    @Test
+    void shouldExcludeDeletedWhenFindByPathGivenAllowDeletedFalse() throws IOException {
+        // Given
+        String tenantId = TestsUtils.randomTenant();
+        String namespace = TestsUtils.randomNamespace();
+        String path = "/test/deleted.txt";
+
+        NamespaceFileMetadata saved = stateStore.save(NamespaceFileMetadata.builder()
+            .tenantId(tenantId)
+            .namespace(namespace)
+            .path(path)
+            .size(10L)
+            .build());
+        stateStore.delete(saved);
+
+        // When
+        Optional<NamespaceFileMetadata> withoutDeleted = stateStore.findByPath(tenantId, namespace, path, null, false);
+        Optional<NamespaceFileMetadata> withDeleted = stateStore.findByPath(tenantId, namespace, path, null, true);
+
+        // Then
+        assertThat(withoutDeleted).isEmpty();
+        assertThat(withDeleted).isPresent();
+        assertThat(withDeleted.get().isDeleted()).isTrue();
+    }
+
+    @Test
+    void shouldReturnEmptyWhenFindByPathGivenNonexistentPath() throws IOException {
+        // Given
+        String tenantId = TestsUtils.randomTenant();
+        String namespace = TestsUtils.randomNamespace();
+
+        // When
+        Optional<NamespaceFileMetadata> result = stateStore.findByPath(tenantId, namespace, "/nonexistent", null, false);
+
+        // Then
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    void shouldReturnDirectChildrenWhenFindChildrenGivenNonRecursive() {
+        // Given
+        String tenantId = TestsUtils.randomTenant();
+        String namespace = TestsUtils.randomNamespace();
+
+        stateStore.save(NamespaceFileMetadata.builder()
+            .tenantId(tenantId).namespace(namespace).path("/parent/").size(0L).build());
+        stateStore.save(NamespaceFileMetadata.builder()
+            .tenantId(tenantId).namespace(namespace).path("/parent/child1.txt").size(10L).build());
+        stateStore.save(NamespaceFileMetadata.builder()
+            .tenantId(tenantId).namespace(namespace).path("/parent/child2.txt").size(20L).build());
+        stateStore.save(NamespaceFileMetadata.builder()
+            .tenantId(tenantId).namespace(namespace).path("/parent/sub/").size(0L).build());
+        stateStore.save(NamespaceFileMetadata.builder()
+            .tenantId(tenantId).namespace(namespace).path("/parent/sub/deep.txt").size(30L).build());
+
+        // When
+        List<NamespaceFileMetadata> directChildren = stateStore.findChildren(tenantId, namespace, "/parent/", false);
+
+        // Then
+        assertThat(directChildren).extracting(NamespaceFileMetadata::getPath)
+            .containsExactlyInAnyOrder("/parent/child1.txt", "/parent/child2.txt", "/parent/sub/");
+    }
+
+    @Test
+    void shouldReturnAllDescendantsWhenFindChildrenGivenRecursive() {
+        // Given
+        String tenantId = TestsUtils.randomTenant();
+        String namespace = TestsUtils.randomNamespace();
+
+        stateStore.save(NamespaceFileMetadata.builder()
+            .tenantId(tenantId).namespace(namespace).path("/dir/").size(0L).build());
+        stateStore.save(NamespaceFileMetadata.builder()
+            .tenantId(tenantId).namespace(namespace).path("/dir/a.txt").size(10L).build());
+        stateStore.save(NamespaceFileMetadata.builder()
+            .tenantId(tenantId).namespace(namespace).path("/dir/sub/").size(0L).build());
+        stateStore.save(NamespaceFileMetadata.builder()
+            .tenantId(tenantId).namespace(namespace).path("/dir/sub/b.txt").size(20L).build());
+
+        // When
+        List<NamespaceFileMetadata> allDescendants = stateStore.findChildren(tenantId, namespace, "/dir/", true);
+
+        // Then
+        assertThat(allDescendants).extracting(NamespaceFileMetadata::getPath)
+            .containsExactlyInAnyOrder("/dir/a.txt", "/dir/sub/", "/dir/sub/b.txt");
+    }
+
+    @Test
+    void shouldNormalizeParentPathWhenFindChildrenGivenPathWithoutTrailingSlash() {
+        // Given
+        String tenantId = TestsUtils.randomTenant();
+        String namespace = TestsUtils.randomNamespace();
+
+        stateStore.save(NamespaceFileMetadata.builder()
+            .tenantId(tenantId).namespace(namespace).path("/norm/").size(0L).build());
+        stateStore.save(NamespaceFileMetadata.builder()
+            .tenantId(tenantId).namespace(namespace).path("/norm/file.txt").size(10L).build());
+
+        // When
+        List<NamespaceFileMetadata> result = stateStore.findChildren(tenantId, namespace, "/norm", false);
+
+        // Then
+        assertThat(result).extracting(NamespaceFileMetadata::getPath)
+            .containsExactly("/norm/file.txt");
+    }
+
+    @Test
+    void shouldReturnAllFilesWhenFindAllGivenNullContaining() {
+        // Given
+        String tenantId = TestsUtils.randomTenant();
+        String namespace = TestsUtils.randomNamespace();
+
+        stateStore.save(NamespaceFileMetadata.builder()
+            .tenantId(tenantId).namespace(namespace).path("/a.txt").size(10L).build());
+        stateStore.save(NamespaceFileMetadata.builder()
+            .tenantId(tenantId).namespace(namespace).path("/b.txt").size(20L).build());
+
+        // When
+        List<NamespaceFileMetadata> result = stateStore.findAll(tenantId, namespace, null);
+
+        // Then
+        assertThat(result).extracting(NamespaceFileMetadata::getPath)
+            .containsExactlyInAnyOrder("/a.txt", "/b.txt");
+    }
+
+    @Test
+    void shouldFilterBySubstringWhenFindAllGivenContainingValue() {
+        // Given
+        String tenantId = TestsUtils.randomTenant();
+        String namespace = TestsUtils.randomNamespace();
+
+        stateStore.save(NamespaceFileMetadata.builder()
+            .tenantId(tenantId).namespace(namespace).path("/scripts/deploy.sh").size(10L).build());
+        stateStore.save(NamespaceFileMetadata.builder()
+            .tenantId(tenantId).namespace(namespace).path("/config/app.yml").size(20L).build());
+
+        // When
+        List<NamespaceFileMetadata> result = stateStore.findAll(tenantId, namespace, "deploy");
+
+        // Then
+        assertThat(result).extracting(NamespaceFileMetadata::getPath)
+            .containsExactly("/scripts/deploy.sh");
+    }
+
+    @Test
+    void shouldReturnAllFilesWhenFindAllGivenRootSlashAsContaining() {
+        // Given
+        String tenantId = TestsUtils.randomTenant();
+        String namespace = TestsUtils.randomNamespace();
+
+        stateStore.save(NamespaceFileMetadata.builder()
+            .tenantId(tenantId).namespace(namespace).path("/x.txt").size(10L).build());
+        stateStore.save(NamespaceFileMetadata.builder()
+            .tenantId(tenantId).namespace(namespace).path("/y.txt").size(20L).build());
+
+        // When
+        List<NamespaceFileMetadata> result = stateStore.findAll(tenantId, namespace, "/");
+
+        // Then
+        assertThat(result).hasSize(2);
+    }
+
+    @Test
+    void shouldReturnMatchingEntriesWhenFindByPathsGivenMultiplePaths() {
+        // Given
+        String tenantId = TestsUtils.randomTenant();
+        String namespace = TestsUtils.randomNamespace();
+
+        stateStore.save(NamespaceFileMetadata.builder()
+            .tenantId(tenantId).namespace(namespace).path("/one.txt").size(10L).build());
+        stateStore.save(NamespaceFileMetadata.builder()
+            .tenantId(tenantId).namespace(namespace).path("/two.txt").size(20L).build());
+        stateStore.save(NamespaceFileMetadata.builder()
+            .tenantId(tenantId).namespace(namespace).path("/three.txt").size(30L).build());
+
+        // When
+        List<NamespaceFileMetadata> result = stateStore.findByPaths(tenantId, namespace,
+            List.of("/one.txt", "/three.txt"), false);
+
+        // Then
+        assertThat(result).extracting(NamespaceFileMetadata::getPath)
+            .containsExactlyInAnyOrder("/one.txt", "/three.txt");
+    }
+
+    @Test
+    void shouldExcludeDeletedWhenFindByPathsGivenAllowDeletedFalse() {
+        // Given
+        String tenantId = TestsUtils.randomTenant();
+        String namespace = TestsUtils.randomNamespace();
+
+        NamespaceFileMetadata saved = stateStore.save(NamespaceFileMetadata.builder()
+            .tenantId(tenantId).namespace(namespace).path("/del.txt").size(10L).build());
+        stateStore.save(saved.toDeleted());
+
+        // When
+        List<NamespaceFileMetadata> withoutDeleted = stateStore.findByPaths(tenantId, namespace, List.of("/del.txt"), false);
+        List<NamespaceFileMetadata> withDeleted = stateStore.findByPaths(tenantId, namespace, List.of("/del.txt"), true);
+
+        // Then
+        assertThat(withoutDeleted).isEmpty();
+        assertThat(withDeleted).hasSize(1);
+        assertThat(withDeleted.getFirst().isDeleted()).isTrue();
+    }
+
+    @Test
+    void shouldReturnAllVersionsWhenFindAllVersionsByPathsGivenMultipleVersions() {
+        // Given
+        String tenantId = TestsUtils.randomTenant();
+        String namespace = TestsUtils.randomNamespace();
+        String path = "/versioned.txt";
+
+        stateStore.save(NamespaceFileMetadata.builder()
+            .tenantId(tenantId).namespace(namespace).path(path).size(10L).build());
+        stateStore.save(NamespaceFileMetadata.builder()
+            .tenantId(tenantId).namespace(namespace).path(path).size(20L).build());
+
+        // When
+        List<NamespaceFileMetadata> result = stateStore.findAllVersionsByPaths(tenantId, namespace, List.of(path));
+
+        // Then
+        assertThat(result).hasSize(2);
+        assertThat(result).extracting(NamespaceFileMetadata::getVersion)
+            .containsExactlyInAnyOrder(1, 2);
+    }
+
+    @Test
+    void shouldReturnTrueWhenExistsByNamespaceGivenActiveFiles() {
+        // Given
+        String tenantId = TestsUtils.randomTenant();
+        String namespace = TestsUtils.randomNamespace();
+
+        stateStore.save(NamespaceFileMetadata.builder()
+            .tenantId(tenantId).namespace(namespace).path("/exists.txt").size(10L).build());
+
+        // When / Then
+        assertThat(stateStore.existsByNamespace(tenantId, namespace)).isTrue();
+    }
+
+    @Test
+    void shouldReturnFalseWhenExistsByNamespaceGivenEmptyNamespace() {
+        // Given
+        String tenantId = TestsUtils.randomTenant();
+        String namespace = TestsUtils.randomNamespace();
+
+        // When / Then
+        assertThat(stateStore.existsByNamespace(tenantId, namespace)).isFalse();
+    }
+
+    @Test
+    void shouldReturnFalseWhenExistsByNamespaceGivenAllFilesDeleted() {
+        // Given
+        String tenantId = TestsUtils.randomTenant();
+        String namespace = TestsUtils.randomNamespace();
+
+        NamespaceFileMetadata saved = stateStore.save(NamespaceFileMetadata.builder()
+            .tenantId(tenantId).namespace(namespace).path("/gone.txt").size(10L).build());
+        stateStore.save(saved.toDeleted());
+
+        // When / Then
+        assertThat(stateStore.existsByNamespace(tenantId, namespace)).isFalse();
+    }
+
+    @Test
+    void shouldIncrementVersionWhenSaveGivenSamePathSavedTwice() {
+        // Given
+        String tenantId = TestsUtils.randomTenant();
+        String namespace = TestsUtils.randomNamespace();
+        String path = "/incr.txt";
+
+        // When
+        NamespaceFileMetadata v1 = stateStore.save(NamespaceFileMetadata.builder()
+            .tenantId(tenantId).namespace(namespace).path(path).size(10L).build());
+        NamespaceFileMetadata v2 = stateStore.save(NamespaceFileMetadata.builder()
+            .tenantId(tenantId).namespace(namespace).path(path).size(20L).build());
+
+        // Then
+        assertThat(v1.getVersion()).isEqualTo(1);
+        assertThat(v2.getVersion()).isEqualTo(2);
+    }
+
+    @Test
+    void shouldSoftDeleteWhenDeleteGivenActiveEntry() throws IOException {
+        // Given
+        String tenantId = TestsUtils.randomTenant();
+        String namespace = TestsUtils.randomNamespace();
+        String path = "/soft.txt";
+
+        NamespaceFileMetadata saved = stateStore.save(NamespaceFileMetadata.builder()
+            .tenantId(tenantId).namespace(namespace).path(path).size(10L).build());
+
+        // When
+        NamespaceFileMetadata deleted = stateStore.delete(saved);
+
+        // Then
+        assertThat(deleted.isDeleted()).isTrue();
+
+        Optional<NamespaceFileMetadata> found = stateStore.findByPath(tenantId, namespace, path, null, true);
+        assertThat(found).isPresent();
+        assertThat(found.get().isDeleted()).isTrue();
+
+        assertThat(stateStore.findByPath(tenantId, namespace, path, null, false)).isEmpty();
+    }
+
+    @Test
+    void shouldExcludeDeletedWhenFindChildrenGivenDeletedEntries() {
+        // Given
+        String tenantId = TestsUtils.randomTenant();
+        String namespace = TestsUtils.randomNamespace();
+
+        stateStore.save(NamespaceFileMetadata.builder()
+            .tenantId(tenantId).namespace(namespace).path("/parent2/").size(0L).build());
+        stateStore.save(NamespaceFileMetadata.builder()
+            .tenantId(tenantId).namespace(namespace).path("/parent2/alive.txt").size(10L).build());
+        NamespaceFileMetadata toDelete = stateStore.save(NamespaceFileMetadata.builder()
+            .tenantId(tenantId).namespace(namespace).path("/parent2/dead.txt").size(20L).build());
+        stateStore.save(toDelete.toDeleted());
+
+        // When
+        List<NamespaceFileMetadata> result = stateStore.findChildren(tenantId, namespace, "/parent2/", false);
+
+        // Then
+        assertThat(result).extracting(NamespaceFileMetadata::getPath)
+            .containsExactly("/parent2/alive.txt");
+    }
+
+    @Test
+    void shouldExcludeDeletedWhenFindAllGivenDeletedEntries() {
+        // Given
+        String tenantId = TestsUtils.randomTenant();
+        String namespace = TestsUtils.randomNamespace();
+
+        stateStore.save(NamespaceFileMetadata.builder()
+            .tenantId(tenantId).namespace(namespace).path("/alive2.txt").size(10L).build());
+        NamespaceFileMetadata toDelete = stateStore.save(NamespaceFileMetadata.builder()
+            .tenantId(tenantId).namespace(namespace).path("/dead2.txt").size(20L).build());
+        stateStore.save(toDelete.toDeleted());
+
+        // When
+        List<NamespaceFileMetadata> result = stateStore.findAll(tenantId, namespace, null);
+
+        // Then
+        assertThat(result).extracting(NamespaceFileMetadata::getPath)
+            .containsExactly("/alive2.txt");
+    }
+
+    @Test
+    void shouldReturnDeletedVersionWhenFindByPathGivenSpecificVersionAndAllowDeleted() throws IOException {
+        // Given
+        String tenantId = TestsUtils.randomTenant();
+        String namespace = TestsUtils.randomNamespace();
+        String path = "/ver-del.txt";
+
+        stateStore.save(NamespaceFileMetadata.builder()
+            .tenantId(tenantId).namespace(namespace).path(path).size(10L).build());
+        NamespaceFileMetadata v2 = stateStore.save(NamespaceFileMetadata.builder()
+            .tenantId(tenantId).namespace(namespace).path(path).size(20L).build());
+        stateStore.delete(v2);
+
+        // When
+        Optional<NamespaceFileMetadata> result = stateStore.findByPath(tenantId, namespace, path, 2, true);
+
+        // Then
+        assertThat(result).isPresent();
+        assertThat(result.get().getVersion()).isEqualTo(2);
+        assertThat(result.get().isDeleted()).isTrue();
+    }
+
+    @Test
+    void shouldReturnEmptyWhenFindByPathGivenNonexistentVersion() throws IOException {
+        // Given
+        String tenantId = TestsUtils.randomTenant();
+        String namespace = TestsUtils.randomNamespace();
+        String path = "/ver-missing.txt";
+
+        stateStore.save(NamespaceFileMetadata.builder()
+            .tenantId(tenantId).namespace(namespace).path(path).size(10L).build());
+
+        // When
+        Optional<NamespaceFileMetadata> result = stateStore.findByPath(tenantId, namespace, path, 99, false);
+
+        // Then
+        assertThat(result).isEmpty();
+    }
+}

--- a/core/src/test/java/io/kestra/core/runners/pebble/functions/ReadFileFunctionTest.java
+++ b/core/src/test/java/io/kestra/core/runners/pebble/functions/ReadFileFunctionTest.java
@@ -34,7 +34,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @MicronautTest(rebuildContext = true)
-@Property(name="kestra.server-type", value="WORKER")
+@Property(name="kestra.server-type", value="STANDALONE")
 @Execution(ExecutionMode.SAME_THREAD)
 class ReadFileFunctionTest {
     @Inject

--- a/core/src/test/java/io/kestra/core/storages/InternalNamespaceTest.java
+++ b/core/src/test/java/io/kestra/core/storages/InternalNamespaceTest.java
@@ -1,6 +1,6 @@
 package io.kestra.core.storages;
 
-import io.kestra.core.repositories.NamespaceFileMetadataRepositoryInterface;
+import io.kestra.core.namespace.NamespaceFileMetadataStateStore;
 import io.kestra.core.utils.PathMatcherPredicate;
 import io.kestra.core.utils.TestsUtils;
 import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
@@ -8,12 +8,10 @@ import jakarta.inject.Inject;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.slf4j.Logger;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.file.Path;
 import java.util.List;
@@ -29,13 +27,13 @@ class InternalNamespaceTest {
     private StorageInterface storageInterface;
 
     @Inject
-    private NamespaceFileMetadataRepositoryInterface namespaceFileMetadataRepository;
+    private NamespaceFileMetadataStateStore namespaceFileMetadataStateStore;
 
     @Test
     void shouldGetAllNamespaceFiles() throws IOException, URISyntaxException {
         // Given
         final String namespaceId = TestsUtils.randomNamespace();
-        final InternalNamespace namespace = new InternalNamespace(log, MAIN_TENANT, namespaceId, storageInterface, namespaceFileMetadataRepository);
+        final InternalNamespace namespace = new InternalNamespace(log, MAIN_TENANT, namespaceId, storageInterface, namespaceFileMetadataStateStore);
 
         // When
         namespace.putFile(Path.of("/sub/dir/file1.txt"), new ByteArrayInputStream("1".getBytes()));
@@ -53,7 +51,7 @@ class InternalNamespaceTest {
     void shouldPutFileGivenNoTenant() throws IOException, URISyntaxException {
         // Given
         final String namespaceId = TestsUtils.randomNamespace();
-        final InternalNamespace namespace = new InternalNamespace(log, MAIN_TENANT, namespaceId, storageInterface, namespaceFileMetadataRepository);
+        final InternalNamespace namespace = new InternalNamespace(log, MAIN_TENANT, namespaceId, storageInterface, namespaceFileMetadataStateStore);
 
         // When
         List<NamespaceFile> namespaceFiles = namespace.putFile(Path.of("/sub/dir/file.txt"), new ByteArrayInputStream("1".getBytes()));
@@ -77,7 +75,7 @@ class InternalNamespaceTest {
     void shouldSucceedPutFileGivenExistingFileForConflictOverwrite() throws IOException, URISyntaxException {
         // Given
         final String namespaceId = TestsUtils.randomNamespace();
-        final InternalNamespace namespace = new InternalNamespace(log, MAIN_TENANT, namespaceId, storageInterface, namespaceFileMetadataRepository);
+        final InternalNamespace namespace = new InternalNamespace(log, MAIN_TENANT, namespaceId, storageInterface, namespaceFileMetadataStateStore);
 
         NamespaceFile namespaceFile = namespace.get(Path.of("/sub/dir/file.txt"));
 
@@ -96,7 +94,7 @@ class InternalNamespaceTest {
     void shouldFailPutFileGivenExistingFileForError() throws IOException, URISyntaxException {
         // Given
         final String namespaceId = TestsUtils.randomNamespace();
-        final InternalNamespace namespace = new InternalNamespace(log, MAIN_TENANT, namespaceId, storageInterface, namespaceFileMetadataRepository);
+        final InternalNamespace namespace = new InternalNamespace(log, MAIN_TENANT, namespaceId, storageInterface, namespaceFileMetadataStateStore);
 
         NamespaceFile namespaceFile = namespace.get(Path.of("/sub/dir/file.txt"));
 
@@ -113,7 +111,7 @@ class InternalNamespaceTest {
     void shouldIgnorePutFileGivenExistingFileForSkip() throws IOException, URISyntaxException {
         // Given
         final String namespaceId = TestsUtils.randomNamespace();
-        final InternalNamespace namespace = new InternalNamespace(log, MAIN_TENANT, namespaceId, storageInterface, namespaceFileMetadataRepository);
+        final InternalNamespace namespace = new InternalNamespace(log, MAIN_TENANT, namespaceId, storageInterface, namespaceFileMetadataStateStore);
 
         NamespaceFile namespaceFile = namespace.get(Path.of("/sub/dir/file.txt"));
 
@@ -132,7 +130,7 @@ class InternalNamespaceTest {
     void shouldFindAllMatchingGivenNoTenant() throws IOException, URISyntaxException {
         // Given
         final String namespaceId = TestsUtils.randomNamespace();
-        final InternalNamespace namespace = new InternalNamespace(log, MAIN_TENANT, namespaceId, storageInterface, namespaceFileMetadataRepository);
+        final InternalNamespace namespace = new InternalNamespace(log, MAIN_TENANT, namespaceId, storageInterface, namespaceFileMetadataStateStore);
 
         // When
         namespace.putFile(Path.of("/a/b/c/1.sql"), new ByteArrayInputStream("1".getBytes()));
@@ -155,12 +153,12 @@ class InternalNamespaceTest {
     void shouldFindAllGivenTenant() throws IOException, URISyntaxException {
         // Given
         final String namespaceId = TestsUtils.randomNamespace();
-        final InternalNamespace namespaceTenant1 = new InternalNamespace(log, "tenant1", namespaceId, storageInterface, namespaceFileMetadataRepository);
+        final InternalNamespace namespaceTenant1 = new InternalNamespace(log, "tenant1", namespaceId, storageInterface, namespaceFileMetadataStateStore);
         NamespaceFile namespaceFile1 = namespaceTenant1.putFile(Path.of("/a/b/c/test.txt"), new ByteArrayInputStream("1".getBytes())).stream()
             .filter(namespaceFile -> namespaceFile.path().endsWith("test.txt"))
             .findFirst().get();
 
-        final InternalNamespace namespaceTenant2 = new InternalNamespace(log, "tenant2", namespaceId, storageInterface, namespaceFileMetadataRepository);
+        final InternalNamespace namespaceTenant2 = new InternalNamespace(log, "tenant2", namespaceId, storageInterface, namespaceFileMetadataStateStore);
         NamespaceFile namespaceFile2 = namespaceTenant2.putFile(Path.of("/a/b/c/test.txt"), new ByteArrayInputStream("1".getBytes())).stream()
             .filter(namespaceFile -> namespaceFile.path().endsWith("test.txt"))
             .findFirst().get();
@@ -179,7 +177,7 @@ class InternalNamespaceTest {
     void shouldReturnNoNamespaceFileForEmptyNamespace() throws IOException {
         // Given
         final String namespaceId = TestsUtils.randomNamespace();
-        final InternalNamespace namespace = new InternalNamespace(log, MAIN_TENANT, namespaceId, storageInterface, namespaceFileMetadataRepository);
+        final InternalNamespace namespace = new InternalNamespace(log, MAIN_TENANT, namespaceId, storageInterface, namespaceFileMetadataStateStore);
         List<NamespaceFile> namespaceFiles = namespace.findAllFilesMatching((unused) -> true);
         assertThat(namespaceFiles.size()).isZero();
     }
@@ -188,7 +186,7 @@ class InternalNamespaceTest {
     void shouldCreateDirectory() throws IOException {
         // Given
         final String namespaceId = TestsUtils.randomNamespace();
-        final InternalNamespace namespace = new InternalNamespace(log, MAIN_TENANT, namespaceId, storageInterface, namespaceFileMetadataRepository);
+        final InternalNamespace namespace = new InternalNamespace(log, MAIN_TENANT, namespaceId, storageInterface, namespaceFileMetadataStateStore);
 
         // When
         NamespaceFile directory = namespace.createDirectory(Path.of("my-directory"));

--- a/core/src/test/java/io/kestra/plugin/core/namespace/PurgeFilesTest.java
+++ b/core/src/test/java/io/kestra/plugin/core/namespace/PurgeFilesTest.java
@@ -11,12 +11,9 @@ import io.kestra.core.models.property.Property;
 import io.kestra.core.models.validations.ModelValidator;
 import io.kestra.core.repositories.FlowRepositoryInterface;
 import io.kestra.core.runners.RunContext;
+import io.kestra.core.namespace.NamespaceFileService;
 import io.kestra.core.storages.Namespace;
 import io.kestra.core.storages.NamespaceFile;
-import io.kestra.core.storages.kv.KVEntry;
-import io.kestra.core.storages.kv.KVMetadata;
-import io.kestra.core.storages.kv.KVStore;
-import io.kestra.core.storages.kv.KVValueAndMetadata;
 import io.kestra.core.utils.IdUtils;
 import io.kestra.core.utils.TestsUtils;
 import io.micronaut.data.model.Pageable;
@@ -31,7 +28,6 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
-import java.time.Duration;
 import java.time.Instant;
 import java.util.Collections;
 import java.util.List;
@@ -58,6 +54,9 @@ public class PurgeFilesTest {
 
     @Inject
     ModelValidator modelValidator;
+
+    @Inject
+    NamespaceFileService namespaceFileService;
 
 
     @BeforeEach
@@ -165,7 +164,7 @@ public class PurgeFilesTest {
         Instant afterFirstVersion = Instant.now();
         namespaceStorage.putFile(Path.of("my/first/file.txt"), new ByteArrayInputStream("another value".getBytes(StandardCharsets.UTF_8)));
 
-        List<NamespaceFile> namespaceFiles = namespaceStorage.find(Pageable.UNPAGED, Collections.emptyList(), true, FetchVersion.ALL);
+        List<NamespaceFile> namespaceFiles = namespaceFileService.find(Pageable.UNPAGED, MAIN_TENANT, namespace, Collections.emptyList(), true, FetchVersion.ALL);
         // "/", "/my", "/my/first", "/my/first/file.txt" x2 versions
         assertThat(namespaceFiles.size()).isEqualTo(5);
 
@@ -177,7 +176,7 @@ public class PurgeFilesTest {
 
         assertThat(run.getSize()).isEqualTo(1L);
 
-        namespaceFiles = namespaceStorage.find(Pageable.UNPAGED, Collections.emptyList(), true, FetchVersion.ALL);
+        namespaceFiles = namespaceFileService.find(Pageable.UNPAGED, MAIN_TENANT, namespace, Collections.emptyList(), true, FetchVersion.ALL);
         assertThat(namespaceFiles.size()).isEqualTo(4);
         List<NamespaceFile> files = namespaceFiles.stream().filter(nsFile -> nsFile.path().endsWith("file.txt")).toList();
         assertThat(files.size()).isEqualTo(1);
@@ -196,7 +195,7 @@ public class PurgeFilesTest {
         namespaceStorage.putFile(Path.of("my/first/file.txt"), new ByteArrayInputStream("another value".getBytes(StandardCharsets.UTF_8)));
         namespaceStorage.putFile(Path.of("my/first/file.txt"), new ByteArrayInputStream("yet another value".getBytes(StandardCharsets.UTF_8)));
 
-        List<NamespaceFile> namespaceFiles = namespaceStorage.find(Pageable.UNPAGED, Collections.emptyList(), true, FetchVersion.ALL);
+        List<NamespaceFile> namespaceFiles = namespaceFileService.find(Pageable.UNPAGED, MAIN_TENANT, namespace, Collections.emptyList(), true, FetchVersion.ALL);
         assertThat(namespaceFiles.size()).isEqualTo(6);
 
         PurgeFiles purgeFiles = PurgeFiles.builder()
@@ -207,7 +206,7 @@ public class PurgeFilesTest {
 
         assertThat(run.getSize()).isEqualTo(1L);
 
-        namespaceFiles = namespaceStorage.find(Pageable.UNPAGED, Collections.emptyList(), true, FetchVersion.ALL);
+        namespaceFiles = namespaceFileService.find(Pageable.UNPAGED, MAIN_TENANT, namespace, Collections.emptyList(), true, FetchVersion.ALL);
         assertThat(namespaceFiles.size()).isEqualTo(5);
         List<NamespaceFile> files = namespaceFiles.stream().filter(nsFile -> nsFile.path().endsWith("file.txt")).toList();
         assertThat(files.size()).isEqualTo(2);

--- a/jdbc-h2/src/test/java/io/kestra/repository/h2/H2DefaultNamespaceFileMetadataStateStoreTest.java
+++ b/jdbc-h2/src/test/java/io/kestra/repository/h2/H2DefaultNamespaceFileMetadataStateStoreTest.java
@@ -1,0 +1,7 @@
+package io.kestra.repository.h2;
+
+import io.kestra.core.namespace.AbstractDefaultNamespaceFileMetadataStateStoreTest;
+
+public class H2DefaultNamespaceFileMetadataStateStoreTest extends AbstractDefaultNamespaceFileMetadataStateStoreTest {
+
+}

--- a/jdbc-mysql/src/test/java/io/kestra/repository/mysql/MysqlDefaultNamespaceFileMetadataStateStoreTest.java
+++ b/jdbc-mysql/src/test/java/io/kestra/repository/mysql/MysqlDefaultNamespaceFileMetadataStateStoreTest.java
@@ -1,0 +1,6 @@
+package io.kestra.repository.mysql;
+
+import io.kestra.core.namespace.AbstractDefaultNamespaceFileMetadataStateStoreTest;
+
+public class MysqlDefaultNamespaceFileMetadataStateStoreTest extends AbstractDefaultNamespaceFileMetadataStateStoreTest {
+}

--- a/jdbc-postgres/src/test/java/io/kestra/repository/postgres/PostgresDefaultNamespaceFileMetadataStateStoreTest.java
+++ b/jdbc-postgres/src/test/java/io/kestra/repository/postgres/PostgresDefaultNamespaceFileMetadataStateStoreTest.java
@@ -1,0 +1,6 @@
+package io.kestra.repository.postgres;
+
+import io.kestra.core.namespace.AbstractDefaultNamespaceFileMetadataStateStoreTest;
+
+public class PostgresDefaultNamespaceFileMetadataStateStoreTest extends AbstractDefaultNamespaceFileMetadataStateStoreTest {
+}

--- a/webserver/src/main/java/io/kestra/webserver/controllers/api/NamespaceFileController.java
+++ b/webserver/src/main/java/io/kestra/webserver/controllers/api/NamespaceFileController.java
@@ -1,12 +1,11 @@
 package io.kestra.webserver.controllers.api;
 
 import io.kestra.core.exceptions.FlowProcessingException;
-import io.kestra.core.models.FetchVersion;
 import io.kestra.core.models.QueryFilter;
 import io.kestra.core.models.namespaces.files.NamespaceFileMetadata;
 import io.kestra.core.repositories.ArrayListTotal;
-import io.kestra.core.repositories.NamespaceFileMetadataRepositoryInterface;
 import io.kestra.core.services.FlowService;
+import io.kestra.core.namespace.NamespaceFileService;
 import io.kestra.core.storages.*;
 import io.kestra.core.tenant.TenantService;
 import io.micronaut.core.annotation.Nullable;
@@ -58,7 +57,7 @@ public class NamespaceFileController {
     @Inject
     private NamespaceFactory namespaceFactory;
     @Inject
-    private NamespaceFileMetadataRepositoryInterface namespaceFileMetadataRepository;
+    private NamespaceFileService namespaceFileService;
 
     private final List<Pattern> forbiddenPathPatterns = List.of(
         Pattern.compile("/" + FLOWS_FOLDER + "(/.*)?$")
@@ -135,10 +134,7 @@ public class NamespaceFileController {
 
         encodedPath = Optional.ofNullable(encodedPath).orElse(URI.create("/"));
 
-        ArrayListTotal<NamespaceFileMetadata> namespaceFileMetadata = namespaceFileMetadataRepository.find(Pageable.UNPAGED, tenantService.resolveTenant(), List.of(
-            QueryFilter.builder().field(QueryFilter.Field.NAMESPACE).operation(QueryFilter.Op.EQUALS).value(namespace).build(),
-            QueryFilter.builder().field(QueryFilter.Field.PATH).operation(QueryFilter.Op.EQUALS).value(encodedPath.getPath()).build()
-        ), true, FetchVersion.ALL);
+        ArrayListTotal<NamespaceFileMetadata> namespaceFileMetadata = namespaceFileService.findRevisions(tenantService.resolveTenant(), namespace, encodedPath.getPath());
 
         if (namespaceFileMetadata.stream()
             .filter(NamespaceFileMetadata::isLast)
@@ -343,7 +339,7 @@ public class NamespaceFileController {
 
         String zombieAwarePathToDelete = pathWithoutScheme;
         String parentPathToCheck = NamespaceFileMetadata.parentPath(zombieAwarePathToDelete);
-        while (parentPathToCheck != null && !parentPathToCheck.equals("/") && namespaceFileMetadataRepository.find(Pageable.from(1, 2), tenantService.resolveTenant(), List.of(
+        while (parentPathToCheck != null && !parentPathToCheck.equals("/") && namespaceFileService.findMetadata(Pageable.from(1, 2), tenantService.resolveTenant(), List.of(
             QueryFilter.builder().field(QueryFilter.Field.PARENT_PATH).operation(QueryFilter.Op.EQUALS).value(parentPathToCheck).build()
         ), false).size() == 1) {
             zombieAwarePathToDelete = parentPathToCheck;

--- a/worker-controller/src/main/java/io/kestra/controller/grpc/services/GrpcNSMetadataControllerService.java
+++ b/worker-controller/src/main/java/io/kestra/controller/grpc/services/GrpcNSMetadataControllerService.java
@@ -1,0 +1,200 @@
+package io.kestra.controller.grpc.services;
+
+import io.grpc.stub.StreamObserver;
+import io.kestra.controller.grpc.*;
+import io.kestra.controller.messages.MessageFormat;
+import io.kestra.controller.messages.MessageFormats;
+import io.kestra.controller.messages.RequestOrResponseHeaderFactory;
+import io.kestra.core.models.namespaces.files.NamespaceFileMetadata;
+import io.kestra.core.namespace.NamespaceFileMetadataStateStore;
+import io.kestra.core.worker.models.WorkerInfo;
+import io.micronaut.context.annotation.Requires;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * gRPC service implementation for namespace file metadata operations.
+ * Provides worker-safe namespace file metadata read/write to workers via gRPC.
+ */
+@Singleton
+@Requires(property = "kestra.server-type", pattern = "(CONTROLLER|STANDALONE)")
+public class GrpcNSMetadataControllerService extends NamespaceFileMetadataServiceGrpc.NamespaceFileMetadataServiceImplBase implements WorkerControllerService {
+
+    private static final Logger log = LoggerFactory.getLogger(GrpcNSMetadataControllerService.class);
+    private static final MessageFormat MESSAGE_FORMAT = MessageFormats.JSON;
+
+    private final NamespaceFileMetadataStateStore stateStore;
+    private final WorkerInfo workerInfo;
+
+    @Inject
+    public GrpcNSMetadataControllerService(final NamespaceFileMetadataStateStore stateStore,
+                                           final WorkerInfo workerInfo) {
+        this.stateStore = stateStore;
+        this.workerInfo = workerInfo;
+    }
+
+    @Override
+    public void findByPath(NamespaceFileMetadataPathRequest request, StreamObserver<OpaqueData> responseObserver) {
+        try {
+            Integer version = request.hasVersion() ? request.getVersion() : null;
+
+            log.trace("Received findByPath request: tenantId={}, namespace={}, path={}, version={}, allowDeleted={}",
+                request.getTenantId(), request.getNamespace(), request.getPath(), version, request.getAllowDeleted());
+
+            Optional<NamespaceFileMetadata> result = stateStore.findByPath(
+                request.getTenantId(), request.getNamespace(), request.getPath(),
+                version, request.getAllowDeleted());
+
+            OpaqueData response = OpaqueData.newBuilder()
+                .setHeader(RequestOrResponseHeaderFactory.create(workerInfo.getWorkerId()))
+                .setMessage(MESSAGE_FORMAT.toByteString(result.orElse(null)))
+                .build();
+
+            responseObserver.onNext(response);
+            responseObserver.onCompleted();
+        } catch (Exception e) {
+            log.error("Error during findByPath", e);
+            responseObserver.onError(e);
+        }
+    }
+
+    @Override
+    public void findChildren(NamespaceFileMetadataChildrenRequest request, StreamObserver<OpaqueData> responseObserver) {
+        try {
+            log.trace("Received findChildren request: tenantId={}, namespace={}, parentPath={}, recursive={}",
+                request.getTenantId(), request.getNamespace(), request.getParentPath(), request.getRecursive());
+
+            List<NamespaceFileMetadata> result = stateStore.findChildren(
+                request.getTenantId(), request.getNamespace(),
+                request.getParentPath(), request.getRecursive());
+
+            OpaqueData response = OpaqueData.newBuilder()
+                .setHeader(RequestOrResponseHeaderFactory.create(workerInfo.getWorkerId()))
+                .setMessage(MESSAGE_FORMAT.toByteString(result))
+                .build();
+
+            responseObserver.onNext(response);
+            responseObserver.onCompleted();
+        } catch (Exception e) {
+            log.error("Error during findChildren", e);
+            responseObserver.onError(e);
+        }
+    }
+
+    @Override
+    public void findAll(NamespaceFileMetadataFindAllRequest request, StreamObserver<OpaqueData> responseObserver) {
+        try {
+            String containing = request.hasContaining() ? request.getContaining() : null;
+
+            log.trace("Received findAll request: tenantId={}, namespace={}, containing={}",
+                request.getTenantId(), request.getNamespace(), containing);
+
+            List<NamespaceFileMetadata> result = stateStore.findAll(
+                request.getTenantId(), request.getNamespace(), containing);
+
+            OpaqueData response = OpaqueData.newBuilder()
+                .setHeader(RequestOrResponseHeaderFactory.create(workerInfo.getWorkerId()))
+                .setMessage(MESSAGE_FORMAT.toByteString(result))
+                .build();
+
+            responseObserver.onNext(response);
+            responseObserver.onCompleted();
+        } catch (Exception e) {
+            log.error("Error during findAll", e);
+            responseObserver.onError(e);
+        }
+    }
+
+    @Override
+    public void findByPaths(NamespaceFileMetadataPathsRequest request, StreamObserver<OpaqueData> responseObserver) {
+        try {
+            log.trace("Received findByPaths request: tenantId={}, namespace={}, paths={}, allowDeleted={}",
+                request.getTenantId(), request.getNamespace(), request.getPathsList(), request.getAllowDeleted());
+
+            List<NamespaceFileMetadata> result = stateStore.findByPaths(
+                request.getTenantId(), request.getNamespace(),
+                request.getPathsList(), request.getAllowDeleted());
+
+            OpaqueData response = OpaqueData.newBuilder()
+                .setHeader(RequestOrResponseHeaderFactory.create(workerInfo.getWorkerId()))
+                .setMessage(MESSAGE_FORMAT.toByteString(result))
+                .build();
+
+            responseObserver.onNext(response);
+            responseObserver.onCompleted();
+        } catch (Exception e) {
+            log.error("Error during findByPaths", e);
+            responseObserver.onError(e);
+        }
+    }
+
+    @Override
+    public void findAllVersionsByPaths(NamespaceFileMetadataPathsRequest request, StreamObserver<OpaqueData> responseObserver) {
+        try {
+            log.trace("Received findAllVersionsByPaths request: tenantId={}, namespace={}, paths={}",
+                request.getTenantId(), request.getNamespace(), request.getPathsList());
+
+            List<NamespaceFileMetadata> result = stateStore.findAllVersionsByPaths(
+                request.getTenantId(), request.getNamespace(), request.getPathsList());
+
+            OpaqueData response = OpaqueData.newBuilder()
+                .setHeader(RequestOrResponseHeaderFactory.create(workerInfo.getWorkerId()))
+                .setMessage(MESSAGE_FORMAT.toByteString(result))
+                .build();
+
+            responseObserver.onNext(response);
+            responseObserver.onCompleted();
+        } catch (Exception e) {
+            log.error("Error during findAllVersionsByPaths", e);
+            responseObserver.onError(e);
+        }
+    }
+
+    @Override
+    public void existsByNamespace(NamespaceRequest request, StreamObserver<BooleanResponse> responseObserver) {
+        try {
+            log.trace("Received existsByNamespace request: tenantId={}, namespace={}",
+                request.getTenantId(), request.getNamespace());
+
+            boolean exists = stateStore.existsByNamespace(request.getTenantId(), request.getNamespace());
+
+            BooleanResponse response = BooleanResponse.newBuilder()
+                .setHeader(RequestOrResponseHeaderFactory.create(workerInfo.getWorkerId()))
+                .setValue(exists)
+                .build();
+
+            responseObserver.onNext(response);
+            responseObserver.onCompleted();
+        } catch (Exception e) {
+            log.error("Error during existsByNamespace", e);
+            responseObserver.onError(e);
+        }
+    }
+
+    @Override
+    public void save(OpaqueData request, StreamObserver<OpaqueData> responseObserver) {
+        try {
+            log.trace("Received save request");
+
+            NamespaceFileMetadata item = MESSAGE_FORMAT.fromByteString(request.getMessage(), NamespaceFileMetadata.class);
+
+            NamespaceFileMetadata result = stateStore.save(item);
+
+            OpaqueData response = OpaqueData.newBuilder()
+                .setHeader(RequestOrResponseHeaderFactory.create(workerInfo.getWorkerId()))
+                .setMessage(MESSAGE_FORMAT.toByteString(result))
+                .build();
+
+            responseObserver.onNext(response);
+            responseObserver.onCompleted();
+        } catch (Exception e) {
+            log.error("Error during save", e);
+            responseObserver.onError(e);
+        }
+    }
+}

--- a/worker-controller/src/main/proto/metastore.proto
+++ b/worker-controller/src/main/proto/metastore.proto
@@ -30,6 +30,34 @@ service KVMetadataService {
   rpc deleteByName(KVMetadataRequest) returns (OpaqueData);
 }
 
+// Service for namespace file metadata operations - provides file metadata read/write to workers.
+// Only exposes worker-safe operations. Server-only operations (paginated listing with
+// advanced filters, version-aware queries, purge) require direct repository access via
+// NamespaceFileService.
+service NamespaceFileMetadataService {
+  // Find a namespace file metadata entry by tenant, namespace, and path.
+  // Optionally filter by a specific version and/or include deleted entries.
+  rpc findByPath(NamespaceFileMetadataPathRequest) returns (OpaqueData);
+
+  // Find children of a given parent path
+  rpc findChildren(NamespaceFileMetadataChildrenRequest) returns (OpaqueData);
+
+  // Find all non-deleted entries for a given tenant and namespace, with optional containing filter
+  rpc findAll(NamespaceFileMetadataFindAllRequest) returns (OpaqueData);
+
+  // Find namespace file metadata entries by a list of paths
+  rpc findByPaths(NamespaceFileMetadataPathsRequest) returns (OpaqueData);
+
+  // Find all versions of namespace file metadata entries by a list of paths
+  rpc findAllVersionsByPaths(NamespaceFileMetadataPathsRequest) returns (OpaqueData);
+
+  // Check whether any non-deleted namespace file entries exist in a namespace
+  rpc existsByNamespace(NamespaceRequest) returns (BooleanResponse);
+
+  // Save a namespace file metadata entry
+  rpc save(OpaqueData) returns (OpaqueData);
+}
+
 // Request to check if a namespace exists
 message NamespaceRequest {
   RequestOrResponseHeader header = 1;
@@ -55,4 +83,42 @@ message KVMetadataRequest {
   string namespace = 3;
   // The KV metadata entry name
   string name = 4;
+}
+
+// Request to find a namespace file metadata entry by path, with optional version filter
+message NamespaceFileMetadataPathRequest {
+  RequestOrResponseHeader header = 1;
+  string tenant_id = 2;
+  string namespace = 3;
+  string path = 4;
+  // Optional: when set, look up a specific version
+  optional int32 version = 5;
+  // Whether to include deleted entries (only used when version is set)
+  bool allow_deleted = 6;
+}
+
+// Request to find children of a parent path
+message NamespaceFileMetadataChildrenRequest {
+  RequestOrResponseHeader header = 1;
+  string tenant_id = 2;
+  string namespace = 3;
+  string parent_path = 4;
+  bool recursive = 5;
+}
+
+// Request to find all entries with optional containing filter
+message NamespaceFileMetadataFindAllRequest {
+  RequestOrResponseHeader header = 1;
+  string tenant_id = 2;
+  string namespace = 3;
+  optional string containing = 4;
+}
+
+// Request to find entries by a list of paths
+message NamespaceFileMetadataPathsRequest {
+  RequestOrResponseHeader header = 1;
+  string tenant_id = 2;
+  string namespace = 3;
+  repeated string paths = 4;
+  bool allow_deleted = 5;
 }

--- a/worker/src/main/java/io/kestra/worker/GrpcStubFactory.java
+++ b/worker/src/main/java/io/kestra/worker/GrpcStubFactory.java
@@ -7,6 +7,8 @@ import io.kestra.controller.grpc.KVMetadataServiceGrpc;
 import io.kestra.controller.grpc.KVMetadataServiceGrpc.KVMetadataServiceBlockingStub;
 import io.kestra.controller.grpc.LivenessControllerServiceGrpc;
 import io.kestra.controller.grpc.LivenessControllerServiceGrpc.LivenessControllerServiceBlockingStub;
+import io.kestra.controller.grpc.NamespaceFileMetadataServiceGrpc;
+import io.kestra.controller.grpc.NamespaceFileMetadataServiceGrpc.NamespaceFileMetadataServiceBlockingStub;
 import io.kestra.controller.grpc.WorkerControllerServiceGrpc;
 import io.kestra.controller.grpc.WorkerControllerServiceGrpc.WorkerControllerServiceBlockingStub;
 import io.kestra.controller.grpc.WorkerControllerServiceGrpc.WorkerControllerServiceStub;
@@ -57,5 +59,11 @@ public class GrpcStubFactory {
     @Singleton
     public KVMetadataServiceBlockingStub kvMetadataServiceBlockingStub(GrpcChannelManager manager) {
         return KVMetadataServiceGrpc.newBlockingStub(manager.getDefaultChannel());
+    }
+
+    @Bean
+    @Singleton
+    public NamespaceFileMetadataServiceBlockingStub namespaceFileMetadataServiceBlockingStub() {
+        return NamespaceFileMetadataServiceGrpc.newBlockingStub(grpcChannelManager.getDefaultChannel());
     }
 }

--- a/worker/src/main/java/io/kestra/worker/stores/GrpcWorkerNamespaceFileMetadataStateStore.java
+++ b/worker/src/main/java/io/kestra/worker/stores/GrpcWorkerNamespaceFileMetadataStateStore.java
@@ -1,0 +1,174 @@
+package io.kestra.worker.stores;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import io.kestra.controller.grpc.*;
+import io.kestra.controller.messages.MessageFormat;
+import io.kestra.controller.messages.MessageFormats;
+import io.kestra.controller.messages.RequestOrResponseHeaderFactory;
+import io.kestra.core.models.namespaces.files.NamespaceFileMetadata;
+import io.kestra.core.namespace.DefaultNamespaceFileMetadataStateStore;
+import io.kestra.core.namespace.NamespaceFileMetadataStateStore;
+import io.kestra.core.worker.models.WorkerInfo;
+import io.micronaut.context.annotation.Replaces;
+import io.micronaut.context.annotation.Requires;
+import jakarta.annotation.Nullable;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+import lombok.extern.slf4j.Slf4j;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Worker-side implementation of {@link NamespaceFileMetadataStateStore} that communicates
+ * with the controller via gRPC.
+ * <p>
+ * This implementation is used only by workers and replaces the default implementation
+ * that uses repositories (which are not available to workers).
+ * Only exposes worker-safe operations.
+ */
+@Singleton
+@Slf4j
+@Requires(property = "kestra.server-type", value = "WORKER")
+@Replaces(DefaultNamespaceFileMetadataStateStore.class)
+public class GrpcWorkerNamespaceFileMetadataStateStore implements NamespaceFileMetadataStateStore {
+
+    private static final MessageFormat MESSAGE_FORMAT = MessageFormats.JSON;
+    private static final TypeReference<List<NamespaceFileMetadata>> LIST_TYPE = new TypeReference<>() {};
+
+    private final NamespaceFileMetadataServiceGrpc.NamespaceFileMetadataServiceBlockingStub stub;
+    private final WorkerInfo workerInfo;
+
+    @Inject
+    public GrpcWorkerNamespaceFileMetadataStateStore(
+        final NamespaceFileMetadataServiceGrpc.NamespaceFileMetadataServiceBlockingStub stub,
+        final WorkerInfo workerInfo) {
+        this.stub = stub;
+        this.workerInfo = workerInfo;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public Optional<NamespaceFileMetadata> findByPath(String tenantId, String namespace, String path,
+                                                      @Nullable Integer version, boolean allowDeleted) throws IOException {
+        log.trace("Fetching namespace file metadata by path via gRPC: tenantId={}, namespace={}, path={}, version={}, allowDeleted={}",
+            tenantId, namespace, path, version, allowDeleted);
+
+        NamespaceFileMetadataPathRequest.Builder requestBuilder = NamespaceFileMetadataPathRequest.newBuilder()
+            .setHeader(RequestOrResponseHeaderFactory.create(workerInfo.getWorkerId()))
+            .setTenantId(tenantId)
+            .setNamespace(namespace)
+            .setPath(path)
+            .setAllowDeleted(allowDeleted);
+
+        if (version != null) {
+            requestBuilder.setVersion(version);
+        }
+
+        OpaqueData response = stub.findByPath(requestBuilder.build());
+        return Optional.ofNullable(MESSAGE_FORMAT.fromByteString(response.getMessage(), NamespaceFileMetadata.class));
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public List<NamespaceFileMetadata> findChildren(String tenantId, String namespace, @Nullable String parentPath, boolean recursive) {
+        log.trace("Fetching namespace file metadata children via gRPC: tenantId={}, namespace={}, parentPath={}, recursive={}",
+            tenantId, namespace, parentPath, recursive);
+
+        NamespaceFileMetadataChildrenRequest.Builder requestBuilder = NamespaceFileMetadataChildrenRequest.newBuilder()
+            .setHeader(RequestOrResponseHeaderFactory.create(workerInfo.getWorkerId()))
+            .setTenantId(tenantId)
+            .setNamespace(namespace)
+            .setRecursive(recursive);
+
+        if (parentPath != null) {
+            requestBuilder.setParentPath(parentPath);
+        }
+
+        OpaqueData response = stub.findChildren(requestBuilder.build());
+        return MESSAGE_FORMAT.fromByteString(response.getMessage(), LIST_TYPE);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public List<NamespaceFileMetadata> findAll(String tenantId, String namespace, @Nullable String containing) {
+        log.trace("Fetching all namespace file metadata via gRPC: tenantId={}, namespace={}, containing={}", tenantId, namespace, containing);
+
+        NamespaceFileMetadataFindAllRequest.Builder requestBuilder = NamespaceFileMetadataFindAllRequest.newBuilder()
+            .setHeader(RequestOrResponseHeaderFactory.create(workerInfo.getWorkerId()))
+            .setTenantId(tenantId)
+            .setNamespace(namespace);
+
+        if (containing != null) {
+            requestBuilder.setContaining(containing);
+        }
+
+        OpaqueData response = stub.findAll(requestBuilder.build());
+        return MESSAGE_FORMAT.fromByteString(response.getMessage(), LIST_TYPE);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public List<NamespaceFileMetadata> findByPaths(String tenantId, String namespace, List<String> paths, boolean allowDeleted) {
+        log.trace("Fetching namespace file metadata by paths via gRPC: tenantId={}, namespace={}, paths={}, allowDeleted={}",
+            tenantId, namespace, paths, allowDeleted);
+
+        NamespaceFileMetadataPathsRequest request = NamespaceFileMetadataPathsRequest.newBuilder()
+            .setHeader(RequestOrResponseHeaderFactory.create(workerInfo.getWorkerId()))
+            .setTenantId(tenantId)
+            .setNamespace(namespace)
+            .addAllPaths(paths)
+            .setAllowDeleted(allowDeleted)
+            .build();
+
+        OpaqueData response = stub.findByPaths(request);
+        return MESSAGE_FORMAT.fromByteString(response.getMessage(), LIST_TYPE);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public List<NamespaceFileMetadata> findAllVersionsByPaths(String tenantId, String namespace, List<String> paths) {
+        log.trace("Fetching all versions of namespace file metadata by paths via gRPC: tenantId={}, namespace={}, paths={}",
+            tenantId, namespace, paths);
+
+        NamespaceFileMetadataPathsRequest request = NamespaceFileMetadataPathsRequest.newBuilder()
+            .setHeader(RequestOrResponseHeaderFactory.create(workerInfo.getWorkerId()))
+            .setTenantId(tenantId)
+            .setNamespace(namespace)
+            .addAllPaths(paths)
+            .build();
+
+        OpaqueData response = stub.findAllVersionsByPaths(request);
+        return MESSAGE_FORMAT.fromByteString(response.getMessage(), LIST_TYPE);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public boolean existsByNamespace(String tenantId, String namespace) {
+        log.trace("Checking namespace file existence by namespace via gRPC: tenantId={}, namespace={}", tenantId, namespace);
+
+        NamespaceRequest request = NamespaceRequest.newBuilder()
+            .setHeader(RequestOrResponseHeaderFactory.create(workerInfo.getWorkerId()))
+            .setTenantId(tenantId)
+            .setNamespace(namespace)
+            .build();
+
+        BooleanResponse response = stub.existsByNamespace(request);
+        return response.getValue();
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public NamespaceFileMetadata save(NamespaceFileMetadata item) {
+        log.trace("Saving namespace file metadata via gRPC: namespace={}, path={}", item.getNamespace(), item.getPath());
+
+        OpaqueData request = OpaqueData.newBuilder()
+            .setHeader(RequestOrResponseHeaderFactory.create(workerInfo.getWorkerId()))
+            .setMessage(MESSAGE_FORMAT.toByteString(item))
+            .build();
+
+        OpaqueData response = stub.save(request);
+        return MESSAGE_FORMAT.fromByteString(response.getMessage(), NamespaceFileMetadata.class);
+    }
+}


### PR DESCRIPTION
- Introduce NamespaceFileMetadataStateStore abstraction with default
- Add repository-based and gRPC (worker-based) implementations
- Move server-only operations (paginated listing, purge) to NamespaceFileService.
- Refactor PurgeFiles, Version tasks to use additionalService()
- Add tests for DefaultNamespaceFileMetadataStateStore across H2, Postgres, and MySQL

Part-of: kestra-io/kestra-ee#6745