### PR TITLE
fix(system): add @PreDestroy shutdown to PosthogService

### DIFF
--- a/webserver/src/main/java/io/kestra/webserver/services/posthog/PosthogService.java
+++ b/webserver/src/main/java/io/kestra/webserver/services/posthog/PosthogService.java
@@ -7,18 +7,21 @@ import io.kestra.core.utils.EditionProvider;
 import io.kestra.core.utils.VersionProvider;
 import io.micronaut.http.client.HttpClient;
 import io.micronaut.http.client.annotation.Client;
+import jakarta.annotation.PreDestroy;
 import jakarta.inject.Singleton;
+import lombok.extern.slf4j.Slf4j;
 
 import java.util.HashMap;
 import java.util.Map;
 
+@Slf4j
 @Singleton
 public class PosthogService {
-    private PostHog postHog;
+    private final PostHog postHog;
 
-    private InstanceService instanceService;
-    private VersionProvider versionProvider;
-    private EditionProvider editionProvider;
+    private final InstanceService instanceService;
+    private final VersionProvider versionProvider;
+    private final EditionProvider editionProvider;
 
     public PosthogService(InstanceService instanceService, VersionProvider versionProvider, EditionProvider editionProvider, @Client("api") HttpClient httpClient) {
         this.instanceService = instanceService;
@@ -44,6 +47,16 @@ public class PosthogService {
             )));
 
         postHog.capture(distinctId, event, properties);
+    }
+
+    /** Gracefully shuts down the PostHog client, flushing any pending events. */
+    @PreDestroy
+    public void shutdown() {
+        try {
+            postHog.shutdown();
+        } catch (Exception e) {
+            log.warn("Error shutting down PostHog client", e);
+        }
     }
 
     private record PosthogConfig(String apiHost, String token) {


### PR DESCRIPTION
The PostHog Java client spawns a background thread (QueueManager) with an unbounded internal LinkedList queue. PosthogService never called PostHog.shutdown().

Add @PreDestroy to call PostHog.shutdown(), which stops the background thread and flushes remaining events. Also make fields final.