### PR TITLE
fix(storage-local): handle filenames with spaces and special characters in list/allByPrefix

### DIFF
--- a/storage-local/src/main/java/io/kestra/storage/local/LocalStorage.java
+++ b/storage-local/src/main/java/io/kestra/storage/local/LocalStorage.java
@@ -112,17 +112,16 @@ public class LocalStorage implements StorageInterface {
         Files.walkFileTree(fsPath, new SimpleFileVisitor<>() {
             @Override
             public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attrs) throws IOException {
-                String dirPath = dir.toString().replace("\\", "/");
                 if (includeDirectories) {
-                    uris.add(URI.create(dirPath + "/"));
+                    uris.add(URI.create(dir.toUri().getRawPath() + "/"));
                 }
-                return super.preVisitDirectory(Path.of(dirPath), attrs);
+                return super.preVisitDirectory(dir, attrs);
             }
 
             @Override
             public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) {
                 if (!file.getFileName().toString().endsWith(".metadata")) {
-                    uris.add(URI.create(file.toString().replace("\\", "/")));
+                    uris.add(URI.create(file.toUri().getRawPath()));
                 }
                 return FileVisitResult.CONTINUE;
             }
@@ -135,10 +134,10 @@ public class LocalStorage implements StorageInterface {
             }
         });
 
-        URI fsPathUri = URI.create(fsPath.toString().replace("\\", "/"));
+        URI fsPathUri = URI.create(fsPath.toUri().getRawPath());
         return uris.stream().sorted(Comparator.reverseOrder())
             .map(fsPathUri::relativize)
-            .map(URI::getPath)
+            .map(URI::getRawPath)
             .filter(Predicate.not(String::isEmpty))
             .map(path ->
             {
@@ -160,11 +159,7 @@ public class LocalStorage implements StorageInterface {
                 .filter(path -> !path.getFileName().toString().endsWith(".metadata"))
                 .map(throwFunction(file ->
                 {
-                    URI relative = URI.create(
-                        getLocalPath(tenantId, null).relativize(
-                            Path.of(file.toUri())
-                        ).toString().replace("\\", "/")
-                    );
+                    URI relative = toRelativeUri(getLocalPath(tenantId, null), file);
                     return getAttributes(tenantId, namespace, relative);
                 }))
                 .toList();
@@ -180,17 +175,30 @@ public class LocalStorage implements StorageInterface {
                 .filter(path -> !path.getFileName().toString().endsWith(".metadata"))
                 .map(throwFunction(file ->
                 {
-                    URI relative = URI.create(
-                        getInstancePath(null).relativize(
-                            Path.of(file.toUri())
-                        ).toString().replace("\\", "/")
-                    );
+                    URI relative = toRelativeUri(getInstancePath(null), file);
                     return getInstanceAttributes(namespace, relative);
                 }))
                 .toList();
         } catch (NoSuchFileException e) {
             throw new FileNotFoundException(e.getMessage());
         }
+    }
+
+    /**
+     * Converts a file path to a relative URI against the given base path.
+     * Uses the encoded raw path from file.toUri() to safely handle filenames
+     * containing special characters such as spaces or non-ASCII characters.
+     */
+    private static URI toRelativeUri(Path basePath, Path file) {
+        String baseRawPath = basePath.toUri().getRawPath();
+        if (!baseRawPath.endsWith("/")) {
+            baseRawPath += "/";
+        }
+        String fileRawPath = file.toUri().getRawPath();
+        String encodedRelative = fileRawPath.startsWith(baseRawPath)
+            ? fileRawPath.substring(baseRawPath.length())
+            : fileRawPath;
+        return URI.create(encodedRelative);
     }
 
     @Override

--- a/storage-local/src/main/java/io/kestra/storage/local/LocalStorage.java
+++ b/storage-local/src/main/java/io/kestra/storage/local/LocalStorage.java
@@ -188,6 +188,9 @@ public class LocalStorage implements StorageInterface {
      * Converts a file path to a relative URI against the given base path.
      * Uses the encoded raw path from file.toUri() to safely handle filenames
      * containing special characters such as spaces or non-ASCII characters.
+     *
+     * @throws IllegalArgumentException if the file path is not under the base path,
+     *         preventing path traversal attacks
      */
     private static URI toRelativeUri(Path basePath, Path file) {
         String baseRawPath = basePath.toUri().getRawPath();
@@ -195,10 +198,12 @@ public class LocalStorage implements StorageInterface {
             baseRawPath += "/";
         }
         String fileRawPath = file.toUri().getRawPath();
-        String encodedRelative = fileRawPath.startsWith(baseRawPath)
-            ? fileRawPath.substring(baseRawPath.length())
-            : fileRawPath;
-        return URI.create(encodedRelative);
+        if (!fileRawPath.startsWith(baseRawPath)) {
+            throw new IllegalArgumentException(
+                "File path '" + fileRawPath + "' is not under base path '" + baseRawPath + "'"
+            );
+        }
+        return URI.create(fileRawPath.substring(baseRawPath.length()));
     }
 
     @Override

--- a/storage-local/src/main/java/io/kestra/storage/local/LocalStorage.java
+++ b/storage-local/src/main/java/io/kestra/storage/local/LocalStorage.java
@@ -97,17 +97,16 @@ public class LocalStorage implements StorageInterface {
         Files.walkFileTree(fsPath, new SimpleFileVisitor<>() {
             @Override
             public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attrs) throws IOException {
-                String dirPath = dir.toString().replace("\\", "/");
                 if (includeDirectories) {
-                    uris.add(URI.create(dirPath + "/"));
+                    uris.add(URI.create(dir.toUri().getRawPath() + "/"));
                 }
-                return super.preVisitDirectory(Path.of(dirPath), attrs);
+                return super.preVisitDirectory(dir, attrs);
             }
 
             @Override
             public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) {
                 if (!file.getFileName().toString().endsWith(".metadata")) {
-                    uris.add(URI.create(file.toString().replace("\\", "/")));
+                    uris.add(URI.create(file.toUri().getRawPath()));
                 }
                 return FileVisitResult.CONTINUE;
             }
@@ -120,10 +119,10 @@ public class LocalStorage implements StorageInterface {
             }
         });
 
-        URI fsPathUri = URI.create(fsPath.toString().replace("\\", "/"));
+        URI fsPathUri = URI.create(fsPath.toUri().getRawPath());
         return uris.stream().sorted(Comparator.reverseOrder())
             .map(fsPathUri::relativize)
-            .map(URI::getPath)
+            .map(URI::getRawPath)
             .filter(Predicate.not(String::isEmpty))
             .map(path ->
             {
@@ -145,11 +144,7 @@ public class LocalStorage implements StorageInterface {
                 .filter(path -> !path.getFileName().toString().endsWith(".metadata"))
                 .map(throwFunction(file ->
                 {
-                    URI relative = URI.create(
-                        getLocalPath(tenantId, null).relativize(
-                            Path.of(file.toUri())
-                        ).toString().replace("\\", "/")
-                    );
+                    URI relative = toRelativeUri(getLocalPath(tenantId, null), file);
                     return getAttributes(tenantId, namespace, relative);
                 }))
                 .toList();
@@ -165,17 +160,30 @@ public class LocalStorage implements StorageInterface {
                 .filter(path -> !path.getFileName().toString().endsWith(".metadata"))
                 .map(throwFunction(file ->
                 {
-                    URI relative = URI.create(
-                        getInstancePath(null).relativize(
-                            Path.of(file.toUri())
-                        ).toString().replace("\\", "/")
-                    );
+                    URI relative = toRelativeUri(getInstancePath(null), file);
                     return getInstanceAttributes(namespace, relative);
                 }))
                 .toList();
         } catch (NoSuchFileException e) {
             throw new FileNotFoundException(e.getMessage());
         }
+    }
+
+    /**
+     * Converts a file path to a relative URI against the given base path.
+     * Uses the encoded raw path from file.toUri() to safely handle filenames
+     * containing special characters such as spaces or non-ASCII characters.
+     */
+    private static URI toRelativeUri(Path basePath, Path file) {
+        String baseRawPath = basePath.toUri().getRawPath();
+        if (!baseRawPath.endsWith("/")) {
+            baseRawPath += "/";
+        }
+        String fileRawPath = file.toUri().getRawPath();
+        String encodedRelative = fileRawPath.startsWith(baseRawPath)
+            ? fileRawPath.substring(baseRawPath.length())
+            : fileRawPath;
+        return URI.create(encodedRelative);
     }
 
     @Override

--- a/tests/src/main/java/io/kestra/core/storage/StorageTestSuite.java
+++ b/tests/src/main/java/io/kestra/core/storage/StorageTestSuite.java
@@ -178,6 +178,27 @@ public abstract class StorageTestSuite {
     }
 
     @Test
+    void filesByPrefixWithSpaceInFilename() throws Exception {
+        var namespaceName = "filesByPrefix_space_test_namespace";
+
+        // URI.create() rejects spaces, use new URI(null, null, path, null) to encode them
+        storageInterface.put(MAIN_TENANT, namespaceName,
+            new URI(null, null, "/" + namespaceName + "/file with space.txt", null),
+            new ByteArrayInputStream(new byte[0]));
+        storageInterface.put(MAIN_TENANT, namespaceName,
+            new URI(null, null, "/" + namespaceName + "/folder/nested file.txt", null),
+            new ByteArrayInputStream(new byte[0]));
+
+        // Before the fix, this threw: IllegalArgumentException: Illegal character in path
+        List<URI> res = storageInterface.allByPrefix(MAIN_TENANT, namespaceName,
+            URI.create("kestra:///" + namespaceName + "/"), false);
+        assertThat(res).containsExactlyInAnyOrder(
+            new URI("kestra:///" + namespaceName + "/file%20with%20space.txt"),
+            new URI("kestra:///" + namespaceName + "/folder/nested%20file.txt")
+        );
+    }
+
+    @Test
     void objectsByPrefix() throws IOException {
         storageInterface.put(MAIN_TENANT, "some_namespace", URI.create("/some_namespace/file.txt"), new ByteArrayInputStream(new byte[0]));
         storageInterface.put("tenant", "some_namespace", URI.create("/some_namespace/tenant_file.txt"), new ByteArrayInputStream(new byte[0]));
@@ -298,6 +319,22 @@ public abstract class StorageTestSuite {
         list = storageInterface.list(tenantId, prefix, new URI("/" + prefix + "/storage"));
         assertThat(list.stream().map(FileAttributes::getFileName).toList()).containsExactlyInAnyOrder("root.yml", "level1", "another");
         assertThat(list.stream().filter(f -> f.getFileName().equals("root.yml")).findFirst().get().getMetadata()).containsEntry("someMetadata", "someValue");
+    }
+
+    @Test
+    void listWithSpaceInFilename() throws Exception {
+        String prefix = IdUtils.create();
+        String tenantId = IdUtils.create();
+
+        // putFile() uses new URI(path) internally which rejects spaces in paths.
+        // We call storageInterface.put() directly with a properly encoded URI instead.
+        URI fileWithSpace = new URI(null, null, "/" + prefix + "/storage/file with space.txt", null);
+        storageInterface.put(tenantId, null, fileWithSpace, new ByteArrayInputStream(CONTENT_STRING.getBytes()));
+
+        // Before the fix, this threw: IllegalArgumentException: Illegal character in path
+        List<FileAttributes> list = storageInterface.list(tenantId, prefix, new URI("/" + prefix + "/storage"));
+        assertThat(list.stream().map(FileAttributes::getFileName).toList())
+            .containsExactlyInAnyOrder("file with space.txt");
     }
     //endregion
 


### PR DESCRIPTION
## Summary

Fixes #15200

`URI.create()` rejects raw spaces (RFC 2396), causing `IllegalArgumentException: Illegal character in path` when listing namespace files or running flows with `namespaceFiles` if any filename contains a space.

## Root Cause

Three methods were affected in `LocalStorage`:

**`list()` / `listInstanceResource()`**

The chain `Path.of(file.toUri()).relativize().toString()` decodes `%20` back to a literal space, which `URI.create()` then rejects:

```java
// BEFORE
URI relative = URI.create(
    getLocalPath(tenantId, null).relativize(
        Path.of(file.toUri())  // decodes %20 -> space
    ).toString().replace("\\", "/")
);
```

**`allByPrefix()`**

`Path.toString()` returns the raw OS path (spaces intact); `URI.create()` rejects it. Additionally, `URI::getPath` strips percent-encoding from the stream result:

```java
// BEFORE
uris.add(URI.create(file.toString().replace("\\", "/")));  // spaces crash URI.create
.map(URI::getPath)  // strips %20 encoding
```

## Fix

- Add a `toRelativeUri(Path basePath, Path file)` helper that stays in the percent-encoded domain throughout, using `toUri().getRawPath()` for both paths and a plain string prefix-strip instead of `Path.relativize()`.
- Replace all four `URI.create(path.toString()…)` calls in `allByPrefix()` with `URI.create(path.toUri().getRawPath())`, and change `URI::getPath` → `URI::getRawPath` in the stream pipeline.
- The explicit `.replace("\\", "/")` Windows workaround is no longer needed since `toUri().getRawPath()` always uses `/` per the URI standard.

```java
// AFTER — shared helper
private static URI toRelativeUri(Path basePath, Path file) {
    String baseRawPath = basePath.toUri().getRawPath();
    if (!baseRawPath.endsWith("/")) baseRawPath += "/";
    String fileRawPath = file.toUri().getRawPath();
    String encodedRelative = fileRawPath.startsWith(baseRawPath)
        ? fileRawPath.substring(baseRawPath.length())
        : fileRawPath;
    return URI.create(encodedRelative);
}
```

## Tests

Two test cases added to `StorageTestSuite`:

- `listWithSpaceInFilename()` — verifies `list()` returns files with spaces in their names without throwing.
- `filesByPrefixWithSpaceInFilename()` — verifies `allByPrefix()` returns correctly percent-encoded URIs (e.g. `file%20with%20space.txt`) for files with spaces.

## Note on Non-ASCII Filenames

Filenames with non-ASCII characters only (e.g. Chinese `中文.txt`) did not previously crash because Java's `URI.create()` permits characters above `0x7F`. The space character (`0x20`) is explicitly listed as illegal in RFC 2396. Other characters that would also trigger the crash include `#`, `?`, `[`, `]`.
