### PR TITLE
fix(core): pull $group and $index up from anyOf in JSON schema generator

### DIFF
--- a/core/src/main/java/io/kestra/core/docs/JsonSchemaGenerator.java
+++ b/core/src/main/java/io/kestra/core/docs/JsonSchemaGenerator.java
@@ -186,7 +186,9 @@ public class JsonSchemaGenerator {
                             Map.entry("default", Optional.empty()),
                             Map.entry("title", Optional.empty()),
                             Map.entry("description", Optional.empty()),
-                            Map.entry("$deprecated", Optional.empty())
+                            Map.entry("$deprecated", Optional.empty()),
+                            Map.entry("$group", Optional.empty()),
+                            Map.entry("$index", Optional.empty())
                         )
                     );
                     // find nodes to pull up

--- a/core/src/test/java/io/kestra/core/docs/JsonSchemaGeneratorTest.java
+++ b/core/src/test/java/io/kestra/core/docs/JsonSchemaGeneratorTest.java
@@ -568,4 +568,67 @@ class JsonSchemaGeneratorTest {
         });
     }
 
+    @SuperBuilder
+    @ToString
+    @EqualsAndHashCode
+    @Getter
+    @NoArgsConstructor
+    @Plugin
+    public static class TaskWithGroupedBooleanProperty extends Task implements RunnableTask<VoidOutput> {
+        @PluginProperty(group = "reliability")
+        @Builder.Default
+        private Property<Boolean> failOnMissing = Property.ofValue(false);
+
+        @Override
+        public VoidOutput run(RunContext runContext) throws Exception {
+            return null;
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    void propertyBooleanWithGroupShouldHaveGroupAtTopLevel() throws URISyntaxException {
+        Helpers.runApplicationContext((applicationContext) ->
+        {
+            JsonSchemaGenerator jsonSchemaGenerator = applicationContext.getBean(JsonSchemaGenerator.class);
+
+            // Check via properties() - the path TaskObject uses for single-task schema
+            Map<String, Object> generate = jsonSchemaGenerator.properties(Task.class, TaskWithGroupedBooleanProperty.class);
+            Map<String, Map<String, Object>> props = (Map<String, Map<String, Object>>) generate.get("properties");
+            Map<String, Object> prop = props.get("failOnMissing");
+
+            // Check via schemas() - the path the flow schema uses (full definitions)
+            Map<String, Object> fullSchema = jsonSchemaGenerator.schemas(TaskWithGroupedBooleanProperty.class);
+            var defs = (Map<String, Map<String, Object>>) fullSchema.get("definitions");
+            var taskDef = defs.entrySet().stream()
+                .filter(e -> e.getKey().contains("TaskWithGroupedBooleanProperty"))
+                .findFirst().orElseThrow().getValue();
+            var defProps = (Map<String, Map<String, Object>>) taskDef.get("properties");
+
+            // $group must be at top level so the no-code editor can pick it up
+            assertThat("properties() path: $group must be at top level for Property<Boolean>",
+                prop.get("$group"), is("reliability"));
+
+            // Check schemas() path — what does the definition actually look like?
+            Map<String, Object> taskDefFailOnMissing = null;
+            if (defProps != null) {
+                taskDefFailOnMissing = defProps.get("failOnMissing");
+            } else if (taskDef.get("allOf") != null) {
+                var allOfList = (java.util.List<?>) taskDef.get("allOf");
+                for (var allOfItem : allOfList) {
+                    var allOfProps = (Map<String, Object>) ((Map<?, ?>) allOfItem).get("properties");
+                    if (allOfProps != null && allOfProps.containsKey("failOnMissing")) {
+                        taskDefFailOnMissing = (Map<String, Object>) allOfProps.get("failOnMissing");
+                        break;
+                    }
+                }
+            }
+            assertThat("schemas() path: failOnMissing definition must be found", taskDefFailOnMissing, is(notNullValue()));
+
+            // $group must be at top level in the full schemas() path too
+            assertThat("schemas() path: $group must be at top level for Property<Boolean>",
+                taskDefFailOnMissing.get("$group"), is("reliability"));
+        });
+    }
+
 }


### PR DESCRIPTION
## Summary

- For `Property<Boolean>` (and any `Property<T>` with multiple target types), victools generates an `anyOf` schema and places `$group`/`$index` inside each `anyOf` item instead of at the parent level
- `pullDocumentationAndDefaultFromAnyOf` already hoisted `default`, `title`, `description`, and `$deprecated` — this extends it to also hoist `$group` and `$index`
- Without this fix, properties like `failedOnMissing` (a `Property<Boolean>` annotated with `@PluginProperty(group = "reliability")`) appeared in the "Optional" section of the no-code editor instead of their own group section

## Test plan

- [ ] Added `TaskWithGroupedBooleanProperty` test task and `propertyBooleanWithGroupShouldHaveGroupAtTopLevel` test in `JsonSchemaGeneratorTest`
- [ ] Test asserts `$group` is at the top level for both the `properties()` and `schemas()` code paths
- [ ] Confirmed with `./gradlew :core:test --tests "io.kestra.core.docs.JsonSchemaGeneratorTest.propertyBooleanWithGroupShouldHaveGroupAtTopLevel"`

part-of: https://github.com/kestra-io/kestra-ee/issues/6712