### PR TITLE
refactor(core): add subscriber tracking lifebelt to AbstractQueue

### DIFF
--- a/queue-jdbc/src/main/java/io/kestra/queue/jdbc/JdbcBroadcastQueue.java
+++ b/queue-jdbc/src/main/java/io/kestra/queue/jdbc/JdbcBroadcastQueue.java
@@ -32,7 +32,7 @@ public class JdbcBroadcastQueue<T extends BroadcastEvent> extends AbstractBroadc
     }
 
     @Override
-    public QueueSubscriber<T> subscriber() {
+    protected QueueSubscriber<T> doSubscriber() {
         return new JdbcBroadcastSubscriber<>(
             cls,
             queueService,

--- a/queue-jdbc/src/main/java/io/kestra/queue/jdbc/JdbcDispatchQueue.java
+++ b/queue-jdbc/src/main/java/io/kestra/queue/jdbc/JdbcDispatchQueue.java
@@ -32,7 +32,7 @@ public class JdbcDispatchQueue<T extends DispatchEvent> extends AbstractDispatch
     }
 
     @Override
-    public QueueSubscriber<T> subscriber() {
+    protected QueueSubscriber<T> doSubscriber() {
         return new JdbcDispatchSubscriber<>(
             cls,
             queueService,

--- a/queue-jdbc/src/main/java/io/kestra/queue/jdbc/JdbcKeyedDispatchQueue.java
+++ b/queue-jdbc/src/main/java/io/kestra/queue/jdbc/JdbcKeyedDispatchQueue.java
@@ -32,7 +32,7 @@ public class JdbcKeyedDispatchQueue<T extends KeyedDispatchEvent> extends Abstra
     }
 
     @Override
-    public QueueSubscriber<T> subscriber(String routingKey) {
+    protected QueueSubscriber<T> doSubscriber(String routingKey) {
         return new JdbcDispatchSubscriber<>(
             cls,
             queueService,

--- a/queue-jdbc/src/main/java/io/kestra/queue/jdbc/JdbcVNodeDispatchQueue.java
+++ b/queue-jdbc/src/main/java/io/kestra/queue/jdbc/JdbcVNodeDispatchQueue.java
@@ -59,7 +59,7 @@ public class JdbcVNodeDispatchQueue<T extends VNodeDispatchEvent> extends Abstra
     }
 
     @Override
-    public QueueSubscriber<T> subscriber(Set<Integer> vNodes) {
+    protected QueueSubscriber<T> doSubscriber(Set<Integer> vNodes) {
         return new JdbcDispatchSubscriber<>(
             cls,
             queueService,

--- a/queue/src/main/java/io/kestra/queue/AbstractBroadcastQueue.java
+++ b/queue/src/main/java/io/kestra/queue/AbstractBroadcastQueue.java
@@ -8,6 +8,7 @@ import java.util.concurrent.CompletionStage;
 import io.kestra.core.metrics.MetricRegistry;
 import io.kestra.core.queues.BroadcastQueueInterface;
 import io.kestra.core.queues.QueueException;
+import io.kestra.core.queues.QueueSubscriber;
 import io.kestra.core.queues.event.BroadcastEvent;
 import io.kestra.core.utils.ExecutorsUtils;
 
@@ -61,6 +62,13 @@ public abstract class AbstractBroadcastQueue<T extends BroadcastEvent> extends A
             }
         }, asyncPoolExecutor);
     }
+
+    @Override
+    public final QueueSubscriber<T> subscriber() {
+        return trackSubscriber(doSubscriber());
+    }
+
+    protected abstract QueueSubscriber<T> doSubscriber();
 
     protected abstract void doEmit(byte[] message, String key) throws QueueException;
 

--- a/queue/src/main/java/io/kestra/queue/AbstractDispatchQueue.java
+++ b/queue/src/main/java/io/kestra/queue/AbstractDispatchQueue.java
@@ -8,6 +8,7 @@ import java.util.concurrent.CompletionStage;
 import io.kestra.core.metrics.MetricRegistry;
 import io.kestra.core.queues.DispatchQueueInterface;
 import io.kestra.core.queues.QueueException;
+import io.kestra.core.queues.QueueSubscriber;
 import io.kestra.core.queues.event.DispatchEvent;
 import io.kestra.core.utils.ExecutorsUtils;
 
@@ -61,6 +62,13 @@ public abstract class AbstractDispatchQueue<T extends DispatchEvent> extends Abs
             }
         }, asyncPoolExecutor);
     }
+
+    @Override
+    public final QueueSubscriber<T> subscriber() {
+        return trackSubscriber(doSubscriber());
+    }
+
+    protected abstract QueueSubscriber<T> doSubscriber();
 
     protected abstract void doEmit(byte[] message, String key) throws QueueException;
 

--- a/queue/src/main/java/io/kestra/queue/AbstractKeyedDispatchQueue.java
+++ b/queue/src/main/java/io/kestra/queue/AbstractKeyedDispatchQueue.java
@@ -8,6 +8,7 @@ import java.util.concurrent.CompletionStage;
 import io.kestra.core.metrics.MetricRegistry;
 import io.kestra.core.queues.KeyedDispatchQueueInterface;
 import io.kestra.core.queues.QueueException;
+import io.kestra.core.queues.QueueSubscriber;
 import io.kestra.core.queues.event.KeyedDispatchEvent;
 import io.kestra.core.utils.ExecutorsUtils;
 
@@ -62,6 +63,13 @@ public abstract class AbstractKeyedDispatchQueue<T extends KeyedDispatchEvent> e
             }
         }, asyncPoolExecutor);
     }
+
+    @Override
+    public final QueueSubscriber<T> subscriber(String routingKey) {
+        return trackSubscriber(doSubscriber(routingKey));
+    }
+
+    protected abstract QueueSubscriber<T> doSubscriber(String routingKey);
 
     protected abstract void doEmit(String routingKey, byte[] message, String key) throws QueueException;
 

--- a/queue/src/main/java/io/kestra/queue/AbstractQueue.java
+++ b/queue/src/main/java/io/kestra/queue/AbstractQueue.java
@@ -13,6 +13,7 @@ import com.google.common.base.CaseFormat;
 
 import io.kestra.core.metrics.MetricRegistry;
 import io.kestra.core.queues.GenericQueueInterface;
+import io.kestra.core.queues.QueueSubscriber;
 import io.kestra.core.queues.event.Event;
 import io.kestra.core.utils.ExecutorsUtils;
 
@@ -27,6 +28,7 @@ abstract class AbstractQueue<T extends Event> implements GenericQueueInterface<T
     protected final ExecutorService asyncPoolExecutor;
     protected final Counter emitCounter;
     private final List<Consumer<T>> listeners = new CopyOnWriteArrayList<>();
+    private final List<QueueSubscriber<?>> subscribers = new CopyOnWriteArrayList<>();
 
     AbstractQueue(Class<T> cls, QueueService queueService, ExecutorsUtils executorsUtils, MetricRegistry metricRegistry) {
         this.cls = cls;
@@ -86,8 +88,31 @@ abstract class AbstractQueue<T extends Event> implements GenericQueueInterface<T
         return listeners;
     }
 
+    /**
+     * Tracks a subscriber so it can be closed when the queue is closed.
+     * Subclasses should call this method when creating subscribers.
+     *
+     * @param subscriber the subscriber to track
+     * @return the subscriber, for fluent chaining
+     */
+    protected <S extends QueueSubscriber<T>> S trackSubscriber(S subscriber) {
+        subscribers.add(subscriber);
+        return subscriber;
+    }
+
     @Override
     public void close() {
+        for (QueueSubscriber<?> subscriber : subscribers) {
+            if (subscriber instanceof AbstractSubscriber<?> abs && abs.isActive()) {
+                LOG.warn("{} closing subscriber that was not closed by its caller", queueName());
+                try {
+                    subscriber.close();
+                } catch (Exception e) {
+                    LOG.error("{} error closing subscriber", queueName(), e);
+                }
+            }
+        }
+        subscribers.clear();
         this.asyncPoolExecutor.shutdown();
     }
 }

--- a/queue/src/main/java/io/kestra/queue/AbstractVNodeDispatchQueue.java
+++ b/queue/src/main/java/io/kestra/queue/AbstractVNodeDispatchQueue.java
@@ -5,8 +5,11 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.CompletionStage;
 
+import java.util.Set;
+
 import io.kestra.core.metrics.MetricRegistry;
 import io.kestra.core.queues.QueueException;
+import io.kestra.core.queues.QueueSubscriber;
 import io.kestra.core.queues.VNodeDispatchQueueInterface;
 import io.kestra.core.queues.event.VNodeDispatchEvent;
 import io.kestra.core.utils.ExecutorsUtils;
@@ -61,6 +64,13 @@ public abstract class AbstractVNodeDispatchQueue<T extends VNodeDispatchEvent> e
             }
         }, asyncPoolExecutor);
     }
+
+    @Override
+    public final QueueSubscriber<T> subscriber(Set<Integer> vNodes) {
+        return trackSubscriber(doSubscriber(vNodes));
+    }
+
+    protected abstract QueueSubscriber<T> doSubscriber(Set<Integer> vNodes);
 
     protected abstract void doEmit(byte[] message, String key) throws QueueException;
 


### PR DESCRIPTION
Track all subscribers created via subscriber() so the queue can close any that were not closed by their callers. Uses the existing emit/doEmit template-method pattern: subscriber() is now final in the abstract queue classes and delegates to doSubscriber() in concrete implementations.