### PR TITLE
fix(core): replace deprecated next() callback with return values in vue router guards

### DIFF
--- a/ui/src/main.js
+++ b/ui/src/main.js
@@ -22,9 +22,9 @@ const handleAuthError = (error, to) => {
 }
 
 initApp(app, routes, null, en).then(({router, piniaStore}) => {
-    router.beforeEach(async (to, from, next) => {
+    router.beforeEach(async (to, from) => {
         if(to.path === from.path && to.query === from.query) {
-            return next(); // Prevent navigation if the path and query are the same
+            return; // Prevent navigation if the path and query are the same
         }
 
         try {
@@ -40,44 +40,42 @@ initApp(app, routes, null, en).then(({router, piniaStore}) => {
                     // Creds exist in config but failed validation
                     // Route to login to show errors
                     if (to.name === "login") {
-                        return next();
+                        return;
                     }
 
-                    return next({name: "login"})
+                    return {name: "login"}
                 } else {
                     // No creds in config - redirect to set it up
                     if (to.name === "setup") {
-                        return next();
+                        return;
                     }
 
-                    return next({name: "setup"})
+                    return {name: "setup"}
                 }
             }
 
             if (to.meta?.anonymous === true) {
                 if (to.name === "setup") {
-                    return next({name: "login"});
+                    return {name: "login"};
                 }
-                return next();
+                return;
             }
 
             const hasCredentials = BasicAuth.isLoggedIn()
 
             if (!hasCredentials) {
                 const fromPath = to.fullPath !== "/ui/login" ? to.fullPath : undefined
-                return next({name: "login", query: fromPath ? {from: fromPath} : {}})
+                return {name: "login", query: fromPath ? {from: fromPath} : {}}
             }
 
             // Check if basic auth setup is still in progress
             const isSetupInProgress = localStorage.getItem("basicAuthSetupInProgress")
             if (isSetupInProgress === "true") {
-                return next({name: "setup"})
+                return {name: "setup"}
             }
-
-            return next();
         } catch (error) {
             console.error("Error during authentication check:", error);
-            return next(handleAuthError(error, to))
+            return handleAuthError(error, to)
         }
     });
 

--- a/ui/src/utils/axios.ts
+++ b/ui/src/utils/axios.ts
@@ -270,14 +270,12 @@ const createAxios = (
         indexes: null
     };
 
-    router?.beforeEach((_to, _from, next) => {
+    router?.beforeEach(() => {
         if (pendingRoute) {
             requestsTotal--;
         }
         pendingRoute = true;
         initProgress();
-
-        next();
     });
 
     router?.afterEach(() => {

--- a/ui/src/utils/init.js
+++ b/ui/src/utils/init.js
@@ -49,7 +49,7 @@ export default async (app, routes, _stores, translations, additionalTranslations
     /**
      * Manage docId initialization for Contextual docs
      */
-    router.beforeEach((to, from, next) => {
+    router.beforeEach((to, from) => {
         // set the docId from the path
         // so it has a default
         const pathArray = to.path.split("/");
@@ -61,9 +61,7 @@ export default async (app, routes, _stores, translations, additionalTranslations
         // propagate showDocId query param
         // to the next page to facilitate docs binding
         if(to.query["showDocId"] === undefined && from.query["showDocId"] !== undefined){
-            next({path: to.path, query: {...to.query, showDocId: from.query["showDocId"]}})
-        }else{
-            next()
+            return {path: to.path, query: {...to.query, showDocId: from.query["showDocId"]}}
         }
     })
 

--- a/ui/src/utils/unsavedChange.ts
+++ b/ui/src/utils/unsavedChange.ts
@@ -31,18 +31,15 @@ export default (app: any, router: Router) => {
         return JSON.stringify(filteredRouteForEquals(route1)) === JSON.stringify(filteredRouteForEquals(route2))
     }
 
-    router.beforeEach(async (to, from, next) => {
+    router.beforeEach(async (to, from) => {
         if (unsavedChangesStore.unsavedChange && !routeEqualsExceptHash(from, to)) {
             const shouldLeave = await unsavedChangesStore.showDialog();
             if (shouldLeave) {
                 unsavedChangesStore.unsavedChange = false;
-                next()
-                return;
+                return true;
             } else {
-                next(false);
-                return;
+                return false;
             }
         }
-        next();
     });
 }


### PR DESCRIPTION
## Summary

- Replace deprecated `next()` callback pattern in all Vue Router navigation guards with the modern `return` value approach
- Affects `main.js`, `utils/init.js`, `utils/unsavedChange.ts`, and `utils/axios.ts`

Closes https://github.com/kestra-io/kestra-ee/issues/7704.

## Test plan

- [ ] Navigate between pages — no Vue Router deprecation warnings in the browser console
- [ ] Unsaved changes dialog still blocks navigation correctly
- [ ] Login/setup redirects still work as expected
- [ ] Progress bar still shows on navigation