### PR TITLE
feat: validate JSON flow inputs against jsonSchema

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -66,6 +66,9 @@ dependencies {
         exclude group: 'com.fasterxml.jackson.core'
     }
 
+    // Json schema validator
+    implementation 'com.networknt:json-schema-validator'
+
     // micrometer
     implementation "io.micronaut.micrometer:micronaut-micrometer-observation"
     implementation 'io.micrometer:micrometer-java21'

--- a/core/src/main/java/io/kestra/core/models/flows/input/JsonInput.java
+++ b/core/src/main/java/io/kestra/core/models/flows/input/JsonInput.java
@@ -1,7 +1,19 @@
 package io.kestra.core.models.flows.input;
 
-import io.kestra.core.models.flows.Input;
+import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.networknt.schema.Error;
+import com.networknt.schema.Schema;
+import com.networknt.schema.SchemaRegistry;
+import com.networknt.schema.dialect.Dialects;
+
+import io.kestra.core.models.flows.Input;
+import io.kestra.core.models.validations.ManualConstraintViolation;
+import io.kestra.core.serializers.JacksonMapper;
 import jakarta.validation.ConstraintViolationException;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -11,8 +23,56 @@ import lombok.experimental.SuperBuilder;
 @Getter
 @NoArgsConstructor
 public class JsonInput extends Input<Object> {
+    private static final ObjectMapper MAPPER = JacksonMapper.ofJson();
+    private static final SchemaRegistry SCHEMA_REGISTRY = SchemaRegistry.withDialect(Dialects.getDraft202012());
+    private static final ConcurrentHashMap<String, Schema> SCHEMA_CACHE = new ConcurrentHashMap<>();
+
+    @io.swagger.v3.oas.annotations.media.Schema(title = "A JSON schema used to validate the input value.")
+    String jsonSchema;
+
     @Override
     public void validate(Object input) throws ConstraintViolationException {
-        // no validation yet
+        if (jsonSchema == null || jsonSchema.isBlank()) {
+            return;
+        }
+
+        try {
+            JsonNode schemaNode = MAPPER.readTree(jsonSchema);
+            Schema schema = getOrCreateSchema(schemaNode);
+
+            JsonNode inputNode = (input instanceof String s) ? MAPPER.readTree(s) : MAPPER.valueToTree(input);
+            List<Error> errors = schema.validate(inputNode);
+
+            if (!errors.isEmpty()) {
+                throw ManualConstraintViolation.toConstraintViolationException(
+                    "it must match the json schema: " + errors,
+                    this,
+                    JsonInput.class,
+                    getId(),
+                    input
+                );
+            }
+        } catch (JsonProcessingException e) {
+            throw ManualConstraintViolation.toConstraintViolationException(
+                "Invalid JSON content or schema: " + e.getMessage(),
+                this,
+                JsonInput.class,
+                getId(),
+                input
+            );
+        } catch (RuntimeException e) {
+            throw ManualConstraintViolation.toConstraintViolationException(
+                "Invalid JSON schema: " + e.getMessage(),
+                this,
+                JsonInput.class,
+                getId(),
+                jsonSchema
+            );
+        }
+    }
+
+    private static Schema getOrCreateSchema(JsonNode schemaNode) {
+        String cacheKey = schemaNode.has("$id") ? schemaNode.get("$id").asText() : Integer.toString(schemaNode.hashCode());
+        return SCHEMA_CACHE.computeIfAbsent(cacheKey, key -> SCHEMA_REGISTRY.getSchema(schemaNode));
     }
 }

--- a/core/src/main/java/io/kestra/core/models/flows/input/JsonInput.java
+++ b/core/src/main/java/io/kestra/core/models/flows/input/JsonInput.java
@@ -1,7 +1,6 @@
 package io.kestra.core.models.flows.input;
 
 import java.util.List;
-import java.util.concurrent.ConcurrentHashMap;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -25,7 +24,6 @@ import lombok.experimental.SuperBuilder;
 public class JsonInput extends Input<Object> {
     private static final ObjectMapper MAPPER = JacksonMapper.ofJson();
     private static final SchemaRegistry SCHEMA_REGISTRY = SchemaRegistry.withDialect(Dialects.getDraft202012());
-    private static final ConcurrentHashMap<String, Schema> SCHEMA_CACHE = new ConcurrentHashMap<>();
 
     @io.swagger.v3.oas.annotations.media.Schema(title = "A JSON schema used to validate the input value.")
     String jsonSchema;
@@ -38,7 +36,7 @@ public class JsonInput extends Input<Object> {
 
         try {
             JsonNode schemaNode = MAPPER.readTree(jsonSchema);
-            Schema schema = getOrCreateSchema(schemaNode);
+            Schema schema = SCHEMA_REGISTRY.getSchema(schemaNode);
 
             JsonNode inputNode = (input instanceof String s) ? MAPPER.readTree(s) : MAPPER.valueToTree(input);
             List<Error> errors = schema.validate(inputNode);
@@ -69,10 +67,5 @@ public class JsonInput extends Input<Object> {
                 jsonSchema
             );
         }
-    }
-
-    private static Schema getOrCreateSchema(JsonNode schemaNode) {
-        String cacheKey = schemaNode.has("$id") ? schemaNode.get("$id").asText() : Integer.toString(schemaNode.hashCode());
-        return SCHEMA_CACHE.computeIfAbsent(cacheKey, key -> SCHEMA_REGISTRY.getSchema(schemaNode));
     }
 }

--- a/core/src/main/java/io/kestra/core/models/flows/input/JsonInput.java
+++ b/core/src/main/java/io/kestra/core/models/flows/input/JsonInput.java
@@ -3,12 +3,14 @@ package io.kestra.core.models.flows.input;
 import java.util.List;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.core.JacksonException;
 import com.networknt.schema.Error;
 import com.networknt.schema.Schema;
 import com.networknt.schema.SchemaRegistry;
 import com.networknt.schema.dialect.Dialects;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.json.JsonMapper;
 
 import io.kestra.core.models.flows.Input;
 import io.kestra.core.models.validations.ManualConstraintViolation;
@@ -22,7 +24,8 @@ import lombok.experimental.SuperBuilder;
 @Getter
 @NoArgsConstructor
 public class JsonInput extends Input<Object> {
-    private static final ObjectMapper MAPPER = JacksonMapper.ofJson();
+    private static final ObjectMapper FASTERXML_MAPPER = JacksonMapper.ofJson();
+    private static final JsonMapper TOOLS_MAPPER = JsonMapper.builder().build();
     private static final SchemaRegistry SCHEMA_REGISTRY = SchemaRegistry.withDialect(Dialects.getDraft202012());
 
     @io.swagger.v3.oas.annotations.media.Schema(title = "A JSON schema used to validate the input value.")
@@ -35,10 +38,11 @@ public class JsonInput extends Input<Object> {
         }
 
         try {
-            JsonNode schemaNode = MAPPER.readTree(jsonSchema);
+            final JsonNode schemaNode = TOOLS_MAPPER.readTree(jsonSchema);
             Schema schema = SCHEMA_REGISTRY.getSchema(schemaNode);
 
-            JsonNode inputNode = (input instanceof String s) ? MAPPER.readTree(s) : MAPPER.valueToTree(input);
+            String inputJson = (input instanceof String s) ? s : FASTERXML_MAPPER.writeValueAsString(input);
+            JsonNode inputNode = TOOLS_MAPPER.readTree(inputJson);
             List<Error> errors = schema.validate(inputNode);
 
             if (!errors.isEmpty()) {
@@ -50,7 +54,7 @@ public class JsonInput extends Input<Object> {
                     input
                 );
             }
-        } catch (JsonProcessingException e) {
+        } catch (JsonProcessingException | JacksonException e) {
             throw ManualConstraintViolation.toConstraintViolationException(
                 "Invalid JSON content or schema: " + e.getMessage(),
                 this,

--- a/core/src/test/java/io/kestra/core/models/flows/input/JsonInputSchemaFlowIntegrationTest.java
+++ b/core/src/test/java/io/kestra/core/models/flows/input/JsonInputSchemaFlowIntegrationTest.java
@@ -1,0 +1,79 @@
+package io.kestra.core.models.flows.input;
+
+import java.util.Map;
+import java.util.concurrent.TimeoutException;
+
+import org.junit.jupiter.api.Test;
+
+import io.kestra.core.exceptions.InputOutputValidationException;
+import io.kestra.core.junit.annotations.KestraTest;
+import io.kestra.core.junit.annotations.LoadFlows;
+import io.kestra.core.models.executions.Execution;
+import io.kestra.core.models.flows.State;
+import io.kestra.core.queues.QueueException;
+import io.kestra.core.runners.FlowInputOutput;
+import io.kestra.core.runners.TestRunnerUtils;
+
+import jakarta.inject.Inject;
+
+import static io.kestra.core.tenant.TenantService.MAIN_TENANT;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@KestraTest(startRunner = true)
+class JsonInputSchemaFlowIntegrationTest {
+    @Inject
+    private TestRunnerUtils runnerUtils;
+
+    @Inject
+    private FlowInputOutput flowIO;
+
+    @Test
+    @LoadFlows("flows/valids/json-input-schema-validation.yaml")
+    void shouldRunFlowWhenJsonInputMatchesSchema() throws TimeoutException, QueueException, io.kestra.core.exceptions.InternalException {
+        // Given
+        Map<String, Object> inputs = Map.of(
+            "jsonWithSchema", Map.of("name", "kestra"),
+            "jsonWithoutSchema", Map.of("any", "shape")
+        );
+
+        // When
+        Execution execution = runnerUtils.runOne(
+            MAIN_TENANT,
+            "io.kestra.tests",
+            "json-input-schema-validation",
+            null,
+            (flow, execution1) -> flowIO.readExecutionInputs(flow, execution1, inputs)
+        );
+
+        // Then
+        assertThat(execution.getState().getCurrent()).isEqualTo(State.Type.SUCCESS);
+        assertThat(execution.getTaskRunList()).hasSize(2);
+    }
+
+    @Test
+    @LoadFlows("flows/valids/json-input-schema-validation.yaml")
+    void shouldFailWhenJsonInputDoesNotMatchSchema() {
+        // Given
+        Map<String, Object> inputs = Map.of(
+            "jsonWithSchema", Map.of("name", 42),
+            "jsonWithoutSchema", Map.of("ok", true)
+        );
+
+        // When
+        InputOutputValidationException exception = assertThrows(
+            InputOutputValidationException.class,
+            () -> runnerUtils.runOne(
+                MAIN_TENANT,
+                "io.kestra.tests",
+                "json-input-schema-validation",
+                null,
+                (flow, execution1) -> flowIO.readExecutionInputs(flow, execution1, inputs)
+            )
+        );
+
+        // Then
+        assertThat(exception.getMessage()).contains("Invalid value for input `jsonWithSchema`");
+        assertThat(exception.getMessage()).contains("it must match the json schema");
+    }
+}

--- a/core/src/test/java/io/kestra/core/models/flows/input/JsonInputTest.java
+++ b/core/src/test/java/io/kestra/core/models/flows/input/JsonInputTest.java
@@ -1,0 +1,141 @@
+package io.kestra.core.models.flows.input;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import jakarta.validation.ConstraintViolationException;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class JsonInputTest {
+    @Test
+    void shouldValidateInputAgainstSchema() {
+        // Given
+        JsonInput input = JsonInput.builder()
+            .id("payload")
+            .jsonSchema("""
+                {
+                  "$schema": "https://json-schema.org/draft/2020-12/schema",
+                  "type": "object",
+                  "required": ["name"],
+                  "properties": {
+                    "name": { "type": "string" },
+                    "age": { "type": "integer" }
+                  },
+                  "additionalProperties": false
+                }
+                """)
+            .build();
+
+        // When / Then
+        assertDoesNotThrow(() -> input.validate(Map.of("name", "kestra", "age", 3)));
+    }
+
+    @Test
+    void shouldFailWhenInputDoesNotMatchSchema() {
+        // Given
+        JsonInput input = JsonInput.builder()
+            .id("payload")
+            .jsonSchema("""
+                {
+                  "$schema": "https://json-schema.org/draft/2020-12/schema",
+                  "type": "object",
+                  "required": ["name"],
+                  "properties": {
+                    "name": { "type": "string" }
+                  },
+                  "additionalProperties": false
+                }
+                """)
+            .build();
+
+        // When
+        ConstraintViolationException exception = assertThrows(
+            ConstraintViolationException.class,
+            () -> input.validate(Map.of("unknown", "value"))
+        );
+
+        // Then
+        assertTrue(exception.getMessage().contains("it must match the json schema"));
+    }
+
+    @Test
+    void shouldFailWhenSchemaIsInvalidJson() {
+        // Given
+        JsonInput input = JsonInput.builder()
+            .id("payload")
+            .jsonSchema("{ this-is-not-json")
+            .build();
+
+        // When
+        ConstraintViolationException exception = assertThrows(
+            ConstraintViolationException.class,
+            () -> input.validate(Map.of("name", "kestra"))
+        );
+
+        // Then
+        assertTrue(exception.getMessage().contains("Invalid JSON content or schema"));
+    }
+
+    @Test
+    void shouldValidateWhenInputIsAJsonString() {
+        // Given
+        JsonInput input = JsonInput.builder()
+            .id("payload")
+            .jsonSchema("""
+                {
+                  "$schema": "https://json-schema.org/draft/2020-12/schema",
+                  "type": "object",
+                  "required": ["name"],
+                  "properties": {
+                    "name": { "type": "string" }
+                  }
+                }
+                """)
+            .build();
+
+        // When / Then
+        assertDoesNotThrow(() -> input.validate("{\"name\":\"kestra\"}"));
+    }
+
+    @Test
+    void shouldFailWhenInputStringIsInvalidJson() {
+        // Given
+        JsonInput input = JsonInput.builder()
+            .id("payload")
+            .jsonSchema("""
+                {
+                  "$schema": "https://json-schema.org/draft/2020-12/schema",
+                  "type": "object",
+                  "properties": {
+                    "name": { "type": "string" }
+                  }
+                }
+                """)
+            .build();
+
+        // When
+        ConstraintViolationException exception = assertThrows(
+            ConstraintViolationException.class,
+            () -> input.validate("{not-json}")
+        );
+
+        // Then
+        assertTrue(exception.getMessage().contains("Invalid JSON content or schema"));
+    }
+
+    @Test
+    void shouldSkipValidationWhenSchemaIsBlank() {
+        // Given
+        JsonInput input = JsonInput.builder()
+            .id("payload")
+            .jsonSchema("   ")
+            .build();
+
+        // When / Then
+        assertDoesNotThrow(() -> input.validate(Map.of("anything", true)));
+    }
+}

--- a/core/src/test/resources/flows/valids/json-input-schema-validation.yaml
+++ b/core/src/test/resources/flows/valids/json-input-schema-validation.yaml
@@ -1,0 +1,26 @@
+id: json-input-schema-validation
+namespace: io.kestra.tests
+
+inputs:
+  - id: jsonWithSchema
+    type: JSON
+    jsonSchema: |
+      {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "type": "object",
+        "required": ["name"],
+        "properties": {
+          "name": { "type": "string" }
+        },
+        "additionalProperties": false
+      }
+  - id: jsonWithoutSchema
+    type: JSON
+
+tasks:
+  - id: withSchema
+    type: io.kestra.plugin.core.debug.Return
+    format: "{{ inputs.jsonWithSchema }}"
+  - id: withoutSchema
+    type: io.kestra.plugin.core.debug.Return
+    format: "{{ inputs.jsonWithoutSchema }}"

--- a/platform/build.gradle
+++ b/platform/build.gradle
@@ -113,6 +113,7 @@ dependencies {
         api group: 'com.github.victools', name: 'jsonschema-module-jakarta-validation', version: jsonschemaVersion
         api group: 'com.github.victools', name: 'jsonschema-module-jackson', version: jsonschemaVersion
         api group: 'com.github.victools', name: 'jsonschema-module-swagger-2', version: jsonschemaVersion
+        api group: 'com.networknt', name: 'json-schema-validator', version: '2.0.0'
         api 'com.h2database:h2:2.4.240'
         api 'com.mysql:mysql-connector-j:9.6.0'
         api 'org.postgresql:postgresql:42.7.10'

--- a/platform/build.gradle
+++ b/platform/build.gradle
@@ -113,7 +113,7 @@ dependencies {
         api group: 'com.github.victools', name: 'jsonschema-module-jakarta-validation', version: jsonschemaVersion
         api group: 'com.github.victools', name: 'jsonschema-module-jackson', version: jsonschemaVersion
         api group: 'com.github.victools', name: 'jsonschema-module-swagger-2', version: jsonschemaVersion
-        api group: 'com.networknt', name: 'json-schema-validator', version: '2.0.0'
+        api group: 'com.networknt', name: 'json-schema-validator', version: '3.0.1'
         api 'com.h2database:h2:2.4.240'
         api 'com.mysql:mysql-connector-j:9.6.0'
         api 'org.postgresql:postgresql:42.7.10'


### PR DESCRIPTION
### ✨ Description

This PR adds runtime validation for JSON flow inputs when jsonSchema is provided on JsonInput.

Changes included:

- Implements JsonInput.validate(...) in:
    - kestra/core/src/main/java/io/kestra/core/models/flows/input/JsonInput.java
- Uses the same JSON schema validation stack used in the MCP Java SDK (com.networknt:json-schema-
validator) to avoid custom/partial schema logic.
- Supports validation for both:
    - object/map input values
    - string input values containing JSON
- Dependency updates:
    - kestra/core/build.gradle adds com.networknt:json-schema-validator
    - kestra/platform/build.gradle pins com.networknt:json-schema-validator:2.0.0

This is implemented to support MCP worker work where structured JSON input validation is required.

### 🔗 Related Issue

Relates to https://github.com/kestra-io/kestra/issues/15040.

### 🛠️ Backend Checklist

- [x] Code compiles successfully and passes all checks
- [x] All unit and integration tests pass

### 📝 Additional Notes

- The validator implementation intentionally mirrors MCP Java SDK’s NetworkNT approach (SchemaRegistry and dialect-based schema validation) for consistency.