### PR TITLE
fix(core): streamline execution status change

### DIFF
--- a/ui/src/components/executions/ChangeExecutionStatus.vue
+++ b/ui/src/components/executions/ChangeExecutionStatus.vue
@@ -55,17 +55,14 @@
 
 <script setup lang="ts">
     import {ref, computed} from "vue";
-    import {useRouter, useRoute} from "vue-router";
     import {useI18n} from "vue-i18n";
 
     import SwapHorizontal from "vue-material-design-icons/SwapHorizontal.vue";
 
     import {State, Status} from "@kestra-io/ui-libs";
-    import * as ExecutionUtils from "../../utils/executionUtils";
     import permission from "../../models/permission";
     import action from "../../models/action";
     import {useToast} from "../../utils/toast";
-    import {useAxios} from "../../utils/axios";
 
     import {Execution, useExecutionsStore} from "../../stores/executions";
     import {useAuthStore} from "override/stores/auth";
@@ -78,9 +75,6 @@
 
     const {t} = useI18n({useScope: "global"});
     const toast = useToast();
-    const router = useRouter();
-    const route = useRoute();
-    const axios = useAxios();
 
     const executionsStore = useExecutionsStore();
     const authStore = useAuthStore();
@@ -130,33 +124,15 @@
     const changeStatus = async () => {
         visible.value = false;
 
-        const response = await executionsStore.changeExecutionStatus({
+        await executionsStore.changeExecutionStatus({
             executionId: props.execution.id,
             state: selectedStatus.value!
         });
 
-        let execution;
-        if (response.data.id === props.execution.id) {
-            execution = await ExecutionUtils.waitForState(axios, response.data);
-        } else {
-            execution = response.data;
-        }
+        const execution = await executionsStore.waitForStateChange(props.execution) as Execution;
 
         executionsStore.execution = execution;
-        if (execution.id === props.execution.id) {
-            emit("follow");
-        } else {
-            router.push({
-                name: "executions/update",
-                params: {
-                    namespace: execution.namespace,
-                    flowId: execution.flowId,
-                    id: execution.id,
-                    tab: "gantt",
-                    tenant: route.params.tenant
-                }
-            });
-        }
+        emit("follow");
         toast.success(t("change execution state done"));
     };
 </script>

--- a/ui/src/components/executions/ChangeStatus.vue
+++ b/ui/src/components/executions/ChangeStatus.vue
@@ -69,11 +69,8 @@
     import permission from "../../models/permission";
     import action from "../../models/action";
     import {State, Status} from "@kestra-io/ui-libs"
-    import * as ExecutionUtils from "../../utils/executionUtils";
     import {shallowRef, ref} from "vue";
     import {useAuthStore} from "override/stores/auth"
-    import {useAxios} from "../../utils/axios";
-    import {useRoute, useRouter} from "vue-router";
     import {useToast} from "../../utils/toast";
     import {useI18n} from "vue-i18n";
 
@@ -102,13 +99,11 @@
         emits: ["follow"],
         setup(props, {emit}) {
             const visible = ref(false);
+            const selectedStatus = ref(undefined);
 
             const {t} = useI18n();
 
             const executionsStore = useExecutionsStore();
-            const $http = useAxios();
-            const router = useRouter();
-            const route = useRoute();
             const toast = useToast();
 
             function changeStatus() {
@@ -118,31 +113,12 @@
                     .changeStatus({
                         executionId: props.execution.id,
                         taskRunId: props.taskRun.id,
-                        state: this.selectedStatus
+                        state: selectedStatus.value
                     })
-                    .then(response => {
-                        if (response.data.id === props.execution.id) {
-                            return ExecutionUtils.waitForState($http, response.data);
-                        } else {
-                            return response.data;
-                        }
-                    })
+                    .then(() => executionsStore.waitForStateChange(props.execution))
                     .then((execution) => {
                         executionsStore.execution = execution;
-                        if (execution.id === props.execution.id) {
-                            emit("follow")
-                        } else {
-                            router.push({
-                                name: "executions/update",
-                                params: {
-                                    namespace: execution.namespace,
-                                    flowId: execution.flowId,
-                                    id: execution.id,
-                                    tab: "gantt",
-                                    tenant: route.params.tenant
-                                }
-                            });
-                        }
+                        emit("follow")
 
                         toast.success(t("change state done"));
                     })
@@ -150,6 +126,7 @@
 
             return {
                 visible,
+                selectedStatus,
                 changeStatus
             }
         },
@@ -201,7 +178,6 @@
         },
         data() {
             return {
-                selectedStatus: undefined,
                 icon: {StateMachine: shallowRef(StateMachine)}
             };
         },

--- a/ui/src/components/executions/Executions.vue
+++ b/ui/src/components/executions/Executions.vue
@@ -904,15 +904,16 @@
         return t("bulk replay", {"executionCount": queryBulkAction.value ? executionsStore.total : selection.value.length});
     };
 
-    const changeStatus = () => {
+    const changeStatus = async () => {
         changeStatusDialogVisible.value = false;
         actionOptions.value.newStatus = selectedStatus.value;
 
-        genericConfirmCallback(
+        await genericConfirmCallback(
             "queryChangeExecutionStatus",
             "bulkChangeExecutionStatus",
             "executions state changed"
         );
+        window.setTimeout(() => loadData(), 100);
     };
 
     const changeStatusToast = () => {

--- a/ui/src/stores/executions.ts
+++ b/ui/src/stores/executions.ts
@@ -7,6 +7,7 @@ import throttle from "lodash/throttle";
 import {useRoute} from "vue-router";
 import {CLUSTER_PREFIX} from "@kestra-io/ui-libs/src/utils/constants.ts";
 import {useAxios} from "../utils/axios";
+import * as ExecutionUtils from "../utils/executionUtils";
 
 interface LogsState {
     total: number;
@@ -34,6 +35,9 @@ export interface Execution{
         value?: string
         executionId?: string
         outputs?: Record<string, any>
+        state?: {
+            current: string
+        }
     }[]
     state: {
         current: string;
@@ -218,6 +222,11 @@ export const useExecutionsStore = defineStore("executions", () => {
                 taskRunId: options.taskRunId,
                 state: options.state,
             })
+    }
+    const waitForStateChange = async (source: Execution) => {
+        const updated = await ExecutionUtils.waitForState(axios, source) as Execution;
+        execution.value = updated;
+        return updated;
     }
 
     const kill = (options: { id: string; isOnKillCascade?: boolean }) => {
@@ -624,7 +633,6 @@ export const useExecutionsStore = defineStore("executions", () => {
 
             return !nodeExecution.taskRunList?.some((taskRun: { taskId: string }) => taskRun.taskId === nodeToCheck.task?.id);
 
-
         }
 
     const loadAugmentedGraph = async (options: { id: string; params?: Record<string, any> }) => {
@@ -778,6 +786,7 @@ export const useExecutionsStore = defineStore("executions", () => {
         replayExecutionWithInputs,
         changeExecutionStatus,
         changeStatus,
+        waitForStateChange,
         kill,
         bulkKill,
         queryKill,

--- a/ui/src/utils/executionUtils.ts
+++ b/ui/src/utils/executionUtils.ts
@@ -4,16 +4,16 @@ import {apiUrl} from "override/utils/route";
 interface Execution {
     id: string,
     state: {
-        histories: any[]
+        histories?: any[]
     },
     taskRunList: Array<{
-        state: {
+        state?: {
             current: string
         }
     }>
 }
 
-export function waitFor($http: AxiosInstance, execution: Execution, predicate: (data: any) => boolean) {
+export function waitFor($http: AxiosInstance, execution: {id: string}, predicate: (data: any) => boolean) {
     return new Promise((resolve) => {
         const callback = () => {
             $http.get(`${apiUrl()}/executions/${execution.id}`).then(response => {
@@ -37,11 +37,11 @@ export function waitFor($http: AxiosInstance, execution: Execution, predicate: (
 }
 
 export function findTaskRunsByState(execution: Execution, state: string)  {
-    return execution.taskRunList.filter((taskRun) => taskRun.state.current === state);
+    return execution.taskRunList.filter((taskRun) => taskRun.state?.current === state);
 }
 
-export function statePredicate(execution: Execution, current: {state: {histories: any[]}}) {
-    return current.state.histories.length >= execution.state.histories.length
+export function statePredicate(execution: Execution, current: {state: {histories?: any[]}}) {
+    return (current.state.histories?.length ?? 0) >= (execution.state.histories?.length ?? 0)
 }
 
 export function waitForState($http: AxiosInstance, execution: Execution) {
@@ -49,5 +49,3 @@ export function waitForState($http: AxiosInstance, execution: Execution) {
         return statePredicate(execution, current);
     })
 }
-
-


### PR DESCRIPTION
Closes https://github.com/kestra-io/kestra-ee/issues/7342

**Original issue:** Changing status was crashing the instance - same issue **_also reproducible in 1.3.9. same cause but different error._**
**Cause:** Old code passed state: `this.selectedStatus` from inside the `setup()` function, where this is `nnull` — meaning the **state being sent was always null  in payload**
**Fix Summary:**  The commit moves `selectedStatus` into the `setup() `ref and uses selectedStatus.value, now we have payload populated with state --> **This needs backport to 1.3**

---

**After fixing above I found another Issue when you change Status: Gantt/Overview will not be updated until manual refresh. (Only in develop because of related changes in kestra V2)**

**Cause**: In Kestra V2 the backend made `POST /executions/{id}/change-status` and `POST /executions/{id}/state` async — they now return `ApiAsyncEvent `(`{eventId}`) instead of the updated `Execution`. The old frontend branched on `response.data.id === props.execution.id`, which was always `false` (`id is undefined`), so it skipped the wait and **rendered against stale state.**
**Fix Summary:** Added `waitForStateChange` that polls `GET /executions/{id}` until `state.histories.length` grows past the pre-command value — the deterministic signal the async event was processed. Both components now: fire the command → await waitForStateChange → emit("follow"), so the new SSE starts from the already-updated state.