### PR TITLE
build(deps): improve Gradle caching for UI tasks

### DIFF
--- a/ui/build.gradle
+++ b/ui/build.gradle
@@ -8,11 +8,16 @@ node {
     npmInstallCommand = "ci"
 }
 
+tasks.named('npmInstall') {
+    inputs.file('package.json')
+    inputs.file('package-lock.json')
+    outputs.dir('node_modules')
+}
+
 tasks.register('assembleFrontend', NpmTask) {
     dependsOn npmInstall
     description = 'Builds the frontend'
 
-    inputs.files(fileTree('node_modules'))
     inputs.files(fileTree('src'))
     inputs.file('index.html')
     inputs.file('package.json')


### PR DESCRIPTION
Add proper inputs/outputs declarations to `npmInstall` task so Gradle can skip it when `package.json`/`package-lock.json` haven't changed. Remove `node_modules` from `assembleFrontend` inputs to avoid hashing tens of thousands of files on every build.

Companion EE PR: https://github.com/kestra-io/kestra-ee/pull/7523