### PR TITLE
test(tests): mock playground store in TaskList storybook story

### DIFF
--- a/ui/tests/storybook/components/no-code/components/tasks/TaskList.stories.tsx
+++ b/ui/tests/storybook/components/no-code/components/tasks/TaskList.stories.tsx
@@ -1,3 +1,11 @@
+import {vi} from "vitest";
+
+// playground store imports @kestra-io/topology (dagre + @vue-flow/core) at module level,
+// which crashes the Chromium browser runner — mock it to avoid the import chain entirely.
+vi.mock("../../../../../../src/stores/playground", () => ({
+    usePlaygroundStore: () => ({enabled: false, runUntilTask: vi.fn()}),
+}));
+
 import {computed, provide, ref} from "vue";
 import TaskList from "../../../../../../src/components/no-code/components/tasks/TaskList.vue";
 import {Meta, StoryObj} from "@storybook/vue3-vite";


### PR DESCRIPTION
## Summary

- `playground.ts` imports `@kestra-io/topology/vue-flow-utils` (which pulls in `@vue-flow/core` + `dagre`) at module-evaluation time, before any component renders
- In the vitest browser (Chromium/Playwright) runner, this crashes the page before the vitest runner context is initialized, causing: `Error: Vitest failed to find the runner` for `TaskList.stories.tsx` only
- Fix: mock `usePlaygroundStore` in the story so `playground.ts` is never evaluated

## Test plan

- [ ] `npm run test:storybook` passes all 42 story tests (was 1 failed | 41 passed)
- [ ] CI design system workflow green