### PR TITLE
fix(core): replace HTTP URL regex with java.net.URI for URI input validation

### DIFF
--- a/core/src/main/java/io/kestra/core/runners/FlowInputOutput.java
+++ b/core/src/main/java/io/kestra/core/runners/FlowInputOutput.java
@@ -47,8 +47,6 @@ import java.time.LocalTime;
 import java.util.*;
 import java.util.function.Function;
 import java.util.function.Supplier;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import static io.kestra.core.utils.Rethrow.throwFunction;
@@ -58,7 +56,7 @@ import static io.kestra.core.utils.Rethrow.throwFunction;
  */
 @Singleton
 public class FlowInputOutput {
-    private static final Pattern URI_PATTERN = Pattern.compile("^[a-z]+:\\/\\/(?:www\\.)?[-a-zA-Z0-9@:%._\\+~#=]{1,256}\\.[a-zA-Z0-9()]{1,6}\\b(?:[-a-zA-Z0-9()@:%_\\+.~#?&\\/=]*)$");
+
     private static final ObjectMapper YAML_MAPPER = JacksonMapper.ofYaml();
 
     private final StorageInterface storageInterface;
@@ -493,12 +491,11 @@ public class FlowInputOutput {
                 case JSON -> (current instanceof Map || current instanceof Collection<?>) ? current :  JacksonMapper.toObject(current.toString());
                 case YAML -> (current instanceof Map || current instanceof Collection<?>) ? current : YAML_MAPPER.readValue(current.toString(), JacksonMapper.OBJECT_TYPE_REFERENCE);
                 case URI -> {
-                    Matcher matcher = URI_PATTERN.matcher(current.toString());
-                    if (matcher.matches()) {
-                        yield current.toString();
-                    } else {
+                    URI uri = java.net.URI.create(current.toString());
+                    if (uri.getScheme() == null) {
                         throw new IllegalArgumentException("Invalid URI format.");
                     }
+                    yield current.toString();
                 }
                 case ARRAY, MULTISELECT -> {
                     List<?> asList;

--- a/core/src/test/java/io/kestra/core/runners/FlowInputOutputTest.java
+++ b/core/src/test/java/io/kestra/core/runners/FlowInputOutputTest.java
@@ -8,6 +8,7 @@ import io.kestra.core.models.flows.input.InputAndValue;
 import io.kestra.core.models.flows.input.IntInput;
 import io.kestra.core.models.flows.input.MultiselectInput;
 import io.kestra.core.models.flows.input.StringInput;
+import io.kestra.core.models.flows.input.URIInput;
 import io.kestra.core.models.property.Property;
 import io.kestra.core.repositories.KvMetadataRepositoryInterface;
 import io.kestra.core.secret.SecretNotFoundException;
@@ -25,8 +26,11 @@ import io.micronaut.test.annotation.MockBean;
 import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
 import jakarta.inject.Inject;
 import org.jetbrains.annotations.Nullable;
+import io.kestra.core.exceptions.InputOutputValidationException;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.reactivestreams.Publisher;
 import reactor.core.publisher.Mono;
 
@@ -444,6 +448,92 @@ class FlowInputOutputTest {
 
         Assertions.assertNotNull(outputs);
         Assertions.assertTrue(outputs.containsKey("empty_file"));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+        "kestra:///io/kestra/tests/executions/abc/tasks/hello/run1/results.ion",
+        "jdbc:duckdb:",
+        "file:///tmp/myfile.csv",
+        "http://localhost:8080/api",
+        "nsfile:///file.txt"
+    })
+    void shouldAcceptValidUriInputs(String validUri) {
+        Flow flow = Flow.builder()
+            .id("test-flow")
+            .namespace("io.kestra.test")
+            .inputs(List.of(
+                URIInput.builder().id("uri").type(Type.URI).required(true).build()
+            ))
+            .build();
+
+        Map<String, Object> result = flowInputOutput.readExecutionInputs(flow, DEFAULT_TEST_EXECUTION, Map.of("uri", validUri));
+
+        assertThat(result.get("uri")).isEqualTo(validUri);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+        "justastring",
+        "not a uri",
+        ""
+    })
+    void shouldRejectInvalidUriInputs(String invalidUri) {
+        Flow flow = Flow.builder()
+            .id("test-flow")
+            .namespace("io.kestra.test")
+            .inputs(List.of(
+                URIInput.builder().id("uri").type(Type.URI).required(true).build()
+            ))
+            .build();
+
+        Assertions.assertThrows(
+            InputOutputValidationException.class,
+            () -> flowInputOutput.readExecutionInputs(flow, DEFAULT_TEST_EXECUTION, Map.of("uri", invalidUri))
+        );
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+        "kestra:///io/kestra/tests/executions/abc/tasks/hello/run1/results.ion",
+        "jdbc:duckdb:",
+        "file:///tmp/myfile.csv",
+        "http://localhost:8080/api",
+        "nsfile:///file.txt"
+    })
+    void shouldAcceptValidUriOutputs(String validUri) {
+        Flow flow = Flow.builder()
+            .id("test-flow")
+            .namespace("io.kestra.test")
+            .outputs(List.of(
+                Output.builder().id("duck").type(Type.URI).build()
+            ))
+            .build();
+
+        Map<String, Object> result = flowInputOutput.typedOutputs(flow, DEFAULT_TEST_EXECUTION, Map.of("duck", validUri));
+
+        assertThat(result.get("duck")).isEqualTo(validUri);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+        "justastring",
+        "not a uri",
+        ""
+    })
+    void shouldRejectInvalidUriOutputs(String invalidUri) {
+        Flow flow = Flow.builder()
+            .id("test-flow")
+            .namespace("io.kestra.test")
+            .outputs(List.of(
+                Output.builder().id("duck").type(Type.URI).build()
+            ))
+            .build();
+
+        Assertions.assertThrows(
+            InputOutputValidationException.class,
+            () -> flowInputOutput.typedOutputs(flow, DEFAULT_TEST_EXECUTION, Map.of("duck", invalidUri))
+        );
     }
 
     private static class MemoryCompletedPart implements CompletedPart {

--- a/core/src/test/java/io/kestra/core/runners/InputsTest.java
+++ b/core/src/test/java/io/kestra/core/runners/InputsTest.java
@@ -26,6 +26,8 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import reactor.core.publisher.Flux;
 
@@ -335,15 +337,38 @@ public class InputsTest {
         assertThat(e.getMessage()).contains("Invalid value for input `validatedTime`. Cause: it must be before `11:59:59`");
     }
 
-    @Test
+    @ParameterizedTest
+    @ValueSource(strings = {
+        "justastring",
+        "not a uri",
+        ""
+    })
     @LoadFlows(value = {"flows/valids/inputs.yaml"}, tenantId = "tenant11")
-    void inputFailed() {
+    void inputUriRejectsInvalidUris(String invalidUri) {
         HashMap<String, Object> map = new HashMap<>(inputs);
-        map.put("uri", "http:/bla");
+        map.put("uri", invalidUri);
 
         InputOutputValidationException e = assertThrows(InputOutputValidationException.class, () -> typedInputs(map, "tenant11"));
 
-        assertThat(e.getMessage()).contains(  "Invalid value for input `uri`. Cause: Invalid URI format." );
+        assertThat(e.getMessage()).contains("Invalid value for input `uri`");
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+        "kestra:///io/kestra/tests/inputs/file/test.yml",
+        "jdbc:duckdb:",
+        "file:///tmp/myfile.csv",
+        "http://localhost:8080/api",
+        "nsfile:///file.txt"
+    })
+    @LoadFlows(value = {"flows/valids/inputs.yaml"}, tenantId = "tenant11")
+    void inputUriAcceptsValidUris(String validUri) {
+        HashMap<String, Object> map = new HashMap<>(inputs);
+        map.put("uri", validUri);
+
+        Map<String, Object> typeds = typedInputs(map, "tenant11");
+
+        assertThat(typeds.get("uri")).isEqualTo(validUri);
     }
 
     @Test

--- a/core/src/test/java/io/kestra/core/runners/InputsTest.java
+++ b/core/src/test/java/io/kestra/core/runners/InputsTest.java
@@ -26,8 +26,6 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ValueSource;
 
 import reactor.core.publisher.Flux;
 
@@ -337,38 +335,15 @@ public class InputsTest {
         assertThat(e.getMessage()).contains("Invalid value for input `validatedTime`. Cause: it must be before `11:59:59`");
     }
 
-    @ParameterizedTest
-    @ValueSource(strings = {
-        "justastring",
-        "not a uri",
-        ""
-    })
+    @Test
     @LoadFlows(value = {"flows/valids/inputs.yaml"}, tenantId = "tenant11")
-    void inputUriRejectsInvalidUris(String invalidUri) {
+    void inputUriFailed() {
         HashMap<String, Object> map = new HashMap<>(inputs);
-        map.put("uri", invalidUri);
+        map.put("uri", "justastring");
 
         InputOutputValidationException e = assertThrows(InputOutputValidationException.class, () -> typedInputs(map, "tenant11"));
 
-        assertThat(e.getMessage()).contains("Invalid value for input `uri`");
-    }
-
-    @ParameterizedTest
-    @ValueSource(strings = {
-        "kestra:///io/kestra/tests/inputs/file/test.yml",
-        "jdbc:duckdb:",
-        "file:///tmp/myfile.csv",
-        "http://localhost:8080/api",
-        "nsfile:///file.txt"
-    })
-    @LoadFlows(value = {"flows/valids/inputs.yaml"}, tenantId = "tenant11")
-    void inputUriAcceptsValidUris(String validUri) {
-        HashMap<String, Object> map = new HashMap<>(inputs);
-        map.put("uri", validUri);
-
-        Map<String, Object> typeds = typedInputs(map, "tenant11");
-
-        assertThat(typeds.get("uri")).isEqualTo(validUri);
+        assertThat(e.getMessage()).contains("Invalid value for input `uri`. Cause: Invalid URI format.");
     }
 
     @Test


### PR DESCRIPTION
## Summary

Fixes #14536

The `URI_PATTERN` regex in `FlowInputOutput.java` was an HTTP/HTTPS **URL** validator, not a **URI** validator. It required a TLD (e.g. `.com`), which caused it to reject perfectly valid URIs:

- `kestra:///io/kestra/tests/executions/abc/tasks/hello/run1/results.ion` (Kestra internal storage)
- `jdbc:duckdb:` (JDBC connection strings)
- `file:///tmp/myfile.csv`
- `nsfile:///file.txt`
- `http://localhost:8080/api` (no TLD)

This PR replaces the custom regex with `java.net.URI.create()` + a scheme-presence check.

## Root cause

The regex was introduced in commit `9df2050f1` ("feat(core): add URI as input type", Sept 2022) when the URI input type was first added. The developer grabbed a common "URL validator" regex from the internet to provide basic validation. It was never intended as a security boundary - `URIInput.validate()` still has a literal `// no validation yet` comment.

Commit `06474c0` (referenced in the issue) did **not** introduce the regex - it only moved `URI_PATTERN` from `RunnerUtils.java` to `FlowInputOutput.java` and changed its visibility from `public static` to `private static final` as part of a refactoring for the dynamic Pause timeout feature.

## Changes

### `FlowInputOutput.java`
- **Removed** `URI_PATTERN` regex field and unused `Matcher`/`Pattern` imports
- **Replaced** the `case URI` block with `java.net.URI.create()` + `getScheme() == null` check

This is:
- **RFC 2396 compliant** - `java.net.URI` implements the actual URI spec
- **Consistent** - `case FILE` (10 lines above) already uses `URI.create()` with no custom regex in the same `parseType()` method
- **Simple** - one line of stdlib vs a 100+ char hand-rolled regex

`URI.create()` throws `IllegalArgumentException` on malformed input (already caught by the existing handler). The `getScheme() == null` check rejects bare strings like `justastring` that are technically valid relative URI references but not meaningful URIs.

### `FlowInputOutputTest.java` (unit tests)
Added parameterized tests covering both input and output paths through `FlowInputOutput` directly:
- `shouldAcceptValidUriInputs` - 5 valid URIs via `readExecutionInputs()`
- `shouldRejectInvalidUriInputs` - 3 invalid URIs via `readExecutionInputs()`
- `shouldAcceptValidUriOutputs` - 5 valid URIs via `typedOutputs()`
- `shouldRejectInvalidUriOutputs` - 3 invalid URIs via `typedOutputs()`

### `InputsTest.java` (integration test)
- **Replaced** old `inputFailed` test (used `"http:/bla"` which is valid per RFC 2396) with `inputUriFailed` (uses `"justastring"`) to verify rejection propagates through the full flow execution stack

## Test plan

- [x] `./gradlew core:test --tests "io.kestra.core.runners.FlowInputOutputTest"` - 30 tests pass
- [x] `./gradlew core:test --tests "io.kestra.core.runners.InputsTest"` - 22 tests pass
- [x] URIs **accepted** (unit tested for both inputs and outputs): `kestra:///path`, `jdbc:duckdb:`, `file:///tmp/f`, `http://localhost:8080/api`, `nsfile:///file.txt`
- [x] URIs **rejected** (unit tested for both inputs and outputs): `justastring` (no scheme), `not a uri` (spaces), `` (empty)
- [x] Integration test verifies rejection through full flow execution stack