### PR TITLE
chore(executions): improve replay and restart dialogs

### DIFF
--- a/ui/src/components/executions/overview/components/actions/Restart.vue
+++ b/ui/src/components/executions/overview/components/actions/Restart.vue
@@ -37,7 +37,37 @@
     </el-tooltip>
 
     <el-dialog
-        v-if="enabled && isOpen"
+        v-if="enabled && isOpen && !isReplay"
+        v-model="isOpen"
+        destroyOnClose
+        :appendToBody="true"
+        width="500px"
+    >
+        <template #header>
+            <div class="modal-header m-0">
+                <h3 class="modal-title">
+                    {{ t("restart execution title") }}
+                </h3>
+                <el-divider />
+            </div>
+        </template>
+
+        <div class="p-3 pt-0">
+            <p class="mb-0" v-html="t('restart confirm', {id: execution.id})" />
+        </div>
+
+        <template #footer>
+            <el-button @click="isOpen = false">
+                {{ t("cancel") }}
+            </el-button>
+            <el-button type="primary" @click="handleRestartExecute">
+                {{ t("restart") }}
+            </el-button>
+        </template>
+    </el-dialog>
+
+    <el-dialog
+        v-if="enabled && isOpen && isReplay"
         v-model="isOpen"
         destroyOnClose
         :appendToBody="true"
@@ -46,7 +76,7 @@
         <template #header>
             <div class="modal-header m-0">
                 <h3 class="modal-title">
-                    {{ t(isReplay ? "replay execution title" : "restart execution title") }}
+                    {{ t("replay execution title") }}
                 </h3>
                 <el-divider />
             </div>
@@ -296,6 +326,11 @@
         restart()
     }
 
+    const handleRestartExecute = () => {
+        isOpen.value = false
+        restart()
+    }
+
     const handleReplayExecute = () => {
         isOpen.value = false
 
@@ -349,7 +384,7 @@
         toast.success(t("replayed"))
     }
 
-    watch(isOpen, (newValue) => newValue && loadRevision())
+    watch(isOpen, (newValue) => newValue && props.isReplay && loadRevision())
 
     watch(effectiveRevision, async (newRevision, oldRevision) => {
         if (!isOpen.value || newRevision === undefined || newRevision === oldRevision) return


### PR DESCRIPTION
Closes https://github.com/kestra-io/kestra-ee/issues/7130.

## Summary

- Split the shared Restart/Replay dialog into two separate dialogs
- **Restart dialog** is now a simple confirmation: "Are you sure you want to restart execution `{id}`?" with Cancel / Restart buttons — no misleading "this will create a new execution" text, no revision/inputs options
- **Replay dialog** is unchanged

## Changes

- `Restart.vue`: separate `v-if="!isReplay"` and `v-if="isReplay"` dialogs instead of one shared dialog
- Added `handleRestartExecute` — closes dialog and calls `restart()` directly
- `loadRevision()` watch now only triggers when opening in replay mode (no unnecessary API calls on restart)

<img width="646" height="278" alt="image" src="https://github.com/user-attachments/assets/ac0a75d9-c4fc-4e1a-bdbc-fd2e36b50e7a" />
<img width="679" height="440" alt="image" src="https://github.com/user-attachments/assets/591f644c-3970-4c5b-bf4a-96e3f359d5bb" />
