### PR TITLE
feat(worker): add gRPC server events reporting relay and worker configs propagation

### DIFF
--- a/core/src/main/java/io/kestra/core/reporter/Reportable.java
+++ b/core/src/main/java/io/kestra/core/reporter/Reportable.java
@@ -39,7 +39,9 @@ public interface Reportable<T extends Reportable.Event> {
     /**
      * Checks whether this reportable is enabled for scheduled reporting.
      */
-    boolean isEnabled();
+    default boolean isEnabled() {
+        return true;
+    }
 
     /**
      * Generates a report for the given timestamp and tenant.

--- a/core/src/main/java/io/kestra/core/reporter/ReportableScheduler.java
+++ b/core/src/main/java/io/kestra/core/reporter/ReportableScheduler.java
@@ -10,7 +10,7 @@ import jakarta.inject.Singleton;
 import lombok.extern.slf4j.Slf4j;
 
 @Singleton
-@Requires(property = "kestra.anonymous-usage-report.enabled", value = "true")
+@Requires(property = "kestra." + UsageReportConfig.ANONYMOUS_USAGE_REPORT + ".enabled", value = "true")
 @Requires(property = "kestra.server-type")
 @Slf4j
 public class ReportableScheduler {

--- a/core/src/main/java/io/kestra/core/reporter/ServerEventSender.java
+++ b/core/src/main/java/io/kestra/core/reporter/ServerEventSender.java
@@ -15,9 +15,9 @@ import io.kestra.core.services.InstanceService;
 import io.kestra.core.utils.IdUtils;
 import io.kestra.core.utils.VersionProvider;
 
-import io.micronaut.context.annotation.Value;
 import io.micronaut.core.type.Argument;
 import io.micronaut.http.HttpRequest;
+import io.micronaut.http.MediaType;
 import io.micronaut.http.MutableHttpRequest;
 import io.micronaut.http.client.annotation.Client;
 import io.micronaut.http.client.exceptions.HttpClientResponseException;
@@ -45,18 +45,42 @@ public class ServerEventSender {
     @Inject
     private InstanceService instanceService;
 
-    private final ServerType serverType;
-
+    @Inject
     @Setter
-    @Value("${kestra.anonymous-usage-report.uri:'https://api.kestra.io/v1/reports/server-events'}")
-    protected URI url;
+    private UsageReportConfig usageReportConfig;
+
+    private final ServerType serverType;
 
     public ServerEventSender() {
         this.serverType = KestraContext.getContext().getServerType();
     }
 
     public void send(final Instant now, final Type type, Object event) {
-        ServerEvent serverEvent = ServerEvent
+        ServerEvent serverEvent = buildServerEvent(now, event);
+        try {
+            MutableHttpRequest<ServerEvent> request = this.request(serverEvent, type);
+
+            if (log.isTraceEnabled()) {
+                log.trace("Report anonymous usage: '{}'", OBJECT_MAPPER.writeValueAsString(serverEvent));
+            }
+
+            client.toBlocking().retrieve(request, Argument.of(Result.class), Argument.of(JsonError.class));
+        } catch (HttpClientResponseException t) {
+            log.trace("Unable to report anonymous usage with body '{}'", t.getResponse().getBody(String.class), t);
+        } catch (Exception t) {
+            log.trace("Unable to handle anonymous usage", t);
+        }
+    }
+
+    /**
+     * Builds a {@link ServerEvent} wrapping the given payload.
+     *
+     * @param now the current time
+     * @param event the event payload
+     * @return the built server event
+     */
+    protected ServerEvent buildServerEvent(final Instant now, Object event) {
+        return ServerEvent
             .builder()
             .uuid(UUID.randomUUID().toString())
             .sessionUuid(SESSION_UUID)
@@ -67,29 +91,50 @@ public class ServerEventSender {
             .payload(event)
             .zoneId(ZoneId.systemDefault())
             .build();
-        try {
-            MutableHttpRequest<ServerEvent> request = this.request(serverEvent, type);
-
-            if (log.isTraceEnabled()) {
-                log.trace("Report anonymous usage: '{}'", OBJECT_MAPPER.writeValueAsString(serverEvent));
-            }
-
-            this.handleResponse(client.toBlocking().retrieve(request, Argument.of(Result.class), Argument.of(JsonError.class)));
-        } catch (HttpClientResponseException t) {
-            log.trace("Unable to report anonymous usage with body '{}'", t.getResponse().getBody(String.class), t);
-        } catch (Exception t) {
-            log.trace("Unable to handle anonymous usage", t);
-        }
-    }
-
-    private void handleResponse(Result result) {
-
     }
 
     protected MutableHttpRequest<ServerEvent> request(ServerEvent event, Type type) throws Exception {
-        URI baseUri = URI.create(this.url.toString().endsWith("/") ? this.url.toString() : this.url + "/");
+        String uri = this.usageReportConfig.uri().toString();
+        URI baseUri = URI.create(uri.endsWith("/") ? uri : uri + "/");
         URI resolvedUri = baseUri.resolve(type.name().toLowerCase());
         return HttpRequest.POST(resolvedUri, event)
+            .header("User-Agent", "Kestra/" + versionProvider.getVersion());
+    }
+
+    /**
+     * Sends a pre-serialized event payload (raw JSON bytes) to the reporting endpoint.
+     * <p>
+     * This is used by the controller to relay telemetry reports received from workers
+     * without deserializing and re-serializing the event.
+     *
+     * @param payload the raw JSON bytes of the serialized {@link ServerEvent}
+     * @param eventType the event type name
+     */
+    public void sendRaw(final byte[] payload, final String eventType) {
+        try {
+            MutableHttpRequest<byte[]> request = this.requestRaw(payload, eventType);
+            client.toBlocking().exchange(request);
+        } catch (HttpClientResponseException t) {
+            log.trace("Unable to relay telemetry report with body '{}'", t.getResponse().getBody(String.class), t);
+        } catch (Exception t) {
+            log.trace("Unable to relay telemetry report", t);
+        }
+    }
+
+    /**
+     * Builds an HTTP request for raw pre-serialized bytes.
+     * <p>
+     * Subclasses can override this to add custom headers (e.g., license headers).
+     *
+     * @param payload the raw JSON bytes
+     * @param eventType the event type name
+     * @return the mutable HTTP request
+     */
+    protected MutableHttpRequest<byte[]> requestRaw(byte[] payload, String eventType) throws Exception {
+        URI baseUri = URI.create(this.usageReportConfig.uri().toString().endsWith("/") ? this.usageReportConfig.uri().toString() : this.usageReportConfig.uri() + "/");
+        URI resolvedUri = baseUri.resolve(eventType.toLowerCase());
+        return HttpRequest.POST(resolvedUri, payload)
+            .contentType(MediaType.APPLICATION_JSON_TYPE)
             .header("User-Agent", "Kestra/" + versionProvider.getVersion());
     }
 }

--- a/core/src/main/java/io/kestra/core/reporter/UsageReportConfig.java
+++ b/core/src/main/java/io/kestra/core/reporter/UsageReportConfig.java
@@ -1,0 +1,35 @@
+package io.kestra.core.reporter;
+
+import java.net.URI;
+import java.time.Duration;
+
+import io.micronaut.context.annotation.ConfigurationProperties;
+import io.micronaut.core.bind.annotation.Bindable;
+
+/**
+ * Configuration for anonymous usage reporting.
+ * <p>
+ * Bound from {@code kestra.anonymous-usage-report.*} properties.
+ * Also used for gRPC propagation between controller and worker.
+ */
+@ConfigurationProperties("kestra." + UsageReportConfig.ANONYMOUS_USAGE_REPORT)
+public record UsageReportConfig(
+    @Bindable(defaultValue = "true") boolean enabled,
+    @Bindable(defaultValue = DEFAULT_URI) URI uri,
+    @Bindable(defaultValue = "5m") Duration initialDelay,
+    @Bindable(defaultValue = "5m") Duration fixedDelay
+) {
+
+    public static final String ANONYMOUS_USAGE_REPORT = "anonymous-usage-report";
+    
+    public static final String DEFAULT_URI = "https://api.kestra.io/v1/reports/server-events";
+    
+    public static UsageReportConfig getDefault() {
+        return new UsageReportConfig(
+            true,
+            URI.create(DEFAULT_URI),
+            Duration.ofMinutes(5),
+            Duration.ofMinutes(5)
+        );
+    }
+}

--- a/core/src/main/java/io/kestra/core/reporter/reports/FeatureUsageReport.java
+++ b/core/src/main/java/io/kestra/core/reporter/reports/FeatureUsageReport.java
@@ -3,8 +3,6 @@ package io.kestra.core.reporter.reports;
 import java.time.Instant;
 import java.util.Objects;
 
-import io.kestra.core.contexts.KestraContext;
-import io.kestra.core.models.ServerType;
 import io.kestra.core.models.collectors.ExecutionUsage;
 import io.kestra.core.models.collectors.FlowUsage;
 import io.kestra.core.reporter.AbstractReportable;
@@ -15,6 +13,7 @@ import io.kestra.core.repositories.DashboardRepositoryInterface;
 import io.kestra.core.repositories.ExecutionRepositoryInterface;
 import io.kestra.core.repositories.FlowRepositoryInterface;
 
+import io.micronaut.context.annotation.Requires;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 import lombok.Getter;
@@ -22,12 +21,12 @@ import lombok.experimental.SuperBuilder;
 import lombok.extern.jackson.Jacksonized;
 
 @Singleton
+@Requires(property = "kestra.server-type", pattern = "STANDALONE|EXECUTOR")
 public class FeatureUsageReport extends AbstractReportable<FeatureUsageReport.UsageEvent> {
 
     private final FlowRepositoryInterface flowRepository;
     private final ExecutionRepositoryInterface executionRepository;
     private final DashboardRepositoryInterface dashboardRepository;
-    private final boolean enabled;
 
     @Inject
     public FeatureUsageReport(FlowRepositoryInterface flowRepository,
@@ -37,9 +36,6 @@ public class FeatureUsageReport extends AbstractReportable<FeatureUsageReport.Us
         this.flowRepository = flowRepository;
         this.executionRepository = executionRepository;
         this.dashboardRepository = dashboardRepository;
-
-        ServerType serverType = KestraContext.getContext().getServerType();
-        this.enabled = ServerType.EXECUTOR.equals(serverType) || ServerType.STANDALONE.equals(serverType);
     }
 
     @Override
@@ -50,11 +46,6 @@ public class FeatureUsageReport extends AbstractReportable<FeatureUsageReport.Us
             .executions(ExecutionUsage.of(executionRepository, interval.from(), interval.to()))
             .dashboards(new Count(dashboardRepository.countAllForAllTenants()))
             .build();
-    }
-
-    @Override
-    public boolean isEnabled() {
-        return enabled;
     }
 
     @Override

--- a/core/src/main/java/io/kestra/core/reporter/reports/ServiceUsageReport.java
+++ b/core/src/main/java/io/kestra/core/reporter/reports/ServiceUsageReport.java
@@ -3,31 +3,27 @@ package io.kestra.core.reporter.reports;
 import java.time.Duration;
 import java.time.Instant;
 
-import io.kestra.core.contexts.KestraContext;
-import io.kestra.core.models.ServerType;
 import io.kestra.core.models.collectors.ServiceUsage;
 import io.kestra.core.reporter.AbstractReportable;
 import io.kestra.core.reporter.Schedules;
 import io.kestra.core.reporter.Types;
 import io.kestra.core.repositories.ServiceInstanceRepositoryInterface;
 
+import io.micronaut.context.annotation.Requires;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 import lombok.Builder;
 
 @Singleton
+@Requires(property = "kestra.server-type", pattern = "STANDALONE|EXECUTOR")
 public class ServiceUsageReport extends AbstractReportable<ServiceUsageReport.ServiceUsageEvent> {
 
     private final ServiceInstanceRepositoryInterface serviceInstanceRepository;
-    private final boolean isEnabled;
 
     @Inject
     public ServiceUsageReport(ServiceInstanceRepositoryInterface serviceInstanceRepository) {
         super(Types.SERVICE_USAGE, Schedules.daily(), false);
         this.serviceInstanceRepository = serviceInstanceRepository;
-
-        ServerType serverType = KestraContext.getContext().getServerType();
-        this.isEnabled = ServerType.STANDALONE.equals(serverType) || ServerType.EXECUTOR.equals(serverType);
     }
 
     @Override
@@ -37,11 +33,6 @@ public class ServiceUsageReport extends AbstractReportable<ServiceUsageReport.Se
             .builder()
             .services(ServiceUsage.of(period.from().toInstant(), period.to().toInstant(), serviceInstanceRepository, Duration.ofMinutes(5)))
             .build();
-    }
-
-    @Override
-    public boolean isEnabled() {
-        return isEnabled;
     }
 
     @Builder

--- a/worker-controller/src/main/java/io/kestra/controller/grpc/services/DefaultWorkerConfigsProvider.java
+++ b/worker-controller/src/main/java/io/kestra/controller/grpc/services/DefaultWorkerConfigsProvider.java
@@ -1,0 +1,29 @@
+package io.kestra.controller.grpc.services;
+
+import java.util.Map;
+
+import io.kestra.core.reporter.UsageReportConfig;
+
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+
+/**
+ * Default {@link WorkerConfigsProvider} that propagates the telemetry configuration.
+ */
+@Singleton
+public class DefaultWorkerConfigsProvider implements WorkerConfigsProvider {
+
+    protected final UsageReportConfig usageReportConfig;
+
+    @Inject
+    public DefaultWorkerConfigsProvider(UsageReportConfig usageReportConfig) {
+        this.usageReportConfig = usageReportConfig;
+    }
+
+    @Override
+    public Map<String, Object> get() {
+        return Map.of(
+            UsageReportConfig.ANONYMOUS_USAGE_REPORT, usageReportConfig
+        );
+    }
+}

--- a/worker-controller/src/main/java/io/kestra/controller/grpc/services/GrpcConnectControllerService.java
+++ b/worker-controller/src/main/java/io/kestra/controller/grpc/services/GrpcConnectControllerService.java
@@ -4,6 +4,7 @@ import io.kestra.controller.grpc.ConnectControllerServiceGrpc;
 import io.kestra.controller.grpc.ConnectRequest;
 import io.kestra.controller.grpc.ConnectResponse;
 import io.kestra.controller.grpc.WorkerControllerService;
+import io.kestra.controller.messages.MessageFormats;
 import io.kestra.core.services.WorkerGroupService;
 
 import io.grpc.stub.StreamObserver;
@@ -22,11 +23,15 @@ import lombok.extern.slf4j.Slf4j;
 public class GrpcConnectControllerService extends ConnectControllerServiceGrpc.ConnectControllerServiceImplBase implements WorkerControllerService {
 
     public static final String DEFAULT_WORKER_GROUP = "";
+
     private final WorkerGroupService workerGroupService;
+    private final WorkerConfigsProvider workerConfigsProvider;
 
     @Inject
-    public GrpcConnectControllerService(WorkerGroupService workerGroupService) {
+    public GrpcConnectControllerService(WorkerGroupService workerGroupService,
+        WorkerConfigsProvider workerConfigsProvider) {
         this.workerGroupService = workerGroupService;
+        this.workerConfigsProvider = workerConfigsProvider;
     }
 
     /**
@@ -54,6 +59,7 @@ public class GrpcConnectControllerService extends ConnectControllerServiceGrpc.C
         ConnectResponse response = ConnectResponse.newBuilder()
             .setHeader(request.getHeader())
             .setWorkerGroup(resolvedWorkerGroup != null ? resolvedWorkerGroup : DEFAULT_WORKER_GROUP)
+            .setWorkerConfigs(MessageFormats.JSON.toByteString(workerConfigsProvider.get()))
             .build();
 
         responseObserver.onNext(response);

--- a/worker-controller/src/main/java/io/kestra/controller/grpc/services/GrpcWorkerReportingService.java
+++ b/worker-controller/src/main/java/io/kestra/controller/grpc/services/GrpcWorkerReportingService.java
@@ -1,0 +1,62 @@
+package io.kestra.controller.grpc.services;
+
+import io.kestra.controller.grpc.WorkerControllerService;
+import io.kestra.core.reporter.ServerEventSender;
+import io.kestra.controller.grpc.WorkerReportRequest;
+import io.kestra.controller.grpc.WorkerReportResponse;
+import io.kestra.controller.grpc.WorkerReportingServiceGrpc;
+
+import io.grpc.stub.StreamObserver;
+import io.micronaut.context.annotation.Requires;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * gRPC service that receives server events reports from workers and relays them
+ * to the reporting endpoint via the {@link ServerEventSender}.
+ * <p>
+ * The worker sends a pre-built {@code ServerEvent} as JSON bytes. This service
+ * forwards those bytes using {@link ServerEventSender#sendRaw(byte[], String)},
+ * which adds the appropriate headers (including EE license headers when applicable).
+ */
+@Singleton
+@Slf4j
+public class GrpcWorkerReportingService
+    extends WorkerReportingServiceGrpc.WorkerReportingServiceImplBase
+    implements WorkerControllerService {
+
+    private final ServerEventSender serverEventSender;
+
+    @Inject
+    public GrpcWorkerReportingService(ServerEventSender serverEventSender) {
+        this.serverEventSender = serverEventSender;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void sendReport(WorkerReportRequest request, StreamObserver<WorkerReportResponse> responseObserver) {
+        try {
+            String eventType = request.getEventType();
+            byte[] payload = request.getPayload().toByteArray();
+
+            serverEventSender.sendRaw(payload, eventType);
+
+            responseObserver.onNext(
+                WorkerReportResponse.newBuilder()
+                    .setHeader(request.getHeader())
+                    .setSuccess(true)
+                    .build()
+            );
+            responseObserver.onCompleted();
+        } catch (Exception e) {
+            log.warn("Failed to relay worker server events report", e);
+            responseObserver.onNext(
+                WorkerReportResponse.newBuilder()
+                    .setSuccess(false)
+                    .build()
+            );
+            responseObserver.onCompleted();
+        }
+    }
+}

--- a/worker-controller/src/main/java/io/kestra/controller/grpc/services/WorkerConfigsProvider.java
+++ b/worker-controller/src/main/java/io/kestra/controller/grpc/services/WorkerConfigsProvider.java
@@ -1,0 +1,20 @@
+package io.kestra.controller.grpc.services;
+
+import java.util.Map;
+
+/**
+ * Provides configuration to be sent to workers during the connect handshake.
+ * <p>
+ * The returned map is serialized and included in the {@code worker_configs} field of the
+ * {@code ConnectResponse} proto message. EE modules can replace the default
+ * implementation to add license-dependent configuration.
+ */
+public interface WorkerConfigsProvider {
+
+    /**
+     * Returns the configuration map to propagate to the connecting worker.
+     *
+     * @return an unmodifiable map of configuration key-value pairs
+     */
+    Map<String, Object> get();
+}

--- a/worker-controller/src/main/proto/connect_controller.proto
+++ b/worker-controller/src/main/proto/connect_controller.proto
@@ -23,4 +23,6 @@ message ConnectResponse {
   RequestOrResponseHeader header = 1;
   // The resolved worker group name (may be empty if no group is resolved)
   string workerGroup = 2;
+  // Serialized JSON configuration propagated from the controller to the worker
+  bytes worker_configs = 3;
 }

--- a/worker-controller/src/main/proto/worker_reporting.proto
+++ b/worker-controller/src/main/proto/worker_reporting.proto
@@ -1,0 +1,26 @@
+syntax = "proto3";
+
+option java_package = "io.kestra.controller.grpc";
+option java_multiple_files = true;
+
+import "request.proto";
+
+// Service for workers to forward server events reports to the controller.
+// The controller then relays them to api.kestra.io.
+service WorkerReportingService {
+  // [Unary] Forward a server events report from a worker to the controller.
+  rpc sendReport(WorkerReportRequest) returns (WorkerReportResponse);
+}
+
+message WorkerReportRequest {
+  RequestOrResponseHeader header = 1;
+  // The event type name (matches io.kestra.core.reporter.Type.name())
+  string event_type = 2;
+  // JSON-serialized ServerEvent payload
+  bytes payload = 3;
+}
+
+message WorkerReportResponse {
+  RequestOrResponseHeader header = 1;
+  bool success = 2;
+}

--- a/worker/src/main/java/io/kestra/worker/GrpcStubFactory.java
+++ b/worker/src/main/java/io/kestra/worker/GrpcStubFactory.java
@@ -12,6 +12,7 @@ import io.kestra.controller.grpc.NamespaceFileMetadataServiceGrpc.NamespaceFileM
 import io.kestra.controller.grpc.WorkerControllerServiceGrpc.WorkerControllerServiceBlockingStub;
 import io.kestra.controller.grpc.WorkerControllerServiceGrpc.WorkerControllerServiceStub;
 import io.kestra.controller.grpc.WorkerFlowMetaStoreServiceGrpc.WorkerFlowMetaStoreServiceBlockingStub;
+import io.kestra.controller.grpc.WorkerReportingServiceGrpc;
 
 import io.grpc.Deadline;
 import io.grpc.stub.AbstractStub;
@@ -81,7 +82,12 @@ public class GrpcStubFactory {
 
     @Bean
     @Singleton
+    public WorkerReportingServiceGrpc.WorkerReportingServiceBlockingStub workerReportingServiceBlockingStub(GrpcChannelManager manager) {
+        return WorkerReportingServiceGrpc.newBlockingStub(manager.getDefaultChannel());
+    }
 
+    @Bean
+    @Singleton
     public <S extends AbstractStub<S>> S withWaitForReady(S stub, boolean deadline) {
         if (workerControllersConfiguration.waitForReady().enabled()) {
             stub = stub.withWaitForReady();

--- a/worker/src/main/java/io/kestra/worker/reporter/GrpcServerEventSender.java
+++ b/worker/src/main/java/io/kestra/worker/reporter/GrpcServerEventSender.java
@@ -1,0 +1,72 @@
+package io.kestra.worker.reporter;
+
+import java.time.Instant;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.protobuf.ByteString;
+
+import io.kestra.controller.messages.RequestOrResponseHeaderFactory;
+import io.kestra.core.reporter.ServerEvent;
+import io.kestra.core.reporter.ServerEventSender;
+import io.kestra.core.reporter.Type;
+import io.kestra.core.serializers.JacksonMapper;
+import io.kestra.core.worker.models.WorkerInfo;
+import io.kestra.controller.grpc.WorkerReportRequest;
+import io.kestra.controller.grpc.WorkerReportResponse;
+import io.kestra.controller.grpc.WorkerReportingServiceGrpc;
+
+import io.micronaut.context.annotation.Replaces;
+import io.micronaut.context.annotation.Requires;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * gRPC-based {@link ServerEventSender} for workers.
+ * <p>
+ * Instead of sending HTTP requests directly to the reporting endpoint, this sender
+ * forwards events via gRPC to the controller, which then relays them.
+ */
+@Singleton
+@Replaces(ServerEventSender.class)
+@Requires(property = "kestra.server-type", value = "WORKER")
+@Slf4j
+public class GrpcServerEventSender extends ServerEventSender {
+
+    private static final ObjectMapper OBJECT_MAPPER = JacksonMapper.ofJson();
+
+    private final WorkerReportingServiceGrpc.WorkerReportingServiceBlockingStub reportingStub;
+    private final WorkerInfo workerInfo;
+
+    @Inject
+    public GrpcServerEventSender(WorkerReportingServiceGrpc.WorkerReportingServiceBlockingStub reportingStub, WorkerInfo workerInfo) {
+        this.reportingStub = reportingStub;
+        this.workerInfo = workerInfo;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void send(final Instant now, final Type type, Object event) {
+        try {
+            ServerEvent serverEvent = buildServerEvent(now, event);
+            byte[] payload = OBJECT_MAPPER.writeValueAsBytes(serverEvent);
+
+            WorkerReportRequest request = WorkerReportRequest.newBuilder()
+                .setHeader(RequestOrResponseHeaderFactory.create(workerInfo.getWorkerId()))
+                .setEventType(type.name())
+                .setPayload(ByteString.copyFrom(payload))
+                .build();
+
+            if (log.isTraceEnabled()) {
+                log.trace("Sending server events report via gRPC for event-type '{}'", type.name());
+            }
+
+            WorkerReportResponse response = reportingStub.sendReport(request);
+            if (!response.getSuccess()) {
+                log.debug("Controller rejected server events report for event-type '{}'", type.name());
+            }
+        } catch (Exception e) {
+            log.debug("Failed to send worker server events report via gRPC for event-type '{}'", type.name(), e);
+        }
+    }
+}

--- a/worker/src/main/java/io/kestra/worker/services/GrpcWorkerConnectionService.java
+++ b/worker/src/main/java/io/kestra/worker/services/GrpcWorkerConnectionService.java
@@ -1,14 +1,22 @@
 package io.kestra.worker.services;
 
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 import io.kestra.controller.config.WorkerControllersConfiguration;
 import io.kestra.controller.grpc.ConnectControllerServiceGrpc.ConnectControllerServiceBlockingStub;
 import io.kestra.controller.grpc.ConnectRequest;
 import io.kestra.controller.grpc.ConnectResponse;
+import io.kestra.controller.messages.MessageFormats;
 import io.kestra.controller.messages.RequestOrResponseHeaderFactory;
+import io.kestra.core.reporter.UsageReportConfig;
+import io.kestra.core.serializers.JacksonMapper;
 
 import io.grpc.Deadline;
+import io.micronaut.core.annotation.Nullable;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 import lombok.extern.slf4j.Slf4j;
@@ -23,14 +31,21 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class GrpcWorkerConnectionService implements WorkerConnectionService {
 
+    private static final ObjectMapper OBJECT_MAPPER = JacksonMapper.ofJson(false);
+    private static final TypeReference<Map<String, Object>> MAP_TYPE = new TypeReference<>() {};
+
     private final ConnectControllerServiceBlockingStub connectControllerService;
     private final WorkerControllersConfiguration workerControllersConfiguration;
+    @Nullable
+    private final WorkerReportableScheduler workerReportableScheduler;
 
     @Inject
     public GrpcWorkerConnectionService(ConnectControllerServiceBlockingStub connectControllerService,
-        WorkerControllersConfiguration workerControllersConfiguration) {
+        WorkerControllersConfiguration workerControllersConfiguration,
+        @Nullable WorkerReportableScheduler workerReportableScheduler) {
         this.connectControllerService = connectControllerService;
         this.workerControllersConfiguration = workerControllersConfiguration;
+        this.workerReportableScheduler = workerReportableScheduler;
     }
 
     /**
@@ -54,17 +69,42 @@ public class GrpcWorkerConnectionService implements WorkerConnectionService {
                 stub = stub.withDeadline(Deadline.after(deadlineMs, TimeUnit.MILLISECONDS));
             }
             ConnectResponse response = stub.connect(request);
-            String resolvedGroup = response.getWorkerGroup();
-            if (resolvedGroup == null || resolvedGroup.isEmpty()) {
-                log.debug("No worker group resolved for key: {}", workerGroupKey);
-                return new ConnectionResult(null);
-            }
-
-            log.info("Worker group resolved via connect service: '{}' for key '{}'", resolvedGroup, workerGroupKey);
-            return new ConnectionResult(resolvedGroup);
+            return toConnectionResult(response, workerGroupKey);
         } catch (Exception e) {
             log.error("Failed to send connect request to controller", e);
             throw new WorkerConnectionFailedException("Failed connecting to Kestra controller. Cause: " + e.getMessage());
         }
+    }
+
+    /**
+     * Converts a {@link ConnectResponse} into a {@link ConnectionResult}.
+     * <p>
+     * Subclasses can override this to extract additional fields from the response.
+     *
+     * @param response the gRPC connect response
+     * @param workerGroupKey the original worker group key from configuration
+     * @return the connection result
+     */
+    protected ConnectionResult toConnectionResult(ConnectResponse response, String workerGroupKey) {
+        // Extract telemetry configuration from serialized worker configs
+        if (workerReportableScheduler != null && !response.getWorkerConfigs().isEmpty()) {
+            Map<String, Object> configs = MessageFormats.JSON.fromByteString(response.getWorkerConfigs(), MAP_TYPE);
+            if (configs != null && configs.containsKey(UsageReportConfig.ANONYMOUS_USAGE_REPORT)) {
+                UsageReportConfig config = OBJECT_MAPPER.convertValue(
+                    configs.get(UsageReportConfig.ANONYMOUS_USAGE_REPORT), UsageReportConfig.class
+                );
+                workerReportableScheduler.init(config);
+                log.debug("Worker usage reporting is {}", config.enabled() ? "enabled" : "disabled");
+            }
+        }
+
+        String resolvedGroup = response.getWorkerGroup();
+        if (resolvedGroup == null || resolvedGroup.isEmpty()) {
+            log.debug("No worker group resolved for key: {}", workerGroupKey);
+            return new ConnectionResult(null);
+        }
+
+        log.info("Worker group resolved via connect service: '{}' for key '{}'", resolvedGroup, workerGroupKey);
+        return new ConnectionResult(resolvedGroup);
     }
 }

--- a/worker/src/main/java/io/kestra/worker/services/WorkerReportableScheduler.java
+++ b/worker/src/main/java/io/kestra/worker/services/WorkerReportableScheduler.java
@@ -1,0 +1,105 @@
+package io.kestra.worker.services;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+
+import io.kestra.core.reporter.ReportableRegistry;
+import io.kestra.core.reporter.ReportableScheduler;
+import io.kestra.core.reporter.ServerEventSender;
+import io.kestra.core.reporter.UsageReportConfig;
+import io.kestra.core.utils.ExecutorsUtils;
+
+import io.micronaut.context.annotation.Replaces;
+import io.micronaut.context.annotation.Requires;
+import jakarta.annotation.PreDestroy;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * {@link ReportableScheduler} for workers.
+ * <p>
+ * Unlike the standard {@link ReportableScheduler} which requires
+ * {@code kestra.anonymous-usage-report.enabled=true}, this scheduler is always instantiated
+ * on workers. Reporting is gated by {@link #init(UsageReportConfig)}, which is
+ * called during the initial worker-to-controller connection based on the controller's configuration.
+ * <p>
+ * Scheduling is programmatic: no work is scheduled until the controller enables reporting.
+ */
+@Singleton
+@Replaces(ReportableScheduler.class)
+@Requires(property = "kestra.server-type", value = "WORKER")
+@Slf4j
+public class WorkerReportableScheduler extends ReportableScheduler {
+
+    private final Object lock = new Object();
+    private boolean enabled = false;
+    private ScheduledExecutorService scheduledExecutorService;
+    private ScheduledFuture<?> scheduledFuture;
+
+    @Inject
+    public WorkerReportableScheduler(ReportableRegistry registry, ServerEventSender sender) {
+        super(registry, sender);
+    }
+
+    /**
+     * Initializes reporting based on the given configuration.
+     *
+     * @param config the usage report configuration received from the controller.
+     */
+    public void init(UsageReportConfig config) {
+        synchronized (lock) {
+            if (this.enabled == config.enabled()) {
+                return;
+            }
+            this.enabled = config.enabled();
+            if (config.enabled()) {
+                startScheduling(config.initialDelay(), config.fixedDelay());
+            } else {
+                stopScheduling();
+            }
+        }
+    }
+
+    private void startScheduling(Duration initialDelay, Duration fixedDelay) {
+        if (scheduledExecutorService == null) {
+            scheduledExecutorService = Executors.newSingleThreadScheduledExecutor(
+                r -> new Thread(r, "worker-reportable-scheduler")
+            );
+        }
+        scheduledFuture = scheduledExecutorService.scheduleAtFixedRate(
+            this::tick,
+            initialDelay.toMillis(),
+            fixedDelay.toMillis(),
+            TimeUnit.MILLISECONDS
+        );
+        log.debug("Worker reportable scheduler started (initialDelay={}, fixedDelay={})", initialDelay, fixedDelay);
+    }
+
+    private void stopScheduling() {
+        if (scheduledFuture != null) {
+            scheduledFuture.cancel(false);
+            scheduledFuture = null;
+        }
+        log.debug("Worker reportable scheduler stopped");
+    }
+
+    @PreDestroy
+    public void close() {
+        synchronized (lock) {
+            if (scheduledExecutorService != null) {
+                ExecutorsUtils.closeScheduledThreadPool(
+                    scheduledExecutorService,
+                    Duration.ofSeconds(5),
+                    scheduledFuture != null ? List.of(scheduledFuture) : List.of()
+                );
+                scheduledFuture = null;
+                scheduledExecutorService = null;
+            }
+        }
+    }
+}


### PR DESCRIPTION
Workers now receive configuration from the controller during the connect handshake via a generic worker_configs map in the proto. This includes server events reporting enablement, gated by WorkerReportableScheduler.

- Add WorkerConfigsProvider interface and DefaultWorkerConfigsProvider
- Add worker_configs map to ConnectResponse proto
- Add WorkerReportableScheduler for controller-gated reporting on workers
- Add sendRaw/requestRaw to ServerEventSender for pre-serialized relay
- Exclude repository-dependent Reportables from WORKER server type