### PR TITLE
feat(core): monitor queue subscriber pause/resume and fix subscribers gauge

### DIFF
--- a/core/src/main/java/io/kestra/core/metrics/MetricRegistry.java
+++ b/core/src/main/java/io/kestra/core/metrics/MetricRegistry.java
@@ -179,10 +179,10 @@ public class MetricRegistry {
     public static final String METRIC_QUEUE_MESSAGE_LAG_COUNT_DESCRIPTION = "Total number of messages in the queue that are not yet consumed";
     public static final String METRIC_QUEUE_SUBSCRIBERS_COUNT = "queue.subscribers.count";
     public static final String METRIC_QUEUE_SUBSCRIBERS_COUNT_DESCRIPTION = "Queue subscribers count";
-    public static final String METRIC_QUEUE_SUBSCRIBER_PAUSE_COUNT = "queue.subscriber.pause.count";
-    public static final String METRIC_QUEUE_SUBSCRIBER_PAUSE_COUNT_DESCRIPTION = "The total number of queue subscriber pause operations";
-    public static final String METRIC_QUEUE_SUBSCRIBER_RESUME_COUNT = "queue.subscriber.resume.count";
-    public static final String METRIC_QUEUE_SUBSCRIBER_RESUME_COUNT_DESCRIPTION = "The total number of queue subscriber resume operations";
+    public static final String METRIC_QUEUE_SUBSCRIBERS_PAUSE_COUNT = "queue.subscribers.pause.count";
+    public static final String METRIC_QUEUE_SUBSCRIBERS_PAUSE_COUNT_DESCRIPTION = "The total number of queue subscribers pause operations";
+    public static final String METRIC_QUEUE_SUBSCRIBERS_RESUME_COUNT = "queue.subscribers.resume.count";
+    public static final String METRIC_QUEUE_SUBSCRIBERS_RESUME_COUNT_DESCRIPTION = "The total number of queue subscribers resume operations";
 
     public static final String TAG_TASK_TYPE = "task_type";
     public static final String TAG_TRIGGER_TYPE = "trigger_type";

--- a/core/src/main/java/io/kestra/core/metrics/MetricRegistry.java
+++ b/core/src/main/java/io/kestra/core/metrics/MetricRegistry.java
@@ -179,6 +179,10 @@ public class MetricRegistry {
     public static final String METRIC_QUEUE_MESSAGE_LAG_COUNT_DESCRIPTION = "Total number of messages in the queue that are not yet consumed";
     public static final String METRIC_QUEUE_SUBSCRIBERS_COUNT = "queue.subscribers.count";
     public static final String METRIC_QUEUE_SUBSCRIBERS_COUNT_DESCRIPTION = "Queue subscribers count";
+    public static final String METRIC_QUEUE_SUBSCRIBER_PAUSE_COUNT = "queue.subscriber.pause.count";
+    public static final String METRIC_QUEUE_SUBSCRIBER_PAUSE_COUNT_DESCRIPTION = "The total number of queue subscriber pause operations";
+    public static final String METRIC_QUEUE_SUBSCRIBER_RESUME_COUNT = "queue.subscriber.resume.count";
+    public static final String METRIC_QUEUE_SUBSCRIBER_RESUME_COUNT_DESCRIPTION = "The total number of queue subscriber resume operations";
 
     public static final String TAG_TASK_TYPE = "task_type";
     public static final String TAG_TRIGGER_TYPE = "trigger_type";

--- a/core/src/main/java/io/kestra/core/queues/QueueSubscriber.java
+++ b/core/src/main/java/io/kestra/core/queues/QueueSubscriber.java
@@ -63,4 +63,13 @@ public interface QueueSubscriber<T extends Event> {
      * has fully stopped.
      */
     void close();
+
+    /**
+     * Returns whether this subscriber is currently active (subscribed and not yet closed).
+     *
+     * @return true if active; false if not yet started or already closed
+     */
+    default boolean isActive() {
+        return true;
+    }
 }

--- a/jdbc-mysql/build.gradle
+++ b/jdbc-mysql/build.gradle
@@ -1,6 +1,6 @@
- configurations {
-     compileClasspath.extendsFrom(micronaut)
- }
+configurations {
+    implementation.extendsFrom(micronaut)
+}
 
 dependencies {
     implementation project(":core")

--- a/queue/src/main/java/io/kestra/queue/AbstractQueue.java
+++ b/queue/src/main/java/io/kestra/queue/AbstractQueue.java
@@ -28,12 +28,14 @@ abstract class AbstractQueue<T extends Event> implements GenericQueueInterface<T
     protected final QueueService queueService;
     protected final ExecutorService asyncPoolExecutor;
     protected final Counter emitCounter;
+    protected final MetricRegistry metricRegistry;
     private final List<Consumer<T>> listeners = new CopyOnWriteArrayList<>();
     private final List<QueueSubscriber<?>> subscribers = new CopyOnWriteArrayList<>();
 
     AbstractQueue(Class<T> cls, QueueService queueService, ExecutorsUtils executorsUtils, MetricRegistry metricRegistry) {
         this.cls = cls;
         this.queueService = queueService;
+        this.metricRegistry = metricRegistry;
         int maxAsyncThreads = Math.max(4, executorsUtils.getAllocatedCpuCores());
         this.asyncPoolExecutor = executorsUtils.maxCachedThreadPool(maxAsyncThreads, "queue-async-" + queueName());
         this.emitCounter = metricRegistry.counter(MetricRegistry.METRIC_QUEUE_EMIT_COUNT, MetricRegistry.METRIC_QUEUE_EMIT_COUNT_DESCRIPTION, MetricRegistry.TAG_QUEUE_NAME, queueName());
@@ -91,21 +93,31 @@ abstract class AbstractQueue<T extends Event> implements GenericQueueInterface<T
     }
 
     /**
-     * Tracks a subscriber so it can be closed when the queue is closed.
-     * Subclasses should call this method when creating subscribers.
+     * Wraps a subscriber in a {@link MonitoredQueueSubscriber} for pause/resume metric tracking
+     * and registers it so it can be closed when the queue is closed. The returned wrapper also
+     * calls {@link #untrackSubscriber(QueueSubscriber)} on close so {@code queue.subscribers.count}
+     * reflects only currently-live subscribers.
      *
-     * @param subscriber the subscriber to track
-     * @return the subscriber, for fluent chaining
+     * @param subscriber the underlying subscriber to track
+     * @return the monitoring wrapper, for fluent chaining
      */
-    protected <S extends QueueSubscriber<T>> S trackSubscriber(S subscriber) {
-        subscribers.add(subscriber);
-        return subscriber;
+    protected QueueSubscriber<T> trackSubscriber(QueueSubscriber<T> subscriber) {
+        MonitoredQueueSubscriber<T> wrapper = new MonitoredQueueSubscriber<>(subscriber, this, metricRegistry);
+        subscribers.add(wrapper);
+        return wrapper;
+    }
+
+    /**
+     * Removes a subscriber from the tracking list. Called by {@link MonitoredQueueSubscriber#close()}.
+     */
+    void untrackSubscriber(QueueSubscriber<?> subscriber) {
+        subscribers.remove(subscriber);
     }
 
     @Override
     public void close() {
         for (QueueSubscriber<?> subscriber : subscribers) {
-            if (subscriber instanceof AbstractSubscriber<?> abs && abs.isActive()) {
+            if (subscriber.isActive()) {
                 LOG.warn("{} closing subscriber that was not closed by its caller", queueName());
                 try {
                     subscriber.close();

--- a/queue/src/main/java/io/kestra/queue/AbstractSubscriber.java
+++ b/queue/src/main/java/io/kestra/queue/AbstractSubscriber.java
@@ -175,7 +175,8 @@ public abstract class AbstractSubscriber<T extends Event> implements QueueSubscr
         }
     }
 
-    protected boolean isActive() {
+    @Override
+    public boolean isActive() {
         return this.active.get();
     }
 

--- a/queue/src/main/java/io/kestra/queue/MonitoredQueueSubscriber.java
+++ b/queue/src/main/java/io/kestra/queue/MonitoredQueueSubscriber.java
@@ -1,0 +1,76 @@
+package io.kestra.queue;
+
+import java.util.List;
+import java.util.function.Consumer;
+
+import io.kestra.core.exceptions.DeserializationException;
+import io.kestra.core.metrics.MetricRegistry;
+import io.kestra.core.queues.QueueSubscriber;
+import io.kestra.core.queues.event.Event;
+import io.kestra.core.utils.Either;
+
+import io.micrometer.core.instrument.Counter;
+
+/**
+ * Decorator that records pause/resume metrics for a {@link QueueSubscriber} and
+ * removes itself from its parent queue's tracking list on close.
+ */
+final class MonitoredQueueSubscriber<T extends Event> implements QueueSubscriber<T> {
+    private final QueueSubscriber<T> delegate;
+    private final AbstractQueue<T> queue;
+    private final Counter pauseCounter;
+    private final Counter resumeCounter;
+
+    MonitoredQueueSubscriber(QueueSubscriber<T> delegate, AbstractQueue<T> queue, MetricRegistry metricRegistry) {
+        this.delegate = delegate;
+        this.queue = queue;
+        this.pauseCounter = metricRegistry.counter(
+            MetricRegistry.METRIC_QUEUE_SUBSCRIBER_PAUSE_COUNT,
+            MetricRegistry.METRIC_QUEUE_SUBSCRIBER_PAUSE_COUNT_DESCRIPTION,
+            MetricRegistry.TAG_QUEUE_NAME, queue.queueName()
+        );
+        this.resumeCounter = metricRegistry.counter(
+            MetricRegistry.METRIC_QUEUE_SUBSCRIBER_RESUME_COUNT,
+            MetricRegistry.METRIC_QUEUE_SUBSCRIBER_RESUME_COUNT_DESCRIPTION,
+            MetricRegistry.TAG_QUEUE_NAME, queue.queueName()
+        );
+    }
+
+    @Override
+    public QueueSubscriber<T> subscribe(Consumer<Either<T, DeserializationException>> consumer) {
+        delegate.subscribe(consumer);
+        return this;
+    }
+
+    @Override
+    public QueueSubscriber<T> subscribeBatch(Consumer<List<Either<T, DeserializationException>>> consumer) {
+        delegate.subscribeBatch(consumer);
+        return this;
+    }
+
+    @Override
+    public void pause() {
+        pauseCounter.increment();
+        delegate.pause();
+    }
+
+    @Override
+    public void resume() {
+        resumeCounter.increment();
+        delegate.resume();
+    }
+
+    @Override
+    public void close() {
+        try {
+            delegate.close();
+        } finally {
+            queue.untrackSubscriber(this);
+        }
+    }
+
+    @Override
+    public boolean isActive() {
+        return delegate.isActive();
+    }
+}

--- a/queue/src/main/java/io/kestra/queue/MonitoredQueueSubscriber.java
+++ b/queue/src/main/java/io/kestra/queue/MonitoredQueueSubscriber.java
@@ -25,13 +25,13 @@ final class MonitoredQueueSubscriber<T extends Event> implements QueueSubscriber
         this.delegate = delegate;
         this.queue = queue;
         this.pauseCounter = metricRegistry.counter(
-            MetricRegistry.METRIC_QUEUE_SUBSCRIBER_PAUSE_COUNT,
-            MetricRegistry.METRIC_QUEUE_SUBSCRIBER_PAUSE_COUNT_DESCRIPTION,
+            MetricRegistry.METRIC_QUEUE_SUBSCRIBERS_PAUSE_COUNT,
+            MetricRegistry.METRIC_QUEUE_SUBSCRIBERS_PAUSE_COUNT_DESCRIPTION,
             MetricRegistry.TAG_QUEUE_NAME, queue.queueName()
         );
         this.resumeCounter = metricRegistry.counter(
-            MetricRegistry.METRIC_QUEUE_SUBSCRIBER_RESUME_COUNT,
-            MetricRegistry.METRIC_QUEUE_SUBSCRIBER_RESUME_COUNT_DESCRIPTION,
+            MetricRegistry.METRIC_QUEUE_SUBSCRIBERS_RESUME_COUNT,
+            MetricRegistry.METRIC_QUEUE_SUBSCRIBERS_RESUME_COUNT_DESCRIPTION,
             MetricRegistry.TAG_QUEUE_NAME, queue.queueName()
         );
     }

--- a/queue/src/test/java/io/kestra/queue/AbstractDispatchQueueTest.java
+++ b/queue/src/test/java/io/kestra/queue/AbstractDispatchQueueTest.java
@@ -23,8 +23,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.IntStream;
 
-import io.kestra.core.queues.*;
-
 import static io.kestra.core.utils.Rethrow.throwConsumer;
 import static org.awaitility.Awaitility.await;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -289,8 +287,8 @@ public abstract class AbstractDispatchQueueTest extends AbstractQueueTest {
         // Given
         String queueName = ((GenericQueueInterface<?>) dispatchQueue).queueName();
         Tags tags = Tags.of(MetricRegistry.TAG_QUEUE_NAME, queueName);
-        double pauseBefore = counterValue(MetricRegistry.METRIC_QUEUE_SUBSCRIBER_PAUSE_COUNT, tags);
-        double resumeBefore = counterValue(MetricRegistry.METRIC_QUEUE_SUBSCRIBER_RESUME_COUNT, tags);
+        double pauseBefore = counterValue(MetricRegistry.METRIC_QUEUE_SUBSCRIBERS_PAUSE_COUNT, tags);
+        double resumeBefore = counterValue(MetricRegistry.METRIC_QUEUE_SUBSCRIBERS_RESUME_COUNT, tags);
 
         QueueSubscriber<TestDispatch> subscriber = dispatchQueue
             .subscriber()
@@ -304,8 +302,8 @@ public abstract class AbstractDispatchQueueTest extends AbstractQueueTest {
         subscriber.close();
 
         // Then
-        assertThat(counterValue(MetricRegistry.METRIC_QUEUE_SUBSCRIBER_PAUSE_COUNT, tags) - pauseBefore).isEqualTo(2.0);
-        assertThat(counterValue(MetricRegistry.METRIC_QUEUE_SUBSCRIBER_RESUME_COUNT, tags) - resumeBefore).isEqualTo(2.0);
+        assertThat(counterValue(MetricRegistry.METRIC_QUEUE_SUBSCRIBERS_PAUSE_COUNT, tags) - pauseBefore).isEqualTo(2.0);
+        assertThat(counterValue(MetricRegistry.METRIC_QUEUE_SUBSCRIBERS_RESUME_COUNT, tags) - resumeBefore).isEqualTo(2.0);
     }
 
     @Test

--- a/queue/src/test/java/io/kestra/queue/AbstractDispatchQueueTest.java
+++ b/queue/src/test/java/io/kestra/queue/AbstractDispatchQueueTest.java
@@ -1,10 +1,12 @@
 package io.kestra.queue;
 
 import io.kestra.core.contexts.KestraContext;
+import io.kestra.core.metrics.MetricRegistry;
 import io.kestra.core.queues.*;
 import io.kestra.core.queues.event.DispatchEvent;
 import io.kestra.core.services.IgnoreExecutionService;
 import io.kestra.core.utils.IdUtils;
+import io.micrometer.core.instrument.Tags;
 import jakarta.inject.Inject;
 import org.apache.commons.lang3.tuple.Pair;
 import org.junit.jupiter.api.AfterEach;
@@ -37,6 +39,9 @@ public abstract class AbstractDispatchQueueTest extends AbstractQueueTest {
 
     @Inject
     private IgnoreExecutionService ignoreExecutionService;
+
+    @Inject
+    private MetricRegistry metricRegistry;
 
     private KestraContext realContext;
     protected NoOpShutdownContext noOpShutdownContext;
@@ -277,6 +282,65 @@ public abstract class AbstractDispatchQueueTest extends AbstractQueueTest {
         assertThat(list.stream().filter(i -> i.getLeft().isBefore(resumeTime)).count()).isEqualTo(1);
         assertThat(list.stream().filter(i -> i.getLeft().isAfter(resumeTime)).count()).isEqualTo(4);
         assertThat(list.stream().filter(i -> i.getLeft().isAfter(resumeTime2)).count()).isEqualTo(2);
+    }
+
+    @Test
+    void shouldRecordPauseAndResumeCounters() throws QueueException, InterruptedException {
+        // Given
+        String queueName = ((GenericQueueInterface<?>) dispatchQueue).queueName();
+        Tags tags = Tags.of(MetricRegistry.TAG_QUEUE_NAME, queueName);
+        double pauseBefore = counterValue(MetricRegistry.METRIC_QUEUE_SUBSCRIBER_PAUSE_COUNT, tags);
+        double resumeBefore = counterValue(MetricRegistry.METRIC_QUEUE_SUBSCRIBER_RESUME_COUNT, tags);
+
+        QueueSubscriber<TestDispatch> subscriber = dispatchQueue
+            .subscriber()
+            .subscribe(e -> {});
+
+        // When
+        subscriber.pause();
+        subscriber.resume();
+        subscriber.pause();
+        subscriber.resume();
+        subscriber.close();
+
+        // Then
+        assertThat(counterValue(MetricRegistry.METRIC_QUEUE_SUBSCRIBER_PAUSE_COUNT, tags) - pauseBefore).isEqualTo(2.0);
+        assertThat(counterValue(MetricRegistry.METRIC_QUEUE_SUBSCRIBER_RESUME_COUNT, tags) - resumeBefore).isEqualTo(2.0);
+    }
+
+    @Test
+    void shouldRemoveSubscribersFromGaugeOnClose() throws QueueException, InterruptedException {
+        // Given
+        String queueName = ((GenericQueueInterface<?>) dispatchQueue).queueName();
+        Tags tags = Tags.of(MetricRegistry.TAG_QUEUE_NAME, queueName);
+        double baseline = gaugeValue(MetricRegistry.METRIC_QUEUE_SUBSCRIBERS_COUNT, tags);
+
+        // When - subscribe two
+        QueueSubscriber<TestDispatch> sub1 = dispatchQueue.subscriber().subscribe(e -> {});
+        QueueSubscriber<TestDispatch> sub2 = dispatchQueue.subscriber().subscribe(e -> {});
+
+        // Then
+        assertThat(gaugeValue(MetricRegistry.METRIC_QUEUE_SUBSCRIBERS_COUNT, tags) - baseline).isEqualTo(2.0);
+
+        // When - close one
+        sub1.close();
+        // Then
+        assertThat(gaugeValue(MetricRegistry.METRIC_QUEUE_SUBSCRIBERS_COUNT, tags) - baseline).isEqualTo(1.0);
+
+        // When - close the other
+        sub2.close();
+        // Then
+        assertThat(gaugeValue(MetricRegistry.METRIC_QUEUE_SUBSCRIBERS_COUNT, tags) - baseline).isEqualTo(0.0);
+    }
+
+    private double counterValue(String name, Tags tags) {
+        var counter = metricRegistry.find(name).tags(tags).counter();
+        return counter == null ? 0.0 : counter.count();
+    }
+
+    private double gaugeValue(String name, Tags tags) {
+        var gauge = metricRegistry.find(name).tags(tags).gauge();
+        return gauge == null ? 0.0 : gauge.value();
     }
 
     @Test

--- a/queue/src/test/java/io/kestra/queue/MonitoredQueueSubscriberTest.java
+++ b/queue/src/test/java/io/kestra/queue/MonitoredQueueSubscriberTest.java
@@ -1,0 +1,162 @@
+package io.kestra.queue;
+
+import java.util.List;
+import java.util.function.Consumer;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import io.kestra.core.exceptions.DeserializationException;
+import io.kestra.core.metrics.MetricConfig;
+import io.kestra.core.metrics.MetricRegistry;
+import io.kestra.core.queues.QueueSubscriber;
+import io.kestra.core.queues.event.Event;
+import io.kestra.core.utils.Either;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class MonitoredQueueSubscriberTest {
+
+    private static final String QUEUE_NAME = "test_queue";
+
+    private MeterRegistry meterRegistry;
+    private MetricRegistry metricRegistry;
+    @SuppressWarnings("rawtypes")
+    private AbstractQueue queue;
+    @SuppressWarnings("unchecked")
+    private QueueSubscriber<TestEvent> delegate;
+    private MonitoredQueueSubscriber<TestEvent> monitored;
+
+    @BeforeEach
+    @SuppressWarnings("unchecked")
+    void setUp() {
+        meterRegistry = new SimpleMeterRegistry();
+        metricRegistry = new MetricRegistry(meterRegistry, new MetricConfig());
+        queue = mock(AbstractQueue.class);
+        when(queue.queueName()).thenReturn(QUEUE_NAME);
+        delegate = mock(QueueSubscriber.class);
+        monitored = new MonitoredQueueSubscriber<>(delegate, queue, metricRegistry);
+    }
+
+    private double pauseCount() {
+        return meterRegistry.get(MetricRegistry.METRIC_QUEUE_SUBSCRIBER_PAUSE_COUNT).counter().count();
+    }
+
+    private double resumeCount() {
+        return meterRegistry.get(MetricRegistry.METRIC_QUEUE_SUBSCRIBER_RESUME_COUNT).counter().count();
+    }
+
+    @Test
+    void shouldIncrementPauseCounterAndDelegate() {
+        // When
+        monitored.pause();
+        monitored.pause();
+
+        // Then
+        assertThat(pauseCount()).isEqualTo(2.0);
+        assertThat(resumeCount()).isEqualTo(0.0);
+        verify(delegate, times(2)).pause();
+    }
+
+    @Test
+    void shouldIncrementResumeCounterAndDelegate() {
+        // When
+        monitored.resume();
+        monitored.resume();
+        monitored.resume();
+
+        // Then
+        assertThat(resumeCount()).isEqualTo(3.0);
+        assertThat(pauseCount()).isEqualTo(0.0);
+        verify(delegate, times(3)).resume();
+    }
+
+    @Test
+    void shouldTagCountersWithQueueName() {
+        // When
+        monitored.pause();
+        monitored.resume();
+
+        // Then
+        assertThat(meterRegistry.get(MetricRegistry.METRIC_QUEUE_SUBSCRIBER_PAUSE_COUNT)
+            .tag(MetricRegistry.TAG_QUEUE_NAME, QUEUE_NAME)
+            .counter().count()).isEqualTo(1.0);
+        assertThat(meterRegistry.get(MetricRegistry.METRIC_QUEUE_SUBSCRIBER_RESUME_COUNT)
+            .tag(MetricRegistry.TAG_QUEUE_NAME, QUEUE_NAME)
+            .counter().count()).isEqualTo(1.0);
+    }
+
+    @Test
+    void subscribeShouldReturnWrapperNotDelegate() {
+        // Given
+        Consumer<Either<TestEvent, DeserializationException>> consumer = e -> {};
+
+        // When
+        QueueSubscriber<TestEvent> returned = monitored.subscribe(consumer);
+
+        // Then
+        assertThat(returned).isSameAs(monitored);
+        verify(delegate).subscribe(consumer);
+    }
+
+    @Test
+    void subscribeBatchShouldUseDelegateNativeBatchAndReturnWrapper() {
+        // Given
+        Consumer<List<Either<TestEvent, DeserializationException>>> batchConsumer = items -> {};
+
+        // When
+        QueueSubscriber<TestEvent> returned = monitored.subscribeBatch(batchConsumer);
+
+        // Then
+        assertThat(returned).isSameAs(monitored);
+        verify(delegate).subscribeBatch(batchConsumer);
+        // Must hit the delegate's native batch method, not the default routing through subscribe()
+        verify(delegate, never()).subscribe(any());
+    }
+
+    @Test
+    void closeShouldDelegateAndUntrack() {
+        // When
+        monitored.close();
+
+        // Then
+        verify(delegate).close();
+        verify(queue).untrackSubscriber(monitored);
+    }
+
+    @Test
+    void closeShouldUntrackEvenIfDelegateThrows() {
+        // Given
+        doThrow(new RuntimeException("boom")).when(delegate).close();
+
+        // When / Then
+        assertThatThrownBy(monitored::close)
+            .isInstanceOf(RuntimeException.class)
+            .hasMessage("boom");
+        verify(queue).untrackSubscriber(monitored);
+    }
+
+    @Test
+    void isActiveShouldDelegate() {
+        // Given
+        when(delegate.isActive()).thenReturn(true).thenReturn(false);
+
+        // Then
+        assertThat(monitored.isActive()).isTrue();
+        assertThat(monitored.isActive()).isFalse();
+    }
+
+    private record TestEvent(String key) implements Event {
+    }
+}

--- a/queue/src/test/java/io/kestra/queue/MonitoredQueueSubscriberTest.java
+++ b/queue/src/test/java/io/kestra/queue/MonitoredQueueSubscriberTest.java
@@ -50,11 +50,11 @@ class MonitoredQueueSubscriberTest {
     }
 
     private double pauseCount() {
-        return meterRegistry.get(MetricRegistry.METRIC_QUEUE_SUBSCRIBER_PAUSE_COUNT).counter().count();
+        return meterRegistry.get(MetricRegistry.METRIC_QUEUE_SUBSCRIBERS_PAUSE_COUNT).counter().count();
     }
 
     private double resumeCount() {
-        return meterRegistry.get(MetricRegistry.METRIC_QUEUE_SUBSCRIBER_RESUME_COUNT).counter().count();
+        return meterRegistry.get(MetricRegistry.METRIC_QUEUE_SUBSCRIBERS_RESUME_COUNT).counter().count();
     }
 
     @Test
@@ -89,10 +89,10 @@ class MonitoredQueueSubscriberTest {
         monitored.resume();
 
         // Then
-        assertThat(meterRegistry.get(MetricRegistry.METRIC_QUEUE_SUBSCRIBER_PAUSE_COUNT)
+        assertThat(meterRegistry.get(MetricRegistry.METRIC_QUEUE_SUBSCRIBERS_PAUSE_COUNT)
             .tag(MetricRegistry.TAG_QUEUE_NAME, QUEUE_NAME)
             .counter().count()).isEqualTo(1.0);
-        assertThat(meterRegistry.get(MetricRegistry.METRIC_QUEUE_SUBSCRIBER_RESUME_COUNT)
+        assertThat(meterRegistry.get(MetricRegistry.METRIC_QUEUE_SUBSCRIBERS_RESUME_COUNT)
             .tag(MetricRegistry.TAG_QUEUE_NAME, QUEUE_NAME)
             .counter().count()).isEqualTo(1.0);
     }


### PR DESCRIPTION
Wrap every QueueSubscriber returned by AbstractQueue.trackSubscriber in a MonitoredQueueSubscriber decorator that records two new counters (queue.subscriber.pause.count, queue.subscriber.resume.count) tagged by queue_name, and removes itself from the tracked-subscribers list on close via a new AbstractQueue.untrackSubscriber method.