### PR TITLE
fix(scheduler): apply trigger conditions when persisting nextEvaluationDate

### DIFF
--- a/core/src/main/java/io/kestra/core/validations/validator/ScheduleValidator.java
+++ b/core/src/main/java/io/kestra/core/validations/validator/ScheduleValidator.java
@@ -1,7 +1,5 @@
 package io.kestra.core.validations.validator;
 
-import com.cronutils.model.Cron;
-
 import io.kestra.core.validations.ScheduleValidation;
 import io.kestra.plugin.core.trigger.Schedule;
 
@@ -25,8 +23,9 @@ public class ScheduleValidator implements ConstraintValidator<ScheduleValidation
 
         if (value.getCron() != null) { // if null, the standard @NotNull will do its job
             try {
-                Cron parsed = value.parseCron();
-                parsed.validate();
+                // parseCron() now parses + validates on first call and caches the result,
+                // so repeated validation runs on the scheduler hot path are O(1).
+                value.parseCron();
             } catch (IllegalArgumentException e) {
                 context.disableDefaultConstraintViolation();
                 context.buildConstraintViolationWithTemplate("invalid cron expression '" + value.getCron() + "': " + e.getMessage())

--- a/core/src/main/java/io/kestra/plugin/core/condition/DateTimeBetween.java
+++ b/core/src/main/java/io/kestra/plugin/core/condition/DateTimeBetween.java
@@ -104,7 +104,7 @@ public class DateTimeBetween extends Condition implements ScheduleCondition {
     @Override
     public boolean test(ConditionContext conditionContext) throws InternalException {
         Map<String, Object> vars = conditionContext.getVariables();
-        String renderedDate = conditionContext.getRunContext().render(this.date).as(String.class, vars).orElseThrow();
+        String renderedDate = conditionContext.getRunContext().render(this.date).skipCache().as(String.class, vars).orElseThrow();
 
         ZonedDateTime currentDate;
         try {

--- a/core/src/main/java/io/kestra/plugin/core/condition/DayWeek.java
+++ b/core/src/main/java/io/kestra/plugin/core/condition/DayWeek.java
@@ -72,7 +72,7 @@ public class DayWeek extends Condition implements ScheduleCondition {
     @Override
     public boolean test(ConditionContext conditionContext) throws InternalException {
         RunContext runContext = conditionContext.getRunContext();
-        String render = runContext.render(date).as(String.class, conditionContext.getVariables()).orElseThrow();
+        String render = runContext.render(date).skipCache().as(String.class, conditionContext.getVariables()).orElseThrow();
         LocalDate currentDate = DateUtils.parseLocalDate(render);
 
         return currentDate.getDayOfWeek().equals(runContext.render(dayOfWeek).as(DayOfWeek.class, conditionContext.getVariables()).orElseThrow());

--- a/core/src/main/java/io/kestra/plugin/core/condition/DayWeekInMonth.java
+++ b/core/src/main/java/io/kestra/plugin/core/condition/DayWeekInMonth.java
@@ -81,7 +81,7 @@ public class DayWeekInMonth extends Condition implements ScheduleCondition {
         Map<String, Object> vars = conditionContext.getVariables();
         RunContext runContext = conditionContext.getRunContext();
 
-        String render = runContext.render(this.date).as(String.class, vars).orElseThrow();
+        String render = runContext.render(this.date).skipCache().as(String.class, vars).orElseThrow();
         LocalDate currentDate = DateUtils.parseLocalDate(render);
         LocalDate computed;
 

--- a/core/src/main/java/io/kestra/plugin/core/condition/PublicHoliday.java
+++ b/core/src/main/java/io/kestra/plugin/core/condition/PublicHoliday.java
@@ -109,7 +109,7 @@ public class PublicHoliday extends Condition implements ScheduleCondition {
         var renderedSubDivision = conditionContext.getRunContext().render(this.subDivision).as(String.class).orElse(null);
 
         HolidayManager holidayManager = renderedCountry != null ? HolidayManager.getInstance(ManagerParameters.create(renderedCountry)) : HolidayManager.getInstance();
-        LocalDate currentDate = DateUtils.parseLocalDate(conditionContext.getRunContext().render(date).as(String.class, variables).orElseThrow());
+        LocalDate currentDate = DateUtils.parseLocalDate(conditionContext.getRunContext().render(date).skipCache().as(String.class, variables).orElseThrow());
         return renderedSubDivision == null ? holidayManager.isHoliday(currentDate) : holidayManager.isHoliday(currentDate, renderedSubDivision);
     }
 }

--- a/core/src/main/java/io/kestra/plugin/core/condition/Weekend.java
+++ b/core/src/main/java/io/kestra/plugin/core/condition/Weekend.java
@@ -65,7 +65,7 @@ public class Weekend extends Condition implements ScheduleCondition {
 
     @Override
     public boolean test(ConditionContext conditionContext) throws InternalException {
-        String render = conditionContext.getRunContext().render(date).as(String.class, conditionContext.getVariables()).orElseThrow();
+        String render = conditionContext.getRunContext().render(date).skipCache().as(String.class, conditionContext.getVariables()).orElseThrow();
         LocalDate currentDate = DateUtils.parseLocalDate(render);
 
         return currentDate.getDayOfWeek().equals(DayOfWeek.SATURDAY) ||

--- a/core/src/main/java/io/kestra/plugin/core/trigger/Schedule.java
+++ b/core/src/main/java/io/kestra/plugin/core/trigger/Schedule.java
@@ -33,8 +33,6 @@ import lombok.AccessLevel;
 import lombok.experimental.SuperBuilder;
 import lombok.extern.slf4j.Slf4j;
 
-import static io.kestra.core.utils.Rethrow.throwPredicate;
-
 @Slf4j
 @SuperBuilder
 @ToString
@@ -220,6 +218,9 @@ public class Schedule extends AbstractTrigger implements Schedulable, TriggerOut
 
     @Getter(AccessLevel.NONE)
     private transient Cron cachedCron;
+
+    @Getter(AccessLevel.NONE)
+    private transient List<ScheduleCondition> cachedScheduleConditions;
 
     private RecoverMissedSchedules recoverMissedSchedules;
 
@@ -571,27 +572,36 @@ public class Schedule extends AbstractTrigger implements Schedulable, TriggerOut
         return output;
     }
 
+    /**
+     * Evaluates all {@link ScheduleCondition}s against the given context. Every caller must
+     * provide a context that already contains the {@code trigger} and {@code schedule}
+     * variables (see {@link #conditionContext(ConditionContext, Output)}).
+     */
     private boolean validateScheduleCondition(ConditionContext conditionContext) throws InternalException {
-        final ConditionContext finalConditionContext;
-        if (!conditionContext.getVariables().containsKey("trigger") && conditionContext.getVariables().containsKey("schedule")) {
-            finalConditionContext = conditionContext.withVariables(
-                ImmutableMap.<String, Object> builder()
-                    .putAll(conditionContext.getVariables())
-                    .put("trigger", conditionContext.getVariables().get("schedule"))
-                    .build()
-            );
-        } else {
-            finalConditionContext = conditionContext;
+        for (ScheduleCondition condition : scheduleConditions()) {
+            if (!condition.test(conditionContext)) {
+                return false;
+            }
         }
-
-        if (conditions != null) {
-            return conditions.stream()
-                .filter(c -> c instanceof ScheduleCondition)
-                .map(c -> (ScheduleCondition) c)
-                .allMatch(throwPredicate(condition -> condition.test(finalConditionContext)));
-        }
-
         return true;
+    }
+
+    /**
+     * Returns (and memoizes) the subset of {@link #conditions} that implement
+     * {@link ScheduleCondition}. The list is computed once per {@link Schedule} instance
+     * rather than re-filtered on every hot-loop iteration through
+     * {@link #findNextDateMatchingConditions} / {@link #findPreviousDateMatchingConditions}.
+     */
+    private synchronized List<ScheduleCondition> scheduleConditions() {
+        if (this.cachedScheduleConditions == null) {
+            this.cachedScheduleConditions = conditions == null
+                ? List.of()
+                : conditions.stream()
+                    .filter(c -> c instanceof ScheduleCondition)
+                    .map(c -> (ScheduleCondition) c)
+                    .toList();
+        }
+        return this.cachedScheduleConditions;
     }
 
     @SuperBuilder

--- a/core/src/main/java/io/kestra/plugin/core/trigger/Schedule.java
+++ b/core/src/main/java/io/kestra/plugin/core/trigger/Schedule.java
@@ -218,6 +218,9 @@ public class Schedule extends AbstractTrigger implements Schedulable, TriggerOut
     @Getter(AccessLevel.NONE)
     private transient ExecutionTime executionTime;
 
+    @Getter(AccessLevel.NONE)
+    private transient Cron cachedCron;
+
     private RecoverMissedSchedules recoverMissedSchedules;
 
     @Override
@@ -382,9 +385,23 @@ public class Schedule extends AbstractTrigger implements Schedulable, TriggerOut
         return Optional.of(execution);
     }
 
-    public Cron parseCron() {
-        CronParser parser = Boolean.TRUE.equals(withSeconds) ? CRON_PARSER_WITH_SECONDS : CRON_PARSER;
-        return parser.parse(this.cron);
+    /**
+     * Parses and validates this trigger's cron expression.
+     * <p>
+     * The parsed {@link Cron} is memoized on the instance so repeat callers (e.g. every
+     * {@link ScheduleValidation} invocation on the scheduling hot path) do not reconstruct
+     * a new {@link CronParser} and rebuild its internal regex patterns each time. Throws
+     * {@link IllegalArgumentException} on the first call if the cron is invalid; once the
+     * cached value is returned the call is O(1).
+     */
+    public synchronized Cron parseCron() {
+        if (this.cachedCron == null) {
+            CronParser parser = Boolean.TRUE.equals(withSeconds) ? CRON_PARSER_WITH_SECONDS : CRON_PARSER;
+            Cron parsed = parser.parse(this.cron);
+            parsed.validate();
+            this.cachedCron = parsed;
+        }
+        return this.cachedCron;
     }
 
     private Optional<Output> scheduleDates(ExecutionTime executionTime, ZonedDateTime date) {
@@ -420,7 +437,8 @@ public class Schedule extends AbstractTrigger implements Schedulable, TriggerOut
     }
 
     @VisibleForTesting
-    synchronized ExecutionTime executionTime() {
+    synchronized ExecutionTime 
+    executionTime() {
         if (this.executionTime == null) {
             Cron parsed = parseCron();
             this.executionTime = ExecutionTime.forCron(parsed);

--- a/core/src/main/java/io/kestra/plugin/core/trigger/Schedule.java
+++ b/core/src/main/java/io/kestra/plugin/core/trigger/Schedule.java
@@ -237,11 +237,10 @@ public class Schedule extends AbstractTrigger implements Schedulable, TriggerOut
             // previous present & conditions
             if (this.getConditions() != null) {
                 try {
-                    Optional<ZonedDateTime> next = this.truePreviousNextDateWithCondition(
+                    Optional<ZonedDateTime> next = this.findNextDateMatchingConditions(
                         executionTime,
                         conditionContext,
-                        lastDate,
-                        true
+                        lastDate
                     );
 
                     if (next.isPresent()) {
@@ -294,11 +293,10 @@ public class Schedule extends AbstractTrigger implements Schedulable, TriggerOut
         ExecutionTime executionTime = this.executionTime();
         if (this.getConditions() != null) {
             try {
-                Optional<ZonedDateTime> previous = this.truePreviousNextDateWithCondition(
+                Optional<ZonedDateTime> previous = this.findPreviousDateMatchingConditions(
                     executionTime,
                     conditionContext,
-                    SchedulerClock.now(),
-                    false
+                    SchedulerClock.now()
                 );
 
                 if (previous.isPresent()) {
@@ -451,56 +449,82 @@ public class Schedule extends AbstractTrigger implements Schedulable, TriggerOut
         Output.OutputBuilder<?, ?> outputBuilder = Output.builder()
             .date(output.getDate());
 
-        this.truePreviousNextDateWithCondition(executionTime, conditionContext, ZonedDateTime.from(output.getDate()), true)
+        this.findNextDateMatchingConditions(executionTime, conditionContext, ZonedDateTime.from(output.getDate()))
             .ifPresent(outputBuilder::next);
 
-        this.truePreviousNextDateWithCondition(executionTime, conditionContext, ZonedDateTime.from(output.getDate()), false)
+        this.findPreviousDateMatchingConditions(executionTime, conditionContext, ZonedDateTime.from(output.getDate()))
             .ifPresent(outputBuilder::previous);
 
         return outputBuilder.build();
     }
 
+    /**
+     * Walks forward from {@code fromDate} through successive cron executions and returns the
+     * first one where all schedule conditions match. Gives up after 10 years of lookahead.
+     */
     @VisibleForTesting
-    Optional<ZonedDateTime> truePreviousNextDateWithCondition(ExecutionTime executionTime, ConditionContext conditionContext, ZonedDateTime toTestDate, boolean next) throws InternalException {
+    Optional<ZonedDateTime> findNextDateMatchingConditions(ExecutionTime executionTime, ConditionContext conditionContext, ZonedDateTime fromDate) throws InternalException {
         int upperYearBound = SchedulerClock.now().getYear() + 10;
-        int lowerYearBound = SchedulerClock.now().getYear() - 10;
 
-        while ((next && toTestDate.getYear() < upperYearBound) || (!next && toTestDate.getYear() > lowerYearBound)) {
-
-            Optional<ZonedDateTime> currentDate = next ? executionTime.nextExecution(toTestDate) : executionTime.lastExecution(toTestDate);
-
-            if (currentDate.isEmpty()) {
-                return currentDate;
+        while (fromDate.getYear() < upperYearBound) {
+            Optional<ZonedDateTime> candidate = executionTime.nextExecution(fromDate);
+            if (candidate.isEmpty()) {
+                return candidate;
             }
 
-            Optional<Output> currentOutput = this.scheduleDates(executionTime, currentDate.get());
-
-            if (currentOutput.isEmpty()) {
+            Optional<Output> candidateOutput = this.scheduleDates(executionTime, candidate.get());
+            if (candidateOutput.isEmpty()) {
                 return Optional.empty();
             }
 
-            ConditionContext currentConditionContext = this.conditionContext(conditionContext, currentOutput.get());
-
-            if (!currentConditionContext.getVariables().containsKey("trigger")) {
-                currentConditionContext = currentConditionContext.withVariables(
-                    ImmutableMap.<String, Object> builder()
-                        .putAll(currentConditionContext.getVariables())
-                        .put("trigger", currentOutput.get().toMap())
-                        .build()
-                );
+            if (allScheduleConditionsMatch(conditionContext, candidateOutput.get())) {
+                return candidate;
             }
 
-            boolean conditionResults = this.validateScheduleCondition(currentConditionContext);
-            if (conditionResults) {
-                return currentDate;
-            }
-
-            toTestDate = next
-                ? currentDate.get().plusSeconds(1)
-                : currentDate.get().minusSeconds(1);
+            fromDate = candidate.get().plusSeconds(1);
         }
 
         return Optional.empty();
+    }
+
+    /**
+     * Walks backward from {@code fromDate} through preceding cron executions and returns the
+     * first one where all schedule conditions match. Gives up after 10 years of lookback.
+     */
+    @VisibleForTesting
+    Optional<ZonedDateTime> findPreviousDateMatchingConditions(ExecutionTime executionTime, ConditionContext conditionContext, ZonedDateTime fromDate) throws InternalException {
+        int lowerYearBound = SchedulerClock.now().getYear() - 10;
+
+        while (fromDate.getYear() > lowerYearBound) {
+            Optional<ZonedDateTime> candidate = executionTime.lastExecution(fromDate);
+            if (candidate.isEmpty()) {
+                return candidate;
+            }
+
+            Optional<Output> candidateOutput = this.scheduleDates(executionTime, candidate.get());
+            if (candidateOutput.isEmpty()) {
+                return Optional.empty();
+            }
+
+            if (allScheduleConditionsMatch(conditionContext, candidateOutput.get())) {
+                return candidate;
+            }
+
+            fromDate = candidate.get().minusSeconds(1);
+        }
+
+        return Optional.empty();
+    }
+
+    /**
+     * Evaluates all {@link ScheduleCondition}s for a single cron-execution candidate, after
+     * injecting {@code schedule} and {@code trigger} variables derived from that candidate's
+     * schedule dates (so conditions like {@link io.kestra.plugin.core.condition.DayWeek} can
+     * render {@code {{ trigger.date }}}).
+     */
+    private boolean allScheduleConditionsMatch(ConditionContext baseContext, Output candidateOutput) throws InternalException {
+        ConditionContext contextWithSchedule = this.conditionContext(baseContext, candidateOutput);
+        return this.validateScheduleCondition(contextWithSchedule);
     }
 
     private Output handleMaxDelay(Output output) {

--- a/core/src/test/java/io/kestra/plugin/core/trigger/ScheduleTest.java
+++ b/core/src/test/java/io/kestra/plugin/core/trigger/ScheduleTest.java
@@ -730,7 +730,7 @@ class ScheduleTest {
             .runContext(runContextInitializer.forScheduler((DefaultRunContext) runContextFactory.of(), triggerContext, trigger))
             .build();
 
-        Optional<ZonedDateTime> result = trigger.truePreviousNextDateWithCondition(trigger.executionTime(), conditionContext, now, true);
+        Optional<ZonedDateTime> result = trigger.findNextDateMatchingConditions(trigger.executionTime(), conditionContext, now);
         assertThat(result).isNotEmpty();
     }
 
@@ -764,7 +764,7 @@ class ScheduleTest {
             .runContext(runContextInitializer.forScheduler((DefaultRunContext) runContextFactory.of(), triggerContext, trigger))
             .build();
 
-        Optional<ZonedDateTime> result = trigger.truePreviousNextDateWithCondition(trigger.executionTime(), conditionContext, now, true);
+        Optional<ZonedDateTime> result = trigger.findNextDateMatchingConditions(trigger.executionTime(), conditionContext, now);
         assertThat(result).isNotEmpty();
     }
 
@@ -793,7 +793,7 @@ class ScheduleTest {
             .runContext(runContextInitializer.forScheduler((DefaultRunContext) runContextFactory.of(), triggerContext, trigger))
             .build();
 
-        Optional<ZonedDateTime> result = trigger.truePreviousNextDateWithCondition(trigger.executionTime(), conditionContext, now, true);
+        Optional<ZonedDateTime> result = trigger.findNextDateMatchingConditions(trigger.executionTime(), conditionContext, now);
         assertThat(result).isNotEmpty();
     }
 

--- a/scheduler/src/main/java/io/kestra/scheduler/TriggerEventHandler.java
+++ b/scheduler/src/main/java/io/kestra/scheduler/TriggerEventHandler.java
@@ -20,6 +20,7 @@ import io.kestra.core.models.flows.FlowWithSource;
 import io.kestra.core.models.triggers.AbstractTrigger;
 import io.kestra.core.models.triggers.Backfill;
 import io.kestra.core.models.triggers.PollingTriggerInterface;
+import io.kestra.core.models.triggers.TriggerContext;
 import io.kestra.core.queues.BroadcastQueueInterface;
 import io.kestra.core.queues.QueueException;
 import io.kestra.core.runners.RunContext;
@@ -137,12 +138,8 @@ public class TriggerEventHandler {
                 return;
             }
 
-            RunContext runContext = runContextFactory.of(flow, trigger);
-            ConditionContext conditionContext = conditionService.conditionContext(runContext, flow, null);
-
-            if (trigger instanceof PollingTriggerInterface pollingTriggerInterface) {
-                ZonedDateTime nextEvaluationDate = pollingTriggerInterface.nextEvaluationDate(conditionContext, Optional.of(state.context()));
-                state = state.updateForNextEvaluationDate(clock, nextEvaluationDate);
+            if (trigger instanceof PollingTriggerInterface) {
+                state = state.updateForNextEvaluationDate(clock, nextEvaluationDate(clock, flow, trigger, state.context()));
             }
 
             triggerStateStore.save(state);
@@ -204,7 +201,7 @@ public class TriggerEventHandler {
             if (wasDisabled && !event.disabled()) {
                 Pair<Flow, AbstractTrigger> data = findTrigger(event, null);
                 if (data.getRight() != null) {
-                    state = state.updateForNextEvaluationDate(clock, NextEvaluationDate.get(clock, data.getRight()));
+                    state = state.updateForNextEvaluationDate(clock, nextEvaluationDate(clock, data.getLeft(), data.getRight(), state.context()));
                 }
             }
             triggerStateStore.save(state);
@@ -243,7 +240,7 @@ public class TriggerEventHandler {
 
             TriggerState newState = state;
             if (data.getRight() != null) {
-                newState = newState.updateForNextEvaluationDate(clock, NextEvaluationDate.get(clock, data.getRight()));
+                newState = newState.updateForNextEvaluationDate(clock, nextEvaluationDate(clock, data.getLeft(), data.getRight(), state.context()));
             }
 
             if (event.evaluation() != null) {
@@ -288,7 +285,7 @@ public class TriggerEventHandler {
                 .lastEventId(clock, event.eventId())
                 .reset(clock);
             if (data.getRight() != null) {
-                state = state.updateForNextEvaluationDate(clock, NextEvaluationDate.get(clock, data.getRight()));
+                state = state.updateForNextEvaluationDate(clock, nextEvaluationDate(clock, data.getLeft(), data.getRight(), state.context()));
             }
             triggerStateStore.save(state);
         });
@@ -307,7 +304,7 @@ public class TriggerEventHandler {
                 state = state
                     .lastEventId(clock, event.eventId())
                     .update(clock, data.getRight())
-                    .updateForNextEvaluationDate(clock, NextEvaluationDate.get(clock, data.getRight()));
+                    .updateForNextEvaluationDate(clock, nextEvaluationDate(clock, data.getLeft(), data.getRight(), state.context()));
                 triggerStateStore.save(state);
             }
         });
@@ -365,13 +362,24 @@ public class TriggerEventHandler {
     void onTriggerCreated(Clock clock, TriggerCreated event, Integer vNode) {
         Pair<Flow, AbstractTrigger> data = findTrigger(event, event.revision());
         if (data.getRight() != null) {
+            Flow flow = data.getLeft();
             AbstractTrigger trigger = data.getRight();
             TriggerState state = TriggerState
                 .of(event.id(), TriggerType.from(trigger), trigger.getStopAfter(), trigger.isDisabled(), vNode)
-                .lastEventId(clock, event.eventId())
-                .updateForNextEvaluationDate(clock, NextEvaluationDate.get(clock, trigger));
+                .lastEventId(clock, event.eventId());
+            state = state.updateForNextEvaluationDate(clock, nextEvaluationDate(clock, flow, trigger, state.context()));
             triggerStateStore.save(state);
         }
+    }
+
+    /**
+     * Computes the next evaluation date for the given trigger, taking the trigger's conditions into account
+     * so handlers don't overwrite a condition-aware date (e.g. {@code DayWeek=SUNDAY}) with the next raw cron tick.
+     */
+    private ZonedDateTime nextEvaluationDate(Clock clock, Flow flow, AbstractTrigger trigger, TriggerContext triggerContext) {
+        RunContext runContext = runContextFactory.of(flow, trigger);
+        ConditionContext conditionContext = conditionService.conditionContext(runContext, flow, null);
+        return NextEvaluationDate.get(clock, trigger, triggerContext, conditionContext);
     }
 
     private Pair<Flow, AbstractTrigger> findTrigger(TriggerEvent event, Integer revision) {

--- a/scheduler/src/main/java/io/kestra/scheduler/TriggerScheduler.java
+++ b/scheduler/src/main/java/io/kestra/scheduler/TriggerScheduler.java
@@ -213,7 +213,10 @@ public class TriggerScheduler {
                                 }
                             }
                             case NONE -> {
-                                ZonedDateTime nextEvaluationDate = schedulableTrigger.nextEvaluationDate();
+                                // Skip missed slots by starting from now (null triggerContext causes
+                                // NextEvaluationDate.get to seed date=now), which also lets Schedule
+                                // apply trigger conditions (e.g. DayWeek) to the next computed tick.
+                                ZonedDateTime nextEvaluationDate = NextEvaluationDate.get(clock, trigger, null, conditionContext);
                                 if (!Objects.equals(currentTriggerState.getNextEvaluationDate(), nextEvaluationDate.toInstant())) {
                                     currentTriggerState = currentTriggerState.updateForNextEvaluationDate(clock, nextEvaluationDate);
                                     triggerStateStore.save(currentTriggerState);
@@ -395,8 +398,11 @@ public class TriggerScheduler {
     private Optional<TriggerState> updateNextEvaluationDateAndGetOnSuccess(Clock clock, TriggerState currentTriggerState, TriggerEvaluationContext lastTriggerEvaluationContext) {
         Logger logger = lastTriggerEvaluationContext.conditionContext().getRunContext().logger();
         try {
+            // Use currentTriggerState.context() — the caller has already set evaluatedAt=nextEvaluationDate on it.
+            // lastTriggerEvaluationContext.triggerState() is frozen at fetch time and can still carry a null
+            // evaluatedAt (first evaluation after creation), which would make Schedule skip the conditions branch.
             ZonedDateTime nextEvaluationDate = NextEvaluationDate
-                .get(clock, lastTriggerEvaluationContext.trigger(), lastTriggerEvaluationContext.triggerState().context(), lastTriggerEvaluationContext.conditionContext());
+                .get(clock, lastTriggerEvaluationContext.trigger(), currentTriggerState.context(), lastTriggerEvaluationContext.conditionContext());
             return Optional.of(currentTriggerState.updateForNextEvaluationDate(clock, nextEvaluationDate));
         } catch (Exception e) {
             if (e instanceof InvalidTriggerConfigurationException) {

--- a/scheduler/src/main/java/io/kestra/scheduler/internals/DefaultSchedulableTriggerFetcher.java
+++ b/scheduler/src/main/java/io/kestra/scheduler/internals/DefaultSchedulableTriggerFetcher.java
@@ -79,8 +79,8 @@ public class DefaultSchedulableTriggerFetcher implements SchedulableTriggerFetch
                 );
 
                 // Check whether the Flow still exists
-                if (maybeFlowTrigger.isEmpty()) {
-                    triggerStateStore.delete(triggerState); // Delete triggerState state
+                if (maybeFlowTrigger.isEmpty() || maybeFlowTrigger.get().isDeleted()) {
+                    triggerStateStore.delete(triggerState);
                     return null;
                 }
 
@@ -89,7 +89,7 @@ public class DefaultSchedulableTriggerFetcher implements SchedulableTriggerFetch
                 // Validate that the trigger still exists and is enabled before processing. This check covers several cases:
                 // 1. The overall Flow might be disabled 
                 // 2. The specific trigger may have been removed.
-                // 3. The trigger itself may have been disabled .
+                // 3. The trigger itself may have been disabled.
                 // 
                 // 2. and 3. can occur if the Flow has been updated but the associated TriggerEvent
                 // has not yet been processed. In these cases, 

--- a/scheduler/src/main/java/io/kestra/scheduler/internals/NextEvaluationDate.java
+++ b/scheduler/src/main/java/io/kestra/scheduler/internals/NextEvaluationDate.java
@@ -26,18 +26,28 @@ public abstract class NextEvaluationDate {
      * @throws InvalidTriggerConfigurationException if something bad happens while computing next evaluation date.
      */
     public static ZonedDateTime get(Clock clock, AbstractTrigger trigger, TriggerContext triggerContext, ConditionContext conditionContext) throws InvalidTriggerConfigurationException {
-        ZonedDateTime nextExecutionDate;
-
-        if (trigger instanceof PollingTriggerInterface pollingTrigger) {
-            nextExecutionDate = pollingTrigger.nextEvaluationDate(conditionContext, Optional.ofNullable(triggerContext));
-        } else {
-            nextExecutionDate = ZonedDateTime.now(clock); // real-time trigger
+        if (!(trigger instanceof PollingTriggerInterface pollingTrigger)) {
+            return ZonedDateTime.now(clock); // real-time trigger
         }
-        return nextExecutionDate;
+        // Seed date=now when the context has neither a prior evaluation date nor a backfill, so
+        // Schedule takes its conditions-aware branch instead of falling back to the unconditioned
+        // next cron tick (which would ignore DayWeek/DayWeekInMonth etc. at creation time).
+        TriggerContext effectiveContext = triggerContext;
+        if (effectiveContext == null || (effectiveContext.getDate() == null && effectiveContext.getBackfill() == null)) {
+            effectiveContext = (effectiveContext != null ? effectiveContext.toBuilder() : TriggerContext.builder())
+                .date(ZonedDateTime.now(clock))
+                .build();
+        }
+        return pollingTrigger.nextEvaluationDate(conditionContext, Optional.of(effectiveContext));
     }
 
     /**
      * Computes the next evaluation date for the given trigger.
+     * <p>
+     * <b>Warning:</b> this overload ignores trigger conditions and returns the next raw cron tick.
+     * Prefer {@link #get(Clock, AbstractTrigger, TriggerContext, ConditionContext)} whenever a
+     * {@link ConditionContext} can be built — only use this overload from paths where one is
+     * genuinely unavailable (e.g. error recovery after an exception).
      *
      * @param clock the clock
      * @param trigger the trigger.

--- a/scheduler/src/test/java/io/kestra/scheduler/Fixtures.java
+++ b/scheduler/src/test/java/io/kestra/scheduler/Fixtures.java
@@ -1,5 +1,6 @@
 package io.kestra.scheduler;
 
+import java.time.DayOfWeek;
 import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.function.Function;
@@ -8,6 +9,7 @@ import io.kestra.core.models.flows.FlowWithSource;
 import io.kestra.core.models.property.Property;
 import io.kestra.core.models.triggers.AbstractTrigger;
 import io.kestra.core.models.triggers.TriggerId;
+import io.kestra.plugin.core.condition.DayWeek;
 import io.kestra.plugin.core.debug.Return;
 import io.kestra.plugin.core.trigger.Schedule;
 import io.kestra.plugin.core.trigger.ScheduleOnDates;
@@ -85,5 +87,21 @@ public interface Fixtures {
             .timezone(timeZone);
 
         return flowWithTrigger(builder.apply(schedule));
+    }
+
+    static FlowWithSource flowWithEveryMinuteScheduleOnDayWeek(String timeZone, DayOfWeek dayOfWeek) {
+        Schedule schedule = Schedule.builder()
+            .id(TEST_TRIGGER_ID)
+            .type(Schedule.class.getName())
+            .cron("*/1 * * * *")
+            .timezone(timeZone)
+            .conditions(List.of(
+                DayWeek.builder()
+                    .type(DayWeek.class.getName())
+                    .dayOfWeek(Property.ofValue(dayOfWeek))
+                    .build()
+            ))
+            .build();
+        return flowWithTrigger(schedule);
     }
 }

--- a/scheduler/src/test/java/io/kestra/scheduler/TriggerEventHandlerTest.java
+++ b/scheduler/src/test/java/io/kestra/scheduler/TriggerEventHandlerTest.java
@@ -1,11 +1,15 @@
 package io.kestra.scheduler;
 
 import java.time.Clock;
+import java.time.DayOfWeek;
 import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.Optional;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -73,6 +77,11 @@ class TriggerEventHandlerTest {
         triggerId = Fixtures.triggerId();
         triggerState = TriggerState.of(triggerId, TriggerType.SCHEDULE, null, false, 0);
         executionKilledQueue = Mockito.mock(BroadcastQueueInterface.class);
+    }
+
+    @AfterEach
+    void tearDown() {
+        SchedulerClock.setClock(Clock.systemDefaultZone());
     }
 
     TriggerEventHandler newTriggerEventHandler(List<FlowWithSource> flows) {
@@ -539,5 +548,103 @@ class TriggerEventHandlerTest {
         assertThat(updated).get().extracting(TriggerState::getBackfill).isNull();
         assertThat(updated).get().extracting(TriggerState::getNextEvaluationDate).isEqualTo(previousNextEvaluationDate.toInstant());
         assertThat(updated).get().extracting(TriggerState::getLastEventId).isEqualTo(event.eventId());
+    }
+
+    // Fixed clock on Wednesday 2024-01-03 at 10:00 in the system default zone.
+    // With cron "*/1 * * * *" + DayWeek=SUNDAY condition, the next matching tick is the next
+    // Sunday 00:00 in the Schedule's timezone (system default). The exact instant depends on
+    // the system zone, so the tests assert on day-of-week rather than a hard-coded instant.
+    private static final ZonedDateTime FIXED_WEDNESDAY = LocalDateTime.of(2024, 1, 3, 10, 0)
+        .atZone(ZoneId.systemDefault());
+
+    private Clock fixWedClock() {
+        Clock fixed = Clock.fixed(FIXED_WEDNESDAY.toInstant(), ZoneId.systemDefault());
+        SchedulerClock.setClock(fixed);
+        return fixed;
+    }
+
+    private void assertMatchesNextSunday(TriggerState state) {
+        assertThat(state.getNextEvaluationDate()).isNotNull();
+        ZonedDateTime nextZoned = state.getNextEvaluationDate().atZone(ZoneId.systemDefault());
+        assertThat(nextZoned.getDayOfWeek())
+            .as("nextEvaluationDate should fall on a SUNDAY in the schedule's timezone, but was %s", nextZoned)
+            .isEqualTo(DayOfWeek.SUNDAY);
+        assertThat(nextZoned).isAfter(FIXED_WEDNESDAY);
+    }
+
+    @Test
+    void shouldComputeNextEvaluationDateRespectingConditionsWhenTriggerCreated() {
+        // GIVEN a brand-new trigger (evaluatedAt=null) with DayWeek=SUNDAY condition, clock on Friday
+        Clock clock = fixWedClock();
+        handler = newTriggerEventHandler(List.of(Fixtures.flowWithEveryMinuteScheduleOnDayWeek(ZoneId.systemDefault().getId(), DayOfWeek.SUNDAY)));
+        TriggerCreated event = new TriggerCreated(triggerId, 0);
+
+        // WHEN
+        handler.handle(clock, TEST_VNODE, event);
+
+        // THEN persisted nextEvaluationDate falls on SUNDAY, not the next raw cron tick
+        Optional<TriggerState> saved = triggerStateStore.findById(triggerId);
+        assertThat(saved).isPresent();
+        assertMatchesNextSunday(saved.get());
+    }
+
+    @Test
+    void shouldRecomputeNextEvaluationDateRespectingConditionsWhenTriggerUpdated() {
+        // GIVEN a trigger evaluated once before the update event fires
+        Clock clock = fixWedClock();
+        triggerStateStore.save(triggerState
+            .evaluatedAt(clock, FIXED_WEDNESDAY)
+            .updateForNextEvaluationDate(clock, FIXED_WEDNESDAY.plusMinutes(1)));
+        FlowWithSource flow = Fixtures.flowWithEveryMinuteScheduleOnDayWeek(ZoneId.systemDefault().getId(), DayOfWeek.SUNDAY);
+        handler = newTriggerEventHandler(List.of(flow));
+        TriggerUpdated event = new TriggerUpdated(triggerId, flow.getRevision());
+
+        // WHEN
+        handler.handle(clock, TEST_VNODE, event);
+
+        // THEN
+        Optional<TriggerState> updated = triggerStateStore.findById(triggerId);
+        assertThat(updated).isPresent();
+        assertMatchesNextSunday(updated.get());
+    }
+
+    @Test
+    void shouldRecomputeNextEvaluationDateRespectingConditionsWhenTriggerReset() {
+        // GIVEN
+        Clock clock = fixWedClock();
+        triggerStateStore.save(triggerState
+            .evaluatedAt(clock, FIXED_WEDNESDAY)
+            .updateForNextEvaluationDate(clock, FIXED_WEDNESDAY.plusMinutes(1)));
+        handler = newTriggerEventHandler(List.of(Fixtures.flowWithEveryMinuteScheduleOnDayWeek(ZoneId.systemDefault().getId(), DayOfWeek.SUNDAY)));
+        ResetTrigger event = new ResetTrigger(triggerId);
+
+        // WHEN
+        handler.handle(clock, TEST_VNODE, event);
+
+        // THEN
+        Optional<TriggerState> updated = triggerStateStore.findById(triggerId);
+        assertThat(updated).isPresent();
+        assertMatchesNextSunday(updated.get());
+    }
+
+    @Test
+    void shouldRecomputeNextEvaluationDateRespectingConditionsWhenTriggerReEnabled() {
+        // GIVEN a trigger evaluated once before being disabled and re-enabled
+        Clock clock = fixWedClock();
+        triggerStateStore.save(triggerState
+            .evaluatedAt(clock, FIXED_WEDNESDAY)
+            .updateForNextEvaluationDate(clock, FIXED_WEDNESDAY.plusMinutes(1))
+            .disabled(clock, true));
+        handler = newTriggerEventHandler(List.of(Fixtures.flowWithEveryMinuteScheduleOnDayWeek(ZoneId.systemDefault().getId(), DayOfWeek.SUNDAY)));
+        SetDisableTrigger event = new SetDisableTrigger(triggerId, false);
+
+        // WHEN
+        handler.handle(clock, TEST_VNODE, event);
+
+        // THEN
+        Optional<TriggerState> updated = triggerStateStore.findById(triggerId);
+        assertThat(updated).isPresent();
+        assertThat(updated.get().isDisabled()).isFalse();
+        assertMatchesNextSunday(updated.get());
     }
 }

--- a/scheduler/src/test/java/io/kestra/scheduler/TriggerSchedulerTest.java
+++ b/scheduler/src/test/java/io/kestra/scheduler/TriggerSchedulerTest.java
@@ -317,6 +317,31 @@ class TriggerSchedulerTest {
     }
 
     @Test
+    void shouldStoreNextConditionMatchingDateOnFirstEvaluationWhenConditionFails() {
+        // GIVEN clock fixed on a Friday at 10:00, a */1 min cron + DayWeek=SUNDAY condition
+        ZonedDateTime friday = java.time.LocalDateTime.of(2024, 1, 5, 10, 0)
+            .atZone(ZoneId.systemDefault());
+        SchedulerClock.setClock(Clock.fixed(friday.toInstant(), ZoneId.systemDefault()));
+
+        FlowWithSource flow = Fixtures.flowWithEveryMinuteScheduleOnDayWeek(
+            ZoneId.systemDefault().getId(), DayOfWeek.SUNDAY);
+        TriggerScheduler scheduler = newTriggerScheduler(List.of(flow));
+        scheduler.onStart(SchedulerClock.getClock(), SchedulerClock.now().toInstant(), NODES_ASSIGNMENTS);
+
+        // WHEN the first cron tick fires (1 minute later)
+        SchedulerClock.offset(Duration.ofMinutes(1));
+        scheduler.onSchedule(SchedulerClock.getClock(), SchedulerClock.now().toInstant(), NODES_ASSIGNMENTS);
+
+        // THEN the condition failed (Friday ≠ Sunday) and the persisted nextEvaluationDate is on a Sunday
+        TriggerState state = triggerStateStore.findById(Fixtures.triggerId()).orElseThrow();
+        ZonedDateTime nextZoned = state.getNextEvaluationDate().atZone(ZoneId.systemDefault());
+        assertThat(nextZoned.getDayOfWeek())
+            .as("nextEvaluationDate should fall on a SUNDAY, but was %s", nextZoned)
+            .isEqualTo(DayOfWeek.SUNDAY);
+        assertThat(triggerExecutionPublisher.executions().size()).isEqualTo(0);
+    }
+
+    @Test
     void shouldRecoverMissingScheduleGivenALL() {
         // region [GIVEN]
         FlowWithSource flow = Fixtures.flowWithSchedulePT15M(

--- a/scheduler/src/test/java/io/kestra/scheduler/TriggerSchedulerTest.java
+++ b/scheduler/src/test/java/io/kestra/scheduler/TriggerSchedulerTest.java
@@ -595,6 +595,28 @@ class TriggerSchedulerTest {
     }
 
     @Test
+    void shouldDeleteOrphanTriggerStateOnScheduleGivenSoftDeletedFlow() {
+        // region [GIVEN]
+        FlowWithSource deletedFlow = Fixtures.flowWithSchedulePT15M(TEST_TZ).toDeleted();
+
+        TriggerState initialState = TriggerState
+            .of(Fixtures.triggerId(), TriggerType.SCHEDULE, List.of(), false, 0)
+            .updateForNextEvaluationDate(SchedulerClock.getClock(), SchedulerClock.now());
+        triggerStateStore.save(initialState);
+
+        TriggerScheduler scheduler = newTriggerScheduler(List.of(deletedFlow));
+        // endregion [GIVEN]
+
+        // WHEN
+        scheduler.onSchedule(SchedulerClock.getClock(), SchedulerClock.now().toInstant(), NODES_ASSIGNMENTS);
+
+        // THEN
+        TriggerState state = triggerStateStore.findById(Fixtures.triggerId()).orElse(null);
+        assertThat(state).isNull();
+        assertThat(triggerExecutionPublisher.executions().size()).isEqualTo(0);
+    }
+
+    @Test
     void shouldScheduleScheduleTriggerWithBackfill() {
         // region [GIVEN]
         FlowWithSource flow = Fixtures.flowWithSchedulePT15M(TEST_TZ);

--- a/scheduler/src/test/java/io/kestra/scheduler/utils/InMemoryTriggerStateStore.java
+++ b/scheduler/src/test/java/io/kestra/scheduler/utils/InMemoryTriggerStateStore.java
@@ -45,7 +45,7 @@ public class InMemoryTriggerStateStore implements TriggerStateStore {
 
     @Override
     public Optional<TriggerState> findById(TriggerId triggerId) {
-        return Optional.ofNullable(store.get(triggerId));
+        return Optional.ofNullable(store.get(TriggerId.of(triggerId)));
     }
 
     @Override
@@ -58,7 +58,7 @@ public class InMemoryTriggerStateStore implements TriggerStateStore {
 
     @Override
     public void delete(TriggerId triggerId) {
-        store.remove(triggerId);
+        store.remove(TriggerId.of(triggerId));
     }
 
     @Override


### PR DESCRIPTION
Trigger handlers and updateNextEvaluationDateAndGetOnSuccess were computing the next date without conditions (or with a stale TriggerContext carrying a null evaluatedAt on first evaluation), so the UI showed the next raw cron tick instead of the next condition-matching tick.

Closes: kestra-io/kestra-ee#7356
Closes: kestra-io/kestra-ee#7353