### PR TITLE
fix(executor): defer WorkerJobRunningStateStore and CREATED state event to fix flaky test initialization

### DIFF
--- a/executor/src/main/java/io/kestra/executor/DefaultExecutor.java
+++ b/executor/src/main/java/io/kestra/executor/DefaultExecutor.java
@@ -153,11 +153,12 @@ public class DefaultExecutor extends AbstractService implements Executor {
         this.numberOfThreads = threadCount != 0 ? threadCount : Math.max(4, KestraContext.getContext().getAllocatedCpuCores());
         this.workerTaskResultExecutorService = executorsUtils.maxCachedThreadPool(numberOfThreads, "executor-worker-task-result-executor");
         this.executionExecutorService = executorsUtils.maxCachedThreadPool(numberOfThreads, "executor-execution-event-executor");
-        setState(ServiceState.CREATED);
     }
 
     @PostConstruct
-    void initMetrics() {
+    void init() {
+        setState(ServiceState.CREATED);
+
         // create metrics to store thread count
         this.metricRegistry.gauge(MetricRegistry.METRIC_EXECUTOR_THREAD_COUNT, MetricRegistry.METRIC_EXECUTOR_THREAD_COUNT_DESCRIPTION, numberOfThreads);
     }

--- a/executor/src/main/java/io/kestra/executor/ExecutorService.java
+++ b/executor/src/main/java/io/kestra/executor/ExecutorService.java
@@ -6,6 +6,7 @@ import java.util.*;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
+import jakarta.inject.Provider;
 import org.slf4j.Logger;
 import org.slf4j.event.Level;
 
@@ -70,7 +71,7 @@ public class ExecutorService {
     private WorkerGroupMetaStore workerGroupMetaStore;
 
     @Inject
-    private WorkerJobRunningStateStore workerJobRunningStateStore;
+    private Provider<WorkerJobRunningStateStore> workerJobRunningStateStore;
 
     protected FlowMetaStoreInterface flowExecutorInterface;
 
@@ -1214,7 +1215,7 @@ public class ExecutorService {
         executor.withExecution(newExecution, "addWorkerTaskResult");
         if (taskRun.getState().isTerminated()) {
             log.trace("TaskRun terminated: {}", taskRun);
-            workerJobRunningStateStore.deleteByKey(taskRun.getId());
+            workerJobRunningStateStore.get().deleteByKey(taskRun.getId());
             metricRegistry
                 .counter(
                     MetricRegistry.METRIC_EXECUTOR_TASKRUN_ENDED_COUNT,
@@ -1416,7 +1417,7 @@ public class ExecutorService {
     /**
      * Handle flow ExecutionChangedSLA on an executor.
      * If there are SLA violations, it will take care of updating the execution based on the SLA behavior.
-     * 
+     *
      * @see #processViolation(RunContext, ExecutorContext, Violation)
      *      <p>
      *      WARNING: ATM, only the first violation will update the execution.


### PR DESCRIPTION
### ✨ Description
defer WorkerJobRunningStateStore and CREATED state event to fix flaky test initialization                                                                                                                                                                                                                                                                                                                                                           
                                                                                                                                                                                                                                                        
### 🛠️  Backend Checklist                                                                                                                                                                                                                                                                                                                          
                                                                                                                                                                                                                                                                                                                                               
- [x] Code compiles successfully and passes all checks
- [x] All unit and integration tests pass