### PR TITLE
fix(scripts): log beforeCommands output at DEBUG level

### DIFF
--- a/core/src/main/java/io/kestra/core/models/tasks/runners/DefaultLogConsumer.java
+++ b/core/src/main/java/io/kestra/core/models/tasks/runners/DefaultLogConsumer.java
@@ -8,7 +8,11 @@ import io.kestra.core.runners.RunContext;
  * Default implementation of an @{link {@link AbstractLogConsumer}}
  */
 public class DefaultLogConsumer extends AbstractLogConsumer {
+    private static final String LOG_DEBUG_MARKER = "##kestra:log:debug##";
+    private static final String LOG_INFO_MARKER = "##kestra:log:info##";
+
     private final RunContext runContext;
+    private volatile boolean debugMode = false;
 
     public DefaultLogConsumer(RunContext runContext) {
         this.runContext = runContext;
@@ -20,7 +24,15 @@ public class DefaultLogConsumer extends AbstractLogConsumer {
     }
 
     public void accept(String line, Boolean isStdErr, Instant instant) {
-        outputs.putAll(PluginUtilsService.parseOut(line, runContext.logger(), runContext, isStdErr, instant));
+        if (LOG_DEBUG_MARKER.equals(line)) {
+            debugMode = true;
+            return;
+        }
+        if (LOG_INFO_MARKER.equals(line)) {
+            debugMode = false;
+            return;
+        }
+        outputs.putAll(PluginUtilsService.parseOut(line, runContext.logger(), runContext, isStdErr, instant, debugMode));
 
         if (isStdErr) {
             this.stdErrCount.incrementAndGet();

--- a/core/src/main/java/io/kestra/core/models/tasks/runners/PluginUtilsService.java
+++ b/core/src/main/java/io/kestra/core/models/tasks/runners/PluginUtilsService.java
@@ -112,6 +112,10 @@ abstract public class PluginUtilsService {
     }
 
     public static Map<String, Object> parseOut(String line, Logger logger, RunContext runContext, boolean isStdErr, Instant customInstant) {
+        return parseOut(line, logger, runContext, isStdErr, customInstant, false);
+    }
+
+    public static Map<String, Object> parseOut(String line, Logger logger, RunContext runContext, boolean isStdErr, Instant customInstant, boolean debug) {
 
         TaskLogLineMatcher logLineMatcher = ((DefaultRunContext) runContext).services().taskLogLineMatcher();
 
@@ -123,6 +127,8 @@ abstract public class PluginUtilsService {
                 outputs.putAll(taskLogMatch.outputs());
             } else if (isStdErr) {
                 runContext.logger().error(line);
+            } else if (debug) {
+                runContext.logger().debug(line);
             } else {
                 runContext.logger().info(line);
             }

--- a/core/src/test/java/io/kestra/core/models/tasks/runners/DefaultLogConsumerTest.java
+++ b/core/src/test/java/io/kestra/core/models/tasks/runners/DefaultLogConsumerTest.java
@@ -1,0 +1,57 @@
+package io.kestra.core.models.tasks.runners;
+
+import org.junit.jupiter.api.Test;
+
+import io.kestra.core.context.TestRunContextFactory;
+import io.kestra.core.junit.annotations.KestraTest;
+import io.kestra.core.utils.IdUtils;
+
+import jakarta.inject.Inject;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@KestraTest
+class DefaultLogConsumerTest {
+    @Inject
+    private TestRunContextFactory runContextFactory;
+
+    @Test
+    void markerLinesAreSwallowedAndNotCounted() {
+        var runContext = runContextFactory.of("id", "namespace", IdUtils.create());
+        var consumer = new DefaultLogConsumer(runContext);
+
+        consumer.accept("##kestra:log:debug##", false);
+        assertThat(consumer.getStdOutCount()).isZero();
+        assertThat(consumer.getStdErrCount()).isZero();
+
+        consumer.accept("##kestra:log:info##", false);
+        assertThat(consumer.getStdOutCount()).isZero();
+        assertThat(consumer.getStdErrCount()).isZero();
+    }
+
+    @Test
+    void regularLinesAreCounted() {
+        var runContext = runContextFactory.of("id", "namespace", IdUtils.create());
+        var consumer = new DefaultLogConsumer(runContext);
+
+        consumer.accept("##kestra:log:debug##", false);
+        consumer.accept("some before-command output", false);
+        consumer.accept("##kestra:log:info##", false);
+        consumer.accept("main output", false);
+
+        assertThat(consumer.getStdOutCount()).isEqualTo(2);
+        assertThat(consumer.getStdErrCount()).isZero();
+    }
+
+    @Test
+    void stderrLinesAreCountedEvenInDebugMode() {
+        var runContext = runContextFactory.of("id", "namespace", IdUtils.create());
+        var consumer = new DefaultLogConsumer(runContext);
+
+        consumer.accept("##kestra:log:debug##", false);
+        consumer.accept("stderr during beforeCommands", true);
+
+        assertThat(consumer.getStdErrCount()).isEqualTo(1);
+        assertThat(consumer.getStdOutCount()).isZero();
+    }
+}

--- a/core/src/test/java/io/kestra/core/models/tasks/runners/DefaultLogConsumerTest.java
+++ b/core/src/test/java/io/kestra/core/models/tasks/runners/DefaultLogConsumerTest.java
@@ -1,6 +1,11 @@
 package io.kestra.core.models.tasks.runners;
 
+import java.util.List;
+
 import org.junit.jupiter.api.Test;
+
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
 
 import io.kestra.core.context.TestRunContextFactory;
 import io.kestra.core.junit.annotations.KestraTest;
@@ -53,5 +58,35 @@ class DefaultLogConsumerTest {
 
         assertThat(consumer.getStdErrCount()).isEqualTo(1);
         assertThat(consumer.getStdOutCount()).isZero();
+    }
+
+    @Test
+    void linesInDebugModeAreLoggedAtDebugLevel() {
+        // Given
+        var runContext = runContextFactory.of("id", "namespace", IdUtils.create());
+        var consumer = new DefaultLogConsumer(runContext);
+
+        var listAppender = new ListAppender<ILoggingEvent>();
+        listAppender.start();
+        var logger = (ch.qos.logback.classic.Logger) runContext.logger();
+        logger.setLevel(ch.qos.logback.classic.Level.DEBUG);
+        logger.addAppender(listAppender);
+
+        // When
+        consumer.accept("##kestra:log:debug##", false);
+        consumer.accept("before-command output", false);
+        consumer.accept("##kestra:log:info##", false);
+        consumer.accept("main output", false);
+
+        // Then
+        List<ILoggingEvent> events = listAppender.list;
+        assertThat(events).anySatisfy(e -> {
+            assertThat(e.getFormattedMessage()).isEqualTo("before-command output");
+            assertThat(e.getLevel()).isEqualTo(ch.qos.logback.classic.Level.DEBUG);
+        });
+        assertThat(events).anySatisfy(e -> {
+            assertThat(e.getFormattedMessage()).isEqualTo("main output");
+            assertThat(e.getLevel()).isEqualTo(ch.qos.logback.classic.Level.INFO);
+        });
     }
 }

--- a/script/src/main/java/io/kestra/plugin/scripts/exec/scripts/runners/CommandsWrapper.java
+++ b/script/src/main/java/io/kestra/plugin/scripts/exec/scripts/runners/CommandsWrapper.java
@@ -163,10 +163,19 @@ public class CommandsWrapper implements TaskCommands {
         List<String> renderedBeforeCommands = this.renderCommands(runContext, beforeCommands);
         List<String> renderedInterpreter = this.renderCommands(runContext, interpreter);
 
+        List<String> effectiveBeforeCommands = this.isBeforeCommandsWithOptions() ? getBeforeCommandsWithOptions(renderedBeforeCommands) : renderedBeforeCommands;
+        if (!renderedBeforeCommands.isEmpty()) {
+            List<String> marked = new ArrayList<>();
+            marked.add("echo '##kestra:log:debug##'");
+            marked.addAll(effectiveBeforeCommands);
+            marked.add("echo '##kestra:log:info##'");
+            effectiveBeforeCommands = marked;
+        }
+
         List<String> finalCommands = renderedBeforeCommands.isEmpty() && renderedInterpreter.isEmpty() ? renderedCommands
             : ScriptService.scriptCommands(
                 renderedInterpreter,
-                this.isBeforeCommandsWithOptions() ? getBeforeCommandsWithOptions(renderedBeforeCommands) : renderedBeforeCommands,
+                effectiveBeforeCommands,
                 renderedCommands,
                 Optional.ofNullable(targetOS).orElse(TargetOS.AUTO)
             );


### PR DESCRIPTION
## Summary

- Injects `echo '##kestra:log:debug##'` / `echo '##kestra:log:info##'` sentinel lines around `beforeCommands` in the merged shell script (`CommandsWrapper`)
- `DefaultLogConsumer` detects these markers, flips a `debugMode` flag, and silently swallows the marker lines (not counted, not logged)
- `PluginUtilsService.parseOut` gains a `debug` overload: when `debug=true` and stdout, logs at `DEBUG` instead of `INFO`; stderr always stays at `ERROR` for visibility

This preserves shell state sharing between `beforeCommands` and the main `commands` (single script execution) while reducing log noise for setup steps like `pip install -r requirements.txt`.

## Test plan

- [ ] `DefaultLogConsumerTest` — 3 new unit tests: markers are swallowed (not counted), regular lines are counted, stderr always counted even in debug mode
- [ ] Manual: run a Shell or Python task with `beforeCommands: ["pip install requests"]` — setup output should disappear at INFO level and reappear at DEBUG
- [ ] Confirm stderr from a failing `beforeCommands` still surfaces at ERROR level

**What to verify:**
1. `pip install requests` and `apt-get install` output → **DEBUG** level (hidden at default log level, visible when log level set to DEBUG)
2. Main `commands` output (`Status: 200`, `main command`) → **INFO** level (visible by default)
3. `beforeCommands` stderr → **ERROR** level (always visible regardless of log level)

Part-of: https://github.com/kestra-io/kestra/issues/13648