### PR TITLE
feat(flows): validate Schedule triggers inputs

### DIFF
--- a/core/src/main/java/io/kestra/core/validations/validator/FlowValidator.java
+++ b/core/src/main/java/io/kestra/core/validations/validator/FlowValidator.java
@@ -10,7 +10,6 @@ import io.kestra.core.utils.ListUtils;
 import io.kestra.core.validations.FlowValidation;
 import io.kestra.plugin.core.trigger.Schedule;
 import io.micronaut.core.annotation.AnnotationValue;
-import io.micronaut.core.annotation.Introspected;
 import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.annotation.Nullable;
 import io.micronaut.validation.validator.constraints.ConstraintValidator;
@@ -28,7 +27,6 @@ import static io.kestra.core.models.Label.READ_ONLY;
 import static io.kestra.core.models.Label.SYSTEM_PREFIX;
 
 @Singleton
-@Introspected
 public class FlowValidator implements ConstraintValidator<FlowValidation, Flow> {
     @Inject
     private NamespaceService namespaceService;

--- a/core/src/main/java/io/kestra/core/validations/validator/FlowValidator.java
+++ b/core/src/main/java/io/kestra/core/validations/validator/FlowValidator.java
@@ -1,10 +1,5 @@
 package io.kestra.core.validations.validator;
 
-import java.lang.reflect.Field;
-import java.util.*;
-import java.util.regex.Pattern;
-import java.util.stream.Collectors;
-
 import io.kestra.core.models.flows.Data;
 import io.kestra.core.models.flows.Flow;
 import io.kestra.core.models.flows.Input;
@@ -13,8 +8,9 @@ import io.kestra.core.models.tasks.Task;
 import io.kestra.core.services.NamespaceService;
 import io.kestra.core.utils.ListUtils;
 import io.kestra.core.validations.FlowValidation;
-
+import io.kestra.plugin.core.trigger.Schedule;
 import io.micronaut.core.annotation.AnnotationValue;
+import io.micronaut.core.annotation.Introspected;
 import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.annotation.Nullable;
 import io.micronaut.validation.validator.constraints.ConstraintValidator;
@@ -22,10 +18,17 @@ import io.micronaut.validation.validator.constraints.ConstraintValidatorContext;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 
+import java.lang.reflect.Field;
+import java.util.*;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
 import static io.kestra.core.models.Label.READ_ONLY;
 import static io.kestra.core.models.Label.SYSTEM_PREFIX;
 
 @Singleton
+@Introspected
 public class FlowValidator implements ConstraintValidator<FlowValidation, Flow> {
     @Inject
     private NamespaceService namespaceService;
@@ -84,6 +87,9 @@ public class FlowValidator implements ConstraintValidator<FlowValidation, Flow> 
         if (!duplicateIds.isEmpty()) {
             violations.add("Duplicate output with name [" + String.join(", ", duplicateIds) + "]");
         }
+
+        // No missing defaults for schedule triggers
+        findMissingInputsForScheduleTriggers(value).forEach(violations::add);
 
         // system labels
         ListUtils.emptyOnNull(value.getLabels()).stream()
@@ -216,6 +222,37 @@ public class FlowValidator implements ConstraintValidator<FlowValidation, Flow> 
             .distinct()
             .filter(entry -> Collections.frequency(taskIds, entry) > 1)
             .toList();
+    }
+
+    /**
+     * @return the violation formatted message of missing inputs for each schedule trigger
+     */
+    private Stream<String> findMissingInputsForScheduleTriggers(Flow value) {
+        if (!ListUtils.emptyOnNull(value.getTriggers()).isEmpty()
+            && !ListUtils.emptyOnNull(value.getInputs()).isEmpty()) {
+            // Find inputs without defaults
+            Set<String> inputsWithoutDefaults = value.getInputs().stream()
+                .filter(input -> input.getDefaults() == null)
+                .map(Data::getId)
+                .collect(Collectors.toSet());
+            // Find schedules with missing inputs or null inputs
+            return value.getTriggers().stream()
+                .filter(Schedule.class::isInstance)
+                .map(Schedule.class::cast)
+                .flatMap(schedule -> {
+                    Set<String> violations = new HashSet<>();
+                    Map<String, Object> scheduleInputs = schedule.getInputs() != null ? schedule.getInputs() : new HashMap<>();
+                    var missingInputs = inputsWithoutDefaults.stream()
+                        .filter(inputId -> !scheduleInputs.containsKey(inputId))
+                        .collect(Collectors.joining(" | "));
+                    if (!missingInputs.isEmpty()) {
+                        violations.add("Missing inputs for Schedule Trigger '%s', missing inputs: '%s'".formatted(schedule.getId(), missingInputs));
+                    }
+                    return violations.stream();
+                });
+        } else {
+            return Stream.empty();
+        }
     }
 
     /**

--- a/core/src/main/java/io/kestra/core/validations/validator/FlowValidator.java
+++ b/core/src/main/java/io/kestra/core/validations/validator/FlowValidator.java
@@ -1,10 +1,5 @@
 package io.kestra.core.validations.validator;
 
-import java.lang.reflect.Field;
-import java.util.*;
-import java.util.regex.Pattern;
-import java.util.stream.Collectors;
-
 import io.kestra.core.models.flows.Data;
 import io.kestra.core.models.flows.Flow;
 import io.kestra.core.models.flows.Input;
@@ -13,8 +8,9 @@ import io.kestra.core.models.tasks.Task;
 import io.kestra.core.services.NamespaceService;
 import io.kestra.core.utils.ListUtils;
 import io.kestra.core.validations.FlowValidation;
-
+import io.kestra.plugin.core.trigger.Schedule;
 import io.micronaut.core.annotation.AnnotationValue;
+import io.micronaut.core.annotation.Introspected;
 import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.annotation.Nullable;
 import io.micronaut.validation.validator.constraints.ConstraintValidator;
@@ -22,10 +18,17 @@ import io.micronaut.validation.validator.constraints.ConstraintValidatorContext;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 
+import java.lang.reflect.Field;
+import java.util.*;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
 import static io.kestra.core.models.Label.READ_ONLY;
 import static io.kestra.core.models.Label.SYSTEM_PREFIX;
 
 @Singleton
+@Introspected
 public class FlowValidator implements ConstraintValidator<FlowValidation, Flow> {
     public static List<String> RESERVED_FLOW_IDS = List.of(
         "pause",
@@ -101,6 +104,9 @@ public class FlowValidator implements ConstraintValidator<FlowValidation, Flow> 
         if (!duplicateIds.isEmpty()) {
             violations.add("Duplicate output with name [" + String.join(", ", duplicateIds) + "]");
         }
+
+        // No missing defaults for schedule triggers
+        findMissingInputsForScheduleTriggers(value).forEach(violations::add);
 
         // preconditions unique id
         duplicateIds = getDuplicates(
@@ -246,6 +252,37 @@ public class FlowValidator implements ConstraintValidator<FlowValidation, Flow> 
             .distinct()
             .filter(entry -> Collections.frequency(taskIds, entry) > 1)
             .toList();
+    }
+
+    /**
+     * @return the violation formatted message of missing inputs for each schedule trigger
+     */
+    private Stream<String> findMissingInputsForScheduleTriggers(Flow value) {
+        if (!ListUtils.emptyOnNull(value.getTriggers()).isEmpty()
+            && !ListUtils.emptyOnNull(value.getInputs()).isEmpty()) {
+            // Find inputs without defaults
+            Set<String> inputsWithoutDefaults = value.getInputs().stream()
+                .filter(input -> input.getDefaults() == null)
+                .map(Data::getId)
+                .collect(Collectors.toSet());
+            // Find schedules with missing inputs or null inputs
+            return value.getTriggers().stream()
+                .filter(Schedule.class::isInstance)
+                .map(Schedule.class::cast)
+                .flatMap(schedule -> {
+                    Set<String> violations = new HashSet<>();
+                    Map<String, Object> scheduleInputs = schedule.getInputs() != null ? schedule.getInputs() : new HashMap<>();
+                    var missingInputs = inputsWithoutDefaults.stream()
+                        .filter(inputId -> !scheduleInputs.containsKey(inputId))
+                        .collect(Collectors.joining(" | "));
+                    if (!missingInputs.isEmpty()) {
+                        violations.add("Missing inputs for Schedule Trigger '%s', missing inputs: '%s'".formatted(schedule.getId(), missingInputs));
+                    }
+                    return violations.stream();
+                });
+        } else {
+            return Stream.empty();
+        }
     }
 
     /**

--- a/core/src/test/java/io/kestra/core/validations/FlowValidationTest.java
+++ b/core/src/test/java/io/kestra/core/validations/FlowValidationTest.java
@@ -1,16 +1,8 @@
 package io.kestra.core.validations;
 
-import java.io.File;
-import java.net.URL;
-import java.util.List;
-import java.util.Optional;
-
-import org.junit.jupiter.api.Test;
-
 import com.fasterxml.jackson.core.JsonLocation;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-
 import io.kestra.core.junit.annotations.KestraTest;
 import io.kestra.core.models.assets.AssetIdentifier;
 import io.kestra.core.models.assets.AssetsDeclaration;
@@ -24,10 +16,15 @@ import io.kestra.core.services.FlowService;
 import io.kestra.core.tenant.TenantService;
 import io.kestra.core.utils.TestsUtils;
 import io.kestra.plugin.core.log.Log;
-
 import jakarta.inject.Inject;
 import jakarta.validation.ConstraintViolation;
 import jakarta.validation.ConstraintViolationException;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.net.URL;
+import java.util.List;
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -205,6 +202,44 @@ class FlowValidationTest {
         // Then
         assertThat(validate.isPresent()).isEqualTo(true);
         assertThat(validate.get().getMessage()).contains("Inputs with a default value cannot also have a prefill.");
+    }
+
+    @Test
+    void scheduledFlowInputDefaults_valid() {
+        // Given
+        Flow flow = this.parse("flows/valids/scheduled-inputs-defaults.yaml");
+
+        // When
+        Optional<ConstraintViolationException> validate = modelValidator.isValid(flow);
+
+        // Then
+        assertThat(validate).isEmpty();
+    }
+
+    @Test
+    void scheduledFlowMissingInputDefaults_failValidation() {
+        // Given
+        Flow flow = this.parse("flows/invalids/scheduled-missing-inputs-defaults.yaml");
+
+        // When
+        Optional<ConstraintViolationException> validate = modelValidator.isValid(flow);
+
+        // Then
+        assertThat(validate).isPresent();
+        assertThat(validate.get().getMessage()).contains("Missing inputs for Schedule Trigger 'every_minute', missing inputs: 'user2'");
+    }
+
+    @Test
+    void scheduledFlowMissingInputDefaults2_failValidation() {
+        // Given
+        Flow flow = this.parse("flows/invalids/scheduled-missing-inputs-defaults-2.yaml");
+
+        // When
+        Optional<ConstraintViolationException> validate = modelValidator.isValid(flow);
+
+        // Then
+        assertThat(validate).isPresent();
+        assertThat(validate.get().getMessage()).contains("Missing inputs for Schedule Trigger 'every_minute', missing inputs: 'user2'");
     }
 
     @Test

--- a/core/src/test/resources/flows/invalids/scheduled-missing-inputs-defaults-2.yaml
+++ b/core/src/test/resources/flows/invalids/scheduled-missing-inputs-defaults-2.yaml
@@ -1,0 +1,17 @@
+id: scheduled_missing_inputs_defaults_2
+namespace: io.kestra.tests
+
+inputs:
+  - id: user2
+    type: STRING
+
+
+tasks:
+  - id: hello
+    type: io.kestra.plugin.core.log.Log
+    message: hey there {{ inputs.user2 }}! 👋
+
+triggers:
+  - id: every_minute
+    type: io.kestra.plugin.core.trigger.Schedule
+    cron: "*/1 * * * *"

--- a/core/src/test/resources/flows/invalids/scheduled-missing-inputs-defaults.yaml
+++ b/core/src/test/resources/flows/invalids/scheduled-missing-inputs-defaults.yaml
@@ -1,0 +1,20 @@
+id: scheduled_missing_inputs_defaults
+namespace: io.kestra.tests
+
+inputs:
+  - id: user
+    type: STRING
+    defaults: John
+  - id: user2
+    type: STRING
+
+
+tasks:
+  - id: hello
+    type: io.kestra.plugin.core.log.Log
+    message: hey there {{ inputs.user }}! 👋
+
+triggers:
+  - id: every_minute
+    type: io.kestra.plugin.core.trigger.Schedule
+    cron: "*/1 * * * *"

--- a/core/src/test/resources/flows/valids/scheduled-inputs-defaults.yaml
+++ b/core/src/test/resources/flows/valids/scheduled-inputs-defaults.yaml
@@ -1,0 +1,17 @@
+id: scheduled_inputs_defaults
+namespace: io.kestra.tests
+
+inputs:
+  - id: user
+    type: STRING
+    defaults: John
+
+tasks:
+  - id: hello
+    type: io.kestra.plugin.core.log.Log
+    message: hey there {{ inputs.user }}! 👋
+
+triggers:
+  - id: every_minute
+    type: io.kestra.plugin.core.trigger.Schedule
+    cron: "*/1 * * * *"

--- a/core/src/test/resources/flows/valids/switch.yaml
+++ b/core/src/test/resources/flows/valids/switch.yaml
@@ -47,3 +47,5 @@ triggers:
   - id: schedule
     type: io.kestra.plugin.core.trigger.Schedule
     cron: "0 * * * *"
+    inputs:
+      string: FIRST

--- a/core/src/test/resources/flows/valids/task-flow.yaml
+++ b/core/src/test/resources/flows/valids/task-flow.yaml
@@ -26,3 +26,5 @@ triggers:
   - id: schedule
     type: io.kestra.plugin.core.trigger.Schedule
     cron: "0 * * * *"
+    inputs:
+      string: hello


### PR DESCRIPTION
otherwise you can save an invalid Flow without knowing it, and it will fail systematically at each schedule

- fixes https://github.com/kestra-io/kestra/issues/2881
- this commit add tests from already existing PR https://github.com/kestra-io/kestra/pull/8107#issuecomment-4030735988 from https://github.com/VTKop
