### PR TITLE
fix: use absolute path to signify output location

### DIFF
--- a/ui/build.gradle
+++ b/ui/build.gradle
@@ -17,6 +17,8 @@ tasks.register('assembleFrontend', NpmTask) {
     inputs.file('index.html')
     inputs.file('package.json')
     inputs.file('vite.config.js')
+    inputs.file('openapi-ts.config.ts')
+    inputs.file('../openapi.yml')
 
     args = ['run', 'build']
     outputs.dir('../webserver/src/main/resources/ui')

--- a/ui/build.gradle
+++ b/ui/build.gradle
@@ -18,7 +18,7 @@ tasks.register('assembleFrontend', NpmTask) {
     inputs.file('package.json')
     inputs.file('vite.config.js')
     inputs.file('openapi-ts.config.ts')
-    inputs.file('../openapi.yml')
+    // inputs.file('../openapi.yml')
 
     args = ['run', 'build']
     outputs.dir('../webserver/src/main/resources/ui')

--- a/ui/build.gradle
+++ b/ui/build.gradle
@@ -4,7 +4,7 @@ plugins {
 
 node {
     download = true
-    version = '22.12.0'
+    version = '22.13.0'
     npmInstallCommand = "ci"
 }
 

--- a/ui/openapi-ts.config.ts
+++ b/ui/openapi-ts.config.ts
@@ -1,5 +1,9 @@
 import {defineConfig} from "@hey-api/openapi-ts";
+// @ts-expect-error need a second tsconfig file for node execution (vite.config, openapi-ts.config, vitest.config)
+import * as path from "path";
 import {defineKestraHeyConfig} from "./heyapi-sdk-plugin";
+
+const __dirname = path.dirname(new URL(import.meta.url).pathname);
 
 const generateHash = (str: string) => {
   let hash = 0;
@@ -13,7 +17,7 @@ const generateHash = (str: string) => {
 export default defineConfig({
   input: "../openapi.yml",
   output: {
-    path: "./src/generated/kestra-api",
+    path: path.resolve(__dirname, "./src/generated/kestra-api"),
     postProcess: ["eslint"],
   },
   
@@ -30,8 +34,6 @@ export default defineConfig({
             },
         }
     },
-    defineKestraHeyConfig({
-        output: "./src/generated/kestra-heyapi-sdk",
-    })
+    defineKestraHeyConfig()
   ],
 });

--- a/ui/openapi-ts.config.ts
+++ b/ui/openapi-ts.config.ts
@@ -1,4 +1,4 @@
-import {defineConfig} from "@hey-api/openapi-ts";
+import type {UserConfig} from "@hey-api/openapi-ts";
 // @ts-expect-error need a second tsconfig file for node execution (vite.config, openapi-ts.config, vitest.config)
 import * as path from "path";
 import {defineKestraHeyConfig} from "./heyapi-sdk-plugin";
@@ -14,7 +14,7 @@ const generateHash = (str: string) => {
   return hash.toString(16).replace("-", "0");
 };
 
-export default defineConfig({
+export default {
   input: "../openapi.yml",
   output: {
     path: path.resolve(__dirname, "./src/generated/kestra-api"),
@@ -36,4 +36,4 @@ export default defineConfig({
     },
     defineKestraHeyConfig()
   ],
-});
+} satisfies UserConfig


### PR DESCRIPTION
This change avoids the creation of the OSS SDK in the context of EE