### PR TITLE
fix(ui): execution outputs tab task list scroll clipping

### DIFF
--- a/ui/src/components/Tabs.vue
+++ b/ui/src/components/Tabs.vue
@@ -199,6 +199,7 @@ section.container.mt-4:has(> section.empty) {
     margin: 0 !important;
     padding: 0;
     flex-grow: 1;
+    min-height: 0;
 }
 
 .no-overflow {

--- a/ui/src/components/executions/outputs/Wrapper.vue
+++ b/ui/src/components/executions/outputs/Wrapper.vue
@@ -444,7 +444,7 @@
 .outputs {
     display: flex;
     width: 100%;
-    height: 100vh;
+    height: 100%;
     overflow: hidden;
 }
 
@@ -464,7 +464,7 @@
 }
 
 :deep(.el-cascader-menu__list) {
-    min-height: 100vh;
+    min-height: 100%;
 }
 
 :deep(.el-cascader-panel) {
@@ -532,7 +532,7 @@
             & .task-label {
                 width: 100%;
                 max-width: 100%;
-                
+
                 & .task-iteration-value {
                     display: inline-block;
                     width: 80px;
@@ -556,7 +556,7 @@
     }
 }
 .content-container {
-    height: calc(100vh - 0px);
+    height: 100%;
     overflow-y: scroll;
     overflow-x: hidden;
     scrollbar-gutter: stable;


### PR DESCRIPTION
### ✨ Description

Fixed execution outputs tab task list being clipped by replacing `100vh` with `100%` in `Wrapper.vue` and adding `min-height: 0` to `.maximized` in `Tabs.vue`.

The cascader panel used viewport-relative heights which exceeded the available tab space, causing `overflow: hidden` to cut off tasks beyond the visible area.

### 🔗 Related Issue

N/A

### 📸 Images

**Before:**
<img width="1495" height="916" alt="image" src="https://github.com/user-attachments/assets/20aa6127-3d04-4cd0-8c08-3bf07d734f83" />

**After:**
<img width="1493" height="917" alt="image" src="https://github.com/user-attachments/assets/e76e9ddd-85f7-4005-9b59-894d1bb27e8c" />

### 🎨 Frontend Checklist

- [x] Code builds without errors (`npm run build`)
- [x] All existing E2E tests pass (`npm run test:e2e`)
- [x] Screenshots or video recordings attached showing the `UI` changes

### 📝 Additional Notes

Opening directly against `1.2` release branch as `develop` is now dedicated to version `2.0`.
Please backport to all affected `1.x` releases, thanks!