### PR TITLE
ci: pass GITHUB_TO_SLACK_MAP to slack-status on develop failure

### DIFF
--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -101,3 +101,4 @@ jobs:
         with:
           webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
           channel: 'C09FF36GKE1'
+          users-map: ${{ vars.GH_TO_SLACK_MAP }}


### PR DESCRIPTION
- forward the new \`users-map\` input on the \`slack-status\` composite action so the responsible committer is @-mentioned in Slack when develop fails (notifications today are silently ignored because nobody is pinged)
- value comes from the org-level \`GITHUB_TO_SLACK_MAP\` variable kept out of this public repo and managed by terraform in kestra-io/infra
- companion PRs: kestra-io/actions#88 (action change), kestra-io/infra#199 (variable), companion EE PR in kestra-io/kestra-ee