### PR TITLE
chore(helm): sync chart versions to 1.3.16 in develop

### DIFF
--- a/charts/kestra-starter/Chart.yaml
+++ b/charts/kestra-starter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 type: application
-version: "1.1.23"
-appVersion: "v1.3.14"
+version: "1.3.16"
+appVersion: "v1.3.16"
 name: kestra-starter
 description: Infinitely scalable, event-driven, language-agnostic orchestration and scheduling platform to manage millions of workflows declaratively in code.
 home: https://kestra.io
@@ -40,4 +40,4 @@ dependencies:
     version: "1.5.7"
   - name: kestra
     repository: https://helm.kestra.io/
-    version: "1.0.53"
+    version: "1.3.16"

--- a/charts/kestra-starter/README.md
+++ b/charts/kestra-starter/README.md
@@ -26,7 +26,7 @@
 
 # kestra-starter
 
-![Version: 1.1.23](https://img.shields.io/badge/Version-1.1.23-informational?style=flat-square) ![AppVersion: v1.3.14](https://img.shields.io/badge/AppVersion-v1.3.14-informational?style=flat-square)
+![Version: 1.3.16](https://img.shields.io/badge/Version-1.3.16-informational?style=flat-square) ![AppVersion: v1.3.16](https://img.shields.io/badge/AppVersion-v1.3.16-informational?style=flat-square)
 
 Infinitely scalable, event-driven, language-agnostic orchestration and scheduling platform to manage millions of workflows declaratively in code.
 
@@ -38,7 +38,7 @@ To install the chart with the release name `my-kestra-starter`:
 
 ```console
 $ helm repo add kestra https://helm.kestra.io/
-$ helm install my-kestra-starter kestra/kestra-starter --version 1.1.23
+$ helm install my-kestra-starter kestra/kestra-starter --version 1.3.16
 ```
 
 ## Requirements
@@ -46,7 +46,7 @@ $ helm install my-kestra-starter kestra/kestra-starter --version 1.1.23
 | Repository | Name | Version |
 |------------|------|---------|
 | https://groundhog2k.github.io/helm-charts/ | postgres | 1.5.7 |
-| https://helm.kestra.io/ | kestra | 1.0.53 |
+| https://helm.kestra.io/ | kestra | 1.3.16 |
 
 ## Values
 

--- a/charts/kestra/Chart.yaml
+++ b/charts/kestra/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 type: application
-version: "1.0.53"
-appVersion: "v1.3.14"
+version: "1.3.16"
+appVersion: "v1.3.16"
 name: kestra
 description: Infinitely scalable, event-driven, language-agnostic orchestration and scheduling platform to manage millions of workflows declaratively in code.
 home: https://kestra.io

--- a/charts/kestra/README.md
+++ b/charts/kestra/README.md
@@ -26,7 +26,7 @@
 
 # kestra
 
-![Version: 1.0.53](https://img.shields.io/badge/Version-1.0.53-informational?style=flat-square) ![AppVersion: v1.3.14](https://img.shields.io/badge/AppVersion-v1.3.14-informational?style=flat-square)
+![Version: 1.3.16](https://img.shields.io/badge/Version-1.3.16-informational?style=flat-square) ![AppVersion: v1.3.16](https://img.shields.io/badge/AppVersion-v1.3.16-informational?style=flat-square)
 
 Infinitely scalable, event-driven, language-agnostic orchestration and scheduling platform to manage millions of workflows declaratively in code.
 
@@ -38,7 +38,7 @@ To install the chart with the release name `my-kestra`:
 
 ```console
 $ helm repo add kestra https://helm.kestra.io/
-$ helm install my-kestra kestra/kestra --version 1.0.53
+$ helm install my-kestra kestra/kestra --version 1.3.16
 ```
 
 ## Migration from 0.x.x to 1.0.0


### PR DESCRIPTION
Manually syncs `charts/kestra` and `charts/kestra-starter` in `develop` to match the 1.3.16 charts already published to GCS.

The automated sync step in `helm-release.yml` failed on the 1.3.16 release run because the `develop` branch ruleset has no bypass actor configured — this PR is the manual fix.

Changes:
- `charts/kestra`: version `1.0.53` → `1.3.16`, appVersion `v1.3.14` → `v1.3.16`
- `charts/kestra-starter`: version `1.1.23` → `1.3.16`, appVersion `v1.3.14` → `v1.3.16`, kestra dep `1.0.53` → `1.3.16`
- README.md files regenerated via helm-docs