### PR TITLE
build(deps): pin axios to version 1.13.6 to mitigate supply chain attack via dependency injection

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -16,7 +16,7 @@
                 "@vue-flow/core": "^1.48.2",
                 "@vueuse/core": "^14.2.1",
                 "ansi-to-html": "^0.7.2",
-                "axios": "^1.13.6",
+                "axios": "1.13.6",
                 "bootstrap": "^5.3.8",
                 "buffer": "^6.0.3",
                 "chart.js": "^4.5.1",

--- a/ui/package.json
+++ b/ui/package.json
@@ -153,6 +153,7 @@
         "lightningcss-linux-x64-gnu": "^1.32.0"
     },
     "overrides": {
+        "axios": "1.13.6",
         "bootstrap": {
             "@popperjs/core": "npm:@sxzz/popperjs-es@^2.11.7"
         },

--- a/ui/package.json
+++ b/ui/package.json
@@ -32,7 +32,7 @@
         "@vue-flow/core": "^1.48.2",
         "@vueuse/core": "^14.2.1",
         "ansi-to-html": "^0.7.2",
-        "axios": "^1.13.6",
+        "axios": "1.13.6",
         "bootstrap": "^5.3.8",
         "buffer": "^6.0.3",
         "chart.js": "^4.5.1",


### PR DESCRIPTION
Pin `axios` to exact version 1.13.6 to prevent resolution of compromised versions.

https://safedep.io/axios-npm-supply-chain-compromise