### PR TITLE
fix: only remove worker job running on terminal task state

### DIFF
--- a/worker-controller/src/main/java/io/kestra/controller/grpc/services/GrpcWorkerControllerService.java
+++ b/worker-controller/src/main/java/io/kestra/controller/grpc/services/GrpcWorkerControllerService.java
@@ -175,8 +175,10 @@ public class GrpcWorkerControllerService extends WorkerControllerServiceGrpc.Wor
             try {
                 workerTaskResultQueue.emit(workerTaskResult);
 
-                // remove the worker job running as the task has been done by the worker and the result send to the queue
-                workerJobRunningStateStore.deleteByKey(workerTaskResult.getTaskRun().getId());
+                // only remove the worker job running once the task has reached a terminal state
+                if (workerTaskResult.getTaskRun().getState().isTerminated()) {
+                    workerJobRunningStateStore.deleteByKey(workerTaskResult.getTaskRun().getId());
+                }
             } catch (QueueException e) {
                 // If there is a QueueException it can either be caused by the message limit or another queue issue.
                 // We fail the task and try to resend it.
@@ -195,8 +197,10 @@ public class GrpcWorkerControllerService extends WorkerControllerServiceGrpc.Wor
                 try {
                     this.workerTaskResultQueue.emit(failed);
 
-                    // remove the worker job running as the task has been done by the worker and the result send to the queue
-                    workerJobRunningStateStore.deleteByKey(failed.getTaskRun().getId());
+                    // only remove the worker job running once the task has reached a terminal state
+                    if (failed.getTaskRun().getState().isTerminated()) {
+                        workerJobRunningStateStore.deleteByKey(failed.getTaskRun().getId());
+                    }
                 } catch (QueueException ex) {
                     log.error("Unable to emit the worker task result for task {} taskrun {}", failed.getTaskRun().getTaskId(), failed.getTaskRun().getId(), e);
                 }


### PR DESCRIPTION
✨ Description       

GrpcWorkerControllerService was deleting the WorkerTaskRunning record from the database on every result received from the worker, including intermediate  
RUNNING state results.
                                                                                                                                                          
Because a worker sends a RUNNING result as soon as it begins executing a task, the record was being removed before the task had actually finished. If the 
worker was then forcefully terminated before sending a final result, the liveness coordinator's recovery scan found no WorkerTaskRunning entries for that
worker and had nothing to resubmit — causing the task to be silently lost rather than re-dispatched to a healthy worker.                                  
                                                          
The fix restores the isTerminated() guard so that the WorkerTaskRunning record is only deleted once the task has reached a terminal state (SUCCESS,       
FAILED, KILLED, etc.), keeping the record alive for the full duration of execution and ensuring the liveness coordinator can correctly resubmit tasks when
 a worker dies mid-execution.  