### PR TITLE
fix(tests): replace sampletestfile.com with embedded server

### DIFF
--- a/core/src/test/java/io/kestra/plugin/core/http/DownloadTest.java
+++ b/core/src/test/java/io/kestra/plugin/core/http/DownloadTest.java
@@ -1,7 +1,6 @@
 package io.kestra.plugin.core.http;
 
 import java.io.IOException;
-import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 
@@ -36,7 +35,8 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @KestraTest
 class DownloadTest {
-    public static final String FILE = "https://sampletestfile.com/wp-content/uploads/2023/07/500KB-CSV.csv";
+    private static final String CSV_CONTENT = "id,name,value\n1,foo,100\n2,bar,200\n3,baz,300\n";
+
     @Inject
     private TestRunContextFactory runContextFactory;
 
@@ -48,10 +48,15 @@ class DownloadTest {
 
     @Test
     void run() throws Exception {
+        EmbeddedServer embeddedServer = applicationContext.getBean(EmbeddedServer.class);
+        embeddedServer.start();
+
+        String url = embeddedServer.getURI() + "/sample.csv";
+
         Download task = Download.builder()
             .id(DownloadTest.class.getSimpleName())
             .type(DownloadTest.class.getName())
-            .uri(Property.ofValue(FILE))
+            .uri(Property.ofValue(url))
             .build();
 
         RunContext runContext = TestsUtils.mockRunContext(this.runContextFactory, task, ImmutableMap.of());
@@ -59,7 +64,7 @@ class DownloadTest {
         Download.Output output = task.run(runContext);
 
         assertThat(IOUtils.toString(this.storageInterface.get(MAIN_TENANT, null, output.getUri()), StandardCharsets.UTF_8))
-            .isEqualTo(IOUtils.toString(new URI(FILE).toURL().openStream(), StandardCharsets.UTF_8));
+            .isEqualTo(CSV_CONTENT);
         assertThat(output.getUri().toString()).endsWith(".csv");
     }
 
@@ -278,6 +283,12 @@ class DownloadTest {
 
     @Controller()
     public static class SlackWebController {
+        @Get("sample.csv")
+        public HttpResponse<byte[]> csv() {
+            return HttpResponse.ok(CSV_CONTENT.getBytes(StandardCharsets.UTF_8))
+                .contentType(io.micronaut.http.MediaType.TEXT_CSV_TYPE);
+        }
+
         @Get("500")
         public HttpResponse<String> error() {
             return HttpResponse.serverError();

--- a/core/src/test/java/io/kestra/plugin/core/http/RequestTest.java
+++ b/core/src/test/java/io/kestra/plugin/core/http/RequestTest.java
@@ -95,21 +95,26 @@ class RequestTest {
 
     @Test
     void head() throws Exception {
-        final String url = "https://sampletestfile.com/wp-content/uploads/2023/07/500KB-CSV.csv";
+        try (
+            ApplicationContext applicationContext = ApplicationContext.run();
+            EmbeddedServer server = applicationContext.getBean(EmbeddedServer.class).start();
+        ) {
+            String url = server.getURL().toString() + "/headonly";
 
-        Request task = Request.builder()
-            .id(RequestTest.class.getSimpleName())
-            .type(RequestTest.class.getName())
-            .uri(Property.ofValue(url))
-            .method(Property.ofValue("HEAD"))
-            .build();
+            Request task = Request.builder()
+                .id(RequestTest.class.getSimpleName())
+                .type(RequestTest.class.getName())
+                .uri(Property.ofValue(url))
+                .method(Property.ofValue("HEAD"))
+                .build();
 
-        RunContext runContext = TestsUtils.mockRunContext(this.runContextFactory, task, ImmutableMap.of());
+            RunContext runContext = TestsUtils.mockRunContext(this.runContextFactory, task, ImmutableMap.of());
 
-        Request.Output output = task.run(runContext);
+            Request.Output output = task.run(runContext);
 
-        assertThat(output.getUri()).isEqualTo(URI.create(url));
-        assertThat(output.getHeaders().get("content-length").getFirst()).isEqualTo("512789");
+            assertThat(output.getUri()).isEqualTo(URI.create(url));
+            assertThat(output.getCode()).isEqualTo(200);
+        }
     }
 
     @Test
@@ -853,6 +858,11 @@ class RequestTest {
 
         @Head("/hello")
         HttpResponse<String> head() {
+            return HttpResponse.ok();
+        }
+
+        @Head("/headonly")
+        HttpResponse<Void> headonly() {
             return HttpResponse.ok();
         }
 


### PR DESCRIPTION
- `sampletestfile.com` is down, breaking `DownloadTest.run()` and `RequestTest.head()`
- Replaced external HTTP calls with the Micronaut embedded server already used by other tests in the same classes
- Tests are now self-contained and won't break when external sites go down
