### PR TITLE
Fix/topology refresh after revision restore

### DIFF
--- a/ui/src/components/flows/FlowRevisions.vue
+++ b/ui/src/components/flows/FlowRevisions.vue
@@ -64,7 +64,9 @@
         return flowStore.saveFlow({flow: revisionSource})
             .then((response:any) => {
                 toast.saved(response.id);
-                flowStore.flowYaml = response.source;
+            })
+            .then(() => {
+                return flowStore.initYamlSource();
             })
             .then(() => {
                 router.push({query: {}});

--- a/ui/src/components/logs/LogLine.vue
+++ b/ui/src/components/logs/LogLine.vue
@@ -277,8 +277,8 @@ div.line {
         opacity: 0;
         pointer-events: none;
         transition: opacity 0.15s ease-in-out;
-        top: 50%;
-        transform: translateY(-50%);
+        top: 0.5rem;
+        right: 0.5rem;
     }
 
     &:hover :deep(.clipboard) {

--- a/ui/src/components/logs/LogLine.vue
+++ b/ui/src/components/logs/LogLine.vue
@@ -165,16 +165,20 @@
 
     // Initial markdown render
     (async () => {
-        renderedMarkdown.value = await Markdown.render(message.value, {onlyLink: true, html: true});
+        renderedMarkdown.value = (await Markdown.render(message.value, {onlyLink: true, html: true})).trim();
     })();
 </script>
 <style scoped lang="scss">
 div.line {
     position: relative;
     cursor: text;
-    white-space: pre-wrap;
+    white-space: pre-line;
     word-break: break-all;
-    display: block;
+    display: flex;
+    align-items: center;
+    padding: 0.15rem 0.5rem;
+    min-height: 2rem;
+
 
     border-left-width: 2px !important;
     border-left-style: solid;
@@ -254,6 +258,8 @@ div.line {
 
     .message {
         line-height: 1.8;
+         display: inline-block;
+        vertical-align: middle;
     }
 
     p, :deep(.log-content p) {
@@ -271,6 +277,8 @@ div.line {
         opacity: 0;
         pointer-events: none;
         transition: opacity 0.15s ease-in-out;
+        top: 50%;
+        transform: translateY(-50%);
     }
 
     &:hover :deep(.clipboard) {


### PR DESCRIPTION
### ✨ Description

This PR fixes an issue where restoring a flow revision updated the YAML editor correctly, but the topology graph remained stale until navigating away from the Flow page and returning.

After calling saveFlow() during revision restore, the graph (flowGraph) was not regenerated. As a result, the editor and topology became out of sync.

This change calls initYamlSource() after a successful restore to:

1) Reinitialize the YAML state

2) Regenerate the topology graph

3) Ensure both the editor and topology reflect the restored revision immediately

Now, restoring a revision updates both the YAML and topology without requiring navigation.

### 🔗 Related Issue

Closes :#14725

### 🎨 Frontend Checklist

_If this PR does not include any frontend changes, delete this entire section._

- [ ] Code builds without errors (`npm run build`)
- [ ] All existing E2E tests pass (`npm run test:e2e`)
- [x] Screenshots or video recordings attached showing the `UI` changes


[topology.webm](https://github.com/user-attachments/assets/9ba38023-638c-4818-b912-914fe0c7b1be)
