### PR TITLE
fix(jdbc): next task deduplication could have false-positive skips

### DIFF
--- a/jdbc/src/main/java/io/kestra/jdbc/runner/JdbcExecutor.java
+++ b/jdbc/src/main/java/io/kestra/jdbc/runner/JdbcExecutor.java
@@ -640,9 +640,10 @@ public class JdbcExecutor implements ExecutorInterface {
                         }
                         executor = executorService.process(executor);
 
-                        if (!executor.getNexts().isEmpty() && deduplicateNexts(execution, executorState, executor.getNexts())) {
+                        List<TaskRun> nexts = deduplicateNexts(execution, executorState, executor.getNexts());
+                        if (!nexts.isEmpty()) {
                             executor.withExecution(
-                                executorService.onNexts(executor.getExecution(), executor.getNexts()),
+                                executorService.onNexts(executor.getExecution(), nexts),
                                 "onNexts"
                             );
                         }
@@ -1460,10 +1461,10 @@ public class JdbcExecutor implements ExecutorInterface {
         });
     }
 
-    private boolean deduplicateNexts(Execution execution, ExecutorState executorState, List<TaskRun> taskRuns) {
+    private List<TaskRun> deduplicateNexts(Execution execution, ExecutorState executorState, List<TaskRun> taskRuns) {
         return taskRuns
             .stream()
-            .anyMatch(taskRun -> {
+            .filter(taskRun -> {
                 // As retry is now handled outside the worker,
                 // we now add the attempt size to the deduplication key
                 String deduplicationKey = taskRun.getParentTaskRunId() + "-" +
@@ -1479,7 +1480,7 @@ public class JdbcExecutor implements ExecutorInterface {
                     executorState.getChildDeduplication().put(deduplicationKey, taskRun.getId());
                     return true;
                 }
-            });
+            }).toList();
     }
 
     private boolean deduplicateWorkerTask(Execution execution, ExecutorState executorState, TaskRun taskRun) {


### PR DESCRIPTION
I initially thought it was linked to such [failure](https://github.com/kestra-io/kestra/actions/runs/22729761619/job/65915400552?pr=14947#step:6:5106) but the more I look the more I think it's due to [error taskruns removal upon restart](https://github.com/kestra-io/kestra/blob/develop/core/src/main/java/io/kestra/core/services/ExecutionService.java#L225), which removes the attempts and I'm not sure the ExecutorState has been cleared in-between so it leads to duplicate key and so the error handler is not executed.

Anyway I found it weird to do anyMatch and discard EVERY nexts instead of just filtering to keep only-seen-once at the end.