### PR TITLE
feat(system): expose the trace context in the run variables

### DIFF
--- a/core/src/main/java/io/kestra/core/runners/DefaultRunContext.java
+++ b/core/src/main/java/io/kestra/core/runners/DefaultRunContext.java
@@ -130,6 +130,14 @@ public class DefaultRunContext extends RunContext {
     @Override
     public void setTraceParent(String traceParent) {
         this.traceParent = traceParent;
+
+        // add it inside variables if not already present to be available in expressions
+        if (traceParent != null && !this.variables.containsKey("trace")) {
+            this.variables = ImmutableMap.<String, Object>builder()
+                .putAll(this.variables)
+                .put("trace", Map.of("parent", traceParent))
+                .build();
+        }
     }
 
     @JsonIgnore
@@ -685,7 +693,7 @@ public class DefaultRunContext extends RunContext {
             context.applicationContext = applicationContext;
             context.variableRenderer = variableRenderer;
             context.meterRegistry = meterRegistry;
-            context.variables = Optional.ofNullable(variables).map(ImmutableMap::copyOf).orElse(ImmutableMap.of());
+            context.variables = variables;
             context.pluginConfiguration = Optional.ofNullable(pluginConfiguration).map(ImmutableMap::copyOf).orElse(ImmutableMap.of());
             context.logger = logger;
             context.secretKey = secretKey;

--- a/webserver/src/test/java/io/kestra/webserver/otel/TracesTest.java
+++ b/webserver/src/test/java/io/kestra/webserver/otel/TracesTest.java
@@ -52,14 +52,14 @@ public class TracesTest {
     }
 
     @Test
-    @LoadFlowsWithTenant({ "flows/valids/minimal.yaml" })
+    @LoadFlowsWithTenant({ "flows/traces.yaml" })
     void runningAFlowShouldGenerateTraces(String tenantId) {
         when(tenantService.resolveTenant()).thenReturn(tenantId);
 
         // running a flow until completion
         Execution result = client.toBlocking().retrieve(
             HttpRequest
-                .POST("/api/v1/%s/executions/io.kestra.tests/minimal?wait=true".formatted(tenantId), null)
+                .POST("/api/v1/%s/executions/io.kestra.tests/trace-parent?wait=true".formatted(tenantId), null)
                 .contentType(MediaType.MULTIPART_FORM_DATA_TYPE),
             Execution.class
         );
@@ -67,12 +67,12 @@ public class TracesTest {
 
         List<SpanData> spans = otelTesting.getSpans().stream().filter(span -> tenantId.equals(span.getAttributes().get(TraceUtils.ATTR_TENANT_ID))).toList();
         assertThat(spans).hasSizeGreaterThanOrEqualTo(6); // rarely, CI shows 6 traces and not 7 and even sometimes 14, probably due to asynchronicity
-        assertThat(spans).extracting(SpanData::getName).contains("EXECUTOR - %s_io.kestra.tests_minimal".formatted(tenantId), "WORKER - io.kestra.plugin.core.debug.Return");
+        assertThat(spans).extracting(SpanData::getName).contains("EXECUTOR - %s_io.kestra.tests_trace-parent".formatted(tenantId), "WORKER - io.kestra.plugin.core.output.OutputValues");
         Attributes attributes = spans.getFirst().getAttributes();
         assertThat(attributes.size()).isEqualTo(5);
         assertThat(attributes.get(TraceUtils.ATTR_TENANT_ID)).isEqualTo(tenantId);
         assertThat(attributes.get(TraceUtils.ATTR_NAMESPACE)).isEqualTo("io.kestra.tests");
-        assertThat(attributes.get(TraceUtils.ATTR_FLOW_ID)).isEqualTo("minimal");
+        assertThat(attributes.get(TraceUtils.ATTR_FLOW_ID)).isEqualTo("trace-parent");
         assertThat(attributes.get(TraceUtils.ATTR_EXECUTION_ID)).isEqualTo(result.getId());
         assertThat(attributes.get(TraceUtils.ATTR_SOURCE)).isEqualTo("io.kestra.executor.DefaultExecutor");
     }

--- a/webserver/src/test/resources/flows/traces.yaml
+++ b/webserver/src/test/resources/flows/traces.yaml
@@ -1,0 +1,8 @@
+id: trace-parent
+namespace: io.kestra.tests
+
+tasks:
+  - id: hello
+    type: io.kestra.plugin.core.output.OutputValues
+    values:
+      traceparent: "{{trace.parent}}"


### PR DESCRIPTION
Closes https://github.com/kestra-io/kestra-ee/issues/6826

I also take the opportunity to remove an unnecessary clone of the variable map inside the `DefaultRunContext` as the `RunVariable` already return an unmodifiable map.
