### PR TITLE
feat(flows): query flows base on trigger type

### DIFF
--- a/core/src/main/java/io/kestra/core/repositories/FlowRepositoryInterface.java
+++ b/core/src/main/java/io/kestra/core/repositories/FlowRepositoryInterface.java
@@ -15,6 +15,7 @@ import io.kestra.plugin.core.dashboard.data.Flows;
 import io.micronaut.data.model.Pageable;
 import jakarta.annotation.Nullable;
 import jakarta.validation.ConstraintViolationException;
+import jakarta.validation.constraints.NotNull;
 import reactor.core.publisher.Flux;
 
 public interface FlowRepositoryInterface extends QueryBuilderInterface<Flows.Fields> {
@@ -160,6 +161,12 @@ public interface FlowRepositoryInterface extends QueryBuilderInterface<Flows.Fie
         Pageable pageable,
         @Nullable String tenantId,
         @Nullable List<QueryFilter> filters);
+
+    ArrayListTotal<Flow> find(
+        Pageable pageable,
+        @Nullable String tenantId,
+        @Nullable String namespace,
+        @Nullable Class<? extends io.kestra.core.models.triggers.AbstractTrigger> triggerClass);
 
     ArrayListTotal<FlowWithSource> findWithSource(
         Pageable pageable,

--- a/core/src/main/java/io/kestra/core/repositories/FlowRepositoryInterface.java
+++ b/core/src/main/java/io/kestra/core/repositories/FlowRepositoryInterface.java
@@ -15,7 +15,6 @@ import io.kestra.plugin.core.dashboard.data.Flows;
 import io.micronaut.data.model.Pageable;
 import jakarta.annotation.Nullable;
 import jakarta.validation.ConstraintViolationException;
-import jakarta.validation.constraints.NotNull;
 import reactor.core.publisher.Flux;
 
 public interface FlowRepositoryInterface extends QueryBuilderInterface<Flows.Fields> {

--- a/core/src/main/java/io/kestra/core/repositories/FlowRepositoryInterface.java
+++ b/core/src/main/java/io/kestra/core/repositories/FlowRepositoryInterface.java
@@ -165,7 +165,7 @@ public interface FlowRepositoryInterface extends QueryBuilderInterface<Flows.Fie
     ArrayListTotal<Flow> find(
         Pageable pageable,
         @Nullable String tenantId,
-        @Nullable String namespace,
+        String namespace,
         @Nullable Class<? extends io.kestra.core.models.triggers.AbstractTrigger> triggerClass);
 
     ArrayListTotal<FlowWithSource> findWithSource(

--- a/core/src/test/java/io/kestra/core/repositories/AbstractFlowRepositoryTest.java
+++ b/core/src/test/java/io/kestra/core/repositories/AbstractFlowRepositoryTest.java
@@ -84,7 +84,7 @@ public abstract class AbstractFlowRepositoryTest {
     }
 
     @Test
-    void givenFlowWithTriggerWhenFindingFlowWithGivenTriggerClassShouldFindFlowWithTriggerClass() {
+    void givenFlowWithTrigger_whenFindingFlowWithGivenTriggerClass_thenFindFlowWithTriggerClass() {
         // Given
         String tenant = TestsUtils.randomTenant(this.getClass().getSimpleName());
 
@@ -117,6 +117,47 @@ public abstract class AbstractFlowRepositoryTest {
         } finally {
             deleteFlow(flowWithTrigger);
             deleteFlow(flowWithoutTrigger);
+        }
+    }
+
+    @Test
+    void givenMultipleFlowWithTriggerIsDistinctNamespaceWithCommonPrefix_whenFindingFlowWithGivenTriggerClass_shouldFindFlowWithTriggerClassAndFullyMatchingNamespace() {
+        // Given
+        String tenant = TestsUtils.randomTenant(this.getClass().getSimpleName());
+        String childNamespace = TEST_NAMESPACE + ".child";
+
+        UnitTest trigger = UnitTest.builder()
+            .id("trigger")
+            .type(UnitTest.class.getName())
+            .build();
+
+        FlowWithSource flowInBaseNamespace = builder(tenant, "flow-in-base-namespace", TEST_FLOW_ID)
+            .triggers(List.of(trigger))
+            .build();
+        FlowWithSource flowInChildNamespace = builder(tenant, "flow-in-child-namespace", TEST_FLOW_ID)
+            .namespace(childNamespace)
+            .triggers(List.of(trigger))
+            .build();
+
+        flowInBaseNamespace = flowRepository.create(GenericFlow.of(flowInBaseNamespace));
+        flowInChildNamespace = flowRepository.create(GenericFlow.of(flowInChildNamespace));
+
+        try {
+            // When
+            ArrayListTotal<Flow> results = flowRepository.find(
+                Pageable.UNPAGED,
+                tenant,
+                TEST_NAMESPACE,
+                UnitTest.class
+            );
+
+            // Then
+            assertThat(results).hasSize(1);
+            assertThat(results.getFirst().getId()).isEqualTo("flow-in-base-namespace");
+            assertThat(results.getFirst().getNamespace()).isEqualTo(TEST_NAMESPACE);
+        } finally {
+            deleteFlow(flowInBaseNamespace);
+            deleteFlow(flowInChildNamespace);
         }
     }
 

--- a/core/src/test/java/io/kestra/core/repositories/AbstractFlowRepositoryTest.java
+++ b/core/src/test/java/io/kestra/core/repositories/AbstractFlowRepositoryTest.java
@@ -83,6 +83,43 @@ public abstract class AbstractFlowRepositoryTest {
             .tasks(Collections.singletonList(Return.builder().id(taskId).type(Return.class.getName()).format(Property.ofValue(TEST_FLOW_ID)).build()));
     }
 
+    @Test
+    void givenFlowWithTriggerWhenFindingFlowWithGivenTriggerClassShouldFindFlowWithTriggerClass() {
+        // Given
+        String tenant = TestsUtils.randomTenant(this.getClass().getSimpleName());
+
+        UnitTest trigger = UnitTest.builder()
+            .id("trigger")
+            .type(UnitTest.class.getName())
+            .build();
+
+        FlowWithSource flowWithTrigger = builder(tenant, "flow-with-trigger", TEST_FLOW_ID)
+            .triggers(List.of(trigger))
+            .build();
+        FlowWithSource flowWithoutTrigger = builder(tenant, "flow-without-trigger", TEST_FLOW_ID)
+            .build();
+
+        flowWithTrigger = flowRepository.create(GenericFlow.of(flowWithTrigger));
+        flowWithoutTrigger = flowRepository.create(GenericFlow.of(flowWithoutTrigger));
+
+        try {
+            // When
+            ArrayListTotal<Flow> results = flowRepository.find(
+                Pageable.UNPAGED,
+                tenant,
+                TEST_NAMESPACE,
+                UnitTest.class
+            );
+
+            // Then
+            assertThat(results).hasSize(1);
+            assertThat(results.getFirst().getId()).isEqualTo("flow-with-trigger");
+        } finally {
+            deleteFlow(flowWithTrigger);
+            deleteFlow(flowWithoutTrigger);
+        }
+    }
+
     @ParameterizedTest
     @MethodSource("filterCombinations")
     void should_find_all(QueryFilter filter) {

--- a/jdbc-h2/src/main/java/io/kestra/repository/h2/H2FlowRepository.java
+++ b/jdbc-h2/src/main/java/io/kestra/repository/h2/H2FlowRepository.java
@@ -38,4 +38,9 @@ public class H2FlowRepository extends AbstractJdbcFlowRepository {
     protected Condition findSourceCodeCondition(String query) {
         return H2FlowRepositoryService.findSourceCodeCondition(this.jdbcRepository, query);
     }
+
+    @Override
+    protected Condition findTriggerClassCondition(Class<? extends io.kestra.core.models.triggers.AbstractTrigger> triggerClass) {
+        return H2FlowRepositoryService.findTriggerClassCondition(triggerClass);
+    }
 }

--- a/jdbc-h2/src/main/java/io/kestra/repository/h2/H2FlowRepositoryService.java
+++ b/jdbc-h2/src/main/java/io/kestra/repository/h2/H2FlowRepositoryService.java
@@ -39,6 +39,25 @@ public abstract class H2FlowRepositoryService {
         return jdbcRepository.fullTextCondition(List.of("source_code"), query);
     }
 
+    /**
+     * Builds a condition that matches flows containing at least one trigger of the given class type.
+     * Uses the custom JQ_STRING function to extract the first matching trigger type from the JSON array.
+     *
+     * @param triggerClass the trigger class to filter by, or {@code null} to match all flows
+     * @return a jOOQ {@link Condition}
+     */
+    public static Condition findTriggerClassCondition(Class<? extends io.kestra.core.models.triggers.AbstractTrigger> triggerClass) {
+        if (triggerClass == null) {
+            return DSL.trueCondition();
+        }
+        Field<String> matchedType = DSL.field(
+            "JQ_STRING(\"value\", CONCAT('.triggers[]? | select(.type == \"', {0}, '\") | .type'))",
+            String.class,
+            DSL.val(triggerClass.getName(), String.class)
+        );
+        return matchedType.isNotNull();
+    }
+
     public static Condition findCondition(Object labels, QueryFilter.Op operation) {
         List<Condition> conditions = new ArrayList<>();
 

--- a/jdbc-mysql/src/main/java/io/kestra/repository/mysql/MysqlFlowRepository.java
+++ b/jdbc-mysql/src/main/java/io/kestra/repository/mysql/MysqlFlowRepository.java
@@ -38,4 +38,9 @@ public class MysqlFlowRepository extends AbstractJdbcFlowRepository {
     protected Condition findSourceCodeCondition(String query) {
         return MysqlFlowRepositoryService.findSourceCodeCondition(this.jdbcRepository, query);
     }
+
+    @Override
+    protected Condition findTriggerClassCondition(Class<? extends io.kestra.core.models.triggers.AbstractTrigger> triggerClass) {
+        return MysqlFlowRepositoryService.findTriggerClassCondition(triggerClass);
+    }
 }

--- a/jdbc-mysql/src/main/java/io/kestra/repository/mysql/MysqlFlowRepositoryService.java
+++ b/jdbc-mysql/src/main/java/io/kestra/repository/mysql/MysqlFlowRepositoryService.java
@@ -36,6 +36,23 @@ public abstract class MysqlFlowRepositoryService {
         return jdbcRepository.fullTextCondition(Collections.singletonList("source_code"), query);
     }
 
+    /**
+     * Builds a condition that matches flows containing at least one trigger of the given class type.
+     * Uses JSON_SEARCH to check if the type value exists anywhere in the triggers array.
+     *
+     * @param triggerClass the trigger class to filter by, or {@code null} to match all flows
+     * @return a jOOQ {@link Condition}
+     */
+    public static Condition findTriggerClassCondition(Class<? extends io.kestra.core.models.triggers.AbstractTrigger> triggerClass) {
+        if (triggerClass == null) {
+            return DSL.trueCondition();
+        }
+        return DSL.condition(
+            "JSON_SEARCH(`value`, 'one', {0}, NULL, '$.triggers[*].type') IS NOT NULL",
+            DSL.val(triggerClass.getName(), String.class)
+        );
+    }
+
     public static Condition findCondition(Object labels, QueryFilter.Op operation) {
         List<Condition> conditions = new ArrayList<>();
 

--- a/jdbc-postgres/src/main/java/io/kestra/repository/postgres/PostgresFlowRepository.java
+++ b/jdbc-postgres/src/main/java/io/kestra/repository/postgres/PostgresFlowRepository.java
@@ -38,4 +38,9 @@ public class PostgresFlowRepository extends AbstractJdbcFlowRepository {
     protected Condition findSourceCodeCondition(String query) {
         return PostgresFlowRepositoryService.findSourceCodeCondition(this.jdbcRepository, query);
     }
+
+    @Override
+    protected Condition findTriggerClassCondition(Class<? extends io.kestra.core.models.triggers.AbstractTrigger> triggerClass) {
+        return PostgresFlowRepositoryService.findTriggerClassCondition(triggerClass);
+    }
 }

--- a/jdbc-postgres/src/main/java/io/kestra/repository/postgres/PostgresFlowRepositoryService.java
+++ b/jdbc-postgres/src/main/java/io/kestra/repository/postgres/PostgresFlowRepositoryService.java
@@ -37,6 +37,23 @@ public abstract class PostgresFlowRepositoryService {
         return jdbcRepository.fullTextCondition(Collections.singletonList("FULLTEXT_INDEX(source_code)"), query);
     }
 
+    /**
+     * Builds a condition that matches flows containing at least one trigger of the given class type.
+     * Uses jsonb_path_exists to check if any element in the triggers array has a matching type field.
+     *
+     * @param triggerClass the trigger class to filter by, or {@code null} to match all flows
+     * @return a jOOQ {@link Condition}
+     */
+    public static Condition findTriggerClassCondition(Class<? extends io.kestra.core.models.triggers.AbstractTrigger> triggerClass) {
+        if (triggerClass == null) {
+            return DSL.trueCondition();
+        }
+        return DSL.condition(
+            "jsonb_path_exists(value, '$.triggers[*] ? (@.type == $triggerType)', jsonb_build_object('triggerType', {0}::text))",
+            DSL.val(triggerClass.getName(), String.class)
+        );
+    }
+
     public static Condition findCondition(Object labels, QueryFilter.Op operation) {
         List<Condition> conditions = new ArrayList<>();
 

--- a/jdbc/src/main/java/io/kestra/jdbc/repository/AbstractJdbcFlowRepository.java
+++ b/jdbc/src/main/java/io/kestra/jdbc/repository/AbstractJdbcFlowRepository.java
@@ -6,6 +6,7 @@ import java.time.ZonedDateTime;
 import java.util.*;
 import java.util.stream.Collectors;
 
+import jakarta.validation.constraints.NotNull;
 import org.jooq.*;
 import org.jooq.Record;
 import org.jooq.impl.DSL;
@@ -652,6 +653,28 @@ public abstract class AbstractJdbcFlowRepository extends AbstractJdbcRepository 
     }
 
     @Override
+    public ArrayListTotal<Flow> find(
+            Pageable pageable,
+            @Nullable String tenantId,
+            @Nullable String namespace,
+            @Nullable Class<? extends io.kestra.core.models.triggers.AbstractTrigger> triggerClass
+        ) {
+        return this.jdbcRepository
+            .getDslContextWrapper()
+            .transactionResult(configuration ->
+            {
+                DSLContext context = DSL.using(configuration);
+                return (ArrayListTotal) this.jdbcRepository.fetchPage(
+                    context,
+                    getFindFlowSelect(tenantId, null, context, null)
+                        .and(findTriggerClassCondition(triggerClass)
+                        .and(NAMESPACE_FIELD.eq(namespace))),
+                    pageable
+                );
+            });
+    }
+
+    @Override
     @SuppressWarnings({ "unchecked", "rawtypes" })
     public ArrayListTotal<FlowWithSource> findWithSource(Pageable pageable, @Nullable String tenantId, @Nullable List<QueryFilter> filters) {
         return this.jdbcRepository
@@ -689,6 +712,8 @@ public abstract class AbstractJdbcFlowRepository extends AbstractJdbcRepository 
     }
 
     abstract protected Condition findSourceCodeCondition(String query);
+
+    abstract protected Condition findTriggerClassCondition(Class<? extends io.kestra.core.models.triggers.AbstractTrigger> triggerClass);
 
     @Override
     @SuppressWarnings({ "unchecked", "rawtypes" })

--- a/jdbc/src/main/java/io/kestra/jdbc/repository/AbstractJdbcFlowRepository.java
+++ b/jdbc/src/main/java/io/kestra/jdbc/repository/AbstractJdbcFlowRepository.java
@@ -667,8 +667,8 @@ public abstract class AbstractJdbcFlowRepository extends AbstractJdbcRepository 
                 return (ArrayListTotal) this.jdbcRepository.fetchPage(
                     context,
                     getFindFlowSelect(tenantId, null, context, null)
-                        .and(findTriggerClassCondition(triggerClass)
-                        .and(NAMESPACE_FIELD.eq(namespace))),
+                        .and(findTriggerClassCondition(triggerClass))
+                        .and(NAMESPACE_FIELD.eq(namespace)),
                     pageable
                 );
             });

--- a/jdbc/src/main/java/io/kestra/jdbc/repository/AbstractJdbcFlowRepository.java
+++ b/jdbc/src/main/java/io/kestra/jdbc/repository/AbstractJdbcFlowRepository.java
@@ -656,7 +656,7 @@ public abstract class AbstractJdbcFlowRepository extends AbstractJdbcRepository 
     public ArrayListTotal<Flow> find(
             Pageable pageable,
             @Nullable String tenantId,
-            @Nullable String namespace,
+            String namespace,
             @Nullable Class<? extends io.kestra.core.models.triggers.AbstractTrigger> triggerClass
         ) {
         return this.jdbcRepository

--- a/jdbc/src/main/java/io/kestra/jdbc/repository/AbstractJdbcFlowRepository.java
+++ b/jdbc/src/main/java/io/kestra/jdbc/repository/AbstractJdbcFlowRepository.java
@@ -6,7 +6,6 @@ import java.time.ZonedDateTime;
 import java.util.*;
 import java.util.stream.Collectors;
 
-import jakarta.validation.constraints.NotNull;
 import org.jooq.*;
 import org.jooq.Record;
 import org.jooq.impl.DSL;


### PR DESCRIPTION
✨ Description                                                                                                                                                                                                                                                                                                     
                  
  Adds the ability to query flows by trigger type across all repository implementations (H2, MySQL, PostgreSQL, and Elasticsearch).                                                                                                                                                                       
                                                                                                                                                                                                                                                            
  🔗 Related Issue                                                                                                                                                                                                                                                                                                   
                                                                                                                                                                                                                                                                                                                     
This is a prerequisite for MCP server support, which requires resolving all flows within a namespace that expose a specific trigger type in order to determine which flows are callable. 
Relates to https://github.com/kestra-io/kestra/issues/15040.                                                                                                                      
   
  🛠️  Backend Checklist                                                                                                                                                                                                                                                                                               
                  
  - Code compiles successfully and passes all checks                                                                                                                                                                                                                                                                 
  - All unit and integration tests pass
  
  📝 Additional Notes
                                                                                                                                                                                                                                                                                                                     
  The new find(Pageable, tenantId, namespace, triggerClass) method requires both tenantId and namespace to be provided alongside the trigger class. This is intentional — it ensures queries align with the existing indexes on tenant_id and namespace in the JDBC implementations, avoiding full-table scans when
  filtering by trigger type in the serialised JSON value column.