### PR TITLE
Chore/loop improvements

### DIFF
--- a/core/src/test/java/io/kestra/core/runners/AbstractRunnerTest.java
+++ b/core/src/test/java/io/kestra/core/runners/AbstractRunnerTest.java
@@ -703,6 +703,12 @@ public abstract class AbstractRunnerTest {
     }
 
     @Test
+    @ExecuteFlow("flows/valids/loop-outputs-failed-render.yaml")
+    protected void loopOutputsFailedRender(Execution execution) throws Exception {
+        loopCaseTest.loopOutputsFailedRender(execution);
+    }
+
+    @Test
     @LoadFlows(value = { "flows/valids/minimal.yaml" }, tenantId = TENANT_1)
     void shouldScheduleOnDate() throws Exception {
         scheduleDateCaseTest.shouldScheduleOnDate(TENANT_1);

--- a/core/src/test/java/io/kestra/plugin/core/flow/LoopCaseTest.java
+++ b/core/src/test/java/io/kestra/plugin/core/flow/LoopCaseTest.java
@@ -398,6 +398,23 @@ public class LoopCaseTest {
         }
     }
 
+    public void loopOutputsFailedRender(Execution execution) {
+        // Then — the loop output expression references a non-existent task, causing render to fail.
+        // The TerminatedLoopExecution carries FAILED state and, with transmitFailed=true (default),
+        // immediately terminates the loop and propagates the failure to the parent execution.
+        assertThat(execution.getState().getCurrent()).isEqualTo(State.Type.FAILED);
+        assertThat(execution.getTaskRunList()).hasSize(1);
+        assertThat(execution.getTaskRunList().getFirst().getState().getCurrent()).isEqualTo(State.Type.FAILED);
+
+        // Only one sub-execution ran before the loop was terminated (transmitFailed=true by default).
+        // The sub-execution itself is FAILED (output rendering failed), but its inner tasks succeeded.
+        List<Execution> subExecutions = loopSubExecutions(execution);
+        assertThat(subExecutions).hasSize(1);
+        Execution subExecution = subExecutions.getFirst();
+        assertThat(subExecution.getState().getCurrent()).isEqualTo(State.Type.FAILED);
+        assertThat(subExecution.getTaskRunList()).allMatch(tr -> tr.getState().getCurrent() == State.Type.SUCCESS);
+    }
+
     public void loopOutputsAuto(Execution execution) throws InternalException, IOException {
         assertThat(execution.getState().getCurrent()).isEqualTo(State.Type.SUCCESS);
         assertThat(execution.getTaskRunList()).hasSize(3);

--- a/core/src/test/resources/flows/valids/loop-outputs-failed-render.yaml
+++ b/core/src/test/resources/flows/valids/loop-outputs-failed-render.yaml
@@ -1,0 +1,15 @@
+id: loop-outputs-failed-render
+namespace: io.kestra.tests
+
+tasks:
+  - id: loop
+    type: io.kestra.plugin.core.flow.Loop
+    values: ["value 1", "value 2", "value 3"]
+    outputs:
+      - id: value
+        type: STRING
+        value: "{{outputs.nonExistentTask.value}}"
+    tasks:
+      - id: doWork
+        type: io.kestra.plugin.core.debug.Return
+        format: "some output"

--- a/executor/src/main/java/io/kestra/executor/DefaultExecutor.java
+++ b/executor/src/main/java/io/kestra/executor/DefaultExecutor.java
@@ -784,11 +784,20 @@ public class DefaultExecutor extends AbstractService implements Executor {
                                 e
                             );
                             runContext.logger().error("Failed to render output values: {}", e.getMessage(), e);
-                            // FIXME should we fail the execution?
+                            execution = execution.withState(State.Type.FAILED);
+                            // Persist the FAILED state so the sub-execution is correctly reflected in the DB.
+                            try {
+                                executionStateStore.lock(execution.getId(), exec ->
+                                    new ExecutorContext(exec).withExecution(exec.withState(State.Type.FAILED), "failedOutputRender")
+                                );
+                            } catch (Exception persistException) {
+                                log.error("Failed to persist FAILED state for loop sub-execution {}", execution.getId(), persistException);
+                            }
+                            executor = executor.withExecution(execution, "failedOutputRender");
                         }
 
                     }
-                    var terminatedLoopExecution = new TerminatedLoopExecution(executor.getExecution().getLoopRun(), executor.getExecution().getId(), executor.getExecution().getState().getCurrent(), outputs);
+                    var terminatedLoopExecution = new TerminatedLoopExecution(execution.getLoopRun(), execution.getId(), execution.getState().getCurrent(), outputs);
                     terminatedLoopExecutionQueue.emit(terminatedLoopExecution);
                 }
 
@@ -868,6 +877,9 @@ public class DefaultExecutor extends AbstractService implements Executor {
                         Execution failed = execution.failedExecutionFromExecutor(e).execution().withState(State.Type.FAILED);
                         ExecutionEvent event = new ExecutionEvent(failed, ExecutionEventType.TERMINATED);
                         this.executionEventQueue.emit(event);
+
+                        // update all execution followers
+                        this.followExecutionEventQueue.emitAsync(new FollowExecutionEvent(failed, ExecutionEventType.UPDATED));
                     } catch (QueueException ex) {
                         log.error("Unable to emit the execution {}", execution.getId(), ex);
                     }

--- a/executor/src/main/java/io/kestra/executor/ExecutorService.java
+++ b/executor/src/main/java/io/kestra/executor/ExecutorService.java
@@ -681,7 +681,6 @@ public class ExecutorService {
                             }
                         }
 
-                        // TODO we may need to also start the attempts...
                         executor.withExecution(executor.getExecution()
                             .withTaskRun(taskRun.withState(State.Type.RUNNING)), "handleLoop");
                     }

--- a/executor/src/main/java/io/kestra/executor/handler/TerminatedLoopExecutionMessageHandler.java
+++ b/executor/src/main/java/io/kestra/executor/handler/TerminatedLoopExecutionMessageHandler.java
@@ -3,13 +3,12 @@ package io.kestra.executor.handler;
 import io.kestra.core.exceptions.FlowNotFoundException;
 import io.kestra.core.exceptions.InternalException;
 import java.io.IOException;
-import io.kestra.core.models.executions.Execution;
-import io.kestra.core.models.executions.TaskRun;
-import io.kestra.core.models.executions.TaskRunAttempt;
-import io.kestra.core.models.executions.TerminatedLoopExecution;
+
+import io.kestra.core.models.executions.*;
 import io.kestra.core.models.flows.FlowWithSource;
 import io.kestra.core.models.flows.State;
 import io.kestra.core.models.tasks.Task;
+import io.kestra.core.queues.BroadcastQueueInterface;
 import io.kestra.core.queues.DispatchQueueInterface;
 import io.kestra.core.queues.QueueException;
 import io.kestra.core.runners.*;
@@ -45,6 +44,9 @@ public class TerminatedLoopExecutionMessageHandler implements ExecutorMessageHan
 
     @Inject
     private DispatchQueueInterface<Execution> executionQueue;
+
+    @Inject
+    private BroadcastQueueInterface<FollowExecutionEvent> followExecutionEventQueue;
 
     @Override
     public Optional<ExecutorContext> handle(TerminatedLoopExecution message) {
@@ -103,8 +105,8 @@ public class TerminatedLoopExecutionMessageHandler implements ExecutorMessageHan
                                 executionQueue.emit(loopExecution);
                             }
                         }
-                        // we don't update the execution itself as the loop is still running
-                        // TODO we may need to send a follow execution message to update the UI
+                        // we don't update the execution itself as the loop is still running, but we send a follow execution event to update the UI
+                        followExecutionEventQueue.emitAsync(new FollowExecutionEvent(execution, ExecutionEventType.UPDATED));
                         return null;
                     } else {
                         // All iterations have been started — save the decremented counts and either
@@ -115,7 +117,8 @@ public class TerminatedLoopExecutionMessageHandler implements ExecutorMessageHan
                             return terminateLoop(parentTaskRun, loop, executor, State.Type.SUCCESS);
                         } else {
                             // Some iterations are still running — wait for them.
-                            // TODO we may need to send a follow execution message to update the UI
+                            // we don't update the execution itself as the loop is still running, but we send a follow execution event to update the UI
+                            followExecutionEventQueue.emitAsync(new FollowExecutionEvent(execution, ExecutionEventType.UPDATED));
                             return null;
                         }
                     }


### PR DESCRIPTION
- Fail a loop sub-execution when it cannot render its outputs
- Send follow execution events each time loop outputs are updated to allow updating the UI