### PR TITLE
fix(core): improve hover style on onboarding resource list items

### DIFF
--- a/ui/src/components/onboarding/OnboardingResourceList.vue
+++ b/ui/src/components/onboarding/OnboardingResourceList.vue
@@ -66,7 +66,7 @@
         }
 
         &:hover {
-            background: var(--ks-button-background-secondary);
+            background: var(--ks-button-background-secondary-hover);
             text-decoration: none;
         }
     }


### PR DESCRIPTION
## Summary
- Use `--ks-button-background-secondary-hover` on hover instead of `--ks-button-background-secondary` for a more noticeable highlight on onboarding resource list items

## Test plan
- [ ] Hover over items in the onboarding resource list (welcome page, apps, tests no-data pages) and verify the background changes visibly