### PR TITLE
fix: replay to restart non-terminated parallel siblings

### DIFF
--- a/core/src/main/java/io/kestra/core/services/ExecutionService.java
+++ b/core/src/main/java/io/kestra/core/services/ExecutionService.java
@@ -299,18 +299,53 @@ public class ExecutionService {
             );
 
             // remove all child for replay task id
-            Set<String> taskRunToRemove = GraphUtils.successors(graphCluster, Set.of(taskRunId))
+            Set<String> originalTaskRunToRemove = GraphUtils.successors(graphCluster, Set.of(taskRunId))
                 .stream()
                 .filter(task -> task instanceof AbstractGraphTask)
                 .map(task -> ((AbstractGraphTask) task))
                 .filter(task -> task.getTaskRun() != null)
                 .filter(task -> !task.getTaskRun().getId().equals(taskRunId))
                 .filter(task -> !taskRunToRestart.contains(task.getTaskRun().getId()))
-                .map(s -> mappingTaskRunId.get(s.getTaskRun().getId()))
+                .map(s -> s.getTaskRun().getId())
+                .collect(Collectors.toSet());
+
+            Set<String> taskRunToRemove = originalTaskRunToRemove
+                .stream()
+                .map(mappingTaskRunId::get)
                 .collect(Collectors.toSet());
 
             taskRunToRemove
                 .forEach(r -> newTaskRuns.removeIf(taskRun -> taskRun.getId().equals(r)));
+
+            // Restart non-terminated task runs (e.g., running in parallel) from the previous execution.
+            // We must remap using the original task runs to keep id/parent mapping consistent.
+            List<TaskRun> tasksToRestart = execution.getTaskRunList()
+                .stream()
+                .filter(taskRun -> !taskRunToRestart.contains(taskRun.getId()))
+                .filter(taskRun -> !originalTaskRunToRemove.contains(taskRun.getId()))
+                .filter(taskRun -> !taskRun.getState().isTerminated())
+                .toList();
+
+            Set<String> taskRunToRestartMapped = tasksToRestart
+                .stream()
+                .map(TaskRun::getId)
+                .map(mappingTaskRunId::get)
+                .filter(Objects::nonNull)
+                .collect(Collectors.toSet());
+
+            newTaskRuns.removeIf(taskRun -> taskRunToRestartMapped.contains(taskRun.getId()));
+
+            for (TaskRun originalTaskRun : tasksToRestart) {
+                TaskRun restartedTaskRun = this.mapTaskRun(
+                    flow,
+                    originalTaskRun,
+                    mappingTaskRunId,
+                    newExecutionId,
+                    State.Type.RESTARTED,
+                    true
+                );
+                newTaskRuns.add(restartedTaskRun);
+            }
 
             // Worker task, we need to remove all child in order to be restarted
             this.removeWorkerTask(flow, execution, taskRunToRestart, mappingTaskRunId)

--- a/core/src/test/java/io/kestra/core/runners/ExecutionServiceTest.java
+++ b/core/src/test/java/io/kestra/core/runners/ExecutionServiceTest.java
@@ -240,6 +240,33 @@ class ExecutionServiceTest {
     }
 
     @Test
+    @LoadFlows({"flows/valids/parallel-nested.yaml"})
+    void replayParallelRestartsRunningSibling() throws Exception {
+        Execution execution = runnerUtils.runOne(MAIN_TENANT, "io.kestra.tests", "parallel-nested");
+        assertThat(execution.getTaskRunList()).hasSize(11);
+        assertThat(execution.getState().getCurrent()).isEqualTo(State.Type.SUCCESS);
+
+        TaskRun replayTarget = execution.findTaskRunByTaskIdAndValue("1-3-2_par", List.of());
+        TaskRun runningSibling = execution.findTaskRunByTaskIdAndValue("1-3-3_end", List.of());
+
+        Execution executionWithRunningSibling = execution.withTaskRunList(
+            execution.getTaskRunList()
+                .stream()
+                .map(taskRun -> taskRun.getId().equals(runningSibling.getId())
+                    ? taskRun.withState(State.Type.RUNNING)
+                    : taskRun)
+                .toList()
+        );
+
+        Execution restart = executionService.replay(executionWithRunningSibling, replayTarget.getId(), null);
+
+        TaskRun restartedSibling = restart.findTaskRunByTaskIdAndValue("1-3-3_end", List.of());
+        assertThat(restartedSibling.getState().getCurrent()).isEqualTo(State.Type.RESTARTED);
+        assertThat(restartedSibling.getId()).isNotEqualTo(runningSibling.getId());
+        assertThat(restart.getLabels()).contains(new Label(Label.REPLAY, "true"));
+    }
+
+    @Test
     @ExecuteFlow(value = "flows/valids/each-sequential-nested.yaml", tenantId = TENANT_2)
     void replayEachSeq(Execution execution) throws Exception {
         assertThat(execution.getTaskRunList()).hasSize(23);


### PR DESCRIPTION
Closes  #11223

**Description**  
When replaying a single task inside a Parallel/DAG, non‑terminated sibling task runs from the previous execution were inherited as RUNNING in the new execution. These task runs are never rescheduled, so the execution can get stuck in RUNNING.  
This change restarts those non‑terminated siblings by remapping their original task runs to new taskRunIds and marking them RESTARTED.

**Behavior Change**  
Replay now restarts any non‑terminated sibling task runs (not part of the replay subtree), instead of inheriting them as RUNNING.

**Tests**  
`./gradlew :core:test --tests io.kestra.core.runners.ExecutionServiceTest.replayParallelRestartsRunningSibling`  