### PR TITLE
fix: remove invalid tenant field from flow overview chart filters

### DIFF
--- a/ui/src/components/executions/overview/Overview.vue
+++ b/ui/src/components/executions/overview/Overview.vue
@@ -459,15 +459,6 @@
         if (!execution.value) return [];
 
         return [
-            ...(execution.value.tenantId
-                ? [
-                    {
-                        field: "tenant",
-                        operation: "EQUALS",
-                        value: execution.value.tenantId,
-                    },
-                ]
-                : []),
             {
                 field: "namespace",
                 operation: "EQUALS",


### PR DESCRIPTION
✨ Description
                                                                                                                                                                                                                                                                                                       
The execution overview page crashed with a 400 deserialization error when viewing any execution belonging to a tenant in EE. The Overview.vue component was including { field: "tenant", operation: "EQUALS", value: tenantId } in the chart preview filters, but "tenant" is not a valid QueryFilter.Field value
on the backend — causing Jackson to throw:                                                                                                                                                                                                                                                                         

```                                                            
Cannot construct instance of QueryFilter$Field, problem: Unsupported field 'tenant'                                                                                                                                                                                                                              
```                                                       
This filter was redundant: tenant isolation is already enforced at the API level via the {tenant} URL path parameter and tenantService.resolveTenant(). The fix removes the invalid filter entry.