### PR TITLE
fix(tests): adjust flaky test timeouts for Kafka/ES runners

### DIFF
--- a/core/src/test/java/io/kestra/core/runners/FlowConcurrencyCaseTest.java
+++ b/core/src/test/java/io/kestra/core/runners/FlowConcurrencyCaseTest.java
@@ -253,7 +253,7 @@ public class FlowConcurrencyCaseTest {
             runnerUtils.killExecution(execution3);
 
             // await that they are all terminated, note that as KILLED is received twice, some messages would still be pending, but this is the best we can do
-            runnerUtils.awaitFlowExecutionNumber(3, tenantId, NAMESPACE, "flow-concurrency-queue-killed", Duration.ofSeconds(60));
+            runnerUtils.awaitFlowExecutionNumber(3, tenantId, NAMESPACE, "flow-concurrency-queue-killed", Duration.ofSeconds(30));
         }
     }
 
@@ -295,7 +295,7 @@ public class FlowConcurrencyCaseTest {
             runnerUtils.killExecution(execution3);
 
             // await that they are all terminated, note that as KILLED is received twice, some messages would still be pending, but this is the best we can do
-            runnerUtils.awaitFlowExecutionNumber(3, tenantId, NAMESPACE, "flow-concurrency-queue-killed", Duration.ofSeconds(60));
+            runnerUtils.awaitFlowExecutionNumber(3, tenantId, NAMESPACE, "flow-concurrency-queue-killed", Duration.ofSeconds(30));
         }
     }
 

--- a/core/src/test/java/io/kestra/plugin/core/flow/RetryCaseTest.java
+++ b/core/src/test/java/io/kestra/plugin/core/flow/RetryCaseTest.java
@@ -100,7 +100,7 @@ public class RetryCaseTest {
         runnerUtils.runOne(
             Execution.newExecution(flow, null),
             flow,
-            Duration.ofSeconds(10)
+            Duration.ofSeconds(30)
         );
         Await.until(
             () -> "flow should have ended in Failed state",
@@ -113,7 +113,7 @@ public class RetryCaseTest {
                 }
             },
             Duration.ofMillis(100),
-            Duration.ofSeconds(10)
+            Duration.ofSeconds(30)
         );
         var executions = executionRepository.findByFlowId(flow.getTenantId(), flow.getNamespace(), flow.getId(), Pageable.UNPAGED);
         assertThat(executions.stream().map(e -> e.getState().getCurrent())).contains(State.Type.RETRIED, State.Type.RETRIED, State.Type.FAILED);


### PR DESCRIPTION
## Summary
- **RetryCaseTest**: increase `runOne` and `Await.until` timeouts from 10s to 30s — the `CREATE_NEW_EXECUTION` retry flows need multiple Kafka/ES message roundtrips per retry cycle, pushing total time past 10s in CI
- **FlowConcurrencyCaseTest**: reduce `awaitFlowExecutionNumber` timeout from 60s to 30s — the flow sleep was already reduced to PT10S in #15755, so 30s is sufficient

## Test plan
- [ ] EE CI passes `KafkaRunnerRetryTest.retryNewExecutionTaskDuration()`
- [ ] EE CI passes `ElasticsearchRunnerRetryTest.retryNewExecutionTaskAttempts()`
- [ ] Concurrency kill tests still pass with the reduced 30s timeout