### PR TITLE
test(core): fix e2e test reliability and unskip flaky tests

### DIFF
--- a/ui/tests/e2e/api/base.api.ts
+++ b/ui/tests/e2e/api/base.api.ts
@@ -2,12 +2,13 @@ import {APIRequestContext} from "playwright/test";
 import {shared} from "../fixtures/shared";
 
 export class BaseApi {
-    protected static readonly BASED_PAIR = Buffer.from(`${shared.username}:${shared.password}`).toString("base64");
-    protected static readonly AUTH = `Basic ${BaseApi.BASED_PAIR}`;
+    protected static get AUTH(): string {
+        return `Basic ${Buffer.from(`${shared.username}:${shared.password}`).toString("base64")}`;
+    }
 
     protected readonly apiUrl: string;
 
     constructor(public readonly request: APIRequestContext, protected readonly baseURL: string | undefined) {
-        this.apiUrl = `${baseURL}/api/v1/main`;
+        this.apiUrl = `${baseURL}/api/v1`;
     }
 }

--- a/ui/tests/e2e/executions/execution-bulk-actions.spec.ts
+++ b/ui/tests/e2e/executions/execution-bulk-actions.spec.ts
@@ -8,8 +8,7 @@ test.describe("Executions' view Bulk Actions", () => {
     // Use specific flow to create executions
     test.use({flow: {fileName: "hello.yaml", flowId: "my-hello-flow-1"}});
 
-    // TODO debug flakiness and re enable
-    test.skip("Labels changed only on a filtered set of executions when using Select All", async ({executionsPage, executionsApi, page}) => {
+    test("Labels changed only on a filtered set of executions when using Select All", async ({executionsPage, executionsApi, page}) => {
         test.slow(); // creating many executions
         expect(page.getByRole("heading", {name: "Executions"})).toBeVisible();
 

--- a/ui/tests/e2e/fixtures/shared.ts
+++ b/ui/tests/e2e/fixtures/shared.ts
@@ -2,7 +2,7 @@
  * TODO: use ENV instead
  */
 export const shared = {
-    namespace: process.env.E2E_NAMESPACE ?? "company.team",
-    username: process.env.E2E_USERNAME ?? "user@kestra.io",
-    password: process.env.E2E_PASSWORD ?? "DemoDemo1"
+    get namespace() { return process.env.E2E_NAMESPACE ?? "company.team"; },
+    get username() { return process.env.E2E_USERNAME ?? "user@kestra.io"; },
+    get password() { return process.env.E2E_PASSWORD ?? "DemoDemo1"; }
 };

--- a/ui/tests/e2e/flow.spec.ts
+++ b/ui/tests/e2e/flow.spec.ts
@@ -23,10 +23,11 @@ test.describe("Flow Page", () => {
 
         await page.goto("/ui");
 
-        await test.step("login in", async () => {
+        await test.step("login", async () => {
             await page.getByRole("textbox", {name: "Email"}).fill(shared.username);
             await page.getByRole("textbox", {name: "Password"}).fill(shared.password);
             await page.getByRole("button", {name: "Login"}).click();
+            await page.waitForURL("**/ui/**");
         });
     });
 
@@ -66,7 +67,7 @@ test.describe("Flow Page", () => {
 
         await test.step("create a the flow by pasting the YAML", async () => {
             await page.locator("#side-menu .sidebar-toggle").click();
-            await page.waitForURL("**/flows");
+            await expect(page.getByRole("button", {name: "Create", exact: true})).toBeVisible();
             await page.getByRole("button", {name: "Create", exact: true}).click();
             await page.waitForURL("**/flows/new");
             await page.getByTestId("monaco-editor").getByText("Hello World").isVisible();
@@ -91,7 +92,7 @@ test.describe("Flow Page", () => {
 
             await expect(page.getByRole("dialog").getByText("INPUT_A", {exact: true})).toBeVisible();
             await page.getByRole("dialog").getByTestId("monaco-editor").getByRole("textbox").fill(inputValue);
-            await page.waitForTimeout(2100);
+            await expect(page.getByRole("dialog").getByRole("button", {name: "Execute"})).toBeEnabled();
             await page.getByRole("dialog").getByRole("button", {name: "Execute"}).click();
 
             await page.getByText("log_hello_task").click();

--- a/ui/tests/e2e/pages/executions.page.ts
+++ b/ui/tests/e2e/pages/executions.page.ts
@@ -11,7 +11,7 @@ export class ExecutionsPage extends BasePage {
 
     async goto() {
         await this.login();
-        await this.page.goto("/ui/main/executions");
+        await this.page.goto("/ui/executions");
 
         await expect(this.page.getByRole("heading", {name: "Executions"})).toBeVisible();
     }
@@ -104,6 +104,8 @@ export class ExecutionsPage extends BasePage {
         await this.page.getByRole("button", {name: "OK"}).click();
         // Confirm
         await this.page.getByRole("button", {name: "OK"}).click();
+        await this.page.reload();
+        await this.page.waitForLoadState("networkidle");
     }
 
     async setPaginationTo(size: Pagination) {

--- a/ui/tests/e2e/playwright.config.ts
+++ b/ui/tests/e2e/playwright.config.ts
@@ -18,13 +18,13 @@ import {devices} from "@playwright/test";
 const config: PlaywrightTestConfig = {
     testDir: "./",
     /* Maximum time one test can run for. */
-    timeout: 30 * 1000,
+    timeout: 60 * 1000,
     expect: {
         /**
          * Maximum time expect() should wait for the condition to be met.
          * For example in `await expect(locator).toHaveText();`
          */
-        timeout: 5000,
+        timeout: 15000,
         toHaveScreenshot: {
             maxDiffPixelRatio: 0.02,
         },


### PR DESCRIPTION
## Summary

- Fix credentials evaluated too early: `shared.ts` properties and `BaseApi.AUTH` were plain values/static fields initialised at module-load time, before `dotenv.config()` ran in the Playwright worker — converted to getters so `process.env` is read at call time
- Fix API base path: `/api/v1/main` → `/api/v1` (EE path was used by mistake in the OSS test suite)
- Fix executions page navigation URL: `/ui/main/executions` → `/ui/executions`
- Add `waitForURL` after login to ensure session redirect completes before tests navigate
- Replace `waitForTimeout(2100)` with `expect(executeBtn).toBeEnabled()` for a condition-based wait
- Replace `waitForURL` after sidebar toggle (no navigation) with `expect(createBtn).toBeVisible()`
- Add `page.reload()` after bulk label change so assertion reads fresh server data
- Increase test timeout 30s → 60s, expect timeout 5s → 15s
- Unskip the "Labels changed only on a filtered set of executions" bulk action test

## Test plan

- [x] All 5 e2e tests pass against the dockerised OSS backend (`npm run test:e2e`)
- [x] All 5 e2e tests pass against a local dev instance (`npm run test:e2e-without-starting-backend`)