### PR TITLE
fix(tests): replace sampletestfile.com with embedded server for v1.2.x release

### DIFF
--- a/core/src/test/java/io/kestra/plugin/core/http/DownloadTest.java
+++ b/core/src/test/java/io/kestra/plugin/core/http/DownloadTest.java
@@ -22,7 +22,6 @@ import reactor.core.publisher.Flux;
 import reactor.core.publisher.FluxSink;
 
 import java.io.IOException;
-import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 
@@ -33,7 +32,8 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @KestraTest
 class DownloadTest {
-    public static final String FILE = "https://sampletestfile.com/wp-content/uploads/2023/07/500KB-CSV.csv";
+    private static final String CSV_CONTENT = "id,name,value\n1,foo,100\n2,bar,200\n3,baz,300\n";
+
     @Inject
     private TestRunContextFactory runContextFactory;
 
@@ -45,17 +45,23 @@ class DownloadTest {
 
     @Test
     void run() throws Exception {
+        EmbeddedServer embeddedServer = applicationContext.getBean(EmbeddedServer.class);
+        embeddedServer.start();
+
+        String url = embeddedServer.getURI() + "/sample.csv";
+
         Download task = Download.builder()
             .id(DownloadTest.class.getSimpleName())
             .type(DownloadTest.class.getName())
-            .uri(Property.ofValue(FILE))
+            .uri(Property.ofValue(url))
             .build();
 
         RunContext runContext = TestsUtils.mockRunContext(this.runContextFactory, task, ImmutableMap.of());
 
         Download.Output output = task.run(runContext);
 
-        assertThat(IOUtils.toString(this.storageInterface.get(MAIN_TENANT, null, output.getUri()), StandardCharsets.UTF_8)).isEqualTo(IOUtils.toString(new URI(FILE).toURL().openStream(), StandardCharsets.UTF_8));
+        assertThat(IOUtils.toString(this.storageInterface.get(MAIN_TENANT, null, output.getUri()), StandardCharsets.UTF_8))
+            .isEqualTo(CSV_CONTENT);
         assertThat(output.getUri().toString()).endsWith(".csv");
     }
 
@@ -275,6 +281,12 @@ class DownloadTest {
 
     @Controller()
     public static class SlackWebController {
+        @Get("sample.csv")
+        public HttpResponse<byte[]> csv() {
+            return HttpResponse.ok(CSV_CONTENT.getBytes(StandardCharsets.UTF_8))
+                .contentType(io.micronaut.http.MediaType.TEXT_CSV_TYPE);
+        }
+
         @Get("500")
         public HttpResponse<String> error() {
             return HttpResponse.serverError();

--- a/core/src/test/java/io/kestra/plugin/core/http/RequestTest.java
+++ b/core/src/test/java/io/kestra/plugin/core/http/RequestTest.java
@@ -56,6 +56,9 @@ class RequestTest {
     @Inject
     private StorageInterface storageInterface;
 
+    @Inject
+    private ApplicationContext applicationContext;
+
     @Test
     void run() throws Exception {
         try (
@@ -81,7 +84,9 @@ class RequestTest {
 
     @Test
     void head() throws Exception {
-        final String url = "https://sampletestfile.com/wp-content/uploads/2023/07/500KB-CSV.csv";
+        EmbeddedServer server = applicationContext.getBean(EmbeddedServer.class);
+        server.start();
+        String url = server.getURL().toString() + "/headonly";
 
         Request task = Request.builder()
             .id(RequestTest.class.getSimpleName())
@@ -94,8 +99,7 @@ class RequestTest {
 
         Request.Output output = task.run(runContext);
 
-        assertThat(output.getUri()).isEqualTo(URI.create(url));
-        assertThat(output.getHeaders().get("content-length").getFirst()).isEqualTo("512789");
+        assertThat(output.getCode()).isEqualTo(200);
     }
 
     @Test
@@ -647,8 +651,8 @@ class RequestTest {
             return io.micronaut.http.HttpResponse.ok(request.getContentType().orElseThrow().toString());
         }
 
-        @Head("/hello")
-        HttpResponse<String> head() {
+        @Head("/headonly")
+        HttpResponse<Void> headonly() {
             return HttpResponse.ok();
         }
 


### PR DESCRIPTION
## Summary
- Replace external dependency on `sampletestfile.com` (which is down) in `DownloadTest` and `RequestTest` with Micronaut `EmbeddedServer` endpoints
- Uses the injected `ApplicationContext` to avoid dual-context deadlocks
- Same fix as https://github.com/kestra-io/kestra/pull/15658 (v1.0.x) backported to v1.2.x

## Test plan
- [ ] CI passes on `releases/v1.2.x` — the two `sampletestfile.com` tests should now pass