### PR TITLE
feat(worker): internal-storage based service discovery for controller gRPC

### DIFF
--- a/core/src/main/java/io/kestra/core/server/ServiceLivenessListener.java
+++ b/core/src/main/java/io/kestra/core/server/ServiceLivenessListener.java
@@ -1,0 +1,28 @@
+package io.kestra.core.server;
+
+import java.time.Instant;
+
+/**
+ * Hook invoked after a successful service liveness state update, on both the
+ * scheduled heartbeat tick and event-driven state transitions.
+ * <p>
+ * Implementations are registered as Micronaut beans and discovered automatically
+ * by {@link ServiceLivenessManager}. They must be fast and non-throwing:
+ * exceptions are caught and logged by the manager so that a broken listener
+ * does not break the liveness pipeline.
+ * <p>
+ * Invocation order across registered listeners is not guaranteed.
+ */
+public interface ServiceLivenessListener {
+
+    /**
+     * Called with the latest remote view of a service instance once its liveness
+     * state update has been confirmed (either {@code SUCCEEDED} or recovered via
+     * {@code ABORTED}). Not invoked on {@code FAILED} transitions.
+     *
+     * @param now      the instant the update happened.
+     * @param instance the service instance after the successful update.
+     * @param newState the state the instance is in after the update.
+     */
+    void onLivenessUpdate(Instant now, ServiceInstance instance, Service.ServiceState newState);
+}

--- a/core/src/main/java/io/kestra/core/server/ServiceLivenessManager.java
+++ b/core/src/main/java/io/kestra/core/server/ServiceLivenessManager.java
@@ -39,6 +39,7 @@ public class ServiceLivenessManager extends AbstractServiceLivenessTask {
     protected final OnStateTransitionFailureCallback onStateTransitionFailureCallback;
     private final ServerInstanceFactory serverInstanceFactory;
     private final ServiceRegistry serviceRegistry;
+    private final List<ServiceLivenessListener> livenessListeners;
 
     private Instant lastSucceedStateUpdated;
 
@@ -47,8 +48,18 @@ public class ServiceLivenessManager extends AbstractServiceLivenessTask {
         final ServiceRegistry serviceRegistry,
         final LocalServiceStateFactory localServiceStateFactory,
         final ServerInstanceFactory serverInstanceFactory,
+        final ServiceLivenessUpdater serviceLivenessUpdater,
+        final List<ServiceLivenessListener> livenessListeners) {
+        this(configuration, serviceRegistry, localServiceStateFactory, serverInstanceFactory, serviceLivenessUpdater, new DefaultStateTransitionFailureCallback(), livenessListeners);
+    }
+
+    @VisibleForTesting
+    public ServiceLivenessManager(final ServerConfig configuration,
+        final ServiceRegistry serviceRegistry,
+        final LocalServiceStateFactory localServiceStateFactory,
+        final ServerInstanceFactory serverInstanceFactory,
         final ServiceLivenessUpdater serviceLivenessUpdater) {
-        this(configuration, serviceRegistry, localServiceStateFactory, serverInstanceFactory, serviceLivenessUpdater, new DefaultStateTransitionFailureCallback());
+        this(configuration, serviceRegistry, localServiceStateFactory, serverInstanceFactory, serviceLivenessUpdater, new DefaultStateTransitionFailureCallback(), List.of());
     }
 
     @VisibleForTesting
@@ -58,12 +69,24 @@ public class ServiceLivenessManager extends AbstractServiceLivenessTask {
         final ServerInstanceFactory serverInstanceFactory,
         final ServiceLivenessUpdater serviceLivenessUpdater,
         final OnStateTransitionFailureCallback onStateTransitionFailureCallback) {
+        this(configuration, serviceRegistry, localServiceStateFactory, serverInstanceFactory, serviceLivenessUpdater, onStateTransitionFailureCallback, List.of());
+    }
+
+    @VisibleForTesting
+    public ServiceLivenessManager(final ServerConfig configuration,
+        final ServiceRegistry serviceRegistry,
+        final LocalServiceStateFactory localServiceStateFactory,
+        final ServerInstanceFactory serverInstanceFactory,
+        final ServiceLivenessUpdater serviceLivenessUpdater,
+        final OnStateTransitionFailureCallback onStateTransitionFailureCallback,
+        final List<ServiceLivenessListener> livenessListeners) {
         super(TASK_NAME, configuration);
         this.serviceRegistry = serviceRegistry;
         this.localServiceStateFactory = localServiceStateFactory;
         this.serverInstanceFactory = serverInstanceFactory;
         this.serviceLivenessUpdater = serviceLivenessUpdater;
         this.onStateTransitionFailureCallback = onStateTransitionFailureCallback;
+        this.livenessListeners = livenessListeners == null ? List.of() : List.copyOf(livenessListeners);
     }
 
     /**
@@ -319,6 +342,13 @@ public class ServiceLivenessManager extends AbstractServiceLivenessTask {
             }
             // Update the local instance
             this.serviceRegistry.register(localServiceState.with(remoteInstance));
+
+            // Notify listeners on successful state update (SUCCEEDED or recovered ABORTED).
+            // Not invoked on FAILED so downstream sinks (e.g., discovery registry) stop
+            // refreshing when the coordinator has lost track of the service.
+            if (isStateTransitionSucceed) {
+                notifyLivenessListeners(now, remoteInstance, remoteInstance.state());
+            }
         } catch (Exception e) {
             final ServiceInstance localInstance = localServiceState.instance();
             log.error(
@@ -338,6 +368,26 @@ public class ServiceLivenessManager extends AbstractServiceLivenessTask {
             }
         }
         return Optional.ofNullable(localServiceState(service)).map(LocalServiceState::instance).orElse(null);
+    }
+
+    /**
+     * Invokes every registered {@link ServiceLivenessListener}. Listener failures are
+     * caught and logged so that a broken listener cannot break the heartbeat pipeline.
+     */
+    private void notifyLivenessListeners(final Instant now,
+        final ServiceInstance instance,
+        final Service.ServiceState newState) {
+        if (livenessListeners.isEmpty()) {
+            return;
+        }
+        for (ServiceLivenessListener listener : livenessListeners) {
+            try {
+                listener.onLivenessUpdate(now, instance, newState);
+            } catch (Exception e) {
+                log.warn("Liveness listener [{}] threw an exception; ignoring",
+                    listener.getClass().getName(), e);
+            }
+        }
     }
 
     private void mayDisableStateUpdate(final Service service, final ServiceInstance instance) {

--- a/core/src/test/java/io/kestra/core/server/ServiceLivenessManagerTest.java
+++ b/core/src/test/java/io/kestra/core/server/ServiceLivenessManagerTest.java
@@ -27,6 +27,8 @@ import io.kestra.core.utils.Network;
 import static io.kestra.core.server.ServiceStateTransition.Result.ABORTED;
 import static io.kestra.core.server.ServiceStateTransition.Result.FAILED;
 import static io.kestra.core.server.ServiceStateTransition.Result.SUCCEEDED;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 @ExtendWith({ MockitoExtension.class })
@@ -42,6 +44,7 @@ public class ServiceLivenessManagerTest {
     ArgumentCaptor<ServiceInstance> workerInstanceCaptor;
 
     private ServiceLivenessManager serviceLivenessManager;
+    private ServiceLivenessListener livenessListener;
 
     @Mock
     private ServiceLivenessManager.OnStateTransitionFailureCallback onStateTransitionFailureCallback;
@@ -64,13 +67,15 @@ public class ServiceLivenessManagerTest {
         KestraContext context = Mockito.mock(KestraContext.class);
         KestraContext.setContext(context);
         when(context.getServerType()).thenReturn(ServerType.INDEXER);
+        this.livenessListener = Mockito.mock(ServiceLivenessListener.class);
         this.serviceLivenessManager = new ServiceLivenessManager(
             config,
             new ServiceRegistry(),
             new LocalServiceStateFactory(config, new ServerInstanceFactory(context, null)),
             new ServerInstanceFactory(kestraContext, null),
             serviceLivenessUpdater,
-            onStateTransitionFailureCallback
+            onStateTransitionFailureCallback,
+            List.of(livenessListener)
         );
     }
 
@@ -161,6 +166,84 @@ public class ServiceLivenessManagerTest {
             .execute(Mockito.any(), Mockito.any(), Mockito.any(), Mockito.eq(true));
     }
 
+    @Test
+    void shouldNotifyLivenessListenerOnScheduledSuccess() {
+        // Given
+        Service running = newServiceForState(Service.ServiceState.RUNNING);
+        serviceLivenessManager.updateServiceInstance(running, serviceInstanceFor(running));
+
+        ServiceInstance updated = serviceInstanceFor(running);
+        when(serviceLivenessUpdater.update(Mockito.any(ServiceInstance.class), Mockito.any(Service.ServiceState.class)))
+            .thenReturn(new ServiceStateTransition.Response(SUCCEEDED, updated));
+
+        // When
+        Instant now = Instant.now();
+        serviceLivenessManager.onSchedule(now);
+
+        // Then
+        verify(livenessListener).onLivenessUpdate(
+            Mockito.eq(now),
+            Mockito.any(ServiceInstance.class),
+            Mockito.eq(Service.ServiceState.RUNNING)
+        );
+    }
+
+    @Test
+    void shouldNotifyLivenessListenerOnRecoveredAbortedTransition() {
+        // Given
+        Service running = newServiceForState(Service.ServiceState.RUNNING);
+        serviceLivenessManager.updateServiceInstance(running, serviceInstanceFor(running));
+
+        when(serviceLivenessUpdater.update(Mockito.any(ServiceInstance.class), Mockito.any(Service.ServiceState.class)))
+            .thenReturn(new ServiceStateTransition.Response(ABORTED));
+
+        // When
+        serviceLivenessManager.onSchedule(Instant.now());
+
+        // Then — ABORTED is recovered and treated as success
+        verify(livenessListener).onLivenessUpdate(
+            Mockito.any(Instant.class),
+            Mockito.any(ServiceInstance.class),
+            Mockito.any(Service.ServiceState.class)
+        );
+    }
+
+    @Test
+    void shouldNotNotifyLivenessListenerOnFailedTransition() {
+        // Given
+        Service running = newServiceForState(Service.ServiceState.RUNNING);
+        serviceLivenessManager.updateServiceInstance(running, serviceInstanceFor(running));
+
+        when(serviceLivenessUpdater.update(Mockito.any(ServiceInstance.class), Mockito.any(Service.ServiceState.class)))
+            .thenReturn(new ServiceStateTransition.Response(FAILED, serviceInstanceFor(running)));
+
+        // When
+        serviceLivenessManager.onSchedule(Instant.now());
+
+        // Then
+        verifyNoInteractions(livenessListener);
+    }
+
+    @Test
+    void shouldSwallowLivenessListenerException() {
+        // Given
+        Service running = newServiceForState(Service.ServiceState.RUNNING);
+        serviceLivenessManager.updateServiceInstance(running, serviceInstanceFor(running));
+
+        ServiceInstance updated = serviceInstanceFor(running);
+        when(serviceLivenessUpdater.update(Mockito.any(ServiceInstance.class), Mockito.any(Service.ServiceState.class)))
+            .thenReturn(new ServiceStateTransition.Response(SUCCEEDED, updated));
+
+        Mockito.doThrow(new RuntimeException("listener-boom"))
+            .when(livenessListener).onLivenessUpdate(Mockito.any(), Mockito.any(), Mockito.any());
+
+        // When / Then — exception must not propagate
+        serviceLivenessManager.onSchedule(Instant.now());
+
+        verify(livenessListener).onLivenessUpdate(Mockito.any(), Mockito.any(), Mockito.any());
+        Assertions.assertEquals(updated, serviceLivenessManager.allServiceInstances().getFirst());
+    }
+    
     @Test
     void shouldRegisterNewInstanceAfterPreviousOneTerminated() {
         // Given - a service that completed a terminal state transition (isStateUpdatable = false)

--- a/worker-controller/src/main/java/io/kestra/controller/GrpcChannelManager.java
+++ b/worker-controller/src/main/java/io/kestra/controller/GrpcChannelManager.java
@@ -1,5 +1,7 @@
 package io.kestra.controller;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.annotations.VisibleForTesting;
 import io.grpc.ChannelCredentials;
 import io.grpc.Channel;
@@ -8,19 +10,34 @@ import io.grpc.Grpc;
 import io.grpc.InsecureChannelCredentials;
 import io.grpc.ManagedChannel;
 import io.grpc.ManagedChannelBuilder;
+import io.grpc.NameResolverProvider;
 import io.grpc.NameResolverRegistry;
 import io.kestra.controller.config.GrpcChannelConfiguration;
 import io.kestra.controller.config.GrpcConfiguration;
 import io.kestra.controller.config.WorkerControllersConfiguration;
+import io.kestra.controller.discovery.ControllerRegistration;
+import io.kestra.controller.discovery.ControllerRegistry;
 import io.kestra.controller.grpc.resolver.StaticNameResolverProvider;
+import io.kestra.controller.grpc.resolver.StorageNameResolverProvider;
 import io.kestra.core.contexts.KestraContext;
+import io.kestra.core.serializers.JacksonMapper;
+import io.kestra.core.storages.FileAttributes;
+import io.kestra.core.storages.StorageInterface;
+import io.kestra.core.utils.ExecutorsUtils;
 import jakarta.annotation.PostConstruct;
 import jakarta.annotation.PreDestroy;
 import jakarta.inject.Inject;
+import jakarta.inject.Provider;
 import jakarta.inject.Singleton;
 import lombok.extern.slf4j.Slf4j;
 
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStream;
 import java.net.InetSocketAddress;
+import java.net.URI;
+import java.time.Instant;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -29,14 +46,16 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
 
 /**
  * Manages gRPC channels for worker-to-controller communication.
  * <p>
- * Supports two service discovery strategies:
+ * Supports three service discovery strategies:
  * <ul>
  * <li>STATIC: Explicit list of controller endpoints with gRPC load-balancing</li>
  * <li>DNS: DNS SRV/A record resolution with gRPC load-balancing</li>
+ * <li>STORAGE: Dynamic discovery via Kestra internal storage (controllers self-register)</li>
  * </ul>
  * <p>
  */
@@ -44,15 +63,27 @@ import java.util.concurrent.atomic.AtomicReference;
 @Slf4j
 public class GrpcChannelManager {
 
+    private static final ObjectMapper MAPPER = JacksonMapper.ofJson();
+
     private static final AtomicBoolean STATIC_RESOLVER_REGISTERED = new AtomicBoolean(false);
     // Reference to the registered resolver provider for cleanup
-    private static final AtomicReference<StaticNameResolverProvider> REGISTERED_RESOLVER_PROVIDER = new AtomicReference<>();
-    
+    private static final AtomicReference<StaticNameResolverProvider> REGISTERED_STATIC_RESOLVER_PROVIDER = new AtomicReference<>();
+
+    private static final AtomicBoolean STORAGE_RESOLVER_REGISTERED = new AtomicBoolean(false);
+    private static final AtomicReference<StorageNameResolverProvider> REGISTERED_STORAGE_RESOLVER_PROVIDER = new AtomicReference<>();
+
     private volatile ManagedChannel defaultChannel;
     private final AtomicBoolean stopped = new AtomicBoolean(false);
     private final GrpcChannelConfiguration grpcChannelConfiguration;
     private final GrpcConfiguration grpcConfiguration;
     private final WorkerControllersConfiguration controllersConfig;
+    private final Provider<StorageInterface> storageInterface;
+
+    // Last known good list of storage-discovered endpoints — used to ride out transient storage failures.
+    private volatile List<EquivalentAddressGroup> lastKnownStorageAddresses = List.of();
+
+    // One-shot guard for the "first endpoints loaded from storage" log line.
+    private final AtomicBoolean firstStorageLoadLogged = new AtomicBoolean(false);
 
     // ExecutorService shared across channels
     private final ExecutorService sharedExecutorService;
@@ -63,12 +94,19 @@ public class GrpcChannelManager {
      * @param grpcChannelConfiguration the gRPC channel configuration.
      * @param grpcConfiguration        the global gRPC configuration.
      * @param controllersConfig        the multi-endpoint controllers configuration.
+     * @param storageInterface         the internal storage used for STORAGE discovery. May be {@code null}
+     *                                 when Kestra is started without storage (only STATIC/DNS are then usable).
      */
     @Inject
-    public GrpcChannelManager(GrpcChannelConfiguration grpcChannelConfiguration, GrpcConfiguration grpcConfiguration, WorkerControllersConfiguration controllersConfig) {
+    public GrpcChannelManager(
+        GrpcChannelConfiguration grpcChannelConfiguration,
+        GrpcConfiguration grpcConfiguration,
+        WorkerControllersConfiguration controllersConfig,
+        Provider<StorageInterface> storageInterface) {
         this.grpcChannelConfiguration = grpcChannelConfiguration;
         this.grpcConfiguration = grpcConfiguration;
         this.controllersConfig = controllersConfig;
+        this.storageInterface = storageInterface;
         this.sharedExecutorService = Executors.newThreadPerTaskExecutor(Thread.ofVirtual().name("grpc-channel-", 0).factory());
     }
 
@@ -112,6 +150,7 @@ public class GrpcChannelManager {
         ManagedChannelBuilder<?> builder = switch (controllersConfig.type()) {
             case STATIC -> createStaticChannelBuilder();
             case DNS -> createDnsChannelBuilder();
+            case STORAGE -> createStorageChannelBuilder();
         };
         return configureChannel(builder).build();
     }
@@ -139,9 +178,92 @@ public class GrpcChannelManager {
         if (STATIC_RESOLVER_REGISTERED.compareAndSet(false, true)) {
             StaticNameResolverProvider resolverProvider = new StaticNameResolverProvider(addresses);
             NameResolverRegistry.getDefaultRegistry().register(resolverProvider);
-            REGISTERED_RESOLVER_PROVIDER.set(resolverProvider);
+            REGISTERED_STATIC_RESOLVER_PROVIDER.set(resolverProvider);
         }
         return Grpc.newChannelBuilder("static:///controllers", createChannelCredentials());
+    }
+
+    /**
+     * Creates a channel builder for internal-storage-based discovery.
+     */
+    private ManagedChannelBuilder<?> createStorageChannelBuilder() {
+        WorkerControllersConfiguration.StorageConfig storageConfig = controllersConfig.storageConfig();
+        if (storageConfig == null) {
+            throw new IllegalStateException("Storage configuration is required when kestra.worker.controllers.type=STORAGE");
+        }
+        if (storageInterface == null) {
+            throw new IllegalStateException("StorageInterface bean is not available; cannot use STORAGE discovery");
+        }
+        log.info("Configuring storage discovery with refresh interval {}", storageConfig.refreshInterval());
+
+        if (STORAGE_RESOLVER_REGISTERED.compareAndSet(false, true)) {
+            StorageNameResolverProvider resolverProvider = new StorageNameResolverProvider(
+                this::discoverControllersFromStorage,
+                storageConfig.refreshInterval()
+            );
+            NameResolverRegistry.getDefaultRegistry().register(resolverProvider);
+            REGISTERED_STORAGE_RESOLVER_PROVIDER.set(resolverProvider);
+        }
+        return Grpc.newChannelBuilder("storage:///controllers", createChannelCredentials());
+    }
+
+    /**
+     * Lists live controllers from internal storage. Entries whose {@code expiresAt} is in the past
+     * are filtered out. Malformed entries are dropped individually, but a transient storage error on
+     * any list or read call causes us to return the last known good list unchanged, so that a single
+     * failed round-trip does not flap the LB pool.
+     */
+    @VisibleForTesting
+    List<EquivalentAddressGroup> discoverControllersFromStorage() {
+        List<FileAttributes> files;
+        try {
+            files = storageInterface.get().listInstanceResource(null, ControllerRegistry.REGISTRY_PREFIX);
+        } catch (FileNotFoundException e) {
+            // Registry prefix does not exist yet — no controllers registered.
+            lastKnownStorageAddresses = List.of();
+            return lastKnownStorageAddresses;
+        } catch (IOException e) {
+            log.warn("Failed to list controller registry from storage; returning last known good list ({} entries)",
+                lastKnownStorageAddresses.size(), e);
+            return lastKnownStorageAddresses;
+        }
+
+        Instant now = Instant.now();
+        List<EquivalentAddressGroup> addresses = new ArrayList<>(files.size());
+        for (FileAttributes attr : files) {
+            if (attr.getType() != FileAttributes.FileType.File) {
+                continue;
+            }
+            URI entryUri = ControllerRegistry.REGISTRY_PREFIX.resolve(attr.getFileName());
+            try (InputStream in = storageInterface.get().getInstanceResource(null, entryUri)) {
+                ControllerRegistration registration = MAPPER.readValue(in, ControllerRegistration.class);
+                if (registration.isExpired(now)) {
+                    log.debug("Skipping expired controller registration [{}] at {}", registration.id(), entryUri);
+                    continue;
+                }
+                addresses.add(new EquivalentAddressGroup(new InetSocketAddress(registration.host(), registration.port())));
+            } catch (JsonProcessingException e) {
+                // Malformed JSON — drop just this entry, likely from a stale or partial writer.
+                log.warn("Skipping malformed controller registration at {}", entryUri, e);
+            } catch (IOException e) {
+                // Transient storage failure on a per-entry read — treat as we would a list() failure
+                // and preserve the last known good list rather than committing a shrunken pool.
+                log.warn("Transient storage error reading controller registration at {}; returning last known good list ({} entries)",
+                    entryUri, lastKnownStorageAddresses.size(), e);
+                return lastKnownStorageAddresses;
+            }
+        }
+        lastKnownStorageAddresses = List.copyOf(addresses);
+        if (!addresses.isEmpty() && firstStorageLoadLogged.compareAndSet(false, true)) {
+            log.info("Discovered {} controller endpoint(s) from internal storage: {}",
+                addresses.size(),
+                addresses.stream()
+                    .flatMap(group -> group.getAddresses().stream())
+                    .map(Object::toString)
+                    .toList()
+            );
+        }
+        return lastKnownStorageAddresses;
     }
 
     /**
@@ -233,35 +355,39 @@ public class GrpcChannelManager {
         // Unregister the static name resolver provider to prevent memory leaks
         // and allow clean re-initialization in tests.
         // Use getAndSet to atomically retrieve and clear, preventing double-deregister races.
-        StaticNameResolverProvider provider = REGISTERED_RESOLVER_PROVIDER.getAndSet(null);
-        if (provider != null) {
+        StaticNameResolverProvider staticProvider = REGISTERED_STATIC_RESOLVER_PROVIDER.getAndSet(null);
+        if (staticProvider != null) {
             STATIC_RESOLVER_REGISTERED.set(false);
-            try {
-                NameResolverRegistry.getDefaultRegistry().deregister(provider);
-                log.debug("Unregistered static name resolver provider");
-            } catch (Exception e) {
-                log.debug("Error while unregistering static name resolver provider", e);
-            }
+            deregisterSilently(staticProvider, "static");
+        }
+
+        StorageNameResolverProvider storageProvider = REGISTERED_STORAGE_RESOLVER_PROVIDER.getAndSet(null);
+        if (storageProvider != null) {
+            STORAGE_RESOLVER_REGISTERED.set(false);
+            deregisterSilently(storageProvider, "storage");
         }
 
         // Shutdown executor service
         if (this.sharedExecutorService != null) {
-            try {
-                this.sharedExecutorService.shutdown();
-                if (!this.sharedExecutorService.awaitTermination(grpcChannelConfiguration.shutdownTimeout().toSeconds(), TimeUnit.SECONDS)) {
-                    log.warn("Executor service did not terminate within timeout, forcing shutdown");
-                    this.sharedExecutorService.shutdownNow();
-                }
-            } catch (InterruptedException e) {
-                log.debug("Interrupted while shutting down executor service", e);
-                this.sharedExecutorService.shutdownNow();
-                Thread.currentThread().interrupt();
-            }
+            ExecutorsUtils.closeExecutorService(
+                "grpc-channel",
+                this.sharedExecutorService,
+                grpcChannelConfiguration.shutdownTimeout()
+            );
         }
     }
 
     private void shutdownChannelAndWait() throws InterruptedException {
         this.defaultChannel.shutdown().awaitTermination(grpcChannelConfiguration.shutdownTimeout().toSeconds(), TimeUnit.SECONDS);
+    }
+
+    private static void deregisterSilently(NameResolverProvider provider, String name) {
+        try {
+            NameResolverRegistry.getDefaultRegistry().deregister(provider);
+            log.debug("Unregistered {} name resolver provider", name);
+        } catch (Exception e) {
+            log.debug("Error while unregistering {} name resolver provider", name, e);
+        }
     }
 
     /**

--- a/worker-controller/src/main/java/io/kestra/controller/config/ControllerAdvertiseConfiguration.java
+++ b/worker-controller/src/main/java/io/kestra/controller/config/ControllerAdvertiseConfiguration.java
@@ -1,0 +1,41 @@
+package io.kestra.controller.config;
+
+import java.time.Duration;
+
+import io.micronaut.context.annotation.ConfigurationProperties;
+import io.micronaut.core.annotation.Nullable;
+import io.micronaut.core.bind.annotation.Bindable;
+
+/**
+ * Configuration for the controller self-advertisement in Kestra internal storage.
+ * <p>
+ * When enabled, the controller writes its reachable gRPC endpoint to a well-known location
+ * in internal storage, so that workers configured with
+ * {@code kestra.worker.controllers.type=STORAGE} can discover it dynamically.
+ *
+ * @param enabled           Whether the controller publishes its endpoint to internal storage.
+ *                          Defaults to {@code false}; set to {@code true} to opt in to self-advertisement
+ *                          when workers use {@code kestra.worker.controllers.type=STORAGE}.
+ * @param host              The host that should be advertised to workers. When {@code null}, falls back
+ *                          to {@link io.kestra.core.utils.Network#localHostname()}. Should be set
+ *                          explicitly in containerized environments where the local hostname is not reachable.
+ * @param heartbeatInterval How often the controller refreshes its registry entry. The published TTL
+ *                          is {@code heartbeatInterval * 3} so that up to two missed schedules do not
+ *                          cause workers to prematurely drop the entry. Defaults to 5 minutes.
+ */
+@ConfigurationProperties("kestra.controller.advertise")
+public record ControllerAdvertiseConfiguration(
+    @Bindable(defaultValue = "false") boolean enabled,
+    @Nullable String host,
+    @Bindable(defaultValue = "5m") Duration heartbeatInterval) {
+
+    /**
+     * Returns the TTL to publish in each registry entry. Set to three times the heartbeat interval,
+     * so that up to two missed heartbeats do not immediately expire the entry.
+     *
+     * @return the registry entry TTL.
+     */
+    public Duration ttl() {
+        return heartbeatInterval.multipliedBy(3);
+    }
+}

--- a/worker-controller/src/main/java/io/kestra/controller/config/WorkerControllersConfiguration.java
+++ b/worker-controller/src/main/java/io/kestra/controller/config/WorkerControllersConfiguration.java
@@ -18,31 +18,13 @@ import static io.kestra.controller.config.ControllerConfiguration.DEFAULT_GRPC_P
 /**
  * Configuration for worker-to-controller service discovery.
  * <p>
- * Supports two discovery strategies:
+ * Supports three discovery strategies:
  * <ul>
  * <li>STATIC: Explicit list of controller endpoints with gRPC load-balancing</li>
  * <li>DNS: DNS SRV/A record resolution with gRPC load-balancing</li>
+ * <li>STORAGE: Dynamic discovery via Kestra internal storage (controllers self-register)</li>
  * </ul>
  * <p>
- * Example configuration:
- * 
- * <pre>
- * kestra:
- *   worker:
- *     controllers:
- *       type: STATIC
- *       static:
- *         endpoints:
- *           - host: controller-1.example.com
- *             port: 9096
- *           - host: controller-2.example.com
- *             port: 9096
- *       load-balancing:
- *         policy: ROUND_ROBIN
- *       health-check:
- *         enabled: true
- *         interval: PT30S
- * </pre>
  */
 @ConfigurationProperties("kestra.worker.controllers")
 public record WorkerControllersConfiguration(
@@ -52,6 +34,8 @@ public record WorkerControllersConfiguration(
     @Nullable StaticConfig staticConfig,
 
     @Nullable DnsConfig dnsConfig,
+
+    @Nullable StorageConfig storageConfig,
 
     @Valid LoadBalancing loadBalancing,
 
@@ -69,7 +53,11 @@ public record WorkerControllersConfiguration(
         /**
          * DNS-based discovery using SRV or A records.
          */
-        DNS
+        DNS,
+        /**
+         * Dynamic discovery via Kestra internal storage; controllers self-register their endpoint.
+         */
+        STORAGE
     }
 
     @ConfigurationProperties("static")
@@ -117,6 +105,15 @@ public record WorkerControllersConfiguration(
              */
             A
         }
+    }
+
+    /**
+     * Internal storage-based discovery configuration.
+     */
+    @ConfigurationProperties("storage")
+    @Requires(property = "kestra.worker.controllers.type", value = "STORAGE")
+    public record StorageConfig(
+        @Bindable(defaultValue = "PT30S") Duration refreshInterval) {
     }
 
     /**

--- a/worker-controller/src/main/java/io/kestra/controller/discovery/ControllerRegistration.java
+++ b/worker-controller/src/main/java/io/kestra/controller/discovery/ControllerRegistration.java
@@ -1,0 +1,29 @@
+package io.kestra.controller.discovery;
+
+import java.time.Instant;
+
+/**
+ * Payload written to internal storage by a controller so that workers using
+ * {@code kestra.worker.controllers.type=STORAGE} can discover its gRPC endpoint.
+ *
+ * @param id          Unique identifier of the controller JVM (stable for the lifetime of the process).
+ * @param host        The host advertised for gRPC connections.
+ * @param port        The bound gRPC port.
+ * @param heartbeatAt When the controller last refreshed this entry.
+ * @param expiresAt   When this entry should be considered stale. Computed as
+ *                    {@code heartbeatAt + heartbeatInterval * 3}.
+ */
+public record ControllerRegistration(
+    String id,
+    String host,
+    int port,
+    Instant heartbeatAt,
+    Instant expiresAt) {
+
+    /**
+     * @return {@code true} if this entry has expired relative to the given instant.
+     */
+    public boolean isExpired(Instant now) {
+        return expiresAt != null && now.isAfter(expiresAt);
+    }
+}

--- a/worker-controller/src/main/java/io/kestra/controller/discovery/ControllerRegistry.java
+++ b/worker-controller/src/main/java/io/kestra/controller/discovery/ControllerRegistry.java
@@ -1,0 +1,28 @@
+package io.kestra.controller.discovery;
+
+import java.net.URI;
+
+/**
+ * Well-known locations for the controller registry in internal storage.
+ * <p>
+ * Entries are stored as instance resources (namespace = {@code null}, no tenant) under a shared
+ * prefix so that every Kestra process can list them.
+ */
+public final class ControllerRegistry {
+
+    /** Prefix under which all controller registration files are stored. */
+    public static final URI REGISTRY_PREFIX = URI.create("/_cluster/controllers/registry/");
+
+    private ControllerRegistry() {
+    }
+
+    /**
+     * Returns the URI where the registration for the given controller id is stored.
+     *
+     * @param id the controller JVM identifier.
+     * @return the target URI in internal storage.
+     */
+    public static URI entryUri(final String id) {
+        return REGISTRY_PREFIX.resolve(id + ".json");
+    }
+}

--- a/worker-controller/src/main/java/io/kestra/controller/discovery/ControllerStorageRegistrar.java
+++ b/worker-controller/src/main/java/io/kestra/controller/discovery/ControllerStorageRegistrar.java
@@ -1,0 +1,145 @@
+package io.kestra.controller.discovery;
+
+import java.io.ByteArrayInputStream;
+import java.io.Closeable;
+import java.io.IOException;
+import java.net.URI;
+import java.time.Instant;
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import io.kestra.controller.config.ControllerAdvertiseConfiguration;
+import io.kestra.controller.config.ControllerConfiguration;
+import io.kestra.core.serializers.JacksonMapper;
+import io.kestra.core.server.Service;
+import io.kestra.core.server.ServiceInstance;
+import io.kestra.core.server.ServiceLivenessListener;
+import io.kestra.core.server.ServiceType;
+import io.kestra.core.storages.StorageInterface;
+import io.kestra.core.utils.Network;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.micronaut.context.annotation.Requires;
+import jakarta.annotation.PreDestroy;
+import jakarta.inject.Inject;
+import jakarta.inject.Provider;
+import jakarta.inject.Singleton;
+import lombok.extern.slf4j.Slf4j;
+
+
+/**
+ * Publishes the controller's gRPC endpoint to internal storage on every successful
+ * liveness update, so that workers configured with
+ * {@code kestra.worker.controllers.type=STORAGE} can discover it dynamically.
+ * <p>
+ * Hooks into {@link io.kestra.core.server.ServiceLivenessManager} as a
+ * {@link ServiceLivenessListener} rather than running its own scheduler: the
+ * liveness heartbeat becomes the single source of truth driving storage refreshes,
+ * so a storage entry cannot outlive the controller's liveness state.
+ * <p>
+ * Storage writes are throttled to
+ * {@link ControllerAdvertiseConfiguration#heartbeatInterval()} because the liveness
+ * tick fires at a much higher cadence (~seconds) than is desirable for object
+ * storage round-trips (~minutes).
+ */
+@Singleton
+@Slf4j
+@Requires(property = "kestra.server-type", pattern = "(CONTROLLER|STANDALONE)")
+@Requires(property = "kestra.controller.advertise.enabled", value = "true", defaultValue = "false")
+public class ControllerStorageRegistrar implements ServiceLivenessListener, Closeable {
+
+    private static final ObjectMapper MAPPER = JacksonMapper.ofJson();
+
+    private final Provider<StorageInterface> storageInterface;
+    private final ControllerAdvertiseConfiguration advertiseConfig;
+    private final ControllerConfiguration controllerConfig;
+
+    private volatile String registrationId;
+    private volatile Instant lastWrittenAt;
+    private final AtomicBoolean closed = new AtomicBoolean(false);
+
+    private final String resolvedHost;
+
+    @Inject
+    public ControllerStorageRegistrar(final Provider<StorageInterface> storageInterface,
+                                      final ControllerAdvertiseConfiguration advertiseConfig,
+                                      final ControllerConfiguration controllerConfig) {
+        this.storageInterface = Objects.requireNonNull(storageInterface, "StorageInterface cannot be null");
+        this.advertiseConfig = Objects.requireNonNull(advertiseConfig, "ControllerAdvertiseConfiguration cannot be null");
+        this.controllerConfig = Objects.requireNonNull(controllerConfig, "ControllerConfiguration cannot be null");
+
+        String host = advertiseConfig.host();
+        this.resolvedHost =  host != null && !host.isBlank() ? host : Network.localHostname();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void onLivenessUpdate(final Instant now,
+        final ServiceInstance instance,
+        final Service.ServiceState newState) {
+        if (closed.get() ||
+            instance.type() != ServiceType.CONTROLLER ||
+            newState != Service.ServiceState.RUNNING ||
+            !isDueForRefresh(now)) {
+            return;
+        }
+
+        final String id = instance.uid();
+        try {
+            writeEntry(now, id);
+        } catch (IOException e) {
+            // Do NOT advance lastWrittenAt — next liveness tick will retry.
+            log.warn("Failed to refresh controller [{}] registration in internal storage", id, e);
+            return;
+        }
+
+        if (lastWrittenAt == null) {
+            log.info("Controller [{}] registered in internal storage at [{}]; heartbeat every {}",
+                id, resolvedHost, advertiseConfig.heartbeatInterval());
+        }
+        this.registrationId = id;
+        this.lastWrittenAt = now;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    @PreDestroy
+    public void close() {
+        if (!closed.compareAndSet(false, true)) {
+            return;
+        }
+        if (registrationId == null) {
+            return;
+        }
+        try {
+            storageInterface.get().deleteInstanceResource(null, ControllerRegistry.entryUri(registrationId));
+            log.info("Controller [{}] deregistered from internal storage", registrationId);
+        } catch (IOException e) {
+            log.warn("Failed to deregister controller [{}] from internal storage", registrationId, e);
+        }
+    }
+
+    private boolean isDueForRefresh(final Instant now) {
+        if (lastWrittenAt == null) {
+            return true;
+        }
+        return !now.isBefore(lastWrittenAt.plus(advertiseConfig.heartbeatInterval()));
+    }
+
+    private void writeEntry(final Instant now, final String id) throws IOException {
+        final URI uri = ControllerRegistry.entryUri(id);
+        final ControllerRegistration registration = new ControllerRegistration(
+            id,
+            resolvedHost,
+            controllerConfig.port(),
+            now,
+            now.plus(advertiseConfig.ttl())
+        );
+        final byte[] payload = MAPPER.writeValueAsBytes(registration);
+        storageInterface.get().putInstanceResource(null, uri, new ByteArrayInputStream(payload));
+    }
+}

--- a/worker-controller/src/main/java/io/kestra/controller/grpc/resolver/StaticNameResolver.java
+++ b/worker-controller/src/main/java/io/kestra/controller/grpc/resolver/StaticNameResolver.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 import io.grpc.EquivalentAddressGroup;
 import io.grpc.NameResolver;
+import io.grpc.StatusOr;
 
 /**
  * A gRPC NameResolver that resolves to a static list of controller addresses.
@@ -46,7 +47,9 @@ public class StaticNameResolver extends NameResolver {
 
     private void resolve() {
         if (listener != null) {
-            listener.onResult(ResolutionResult.newBuilder().setAddresses(addresses).build());
+            listener.onResult2(ResolutionResult.newBuilder()
+                .setAddressesOrError(StatusOr.fromValue(addresses))
+                .build());
         }
     }
 

--- a/worker-controller/src/main/java/io/kestra/controller/grpc/resolver/StorageNameResolver.java
+++ b/worker-controller/src/main/java/io/kestra/controller/grpc/resolver/StorageNameResolver.java
@@ -1,0 +1,126 @@
+package io.kestra.controller.grpc.resolver;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
+
+import io.grpc.EquivalentAddressGroup;
+import io.grpc.NameResolver;
+import io.grpc.StatusOr;
+import io.kestra.core.utils.ExecutorsUtils;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * A gRPC {@link NameResolver} that resolves controller endpoints from Kestra internal storage.
+ * <p>
+ * On {@link #start(Listener2)} it pushes an initial resolution and schedules a periodic refresh
+ * using the configured interval. Each tick queries the supplier and notifies the listener only
+ * when the resolved set of addresses actually changes, to avoid churning the gRPC load-balancing
+ * pool.
+ */
+@Slf4j
+public class StorageNameResolver extends NameResolver {
+
+    private static final String AUTHORITY = "controllers";
+
+    private final Supplier<List<EquivalentAddressGroup>> addressSupplier;
+    private final Duration refreshInterval;
+
+    private volatile Listener2 listener;
+    private volatile ScheduledExecutorService scheduler;
+    private volatile ScheduledFuture<?> refreshFuture;
+    private volatile Set<EquivalentAddressGroup> lastAddresses = Set.of();
+
+    /**
+     * Creates a new {@link StorageNameResolver}.
+     *
+     * @param addressSupplier supplies the current list of controller endpoints.
+     * @param refreshInterval how often to poll the supplier.
+     */
+    public StorageNameResolver(
+        final Supplier<List<EquivalentAddressGroup>> addressSupplier,
+        final Duration refreshInterval) {
+        this.addressSupplier = Objects.requireNonNull(addressSupplier);
+        this.refreshInterval = Objects.requireNonNull(refreshInterval);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void start(Listener2 listener) {
+        this.listener = listener;
+        this.scheduler = Executors.newSingleThreadScheduledExecutor(
+            Thread.ofVirtual().name("storage-name-resolver-", 0).factory()
+        );
+        resolve();
+        long intervalMillis = refreshInterval.toMillis();
+        this.refreshFuture = scheduler.scheduleAtFixedRate(
+            this::resolveQuietly,
+            intervalMillis,
+            intervalMillis,
+            TimeUnit.MILLISECONDS
+        );
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void refresh() {
+        resolveQuietly();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getServiceAuthority() {
+        return AUTHORITY;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void shutdown() {
+        if (refreshFuture != null) {
+            refreshFuture.cancel(false);
+        }
+        if (scheduler != null) {
+            ExecutorsUtils.closeExecutorService("storage-name-resolver", scheduler, Duration.ofSeconds(10));
+        }
+    }
+
+    private void resolveQuietly() {
+        try {
+            resolve();
+        } catch (Exception e) {
+            log.warn("Storage name resolver refresh failed", e);
+        }
+    }
+
+    // Synchronized to serialize concurrent refresh() and scheduled-tick invocations: without the lock,
+    // two threads racing on the compare-and-notify can reorder listener.onResult2 calls and leave
+    // gRPC with a stale address set as "latest".
+    private synchronized void resolve() {
+        if (listener == null) {
+            return;
+        }
+        List<EquivalentAddressGroup> addresses = addressSupplier.get();
+        Set<EquivalentAddressGroup> next = Set.copyOf(addresses);
+        if (next.equals(lastAddresses)) {
+            return;
+        }
+        lastAddresses = next;
+        listener.onResult2(ResolutionResult.newBuilder()
+            .setAddressesOrError(StatusOr.fromValue(addresses))
+            .build());
+    }
+}

--- a/worker-controller/src/main/java/io/kestra/controller/grpc/resolver/StorageNameResolverProvider.java
+++ b/worker-controller/src/main/java/io/kestra/controller/grpc/resolver/StorageNameResolverProvider.java
@@ -1,0 +1,66 @@
+package io.kestra.controller.grpc.resolver;
+
+import java.net.URI;
+import java.time.Duration;
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Supplier;
+
+import io.grpc.EquivalentAddressGroup;
+import io.grpc.NameResolver;
+import io.grpc.NameResolverProvider;
+
+/**
+ * A gRPC {@link NameResolverProvider} that serves the {@code storage:///} scheme, backed by
+ * Kestra internal storage.
+ * <p>
+ * Usage:
+ *
+ * <pre>
+ * ManagedChannelBuilder.forTarget("storage:///controllers")
+ * </pre>
+ */
+public class StorageNameResolverProvider extends NameResolverProvider {
+
+    private static final String SCHEME = "storage";
+    private static final int PRIORITY = 5;
+
+    private final Supplier<List<EquivalentAddressGroup>> addressSupplier;
+    private final Duration refreshInterval;
+
+    /**
+     * Creates a new provider.
+     *
+     * @param addressSupplier supplies the current list of controller endpoints, polled on a schedule.
+     * @param refreshInterval how often the returned resolver polls the supplier.
+     */
+    public StorageNameResolverProvider(
+        final Supplier<List<EquivalentAddressGroup>> addressSupplier,
+        final Duration refreshInterval) {
+        this.addressSupplier = Objects.requireNonNull(addressSupplier);
+        this.refreshInterval = Objects.requireNonNull(refreshInterval);
+    }
+
+    @Override
+    public NameResolver newNameResolver(URI targetUri, NameResolver.Args args) {
+        if (!SCHEME.equals(targetUri.getScheme())) {
+            return null;
+        }
+        return new StorageNameResolver(addressSupplier, refreshInterval);
+    }
+
+    @Override
+    public String getDefaultScheme() {
+        return SCHEME;
+    }
+
+    @Override
+    protected boolean isAvailable() {
+        return true;
+    }
+
+    @Override
+    protected int priority() {
+        return PRIORITY;
+    }
+}

--- a/worker-controller/src/test/java/io/kestra/controller/GrpcChannelManagerStorageTest.java
+++ b/worker-controller/src/test/java/io/kestra/controller/GrpcChannelManagerStorageTest.java
@@ -1,0 +1,193 @@
+package io.kestra.controller;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import io.kestra.controller.config.GrpcChannelConfiguration;
+import io.kestra.controller.config.GrpcConfiguration;
+import io.kestra.controller.config.WorkerControllersConfiguration;
+import io.kestra.controller.config.WorkerControllersConfiguration.DiscoveryType;
+import io.kestra.controller.config.WorkerControllersConfiguration.HealthCheck;
+import io.kestra.controller.config.WorkerControllersConfiguration.LoadBalancing;
+import io.kestra.controller.config.WorkerControllersConfiguration.StorageConfig;
+import io.kestra.controller.discovery.ControllerRegistration;
+import io.kestra.controller.discovery.ControllerRegistry;
+import io.kestra.core.contexts.KestraContext;
+import io.kestra.core.serializers.JacksonMapper;
+import io.kestra.core.storages.StorageInterface;
+import io.kestra.storage.local.LocalStorage;
+
+import io.grpc.EquivalentAddressGroup;
+import org.mockito.Mockito;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class GrpcChannelManagerStorageTest {
+
+    private static final ObjectMapper MAPPER = JacksonMapper.ofJson();
+
+    @TempDir
+    Path tempDir;
+
+    private StorageInterface storage;
+    private GrpcChannelManager channelManager;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        // Given — a local internal storage rooted in a JUnit-managed temp directory
+        LocalStorage local = new LocalStorage();
+        local.setBasePath(tempDir);
+        local.init();
+        storage = local;
+
+        KestraContext ctx = Mockito.mock(KestraContext.class);
+        Mockito.when(ctx.getVersion()).thenReturn("test");
+        KestraContext.setContext(ctx);
+    }
+
+    @AfterEach
+    void tearDown() {
+        if (channelManager != null) {
+            channelManager.close();
+            channelManager = null;
+        }
+        KestraContext.setContext(null);
+    }
+
+    @Test
+    void shouldDiscoverRegisteredControllersFromStorage() throws Exception {
+        // Given — two live controllers registered in storage
+        writeRegistration("c1", "controller-1", 6001, Duration.ofMinutes(5));
+        writeRegistration("c2", "controller-2", 6002, Duration.ofMinutes(5));
+
+        channelManager = newManager();
+
+        // When
+        List<EquivalentAddressGroup> discovered = channelManager.discoverControllersFromStorage();
+
+        // Then
+        assertThat(discovered).hasSize(2);
+        assertThat(discovered).extracting(g -> (InetSocketAddress) g.getAddresses().get(0))
+            .extracting(InetSocketAddress::getHostString)
+            .containsExactlyInAnyOrder("controller-1", "controller-2");
+    }
+
+    @Test
+    void shouldFilterOutExpiredRegistrations() throws Exception {
+        // Given — one live + one expired entry
+        writeRegistration("live", "controller-live", 7001, Duration.ofMinutes(5));
+        writeRegistration("stale", "controller-stale", 7002, Duration.ofMinutes(-1));
+
+        channelManager = newManager();
+
+        // When
+        List<EquivalentAddressGroup> discovered = channelManager.discoverControllersFromStorage();
+
+        // Then
+        assertThat(discovered).hasSize(1);
+        InetSocketAddress addr = (InetSocketAddress) discovered.get(0).getAddresses().get(0);
+        assertThat(addr.getHostString()).isEqualTo("controller-live");
+    }
+
+    @Test
+    void shouldFallBackToLastKnownGoodWhenPerEntryReadThrows() throws Exception {
+        // Given — two live controllers registered, seeded into last-known-good via a first successful discovery
+        writeRegistration("c1", "controller-1", 6001, Duration.ofMinutes(5));
+        writeRegistration("c2", "controller-2", 6002, Duration.ofMinutes(5));
+
+        StorageInterface spy = Mockito.spy(storage);
+        storage = spy;
+        channelManager = newManager();
+        List<EquivalentAddressGroup> firstLoad = channelManager.discoverControllersFromStorage();
+        assertThat(firstLoad).hasSize(2);
+
+        // When — a subsequent per-entry read throws a transient IOException for c2
+        URI c2Uri = ControllerRegistry.entryUri("c2");
+        Mockito.doThrow(new IOException("transient")).when(spy).getInstanceResource(null, c2Uri);
+        List<EquivalentAddressGroup> secondLoad = channelManager.discoverControllersFromStorage();
+
+        // Then — the method returns the last known good list, not a shrunken pool
+        assertThat(secondLoad).hasSize(2);
+        assertThat(secondLoad).extracting(g -> (InetSocketAddress) g.getAddresses().get(0))
+            .extracting(InetSocketAddress::getHostString)
+            .containsExactlyInAnyOrder("controller-1", "controller-2");
+    }
+
+    @Test
+    void shouldDropMalformedEntryButIncludeValidOnes() throws Exception {
+        // Given — one valid controller and one malformed JSON file under the registry prefix
+        writeRegistration("valid", "controller-valid", 7001, Duration.ofMinutes(5));
+        storage.putInstanceResource(
+            null,
+            ControllerRegistry.entryUri("bad"),
+            new ByteArrayInputStream("not json".getBytes(StandardCharsets.UTF_8))
+        );
+
+        channelManager = newManager();
+
+        // When
+        List<EquivalentAddressGroup> discovered = channelManager.discoverControllersFromStorage();
+
+        // Then — the malformed entry is dropped, the valid one is kept
+        assertThat(discovered).hasSize(1);
+        InetSocketAddress addr = (InetSocketAddress) discovered.get(0).getAddresses().get(0);
+        assertThat(addr.getHostString()).isEqualTo("controller-valid");
+    }
+
+    @Test
+    void shouldReturnEmptyListWhenRegistryPrefixDoesNotExist() {
+        // Given — no registration written
+        channelManager = newManager();
+
+        // When
+        List<EquivalentAddressGroup> discovered = channelManager.discoverControllersFromStorage();
+
+        // Then
+        assertThat(discovered).isEmpty();
+    }
+
+    private void writeRegistration(String id, String host, int port, Duration remainingTtl) throws Exception {
+        Instant now = Instant.now();
+        ControllerRegistration registration = new ControllerRegistration(
+            id,
+            host,
+            port,
+            now,
+            now.plus(remainingTtl)
+        );
+        byte[] payload = MAPPER.writeValueAsBytes(registration);
+        storage.putInstanceResource(null, ControllerRegistry.entryUri(id), new ByteArrayInputStream(payload));
+    }
+
+    private GrpcChannelManager newManager() {
+        GrpcChannelConfiguration channelConfig = new GrpcChannelConfiguration(
+            1, Duration.ofMinutes(1), Duration.ofSeconds(3)
+        );
+        GrpcConfiguration grpcConfig = new GrpcConfiguration(false, Integer.MAX_VALUE);
+        WorkerControllersConfiguration config = new WorkerControllersConfiguration(
+            DiscoveryType.STORAGE,
+            null,
+            null,
+            new StorageConfig(Duration.ofMinutes(1)),
+            new LoadBalancing(LoadBalancing.Policy.ROUND_ROBIN),
+            new HealthCheck(false),
+            new WorkerControllersConfiguration.WaitForReady(true, Duration.ofSeconds(1))
+        );
+        GrpcChannelManager manager = new GrpcChannelManager(channelConfig, grpcConfig, config, () -> storage);
+        // Intentionally skip init() — we only exercise discoverControllersFromStorage() here.
+        return manager;
+    }
+}

--- a/worker-controller/src/test/java/io/kestra/controller/GrpcChannelManagerTest.java
+++ b/worker-controller/src/test/java/io/kestra/controller/GrpcChannelManagerTest.java
@@ -56,7 +56,7 @@ class GrpcChannelManagerTest {
         GrpcChannelConfiguration channelConfig = createDefaultChannelConfig();
 
         // When
-        channelManager = new GrpcChannelManager(channelConfig, createDefaultGrpcConfig(), config);
+        channelManager = new GrpcChannelManager(channelConfig, createDefaultGrpcConfig(), config, null);
         channelManager.init();
 
         // Then
@@ -78,7 +78,7 @@ class GrpcChannelManagerTest {
         GrpcChannelConfiguration channelConfig = createDefaultChannelConfig();
 
         // When
-        channelManager = new GrpcChannelManager(channelConfig, createDefaultGrpcConfig(), config);
+        channelManager = new GrpcChannelManager(channelConfig, createDefaultGrpcConfig(), config, null);
         channelManager.init();
 
         // Then
@@ -93,7 +93,7 @@ class GrpcChannelManagerTest {
         GrpcChannelConfiguration channelConfig = createDefaultChannelConfig();
 
         // When
-        channelManager = new GrpcChannelManager(channelConfig, createDefaultGrpcConfig(), config);
+        channelManager = new GrpcChannelManager(channelConfig, createDefaultGrpcConfig(), config, null);
         channelManager.init();
 
         // Then
@@ -108,7 +108,7 @@ class GrpcChannelManagerTest {
         GrpcChannelConfiguration channelConfig = createDefaultChannelConfig();
 
         // When
-        channelManager = new GrpcChannelManager(channelConfig, createDefaultGrpcConfig(), config);
+        channelManager = new GrpcChannelManager(channelConfig, createDefaultGrpcConfig(), config, null);
         channelManager.init();
 
         // Then
@@ -121,7 +121,7 @@ class GrpcChannelManagerTest {
         // Given
         WorkerControllersConfiguration config = createStaticConfig(List.of());
         GrpcChannelConfiguration channelConfig = createDefaultChannelConfig();
-        channelManager = new GrpcChannelManager(channelConfig, createDefaultGrpcConfig(), config);
+        channelManager = new GrpcChannelManager(channelConfig, createDefaultGrpcConfig(), config, null);
 
         // When/Then
         assertThatThrownBy(() -> channelManager.init())
@@ -136,12 +136,13 @@ class GrpcChannelManagerTest {
             DiscoveryType.STATIC,
             null,
             null,
+            null,
             new LoadBalancing(LoadBalancing.Policy.ROUND_ROBIN),
             new HealthCheck(true),
             new WorkerControllersConfiguration.WaitForReady(true, Duration.ofSeconds(1))
         );
         GrpcChannelConfiguration channelConfig = createDefaultChannelConfig();
-        channelManager = new GrpcChannelManager(channelConfig, createDefaultGrpcConfig(), config);
+        channelManager = new GrpcChannelManager(channelConfig, createDefaultGrpcConfig(), config, null);
 
         // When/Then
         assertThatThrownBy(() -> channelManager.init())
@@ -156,12 +157,13 @@ class GrpcChannelManagerTest {
             DiscoveryType.DNS,
             null,
             new DnsConfig("", 9096, DnsConfig.DnsRecordType.SRV, Duration.ofSeconds(30)),
+            null,
             new LoadBalancing(LoadBalancing.Policy.ROUND_ROBIN),
             new HealthCheck(true),
             new WorkerControllersConfiguration.WaitForReady(true, Duration.ofSeconds(1))
         );
         GrpcChannelConfiguration channelConfig = createDefaultChannelConfig();
-        channelManager = new GrpcChannelManager(channelConfig, createDefaultGrpcConfig(), config);
+        channelManager = new GrpcChannelManager(channelConfig, createDefaultGrpcConfig(), config, null);
 
         // When/Then
         assertThatThrownBy(() -> channelManager.init())
@@ -176,12 +178,13 @@ class GrpcChannelManagerTest {
             DiscoveryType.DNS,
             null,
             null,
+            null,
             new LoadBalancing(LoadBalancing.Policy.ROUND_ROBIN),
             new HealthCheck(true),
             new WorkerControllersConfiguration.WaitForReady(true, Duration.ofSeconds(1))
         );
         GrpcChannelConfiguration channelConfig = createDefaultChannelConfig();
-        channelManager = new GrpcChannelManager(channelConfig, createDefaultGrpcConfig(), config);
+        channelManager = new GrpcChannelManager(channelConfig, createDefaultGrpcConfig(), config, null);
 
         // When/Then
         assertThatThrownBy(() -> channelManager.init())
@@ -196,7 +199,7 @@ class GrpcChannelManagerTest {
             List.of(new Endpoint("localhost", 9096))
         );
         GrpcChannelConfiguration channelConfig = createDefaultChannelConfig();
-        channelManager = new GrpcChannelManager(channelConfig, createDefaultGrpcConfig(), config);
+        channelManager = new GrpcChannelManager(channelConfig, createDefaultGrpcConfig(), config, null);
         channelManager.init();
 
         // When
@@ -214,7 +217,7 @@ class GrpcChannelManagerTest {
             List.of(new Endpoint("localhost", 9096))
         );
         GrpcChannelConfiguration channelConfig = createDefaultChannelConfig();
-        channelManager = new GrpcChannelManager(channelConfig, createDefaultGrpcConfig(), config);
+        channelManager = new GrpcChannelManager(channelConfig, createDefaultGrpcConfig(), config, null);
 
         // When - call init multiple times
         channelManager.init();
@@ -233,7 +236,7 @@ class GrpcChannelManagerTest {
             List.of(new Endpoint("localhost", 9096))
         );
         GrpcChannelConfiguration channelConfig = createDefaultChannelConfig();
-        channelManager = new GrpcChannelManager(channelConfig, createDefaultGrpcConfig(), config);
+        channelManager = new GrpcChannelManager(channelConfig, createDefaultGrpcConfig(), config, null);
         channelManager.init();
         ManagedChannel channel = (ManagedChannel) channelManager.getDefaultChannel();
 
@@ -254,7 +257,7 @@ class GrpcChannelManagerTest {
             List.of(new Endpoint("localhost", 9096))
         );
         GrpcChannelConfiguration channelConfig = createDefaultChannelConfig();
-        channelManager = new GrpcChannelManager(channelConfig, createDefaultGrpcConfig(), config);
+        channelManager = new GrpcChannelManager(channelConfig, createDefaultGrpcConfig(), config, null);
         channelManager.init();
 
         // When - call close multiple times
@@ -273,7 +276,7 @@ class GrpcChannelManagerTest {
             List.of(new Endpoint("localhost", 9096))
         );
         GrpcChannelConfiguration channelConfig = createDefaultChannelConfig();
-        channelManager = new GrpcChannelManager(channelConfig, createDefaultGrpcConfig(), config);
+        channelManager = new GrpcChannelManager(channelConfig, createDefaultGrpcConfig(), config, null);
         // Note: init() is NOT called
 
         // When/Then - should not throw
@@ -287,7 +290,7 @@ class GrpcChannelManagerTest {
             List.of(new Endpoint("localhost", 9096))
         );
         GrpcChannelConfiguration channelConfig = createDefaultChannelConfig();
-        channelManager = new GrpcChannelManager(channelConfig, createDefaultGrpcConfig(), config);
+        channelManager = new GrpcChannelManager(channelConfig, createDefaultGrpcConfig(), config, null);
         channelManager.init();
 
         // When
@@ -311,7 +314,7 @@ class GrpcChannelManagerTest {
         GrpcChannelConfiguration channelConfig = createDefaultChannelConfig();
 
         // When
-        channelManager = new GrpcChannelManager(channelConfig, createDefaultGrpcConfig(), config);
+        channelManager = new GrpcChannelManager(channelConfig, createDefaultGrpcConfig(), config, null);
         channelManager.init();
 
         // Then - channel is created successfully (load balancing is internal to gRPC)
@@ -328,7 +331,7 @@ class GrpcChannelManagerTest {
         GrpcChannelConfiguration channelConfig = createDefaultChannelConfig();
 
         // When
-        channelManager = new GrpcChannelManager(channelConfig, createDefaultGrpcConfig(), config);
+        channelManager = new GrpcChannelManager(channelConfig, createDefaultGrpcConfig(), config, null);
         channelManager.init();
 
         // Then - channel is created successfully
@@ -345,7 +348,7 @@ class GrpcChannelManagerTest {
         GrpcChannelConfiguration channelConfig = createDefaultChannelConfig();
 
         // When
-        channelManager = new GrpcChannelManager(channelConfig, createDefaultGrpcConfig(), config);
+        channelManager = new GrpcChannelManager(channelConfig, createDefaultGrpcConfig(), config, null);
         channelManager.init();
 
         // Then - channel is created with health check config
@@ -362,7 +365,7 @@ class GrpcChannelManagerTest {
         GrpcChannelConfiguration channelConfig = createDefaultChannelConfig();
 
         // When
-        channelManager = new GrpcChannelManager(channelConfig, createDefaultGrpcConfig(), config);
+        channelManager = new GrpcChannelManager(channelConfig, createDefaultGrpcConfig(), config, null);
         channelManager.init();
 
         // Then - channel is created without health check
@@ -391,7 +394,7 @@ class GrpcChannelManagerTest {
         );
 
         // When
-        channelManager = new GrpcChannelManager(channelConfig, createDefaultGrpcConfig(), config);
+        channelManager = new GrpcChannelManager(channelConfig, createDefaultGrpcConfig(), config, null);
         channelManager.init();
 
         // Then - channel is created (configuration is applied internally)
@@ -418,14 +421,14 @@ class GrpcChannelManagerTest {
         GrpcChannelConfiguration channelConfig = createDefaultChannelConfig();
 
         // First manager registers the resolver
-        GrpcChannelManager manager1 = new GrpcChannelManager(channelConfig, createDefaultGrpcConfig(), config);
+        GrpcChannelManager manager1 = new GrpcChannelManager(channelConfig, createDefaultGrpcConfig(), config, null);
         manager1.init();
 
         // Close first manager - should unregister resolver
         manager1.close();
 
         // Second manager should be able to register a new resolver
-        GrpcChannelManager manager2 = new GrpcChannelManager(channelConfig, createDefaultGrpcConfig(), config);
+        GrpcChannelManager manager2 = new GrpcChannelManager(channelConfig, createDefaultGrpcConfig(), config, null);
         manager2.init();
 
         // Then - both should work without conflict
@@ -442,6 +445,7 @@ class GrpcChannelManagerTest {
             DiscoveryType.STATIC,
             new StaticConfig(endpoints),
             null,
+            null,
             new LoadBalancing(LoadBalancing.Policy.ROUND_ROBIN),
             new HealthCheck(true),
             new WorkerControllersConfiguration.WaitForReady(true, Duration.ofSeconds(1))
@@ -454,6 +458,7 @@ class GrpcChannelManagerTest {
         return new WorkerControllersConfiguration(
             DiscoveryType.STATIC,
             new StaticConfig(endpoints),
+            null,
             null,
             new LoadBalancing(policy),
             new HealthCheck(true),
@@ -468,6 +473,7 @@ class GrpcChannelManagerTest {
             DiscoveryType.STATIC,
             new StaticConfig(endpoints),
             null,
+            null,
             new LoadBalancing(LoadBalancing.Policy.ROUND_ROBIN),
             new HealthCheck(healthCheckEnabled),
             new WorkerControllersConfiguration.WaitForReady(true, Duration.ofSeconds(1))
@@ -479,6 +485,7 @@ class GrpcChannelManagerTest {
             DiscoveryType.DNS,
             null,
             new DnsConfig(hostname, 9096, DnsConfig.DnsRecordType.SRV, Duration.ofSeconds(30)),
+            null,
             new LoadBalancing(LoadBalancing.Policy.ROUND_ROBIN),
             new HealthCheck(true),
             new WorkerControllersConfiguration.WaitForReady(true, Duration.ofSeconds(1))
@@ -490,6 +497,7 @@ class GrpcChannelManagerTest {
             DiscoveryType.DNS,
             null,
             new DnsConfig(hostname, defaultPort, DnsConfig.DnsRecordType.A, Duration.ofSeconds(30)),
+            null,
             new LoadBalancing(LoadBalancing.Policy.ROUND_ROBIN),
             new HealthCheck(true),
             new WorkerControllersConfiguration.WaitForReady(true, Duration.ofSeconds(1))

--- a/worker-controller/src/test/java/io/kestra/controller/discovery/ControllerStorageRegistrarTest.java
+++ b/worker-controller/src/test/java/io/kestra/controller/discovery/ControllerStorageRegistrarTest.java
@@ -1,0 +1,242 @@
+package io.kestra.controller.discovery;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URI;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import io.kestra.controller.config.ControllerAdvertiseConfiguration;
+import io.kestra.controller.config.ControllerConfiguration;
+import io.kestra.core.serializers.JacksonMapper;
+import io.kestra.core.server.Service;
+import io.kestra.core.server.ServerConfig;
+import io.kestra.core.server.ServerInstance;
+import io.kestra.core.server.ServiceInstance;
+import io.kestra.core.server.ServiceType;
+import io.kestra.core.server.WorkerTaskRestartStrategy;
+import io.kestra.core.storages.StorageInterface;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+class ControllerStorageRegistrarTest {
+
+    private static final ObjectMapper MAPPER = JacksonMapper.ofJson();
+    private static final int GRPC_PORT = 50051;
+
+    private StorageInterface storage;
+
+    @BeforeEach
+    void setUp() {
+        storage = mock(StorageInterface.class);
+    }
+
+    @Test
+    void shouldRegisterOnFirstRunningLivenessUpdate() throws Exception {
+        // Given
+        ControllerStorageRegistrar registrar = newRegistrar("controller-1.example.com", Duration.ofMinutes(5));
+        ServiceInstance instance = controllerInstance();
+
+        // When
+        registrar.onLivenessUpdate(Instant.now(), instance, Service.ServiceState.RUNNING);
+
+        // Then
+        ControllerRegistration written = captureWritten();
+        assertThat(written.id()).isEqualTo(instance.uid());
+        assertThat(written.host()).isEqualTo("controller-1.example.com");
+        assertThat(written.port()).isEqualTo(GRPC_PORT);
+        assertThat(written.expiresAt()).isAfter(written.heartbeatAt());
+
+        registrar.close();
+    }
+
+    @Test
+    void shouldIgnoreNonControllerServices() throws Exception {
+        // Given
+        ControllerStorageRegistrar registrar = newRegistrar("host", Duration.ofMinutes(5));
+
+        // When — a worker instance in RUNNING state
+        ServiceInstance workerInstance = instanceFor(ServiceType.WORKER);
+        registrar.onLivenessUpdate(Instant.now(), workerInstance, Service.ServiceState.RUNNING);
+
+        // Then
+        verify(storage, never()).putInstanceResource(any(), any(), any(InputStream.class));
+
+        registrar.close();
+    }
+
+    @Test
+    void shouldIgnoreNonRunningStates() throws Exception {
+        // Given
+        ControllerStorageRegistrar registrar = newRegistrar("host", Duration.ofMinutes(5));
+        ServiceInstance instance = controllerInstance();
+
+        // When
+        registrar.onLivenessUpdate(Instant.now(), instance, Service.ServiceState.CREATED);
+        registrar.onLivenessUpdate(Instant.now(), instance, Service.ServiceState.TERMINATING);
+
+        // Then
+        verify(storage, never()).putInstanceResource(any(), any(), any(InputStream.class));
+
+        registrar.close();
+    }
+
+    @Test
+    void shouldThrottleWritesWithinHeartbeatInterval() throws Exception {
+        // Given — 1-minute advertise interval
+        ControllerStorageRegistrar registrar = newRegistrar("host", Duration.ofMinutes(1));
+        ServiceInstance instance = controllerInstance();
+
+        Instant t0 = Instant.parse("2026-04-15T10:00:00Z");
+
+        // When — first call writes, second call within interval does not
+        registrar.onLivenessUpdate(t0, instance, Service.ServiceState.RUNNING);
+        registrar.onLivenessUpdate(t0.plusSeconds(5), instance, Service.ServiceState.RUNNING);
+        registrar.onLivenessUpdate(t0.plusSeconds(30), instance, Service.ServiceState.RUNNING);
+
+        // Then
+        verify(storage, times(1)).putInstanceResource(isNull(), any(URI.class), any(InputStream.class));
+
+        registrar.close();
+    }
+
+    @Test
+    void shouldWriteAgainAfterHeartbeatInterval() throws Exception {
+        // Given
+        ControllerStorageRegistrar registrar = newRegistrar("host", Duration.ofMinutes(1));
+        ServiceInstance instance = controllerInstance();
+
+        Instant t0 = Instant.parse("2026-04-15T10:00:00Z");
+
+        // When — calls spaced by exactly the heartbeat interval
+        registrar.onLivenessUpdate(t0, instance, Service.ServiceState.RUNNING);
+        registrar.onLivenessUpdate(t0.plus(Duration.ofMinutes(1)), instance, Service.ServiceState.RUNNING);
+        registrar.onLivenessUpdate(t0.plus(Duration.ofMinutes(2)), instance, Service.ServiceState.RUNNING);
+
+        // Then
+        verify(storage, times(3)).putInstanceResource(isNull(), any(URI.class), any(InputStream.class));
+
+        registrar.close();
+    }
+
+    @Test
+    void shouldRetryOnNextTickAfterIoException() throws Exception {
+        // Given
+        ControllerStorageRegistrar registrar = newRegistrar("host", Duration.ofMinutes(1));
+        ServiceInstance instance = controllerInstance();
+
+        doThrow(new IOException("boom"))
+            .doReturn(URI.create("/controllers/registry/" + instance.uid() + ".json"))
+            .when(storage).putInstanceResource(isNull(), any(URI.class), any(InputStream.class));
+
+        Instant t0 = Instant.parse("2026-04-15T10:00:00Z");
+
+        // When — first call fails, second call (still within "interval") should retry
+        // because lastWrittenAt was not advanced on failure.
+        registrar.onLivenessUpdate(t0, instance, Service.ServiceState.RUNNING);
+        registrar.onLivenessUpdate(t0.plusSeconds(1), instance, Service.ServiceState.RUNNING);
+
+        // Then
+        verify(storage, times(2)).putInstanceResource(isNull(), any(URI.class), any(InputStream.class));
+
+        registrar.close();
+    }
+
+    @Test
+    void shouldDeleteEntryOnClose() throws Exception {
+        // Given
+        ControllerStorageRegistrar registrar = newRegistrar("host", Duration.ofMinutes(5));
+        ServiceInstance instance = controllerInstance();
+        registrar.onLivenessUpdate(Instant.now(), instance, Service.ServiceState.RUNNING);
+
+        // When
+        registrar.close();
+
+        // Then
+        verify(storage, times(1)).deleteInstanceResource(isNull(), any(URI.class));
+    }
+
+    @Test
+    void shouldSkipDeleteWhenNeverRegistered() throws Exception {
+        // Given — no RUNNING update ever fired
+        ControllerStorageRegistrar registrar = newRegistrar("host", Duration.ofMinutes(5));
+
+        // When
+        registrar.close();
+
+        // Then
+        verify(storage, never()).deleteInstanceResource(any(), any());
+    }
+
+    private ControllerStorageRegistrar newRegistrar(String host, Duration heartbeatInterval) {
+        ControllerAdvertiseConfiguration advertise = new ControllerAdvertiseConfiguration(
+            true,
+            host,
+            heartbeatInterval
+        );
+        ControllerConfiguration controllerConfig = new ControllerConfiguration(
+            GRPC_PORT,
+            Duration.ZERO,
+            Duration.ZERO
+        );
+        return new ControllerStorageRegistrar(() -> storage, advertise, controllerConfig);
+    }
+
+    private ControllerRegistration captureWritten() throws IOException {
+        ArgumentCaptor<InputStream> payloadCaptor = ArgumentCaptor.forClass(InputStream.class);
+        verify(storage).putInstanceResource(isNull(), any(URI.class), payloadCaptor.capture());
+        return MAPPER.readValue(payloadCaptor.getValue(), ControllerRegistration.class);
+    }
+
+    private ServiceInstance controllerInstance() {
+        return instanceFor(ServiceType.CONTROLLER);
+    }
+
+    private ServiceInstance instanceFor(ServiceType type) {
+        ServerConfig config = new ServerConfig(
+            Duration.ZERO,
+            WorkerTaskRestartStrategy.AFTER_TERMINATION_GRACE_PERIOD,
+            new ServerConfig.Liveness(
+                true,
+                Duration.ZERO,
+                Duration.ofSeconds(10),
+                Duration.ofSeconds(5),
+                Duration.ofSeconds(5)
+            )
+        );
+        return new ServiceInstance(
+            UUID.randomUUID().toString(),
+            type,
+            Service.ServiceState.RUNNING,
+            new ServerInstance(
+                ServerInstance.Type.SERVER,
+                "N/A",
+                "localhost",
+                Map.of(),
+                Set.of()
+            ),
+            Instant.now(),
+            Instant.now(),
+            List.of(),
+            config,
+            Map.of(),
+            Set.of()
+        );
+    }
+}

--- a/worker-controller/src/test/java/io/kestra/controller/resolver/StorageNameResolverTest.java
+++ b/worker-controller/src/test/java/io/kestra/controller/resolver/StorageNameResolverTest.java
@@ -1,0 +1,153 @@
+package io.kestra.controller.resolver;
+
+import java.net.InetSocketAddress;
+import java.net.URI;
+import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.Test;
+
+import io.kestra.controller.grpc.resolver.StorageNameResolver;
+import io.kestra.controller.grpc.resolver.StorageNameResolverProvider;
+
+import io.grpc.EquivalentAddressGroup;
+import io.grpc.NameResolver;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class StorageNameResolverTest {
+
+    @Test
+    void shouldPublishInitialAddressesOnStart() {
+        // Given
+        List<EquivalentAddressGroup> addresses = List.of(
+            new EquivalentAddressGroup(new InetSocketAddress("controller-1", 9096)),
+            new EquivalentAddressGroup(new InetSocketAddress("controller-2", 9097))
+        );
+        StorageNameResolver resolver = new StorageNameResolver(() -> addresses, Duration.ofMinutes(1));
+        AtomicReference<NameResolver.ResolutionResult> result = new AtomicReference<>();
+
+        // When
+        resolver.start(new TestListener(result, new AtomicInteger()));
+
+        // Then
+        assertThat(result.get()).isNotNull();
+        assertThat(result.get().getAddresses()).hasSize(2);
+
+        resolver.shutdown();
+    }
+
+    @Test
+    void shouldNotNotifyListenerWhenAddressesAreUnchanged() {
+        // Given
+        List<EquivalentAddressGroup> addresses = List.of(
+            new EquivalentAddressGroup(new InetSocketAddress("controller-1", 9096))
+        );
+        StorageNameResolver resolver = new StorageNameResolver(() -> addresses, Duration.ofMinutes(1));
+        AtomicInteger callCount = new AtomicInteger();
+        resolver.start(new TestListener(new AtomicReference<>(), callCount));
+
+        // When
+        resolver.refresh();
+        resolver.refresh();
+
+        // Then — initial start + unchanged refreshes should produce a single notification
+        assertThat(callCount.get()).isEqualTo(1);
+
+        resolver.shutdown();
+    }
+
+    @Test
+    void shouldNotifyListenerWhenAddressesChange() {
+        // Given
+        AtomicReference<List<EquivalentAddressGroup>> supplied = new AtomicReference<>(List.of(
+            new EquivalentAddressGroup(new InetSocketAddress("controller-1", 9096))
+        ));
+        StorageNameResolver resolver = new StorageNameResolver(supplied::get, Duration.ofMinutes(1));
+        AtomicInteger callCount = new AtomicInteger();
+        AtomicReference<NameResolver.ResolutionResult> result = new AtomicReference<>();
+        resolver.start(new TestListener(result, callCount));
+
+        // When
+        supplied.set(List.of(
+            new EquivalentAddressGroup(new InetSocketAddress("controller-1", 9096)),
+            new EquivalentAddressGroup(new InetSocketAddress("controller-2", 9097))
+        ));
+        resolver.refresh();
+
+        // Then
+        assertThat(callCount.get()).isEqualTo(2);
+        assertThat(result.get().getAddresses()).hasSize(2);
+
+        resolver.shutdown();
+    }
+
+    @Test
+    void shouldPollSupplierOnSchedule() {
+        // Given — sub-second refresh interval so the scheduled tick fires during the test
+        AtomicInteger supplierCalls = new AtomicInteger();
+        StorageNameResolver resolver = new StorageNameResolver(() -> {
+            supplierCalls.incrementAndGet();
+            return List.of(new EquivalentAddressGroup(new InetSocketAddress("controller", 9096)));
+        }, Duration.ofMillis(100));
+        resolver.start(new TestListener(new AtomicReference<>(), new AtomicInteger()));
+
+        // When — wait for the scheduler to tick at least a couple of times
+        Awaitility.await()
+            .atMost(Duration.ofSeconds(2))
+            .pollInterval(50, TimeUnit.MILLISECONDS)
+            .until(() -> supplierCalls.get() >= 3);
+
+        resolver.shutdown();
+
+        // Then
+        assertThat(supplierCalls.get()).isGreaterThanOrEqualTo(3);
+    }
+
+    @Test
+    void providerShouldCreateResolverForStorageScheme() {
+        // Given
+        StorageNameResolverProvider provider = new StorageNameResolverProvider(List::of, Duration.ofMinutes(1));
+
+        // When
+        NameResolver resolver = provider.newNameResolver(URI.create("storage:///controllers"), null);
+
+        // Then
+        assertThat(resolver).isInstanceOf(StorageNameResolver.class);
+        assertThat(provider.getDefaultScheme()).isEqualTo("storage");
+    }
+
+    @Test
+    void providerShouldReturnNullForWrongScheme() {
+        // Given
+        StorageNameResolverProvider provider = new StorageNameResolverProvider(List::of, Duration.ofMinutes(1));
+
+        // When / Then
+        assertThat(provider.newNameResolver(URI.create("dns:///localhost"), null)).isNull();
+    }
+
+    private static class TestListener extends NameResolver.Listener2 {
+        private final AtomicReference<NameResolver.ResolutionResult> result;
+        private final AtomicInteger callCount;
+
+        TestListener(AtomicReference<NameResolver.ResolutionResult> result, AtomicInteger callCount) {
+            this.result = result;
+            this.callCount = callCount;
+        }
+
+        @Override
+        public void onResult(NameResolver.ResolutionResult resolutionResult) {
+            result.set(resolutionResult);
+            callCount.incrementAndGet();
+        }
+
+        @Override
+        public void onError(io.grpc.Status error) {
+            // Not used in tests
+        }
+    }
+}


### PR DESCRIPTION
Adds STORAGE to kestra.worker.controllers.type so workers can discover controllers dynamically via the internal storage registry instead of a hand-maintained static list or external DNS.

Controllers opt in with kestra.controller.advertise.enabled=true, then self-publish their gRPC endpoint to controllers/registry/<id>.json with a TTL equal to heartbeatInterval * 3 (tolerates one missed heartbeat). Workers poll the registry on a refresh interval, filter out expired entries, and fall back to the last known-good list on transient storage errors to avoid flapping the load-balancing pool.