### PR TITLE
fix(pebble): prevent parent taskrun list mutation in CurrentEachOutputFunction

### DIFF
--- a/core/src/main/java/io/kestra/core/runners/pebble/functions/CurrentEachOutputFunction.java
+++ b/core/src/main/java/io/kestra/core/runners/pebble/functions/CurrentEachOutputFunction.java
@@ -29,7 +29,9 @@ public class CurrentEachOutputFunction implements Function {
             for (Map<?, ?> parent : parents) {
                 Map<?, ?> taskrun = (Map<?, ?>) parent.get("taskrun");
                 if (taskrun != null) {
-                    if(outputs.get(taskrun.get("value")) == null) return null;
+                    if(outputs.get(taskrun.get("value")) == null) {
+                        return null;
+                    }
                     outputs = (Map<?, ?>) outputs.get(taskrun.get("value"));
                 }
             }

--- a/core/src/main/java/io/kestra/core/runners/pebble/functions/CurrentEachOutputFunction.java
+++ b/core/src/main/java/io/kestra/core/runners/pebble/functions/CurrentEachOutputFunction.java
@@ -29,12 +29,8 @@ public class CurrentEachOutputFunction implements Function {
             for (Map<?, ?> parent : parents) {
                 Map<?, ?> taskrun = (Map<?, ?>) parent.get("taskrun");
                 if (taskrun != null) {
-                    if(outputs.get(taskrun.get("value")) != null){
-                        outputs = (Map<?, ?>) outputs.get(taskrun.get("value"));
-                    }
-                    else {
-                        throw new PebbleException(null, "No execution outputs for the current task runs path", lineNumber, self.getName());
-                    }
+                    if(outputs.get(taskrun.get("value")) == null) return null;
+                    outputs = (Map<?, ?>) outputs.get(taskrun.get("value"));
                 }
             }
         }

--- a/core/src/main/java/io/kestra/core/runners/pebble/functions/CurrentEachOutputFunction.java
+++ b/core/src/main/java/io/kestra/core/runners/pebble/functions/CurrentEachOutputFunction.java
@@ -24,10 +24,8 @@ public class CurrentEachOutputFunction implements Function {
         }
 
         Map<?, ?> outputs = (Map<?, ?>) args.get("outputs");
-        List<Map<?, ?>> immutableParents = (List<Map<?, ?>>) context.getVariable("parents");
-        if (immutableParents != null && !immutableParents.isEmpty()) {
-            List<Map<?, ?>> parents = new ArrayList<>(immutableParents);
-            Collections.reverse(parents);
+        List<Map<?, ?>> parents = ((List<Map<?, ?>>) context.getVariable("parents")).reversed();
+        if (parents != null && !parents.isEmpty()) {
             for (Map<?, ?> parent : parents) {
                 Map<?, ?> taskrun = (Map<?, ?>) parent.get("taskrun");
                 if (taskrun != null) {

--- a/core/src/main/java/io/kestra/core/runners/pebble/functions/CurrentEachOutputFunction.java
+++ b/core/src/main/java/io/kestra/core/runners/pebble/functions/CurrentEachOutputFunction.java
@@ -5,6 +5,7 @@ import io.pebbletemplates.pebble.extension.Function;
 import io.pebbletemplates.pebble.template.EvaluationContext;
 import io.pebbletemplates.pebble.template.PebbleTemplate;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -23,13 +24,19 @@ public class CurrentEachOutputFunction implements Function {
         }
 
         Map<?, ?> outputs = (Map<?, ?>) args.get("outputs");
-        List<Map<?, ?>> parents = (List<Map<?, ?>>) context.getVariable("parents");
-        if (parents != null && !parents.isEmpty()) {
+        List<Map<?, ?>> immutableParents = (List<Map<?, ?>>) context.getVariable("parents");
+        if (immutableParents != null && !immutableParents.isEmpty()) {
+            List<Map<?, ?>> parents = new ArrayList<>(immutableParents);
             Collections.reverse(parents);
             for (Map<?, ?> parent : parents) {
                 Map<?, ?> taskrun = (Map<?, ?>) parent.get("taskrun");
                 if (taskrun != null) {
-                    outputs = (Map<?, ?>) outputs.get(taskrun.get("value"));
+                    if(outputs.get(taskrun.get("value")) != null){
+                        outputs = (Map<?, ?>) outputs.get(taskrun.get("value"));
+                    }
+                    else {
+                        throw new PebbleException(null, "No execution outputs for the current task runs path", lineNumber, self.getName());
+                    }
                 }
             }
         }

--- a/core/src/test/java/io/kestra/plugin/core/flow/CurrentEachOutputFunctionTest.java
+++ b/core/src/test/java/io/kestra/plugin/core/flow/CurrentEachOutputFunctionTest.java
@@ -17,18 +17,18 @@ public class CurrentEachOutputFunctionTest {
         var output1 = (Map<String, Object>) execution.outputs().get("1-1-1_return");
         var outputv11 = (Map<String, Object>) output1.get("v11");
         var outputv11v21 = (Map<String, Object>) outputv11.get("v21");
-        assertThat(((Map<String, Object>) outputv11v21.get("v31")).get("value")).isEqualTo("return-v11-v21-v31");
-        assertThat(((Map<String, Object>) outputv11v21.get("v32")).get("value")).isEqualTo("return-v11-v21-v32");
+        assertThat(((Map<String, Object>) outputv11v21.get("v31")).get("value")).isEqualTo("return-v11-v21-v31-v11-v21-v31");
+        assertThat(((Map<String, Object>) outputv11v21.get("v32")).get("value")).isEqualTo("return-v11-v21-v32-v11-v21-v32");
         var outputv11v22 = (Map<String, Object>) outputv11.get("v22");
-        assertThat(((Map<String, Object>) outputv11v22.get("v31")).get("value")).isEqualTo("return-v11-v22-v31");
-        assertThat(((Map<String, Object>) outputv11v22.get("v32")).get("value")).isEqualTo("return-v11-v22-v32");
+        assertThat(((Map<String, Object>) outputv11v22.get("v31")).get("value")).isEqualTo("return-v11-v22-v31-v11-v22-v31");
+        assertThat(((Map<String, Object>) outputv11v22.get("v32")).get("value")).isEqualTo("return-v11-v22-v32-v11-v22-v32");
         var outputv12 = (Map<String, Object>) output1.get("v12");
         var outputv12v21 = (Map<String, Object>) outputv12.get("v21");
-        assertThat(((Map<String, Object>) outputv12v21.get("v31")).get("value")).isEqualTo("return-v12-v21-v31");
-        assertThat(((Map<String, Object>) outputv12v21.get("v32")).get("value")).isEqualTo("return-v12-v21-v32");
+        assertThat(((Map<String, Object>) outputv12v21.get("v31")).get("value")).isEqualTo("return-v12-v21-v31-v12-v21-v31");
+        assertThat(((Map<String, Object>) outputv12v21.get("v32")).get("value")).isEqualTo("return-v12-v21-v32-v12-v21-v32");
         var outputv12v22 = (Map<String, Object>) outputv12.get("v22");
-        assertThat(((Map<String, Object>) outputv12v22.get("v31")).get("value")).isEqualTo("return-v12-v22-v31");
-        assertThat(((Map<String, Object>) outputv12v22.get("v32")).get("value")).isEqualTo("return-v12-v22-v32");
+        assertThat(((Map<String, Object>) outputv12v22.get("v31")).get("value")).isEqualTo("return-v12-v22-v31-v12-v22-v31");
+        assertThat(((Map<String, Object>) outputv12v22.get("v32")).get("value")).isEqualTo("return-v12-v22-v32-v12-v22-v32");
 
         var output2 = (Map<String, Object>) execution.outputs().get("2-1_return");
         assertThat(((Map<String, Object>) output2.get("v41")).get("value")).isEqualTo("return-v41");

--- a/core/src/test/resources/flows/valids/current-output.yaml
+++ b/core/src/test/resources/flows/valids/current-output.yaml
@@ -18,8 +18,8 @@ tasks:
               format: "{{ parents[1].taskrun.value }}-{{ parents[0].taskrun.value }}-{{ taskrun.value }}"
             - id: 1-1-1_return
               type: io.kestra.plugin.core.debug.Return
-              #format: "return-{{ outputs['1-1-1_output'][parents[1].taskrun.value][parents[0].taskrun.value][taskrun.value].value }}"
-              format: "return-{{ currentEachOutput(outputs['1-1-1_output']).value }}"
+              #format: "return-{{ outputs['1-1-1_output'][parents[1].taskrun.value][parents[0].taskrun.value][taskrun.value].value }}-{{ outputs['1-1-1_output'][parents[1].taskrun.value][parents[0].taskrun.value][taskrun.value].value }}"
+              format: "return-{{ currentEachOutput(outputs['1-1-1_output']).value }}-{{ currentEachOutput(outputs['1-1-1_output']).value }}"
   - id: 2_each
     type: io.kestra.plugin.core.flow.ForEach
     values: '["v41", "v42"]'


### PR DESCRIPTION
# Problem
- currently, parent taskrun list maintain reference at memory hence mutating the list by reversing it is preserved in evaluation context and since pebble template uses the same context to evaluate the string template, so if we called the same function more than one it will fail as it will not start from root
- consider three nested ForEach so two parents exist say [v_inner, v_outer], the first time it will reverse parents in memory so it will be [v_outer, v_inner], and calling the function for the second time it will see the reversed list and reverse again returning to the original one hence starting to read outputs from inner to root causing failure!
- the same problem fixed here before merging this PR #12566

# Solution
- make parent taskrun list immutable so that it will be memory safe and each time we read parents and reverse to start from the root as exepected.

# Testing 
- calling the same function more than once at the same string template should works without failures  