### PR TITLE
fix: add correct 'CANCELLED' type for Exit task while keeping compati…

### DIFF
--- a/core/src/main/java/io/kestra/plugin/core/execution/Exit.java
+++ b/core/src/main/java/io/kestra/plugin/core/execution/Exit.java
@@ -133,11 +133,11 @@ public class Exit extends Task implements ExecutionUpdatableTask {
             case WARNING -> State.Type.WARNING;
             case KILLED -> State.Type.KILLED;
             case FAILED -> State.Type.FAILED;
-            case CANCELED -> State.Type.CANCELLED;
+            case CANCELED, CANCELLED -> State.Type.CANCELLED;
         };
     }
 
     public enum ExitState {
-        SUCCESS, WARNING, KILLED, FAILED, CANCELED
+        SUCCESS, WARNING, KILLED, FAILED, @Deprecated(since = "1.3", forRemoval = true) CANCELED, CANCELLED
     }
 }

--- a/core/src/test/java/io/kestra/plugin/core/execution/ExitTest.java
+++ b/core/src/test/java/io/kestra/plugin/core/execution/ExitTest.java
@@ -1,12 +1,12 @@
 package io.kestra.plugin.core.execution;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 import io.kestra.core.junit.annotations.ExecuteFlow;
 import io.kestra.core.junit.annotations.KestraTest;
 import io.kestra.core.models.executions.Execution;
 import io.kestra.core.models.flows.State;
 import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 @KestraTest(startRunner = true)
 class ExitTest {
@@ -39,5 +39,23 @@ class ExitTest {
         assertThat(execution.findTaskRunsByTaskId("nested_bool_check").getFirst().getState().getCurrent()).isEqualTo(State.Type.FAILED);
         assertThat(execution.findTaskRunsByTaskId("nested_bool_check").getFirst().getAttempts().getFirst().getState().getCurrent()).isEqualTo(State.Type.FAILED);
         assertThat(execution.findTaskRunsByTaskId("nested_was_false").getFirst().getState().getCurrent()).isEqualTo(State.Type.FAILED);
+    }
+
+    @Test
+    @ExecuteFlow("flows/valids/exit-canceled.yaml")
+    void shouldExitWithCanceled(Execution execution) {
+        assertThat(execution.getState().getCurrent()).isEqualTo(State.Type.CANCELLED);
+        assertThat(execution.getTaskRunList()).hasSize(2);
+        assertThat(execution.getTaskRunList().getFirst().getState().getCurrent()).isEqualTo(State.Type.CANCELLED);
+        assertThat(execution.getTaskRunList().get(1).getState().getCurrent()).isEqualTo(State.Type.CANCELLED);
+    }
+
+    @Test
+    @ExecuteFlow("flows/valids/exit-cancelled.yaml")
+    void shouldExitWithCancelled(Execution execution) {
+        assertThat(execution.getState().getCurrent()).isEqualTo(State.Type.CANCELLED);
+        assertThat(execution.getTaskRunList()).hasSize(2);
+        assertThat(execution.getTaskRunList().getFirst().getState().getCurrent()).isEqualTo(State.Type.CANCELLED);
+        assertThat(execution.getTaskRunList().get(1).getState().getCurrent()).isEqualTo(State.Type.CANCELLED);
     }
 }

--- a/core/src/test/resources/flows/valids/exit-canceled.yaml
+++ b/core/src/test/resources/flows/valids/exit-canceled.yaml
@@ -1,0 +1,26 @@
+id: exit-canceled
+namespace: io.kestra.tests
+
+inputs:
+  - id: state
+    type: SELECT
+    values:
+      - CONTINUE
+      - END
+    defaults: END
+
+tasks:
+  - id: if
+    type: io.kestra.plugin.core.flow.If
+    condition: "{{inputs.state == 'CONTINUE'}}"
+    then:
+      - id: hello
+        type: io.kestra.plugin.core.log.Log
+        message: I'm continuing
+    else:
+      - id: exit
+        type: io.kestra.plugin.core.execution.Exit
+        state: CANCELED
+  - id: end
+    type: io.kestra.plugin.core.log.Log
+    message: I'm ending

--- a/core/src/test/resources/flows/valids/exit-cancelled.yaml
+++ b/core/src/test/resources/flows/valids/exit-cancelled.yaml
@@ -1,0 +1,26 @@
+id: exit-cancelled
+namespace: io.kestra.tests
+
+inputs:
+  - id: state
+    type: SELECT
+    values:
+      - CONTINUE
+      - END
+    defaults: END
+
+tasks:
+  - id: if
+    type: io.kestra.plugin.core.flow.If
+    condition: "{{inputs.state == 'CONTINUE'}}"
+    then:
+      - id: hello
+        type: io.kestra.plugin.core.log.Log
+        message: I'm continuing
+    else:
+      - id: exit
+        type: io.kestra.plugin.core.execution.Exit
+        state: CANCELLED
+  - id: end
+    type: io.kestra.plugin.core.log.Log
+    message: I'm ending


### PR DESCRIPTION
…bility with previous and now deprecated 'CANCELED'

close #14719
