### PR TITLE
fix(core): strip null bytes from JSONB values before PostgreSQL insert

### DIFF
--- a/jdbc-postgres/src/main/java/io/kestra/repository/postgres/PostgresRepository.java
+++ b/jdbc-postgres/src/main/java/io/kestra/repository/postgres/PostgresRepository.java
@@ -17,6 +17,7 @@ import org.jooq.SelectConditionStep;
 import org.jooq.impl.DSL;
 
 import io.kestra.core.repositories.ArrayListTotal;
+import io.kestra.jdbc.JdbcJsonbUtils;
 import io.kestra.jdbc.JdbcTableConfig;
 import io.kestra.jdbc.JooqDSLContextWrapper;
 
@@ -60,7 +61,7 @@ public class PostgresRepository<T> extends io.kestra.jdbc.AbstractJdbcRepository
     public Map<Field<Object>, Object> persistFields(T entity) {
         String json = MAPPER.writeValueAsString(entity);
         Map<Field<Object>, Object> fields = HashMap.newHashMap(1);
-        fields.put(VALUE_FIELD, DSL.val(JSONB.valueOf(json)));
+        fields.put(VALUE_FIELD, DSL.val(JdbcJsonbUtils.valueOf(json)));
         return fields;
     }
 

--- a/jdbc/src/main/java/io/kestra/jdbc/JdbcJsonbUtils.java
+++ b/jdbc/src/main/java/io/kestra/jdbc/JdbcJsonbUtils.java
@@ -1,0 +1,14 @@
+package io.kestra.jdbc;
+
+import org.jooq.JSONB;
+
+/**
+ * Strips PostgreSQL-incompatible null bytes from JSONB payloads.
+ */
+public final class JdbcJsonbUtils {
+    private JdbcJsonbUtils() {}
+
+    public static JSONB valueOf(String json) {
+        return json == null ? null : JSONB.valueOf(json.replace("\u0000", ""));
+    }
+}

--- a/jdbc/src/test/java/io/kestra/jdbc/JdbcJsonbUtilsTest.java
+++ b/jdbc/src/test/java/io/kestra/jdbc/JdbcJsonbUtilsTest.java
@@ -1,0 +1,53 @@
+package io.kestra.jdbc;
+
+import org.jooq.JSONB;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class JdbcJsonbUtilsTest {
+    @Test
+    void shouldReturnNullForNullInput() {
+        assertThat(JdbcJsonbUtils.valueOf(null)).isNull();
+    }
+
+    @Test
+    void shouldStripNullBytes() {
+        // Given
+        String jsonWithNullBytes = "{\"key\":\"value\u0000with\u0000nulls\"}";
+
+        // When
+        JSONB result = JdbcJsonbUtils.valueOf(jsonWithNullBytes);
+
+        // Then
+        assertThat(result).isNotNull();
+        assertThat(result.data()).isEqualTo("{\"key\":\"valuewithnulls\"}");
+        assertThat(result.data()).doesNotContain("\u0000");
+    }
+
+    @Test
+    void shouldLeaveCleanJsonUnchanged() {
+        // Given
+        String cleanJson = "{\"key\":\"value\",\"number\":42}";
+
+        // When
+        JSONB result = JdbcJsonbUtils.valueOf(cleanJson);
+
+        // Then
+        assertThat(result).isNotNull();
+        assertThat(result.data()).isEqualTo(cleanJson);
+    }
+
+    @Test
+    void shouldHandleJsonWithOnlyNullByte() {
+        // Given
+        String onlyNullByte = "\u0000";
+
+        // When
+        JSONB result = JdbcJsonbUtils.valueOf(onlyNullByte);
+
+        // Then
+        assertThat(result).isNotNull();
+        assertThat(result.data()).isEmpty();
+    }
+}

--- a/queue-jdbc/src/main/java/io/kestra/queue/jdbc/client/JdbcQueueClient.java
+++ b/queue-jdbc/src/main/java/io/kestra/queue/jdbc/client/JdbcQueueClient.java
@@ -18,6 +18,7 @@ import org.jooq.impl.DSL;
 import io.kestra.core.queues.QueueException;
 import io.kestra.core.queues.UnsupportedMessageException;
 import io.kestra.jdbc.AbstractJdbcRepository;
+import io.kestra.jdbc.JdbcJsonbUtils;
 import io.kestra.jdbc.JdbcQueueItem;
 import io.kestra.jdbc.JooqDSLContextWrapper;
 import io.kestra.jdbc.runner.JdbcQueueConfiguration;
@@ -95,7 +96,7 @@ public class JdbcQueueClient {
                 fields.put(field("type"), queueNameToType(queue));
                 fields.put(field("routing_key"), (routingKey == null || routingKey.isEmpty()) ? null : routingKey);
                 fields.put(field("key"), key);
-                fields.put(field("value"), JSONB.valueOf(value));
+                fields.put(field("value"), JdbcJsonbUtils.valueOf(value));
                 fields.put(field("created"), Instant.now());
 
                 var insert = context
@@ -154,7 +155,7 @@ public class JdbcQueueClient {
                         queueNameToType(entry.queue),
                         (entry.routingKey == null || entry.routingKey.isEmpty()) ? null : entry.routingKey,
                         entry.key,
-                        JSONB.valueOf(entry.value),
+                        JdbcJsonbUtils.valueOf(entry.value),
                         now
                     );
                 }


### PR DESCRIPTION
- PostgreSQL rejects JSONB payloads containing `\u0000` null bytes. Previously, we caught the error after the fact in `JdbcQueueClient` and threw `UnsupportedMessageException`, losing the message.
- Introduces `JdbcJsonbUtils.valueOf()` which proactively strips null bytes before creating `JSONB` values, applied at all 3 call sites (`PostgresRepository`, `JdbcQueueClient` single + batch publish)