### PR TITLE
perf(core): improve resolving task runs in Execution and FlowableUtils

### DIFF
--- a/core/src/main/java/io/kestra/core/models/executions/Execution.java
+++ b/core/src/main/java/io/kestra/core/models/executions/Execution.java
@@ -42,6 +42,7 @@ import java.time.ZonedDateTime;
 import java.time.chrono.ChronoZonedDateTime;
 import java.util.*;
 import java.util.function.BiFunction;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import java.util.zip.CRC32;
@@ -562,14 +563,14 @@ public class Execution implements SoftDeletable<Execution>, TenantInterface, Has
             return Collections.emptyList();
         }
 
+        Map<String, List<ResolvedTask>> resolvedTasksByIds = resolvedTasks.stream().collect(Collectors.groupingBy(
+            resolvedTask -> resolvedTask.getTask().getId()
+        ));
+
         return this
             .getTaskRunList()
             .stream()
-            .filter(t -> resolvedTasks
-                .stream()
-                .anyMatch(
-                    resolvedTask -> FlowableUtils.isTaskRunFor(resolvedTask, t, parentTaskRun))
-            )
+            .filter(t -> FlowableUtils.isResolvedTaskFor(t, parentTaskRun, resolvedTasksByIds))
             .toList();
     }
 

--- a/core/src/main/java/io/kestra/core/runners/FlowableUtils.java
+++ b/core/src/main/java/io/kestra/core/runners/FlowableUtils.java
@@ -16,6 +16,7 @@ import io.kestra.plugin.core.flow.Dag;
 
 import java.util.*;
 import java.util.function.BiFunction;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -460,14 +461,13 @@ public class FlowableUtils {
         if (concurrency > 0 && runningCount > concurrency) {
             return Collections.emptyList();
         }
-
+        Map<String, List<TaskRun>> taskRunsByIds = taskRuns.stream().collect(Collectors.groupingBy(
+            TaskRun::getTaskId
+        ));
         // find all not created tasks
         List<ResolvedTask> notFinds = currentTasks
             .stream()
-            .filter(resolvedTask -> taskRuns
-                .stream()
-                .noneMatch(taskRun -> FlowableUtils.isTaskRunFor(resolvedTask, taskRun, parentTaskRun))
-            )
+            .filter(resolvedTask -> !FlowableUtils.isTaskRunFor(resolvedTask, parentTaskRun, taskRunsByIds))
             .toList();
 
         // first created, leave
@@ -565,13 +565,39 @@ public class FlowableUtils {
         return result;
     }
 
-    public static boolean isTaskRunFor(ResolvedTask resolvedTask, TaskRun taskRun, TaskRun parentTaskRun) {
-        return resolvedTask.getTask().getId().equals(taskRun.getTaskId()) &&
-            (
-                parentTaskRun == null || parentTaskRun.getId().equals(taskRun.getParentTaskRunId())
-            ) &&
-            (
-                resolvedTask.getValue() == null || resolvedTask.getValue().equals(taskRun.getValue())
+    public static boolean isResolvedTaskFor(TaskRun taskRun, TaskRun parentTaskRun, Map<String, List<ResolvedTask>> resolvedTasksByIds) {
+        if (parentTaskRun != null && !parentTaskRun.getId().equals(taskRun.getParentTaskRunId())) {
+            return false;
+        }
+
+        List<ResolvedTask> matchingTasks = resolvedTasksByIds.get(taskRun.getTaskId());
+        if (matchingTasks == null) {
+            return false;
+        }
+
+        for (ResolvedTask rt : matchingTasks) {
+            if (rt.getValue() == null || rt.getValue().equals(taskRun.getValue())) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public static boolean isTaskRunFor(ResolvedTask resolvedTask, TaskRun parentTaskRun, Map<String, List<TaskRun>> taskRunsByIds) {
+        List<TaskRun> matchingRuns = taskRunsByIds.get(resolvedTask.getTask().getId());
+        if (matchingRuns == null) {
+            return false;
+        }
+
+        for (TaskRun tr : matchingRuns) {
+            boolean isMatch = (
+                parentTaskRun == null || parentTaskRun.getId().equals(tr.getParentTaskRunId())
+            ) && (
+                resolvedTask.getValue() == null || resolvedTask.getValue().equals(tr.getValue())
             );
+            
+            if (isMatch) return true;
+        }
+        return false;
     }
 }


### PR DESCRIPTION
- findTaskRunByTasks() is extremely important for resolving task runs at executor life cycle but it performs in a brute force way when finding task runs  from resolved tasks performing  in O(T*R) where T is the number of task runs and R is the number of resolved tasks which may perform worse under heavy load
- The proposed change is pre-storing either resolved tasks or task runs in a map by ids using HashMap lookup in O(1) avoiding brute force check turning performance to O(T + R) which is much better under heavy load
- This change enhances performance keeping the readability concern clear by encapsulating the logic into isResolvedTaskFor() and isTaskRunFor() methods 