### PR TITLE
refactor(executions): throw ConflictException for state conflicts in ExecutionController

### DIFF
--- a/webserver/src/main/java/io/kestra/webserver/controllers/api/ExecutionController.java
+++ b/webserver/src/main/java/io/kestra/webserver/controllers/api/ExecutionController.java
@@ -27,6 +27,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.kestra.core.async.AsyncOperationProcessedEvent;
 import io.kestra.core.debug.Breakpoint;
 import io.kestra.core.events.CrudEvent;
+import io.kestra.core.exceptions.ConflictException;
 import io.kestra.core.exceptions.IllegalVariableEvaluationException;
 import io.kestra.core.exceptions.InternalException;
 import io.kestra.core.executor.command.*;
@@ -133,8 +134,6 @@ import static io.kestra.core.models.Label.SYSTEM_PREFIX;
 import static io.kestra.core.utils.Rethrow.throwConsumer;
 import static io.kestra.core.utils.Rethrow.throwFunction;
 
-// FIXME for all update on the execution (resume, pause, force run, ...) we validate the state and if validation fail we throws
-//  sometimes an IllegalStateException sometimes an IllegalArgumentException: this would be great to always throw the same exception.
 @Slf4j
 @Controller("/api/v1/{tenant}/executions")
 public class ExecutionController {
@@ -539,10 +538,10 @@ public class ExecutionController {
 
         var flow = maybeFlow.get();
         if (flow.isDisabled()) {
-            throw new IllegalStateException("Cannot execute a disabled flow");
+            throw new ConflictException("Cannot execute flow: flow is disabled.");
         }
         if (flow instanceof FlowWithException fwe) {
-            throw new IllegalStateException("Cannot execute an invalid flow: " + fwe.getException());
+            throw new ConflictException("Cannot execute flow: flow is invalid: " + fwe.getException());
         }
 
         Optional<AbstractWebhookTrigger> maybeWebhook = (flow.getTriggers() == null ? new ArrayList<AbstractTrigger>()
@@ -958,9 +957,8 @@ public class ExecutionController {
         this.controlRevision(execution, revision);
 
         if (!(execution.getState().canBeRestarted())) {
-            throw new IllegalStateException(
-                "Execution must be terminated or paused to be restarted, " +
-                    "current state is '" + execution.getState().getCurrent() + "' !"
+            throw new ConflictException(
+                "Cannot restart execution: current state is '" + execution.getState().getCurrent() + "', expected terminated or paused."
             );
         }
 
@@ -1190,7 +1188,7 @@ public class ExecutionController {
         Execution execution = executionRepository.findById(tenantService.resolveTenant(), executionId).orElseThrow(NotFoundException::new);
 
         if (!execution.getState().canChangeStatus()) {
-            throw new IllegalArgumentException("You can only change the state of a task run for a terminated non killed execution.");
+            throw new ConflictException("Cannot change task run state: execution must be terminated and not killed.");
         }
 
         return awaitBlockingAction(
@@ -1219,7 +1217,7 @@ public class ExecutionController {
         Execution execution = executionRepository.findById(tenantService.resolveTenant(), executionId).orElseThrow(NotFoundException::new);
 
         if (!execution.getState().canChangeStatus()) {
-            throw new IllegalArgumentException("You can only change the state of a terminated non killed execution.");
+            throw new ConflictException("Cannot change execution state: execution must be terminated and not killed.");
         }
 
         return awaitBlockingAction(
@@ -1326,7 +1324,7 @@ public class ExecutionController {
     protected Mono<HttpResponse<?>> killExecution(Execution execution, Boolean isOnKillCascade) {
         // Always emit an EXECUTION_KILLED event when isOnKillCascade=true.
         if (execution.getState().isTerminated() && !isOnKillCascade) {
-            throw new IllegalStateException("Cannot kill execution '%s'. Reason: Execution already terminated.".formatted(execution.getId()));
+            throw new ConflictException("Cannot kill execution: execution is already terminated.");
         }
 
         eventPublisher.publishEvent(CrudEvent.of(execution, execution.withState(State.Type.KILLING)));
@@ -1486,10 +1484,10 @@ public class ExecutionController {
         @Parameter(description = "\"Set a list of breakpoints at specific tasks 'id.value', separated by a coma.") @QueryValue Optional<String> breakpoints) throws Exception {
         Execution execution = executionService.getExecution(tenantService.resolveTenant(), executionId, true);
         if (!execution.getState().isBreakpoint()) {
-            throw new IllegalStateException("Execution is not suspended");
+            throw new ConflictException("Cannot resume execution: execution is not suspended.");
         }
         if (ListUtils.isEmpty(execution.getBreakpoints())) {
-            throw new IllegalStateException("Execution has no breakpoint");
+            throw new ConflictException("Cannot resume execution: no breakpoint defined.");
         }
 
         return awaitBlockingAction(
@@ -1584,7 +1582,7 @@ public class ExecutionController {
         @Parameter(description = "The execution id") @PathVariable String executionId) throws Exception {
         Execution execution = executionRepository.findById(tenantService.resolveTenant(), executionId).orElseThrow(NotFoundException::new);
         if (!execution.getState().isRunning()) {
-            throw new IllegalArgumentException("The execution is not running");
+            throw new ConflictException("Cannot pause execution: execution is not running.");
         }
 
         return awaitBlockingAction(
@@ -2008,7 +2006,7 @@ public class ExecutionController {
         Execution execution = executionRepository.findById(tenantService.resolveTenant(), executionId).orElseThrow(NotFoundException::new);
 
         if (execution.getState().getCurrent() != State.Type.QUEUED) {
-            throw new IllegalArgumentException("Only QUEUED execution can be unqueued");
+            throw new ConflictException("Cannot unqueue execution: only QUEUED executions can be unqueued.");
         }
 
         return awaitBlockingAction(
@@ -2097,7 +2095,7 @@ public class ExecutionController {
         Execution execution = executionRepository.findById(tenantService.resolveTenant(), executionId).orElseThrow(NotFoundException::new);
 
         if (execution.getState().isTerminated()) {
-            throw new IllegalArgumentException("Only non terminated executions can be forced run.");
+            throw new ConflictException("Cannot force run execution: only non-terminated executions can be force run.");
         }
 
         return awaitBlockingAction(

--- a/webserver/src/test/java/io/kestra/webserver/controllers/api/ExecutionControllerRunnerTest.java
+++ b/webserver/src/test/java/io/kestra/webserver/controllers/api/ExecutionControllerRunnerTest.java
@@ -500,7 +500,7 @@ class ExecutionControllerRunnerTest {
 
         assertThat(e.getStatus().getCode()).isEqualTo(HttpStatus.CONFLICT.getCode());
         assertThat(e.getResponse().getBody(String.class).isPresent()).isTrue();
-        assertThat(e.getResponse().getBody(String.class).get()).contains("Execution must be terminated or paused to be restarted, current state is 'SUCCESS'");
+        assertThat(e.getResponse().getBody(String.class).get()).contains("Cannot restart execution: current state is 'SUCCESS', expected terminated or paused.");
     }
 
     @Test
@@ -1343,8 +1343,8 @@ class ExecutionControllerRunnerTest {
             )
         );
 
-        assertThat(e.getStatus().getCode()).isEqualTo(HttpStatus.UNPROCESSABLE_ENTITY.getCode());
-        assertThat(e.getMessage()).contains("Illegal argument: You can only change the state of a terminated non killed execution.");
+        assertThat(e.getStatus().getCode()).isEqualTo(HttpStatus.CONFLICT.getCode());
+        assertThat(e.getMessage()).contains("Conflict: Cannot change execution state: execution must be terminated and not killed.");
 
         e = assertThrows(
             HttpClientResponseException.class,
@@ -1389,10 +1389,10 @@ class ExecutionControllerRunnerTest {
             )
         );
 
-        assertThat(e.getStatus().getCode()).isEqualTo(HttpStatus.UNPROCESSABLE_ENTITY.getCode());
+        assertThat(e.getStatus().getCode()).isEqualTo(HttpStatus.CONFLICT.getCode());
         bulkErrorResponse = e.getResponse().getBody(String.class);
         assertThat(bulkErrorResponse).isPresent();
-        assertThat(bulkErrorResponse.get()).contains("You can only change the state of a task run for a terminated non killed execution.");
+        assertThat(bulkErrorResponse.get()).contains("Cannot change task run state: execution must be terminated and not killed.");
     }
 
     @Test
@@ -1916,7 +1916,7 @@ class ExecutionControllerRunnerTest {
         Execution completed = runnerUtils.runOne(TENANT_ID, TESTS_FLOW_NS, "minimal");
 
         var notRunning = assertThrows(HttpClientResponseException.class, () -> client.toBlocking().exchange(HttpRequest.POST("/api/v1/main/executions/" + completed.getId() + "/pause", null)));
-        assertThat(notRunning.getStatus().getCode()).isEqualTo(HttpStatus.UNPROCESSABLE_ENTITY.getCode());
+        assertThat(notRunning.getStatus().getCode()).isEqualTo(HttpStatus.CONFLICT.getCode());
     }
 
     @Test
@@ -2021,7 +2021,7 @@ class ExecutionControllerRunnerTest {
         var notRunning = assertThrows(
             HttpClientResponseException.class, () -> client.toBlocking().exchange(HttpRequest.POST("/api/v1/" + tenantId + "/executions/" + completed.getId() + "/unqueue", null))
         );
-        assertThat(notRunning.getStatus().getCode()).isEqualTo(HttpStatus.UNPROCESSABLE_ENTITY.getCode());
+        assertThat(notRunning.getStatus().getCode()).isEqualTo(HttpStatus.CONFLICT.getCode());
     }
 
     @Test
@@ -2108,7 +2108,7 @@ class ExecutionControllerRunnerTest {
         var notRunning = assertThrows(
             HttpClientResponseException.class, () -> client.toBlocking().exchange(HttpRequest.POST("/api/v1/%s/executions/".formatted(tenantId) + completed.getId() + "/force-run", null))
         );
-        assertThat(notRunning.getStatus().getCode()).isEqualTo(HttpStatus.UNPROCESSABLE_ENTITY.getCode());
+        assertThat(notRunning.getStatus().getCode()).isEqualTo(HttpStatus.CONFLICT.getCode());
     }
 
     @Test
@@ -2639,7 +2639,7 @@ class ExecutionControllerRunnerTest {
         );
 
         assertThat(e.getStatus().getCode()).isEqualTo(HttpStatus.CONFLICT.getCode());
-        assertThat(e.getMessage()).contains("Execution must be terminated or paused to be restarted, current state is 'KILLED'");
+        assertThat(e.getMessage()).contains("Cannot restart execution: current state is 'KILLED', expected terminated or paused.");
 
         e = assertThrows(
             HttpClientResponseException.class,


### PR DESCRIPTION
State-mutating endpoints (restart, pause, force-run, kill, resume, unqueue, change-status, ...) inconsistently threw IllegalStateException (mapped to 409) or IllegalArgumentException (mapped to 422) when the execution was in the wrong state. Replace those with ConflictException so all state conflicts return 409, and normalize the error messages to a consistent "Cannot <action>: <reason>." format.