### PR TITLE
fix(scheduler): serialize when-condition candidate dates in trigger timezone

### DIFF
--- a/core/src/main/java/io/kestra/plugin/core/trigger/Schedule.java
+++ b/core/src/main/java/io/kestra/plugin/core/trigger/Schedule.java
@@ -524,9 +524,12 @@ public class Schedule extends AbstractTrigger implements Schedulable, TriggerOut
      * schedule dates (so when can render {@code {{ trigger.date }}}).
      */
     private boolean whenConditionMatch(RunContext runContext, Output candidateOutput) throws InternalException {
+        Map<String, Object> outputMap = this.timezone != null
+            ? candidateOutput.toMap(ZoneId.of(this.timezone))
+            : candidateOutput.toMap();
         Map<String, Object> additionalVariables = Map.of(
-            "schedule", candidateOutput.toMap(),
-            "trigger", candidateOutput.toMap()
+            "schedule", outputMap,
+            "trigger", outputMap
         );
         return this.getWhen() == null || TruthUtils.isTruthy(runContext.render(this.getWhen(), additionalVariables));
     }

--- a/scheduler/src/test/java/io/kestra/scheduler/TriggerSchedulerTest.java
+++ b/scheduler/src/test/java/io/kestra/scheduler/TriggerSchedulerTest.java
@@ -16,7 +16,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.reactivestreams.Publisher;
 
-import io.kestra.core.junit.annotations.FlakyTest;
 import io.kestra.core.metrics.MetricRegistry;
 import io.kestra.core.models.annotations.Plugin;
 import io.kestra.core.models.conditions.ConditionContext;
@@ -274,7 +273,6 @@ class TriggerSchedulerTest {
     }
 
     @Test
-    @FlakyTest
     void shouldSucceedScheduleConditionalScheduleTriggerGivenValidTimeZone() {
         // region [GIVEN]
         FlowWithSource flow = Fixtures.defaultFlow(


### PR DESCRIPTION
## Summary

- `Schedule.whenConditionMatch()` was calling `candidateOutput.toMap()` which serializes `ZonedDateTime` using `JacksonMapper.MAPPER` with `setTimeZone(TimeZone.getDefault())`
- On CI machines running UTC, midnight Paris dates like `2025-11-03T00:00+01:00` were serialized as `2025-11-02T23:00:00Z`
- `isDayWeekInMonth` then extracted the wrong local date (Nov 2 instead of Nov 3), causing `findNextDateMatchingConditions` to skip the expected Monday and advance to next month's first Monday
- The scheduler missed the scheduled execution, making the test fail only on UTC-timezone hosts

## Fix

Use `candidateOutput.toMap(ZoneId.of(this.timezone))` so candidate dates are always serialized in the trigger's configured timezone — matching the pattern already used in `Schedule.evaluate()`.

Removes `@FlakyTest` from `shouldSucceedScheduleConditionalScheduleTriggerGivenValidTimeZone` since the test is now deterministic on all timezones.

## Test plan

- [x] `shouldSucceedScheduleConditionalScheduleTriggerGivenValidTimeZone` passes under `./gradlew :scheduler:test` (no longer flaky)
- [x] Full scheduler test suite: 75 passing, 0 failing
- [x] `ScheduleTest` and `IsDayWeekInMonthFunctionTest` in core: 37 passing, 0 failing