### PR TITLE
fix: add PARENT_ID query filter field to openapi spec

### DIFF
--- a/openapi.yml
+++ b/openapi.yml
@@ -7695,6 +7695,7 @@ components:
       - STATUS
       - EMAIL
       - TIME_RANGE
+      - PARENT_ID
       - TRIGGER_EXECUTION_ID
       - TRIGGER_ID
       - TRIGGER_STATE


### PR DESCRIPTION
### ✨ Description

The openapi spec on development is currently out of date and does not include PARENT_ID query filter.

