### PR TITLE
fix(triggers): expose trigger.date for ScheduleOnDates in configured timezone

### DIFF
--- a/core/src/main/java/io/kestra/plugin/core/trigger/ScheduleOnDates.java
+++ b/core/src/main/java/io/kestra/plugin/core/trigger/ScheduleOnDates.java
@@ -4,7 +4,6 @@ import java.time.Duration;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.time.temporal.ChronoUnit;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -21,6 +20,7 @@ import io.kestra.core.models.tasks.VoidOutput;
 import io.kestra.core.models.triggers.*;
 import io.kestra.core.runners.RunContext;
 import io.kestra.core.scheduler.SchedulerClock;
+import io.kestra.core.serializers.JacksonMapper;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
@@ -74,11 +74,16 @@ public class ScheduleOnDates extends AbstractTrigger implements Schedulable, Tri
         if (nextDate.isPresent()) {
             log.info("Schedule execution on {}", nextDate.get());
 
+            Map<String, Object> rawVariables = Map.of("date", nextDate.get());
+            Map<String, Object> variables = timezone != null
+                ? JacksonMapper.toMap(rawVariables, ZoneId.of(runContext.render(timezone)))
+                : JacksonMapper.toMap(rawVariables);
+
             Execution execution = SchedulableExecutionFactory.createExecution(
                 this,
                 conditionContext,
                 triggerContext,
-                Collections.emptyMap(),
+                variables,
                 nextDate.orElse(null)
             );
 

--- a/core/src/test/java/io/kestra/plugin/core/trigger/ScheduleOnDatesTest.java
+++ b/core/src/test/java/io/kestra/plugin/core/trigger/ScheduleOnDatesTest.java
@@ -1,8 +1,10 @@
 package io.kestra.plugin.core.trigger;
 
+import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 import org.junit.jupiter.api.Test;
@@ -10,6 +12,7 @@ import org.junit.jupiter.api.Test;
 import io.kestra.core.junit.annotations.KestraTest;
 import io.kestra.core.models.Label;
 import io.kestra.core.models.conditions.ConditionContext;
+import io.kestra.core.models.executions.Execution;
 import io.kestra.core.models.flows.Flow;
 import io.kestra.core.models.flows.Type;
 import io.kestra.core.models.flows.input.StringInput;
@@ -77,6 +80,68 @@ class ScheduleOnDatesTest {
 
         // then
         assertThat(nextDate).isEqualTo(after);
+    }
+
+    @Test
+    public void shouldExposeTriggerDateInConfiguredTimezoneWhenEvaluate() throws Exception {
+        // Given
+        var fireDate = ZonedDateTime.parse("2025-05-01T17:15:00+02:00[Europe/Paris]");
+        var scheduleOnDates = ScheduleOnDates.builder()
+            .id(IdUtils.create())
+            .type(ScheduleOnDates.class.getName())
+            .interval(null)
+            .timezone("Europe/Paris")
+            .dates(Property.ofValue(List.of(fireDate)))
+            .build();
+
+        var conditionContext = conditionContext(scheduleOnDates);
+        var triggerContext = TriggerContext.builder()
+            .namespace(conditionContext.getFlow().getNamespace())
+            .flowId(conditionContext.getFlow().getId())
+            .triggerId(scheduleOnDates.getId())
+            .date(fireDate)
+            .build();
+
+        // When
+        Optional<Execution> evaluate = scheduleOnDates.evaluate(conditionContext, triggerContext);
+
+        // Then
+        assertThat(evaluate).isPresent();
+        Map<String, Object> vars = evaluate.get().getTrigger().getVariables();
+        assertThat(vars).containsKey("date");
+        var renderedDate = ZonedDateTime.parse((String) vars.get("date"));
+        assertThat(renderedDate.toInstant()).isEqualTo(fireDate.toInstant());
+        assertThat(renderedDate.getOffset()).isEqualTo(ZoneId.of("Europe/Paris").getRules().getOffset(fireDate.toInstant()));
+    }
+
+    @Test
+    public void shouldExposeTriggerDateConvertedFromUtcToConfiguredTimezone() throws Exception {
+        // Given - dates declared in UTC, trigger configured in Asia/Tokyo
+        var fireDateUtc = ZonedDateTime.parse("2025-05-01T08:00:00Z");
+        var scheduleOnDates = ScheduleOnDates.builder()
+            .id(IdUtils.create())
+            .type(ScheduleOnDates.class.getName())
+            .interval(null)
+            .timezone("Asia/Tokyo")
+            .dates(Property.ofValue(List.of(fireDateUtc)))
+            .build();
+
+        var conditionContext = conditionContext(scheduleOnDates);
+        var triggerContext = TriggerContext.builder()
+            .namespace(conditionContext.getFlow().getNamespace())
+            .flowId(conditionContext.getFlow().getId())
+            .triggerId(scheduleOnDates.getId())
+            .date(fireDateUtc)
+            .build();
+
+        // When
+        Optional<Execution> evaluate = scheduleOnDates.evaluate(conditionContext, triggerContext);
+
+        // Then - same instant, but rendered in Tokyo (+09:00)
+        assertThat(evaluate).isPresent();
+        var renderedDate = ZonedDateTime.parse((String) evaluate.get().getTrigger().getVariables().get("date"));
+        assertThat(renderedDate.toInstant()).isEqualTo(fireDateUtc.toInstant());
+        assertThat(renderedDate.getOffset()).isEqualTo(ZoneId.of("Asia/Tokyo").getRules().getOffset(fireDateUtc.toInstant()));
     }
 
     @Test


### PR DESCRIPTION
evaluate() passed Collections.emptyMap() as trigger variables, so {{ trigger.date }} threw AttributeNotFoundException under strict Pebble. Now serializes `date` in the trigger's configured timezone, matching the pattern used by Schedule.evaluate().

Closes kestra-io/kestra-ee#7577

**QA**

```
id: qa_schedule_on_dates_timezone
namespace: company.team.qa
description: |
  Validates ScheduleOnDates exposes `trigger.date` in the configured
  timezone. To run: edit the date in `triggers.tokyo.dates` to roughly
  2 minutes in the future (UTC), save, and wait for the execution.
tasks:
  - id: log_dates
    type: io.kestra.plugin.core.log.Log
    message: |
      formatted (UTC)      = {{ trigger.date | date("yyyy-MM-dd HH:mm:ss XXX", timeZone="UTC") }}
  - id: assert_tokyo_offset
    type: io.kestra.plugin.core.flow.If
    condition: "{{ (trigger.date | string) | endsWith('+09:00') }}"
    then:
      - id: pass
        type: io.kestra.plugin.core.log.Log
        message: "PASS — trigger.date carries Tokyo offset (+09:00)"
    else:
      - id: fail
        type: io.kestra.plugin.core.execution.Fail
        errorMessage: "FAIL — expected trigger.date to end with +09:00 but got '{{ trigger.date }}'"

triggers:
  - id: tokyo
    type: io.kestra.plugin.core.trigger.ScheduleOnDates
    timezone: Asia/Tokyo
    dates:
      # Edit to ~2 minutes in the future, in UTC. Example shape:
      - "2026-05-04T17:23:00Z"
```