### PR TITLE
fix(executions): replay must copy the outputs

### DIFF
--- a/core/src/main/java/io/kestra/core/runners/DefaultRunContext.java
+++ b/core/src/main/java/io/kestra/core/runners/DefaultRunContext.java
@@ -621,7 +621,7 @@ public class DefaultRunContext extends RunContext {
     @Override
     public Map<String, Object> currentOutput() {
         Map<?, ?> allOutputs = (Map<?, ?>) variables.get("outputs");
-        Map<?, ?> outputs = (Map<?, ?>) allOutputs.get(taskRunInfo().taskId());
+        Map<?, ?> outputs = (Map<?, ?>) MapUtils.emptyOnNull(allOutputs).get(taskRunInfo().taskId());
         List<Map<?, ?>> parents = (List<Map<?, ?>>) variables.get("parents");
         if (!ListUtils.isEmpty(parents) && !MapUtils.isEmpty(outputs)) {
             Collections.reverse(parents);

--- a/core/src/main/java/io/kestra/core/services/ExecutionService.java
+++ b/core/src/main/java/io/kestra/core/services/ExecutionService.java
@@ -282,14 +282,17 @@ public class ExecutionService {
             newTaskRuns.addAll(
                 execution.getTaskRunList()
                     .stream()
-                    .map(throwFunction(originalTaskRun -> this.mapTaskRun(
-                        flow,
-                        originalTaskRun,
-                        mappingTaskRunId,
-                        newExecutionId,
-                        State.Type.RESTARTED,
-                        taskRunToRestart.contains(originalTaskRun.getId()))
-                    ))
+                    .map(throwFunction(originalTaskRun -> {
+                        TaskRun newTaskRun = this.mapTaskRun(
+                                flow,
+                                originalTaskRun,
+                                mappingTaskRunId,
+                                newExecutionId,
+                                State.Type.RESTARTED,
+                                taskRunToRestart.contains(originalTaskRun.getId()));
+                        taskOutputService.copyOutputs(originalTaskRun, newTaskRun);
+                        return newTaskRun;
+                    }))
                     .toList()
             );
 

--- a/core/src/main/java/io/kestra/core/services/TaskOutputService.java
+++ b/core/src/main/java/io/kestra/core/services/TaskOutputService.java
@@ -266,4 +266,12 @@ public class TaskOutputService {
     public int purge(List<Execution> executions) {
         return this.outputRepository.purgeByExecutionIds(executions.stream().map(Execution::getId).toList());
     }
+
+    public void copyOutputs(TaskRun originalTaskRun, TaskRun newTaskRun) {
+        var previousOutput = outputRepository.findById(originalTaskRun.getTenantId(), originalTaskRun.getId());
+        if (previousOutput.isPresent()) {
+            var newOutput = new TaskOutput(newTaskRun.getId(), newTaskRun.getTenantId(), newTaskRun.getExecutionId(), previousOutput.get().value(), previousOutput.get().uri());
+            outputRepository.save(newOutput);
+        }
+    }
 }

--- a/core/src/main/java/io/kestra/plugin/core/flow/LoopUntil.java
+++ b/core/src/main/java/io/kestra/plugin/core/flow/LoopUntil.java
@@ -19,6 +19,7 @@ import io.kestra.core.models.tasks.Task;
 import io.kestra.core.runners.FlowableUtils;
 import io.kestra.core.runners.RunContext;
 import io.kestra.core.utils.GraphUtils;
+import io.kestra.core.utils.MapUtils;
 import io.kestra.core.utils.TruthUtils;
 import io.micronaut.core.annotation.Introspected;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -240,14 +241,13 @@ public class LoopUntil extends Task implements FlowableTask<LoopUntil.Output> {
 
     }
 
-    @SuppressWarnings("unchecked")
     @Override
     public LoopUntil.Output outputs(RunContext runContext) throws IllegalVariableEvaluationException {
-       Map<String, Object> outputs = (Map<String, Object>) runContext.getVariables().get("outputs");
-        if (outputs != null && outputs.get(this.id) != null) {
-            return Output.builder().iterationCount((Integer) ((Map<String, Object>) outputs.get(this.id)).get("iterationCount")).build();
+       Map<String, Object> outputs = runContext.currentOutput();
+        if (!MapUtils.isEmpty(outputs)) {
+            return Output.builder().iterationCount((Integer) outputs.get("iterationCount")).build();
         }
-        return LoopUntil.Output.builder()
+        return Output.builder()
             .iterationCount(INITIAL_LOOP_VALUE)
             .build();
     }

--- a/core/src/test/java/io/kestra/core/runners/AbstractRunnerTest.java
+++ b/core/src/test/java/io/kestra/core/runners/AbstractRunnerTest.java
@@ -160,9 +160,21 @@ public abstract class AbstractRunnerTest {
     }
 
     @Test
-    @LoadFlows({"flows/valids/restart-each.yaml"})
+    @LoadFlows({"flows/valids/replay.yaml"})
     void replay() throws Exception {
         restartCaseTest.replay();
+    }
+
+    @Test
+    @LoadFlows({"flows/valids/replay.yaml"})
+    void replayFromTaskId() throws Exception {
+        restartCaseTest.replayFromTaskId();
+    }
+
+    @Test
+    @LoadFlows({"flows/valids/restart-each.yaml"})
+    void replayEach() throws Exception {
+        restartCaseTest.replayEach();
     }
 
     @Test

--- a/core/src/test/java/io/kestra/core/runners/RestartCaseTest.java
+++ b/core/src/test/java/io/kestra/core/runners/RestartCaseTest.java
@@ -1,11 +1,13 @@
 package io.kestra.core.runners;
 
+import io.kestra.core.exceptions.InternalException;
 import io.kestra.core.models.executions.Execution;
 import io.kestra.core.models.executions.TaskRun;
 import io.kestra.core.models.flows.Flow;
 import io.kestra.core.models.flows.State;
 import io.kestra.core.models.flows.State.Type;
 import io.kestra.core.queues.DispatchQueueInterface;
+import io.kestra.core.queues.QueueException;
 import io.kestra.core.repositories.FlowRepositoryInterface;
 import io.kestra.core.services.ExecutionService;
 
@@ -13,6 +15,7 @@ import java.time.Duration;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.TimeoutException;
 
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
@@ -137,6 +140,66 @@ public class RestartCaseTest {
     }
 
     public void replay() throws Exception {
+        Flow flow = flowRepository.findById(MAIN_TENANT, "io.kestra.tests", "replay").orElseThrow();
+
+        Execution firstExecution = runnerUtils.runOne(MAIN_TENANT, flow.getNamespace(), flow.getId(), Duration.ofSeconds(60));
+
+        assertThat(firstExecution.getState().getCurrent()).isEqualTo(State.Type.SUCCESS);
+
+        // wait
+        Execution restartedExec = executionService.replay(firstExecution, flow, null, null, Optional.empty());
+        executionQueue.emit(restartedExec);
+
+        assertThat(restartedExec.getState().getCurrent()).isEqualTo(Type.CREATED);
+        assertThat(restartedExec.getState().getHistories()).hasSize(1);
+        assertThat(restartedExec.getTaskRunList()).isEmpty();
+
+        assertThat(restartedExec.getId()).isNotEqualTo(firstExecution.getId());
+        Execution finishedRestartedExecution = runnerUtils.emitAndAwaitChildExecution(
+            flow,
+            firstExecution,
+            restartedExec.withTenantId(MAIN_TENANT),
+            Duration.ofSeconds(60)
+        );
+
+        assertThat(finishedRestartedExecution).isNotNull();
+        assertThat(finishedRestartedExecution.getId()).isNotEqualTo(firstExecution.getId());
+        assertThat(finishedRestartedExecution.getParentId()).isEqualTo(firstExecution.getId());
+        assertThat(finishedRestartedExecution.getState().getCurrent()).isEqualTo(State.Type.SUCCESS);
+    }
+
+    public void replayFromTaskId() throws Exception {
+        Flow flow = flowRepository.findById(MAIN_TENANT, "io.kestra.tests", "replay").orElseThrow();
+
+        Execution firstExecution = runnerUtils.runOne(MAIN_TENANT, flow.getNamespace(), flow.getId(), Duration.ofSeconds(60));
+
+        assertThat(firstExecution.getState().getCurrent()).isEqualTo(State.Type.SUCCESS);
+
+        // wait
+        Execution restartedExec = executionService.replay(firstExecution, flow, firstExecution.findTaskRunsByTaskId("log").getFirst().getId(), null, Optional.empty());
+        executionQueue.emit(restartedExec);
+
+        assertThat(restartedExec.getState().getCurrent()).isEqualTo(State.Type.RESTARTED);
+        assertThat(restartedExec.getState().getHistories()).hasSize(4);
+        assertThat(restartedExec.getTaskRunList()).hasSize(2);
+        assertThat(restartedExec.getTaskRunList().get(1).getState().getCurrent()).isEqualTo(State.Type.RESTARTED);
+
+        assertThat(restartedExec.getId()).isNotEqualTo(firstExecution.getId());
+        assertThat(restartedExec.getTaskRunList().get(1).getId()).isNotEqualTo(firstExecution.getTaskRunList().get(1).getId());
+        Execution finishedRestartedExecution = runnerUtils.emitAndAwaitChildExecution(
+            flow,
+            firstExecution,
+            restartedExec.withTenantId(MAIN_TENANT),
+            Duration.ofSeconds(60)
+        );
+
+        assertThat(finishedRestartedExecution).isNotNull();
+        assertThat(finishedRestartedExecution.getId()).isNotEqualTo(firstExecution.getId());
+        assertThat(finishedRestartedExecution.getParentId()).isEqualTo(firstExecution.getId());
+        assertThat(finishedRestartedExecution.getState().getCurrent()).isEqualTo(State.Type.SUCCESS);
+    }
+
+    public void replayEach() throws Exception {
         Flow flow = flowRepository.findById(MAIN_TENANT, "io.kestra.tests", "restart-each").orElseThrow();
 
         Execution firstExecution = runnerUtils.runOne(MAIN_TENANT, flow.getNamespace(), flow.getId(), Duration.ofSeconds(60));
@@ -317,8 +380,8 @@ public class RestartCaseTest {
         Flow flow = flowRepository.findById(MAIN_TENANT, "io.kestra.tests", "loop-until-restart").orElseThrow();
 
         Execution firstExecution = runnerUtils.runOne(MAIN_TENANT, flow.getNamespace(), flow.getId(), Duration.ofSeconds(60));
-
         assertThat(firstExecution.getState().getCurrent()).isEqualTo(Type.FAILED);
+
          // restarting case
         Execution restartedExecution = executionService.restart(firstExecution, flow, null);
         assertThat(restartedExecution).isNotNull();
@@ -344,11 +407,9 @@ public class RestartCaseTest {
         assertThat(replayedExecution.getId()).isNotEqualTo(firstExecution.getId());
         executionQueue.emit(replayedExecution);
 
-        Execution finalReplayedExecution = runnerUtils.emitAndAwaitChildExecution(
-            flow,
-            firstExecution,
-            replayedExecution.withTenantId(MAIN_TENANT),
-            Duration.ofSeconds(60)
+        Execution finalReplayedExecution = runnerUtils.awaitExecution(
+            execution -> execution.getState().isTerminated(),
+            replayedExecution
         );
         assertThat(finalReplayedExecution.getState().getCurrent()).isEqualTo(Type.FAILED);
 

--- a/core/src/test/resources/flows/valids/replay.yaml
+++ b/core/src/test/resources/flows/valids/replay.yaml
@@ -1,0 +1,11 @@
+id: replay
+namespace: io.kestra.tests
+
+tasks:
+  - id: output
+    type: io.kestra.plugin.core.output.OutputValues
+    values:
+      name: World
+  - id: log
+    type: io.kestra.plugin.core.log.Log
+    message: "Hello {{ outputs.output.values.name }}"


### PR DESCRIPTION
The main fix is on the executor service, the rest is polishing only