### PR TITLE
fix(backup): add findDistinctNamespace to KV and namespace-file metadata repos

### DIFF
--- a/core/src/main/java/io/kestra/core/repositories/KvMetadataRepositoryInterface.java
+++ b/core/src/main/java/io/kestra/core/repositories/KvMetadataRepositoryInterface.java
@@ -3,6 +3,7 @@ package io.kestra.core.repositories;
 import java.io.IOException;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 import io.kestra.core.models.FetchVersion;
 import io.kestra.core.models.QueryFilter;
@@ -11,9 +12,7 @@ import io.kestra.core.models.kv.PersistedKvMetadata;
 import io.micronaut.data.model.Pageable;
 
 public interface KvMetadataRepositoryInterface {
-    default List<String> findDistinctNamespace(String tenantId) {
-        return List.of();
-    }
+    Set<String> findDistinctNamespace(String tenantId);
 
     Optional<PersistedKvMetadata> findByName(
         String tenantId,

--- a/core/src/main/java/io/kestra/core/repositories/KvMetadataRepositoryInterface.java
+++ b/core/src/main/java/io/kestra/core/repositories/KvMetadataRepositoryInterface.java
@@ -11,6 +11,10 @@ import io.kestra.core.models.kv.PersistedKvMetadata;
 import io.micronaut.data.model.Pageable;
 
 public interface KvMetadataRepositoryInterface {
+    default List<String> findDistinctNamespace(String tenantId) {
+        return List.of();
+    }
+
     Optional<PersistedKvMetadata> findByName(
         String tenantId,
         String namespace,

--- a/core/src/main/java/io/kestra/core/repositories/NamespaceFileMetadataRepositoryInterface.java
+++ b/core/src/main/java/io/kestra/core/repositories/NamespaceFileMetadataRepositoryInterface.java
@@ -3,6 +3,7 @@ package io.kestra.core.repositories;
 import java.io.IOException;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 import io.kestra.core.models.FetchVersion;
 import io.kestra.core.models.QueryFilter;
@@ -11,9 +12,7 @@ import io.kestra.core.models.namespaces.files.NamespaceFileMetadata;
 import io.micronaut.data.model.Pageable;
 
 public interface NamespaceFileMetadataRepositoryInterface {
-    default List<String> findDistinctNamespace(String tenantId) {
-        return List.of();
-    }
+    Set<String> findDistinctNamespace(String tenantId);
 
     Optional<NamespaceFileMetadata> findByPath(
         String tenantId,

--- a/core/src/main/java/io/kestra/core/repositories/NamespaceFileMetadataRepositoryInterface.java
+++ b/core/src/main/java/io/kestra/core/repositories/NamespaceFileMetadataRepositoryInterface.java
@@ -11,6 +11,10 @@ import io.kestra.core.models.namespaces.files.NamespaceFileMetadata;
 import io.micronaut.data.model.Pageable;
 
 public interface NamespaceFileMetadataRepositoryInterface {
+    default List<String> findDistinctNamespace(String tenantId) {
+        return List.of();
+    }
+
     Optional<NamespaceFileMetadata> findByPath(
         String tenantId,
         String namespace,

--- a/core/src/test/java/io/kestra/core/repositories/AbstractKvMetadataRepositoryTest.java
+++ b/core/src/test/java/io/kestra/core/repositories/AbstractKvMetadataRepositoryTest.java
@@ -6,6 +6,7 @@ import java.time.temporal.ChronoUnit;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Stream;
 
 import org.junit.jupiter.api.Test;
@@ -274,7 +275,7 @@ public abstract class AbstractKvMetadataRepositoryTest {
         PersistedKvMetadata deletedEntry = kvMetadataRepositoryInterface.save(buildTestKvDescription(tenantId, deletedNamespace, "key3"));
         kvMetadataRepositoryInterface.delete(deletedEntry);
 
-        List<String> namespaces = kvMetadataRepositoryInterface.findDistinctNamespace(tenantId);
+        Set<String> namespaces = kvMetadataRepositoryInterface.findDistinctNamespace(tenantId);
 
         assertThat(namespaces).containsExactlyInAnyOrder(namespace1, namespace2);
         assertThat(namespaces).doesNotContain(deletedNamespace);

--- a/core/src/test/java/io/kestra/core/repositories/AbstractKvMetadataRepositoryTest.java
+++ b/core/src/test/java/io/kestra/core/repositories/AbstractKvMetadataRepositoryTest.java
@@ -262,6 +262,24 @@ public abstract class AbstractKvMetadataRepositoryTest {
         assertThat(kvMetadataRepositoryInterface.findByName(tenantId, namespace, key).isPresent()).isFalse();
     }
 
+    @Test
+    void findDistinctNamespace() throws IOException {
+        String tenantId = TestsUtils.randomTenant();
+        String namespace1 = TestsUtils.randomNamespace();
+        String namespace2 = TestsUtils.randomNamespace();
+        String deletedNamespace = TestsUtils.randomNamespace();
+
+        kvMetadataRepositoryInterface.save(buildTestKvDescription(tenantId, namespace1, "key1"));
+        kvMetadataRepositoryInterface.save(buildTestKvDescription(tenantId, namespace2, "key2"));
+        PersistedKvMetadata deletedEntry = kvMetadataRepositoryInterface.save(buildTestKvDescription(tenantId, deletedNamespace, "key3"));
+        kvMetadataRepositoryInterface.delete(deletedEntry);
+
+        List<String> namespaces = kvMetadataRepositoryInterface.findDistinctNamespace(tenantId);
+
+        assertThat(namespaces).containsExactlyInAnyOrder(namespace1, namespace2);
+        assertThat(namespaces).doesNotContain(deletedNamespace);
+    }
+
     protected static PersistedKvMetadata buildTestKvDescription(String tenantId, String namespace, String key) {
         return PersistedKvMetadata.builder()
             .tenantId(tenantId)

--- a/core/src/test/java/io/kestra/core/repositories/AbstractNamespaceFileMetadataRepositoryTest.java
+++ b/core/src/test/java/io/kestra/core/repositories/AbstractNamespaceFileMetadataRepositoryTest.java
@@ -317,6 +317,27 @@ public abstract class AbstractNamespaceFileMetadataRepositoryTest {
     }
 
     @Test
+    void findDistinctNamespace() throws IOException {
+        String tenantId = TestsUtils.randomTenant();
+        String namespace1 = TestsUtils.randomNamespace();
+        String namespace2 = TestsUtils.randomNamespace();
+        String deletedNamespace = TestsUtils.randomNamespace();
+
+        namespaceFileMetadataRepositoryInterface.save(NamespaceFileMetadata.builder()
+            .tenantId(tenantId).namespace(namespace1).path("file1.txt").size(1L).build());
+        namespaceFileMetadataRepositoryInterface.save(NamespaceFileMetadata.builder()
+            .tenantId(tenantId).namespace(namespace2).path("file2.txt").size(1L).build());
+        NamespaceFileMetadata deletedEntry = namespaceFileMetadataRepositoryInterface.save(NamespaceFileMetadata.builder()
+            .tenantId(tenantId).namespace(deletedNamespace).path("file3.txt").size(1L).build());
+        namespaceFileMetadataRepositoryInterface.delete(deletedEntry);
+
+        List<String> namespaces = namespaceFileMetadataRepositoryInterface.findDistinctNamespace(tenantId);
+
+        assertThat(namespaces).containsExactlyInAnyOrder(namespace1, namespace2);
+        assertThat(namespaces).doesNotContain(deletedNamespace);
+    }
+
+    @Test
     void purgeAllVersions() throws IOException {
         String tenantId = TestsUtils.randomTenant();
         String namespace = TestsUtils.randomNamespace();

--- a/core/src/test/java/io/kestra/core/repositories/AbstractNamespaceFileMetadataRepositoryTest.java
+++ b/core/src/test/java/io/kestra/core/repositories/AbstractNamespaceFileMetadataRepositoryTest.java
@@ -5,6 +5,7 @@ import java.time.Instant;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Stream;
 
 import org.junit.jupiter.api.Test;
@@ -331,7 +332,7 @@ public abstract class AbstractNamespaceFileMetadataRepositoryTest {
             .tenantId(tenantId).namespace(deletedNamespace).path("file3.txt").size(1L).build());
         namespaceFileMetadataRepositoryInterface.delete(deletedEntry);
 
-        List<String> namespaces = namespaceFileMetadataRepositoryInterface.findDistinctNamespace(tenantId);
+        Set<String> namespaces = namespaceFileMetadataRepositoryInterface.findDistinctNamespace(tenantId);
 
         assertThat(namespaces).containsExactlyInAnyOrder(namespace1, namespace2);
         assertThat(namespaces).doesNotContain(deletedNamespace);

--- a/jdbc/src/main/java/io/kestra/jdbc/repository/AbstractJdbcKvMetadataRepository.java
+++ b/jdbc/src/main/java/io/kestra/jdbc/repository/AbstractJdbcKvMetadataRepository.java
@@ -42,11 +42,11 @@ public abstract class AbstractJdbcKvMetadataRepository extends AbstractJdbcCrudR
     }
 
     @Override
-    public List<String> findDistinctNamespace(String tenantId) {
+    public Set<String> findDistinctNamespace(String tenantId) {
         return this.jdbcRepository
             .getDslContextWrapper()
             .transactionResult(
-                configuration -> DSL
+                configuration -> new HashSet<>(DSL
                     .using(configuration)
                     .select(field("namespace"))
                     .from(this.jdbcRepository.getTable())
@@ -54,7 +54,7 @@ public abstract class AbstractJdbcKvMetadataRepository extends AbstractJdbcCrudR
                     .and(lastCondition())
                     .groupBy(field("namespace"))
                     .fetch()
-                    .map(record -> record.getValue("namespace", String.class))
+                    .map(record -> record.getValue("namespace", String.class)))
             );
     }
 

--- a/jdbc/src/main/java/io/kestra/jdbc/repository/AbstractJdbcKvMetadataRepository.java
+++ b/jdbc/src/main/java/io/kestra/jdbc/repository/AbstractJdbcKvMetadataRepository.java
@@ -42,6 +42,23 @@ public abstract class AbstractJdbcKvMetadataRepository extends AbstractJdbcCrudR
     }
 
     @Override
+    public List<String> findDistinctNamespace(String tenantId) {
+        return this.jdbcRepository
+            .getDslContextWrapper()
+            .transactionResult(
+                configuration -> DSL
+                    .using(configuration)
+                    .select(field("namespace"))
+                    .from(this.jdbcRepository.getTable())
+                    .where(this.defaultFilter(tenantId, false))
+                    .and(lastCondition())
+                    .groupBy(field("namespace"))
+                    .fetch()
+                    .map(record -> record.getValue("namespace", String.class))
+            );
+    }
+
+    @Override
     public Optional<PersistedKvMetadata> findByName(String tenantId, String namespace, String name) {
         var condition = field("namespace").eq(namespace)
             .and(field("name").eq(name))

--- a/jdbc/src/main/java/io/kestra/jdbc/repository/AbstractJdbcNamespaceFileMetadataRepository.java
+++ b/jdbc/src/main/java/io/kestra/jdbc/repository/AbstractJdbcNamespaceFileMetadataRepository.java
@@ -45,6 +45,23 @@ public abstract class AbstractJdbcNamespaceFileMetadataRepository extends Abstra
     }
 
     @Override
+    public List<String> findDistinctNamespace(String tenantId) {
+        return this.jdbcRepository
+            .getDslContextWrapper()
+            .transactionResult(
+                configuration -> DSL
+                    .using(configuration)
+                    .select(field("namespace"))
+                    .from(this.jdbcRepository.getTable())
+                    .where(this.defaultFilter(tenantId, false))
+                    .and(lastCondition())
+                    .groupBy(field("namespace"))
+                    .fetch()
+                    .map(record -> record.getValue("namespace", String.class))
+            );
+    }
+
+    @Override
     public Optional<NamespaceFileMetadata> findByPath(String tenantId, String namespace, String path) {
         return jdbcRepository
             .getDslContextWrapper()

--- a/jdbc/src/main/java/io/kestra/jdbc/repository/AbstractJdbcNamespaceFileMetadataRepository.java
+++ b/jdbc/src/main/java/io/kestra/jdbc/repository/AbstractJdbcNamespaceFileMetadataRepository.java
@@ -1,9 +1,11 @@
 package io.kestra.jdbc.repository;
 
 import java.time.Instant;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -45,11 +47,11 @@ public abstract class AbstractJdbcNamespaceFileMetadataRepository extends Abstra
     }
 
     @Override
-    public List<String> findDistinctNamespace(String tenantId) {
+    public Set<String> findDistinctNamespace(String tenantId) {
         return this.jdbcRepository
             .getDslContextWrapper()
             .transactionResult(
-                configuration -> DSL
+                configuration -> new HashSet<>(DSL
                     .using(configuration)
                     .select(field("namespace"))
                     .from(this.jdbcRepository.getTable())
@@ -57,7 +59,7 @@ public abstract class AbstractJdbcNamespaceFileMetadataRepository extends Abstra
                     .and(lastCondition())
                     .groupBy(field("namespace"))
                     .fetch()
-                    .map(record -> record.getValue("namespace", String.class))
+                    .map(record -> record.getValue("namespace", String.class)))
             );
     }
 


### PR DESCRIPTION
- Add default `findDistinctNamespace(tenantId)` to `KvMetadataRepositoryInterface` and `NamespaceFileMetadataRepositoryInterface` (returns `List.of()` — non-breaking for external implementers)
- Override in `AbstractJdbcKvMetadataRepository` and `AbstractJdbcNamespaceFileMetadataRepository` using `select + groupBy` on `last=true` rows
- Add `findDistinctNamespace` test in abstract KV and NSFile metadata repo test classes

Companion EE PR: https://github.com/kestra-io/kestra-ee/pull/7655