### PR TITLE
fix: set plugin classloader as thread context in TemplatedTask

### DIFF
--- a/core/src/main/java/io/kestra/plugin/core/templating/TemplatedTask.java
+++ b/core/src/main/java/io/kestra/plugin/core/templating/TemplatedTask.java
@@ -68,7 +68,13 @@ public class TemplatedTask extends Task implements RunnableTask<Output> {
                 throw new IllegalArgumentException("The templated task cannot be of type 'io.kestra.plugin.core.templating.TemplatedTask'");
             }
             if (task instanceof RunnableTask<?> runnableTask) {
-                return runnableTask.run(runContext);
+                ClassLoader previous = Thread.currentThread().getContextClassLoader();
+                Thread.currentThread().setContextClassLoader(runnableTask.getClass().getClassLoader());
+                try {
+                    return runnableTask.run(runContext);
+                } finally {
+                    Thread.currentThread().setContextClassLoader(previous);
+                }
             }
             throw new IllegalArgumentException("The templated task must be a runnable task");
         } catch (JsonProcessingException e) {

--- a/core/src/main/java/io/kestra/plugin/core/templating/TemplatedTask.java
+++ b/core/src/main/java/io/kestra/plugin/core/templating/TemplatedTask.java
@@ -68,6 +68,8 @@ public class TemplatedTask extends Task implements RunnableTask<Output> {
                 throw new IllegalArgumentException("The templated task cannot be of type 'io.kestra.plugin.core.templating.TemplatedTask'");
             }
             if (task instanceof RunnableTask<?> runnableTask) {
+                // we set the context classloader to the classloader of the resolved plugin class,
+                // so that ServiceLoader lookups inside the task resolve against the correct classloader.
                 ClassLoader previous = Thread.currentThread().getContextClassLoader();
                 Thread.currentThread().setContextClassLoader(runnableTask.getClass().getClassLoader());
                 try {


### PR DESCRIPTION
TemplatedTask is part of io.kestra.plugin.core so it runs with the SYSTEM classloader as thread context, so when it runs an inner plugin task, `ServiceLoader` inside libraries like LangChain4j reads the `SYSTEM` classloader but the interface was loaded by the plugin's own classloader which causes micmatch

fixes https://github.com/kestra-io/kestra/issues/13193