### PR TITLE
fix(tasks): fix property grouping in no-code editor

### DIFF
--- a/ui/src/components/no-code/components/tasks/TaskObject.vue
+++ b/ui/src/components/no-code/components/tasks/TaskObject.vue
@@ -95,7 +95,7 @@
     // Groups expanded by default
     const GROUPS_EXPANDED_BY_DEFAULT = new Set(["connection", "source", "destination"]);
 
-    const activeNames = ref<string[]>([...GROUPS_EXPANDED_BY_DEFAULT, "optional"]);
+    const activeNames = ref<string[]>([...GROUPS_EXPANDED_BY_DEFAULT, "optional", "advanced"]);
 
     const FIRST_FIELDS = ["id", "forced", "on", "field", "type"];
 
@@ -137,13 +137,16 @@
     }
 
     function isPartOfGroup(value: any, groups: string[]) {
+        // Check top-level $group first: for Property<T> fields the schema generator places
+        // $group at the root even when anyOf is present, so we must not short-circuit on anyOf.
+        if (value?.$group) return groups.includes(value.$group);
         if (value?.allOf) {
             return value.allOf.some((item: any) => isPartOfGroup(item, groups));
         }
         if (value?.anyOf) {
             return value.anyOf.some((item: any) => isPartOfGroup(item, groups));
         }
-        return value?.$group && groups.includes(value.$group);
+        return false;
     }
 
     function getGroup(value: any): string | null {


### PR DESCRIPTION
## Summary

- Fix `isPartOfGroup()` to check top-level `$group` before diving into `anyOf`/`allOf`: the schema generator always places `$group` at the root of a `Property<T>` schema, so the previous `anyOf` short-circuit made the final `$group` check unreachable. This caused non-required `group="main"` properties to silently disappear from both the main section and all group sections.
- Expand the `"advanced"` group by default so properties annotated with `group="advanced"` are immediately visible without a manual click (addresses QA findings from kestra-io/kestra-ee#6712).

## Test plan

- [ ] Open any task with `group="main"` non-required `Property<T>` fields — verify they appear in the main (non-collapsed) section
- [ ] Open a task with `group="advanced"` properties (e.g. plugin-notion, plugin-airtable) — verify the Advanced section is expanded by default and all properties are visible
- [ ] Verify other groups (`connection`, `source`, `destination`, `optional`) still expand/collapse as expected
- [ ] Verify deprecated properties still only show when a value is set

Part-of: https://github.com/kestra-io/kestra-ee/issues/6712