### PR TITLE
fix(tests): allow test loader extensions to work with MicronautTest

### DIFF
--- a/tests/src/main/java/io/kestra/core/junit/extensions/AbstractLoaderExtension.java
+++ b/tests/src/main/java/io/kestra/core/junit/extensions/AbstractLoaderExtension.java
@@ -18,6 +18,7 @@ import io.kestra.core.utils.TestsUtils;
 
 import io.micronaut.context.ApplicationContext;
 import io.micronaut.data.model.Pageable;
+import io.micronaut.test.extensions.junit5.MicronautJunit5Extension;
 
 import static io.kestra.core.junit.extensions.ExtensionUtils.loadFile;
 
@@ -27,14 +28,21 @@ public abstract class AbstractLoaderExtension {
 
     protected void loadApplicationContext(ExtensionContext extensionContext) {
         if (context == null) {
-            extensionContext.getRoot().getStore(ExtensionContext.Namespace.create(KestraTestExtension.class, extensionContext.getTestClass().get())).put("test", "bla");
+            // Try KestraTestExtension namespace (used by @KestraTest)
+            context = extensionContext.getRoot().getStore(
+                ExtensionContext.Namespace.create(KestraTestExtension.class, extensionContext.getTestClass().get())
+            ).get(ApplicationContext.class, ApplicationContext.class);
 
-            context = extensionContext.getRoot().getStore(ExtensionContext.Namespace.create(KestraTestExtension.class, extensionContext.getTestClass().get()))
-                .get(ApplicationContext.class, ApplicationContext.class);
+            // Fallback to MicronautJunit5Extension namespace (used by @MicronautTest)
+            if (context == null) {
+                context = extensionContext.getRoot().getStore(
+                    ExtensionContext.Namespace.create(MicronautJunit5Extension.class)
+                ).get(ApplicationContext.class, ApplicationContext.class);
+            }
 
             if (context == null) {
                 throw new IllegalStateException(
-                    "No application context, to use '@LoadFlows' annotation, you need to add '@KestraTest'"
+                    "No application context, to use this annotation you need to add '@KestraTest' or '@MicronautTest'"
                 );
             }
         }

--- a/tests/src/main/java/io/kestra/core/junit/extensions/KestraTestExtension.java
+++ b/tests/src/main/java/io/kestra/core/junit/extensions/KestraTestExtension.java
@@ -1,7 +1,5 @@
 package io.kestra.core.junit.extensions;
 
-import java.util.Set;
-
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.platform.commons.support.AnnotationSupport;
 
@@ -15,16 +13,21 @@ import io.micronaut.test.extensions.junit5.MicronautJunit5Extension;
 public class KestraTestExtension extends MicronautJunit5Extension {
     @Override
     protected MicronautTestValue buildMicronautTestValue(Class<?> testClass) {
-        testProperties.put("kestra.jdbc.executor.thread-count", Runtime.getRuntime().availableProcessors() * 4);
         return AnnotationSupport
             .findAnnotation(testClass, KestraTest.class)
             .map(kestraTestAnnotation ->
             {
-                var envsSet = new java.util.HashSet<>(Set.of(kestraTestAnnotation.environments()));
-                envsSet.add("test");// add test env if not already present
+                // "test" first so DB-specific configs override test defaults
+                var envs = new java.util.ArrayList<String>();
+                envs.add("test");
+                for (String env : kestraTestAnnotation.environments()) {
+                    if (!"test".equals(env)) {
+                        envs.add(env);
+                    }
+                }
                 return new MicronautTestValue(
                     kestraTestAnnotation.application(),
-                    envsSet.toArray(new String[0]),
+                    envs.toArray(new String[0]),
                     kestraTestAnnotation.packages(),
                     kestraTestAnnotation.propertySources(),
                     kestraTestAnnotation.rollback(),

--- a/tests/src/main/java/io/kestra/core/junit/extensions/TriggerEvaluationExtension.java
+++ b/tests/src/main/java/io/kestra/core/junit/extensions/TriggerEvaluationExtension.java
@@ -20,6 +20,7 @@ import io.kestra.core.runners.RunContextInitializer;
 import io.kestra.core.serializers.YamlParser;
 
 import io.micronaut.context.ApplicationContext;
+import io.micronaut.test.extensions.junit5.MicronautJunit5Extension;
 import lombok.SneakyThrows;
 
 /**
@@ -63,12 +64,20 @@ public class TriggerEvaluationExtension implements ParameterResolver {
 
     private void ensureContext(ExtensionContext extensionContext) {
         if (context == null) {
+            // Try KestraTestExtension namespace (used by @KestraTest)
             context = extensionContext.getRoot()
                 .getStore(ExtensionContext.Namespace.create(KestraTestExtension.class, extensionContext.getTestClass().get()))
                 .get(ApplicationContext.class, ApplicationContext.class);
 
+            // Fallback to MicronautJunit5Extension namespace (used by @MicronautTest)
             if (context == null) {
-                throw new IllegalStateException("No ApplicationContext found. Add @KestraTest to the test class.");
+                context = extensionContext.getRoot()
+                    .getStore(ExtensionContext.Namespace.create(MicronautJunit5Extension.class))
+                    .get(ApplicationContext.class, ApplicationContext.class);
+            }
+
+            if (context == null) {
+                throw new IllegalStateException("No ApplicationContext found. Add @KestraTest or @MicronautTest to the test class.");
             }
             runContextFactory = context.getBean(RunContextFactory.class);
             runContextInitializer = context.getBean(RunContextInitializer.class);


### PR DESCRIPTION
AbstractLoaderExtension and TriggerEvaluationExtension hardcoded the ApplicationContext lookup to the KestraTestExtension store namespace. Add a fallback to also check MicronautJunit5Extension namespace so loader annotations work with plain MicronautTest.