### PR TITLE
[backport releases/v1.3.x] fix(flows): autocomplete reliability in pebble blocks

### DIFF
--- a/ui/src/components/inputs/MonacoEditor.vue
+++ b/ui/src/components/inputs/MonacoEditor.vue
@@ -31,6 +31,7 @@
     import JsonWorker from "monaco-editor/esm/vs/language/json/json.worker?worker";
     import TypeScriptWorker from "monaco-editor/esm/vs/language/typescript/ts.worker?worker";
     import YamlWorker from "./yaml.worker.js?worker";
+    import {isOffsetInPebbleBlock} from "../../utils/pebbleBlock";
 
     const NodeTypesRaw = import.meta.glob("/node_modules/@types/node/**/*.d.ts", {eager: true, query: "?raw", import: "default"});
 
@@ -77,20 +78,12 @@
     };
 
     function isCursorInPebbleBlock(editor: monaco.editor.ICodeEditor) {
-        const editorValue = editor.getValue()
-        const cursorPos = editor.getPosition()
-
+        const cursorPos = editor.getPosition();
         if(!cursorPos){
             return false;
         }
-
-        // get the absolute index in the string
-        const absoluteOffset = editor.getModel()?.getOffsetAt(cursorPos) ?? 0
-
-        // if the previous token is {{ it means we are in a pebble block -> true
-        // if a }} comes after the {{ we have come out of the block and are not -> false
-        // if both are empty, they both return -1 -> false
-        return editorValue.lastIndexOf("{{", absoluteOffset) > editorValue.lastIndexOf("}}", absoluteOffset);
+        const absoluteOffset = editor.getModel()?.getOffsetAt(cursorPos) ?? 0;
+        return isOffsetInPebbleBlock(editor.getValue(), absoluteOffset);
     }
 </script>
 
@@ -921,11 +914,17 @@
                     }
                 });
 
+                let wasInPebbleBlock = false;
                 localEditor.value.onDidChangeCursorPosition(debounce(() => {
+                    if (!localEditor.value) return;
+                    const inPebble = isCursorInPebbleBlock(localEditor.value);
                     if (suggestController.model.state !== 0) {
                         suggestController.cancelSuggestWidget();
-                        localEditor.value!.trigger("refreshSuggestionsOnCursorMove", "editor.action.triggerSuggest", {});
+                        localEditor.value.trigger("refreshSuggestionsOnCursorMove", "editor.action.triggerSuggest", {});
+                    } else if (inPebble && !wasInPebbleBlock) {
+                        localEditor.value.trigger("triggerSuggestionsInPebbleBlock", "editor.action.triggerSuggest", {});
                     }
+                    wasInPebbleBlock = inPebble;
                 }, 300))
 
                 localEditor.value.onMouseMove((e) => {

--- a/ui/src/composables/monaco/languages/pebbleLanguageConfigurator.ts
+++ b/ui/src/composables/monaco/languages/pebbleLanguageConfigurator.ts
@@ -146,7 +146,7 @@ export function registerNestedValueAutoCompletion(
 
             const startOfWordColumn = position.column - parentFieldMatcher.matches[2].length;
             return {
-                suggestions: (await autoCompletion.nestedFieldAutoCompletion(source, parsed, parentFieldMatcher.matches[1]))
+                suggestions: (await autoCompletion.nestedFieldAutoCompletion(source, parsed, parentFieldMatcher.matches[1], model.getOffsetAt(position)))
                     .map(s => propertySuggestion(s, {
                         lineNumber: position.lineNumber,
                         startColumn: startOfWordColumn,

--- a/ui/src/composables/monaco/languages/pebbleLanguageConfigurator.ts
+++ b/ui/src/composables/monaco/languages/pebbleLanguageConfigurator.ts
@@ -67,6 +67,7 @@ export function registerPebbleAutocompletion(
 
             const startOfWordColumn = position.column - rootPebbleVariableMatcher.matches[1].length;
             return {
+                incomplete: true,
                 suggestions: (await (autoCompletion.rootFieldAutoCompletion()))
                     .map(s => propertySuggestion(s, {
                         lineNumber: position.lineNumber,
@@ -99,6 +100,7 @@ export function registerFunctionParametersAutoCompletion(
                 ?? 0;
             const startOfWordColumn = position.column - wordStartOffset;
             return {
+                incomplete: true,
                 suggestions: (await autoCompletion.functionAutoCompletion(
                         parsed,
                         functionMatcher.matches[1],
@@ -146,6 +148,7 @@ export function registerNestedValueAutoCompletion(
 
             const startOfWordColumn = position.column - parentFieldMatcher.matches[2].length;
             return {
+                incomplete: true,
                 suggestions: (await autoCompletion.nestedFieldAutoCompletion(source, parsed, parentFieldMatcher.matches[1], model.getOffsetAt(position)))
                     .map(s => propertySuggestion(s, {
                         lineNumber: position.lineNumber,
@@ -183,6 +186,7 @@ export function registerFilterAutoCompletion(
             const endColumn = position.column;
 
             return {
+                incomplete: true,
                 suggestions: (await autoCompletion.filterAutoCompletion())
                     .map(s => propertySuggestion(s, {
                         lineNumber: position.lineNumber,

--- a/ui/src/override/services/flowAutoCompletionProvider.ts
+++ b/ui/src/override/services/flowAutoCompletionProvider.ts
@@ -87,6 +87,59 @@ export class FlowAutoCompletion extends YamlAutoCompletion {
             .filter(task => typeof task?.get === "function" && task?.get("id"));
     }
 
+    private cursorProbeIndexes(source: string, cursorIndex: number): number[] {
+        const safeCursorIndex = Math.max(0, Math.min(cursorIndex - 1, source.length - 1));
+        const probeIndexes = [safeCursorIndex];
+        let previousNonWhitespace = safeCursorIndex;
+        while (previousNonWhitespace > 0 && /\s/.test(source.charAt(previousNonWhitespace))) {
+            previousNonWhitespace--;
+        }
+        if (previousNonWhitespace !== safeCursorIndex) {
+            probeIndexes.push(previousNonWhitespace);
+        }
+
+        return probeIndexes;
+    }
+
+    private taskIdFromCandidates(candidates: any[]): string | undefined {
+        for (let i = candidates.length - 1; i >= 0; i--) {
+            const candidate = candidates[i];
+            if (
+                candidate && typeof candidate === "object"
+                && typeof candidate.id === "string"
+                && typeof candidate.type === "string"
+            ) {
+                return candidate.id;
+            }
+        }
+
+        return undefined;
+    }
+
+    private currentTaskIdAtCursor(source: string, cursorIndex?: number): string | undefined {
+        if (cursorIndex === undefined || source.length === 0) {
+            return undefined;
+        }
+
+        const probeIndexes = this.cursorProbeIndexes(source, cursorIndex);
+
+        try {
+            for (const probeIndex of probeIndexes) {
+                const localized = YAML_UTILS.localizeElementAtIndex(source, probeIndex);
+                const candidates = [...(localized?.parents ?? []), localized?.value];
+
+                const taskId = this.taskIdFromCandidates(candidates);
+                if (taskId) {
+                    return taskId;
+                }
+            }
+        } catch {
+            return undefined;
+        }
+
+        return undefined;
+    }
+
     private async outputsFor(taskId: string, source: string): Promise<string[]> {
         const taskType = this.tasks(this.completionSource?.value ?? source).filter(task => task.get("id") === taskId)
             .map(task => task.get("type"))
@@ -119,12 +172,18 @@ export class FlowAutoCompletion extends YamlAutoCompletion {
         return distinct(fetchTriggerVarsByType.flat());
     }
 
-    async nestedFieldAutoCompletion(source: string, parsed: any | undefined, parentField: string): Promise<string[]> {
+    async nestedFieldAutoCompletion(source: string, parsed: any | undefined, parentField: string, cursorIndex?: number): Promise<string[]> {
         switch (parentField) {
             case "inputs":
                 return Promise.resolve(parsed?.inputs?.map((input: {id?: string}) => input.id) ?? []);
-            case "outputs":
-                return Promise.resolve(parsed?.tasks?.map((task: {id?: string}) => task.id).filter(Boolean) ?? []);
+            case "outputs": {
+                const currentTaskId = this.currentTaskIdAtCursor(source, cursorIndex);
+                return Promise.resolve(
+                    parsed?.tasks
+                        ?.map((task: {id?: string}) => task.id)
+                        .filter((taskId: string | undefined) => taskId && taskId !== currentTaskId) ?? []
+                );
+            }
             case "labels":
                 return Promise.resolve(Object.keys(parsed?.labels ?? {}));
             case "flow":

--- a/ui/src/services/autoCompletionProvider.ts
+++ b/ui/src/services/autoCompletionProvider.ts
@@ -46,7 +46,7 @@ export class PebbleAutoCompletion {
         return Promise.resolve([]);
     }
 
-    nestedFieldAutoCompletion(_source: string, _parsed: any | undefined, _parentField: string): Promise<string[]> {
+    nestedFieldAutoCompletion(_source: string, _parsed: any | undefined, _parentField: string, _cursorIndex?: number): Promise<string[]> {
         return Promise.resolve([])
     }
 

--- a/ui/src/utils/pebbleBlock.ts
+++ b/ui/src/utils/pebbleBlock.ts
@@ -1,0 +1,19 @@
+/**
+ * Returns true when `offset` (cursor position, between characters) sits inside an
+ * unclosed `{{ ... }}` pebble block in `text`.
+ *
+ * The cursor at offset N sits between characters at index (N-1) and N, so we
+ * search up to (N-1) — otherwise a `}}` that starts AT N (e.g. cursor placed
+ * right before `}}` of an empty `{{ }}` block) would be treated as closing the
+ * block, hiding autocomplete.
+ */
+export function isOffsetInPebbleBlock(text: string, offset: number): boolean {
+    // Cursor at offset 0 sits before everything — nothing can have opened.
+    // For offset >= 2, search up to (offset - 1) so a `}}` that starts AT the
+    // cursor is not treated as a closer.
+    if (offset < 2) {
+        return false;
+    }
+    const searchUpTo = offset - 1;
+    return text.lastIndexOf("{{", searchUpTo) > text.lastIndexOf("}}", searchUpTo);
+}

--- a/ui/tests/unit/composables/pebbleLanguageConfigurator.spec.ts
+++ b/ui/tests/unit/composables/pebbleLanguageConfigurator.spec.ts
@@ -1,0 +1,38 @@
+import {describe, expect, it, vi} from "vitest";
+
+(globalThis as any).MonacoEnvironment = {
+    getWorker: () => ({postMessage(){}, terminate(){}, addEventListener(){}, removeEventListener(){}}),
+};
+
+import * as monaco from "monaco-editor/esm/vs/editor/editor.api";
+
+vi.mock("@kestra-io/ui-libs/flow-yaml-utils", () => ({parse: () => ({})}));
+
+import {
+    registerPebbleAutocompletion,
+    registerFunctionParametersAutoCompletion,
+    registerNestedValueAutoCompletion,
+    registerFilterAutoCompletion,
+} from "../../../src/composables/monaco/languages/pebbleLanguageConfigurator";
+
+describe.each([
+    ["pebble root variable", "{{ inputs",  10, registerPebbleAutocompletion,             {rootFieldAutoCompletion:   () => Promise.resolve(["inputs"])}],
+    ["function parameters",  "{{ secret(", 11, registerFunctionParametersAutoCompletion, {functionAutoCompletion:    () => Promise.resolve(["'value'"])}],
+    ["nested value",         "{{ flow.",    9, registerNestedValueAutoCompletion,        {nestedFieldAutoCompletion: () => Promise.resolve(["id"])}],
+    ["filter",               "{{ x | up",  10, registerFilterAutoCompletion,             {filterAutoCompletion:      () => Promise.resolve(["upper"])}],
+])("%s autocompletion", (_label, text, column, register, ac) => {
+    it("returns incomplete:true so Monaco re-invokes provider on every keystroke", async () => {
+        const spy = vi.spyOn(monaco.languages, "registerCompletionItemProvider")
+            .mockImplementation((() => ({dispose: () => {}})) as any);
+        const model = monaco.editor.createModel(text);
+        try {
+            register([], ac as any, ["yaml"]);
+            const provider = spy.mock.calls[0][1] as any;
+            const result = await provider.provideCompletionItems(model, {lineNumber: 1, column} as any);
+            expect(result.incomplete).toBe(true);
+        } finally {
+            model.dispose();
+            spy.mockRestore();
+        }
+    });
+});

--- a/ui/tests/unit/services/flowAutoCompletionProvider.spec.ts
+++ b/ui/tests/unit/services/flowAutoCompletionProvider.spec.ts
@@ -35,6 +35,21 @@ triggers:
 id: my-flow
 namespace: my.namespace`;
 
+const flowWithOutputsAutocompleteInTask = [
+    "tasks:",
+    "  - id: download",
+    "    type: io.kestra.plugin.core.http.Download",
+    "    uri: https://example.com/file.txt",
+    "  - id: filter",
+    "    type: io.kestra.plugin.core.storage.FilterItems",
+    "    from: \"{{ outputs. }}\"",
+    "  - id: upload",
+    "    type: io.kestra.plugin.core.storage.Upload",
+    "    from: \"{{ outputs.download.uri }}\"",
+    "id: my-flow",
+    "namespace: my.namespace"
+].join("\n");
+
 const propertiesSchemaWrapper = (properties: Record<string, any>) => ({
     schema: {
         outputs: {
@@ -124,6 +139,7 @@ const namespacesStore = {
 
 const provider = new FlowAutoCompletion(flowStore, pluginsStore, namespacesStore);
 const parsed = YAML_UTILS.parse(defaultFlow);
+const flowWithOutputsAutocompleteInTaskParsed = YAML_UTILS.parse(flowWithOutputsAutocompleteInTask);
 
 describe("FlowAutoCompletionProvider", () => {
     it("root autocompletions", async () => {
@@ -185,6 +201,24 @@ describe("FlowAutoCompletionProvider", () => {
         expect(await provider.nestedFieldAutoCompletion(defaultFlow, parsed, "outputs.task2")).toEqual(["value"]);
         expect(await provider.nestedFieldAutoCompletion(defaultFlow, parsed, "outputs.task3")).toEqual([]);
         expect(await provider.nestedFieldAutoCompletion(defaultFlow, parsed, "bad")).toEqual([]);
+    })
+
+    it("outputs autocomplete excludes current task id", async () => {
+        const cursorIndex = flowWithOutputsAutocompleteInTask.indexOf("outputs.") + "outputs.".length;
+        expect(cursorIndex).toBeGreaterThan(0);
+
+        expect(await provider.nestedFieldAutoCompletion(
+            flowWithOutputsAutocompleteInTask,
+            flowWithOutputsAutocompleteInTaskParsed,
+            "outputs",
+            cursorIndex
+        )).toEqual(["download", "upload"]);
+
+        expect(await provider.nestedFieldAutoCompletion(
+            flowWithOutputsAutocompleteInTask,
+            flowWithOutputsAutocompleteInTaskParsed,
+            "outputs"
+        )).toEqual(["download", "filter", "upload"]);
     })
 
     it("value autocompletions", async () => {

--- a/ui/tests/unit/utils/pebbleBlock.spec.ts
+++ b/ui/tests/unit/utils/pebbleBlock.spec.ts
@@ -1,0 +1,61 @@
+import {describe, expect, it} from "vitest";
+import {isOffsetInPebbleBlock} from "../../../src/utils/pebbleBlock";
+
+describe("isOffsetInPebbleBlock", () => {
+    it("returns false outside any pebble block", () => {
+        const text = "hello world";
+        expect(isOffsetInPebbleBlock(text, 0)).toBe(false);
+        expect(isOffsetInPebbleBlock(text, 5)).toBe(false);
+        expect(isOffsetInPebbleBlock(text, text.length)).toBe(false);
+    });
+
+    it("returns true between {{ and }} with a space", () => {
+        // text:    {{ }}
+        // offsets: 0123 4
+        const text = "{{ }}";
+        // cursor right after `{{` (offset 2): inside
+        expect(isOffsetInPebbleBlock(text, 2)).toBe(true);
+        // cursor between space and `}}` (offset 3): inside — this is the bug fixed
+        expect(isOffsetInPebbleBlock(text, 3)).toBe(true);
+    });
+
+    it("returns true for the common Monaco auto-close case `{{ }}` cursor right before `}}`", () => {
+        // YAML-like text Monaco produces when typing `{{` and auto-closing
+        const text = "message: \"{{ }}\"";
+        const closingStart = text.indexOf("}}"); // 13
+        // cursor right before `}}` (would be the natural caret position after auto-close)
+        expect(isOffsetInPebbleBlock(text, closingStart)).toBe(true);
+    });
+
+    it("returns false right after the closing }}", () => {
+        const text = "{{ x }}";
+        const afterClose = text.indexOf("}}") + 2;
+        expect(isOffsetInPebbleBlock(text, afterClose)).toBe(false);
+    });
+
+    it("handles multiple pebble blocks on one line", () => {
+        const text = "{{ a }} and {{ b }}";
+        const firstClose = text.indexOf("}}"); // 5
+        const secondOpen = text.indexOf("{{", firstClose + 2);
+        // between the two blocks → false
+        expect(isOffsetInPebbleBlock(text, firstClose + 2)).toBe(false);
+        // inside the second block
+        expect(isOffsetInPebbleBlock(text, secondOpen + 3)).toBe(true);
+    });
+
+    it("returns false when only `}}` exists before cursor", () => {
+        const text = "}}abc";
+        expect(isOffsetInPebbleBlock(text, 4)).toBe(false);
+    });
+
+    it("returns false at offset 0 even with `{{` later in text", () => {
+        const text = "{{ x }}";
+        expect(isOffsetInPebbleBlock(text, 0)).toBe(false);
+    });
+
+    it("clamps negative-style searches gracefully", () => {
+        // offset 1 means searchUpTo=0; lastIndexOf at 0 only matches if `{{` starts at 0
+        const text = "{{ }}";
+        expect(isOffsetInPebbleBlock(text, 1)).toBe(false);
+    });
+});


### PR DESCRIPTION
Backport of:
- kestra-io/kestra#15087 — fix(core): prevent output autocompletion from including current task id (cherry-picked from d54f444fbe3eed99f4fa73d3c6cbc66f033ea107)
- kestra-io/kestra#15794 — fix(flows): autocomplete reliability in pebble blocks (cherry-picked from a0ab21b4676f48006a501b5507397c0f4988fef7)

Cherry-picked with `-x`. #15087 is required first to avoid a conflict in `pebbleLanguageConfigurator.ts` introduced by the `cursorIndex` parameter.