### PR TITLE
fix(helm): sync Chart.yaml versions back to develop after release

### DIFF
--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -19,6 +19,9 @@ on:
         required: false
         type: boolean
         default: false
+    secrets:
+      GH_PERSONAL_TOKEN:
+        required: false
 
 permissions:
   contents: write
@@ -197,6 +200,10 @@ jobs:
           set -euo pipefail
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          # Use PAT to bypass branch protection on develop
+          TOKEN="${{ secrets.GH_PERSONAL_TOKEN }}"
+          git remote set-url origin "https://x-access-token:${TOKEN}@github.com/${{ github.repository }}.git"
 
           # Rebase onto current develop so we don't clobber unrelated commits
           git fetch origin develop

--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -21,8 +21,9 @@ on:
         default: false
 
 permissions:
-  contents: read
+  contents: write
   id-token: write
+  pull-requests: write
 
 jobs:
   helm-release:
@@ -41,12 +42,15 @@ jobs:
         with:
           version: v3.12.3
 
-      - name: Install kubeconform
+      - name: Install kubeconform and helm-docs
         run: |
           set -euo pipefail
           curl -fsSL -o /tmp/kc.tar.gz \
             https://github.com/yannh/kubeconform/releases/download/v0.7.0/kubeconform-linux-amd64.tar.gz
           tar -xzf /tmp/kc.tar.gz -C /usr/local/bin kubeconform
+          curl -fsSL -o /tmp/hd.tar.gz \
+            https://github.com/norwoodj/helm-docs/releases/download/v1.14.2/helm-docs_1.14.2_Linux_x86_64.tar.gz
+          tar -xzf /tmp/hd.tar.gz -C /usr/local/bin helm-docs
 
       - name: Verify helm-docs are up to date
         uses: losisin/helm-docs-github-action@v1
@@ -183,3 +187,38 @@ jobs:
           gsutil cp release/index.yaml gs://${BUCKET}/index.yaml
           echo "Published:"
           ls -lh release/*.tgz
+
+      - name: Sync Chart.yaml versions back to develop
+        if: ${{ steps.config.outputs.dry_run == 'false' }}
+        env:
+          VERSION: ${{ steps.config.outputs.version }}
+          TAG: ${{ steps.config.outputs.tag }}
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          # Rebase onto current develop so we don't clobber unrelated commits
+          git fetch origin develop
+          git checkout -B develop origin/develop
+
+          # Re-apply version bump (same logic as Update Chart.yaml versions step)
+          for chart in charts/kestra charts/kestra-starter; do
+            sed -i "s/^version:.*/version: \"${VERSION}\"/" ${chart}/Chart.yaml
+            sed -i "s/^appVersion:.*/appVersion: \"${TAG}\"/" ${chart}/Chart.yaml
+          done
+          awk -v ver="${VERSION}" '
+            /- name: kestra/ { found=1 }
+            found && /version:/ { sub(/version:.*/, "version: \"" ver "\""); found=0 }
+            { print }
+          ' charts/kestra-starter/Chart.yaml > /tmp/chart-starter.yaml
+          mv /tmp/chart-starter.yaml charts/kestra-starter/Chart.yaml
+
+          # Regenerate docs for the new versions
+          helm-docs
+
+          git add charts/kestra/Chart.yaml charts/kestra/README.md \
+                  charts/kestra-starter/Chart.yaml charts/kestra-starter/README.md
+          git diff --cached --quiet && echo "Nothing to commit — already in sync." && exit 0
+          git commit -m "chore(helm): bump chart versions to ${VERSION} [skip ci]"
+          git push origin develop

--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -51,3 +51,5 @@ jobs:
     uses: ./.github/workflows/helm-release.yml
     with:
       dry_run: ${{ inputs.dry-run }}
+    secrets:
+      GH_PERSONAL_TOKEN: ${{ secrets.GH_PERSONAL_TOKEN }}

--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -51,5 +51,3 @@ jobs:
     uses: ./.github/workflows/helm-release.yml
     with:
       dry_run: ${{ inputs.dry-run }}
-    secrets:
-      GH_PERSONAL_TOKEN: ${{ secrets.GH_PERSONAL_TOKEN }}


### PR DESCRIPTION
Fixes #15959

After a successful GCS upload, checkout `develop`, re-apply the version bump to `Chart.yaml` + `README.md`, and push a `[skip ci]` bot commit.

**Why:** `helm-release.yml` mutates `Chart.yaml` in-workflow but never commits it back. Users with the kestra repo as a git submodule see stale versions that don't match `helm.kestra.io`. See issue #15959 for full context.

**Changes:**
- `permissions`: `contents: write` + `pull-requests: write` (needed for the push)
- `Install kubeconform and helm-docs`: adds `helm-docs` binary install so the sync step can call it directly
- New step `Sync Chart.yaml versions back to develop`: runs only on `dry_run == false`, after upload
