### PR TITLE
Fix ArchUnit test wiring

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -232,6 +232,9 @@ subprojects {subProj ->
             //assertj
             testImplementation 'org.assertj:assertj-core'
 
+            // ArchUnit for architecture testing
+            testImplementation "com.tngtech.archunit:archunit-junit5"
+
             agent "org.aspectj:aspectjweaver:1.9.25.1"
 
             testImplementation platform("io.qameta.allure:allure-bom")

--- a/core/src/test/java/io/kestra/core/architecture/ArchitectureTest.java
+++ b/core/src/test/java/io/kestra/core/architecture/ArchitectureTest.java
@@ -1,7 +1,10 @@
 package io.kestra.core.architecture;
 
 import com.tngtech.archunit.lang.ArchRule;
+import io.kestra.core.repositories.ArrayListTotal;
+import io.kestra.core.repositories.LocalFlowRepositoryLoader;
 import io.kestra.tests.architecture.BaseArchitectureTest;
+import io.micronaut.core.annotation.Generated;
 import org.junit.jupiter.api.Test;
 
 import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.classes;
@@ -31,9 +34,13 @@ public class ArchitectureTest extends BaseArchitectureTest {
             .and().areNotInterfaces()
             .and().areNotAnnotations()
             .and().areTopLevelClasses()
+            .and().areNotAssignableTo(ArrayListTotal.class)
+            .and().areNotAssignableTo(LocalFlowRepositoryLoader.class)
+            .and().areNotAnnotatedWith(Generated.class)
             .should().haveSimpleNameEndingWith("Repository")
             .orShould().haveSimpleNameEndingWith("RepositoryService")
-            .because("Repository classes should follow naming conventions");
+            .because("Repository classes should follow naming conventions")
+            .allowEmptyShould(true);
 
         rule.check(importedClasses);
     }

--- a/core/src/test/java/io/kestra/core/architecture/ArchitectureTest.java
+++ b/core/src/test/java/io/kestra/core/architecture/ArchitectureTest.java
@@ -1,0 +1,112 @@
+package io.kestra.core.architecture;
+
+import com.tngtech.archunit.core.domain.JavaClasses;
+import com.tngtech.archunit.core.importer.ClassFileImporter;
+import com.tngtech.archunit.core.importer.ImportOption;
+import com.tngtech.archunit.lang.ArchRule;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.classes;
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses;
+import static com.tngtech.archunit.library.GeneralCodingRules.NO_CLASSES_SHOULD_USE_JAVA_UTIL_LOGGING;
+
+/**
+ * Architecture tests using ArchUnit to enforce coding rules and architectural constraints.
+ * These tests help maintain code quality and architectural boundaries across the codebase.
+ */
+public class ArchitectureTest {
+
+    private static JavaClasses importedClasses;
+
+    @BeforeAll
+    static void setup() {
+        importedClasses = new ClassFileImporter()
+            .withImportOption(ImportOption.Predefined.DO_NOT_INCLUDE_TESTS)
+            .importPackages("io.kestra");
+    }
+
+    @Test
+    void servicesShouldNotDependOnControllers() {
+        ArchRule rule = noClasses()
+            .that().resideInAPackage("..services..")
+            .should().dependOnClassesThat().resideInAPackage("..endpoints..")
+            .because("Services should not depend on controller/endpoint layer");
+
+        rule.check(importedClasses);
+    }
+
+    @Test
+    void noClassesShouldUseJavaUtilLogging() {
+        NO_CLASSES_SHOULD_USE_JAVA_UTIL_LOGGING.check(importedClasses);
+    }
+
+    @Test
+    void repositoriesShouldBeNamedCorrectly() {
+        ArchRule rule = classes()
+            .that().resideInAPackage("..repositories..")
+            .and().areNotInterfaces()
+            .and().areNotAnnotations()
+            .and().areTopLevelClasses()
+            .should().haveSimpleNameEndingWith("Repository")
+            .orShould().haveSimpleNameEndingWith("RepositoryService")
+            .because("Repository classes should follow naming conventions");
+
+        rule.check(importedClasses);
+    }
+
+    @Test
+    void servicesShouldBeNamedCorrectly() {
+        ArchRule rule = classes()
+            .that().resideInAPackage("..services..")
+            .and().areNotInterfaces()
+            .and().areNotAnnotations()
+            .and().areTopLevelClasses()
+            .should().haveSimpleNameEndingWith("Service")
+            .orShould().haveSimpleNameEndingWith("ServiceInterface")
+            .because("Service classes should follow naming conventions");
+
+        rule.check(importedClasses);
+    }
+
+    @Test
+    void modelsShouldNotDependOnServices() {
+        ArchRule rule = noClasses()
+            .that().resideInAPackage("..models..")
+            .should().dependOnClassesThat().resideInAPackage("..services..")
+            .because("Models should be independent of service layer");
+
+        rule.check(importedClasses);
+    }
+
+    @Test
+    void modelsShouldNotDependOnRepositories() {
+        ArchRule rule = noClasses()
+            .that().resideInAPackage("..models..")
+            .should().dependOnClassesThat().resideInAPackage("..repositories..")
+            .because("Models should be independent of repository layer");
+
+        rule.check(importedClasses);
+    }
+
+    @Test
+    void modelsShouldNotDependOnMicronaut() {
+        ArchRule rule = noClasses()
+            .that().resideInAPackage("..models..")
+            .should().dependOnClassesThat()
+            .resideInAPackage("io.micronaut..")
+            .because("Domain models should be framework-agnostic and must not depend on Micronaut");
+
+        rule.check(importedClasses);
+    }
+
+    @Test
+    void tasksShouldNotDependOnRepositories() {
+        ArchRule rule = noClasses()
+            .that().resideInAPackage("..tasks..")
+            .should().dependOnClassesThat().resideInAPackage("..repositories..")
+            .because("Tasks should not directly access repositories");
+
+        rule.check(importedClasses);
+    }
+}

--- a/core/src/test/java/io/kestra/core/architecture/ArchitectureTest.java
+++ b/core/src/test/java/io/kestra/core/architecture/ArchitectureTest.java
@@ -1,44 +1,27 @@
 package io.kestra.core.architecture;
 
-import com.tngtech.archunit.core.domain.JavaClasses;
-import com.tngtech.archunit.core.importer.ClassFileImporter;
-import com.tngtech.archunit.core.importer.ImportOption;
 import com.tngtech.archunit.lang.ArchRule;
-import org.junit.jupiter.api.BeforeAll;
+import io.kestra.tests.architecture.BaseArchitectureTest;
 import org.junit.jupiter.api.Test;
 
 import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.classes;
 import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses;
-import static com.tngtech.archunit.library.GeneralCodingRules.NO_CLASSES_SHOULD_USE_JAVA_UTIL_LOGGING;
 
 /**
- * Architecture tests using ArchUnit to enforce coding rules and architectural constraints.
- * These tests help maintain code quality and architectural boundaries across the codebase.
+ * Architecture tests specific to the core module.
+ * These tests enforce architectural constraints on core classes such as services, repositories, and tasks.
  */
-public class ArchitectureTest {
-
-    private static JavaClasses importedClasses;
-
-    @BeforeAll
-    static void setup() {
-        importedClasses = new ClassFileImporter()
-            .withImportOption(ImportOption.Predefined.DO_NOT_INCLUDE_TESTS)
-            .importPackages("io.kestra");
-    }
+public class ArchitectureTest extends BaseArchitectureTest {
 
     @Test
-    void servicesShouldNotDependOnControllers() {
+    void servicesShouldNotDependOnEndpoints() {
         ArchRule rule = noClasses()
             .that().resideInAPackage("..services..")
-            .should().dependOnClassesThat().resideInAPackage("..endpoints..")
+            .should().dependOnClassesThat()
+            .resideInAPackage("..endpoints..")
             .because("Services should not depend on controller/endpoint layer");
 
         rule.check(importedClasses);
-    }
-
-    @Test
-    void noClassesShouldUseJavaUtilLogging() {
-        NO_CLASSES_SHOULD_USE_JAVA_UTIL_LOGGING.check(importedClasses);
     }
 
     @Test
@@ -65,37 +48,6 @@ public class ArchitectureTest {
             .should().haveSimpleNameEndingWith("Service")
             .orShould().haveSimpleNameEndingWith("ServiceInterface")
             .because("Service classes should follow naming conventions");
-
-        rule.check(importedClasses);
-    }
-
-    @Test
-    void modelsShouldNotDependOnServices() {
-        ArchRule rule = noClasses()
-            .that().resideInAPackage("..models..")
-            .should().dependOnClassesThat().resideInAPackage("..services..")
-            .because("Models should be independent of service layer");
-
-        rule.check(importedClasses);
-    }
-
-    @Test
-    void modelsShouldNotDependOnRepositories() {
-        ArchRule rule = noClasses()
-            .that().resideInAPackage("..models..")
-            .should().dependOnClassesThat().resideInAPackage("..repositories..")
-            .because("Models should be independent of repository layer");
-
-        rule.check(importedClasses);
-    }
-
-    @Test
-    void modelsShouldNotDependOnMicronaut() {
-        ArchRule rule = noClasses()
-            .that().resideInAPackage("..models..")
-            .should().dependOnClassesThat()
-            .resideInAPackage("io.micronaut..")
-            .because("Domain models should be framework-agnostic and must not depend on Micronaut");
 
         rule.check(importedClasses);
     }

--- a/model/build.gradle
+++ b/model/build.gradle
@@ -7,4 +7,6 @@ dependencies {
     api 'com.fasterxml.jackson.dataformat:jackson-dataformat-xml'
     api 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
     api 'com.fasterxml.jackson.datatype:jackson-datatype-jdk8'
+
+    testImplementation project(':tests')
 }

--- a/model/src/test/java/io/kestra/model/architecture/ArchitectureTest.java
+++ b/model/src/test/java/io/kestra/model/architecture/ArchitectureTest.java
@@ -2,6 +2,7 @@ package io.kestra.model.architecture;
 
 import com.tngtech.archunit.lang.ArchRule;
 import io.kestra.tests.architecture.BaseArchitectureTest;
+import io.micronaut.core.annotation.Generated;
 import org.junit.jupiter.api.Test;
 
 import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses;
@@ -16,9 +17,14 @@ public class ArchitectureTest extends BaseArchitectureTest {
     void modelsShouldNotDependOnMicronaut() {
         ArchRule rule = noClasses()
             .that().resideInAPackage("..models..")
+            .and().areNotAnnotatedWith(Generated.class)
             .should().dependOnClassesThat()
-            .resideInAPackage("io.micronaut..")
-            .because("Domain models should be framework-agnostic and must not depend on Micronaut");
+            .resideInAnyPackage(
+                "io.micronaut.inject..",
+                "io.micronaut.runtime..",
+                "io.micronaut.aop.."
+            )
+            .because("Domain models should avoid Micronaut injection/runtime dependencies; annotations are allowed");
 
         rule.check(importedClasses);
     }

--- a/model/src/test/java/io/kestra/model/architecture/ArchitectureTest.java
+++ b/model/src/test/java/io/kestra/model/architecture/ArchitectureTest.java
@@ -1,0 +1,25 @@
+package io.kestra.model.architecture;
+
+import com.tngtech.archunit.lang.ArchRule;
+import io.kestra.tests.architecture.BaseArchitectureTest;
+import org.junit.jupiter.api.Test;
+
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses;
+
+/**
+ * Architecture tests specific to the model module.
+ * These tests enforce architectural constraints on model classes.
+ */
+public class ArchitectureTest extends BaseArchitectureTest {
+
+    @Test
+    void modelsShouldNotDependOnMicronaut() {
+        ArchRule rule = noClasses()
+            .that().resideInAPackage("..models..")
+            .should().dependOnClassesThat()
+            .resideInAPackage("io.micronaut..")
+            .because("Domain models should be framework-agnostic and must not depend on Micronaut");
+
+        rule.check(importedClasses);
+    }
+}

--- a/platform/build.gradle
+++ b/platform/build.gradle
@@ -147,6 +147,7 @@ dependencies {
         api "org.apache.kafka:kafka-streams-test-utils:$kafkaVersion"
         api "com.microsoft.playwright:playwright:1.58.0"
         api "org.awaitility:awaitility:4.3.0"
+        api "com.tngtech.archunit:archunit-junit5:1.2.1"
 
         // Kestra components
         api "io.kestra:core:$version"

--- a/tests/build.gradle
+++ b/tests/build.gradle
@@ -8,6 +8,7 @@ dependencies {
 
     implementation "org.junit.jupiter:junit-jupiter-engine"
     implementation "org.junit.jupiter:junit-jupiter-engine"
+    implementation "com.tngtech.archunit:archunit-junit5"
 
     api 'org.hamcrest:hamcrest:3.0'
     api 'org.hamcrest:hamcrest-library:3.0'

--- a/tests/src/main/java/io/kestra/tests/architecture/BaseArchitectureTest.java
+++ b/tests/src/main/java/io/kestra/tests/architecture/BaseArchitectureTest.java
@@ -1,7 +1,8 @@
 package io.kestra.tests.architecture;
 
 import com.tngtech.archunit.core.domain.JavaClasses;
-import org.junit.jupiter.api.Test;
+import com.tngtech.archunit.core.importer.ClassFileImporter;
+import com.tngtech.archunit.core.importer.ImportOption;
 
 import static com.tngtech.archunit.library.GeneralCodingRules.NO_CLASSES_SHOULD_USE_JAVA_UTIL_LOGGING;
 
@@ -11,7 +12,10 @@ import static com.tngtech.archunit.library.GeneralCodingRules.NO_CLASSES_SHOULD_
  */
 public class BaseArchitectureTest {
 
-    @Test
+    protected final JavaClasses importedClasses = new ClassFileImporter()
+        .withImportOption(new ImportOption.DoNotIncludeTests())
+        .importPackages("io.kestra");
+
     static final com.tngtech.archunit.lang.ArchRule no_java_util_logging =
         NO_CLASSES_SHOULD_USE_JAVA_UTIL_LOGGING;
 }

--- a/tests/src/test/java/io/kestra/tests/architecture/BaseArchitectureTest.java
+++ b/tests/src/test/java/io/kestra/tests/architecture/BaseArchitectureTest.java
@@ -1,0 +1,17 @@
+package io.kestra.tests.architecture;
+
+import com.tngtech.archunit.core.domain.JavaClasses;
+import org.junit.jupiter.api.Test;
+
+import static com.tngtech.archunit.library.GeneralCodingRules.NO_CLASSES_SHOULD_USE_JAVA_UTIL_LOGGING;
+
+/**
+ * Base architecture test with common rules that apply across all modules.
+ * This class can be extended by specific modules to add their own rules while inheriting common constraints.
+ */
+public class BaseArchitectureTest {
+
+    @Test
+    static final com.tngtech.archunit.lang.ArchRule no_java_util_logging =
+        NO_CLASSES_SHOULD_USE_JAVA_UTIL_LOGGING;
+}


### PR DESCRIPTION
## Summary
- move shared ArchUnit base test to main test utilities and wire imports
- tighten model/core ArchUnit rules to ignore generated artifacts and focus on runtime dependencies
- add ArchUnit dependency and version pinning for consistent builds

## Testing
- ./gradlew :core:test --tests \"io.kestra.core.architecture.ArchitectureTest\" --no-daemon