### PR TITLE
fix(core): fix multiple race conditions in AbstractSubscriber state

### DIFF
--- a/queue/src/main/java/io/kestra/queue/AbstractPollingSubscriber.java
+++ b/queue/src/main/java/io/kestra/queue/AbstractPollingSubscriber.java
@@ -17,7 +17,7 @@ import static org.awaitility.Awaitility.await;
 
 /**
  * A subscriber that uses a polling mechanism.
- * It used the {@link QueuePoller} to periodically execute a poll query (wheter on a database or a message broker)
+ * It used the {@link QueuePoller} to periodically execute a poll query (whether on a database or a message broker)
  * with a polling sleep defined by a {@link QueuePollerConfiguration}.
  */
 @Slf4j
@@ -59,35 +59,37 @@ public abstract class AbstractPollingSubscriber<T extends Event> extends Abstrac
             List<QueuePollerConfiguration.Step> steps = configuration.computeSteps();
             ZonedDateTime lastPoll = ZonedDateTime.now();
 
-            while (this.isRunning() || this.isPaused()) {
-                try {
-                    this.waitIfPaused();
+            try {
+                while (this.isActive()) {
+                    try {
+                        this.waitIfPaused();
 
-                    // Check if the loop was stopped while being paused
-                    if (!this.isRunning()) {
-                        return;
-                    }
+                        // Check if the loop was stopped while being paused
+                        if (!this.isActive()) {
+                            return;
+                        }
 
-                    lastPoll = queuePoller.pollOnce(lastPoll, steps);
-                } catch (InterruptedException e) {
-                    Thread.currentThread().interrupt();
-                    log.error("Interrupted while waiting. Stopping.", e);
-                    this.markEnd();
-                } catch(Exception e) {
-                    if ("io.micronaut.transaction.exceptions.CannotCreateTransactionException".equals(e.getClass().getName())) {
-                        // we ignore a transaction creation error as it is either Kestra shutting down or some other place that will fail
-                        log.debug("Can't poll on receive", e);
-                    } else {
-                        log.error("Unexpected error while polling messages", e);
+                        lastPoll = queuePoller.pollOnce(lastPoll, steps);
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                        log.error("Interrupted while waiting. Stopping.", e);
                         this.markEnd();
+                    } catch (Exception e) {
+                        if ("io.micronaut.transaction.exceptions.CannotCreateTransactionException".equals(e.getClass().getName())) {
+                            // we ignore a transaction creation error as it is either Kestra shutting down or some other place that will fail
+                            log.debug("Can't poll on receive", e);
+                        } else {
+                            log.error("Unexpected error while polling messages. Stopping.", e);
+                            this.markEnd();
+                        }
                     }
                 }
+            } finally {
+                this.markEnd();
             }
-
-            this.markEnd();
         });
 
-        await().until(this::isRunning);
+        await().until(this::isActive);
 
         return this;
     }

--- a/queue/src/main/java/io/kestra/queue/AbstractSubscriber.java
+++ b/queue/src/main/java/io/kestra/queue/AbstractSubscriber.java
@@ -10,17 +10,21 @@ import lombok.extern.slf4j.Slf4j;
 
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.locks.Condition;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Consumer;
 
 @Slf4j
 public abstract class AbstractSubscriber<T extends Event> implements QueueSubscriber<T> {
+    private static final long CLOSE_TIMEOUT_SECONDS = 30;
+
     private final CountDownLatch stopped = new CountDownLatch(1);
     private final ReentrantLock pauseLock = new ReentrantLock();
     private final Condition unpaused = pauseLock.newCondition();
-    private final AtomicReference<State> state = new AtomicReference<>(State.STOPPED);
+    private final AtomicBoolean active = new AtomicBoolean(false);
+    private final AtomicBoolean paused = new AtomicBoolean(false);
 
     protected final Class<T> cls;
     protected final QueueService queueService;
@@ -115,20 +119,20 @@ public abstract class AbstractSubscriber<T extends Event> implements QueueSubscr
      * This method should be called by subclasses before processing each message
      * to honor the pause/resume contract. If the subscriber is not paused, this
      * method returns immediately. If paused, it blocks until {@link #resume()}
-     * is called.
+     * is called or the subscriber is closed.
      *
      * @throws InterruptedException if the thread is interrupted while waiting
      */
     protected void waitIfPaused() throws InterruptedException {
-        // return immediately if not paused.
-        if (!this.state.get().equals(State.PAUSED)) {
+        // return immediately if not paused
+        if (!this.paused.get()) {
             return;
         }
 
-        // lock and wait until resumed
+        // lock and wait until resumed or closed
         pauseLock.lock();
         try {
-            while (this.state.get().equals(State.PAUSED)) {
+            while (this.paused.get() && this.active.get()) {
                 if (log.isDebugEnabled()) {
                     log.debug("{} paused, waiting to resume", logPrefix);
                 }
@@ -144,64 +148,47 @@ public abstract class AbstractSubscriber<T extends Event> implements QueueSubscr
         }
     }
 
-    protected boolean isRunning() {
-        return this.state.get() == State.RUNNING;
+    protected boolean isActive() {
+        return this.active.get();
     }
 
     protected boolean isPaused() {
-        return this.state.get() == State.PAUSED;
-    }
-
-    private boolean changeState(State expected, State newState) {
-        if (log.isDebugEnabled()) {
-            log.debug("{} change state requested {} to {}", logPrefix, expected, newState);
-        }
-
-        if (this.state.compareAndSet(expected, newState)) {
-            return true;
-        }
-
-        throw new IllegalStateException(logPrefix + " illegal state change to " + newState + " from " + expected + ", current state is " + this.state.get());
+        return this.paused.get();
     }
 
     protected void markReady() {
         if (log.isDebugEnabled()) {
-            log.debug("{} Mark ready received", logPrefix);
+            log.debug("{} mark ready received", logPrefix);
         }
 
-        this.changeState(State.STOPPED, State.RUNNING);
+        this.active.set(true);
     }
 
+    /** {@inheritDoc} */
     @Override
     public void pause() {
         if (log.isDebugEnabled()) {
             log.debug("{} pause received", logPrefix);
         }
 
-        if (this.state.get() == State.PAUSED) {
-            return; // already paused
+        pauseLock.lock();
+        try {
+            this.paused.set(true);
+        } finally {
+            pauseLock.unlock();
         }
-
-        this.changeState(State.RUNNING, State.PAUSED);
     }
 
+    /** {@inheritDoc} */
     @Override
     public void resume() {
-        if (this.state.get() == State.STOPPED) {
-            return;
-        }
-
         if (log.isDebugEnabled()) {
             log.debug("{} resume received", logPrefix);
         }
 
         pauseLock.lock();
         try {
-            if (this.state.get() == State.RUNNING) {
-                return; // already running
-            }
-
-            if (this.changeState(State.PAUSED, State.RUNNING)) {
+            if (this.paused.compareAndSet(true, false)) {
                 unpaused.signalAll();
             }
         } finally {
@@ -209,21 +196,21 @@ public abstract class AbstractSubscriber<T extends Event> implements QueueSubscr
         }
     }
 
+    /**
+     * Marks the subscriber as stopped and unblocks any waiting threads.
+     */
     protected void markEnd() {
         if (log.isDebugEnabled()) {
             log.debug("{} mark end received", logPrefix);
         }
-
-        if (this.isRunning()) {
-            this.changeState(State.RUNNING, State.STOPPED);
-        }
-
+        this.active.set(false);
         this.stopped.countDown();
     }
 
+    /** {@inheritDoc} */
     @Override
     public void close() {
-        if (this.state.get() == State.STOPPED) {
+        if (!this.active.compareAndSet(true, false)) {
             return;
         }
 
@@ -231,28 +218,17 @@ public abstract class AbstractSubscriber<T extends Event> implements QueueSubscr
             log.debug("{} close received", logPrefix);
         }
 
-        // in case it's paused and blocked
+        // unblock waitIfPaused() if paused
         resume();
 
-        // already stopped
+        // wait for the subscriber loop to finish
         try {
-            this.changeState(State.RUNNING, State.STOPPED);
-        } catch (IllegalStateException ignored) {
-            return;
-        }
-
-        // wait for the queue to be stopped
-        try {
-            stopped.await();
+            if (!stopped.await(CLOSE_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
+                log.warn("{} timed out after {}s waiting for subscriber to stop", logPrefix, CLOSE_TIMEOUT_SECONDS);
+            }
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
             log.warn("{} interrupted while waiting to be stopped.", logPrefix);
         }
-    }
-
-    public enum State {
-        RUNNING,
-        PAUSED,
-        STOPPED
     }
 }

--- a/queue/src/test/java/io/kestra/queue/AbstractSubscriberTest.java
+++ b/queue/src/test/java/io/kestra/queue/AbstractSubscriberTest.java
@@ -1,0 +1,454 @@
+package io.kestra.queue;
+
+import io.kestra.core.exceptions.DeserializationException;
+import io.kestra.core.metrics.MetricRegistry;
+import io.kestra.core.queues.QueueSubscriber;
+import io.kestra.core.queues.event.Event;
+import io.kestra.core.utils.Either;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class AbstractSubscriberTest {
+
+    private QueueService queueService;
+    private MetricRegistry metricRegistry;
+
+    @BeforeEach
+    void setUp() {
+        queueService = mock(QueueService.class);
+        metricRegistry = mock(MetricRegistry.class);
+        when(metricRegistry.timer(anyString(), anyString(), anyString(), anyString()))
+            .thenReturn(mock(io.micrometer.core.instrument.Timer.class));
+    }
+
+    private TestSubscriber createSubscriber() {
+        return new TestSubscriber(queueService, metricRegistry);
+    }
+
+    @Test
+    void shouldStartNotRunningAndNotPaused() {
+        // Given
+        var subscriber = createSubscriber();
+
+        // Then
+        assertThat(subscriber.isActive()).isFalse();
+        assertThat(subscriber.isPaused()).isFalse();
+    }
+
+    @Test
+    void shouldSetRunningOnMarkReady() {
+        // Given
+        var subscriber = createSubscriber();
+
+        // When
+        subscriber.markReady();
+
+        // Then
+        assertThat(subscriber.isActive()).isTrue();
+    }
+
+    @Test
+    void markReadyShouldBeIdempotent() {
+        // Given
+        var subscriber = createSubscriber();
+
+        // When
+        subscriber.markReady();
+        subscriber.markReady();
+
+        // Then
+        assertThat(subscriber.isActive()).isTrue();
+    }
+
+    @Test
+    void shouldClearRunningOnMarkEnd() {
+        // Given
+        var subscriber = createSubscriber();
+        subscriber.markReady();
+
+        // When
+        subscriber.markEnd();
+
+        // Then
+        assertThat(subscriber.isActive()).isFalse();
+    }
+
+    @Test
+    void markEndShouldBeIdempotent() {
+        // Given
+        var subscriber = createSubscriber();
+        subscriber.markReady();
+
+        // When/Then
+        assertThatNoException().isThrownBy(() -> {
+            subscriber.markEnd();
+            subscriber.markEnd();
+        });
+        assertThat(subscriber.isActive()).isFalse();
+    }
+
+    @Test
+    void markEndShouldBeCallableWhenNeverStarted() {
+        // Given
+        var subscriber = createSubscriber();
+
+        // When/Then
+        assertThatNoException().isThrownBy(subscriber::markEnd);
+    }
+
+    @Test
+    void shouldSetPausedOnPause() {
+        // Given
+        var subscriber = createSubscriber();
+        subscriber.markReady();
+
+        // When
+        subscriber.pause();
+
+        // Then
+        assertThat(subscriber.isPaused()).isTrue();
+    }
+
+    @Test
+    void shouldClearPausedOnResume() {
+        // Given
+        var subscriber = createSubscriber();
+        subscriber.markReady();
+        subscriber.pause();
+
+        // When
+        subscriber.resume();
+
+        // Then
+        assertThat(subscriber.isPaused()).isFalse();
+    }
+
+    @Test
+    void pauseShouldBeIdempotent() {
+        // Given
+        var subscriber = createSubscriber();
+        subscriber.markReady();
+
+        // When
+        subscriber.pause();
+        subscriber.pause();
+
+        // Then
+        assertThat(subscriber.isPaused()).isTrue();
+    }
+
+    @Test
+    void resumeShouldBeIdempotentWhenNotPaused() {
+        // Given
+        var subscriber = createSubscriber();
+        subscriber.markReady();
+
+        // When/Then
+        assertThatNoException().isThrownBy(subscriber::resume);
+        assertThat(subscriber.isPaused()).isFalse();
+    }
+
+    @Test
+    void shouldAllowPauseBeforeMarkReady() {
+        // Given
+        var subscriber = createSubscriber();
+
+        // When
+        assertThatNoException().isThrownBy(subscriber::pause);
+
+        // Then
+        assertThat(subscriber.isPaused()).isTrue();
+        assertThat(subscriber.isActive()).isFalse();
+    }
+
+    @Test
+    void shouldAllowPauseAfterClose() {
+        // Given
+        var subscriber = createSubscriber();
+        subscriber.markReady();
+        subscriber.markEnd();
+        subscriber.close();
+
+        // When/Then
+        assertThatNoException().isThrownBy(subscriber::pause);
+    }
+
+    @Test
+    void shouldAllowResumeAfterClose() {
+        // Given
+        var subscriber = createSubscriber();
+        subscriber.markReady();
+        subscriber.markEnd();
+        subscriber.close();
+
+        // When/Then
+        assertThatNoException().isThrownBy(subscriber::resume);
+    }
+
+    @Test
+    void waitIfPausedShouldReturnImmediatelyWhenNotPaused() throws InterruptedException {
+        // Given
+        var subscriber = createSubscriber();
+        subscriber.markReady();
+
+        // When/Then - should not block
+        subscriber.waitIfPaused();
+    }
+
+    @Test
+    void waitIfPausedShouldBlockUntilResumed() throws InterruptedException {
+        // Given
+        var subscriber = createSubscriber();
+        subscriber.markReady();
+        subscriber.pause();
+
+        var waitStarted = new CountDownLatch(1);
+        var waitCompleted = new CountDownLatch(1);
+
+        // When
+        Thread waiter = Thread.ofVirtual().start(() -> {
+            try {
+                waitStarted.countDown();
+                subscriber.waitIfPaused();
+                waitCompleted.countDown();
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+        });
+
+        // Then - should be blocked
+        assertThat(waitStarted.await(1, TimeUnit.SECONDS)).isTrue();
+        assertThat(waitCompleted.await(100, TimeUnit.MILLISECONDS)).isFalse();
+
+        // When - resume
+        subscriber.resume();
+
+        // Then - should unblock
+        assertThat(waitCompleted.await(1, TimeUnit.SECONDS)).isTrue();
+        waiter.join(1000);
+    }
+
+    @Test
+    void waitIfPausedShouldUnblockWhenClosed() throws InterruptedException {
+        // Given
+        var subscriber = createSubscriber();
+        subscriber.markReady();
+        subscriber.pause();
+
+        var waitCompleted = new CountDownLatch(1);
+
+        // Simulate a real subscriber loop: waitIfPaused → markEnd on exit
+        Thread waiter = Thread.ofVirtual().start(() -> {
+            try {
+                subscriber.waitIfPaused();
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            } finally {
+                subscriber.markEnd();
+                waitCompleted.countDown();
+            }
+        });
+
+        Thread.sleep(50);
+
+        // When
+        subscriber.close();
+
+        // Then
+        assertThat(waitCompleted.await(2, TimeUnit.SECONDS)).isTrue();
+        waiter.join(1000);
+    }
+
+    @Test
+    void closeShouldBeIdempotent() {
+        // Given
+        var subscriber = createSubscriber();
+        subscriber.markReady();
+        subscriber.markEnd();
+
+        // When/Then
+        assertThatNoException().isThrownBy(() -> {
+            subscriber.close();
+            subscriber.close();
+        });
+    }
+
+    @Test
+    void closeShouldBeNoOpWhenNeverStarted() {
+        // Given
+        var subscriber = createSubscriber();
+
+        // When/Then
+        assertThatNoException().isThrownBy(subscriber::close);
+    }
+
+    @Test
+    void closeShouldSetRunningToFalse() {
+        // Given
+        var subscriber = createSubscriber();
+        subscriber.markReady();
+        subscriber.markEnd();
+
+        // When
+        subscriber.close();
+
+        // Then
+        assertThat(subscriber.isActive()).isFalse();
+    }
+
+    @Test
+    void closeShouldResumeAndUnblockLoop() throws InterruptedException {
+        // Given - subscriber is running and paused with a simulated loop
+        var subscriber = createSubscriber();
+        subscriber.markReady();
+        subscriber.pause();
+
+        var closeCompleted = new CountDownLatch(1);
+
+        Thread loop = Thread.ofVirtual().start(() -> {
+            try {
+                subscriber.waitIfPaused();
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            } finally {
+                subscriber.markEnd();
+            }
+        });
+
+        Thread.sleep(50);
+
+        // When
+        Thread closer = Thread.ofVirtual().start(() -> {
+            subscriber.close();
+            closeCompleted.countDown();
+        });
+
+        // Then
+        assertThat(closeCompleted.await(2, TimeUnit.SECONDS)).isTrue();
+        loop.join(1000);
+        closer.join(1000);
+    }
+
+    @Test
+    void shouldSupportPauseBeforeSubscribePattern() throws InterruptedException {
+        // Given - this is the pattern used in WorkerJobDispatcher:
+        // pause() → subscribe() → resume() when ready
+        var subscriber = createSubscriber();
+        subscriber.pause();
+
+        var loopEntered = new CountDownLatch(1);
+        var messageProcessed = new AtomicBoolean(false);
+        var loopExited = new CountDownLatch(1);
+
+        // When - start the subscriber loop (simulating subscribe)
+        Thread loop = Thread.ofVirtual().start(() -> {
+            subscriber.markReady();
+            try {
+                while (subscriber.isActive()) {
+                    loopEntered.countDown();
+                    subscriber.waitIfPaused();
+                    if (!subscriber.isActive()) break;
+                    messageProcessed.set(true);
+                    break;
+                }
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            } finally {
+                subscriber.markEnd();
+                loopExited.countDown();
+            }
+        });
+
+        // Then - loop should be blocked on waitIfPaused
+        assertThat(loopEntered.await(1, TimeUnit.SECONDS)).isTrue();
+        Thread.sleep(50);
+        assertThat(messageProcessed.get()).isFalse();
+
+        // When - resume
+        subscriber.resume();
+
+        // Then - loop processes and exits
+        assertThat(loopExited.await(1, TimeUnit.SECONDS)).isTrue();
+        assertThat(messageProcessed.get()).isTrue();
+        loop.join(1000);
+    }
+
+    @Test
+    void shouldNotThrowOnConcurrentPauseAndClose() throws InterruptedException {
+        // Given
+        var subscriber = createSubscriber();
+        subscriber.markReady();
+
+        var loopExited = new CountDownLatch(1);
+        Thread loop = Thread.ofVirtual().start(() -> {
+            try {
+                while (subscriber.isActive()) {
+                    subscriber.waitIfPaused();
+                    if (!subscriber.isActive()) break;
+                    Thread.sleep(5);
+                }
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            } finally {
+                subscriber.markEnd();
+                loopExited.countDown();
+            }
+        });
+
+        // When - pause and close concurrently
+        var errors = new AtomicReference<Throwable>();
+
+        Thread pauser = Thread.ofVirtual().start(() -> {
+            try {
+                subscriber.pause();
+            } catch (Throwable t) {
+                errors.set(t);
+            }
+        });
+
+        Thread closer = Thread.ofVirtual().start(() -> {
+            try {
+                subscriber.close();
+            } catch (Throwable t) {
+                errors.compareAndSet(null, t);
+            }
+        });
+
+        // Then
+        pauser.join(1000);
+        closer.join(2000);
+        assertThat(loopExited.await(2, TimeUnit.SECONDS)).isTrue();
+        assertThat(errors.get()).isNull();
+        loop.join(1000);
+    }
+
+    /**
+     * Minimal concrete implementation for testing AbstractSubscriber.
+     */
+    static class TestSubscriber extends AbstractSubscriber<TestEvent> {
+
+        TestSubscriber(QueueService queueService, MetricRegistry metricRegistry) {
+            super(TestEvent.class, "test-queue", queueService, metricRegistry);
+        }
+
+        @Override
+        public QueueSubscriber<TestEvent> subscribe(Consumer<Either<TestEvent, DeserializationException>> consumer) {
+            return this;
+        }
+    }
+
+    record TestEvent(String key) implements Event {
+    }
+}

--- a/worker-controller/src/main/java/io/kestra/controller/grpc/services/WorkerJobDispatcher.java
+++ b/worker-controller/src/main/java/io/kestra/controller/grpc/services/WorkerJobDispatcher.java
@@ -212,11 +212,8 @@ public class WorkerJobDispatcher {
     private GroupState createGroupState(String workerGroup) {
         String workerGroupOrNull = workerGroup.isEmpty() ? null : workerGroup;
         QueueSubscriber<WorkerJobEvent> subscriber = workerJobEventQueue.subscriber(workerGroupOrNull);
-        subscriber.subscribe(either -> handleIncomingJob(workerGroup, either));
-        
-        // TODO we should be able to start in paused state and only resume when the first worker with permits connects,
-        //  but that requires a code change in the queue implementation to support starting paused
         subscriber.pause();  // Start paused until workers connect with permits
+        subscriber.subscribe(either -> handleIncomingJob(workerGroup, either));
         log.info("Created queue subscription for worker group '{}' (initially paused)", WorkerGroup.forLog(workerGroup));
         return new GroupState(subscriber);
     }

--- a/worker/src/main/java/io/kestra/worker/fetchers/WorkerJobFetcher.java
+++ b/worker/src/main/java/io/kestra/worker/fetchers/WorkerJobFetcher.java
@@ -209,7 +209,7 @@ public class WorkerJobFetcher extends WorkerLoop {
                 .setMaxConcurrency(workerContext.workerThreads())
                 .build());
 
-        requestStream.onNext(requestBuilder.build());
+        doSend(requestStream, requestBuilder.build());
         lastSentPermits.set(initialPermits);
         log.info("Connected to controller: workerId={}, workerGroup={}, maxConcurrency={}, initialPermits={}",
             workerContext.workerId(),
@@ -328,7 +328,12 @@ public class WorkerJobFetcher extends WorkerLoop {
 
     private void doSend(ClientCallStreamObserver<WorkerJobRequest> observer, WorkerJobRequest request) {
         synchronized (streamLock) {
-            observer.onNext(request);
+            try {
+                observer.onNext(request);
+            } catch (IllegalStateException e) {
+                log.warn("Stream cancelled, will reconnect: {}", e.getMessage());
+                requestObserverRef.set(null);
+            }
         }
     }
 

--- a/worker/src/main/java/io/kestra/worker/fetchers/WorkerJobFetcher.java
+++ b/worker/src/main/java/io/kestra/worker/fetchers/WorkerJobFetcher.java
@@ -158,8 +158,11 @@ public class WorkerJobFetcher extends WorkerLoop {
                 public void onError(Throwable t) {
                     if (!isRunning()) {
                         log.debug("Stream closed during shutdown: {}", t.getMessage());
+                    // log with WARN level if stream fails during normal operation because it will be automatically retried and can indicate transient issues
+                    } else if (t.getCause() != null) {
+                        log.warn("Stream error: {}. Cause: {}", t.getMessage(), t.getCause().getMessage());
                     } else {
-                        log.error("Stream error: {}", t.getMessage(), t);
+                        log.warn("Stream error: {}", t.getMessage());
                     }
                     requestObserverRef.set(null);
                     streamCompleted.countDown();


### PR DESCRIPTION
Replace State enum with two independent AtomicBooleans (running, paused)
- Fix pause() threw IllegalStateException when subscriber was stopped
- Fix close() could hang forever (no timeout on stopped.await())
- Fix pause() before subscribe() was impossible (state started as STOPPED)
- Fix races between pause() and concurrent close()

Add unit-tests for AbstractSubscriber

Part-of: kestra-io/kestra-ee#6758