### PR TITLE
fix(tasks): inject outputFiles into Pebble context in CommandsWrapper.render()

### DIFF
--- a/script/src/main/java/io/kestra/plugin/scripts/exec/scripts/runners/CommandsWrapper.java
+++ b/script/src/main/java/io/kestra/plugin/scripts/exec/scripts/runners/CommandsWrapper.java
@@ -265,7 +265,21 @@ public class CommandsWrapper implements TaskCommands {
             return null;
         }
 
-        return runContext.render(command).as(String.class, taskRunner.additionalVars(runContext, this))
+        Map<String, Object> additionalVars = taskRunner.additionalVars(runContext, this);
+        if (this.outputFiles != null && !this.outputFiles.isEmpty()) {
+            String workingDir = String.valueOf(additionalVars.getOrDefault(ScriptService.VAR_WORKING_DIR, this.workingDirectory));
+            Map<String, String> outputFilesMap = new LinkedHashMap<>();
+            for (String name : this.outputFiles) {
+                if (!name.contains("*") && !name.contains("?") && !name.contains("[")) {
+                    outputFilesMap.put(name, workingDir + "/" + name);
+                }
+            }
+            if (!outputFilesMap.isEmpty()) {
+                additionalVars.put("outputFiles", outputFilesMap);
+            }
+        }
+
+        return runContext.render(command).as(String.class, additionalVars)
             .map(throwFunction(c -> ScriptService.replaceInternalStorage(runContext, c, taskRunner instanceof RemoteRunnerInterface)))
             .orElse(null);
     }


### PR DESCRIPTION
:warning: To backport to `releases/v1.3.x` branch.

## Summary

- `CommandsWrapper.render(RunContext, Property<String>)` was missing the `outputFiles` map injection that already existed in `run()`
- `Script.run()` calls `render()` before `run()`, so `{{ outputFiles.name }}` resolved against a context without `outputFiles` and threw `IllegalVariableEvaluationException`
- Added the same non-glob `name → workingDir/name` map building to `render()` so the variable is available at script render time

## Related

Part-of https://github.com/kestra-io/kestra/issues/13765