### PR TITLE
fix(core): fix GraphUtils.successors() to include error handler tasks

### DIFF
--- a/core/src/main/java/io/kestra/core/utils/GraphUtils.java
+++ b/core/src/main/java/io/kestra/core/utils/GraphUtils.java
@@ -143,9 +143,28 @@ public class GraphUtils {
             .filter(task -> ((AbstractGraphTask) task).getTaskRun() != null && taskRunIds.contains(((AbstractGraphTask) task).getTaskRun().getId()))
             .toList();
 
-        Set<String> edgeUuid = selectedTaskRuns
+        // Collect UIDs of all GraphClusterRoot nodes for efficient lookup
+        Set<String> allClusterRootUids = nodes.stream()
+            .filter(GraphClusterRoot.class::isInstance)
+            .map(AbstractGraph::getUid)
+            .collect(Collectors.toSet());
+
+        // For each selected task, also find the containing cluster's root.
+        // Error handlers are connected to the cluster root (not the task node),
+        // so we must also traverse from root to capture them.
+        Set<String> startingUids = new HashSet<>();
+        for (AbstractGraph task : selectedTaskRuns) {
+            startingUids.add(task.getUid());
+            edges.stream()
+                .filter(edge -> edge.getTarget().equals(task.getUid()))
+                .map(FlowGraph.Edge::getSource)
+                .filter(allClusterRootUids::contains)
+                .forEach(startingUids::add);
+        }
+
+        Set<String> edgeUuid = startingUids
             .stream()
-            .flatMap(task -> recursiveEdge(edges, task.getUid()).stream())
+            .flatMap(uid -> recursiveEdge(edges, uid).stream())
             .map(FlowGraph.Edge::getSource)
             .collect(Collectors.toSet());
 

--- a/core/src/test/java/io/kestra/core/runners/ExecutionServiceTest.java
+++ b/core/src/test/java/io/kestra/core/runners/ExecutionServiceTest.java
@@ -496,6 +496,37 @@ class ExecutionServiceTest {
     }
 
     @Test
+    @LoadFlows({"flows/valids/replay-sequential-with-error-handler.yaml"})
+    void replaySequentialWithErrorHandler() throws Exception {
+        // Given: run the flow — failing-task fails, error-handler runs, sequential fails
+        Execution execution = runnerUtils.runOne(MAIN_TENANT, "io.kestra.tests", "replay-sequential-with-error-handler");
+        assertThat(execution.getState().getCurrent()).isEqualTo(State.Type.FAILED);
+        // task runs: before, sequential, failing-task, error-handler = 4
+        assertThat(execution.getTaskRunList()).hasSize(4);
+
+        String sequentialTaskRunId = execution.findTaskRunByTaskIdAndValue("sequential", List.of()).getId();
+
+        // When: replay from the parent Sequential task
+        Execution replay = executionService.replay(execution, sequentialTaskRunId, null);
+
+        // Then: the stale error-handler task run must be removed
+        assertThat(replay.getState().getCurrent()).isEqualTo(State.Type.RESTARTED);
+        assertThat(replay.getTaskRunList()).hasSize(2); // before + sequential only
+        assertThat(replay.findTaskRunByTaskIdAndValue("sequential", List.of()).getState().getCurrent())
+            .isEqualTo(State.Type.RUNNING);
+        assertThat(replay.getTaskRunList().stream()
+            .noneMatch(tr -> tr.getTaskId().equals("error-handler"))).isTrue();
+
+        // And: the replayed execution should terminate (not hang indefinitely in RUNNING)
+        Execution result = runnerUtils.emitAndAwaitExecution(
+            e -> e.getId().equals(replay.getId()) && e.getState().isTerminated(),
+            replay,
+            Duration.ofSeconds(30)
+        );
+        assertThat(result.getState().getCurrent()).isEqualTo(State.Type.FAILED);
+    }
+
+    @Test
     @LoadFlows({"flows/valids/each-pause.yaml"})
     void killExecutionWithFlowableTask() throws Exception {
         Execution execution = runnerUtils.runOneUntilPaused(MAIN_TENANT, "io.kestra.tests", "each-pause");

--- a/core/src/test/resources/flows/valids/replay-sequential-with-error-handler.yaml
+++ b/core/src/test/resources/flows/valids/replay-sequential-with-error-handler.yaml
@@ -1,0 +1,16 @@
+id: replay-sequential-with-error-handler
+namespace: io.kestra.tests
+
+tasks:
+  - id: before
+    type: io.kestra.plugin.core.debug.Return
+    format: "before"
+  - id: sequential
+    type: io.kestra.plugin.core.flow.Sequential
+    tasks:
+      - id: failing-task
+        type: io.kestra.plugin.core.execution.Fail
+    errors:
+      - id: error-handler
+        type: io.kestra.plugin.core.debug.Return
+        format: "error handled"


### PR DESCRIPTION
Closes kestra-io/kestra-ee#6959