### PR TITLE
chore: use venv to install custom python packages in kestra docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN apt-get update -y && \
     rm -rf /var/lib/apt/lists/* /var/tmp/* /tmp/* && \
     curl -LsSf https://astral.sh/uv/0.6.17/install.sh | sh && mv /root/.local/bin/uv /bin && mv /root/.local/bin/uvx /bin && \
     if [ -n "${KESTRA_PLUGINS}" ]; then /app/kestra plugins install ${KESTRA_PLUGINS} && rm -rf /tmp/*; fi && \
-    if [ -n "${PYTHON_LIBRARIES}" ]; then uv pip install --system ${PYTHON_LIBRARIES}; fi && \
+    if [ -n "${PYTHON_LIBRARIES}" ]; then uv pip install --system --break-system-packages ${PYTHON_LIBRARIES}; fi && \
     chown -R kestra:kestra /app
 
 USER kestra

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,8 @@ ARG KESTRA_PLUGINS=""
 ARG APT_PACKAGES=""
 ARG PYTHON_LIBRARIES=""
 
+ENV PATH="/app/.venv/bin:$PATH"
+
 WORKDIR /app
 
 RUN groupadd kestra && \
@@ -19,7 +21,7 @@ RUN apt-get update -y && \
     rm -rf /var/lib/apt/lists/* /var/tmp/* /tmp/* && \
     curl -LsSf https://astral.sh/uv/0.6.17/install.sh | sh && mv /root/.local/bin/uv /bin && mv /root/.local/bin/uvx /bin && \
     if [ -n "${KESTRA_PLUGINS}" ]; then /app/kestra plugins install ${KESTRA_PLUGINS} && rm -rf /tmp/*; fi && \
-    if [ -n "${PYTHON_LIBRARIES}" ]; then uv pip install --system --break-system-packages ${PYTHON_LIBRARIES}; fi && \
+    if [ -n "${PYTHON_LIBRARIES}" ]; then uv venv /app/.venv && uv pip install --python /app/.venv/bin/python ${PYTHON_LIBRARIES}; fi && \
     chown -R kestra:kestra /app
 
 USER kestra


### PR DESCRIPTION
### Description:

When trying to build our docker images we get the following error:
```
#15 92.98 error: The interpreter at /usr is externally managed, and indicates the following:
#15 92.98 
#15 92.98   To install Python packages system-wide, try apt install
#15 92.98   python3-xyz, where xyz is the package you are trying to
#15 92.98   install.
#15 92.98 
#15 92.98   If you wish to install a non-Debian-packaged Python package,
#15 92.98   create a virtual environment using python3 -m venv path/to/venv.
#15 92.98   Then use path/to/venv/bin/python and path/to/venv/bin/pip. Make
#15 92.98   sure you have python3-full installed.
#15 92.98 
#15 92.98   If you wish to install a non-Debian packaged Python application,
#15 92.98   it may be easiest to use pipx install xyz, which will manage a
#15 92.98   virtual environment for you. Make sure you have pipx installed.
#15 92.98 
#15 92.98   See /usr/share/doc/python3.12/README.venv for more information.
#15 92.98 
```

I believe this is due to [PEP 668](https://peps.python.org/pep-0668/). To resolve this issue it is sudgested that we use a venv to install our package into our docker image. This pr installs the package into a venv and then adds that venv to the system path.

I've also done a test to make sure that flows that reqire packages set in the PYTHON_LIBRARIES env var are still accessible after this change.


#### Test flow
```
id: python_scripts
namespace: company.team

tasks:
  - id: outputs_metrics
    type: io.kestra.plugin.scripts.python.Script
    taskRunner:
      type: io.kestra.plugin.core.runner.Process

    script: |
      import pandas
      print("pandas imported successfully")
```

Flow logs
```
pandas imported successfully
```
