### PR TITLE
[backport releases/v1.3.x] fix(backup): add findDistinctNamespace to KV and namespace-file metadata repos (#15873)

### DIFF
--- a/core/src/main/java/io/kestra/core/repositories/KvMetadataRepositoryInterface.java
+++ b/core/src/main/java/io/kestra/core/repositories/KvMetadataRepositoryInterface.java
@@ -3,6 +3,7 @@ package io.kestra.core.repositories;
 import java.io.IOException;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 import io.kestra.core.models.FetchVersion;
 import io.kestra.core.models.QueryFilter;
@@ -11,6 +12,8 @@ import io.kestra.core.models.kv.PersistedKvMetadata;
 import io.micronaut.data.model.Pageable;
 
 public interface KvMetadataRepositoryInterface extends SaveRepositoryInterface<PersistedKvMetadata> {
+    Set<String> findDistinctNamespace(String tenantId);
+
     Optional<PersistedKvMetadata> findByName(
         String tenantId,
         String namespace,

--- a/core/src/main/java/io/kestra/core/repositories/NamespaceFileMetadataRepositoryInterface.java
+++ b/core/src/main/java/io/kestra/core/repositories/NamespaceFileMetadataRepositoryInterface.java
@@ -3,6 +3,7 @@ package io.kestra.core.repositories;
 import java.io.IOException;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 import io.kestra.core.models.FetchVersion;
 import io.kestra.core.models.QueryFilter;
@@ -11,6 +12,8 @@ import io.kestra.core.models.namespaces.files.NamespaceFileMetadata;
 import io.micronaut.data.model.Pageable;
 
 public interface NamespaceFileMetadataRepositoryInterface extends SaveRepositoryInterface<NamespaceFileMetadata> {
+    Set<String> findDistinctNamespace(String tenantId);
+
     Optional<NamespaceFileMetadata> findByPath(
         String tenantId,
         String namespace,

--- a/core/src/test/java/io/kestra/core/repositories/AbstractKvMetadataRepositoryTest.java
+++ b/core/src/test/java/io/kestra/core/repositories/AbstractKvMetadataRepositoryTest.java
@@ -6,6 +6,7 @@ import java.time.temporal.ChronoUnit;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Stream;
 
 import org.junit.jupiter.api.Test;
@@ -260,6 +261,24 @@ public abstract class AbstractKvMetadataRepositoryTest {
         assertThat(purgedAmount).isEqualTo(2);
 
         assertThat(kvMetadataRepositoryInterface.findByName(tenantId, namespace, key).isPresent()).isFalse();
+    }
+
+    @Test
+    void findDistinctNamespace() throws IOException {
+        String tenantId = TestsUtils.randomTenant();
+        String namespace1 = TestsUtils.randomNamespace();
+        String namespace2 = TestsUtils.randomNamespace();
+        String deletedNamespace = TestsUtils.randomNamespace();
+
+        kvMetadataRepositoryInterface.save(buildTestKvDescription(tenantId, namespace1, "key1"));
+        kvMetadataRepositoryInterface.save(buildTestKvDescription(tenantId, namespace2, "key2"));
+        PersistedKvMetadata deletedEntry = kvMetadataRepositoryInterface.save(buildTestKvDescription(tenantId, deletedNamespace, "key3"));
+        kvMetadataRepositoryInterface.delete(deletedEntry);
+
+        Set<String> namespaces = kvMetadataRepositoryInterface.findDistinctNamespace(tenantId);
+
+        assertThat(namespaces).containsExactlyInAnyOrder(namespace1, namespace2);
+        assertThat(namespaces).doesNotContain(deletedNamespace);
     }
 
     protected static PersistedKvMetadata buildTestKvDescription(String tenantId, String namespace, String key) {

--- a/core/src/test/java/io/kestra/core/repositories/AbstractNamespaceFileMetadataRepositoryTest.java
+++ b/core/src/test/java/io/kestra/core/repositories/AbstractNamespaceFileMetadataRepositoryTest.java
@@ -5,6 +5,7 @@ import java.time.Instant;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Stream;
 
 import org.junit.jupiter.api.Test;
@@ -314,6 +315,27 @@ public abstract class AbstractNamespaceFileMetadataRepositoryTest {
         Instant now = Instant.now();
         assertThat(result.stream().map(nsFileMetadata -> nsFileMetadata.toBuilder().created(now).updated(null).build()).toList())
             .containsExactlyInAnyOrderElementsOf(expected.stream().map(nsFileMetadata -> nsFileMetadata.toBuilder().created(now).updated(null).build()).toList());
+    }
+
+    @Test
+    void findDistinctNamespace() throws IOException {
+        String tenantId = TestsUtils.randomTenant();
+        String namespace1 = TestsUtils.randomNamespace();
+        String namespace2 = TestsUtils.randomNamespace();
+        String deletedNamespace = TestsUtils.randomNamespace();
+
+        namespaceFileMetadataRepositoryInterface.save(NamespaceFileMetadata.builder()
+            .tenantId(tenantId).namespace(namespace1).path("file1.txt").size(1L).build());
+        namespaceFileMetadataRepositoryInterface.save(NamespaceFileMetadata.builder()
+            .tenantId(tenantId).namespace(namespace2).path("file2.txt").size(1L).build());
+        NamespaceFileMetadata deletedEntry = namespaceFileMetadataRepositoryInterface.save(NamespaceFileMetadata.builder()
+            .tenantId(tenantId).namespace(deletedNamespace).path("file3.txt").size(1L).build());
+        namespaceFileMetadataRepositoryInterface.delete(deletedEntry);
+
+        Set<String> namespaces = namespaceFileMetadataRepositoryInterface.findDistinctNamespace(tenantId);
+
+        assertThat(namespaces).containsExactlyInAnyOrder(namespace1, namespace2);
+        assertThat(namespaces).doesNotContain(deletedNamespace);
     }
 
     @Test

--- a/jdbc/src/main/java/io/kestra/jdbc/repository/AbstractJdbcKvMetadataRepository.java
+++ b/jdbc/src/main/java/io/kestra/jdbc/repository/AbstractJdbcKvMetadataRepository.java
@@ -42,6 +42,23 @@ public abstract class AbstractJdbcKvMetadataRepository extends AbstractJdbcCrudR
     }
 
     @Override
+    public Set<String> findDistinctNamespace(String tenantId) {
+        return this.jdbcRepository
+            .getDslContextWrapper()
+            .transactionResult(
+                configuration -> new HashSet<>(DSL
+                    .using(configuration)
+                    .select(field("namespace"))
+                    .from(this.jdbcRepository.getTable())
+                    .where(this.defaultFilter(tenantId, false))
+                    .and(lastCondition())
+                    .groupBy(field("namespace"))
+                    .fetch()
+                    .map(record -> record.getValue("namespace", String.class)))
+            );
+    }
+
+    @Override
     public Optional<PersistedKvMetadata> findByName(String tenantId, String namespace, String name) {
         var condition = field("namespace").eq(namespace)
             .and(field("name").eq(name))

--- a/jdbc/src/main/java/io/kestra/jdbc/repository/AbstractJdbcNamespaceFileMetadataRepository.java
+++ b/jdbc/src/main/java/io/kestra/jdbc/repository/AbstractJdbcNamespaceFileMetadataRepository.java
@@ -1,9 +1,11 @@
 package io.kestra.jdbc.repository;
 
 import java.time.Instant;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -42,6 +44,23 @@ public abstract class AbstractJdbcNamespaceFileMetadataRepository extends Abstra
     @Override
     protected Condition findQueryCondition(String query) {
         return findCondition(query);
+    }
+
+    @Override
+    public Set<String> findDistinctNamespace(String tenantId) {
+        return this.jdbcRepository
+            .getDslContextWrapper()
+            .transactionResult(
+                configuration -> new HashSet<>(DSL
+                    .using(configuration)
+                    .select(field("namespace"))
+                    .from(this.jdbcRepository.getTable())
+                    .where(this.defaultFilter(tenantId, false))
+                    .and(lastCondition())
+                    .groupBy(field("namespace"))
+                    .fetch()
+                    .map(record -> record.getValue("namespace", String.class)))
+            );
     }
 
     @Override


### PR DESCRIPTION
Backport of kestra-io/kestra#15873 — fix(backup): add findDistinctNamespace to KV and namespace-file metadata repos (cherry-picked from a145a3ea53fbe459d03333b231f85a482dbb19fc).