### PR TITLE
fix(webserver): disable PostHog beans in test environment

### DIFF
--- a/webserver/src/main/java/io/kestra/webserver/services/ai/AiService.java
+++ b/webserver/src/main/java/io/kestra/webserver/services/ai/AiService.java
@@ -162,7 +162,7 @@ public abstract class AiService<T extends AiConfiguration> implements AiServiceI
                 "$ai_input_state", inputState
             ));
         }
-        metadataByConversationId.put(conversationId, new ConversationMetadata(conversationId, userInfo.ip(), parentSpanId));
+        metadataByConversationId.put(conversationId, new ConversationMetadata(conversationId, ip, parentSpanId));
 
         return new GenerationContext(conversationId, ip, parentSpanId);
     }

--- a/webserver/src/main/java/io/kestra/webserver/services/ai/AiService.java
+++ b/webserver/src/main/java/io/kestra/webserver/services/ai/AiService.java
@@ -149,18 +149,20 @@ public abstract class AiService<T extends AiConfiguration> implements AiServiceI
             return null;
         }
         String parentSpanId = IdUtils.create();
-        this.postHogService.capture(conversationId, "$ai_trace", Map.of(
-            "$ai_trace_id", conversationId,
-            "$ai_span_name", spanName + "Session",
-            "$ai_input_state", inputState
-        ));
-        this.postHogService.capture(conversationId, "$ai_span", Map.of(
-            "$ai_trace_id", conversationId,
-            "$ai_span_id", parentSpanId,
-            "$ai_span_name", spanName + "Attempt",
-            "$ai_input_state", inputState
-        ));
-        metadataByConversationId.put(conversationId, new ConversationMetadata(conversationId, ip, parentSpanId));
+        if(postHogService != null){
+            this.postHogService.capture(conversationId, "$ai_trace", Map.of(
+                "$ai_trace_id", conversationId,
+                "$ai_span_name", spanName + "Session",
+                "$ai_input_state", inputState
+            ));
+            this.postHogService.capture(conversationId, "$ai_span", Map.of(
+                "$ai_trace_id", conversationId,
+                "$ai_span_id", parentSpanId,
+                "$ai_span_name", spanName + "Attempt",
+                "$ai_input_state", inputState
+            ));
+        }
+        metadataByConversationId.put(conversationId, new ConversationMetadata(conversationId, userInfo.ip(), parentSpanId));
 
         return new GenerationContext(conversationId, ip, parentSpanId);
     }
@@ -172,14 +174,16 @@ public abstract class AiService<T extends AiConfiguration> implements AiServiceI
             return result;
         }
         metadataByConversationId.remove(context.conversationId());
-        Map<String, Object> aiOutput = (outputState == null || outputState.isEmpty()) ? Map.of(outputKey, result) : outputState;
-        this.postHogService.capture(context.conversationId(), "$ai_span", Map.of(
-            "$ai_trace_id", context.conversationId(),
-            "$ai_span_id", IdUtils.create(),
-            "$ai_span_name", spanName,
-            "$ai_input_state", Map.of(),
-            "$ai_output_state", aiOutput
-        ));
+        if (this.postHogService != null) {
+            Map<String, Object> aiOutput = (outputState == null || outputState.isEmpty()) ? Map.of(outputKey, result) : outputState;
+            this.postHogService.capture(context.conversationId(), "$ai_span", Map.of(
+                "$ai_trace_id", context.conversationId(),
+                "$ai_span_id", IdUtils.create(),
+                "$ai_span_name", spanName,
+                "$ai_input_state", Map.of(),
+                "$ai_output_state", aiOutput
+            ));
+        }
 
         return result;
     }

--- a/webserver/src/main/java/io/kestra/webserver/services/ai/AiServiceManager.java
+++ b/webserver/src/main/java/io/kestra/webserver/services/ai/AiServiceManager.java
@@ -8,6 +8,7 @@ import io.kestra.core.utils.VersionProvider;
 import io.kestra.webserver.services.ai.gemini.GeminiAiService;
 import io.kestra.webserver.services.ai.gemini.GeminiConfiguration;
 import io.kestra.webserver.services.posthog.PosthogService;
+import io.micronaut.core.annotation.Nullable;
 import io.micronaut.context.annotation.Requires;
 import io.micronaut.core.value.PropertyResolver;
 import jakarta.inject.Singleton;
@@ -34,7 +35,7 @@ public class AiServiceManager {
         io.kestra.core.docs.JsonSchemaGenerator jsonSchemaGenerator,
         VersionProvider versionProvider,
         InstanceService instanceService,
-        PosthogService posthogService,
+        @Nullable PosthogService posthogService,
         List<dev.langchain4j.model.chat.listener.ChatModelListener> listeners,
         NamespaceContextTool namespaceContextTool
     ) {

--- a/webserver/src/main/java/io/kestra/webserver/services/ai/PosthogChatModelListener.java
+++ b/webserver/src/main/java/io/kestra/webserver/services/ai/PosthogChatModelListener.java
@@ -12,6 +12,7 @@ import dev.langchain4j.model.chat.response.ChatResponse;
 import io.kestra.core.utils.IdUtils;
 import io.kestra.webserver.services.posthog.PosthogService;
 import io.micrometer.core.instrument.Clock;
+import io.micronaut.context.annotation.Requires;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 import lombok.extern.slf4j.Slf4j;
@@ -22,6 +23,7 @@ import java.util.Optional;
 
 @Singleton
 @Slf4j
+@Requires(beans = PosthogService.class)
 public class PosthogChatModelListener implements ChatModelListener {
     @Inject
     private PosthogService posthogService;

--- a/webserver/src/main/java/io/kestra/webserver/services/posthog/PosthogService.java
+++ b/webserver/src/main/java/io/kestra/webserver/services/posthog/PosthogService.java
@@ -5,6 +5,7 @@ import com.posthog.java.PostHog;
 import io.kestra.core.services.InstanceService;
 import io.kestra.core.utils.EditionProvider;
 import io.kestra.core.utils.VersionProvider;
+import io.micronaut.context.annotation.Requires;
 import io.micronaut.http.client.HttpClient;
 import io.micronaut.http.client.annotation.Client;
 import jakarta.annotation.PreDestroy;
@@ -16,6 +17,7 @@ import java.util.Map;
 
 @Slf4j
 @Singleton
+@Requires(notEnv = "test")
 public class PosthogService {
     private final PostHog postHog;
 


### PR DESCRIPTION
Add @Requires(notEnv = "test") to PosthogService and @Requires(beans = PosthogService.class)
to PosthogChatModelListener so neither bean is initialized during tests. Make PosthogService
@Nullable in AiServiceManager and guard capture() calls in AiService to handle the absent bean.
