### PR TITLE
build(deps): add distinct commit prefixes for topology and design-system dependabot sections

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -33,6 +33,10 @@ updates:
   # Maintain dependencies for NPM modules
   - package-ecosystem: "npm"
     directory: "/ui"
+    commit-message:
+      prefix: "build(deps)"
+      prefix-development: "build(deps)"
+      include: "scope"
     schedule:
       interval: "weekly"
       day: "wednesday"
@@ -146,6 +150,10 @@ updates:
   # Maintain dependencies for ui/packages/design-system
   - package-ecosystem: "npm"
     directory: "/ui/packages/design-system"
+    commit-message:
+      prefix: "build(design-system)"
+      prefix-development: "build(design-system)"
+      include: "scope"
     schedule:
       interval: "weekly"
       day: "wednesday"
@@ -244,6 +252,10 @@ updates:
   # Maintain dependencies for ui/packages/topology
   - package-ecosystem: "npm"
     directory: "/ui/packages/topology"
+    commit-message:
+      prefix: "build(topology)"
+      prefix-development: "build(topology)"
+      include: "scope"
     schedule:
       interval: "weekly"
       day: "wednesday"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -356,6 +356,6 @@ docker compose -f docker-compose-ci.yml down
 ## Pull request guidelines
 - Always add tests, keep your branch rebased instead of merged, and adhere to the commit message recommendations from https://www.conventionalcommits.org/en/v1.0.0.
 - Use types: chore, feat, fix, refactor, test, docs, build
-- Use scopes: apps, assets, core, dashboards, deps, executions, flows, iam, namespaces, plugins, secrets, storage, scheduler, system, tasks, tenants, tests, triggers, variables, version, worker
+- Use scopes: apps, assets, core, dashboards, deps, design-system, executions, flows, iam, namespaces, plugins, secrets, storage, scheduler, system, tasks, tenants, tests, topology, triggers, variables, version, worker
 
 This document should be updated as the codebase evolves. When in doubt, follow existing patterns in the codebase and maintain consistency with established conventions.


### PR DESCRIPTION
## Summary

- Adds `commit-message` prefixes to the three npm Dependabot sections so PRs are immediately distinguishable by scope
- `/ui` → `build(deps)` (unchanged behavior, now explicit)
- `/ui/packages/design-system` → `build(design-system)`
- `/ui/packages/topology` → `build(topology)`
- Also registers `topology` and `design-system` as valid commit scopes in `AGENTS.md`

## Test plan

- [ ] Verify next Dependabot PR for `/ui/packages/topology` is titled `build(topology): bump ...`
- [ ] Verify next Dependabot PR for `/ui/packages/design-system` is titled `build(design-system): bump ...`