### PR TITLE
feat(assets): add purge & search asset lineage endpoint

### DIFF
--- a/core/src/main/java/io/kestra/core/models/QueryFilter.java
+++ b/core/src/main/java/io/kestra/core/models/QueryFilter.java
@@ -412,8 +412,8 @@ public record QueryFilter(
         ASSET_LINEAGE_EVENT {
             @Override
             public List<Field> supportedField() {
+                // ASSET_ID is not supported for now as it needs complex json parsing
                 return List.of(
-                    Field.ASSET_ID,
                     Field.NAMESPACE,
                     Field.FLOW_ID,
                     Field.FLOW_REVISION,

--- a/core/src/test/java/io/kestra/core/models/QueryFilterTest.java
+++ b/core/src/test/java/io/kestra/core/models/QueryFilterTest.java
@@ -174,15 +174,6 @@ public class QueryFilterTest {
             Arguments.of(QueryFilter.builder().field(Field.ASSET_ID).operation(Op.IN).build(), Resource.ASSET_USAGE),
             Arguments.of(QueryFilter.builder().field(Field.ASSET_ID).operation(Op.NOT_IN).build(), Resource.ASSET_USAGE),
 
-            Arguments.of(QueryFilter.builder().field(Field.ASSET_ID).operation(Op.EQUALS).build(), Resource.ASSET_LINEAGE_EVENT),
-            Arguments.of(QueryFilter.builder().field(Field.ASSET_ID).operation(Op.NOT_EQUALS).build(), Resource.ASSET_LINEAGE_EVENT),
-            Arguments.of(QueryFilter.builder().field(Field.ASSET_ID).operation(Op.CONTAINS).build(), Resource.ASSET_LINEAGE_EVENT),
-            Arguments.of(QueryFilter.builder().field(Field.ASSET_ID).operation(Op.STARTS_WITH).build(), Resource.ASSET_LINEAGE_EVENT),
-            Arguments.of(QueryFilter.builder().field(Field.ASSET_ID).operation(Op.ENDS_WITH).build(), Resource.ASSET_LINEAGE_EVENT),
-            Arguments.of(QueryFilter.builder().field(Field.ASSET_ID).operation(Op.REGEX).build(), Resource.ASSET_LINEAGE_EVENT),
-            Arguments.of(QueryFilter.builder().field(Field.ASSET_ID).operation(Op.IN).build(), Resource.ASSET_LINEAGE_EVENT),
-            Arguments.of(QueryFilter.builder().field(Field.ASSET_ID).operation(Op.NOT_IN).build(), Resource.ASSET_LINEAGE_EVENT),
-
             Arguments.of(QueryFilter.builder().field(Field.TYPE).operation(Op.EQUALS).build(), Resource.ASSET),
             Arguments.of(QueryFilter.builder().field(Field.TYPE).operation(Op.NOT_EQUALS).build(), Resource.ASSET),
             Arguments.of(QueryFilter.builder().field(Field.TYPE).operation(Op.CONTAINS).build(), Resource.ASSET),
@@ -379,12 +370,6 @@ public class QueryFilterTest {
             Arguments.of(QueryFilter.builder().field(Field.ASSET_ID).operation(Op.LESS_THAN_OR_EQUAL_TO).build(), Resource.ASSET_USAGE),
             Arguments.of(QueryFilter.builder().field(Field.ASSET_ID).operation(Op.GREATER_THAN).build(), Resource.ASSET_USAGE),
             Arguments.of(QueryFilter.builder().field(Field.ASSET_ID).operation(Op.GREATER_THAN_OR_EQUAL_TO).build(), Resource.ASSET_USAGE),
-
-            Arguments.of(QueryFilter.builder().field(Field.ASSET_ID).operation(Op.PREFIX).build(), Resource.ASSET_LINEAGE_EVENT),
-            Arguments.of(QueryFilter.builder().field(Field.ASSET_ID).operation(Op.LESS_THAN).build(), Resource.ASSET_LINEAGE_EVENT),
-            Arguments.of(QueryFilter.builder().field(Field.ASSET_ID).operation(Op.LESS_THAN_OR_EQUAL_TO).build(), Resource.ASSET_LINEAGE_EVENT),
-            Arguments.of(QueryFilter.builder().field(Field.ASSET_ID).operation(Op.GREATER_THAN).build(), Resource.ASSET_LINEAGE_EVENT),
-            Arguments.of(QueryFilter.builder().field(Field.ASSET_ID).operation(Op.GREATER_THAN_OR_EQUAL_TO).build(), Resource.ASSET_LINEAGE_EVENT),
 
             Arguments.of(QueryFilter.builder().field(Field.TYPE).operation(Op.PREFIX).build(), Resource.ASSET),
             Arguments.of(QueryFilter.builder().field(Field.TYPE).operation(Op.LESS_THAN).build(), Resource.ASSET),


### PR DESCRIPTION
part of https://github.com/kestra-io/kestra-ee/issues/6378

The ASSET_ID filter was not implemented for asset lineage events(requires custom condition to search in inputs.id & outputs.id) so for now I removed it