### PR TITLE
test(tasks): fix qaKv sanity check size assertion (6 -> 7)

### DIFF
--- a/core/src/test/java/io/kestra/core/tasks/test/SanityCheckTest.java
+++ b/core/src/test/java/io/kestra/core/tasks/test/SanityCheckTest.java
@@ -37,7 +37,7 @@ class SanityCheckTest {
     @Test
     @ExecuteFlow("sanity-checks/kv.yaml")
     void qaKv(Execution execution) {
-        assertThat(execution.getTaskRunList()).hasSize(6);
+        assertThat(execution.getTaskRunList()).hasSize(7);
         assertThat(execution.getState().getCurrent()).isEqualTo(State.Type.SUCCESS);
     }
 


### PR DESCRIPTION
## Summary

`SanityCheckTest.qaKv` asserts `hasSize(6)` against the `sanity-checks/kv.yaml` flow, but the flow has had **7 tasks** since #14716 added the `put` task. The test fails deterministically with `Expected size: 6 but was: 7`.

The failure has been hidden because the test is tagged `@FlakyTest` (`@Tag("flaky")`), so regular `./gradlew test` skips it and the failure only surfaces in the non-blocking `flakyTest` run.

## Root cause

| When | Commit | What |
|---|---|---|
| 2025-10-10 | `ff18fc40e` (#11914) | Added `@FlakyTest` to `qaKv` for an earlier timing-related flake |
| 2026-02-19 | `746d7c9ae` (#14716) | Added 7th task (`put`) to `kv.yaml`, did not update the test |

The 7-task flow is the source of truth; the `hasSize(6)` is stale.

## Fix

Update assertion to `hasSize(7)`. `@FlakyTest` is intentionally left in place — it predates the put-task change and likely covers a separate timing concern that is out of scope here.

## Test plan

- [x] Reproduced failure locally: `./gradlew :core:flakyTest --tests "io.kestra.core.tasks.test.SanityCheckTest.qaKv" --rerun-tasks` -> `Expected size: 6 but was: 7`
- [x] After fix, same command passes (`✔ qaKv(Execution)`)
- [ ] CI green