### PR TITLE
fix(ui): align in-app plugin docs search with Plugins tab

### DIFF
--- a/ui/src/components/plugins/PluginList.vue
+++ b/ui/src/components/plugins/PluginList.vue
@@ -132,6 +132,10 @@
                     : []
             );
 
+    const getPluginDisplayName = (plugin: any): string => {
+        return plugin?.manifest?.["X-Kestra-Title"];
+    };
+
     const isPluginVisible = (plugin: any): boolean => {
         if (!plugin) return false;
         return getPluginElements(plugin).length > 0;
@@ -161,8 +165,8 @@
             )
             .filter(isPluginVisible)
             .sort((a, b) => {
-                const nameA = (a.manifest?.["X-Kestra-Title"] ?? "").toLowerCase();
-                const nameB = (b.manifest?.["X-Kestra-Title"] ?? "").toLowerCase();
+                const nameA = (getPluginDisplayName(a) ?? "").toLowerCase();
+                const nameB = (getPluginDisplayName(b) ?? "").toLowerCase();
                 return nameA < nameB ? -1 : nameA > nameB ? 1 : 0;
             });
     });
@@ -171,6 +175,7 @@
         if (!searchQuery.value) return basePlugins.value;
         const query = searchQuery.value.toLowerCase();
         return basePlugins.value.filter(plugin =>
+            (getPluginDisplayName(plugin) ?? "").toLowerCase().includes(query) ||
             (plugin.title ?? "").toLowerCase().includes(query) ||
             getPluginElements(plugin).some(element => element.toLowerCase().includes(query))
         );

--- a/ui/src/components/plugins/PluginList.vue
+++ b/ui/src/components/plugins/PluginList.vue
@@ -18,7 +18,7 @@
             >
                 <a
                     v-if="index < navigationStack.length - 1"
-                    href="#" 
+                    href="#"
                     @click.prevent="goToStep(index)"
                 >
                     {{ item.title }}
@@ -26,11 +26,11 @@
                 <span v-else>{{ item.title }}</span>
             </el-breadcrumb-item>
         </el-breadcrumb>
-        <SearchField 
-            v-if="navigationStack.length === 0" 
-            class="search-field" 
-            :router="false" 
-            @search="value => searchQuery = value" 
+        <SearchField
+            v-if="navigationStack.length === 0"
+            class="search-field"
+            :router="false"
+            @search="value => searchQuery = value"
         />
     </div>
 
@@ -64,7 +64,7 @@
     </div>
 
     <div v-else-if="currentView === 'documentation'" :class="['doc-view', {'no-padding': !currentDocumentationPlugin}]" ref="docRef">
-        <PluginDocumentation 
+        <PluginDocumentation
             :plugin="currentDocumentationPlugin"
         />
     </div>
@@ -123,32 +123,18 @@
         navigationStack.value.push({title, type, data});
     };
 
-    const getPluginElements = (plugin: any): string[] => 
+    const getPluginElements = (plugin: any): string[] =>
         Object.entries(plugin ?? {})
             .filter(([elementType, elements]) => isEntryAPluginElementPredicate(elementType, elements))
-            .flatMap(([, elements]) => 
-                Array.isArray(elements) 
-                    ? elements.filter(({deprecated}) => !deprecated).map(({cls}) => cls) 
+            .flatMap(([, elements]) =>
+                Array.isArray(elements)
+                    ? elements.filter(({deprecated}) => !deprecated).map(({cls}) => cls)
                     : []
             );
-
-    const getPluginDisplayName = (plugin: any): string => {
-        return plugin?.manifest?.["X-Kestra-Title"];
-    };
 
     const isPluginVisible = (plugin: any): boolean => {
         if (!plugin) return false;
         return getPluginElements(plugin).length > 0;
-    };
-
-    const removeDuplicatePlugins = (plugins: any[]) => {
-        const seen = new Set();
-        return plugins.filter(plugin => {
-            const key = `${plugin.title || plugin.group}-${plugin.group}-${plugin.subGroup}`;
-            if (seen.has(key)) return false;
-            seen.add(key);
-            return true;
-        });
     };
 
     const resetToListView = () => {
@@ -159,21 +145,34 @@
         currentDocumentationPlugin.value = null;
     };
 
-    const basePlugins = computed(() => 
-        removeDuplicatePlugins(
-            (props.plugins ?? [])
-                .filter(plugin => plugin && (plugin.group || plugin.subGroup))
-        )
+    const basePlugins = computed(() => {
+        const grouped = (props.plugins ?? []).reduce((acc: Record<string, any[]>, plugin: any) => {
+            (acc[plugin.group] ??= []).push(plugin);
+            return acc;
+        }, {});
+
+        const filtered = Object.values(grouped).flatMap(group =>
+            group.filter((p: any) => p.subGroup).length ? group.filter((p: any) => p.subGroup) : group.filter((p: any) => !p.subGroup)
+        );
+
+        return filtered
+            .filter((plugin, index, self) =>
+                index === self.findIndex(t => t.title === plugin.title && t.group === plugin.group)
+            )
             .filter(isPluginVisible)
-            .sort((a, b) => (getPluginDisplayName(a) ?? "").toLowerCase().localeCompare((getPluginDisplayName(b) ?? "").toLowerCase()))
-    );
+            .sort((a, b) => {
+                const nameA = (a.manifest?.["X-Kestra-Title"] ?? "").toLowerCase();
+                const nameB = (b.manifest?.["X-Kestra-Title"] ?? "").toLowerCase();
+                return nameA < nameB ? -1 : nameA > nameB ? 1 : 0;
+            });
+    });
 
     const sortedPlugins = computed(() => {
         if (!searchQuery.value) return basePlugins.value;
         const query = searchQuery.value.toLowerCase();
-        return basePlugins.value.filter(plugin => 
-            (getPluginDisplayName(plugin) ?? "").toLowerCase().includes(query) ||
-            (plugin.title ?? "").toLowerCase().includes(query)
+        return basePlugins.value.filter(plugin =>
+            (plugin.title ?? "").toLowerCase().includes(query) ||
+            getPluginElements(plugin).some(element => element.toLowerCase().includes(query))
         );
     });
 
@@ -236,7 +235,7 @@
     };
 
     const getSubgroupTitle = (group: string, subgroup: string): string => {
-        const subgroupPlugin = props.plugins.find(p => 
+        const subgroupPlugin = props.plugins.find(p =>
             p.group === group && (p.subGroup === subgroup || p.subGroup?.endsWith(`.${subgroup}`))
         );
         return formatPluginTitle(subgroupPlugin?.title) ?? formatPluginTitle(subgroup) ?? subgroup;


### PR DESCRIPTION
closes https://github.com/kestra-io/kestra/issues/14817

- Tried to align with the plugins tab search


<img width="690" height="714" alt="Screenshot 2026-02-27 at 12 23 17 PM" src="https://github.com/user-attachments/assets/bdeea145-be56-49d3-a761-1b77b90017c8" />
