### PR TITLE
feat(tasks): inject outputFiles map into Pebble context for script tasks

### DIFF
--- a/script/src/main/java/io/kestra/plugin/scripts/exec/AbstractExecScript.java
+++ b/script/src/main/java/io/kestra/plugin/scripts/exec/AbstractExecScript.java
@@ -93,6 +93,13 @@ public abstract class AbstractExecScript extends Task implements NamespaceFilesI
 
     private Object inputFiles;
 
+    @Schema(
+        title = "List of output file names to capture after execution.",
+        description = """
+            Declares files produced by the script that should be uploaded to Kestra's internal storage.
+            Use `{{ outputFiles["filename"] }}` in your script body to get the resolved absolute path — this works for local runners (Process, Docker) and remote runners (Kubernetes, cloud batch).
+            Glob patterns (e.g. `*.csv`) are supported for post-run collection but cannot be referenced via Pebble expressions inside the script."""
+    )
     private Property<List<String>> outputFiles;
 
     @Schema(

--- a/script/src/main/java/io/kestra/plugin/scripts/exec/scripts/runners/CommandsWrapper.java
+++ b/script/src/main/java/io/kestra/plugin/scripts/exec/scripts/runners/CommandsWrapper.java
@@ -153,8 +153,25 @@ public class CommandsWrapper implements TaskCommands {
             NamespaceFilesUtils.loadNamespaceFiles(runContext, this.namespaceFiles);
         }
 
+        // Inject non-glob outputFiles into the Pebble render context as a name→path map before any rendering.
+        // This makes {{ outputFiles["name"] }} resolvable in scripts, consistent with JDBC tasks.
+        // Glob patterns are skipped here — they cannot resolve to a single path; post-run collection still handles them.
+        Map<String, Object> runnerVars = taskRunner.additionalVars(runContext, this);
+        if (this.outputFiles != null && !this.outputFiles.isEmpty()) {
+            String workingDir = String.valueOf(runnerVars.getOrDefault(ScriptService.VAR_WORKING_DIR, this.workingDirectory));
+            Map<String, String> outputFilesMap = new LinkedHashMap<>();
+            for (String name : this.outputFiles) {
+                if (!name.contains("*") && !name.contains("?") && !name.contains("[")) {
+                    outputFilesMap.put(name, workingDir + "/" + name);
+                }
+            }
+            if (!outputFilesMap.isEmpty()) {
+                runnerVars.put("outputFiles", outputFilesMap);
+            }
+        }
+
         if (this.inputFiles != null) {
-            FilesService.inputFiles(runContext, taskRunner.additionalVars(runContext, this), this.inputFiles);
+            FilesService.inputFiles(runContext, runnerVars, this.inputFiles);
         }
 
         RunContext taskRunnerRunContext = runContext.cloneForPlugin(taskRunner);

--- a/script/src/test/java/io/kestra/plugin/scripts/exec/scripts/runners/CommandsWrapperOutputFilesTest.java
+++ b/script/src/test/java/io/kestra/plugin/scripts/exec/scripts/runners/CommandsWrapperOutputFilesTest.java
@@ -1,0 +1,82 @@
+package io.kestra.plugin.scripts.exec.scripts.runners;
+
+import com.google.common.collect.ImmutableMap;
+import io.kestra.core.context.TestRunContextFactory;
+import io.kestra.core.junit.annotations.KestraTest;
+import io.kestra.core.models.property.Property;
+import io.kestra.core.models.tasks.Task;
+import io.kestra.core.runners.RunContext;
+import io.kestra.core.storages.StorageInterface;
+import io.kestra.core.tenant.TenantService;
+import io.kestra.core.utils.TestsUtils;
+import io.kestra.plugin.core.runner.Process;
+import io.kestra.plugin.scripts.exec.scripts.models.ScriptOutput;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@KestraTest
+class CommandsWrapperOutputFilesTest {
+
+    private static final Task TASK = new Task() {
+        @Override
+        public String getId() {
+            return "test";
+        }
+
+        @Override
+        public String getType() {
+            return "test";
+        }
+    };
+
+    @Inject
+    private TestRunContextFactory runContextFactory;
+
+    @Inject
+    private StorageInterface storageInterface;
+
+    @Test
+    void shouldResolveOutputFilesPebbleExpressionInScript() throws Exception {
+        // Given
+        RunContext runContext = TestsUtils.mockRunContext(runContextFactory, TASK, ImmutableMap.of());
+
+        // Use Property.ofExpression to simulate YAML deserialization (value=null → Pebble rendering runs).
+        // Dot-notation {{ outputFiles.outfile }} avoids nested quote escaping in the JSON expression.
+        // When — script writes the resolved Pebble path to 'outfile' so the content proves resolution.
+        ScriptOutput run = new CommandsWrapper(runContext)
+            .withTaskRunner(Process.instance())
+            .withOutputFiles(List.of("outfile"))
+            .withInterpreter(Property.ofValue(List.of("/bin/sh", "-c")))
+            .withCommands(Property.<List<String>>ofExpression("[\"echo -n {{ outputFiles.outfile }} > outfile\"]"))
+            .run();
+
+        // Then
+        assertThat(run.getExitCode()).isEqualTo(0);
+        assertThat(run.getOutputFiles()).containsKey("outfile");
+        String content = new String(storageInterface.get(TenantService.MAIN_TENANT, null, run.getOutputFiles().get("outfile")).readAllBytes());
+        // The file content should be the resolved absolute path ending with /outfile
+        assertThat(content).endsWith("/outfile");
+    }
+
+    @Test
+    void shouldStillCollectGlobOutputFilesAfterExecution() throws Exception {
+        // Given — glob patterns are NOT injected into Pebble context but are still collected post-run
+        RunContext runContext = TestsUtils.mockRunContext(runContextFactory, TASK, ImmutableMap.of());
+
+        // When
+        ScriptOutput run = new CommandsWrapper(runContext)
+            .withTaskRunner(Process.instance())
+            .withOutputFiles(List.of("*.txt"))
+            .withInterpreter(Property.ofValue(List.of("/bin/sh", "-c")))
+            .withCommands(Property.ofValue(List.of("echo hello > result.txt")))
+            .run();
+
+        // Then — glob still collected even though it was not in the Pebble context
+        assertThat(run.getExitCode()).isEqualTo(0);
+        assertThat(run.getOutputFiles()).containsKey("result.txt");
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #13765 — `{{ outputFiles["name"] }}` now resolves correctly inside script bodies for all runners.

**Root cause:** `CommandsWrapper.run()` built a Pebble render context via `taskRunner.additionalVars()` but never seeded an `outputFiles` key into it. DuckDB already did this correctly via `PluginUtilsService.createOutputFiles()` — this PR replicates that pattern in the Script pipeline.

**Changes:**
- `CommandsWrapper.run()`: after obtaining `runnerVars` from `taskRunner.additionalVars()`, inject `outputFiles: {name → workingDir/name}` for non-glob filenames. The map is written into the cached mutable `HashMap` returned by `additionalVars()`, so all subsequent `renderCommands()` calls see it automatically.
- `AbstractExecScript.outputFiles`: add `@Schema` annotation documenting Pebble usage and the glob caveat (glob entries cannot resolve to a single path — post-run collection still handles them).
- New test class `CommandsWrapperOutputFilesTest` with two tests: Pebble expression resolution for `Process` runner, and glob backward-compat verification.

**Backward compat:** existing scripts using plain filenames (e.g., `fs.writeFileSync('out.txt', ...)`) keep working — they write relative to `workingDir`, and `FilesService.outputFiles` globs them post-run regardless.

## Test plan

- [ ] `./gradlew :script:test --tests "*CommandsWrapperOutputFilesTest*"` — both tests pass
- [ ] `./gradlew :script:test` — no regressions
- [ ] Script task with `outputFiles: ["*.csv"]` still uploads glob-matched files (backward compat)
- [ ] Script task with `outputFiles: ["out.txt"]` and `{{ outputFiles["out.txt"] }}` in body resolves to `<workingDir>/out.txt` for Process runner
- [ ] Same form works in Docker runner (remote path inside container)