### PR TITLE
fix(core): convert PluginDefaultService to constructor injection

### DIFF
--- a/core/src/main/java/io/kestra/core/services/PluginDefaultService.java
+++ b/core/src/main/java/io/kestra/core/services/PluginDefaultService.java
@@ -65,14 +65,22 @@ public class PluginDefaultService {
     };
 
     @Nullable
-    @Inject
     protected PluginGlobalDefaultConfiguration pluginGlobalDefault;
 
-    @Inject
-    private RunContextLoggerFactory runContextLoggerFactory;
+    private final RunContextLoggerFactory runContextLoggerFactory;
+
+    protected final PluginRegistry pluginRegistry;
 
     @Inject
-    protected PluginRegistry pluginRegistry;
+    public PluginDefaultService(
+        @Nullable PluginGlobalDefaultConfiguration pluginGlobalDefault,
+        RunContextLoggerFactory runContextLoggerFactory,
+        PluginRegistry pluginRegistry
+    ) {
+        this.pluginGlobalDefault = pluginGlobalDefault;
+        this.runContextLoggerFactory = runContextLoggerFactory;
+        this.pluginRegistry = pluginRegistry;
+    }
 
     @PostConstruct
     void validateGlobalPluginDefault() {


### PR DESCRIPTION
## Summary
- Convert `PluginDefaultService` from field injection to constructor injection
- Companion PR for kestra-io/kestra-ee#7531 — branch names match so EE CI picks this up automatically

## Context
The EE `PluginDefaultService` subclass adds `NamespaceMetaStoreInterface` via field injection, causing intermittent `DependencyInjectionException` in CI when `@MockBean` replacements race with field injection. Constructor injection makes resolution deterministic.

## Test plan
- [x] `PluginDefaultServiceOverrideTest` passes
- [x] `PluginDefaultServiceTest` passes (EE)
- [x] `InStorageOutputValuesFromExecutorTest` passes (EE)