### PR TITLE
Support nullable worker-group key rendering

### DIFF
--- a/core/src/main/java/io/kestra/core/models/property/Data.java
+++ b/core/src/main/java/io/kestra/core/models/property/Data.java
@@ -98,8 +98,11 @@ public class Data {
 
         if (from instanceof String str) {
             var renderedString = runContext.render(str);
+            if (renderedString == null) {
+                return Flux.empty();
+            }
             if (URIFetcher.supports(renderedString)) {
-                var uri = URIFetcher.of(runContext.render(str));
+                var uri = URIFetcher.of(renderedString);
                 try {
                     var reader = new BufferedReader(new InputStreamReader(uri.fetch(runContext)), FileSerde.BUFFER_SIZE);
                     return FileSerde.readAll(reader, clazz)

--- a/core/src/main/java/io/kestra/core/models/property/PropertyContext.java
+++ b/core/src/main/java/io/kestra/core/models/property/PropertyContext.java
@@ -2,6 +2,7 @@ package io.kestra.core.models.property;
 
 import io.kestra.core.exceptions.IllegalVariableEvaluationException;
 import io.kestra.core.runners.VariableRenderer;
+import io.micronaut.core.annotation.Nullable;
 
 import java.util.Map;
 
@@ -12,6 +13,7 @@ import java.util.Map;
  */
 public interface PropertyContext {
     
+    @Nullable
     String render(String inline, Map<String, Object> variables) throws IllegalVariableEvaluationException;
     
     Map<String, Object> render(Map<String, Object> inline, Map<String, Object> variables) throws IllegalVariableEvaluationException;
@@ -25,6 +27,7 @@ public interface PropertyContext {
     static PropertyContext create(final VariableRenderer renderer) {
         return new PropertyContext() {
             @Override
+            @Nullable
             public String render(String inline, Map<String, Object> variables) throws IllegalVariableEvaluationException {
                 return renderer.render(inline, variables);
             }

--- a/core/src/main/java/io/kestra/core/models/tasks/runners/PluginUtilsService.java
+++ b/core/src/main/java/io/kestra/core/models/tasks/runners/PluginUtilsService.java
@@ -146,10 +146,16 @@ abstract public class PluginUtilsService {
         String realFlowId;
         if (executionId != null) {
             realExecutionId = runContext.render(executionId);
+            if (realExecutionId == null) {
+                throw new IllegalVariableEvaluationException("Unable to resolve executionId: rendered value is null");
+            }
 
             if (namespace != null && flowId != null) {
                 realNamespace = runContext.render(namespace);
                 realFlowId = runContext.render(flowId);
+                if (realNamespace == null || realFlowId == null) {
+                    throw new IllegalVariableEvaluationException("Unable to resolve namespace/flowId: rendered value is null");
+                }
                 // validate that the flow exists: a.k.a access is authorized by this namespace
                 runContext.acl().allowNamespace(realNamespace).check();
             } else if (namespace != null || flowId != null) {
@@ -178,6 +184,9 @@ abstract public class PluginUtilsService {
         if (inputFiles != null && !inputFiles.isEmpty()) {
             for (String fileName : inputFiles.keySet()) {
                 String finalFileName = runContext.render(fileName);
+                if (finalFileName == null) {
+                    throw new IllegalVariableEvaluationException("Unable to create input file: rendered file name is null");
+                }
 
                 PluginUtilsService.validFilename(finalFileName);
 
@@ -203,7 +212,11 @@ abstract public class PluginUtilsService {
                     rFile = inputFiles.get(fileName);
                 }
 
-                if (URIFetcher.supports(rFile)) {
+                if (rFile == null) {
+                    if (!new File(filePath).createNewFile()) {
+                        throw new IOException("Unable to create the file: " + filePath);
+                    }
+                } else if (URIFetcher.supports(rFile)) {
                     var uri = URIFetcher.of(rFile);
                     try (
                         InputStream inputStream = new BufferedInputStream(uri.fetch(runContext));

--- a/core/src/main/java/io/kestra/core/runners/DefaultRunContext.java
+++ b/core/src/main/java/io/kestra/core/runners/DefaultRunContext.java
@@ -22,6 +22,7 @@ import io.kestra.core.utils.ListUtils;
 import io.kestra.core.utils.VersionProvider;
 import io.micronaut.context.ApplicationContext;
 import io.micronaut.core.annotation.Introspected;
+import io.micronaut.core.annotation.Nullable;
 import jakarta.validation.ConstraintViolation;
 import jakarta.validation.ConstraintViolationException;
 import jakarta.validation.Validator;
@@ -40,7 +41,6 @@ import java.nio.file.Path;
 import java.security.GeneralSecurityException;
 import java.util.*;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.stream.Collectors;
 
 import static io.kestra.core.utils.MapUtils.mergeWithNullableValues;
 import static io.kestra.core.utils.Rethrow.throwFunction;
@@ -257,6 +257,7 @@ public class DefaultRunContext extends RunContext {
      * {@inheritDoc}
      */
     @Override
+    @Nullable
     public String render(String inline) throws IllegalVariableEvaluationException {
         return variableRenderer.render(inline, this.variables);
     }
@@ -270,11 +271,6 @@ public class DefaultRunContext extends RunContext {
     }
 
     @Override
-    public String renderNullableString(String inline) throws IllegalVariableEvaluationException {
-        return variableRenderer.renderNullableString(inline, this.variables);
-    }
-
-    @Override
     public <T> RunContextProperty<T> render(Property<T> inline) {
         return new RunContextProperty<>(inline, this);
     }
@@ -284,6 +280,7 @@ public class DefaultRunContext extends RunContext {
      */
     @Override
     @SuppressWarnings("unchecked")
+    @Nullable
     public String render(String inline, Map<String, Object> variables) throws IllegalVariableEvaluationException {
         return variableRenderer.render(inline, mergeWithNullableValues(this.variables, decryptVariables(variables)));
     }
@@ -346,14 +343,20 @@ public class DefaultRunContext extends RunContext {
         }
 
         Map<String, Object> allVariables = mergeWithNullableValues(this.variables, decryptVariables(variables));
-        return inline
-            .entrySet()
-            .stream()
-            .map(throwFunction(entry -> new AbstractMap.SimpleEntry<>(
-                this.render(entry.getKey(), allVariables),
-                this.render(entry.getValue(), allVariables)
-            )))
-            .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+        Map<String, String> rendered = new LinkedHashMap<>();
+        for (Map.Entry<String, String> entry : inline.entrySet()) {
+            String renderedKey = this.render(entry.getKey(), allVariables);
+            if (renderedKey == null) {
+                throw new IllegalVariableEvaluationException("Unable to render map: key rendered to null");
+            }
+
+            String renderedValue = this.render(entry.getValue(), allVariables);
+            if (renderedValue != null) {
+                rendered.put(renderedKey, renderedValue);
+            }
+        }
+
+        return rendered;
     }
 
     @Override

--- a/core/src/main/java/io/kestra/core/runners/DefaultRunContext.java
+++ b/core/src/main/java/io/kestra/core/runners/DefaultRunContext.java
@@ -270,6 +270,11 @@ public class DefaultRunContext extends RunContext {
     }
 
     @Override
+    public String renderNullableString(String inline) throws IllegalVariableEvaluationException {
+        return variableRenderer.renderNullableString(inline, this.variables);
+    }
+
+    @Override
     public <T> RunContextProperty<T> render(Property<T> inline) {
         return new RunContextProperty<>(inline, this);
     }

--- a/core/src/main/java/io/kestra/core/runners/ExecutableUtils.java
+++ b/core/src/main/java/io/kestra/core/runners/ExecutableUtils.java
@@ -167,7 +167,16 @@ public final class ExecutableUtils {
 
             List<Label> newLabels = inheritLabels ? new ArrayList<>(filterLabels(currentExecution.getLabels(), flow)) : new ArrayList<>(systemLabels(currentExecution));
             if (labels != null) {
-                labels.forEach(throwConsumer(label -> newLabels.add(new Label(runContext.render(label.key()), runContext.render(label.value())))));
+                labels.forEach(throwConsumer(label -> {
+                    String renderedKey = runContext.render(label.key());
+                    String renderedValue = runContext.render(label.value());
+                    if (renderedKey == null || renderedValue == null) {
+                        runContext.logger().warn("Skipping subflow label '{}' because key or value rendered to null", label.key());
+                        return;
+                    }
+
+                    newLabels.add(new Label(renderedKey, renderedValue));
+                }));
             }
 
             var variables = ImmutableMap.<String, Object>builder().putAll(Map.of(

--- a/core/src/main/java/io/kestra/core/runners/FilesService.java
+++ b/core/src/main/java/io/kestra/core/runners/FilesService.java
@@ -1,5 +1,6 @@
 package io.kestra.core.runners;
 
+import io.kestra.core.exceptions.IllegalVariableEvaluationException;
 import io.kestra.core.models.property.URIFetcher;
 import io.kestra.core.models.tasks.runners.PluginUtilsService;
 import io.kestra.core.serializers.FileSerde;
@@ -33,7 +34,12 @@ public abstract class FilesService {
 
          inputFiles
              .forEach(throwBiConsumer((fileName, input) -> {
-                 var file = new File(runContext.workingDir().path().toString(), runContext.render(fileName, additionalVars));
+                 String renderedFileName = runContext.render(fileName, additionalVars);
+                 if (renderedFileName == null) {
+                     throw new IllegalVariableEvaluationException("Unable to create input file: rendered file name is null");
+                 }
+
+                 var file = new File(runContext.workingDir().path().toString(), renderedFileName);
 
                  if (!file.getParentFile().exists()) {
                      //noinspection ResultOfMethodCallIgnored
@@ -66,6 +72,9 @@ public abstract class FilesService {
 
     public static Map<String, URI> outputFiles(RunContext runContext, List<String> outputs) throws Exception {
         List<String> renderedOutputs = outputs != null ? runContext.render(outputs) : null;
+        if (renderedOutputs != null && renderedOutputs.stream().anyMatch(Objects::isNull)) {
+            throw new IllegalVariableEvaluationException("Unable to capture output files: one or more rendered output patterns are null");
+        }
         List<Path> allFilesMatching = runContext.workingDir().findAllFilesMatching(renderedOutputs);
         var outputFiles = allFilesMatching.stream()
             .map(throwFunction(path -> new AbstractMap.SimpleEntry<>(

--- a/core/src/main/java/io/kestra/core/runners/RunContext.java
+++ b/core/src/main/java/io/kestra/core/runners/RunContext.java
@@ -59,6 +59,8 @@ public abstract class RunContext implements PropertyContext {
 
     public abstract Object renderTyped(String inline) throws IllegalVariableEvaluationException;
 
+    public abstract String renderNullableString(String inline) throws IllegalVariableEvaluationException;
+
     public abstract String render(String inline, Map<String, Object> variables) throws IllegalVariableEvaluationException;
 
     public abstract <T> RunContextProperty<T> render(Property<T> inline);

--- a/core/src/main/java/io/kestra/core/runners/RunContext.java
+++ b/core/src/main/java/io/kestra/core/runners/RunContext.java
@@ -12,6 +12,7 @@ import io.kestra.core.models.property.PropertyContext;
 import io.kestra.core.storages.StateStore;
 import io.kestra.core.storages.Storage;
 import io.kestra.core.storages.kv.KVStore;
+import io.micronaut.core.annotation.Nullable;
 import org.slf4j.Logger;
 
 import java.net.URI;
@@ -55,12 +56,12 @@ public abstract class RunContext implements PropertyContext {
 
     public abstract void setTraceParent(String traceParent);
 
+    @Nullable
     public abstract String render(String inline) throws IllegalVariableEvaluationException;
 
     public abstract Object renderTyped(String inline) throws IllegalVariableEvaluationException;
 
-    public abstract String renderNullableString(String inline) throws IllegalVariableEvaluationException;
-
+    @Nullable
     public abstract String render(String inline, Map<String, Object> variables) throws IllegalVariableEvaluationException;
 
     public abstract <T> RunContextProperty<T> render(Property<T> inline);

--- a/core/src/main/java/io/kestra/core/runners/VariableRenderer.java
+++ b/core/src/main/java/io/kestra/core/runners/VariableRenderer.java
@@ -60,6 +60,34 @@ public class VariableRenderer {
         return this.render(inline, variables, this.variableConfiguration.getRecursiveRendering(), false);
     }
 
+    /**
+     * Render a string expression while preserving semantic {@code null} for single-expression templates.
+     * <p>
+     * For expressions that render to non-string objects, this method stringifies the typed result
+     * using the same writer used by regular string rendering.
+     */
+    public String renderNullableString(String inline, Map<String, Object> variables) throws IllegalVariableEvaluationException {
+        Object typedValue;
+        try {
+            typedValue = this.renderTyped(inline, variables);
+        } catch (IllegalArgumentException e) {
+            // Typed rendering cannot concatenate complex types with literals.
+            // Fall back to standard string rendering for those mixed templates.
+            return this.render(inline, variables);
+        }
+        if (typedValue == null) {
+            return null;
+        }
+
+        if (typedValue instanceof String typedString) {
+            return typedString;
+        }
+
+        JsonWriter writer = new JsonWriter();
+        writer.write(typedValue);
+        return (String) writer.output();
+    }
+
     public String render(String inline, Map<String, Object> variables, boolean recursive) throws IllegalVariableEvaluationException {
         return (String) this.render(inline, variables, recursive, true);
     }

--- a/core/src/main/java/io/kestra/core/runners/VariableRenderer.java
+++ b/core/src/main/java/io/kestra/core/runners/VariableRenderer.java
@@ -57,42 +57,19 @@ public class VariableRenderer {
     }
 
     public Object renderTyped(String inline, Map<String, Object> variables) throws IllegalVariableEvaluationException {
-        return this.render(inline, variables, this.variableConfiguration.getRecursiveRendering(), false);
+        return this.renderInternal(inline, variables, this.variableConfiguration.getRecursiveRendering(), false);
     }
 
-    /**
-     * Render a string expression while preserving semantic {@code null} for single-expression templates.
-     * <p>
-     * For expressions that render to non-string objects, this method stringifies the typed result
-     * using the same writer used by regular string rendering.
-     */
-    public String renderNullableString(String inline, Map<String, Object> variables) throws IllegalVariableEvaluationException {
-        Object typedValue;
-        try {
-            typedValue = this.renderTyped(inline, variables);
-        } catch (IllegalArgumentException e) {
-            // Typed rendering cannot concatenate complex types with literals.
-            // Fall back to standard string rendering for those mixed templates.
-            return this.render(inline, variables);
-        }
-        if (typedValue == null) {
-            return null;
-        }
-
-        if (typedValue instanceof String typedString) {
-            return typedString;
-        }
-
-        JsonWriter writer = new JsonWriter();
-        writer.write(typedValue);
-        return (String) writer.output();
-    }
-
+    @Nullable
     public String render(String inline, Map<String, Object> variables, boolean recursive) throws IllegalVariableEvaluationException {
-        return (String) this.render(inline, variables, recursive, true);
+        return (String) this.renderInternal(inline, variables, recursive, true);
     }
 
     public Object render(Object inline, Map<String, Object> variables, boolean recursive, boolean stringify) throws IllegalVariableEvaluationException {
+        return this.renderInternal(inline, variables, recursive, stringify);
+    }
+
+    private Object renderInternal(Object inline, Map<String, Object> variables, boolean recursive, boolean stringify) throws IllegalVariableEvaluationException {
         if (inline == null) {
             return null;
         }
@@ -186,7 +163,7 @@ public class VariableRenderer {
         }
 
         Object result = this.renderOnce(inline, variables, stringify);
-        if (result.equals(inline)) {
+        if (Objects.equals(result, inline)) {
             return result;
         }
 
@@ -202,7 +179,7 @@ public class VariableRenderer {
 
         for (Map.Entry<String, Object> r : in.entrySet()) {
             String key = this.render(r.getKey(), variables);
-            Object value = renderObject(r.getValue(), variables, recursive).orElse(r.getValue());
+            Object value = renderObject(r.getValue(), variables, recursive).orElse(null);
 
             map.putIfAbsent(
                 key,
@@ -226,7 +203,7 @@ public class VariableRenderer {
         } else if (object instanceof Set set) {
             return Optional.of(this.render(set, variables, recursive));
         } else if (object instanceof String string) {
-            return Optional.of(this.render(string, variables, recursive));
+            return Optional.ofNullable(this.render(string, variables, recursive));
         }
 
         // Return the given object if it cannot be rendered.
@@ -241,7 +218,7 @@ public class VariableRenderer {
         List<Object> result = new ArrayList<>();
 
         for (Object inline : list) {
-            result.add(this.renderObject(inline, variables, recursive).orElse(inline));
+            result.add(this.renderObject(inline, variables, recursive).orElse(null));
         }
 
         return result;

--- a/core/src/main/java/io/kestra/core/runners/pebble/JsonWriter.java
+++ b/core/src/main/java/io/kestra/core/runners/pebble/JsonWriter.java
@@ -15,50 +15,65 @@ public class JsonWriter extends OutputWriter implements SpecializedWriter {
     private static final ObjectMapper MAPPER = JacksonMapper.ofJson();
 
     private final StringWriter stringWriter = new StringWriter();
+    private boolean hasOutput = false;
 
     @Override
     public void writeSpecialized(int i) {
+        hasOutput = true;
         stringWriter.getBuffer().append(i);
     }
 
     @Override
     public void writeSpecialized(long l) {
+        hasOutput = true;
         stringWriter.getBuffer().append(l);
     }
 
     @Override
     public void writeSpecialized(double d) {
+        hasOutput = true;
         stringWriter.getBuffer().append(d);
     }
 
     @Override
     public void writeSpecialized(float f) {
+        hasOutput = true;
         stringWriter.getBuffer().append(f);
     }
 
     @Override
     public void writeSpecialized(short s) {
+        hasOutput = true;
         stringWriter.getBuffer().append(s);
     }
 
     @Override
     public void writeSpecialized(byte b) {
+        hasOutput = true;
         stringWriter.getBuffer().append(b);
     }
 
     @Override
     public void writeSpecialized(char c) {
+        hasOutput = true;
         stringWriter.getBuffer().append(c);
     }
 
     @Override
     public void writeSpecialized(String s) {
-        stringWriter.getBuffer().append(s);
+        if (s != null) {
+            hasOutput = true;
+            stringWriter.getBuffer().append(s);
+        }
     }
 
     @SneakyThrows
     @Override
     public void write(Object o) {
+        if (o == null) {
+            return;
+        }
+
         if (o instanceof Map) {
             writeSpecialized(MAPPER.writeValueAsString(o));
         } else if (o instanceof Collection) {
@@ -72,6 +87,9 @@ public class JsonWriter extends OutputWriter implements SpecializedWriter {
 
     @Override
     public void write(char[] cbuf, int off, int len) throws IOException {
+        if (len > 0) {
+            hasOutput = true;
+        }
         this.stringWriter.write(cbuf, off, len);
     }
 
@@ -92,6 +110,10 @@ public class JsonWriter extends OutputWriter implements SpecializedWriter {
 
     @Override
     public Object output() {
-        return this.toString();
+        if (hasOutput) {
+            return this.toString();
+        }
+
+        return null;
     }
 }

--- a/core/src/main/java/io/kestra/core/utils/TruthUtils.java
+++ b/core/src/main/java/io/kestra/core/utils/TruthUtils.java
@@ -10,6 +10,6 @@ abstract public class TruthUtils {
     }
 
     public static boolean isFalsy(String condition) {
-        return condition != null && FALSE_VALUES.contains(condition.trim());
+        return condition == null || FALSE_VALUES.contains(condition.trim());
     }
 }

--- a/core/src/main/java/io/kestra/plugin/core/execution/Labels.java
+++ b/core/src/main/java/io/kestra/plugin/core/execution/Labels.java
@@ -99,7 +99,8 @@ public class Labels extends Task implements ExecutionUpdatableTask {
         Map<String, String> labelsAsMap;
         if (labels instanceof String labelStr) {
             try {
-                labelsAsMap = MAPPER.readValue(runContext.render(labelStr), MAP_TYPE_REFERENCE);
+                String renderedLabels = runContext.render(labelStr);
+                labelsAsMap = renderedLabels == null ? Map.of() : MAPPER.readValue(renderedLabels, MAP_TYPE_REFERENCE);
             } catch (JsonProcessingException e) {
                 throw new IllegalVariableEvaluationException(e);
             }
@@ -107,9 +108,14 @@ public class Labels extends Task implements ExecutionUpdatableTask {
             labelsAsMap = labelsList.stream()
                 .map(throwFunction(label -> {
                         if (label instanceof Map<?, ?> labelMap) {
+                            String key = runContext.render((String) labelMap.get("key"));
+                            String value = runContext.render((String) labelMap.get("value"));
+                            if (key == null || value == null) {
+                                throw new IllegalVariableEvaluationException("Label key and value cannot render to null");
+                            }
                             return Map.entry(
-                                runContext.render((String) labelMap.get("key")),
-                                runContext.render((String) labelMap.get("value"))
+                                key,
+                                value
                             );
                         } else {
                             throw new IllegalVariableEvaluationException("Unknown value type: " + label.getClass());
@@ -123,7 +129,14 @@ public class Labels extends Task implements ExecutionUpdatableTask {
         } else if (labels instanceof Map<?, ?> map) {
             labelsAsMap = map.entrySet()
                 .stream()
-                .map(throwFunction(entry -> Map.entry(runContext.render((String) entry.getKey()), runContext.render((String) entry.getValue()))))
+                .map(throwFunction(entry -> {
+                    String key = runContext.render((String) entry.getKey());
+                    String value = runContext.render((String) entry.getValue());
+                    if (key == null || value == null) {
+                        throw new IllegalVariableEvaluationException("Label key and value cannot render to null");
+                    }
+                    return Map.entry(key, value);
+                }))
                 .collect(Collectors.toMap(
                     Map.Entry::getKey,
                     Map.Entry::getValue

--- a/core/src/main/java/io/kestra/plugin/core/flow/ForEachItem.java
+++ b/core/src/main/java/io/kestra/plugin/core/flow/ForEachItem.java
@@ -407,7 +407,7 @@ public class ForEachItem extends Task implements FlowableTask<VoidOutput>, Child
         @Override
         public ForEachItemSplit.Output run(RunContext runContext) throws Exception {
             var renderedUri = runContext.render(this.items);
-            if (!renderedUri.startsWith("kestra://")) {
+            if (renderedUri == null || !renderedUri.startsWith("kestra://")) {
                 var errorMessage = "Unable to split the items from " + renderedUri + ", this is not an internal storage URI!";
                 runContext.logger().error(errorMessage);
                 throw new IllegalArgumentException(errorMessage);

--- a/core/src/main/java/io/kestra/plugin/core/http/AbstractHttp.java
+++ b/core/src/main/java/io/kestra/plugin/core/http/AbstractHttp.java
@@ -32,6 +32,7 @@ import java.util.AbstractMap;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 import static io.kestra.core.utils.Rethrow.throwFunction;
@@ -134,10 +135,19 @@ public abstract class AbstractHttp extends Task implements HttpInterface {
                 HashMap<String, Object> multipart = new HashMap<>();
 
                 for (Map.Entry<String, Object> e : renderedFormData.entrySet()) {
+                    if (e.getKey() == null) {
+                        throw new IllegalVariableEvaluationException("HTTP formData key cannot be null");
+                    }
                     String key = runContext.render(e.getKey());
+                    if (key == null) {
+                        throw new IllegalVariableEvaluationException("HTTP formData key cannot render to null");
+                    }
 
                     if (e.getValue() instanceof String stringValue) {
                         String render = runContext.render(stringValue);
+                        if (render == null) {
+                            continue;
+                        }
 
                         if (render.startsWith("kestra://")) {
                             File tempFile = runContext.workingDir().createTempFile().toFile();
@@ -153,6 +163,9 @@ public abstract class AbstractHttp extends Task implements HttpInterface {
                     } else if (e.getValue() instanceof Map mapValue && ((Map<String, String>) mapValue).containsKey("name") && ((Map<String, String>) mapValue).containsKey("content")) {
                         String name = runContext.render(((Map<String, String>) mapValue).get("name"));
                         String content = runContext.render(((Map<String, String>) mapValue).get("content"));
+                        if (name == null || content == null) {
+                            throw new IllegalVariableEvaluationException("HTTP multipart form file entry requires non-null name and content");
+                        }
 
                         File tempFile = runContext.workingDir().createTempFile().toFile();
                         File renamedFile = new File(Files.move(tempFile.toPath(), tempFile.toPath().resolveSibling(name)).toUri());
@@ -187,16 +200,31 @@ public abstract class AbstractHttp extends Task implements HttpInterface {
 
         var renderedHeader = runContext.render(this.headers).asMap(CharSequence.class, CharSequence.class);
         if (!renderedHeader.isEmpty()) {
+            var headerEntries = renderedHeader
+                .entrySet()
+                .stream()
+                .map(throwFunction(e -> {
+                    if (e.getKey() == null) {
+                        throw new IllegalVariableEvaluationException("HTTP header key cannot be null");
+                    }
+                    if (e.getValue() == null) {
+                        return null;
+                    }
+                    String renderedValue = runContext.render(e.getValue().toString());
+                    if (renderedValue == null) {
+                        return null;
+                    }
+
+                    return new AbstractMap.SimpleEntry<>(
+                        e.getKey().toString(),
+                        renderedValue
+                    );
+                }))
+                .filter(Objects::nonNull)
+                .collect(Collectors.groupingBy(AbstractMap.SimpleEntry::getKey, Collectors.mapping(AbstractMap.SimpleEntry::getValue, Collectors.toList())));
+
             request.headers(HttpHeaders.of(
-                renderedHeader
-                    .entrySet()
-                    .stream()
-                    .map(throwFunction(e -> new AbstractMap.SimpleEntry<>(
-                            e.getKey().toString(),
-                            runContext.render(e.getValue().toString())
-                        ))
-                    )
-                    .collect(Collectors.groupingBy(AbstractMap.SimpleEntry::getKey, Collectors.mapping(AbstractMap.SimpleEntry::getValue, Collectors.toList()))),
+                headerEntries,
                 (a, b) -> true)
             );
         }

--- a/core/src/main/java/io/kestra/plugin/core/namespace/DeleteFiles.java
+++ b/core/src/main/java/io/kestra/plugin/core/namespace/DeleteFiles.java
@@ -3,6 +3,7 @@ package io.kestra.plugin.core.namespace;
 import io.kestra.core.models.annotations.Example;
 import io.kestra.core.models.annotations.Plugin;
 import io.kestra.core.models.annotations.PluginProperty;
+import io.kestra.core.exceptions.IllegalVariableEvaluationException;
 import io.kestra.core.models.executions.metrics.Counter;
 import io.kestra.core.models.property.Property;
 import io.kestra.core.models.tasks.RunnableTask;
@@ -26,6 +27,7 @@ import java.net.URI;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.TreeSet;
 
@@ -109,9 +111,16 @@ public class DeleteFiles extends Task implements RunnableTask<Output> {
 
         List<String> renderedFiles;
         if (files instanceof String filesString) {
-            renderedFiles = List.of(runContext.render(filesString));
+            String renderedFile = runContext.render(filesString);
+            if (renderedFile == null) {
+                throw new IllegalVariableEvaluationException("Unable to delete files: rendered file pattern is null");
+            }
+            renderedFiles = List.of(renderedFile);
         } else if (files instanceof List<?> filesList) {
             renderedFiles = runContext.render((List<String>) filesList);
+            if (renderedFiles.stream().anyMatch(Objects::isNull)) {
+                throw new IllegalVariableEvaluationException("Unable to delete files: one or more rendered file patterns are null");
+            }
         } else {
             throw new IllegalArgumentException("Files must be a String or a list of String");
         }

--- a/core/src/main/java/io/kestra/plugin/core/namespace/DownloadFiles.java
+++ b/core/src/main/java/io/kestra/plugin/core/namespace/DownloadFiles.java
@@ -3,6 +3,7 @@ package io.kestra.plugin.core.namespace;
 import io.kestra.core.models.annotations.Example;
 import io.kestra.core.models.annotations.Plugin;
 import io.kestra.core.models.annotations.PluginProperty;
+import io.kestra.core.exceptions.IllegalVariableEvaluationException;
 import io.kestra.core.models.executions.metrics.Counter;
 import io.kestra.core.models.property.Property;
 import io.kestra.core.models.tasks.RunnableTask;
@@ -25,6 +26,7 @@ import java.net.URI;
 import java.util.AbstractMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 import static io.kestra.core.storages.NamespaceFile.toLogicalPath;
@@ -110,9 +112,16 @@ public class DownloadFiles extends Task implements RunnableTask<DownloadFiles.Ou
 
         List<String> renderedFiles;
         if (files instanceof String filesString) {
-            renderedFiles = List.of(runContext.render(filesString));
+            String renderedFile = runContext.render(filesString);
+            if (renderedFile == null) {
+                throw new IllegalVariableEvaluationException("Unable to download files: rendered file pattern is null");
+            }
+            renderedFiles = List.of(renderedFile);
         } else if (files instanceof List<?> filesList) {
             renderedFiles = runContext.render((List<String>) filesList);
+            if (renderedFiles.stream().anyMatch(Objects::isNull)) {
+                throw new IllegalVariableEvaluationException("Unable to download files: one or more rendered file patterns are null");
+            }
         } else {
             throw new IllegalArgumentException("The files property must be a string or a list of strings.");
         }

--- a/core/src/test/java/io/kestra/core/runners/VariableRendererTest.java
+++ b/core/src/test/java/io/kestra/core/runners/VariableRendererTest.java
@@ -74,27 +74,33 @@ class VariableRendererTest {
     }
 
     @Test
-    void shouldRenderNullableStringAsNull() throws IllegalVariableEvaluationException {
-        assertThat(variableRenderer.renderNullableString("{{ null }}", Map.of())).isNull();
-        assertThat(variableRenderer.renderNullableString("{{ true ? null : 'work' }}", Map.of())).isNull();
+    void shouldRenderStringAsNull() throws IllegalVariableEvaluationException {
+        assertThat(variableRenderer.render("{{ null }}", Map.of())).isNull();
+        assertThat(variableRenderer.render("{{ true ? null : 'work' }}", Map.of())).isNull();
     }
 
     @Test
-    void shouldRenderNullableStringAsString() throws IllegalVariableEvaluationException {
-        assertThat(variableRenderer.renderNullableString("{{ false ? null : 'work' }}", Map.of())).isEqualTo("work");
-        assertThat(variableRenderer.renderNullableString("{{ 42 }}", Map.of())).isEqualTo("42");
-        assertThat(variableRenderer.renderNullableString("{{ true }}", Map.of())).isEqualTo("true");
+    void shouldRenderStringAsString() throws IllegalVariableEvaluationException {
+        assertThat(variableRenderer.render("{{ false ? null : 'work' }}", Map.of())).isEqualTo("work");
+        assertThat(variableRenderer.render("{{ 42 }}", Map.of())).isEqualTo("42");
+        assertThat(variableRenderer.render("{{ true }}", Map.of())).isEqualTo("true");
     }
 
     @Test
-    void shouldRenderNullableStringForComplexTypes() throws IllegalVariableEvaluationException {
-        assertThat(variableRenderer.renderNullableString("{{ {'a': 1} }}", Map.of())).isEqualTo("{\"a\":1}");
-        assertThat(variableRenderer.renderNullableString("{{ [1, 2, 3] }}", Map.of())).isEqualTo("[1,2,3]");
+    void shouldRenderStringWithExplicitEmptyOutput() throws IllegalVariableEvaluationException {
+        assertThat(variableRenderer.render("{{ '' }}", Map.of())).isEqualTo("");
+        assertThat(variableRenderer.render("prefix {{ null }}", Map.of())).isEqualTo("prefix ");
     }
 
     @Test
-    void shouldFallbackToStringRenderingForMixedComplexTemplate() throws IllegalVariableEvaluationException {
-        assertThat(variableRenderer.renderNullableString("prefix {{ {'a': 1} }}", Map.of()))
+    void shouldRenderStringForComplexTypes() throws IllegalVariableEvaluationException {
+        assertThat(variableRenderer.render("{{ {'a': 1} }}", Map.of())).isEqualTo("{\"a\":1}");
+        assertThat(variableRenderer.render("{{ [1, 2, 3] }}", Map.of())).isEqualTo("[1,2,3]");
+    }
+
+    @Test
+    void shouldRenderStringForMixedComplexTemplate() throws IllegalVariableEvaluationException {
+        assertThat(variableRenderer.render("prefix {{ {'a': 1} }}", Map.of()))
             .isEqualTo("prefix {\"a\":1}");
     }
 

--- a/core/src/test/java/io/kestra/core/runners/VariableRendererTest.java
+++ b/core/src/test/java/io/kestra/core/runners/VariableRendererTest.java
@@ -74,6 +74,31 @@ class VariableRendererTest {
     }
 
     @Test
+    void shouldRenderNullableStringAsNull() throws IllegalVariableEvaluationException {
+        assertThat(variableRenderer.renderNullableString("{{ null }}", Map.of())).isNull();
+        assertThat(variableRenderer.renderNullableString("{{ true ? null : 'work' }}", Map.of())).isNull();
+    }
+
+    @Test
+    void shouldRenderNullableStringAsString() throws IllegalVariableEvaluationException {
+        assertThat(variableRenderer.renderNullableString("{{ false ? null : 'work' }}", Map.of())).isEqualTo("work");
+        assertThat(variableRenderer.renderNullableString("{{ 42 }}", Map.of())).isEqualTo("42");
+        assertThat(variableRenderer.renderNullableString("{{ true }}", Map.of())).isEqualTo("true");
+    }
+
+    @Test
+    void shouldRenderNullableStringForComplexTypes() throws IllegalVariableEvaluationException {
+        assertThat(variableRenderer.renderNullableString("{{ {'a': 1} }}", Map.of())).isEqualTo("{\"a\":1}");
+        assertThat(variableRenderer.renderNullableString("{{ [1, 2, 3] }}", Map.of())).isEqualTo("[1,2,3]");
+    }
+
+    @Test
+    void shouldFallbackToStringRenderingForMixedComplexTemplate() throws IllegalVariableEvaluationException {
+        assertThat(variableRenderer.renderNullableString("prefix {{ {'a': 1} }}", Map.of()))
+            .isEqualTo("prefix {\"a\":1}");
+    }
+
+    @Test
     void shouldKeepKeyOrderWhenRenderingMap() throws IllegalVariableEvaluationException {
         final Map<String, Object> input = new LinkedHashMap<>();
         input.put("foo-1", "A");

--- a/core/src/test/java/io/kestra/core/runners/pebble/PebbleVariableRendererTest.java
+++ b/core/src/test/java/io/kestra/core/runners/pebble/PebbleVariableRendererTest.java
@@ -71,7 +71,7 @@ class PebbleVariableRendererTest {
         assertThat((String) render.get("map")).startsWith("{");
         assertThat((String) render.get("map")).endsWith("}");
         assertThat((String) render.get("escape")).contains("[\"string\",1,1.123] // {");
-        assertThat((String) render.get("empty")).isEqualTo("");
+        assertThat(render.get("empty")).isNull();
         assertThat((String) render.get("concat")).isEqualTo("applepearbanana");
     }
 

--- a/core/src/test/java/io/kestra/core/runners/pebble/expression/UndefinedCoalescingExpressionTest.java
+++ b/core/src/test/java/io/kestra/core/runners/pebble/expression/UndefinedCoalescingExpressionTest.java
@@ -23,7 +23,7 @@ class UndefinedCoalescingExpressionTest {
 
         String render = variableRenderer.render("{{ null ??? 'IS NULL' }}", vars);
 
-        assertThat(render).isEqualTo("");
+        assertThat(render).isNull();
 
         render = variableRenderer.render("{{ undefined ??? 'IS UNDEFINED' }}", vars);
 

--- a/core/src/test/java/io/kestra/core/runners/pebble/filters/JqFilterTest.java
+++ b/core/src/test/java/io/kestra/core/runners/pebble/filters/JqFilterTest.java
@@ -125,7 +125,7 @@ class JqFilterTest {
         assertThat(variableRenderer.render("{{ vars | jq(\".int\") | first | className }}", vars)).isEqualTo("java.lang.Integer");
         assertThat(variableRenderer.render("{{ vars | jq(\".float\") | first | className }}", vars)).isEqualTo("java.lang.Float");
         assertThat(variableRenderer.render("{{ vars | jq(\".bool\") | first | className }}", vars)).isEqualTo("java.lang.Boolean");
-        assertThat(variableRenderer.render("{{ vars | jq(\".null\") | first | className }}", vars)).isEqualTo("");
+        assertThat(variableRenderer.render("{{ vars | jq(\".null\") | first | className }}", vars)).isNull();
     }
 
     @Test

--- a/core/src/test/java/io/kestra/core/utils/TruthUtilsTest.java
+++ b/core/src/test/java/io/kestra/core/utils/TruthUtilsTest.java
@@ -15,6 +15,7 @@ class TruthUtilsTest {
 
     @Test
     void isFalsy() {
+        assertThat(TruthUtils.isFalsy(null)).isTrue();
         assertThat(TruthUtils.isFalsy("false")).isTrue();
         assertThat(TruthUtils.isFalsy("     false ")).isTrue();
         assertThat(TruthUtils.isFalsy("0")).isTrue();

--- a/executor/src/main/java/io/kestra/executor/ExecutorService.java
+++ b/executor/src/main/java/io/kestra/executor/ExecutorService.java
@@ -858,7 +858,7 @@ public class ExecutorService {
                     if (workerGroup.isPresent()) {
                         // Check if the worker group exist
                         String tenantId = executor.getFlow().getTenantId();
-                        String workerGroupKey = runContext.render(workerGroup.get().getKey());
+                        String workerGroupKey = runContext.renderNullableString(workerGroup.get().getKey());
                         if (workerGroupExecutorInterface.isWorkerGroupExistForKey(workerGroupKey, tenantId)) {
                             // Check whether at-least one worker is available
                             if (workerGroupExecutorInterface.isWorkerGroupAvailableForKey(workerGroupKey)) {

--- a/executor/src/main/java/io/kestra/executor/ExecutorService.java
+++ b/executor/src/main/java/io/kestra/executor/ExecutorService.java
@@ -858,7 +858,7 @@ public class ExecutorService {
                     if (workerGroup.isPresent()) {
                         // Check if the worker group exist
                         String tenantId = executor.getFlow().getTenantId();
-                        String workerGroupKey = runContext.renderNullableString(workerGroup.get().getKey());
+                        String workerGroupKey = runContext.render(workerGroup.get().getKey());
                         if (workerGroupExecutorInterface.isWorkerGroupExistForKey(workerGroupKey, tenantId)) {
                             // Check whether at-least one worker is available
                             if (workerGroupExecutorInterface.isWorkerGroupAvailableForKey(workerGroupKey)) {

--- a/scheduler/src/main/java/io/kestra/scheduler/AbstractScheduler.java
+++ b/scheduler/src/main/java/io/kestra/scheduler/AbstractScheduler.java
@@ -1062,7 +1062,7 @@ public abstract class AbstractScheduler implements Scheduler {
                 // Check if the worker group exist
                 String tenantId = flowWithTrigger.getFlow().getTenantId();
                 RunContext runContext = flowWithTrigger.conditionContext.getRunContext();
-                String workerGroupKey = runContext.renderNullableString(workerGroup.get().getKey());
+                String workerGroupKey = runContext.render(workerGroup.get().getKey());
                 if (workerGroupExecutorInterface.isWorkerGroupExistForKey(workerGroupKey, tenantId)) {
                     // Check whether at-least one worker is available
                     if (workerGroupExecutorInterface.isWorkerGroupAvailableForKey(workerGroupKey)) {

--- a/scheduler/src/main/java/io/kestra/scheduler/AbstractScheduler.java
+++ b/scheduler/src/main/java/io/kestra/scheduler/AbstractScheduler.java
@@ -1062,7 +1062,7 @@ public abstract class AbstractScheduler implements Scheduler {
                 // Check if the worker group exist
                 String tenantId = flowWithTrigger.getFlow().getTenantId();
                 RunContext runContext = flowWithTrigger.conditionContext.getRunContext();
-                String workerGroupKey = runContext.render(workerGroup.get().getKey());
+                String workerGroupKey = runContext.renderNullableString(workerGroup.get().getKey());
                 if (workerGroupExecutorInterface.isWorkerGroupExistForKey(workerGroupKey, tenantId)) {
                     // Check whether at-least one worker is available
                     if (workerGroupExecutorInterface.isWorkerGroupAvailableForKey(workerGroupKey)) {

--- a/webserver/src/main/java/io/kestra/webserver/controllers/api/ExecutionController.java
+++ b/webserver/src/main/java/io/kestra/webserver/controllers/api/ExecutionController.java
@@ -581,8 +581,8 @@ public class ExecutionController {
             .filter(w -> {
                 RunContext runContext = runContextFactory.of(flow, w);
                 try {
-                    String webhookKey = runContext.render(w.getKey()).trim();
-                    return webhookKey.equals(key);
+                    String webhookKey = runContext.render(w.getKey());
+                    return webhookKey != null && webhookKey.trim().equals(key);
                 } catch (IllegalVariableEvaluationException e) {
                     // be conservative, don't crash but filter the webhook
                     log.warn("Unable to render the webhook key {}, the webhook will be ignored", key, e);


### PR DESCRIPTION
This change fixes worker group key rendering so Pebble expressions can intentionally resolve to `null` and behave the same as if no `workerGroup.key` was set.

Expressions like `{{ null }}` or `{{ true ? null : 'work' }}` were effectively coerced to string output with `render(...)`.

fixes: https://github.com/kestra-io/kestra-ee/issues/6629

## What changed
- Added nullable string rendering path via `renderNullableString(...)` in run variable rendering.
  - preserve semantic `null`,
  - stringify typed non-string values consistently,
  - fallback to standard string rendering for mixed templates.
- Updated worker-group key resolution in executor and scheduler to use nullable rendering.

Users can now intentionally set `workerGroup.key` to `null` through e.g. a Pebble expression and get default routing behavior.

## Follow-up in EE required
A follow-up change is needed in `kestra-ee`:
- [`runner-kafka-ee/.../WorkerJobTopicNameExtractor`](https://github.com/kestra-io/kestra-ee/blob/da8b7fd05b1a088c2712b556eee802ae70808a51/runner-kafka-ee/src/main/java/io/kestra/ee/runner/kafka/streams/WorkerJobTopicNameExtractor.java#L47) should use `runContext.renderNullableString(...)` for worker-group key rendering to keep behavior aligned with OSS executor/scheduler routing.
