### PR TITLE
Feat/execution endpoint return type

### DIFF
--- a/core/src/main/java/io/kestra/core/models/executions/Execution.java
+++ b/core/src/main/java/io/kestra/core/models/executions/Execution.java
@@ -25,7 +25,6 @@ import io.kestra.core.models.flows.FlowInterface;
 import io.kestra.core.models.flows.State;
 import io.kestra.core.models.tasks.ResolvedTask;
 import io.kestra.core.queues.event.DispatchEvent;
-import io.kestra.core.runners.FlowableUtils;
 import io.kestra.core.runners.RunContextLogger;
 import io.kestra.core.serializers.ListOrMapOfLabelDeserializer;
 import io.kestra.core.serializers.ListOrMapOfLabelSerializer;
@@ -55,6 +54,9 @@ import lombok.extern.slf4j.Slf4j;
 @ToString
 @EqualsAndHashCode
 public class Execution implements SoftDeletable<Execution>, TenantInterface, HasUID, DispatchEvent {
+    // !!! WARNING !!!
+    // When you add anything in this class, make sure to also update ApiExecution and ApiLightExecution in the webserver module
+    // !!!!!!!!!!!!!!!
 
     @With
     @Hidden

--- a/openapi.yml
+++ b/openapi.yml
@@ -1165,7 +1165,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/PagedResults_Execution_"
+                $ref: "#/components/schemas/PagedResults_ApiLightExecution_"
   /api/v1/{tenant}/executions/by-ids:
     delete:
       tags:
@@ -2061,7 +2061,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/PagedResults_Execution_"
+                $ref: "#/components/schemas/PagedResults_ApiLightExecution_"
   /api/v1/{tenant}/executions/unqueue/by-ids:
     post:
       tags:
@@ -2405,7 +2405,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Execution"
+                $ref: "#/components/schemas/ApiExecution"
     delete:
       tags:
       - Executions
@@ -5824,6 +5824,108 @@ components:
             type: string
         existingOnly:
           type: boolean
+    ApiExecution:
+      type: object
+      properties:
+        tenantId:
+          type: string
+        id:
+          type: string
+        namespace:
+          type: string
+        flowId:
+          type: string
+        flowRevision:
+          type: integer
+          format: int32
+        taskRunList:
+          type: array
+          items:
+            $ref: "#/components/schemas/ApiTaskRun"
+        inputs:
+          type: object
+          additionalProperties:
+            type: object
+        outputs:
+          type: object
+          additionalProperties:
+            type: object
+        labels:
+          type: array
+          items:
+            $ref: "#/components/schemas/Label"
+        variables:
+          type: object
+          additionalProperties:
+            type: object
+        state:
+          $ref: "#/components/schemas/State"
+        parentId:
+          type: string
+        originalId:
+          type: string
+        trigger:
+          $ref: "#/components/schemas/ExecutionTrigger"
+        metadata:
+          $ref: "#/components/schemas/ExecutionMetadata"
+        scheduleDate:
+          type: string
+          format: date-time
+        traceParent:
+          type: string
+        fixtures:
+          type: array
+          items:
+            $ref: "#/components/schemas/TaskFixture"
+        kind:
+          $ref: "#/components/schemas/ExecutionKind"
+        breakpoints:
+          type: array
+          items:
+            $ref: "#/components/schemas/Breakpoint"
+        loopRun:
+          $ref: "#/components/schemas/LoopRun"
+    ApiLightExecution:
+      type: object
+      properties:
+        tenantId:
+          type: string
+        id:
+          type: string
+        namespace:
+          type: string
+        flowId:
+          type: string
+        flowRevision:
+          type: integer
+          format: int32
+        inputs:
+          type: object
+          additionalProperties:
+            type: object
+        outputs:
+          type: object
+          additionalProperties:
+            type: object
+        labels:
+          type: array
+          items:
+            $ref: "#/components/schemas/Label"
+        state:
+          $ref: "#/components/schemas/State"
+        parentId:
+          type: string
+        originalId:
+          type: string
+        trigger:
+          $ref: "#/components/schemas/ExecutionTrigger"
+        scheduleDate:
+          type: string
+          format: date-time
+        kind:
+          $ref: "#/components/schemas/ExecutionKind"
+        loopRun:
+          $ref: "#/components/schemas/LoopRun"
     ApiSecretListResponse_ApiSecretMeta_:
       required:
       - readOnly
@@ -5846,6 +5948,32 @@ components:
       properties:
         key:
           type: string
+    ApiTaskRun:
+      type: object
+      properties:
+        id:
+          type: string
+        taskId:
+          type: string
+        parentTaskRunId:
+          type: string
+        value:
+          type: string
+        attempts:
+          type: array
+          items:
+            $ref: "#/components/schemas/TaskRunAttempt"
+        assets:
+          $ref: "#/components/schemas/AssetsInOut"
+        state:
+          $ref: "#/components/schemas/State"
+        iteration:
+          type: integer
+          format: int32
+        dynamic:
+          type: boolean
+        forceExecution:
+          type: boolean
     ApiTriggerAndState:
       type: object
       properties:
@@ -7269,6 +7397,19 @@ components:
           format: int32
         inline:
           type: boolean
+    PagedResults_ApiLightExecution_:
+      required:
+      - results
+      - total
+      type: object
+      properties:
+        results:
+          type: array
+          items:
+            $ref: "#/components/schemas/ApiLightExecution"
+        total:
+          type: integer
+          format: int64
     PagedResults_ApiTriggerAndState_:
       required:
       - results
@@ -7331,19 +7472,6 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/DashboardController.DashboardResponse"
-        total:
-          type: integer
-          format: int64
-    PagedResults_Execution_:
-      required:
-      - results
-      - total
-      type: object
-      properties:
-        results:
-          type: array
-          items:
-            $ref: "#/components/schemas/Execution"
         total:
           type: integer
           format: int64
@@ -7905,9 +8033,6 @@ components:
     State:
       required:
       - current
-      - getDuration
-      - getEndDate
-      - getStartDate
       type: object
       properties:
         duration:
@@ -7931,6 +8056,7 @@ components:
             $ref: "#/components/schemas/State.History"
         getDuration:
           type: string
+          nullable: true
           readOnly: true
         getStartDate:
           type: string
@@ -7939,6 +8065,7 @@ components:
         getEndDate:
           type: string
           format: date-time
+          nullable: true
           readOnly: true
     State.History:
       required:

--- a/webserver/src/main/java/io/kestra/webserver/controllers/api/ExecutionController.java
+++ b/webserver/src/main/java/io/kestra/webserver/controllers/api/ExecutionController.java
@@ -13,11 +13,14 @@ import java.time.Instant;
 import java.time.ZonedDateTime;
 import java.util.*;
 
+import io.kestra.core.repositories.ArrayListTotal;
 import io.kestra.core.serializers.JacksonMapper;
 import io.kestra.core.utils.Await;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import io.kestra.webserver.models.api.ApiExecution;
+import io.kestra.webserver.models.api.ApiLightExecution;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.reactivestreams.Publisher;
@@ -158,9 +161,6 @@ public class ExecutionController {
     protected ExecutionService executionService;
 
     @Inject
-    private ConditionService conditionService;
-
-    @Inject
     private ExecutionStreamingService streamingService;
 
     @Inject
@@ -220,7 +220,7 @@ public class ExecutionController {
     @ExecuteOn(TaskExecutors.IO)
     @Get(uri = "/search")
     @Operation(tags = { "Executions" }, summary = "Search for executions")
-    public PagedResults<Execution> searchExecutions(
+    public PagedResults<ApiLightExecution> searchExecutions(
         @Parameter(description = "The current page") @QueryValue(defaultValue = "1") @Min(1) int page,
         @Parameter(description = "The current page size") @QueryValue(defaultValue = "10") @Min(1) int size,
         @Parameter(
@@ -235,13 +235,15 @@ public class ExecutionController {
         ) @QueryFilterFormat List<QueryFilter> filters
 
     ) {
-        return PagedResults.of(
-            executionRepository.find(
-                PageableUtils.from(page, size, sort, executionRepository.sortMapping()),
-                tenantService.resolveTenant(),
-                QueryFilterUtils.replaceTimeRangeWithComputedStartDateFilter(filters)
-            )
+        var executions = executionRepository.find(
+            PageableUtils.from(page, size, sort, executionRepository.sortMapping()),
+            tenantService.resolveTenant(),
+            QueryFilterUtils.replaceTimeRangeWithComputedStartDateFilter(filters)
         );
+        var apiExecution = executions.stream()
+            .map(execution -> ApiLightExecution.of(execution))
+            .toList();
+        return PagedResults.of(new ArrayListTotal<>(apiExecution, executions.getTotal()));
     }
 
     @ExecuteOn(TaskExecutors.IO)
@@ -359,10 +361,11 @@ public class ExecutionController {
     @ExecuteOn(TaskExecutors.IO)
     @Get(uri = "/{executionId}")
     @Operation(tags = { "Executions" }, summary = "Get an execution")
-    public Execution getExecution(
+    public ApiExecution getExecution(
         @Parameter(description = "The execution id") @PathVariable String executionId) {
         return executionRepository
             .findById(tenantService.resolveTenant(), executionId)
+            .map(ApiExecution::of)
             .orElse(null);
     }
 
@@ -452,15 +455,16 @@ public class ExecutionController {
     @ExecuteOn(TaskExecutors.IO)
     @Get
     @Operation(tags = { "Executions" }, summary = "Search for executions for a flow")
-    public PagedResults<Execution> searchExecutionsByFlowId(
+    public PagedResults<ApiLightExecution> searchExecutionsByFlowId(
         @Parameter(description = "The flow namespace") @QueryValue String namespace,
         @Parameter(description = "The flow id") @QueryValue String flowId,
         @Parameter(description = "The current page") @QueryValue(defaultValue = "1") @Min(1) int page,
         @Parameter(description = "The current page size") @QueryValue(defaultValue = "10") @Min(1) int size) {
-        return PagedResults.of(
-            executionRepository
-                .findByFlowId(tenantService.resolveTenant(), namespace, flowId, PageableUtils.from(page, size))
-        );
+        var executions = executionRepository.findByFlowId(tenantService.resolveTenant(), namespace, flowId, PageableUtils.from(page, size));
+        var apiExecution = executions.stream()
+            .map(execution -> ApiLightExecution.of(execution))
+            .toList();
+        return PagedResults.of(new ArrayListTotal<>(apiExecution, executions.getTotal()));
     }
 
     @ExecuteOn(TaskExecutors.IO)

--- a/webserver/src/main/java/io/kestra/webserver/models/api/ApiExecution.java
+++ b/webserver/src/main/java/io/kestra/webserver/models/api/ApiExecution.java
@@ -1,0 +1,39 @@
+package io.kestra.webserver.models.api;
+
+import io.kestra.core.debug.Breakpoint;
+import io.kestra.core.models.Label;
+import io.kestra.core.models.executions.*;
+import io.kestra.core.models.flows.State;
+import io.kestra.core.test.flow.TaskFixture;
+import io.kestra.core.utils.ListUtils;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+
+public record ApiExecution(String tenantId,
+                           String id,
+                           String namespace,
+                           String flowId,
+                           Integer flowRevision,
+                           List<ApiTaskRun> taskRunList,
+                           Map<String, Object> inputs,
+                           Map<String, Object> outputs,
+                           List<Label> labels,
+                           Map<String, Object> variables,
+                           State state,
+                           String parentId,
+                           String originalId,
+                           ExecutionTrigger trigger,
+                           ExecutionMetadata metadata,
+                           Instant scheduleDate,
+                           String traceParent,
+                           List<TaskFixture> fixtures,
+                           ExecutionKind kind,
+                           List<Breakpoint> breakpoints,
+                           LoopRun loopRun) {
+
+    public static ApiExecution of(Execution execution) {
+        return new ApiExecution(execution.getTenantId(), execution.getId(), execution.getNamespace(), execution.getFlowId(), execution.getFlowRevision(), ListUtils.emptyOnNull(execution.getTaskRunList()).stream().map(ApiTaskRun::of).toList(), execution.getInputs(), execution.getOutputs(), execution.getLabels(), execution.getVariables(), execution.getState(), execution.getParentId(), execution.getOriginalId(), execution.getTrigger(), execution.getMetadata(), execution.getScheduleDate(), execution.getTraceParent(), execution.getFixtures(), execution.getKind(), execution.getBreakpoints(), execution.getLoopRun());
+    }
+}

--- a/webserver/src/main/java/io/kestra/webserver/models/api/ApiLightExecution.java
+++ b/webserver/src/main/java/io/kestra/webserver/models/api/ApiLightExecution.java
@@ -1,0 +1,29 @@
+package io.kestra.webserver.models.api;
+
+import io.kestra.core.models.Label;
+import io.kestra.core.models.executions.*;
+import io.kestra.core.models.flows.State;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+
+public record ApiLightExecution(String tenantId,
+                                String id,
+                                String namespace,
+                                String flowId,
+                                Integer flowRevision,
+                                Map<String, Object> inputs,
+                                Map<String, Object> outputs,
+                                List<Label> labels,
+                                State state,
+                                String parentId,
+                                String originalId,
+                                ExecutionTrigger trigger,
+                                Instant scheduleDate,
+                                ExecutionKind kind,
+                                LoopRun loopRun) {
+    public static ApiLightExecution of(Execution execution) {
+        return new ApiLightExecution(execution.getTenantId(), execution.getId(), execution.getNamespace(), execution.getFlowId(), execution.getFlowRevision(), execution.getInputs(), execution.getOutputs(), execution.getLabels(), execution.getState(), execution.getParentId(), execution.getOriginalId(), execution.getTrigger(), execution.getScheduleDate(), execution.getKind(), execution.getLoopRun());
+    }
+}

--- a/webserver/src/main/java/io/kestra/webserver/models/api/ApiTaskRun.java
+++ b/webserver/src/main/java/io/kestra/webserver/models/api/ApiTaskRun.java
@@ -1,0 +1,23 @@
+package io.kestra.webserver.models.api;
+
+import io.kestra.core.models.assets.AssetsInOut;
+import io.kestra.core.models.executions.TaskRun;
+import io.kestra.core.models.executions.TaskRunAttempt;
+import io.kestra.core.models.flows.State;
+
+import java.util.List;
+
+public record ApiTaskRun(String id,
+                         String taskId,
+                         String parentTaskRunId,
+                         String value,
+                         List<TaskRunAttempt> attempts,
+                         AssetsInOut assets,
+                         State state,
+                         Integer iteration,
+                         Boolean dynamic,
+                         Boolean forceExecution) {
+    public static ApiTaskRun of(TaskRun taskRun) {
+        return new ApiTaskRun(taskRun.getId(), taskRun.getTaskId(), taskRun.getParentTaskRunId(), taskRun.getValue(), taskRun.getAttempts(), taskRun.getAssets(), taskRun.getState(), taskRun.getIteration(), taskRun.getDynamic(), taskRun.getForceExecution());
+    }
+}

--- a/webserver/src/main/java/io/kestra/webserver/models/namespaces/DisabledInterface.java
+++ b/webserver/src/main/java/io/kestra/webserver/models/namespaces/DisabledInterface.java
@@ -1,5 +1,0 @@
-package io.kestra.webserver.models.namespaces;
-
-public interface DisabledInterface {
-    boolean isDisabled();
-}


### PR DESCRIPTION
Closes https://github.com/kestra-io/kestra-ee/issues/7469

@tchiotludo it would be worth reviewing what we expose and maybe removing more attributes from the `ApiLightExecution` record which is the record used when we list executions.

Companion PR: https://github.com/kestra-io/kestra-ee/pull/7476
