### PR TITLE
feat(flow, execution): `Loop` task with transparent sub-executions

### DIFF
--- a/core/src/main/java/io/kestra/core/models/executions/Execution.java
+++ b/core/src/main/java/io/kestra/core/models/executions/Execution.java
@@ -130,6 +130,9 @@ public class Execution implements SoftDeletable<Execution>, TenantInterface, Has
     @Nullable
     List<Breakpoint> breakpoints;
 
+    @Nullable
+    LoopRun loopRun;
+
     @Override
     @JsonIgnore
     public String uid() {
@@ -276,7 +279,8 @@ public class Execution implements SoftDeletable<Execution>, TenantInterface, Has
             this.traceParent,
             this.fixtures,
             this.kind,
-            this.breakpoints
+            this.breakpoints,
+            this.loopRun
         );
     }
 
@@ -302,7 +306,8 @@ public class Execution implements SoftDeletable<Execution>, TenantInterface, Has
             this.traceParent,
             this.fixtures,
             this.kind,
-            this.breakpoints
+            this.breakpoints,
+            this.loopRun
         );
     }
 
@@ -343,7 +348,8 @@ public class Execution implements SoftDeletable<Execution>, TenantInterface, Has
             this.traceParent,
             this.fixtures,
             this.kind,
-            this.breakpoints
+            this.breakpoints,
+            this.loopRun
         );
     }
 
@@ -369,7 +375,8 @@ public class Execution implements SoftDeletable<Execution>, TenantInterface, Has
             this.traceParent,
             this.fixtures,
             this.kind,
-            newBreakpoints
+            newBreakpoints,
+            this.loopRun
         );
     };
 
@@ -405,8 +412,57 @@ public class Execution implements SoftDeletable<Execution>, TenantInterface, Has
             this.traceParent,
             this.fixtures,
             this.kind,
-            this.breakpoints
+            this.breakpoints,
+            this.loopRun
         );
+    }
+
+    /**
+     * Creates a derived loop execution from the current execution and the loop task run
+     * with the given index information (value and index).
+     */
+    public Execution loopExecution(String loopExecutionId, TaskRun taskRun, String value, int index) {
+        return new Execution(
+            this.tenantId,
+            loopExecutionId,
+            this.namespace,
+            this.flowId,
+            this.flowRevision,
+            null,
+            this.inputs,
+            this.outputs,
+            this.labels,
+            this.variables,
+            this.state,
+            this.id,
+            this.originalId,
+            this.trigger,
+            this.deleted,
+            this.metadata,
+            this.scheduleDate,
+            this.traceParent,
+            this.fixtures,
+            ExecutionKind.LOOP,
+            this.breakpoints,
+            new LoopRun(this.id, taskRun.getTaskId(), taskRun.getId(), value, index, computeParents())
+        );
+    }
+
+    /**
+     * Computes loop parents from the current execution's loop run for inclusion in a new loop execution.
+     */
+    private List<LoopRun.Parent> computeParents() {
+        if (this.loopRun == null) {
+            return null;
+        }
+
+        List<LoopRun.Parent> parents = new ArrayList<>();
+        if (this.loopRun.parents() != null) {
+            parents.addAll(this.loopRun.parents());
+        }
+
+        parents.add(new LoopRun.Parent(this.loopRun.value(), this.loopRun.index()));
+        return parents;
     }
 
     public List<TaskRun> findTaskRunsByTaskId(String id) {

--- a/core/src/main/java/io/kestra/core/models/executions/ExecutionKind.java
+++ b/core/src/main/java/io/kestra/core/models/executions/ExecutionKind.java
@@ -9,5 +9,6 @@ package io.kestra.core.models.executions;
 public enum ExecutionKind {
     NORMAL,
     TEST,
-    PLAYGROUND
+    PLAYGROUND,
+    LOOP
 }

--- a/core/src/main/java/io/kestra/core/models/executions/LoopRun.java
+++ b/core/src/main/java/io/kestra/core/models/executions/LoopRun.java
@@ -1,0 +1,7 @@
+package io.kestra.core.models.executions;
+
+import java.util.List;
+
+public record LoopRun(String executionId, String taskId, String taskRunId, String value, int index, List<Parent> parents) {
+    public record Parent(String value, int index) {}
+}

--- a/core/src/main/java/io/kestra/core/models/executions/TerminatedLoopExecution.java
+++ b/core/src/main/java/io/kestra/core/models/executions/TerminatedLoopExecution.java
@@ -1,0 +1,21 @@
+package io.kestra.core.models.executions;
+
+import io.kestra.core.models.flows.State;
+import io.kestra.core.queues.event.DispatchEvent;
+
+public record TerminatedLoopExecution(LoopRun loopRun, String executionId, State.Type state) implements DispatchEvent {
+    @Override
+    public String key() {
+        return executionId;
+    }
+
+    public String toStringState() {
+        return "TerminatedLoopExecution(" +
+            "id=" + this.loopRun.taskRunId() +
+            ", taskId=" + this.loopRun.taskId() +
+            ", value=" + this.loopRun.value() +
+            ", index=" + this.loopRun.index() +
+            ", state=" + state +
+            ")";
+    }
+}

--- a/core/src/main/java/io/kestra/core/models/flows/State.java
+++ b/core/src/main/java/io/kestra/core/models/flows/State.java
@@ -271,6 +271,10 @@ public class State {
             return this == Type.WARNING || this == Type.SUCCESS || this == Type.RETRIED || this == Type.SKIPPED || this == Type.RESUBMITTED;
         }
 
+        public boolean isTerminatedInError() {
+            return this == Type.FAILED || this == Type.KILLED || this == Type.CANCELLED;
+        }
+
         public boolean isCreated() {
             return this == Type.CREATED || this == Type.RESTARTED;
         }

--- a/core/src/main/java/io/kestra/core/runners/FlowableUtils.java
+++ b/core/src/main/java/io/kestra/core/runners/FlowableUtils.java
@@ -20,8 +20,15 @@ import io.kestra.core.models.tasks.Task;
 import io.kestra.core.serializers.JacksonMapper;
 import io.kestra.core.utils.ListUtils;
 import io.kestra.plugin.core.flow.Dag;
+import org.jspecify.annotations.NonNull;
+
+import static io.kestra.core.utils.Rethrow.throwFunction;
 
 public class FlowableUtils {
+    private final static TypeReference<List<Object>> TYPE_REFERENCE = new TypeReference<>() {
+    };
+    private final static ObjectMapper MAPPER = JacksonMapper.ofJson(true);
+
     public static List<NextTaskRun> resolveSequentialNexts(
         Execution execution,
         List<ResolvedTask> tasks) {
@@ -483,31 +490,80 @@ public class FlowableUtils {
         return Collections.emptyList();
     }
 
-    private final static TypeReference<List<Object>> TYPE_REFERENCE = new TypeReference<>() {
-    };
-    private final static ObjectMapper MAPPER = JacksonMapper.ofJson(true);
-
-    @SuppressWarnings({ "unchecked", "rawtypes" })
+    /**
+     * Resolves the values, then for each value create a {@link ResolvedTask} with it.
+     *
+     * @see #resolveValues(RunContext, Object)
+     */
     public static List<ResolvedTask> resolveEachTasks(RunContext runContext, TaskRun parentTaskRun, List<Task> tasks, Object value) throws IllegalVariableEvaluationException {
-        List<Object> values;
+        List<String> distinctValue = resolveValues(runContext, value);
+
+        ArrayList<ResolvedTask> result = new ArrayList<>();
+
+        int iteration = 0;
+        for (String current : distinctValue) {
+            for (Task task : tasks) {
+                result.add(
+                    ResolvedTask.builder()
+                        .task(task)
+                        .value(current)
+                        .iteration(iteration)
+                        .parentId(parentTaskRun.getId())
+                        .build()
+                );
+            }
+
+            iteration++;
+        }
+
+        return result;
+    }
+
+    /**
+     * Resolves a single Object values to a List of String representation.
+     * It supports:
+     * - A String that will be rendered then parsed as a JSON array.
+     * - A List of Objects that will be converted to a List of String, each object being rendered then parsed as a JSON object.
+     *
+     * @throws IllegalVariableEvaluationException in case of JSON error, unsupported value type or duplicate values.
+     */
+    public static List<String> resolveValues(RunContext runContext, Object value) throws IllegalVariableEvaluationException {
+        List<String> resolvedValues;
 
         if (value instanceof String stringValue) {
             String renderValue = runContext.render(stringValue);
             try {
-                values = MAPPER.readValue(renderValue, TYPE_REFERENCE);
+                resolvedValues = MAPPER.readValue(renderValue, TYPE_REFERENCE)
+                    .stream()
+                    .map(throwFunction(obj -> {
+                        if (obj instanceof String s) {
+                            return s;
+                        } else if (obj == null) {
+                            throw new IllegalVariableEvaluationException(
+                                "Found a null value inside the iteration values=" + serializeAsString(value)
+                            );
+                        } else {
+                            return serializeAsString(obj);
+                        }
+                    }))
+                    .toList();
             } catch (JsonProcessingException e) {
                 throw new IllegalVariableEvaluationException(e);
             }
         } else if (value instanceof List<?> listValue) {
-            values = new ArrayList<>(listValue.size());
+            resolvedValues = new ArrayList<>(listValue.size());
             for (Object obj : (List<Object>) value) {
                 if (obj instanceof String stringObj) {
-                    values.add(runContext.render(stringObj));
-                } else if (obj instanceof Integer) {
-                    values.add(runContext.render(obj.toString()));
+                    resolvedValues.add(runContext.render(stringObj));
+                } else if (obj instanceof Number) {
+                    resolvedValues.add(runContext.render(obj.toString()));
                 } else if (obj instanceof Map mapObj) {
                     //JSON or YAML map
-                    values.add(runContext.render(mapObj));
+                    resolvedValues.add(serializeAsString(runContext.render(mapObj)));
+                } else if (obj == null) {
+                    throw new IllegalVariableEvaluationException(
+                        "Found a null value inside the iteration values=" + serializeAsString(value)
+                    );
                 } else {
                     throw new IllegalVariableEvaluationException("Unknown value element type: " + obj.getClass());
                 }
@@ -516,46 +572,18 @@ public class FlowableUtils {
             throw new IllegalVariableEvaluationException("Unknown value type: " + value.getClass());
         }
 
-        List<Object> distinctValue = values
+        return resolvedValues
             .stream()
             .distinct()
             .toList();
+    }
 
-        long nullCount = distinctValue
-            .stream()
-            .filter(Objects::isNull)
-            .count();
-
-        if (nullCount > 0) {
-            throw new IllegalVariableEvaluationException(
-                "Found '" + nullCount + "' null values on Each, " +
-                    "with values=" + Arrays.toString(values.toArray())
-            );
+    private static String serializeAsString(Object obj) throws IllegalVariableEvaluationException {
+        try {
+            return MAPPER.writeValueAsString(obj);
+        } catch (JsonProcessingException e) {
+            throw new IllegalVariableEvaluationException(e);
         }
-
-        ArrayList<ResolvedTask> result = new ArrayList<>();
-
-        int iteration = 0;
-        for (Object current : distinctValue) {
-            try {
-                String resolvedValue = current instanceof String stringValue ? stringValue : MAPPER.writeValueAsString(current);
-                for (Task task : tasks) {
-                    result.add(
-                        ResolvedTask.builder()
-                            .task(task)
-                            .value(resolvedValue)
-                            .iteration(iteration)
-                            .parentId(parentTaskRun.getId())
-                            .build()
-                    );
-                }
-            } catch (JsonProcessingException e) {
-                throw new IllegalVariableEvaluationException(e);
-            }
-            iteration++;
-        }
-
-        return result;
     }
 
     /**

--- a/core/src/main/java/io/kestra/core/runners/RunVariables.java
+++ b/core/src/main/java/io/kestra/core/runners/RunVariables.java
@@ -9,6 +9,7 @@ import com.google.common.collect.ImmutableMap;
 import io.kestra.core.exceptions.IllegalVariableEvaluationException;
 import io.kestra.core.models.Label;
 import io.kestra.core.models.executions.Execution;
+import io.kestra.core.models.executions.LoopRun;
 import io.kestra.core.models.executions.TaskRun;
 import io.kestra.core.models.flows.FlowInterface;
 import io.kestra.core.models.flows.GenericFlow;
@@ -118,6 +119,30 @@ public final class RunVariables {
             "id", trigger.getId(),
             "type", trigger.getType()
         );
+    }
+
+    /**
+     * Creates an immutable map representation of the given {@link LoopRun}.
+     */
+    static Map<String, Object> of(LoopRun loopRun) {
+        Map<String, Object> loopRunMap = new HashMap<>();
+        loopRunMap.put("value", loopRun.value());
+        loopRunMap.put("index", loopRun.index());
+        if (loopRun.parents() != null) {
+            loopRunMap.put("parent", Map.of(
+                "value", loopRun.parents().getLast().value(),
+                "index", loopRun.parents().getLast().index())
+            );
+            if (loopRun.parents().size() > 1) {
+                List<Map<String, Object>> parents = new ArrayList<>();
+                loopRun.parents().forEach(parent -> parents.add(Map.of(
+                    "value", parent.value(),
+                    "index", parent.index()
+                )));
+                loopRunMap.put("parents", parents);
+            }
+        }
+        return loopRunMap;
     }
 
     /**
@@ -288,6 +313,7 @@ public final class RunVariables {
 
                     builder.put("tasks", tasksMap);
                 }
+
                 // Inputs
                 Map<String, Object> inputs = this.inputs == null ? new HashMap<>() : new HashMap<>(this.inputs);
                 if (execution.getInputs() != null) {
@@ -364,6 +390,11 @@ public final class RunVariables {
                         .namespace(execution.getNamespace())
                         .build();
                     builder.put("flow", RunVariables.of(flowFromExecution));
+                }
+
+                // item from Loop
+                if (execution.getLoopRun() != null) {
+                    builder.put("item", RunVariables.of(execution.getLoopRun()));
                 }
             } else if (flow != null) {
                 // if the execution is null, we should add flow labels

--- a/core/src/main/java/io/kestra/core/services/ExecutionService.java
+++ b/core/src/main/java/io/kestra/core/services/ExecutionService.java
@@ -999,15 +999,21 @@ public class ExecutionService {
     }
 
     /**
-     * Remove true if the execution is terminated, including afterExecution tasks.
+     * Remove true if the execution is terminated, including afterExecution tasks if it's not a loop execution.
      */
     public boolean isTerminated(Flow flow, Execution execution) {
         if (!execution.getState().isTerminated()) {
             return false;
         }
 
-        List<ResolvedTask> afterExecution = resolveAfterExecutionTasks(flow);
-        return execution.isTerminated(afterExecution);
+        // only process after execution tasks if not a loop execution
+        if (execution.getKind() != ExecutionKind.LOOP) {
+            List<ResolvedTask> afterExecution = resolveAfterExecutionTasks(flow);
+            return execution.isTerminated(afterExecution);
+        } else {
+            // for loop executions, if the execution is terminated, there is nothing else to check
+            return true;
+        }
     }
 
     /**

--- a/core/src/main/java/io/kestra/plugin/core/flow/Loop.java
+++ b/core/src/main/java/io/kestra/plugin/core/flow/Loop.java
@@ -1,0 +1,347 @@
+package io.kestra.plugin.core.flow;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.kestra.core.exceptions.IllegalVariableEvaluationException;
+import io.kestra.core.models.annotations.Example;
+import io.kestra.core.models.annotations.Plugin;
+import io.kestra.core.models.annotations.PluginProperty;
+import io.kestra.core.models.executions.Execution;
+import io.kestra.core.models.executions.ExecutionKind;
+import io.kestra.core.models.executions.NextTaskRun;
+import io.kestra.core.models.executions.TaskRun;
+import io.kestra.core.models.flows.State;
+import io.kestra.core.models.hierarchies.GraphCluster;
+import io.kestra.core.models.hierarchies.RelationType;
+import io.kestra.core.models.tasks.FlowableTask;
+import io.kestra.core.models.tasks.ResolvedTask;
+import io.kestra.core.models.tasks.Task;
+import io.kestra.core.runners.FlowableUtils;
+import io.kestra.core.runners.RunContext;
+import io.kestra.core.utils.GraphUtils;
+import io.kestra.core.utils.MapUtils;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.PositiveOrZero;
+import lombok.*;
+import lombok.experimental.SuperBuilder;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+@SuperBuilder
+@ToString
+@EqualsAndHashCode
+@Getter
+@NoArgsConstructor
+@Schema(
+    title = "Execute child tasks for each value in a list.",
+    description = """
+        Renders `values` (JSON array, YAML list, or expression) and runs the child task group once per item. The current item is available as `item.value`; `item.index` exposes the index.
+
+        Control parallelism with `concurrencyLimit` (0 = unlimited, 1 = fully serialized, N = up to N concurrent task groups). To run tasks inside each group in parallel, wrap them in a `Parallel` task."""
+)
+@Plugin(
+    examples = {
+        @Example(
+            full = true,
+            title = """
+                The `{{ item.value }}` from the `loop` task is available only to direct child tasks \
+                such as the `before_if` and the `if` tasks.""",
+            code = """
+                id: for_loop_example
+                namespace: company.team
+
+                tasks:
+                  - id: loop
+                    type: io.kestra.plugin.core.flow.Loop
+                    values: ["value 1", "value 2", "value 3"]
+                    tasks:
+                      - id: before_if
+                        type: io.kestra.plugin.core.debug.Return
+                        format: "Before if {{ item.value }}"
+                      - id: if
+                        type: io.kestra.plugin.core.flow.If
+                        condition: '{{ item.value == "value 2" }}'
+                        then:
+                          - id: after_if
+                            type: io.kestra.plugin.core.debug.Return
+                            format: "After if {{ item.value }}"
+                """
+        ),
+        @Example(
+            full = true,
+            title = """
+                This flow uses YAML-style array for `values`. The task `loop` iterates over a list of values \
+                and executes the `return` child task for each value. The `concurrencyLimit` property is set to 2, \
+                so the `return` task will run concurrently for the first two values in the list at first. \
+                The `return` task will run for the next two values only after the task runs for the first two values \
+                have completed.""",
+            code = """
+                id: for_each_value
+                namespace: company.team
+
+                tasks:
+                  - id: for_each
+                    type: io.kestra.plugin.core.flow.Loop
+                    values:
+                      - value 1
+                      - value 2
+                      - value 3
+                      - value 4
+                    concurrencyLimit: 2
+                    tasks:
+                      - id: return
+                        type: io.kestra.plugin.core.debug.Return
+                        format: "{{ task.id }} with value {{ item.value }}"
+                """
+        ),
+        @Example(
+            full = true,
+            title = """
+                This example shows how to run tasks in parallel for each value in the list. \
+                All child tasks of the `parallel` task will run in parallel. \
+                However, due to the `concurrencyLimit` property set to 2, \
+                only two `parallel` task groups will run at any given time.""",
+            code = """
+                id: parallel_tasks_example
+                namespace: company.team
+
+                tasks:
+                  - id: for_each
+                    type: io.kestra.plugin.core.flow.Loop
+                    values: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+                    concurrencyLimit: 2
+                    tasks:
+                      - id: parallel
+                        type: io.kestra.plugin.core.flow.Parallel
+                        tasks:
+                        - id: log
+                          type: io.kestra.plugin.core.log.Log
+                          message: Processing {{ item.value }}
+                        - id: shell
+                          type: io.kestra.plugin.scripts.shell.Commands
+                          commands:
+                            - sleep {{ item.value }}
+                """
+        ),
+        @Example(
+            full = true,
+            title = """
+                This example demonstrates processing data across nested loops of S3 buckets, years, and months. \
+                It generates structured identifiers (e.g., `bucket1_2025_March`) by combining values from each loop level, \
+                while accessing parent loop values like years and buckets, which can be useful for partitioned \
+                storage paths or time-based datasets. The flow uses dynamic expressions referencing parent context.""",
+            code = """
+                id: loop_multiple_times
+                namespace: company.team
+
+                inputs:
+                  - id: s3_buckets
+                    type: ARRAY
+                    itemType: STRING
+                    defaults:
+                      - bucket1
+                      - bucket2
+
+                  - id: years
+                    type: ARRAY
+                    itemType: INT
+                    defaults:
+                      - 2025
+                      - 2026
+
+                  - id: months
+                    type: ARRAY
+                    itemType: STRING
+                    defaults:
+                      - March
+                      - April
+
+                tasks:
+                  - id: buckets
+                    type: io.kestra.plugin.core.flow.Loop
+                    values: "{{inputs.s3_buckets}}"
+                    tasks:
+                      - id: year
+                        type: io.kestra.plugin.core.flow.Loop
+                        values: "{{inputs.years}}"
+                        tasks:
+                          - id: month
+                            type: io.kestra.plugin.core.flow.Loop
+                            values: "{{inputs.months}}"
+                            tasks:
+                              - id: full_table_name
+                                type: io.kestra.plugin.core.log.Log
+                                message: |
+                                  Full table name: {{item.parents[1].item.value }}_{{item.parent.value}}_{{item.value}}
+                                  Direct/current loop (months): {{item.value}}
+                                  Value of loop one higher up (years): {{item.parents[0].value}}
+                                  Further up (table types): {{item.parents[1].value}}
+                """
+        ),
+    }
+)
+public class Loop extends Task implements FlowableTask<Loop.Output> {
+    public static final String ITERATION_COUNT_OUTPUT = "iterationCount";
+    public static final String RUNNING_ITERATIONS_OUTPUT = "runningIterations";
+    public static final String TERMINATED_ITERATIONS_OUTPUT = "terminatedIterations";
+
+    @Valid
+    protected List<Task> errors;
+
+    @Valid
+    @JsonProperty("finally")
+    @Getter(AccessLevel.NONE)
+    protected List<Task> _finally;
+
+    public List<Task> getFinally() {
+        return this._finally;
+    }
+
+    @Valid
+    @PluginProperty
+    @NotEmpty(message = "The 'tasks' property cannot be empty")
+    private List<Task> tasks;
+
+    // TODO support URI directly
+    @NotNull
+    @PluginProperty(dynamic = true)
+    @Schema(
+        title = "The list of values for which Kestra will execute a group of tasks",
+        description = """
+            Values can be defined as:
+            - A list of objects, individual objects will be coalesce to strings
+            - A string which will be deserialized as a JSON array""",
+        oneOf = { String.class, Object[].class }
+    )
+    private Object values;
+
+    @PositiveOrZero
+    @NotNull
+    @Builder.Default
+    @Schema(
+        title = "The number of concurrent task groups for each value in the `values` array",
+        description = """
+            A `concurrencyLimit` of 0 means no limit — all task groups run in parallel.
+
+            A `concurrencyLimit` of 1 means full serialization — only one task group runs at a time, in order.
+
+            A `concurrencyLimit` greater than 1 allows up to the specified number of task groups to run in parallel.
+            """
+    )
+    @PluginProperty
+    private final Integer concurrencyLimit = 1;
+
+    @Builder.Default
+    @Schema(
+        title = "Flag specifying whether to fail the current task if any loop iteration fails or is killed."
+    )
+    @PluginProperty
+    private final Boolean transmitFailed = true;
+
+    // FIXME there are a lot of duplication with Sequential but as it needs to return a different output it cannot extend it
+
+    @Override
+    public GraphCluster tasksTree(Execution execution, TaskRun taskRun, List<String> parentValues) throws IllegalVariableEvaluationException {
+        GraphCluster subGraph = new GraphCluster(this, taskRun, parentValues, RelationType.DYNAMIC);
+
+        // Loop executes task groups concurrently, not the task inside the group concurrently,
+        // so the topology should display it as a sequential.
+        GraphUtils.sequential(
+            subGraph,
+            this.getTasks(),
+            this.getErrors(),
+            this.getFinally(),
+            taskRun,
+            execution
+        );
+
+        return subGraph;
+    }
+
+    @Override
+    public List<Task> allChildTasks() {
+        return Stream
+            .concat(
+                this.getTasks() != null ? this.getTasks().stream() : Stream.empty(),
+                Stream.concat(
+                    this.getErrors() != null ? this.getErrors().stream() : Stream.empty(),
+                    this.getFinally() != null ? this.getFinally().stream() : Stream.empty()
+                )
+            )
+            .toList();
+    }
+
+    @Override
+    public List<ResolvedTask> childTasks(RunContext runContext, TaskRun parentTaskRun) throws IllegalVariableEvaluationException {
+        return FlowableUtils.resolveTasks(this.getTasks(), parentTaskRun);
+    }
+
+    @Override
+    public Optional<State.Type> resolveState(RunContext runContext, Execution execution, TaskRun parentTaskRun) throws IllegalVariableEvaluationException {
+        if (!isMySubExecution(execution, parentTaskRun)) {
+            // Not in this loop's own sub-execution — state is managed by the TerminatedLoopExecutionMessageHandler.
+            return Optional.empty();
+        }
+
+        List<ResolvedTask> childTasks = this.childTasks(runContext, parentTaskRun);
+
+        return FlowableUtils.resolveSequentialState(
+            execution,
+            childTasks,
+            FlowableUtils.resolveTasks(this.getErrors(), parentTaskRun),
+            FlowableUtils.resolveTasks(this.getFinally(), parentTaskRun),
+            parentTaskRun,
+            runContext,
+            this.isAllowFailure(),
+            this.isAllowWarning()
+        );
+    }
+
+    @Override
+    public List<NextTaskRun> resolveNexts(RunContext runContext, Execution execution, TaskRun parentTaskRun) throws IllegalVariableEvaluationException {
+        if (!isMySubExecution(execution, parentTaskRun)) {
+            // We are not in this loop's own sub-execution (either we're in the main execution,
+            // or in a parent loop's sub-execution), so we don't resolve any next tasks to
+            // avoid executing subtasks outside of the dedicated loop iteration execution.
+            return Collections.emptyList();
+        }
+
+        return FlowableUtils.resolveSequentialNexts(
+            execution,
+            this.childTasks(runContext, parentTaskRun),
+            FlowableUtils.resolveTasks(this.errors, parentTaskRun),
+            FlowableUtils.resolveTasks(this._finally, parentTaskRun),
+            parentTaskRun
+        );
+    }
+
+    @Builder
+    @Getter
+    public static class Output implements io.kestra.core.models.tasks.Output {
+        @Schema(
+            title = "The counter of iterations for each loop branch execution"
+        )
+        private Integer iterations;
+    }
+
+    @Override
+    public Output outputs(RunContext runContext) throws Exception {
+        var currentOutputs = runContext.currentOutput();
+        if (!MapUtils.isEmpty(currentOutputs) && currentOutputs.containsKey("iterations")) {
+            Integer iterations = (Integer) currentOutputs.get("iterations");
+            return Output.builder().iterations(iterations).build();
+        } else {
+            return Output.builder().iterations(0).build();
+        }
+    }
+
+    public boolean isMySubExecution(Execution execution, TaskRun parentTaskRun) {
+        return execution.getKind() == ExecutionKind.LOOP &&
+            execution.getLoopRun() != null && execution.getLoopRun().taskRunId().equals(parentTaskRun.getId());
+    }
+}

--- a/core/src/main/java/io/kestra/plugin/core/flow/Sequential.java
+++ b/core/src/main/java/io/kestra/plugin/core/flow/Sequential.java
@@ -99,6 +99,7 @@ public class Sequential extends Task implements FlowableTask<VoidOutput> {
         return subGraph;
     }
 
+    @Override
     public List<Task> allChildTasks() {
         return Stream
             .concat(

--- a/core/src/test/java/io/kestra/core/models/executions/ExecutionTest.java
+++ b/core/src/test/java/io/kestra/core/models/executions/ExecutionTest.java
@@ -279,6 +279,7 @@ class ExecutionTest {
             null,
             null,
             null,
+            null,
             null
         );
         assertThat(executionNew.getLabels()).containsExactly(new Label("test", "value2"));

--- a/core/src/test/java/io/kestra/core/runners/AbstractRunnerTest.java
+++ b/core/src/test/java/io/kestra/core/runners/AbstractRunnerTest.java
@@ -74,6 +74,9 @@ public abstract class AbstractRunnerTest {
     protected LoopUntilCaseTest loopUntilTestCaseTest;
 
     @Inject
+    protected LoopCaseTest loopCaseTest;
+
+    @Inject
     protected ScheduleDateCaseTest scheduleDateCaseTest;
 
     @Inject
@@ -321,7 +324,7 @@ public abstract class AbstractRunnerTest {
 
         assertThat(execution.getTaskRunList()).hasSize(1);
         assertThat(execution.getState().getCurrent()).isEqualTo(State.Type.FAILED);
-        LogEntry matchingLog = TestsUtils.awaitLog(logs, logEntry -> logEntry.getMessage().contains("Found '1' null values on Each, with values=[1, null, {key=my-key, value=my-value}]"));
+        LogEntry matchingLog = TestsUtils.awaitLog(logs, logEntry -> logEntry.getMessage().contains("Found a null value inside the iteration values"));
         assertThat(matchingLog).isNotNull();
     }
 
@@ -537,6 +540,72 @@ public abstract class AbstractRunnerTest {
     @LoadFlows(value = { "flows/valids/waitfor-multiple-tasks-failed.yaml" }, tenantId = "waitformultipletasksfailed")
     void waitforMultipleTasksFailed() throws Exception {
         loopUntilTestCaseTest.waitforMultipleTasksFailed("waitformultipletasksfailed");
+    }
+
+    @Test
+    @ExecuteFlow("flows/valids/loop-serial.yaml")
+    protected void loopSerial(Execution execution) throws Exception {
+        loopCaseTest.loopSerial(execution);
+    }
+
+    @Test
+    @ExecuteFlow("flows/valids/loop-serial-multiple-tasks.yaml")
+    protected void loopSerialMultipleTasks(Execution execution) throws Exception {
+        loopCaseTest.loopSerialMultipleTasks(execution);
+    }
+
+    @Test
+    @ExecuteFlow("flows/valids/loop-failed.yaml")
+    protected void loopFailed(Execution execution) throws Exception {
+        loopCaseTest.loopFailed(execution);
+    }
+
+    @Test
+    @ExecuteFlow("flows/valids/loop-failed-no-transmit.yaml")
+    protected void loopTransmitFailedFalse(Execution execution) throws Exception {
+        loopCaseTest.loopTransmitFailedFalse(execution);
+    }
+
+    @Test
+    @ExecuteFlow("flows/valids/loop-parallel-unlimited.yaml")
+    protected void loopParallelUnlimited(Execution execution) throws Exception {
+        loopCaseTest.loopParallelUnlimited(execution);
+    }
+
+    @Test
+    @ExecuteFlow("flows/valids/loop-parallel-equal.yaml")
+    protected void loopParallelEqual(Execution execution) throws Exception {
+        loopCaseTest.loopParallelEqual(execution);
+    }
+
+    @Test
+    @ExecuteFlow("flows/valids/loop-parallel-more.yaml")
+    protected void loopParallelMore(Execution execution) throws Exception {
+        loopCaseTest.loopParallelMore(execution);
+    }
+
+    @Test
+    @ExecuteFlow("flows/valids/loop-parallel-less.yaml")
+    protected void loopParallelLess(Execution execution) throws Exception {
+        loopCaseTest.loopParallelLess(execution);
+    }
+
+    @Test
+    @ExecuteFlow("flows/valids/loop-flowable.yaml")
+    protected void loopFlowable(Execution execution) throws Exception {
+        loopCaseTest.loopFlowable(execution);
+    }
+
+    @Test
+    @ExecuteFlow("flows/valids/loop-multiple.yaml")
+    protected void loopMultiple(Execution execution) throws Exception {
+        loopCaseTest.loopMultiple(execution);
+    }
+
+    @Test
+    @ExecuteFlow("flows/valids/loop-nested.yaml")
+    protected void loopNested(Execution execution) throws Exception {
+        loopCaseTest.loopNested(execution);
     }
 
     @Test

--- a/core/src/test/java/io/kestra/plugin/core/flow/LoopCaseTest.java
+++ b/core/src/test/java/io/kestra/plugin/core/flow/LoopCaseTest.java
@@ -1,0 +1,283 @@
+package io.kestra.plugin.core.flow;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+
+import io.kestra.core.exceptions.InternalException;
+import io.kestra.core.models.executions.Execution;
+import io.kestra.core.models.executions.LoopRun;
+import io.kestra.core.models.executions.TaskRun;
+import io.kestra.core.models.flows.State;
+import io.kestra.core.repositories.ExecutionRepositoryInterface;
+import io.kestra.core.services.TaskOutputService;
+import io.micronaut.data.model.Pageable;
+
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+
+import static io.kestra.core.utils.Rethrow.throwPredicate;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Singleton
+public class LoopCaseTest {
+    @Inject
+    private TaskOutputService taskOutputService;
+
+    @Inject
+    private ExecutionRepositoryInterface executionRepository;
+
+    public void loopSerial(Execution execution) throws InternalException {
+        // Then
+        assertThat(execution.getState().getCurrent()).isEqualTo(State.Type.SUCCESS);
+        assertThat(execution.getTaskRunList()).hasSize(1);
+        TaskRun loopTaskRun = execution.getTaskRunList().getFirst();
+        assertThat(loopTaskRun.getState().getCurrent()).isEqualTo(State.Type.SUCCESS);
+        assertThat(taskOutputService.getOutputs(loopTaskRun))
+            .containsEntry(Loop.ITERATION_COUNT_OUTPUT, 3)
+            .containsEntry(Loop.TERMINATED_ITERATIONS_OUTPUT, 3);
+
+        // 3 loop sub-executions, one per iteration, all with SUCCESS
+        List<Execution> subExecutions = loopSubExecutions(execution);
+        assertThat(subExecutions).hasSize(3);
+        assertThat(subExecutions).allMatch(sub -> sub.getState().getCurrent() == State.Type.SUCCESS);
+        assertThat(subExecutions).allMatch(throwPredicate(sub -> {
+            String expectedValue = sub.getLoopRun().index() + " - " + sub.getLoopRun().value();
+            return expectedValue.equals(taskOutputService.getOutputs(sub.getTaskRunList().getFirst()).get("value"));
+        }));
+    }
+
+    public void loopSerialMultipleTasks(Execution execution) throws InternalException {
+        // Then
+        assertThat(execution.getState().getCurrent()).isEqualTo(State.Type.SUCCESS);
+        assertThat(execution.getTaskRunList()).hasSize(1);
+        TaskRun loopTaskRun = execution.getTaskRunList().getFirst();
+        assertThat(loopTaskRun.getState().getCurrent()).isEqualTo(State.Type.SUCCESS);
+        assertThat(taskOutputService.getOutputs(loopTaskRun))
+            .containsEntry(Loop.ITERATION_COUNT_OUTPUT, 2)
+            .containsEntry(Loop.TERMINATED_ITERATIONS_OUTPUT, 2);
+
+        // 2 loop sub-executions, one per iteration, each running 2 child tasks
+        List<Execution> subExecutions = loopSubExecutions(execution);
+        assertThat(subExecutions).hasSize(2);
+        assertThat(subExecutions).allMatch(sub -> sub.getState().getCurrent() == State.Type.SUCCESS);
+        assertThat(subExecutions).allMatch(sub -> sub.getTaskRunList().size() == 2);
+    }
+
+    public void loopFailed(Execution execution) {
+        // Then — first failing iteration terminates the loop immediately with transmitFailed=true (default)
+        assertThat(execution.getState().getCurrent()).isEqualTo(State.Type.FAILED);
+        assertThat(execution.getTaskRunList()).hasSize(1);
+        assertThat(execution.getTaskRunList().getFirst().getState().getCurrent()).isEqualTo(State.Type.FAILED);
+
+        // Only one sub-execution ran before the loop was terminated
+        List<Execution> subExecutions = loopSubExecutions(execution);
+        assertThat(subExecutions).hasSize(1);
+        assertThat(subExecutions.getFirst().getState().getCurrent()).isEqualTo(State.Type.FAILED);
+    }
+
+    public void loopTransmitFailedFalse(Execution execution) throws InternalException {
+        // Then — all iterations run but failures are not propagated, loop ends with SUCCESS
+        assertThat(execution.getState().getCurrent()).isEqualTo(State.Type.SUCCESS);
+        assertThat(execution.getTaskRunList()).hasSize(1);
+        TaskRun loopTaskRun = execution.getTaskRunList().getFirst();
+        assertThat(loopTaskRun.getState().getCurrent()).isEqualTo(State.Type.SUCCESS);
+        assertThat(taskOutputService.getOutputs(loopTaskRun))
+            .containsEntry(Loop.ITERATION_COUNT_OUTPUT, 3)
+            .containsEntry(Loop.TERMINATED_ITERATIONS_OUTPUT, 3);
+
+        // All 3 sub-executions ran and each failed individually (failure not propagated to the loop)
+        List<Execution> subExecutions = loopSubExecutions(execution);
+        assertThat(subExecutions).hasSize(3);
+        assertThat(subExecutions).allMatch(sub -> sub.getState().getCurrent() == State.Type.FAILED);
+    }
+
+    public void loopParallelUnlimited(Execution execution) throws InternalException {
+        // Then — concurrencyLimit: 0 means all 3 iterations start in parallel
+        assertThat(execution.getState().getCurrent()).isEqualTo(State.Type.SUCCESS);
+        assertThat(execution.getTaskRunList()).hasSize(1);
+        TaskRun loopTaskRun = execution.getTaskRunList().getFirst();
+        assertThat(loopTaskRun.getState().getCurrent()).isEqualTo(State.Type.SUCCESS);
+        assertThat(taskOutputService.getOutputs(loopTaskRun))
+            .containsEntry(Loop.ITERATION_COUNT_OUTPUT, 3)
+            .containsEntry(Loop.TERMINATED_ITERATIONS_OUTPUT, 3);
+
+        List<Execution> subExecutions = loopSubExecutions(execution);
+        assertThat(subExecutions).hasSize(3);
+        assertThat(subExecutions).allMatch(sub -> sub.getState().getCurrent() == State.Type.SUCCESS);
+        assertThat(subExecutions).allMatch(throwPredicate(sub -> {
+            String expectedValue = sub.getLoopRun().index() + " - " + sub.getLoopRun().value();
+            return expectedValue.equals(taskOutputService.getOutputs(sub.getTaskRunList().getFirst()).get("value"));
+        }));
+    }
+
+    public void loopParallelEqual(Execution execution) throws InternalException {
+        // Then — concurrencyLimit equals the number of iterations: all 3 start at once
+        assertThat(execution.getState().getCurrent()).isEqualTo(State.Type.SUCCESS);
+        assertThat(execution.getTaskRunList()).hasSize(1);
+        TaskRun loopTaskRun = execution.getTaskRunList().getFirst();
+        assertThat(loopTaskRun.getState().getCurrent()).isEqualTo(State.Type.SUCCESS);
+        assertThat(taskOutputService.getOutputs(loopTaskRun))
+            .containsEntry(Loop.ITERATION_COUNT_OUTPUT, 3)
+            .containsEntry(Loop.TERMINATED_ITERATIONS_OUTPUT, 3);
+
+        List<Execution> subExecutions = loopSubExecutions(execution);
+        assertThat(subExecutions).hasSize(3);
+        assertThat(subExecutions).allMatch(sub -> sub.getState().getCurrent() == State.Type.SUCCESS);
+        assertThat(subExecutions).allMatch(throwPredicate(sub -> {
+            String expectedValue = sub.getLoopRun().index() + " - " + sub.getLoopRun().value();
+            return expectedValue.equals(taskOutputService.getOutputs(sub.getTaskRunList().getFirst()).get("value"));
+        }));
+    }
+
+    public void loopParallelMore(Execution execution) throws InternalException {
+        // Then — concurrencyLimit (5) exceeds the number of iterations (3): all 3 start at once
+        assertThat(execution.getState().getCurrent()).isEqualTo(State.Type.SUCCESS);
+        assertThat(execution.getTaskRunList()).hasSize(1);
+        TaskRun loopTaskRun = execution.getTaskRunList().getFirst();
+        assertThat(loopTaskRun.getState().getCurrent()).isEqualTo(State.Type.SUCCESS);
+        assertThat(taskOutputService.getOutputs(loopTaskRun))
+            .containsEntry(Loop.ITERATION_COUNT_OUTPUT, 3)
+            .containsEntry(Loop.TERMINATED_ITERATIONS_OUTPUT, 3);
+
+        List<Execution> subExecutions = loopSubExecutions(execution);
+        assertThat(subExecutions).hasSize(3);
+        assertThat(subExecutions).allMatch(sub -> sub.getState().getCurrent() == State.Type.SUCCESS);
+        assertThat(subExecutions).allMatch(throwPredicate(sub -> {
+            String expectedValue = sub.getLoopRun().index() + " - " + sub.getLoopRun().value();
+            return expectedValue.equals(taskOutputService.getOutputs(sub.getTaskRunList().getFirst()).get("value"));
+        }));
+    }
+
+    public void loopParallelLess(Execution execution) throws InternalException {
+        // Then — concurrencyLimit (2) is less than the number of iterations (4): runs in batches
+        assertThat(execution.getState().getCurrent()).isEqualTo(State.Type.SUCCESS);
+        assertThat(execution.getTaskRunList()).hasSize(1);
+        TaskRun loopTaskRun = execution.getTaskRunList().getFirst();
+        assertThat(loopTaskRun.getState().getCurrent()).isEqualTo(State.Type.SUCCESS);
+        assertThat(taskOutputService.getOutputs(loopTaskRun))
+            .containsEntry(Loop.ITERATION_COUNT_OUTPUT, 4)
+            .containsEntry(Loop.TERMINATED_ITERATIONS_OUTPUT, 4);
+
+        List<Execution> subExecutions = loopSubExecutions(execution);
+        assertThat(subExecutions).hasSize(4);
+        assertThat(subExecutions).allMatch(sub -> sub.getState().getCurrent() == State.Type.SUCCESS);
+        assertThat(subExecutions).allMatch(throwPredicate(sub -> {
+            String expectedValue = sub.getLoopRun().index() + " - " + sub.getLoopRun().value();
+            return expectedValue.equals(taskOutputService.getOutputs(sub.getTaskRunList().getFirst()).get("value"));
+        }));
+    }
+
+    public void loopFlowable(Execution execution) throws InternalException {
+        // Then
+        assertThat(execution.getState().getCurrent()).isEqualTo(State.Type.SUCCESS);
+        assertThat(execution.getTaskRunList()).hasSize(1);
+        TaskRun loopTaskRun = execution.getTaskRunList().getFirst();
+        assertThat(loopTaskRun.getState().getCurrent()).isEqualTo(State.Type.SUCCESS);
+        assertThat(taskOutputService.getOutputs(loopTaskRun))
+            .containsEntry(Loop.ITERATION_COUNT_OUTPUT, 3)
+            .containsEntry(Loop.TERMINATED_ITERATIONS_OUTPUT, 3);
+
+        // 3 loop sub-executions, one per iteration, all with SUCCESS
+        List<Execution> subExecutions = loopSubExecutions(execution);
+        assertThat(subExecutions).hasSize(3);
+        assertThat(subExecutions).allMatch(sub -> sub.getState().getCurrent() == State.Type.SUCCESS);
+    }
+
+    public void loopMultiple(Execution execution) throws InternalException {
+        // Then — flow has 2 sequential Loop tasks (loop1 + loop2), each with 3 values
+        assertThat(execution.getState().getCurrent()).isEqualTo(State.Type.SUCCESS);
+        assertThat(execution.getTaskRunList()).hasSize(2);
+        for (TaskRun loopTaskRun : execution.getTaskRunList()) {
+            assertThat(loopTaskRun.getState().getCurrent()).isEqualTo(State.Type.SUCCESS);
+            assertThat(taskOutputService.getOutputs(loopTaskRun))
+                .containsEntry(Loop.ITERATION_COUNT_OUTPUT, 3)
+                .containsEntry(Loop.TERMINATED_ITERATIONS_OUTPUT, 3);
+        }
+
+        // 6 loop sub-executions total (3 per loop task), all with SUCCESS
+        List<Execution> subExecutions = loopSubExecutions(execution);
+        assertThat(subExecutions).hasSize(6);
+        assertThat(subExecutions).allMatch(sub -> sub.getState().getCurrent() == State.Type.SUCCESS);
+        assertThat(subExecutions).allMatch(throwPredicate(sub -> {
+            String expectedValue = sub.getLoopRun().index() + " - " + sub.getLoopRun().value();
+            return expectedValue.equals(taskOutputService.getOutputs(sub.getTaskRunList().getFirst()).get("value"));
+        }));
+    }
+
+    public void loopNested(Execution execution) throws InternalException {
+        // Then
+        assertThat(execution.getState().getCurrent()).isEqualTo(State.Type.SUCCESS);
+        assertThat(execution.getTaskRunList()).hasSize(1);
+        TaskRun loopTaskRun = execution.getTaskRunList().getFirst();
+        assertThat(loopTaskRun.getState().getCurrent()).isEqualTo(State.Type.SUCCESS);
+        assertThat(taskOutputService.getOutputs(loopTaskRun))
+            .containsEntry(Loop.ITERATION_COUNT_OUTPUT, 3)
+            .containsEntry(Loop.TERMINATED_ITERATIONS_OUTPUT, 3);
+
+        // 3 loop sub-executions, one per iteration, all with SUCCESS
+        List<Execution> subExecutions = loopSubExecutions(execution);
+        assertThat(subExecutions).hasSize(3);
+        assertThat(subExecutions).allMatch(sub -> sub.getState().getCurrent() == State.Type.SUCCESS);
+        assertThat(subExecutions).allMatch(throwPredicate(sub -> {
+            TaskRun subLoopTaskRun = sub.getTaskRunList().getFirst();
+            Map<String, Object> subLoopOutputs = taskOutputService.getOutputs(subLoopTaskRun);
+            return subLoopTaskRun.getState().getCurrent() == State.Type.SUCCESS
+                && Integer.valueOf(3).equals(subLoopOutputs.get(Loop.ITERATION_COUNT_OUTPUT))
+                && Integer.valueOf(3).equals(subLoopOutputs.get(Loop.TERMINATED_ITERATIONS_OUTPUT));
+        }));
+
+        // each loop1 sub-execution should have 3 loop2 sub-executions, each running loop3
+        for (Execution loop1SubExec : subExecutions) {
+            List<Execution> loop2SubExecutions = loopSubExecutions(loop1SubExec);
+            assertThat(loop2SubExecutions).hasSize(3);
+            assertThat(loop2SubExecutions).allMatch(sub -> sub.getState().getCurrent() == State.Type.SUCCESS);
+            assertThat(loop2SubExecutions).allMatch(throwPredicate(sub -> {
+                TaskRun loop3TaskRun = sub.getTaskRunList().getFirst();
+                Map<String, Object> loop3Outputs = taskOutputService.getOutputs(loop3TaskRun);
+                return loop3TaskRun.getState().getCurrent() == State.Type.SUCCESS
+                    && Integer.valueOf(3).equals(loop3Outputs.get(Loop.ITERATION_COUNT_OUTPUT))
+                    && Integer.valueOf(3).equals(loop3Outputs.get(Loop.TERMINATED_ITERATIONS_OUTPUT));
+            }));
+            // each loop2 sub-execution should have 3 loop3 sub-executions with Return task outputs
+            for (Execution loop2SubExec : loop2SubExecutions) {
+                List<Execution> loop3SubExecutions = loopSubExecutions(loop2SubExec);
+                assertThat(loop3SubExecutions).hasSize(3);
+                assertThat(loop3SubExecutions).allMatch(sub -> sub.getState().getCurrent() == State.Type.SUCCESS);
+                for (Execution loop3SubExec : loop3SubExecutions) {
+                    LoopRun lr = loop3SubExec.getLoopRun();
+                    assertThat(lr).isNotNull();
+                    assertThat(lr.parents()).isNotNull();
+                    LoopRun.Parent loop2Parent = lr.parents().getLast();
+                    LoopRun.Parent loop1Parent = lr.parents().getFirst();
+
+                    // item: "{{item.index}} - {{item.value}}"
+                    TaskRun itemRun = loop3SubExec.getTaskRunList().stream().filter(tr -> "item".equals(tr.getTaskId())).findFirst().orElseThrow();
+                    assertThat(taskOutputService.getOutputs(itemRun))
+                        .containsEntry("value", lr.index() + " - " + lr.value());
+
+                    // parent: "{{item.parent.index}} - {{item.parent.value}}" — resolves to the loop2 context
+                    TaskRun parentRun = loop3SubExec.getTaskRunList().stream().filter(tr -> "parent".equals(tr.getTaskId())).findFirst().orElseThrow();
+                    assertThat(taskOutputService.getOutputs(parentRun))
+                        .containsEntry("value", loop2Parent.index() + " - " + loop2Parent.value());
+
+                    // parents: "{{item.parents[0].index}} - {{item.parents[0].value}} - {{item.parents[1].index}} - {{item.parents[1].value}}"
+                    // parents[0] = loop1 context, parents[1] = loop2 context
+                    TaskRun parentsRun = loop3SubExec.getTaskRunList().stream().filter(tr -> "parents".equals(tr.getTaskId())).findFirst().orElseThrow();
+                    assertThat(taskOutputService.getOutputs(parentsRun))
+                        .containsEntry("value", loop1Parent.index() + " - " + loop1Parent.value() + " - " + loop2Parent.index() + " - " + loop2Parent.value());
+                }
+            }
+        }
+    }
+
+    /** Returns the loop sub-executions for the given parent execution, sorted by iteration index. */
+    private List<Execution> loopSubExecutions(Execution parentExecution) {
+        // FIXME retrieving loop sub-executions for a given loop should be more easy
+        return executionRepository.findByFlowId(parentExecution.getTenantId(), parentExecution.getNamespace(), parentExecution.getFlowId(), Pageable.UNPAGED)
+            .stream()
+            .filter(exec -> parentExecution.getId().equals(exec.getParentId()))
+            .sorted(Comparator.comparingInt(exec -> exec.getLoopRun().index()))
+            .toList();
+    }
+}

--- a/core/src/test/resources/flows/valids/loop-failed-no-transmit.yaml
+++ b/core/src/test/resources/flows/valids/loop-failed-no-transmit.yaml
@@ -1,0 +1,11 @@
+id: loop-failed-no-transmit
+namespace: io.kestra.tests
+
+tasks:
+  - id: loop
+    type: io.kestra.plugin.core.flow.Loop
+    values: ["value 1", "value 2", "value 3"]
+    transmitFailed: false
+    tasks:
+      - id: fail
+        type: io.kestra.plugin.core.execution.Fail

--- a/core/src/test/resources/flows/valids/loop-failed.yaml
+++ b/core/src/test/resources/flows/valids/loop-failed.yaml
@@ -1,0 +1,10 @@
+id: loop-failed
+namespace: io.kestra.tests
+
+tasks:
+  - id: loop
+    type: io.kestra.plugin.core.flow.Loop
+    values: ["value 1", "value 2", "value 3"]
+    tasks:
+      - id: fail
+        type: io.kestra.plugin.core.execution.Fail

--- a/core/src/test/resources/flows/valids/loop-flowable.yaml
+++ b/core/src/test/resources/flows/valids/loop-flowable.yaml
@@ -1,0 +1,18 @@
+id: loop-flowable
+namespace: io.kestra.tests
+
+tasks:
+  - id: loop
+    type: io.kestra.plugin.core.flow.Loop
+    values: ["value 1", "value 2", "value 3"]
+    tasks:
+      - id: before_if
+        type: io.kestra.plugin.core.debug.Return
+        format: "Before if {{ item.value }}"
+      - id: if
+        type: io.kestra.plugin.core.flow.If
+        condition: '{{ item.value == "value 2" }}'
+        then:
+          - id: after_if
+            type: io.kestra.plugin.core.debug.Return
+            format: "After if {{ item.value }}"

--- a/core/src/test/resources/flows/valids/loop-multiple.yaml
+++ b/core/src/test/resources/flows/valids/loop-multiple.yaml
@@ -1,0 +1,18 @@
+id: loop-multiple
+namespace: io.kestra.tests
+
+tasks:
+  - id: loop1
+    type: io.kestra.plugin.core.flow.Loop
+    values: ["value 1", "value 2", "value 3"]
+    tasks:
+      - id: return1
+        type: io.kestra.plugin.core.debug.Return
+        format: "{{item.index}} - {{ item.value }}"
+  - id: loop2
+    type: io.kestra.plugin.core.flow.Loop
+    values: ["value 1", "value 2", "value 3"]
+    tasks:
+      - id: return2
+        type: io.kestra.plugin.core.debug.Return
+        format: "{{item.index}} - {{ item.value }}"

--- a/core/src/test/resources/flows/valids/loop-nested.yaml
+++ b/core/src/test/resources/flows/valids/loop-nested.yaml
@@ -1,0 +1,25 @@
+id: loop-nested
+namespace: io.kestra.tests
+
+tasks:
+  - id: loop1
+    type: io.kestra.plugin.core.flow.Loop
+    values: [1, 2, 3]
+    tasks:
+      - id: loop2
+        type: io.kestra.plugin.core.flow.Loop
+        values: [1, 2, 3]
+        tasks:
+          - id: loop3
+            type: io.kestra.plugin.core.flow.Loop
+            values: [ 1, 2, 3 ]
+            tasks:
+            - id: item
+              type: io.kestra.core.tasks.debugs.Return
+              format: "{{item.index}} - {{item.value}}"
+            - id: parent
+              type: io.kestra.core.tasks.debugs.Return
+              format: "{{item.parent.index}} - {{item.parent.value}}"
+            - id: parents
+              type: io.kestra.core.tasks.debugs.Return
+              format: "{{item.parents[0].index}} - {{item.parents[0].value}} - {{item.parents[1].index}} - {{item.parents[1].value}}"

--- a/core/src/test/resources/flows/valids/loop-parallel-equal.yaml
+++ b/core/src/test/resources/flows/valids/loop-parallel-equal.yaml
@@ -1,0 +1,12 @@
+id: loop-parallel-equal
+namespace: io.kestra.tests
+
+tasks:
+  - id: loop
+    type: io.kestra.plugin.core.flow.Loop
+    concurrencyLimit: 3
+    values: ["value 1", "value 2", "value 3"]
+    tasks:
+      - id: item
+        type: io.kestra.core.tasks.debugs.Return
+        format: "{{item.index}} - {{item.value}}"

--- a/core/src/test/resources/flows/valids/loop-parallel-less.yaml
+++ b/core/src/test/resources/flows/valids/loop-parallel-less.yaml
@@ -1,0 +1,12 @@
+id: loop-parallel-less
+namespace: io.kestra.tests
+
+tasks:
+  - id: loop
+    type: io.kestra.plugin.core.flow.Loop
+    concurrencyLimit: 2
+    values: ["value 1", "value 2", "value 3", "value 4"]
+    tasks:
+      - id: item
+        type: io.kestra.core.tasks.debugs.Return
+        format: "{{item.index}} - {{item.value}}"

--- a/core/src/test/resources/flows/valids/loop-parallel-more.yaml
+++ b/core/src/test/resources/flows/valids/loop-parallel-more.yaml
@@ -1,0 +1,12 @@
+id: loop-parallel-more
+namespace: io.kestra.tests
+
+tasks:
+  - id: loop
+    type: io.kestra.plugin.core.flow.Loop
+    concurrencyLimit: 5
+    values: ["value 1", "value 2", "value 3"]
+    tasks:
+      - id: item
+        type: io.kestra.core.tasks.debugs.Return
+        format: "{{item.index}} - {{item.value}}"

--- a/core/src/test/resources/flows/valids/loop-parallel-unlimited.yaml
+++ b/core/src/test/resources/flows/valids/loop-parallel-unlimited.yaml
@@ -1,0 +1,12 @@
+id: loop-parallel-unlimited
+namespace: io.kestra.tests
+
+tasks:
+  - id: loop
+    type: io.kestra.plugin.core.flow.Loop
+    concurrencyLimit: 0
+    values: ["value 1", "value 2", "value 3"]
+    tasks:
+      - id: item
+        type: io.kestra.core.tasks.debugs.Return
+        format: "{{item.index}} - {{item.value}}"

--- a/core/src/test/resources/flows/valids/loop-serial-multiple-tasks.yaml
+++ b/core/src/test/resources/flows/valids/loop-serial-multiple-tasks.yaml
@@ -1,0 +1,14 @@
+id: loop-serial-multiple-tasks
+namespace: io.kestra.tests
+
+tasks:
+  - id: loop
+    type: io.kestra.plugin.core.flow.Loop
+    values: ["value 1", "value 2"]
+    tasks:
+      - id: first
+        type: io.kestra.plugin.core.log.Log
+        message: "First task for {{ item.value }}"
+      - id: second
+        type: io.kestra.plugin.core.log.Log
+        message: "Second task for {{ item.value }}"

--- a/core/src/test/resources/flows/valids/loop-serial.yaml
+++ b/core/src/test/resources/flows/valids/loop-serial.yaml
@@ -1,0 +1,11 @@
+id: loop-serial
+namespace: io.kestra.tests
+
+tasks:
+  - id: loop
+    type: io.kestra.plugin.core.flow.Loop
+    values: ["value 1", "value 2", "value 3"]
+    tasks:
+      - id: item
+        type: io.kestra.core.tasks.debugs.Return
+        format: "{{item.index}} - {{item.value}}"

--- a/executor/src/main/java/io/kestra/executor/DefaultExecutor.java
+++ b/executor/src/main/java/io/kestra/executor/DefaultExecutor.java
@@ -78,13 +78,13 @@ public class DefaultExecutor extends AbstractService implements Executor {
     @Inject
     private DispatchQueueInterface<MultipleConditionEvent> multipleConditionEventQueue;
     @Inject
+    private DispatchQueueInterface<TerminatedLoopExecution> terminatedLoopExecutionQueue;
+    @Inject
     private KillSwitchService killSwitchService;
     @Inject
     private ExecutorService executorService;
     @Inject
     private ExecutionService executionService;
-    @Inject
-    private VariablesService variablesService;
     @Inject
     private FlowTriggerService flowTriggerService;
     @Inject
@@ -130,6 +130,8 @@ public class DefaultExecutor extends AbstractService implements Executor {
     private SubflowExecutionEndMessageHandler subflowExecutionEndMessageHandler;
     @Inject
     private MultipleConditionEventMessageHandler multipleConditionEventMessageHandler;
+    @Inject
+    private TerminatedLoopExecutionMessageHandler terminatedLoopExecutionMessageHandler;
 
     private final ScheduledExecutorService scheduledExecutorService = Executors.newSingleThreadScheduledExecutor();
     private ScheduledFuture<?> executionDelayFuture;
@@ -220,6 +222,7 @@ public class DefaultExecutor extends AbstractService implements Executor {
         this.queueSubscribers.addFirst(this.subflowExecutionResultQueue.subscriber().subscribe(this::subflowExecutionResultQueue));
         this.queueSubscribers.addFirst(this.subflowExecutionEndQueue.subscriber().subscribe(this::subflowExecutionEndQueue));
         this.queueSubscribers.addFirst(this.multipleConditionEventQueue.subscriber().subscribe(this::multipleConditionEventQueue));
+        this.queueSubscribers.addFirst(this.terminatedLoopExecutionQueue.subscriber().subscribe(this::loopExecutionTerminatedQueue));
         this.queueSubscribers.addFirst(this.killQueue.subscriber().subscribe(this::killQueue));
 
         // Register maintenance listener
@@ -467,6 +470,18 @@ public class DefaultExecutor extends AbstractService implements Executor {
         MultipleConditionEvent multipleConditionEvent = either.getLeft();
 
         multipleConditionEventMessageHandler.handle(multipleConditionEvent);
+    }
+
+    private void loopExecutionTerminatedQueue(Either<TerminatedLoopExecution, DeserializationException> either) {
+        if (either.isRight()) {
+            log.error("Unable to deserialize a terminated loop execution event: {}", either.getRight().getMessage());
+            return;
+        }
+
+        TerminatedLoopExecution terminatedLoopExecution = either.getLeft();
+
+        Optional<ExecutorContext> maybeExecutor = terminatedLoopExecutionMessageHandler.handle(terminatedLoopExecution);
+        maybeExecutor.ifPresent(this::toExecution);
     }
 
     private void handleKillSwitchedExecution(EvaluationType evaluationType, Execution message) {
@@ -731,6 +746,12 @@ public class DefaultExecutor extends AbstractService implements Executor {
                         executor.getExecution(), parentExecutionId, taskRunId, taskId, execution.getState().getCurrent(), outputs
                     );
                     this.subflowExecutionEndQueue.emit(subflowExecutionEnd);
+                }
+
+                // if it was a loop execution, we send a terminated loop execution message to the parent execution
+                if (executor.getExecution().getKind() == ExecutionKind.LOOP) {
+                    var terminatedLoopExecution = new TerminatedLoopExecution(executor.getExecution().getLoopRun(), executor.getExecution().getId(), executor.getExecution().getState().getCurrent());
+                    terminatedLoopExecutionQueue.emit(terminatedLoopExecution);
                 }
 
                 // purge SLA monitors

--- a/executor/src/main/java/io/kestra/executor/ExecutorContext.java
+++ b/executor/src/main/java/io/kestra/executor/ExecutorContext.java
@@ -39,6 +39,7 @@ public class ExecutorContext {
     private final List<ExecutionDelay> executionDelays = new ArrayList<>(0);
     private final List<SubflowExecution<?>> subflowExecutions = new ArrayList<>(0);
     private final List<SubflowExecutionResult> subflowExecutionResults = new ArrayList<>(0);
+    private final List<Execution> loopExecutions = new ArrayList<>(0);
     private State.Type originalState;
 
     public ExecutorContext(Execution execution) {
@@ -108,6 +109,13 @@ public class ExecutorContext {
 
     public ExecutorContext withSubflowExecutionResults(List<SubflowExecutionResult> subflowExecutionResults, String from) {
         this.subflowExecutionResults.addAll(subflowExecutionResults);
+        this.from.add(from);
+
+        return this;
+    }
+
+    public ExecutorContext withLoopExecution(Execution loopExecution, String from) {
+        this.loopExecutions.add(loopExecution);
         this.from.add(from);
 
         return this;

--- a/executor/src/main/java/io/kestra/executor/ExecutorService.java
+++ b/executor/src/main/java/io/kestra/executor/ExecutorService.java
@@ -6,6 +6,8 @@ import java.util.*;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
+import io.kestra.core.utils.*;
+import io.kestra.plugin.core.flow.*;
 import org.slf4j.Logger;
 import org.slf4j.event.Level;
 
@@ -34,14 +36,6 @@ import io.kestra.core.runners.SubflowExecutionEnd;
 import io.kestra.core.services.*;
 import io.kestra.core.test.flow.TaskFixture;
 import io.kestra.core.trace.propagation.RunContextTextMapSetter;
-import io.kestra.core.utils.ListUtils;
-import io.kestra.core.utils.Logs;
-import io.kestra.core.utils.MapUtils;
-import io.kestra.core.utils.TruthUtils;
-import io.kestra.plugin.core.flow.LoopUntil;
-import io.kestra.plugin.core.flow.Pause;
-import io.kestra.plugin.core.flow.Subflow;
-import io.kestra.plugin.core.flow.WorkingDirectory;
 
 import io.micronaut.context.ApplicationContext;
 import io.opentelemetry.api.OpenTelemetry;
@@ -166,13 +160,13 @@ public class ExecutorService {
             //then set the execution to killed
             executor = this.handleKilling(executor);
 
-            // process next task if not killing or killed
+            // process next task if not killing, killed or queued
             if (
                 executor.getExecution().getState().getCurrent() != State.Type.KILLING && executor.getExecution().getState().getCurrent() != State.Type.KILLED
                     && executor.getExecution().getState().getCurrent() != State.Type.QUEUED
             ) {
                 executor = this.handleNext(executor);
-                executor = this.handleChildNext(executor);
+                executor = this.handleFlowableTasks(executor);
             }
 
             // but keep listeners on killing
@@ -415,8 +409,22 @@ public class ExecutorService {
     private ExecutorContext onEnd(ExecutorContext executor) {
         final FlowWithSource flow = executor.getFlow();
 
+        // For LOOP sub-executions, use guessFinalState(List<ResolvedTask>, TaskRun, boolean, boolean) to compute the final state from the Loop's child tasks directly.
+        State.Type finalState;
+        if (executor.getExecution().getKind() == ExecutionKind.LOOP && executor.getExecution().getLoopRun() != null) {
+            Loop loop = (Loop) flow.findTaskByTaskIdOrNull(executor.getExecution().getLoopRun().taskId());
+            if (loop != null) {
+                List<ResolvedTask> childTasks = loop.getTasks().stream().map(ResolvedTask::of).toList();
+                finalState = executor.getExecution().guessFinalState(childTasks, null, false, false);
+            } else {
+                finalState = executor.getExecution().guessFinalState(flow);
+            }
+        } else {
+            finalState = executor.getExecution().guessFinalState(flow);
+        }
+
         Execution newExecution = executor.getExecution()
-            .withState(executor.getExecution().guessFinalState(flow));
+            .withState(finalState);
 
         if (flow.getOutputs() != null) {
             RunContext runContext = runContextFactory.of(executor.getFlow(), executor.getExecution());
@@ -461,14 +469,28 @@ public class ExecutorService {
         return executor.withExecution(newExecution, "onEnd");
     }
 
-    private ExecutorContext handleNext(ExecutorContext executor) {
-        List<NextTaskRun> nextTaskRuns = FlowableUtils
-            .resolveSequentialNexts(
+    private ExecutorContext handleNext(ExecutorContext executor) throws InternalException {
+        List<NextTaskRun> nextTaskRuns;
+        if (executor.getExecution().getKind() != ExecutionKind.LOOP) {
+            nextTaskRuns = FlowableUtils.resolveSequentialNexts(
+                    executor.getExecution(),
+                    ResolvedTask.of(executor.getFlow().getTasks()),
+                    ResolvedTask.of(executor.getFlow().getErrors()),
+                    ResolvedTask.of(executor.getFlow().getFinally())
+                );
+        } else if (executor.getExecution().getLoopRun() != null) { // should always be true but better be safe
+            // for LOOP executions: we only execute the loop itself, not the whole execution
+            Loop loop = (Loop) executor.getFlow().findTaskByTaskId(executor.getExecution().getLoopRun().taskId());
+            nextTaskRuns = FlowableUtils.resolveSequentialNexts(
                 executor.getExecution(),
-                ResolvedTask.of(executor.getFlow().getTasks()),
-                ResolvedTask.of(executor.getFlow().getErrors()),
-                ResolvedTask.of(executor.getFlow().getFinally())
+                ResolvedTask.of(loop.getTasks()),
+                ResolvedTask.of(loop.getErrors()),
+                ResolvedTask.of(loop.getFinally())
             );
+        } else {
+            // should never happen but better be safe
+            return executor;
+        }
 
         if (nextTaskRuns.isEmpty()) {
             return executor;
@@ -480,7 +502,7 @@ public class ExecutorService {
         );
     }
 
-    private ExecutorContext handleChildNext(ExecutorContext executor) throws InternalException {
+    private ExecutorContext handleFlowableTasks(ExecutorContext executor) throws InternalException {
         if (executor.getExecution().getTaskRunList() == null) {
             return executor;
         }
@@ -615,6 +637,29 @@ public class ExecutorService {
                     .executionKind(executor.getExecution().getKind())
                     .build();
                 onPauses.add(new ExecutorContext.ExecutorWorkerTask(pauseWorkerTask, runContext));
+            } else if (task instanceof Loop loop) {
+                if (!loop.isMySubExecution(executor.getExecution(), taskRun)) {
+                    if (taskRun.getState().getCurrent() == State.Type.CREATED) {
+                        RunContext runContext = runContextFactory.of(executor.getFlow(), task, executor.getExecution(), taskRun);
+                        List<String> values = FlowableUtils.resolveValues(runContext, loop.getValues());
+                        int limit = loop.getConcurrencyLimit() == 0 ? values.size() : (loop.getConcurrencyLimit() > values.size() ? values.size() : loop.getConcurrencyLimit());
+
+                        // save the iteration information in outputs to know how many loop iterations we already triggered
+                        taskOutputService.saveOutputs(taskRun, Map.of(
+                            Loop.ITERATION_COUNT_OUTPUT, values.size(),
+                            Loop.RUNNING_ITERATIONS_OUTPUT, limit,
+                            Loop.TERMINATED_ITERATIONS_OUTPUT, 0)
+                        );
+
+                        for (int i = 0; i < limit; i++) {
+                            var loopExecution = executor.getExecution().loopExecution(IdUtils.create(), taskRun, values.get(i), i);
+                            executor.withLoopExecution(loopExecution, "handleLoopExecution");
+                        }
+                        // TODO we may need to also start the attempts...
+                        executor.withExecution(executor.getExecution()
+                            .withTaskRun(taskRun.withState(State.Type.RUNNING)), "handleLoop");
+                    }
+                }
             }
 
             // If the task is retrying
@@ -781,18 +826,24 @@ public class ExecutorService {
         return executor;
     }
 
-    private ExecutorContext handleEnd(ExecutorContext executor) {
+    private ExecutorContext handleEnd(ExecutorContext executor) throws InternalException {
         if (executor.getExecution().getState().isTerminated() || executor.getExecution().getState().isPaused() || executor.getExecution().getState().isRetrying()) {
             return executor;
         }
 
-        List<ResolvedTask> currentTasks = executor.getExecution().findTaskDependingFlowState(
-            ResolvedTask.of(executor.getFlow().getTasks()),
-            ResolvedTask.of(executor.getFlow().getErrors()),
-            ResolvedTask.of(executor.getFlow().getFinally())
-        );
+        List<ResolvedTask> currentTasks = null;
+        if (executor.getExecution().getKind() != ExecutionKind.LOOP) {
+            currentTasks = executor.getExecution().findTaskDependingFlowState(
+                ResolvedTask.of(executor.getFlow().getTasks()),
+                ResolvedTask.of(executor.getFlow().getErrors()),
+                ResolvedTask.of(executor.getFlow().getFinally())
+            );
+        } else if (executor.getExecution().getLoopRun() != null) { // should always be true but better be safe
+            Loop loop = (Loop) executor.getFlow().findTaskByTaskId(executor.getExecution().getLoopRun().taskId());
+            currentTasks = loop.getTasks().stream().map(ResolvedTask::of).toList();
+        }
 
-        if (!executor.getExecution().isTerminated(currentTasks)) {
+        if (currentTasks == null || !executor.getExecution().isTerminated(currentTasks)) {
             return executor;
         }
 
@@ -1311,20 +1362,7 @@ public class ExecutorService {
         return taskRuns.size() > ListUtils.emptyOnNull(execution.getTaskRunList()).size() ? execution.withTaskRunList(taskRuns) : null;
     }
 
-    public boolean canBePurged(final ExecutorContext executor) {
-        return executor.getExecution().isDeleted() || (executor.getFlow() != null &&
-        // is terminated
-            executionService.isTerminated(executor.getFlow(), executor.getExecution())
-            // we don't purge pause execution in order to be able to restart automatically in case of delay
-            && executor.getExecution().getState().getCurrent() != State.Type.PAUSED
-            // we don't purge killed execution in order to have feedback about child running tasks
-            // this can be killed lately (after the executor kill the execution), but we want to keep
-            // feedback about the actual state (killed or not)
-            // @TODO: this can lead to infinite state store for most executor topic
-            && executor.getExecution().getState().getCurrent() != State.Type.KILLED);
-    }
-
-    public void log(Logger log, Boolean in, WorkerJob value) {
+    public void log(Logger log, boolean in, WorkerJob value) {
         if (log.isDebugEnabled()) { // taskRun().toStringState() is costly so we avoid calling it if not needed
             if (value instanceof WorkerTask workerTask) {
                 log.debug(
@@ -1344,7 +1382,7 @@ public class ExecutorService {
         }
     }
 
-    public void log(Logger log, Boolean in, WorkerTaskResult value) {
+    public void log(Logger log, boolean in, WorkerTaskResult value) {
         if (log.isDebugEnabled()) { // taskRun().toStringState() is costly so we avoid calling it if not needed
             log.debug(
                 "{} {} : {}",
@@ -1355,7 +1393,7 @@ public class ExecutorService {
         }
     }
 
-    public void log(Logger log, Boolean in, SubflowExecutionResult value) {
+    public void log(Logger log, boolean in, SubflowExecutionResult value) {
         if (log.isDebugEnabled()) { // taskRun().toStringState() is costly so we avoid calling it if not needed
             log.debug(
                 "{} {} : {}",
@@ -1366,7 +1404,7 @@ public class ExecutorService {
         }
     }
 
-    public void log(Logger log, Boolean in, SubflowExecutionEnd value) {
+    public void log(Logger log, boolean in, SubflowExecutionEnd value) {
         if (log.isDebugEnabled()) { // taskRun().toStringState() is costly so we avoid calling it if not needed
             log.debug(
                 "{} {} : {}",
@@ -1377,7 +1415,7 @@ public class ExecutorService {
         }
     }
 
-    public void log(Logger log, Boolean in, Execution value) {
+    public void log(Logger log, boolean in, Execution value) {
         if (log.isDebugEnabled()) { // taskRun().toStringState() is costly so we avoid calling it if not needed
             log.debug(
                 "{} {} [key='{}']\n{}",
@@ -1389,7 +1427,7 @@ public class ExecutorService {
         }
     }
 
-    public void log(Logger log, Boolean in, ExecutorContext value) {
+    public void log(Logger log, boolean in, ExecutorContext value) {
         if (log.isDebugEnabled()) { // taskRun().toStringState() is costly so we avoid calling it if not needed
             log.debug(
                 "{} {} [key='{}', from='{}', crc32='{}']\n{}",
@@ -1399,6 +1437,17 @@ public class ExecutorService {
                 value.getFrom(),
                 value.getExecution().toCrc32State(),
                 value.getExecution().toStringState()
+            );
+        }
+    }
+
+    public void log(Logger log, boolean in, TerminatedLoopExecution value) {
+        if (log.isDebugEnabled()) { // taskRun().toStringState() is costly so we avoid calling it if not needed
+            log.debug(
+                "{} {} : {}",
+                in ? "<< IN " : ">> OUT",
+                value.getClass().getSimpleName(),
+                value.toStringState()
             );
         }
     }
@@ -1416,7 +1465,7 @@ public class ExecutorService {
     /**
      * Handle flow ExecutionChangedSLA on an executor.
      * If there are SLA violations, it will take care of updating the execution based on the SLA behavior.
-     * 
+     *
      * @see #processViolation(RunContext, ExecutorContext, Violation)
      *      <p>
      *      WARNING: ATM, only the first violation will update the execution.

--- a/executor/src/main/java/io/kestra/executor/handler/ExecutionEventMessageHandler.java
+++ b/executor/src/main/java/io/kestra/executor/handler/ExecutionEventMessageHandler.java
@@ -5,15 +5,12 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
+import io.kestra.core.models.executions.*;
 import org.apache.commons.lang3.tuple.Pair;
 import org.slf4j.event.Level;
 
 import io.kestra.core.exceptions.FlowNotFoundException;
 import io.kestra.core.exceptions.InternalException;
-import io.kestra.core.models.executions.Execution;
-import io.kestra.core.models.executions.LogEntry;
-import io.kestra.core.models.executions.TaskRun;
-import io.kestra.core.models.executions.TaskRunAttempt;
 import io.kestra.core.models.flows.FlowId;
 import io.kestra.core.models.flows.FlowWithSource;
 import io.kestra.core.models.flows.State;
@@ -70,6 +67,8 @@ public class ExecutionEventMessageHandler implements ExecutorMessageHandler<Exec
     private DispatchQueueInterface<SubflowExecutionResult> subflowExecutionResultQueue;
     @Inject
     private DispatchQueueInterface<Execution> executionQueue;
+    @Inject
+    private DispatchQueueInterface<TerminatedLoopExecution> terminatedLoopExecutionQueue;
     @Inject
     private RunContextLoggerFactory runContextLoggerFactory;
 
@@ -269,6 +268,11 @@ public class ExecutionEventMessageHandler implements ExecutorMessageHandler<Exec
 
                                 executionQueue.emit(subflowExecution.getExecution());
                             }));
+                        }
+
+                        // trigger new loop executions
+                        if (!executor.getLoopExecutions().isEmpty()) {
+                            executor.getLoopExecutions().forEach(throwConsumer(loopExecution -> executionQueue.emit(loopExecution)));
                         }
 
                         return executor;

--- a/executor/src/main/java/io/kestra/executor/handler/TerminatedLoopExecutionMessageHandler.java
+++ b/executor/src/main/java/io/kestra/executor/handler/TerminatedLoopExecutionMessageHandler.java
@@ -1,0 +1,137 @@
+package io.kestra.executor.handler;
+
+import io.kestra.core.exceptions.FlowNotFoundException;
+import io.kestra.core.exceptions.InternalException;
+import io.kestra.core.models.executions.Execution;
+import io.kestra.core.models.executions.TaskRun;
+import io.kestra.core.models.executions.TaskRunAttempt;
+import io.kestra.core.models.executions.TerminatedLoopExecution;
+import io.kestra.core.models.flows.FlowWithSource;
+import io.kestra.core.models.flows.State;
+import io.kestra.core.models.tasks.Task;
+import io.kestra.core.queues.DispatchQueueInterface;
+import io.kestra.core.queues.QueueException;
+import io.kestra.core.runners.*;
+import io.kestra.core.services.TaskOutputService;
+import io.kestra.core.utils.IdUtils;
+import io.kestra.executor.*;
+import io.kestra.plugin.core.flow.Loop;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+@Singleton
+@Slf4j
+public class TerminatedLoopExecutionMessageHandler implements ExecutorMessageHandler<TerminatedLoopExecution> {
+    @Inject
+    private ExecutorService executorService;
+
+    @Inject
+    private TaskOutputService taskOutputService;
+
+    @Inject
+    private ExecutionStateStore executionStateStore;
+
+    @Inject
+    private RunContextFactory runContextFactory;
+
+    @Inject
+    private FlowMetaStoreInterface flowMetaStore;
+
+    @Inject
+    private DispatchQueueInterface<Execution> executionQueue;
+
+    @Override
+    public Optional<ExecutorContext> handle(TerminatedLoopExecution message) {
+        if (log.isDebugEnabled()) {
+            executorService.log(log, true, message);
+        }
+
+        return executionStateStore.lock(message.loopRun().executionId(), execution ->
+        {
+            try {
+                final FlowWithSource flow = flowMetaStore.findByExecutionThenInjectDefaults(execution).orElseThrow(() -> new FlowNotFoundException(execution));
+                ExecutorContext executor = new ExecutorContext(execution, flow);
+                TaskRun parentTaskRun = execution.findTaskRunByTaskRunId(message.loopRun().taskRunId());
+                Loop loop = (Loop) executor.getFlow().findTaskByTaskId(message.loopRun().taskId());
+
+                if (loop.getTransmitFailed() && message.state().isTerminatedInError()) {
+                    // immediately terminate the loop
+                    return terminateLoop(parentTaskRun, loop, executor, message.state());
+                } else {
+                    // increment iteration
+                    Map<String, Object> outputs = taskOutputService.getOutputs(parentTaskRun);
+                    int iterationCount = (Integer) outputs.get(Loop.ITERATION_COUNT_OUTPUT);
+                    int runningIteration = (Integer) outputs.get(Loop.RUNNING_ITERATIONS_OUTPUT) - 1;
+                    int terminatedIteration = (Integer) outputs.get(Loop.TERMINATED_ITERATIONS_OUTPUT) + 1;
+
+                    // Check the next iteration index
+                    int nextIndex = runningIteration + terminatedIteration;
+                    if (nextIndex < iterationCount) {
+                        taskOutputService.saveOutputs(parentTaskRun, Map.of(
+                            Loop.ITERATION_COUNT_OUTPUT, iterationCount,
+                            Loop.RUNNING_ITERATIONS_OUTPUT, runningIteration + 1,
+                            Loop.TERMINATED_ITERATIONS_OUTPUT, terminatedIteration)
+                        );
+                        RunContext runContext = runContextFactory.of(executor.getFlow(), loop, executor.getExecution(), parentTaskRun);
+                        String value = FlowableUtils.resolveValues(runContext, loop.getValues()).get(nextIndex);
+                        var loopExecution = executor.getExecution().loopExecution(IdUtils.create(), parentTaskRun, value, nextIndex);
+                        executionQueue.emit(loopExecution);
+                        // we don't update the execution itself as the loop is still running
+                        // TODO we may need to send a follow execution message to update the UI
+                        return null;
+                    } else {
+                        // All iterations have been started — save the decremented counts and either
+                        // terminate (if all are done) or wait for the remaining in-flight ones.
+                        taskOutputService.saveOutputs(parentTaskRun, Map.of(
+                            Loop.ITERATION_COUNT_OUTPUT, iterationCount,
+                            Loop.RUNNING_ITERATIONS_OUTPUT, runningIteration,
+                            Loop.TERMINATED_ITERATIONS_OUTPUT, terminatedIteration)
+                        );
+                        if (terminatedIteration == iterationCount) {
+                            // All iterations have completed — end the loop with success.
+                            return terminateLoop(parentTaskRun, loop, executor, State.Type.SUCCESS);
+                        } else {
+                            // Some iterations are still running — wait for them.
+                            // TODO we may need to send a follow execution message to update the UI
+                            return null;
+                        }
+                    }
+                }
+            } catch (InternalException | QueueException e) {
+                return executorService.handleFailedExecutionFromExecutor(new ExecutorContext(execution), e);
+            } catch (FlowNotFoundException e) {
+                // avoid infinite loop for FlowNotFoundException
+                if (!execution.getState().getCurrent().isFailed()) {
+                    return executorService.handleFailedExecutionFromExecutor(new ExecutorContext(execution), e);
+                }
+
+                return null;
+            }
+        });
+    }
+
+    // terminate the loop and its attempts
+    private ExecutorContext terminateLoop(TaskRun parentTaskRun, Task task, final ExecutorContext executor, State.Type state) throws InternalException {
+        State.Type finalState = state == State.Type.FAILED ? stateFailure(task) : State.Type.SUCCESS;
+        List<TaskRunAttempt> attempts = Optional.ofNullable(parentTaskRun.getAttempts())
+            .map(ArrayList::new)
+            .orElseGet(ArrayList::new);
+        TaskRunAttempt updated = attempts.getLast().withState(finalState);
+        attempts.set(attempts.size() - 1, updated);
+        TaskRun newTaskRun = parentTaskRun.withState(finalState)
+            .withAttempts(attempts);
+        WorkerTaskResult workerTaskResult = new WorkerTaskResult(newTaskRun);
+        executorService.addWorkerTaskResult(executor, () -> executor.getFlow(), workerTaskResult);
+        return executor;
+    }
+
+    private State.Type stateFailure(Task task) {
+        return task.isAllowFailure() ? (task.isAllowWarning() ? State.Type.SUCCESS : State.Type.WARNING) : State.Type.FAILED;
+    }
+}

--- a/executor/src/test/java/io/kestra/executor/handler/TerminatedLoopExecutionMessageHandlerTest.java
+++ b/executor/src/test/java/io/kestra/executor/handler/TerminatedLoopExecutionMessageHandlerTest.java
@@ -1,0 +1,160 @@
+package io.kestra.executor.handler;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import io.kestra.core.utils.TestsUtils;
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import org.junit.jupiter.api.Test;
+
+import io.kestra.core.exceptions.InternalException;
+import io.kestra.core.models.executions.Execution;
+import io.kestra.core.models.executions.LoopRun;
+import io.kestra.core.models.executions.TaskRun;
+import io.kestra.core.models.executions.TaskRunAttempt;
+import io.kestra.core.models.executions.TerminatedLoopExecution;
+import io.kestra.core.models.flows.Flow;
+import io.kestra.core.models.flows.GenericFlow;
+import io.kestra.core.models.flows.State;
+import io.kestra.core.repositories.ExecutionRepositoryInterface;
+import io.kestra.core.repositories.FlowRepositoryInterface;
+import io.kestra.core.services.TaskOutputService;
+import io.kestra.core.utils.IdUtils;
+import io.kestra.plugin.core.flow.Loop;
+import io.kestra.plugin.core.log.Log;
+
+import jakarta.inject.Inject;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@MicronautTest
+class TerminatedLoopExecutionMessageHandlerTest {
+    @Inject
+    private TerminatedLoopExecutionMessageHandler handler;
+
+    @Inject
+    private ExecutionRepositoryInterface executionRepository;
+
+    @Inject
+    private FlowRepositoryInterface flowRepository;
+
+    @Inject
+    private TaskOutputService taskOutputService;
+
+    @Test
+    void shouldReturnEmptyForNonExistingExecution() {
+        // Given
+        var loopRun = new LoopRun("nonExistingExecution", "loop", "taskrun", "a", 0, null);
+        var message = new TerminatedLoopExecution(loopRun, "nonExistingExecution", State.Type.SUCCESS);
+
+        // When
+        var maybeExecutor = handler.handle(message);
+
+        // Then
+        assertThat(maybeExecutor).isEmpty();
+    }
+
+    @Test
+    void shouldTerminateLoopWithSuccessOnLastIteration() throws InternalException {
+        // Given
+        var flow = flowRepository.create(GenericFlow.of(loopFlow()));
+        var execution = Execution.newExecution(flow, Collections.emptyList());
+        String loopTaskRunId = IdUtils.create();
+        var loopTaskRun = loopTaskRun(loopTaskRunId, execution);
+        executionRepository.save(execution.withTaskRunList(List.of(loopTaskRun)));
+        // terminatedIteration + 1 = 3 == iterationCount = 3 → terminates with SUCCESS
+        taskOutputService.saveOutputs(loopTaskRun, Map.of(
+            Loop.ITERATION_COUNT_OUTPUT, 3,
+            Loop.RUNNING_ITERATIONS_OUTPUT, 1,
+            Loop.TERMINATED_ITERATIONS_OUTPUT, 2
+        ));
+
+        // When
+        var loopRun = new LoopRun(execution.getId(), "loop", loopTaskRunId, "c", 2, null);
+        var message = new TerminatedLoopExecution(loopRun, execution.getId(), State.Type.SUCCESS);
+        var maybeExecutor = handler.handle(message);
+
+        // Then
+        assertThat(maybeExecutor).isPresent();
+        var taskRun = maybeExecutor.get().getExecution().findTaskRunByTaskRunId(loopTaskRunId);
+        assertThat(taskRun.getState().getCurrent()).isEqualTo(State.Type.SUCCESS);
+    }
+
+    @Test
+    void shouldTerminateLoopImmediatelyWhenTransmitFailedIsEnabled() throws InternalException {
+        // Given — transmitFailed defaults to true in Loop
+        var flow = flowRepository.create(GenericFlow.of(loopFlow()));
+        var execution = Execution.newExecution(flow, Collections.emptyList());
+        String loopTaskRunId = IdUtils.create();
+        var loopTaskRun = loopTaskRun(loopTaskRunId, execution);
+        executionRepository.save(execution.withTaskRunList(List.of(loopTaskRun)));
+
+        // When — one iteration fails, loop should terminate immediately
+        var loopRun = new LoopRun(execution.getId(), "loop", loopTaskRunId, "a", 0, null);
+        var message = new TerminatedLoopExecution(loopRun, execution.getId(), State.Type.FAILED);
+        var maybeExecutor = handler.handle(message);
+
+        // Then
+        assertThat(maybeExecutor).isPresent();
+        var taskRun = maybeExecutor.get().getExecution().findTaskRunByTaskRunId(loopTaskRunId);
+        assertThat(taskRun.getState().getCurrent()).isEqualTo(State.Type.FAILED);
+    }
+
+    @Test
+    void shouldEmitNextIterationWhenMoreIterationsRemain() throws InternalException {
+        // Given
+        var flow = flowRepository.create(GenericFlow.of(loopFlow()));
+        var execution = Execution.newExecution(flow, Collections.emptyList());
+        String loopTaskRunId = IdUtils.create();
+        var loopTaskRun = loopTaskRun(loopTaskRunId, execution);
+        executionRepository.save(execution.withTaskRunList(List.of(loopTaskRun)));
+        // terminatedIteration + 1 = 1 < iterationCount = 3 → emit next, handler returns null
+        taskOutputService.saveOutputs(loopTaskRun, Map.of(
+            Loop.ITERATION_COUNT_OUTPUT, 3,
+            Loop.RUNNING_ITERATIONS_OUTPUT, 1,
+            Loop.TERMINATED_ITERATIONS_OUTPUT, 0
+        ));
+
+        // When
+        var loopRun = new LoopRun(execution.getId(), "loop", loopTaskRunId, "a", 0, null);
+        var message = new TerminatedLoopExecution(loopRun, execution.getId(), State.Type.SUCCESS);
+        var maybeExecutor = handler.handle(message);
+
+        // Then — handler emits next loop execution and returns empty (null from inner lambda)
+        assertThat(maybeExecutor).isEmpty();
+    }
+
+    private Flow loopFlow() {
+        var logTask = Log.builder().id("log").type(Log.class.getName()).message("Hello").build();
+        var loopTask = Loop.builder()
+            .id("loop")
+            .type(Loop.class.getName())
+            .values(List.of("a", "b", "c"))
+            .tasks(List.of(logTask))
+            .build();
+        return Flow.builder()
+            .tenantId(TestsUtils.randomTenant(this.getClass().getSimpleName()))
+            .namespace("namespace")
+            .id(IdUtils.create())
+            .tasks(List.of(loopTask))
+            .build();
+    }
+
+    private TaskRun loopTaskRun(String id, Execution execution) {
+        return TaskRun.builder()
+            .id(id)
+            .tenantId(execution.getTenantId())
+            .executionId(execution.getId())
+            .namespace(execution.getNamespace())
+            .flowId(execution.getFlowId())
+            .taskId("loop")
+            .state(new State().withState(State.Type.RUNNING))
+            .attempts(List.of(
+                TaskRunAttempt.builder()
+                    .state(new State().withState(State.Type.RUNNING))
+                    .build()
+            ))
+            .build();
+    }
+}

--- a/queue-jdbc/src/main/java/io/kestra/queue/jdbc/JdbcQueueFactory.java
+++ b/queue-jdbc/src/main/java/io/kestra/queue/jdbc/JdbcQueueFactory.java
@@ -1,10 +1,7 @@
 package io.kestra.queue.jdbc;
 
 import io.kestra.core.executor.command.ExecutionCommand;
-import io.kestra.core.models.executions.Execution;
-import io.kestra.core.models.executions.ExecutionKilled;
-import io.kestra.core.models.executions.LogEntry;
-import io.kestra.core.models.executions.MetricEntry;
+import io.kestra.core.models.executions.*;
 import io.kestra.core.models.flows.FlowInterface;
 import io.kestra.core.queues.BroadcastQueueInterface;
 import io.kestra.core.queues.DispatchQueueInterface;
@@ -161,6 +158,15 @@ public class JdbcQueueFactory implements QueueFactoryInterface<JdbcDependencies>
     public DispatchQueueInterface<WorkerTaskResult> workerTaskResultQueue(JdbcDependencies dependencies) {
         return new JdbcDispatchQueue<>(
             WorkerTaskResult.class, dependencies.queueService(), dependencies.jdbcQueueClient(), dependencies.executorsUtils(), dependencies.metricRegistry(),
+            dependencies.ignoreExecutionService()
+        );
+    }
+
+    @QueueBean
+    @Override
+    public DispatchQueueInterface<TerminatedLoopExecution> terminatedLoopExecutionQueue(JdbcDependencies dependencies) {
+        return new JdbcDispatchQueue<>(
+            TerminatedLoopExecution.class, dependencies.queueService(), dependencies.jdbcQueueClient(), dependencies.executorsUtils(), dependencies.metricRegistry(),
             dependencies.ignoreExecutionService()
         );
     }

--- a/queue/src/main/java/io/kestra/queue/QueueFactoryInterface.java
+++ b/queue/src/main/java/io/kestra/queue/QueueFactoryInterface.java
@@ -1,10 +1,7 @@
 package io.kestra.queue;
 
 import io.kestra.core.executor.command.ExecutionCommand;
-import io.kestra.core.models.executions.Execution;
-import io.kestra.core.models.executions.ExecutionKilled;
-import io.kestra.core.models.executions.LogEntry;
-import io.kestra.core.models.executions.MetricEntry;
+import io.kestra.core.models.executions.*;
 import io.kestra.core.models.flows.FlowInterface;
 import io.kestra.core.queues.BroadcastQueueInterface;
 import io.kestra.core.queues.DispatchQueueInterface;
@@ -50,4 +47,6 @@ public interface QueueFactoryInterface<D> {
     KeyedDispatchQueueInterface<WorkerJobEvent> workerJobEventQueue(D dependencies);
 
     DispatchQueueInterface<WorkerTaskResult> workerTaskResultQueue(D dependencies);
+
+    DispatchQueueInterface<TerminatedLoopExecution> terminatedLoopExecutionQueue(D dependencies);
 }

--- a/webserver/src/main/java/io/kestra/webserver/controllers/api/ExecutionController.java
+++ b/webserver/src/main/java/io/kestra/webserver/controllers/api/ExecutionController.java
@@ -841,10 +841,10 @@ public class ExecutionController {
         // This is not nice, but we cannot use @AllArgsConstructor as it would open a bunch of necessary changes on the Execution class.
         ExecutionResponse(String tenantId, String id, String namespace, String flowId, Integer flowRevision, List<TaskRun> taskRunList, Map<String, Object> inputs, Map<String, Object> outputs,
             List<Label> labels, Map<String, Object> variables, State state, String parentId, String originalId, ExecutionTrigger trigger, boolean deleted, ExecutionMetadata metadata,
-            Instant scheduleDate, String traceParent, List<TaskFixture> fixtures, ExecutionKind kind, List<Breakpoint> breakpoints, URI url) {
+            Instant scheduleDate, String traceParent, List<TaskFixture> fixtures, ExecutionKind kind, List<Breakpoint> breakpoints, LoopRun loopRun, URI url) {
             super(
                 tenantId, id, namespace, flowId, flowRevision, taskRunList, inputs, outputs, labels, variables, state, parentId, originalId, trigger, deleted, metadata, scheduleDate,
-                traceParent, fixtures, kind, breakpoints
+                traceParent, fixtures, kind, breakpoints, loopRun
             );
 
             this.url = url;
@@ -873,6 +873,7 @@ public class ExecutionController {
                 execution.getFixtures(),
                 execution.getKind(),
                 execution.getBreakpoints(),
+                execution.getLoopRun(),
                 url
             );
         }
@@ -2813,7 +2814,7 @@ public class ExecutionController {
 
     /**
      * For override purpose.
-     * 
+     *
      * @param execution
      * @return true if the user has the authorization, false else.
      */


### PR DESCRIPTION
Closes https://github.com/kestra-io/kestra-ee/issues/7112*  

## Description

Loop iterations are now run in separate sub-executions, called loop executions.
These loup execution has an execution kind of type LOOP and a `LoopRun` attribute which contains the context of the loop including its value and iteration, and all of it's parents values and iterations.

Each loop iteration then executes on an isolated context.

A concurrencyLimit allow to start loop executions concurrently.

The loop context is available to expressions in the `item` variable.

## Examples:

A basic loop with a single task will creates 3 loop executions:

```yaml
id: loop-serial
namespace: io.kestra.tests

tasks:
  - id: loop
    type: io.kestra.plugin.core.flow.Loop
    values: ["value 1", "value 2", "value 3"]
    tasks:
      - id: item
        type: io.kestra.core.tasks.debugs.Return
        format: "{{item.index}} - {{item.value}}"
```

Multiple loops in the same execution:

```yaml
id: loop-multiple
namespace: io.kestra.tests

tasks:
  - id: loop1
    type: io.kestra.plugin.core.flow.Loop
    values: ["value 1", "value 2", "value 3"]
    tasks:
      - id: return1
        type: io.kestra.plugin.core.debug.Return
        format: "{{item.index}} - {{ item.value }}"
  - id: loop2
    type: io.kestra.plugin.core.flow.Loop
    values: ["value 1", "value 2", "value 3"]
    tasks:
      - id: return2
        type: io.kestra.plugin.core.debug.Return
        format: "{{item.index}} - {{ item.value }}"
```

Flowables can be used inside a loop, they could directly access item information (no need for parent.item.value) as the item is boutond to the loop execution not the loop direct subtasks

```yaml
id: loop-flowable
namespace: io.kestra.tests

tasks:
  - id: loop
    type: io.kestra.plugin.core.flow.Loop
    values: ["value 1", "value 2", "value 3"]
    tasks:
      - id: before_if
        type: io.kestra.plugin.core.debug.Return
        format: "Before if {{ item.value }}"
      - id: if
        type: io.kestra.plugin.core.flow.If
        condition: '{{ item.value == "value 2" }}'
        then:
          - id: after_if
            type: io.kestra.plugin.core.debug.Return
            format: "After if {{ item.value }}"
```

Unlimited nested loops are possible, you can use item.parent to access the direct parent value and index, and `item.parent[idx]`  to access any parents in the hierarchy.

```yaml
id: loop-nested
namespace: io.kestra.tests

tasks:
  - id: loop1
    type: io.kestra.plugin.core.flow.Loop
    values: [1, 2, 3]
    tasks:
      - id: loop2
        type: io.kestra.plugin.core.flow.Loop
        values: [1, 2, 3]
        tasks:
          - id: loop3
            type: io.kestra.plugin.core.flow.Loop
            values: [ 1, 2, 3 ]
            tasks:
            - id: item
              type: io.kestra.core.tasks.debugs.Return
              format: "{{item.index}} - {{item.value}}"
            - id: parent
              type: io.kestra.core.tasks.debugs.Return
              format: "{{item.parent.index}} - {{item.parent.value}}"
            - id: parents
              type: io.kestra.core.tasks.debugs.Return
              format: "{{item.parents[0].index}} - {{item.parents[0].value}} - {{item.parents[1].index}} - {{item.parents[1].value}}"
```

`transmitFailed` can be used to control wether or not the loop should fail if one of its sub-tasks fail:

```yaml
id: loop-failed-no-transmit
namespace: io.kestra.tests

tasks:
  - id: loop
    type: io.kestra.plugin.core.flow.Loop
    values: ["value 1", "value 2", "value 3"]
    transmitFailed: false
    tasks:
      - id: fail
        type: io.kestra.plugin.core.execution.Fail
```

## Remaining work:

- [x] Nested loops
- [ ] A loop has multiple iterations so maybe rename item -> iteration
- [ ] Kill
- [ ] Support Map as values
- [ ] Support internal storage as values
- [ ] Support loop iteration input
- [ ] Support loop iteration output (as loop execution output?) and provide a way to merge them post loop
- [ ] Should we support a wait to trigger and forget loop iterations?
- [ ] UI
- [ ] ...
