### PR TITLE
feat(core): make sidebar logo destination configurable via prop

### DIFF
--- a/ui/src/components/layout/SideBar.vue
+++ b/ui/src/components/layout/SideBar.vue
@@ -15,7 +15,7 @@
                 @toggle="collapsed = onToggleCollapse(!collapsed)"
             />
             <div class="logo">
-                <component :is="props.showLink ? 'router-link' : 'div'" :to="{name: 'welcome'}">
+                <component :is="props.showLink ? 'router-link' : 'div'" :to="props.logoTo">
                     <span class="img" />
                 </component>
             </div>
@@ -46,9 +46,11 @@
 
     const props = withDefaults(defineProps<{
         menu: MenuItem[],
-        showLink?: boolean
+        showLink?: boolean,
+        logoTo?: object
     }>(), {
-        showLink: true
+        showLink: true,
+        logoTo: () => ({name: "welcome"})
     })
 
     const $emit = defineEmits(["menu-collapse"])

--- a/ui/tests/storybook/layout/SideBar.stories.jsx
+++ b/ui/tests/storybook/layout/SideBar.stories.jsx
@@ -18,6 +18,11 @@ export default {
   decorators: [
     vueRouter([
       {
+          path: "/",
+          name: "home",
+          component: {template: "<div>home</div>"}
+      },
+      {
           path: "/welcome",
           name: "welcome",
           component: {template: "<div>welcome</div>"}


### PR DESCRIPTION
## Summary
- Added `logoTo` prop to `SideBar.vue` to make the logo link destination configurable (defaults to `{name: 'welcome'}`)
- Fixed storybook router to include both `home` and `welcome` routes

## Test plan
- [ ] Click the logo in OSS — should navigate to the welcome page
- [ ] Storybook renders without router warnings