### PR TITLE
test(tests): fix flaky focusNode unit test by using fake timers for rAF

### DIFF
--- a/ui/tests/unit/dependencies/composables/useDependencies.spec.ts
+++ b/ui/tests/unit/dependencies/composables/useDependencies.spec.ts
@@ -314,6 +314,7 @@ describe("useDependencies composable", () => {
             ],
             count: 3,
         });
+        vi.useFakeTimers();
         const wrapper = mount({
             template: "<div></div>",
             setup() {
@@ -323,13 +324,14 @@ describe("useDependencies composable", () => {
                 return {composable};
             },
         });
-        // Flush microtasks (promise resolution + Vue reactivity) then
-        // allow jsdom's setTimeout-based requestAnimationFrame to fire.
+        // Flush microtasks (promise resolution + Vue reactivity) so onMounted's
+        // async fetch resolves, then advance fake timers past jsdom's rAF polyfill
+        // (setTimeout 16 ms) so capturePositions() runs and storedPositions is populated.
         await nextTick();
         await nextTick();
-        await new Promise(resolve => setTimeout(resolve, 0));
-        await new Promise(resolve => setTimeout(resolve, 0));
+        await vi.runAllTimersAsync();
         await nextTick();
+        vi.useRealTimers();
         chartMock.setOption.mockClear();
         const {selectNode} = wrapper.vm.composable as ReturnType<typeof useDependencies>;
         return {selectNode, chartMock};


### PR DESCRIPTION
## Summary

- `mountWithChart` awaited only `setTimeout(0)` callbacks, but jsdom polyfills `requestAnimationFrame` as `setTimeout(cb, 16)` — so `poll()` (which populates `storedPositions` via `capturePositions()`) hadn't fired before `selectNode` was called
- This left `storedPositions` empty → `focusNode` skipped → `setOption` with `zoom: 1.8` never called
- The race only manifests in CI where timer scheduling is stricter

## Fix

Replace manual `setTimeout(0)` waits with `vi.useFakeTimers()` + `vi.runAllTimersAsync()` so the `requestAnimationFrame` callback fires deterministically before assertions run.

## Test plan

- [ ] `npm run test:unit` passes all 17 tests in `useDependencies.spec.ts`