### PR TITLE
fix(triggers): separate delete path in recomputeTriggers to prevent fallthrough

### DIFF
--- a/core/src/main/java/io/kestra/core/services/FlowService.java
+++ b/core/src/main/java/io/kestra/core/services/FlowService.java
@@ -215,10 +215,15 @@ public class FlowService {
     private void recomputeTriggers(FlowWithSource flow) {
         var previous = flow.getRevision() <= 1 ? null : flowRepository.findById(flow.getTenantId(), flow.getNamespace(), flow.getId(), Optional.of(flow.getRevision() - 1)).orElse(null);
 
-        if (flow.isDeleted() || previous != null) {
-            List<AbstractTrigger> triggersDeleted = flow.isDeleted() ? ListUtils.emptyOnNull(flow.getTriggers()) : FlowService.findRemovedTrigger(flow, previous);
+        if (flow.isDeleted()) {
+            ListUtils.emptyOnNull(flow.getTriggers()).forEach(
+                trigger -> sendTriggerEvent(new TriggerDeleted(TriggerId.of(flow, trigger)))
+            );
+            return;
+        }
 
-            triggersDeleted.forEach(
+        if (previous != null) {
+            FlowService.findRemovedTrigger(flow, previous).forEach(
                 trigger -> sendTriggerEvent(new TriggerDeleted(TriggerId.of(flow, trigger)))
             );
 


### PR DESCRIPTION
## Summary
- Separates the delete path in `recomputeTriggers()` with an early `return` so that deleting a flow only emits `TriggerDeleted` events and doesn't fall through to the update/create blocks below.

Closes #15282