### PR TITLE
fix: filter out deprecated definitions from plugin documentation

### DIFF
--- a/ui/src/components/plugins/Plugin.vue
+++ b/ui/src/components/plugins/Plugin.vue
@@ -141,19 +141,9 @@
 
         const filteredDefinitions = Object.entries(schema.definitions).reduce(
             (acc, [key, value]: [string, any]) => {
-                const title: string = value?.title ?? "";
-
-                const shouldFilter =
-                    value?.deprecated === true ||
-                    value?.hidden === true ||
-                    key.includes("FlowCondition") ||
-                    key.includes("FlowNamespaceCondition") ||
-                    /condition for a (specific flow|flow namespace)/i.test(title);
-
-                if (!shouldFilter) {
+                if (!value?.$deprecated) {
                     acc[key] = value;
                 }
-
                 return acc;
             },
             {} as Record<string, any>

--- a/ui/src/components/plugins/Plugin.vue
+++ b/ui/src/components/plugins/Plugin.vue
@@ -59,11 +59,7 @@
             </div>
         </template>
         <template #menu>
-            <Toc
-                @router-change="onRouterChange"
-                v-if="pluginsStore.plugins"
-                :plugins="pluginsStore.plugins.filter(p => !p.subGroup && !p.deprecated)"
-            />
+            <Toc @router-change="onRouterChange" v-if="pluginsStore.plugins" :plugins="pluginsStore.plugins.filter(p => !p.subGroup)" />
         </template>
         <template #content>
             <div class="plugin-doc" v-if="pluginsStore.plugin">
@@ -100,6 +96,7 @@
     import {usePluginsStore} from "../../stores/plugins";
     import {useMiscStore} from "override/stores/misc";
     import {getPluginReleaseUrl} from "../../utils/pluginUtils";
+    import type {JSONSchema} from "@kestra-io/ui-libs";
 
 
     const pluginsStore = usePluginsStore();
@@ -135,55 +132,41 @@
         return split ? split[split.length - 1] : undefined;
     });
 
-    /**
-     * Filters out deprecated/hidden definitions from a definitions map.
-     * Handles both `definitions` (JSON Schema draft-07) and `$defs` (draft-2019+).
-     */
-    function filterDefinitions(defs: Record<string, any>): Record<string, any> {
-        return Object.entries(defs).reduce((acc, [key, value]: [string, any]) => {
-            const title: string = value?.title ?? "";
+    const filteredSchema = computed((): JSONSchema => {
+        const schema = pluginsStore.plugin?.schema as JSONSchema;
 
-            const shouldFilter =
-                value?.deprecated === true ||
-                value?.hidden === true ||
-                key.includes("FlowCondition") ||
-                key.includes("FlowNamespaceCondition") ||
-                /condition for a (specific flow|flow namespace)/i.test(title);
-
-            if (!shouldFilter) {
-                acc[key] = value;
-            }
-
-            return acc;
-        }, {} as Record<string, any>);
-    }
-
-    /**
-     * filteredSchema watches pluginsStore.plugin directly so Vue tracks
-     * reactivity properly, including after nextTick-delayed cache assignments.
-     */
-    const filteredSchema = computed(() => {
-        const plugin = pluginsStore.plugin;
-
-        if (!plugin?.schema) {
-            return undefined;
+        if (!schema?.definitions) {
+            return schema;
         }
 
-        const schema = plugin.schema;
-        const result: any = {...schema};
+        const filteredDefinitions = Object.entries(schema.definitions).reduce(
+            (acc, [key, value]: [string, any]) => {
+                const title: string = value?.title ?? "";
 
-        if (schema.definitions && Object.keys(schema.definitions).length > 0) {
-            result.definitions = filterDefinitions(schema.definitions);
-        }
+                const shouldFilter =
+                    value?.deprecated === true ||
+                    value?.hidden === true ||
+                    key.includes("FlowCondition") ||
+                    key.includes("FlowNamespaceCondition") ||
+                    /condition for a (specific flow|flow namespace)/i.test(title);
 
-        if (schema.$defs && Object.keys(schema.$defs).length > 0) {
-            result.$defs = filterDefinitions(schema.$defs);
-        }
+                if (!shouldFilter) {
+                    acc[key] = value;
+                }
 
-        return result;
+                return acc;
+            },
+            {} as Record<string, any>
+        );
+
+        return {
+            ...schema,
+            definitions: filteredDefinitions,
+        };
     });
 
     const releaseNotesUrl = computed(() => getPluginReleaseUrl(pluginType.value));
+
 
     const isPluginList = computed(
         () => typeof route.name === "string" && route.name === "plugins/list"
@@ -256,6 +239,7 @@
         },
         {immediate: true}
     );
+
 
     watch(
         () => pluginsStore.plugins,

--- a/ui/src/components/plugins/Plugin.vue
+++ b/ui/src/components/plugins/Plugin.vue
@@ -59,7 +59,11 @@
             </div>
         </template>
         <template #menu>
-            <Toc @router-change="onRouterChange" v-if="pluginsStore.plugins" :plugins="pluginsStore.plugins.filter(p => !p.subGroup)" />
+            <Toc
+                @router-change="onRouterChange"
+                v-if="pluginsStore.plugins"
+                :plugins="pluginsStore.plugins.filter(p => !p.subGroup && !p.deprecated)"
+            />
         </template>
         <template #content>
             <div class="plugin-doc" v-if="pluginsStore.plugin">
@@ -67,7 +71,7 @@
                     <SchemaToHtml
                         class="plugin-schema"
                         :darkMode="miscStore.theme === 'dark'"
-                        :schema="pluginsStore.plugin.schema"
+                        :schema="filteredSchema"
                         :propsInitiallyExpanded="true"
                         :pluginType="pluginType!"
                         noUrlChange
@@ -131,8 +135,55 @@
         return split ? split[split.length - 1] : undefined;
     });
 
-    const releaseNotesUrl = computed(() => getPluginReleaseUrl(pluginType.value));
+    /**
+     * Filters out deprecated/hidden definitions from a definitions map.
+     * Handles both `definitions` (JSON Schema draft-07) and `$defs` (draft-2019+).
+     */
+    function filterDefinitions(defs: Record<string, any>): Record<string, any> {
+        return Object.entries(defs).reduce((acc, [key, value]: [string, any]) => {
+            const title: string = value?.title ?? "";
 
+            const shouldFilter =
+                value?.deprecated === true ||
+                value?.hidden === true ||
+                key.includes("FlowCondition") ||
+                key.includes("FlowNamespaceCondition") ||
+                /condition for a (specific flow|flow namespace)/i.test(title);
+
+            if (!shouldFilter) {
+                acc[key] = value;
+            }
+
+            return acc;
+        }, {} as Record<string, any>);
+    }
+
+    /**
+     * filteredSchema watches pluginsStore.plugin directly so Vue tracks
+     * reactivity properly, including after nextTick-delayed cache assignments.
+     */
+    const filteredSchema = computed(() => {
+        const plugin = pluginsStore.plugin;
+
+        if (!plugin?.schema) {
+            return undefined;
+        }
+
+        const schema = plugin.schema;
+        const result: any = {...schema};
+
+        if (schema.definitions && Object.keys(schema.definitions).length > 0) {
+            result.definitions = filterDefinitions(schema.definitions);
+        }
+
+        if (schema.$defs && Object.keys(schema.$defs).length > 0) {
+            result.$defs = filterDefinitions(schema.$defs);
+        }
+
+        return result;
+    });
+
+    const releaseNotesUrl = computed(() => getPluginReleaseUrl(pluginType.value));
 
     const isPluginList = computed(
         () => typeof route.name === "string" && route.name === "plugins/list"
@@ -205,7 +256,6 @@
         },
         {immediate: true}
     );
-
 
     watch(
         () => pluginsStore.plugins,

--- a/ui/src/components/plugins/PluginDocumentation.vue
+++ b/ui/src/components/plugins/PluginDocumentation.vue
@@ -61,6 +61,7 @@
     import {usePluginsStore} from "../../stores/plugins";
     import GitHub from "vue-material-design-icons/Github.vue";
     import intro from "../../assets/docs/basic.md?raw";
+    import type {JSONSchema} from "@kestra-io/ui-libs";
 
     const props = withDefaults(defineProps<{
         overrideIntro?: string | null;
@@ -100,52 +101,37 @@
         }
     };
 
-    /**
-     * Filters out deprecated/hidden definitions from a definitions map.
-     * Handles both `definitions` (JSON Schema draft-07) and `$defs` (draft-2019+).
-     */
-    function filterDefinitions(defs: Record<string, any>): Record<string, any> {
-        return Object.entries(defs).reduce((acc, [key, value]: [string, any]) => {
-            const title: string = value?.title ?? "";
+    const filteredSchema = computed((): JSONSchema => {
+        const schema = currentPlugin.value?.schema as JSONSchema;
 
-            const shouldFilter =
-                value?.deprecated === true ||
-                value?.hidden === true ||
-                key.includes("FlowCondition") ||
-                key.includes("FlowNamespaceCondition") ||
-                /condition for a (specific flow|flow namespace)/i.test(title);
-
-            if (!shouldFilter) {
-                acc[key] = value;
-            }
-
-            return acc;
-        }, {} as Record<string, any>);
-    }
-
-    /**
-     * Returns the schema with deprecated definitions removed.
-     * Watches currentPlugin directly so Vue tracks reactivity properly.
-     */
-    const filteredSchema = computed(() => {
-        const plugin = currentPlugin.value;
-
-        if (!plugin?.schema) {
-            return undefined;
+        if (!schema?.definitions) {
+            return schema;
         }
 
-        const schema = plugin.schema;
-        const result: any = {...schema};
+        const filteredDefinitions = Object.entries(schema.definitions).reduce(
+            (acc, [key, value]: [string, any]) => {
+                const title: string = value?.title ?? "";
 
-        if (schema.definitions && Object.keys(schema.definitions).length > 0) {
-            result.definitions = filterDefinitions(schema.definitions);
-        }
+                const shouldFilter =
+                    value?.deprecated === true ||
+                    value?.hidden === true ||
+                    key.includes("FlowCondition") ||
+                    key.includes("FlowNamespaceCondition") ||
+                    /condition for a (specific flow|flow namespace)/i.test(title);
 
-        if (schema.$defs && Object.keys(schema.$defs).length > 0) {
-            result.$defs = filterDefinitions(schema.$defs);
-        }
+                if (!shouldFilter) {
+                    acc[key] = value;
+                }
 
-        return result;
+                return acc;
+            },
+            {} as Record<string, any>
+        );
+
+        return {
+            ...schema,
+            definitions: filteredDefinitions,
+        };
     });
 </script>
 

--- a/ui/src/components/plugins/PluginDocumentation.vue
+++ b/ui/src/components/plugins/PluginDocumentation.vue
@@ -25,14 +25,14 @@
                 <SchemaToHtml
                     class="plugin-schema"
                     :darkMode="miscStore.theme === 'dark'"
-                    :schema="currentPlugin?.schema"
+                    :schema="filteredSchema"
                     :pluginType="currentPlugin?.cls"
                     :forceIncludeProperties="pluginsStore.forceIncludeProperties"
                     noUrlChange
                 >
                     <template #markdown="{content}">
                         <!-- Plugin schema content: search disabled -->
-                        <Markdown 
+                        <Markdown
                             font-size-var="font-size-base"
                             :source="content"
                         />
@@ -99,6 +99,54 @@
             window.open(releaseNotesUrl.value, "_blank");
         }
     };
+
+    /**
+     * Filters out deprecated/hidden definitions from a definitions map.
+     * Handles both `definitions` (JSON Schema draft-07) and `$defs` (draft-2019+).
+     */
+    function filterDefinitions(defs: Record<string, any>): Record<string, any> {
+        return Object.entries(defs).reduce((acc, [key, value]: [string, any]) => {
+            const title: string = value?.title ?? "";
+
+            const shouldFilter =
+                value?.deprecated === true ||
+                value?.hidden === true ||
+                key.includes("FlowCondition") ||
+                key.includes("FlowNamespaceCondition") ||
+                /condition for a (specific flow|flow namespace)/i.test(title);
+
+            if (!shouldFilter) {
+                acc[key] = value;
+            }
+
+            return acc;
+        }, {} as Record<string, any>);
+    }
+
+    /**
+     * Returns the schema with deprecated definitions removed.
+     * Watches currentPlugin directly so Vue tracks reactivity properly.
+     */
+    const filteredSchema = computed(() => {
+        const plugin = currentPlugin.value;
+
+        if (!plugin?.schema) {
+            return undefined;
+        }
+
+        const schema = plugin.schema;
+        const result: any = {...schema};
+
+        if (schema.definitions && Object.keys(schema.definitions).length > 0) {
+            result.definitions = filterDefinitions(schema.definitions);
+        }
+
+        if (schema.$defs && Object.keys(schema.$defs).length > 0) {
+            result.$defs = filterDefinitions(schema.$defs);
+        }
+
+        return result;
+    });
 </script>
 
 <style scoped lang="scss">

--- a/ui/src/components/plugins/PluginDocumentation.vue
+++ b/ui/src/components/plugins/PluginDocumentation.vue
@@ -110,19 +110,9 @@
 
         const filteredDefinitions = Object.entries(schema.definitions).reduce(
             (acc, [key, value]: [string, any]) => {
-                const title: string = value?.title ?? "";
-
-                const shouldFilter =
-                    value?.deprecated === true ||
-                    value?.hidden === true ||
-                    key.includes("FlowCondition") ||
-                    key.includes("FlowNamespaceCondition") ||
-                    /condition for a (specific flow|flow namespace)/i.test(title);
-
-                if (!shouldFilter) {
+                if (!value?.$deprecated) {
                     acc[key] = value;
                 }
-
                 return acc;
             },
             {} as Record<string, any>


### PR DESCRIPTION
Fixes #14293 

Deprecated definitions like `FlowCondition` and `FlowNamespaceCondition` were 
still showing in the Definitions section despite being marked as deprecated.

The API response already includes a `$deprecated: "true"` field on deprecated 
definitions. The `SchemaToHtml` component in ui-libs uses this field to hide 
deprecated properties, but the same check wasn't applied to definitions.

This fix adds a `filteredSchema` computed property in both `Plugin.vue` and 
`PluginDocumentation.vue` that filters out definitions with `$deprecated` before 
passing the schema to `SchemaToHtml` — a generic solution that works across all 
plugins, not just the ones in this issue.

**Tested:**
- Deprecated definitions no longer appear on the standalone Plugins page
- Deprecated definitions no longer appear in the in-app editor Documentation panel
- `npm run test:types` passes with no errors

<img width="602" height="221" alt="Screenshot 2026-02-27 223250" src="https://github.com/user-attachments/assets/140bdf7a-1b48-4111-bb74-3be20f5ebb6d" />

## Screenshots 
Before:
<img width="1913" height="843" alt="image" src="https://github.com/user-attachments/assets/53827ac6-cf65-4229-ac7b-b87a5985037e" />

After: only valid, non-deprecated definitions shown
<img width="1919" height="1023" alt="Screenshot 2026-02-27 222328" src="https://github.com/user-attachments/assets/4e252d17-b226-453b-b99a-18226e8a5ef8" />
