### PR TITLE
refactor(ui): simplify ContextInfoBar splitter sizing

### DIFF
--- a/ui/src/components/ContextInfoBar.vue
+++ b/ui/src/components/ContextInfoBar.vue
@@ -1,9 +1,7 @@
 <template>
-    <div v-if="Object.keys(buttons).length" class="barWrapper" :class="{opened: activeTab?.length > 0}">
-        <button v-if="activeTab.length" class="barResizer" ref="resizeHandle" @mousedown="startResizing" />
-
+    <div v-if="hasButtons && !activeTab.length" class="barWrapper">
         <el-button
-            v-for="(button, key) of {...buttons, ...props.additionalButtons}"
+            v-for="(button, key) of contextButtons"
             :key="key"
             :type="activeTab === key ? 'primary' : 'default'"
             :tag="button.url ? 'a' : 'button'"
@@ -35,25 +33,74 @@
             <WeatherSunny v-else />
         </el-button>
     </div>
-    <div class="panelWrapper" ref="panelWrapper" :class="{panelTabResizing: resizing}" :style="{width: activeTab?.length ? `${panelWidth}px` : 0}">
-        <div :style="{overflow: 'hidden'}">
-            <button v-if="activeTab.length" class="closeButton" @click="setActiveTab('')">
-                <Close />
-            </button>
-            <KeepAlive v-if="activeTab">
-                <ContextDocs v-if="activeTab === 'docs'" />
-                <ContextNews v-else-if="activeTab === 'news'" />
-                <template v-else>
-                    {{ activeTab }}
-                </template>
-            </KeepAlive>
-        </div>
+
+    <div v-else-if="hasButtons" class="contextInfoSidebar" :style="{width: `${sidebarWidth}px`}">
+        <el-splitter
+            class="contextInfoSplitter"
+            :style="{width: `${maxSidebarWidth}px`}"
+        >
+            <el-splitter-panel class="contextInfoSpacerPanel" :min="0" />
+
+            <el-splitter-panel v-model:size="sidebarWidth" :min="minSidebarWidth" :max="maxSidebarWidth">
+                <div class="contextInfoContent">
+                    <div class="barWrapper opened">
+                        <el-button
+                            v-for="(button, key) of contextButtons"
+                            :key="key"
+                            :type="activeTab === key ? 'primary' : 'default'"
+                            :tag="button.url ? 'a' : 'button'"
+                            :href="button.url"
+                            @click="() => {if(!button.url){ setActiveTab(key as string)}}"
+                            :target="button.url ? '_blank' : undefined"
+                        >
+                            <component :is="button.icon" class="context-button-icon" />{{ button.title }}
+                            <OpenInNew v-if="button.url" class="open-in-new" />
+                            <div v-if="button.hasUnreadMarker === true && hasUnread" class="newsDot" />
+                        </el-button>
+
+                        <div style="flex:1" />
+
+                        <el-tooltip
+                            effect="light"
+                            :persistent="false"
+                            transition=""
+                            :hideAfter="0"
+                            :disabled="!miscStore.configs?.commitId"
+                        >
+                            <template #content>
+                                <code>{{ miscStore.configs?.commitId }}</code> <DateAgo v-if="miscStore.configs?.commitDate" :inverted="true" :date="miscStore.configs.commitDate" />
+                            </template>
+                            <span class="versionNumber">{{ miscStore.configs?.version }}</span>
+                        </el-tooltip>
+                        <el-button class="theme-switcher" @click="onSwitchTheme">
+                            <WeatherNight v-if="themeIsDark" />
+                            <WeatherSunny v-else />
+                        </el-button>
+                    </div>
+
+                    <div class="panelWrapper">
+                        <div :style="{overflow: 'hidden'}">
+                            <button v-if="activeTab.length" class="closeButton" @click="setActiveTab('')">
+                                <Close />
+                            </button>
+                            <KeepAlive v-if="activeTab">
+                                <ContextDocs v-if="activeTab === 'docs'" />
+                                <ContextNews v-else-if="activeTab === 'news'" />
+                                <template v-else>
+                                    {{ activeTab }}
+                                </template>
+                            </KeepAlive>
+                        </div>
+                    </div>
+                </div>
+            </el-splitter-panel>
+        </el-splitter>
     </div>
 </template>
 
 <script setup lang="ts">
-    import {computed, ref, watch, type Ref, type Component, PropType} from "vue";
-    import {useMouse, watchThrottled, useStorage} from "@vueuse/core"
+    import {computed, ref, watch, type Component, PropType} from "vue";
+    import {useStorage, useWindowSize} from "@vueuse/core"
     import ContextDocs from "./docs/ContextDocs.vue"
     import ContextNews from "./layout/ContextNews.vue"
     import DateAgo from "./layout/DateAgo.vue"
@@ -74,6 +121,8 @@
     const miscStore = useMiscStore();
 
     const activeTab = computed(() => miscStore.contextInfoBarOpenTab)
+    const contextButtons = computed(() => ({...buttons, ...props.additionalButtons}))
+    const hasButtons = computed(() => Object.keys(contextButtons.value).length > 0)
 
     const lastNewsReadDate = useStorage<string | null>("feeds", null)
 
@@ -97,41 +146,17 @@
         }
     });
 
-    const panelWidth = ref(640)
+    const BAR_WIDTH_PX = 64
+    const PANEL_MIN_WIDTH_PX = 50
 
-    const {startResizing, resizing} = useResizablePanel(activeTab)
+    const sidebarWidth = ref(704)
+    const {width: windowWidth} = useWindowSize()
+    const minSidebarWidth = BAR_WIDTH_PX + PANEL_MIN_WIDTH_PX
+    const maxSidebarWidth = computed(() => windowWidth.value * 0.5 + BAR_WIDTH_PX)
 
-    function useResizablePanel(localActiveTab: Ref<string>) {
-        const {x} = useMouse()
-
-        const resizing = ref(false)
-        const resizingStartPosition = ref(0)
-        const referencePanelWidth = ref(0)
-        const startResizing = () => {
-            resizingStartPosition.value = x.value;
-            referencePanelWidth.value = panelWidth.value;
-            resizing.value = true;
-
-            document.body.addEventListener("mouseup", () => {
-                resizing.value = false;
-            }, {once: true})
-        }
-
-        watchThrottled(x, () => {
-            if(resizing.value){
-                const newPanelWidth = referencePanelWidth.value + (resizingStartPosition.value - x.value);
-                panelWidth.value = Math.min(Math.max(newPanelWidth, 50), window.innerWidth * .5)
-            }
-        }, {throttle:20})
-
-        watch(localActiveTab, (value) => {
-            if(value.length){
-                x.value = 0;
-            }
-        })
-
-        return {startResizing, resizing}
-    }
+    watch(maxSidebarWidth, (value) => {
+        sidebarWidth.value = Math.min(Math.max(sidebarWidth.value, minSidebarWidth), value)
+    })
 
     function setActiveTab(tab: string) {
         if (activeTab.value === tab) {
@@ -153,27 +178,57 @@
 <style scoped lang="scss">
     @use 'element-plus/theme-chalk/src/mixins/mixins' as *;
 
-    .barResizer {
-        height: 100vh;
-        width: 5px;
+    .contextInfoSplitter {
         position: absolute;
         top: 0;
-        left: 0;
-        z-index: 1040;
-        background-color: var(--ks-button-background-primary);
-        opacity: 0;
-        transition: opacity .1s;
-        border: none;
-        cursor: col-resize;
+        right: 0;
+        bottom: 0;
+        height: 100%;
+        flex-shrink: 0;
 
-        &:hover {
-            opacity: 1;
+        :deep(.el-splitter-panel) {
+            min-width: 0;
         }
+
+        :deep(.contextInfoSpacerPanel) {
+            overflow: hidden;
+            pointer-events: none;
+        }
+
+        :deep(.el-splitter-bar) {
+            background-color: transparent;
+        }
+
+        :deep(.el-splitter__splitter) {
+            width: 5px;
+            background-color: transparent;
+            transition: background-color .1s;
+
+            &:hover,
+            &.is-dragging {
+                background-color: var(--ks-button-background-primary);
+            }
+        }
+    }
+
+    .contextInfoContent {
+        display: flex;
+        height: 100%;
+        width: 100%;
+    }
+
+    .contextInfoSidebar {
+        position: relative;
+        height: 100%;
+        flex-shrink: 0;
+        overflow: hidden;
     }
 
     .barWrapper {
         position: relative;
         width: 4rem;
+        min-width: 4rem;
+        flex-shrink: 0;
         padding: 0.75rem;
         writing-mode: vertical-rl;
         text-orientation: mixed;
@@ -246,8 +301,9 @@
     }
 
     .panelWrapper {
-        transition: width .1s;
-        width: 0;
+        flex: 1;
+        height: 100%;
+        min-width: 0;
         position: relative;
         overflow-y: auto;
         &::-webkit-scrollbar {
@@ -265,8 +321,5 @@
             z-index: 5;
         }
 
-        &.panelTabResizing {
-            transition: none;
-        }
     }
 </style>


### PR DESCRIPTION
closes #11310 

### ✨ Description

What does this PR change?  
Refactor `ContextInfoBar` to use Element Plus Splitter for sidebar sizing with a simpler layout and less custom resize logic.

- remove custom mouse-based resize behavior
- let `el-splitter` own the sidebar width
- simplify the inner panel layout to rely on flex sizing
- keep the existing open/close behavior of the context bar


### 🎨 Frontend Checklist

_If this PR does not include any frontend changes, delete this entire section._

- [x] Code builds without errors (`npm run build`)
- [ ] All existing E2E tests pass (`npm run test:e2e`)
- [x] Screenshots or video recordings attached showing the `UI` changes

some e2e tests are breaking, not sure if they are related to my code changes.


https://github.com/user-attachments/assets/1f870eae-69f2-4fd9-8099-ebaf92232f51

