### PR TITLE
fix(worker): route null or blank workerGroup.key to the default worker group

### DIFF
--- a/core/src/main/java/io/kestra/core/models/tasks/WorkerGroup.java
+++ b/core/src/main/java/io/kestra/core/models/tasks/WorkerGroup.java
@@ -26,6 +26,17 @@ public class WorkerGroup {
      * @return formatted worker group
      */
     public static String forLog(String workerGroup) {
-        return workerGroup == null || workerGroup.isEmpty() ? "(default)" : workerGroup;
+        return isDefault(workerGroup) ? "(default)" : workerGroup;
+    }
+
+    /**
+     * A worker-group key refers to the default (unnamed) worker group when it is
+     * {@code null} or blank.
+     *
+     * @param key the worker-group key to test
+     * @return {@code true} when the key refers to the default worker group
+     */
+    public static boolean isDefault(String key) {
+        return key == null || key.isBlank();
     }
 }

--- a/core/src/test/java/io/kestra/core/models/tasks/WorkerGroupTest.java
+++ b/core/src/test/java/io/kestra/core/models/tasks/WorkerGroupTest.java
@@ -1,0 +1,40 @@
+package io.kestra.core.models.tasks;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class WorkerGroupTest {
+
+    @Test
+    void isDefaultShouldReturnTrueForNullKey() {
+        assertThat(WorkerGroup.isDefault(null)).isTrue();
+    }
+
+    @Test
+    void isDefaultShouldReturnTrueForEmptyKey() {
+        assertThat(WorkerGroup.isDefault("")).isTrue();
+    }
+
+    @Test
+    void isDefaultShouldReturnTrueForBlankKey() {
+        assertThat(WorkerGroup.isDefault("   ")).isTrue();
+    }
+
+    @Test
+    void isDefaultShouldReturnFalseForNamedKey() {
+        assertThat(WorkerGroup.isDefault("my-group")).isFalse();
+    }
+
+    @Test
+    void forLogShouldReturnDefaultPlaceholderForNullOrBlank() {
+        assertThat(WorkerGroup.forLog(null)).isEqualTo("(default)");
+        assertThat(WorkerGroup.forLog("")).isEqualTo("(default)");
+        assertThat(WorkerGroup.forLog("  ")).isEqualTo("(default)");
+    }
+
+    @Test
+    void forLogShouldReturnKeyWhenNamed() {
+        assertThat(WorkerGroup.forLog("my-group")).isEqualTo("my-group");
+    }
+}

--- a/executor/src/main/java/io/kestra/executor/ExecutorService.java
+++ b/executor/src/main/java/io/kestra/executor/ExecutorService.java
@@ -928,6 +928,10 @@ public class ExecutorService {
                     // Check if the worker group exist
                     String tenantId = executor.getFlow().getTenantId();
                     String workerGroupKey = runContext.render(workerGroup.get().getKey());
+                    if (WorkerGroup.isDefault(workerGroupKey)) {
+                        // Explicit default worker group - dispatch without existence check
+                        return new ExecutorContext.ExecutorWorkerTask(workerTask, runContext);
+                    }
                     if (workerGroupMetaStore.isWorkerGroupExistForKey(workerGroupKey, tenantId)) {
                         // Check whether at-least one worker is available
                         if (workerGroupMetaStore.isWorkerGroupAvailableForKey(workerGroupKey)) {

--- a/scheduler/src/main/java/io/kestra/scheduler/pubsub/TriggerWorkerJobPublisher.java
+++ b/scheduler/src/main/java/io/kestra/scheduler/pubsub/TriggerWorkerJobPublisher.java
@@ -68,6 +68,11 @@ public class TriggerWorkerJobPublisher {
                 String tenantId = triggerState.getTenantId();
                 RunContext runContext = conditionContext.getRunContext();
                 String workerGroupKey = runContext.render(workerGroup.get().getKey());
+                if (WorkerGroup.isDefault(workerGroupKey)) {
+                    // Explicit default worker group - dispatch without existence check
+                    this.workerJobEventQueue.emit(null, WorkerJobEvent.of(workerTrigger, null));
+                    return;
+                }
                 if (workerGroupMetaStore.isWorkerGroupExistForKey(workerGroupKey, tenantId)) {
                     // Check whether at-least one worker is available
                     if (workerGroupMetaStore.isWorkerGroupAvailableForKey(workerGroupKey)) {


### PR DESCRIPTION
Empty or null keys now short-circuit to the default worker-group.

Related-to: kestra-io/kestra-ee#6629