### PR TITLE
fix(topology): publish workflow for topology package

### DIFF
--- a/.github/workflows/publish-design-system.yml
+++ b/.github/workflows/publish-design-system.yml
@@ -65,6 +65,7 @@ jobs:
         run: npm ci
 
       - name: Install Playwright browsers
+        if: inputs.skip-test != 'true' && inputs.package == 'design-system'
         run: npx playwright install --with-deps chromium
 
       - name: Run tests
@@ -112,4 +113,4 @@ jobs:
         run: npm publish --workspace @kestra-io/${{ inputs.package }} --access public
       
       - name: Create release tarball
-        run: npm pack --workspace @kestra-io/${{ inputs.package }} --pack-destination packages/design-system
+        run: npm pack --workspace @kestra-io/${{ inputs.package }} --pack-destination packages/${{ inputs.package }}


### PR DESCRIPTION
Workflow improvements:

* Added a condition to the "Install Playwright browsers" step so that browsers are only installed when tests are not skipped and the selected package is `design-system`.

Packaging fix:

* Updated the "Create release tarball" step to place the tarball in the correct package directory based on the input package name, instead of always using the `design-system` directory.