### PR TITLE
build(deps): use netty-codec-multipart-vintage again

### DIFF
--- a/webserver/build.gradle
+++ b/webserver/build.gradle
@@ -21,6 +21,10 @@ dependencies {
     implementation "io.micronaut:micronaut-management"
     implementation "io.micronaut:micronaut-http-client"
     implementation "io.micronaut:micronaut-http-server-netty"
+    // See https://github.com/netty-contrib/codec-multipart/pull/25
+    // See https://github.com/kestra-io/kestra/issues/9743
+    // There is an issue on Netty multipart content decoding that is fixed in 5.x, this library will bring the same fix for 4.x
+    implementation("io.netty.contrib:netty-codec-multipart-vintage:1.0.0.Final")
     implementation "io.micronaut.cache:micronaut-cache-core"
     implementation "io.micronaut.cache:micronaut-cache-caffeine"
 


### PR DESCRIPTION
### ✨ Description

Try using the Netty fix again as the used Micronaut version is now 4.10.11.

Backporting this potential fix to previous version(s) would be appreciated.

### 🔗 Related Issue

Relates to #13733
Fixes #9743

### 🛠️ Backend Checklist

- [x] Code compiles successfully and passes all checks
- [x] All unit and integration tests pass

### 📝 Additional Notes

The previously failing `importFlowsWithZip()` test passes correctly.
