### PR TITLE
chore(system): provide a way to set the allocated CPU count

### DIFF
--- a/core/src/main/java/io/kestra/core/contexts/KestraContext.java
+++ b/core/src/main/java/io/kestra/core/contexts/KestraContext.java
@@ -31,6 +31,7 @@ public abstract class KestraContext {
 
     // Properties
     public static final String KESTRA_SERVER_TYPE = "kestra.server-type";
+    public static final String KESTRA_ALLOCATED_CPU_CORES = "kestra.allocated-cpu-cores";
 
     // Those properties are injected bases on the CLI args.
     private static final String KESTRA_WORKER_MAX_NUM_THREADS = "kestra.worker.max-num-threads";
@@ -62,6 +63,13 @@ public abstract class KestraContext {
      * @return The {@link ServerType}.
      */
     public abstract ServerType getServerType();
+
+    /**
+     * Number of CPU cores allocated for the Kestra process.
+     * It defaults to the number of available CPU cores but can be overriden by setting {@link #KESTRA_ALLOCATED_CPU_CORES} configuration property.
+     * It is used everywhere we compute a number of threads based on the number of CPU cores instead of directly relying on the number of available CPU cores.
+     */
+    public abstract int getAllocatedCpuCores();
 
     public abstract Optional<Integer> getWorkerMaxNumThreads();
 
@@ -134,6 +142,12 @@ public abstract class KestraContext {
             return Optional.ofNullable(environment)
                 .flatMap(env -> env.getProperty(KESTRA_SERVER_TYPE, ServerType.class))
                 .orElse(ServerType.STANDALONE);
+        }
+
+        @Override
+        public int getAllocatedCpuCores() {
+            return applicationContext.getProperty(KESTRA_ALLOCATED_CPU_CORES, Integer.class)
+                .orElse(Runtime.getRuntime().availableProcessors());
         }
 
         /** {@inheritDoc} **/

--- a/core/src/main/java/io/kestra/core/runners/Scheduler.java
+++ b/core/src/main/java/io/kestra/core/runners/Scheduler.java
@@ -1,16 +1,17 @@
 package io.kestra.core.runners;
 
+import io.kestra.core.contexts.KestraContext;
 import io.kestra.core.server.Service;
 
 public interface Scheduler extends Service, Runnable{
-    
-    // The default max threads 
+
+    // The default max threads
     int MIN_MAX_THREAD = 4;
-        
+
     static int defaultMaxNumThreads() {
-        return Math.min(MIN_MAX_THREAD, Runtime.getRuntime().availableProcessors());
+        return Math.max(MIN_MAX_THREAD, KestraContext.getContext().getAllocatedCpuCores());
     }
-    
+
     /**
      * Starts the scheduler.
      */
@@ -18,18 +19,18 @@ public interface Scheduler extends Service, Runnable{
     default void run() {
         start(defaultMaxNumThreads());
     }
-    
+
     /**
      * Starts the scheduler.
-     * 
+     *
      * @param maxThreads    The maximum number of threads that can be used
-     *                      by the scheduler for handling trigger scheduling. 
+     *                      by the scheduler for handling trigger scheduling.
      */
     void start(int maxThreads);
-    
+
     /**
      * Checks whether this scheduler is processing triggers.
-     * 
+     *
      * @return {@code true} if this scheduler is active, otherwise {@code false}.
      */
     boolean isActive();

--- a/core/src/main/java/io/kestra/core/runners/Worker.java
+++ b/core/src/main/java/io/kestra/core/runners/Worker.java
@@ -10,8 +10,12 @@ import java.util.List;
 public interface Worker extends Service {
     String EXECUTOR_NAME = "worker";
 
+    /**
+     * The default number of threads for the worker service.
+     * Only used for display/documentation of commands as in runtime KestraContext.getAllocatedCpuCores() is used instead
+     */
     static int defaultNumThreads() {
-        return Math.min(Runtime.getRuntime().availableProcessors() * 8, Runtime.getRuntime().availableProcessors());
+        return Runtime.getRuntime().availableProcessors() * 8;
     }
 
     /**

--- a/core/src/main/java/io/kestra/core/services/FlowService.java
+++ b/core/src/main/java/io/kestra/core/services/FlowService.java
@@ -1,6 +1,7 @@
 package io.kestra.core.services;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import io.kestra.core.contexts.KestraContext;
 import io.kestra.core.exceptions.FlowProcessingException;
 import io.kestra.core.exceptions.IllegalVariableEvaluationException;
 import io.kestra.core.models.executions.Execution;
@@ -89,7 +90,7 @@ public class FlowService {
 
     @Inject
     public FlowService(ExecutorsUtils executorsUtils) {
-        this.executorService = executorsUtils.maxCachedThreadPool(Runtime.getRuntime().availableProcessors(), "flow-service");
+        this.executorService = executorsUtils.maxCachedThreadPool(KestraContext.getContext().getAllocatedCpuCores(), "flow-service");
     }
 
     @PreDestroy

--- a/core/src/main/java/io/kestra/core/utils/ExecutorsUtils.java
+++ b/core/src/main/java/io/kestra/core/utils/ExecutorsUtils.java
@@ -1,5 +1,6 @@
 package io.kestra.core.utils;
 
+import io.kestra.core.contexts.KestraContext;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.binder.jvm.ExecutorServiceMetrics;
 
@@ -7,6 +8,7 @@ import java.time.Duration;
 import java.util.List;
 import java.util.concurrent.*;
 
+import io.micronaut.context.annotation.Value;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 import lombok.extern.slf4j.Slf4j;
@@ -22,6 +24,13 @@ public class ExecutorsUtils {
 
     @Inject
     private MeterRegistry meterRegistry;
+
+    @Value("${" + KestraContext.KESTRA_ALLOCATED_CPU_CORES + ":0}")
+    private int allocatedCpuCores;
+
+    public int getAllocatedCpuCores() {
+        return allocatedCpuCores == 0 ? Runtime.getRuntime().availableProcessors() : allocatedCpuCores;
+    }
 
     public ExecutorService cachedThreadPool(String name) {
         return this.wrap(

--- a/core/src/main/java/io/kestra/core/utils/NamespaceFilesUtils.java
+++ b/core/src/main/java/io/kestra/core/utils/NamespaceFilesUtils.java
@@ -1,6 +1,7 @@
 package io.kestra.core.utils;
 
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import io.kestra.core.contexts.KestraContext;
 import io.kestra.core.models.executions.metrics.Counter;
 import io.kestra.core.models.executions.metrics.Timer;
 import io.kestra.core.models.tasks.FileExistComportment;
@@ -23,7 +24,7 @@ import java.util.concurrent.*;
 import static io.kestra.core.utils.Rethrow.throwConsumer;
 
 public final class NamespaceFilesUtils {
-    private static final int maxThreads = Math.max(Runtime.getRuntime().availableProcessors() * 4, 32);
+    private static final int maxThreads = Math.max(KestraContext.getContext().getAllocatedCpuCores() * 4, 32);
     private static final ExecutorService EXECUTOR_SERVICE = new ThreadPoolExecutor(
         0,
         maxThreads,

--- a/core/src/test/java/io/kestra/core/contexts/KestraContextTest.java
+++ b/core/src/test/java/io/kestra/core/contexts/KestraContextTest.java
@@ -31,4 +31,9 @@ class KestraContextTest {
         // Then
         assertThat(context.getWorkerGroupKey()).isEqualTo(Optional.of("my-key"));
     }
+
+    @Test
+    void shouldGetAllocatedCpuCores() {
+        assertThat(context.getAllocatedCpuCores()).isEqualTo(Runtime.getRuntime().availableProcessors());
+    }
 }

--- a/executor/src/main/java/io/kestra/executor/DefaultExecutor.java
+++ b/executor/src/main/java/io/kestra/executor/DefaultExecutor.java
@@ -151,7 +151,7 @@ public class DefaultExecutor extends AbstractService implements Executor {
         // By default, we start available processors count threads with a minimum of 4 by executor service
         // for the worker task result queue and the execution queue.
         // Other queues would not benefit from more consumers.
-        this.numberOfThreads = threadCount != 0 ? threadCount : Math.max(4, Runtime.getRuntime().availableProcessors());
+        this.numberOfThreads = threadCount != 0 ? threadCount : Math.max(4, KestraContext.getContext().getAllocatedCpuCores());
         this.workerTaskResultExecutorService = executorsUtils.maxCachedThreadPool(numberOfThreads, "executor-worker-task-result-executor");
         this.executionExecutorService = executorsUtils.maxCachedThreadPool(numberOfThreads, "executor-execution-event-executor");
         setState(ServiceState.CREATED);

--- a/queue/src/main/java/io/kestra/queue/AbstractQueue.java
+++ b/queue/src/main/java/io/kestra/queue/AbstractQueue.java
@@ -17,12 +17,10 @@ import java.util.concurrent.ExecutorService;
 import java.util.function.Consumer;
 
 abstract class AbstractQueue<T extends Event> implements GenericQueueInterface<T> {
-    private static final int MAX_ASYNC_THREADS = Runtime.getRuntime().availableProcessors();
     private static final Logger LOG = LoggerFactory.getLogger(AbstractQueue.class);
 
     protected final Class<T> cls;
     protected final QueueService queueService;
-
     protected final ExecutorService asyncPoolExecutor;
     protected final Counter emitCounter;
     private final List<Consumer<T>> listeners = new CopyOnWriteArrayList<>();
@@ -30,7 +28,8 @@ abstract class AbstractQueue<T extends Event> implements GenericQueueInterface<T
     AbstractQueue(Class<T> cls, QueueService queueService, ExecutorsUtils executorsUtils, MetricRegistry metricRegistry) {
         this.cls = cls;
         this.queueService = queueService;
-        this.asyncPoolExecutor = executorsUtils.maxCachedThreadPool(MAX_ASYNC_THREADS, "queue-async-" + queueName());
+        int maxAsyncThreads = Math.max(4, executorsUtils.getAllocatedCpuCores());
+        this.asyncPoolExecutor = executorsUtils.maxCachedThreadPool(maxAsyncThreads, "queue-async-" + queueName());
         this.emitCounter = metricRegistry.counter(MetricRegistry.METRIC_QUEUE_EMIT_COUNT, MetricRegistry.METRIC_QUEUE_EMIT_COUNT_DESCRIPTION, MetricRegistry.TAG_QUEUE_NAME, queueName());
 
         if (LOG.isDebugEnabled()) {

--- a/queue/src/test/java/io/kestra/queue/NoOpShutdownContext.java
+++ b/queue/src/test/java/io/kestra/queue/NoOpShutdownContext.java
@@ -47,6 +47,8 @@ public class NoOpShutdownContext extends KestraContext {
     }
 
     @Override public ServerType getServerType() { return delegate != null ? delegate.getServerType() : null; }
+
+    @Override public int getAllocatedCpuCores() {return delegate != null ? delegate.getAllocatedCpuCores() : Runtime.getRuntime().availableProcessors();}
     @Override public Optional<Integer> getWorkerMaxNumThreads() { return delegate != null ? delegate.getWorkerMaxNumThreads() : Optional.empty(); }
     @Override public Optional<String> getWorkerGroupKey() { return delegate != null ? delegate.getWorkerGroupKey() : Optional.empty(); }
     @Override public void injectWorkerConfigs(Integer maxNumThreads, String workerGroupKey) { if (delegate != null) delegate.injectWorkerConfigs(maxNumThreads, workerGroupKey); }


### PR DESCRIPTION
In Kestra, we use `Runtime.getRuntime().availableCpuCount()` in a bunch of places to configure thread pools.
As a convenient method to configure kestra, we provide a configuration option to override the allocated CPU cores in case a user don't want Kestra to use too much CPU (or he didn't want to configure container limits).

I also take the opportunity to:
- fix the wrong computation on the Scheduler
- use cpu*8 in the Worker as we had
- use a min of 4 async treads in the queue

Closes https://github.com/kestra-io/kestra-ee/issues/6394

@fhussonnois be careful as when you want to have a minimum of a static number and a computed number you should use Math.max() so it uses the computed number or the static number if it's more than the computed one.