### PR TITLE
build(deps): ignore eslint-plugin-vue updates in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -61,7 +61,8 @@ updates:
       major:
         update-types: ["major"]
         applies-to: version-updates
-        exclude-patterns: [
+        exclude-patterns:
+          [
             "@esbuild/*",
             "@rollup/*",
             "@rolldown/*",
@@ -73,8 +74,6 @@ updates:
             "eslint-plugin-storybook",
             "vitest",
             "@vitest/*",
-            # Temporary exclusion of these packages from major updates
-            "eslint-plugin-vue",
           ]
 
       minor:
@@ -128,6 +127,10 @@ updates:
       - dependency-name: "@eslint/js"
         update-types: ["version-update:semver-major"]
 
+      # Ignore eslint-plugin-vue all updates (v10 requires eslint ^10 but project is on eslint ^9)
+      - dependency-name: "eslint-plugin-vue"
+        versions: ["*"]
+
       # Ignore vue-router major updates (v5 conflicts with @kestra-io/ui-libs peer requirement ^4.5.0)
       - dependency-name: "vue-router"
         update-types: ["version-update:semver-major"]
@@ -135,7 +138,7 @@ updates:
       # Ignore updates to monaco-yaml; version is pinned to 5.3.1 due to patch-package script additions
       - dependency-name: "monaco-yaml"
         versions: [">=5.3.2"]
-      
+
       # Temporarily ignore all axios updates due to recent supply chain vulnerability, see https://github.com/axios/axios/issues/10604
       - dependency-name: "axios"
         versions: ["*"]


### PR DESCRIPTION
## Summary
- Removes `eslint-plugin-vue` from the temporary `major` group exclusion
- Adds a full ignore entry for `eslint-plugin-vue` (all versions) alongside other eslint-related ignores

## Reason
`eslint-plugin-vue` v10 requires `eslint ^10`, but the project is currently on `eslint ^9`, so all updates should be ignored until the eslint upgrade is done.