### PR TITLE
fix(worker): exclude repository-dependent beans from workers and add gRPC maintenance endpoint

### DIFF
--- a/core/src/main/java/io/kestra/core/namespace/DefaultNamespaceFileMetadataStateStore.java
+++ b/core/src/main/java/io/kestra/core/namespace/DefaultNamespaceFileMetadataStateStore.java
@@ -24,7 +24,7 @@ import jakarta.inject.Singleton;
  * where the repository is available. Workers use a gRPC-based implementation instead.
  */
 @Singleton
-@Requires(property = "kestra.server-type", notEquals = "WORKER")
+@Requires(beans = NamespaceFileMetadataRepositoryInterface.class)
 public class DefaultNamespaceFileMetadataStateStore implements NamespaceFileMetadataStateStore {
 
     private final NamespaceFileMetadataRepositoryInterface repository;

--- a/core/src/main/java/io/kestra/core/runners/DefaultKVMetadataStateStore.java
+++ b/core/src/main/java/io/kestra/core/runners/DefaultKVMetadataStateStore.java
@@ -22,7 +22,7 @@ import jakarta.inject.Singleton;
  * where the repository is available. Workers use a gRPC-based implementation instead.
  */
 @Singleton
-@Requires(property = "kestra.server-type", notEquals = "WORKER")
+@Requires(beans = KvMetadataRepositoryInterface.class)
 public class DefaultKVMetadataStateStore implements KVMetadataStateStore {
 
     private final KvMetadataRepositoryInterface kvMetadataRepository;

--- a/core/src/main/java/io/kestra/core/services/InstanceService.java
+++ b/core/src/main/java/io/kestra/core/services/InstanceService.java
@@ -8,6 +8,8 @@ import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 import lombok.extern.slf4j.Slf4j;
 
+import java.util.Optional;
+
 @Singleton
 @Slf4j
 public class InstanceService {
@@ -15,8 +17,8 @@ public class InstanceService {
     private final SettingRepositoryInterface settingRepository;
 
     @Inject
-    public InstanceService(SettingRepositoryInterface settingRepository) {
-        this.settingRepository = settingRepository;
+    public InstanceService(Optional<SettingRepositoryInterface> settingRepository) {
+        this.settingRepository = settingRepository.orElse(null);
     }
 
     private volatile Setting instanceIdSetting;
@@ -33,6 +35,12 @@ public class InstanceService {
     }
 
     private Setting fetchInstanceUuid() {
+        if (settingRepository == null) {
+            return Setting.builder()
+                .key(Setting.INSTANCE_UUID)
+                .value(IdUtils.create())
+                .build();
+        }
         return settingRepository
             .findByKey(Setting.INSTANCE_UUID)
             .orElseGet(

--- a/core/src/main/java/io/kestra/core/services/InstanceService.java
+++ b/core/src/main/java/io/kestra/core/services/InstanceService.java
@@ -35,12 +35,6 @@ public class InstanceService {
     }
 
     private Setting fetchInstanceUuid() {
-        if (settingRepository == null) {
-            return Setting.builder()
-                .key(Setting.INSTANCE_UUID)
-                .value(IdUtils.create())
-                .build();
-        }
         return settingRepository
             .findByKey(Setting.INSTANCE_UUID)
             .orElseGet(

--- a/worker-controller/src/main/java/io/kestra/controller/grpc/services/GrpcLivenessControllerService.java
+++ b/worker-controller/src/main/java/io/kestra/controller/grpc/services/GrpcLivenessControllerService.java
@@ -1,11 +1,7 @@
 package io.kestra.controller.grpc.services;
 
-import java.util.concurrent.atomic.AtomicBoolean;
-
-import io.kestra.controller.grpc.HeartbeatRequest;
-import io.kestra.controller.grpc.HeartbeatResponse;
-import io.kestra.controller.grpc.LivenessControllerServiceGrpc;
-import io.kestra.controller.grpc.WorkerControllerService;
+import io.grpc.stub.StreamObserver;
+import io.kestra.controller.grpc.*;
 import io.kestra.controller.messages.HeartbeatMessage;
 import io.kestra.controller.messages.HeartbeatMessageReply;
 import io.kestra.controller.messages.MessageFormat;
@@ -13,11 +9,11 @@ import io.kestra.core.server.ServiceLivenessUpdater;
 import io.kestra.core.server.ServiceStateTransition;
 import io.kestra.core.services.MaintenanceService;
 import io.kestra.core.utils.Disposable;
-
-import io.grpc.stub.StreamObserver;
 import jakarta.annotation.PreDestroy;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
+
+import java.util.concurrent.atomic.AtomicBoolean;
 
 @Singleton
 public class GrpcLivenessControllerService extends LivenessControllerServiceGrpc.LivenessControllerServiceImplBase implements WorkerControllerService {
@@ -79,6 +75,19 @@ public class GrpcLivenessControllerService extends LivenessControllerServiceGrpc
                 )
                 .build()
         );
+        responseObserver.onCompleted();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void getMaintenanceMode(EmptyRequest request, StreamObserver<GetMaintenanceResponse> responseObserver) {
+        GetMaintenanceResponse response = GetMaintenanceResponse.newBuilder()
+            .setHeader(request.getHeader())
+            .setMaintenance(maintenanceMode.get())
+            .build();
+        responseObserver.onNext(response);
         responseObserver.onCompleted();
     }
 


### PR DESCRIPTION
Use @Requires(beans = XxxRepository.class) on all beans that inject repositories Add getMaintenanceMode gRPC endpoint
Make SettingRepository optional in InstanceService to prevent
  worker startup failure
Upgrade spotless dependencies
