### PR TITLE
build(deps): remove include scope from dependabot commit-message config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -36,7 +36,6 @@ updates:
     commit-message:
       prefix: "build(deps)"
       prefix-development: "build(deps)"
-      include: "scope"
     schedule:
       interval: "weekly"
       day: "wednesday"
@@ -153,7 +152,6 @@ updates:
     commit-message:
       prefix: "build(design-system)"
       prefix-development: "build(design-system)"
-      include: "scope"
     schedule:
       interval: "weekly"
       day: "wednesday"
@@ -255,7 +253,6 @@ updates:
     commit-message:
       prefix: "build(topology)"
       prefix-development: "build(topology)"
-      include: "scope"
     schedule:
       interval: "weekly"
       day: "wednesday"


### PR DESCRIPTION
## Summary

- Adds `commit-message` prefixes to the three npm Dependabot sections so PRs are immediately distinguishable by scope:
  - `/ui` → `build(deps):`
  - `/ui/packages/design-system` → `build(design-system):`
  - `/ui/packages/topology` → `build(topology):`
- Also registers `topology` and `design-system` as valid commit scopes in `AGENTS.md`