### PR TITLE
fix(tests): make testLastDayCron deterministic

### DIFF
--- a/core/src/test/java/io/kestra/plugin/core/trigger/ScheduleTest.java
+++ b/core/src/test/java/io/kestra/plugin/core/trigger/ScheduleTest.java
@@ -683,6 +683,7 @@ class ScheduleTest {
             .build();
 
         ZonedDateTime now = ZonedDateTime.now()
+            .withDayOfMonth(1)
             .withHour(12)
             .withMinute(0)
             .withSecond(0)


### PR DESCRIPTION
## Summary
- `ScheduleTest.testLastDayCron()` fails on the last day of any month because `ZonedDateTime.now()` is used as the previous trigger date
- On a last-day (e.g. April 30), `nextEvaluationDate` correctly returns the last day of the *next* month, but the test expected the current month's last day
- Fix: anchor `now` to `withDayOfMonth(1)` so the test always executes as if it is early in the month, making the next L-cron hit predictably within the same month

## Root cause
The cron `0 12 L * *` fires at noon on the last day of each month. When the test ran on April 30 at noon, the previous-trigger date was April 30 12:00, so `nextEvaluationDate` returned May 31 (day 31) — but the assertion expected day 30 (April's last day).

## Test plan
- [x] `./gradlew :core:test --tests "io.kestra.plugin.core.trigger.ScheduleTest.testLastDayCron"` passes locally
- [x] 1-line change, no production code touched