### PR TITLE
fix(system): test can deadlock

### DIFF
--- a/core/src/main/java/io/kestra/core/contexts/KestraContext.java
+++ b/core/src/main/java/io/kestra/core/contexts/KestraContext.java
@@ -169,7 +169,9 @@ public abstract class KestraContext {
         public void shutdown() {
             if (isShutdown.compareAndSet(false, true)) {
                 log.info("Kestra server - Shutdown initiated");
-                applicationContext.close();
+                if (applicationContext.isRunning()) {
+                    applicationContext.close();
+                }
                 log.info("Kestra server - Shutdown completed");
             }
         }

--- a/core/src/main/java/io/kestra/core/utils/ThreadUncaughtExceptionHandler.java
+++ b/core/src/main/java/io/kestra/core/utils/ThreadUncaughtExceptionHandler.java
@@ -22,10 +22,11 @@ public final class ThreadUncaughtExceptionHandler implements UncaughtExceptionHa
             System.err.println(e.getMessage());
             System.err.println(errorInLogging.getMessage());
         } finally {
-            KestraContext.getContext().shutdown();
-
             if (!isTest) {
+                KestraContext.getContext().shutdown();
                 Runtime.getRuntime().exit(1);
+            } else {
+                throw new RuntimeException(e);
             }
         }
     }

--- a/queue/src/main/java/io/kestra/queue/QueueService.java
+++ b/queue/src/main/java/io/kestra/queue/QueueService.java
@@ -20,8 +20,9 @@ import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 
 import java.io.IOException;
-import java.util.Arrays;
+import java.time.Duration;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.TimeUnit;
 
 @Slf4j
 @Singleton
@@ -50,6 +51,14 @@ public class QueueService {
     @PreDestroy
     void close() {
         this.executorService.shutdown();
+        try {
+            if (!this.executorService.awaitTermination(30, TimeUnit.SECONDS)) {
+                this.executorService.shutdownNow();
+            }
+        } catch (InterruptedException e) {
+            log.error("Unexpected error while trying to shutdown the queue executor service", e);
+            this.executorService.shutdownNow();
+        }
     }
 
     public void execute(Runnable runnable) {


### PR DESCRIPTION
Tests can deadlock as the application context was closed in the `ThreadUncaughtExceptionHandler` and by the Micronaut test support.

Also wait for termination on the queue service to force closing queue consumers.
