### PR TITLE
fix(core): sort and filter ForEachItem merge outputs for consistent ordering

### DIFF
--- a/core/src/main/java/io/kestra/plugin/core/flow/ForEachItem.java
+++ b/core/src/main/java/io/kestra/plugin/core/flow/ForEachItem.java
@@ -37,6 +37,7 @@ import java.io.*;
 import java.net.URI;
 import java.time.ZonedDateTime;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -599,11 +600,13 @@ public class ForEachItem extends Task implements FlowableTask<VoidOutput>, Child
             URI subflowOutputsBaseUri = URI.create(StorageContext.KESTRA_PROTOCOL + subflowOutputsBase + "/");
 
             if (runContext.storage().isFileExist(subflowOutputsBaseUri)) {
-                List<FileAttributes> list = runContext.storage().list(subflowOutputsBaseUri);;
+                List<FileAttributes> list = runContext.storage().list(subflowOutputsBaseUri);
 
                 if (!list.isEmpty()) {
                     // Merge outputs from each sub-flow into a single stored in the internal storage.
                     List<InputStream> streams = list.stream()
+                        .filter(attr -> attr.getType() == FileAttributes.FileType.Directory)
+                        .sorted(Comparator.comparingInt(attr -> Integer.parseInt(attr.getFileName())))
                         .map(throwFunction(attr -> {
                             URI file = subflowOutputsBaseUri.resolve(attr.getFileName() + "/outputs.ion");
                             return runContext.storage().getFile(file);


### PR DESCRIPTION
The ForEachItemMergeOutputs task listed iteration directories without sorting or filtering, causing subflowOutputs to have non-deterministic ordering across runs depending on the storage backend.

Filter for directories only and sort numerically by iteration index.

Fixes kestra-io/kestra-ee#7122