### PR TITLE
feat(jdbc): support delete/purge/purgebycondition inside AbstractJdbcCrudRepository for central use

### DIFF
--- a/core/src/main/java/io/kestra/core/repositories/ExecutionRepositoryInterface.java
+++ b/core/src/main/java/io/kestra/core/repositories/ExecutionRepositoryInterface.java
@@ -110,7 +110,7 @@ public interface ExecutionRepositoryInterface extends QueryBuilderInterface<Exec
     @VisibleForTesting
     Execution delete(Execution execution);
 
-    Integer purge(Execution execution);
+    boolean purge(Execution execution);
 
     Integer purge(List<Execution> executions);
 

--- a/jdbc/src/main/java/io/kestra/jdbc/repository/AbstractJdbcCrudRepository.java
+++ b/jdbc/src/main/java/io/kestra/jdbc/repository/AbstractJdbcCrudRepository.java
@@ -145,28 +145,44 @@ public abstract class AbstractJdbcCrudRepository<T> extends AbstractJdbcReposito
     }
 
     /**
-     * Hard-delete an item from the database
-     * Use this for physical purge operations.
+     * Hard-delete an item from the database.
+     * Use this for physical purge operations on a single item.
      *
      * @param item the item to purge.
+     * @return {@code true} if the item was deleted, {@code false} if it was not found.
      */
-    public Integer purge(T item) {
-        return this.jdbcRepository.delete(item);
+    public boolean purge(T item) {
+        return this.jdbcRepository.delete(item) > 0;
     }
 
     /**
-     * Hard-delete all items matching the given condition within a transaction context.
-     * Use this for bulk purge operations.
+     * Hard-delete all items matching the given condition for the given tenant.
      *
-     * @param context   the DSL context (transaction-aware).
+     * @param tenantId  the tenant ID used to build the default filter.
      * @param condition the condition to match items for deletion.
      * @return the number of deleted rows.
      */
-    protected Integer purgeByCondition(DSLContext context, Condition condition) {
-        return context
-            .delete(this.jdbcRepository.getTable())
-            .where(condition)
-            .execute();
+    protected Integer purge(String tenantId, Condition condition) {
+        return purge(defaultFilter(tenantId), condition);
+    }
+
+    /**
+     * Hard-delete all items matching the given conditions.
+     *
+     * @param defaultFilter the base filter condition (e.g. tenant isolation).
+     * @param condition     the condition to match items for deletion.
+     * @return the number of deleted rows.
+     */
+    protected Integer purge(Condition defaultFilter, Condition condition) {
+        return this.jdbcRepository
+            .getDslContextWrapper()
+            .transactionResult(configuration ->
+                DSL.using(configuration)
+                    .delete(this.jdbcRepository.getTable())
+                    .where(defaultFilter)
+                    .and(condition)
+                    .execute()
+            );
     }
 
     /**

--- a/jdbc/src/main/java/io/kestra/jdbc/repository/AbstractJdbcCrudRepository.java
+++ b/jdbc/src/main/java/io/kestra/jdbc/repository/AbstractJdbcCrudRepository.java
@@ -24,7 +24,7 @@ import reactor.core.publisher.FluxSink;
  * If the child repository uses a default filter, it should override it.
  * <p>
  * For example, to avoid supporting allowDeleted:
- * 
+ *
  * <pre>
  * {@code
  * &#64;Override
@@ -122,6 +122,51 @@ public abstract class AbstractJdbcCrudRepository<T> extends AbstractJdbcReposito
     public void deleteWithoutAcl(T item) {
         T deleted = (T) ((SoftDeletable<?>) item).toDeleted();
         this.jdbcRepository.persist(deleted);
+    }
+
+    /**
+     * Delete an item.
+     * If the entity implements {@link SoftDeletable}, it will be soft-deleted
+     * Otherwise, it will be hard-deleted
+     *
+     * @param item the item to delete.
+     * @return the deleted item.
+     */
+    @SuppressWarnings("unchecked")
+    public T delete(T item) {
+        if (item instanceof SoftDeletable<?> softDeletable) {
+            T deleted = (T) softDeletable.toDeleted();
+            this.jdbcRepository.persist(deleted);
+            return deleted;
+        }
+
+        this.jdbcRepository.delete(item);
+        return item;
+    }
+
+    /**
+     * Hard-delete an item from the database
+     * Use this for physical purge operations.
+     *
+     * @param item the item to purge.
+     */
+    public Integer purge(T item) {
+        return this.jdbcRepository.delete(item);
+    }
+
+    /**
+     * Hard-delete all items matching the given condition within a transaction context.
+     * Use this for bulk purge operations.
+     *
+     * @param context   the DSL context (transaction-aware).
+     * @param condition the condition to match items for deletion.
+     * @return the number of deleted rows.
+     */
+    protected Integer purgeByCondition(DSLContext context, Condition condition) {
+        return context
+            .delete(this.jdbcRepository.getTable())
+            .where(condition)
+            .execute();
     }
 
     /**

--- a/jdbc/src/main/java/io/kestra/jdbc/repository/AbstractJdbcExecutionRepository.java
+++ b/jdbc/src/main/java/io/kestra/jdbc/repository/AbstractJdbcExecutionRepository.java
@@ -710,10 +710,10 @@ public abstract class AbstractJdbcExecutionRepository extends AbstractJdbcCrudRe
     }
 
     @Override
-    public Integer purge(Execution execution) {
-        int delete = this.jdbcRepository.delete(execution);
+    public boolean purge(Execution execution) {
+        boolean deleted = this.jdbcRepository.delete(execution) > 0;
         eventPublisher.publishEvent(CrudEvent.delete(execution));
-        return delete;
+        return deleted;
     }
 
     @Override

--- a/jdbc/src/main/java/io/kestra/jdbc/repository/AbstractJdbcKvMetadataRepository.java
+++ b/jdbc/src/main/java/io/kestra/jdbc/repository/AbstractJdbcKvMetadataRepository.java
@@ -93,6 +93,11 @@ public abstract class AbstractJdbcKvMetadataRepository extends AbstractJdbcCrudR
     }
 
     @Override
+    public PersistedKvMetadata delete(PersistedKvMetadata persistedKvMetadata) {
+        return this.save(persistedKvMetadata.toDeleted());
+    }
+
+    @Override
     public Integer purge(List<PersistedKvMetadata> persistedKvsMetadata) {
         return this.jdbcRepository
             .getDslContextWrapper()

--- a/jdbc/src/main/java/io/kestra/jdbc/repository/AbstractJdbcLogRepository.java
+++ b/jdbc/src/main/java/io/kestra/jdbc/repository/AbstractJdbcLogRepository.java
@@ -173,22 +173,12 @@ public abstract class AbstractJdbcLogRepository extends AbstractJdbcCrudReposito
 
     @Override
     public Integer purge(Execution execution) {
-        return this.jdbcRepository.getDslContextWrapper().transactionResult(configuration ->
-        {
-            DSLContext context = DSL.using(configuration);
-
-            return context.delete(this.jdbcRepository.getTable()).where(field("execution_id", String.class).eq(execution.getId())).execute();
-        });
+        return purge(DSL.noCondition(), field("execution_id", String.class).eq(execution.getId()));
     }
 
     @Override
     public Integer purge(List<Execution> executions) {
-        return this.jdbcRepository.getDslContextWrapper().transactionResult(configuration ->
-        {
-            DSLContext context = DSL.using(configuration);
-
-            return context.delete(this.jdbcRepository.getTable()).where(field("execution_id", String.class).in(executions.stream().map(Execution::getId).toList())).execute();
-        });
+        return purge(DSL.noCondition(), field("execution_id", String.class).in(executions.stream().map(Execution::getId).toList()));
     }
 
     @Override

--- a/jdbc/src/main/java/io/kestra/jdbc/repository/AbstractJdbcMetricRepository.java
+++ b/jdbc/src/main/java/io/kestra/jdbc/repository/AbstractJdbcMetricRepository.java
@@ -175,31 +175,12 @@ public abstract class AbstractJdbcMetricRepository extends AbstractJdbcCrudRepos
 
     @Override
     public Integer purge(Execution execution) {
-        return this.jdbcRepository
-
-            .getDslContextWrapper()
-            .transactionResult(configuration ->
-            {
-                DSLContext context = DSL.using(configuration);
-
-                return context.delete(this.jdbcRepository.getTable())
-                    .where(field("execution_id", String.class).eq(execution.getId()))
-                    .execute();
-            });
+        return purge(DSL.noCondition(), field("execution_id", String.class).eq(execution.getId()));
     }
 
     @Override
     public Integer purge(List<Execution> executions) {
-        return this.jdbcRepository
-            .getDslContextWrapper()
-            .transactionResult(configuration ->
-            {
-                DSLContext context = DSL.using(configuration);
-
-                return context.delete(this.jdbcRepository.getTable())
-                    .where(field("execution_id", String.class).in(executions.stream().map(Execution::getId).toList()))
-                    .execute();
-            });
+        return purge(DSL.noCondition(), field("execution_id", String.class).in(executions.stream().map(Execution::getId).toList()));
     }
 
     @Override


### PR DESCRIPTION
### ✨ Description

This PR adds 3 new methods to `AbstractJdbcCrudRepository` to provide a unified deletion mechanism across all JDBC repositories.

- **`delete(T item)`** - Soft-deletes the entity if it implements `SoftDeletable` (persists with `deleted = true`), otherwise hard-deletes it. Returns the deleted item in both cases. Child repositories that need existence validation or `CrudEvent` publishing can override this method.

- **`purge(T item)`** - Always hard-deletes the entity regardless of `SoftDeletable`. Returns the number of deleted rows. Child repositories that need `CrudEvent` publishing can override this method.

- **`purgeByCondition(DSLContext context, Condition condition)`** - Bulk hard-delete by condition. Centralizes the raw `context.delete().where().execute()` pattern currently repeated across multiple repositories.

**Existing overrides (unaffected):**
- `AbstractJdbcExecutionRepository.delete()` overrides base `delete()` - adds existence validation via `findById` and fires `CrudEvent.delete()`
- `AbstractJdbcExecutionRepository.purge()` overrides base `purge()` - additionally fires `CrudEvent.delete()`
- `AbstractJdbcFlowRepository.deleteWithoutAcl()` remains unchanged - has its own flow-specific deletion logic

**Repositories not yet using the new methods:**
- `AbstractJdbcSettingRepository`, `AbstractJdbcServiceInstanceRepository`, and `AbstractJdbcLockRepository` still call `this.jdbcRepository.delete()` directly instead of the new base `delete()` method
- `AbstractJdbcLogRepository`, `AbstractJdbcMetricRepository`, and `AbstractJdbcFlowTopologyRepository` still use raw `context.delete().where().execute()` directly instead of the new `purgeByCondition()` (new method)

Closes https://github.com/kestra-io/kestra/issues/13001

### 🛠️ Backend Checklist

- [X] Code compiles successfully and passes all checks
- [X] All unit and integration tests pass

### 📝 Additional Notes

I left the `purgeByCondition` implementation unchanged in this PR to keep the scope focused. Migrating them to use the new base methods can be done incrementally in follow-up PRs without any risk of breaking existing behavior (Or will do in here if needed now!)
