### PR TITLE
fix(executions): followExecution was broken because awaitility used a separate thread

### DIFF
--- a/cli/src/main/java/io/kestra/cli/StandAloneRunner.java
+++ b/cli/src/main/java/io/kestra/cli/StandAloneRunner.java
@@ -22,6 +22,7 @@ import jakarta.annotation.PreDestroy;
 import jakarta.inject.Inject;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
+import io.kestra.core.utils.Await;
 
 @Slf4j
 public class StandAloneRunner implements Runnable, AutoCloseable {
@@ -83,7 +84,7 @@ public class StandAloneRunner implements Runnable, AutoCloseable {
         }
 
         try {
-            Awaitility.await().atMost(runningTimeout).until(
+            Await.await().atMost(runningTimeout).until(
                 () -> servers.stream().allMatch(s -> Optional.ofNullable(s.getState()).orElse(Service.ServiceState.RUNNING).isRunning())
             );
         } catch (ConditionTimeoutException e) {

--- a/cli/src/main/java/io/kestra/cli/commands/servers/ControllerCommand.java
+++ b/cli/src/main/java/io/kestra/cli/commands/servers/ControllerCommand.java
@@ -13,6 +13,7 @@ import io.micronaut.context.ApplicationContext;
 import jakarta.inject.Inject;
 import picocli.CommandLine;
 import picocli.CommandLine.Command;
+import io.kestra.core.utils.Await;
 
 @Command(
     name = "controller",
@@ -45,7 +46,7 @@ public class ControllerCommand extends AbstractServerCommand {
         Controller controller = applicationContext.getBean(Controller.class);
         controller.start();
 
-        Awaitility.await().forever().until(() -> !this.applicationContext.isRunning());
+        Await.await().forever().until(() -> !this.applicationContext.isRunning());
 
         return 0;
     }

--- a/cli/src/main/java/io/kestra/cli/commands/servers/ExecutorCommand.java
+++ b/cli/src/main/java/io/kestra/cli/commands/servers/ExecutorCommand.java
@@ -18,6 +18,7 @@ import org.awaitility.Awaitility;
 import io.micronaut.context.ApplicationContext;
 import jakarta.inject.Inject;
 import picocli.CommandLine;
+import io.kestra.core.utils.Await;
 
 @CommandLine.Command(
     name = "executor",
@@ -86,7 +87,7 @@ public class ExecutorCommand extends AbstractServerCommand {
         Executor executorService = applicationContext.getBean(Executor.class);
         executorService.run();
 
-        Awaitility.await().forever().until(() -> !this.applicationContext.isRunning());
+        Await.await().forever().until(() -> !this.applicationContext.isRunning());
 
         return 0;
     }

--- a/cli/src/main/java/io/kestra/cli/commands/servers/IndexerCommand.java
+++ b/cli/src/main/java/io/kestra/cli/commands/servers/IndexerCommand.java
@@ -14,6 +14,7 @@ import org.awaitility.Awaitility;
 import io.micronaut.context.ApplicationContext;
 import jakarta.inject.Inject;
 import picocli.CommandLine;
+import io.kestra.core.utils.Await;
 
 @CommandLine.Command(
     name = "indexer",
@@ -48,7 +49,7 @@ public class IndexerCommand extends AbstractServerCommand {
         Indexer indexer = applicationContext.getBean(Indexer.class);
         indexer.run();
 
-        Awaitility.await().forever().until(() -> !this.applicationContext.isRunning());
+        Await.await().forever().until(() -> !this.applicationContext.isRunning());
 
         return 0;
     }

--- a/cli/src/main/java/io/kestra/cli/commands/servers/SchedulerCommand.java
+++ b/cli/src/main/java/io/kestra/cli/commands/servers/SchedulerCommand.java
@@ -13,6 +13,7 @@ import io.micronaut.context.ApplicationContext;
 import jakarta.inject.Inject;
 import lombok.extern.slf4j.Slf4j;
 import picocli.CommandLine;
+import io.kestra.core.utils.Await;
 
 @CommandLine.Command(
     name = "scheduler",
@@ -40,7 +41,7 @@ public class SchedulerCommand extends AbstractServerCommand {
         Scheduler scheduler = applicationContext.getBean(Scheduler.class);
         scheduler.start(Optional.ofNullable(this.maxThread).orElse(Scheduler.defaultMaxNumThreads()));
 
-        Awaitility.await().forever().until(() -> !this.applicationContext.isRunning());
+        Await.await().forever().until(() -> !this.applicationContext.isRunning());
 
         return 0;
     }

--- a/cli/src/main/java/io/kestra/cli/commands/servers/StandAloneCommand.java
+++ b/cli/src/main/java/io/kestra/cli/commands/servers/StandAloneCommand.java
@@ -23,6 +23,7 @@ import jakarta.annotation.Nullable;
 import jakarta.inject.Inject;
 import picocli.CommandLine;
 import picocli.CommandLine.Option;
+import io.kestra.core.utils.Await;
 
 @CommandLine.Command(
     name = "standalone",
@@ -139,7 +140,7 @@ public class StandAloneCommand extends AbstractServerCommand {
                 fileWatcher.startListeningFromConfig();
             }
 
-            Awaitility.await().forever().until(() -> !this.applicationContext.isRunning());
+            Await.await().forever().until(() -> !this.applicationContext.isRunning());
         }
 
         return 0;

--- a/cli/src/main/java/io/kestra/cli/commands/servers/WebServerCommand.java
+++ b/cli/src/main/java/io/kestra/cli/commands/servers/WebServerCommand.java
@@ -19,6 +19,7 @@ import jakarta.inject.Inject;
 import lombok.extern.slf4j.Slf4j;
 import picocli.CommandLine;
 import picocli.CommandLine.Option;
+import io.kestra.core.utils.Await;
 
 @CommandLine.Command(
     name = "webserver",
@@ -93,7 +94,7 @@ public class WebServerCommand extends AbstractServerCommand {
         }
 
         log.info("Webserver started");
-        Awaitility.await().forever().until(() -> !this.applicationContext.isRunning());
+        Await.await().forever().until(() -> !this.applicationContext.isRunning());
         return 0;
     }
 }

--- a/cli/src/main/java/io/kestra/cli/commands/servers/WorkerCommand.java
+++ b/cli/src/main/java/io/kestra/cli/commands/servers/WorkerCommand.java
@@ -11,6 +11,7 @@ import io.micronaut.context.ApplicationContext;
 import jakarta.inject.Inject;
 import picocli.CommandLine;
 import picocli.CommandLine.Option;
+import io.kestra.core.utils.Await;
 
 @CommandLine.Command(
     name = "worker",
@@ -46,7 +47,7 @@ public class WorkerCommand extends AbstractServerCommand {
         Worker worker = applicationContext.getBean(Worker.class);
         worker.start(this.thread, this.workerGroupKey);
 
-        Awaitility.await().forever().until(() -> !this.applicationContext.isRunning());
+        Await.await().forever().until(() -> !this.applicationContext.isRunning());
 
         return 0;
     }

--- a/core/src/main/java/io/kestra/core/server/ServiceRegistry.java
+++ b/core/src/main/java/io/kestra/core/server/ServiceRegistry.java
@@ -9,6 +9,7 @@ import org.awaitility.Awaitility;
 import org.awaitility.core.ConditionTimeoutException;
 
 import jakarta.inject.Singleton;
+import io.kestra.core.utils.Await;
 
 /**
  * Service for registering local service states.
@@ -47,7 +48,7 @@ public final class ServiceRegistry {
     }
 
     public Service waitForServiceAndGet(final ServiceType type) {
-        Awaitility.await().forever().until(() -> containsService(type));
+        Await.await().forever().until(() -> containsService(type));
         return getServiceByType(type);
     }
 
@@ -84,7 +85,7 @@ public final class ServiceRegistry {
         if (!containsService(type))
             return false;
         try {
-            Awaitility.await().atMost(maxWaitDuration).pollInterval(Duration.ofMillis(100)).until(() ->
+            Await.await().atMost(maxWaitDuration).pollInterval(Duration.ofMillis(100)).until(() ->
             {
                 LocalServiceState service = get(type);
                 return service != null && service.instance().is(state);

--- a/core/src/main/java/io/kestra/core/utils/Await.java
+++ b/core/src/main/java/io/kestra/core/utils/Await.java
@@ -1,22 +1,36 @@
 package io.kestra.core.utils;
 
+import org.awaitility.Awaitility;
+import org.awaitility.core.ConditionFactory;
+
 import java.time.Duration;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BooleanSupplier;
 import java.util.function.Supplier;
 
-/**
- * @deprecated use {@link org.awaitility.Awaitility} instead
- */
-@Deprecated
+
 public class Await {
     private static final Duration defaultSleep = Duration.ofMillis(100);
 
+    public static ConditionFactory await(){
+        Awaitility.pollInSameThread();
+        Awaitility.setDefaultPollDelay(defaultSleep);
+        return Awaitility.await();
+    }
+
+    /**
+     * @deprecated use {@link #await()} instead
+     */
+    @Deprecated
     public static void until(BooleanSupplier condition) {
         Await.until(condition, null);
     }
 
+    /**
+     * @deprecated use {@link #await()} instead
+     */
+    @Deprecated
     public static void until(BooleanSupplier condition, Duration sleep) {
         if (sleep == null) {
             sleep = defaultSleep;
@@ -31,10 +45,18 @@ public class Await {
         }
     }
 
+    /**
+     * @deprecated use {@link #await()} instead
+     */
+    @Deprecated
     public static void until(BooleanSupplier condition, Duration sleep, Duration timeout) throws TimeoutException {
         until(null, condition, sleep, timeout);
     }
 
+    /**
+     * @deprecated use {@link #await()} instead
+     */
+    @Deprecated
     public static void until(Supplier<String> errorMessageInCaseOfFailure, BooleanSupplier condition, Duration sleep, Duration timeout) throws TimeoutException {
         if (sleep == null) {
             sleep = defaultSleep;
@@ -73,6 +95,10 @@ public class Await {
         };
     }
 
+    /**
+     * @deprecated use {@link #await()} instead
+     */
+    @Deprecated
     public static <T> T until(Supplier<T> supplier, Duration sleep, Duration timeout) throws TimeoutException {
         AtomicReference<T> result = new AtomicReference<>();
 
@@ -81,6 +107,10 @@ public class Await {
         return result.get();
     }
 
+    /**
+     * @deprecated use {@link #await()} instead
+     */
+    @Deprecated
     public static <T> T until(Supplier<T> supplier, Duration sleep) {
         AtomicReference<T> result = new AtomicReference<>();
 

--- a/core/src/main/java/io/kestra/core/utils/Await.java
+++ b/core/src/main/java/io/kestra/core/utils/Await.java
@@ -14,9 +14,10 @@ public class Await {
     private static final Duration defaultSleep = Duration.ofMillis(100);
 
     public static ConditionFactory await(){
-        Awaitility.pollInSameThread();
-        Awaitility.setDefaultPollDelay(defaultSleep);
-        return Awaitility.await();
+        return Awaitility
+            .await()
+            .pollInSameThread()
+            .pollDelay(defaultSleep);
     }
 
     /**

--- a/core/src/main/java/io/kestra/core/utils/Await.java
+++ b/core/src/main/java/io/kestra/core/utils/Await.java
@@ -20,12 +20,8 @@ public class Await {
             .pollDelay(defaultSleep);
     }
 
-    /**
-     * @deprecated use {@link #await()} instead
-     */
-    @Deprecated
     public static void until(BooleanSupplier condition) {
-        Await.until(condition, null);
+        await().forever().until(condition::getAsBoolean);
     }
 
     /**

--- a/script/src/main/java/io/kestra/plugin/scripts/runner/docker/Docker.java
+++ b/script/src/main/java/io/kestra/plugin/scripts/runner/docker/Docker.java
@@ -55,6 +55,7 @@ import lombok.experimental.SuperBuilder;
 import static io.kestra.core.utils.Rethrow.throwConsumer;
 import static io.kestra.core.utils.Rethrow.throwFunction;
 import static io.kestra.core.utils.WindowsUtils.windowsToUnixPath;
+import io.kestra.core.utils.Await;
 
 @SuperBuilder(toBuilder = true)
 @ToString
@@ -608,7 +609,7 @@ public class Docker extends TaskRunner<Docker.DockerTaskRunnerDetailResult> {
                 WaitContainerResultCallback result = dockerClient.waitContainerCmd(runContainerId).start();
 
                 Integer exitCode = result.awaitStatusCode();
-                Awaitility.await().forever().until(ended::get);
+                Await.await().forever().until(ended::get);
 
                 if (exitCode != 0) {
                     if (needVolume && FileHandlingStrategy.VOLUME.equals(strategy) && filesVolumeName != null) {

--- a/tests/src/main/java/io/kestra/core/runners/TestRunner.java
+++ b/tests/src/main/java/io/kestra/core/runners/TestRunner.java
@@ -19,6 +19,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.atomic.AtomicBoolean;
+import io.kestra.core.utils.Await;
 
 @SuppressWarnings("try")
 @Slf4j
@@ -81,7 +82,7 @@ public class TestRunner implements Runnable, AutoCloseable {
         servers.add(indexer);
 
         try {
-            Awaitility.await().atMost(runningTimeout).until(() -> servers.stream().allMatch(s -> Optional.ofNullable(s.getState()).orElse(Service.ServiceState.RUNNING).isRunning()));
+            Await.await().atMost(runningTimeout).until(() -> servers.stream().allMatch(s -> Optional.ofNullable(s.getState()).orElse(Service.ServiceState.RUNNING).isRunning()));
         } catch (ConditionTimeoutException e) {
             throw new RuntimeException(
                 servers.stream().filter(s -> !Optional.ofNullable(s.getState()).orElse(Service.ServiceState.RUNNING).isRunning())

--- a/webserver/src/main/java/io/kestra/webserver/controllers/api/ExecutionController.java
+++ b/webserver/src/main/java/io/kestra/webserver/controllers/api/ExecutionController.java
@@ -14,7 +14,7 @@ import java.time.ZonedDateTime;
 import java.util.*;
 
 import io.kestra.core.serializers.JacksonMapper;
-import org.awaitility.Awaitility;
+import io.kestra.core.utils.Await;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -24,7 +24,6 @@ import org.reactivestreams.Publisher;
 import org.slf4j.Logger;
 import org.slf4j.event.Level;
 
-import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import io.kestra.core.debug.Breakpoint;
@@ -1714,7 +1713,7 @@ public class ExecutionController {
 
             // Check if execution exists
             try {
-                Execution execution = Awaitility.await()
+                Execution execution = Await.await()
                     .atMost(Duration.ofSeconds(10))
                     .pollInterval(Duration.ofMillis(500))
                     .until(
@@ -2209,7 +2208,7 @@ public class ExecutionController {
         //  This should not be an issue as long as it executes on an IO thread.
 
         // Check if execution exists
-        Execution current = Awaitility.await()
+        Execution current = Await.await()
             .atMost(Duration.ofSeconds(10))
             .pollInterval(Duration.ofMillis(500))
             .until(

--- a/worker/src/main/java/io/kestra/worker/WorkerAgent.java
+++ b/worker/src/main/java/io/kestra/worker/WorkerAgent.java
@@ -42,6 +42,7 @@ import lombok.extern.slf4j.Slf4j;
 
 import static io.kestra.core.server.Service.ServiceState.TERMINATED_FORCED;
 import static io.kestra.core.server.Service.ServiceState.TERMINATED_GRACEFULLY;
+import io.kestra.core.utils.Await;
 
 @Slf4j
 @Singleton
@@ -287,7 +288,7 @@ public class WorkerAgent extends AbstractService implements Worker {
         );
 
         // Wait for jobs completion
-        Awaitility.await()
+        Await.await()
             .pollInterval(Duration.ofSeconds(1))
             .ignoreExceptions()
             .until(() ->


### PR DESCRIPTION
we now wrap Awatility inside our Await to have a centralized configuration. Thanks to that by default Awatility use the same thread for polling.
