### PR TITLE
feat(execution): cache Flow with plugin defaults in the FlowMetaStore

### DIFF
--- a/core/src/main/java/io/kestra/core/runners/DefaultFlowMetaStore.java
+++ b/core/src/main/java/io/kestra/core/runners/DefaultFlowMetaStore.java
@@ -28,13 +28,15 @@ public class DefaultFlowMetaStore implements FlowMetaStoreInterface {
     private final PluginDefaultService pluginDefaultService;
     private final ConcurrentHashMap<String, FlowWithSource> cache = new ConcurrentHashMap<>();
     private final BroadcastQueueInterface<FlowInterface> flowQueue;
+    private final FlowWithDefaultCache withDefaultCache;
 
     private QueueSubscriber<FlowInterface> subscriber;
 
-    public DefaultFlowMetaStore(FlowRepositoryInterface flowRepository, PluginDefaultService pluginDefaultService, BroadcastQueueInterface<FlowInterface> flowQueue) {
+    public DefaultFlowMetaStore(FlowRepositoryInterface flowRepository, PluginDefaultService pluginDefaultService, BroadcastQueueInterface<FlowInterface> flowQueue, FlowWithDefaultCache withDefaultCache) {
         this.flowRepository = flowRepository;
         this.pluginDefaultService = pluginDefaultService;
         this.flowQueue = flowQueue;
+        this.withDefaultCache = withDefaultCache;
 
         flowRepository.findAllWithSourceForAllTenants().forEach(it -> cache.put(it.uidWithoutRevision(), it));
     }
@@ -64,6 +66,9 @@ public class DefaultFlowMetaStore implements FlowMetaStoreInterface {
                         log.error("Unable to inject version defaults for flow {}", flow.getId(), e);
                     }
                 }
+
+                // always clear the withDefault cache so it's recomputed
+                withDefaultCache.invalidate(flow.uid());
             }
         });
     }
@@ -94,11 +99,20 @@ public class DefaultFlowMetaStore implements FlowMetaStoreInterface {
         return (Optional) Optional
             .ofNullable(flow)
             // this can happen if an execution is still running with an old revision or if the flow was deleted
-            .or(() -> flowRepository.findByIdWithSource(tenantId, namespace, id, revision)); // TODO evaluate if a cache is needed here
+            .or(() -> flowRepository.findByIdWithSource(tenantId, namespace, id, revision));
     }
 
     @Override
     public Optional<FlowWithSource> findByExecutionThenInjectDefaults(Execution execution) {
-        return findByExecution(execution).map(it -> pluginDefaultService.injectDefaults(it, execution));
+        var flowId = FlowId.uid(execution.getTenantId(), execution.getNamespace(), execution.getFlowId(), Optional.ofNullable(execution.getFlowRevision()));
+        var fromCache = withDefaultCache.getIfPresent(flowId);
+        if (fromCache.isPresent()) {
+            return fromCache;
+        }
+
+        var flowWithDefault = findByExecution(execution).map(it -> pluginDefaultService.injectDefaults(it, execution));
+        flowWithDefault.ifPresent(it -> withDefaultCache.put(flowId, it));
+        return flowWithDefault;
     }
+
 }

--- a/core/src/main/java/io/kestra/core/runners/FlowWithDefaultCache.java
+++ b/core/src/main/java/io/kestra/core/runners/FlowWithDefaultCache.java
@@ -1,0 +1,73 @@
+package io.kestra.core.runners;
+
+import java.util.Objects;
+import java.util.Optional;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.google.common.annotations.VisibleForTesting;
+
+import io.kestra.core.models.flows.FlowWithSource;
+
+import jakarta.inject.Singleton;
+
+/**
+ * A cache for flows with plugin defaults already injected, keyed by flow UID (including revision).
+ *
+ * <p>Cache entries can be selectively expired at tenant or namespace granularity, which is useful
+ * when plugin defaults change at those levels.</p>
+ */
+@Singleton
+public class FlowWithDefaultCache {
+    private final Cache<String, FlowWithSource> cache = Caffeine.newBuilder()
+        .maximumSize(1000)
+        .recordStats()
+        .build();
+
+    /** Returns the cached entry for the given flow UID, or empty if absent. */
+    public Optional<FlowWithSource> getIfPresent(String key) {
+        return Optional.ofNullable(cache.getIfPresent(key));
+    }
+
+    /** Adds or replaces a cache entry. */
+    public void put(String key, FlowWithSource flow) {
+        cache.put(key, flow);
+    }
+
+    /** Expires the cache entry for the given flow UID. */
+    public void invalidate(String key) {
+        cache.invalidate(key);
+    }
+
+    /**
+     * Expires all cache entries belonging to the given tenant.
+     * Useful when tenant-level plugin defaults change.
+     *
+     * @param tenantId the tenant identifier, may be {@code null} for single-tenant deployments
+     */
+    public void flush(String tenantId) {
+        cache.asMap().values().stream()
+            .filter(flow -> Objects.equals(flow.getTenantId(), tenantId))
+            .map(f -> f.uid())
+            .forEach(cache::invalidate);
+    }
+
+    /**
+     * Expires all cache entries belonging to the given namespace within a tenant.
+     * Useful when namespace-level plugin defaults change.
+     *
+     * @param tenantId  the tenant identifier, may be {@code null} for single-tenant deployments
+     * @param namespace the namespace
+     */
+    public void flush(String tenantId, String namespace) {
+        cache.asMap().values().stream()
+            .filter(flow -> Objects.equals(flow.getTenantId(), tenantId) && Objects.equals(flow.getNamespace(), namespace))
+            .map(f -> f.uid())
+            .forEach(cache::invalidate);
+    }
+
+    @VisibleForTesting
+    void clear() {
+        cache.invalidateAll();
+    }
+}

--- a/core/src/main/java/io/kestra/core/utils/QueueCache.java
+++ b/core/src/main/java/io/kestra/core/utils/QueueCache.java
@@ -2,6 +2,7 @@ package io.kestra.core.utils;
 
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Consumer;
 
 import com.google.common.annotations.VisibleForTesting;
 
@@ -15,35 +16,66 @@ import lombok.extern.slf4j.Slf4j;
 
 /**
  * A cache backed by a queue.
- * 
+ *
  * @param <T> the item of the cache
  */
 @Slf4j
 public class QueueCache<T extends SoftDeletable<T> & HasUID & BroadcastEvent> implements AutoCloseable {
     private final Map<String, T> cache;
     private final BroadcastQueueInterface<T> queue;
+    private final Optional<Consumer<T>> invalidationListener;
 
     private QueueSubscriber<T> subscriber;
 
     /**
      * Create a cache backed by a queue.
      *
+     * @see #QueueCache(BroadcastQueueInterface, Consumer)
      * @see #QueueCache(BroadcastQueueInterface, List)
+     * @see #QueueCache(BroadcastQueueInterface, List, Consumer))
      */
     public QueueCache(BroadcastQueueInterface<T> queue) {
-        this(queue, Collections.emptyList());
+        this(queue, Collections.emptyList(), null);
+    }
+
+    /**
+     * Create a cache backed by a queue with an invalidation listener.
+     * The invalidation listener will be called whenever an item is removed or updated from the cache.
+     *
+     * @see #QueueCache(BroadcastQueueInterface)
+     * @see #QueueCache(BroadcastQueueInterface, List)
+     * @see #QueueCache(BroadcastQueueInterface, List, Consumer)
+     */
+    public QueueCache(BroadcastQueueInterface<T> queue, Consumer<T> invalidationListener) {
+        this(queue, Collections.emptyList(), invalidationListener);
     }
 
     /**
      * Create a cache backed by a queue initialized with a list of items.
      *
      * @see #QueueCache(BroadcastQueueInterface)
+     * @see #QueueCache(BroadcastQueueInterface, Consumer)
+     * @see #QueueCache(BroadcastQueueInterface, List, Consumer)
      */
     public QueueCache(BroadcastQueueInterface<T> queue, List<T> initial) {
+        this(queue, initial, null);
+    }
+
+    /**
+     * Create a cache backed by a queue initialized with a list of items and an invalidation listener.
+     * The invalidation listener will be called whenever an item is removed or updated from the cache.
+     *
+     * @see #QueueCache(BroadcastQueueInterface)
+     * @see #QueueCache(BroadcastQueueInterface, Consumer)
+     * @see #QueueCache(BroadcastQueueInterface, List)
+     */
+    public QueueCache(BroadcastQueueInterface<T> queue, List<T> initial, Consumer<T> invalidationListener) {
         this.queue = queue;
         this.cache = new ConcurrentHashMap<>(calculateHashMapCapacity(initial.size()));
+        this.invalidationListener = Optional.ofNullable(invalidationListener);
 
         initial.forEach(it -> cache.put(it.uid(), it));
+
     }
 
     // this method is copied from HashMap.newHashMap() as the same didn't exist for ConcurrentHashMap
@@ -65,6 +97,8 @@ public class QueueCache<T extends SoftDeletable<T> & HasUID & BroadcastEvent> im
                 } else {
                     cache.put(item.uid(), item);
                 }
+
+                invalidationListener.ifPresent(listener -> listener.accept(item));
             }
         });
     }

--- a/core/src/test/java/io/kestra/core/runners/DefaultFlowMetaStoreTest.java
+++ b/core/src/test/java/io/kestra/core/runners/DefaultFlowMetaStoreTest.java
@@ -32,11 +32,15 @@ class DefaultFlowMetaStoreTest {
     private DefaultFlowMetaStore flowMetaStore;
 
     @Inject
+    private FlowWithDefaultCache flowWithDefaultCache;
+
+    @Inject
     private FlowService flowService;
 
     @AfterEach
     void clean() {
         flowMetaStore.clearCache();
+        flowWithDefaultCache.clear();
     }
 
     @Test

--- a/core/src/test/java/io/kestra/core/runners/FlowWithDefaultCacheTest.java
+++ b/core/src/test/java/io/kestra/core/runners/FlowWithDefaultCacheTest.java
@@ -1,0 +1,107 @@
+package io.kestra.core.runners;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import io.kestra.core.models.flows.FlowWithSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class FlowWithDefaultCacheTest {
+    private FlowWithDefaultCache cache;
+
+    @BeforeEach
+    void setUp() {
+        cache = new FlowWithDefaultCache();
+    }
+
+    @Test
+    void shouldReturnEmptyOnCacheMiss() {
+        assertThat(cache.getIfPresent("unknown-key")).isEmpty();
+    }
+
+    @Test
+    void shouldReturnValueOnCacheHit() {
+        FlowWithSource flow = flush("tenant", "ns", "flow-a", 1);
+        cache.put(flow.uid(), flow);
+
+        assertThat(cache.getIfPresent(flow.uid())).contains(flow);
+    }
+
+    @Test
+    void shouldInvalidateByKey() {
+        FlowWithSource flow = flush("tenant", "ns", "flow-a", 1);
+        cache.put(flow.uid(), flow);
+
+        cache.invalidate(flow.uid());
+
+        assertThat(cache.getIfPresent(flow.uid())).isEmpty();
+    }
+
+    @Test
+    void shouldFlushAllEntriesForTenant() {
+        FlowWithSource flowA = flush("tenant-1", "ns", "flow-a", 1);
+        FlowWithSource flowB = flush("tenant-1", "ns", "flow-b", 1);
+        FlowWithSource flowC = flush("tenant-2", "ns", "flow-c", 1);
+        cache.put(flowA.uid(), flowA);
+        cache.put(flowB.uid(), flowB);
+        cache.put(flowC.uid(), flowC);
+
+        cache.flush("tenant-1");
+
+        assertThat(cache.getIfPresent(flowA.uid())).isEmpty();
+        assertThat(cache.getIfPresent(flowB.uid())).isEmpty();
+        assertThat(cache.getIfPresent(flowC.uid())).contains(flowC);
+    }
+
+    @Test
+    void shouldFlushNullTenantEntries() {
+        FlowWithSource flowNull = flush(null, "ns", "flow-a", 1);
+        FlowWithSource flowOther = flush("tenant-1", "ns", "flow-b", 1);
+        cache.put(flowNull.uid(), flowNull);
+        cache.put(flowOther.uid(), flowOther);
+
+        cache.flush(null);
+
+        assertThat(cache.getIfPresent(flowNull.uid())).isEmpty();
+        assertThat(cache.getIfPresent(flowOther.uid())).contains(flowOther);
+    }
+
+    @Test
+    void shouldExpireAllFlowsInNamespace() {
+        FlowWithSource flowA = flush("tenant-1", "ns-a", "flow-a", 1);
+        FlowWithSource flowB = flush("tenant-1", "ns-a", "flow-b", 1);
+        FlowWithSource flowC = flush("tenant-1", "ns-b", "flow-c", 1);
+        cache.put(flowA.uid(), flowA);
+        cache.put(flowB.uid(), flowB);
+        cache.put(flowC.uid(), flowC);
+
+        cache.flush("tenant-1", "ns-a");
+
+        assertThat(cache.getIfPresent(flowA.uid())).isEmpty();
+        assertThat(cache.getIfPresent(flowB.uid())).isEmpty();
+        assertThat(cache.getIfPresent(flowC.uid())).contains(flowC);
+    }
+
+    @Test
+    void shouldNotExpireFlowsOfOtherTenantInSameNamespace() {
+        FlowWithSource flowT1 = flush("tenant-1", "ns", "flow-a", 1);
+        FlowWithSource flowT2 = flush("tenant-2", "ns", "flow-a", 1);
+        cache.put(flowT1.uid(), flowT1);
+        cache.put(flowT2.uid(), flowT2);
+
+        cache.flush("tenant-1", "ns");
+
+        assertThat(cache.getIfPresent(flowT1.uid())).isEmpty();
+        assertThat(cache.getIfPresent(flowT2.uid())).contains(flowT2);
+    }
+
+    private FlowWithSource flush(String tenantId, String namespace, String id, int revision) {
+        return FlowWithSource.builder()
+            .tenantId(tenantId)
+            .namespace(namespace)
+            .id(id)
+            .revision(revision)
+            .build();
+    }
+}


### PR DESCRIPTION
Cache Flow after computing their plugin default, as this is a very costly operation.
Provides entry points to flush the cache when tenant-level or namespace-level plugin default changes (EE).

## Preliminary results

Performance greatly improves at high throughput; tail latency decrease of approx 50%!

  | 2.0 | 2.0 plugin default cache
-- | -- | --
**Benchmark 1** |   |  
500 exec/mn | 155ms | 151ms
1000 exec/mn | 155ms | 143ms
1500 exec/mn | 155ms | 146ms
2000 exec/mn | 161ms | 152ms
2500 exec/m | 161ms | 163ms
3000 exec/m, | 413ms | **208ms**
  |   |  
**Benchmark 2** |   |  
100 exec/mn | 494ms | 483ms
200 exec/mn | 507ms | 487ms
300 exec/mn | 512ms | 512ms
400 exec /mn | 532ms | 506ms
500 exec/mn | 610ms | 547ms
600 exec/mn | 1s | **693ms**