### PR TITLE
fix: filter out deprecated definitions from plugin documentation

### DIFF
--- a/ui/src/components/plugins/Plugin.vue
+++ b/ui/src/components/plugins/Plugin.vue
@@ -59,11 +59,7 @@
             </div>
         </template>
         <template #menu>
-            <Toc
-                @router-change="onRouterChange"
-                v-if="pluginsStore.plugins"
-                :plugins="pluginsStore.plugins.filter(p => !p.subGroup && !p.deprecated)"
-            />
+            <Toc @router-change="onRouterChange" v-if="pluginsStore.plugins" :plugins="pluginsStore.plugins.filter(p => !p.subGroup)" />
         </template>
         <template #content>
             <div class="plugin-doc" v-if="pluginsStore.plugin">
@@ -100,6 +96,7 @@
     import {usePluginsStore} from "../../stores/plugins";
     import {useMiscStore} from "override/stores/misc";
     import {getPluginReleaseUrl} from "../../utils/pluginUtils";
+    import type {JSONSchema} from "@kestra-io/ui-libs";
 
 
     const pluginsStore = usePluginsStore();
@@ -135,55 +132,41 @@
         return split ? split[split.length - 1] : undefined;
     });
 
-    /**
-     * Filters out deprecated/hidden definitions from a definitions map.
-     * Handles both `definitions` (JSON Schema draft-07) and `$defs` (draft-2019+).
-     */
-    function filterDefinitions(defs: Record<string, any>): Record<string, any> {
-        return Object.entries(defs).reduce((acc, [key, value]: [string, any]) => {
-            const title: string = value?.title ?? "";
+    const filteredSchema = computed((): JSONSchema => {
+        const schema = pluginsStore.plugin?.schema as JSONSchema;
 
-            const shouldFilter =
-                value?.deprecated === true ||
-                value?.hidden === true ||
-                key.includes("FlowCondition") ||
-                key.includes("FlowNamespaceCondition") ||
-                /condition for a (specific flow|flow namespace)/i.test(title);
-
-            if (!shouldFilter) {
-                acc[key] = value;
-            }
-
-            return acc;
-        }, {} as Record<string, any>);
-    }
-
-    /**
-     * filteredSchema watches pluginsStore.plugin directly so Vue tracks
-     * reactivity properly, including after nextTick-delayed cache assignments.
-     */
-    const filteredSchema = computed(() => {
-        const plugin = pluginsStore.plugin;
-
-        if (!plugin?.schema) {
-            return undefined;
+        if (!schema?.definitions) {
+            return schema;
         }
 
-        const schema = plugin.schema;
-        const result: any = {...schema};
+        const filteredDefinitions = Object.entries(schema.definitions).reduce(
+            (acc, [key, value]: [string, any]) => {
+                const title: string = value?.title ?? "";
 
-        if (schema.definitions && Object.keys(schema.definitions).length > 0) {
-            result.definitions = filterDefinitions(schema.definitions);
-        }
+                const shouldFilter =
+                    value?.deprecated === true ||
+                    value?.hidden === true ||
+                    key.includes("FlowCondition") ||
+                    key.includes("FlowNamespaceCondition") ||
+                    /condition for a (specific flow|flow namespace)/i.test(title);
 
-        if (schema.$defs && Object.keys(schema.$defs).length > 0) {
-            result.$defs = filterDefinitions(schema.$defs);
-        }
+                if (!shouldFilter) {
+                    acc[key] = value;
+                }
 
-        return result;
+                return acc;
+            },
+            {} as Record<string, any>
+        );
+
+        return {
+            ...schema,
+            definitions: filteredDefinitions,
+        };
     });
 
     const releaseNotesUrl = computed(() => getPluginReleaseUrl(pluginType.value));
+
 
     const isPluginList = computed(
         () => typeof route.name === "string" && route.name === "plugins/list"
@@ -256,6 +239,7 @@
         },
         {immediate: true}
     );
+
 
     watch(
         () => pluginsStore.plugins,

--- a/ui/src/components/plugins/Plugin.vue
+++ b/ui/src/components/plugins/Plugin.vue
@@ -59,7 +59,11 @@
             </div>
         </template>
         <template #menu>
-            <Toc @router-change="onRouterChange" v-if="pluginsStore.plugins" :plugins="pluginsStore.plugins.filter(p => !p.subGroup)" />
+            <Toc
+                @router-change="onRouterChange"
+                v-if="pluginsStore.plugins"
+                :plugins="pluginsStore.plugins.filter(p => !p.subGroup && !p.deprecated)"
+            />
         </template>
         <template #content>
             <div class="plugin-doc" v-if="pluginsStore.plugin">
@@ -67,7 +71,7 @@
                     <SchemaToHtml
                         class="plugin-schema"
                         :darkMode="miscStore.theme === 'dark'"
-                        :schema="pluginsStore.plugin.schema"
+                        :schema="filteredSchema"
                         :propsInitiallyExpanded="true"
                         :pluginType="pluginType!"
                         noUrlChange
@@ -131,8 +135,55 @@
         return split ? split[split.length - 1] : undefined;
     });
 
-    const releaseNotesUrl = computed(() => getPluginReleaseUrl(pluginType.value));
+    /**
+     * Filters out deprecated/hidden definitions from a definitions map.
+     * Handles both `definitions` (JSON Schema draft-07) and `$defs` (draft-2019+).
+     */
+    function filterDefinitions(defs: Record<string, any>): Record<string, any> {
+        return Object.entries(defs).reduce((acc, [key, value]: [string, any]) => {
+            const title: string = value?.title ?? "";
 
+            const shouldFilter =
+                value?.deprecated === true ||
+                value?.hidden === true ||
+                key.includes("FlowCondition") ||
+                key.includes("FlowNamespaceCondition") ||
+                /condition for a (specific flow|flow namespace)/i.test(title);
+
+            if (!shouldFilter) {
+                acc[key] = value;
+            }
+
+            return acc;
+        }, {} as Record<string, any>);
+    }
+
+    /**
+     * filteredSchema watches pluginsStore.plugin directly so Vue tracks
+     * reactivity properly, including after nextTick-delayed cache assignments.
+     */
+    const filteredSchema = computed(() => {
+        const plugin = pluginsStore.plugin;
+
+        if (!plugin?.schema) {
+            return undefined;
+        }
+
+        const schema = plugin.schema;
+        const result: any = {...schema};
+
+        if (schema.definitions && Object.keys(schema.definitions).length > 0) {
+            result.definitions = filterDefinitions(schema.definitions);
+        }
+
+        if (schema.$defs && Object.keys(schema.$defs).length > 0) {
+            result.$defs = filterDefinitions(schema.$defs);
+        }
+
+        return result;
+    });
+
+    const releaseNotesUrl = computed(() => getPluginReleaseUrl(pluginType.value));
 
     const isPluginList = computed(
         () => typeof route.name === "string" && route.name === "plugins/list"
@@ -205,7 +256,6 @@
         },
         {immediate: true}
     );
-
 
     watch(
         () => pluginsStore.plugins,

--- a/ui/src/components/plugins/PluginDocumentation.vue
+++ b/ui/src/components/plugins/PluginDocumentation.vue
@@ -61,6 +61,7 @@
     import {usePluginsStore} from "../../stores/plugins";
     import GitHub from "vue-material-design-icons/Github.vue";
     import intro from "../../assets/docs/basic.md?raw";
+    import type {JSONSchema} from "@kestra-io/ui-libs";
 
     const props = withDefaults(defineProps<{
         overrideIntro?: string | null;
@@ -100,52 +101,37 @@
         }
     };
 
-    /**
-     * Filters out deprecated/hidden definitions from a definitions map.
-     * Handles both `definitions` (JSON Schema draft-07) and `$defs` (draft-2019+).
-     */
-    function filterDefinitions(defs: Record<string, any>): Record<string, any> {
-        return Object.entries(defs).reduce((acc, [key, value]: [string, any]) => {
-            const title: string = value?.title ?? "";
+    const filteredSchema = computed((): JSONSchema => {
+        const schema = currentPlugin.value?.schema as JSONSchema;
 
-            const shouldFilter =
-                value?.deprecated === true ||
-                value?.hidden === true ||
-                key.includes("FlowCondition") ||
-                key.includes("FlowNamespaceCondition") ||
-                /condition for a (specific flow|flow namespace)/i.test(title);
-
-            if (!shouldFilter) {
-                acc[key] = value;
-            }
-
-            return acc;
-        }, {} as Record<string, any>);
-    }
-
-    /**
-     * Returns the schema with deprecated definitions removed.
-     * Watches currentPlugin directly so Vue tracks reactivity properly.
-     */
-    const filteredSchema = computed(() => {
-        const plugin = currentPlugin.value;
-
-        if (!plugin?.schema) {
-            return undefined;
+        if (!schema?.definitions) {
+            return schema;
         }
 
-        const schema = plugin.schema;
-        const result: any = {...schema};
+        const filteredDefinitions = Object.entries(schema.definitions).reduce(
+            (acc, [key, value]: [string, any]) => {
+                const title: string = value?.title ?? "";
 
-        if (schema.definitions && Object.keys(schema.definitions).length > 0) {
-            result.definitions = filterDefinitions(schema.definitions);
-        }
+                const shouldFilter =
+                    value?.deprecated === true ||
+                    value?.hidden === true ||
+                    key.includes("FlowCondition") ||
+                    key.includes("FlowNamespaceCondition") ||
+                    /condition for a (specific flow|flow namespace)/i.test(title);
 
-        if (schema.$defs && Object.keys(schema.$defs).length > 0) {
-            result.$defs = filterDefinitions(schema.$defs);
-        }
+                if (!shouldFilter) {
+                    acc[key] = value;
+                }
 
-        return result;
+                return acc;
+            },
+            {} as Record<string, any>
+        );
+
+        return {
+            ...schema,
+            definitions: filteredDefinitions,
+        };
     });
 </script>
 

--- a/ui/src/components/plugins/PluginDocumentation.vue
+++ b/ui/src/components/plugins/PluginDocumentation.vue
@@ -25,14 +25,14 @@
                 <SchemaToHtml
                     class="plugin-schema"
                     :darkMode="miscStore.theme === 'dark'"
-                    :schema="currentPlugin?.schema"
+                    :schema="filteredSchema"
                     :pluginType="currentPlugin?.cls"
                     :forceIncludeProperties="pluginsStore.forceIncludeProperties"
                     noUrlChange
                 >
                     <template #markdown="{content}">
                         <!-- Plugin schema content: search disabled -->
-                        <Markdown 
+                        <Markdown
                             font-size-var="font-size-base"
                             :source="content"
                         />
@@ -99,6 +99,54 @@
             window.open(releaseNotesUrl.value, "_blank");
         }
     };
+
+    /**
+     * Filters out deprecated/hidden definitions from a definitions map.
+     * Handles both `definitions` (JSON Schema draft-07) and `$defs` (draft-2019+).
+     */
+    function filterDefinitions(defs: Record<string, any>): Record<string, any> {
+        return Object.entries(defs).reduce((acc, [key, value]: [string, any]) => {
+            const title: string = value?.title ?? "";
+
+            const shouldFilter =
+                value?.deprecated === true ||
+                value?.hidden === true ||
+                key.includes("FlowCondition") ||
+                key.includes("FlowNamespaceCondition") ||
+                /condition for a (specific flow|flow namespace)/i.test(title);
+
+            if (!shouldFilter) {
+                acc[key] = value;
+            }
+
+            return acc;
+        }, {} as Record<string, any>);
+    }
+
+    /**
+     * Returns the schema with deprecated definitions removed.
+     * Watches currentPlugin directly so Vue tracks reactivity properly.
+     */
+    const filteredSchema = computed(() => {
+        const plugin = currentPlugin.value;
+
+        if (!plugin?.schema) {
+            return undefined;
+        }
+
+        const schema = plugin.schema;
+        const result: any = {...schema};
+
+        if (schema.definitions && Object.keys(schema.definitions).length > 0) {
+            result.definitions = filterDefinitions(schema.definitions);
+        }
+
+        if (schema.$defs && Object.keys(schema.$defs).length > 0) {
+            result.$defs = filterDefinitions(schema.$defs);
+        }
+
+        return result;
+    });
 </script>
 
 <style scoped lang="scss">


### PR DESCRIPTION
While browsing the plugin docs for `io.kestra.plugin.core.trigger.Flow`, deprecated definitions were still showing up in the Definitions section — entries like "Condition for a specific flow of an execution." and "Condition for a specific flow. Note that this condition is deprecated, use `io.kestra.plugin.core.condition.ExecutionFlow` instead."
These shouldn't be visible to users since they're deprecated and can cause confusion about which conditions to actually use.

## What changed:
A `filteredSchema` computed property was added in both Plugin.vue (the standalone Plugins page) and `PluginDocumentation.vue` (the in-app editor Documentation panel) that strips out deprecated definitions before passing the schema to `SchemaToHtml`.

## A definition is filtered out if:

- it has `deprecated: true`
- it has `hidden: true`
- its key contains `FlowCondition` or `FlowNamespaceCondition`
- its title matches `condition for a specific flow` or `condition for a flow namespace`

## Tested:

- Deprecated definitions no longer appear on the Flow trigger plugin page
- The same fix works in the in-app Documentation panel inside the flow editor
- `npm run test:types` passes with no errors

<img width="799" height="315" alt="Screenshot 2026-02-26 153921" src="https://github.com/user-attachments/assets/1bcab3e9-98a2-401b-b2f1-db565450df83" />

## Screenshots

Before: deprecated definitions visible in Definitions section 
<img width="1913" height="843" alt="Screenshot 2026-02-25 225701" src="https://github.com/user-attachments/assets/3713958b-22ff-4079-9d2f-0f06aa45d1fd" />

After: only valid, non-deprecated definitions shown
<img width="1919" height="930" alt="Screenshot 2026-02-26 153858" src="https://github.com/user-attachments/assets/5c85bd34-4cb1-42ae-a547-3c6fc81a73b0" />


Fixes #14293 