### PR TITLE
  fix(scheduler): honor recover missed schedules on trigger re-enable

### DIFF
--- a/scheduler/src/main/java/io/kestra/scheduler/TriggerEventHandler.java
+++ b/scheduler/src/main/java/io/kestra/scheduler/TriggerEventHandler.java
@@ -20,6 +20,8 @@ import io.kestra.core.models.flows.FlowWithSource;
 import io.kestra.core.models.triggers.AbstractTrigger;
 import io.kestra.core.models.triggers.Backfill;
 import io.kestra.core.models.triggers.PollingTriggerInterface;
+import io.kestra.core.models.triggers.RecoverMissedSchedules;
+import io.kestra.core.models.triggers.Schedulable;
 import io.kestra.core.queues.BroadcastQueueInterface;
 import io.kestra.core.queues.QueueException;
 import io.kestra.core.runners.RunContext;
@@ -197,16 +199,50 @@ public class TriggerEventHandler {
             state = state
                 .lastEventId(clock, event.eventId())
                 .disabled(clock, event.disabled());
-            // if the trigger is re-enabled, re-compute the next evaluation date
-            // this is required to not backfill all missed scheduling after re-enabling trigger.
             if (wasDisabled && !event.disabled()) {
                 Pair<Flow, AbstractTrigger> data = findTrigger(event, null);
-                if (data.getRight() != null) {
-                    state = state.updateForNextEvaluationDate(clock, NextEvaluationDate.get(clock, data.getRight()));
+                Flow flow = data.getLeft();
+                AbstractTrigger trigger = data.getRight();
+                if (flow != null && trigger != null) {
+                    state = updateStateForReEnabledTrigger(clock, state, flow, trigger);
                 }
             }
             triggerStateStore.save(state);
         });
+    }
+
+    private TriggerState updateStateForReEnabledTrigger(Clock clock, TriggerState state, Flow flow, AbstractTrigger trigger) {
+        if (!(trigger instanceof Schedulable schedulableTrigger)) {
+            return state.updateForNextEvaluationDate(clock, NextEvaluationDate.get(clock, trigger));
+        }
+
+        RunContext runContext = runContextFactory.of(flow, trigger);
+        ConditionContext conditionContext = conditionService.conditionContext(runContext, flow, null);
+        RecoverMissedSchedules recoverMissedSchedules = Optional.ofNullable(schedulableTrigger.getRecoverMissedSchedules())
+            .orElseGet(() -> schedulableTrigger.defaultRecoverMissedSchedules(runContext));
+
+        try {
+            return switch (recoverMissedSchedules) {
+                case NONE -> state.updateForNextEvaluationDate(clock, schedulableTrigger.nextEvaluationDate());
+                case LAST -> state.updateForNextEvaluationDate(clock, schedulableTrigger.previousEvaluationDate(conditionContext));
+                case ALL -> {
+                    if (state.getNextEvaluationDate() == null) {
+                        yield state.updateForNextEvaluationDate(clock, NextEvaluationDate.get(clock, trigger, state.context(), conditionContext));
+                    }
+                    yield state;
+                }
+            };
+        } catch (Exception e) {
+            Logs.logExecution(
+                flow,
+                runContext.logger(),
+                Level.WARN,
+                "[trigger: {}] Unable to restore recoverMissedSchedules behavior on re-enable, falling back to next evaluation from now",
+                trigger.getId(),
+                e
+            );
+            return state.updateForNextEvaluationDate(clock, NextEvaluationDate.get(clock, trigger));
+        }
     }
 
     /**

--- a/scheduler/src/test/java/io/kestra/scheduler/TriggerEventHandlerTest.java
+++ b/scheduler/src/test/java/io/kestra/scheduler/TriggerEventHandlerTest.java
@@ -14,9 +14,13 @@ import io.kestra.core.models.executions.ExecutionKilled;
 import io.kestra.core.models.flows.FlowWithSource;
 import io.kestra.core.models.flows.State;
 import io.kestra.core.models.triggers.Backfill;
+import io.kestra.core.models.triggers.RecoverMissedSchedules;
+import io.kestra.core.models.triggers.Schedulable;
+import io.kestra.core.models.triggers.TriggerEvaluationResult;
 import io.kestra.core.models.triggers.TriggerId;
 import io.kestra.core.queues.BroadcastQueueInterface;
 import io.kestra.core.queues.QueueException;
+import io.kestra.core.runners.RunContext;
 import io.kestra.core.runners.RunContextFactory;
 import io.kestra.core.scheduler.SchedulerClock;
 import io.kestra.core.scheduler.events.CreateBackfillTrigger;
@@ -33,7 +37,6 @@ import io.kestra.core.scheduler.model.TriggerState;
 import io.kestra.core.scheduler.model.TriggerType;
 import io.kestra.core.services.ConditionService;
 import io.kestra.core.utils.IdUtils;
-import io.kestra.core.models.triggers.TriggerEvaluationResult;
 import io.kestra.scheduler.utils.CollectorTriggerExecutionPublisher;
 import io.kestra.scheduler.utils.InMemoryFlowMetaStore;
 import io.kestra.scheduler.utils.InMemoryTriggerStateStore;
@@ -208,10 +211,13 @@ class TriggerEventHandlerTest {
     @Test
     void shouldUpdateNextEvaluationDateWhenReEnablingTrigger() {
         // GIVEN
+        FlowWithSource flow = Fixtures.defaultFlow(builder -> builder
+            .recoverMissedSchedules(RecoverMissedSchedules.NONE)
+            .build());
         ZonedDateTime initialNextEvaluationDate = SchedulerClock.now().minusMinutes(30);
         triggerStateStore.save(triggerState.updateForNextEvaluationDate(CLOCK, initialNextEvaluationDate).disabled(CLOCK, true));
 
-        handler = newTriggerEventHandler(List.of(Fixtures.defaultFlow()));
+        handler = newTriggerEventHandler(List.of(flow));
         SetDisableTrigger event = new SetDisableTrigger(triggerId, false);
 
         // WHEN
@@ -223,6 +229,53 @@ class TriggerEventHandlerTest {
         assertThat(updated.get().isDisabled()).isFalse();
         assertThat(updated.get().getUpdatedAt()).isAfter(triggerState.getUpdatedAt());
         assertThat(updated.get().getNextEvaluationDate()).isAfter(initialNextEvaluationDate.toInstant());
+        assertThat(updated.get().getLastEventId()).isEqualTo(event.eventId());
+    }
+
+    @Test
+    void shouldRecoverOnlyLastMissedScheduleWhenReEnablingTrigger() throws Exception {
+        // GIVEN
+        FlowWithSource flow = Fixtures.defaultFlow(builder -> builder
+            .recoverMissedSchedules(RecoverMissedSchedules.LAST)
+            .build());
+        ZonedDateTime initialNextEvaluationDate = SchedulerClock.now().minusHours(1);
+        triggerStateStore.save(triggerState.updateForNextEvaluationDate(CLOCK, initialNextEvaluationDate).disabled(CLOCK, true));
+
+        handler = newTriggerEventHandler(List.of(flow));
+        SetDisableTrigger event = new SetDisableTrigger(triggerId, false);
+
+        // WHEN
+        handler.handle(CLOCK, TEST_VNODE, event);
+
+        // THEN
+        Optional<TriggerState> updated = triggerStateStore.findById(triggerId);
+        ZonedDateTime expectedPreviousDate = schedulableTrigger(flow).previousEvaluationDate(conditionContext(flow));
+        assertThat(updated).isPresent();
+        assertThat(updated.get().isDisabled()).isFalse();
+        assertThat(updated.get().getNextEvaluationDate()).isEqualTo(expectedPreviousDate.toInstant());
+        assertThat(updated.get().getLastEventId()).isEqualTo(event.eventId());
+    }
+
+    @Test
+    void shouldPreserveBacklogWhenReEnablingTriggerConfiguredWithAll() {
+        // GIVEN
+        FlowWithSource flow = Fixtures.defaultFlow(builder -> builder
+            .recoverMissedSchedules(RecoverMissedSchedules.ALL)
+            .build());
+        ZonedDateTime initialNextEvaluationDate = SchedulerClock.now().minusHours(1);
+        triggerStateStore.save(triggerState.updateForNextEvaluationDate(CLOCK, initialNextEvaluationDate).disabled(CLOCK, true));
+
+        handler = newTriggerEventHandler(List.of(flow));
+        SetDisableTrigger event = new SetDisableTrigger(triggerId, false);
+
+        // WHEN
+        handler.handle(CLOCK, TEST_VNODE, event);
+
+        // THEN
+        Optional<TriggerState> updated = triggerStateStore.findById(triggerId);
+        assertThat(updated).isPresent();
+        assertThat(updated.get().isDisabled()).isFalse();
+        assertThat(updated.get().getNextEvaluationDate()).isEqualTo(initialNextEvaluationDate.toInstant());
         assertThat(updated.get().getLastEventId()).isEqualTo(event.eventId());
     }
 
@@ -477,5 +530,14 @@ class TriggerEventHandlerTest {
         assertThat(updated).get().extracting(TriggerState::getBackfill).isNull();
         assertThat(updated).get().extracting(TriggerState::getNextEvaluationDate).isEqualTo(previousNextEvaluationDate.toInstant());
         assertThat(updated).get().extracting(TriggerState::getLastEventId).isEqualTo(event.eventId());
+    }
+
+    private Schedulable schedulableTrigger(FlowWithSource flow) {
+        return (Schedulable) flow.getTriggers().getFirst();
+    }
+
+    private io.kestra.core.models.conditions.ConditionContext conditionContext(FlowWithSource flow) {
+        RunContext runContext = runContextFactory.of(flow, flow.getTriggers().getFirst());
+        return conditionService.conditionContext(runContext, flow, null);
     }
 }


### PR DESCRIPTION
## What changed

  This fixes schedule trigger re-enable behavior so it respects
  `recoverMissedSchedules` instead of always recomputing from the current
  time.

  When a disabled trigger is re-enabled:
  - `NONE` resumes from the next future evaluation
  - `LAST` restores only the last missed schedule
  - `ALL` preserves the backlog behavior

  ## Why

  Issue Fixes #14349 reports that disabling and re-enabling a schedule trigger
  ignores `recoverMissedSchedules`.

  On `develop`, the scheduler had already been changed to avoid replaying
  every missed run, but re-enable still did not respect the configured
  recovery mode. It always recomputed the next evaluation date from the
  generic re-enable path.

  This change applies the configured `recoverMissedSchedules` behavior
  during trigger re-enable.

  ## Testing

  Ran:
  - `./gradlew :scheduler:test --tests
  io.kestra.scheduler.TriggerEventHandlerTest`

  Added coverage for:
  - re-enable with `NONE`
  - re-enable with `LAST`
  - re-enable with `ALL`

  Fixes #14349