### PR TITLE
fix(worker): prevent duplicate SubflowExecutionEnd delivery across executor JVMs

### DIFF
--- a/jdbc/src/main/java/io/kestra/jdbc/runner/JdbcExecutor.java
+++ b/jdbc/src/main/java/io/kestra/jdbc/runner/JdbcExecutor.java
@@ -340,7 +340,10 @@ public class JdbcExecutor implements ExecutorInterface {
         );
         this.receiveCancellations.addFirst(this.killQueue.receive(Executor.class, this::killQueue));
         this.receiveCancellations.addFirst(this.subflowExecutionResultQueue.receive(Executor.class, this::subflowExecutionResultQueue));
-        this.receiveCancellations.addFirst(this.subflowExecutionEndQueue.receive(Executor.class, this::subflowExecutionEndQueue));
+        this.receiveCancellations.addFirst(
+            ((JdbcQueue<SubflowExecutionEnd>) this.subflowExecutionEndQueue)
+                .receiveTransaction(null, Executor.class, (dslContext, eithers) -> eithers.forEach(this::subflowExecutionEndQueue))
+        );
         this.receiveCancellations.addFirst(this.multipleConditionEventQueue.receive(Executor.class, this::multipleConditionEventQueue));
         this.receiveCancellations.addFirst(maintenanceService.listen(new MaintenanceService.MaintenanceListener() {
             @Override


### PR DESCRIPTION
Switch the subflowExecutionEndQueue subscription from receive() (inTransaction=false) to receiveTransaction() (inTransaction=true) so the consumer_<queueType> flag is flipped atomically with consumption. This closes the window where a second executor JVM could re-fetch the same row after the first JVM's FOR UPDATE SKIP LOCKED lock released but before the flag was set, causing ForEachItem iterations to be over-counted.

Add regression test that simulates at-least-once duplicate delivery and asserts iterations.SUCCESS equals numberOfBatches with no over-counting.


## Reproducer

Start standalone Kestra server with one additional Executor

**Flows**

```yaml
# Child
id: child_flow_logger
namespace: company.team
inputs:
  - id: item_to_log
    type: STRING
tasks:
  - id: hello
    type: io.kestra.plugin.core.log.Log
    message: "Item {{ inputs.item_to_log }}"
outputs:
  - id: final
    type: STRING
    value: "{{ inputs.item_to_log }}"

# Parent
id: foreach_item_example
namespace: company.team

tasks:
  - id: create_list_file
    type: io.kestra.plugin.scripts.shell.Script
    outputFiles:
      - items.jsonl
    script: |
      cat > items.jsonl << 'EOF'
      {"id":1,"name":"Apple"}
      {"id":2,"name":"Banana"}
      {"id":3,"name":"Cherry"}
      {"id":4,"name":"Watermelon"}
      {"id":5,"name":"Grape"}
      {"id":6,"name":"Pear"}
      EOF

  - id: for_each_item
    type: io.kestra.plugin.core.flow.ForEachItem
    items: "{{ outputs.create_list_file.outputFiles['items.jsonl'] }}"
    wait: true
    transmitFailed: true
    namespace: company.team
    flowId: child_flow_logger
    inputs:
      item_to_log: "{{ json(read(taskrun.items)) }}"

  - id: return_for_each_child
    type: io.kestra.plugin.core.log.Log
    message: "{{ read(outputs.for_each_item_merge.subflowOutputs) }}"

outputs:
  - id: final
    type: STRING
    value: "{{ outputs.for_each_item_merge.subflowOutputs }}"
````

**Before Fix**

Missing output /= All executions =6 / success = 16

<img width="2147" height="660" alt="kestra-before-fix" src="https://github.com/user-attachments/assets/39c79061-5cb3-4013-9aba-c5792fba8496" />


**After Fix**

No missing output / ForEachItem = All executions/success = 6

<img width="2147" height="660" alt="kestra-after-fix" src="https://github.com/user-attachments/assets/c05ad97a-fd89-4bf0-b3ce-ce83cfa90e7a" />


