### PR TITLE
fix: audit query filters

### DIFF
--- a/core/src/main/java/io/kestra/core/models/QueryFilter.java
+++ b/core/src/main/java/io/kestra/core/models/QueryFilter.java
@@ -278,7 +278,7 @@ public record QueryFilter(
         RESOURCES("resources") {
             @Override
             public List<Op> supportedOp() {
-                return List.of(Op.CONTAINS, Op.IN);
+                return List.of(Op.IN);
             }
         },
         DETAILS("details") {

--- a/core/src/test/java/io/kestra/core/models/QueryFilterTest.java
+++ b/core/src/test/java/io/kestra/core/models/QueryFilterTest.java
@@ -463,6 +463,138 @@ public class QueryFilterTest {
                     Op.EQUALS,
                     Op.NOT_EQUALS
                 )
+            ),
+
+            buildQueryFiltersForOperations(
+                Field.QUERY, Resource.AUDIT_LOG,
+                Set.of(
+                    Op.EQUALS,
+                    Op.NOT_EQUALS
+                )
+            ),
+
+            buildQueryFiltersForOperations(
+                Field.NAMESPACE, Resource.AUDIT_LOG,
+                Set.of(
+                    Op.EQUALS,
+                    Op.NOT_EQUALS,
+                    Op.IN,
+                    Op.NOT_IN,
+                    Op.STARTS_WITH,
+                    Op.ENDS_WITH,
+                    Op.CONTAINS,
+                    Op.REGEX,
+                    Op.PREFIX
+                )
+            ),
+
+            buildQueryFiltersForOperations(
+                Field.FLOW_ID, Resource.AUDIT_LOG,
+                Set.of(
+                    Op.EQUALS,
+                    Op.NOT_EQUALS,
+                    Op.STARTS_WITH,
+                    Op.ENDS_WITH,
+                    Op.CONTAINS,
+                    Op.REGEX,
+                    Op.IN,
+                    Op.NOT_IN,
+                    Op.PREFIX
+                )
+            ),
+
+            buildQueryFiltersForOperations(
+                Field.EXECUTION_ID, Resource.AUDIT_LOG,
+                Set.of(
+                    Op.EQUALS,
+                    Op.NOT_EQUALS,
+                    Op.IN,
+                    Op.NOT_IN,
+                    Op.STARTS_WITH,
+                    Op.ENDS_WITH,
+                    Op.CONTAINS
+                )
+            ),
+
+            buildQueryFiltersForOperations(
+                Field.ID, Resource.AUDIT_LOG,
+                Set.of(
+                    Op.EQUALS,
+                    Op.NOT_EQUALS,
+                    Op.CONTAINS,
+                    Op.STARTS_WITH,
+                    Op.ENDS_WITH,
+                    Op.REGEX,
+                    Op.IN,
+                    Op.NOT_IN
+                )
+            ),
+
+            buildQueryFiltersForOperations(
+                Field.USER_ID, Resource.AUDIT_LOG,
+                Set.of(
+                    Op.EQUALS
+                )
+            ),
+
+            buildQueryFiltersForOperations(
+                Field.TYPE, Resource.AUDIT_LOG,
+                Set.of(
+                    Op.EQUALS,
+                    Op.NOT_EQUALS,
+                    Op.CONTAINS,
+                    Op.STARTS_WITH,
+                    Op.ENDS_WITH,
+                    Op.REGEX,
+                    Op.IN,
+                    Op.NOT_IN
+                )
+            ),
+
+            buildQueryFiltersForOperations(
+                Field.RESOURCES, Resource.AUDIT_LOG,
+                Set.of(
+                    Op.IN
+                )
+            ),
+
+            buildQueryFiltersForOperations(
+                Field.ACTION, Resource.AUDIT_LOG,
+                Set.of(
+                    Op.EQUALS,
+                    Op.IN
+                )
+            ),
+
+            buildQueryFiltersForOperations(
+                Field.DETAILS, Resource.AUDIT_LOG,
+                Set.of(
+                    Op.EQUALS
+                )
+            ),
+
+            buildQueryFiltersForOperations(
+                Field.START_DATE, Resource.AUDIT_LOG,
+                Set.of(
+                    Op.EQUALS,
+                    Op.NOT_EQUALS,
+                    Op.GREATER_THAN,
+                    Op.LESS_THAN,
+                    Op.GREATER_THAN_OR_EQUAL_TO,
+                    Op.LESS_THAN_OR_EQUAL_TO
+                )
+            ),
+
+            buildQueryFiltersForOperations(
+                Field.END_DATE, Resource.AUDIT_LOG,
+                Set.of(
+                    Op.EQUALS,
+                    Op.NOT_EQUALS,
+                    Op.GREATER_THAN,
+                    Op.LESS_THAN,
+                    Op.GREATER_THAN_OR_EQUAL_TO,
+                    Op.LESS_THAN_OR_EQUAL_TO
+                )
             )
         ).flatMap(s -> s);
     }
@@ -1089,6 +1221,174 @@ public class QueryFilterTest {
                     Op.LESS_THAN,
                     Op.GREATER_THAN_OR_EQUAL_TO,
                     Op.LESS_THAN_OR_EQUAL_TO
+                )
+            ),
+
+            buildQueryFiltersForOperations(
+                Field.QUERY, Resource.AUDIT_LOG,
+                Set.of(
+                    Op.GREATER_THAN,
+                    Op.LESS_THAN,
+                    Op.GREATER_THAN_OR_EQUAL_TO,
+                    Op.LESS_THAN_OR_EQUAL_TO,
+                    Op.IN,
+                    Op.NOT_IN,
+                    Op.STARTS_WITH,
+                    Op.ENDS_WITH,
+                    Op.CONTAINS,
+                    Op.REGEX,
+                    Op.PREFIX
+                )
+            ),
+
+            buildQueryFiltersForOperations(
+                Field.NAMESPACE, Resource.AUDIT_LOG,
+                Set.of(
+                    Op.GREATER_THAN,
+                    Op.LESS_THAN,
+                    Op.GREATER_THAN_OR_EQUAL_TO,
+                    Op.LESS_THAN_OR_EQUAL_TO
+                )
+            ),
+
+            buildQueryFiltersForOperations(
+                Field.FLOW_ID, Resource.AUDIT_LOG,
+                Set.of(
+                    Op.GREATER_THAN,
+                    Op.LESS_THAN,
+                    Op.GREATER_THAN_OR_EQUAL_TO,
+                    Op.LESS_THAN_OR_EQUAL_TO
+                )
+            ),
+
+            buildQueryFiltersForOperations(
+                Field.EXECUTION_ID, Resource.AUDIT_LOG,
+                Set.of(
+                    Op.GREATER_THAN,
+                    Op.LESS_THAN,
+                    Op.GREATER_THAN_OR_EQUAL_TO,
+                    Op.LESS_THAN_OR_EQUAL_TO,
+                    Op.REGEX,
+                    Op.PREFIX
+                )
+            ),
+
+            buildQueryFiltersForOperations(
+                Field.ID, Resource.AUDIT_LOG,
+                Set.of(
+                    Op.PREFIX,
+                    Op.LESS_THAN,
+                    Op.LESS_THAN_OR_EQUAL_TO,
+                    Op.GREATER_THAN,
+                    Op.GREATER_THAN_OR_EQUAL_TO
+                )
+            ),
+
+            buildQueryFiltersForOperations(
+                Field.USER_ID, Resource.AUDIT_LOG,
+                Set.of(
+                    Op.NOT_EQUALS,
+                    Op.GREATER_THAN,
+                    Op.LESS_THAN,
+                    Op.GREATER_THAN_OR_EQUAL_TO,
+                    Op.LESS_THAN_OR_EQUAL_TO,
+                    Op.IN,
+                    Op.NOT_IN,
+                    Op.STARTS_WITH,
+                    Op.ENDS_WITH,
+                    Op.CONTAINS,
+                    Op.REGEX,
+                    Op.PREFIX
+                )
+            ),
+
+            buildQueryFiltersForOperations(
+                Field.TYPE, Resource.AUDIT_LOG,
+                Set.of(
+                    Op.PREFIX,
+                    Op.LESS_THAN,
+                    Op.LESS_THAN_OR_EQUAL_TO,
+                    Op.GREATER_THAN,
+                    Op.GREATER_THAN_OR_EQUAL_TO
+                )
+            ),
+
+            buildQueryFiltersForOperations(
+                Field.RESOURCES, Resource.AUDIT_LOG,
+                Set.of(
+                    Op.EQUALS,
+                    Op.NOT_EQUALS,
+                    Op.GREATER_THAN,
+                    Op.LESS_THAN,
+                    Op.GREATER_THAN_OR_EQUAL_TO,
+                    Op.LESS_THAN_OR_EQUAL_TO,
+                    Op.NOT_IN,
+                    Op.STARTS_WITH,
+                    Op.ENDS_WITH,
+                    Op.CONTAINS,
+                    Op.REGEX,
+                    Op.PREFIX
+                )
+            ),
+
+            buildQueryFiltersForOperations(
+                Field.ACTION, Resource.AUDIT_LOG,
+                Set.of(
+                    Op.NOT_EQUALS,
+                    Op.GREATER_THAN,
+                    Op.LESS_THAN,
+                    Op.GREATER_THAN_OR_EQUAL_TO,
+                    Op.LESS_THAN_OR_EQUAL_TO,
+                    Op.NOT_IN,
+                    Op.STARTS_WITH,
+                    Op.ENDS_WITH,
+                    Op.CONTAINS,
+                    Op.REGEX,
+                    Op.PREFIX
+                )
+            ),
+
+            buildQueryFiltersForOperations(
+                Field.DETAILS, Resource.AUDIT_LOG,
+                Set.of(
+                    Op.NOT_EQUALS,
+                    Op.GREATER_THAN,
+                    Op.LESS_THAN,
+                    Op.GREATER_THAN_OR_EQUAL_TO,
+                    Op.LESS_THAN_OR_EQUAL_TO,
+                    Op.IN,
+                    Op.NOT_IN,
+                    Op.STARTS_WITH,
+                    Op.ENDS_WITH,
+                    Op.CONTAINS,
+                    Op.REGEX,
+                    Op.PREFIX
+                )
+            ),
+
+            buildQueryFiltersForOperations(
+                Field.START_DATE, Resource.AUDIT_LOG,
+                Set.of(
+                    Op.IN,
+                    Op.NOT_IN,
+                    Op.STARTS_WITH,
+                    Op.ENDS_WITH,
+                    Op.CONTAINS,
+                    Op.REGEX,
+                    Op.PREFIX
+                )
+            ),
+
+            buildQueryFiltersForOperations(
+                Field.END_DATE, Resource.AUDIT_LOG,
+                Set.of(
+                    Op.IN,
+                    Op.NOT_IN,
+                    Op.STARTS_WITH,
+                    Op.ENDS_WITH,
+                    Op.CONTAINS,
+                    Op.REGEX,
+                    Op.PREFIX
                 )
             )
         ).flatMap(s -> s);

--- a/tests/src/main/java/io/kestra/core/utils/QueryFilterTestUtils.java
+++ b/tests/src/main/java/io/kestra/core/utils/QueryFilterTestUtils.java
@@ -1,0 +1,48 @@
+package io.kestra.core.utils;
+
+import io.kestra.core.models.QueryFilter;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * Test utility for converting {@link QueryFilter} instances to PHP-style URL query parameters
+ * compatible with the format parsed by {@code QueryFilterFormatBinder}.
+ *
+ * <p>Example usage:
+ * <pre>{@code
+ * Map<String, String> params = QueryFilterTestUtils.toQueryParams(filters);
+ * UriBuilder builder = UriBuilder.of("/api/v1/executions/search");
+ * params.forEach(builder::queryParam);
+ * }</pre>
+ */
+public final class QueryFilterTestUtils {
+
+    private QueryFilterTestUtils() {
+    }
+
+    public static Map<String, String> toQueryParams(List<QueryFilter> filters) {
+        Map<String, String> result = new LinkedHashMap<>();
+        for (QueryFilter filter : filters) {
+            String baseKey = "filters[%s][%s]".formatted(
+                filter.field().value(),
+                filter.operation().name()
+            );
+            serializeValue(baseKey, filter.value(), result);
+        }
+        return result;
+    }
+
+    @SuppressWarnings("unchecked")
+    private static void serializeValue(String baseKey, Object value, Map<String, String> result) {
+        if (value instanceof List<?> list) {
+            result.put(baseKey, list.stream().map(String::valueOf).collect(Collectors.joining(",")));
+        } else if (value instanceof Map<?, ?> map) {
+            ((Map<String, String>) map).forEach((k, v) -> result.put(baseKey + "[" + k + "]", v));
+        } else {
+            result.put(baseKey, String.valueOf(value));
+        }
+    }
+}


### PR DESCRIPTION
### ✨ Description

This PR cleans up the audit log filters and introduces a new utility for controller tests:

Removes the CONTAINS operator for resources: resources is a singular item, not a collection, making CONTAINS conceptually incorrect. In v1.3, the UI and API used CONTAINS as a workaround for an EQUALS operation. I originally retained it to preserve backward compatibility, but since these audit log filters are slated for the 2.0 release, we can safely drop this legacy behavior and enforce the correct operator.

Adds QueryFilterTestUtils: This new utility helps serialize QueryFilter objects into the exact format supported by our endpoint. This abstracts away the boilerplate and streamlines the creation of controller tests.

### 🔗 Related Issue
Relates to kestra-io/kestra#15299 


### 🛠️ Backend Checklist
- [x] Code compiles successfully and passes all checks
- [x] All unit and integration tests pass