### PR TITLE
feat(ui): add color code to log level filter

### DIFF
--- a/ui/src/components/filter/components/layout/FilterSelect.vue
+++ b/ui/src/components/filter/components/layout/FilterSelect.vue
@@ -13,7 +13,15 @@
                     :key="option.value"
                     :label="option.label"
                     :value="option.value"
-                />
+                >
+                    <span v-if="option.color" class="color-option">
+                        <span
+                            class="color-dot"
+                            :style="{backgroundColor: option.color}"
+                        />
+                        {{ option.label }}
+                    </span>
+                </el-option>
             </el-select>
         </div>
 
@@ -50,7 +58,7 @@
         endDateValue?: Date | null;
         startDateValue?: Date | null;
         timeRangeMode?: "predefined" | "custom";
-        options: {value: string; label: string}[];
+        options: {value: string; label: string; color?: string}[];
     }>();
 
     const emit = defineEmits<{
@@ -119,5 +127,19 @@
 
 .el-select-dropdown__item {
     font-size: 14px;
+}
+
+.color-option {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+
+    .color-dot {
+        display: inline-block;
+        width: 10px;
+        height: 10px;
+        border-radius: 50%;
+        flex-shrink: 0;
+    }
 }
 </style>

--- a/ui/src/components/filter/composables/useValues.ts
+++ b/ui/src/components/filter/composables/useValues.ts
@@ -92,7 +92,11 @@ export function useValues(label: string | undefined, t?: ReturnType<typeof useI1
                 value: "TEST",
             }]),
         ],
-        LEVELS: buildFromArray(["TRACE", "DEBUG", "INFO", "WARN", "ERROR"]),
+        LEVELS: ["TRACE", "DEBUG", "INFO", "WARN", "ERROR"].map(level => ({
+            label: level,
+            value: level,
+            color: `var(--ks-log-border-${level.toLowerCase()})`,
+        })),
         TYPES: auditLogTypes,
         PERMISSIONS: buildFromObject(permission),
         ACTIONS: buildFromObject({

--- a/ui/src/components/filter/utils/filterTypes.ts
+++ b/ui/src/components/filter/utils/filterTypes.ts
@@ -37,6 +37,7 @@ export interface FilterKeyConfig {
 export interface FilterValue {
     label: string;
     value: string;
+    color?: string;
     description?: string;
 }
 


### PR DESCRIPTION
### ✨ Description

This PR adds log severity color codes to the log filter options improving user orientation.

Note no log-specific filter was crated, as the color option was added to the existing filter instead.

### 🎨 Frontend Checklist

- [x] Code builds without errors (`npm run build`)
- [ ] All existing E2E tests pass (`npm run test:e2e`)
- [x] Screenshots or video recordings attached showing the `UI` changes

![log_level](https://github.com/user-attachments/assets/28f9ac50-378c-435a-82ab-ecf3071c78a5)


