### PR TITLE
fix(core): keep other tabs with code editor in disabled state during tour

### DIFF
--- a/ui/src/components/MultiPanelGenericEditorView.vue
+++ b/ui/src/components/MultiPanelGenericEditorView.vue
@@ -64,9 +64,9 @@
     };
 
     const {panels, saveState} = useStoredPanels(
-        props.saveKey, 
-        props.editorElements, 
-        props.defaultActiveTabs, 
+        props.saveKey,
+        props.editorElements,
+        props.defaultActiveTabs,
         props.preSerializePanels,
     );
 
@@ -94,8 +94,6 @@
             }
         }
     }
-
-
 
     const openTabs = computed(() => panels.value.flatMap(p => p.tabs.map(t => t.uid)));
 
@@ -152,3 +150,4 @@
         }
     }
 </style>
+

--- a/ui/src/components/flows/MultiPanelFlowEditorView.vue
+++ b/ui/src/components/flows/MultiPanelFlowEditorView.vue
@@ -2,8 +2,8 @@
     <div class="flow-editor-shell">
         <MultiPanelGenericEditorView
             ref="editorView"
-            :class="{playgroundMode}"
-            :editorElements="editorElements"
+            :class="{playgroundMode, 'tour-mode': isGuidedCodeOnly}"
+            :editorElements="EDITOR_ELEMENTS"
             :defaultActiveTabs="tabs"
             :saveKey
             :preSerializePanels="preSerializePanels"
@@ -86,9 +86,12 @@
     const saveKey = computed(() => flowStore.isCreating ? undefined : alwaysSaveKey.value);
 
     watch(() => flowStore.isCreating, (isCreating) => {
-        if(!isCreating){
-            // when switching from creating to editing, ensure the saveKey is updated
-            editorView.value?.saveState(alwaysSaveKey.value);
+        if (!isCreating) {
+            if (isGuidedCodeOnly.value && alwaysSaveKey.value) {
+                localStorage.removeItem(alwaysSaveKey.value);
+            } else {
+                editorView.value?.saveState(alwaysSaveKey.value);
+            }
         }
     })
 
@@ -153,14 +156,14 @@
     const isGuidedCodeOnly = computed(
         () => onboardingV2Store.isGuidedActive && onboardingV2Store.state.editorMode === "code_only",
     );
-    watch(isGuidedCodeOnly, (guided) => {
+    watch(isGuidedCodeOnly, (guided, wasGuided) => {
         if (guided && playgroundStore.enabled) {
             playgroundStore.enabled = false;
         }
+        if (!guided && wasGuided && alwaysSaveKey.value) {
+            localStorage.removeItem(alwaysSaveKey.value);
+        }
     }, {immediate: true});
-    const editorElements = computed(() => (isGuidedCodeOnly.value
-        ? EDITOR_ELEMENTS.filter((element) => element.uid === "code")
-        : EDITOR_ELEMENTS));
     const tabs = computed(() => (isGuidedCodeOnly.value ? ["code"] : DEFAULT_ACTIVE_TABS));
 
     flowStore.creationId = flowStore.creationId ?? Utils.uid()
@@ -201,6 +204,20 @@
         #{--el-color-primary}: colorPalette.$base-blue-500;
         color: colorPalette.$base-white;
         background-position: 10% 0;
+    }
+
+    .tour-mode :deep(.tabs-wrapper button) {
+        transition: opacity 0.2s ease;
+
+        &:first-child {
+            opacity: 1;
+        }
+
+        &:not(:first-child) {
+            opacity: 0.45;
+            pointer-events: none;
+            cursor: not-allowed;
+        }
     }
 
     .flow-editor-shell {

--- a/ui/tests/e2e/flow.spec.ts
+++ b/ui/tests/e2e/flow.spec.ts
@@ -8,7 +8,6 @@ import {shared} from "./fixtures/shared";
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
-
 const helloFlowYaml = fs.readFileSync(
     path.resolve(__dirname, "./fixtures/flows/hello.yaml"),
     "utf-8"
@@ -100,3 +99,4 @@ test.describe("Flow Page", () => {
         });
     });
 });
+


### PR DESCRIPTION
Closes https://github.com/kestra-io/kestra-ee/issues/7290

**Issue was**


- Guided tour filtered the tabs array to show only code tab while tour was in progress. (as pointed in GH issue description)
- If tour completes/cancels, only then all tabs were showing.


**What I Did**


- Show all tabs, Active panel will be restricted to `code` only. other tabs will be disabled during the tour — users can see they exist but can't interact, keeping focus on the `code`.
- Don't persist state on save - If tour completes/cancels while editor is still open - remove the `localStorage` key which means `editorMode: "code_only" `becomes `editorMode: "normal"`