### PR TITLE
fix(core): convert PluginDefaultService to constructor injection

### DIFF
--- a/core/src/main/java/io/kestra/core/services/PluginDefaultService.java
+++ b/core/src/main/java/io/kestra/core/services/PluginDefaultService.java
@@ -65,14 +65,22 @@ public class PluginDefaultService {
     };
 
     @Nullable
-    @Inject
     protected PluginGlobalDefaultConfiguration pluginGlobalDefault;
 
-    @Inject
-    private RunContextLoggerFactory runContextLoggerFactory;
+    private final RunContextLoggerFactory runContextLoggerFactory;
+
+    protected final PluginRegistry pluginRegistry;
 
     @Inject
-    protected PluginRegistry pluginRegistry;
+    public PluginDefaultService(
+        @Nullable PluginGlobalDefaultConfiguration pluginGlobalDefault,
+        RunContextLoggerFactory runContextLoggerFactory,
+        PluginRegistry pluginRegistry
+    ) {
+        this.pluginGlobalDefault = pluginGlobalDefault;
+        this.runContextLoggerFactory = runContextLoggerFactory;
+        this.pluginRegistry = pluginRegistry;
+    }
 
     @PostConstruct
     void validateGlobalPluginDefault() {


### PR DESCRIPTION
## Summary
- Convert `PluginDefaultService` from field injection (`@Inject` on fields) to constructor injection
- The `pluginGlobalDefault`, `runContextLoggerFactory`, and `pluginRegistry` fields are now set via constructor
- `pluginGlobalDefault` remains non-final because `PluginDefaultServiceOverrideTest` mutates it directly

## Context
Companion PR for kestra-io/kestra-ee#7531.

The EE `PluginDefaultService` subclass adds a `NamespaceMetaStoreInterface` field via `@Inject`. With field injection, Micronaut sometimes resolves the bean graph before `@MockBean` factory methods are registered, causing intermittent `DependencyInjectionException: No bean of type [NamespaceMetaStoreInterface] exists` in CI. Constructor injection makes resolution deterministic.

## Test plan
- [x] `PluginDefaultServiceOverrideTest` passes
- [x] `PluginDefaultServiceTest` passes (EE)
- [x] `InStorageOutputValuesFromExecutorTest` passes (EE — previously flaky)
- [ ] CI green