### PR TITLE
fix(storage): avoid double ION serialization of KV values during backup restore

### DIFF
--- a/core/src/main/java/io/kestra/core/storages/kv/InternalKVStore.java
+++ b/core/src/main/java/io/kestra/core/storages/kv/InternalKVStore.java
@@ -98,6 +98,36 @@ public class InternalKVStore implements KVStore {
     }
 
     /**
+     * Puts a KV entry using an already-serialized (raw) value, bypassing ION serialization.
+     * This is intended for backup/restore where the value is already in its stored ION format.
+     *
+     * @param key      The key.
+     * @param metadata The metadata (nullable).
+     * @param rawValue The raw ION-serialized value bytes.
+     */
+    public void putRaw(String key, @Nullable KVMetadata metadata, byte[] rawValue) throws IOException {
+        KVStore.validateKey(key);
+
+        PersistedKvMetadata saved = this.kvMetadataStateStore.save(
+            PersistedKvMetadata.builder()
+                .tenantId(this.tenant)
+                .namespace(this.namespace)
+                .name(key)
+                .description(Optional.ofNullable(metadata).map(KVMetadata::getDescription).orElse(null))
+                .expirationDate(Optional.ofNullable(metadata).map(KVMetadata::getExpirationDate).orElse(null))
+                .deleted(false)
+                .build()
+        );
+        KVValueAndMetadata wrapper = new KVValueAndMetadata(metadata, null);
+        this.storage.put(
+            this.tenant, this.namespace, this.storageUri(key, saved.getVersion()), new StorageObject(
+                wrapper.metadataAsMap(),
+                new ByteArrayInputStream(rawValue)
+            )
+        );
+    }
+
+    /**
      * {@inheritDoc}
      */
     @Override

--- a/core/src/test/java/io/kestra/core/storages/InternalKVStoreTest.java
+++ b/core/src/test/java/io/kestra/core/storages/InternalKVStoreTest.java
@@ -256,6 +256,61 @@ class InternalKVStoreTest {
         Assertions.assertDoesNotThrow(() -> KVStore.validateKey("AN_UPPER.CASE-key"));
     }
 
+    @Test
+    void putRawShouldPreserveStringValue() throws IOException, ResourceExpiredException {
+        // Given - simulate backup/restore: put a value, read it raw, then putRaw into a new store
+        InternalKVStore source = kv();
+        InternalKVStore target = kv();
+
+        String stringValue = "/in";
+        source.put(TEST_KV_KEY, new KVValueAndMetadata(new KVMetadata("desc", Duration.ofMinutes(5)), stringValue));
+
+        // When - simulate backup read + restore write
+        String rawValue = source.getRawValue(TEST_KV_KEY).orElseThrow();
+        target.putRaw(TEST_KV_KEY, new KVMetadata("desc", Duration.ofMinutes(5)), rawValue.getBytes(java.nio.charset.StandardCharsets.UTF_8));
+
+        // Then - value should be identical after roundtrip
+        Optional<KVValue> result = target.getValue(TEST_KV_KEY);
+        assertThat(result).isPresent();
+        assertThat(result.get().value()).isEqualTo(stringValue);
+    }
+
+    @Test
+    void putRawShouldPreserveComplexValue() throws IOException, ResourceExpiredException {
+        // Given
+        InternalKVStore source = kv();
+        InternalKVStore target = kv();
+
+        source.put(TEST_KV_KEY, new KVValueAndMetadata(new KVMetadata(null, (Duration) null), complexValue));
+
+        // When
+        String rawValue = source.getRawValue(TEST_KV_KEY).orElseThrow();
+        target.putRaw(TEST_KV_KEY, new KVMetadata(null, (Duration) null), rawValue.getBytes(java.nio.charset.StandardCharsets.UTF_8));
+
+        // Then
+        Optional<KVValue> result = target.getValue(TEST_KV_KEY);
+        assertThat(result).isPresent();
+        assertThat(result.get().value()).isEqualTo(complexValue);
+    }
+
+    @Test
+    void putRawShouldPreserveNumericValue() throws IOException, ResourceExpiredException {
+        // Given
+        InternalKVStore source = kv();
+        InternalKVStore target = kv();
+
+        source.put(TEST_KV_KEY, new KVValueAndMetadata(new KVMetadata(null, (Duration) null), 42));
+
+        // When
+        String rawValue = source.getRawValue(TEST_KV_KEY).orElseThrow();
+        target.putRaw(TEST_KV_KEY, new KVMetadata(null, (Duration) null), rawValue.getBytes(java.nio.charset.StandardCharsets.UTF_8));
+
+        // Then
+        Optional<KVValue> result = target.getValue(TEST_KV_KEY);
+        assertThat(result).isPresent();
+        assertThat(result.get().value()).isEqualTo(42);
+    }
+
     private InternalKVStore kv() {
         final String namespaceId = "io.kestra." + IdUtils.create();
         return new InternalKVStore(MAIN_TENANT, namespaceId, storageInterface, kvMetadataStateStore);


### PR DESCRIPTION
Closes https://github.com/kestra-io/kestra/issues/15494