### PR TITLE
Add Java Aspire AppHost for local Kestra

### DIFF
--- a/ASPIRE_APPHOST_STATUS.md
+++ b/ASPIRE_APPHOST_STATUS.md
@@ -1,0 +1,38 @@
+# Aspire AppHost status for Kestra
+
+## Files
+
+- `AppHost.java` - Java AppHost for running Kestra under Aspire from the local source tree
+- `aspire.config.json` - Java AppHost configuration and Aspire package references
+- `ASPIRE_APPHOST_STATUS.md` - this status note
+
+## Resources created
+
+- `postgres` - PostgreSQL 18 using the built-in Aspire PostgreSQL integration
+- `kestra-db` - the `kestra` PostgreSQL database resource
+- `kestra-build` - a transient executable resource that runs `./gradlew writeExecutableJar --no-daemon`
+- `kestra` - a source-backed executable resource that launches `build/executable/kestra-2.0.0-SNAPSHOT`
+
+## What was achieved
+
+- The final AppHost is written in **Java**, matching the Kestra repository language.
+- Kestra runs from the **local clone/source**, not from a pre-published application container.
+- The AppHost builds Kestra automatically before startup by making `kestra` wait for `kestra-build` to complete successfully.
+- PostgreSQL credentials are modeled with Aspire parameters, and the password is marked as a secret.
+- The PostgreSQL JDBC connection uses Aspire-resolved references from the PostgreSQL resource instead of a hard-coded connection string.
+- Aspire OTLP wiring is enabled with `withOtlpExporter()`, so telemetry is sent to the Aspire dashboard endpoints during local runs.
+- Kestra health is checked on the management endpoint.
+
+## Important implementation details
+
+- The generated Kestra executable is a shell-prefixed self-run launcher, so the AppHost runs it through `/bin/sh`.
+- The launcher expects `build/executable/confs/` to exist before startup.
+- Kestra must define both `datasources.default` and `datasources.postgres` in its generated configuration.
+- The AppHost binds Kestra's HTTP and management ports from Aspire-assigned endpoint environment variables.
+
+## Limitations
+
+- The remaining known limitation is an **Aspire Java/polyglot limitation** for self-endpoint expression resolution on the same executable resource.
+- A direct self-endpoint expression attempt such as `ReferenceExpression.refExpr("http://%s/", kestra.getEndpoint("http"))` was passed through literally instead of resolving to the running endpoint.
+- Because of that limitation, `kestra.url` still uses `http://localhost:${KESTRA_HTTP_PORT}/` rather than a fully resolved Aspire self-endpoint expression.
+- This harness is intended for **local development/run mode**. The transient `kestra-build` step and `waitForCompletion(...)` behavior are local-run concerns, not deployment-manifest behavior.

--- a/AppHost.java
+++ b/AppHost.java
@@ -9,10 +9,50 @@ void main(String[] args) throws Exception {
     var postgresDataPath = dataRoot.resolve("postgres");
     var storagePath = dataRoot.resolve("storage");
     var tempPath = dataRoot.resolve("tmp");
+    var storageDir = storagePath.toAbsolutePath().toString().replace("\\", "/");
+    var tempDir = tempPath.resolve("tmp").toAbsolutePath().toString().replace("\\", "/");
+    var javaHome = System.getProperty("java.home");
+    var kestraExecutable = "./build/executable/kestra-2.0.0-SNAPSHOT";
+    var kestraConfigDir = Path.of(builder.appHostDirectory(), "build", "executable", "confs");
 
     Files.createDirectories(postgresDataPath);
     Files.createDirectories(storagePath);
     Files.createDirectories(tempPath.resolve("tmp"));
+    Files.createDirectories(kestraConfigDir);
+    var kestraConfiguration = """
+        micronaut:
+          server:
+            port: ${KESTRA_HTTP_PORT}
+        datasources:
+          default:
+            url: ${KESTRA_PG_URL}
+            driverClassName: org.postgresql.Driver
+            username: ${KESTRA_PG_USERNAME}
+            password: ${KESTRA_PG_PASSWORD}
+          postgres:
+            url: ${KESTRA_PG_URL}
+            driverClassName: org.postgresql.Driver
+            username: ${KESTRA_PG_USERNAME}
+            password: ${KESTRA_PG_PASSWORD}
+        endpoints:
+          all:
+            port: ${KESTRA_MANAGEMENT_PORT}
+        kestra:
+          repository:
+            type: postgres
+          executor:
+            thread-count: 1
+          storage:
+            type: local
+            local:
+              base-path: "%s"
+          queue:
+            type: postgres
+          tasks:
+            tmp-dir:
+              path: %s
+          url: http://localhost:${KESTRA_HTTP_PORT}/
+        """.formatted(storageDir, tempDir);
 
     var postgresUser = builder.addParameterWithValue("postgres-user", "kestra");
     var postgresPassword = builder.addParameterWithValue("postgres-password", "k3str4", new AddParameterWithValueOptions().secret(true));
@@ -25,46 +65,19 @@ void main(String[] args) throws Exception {
 
     var kestraDatabase = postgres.addDatabase("kestra-db", "kestra");
 
-    var kestra = builder.addContainer("kestra", "kestra/kestra:latest")
-        .withArgs(new String[] { "server", "standalone", "--worker-thread", "1", "--no-indexer", "--no-tutorials" })
-        .withImagePullPolicy(ImagePullPolicy.ALWAYS)
+    var kestra = builder.addExecutable("kestra", "/bin/sh", builder.appHostDirectory(), new String[] { kestraExecutable, "server", "standalone", "--worker-thread", "1", "--no-indexer", "--no-tutorials" })
         .withOtlpExporter()
-        .withBindMount(storagePath.toString(), "/app/storage")
-        .withBindMount(tempPath.toString(), "/tmp/kestra-wd")
+        .withEnvironment("JAVA_HOME", javaHome)
         .withEnvironment("JAVA_OPTS", "-Xms256m -Xmx768m")
-        .withEnvironment("KESTRA_CONFIGURATION", """
-            datasources:
-              postgres:
-                url: jdbc:postgresql://postgres:5432/kestra
-                driverClassName: org.postgresql.Driver
-                username: kestra
-                password: k3str4
-            kestra:
-              repository:
-                type: postgres
-              executor:
-                thread-count: 1
-              storage:
-                type: local
-                local:
-                  base-path: "/app/storage"
-              queue:
-                type: postgres
-              tasks:
-                tmp-dir:
-                  path: /tmp/kestra-wd/tmp
-              url: http://localhost:8080/
-            """)
-        .withHttpEndpoint(new WithHttpEndpointOptions().name("http").targetPort(8080.0))
-        .withHttpEndpoint(new WithHttpEndpointOptions().name("management").targetPort(8081.0))
+        .withEnvironment("KESTRA_CONFIGURATION", kestraConfiguration)
+        .withEnvironment("KESTRA_PG_URL", kestraDatabase.jdbcConnectionString())
+        .withEnvironment("KESTRA_PG_USERNAME", postgres.userNameReference())
+        .withEnvironment("KESTRA_PG_PASSWORD", postgresPassword)
+        .withHttpEndpoint(new WithHttpEndpointOptions().name("http").env("KESTRA_HTTP_PORT"))
+        .withHttpEndpoint(new WithHttpEndpointOptions().name("management").env("KESTRA_MANAGEMENT_PORT"))
         .withExternalHttpEndpoints()
         .withHttpHealthCheck(new WithHttpHealthCheckOptions().path("/health").endpointName("management"))
         .waitFor(kestraDatabase);
-
-    var dockerSocket = Path.of("/var/run/docker.sock");
-    if (Files.exists(dockerSocket)) {
-        kestra.withBindMount(dockerSocket.toString(), "/var/run/docker.sock");
-    }
 
     builder.build().run();
 }

--- a/AppHost.java
+++ b/AppHost.java
@@ -1,0 +1,70 @@
+import aspire.*;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+void main(String[] args) throws Exception {
+    var builder = DistributedApplication.CreateBuilder(args);
+
+    var dataRoot = Path.of(builder.appHostDirectory(), ".data");
+    var postgresDataPath = dataRoot.resolve("postgres");
+    var storagePath = dataRoot.resolve("storage");
+    var tempPath = dataRoot.resolve("tmp");
+
+    Files.createDirectories(postgresDataPath);
+    Files.createDirectories(storagePath);
+    Files.createDirectories(tempPath.resolve("tmp"));
+
+    var postgresUser = builder.addParameterWithValue("postgres-user", "kestra");
+    var postgresPassword = builder.addParameterWithValue("postgres-password", "k3str4", new AddParameterWithValueOptions().secret(true));
+
+    var postgres = builder.addPostgres("postgres")
+        .withUserName(postgresUser)
+        .withPassword(postgresPassword)
+        .withImageTag("18")
+        .withDataBindMount(postgresDataPath.toString());
+
+    var kestraDatabase = postgres.addDatabase("kestra-db", "kestra");
+
+    var kestra = builder.addContainer("kestra", "kestra/kestra:latest")
+        .withArgs(new String[] { "server", "standalone", "--worker-thread", "1", "--no-indexer", "--no-tutorials" })
+        .withImagePullPolicy(ImagePullPolicy.ALWAYS)
+        .withOtlpExporter()
+        .withBindMount(storagePath.toString(), "/app/storage")
+        .withBindMount(tempPath.toString(), "/tmp/kestra-wd")
+        .withEnvironment("JAVA_OPTS", "-Xms256m -Xmx768m")
+        .withEnvironment("KESTRA_CONFIGURATION", """
+            datasources:
+              postgres:
+                url: jdbc:postgresql://postgres:5432/kestra
+                driverClassName: org.postgresql.Driver
+                username: kestra
+                password: k3str4
+            kestra:
+              repository:
+                type: postgres
+              executor:
+                thread-count: 1
+              storage:
+                type: local
+                local:
+                  base-path: "/app/storage"
+              queue:
+                type: postgres
+              tasks:
+                tmp-dir:
+                  path: /tmp/kestra-wd/tmp
+              url: http://localhost:8080/
+            """)
+        .withHttpEndpoint(new WithHttpEndpointOptions().name("http").targetPort(8080.0))
+        .withHttpEndpoint(new WithHttpEndpointOptions().name("management").targetPort(8081.0))
+        .withExternalHttpEndpoints()
+        .withHttpHealthCheck(new WithHttpHealthCheckOptions().path("/health").endpointName("management"))
+        .waitFor(kestraDatabase);
+
+    var dockerSocket = Path.of("/var/run/docker.sock");
+    if (Files.exists(dockerSocket)) {
+        kestra.withBindMount(dockerSocket.toString(), "/var/run/docker.sock");
+    }
+
+    builder.build().run();
+}

--- a/AppHost.java
+++ b/AppHost.java
@@ -12,6 +12,7 @@ void main(String[] args) throws Exception {
     var storageDir = storagePath.toAbsolutePath().toString().replace("\\", "/");
     var tempDir = tempPath.resolve("tmp").toAbsolutePath().toString().replace("\\", "/");
     var javaHome = System.getProperty("java.home");
+    var gradleJavaHome = "-Dorg.gradle.java.home=" + javaHome;
     var kestraExecutable = "./build/executable/kestra-2.0.0-SNAPSHOT";
     var kestraConfigDir = Path.of(builder.appHostDirectory(), "build", "executable", "confs");
 
@@ -64,6 +65,10 @@ void main(String[] args) throws Exception {
         .withDataBindMount(postgresDataPath.toString());
 
     var kestraDatabase = postgres.addDatabase("kestra-db", "kestra");
+    var kestraBuild = builder.addExecutable("kestra-build", "./gradlew", builder.appHostDirectory(), new String[] { "writeExecutableJar", "--no-daemon" })
+        .excludeFromManifest()
+        .withEnvironment("JAVA_HOME", javaHome)
+        .withEnvironment("GRADLE_OPTS", gradleJavaHome);
 
     var kestra = builder.addExecutable("kestra", "/bin/sh", builder.appHostDirectory(), new String[] { kestraExecutable, "server", "standalone", "--worker-thread", "1", "--no-indexer", "--no-tutorials" })
         .withOtlpExporter()
@@ -77,6 +82,7 @@ void main(String[] args) throws Exception {
         .withHttpEndpoint(new WithHttpEndpointOptions().name("management").env("KESTRA_MANAGEMENT_PORT"))
         .withExternalHttpEndpoints()
         .withHttpHealthCheck(new WithHttpHealthCheckOptions().path("/health").endpointName("management"))
+        .waitForCompletion(kestraBuild)
         .waitFor(kestraDatabase);
 
     builder.build().run();

--- a/aspire.config.json
+++ b/aspire.config.json
@@ -1,0 +1,22 @@
+{
+  "appHost": {
+    "path": "AppHost.java",
+    "language": "java"
+  },
+  "sdk": {
+    "version": "13.3.0-preview.1.26221.2"
+  },
+  "channel": "daily",
+  "profiles": {
+    "https": {
+      "applicationUrl": "https://localhost:19751;http://localhost:22347",
+      "environmentVariables": {
+        "ASPIRE_DASHBOARD_OTLP_ENDPOINT_URL": "https://localhost:35384",
+        "ASPIRE_RESOURCE_SERVICE_ENDPOINT_URL": "https://localhost:51827"
+      }
+    }
+  },
+  "packages": {
+    "Aspire.Hosting.PostgreSQL": "13.3.0-preview.1.26221.3"
+  }
+}


### PR DESCRIPTION
## Summary
- add a Java `AppHost.java` that runs Kestra from the local source tree under Aspire
- use Aspire PostgreSQL integration, a transient `kestra-build` step, and OTLP dashboard wiring
- add `ASPIRE_APPHOST_STATUS.md` describing the resources created, what works, and the remaining limitation

## What works
- local source-backed Kestra execution under a Java AppHost
- transient Gradle build before launch via `waitForCompletion(...)`
- Aspire parameters/secrets for PostgreSQL credentials
- OTLP export to the Aspire dashboard during local runs

## Known limitation
- self-endpoint expression resolution for the same Java executable resource does not currently resolve as expected, so `kestra.url` still uses `http://localhost:${KESTRA_HTTP_PORT}/` instead of a fully resolved Aspire self-endpoint expression
