### PR TITLE
fix(build): replace Copy task with plain task for generateOpenapiSpec

### DIFF
--- a/webserver/build.gradle
+++ b/webserver/build.gradle
@@ -53,13 +53,17 @@ tasks.withType(JavaCompile).configureEach {
         "-Amicronaut.openapi.expand.version=${project.version}"
     ]
 }
-tasks.register('generateOpenapiSpec', Copy) {
-    def compileJavaProvider = tasks.named('compileJava')
+tasks.register('generateOpenapiSpec') {
+    dependsOn tasks.named('compileJava')
     def openapiSpecPath = project.layout.buildDirectory.file("classes/java/main/META-INF/swagger/kestra.yml")
+    def outputFile = file("${project.getParent().projectDir}/openapi.yml")
 
-    from(compileJavaProvider.map(compileTask -> compileTask.outputs.files.filter{File f -> f == file(openapiSpecPath)}.singleFile))
-    into file("${project.getParent().projectDir}")
-    rename { 'openapi.yml' }
+    inputs.file(openapiSpecPath)
+    outputs.file(outputFile)
+
+    doLast {
+        outputFile.bytes = openapiSpecPath.get().asFile.bytes
+    }
 }
 
 tasks.named('jar', Jar) {


### PR DESCRIPTION
Gradle 9.4 treats the `into` directory of a Copy task as a declared output. Since generateOpenapiSpec copied into the root project directory, Gradle inferred that this task owned the entire project tree, causing implicit dependency errors for every task in every module (jar, processResources, compileJava, sourcesJar, etc.).

Switching to a plain task with explicit inputs/outputs scoped to the single openapi.yml file eliminates the false ownership claim.