### PR TITLE
chore(ui): avoid deep type expansion in playground store

### DIFF
--- a/ui/src/stores/playground.ts
+++ b/ui/src/stores/playground.ts
@@ -1,4 +1,4 @@
-import {computed, ref, watch} from "vue";
+import {computed, ref, watch, type Ref} from "vue";
 import {defineStore} from "pinia";
 import {useUrlSearchParams} from "@vueuse/core"
 import * as VueFlowUtils from "@kestra-io/ui-libs/vue-flow-utils"
@@ -53,7 +53,7 @@ export const usePlaygroundStore = defineStore("playground", () => {
         });
     }
 
-    const executions = ref<ExecutionWithGraph[]>([])
+    const executions = ref([]) as Ref<ExecutionWithGraph[]>
     function addExecution(execution: ExecutionWithGraph, graph: VueFlowUtils.FlowGraph) {
         execution.graph = graph
         executions.value.unshift(execution);
@@ -82,7 +82,7 @@ export const usePlaygroundStore = defineStore("playground", () => {
                 defaultInputValues[input.id] = safeDef;
             }
         }
-        
+
         return executionsStore.triggerExecution({
             id: flow.id,
             namespace: flow.namespace,
@@ -97,7 +97,7 @@ export const usePlaygroundStore = defineStore("playground", () => {
 
         // check that the inputs and labels have not changed between the last execution and the current flow
         // if they have changed, we cannot replay the execution and must trigger a new one
-        if(lastExecution && lastExecution.flowRevision && flowStore.flow?.revision 
+        if(lastExecution && lastExecution.flowRevision && flowStore.flow?.revision
             && lastExecution.flowRevision < flowStore.flow.revision){
             const lastExecutionFlow = await flowStore.loadFlow({
                 namespace: flowStore.flow.namespace || "",
@@ -106,7 +106,7 @@ export const usePlaygroundStore = defineStore("playground", () => {
                 store: false,
             })
 
-            if(!isEqual(lastExecutionFlow.inputs, flowStore.flow.inputs) 
+            if(!isEqual(lastExecutionFlow.inputs, flowStore.flow.inputs)
                 || !isEqual(lastExecutionFlow.labels, flowStore.flow.labels)){
                 return await triggerExecution(flowStore.flow, breakpoints);
             };


### PR DESCRIPTION
### ✨ Description

What does this PR change?  
Avoids vue-tsc deep type instantiation errors in Playground by preventing Vue’s UnwrapRef from expanding FlowGraph.


### 🎨 Frontend Checklist

_If this PR does not include any frontend changes, delete this entire section._

- [x] Code builds without errors (`npm run build`)
- [x] All existing E2E tests pass (`npm run test:e2e`)
~~Screenshots or video recordings attached showing the `UI` changes~~