### PR TITLE
fix(core): preserve null in string rendering for Pebble templates

### DIFF
--- a/core/src/main/java/io/kestra/core/runners/DefaultRunContext.java
+++ b/core/src/main/java/io/kestra/core/runners/DefaultRunContext.java
@@ -9,7 +9,6 @@ import java.nio.file.Path;
 import java.security.GeneralSecurityException;
 import java.util.*;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.RandomStringUtils;
 import org.slf4j.Logger;
@@ -341,18 +340,18 @@ public class DefaultRunContext extends RunContext {
         }
 
         Map<String, Object> allVariables = mergeWithNullableValues(this.variables, decryptVariables(variables));
-        return inline
-            .entrySet()
-            .stream()
-            .map(
-                throwFunction(
-                    entry -> new AbstractMap.SimpleEntry<>(
-                        this.render(entry.getKey(), allVariables),
-                        this.render(entry.getValue(), allVariables)
-                    )
-                )
-            )
-            .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+        Map<String, String> rendered = new LinkedHashMap<>();
+        for (Map.Entry<String, String> entry : inline.entrySet()) {
+            String renderedKey = this.render(entry.getKey(), allVariables);
+            if (renderedKey == null) {
+                throw new IllegalVariableEvaluationException("Unable to render map: key rendered to null");
+            }
+            String renderedValue = this.render(entry.getValue(), allVariables);
+            if (renderedValue != null) {
+                rendered.put(renderedKey, renderedValue);
+            }
+        }
+        return rendered;
     }
 
     @Override

--- a/core/src/main/java/io/kestra/core/runners/VariableRenderer.java
+++ b/core/src/main/java/io/kestra/core/runners/VariableRenderer.java
@@ -63,7 +63,11 @@ public class VariableRenderer {
     }
 
     public String render(String inline, Map<String, Object> variables, boolean recursive) throws IllegalVariableEvaluationException {
-        return (String) this.render(inline, variables, recursive, true);
+        if (inline == null) {
+            return null;
+        }
+        String result = (String) this.render(inline, variables, recursive, true);
+        return result != null ? result : "";
     }
 
     public Object render(Object inline, Map<String, Object> variables, boolean recursive, boolean stringify) throws IllegalVariableEvaluationException {
@@ -170,7 +174,7 @@ public class VariableRenderer {
         }
 
         Object result = this.renderOnce(inline, variables, stringify);
-        if (result.equals(inline)) {
+        if (result == null || Objects.equals(result, inline)) {
             return result;
         }
 
@@ -186,7 +190,7 @@ public class VariableRenderer {
 
         for (Map.Entry<String, Object> r : in.entrySet()) {
             String key = this.render(r.getKey(), variables);
-            Object value = renderObject(r.getValue(), variables, recursive).orElse(r.getValue());
+            Object value = renderObject(r.getValue(), variables, recursive).orElse(null);
 
             map.putIfAbsent(
                 key,
@@ -210,7 +214,7 @@ public class VariableRenderer {
         } else if (object instanceof Set set) {
             return Optional.of(this.render(set, variables, recursive));
         } else if (object instanceof String string) {
-            return Optional.of(this.render(string, variables, recursive));
+            return Optional.ofNullable(this.render(string, variables, recursive, true));
         }
 
         // Return the given object if it cannot be rendered.
@@ -225,7 +229,7 @@ public class VariableRenderer {
         List<Object> result = new ArrayList<>();
 
         for (Object inline : list) {
-            result.add(this.renderObject(inline, variables, recursive).orElse(inline));
+            result.add(this.renderObject(inline, variables, recursive).orElse(null));
         }
 
         return result;

--- a/core/src/main/java/io/kestra/core/runners/pebble/JsonWriter.java
+++ b/core/src/main/java/io/kestra/core/runners/pebble/JsonWriter.java
@@ -16,50 +16,65 @@ public class JsonWriter extends OutputWriter implements SpecializedWriter {
     private static final ObjectMapper MAPPER = JacksonMapper.ofJson();
 
     private final StringWriter stringWriter = new StringWriter();
+    private boolean hasOutput = false;
 
     @Override
     public void writeSpecialized(int i) {
+        hasOutput = true;
         stringWriter.getBuffer().append(i);
     }
 
     @Override
     public void writeSpecialized(long l) {
+        hasOutput = true;
         stringWriter.getBuffer().append(l);
     }
 
     @Override
     public void writeSpecialized(double d) {
+        hasOutput = true;
         stringWriter.getBuffer().append(d);
     }
 
     @Override
     public void writeSpecialized(float f) {
+        hasOutput = true;
         stringWriter.getBuffer().append(f);
     }
 
     @Override
     public void writeSpecialized(short s) {
+        hasOutput = true;
         stringWriter.getBuffer().append(s);
     }
 
     @Override
     public void writeSpecialized(byte b) {
+        hasOutput = true;
         stringWriter.getBuffer().append(b);
     }
 
     @Override
     public void writeSpecialized(char c) {
+        hasOutput = true;
         stringWriter.getBuffer().append(c);
     }
 
     @Override
     public void writeSpecialized(String s) {
+        if (s == null) {
+            return;
+        }
+        hasOutput = true;
         stringWriter.getBuffer().append(s);
     }
 
     @SneakyThrows
     @Override
     public void write(Object o) {
+        if (o == null) {
+            return;
+        }
         if (o instanceof Map) {
             writeSpecialized(MAPPER.writeValueAsString(o));
         } else if (o instanceof Collection) {
@@ -73,6 +88,9 @@ public class JsonWriter extends OutputWriter implements SpecializedWriter {
 
     @Override
     public void write(char[] cbuf, int off, int len) throws IOException {
+        if (len > 0) {
+            hasOutput = true;
+        }
         this.stringWriter.write(cbuf, off, len);
     }
 
@@ -93,6 +111,6 @@ public class JsonWriter extends OutputWriter implements SpecializedWriter {
 
     @Override
     public Object output() {
-        return this.toString();
+        return hasOutput ? this.toString() : null;
     }
 }

--- a/core/src/test/java/io/kestra/core/runners/VariableRendererTest.java
+++ b/core/src/test/java/io/kestra/core/runners/VariableRendererTest.java
@@ -119,6 +119,44 @@ class VariableRendererTest {
         assertThat(result_value3.keySet()).containsExactly("bar-1", "bar-2", "bar-3");
     }
 
+    @Test
+    void shouldRenderStringAsEmptyForNull() throws IllegalVariableEvaluationException {
+        assertThat(variableRenderer.render("{{ null }}", Map.of())).isEmpty();
+        assertThat(variableRenderer.render("{{ true ? null : 'work' }}", Map.of())).isEmpty();
+    }
+
+    @Test
+    void shouldRenderStringAsString() throws IllegalVariableEvaluationException {
+        assertThat(variableRenderer.render("{{ false ? null : 'work' }}", Map.of())).isEqualTo("work");
+        assertThat(variableRenderer.render("{{ 42 }}", Map.of())).isEqualTo("42");
+        assertThat(variableRenderer.render("{{ true }}", Map.of())).isEqualTo("true");
+    }
+
+    @Test
+    void shouldRenderStringAsEmptyForNullRecursively() throws IllegalVariableEvaluationException {
+        assertThat(variableRenderer.render("{{ null }}", Map.of(), true)).isEmpty();
+        assertThat(variableRenderer.render("prefix {{ null }}", Map.of(), true)).isEqualTo("prefix ");
+    }
+
+    @Test
+    void shouldRenderStringWithExplicitEmptyOutput() throws IllegalVariableEvaluationException {
+        assertThat(variableRenderer.render("{{ '' }}", Map.of())).isEqualTo("");
+        assertThat(variableRenderer.render("prefix {{ null }}", Map.of())).isEqualTo("prefix ");
+    }
+
+    @Test
+    void shouldRenderMapWithNullValues() throws IllegalVariableEvaluationException {
+        Map<String, Object> input = new LinkedHashMap<>();
+        input.put("key1", "{{ null }}");
+        input.put("key2", "{{ 'hello' }}");
+        input.put("key3", "static");
+        Map<String, Object> result = variableRenderer.render(input, Map.of());
+        assertThat(result.get("key1")).isNull();
+        assertThat(result.get("key2")).isEqualTo("hello");
+        assertThat(result.get("key3")).isEqualTo("static");
+        assertThat(result).containsKey("key1");
+    }
+
     public static class TestVariableRenderer extends VariableRenderer {
 
         public TestVariableRenderer(PebbleEngineFactory pebbleEngineFactory,

--- a/core/src/test/java/io/kestra/core/runners/pebble/PebbleVariableRendererTest.java
+++ b/core/src/test/java/io/kestra/core/runners/pebble/PebbleVariableRendererTest.java
@@ -74,7 +74,7 @@ class PebbleVariableRendererTest {
         assertThat((String) render.get("map")).startsWith("{");
         assertThat((String) render.get("map")).endsWith("}");
         assertThat((String) render.get("escape")).contains("[\"string\",1,1.123] // {");
-        assertThat((String) render.get("empty")).isEqualTo("");
+        assertThat(render.get("empty")).isNull();
         assertThat((String) render.get("concat")).isEqualTo("applepearbanana");
     }
 


### PR DESCRIPTION
When a Pebble expression evaluates to null (e.g. `{{ inputs.overrideDate ?? null }}`), `JsonWriter.output()` was returning `""` instead of `null`.

**Root cause:** `JsonWriter` unconditionally called `StringWriter.toString()` which returns `""` even when nothing was written. Meanwhile, `TypedObjectWriter` already handled this correctly.

**Why it worked before v0.17:** the global Jackson serialization was `NON_EMPTY` (commit `4c9c187d4` changed it to `NON_NULL` in v0.17), which silently stripped empty string entries from maps