### PR TITLE
build(ui): upgrade Vite from rolldown-vite 7 to Vite 8

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -106,7 +106,6 @@
                 "playwright": "^1.55.0",
                 "prettier": "^3.8.1",
                 "rimraf": "^6.1.3",
-                "rolldown-vite": "^7.3.1",
                 "rollup-plugin-copy": "^3.5.0",
                 "sass": "^1.98.0",
                 "storybook": "^10.3.3",
@@ -115,7 +114,7 @@
                 "typescript": "^5.9.3",
                 "typescript-eslint": "^8.58.0",
                 "uuid": "^13.0.0",
-                "vite": "npm:rolldown-vite@latest",
+                "vite": "^8.0.0",
                 "vitest": "^4.1.2",
                 "vue-tsc": "^3.2.6"
             },
@@ -591,15 +590,6 @@
             },
             "peerDependencies": {
                 "@babel/core": "^7.0.0-0"
-            }
-        },
-        "node_modules/@babel/runtime": {
-            "version": "7.28.6",
-            "dev": true,
-            "license": "MIT",
-            "peer": true,
-            "engines": {
-                "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/runtime-corejs3": {
@@ -1963,6 +1953,7 @@
         },
         "node_modules/@jridgewell/gen-mapping": {
             "version": "0.3.13",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@jridgewell/sourcemap-codec": "^1.5.0",
@@ -1971,6 +1962,7 @@
         },
         "node_modules/@jridgewell/remapping": {
             "version": "2.3.5",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@jridgewell/gen-mapping": "^0.3.5",
@@ -1979,6 +1971,7 @@
         },
         "node_modules/@jridgewell/resolve-uri": {
             "version": "3.1.2",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=6.0.0"
@@ -1990,6 +1983,7 @@
         },
         "node_modules/@jridgewell/trace-mapping": {
             "version": "0.3.31",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@jridgewell/resolve-uri": "^3.1.0",
@@ -2372,130 +2366,6 @@
                 "node": ">= 8"
             }
         },
-        "node_modules/@nuxt/kit": {
-            "version": "4.3.1",
-            "resolved": "https://registry.npmjs.org/@nuxt/kit/-/kit-4.3.1.tgz",
-            "integrity": "sha512-UjBFt72dnpc+83BV3OIbCT0YHLevJtgJCHpxMX0YRKWLDhhbcDdUse87GtsQBrjvOzK7WUNUYLDS/hQLYev5rA==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "c12": "^3.3.3",
-                "consola": "^3.4.2",
-                "defu": "^6.1.4",
-                "destr": "^2.0.5",
-                "errx": "^0.1.0",
-                "exsolve": "^1.0.8",
-                "ignore": "^7.0.5",
-                "jiti": "^2.6.1",
-                "klona": "^2.0.6",
-                "mlly": "^1.8.0",
-                "ohash": "^2.0.11",
-                "pathe": "^2.0.3",
-                "pkg-types": "^2.3.0",
-                "rc9": "^3.0.0",
-                "scule": "^1.3.0",
-                "semver": "^7.7.4",
-                "tinyglobby": "^0.2.15",
-                "ufo": "^1.6.3",
-                "unctx": "^2.5.0",
-                "untyped": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=18.12.0"
-            }
-        },
-        "node_modules/@nuxtjs/mdc": {
-            "version": "0.20.1",
-            "resolved": "https://registry.npmjs.org/@nuxtjs/mdc/-/mdc-0.20.1.tgz",
-            "integrity": "sha512-fGmtLDQAmmDHF5Z37Apfc3k806rb2XWDOQFhb5xlDSL7+HiiUjyFy3ctx3qWdlC08dRzfAetmsGOYbfDqYsB/w==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "@nuxt/kit": "^4.2.2",
-                "@shikijs/core": "^3.21.0",
-                "@shikijs/langs": "^3.21.0",
-                "@shikijs/themes": "^3.21.0",
-                "@shikijs/transformers": "^3.21.0",
-                "@types/hast": "^3.0.4",
-                "@types/mdast": "^4.0.4",
-                "@vue/compiler-core": "^3.5.26",
-                "consola": "^3.4.2",
-                "debug": "^4.4.3",
-                "defu": "^6.1.4",
-                "destr": "^2.0.5",
-                "detab": "^3.0.2",
-                "github-slugger": "^2.0.0",
-                "hast-util-format": "^1.1.0",
-                "hast-util-to-mdast": "^10.1.2",
-                "hast-util-to-string": "^3.0.1",
-                "mdast-util-to-hast": "^13.2.1",
-                "micromark-util-sanitize-uri": "^2.0.1",
-                "parse5": "^8.0.0",
-                "pathe": "^2.0.3",
-                "property-information": "^7.1.0",
-                "rehype-external-links": "^3.0.0",
-                "rehype-minify-whitespace": "^6.0.2",
-                "rehype-raw": "^7.0.0",
-                "rehype-remark": "^10.0.1",
-                "rehype-slug": "^6.0.0",
-                "rehype-sort-attribute-values": "^5.0.1",
-                "rehype-sort-attributes": "^5.0.1",
-                "remark-emoji": "^5.0.2",
-                "remark-gfm": "^4.0.1",
-                "remark-mdc": "^3.10.0",
-                "remark-parse": "^11.0.0",
-                "remark-rehype": "^11.1.2",
-                "remark-stringify": "^11.0.0",
-                "scule": "^1.3.0",
-                "shiki": "^3.21.0",
-                "ufo": "^1.6.3",
-                "unified": "^11.0.5",
-                "unist-builder": "^4.0.0",
-                "unist-util-visit": "^5.0.0",
-                "unwasm": "^0.5.3",
-                "vfile": "^6.0.3"
-            }
-        },
-        "node_modules/@nuxtjs/mdc/node_modules/@shikijs/engine-javascript": {
-            "version": "3.23.0",
-            "resolved": "https://registry.npmjs.org/@shikijs/engine-javascript/-/engine-javascript-3.23.0.tgz",
-            "integrity": "sha512-aHt9eiGFobmWR5uqJUViySI1bHMqrAgamWE1TYSUoftkAeCCAiGawPMwM+VCadylQtF4V3VNOZ5LmfItH5f3yA==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "@shikijs/types": "3.23.0",
-                "@shikijs/vscode-textmate": "^10.0.2",
-                "oniguruma-to-es": "^4.3.4"
-            }
-        },
-        "node_modules/@nuxtjs/mdc/node_modules/@shikijs/engine-oniguruma": {
-            "version": "3.23.0",
-            "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-3.23.0.tgz",
-            "integrity": "sha512-1nWINwKXxKKLqPibT5f4pAFLej9oZzQTsby8942OTlsJzOBZ0MWKiwzMsd+jhzu8YPCHAswGnnN1YtQfirL35g==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "@shikijs/types": "3.23.0",
-                "@shikijs/vscode-textmate": "^10.0.2"
-            }
-        },
-        "node_modules/@nuxtjs/mdc/node_modules/shiki": {
-            "version": "3.23.0",
-            "resolved": "https://registry.npmjs.org/shiki/-/shiki-3.23.0.tgz",
-            "integrity": "sha512-55Dj73uq9ZXL5zyeRPzHQsK7Nbyt6Y10k5s7OjuFZGMhpp4r/rsLBH0o/0fstIzX1Lep9VxefWljK/SKCzygIA==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "@shikijs/core": "3.23.0",
-                "@shikijs/engine-javascript": "3.23.0",
-                "@shikijs/engine-oniguruma": "3.23.0",
-                "@shikijs/langs": "3.23.0",
-                "@shikijs/themes": "3.23.0",
-                "@shikijs/types": "3.23.0",
-                "@shikijs/vscode-textmate": "^10.0.2",
-                "@types/hast": "^3.0.4"
-            }
-        },
         "node_modules/@octokit/auth-token": {
             "version": "4.0.0",
             "dev": true,
@@ -2857,22 +2727,6 @@
             "license": "Apache-2.0",
             "engines": {
                 "node": ">=14"
-            }
-        },
-        "node_modules/@oxc-project/runtime": {
-            "version": "0.101.0",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": "^20.19.0 || >=22.12.0"
-            }
-        },
-        "node_modules/@oxc-project/types": {
-            "version": "0.101.0",
-            "dev": true,
-            "license": "MIT",
-            "funding": {
-                "url": "https://github.com/sponsors/Boshen"
             }
         },
         "node_modules/@parcel/watcher": {
@@ -3304,23 +3158,6 @@
             "version": "1.1.0",
             "license": "BSD-3-Clause"
         },
-        "node_modules/@rolldown/binding-android-arm64": {
-            "version": "1.0.0-beta.53",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-beta.53.tgz",
-            "integrity": "sha512-Ok9V8o7o6YfSdTTYA/uHH30r3YtOxLD6G3wih/U9DO0ucBBFq8WPt/DslU53OgfteLRHITZny9N/qCUxMf9kjQ==",
-            "cpu": [
-                "arm64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "android"
-            ],
-            "engines": {
-                "node": "^20.19.0 || >=22.12.0"
-            }
-        },
         "node_modules/@rolldown/binding-darwin-arm64": {
             "version": "1.0.0-rc.12",
             "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.12.tgz",
@@ -3353,29 +3190,12 @@
                 "node": "^20.19.0 || >=22.12.0"
             }
         },
-        "node_modules/@rolldown/binding-freebsd-x64": {
-            "version": "1.0.0-beta.53",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-beta.53.tgz",
-            "integrity": "sha512-9Tmp7bBvKqyDkMcL4e089pH3RsjD3SUungjmqWtyhNOxoQMh0fSmINTyYV8KXtE+JkxYMPWvnEt+/mfpVCkk8w==",
+        "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+            "version": "1.0.0-rc.12",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.12.tgz",
+            "integrity": "sha512-AP3E9BpcUYliZCxa3w5Kwj9OtEVDYK6sVoUzy4vTOJsjPOgdaJZKFmN4oOlX0Wp0RPV2ETfmIra9x1xuayFB7g==",
             "cpu": [
-                "x64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "freebsd"
-            ],
-            "engines": {
-                "node": "^20.19.0 || >=22.12.0"
-            }
-        },
-        "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-            "version": "1.0.0-beta.53",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-beta.53.tgz",
-            "integrity": "sha512-a1y5fiB0iovuzdbjUxa7+Zcvgv+mTmlGGC4XydVIsyl48eoxgaYkA3l9079hyTyhECsPq+mbr0gVQsFU11OJAQ==",
-            "cpu": [
-                "arm"
+                "ppc64"
             ],
             "dev": true,
             "license": "MIT",
@@ -3387,29 +3207,12 @@
                 "node": "^20.19.0 || >=22.12.0"
             }
         },
-        "node_modules/@rolldown/binding-linux-arm64-gnu": {
-            "version": "1.0.0-beta.53",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-beta.53.tgz",
-            "integrity": "sha512-bpIGX+ov9PhJYV+wHNXl9rzq4F0QvILiURn0y0oepbQx+7stmQsKA0DhPGwmhfvF856wq+gbM8L92SAa/CBcLg==",
+        "node_modules/@rolldown/binding-linux-s390x-gnu": {
+            "version": "1.0.0-rc.12",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.12.tgz",
+            "integrity": "sha512-nWwpvUSPkoFmZo0kQazZYOrT7J5DGOJ/+QHHzjvNlooDZED8oH82Yg67HvehPPLAg5fUff7TfWFHQS8IV1n3og==",
             "cpu": [
-                "arm64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": "^20.19.0 || >=22.12.0"
-            }
-        },
-        "node_modules/@rolldown/binding-linux-arm64-musl": {
-            "version": "1.0.0-beta.53",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-beta.53.tgz",
-            "integrity": "sha512-bGe5EBB8FVjHBR1mOLOPEFg1Lp3//7geqWkU5NIhxe+yH0W8FVrQ6WRYOap4SUTKdklD/dC4qPLREkMMQ855FA==",
-            "cpu": [
-                "arm64"
+                "s390x"
             ],
             "dev": true,
             "license": "MIT",
@@ -3432,91 +3235,6 @@
             "optional": true,
             "os": [
                 "linux"
-            ],
-            "engines": {
-                "node": "^20.19.0 || >=22.12.0"
-            }
-        },
-        "node_modules/@rolldown/binding-linux-x64-musl": {
-            "version": "1.0.0-beta.53",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-beta.53.tgz",
-            "integrity": "sha512-VGl9JIGjoJh3H8Mb+7xnVqODajBmrdOOb9lxWXdcmxyI+zjB2sux69br0hZJDTyLJfvBoYm439zPACYbCjGRmw==",
-            "cpu": [
-                "x64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": "^20.19.0 || >=22.12.0"
-            }
-        },
-        "node_modules/@rolldown/binding-openharmony-arm64": {
-            "version": "1.0.0-beta.53",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-beta.53.tgz",
-            "integrity": "sha512-B4iIserJXuSnNzA5xBLFUIjTfhNy7d9sq4FUMQY3GhQWGVhS2RWWzzDnkSU6MUt7/aHUrep0CdQfXUJI9D3W7A==",
-            "cpu": [
-                "arm64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "openharmony"
-            ],
-            "engines": {
-                "node": "^20.19.0 || >=22.12.0"
-            }
-        },
-        "node_modules/@rolldown/binding-wasm32-wasi": {
-            "version": "1.0.0-beta.53",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-beta.53.tgz",
-            "integrity": "sha512-BUjAEgpABEJXilGq/BPh7jeU3WAJ5o15c1ZEgHaDWSz3LB881LQZnbNJHmUiM4d1JQWMYYyR1Y490IBHi2FPJg==",
-            "cpu": [
-                "wasm32"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "@napi-rs/wasm-runtime": "^1.1.0"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@rolldown/binding-win32-arm64-msvc": {
-            "version": "1.0.0-beta.53",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-beta.53.tgz",
-            "integrity": "sha512-s27uU7tpCWSjHBnxyVXHt3rMrQdJq5MHNv3BzsewCIroIw3DJFjMH1dzCPPMUFxnh1r52Nf9IJ/eWp6LDoyGcw==",
-            "cpu": [
-                "arm64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "win32"
-            ],
-            "engines": {
-                "node": "^20.19.0 || >=22.12.0"
-            }
-        },
-        "node_modules/@rolldown/binding-win32-x64-msvc": {
-            "version": "1.0.0-beta.53",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-beta.53.tgz",
-            "integrity": "sha512-cjWL/USPJ1g0en2htb4ssMjIycc36RvdQAx1WlXnS6DpULswiUTVXPDesTifSKYSyvx24E0YqQkEm0K/M2Z/AA==",
-            "cpu": [
-                "x64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "win32"
             ],
             "engines": {
                 "node": "^20.19.0 || >=22.12.0"
@@ -3576,19 +3294,6 @@
             "hasInstallScript": true,
             "license": "Apache-2.0"
         },
-        "node_modules/@shikijs/core": {
-            "version": "3.23.0",
-            "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-3.23.0.tgz",
-            "integrity": "sha512-NSWQz0riNb67xthdm5br6lAkvpDJRTgB36fxlo37ZzM2yq0PQFFzbd8psqC2XMPgCzo1fW6cVi18+ArJ44wqgA==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "@shikijs/types": "3.23.0",
-                "@shikijs/vscode-textmate": "^10.0.2",
-                "@types/hast": "^3.0.4",
-                "hast-util-to-html": "^9.0.5"
-            }
-        },
         "node_modules/@shikijs/engine-javascript": {
             "version": "4.0.2",
             "resolved": "https://registry.npmjs.org/@shikijs/engine-javascript/-/engine-javascript-4.0.2.tgz",
@@ -3642,16 +3347,6 @@
                 "node": ">=20"
             }
         },
-        "node_modules/@shikijs/langs": {
-            "version": "3.23.0",
-            "resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-3.23.0.tgz",
-            "integrity": "sha512-2Ep4W3Re5aB1/62RSYQInK9mM3HsLeB91cHqznAJMuylqjzNVAVCMnNWRHFtcNHXsoNRayP9z1qj4Sq3nMqYXg==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "@shikijs/types": "3.23.0"
-            }
-        },
         "node_modules/@shikijs/markdown-it": {
             "version": "4.0.2",
             "resolved": "https://registry.npmjs.org/@shikijs/markdown-it/-/markdown-it-4.0.2.tgz",
@@ -3674,54 +3369,9 @@
                 }
             }
         },
-        "node_modules/@shikijs/themes": {
-            "version": "3.23.0",
-            "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-3.23.0.tgz",
-            "integrity": "sha512-5qySYa1ZgAT18HR/ypENL9cUSGOeI2x+4IvYJu4JgVJdizn6kG4ia5Q1jDEOi7gTbN4RbuYtmHh0W3eccOrjMA==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "@shikijs/types": "3.23.0"
-            }
-        },
-        "node_modules/@shikijs/transformers": {
-            "version": "3.23.0",
-            "resolved": "https://registry.npmjs.org/@shikijs/transformers/-/transformers-3.23.0.tgz",
-            "integrity": "sha512-F9msZVxdF+krQNSdQ4V+Ja5QemeAoTQ2jxt7nJCwhDsdF1JWS3KxIQXA3lQbyKwS3J61oHRUSv4jYWv3CkaKTQ==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "@shikijs/core": "3.23.0",
-                "@shikijs/types": "3.23.0"
-            }
-        },
-        "node_modules/@shikijs/types": {
-            "version": "3.23.0",
-            "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-3.23.0.tgz",
-            "integrity": "sha512-3JZ5HXOZfYjsYSk0yPwBrkupyYSLpAE26Qc0HLghhZNGTZg/SKxXIIgoxOpmmeQP0RRSDJTk1/vPfw9tbw+jSQ==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "@shikijs/vscode-textmate": "^10.0.2",
-                "@types/hast": "^3.0.4"
-            }
-        },
         "node_modules/@shikijs/vscode-textmate": {
             "version": "10.0.2",
             "license": "MIT"
-        },
-        "node_modules/@sindresorhus/is": {
-            "version": "4.6.0",
-            "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.6.0.tgz",
-            "integrity": "sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==",
-            "license": "MIT",
-            "peer": true,
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sindresorhus/is?sponsor=1"
-            }
         },
         "node_modules/@standard-schema/spec": {
             "version": "1.1.0",
@@ -4544,40 +4194,6 @@
                 "node": ">=10"
             }
         },
-        "node_modules/@testing-library/dom": {
-            "version": "10.4.1",
-            "dev": true,
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "@babel/code-frame": "^7.10.4",
-                "@babel/runtime": "^7.12.5",
-                "@types/aria-query": "^5.0.1",
-                "aria-query": "5.3.0",
-                "dom-accessibility-api": "^0.5.9",
-                "lz-string": "^1.5.0",
-                "picocolors": "1.1.1",
-                "pretty-format": "^27.0.2"
-            },
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@testing-library/dom/node_modules/aria-query": {
-            "version": "5.3.0",
-            "dev": true,
-            "license": "Apache-2.0",
-            "peer": true,
-            "dependencies": {
-                "dequal": "^2.0.3"
-            }
-        },
-        "node_modules/@testing-library/dom/node_modules/dom-accessibility-api": {
-            "version": "0.5.16",
-            "dev": true,
-            "license": "MIT",
-            "peer": true
-        },
         "node_modules/@testing-library/jest-dom": {
             "version": "6.9.1",
             "dev": true,
@@ -4638,12 +4254,6 @@
             "dependencies": {
                 "tslib": "^2.4.0"
             }
-        },
-        "node_modules/@types/aria-query": {
-            "version": "5.0.4",
-            "dev": true,
-            "license": "MIT",
-            "peer": true
         },
         "node_modules/@types/bootstrap": {
             "version": "5.2.10",
@@ -4915,16 +4525,6 @@
                 "@types/d3-selection": "*"
             }
         },
-        "node_modules/@types/debug": {
-            "version": "4.1.12",
-            "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.12.tgz",
-            "integrity": "sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "@types/ms": "*"
-            }
-        },
         "node_modules/@types/deep-eql": {
             "version": "4.0.2",
             "dev": true,
@@ -4932,6 +4532,7 @@
         },
         "node_modules/@types/estree": {
             "version": "1.0.8",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/@types/fs-extra": {
@@ -4979,11 +4580,6 @@
             "dev": true,
             "license": "MIT"
         },
-        "node_modules/@types/linkify-it": {
-            "version": "5.0.0",
-            "license": "MIT",
-            "peer": true
-        },
         "node_modules/@types/lodash": {
             "version": "4.17.23",
             "license": "MIT"
@@ -4995,26 +4591,12 @@
                 "@types/lodash": "*"
             }
         },
-        "node_modules/@types/markdown-it": {
-            "version": "14.1.2",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "@types/linkify-it": "^5",
-                "@types/mdurl": "^2"
-            }
-        },
         "node_modules/@types/mdast": {
             "version": "4.0.4",
             "license": "MIT",
             "dependencies": {
                 "@types/unist": "*"
             }
-        },
-        "node_modules/@types/mdurl": {
-            "version": "2.0.0",
-            "license": "MIT",
-            "peer": true
         },
         "node_modules/@types/minimatch": {
             "version": "5.1.2",
@@ -5028,13 +4610,6 @@
             "dependencies": {
                 "moment": "*"
             }
-        },
-        "node_modules/@types/ms": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
-            "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
-            "license": "MIT",
-            "peer": true
         },
         "node_modules/@types/node": {
             "version": "25.5.0",
@@ -6431,17 +6006,6 @@
                 "node": ">= 10.0.0"
             }
         },
-        "node_modules/bail": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/bail/-/bail-2.0.2.tgz",
-            "integrity": "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==",
-            "license": "MIT",
-            "peer": true,
-            "funding": {
-                "type": "github",
-                "url": "https://github.com/sponsors/wooorm"
-            }
-        },
         "node_modules/balanced-match": {
             "version": "1.0.2",
             "license": "MIT"
@@ -6615,6 +6179,7 @@
         },
         "node_modules/c12": {
             "version": "3.3.3",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "chokidar": "^5.0.0",
@@ -6641,6 +6206,7 @@
         },
         "node_modules/c12/node_modules/rc9": {
             "version": "2.1.2",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "defu": "^6.1.4",
@@ -6762,27 +6328,6 @@
             "dev": true,
             "license": "MIT"
         },
-        "node_modules/char-regex": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/char-regex/-/char-regex-1.0.2.tgz",
-            "integrity": "sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==",
-            "license": "MIT",
-            "peer": true,
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "node_modules/character-entities": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.2.tgz",
-            "integrity": "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==",
-            "license": "MIT",
-            "peer": true,
-            "funding": {
-                "type": "github",
-                "url": "https://github.com/sponsors/wooorm"
-            }
-        },
         "node_modules/character-entities-html4": {
             "version": "2.1.0",
             "license": "MIT",
@@ -6805,17 +6350,6 @@
             "license": "MIT",
             "dependencies": {
                 "is-regex": "^1.0.3"
-            }
-        },
-        "node_modules/character-reference-invalid": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-2.0.1.tgz",
-            "integrity": "sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==",
-            "license": "MIT",
-            "peer": true,
-            "funding": {
-                "type": "github",
-                "url": "https://github.com/sponsors/wooorm"
             }
         },
         "node_modules/charenc": {
@@ -6871,6 +6405,7 @@
         },
         "node_modules/chokidar": {
             "version": "5.0.0",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "readdirp": "^5.0.0"
@@ -6898,6 +6433,7 @@
         },
         "node_modules/citty": {
             "version": "0.1.6",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "consola": "^3.2.3"
@@ -7011,6 +6547,7 @@
         },
         "node_modules/confbox": {
             "version": "0.2.4",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/config-chain": {
@@ -7024,6 +6561,7 @@
         },
         "node_modules/consola": {
             "version": "3.4.2",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": "^14.18.0 || >=16.10.0"
@@ -7708,6 +7246,7 @@
         },
         "node_modules/debug": {
             "version": "4.4.3",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "ms": "^2.1.3"
@@ -7725,20 +7264,6 @@
             "version": "10.6.0",
             "dev": true,
             "license": "MIT"
-        },
-        "node_modules/decode-named-character-reference": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.3.0.tgz",
-            "integrity": "sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "character-entities": "^2.0.0"
-            },
-            "funding": {
-                "type": "github",
-                "url": "https://github.com/sponsors/wooorm"
-            }
         },
         "node_modules/deep-eql": {
             "version": "5.0.2",
@@ -7821,6 +7346,7 @@
         },
         "node_modules/defu": {
             "version": "6.1.4",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/delaunator": {
@@ -7853,18 +7379,8 @@
         },
         "node_modules/destr": {
             "version": "2.0.5",
+            "dev": true,
             "license": "MIT"
-        },
-        "node_modules/detab": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/detab/-/detab-3.0.2.tgz",
-            "integrity": "sha512-7Bp16Bk8sk0Y6gdXiCtnpGbghn8atnTJdd/82aWvS5ESnlcNvgUc10U2NYS0PAiDSGjWiI8qs/Cv1b2uSGdQ8w==",
-            "license": "MIT",
-            "peer": true,
-            "funding": {
-                "type": "github",
-                "url": "https://github.com/sponsors/wooorm"
-            }
         },
         "node_modules/detect-libc": {
             "version": "2.1.2",
@@ -8057,24 +7573,6 @@
             "dev": true,
             "license": "MIT"
         },
-        "node_modules/emojilib": {
-            "version": "2.4.0",
-            "resolved": "https://registry.npmjs.org/emojilib/-/emojilib-2.4.0.tgz",
-            "integrity": "sha512-5U0rVMU5Y2n2+ykNLQqMoqklN9ICBT/KsvC1Gz6vqHbz2AXXGkG+Pm5rMWk/8Vjrr/mY9985Hi8DYzn1F09Nyw==",
-            "license": "MIT",
-            "peer": true
-        },
-        "node_modules/emoticon": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/emoticon/-/emoticon-4.1.0.tgz",
-            "integrity": "sha512-VWZfnxqwNcc51hIy/sbOdEem6D+cVtpPzEEtVAFdaas30+1dgkyaOQ4sQ6Bp0tOMqWO1v+HQfYaoodOkdhK6SQ==",
-            "license": "MIT",
-            "peer": true,
-            "funding": {
-                "type": "github",
-                "url": "https://github.com/sponsors/wooorm"
-            }
-        },
         "node_modules/entities": {
             "version": "7.0.1",
             "license": "BSD-2-Clause",
@@ -8095,13 +7593,6 @@
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
             }
-        },
-        "node_modules/errx": {
-            "version": "0.1.0",
-            "resolved": "https://registry.npmjs.org/errx/-/errx-0.1.0.tgz",
-            "integrity": "sha512-fZmsRiDNv07K6s2KkKFTiD2aIvECa7++PKyD5NC32tpRw46qZA3sOz+aM+/V9V0GDHxVTKLziveV4JhzBHDp9Q==",
-            "license": "MIT",
-            "peer": true
         },
         "node_modules/es-define-property": {
             "version": "1.0.1",
@@ -8593,6 +8084,7 @@
         },
         "node_modules/estree-walker": {
             "version": "3.0.3",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@types/estree": "^1.0.0"
@@ -8629,6 +8121,7 @@
         },
         "node_modules/exsolve": {
             "version": "1.0.8",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/ext": {
@@ -8637,13 +8130,6 @@
             "dependencies": {
                 "type": "^2.7.2"
             }
-        },
-        "node_modules/extend": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-            "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
-            "license": "MIT",
-            "peer": true
         },
         "node_modules/fast-deep-equal": {
             "version": "3.1.3",
@@ -8754,19 +8240,6 @@
             "license": "Apache-2.0",
             "dependencies": {
                 "micromatch": "^4.0.2"
-            }
-        },
-        "node_modules/flat": {
-            "version": "6.0.1",
-            "resolved": "https://registry.npmjs.org/flat/-/flat-6.0.1.tgz",
-            "integrity": "sha512-/3FfIa8mbrg3xE7+wAhWeV+bd7L2Mof+xtZb5dRDKZ+wDvYJK4WDYeIOuOhre5Yv5aQObZrlbRmk3RTSiuQBtw==",
-            "license": "BSD-3-Clause",
-            "peer": true,
-            "bin": {
-                "flat": "cli.js"
-            },
-            "engines": {
-                "node": ">=18"
             }
         },
         "node_modules/flat-cache": {
@@ -8939,6 +8412,7 @@
         },
         "node_modules/giget": {
             "version": "2.0.0",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "citty": "^0.1.6",
@@ -8951,13 +8425,6 @@
             "bin": {
                 "giget": "dist/cli.mjs"
             }
-        },
-        "node_modules/github-slugger": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/github-slugger/-/github-slugger-2.0.0.tgz",
-            "integrity": "sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw==",
-            "license": "ISC",
-            "peer": true
         },
         "node_modules/glob": {
             "version": "10.5.0",
@@ -9164,220 +8631,6 @@
                 "node": ">= 0.4"
             }
         },
-        "node_modules/hast-util-embedded": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/hast-util-embedded/-/hast-util-embedded-3.0.0.tgz",
-            "integrity": "sha512-naH8sld4Pe2ep03qqULEtvYr7EjrLK2QHY8KJR6RJkTUjPGObe1vnx585uzem2hGra+s1q08DZZpfgDVYRbaXA==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "@types/hast": "^3.0.0",
-                "hast-util-is-element": "^3.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/unified"
-            }
-        },
-        "node_modules/hast-util-format": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/hast-util-format/-/hast-util-format-1.1.0.tgz",
-            "integrity": "sha512-yY1UDz6bC9rDvCWHpx12aIBGRG7krurX0p0Fm6pT547LwDIZZiNr8a+IHDogorAdreULSEzP82Nlv5SZkHZcjA==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "@types/hast": "^3.0.0",
-                "hast-util-embedded": "^3.0.0",
-                "hast-util-minify-whitespace": "^1.0.0",
-                "hast-util-phrasing": "^3.0.0",
-                "hast-util-whitespace": "^3.0.0",
-                "html-whitespace-sensitive-tag-names": "^3.0.0",
-                "unist-util-visit-parents": "^6.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/unified"
-            }
-        },
-        "node_modules/hast-util-from-parse5": {
-            "version": "8.0.3",
-            "resolved": "https://registry.npmjs.org/hast-util-from-parse5/-/hast-util-from-parse5-8.0.3.tgz",
-            "integrity": "sha512-3kxEVkEKt0zvcZ3hCRYI8rqrgwtlIOFMWkbclACvjlDw8Li9S2hk/d51OI0nr/gIpdMHNepwgOKqZ/sy0Clpyg==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "@types/hast": "^3.0.0",
-                "@types/unist": "^3.0.0",
-                "devlop": "^1.0.0",
-                "hastscript": "^9.0.0",
-                "property-information": "^7.0.0",
-                "vfile": "^6.0.0",
-                "vfile-location": "^5.0.0",
-                "web-namespaces": "^2.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/unified"
-            }
-        },
-        "node_modules/hast-util-has-property": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/hast-util-has-property/-/hast-util-has-property-3.0.0.tgz",
-            "integrity": "sha512-MNilsvEKLFpV604hwfhVStK0usFY/QmM5zX16bo7EjnAEGofr5YyI37kzopBlZJkHD4t887i+q/C8/tr5Q94cA==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "@types/hast": "^3.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/unified"
-            }
-        },
-        "node_modules/hast-util-heading-rank": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/hast-util-heading-rank/-/hast-util-heading-rank-3.0.0.tgz",
-            "integrity": "sha512-EJKb8oMUXVHcWZTDepnr+WNbfnXKFNf9duMesmr4S8SXTJBJ9M4Yok08pu9vxdJwdlGRhVumk9mEhkEvKGifwA==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "@types/hast": "^3.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/unified"
-            }
-        },
-        "node_modules/hast-util-is-body-ok-link": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/hast-util-is-body-ok-link/-/hast-util-is-body-ok-link-3.0.1.tgz",
-            "integrity": "sha512-0qpnzOBLztXHbHQenVB8uNuxTnm/QBFUOmdOSsEn7GnBtyY07+ENTWVFBAnXd/zEgd9/SUG3lRY7hSIBWRgGpQ==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "@types/hast": "^3.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/unified"
-            }
-        },
-        "node_modules/hast-util-is-element": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/hast-util-is-element/-/hast-util-is-element-3.0.0.tgz",
-            "integrity": "sha512-Val9mnv2IWpLbNPqc/pUem+a7Ipj2aHacCwgNfTiK0vJKl0LF+4Ba4+v1oPHFpf3bLYmreq0/l3Gud9S5OH42g==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "@types/hast": "^3.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/unified"
-            }
-        },
-        "node_modules/hast-util-minify-whitespace": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/hast-util-minify-whitespace/-/hast-util-minify-whitespace-1.0.1.tgz",
-            "integrity": "sha512-L96fPOVpnclQE0xzdWb/D12VT5FabA7SnZOUMtL1DbXmYiHJMXZvFkIZfiMmTCNJHUeO2K9UYNXoVyfz+QHuOw==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "@types/hast": "^3.0.0",
-                "hast-util-embedded": "^3.0.0",
-                "hast-util-is-element": "^3.0.0",
-                "hast-util-whitespace": "^3.0.0",
-                "unist-util-is": "^6.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/unified"
-            }
-        },
-        "node_modules/hast-util-parse-selector": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/hast-util-parse-selector/-/hast-util-parse-selector-4.0.0.tgz",
-            "integrity": "sha512-wkQCkSYoOGCRKERFWcxMVMOcYE2K1AaNLU8DXS9arxnLOUEWbOXKXiJUNzEpqZ3JOKpnha3jkFrumEjVliDe7A==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "@types/hast": "^3.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/unified"
-            }
-        },
-        "node_modules/hast-util-phrasing": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/hast-util-phrasing/-/hast-util-phrasing-3.0.1.tgz",
-            "integrity": "sha512-6h60VfI3uBQUxHqTyMymMZnEbNl1XmEGtOxxKYL7stY2o601COo62AWAYBQR9lZbYXYSBoxag8UpPRXK+9fqSQ==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "@types/hast": "^3.0.0",
-                "hast-util-embedded": "^3.0.0",
-                "hast-util-has-property": "^3.0.0",
-                "hast-util-is-body-ok-link": "^3.0.0",
-                "hast-util-is-element": "^3.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/unified"
-            }
-        },
-        "node_modules/hast-util-raw": {
-            "version": "9.1.0",
-            "resolved": "https://registry.npmjs.org/hast-util-raw/-/hast-util-raw-9.1.0.tgz",
-            "integrity": "sha512-Y8/SBAHkZGoNkpzqqfCldijcuUKh7/su31kEBp67cFY09Wy0mTRgtsLYsiIxMJxlu0f6AA5SUTbDR8K0rxnbUw==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "@types/hast": "^3.0.0",
-                "@types/unist": "^3.0.0",
-                "@ungap/structured-clone": "^1.0.0",
-                "hast-util-from-parse5": "^8.0.0",
-                "hast-util-to-parse5": "^8.0.0",
-                "html-void-elements": "^3.0.0",
-                "mdast-util-to-hast": "^13.0.0",
-                "parse5": "^7.0.0",
-                "unist-util-position": "^5.0.0",
-                "unist-util-visit": "^5.0.0",
-                "vfile": "^6.0.0",
-                "web-namespaces": "^2.0.0",
-                "zwitch": "^2.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/unified"
-            }
-        },
-        "node_modules/hast-util-raw/node_modules/entities": {
-            "version": "6.0.1",
-            "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
-            "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
-            "license": "BSD-2-Clause",
-            "peer": true,
-            "engines": {
-                "node": ">=0.12"
-            },
-            "funding": {
-                "url": "https://github.com/fb55/entities?sponsor=1"
-            }
-        },
-        "node_modules/hast-util-raw/node_modules/parse5": {
-            "version": "7.3.0",
-            "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
-            "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "entities": "^6.0.0"
-            },
-            "funding": {
-                "url": "https://github.com/inikulin/parse5?sponsor=1"
-            }
-        },
         "node_modules/hast-util-to-html": {
             "version": "9.0.5",
             "license": "MIT",
@@ -9399,107 +8652,11 @@
                 "url": "https://opencollective.com/unified"
             }
         },
-        "node_modules/hast-util-to-mdast": {
-            "version": "10.1.2",
-            "resolved": "https://registry.npmjs.org/hast-util-to-mdast/-/hast-util-to-mdast-10.1.2.tgz",
-            "integrity": "sha512-FiCRI7NmOvM4y+f5w32jPRzcxDIz+PUqDwEqn1A+1q2cdp3B8Gx7aVrXORdOKjMNDQsD1ogOr896+0jJHW1EFQ==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "@types/hast": "^3.0.0",
-                "@types/mdast": "^4.0.0",
-                "@ungap/structured-clone": "^1.0.0",
-                "hast-util-phrasing": "^3.0.0",
-                "hast-util-to-html": "^9.0.0",
-                "hast-util-to-text": "^4.0.0",
-                "hast-util-whitespace": "^3.0.0",
-                "mdast-util-phrasing": "^4.0.0",
-                "mdast-util-to-hast": "^13.0.0",
-                "mdast-util-to-string": "^4.0.0",
-                "rehype-minify-whitespace": "^6.0.0",
-                "trim-trailing-lines": "^2.0.0",
-                "unist-util-position": "^5.0.0",
-                "unist-util-visit": "^5.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/unified"
-            }
-        },
-        "node_modules/hast-util-to-parse5": {
-            "version": "8.0.1",
-            "resolved": "https://registry.npmjs.org/hast-util-to-parse5/-/hast-util-to-parse5-8.0.1.tgz",
-            "integrity": "sha512-MlWT6Pjt4CG9lFCjiz4BH7l9wmrMkfkJYCxFwKQic8+RTZgWPuWxwAfjJElsXkex7DJjfSJsQIt931ilUgmwdA==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "@types/hast": "^3.0.0",
-                "comma-separated-tokens": "^2.0.0",
-                "devlop": "^1.0.0",
-                "property-information": "^7.0.0",
-                "space-separated-tokens": "^2.0.0",
-                "web-namespaces": "^2.0.0",
-                "zwitch": "^2.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/unified"
-            }
-        },
-        "node_modules/hast-util-to-string": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/hast-util-to-string/-/hast-util-to-string-3.0.1.tgz",
-            "integrity": "sha512-XelQVTDWvqcl3axRfI0xSeoVKzyIFPwsAGSLIsKdJKQMXDYJS4WYrBNF/8J7RdhIcFI2BOHgAifggsvsxp/3+A==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "@types/hast": "^3.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/unified"
-            }
-        },
-        "node_modules/hast-util-to-text": {
-            "version": "4.0.2",
-            "resolved": "https://registry.npmjs.org/hast-util-to-text/-/hast-util-to-text-4.0.2.tgz",
-            "integrity": "sha512-KK6y/BN8lbaq654j7JgBydev7wuNMcID54lkRav1P0CaE1e47P72AWWPiGKXTJU271ooYzcvTAn/Zt0REnvc7A==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "@types/hast": "^3.0.0",
-                "@types/unist": "^3.0.0",
-                "hast-util-is-element": "^3.0.0",
-                "unist-util-find-after": "^5.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/unified"
-            }
-        },
         "node_modules/hast-util-whitespace": {
             "version": "3.0.0",
             "license": "MIT",
             "dependencies": {
                 "@types/hast": "^3.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/unified"
-            }
-        },
-        "node_modules/hastscript": {
-            "version": "9.0.1",
-            "resolved": "https://registry.npmjs.org/hastscript/-/hastscript-9.0.1.tgz",
-            "integrity": "sha512-g7df9rMFX/SPi34tyGCyUBREQoKkapwdY/T04Qn9TDWfHhAYt4/I0gMVirzK5wEzeUqIjEB+LXC/ypb7Aqno5w==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "@types/hast": "^3.0.0",
-                "comma-separated-tokens": "^2.0.0",
-                "hast-util-parse-selector": "^4.0.0",
-                "property-information": "^7.0.0",
-                "space-separated-tokens": "^2.0.0"
             },
             "funding": {
                 "type": "opencollective",
@@ -9544,17 +8701,6 @@
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/wooorm"
-            }
-        },
-        "node_modules/html-whitespace-sensitive-tag-names": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/html-whitespace-sensitive-tag-names/-/html-whitespace-sensitive-tag-names-3.0.1.tgz",
-            "integrity": "sha512-q+310vW8zmymYHALr1da4HyXUQ0zgiIwIicEfotYPWGN0OJVEN/58IJ3A4GBYcEq3LGAZqKb+ugvP0GNB9CEAA==",
-            "license": "MIT",
-            "peer": true,
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/unified"
             }
         },
         "node_modules/humanize-duration": {
@@ -9610,6 +8756,7 @@
         },
         "node_modules/ignore": {
             "version": "7.0.5",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">= 4"
@@ -9683,45 +8830,6 @@
                 "node": ">=12"
             }
         },
-        "node_modules/is-absolute-url": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/is-absolute-url/-/is-absolute-url-4.0.1.tgz",
-            "integrity": "sha512-/51/TKE88Lmm7Gc4/8btclNXWS+g50wXhYJq8HWIBAGUBnoAdRu1aXeh364t/O7wXDAcTJDP8PNuNKWUDWie+A==",
-            "license": "MIT",
-            "peer": true,
-            "engines": {
-                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/is-alphabetical": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-2.0.1.tgz",
-            "integrity": "sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==",
-            "license": "MIT",
-            "peer": true,
-            "funding": {
-                "type": "github",
-                "url": "https://github.com/sponsors/wooorm"
-            }
-        },
-        "node_modules/is-alphanumerical": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-2.0.1.tgz",
-            "integrity": "sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "is-alphabetical": "^2.0.0",
-                "is-decimal": "^2.0.0"
-            },
-            "funding": {
-                "type": "github",
-                "url": "https://github.com/sponsors/wooorm"
-            }
-        },
         "node_modules/is-buffer": {
             "version": "1.1.6",
             "license": "MIT"
@@ -9738,17 +8846,6 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/is-decimal": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-2.0.1.tgz",
-            "integrity": "sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==",
-            "license": "MIT",
-            "peer": true,
-            "funding": {
-                "type": "github",
-                "url": "https://github.com/sponsors/wooorm"
             }
         },
         "node_modules/is-docker": {
@@ -9818,17 +8915,6 @@
                 "node": ">=0.10.0"
             }
         },
-        "node_modules/is-hexadecimal": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-2.0.1.tgz",
-            "integrity": "sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==",
-            "license": "MIT",
-            "peer": true,
-            "funding": {
-                "type": "github",
-                "url": "https://github.com/sponsors/wooorm"
-            }
-        },
         "node_modules/is-in-ssh": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/is-in-ssh/-/is-in-ssh-1.0.0.tgz",
@@ -9883,19 +8969,6 @@
             "license": "MIT",
             "engines": {
                 "node": ">=0.12.0"
-            }
-        },
-        "node_modules/is-plain-obj": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
-            "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
-            "license": "MIT",
-            "peer": true,
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/is-plain-object": {
@@ -10014,6 +9087,7 @@
         },
         "node_modules/jiti": {
             "version": "2.6.1",
+            "dev": true,
             "license": "MIT",
             "bin": {
                 "jiti": "lib/jiti-cli.mjs"
@@ -10272,23 +9346,6 @@
                 "graceful-fs": "^4.1.11"
             }
         },
-        "node_modules/klona": {
-            "version": "2.0.6",
-            "resolved": "https://registry.npmjs.org/klona/-/klona-2.0.6.tgz",
-            "integrity": "sha512-dhG34DXATL5hSxJbIexCft8FChFXtmskoZYnoPWjXQuebWYCNkVeV3KkGegCK9CP1oswI/vQibS2GY7Em/sJJA==",
-            "license": "MIT",
-            "peer": true,
-            "engines": {
-                "node": ">= 8"
-            }
-        },
-        "node_modules/knitwork": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/knitwork/-/knitwork-1.3.0.tgz",
-            "integrity": "sha512-4LqMNoONzR43B1W0ek0fhXMsDNW/zxa1NdFAVMY+k28pgZLovR4G3PB5MrpTxCy1QaZCqNoiaKPr5w5qZHfSNw==",
-            "license": "MIT",
-            "peer": true
-        },
         "node_modules/langium": {
             "version": "4.2.1",
             "resolved": "https://registry.npmjs.org/langium/-/langium-4.2.1.tgz",
@@ -10325,7 +9382,9 @@
             }
         },
         "node_modules/lightningcss": {
-            "version": "1.31.1",
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+            "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
             "dev": true,
             "license": "MPL-2.0",
             "dependencies": {
@@ -10339,23 +9398,23 @@
                 "url": "https://opencollective.com/parcel"
             },
             "optionalDependencies": {
-                "lightningcss-android-arm64": "1.31.1",
-                "lightningcss-darwin-arm64": "1.31.1",
-                "lightningcss-darwin-x64": "1.31.1",
-                "lightningcss-freebsd-x64": "1.31.1",
-                "lightningcss-linux-arm-gnueabihf": "1.31.1",
-                "lightningcss-linux-arm64-gnu": "1.31.1",
-                "lightningcss-linux-arm64-musl": "1.31.1",
-                "lightningcss-linux-x64-gnu": "1.31.1",
-                "lightningcss-linux-x64-musl": "1.31.1",
-                "lightningcss-win32-arm64-msvc": "1.31.1",
-                "lightningcss-win32-x64-msvc": "1.31.1"
+                "lightningcss-android-arm64": "1.32.0",
+                "lightningcss-darwin-arm64": "1.32.0",
+                "lightningcss-darwin-x64": "1.32.0",
+                "lightningcss-freebsd-x64": "1.32.0",
+                "lightningcss-linux-arm-gnueabihf": "1.32.0",
+                "lightningcss-linux-arm64-gnu": "1.32.0",
+                "lightningcss-linux-arm64-musl": "1.32.0",
+                "lightningcss-linux-x64-gnu": "1.32.0",
+                "lightningcss-linux-x64-musl": "1.32.0",
+                "lightningcss-win32-arm64-msvc": "1.32.0",
+                "lightningcss-win32-x64-msvc": "1.32.0"
             }
         },
         "node_modules/lightningcss-android-arm64": {
-            "version": "1.31.1",
-            "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.31.1.tgz",
-            "integrity": "sha512-HXJF3x8w9nQ4jbXRiNppBCqeZPIAfUo8zE/kOEGbW5NZvGc/K7nMxbhIr+YlFlHW5mpbg/YFPdbnCh1wAXCKFg==",
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+            "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
             "cpu": [
                 "arm64"
             ],
@@ -10414,9 +9473,9 @@
             }
         },
         "node_modules/lightningcss-freebsd-x64": {
-            "version": "1.31.1",
-            "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.31.1.tgz",
-            "integrity": "sha512-1RINmQKAItO6ISxYgPwszQE1BrsVU5aB45ho6O42mu96UiZBxEXsuQ7cJW4zs4CEodPUioj/QrXW1r9pLUM74A==",
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+            "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
             "cpu": [
                 "x64"
             ],
@@ -10435,9 +9494,9 @@
             }
         },
         "node_modules/lightningcss-linux-arm-gnueabihf": {
-            "version": "1.31.1",
-            "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.31.1.tgz",
-            "integrity": "sha512-OOCm2//MZJ87CdDK62rZIu+aw9gBv4azMJuA8/KB74wmfS3lnC4yoPHm0uXZ/dvNNHmnZnB8XLAZzObeG0nS1g==",
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+            "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
             "cpu": [
                 "arm"
             ],
@@ -10456,9 +9515,9 @@
             }
         },
         "node_modules/lightningcss-linux-arm64-gnu": {
-            "version": "1.31.1",
-            "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.31.1.tgz",
-            "integrity": "sha512-WKyLWztD71rTnou4xAD5kQT+982wvca7E6QoLpoawZ1gP9JM0GJj4Tp5jMUh9B3AitHbRZ2/H3W5xQmdEOUlLg==",
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+            "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
             "cpu": [
                 "arm64"
             ],
@@ -10477,9 +9536,9 @@
             }
         },
         "node_modules/lightningcss-linux-arm64-musl": {
-            "version": "1.31.1",
-            "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.31.1.tgz",
-            "integrity": "sha512-mVZ7Pg2zIbe3XlNbZJdjs86YViQFoJSpc41CbVmKBPiGmC4YrfeOyz65ms2qpAobVd7WQsbW4PdsSJEMymyIMg==",
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+            "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
             "cpu": [
                 "arm64"
             ],
@@ -10518,9 +9577,9 @@
             }
         },
         "node_modules/lightningcss-linux-x64-musl": {
-            "version": "1.31.1",
-            "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.31.1.tgz",
-            "integrity": "sha512-eowF8PrKHw9LpoZii5tdZwnBcYDxRw2rRCyvAXLi34iyeYfqCQNA9rmUM0ce62NlPhCvof1+9ivRaTY6pSKDaA==",
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+            "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
             "cpu": [
                 "x64"
             ],
@@ -10539,9 +9598,9 @@
             }
         },
         "node_modules/lightningcss-win32-arm64-msvc": {
-            "version": "1.31.1",
-            "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.31.1.tgz",
-            "integrity": "sha512-aJReEbSEQzx1uBlQizAOBSjcmr9dCdL3XuC/6HLXAxmtErsj2ICo5yYggg1qOODQMtnjNQv2UHb9NpOuFtYe4w==",
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+            "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
             "cpu": [
                 "arm64"
             ],
@@ -10560,9 +9619,9 @@
             }
         },
         "node_modules/lightningcss-win32-x64-msvc": {
-            "version": "1.31.1",
-            "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.31.1.tgz",
-            "integrity": "sha512-I9aiFrbd7oYHwlnQDqr1Roz+fTz61oDDJX7n9tYF9FJymH1cIN1DtKw3iYt6b8WZgEjoNwVSncwF4wx/ZedMhw==",
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+            "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
             "cpu": [
                 "x64"
             ],
@@ -10571,69 +9630,6 @@
             "optional": true,
             "os": [
                 "win32"
-            ],
-            "engines": {
-                "node": ">= 12.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/parcel"
-            }
-        },
-        "node_modules/lightningcss/node_modules/lightningcss-darwin-arm64": {
-            "version": "1.31.1",
-            "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.31.1.tgz",
-            "integrity": "sha512-02uTEqf3vIfNMq3h/z2cJfcOXnQ0GRwQrkmPafhueLb2h7mqEidiCzkE4gBMEH65abHRiQvhdcQ+aP0D0g67sg==",
-            "cpu": [
-                "arm64"
-            ],
-            "dev": true,
-            "license": "MPL-2.0",
-            "optional": true,
-            "os": [
-                "darwin"
-            ],
-            "engines": {
-                "node": ">= 12.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/parcel"
-            }
-        },
-        "node_modules/lightningcss/node_modules/lightningcss-darwin-x64": {
-            "version": "1.31.1",
-            "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.31.1.tgz",
-            "integrity": "sha512-1ObhyoCY+tGxtsz1lSx5NXCj3nirk0Y0kB/g8B8DT+sSx4G9djitg9ejFnjb3gJNWo7qXH4DIy2SUHvpoFwfTA==",
-            "cpu": [
-                "x64"
-            ],
-            "dev": true,
-            "license": "MPL-2.0",
-            "optional": true,
-            "os": [
-                "darwin"
-            ],
-            "engines": {
-                "node": ">= 12.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/parcel"
-            }
-        },
-        "node_modules/lightningcss/node_modules/lightningcss-linux-x64-gnu": {
-            "version": "1.31.1",
-            "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.31.1.tgz",
-            "integrity": "sha512-xGlFWRMl+0KvUhgySdIaReQdB4FNudfUTARn7q0hh/V67PVGCs3ADFjw+6++kG1RNd0zdGRlEKa+T13/tQjPMA==",
-            "cpu": [
-                "x64"
-            ],
-            "dev": true,
-            "license": "MPL-2.0",
-            "optional": true,
-            "os": [
-                "linux"
             ],
             "engines": {
                 "node": ">= 12.0.0"
@@ -10892,17 +9888,6 @@
             "version": "5.3.2",
             "license": "Apache-2.0"
         },
-        "node_modules/longest-streak": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-3.1.0.tgz",
-            "integrity": "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==",
-            "license": "MIT",
-            "peer": true,
-            "funding": {
-                "type": "github",
-                "url": "https://github.com/sponsors/wooorm"
-            }
-        },
         "node_modules/loupe": {
             "version": "3.2.1",
             "dev": true,
@@ -10916,15 +9901,6 @@
                 "yallist": "^3.0.2"
             }
         },
-        "node_modules/lz-string": {
-            "version": "1.5.0",
-            "dev": true,
-            "license": "MIT",
-            "peer": true,
-            "bin": {
-                "lz-string": "bin/bin.js"
-            }
-        },
         "node_modules/magic-string": {
             "version": "0.30.21",
             "license": "MIT",
@@ -10936,7 +9912,7 @@
             "version": "0.5.2",
             "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.2.tgz",
             "integrity": "sha512-E3ZJh4J3S9KfwdjZhe2afj6R9lGIN5Pher1pF39UGrXRqq/VDaGVIGN13BjHd2u8B61hArAGOnso7nBOouW3TQ==",
-            "devOptional": true,
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@babel/parser": "^7.29.0",
@@ -11042,17 +10018,6 @@
                 "url": "https://github.com/fb55/entities?sponsor=1"
             }
         },
-        "node_modules/markdown-table": {
-            "version": "3.0.4",
-            "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-3.0.4.tgz",
-            "integrity": "sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==",
-            "license": "MIT",
-            "peer": true,
-            "funding": {
-                "type": "github",
-                "url": "https://github.com/sponsors/wooorm"
-            }
-        },
         "node_modules/marked": {
             "version": "16.4.2",
             "resolved": "https://registry.npmjs.org/marked/-/marked-16.4.2.tgz",
@@ -11085,183 +10050,6 @@
                 "is-buffer": "~1.1.6"
             }
         },
-        "node_modules/mdast-util-find-and-replace": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/mdast-util-find-and-replace/-/mdast-util-find-and-replace-3.0.2.tgz",
-            "integrity": "sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "@types/mdast": "^4.0.0",
-                "escape-string-regexp": "^5.0.0",
-                "unist-util-is": "^6.0.0",
-                "unist-util-visit-parents": "^6.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/unified"
-            }
-        },
-        "node_modules/mdast-util-find-and-replace/node_modules/escape-string-regexp": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
-            "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
-            "license": "MIT",
-            "peer": true,
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/mdast-util-from-markdown": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.3.tgz",
-            "integrity": "sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "@types/mdast": "^4.0.0",
-                "@types/unist": "^3.0.0",
-                "decode-named-character-reference": "^1.0.0",
-                "devlop": "^1.0.0",
-                "mdast-util-to-string": "^4.0.0",
-                "micromark": "^4.0.0",
-                "micromark-util-decode-numeric-character-reference": "^2.0.0",
-                "micromark-util-decode-string": "^2.0.0",
-                "micromark-util-normalize-identifier": "^2.0.0",
-                "micromark-util-symbol": "^2.0.0",
-                "micromark-util-types": "^2.0.0",
-                "unist-util-stringify-position": "^4.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/unified"
-            }
-        },
-        "node_modules/mdast-util-gfm": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/mdast-util-gfm/-/mdast-util-gfm-3.1.0.tgz",
-            "integrity": "sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "mdast-util-from-markdown": "^2.0.0",
-                "mdast-util-gfm-autolink-literal": "^2.0.0",
-                "mdast-util-gfm-footnote": "^2.0.0",
-                "mdast-util-gfm-strikethrough": "^2.0.0",
-                "mdast-util-gfm-table": "^2.0.0",
-                "mdast-util-gfm-task-list-item": "^2.0.0",
-                "mdast-util-to-markdown": "^2.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/unified"
-            }
-        },
-        "node_modules/mdast-util-gfm-autolink-literal": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/mdast-util-gfm-autolink-literal/-/mdast-util-gfm-autolink-literal-2.0.1.tgz",
-            "integrity": "sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "@types/mdast": "^4.0.0",
-                "ccount": "^2.0.0",
-                "devlop": "^1.0.0",
-                "mdast-util-find-and-replace": "^3.0.0",
-                "micromark-util-character": "^2.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/unified"
-            }
-        },
-        "node_modules/mdast-util-gfm-footnote": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/mdast-util-gfm-footnote/-/mdast-util-gfm-footnote-2.1.0.tgz",
-            "integrity": "sha512-sqpDWlsHn7Ac9GNZQMeUzPQSMzR6Wv0WKRNvQRg0KqHh02fpTz69Qc1QSseNX29bhz1ROIyNyxExfawVKTm1GQ==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "@types/mdast": "^4.0.0",
-                "devlop": "^1.1.0",
-                "mdast-util-from-markdown": "^2.0.0",
-                "mdast-util-to-markdown": "^2.0.0",
-                "micromark-util-normalize-identifier": "^2.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/unified"
-            }
-        },
-        "node_modules/mdast-util-gfm-strikethrough": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/mdast-util-gfm-strikethrough/-/mdast-util-gfm-strikethrough-2.0.0.tgz",
-            "integrity": "sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "@types/mdast": "^4.0.0",
-                "mdast-util-from-markdown": "^2.0.0",
-                "mdast-util-to-markdown": "^2.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/unified"
-            }
-        },
-        "node_modules/mdast-util-gfm-table": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/mdast-util-gfm-table/-/mdast-util-gfm-table-2.0.0.tgz",
-            "integrity": "sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "@types/mdast": "^4.0.0",
-                "devlop": "^1.0.0",
-                "markdown-table": "^3.0.0",
-                "mdast-util-from-markdown": "^2.0.0",
-                "mdast-util-to-markdown": "^2.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/unified"
-            }
-        },
-        "node_modules/mdast-util-gfm-task-list-item": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/mdast-util-gfm-task-list-item/-/mdast-util-gfm-task-list-item-2.0.0.tgz",
-            "integrity": "sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "@types/mdast": "^4.0.0",
-                "devlop": "^1.0.0",
-                "mdast-util-from-markdown": "^2.0.0",
-                "mdast-util-to-markdown": "^2.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/unified"
-            }
-        },
-        "node_modules/mdast-util-phrasing": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/mdast-util-phrasing/-/mdast-util-phrasing-4.1.0.tgz",
-            "integrity": "sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "@types/mdast": "^4.0.0",
-                "unist-util-is": "^6.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/unified"
-            }
-        },
         "node_modules/mdast-util-to-hast": {
             "version": "13.2.1",
             "license": "MIT",
@@ -11275,42 +10063,6 @@
                 "unist-util-position": "^5.0.0",
                 "unist-util-visit": "^5.0.0",
                 "vfile": "^6.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/unified"
-            }
-        },
-        "node_modules/mdast-util-to-markdown": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-2.1.2.tgz",
-            "integrity": "sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "@types/mdast": "^4.0.0",
-                "@types/unist": "^3.0.0",
-                "longest-streak": "^3.0.0",
-                "mdast-util-phrasing": "^4.0.0",
-                "mdast-util-to-string": "^4.0.0",
-                "micromark-util-classify-character": "^2.0.0",
-                "micromark-util-decode-string": "^2.0.0",
-                "unist-util-visit": "^5.0.0",
-                "zwitch": "^2.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/unified"
-            }
-        },
-        "node_modules/mdast-util-to-string": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-4.0.0.tgz",
-            "integrity": "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "@types/mdast": "^4.0.0"
             },
             "funding": {
                 "type": "opencollective",
@@ -11381,317 +10133,6 @@
                 "uuid": "dist/esm/bin/uuid"
             }
         },
-        "node_modules/micromark": {
-            "version": "4.0.2",
-            "resolved": "https://registry.npmjs.org/micromark/-/micromark-4.0.2.tgz",
-            "integrity": "sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==",
-            "funding": [
-                {
-                    "type": "GitHub Sponsors",
-                    "url": "https://github.com/sponsors/unifiedjs"
-                },
-                {
-                    "type": "OpenCollective",
-                    "url": "https://opencollective.com/unified"
-                }
-            ],
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "@types/debug": "^4.0.0",
-                "debug": "^4.0.0",
-                "decode-named-character-reference": "^1.0.0",
-                "devlop": "^1.0.0",
-                "micromark-core-commonmark": "^2.0.0",
-                "micromark-factory-space": "^2.0.0",
-                "micromark-util-character": "^2.0.0",
-                "micromark-util-chunked": "^2.0.0",
-                "micromark-util-combine-extensions": "^2.0.0",
-                "micromark-util-decode-numeric-character-reference": "^2.0.0",
-                "micromark-util-encode": "^2.0.0",
-                "micromark-util-normalize-identifier": "^2.0.0",
-                "micromark-util-resolve-all": "^2.0.0",
-                "micromark-util-sanitize-uri": "^2.0.0",
-                "micromark-util-subtokenize": "^2.0.0",
-                "micromark-util-symbol": "^2.0.0",
-                "micromark-util-types": "^2.0.0"
-            }
-        },
-        "node_modules/micromark-core-commonmark": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/micromark-core-commonmark/-/micromark-core-commonmark-2.0.3.tgz",
-            "integrity": "sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==",
-            "funding": [
-                {
-                    "type": "GitHub Sponsors",
-                    "url": "https://github.com/sponsors/unifiedjs"
-                },
-                {
-                    "type": "OpenCollective",
-                    "url": "https://opencollective.com/unified"
-                }
-            ],
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "decode-named-character-reference": "^1.0.0",
-                "devlop": "^1.0.0",
-                "micromark-factory-destination": "^2.0.0",
-                "micromark-factory-label": "^2.0.0",
-                "micromark-factory-space": "^2.0.0",
-                "micromark-factory-title": "^2.0.0",
-                "micromark-factory-whitespace": "^2.0.0",
-                "micromark-util-character": "^2.0.0",
-                "micromark-util-chunked": "^2.0.0",
-                "micromark-util-classify-character": "^2.0.0",
-                "micromark-util-html-tag-name": "^2.0.0",
-                "micromark-util-normalize-identifier": "^2.0.0",
-                "micromark-util-resolve-all": "^2.0.0",
-                "micromark-util-subtokenize": "^2.0.0",
-                "micromark-util-symbol": "^2.0.0",
-                "micromark-util-types": "^2.0.0"
-            }
-        },
-        "node_modules/micromark-extension-gfm": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/micromark-extension-gfm/-/micromark-extension-gfm-3.0.0.tgz",
-            "integrity": "sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "micromark-extension-gfm-autolink-literal": "^2.0.0",
-                "micromark-extension-gfm-footnote": "^2.0.0",
-                "micromark-extension-gfm-strikethrough": "^2.0.0",
-                "micromark-extension-gfm-table": "^2.0.0",
-                "micromark-extension-gfm-tagfilter": "^2.0.0",
-                "micromark-extension-gfm-task-list-item": "^2.0.0",
-                "micromark-util-combine-extensions": "^2.0.0",
-                "micromark-util-types": "^2.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/unified"
-            }
-        },
-        "node_modules/micromark-extension-gfm-autolink-literal": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/micromark-extension-gfm-autolink-literal/-/micromark-extension-gfm-autolink-literal-2.1.0.tgz",
-            "integrity": "sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "micromark-util-character": "^2.0.0",
-                "micromark-util-sanitize-uri": "^2.0.0",
-                "micromark-util-symbol": "^2.0.0",
-                "micromark-util-types": "^2.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/unified"
-            }
-        },
-        "node_modules/micromark-extension-gfm-footnote": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/micromark-extension-gfm-footnote/-/micromark-extension-gfm-footnote-2.1.0.tgz",
-            "integrity": "sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "devlop": "^1.0.0",
-                "micromark-core-commonmark": "^2.0.0",
-                "micromark-factory-space": "^2.0.0",
-                "micromark-util-character": "^2.0.0",
-                "micromark-util-normalize-identifier": "^2.0.0",
-                "micromark-util-sanitize-uri": "^2.0.0",
-                "micromark-util-symbol": "^2.0.0",
-                "micromark-util-types": "^2.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/unified"
-            }
-        },
-        "node_modules/micromark-extension-gfm-strikethrough": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/micromark-extension-gfm-strikethrough/-/micromark-extension-gfm-strikethrough-2.1.0.tgz",
-            "integrity": "sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "devlop": "^1.0.0",
-                "micromark-util-chunked": "^2.0.0",
-                "micromark-util-classify-character": "^2.0.0",
-                "micromark-util-resolve-all": "^2.0.0",
-                "micromark-util-symbol": "^2.0.0",
-                "micromark-util-types": "^2.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/unified"
-            }
-        },
-        "node_modules/micromark-extension-gfm-table": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/micromark-extension-gfm-table/-/micromark-extension-gfm-table-2.1.1.tgz",
-            "integrity": "sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "devlop": "^1.0.0",
-                "micromark-factory-space": "^2.0.0",
-                "micromark-util-character": "^2.0.0",
-                "micromark-util-symbol": "^2.0.0",
-                "micromark-util-types": "^2.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/unified"
-            }
-        },
-        "node_modules/micromark-extension-gfm-tagfilter": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/micromark-extension-gfm-tagfilter/-/micromark-extension-gfm-tagfilter-2.0.0.tgz",
-            "integrity": "sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "micromark-util-types": "^2.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/unified"
-            }
-        },
-        "node_modules/micromark-extension-gfm-task-list-item": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/micromark-extension-gfm-task-list-item/-/micromark-extension-gfm-task-list-item-2.1.0.tgz",
-            "integrity": "sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "devlop": "^1.0.0",
-                "micromark-factory-space": "^2.0.0",
-                "micromark-util-character": "^2.0.0",
-                "micromark-util-symbol": "^2.0.0",
-                "micromark-util-types": "^2.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/unified"
-            }
-        },
-        "node_modules/micromark-factory-destination": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/micromark-factory-destination/-/micromark-factory-destination-2.0.1.tgz",
-            "integrity": "sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==",
-            "funding": [
-                {
-                    "type": "GitHub Sponsors",
-                    "url": "https://github.com/sponsors/unifiedjs"
-                },
-                {
-                    "type": "OpenCollective",
-                    "url": "https://opencollective.com/unified"
-                }
-            ],
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "micromark-util-character": "^2.0.0",
-                "micromark-util-symbol": "^2.0.0",
-                "micromark-util-types": "^2.0.0"
-            }
-        },
-        "node_modules/micromark-factory-label": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/micromark-factory-label/-/micromark-factory-label-2.0.1.tgz",
-            "integrity": "sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==",
-            "funding": [
-                {
-                    "type": "GitHub Sponsors",
-                    "url": "https://github.com/sponsors/unifiedjs"
-                },
-                {
-                    "type": "OpenCollective",
-                    "url": "https://opencollective.com/unified"
-                }
-            ],
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "devlop": "^1.0.0",
-                "micromark-util-character": "^2.0.0",
-                "micromark-util-symbol": "^2.0.0",
-                "micromark-util-types": "^2.0.0"
-            }
-        },
-        "node_modules/micromark-factory-space": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/micromark-factory-space/-/micromark-factory-space-2.0.1.tgz",
-            "integrity": "sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==",
-            "funding": [
-                {
-                    "type": "GitHub Sponsors",
-                    "url": "https://github.com/sponsors/unifiedjs"
-                },
-                {
-                    "type": "OpenCollective",
-                    "url": "https://opencollective.com/unified"
-                }
-            ],
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "micromark-util-character": "^2.0.0",
-                "micromark-util-types": "^2.0.0"
-            }
-        },
-        "node_modules/micromark-factory-title": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/micromark-factory-title/-/micromark-factory-title-2.0.1.tgz",
-            "integrity": "sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw==",
-            "funding": [
-                {
-                    "type": "GitHub Sponsors",
-                    "url": "https://github.com/sponsors/unifiedjs"
-                },
-                {
-                    "type": "OpenCollective",
-                    "url": "https://opencollective.com/unified"
-                }
-            ],
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "micromark-factory-space": "^2.0.0",
-                "micromark-util-character": "^2.0.0",
-                "micromark-util-symbol": "^2.0.0",
-                "micromark-util-types": "^2.0.0"
-            }
-        },
-        "node_modules/micromark-factory-whitespace": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/micromark-factory-whitespace/-/micromark-factory-whitespace-2.0.1.tgz",
-            "integrity": "sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ==",
-            "funding": [
-                {
-                    "type": "GitHub Sponsors",
-                    "url": "https://github.com/sponsors/unifiedjs"
-                },
-                {
-                    "type": "OpenCollective",
-                    "url": "https://opencollective.com/unified"
-                }
-            ],
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "micromark-factory-space": "^2.0.0",
-                "micromark-util-character": "^2.0.0",
-                "micromark-util-symbol": "^2.0.0",
-                "micromark-util-types": "^2.0.0"
-            }
-        },
         "node_modules/micromark-util-character": {
             "version": "2.1.1",
             "funding": [
@@ -11710,112 +10151,6 @@
                 "micromark-util-types": "^2.0.0"
             }
         },
-        "node_modules/micromark-util-chunked": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/micromark-util-chunked/-/micromark-util-chunked-2.0.1.tgz",
-            "integrity": "sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==",
-            "funding": [
-                {
-                    "type": "GitHub Sponsors",
-                    "url": "https://github.com/sponsors/unifiedjs"
-                },
-                {
-                    "type": "OpenCollective",
-                    "url": "https://opencollective.com/unified"
-                }
-            ],
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "micromark-util-symbol": "^2.0.0"
-            }
-        },
-        "node_modules/micromark-util-classify-character": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/micromark-util-classify-character/-/micromark-util-classify-character-2.0.1.tgz",
-            "integrity": "sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q==",
-            "funding": [
-                {
-                    "type": "GitHub Sponsors",
-                    "url": "https://github.com/sponsors/unifiedjs"
-                },
-                {
-                    "type": "OpenCollective",
-                    "url": "https://opencollective.com/unified"
-                }
-            ],
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "micromark-util-character": "^2.0.0",
-                "micromark-util-symbol": "^2.0.0",
-                "micromark-util-types": "^2.0.0"
-            }
-        },
-        "node_modules/micromark-util-combine-extensions": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/micromark-util-combine-extensions/-/micromark-util-combine-extensions-2.0.1.tgz",
-            "integrity": "sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg==",
-            "funding": [
-                {
-                    "type": "GitHub Sponsors",
-                    "url": "https://github.com/sponsors/unifiedjs"
-                },
-                {
-                    "type": "OpenCollective",
-                    "url": "https://opencollective.com/unified"
-                }
-            ],
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "micromark-util-chunked": "^2.0.0",
-                "micromark-util-types": "^2.0.0"
-            }
-        },
-        "node_modules/micromark-util-decode-numeric-character-reference": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/micromark-util-decode-numeric-character-reference/-/micromark-util-decode-numeric-character-reference-2.0.2.tgz",
-            "integrity": "sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==",
-            "funding": [
-                {
-                    "type": "GitHub Sponsors",
-                    "url": "https://github.com/sponsors/unifiedjs"
-                },
-                {
-                    "type": "OpenCollective",
-                    "url": "https://opencollective.com/unified"
-                }
-            ],
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "micromark-util-symbol": "^2.0.0"
-            }
-        },
-        "node_modules/micromark-util-decode-string": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/micromark-util-decode-string/-/micromark-util-decode-string-2.0.1.tgz",
-            "integrity": "sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ==",
-            "funding": [
-                {
-                    "type": "GitHub Sponsors",
-                    "url": "https://github.com/sponsors/unifiedjs"
-                },
-                {
-                    "type": "OpenCollective",
-                    "url": "https://opencollective.com/unified"
-                }
-            ],
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "decode-named-character-reference": "^1.0.0",
-                "micromark-util-character": "^2.0.0",
-                "micromark-util-decode-numeric-character-reference": "^2.0.0",
-                "micromark-util-symbol": "^2.0.0"
-            }
-        },
         "node_modules/micromark-util-encode": {
             "version": "2.0.1",
             "funding": [
@@ -11829,63 +10164,6 @@
                 }
             ],
             "license": "MIT"
-        },
-        "node_modules/micromark-util-html-tag-name": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/micromark-util-html-tag-name/-/micromark-util-html-tag-name-2.0.1.tgz",
-            "integrity": "sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA==",
-            "funding": [
-                {
-                    "type": "GitHub Sponsors",
-                    "url": "https://github.com/sponsors/unifiedjs"
-                },
-                {
-                    "type": "OpenCollective",
-                    "url": "https://opencollective.com/unified"
-                }
-            ],
-            "license": "MIT",
-            "peer": true
-        },
-        "node_modules/micromark-util-normalize-identifier": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/micromark-util-normalize-identifier/-/micromark-util-normalize-identifier-2.0.1.tgz",
-            "integrity": "sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==",
-            "funding": [
-                {
-                    "type": "GitHub Sponsors",
-                    "url": "https://github.com/sponsors/unifiedjs"
-                },
-                {
-                    "type": "OpenCollective",
-                    "url": "https://opencollective.com/unified"
-                }
-            ],
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "micromark-util-symbol": "^2.0.0"
-            }
-        },
-        "node_modules/micromark-util-resolve-all": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/micromark-util-resolve-all/-/micromark-util-resolve-all-2.0.1.tgz",
-            "integrity": "sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==",
-            "funding": [
-                {
-                    "type": "GitHub Sponsors",
-                    "url": "https://github.com/sponsors/unifiedjs"
-                },
-                {
-                    "type": "OpenCollective",
-                    "url": "https://opencollective.com/unified"
-                }
-            ],
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "micromark-util-types": "^2.0.0"
-            }
         },
         "node_modules/micromark-util-sanitize-uri": {
             "version": "2.0.1",
@@ -11904,29 +10182,6 @@
                 "micromark-util-character": "^2.0.0",
                 "micromark-util-encode": "^2.0.0",
                 "micromark-util-symbol": "^2.0.0"
-            }
-        },
-        "node_modules/micromark-util-subtokenize": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/micromark-util-subtokenize/-/micromark-util-subtokenize-2.1.0.tgz",
-            "integrity": "sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA==",
-            "funding": [
-                {
-                    "type": "GitHub Sponsors",
-                    "url": "https://github.com/sponsors/unifiedjs"
-                },
-                {
-                    "type": "OpenCollective",
-                    "url": "https://opencollective.com/unified"
-                }
-            ],
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "devlop": "^1.0.0",
-                "micromark-util-chunked": "^2.0.0",
-                "micromark-util-symbol": "^2.0.0",
-                "micromark-util-types": "^2.0.0"
             }
         },
         "node_modules/micromark-util-symbol": {
@@ -12192,6 +10447,7 @@
         },
         "node_modules/ms": {
             "version": "2.1.3",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/muggle-string": {
@@ -12258,22 +10514,6 @@
                 "node": ">=10.5.0"
             }
         },
-        "node_modules/node-emoji": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/node-emoji/-/node-emoji-2.2.0.tgz",
-            "integrity": "sha512-Z3lTE9pLaJF47NyMhd4ww1yFTAP8YhYI8SleJiHzM46Fgpm5cnNzSl9XfzFNqbaz+VlJrIj3fXQ4DeN1Rjm6cw==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "@sindresorhus/is": "^4.6.0",
-                "char-regex": "^1.0.2",
-                "emojilib": "^2.4.0",
-                "skin-tone": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=18"
-            }
-        },
         "node_modules/node-fetch-commonjs": {
             "version": "3.3.2",
             "license": "MIT",
@@ -12291,6 +10531,7 @@
         },
         "node_modules/node-fetch-native": {
             "version": "1.6.7",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/node-gyp-build": {
@@ -12348,6 +10589,7 @@
         },
         "node_modules/nypm": {
             "version": "0.6.5",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "citty": "^0.2.0",
@@ -12363,6 +10605,7 @@
         },
         "node_modules/nypm/node_modules/citty": {
             "version": "0.2.0",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/object-assign": {
@@ -12394,6 +10637,7 @@
         },
         "node_modules/ohash": {
             "version": "2.0.11",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/once": {
@@ -12538,35 +10782,9 @@
                 "node": ">=6"
             }
         },
-        "node_modules/parse-entities": {
-            "version": "4.0.2",
-            "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-4.0.2.tgz",
-            "integrity": "sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "@types/unist": "^2.0.0",
-                "character-entities-legacy": "^3.0.0",
-                "character-reference-invalid": "^2.0.0",
-                "decode-named-character-reference": "^1.0.0",
-                "is-alphanumerical": "^2.0.0",
-                "is-decimal": "^2.0.0",
-                "is-hexadecimal": "^2.0.0"
-            },
-            "funding": {
-                "type": "github",
-                "url": "https://github.com/sponsors/wooorm"
-            }
-        },
-        "node_modules/parse-entities/node_modules/@types/unist": {
-            "version": "2.0.11",
-            "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.11.tgz",
-            "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==",
-            "license": "MIT",
-            "peer": true
-        },
         "node_modules/parse5": {
             "version": "8.0.0",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "entities": "^6.0.0"
@@ -12577,6 +10795,7 @@
         },
         "node_modules/parse5/node_modules/entities": {
             "version": "6.0.1",
+            "dev": true,
             "license": "BSD-2-Clause",
             "engines": {
                 "node": ">=0.12"
@@ -12706,6 +10925,7 @@
         },
         "node_modules/perfect-debounce": {
             "version": "2.1.0",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/picocolors": {
@@ -12746,6 +10966,7 @@
         },
         "node_modules/pkg-types": {
             "version": "2.3.0",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "confbox": "^0.2.2",
@@ -12924,32 +11145,6 @@
             },
             "engines": {
                 "node": ">=6.0.0"
-            }
-        },
-        "node_modules/pretty-format": {
-            "version": "27.5.1",
-            "dev": true,
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "ansi-regex": "^5.0.1",
-                "ansi-styles": "^5.0.0",
-                "react-is": "^17.0.1"
-            },
-            "engines": {
-                "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
-            }
-        },
-        "node_modules/pretty-format/node_modules/ansi-styles": {
-            "version": "5.2.0",
-            "dev": true,
-            "license": "MIT",
-            "peer": true,
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
             }
         },
         "node_modules/prismjs": {
@@ -13223,46 +11418,9 @@
                 "node": ">= 12"
             }
         },
-        "node_modules/rc9": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/rc9/-/rc9-3.0.0.tgz",
-            "integrity": "sha512-MGOue0VqscKWQ104udASX/3GYDcKyPI4j4F8gu/jHHzglpmy9a/anZK3PNe8ug6aZFl+9GxLtdhe3kVZuMaQbA==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "defu": "^6.1.4",
-                "destr": "^2.0.5"
-            }
-        },
-        "node_modules/react": {
-            "version": "19.2.4",
-            "dev": true,
-            "license": "MIT",
-            "peer": true,
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/react-dom": {
-            "version": "19.2.4",
-            "dev": true,
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "scheduler": "^0.27.0"
-            },
-            "peerDependencies": {
-                "react": "^19.2.4"
-            }
-        },
-        "node_modules/react-is": {
-            "version": "17.0.2",
-            "dev": true,
-            "license": "MIT",
-            "peer": true
-        },
         "node_modules/readdirp": {
             "version": "5.0.0",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">= 20.19.0"
@@ -13322,237 +11480,6 @@
             "resolved": "https://registry.npmjs.org/regex-utilities/-/regex-utilities-2.3.0.tgz",
             "integrity": "sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng==",
             "license": "MIT"
-        },
-        "node_modules/rehype-external-links": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/rehype-external-links/-/rehype-external-links-3.0.0.tgz",
-            "integrity": "sha512-yp+e5N9V3C6bwBeAC4n796kc86M4gJCdlVhiMTxIrJG5UHDMh+PJANf9heqORJbt1nrCbDwIlAZKjANIaVBbvw==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "@types/hast": "^3.0.0",
-                "@ungap/structured-clone": "^1.0.0",
-                "hast-util-is-element": "^3.0.0",
-                "is-absolute-url": "^4.0.0",
-                "space-separated-tokens": "^2.0.0",
-                "unist-util-visit": "^5.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/unified"
-            }
-        },
-        "node_modules/rehype-minify-whitespace": {
-            "version": "6.0.2",
-            "resolved": "https://registry.npmjs.org/rehype-minify-whitespace/-/rehype-minify-whitespace-6.0.2.tgz",
-            "integrity": "sha512-Zk0pyQ06A3Lyxhe9vGtOtzz3Z0+qZ5+7icZ/PL/2x1SHPbKao5oB/g/rlc6BCTajqBb33JcOe71Ye1oFsuYbnw==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "@types/hast": "^3.0.0",
-                "hast-util-minify-whitespace": "^1.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/unified"
-            }
-        },
-        "node_modules/rehype-raw": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/rehype-raw/-/rehype-raw-7.0.0.tgz",
-            "integrity": "sha512-/aE8hCfKlQeA8LmyeyQvQF3eBiLRGNlfBJEvWH7ivp9sBqs7TNqBL5X3v157rM4IFETqDnIOO+z5M/biZbo9Ww==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "@types/hast": "^3.0.0",
-                "hast-util-raw": "^9.0.0",
-                "vfile": "^6.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/unified"
-            }
-        },
-        "node_modules/rehype-remark": {
-            "version": "10.0.1",
-            "resolved": "https://registry.npmjs.org/rehype-remark/-/rehype-remark-10.0.1.tgz",
-            "integrity": "sha512-EmDndlb5NVwXGfUa4c9GPK+lXeItTilLhE6ADSaQuHr4JUlKw9MidzGzx4HpqZrNCt6vnHmEifXQiiA+CEnjYQ==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "@types/hast": "^3.0.0",
-                "@types/mdast": "^4.0.0",
-                "hast-util-to-mdast": "^10.0.0",
-                "unified": "^11.0.0",
-                "vfile": "^6.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/unified"
-            }
-        },
-        "node_modules/rehype-slug": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/rehype-slug/-/rehype-slug-6.0.0.tgz",
-            "integrity": "sha512-lWyvf/jwu+oS5+hL5eClVd3hNdmwM1kAC0BUvEGD19pajQMIzcNUd/k9GsfQ+FfECvX+JE+e9/btsKH0EjJT6A==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "@types/hast": "^3.0.0",
-                "github-slugger": "^2.0.0",
-                "hast-util-heading-rank": "^3.0.0",
-                "hast-util-to-string": "^3.0.0",
-                "unist-util-visit": "^5.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/unified"
-            }
-        },
-        "node_modules/rehype-sort-attribute-values": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/rehype-sort-attribute-values/-/rehype-sort-attribute-values-5.0.1.tgz",
-            "integrity": "sha512-lU3ABJO5frbUgV132YS6SL7EISf//irIm9KFMaeu5ixHfgWf6jhe+09Uf/Ef8pOYUJWKOaQJDRJGCXs6cNsdsQ==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "@types/hast": "^3.0.0",
-                "hast-util-is-element": "^3.0.0",
-                "unist-util-visit": "^5.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/unified"
-            }
-        },
-        "node_modules/rehype-sort-attributes": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/rehype-sort-attributes/-/rehype-sort-attributes-5.0.1.tgz",
-            "integrity": "sha512-Bxo+AKUIELcnnAZwJDt5zUDDRpt4uzhfz9d0PVGhcxYWsbFj5Cv35xuWxu5r1LeYNFNhgGqsr9Q2QiIOM/Qctg==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "@types/hast": "^3.0.0",
-                "unist-util-visit": "^5.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/unified"
-            }
-        },
-        "node_modules/remark-emoji": {
-            "version": "5.0.2",
-            "resolved": "https://registry.npmjs.org/remark-emoji/-/remark-emoji-5.0.2.tgz",
-            "integrity": "sha512-IyIqGELcyK5AVdLFafoiNww+Eaw/F+rGrNSXoKucjo95uL267zrddgxGM83GN1wFIb68pyDuAsY3m5t2Cav1pQ==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "@types/mdast": "^4.0.4",
-                "emoticon": "^4.0.1",
-                "mdast-util-find-and-replace": "^3.0.1",
-                "node-emoji": "^2.1.3",
-                "unified": "^11.0.4"
-            },
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/remark-gfm": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/remark-gfm/-/remark-gfm-4.0.1.tgz",
-            "integrity": "sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "@types/mdast": "^4.0.0",
-                "mdast-util-gfm": "^3.0.0",
-                "micromark-extension-gfm": "^3.0.0",
-                "remark-parse": "^11.0.0",
-                "remark-stringify": "^11.0.0",
-                "unified": "^11.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/unified"
-            }
-        },
-        "node_modules/remark-mdc": {
-            "version": "3.10.0",
-            "resolved": "https://registry.npmjs.org/remark-mdc/-/remark-mdc-3.10.0.tgz",
-            "integrity": "sha512-gJhrSs4bGyqr7eSuLoaLlpmiDZrJ9fP/8gTA/w1CnKnW/mfxc9VKM+ndzpOxHQnpAU4tjD8QqF6SMLiOvIVTYA==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "@types/mdast": "^4.0.4",
-                "@types/unist": "^3.0.3",
-                "flat": "^6.0.1",
-                "mdast-util-from-markdown": "^2.0.2",
-                "mdast-util-to-markdown": "^2.1.2",
-                "micromark": "^4.0.2",
-                "micromark-core-commonmark": "^2.0.3",
-                "micromark-factory-space": "^2.0.1",
-                "micromark-factory-whitespace": "^2.0.1",
-                "micromark-util-character": "^2.1.1",
-                "micromark-util-types": "^2.0.2",
-                "parse-entities": "^4.0.2",
-                "scule": "^1.3.0",
-                "stringify-entities": "^4.0.4",
-                "unified": "^11.0.5",
-                "unist-util-visit": "^5.0.0",
-                "unist-util-visit-parents": "^6.0.2",
-                "yaml": "^2.8.2"
-            }
-        },
-        "node_modules/remark-parse": {
-            "version": "11.0.0",
-            "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-11.0.0.tgz",
-            "integrity": "sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "@types/mdast": "^4.0.0",
-                "mdast-util-from-markdown": "^2.0.0",
-                "micromark-util-types": "^2.0.0",
-                "unified": "^11.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/unified"
-            }
-        },
-        "node_modules/remark-rehype": {
-            "version": "11.1.2",
-            "resolved": "https://registry.npmjs.org/remark-rehype/-/remark-rehype-11.1.2.tgz",
-            "integrity": "sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "@types/hast": "^3.0.0",
-                "@types/mdast": "^4.0.0",
-                "mdast-util-to-hast": "^13.0.0",
-                "unified": "^11.0.0",
-                "vfile": "^6.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/unified"
-            }
-        },
-        "node_modules/remark-stringify": {
-            "version": "11.0.0",
-            "resolved": "https://registry.npmjs.org/remark-stringify/-/remark-stringify-11.0.0.tgz",
-            "integrity": "sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "@types/mdast": "^4.0.0",
-                "mdast-util-to-markdown": "^2.0.0",
-                "unified": "^11.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/unified"
-            }
         },
         "node_modules/repeat-string": {
             "version": "1.6.1",
@@ -13744,205 +11671,6 @@
             "resolved": "https://registry.npmjs.org/robust-predicates/-/robust-predicates-3.0.2.tgz",
             "integrity": "sha512-IXgzBWvWQwE6PrDI05OvmXUIruQTcoMDzRsOd5CDvHCVLcLHMTSYvOK5Cm46kWqlV3yAbuSpBZdJ5oP5OUoStg==",
             "license": "Unlicense"
-        },
-        "node_modules/rolldown": {
-            "version": "1.0.0-beta.53",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@oxc-project/types": "=0.101.0",
-                "@rolldown/pluginutils": "1.0.0-beta.53"
-            },
-            "bin": {
-                "rolldown": "bin/cli.mjs"
-            },
-            "engines": {
-                "node": "^20.19.0 || >=22.12.0"
-            },
-            "optionalDependencies": {
-                "@rolldown/binding-android-arm64": "1.0.0-beta.53",
-                "@rolldown/binding-darwin-arm64": "1.0.0-beta.53",
-                "@rolldown/binding-darwin-x64": "1.0.0-beta.53",
-                "@rolldown/binding-freebsd-x64": "1.0.0-beta.53",
-                "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-beta.53",
-                "@rolldown/binding-linux-arm64-gnu": "1.0.0-beta.53",
-                "@rolldown/binding-linux-arm64-musl": "1.0.0-beta.53",
-                "@rolldown/binding-linux-x64-gnu": "1.0.0-beta.53",
-                "@rolldown/binding-linux-x64-musl": "1.0.0-beta.53",
-                "@rolldown/binding-openharmony-arm64": "1.0.0-beta.53",
-                "@rolldown/binding-wasm32-wasi": "1.0.0-beta.53",
-                "@rolldown/binding-win32-arm64-msvc": "1.0.0-beta.53",
-                "@rolldown/binding-win32-x64-msvc": "1.0.0-beta.53"
-            }
-        },
-        "node_modules/rolldown-vite": {
-            "version": "7.3.1",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@oxc-project/runtime": "0.101.0",
-                "fdir": "^6.5.0",
-                "lightningcss": "^1.30.2",
-                "picomatch": "^4.0.3",
-                "postcss": "^8.5.6",
-                "rolldown": "1.0.0-beta.53",
-                "tinyglobby": "^0.2.15"
-            },
-            "bin": {
-                "vite": "bin/vite.js"
-            },
-            "engines": {
-                "node": "^20.19.0 || >=22.12.0"
-            },
-            "funding": {
-                "url": "https://github.com/vitejs/vite?sponsor=1"
-            },
-            "optionalDependencies": {
-                "fsevents": "~2.3.3"
-            },
-            "peerDependencies": {
-                "@types/node": "^20.19.0 || >=22.12.0",
-                "esbuild": "^0.27.0",
-                "jiti": ">=1.21.0",
-                "less": "^4.0.0",
-                "sass": "^1.70.0",
-                "sass-embedded": "^1.70.0",
-                "stylus": ">=0.54.8",
-                "sugarss": "^5.0.0",
-                "terser": "^5.16.0",
-                "tsx": "^4.8.1",
-                "yaml": "^2.4.2"
-            },
-            "peerDependenciesMeta": {
-                "@types/node": {
-                    "optional": true
-                },
-                "esbuild": {
-                    "optional": true
-                },
-                "jiti": {
-                    "optional": true
-                },
-                "less": {
-                    "optional": true
-                },
-                "sass": {
-                    "optional": true
-                },
-                "sass-embedded": {
-                    "optional": true
-                },
-                "stylus": {
-                    "optional": true
-                },
-                "sugarss": {
-                    "optional": true
-                },
-                "terser": {
-                    "optional": true
-                },
-                "tsx": {
-                    "optional": true
-                },
-                "yaml": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/rolldown-vite/node_modules/fdir": {
-            "version": "6.5.0",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=12.0.0"
-            },
-            "peerDependencies": {
-                "picomatch": "^3 || ^4"
-            },
-            "peerDependenciesMeta": {
-                "picomatch": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/rolldown-vite/node_modules/fsevents": {
-            "version": "2.3.3",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "darwin"
-            ],
-            "engines": {
-                "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-            }
-        },
-        "node_modules/rolldown-vite/node_modules/picomatch": {
-            "version": "4.0.4",
-            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-            "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/jonschlinkert"
-            }
-        },
-        "node_modules/rolldown/node_modules/@rolldown/binding-darwin-arm64": {
-            "version": "1.0.0-beta.53",
-            "cpu": [
-                "arm64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "darwin"
-            ],
-            "engines": {
-                "node": "^20.19.0 || >=22.12.0"
-            }
-        },
-        "node_modules/rolldown/node_modules/@rolldown/binding-darwin-x64": {
-            "version": "1.0.0-beta.53",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-beta.53.tgz",
-            "integrity": "sha512-GTXe+mxsCGUnJOFMhfGWmefP7Q9TpYUseHvhAhr21nCTgdS8jPsvirb0tJwM3lN0/u/cg7bpFNa16fQrjKrCjQ==",
-            "cpu": [
-                "x64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "darwin"
-            ],
-            "engines": {
-                "node": "^20.19.0 || >=22.12.0"
-            }
-        },
-        "node_modules/rolldown/node_modules/@rolldown/binding-linux-x64-gnu": {
-            "version": "1.0.0-beta.53",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-beta.53.tgz",
-            "integrity": "sha512-qL+63WKVQs1CMvFedlPt0U9PiEKJOAL/bsHMKUDS6Vp2Q+YAv/QLPu8rcvkfIMvQ0FPU2WL0aX4eWwF6e/GAnA==",
-            "cpu": [
-                "x64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": "^20.19.0 || >=22.12.0"
-            }
-        },
-        "node_modules/rolldown/node_modules/@rolldown/pluginutils": {
-            "version": "1.0.0-beta.53",
-            "dev": true,
-            "license": "MIT"
         },
         "node_modules/rollup-plugin-copy": {
             "version": "3.5.0",
@@ -14154,19 +11882,6 @@
                 "node": ">=v12.22.7"
             }
         },
-        "node_modules/scheduler": {
-            "version": "0.27.0",
-            "dev": true,
-            "license": "MIT",
-            "peer": true
-        },
-        "node_modules/scule": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/scule/-/scule-1.3.0.tgz",
-            "integrity": "sha512-6FtHJEvt+pVMIB9IBY+IcCJ6Z5f1iQnytgyfKMhDKgmzYG+TeH/wx1y3l27rshSbLiSanrR9ffZDrEsmjlQF2g==",
-            "license": "MIT",
-            "peer": true
-        },
         "node_modules/semver": {
             "version": "7.7.4",
             "license": "ISC",
@@ -14331,19 +12046,6 @@
             },
             "engines": {
                 "node": ">=18"
-            }
-        },
-        "node_modules/skin-tone": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/skin-tone/-/skin-tone-2.0.0.tgz",
-            "integrity": "sha512-kUMbT1oBJCpgrnKoSr0o6wPtvRWT9W9UKvGLwfJYO2WuahZRHOpEyL1ckyMGgMWh0UdpmaoFqKKD29WTomNEGA==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "unicode-emoji-modifier-base": "^1.0.0"
-            },
-            "engines": {
-                "node": ">=8"
             }
         },
         "node_modules/slash": {
@@ -14783,6 +12485,7 @@
         },
         "node_modules/tinyglobby": {
             "version": "0.2.15",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "fdir": "^6.5.0",
@@ -14797,6 +12500,7 @@
         },
         "node_modules/tinyglobby/node_modules/fdir": {
             "version": "6.5.0",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=12.0.0"
@@ -14814,6 +12518,7 @@
             "version": "4.0.4",
             "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
             "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=12"
@@ -14948,28 +12653,6 @@
                 "url": "https://github.com/sponsors/wooorm"
             }
         },
-        "node_modules/trim-trailing-lines": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/trim-trailing-lines/-/trim-trailing-lines-2.1.0.tgz",
-            "integrity": "sha512-5UR5Biq4VlVOtzqkm2AZlgvSlDJtME46uV0br0gENbwN4l5+mMKT4b9gJKqWtuL2zAIqajGJGuvbCbcAJUZqBg==",
-            "license": "MIT",
-            "peer": true,
-            "funding": {
-                "type": "github",
-                "url": "https://github.com/sponsors/wooorm"
-            }
-        },
-        "node_modules/trough": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/trough/-/trough-2.2.0.tgz",
-            "integrity": "sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==",
-            "license": "MIT",
-            "peer": true,
-            "funding": {
-                "type": "github",
-                "url": "https://github.com/sponsors/wooorm"
-            }
-        },
         "node_modules/ts-api-utils": {
             "version": "2.5.0",
             "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
@@ -15093,7 +12776,7 @@
         },
         "node_modules/typescript": {
             "version": "5.9.3",
-            "devOptional": true,
+            "dev": true,
             "license": "Apache-2.0",
             "bin": {
                 "tsc": "bin/tsc",
@@ -15137,48 +12820,6 @@
             "integrity": "sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q==",
             "license": "MIT"
         },
-        "node_modules/unctx": {
-            "version": "2.5.0",
-            "resolved": "https://registry.npmjs.org/unctx/-/unctx-2.5.0.tgz",
-            "integrity": "sha512-p+Rz9x0R7X+CYDkT+Xg8/GhpcShTlU8n+cf9OtOEf7zEQsNcCZO1dPKNRDqvUTaq+P32PMMkxWHwfrxkqfqAYg==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "acorn": "^8.15.0",
-                "estree-walker": "^3.0.3",
-                "magic-string": "^0.30.21",
-                "unplugin": "^2.3.11"
-            }
-        },
-        "node_modules/unctx/node_modules/picomatch": {
-            "version": "4.0.4",
-            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-            "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
-            "license": "MIT",
-            "peer": true,
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/jonschlinkert"
-            }
-        },
-        "node_modules/unctx/node_modules/unplugin": {
-            "version": "2.3.11",
-            "resolved": "https://registry.npmjs.org/unplugin/-/unplugin-2.3.11.tgz",
-            "integrity": "sha512-5uKD0nqiYVzlmCRs01Fhs2BdkEgBS3SAVP6ndrBsuK42iC2+JHyxM05Rm9G8+5mkmRtzMZGY8Ct5+mliZxU/Ww==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "@jridgewell/remapping": "^2.3.5",
-                "acorn": "^8.15.0",
-                "picomatch": "^4.0.3",
-                "webpack-virtual-modules": "^0.6.2"
-            },
-            "engines": {
-                "node": ">=18.12.0"
-            }
-        },
         "node_modules/undici": {
             "version": "5.29.0",
             "dev": true,
@@ -15193,65 +12834,6 @@
         "node_modules/undici-types": {
             "version": "7.18.2",
             "license": "MIT"
-        },
-        "node_modules/unicode-emoji-modifier-base": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/unicode-emoji-modifier-base/-/unicode-emoji-modifier-base-1.0.0.tgz",
-            "integrity": "sha512-yLSH4py7oFH3oG/9K+XWrz1pSi3dfUrWEnInbxMfArOfc1+33BlGPQtLsOYwvdMy11AwUBetYuaRxSPqgkq+8g==",
-            "license": "MIT",
-            "peer": true,
-            "engines": {
-                "node": ">=4"
-            }
-        },
-        "node_modules/unified": {
-            "version": "11.0.5",
-            "resolved": "https://registry.npmjs.org/unified/-/unified-11.0.5.tgz",
-            "integrity": "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "@types/unist": "^3.0.0",
-                "bail": "^2.0.0",
-                "devlop": "^1.0.0",
-                "extend": "^3.0.0",
-                "is-plain-obj": "^4.0.0",
-                "trough": "^2.0.0",
-                "vfile": "^6.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/unified"
-            }
-        },
-        "node_modules/unist-builder": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/unist-builder/-/unist-builder-4.0.0.tgz",
-            "integrity": "sha512-wmRFnH+BLpZnTKpc5L7O67Kac89s9HMrtELpnNaE6TAobq5DTZZs5YaTQfAZBA9bFPECx2uVAPO31c+GVug8mg==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "@types/unist": "^3.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/unified"
-            }
-        },
-        "node_modules/unist-util-find-after": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/unist-util-find-after/-/unist-util-find-after-5.0.0.tgz",
-            "integrity": "sha512-amQa0Ep2m6hE2g72AugUItjbuM8X8cGQnFoHk0pGfrFeT9GZhzN5SW8nRsiGKK7Aif4CrACPENkA6P/Lw6fHGQ==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "@types/unist": "^3.0.0",
-                "unist-util-is": "^6.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/unified"
-            }
         },
         "node_modules/unist-util-is": {
             "version": "6.0.1",
@@ -15340,38 +12922,6 @@
             "version": "3.0.0",
             "license": "MIT"
         },
-        "node_modules/untyped": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/untyped/-/untyped-2.0.0.tgz",
-            "integrity": "sha512-nwNCjxJTjNuLCgFr42fEak5OcLuB3ecca+9ksPFNvtfYSLpjf+iJqSIaSnIile6ZPbKYxI5k2AfXqeopGudK/g==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "citty": "^0.1.6",
-                "defu": "^6.1.4",
-                "jiti": "^2.4.2",
-                "knitwork": "^1.2.0",
-                "scule": "^1.3.0"
-            },
-            "bin": {
-                "untyped": "dist/cli.mjs"
-            }
-        },
-        "node_modules/unwasm": {
-            "version": "0.5.3",
-            "resolved": "https://registry.npmjs.org/unwasm/-/unwasm-0.5.3.tgz",
-            "integrity": "sha512-keBgTSfp3r6+s9ZcSma+0chwxQdmLbB5+dAD9vjtB21UTMYuKAxHXCU1K2CbCtnP09EaWeRvACnXk0EJtUx+hw==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "exsolve": "^1.0.8",
-                "knitwork": "^1.3.0",
-                "magic-string": "^0.30.21",
-                "mlly": "^1.8.0",
-                "pathe": "^2.0.3",
-                "pkg-types": "^2.3.0"
-            }
-        },
         "node_modules/update-browserslist-db": {
             "version": "1.2.3",
             "dev": true,
@@ -15455,21 +13005,6 @@
                 "url": "https://opencollective.com/unified"
             }
         },
-        "node_modules/vfile-location": {
-            "version": "5.0.3",
-            "resolved": "https://registry.npmjs.org/vfile-location/-/vfile-location-5.0.3.tgz",
-            "integrity": "sha512-5yXvWDEgqeiYiBe1lbxYF7UMAIm/IcopxMHrMQDq3nvKcjPKIhZklUKL+AE7J7uApI4kwe2snsK+eI6UTj9EHg==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "@types/unist": "^3.0.0",
-                "vfile": "^6.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/unified"
-            }
-        },
         "node_modules/vfile-message": {
             "version": "4.0.3",
             "license": "MIT",
@@ -15483,19 +13018,16 @@
             }
         },
         "node_modules/vite": {
-            "name": "rolldown-vite",
-            "version": "7.3.1",
-            "resolved": "https://registry.npmjs.org/rolldown-vite/-/rolldown-vite-7.3.1.tgz",
-            "integrity": "sha512-LYzdNAjRHhF2yA4JUQm/QyARyi216N2rpJ0lJZb8E9FU2y5v6Vk+xq/U4XBOxMefpWixT5H3TslmAHm1rqIq2w==",
+            "version": "8.0.3",
+            "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.3.tgz",
+            "integrity": "sha512-B9ifbFudT1TFhfltfaIPgjo9Z3mDynBTJSUYxTjOQruf/zHH+ezCQKcoqO+h7a9Pw9Nm/OtlXAiGT1axBgwqrQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@oxc-project/runtime": "0.101.0",
-                "fdir": "^6.5.0",
-                "lightningcss": "^1.30.2",
-                "picomatch": "^4.0.3",
-                "postcss": "^8.5.6",
-                "rolldown": "1.0.0-beta.53",
+                "lightningcss": "^1.32.0",
+                "picomatch": "^4.0.4",
+                "postcss": "^8.5.8",
+                "rolldown": "1.0.0-rc.12",
                 "tinyglobby": "^0.2.15"
             },
             "bin": {
@@ -15512,6 +13044,7 @@
             },
             "peerDependencies": {
                 "@types/node": "^20.19.0 || >=22.12.0",
+                "@vitejs/devtools": "^0.1.0",
                 "esbuild": "^0.27.0",
                 "jiti": ">=1.21.0",
                 "less": "^4.0.0",
@@ -15525,6 +13058,9 @@
             },
             "peerDependenciesMeta": {
                 "@types/node": {
+                    "optional": true
+                },
+                "@vitejs/devtools": {
                     "optional": true
                 },
                 "esbuild": {
@@ -15559,23 +13095,192 @@
                 }
             }
         },
-        "node_modules/vite/node_modules/fdir": {
-            "version": "6.5.0",
-            "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
-            "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+        "node_modules/vite/node_modules/@oxc-project/types": {
+            "version": "0.122.0",
+            "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.122.0.tgz",
+            "integrity": "sha512-oLAl5kBpV4w69UtFZ9xqcmTi+GENWOcPF7FCrczTiBbmC0ibXxCwyvZGbO39rCVEuLGAZM84DH0pUIyyv/YJzA==",
             "dev": true,
             "license": "MIT",
-            "engines": {
-                "node": ">=12.0.0"
-            },
-            "peerDependencies": {
-                "picomatch": "^3 || ^4"
-            },
-            "peerDependenciesMeta": {
-                "picomatch": {
-                    "optional": true
-                }
+            "funding": {
+                "url": "https://github.com/sponsors/Boshen"
             }
+        },
+        "node_modules/vite/node_modules/@rolldown/binding-android-arm64": {
+            "version": "1.0.0-rc.12",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.12.tgz",
+            "integrity": "sha512-pv1y2Fv0JybcykuiiD3qBOBdz6RteYojRFY1d+b95WVuzx211CRh+ytI/+9iVyWQ6koTh5dawe4S/yRfOFjgaA==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/vite/node_modules/@rolldown/binding-freebsd-x64": {
+            "version": "1.0.0-rc.12",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.12.tgz",
+            "integrity": "sha512-dMLeprcVsyJsKolRXyoTH3NL6qtsT0Y2xeuEA8WQJquWFXkEC4bcu1rLZZSnZRMtAqwtrF/Ib9Ddtpa/Gkge9Q==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/vite/node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+            "version": "1.0.0-rc.12",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.12.tgz",
+            "integrity": "sha512-YqWjAgGC/9M1lz3GR1r1rP79nMgo3mQiiA+Hfo+pvKFK1fAJ1bCi0ZQVh8noOqNacuY1qIcfyVfP6HoyBRZ85Q==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/vite/node_modules/@rolldown/binding-linux-arm64-gnu": {
+            "version": "1.0.0-rc.12",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.12.tgz",
+            "integrity": "sha512-/I5AS4cIroLpslsmzXfwbe5OmWvSsrFuEw3mwvbQ1kDxJ822hFHIx+vsN/TAzNVyepI/j/GSzrtCIwQPeKCLIg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/vite/node_modules/@rolldown/binding-linux-arm64-musl": {
+            "version": "1.0.0-rc.12",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.12.tgz",
+            "integrity": "sha512-V6/wZztnBqlx5hJQqNWwFdxIKN0m38p8Jas+VoSfgH54HSj9tKTt1dZvG6JRHcjh6D7TvrJPWFGaY9UBVOaWPw==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/vite/node_modules/@rolldown/binding-linux-x64-musl": {
+            "version": "1.0.0-rc.12",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.12.tgz",
+            "integrity": "sha512-Jpw/0iwoKWx3LJ2rc1yjFrj+T7iHZn2JDg1Yny1ma0luviFS4mhAIcd1LFNxK3EYu3DHWCps0ydXQ5i/rrJ2ig==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/vite/node_modules/@rolldown/binding-openharmony-arm64": {
+            "version": "1.0.0-rc.12",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.12.tgz",
+            "integrity": "sha512-vRugONE4yMfVn0+7lUKdKvN4D5YusEiPilaoO2sgUWpCvrncvWgPMzK00ZFFJuiPgLwgFNP5eSiUlv2tfc+lpA==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "openharmony"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/vite/node_modules/@rolldown/binding-wasm32-wasi": {
+            "version": "1.0.0-rc.12",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.12.tgz",
+            "integrity": "sha512-ykGiLr/6kkiHc0XnBfmFJuCjr5ZYKKofkx+chJWDjitX+KsJuAmrzWhwyOMSHzPhzOHOy7u9HlFoa5MoAOJ/Zg==",
+            "cpu": [
+                "wasm32"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "@napi-rs/wasm-runtime": "^1.1.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/vite/node_modules/@rolldown/binding-win32-arm64-msvc": {
+            "version": "1.0.0-rc.12",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.12.tgz",
+            "integrity": "sha512-5eOND4duWkwx1AzCxadcOrNeighiLwMInEADT0YM7xeEOOFcovWZCq8dadXgcRHSf3Ulh1kFo/qvzoFiCLOL1Q==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/vite/node_modules/@rolldown/binding-win32-x64-msvc": {
+            "version": "1.0.0-rc.12",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.12.tgz",
+            "integrity": "sha512-PyqoipaswDLAZtot351MLhrlrh6lcZPo2LSYE+VDxbVk24LVKAGOuE4hb8xZQmrPAuEtTZW8E6D2zc5EUZX4Lw==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/vite/node_modules/@rolldown/pluginutils": {
+            "version": "1.0.0-rc.12",
+            "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.12.tgz",
+            "integrity": "sha512-HHMwmarRKvoFsJorqYlFeFRzXZqCt2ETQlEDOb9aqssrnVBB1/+xgTGtuTrIk5vzLNX1MjMtTf7W9z3tsSbrxw==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/vite/node_modules/fsevents": {
             "version": "2.3.3",
@@ -15603,6 +13308,40 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/jonschlinkert"
+            }
+        },
+        "node_modules/vite/node_modules/rolldown": {
+            "version": "1.0.0-rc.12",
+            "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.12.tgz",
+            "integrity": "sha512-yP4USLIMYrwpPHEFB5JGH1uxhcslv6/hL0OyvTuY+3qlOSJvZ7ntYnoWpehBxufkgN0cvXxppuTu5hHa/zPh+A==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@oxc-project/types": "=0.122.0",
+                "@rolldown/pluginutils": "1.0.0-rc.12"
+            },
+            "bin": {
+                "rolldown": "bin/cli.mjs"
+            },
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            },
+            "optionalDependencies": {
+                "@rolldown/binding-android-arm64": "1.0.0-rc.12",
+                "@rolldown/binding-darwin-arm64": "1.0.0-rc.12",
+                "@rolldown/binding-darwin-x64": "1.0.0-rc.12",
+                "@rolldown/binding-freebsd-x64": "1.0.0-rc.12",
+                "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.12",
+                "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.12",
+                "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.12",
+                "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.12",
+                "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.12",
+                "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.12",
+                "@rolldown/binding-linux-x64-musl": "1.0.0-rc.12",
+                "@rolldown/binding-openharmony-arm64": "1.0.0-rc.12",
+                "@rolldown/binding-wasm32-wasi": "1.0.0-rc.12",
+                "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.12",
+                "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.12"
             }
         },
         "node_modules/vitest": {
@@ -16175,17 +13914,6 @@
                 "node": ">=18"
             }
         },
-        "node_modules/web-namespaces": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/web-namespaces/-/web-namespaces-2.0.1.tgz",
-            "integrity": "sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==",
-            "license": "MIT",
-            "peer": true,
-            "funding": {
-                "type": "github",
-                "url": "https://github.com/sponsors/wooorm"
-            }
-        },
         "node_modules/web-streams-polyfill": {
             "version": "3.3.3",
             "license": "MIT",
@@ -16212,6 +13940,7 @@
         },
         "node_modules/webpack-virtual-modules": {
             "version": "0.6.2",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/whatwg-mimetype": {

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -592,6 +592,17 @@
                 "@babel/core": "^7.0.0-0"
             }
         },
+        "node_modules/@babel/runtime": {
+            "version": "7.29.2",
+            "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+            "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
         "node_modules/@babel/runtime-corejs3": {
             "version": "7.29.0",
             "license": "MIT",
@@ -1953,7 +1964,6 @@
         },
         "node_modules/@jridgewell/gen-mapping": {
             "version": "0.3.13",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@jridgewell/sourcemap-codec": "^1.5.0",
@@ -1962,7 +1972,6 @@
         },
         "node_modules/@jridgewell/remapping": {
             "version": "2.3.5",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@jridgewell/gen-mapping": "^0.3.5",
@@ -1971,7 +1980,6 @@
         },
         "node_modules/@jridgewell/resolve-uri": {
             "version": "3.1.2",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=6.0.0"
@@ -1983,7 +1991,6 @@
         },
         "node_modules/@jridgewell/trace-mapping": {
             "version": "0.3.31",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@jridgewell/resolve-uri": "^3.1.0",
@@ -2364,6 +2371,91 @@
             },
             "engines": {
                 "node": ">= 8"
+            }
+        },
+        "node_modules/@nuxt/kit": {
+            "version": "4.4.2",
+            "resolved": "https://registry.npmjs.org/@nuxt/kit/-/kit-4.4.2.tgz",
+            "integrity": "sha512-5+IPRNX2CjkBhuWUwz0hBuLqiaJPRoKzQ+SvcdrQDbAyE+VDeFt74VpSFr5/R0ujrK4b+XnSHUJWdS72w6hsog==",
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "c12": "^3.3.3",
+                "consola": "^3.4.2",
+                "defu": "^6.1.4",
+                "destr": "^2.0.5",
+                "errx": "^0.1.0",
+                "exsolve": "^1.0.8",
+                "ignore": "^7.0.5",
+                "jiti": "^2.6.1",
+                "klona": "^2.0.6",
+                "mlly": "^1.8.1",
+                "ohash": "^2.0.11",
+                "pathe": "^2.0.3",
+                "pkg-types": "^2.3.0",
+                "rc9": "^3.0.0",
+                "scule": "^1.3.0",
+                "semver": "^7.7.4",
+                "tinyglobby": "^0.2.15",
+                "ufo": "^1.6.3",
+                "unctx": "^2.5.0",
+                "untyped": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=18.12.0"
+            }
+        },
+        "node_modules/@nuxtjs/mdc": {
+            "version": "0.21.1",
+            "resolved": "https://registry.npmjs.org/@nuxtjs/mdc/-/mdc-0.21.1.tgz",
+            "integrity": "sha512-DIeUD7IahWVUSoZExysxH9dX51Io6hcQYgGJODq0cMTGqaoDD32lRfHBJxYUmy+sUCV1+1hfa2ixspgJgEd2GA==",
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@nuxt/kit": "^4.4.2",
+                "@shikijs/core": "^4.0.2",
+                "@shikijs/engine-javascript": "^4.0.2",
+                "@shikijs/langs": "^4.0.2",
+                "@shikijs/themes": "^4.0.2",
+                "@shikijs/transformers": "^4.0.2",
+                "@types/hast": "^3.0.4",
+                "@types/mdast": "^4.0.4",
+                "@vue/compiler-core": "^3.5.31",
+                "consola": "^3.4.2",
+                "debug": "^4.4.3",
+                "defu": "^6.1.4",
+                "destr": "^2.0.5",
+                "detab": "^3.0.2",
+                "github-slugger": "^2.0.0",
+                "hast-util-format": "^1.1.0",
+                "hast-util-to-mdast": "^10.1.2",
+                "hast-util-to-string": "^3.0.1",
+                "mdast-util-to-hast": "^13.2.1",
+                "micromark-util-sanitize-uri": "^2.0.1",
+                "parse5": "^8.0.0",
+                "pathe": "^2.0.3",
+                "property-information": "^7.1.0",
+                "rehype-external-links": "^3.0.0",
+                "rehype-minify-whitespace": "^6.0.2",
+                "rehype-raw": "^7.0.0",
+                "rehype-remark": "^10.0.1",
+                "rehype-slug": "^6.0.0",
+                "rehype-sort-attribute-values": "^5.0.1",
+                "rehype-sort-attributes": "^5.0.1",
+                "remark-emoji": "^5.0.2",
+                "remark-gfm": "^4.0.1",
+                "remark-mdc": "^3.10.0",
+                "remark-parse": "^11.0.0",
+                "remark-rehype": "^11.1.2",
+                "remark-stringify": "^11.0.0",
+                "scule": "^1.3.0",
+                "shiki": "^4.0.2",
+                "ufo": "^1.6.3",
+                "unified": "^11.0.5",
+                "unist-builder": "^4.0.0",
+                "unist-util-visit": "^5.1.0",
+                "unwasm": "^0.5.3",
+                "vfile": "^6.0.3"
             }
         },
         "node_modules/@octokit/auth-token": {
@@ -3294,6 +3386,22 @@
             "hasInstallScript": true,
             "license": "Apache-2.0"
         },
+        "node_modules/@shikijs/core": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-4.0.2.tgz",
+            "integrity": "sha512-hxT0YF4ExEqB8G/qFdtJvpmHXBYJ2lWW7qTHDarVkIudPFE6iCIrqdgWxGn5s+ppkGXI0aEGlibI0PAyzP3zlw==",
+            "license": "MIT",
+            "dependencies": {
+                "@shikijs/primitive": "4.0.2",
+                "@shikijs/types": "4.0.2",
+                "@shikijs/vscode-textmate": "^10.0.2",
+                "@types/hast": "^3.0.4",
+                "hast-util-to-html": "^9.0.5"
+            },
+            "engines": {
+                "node": ">=20"
+            }
+        },
         "node_modules/@shikijs/engine-javascript": {
             "version": "4.0.2",
             "resolved": "https://registry.npmjs.org/@shikijs/engine-javascript/-/engine-javascript-4.0.2.tgz",
@@ -3303,19 +3411,6 @@
                 "@shikijs/types": "4.0.2",
                 "@shikijs/vscode-textmate": "^10.0.2",
                 "oniguruma-to-es": "^4.3.4"
-            },
-            "engines": {
-                "node": ">=20"
-            }
-        },
-        "node_modules/@shikijs/engine-javascript/node_modules/@shikijs/types": {
-            "version": "4.0.2",
-            "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-4.0.2.tgz",
-            "integrity": "sha512-qzbeRooUTPnLE+sHD/Z8DStmaDgnbbc/pMrU203950aRqjX/6AFHeDYT+j00y2lPdz0ywJKx7o/7qnqTivtlXg==",
-            "license": "MIT",
-            "dependencies": {
-                "@shikijs/vscode-textmate": "^10.0.2",
-                "@types/hast": "^3.0.4"
             },
             "engines": {
                 "node": ">=20"
@@ -3334,14 +3429,13 @@
                 "node": ">=20"
             }
         },
-        "node_modules/@shikijs/engine-oniguruma/node_modules/@shikijs/types": {
+        "node_modules/@shikijs/langs": {
             "version": "4.0.2",
-            "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-4.0.2.tgz",
-            "integrity": "sha512-qzbeRooUTPnLE+sHD/Z8DStmaDgnbbc/pMrU203950aRqjX/6AFHeDYT+j00y2lPdz0ywJKx7o/7qnqTivtlXg==",
+            "resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-4.0.2.tgz",
+            "integrity": "sha512-KaXby5dvoeuZzN0rYQiPMjFoUrz4hgwIE+D6Du9owcHcl6/g16/yT5BQxSW5cGt2MZBz6Hl0YuRqf12omRfUUg==",
             "license": "MIT",
             "dependencies": {
-                "@shikijs/vscode-textmate": "^10.0.2",
-                "@types/hast": "^3.0.4"
+                "@shikijs/types": "4.0.2"
             },
             "engines": {
                 "node": ">=20"
@@ -3369,9 +3463,75 @@
                 }
             }
         },
+        "node_modules/@shikijs/primitive": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/@shikijs/primitive/-/primitive-4.0.2.tgz",
+            "integrity": "sha512-M6UMPrSa3fN5ayeJwFVl9qWofl273wtK1VG8ySDZ1mQBfhCpdd8nEx7nPZ/tk7k+TYcpqBZzj/AnwxT9lO+HJw==",
+            "license": "MIT",
+            "dependencies": {
+                "@shikijs/types": "4.0.2",
+                "@shikijs/vscode-textmate": "^10.0.2",
+                "@types/hast": "^3.0.4"
+            },
+            "engines": {
+                "node": ">=20"
+            }
+        },
+        "node_modules/@shikijs/themes": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-4.0.2.tgz",
+            "integrity": "sha512-mjCafwt8lJJaVSsQvNVrJumbnnj1RI8jbUKrPKgE6E3OvQKxnuRoBaYC51H4IGHePsGN/QtALglWBU7DoKDFnA==",
+            "license": "MIT",
+            "dependencies": {
+                "@shikijs/types": "4.0.2"
+            },
+            "engines": {
+                "node": ">=20"
+            }
+        },
+        "node_modules/@shikijs/transformers": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/@shikijs/transformers/-/transformers-4.0.2.tgz",
+            "integrity": "sha512-1+L0gf9v+SdDXs08vjaLb3mBFa8U7u37cwcBQIv/HCocLwX69Tt6LpUCjtB+UUTvQxI7BnjZKhN/wMjhHBcJGg==",
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@shikijs/core": "4.0.2",
+                "@shikijs/types": "4.0.2"
+            },
+            "engines": {
+                "node": ">=20"
+            }
+        },
+        "node_modules/@shikijs/types": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-4.0.2.tgz",
+            "integrity": "sha512-qzbeRooUTPnLE+sHD/Z8DStmaDgnbbc/pMrU203950aRqjX/6AFHeDYT+j00y2lPdz0ywJKx7o/7qnqTivtlXg==",
+            "license": "MIT",
+            "dependencies": {
+                "@shikijs/vscode-textmate": "^10.0.2",
+                "@types/hast": "^3.0.4"
+            },
+            "engines": {
+                "node": ">=20"
+            }
+        },
         "node_modules/@shikijs/vscode-textmate": {
             "version": "10.0.2",
             "license": "MIT"
+        },
+        "node_modules/@sindresorhus/is": {
+            "version": "4.6.0",
+            "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.6.0.tgz",
+            "integrity": "sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==",
+            "license": "MIT",
+            "peer": true,
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sindresorhus/is?sponsor=1"
+            }
         },
         "node_modules/@standard-schema/spec": {
             "version": "1.1.0",
@@ -4194,6 +4354,46 @@
                 "node": ">=10"
             }
         },
+        "node_modules/@testing-library/dom": {
+            "version": "10.4.1",
+            "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+            "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@babel/code-frame": "^7.10.4",
+                "@babel/runtime": "^7.12.5",
+                "@types/aria-query": "^5.0.1",
+                "aria-query": "5.3.0",
+                "dom-accessibility-api": "^0.5.9",
+                "lz-string": "^1.5.0",
+                "picocolors": "1.1.1",
+                "pretty-format": "^27.0.2"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@testing-library/dom/node_modules/aria-query": {
+            "version": "5.3.0",
+            "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+            "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "dequal": "^2.0.3"
+            }
+        },
+        "node_modules/@testing-library/dom/node_modules/dom-accessibility-api": {
+            "version": "0.5.16",
+            "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+            "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true
+        },
         "node_modules/@testing-library/jest-dom": {
             "version": "6.9.1",
             "dev": true,
@@ -4254,6 +4454,14 @@
             "dependencies": {
                 "tslib": "^2.4.0"
             }
+        },
+        "node_modules/@types/aria-query": {
+            "version": "5.0.4",
+            "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+            "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/@types/bootstrap": {
             "version": "5.2.10",
@@ -4525,6 +4733,16 @@
                 "@types/d3-selection": "*"
             }
         },
+        "node_modules/@types/debug": {
+            "version": "4.1.13",
+            "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
+            "integrity": "sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==",
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@types/ms": "*"
+            }
+        },
         "node_modules/@types/deep-eql": {
             "version": "4.0.2",
             "dev": true,
@@ -4532,7 +4750,6 @@
         },
         "node_modules/@types/estree": {
             "version": "1.0.8",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/@types/fs-extra": {
@@ -4580,6 +4797,13 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/@types/linkify-it": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-5.0.0.tgz",
+            "integrity": "sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q==",
+            "license": "MIT",
+            "peer": true
+        },
         "node_modules/@types/lodash": {
             "version": "4.17.23",
             "license": "MIT"
@@ -4591,12 +4815,30 @@
                 "@types/lodash": "*"
             }
         },
+        "node_modules/@types/markdown-it": {
+            "version": "14.1.2",
+            "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-14.1.2.tgz",
+            "integrity": "sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog==",
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@types/linkify-it": "^5",
+                "@types/mdurl": "^2"
+            }
+        },
         "node_modules/@types/mdast": {
             "version": "4.0.4",
             "license": "MIT",
             "dependencies": {
                 "@types/unist": "*"
             }
+        },
+        "node_modules/@types/mdurl": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/@types/mdurl/-/mdurl-2.0.0.tgz",
+            "integrity": "sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==",
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/@types/minimatch": {
             "version": "5.1.2",
@@ -4610,6 +4852,13 @@
             "dependencies": {
                 "moment": "*"
             }
+        },
+        "node_modules/@types/ms": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
+            "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/@types/node": {
             "version": "25.5.0",
@@ -5783,7 +6032,9 @@
             }
         },
         "node_modules/acorn": {
-            "version": "8.15.0",
+            "version": "8.16.0",
+            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+            "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
             "license": "MIT",
             "bin": {
                 "acorn": "bin/acorn"
@@ -6006,6 +6257,17 @@
                 "node": ">= 10.0.0"
             }
         },
+        "node_modules/bail": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/bail/-/bail-2.0.2.tgz",
+            "integrity": "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==",
+            "license": "MIT",
+            "peer": true,
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/wooorm"
+            }
+        },
         "node_modules/balanced-match": {
             "version": "1.0.2",
             "license": "MIT"
@@ -6179,7 +6441,6 @@
         },
         "node_modules/c12": {
             "version": "3.3.3",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "chokidar": "^5.0.0",
@@ -6206,7 +6467,6 @@
         },
         "node_modules/c12/node_modules/rc9": {
             "version": "2.1.2",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "defu": "^6.1.4",
@@ -6328,6 +6588,27 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/char-regex": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/char-regex/-/char-regex-1.0.2.tgz",
+            "integrity": "sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==",
+            "license": "MIT",
+            "peer": true,
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/character-entities": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.2.tgz",
+            "integrity": "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==",
+            "license": "MIT",
+            "peer": true,
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/wooorm"
+            }
+        },
         "node_modules/character-entities-html4": {
             "version": "2.1.0",
             "license": "MIT",
@@ -6350,6 +6631,17 @@
             "license": "MIT",
             "dependencies": {
                 "is-regex": "^1.0.3"
+            }
+        },
+        "node_modules/character-reference-invalid": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-2.0.1.tgz",
+            "integrity": "sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==",
+            "license": "MIT",
+            "peer": true,
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/wooorm"
             }
         },
         "node_modules/charenc": {
@@ -6405,7 +6697,6 @@
         },
         "node_modules/chokidar": {
             "version": "5.0.0",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "readdirp": "^5.0.0"
@@ -6433,7 +6724,6 @@
         },
         "node_modules/citty": {
             "version": "0.1.6",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "consola": "^3.2.3"
@@ -6547,7 +6837,6 @@
         },
         "node_modules/confbox": {
             "version": "0.2.4",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/config-chain": {
@@ -6561,7 +6850,6 @@
         },
         "node_modules/consola": {
             "version": "3.4.2",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": "^14.18.0 || >=16.10.0"
@@ -7246,7 +7534,6 @@
         },
         "node_modules/debug": {
             "version": "4.4.3",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "ms": "^2.1.3"
@@ -7264,6 +7551,20 @@
             "version": "10.6.0",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/decode-named-character-reference": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.3.0.tgz",
+            "integrity": "sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==",
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "character-entities": "^2.0.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/wooorm"
+            }
         },
         "node_modules/deep-eql": {
             "version": "5.0.2",
@@ -7345,8 +7646,9 @@
             }
         },
         "node_modules/defu": {
-            "version": "6.1.4",
-            "dev": true,
+            "version": "6.1.6",
+            "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.6.tgz",
+            "integrity": "sha512-f8mefEW4WIVg4LckePx3mALjQSPQgFlg9U8yaPdlsbdYcHQyj9n2zL2LJEA52smeYxOvmd/nB7TpMtHGMTHcug==",
             "license": "MIT"
         },
         "node_modules/delaunator": {
@@ -7379,8 +7681,18 @@
         },
         "node_modules/destr": {
             "version": "2.0.5",
-            "dev": true,
             "license": "MIT"
+        },
+        "node_modules/detab": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/detab/-/detab-3.0.2.tgz",
+            "integrity": "sha512-7Bp16Bk8sk0Y6gdXiCtnpGbghn8atnTJdd/82aWvS5ESnlcNvgUc10U2NYS0PAiDSGjWiI8qs/Cv1b2uSGdQ8w==",
+            "license": "MIT",
+            "peer": true,
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/wooorm"
+            }
         },
         "node_modules/detect-libc": {
             "version": "2.1.2",
@@ -7573,6 +7885,24 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/emojilib": {
+            "version": "2.4.0",
+            "resolved": "https://registry.npmjs.org/emojilib/-/emojilib-2.4.0.tgz",
+            "integrity": "sha512-5U0rVMU5Y2n2+ykNLQqMoqklN9ICBT/KsvC1Gz6vqHbz2AXXGkG+Pm5rMWk/8Vjrr/mY9985Hi8DYzn1F09Nyw==",
+            "license": "MIT",
+            "peer": true
+        },
+        "node_modules/emoticon": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/emoticon/-/emoticon-4.1.0.tgz",
+            "integrity": "sha512-VWZfnxqwNcc51hIy/sbOdEem6D+cVtpPzEEtVAFdaas30+1dgkyaOQ4sQ6Bp0tOMqWO1v+HQfYaoodOkdhK6SQ==",
+            "license": "MIT",
+            "peer": true,
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/wooorm"
+            }
+        },
         "node_modules/entities": {
             "version": "7.0.1",
             "license": "BSD-2-Clause",
@@ -7593,6 +7923,13 @@
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
             }
+        },
+        "node_modules/errx": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/errx/-/errx-0.1.0.tgz",
+            "integrity": "sha512-fZmsRiDNv07K6s2KkKFTiD2aIvECa7++PKyD5NC32tpRw46qZA3sOz+aM+/V9V0GDHxVTKLziveV4JhzBHDp9Q==",
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/es-define-property": {
             "version": "1.0.1",
@@ -8084,7 +8421,6 @@
         },
         "node_modules/estree-walker": {
             "version": "3.0.3",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@types/estree": "^1.0.0"
@@ -8121,7 +8457,6 @@
         },
         "node_modules/exsolve": {
             "version": "1.0.8",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/ext": {
@@ -8130,6 +8465,13 @@
             "dependencies": {
                 "type": "^2.7.2"
             }
+        },
+        "node_modules/extend": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+            "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/fast-deep-equal": {
             "version": "3.1.3",
@@ -8240,6 +8582,19 @@
             "license": "Apache-2.0",
             "dependencies": {
                 "micromatch": "^4.0.2"
+            }
+        },
+        "node_modules/flat": {
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/flat/-/flat-6.0.1.tgz",
+            "integrity": "sha512-/3FfIa8mbrg3xE7+wAhWeV+bd7L2Mof+xtZb5dRDKZ+wDvYJK4WDYeIOuOhre5Yv5aQObZrlbRmk3RTSiuQBtw==",
+            "license": "BSD-3-Clause",
+            "peer": true,
+            "bin": {
+                "flat": "cli.js"
+            },
+            "engines": {
+                "node": ">=18"
             }
         },
         "node_modules/flat-cache": {
@@ -8412,7 +8767,6 @@
         },
         "node_modules/giget": {
             "version": "2.0.0",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "citty": "^0.1.6",
@@ -8425,6 +8779,13 @@
             "bin": {
                 "giget": "dist/cli.mjs"
             }
+        },
+        "node_modules/github-slugger": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/github-slugger/-/github-slugger-2.0.0.tgz",
+            "integrity": "sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw==",
+            "license": "ISC",
+            "peer": true
         },
         "node_modules/glob": {
             "version": "10.5.0",
@@ -8631,6 +8992,220 @@
                 "node": ">= 0.4"
             }
         },
+        "node_modules/hast-util-embedded": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/hast-util-embedded/-/hast-util-embedded-3.0.0.tgz",
+            "integrity": "sha512-naH8sld4Pe2ep03qqULEtvYr7EjrLK2QHY8KJR6RJkTUjPGObe1vnx585uzem2hGra+s1q08DZZpfgDVYRbaXA==",
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@types/hast": "^3.0.0",
+                "hast-util-is-element": "^3.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/hast-util-format": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/hast-util-format/-/hast-util-format-1.1.0.tgz",
+            "integrity": "sha512-yY1UDz6bC9rDvCWHpx12aIBGRG7krurX0p0Fm6pT547LwDIZZiNr8a+IHDogorAdreULSEzP82Nlv5SZkHZcjA==",
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@types/hast": "^3.0.0",
+                "hast-util-embedded": "^3.0.0",
+                "hast-util-minify-whitespace": "^1.0.0",
+                "hast-util-phrasing": "^3.0.0",
+                "hast-util-whitespace": "^3.0.0",
+                "html-whitespace-sensitive-tag-names": "^3.0.0",
+                "unist-util-visit-parents": "^6.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/hast-util-from-parse5": {
+            "version": "8.0.3",
+            "resolved": "https://registry.npmjs.org/hast-util-from-parse5/-/hast-util-from-parse5-8.0.3.tgz",
+            "integrity": "sha512-3kxEVkEKt0zvcZ3hCRYI8rqrgwtlIOFMWkbclACvjlDw8Li9S2hk/d51OI0nr/gIpdMHNepwgOKqZ/sy0Clpyg==",
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@types/hast": "^3.0.0",
+                "@types/unist": "^3.0.0",
+                "devlop": "^1.0.0",
+                "hastscript": "^9.0.0",
+                "property-information": "^7.0.0",
+                "vfile": "^6.0.0",
+                "vfile-location": "^5.0.0",
+                "web-namespaces": "^2.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/hast-util-has-property": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/hast-util-has-property/-/hast-util-has-property-3.0.0.tgz",
+            "integrity": "sha512-MNilsvEKLFpV604hwfhVStK0usFY/QmM5zX16bo7EjnAEGofr5YyI37kzopBlZJkHD4t887i+q/C8/tr5Q94cA==",
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@types/hast": "^3.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/hast-util-heading-rank": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/hast-util-heading-rank/-/hast-util-heading-rank-3.0.0.tgz",
+            "integrity": "sha512-EJKb8oMUXVHcWZTDepnr+WNbfnXKFNf9duMesmr4S8SXTJBJ9M4Yok08pu9vxdJwdlGRhVumk9mEhkEvKGifwA==",
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@types/hast": "^3.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/hast-util-is-body-ok-link": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/hast-util-is-body-ok-link/-/hast-util-is-body-ok-link-3.0.1.tgz",
+            "integrity": "sha512-0qpnzOBLztXHbHQenVB8uNuxTnm/QBFUOmdOSsEn7GnBtyY07+ENTWVFBAnXd/zEgd9/SUG3lRY7hSIBWRgGpQ==",
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@types/hast": "^3.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/hast-util-is-element": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/hast-util-is-element/-/hast-util-is-element-3.0.0.tgz",
+            "integrity": "sha512-Val9mnv2IWpLbNPqc/pUem+a7Ipj2aHacCwgNfTiK0vJKl0LF+4Ba4+v1oPHFpf3bLYmreq0/l3Gud9S5OH42g==",
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@types/hast": "^3.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/hast-util-minify-whitespace": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/hast-util-minify-whitespace/-/hast-util-minify-whitespace-1.0.1.tgz",
+            "integrity": "sha512-L96fPOVpnclQE0xzdWb/D12VT5FabA7SnZOUMtL1DbXmYiHJMXZvFkIZfiMmTCNJHUeO2K9UYNXoVyfz+QHuOw==",
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@types/hast": "^3.0.0",
+                "hast-util-embedded": "^3.0.0",
+                "hast-util-is-element": "^3.0.0",
+                "hast-util-whitespace": "^3.0.0",
+                "unist-util-is": "^6.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/hast-util-parse-selector": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/hast-util-parse-selector/-/hast-util-parse-selector-4.0.0.tgz",
+            "integrity": "sha512-wkQCkSYoOGCRKERFWcxMVMOcYE2K1AaNLU8DXS9arxnLOUEWbOXKXiJUNzEpqZ3JOKpnha3jkFrumEjVliDe7A==",
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@types/hast": "^3.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/hast-util-phrasing": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/hast-util-phrasing/-/hast-util-phrasing-3.0.1.tgz",
+            "integrity": "sha512-6h60VfI3uBQUxHqTyMymMZnEbNl1XmEGtOxxKYL7stY2o601COo62AWAYBQR9lZbYXYSBoxag8UpPRXK+9fqSQ==",
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@types/hast": "^3.0.0",
+                "hast-util-embedded": "^3.0.0",
+                "hast-util-has-property": "^3.0.0",
+                "hast-util-is-body-ok-link": "^3.0.0",
+                "hast-util-is-element": "^3.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/hast-util-raw": {
+            "version": "9.1.0",
+            "resolved": "https://registry.npmjs.org/hast-util-raw/-/hast-util-raw-9.1.0.tgz",
+            "integrity": "sha512-Y8/SBAHkZGoNkpzqqfCldijcuUKh7/su31kEBp67cFY09Wy0mTRgtsLYsiIxMJxlu0f6AA5SUTbDR8K0rxnbUw==",
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@types/hast": "^3.0.0",
+                "@types/unist": "^3.0.0",
+                "@ungap/structured-clone": "^1.0.0",
+                "hast-util-from-parse5": "^8.0.0",
+                "hast-util-to-parse5": "^8.0.0",
+                "html-void-elements": "^3.0.0",
+                "mdast-util-to-hast": "^13.0.0",
+                "parse5": "^7.0.0",
+                "unist-util-position": "^5.0.0",
+                "unist-util-visit": "^5.0.0",
+                "vfile": "^6.0.0",
+                "web-namespaces": "^2.0.0",
+                "zwitch": "^2.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/hast-util-raw/node_modules/entities": {
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+            "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+            "license": "BSD-2-Clause",
+            "peer": true,
+            "engines": {
+                "node": ">=0.12"
+            },
+            "funding": {
+                "url": "https://github.com/fb55/entities?sponsor=1"
+            }
+        },
+        "node_modules/hast-util-raw/node_modules/parse5": {
+            "version": "7.3.0",
+            "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+            "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "entities": "^6.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/inikulin/parse5?sponsor=1"
+            }
+        },
         "node_modules/hast-util-to-html": {
             "version": "9.0.5",
             "license": "MIT",
@@ -8652,11 +9227,107 @@
                 "url": "https://opencollective.com/unified"
             }
         },
+        "node_modules/hast-util-to-mdast": {
+            "version": "10.1.2",
+            "resolved": "https://registry.npmjs.org/hast-util-to-mdast/-/hast-util-to-mdast-10.1.2.tgz",
+            "integrity": "sha512-FiCRI7NmOvM4y+f5w32jPRzcxDIz+PUqDwEqn1A+1q2cdp3B8Gx7aVrXORdOKjMNDQsD1ogOr896+0jJHW1EFQ==",
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@types/hast": "^3.0.0",
+                "@types/mdast": "^4.0.0",
+                "@ungap/structured-clone": "^1.0.0",
+                "hast-util-phrasing": "^3.0.0",
+                "hast-util-to-html": "^9.0.0",
+                "hast-util-to-text": "^4.0.0",
+                "hast-util-whitespace": "^3.0.0",
+                "mdast-util-phrasing": "^4.0.0",
+                "mdast-util-to-hast": "^13.0.0",
+                "mdast-util-to-string": "^4.0.0",
+                "rehype-minify-whitespace": "^6.0.0",
+                "trim-trailing-lines": "^2.0.0",
+                "unist-util-position": "^5.0.0",
+                "unist-util-visit": "^5.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/hast-util-to-parse5": {
+            "version": "8.0.1",
+            "resolved": "https://registry.npmjs.org/hast-util-to-parse5/-/hast-util-to-parse5-8.0.1.tgz",
+            "integrity": "sha512-MlWT6Pjt4CG9lFCjiz4BH7l9wmrMkfkJYCxFwKQic8+RTZgWPuWxwAfjJElsXkex7DJjfSJsQIt931ilUgmwdA==",
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@types/hast": "^3.0.0",
+                "comma-separated-tokens": "^2.0.0",
+                "devlop": "^1.0.0",
+                "property-information": "^7.0.0",
+                "space-separated-tokens": "^2.0.0",
+                "web-namespaces": "^2.0.0",
+                "zwitch": "^2.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/hast-util-to-string": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/hast-util-to-string/-/hast-util-to-string-3.0.1.tgz",
+            "integrity": "sha512-XelQVTDWvqcl3axRfI0xSeoVKzyIFPwsAGSLIsKdJKQMXDYJS4WYrBNF/8J7RdhIcFI2BOHgAifggsvsxp/3+A==",
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@types/hast": "^3.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/hast-util-to-text": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/hast-util-to-text/-/hast-util-to-text-4.0.2.tgz",
+            "integrity": "sha512-KK6y/BN8lbaq654j7JgBydev7wuNMcID54lkRav1P0CaE1e47P72AWWPiGKXTJU271ooYzcvTAn/Zt0REnvc7A==",
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@types/hast": "^3.0.0",
+                "@types/unist": "^3.0.0",
+                "hast-util-is-element": "^3.0.0",
+                "unist-util-find-after": "^5.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
         "node_modules/hast-util-whitespace": {
             "version": "3.0.0",
             "license": "MIT",
             "dependencies": {
                 "@types/hast": "^3.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/hastscript": {
+            "version": "9.0.1",
+            "resolved": "https://registry.npmjs.org/hastscript/-/hastscript-9.0.1.tgz",
+            "integrity": "sha512-g7df9rMFX/SPi34tyGCyUBREQoKkapwdY/T04Qn9TDWfHhAYt4/I0gMVirzK5wEzeUqIjEB+LXC/ypb7Aqno5w==",
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@types/hast": "^3.0.0",
+                "comma-separated-tokens": "^2.0.0",
+                "hast-util-parse-selector": "^4.0.0",
+                "property-information": "^7.0.0",
+                "space-separated-tokens": "^2.0.0"
             },
             "funding": {
                 "type": "opencollective",
@@ -8701,6 +9372,17 @@
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/wooorm"
+            }
+        },
+        "node_modules/html-whitespace-sensitive-tag-names": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/html-whitespace-sensitive-tag-names/-/html-whitespace-sensitive-tag-names-3.0.1.tgz",
+            "integrity": "sha512-q+310vW8zmymYHALr1da4HyXUQ0zgiIwIicEfotYPWGN0OJVEN/58IJ3A4GBYcEq3LGAZqKb+ugvP0GNB9CEAA==",
+            "license": "MIT",
+            "peer": true,
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
             }
         },
         "node_modules/humanize-duration": {
@@ -8756,7 +9438,6 @@
         },
         "node_modules/ignore": {
             "version": "7.0.5",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">= 4"
@@ -8830,6 +9511,45 @@
                 "node": ">=12"
             }
         },
+        "node_modules/is-absolute-url": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/is-absolute-url/-/is-absolute-url-4.0.1.tgz",
+            "integrity": "sha512-/51/TKE88Lmm7Gc4/8btclNXWS+g50wXhYJq8HWIBAGUBnoAdRu1aXeh364t/O7wXDAcTJDP8PNuNKWUDWie+A==",
+            "license": "MIT",
+            "peer": true,
+            "engines": {
+                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/is-alphabetical": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-2.0.1.tgz",
+            "integrity": "sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==",
+            "license": "MIT",
+            "peer": true,
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/wooorm"
+            }
+        },
+        "node_modules/is-alphanumerical": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-2.0.1.tgz",
+            "integrity": "sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==",
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "is-alphabetical": "^2.0.0",
+                "is-decimal": "^2.0.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/wooorm"
+            }
+        },
         "node_modules/is-buffer": {
             "version": "1.1.6",
             "license": "MIT"
@@ -8846,6 +9566,17 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/is-decimal": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-2.0.1.tgz",
+            "integrity": "sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==",
+            "license": "MIT",
+            "peer": true,
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/wooorm"
             }
         },
         "node_modules/is-docker": {
@@ -8915,6 +9646,17 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/is-hexadecimal": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-2.0.1.tgz",
+            "integrity": "sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==",
+            "license": "MIT",
+            "peer": true,
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/wooorm"
+            }
+        },
         "node_modules/is-in-ssh": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/is-in-ssh/-/is-in-ssh-1.0.0.tgz",
@@ -8969,6 +9711,19 @@
             "license": "MIT",
             "engines": {
                 "node": ">=0.12.0"
+            }
+        },
+        "node_modules/is-plain-obj": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+            "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+            "license": "MIT",
+            "peer": true,
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/is-plain-object": {
@@ -9087,7 +9842,6 @@
         },
         "node_modules/jiti": {
             "version": "2.6.1",
-            "dev": true,
             "license": "MIT",
             "bin": {
                 "jiti": "lib/jiti-cli.mjs"
@@ -9345,6 +10099,23 @@
             "dependencies": {
                 "graceful-fs": "^4.1.11"
             }
+        },
+        "node_modules/klona": {
+            "version": "2.0.6",
+            "resolved": "https://registry.npmjs.org/klona/-/klona-2.0.6.tgz",
+            "integrity": "sha512-dhG34DXATL5hSxJbIexCft8FChFXtmskoZYnoPWjXQuebWYCNkVeV3KkGegCK9CP1oswI/vQibS2GY7Em/sJJA==",
+            "license": "MIT",
+            "peer": true,
+            "engines": {
+                "node": ">= 8"
+            }
+        },
+        "node_modules/knitwork": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/knitwork/-/knitwork-1.3.0.tgz",
+            "integrity": "sha512-4LqMNoONzR43B1W0ek0fhXMsDNW/zxa1NdFAVMY+k28pgZLovR4G3PB5MrpTxCy1QaZCqNoiaKPr5w5qZHfSNw==",
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/langium": {
             "version": "4.2.1",
@@ -9888,6 +10659,17 @@
             "version": "5.3.2",
             "license": "Apache-2.0"
         },
+        "node_modules/longest-streak": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-3.1.0.tgz",
+            "integrity": "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==",
+            "license": "MIT",
+            "peer": true,
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/wooorm"
+            }
+        },
         "node_modules/loupe": {
             "version": "3.2.1",
             "dev": true,
@@ -9901,6 +10683,17 @@
                 "yallist": "^3.0.2"
             }
         },
+        "node_modules/lz-string": {
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+            "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "bin": {
+                "lz-string": "bin/bin.js"
+            }
+        },
         "node_modules/magic-string": {
             "version": "0.30.21",
             "license": "MIT",
@@ -9912,7 +10705,7 @@
             "version": "0.5.2",
             "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.2.tgz",
             "integrity": "sha512-E3ZJh4J3S9KfwdjZhe2afj6R9lGIN5Pher1pF39UGrXRqq/VDaGVIGN13BjHd2u8B61hArAGOnso7nBOouW3TQ==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT",
             "dependencies": {
                 "@babel/parser": "^7.29.0",
@@ -10018,6 +10811,17 @@
                 "url": "https://github.com/fb55/entities?sponsor=1"
             }
         },
+        "node_modules/markdown-table": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-3.0.4.tgz",
+            "integrity": "sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==",
+            "license": "MIT",
+            "peer": true,
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/wooorm"
+            }
+        },
         "node_modules/marked": {
             "version": "16.4.2",
             "resolved": "https://registry.npmjs.org/marked/-/marked-16.4.2.tgz",
@@ -10050,6 +10854,183 @@
                 "is-buffer": "~1.1.6"
             }
         },
+        "node_modules/mdast-util-find-and-replace": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/mdast-util-find-and-replace/-/mdast-util-find-and-replace-3.0.2.tgz",
+            "integrity": "sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==",
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@types/mdast": "^4.0.0",
+                "escape-string-regexp": "^5.0.0",
+                "unist-util-is": "^6.0.0",
+                "unist-util-visit-parents": "^6.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/mdast-util-find-and-replace/node_modules/escape-string-regexp": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+            "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
+            "license": "MIT",
+            "peer": true,
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/mdast-util-from-markdown": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.3.tgz",
+            "integrity": "sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==",
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@types/mdast": "^4.0.0",
+                "@types/unist": "^3.0.0",
+                "decode-named-character-reference": "^1.0.0",
+                "devlop": "^1.0.0",
+                "mdast-util-to-string": "^4.0.0",
+                "micromark": "^4.0.0",
+                "micromark-util-decode-numeric-character-reference": "^2.0.0",
+                "micromark-util-decode-string": "^2.0.0",
+                "micromark-util-normalize-identifier": "^2.0.0",
+                "micromark-util-symbol": "^2.0.0",
+                "micromark-util-types": "^2.0.0",
+                "unist-util-stringify-position": "^4.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/mdast-util-gfm": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/mdast-util-gfm/-/mdast-util-gfm-3.1.0.tgz",
+            "integrity": "sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ==",
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "mdast-util-from-markdown": "^2.0.0",
+                "mdast-util-gfm-autolink-literal": "^2.0.0",
+                "mdast-util-gfm-footnote": "^2.0.0",
+                "mdast-util-gfm-strikethrough": "^2.0.0",
+                "mdast-util-gfm-table": "^2.0.0",
+                "mdast-util-gfm-task-list-item": "^2.0.0",
+                "mdast-util-to-markdown": "^2.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/mdast-util-gfm-autolink-literal": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/mdast-util-gfm-autolink-literal/-/mdast-util-gfm-autolink-literal-2.0.1.tgz",
+            "integrity": "sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==",
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@types/mdast": "^4.0.0",
+                "ccount": "^2.0.0",
+                "devlop": "^1.0.0",
+                "mdast-util-find-and-replace": "^3.0.0",
+                "micromark-util-character": "^2.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/mdast-util-gfm-footnote": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/mdast-util-gfm-footnote/-/mdast-util-gfm-footnote-2.1.0.tgz",
+            "integrity": "sha512-sqpDWlsHn7Ac9GNZQMeUzPQSMzR6Wv0WKRNvQRg0KqHh02fpTz69Qc1QSseNX29bhz1ROIyNyxExfawVKTm1GQ==",
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@types/mdast": "^4.0.0",
+                "devlop": "^1.1.0",
+                "mdast-util-from-markdown": "^2.0.0",
+                "mdast-util-to-markdown": "^2.0.0",
+                "micromark-util-normalize-identifier": "^2.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/mdast-util-gfm-strikethrough": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/mdast-util-gfm-strikethrough/-/mdast-util-gfm-strikethrough-2.0.0.tgz",
+            "integrity": "sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg==",
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@types/mdast": "^4.0.0",
+                "mdast-util-from-markdown": "^2.0.0",
+                "mdast-util-to-markdown": "^2.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/mdast-util-gfm-table": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/mdast-util-gfm-table/-/mdast-util-gfm-table-2.0.0.tgz",
+            "integrity": "sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg==",
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@types/mdast": "^4.0.0",
+                "devlop": "^1.0.0",
+                "markdown-table": "^3.0.0",
+                "mdast-util-from-markdown": "^2.0.0",
+                "mdast-util-to-markdown": "^2.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/mdast-util-gfm-task-list-item": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/mdast-util-gfm-task-list-item/-/mdast-util-gfm-task-list-item-2.0.0.tgz",
+            "integrity": "sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ==",
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@types/mdast": "^4.0.0",
+                "devlop": "^1.0.0",
+                "mdast-util-from-markdown": "^2.0.0",
+                "mdast-util-to-markdown": "^2.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/mdast-util-phrasing": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/mdast-util-phrasing/-/mdast-util-phrasing-4.1.0.tgz",
+            "integrity": "sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==",
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@types/mdast": "^4.0.0",
+                "unist-util-is": "^6.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
         "node_modules/mdast-util-to-hast": {
             "version": "13.2.1",
             "license": "MIT",
@@ -10063,6 +11044,42 @@
                 "unist-util-position": "^5.0.0",
                 "unist-util-visit": "^5.0.0",
                 "vfile": "^6.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/mdast-util-to-markdown": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-2.1.2.tgz",
+            "integrity": "sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==",
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@types/mdast": "^4.0.0",
+                "@types/unist": "^3.0.0",
+                "longest-streak": "^3.0.0",
+                "mdast-util-phrasing": "^4.0.0",
+                "mdast-util-to-string": "^4.0.0",
+                "micromark-util-classify-character": "^2.0.0",
+                "micromark-util-decode-string": "^2.0.0",
+                "unist-util-visit": "^5.0.0",
+                "zwitch": "^2.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/mdast-util-to-string": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-4.0.0.tgz",
+            "integrity": "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==",
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@types/mdast": "^4.0.0"
             },
             "funding": {
                 "type": "opencollective",
@@ -10133,6 +11150,317 @@
                 "uuid": "dist/esm/bin/uuid"
             }
         },
+        "node_modules/micromark": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/micromark/-/micromark-4.0.2.tgz",
+            "integrity": "sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==",
+            "funding": [
+                {
+                    "type": "GitHub Sponsors",
+                    "url": "https://github.com/sponsors/unifiedjs"
+                },
+                {
+                    "type": "OpenCollective",
+                    "url": "https://opencollective.com/unified"
+                }
+            ],
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@types/debug": "^4.0.0",
+                "debug": "^4.0.0",
+                "decode-named-character-reference": "^1.0.0",
+                "devlop": "^1.0.0",
+                "micromark-core-commonmark": "^2.0.0",
+                "micromark-factory-space": "^2.0.0",
+                "micromark-util-character": "^2.0.0",
+                "micromark-util-chunked": "^2.0.0",
+                "micromark-util-combine-extensions": "^2.0.0",
+                "micromark-util-decode-numeric-character-reference": "^2.0.0",
+                "micromark-util-encode": "^2.0.0",
+                "micromark-util-normalize-identifier": "^2.0.0",
+                "micromark-util-resolve-all": "^2.0.0",
+                "micromark-util-sanitize-uri": "^2.0.0",
+                "micromark-util-subtokenize": "^2.0.0",
+                "micromark-util-symbol": "^2.0.0",
+                "micromark-util-types": "^2.0.0"
+            }
+        },
+        "node_modules/micromark-core-commonmark": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/micromark-core-commonmark/-/micromark-core-commonmark-2.0.3.tgz",
+            "integrity": "sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==",
+            "funding": [
+                {
+                    "type": "GitHub Sponsors",
+                    "url": "https://github.com/sponsors/unifiedjs"
+                },
+                {
+                    "type": "OpenCollective",
+                    "url": "https://opencollective.com/unified"
+                }
+            ],
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "decode-named-character-reference": "^1.0.0",
+                "devlop": "^1.0.0",
+                "micromark-factory-destination": "^2.0.0",
+                "micromark-factory-label": "^2.0.0",
+                "micromark-factory-space": "^2.0.0",
+                "micromark-factory-title": "^2.0.0",
+                "micromark-factory-whitespace": "^2.0.0",
+                "micromark-util-character": "^2.0.0",
+                "micromark-util-chunked": "^2.0.0",
+                "micromark-util-classify-character": "^2.0.0",
+                "micromark-util-html-tag-name": "^2.0.0",
+                "micromark-util-normalize-identifier": "^2.0.0",
+                "micromark-util-resolve-all": "^2.0.0",
+                "micromark-util-subtokenize": "^2.0.0",
+                "micromark-util-symbol": "^2.0.0",
+                "micromark-util-types": "^2.0.0"
+            }
+        },
+        "node_modules/micromark-extension-gfm": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/micromark-extension-gfm/-/micromark-extension-gfm-3.0.0.tgz",
+            "integrity": "sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w==",
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "micromark-extension-gfm-autolink-literal": "^2.0.0",
+                "micromark-extension-gfm-footnote": "^2.0.0",
+                "micromark-extension-gfm-strikethrough": "^2.0.0",
+                "micromark-extension-gfm-table": "^2.0.0",
+                "micromark-extension-gfm-tagfilter": "^2.0.0",
+                "micromark-extension-gfm-task-list-item": "^2.0.0",
+                "micromark-util-combine-extensions": "^2.0.0",
+                "micromark-util-types": "^2.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/micromark-extension-gfm-autolink-literal": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/micromark-extension-gfm-autolink-literal/-/micromark-extension-gfm-autolink-literal-2.1.0.tgz",
+            "integrity": "sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==",
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "micromark-util-character": "^2.0.0",
+                "micromark-util-sanitize-uri": "^2.0.0",
+                "micromark-util-symbol": "^2.0.0",
+                "micromark-util-types": "^2.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/micromark-extension-gfm-footnote": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/micromark-extension-gfm-footnote/-/micromark-extension-gfm-footnote-2.1.0.tgz",
+            "integrity": "sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw==",
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "devlop": "^1.0.0",
+                "micromark-core-commonmark": "^2.0.0",
+                "micromark-factory-space": "^2.0.0",
+                "micromark-util-character": "^2.0.0",
+                "micromark-util-normalize-identifier": "^2.0.0",
+                "micromark-util-sanitize-uri": "^2.0.0",
+                "micromark-util-symbol": "^2.0.0",
+                "micromark-util-types": "^2.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/micromark-extension-gfm-strikethrough": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/micromark-extension-gfm-strikethrough/-/micromark-extension-gfm-strikethrough-2.1.0.tgz",
+            "integrity": "sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw==",
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "devlop": "^1.0.0",
+                "micromark-util-chunked": "^2.0.0",
+                "micromark-util-classify-character": "^2.0.0",
+                "micromark-util-resolve-all": "^2.0.0",
+                "micromark-util-symbol": "^2.0.0",
+                "micromark-util-types": "^2.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/micromark-extension-gfm-table": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/micromark-extension-gfm-table/-/micromark-extension-gfm-table-2.1.1.tgz",
+            "integrity": "sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg==",
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "devlop": "^1.0.0",
+                "micromark-factory-space": "^2.0.0",
+                "micromark-util-character": "^2.0.0",
+                "micromark-util-symbol": "^2.0.0",
+                "micromark-util-types": "^2.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/micromark-extension-gfm-tagfilter": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/micromark-extension-gfm-tagfilter/-/micromark-extension-gfm-tagfilter-2.0.0.tgz",
+            "integrity": "sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg==",
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "micromark-util-types": "^2.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/micromark-extension-gfm-task-list-item": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/micromark-extension-gfm-task-list-item/-/micromark-extension-gfm-task-list-item-2.1.0.tgz",
+            "integrity": "sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw==",
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "devlop": "^1.0.0",
+                "micromark-factory-space": "^2.0.0",
+                "micromark-util-character": "^2.0.0",
+                "micromark-util-symbol": "^2.0.0",
+                "micromark-util-types": "^2.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/micromark-factory-destination": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/micromark-factory-destination/-/micromark-factory-destination-2.0.1.tgz",
+            "integrity": "sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==",
+            "funding": [
+                {
+                    "type": "GitHub Sponsors",
+                    "url": "https://github.com/sponsors/unifiedjs"
+                },
+                {
+                    "type": "OpenCollective",
+                    "url": "https://opencollective.com/unified"
+                }
+            ],
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "micromark-util-character": "^2.0.0",
+                "micromark-util-symbol": "^2.0.0",
+                "micromark-util-types": "^2.0.0"
+            }
+        },
+        "node_modules/micromark-factory-label": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/micromark-factory-label/-/micromark-factory-label-2.0.1.tgz",
+            "integrity": "sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==",
+            "funding": [
+                {
+                    "type": "GitHub Sponsors",
+                    "url": "https://github.com/sponsors/unifiedjs"
+                },
+                {
+                    "type": "OpenCollective",
+                    "url": "https://opencollective.com/unified"
+                }
+            ],
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "devlop": "^1.0.0",
+                "micromark-util-character": "^2.0.0",
+                "micromark-util-symbol": "^2.0.0",
+                "micromark-util-types": "^2.0.0"
+            }
+        },
+        "node_modules/micromark-factory-space": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/micromark-factory-space/-/micromark-factory-space-2.0.1.tgz",
+            "integrity": "sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==",
+            "funding": [
+                {
+                    "type": "GitHub Sponsors",
+                    "url": "https://github.com/sponsors/unifiedjs"
+                },
+                {
+                    "type": "OpenCollective",
+                    "url": "https://opencollective.com/unified"
+                }
+            ],
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "micromark-util-character": "^2.0.0",
+                "micromark-util-types": "^2.0.0"
+            }
+        },
+        "node_modules/micromark-factory-title": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/micromark-factory-title/-/micromark-factory-title-2.0.1.tgz",
+            "integrity": "sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw==",
+            "funding": [
+                {
+                    "type": "GitHub Sponsors",
+                    "url": "https://github.com/sponsors/unifiedjs"
+                },
+                {
+                    "type": "OpenCollective",
+                    "url": "https://opencollective.com/unified"
+                }
+            ],
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "micromark-factory-space": "^2.0.0",
+                "micromark-util-character": "^2.0.0",
+                "micromark-util-symbol": "^2.0.0",
+                "micromark-util-types": "^2.0.0"
+            }
+        },
+        "node_modules/micromark-factory-whitespace": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/micromark-factory-whitespace/-/micromark-factory-whitespace-2.0.1.tgz",
+            "integrity": "sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ==",
+            "funding": [
+                {
+                    "type": "GitHub Sponsors",
+                    "url": "https://github.com/sponsors/unifiedjs"
+                },
+                {
+                    "type": "OpenCollective",
+                    "url": "https://opencollective.com/unified"
+                }
+            ],
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "micromark-factory-space": "^2.0.0",
+                "micromark-util-character": "^2.0.0",
+                "micromark-util-symbol": "^2.0.0",
+                "micromark-util-types": "^2.0.0"
+            }
+        },
         "node_modules/micromark-util-character": {
             "version": "2.1.1",
             "funding": [
@@ -10151,6 +11479,112 @@
                 "micromark-util-types": "^2.0.0"
             }
         },
+        "node_modules/micromark-util-chunked": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/micromark-util-chunked/-/micromark-util-chunked-2.0.1.tgz",
+            "integrity": "sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==",
+            "funding": [
+                {
+                    "type": "GitHub Sponsors",
+                    "url": "https://github.com/sponsors/unifiedjs"
+                },
+                {
+                    "type": "OpenCollective",
+                    "url": "https://opencollective.com/unified"
+                }
+            ],
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "micromark-util-symbol": "^2.0.0"
+            }
+        },
+        "node_modules/micromark-util-classify-character": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/micromark-util-classify-character/-/micromark-util-classify-character-2.0.1.tgz",
+            "integrity": "sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q==",
+            "funding": [
+                {
+                    "type": "GitHub Sponsors",
+                    "url": "https://github.com/sponsors/unifiedjs"
+                },
+                {
+                    "type": "OpenCollective",
+                    "url": "https://opencollective.com/unified"
+                }
+            ],
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "micromark-util-character": "^2.0.0",
+                "micromark-util-symbol": "^2.0.0",
+                "micromark-util-types": "^2.0.0"
+            }
+        },
+        "node_modules/micromark-util-combine-extensions": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/micromark-util-combine-extensions/-/micromark-util-combine-extensions-2.0.1.tgz",
+            "integrity": "sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg==",
+            "funding": [
+                {
+                    "type": "GitHub Sponsors",
+                    "url": "https://github.com/sponsors/unifiedjs"
+                },
+                {
+                    "type": "OpenCollective",
+                    "url": "https://opencollective.com/unified"
+                }
+            ],
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "micromark-util-chunked": "^2.0.0",
+                "micromark-util-types": "^2.0.0"
+            }
+        },
+        "node_modules/micromark-util-decode-numeric-character-reference": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/micromark-util-decode-numeric-character-reference/-/micromark-util-decode-numeric-character-reference-2.0.2.tgz",
+            "integrity": "sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==",
+            "funding": [
+                {
+                    "type": "GitHub Sponsors",
+                    "url": "https://github.com/sponsors/unifiedjs"
+                },
+                {
+                    "type": "OpenCollective",
+                    "url": "https://opencollective.com/unified"
+                }
+            ],
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "micromark-util-symbol": "^2.0.0"
+            }
+        },
+        "node_modules/micromark-util-decode-string": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/micromark-util-decode-string/-/micromark-util-decode-string-2.0.1.tgz",
+            "integrity": "sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ==",
+            "funding": [
+                {
+                    "type": "GitHub Sponsors",
+                    "url": "https://github.com/sponsors/unifiedjs"
+                },
+                {
+                    "type": "OpenCollective",
+                    "url": "https://opencollective.com/unified"
+                }
+            ],
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "decode-named-character-reference": "^1.0.0",
+                "micromark-util-character": "^2.0.0",
+                "micromark-util-decode-numeric-character-reference": "^2.0.0",
+                "micromark-util-symbol": "^2.0.0"
+            }
+        },
         "node_modules/micromark-util-encode": {
             "version": "2.0.1",
             "funding": [
@@ -10164,6 +11598,63 @@
                 }
             ],
             "license": "MIT"
+        },
+        "node_modules/micromark-util-html-tag-name": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/micromark-util-html-tag-name/-/micromark-util-html-tag-name-2.0.1.tgz",
+            "integrity": "sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA==",
+            "funding": [
+                {
+                    "type": "GitHub Sponsors",
+                    "url": "https://github.com/sponsors/unifiedjs"
+                },
+                {
+                    "type": "OpenCollective",
+                    "url": "https://opencollective.com/unified"
+                }
+            ],
+            "license": "MIT",
+            "peer": true
+        },
+        "node_modules/micromark-util-normalize-identifier": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/micromark-util-normalize-identifier/-/micromark-util-normalize-identifier-2.0.1.tgz",
+            "integrity": "sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==",
+            "funding": [
+                {
+                    "type": "GitHub Sponsors",
+                    "url": "https://github.com/sponsors/unifiedjs"
+                },
+                {
+                    "type": "OpenCollective",
+                    "url": "https://opencollective.com/unified"
+                }
+            ],
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "micromark-util-symbol": "^2.0.0"
+            }
+        },
+        "node_modules/micromark-util-resolve-all": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/micromark-util-resolve-all/-/micromark-util-resolve-all-2.0.1.tgz",
+            "integrity": "sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==",
+            "funding": [
+                {
+                    "type": "GitHub Sponsors",
+                    "url": "https://github.com/sponsors/unifiedjs"
+                },
+                {
+                    "type": "OpenCollective",
+                    "url": "https://opencollective.com/unified"
+                }
+            ],
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "micromark-util-types": "^2.0.0"
+            }
         },
         "node_modules/micromark-util-sanitize-uri": {
             "version": "2.0.1",
@@ -10182,6 +11673,29 @@
                 "micromark-util-character": "^2.0.0",
                 "micromark-util-encode": "^2.0.0",
                 "micromark-util-symbol": "^2.0.0"
+            }
+        },
+        "node_modules/micromark-util-subtokenize": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/micromark-util-subtokenize/-/micromark-util-subtokenize-2.1.0.tgz",
+            "integrity": "sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA==",
+            "funding": [
+                {
+                    "type": "GitHub Sponsors",
+                    "url": "https://github.com/sponsors/unifiedjs"
+                },
+                {
+                    "type": "OpenCollective",
+                    "url": "https://opencollective.com/unified"
+                }
+            ],
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "devlop": "^1.0.0",
+                "micromark-util-chunked": "^2.0.0",
+                "micromark-util-symbol": "^2.0.0",
+                "micromark-util-types": "^2.0.0"
             }
         },
         "node_modules/micromark-util-symbol": {
@@ -10307,15 +11821,15 @@
             "license": "MIT"
         },
         "node_modules/mlly": {
-            "version": "1.8.0",
-            "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.8.0.tgz",
-            "integrity": "sha512-l8D9ODSRWLe2KHJSifWGwBqpTZXIXTeo8mlKjY+E2HAakaTeNpqAyBZ8GSqLzHgw4XmHmC8whvpjJNMbFZN7/g==",
+            "version": "1.8.2",
+            "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.8.2.tgz",
+            "integrity": "sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA==",
             "license": "MIT",
             "dependencies": {
-                "acorn": "^8.15.0",
+                "acorn": "^8.16.0",
                 "pathe": "^2.0.3",
                 "pkg-types": "^1.3.1",
-                "ufo": "^1.6.1"
+                "ufo": "^1.6.3"
             }
         },
         "node_modules/mlly/node_modules/confbox": {
@@ -10447,7 +11961,6 @@
         },
         "node_modules/ms": {
             "version": "2.1.3",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/muggle-string": {
@@ -10514,6 +12027,22 @@
                 "node": ">=10.5.0"
             }
         },
+        "node_modules/node-emoji": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/node-emoji/-/node-emoji-2.2.0.tgz",
+            "integrity": "sha512-Z3lTE9pLaJF47NyMhd4ww1yFTAP8YhYI8SleJiHzM46Fgpm5cnNzSl9XfzFNqbaz+VlJrIj3fXQ4DeN1Rjm6cw==",
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@sindresorhus/is": "^4.6.0",
+                "char-regex": "^1.0.2",
+                "emojilib": "^2.4.0",
+                "skin-tone": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
         "node_modules/node-fetch-commonjs": {
             "version": "3.3.2",
             "license": "MIT",
@@ -10531,7 +12060,6 @@
         },
         "node_modules/node-fetch-native": {
             "version": "1.6.7",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/node-gyp-build": {
@@ -10589,7 +12117,6 @@
         },
         "node_modules/nypm": {
             "version": "0.6.5",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "citty": "^0.2.0",
@@ -10605,7 +12132,6 @@
         },
         "node_modules/nypm/node_modules/citty": {
             "version": "0.2.0",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/object-assign": {
@@ -10637,7 +12163,6 @@
         },
         "node_modules/ohash": {
             "version": "2.0.11",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/once": {
@@ -10782,9 +12307,35 @@
                 "node": ">=6"
             }
         },
+        "node_modules/parse-entities": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-4.0.2.tgz",
+            "integrity": "sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==",
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@types/unist": "^2.0.0",
+                "character-entities-legacy": "^3.0.0",
+                "character-reference-invalid": "^2.0.0",
+                "decode-named-character-reference": "^1.0.0",
+                "is-alphanumerical": "^2.0.0",
+                "is-decimal": "^2.0.0",
+                "is-hexadecimal": "^2.0.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/wooorm"
+            }
+        },
+        "node_modules/parse-entities/node_modules/@types/unist": {
+            "version": "2.0.11",
+            "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.11.tgz",
+            "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==",
+            "license": "MIT",
+            "peer": true
+        },
         "node_modules/parse5": {
             "version": "8.0.0",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "entities": "^6.0.0"
@@ -10795,7 +12346,6 @@
         },
         "node_modules/parse5/node_modules/entities": {
             "version": "6.0.1",
-            "dev": true,
             "license": "BSD-2-Clause",
             "engines": {
                 "node": ">=0.12"
@@ -10925,7 +12475,6 @@
         },
         "node_modules/perfect-debounce": {
             "version": "2.1.0",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/picocolors": {
@@ -10966,7 +12515,6 @@
         },
         "node_modules/pkg-types": {
             "version": "2.3.0",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "confbox": "^0.2.2",
@@ -11145,6 +12693,36 @@
             },
             "engines": {
                 "node": ">=6.0.0"
+            }
+        },
+        "node_modules/pretty-format": {
+            "version": "27.5.1",
+            "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+            "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "ansi-regex": "^5.0.1",
+                "ansi-styles": "^5.0.0",
+                "react-is": "^17.0.1"
+            },
+            "engines": {
+                "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+            }
+        },
+        "node_modules/pretty-format/node_modules/ansi-styles": {
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+            "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
             }
         },
         "node_modules/prismjs": {
@@ -11418,9 +12996,52 @@
                 "node": ">= 12"
             }
         },
+        "node_modules/rc9": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/rc9/-/rc9-3.0.1.tgz",
+            "integrity": "sha512-gMDyleLWVE+i6Sgtc0QbbY6pEKqYs97NGi6isHQPqYlLemPoO8dxQ3uGi0f4NiP98c+jMW6cG1Kx9dDwfvqARQ==",
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "defu": "^6.1.6",
+                "destr": "^2.0.5"
+            }
+        },
+        "node_modules/react": {
+            "version": "19.2.4",
+            "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
+            "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/react-dom": {
+            "version": "19.2.4",
+            "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
+            "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "scheduler": "^0.27.0"
+            },
+            "peerDependencies": {
+                "react": "^19.2.4"
+            }
+        },
+        "node_modules/react-is": {
+            "version": "17.0.2",
+            "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+            "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true
+        },
         "node_modules/readdirp": {
             "version": "5.0.0",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">= 20.19.0"
@@ -11480,6 +13101,237 @@
             "resolved": "https://registry.npmjs.org/regex-utilities/-/regex-utilities-2.3.0.tgz",
             "integrity": "sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng==",
             "license": "MIT"
+        },
+        "node_modules/rehype-external-links": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/rehype-external-links/-/rehype-external-links-3.0.0.tgz",
+            "integrity": "sha512-yp+e5N9V3C6bwBeAC4n796kc86M4gJCdlVhiMTxIrJG5UHDMh+PJANf9heqORJbt1nrCbDwIlAZKjANIaVBbvw==",
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@types/hast": "^3.0.0",
+                "@ungap/structured-clone": "^1.0.0",
+                "hast-util-is-element": "^3.0.0",
+                "is-absolute-url": "^4.0.0",
+                "space-separated-tokens": "^2.0.0",
+                "unist-util-visit": "^5.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/rehype-minify-whitespace": {
+            "version": "6.0.2",
+            "resolved": "https://registry.npmjs.org/rehype-minify-whitespace/-/rehype-minify-whitespace-6.0.2.tgz",
+            "integrity": "sha512-Zk0pyQ06A3Lyxhe9vGtOtzz3Z0+qZ5+7icZ/PL/2x1SHPbKao5oB/g/rlc6BCTajqBb33JcOe71Ye1oFsuYbnw==",
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@types/hast": "^3.0.0",
+                "hast-util-minify-whitespace": "^1.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/rehype-raw": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/rehype-raw/-/rehype-raw-7.0.0.tgz",
+            "integrity": "sha512-/aE8hCfKlQeA8LmyeyQvQF3eBiLRGNlfBJEvWH7ivp9sBqs7TNqBL5X3v157rM4IFETqDnIOO+z5M/biZbo9Ww==",
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@types/hast": "^3.0.0",
+                "hast-util-raw": "^9.0.0",
+                "vfile": "^6.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/rehype-remark": {
+            "version": "10.0.1",
+            "resolved": "https://registry.npmjs.org/rehype-remark/-/rehype-remark-10.0.1.tgz",
+            "integrity": "sha512-EmDndlb5NVwXGfUa4c9GPK+lXeItTilLhE6ADSaQuHr4JUlKw9MidzGzx4HpqZrNCt6vnHmEifXQiiA+CEnjYQ==",
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@types/hast": "^3.0.0",
+                "@types/mdast": "^4.0.0",
+                "hast-util-to-mdast": "^10.0.0",
+                "unified": "^11.0.0",
+                "vfile": "^6.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/rehype-slug": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/rehype-slug/-/rehype-slug-6.0.0.tgz",
+            "integrity": "sha512-lWyvf/jwu+oS5+hL5eClVd3hNdmwM1kAC0BUvEGD19pajQMIzcNUd/k9GsfQ+FfECvX+JE+e9/btsKH0EjJT6A==",
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@types/hast": "^3.0.0",
+                "github-slugger": "^2.0.0",
+                "hast-util-heading-rank": "^3.0.0",
+                "hast-util-to-string": "^3.0.0",
+                "unist-util-visit": "^5.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/rehype-sort-attribute-values": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/rehype-sort-attribute-values/-/rehype-sort-attribute-values-5.0.1.tgz",
+            "integrity": "sha512-lU3ABJO5frbUgV132YS6SL7EISf//irIm9KFMaeu5ixHfgWf6jhe+09Uf/Ef8pOYUJWKOaQJDRJGCXs6cNsdsQ==",
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@types/hast": "^3.0.0",
+                "hast-util-is-element": "^3.0.0",
+                "unist-util-visit": "^5.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/rehype-sort-attributes": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/rehype-sort-attributes/-/rehype-sort-attributes-5.0.1.tgz",
+            "integrity": "sha512-Bxo+AKUIELcnnAZwJDt5zUDDRpt4uzhfz9d0PVGhcxYWsbFj5Cv35xuWxu5r1LeYNFNhgGqsr9Q2QiIOM/Qctg==",
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@types/hast": "^3.0.0",
+                "unist-util-visit": "^5.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/remark-emoji": {
+            "version": "5.0.2",
+            "resolved": "https://registry.npmjs.org/remark-emoji/-/remark-emoji-5.0.2.tgz",
+            "integrity": "sha512-IyIqGELcyK5AVdLFafoiNww+Eaw/F+rGrNSXoKucjo95uL267zrddgxGM83GN1wFIb68pyDuAsY3m5t2Cav1pQ==",
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@types/mdast": "^4.0.4",
+                "emoticon": "^4.0.1",
+                "mdast-util-find-and-replace": "^3.0.1",
+                "node-emoji": "^2.1.3",
+                "unified": "^11.0.4"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/remark-gfm": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/remark-gfm/-/remark-gfm-4.0.1.tgz",
+            "integrity": "sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==",
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@types/mdast": "^4.0.0",
+                "mdast-util-gfm": "^3.0.0",
+                "micromark-extension-gfm": "^3.0.0",
+                "remark-parse": "^11.0.0",
+                "remark-stringify": "^11.0.0",
+                "unified": "^11.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/remark-mdc": {
+            "version": "3.10.0",
+            "resolved": "https://registry.npmjs.org/remark-mdc/-/remark-mdc-3.10.0.tgz",
+            "integrity": "sha512-gJhrSs4bGyqr7eSuLoaLlpmiDZrJ9fP/8gTA/w1CnKnW/mfxc9VKM+ndzpOxHQnpAU4tjD8QqF6SMLiOvIVTYA==",
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@types/mdast": "^4.0.4",
+                "@types/unist": "^3.0.3",
+                "flat": "^6.0.1",
+                "mdast-util-from-markdown": "^2.0.2",
+                "mdast-util-to-markdown": "^2.1.2",
+                "micromark": "^4.0.2",
+                "micromark-core-commonmark": "^2.0.3",
+                "micromark-factory-space": "^2.0.1",
+                "micromark-factory-whitespace": "^2.0.1",
+                "micromark-util-character": "^2.1.1",
+                "micromark-util-types": "^2.0.2",
+                "parse-entities": "^4.0.2",
+                "scule": "^1.3.0",
+                "stringify-entities": "^4.0.4",
+                "unified": "^11.0.5",
+                "unist-util-visit": "^5.0.0",
+                "unist-util-visit-parents": "^6.0.2",
+                "yaml": "^2.8.2"
+            }
+        },
+        "node_modules/remark-parse": {
+            "version": "11.0.0",
+            "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-11.0.0.tgz",
+            "integrity": "sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==",
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@types/mdast": "^4.0.0",
+                "mdast-util-from-markdown": "^2.0.0",
+                "micromark-util-types": "^2.0.0",
+                "unified": "^11.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/remark-rehype": {
+            "version": "11.1.2",
+            "resolved": "https://registry.npmjs.org/remark-rehype/-/remark-rehype-11.1.2.tgz",
+            "integrity": "sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw==",
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@types/hast": "^3.0.0",
+                "@types/mdast": "^4.0.0",
+                "mdast-util-to-hast": "^13.0.0",
+                "unified": "^11.0.0",
+                "vfile": "^6.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/remark-stringify": {
+            "version": "11.0.0",
+            "resolved": "https://registry.npmjs.org/remark-stringify/-/remark-stringify-11.0.0.tgz",
+            "integrity": "sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==",
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@types/mdast": "^4.0.0",
+                "mdast-util-to-markdown": "^2.0.0",
+                "unified": "^11.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
         },
         "node_modules/repeat-string": {
             "version": "1.6.1",
@@ -11882,6 +13734,21 @@
                 "node": ">=v12.22.7"
             }
         },
+        "node_modules/scheduler": {
+            "version": "0.27.0",
+            "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+            "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true
+        },
+        "node_modules/scule": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/scule/-/scule-1.3.0.tgz",
+            "integrity": "sha512-6FtHJEvt+pVMIB9IBY+IcCJ6Z5f1iQnytgyfKMhDKgmzYG+TeH/wx1y3l27rshSbLiSanrR9ffZDrEsmjlQF2g==",
+            "license": "MIT",
+            "peer": true
+        },
         "node_modules/semver": {
             "version": "7.7.4",
             "license": "ISC",
@@ -11944,73 +13811,6 @@
                 "node": ">=20"
             }
         },
-        "node_modules/shiki/node_modules/@shikijs/core": {
-            "version": "4.0.2",
-            "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-4.0.2.tgz",
-            "integrity": "sha512-hxT0YF4ExEqB8G/qFdtJvpmHXBYJ2lWW7qTHDarVkIudPFE6iCIrqdgWxGn5s+ppkGXI0aEGlibI0PAyzP3zlw==",
-            "license": "MIT",
-            "dependencies": {
-                "@shikijs/primitive": "4.0.2",
-                "@shikijs/types": "4.0.2",
-                "@shikijs/vscode-textmate": "^10.0.2",
-                "@types/hast": "^3.0.4",
-                "hast-util-to-html": "^9.0.5"
-            },
-            "engines": {
-                "node": ">=20"
-            }
-        },
-        "node_modules/shiki/node_modules/@shikijs/langs": {
-            "version": "4.0.2",
-            "resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-4.0.2.tgz",
-            "integrity": "sha512-KaXby5dvoeuZzN0rYQiPMjFoUrz4hgwIE+D6Du9owcHcl6/g16/yT5BQxSW5cGt2MZBz6Hl0YuRqf12omRfUUg==",
-            "license": "MIT",
-            "dependencies": {
-                "@shikijs/types": "4.0.2"
-            },
-            "engines": {
-                "node": ">=20"
-            }
-        },
-        "node_modules/shiki/node_modules/@shikijs/primitive": {
-            "version": "4.0.2",
-            "resolved": "https://registry.npmjs.org/@shikijs/primitive/-/primitive-4.0.2.tgz",
-            "integrity": "sha512-M6UMPrSa3fN5ayeJwFVl9qWofl273wtK1VG8ySDZ1mQBfhCpdd8nEx7nPZ/tk7k+TYcpqBZzj/AnwxT9lO+HJw==",
-            "license": "MIT",
-            "dependencies": {
-                "@shikijs/types": "4.0.2",
-                "@shikijs/vscode-textmate": "^10.0.2",
-                "@types/hast": "^3.0.4"
-            },
-            "engines": {
-                "node": ">=20"
-            }
-        },
-        "node_modules/shiki/node_modules/@shikijs/themes": {
-            "version": "4.0.2",
-            "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-4.0.2.tgz",
-            "integrity": "sha512-mjCafwt8lJJaVSsQvNVrJumbnnj1RI8jbUKrPKgE6E3OvQKxnuRoBaYC51H4IGHePsGN/QtALglWBU7DoKDFnA==",
-            "license": "MIT",
-            "dependencies": {
-                "@shikijs/types": "4.0.2"
-            },
-            "engines": {
-                "node": ">=20"
-            }
-        },
-        "node_modules/shiki/node_modules/@shikijs/types": {
-            "version": "4.0.2",
-            "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-4.0.2.tgz",
-            "integrity": "sha512-qzbeRooUTPnLE+sHD/Z8DStmaDgnbbc/pMrU203950aRqjX/6AFHeDYT+j00y2lPdz0ywJKx7o/7qnqTivtlXg==",
-            "license": "MIT",
-            "dependencies": {
-                "@shikijs/vscode-textmate": "^10.0.2",
-                "@types/hast": "^3.0.4"
-            },
-            "engines": {
-                "node": ">=20"
-            }
-        },
         "node_modules/short-unique-id": {
             "version": "5.3.2",
             "license": "Apache-2.0",
@@ -12046,6 +13846,19 @@
             },
             "engines": {
                 "node": ">=18"
+            }
+        },
+        "node_modules/skin-tone": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/skin-tone/-/skin-tone-2.0.0.tgz",
+            "integrity": "sha512-kUMbT1oBJCpgrnKoSr0o6wPtvRWT9W9UKvGLwfJYO2WuahZRHOpEyL1ckyMGgMWh0UdpmaoFqKKD29WTomNEGA==",
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "unicode-emoji-modifier-base": "^1.0.0"
+            },
+            "engines": {
+                "node": ">=8"
             }
         },
         "node_modules/slash": {
@@ -12485,7 +14298,6 @@
         },
         "node_modules/tinyglobby": {
             "version": "0.2.15",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "fdir": "^6.5.0",
@@ -12500,7 +14312,6 @@
         },
         "node_modules/tinyglobby/node_modules/fdir": {
             "version": "6.5.0",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=12.0.0"
@@ -12518,7 +14329,6 @@
             "version": "4.0.4",
             "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
             "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=12"
@@ -12653,6 +14463,28 @@
                 "url": "https://github.com/sponsors/wooorm"
             }
         },
+        "node_modules/trim-trailing-lines": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/trim-trailing-lines/-/trim-trailing-lines-2.1.0.tgz",
+            "integrity": "sha512-5UR5Biq4VlVOtzqkm2AZlgvSlDJtME46uV0br0gENbwN4l5+mMKT4b9gJKqWtuL2zAIqajGJGuvbCbcAJUZqBg==",
+            "license": "MIT",
+            "peer": true,
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/wooorm"
+            }
+        },
+        "node_modules/trough": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/trough/-/trough-2.2.0.tgz",
+            "integrity": "sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==",
+            "license": "MIT",
+            "peer": true,
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/wooorm"
+            }
+        },
         "node_modules/ts-api-utils": {
             "version": "2.5.0",
             "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
@@ -12776,7 +14608,7 @@
         },
         "node_modules/typescript": {
             "version": "5.9.3",
-            "dev": true,
+            "devOptional": true,
             "license": "Apache-2.0",
             "bin": {
                 "tsc": "bin/tsc",
@@ -12820,6 +14652,48 @@
             "integrity": "sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q==",
             "license": "MIT"
         },
+        "node_modules/unctx": {
+            "version": "2.5.0",
+            "resolved": "https://registry.npmjs.org/unctx/-/unctx-2.5.0.tgz",
+            "integrity": "sha512-p+Rz9x0R7X+CYDkT+Xg8/GhpcShTlU8n+cf9OtOEf7zEQsNcCZO1dPKNRDqvUTaq+P32PMMkxWHwfrxkqfqAYg==",
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "acorn": "^8.15.0",
+                "estree-walker": "^3.0.3",
+                "magic-string": "^0.30.21",
+                "unplugin": "^2.3.11"
+            }
+        },
+        "node_modules/unctx/node_modules/picomatch": {
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+            "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+            "license": "MIT",
+            "peer": true,
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/jonschlinkert"
+            }
+        },
+        "node_modules/unctx/node_modules/unplugin": {
+            "version": "2.3.11",
+            "resolved": "https://registry.npmjs.org/unplugin/-/unplugin-2.3.11.tgz",
+            "integrity": "sha512-5uKD0nqiYVzlmCRs01Fhs2BdkEgBS3SAVP6ndrBsuK42iC2+JHyxM05Rm9G8+5mkmRtzMZGY8Ct5+mliZxU/Ww==",
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@jridgewell/remapping": "^2.3.5",
+                "acorn": "^8.15.0",
+                "picomatch": "^4.0.3",
+                "webpack-virtual-modules": "^0.6.2"
+            },
+            "engines": {
+                "node": ">=18.12.0"
+            }
+        },
         "node_modules/undici": {
             "version": "5.29.0",
             "dev": true,
@@ -12834,6 +14708,65 @@
         "node_modules/undici-types": {
             "version": "7.18.2",
             "license": "MIT"
+        },
+        "node_modules/unicode-emoji-modifier-base": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/unicode-emoji-modifier-base/-/unicode-emoji-modifier-base-1.0.0.tgz",
+            "integrity": "sha512-yLSH4py7oFH3oG/9K+XWrz1pSi3dfUrWEnInbxMfArOfc1+33BlGPQtLsOYwvdMy11AwUBetYuaRxSPqgkq+8g==",
+            "license": "MIT",
+            "peer": true,
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/unified": {
+            "version": "11.0.5",
+            "resolved": "https://registry.npmjs.org/unified/-/unified-11.0.5.tgz",
+            "integrity": "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==",
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@types/unist": "^3.0.0",
+                "bail": "^2.0.0",
+                "devlop": "^1.0.0",
+                "extend": "^3.0.0",
+                "is-plain-obj": "^4.0.0",
+                "trough": "^2.0.0",
+                "vfile": "^6.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/unist-builder": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/unist-builder/-/unist-builder-4.0.0.tgz",
+            "integrity": "sha512-wmRFnH+BLpZnTKpc5L7O67Kac89s9HMrtELpnNaE6TAobq5DTZZs5YaTQfAZBA9bFPECx2uVAPO31c+GVug8mg==",
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@types/unist": "^3.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/unist-util-find-after": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/unist-util-find-after/-/unist-util-find-after-5.0.0.tgz",
+            "integrity": "sha512-amQa0Ep2m6hE2g72AugUItjbuM8X8cGQnFoHk0pGfrFeT9GZhzN5SW8nRsiGKK7Aif4CrACPENkA6P/Lw6fHGQ==",
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@types/unist": "^3.0.0",
+                "unist-util-is": "^6.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
         },
         "node_modules/unist-util-is": {
             "version": "6.0.1",
@@ -12922,6 +14855,38 @@
             "version": "3.0.0",
             "license": "MIT"
         },
+        "node_modules/untyped": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/untyped/-/untyped-2.0.0.tgz",
+            "integrity": "sha512-nwNCjxJTjNuLCgFr42fEak5OcLuB3ecca+9ksPFNvtfYSLpjf+iJqSIaSnIile6ZPbKYxI5k2AfXqeopGudK/g==",
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "citty": "^0.1.6",
+                "defu": "^6.1.4",
+                "jiti": "^2.4.2",
+                "knitwork": "^1.2.0",
+                "scule": "^1.3.0"
+            },
+            "bin": {
+                "untyped": "dist/cli.mjs"
+            }
+        },
+        "node_modules/unwasm": {
+            "version": "0.5.3",
+            "resolved": "https://registry.npmjs.org/unwasm/-/unwasm-0.5.3.tgz",
+            "integrity": "sha512-keBgTSfp3r6+s9ZcSma+0chwxQdmLbB5+dAD9vjtB21UTMYuKAxHXCU1K2CbCtnP09EaWeRvACnXk0EJtUx+hw==",
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "exsolve": "^1.0.8",
+                "knitwork": "^1.3.0",
+                "magic-string": "^0.30.21",
+                "mlly": "^1.8.0",
+                "pathe": "^2.0.3",
+                "pkg-types": "^2.3.0"
+            }
+        },
         "node_modules/update-browserslist-db": {
             "version": "1.2.3",
             "dev": true,
@@ -12999,6 +14964,21 @@
             "dependencies": {
                 "@types/unist": "^3.0.0",
                 "vfile-message": "^4.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/vfile-location": {
+            "version": "5.0.3",
+            "resolved": "https://registry.npmjs.org/vfile-location/-/vfile-location-5.0.3.tgz",
+            "integrity": "sha512-5yXvWDEgqeiYiBe1lbxYF7UMAIm/IcopxMHrMQDq3nvKcjPKIhZklUKL+AE7J7uApI4kwe2snsK+eI6UTj9EHg==",
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@types/unist": "^3.0.0",
+                "vfile": "^6.0.0"
             },
             "funding": {
                 "type": "opencollective",
@@ -13914,6 +15894,17 @@
                 "node": ">=18"
             }
         },
+        "node_modules/web-namespaces": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/web-namespaces/-/web-namespaces-2.0.1.tgz",
+            "integrity": "sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==",
+            "license": "MIT",
+            "peer": true,
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/wooorm"
+            }
+        },
         "node_modules/web-streams-polyfill": {
             "version": "3.3.3",
             "license": "MIT",
@@ -13940,7 +15931,6 @@
         },
         "node_modules/webpack-virtual-modules": {
             "version": "0.6.2",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/whatwg-mimetype": {

--- a/ui/package.json
+++ b/ui/package.json
@@ -122,7 +122,6 @@
         "playwright": "^1.55.0",
         "prettier": "^3.8.1",
         "rimraf": "^6.1.3",
-        "rolldown-vite": "^7.3.1",
         "rollup-plugin-copy": "^3.5.0",
         "sass": "^1.98.0",
         "storybook": "^10.3.3",
@@ -131,7 +130,7 @@
         "typescript": "^5.9.3",
         "typescript-eslint": "^8.58.0",
         "uuid": "^13.0.0",
-        "vite": "npm:rolldown-vite@latest",
+        "vite": "^8.0.0",
         "vitest": "^4.1.2",
         "vue-tsc": "^3.2.6"
     },
@@ -158,7 +157,7 @@
             "@popperjs/core": "npm:@sxzz/popperjs-es@^2.11.7"
         },
         "storybook": "$storybook",
-        "vite": "npm:rolldown-vite@latest"
+        "vite": "^8.0.0"
     },
     "lint-staged": {
         "**/*.{js,mjs,cjs,ts,vue}": "eslint --fix"

--- a/ui/package.json
+++ b/ui/package.json
@@ -157,7 +157,10 @@
             "@popperjs/core": "npm:@sxzz/popperjs-es@^2.11.7"
         },
         "storybook": "$storybook",
-        "vite": "^8.0.0"
+        "vite": "^8.0.0",
+        "@codecov/vite-plugin": {
+            "vite": "$vite"
+        }
     },
     "lint-staged": {
         "**/*.{js,mjs,cjs,ts,vue}": "eslint --fix"

--- a/ui/plugins/stub-nuxtjs-mdc.js
+++ b/ui/plugins/stub-nuxtjs-mdc.js
@@ -1,0 +1,26 @@
+/**
+ * Stub for @nuxtjs/mdc, which is a peer dependency of @kestra-io/ui-libs that is
+ * not installed in this project. All imports from @nuxtjs/mdc/* are aliased to this
+ * file in vite.config.js to prevent Rolldown from erroring on unresolved imports.
+ */
+import {computed as vueComputed} from "vue";
+
+// Re-export stubs from @kestra-io/ui-libs where applicable
+export const useRuntimeConfig = () => ({
+    public: {
+        mdc: {
+            headings: {
+                anchorLinks: true
+            }
+        }
+    }
+});
+export const computed = vueComputed;
+export const resolveComponent = () => undefined;
+
+// Stubs for @nuxtjs/mdc/runtime named exports
+export const createMarkdownParser = async () => () => null;
+export const createShikiHighlighter = async () => ({});
+export const rehypeHighlight = () => {};
+
+export default {};

--- a/ui/vite.config.js
+++ b/ui/vite.config.js
@@ -5,13 +5,16 @@ import vue from "@vitejs/plugin-vue";
 import {commit} from "./plugins/commit"
 import {codecovVitePlugin} from "@codecov/vite-plugin";
 
+const MDC_STUB = path.resolve(__dirname, "node_modules/@kestra-io/ui-libs/stub-mdc-imports.js");
+const NUXTJS_MDC_STUB = path.resolve(__dirname, "plugins/stub-nuxtjs-mdc.js");
+
 export default defineConfig({
     base: "",
     build: {
         outDir: "../webserver/src/main/resources/ui",
         rollupOptions: {
             output: {
-                advancedChunks: {
+                codeSplitting: {
                     groups: [
                         {
                             test: /src\/components\/dashboard/i,
@@ -40,15 +43,19 @@ export default defineConfig({
         }
     },
     resolve: {
-        alias: {
-            "override": path.resolve(__dirname, "src/override/"),
-            "kestra-api": path.resolve(__dirname, "src/generated/kestra-api/"),
-            "#imports": path.resolve(__dirname, "node_modules/@kestra-io/ui-libs/stub-mdc-imports.js"),
-            "#build/mdc-image-component.mjs": path.resolve(__dirname, "node_modules/@kestra-io/ui-libs/stub-mdc-imports.js"),
-            "#mdc-imports": path.resolve(__dirname, "node_modules/@kestra-io/ui-libs/stub-mdc-imports.js"),
-            "#mdc-configs": path.resolve(__dirname, "node_modules/@kestra-io/ui-libs/stub-mdc-imports.js"),
-            "@storybook/addon-actions": "storybook/actions",
-        },
+        alias: [
+            {find: "override", replacement: path.resolve(__dirname, "src/override/")},
+            {find: "kestra-api", replacement: path.resolve(__dirname, "src/generated/kestra-api/")},
+            {find: "#imports", replacement: MDC_STUB},
+            {find: "#build/mdc-image-component.mjs", replacement: MDC_STUB},
+            {find: "#mdc-imports", replacement: MDC_STUB},
+            {find: "#mdc-configs", replacement: MDC_STUB},
+            {find: "@storybook/addon-actions", replacement: "storybook/actions"},
+            // @nuxtjs/mdc is a peer dep of @kestra-io/ui-libs that is not installed here;
+            // all its subpaths are stubbed out to prevent Rolldown from erroring on
+            // unresolved imports (Vite 8 treats them as errors, not warnings).
+            {find: /^@nuxtjs\/mdc(\/.*)?$/, replacement: NUXTJS_MDC_STUB},
+        ],
     },
     plugins: [
         vue({

--- a/ui/vitest.config.js
+++ b/ui/vitest.config.js
@@ -17,9 +17,7 @@ const dirname =
 export default defineConfig({
     plugins: [vue()],
     resolve: {
-        alias: {
-            ...viteConfig.resolve.alias,
-        },
+        alias: viteConfig.resolve.alias,
     },
     test: {
         projects: [

--- a/ui/vitest.config.unit.js
+++ b/ui/vitest.config.unit.js
@@ -8,9 +8,7 @@ export default defineProject({
         vue(),
     ],
     resolve: {
-        alias: {
-            ...viteConfig.resolve.alias,
-        },
+        alias: viteConfig.resolve.alias,
     },
     test: {
         name: "unit",


### PR DESCRIPTION
- Replace `"vite": "npm:rolldown-vite@latest"` alias with `"vite": "^8.0.0"`
  (rolldown-vite is now officially deprecated; Vite 8 ships with Rolldown natively)
- Remove `rolldown-vite` devDependency
- Update `overrides.vite` to `"^8.0.0"`
- Migrate `advancedChunks` → `codeSplitting` in vite.config.js (deprecated in Vite 8)
- Convert `resolve.alias` from object to array form to allow regex-based aliases
- Add `/^@nuxtjs\/mdc/` regex alias + stub: Rolldown in Vite 8 treats unresolved imports
  as errors (was a warning in rolldown-vite 7); `@nuxtjs/mdc` is a peer dep of
  `@kestra-io/ui-libs` that is intentionally not installed
- Update vitest configs to pass `viteConfig.resolve.alias` directly (array, not spread)

https://claude.ai/code/session_01SagFQxoe5NMnmdjs1qXXjV