### PR TITLE
fix(helm): fetch kestra-starter postgres dep before packaging

### DIFF
--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -84,11 +84,12 @@ jobs:
         env:
           VERSION: ${{ steps.config.outputs.version }}
         run: |
-          # Place freshly packaged kestra tgz as bundled dep so helm package
-          # does not need network access to resolve the kestra dependency.
+          helm repo add groundhog2k https://groundhog2k.github.io/helm-charts/
+          helm repo update groundhog2k
           mkdir -p charts/kestra-starter/charts/
           cp release/kestra-${VERSION}.tgz charts/kestra-starter/charts/
-          # Remove stale Chart.lock — version bump makes it invalid
+          POSTGRES_VER=$(awk '/- name: postgres/{found=1} found && /version:/{gsub(/"/, ""); print $2; exit}' charts/kestra-starter/Chart.yaml)
+          helm pull groundhog2k/postgres --version "${POSTGRES_VER}" -d charts/kestra-starter/charts/
           rm -f charts/kestra-starter/Chart.lock
 
       - name: Lint kestra-starter chart


### PR DESCRIPTION
## Summary
kestra-starter/Chart.yaml declares a postgres dependency (groundhog2k chart, version read dynamically from Chart.yaml) but it was never fetched during the release workflow, causing helm package charts/kestra-starter to fail.

## Changes
- Add groundhog2k helm repo and pull postgres into charts/kestra-starter/charts/ in the bundle step, before lint and package run

ref kestra-io/helm-charts#284