### PR TITLE
fix(ui): resolve Windows path generation bug in openapi-ts resulting in ENOENT errors

### DIFF
--- a/ui/openapi-ts.config.ts
+++ b/ui/openapi-ts.config.ts
@@ -1,9 +1,11 @@
 import type {UserConfig} from "@hey-api/openapi-ts";
 // @ts-expect-error need a second tsconfig file for node execution (vite.config, openapi-ts.config, vitest.config)
 import * as path from "path";
+import {fileURLToPath} from "url";
 import {defineKestraHeyConfig} from "./heyapi-sdk-plugin";
 
-const __dirname = path.dirname(new URL(import.meta.url).pathname);
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
 
 const generateHash = (str: string) => {
   let hash = 0;


### PR DESCRIPTION
# Description
This PR fixes a critical cross-platform issue in openapi-ts.config.ts
 that prevents Windows users from successfully running npm install and generating the OpenAPI client bundle.
 
# Problem
 On Windows environments, running npm run generate:openapi (triggered during npm install postinstall) crashes with the following error:
<img width="742" height="392" alt="openapi" src="https://github.com/user-attachments/assets/4a8e43b0-0748-482f-826c-32345bcf64f3" />

# Root Cause 
The bug occurs due to how new URL(import.meta.url).pathname behaves on Windows. When converting the module's file:// protocol to a path, the native JS URL object yields a string with a leading forward slash before the drive letter (e.g., /E:/kestra/ui/openapi-ts.config.ts).

When Node's path.resolve() combines this with a relative string, it perceives the leading slash as an absolute path from root, prepending the local drive letter again. This results in the illegal double-drive-letter folder path (E:\E:\...), crashing the application during the directory mkdir step.

# Solution
Replaced the basic URL parsing with Node's native fileURLToPath standard library method. This method correctly interprets the file:// scheme on all host operating systems, ensuring that paths generated on Windows accurately match standard Windows File System conventions.
