### PR TITLE
fix(logs): better handling on repository filters inheritance

### DIFF
--- a/jdbc/src/main/java/io/kestra/jdbc/repository/AbstractJdbcLogRepository.java
+++ b/jdbc/src/main/java/io/kestra/jdbc/repository/AbstractJdbcLogRepository.java
@@ -35,8 +35,7 @@ public abstract class AbstractJdbcLogRepository extends AbstractJdbcCrudReposito
     private static final Condition NORMAL_KIND_CONDITION = field("execution_kind").isNull().or(field("execution_kind").eq(ExecutionKind.NORMAL.name()));
     private static final String DATE_COLUMN = "timestamp";
 
-    public AbstractJdbcLogRepository(io.kestra.jdbc.AbstractJdbcRepository<LogEntry> jdbcRepository,
-        JdbcFilterService filterService) {
+    public AbstractJdbcLogRepository(io.kestra.jdbc.AbstractJdbcRepository<LogEntry> jdbcRepository, JdbcFilterService filterService) {
         super(jdbcRepository);
 
         this.filterService = filterService;
@@ -53,16 +52,9 @@ public abstract class AbstractJdbcLogRepository extends AbstractJdbcCrudReposito
 
     protected Map<Logs.Fields, String> getFieldsMapping() {
         return Map.of(
-            Logs.Fields.DATE, DATE_COLUMN,
-            Logs.Fields.NAMESPACE, "namespace",
-            Logs.Fields.FLOW_ID, "flow_id",
-            Logs.Fields.TASK_ID, "task_id",
-            Logs.Fields.EXECUTION_ID, "execution_id",
+            Logs.Fields.DATE, DATE_COLUMN, Logs.Fields.NAMESPACE, "namespace", Logs.Fields.FLOW_ID, "flow_id", Logs.Fields.TASK_ID, "task_id", Logs.Fields.EXECUTION_ID, "execution_id",
             Logs.Fields.TASK_RUN_ID, "taskrun_id",
-            Logs.Fields.ATTEMPT_NUMBER, "attempt_number",
-            Logs.Fields.TRIGGER_ID, "trigger_id",
-            Logs.Fields.LEVEL, "level",
-            Logs.Fields.MESSAGE, "message"
+            Logs.Fields.ATTEMPT_NUMBER, "attempt_number", Logs.Fields.TRIGGER_ID, "trigger_id", Logs.Fields.LEVEL, "level", Logs.Fields.MESSAGE, "message"
         );
     }
 
@@ -81,18 +73,13 @@ public abstract class AbstractJdbcLogRepository extends AbstractJdbcCrudReposito
     }
 
     @Override
-    public ArrayListTotal<LogEntry> find(
-        Pageable pageable,
-        @Nullable String tenantId,
-        @Nullable List<QueryFilter> filters) {
+    public ArrayListTotal<LogEntry> find(Pageable pageable, @Nullable String tenantId, @Nullable List<QueryFilter> filters) {
         var condition = NORMAL_KIND_CONDITION.and(this.filter(filters, DATE_COLUMN, Resource.LOG));
         return findPage(pageable, tenantId, condition);
     }
 
     @Override
-    public Flux<LogEntry> findAsync(
-        @Nullable String tenantId,
-        List<QueryFilter> filters) {
+    public Flux<LogEntry> findAsync(@Nullable String tenantId, List<QueryFilter> filters) {
         var condition = NORMAL_KIND_CONDITION.and(this.filter(filters, DATE_COLUMN, Resource.LOG));
         return findAsync(tenantId, condition, field(DATE_COLUMN).asc());
     }
@@ -108,34 +95,17 @@ public abstract class AbstractJdbcLogRepository extends AbstractJdbcCrudReposito
     }
 
     private List<LogEntry> findByExecutionId(String tenantId, String executionId, Level minLevel, boolean withAccessControl) {
-        return this.query(
-            tenantId,
-            field("execution_id").eq(executionId),
-            minLevel,
-            withAccessControl
-        );
+        return this.query(tenantId, field("execution_id").eq(executionId), minLevel, withAccessControl);
     }
 
     @Override
     public ArrayListTotal<LogEntry> findByExecutionId(String tenantId, String executionId, Level minLevel, Pageable pageable) {
-        return this.query(
-            tenantId,
-            field("execution_id").eq(executionId),
-            minLevel,
-            pageable
-        );
+        return this.query(tenantId, field("execution_id").eq(executionId), minLevel, pageable);
     }
 
     @Override
     public List<LogEntry> findByExecutionId(String tenantId, String namespace, String flowId, String executionId, Level minLevel) {
-        return this.query(
-            tenantId,
-            field("execution_id").eq(executionId)
-                .and(field("namespace").eq(namespace))
-                .and(field("flow_id").eq(flowId)),
-            minLevel,
-            true
-        );
+        return this.query(tenantId, field("execution_id").eq(executionId).and(field("namespace").eq(namespace)).and(field("flow_id").eq(flowId)), minLevel, true);
     }
 
     @Override
@@ -149,37 +119,18 @@ public abstract class AbstractJdbcLogRepository extends AbstractJdbcCrudReposito
     }
 
     private List<LogEntry> findByExecutionIdAndTaskId(String tenantId, String executionId, String taskId, Level minLevel, boolean withAccessControl) {
-        return this.query(
-            tenantId,
-            field("execution_id").eq(executionId)
-                .and(field("task_id").eq(taskId)),
-            minLevel,
-            withAccessControl
-        );
+        return this.query(tenantId, field("execution_id").eq(executionId).and(field("task_id").eq(taskId)), minLevel, withAccessControl);
     }
 
     @Override
     public ArrayListTotal<LogEntry> findByExecutionIdAndTaskId(String tenantId, String executionId, String taskId, Level minLevel, Pageable pageable) {
-        return this.query(
-            tenantId,
-            field("execution_id").eq(executionId)
-                .and(field("task_id").eq(taskId)),
-            minLevel,
-            pageable
-        );
+        return this.query(tenantId, field("execution_id").eq(executionId).and(field("task_id").eq(taskId)), minLevel, pageable);
     }
 
     @Override
     public List<LogEntry> findByExecutionIdAndTaskId(String tenantId, String namespace, String flowId, String executionId, String taskId, Level minLevel) {
-        return this.query(
-            tenantId,
-            field("execution_id").eq(executionId)
-                .and(field("namespace").eq(namespace))
-                .and(field("flow_id").eq(flowId))
-                .and(field("task_id").eq(taskId)),
-            minLevel,
-            true
-        );
+        return this
+            .query(tenantId, field("execution_id").eq(executionId).and(field("namespace").eq(namespace)).and(field("flow_id").eq(flowId)).and(field("task_id").eq(taskId)), minLevel, true);
     }
 
     @Override
@@ -193,24 +144,12 @@ public abstract class AbstractJdbcLogRepository extends AbstractJdbcCrudReposito
     }
 
     private List<LogEntry> findByExecutionIdAndTaskRunId(String tenantId, String executionId, String taskRunId, Level minLevel, boolean withAccessControl) {
-        return this.query(
-            tenantId,
-            field("execution_id").eq(executionId)
-                .and(field("taskrun_id").eq(taskRunId)),
-            minLevel,
-            withAccessControl
-        );
+        return this.query(tenantId, field("execution_id").eq(executionId).and(field("taskrun_id").eq(taskRunId)), minLevel, withAccessControl);
     }
 
     @Override
     public ArrayListTotal<LogEntry> findByExecutionIdAndTaskRunId(String tenantId, String executionId, String taskRunId, Level minLevel, Pageable pageable) {
-        return this.query(
-            tenantId,
-            field("execution_id").eq(executionId)
-                .and(field("taskrun_id").eq(taskRunId)),
-            minLevel,
-            pageable
-        );
+        return this.query(tenantId, field("execution_id").eq(executionId).and(field("taskrun_id").eq(taskRunId)), minLevel, pageable);
     }
 
     @Override
@@ -224,170 +163,128 @@ public abstract class AbstractJdbcLogRepository extends AbstractJdbcCrudReposito
     }
 
     private List<LogEntry> findByExecutionIdAndTaskRunIdAndAttempt(String tenantId, String executionId, String taskRunId, Level minLevel, Integer attempt, boolean withAccessControl) {
-        return this.query(
-            tenantId,
-            field("execution_id").eq(executionId)
-                .and(field("taskrun_id").eq(taskRunId))
-                .and(field("attempt_number").eq(attempt)),
-            minLevel,
-            withAccessControl
-        );
+        return this.query(tenantId, field("execution_id").eq(executionId).and(field("taskrun_id").eq(taskRunId)).and(field("attempt_number").eq(attempt)), minLevel, withAccessControl);
     }
 
     @Override
     public ArrayListTotal<LogEntry> findByExecutionIdAndTaskRunIdAndAttempt(String tenantId, String executionId, String taskRunId, Level minLevel, Integer attempt, Pageable pageable) {
-        return this.query(
-            tenantId,
-            field("execution_id").eq(executionId)
-                .and(field("taskrun_id").eq(taskRunId))
-                .and(field("attempt_number").eq(attempt)),
-            minLevel,
-            pageable
-        );
+        return this.query(tenantId, field("execution_id").eq(executionId).and(field("taskrun_id").eq(taskRunId)).and(field("attempt_number").eq(attempt)), minLevel, pageable);
     }
 
     @Override
     public Integer purge(Execution execution) {
-        return this.jdbcRepository
-            .getDslContextWrapper()
-            .transactionResult(configuration ->
-            {
-                DSLContext context = DSL.using(configuration);
+        return this.jdbcRepository.getDslContextWrapper().transactionResult(configuration ->
+        {
+            DSLContext context = DSL.using(configuration);
 
-                return context.delete(this.jdbcRepository.getTable())
-                    .where(field("execution_id", String.class).eq(execution.getId()))
-                    .execute();
-            });
+            return context.delete(this.jdbcRepository.getTable()).where(field("execution_id", String.class).eq(execution.getId())).execute();
+        });
     }
 
     @Override
     public Integer purge(List<Execution> executions) {
-        return this.jdbcRepository
-            .getDslContextWrapper()
-            .transactionResult(configuration ->
-            {
-                DSLContext context = DSL.using(configuration);
+        return this.jdbcRepository.getDslContextWrapper().transactionResult(configuration ->
+        {
+            DSLContext context = DSL.using(configuration);
 
-                return context.delete(this.jdbcRepository.getTable())
-                    .where(field("execution_id", String.class).in(executions.stream().map(Execution::getId).toList()))
-                    .execute();
-            });
+            return context.delete(this.jdbcRepository.getTable()).where(field("execution_id", String.class).in(executions.stream().map(Execution::getId).toList())).execute();
+        });
     }
 
     @Override
     public void deleteByQuery(String tenantId, String executionId, String taskId, String taskRunId, Level minLevel, Integer attempt) {
-        this.jdbcRepository
-            .getDslContextWrapper()
-            .transaction(configuration ->
-            {
-                DSLContext context = DSL.using(configuration);
+        this.jdbcRepository.getDslContextWrapper().transaction(configuration ->
+        {
+            DSLContext context = DSL.using(configuration);
 
-                var delete = context
-                    .delete(this.jdbcRepository.getTable())
-                    .where(this.defaultFilter(tenantId))
-                    .and(field("execution_id").eq(executionId));
+            var delete = context.delete(this.jdbcRepository.getTable()).where(this.defaultFilter(tenantId)).and(field("execution_id").eq(executionId));
 
-                if (taskId != null) {
-                    delete = delete.and(field("task_id").eq(taskId));
-                }
+            if (taskId != null) {
+                delete = delete.and(field("task_id").eq(taskId));
+            }
 
-                if (taskRunId != null) {
-                    delete = delete.and(field("taskrun_id").eq(taskRunId));
-                }
+            if (taskRunId != null) {
+                delete = delete.and(field("taskrun_id").eq(taskRunId));
+            }
 
-                if (minLevel != null) {
-                    delete = delete.and(minLevel(minLevel));
-                }
+            if (minLevel != null) {
+                delete = delete.and(minLevel(minLevel));
+            }
 
-                if (attempt != null) {
-                    delete = delete.and(field("attempt_number").eq(attempt));
-                }
+            if (attempt != null) {
+                delete = delete.and(field("attempt_number").eq(attempt));
+            }
 
-                delete.execute();
-            });
+            delete.execute();
+        });
     }
 
     @Override
     public void deleteByQuery(String tenantId, String namespace, String flowId, String triggerId) {
-        this.jdbcRepository
-            .getDslContextWrapper()
-            .transaction(configuration ->
-            {
-                DSLContext context = DSL.using(configuration);
+        this.jdbcRepository.getDslContextWrapper().transaction(configuration ->
+        {
+            DSLContext context = DSL.using(configuration);
 
-                var delete = context
-                    .delete(this.jdbcRepository.getTable())
-                    .where(this.defaultFilter(tenantId))
-                    .and(field("namespace").eq(namespace))
-                    .and(field("flow_id").eq(flowId));
+            var delete = context.delete(this.jdbcRepository.getTable()).where(this.defaultFilter(tenantId)).and(field("namespace").eq(namespace)).and(field("flow_id").eq(flowId));
 
-                if (triggerId != null) {
-                    delete = delete.and(field("trigger_id").eq(triggerId));
-                }
+            if (triggerId != null) {
+                delete = delete.and(field("trigger_id").eq(triggerId));
+            }
 
-                delete.execute();
-            });
+            delete.execute();
+        });
     }
 
     @Override
     public int deleteByQuery(String tenantId, String namespace, String flowId, String executionId, List<Level> logLevels, ZonedDateTime startDate, ZonedDateTime endDate,
         boolean purgeExecutionLogs, boolean purgeNonExecutionLogs) {
-        return this.jdbcRepository
-            .getDslContextWrapper()
-            .transactionResult(configuration ->
-            {
-                DSLContext context = DSL.using(configuration);
+        return this.jdbcRepository.getDslContextWrapper().transactionResult(configuration ->
+        {
+            DSLContext context = DSL.using(configuration);
 
-                var delete = context
-                    .delete(this.jdbcRepository.getTable())
-                    .where(this.defaultFilter(tenantId))
-                    .and(field(DATE_COLUMN).lessOrEqual(endDate.toOffsetDateTime()));
+            var delete = context.delete(this.jdbcRepository.getTable()).where(this.defaultFilter(tenantId)).and(field(DATE_COLUMN).lessOrEqual(endDate.toOffsetDateTime()));
 
-                if (startDate != null) {
-                    delete = delete.and(field(DATE_COLUMN).greaterOrEqual(startDate.toOffsetDateTime()));
-                }
+            if (startDate != null) {
+                delete = delete.and(field(DATE_COLUMN).greaterOrEqual(startDate.toOffsetDateTime()));
+            }
 
-                if (namespace != null) {
-                    delete = delete.and(field("namespace").eq(namespace));
-                }
+            if (namespace != null) {
+                delete = delete.and(field("namespace").eq(namespace));
+            }
 
-                if (flowId != null) {
-                    delete = delete.and(field("flow_id").eq(flowId));
-                }
+            if (flowId != null) {
+                delete = delete.and(field("flow_id").eq(flowId));
+            }
 
-                if (executionId != null) {
-                    delete = delete.and(field("execution_id").eq(executionId));
-                }
+            if (executionId != null) {
+                delete = delete.and(field("execution_id").eq(executionId));
+            }
 
-                if (logLevels != null) {
-                    delete = delete.and(levelsCondition(logLevels));
-                }
+            if (logLevels != null) {
+                delete = delete.and(levelsCondition(logLevels));
+            }
 
-                if (purgeExecutionLogs && !purgeNonExecutionLogs) {
-                    delete = delete.and(field("execution_id").isNotNull());
-                } else if (purgeNonExecutionLogs && !purgeExecutionLogs) {
-                    delete = delete.and(field("execution_id").isNull());
-                }
+            if (purgeExecutionLogs && !purgeNonExecutionLogs) {
+                delete = delete.and(field("execution_id").isNotNull());
+            } else if (purgeNonExecutionLogs && !purgeExecutionLogs) {
+                delete = delete.and(field("execution_id").isNull());
+            }
 
-                return delete.execute();
-            });
+            return delete.execute();
+        });
     }
 
     @Override
     public void deleteByFilters(String tenantId, List<QueryFilter> filters) {
-        this.jdbcRepository
-            .getDslContextWrapper()
-            .transactionResult(configuration ->
-            {
-                DSLContext context = DSL.using(configuration);
+        this.jdbcRepository.getDslContextWrapper().transactionResult(configuration ->
+        {
+            DSLContext context = DSL.using(configuration);
 
-                var delete = context
-                    .delete(this.jdbcRepository.getTable())
-                    .where(this.defaultFilter(tenantId));
-                delete = delete.and(this.filter(filters, DATE_COLUMN, Resource.LOG));
+            var delete = context.delete(this.jdbcRepository.getTable()).where(this.defaultFilter(tenantId));
+            delete = delete.and(this.filter(filters, DATE_COLUMN, Resource.LOG));
 
-                return delete.execute();
-            });
+            return delete.execute();
+        });
     }
 
     private ArrayListTotal<LogEntry> query(String tenantId, Condition condition, Level minLevel, Pageable pageable) {
@@ -425,17 +322,9 @@ public abstract class AbstractJdbcLogRepository extends AbstractJdbcCrudReposito
                 filters.addAll(dataFilter.getNumerator());
             }
 
-            SelectConditionStep selectStep = context
-                .select(field)
-                .from(this.jdbcRepository.getTable())
-                .where(this.defaultFilter(tenantId));
+            SelectConditionStep selectStep = context.select(field).from(this.jdbcRepository.getTable()).where(this.defaultFilter(tenantId));
 
-            var selectConditionStep = where(
-                selectStep,
-                filterService,
-                filters,
-                getFieldsMapping()
-            ).and(NORMAL_KIND_CONDITION);
+            var selectConditionStep = where(selectStep, filterService, filters, getFieldsMapping()).and(NORMAL_KIND_CONDITION);
 
             Record result = selectConditionStep.fetchOne();
             if (result != null) {
@@ -447,65 +336,63 @@ public abstract class AbstractJdbcLogRepository extends AbstractJdbcCrudReposito
     }
 
     @Override
-    public ArrayListTotal<Map<String, Object>> fetchData(
-        String tenantId,
-        DataFilter<Logs.Fields, ? extends ColumnDescriptor<Logs.Fields>> descriptors,
-        ZonedDateTime startDate,
-        ZonedDateTime endDate,
-        Pageable pageable) {
-        return this.jdbcRepository
-            .getDslContextWrapper()
-            .transactionResult(configuration ->
-            {
-                DSLContext context = DSL.using(configuration);
+    public ArrayListTotal<Map<String, Object>> fetchData(String tenantId, DataFilter<Logs.Fields, ? extends ColumnDescriptor<Logs.Fields>> descriptors, ZonedDateTime startDate,
+        ZonedDateTime endDate, Pageable pageable) {
+        return this.jdbcRepository.getDslContextWrapper().transactionResult(configuration ->
+        {
+            DSLContext context = DSL.using(configuration);
 
-                Map<String, ? extends ColumnDescriptor<Logs.Fields>> columnsWithoutDate = descriptors.getColumns().entrySet().stream()
-                    .filter(entry -> entry.getValue().getField() == null || !dateFields().contains(entry.getValue().getField()))
-                    .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+            Map<String, ? extends ColumnDescriptor<Logs.Fields>> columnsWithoutDate = descriptors.getColumns().entrySet().stream()
+                .filter(entry -> entry.getValue().getField() == null || !dateFields().contains(entry.getValue().getField()))
+                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
 
-                boolean hasAgg = descriptors.getColumns().entrySet().stream().anyMatch(col -> col.getValue().getAgg() != null);
-                // Generate custom fields for date as they probably need formatting
-                // If they don't have aggs, we format datetime to minutes
-                List<Field<Date>> dateFields = generateDateFields(descriptors, getFieldsMapping(), startDate, endDate, dateFields(), hasAgg ? null : DateUtils.GroupType.MINUTE);
+            boolean hasAgg = descriptors.getColumns().entrySet().stream().anyMatch(col -> col.getValue().getAgg() != null);
+            // Generate custom fields for date as they probably need formatting
+            // If they don't have aggs, we format datetime to minutes
+            List<Field<Date>> dateFields = generateDateFields(descriptors, getFieldsMapping(), startDate, endDate, dateFields(), hasAgg ? null : DateUtils.GroupType.MINUTE);
 
-                // Init request
-                SelectConditionStep<Record> selectConditionStep = select(
-                    context,
-                    filterService,
-                    columnsWithoutDate,
-                    dateFields,
-                    this.getFieldsMapping(),
-                    this.jdbcRepository.getTable(),
-                    tenantId
-                );
+            // Init request
+            SelectConditionStep<Record> selectConditionStep = select(context, filterService, columnsWithoutDate, dateFields, this.getFieldsMapping(), this.jdbcRepository.getTable(), tenantId);
 
-                // Apply Where filter
-                selectConditionStep = where(selectConditionStep, filterService, descriptors.getWhere(), getWhereMapping())
-                    .and(NORMAL_KIND_CONDITION);
+            // Apply Where filter
+            selectConditionStep = where(selectConditionStep, filterService, descriptors.getWhere(), getWhereMapping()).and(NORMAL_KIND_CONDITION);
 
-                List<? extends ColumnDescriptor<Logs.Fields>> columnsWithoutDateWithOutAggs = columnsWithoutDate.values().stream()
-                    .filter(column -> column.getAgg() == null)
-                    .toList();
+            List<? extends ColumnDescriptor<Logs.Fields>> columnsWithoutDateWithOutAggs = columnsWithoutDate.values().stream().filter(column -> column.getAgg() == null).toList();
 
-                // Apply GroupBy for aggregation
-                SelectHavingStep<Record> selectHavingStep = groupBy(
-                    selectConditionStep,
-                    columnsWithoutDateWithOutAggs,
-                    dateFields,
-                    getFieldsMapping()
-                );
+            // Apply GroupBy for aggregation
+            SelectHavingStep<Record> selectHavingStep = groupBy(selectConditionStep, columnsWithoutDateWithOutAggs, dateFields, getFieldsMapping());
 
-                // Apply OrderBy
-                SelectSeekStepN<Record> selectSeekStep = orderBy(selectHavingStep, descriptors);
+            // Apply OrderBy
+            SelectSeekStepN<Record> selectSeekStep = orderBy(selectHavingStep, descriptors);
 
-                // Fetch and paginate if provided
-                return fetchSeekStep(selectSeekStep, pageable);
-            });
+            // Fetch and paginate if provided
+            return fetchSeekStep(selectSeekStep, pageable);
+        });
+    }
+
+    @Override
+    protected Condition defaultFilterWithNoACL(String tenantId) {
+        return buildTenantCondition(tenantId);
     }
 
     @Override
     protected Condition defaultFilter(String tenantId) {
-        return buildTenantCondition(tenantId);
+        return defaultFilterWithNoACL(tenantId);
+    }
+
+    @Override
+    protected Condition defaultFilter(Boolean allowDeleted) {
+        return this.defaultFilter();
+    }
+
+    @Override
+    protected Condition defaultFilterWithNoACL(String tenantId, boolean deleted) {
+        return this.defaultFilterWithNoACL(tenantId);
+    }
+
+    @Override
+    protected Condition defaultFilter(String tenantId, boolean allowDeleted) {
+        return this.defaultFilter(tenantId);
     }
 
     @Override


### PR DESCRIPTION
closes https://github.com/kestra-io/kestra-ee/issues/7327

The only part worth checking is the defaultFilters refactoring at the end, other changes are pure spotless (idk why it applies now, I thought there was a big apply at some point).

The goal is to make sure there are no gaps in our default filter handling and prevent breakage due to inclusion of "deleted" condition in logs which are no longer soft-deletable