### PR TITLE
fix(worker): prevent stale stream cancel from wiping new worker registration

### DIFF
--- a/worker-controller/src/main/java/io/kestra/controller/grpc/services/GrpcWorkerControllerService.java
+++ b/worker-controller/src/main/java/io/kestra/controller/grpc/services/GrpcWorkerControllerService.java
@@ -86,7 +86,7 @@ public class GrpcWorkerControllerService extends WorkerControllerServiceGrpc.Wor
             WorkerStreamContext<WorkerJobResponse> ctx = contextRef.get();
             if (ctx != null) {
                 log.info("Worker [{}] stream cancelled", ctx.getWorkerId());
-                workerJobDispatcher.unregisterWorker(ctx.getWorkerId());
+                workerJobDispatcher.unregisterWorker(ctx);
             } else {
                 log.info("Worker stream cancelled before initialization");
             }
@@ -148,7 +148,7 @@ public class GrpcWorkerControllerService extends WorkerControllerServiceGrpc.Wor
                 WorkerStreamContext<WorkerJobResponse> context = contextRef.get();
                 if (context != null) {
                     log.warn("Worker [{}] stream error: {}", context.getWorkerId(), t.getMessage());
-                    workerJobDispatcher.unregisterWorker(context.getWorkerId());
+                    workerJobDispatcher.unregisterWorker(context);
                 } else {
                     log.warn("Worker stream error before initialization: {}", t.getMessage());
                 }
@@ -159,7 +159,7 @@ public class GrpcWorkerControllerService extends WorkerControllerServiceGrpc.Wor
                 WorkerStreamContext<WorkerJobResponse> context = contextRef.get();
                 if (context != null) {
                     log.info("Worker [{}] stream completed normally", context.getWorkerId());
-                    workerJobDispatcher.unregisterWorker(context.getWorkerId());
+                    workerJobDispatcher.unregisterWorker(context);
                 }
                 responseObserver.onCompleted();
             }

--- a/worker-controller/src/main/java/io/kestra/controller/grpc/services/WorkerJobDispatcher.java
+++ b/worker-controller/src/main/java/io/kestra/controller/grpc/services/WorkerJobDispatcher.java
@@ -329,30 +329,35 @@ public class WorkerJobDispatcher {
     /**
      * Unregisters a worker when the stream disconnects.
      * If this was the last worker for the group, disposes the subscription immediately.
+     * <p>
+     * This method is scoped to a specific stream context: it only removes the registration
+     * if the given {@code context} is still the one currently registered for the worker id.
+     * This prevents a late-firing {@code onError}/{@code onCancel} callback for a stale
+     * stream (e.g., after an HTTP/2 GOAWAY reconnect) from wiping out a fresh registration
+     * the same worker has already established on a new stream.
      *
-     * @param workerId the worker's unique identifier
+     * @param context the worker stream context whose stream has closed
      */
-    public void unregisterWorker(String workerId) {
-        Objects.requireNonNull(workerId, "workerId must not be null");
+    public void unregisterWorker(WorkerStreamContext<WorkerJobResponse> context) {
+        Objects.requireNonNull(context, "context must not be null");
 
-        WorkerStreamContext<WorkerJobResponse> context = activeStreams.get(workerId);
-        if (context == null) {
-            log.warn("Worker [{}] not found", workerId);
-            return;
-        }
-
+        String workerId = context.getWorkerId();
         String workerGroup = context.getWorkerGroup();
+
         GroupState state = groupStates.get(workerGroup);
         if (state == null) {
-            activeStreams.remove(workerId);
+            // No group state — either already disposed, or this context was never the registered one.
+            // Only evict activeStreams if THIS context is still mapped (atomic compare-and-remove).
+            activeStreams.remove(workerId, context);
             return;
         }
 
         state.lock.lock();
         try {
-            // Remove worker from indexes
-            context = activeStreams.remove(workerId);
-            if (context == null) {
+            // Atomic compare-and-remove: only evict if THIS context is still the registered one.
+            // A superseded stale stream must not remove a newer registration for the same workerId.
+            if (!activeStreams.remove(workerId, context)) {
+                log.debug("Ignoring stale unregister for worker [{}]: stream already superseded or unknown", workerId);
                 return;
             }
 

--- a/worker-controller/src/test/java/io/kestra/controller/grpc/services/WorkerJobDispatcherTest.java
+++ b/worker-controller/src/test/java/io/kestra/controller/grpc/services/WorkerJobDispatcherTest.java
@@ -251,7 +251,7 @@ class WorkerJobDispatcherTest {
             dispatcher.registerWorker(context);
 
             // When
-            dispatcher.unregisterWorker("worker-1");
+            dispatcher.unregisterWorker(context);
 
             // Then
             assertThat(dispatcher.getActiveWorkerCount()).isEqualTo(0);
@@ -260,8 +260,11 @@ class WorkerJobDispatcherTest {
 
         @Test
         void shouldHandleUnregisteringUnknownWorker() {
+            // Given - a context that was never registered
+            WorkerStreamContext<WorkerJobResponse> unknown = createWorkerContext("unknown-worker", WORKER_GROUP_A, 10);
+
             // When/Then - should not throw
-            dispatcher.unregisterWorker("unknown-worker");
+            dispatcher.unregisterWorker(unknown);
             assertThat(dispatcher.getActiveWorkerCount()).isEqualTo(0);
         }
 
@@ -274,7 +277,7 @@ class WorkerJobDispatcherTest {
             dispatcher.registerWorker(context2);
 
             // When
-            dispatcher.unregisterWorker("worker-1");
+            dispatcher.unregisterWorker(context1);
 
             // Then
             assertThat(dispatcher.getActiveWorkerCount(WORKER_GROUP_A)).isEqualTo(1);
@@ -481,7 +484,7 @@ class WorkerJobDispatcherTest {
             MockQueueSubscriber subscriber = getSubscriberForGroup(WORKER_GROUP_A);
 
             // When
-            dispatcher.unregisterWorker("worker-1");
+            dispatcher.unregisterWorker(context);
 
             // Then - subscription should be closed immediately
             assertThat(subscriber.closed.get()).isTrue();
@@ -492,7 +495,7 @@ class WorkerJobDispatcherTest {
             // Given
             WorkerStreamContext<WorkerJobResponse> context1 = createWorkerContext("worker-1", WORKER_GROUP_A, 10);
             dispatcher.registerWorker(context1);
-            dispatcher.unregisterWorker("worker-1");
+            dispatcher.unregisterWorker(context1);
 
             MockQueueSubscriber originalSubscriber = getSubscriberForGroup(WORKER_GROUP_A);
             assertThat(originalSubscriber.closed.get()).isTrue(); // Verify disposed
@@ -568,10 +571,10 @@ class WorkerJobDispatcherTest {
                 // When
                 for (int i = 0; i < numIterations; i++) {
                     final String workerId = "worker-" + i;
+                    final WorkerStreamContext<WorkerJobResponse> context = createWorkerContext(workerId, WORKER_GROUP_A, 10);
                     executor.submit(() ->
                         {
                             try {
-                                WorkerStreamContext<WorkerJobResponse> context = createWorkerContext(workerId, WORKER_GROUP_A, 10);
                                 dispatcher.registerWorker(context);
                             } catch (Exception e) {
                                 errors.incrementAndGet();
@@ -583,7 +586,7 @@ class WorkerJobDispatcherTest {
                     executor.submit(() ->
                     {
                         try {
-                            dispatcher.unregisterWorker(workerId);
+                            dispatcher.unregisterWorker(context);
                         } catch (Exception e) {
                             errors.incrementAndGet();
                         } finally {
@@ -831,7 +834,7 @@ class WorkerJobDispatcherTest {
         dispatcher.registerWorker(context);
 
         // When
-        dispatcher.unregisterWorker("worker-1");
+        dispatcher.unregisterWorker(context);
 
         // Then
         verify(mockMetricRegistry).counter(
@@ -890,12 +893,45 @@ class WorkerJobDispatcherTest {
         dispatcher.registerWorker(context);
 
         // When
-        dispatcher.unregisterWorker("worker-1");
+        dispatcher.unregisterWorker(context);
 
         // Then - find should be called to locate gauges for removal
         verify(mockMetricRegistry, atLeastOnce()).find(MetricRegistry.METRIC_CONTROLLER_ACTIVE_WORKER_COUNT);
         verify(mockMetricRegistry, atLeastOnce()).find(MetricRegistry.METRIC_CONTROLLER_AVAILABLE_PERMITS_COUNT);
         verify(mockMetricRegistry, atLeastOnce()).find(MetricRegistry.METRIC_CONTROLLER_INFLIGHT_COUNT);
+    }
+
+    @Test
+    void shouldNotRemoveNewerRegistrationWhenStaleStreamCancelLateFires() {
+        // Reproduces the bug where a delayed onError/onCancel for an old stream
+        // (e.g., after an HTTP/2 GOAWAY max_age reconnect) wipes out a fresh
+        // registration the worker has already established for the same workerId.
+        // The controller then has no worker state and jobs get re-queued while
+        // the worker is still happily connected on the new stream.
+
+        // Given - a worker is registered with stream A
+        WorkerStreamContext<WorkerJobResponse> streamA = createWorkerContext("worker-1", WORKER_GROUP_A, 10);
+        dispatcher.registerWorker(streamA);
+
+        // And - stream A has been unregistered (e.g., GOAWAY received)
+        dispatcher.unregisterWorker(streamA);
+
+        // And - the worker reconnects as stream B for the same workerId
+        WorkerStreamContext<WorkerJobResponse> streamB = createWorkerContext("worker-1", WORKER_GROUP_A, 10);
+        dispatcher.registerWorker(streamB);
+
+        // When - a late onError/onCancel callback fires for the stale stream A
+        dispatcher.unregisterWorker(streamA);
+
+        // Then - stream B's registration must remain intact
+        assertThat(dispatcher.getActiveWorkerCount()).isEqualTo(1);
+        assertThat(dispatcher.getActiveWorkerCount(WORKER_GROUP_A)).isEqualTo(1);
+        MockQueueSubscriber activeSubscriber = createdSubscribers.stream()
+            .filter(s -> s.group.equals(WORKER_GROUP_A))
+            .filter(s -> !s.closed.get())
+            .findFirst()
+            .orElse(null);
+        assertThat(activeSubscriber).isNotNull();
     }
 
     /**


### PR DESCRIPTION
A late-firing onError/onCancel callback for an old gRPC stream (e.g., after an HTTP/2 GOAWAY reconnect) was evicting the fresh registration that the same worker had already established on a new stream, leaving the controller with no worker state and causing jobs to be re-queued while the worker was still connected.

Scope unregisterWorker to the specific WorkerStreamContext and use an atomic ConcurrentHashMap.remove(key, value) so superseded streams cannot disturb a newer registration for the same workerId