### PR TITLE
fix(ui): output autocomplete to exclude current task id

### DIFF
--- a/ui/src/composables/monaco/languages/pebbleLanguageConfigurator.ts
+++ b/ui/src/composables/monaco/languages/pebbleLanguageConfigurator.ts
@@ -146,7 +146,7 @@ export function registerNestedValueAutoCompletion(
 
             const startOfWordColumn = position.column - parentFieldMatcher.matches[2].length;
             return {
-                suggestions: (await autoCompletion.nestedFieldAutoCompletion(source, parsed, parentFieldMatcher.matches[1]))
+                suggestions: (await autoCompletion.nestedFieldAutoCompletion(source, parsed, parentFieldMatcher.matches[1], model.getOffsetAt(position)))
                     .map(s => propertySuggestion(s, {
                         lineNumber: position.lineNumber,
                         startColumn: startOfWordColumn,

--- a/ui/src/override/services/flowAutoCompletionProvider.ts
+++ b/ui/src/override/services/flowAutoCompletionProvider.ts
@@ -87,6 +87,59 @@ export class FlowAutoCompletion extends YamlAutoCompletion {
             .filter(task => typeof task?.get === "function" && task?.get("id"));
     }
 
+    private cursorProbeIndexes(source: string, cursorIndex: number): number[] {
+        const safeCursorIndex = Math.max(0, Math.min(cursorIndex - 1, source.length - 1));
+        const probeIndexes = [safeCursorIndex];
+        let previousNonWhitespace = safeCursorIndex;
+        while (previousNonWhitespace > 0 && /\s/.test(source.charAt(previousNonWhitespace))) {
+            previousNonWhitespace--;
+        }
+        if (previousNonWhitespace !== safeCursorIndex) {
+            probeIndexes.push(previousNonWhitespace);
+        }
+
+        return probeIndexes;
+    }
+
+    private taskIdFromCandidates(candidates: any[]): string | undefined {
+        for (let i = candidates.length - 1; i >= 0; i--) {
+            const candidate = candidates[i];
+            if (
+                candidate && typeof candidate === "object"
+                && typeof candidate.id === "string"
+                && typeof candidate.type === "string"
+            ) {
+                return candidate.id;
+            }
+        }
+
+        return undefined;
+    }
+
+    private currentTaskIdAtCursor(source: string, cursorIndex?: number): string | undefined {
+        if (cursorIndex === undefined || source.length === 0) {
+            return undefined;
+        }
+
+        const probeIndexes = this.cursorProbeIndexes(source, cursorIndex);
+
+        try {
+            for (const probeIndex of probeIndexes) {
+                const localized = YAML_UTILS.localizeElementAtIndex(source, probeIndex);
+                const candidates = [...(localized?.parents ?? []), localized?.value];
+
+                const taskId = this.taskIdFromCandidates(candidates);
+                if (taskId) {
+                    return taskId;
+                }
+            }
+        } catch {
+            return undefined;
+        }
+
+        return undefined;
+    }
+
     private async outputsFor(taskId: string, source: string): Promise<string[]> {
         const taskType = this.tasks(this.completionSource?.value ?? source).filter(task => task.get("id") === taskId)
             .map(task => task.get("type"))
@@ -119,12 +172,18 @@ export class FlowAutoCompletion extends YamlAutoCompletion {
         return distinct(fetchTriggerVarsByType.flat());
     }
 
-    async nestedFieldAutoCompletion(source: string, parsed: any | undefined, parentField: string): Promise<string[]> {
+    async nestedFieldAutoCompletion(source: string, parsed: any | undefined, parentField: string, cursorIndex?: number): Promise<string[]> {
         switch (parentField) {
             case "inputs":
                 return Promise.resolve(parsed?.inputs?.map((input: {id?: string}) => input.id) ?? []);
-            case "outputs":
-                return Promise.resolve(parsed?.tasks?.map((task: {id?: string}) => task.id).filter(Boolean) ?? []);
+            case "outputs": {
+                const currentTaskId = this.currentTaskIdAtCursor(source, cursorIndex);
+                return Promise.resolve(
+                    parsed?.tasks
+                        ?.map((task: {id?: string}) => task.id)
+                        .filter((taskId: string | undefined) => taskId && taskId !== currentTaskId) ?? []
+                );
+            }
             case "labels":
                 return Promise.resolve(Object.keys(parsed?.labels ?? {}));
             case "flow":

--- a/ui/src/services/autoCompletionProvider.ts
+++ b/ui/src/services/autoCompletionProvider.ts
@@ -8,7 +8,7 @@ export class PebbleAutoCompletion {
         return Promise.resolve([]);
     }
 
-    nestedFieldAutoCompletion(_source: string, _parsed: any | undefined, _parentField: string): Promise<string[]> {
+    nestedFieldAutoCompletion(_source: string, _parsed: any | undefined, _parentField: string, _cursorIndex?: number): Promise<string[]> {
         return Promise.resolve([])
     }
 

--- a/ui/tests/unit/services/flowAutoCompletionProvider.spec.ts
+++ b/ui/tests/unit/services/flowAutoCompletionProvider.spec.ts
@@ -35,6 +35,21 @@ triggers:
 id: my-flow
 namespace: my.namespace`;
 
+const flowWithOutputsAutocompleteInTask = [
+    "tasks:",
+    "  - id: download",
+    "    type: io.kestra.plugin.core.http.Download",
+    "    uri: https://example.com/file.txt",
+    "  - id: filter",
+    "    type: io.kestra.plugin.core.storage.FilterItems",
+    "    from: \"{{ outputs. }}\"",
+    "  - id: upload",
+    "    type: io.kestra.plugin.core.storage.Upload",
+    "    from: \"{{ outputs.download.uri }}\"",
+    "id: my-flow",
+    "namespace: my.namespace"
+].join("\n");
+
 const propertiesSchemaWrapper = (properties: Record<string, any>) => ({
     schema: {
         outputs: {
@@ -124,6 +139,7 @@ const namespacesStore = {
 
 const provider = new FlowAutoCompletion(flowStore, pluginsStore, namespacesStore);
 const parsed = YAML_UTILS.parse(defaultFlow);
+const flowWithOutputsAutocompleteInTaskParsed = YAML_UTILS.parse(flowWithOutputsAutocompleteInTask);
 
 describe("FlowAutoCompletionProvider", () => {
     it("root autocompletions", async () => {
@@ -185,6 +201,24 @@ describe("FlowAutoCompletionProvider", () => {
         expect(await provider.nestedFieldAutoCompletion(defaultFlow, parsed, "outputs.task2")).toEqual(["value"]);
         expect(await provider.nestedFieldAutoCompletion(defaultFlow, parsed, "outputs.task3")).toEqual([]);
         expect(await provider.nestedFieldAutoCompletion(defaultFlow, parsed, "bad")).toEqual([]);
+    })
+
+    it("outputs autocomplete excludes current task id", async () => {
+        const cursorIndex = flowWithOutputsAutocompleteInTask.indexOf("outputs.") + "outputs.".length;
+        expect(cursorIndex).toBeGreaterThan(0);
+
+        expect(await provider.nestedFieldAutoCompletion(
+            flowWithOutputsAutocompleteInTask,
+            flowWithOutputsAutocompleteInTaskParsed,
+            "outputs",
+            cursorIndex
+        )).toEqual(["download", "upload"]);
+
+        expect(await provider.nestedFieldAutoCompletion(
+            flowWithOutputsAutocompleteInTask,
+            flowWithOutputsAutocompleteInTaskParsed,
+            "outputs"
+        )).toEqual(["download", "filter", "upload"]);
     })
 
     it("value autocompletions", async () => {


### PR DESCRIPTION
closes #14223 

### ✨ Description

When editing` {{ outputs. }}` inside a task, autocomplete no longer suggests that same task id. This avoids self-reference suggestions. 
 Added focused unit test coverage for this behavior.



### 🎨 Frontend Checklist

_If this PR does not include any frontend changes, delete this entire section._

- [x] Code builds without errors (`npm run build`)
- [ ] All existing E2E tests pass (`npm run test:e2e`)
- [x] Screenshots or video recordings attached showing the `UI` changes


https://github.com/user-attachments/assets/f015deef-328e-4423-96fc-d6558d1b4a6c

