### PR TITLE
feat: scope dashboard filter

### DIFF
--- a/core/src/main/java/io/kestra/core/models/QueryFilter.java
+++ b/core/src/main/java/io/kestra/core/models/QueryFilter.java
@@ -86,7 +86,7 @@ public record QueryFilter(
         SCOPE("scope") {
             @Override
             public List<Op> supportedOp() {
-                return List.of(Op.EQUALS, Op.NOT_EQUALS);
+                return List.of(Op.EQUALS, Op.NOT_EQUALS, Op.IN, Op.NOT_IN);
             }
         },
         NAMESPACE("namespace") {

--- a/core/src/main/java/io/kestra/plugin/core/dashboard/data/IExecutions.java
+++ b/core/src/main/java/io/kestra/plugin/core/dashboard/data/IExecutions.java
@@ -57,6 +57,11 @@ public interface IExecutions extends IData<IExecutions.Fields> {
                 });
             }
 
+            List<QueryFilter> scopeFilters = filters.stream().filter(f -> f.field().equals(QueryFilter.Field.SCOPE)).toList();
+            if (!scopeFilters.isEmpty()) {
+                updatedWhere.removeIf(filter -> filter.getField().equals(Fields.SCOPE));
+                scopeFilters.forEach(f -> updatedWhere.add(f.toDashboardFilterBuilder(Fields.SCOPE, f.value())));
+            }
         }
 
         if (startDate != null || endDate != null) {
@@ -83,6 +88,7 @@ public interface IExecutions extends IData<IExecutions.Fields> {
         LABELS,
         START_DATE,
         END_DATE,
-        TRIGGER_EXECUTION_ID
+        TRIGGER_EXECUTION_ID,
+        SCOPE
     }
 }

--- a/core/src/test/java/io/kestra/core/models/QueryFilterTest.java
+++ b/core/src/test/java/io/kestra/core/models/QueryFilterTest.java
@@ -54,7 +54,9 @@ public class QueryFilterTest {
                 Field.SCOPE, Resource.EXECUTION,
                 Set.of(
                     Op.EQUALS,
-                    Op.NOT_EQUALS
+                    Op.NOT_EQUALS,
+                    Op.IN,
+                    Op.NOT_IN
                 )
             ),
 
@@ -542,8 +544,6 @@ public class QueryFilterTest {
                     Op.LESS_THAN,
                     Op.GREATER_THAN_OR_EQUAL_TO,
                     Op.LESS_THAN_OR_EQUAL_TO,
-                    Op.IN,
-                    Op.NOT_IN,
                     Op.STARTS_WITH,
                     Op.ENDS_WITH,
                     Op.CONTAINS,

--- a/core/src/test/java/io/kestra/core/repositories/AbstractExecutionRepositoryTest.java
+++ b/core/src/test/java/io/kestra/core/repositories/AbstractExecutionRepositoryTest.java
@@ -52,6 +52,7 @@ import io.micronaut.http.HttpStatus;
 import io.micronaut.http.exceptions.HttpStatusException;
 import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
 import jakarta.inject.Inject;
+import org.junit.jupiter.params.provider.FieldSource;
 import reactor.core.publisher.Flux;
 
 import static io.kestra.core.models.flows.FlowScope.SYSTEM;
@@ -1336,5 +1337,87 @@ public abstract class AbstractExecutionRepositoryTest {
 
         // THEN
         assertThat(flux.collectList().block()).map(Execution::getId).isEqualTo(List.of(execution.getId()));
+    }
+
+    // ---- SCOPE dashboard filter tests ----
+
+    private static final String SCOPE_USER_EXECUTION_ID = "scope-user-exec";
+    private static final String SCOPE_SYSTEM_EXECUTION_ID = "scope-system-exec";
+
+    private static final Duration SCOPE_TEST_DURATION = Duration.ofSeconds(10);
+    private static final Instant SCOPE_TEST_CREATE_DATE = Instant.now().minus(Duration.ofMinutes(5));
+
+    private final Execution scopeUserExecution = Execution.builder()
+        .id(SCOPE_USER_EXECUTION_ID)
+        .namespace(NAMESPACE)
+        .flowId("scope-test")
+        .flowRevision(1)
+        .state(new State(Type.SUCCESS, List.of(
+            new State.History(State.Type.CREATED, SCOPE_TEST_CREATE_DATE),
+            new State.History(Type.SUCCESS, SCOPE_TEST_CREATE_DATE.plus(SCOPE_TEST_DURATION)))))
+        .taskRunList(List.of())
+        .build();
+
+    private final Execution scopeSystemExecution = Execution.builder()
+        .id(SCOPE_SYSTEM_EXECUTION_ID)
+        .namespace(KestraConfig.DEFAULT_SYSTEM_FLOWS_NAMESPACE)
+        .flowId("scope-test")
+        .flowRevision(1)
+        .state(new State(Type.SUCCESS, List.of(
+            new State.History(State.Type.CREATED, SCOPE_TEST_CREATE_DATE),
+            new State.History(Type.SUCCESS, SCOPE_TEST_CREATE_DATE.plus(SCOPE_TEST_DURATION)))))
+        .taskRunList(List.of())
+        .build();
+
+    private record DashboardScopeFilterTestCase(
+        QueryFilter queryFilter,
+        List<String> expectedIds
+    ) {}
+
+    private static QueryFilter scopeFilter(QueryFilter.Op op, Object value) {
+        return QueryFilter.builder()
+            .field(QueryFilter.Field.SCOPE)
+            .operation(op)
+            .value(value)
+            .build();
+    }
+
+    static final List<DashboardScopeFilterTestCase> dashboardScopeFilterTestCases = List.of(
+        new DashboardScopeFilterTestCase(scopeFilter(Op.EQUALS, USER),        List.of(SCOPE_USER_EXECUTION_ID)),
+        new DashboardScopeFilterTestCase(scopeFilter(Op.EQUALS, SYSTEM),      List.of(SCOPE_SYSTEM_EXECUTION_ID)),
+        new DashboardScopeFilterTestCase(scopeFilter(Op.NOT_EQUALS, USER),    List.of(SCOPE_SYSTEM_EXECUTION_ID)),
+        new DashboardScopeFilterTestCase(scopeFilter(Op.NOT_EQUALS, SYSTEM),  List.of(SCOPE_USER_EXECUTION_ID)),
+        new DashboardScopeFilterTestCase(scopeFilter(Op.IN, List.of(USER)),   List.of(SCOPE_USER_EXECUTION_ID)),
+        new DashboardScopeFilterTestCase(scopeFilter(Op.IN, List.of(SYSTEM)), List.of(SCOPE_SYSTEM_EXECUTION_ID)),
+        new DashboardScopeFilterTestCase(scopeFilter(Op.IN,     List.of(USER, SYSTEM)), List.of(SCOPE_USER_EXECUTION_ID, SCOPE_SYSTEM_EXECUTION_ID)),
+        new DashboardScopeFilterTestCase(scopeFilter(Op.NOT_IN, List.of(USER)),   List.of(SCOPE_SYSTEM_EXECUTION_ID)),
+        new DashboardScopeFilterTestCase(scopeFilter(Op.NOT_IN, List.of(SYSTEM)), List.of(SCOPE_USER_EXECUTION_ID)),
+        new DashboardScopeFilterTestCase(scopeFilter(Op.NOT_IN, List.of(USER, SYSTEM)), List.of())
+    );
+
+    @ParameterizedTest
+    @FieldSource("dashboardScopeFilterTestCases")
+    protected void dashboard_fetchData_withScopeFilter(DashboardScopeFilterTestCase testCase) throws IOException {
+        // Given: one execution in the user namespace, one in the system namespace
+        var tenantId = TestsUtils.randomTenant(this.getClass().getSimpleName());
+
+        executionRepository.save(scopeUserExecution.toBuilder().tenantId(tenantId).build());
+        executionRepository.save(scopeSystemExecution.toBuilder().tenantId(tenantId).build());
+
+        // When: apply the scope filter via updateWhereWithGlobalFilters
+        var now = ZonedDateTime.now();
+        var dataFilter = Executions.builder()
+            .type(Executions.class.getName())
+            .columns(Map.of(
+                "id", ColumnDescriptor.<Executions.Fields>builder().field(Executions.Fields.ID).build()
+            ))
+            .build();
+        dataFilter.updateWhereWithGlobalFilters(List.of(testCase.queryFilter()), now.minusHours(1), now);
+
+        ArrayListTotal<Map<String, Object>> data = executionRepository.fetchData(tenantId, dataFilter, now.minusHours(1), now, null);
+
+        // Then: verify the expected execution IDs are returned
+        List<String> returnedIds = data.stream().map(row -> (String) row.get("id")).toList();
+        assertThat(returnedIds).containsExactlyInAnyOrderElementsOf(testCase.expectedIds());
     }
 }

--- a/core/src/test/java/io/kestra/core/repositories/AbstractExecutionRepositoryTest.java
+++ b/core/src/test/java/io/kestra/core/repositories/AbstractExecutionRepositoryTest.java
@@ -220,8 +220,14 @@ public abstract class AbstractExecutionRepositoryTest {
             Arguments.of(QueryFilter.builder().field(Field.QUERY).value("unittest").operation(Op.EQUALS).build(), 29),
             Arguments.of(QueryFilter.builder().field(Field.QUERY).value("unused").operation(Op.NOT_EQUALS).build(), 29),
 
-            Arguments.of(QueryFilter.builder().field(Field.SCOPE).value(List.of(USER)).operation(Op.EQUALS).build(), 29),
-            Arguments.of(QueryFilter.builder().field(Field.SCOPE).value(List.of(SYSTEM)).operation(Op.NOT_EQUALS).build(), 29),
+            Arguments.of(QueryFilter.builder().field(Field.SCOPE).value(USER).operation(Op.EQUALS).build(), 29),
+            Arguments.of(QueryFilter.builder().field(Field.SCOPE).value(SYSTEM).operation(Op.NOT_EQUALS).build(), 29),
+            Arguments.of(QueryFilter.builder().field(Field.SCOPE).value(List.of(USER)).operation(Op.IN).build(), 29),
+            Arguments.of(QueryFilter.builder().field(Field.SCOPE).value(List.of(SYSTEM)).operation(Op.IN).build(), 0),
+            Arguments.of(QueryFilter.builder().field(Field.SCOPE).value(List.of(USER, SYSTEM)).operation(Op.IN).build(), 29),
+            Arguments.of(QueryFilter.builder().field(Field.SCOPE).value(List.of(USER)).operation(Op.NOT_IN).build(), 0),
+            Arguments.of(QueryFilter.builder().field(Field.SCOPE).value(List.of(SYSTEM)).operation(Op.NOT_IN).build(), 29),
+            Arguments.of(QueryFilter.builder().field(Field.SCOPE).value(List.of(USER, SYSTEM)).operation(Op.NOT_IN).build(), 0),
 
             Arguments.of(QueryFilter.builder().field(Field.NAMESPACE).value("io.kestra.unittest").operation(Op.EQUALS).build(), 29),
             Arguments.of(QueryFilter.builder().field(Field.NAMESPACE).value("not.this.one").operation(Op.NOT_EQUALS).build(), 29),
@@ -1419,5 +1425,28 @@ public abstract class AbstractExecutionRepositoryTest {
         // Then: verify the expected execution IDs are returned
         List<String> returnedIds = data.stream().map(row -> (String) row.get("id")).toList();
         assertThat(returnedIds).containsExactlyInAnyOrderElementsOf(testCase.expectedIds());
+    }
+
+    @ParameterizedTest
+    @FieldSource("dashboardScopeFilterTestCases")
+    protected void dashboard_fetchValue_withScopeFilter(DashboardScopeFilterTestCase testCase) throws IOException {
+        // Given: one execution in the user namespace, one in the system namespace
+        var tenantId = TestsUtils.randomTenant(this.getClass().getSimpleName());
+
+        executionRepository.save(scopeUserExecution.toBuilder().tenantId(tenantId).build());
+        executionRepository.save(scopeSystemExecution.toBuilder().tenantId(tenantId).build());
+
+        // When: apply the scope filter via updateWhereWithGlobalFilters
+        var now = ZonedDateTime.now();
+        var dataFilter = ExecutionsKPI.builder()
+            .type(ExecutionsKPI.class.getName())
+            .columns(ColumnDescriptor.<ExecutionsKPI.Fields>builder().field(ExecutionsKPI.Fields.ID).agg(AggregationType.COUNT).build())
+            .build();
+        dataFilter.updateWhereWithGlobalFilters(List.of(testCase.queryFilter()), now.minusHours(1), now);
+
+        Double value = executionRepository.fetchValue(tenantId, dataFilter, now.minusHours(1), now, false);
+
+        // Then: the count should match the number of expected IDs
+        assertThat(value).isEqualTo((double) testCase.expectedIds().size());
     }
 }

--- a/core/src/test/java/io/kestra/core/repositories/AbstractExecutionRepositoryTest.java
+++ b/core/src/test/java/io/kestra/core/repositories/AbstractExecutionRepositoryTest.java
@@ -1403,14 +1403,14 @@ public abstract class AbstractExecutionRepositoryTest {
 
     @ParameterizedTest
     @FieldSource("dashboardScopeFilterTestCases")
-    protected void dashboard_fetchData_withScopeFilter(DashboardScopeFilterTestCase testCase) throws IOException {
-        // Given: one execution in the user namespace, one in the system namespace
+    protected void dashboardFetchDataWithScopeFilter(DashboardScopeFilterTestCase testCase) throws IOException {
+        // Given
         var tenantId = TestsUtils.randomTenant(this.getClass().getSimpleName());
 
         executionRepository.save(scopeUserExecution.toBuilder().tenantId(tenantId).build());
         executionRepository.save(scopeSystemExecution.toBuilder().tenantId(tenantId).build());
 
-        // When: apply the scope filter via updateWhereWithGlobalFilters
+        // When
         var now = ZonedDateTime.now();
         var dataFilter = Executions.builder()
             .type(Executions.class.getName())
@@ -1422,21 +1422,21 @@ public abstract class AbstractExecutionRepositoryTest {
 
         ArrayListTotal<Map<String, Object>> data = executionRepository.fetchData(tenantId, dataFilter, now.minusHours(1), now, null);
 
-        // Then: verify the expected execution IDs are returned
+        // Then
         List<String> returnedIds = data.stream().map(row -> (String) row.get("id")).toList();
         assertThat(returnedIds).containsExactlyInAnyOrderElementsOf(testCase.expectedIds());
     }
 
     @ParameterizedTest
     @FieldSource("dashboardScopeFilterTestCases")
-    protected void dashboard_fetchValue_withScopeFilter(DashboardScopeFilterTestCase testCase) throws IOException {
-        // Given: one execution in the user namespace, one in the system namespace
+    protected void dashboardFetchValueWithScopeFilter(DashboardScopeFilterTestCase testCase) throws IOException {
+        // Given
         var tenantId = TestsUtils.randomTenant(this.getClass().getSimpleName());
 
         executionRepository.save(scopeUserExecution.toBuilder().tenantId(tenantId).build());
         executionRepository.save(scopeSystemExecution.toBuilder().tenantId(tenantId).build());
 
-        // When: apply the scope filter via updateWhereWithGlobalFilters
+        // When
         var now = ZonedDateTime.now();
         var dataFilter = ExecutionsKPI.builder()
             .type(ExecutionsKPI.class.getName())
@@ -1446,7 +1446,7 @@ public abstract class AbstractExecutionRepositoryTest {
 
         Double value = executionRepository.fetchValue(tenantId, dataFilter, now.minusHours(1), now, false);
 
-        // Then: the count should match the number of expected IDs
+        // Then
         assertThat(value).isEqualTo((double) testCase.expectedIds().size());
     }
 }

--- a/jdbc/src/main/java/io/kestra/jdbc/repository/AbstractJdbcExecutionRepository.java
+++ b/jdbc/src/main/java/io/kestra/jdbc/repository/AbstractJdbcExecutionRepository.java
@@ -924,10 +924,23 @@ public abstract class AbstractJdbcExecutionRepository extends AbstractJdbcCrudRe
                 selectConditionStep = selectConditionStep.and(findCondition(null, mergedMap));
             }
 
-            // Remove the state filters from descriptors
+            // Handle SCOPE filters — translate to namespace-based conditions
+            List<AbstractFilter<F>> scopeFilters = filters.stream()
+                .filter(descriptor -> descriptor.getField().equals(Executions.Fields.SCOPE))
+                .toList();
+
+            if (!scopeFilters.isEmpty()) {
+                String systemNamespace = kestraConfig.getSystemFlowNamespace();
+                for (AbstractFilter<F> scopeFilter : scopeFilters) {
+                    selectConditionStep = selectConditionStep.and(toScopeCondition(scopeFilter, systemNamespace));
+                }
+            }
+
+            // Remove the state, label, and scope filters from descriptors
             List<AbstractFilter<F>> remainingFilters = filters.stream()
                 .filter(descriptor -> !descriptor.getField().equals(Executions.Fields.STATE)) // Filter state
                 .filter(descriptor -> !descriptor.getField().equals(Executions.Fields.LABELS) || !(descriptor instanceof Contains<F>)) // Filter labels
+                .filter(descriptor -> !descriptor.getField().equals(Executions.Fields.SCOPE)) // Filter scope
                 .toList();
 
             // Use the generic method addFilters with the remaining filters
@@ -992,6 +1005,37 @@ public abstract class AbstractJdbcExecutionRepository extends AbstractJdbcCrudRe
             );
         }
         return selectConditionStep;
+    }
+
+    @SuppressWarnings("unchecked")
+    private <F extends Enum<F>> Condition toScopeCondition(AbstractFilter<F> filter, String systemNamespace) {
+        return switch (filter) {
+            case EqualTo<F> f -> {
+                FlowScope scope = Enums.fromList(f.getValue(), FlowScope.class).getFirst();
+                yield FlowScope.USER.equals(scope) ? field("namespace").ne(systemNamespace) : field("namespace").eq(systemNamespace);
+            }
+            case NotEqualTo<F> f -> {
+                FlowScope scope = Enums.fromList(f.getValue(), FlowScope.class).getFirst();
+                yield FlowScope.USER.equals(scope) ? field("namespace").eq(systemNamespace) : field("namespace").ne(systemNamespace);
+            }
+            case In<F> f -> {
+                List<FlowScope> scopes = Enums.fromList(f.getValues(), FlowScope.class);
+                boolean includesUser = scopes.contains(FlowScope.USER);
+                boolean includesSystem = scopes.contains(FlowScope.SYSTEM);
+                if (includesUser && includesSystem) yield DSL.noCondition();
+                else if (includesUser) yield field("namespace").ne(systemNamespace);
+                else yield field("namespace").eq(systemNamespace);
+            }
+            case NotIn<F> f -> {
+                List<FlowScope> scopes = Enums.fromList(f.getValues(), FlowScope.class);
+                boolean excludesUser = scopes.contains(FlowScope.USER);
+                boolean excludesSystem = scopes.contains(FlowScope.SYSTEM);
+                if (excludesUser && excludesSystem) yield DSL.falseCondition();
+                else if (excludesUser) yield field("namespace").eq(systemNamespace);
+                else yield field("namespace").ne(systemNamespace);
+            }
+            default -> throw new IllegalArgumentException("Unsupported SCOPE filter type: " + filter.getClass().getSimpleName());
+        };
     }
 
     abstract protected Field<Date> formatDateField(String dateField, DateUtils.GroupType groupType);

--- a/jdbc/src/main/java/io/kestra/jdbc/repository/AbstractJdbcExecutionRepository.java
+++ b/jdbc/src/main/java/io/kestra/jdbc/repository/AbstractJdbcExecutionRepository.java
@@ -36,6 +36,7 @@ import io.kestra.core.repositories.ArrayListTotal;
 import io.kestra.core.repositories.ExecutionRepositoryInterface;
 import io.kestra.core.utils.DateUtils;
 import io.kestra.core.utils.Either;
+import io.kestra.core.utils.Enums;
 import io.kestra.core.utils.ListUtils;
 import io.kestra.executor.ExecutionStateStore;
 import io.kestra.executor.ExecutorContext;

--- a/jdbc/src/main/java/io/kestra/jdbc/repository/AbstractJdbcRepository.java
+++ b/jdbc/src/main/java/io/kestra/jdbc/repository/AbstractJdbcRepository.java
@@ -532,15 +532,34 @@ public abstract class AbstractJdbcRepository {
 
     private Condition applyScopeCondition(Object value, QueryFilter.Op operation) {
         List<FlowScope> flowScopes = Enums.fromList(value, FlowScope.class);
-        if (flowScopes.size() > 1) {
-            throw new InvalidQueryFiltersException("Only one scope can be use in the same time");
-        }
-        FlowScope scope = flowScopes.getFirst();
-
         String systemNamespace = this.kestraConfig.getSystemFlowNamespace();
+
         return switch (operation) {
-            case EQUALS -> FlowScope.USER.equals(scope) ? field("namespace").ne(systemNamespace) : field("namespace").eq(systemNamespace);
-            case NOT_EQUALS -> FlowScope.USER.equals(scope) ? field("namespace").eq(systemNamespace) : field("namespace").ne(systemNamespace);
+            case EQUALS, NOT_EQUALS -> {
+                if (flowScopes.size() > 1) {
+                    throw new InvalidQueryFiltersException("Only one scope can be used at a time with " + operation);
+                }
+                FlowScope scope = flowScopes.getFirst();
+                yield switch (operation) {
+                    case EQUALS -> FlowScope.USER.equals(scope) ? field("namespace").ne(systemNamespace) : field("namespace").eq(systemNamespace);
+                    case NOT_EQUALS -> FlowScope.USER.equals(scope) ? field("namespace").eq(systemNamespace) : field("namespace").ne(systemNamespace);
+                    default -> throw new InvalidQueryFiltersException("Unreachable");
+                };
+            }
+            case IN -> {
+                boolean includesUser = flowScopes.contains(FlowScope.USER);
+                boolean includesSystem = flowScopes.contains(FlowScope.SYSTEM);
+                if (includesUser && includesSystem) yield DSL.noCondition();
+                else if (includesUser) yield field("namespace").ne(systemNamespace);
+                else yield field("namespace").eq(systemNamespace);
+            }
+            case NOT_IN -> {
+                boolean excludesUser = flowScopes.contains(FlowScope.USER);
+                boolean excludesSystem = flowScopes.contains(FlowScope.SYSTEM);
+                if (excludesUser && excludesSystem) yield DSL.falseCondition();
+                else if (excludesUser) yield field("namespace").eq(systemNamespace);
+                else yield field("namespace").ne(systemNamespace);
+            }
             default -> throw new InvalidQueryFiltersException("Unsupported operation for SCOPE: " + operation);
         };
     }

--- a/ui/src/components/dashboard/Dashboard.vue
+++ b/ui/src/components/dashboard/Dashboard.vue
@@ -6,6 +6,7 @@
             :key="`dashboard__${dashboard.id}`"
             :prefix="`dashboard__${dashboard.id}`"
             :configuration="filterConfiguration"
+            :defaultScope="false"
             :tableOptions="{
                 chart: {shown: false},
                 columns: {shown: false},

--- a/ui/src/components/filter/configurations/dashboardFilters.ts
+++ b/ui/src/components/filter/configurations/dashboardFilters.ts
@@ -71,6 +71,18 @@ export const useDashboardFilter = (): ComputedRef<FilterConfiguration> => {
                     showComparatorSelection: true
                 },
                 {
+                    key: "scope",
+                    label: t("filter.scope.label"),
+                    description: t("filter.scope.description"),
+                    comparators: [Comparators.IN, Comparators.NOT_IN],
+                    valueType: "multi-select",
+                    valueProvider: async () => {
+                        const {VALUES} = useValues("executions");
+                        return VALUES.SCOPES;
+                    },
+                    showComparatorSelection: false,
+                },
+                {
                     key: "labels",
                     label: t("filter.labels.label"),
                     description: t("filter.labels.description"),

--- a/ui/src/components/filter/configurations/executionFilter.ts
+++ b/ui/src/components/filter/configurations/executionFilter.ts
@@ -92,8 +92,8 @@ export const useExecutionFilter = (): ComputedRef<FilterConfiguration> => {
                     key: "scope",
                     label: t("filter.scope.label"),
                     description: t("filter.scope.description"),
-                    comparators: [Comparators.EQUALS, Comparators.NOT_EQUALS],
-                    valueType: "radio",
+                    comparators: [Comparators.IN, Comparators.NOT_IN],
+                    valueType: "multi-select",
                     valueProvider: async () => {
                         const {VALUES} = useValues("executions");
                         return VALUES.SCOPES;

--- a/ui/src/components/filter/configurations/flowExecutionFilter.ts
+++ b/ui/src/components/filter/configurations/flowExecutionFilter.ts
@@ -28,8 +28,8 @@ export const useFlowExecutionFilter = (): ComputedRef<FilterConfiguration> => {
                     key: "scope",
                     label: t("filter.scope.label"),
                     description: t("filter.scope.description"),
-                    comparators: [Comparators.EQUALS, Comparators.NOT_EQUALS],
-                    valueType: "radio",
+                    comparators: [Comparators.IN, Comparators.NOT_IN],
+                    valueType: "multi-select",
                     valueProvider: async () => {
                         const {VALUES} = useValues("executions");
                         return VALUES.SCOPES;


### PR DESCRIPTION
✨ Description

This PR introduces Scope filter behavior to dashboards and also adds support for IN and NOT_IN operations on Scope fields.
This PR also replaces usages of EQUALS and NOT_EQUALS with IN and NOT_IN in the UI.

🔗 Related Issue
Closes: kestra-io/kestra/issues/13883