### PR TITLE
fix(tests): fix flaky CI tests for retry and concurrency kill scenarios

### DIFF
--- a/core/src/test/java/io/kestra/core/runners/FlowConcurrencyCaseTest.java
+++ b/core/src/test/java/io/kestra/core/runners/FlowConcurrencyCaseTest.java
@@ -293,7 +293,7 @@ public class FlowConcurrencyCaseTest {
             runnerUtils.killExecution(execution3);
 
             // await that they are all terminated, note that as KILLED is received twice, some messages would still be pending, but this is the best we can do
-            runnerUtils.awaitFlowExecutionNumber(3, tenantId, NAMESPACE, "flow-concurrency-queue-killed");
+            runnerUtils.awaitFlowExecutionNumber(3, tenantId, NAMESPACE, "flow-concurrency-queue-killed", Duration.ofSeconds(60));
         }
     }
 
@@ -335,7 +335,7 @@ public class FlowConcurrencyCaseTest {
             runnerUtils.killExecution(execution3);
 
             // await that they are all terminated, note that as KILLED is received twice, some messages would still be pending, but this is the best we can do
-            runnerUtils.awaitFlowExecutionNumber(3, tenantId, NAMESPACE, "flow-concurrency-queue-killed");
+            runnerUtils.awaitFlowExecutionNumber(3, tenantId, NAMESPACE, "flow-concurrency-queue-killed", Duration.ofSeconds(60));
         }
     }
 

--- a/core/src/test/java/io/kestra/plugin/core/flow/RetryCaseTest.java
+++ b/core/src/test/java/io/kestra/plugin/core/flow/RetryCaseTest.java
@@ -104,7 +104,14 @@ public class RetryCaseTest {
         );
         Await.until(
             () -> "flow should have ended in Failed state",
-            () -> executionRepository.findLatestForStates(flow.getTenantId(), flow.getNamespace(), flow.getId(), List.of(State.Type.FAILED)).isPresent(),
+            () -> {
+                try {
+                    return executionRepository.findLatestForStates(flow.getTenantId(), flow.getNamespace(), flow.getId(), List.of(State.Type.FAILED)).isPresent();
+                } catch (Exception e) {
+                    // Repository may be unavailable during context teardown (e.g., ES connection pool closed)
+                    return false;
+                }
+            },
             Duration.ofMillis(100),
             Duration.ofSeconds(10)
         );

--- a/core/src/test/resources/flows/valids/flow-concurrency-queue-killed.yml
+++ b/core/src/test/resources/flows/valids/flow-concurrency-queue-killed.yml
@@ -8,4 +8,4 @@ concurrency:
 tasks:
   - id: sleep
     type: io.kestra.plugin.core.flow.Sleep
-    duration: PT1M
+    duration: PT10S


### PR DESCRIPTION
## Summary
- **RetryCaseTest**: wrap `findLatestForStates` in try-catch inside `Await.until` to handle ES connection pool shutdown during test context teardown — fixes `ElasticsearchRunnerRetryTest.retryNewExecutionTaskAttempts()` which was consistently failing (not marked `@FlakyTest`)
- **flow-concurrency-queue-killed.yml**: reduce sleep from `PT1M` to `PT10S` — the test only needs the task running briefly to verify concurrency behavior
- **FlowConcurrencyCaseTest**: increase `awaitFlowExecutionNumber` timeout from 20s to 60s in both `flowConcurrencyKilled` and `flowConcurrencyQueueKilled` — kill propagation through Kafka/ES involves multiple async hops and 20s was too tight

These three tests have been consistently failing every CI run on the kestra-ee `develop` branch.

## Test plan
- [ ] Verify `./gradlew :core:compileTestJava` passes
- [ ] Verify EE CI passes: `ElasticsearchRunnerRetryTest.retryNewExecutionTaskAttempts()`
- [ ] Verify EE CI passes: `KafkaRunnerConcurrencyTest.flowConcurrencyKilled()`
- [ ] Verify EE CI passes: `ElasticSearchRunnerConcurrencyTest.flowConcurrencyKilled()`