### PR TITLE
[backport releases/v1.3.x] fix(copilot): NPE in AI Copilot telemetry listeners

### DIFF
--- a/webserver/src/main/java/io/kestra/webserver/services/ai/AiService.java
+++ b/webserver/src/main/java/io/kestra/webserver/services/ai/AiService.java
@@ -3,6 +3,7 @@ package io.kestra.webserver.services.ai;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -181,7 +182,7 @@ public abstract class AiService<T extends AiConfiguration> implements AiServiceI
             return null;
         }
         String parentSpanId = IdUtils.create();
-        String uid = userInfo.uid();
+        String uid = Objects.requireNonNullElse(userInfo.uid(), "api-call");
         this.postHogService.capture(
             uid, "$ai_trace", Map.of(
                 "$ai_trace_id", conversationId,

--- a/webserver/src/main/java/io/kestra/webserver/services/ai/MetadataAppenderChatModelListener.java
+++ b/webserver/src/main/java/io/kestra/webserver/services/ai/MetadataAppenderChatModelListener.java
@@ -1,12 +1,15 @@
 package io.kestra.webserver.services.ai;
 
 import java.util.Map;
+import java.util.Objects;
 import java.util.function.Supplier;
 
 import dev.langchain4j.model.chat.listener.ChatModelListener;
 import dev.langchain4j.model.chat.listener.ChatModelRequestContext;
 import io.micrometer.core.instrument.Clock;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 public record MetadataAppenderChatModelListener(String instanceUid, String provider, String spanName, String baseUrl,
     Supplier<AiService.ConversationMetadata> conversationMetadataGetter) implements ChatModelListener {
 
@@ -23,6 +26,10 @@ public record MetadataAppenderChatModelListener(String instanceUid, String provi
     @Override
     public void onRequest(ChatModelRequestContext requestContext) {
         AiService.ConversationMetadata conversationMetadata = conversationMetadataGetter().get();
+        if (conversationMetadata == null) {
+            log.warn("No conversation metadata found for span '{}', skipping attribute population", this.spanName());
+            return;
+        }
         requestContext.attributes().putAll(
             Map.of(
                 PARENT_ID, conversationMetadata.parentSpanId(),
@@ -30,9 +37,9 @@ public record MetadataAppenderChatModelListener(String instanceUid, String provi
                 START_TIME_KEY_NAME, Clock.SYSTEM.monotonicTime(),
                 CONVERSATION_ID, conversationMetadata.conversationId(),
                 PROVIDER, this.provider(),
-                IP, conversationMetadata.ip(),
+                IP, Objects.requireNonNullElse(conversationMetadata.ip(), ""),
                 INSTANCE_UID, this.instanceUid(),
-                USER_UID, conversationMetadata.uid()
+                USER_UID, Objects.requireNonNullElse(conversationMetadata.uid(), "api-call")
             )
         );
         if (this.baseUrl() != null) {

--- a/webserver/src/main/java/io/kestra/webserver/services/ai/PosthogChatModelListener.java
+++ b/webserver/src/main/java/io/kestra/webserver/services/ai/PosthogChatModelListener.java
@@ -85,12 +85,18 @@ public class PosthogChatModelListener implements ChatModelListener {
     }
 
     private void send(Map<Object, Object> attributes, Map<String, Object> properties) {
-        properties.put("$ai_parent_id", attributes.get(MetadataAppenderChatModelListener.PARENT_ID).toString());
+        Object parentId = attributes.get(MetadataAppenderChatModelListener.PARENT_ID);
+        if (parentId == null) {
+            log.warn("No parent ID found in attributes, skipping PostHog event");
+            return;
+        }
+        properties.put("$ai_parent_id", parentId.toString());
         properties.put("$ai_span_name", attributes.get(MetadataAppenderChatModelListener.SPAN_NAME));
         properties.put("$ai_span_id", IdUtils.create());
 
+        Object rawUid = attributes.get(MetadataAppenderChatModelListener.USER_UID);
         posthogService.capture(
-            attributes.get(MetadataAppenderChatModelListener.USER_UID).toString(),
+            rawUid != null ? rawUid.toString() : "api-call",
             "$ai_generation",
             properties
         );
@@ -107,8 +113,9 @@ public class PosthogChatModelListener implements ChatModelListener {
             properties.put("$ai_base_url", attributes.get(MetadataAppenderChatModelListener.BASE_URL));
         }
 
-        if (attributes.containsKey(MetadataAppenderChatModelListener.IP)) {
-            properties.put("$ip", attributes.get(MetadataAppenderChatModelListener.IP));
+        Object ip = attributes.get(MetadataAppenderChatModelListener.IP);
+        if (ip instanceof String ipStr && !ipStr.isBlank()) {
+            properties.put("$ip", ipStr);
         }
 
         Map<String, Object> parameters = Maps.newHashMap();

--- a/webserver/src/main/java/io/kestra/webserver/services/ai/PosthogChatModelListener.java
+++ b/webserver/src/main/java/io/kestra/webserver/services/ai/PosthogChatModelListener.java
@@ -11,6 +11,7 @@ import io.kestra.webserver.services.posthog.PosthogService;
 
 import dev.langchain4j.data.message.AiMessage;
 import dev.langchain4j.data.message.SystemMessage;
+import dev.langchain4j.data.message.ToolExecutionResultMessage;
 import dev.langchain4j.data.message.UserMessage;
 import dev.langchain4j.model.chat.listener.ChatModelErrorContext;
 import dev.langchain4j.model.chat.listener.ChatModelListener;
@@ -39,11 +40,17 @@ public class PosthogChatModelListener implements ChatModelListener {
         properties.put("$ai_http_status", 200);
         properties.put("$ai_response_id", response.metadata().id());
 
+        AiMessage aiMessage = response.aiMessage();
+        // Intermediate tool-call responses are captured in the inputs of the final generation — skip them.
+        if (aiMessage.hasToolExecutionRequests()) {
+            return;
+        }
+
         properties.put("$ai_input", inputs(request));
         properties.put(
             "$ai_output_choices", Map.of(
                 "content", Map.of(
-                    "text", response.aiMessage().text(),
+                    "text", Optional.ofNullable(aiMessage.text()).orElse(""),
                     "type", "text"
                 ),
                 "role", "assistant"
@@ -144,11 +151,16 @@ public class PosthogChatModelListener implements ChatModelListener {
             .stream()
             .map(chatMessage ->
             {
-                if (chatMessage instanceof AiMessage aiMessage) {
-                    return Map.of(
-                        "role", "assistant",
-                        "content", aiMessage.text()
-                    );
+                if (chatMessage instanceof AiMessage msg) {
+                    String content = msg.hasToolExecutionRequests()
+                        ? msg.toolExecutionRequests().stream()
+                            .map(req -> req.name() + "(" + req.arguments() + ")")
+                            .reduce((a, b) -> a + ", " + b)
+                            .orElse("")
+                        : Optional.ofNullable(msg.text()).orElse("");
+                    return Map.of("role", "assistant", "content", content);
+                } else if (chatMessage instanceof ToolExecutionResultMessage msg) {
+                    return Map.of("role", "tool", "content", Optional.ofNullable(msg.text()).orElse(""));
                 } else if (chatMessage instanceof UserMessage userMessage) {
                     return Map.of(
                         "role", "user",

--- a/webserver/src/test/java/io/kestra/webserver/services/ai/MetadataAppenderChatModelListenerTest.java
+++ b/webserver/src/test/java/io/kestra/webserver/services/ai/MetadataAppenderChatModelListenerTest.java
@@ -1,71 +1,73 @@
 package io.kestra.webserver.services.ai;
 
-import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import dev.langchain4j.model.chat.listener.ChatModelRequestContext;
 
 import org.junit.jupiter.api.Test;
 
-import java.util.HashMap;
-
-import dev.langchain4j.data.message.UserMessage;
-import dev.langchain4j.model.chat.listener.ChatModelRequestContext;
-import dev.langchain4j.model.chat.request.ChatRequest;
-
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 class MetadataAppenderChatModelListenerTest {
 
     @Test
-    void shouldPopulateAttributesWithUserUid() {
+    void shouldNotThrowWhenIpIsNull() {
         // Given
         AiService.ConversationMetadata metadata = new AiService.ConversationMetadata(
-            "conv-1", "192.168.1.1", "parent-span-1", "browser-uid-123"
+            "conv-id", null, "parent-id", "user-uid"
         );
         MetadataAppenderChatModelListener listener = new MetadataAppenderChatModelListener(
-            "instance-uid-456", "google", "FlowGeneration", null, () -> metadata
+            "instance-uid", "openai", "FlowYamlBuilder", null, () -> metadata
         );
+        Map<Object, Object> attributes = new ConcurrentHashMap<>();
+        ChatModelRequestContext requestContext = mock(ChatModelRequestContext.class);
+        when(requestContext.attributes()).thenReturn(attributes);
 
-        ChatRequest request = ChatRequest.builder()
-            .messages(List.of(UserMessage.from("test")))
-            .modelName("gemini-2.0-flash")
-            .build();
-        ChatModelRequestContext requestContext = new ChatModelRequestContext(request, null, new HashMap<>());
-
-        // When
-        listener.onRequest(requestContext);
-
-        // Then
-        assertThat(requestContext.attributes())
-            .containsEntry(MetadataAppenderChatModelListener.USER_UID, "browser-uid-123")
-            .containsEntry(MetadataAppenderChatModelListener.INSTANCE_UID, "instance-uid-456")
-            .containsEntry(MetadataAppenderChatModelListener.CONVERSATION_ID, "conv-1")
-            .containsEntry(MetadataAppenderChatModelListener.IP, "192.168.1.1")
-            .containsEntry(MetadataAppenderChatModelListener.PARENT_ID, "parent-span-1")
-            .containsEntry(MetadataAppenderChatModelListener.SPAN_NAME, "FlowGeneration")
-            .containsEntry(MetadataAppenderChatModelListener.PROVIDER, "google")
-            .doesNotContainKey(MetadataAppenderChatModelListener.BASE_URL);
+        // When/Then
+        assertThatCode(() -> listener.onRequest(requestContext)).doesNotThrowAnyException();
+        assertThat(attributes.get(MetadataAppenderChatModelListener.IP)).isEqualTo("");
     }
 
     @Test
-    void shouldIncludeBaseUrlWhenProvided() {
+    void shouldNotThrowWhenConversationMetadataIsNull() {
+        // Given - metadata not yet stored (race or missing beforeGeneration call)
+        MetadataAppenderChatModelListener listener = new MetadataAppenderChatModelListener(
+            "instance-uid", "openai", "FlowYamlBuilder", null, () -> null
+        );
+        Map<Object, Object> attributes = new ConcurrentHashMap<>();
+        ChatModelRequestContext requestContext = mock(ChatModelRequestContext.class);
+        when(requestContext.attributes()).thenReturn(attributes);
+
+        // When/Then
+        assertThatCode(() -> listener.onRequest(requestContext)).doesNotThrowAnyException();
+        assertThat(attributes).isEmpty();
+    }
+
+    @Test
+    void shouldPopulateAttributesWithNonNullIp() {
         // Given
         AiService.ConversationMetadata metadata = new AiService.ConversationMetadata(
-            "conv-2", "10.0.0.1", "parent-span-2", "user-uid-789"
+            "conv-id", "127.0.0.1", "parent-id", "user-uid"
         );
         MetadataAppenderChatModelListener listener = new MetadataAppenderChatModelListener(
-            "instance-uid-456", "gemini", "FlowGeneration", "https://generativelanguage.googleapis.com", () -> metadata
+            "instance-uid", "openai", "FlowYamlBuilder", "http://base.url", () -> metadata
         );
-
-        ChatRequest request = ChatRequest.builder()
-            .messages(List.of(UserMessage.from("test")))
-            .modelName("gemini-2.0-flash")
-            .build();
-        ChatModelRequestContext requestContext = new ChatModelRequestContext(request, null, new HashMap<>());
+        Map<Object, Object> attributes = new ConcurrentHashMap<>();
+        ChatModelRequestContext requestContext = mock(ChatModelRequestContext.class);
+        when(requestContext.attributes()).thenReturn(attributes);
 
         // When
         listener.onRequest(requestContext);
 
         // Then
-        assertThat(requestContext.attributes())
-            .containsEntry(MetadataAppenderChatModelListener.BASE_URL, "https://generativelanguage.googleapis.com");
+        assertThat(attributes)
+            .containsEntry(MetadataAppenderChatModelListener.PARENT_ID, "parent-id")
+            .containsEntry(MetadataAppenderChatModelListener.IP, "127.0.0.1")
+            .containsEntry(MetadataAppenderChatModelListener.PROVIDER, "openai")
+            .containsEntry(MetadataAppenderChatModelListener.BASE_URL, "http://base.url");
     }
 }

--- a/webserver/src/test/java/io/kestra/webserver/services/ai/PosthogChatModelListenerTest.java
+++ b/webserver/src/test/java/io/kestra/webserver/services/ai/PosthogChatModelListenerTest.java
@@ -4,6 +4,15 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.model.chat.listener.ChatModelErrorContext;
+import dev.langchain4j.model.chat.listener.ChatModelResponseContext;
+import dev.langchain4j.model.chat.request.ChatRequest;
+import dev.langchain4j.model.chat.request.ChatRequestParameters;
+import dev.langchain4j.model.chat.response.ChatResponse;
+import dev.langchain4j.model.chat.response.ChatResponseMetadata;
+import io.kestra.webserver.services.posthog.PosthogService;
+
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
@@ -11,20 +20,15 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import dev.langchain4j.data.message.AiMessage;
-import dev.langchain4j.data.message.UserMessage;
-import dev.langchain4j.model.chat.listener.ChatModelResponseContext;
-import dev.langchain4j.model.chat.listener.ChatModelErrorContext;
-import dev.langchain4j.model.chat.request.ChatRequest;
-import dev.langchain4j.model.chat.response.ChatResponse;
-import dev.langchain4j.model.chat.response.ChatResponseMetadata;
-import dev.langchain4j.model.output.TokenUsage;
-import io.kestra.webserver.services.posthog.PosthogService;
-import io.micrometer.core.instrument.Clock;
-
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class PosthogChatModelListenerTest {
@@ -36,77 +40,178 @@ class PosthogChatModelListenerTest {
     private PosthogChatModelListener listener;
 
     @Test
-    void shouldUseUserUidAsDistinctIdOnResponse() {
+    void shouldNotThrowAndSkipCaptureWhenParentIdMissing() {
+        // Given - attributes with no PARENT_ID (simulates onRequest failure)
+        Map<Object, Object> attributes = new HashMap<>();
+
+        ChatRequestParameters params = mock(ChatRequestParameters.class);
+        ChatRequest chatRequest = mock(ChatRequest.class);
+        when(chatRequest.modelName()).thenReturn("gemini-2.0-flash");
+        when(chatRequest.parameters()).thenReturn(params);
+        when(chatRequest.messages()).thenReturn(List.of());
+
+        AiMessage aiMessage = mock(AiMessage.class);
+        when(aiMessage.hasToolExecutionRequests()).thenReturn(false);
+        when(aiMessage.text()).thenReturn("some response");
+
+        ChatResponseMetadata metadata = mock(ChatResponseMetadata.class);
+        when(metadata.id()).thenReturn("resp-id");
+
+        ChatResponse chatResponse = mock(ChatResponse.class);
+        when(chatResponse.aiMessage()).thenReturn(aiMessage);
+        when(chatResponse.metadata()).thenReturn(metadata);
+        when(chatResponse.tokenUsage()).thenReturn(null);
+
+        ChatModelResponseContext responseContext = mock(ChatModelResponseContext.class);
+        when(responseContext.chatRequest()).thenReturn(chatRequest);
+        when(responseContext.chatResponse()).thenReturn(chatResponse);
+        when(responseContext.attributes()).thenReturn(attributes);
+
+        // When/Then
+        assertThatCode(() -> listener.onResponse(responseContext)).doesNotThrowAnyException();
+        verify(posthogService, never()).capture(any(), any(), any());
+    }
+
+    @Test
+    void shouldCaptureWhenAllAttributesPresent() {
         // Given
         Map<Object, Object> attributes = new HashMap<>();
-        attributes.put(MetadataAppenderChatModelListener.USER_UID, "browser-uid-123");
-        attributes.put(MetadataAppenderChatModelListener.INSTANCE_UID, "instance-uid-456");
-        attributes.put(MetadataAppenderChatModelListener.CONVERSATION_ID, "conv-1");
-        attributes.put(MetadataAppenderChatModelListener.PARENT_ID, "parent-span-1");
-        attributes.put(MetadataAppenderChatModelListener.SPAN_NAME, "FlowGeneration");
-        attributes.put(MetadataAppenderChatModelListener.PROVIDER, "google");
-        attributes.put(MetadataAppenderChatModelListener.START_TIME_KEY_NAME, Clock.SYSTEM.monotonicTime());
+        attributes.put(MetadataAppenderChatModelListener.PARENT_ID, "parent-id");
+        attributes.put(MetadataAppenderChatModelListener.SPAN_NAME, "FlowYamlBuilder");
+        attributes.put(MetadataAppenderChatModelListener.CONVERSATION_ID, "conv-id");
+        attributes.put(MetadataAppenderChatModelListener.USER_UID, "user-uid");
 
-        ChatRequest request = ChatRequest.builder()
-            .messages(List.of(UserMessage.from("Generate a flow")))
-            .modelName("gemini-2.0-flash")
-            .build();
+        ChatRequestParameters params = mock(ChatRequestParameters.class);
+        ChatRequest chatRequest = mock(ChatRequest.class);
+        when(chatRequest.modelName()).thenReturn("gemini-2.0-flash");
+        when(chatRequest.parameters()).thenReturn(params);
+        when(chatRequest.messages()).thenReturn(List.of());
 
-        ChatResponse response = ChatResponse.builder()
-            .aiMessage(AiMessage.from("id: my-flow"))
-            .metadata(ChatResponseMetadata.builder().id("resp-1").tokenUsage(new TokenUsage(10, 20)).build())
-            .build();
+        AiMessage aiMessage = mock(AiMessage.class);
+        when(aiMessage.hasToolExecutionRequests()).thenReturn(false);
+        when(aiMessage.text()).thenReturn("generated yaml");
 
-        ChatModelResponseContext responseContext = new ChatModelResponseContext(response, request, null, attributes);
+        ChatResponseMetadata metadata = mock(ChatResponseMetadata.class);
+        when(metadata.id()).thenReturn("resp-id");
+
+        ChatResponse chatResponse = mock(ChatResponse.class);
+        when(chatResponse.aiMessage()).thenReturn(aiMessage);
+        when(chatResponse.metadata()).thenReturn(metadata);
+        when(chatResponse.tokenUsage()).thenReturn(null);
+
+        ChatModelResponseContext responseContext = mock(ChatModelResponseContext.class);
+        when(responseContext.chatRequest()).thenReturn(chatRequest);
+        when(responseContext.chatResponse()).thenReturn(chatResponse);
+        when(responseContext.attributes()).thenReturn(attributes);
 
         // When
         listener.onResponse(responseContext);
 
         // Then
-        ArgumentCaptor<String> distinctIdCaptor = ArgumentCaptor.forClass(String.class);
-        ArgumentCaptor<Map<String, Object>> propsCaptor = ArgumentCaptor.forClass(Map.class);
-        verify(posthogService).capture(distinctIdCaptor.capture(), eq("$ai_generation"), propsCaptor.capture());
-
-        assertThat(distinctIdCaptor.getValue()).isEqualTo("browser-uid-123");
-        assertThat(propsCaptor.getValue())
-            .containsEntry("$ai_trace_id", "conv-1")
-            .containsEntry("$ai_parent_id", "parent-span-1")
-            .containsEntry("$ai_model", "gemini-2.0-flash")
-            .containsEntry("$ai_input_tokens", 10)
-            .containsEntry("$ai_output_tokens", 20);
+        verify(posthogService, times(1)).capture(eq("user-uid"), eq("$ai_generation"), any());
     }
 
     @Test
-    void shouldUseUserUidAsDistinctIdOnError() {
+    void shouldNotThrowAndSkipCaptureOnErrorWhenParentIdMissing() {
         // Given
         Map<Object, Object> attributes = new HashMap<>();
-        attributes.put(MetadataAppenderChatModelListener.USER_UID, "browser-uid-123");
-        attributes.put(MetadataAppenderChatModelListener.INSTANCE_UID, "instance-uid-456");
-        attributes.put(MetadataAppenderChatModelListener.PARENT_ID, "parent-span-1");
-        attributes.put(MetadataAppenderChatModelListener.SPAN_NAME, "FlowGeneration");
-        attributes.put(MetadataAppenderChatModelListener.PROVIDER, "google");
-        attributes.put(MetadataAppenderChatModelListener.START_TIME_KEY_NAME, Clock.SYSTEM.monotonicTime());
 
-        ChatRequest request = ChatRequest.builder()
-            .messages(List.of(UserMessage.from("Generate a flow")))
-            .modelName("gemini-2.0-flash")
-            .build();
+        ChatRequestParameters params = mock(ChatRequestParameters.class);
+        ChatRequest chatRequest = mock(ChatRequest.class);
+        when(chatRequest.modelName()).thenReturn("gemini-2.0-flash");
+        when(chatRequest.parameters()).thenReturn(params);
 
-        ChatModelErrorContext errorContext = new ChatModelErrorContext(
-            new RuntimeException("API error"), request, null, attributes
-        );
+        ChatModelErrorContext errorContext = mock(ChatModelErrorContext.class);
+        when(errorContext.chatRequest()).thenReturn(chatRequest);
+        when(errorContext.error()).thenReturn(new RuntimeException("LLM error"));
+        when(errorContext.attributes()).thenReturn(attributes);
+
+        // When/Then
+        assertThatCode(() -> listener.onError(errorContext)).doesNotThrowAnyException();
+        verify(posthogService, never()).capture(any(), any(), any());
+    }
+
+    @Test
+    void shouldNotIncludeIpPropertyWhenIpIsBlank() {
+        // Given - blank IP attribute (set by MetadataAppenderChatModelListener when IP is null)
+        Map<Object, Object> attributes = new HashMap<>();
+        attributes.put(MetadataAppenderChatModelListener.PARENT_ID, "parent-id");
+        attributes.put(MetadataAppenderChatModelListener.SPAN_NAME, "FlowYamlBuilder");
+        attributes.put(MetadataAppenderChatModelListener.CONVERSATION_ID, "conv-id");
+        attributes.put(MetadataAppenderChatModelListener.USER_UID, "user-uid");
+        attributes.put(MetadataAppenderChatModelListener.IP, "");
+
+        ChatRequestParameters params = mock(ChatRequestParameters.class);
+        ChatRequest chatRequest = mock(ChatRequest.class);
+        when(chatRequest.modelName()).thenReturn("gemini-2.0-flash");
+        when(chatRequest.parameters()).thenReturn(params);
+        when(chatRequest.messages()).thenReturn(List.of());
+
+        AiMessage aiMessage = mock(AiMessage.class);
+        when(aiMessage.hasToolExecutionRequests()).thenReturn(false);
+        when(aiMessage.text()).thenReturn("generated yaml");
+
+        ChatResponseMetadata metadata = mock(ChatResponseMetadata.class);
+        when(metadata.id()).thenReturn("resp-id");
+
+        ChatResponse chatResponse = mock(ChatResponse.class);
+        when(chatResponse.aiMessage()).thenReturn(aiMessage);
+        when(chatResponse.metadata()).thenReturn(metadata);
+        when(chatResponse.tokenUsage()).thenReturn(null);
+
+        ChatModelResponseContext responseContext = mock(ChatModelResponseContext.class);
+        when(responseContext.chatRequest()).thenReturn(chatRequest);
+        when(responseContext.chatResponse()).thenReturn(chatResponse);
+        when(responseContext.attributes()).thenReturn(attributes);
 
         // When
-        listener.onError(errorContext);
+        listener.onResponse(responseContext);
 
-        // Then
-        ArgumentCaptor<String> distinctIdCaptor = ArgumentCaptor.forClass(String.class);
-        ArgumentCaptor<Map<String, Object>> propsCaptor = ArgumentCaptor.forClass(Map.class);
-        verify(posthogService).capture(distinctIdCaptor.capture(), eq("$ai_generation"), propsCaptor.capture());
+        // Then - $ip must not be present (blank IP causes PostHog 4xx)
+        ArgumentCaptor<Map<String, Object>> propsCaptor = ArgumentCaptor.captor();
+        verify(posthogService, times(1)).capture(eq("user-uid"), eq("$ai_generation"), propsCaptor.capture());
+        assertThat(propsCaptor.getValue()).doesNotContainKey("$ip");
+    }
 
-        assertThat(distinctIdCaptor.getValue()).isEqualTo("browser-uid-123");
-        assertThat(propsCaptor.getValue())
-            .containsEntry("$ai_is_error", true)
-            .containsEntry("$ai_error", "API error");
+    @Test
+    void shouldIncludeIpPropertyWhenIpIsNonBlank() {
+        // Given
+        Map<Object, Object> attributes = new HashMap<>();
+        attributes.put(MetadataAppenderChatModelListener.PARENT_ID, "parent-id");
+        attributes.put(MetadataAppenderChatModelListener.SPAN_NAME, "FlowYamlBuilder");
+        attributes.put(MetadataAppenderChatModelListener.CONVERSATION_ID, "conv-id");
+        attributes.put(MetadataAppenderChatModelListener.USER_UID, "user-uid");
+        attributes.put(MetadataAppenderChatModelListener.IP, "1.2.3.4");
+
+        ChatRequestParameters params = mock(ChatRequestParameters.class);
+        ChatRequest chatRequest = mock(ChatRequest.class);
+        when(chatRequest.modelName()).thenReturn("gemini-2.0-flash");
+        when(chatRequest.parameters()).thenReturn(params);
+        when(chatRequest.messages()).thenReturn(List.of());
+
+        AiMessage aiMessage = mock(AiMessage.class);
+        when(aiMessage.hasToolExecutionRequests()).thenReturn(false);
+        when(aiMessage.text()).thenReturn("generated yaml");
+
+        ChatResponseMetadata metadata = mock(ChatResponseMetadata.class);
+        when(metadata.id()).thenReturn("resp-id");
+
+        ChatResponse chatResponse = mock(ChatResponse.class);
+        when(chatResponse.aiMessage()).thenReturn(aiMessage);
+        when(chatResponse.metadata()).thenReturn(metadata);
+        when(chatResponse.tokenUsage()).thenReturn(null);
+
+        ChatModelResponseContext responseContext = mock(ChatModelResponseContext.class);
+        when(responseContext.chatRequest()).thenReturn(chatRequest);
+        when(responseContext.chatResponse()).thenReturn(chatResponse);
+        when(responseContext.attributes()).thenReturn(attributes);
+
+        // When
+        listener.onResponse(responseContext);
+
+        // Then - $ip must be present and equal to the provided IP
+        ArgumentCaptor<Map<String, Object>> propsCaptor = ArgumentCaptor.captor();
+        verify(posthogService, times(1)).capture(eq("user-uid"), eq("$ai_generation"), propsCaptor.capture());
+        assertThat(propsCaptor.getValue()).containsEntry("$ip", "1.2.3.4");
     }
 }


### PR DESCRIPTION
Backport of:
- fix(copilot): track tool-call responses in PosthogChatModelListener (cherry-picked from b524dc9f89)
- fix(copilot): tolerate anonymous AI calls in telemetry listeners (cherry-picked from a1ca88b92f)

Fixes #15921 — NullPointerException when `aiMessage.text()` is null (tool-call responses) and when AI is called anonymously (null uid/parentId).