### PR TITLE
fix: subflow executions without input parameters (kestra-io#13700)

### DIFF
--- a/cli/src/main/java/io/kestra/cli/services/FileChangedEventListener.java
+++ b/cli/src/main/java/io/kestra/cli/services/FileChangedEventListener.java
@@ -71,7 +71,7 @@ public class FileChangedEventListener {
             this.setup(paths);
 
             // Init existing flows not already in files
-            flowRepositoryInterface.findAllForAllTenants().forEach(flow ->
+            flowRepositoryInterface.findAllWithSourceForAllTenants().forEach(flow ->
             {
                 flowToFile(flow, this.buildPath(flow));
                 flows.add(FlowWithPath.of(flow, this.buildPath(flow).toString()));
@@ -238,8 +238,14 @@ public class FileChangedEventListener {
     private void flowToFile(FlowInterface flow, Path path) {
         Path defaultPath = path != null ? path : this.buildPath(flow);
 
+        String source = flow.sourceOrGenerateIfNull();
+        if (source == null || source.isBlank()) {
+            log.warn("Flow {} has no source, skipping file write to {}", flow.getId(), defaultPath);
+            return;
+        }
+
         try {
-            Files.writeString(defaultPath, flow.source());
+            Files.writeString(defaultPath, source);
             log.info("Flow {} has been written to file {}", flow.getId(), defaultPath);
         } catch (IOException e) {
             log.error("Error writing file: {}", defaultPath, e);


### PR DESCRIPTION
### ✨ Description

Fixes subflows being executed without inputs when Micronaut is in watch mode.

### 🔗 Related Issue

Fixes https://github.com/kestra-io/kestra/issues/13700.

### 🎨 Frontend Checklist

Do not apply.

### 🛠️ Backend Checklist

The fixed issue contains flows and settings that can be used to reproduce the issue.
See: https://github.com/kestra-io/kestra/issues/13700#issue-3735057586

### 📝 Additional Notes

I'm sending the PR after [request](https://github.com/kestra-io/kestra/issues/13700#issuecomment-4205109590) from @loicmathieu.

### 🤖 AI Authors

I'm not an AI but I used Claude Code to help me finding and patching the issue, as I described [here](https://github.com/kestra-io/kestra/issues/13700#issuecomment-4178490006).