### PR TITLE
feat(worker): add controller metrics to WorkerJobDispatcher for capacity planning

### DIFF
--- a/core/src/main/java/io/kestra/core/metrics/MetricRegistry.java
+++ b/core/src/main/java/io/kestra/core/metrics/MetricRegistry.java
@@ -59,6 +59,34 @@ public class MetricRegistry {
     public static final String METRIC_WORKER_KILLED_COUNT = "worker.killed.count";
     public static final String METRIC_WORKER_KILLED_COUNT_DESCRIPTION = "The total number of executions killed events received the Executor";
 
+    // Controller (WorkerJobDispatcher) metrics
+    public static final String METRIC_CONTROLLER_ACTIVE_WORKER_COUNT = "controller.active.worker.count";
+    public static final String METRIC_CONTROLLER_ACTIVE_WORKER_COUNT_DESCRIPTION = "The number of active workers in a group";
+    public static final String METRIC_CONTROLLER_AVAILABLE_PERMITS_COUNT = "controller.available.permits.count";
+    public static final String METRIC_CONTROLLER_AVAILABLE_PERMITS_COUNT_DESCRIPTION = "The total available permits (remaining capacity) in a group";
+    public static final String METRIC_CONTROLLER_INFLIGHT_COUNT = "controller.inflight.count";
+    public static final String METRIC_CONTROLLER_INFLIGHT_COUNT_DESCRIPTION = "The total number of in-flight jobs in a group";
+    public static final String METRIC_CONTROLLER_TOTAL_ACTIVE_WORKER_COUNT = "controller.total.active.worker.count";
+    public static final String METRIC_CONTROLLER_TOTAL_ACTIVE_WORKER_COUNT_DESCRIPTION = "The total number of active workers across all groups";
+    public static final String METRIC_CONTROLLER_TOTAL_AVAILABLE_PERMITS_COUNT = "controller.total.available.permits.count";
+    public static final String METRIC_CONTROLLER_TOTAL_AVAILABLE_PERMITS_COUNT_DESCRIPTION = "The total available permits across all groups";
+    public static final String METRIC_CONTROLLER_JOB_DISPATCHED_COUNT = "controller.job.dispatched.count";
+    public static final String METRIC_CONTROLLER_JOB_DISPATCHED_COUNT_DESCRIPTION = "The total number of jobs dispatched to workers";
+    public static final String METRIC_CONTROLLER_JOB_REQUEUED_COUNT = "controller.job.requeued.count";
+    public static final String METRIC_CONTROLLER_JOB_REQUEUED_COUNT_DESCRIPTION = "The total number of jobs re-queued due to no worker capacity";
+    public static final String METRIC_CONTROLLER_JOB_KILLED_COUNT = "controller.job.killed.count";
+    public static final String METRIC_CONTROLLER_JOB_KILLED_COUNT_DESCRIPTION = "The total number of jobs skipped because the execution was killed";
+    public static final String METRIC_CONTROLLER_JOB_DISPATCH_FAILED_COUNT = "controller.job.dispatch.failed.count";
+    public static final String METRIC_CONTROLLER_JOB_DISPATCH_FAILED_COUNT_DESCRIPTION = "The total number of job dispatch failures";
+    public static final String METRIC_CONTROLLER_WORKER_REGISTERED_COUNT = "controller.worker.registered.count";
+    public static final String METRIC_CONTROLLER_WORKER_REGISTERED_COUNT_DESCRIPTION = "The total number of worker registrations";
+    public static final String METRIC_CONTROLLER_WORKER_UNREGISTERED_COUNT = "controller.worker.unregistered.count";
+    public static final String METRIC_CONTROLLER_WORKER_UNREGISTERED_COUNT_DESCRIPTION = "The total number of worker disconnections";
+    public static final String METRIC_CONTROLLER_SUBSCRIPTION_PAUSED_COUNT = "controller.subscription.paused.count";
+    public static final String METRIC_CONTROLLER_SUBSCRIPTION_PAUSED_COUNT_DESCRIPTION = "The total number of queue subscription pauses";
+    public static final String METRIC_CONTROLLER_SUBSCRIPTION_RESUMED_COUNT = "controller.subscription.resumed.count";
+    public static final String METRIC_CONTROLLER_SUBSCRIPTION_RESUMED_COUNT_DESCRIPTION = "The total number of queue subscription resumes";
+
     public static final String METRIC_EXECUTOR_THREAD_COUNT = "executor.thread.count";
     public static final String METRIC_EXECUTOR_THREAD_COUNT_DESCRIPTION = "The number of executor threads";
     public static final String METRIC_EXECUTOR_TASKRUN_CREATED_COUNT = "executor.taskrun.created.count";

--- a/worker-controller/src/main/java/io/kestra/controller/grpc/services/WorkerJobDispatcher.java
+++ b/worker-controller/src/main/java/io/kestra/controller/grpc/services/WorkerJobDispatcher.java
@@ -10,6 +10,7 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.locks.ReentrantLock;
+import java.util.function.Supplier;
 import java.util.stream.Stream;
 
 import javax.annotation.concurrent.ThreadSafe;
@@ -44,6 +45,7 @@ import io.kestra.core.scheduler.queue.TriggerEventQueue;
 import io.kestra.core.serializers.JacksonMapper;
 import io.kestra.core.server.ClusterEvent;
 import io.kestra.core.utils.Either;
+import io.kestra.core.metrics.MetricRegistry;
 import io.kestra.core.worker.WorkerBroadcastEvent;
 
 import io.micronaut.core.annotation.Nullable;
@@ -90,6 +92,7 @@ public class WorkerJobDispatcher {
     private final WorkerJobRunningStateStore workerJobRunningStateStore;
     private final DispatchQueueInterface<WorkerTaskResult> workerTaskResultQueue;
     private final TriggerEventQueue triggerEventQueue;
+    private final MetricRegistry metricRegistry;
 
     /**
      * Global closed flag to prevent operations after shutdown.
@@ -137,11 +140,13 @@ public class WorkerJobDispatcher {
         BroadcastQueueInterface<ExecutionKilled> executionKilledQueue,
         @Nullable BroadcastQueueInterface<ClusterEvent> clusterEventQueue,
         DispatchQueueInterface<WorkerTaskResult> workerTaskResultQueue,
-        TriggerEventQueue triggerEventQueue) {
+        TriggerEventQueue triggerEventQueue,
+        MetricRegistry metricRegistry) {
         this.workerJobEventQueue = workerJobEventQueue;
         this.workerJobRunningStateStore = workerJobRunningStateStore;
         this.workerTaskResultQueue = workerTaskResultQueue;
         this.triggerEventQueue = triggerEventQueue;
+        this.metricRegistry = metricRegistry;
 
         // Subscribe to execution killed events
         this.killQueueSubscriber = executionKilledQueue.subscriber();
@@ -169,6 +174,20 @@ public class WorkerJobDispatcher {
                 onClusterEvent(either.getLeft());
             });
         }
+
+        // Register global gauges
+        this.metricRegistry.gauge(
+            MetricRegistry.METRIC_CONTROLLER_TOTAL_ACTIVE_WORKER_COUNT,
+            MetricRegistry.METRIC_CONTROLLER_TOTAL_ACTIVE_WORKER_COUNT_DESCRIPTION,
+            (Supplier<Integer>) activeStreams::size
+        );
+        this.metricRegistry.gauge(
+            MetricRegistry.METRIC_CONTROLLER_TOTAL_AVAILABLE_PERMITS_COUNT,
+            MetricRegistry.METRIC_CONTROLLER_TOTAL_AVAILABLE_PERMITS_COUNT_DESCRIPTION,
+            (Supplier<Integer>) () -> activeStreams.values().stream()
+                .mapToInt(WorkerStreamContext::getAvailablePermits)
+                .sum()
+        );
     }
 
     /**
@@ -248,6 +267,11 @@ public class WorkerJobDispatcher {
                 .add(context.getWorkerId());
 
             log.info("Registered worker {} for group '{}'", context.getWorkerId(), WorkerGroup.forLog(workerGroup));
+            metricRegistry.counter(
+                MetricRegistry.METRIC_CONTROLLER_WORKER_REGISTERED_COUNT,
+                MetricRegistry.METRIC_CONTROLLER_WORKER_REGISTERED_COUNT_DESCRIPTION,
+                metricRegistry.workerGroupTags(workerGroup.isEmpty() ? null : workerGroup)
+            ).increment();
 
             // Resume subscription if worker has permits
             if (context.getAvailablePermits() > 0) {
@@ -274,6 +298,31 @@ public class WorkerJobDispatcher {
         subscriber.pause(); // Start paused until workers connect with permits
         subscriber.subscribe(either -> handleIncomingJob(workerGroup, either));
         log.info("Created queue subscription for worker group '{}' (initially paused)", WorkerGroup.forLog(workerGroup));
+
+        // Register per-group gauges
+        String[] groupTags = metricRegistry.workerGroupTags(workerGroupOrNull);
+        metricRegistry.gauge(
+            MetricRegistry.METRIC_CONTROLLER_ACTIVE_WORKER_COUNT,
+            MetricRegistry.METRIC_CONTROLLER_ACTIVE_WORKER_COUNT_DESCRIPTION,
+            (Supplier<Integer>) () -> {
+                Set<String> ids = workerIdsByGroup.get(workerGroup);
+                return ids == null ? 0 : ids.size();
+            },
+            groupTags
+        );
+        metricRegistry.gauge(
+            MetricRegistry.METRIC_CONTROLLER_AVAILABLE_PERMITS_COUNT,
+            MetricRegistry.METRIC_CONTROLLER_AVAILABLE_PERMITS_COUNT_DESCRIPTION,
+            (Supplier<Integer>) () -> getTotalPermitsForGroup(workerGroup),
+            groupTags
+        );
+        metricRegistry.gauge(
+            MetricRegistry.METRIC_CONTROLLER_INFLIGHT_COUNT,
+            MetricRegistry.METRIC_CONTROLLER_INFLIGHT_COUNT_DESCRIPTION,
+            (Supplier<Integer>) () -> getWorkersInGroup(workerGroup).mapToInt(WorkerStreamContext::getInFlightCount).sum(),
+            groupTags
+        );
+
         return new GroupState(subscriber);
     }
 
@@ -313,6 +362,11 @@ public class WorkerJobDispatcher {
             }
 
             log.info("Unregistered worker {} from group '{}', had {} in-flight jobs", workerId, WorkerGroup.forLog(workerGroup), context.getInFlightCount());
+            metricRegistry.counter(
+                MetricRegistry.METRIC_CONTROLLER_WORKER_UNREGISTERED_COUNT,
+                MetricRegistry.METRIC_CONTROLLER_WORKER_UNREGISTERED_COUNT_DESCRIPTION,
+                metricRegistry.workerGroupTags(workerGroup.isEmpty() ? null : workerGroup)
+            ).increment();
 
             // Check if there are any workers left for this group
             int remainingWorkers = groupWorkers == null ? 0 : groupWorkers.size();
@@ -323,6 +377,7 @@ public class WorkerJobDispatcher {
                 workerIdsByGroup.remove(workerGroup);
                 log.info("Disposing subscription for group '{}': no workers remaining", WorkerGroup.forLog(workerGroup));
                 closeSubscriberQuietly(state.subscriber(), workerGroup);
+                removeGroupGauges(workerGroup);
             } else if (!hasAnyPermitsInGroup(workerGroup)) {
                 // Workers exist but no permits - pause
                 pauseSubscription(state, workerGroup);
@@ -410,6 +465,11 @@ public class WorkerJobDispatcher {
                     && killedExecutionIds.getIfPresent(executionId) != null
             ) {
                 log.info("Skipping dispatch of task '{}' for killed execution '{}'", job.uid(), executionId);
+                metricRegistry.counter(
+                    MetricRegistry.METRIC_CONTROLLER_JOB_KILLED_COUNT,
+                    MetricRegistry.METRIC_CONTROLLER_JOB_KILLED_COUNT_DESCRIPTION,
+                    metricRegistry.workerGroupTags(workerGroup.isEmpty() ? null : workerGroup)
+                ).increment();
                 try {
                     workerTaskResultQueue.emit(new WorkerTaskResult(workerTask.getTaskRun().withState(State.Type.KILLED)));
                 } catch (QueueException e) {
@@ -442,6 +502,11 @@ public class WorkerJobDispatcher {
                 // No worker with capacity - pause subscription and re-queue job
                 pauseSubscription(state, workerGroup);
                 log.debug("No workers with permits for group '{}', re-queuing job {}", WorkerGroup.forLog(workerGroup), job.uid());
+                metricRegistry.counter(
+                    MetricRegistry.METRIC_CONTROLLER_JOB_REQUEUED_COUNT,
+                    MetricRegistry.METRIC_CONTROLLER_JOB_REQUEUED_COUNT_DESCRIPTION,
+                    metricRegistry.workerGroupTags(workerGroup.isEmpty() ? null : workerGroup)
+                ).increment();
                 requeue(event);
             }
         } finally {
@@ -541,6 +606,11 @@ public class WorkerJobDispatcher {
 
             context.sendResponse(response);
             log.debug("Dispatched job {} to worker {}", jobId, context.getWorkerId());
+            metricRegistry.counter(
+                MetricRegistry.METRIC_CONTROLLER_JOB_DISPATCHED_COUNT,
+                MetricRegistry.METRIC_CONTROLLER_JOB_DISPATCHED_COUNT_DESCRIPTION,
+                metricRegistry.workerGroupTags(context.getWorkerGroup().isEmpty() ? null : context.getWorkerGroup())
+            ).increment();
 
         } catch (Exception e) {
             log.error("Failed to send job {} to worker {}: {}", jobId, context.getWorkerId(), e.getMessage());
@@ -567,6 +637,12 @@ public class WorkerJobDispatcher {
      */
     private void handleDispatchFailure(WorkerStreamContext<WorkerJobResponse> context, WorkerJob job,
         WorkerJobEvent originalEvent) {
+        metricRegistry.counter(
+            MetricRegistry.METRIC_CONTROLLER_JOB_DISPATCH_FAILED_COUNT,
+            MetricRegistry.METRIC_CONTROLLER_JOB_DISPATCH_FAILED_COUNT_DESCRIPTION,
+            metricRegistry.workerGroupTags(context.getWorkerGroup().isEmpty() ? null : context.getWorkerGroup())
+        ).increment();
+
         // Restore permit to the worker
         context.addPermits(1);
 
@@ -596,6 +672,11 @@ public class WorkerJobDispatcher {
         if (state.isPaused.compareAndSet(false, true)) {
             state.subscriber.pause();
             log.info("Paused subscription for group '{}'", WorkerGroup.forLog(workerGroup));
+            metricRegistry.counter(
+                MetricRegistry.METRIC_CONTROLLER_SUBSCRIPTION_PAUSED_COUNT,
+                MetricRegistry.METRIC_CONTROLLER_SUBSCRIPTION_PAUSED_COUNT_DESCRIPTION,
+                metricRegistry.workerGroupTags(workerGroup.isEmpty() ? null : workerGroup)
+            ).increment();
         }
     }
 
@@ -603,6 +684,11 @@ public class WorkerJobDispatcher {
         if (state.isPaused.compareAndSet(true, false)) {
             state.subscriber.resume();
             log.info("Resumed subscription for group '{}'", WorkerGroup.forLog(workerGroup));
+            metricRegistry.counter(
+                MetricRegistry.METRIC_CONTROLLER_SUBSCRIPTION_RESUMED_COUNT,
+                MetricRegistry.METRIC_CONTROLLER_SUBSCRIPTION_RESUMED_COUNT_DESCRIPTION,
+                metricRegistry.workerGroupTags(workerGroup.isEmpty() ? null : workerGroup)
+            ).increment();
         }
     }
 
@@ -611,6 +697,19 @@ public class WorkerJobDispatcher {
             subscriber.close();
         } catch (Exception e) {
             log.warn("Error closing subscription for group '{}': {}", WorkerGroup.forLog(workerGroup), e.getMessage());
+        }
+    }
+
+    private void removeGroupGauges(String workerGroup) {
+        String workerGroupTag = workerGroup.isEmpty() ? "__default__" : workerGroup;
+        for (String metricName : List.of(
+            MetricRegistry.METRIC_CONTROLLER_ACTIVE_WORKER_COUNT,
+            MetricRegistry.METRIC_CONTROLLER_AVAILABLE_PERMITS_COUNT,
+            MetricRegistry.METRIC_CONTROLLER_INFLIGHT_COUNT)) {
+            metricRegistry.find(metricName)
+                .tag(MetricRegistry.TAG_WORKER_GROUP, workerGroupTag)
+                .gauges()
+                .forEach(metricRegistry::removeMeter);
         }
     }
 

--- a/worker-controller/src/test/java/io/kestra/controller/grpc/services/WorkerJobDispatcherTest.java
+++ b/worker-controller/src/test/java/io/kestra/controller/grpc/services/WorkerJobDispatcherTest.java
@@ -36,12 +36,15 @@ import io.kestra.core.runners.WorkerTask;
 import io.kestra.core.runners.WorkerTaskResult;
 import io.kestra.core.scheduler.queue.TriggerEventQueue;
 import io.kestra.core.server.ClusterEvent;
+import io.kestra.core.metrics.MetricRegistry;
 import io.kestra.core.utils.Either;
 
 import io.grpc.stub.StreamObserver;
+import io.micrometer.core.instrument.search.Search;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 
@@ -63,6 +66,7 @@ class WorkerJobDispatcherTest {
     private DispatchQueueInterface<WorkerTaskResult> mockResultQueue = mock(DispatchQueueInterface.class);
     private WorkerJobDispatcher dispatcher;
     private TriggerEventQueue mockTriggerEventQueue = mock(TriggerEventQueue.class);
+    private MetricRegistry mockMetricRegistry = mock(MetricRegistry.class);
 
     // Captures for verifying interactions
     private List<MockQueueSubscriber> createdSubscribers;
@@ -82,7 +86,29 @@ class WorkerJobDispatcherTest {
         mockClusterEventQueue = mock(BroadcastQueueInterface.class);
         mockResultQueue = mock(DispatchQueueInterface.class);
         mockTriggerEventQueue = mock(TriggerEventQueue.class);
+        mockMetricRegistry = mock(MetricRegistry.class);
         createdSubscribers = new ArrayList<>();
+
+        // Mock workerGroupTags to return proper tag arrays
+        when(mockMetricRegistry.workerGroupTags(any())).thenAnswer(invocation -> {
+            String group = invocation.getArgument(0);
+            return new String[] { "worker_group", group != null ? group : "__default__" };
+        });
+
+        // Mock counter to return a no-op counter
+        io.micrometer.core.instrument.Counter mockCounter = mock(io.micrometer.core.instrument.Counter.class);
+        when(mockMetricRegistry.counter(anyString(), anyString(), any(String[].class))).thenReturn(mockCounter);
+
+        // Mock gauge to return a no-op gauge
+        io.micrometer.core.instrument.Gauge mockGauge = mock(io.micrometer.core.instrument.Gauge.class);
+        when(mockMetricRegistry.gauge(anyString(), anyString(), any(java.util.function.Supplier.class), any(String[].class))).thenReturn(mockGauge);
+        when(mockMetricRegistry.gauge(anyString(), anyString(), any(java.util.function.Supplier.class))).thenReturn(mockGauge);
+
+        // Mock find().tag().gauges() chain for removeGroupGauges
+        Search mockSearch = mock(Search.class);
+        when(mockMetricRegistry.find(anyString())).thenReturn(mockSearch);
+        when(mockSearch.tag(anyString(), anyString())).thenReturn(mockSearch);
+        when(mockSearch.gauges()).thenReturn(java.util.Collections.emptyList());
 
         // Mock kill queue subscriber
         @SuppressWarnings("unchecked")
@@ -109,7 +135,7 @@ class WorkerJobDispatcherTest {
             return subscriber;
         });
 
-        dispatcher = new WorkerJobDispatcher(mockQueue, mockStateStore, mockKillQueue, mockClusterEventQueue, mockResultQueue, mockTriggerEventQueue);
+        dispatcher = new WorkerJobDispatcher(mockQueue, mockStateStore, mockKillQueue, mockClusterEventQueue, mockResultQueue, mockTriggerEventQueue, mockMetricRegistry);
     }
 
     @AfterEach
@@ -736,6 +762,140 @@ class WorkerJobDispatcherTest {
         // Then — both workers should receive the event
         verify(context1.getResponseObserver()).onNext(any(WorkerJobResponse.class));
         verify(context2.getResponseObserver()).onNext(any(WorkerJobResponse.class));
+    }
+
+    @Test
+    void shouldRegisterGlobalGaugesOnConstruction() {
+        // Then - global gauges should have been registered during setUp()
+        verify(mockMetricRegistry).gauge(
+            eq(MetricRegistry.METRIC_CONTROLLER_TOTAL_ACTIVE_WORKER_COUNT),
+            eq(MetricRegistry.METRIC_CONTROLLER_TOTAL_ACTIVE_WORKER_COUNT_DESCRIPTION),
+            any(java.util.function.Supplier.class)
+        );
+        verify(mockMetricRegistry).gauge(
+            eq(MetricRegistry.METRIC_CONTROLLER_TOTAL_AVAILABLE_PERMITS_COUNT),
+            eq(MetricRegistry.METRIC_CONTROLLER_TOTAL_AVAILABLE_PERMITS_COUNT_DESCRIPTION),
+            any(java.util.function.Supplier.class)
+        );
+    }
+
+    @Test
+    void shouldRegisterPerGroupGaugesOnFirstWorkerRegistration() {
+        // Given
+        WorkerStreamContext<WorkerJobResponse> context = createWorkerContext("worker-1", WORKER_GROUP_A, 10);
+
+        // When
+        dispatcher.registerWorker(context);
+
+        // Then
+        verify(mockMetricRegistry).gauge(
+            eq(MetricRegistry.METRIC_CONTROLLER_ACTIVE_WORKER_COUNT),
+            eq(MetricRegistry.METRIC_CONTROLLER_ACTIVE_WORKER_COUNT_DESCRIPTION),
+            any(java.util.function.Supplier.class),
+            any(String[].class)
+        );
+        verify(mockMetricRegistry).gauge(
+            eq(MetricRegistry.METRIC_CONTROLLER_AVAILABLE_PERMITS_COUNT),
+            eq(MetricRegistry.METRIC_CONTROLLER_AVAILABLE_PERMITS_COUNT_DESCRIPTION),
+            any(java.util.function.Supplier.class),
+            any(String[].class)
+        );
+        verify(mockMetricRegistry).gauge(
+            eq(MetricRegistry.METRIC_CONTROLLER_INFLIGHT_COUNT),
+            eq(MetricRegistry.METRIC_CONTROLLER_INFLIGHT_COUNT_DESCRIPTION),
+            any(java.util.function.Supplier.class),
+            any(String[].class)
+        );
+    }
+
+    @Test
+    void shouldIncrementWorkerRegisteredCounterOnRegister() {
+        // Given
+        WorkerStreamContext<WorkerJobResponse> context = createWorkerContext("worker-1", WORKER_GROUP_A, 10);
+
+        // When
+        dispatcher.registerWorker(context);
+
+        // Then
+        verify(mockMetricRegistry).counter(
+            eq(MetricRegistry.METRIC_CONTROLLER_WORKER_REGISTERED_COUNT),
+            eq(MetricRegistry.METRIC_CONTROLLER_WORKER_REGISTERED_COUNT_DESCRIPTION),
+            any(String[].class)
+        );
+    }
+
+    @Test
+    void shouldIncrementWorkerUnregisteredCounterOnUnregister() {
+        // Given
+        WorkerStreamContext<WorkerJobResponse> context = createWorkerContext("worker-1", WORKER_GROUP_A, 10);
+        dispatcher.registerWorker(context);
+
+        // When
+        dispatcher.unregisterWorker("worker-1");
+
+        // Then
+        verify(mockMetricRegistry).counter(
+            eq(MetricRegistry.METRIC_CONTROLLER_WORKER_UNREGISTERED_COUNT),
+            eq(MetricRegistry.METRIC_CONTROLLER_WORKER_UNREGISTERED_COUNT_DESCRIPTION),
+            any(String[].class)
+        );
+    }
+
+    @Test
+    void shouldIncrementJobDispatchedCounterOnDispatch() {
+        // Given
+        WorkerStreamContext<WorkerJobResponse> context = createWorkerContext("worker-1", WORKER_GROUP_A, 10);
+        context.addPermits(5);
+        dispatcher.registerWorker(context);
+
+        MockQueueSubscriber subscriber = getSubscriberForGroup(WORKER_GROUP_A);
+        WorkerJobEvent event = createJobEvent("job-1", WORKER_GROUP_A);
+
+        // When
+        subscriber.deliverJob(event);
+
+        // Then
+        verify(mockMetricRegistry).counter(
+            eq(MetricRegistry.METRIC_CONTROLLER_JOB_DISPATCHED_COUNT),
+            eq(MetricRegistry.METRIC_CONTROLLER_JOB_DISPATCHED_COUNT_DESCRIPTION),
+            any(String[].class)
+        );
+    }
+
+    @Test
+    void shouldIncrementJobRequeuedCounterWhenNoPermits() {
+        // Given
+        WorkerStreamContext<WorkerJobResponse> context = createWorkerContext("worker-1", WORKER_GROUP_A, 10);
+        // No permits
+        dispatcher.registerWorker(context);
+
+        MockQueueSubscriber subscriber = getSubscriberForGroup(WORKER_GROUP_A);
+        WorkerJobEvent event = createJobEvent("job-1", WORKER_GROUP_A);
+
+        // When
+        subscriber.deliverJob(event);
+
+        // Then
+        verify(mockMetricRegistry).counter(
+            eq(MetricRegistry.METRIC_CONTROLLER_JOB_REQUEUED_COUNT),
+            eq(MetricRegistry.METRIC_CONTROLLER_JOB_REQUEUED_COUNT_DESCRIPTION),
+            any(String[].class)
+        );
+    }
+
+    @Test
+    void shouldRemovePerGroupGaugesWhenLastWorkerDisconnects() {
+        // Given
+        WorkerStreamContext<WorkerJobResponse> context = createWorkerContext("worker-1", WORKER_GROUP_A, 10);
+        dispatcher.registerWorker(context);
+
+        // When
+        dispatcher.unregisterWorker("worker-1");
+
+        // Then - find should be called to locate gauges for removal
+        verify(mockMetricRegistry, atLeastOnce()).find(MetricRegistry.METRIC_CONTROLLER_ACTIVE_WORKER_COUNT);
+        verify(mockMetricRegistry, atLeastOnce()).find(MetricRegistry.METRIC_CONTROLLER_AVAILABLE_PERMITS_COUNT);
+        verify(mockMetricRegistry, atLeastOnce()).find(MetricRegistry.METRIC_CONTROLLER_INFLIGHT_COUNT);
     }
 
     /**


### PR DESCRIPTION
  12 metrics added (5 gauges, 7 counters):

```
  ┌──────────────────────────────────────────────┬─────────┬──────────────┐
  │                    Metric                    │  Type   │     Tags     │
  ├──────────────────────────────────────────────┼─────────┼──────────────┤
  │ controller.active.worker.count               │ Gauge   │ worker_group │
  ├──────────────────────────────────────────────┼─────────┼──────────────┤
  │ controller.available.permits.count           │ Gauge   │ worker_group │
  ├──────────────────────────────────────────────┼─────────┼──────────────┤
  │ controller.inflight.count                    │ Gauge   │ worker_group │
  ├──────────────────────────────────────────────┼─────────┼──────────────┤
  │ controller.total.active.worker.count         │ Gauge   │ —            │
  ├──────────────────────────────────────────────┼─────────┼──────────────┤
  │ controller.total.available.permits.count     │ Gauge   │ —            │
  ├──────────────────────────────────────────────┼─────────┼──────────────┤
  │ controller.job.dispatched.count              │ Counter │ worker_group │
  ├──────────────────────────────────────────────┼─────────┼──────────────┤
  │ controller.job.requeued.count                │ Counter │ worker_group │
  ├──────────────────────────────────────────────┼─────────┼──────────────┤
  │ controller.job.killed.count                  │ Counter │ worker_group │
  ├──────────────────────────────────────────────┼─────────┼──────────────┤
  │ controller.job.dispatch.failed.count         │ Counter │ worker_group │
  ├──────────────────────────────────────────────┼─────────┼──────────────┤
  │ controller.worker.registered.count           │ Counter │ worker_group │
  ├──────────────────────────────────────────────┼─────────┼──────────────┤
  │ controller.worker.unregistered.count         │ Counter │ worker_group │
  ├──────────────────────────────────────────────┼─────────┼──────────────┤
  │ controller.subscription.paused/resumed.count │ Counter │ worker_group │
  └──────────────────────────────────────────────┴─────────┴──────────────
````