### PR TITLE
chore: update webserver module test forked jvm to have 5g of max heap.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -256,6 +256,7 @@ subprojects {subProj ->
             t.finalizedBy jacocoTestReport
             t.doFirst {
                 logger.lifecycle("[TASK START] ${t.path}")
+                project.develocity.buildScan.value("${t.path}#maxHeapSize", t.maxHeapSize)
             }
             t.doLast {
                 logger.lifecycle("[TASK END]   ${t.path}")

--- a/webserver/build.gradle
+++ b/webserver/build.gradle
@@ -75,3 +75,7 @@ tasks.named('jar', Jar) {
 tasks.named('compileJava') {
     outputs.file(project.layout.buildDirectory.file("classes/java/main/META-INF/swagger/kestra.yml"))
 }
+
+tasks.withType(Test).configureEach { Test t ->
+    maxHeapSize = '5g'
+}


### PR DESCRIPTION
PR description:                                           
  ## Summary
                                                                                                                                                                                                                                                                                                                     
  - Raises `:webserver` test `maxHeapSize` from `4g` → `5g` via a `tasks.withType(Test).configureEach` block in `webserver/build.gradle`, keeping the override co-located with the module
  - Adds `develocity.buildScan.value("${t.path}#maxHeapSize", t.maxHeapSize)` inside the `doFirst` hook of `commonTestConfig` in root `build.gradle`, capturing the **effective** (post-override) heap value for every test task in the build scan  