### PR TITLE
fix(core): register Gauge in AbstractMetricEntry JsonSubTypes

### DIFF
--- a/core/src/main/java/io/kestra/core/models/executions/AbstractMetricEntry.java
+++ b/core/src/main/java/io/kestra/core/models/executions/AbstractMetricEntry.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.google.common.collect.ImmutableMap;
 import io.kestra.core.metrics.MetricRegistry;
 import io.kestra.core.models.executions.metrics.Counter;
+import io.kestra.core.models.executions.metrics.Gauge;
 import io.kestra.core.models.executions.metrics.Timer;
 import io.micronaut.core.annotation.Introspected;
 import jakarta.annotation.Nullable;
@@ -24,6 +25,7 @@ import jakarta.validation.constraints.NotNull;
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type", visible = true, include = JsonTypeInfo.As.EXISTING_PROPERTY)
 @JsonSubTypes({
     @JsonSubTypes.Type(value = Counter.class, name = "counter"),
+    @JsonSubTypes.Type(value = Gauge.class, name = "gauge"),
     @JsonSubTypes.Type(value = Timer.class, name = "timer"),
 })
 @ToString

--- a/core/src/test/java/io/kestra/core/models/executions/AbstractMetricEntryTest.java
+++ b/core/src/test/java/io/kestra/core/models/executions/AbstractMetricEntryTest.java
@@ -1,0 +1,53 @@
+package io.kestra.core.models.executions;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.kestra.core.models.executions.metrics.Counter;
+import io.kestra.core.models.executions.metrics.Gauge;
+import io.kestra.core.models.executions.metrics.Timer;
+import io.kestra.core.serializers.JacksonMapper;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class AbstractMetricEntryTest {
+    private static final ObjectMapper MAPPER = JacksonMapper.ofJson();
+
+    @Test
+    void shouldDeserializeCounter() throws JsonProcessingException {
+        Counter counter = Counter.of("my.counter", "A counter", 42D);
+        String json = MAPPER.writeValueAsString(counter);
+        AbstractMetricEntry<?> deserialized = MAPPER.readValue(json, AbstractMetricEntry.class);
+
+        assertThat(deserialized).isInstanceOf(Counter.class);
+        assertThat(deserialized.getType()).isEqualTo("counter");
+        assertThat(deserialized.getName()).isEqualTo("my.counter");
+        assertThat(((Counter) deserialized).getValue()).isEqualTo(42D);
+    }
+
+    @Test
+    void shouldDeserializeTimer() throws JsonProcessingException {
+        Timer timer = Timer.of("my.timer", "A timer", Duration.ofSeconds(5));
+        String json = MAPPER.writeValueAsString(timer);
+        AbstractMetricEntry<?> deserialized = MAPPER.readValue(json, AbstractMetricEntry.class);
+
+        assertThat(deserialized).isInstanceOf(Timer.class);
+        assertThat(deserialized.getType()).isEqualTo("timer");
+        assertThat(deserialized.getName()).isEqualTo("my.timer");
+        assertThat(((Timer) deserialized).getValue()).isEqualTo(Duration.ofSeconds(5));
+    }
+
+    @Test
+    void shouldDeserializeGauge() throws JsonProcessingException {
+        Gauge gauge = Gauge.of("my.gauge", "A gauge", 99.5D);
+        String json = MAPPER.writeValueAsString(gauge);
+        AbstractMetricEntry<?> deserialized = MAPPER.readValue(json, AbstractMetricEntry.class);
+
+        assertThat(deserialized).isInstanceOf(Gauge.class);
+        assertThat(deserialized.getType()).isEqualTo("gauge");
+        assertThat(deserialized.getName()).isEqualTo("my.gauge");
+        assertThat(((Gauge) deserialized).getValue()).isEqualTo(99.5D);
+    }
+}

--- a/core/src/test/java/io/kestra/core/runners/RunContextTest.java
+++ b/core/src/test/java/io/kestra/core/runners/RunContextTest.java
@@ -13,6 +13,7 @@ import io.kestra.core.models.executions.Execution;
 import io.kestra.core.models.executions.LogEntry;
 import io.kestra.core.models.executions.TaskRun;
 import io.kestra.core.models.executions.metrics.Counter;
+import io.kestra.core.models.executions.metrics.Gauge;
 import io.kestra.core.models.executions.metrics.Timer;
 import io.kestra.core.models.flows.Flow;
 import io.kestra.core.models.flows.State;
@@ -213,6 +214,12 @@ class RunContextTest {
         runContext.metric(Counter.of("counter", 123D, "key", "value"));
         runContext.metric(Timer.of("duration", Duration.ofSeconds(123), "key", "value"));
 
+        Gauge gauge = Gauge.of("gauge", "Some gauge", 50D);
+        runContext.metric(gauge);
+        runContext.metric(Gauge.of("gauge", "Some gauge", 75D));
+
+        runContext.metric(Gauge.of("gauge", 99D, "key", "value"));
+
         assertThat(runContext.metrics().get(runContext.metrics().indexOf(counter)).getValue()).isEqualTo(42D);
         assertThat(metricRegistry.counter("counter", null).count()).isEqualTo(42D);
         assertThat(runContext.metrics().get(runContext.metrics().indexOf(timer)).getValue()).isEqualTo(Duration.ofSeconds(42));
@@ -223,6 +230,12 @@ class RunContextTest {
 
         assertThat(runContext.metrics().get(3).getValue()).isEqualTo(Duration.ofSeconds(123));
         assertThat(runContext.metrics().get(3).getTags().size()).isEqualTo(1);
+
+        // Gauge replaces value rather than accumulating
+        assertThat(runContext.metrics().get(runContext.metrics().indexOf(gauge)).getValue()).isEqualTo(75D);
+
+        assertThat(runContext.metrics().get(5).getValue()).isEqualTo(99D);
+        assertThat(runContext.metrics().get(5).getTags().size()).isEqualTo(1);
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Register `Gauge.class` in the `@JsonSubTypes` annotation on `AbstractMetricEntry` so Jackson can deserialize `"type": "gauge"` metrics
- `Gauge.java` existed since v1.2.7 but was never wired into the polymorphic type resolver, causing `InvalidTypeIdException` when script tasks emit gauge metrics

## Changes
- **`AbstractMetricEntry.java`** — added `@JsonSubTypes.Type(value = Gauge.class, name = "gauge")`
- **`AbstractMetricEntryTest.java`** (new) — Jackson round-trip serialization tests for Counter, Timer, and Gauge
- **`RunContextTest.metricsIncrement`** — added Gauge coverage alongside existing Counter/Timer assertions

## Test plan
- [x] `AbstractMetricEntryTest` — verifies JSON deserialization of all three metric types (this would have caught the bug)
- [x] `RunContextTest.metricsIncrement` — verifies Gauge works in RunContext alongside Counter and Timer
- [x] `./gradlew :core:compileJava` passes
- [x] Both test classes pass locally

Closes https://github.com/kestra-io/kestra/issues/XXXXX

🤖 Generated with [Claude Code](https://claude.com/claude-code)