### PR TITLE
feat(header): Revise header to combine breadcrumb and title

### DIFF
--- a/ui/src/components/dashboard/components/Header.vue
+++ b/ui/src/components/dashboard/components/Header.vue
@@ -1,7 +1,6 @@
 <template>
     <TopNavBar
         :title="routeInfo.title"
-        :breadcrumb="[{label: $t('dashboards.labels.singular'), link: undefined}]"
         :description="props.dashboard?.description"
     >
         <template v-if="isAllowedDashboard || isAllowedFlow" #additional-right>

--- a/ui/src/components/layout/Breadcrumb.vue
+++ b/ui/src/components/layout/Breadcrumb.vue
@@ -1,0 +1,133 @@
+<template>
+    <div class="breadcrumb">
+        <template v-for="(item, index) in visibleItems" :key="index">
+            <span v-if="index > 0" class="separator">/</span>
+
+            <el-dropdown v-if="item.ellipsis" trigger="click" :showArrow="false" size="large">
+                <button class="ellipsis-btn">
+                    ...
+                </button>
+                <template #dropdown>
+                    <el-dropdown-menu>
+                        <el-dropdown-item
+                            v-for="(collapsed, i) in collapsedItems"
+                            :key="i"
+                            :disabled="collapsed.disabled"
+                        >
+                            <RouterLink v-if="collapsed.link && !collapsed.disabled" :to="collapsed.link" class="breadcrumb-collapse-link">
+                                {{ collapsed.label }}
+                            </RouterLink>
+                            <span v-else>{{ collapsed.label }}</span>
+                        </el-dropdown-item>
+                    </el-dropdown-menu>
+                </template>
+            </el-dropdown>
+
+            <RouterLink
+                v-else-if="item.link && !item.disabled && !item.last"
+                class="item"
+                :to="item.link"
+            >
+                {{ item.label }}
+            </RouterLink>
+
+            <span v-else :class="['item', {'item--last': item.last}]">
+                <template v-if="item.last">
+                    <slot name="title">{{ item.label }}</slot>
+                </template>
+                <template v-else>{{ item.label }}</template>
+            </span>
+        </template>
+    </div>
+</template>
+
+<script setup lang="ts">
+    import {computed} from "vue";
+    import {RouterLink} from "vue-router";
+    import type {BreadcrumbItem} from "./breadcrumbTypes";
+
+    const props = defineProps<{
+        items: BreadcrumbItem[];
+        title: string;
+    }>();
+
+    const allItems = computed<(BreadcrumbItem & {last: boolean; ellipsis: false})[]>(() => [
+        ...props.items.map(item => ({...item, last: false, ellipsis: false as const})),
+        {label: props.title, last: true, ellipsis: false as const},
+    ]);
+
+    const COLLAPSE_THRESHOLD = 5;
+    const shouldCollapse = computed(() => allItems.value.length >= COLLAPSE_THRESHOLD);
+
+    type VisibleItem = BreadcrumbItem & {last: boolean; ellipsis: boolean};
+
+    const visibleItems = computed<VisibleItem[]>(() => {
+        const items = allItems.value;
+        if (!shouldCollapse.value) {
+            return items;
+        }
+        return [
+            items[0],
+            {label: "...", last: false, ellipsis: true},
+            items[items.length - 2],
+            items[items.length - 1],
+        ];
+    });
+
+    const collapsedItems = computed(() => {
+        if (!shouldCollapse.value) return [];
+        const items = allItems.value;
+        return items.slice(1, items.length - 2);
+    });
+</script>
+
+<style scoped lang="scss">
+    .breadcrumb {
+        display: flex;
+        align-items: center;
+        gap: 4px;
+        align-self: stretch;
+
+        .separator {
+            font-size: var(--font-size-sm);
+            color: var(--ks-content-tertiary);
+            user-select: none;
+        }
+
+        .item {
+            font-size: var(--font-size-sm);
+            color: var(--ks-content-tertiary);
+            text-decoration: none;
+            white-space: nowrap;
+
+            &--last {
+                font-size: var(--font-size-base);
+                font-weight: 700;
+                color: var(--ks-content-primary);
+            }
+        }
+
+        a.item:hover {
+            color: var(--ks-content-primary);
+        }
+
+        .ellipsis-btn {
+            font-size: var(--font-size-sm);
+            color: var(--ks-content-primary);
+            background: none;
+            border: none;
+            padding: 0;
+            cursor: pointer;
+
+            &:hover {
+                opacity: 0.8;
+            }
+        }
+    }
+
+    :global(.breadcrumb-collapse-link) {
+        display: block;
+        color: inherit;
+        text-decoration: none;
+    }
+</style>

--- a/ui/src/components/layout/Breadcrumb.vue
+++ b/ui/src/components/layout/Breadcrumb.vue
@@ -1,8 +1,6 @@
 <template>
     <div class="breadcrumb">
-        <template v-for="(item, index) in visibleItems" :key="index">
-            <span v-if="index > 0" class="separator">/</span>
-
+        <template v-for="item in visibleItems" :key="item.label">
             <el-dropdown v-if="item.ellipsis" trigger="click" :showArrow="false" size="large">
                 <button class="ellipsis-btn">
                     ...
@@ -23,21 +21,19 @@
                 </template>
             </el-dropdown>
 
-            <RouterLink
-                v-else-if="item.link && !item.disabled && !item.last"
-                class="item"
-                :to="item.link"
-            >
+            <RouterLink v-else-if="item.link && !item.disabled" class="item" :to="item.link">
                 {{ item.label }}
             </RouterLink>
 
-            <span v-else :class="['item', {'item--last': item.last}]">
-                <template v-if="item.last">
-                    <slot name="title">{{ item.label }}</slot>
-                </template>
-                <template v-else>{{ item.label }}</template>
-            </span>
+            <span v-else class="item">{{ item.label }}</span>
+            <span class="separator">/</span>
         </template>
+
+        <h1 class="item item--last">
+            <slot name="title">
+                {{ title }}
+            </slot>
+        </h1>
     </div>
 </template>
 
@@ -46,39 +42,26 @@
     import {RouterLink} from "vue-router";
     import type {BreadcrumbItem} from "./breadcrumbTypes";
 
-    const props = defineProps<{
+    const {items, title} = defineProps<{
         items: BreadcrumbItem[];
         title: string;
     }>();
 
-    const allItems = computed<(BreadcrumbItem & {last: boolean; ellipsis: false})[]>(() => [
-        ...props.items.map(item => ({...item, last: false, ellipsis: false as const})),
-        {label: props.title, last: true, ellipsis: false as const},
-    ]);
+    const COLLAPSE_THRESHOLD = 4;
 
-    const COLLAPSE_THRESHOLD = 5;
-    const shouldCollapse = computed(() => allItems.value.length >= COLLAPSE_THRESHOLD);
+    type VisibleItem = BreadcrumbItem & {ellipsis?: boolean};
 
-    type VisibleItem = BreadcrumbItem & {last: boolean; ellipsis: boolean};
+    const shouldCollapse = computed(() => items.length >= COLLAPSE_THRESHOLD);
 
-    const visibleItems = computed<VisibleItem[]>(() => {
-        const items = allItems.value;
-        if (!shouldCollapse.value) {
-            return items;
-        }
-        return [
-            items[0],
-            {label: "...", last: false, ellipsis: true},
-            items[items.length - 2],
-            items[items.length - 1],
-        ];
-    });
+    const visibleItems = computed<VisibleItem[]>(() =>
+        shouldCollapse.value
+            ? [items[0], {label: "...", ellipsis: true}, items[items.length - 1]]
+            : items
+    );
 
-    const collapsedItems = computed(() => {
-        if (!shouldCollapse.value) return [];
-        const items = allItems.value;
-        return items.slice(1, items.length - 2);
-    });
+    const collapsedItems = computed<BreadcrumbItem[]>(() =>
+        shouldCollapse.value ? items.slice(1, items.length - 1) : []
+    );
 </script>
 
 <style scoped lang="scss">
@@ -104,6 +87,7 @@
                 font-size: var(--font-size-base);
                 font-weight: 700;
                 color: var(--ks-content-primary);
+                margin: 0;
             }
         }
 

--- a/ui/src/components/layout/TopNavBar.vue
+++ b/ui/src/components/layout/TopNavBar.vue
@@ -78,7 +78,7 @@
     const bookmarksStore = useBookmarksStore();
 
     const breadcrumbItems = computed(() => [
-        {label: t("dashboards.labels.singular"), link: {name: "home"}},
+        {label: t("home"), link: {name: "home"}},
         ...(props.breadcrumb ?? []),
     ]);
 

--- a/ui/src/components/layout/TopNavBar.vue
+++ b/ui/src/components/layout/TopNavBar.vue
@@ -1,44 +1,32 @@
 <template>
-    <nav class="d-flex align-items-center w-100 gap-3 top-bar">
+    <nav class="d-flex align-items-center w-100 top-bar">
         <SidebarToggleButton
             v-if="layoutStore.sideMenuCollapsed"
             @toggle="layoutStore.setSideMenuCollapsed(false)"
         />
-        <div class="d-flex flex-column flex-grow-1 flex-shrink-1 overflow-hidden top-title">
-            <div class="d-flex align-items-end gap-2">
-                <div class="d-flex flex-column gap-2">
-                    <el-breadcrumb v-if="breadcrumb">
-                        <el-breadcrumb-item v-for="(item, x) in breadcrumb" :key="x" :class="{'pe-none': item.disabled}">
-                            <a v-if="item.disabled || !item.link">
-                                {{ item.label }}
-                            </a>
-                            <RouterLink v-else :to="item.link">
-                                {{ item.label }}
-                            </RouterLink>
-                        </el-breadcrumb-item>
-                    </el-breadcrumb>
-                    <h1 class="h5 fw-semibold m-0 d-inline-flex">
-                        <slot name="title">
-                            {{ title }}
-                            <el-tooltip v-if="description" :content="description">
-                                <Information class="ms-2 icon" />
-                            </el-tooltip>
-                            <Badge v-if="beta" label="Beta" />
-                        </slot>
-                        <el-button
-                            class="icon"
-                            :class="{'active': bookmarked}"
-                            :icon="bookmarked ? StarIcon : StarOutlineIcon"
-                            circle
-                            @click="onStarClick"
-                        />
-                    </h1>
-                    <div class="description">
-                        <slot name="description">
-                            {{ longDescription }}
-                        </slot>
-                    </div>
-                </div>
+        <div class="title-section">
+            <div class="d-flex align-items-center gap-2">
+                <Breadcrumb :items="breadcrumbItems" :title="title">
+                    <template v-if="$slots.title" #title>
+                        <slot name="title" />
+                    </template>
+                </Breadcrumb>
+                <el-tooltip v-if="description" :content="description">
+                    <Information class="ms-2 icon" />
+                </el-tooltip>
+                <Badge v-if="beta" label="Beta" />
+                <el-button
+                    class="icon"
+                    :class="{'active': bookmarked}"
+                    :icon="bookmarked ? StarIcon : StarOutlineIcon"
+                    circle
+                    @click="onStarClick"
+                />
+            </div>
+            <div v-if="longDescription || $slots.description" class="description">
+                <slot name="description">
+                    {{ longDescription }}
+                </slot>
             </div>
         </div>
         <div class="d-lg-flex side gap-2 flex-shrink-0 align-items-center mycontainer">
@@ -59,7 +47,7 @@
 <script setup lang="ts">
     import {computed} from "vue";
     import {useI18n} from "vue-i18n";
-    import {useRoute, RouterLink} from "vue-router";
+    import {useRoute} from "vue-router";
     import GlobalSearch from "./GlobalSearch.vue";
     import TrashCan from "vue-material-design-icons/TrashCan.vue";
     import StarOutlineIcon from "vue-material-design-icons/StarOutline.vue";
@@ -72,18 +60,14 @@
     import {useFlowStore} from "../../stores/flow";
     import {useLayoutStore} from "../../stores/layout";
     import SidebarToggleButton from "./SidebarToggleButton.vue";
-
-    type RouterLinkTo = InstanceType<typeof RouterLink>["$props"]["to"];
+    import Breadcrumb from "./Breadcrumb.vue";
+    import type {BreadcrumbItem} from "./breadcrumbTypes";
 
     const props = defineProps<{
         title: string;
         description?: string;
         longDescription?: string;
-        breadcrumb?: {
-            label: string;
-            link?: RouterLinkTo;
-            disabled?: boolean;
-        }[];
+        breadcrumb?: BreadcrumbItem[];
         beta?: boolean;
     }>();
 
@@ -93,6 +77,10 @@
     const layoutStore = useLayoutStore();
     const bookmarksStore = useBookmarksStore();
 
+    const breadcrumbItems = computed(() => [
+        {label: t("dashboards.labels.singular"), link: {name: "home"}},
+        ...(props.breadcrumb ?? []),
+    ]);
 
     const shouldDisplayDeleteButton = computed(() => {
         return route.name === "flows/update" && route.params?.tab === "logs";
@@ -156,47 +144,42 @@
         top: 0;
         position: sticky;
         z-index: 1000;
-        padding: 1rem 2rem;
+        padding: 0.5rem 1rem;
+        gap: 1rem;
         border-bottom: 1px solid var(--ks-border-primary);
         background: var(--ks-background-card);
 
-        .top-title, h1, .el-breadcrumb {
-            white-space: nowrap;
-            max-width: 100%;
-            text-overflow: ellipsis;
-            overflow: hidden;
-        }
-
-        .top-title {
+        .title-section {
             position: relative;
+            display: flex;
+            flex-direction: column;
+            align-items: flex-start;
+            gap: 4px;
+            flex: 1 0 0;
+            min-width: 0;
+            overflow: hidden;
 
-        &::after {
-            content: "";
-            position: absolute;
-            top: 0;
-            right: 0;
-            width: 40px;
-            height: 100%;
-            background: linear-gradient(to left, var(--ks-background-card), transparent);
-            pointer-events: none;
+            &::after {
+                content: "";
+                position: absolute;
+                top: 0;
+                right: 0;
+                width: 40px;
+                height: 100%;
+                background: linear-gradient(to left, var(--ks-background-card), transparent);
+                pointer-events: none;
             }
         }
 
-        h1 {
-            line-height: 1.6;
-            display: flex !important;
-            align-items: center;
-        }
-
         .description {
-            font-size: 0.875rem;
-            margin-top: -0.5rem;
+            font-size: var(--font-size-sm);
             color: var(--ks-content-secondary);
         }
 
         .icon {
             border: none;
             color: var(--ks-content-tertiary);
+            flex-shrink: 0;
 
             &:deep(svg) {
                 fill: currentColor;
@@ -206,17 +189,6 @@
             &.active {
                 color: $base-purple-300;
             }
-        }
-
-        :deep(.el-breadcrumb__item) {
-            display: inline-block;
-        }
-
-        :deep(.el-breadcrumb__inner) {
-            white-space: nowrap;
-            max-width: 100%;
-            text-overflow: ellipsis;
-            overflow: hidden;
         }
 
         .side {
@@ -231,11 +203,11 @@
         }
 
         @media (max-width: 992px) {
-            padding: 0.75rem 1.5rem;
+            padding: 0.5rem 0.75rem;
         }
 
         @media (max-width: 768px) {
-            padding: 0.75rem;
+            padding: 0.5rem;
 
             .mycontainer {
                 display: grid;
@@ -246,8 +218,8 @@
             }
         }
         @media (max-width: 664px) {
-            padding: 0.75rem 0.5rem;
-            
+            padding: 0.5rem;
+
             .mycontainer {
                 display: grid;
                 grid-template-columns: repeat(2, minmax(0, auto));

--- a/ui/src/components/layout/TopNavBar.vue
+++ b/ui/src/components/layout/TopNavBar.vue
@@ -150,7 +150,6 @@
         background: var(--ks-background-card);
 
         .title-section {
-            position: relative;
             display: flex;
             flex-direction: column;
             align-items: flex-start;
@@ -158,22 +157,13 @@
             flex: 1 0 0;
             min-width: 0;
             overflow: hidden;
-
-            &::after {
-                content: "";
-                position: absolute;
-                top: 0;
-                right: 0;
-                width: 40px;
-                height: 100%;
-                background: linear-gradient(to left, var(--ks-background-card), transparent);
-                pointer-events: none;
-            }
+            mask-image: linear-gradient(to right, black calc(100% - 40px), transparent 100%);
         }
 
         .description {
             font-size: var(--font-size-sm);
             color: var(--ks-content-secondary);
+            white-space: nowrap;
         }
 
         .icon {

--- a/ui/src/components/layout/TopNavBar.vue
+++ b/ui/src/components/layout/TopNavBar.vue
@@ -29,12 +29,12 @@
                 </slot>
             </div>
         </div>
-        <div class="d-lg-flex side gap-2 flex-shrink-0 align-items-center mycontainer">
+        <div class="d-lg-flex side gap-2 flex-shrink-0 align-items-center">
             <div class="d-none d-lg-flex align-items-center">
                 <GlobalSearch class="trigger-flow-guided-step" />
             </div>
-            <div class="d-flex side gap-2 flex-shrink-0 align-items-center">
-                <el-button v-if="shouldDisplayDeleteButton && logsStore.logs !== undefined && logsStore.logs.length > 0" @click="deleteLogs()">
+            <div v-if="shouldDisplayDeleteButton && logsStore.logs !== undefined && logsStore.logs.length > 0" class="d-flex side gap-2 flex-shrink-0 align-items-center">
+                <el-button @click="deleteLogs()">
                     <TrashCan class="me-2" />
                     <span>{{ $t("delete logs") }}</span>
                 </el-button>
@@ -153,7 +153,7 @@
             display: flex;
             flex-direction: column;
             align-items: flex-start;
-            gap: 4px;
+            gap: 0.5rem;
             flex: 1 0 0;
             min-width: 0;
             overflow: hidden;
@@ -198,25 +198,6 @@
 
         @media (max-width: 768px) {
             padding: 0.5rem;
-
-            .mycontainer {
-                display: grid;
-                grid-template-columns: repeat(3, minmax(0, auto));
-                grid-template-rows: repeat(2, auto);
-                gap: 10px;
-                overflow: hidden;
-            }
-        }
-        @media (max-width: 664px) {
-            padding: 0.5rem;
-
-            .mycontainer {
-                display: grid;
-                grid-template-columns: repeat(2, minmax(0, auto));
-                grid-template-rows: repeat(2, auto);
-                gap: 10px;
-                overflow: hidden;
-            }
         }
     }
 </style>

--- a/ui/src/components/layout/breadcrumbTypes.ts
+++ b/ui/src/components/layout/breadcrumbTypes.ts
@@ -1,0 +1,9 @@
+import type {RouterLink} from "vue-router";
+
+type RouterLinkTo = InstanceType<typeof RouterLink>["$props"]["to"];
+
+export interface BreadcrumbItem {
+    label: string;
+    link?: RouterLinkTo;
+    disabled?: boolean;
+}

--- a/ui/src/components/namespaces/utils/useHelpers.ts
+++ b/ui/src/components/namespaces/utils/useHelpers.ts
@@ -66,7 +66,7 @@ export function useHelpers() {
         title: parts.value.at(-1) || t("namespaces"),
         breadcrumb: [
             {label: t("namespaces"), link: {name: "namespaces/list"}},
-            ...parts.value.map((_: string, index: number): Breadcrumb => ({
+            ...parts.value.slice(0, -1).map((_: string, index: number): Breadcrumb => ({
                 label: parts.value[index],
                 link: {
                     name: "namespaces/update",
@@ -75,7 +75,6 @@ export function useHelpers() {
                         tab: "overview",
                     },
                 },
-                disabled: index === parts.value.length - 1,
             })),
         ],
     }));

--- a/ui/src/styles/app.scss
+++ b/ui/src/styles/app.scss
@@ -173,7 +173,7 @@ html.full-screen {
 
     --el-transition-duration: 0.2s;
     --el-transition-duration-fast: 0.2s;
-    --top-navbar-height: 79px;
+    --top-navbar-height: 49px;
     #{--menu-width}: global-var.$menu-width;
     #{--menu-collapsed-width}: 65px;
     #{--spacer}: global-var.$spacer;

--- a/ui/src/styles/app.scss
+++ b/ui/src/styles/app.scss
@@ -173,7 +173,12 @@ html.full-screen {
 
     --el-transition-duration: 0.2s;
     --el-transition-duration-fast: 0.2s;
+    
     --top-navbar-height: 49px;
+    &:has(.top-bar .description) {
+        --top-navbar-height: 74px;
+    }
+
     #{--menu-width}: global-var.$menu-width;
     #{--menu-collapsed-width}: 65px;
     #{--spacer}: global-var.$spacer;


### PR DESCRIPTION
closes https://github.com/kestra-io/kestra/issues/11562

**Navigation and Breadcrumb Improvements:**

- Introduced a new `Breadcrumb` component with support for ellipsis/collapsed breadcrumbs for long paths, replacing the previous use of `el-breadcrumb`
- Added a new `BreadcrumbItem` type in `breadcrumbTypes.ts` for type-safe breadcrumb items and updated all relevant usages to use this type
- Updated breadcrumb logic in namespaces helper to avoid marking the last breadcrumb as disabled and to properly slice items

**Top Navigation Bar Redesign:**

- Refactored `TopNavBar.vue` to use the new `Breadcrumb` component, streamlined the title/description section, and improved responsiveness and layout (including mask gradients and spacing tweaks)
- Removed legacy `el-breadcrumb` markup and related CSS, and simplified the header’s structure for better maintainability

**Styling and Layout Adjustments:**

- Reduced the default top navbar height and added logic to increase height when a description is present, improving the visual hierarchy and compactness
- Updated padding and gap values for better spacing in the navigation bar across breakpoints