### PR TITLE
fix(tenants): update taskRunList tenantId during tenant migration

### DIFF
--- a/jdbc-h2/src/main/java/io/kestra/repository/h2/H2TenantMigration.java
+++ b/jdbc-h2/src/main/java/io/kestra/repository/h2/H2TenantMigration.java
@@ -50,4 +50,14 @@ public class H2TenantMigration extends AbstractJdbcTenantMigration {
             """.formatted(table.getName());
         return context.execute(query, "tutorial");
     }
+
+    @Override
+    protected String selectExecutionsQuery() {
+        return "SELECT \"key\", \"value\" FROM \"executions\" LIMIT ? OFFSET ?";
+    }
+
+    @Override
+    protected String updateExecutionQuery() {
+        return "UPDATE \"executions\" SET \"value\" = ? WHERE \"key\" = ?";
+    }
 }

--- a/jdbc-mysql/src/main/java/io/kestra/repository/mysql/MysqlTenantMigration.java
+++ b/jdbc-mysql/src/main/java/io/kestra/repository/mysql/MysqlTenantMigration.java
@@ -39,4 +39,14 @@ public class MysqlTenantMigration extends AbstractJdbcTenantMigration {
 
         return context.execute(query, MAIN_TENANT, MAIN_TENANT);
     }
+
+    @Override
+    protected String selectExecutionsQuery() {
+        return "SELECT `key`, `value` FROM `executions` WHERE JSON_LENGTH(`value`, '$.taskRunList') > 0 LIMIT ? OFFSET ?";
+    }
+
+    @Override
+    protected String updateExecutionQuery() {
+        return "UPDATE `executions` SET `value` = ? WHERE `key` = ?";
+    }
 }

--- a/jdbc-postgres/src/main/java/io/kestra/repository/postgres/PostgresTenantMigration.java
+++ b/jdbc-postgres/src/main/java/io/kestra/repository/postgres/PostgresTenantMigration.java
@@ -2,6 +2,7 @@ package io.kestra.repository.postgres;
 
 import org.jooq.DSLContext;
 import org.jooq.Table;
+import org.jooq.impl.DSL;
 
 import io.kestra.jdbc.JooqDSLContextWrapper;
 import io.kestra.jdbc.repository.AbstractJdbcTenantMigration;
@@ -39,5 +40,53 @@ public class PostgresTenantMigration extends AbstractJdbcTenantMigration {
             """.formatted(table.getQualifiedName());
 
         return context.execute(query, MAIN_TENANT, MAIN_TENANT);
+    }
+
+    @Override
+    protected String selectExecutionsQuery() {
+        return "SELECT key, value FROM executions LIMIT ? OFFSET ?";
+    }
+
+    @Override
+    protected String updateExecutionQuery() {
+        return "UPDATE executions SET value = ? WHERE key = ?";
+    }
+
+    @Override
+    protected int updateExecutionTaskRunsTenantId() {
+        return dslContextWrapper.transactionResult(configuration -> {
+            DSLContext context = DSL.using(configuration);
+            String query = """
+                UPDATE executions
+                SET value = jsonb_set(value, '{taskRunList}',
+                    (SELECT jsonb_agg(elem || jsonb_build_object('tenantId', value->>'tenantId'))
+                     FROM jsonb_array_elements(value->'taskRunList') AS elem)
+                )
+                WHERE value->'taskRunList' IS NOT NULL
+                  AND jsonb_array_length(value->'taskRunList') > 0
+                  AND EXISTS (
+                    SELECT 1 FROM jsonb_array_elements(value->'taskRunList') AS elem
+                    WHERE (elem->>'tenantId') IS NULL
+                  )
+                """;
+            return context.execute(query);
+        });
+    }
+
+    @Override
+    protected int countExecutionsWithMissingTaskRunTenantId() {
+        return dslContextWrapper.transactionResult(configuration -> {
+            DSLContext context = DSL.using(configuration);
+            String query = """
+                SELECT COUNT(*) FROM executions
+                WHERE value->'taskRunList' IS NOT NULL
+                  AND jsonb_array_length(value->'taskRunList') > 0
+                  AND EXISTS (
+                    SELECT 1 FROM jsonb_array_elements(value->'taskRunList') AS elem
+                    WHERE (elem->>'tenantId') IS NULL
+                  )
+                """;
+            return context.fetchOne(query).get(0, int.class);
+        });
     }
 }

--- a/jdbc/src/main/java/io/kestra/jdbc/repository/AbstractJdbcTenantMigration.java
+++ b/jdbc/src/main/java/io/kestra/jdbc/repository/AbstractJdbcTenantMigration.java
@@ -3,10 +3,18 @@ package io.kestra.jdbc.repository;
 import java.util.List;
 import java.util.Locale;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+import io.kestra.core.serializers.JacksonMapper;
 import io.kestra.core.utils.ListUtils;
 import org.jooq.Condition;
 import org.jooq.DSLContext;
 import org.jooq.Field;
+import org.jooq.Record;
+import org.jooq.Result;
 import org.jooq.Schema;
 import org.jooq.Table;
 import org.jooq.impl.DSL;
@@ -15,6 +23,8 @@ import io.kestra.core.repositories.TenantMigrationInterface;
 import io.kestra.jdbc.JooqDSLContextWrapper;
 
 import lombok.extern.slf4j.Slf4j;
+
+import static io.kestra.core.tenant.TenantService.MAIN_TENANT;
 
 @Slf4j
 public abstract class AbstractJdbcTenantMigration implements TenantMigrationInterface {
@@ -104,6 +114,19 @@ public abstract class AbstractJdbcTenantMigration implements TenantMigrationInte
             }
         }
 
+        // Update taskRunList tenantId inside executions
+        if (!dryRun) {
+            int taskRunUpdates = updateExecutionTaskRunsTenantId();
+            log.info("✅ Updated taskRunList tenantId in {} execution(s).", taskRunUpdates);
+        } else {
+            int taskRunCount = countExecutionsWithMissingTaskRunTenantId();
+            if (taskRunCount > 0) {
+                log.info("🔸 executions: {} execution(s) with taskRunList entries missing tenantId.", taskRunCount);
+            } else {
+                log.info("✅ executions: No taskRunList tenantId updates needed.");
+            }
+        }
+
         if (dryRun) {
             log.info("🧪 Dry-run complete. {} row(s) would be updated.", totalAffected);
         } else {
@@ -118,6 +141,101 @@ public abstract class AbstractJdbcTenantMigration implements TenantMigrationInte
     protected abstract int updateTenantIdField(Table<?> table, DSLContext context);
 
     protected abstract int updateTenantIdFieldAndKey(Table<?> table, DSLContext context);
+
+    private static final ObjectMapper MAPPER = JacksonMapper.ofJson();
+    private static final int BATCH_SIZE = 500;
+
+    protected abstract String selectExecutionsQuery();
+
+    protected abstract String updateExecutionQuery();
+
+    protected int updateExecutionTaskRunsTenantId() {
+        return dslContextWrapper.transactionResult(configuration -> {
+            DSLContext context = DSL.using(configuration);
+            int totalUpdated = 0;
+            int offset = 0;
+
+            while (true) {
+                Result<Record> records = context.fetch(selectExecutionsQuery(), BATCH_SIZE, offset);
+
+                if (records.isEmpty()) {
+                    break;
+                }
+
+                for (Record record : records) {
+                    String key = record.get("key", String.class);
+                    String value = record.get("value", String.class);
+                    try {
+                        JsonNode root = MAPPER.readTree(value);
+                        JsonNode taskRunList = root.get("taskRunList");
+                        if (taskRunList == null || !taskRunList.isArray() || taskRunList.isEmpty()) {
+                            continue;
+                        }
+
+                        boolean modified = false;
+                        String tenantId = root.has("tenantId") && !root.get("tenantId").isNull()
+                            ? root.get("tenantId").asText() : MAIN_TENANT;
+                        for (JsonNode taskRun : taskRunList) {
+                            if (taskRun.isObject() && (taskRun.get("tenantId") == null || taskRun.get("tenantId").isNull())) {
+                                ((ObjectNode) taskRun).put("tenantId", tenantId);
+                                modified = true;
+                            }
+                        }
+
+                        if (modified) {
+                            String updatedValue = MAPPER.writeValueAsString(root);
+                            context.execute(updateExecutionQuery(), updatedValue, key);
+                            totalUpdated++;
+                        }
+                    } catch (JsonProcessingException e) {
+                        log.warn("Failed to parse execution JSON for key={}, skipping taskRunList update", key, e);
+                    }
+                }
+
+                offset += BATCH_SIZE;
+            }
+
+            return totalUpdated;
+        });
+    }
+
+    protected int countExecutionsWithMissingTaskRunTenantId() {
+        return dslContextWrapper.transactionResult(configuration -> {
+            DSLContext context = DSL.using(configuration);
+            int count = 0;
+            int offset = 0;
+
+            while (true) {
+                Result<Record> records = context.fetch(selectExecutionsQuery(), BATCH_SIZE, offset);
+
+                if (records.isEmpty()) {
+                    break;
+                }
+
+                for (Record record : records) {
+                    String value = record.get("value", String.class);
+                    try {
+                        JsonNode root = MAPPER.readTree(value);
+                        JsonNode taskRunList = root.get("taskRunList");
+                        if (taskRunList != null && taskRunList.isArray()) {
+                            for (JsonNode taskRun : taskRunList) {
+                                if (taskRun.isObject() && (taskRun.get("tenantId") == null || taskRun.get("tenantId").isNull())) {
+                                    count++;
+                                    break;
+                                }
+                            }
+                        }
+                    } catch (JsonProcessingException e) {
+                        log.warn("Failed to parse execution JSON, skipping", e);
+                    }
+                }
+
+                offset += BATCH_SIZE;
+            }
+
+            return count;
+        });
+    }
 
     protected int deleteTutorialFlows(Table<?> table, DSLContext context) {
         String query = "DELETE FROM %s WHERE namespace = ?".formatted(table.getName());


### PR DESCRIPTION
 - fix #https://github.com/kestra-io/kestra-ee/issues/7588

## Summary
- Tenant migration now updates nested `taskRunList` entries inside executions with the correct `tenantId`
- Shared batch processing logic in `AbstractJdbcTenantMigration`; Postgres uses pure SQL with `jsonb_agg`/`jsonb_array_elements` for efficiency
- MySQL and H2 provide dialect-specific query overrides to the abstract base

## Context
After tenant migration, `taskRunList` entries inside executions retain a null `tenantId`. This causes failures when downstream components (e.g. `WorkerJobTopicNameExtractor`) expect `taskRun.getTenantId()` to be set.

Companion PR: kestra-io/kestra-ee (same branch name)

## Test plan
- [ ] Verify compilation: `./gradlew :jdbc:compileJava :jdbc-postgres:compileJava :jdbc-mysql:compileJava :jdbc-h2:compileJava`
- [ ] Run existing tenant migration tests
- [ ] Test with execution containing taskRuns with null tenantId — verify they get updated