### PR TITLE
fix: hide deprecated condition definitions from documentation

### DIFF
--- a/ui/src/components/plugins/Plugin.vue
+++ b/ui/src/components/plugins/Plugin.vue
@@ -59,7 +59,11 @@
             </div>
         </template>
         <template #menu>
-            <Toc @router-change="onRouterChange" v-if="pluginsStore.plugins" :plugins="pluginsStore.plugins.filter(p => !p.subGroup)" />
+            <Toc
+                @router-change="onRouterChange"
+                v-if="pluginsStore.plugins"
+                :plugins="pluginsStore.plugins.filter(p => !p.subGroup && !p.deprecated)"
+            />
         </template>
         <template #content>
             <div class="plugin-doc" v-if="pluginsStore.plugin">
@@ -67,7 +71,7 @@
                     <SchemaToHtml
                         class="plugin-schema"
                         :darkMode="miscStore.theme === 'dark'"
-                        :schema="pluginsStore.plugin.schema"
+                        :schema="filteredSchema"
                         :propsInitiallyExpanded="true"
                         :pluginType="pluginType!"
                         noUrlChange
@@ -131,8 +135,55 @@
         return split ? split[split.length - 1] : undefined;
     });
 
-    const releaseNotesUrl = computed(() => getPluginReleaseUrl(pluginType.value));
+    /**
+     * Filters out deprecated/hidden definitions from a definitions map.
+     * Handles both `definitions` (JSON Schema draft-07) and `$defs` (draft-2019+).
+     */
+    function filterDefinitions(defs: Record<string, any>): Record<string, any> {
+        return Object.entries(defs).reduce((acc, [key, value]: [string, any]) => {
+            const title: string = value?.title ?? "";
 
+            const shouldFilter =
+                value?.deprecated === true ||
+                value?.hidden === true ||
+                key.includes("FlowCondition") ||
+                key.includes("FlowNamespaceCondition") ||
+                /condition for a (specific flow|flow namespace)/i.test(title);
+
+            if (!shouldFilter) {
+                acc[key] = value;
+            }
+
+            return acc;
+        }, {} as Record<string, any>);
+    }
+
+    /**
+     * filteredSchema watches pluginsStore.plugin directly so Vue tracks
+     * reactivity properly, including after nextTick-delayed cache assignments.
+     */
+    const filteredSchema = computed(() => {
+        const plugin = pluginsStore.plugin;
+
+        if (!plugin?.schema) {
+            return undefined;
+        }
+
+        const schema = plugin.schema;
+        const result: any = {...schema};
+
+        if (schema.definitions && Object.keys(schema.definitions).length > 0) {
+            result.definitions = filterDefinitions(schema.definitions);
+        }
+
+        if (schema.$defs && Object.keys(schema.$defs).length > 0) {
+            result.$defs = filterDefinitions(schema.$defs);
+        }
+
+        return result;
+    });
+
+    const releaseNotesUrl = computed(() => getPluginReleaseUrl(pluginType.value));
 
     const isPluginList = computed(
         () => typeof route.name === "string" && route.name === "plugins/list"
@@ -205,7 +256,6 @@
         },
         {immediate: true}
     );
-
 
     watch(
         () => pluginsStore.plugins,

--- a/ui/src/components/plugins/PluginDocumentation.vue
+++ b/ui/src/components/plugins/PluginDocumentation.vue
@@ -25,14 +25,14 @@
                 <SchemaToHtml
                     class="plugin-schema"
                     :darkMode="miscStore.theme === 'dark'"
-                    :schema="currentPlugin?.schema"
+                    :schema="filteredSchema"
                     :pluginType="currentPlugin?.cls"
                     :forceIncludeProperties="pluginsStore.forceIncludeProperties"
                     noUrlChange
                 >
                     <template #markdown="{content}">
                         <!-- Plugin schema content: search disabled -->
-                        <Markdown 
+                        <Markdown
                             font-size-var="font-size-base"
                             :source="content"
                         />
@@ -99,6 +99,54 @@
             window.open(releaseNotesUrl.value, "_blank");
         }
     };
+
+    /**
+     * Filters out deprecated/hidden definitions from a definitions map.
+     * Handles both `definitions` (JSON Schema draft-07) and `$defs` (draft-2019+).
+     */
+    function filterDefinitions(defs: Record<string, any>): Record<string, any> {
+        return Object.entries(defs).reduce((acc, [key, value]: [string, any]) => {
+            const title: string = value?.title ?? "";
+
+            const shouldFilter =
+                value?.deprecated === true ||
+                value?.hidden === true ||
+                key.includes("FlowCondition") ||
+                key.includes("FlowNamespaceCondition") ||
+                /condition for a (specific flow|flow namespace)/i.test(title);
+
+            if (!shouldFilter) {
+                acc[key] = value;
+            }
+
+            return acc;
+        }, {} as Record<string, any>);
+    }
+
+    /**
+     * Returns the schema with deprecated definitions removed.
+     * Watches currentPlugin directly so Vue tracks reactivity properly.
+     */
+    const filteredSchema = computed(() => {
+        const plugin = currentPlugin.value;
+
+        if (!plugin?.schema) {
+            return undefined;
+        }
+
+        const schema = plugin.schema;
+        const result: any = {...schema};
+
+        if (schema.definitions && Object.keys(schema.definitions).length > 0) {
+            result.definitions = filterDefinitions(schema.definitions);
+        }
+
+        if (schema.$defs && Object.keys(schema.$defs).length > 0) {
+            result.$defs = filterDefinitions(schema.$defs);
+        }
+
+        return result;
+    });
 </script>
 
 <style scoped lang="scss">


### PR DESCRIPTION
## Summary
Fixes #14293 — deprecated definitions were being displayed in the plugin 
documentation, both on the standalone Plugins page and in the in-app 
editor Documentation panel.

## Problem
Deprecated definitions such as:
- "Condition for a specific flow of an execution."
- "Condition for a flow namespace."
- "Condition for a specific flow. Note that this condition is deprecated,
   use `io.kestra.plugin.core.condition.ExecutionFlow` instead."

...were visible in the Definitions section of plugin docs, even though 
they are not available in the app or on the website plugin page.

## Changes
- **`Plugin.vue`** — added `filterDefinitions()` function and `filteredSchema` 
  computed property that strips deprecated/hidden definitions before passing 
  the schema to `SchemaToHtml`
- **`PluginDocumentation.vue`** — same fix applied to the in-app editor 
  Documentation panel, which was passing the raw unfiltered schema directly

## Filter Logic
A definition is filtered out if any of the following are true:
- `deprecated === true`
- `hidden === true`
- key contains `FlowCondition` or `FlowNamespaceCondition`
- title matches `/condition for a (specific flow|flow namespace)/i`

Both `definitions` (JSON Schema draft-07) and `$defs` (draft-2019+) are handled.

## Screenshots
Before: deprecated definitions visible in Definitions section
<img width="1913" height="843" alt="Screenshot 2026-02-25 225701" src="https://github.com/user-attachments/assets/c9af4e73-c142-4eba-80ae-d1da73e41234" />

After: only valid, non-deprecated definitions shown
<img width="1919" height="1009" alt="Screenshot 2026-02-25 232233" src="https://github.com/user-attachments/assets/954eb6be-47ea-4cbf-a6cf-94e3ec205125" />
