### PR TITLE
chore: simplify openapi spec generation

### DIFF
--- a/openapi.yml
+++ b/openapi.yml
@@ -4,7 +4,7 @@ info:
   license:
     name: Apache 2.0
     url: https://raw.githubusercontent.com/kestra-io/kestra/master/LICENSE
-  version: 1.0.0
+  version: 1.4.0-SNAPSHOT
 tags:
 - name: Flows
   description: Flows API

--- a/webserver/build.gradle
+++ b/webserver/build.gradle
@@ -48,29 +48,11 @@ dependencies {
     testImplementation("io.micronaut.sql:micronaut-jooq")
 }
 
-tasks.register('updateOpenapiVersion') {
-    dependsOn processResources
-
-    doLast {
-        def openapiFilePath = "${buildDir}/classes/java/main/META-INF/swagger/kestra.yml"
-        def openapiFile = file(openapiFilePath)
-
-        if (openapiFile.exists()) {
-            def originalText = openapiFile.text
-            def updatedText = originalText.replace('version: 1.0.0', "version: ${project.version}")
-
-            if (updatedText != originalText) {
-                openapiFile.text = updatedText
-                println "Successfully updated 'version' in $openapiFilePath to ${project.version}"
-            } else {
-                println "Warning: Did not find 'version: 1.0.0' to replace in $openapiFilePath. Check OpenAPI generator output."
-            }
-        } else {
-            println "Error: OpenAPI file not found at $openapiFilePath. Skipping version update."
-        }
-    }
+tasks.withType(JavaCompile).configureEach {
+    options.compilerArgs += [
+        "-Amicronaut.openapi.expand.version=${project.version}"
+    ]
 }
-
 tasks.register('generateOpenapiSpec', Copy) {
     def compileJavaProvider = tasks.named('compileJava')
     def openapiSpecPath = project.layout.buildDirectory.file("classes/java/main/META-INF/swagger/kestra.yml")
@@ -81,7 +63,6 @@ tasks.register('generateOpenapiSpec', Copy) {
 }
 
 tasks.named('jar', Jar) {
-    dependsOn updateOpenapiVersion
     exclude '**/spring-configuration-metadata.json'
 }
 

--- a/webserver/src/main/java/io/kestra/webserver/Application.java
+++ b/webserver/src/main/java/io/kestra/webserver/Application.java
@@ -9,6 +9,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 @OpenAPIDefinition(
     info = @Info(
         title = "Kestra",
+        version = "${version}",
         license = @License(name = "Apache 2.0", url = "https://raw.githubusercontent.com/kestra-io/kestra/master/LICENSE")
     ),
     tags = {


### PR DESCRIPTION
forward gradle project version to micronaut, so it can generate a openapi spec with the proper version. Thanks to that updateOpenapiVersion is not needed anymore, it was causing a lot of gradle inc-build issues