### PR TITLE
fix(worker): stop heartbeat after terminal state to fix flaky liveness coordinator test

### DIFF
--- a/core/src/main/java/io/kestra/core/server/LocalServiceState.java
+++ b/core/src/main/java/io/kestra/core/server/LocalServiceState.java
@@ -19,10 +19,14 @@ public record LocalServiceState(Service service,
     }
 
     /**
-     * Convenient method for constructing a new {@link LocalServiceState} from a given instance.
+     * Constructs a new {@link LocalServiceState} from a given instance, preserving the same
+     * {@link AtomicBoolean} reference for {@code isStateUpdatable}. This means that any caller
+     * holding a reference to the old {@code LocalServiceState} can still mutate the shared flag
+     * (e.g., {@code holder.isStateUpdatable().set(false)}) and the change will be visible on the
+     * newly registered instance.
      *
      * @param instance The new instance.
-     * @return a new {@link LocalServiceState}
+     * @return a new {@link LocalServiceState} sharing the same {@code isStateUpdatable} flag.
      */
     public LocalServiceState with(final ServiceInstance instance) {
         return new LocalServiceState(service, instance, isStateUpdatable);

--- a/core/src/main/java/io/kestra/core/server/ServiceLivenessManager.java
+++ b/core/src/main/java/io/kestra/core/server/ServiceLivenessManager.java
@@ -80,6 +80,13 @@ public class ServiceLivenessManager extends AbstractServiceLivenessTask {
             return; // invalid service event.
         }
 
+        // CREATED events always register a new service instance and must bypass the isStateUpdatable
+        // check below, because a new service of the same type may start after a previous one terminated.
+        if (newState == Service.ServiceState.CREATED) {
+            onCreateState(event);
+            return;
+        }
+
         // Check whether the state for this service is updatable.
         // A service (e.g., Worker) is not updatable when its state has already been transitioned to
         // a completed state (e.g., NOT_RUNNING) by an external service (e.g. Executor).
@@ -97,10 +104,14 @@ public class ServiceLivenessManager extends AbstractServiceLivenessTask {
         }
 
         switch (newState) {
-            case CREATED:
-                onCreateState(event);
-                break;
             case RUNNING, TERMINATING, TERMINATED_GRACEFULLY, TERMINATED_FORCED, MAINTENANCE:
+                // Disable further heartbeat updates before persisting the terminal state.
+                // This prevents updatedAt from being refreshed after the transition, allowing
+                // the liveness coordinator to reliably detect that the termination grace period
+                // has elapsed.
+                if (newState.hasCompletedTermination() && holder != null) {
+                    holder.isStateUpdatable().set(false);
+                }
                 updateServiceInstanceState(Instant.now(), event.getService(), newState, NOOP);
                 break;
             default:

--- a/core/src/test/java/io/kestra/core/server/ServiceLivenessManagerTest.java
+++ b/core/src/test/java/io/kestra/core/server/ServiceLivenessManagerTest.java
@@ -161,6 +161,59 @@ public class ServiceLivenessManagerTest {
             .execute(Mockito.any(), Mockito.any(), Mockito.any(), Mockito.eq(true));
     }
 
+    @Test
+    void shouldRegisterNewInstanceAfterPreviousOneTerminated() {
+        // Given - a service that completed a terminal state transition (isStateUpdatable = false)
+        Service terminating = newServiceForState(Service.ServiceState.TERMINATING);
+        serviceLivenessManager.updateServiceInstance(terminating, serviceInstanceFor(terminating));
+
+        Service terminated = newServiceForState(Service.ServiceState.TERMINATED_FORCED);
+        ServiceInstance terminatedInstance = serviceInstanceFor(terminated);
+        when(serviceLivenessUpdater.update(Mockito.any(ServiceInstance.class), Mockito.any(Service.ServiceState.class)))
+            .thenReturn(new ServiceStateTransition.Response(SUCCEEDED, terminatedInstance));
+        serviceLivenessManager.onServiceStateChangeEvent(new ServiceStateChangeEvent(terminated));
+        // At this point isStateUpdatable is false for ServiceType.WORKER
+
+        // When - a CREATED event arrives for a new service of the same type (new worker restarts)
+        Mockito.clearInvocations(serviceLivenessUpdater);
+        Service newWorker = newServiceForState(Service.ServiceState.CREATED);
+        serviceLivenessManager.onServiceStateChangeEvent(new ServiceStateChangeEvent(newWorker));
+
+        // Then - the new CREATED instance is persisted to the DB
+        Mockito.verify(serviceLivenessUpdater, Mockito.atLeastOnce()).update(workerInstanceCaptor.capture());
+        Assertions.assertEquals(Service.ServiceState.CREATED, workerInstanceCaptor.getValue().state());
+
+        // And - the heartbeat resumes for the new instance (isStateUpdatable reset to true)
+        Mockito.clearInvocations(serviceLivenessUpdater);
+        ServiceInstance newInstance = serviceLivenessManager.allServiceInstances().getFirst();
+        when(serviceLivenessUpdater.update(Mockito.any(ServiceInstance.class), Mockito.any(Service.ServiceState.class)))
+            .thenReturn(new ServiceStateTransition.Response(SUCCEEDED, newInstance));
+        serviceLivenessManager.onSchedule(Instant.now());
+        Mockito.verify(serviceLivenessUpdater, Mockito.atLeastOnce())
+            .update(Mockito.any(ServiceInstance.class), Mockito.any(Service.ServiceState.class));
+    }
+
+    @Test
+    void shouldDisableHeartbeatAfterTerminalStateTransition() {
+        // Given - a service in TERMINATING state
+        Service terminating = newServiceForState(Service.ServiceState.TERMINATING);
+        serviceLivenessManager.updateServiceInstance(terminating, serviceInstanceFor(terminating));
+
+        Service terminated = newServiceForState(Service.ServiceState.TERMINATED_FORCED);
+        ServiceInstance terminatedInstance = serviceInstanceFor(terminated);
+        when(serviceLivenessUpdater.update(Mockito.any(ServiceInstance.class), Mockito.any(Service.ServiceState.class)))
+            .thenReturn(new ServiceStateTransition.Response(SUCCEEDED, terminatedInstance));
+
+        // When - the service transitions to TERMINATED_FORCED
+        serviceLivenessManager.onServiceStateChangeEvent(new ServiceStateChangeEvent(terminated));
+
+        // Then - the heartbeat should no longer fire for this service
+        Mockito.clearInvocations(serviceLivenessUpdater);
+        serviceLivenessManager.onSchedule(Instant.now());
+        Mockito.verify(serviceLivenessUpdater, Mockito.never())
+            .update(Mockito.any(ServiceInstance.class), Mockito.any(Service.ServiceState.class));
+    }
+
     public static Service newServiceForState(final Service.ServiceState state) {
         return new Service() {
 


### PR DESCRIPTION
## Summary

- **Root cause**: `ServiceLivenessManager` (heartbeat) continuously refreshed `updatedAt` in the database even after a worker transitioned to a terminal state (`TERMINATED_FORCED`, `TERMINATED_GRACEFULLY`). Because `isTerminationGracePeriodElapsed` uses a strict `isBefore` comparison, this prevented the `ServiceLivenessCoordinator` from ever detecting the elapsed grace period — causing `AbstractServiceLivenessCoordinatorTest.shouldResubmitTaskWhenWorkerIsStopped` to be flaky.
- Set `isStateUpdatable = false` **before** persisting terminal state transitions in `ServiceLivenessManager`, so the heartbeat scheduler immediately stops refreshing `updatedAt` once a worker has terminated.
- Extract `CREATED` event handling to bypass the `isStateUpdatable` guard — a new worker of the same `ServiceType` can start after a previous one terminated, and the stale `false` flag must not block its registration. (`ServiceRegistry` is keyed by `ServiceType`, not service ID.)
- Document the shared-`AtomicBoolean` invariant on `LocalServiceState.with()`, which the fix relies on: callers holding a pre-update `holder` still affect the newly registered instance because the same `AtomicBoolean` instance is threaded through `with()`.