### PR TITLE
fix(test): reduce flaky test failures in queue and runner tests

### DIFF
--- a/core/src/test/java/io/kestra/core/runners/MultipleConditionTriggerCaseTest.java
+++ b/core/src/test/java/io/kestra/core/runners/MultipleConditionTriggerCaseTest.java
@@ -168,7 +168,7 @@ public class MultipleConditionTriggerCaseTest {
         assertThrows(
             RuntimeException.class, () -> runnerUtils.awaitFlowExecution(
                 e -> e.getState().getCurrent().equals(Type.SUCCESS),
-                MAIN_TENANT, "io.kestra.tests.trigger.multiple.preconditions", "flow-trigger-multiple-preconditions-flow-listen", Duration.ofSeconds(1)
+                MAIN_TENANT, "io.kestra.tests.trigger.multiple.preconditions", "flow-trigger-multiple-preconditions-flow-listen", Duration.ofSeconds(3)
             )
         );
     }
@@ -194,7 +194,7 @@ public class MultipleConditionTriggerCaseTest {
         assertThrows(
             RuntimeException.class, () -> runnerUtils.awaitFlowExecution(
                 e -> e.getState().getCurrent().equals(Type.SUCCESS),
-                MAIN_TENANT, "io.kestra.tests.trigger.multiple.conditions", "flow-trigger-multiple-conditions-flow-listen", Duration.ofSeconds(1)
+                MAIN_TENANT, "io.kestra.tests.trigger.multiple.conditions", "flow-trigger-multiple-conditions-flow-listen", Duration.ofSeconds(3)
             )
         );
     }
@@ -222,7 +222,7 @@ public class MultipleConditionTriggerCaseTest {
         assertThrows(
             RuntimeException.class, () -> runnerUtils.awaitFlowExecution(
                 e -> e.getState().getCurrent().equals(Type.SUCCESS),
-                MAIN_TENANT, "io.kestra.tests.trigger.when.condition", "flow-trigger-when-condition-flow-listen", Duration.ofSeconds(1)
+                MAIN_TENANT, "io.kestra.tests.trigger.when.condition", "flow-trigger-when-condition-flow-listen", Duration.ofSeconds(3)
             )
         );
     }
@@ -328,7 +328,7 @@ public class MultipleConditionTriggerCaseTest {
         assertThrows(RuntimeException.class, () -> runnerUtils.awaitFlowExecution(
             e -> e.getState().getCurrent().equals(Type.SUCCESS) && !e.getId().equals(triggerExecution.getId()),
             MAIN_TENANT, "io.kestra.tests.trigger.fire.once.true", "flow-trigger-fire-once-true-flow-listen",
-            Duration.ofSeconds(1)
+            Duration.ofSeconds(3)
         ));
     }
 
@@ -353,7 +353,7 @@ public class MultipleConditionTriggerCaseTest {
         assertThrows(
             RuntimeException.class, () -> runnerUtils.awaitFlowExecution(
                 e -> e.getState().getCurrent().equals(Type.SUCCESS),
-                MAIN_TENANT, "io.kestra.tests.trigger.mixed.conditions", "flow-trigger-mixed-conditions-flow-listen", Duration.ofSeconds(1)
+                MAIN_TENANT, "io.kestra.tests.trigger.mixed.conditions", "flow-trigger-mixed-conditions-flow-listen", Duration.ofSeconds(3)
             )
         );
     }

--- a/queue/src/test/java/io/kestra/queue/AbstractBroadcastQueueTest.java
+++ b/queue/src/test/java/io/kestra/queue/AbstractBroadcastQueueTest.java
@@ -20,7 +20,7 @@ import static io.kestra.core.utils.Rethrow.throwConsumer;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public abstract class AbstractBroadcastQueueTest extends AbstractQueueTest {
-    private static final int DEFAULT_TIMEOUT_SECONDS = 15;
+    private static final int DEFAULT_TIMEOUT_SECONDS = 30;
 
     @Inject
     private BroadcastQueueInterface<TestBroadcast> broadcastQueue;

--- a/queue/src/test/java/io/kestra/queue/AbstractDispatchQueueTest.java
+++ b/queue/src/test/java/io/kestra/queue/AbstractDispatchQueueTest.java
@@ -56,18 +56,25 @@ public abstract class AbstractDispatchQueueTest extends AbstractQueueTest {
     void singleConsumer() throws QueueException, InterruptedException {
         CountDownLatch countDownLatch = new CountDownLatch(2);
         Collection<Integer> list = Collections.synchronizedCollection(new ArrayList<>());
+        Set<String> expectedKeys = Collections.synchronizedSet(new HashSet<>());
 
         QueueSubscriber<TestDispatch> subscriber = dispatchQueue
             .subscriber()
             .subscribe(e ->
             {
-                list.add(e.getLeft().id);
-                countDownLatch.countDown();
+                if (expectedKeys.contains(e.getLeft().key)) {
+                    list.add(e.getLeft().id);
+                    countDownLatch.countDown();
+                }
             });
 
         String prefix = this.keyPrefix();
-        dispatchQueue.emit(new TestDispatch(prefix + "_" + IdUtils.create(), 1));
-        dispatchQueue.emit(new TestDispatch(prefix + "_" + IdUtils.create(), 2));
+        String key1 = prefix + "_" + IdUtils.create();
+        String key2 = prefix + "_" + IdUtils.create();
+        expectedKeys.add(key1);
+        expectedKeys.add(key2);
+        dispatchQueue.emit(new TestDispatch(key1, 1));
+        dispatchQueue.emit(new TestDispatch(key2, 2));
 
         boolean await = countDownLatch.await(DEFAULT_TIMEOUT_SECONDS, TimeUnit.SECONDS);
         subscriber.close();

--- a/tests/src/main/java/io/kestra/core/runners/TestRunnerUtils.java
+++ b/tests/src/main/java/io/kestra/core/runners/TestRunnerUtils.java
@@ -212,12 +212,12 @@ public class TestRunnerUtils {
     }
 
     public Execution emitAndAwaitExecution(Predicate<Execution> predicate, Execution execution) throws QueueException {
-        return emitAndAwaitExecution(predicate, execution, Duration.ofSeconds(20));
+        return emitAndAwaitExecution(predicate, execution, Duration.ofSeconds(45));
     }
 
     public Execution restartExecution(Predicate<Execution> predicate, Execution execution)
         throws QueueException, InterruptedException {
-        return restartExecution(predicate, execution, Duration.ofSeconds(20));
+        return restartExecution(predicate, execution, Duration.ofSeconds(45));
     }
 
     public Execution restartExecution(Predicate<Execution> predicate, Execution execution, Duration duration)
@@ -239,14 +239,14 @@ public class TestRunnerUtils {
     }
 
     public Execution awaitExecution(Predicate<Execution> predicate, Execution execution) {
-        return awaitExecution(predicate, execution, Duration.ofSeconds(20));
+        return awaitExecution(predicate, execution, Duration.ofSeconds(45));
     }
 
     public Execution awaitExecution(Predicate<Execution> predicate, Execution execution, Duration duration) {
         try {
 
             if (duration == null) {
-                duration = Duration.ofSeconds(20);
+                duration = Duration.ofSeconds(45);
             }
             return Await.until(() ->
             {
@@ -287,7 +287,7 @@ public class TestRunnerUtils {
         try {
 
             if (duration == null) {
-                duration = Duration.ofSeconds(20);
+                duration = Duration.ofSeconds(45);
             }
             return Await.until(() ->
             {
@@ -332,7 +332,7 @@ public class TestRunnerUtils {
             );
         try {
             if (duration == null) {
-                duration = Duration.ofSeconds(20);
+                duration = Duration.ofSeconds(45);
             }
             Await.until(() ->
             {
@@ -389,7 +389,7 @@ public class TestRunnerUtils {
         try {
 
             if (duration == null) {
-                duration = Duration.ofSeconds(20);
+                duration = Duration.ofSeconds(45);
             }
             return Await.until(() ->
             {


### PR DESCRIPTION
Companion PR to kestra-io/kestra-ee#7432

- **Dispatch queue `closingConsumer` flake**: Guard consumer callback by expected message keys so stale Kafka topic messages from other tests don't pollute the assertion (was: `[13, 14]` instead of `[1, 2]`)
- **Broadcast queue `pause` timeout**: Increase `DEFAULT_TIMEOUT_SECONDS` from 15s to 30s — Kafka consumer group rebalancing after pause/resume cycles can exceed 15s under CI load
- **Runner test timeouts**: Increase negative assertion timeout from 1s to 3s (ES deletion settling) and default await timeout from 20s to 45s (ES indexing latency under CI load)