### PR TITLE
feat: add EMAIL and SUPER_ADMIN query filters for invitation resource

### DIFF
--- a/core/src/main/java/io/kestra/core/models/QueryFilter.java
+++ b/core/src/main/java/io/kestra/core/models/QueryFilter.java
@@ -340,6 +340,12 @@ public record QueryFilter(
             public List<Op> supportedOp() {
                 return List.of();
             }
+        },
+        SUPER_ADMIN("super_admin") {
+            @Override
+            public List<Op> supportedOp() {
+                return List.of(Op.EQUALS);
+            }
         };
 
         private static final Map<String, Field> BY_VALUE = Arrays.stream(values())
@@ -435,7 +441,7 @@ public record QueryFilter(
         INVITATION {
             @Override
             public List<Field> supportedField() {
-                return List.of(Field.QUERY, Field.EMAIL, Field.STATUS, Field.EXPIRED_AT);
+                return List.of(Field.QUERY, Field.EMAIL, Field.STATUS, Field.EXPIRED_AT, Field.SUPER_ADMIN);
             }
         },
         GROUP {

--- a/core/src/test/java/io/kestra/core/models/QueryFilterTest.java
+++ b/core/src/test/java/io/kestra/core/models/QueryFilterTest.java
@@ -368,6 +368,13 @@ public class QueryFilterTest {
             ),
 
             buildQueryFiltersForOperations(
+                Field.SUPER_ADMIN, Resource.INVITATION,
+                Set.of(
+                    Op.EQUALS
+                )
+            ),
+
+            buildQueryFiltersForOperations(
                 Field.ENABLED, Resource.SECURITY_INTEGRATION,
                 Set.of(
                     Op.EQUALS
@@ -1058,6 +1065,24 @@ public class QueryFilterTest {
                 Field.EXPIRED_AT, Resource.INVITATION,
                 Set.of(
                     Op.EQUALS,
+                    Op.NOT_EQUALS,
+                    Op.GREATER_THAN,
+                    Op.LESS_THAN,
+                    Op.GREATER_THAN_OR_EQUAL_TO,
+                    Op.LESS_THAN_OR_EQUAL_TO,
+                    Op.IN,
+                    Op.NOT_IN,
+                    Op.STARTS_WITH,
+                    Op.ENDS_WITH,
+                    Op.CONTAINS,
+                    Op.REGEX,
+                    Op.PREFIX
+                )
+            ),
+
+            buildQueryFiltersForOperations(
+                Field.SUPER_ADMIN, Resource.INVITATION,
+                Set.of(
                     Op.NOT_EQUALS,
                     Op.GREATER_THAN,
                     Op.LESS_THAN,

--- a/jdbc/src/main/java/io/kestra/jdbc/repository/AbstractJdbcRepository.java
+++ b/jdbc/src/main/java/io/kestra/jdbc/repository/AbstractJdbcRepository.java
@@ -298,6 +298,10 @@ public abstract class AbstractJdbcRepository {
             return getEnabledCondition(value, operation);
         }
 
+        if (field == QueryFilter.Field.SUPER_ADMIN) {
+            return getSuperAdminCondition(value, operation);
+        }
+
         if (field == QueryFilter.Field.STATUS) {
             return statusCondition(value, operation);
         }
@@ -442,6 +446,10 @@ public abstract class AbstractJdbcRepository {
 
     protected Condition getEnabledCondition(Object value, Op operation) {
         return defaultHandlers(QueryFilter.Field.ENABLED, value, operation);
+    }
+
+    protected Condition getSuperAdminCondition(Object value, Op operation) {
+        throw new InvalidQueryFiltersException("getSuperAdminCondition must be overridden for JSONB-backed superAdmin field");
     }
 
     // Generate the condition for Field.STATE

--- a/jdbc/src/test/java/io/kestra/jdbc/repository/AbstractJdbcRepositoryTest.java
+++ b/jdbc/src/test/java/io/kestra/jdbc/repository/AbstractJdbcRepositoryTest.java
@@ -29,7 +29,8 @@ class AbstractJdbcRepositoryTest extends AbstractJdbcRepository {
         QueryFilter.Field.TRIGGER_STATE,
         QueryFilter.Field.METADATA,
         QueryFilter.Field.GROUP,
-        QueryFilter.Field.NAME
+        QueryFilter.Field.NAME,
+        QueryFilter.Field.SUPER_ADMIN
     );
 
     @Test

--- a/ui/packages/design-system/src/components/Data/KsDataTable/KsFilter.locale.ts
+++ b/ui/packages/design-system/src/components/Data/KsDataTable/KsFilter.locale.ts
@@ -126,6 +126,10 @@ export default {
                 "label": "Flow ID",
                 "description": "Filter by flow ID",
             },
+            "email" : {
+                "label": "Email",
+                "description": "Filter by email",
+            },
             "kind": {
                 "label": "Kind",
                 "description": "Filter by execution kind",


### PR DESCRIPTION
### ✨ Description

This PR adds query filter support for the following Field, Resource and Operator combinations:                            

| Resource   | Field       | Operator |                                                                                   
|------------|-------------|----------|                   
| INVITATION | EMAIL       | EQUALS   |
| INVITATION | SUPER_ADMIN | EQUALS   |

The `superAdmin` field lives exclusively in the JSONB `value` blob (no generated column), so each DB dialect provides its 
own condition via an overridable `getSuperAdminCondition` method. The base implementation in `AbstractJdbcRepository`     
throws `InvalidQueryFiltersException` to prevent silent failures if a repo forgets to override it.
                                                                                                             
### 🔗 Related Issue                                                                
relates to: https://github.com/kestra-io/kestra-ee/issues/7087                                                
 
### 🎨 Frontend Checklist                                                                                                 
                                                          
- [x] Code builds without errors (`npm run build`)
- [x] All existing E2E tests pass (`npm run test:e2e`)
- [x] Screenshots or video recordings attached showing the `UI` changes

### 🛠️  Backend Checklist
                                                                                                                          
- [x] Code compiles successfully and passes all checks
- [x] All unit and integration tests pass  