### PR TITLE
fix(core): update timestamp date pattern for AbstractRunnerTest#executionDate

### DIFF
--- a/core/src/test/java/io/kestra/core/runners/AbstractRunnerTest.java
+++ b/core/src/test/java/io/kestra/core/runners/AbstractRunnerTest.java
@@ -662,7 +662,7 @@ public abstract class AbstractRunnerTest {
             "execution-start-date", null, null, Duration.ofSeconds(60));
 
         Map<String, Object> outputs = taskOutputService.getOutputs(execution.getTaskRunList().getFirst());
-        assertThat((String) outputs.get("value")).matches("^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d{6}Z");
+        assertThat((String) outputs.get("value")).matches("^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d{6,9}Z");
     }
 
     @RetryingTest(5)


### PR DESCRIPTION
Changed \d{6} to \d{6,9} to accept both microsecond (6 digits) and nanosecond (9 digits) precision timestamp

Related-to: https://github.com/kestra-io/kestra-ee/pull/7042
