### PR TITLE
Improved set labels dialog layout

### DIFF
--- a/ui/src/components/executions/Executions.vue
+++ b/ui/src/components/executions/Executions.vue
@@ -148,7 +148,7 @@
                                 </el-button>
                             </template>
 
-                            <el-form>
+                            <el-form labelPosition="top">
                                 <ElFormItem :label="$t('execution labels')">
                                     <LabelInput v-model:labels="executionLabels" />
                                 </ElFormItem>

--- a/ui/src/components/executions/SetLabels.vue
+++ b/ui/src/components/executions/SetLabels.vue
@@ -28,7 +28,7 @@
 
         <p v-html="$t('Set labels to execution', {id: execution.id})" />
 
-        <el-form>
+        <el-form labelPosition="top">
             <el-form-item :label="$t('execution labels')">
                 <LabelInput
                     v-model:labels="executionLabels"


### PR DESCRIPTION
### ✨ Description

Relocated the dialog form title/label from the left side of the form to above it. The previous side-by-side layout wasted horizontal space unnecessarily, making the form area narrower than it needed to be. Placing the title above the form gives the inputs the full width of the dialog.

### 📷 Images

Before:
<img width="940" height="257" alt="image" src="https://github.com/user-attachments/assets/15d39e54-cbdb-4367-b24d-c6512cbee243" />

After:
<img width="947" height="283" alt="image" src="https://github.com/user-attachments/assets/b56e3161-f1eb-4c84-8893-57f92747d5b8" />

### 🔗 Related Issue

_No existing issue found._

### 🎨 Frontend Checklist

- [x] Code builds without errors (`npm run build`)
- [x] All existing E2E tests pass (`npm run test:e2e`)
- [x] Screenshots or video recordings attached showing the `UI` changes