### PR TITLE
fix(sanitychecks): simplify value assignment in Put task and format conditions in Assert task

### DIFF
--- a/core/src/test/resources/sanity-checks/kv.yaml
+++ b/core/src/test/resources/sanity-checks/kv.yaml
@@ -16,8 +16,7 @@ tasks:
   - id: put
     type: io.kestra.plugin.core.kv.Put
     key: "{{ vars.key }}"
-    value:
-      - value: "{{ vars.data_updated }}"
+    value: "{{ vars.data_updated }}"
 
   - id: get
     type: io.kestra.plugin.core.kv.Get
@@ -37,5 +36,5 @@ tasks:
 
   - id: assert_delete_get_keys
     type: io.kestra.plugin.core.execution.Assert
-    conditions: 
+    conditions:
       - "{{ outputs.get_keys.keys | length == 0 }}"


### PR DESCRIPTION
fix failing sanity checks: simplify value assignment in Put task and format conditions in Assert task

<img width="939" height="205" alt="Screenshot 2026-03-13 at 4 24 36 PM" src="https://github.com/user-attachments/assets/b90b7bd7-811b-459c-950a-f6af65fb83ed" />
