### PR TITLE
feat(dashboards): redesign Flow Overview page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,3 +68,4 @@ core/src/main/resources/gradle.properties
 # Helm chart dependencies (downloaded at build time, not committed)
 charts/kestra/charts/
 charts/kestra-starter/charts/
+.gstack/

--- a/core/src/main/java/io/kestra/core/models/dashboards/ChartOption.java
+++ b/core/src/main/java/io/kestra/core/models/dashboards/ChartOption.java
@@ -29,6 +29,11 @@ public class ChartOption {
     @Max(12)
     private int width = 6;
 
+    @Builder.Default
+    @Min(1)
+    @Max(4)
+    private int rowSpan = 1;
+
     public List<String> neededColumns() {
         return Collections.emptyList();
     }

--- a/core/src/main/java/io/kestra/plugin/core/dashboard/chart/FailedExecutions.java
+++ b/core/src/main/java/io/kestra/plugin/core/dashboard/chart/FailedExecutions.java
@@ -1,0 +1,117 @@
+package io.kestra.plugin.core.dashboard.chart;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import io.kestra.core.models.annotations.Example;
+import io.kestra.core.models.annotations.Plugin;
+import io.kestra.core.models.dashboards.DataFilter;
+import io.kestra.core.models.dashboards.charts.DataChart;
+import io.kestra.core.models.dashboards.filters.AbstractFilter;
+import io.kestra.core.models.dashboards.filters.In;
+import io.kestra.core.models.flows.State;
+import io.kestra.plugin.core.dashboard.chart.tables.TableColumnDescriptor;
+import io.kestra.plugin.core.dashboard.chart.tables.TableOption;
+import io.kestra.plugin.core.dashboard.data.Executions;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+@SuperBuilder(toBuilder = true)
+@Getter
+@NoArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_DEFAULT)
+@EqualsAndHashCode(callSuper = true)
+@Schema(
+    title = "List recent failed executions, scoped to the dashboard's filters.",
+    description = "Always restricts results to executions in the FAILED state. Inherits sorting, columns and pagination from the standard Table chart options. The chart is contract-bound to `io.kestra.plugin.core.dashboard.data.Executions` data."
+)
+@Plugin(
+    examples = {
+        @Example(
+            title = "Display the recent failed executions for a flow.",
+            full = true,
+            code = """
+                charts:
+                  - id: recent_failures
+                    type: io.kestra.plugin.core.dashboard.chart.FailedExecutions
+                    chartOptions:
+                      displayName: Recent failures
+                      pagination:
+                        enabled: true
+                    data:
+                      type: io.kestra.plugin.core.dashboard.data.Executions
+                      columns:
+                        id:
+                          field: ID
+                          displayName: Execution ID
+                        flowId:
+                          field: FLOW_ID
+                          displayName: Flow
+                        state:
+                          field: STATE
+                          displayName: State
+                        startDate:
+                          field: START_DATE
+                          displayName: Start Date
+                        duration:
+                          field: DURATION
+                          displayName: Duration
+                """
+        )
+    }
+)
+public class FailedExecutions<F extends Enum<F>, D extends DataFilter<F, ? extends TableColumnDescriptor<F>>> extends DataChart<TableOption, D> {
+
+    // Cached instance with the FAILED state filter pre-applied.
+    // The dashboard pipeline (DashboardController + AbstractJdbcDashboardRepository)
+    // calls getData() multiple times per request and mutates the result via
+    // updateWhereWithGlobalFilters. Returning a fresh copy each call would lose
+    // those mutations; mutating the underlying data field would leak across
+    // requests if a Dashboard ever got cached. Caching one copy per chart
+    // instance keeps both invariants without touching shared state.
+    @JsonIgnore
+    @EqualsAndHashCode.Exclude
+    private transient D modifiedData;
+
+    @Override
+    public D getData() {
+        if (modifiedData != null) {
+            return modifiedData;
+        }
+        D data = super.getData();
+        if (data == null) {
+            return null;
+        }
+        if (data instanceof Executions<?> executions) {
+            @SuppressWarnings("unchecked")
+            D copy = (D) executions.toBuilder()
+                .where(withFailedStateFilter(executions.getWhere()))
+                .build();
+            modifiedData = copy;
+        } else {
+            modifiedData = data;
+        }
+        return modifiedData;
+    }
+
+    private static List<AbstractFilter<Executions.Fields>> withFailedStateFilter(List<AbstractFilter<Executions.Fields>> existing) {
+        List<AbstractFilter<Executions.Fields>> result = new ArrayList<>();
+        if (existing != null) {
+            existing.stream()
+                .filter(filter -> !Executions.Fields.STATE.equals(filter.getField()))
+                .forEach(result::add);
+        }
+        result.add(In.<Executions.Fields>builder()
+            .field(Executions.Fields.STATE)
+            .values(List.<Object>of(State.Type.FAILED.name()))
+            .build());
+        return result;
+    }
+}

--- a/core/src/main/java/io/kestra/plugin/core/dashboard/chart/kpis/KpiOption.java
+++ b/core/src/main/java/io/kestra/plugin/core/dashboard/chart/kpis/KpiOption.java
@@ -16,8 +16,20 @@ public class KpiOption extends ChartOption {
     @Builder.Default
     private NumberType numberType = NumberType.FLAT;
 
+    @Builder.Default
+    private Color color = Color.DEFAULT;
+
     public enum NumberType {
         FLAT,
         PERCENTAGE
+    }
+
+    public enum Color {
+        DEFAULT,
+        SUCCESS,
+        DANGER,
+        FAILURE,
+        WARNING,
+        INFO
     }
 }

--- a/core/src/test/java/io/kestra/core/models/dashboards/ChartOptionTest.java
+++ b/core/src/test/java/io/kestra/core/models/dashboards/ChartOptionTest.java
@@ -1,0 +1,65 @@
+package io.kestra.core.models.dashboards;
+
+import java.util.Set;
+
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import io.micronaut.validation.validator.Validator;
+import jakarta.inject.Inject;
+import jakarta.validation.ConstraintViolation;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@MicronautTest
+class ChartOptionTest {
+
+    @Inject
+    private Validator validator;
+
+    @Test
+    void shouldDefaultRowSpanToOne() {
+        ChartOption option = ChartOption.builder()
+            .displayName("KPI")
+            .build();
+
+        assertThat(option.getRowSpan()).isEqualTo(1);
+        assertThat(validator.validate(option)).isEmpty();
+    }
+
+    @Test
+    void shouldAcceptRowSpanWithinAllowedRange() {
+        for (int rowSpan = 1; rowSpan <= 4; rowSpan++) {
+            ChartOption option = ChartOption.builder()
+                .displayName("Errors")
+                .rowSpan(rowSpan)
+                .build();
+
+            Set<ConstraintViolation<ChartOption>> violations = validator.validate(option);
+            assertThat(violations)
+                .as("rowSpan=%d should be valid", rowSpan)
+                .isEmpty();
+        }
+    }
+
+    @Test
+    void shouldRejectRowSpanBelowMinimum() {
+        ChartOption option = ChartOption.builder()
+            .displayName("Errors")
+            .rowSpan(0)
+            .build();
+
+        assertThat(validator.validate(option))
+            .anySatisfy(violation -> assertThat(violation.getPropertyPath().toString()).isEqualTo("rowSpan"));
+    }
+
+    @Test
+    void shouldRejectRowSpanAboveMaximum() {
+        ChartOption option = ChartOption.builder()
+            .displayName("Errors")
+            .rowSpan(5)
+            .build();
+
+        assertThat(validator.validate(option))
+            .anySatisfy(violation -> assertThat(violation.getPropertyPath().toString()).isEqualTo("rowSpan"));
+    }
+}

--- a/core/src/test/java/io/kestra/plugin/core/dashboard/chart/FailedExecutionsTest.java
+++ b/core/src/test/java/io/kestra/plugin/core/dashboard/chart/FailedExecutionsTest.java
@@ -1,0 +1,114 @@
+package io.kestra.plugin.core.dashboard.chart;
+
+import java.util.List;
+import java.util.Map;
+
+import io.kestra.core.models.dashboards.filters.AbstractFilter;
+import io.kestra.core.models.dashboards.filters.In;
+import io.kestra.core.models.flows.State;
+import io.kestra.plugin.core.dashboard.chart.tables.TableColumnDescriptor;
+import io.kestra.plugin.core.dashboard.chart.tables.TableOption;
+import io.kestra.plugin.core.dashboard.data.Executions;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class FailedExecutionsTest {
+
+    @Test
+    void shouldAppendFailedStateFilterWhenWhereIsAbsent() {
+        FailedExecutions<Executions.Fields, Executions<TableColumnDescriptor<Executions.Fields>>> chart =
+            buildChart(buildExecutions(null));
+
+        List<AbstractFilter<Executions.Fields>> where = chart.getData().getWhere();
+
+        assertOnlyFailedStateFilter(where);
+    }
+
+    @Test
+    void shouldPreserveNonStateFiltersAndForceFailed() {
+        AbstractFilter<Executions.Fields> namespaceFilter = In.<Executions.Fields>builder()
+            .field(Executions.Fields.NAMESPACE)
+            .values(List.<Object>of("io.kestra.tests"))
+            .build();
+
+        FailedExecutions<Executions.Fields, Executions<TableColumnDescriptor<Executions.Fields>>> chart =
+            buildChart(buildExecutions(List.of(namespaceFilter)));
+
+        List<AbstractFilter<Executions.Fields>> where = chart.getData().getWhere();
+
+        assertThat(where).hasSize(2);
+        assertThat(where.get(0)).isEqualTo(namespaceFilter);
+        assertThat(where.get(1).getField()).isEqualTo(Executions.Fields.STATE);
+    }
+
+    @Test
+    void shouldOverrideUserSuppliedStateFilter() {
+        AbstractFilter<Executions.Fields> userStateFilter = In.<Executions.Fields>builder()
+            .field(Executions.Fields.STATE)
+            .values(List.<Object>of(State.Type.SUCCESS.name()))
+            .build();
+
+        FailedExecutions<Executions.Fields, Executions<TableColumnDescriptor<Executions.Fields>>> chart =
+            buildChart(buildExecutions(List.of(userStateFilter)));
+
+        assertOnlyFailedStateFilter(chart.getData().getWhere());
+    }
+
+    @Test
+    void shouldBeIdempotentAcrossMultipleGetDataCalls() {
+        AbstractFilter<Executions.Fields> namespaceFilter = In.<Executions.Fields>builder()
+            .field(Executions.Fields.NAMESPACE)
+            .values(List.<Object>of("io.kestra.tests"))
+            .build();
+
+        FailedExecutions<Executions.Fields, Executions<TableColumnDescriptor<Executions.Fields>>> chart =
+            buildChart(buildExecutions(List.of(namespaceFilter)));
+
+        List<AbstractFilter<Executions.Fields>> first = chart.getData().getWhere();
+        List<AbstractFilter<Executions.Fields>> second = chart.getData().getWhere();
+        List<AbstractFilter<Executions.Fields>> third = chart.getData().getWhere();
+
+        assertThat(first).hasSize(2);
+        assertThat(second).hasSize(2);
+        assertThat(third).hasSize(2);
+        assertThat(third.get(1).getField()).isEqualTo(Executions.Fields.STATE);
+    }
+
+    private static FailedExecutions<Executions.Fields, Executions<TableColumnDescriptor<Executions.Fields>>> buildChart(
+        Executions<TableColumnDescriptor<Executions.Fields>> data
+    ) {
+        return FailedExecutions.<Executions.Fields, Executions<TableColumnDescriptor<Executions.Fields>>>builder()
+            .id("recent_failures")
+            .type("io.kestra.plugin.core.dashboard.chart.FailedExecutions")
+            .chartOptions(TableOption.builder().displayName("Recent failures").build())
+            .data(data)
+            .build();
+    }
+
+    private static Executions<TableColumnDescriptor<Executions.Fields>> buildExecutions(List<AbstractFilter<Executions.Fields>> where) {
+        Executions.ExecutionsBuilder<TableColumnDescriptor<Executions.Fields>, ?, ?> builder =
+            Executions.<TableColumnDescriptor<Executions.Fields>>builder()
+                .type("io.kestra.plugin.core.dashboard.data.Executions")
+                .columns(Map.of(
+                    "id", TableColumnDescriptor.<Executions.Fields>builder()
+                        .field(Executions.Fields.ID)
+                        .build()
+                ));
+
+        if (where != null) {
+            builder.where(where);
+        }
+
+        return builder.build();
+    }
+
+    private static void assertOnlyFailedStateFilter(List<AbstractFilter<Executions.Fields>> where) {
+        assertThat(where).hasSize(1);
+        AbstractFilter<Executions.Fields> only = where.get(0);
+        assertThat(only.getField()).isEqualTo(Executions.Fields.STATE);
+        assertThat(only).isInstanceOf(In.class);
+        assertThat(((In<?>) only).getValues()).containsExactly(State.Type.FAILED.name());
+    }
+}

--- a/ui/packages/design-system/src/components/Data/KsDataTable/KsFilter.vue
+++ b/ui/packages/design-system/src/components/Data/KsDataTable/KsFilter.vue
@@ -2,6 +2,10 @@
     <section class="filter">
         <div class="top" :class="{'options': showOptions}">
             <MainFilter />
+            <PresetDurations
+                v-if="presetDurations?.length"
+                :presets="presetDurations"
+            />
             <RightFilter>
                 <template #extra>
                     <slot name="extra" />
@@ -28,6 +32,7 @@
     import MainFilter from "./filter/MainFilter.vue";
     import RightFilter from "./filter/RightFilter.vue";
     import FilterOptions from "./filter/FilterOptions.vue";
+    import PresetDurations, {type PresetDuration} from "./filter/layout/PresetDurations.vue";
 
     const props = withDefaults(defineProps<{
         configuration: FilterConfiguration;
@@ -44,6 +49,7 @@
         defaultScope?: boolean;
         defaultTimeRange?: boolean;
         defaultDuration?: string;
+        presetDurations?: PresetDuration[];
     }>(), {
         buttons: () => ({}),
         tableOptions: () => ({}),
@@ -55,6 +61,7 @@
         defaultScope: undefined,
         defaultTimeRange: undefined,
         defaultDuration: undefined,
+        presetDurations: undefined,
     });
 
     const emits = defineEmits<{

--- a/ui/packages/design-system/src/components/Data/KsDataTable/filter/layout/PresetDurations.vue
+++ b/ui/packages/design-system/src/components/Data/KsDataTable/filter/layout/PresetDurations.vue
@@ -1,0 +1,85 @@
+<template>
+    <div class="preset-durations" data-test="preset-durations">
+        <KsSegmented
+            :modelValue="activeValue"
+            :options="options"
+            :disabled="!timeRangeConfig || filter.readOnly?.value"
+            @change="onChange"
+        />
+    </div>
+</template>
+
+<script setup lang="ts">
+    import {computed, inject} from "vue";
+
+    import KsSegmented from "../../../KsSegmented.vue";
+    import {
+        type AppliedFilter,
+        type FilterKeyConfig,
+        COMPARATOR_LABELS,
+        Comparators,
+    } from "../utils/filterTypes";
+    import {FILTER_CONTEXT_INJECTION_KEY} from "../utils/filterInjectionKeys";
+
+    export interface PresetDuration {
+        label: string;
+        value: string;
+    }
+
+    const props = defineProps<{
+        presets: PresetDuration[]
+    }>();
+
+    const filter = inject(FILTER_CONTEXT_INJECTION_KEY)!;
+
+    const TIME_RANGE_KEY = "timeRange";
+
+    const timeRangeConfig = computed<FilterKeyConfig | undefined>(() =>
+        filter.configuration?.value?.keys?.find((k) => k.key === TIME_RANGE_KEY),
+    );
+
+    const activeValue = computed<string | undefined>(() => {
+        const current = filter.appliedFilters?.value?.find((f) => f.key === TIME_RANGE_KEY)?.value;
+        if (typeof current !== "string") {
+            return undefined;
+        }
+        return props.presets.some((p) => p.value === current) ? current : undefined;
+    });
+
+    const options = computed(() => props.presets.map((p) => ({label: p.label, value: p.value})));
+
+    const onChange = (value: string | number | boolean) => {
+        if (!timeRangeConfig.value || filter.readOnly?.value) {
+            return;
+        }
+        if (typeof value !== "string" || value === activeValue.value) {
+            return;
+        }
+        const preset = props.presets.find((p) => p.value === value);
+        if (!preset) {
+            return;
+        }
+
+        const comparator =
+            (timeRangeConfig.value.comparators?.[0] as Comparators) ?? Comparators.EQUALS;
+
+        const applied: AppliedFilter = {
+            id: `${TIME_RANGE_KEY}-preset-${preset.value}-${Date.now()}`,
+            key: TIME_RANGE_KEY,
+            keyLabel: timeRangeConfig.value.label,
+            comparator,
+            comparatorLabel: COMPARATOR_LABELS[comparator],
+            value: preset.value,
+            valueLabel: preset.label,
+        };
+
+        filter.addFilter(applied);
+    };
+</script>
+
+<style lang="scss" scoped>
+    .preset-durations {
+        display: inline-flex;
+        align-items: center;
+    }
+</style>

--- a/ui/packages/design-system/tests/storybook/Data/PresetDurations.stories.ts
+++ b/ui/packages/design-system/tests/storybook/Data/PresetDurations.stories.ts
@@ -1,0 +1,94 @@
+import type {Meta, StoryObj} from "@storybook/vue3-vite"
+import {computed, ref} from "vue"
+import PresetDurations from "../../../src/components/Data/KsDataTable/filter/layout/PresetDurations.vue"
+import {FILTER_CONTEXT_INJECTION_KEY} from "../../../src/components/Data/KsDataTable/filter/utils/filterInjectionKeys"
+import {Comparators, type AppliedFilter, type FilterConfiguration} from "../../../src/components/Data/KsDataTable/filter/utils/filterTypes"
+
+const meta: Meta<typeof PresetDurations> = {
+    title: "Components/Data/PresetDurations",
+    component: PresetDurations,
+    tags: ["autodocs"],
+    parameters: {
+        docs: {
+            description: {
+                component: "Quick-interval chip strip for time-range filters. Renders inside a KsFilter context — pass `presetDurations` on the parent KsFilter rather than mounting this directly.",
+            },
+        },
+    },
+}
+export default meta
+
+type Story = StoryObj<typeof PresetDurations>
+
+const PRESETS = [
+    {label: "1h", value: "PT1H"},
+    {label: "24h", value: "PT24H"},
+    {label: "7d", value: "PT168H"},
+    {label: "30d", value: "PT720H"},
+]
+
+const TIME_RANGE_CONFIGURATION: FilterConfiguration = {
+    title: "Filters",
+    keys: [
+        {
+            key: "timeRange",
+            label: "Time range",
+            comparators: [Comparators.EQUALS],
+            valueType: "select",
+            valueProvider: async () => PRESETS,
+        },
+    ],
+}
+
+function buildContext(initial?: string) {
+    const applied = ref<AppliedFilter[]>(
+        initial
+            ? [
+                {
+                    id: `timeRange-${initial}`,
+                    key: "timeRange",
+                    keyLabel: "Time range",
+                    valueLabel: PRESETS.find((p) => p.value === initial)?.label ?? initial,
+                    comparator: Comparators.EQUALS,
+                    comparatorLabel: "Equals",
+                    value: initial,
+                },
+            ]
+            : [],
+    )
+
+    return {
+        configuration: computed(() => TIME_RANGE_CONFIGURATION),
+        appliedFilters: applied,
+        readOnly: computed(() => false),
+        addFilter: (f: AppliedFilter) => {
+            applied.value = [...applied.value.filter((x) => x.key !== f.key), f]
+        },
+    }
+}
+
+export const Default: Story = {
+    render: () => ({
+        components: {PresetDurations},
+        setup() {
+            return {presets: PRESETS}
+        },
+        provide() {
+            return {[FILTER_CONTEXT_INJECTION_KEY]: buildContext()}
+        },
+        template: "<div style=\"padding:24px\"><preset-durations :presets=\"presets\" /></div>",
+    }),
+}
+
+export const WithActiveSelection: Story = {
+    render: () => ({
+        components: {PresetDurations},
+        setup() {
+            return {presets: PRESETS}
+        },
+        provide() {
+            return {[FILTER_CONTEXT_INJECTION_KEY]: buildContext("PT24H")}
+        },
+        template: "<div style=\"padding:24px\"><preset-durations :presets=\"presets\" /></div>",
+    }),
+}

--- a/ui/packages/design-system/tests/units/Data/PresetDurations.test.ts
+++ b/ui/packages/design-system/tests/units/Data/PresetDurations.test.ts
@@ -1,0 +1,132 @@
+import {describe, test, expect, vi} from "vitest"
+import {mount} from "@vue/test-utils"
+import {createI18n} from "vue-i18n"
+import {computed, ref} from "vue"
+import KestraDesignSystem from "../../../src/index"
+import PresetDurations from "../../../src/components/Data/KsDataTable/filter/layout/PresetDurations.vue"
+import {FILTER_CONTEXT_INJECTION_KEY} from "../../../src/components/Data/KsDataTable/filter/utils/filterInjectionKeys"
+import {Comparators, type AppliedFilter, type FilterConfiguration} from "../../../src/components/Data/KsDataTable/filter/utils/filterTypes"
+
+const globalConfig = {plugins: [createI18n({legacy: false, locale: "en"}), KestraDesignSystem]}
+
+const PRESETS = [
+    {label: "1h", value: "PT1H"},
+    {label: "24h", value: "PT24H"},
+    {label: "7d", value: "PT168H"},
+]
+
+function buildFilterContext(opts: {
+    appliedFilters?: AppliedFilter[];
+    addFilter?: (f: AppliedFilter) => void;
+    readOnly?: boolean;
+    hasTimeRangeKey?: boolean;
+}) {
+    const configuration: FilterConfiguration = {
+        title: "Test",
+        keys: opts.hasTimeRangeKey === false ? [] : [
+            {
+                key: "timeRange",
+                label: "Time range",
+                comparators: [Comparators.EQUALS],
+                valueType: "select",
+                valueProvider: async () => [],
+            },
+        ],
+    }
+
+    return {
+        configuration: computed(() => configuration),
+        appliedFilters: ref<AppliedFilter[]>(opts.appliedFilters ?? []),
+        addFilter: opts.addFilter ?? vi.fn(),
+        readOnly: computed(() => opts.readOnly ?? false),
+    }
+}
+
+function mountPresetDurations(context: ReturnType<typeof buildFilterContext>, presets = PRESETS) {
+    return mount(PresetDurations, {
+        props: {presets},
+        global: {
+            ...globalConfig,
+            provide: {[FILTER_CONTEXT_INJECTION_KEY as symbol]: context},
+        },
+    })
+}
+
+const root = (wrapper: ReturnType<typeof mountPresetDurations>) =>
+    wrapper.find("[data-test=\"preset-durations\"]")
+const radios = (wrapper: ReturnType<typeof mountPresetDurations>) =>
+    wrapper.findAll("[data-test=\"preset-durations\"] input[type=\"radio\"]")
+const labels = (wrapper: ReturnType<typeof mountPresetDurations>) =>
+    wrapper.findAll("[data-test=\"preset-durations\"] label")
+
+describe("PresetDurations", () => {
+    test("renders one segment per preset", () => {
+        const wrapper = mountPresetDurations(buildFilterContext({}))
+        expect(root(wrapper).exists()).toBe(true)
+        const segments = labels(wrapper)
+        expect(segments).toHaveLength(PRESETS.length)
+        expect(segments[0].text()).toBe("1h")
+        expect(segments[2].text()).toBe("7d")
+    })
+
+    test("marks the segment matching the current timeRange filter as selected", async () => {
+        const applied: AppliedFilter = {
+            id: "tr",
+            key: "timeRange",
+            keyLabel: "Time range",
+            valueLabel: "24h",
+            comparator: Comparators.EQUALS,
+            comparatorLabel: "Equals",
+            value: "PT24H",
+        }
+        const wrapper = mountPresetDurations(buildFilterContext({appliedFilters: [applied]}))
+        await wrapper.vm.$nextTick()
+        const selected = radios(wrapper).filter((r) => (r.element as HTMLInputElement).checked)
+        expect(selected).toHaveLength(1)
+        expect(selected[0].attributes("value") ?? selected[0].element.parentElement?.textContent?.trim()).toBe("24h")
+    })
+
+    test("emits addFilter when an inactive segment is selected", async () => {
+        const addFilter = vi.fn()
+        const wrapper = mountPresetDurations(buildFilterContext({addFilter}))
+        await radios(wrapper)[1].setValue(true)
+        expect(addFilter).toHaveBeenCalledTimes(1)
+        const applied = addFilter.mock.calls[0][0] as AppliedFilter
+        expect(applied.key).toBe("timeRange")
+        expect(applied.value).toBe("PT24H")
+        expect(applied.comparator).toBe(Comparators.EQUALS)
+    })
+
+    test("does not addFilter when selecting the already-active segment", async () => {
+        const addFilter = vi.fn()
+        const applied: AppliedFilter = {
+            id: "tr",
+            key: "timeRange",
+            keyLabel: "Time range",
+            valueLabel: "24h",
+            comparator: Comparators.EQUALS,
+            comparatorLabel: "Equals",
+            value: "PT24H",
+        }
+        const wrapper = mountPresetDurations(buildFilterContext({appliedFilters: [applied], addFilter}))
+        await wrapper.vm.$nextTick()
+        await radios(wrapper)[1].setValue(true)
+        expect(addFilter).not.toHaveBeenCalled()
+    })
+
+    test("shows nothing selected when current timeRange does not match any preset", async () => {
+        const applied: AppliedFilter = {
+            id: "tr",
+            key: "timeRange",
+            keyLabel: "Time range",
+            valueLabel: "12h",
+            comparator: Comparators.EQUALS,
+            comparatorLabel: "Equals",
+            value: "PT12H",
+        }
+        const wrapper = mountPresetDurations(buildFilterContext({appliedFilters: [applied]}))
+        await wrapper.vm.$nextTick()
+        const selected = radios(wrapper).filter((r) => (r.element as HTMLInputElement).checked)
+        expect(selected).toHaveLength(0)
+    })
+})

--- a/ui/src/components/dashboard/Dashboard.vue
+++ b/ui/src/components/dashboard/Dashboard.vue
@@ -14,6 +14,7 @@
             }"
             :showSearchInput="false"
             :defaultDuration="dashboard.timeWindow?.default"
+            :presetDurations="presetDurations"
         />
     </section>
 
@@ -48,6 +49,18 @@
         if (props.isNamespace) return namespaceDashboardFilter.value;
         if (props.isFlow) return flowDashboardFilter.value;
         return dashboardFilter.value;
+    });
+
+    const presetDurations = computed(() => {
+        if (!props.isFlow) {
+            return undefined;
+        }
+        return [
+            {label: t("dashboards.flow_overview.quick_intervals.last_1h"), value: "PT1H"},
+            {label: t("dashboards.flow_overview.quick_intervals.last_24h"), value: "PT24H"},
+            {label: t("dashboards.flow_overview.quick_intervals.last_7d"), value: "PT168H"},
+            {label: t("dashboards.flow_overview.quick_intervals.last_30d"), value: "PT720H"},
+        ];
     });
 
     import YAML_MAIN from "./assets/default_main_definition.yaml?raw";

--- a/ui/src/components/dashboard/assets/default_flow_definition.yaml
+++ b/ui/src/components/dashboard/assets/default_flow_definition.yaml
@@ -11,7 +11,9 @@ charts:
     chartOptions:
       displayName: Success Ratio
       numberType: PERCENTAGE
+      color: SUCCESS
       width: 3
+      rowSpan: 1
     data:
       type: io.kestra.plugin.core.dashboard.data.ExecutionsKPI
       columns:
@@ -23,90 +25,6 @@ charts:
           values:
             - SUCCESS
 
-  - id: kpi_failed_ratio
-    type: io.kestra.plugin.core.dashboard.chart.KPI
-    chartOptions:
-      displayName: Failed Ratio
-      numberType: PERCENTAGE
-      width: 3
-    data:
-      type: io.kestra.plugin.core.dashboard.data.ExecutionsKPI
-      columns:
-        field: ID
-        agg: COUNT
-      numerator:
-        - type: IN
-          field: STATE
-          values:
-            - FAILED
-
-  - id: kpi_in_progress
-    type: io.kestra.plugin.core.dashboard.chart.KPI
-    chartOptions:
-      displayName: In Progress
-      numberType: FLAT
-      width: 3
-    data:
-      type: io.kestra.plugin.core.dashboard.data.ExecutionsKPI
-      columns:
-        field: ID
-        agg: COUNT
-      numerator:
-        - type: IN
-          field: STATE
-          values:
-            - RUNNING
-            - PAUSED
-            - KILLING
-            - RETRYING
-            - RESTARTED
-
-  - id: kpi_pending
-    type: io.kestra.plugin.core.dashboard.chart.KPI
-    chartOptions:
-      displayName: Pending
-      numberType: FLAT
-      width: 3
-    data:
-      type: io.kestra.plugin.core.dashboard.data.ExecutionsKPI
-      columns:
-        field: ID
-        agg: COUNT
-      numerator:
-        - type: IN
-          field: STATE
-          values:
-            - CREATED
-            - QUEUED
-
-  - id: description
-    type: io.kestra.plugin.core.dashboard.chart.Markdown
-    chartOptions:
-      displayName: Description
-      width: 6
-    source:
-      type: FlowDescription
-      namespace: --NAMESPACE--
-      flowId: --FLOW--
-
-  - id: total_executions_pie
-    type: io.kestra.plugin.core.dashboard.chart.Pie
-    chartOptions:
-      displayName: Total Executions
-      graphStyle: DONUT
-      tooltip: ALL
-      width: 6
-    data:
-      type: io.kestra.plugin.core.dashboard.data.Executions
-      columns:
-        id:
-          field: ID
-          displayName: Execution Id
-          agg: COUNT
-        state:
-          field: STATE
-          displayName: State
-
   - id: total_executions_timeseries
     type: io.kestra.plugin.core.dashboard.chart.TimeSeries
     chartOptions:
@@ -116,7 +34,8 @@ charts:
         enabled: true
       column: date
       colorByColumn: state
-      width: 12
+      width: 9
+      rowSpan: 2
     data:
       type: io.kestra.plugin.core.dashboard.data.Executions
       columns:
@@ -135,13 +54,59 @@ charts:
           agg: SUM
           graphStyle: LINES
 
+  - id: kpi_failed_ratio
+    type: io.kestra.plugin.core.dashboard.chart.KPI
+    chartOptions:
+      displayName: Failed Ratio
+      numberType: PERCENTAGE
+      color: DANGER
+      width: 3
+      rowSpan: 1
+    data:
+      type: io.kestra.plugin.core.dashboard.data.ExecutionsKPI
+      columns:
+        field: ID
+        agg: COUNT
+      numerator:
+        - type: IN
+          field: STATE
+          values:
+            - FAILED
+
+  - id: recent_failures
+    type: io.kestra.plugin.core.dashboard.chart.FailedExecutions
+    chartOptions:
+      displayName: Recent failures
+      description: Failed executions in the selected time window. Click a row to inspect ERROR logs.
+      pagination:
+        enabled: true
+      width: 12
+    data:
+      type: io.kestra.plugin.core.dashboard.data.Executions
+      columns:
+        id:
+          field: ID
+          displayName: Execution ID
+        flowId:
+          field: FLOW_ID
+          displayName: Flow
+        state:
+          field: STATE
+          displayName: State
+        startDate:
+          field: START_DATE
+          displayName: Start Date
+        duration:
+          field: DURATION
+          displayName: Duration
+
   - id: executions_in_progress
     type: io.kestra.plugin.core.dashboard.chart.Table
     chartOptions:
-      displayName: Executions In Progress
+      displayName: Executions in progress
       pagination:
         enabled: true
-      width: 6
+      width: 12
     data:
       type: io.kestra.plugin.core.dashboard.data.Executions
       columns:
@@ -175,10 +140,10 @@ charts:
   - id: next_executions
     type: io.kestra.plugin.core.dashboard.chart.Table
     chartOptions:
-      displayName: Next Executions
+      displayName: Next executions
       pagination:
         enabled: true
-      width: 6
+      width: 12
     data:
       type: io.kestra.plugin.core.dashboard.data.Triggers
       columns:
@@ -214,3 +179,13 @@ charts:
           displayName: Total Executions
           agg: COUNT
           graphStyle: BARS
+
+  - id: description
+    type: io.kestra.plugin.core.dashboard.chart.Markdown
+    chartOptions:
+      displayName: Description
+      width: 12
+    source:
+      type: FlowDescription
+      namespace: --NAMESPACE--
+      flowId: --FLOW--

--- a/ui/src/components/dashboard/composables/useDashboards.ts
+++ b/ui/src/components/dashboard/composables/useDashboards.ts
@@ -16,7 +16,9 @@ import {Chart, Parameters, Request} from "../types.ts";
 
 export const isKPIChart = (type: string): boolean => type === "io.kestra.plugin.core.dashboard.chart.KPI";
 
-export const isTableChart = (type: string): boolean => type === "io.kestra.plugin.core.dashboard.chart.Table";
+export const isTableChart = (type: string): boolean =>
+    type === "io.kestra.plugin.core.dashboard.chart.Table"
+    || type === "io.kestra.plugin.core.dashboard.chart.FailedExecutions";
 
 export const getChartTitle = (chart: Chart): string => chart.chartOptions?.displayName ?? chart.id;
 

--- a/ui/src/components/dashboard/dashboard-types.ts
+++ b/ui/src/components/dashboard/dashboard-types.ts
@@ -1,4 +1,5 @@
 import Bar from "./sections/Bar.vue";
+import FailedExecutions from "./sections/FailedExecutions.vue";
 import KPI from "./sections/KPI.vue";
 import Markdown from "./sections/Markdown.vue";
 import Pie from "./sections/Pie.vue";
@@ -7,6 +8,7 @@ import TimeSeries from "./sections/TimeSeries.vue";
 
 export const TYPES: Record<string, any> = {
     "io.kestra.plugin.core.dashboard.chart.Bar": Bar,
+    "io.kestra.plugin.core.dashboard.chart.FailedExecutions": FailedExecutions,
     "io.kestra.plugin.core.dashboard.chart.KPI": KPI,
     "io.kestra.plugin.core.dashboard.chart.Markdown": Markdown,
     "io.kestra.plugin.core.dashboard.chart.Pie": Pie,

--- a/ui/src/components/dashboard/sections/FailedExecutions.vue
+++ b/ui/src/components/dashboard/sections/FailedExecutions.vue
@@ -1,17 +1,23 @@
 <template>
-    <section v-if="data?.results?.length" id="table">
+    <section v-if="data?.results?.length" id="failed-executions">
         <KsDataTable
             :id="containerID"
             :data="data.results"
             :total="isPaginationEnabled(props.chart) ? data.total : 0"
             :currentPage="pageNumber"
             :pageSize="pageSize"
-            :height="240"
+            :height="320"
             size="small"
             @page-changed="handlePageChange"
         >
+            <KsTableColumn type="expand">
+                <template #default="scope">
+                    <ExpandedErrorLogs :executionId="getExecutionId(scope.row)" />
+                </template>
+            </KsTableColumn>
+
             <KsTableColumn
-                v-for="[key, value] in Object.entries( props.chart.data?.columns ?? {} )"
+                v-for="[key, value] in Object.entries(props.chart.data?.columns ?? {})"
                 :label="value.displayName || key"
                 :key
                 :width="value.field === 'STATE' ? 140 : undefined"
@@ -20,23 +26,29 @@
                     <template v-if="resolvedComponent(value.field) === undefined">
                         {{ scope.row[key] }}
                     </template>
-                    <component v-else :is="resolvedComponent(value.field)" v-bind="resolvedProps(value.field, key, scope.row)" />
+                    <component
+                        v-else
+                        :is="resolvedComponent(value.field)"
+                        v-bind="resolvedProps(value.field, key, scope.row)"
+                    />
                 </template>
             </KsTableColumn>
         </KsDataTable>
     </section>
 
-    <KsEmpty v-else :description="EMPTY_TEXT" />
+    <KsEmpty v-else :description="$t('dashboards.flow_overview.recent_failures_empty')" />
 </template>
 
 <script setup lang="ts">
-    import {PropType, watch, ref} from "vue";
+    import {PropType, ref, watch} from "vue";
     import {useRoute} from "vue-router";
 
     import type {Chart} from "../types.ts";
     import {isPaginationEnabled, useChartGenerator} from "../composables/useDashboards";
     import {useTableRenderer} from "./table/useTableRenderer";
     import {FilterObject} from "../../../utils/filters";
+
+    import ExpandedErrorLogs from "./failedExecutions/ExpandedErrorLogs.vue";
 
     const props = defineProps({
         dashboardId: {type: String, required: false, default: undefined},
@@ -54,27 +66,22 @@
             typeof route.params.namespace === "string" ? route.params.namespace : undefined,
     });
 
-    const data = ref();
+    const {generate} = useChartGenerator(props.dashboardId, props, false);
 
-    const {EMPTY_TEXT, generate} = useChartGenerator(props.dashboardId, props, false);
+    const data = ref();
+    const pageNumber = ref(1);
+    const pageSize = ref(10);
 
     const getData = async () => (data.value = await generate(
-        isPaginationEnabled(props.chart) ? {pageNumber: pageNumber.value, pageSize: pageSize.value} : undefined
+        isPaginationEnabled(props.chart) ? {pageNumber: pageNumber.value, pageSize: pageSize.value} : undefined,
     ));
-
-    const pageNumber = ref(1);
-    const pageSize = ref(25);
 
     const handlePageChange = (options: { page?: number; size?: number | string }) => {
         if (pageNumber.value === options.page && pageSize.value === options.size) return;
 
         pageNumber.value = options.page ?? 1;
         const sizeNumber = typeof options.size === "string" ? parseInt(options.size, 10) : options.size;
-        if (sizeNumber && isNaN(sizeNumber)) {
-            pageSize.value = 25;
-            return;
-        };
-        pageSize.value = sizeNumber ?? 25;
+        pageSize.value = sizeNumber && !isNaN(sizeNumber) ? sizeNumber : 10;
 
         return getData();
     };
@@ -83,17 +90,20 @@
         return getData();
     }
 
-    defineExpose({
-        refresh
-    });
+    defineExpose({refresh});
 
-    watch(() => route.params.filters, () => {
-        refresh();
-    }, {deep: true, immediate: true});
+    watch(() => route.params.filters, () => refresh(), {deep: true, immediate: true});
+
+    const getExecutionId = (row: Record<string, any>): string | undefined => {
+        const idColumnEntry = Object.entries(props.chart.data?.columns ?? {})
+            .find(([, descriptor]) => descriptor.field === "ID");
+        const idKey = idColumnEntry?.[0] ?? "id";
+        return typeof row[idKey] === "string" ? row[idKey] : undefined;
+    };
 </script>
 
 <style lang="scss" scoped>
-section#table :deep(.kel-scrollbar__thumb) {
-    background-color: var(--ks-button-background-primary) !important;
-}
+    section#failed-executions {
+        height: 100%;
+    }
 </style>

--- a/ui/src/components/dashboard/sections/KPI.vue
+++ b/ui/src/components/dashboard/sections/KPI.vue
@@ -1,8 +1,11 @@
 <template>
-    <section v-if="data" id="kpi">
-        <span class="pb-2">{{ getChartTitle(props.chart!) }}</span>
-        <p class="m-0 fs-2 fw-bold">
+    <section v-if="data" id="kpi" :class="`kpi--${color}`">
+        <span class="title">{{ getChartTitle(props.chart!) }}</span>
+        <p class="value">
             {{ getPropertyValue(data, "value") }}{{ percentageShown ? "%" : "" }}
+        </p>
+        <p v-if="rawCount" class="raw-count">
+            {{ rawCount }}
         </p>
     </section>
 
@@ -10,13 +13,19 @@
 </template>
 
 <script setup lang="ts">
-    import {PropType, watch} from "vue";
+    import {PropType, computed, ref, watch} from "vue";
 
     import {Chart} from "../composables/useDashboards";
     import {getChartTitle, getPropertyValue, useChartGenerator} from "../composables/useDashboards";
 
     import {useRoute} from "vue-router";
+    import {decodeSearchParams, State} from "@kestra-io/design-system";
+    import {useExecutionsStore} from "../../../stores/executions";
     import {FilterObject} from "../../../utils/filters";
+
+    const VALID_EXECUTION_STATES = new Set<string>(
+        State.arrayAllStates().map((s: {name: string}) => s.name),
+    );
 
     const props = defineProps({
         dashboardId: {type: String, required: false, default: undefined},
@@ -26,29 +35,139 @@
     });
 
     const route = useRoute();
+    const executionsStore = useExecutionsStore();
     const {percentageShown, EMPTY_TEXT, data, generate} = useChartGenerator(props.dashboardId, {...props});
 
+    const color = computed(() => {
+        const value = (props.chart?.chartOptions as Record<string, unknown> | undefined)?.color;
+        return typeof value === "string" ? value.toLowerCase() : "default";
+    });
+
+    const numeratorStates = computed<string[] | undefined>(() => {
+        const numerator = (props.chart?.data as Record<string, any> | undefined)?.numerator as
+            | Array<{ field?: string; values?: string[] }>
+            | undefined;
+        if (!Array.isArray(numerator)) return undefined;
+        const stateFilter = numerator.find((f) => f?.field === "STATE");
+        if (!Array.isArray(stateFilter?.values)) return undefined;
+        const sanitized = stateFilter!.values.filter((v) => VALID_EXECUTION_STATES.has(v));
+        return sanitized.length > 0 ? sanitized : undefined;
+    });
+
+    const rawCount = ref<string | undefined>(undefined);
+    let refreshGeneration = 0;
+
+    function timeWindowFilters(): Record<string, string> {
+        const params: Record<string, string> = {};
+        const decoded = decodeSearchParams(route.query) ?? [];
+        const timeRange = decoded.find((f: any) => f?.field === "timeRange");
+        const startDate = decoded.find((f: any) => f?.field === "startDate");
+        const endDate = decoded.find((f: any) => f?.field === "endDate");
+        if (timeRange?.value) params["filters[timeRange][EQUALS]"] = String(timeRange.value);
+        if (startDate?.value) params["filters[startDate][GREATER_THAN_OR_EQUAL_TO]"] = String(startDate.value);
+        if (endDate?.value) params["filters[endDate][LESS_THAN_OR_EQUAL_TO]"] = String(endDate.value);
+        return params;
+    }
+
+    async function refreshRawCount() {
+        if (!numeratorStates.value || numeratorStates.value.length === 0) {
+            rawCount.value = undefined;
+            return;
+        }
+        const generation = ++refreshGeneration;
+        const flowFilter = props.filters.find((f) => f.field === "flowId");
+        const namespaceFilter = props.filters.find((f) => f.field === "namespace");
+        const baseParams: Record<string, any> = {
+            ...timeWindowFilters(),
+            size: 1,
+            page: 1,
+            commit: false,
+        };
+        if (namespaceFilter?.value) {
+            baseParams["filters[namespace][EQUALS]"] = namespaceFilter.value;
+        }
+        if (flowFilter?.value) {
+            baseParams["filters[flowId][EQUALS]"] = flowFilter.value;
+        }
+
+        try {
+            const [matching, all] = await Promise.all([
+                executionsStore.findExecutions({
+                    ...baseParams,
+                    "filters[state][IN]": numeratorStates.value.join(","),
+                }),
+                executionsStore.findExecutions(baseParams),
+            ]);
+            if (generation !== refreshGeneration) return;
+            const num = matching?.total ?? 0;
+            const denom = all?.total ?? 0;
+            rawCount.value = denom > 0 ? `${num} / ${denom}` : undefined;
+        } catch {
+            if (generation !== refreshGeneration) return;
+            rawCount.value = undefined;
+        }
+    }
+
     function refresh() {
+        refreshRawCount();
         return generate();
     }
 
-    defineExpose({
-        refresh
-    });
+    defineExpose({refresh});
 
-    watch(() => route.params.filters, () => {
-        refresh();
-    }, {deep: true});
+    watch(
+        [() => route.params.filters, () => route.query],
+        () => refresh(),
+        {deep: true, immediate: true},
+    );
 </script>
 
 <style scoped lang="scss">
+    section#kpi {
+        height: 100%;
+        display: flex;
+        flex-direction: column;
+        justify-content: center;
+        align-items: center;
+        text-align: center;
+        gap: 0.25rem;
 
-section#kpi {
-    height: 100%;
-    display: flex;
-    flex-direction: column;
-    justify-content: center;
-    align-items: center;
-    text-align: center;
-}
+        .title {
+            font-size: var(--ks-font-size-sm);
+            color: var(--ks-content-secondary);
+            font-weight: 500;
+        }
+
+        .value {
+            margin: 0;
+            font-size: 2.5rem;
+            font-weight: 700;
+            line-height: 1.1;
+            color: var(--ks-content-primary);
+        }
+
+        .raw-count {
+            margin: 0;
+            font-size: var(--ks-font-size-xs);
+            color: var(--ks-content-tertiary);
+            font-family: monospace;
+        }
+
+        &.kpi--success .value {
+            color: var(--ks-content-success);
+        }
+
+        &.kpi--danger .value,
+        &.kpi--failure .value {
+            color: var(--ks-content-error);
+        }
+
+        &.kpi--warning .value {
+            color: var(--ks-content-warning);
+        }
+
+        &.kpi--info .value {
+            color: var(--ks-content-link);
+        }
+    }
 </style>

--- a/ui/src/components/dashboard/sections/Sections.vue
+++ b/ui/src/components/dashboard/sections/Sections.vue
@@ -6,7 +6,8 @@
                 :key="`chart__${chart.id}`"
                 class="dashboard-block"
                 :class="{
-                    [`dash-width-${chart.chartOptions?.width || 6}`]: true
+                    [`dash-width-${chart.chartOptions?.width || 6}`]: true,
+                    [`dash-height-${chart.chartOptions?.rowSpan || 1}`]: true
                 }"
             >
                 <div class="d-flex flex-column">
@@ -144,6 +145,7 @@ section#charts {
     }
     @container (min-width: #{$tablet}) {
         grid-template-columns: repeat(12, 1fr);
+        grid-auto-flow: row dense;
     }
     &.padding {
         padding: 0 2rem 1rem;
@@ -181,6 +183,15 @@ section#charts {
         }
     }
 
+    // Below the tablet breakpoint, multi-row blocks fall back to grid-row: auto.
+    // Pin a min-height so chart canvases (~240-320px) don't clip when stacked
+    // vertically on narrow viewports.
+    @for $i from 2 through 4 {
+        .dash-height-#{$i} {
+            min-height: #{14rem * $i};
+        }
+    }
+
     @container (min-width: #{$smallMobile}) {
         @for $i from 4 through 12 {
             .dash-width-#{$i} {
@@ -193,6 +204,13 @@ section#charts {
         @for $i from 4 through 12 {
             .dash-width-#{$i} {
                 grid-column: span #{$i};
+            }
+        }
+
+        @for $i from 1 through 4 {
+            .dash-height-#{$i} {
+                grid-row: span #{$i};
+                min-height: 0;
             }
         }
     }

--- a/ui/src/components/dashboard/sections/TimeSeries.vue
+++ b/ui/src/components/dashboard/sections/TimeSeries.vue
@@ -179,6 +179,9 @@
             duration = helper.map(date => groupedDurations[date as string] || 0);
         }
 
+        const lineColor = cssVar("--ks-content-link") || cssVar("--ks-content-secondary") || "#5bb8ff";
+        const areaTop = cssVar("--ks-content-link") || cssVar("--ks-content-secondary") || "#5bb8ff";
+
         return {
             labels: xAxis,
             datasets: yBShown.value
@@ -188,20 +191,14 @@
                         type: "line",
                         data: duration,
                         label: label,
-                        borderColor: cssVar("--ks-gray-100"),
+                        borderColor: lineColor,
                         smooth: true,
                         areaStyle: {
-                            opacity: 0.2,
+                            opacity: 0.08,
                             color: new echarts.graphic.LinearGradient(0, 0, 0, 1, [
-                                {
-                                    offset: 0,
-                                    color: cssVar("--ks-gray-100")
-                                },
-                                {
-                                    offset: 1,
-                                    color: cssVar("--ks-gray-900")
-                                }
-                            ])
+                                {offset: 0, color: areaTop},
+                                {offset: 1, color: "rgba(0,0,0,0)"},
+                            ]),
                         },
                     },
                     ...yDatasetData,
@@ -216,6 +213,7 @@
         const isCompact = props.short || props.execution;
         const showAxes = !isCompact && !verticalLayout.value;
 
+
         const barSeries = (pd.datasets as any[])
             .filter((ds) => ds.type !== "line")
             .map((ds) => ({
@@ -224,6 +222,7 @@
                 data: ds.data,
                 stack: "total",
                 yAxisIndex: 0,
+                z: 3,
                 itemStyle: {color: ds.backgroundColor},
                 barMaxWidth: props.short ? 8 : props.execution ? 24 : 48,
                 ...(props.short ? {barCategoryGap: "0%"} : {}),
@@ -239,7 +238,7 @@
                 smooth: true,
                 showSymbol: false,
                 z: 1,
-                lineStyle: {width: props.short ? 0.5 : 1, color: ds.borderColor},
+                lineStyle: {width: props.short ? 0.5 : 1.5, color: ds.borderColor},
                 ...(ds.areaStyle ? {areaStyle: ds.areaStyle} : {}),
             }));
 
@@ -270,7 +269,7 @@
                 "top": "10px",
                 "right": "10px",
             } : {show: false},
-            series: [...barSeries, ...lineSeries],
+            series: [...lineSeries, ...barSeries],
         };
     });
 

--- a/ui/src/components/dashboard/sections/failedExecutions/ExpandedErrorLogs.vue
+++ b/ui/src/components/dashboard/sections/failedExecutions/ExpandedErrorLogs.vue
@@ -1,0 +1,96 @@
+<template>
+    <div v-ks-loading="loading" class="expanded-error-logs">
+        <KsAlert
+            v-if="error"
+            type="error"
+            showIcon
+            :closable="false"
+            :title="$t('dashboards.flow_overview.errors_load_failed')"
+        />
+
+        <p v-else-if="!loading && !logs.length" class="empty">
+            {{ $t("dashboards.flow_overview.errors_in_execution_empty") }}
+        </p>
+
+        <div v-else-if="!loading" class="logs">
+            <LogLine
+                v-for="(log, index) in logs"
+                :key="`${log.timestamp}-${index}`"
+                :level="log.level"
+                :log="log"
+                :excludeMetas="['namespace', 'flowId', 'executionId']"
+            />
+        </div>
+    </div>
+</template>
+
+<script setup lang="ts">
+    import {ref, watch} from "vue";
+
+    import {KsAlert, vKsLoading} from "@kestra-io/design-system";
+
+    import LogLine from "../../../logs/LogLine.vue";
+    import {useExecutionsStore} from "../../../../stores/executions";
+    import type {Log} from "../../../../stores/logs";
+
+    const props = defineProps<{
+        executionId?: string;
+    }>();
+
+    const store = useExecutionsStore();
+
+    const logs = ref<Log[]>([]);
+    const loading = ref(false);
+    const error = ref(false);
+
+    const fetchLogs = async (executionId: string) => {
+        loading.value = true;
+        error.value = false;
+        try {
+            const response = await store.loadLogs({
+                executionId,
+                params: {minLevel: "ERROR"},
+                store: false,
+            });
+            logs.value = Array.isArray(response) ? response : [];
+        } catch {
+            error.value = true;
+            logs.value = [];
+        } finally {
+            loading.value = false;
+        }
+    };
+
+    watch(
+        () => props.executionId,
+        (executionId) => {
+            if (executionId) {
+                fetchLogs(executionId);
+            } else {
+                logs.value = [];
+                loading.value = false;
+                error.value = false;
+            }
+        },
+        {immediate: true},
+    );
+</script>
+
+<style lang="scss" scoped>
+    .expanded-error-logs {
+        padding: 0.5rem 1rem;
+        background: var(--ks-background-base);
+
+        .empty {
+            margin: 0;
+            font-size: var(--ks-font-size-xs);
+            color: var(--ks-content-tertiary);
+        }
+
+        .logs {
+            display: flex;
+            flex-direction: column;
+            gap: 0.25rem;
+        }
+    }
+</style>

--- a/ui/src/components/dashboard/sections/table/useTableRenderer.ts
+++ b/ui/src/components/dashboard/sections/table/useTableRenderer.ts
@@ -1,0 +1,79 @@
+import type {Component} from "vue";
+import {KsExecutionStatus} from "@kestra-io/design-system";
+
+import Date from "./columns/Date.vue";
+import Duration from "./columns/Duration.vue";
+import Link from "./columns/Link.vue";
+import Namespace from "./columns/Namespace.vue";
+
+export interface TableRendererOptions {
+    chartColumns: () => Record<string, any> | undefined;
+    routeNamespace: () => string | undefined;
+}
+
+/**
+ * Maps a column's `field` (from the chart YAML) to the cell component used to
+ * render its value, plus the props that component expects.
+ *
+ * Why this lives here and not inline in each chart component: the Link cell
+ * needs both `FLOW_ID` and `NAMESPACE` available in the row to build the
+ * router-link target. Per-flow overviews don't have a NAMESPACE column in
+ * their YAML (it's redundant — the namespace is in the route), so we augment
+ * with the route's namespace when missing. Keeping that augmentation in one
+ * place avoids duplicating the workaround in every chart.
+ */
+export function useTableRenderer(options: TableRendererOptions) {
+    const augmentedColumns = (): Record<string, any> => {
+        const columns = options.chartColumns() ?? {};
+        const hasNamespace = Object.values(columns).some((c: any) => c?.field === "NAMESPACE");
+        if (hasNamespace) return columns;
+        return {...columns, namespace: {field: "NAMESPACE", displayName: "Namespace"}};
+    };
+
+    const augmentedRow = (row: Record<string, any>): Record<string, any> => {
+        const fromRow = row.namespace as string | undefined;
+        if (typeof fromRow === "string" && fromRow.length > 0) return row;
+        const fromRoute = options.routeNamespace();
+        return fromRoute !== undefined ? {...row, namespace: fromRoute} : row;
+    };
+
+    const resolvedComponent = (field: string): Component | undefined => {
+        switch (field) {
+        case "ID":
+        case "FLOW_ID":
+            return Link;
+        case "NAMESPACE":
+            return Namespace;
+        case "STATE":
+            return KsExecutionStatus;
+        case "DURATION":
+            return Duration;
+        default:
+            return field?.toLowerCase().includes("date") ? Date : undefined;
+        }
+    };
+
+    const resolvedProps = (field: string, key: string, row: Record<string, any>): Record<string, any> => {
+        const baseProps = {field: key, row: augmentedRow(row), columns: augmentedColumns()};
+
+        switch (field) {
+        case "ID":
+            return {...baseProps, execution: true};
+        case "FLOW_ID":
+            return {...baseProps, flow: true};
+        case "NAMESPACE":
+            return {field: row[key]};
+        case "STATE":
+            return {size: "small", status: row[key]?.toString()};
+        case "DURATION":
+            return {field: row[key], startDate: row["start_date"] ?? row["startDate"]};
+        default:
+            if (field?.toLowerCase().includes("date")) {
+                return {field: row[key]};
+            }
+            return {};
+        }
+    };
+
+    return {resolvedComponent, resolvedProps};
+}

--- a/ui/src/translations/de.json
+++ b/ui/src/translations/de.json
@@ -241,7 +241,18 @@
         "singular": "Dashboard"
       },
       "preview": "Vorschau-Dashboard",
-      "switch": "Dashboard wechseln"
+      "switch": "Dashboard wechseln",
+      "flow_overview": {
+        "recent_failures_empty": "No failed executions in the selected time window.",
+        "errors_in_execution_empty": "No ERROR logs recorded for this execution.",
+        "errors_load_failed": "Failed to load error logs for this execution.",
+        "quick_intervals": {
+          "last_1h": "1h",
+          "last_24h": "24h",
+          "last_7d": "7d",
+          "last_30d": "30d"
+        }
+      }
     },
     "data": "Daten",
     "dataFilters": "Datenfilter",

--- a/ui/src/translations/en.json
+++ b/ui/src/translations/en.json
@@ -1593,7 +1593,18 @@
         "confirmation": "Are you sure you want to delete <code>{title}</code> dashboard?"
       },
       "chart_preview": "Click on a chart source code to see its preview",
-      "export": "Export to CSV"
+      "export": "Export to CSV",
+      "flow_overview": {
+        "recent_failures_empty": "No failed executions in the selected time window.",
+        "errors_in_execution_empty": "No ERROR logs recorded for this execution.",
+        "errors_load_failed": "Failed to load error logs for this execution.",
+        "quick_intervals": {
+          "last_1h": "1h",
+          "last_24h": "24h",
+          "last_7d": "7d",
+          "last_30d": "30d"
+        }
+      }
     },
     "setup": {
       "login": "Login",

--- a/ui/src/translations/es.json
+++ b/ui/src/translations/es.json
@@ -241,7 +241,18 @@
         "singular": "Panel de control"
       },
       "preview": "Vista previa del Dashboard",
-      "switch": "Cambiar Dashboard"
+      "switch": "Cambiar Dashboard",
+      "flow_overview": {
+        "recent_failures_empty": "No failed executions in the selected time window.",
+        "errors_in_execution_empty": "No ERROR logs recorded for this execution.",
+        "errors_load_failed": "Failed to load error logs for this execution.",
+        "quick_intervals": {
+          "last_1h": "1h",
+          "last_24h": "24h",
+          "last_7d": "7d",
+          "last_30d": "30d"
+        }
+      }
     },
     "data": "Datos",
     "dataFilters": "Filtros de Datos",

--- a/ui/src/translations/fr.json
+++ b/ui/src/translations/fr.json
@@ -236,6 +236,17 @@
       },
       "empty": "Il n'y a aucun résultat à afficher.",
       "export": "Exporter vers CSV",
+      "flow_overview": {
+        "recent_failures_empty": "Aucune exécution en échec dans la fenêtre temporelle sélectionnée.",
+        "errors_in_execution_empty": "Aucun log de niveau ERROR pour cette exécution.",
+        "errors_load_failed": "Impossible de charger les logs d'erreur de cette exécution.",
+        "quick_intervals": {
+          "last_1h": "1h",
+          "last_24h": "24h",
+          "last_7d": "7j",
+          "last_30d": "30j"
+        }
+      },
       "labels": {
         "plural": "Tableaux de bord",
         "singular": "Tableau de bord"

--- a/ui/src/translations/hi.json
+++ b/ui/src/translations/hi.json
@@ -241,7 +241,18 @@
         "singular": "डैशबोर्ड"
       },
       "preview": "पूर्वावलोकन डैशबोर्ड",
-      "switch": "डैशबोर्ड स्विच करें"
+      "switch": "डैशबोर्ड स्विच करें",
+      "flow_overview": {
+        "recent_failures_empty": "No failed executions in the selected time window.",
+        "errors_in_execution_empty": "No ERROR logs recorded for this execution.",
+        "errors_load_failed": "Failed to load error logs for this execution.",
+        "quick_intervals": {
+          "last_1h": "1h",
+          "last_24h": "24h",
+          "last_7d": "7d",
+          "last_30d": "30d"
+        }
+      }
     },
     "data": "डेटा",
     "dataFilters": "डेटा फ़िल्टर",

--- a/ui/src/translations/it.json
+++ b/ui/src/translations/it.json
@@ -241,7 +241,18 @@
         "singular": "Dashboard"
       },
       "preview": "Anteprima Dashboard",
-      "switch": "Dashboard Switch"
+      "switch": "Dashboard Switch",
+      "flow_overview": {
+        "recent_failures_empty": "No failed executions in the selected time window.",
+        "errors_in_execution_empty": "No ERROR logs recorded for this execution.",
+        "errors_load_failed": "Failed to load error logs for this execution.",
+        "quick_intervals": {
+          "last_1h": "1h",
+          "last_24h": "24h",
+          "last_7d": "7d",
+          "last_30d": "30d"
+        }
+      }
     },
     "data": "Dati",
     "dataFilters": "Filtri Dati",

--- a/ui/src/translations/ja.json
+++ b/ui/src/translations/ja.json
@@ -241,7 +241,18 @@
         "singular": "ダッシュボード"
       },
       "preview": "プレビュー ダッシュボード",
-      "switch": "ダッシュボードを切り替える"
+      "switch": "ダッシュボードを切り替える",
+      "flow_overview": {
+        "recent_failures_empty": "No failed executions in the selected time window.",
+        "errors_in_execution_empty": "No ERROR logs recorded for this execution.",
+        "errors_load_failed": "Failed to load error logs for this execution.",
+        "quick_intervals": {
+          "last_1h": "1h",
+          "last_24h": "24h",
+          "last_7d": "7d",
+          "last_30d": "30d"
+        }
+      }
     },
     "data": "データ",
     "dataFilters": "データフィルター",

--- a/ui/src/translations/ko.json
+++ b/ui/src/translations/ko.json
@@ -241,7 +241,18 @@
         "singular": "대시보드"
       },
       "preview": "미리보기 대시보드",
-      "switch": "대시보드 전환"
+      "switch": "대시보드 전환",
+      "flow_overview": {
+        "recent_failures_empty": "No failed executions in the selected time window.",
+        "errors_in_execution_empty": "No ERROR logs recorded for this execution.",
+        "errors_load_failed": "Failed to load error logs for this execution.",
+        "quick_intervals": {
+          "last_1h": "1h",
+          "last_24h": "24h",
+          "last_7d": "7d",
+          "last_30d": "30d"
+        }
+      }
     },
     "data": "데이터",
     "dataFilters": "데이터 필터",

--- a/ui/src/translations/pl.json
+++ b/ui/src/translations/pl.json
@@ -241,7 +241,18 @@
         "singular": "Dashboard"
       },
       "preview": "Podgląd Dashboardu",
-      "switch": "Przełącz Dashboard"
+      "switch": "Przełącz Dashboard",
+      "flow_overview": {
+        "recent_failures_empty": "No failed executions in the selected time window.",
+        "errors_in_execution_empty": "No ERROR logs recorded for this execution.",
+        "errors_load_failed": "Failed to load error logs for this execution.",
+        "quick_intervals": {
+          "last_1h": "1h",
+          "last_24h": "24h",
+          "last_7d": "7d",
+          "last_30d": "30d"
+        }
+      }
     },
     "data": "Dane",
     "dataFilters": "Filtry Danych",

--- a/ui/src/translations/pt.json
+++ b/ui/src/translations/pt.json
@@ -241,7 +241,18 @@
         "singular": "Dashboard"
       },
       "preview": "Visualizar Dashboard",
-      "switch": "Alternar Dashboard"
+      "switch": "Alternar Dashboard",
+      "flow_overview": {
+        "recent_failures_empty": "No failed executions in the selected time window.",
+        "errors_in_execution_empty": "No ERROR logs recorded for this execution.",
+        "errors_load_failed": "Failed to load error logs for this execution.",
+        "quick_intervals": {
+          "last_1h": "1h",
+          "last_24h": "24h",
+          "last_7d": "7d",
+          "last_30d": "30d"
+        }
+      }
     },
     "data": "Dados",
     "dataFilters": "Filtros de Dados",

--- a/ui/src/translations/pt_BR.json
+++ b/ui/src/translations/pt_BR.json
@@ -241,7 +241,18 @@
         "singular": "Dashboard"
       },
       "preview": "Visualizar Dashboard",
-      "switch": "Alternar Dashboard"
+      "switch": "Alternar Dashboard",
+      "flow_overview": {
+        "recent_failures_empty": "No failed executions in the selected time window.",
+        "errors_in_execution_empty": "No ERROR logs recorded for this execution.",
+        "errors_load_failed": "Failed to load error logs for this execution.",
+        "quick_intervals": {
+          "last_1h": "1h",
+          "last_24h": "24h",
+          "last_7d": "7d",
+          "last_30d": "30d"
+        }
+      }
     },
     "data": "Dados",
     "dataFilters": "Filtros de Dados",

--- a/ui/src/translations/ru.json
+++ b/ui/src/translations/ru.json
@@ -241,7 +241,18 @@
         "singular": "Панель управления"
       },
       "preview": "Предварительный просмотр Dashboard",
-      "switch": "Переключить Панель управления"
+      "switch": "Переключить Панель управления",
+      "flow_overview": {
+        "recent_failures_empty": "No failed executions in the selected time window.",
+        "errors_in_execution_empty": "No ERROR logs recorded for this execution.",
+        "errors_load_failed": "Failed to load error logs for this execution.",
+        "quick_intervals": {
+          "last_1h": "1h",
+          "last_24h": "24h",
+          "last_7d": "7d",
+          "last_30d": "30d"
+        }
+      }
     },
     "data": "Данные",
     "dataFilters": "Фильтры данных",

--- a/ui/src/translations/zh_CN.json
+++ b/ui/src/translations/zh_CN.json
@@ -241,7 +241,18 @@
         "singular": "仪表板"
       },
       "preview": "预览仪表板",
-      "switch": "切换仪表板"
+      "switch": "切换仪表板",
+      "flow_overview": {
+        "recent_failures_empty": "No failed executions in the selected time window.",
+        "errors_in_execution_empty": "No ERROR logs recorded for this execution.",
+        "errors_load_failed": "Failed to load error logs for this execution.",
+        "quick_intervals": {
+          "last_1h": "1h",
+          "last_24h": "24h",
+          "last_7d": "7d",
+          "last_30d": "30d"
+        }
+      }
     },
     "data": "数据",
     "dataFilters": "数据过滤器",


### PR DESCRIPTION
## Summary

Redesigns the per-flow Overview page (`/ui/main/flows/edit/{namespace}/{flow}/overview`) to feel like a status page for power users — what failed, what's running, what's next — without leaving the YAML-driven dashboard system. Switching between the new layout and the previous one stays a one-click toggle in the dashboard switcher.

The page now reads:

```
filter bar (with 1h / 24h / 7d / 30d preset chips)
  -> Success ratio (green) | Total Executions chart (rowSpan 2) | Failure ratio (red)
  -> Recent failures (inline-expandable error logs)
  -> Executions in progress + Next scheduled
  -> Logs time series
  -> Description card
```

To get there cleanly, three small primitives were added so the layout stays 100% YAML-driven (no bespoke `<FlowOverview>` page). Each primitive is reusable from any other dashboard:

- **`rowSpan` (1-4) on `ChartOption`** — lets a chart claim multiple grid rows. Bean-validated.
- **`color` on `KpiOption`** — semantic palette (`SUCCESS`, `DANGER`, `WARNING`, `INFO`, `DEFAULT`). Drives a CSS class against `--ks-*` tokens — no hex codes.
- **`io.kestra.plugin.core.dashboard.chart.FailedExecutions`** — Table chart variant that pre-applies `In(STATE, [FAILED])` and overrides any user-supplied STATE filter so the chart's contract holds.

On the frontend the changes live entirely under `ui/src/components/dashboard/`:

- `KsFilter` gained a `presetDurations` slot (`KsSegmented` chips above the bar).
- `KPI.vue` fetches the raw count in parallel with the trend (`Promise.all`), guarded by a generation counter so a stale request can't overwrite a fresh one.
- `Sections.vue` uses `grid-auto-flow: row dense` at the tablet breakpoint so a `rowSpan: 2` chart and two single-row KPI tiles backfill into a clean 2x2 pattern. Below the breakpoint multi-row blocks pin a `min-height` to keep ECharts canvases from clipping.
- `TimeSeries.vue` reorders ECharts series so bars (`z: 3`) draw above the line (`z: 1`), and uses `--ks-content-link` for the line — the previous `--ks-gray-100` token resolved to an empty string and rendered an opaque dark gradient that hid the bars.
- `Table.vue` and the new `FailedExecutions.vue` share a `useTableRenderer` composable that maps `field` -> cell component once. The Link cell needs both `FLOW_ID` and `NAMESPACE` to build the router-link target, but per-flow overviews don't have a `NAMESPACE` column (the namespace is in the route), so the composable augments the row + columns from the route in a single place.
- `FailedExecutions.vue` adds an inline-expand row that lazy-fetches ERROR-level logs through `executionsStore.loadLogs({minLevel: 'ERROR'})` and renders them with the existing `LogLine` component.

## Library APIs used

- ECharts series `z` order: https://echarts.apache.org/en/option.html#series-bar.z (used in `TimeSeries.vue` to layer bars above the line).
- Element Plus `<el-segmented>` (wrapped by `KsSegmented`): https://element-plus.org/en-US/component/segmented.html (used in `PresetDurations.vue`).
- Vue 3 `defineProps` / `defineExpose`: https://vuejs.org/api/sfc-script-setup.html (composition-API entry points throughout).
- Lombok `@SuperBuilder(toBuilder = true)`: https://projectlombok.org/features/experimental/SuperBuilder (used in `FailedExecutions` to make a one-shot copy with the failed-state filter applied).
- Micronaut Bean Validation (`@Min` / `@Max`): https://docs.micronaut.io/latest/guide/#beanValidation (used on `ChartOption.rowSpan`).

## Screenshots

### Top — filter chips + KPIs (Success green, Failed red) + Total Executions chart with bars and line

![Top of page](https://github.com/flcarre/kestra/releases/download/screenshots-flow-overview-redesign/55-top.png)

### Middle — Recent failures (continued) + Executions in progress + Next executions

![Middle of page](https://github.com/flcarre/kestra/releases/download/screenshots-flow-overview-redesign/55-mid.png)

### Bottom — Logs time series + Description

![Bottom of page](https://github.com/flcarre/kestra/releases/download/screenshots-flow-overview-redesign/55-bottom.png)

### Inline-expanded error logs + clickable execution / flow IDs

Click any failure row to drop a panel of ERROR-level logs underneath it (no navigation, no modal). Both the Execution ID and the Flow link out to the right page in the rest of the UI.

![Failure row expanded showing two ERROR-level log lines](https://github.com/flcarre/kestra/releases/download/screenshots-flow-overview-redesign/55-failures-expanded.png)

## Test plan

- [x] `./gradlew :core:test --tests "io.kestra.core.models.dashboards.ChartOptionTest"` — 4/4 (validates `rowSpan` Bean Validation bounds + default).
- [x] `./gradlew :core:test --tests "io.kestra.plugin.core.dashboard.chart.FailedExecutionsTest"` — 4/4 (covers state-override and `getData()` idempotence across the multiple invocations the dashboard pipeline performs).
- [x] `npm run test:unit` (design-system) — `PresetDurations.test.ts` 5/5 with `data-test="preset-durations"` semantic selectors, no `.kel-*` internals.
- [x] Manual QA across light + dark mode on every chart variant: KPIs, time series, tables, failure expand, namespace + flow links, preset chips, dashboard switcher, default-vs-custom flow dashboards.
- [ ] Reviewer to confirm bisectable commits make sense (`git log develop..HEAD --oneline` shows 7 commits).

🤖 Generated with [Claude Code](https://claude.com/claude-code)