### PR TITLE
fix(webserver): narrow generateOpenapiSpec output to openapi.yml

### DIFF
--- a/webserver/build.gradle
+++ b/webserver/build.gradle
@@ -53,13 +53,22 @@ tasks.withType(JavaCompile).configureEach {
         "-Amicronaut.openapi.expand.version=${project.version}"
     ]
 }
-tasks.register('generateOpenapiSpec', Copy) {
+tasks.register('generateOpenapiSpec') {
     def compileJavaProvider = tasks.named('compileJava')
     def openapiSpecPath = project.layout.buildDirectory.file("classes/java/main/META-INF/swagger/kestra.yml")
+    def outputFile = project.getParent().layout.projectDirectory.file("openapi.yml")
 
-    from(compileJavaProvider.map(compileTask -> compileTask.outputs.files.filter{File f -> f == file(openapiSpecPath)}.singleFile))
-    into file("${project.getParent().projectDir}")
-    rename { 'openapi.yml' }
+    dependsOn(compileJavaProvider)
+    inputs.file(openapiSpecPath)
+    outputs.file(outputFile)
+
+    doLast {
+        copy {
+            from(openapiSpecPath)
+            into(outputFile.asFile.parentFile)
+            rename { outputFile.asFile.name }
+        }
+    }
 }
 
 tasks.named('jar', Jar) {


### PR DESCRIPTION
## ✨ Description

This PR fixes a Gradle task validation issue caused by :webserver:generateOpenapiSpec declaring an output that was too broad.

This PR narrows the task output to a single file (openapi.yml) by declaring explicit task inputs/outputs and copying only that file. This removes the overlapping output scope and resolves the implicit dependency validation failure.

Closes relates to kestra-io/kestra-ee#6978

### 🛠️ Backend Checklist

  - [x] Code compiles successfully and passes all checks
  - [x] All unit and integration tests pass