### PR TITLE
fix: test task caching and flaky test no-source issues

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -252,7 +252,6 @@ subprojects {subProj ->
             t.timeout = java.time.Duration.ofMinutes(
                 (System.getenv('GRADLE_TEST_TIMEOUT_MIN') ?: '30').toInteger()
             )
-            t.ignoreFailures = true
             t.finalizedBy jacocoTestReport
             t.doFirst {
                 logger.lifecycle("[TASK START] ${t.path}")
@@ -341,6 +340,9 @@ subprojects {subProj ->
                 includeTags 'flaky'
             }
 
+            testClassesDirs = sourceSets.test.output.classesDirs
+            classpath = sourceSets.test.runtimeClasspath
+
             reports {
                 junitXml.required = true
                 junitXml.outputPerTestCase = true
@@ -349,6 +351,9 @@ subprojects {subProj ->
                 junitXml.outputLocation = layout.buildDirectory.dir("test-results/flakyTest")
             }
             commonTestConfig(t)
+            t.ignoreFailures = true
+            t.filter { failOnNoMatchingTests = false }
+            t.outputs.doNotCacheIf("Flaky tests are non-deterministic") { true }
             t.mustRunAfter(tasks.named('test'))
         }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,3 +4,4 @@ org.gradle.jvmargs=-Xmx2g -XX:MaxMetaspaceSize=512m -XX:+HeapDumpOnOutOfMemoryEr
 org.gradle.parallel=true
 org.gradle.caching=true
 org.gradle.priority=low
+org.gradle.continue=true


### PR DESCRIPTION
✨ Description

Fixes two build issues introduced by enabling Develocity build caching:

1. Test tasks were cached after failure. ignoreFailures = true caused all test tasks to always exit with code 0, so Develocity cached "successful" runs that contained failing JUnit XML results. Subsequent runs restored those stale failures from cache. Removed ignoreFailures from commonTestConfig so failed tasks exit non-zero and are not cached. Added org.gradle.continue=true to gradle.properties in both repos so all module tests still run even when one fails.
2. Flaky tests never ran. The flakyTest task was missing testClassesDirs and classpath, which are required for custom Test tasks but not automatically inherited. Without them Gradle marked the task NO-SOURCE and skipped it. Added the missing properties, filter { failOnNoMatchingTests = false } (some modules have no flaky tests), and outputs.doNotCacheIf to prevent non-deterministic results being cached.