### PR TITLE
fix(worker): prevent kill events being lost when worker job queue is full

### DIFF
--- a/worker/src/main/java/io/kestra/worker/fetchers/WorkerJobFetcher.java
+++ b/worker/src/main/java/io/kestra/worker/fetchers/WorkerJobFetcher.java
@@ -308,29 +308,33 @@ public class WorkerJobFetcher extends WorkerLoop {
             }
         }
 
-        List<String> acks = new ArrayList<>();
-        for (WorkerJobPayload payload : response.getJobsList()) {
-            try {
-                String jobId = payload.getJobId();
-                WorkerJob job = MessageFormats.JSON.fromByteString(payload.getJobData(), WorkerJob.class);
-
-                log.debug("Received job: {}", jobId);
-
-                // Put job in local queue (blocking if full - provides local backpressure)
-                workerJobQueue.put(job);
-
-                // Collect ACK for this job (receipt acknowledgment)
-                acks.add(jobId);
-
-            } catch (Exception e) {
-                log.error("Error processing job payload: {}", e.getMessage(), e);
-            }
-        }
-
-        // Send ACKs and request more permits based on remaining capacity
-        // Only send if there were jobs (event-only responses don't need permit updates)
-        if (!acks.isEmpty()) {
-            sendPermitsAndAcks(observer, calculatePermits(), acks);
+        // If this response contains jobs, offload the potentially-blocking queue put to a
+        // virtual thread. Blocking the gRPC onNext() callback would prevent subsequent
+        // messages (including kill events) from being delivered because gRPC serializes
+        // stream message delivery: message N+1 is not dispatched until onNext(N) returns.
+        if (!response.getJobsList().isEmpty()) {
+            List<WorkerJobPayload> jobs = response.getJobsList();
+            Thread.ofVirtual().name("worker-job-receiver").start(() ->
+            {
+                List<String> acks = new ArrayList<>();
+                for (WorkerJobPayload payload : jobs) {
+                    try {
+                        String jobId = payload.getJobId();
+                        WorkerJob job = MessageFormats.JSON.fromByteString(payload.getJobData(), WorkerJob.class);
+                        log.debug("Received job: {}", jobId);
+                        // Blocking put — backpressure is now isolated to this virtual thread.
+                        workerJobQueue.put(job);
+                        acks.add(jobId);
+                    } catch (Exception e) {
+                        log.error("Error processing job payload: {}", e.getMessage(), e);
+                    }
+                }
+                // Send ACKs with current capacity after all puts have completed.
+                ClientCallStreamObserver<WorkerJobRequest> obs = requestObserverRef.get();
+                if (!acks.isEmpty() && obs != null) {
+                    sendPermitsAndAcks(obs, calculatePermits(), acks);
+                }
+            });
         }
     }
 

--- a/worker/src/main/java/io/kestra/worker/processors/AbstractWorkerJobProcessor.java
+++ b/worker/src/main/java/io/kestra/worker/processors/AbstractWorkerJobProcessor.java
@@ -29,6 +29,9 @@ public abstract class AbstractWorkerJobProcessor<T extends WorkerJob> implements
     private final AtomicReference<AbstractWorkerCallable> currentWorkerCallable = new AtomicReference<>();
 
     private final AtomicBoolean stopped = new AtomicBoolean(false);
+    // Tracks whether kill() was called before the callable was set in callJob(),
+    // so the deferred kill can be applied when the callable becomes available.
+    private final AtomicBoolean killRequested = new AtomicBoolean(false);
 
     public AbstractWorkerJobProcessor(String workerGroup,
         MetricRegistry metricRegistry,
@@ -65,6 +68,10 @@ public abstract class AbstractWorkerJobProcessor<T extends WorkerJob> implements
 
     protected io.kestra.core.models.flows.State.Type callJob(AbstractWorkerCallable workerJobCallable) {
         this.currentWorkerCallable.set(workerJobCallable);
+        // If kill() was called before the callable was set, apply it now.
+        if (killRequested.get()) {
+            workerJobCallable.kill();
+        }
         try {
             return tracer.inCurrentContext(
                 workerJobCallable.getRunContext(),
@@ -91,6 +98,7 @@ public abstract class AbstractWorkerJobProcessor<T extends WorkerJob> implements
 
     @Override
     public void kill() {
+        killRequested.set(true);
         Optional.ofNullable(currentWorkerCallable.get()).ifPresent(AbstractWorkerCallable::kill);
     }
 

--- a/worker/src/main/java/io/kestra/worker/processors/internals/AbstractWorkerCallable.java
+++ b/worker/src/main/java/io/kestra/worker/processors/internals/AbstractWorkerCallable.java
@@ -63,6 +63,11 @@ public abstract class AbstractWorkerCallable implements Callable<State.Type> {
     public State.Type call() {
         this.currentThread = Thread.currentThread();
         this.currentThread.setContextClassLoader(classLoader);
+        // If kill() was called before call() started (currentThread was null then),
+        // the interrupt was never sent. Apply it now so the task sees it immediately.
+        if (killed) {
+            this.currentThread.interrupt();
+        }
 
         try {
             return doCall();

--- a/worker/src/main/java/io/kestra/worker/services/ExecutionKilledManager.java
+++ b/worker/src/main/java/io/kestra/worker/services/ExecutionKilledManager.java
@@ -98,6 +98,9 @@ public class ExecutionKilledManager {
 
     /**
      * Registers a running job with its kill callback.
+     * <p>
+     * If the job's execution was already killed before this registration, the kill action
+     * is invoked immediately so queued tasks don't slip through the kill window.
      *
      * @param jobUid the unique identifier of the job
      * @param job the worker job
@@ -105,6 +108,14 @@ public class ExecutionKilledManager {
      */
     public void register(String jobUid, WorkerJob job, Runnable killAction) {
         runningJobs.put(jobUid, new KillableJob(job, killAction));
+        // If a kill event arrived before this job was registered, apply it now.
+        if (job instanceof WorkerTask workerTask) {
+            ExecutionKilledExecution killedExecution = killedExecutions.getIfPresent(workerTask.getTaskRun().getExecutionId());
+            if (killedExecution != null && killedExecution.isEqual(workerTask)) {
+                Logs.logTaskRun(workerTask.getTaskRun(), Level.INFO, "Killing task (execution was already killed before registration)");
+                killAction.run();
+            }
+        }
     }
 
     /**

--- a/worker/src/test/java/io/kestra/worker/WorkerTest.java
+++ b/worker/src/test/java/io/kestra/worker/WorkerTest.java
@@ -148,7 +148,6 @@ class WorkerTest {
     }
 
     @Test
-    @FlakyTest
     void shouldKillTasksWhenExecutionKillEventReceived() throws InterruptedException, QueueException {
         // Given
         List<LogEntry> logs = new CopyOnWriteArrayList<>();
@@ -170,7 +169,14 @@ class WorkerTest {
             workerJobEventQueue.emit(null, WorkerJobEvent.of(workerTask(Duration.ofSeconds(60), executionId), null));
             workerJobEventQueue.emit(null, WorkerJobEvent.of(workerTask(Duration.ofSeconds(1)), null));
 
-            Thread.sleep(500);
+            // Wait until at least one task for this execution is in RUNNING state before killing.
+            // This ensures the callable is set in the processor and the interrupt will land.
+            await()
+                .atMost(Duration.ofSeconds(30))
+                .pollInterval(Duration.ofMillis(100))
+                .until(() -> results.stream()
+                    .anyMatch(r -> r.getTaskRun().getExecutionId().equals(executionId)
+                        && r.getTaskRun().getState().getCurrent() == State.Type.RUNNING));
 
             // When
             ExecutionKilledExecution killedExecution = ExecutionKilledExecution.builder()


### PR DESCRIPTION
⚠️  full Claude PR, to review

## Summary

- **Root cause**: `WorkerJobFetcher.handleJobResponse()` calls `workerJobQueue.put(job)` which blocks when the local queue is at capacity. Because gRPC serialises stream message delivery per stream (via its internal `SerializingExecutor`), a kill event arriving as the next message was never dispatched until the blocked `put()` returned — which only happens when the queue drains, which requires the task to be killed, which requires the kill event. Deadlock.
- **Fix**: Offload the blocking `put()` to a virtual thread so the gRPC `onNext()` callback returns immediately. Kill-event responses are still processed synchronously (before the virtual-thread branch).
- Three additional hardening fixes for adjacent race windows:
  - `AbstractWorkerJobProcessor`: `killRequested` flag so a kill arriving before `callJob()` sets `currentWorkerCallable` is not silently dropped
  - `AbstractWorkerCallable.call()`: deferred self-interrupt when `kill()` ran before `call()` could set `currentThread`
  - `ExecutionKilledManager.register()`: check `killedExecutions` cache at registration time so queued tasks are killed immediately instead of running to completion
- Test: replaced `Thread.sleep(500)` with a deterministic Awaitility await on `State.Type.RUNNING`, and removed `@FlakyTest`

## Test plan

- [x] `WorkerTest#shouldKillTasksWhenExecutionKillEventReceived` passes in 4/4 consecutive local runs
- [x] Full `:worker:test` suite (53 tests) passes