### PR TITLE
feat(worker): forward cluster events to gRPC workers via unified events field

### DIFF
--- a/core/src/main/java/io/kestra/core/worker/WorkerBroadcastEvent.java
+++ b/core/src/main/java/io/kestra/core/worker/WorkerBroadcastEvent.java
@@ -1,0 +1,21 @@
+package io.kestra.core.worker;
+
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import io.kestra.core.models.executions.ExecutionKilled;
+import io.kestra.core.server.ClusterEvent;
+
+/**
+ * Polymorphic event type for broadcasting events to gRPC workers.
+ */
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
+@JsonSubTypes({
+    @JsonSubTypes.Type(value = WorkerBroadcastEvent.KillEvent.class, name = "executionKilled"),
+    @JsonSubTypes.Type(value = WorkerBroadcastEvent.ClusterBroadcast.class, name = "clusterEvent")
+})
+public sealed interface WorkerBroadcastEvent {
+    
+    record KillEvent(ExecutionKilled payload) implements WorkerBroadcastEvent {}
+    
+    record ClusterBroadcast(ClusterEvent payload) implements WorkerBroadcastEvent {}
+}

--- a/worker-controller/src/main/java/io/kestra/controller/grpc/services/WorkerJobDispatcher.java
+++ b/worker-controller/src/main/java/io/kestra/controller/grpc/services/WorkerJobDispatcher.java
@@ -8,7 +8,6 @@ import io.kestra.controller.grpc.WorkerJobPayload;
 import io.kestra.controller.grpc.WorkerJobResponse;
 import io.kestra.controller.messages.MessageFormats;
 import io.kestra.controller.messages.RequestOrResponseHeaderFactory;
-import io.kestra.core.events.EventId;
 import io.kestra.core.exceptions.DeserializationException;
 import io.kestra.core.executor.WorkerJobRunningStateStore;
 import io.kestra.core.models.executions.ExecutionKilled;
@@ -24,12 +23,14 @@ import io.kestra.core.queues.KeyedDispatchQueueInterface;
 import io.kestra.core.queues.QueueException;
 import io.kestra.core.queues.QueueSubscriber;
 import io.kestra.core.runners.*;
+import io.kestra.core.server.ClusterEvent;
 import io.kestra.core.scheduler.events.TriggerEvaluated;
-import io.kestra.core.scheduler.events.TriggerEvent;
 import io.kestra.core.scheduler.events.TriggerReceived;
 import io.kestra.core.scheduler.queue.TriggerEventQueue;
 import io.kestra.core.serializers.JacksonMapper;
 import io.kestra.core.utils.Either;
+import io.kestra.core.worker.WorkerBroadcastEvent;
+import io.micronaut.core.annotation.Nullable;
 import jakarta.annotation.PreDestroy;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
@@ -38,7 +39,6 @@ import lombok.extern.slf4j.Slf4j;
 import javax.annotation.concurrent.ThreadSafe;
 import java.io.IOException;
 import java.time.Duration;
-import java.time.Instant;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
@@ -122,11 +122,17 @@ public class WorkerJobDispatcher {
      */
     private volatile QueueSubscriber<ExecutionKilled> killQueueSubscriber;
 
+    /**
+     * Subscription to the cluster event broadcast queue.
+     */
+    private volatile QueueSubscriber<ClusterEvent> clusterEventSubscriber;
+
     @Inject
     public WorkerJobDispatcher(
         KeyedDispatchQueueInterface<WorkerJobEvent> workerJobEventQueue,
         WorkerJobRunningStateStore workerJobRunningStateStore,
         BroadcastQueueInterface<ExecutionKilled> executionKilledQueue,
+        @Nullable BroadcastQueueInterface<ClusterEvent> clusterEventQueue,
         DispatchQueueInterface<WorkerTaskResult> workerTaskResultQueue,
         TriggerEventQueue triggerEventQueue) {
         this.workerJobEventQueue = workerJobEventQueue;
@@ -146,6 +152,18 @@ public class WorkerJobDispatcher {
                 onExecutionKilled(killed);
             }
         });
+
+        // Subscribe to cluster events to forward them to gRPC workers
+        if (clusterEventQueue != null) {
+            this.clusterEventSubscriber = clusterEventQueue.subscriber();
+            this.clusterEventSubscriber.subscribe(either -> {
+                if (either.isRight()) {
+                    log.error("Deserialization error for ClusterEvent: {}", either.getRight().getMessage());
+                    return;
+                }
+                onClusterEvent(either.getLeft());
+            });
+        }
     }
 
     /**
@@ -158,20 +176,47 @@ public class WorkerJobDispatcher {
             log.info("Received execution killed event for execution '{}'", killedExecution.getExecutionId());
         }
 
-        // Serialize the kill command
-        ByteString killData = MessageFormats.JSON.toByteString(killed);
+        broadcastEvent(new WorkerBroadcastEvent.KillEvent(killed), "kill command");
+    }
 
-        // Broadcast to all connected workers
+    /**
+     * Cluster event types that should NOT be forwarded to gRPC workers.
+     */
+    private static final Set<ClusterEvent.EventType> EXCLUDED_EVENT_TYPES = Set.of(
+        ClusterEvent.EventType.MAINTENANCE_ENTER,
+        ClusterEvent.EventType.MAINTENANCE_EXIT,
+        ClusterEvent.EventType.KILL_SWITCH_SYNC_REQUESTED
+    );
+
+    /**
+     * Handles a cluster event from the broadcast queue and forwards it to all connected workers.
+     * Maintenance and executor-only events are excluded.
+     */
+    private void onClusterEvent(ClusterEvent event) {
+        if (EXCLUDED_EVENT_TYPES.contains(event.eventType())) {
+            log.debug("Skipping cluster event not relevant to workers: type={}", event.eventType());
+            return;
+        }
+        log.info("Received cluster event: type={}, message={}", event.eventType(), event.message());
+        broadcastEvent(new WorkerBroadcastEvent.ClusterBroadcast(event), "cluster event");
+    }
+
+    /**
+     * Broadcasts a {@link WorkerBroadcastEvent} to all connected workers via the events field.
+     */
+    private void broadcastEvent(WorkerBroadcastEvent event, String description) {
+        ByteString eventData = MessageFormats.JSON.toByteString(event);
+
         activeStreams.forEach((workerId, context) -> {
             try {
                 WorkerJobResponse response = WorkerJobResponse.newBuilder()
                     .setHeader(RequestOrResponseHeaderFactory.create(workerId))
-                    .addKillCommands(killData)
+                    .addEvents(eventData)
                     .build();
                 context.sendResponse(response);
-                log.debug("Broadcast kill command to worker {}", workerId);
+                log.debug("Broadcast {} to worker {}", description, workerId);
             } catch (Exception e) {
-                log.warn("Failed to send kill command to worker {}: {}", workerId, e.getMessage());
+                log.warn("Failed to send {} to worker {}: {}", description, workerId, e.getMessage());
             }
         });
     }
@@ -577,6 +622,15 @@ public class WorkerJobDispatcher {
                 killQueueSubscriber.close();
             } catch (Exception e) {
                 log.warn("Error closing kill queue subscription: {}", e.getMessage());
+            }
+        }
+
+        // Close cluster event queue subscription
+        if (clusterEventSubscriber != null) {
+            try {
+                clusterEventSubscriber.close();
+            } catch (Exception e) {
+                log.warn("Error closing cluster event queue subscription: {}", e.getMessage());
             }
         }
 

--- a/worker-controller/src/main/proto/worker_controller.proto
+++ b/worker-controller/src/main/proto/worker_controller.proto
@@ -58,8 +58,8 @@ message WorkerJobResponse {
   // List of jobs to execute (may be empty if no jobs available)
   repeated WorkerJobPayload jobs = 2;
 
-  // Serialized ExecutionKilled commands (JSON format) to be processed by the worker
-  repeated bytes killCommands = 3;
+  // Serialized WorkerBroadcastEvent (JSON format) — carries ExecutionKilled, ClusterEvent, etc.
+  repeated bytes events = 3;
 }
 
 // Individual job payload

--- a/worker-controller/src/test/java/io/kestra/controller/grpc/services/WorkerJobDispatcherTest.java
+++ b/worker-controller/src/test/java/io/kestra/controller/grpc/services/WorkerJobDispatcherTest.java
@@ -5,6 +5,7 @@ import io.kestra.controller.grpc.WorkerJobResponse;
 import io.kestra.core.exceptions.DeserializationException;
 import io.kestra.core.executor.WorkerJobRunningStateStore;
 import io.kestra.core.models.executions.ExecutionKilled;
+import io.kestra.core.contexts.KestraContext;
 import io.kestra.core.queues.BroadcastQueueInterface;
 import io.kestra.core.queues.DispatchQueueInterface;
 import io.kestra.core.queues.KeyedDispatchQueueInterface;
@@ -16,6 +17,7 @@ import io.kestra.core.models.executions.TaskRun;
 import io.kestra.core.runners.WorkerTask;
 import io.kestra.core.runners.WorkerTaskResult;
 import io.kestra.core.scheduler.queue.TriggerEventQueue;
+import io.kestra.core.server.ClusterEvent;
 import io.kestra.core.utils.Either;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -23,6 +25,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
@@ -53,19 +56,28 @@ class WorkerJobDispatcherTest {
     @SuppressWarnings("unchecked")
     private BroadcastQueueInterface<ExecutionKilled> mockKillQueue = mock(BroadcastQueueInterface.class);
     @SuppressWarnings("unchecked")
+    private BroadcastQueueInterface<ClusterEvent> mockClusterEventQueue = mock(BroadcastQueueInterface.class);
+    @SuppressWarnings("unchecked")
     private DispatchQueueInterface<WorkerTaskResult> mockResultQueue = mock(DispatchQueueInterface.class);
     private WorkerJobDispatcher dispatcher;
     private TriggerEventQueue mockTriggerEventQueue = mock(TriggerEventQueue.class);
 
     // Captures for verifying interactions
     private List<MockQueueSubscriber> createdSubscribers;
+    private Consumer<Either<ClusterEvent, DeserializationException>> clusterEventConsumer;
 
     @SuppressWarnings("unchecked")
     @BeforeEach
     void setUp() {
+        // Initialize KestraContext for RequestOrResponseHeaderFactory
+        KestraContext testContext = mock(KestraContext.class);
+        when(testContext.getVersion()).thenReturn("1.0.0-test");
+        KestraContext.setContext(testContext);
+
         mockQueue = mock(KeyedDispatchQueueInterface.class);
         mockStateStore = mock(WorkerJobRunningStateStore.class);
         mockKillQueue = mock(BroadcastQueueInterface.class);
+        mockClusterEventQueue = mock(BroadcastQueueInterface.class);
         mockResultQueue = mock(DispatchQueueInterface.class);
         mockTriggerEventQueue = mock(TriggerEventQueue.class);
         createdSubscribers = new ArrayList<>();
@@ -76,6 +88,15 @@ class WorkerJobDispatcherTest {
         when(killSubscriber.subscribe(any())).thenReturn(killSubscriber);
         when(mockKillQueue.subscriber()).thenReturn(killSubscriber);
 
+        // Mock cluster event queue subscriber and capture the consumer
+        @SuppressWarnings("unchecked")
+        QueueSubscriber<ClusterEvent> clusterEventSubscriber = mock(QueueSubscriber.class);
+        when(clusterEventSubscriber.subscribe(any())).thenAnswer(invocation -> {
+            clusterEventConsumer = invocation.getArgument(0);
+            return clusterEventSubscriber;
+        });
+        when(mockClusterEventQueue.subscriber()).thenReturn(clusterEventSubscriber);
+
         // Create mock subscribers for each group
         when(mockQueue.subscriber(anyString())).thenAnswer(invocation -> {
             String group = invocation.getArgument(0);
@@ -84,7 +105,7 @@ class WorkerJobDispatcherTest {
             return subscriber;
         });
 
-        dispatcher = new WorkerJobDispatcher(mockQueue, mockStateStore, mockKillQueue, mockResultQueue, mockTriggerEventQueue);
+        dispatcher = new WorkerJobDispatcher(mockQueue, mockStateStore, mockKillQueue, mockClusterEventQueue, mockResultQueue, mockTriggerEventQueue);
     }
 
     @AfterEach
@@ -338,15 +359,11 @@ class WorkerJobDispatcherTest {
             // When - simulate job from queue
             subscriber.deliverJob(event);
 
-            // Then - verify dispatch was attempted (state store save is called before send)
-            // Note: In unit tests without Kestra context, the actual send fails and triggers
-            // handleDispatchFailure which restores permits and re-queues. We verify the
-            // dispatch was attempted by checking the state store was called.
+            // Then - verify job was persisted and sent to worker
             verify(mockStateStore).save(any(), any());
-
-            // After dispatch failure, permit is restored and job is re-queued
-            // Verify re-queue happened due to send failure
-            verify(mockQueue).emit(eq(WORKER_GROUP_A), eq(event));
+            verify(context.getResponseObserver()).onNext(any(WorkerJobResponse.class));
+            assertThat(context.getInFlightCount()).isEqualTo(1);
+            assertThat(context.getAvailablePermits()).isEqualTo(4);
         }
 
         @Test
@@ -370,15 +387,15 @@ class WorkerJobDispatcherTest {
             // When
             subscriber.deliverJob(event);
 
-            // Then - verify dispatch was attempted (state store save)
-            // Worker-2 should be selected (lower in-flight count), which we can verify
-            // by checking that state store save was called.
-            // Note: In unit tests, the actual send fails and handleDispatchFailure is called,
-            // but we can verify the worker selection logic worked by checking save was called.
+            // Then - verify dispatch went to worker-2 (lower in-flight count)
             verify(mockStateStore).save(any(), any());
+            verify(context2.getResponseObserver()).onNext(any(WorkerJobResponse.class));
+            verify(context1.getResponseObserver(), never()).onNext(any(WorkerJobResponse.class));
 
             // Worker-1 should still have its 2 original in-flight jobs
             assertThat(context1.getInFlightCount()).isEqualTo(2);
+            // Worker-2 should now have 1 in-flight job
+            assertThat(context2.getInFlightCount()).isEqualTo(1);
         }
 
         @Test
@@ -401,7 +418,7 @@ class WorkerJobDispatcherTest {
         }
 
         @Test
-        void shouldPauseAfterLastPermit() throws QueueException {
+        void shouldPauseAfterLastPermit() {
             // Given
             WorkerStreamContext<WorkerJobResponse> context = createWorkerContext("worker-1", WORKER_GROUP_A, 10);
             context.addPermits(1); // Only one permit
@@ -413,19 +430,11 @@ class WorkerJobDispatcherTest {
             // When
             subscriber.deliverJob(event);
 
-            // Then - verify dispatch was attempted and pause behavior
-            // Note: In unit tests, the send fails but we can verify:
-            // 1. State store save was called (dispatch was attempted)
-            // 2. After the (failed) dispatch attempt, subscription should be paused
-            //    because we started with only 1 permit
+            // Then - job was dispatched and subscription paused after last permit consumed
             verify(mockStateStore).save(any(), any());
-
-            // The subscription should be paused after consuming the last permit,
-            // even though the dispatch ultimately fails and restores the permit.
-            // The pause happens in handleIncomingJob BEFORE handleDispatchFailure restores it.
-            // However, handleDispatchFailure may resume if permits > 0 after restore.
-            // Let's verify the dispatch was attempted:
-            verify(mockQueue).emit(eq(WORKER_GROUP_A), eq(event)); // Job was re-queued after send failure
+            verify(context.getResponseObserver()).onNext(any(WorkerJobResponse.class));
+            assertThat(context.getAvailablePermits()).isEqualTo(0);
+            assertThat(subscriber.isPaused.get()).isTrue();
         }
     }
 
@@ -616,6 +625,104 @@ class WorkerJobDispatcherTest {
             dispatcher.close();
             dispatcher.close();
         }
+    }
+
+    @Test
+    void shouldForwardNonMaintenanceClusterEventsToWorkers() {
+        // Given
+        WorkerStreamContext<WorkerJobResponse> context = createWorkerContext("worker-1", WORKER_GROUP_A, 10);
+        dispatcher.registerWorker(context);
+
+        ClusterEvent event = new ClusterEvent(
+            ClusterEvent.EventType.PLUGINS_SYNC_REQUESTED,
+            LocalDateTime.now(),
+            "test plugin sync"
+        );
+
+        // When
+        clusterEventConsumer.accept(Either.left(event));
+
+        // Then — verify the event was sent to the worker's stream observer
+        verify(context.getResponseObserver()).onNext(any(WorkerJobResponse.class));
+    }
+
+    @Test
+    void shouldFilterOutMaintenanceEnterEvents() {
+        // Given
+        WorkerStreamContext<WorkerJobResponse> context = createWorkerContext("worker-1", WORKER_GROUP_A, 10);
+        dispatcher.registerWorker(context);
+
+        ClusterEvent maintenanceEvent = new ClusterEvent(
+            ClusterEvent.EventType.MAINTENANCE_ENTER,
+            LocalDateTime.now(),
+            "entering maintenance"
+        );
+
+        // When
+        clusterEventConsumer.accept(Either.left(maintenanceEvent));
+
+        // Then — maintenance events should NOT be forwarded (they use heartbeat path)
+        verify(context.getResponseObserver(), never()).onNext(any(WorkerJobResponse.class));
+    }
+
+    @Test
+    void shouldFilterOutMaintenanceExitEvents() {
+        // Given
+        WorkerStreamContext<WorkerJobResponse> context = createWorkerContext("worker-1", WORKER_GROUP_A, 10);
+        dispatcher.registerWorker(context);
+
+        ClusterEvent maintenanceEvent = new ClusterEvent(
+            ClusterEvent.EventType.MAINTENANCE_EXIT,
+            LocalDateTime.now(),
+            "exiting maintenance"
+        );
+
+        // When
+        clusterEventConsumer.accept(Either.left(maintenanceEvent));
+
+        // Then — maintenance events should NOT be forwarded (they use heartbeat path)
+        verify(context.getResponseObserver(), never()).onNext(any(WorkerJobResponse.class));
+    }
+
+    @Test
+    void shouldFilterOutKillSwitchSyncEvents() {
+        // Given
+        WorkerStreamContext<WorkerJobResponse> context = createWorkerContext("worker-1", WORKER_GROUP_A, 10);
+        dispatcher.registerWorker(context);
+
+        ClusterEvent killSwitchEvent = new ClusterEvent(
+            ClusterEvent.EventType.KILL_SWITCH_SYNC_REQUESTED,
+            LocalDateTime.now(),
+            "kill switch sync"
+        );
+
+        // When
+        clusterEventConsumer.accept(Either.left(killSwitchEvent));
+
+        // Then — executor-only events should NOT be forwarded to workers
+        verify(context.getResponseObserver(), never()).onNext(any(WorkerJobResponse.class));
+    }
+
+    @Test
+    void shouldBroadcastClusterEventsToAllConnectedWorkers() {
+        // Given
+        WorkerStreamContext<WorkerJobResponse> context1 = createWorkerContext("worker-1", WORKER_GROUP_A, 10);
+        WorkerStreamContext<WorkerJobResponse> context2 = createWorkerContext("worker-2", WORKER_GROUP_B, 10);
+        dispatcher.registerWorker(context1);
+        dispatcher.registerWorker(context2);
+
+        ClusterEvent event = new ClusterEvent(
+            ClusterEvent.EventType.PLUGINS_SYNC_REQUESTED,
+            LocalDateTime.now(),
+            "plugin sync for all"
+        );
+
+        // When
+        clusterEventConsumer.accept(Either.left(event));
+
+        // Then — both workers should receive the event
+        verify(context1.getResponseObserver()).onNext(any(WorkerJobResponse.class));
+        verify(context2.getResponseObserver()).onNext(any(WorkerJobResponse.class));
     }
 
     /**

--- a/worker/src/main/java/io/kestra/worker/fetchers/WorkerJobFetcher.java
+++ b/worker/src/main/java/io/kestra/worker/fetchers/WorkerJobFetcher.java
@@ -10,14 +10,18 @@ import io.kestra.controller.grpc.WorkerJobRequest;
 import io.kestra.controller.grpc.WorkerJobResponse;
 import io.kestra.controller.messages.MessageFormats;
 import io.kestra.controller.messages.RequestOrResponseHeaderFactory;
-import io.kestra.core.models.executions.ExecutionKilled;
 import io.kestra.core.models.tasks.WorkerGroup;
+import io.kestra.core.queues.BroadcastQueueInterface;
+import io.kestra.core.queues.QueueException;
+import io.kestra.core.worker.WorkerBroadcastEvent;
 import io.kestra.core.runners.WorkerJob;
+import io.kestra.core.server.ClusterEvent;
 import io.kestra.core.worker.models.WorkerContext;
 import io.kestra.worker.services.ExecutionKilledManager;
 import io.kestra.worker.WorkerLoop;
 import io.kestra.worker.queues.WorkerQueue;
 import io.kestra.worker.queues.WorkerQueueRegistry;
+import io.micronaut.core.annotation.Nullable;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 import lombok.extern.slf4j.Slf4j;
@@ -71,6 +75,7 @@ public class WorkerJobFetcher extends WorkerLoop {
     private final WorkerControllerServiceStub workerControllerServiceStub;
     private final WorkerQueueRegistry workerQueueRegistry;
     private final ExecutionKilledManager executionKilledManager;
+    private final BroadcastQueueInterface<ClusterEvent> clusterEventQueue;
 
     private WorkerQueue<WorkerJob> workerJobQueue;
     private WorkerContext workerContext;
@@ -113,15 +118,19 @@ public class WorkerJobFetcher extends WorkerLoop {
      *
      * @param workerControllerServiceStub the gRPC worker controller service stub.
      * @param workerQueueRegistry         the worker queue registry.
+     * @param executionKilledManager      the execution killed manager.
+     * @param clusterEventQueue           the local cluster event broadcast queue for re-emitting events received from the controller.
      */
     @Inject
     public WorkerJobFetcher(final WorkerControllerServiceStub workerControllerServiceStub,
                             final WorkerQueueRegistry workerQueueRegistry,
-                            final ExecutionKilledManager executionKilledManager) {
+                            final ExecutionKilledManager executionKilledManager,
+                            @Nullable final BroadcastQueueInterface<ClusterEvent> clusterEventQueue) {
         super(WorkerJobFetcher.class.getSimpleName());
         this.workerQueueRegistry = workerQueueRegistry;
         this.workerControllerServiceStub = workerControllerServiceStub;
         this.executionKilledManager = executionKilledManager;
+        this.clusterEventQueue = clusterEventQueue;
     }
 
     /**
@@ -261,13 +270,26 @@ public class WorkerJobFetcher extends WorkerLoop {
             return;
         }
 
-        // Process kill commands
-        for (ByteString killData : response.getKillCommandsList()) {
+        // Process broadcast events (kill commands, cluster events, etc.)
+        for (ByteString eventData : response.getEventsList()) {
             try {
-                ExecutionKilled killed = MessageFormats.JSON.fromByteString(killData, ExecutionKilled.class);
-                executionKilledManager.onKillReceived(killed);
+                WorkerBroadcastEvent event = MessageFormats.JSON.fromByteString(eventData, WorkerBroadcastEvent.class);
+                switch (event) {
+                    case WorkerBroadcastEvent.KillEvent killEvent ->
+                        executionKilledManager.onKillReceived(killEvent.payload());
+                    case WorkerBroadcastEvent.ClusterBroadcast clusterBroadcast -> {
+                        if (clusterEventQueue != null) {
+                            log.debug("Received cluster event via gRPC: type={}", clusterBroadcast.payload().eventType());
+                            clusterEventQueue.emit(clusterBroadcast.payload());
+                        } else {
+                            log.warn("Received cluster event but no BroadcastQueue<ClusterEvent> is available, ignoring: type={}", clusterBroadcast.payload().eventType());
+                        }
+                    }
+                }
+            } catch (QueueException e) {
+                log.error("Error emitting cluster event to local queue: {}", e.getMessage(), e);
             } catch (Exception e) {
-                log.error("Error processing kill command: {}", e.getMessage(), e);
+                log.error("Error processing broadcast event: {}", e.getMessage(), e);
             }
         }
 
@@ -291,7 +313,7 @@ public class WorkerJobFetcher extends WorkerLoop {
         }
 
         // Send ACKs and request more permits based on remaining capacity
-        // Only send if there were jobs (kill-only responses don't need permit updates)
+        // Only send if there were jobs (event-only responses don't need permit updates)
         if (!acks.isEmpty()) {
             sendPermitsAndAcks(observer, calculatePermits(), acks);
         }


### PR DESCRIPTION
Replace the killCommands proto field with a polymorphic events field that carries both ExecutionKilled and ClusterEvent via WorkerBroadcastEvent. This allows cluster events like PLUGINS_SYNC_REQUESTED to reach remote gRPC workers which use an InMemoryBroadcastQueue for ClusterEvent.