### PR TITLE
chore(system): only remove worker job running for worker tasks

### DIFF
--- a/executor/src/main/java/io/kestra/executor/ExecutorService.java
+++ b/executor/src/main/java/io/kestra/executor/ExecutorService.java
@@ -62,9 +62,6 @@ public class ExecutorService {
     private WorkerGroupMetaStore workerGroupMetaStore;
 
     @Inject
-    private WorkerJobRunningStateStore workerJobRunningStateStore;
-
-    @Inject
     protected FlowMetaStoreInterface flowExecutorInterface;
 
     @Inject
@@ -1281,7 +1278,6 @@ public class ExecutorService {
         executor.withExecution(newExecution, "addWorkerTaskResult");
         if (taskRun.getState().isTerminated()) {
             log.trace("TaskRun terminated: {}", taskRun);
-            workerJobRunningStateStore.deleteByKey(taskRun.getId());
             metricRegistry
                 .counter(
                     MetricRegistry.METRIC_EXECUTOR_TASKRUN_ENDED_COUNT,

--- a/worker-controller/src/main/java/io/kestra/controller/grpc/services/GrpcWorkerControllerService.java
+++ b/worker-controller/src/main/java/io/kestra/controller/grpc/services/GrpcWorkerControllerService.java
@@ -174,6 +174,9 @@ public class GrpcWorkerControllerService extends WorkerControllerServiceGrpc.Wor
         {
             try {
                 workerTaskResultQueue.emit(workerTaskResult);
+
+                // remove the worker job running as the task has been done by the worker and the result send to the queue
+                workerJobRunningStateStore.deleteByKey(workerTaskResult.getTaskRun().getId());
             } catch (QueueException e) {
                 // If there is a QueueException it can either be caused by the message limit or another queue issue.
                 // We fail the task and try to resend it.
@@ -191,6 +194,9 @@ public class GrpcWorkerControllerService extends WorkerControllerServiceGrpc.Wor
                 contextLogger.logger().error("Unable to emit the worker task result to the queue: {}", e.getMessage(), e);
                 try {
                     this.workerTaskResultQueue.emit(failed);
+
+                    // remove the worker job running as the task has been done by the worker and the result send to the queue
+                    workerJobRunningStateStore.deleteByKey(failed.getTaskRun().getId());
                 } catch (QueueException ex) {
                     log.error("Unable to emit the worker task result for task {} taskrun {}", failed.getTaskRun().getTaskId(), failed.getTaskRun().getId(), e);
                 }


### PR DESCRIPTION
The method where it was, were also used for flowable tasks which didn't have any worker_job_running.

Moving the removal inside the WorkerTaskResultMessageHandler avoid sending DELETE request that would never delete anything to the database.