### PR TITLE
chore(executions): remove subflow check when displaying parent execution field

### DIFF
--- a/ui/src/components/executions/overview/Overview.vue
+++ b/ui/src/components/executions/overview/Overview.vue
@@ -341,9 +341,7 @@
                             )?.value ?? "-",
                     },
                 ]),
-            ...(execution.value.trigger?.type ===
-                "io.kestra.plugin.core.flow.Subflow" &&
-                execution.value.trigger?.variables?.executionId
+            ...(execution.value.trigger?.variables?.executionId
                 ? [
                     {
                         icon: History,


### PR DESCRIPTION
Related to https://github.com/kestra-io/kestra/issues/14273.