### PR TITLE
fix(build): add archunit dependency to tests module

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -239,8 +239,6 @@ subprojects {subProj ->
             //assertj
             testImplementation 'org.assertj:assertj-core'
 
-            testImplementation "com.tngtech.archunit:archunit-junit5"
-
             // awaitility
             testImplementation 'org.awaitility:awaitility'
 

--- a/tests/build.gradle
+++ b/tests/build.gradle
@@ -16,4 +16,6 @@ dependencies {
     api 'org.hamcrest:hamcrest-library:3.0'
     api 'org.mockito:mockito-junit-jupiter'
     api 'org.assertj:assertj-core:3.27.7'
+
+    testImplementation "com.tngtech.archunit:archunit-junit5"
 }


### PR DESCRIPTION
- `:tests:compileTestJava` fails on `develop` — ArchUnit symbols (`ArchRule`, `ArchTest`, `ImportOption`) unresolved in `BaseArchitectureTest.java`
- Fix: add `testImplementation "com.tngtech.archunit:archunit-junit5"` to `tests/build.gradle`