### PR TITLE
chore(deps): ignore generated package-lock.json files in ui packages

### DIFF
--- a/ui/.gitignore
+++ b/ui/.gitignore
@@ -5,3 +5,4 @@ tests/data/
 tests/e2e/.env
 tests/e2e/data/application-secrets.yml
 generated/
+packages/*/package-lock.json


### PR DESCRIPTION
## Summary
- Adds `packages/*/package-lock.json` to `ui/.gitignore` to prevent generated lock files from being tracked in version control