### PR TITLE
fix(plugins): reset version when navigating between plugins

### DIFF
--- a/ui/src/components/plugins/Plugin.vue
+++ b/ui/src/components/plugins/Plugin.vue
@@ -152,6 +152,8 @@
     async function loadPlugin() {
         if (route.params.version) {
             version.value = route.params.version as string;
+        } else {
+            version.value = undefined;
         }
 
         const clsParam = route.params.cls as string | undefined;


### PR DESCRIPTION
Closes https://github.com/kestra-io/kestra-ee/issues/6971


there was two issue due to this:

- version related - `Illegal argument: Unsupported version for type `
- and interrelated to version , `404` when version not found for few plugins.