### PR TITLE
fix: ensure McpServerChangeNotifier is active in McpToolControllerTest

### DIFF
--- a/webserver/src/main/java/io/kestra/mcp/McpServerChangeNotifier.java
+++ b/webserver/src/main/java/io/kestra/mcp/McpServerChangeNotifier.java
@@ -32,7 +32,7 @@ import static io.kestra.plugin.core.trigger.McpToolTrigger.DEFAULT_SERVER_ID;
 @Slf4j
 @Singleton
 @Requires(beans = McpServerHandlerTransport.class)
-@Requires(property = "kestra.server-type", pattern = "WEBSERVER")
+@Requires(property = "kestra.server-type", pattern = "(WEBSERVER|STANDALONE)")
 public class McpServerChangeNotifier {
     private final Provider<McpServerHandlerTransport> mcpServerHandlerTransport;
     private final BroadcastQueueInterface<FlowInterface> flowQueue;

--- a/webserver/src/test/java/io/kestra/webserver/controllers/api/McpToolControllerTest.java
+++ b/webserver/src/test/java/io/kestra/webserver/controllers/api/McpToolControllerTest.java
@@ -40,6 +40,7 @@ import static io.micronaut.http.HttpRequest.*;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @KestraTest
+@io.micronaut.context.annotation.Property(name = "kestra.server-type", value = "WEBSERVER")
 class McpToolControllerTest {
 
     private static final String MCP_TOOL_PATH = "/api/v1/main/mcp";


### PR DESCRIPTION
### ✨ Description

Ensure McpServerChangeNotifier is active in McpToolControllerTest so notification about a change in state of a mcp server is passed back to the mcp client.