### PR TITLE
ci: fix remote cache path

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -7,7 +7,7 @@ buildCache {
     remote(develocity.buildCache) {
         enabled = true
         push = isCI
-        path = "kestra_wip"// TODO remove this once kestra_wip is merged to develop
+        path = "/cache/kestra_wip"// TODO remove this once kestra_wip is merged to develop
     }
 }
 develocity {


### PR DESCRIPTION
it needs to start by /cache/* to work with develocity
