### PR TITLE
fix(ui): prevent text clipping in execution overview state history

### DIFF
--- a/ui/src/components/executions/overview/components/sidebar/Timeline.vue
+++ b/ui/src/components/executions/overview/components/sidebar/Timeline.vue
@@ -1,18 +1,24 @@
 <template>
-    <el-collapse accordion>
+    <el-collapse accordion ref="container">
         <el-collapse-item :icon="ChevronDown">
             <template #title>
                 <span>{{ $t("state_history") }}</span>
             </template>
 
-            <el-timeline>
+            <el-timeline :class="{'is-narrow': isNarrow}">
                 <el-timeline-item
                     v-for="(activity, aIdx) in props.histories"
                     :key="aIdx"
-                    :timestamp="formatDate(activity.date)"
+                    v-bind="isNarrow ? {} : {timestamp: formatDate(activity.date)}"
                     :color="getSchemeValue(activity.state)"
                 >
-                    {{ activity.state }}
+                    <div v-if="isNarrow" class="timeline-row">
+                        <span class="timeline-timestamp">{{ formatDate(activity.date) }}</span>
+                        <span>{{ activity.state }}</span>
+                    </div>
+                    <template v-else>
+                        {{ activity.state }}
+                    </template>
                 </el-timeline-item>
             </el-timeline>
         </el-collapse-item>
@@ -20,6 +26,7 @@
 </template>
 
 <script setup lang="ts">
+    import {ref, onMounted, onBeforeUnmount} from "vue";
     import type {Histories} from "../../../../../stores/executions";
 
     import {getSchemeValue} from "../../../../../utils/scheme";
@@ -33,6 +40,24 @@
     const formatDate = (date: string) => {
         return moment(date)?.format("YYYY-MM-DD HH:mm:ss.SSS") ?? date;
     };
+
+    const container = ref<HTMLElement | null>(null);
+    const isNarrow = ref(false);
+    let ro: ResizeObserver | null = null;
+
+    onMounted(() => {
+        ro = new ResizeObserver(([entry]) => {
+            isNarrow.value = entry.contentRect.width < 220;
+        });
+        const el = (container.value as any)?.$el ?? container.value;
+        if (el) {
+            ro.observe(el);
+        }
+    });
+
+    onBeforeUnmount(() => {
+        ro?.disconnect();
+    });
 </script>
 
 <style scoped lang="scss">
@@ -70,6 +95,10 @@
     padding-left: 50%;
     margin-top: $spacer;
 
+    &.is-narrow {
+        padding-left: 0;
+    }
+
     & :deep(.el-timeline-item) {
         padding-bottom: $spacer;
 
@@ -99,6 +128,18 @@
         bottom: 10%;
         left: 4.5px;
         border-left-width: 1px;
+    }
+
+    .timeline-row {
+        display: flex;
+        flex-wrap: wrap;
+        align-items: baseline;
+        gap: 4px;
+
+        .timeline-timestamp {
+            font-size: $font-size-sm;
+            color: var(--ks-content-tertiary);
+        }
     }
 }
 </style>


### PR DESCRIPTION
### ✨ Description
Fixes timestamp text clipping in the Execution Overview sidebar's State History timeline when the left panel is too narrow.

The root cause is `el-timeline-item`'s `:timestamp` prop which renders timestamps using `position: absolute; left: -210px`. When the panel is narrower than ~210px, timestamps get pushed outside the visible area and clipped by the parent `overflow: hidden`.

Fix uses a `ResizeObserver` to watch the container width. At normal widths, the original El Plus layout is fully preserved (timestamp on left, state on right). Only when the container drops below 220px does it switch to an inline flex layout where timestamps render in normal document flow and can never be clipped.

### 🔗 Related Issue
Closes https://github.com/kestra-io/kestra/issues/14878

### 🎨 Frontend Checklist
- [ ] Code builds without errors (`npm run build`)
- [ ] All existing E2E tests pass (`npm run test:e2e`)
- [ ] Screenshots or video recordings attached showing the `UI` changes

### 📝 Additional Notes
This is a re-submission addressing review feedback from #14969. Only one file changed: `ui/src/components/executions/overview/components/sidebar/Timeline.vue`
<img width="658" height="616" alt="image" src="https://github.com/user-attachments/assets/ae552e7b-bc76-4014-a6ee-880423e4032c" />

https://github.com/user-attachments/assets/d5d8ad42-1356-43a4-b605-d153296765f1

