### PR TITLE
fix(core): use Provider for lazy PluginRegistry resolution in reportable

### DIFF
--- a/core/src/main/java/io/kestra/core/reporter/reports/PluginUsageReport.java
+++ b/core/src/main/java/io/kestra/core/reporter/reports/PluginUsageReport.java
@@ -12,17 +12,19 @@ import io.kestra.core.reporter.Schedules;
 import io.kestra.core.reporter.Types;
 
 import jakarta.inject.Inject;
+import jakarta.inject.Provider;
 import jakarta.inject.Singleton;
 import lombok.Builder;
 
 @Singleton
 public class PluginUsageReport extends AbstractReportable<PluginUsageReport.PluginUsageEvent> {
 
-    private final PluginRegistry pluginRegistry;
+    // Lazy: PluginRegistry may not be fully accessible when this class is instantiated
+    private final Provider<PluginRegistry> pluginRegistry;
     private final boolean enabled;
 
     @Inject
-    public PluginUsageReport(PluginRegistry pluginRegistry) {
+    public PluginUsageReport(Provider<PluginRegistry> pluginRegistry) {
         super(Types.PLUGIN_USAGE, Schedules.daily(), false);
         this.pluginRegistry = pluginRegistry;
 
@@ -34,7 +36,7 @@ public class PluginUsageReport extends AbstractReportable<PluginUsageReport.Plug
     public PluginUsageEvent report(final Instant now, final TimeInterval period) {
         return PluginUsageEvent
             .builder()
-            .plugins(PluginUsage.of(pluginRegistry))
+            .plugins(PluginUsage.of(pluginRegistry.get()))
             .build();
     }
 


### PR DESCRIPTION
PluginRegistry may not be fully accessible when reportable classes are instantiated, preventing Kestra from starting. Wrap PluginRegistry in Provider<> for lazy resolution at report generation time.

Related-to: https://github.com/kestra-io/kestra-ee/pull/7277