### PR TITLE
fix(scripts): clear interrupted flag in Docker runner cleanup to prevent container leak

### DIFF
--- a/script/src/main/java/io/kestra/plugin/scripts/runner/docker/Docker.java
+++ b/script/src/main/java/io/kestra/plugin/scripts/runner/docker/Docker.java
@@ -632,6 +632,10 @@ public class Docker extends TaskRunner<Docker.DockerTaskRunnerDetailResult> {
                     .details(DockerTaskRunnerDetailResult.builder().containerId(runContainerId).build())
                     .build();
             } finally {
+                // Clear the interrupted flag so Docker HTTP cleanup calls are not rejected by the HTTP client
+                // when the thread was interrupted to stop the task (e.g. worker kill). The flag is restored
+                // after cleanup so callers still observe the interrupt state.
+                boolean wasInterrupted = Thread.interrupted();
                 try {
                     // kill container if it's still running, this means there was an exception and the container didn't
                     // come to a normal end.
@@ -653,6 +657,10 @@ public class Docker extends TaskRunner<Docker.DockerTaskRunnerDetailResult> {
                     }
                 } catch (Exception ignored) {
 
+                } finally {
+                    if (wasInterrupted) {
+                        Thread.currentThread().interrupt();
+                    }
                 }
             }
         } catch (RuntimeException e) {

--- a/script/src/main/java/io/kestra/plugin/scripts/runner/docker/Docker.java
+++ b/script/src/main/java/io/kestra/plugin/scripts/runner/docker/Docker.java
@@ -517,26 +517,15 @@ public class Docker extends TaskRunner<Docker.DockerTaskRunnerDetailResult> {
                 if (logger.isDebugEnabled()) {
                     logger.debug("Attaching to logs of container {}", containerId);
                 }
-                if (needVolume && FileHandlingStrategy.VOLUME.equals(strategy)) {
-                    List<String> labelsList = labels.entrySet()
-                        .stream()
-                        .map(entry -> String.join("=", entry.getKey(), entry.getValue()))
-                        .toList();
-                    var volumes = dockerClient.listVolumesCmd()
-                        .withFilter("label", labelsList).exec();
-                    if (volumes.getVolumes() == null || volumes.getVolumes().isEmpty()) {
-                        logger.error("No volume found for resumed container {}", containerId);
-                        throw new TaskException(1, defaultLogConsumer);
-                    } else {
-                        var volume = volumes.getVolumes().get(0);
-                        filesVolumeName = volume.getName();
-                        logger.debug("Volume found with name {} for resumed container {}", filesVolumeName, containerId);
-                    }
-                }
-
+                // Volume lookup is deferred into the inner try block below so that the cleanup
+                // finally always runs even if the thread is interrupted during the lookup.
             }
 
             final String runContainerId = containerId;
+            // True when we attached to an existing container rather than creating a new one.
+            // Used below to defer the volume lookup into the protected try block.
+            final boolean isResumedContainer = runContainerId != null && filesVolumeName == null
+                && needVolume && FileHandlingStrategy.VOLUME.equals(strategy);
 
             if (!Boolean.TRUE.equals(runContext.render(wait).as(Boolean.class).orElseThrow())) {
                 return TaskRunnerResult.<DockerTaskRunnerDetailResult> builder()
@@ -549,6 +538,25 @@ public class Docker extends TaskRunner<Docker.DockerTaskRunnerDetailResult> {
             AtomicBoolean ended = new AtomicBoolean(false);
 
             try {
+                // Resolve the volume for resumed containers here so that cleanup (kill + delete)
+                // in the finally block is guaranteed to run even when interrupted during the lookup.
+                if (isResumedContainer) {
+                    List<String> labelsList = labels.entrySet()
+                        .stream()
+                        .map(entry -> String.join("=", entry.getKey(), entry.getValue()))
+                        .toList();
+                    var volumes = dockerClient.listVolumesCmd()
+                        .withFilter("label", labelsList).exec();
+                    if (volumes.getVolumes() == null || volumes.getVolumes().isEmpty()) {
+                        logger.error("No volume found for resumed container {}", runContainerId);
+                        throw new TaskException(1, defaultLogConsumer);
+                    } else {
+                        var volume = volumes.getVolumes().get(0);
+                        filesVolumeName = volume.getName();
+                        logger.debug("Volume found with name {} for resumed container {}", filesVolumeName, runContainerId);
+                    }
+                }
+
                 dockerClient.logContainerCmd(runContainerId)
                     .withFollowStream(true)
                     .withStdErr(true)

--- a/script/src/test/java/io/kestra/plugin/scripts/runner/docker/DockerTest.java
+++ b/script/src/test/java/io/kestra/plugin/scripts/runner/docker/DockerTest.java
@@ -231,7 +231,6 @@ class DockerTest extends AbstractTaskRunnerTest {
     }
 
     @Test
-    @FlakyTest
     void interruptAfterResume() throws Exception {
         var taskRunId = IdUtils.create();
 


### PR DESCRIPTION
## Summary

- When a worker thread running a Docker task is interrupted (e.g. task kill), the JVM sets the thread-interrupted flag on the thread.
- The cleanup `finally` block then calls `kill()` which makes HTTP calls via Apache HttpClient 5; the client detects the interrupted flag and throws `CancellationException`/`InterruptedIOException`, which is silently swallowed.
- Because `kill()` silently fails, `removeContainerCmd` then runs on a still-running container without `--force`, also fails silently, and the container is left alive after the thread joins.
- Removes `@FlakyTest` from `interruptAfterResume()` which was testing exactly this cleanup scenario.

## Root cause

`Thread.interrupted()` is not cleared before Docker HTTP cleanup calls in the `finally` block. The fix clears the flag at the top of the finally block and restores it afterward so callers still observe the interrupt state.

## Test plan

- [x] `DockerTest.interruptAfterResume()` passes consistently (previously `@FlakyTest`)
- [x] Full `DockerTest` class passes (10 tests, 0 failures)
- [x] Test re-promoted from `@FlakyTest` → `@Test` since root cause is fixed