### PR TITLE
feat(execution): task output endpoint

### DIFF
--- a/openapi.yml
+++ b/openapi.yml
@@ -4769,6 +4769,33 @@ paths:
             application/json:
               schema:
                 type: boolean
+  /api/v1/{tenant}/outputs/{executionId}:
+    get:
+      tags:
+      - Outputs
+      summary: Get task run outputs
+      operationId: getTaskOutputsInformation
+      parameters:
+      - name: executionId
+        in: path
+        description: The execution id
+        required: true
+        schema:
+          type: string
+      - name: tenant
+        in: path
+        required: true
+        schema:
+          type: string
+      responses:
+        "200":
+          description: getTaskOutputsInformation 200 response
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/OutputController.TaskOutputInformation"
   /api/v1/{tenant}/outputs/{executionId}/{taskRunId}:
     get:
       tags:
@@ -4799,7 +4826,9 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/TaskOutput"
+                type: object
+                additionalProperties:
+                  type: object
   /api/v1/{tenant}/secrets:
     get:
       tags:
@@ -7224,6 +7253,20 @@ components:
           type: string
         required:
           type: boolean
+    OutputController.TaskOutputInformation:
+      type: object
+      properties:
+        taskId:
+          type: string
+        taskRunId:
+          type: string
+        value:
+          type: string
+        iteration:
+          type: integer
+          format: int32
+        inline:
+          type: boolean
     PagedResults_ApiTriggerAndState_:
       required:
       - results
@@ -7982,20 +8025,6 @@ components:
             $ref: "#/components/schemas/Input_Object_"
         subflowId:
           $ref: "#/components/schemas/ExecutableTask.SubflowId"
-    TaskOutput:
-      type: object
-      properties:
-        taskRunId:
-          type: string
-        tenantId:
-          type: string
-        executionId:
-          type: string
-        value:
-          type: string
-          format: byte
-        uri:
-          type: string
     TaskRun:
       required:
       - executionId

--- a/webserver/src/main/java/io/kestra/webserver/controllers/api/OutputController.java
+++ b/webserver/src/main/java/io/kestra/webserver/controllers/api/OutputController.java
@@ -1,7 +1,10 @@
 package io.kestra.webserver.controllers.api;
 
-import io.kestra.core.models.executions.TaskOutput;
+import io.kestra.core.exceptions.InternalException;
+import io.kestra.core.exceptions.NotFoundException;
+import io.kestra.core.repositories.ExecutionRepositoryInterface;
 import io.kestra.core.repositories.TaskOutputRepositoryInterface;
+import io.kestra.core.services.TaskOutputService;
 import io.kestra.core.tenant.TenantService;
 
 import io.micronaut.http.annotation.Controller;
@@ -13,8 +16,19 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import jakarta.inject.Inject;
 
+import java.util.List;
+import java.util.Map;
+
+import static io.kestra.core.utils.Rethrow.throwFunction;
+
 @Controller("/api/v1/{tenant}/outputs")
 public class OutputController {
+    @Inject
+    private TaskOutputService taskOutputService;
+
+    @Inject
+    private ExecutionRepositoryInterface executionRepository;
+
     @Inject
     private TaskOutputRepositoryInterface taskOutputRepository;
 
@@ -24,9 +38,32 @@ public class OutputController {
     @ExecuteOn(TaskExecutors.IO)
     @Get(uri = "{executionId}/{taskRunId}")
     @Operation(tags = { "Outputs" }, summary = "Get task run outputs")
-    public TaskOutput getTaskRunOutputs(
-        @Parameter(description = "The execution id") @PathVariable String executionId, // executionId is used in EE to check RBAC
-        @Parameter(description = "The task run id") @PathVariable String taskRunId) {
-        return taskOutputRepository.findById(tenantService.resolveTenant(), taskRunId).orElse(null);
+    public Map<String, Object> getTaskRunOutputs(
+        @Parameter(description = "The execution id") @PathVariable String executionId,
+        @Parameter(description = "The task run id") @PathVariable String taskRunId) throws InternalException {
+        var execution = executionRepository.findById(tenantService.resolveTenant(), executionId).orElseThrow(NotFoundException::new);
+        var taskRun = execution.findTaskRunByTaskRunId(taskRunId);
+        return taskOutputService.getOutputs(taskRun);
     }
+
+    @ExecuteOn(TaskExecutors.IO)
+    @Get(uri = "{executionId}")
+    @Operation(tags = { "Outputs" }, summary = "Get task run outputs")
+    public List<TaskOutputInformation> getTaskOutputsInformation(@Parameter(description = "The execution id") @PathVariable String executionId) throws InternalException {
+        var execution = executionRepository.findById(tenantService.resolveTenant(), executionId).orElseThrow(NotFoundException::new);
+        return taskOutputRepository.findByExecution(execution).stream()
+            .map(throwFunction(taskOutput -> {
+                var taskRun = execution.findTaskRunByTaskRunId(taskOutput.taskRunId());
+                return new TaskOutputInformation(
+                        taskRun.getTaskId(),
+                        taskRun.getId(),
+                        taskRun.getValue(),
+                        taskRun.getIteration(),
+                        taskOutput.value() != null);
+                }
+            ))
+            .toList();
+    }
+
+    public record TaskOutputInformation(String taskId, String taskRunId, String value, Integer iteration, boolean inline) {}
 }

--- a/webserver/src/test/java/io/kestra/webserver/controllers/api/OutputControllerTest.java
+++ b/webserver/src/test/java/io/kestra/webserver/controllers/api/OutputControllerTest.java
@@ -1,7 +1,13 @@
 package io.kestra.webserver.controllers.api;
 
 import java.nio.charset.StandardCharsets;
+import java.util.List;
 
+import io.kestra.core.models.executions.Execution;
+import io.kestra.core.models.executions.TaskRun;
+import io.kestra.core.models.flows.State;
+import io.kestra.core.repositories.ExecutionRepositoryInterface;
+import io.micronaut.core.type.Argument;
 import org.junit.jupiter.api.Test;
 
 import io.kestra.core.junit.annotations.KestraTest;
@@ -27,27 +33,38 @@ class OutputControllerTest {
     @Inject
     private TaskOutputRepositoryInterface taskOutputRepository;
 
+    @Inject
+    private ExecutionRepositoryInterface executionRepository;
+
     @Test
     void getTaskOutput() {
-        String taskRunId = "taskRunId";
         String tenantId = TenantService.MAIN_TENANT;
-        byte[] value = "value".getBytes(StandardCharsets.UTF_8);
+        String taskRunId = "taskRunId";
+        var execution = Execution.builder()
+            .tenantId(tenantId)
+            .id("executionId")
+            .namespace("namespace")
+            .flowId("flowId")
+            .taskRunList(List.of(TaskRun.builder().tenantId(tenantId).id(taskRunId).build()))
+            .state(new State())
+            .build();
+        String value = """
+        {"some":"output"}""";
+        executionRepository.save(execution);
 
-        TaskOutput taskOutput = new TaskOutput(taskRunId, tenantId, "executionId", value, null);
+        TaskOutput taskOutput = new TaskOutput(taskRunId, tenantId, "executionId", value.getBytes(StandardCharsets.UTF_8), null);
         taskOutputRepository.save(taskOutput);
 
-        TaskOutput response = client.toBlocking().retrieve(
+        String response = client.toBlocking().retrieve(
             HttpRequest.GET("/api/v1/" + tenantId + "/outputs/executionId/" + taskRunId),
-            TaskOutput.class
+            String.class
         );
 
-        assertThat(response.taskRunId()).isEqualTo(taskRunId);
-        assertThat(response.tenantId()).isEqualTo(tenantId);
-        assertThat(response.value()).isEqualTo(value);
+        assertThat(response).isEqualTo(value);
     }
 
     @Test
-    void getNotFound() {
+    void getTaskOutputShouldThrowNotFoundWhenTaskRunNotFound() {
         String taskRunId = "notFound";
         String tenantId = TenantService.MAIN_TENANT;
 
@@ -55,6 +72,47 @@ class OutputControllerTest {
             HttpClientResponseException.class, () -> client.toBlocking().retrieve(
                 HttpRequest.GET("/api/v1/" + tenantId + "/outputs/executionId/" + taskRunId),
                 TaskOutput.class
+            )
+        );
+    }
+
+    @Test
+    void getTaskOutputInformation() {
+        String tenantId = TenantService.MAIN_TENANT;
+        String taskRunId = "taskRunId";
+        var execution = Execution.builder()
+            .tenantId(tenantId)
+            .id("executionId")
+            .namespace("namespace")
+            .flowId("flowId")
+            .taskRunList(List.of(TaskRun.builder().tenantId(tenantId).id(taskRunId).build()))
+            .state(new State())
+            .build();
+        String value = """
+        {"some":"output"}""";
+        executionRepository.save(execution);
+
+        TaskOutput taskOutput = new TaskOutput(taskRunId, tenantId, "executionId", value.getBytes(StandardCharsets.UTF_8), null);
+        taskOutputRepository.save(taskOutput);
+
+        List<OutputController.TaskOutputInformation> response = client.toBlocking().retrieve(
+            HttpRequest.GET("/api/v1/" + tenantId + "/outputs/executionId"),
+            Argument.listOf(OutputController.TaskOutputInformation.class)
+        );
+
+        assertThat(response).hasSize(1);
+        assertThat(response.getFirst().taskRunId()).isEqualTo(taskRunId);
+        assertThat(response.getFirst().inline()).isTrue();
+    }
+
+    @Test
+    void getTaskOutputInformationShouldThrowNotFoundWhenTaskRunNotFound() {
+        String tenantId = TenantService.MAIN_TENANT;
+
+        assertThrows(
+            HttpClientResponseException.class, () -> client.toBlocking().retrieve(
+                HttpRequest.GET("/api/v1/" + tenantId + "/outputs/not-found"),
+                Argument.listOf(OutputController.TaskOutputInformation.class)
             )
         );
     }


### PR DESCRIPTION
- Change the return of the by-taskrun endpoint to directely return the map of outputs
- Add an endpoint to list the task output information without including any output content

Companion PR: https://github.com/kestra-io/kestra-ee/pull/7446