### PR TITLE
fix(ai): add isAiApiKeyConfigured flag to config and gate App/Test copilot

### DIFF
--- a/openapi.yml
+++ b/openapi.yml
@@ -9868,6 +9868,8 @@ components:
             type: string
         isAiEnabled:
           type: boolean
+        isAiApiKeyConfigured:
+          type: boolean
         isBasicAuthInitialized:
           type: boolean
         pluginsHash:

--- a/webserver/src/main/java/io/kestra/webserver/controllers/api/MiscController.java
+++ b/webserver/src/main/java/io/kestra/webserver/controllers/api/MiscController.java
@@ -23,6 +23,7 @@ import io.kestra.core.utils.EditionProvider;
 import io.kestra.core.utils.VersionProvider;
 import io.kestra.webserver.services.BasicAuthCredentials;
 import io.kestra.webserver.services.BasicAuthService;
+import io.kestra.webserver.services.ai.AiServiceManager;
 
 import io.micronaut.context.ApplicationContext;
 import io.micronaut.core.annotation.Nullable;
@@ -69,6 +70,9 @@ public class MiscController {
 
     @Inject
     Optional<TemplateRepositoryInterface> templateRepository;
+
+    @Inject
+    Optional<AiServiceManager> aiServiceManager = Optional.empty();
 
     @Inject
     KestraConfig kestraConfig;
@@ -138,6 +142,7 @@ public class MiscController {
                     .build()
             )
             .isAiEnabled(applicationContext.containsBean(AiController.class))
+            .isAiApiKeyConfigured(aiServiceManager.map(AiServiceManager::hasConfiguredProvider).orElse(false))
             .isBasicAuthInitialized(basicAuthService.map(BasicAuthService::isBasicAuthInitialized).orElse(false))
             .systemNamespace(kestraConfig.getSystemFlowNamespace())
             .hiddenLabelsPrefixes(hiddenLabelsPrefixes)
@@ -244,6 +249,8 @@ public class MiscController {
         List<String> hiddenLabelsPrefixes;
 
         Boolean isAiEnabled;
+
+        Boolean isAiApiKeyConfigured;
 
         Boolean isBasicAuthInitialized;
 

--- a/webserver/src/main/java/io/kestra/webserver/services/ai/AiServiceManager.java
+++ b/webserver/src/main/java/io/kestra/webserver/services/ai/AiServiceManager.java
@@ -29,6 +29,7 @@ public class AiServiceManager {
     private final Map<String, AiServiceInterface> aiServices = new HashMap<>();
     private final AiProvidersConfiguration providersConfiguration;
     private String defaultProviderId;
+    private boolean hasConfiguredProvider = false;
     protected final NamespaceContextTool namespaceContextTool;
 
     public AiServiceManager(
@@ -87,6 +88,7 @@ public class AiServiceManager {
                     defaultProviderId = provider.id();
                 }
                 aiServices.put(provider.id(), aiService);
+                hasConfiguredProvider = true;
             }
         } else {
             try {
@@ -158,5 +160,9 @@ public class AiServiceManager {
 
     public String getDefaultProviderId() {
         return defaultProviderId;
+    }
+
+    public boolean hasConfiguredProvider() {
+        return hasConfiguredProvider;
     }
 }

--- a/webserver/src/test/java/io/kestra/webserver/controllers/api/MiscControllerTest.java
+++ b/webserver/src/test/java/io/kestra/webserver/controllers/api/MiscControllerTest.java
@@ -95,6 +95,7 @@ class MiscControllerTest {
         assertThat(response.getIsAiEnabled()).isTrue();
         assertThat(response.getSystemNamespace()).isEqualTo("some.system.ns");
         assertThat(response.getIsConcurrencyViewEnabled()).isTrue();
+        assertThat(response.getIsAiApiKeyConfigured()).isNotNull();
     }
 
     @Test

--- a/webserver/src/test/java/io/kestra/webserver/services/ai/AiServiceManagerTest.java
+++ b/webserver/src/test/java/io/kestra/webserver/services/ai/AiServiceManagerTest.java
@@ -1,0 +1,95 @@
+package io.kestra.webserver.services.ai;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import io.kestra.core.docs.JsonSchemaGenerator;
+import io.kestra.core.plugins.PluginRegistry;
+import io.kestra.core.services.InstanceService;
+import io.kestra.core.utils.VersionProvider;
+import io.kestra.webserver.services.posthog.PosthogService;
+
+import io.micronaut.core.value.PropertyResolver;
+import io.micronaut.http.client.HttpClient;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class AiServiceManagerTest {
+
+    @Mock
+    HttpClient apiHttpClient;
+    @Mock
+    io.micronaut.http.client.BlockingHttpClient blockingHttpClient;
+    @Mock
+    AiProvidersConfiguration providersConfiguration;
+    @Mock
+    PropertyResolver propertyResolver;
+    @Mock
+    PluginRegistry pluginRegistry;
+    @Mock
+    JsonSchemaGenerator jsonSchemaGenerator;
+    @Mock
+    VersionProvider versionProvider;
+    @Mock
+    InstanceService instanceService;
+    @Mock
+    PosthogService posthogService;
+    @Mock
+    NamespaceContextTool namespaceContextTool;
+
+    private AiServiceManager buildManager(List<AiProviderConfiguration> providers) {
+        when(providersConfiguration.providers()).thenReturn(providers);
+
+        return new AiServiceManager(
+            apiHttpClient,
+            providersConfiguration,
+            propertyResolver,
+            pluginRegistry,
+            jsonSchemaGenerator,
+            versionProvider,
+            instanceService,
+            posthogService,
+            List.of(),
+            namespaceContextTool
+        );
+    }
+
+    @Test
+    void hasConfiguredProviderShouldBeFalseWhenNoProvidersConfigured() {
+        when(apiHttpClient.toBlocking()).thenReturn(blockingHttpClient);
+
+        AiServiceManager manager = buildManager(null);
+
+        assertThat(manager.hasConfiguredProvider()).isFalse();
+    }
+
+    @Test
+    void hasConfiguredProviderShouldBeFalseWhenProviderListEmpty() {
+        when(apiHttpClient.toBlocking()).thenReturn(blockingHttpClient);
+
+        AiServiceManager manager = buildManager(List.of());
+
+        assertThat(manager.hasConfiguredProvider()).isFalse();
+    }
+
+    @Test
+    void hasConfiguredProviderShouldBeTrueWhenGeminiProviderConfigured() {
+        AiProviderConfiguration geminiProvider = new AiProviderConfiguration(
+            "gemini-test",
+            "Gemini",
+            "gemini",
+            true,
+            java.util.Map.of("modelName", "gemini-2.5-flash", "apiKey", "fake-key")
+        );
+
+        AiServiceManager manager = buildManager(List.of(geminiProvider));
+
+        assertThat(manager.hasConfiguredProvider()).isTrue();
+    }
+}


### PR DESCRIPTION
Backport of #15590 to `releases/v1.3.x`.

- Add `hasConfiguredProvider()` to `AiServiceManager` — true only when a real provider (not the free-tier fallback `ApiAiService`) is successfully created
- Expose `isAiApiKeyConfigured` in `GET /api/v1/configs` response

Note: `AiCopilotWrapper.vue` frontend change excluded — that component doesn't exist in `releases/v1.3.x`.

Companion EE backport: kestra-io/kestra-ee#7489