### PR TITLE
feat(core): prototype AOT

### DIFF
--- a/cli/src/main/java/io/kestra/cli/StandAloneRunner.java
+++ b/cli/src/main/java/io/kestra/cli/StandAloneRunner.java
@@ -13,6 +13,7 @@ import jakarta.inject.Inject;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 
+import java.lang.management.ManagementFactory;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
@@ -78,6 +79,7 @@ public class StandAloneRunner implements Runnable, AutoCloseable {
 
         try {
             Await.until(() -> servers.stream().allMatch(s -> Optional.ofNullable(s.getState()).orElse(Service.ServiceState.RUNNING).isRunning()), null, runningTimeout);
+            log.info("All services started successfully (JVM running for {}).", Duration.ofMillis(ManagementFactory.getRuntimeMXBean().getUptime()));
         } catch (TimeoutException e) {
             throw new RuntimeException(
                 servers.stream().filter(s -> !Optional.ofNullable(s.getState()).orElse(Service.ServiceState.RUNNING).isRunning())

--- a/cli/src/main/java/io/kestra/cli/commands/servers/StandAloneCommand.java
+++ b/cli/src/main/java/io/kestra/cli/commands/servers/StandAloneCommand.java
@@ -103,6 +103,9 @@ public class StandAloneCommand extends AbstractServerCommand {
     @Option(names = {"--no-controller"}, description = "Flag to disable starting an embedded controller.")
     boolean controllerDisabled = false;
 
+    @Option(names = {"--stop"}, description = "Stop immediatly after start. This can be used to troubleshoot startup issues.")
+    boolean stopImmediately = false;
+
     @Override
     public boolean isFlowAutoLoadEnabled() {
         return !tutorialsDisabled;
@@ -165,7 +168,11 @@ public class StandAloneCommand extends AbstractServerCommand {
                 fileWatcher.startListeningFromConfig();
             }
 
-            Await.until(() -> !this.applicationContext.isRunning());
+            if (!stopImmediately) {
+                Await.until(() -> !this.applicationContext.isRunning());
+            } else {
+                this.applicationContext.stop();
+            }
         }
 
         return 0;

--- a/gradle/jar/selfrun.sh
+++ b/gradle/jar/selfrun.sh
@@ -34,6 +34,8 @@ fi
 # -XX:MaxRAMPercentage=50.0: configure max heap to 50% of available RAM (default 25%)
 KESTRA_JAVA_OPTS="-XX:MaxRAMPercentage=50.0"
 
+echo "KESTRA_AOT_OPTS=${KESTRA_AOT_OPTS}"
+
 # Exec
-exec java ${KESTRA_JAVA_OPTS} ${JAVA_OPTS} ${JAVA_ADD_OPENS} --enable-native-access=ALL-UNNAMED -jar "$0" "$@"
+exec java ${KESTRA_JAVA_OPTS} ${JAVA_OPTS} ${JAVA_ADD_OPENS} ${KESTRA_AOT_OPTS} --enable-native-access=ALL-UNNAMED -jar "$0" "$@"
 exit 127


### PR DESCRIPTION
This is a PoC on using Java AOT to speed up starting Kestra.

Preliminary work involves starting Kestra first to build the AOT cache:
```
export KESTRA_AOT_OPTS="-XX:AOTCacheOutput=kestra.aot"
./build/executable/kestra-1.4.0-SNAPSHOT server local --stop
```

Then starting Kestra with the AOT cache:
```
export KESTRA_AOT_OPTS="-XX:AOTCache=kestra.aot"
./build/executable/kestra-1.4.0-SNAPSHOT server local --stop
```

## Performance gain

Around 50% startup time reduction on a Kestra with no plugins on my local computer (24 vCPU).

**Before**

```
 All services started successfully (JVM running for PT4.394Sms).
```

**After**

``` 
All services started successfully (JVM running for PT2.159Sms)
```

The AOT cache size is approximately 180MB.