### PR TITLE
fix(ci): add 30-min per-test-task timeout to prevent silent CI hangs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -249,6 +249,9 @@ subprojects {subProj ->
         }
 
         def commonTestConfig = { Test t ->
+            t.timeout = java.time.Duration.ofMinutes(
+                (System.getenv('GRADLE_TEST_TIMEOUT_MIN') ?: '30').toInteger()
+            )
             t.ignoreFailures = true
             t.finalizedBy jacocoTestReport
             t.doFirst {


### PR DESCRIPTION
Companion to kestra-io/kestra-ee#7529.

- Intermittently, a test task hangs indefinitely on CI: `[TASK START]` appears but never `[TASK END]`, burning the full runner timeout with no diagnostic output
- Root cause: tests using `@KestraTest(startRunner = true)` start real gRPC/scheduler infrastructure; if `close()` blocks on a non-daemon Netty thread, the forked JVM never exits
- Without a task-level timeout, Gradle waits forever and the build dies with an opaque "operation was canceled"

Adds `t.timeout = Duration.ofMinutes(30)` (overridable via `GRADLE_TEST_TIMEOUT_MIN` env var) in `commonTestConfig`, which is shared by all test tasks (`test`, `unitTest`, `integrationTest`, `flakyTest`).

Effect: a hung test JVM is killed by Gradle after 30 min with `Timeout has been exceeded`, the task fails with a clear message, and the build finishes in ~30 min instead of burning the full runner ceiling.