### PR TITLE
test(executions): unflaky should_find_all by fixing wrong PREFIX value

### DIFF
--- a/core/src/test/java/io/kestra/core/repositories/AbstractExecutionRepositoryTest.java
+++ b/core/src/test/java/io/kestra/core/repositories/AbstractExecutionRepositoryTest.java
@@ -21,7 +21,6 @@ import com.google.common.collect.ImmutableMap;
 
 import io.kestra.core.contexts.KestraConfig;
 import io.kestra.core.exceptions.InvalidQueryFiltersException;
-import io.kestra.core.junit.annotations.FlakyTest;
 import io.kestra.core.models.Label;
 import io.kestra.core.models.QueryFilter;
 import io.kestra.core.models.QueryFilter.Field;
@@ -205,7 +204,6 @@ public abstract class AbstractExecutionRepositoryTest {
 
     @ParameterizedTest
     @MethodSource("filterCombinations")
-    @FlakyTest(description = "Filtering tests are sometimes returning 0")
     void should_find_all(QueryFilter filter, int expectedSize) {
         var tenant = TestsUtils.randomTenant(this.getClass().getSimpleName());
         inject(tenant, "executionTriggerId");
@@ -258,7 +256,7 @@ public abstract class AbstractExecutionRepositoryTest {
             Arguments.of(QueryFilter.builder().field(Field.FLOW_ID).value("[ful]{4}").operation(Op.REGEX).build(), 16),
             Arguments.of(QueryFilter.builder().field(Field.FLOW_ID).value(List.of(FLOW, "other")).operation(Op.IN).build(), 16),
             Arguments.of(QueryFilter.builder().field(Field.FLOW_ID).value(List.of(FLOW, "other2")).operation(Op.NOT_IN).build(), 13),
-            Arguments.of(QueryFilter.builder().field(Field.FLOW_ID).value("ful").operation(Op.PREFIX).build(), 16),
+            Arguments.of(QueryFilter.builder().field(Field.FLOW_ID).value(FLOW).operation(Op.PREFIX).build(), 16),
 
             Arguments.of(QueryFilter.builder().field(Field.START_DATE).value(ZonedDateTime.now().minusMinutes(1)).operation(Op.GREATER_THAN).build(), 29),
             Arguments.of(QueryFilter.builder().field(Field.END_DATE).value(ZonedDateTime.now().plusMinutes(1)).operation(Op.LESS_THAN).build(), 29),


### PR DESCRIPTION
## Summary
- The `should_find_all` parameterized test in `AbstractExecutionRepositoryTest` was tagged `@FlakyTest(description = "Filtering tests are sometimes returning 0")`, but case `[37] FLOW_ID PREFIX "ful", expectedSize=16` was deterministically returning 0 on every run (verified across H2, Postgres, MySQL).
- `Op.PREFIX` is namespace-style: `field = value OR field LIKE value + ".%"`. With `FLOW = "full"`, neither branch matches `"ful"`, so the expected 16 was unreachable. The other PREFIX case (`NAMESPACE PREFIX "io.kestra"`) works because `"io.kestra.unittest"` matches `"io.kestra.%"`.
- Changed the value from `"ful"` to `FLOW` so the eq-branch of PREFIX matches the 16 `"full"` executions, and removed the misleading `@FlakyTest` annotation (and its import).

## Test plan
- [x] `./gradlew :jdbc-h2:test --tests "io.kestra.repository.h2.H2ExecutionRepositoryTest.should_find_all*"` — 5 consecutive runs green
- [x] `./gradlew :jdbc-postgres:test --tests "io.kestra.repository.postgres.PostgresExecutionRepositoryTest.should_find_all*"` — green
- [x] `./gradlew :jdbc-mysql:test --tests "io.kestra.repository.mysql.MysqlExecutionRepositoryTest.should_find_all*"` — green