### PR TITLE
fix(executions): add execution-level Pebble expression eval endpoint

### DIFF
--- a/openapi.yml
+++ b/openapi.yml
@@ -3650,6 +3650,38 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ApiAsyncEvent"
+  /api/v1/{tenant}/executions/{executionId}/eval:
+    post:
+      tags:
+      - Executions
+      summary: Evaluate a variable expression for this execution
+      operationId: evalExpression
+      parameters:
+      - name: executionId
+        in: path
+        description: The execution id
+        required: true
+        schema:
+          type: string
+      - name: tenant
+        in: path
+        required: true
+        schema:
+          type: string
+      requestBody:
+        description: The Pebble expression that should be evaluated
+        content:
+          text/plain:
+            schema:
+              type: string
+        required: true
+      responses:
+        "200":
+          description: evalExpression 200 response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ExecutionController.EvalResult"
   /api/v1/{tenant}/executions/{executionId}/eval/{taskRunId}:
     post:
       tags:

--- a/ui/src/components/executions/overview/Overview.vue
+++ b/ui/src/components/executions/overview/Overview.vue
@@ -122,6 +122,13 @@
                     :key="cIdx"
                     v-bind="cascader"
                     :execution
+                    @debug-path="onDebugPath"
+                />
+
+                <DebugPanel
+                    :property="debugProperty"
+                    :execution
+                    :path="debugPath"
                 />
 
                 <div id="chart">
@@ -199,6 +206,7 @@
     import ErrorAlert from "./components/main/ErrorAlert.vue";
     import Id from "../../Id.vue";
     import Cascader, {type Element} from "./components/main/cascaders/Cascader.vue";
+    import DebugPanel from "./components/main/cascaders/DebugPanel.vue";
     import TimeSeries from "../../dashboard/sections/TimeSeries.vue";
     import PrevNext from "./components/main/PrevNext.vue";
 
@@ -408,6 +416,13 @@
                 (label) => label.key === key && String(label.value) === "true",
             ) ?? false
         );
+    };
+
+    const debugProperty = ref<"outputs" | "trigger" | undefined>(undefined);
+    const debugPath = ref<string | undefined>(undefined);
+    const onDebugPath = (property: string, path: string) => {
+        debugProperty.value = property as "outputs" | "trigger";
+        debugPath.value = path;
     };
 
     const cascaders: Element[] = [

--- a/ui/src/components/executions/overview/components/main/cascaders/Cascader.vue
+++ b/ui/src/components/executions/overview/components/main/cascaders/Cascader.vue
@@ -13,33 +13,10 @@
         </div>
 
         <template v-if="props.elements">
-            <template v-if="props.includeDebug">
-                <el-cascader-panel
-                    :options="filteredOptions"
-                    @expand-change="(p: string[]) => (path = p.join('.'))"
-                >
-                    <template #default="{data}">
-                        <div class="node">
-                            <div :title="data.label">
-                                {{ data.label }}
-                            </div>
-                            <div v-if="data.value && data.children">
-                                <code>{{ itemsCount(data) }}</code>
-                            </div>
-                        </div>
-                        <div v-if="isFile(data.value)" class="node buttons">
-                            <VarValue :value="data.value" :execution />
-                        </div>
-                    </template>
-                </el-cascader-panel>
-                <DebugPanel
-                    :property="props.includeDebug"
-                    :execution
-                    :path
-                />
-            </template>
-
-            <el-cascader-panel v-else :options="filteredOptions">
+            <el-cascader-panel
+                :options="filteredOptions"
+                @expand-change="onExpandChange"
+            >
                 <template #default="{data}">
                     <div class="node">
                         <div :title="data.label">
@@ -62,8 +39,6 @@
 
 <script setup lang="ts">
     import {onMounted, nextTick, computed, ref} from "vue";
-
-    import DebugPanel from "./DebugPanel.vue";
 
     import VarValue from "../../../../VarValue.vue";
 
@@ -95,7 +70,31 @@
         }
     >();
 
+    const emits = defineEmits<{
+        (e: "debugPath", property: string, path: string): void;
+    }>();
+
     const path = ref<string>("");
+
+    const onExpandChange = (p: string[]) => {
+        path.value = p.join(".");
+        if (props.includeDebug) {
+            let debugPath = path.value;
+            if (props.includeDebug === "trigger") {
+                // id and type are metadata, not Pebble-accessible — map to just "trigger"
+                if (debugPath === "id" || debugPath === "type") {
+                    debugPath = "";
+                }
+                // variables.<name> maps to trigger.<name> in Pebble
+                else if (debugPath.startsWith("variables.")) {
+                    debugPath = debugPath.substring("variables.".length);
+                } else if (debugPath === "variables") {
+                    debugPath = "";
+                }
+            }
+            emits("debugPath", props.includeDebug, debugPath);
+        }
+    };
 
     const isFile = (value: unknown): value is string => {
         return typeof value === "string" && (value.startsWith("kestra:///") || value.startsWith("file://") || value.startsWith("nsfile://"));

--- a/ui/src/components/executions/overview/components/main/cascaders/DebugPanel.vue
+++ b/ui/src/components/executions/overview/components/main/cascaders/DebugPanel.vue
@@ -40,7 +40,9 @@
             :title="error"
             showIcon
             :closable="false"
-        />
+        >
+            <pre v-if="stackTrace" class="mb-0 stack-trace">{{ stackTrace }}</pre>
+        </el-alert>
     </div>
 </template>
 
@@ -56,6 +58,8 @@
     import CloseCircleOutline from "vue-material-design-icons/CloseCircleOutline.vue";
 
     import Utils from "../../../../../../utils/utils";
+    import {apiUrl} from "override/utils/route";
+    import {useAxios} from "../../../../../../utils/axios";
 
     const props = defineProps<{
         property: "outputs" | "trigger";
@@ -65,67 +69,53 @@
 
     const result = ref<{ value: string; type: string } | undefined>(undefined);
     const error = ref<string | undefined>(undefined);
+    const stackTrace = ref<string | undefined>(undefined);
 
     const clearAll = () => {
         result.value = undefined;
         error.value = undefined;
+        stackTrace.value = undefined;
     };
 
     const expression = ref<string>("");
     watch(
         () => props.path,
         (path?: string) => {
-            result.value = undefined;
+            clearAll();
             expression.value = `{{ ${props.property}${path ? `.${path}` : ""} }}`;
         },
         {immediate: true},
     );
 
+    const axios = useAxios();
     const onRender = () => {
         if (!props.execution) return;
 
-        result.value = undefined;
-        error.value = undefined;
+        clearAll();
 
-        const clean = expression.value
-            .replace(/^\{\{\s*/, "")
-            .replace(/\s*\}\}$/, "")
-            .trim();
+        const url = `${apiUrl()}/executions/${props.execution.id}/eval`;
+        axios
+            .post(url, expression.value, {headers: {"Content-type": "text/plain"}})
+            .then((response) => {
+                if (response.data.error) {
+                    error.value = response.data.error;
+                    stackTrace.value = response.data.stackTrace;
+                    return;
+                }
 
-        if (clean === "outputs" || clean === "trigger") {
-            result.value = {
-                value: JSON.stringify(props.execution[props.property], null, 2),
-                type: "json",
-            };
-        }
-
-        if (!clean.startsWith("outputs.") && !clean.startsWith("trigger.")) {
-            result.value = undefined;
-            error.value = `Expression must start with "{{ ${props.property}. }}"`;
-            return;
-        }
-
-        const parts = clean.substring(props.property.length + 1).split(".");
-        let target: any = props.execution[props.property];
-
-        for (const part of parts) {
-            if (target && typeof target === "object" && part in target) {
-                target = target[part];
-            } else {
-                result.value = undefined;
-                error.value = `Property "${part}" does not exist on ${props.property}`;
-                return;
-            }
-        }
-
-        if (target && typeof target === "object") {
-            result.value = {
-                value: JSON.stringify(target, null, 2),
-                type: "json",
-            };
-        } else {
-            result.value = {value: String(target), type: "text"};
-        }
+                try {
+                    const parsed = JSON.parse(response.data.result);
+                    result.value = {
+                        value: JSON.stringify(parsed, null, 2),
+                        type: "json",
+                    };
+                } catch {
+                    result.value = {value: response.data.result, type: "text"};
+                }
+            })
+            .catch((err) => {
+                error.value = err.message || "Failed to evaluate expression";
+            });
     };
 </script>
 
@@ -172,6 +162,14 @@
         & :deep(.el-button:nth-of-type(2)) {
             width: calc($spacer * 4);
         }
+    }
+
+    .stack-trace {
+        white-space: pre-wrap;
+        word-wrap: break-word;
+        font-size: $font-size-xs;
+        max-height: calc($spacer * 15);
+        overflow: auto;
     }
 }
 </style>

--- a/ui/src/components/executions/overview/components/main/cascaders/DebugPanel.vue
+++ b/ui/src/components/executions/overview/components/main/cascaders/DebugPanel.vue
@@ -62,9 +62,9 @@
     import {useAxios} from "../../../../../../utils/axios";
 
     const props = defineProps<{
-        property: "outputs" | "trigger";
+        property?: "outputs" | "trigger";
         execution: Execution;
-        path: string;
+        path?: string;
     }>();
 
     const result = ref<{ value: string; type: string } | undefined>(undefined);
@@ -79,10 +79,12 @@
 
     const expression = ref<string>("");
     watch(
-        () => props.path,
-        (path?: string) => {
-            clearAll();
-            expression.value = `{{ ${props.property}${path ? `.${path}` : ""} }}`;
+        () => [props.property, props.path],
+        ([property, path]) => {
+            if (property) {
+                clearAll();
+                expression.value = `{{ ${property}${path ? `.${path}` : ""} }}`;
+            }
         },
         {immediate: true},
     );

--- a/webserver/src/main/java/io/kestra/webserver/controllers/api/ExecutionController.java
+++ b/webserver/src/main/java/io/kestra/webserver/controllers/api/ExecutionController.java
@@ -320,6 +320,31 @@ public class ExecutionController {
     }
 
     @ExecuteOn(TaskExecutors.IO)
+    @Post(uri = "/{executionId}/eval", consumes = MediaType.TEXT_PLAIN)
+    @Operation(tags = { "Executions" }, summary = "Evaluate a variable expression for this execution")
+    public EvalResult evalExpression(
+        @Parameter(description = "The execution id") @PathVariable String executionId,
+        @RequestBody(description = "The Pebble expression that should be evaluated") @Body String expression) {
+        Execution execution = executionRepository
+            .findById(tenantService.resolveTenant(), executionId)
+            .orElseThrow(() -> new NoSuchElementException("Unable to find execution '" + executionId + "'"));
+
+        Flow flow = flowRepository
+            .findByExecution(execution);
+
+        try {
+            return EvalResult.builder()
+                .result(runContextRender(flow, execution, expression))
+                .build();
+        } catch (IllegalVariableEvaluationException e) {
+            return EvalResult.builder()
+                .error(e.getMessage())
+                .stackTrace(ExceptionUtils.getStackTrace(e))
+                .build();
+        }
+    }
+
+    @ExecuteOn(TaskExecutors.IO)
     @Post(uri = "/{executionId}/eval/{taskRunId}", consumes = MediaType.TEXT_PLAIN)
     @Operation(tags = { "Executions" }, summary = "Evaluate a variable expression for this taskrun")
     public EvalResult evalTaskRunExpression(
@@ -348,6 +373,14 @@ public class ExecutionController {
                 .stackTrace(ExceptionUtils.getStackTrace(e))
                 .build();
         }
+    }
+
+    private String runContextRender(Flow flow, Execution execution, String expression) throws IllegalVariableEvaluationException {
+        return runContextFactory.of(
+            flow,
+            execution,
+            false
+        ).render(expression);
     }
 
     private String runContextRender(Flow flow, Task task, Execution execution, TaskRun taskRun, String expression) throws IllegalVariableEvaluationException {

--- a/webserver/src/test/java/io/kestra/webserver/controllers/api/ExecutionControllerRunnerTest.java
+++ b/webserver/src/test/java/io/kestra/webserver/controllers/api/ExecutionControllerRunnerTest.java
@@ -2224,6 +2224,46 @@ class ExecutionControllerRunnerTest {
         assertThat(evalResult.getResult()).isEqualTo("******");
     }
 
+    @Test
+    @ExecuteFlow("flows/valids/minimal.yaml")
+    void shouldEvalExpressionWithExecutionContext(Execution execution) {
+        ExecutionController.EvalResult evalResult = client.toBlocking().retrieve(
+            HttpRequest
+                .POST("/api/v1/main/executions/" + execution.getId() + "/eval", "{{ execution.id }}")
+                .contentType(MediaType.TEXT_PLAIN),
+            ExecutionController.EvalResult.class
+        );
+        assertThat(evalResult.getResult(), org.hamcrest.Matchers.is(execution.getId()));
+        assertThat(evalResult.getError(), org.hamcrest.Matchers.nullValue());
+    }
+
+    @Test
+    @ExecuteFlow("flows/valids/minimal.yaml")
+    void shouldEvalExpressionReturnErrorForInvalidExpression(Execution execution) {
+        ExecutionController.EvalResult evalResult = client.toBlocking().retrieve(
+            HttpRequest
+                .POST("/api/v1/main/executions/" + execution.getId() + "/eval", "{{ invalid_variable }}")
+                .contentType(MediaType.TEXT_PLAIN),
+            ExecutionController.EvalResult.class
+        );
+        assertThat(evalResult.getResult(), org.hamcrest.Matchers.nullValue());
+        assertThat(evalResult.getError(), org.hamcrest.Matchers.notNullValue());
+        assertThat(evalResult.getStackTrace(), org.hamcrest.Matchers.notNullValue());
+    }
+
+    @Test
+    @ExecuteFlow("flows/valids/minimal.yaml")
+    void shouldMaskSensitiveFunctionsWhenEvalExpression(Execution execution) {
+        ExecutionController.EvalResult evalResult = client.toBlocking().retrieve(
+            HttpRequest
+                .POST("/api/v1/main/executions/" + execution.getId() + "/eval", "{{ secret('MY_SECRET') }}")
+                .contentType(MediaType.TEXT_PLAIN),
+            ExecutionController.EvalResult.class
+        );
+        assertThat(evalResult.getError(), org.hamcrest.Matchers.nullValue());
+        assertThat(evalResult.getResult(), org.hamcrest.Matchers.is("******"));
+    }
+
     private ExecutionController.EvalResult evalTaskRunExpression(Execution execution, String expression, int index) {
         return client.toBlocking().retrieve(
             HttpRequest


### PR DESCRIPTION
- Add new `POST /executions/{executionId}/eval` endpoint that evaluates Pebble expressions in the execution context (trigger, inputs, outputs, variables) without requiring a taskRunId
- Rewrite `DebugPanel.vue` to call the backend instead of doing fake client-side property traversal
- Add tests for the new endpoint (valid expression, invalid expression, secret masking)

Fixes https://github.com/kestra-io/kestra-ee/issues/7186
Closes https://github.com/kestra-io/kestra/issues/10844.