### PR TITLE
Properly reset filters and preserve other query params

### DIFF
--- a/ui/src/components/filter/components/KSFilter.vue
+++ b/ui/src/components/filter/components/KSFilter.vue
@@ -74,7 +74,7 @@
         addFilter,
         removeFilter,
         updateFilter,
-        resetToPreApplied,
+        resetToDefaults,
         hasPreApplied,
         getPreApplied
     } = useFilters(
@@ -140,7 +140,7 @@
         toggleOptions,
         updateChart,
         refreshData,
-        resetToPreApplied,
+        resetToDefaults,
         hasPreApplied,
         getPreApplied,
         editSavedFilter: (filter: SavedFilter) => {

--- a/ui/src/components/filter/components/MainFilter.vue
+++ b/ui/src/components/filter/components/MainFilter.vue
@@ -91,7 +91,7 @@
 <script setup lang="ts">
     import {ref, inject, nextTick, computed} from "vue";
     import {useDebounceFn} from "@vueuse/core";
-    
+
     import {FilterOutline} from "../utils/icons";
 
     import FilterChip from "./layout/FilterChip.vue";
@@ -117,8 +117,8 @@
         return filter.configuration.value.keys?.find((key: any) => key.key === appliedFilter.key) ?? null;
     };
 
-    const setChipRef = (filterId: string, el: any) => el 
-        ? chipRefs.value[filterId] = el 
+    const setChipRef = (filterId: string, el: any) => el
+        ? chipRefs.value[filterId] = el
         : delete chipRefs.value[filterId];
 
     const handleAddFilter = (newFilter: AppliedFilter) => {
@@ -130,7 +130,7 @@
     };
 
     const handleReset = () => {
-        filter.resetToPreApplied();
+        filter.resetToDefaults();
     };
 
     const debouncedUpdateSearch = useDebounceFn((value: string) => {

--- a/ui/src/components/filter/composables/useFilters.ts
+++ b/ui/src/components/filter/composables/useFilters.ts
@@ -21,10 +21,10 @@ import {applyDefaultFilters, useDefaultFilter} from "./useDefaultFilter";
 
 
 export function useFilters(
-    configuration: FilterConfiguration, 
-    showSearchInput = true, 
-    legacyQuery = false, 
-    defaultScope?: boolean, 
+    configuration: FilterConfiguration,
+    showSearchInput = true,
+    legacyQuery = false,
+    defaultScope?: boolean,
     defaultTimeRange?: boolean
 ) {
     const router = useRouter();
@@ -97,7 +97,7 @@ export function useFilters(
         delete query.q;
         delete query.search;
         delete query["filters[q][EQUALS]"];
-        
+
         if (trimmedQuery && showSearchInput) {
             const searchKey = configuration.keys?.length > 0 && !legacyQuery
                 ? "filters[q][EQUALS]"
@@ -223,7 +223,7 @@ export function useFilters(
         value: string | string[]
     ): AppliedFilter => {
         const comparator = (config?.comparators?.[0] as Comparators) ?? Comparators.EQUALS;
-        return createAppliedFilter(key, config, comparator, value, 
+        return createAppliedFilter(key, config, comparator, value,
             config?.valueType === "key-value" && Array.isArray(value)
                 ? value.length > 1 ? `${value[0]} +${value.length - 1}` : value[0] ?? ""
                 : Array.isArray(value)
@@ -272,7 +272,7 @@ export function useFilters(
             const config = configuration.keys?.find(k => k.key === key);
             if (!config) return;
 
-            filtersMap.set(key, createFilter(key, config, 
+            filtersMap.set(key, createFilter(key, config,
                 Array.isArray(value)
                     ? (value as string[]).filter(v => v !== null)
                     : config?.valueType === "multi-select"
@@ -530,17 +530,14 @@ export function useFilters(
     };
     useDefaultFilter(defaultFilterOptions);
 
-    const resetToPreApplied = () => {
-        searchQuery.value = "";
+    const resetToDefaults = () => {
         resetDismissedDefaultVisibleKeys();
 
-        const parsedFilters = legacyQuery ? parseLegacyFilters() : parseEncodedFilters();
-
-        const parsedFilterKeys = new Set(parsedFilters.map((f: AppliedFilter) => f.key));
         const {query: defaultQuery} = applyDefaultFilters({}, defaultFilterOptions);
-        const resetFilters = [...parsedFilters, ...createDefaultVisibleFilters(parsedFilterKeys, dismissedDefaultVisibleKeys.value)];
+        const resetFilters: AppliedFilter[] = [];
 
-        if (defaultFilterOptions.includeTimeRange && !resetFilters.some((f) => f.key === "timeRange")) {
+        // Append time range as first filter to preserve order
+        if (defaultFilterOptions.includeTimeRange) {
             const timeRangeConfig = configuration.keys?.find((k) => k.key === "timeRange");
             const timeRangeQueryKey = legacyQuery ? "timeRange" : "filters[timeRange][EQUALS]";
             const defaultTimeRange = defaultQuery[timeRangeQueryKey];
@@ -561,20 +558,22 @@ export function useFilters(
             }
         }
 
-        appliedFilters.value = resetFilters;
+        // Append default filters
+        resetFilters.push(...createDefaultVisibleFilters(new Set(), dismissedDefaultVisibleKeys.value));
 
-        const query = {
-            ...defaultQuery,
-            ...encodeAppliedFiltersToQuery(resetFilters)
-        };
-
-        if (route.query.size) {
-            query.size = route.query.size;
+        // Preserve non-filter query params and
+        // remove page number to reset to first page
+        const currentQuery = {...route.query};
+        clearFilterQueryParams(currentQuery);
+        if (legacyQuery) {
+            clearLegacyParams(currentQuery);
         }
+        delete currentQuery.page;
 
-        router.replace({query});
+        const query = {...currentQuery, ...defaultQuery};
+        router.replace({query}).then(() => appliedFilters.value = resetFilters);
     };
-    
+
     watch(searchQuery, () => {
         updateRoute(searchQuery.value.trim() !== "");
     });
@@ -587,7 +586,7 @@ export function useFilters(
         removeFilter,
         updateFilter,
         clearFilters,
-        resetToPreApplied,
+        resetToDefaults,
         hasPreApplied,
         getPreApplied,
     };

--- a/ui/src/components/filter/composables/useFilters.ts
+++ b/ui/src/components/filter/composables/useFilters.ts
@@ -170,36 +170,6 @@ export function useFilters(
         router.push({query});
     };
 
-    const encodeAppliedFiltersToQuery = (filters: AppliedFilter[]) => {
-        const query: Record<string, any> = {};
-        const validUniqueFilters = getUniqueFilters(filters.filter(isValidFilter));
-
-        if (legacyQuery) {
-            validUniqueFilters.forEach(filter => {
-                if (configuration.keys?.find(k => k.key === filter.key)?.valueType === "key-value") {
-                    (filter.value as string[]).forEach(item => {
-                        const [k, v] = item.split(":");
-                        query[`${filter.key}.${k}`] = v;
-                    });
-                } else if (Array.isArray(filter.value)) {
-                    filter.value.forEach(item =>
-                        appendQueryParam(query, filter.key, item?.toString() ?? "")
-                    );
-                } else if (isTimeRange(filter)) {
-                    const {startDate, endDate} = filter.value as { startDate: Date; endDate: Date };
-                    query.startDate = startDate.toISOString();
-                    query.endDate = endDate.toISOString();
-                } else {
-                    query[filter.key] = filter.value?.toString() || "";
-                }
-            });
-        } else {
-            Object.assign(query, encodeFiltersToQuery(validUniqueFilters, keyOfComparator));
-        }
-
-        return query;
-    };
-
     const createAppliedFilter = (
         key: string,
         config: any,

--- a/ui/src/components/filter/composables/useFilters.ts
+++ b/ui/src/components/filter/composables/useFilters.ts
@@ -533,6 +533,7 @@ export function useFilters(
         if (legacyQuery) {
             clearLegacyParams(currentQuery);
         }
+        delete currentQuery.page;
 
         const query = {...currentQuery, ...defaultQuery};
         router.replace({query}).then(() => appliedFilters.value = resetFilters);

--- a/ui/src/components/filter/composables/useFilters.ts
+++ b/ui/src/components/filter/composables/useFilters.ts
@@ -19,7 +19,6 @@ import {
 import {usePreAppliedFilters} from "./usePreAppliedFilters";
 import {applyDefaultFilters, useDefaultFilter} from "./useDefaultFilter";
 
-
 export function useFilters(
     configuration: FilterConfiguration,
     showSearchInput = true,
@@ -368,7 +367,6 @@ export function useFilters(
         return Array.from(filtersMap.values());
     };
 
-
         /**
         * Initialize default visible filters. These filters are marked with visibleByDefault: true
         * and are automatically added to the filter list when the page loads, even if no value
@@ -528,17 +526,13 @@ export function useFilters(
             }
         }
 
-        // Append default filters
         resetFilters.push(...createDefaultVisibleFilters(new Set(), dismissedDefaultVisibleKeys.value));
 
-        // Preserve non-filter query params and
-        // remove page number to reset to first page
         const currentQuery = {...route.query};
         clearFilterQueryParams(currentQuery);
         if (legacyQuery) {
             clearLegacyParams(currentQuery);
         }
-        delete currentQuery.page;
 
         const query = {...currentQuery, ...defaultQuery};
         router.replace({query}).then(() => appliedFilters.value = resetFilters);
@@ -561,3 +555,4 @@ export function useFilters(
         getPreApplied,
     };
 }
+

--- a/ui/src/components/filter/utils/filterInjectionKeys.ts
+++ b/ui/src/components/filter/utils/filterInjectionKeys.ts
@@ -34,7 +34,7 @@ export interface FilterContext {
     editSavedFilter: (filter: SavedFilter) => void;
     updateProperties: (columns: string[]) => void;
     deleteSavedFilter: (filter: SavedFilter) => void;
-    resetToPreApplied: () => void;
+    resetToDefaults: () => void;
     hasPreApplied: (filterKey: string) => boolean;
     getPreApplied: (filterKey: string) => AppliedFilter | undefined;
     updateSavedFilter: (id: string, name: string, description: string) => void;

--- a/ui/src/components/filter/utils/filterTypes.ts
+++ b/ui/src/components/filter/utils/filterTypes.ts
@@ -103,7 +103,7 @@ export const COMPARATOR_LABELS: Record<Comparators, string> = {
     [Comparators.ENDS_WITH]: "Ends With",
     [Comparators.CONTAINS]: "Contains",
     [Comparators.REGEX]: "Matches Pattern",
-    [Comparators.PREFIX]: "Namespace Prefix",
+    [Comparators.PREFIX]: "Prefix",
 };
 
 export const COMPARATOR_DESCRIPTIONS: Record<Comparators, string> = {


### PR DESCRIPTION
### ✨ Description

Fixes the "Reset" filter button not actually resetting filters to their default state.

Before:
- Clicking reset kept user-applied filters (e.g. selecting execution state `RUNNING` and clicking reset would keep it)
- Pagination params (`size`, `page`) were wiped from the URL, but the UI still showed the old values - causing a mismatch between displayed page size and actual results
- The reset logic re-parsed the current URL to build the "reset" state, effectively resetting to whatever was already applied

After:
- Reset properly clears all user-applied filters and returns to defaults (timeRange, default visible chips)
- Pagination size is preserved, page is dropped (back to page 1)
- Renamed `resetToPreApplied` → `resetToDefaults` to reflect actual behavior

### 🔗 Related Issue

Pylon: `#1528`

### 🎨 Frontend Checklist

- [x] Code builds without errors (`npm run build`)
- [x] All existing E2E tests pass (`npm run test:e2e`)
- [ ] Screenshots or video recordings attached showing the `UI` changes

### 📝 Additional Notes

All testing was done manually. Key scenarios verified:
- Reset clears user-added filters and restores defaults
- Pagination size param is preserved, page is dropped on reset
- Repeated clicks produce stable results (no reordering, no stale params)
- Tested on dashboard, flows, executions and logs pages