### PR TITLE
fix(worker): retry once on UNAUTHENTICATED when sending to controller

### DIFF
--- a/worker/src/main/java/io/kestra/worker/senders/GrpcWorkerIOSender.java
+++ b/worker/src/main/java/io/kestra/worker/senders/GrpcWorkerIOSender.java
@@ -163,7 +163,10 @@ public class GrpcWorkerIOSender<T> extends WorkerLoop implements WorkerIOSender 
 
     private void sendOpaqueData(final BatchMessage<T> batchMessage) {
         OpaqueData request = buildRequest(batchMessage);
-        StreamObserver<OpaqueData> observer = fallbackMapperOnResourceExhausted != null ? new FallbackOnResourceExhaustedObserver(batchMessage) : DEFAULT_OBSERVER;
+        StreamObserver<OpaqueData> baseObserver = fallbackMapperOnResourceExhausted != null
+            ? new FallbackOnResourceExhaustedObserver(batchMessage)
+            : DEFAULT_OBSERVER;
+        StreamObserver<OpaqueData> observer = new RetryOnUnauthenticatedObserver(batchMessage, baseObserver);
         grpcSendMethod.accept(request, observer);
     }
 
@@ -172,6 +175,50 @@ public class GrpcWorkerIOSender<T> extends WorkerLoop implements WorkerIOSender 
             .setHeader(RequestOrResponseHeaderFactory.create(workerContext))
             .setMessage(MessageFormats.JSON.toByteString(batchMessage))
             .build();
+    }
+
+    /**
+     * A per-call {@link StreamObserver} that retries once when the server
+     * rejects the request with {@code UNAUTHENTICATED} (e.g. expired access token).
+     * <p>
+     * The retry re-invokes the gRPC method, which goes through the auth interceptor
+     * again and picks up a refreshed token. The delegate observer handles any further
+     * errors, preventing infinite retry loops.
+     */
+    private class RetryOnUnauthenticatedObserver implements StreamObserver<OpaqueData> {
+
+        private final BatchMessage<T> originalBatch;
+        private final StreamObserver<OpaqueData> delegate;
+
+        RetryOnUnauthenticatedObserver(final BatchMessage<T> originalBatch, final StreamObserver<OpaqueData> delegate) {
+            this.originalBatch = originalBatch;
+            this.delegate = delegate;
+        }
+
+        @Override
+        public void onNext(OpaqueData value) {
+            delegate.onNext(value);
+        }
+
+        @Override
+        public void onError(Throwable t) {
+            if (isUnauthenticated(t)) {
+                LOG.warn("UNAUTHENTICATED error while sending {}, retrying once", eventType.getSimpleName());
+                grpcSendMethod.accept(buildRequest(originalBatch), delegate);
+            } else {
+                delegate.onError(t);
+            }
+        }
+
+        @Override
+        public void onCompleted() {
+            delegate.onCompleted();
+        }
+
+        private static boolean isUnauthenticated(final Throwable t) {
+            return t instanceof StatusRuntimeException sre
+                && sre.getStatus().getCode() == Status.Code.UNAUTHENTICATED;
+        }
     }
 
     /**

--- a/worker/src/test/java/io/kestra/worker/senders/GrpcWorkerIOSenderTest.java
+++ b/worker/src/test/java/io/kestra/worker/senders/GrpcWorkerIOSenderTest.java
@@ -4,6 +4,7 @@ import java.time.Duration;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -24,6 +25,8 @@ import io.kestra.core.utils.IdUtils;
 import io.kestra.core.worker.Controller;
 import io.kestra.core.worker.models.WorkerContext;
 
+import io.grpc.Status;
+import io.grpc.StatusRuntimeException;
 import io.grpc.stub.StreamObserver;
 import io.micronaut.context.ApplicationContext;
 import io.micronaut.context.annotation.Property;
@@ -121,6 +124,42 @@ class GrpcWorkerIOSenderTest {
         assertThat(received.getTaskRun().getId()).isEqualTo(large.getTaskRun().getId());
         assertThat(received.getTaskRun().getState().getCurrent()).isEqualTo(State.Type.FAILED);
         assertThat(received.getOutputs()).isNull();
+    }
+
+    @Test
+    void shouldRetryOnceOnUnauthenticatedError() {
+        // Given - first call fails with UNAUTHENTICATED, second succeeds
+        AtomicInteger callCount = new AtomicInteger(0);
+        doAnswer(inv -> {
+            OpaqueData req = inv.getArgument(0);
+            StreamObserver<OpaqueData> obs = inv.getArgument(1);
+            if (callCount.getAndIncrement() == 0) {
+                obs.onError(new StatusRuntimeException(Status.UNAUTHENTICATED.withDescription("Invalid or expired access token")));
+            } else {
+                obs.onNext(OpaqueData.newBuilder().setHeader(req.getHeader()).build());
+                obs.onCompleted();
+            }
+            return null;
+        }).when(grpcWorkerControllerService).sendWorkerTaskResults(any(), any());
+
+        WorkerTaskResult result = buildTaskResult(Map.of("key", "value"));
+
+        // When
+        taskResultSender.send(List.of(result));
+
+        // Then - should have been called twice (initial + retry)
+        ArgumentCaptor<OpaqueData> captor = ArgumentCaptor.forClass(OpaqueData.class);
+        await()
+            .atMost(Duration.ofSeconds(3))
+            .untilAsserted(() -> {
+                verify(grpcWorkerControllerService, org.mockito.Mockito.atLeast(2))
+                    .sendWorkerTaskResults(captor.capture(), any());
+            });
+
+        // The retried request should contain the same task result
+        WorkerTaskResult received = deserialize(captor.getAllValues().getLast()).records().getFirst();
+        assertThat(received.getTaskRun().getId()).isEqualTo(result.getTaskRun().getId());
+        assertThat(received.getOutputs()).isEqualTo(Map.of("key", "value"));
     }
 
     private static WorkerTaskResult buildTaskResult(Map<String, Object> outputs) {


### PR DESCRIPTION
When a worker's gRPC access token expires during task execution, the result-send call fails with UNAUTHENTICATED and the message is silently dropped — task results, logs, and metrics are lost.

Wrap the send with RetryOnUnauthenticatedObserver so that a single retry goes through the auth interceptor again and picks up a refreshed token. The retry delegates to the base observer, so further failures (including RESOURCE_EXHAUSTED) are still handled and no infinite retry loop can occur.