### PR TITLE
fix(ui): guard DynamicScroller mounts until items are non-empty

### DIFF
--- a/ui/src/components/executions/Gantt.vue
+++ b/ui/src/components/executions/Gantt.vue
@@ -35,6 +35,7 @@
                 </template>
                 <template #default>
                     <DynamicScroller
+                        v-if="filteredSeries.length > 0"
                         :items="filteredSeries"
                         :minItemSize="40"
                         keyField="id"

--- a/ui/src/components/logs/TaskRunDetails.vue
+++ b/ui/src/components/logs/TaskRunDetails.vue
@@ -1,6 +1,6 @@
 <template>
     <DynamicScroller
-        v-if="followedExecution"
+        v-if="followedExecution && currentTaskRuns.length > 0"
         ref="taskRunScroller"
         :items="currentTaskRuns"
         :minItemSize="50"
@@ -639,22 +639,13 @@
                 });
             },
             shouldDisplayLogs(taskRun) {
+                const uid = this.attemptUid(
+                    taskRun.id,
+                    this.selectedAttemptNumberByTaskRunId[taskRun.id],
+                );
                 return (
-                    (this.taskRunId ||
-                        (this.shownAttemptsUid.includes(
-                            this.attemptUid(
-                                taskRun.id,
-                                this.selectedAttemptNumberByTaskRunId[taskRun.id],
-                            ),
-                        ) &&
-                            this.logsWithIndexByAttemptUid[
-                                this.attemptUid(
-                                    taskRun.id,
-                                    this.selectedAttemptNumberByTaskRunId[
-                                        taskRun.id
-                                    ],
-                                )
-                            ]))
+                    (this.taskRunId || this.shownAttemptsUid.includes(uid)) &&
+                    this.logsWithIndexByAttemptUid[uid]?.length > 0
                 );
             },
             closeTargetExecutionSSE() {


### PR DESCRIPTION
Global goal of this PR is to repair E2E that were no longer passing at all for a while.

It fixes a headless Chrome layout race with vue-virtual-scroller v3.

v3 computes viewport as `el.scrollTop + el.clientHeight` with no ResizeObserver fallback. When a `DynamicScroller` mounts inside conditional rendering and `clientHeight=0`, items never render (deadlock — nothing to scroll, no scroll events, no recovery).

Fix: defer each scroller until its items array is non-empty, so the container has settled layout by mount time.