### PR TITLE
fix(core): make deprecated taskDefaults work again

### DIFF
--- a/core/src/main/java/io/kestra/core/services/PluginDefaultService.java
+++ b/core/src/main/java/io/kestra/core/services/PluginDefaultService.java
@@ -66,6 +66,7 @@ public class PluginDefaultService {
     private static final ObjectMapper OBJECT_MAPPER = JacksonMapper.ofYaml().copy()
         .setDefaultPropertyInclusion(JsonInclude.Include.NON_NULL);
     private static final String PLUGIN_DEFAULTS_FIELD = "pluginDefaults";
+    private static final String TASK_DEFAULTS_FIELD = "taskDefaults";
 
     private static final TypeReference<List<PluginDefault>> PLUGIN_DEFAULTS_TYPE_REF = new TypeReference<>() {
     };
@@ -130,6 +131,12 @@ public class PluginDefaultService {
      */
     protected List<PluginDefault> getFlowDefaults(final Map<String, Object> flow) {
         Object defaults = flow.get(PLUGIN_DEFAULTS_FIELD);
+        if (defaults == null) {
+            // Fallback to the deprecated 'taskDefaults' field for backward compatibility.
+            // The deprecation itself is surfaced to the UI via FlowService.deprecationPaths,
+            // which relies on Flow.taskDefaults being populated by Jackson during deserialization.
+            defaults = flow.get(TASK_DEFAULTS_FIELD);
+        }
         if (defaults != null) {
             return OBJECT_MAPPER.convertValue(defaults, PLUGIN_DEFAULTS_TYPE_REF);
         } else {

--- a/core/src/test/java/io/kestra/core/services/PluginDefaultServiceTest.java
+++ b/core/src/test/java/io/kestra/core/services/PluginDefaultServiceTest.java
@@ -316,6 +316,93 @@ class PluginDefaultServiceTest {
     }
 
     @Test
+    void shouldInjectFlowDefaultsGivenDeprecatedTaskDefaults() throws FlowProcessingException {
+        // Given
+        String source = """
+                id: default-test
+                namespace: io.kestra.tests
+
+                tasks:
+                - id: test
+                  type: io.kestra.core.services.PluginDefaultServiceTest$DefaultTester
+                  set: 666
+
+                taskDefaults:
+                - type: io.kestra.core.services.PluginDefaultServiceTest$DefaultTester
+                  forced: false
+                  values:
+                    set: 123
+                    value: 1
+            """;
+
+        // When
+        var tenant = TestsUtils.randomTenant(PluginDefaultServiceTest.class.getSimpleName());
+        FlowWithSource injected = pluginDefaultService.parseFlowWithAllDefaults(tenant, source, false);
+
+        // Then - taskDefaults should behave identically to pluginDefaults
+        assertThat(((DefaultTester) injected.getTasks().getFirst()).getValue(), is(1));
+        assertThat(((DefaultTester) injected.getTasks().getFirst()).getSet(), is(666)); // task value takes precedence over non-forced default
+    }
+
+    @Test
+    void shouldInjectForcedDefaultsGivenDeprecatedTaskDefaults() throws FlowProcessingException {
+        // Given - forced defaults declared via the deprecated 'taskDefaults' key
+        String source = """
+                id: default-test
+                namespace: io.kestra.tests
+
+                tasks:
+                - id: test
+                  type: io.kestra.core.services.PluginDefaultServiceTest$DefaultTester
+                  set: 666
+
+                taskDefaults:
+                - type: io.kestra.core.services.PluginDefaultServiceTest$DefaultTester
+                  forced: true
+                  values:
+                    set: 123
+            """;
+
+        // When
+        var tenant = TestsUtils.randomTenant(PluginDefaultServiceTest.class.getSimpleName());
+        FlowWithSource injected = pluginDefaultService.parseFlowWithAllDefaults(tenant, source, false);
+
+        // Then - forced default overrides the task-level value
+        assertThat(((DefaultTester) injected.getTasks().getFirst()).getSet(), is(123));
+    }
+
+    @Test
+    void shouldPreferPluginDefaultsOverTaskDefaults() throws FlowProcessingException {
+        // Given - flow has both pluginDefaults and taskDefaults; pluginDefaults should win
+        String source = """
+                id: default-test
+                namespace: io.kestra.tests
+
+                tasks:
+                - id: test
+                  type: io.kestra.core.services.PluginDefaultServiceTest$DefaultTester
+                  set: 666
+
+                pluginDefaults:
+                - type: io.kestra.core.services.PluginDefaultServiceTest$DefaultTester
+                  values:
+                    value: 42
+
+                taskDefaults:
+                - type: io.kestra.core.services.PluginDefaultServiceTest$DefaultTester
+                  values:
+                    value: 99
+            """;
+
+        // When
+        var tenant = TestsUtils.randomTenant(PluginDefaultServiceTest.class.getSimpleName());
+        FlowWithSource injected = pluginDefaultService.parseFlowWithAllDefaults(tenant, source, false);
+
+        // Then - pluginDefaults takes precedence
+        assertThat(((DefaultTester) injected.getTasks().getFirst()).getValue(), is(42));
+    }
+
+    @Test
     public void shouldNotInjectDefaultsGivenExistingTaskValue() throws FlowProcessingException {
         // Given
         var tenant = TestsUtils.randomTenant(PluginDefaultServiceTest.class.getSimpleName());


### PR DESCRIPTION
### ✨ Description

The `taskDefaults` property has been [deprecated since v0.17](https://kestra.io/docs/migration-guide/v0.17.0/renamed-plugins). However, not yet removed in v1.3.

Making it ignored silently broke legacy flows.

AFIAK the upcoming v2.0 is going to remove `taskDefaults`, but the versions prior that should not break legacy flows using the property.

### 🛠️ Backend Checklist

_If this PR does not include any backend changes, delete this entire section._

- [x] Code compiles successfully and passes all checks
- [ ] All unit and integration tests pass

### 📝 Additional Notes

Tested on the following flow:

```yaml
id: task_defaults
namespace: company.team

tasks:
  - id: hello
    type: io.kestra.plugin.scripts.shell.Commands
    commands:
       - 'echo "---${ENV_VAR}---"'

taskDefaults:
#pluginDefaults:
  - type: io.kestra.plugin.scripts.shell.Commands
    values:
      taskRunner:
        type: io.kestra.plugin.core.runner.Process
      env:
        ENV_VAR: 'foo'
```

