### PR TITLE
fix: extract FlowAutoLoader interface to core to fix cli-ee compilation

### DIFF
--- a/cli/src/main/java/io/kestra/cli/AbstractCommand.java
+++ b/cli/src/main/java/io/kestra/cli/AbstractCommand.java
@@ -14,11 +14,11 @@ import java.util.concurrent.Callable;
 import com.google.common.collect.ImmutableMap;
 
 import io.kestra.cli.commands.servers.ServerCommandInterface;
+import io.kestra.core.services.FlowAutoLoader;
 import io.kestra.cli.services.StartupHookInterface;
 import io.kestra.core.plugins.PluginManager;
 import io.kestra.core.plugins.PluginRegistry;
 import io.kestra.core.utils.Rethrow;
-import io.kestra.webserver.services.FlowAutoLoaderService;
 
 import io.micronaut.context.ApplicationContext;
 import io.micronaut.context.BeanProvider;
@@ -64,7 +64,7 @@ public abstract class AbstractCommand extends BaseCommand implements Callable<In
     private Optional<EmbeddedServer> embeddedServer;
 
     @Inject
-    private BeanProvider<FlowAutoLoaderService> flowAutoLoaderService;
+    private BeanProvider<FlowAutoLoader> flowAutoLoaderService;
 
     @Inject
     protected Provider<PluginRegistry> pluginRegistryProvider;
@@ -189,7 +189,7 @@ public abstract class AbstractCommand extends BaseCommand implements Callable<In
                 }
 
                 if (isFlowAutoLoadEnabled()) {
-                    flowAutoLoaderService.ifPresent(FlowAutoLoaderService::load);
+                    flowAutoLoaderService.ifPresent(FlowAutoLoader::load);
                 }
             });
     }

--- a/core/src/main/java/io/kestra/core/services/FlowAutoLoader.java
+++ b/core/src/main/java/io/kestra/core/services/FlowAutoLoader.java
@@ -1,0 +1,5 @@
+package io.kestra.core.services;
+
+public interface FlowAutoLoader {
+    void load();
+}

--- a/webserver/src/main/java/io/kestra/webserver/services/FlowAutoLoaderService.java
+++ b/webserver/src/main/java/io/kestra/webserver/services/FlowAutoLoaderService.java
@@ -5,6 +5,7 @@ import java.util.function.Function;
 import java.util.regex.Pattern;
 
 import io.kestra.core.contexts.KestraConfig;
+import io.kestra.core.services.FlowAutoLoader;
 import io.kestra.core.models.flows.GenericFlow;
 import io.kestra.core.services.FlowService;
 import io.kestra.core.tenant.TenantService;
@@ -33,7 +34,7 @@ import static io.kestra.core.utils.Rethrow.throwFunction;
 @Slf4j
 @WebServerEnabled
 @Requires(property = "kestra.tutorial-flows.enabled", value = "true", defaultValue = "true")
-public class FlowAutoLoaderService {
+public class FlowAutoLoaderService implements FlowAutoLoader {
 
     public static final Pattern NAMESPACE_FROM_FLOW_SOURCE_PATTERN = Pattern.compile("^namespace: \\S*", Pattern.MULTILINE);
 


### PR DESCRIPTION
### ✨ Description

Introduces a `FlowAutoLoader` interface in `core` (`io.kestra.core.services`). `AbstractCommand` now injects `BeanProvider<FlowAutoLoader>` rather than the concrete `FlowAutoLoaderService`, decoupling the CLI from the  webserver module's implementation detail.

### 🛠️ Backend Checklist

_If this PR does not include any backend changes, delete this entire section._
- [x] Code compiles successfully and passes all checks
- [x] All unit and integration tests pass