### PR TITLE
fix(log): ignore Prometheus queries

### DIFF
--- a/cli/src/main/resources/application.yml
+++ b/cli/src/main/resources/application.yml
@@ -51,7 +51,7 @@ micronaut:
           - /health/.+
           - /metrics
           - /metrics/.+
-          - /prometheus
+          - /prometheus(\?.*)?
     http-version: HTTP_1_1
   caches:
     default:


### PR DESCRIPTION
### ✨ Description

There are clients querying the Prometheus endpoint using params. For example Blackbox Exporter with `/prometheus?module=http_2xx`.
