### PR TITLE
chore: fix reimplement Execution.findLastByState

### DIFF
--- a/core/src/main/java/io/kestra/core/models/executions/Execution.java
+++ b/core/src/main/java/io/kestra/core/models/executions/Execution.java
@@ -671,6 +671,14 @@ public class Execution implements SoftDeletable<Execution>, TenantInterface, Has
             .findFirst();
     }
 
+    public Optional<TaskRun> findLastByState(List<TaskRun> taskRuns, State.Type state) {
+        return taskRuns
+            .reversed()
+            .stream()
+            .filter(t -> t.getState().getCurrent() == state)
+            .findFirst();
+    }
+
     public Optional<TaskRun> findLastCreated(List<TaskRun> taskRuns) {
         return taskRuns
             .reversed()


### PR DESCRIPTION
### ✨ Description

Reimplement findLastByState as it's used in Kestra EE but was removed in Kestra core for having no usages.

### 🛠️ Backend Checklist

- [x] Code compiles successfully and passes all checks
- [x] All unit and integration tests pass
