### PR TITLE
fix(core): run migrations in @PostConstruct before other beans initialize

### DIFF
--- a/cli/src/main/java/io/kestra/cli/AbstractCommand.java
+++ b/cli/src/main/java/io/kestra/cli/AbstractCommand.java
@@ -20,7 +20,6 @@ import io.kestra.core.plugins.PluginManager;
 import io.kestra.core.plugins.PluginRegistry;
 import io.kestra.core.utils.Rethrow;
 import io.kestra.core.migration.MigrationRunner;
-import io.kestra.core.migration.MigrationRunnerInterface;
 
 import io.micronaut.context.ApplicationContext;
 import io.micronaut.context.BeanProvider;
@@ -94,7 +93,6 @@ public abstract class AbstractCommand extends BaseCommand implements Callable<In
         initLogger();
         sendServerLog();
         maybeInitPlugins();
-        maybeRunMigrations();
         if (this.startupHook != null) {
             this.startupHook.start(this);
         }
@@ -167,38 +165,6 @@ public abstract class AbstractCommand extends BaseCommand implements Callable<In
         if (log.isTraceEnabled() && pluginRegistry != null) {
             pluginRegistry.plugins().forEach(c -> log.trace(c.toString()));
         }
-    }
-
-    /**
-     * Runs pending database migrations before the server starts.
-     * Only executed when a {@link MigrationRunnerInterface} bean is present in the context
-     * (i.e. when a JDBC or compatible backend is configured) and {@link #shouldAutoMigrate()}
-     * returns {@code true}.
-     *
-     * <p>Commands that manage migrations explicitly (e.g. {@code kestra migrate run}) can
-     * override {@link #shouldAutoMigrate()} to return {@code false} and call
-     * {@link MigrationRunnerInterface#runAlways()} directly.
-     */
-    private void maybeRunMigrations() throws Exception {
-        if (!shouldAutoMigrate() || applicationContext == null) {
-            return;
-        }
-        Optional<MigrationRunnerInterface> runner = applicationContext.findBean(MigrationRunnerInterface.class);
-        if (runner.isPresent()) {
-            runner.get().run();
-        }
-    }
-
-    /**
-     * Whether automatic migrations should run as part of this command's startup sequence.
-     * Returns {@code false} by default — only server commands override this to {@code true}.
-     * Migration-specific commands (e.g. {@code kestra migrate run}) bypass this entirely
-     * and call {@link MigrationRunnerInterface#runAlways()} directly.
-     *
-     * @return {@code true} to run migrations automatically on startup
-     */
-    protected boolean shouldAutoMigrate() {
-        return false;
     }
 
     private void maybeStartWebserver() {

--- a/cli/src/main/java/io/kestra/cli/commands/migrations/RunMigrationCommand.java
+++ b/cli/src/main/java/io/kestra/cli/commands/migrations/RunMigrationCommand.java
@@ -39,12 +39,6 @@ public class RunMigrationCommand extends AbstractCommand {
         return Map.of();
     }
 
-    /** Disable the automatic migration in super.call(); we run it explicitly below. */
-    @Override
-    protected boolean shouldAutoMigrate() {
-        return false;
-    }
-
     @Override
     public Integer call() throws Exception {
         super.call();

--- a/cli/src/main/java/io/kestra/cli/commands/migrations/UnlockMigrationCommand.java
+++ b/cli/src/main/java/io/kestra/cli/commands/migrations/UnlockMigrationCommand.java
@@ -39,11 +39,6 @@ public class UnlockMigrationCommand extends AbstractCommand {
     }
 
     @Override
-    protected boolean shouldAutoMigrate() {
-        return false;
-    }
-
-    @Override
     public Integer call() throws Exception {
         super.call();
         try {

--- a/cli/src/main/java/io/kestra/cli/commands/servers/AbstractServerCommand.java
+++ b/cli/src/main/java/io/kestra/cli/commands/servers/AbstractServerCommand.java
@@ -26,11 +26,6 @@ public abstract class AbstractServerCommand extends AbstractCommand implements S
         return super.call();
     }
 
-    @Override
-    protected boolean shouldAutoMigrate() {
-        return true;
-    }
-
     private long maxMemoryInMB() {
         return Runtime.getRuntime().maxMemory() / 1024 / 1024;
     }

--- a/core/src/main/java/io/kestra/core/migration/MigrationRunner.java
+++ b/core/src/main/java/io/kestra/core/migration/MigrationRunner.java
@@ -82,7 +82,7 @@ public class MigrationRunner implements MigrationRunnerInterface {
     /**
      * Called once at context startup (eagerly, before any repository bean is initialized).
      * Delegates to {@link #autoRun()} so EE can override startup behavior without
-     * needing to re-declare {@code @PostConstruct} (which is not inherited by overriding methods
+     * needing to redeclare {@code @PostConstruct} (which is not inherited by overriding methods
      * in Micronaut's compile-time annotation processing).
      */
     @PostConstruct

--- a/core/src/main/java/io/kestra/core/migration/MigrationRunner.java
+++ b/core/src/main/java/io/kestra/core/migration/MigrationRunner.java
@@ -23,9 +23,8 @@ import java.util.List;
  *
  * <p>This service is {@code @Context} — it is eagerly initialized during
  * {@code ApplicationContext.start()}, before any repository or service bean queries the database.
- * {@code AbstractCommand.maybeRunMigrations()} calls {@link #run()} afterward as a validation step;
- * a {@link #hasRun} guard ensures {@link #runAlways()} is never invoked twice on the same node
- * (OSS no-ops silently; EE uses it to enforce the {@code kestra.migration.auto} check).
+ * {@link #initOnStartup()} runs all pending migrations unconditionally in OSS; EE overrides
+ * this method to add opt-in auto-run behavior and fresh-instance detection.
  *
  * <p>Execution flow:
  * <ol>
@@ -38,10 +37,6 @@ import java.util.List;
  *       otherwise skip if already applied (verify checksum) or execute and record</li>
  *   <li>Release the lock</li>
  * </ol>
- *
- * <p>In OSS, {@code run()} is always called unconditionally.
- * EE overrides this bean (via {@code @Replaces}) to add opt-in auto-run behavior and
- * startup failure when pending migrations exist and auto-run is disabled.
  */
 @Slf4j
 @Context
@@ -57,12 +52,11 @@ public class MigrationRunner implements MigrationRunnerInterface {
     static final List<String> INIT_SCRIPT_IDS = List.of("0-init", "0-init-ee", "0-init-queue", "0-init-queue-ee");
 
     /**
-     * Set to {@code true} after {@link #runAlways()} completes on this node.
-     * Guards {@link #run()} against re-executing migrations that {@link #initOnStartup()} already applied,
-     * avoiding a wasteful lock + N DB roundtrips on every CLI command startup.
-     * {@code volatile} because {@link #initOnStartup()} and {@link #run()} may run on different threads.
+     * Set to {@code true} by CLI commands (e.g. {@code migrate run}, {@code migrate unlock})
+     * that handle migrations explicitly. When set, {@link #initOnStartup()} skips automatic
+     * migration execution during context startup.
      */
-    private static volatile boolean skipAutoRun = false;
+    protected static volatile boolean skipAutoRun = false;
 
     public static void setSkipAutoRun(boolean skip) {
         skipAutoRun = skip;
@@ -71,7 +65,7 @@ public class MigrationRunner implements MigrationRunnerInterface {
     protected volatile boolean hasRun = false;
 
     private final MigrationLock lock;
-    private final MigrationHistoryStore historyStore;
+    protected final MigrationHistoryStore historyStore;
     private final Collection<MigrationScript> scripts;
 
     @Inject
@@ -87,12 +81,13 @@ public class MigrationRunner implements MigrationRunnerInterface {
 
     /**
      * Called once at context startup (eagerly, before any repository bean is initialized).
-     * Delegates to {@link #autoRun()} so EE can override startup behavior without adding
-     * a second {@code @PostConstruct}.
+     * Delegates to {@link #autoRun()} so EE can override startup behavior without
+     * needing to re-declare {@code @PostConstruct} (which is not inherited by overriding methods
+     * in Micronaut's compile-time annotation processing).
      */
     @PostConstruct
     @SneakyThrows
-    protected void initOnStartup() {
+    protected final void initOnStartup() {
         if (skipAutoRun) {
             log.debug("Migration auto-run skipped (skipAutoRun flag set).");
             return;
@@ -102,28 +97,13 @@ public class MigrationRunner implements MigrationRunnerInterface {
 
     /**
      * Runs migrations at context startup. OSS always applies all pending scripts.
-     * EE overrides this to respect the {@code kestra.migration.auto} configuration.
+     * EE overrides this to respect the {@code kestra.migration.auto} configuration
+     * and handle fresh-instance detection.
      *
      * @throws Exception if a migration fails
      */
     protected void autoRun() throws Exception {
         runAlways();
-    }
-
-    /**
-     * Called by {@code AbstractCommand.maybeRunMigrations()} after context startup.
-     * In OSS, short-circuits immediately if {@link #initOnStartup()} already ran on this node.
-     * EE overrides this to enforce the {@code kestra.migration.auto} check when {@link #hasRun} is false
-     * (i.e. when {@code auto=false} deferred migration to the {@code kestra migrate run} CLI command).
-     *
-     * @throws MigrationPendingException if EE detects pending scripts and auto-run is disabled
-     * @throws Exception                 if a migration fails
-     */
-    @Override
-    public void run() throws Exception {
-        if (!hasRun) {
-            runAlways();
-        }
     }
 
     /**

--- a/core/src/main/java/io/kestra/core/migration/MigrationRunnerInterface.java
+++ b/core/src/main/java/io/kestra/core/migration/MigrationRunnerInterface.java
@@ -5,21 +5,9 @@ package io.kestra.core.migration;
  *
  * <p>Implementations are Micronaut {@code @Context} beans that run eagerly on
  * {@code ApplicationContext.start()} via {@code @PostConstruct}, before any repository or
- * service bean is initialized. {@code AbstractCommand.maybeRunMigrations()} calls
- * {@link #run()} afterward as a validation step (idempotent in OSS; EE uses it to enforce
- * the {@code kestra.migration.auto} check).
+ * service bean is initialized.
  */
 public interface MigrationRunnerInterface {
-
-    /**
-     * Runs all pending migration scripts.
-     *
-     * <p>In OSS (JDBC), always runs unconditionally.
-     * In EE, behavior depends on the {@code kestra.migration.auto} configuration.
-     *
-     * @throws Exception if a migration fails or if EE detects pending scripts with auto disabled
-     */
-    void run() throws Exception;
 
     /**
      * Unconditionally runs all pending migration scripts, bypassing any auto-run configuration.

--- a/core/src/test/java/io/kestra/core/migration/MigrationRunnerTest.java
+++ b/core/src/test/java/io/kestra/core/migration/MigrationRunnerTest.java
@@ -199,23 +199,6 @@ class MigrationRunnerTest {
     }
 
     @Test
-    void run_doesNotReExecuteAfterRunAlways() throws Exception {
-        // Given: runAlways() already ran (simulating @PostConstruct)
-        AtomicInteger callCount = new AtomicInteger(0);
-        MigrationRunner runner = new MigrationRunner(
-            noOpLock, new InMemoryHistoryStore(),
-            List.of(simpleScript("2.0", callCount::incrementAndGet))
-        );
-        runner.runAlways();
-
-        // When: run() is called (simulating maybeRunMigrations())
-        runner.run();
-
-        // Then: script ran exactly once — run() was a no-op due to hasRun guard
-        assertThat(callCount.get()).isEqualTo(1);
-    }
-
-    @Test
     void runAlways_acquiresAndReleasesLock() throws Exception {
         // Given
         List<String> lockEvents = new ArrayList<>();


### PR DESCRIPTION
## Summary
- Move all migration logic into `initOnStartup()` (`@PostConstruct`) which fires before other `@Context` beans initialize, fixing a crash on fresh EE instances where `auto=false` (default)
- Make `initOnStartup()` `final` and delegate to overridable `autoRun()` hook (Micronaut's compile-time AOP does not inherit `@PostConstruct` to overriding methods)
- Remove the `maybeRunMigrations()` / `shouldAutoMigrate()` / `run()` indirection chain from `AbstractCommand` — no longer needed

Companion PR: kestra-io/kestra-ee (same branch `fix/migration-fresh-instance`)

## Test plan
- [x] `MigrationRunnerTest` passes
- [ ] Fresh H2 instance with `auto=false`: auto-migrates and starts (was crashing with "Table not found")
- [ ] Existing instance with `auto=false`, no pending: starts normally
- [ ] Existing instance with `auto=false`, pending migrations: fails with `MigrationPendingException`
- [ ] `kestra migrate run` still works
- [ ] `kestra migrate unlock` still works