### PR TITLE
fix(ui): prevent content clipping at high zoom levels

### DIFF
--- a/ui/src/styles/app.scss
+++ b/ui/src/styles/app.scss
@@ -244,10 +244,11 @@ body{
 
 #app {
     display: flex;
-    height: 100vh;
-    overflow: hidden;
+    height: auto;
+    min-height: 100vh;
 }
 #app main {
     flex: 1;
-    overflow: auto;
+    min-height: 0;
+    overflow-y: auto;
 }


### PR DESCRIPTION

### ✨ Description

Fixes a UI issue where content was not fully visible at higher zoom levels or scaled displays.

The root cause was improper height handling using viewport units (`100vh`) combined with flex layout, which caused content clipping.
This PR updates the layout to use flexible height (`min-height: 100vh`) and ensures proper scrolling behavior by adding `min-height: 0` to flex children.

---

### 🔗 Related Issue

Closes [https://github.com/kestra-io/kestra/issues/15466](https://github.com/kestra-io/kestra/issues/15466)

---

### 🎨 Frontend Checklist

* [x] Code builds without errors (`npm run build`)
* [ ] All existing E2E tests pass (`npm run test:e2e`)
* [x] Screenshots or video recordings attached showing the `UI` changes

---

### 📝 Additional Notes

* Verified fix on different zoom levels (100%, 150%, 200%)
* Content is now fully visible and scroll behaves correctly
* No backend changes were required

https://github.com/user-attachments/assets/ad400d54-5cdc-4b49-8d02-83f5fc5fab61

