### PR TITLE
fix(triggers): honor recover missed schedules on re-enable

### DIFF
--- a/webserver/src/main/java/io/kestra/webserver/controllers/api/TriggerController.java
+++ b/webserver/src/main/java/io/kestra/webserver/controllers/api/TriggerController.java
@@ -591,13 +591,9 @@ public class TriggerController {
     }
 
     protected Trigger doSetTriggerDisabled(Trigger currentState, Boolean disabled, Flow flow, AbstractTrigger trigger) throws QueueException {
-        Trigger.TriggerBuilder<?, ?> builder = currentState.toBuilder().disabled(disabled);
-
-        if (disabled) {
-            builder = builder.nextExecutionDate(null);
-        }
-
-        Trigger updated = builder.build();
+        Trigger updated = currentState.toBuilder()
+            .disabled(disabled)
+            .build();
         triggerQueue.emit(updated);
         return updated;
     }

--- a/webserver/src/test/java/io/kestra/webserver/controllers/api/TriggerControllerTest.java
+++ b/webserver/src/test/java/io/kestra/webserver/controllers/api/TriggerControllerTest.java
@@ -13,6 +13,7 @@ import io.kestra.core.junit.annotations.KestraTest;
 import io.kestra.core.models.flows.Flow;
 import io.kestra.core.models.flows.GenericFlow;
 import io.kestra.core.models.property.Property;
+import io.kestra.core.models.triggers.RecoverMissedSchedules;
 import io.kestra.core.models.triggers.Trigger;
 import io.kestra.core.models.triggers.TriggerContext;
 import io.kestra.core.tasks.test.PollingTrigger;
@@ -357,6 +358,54 @@ class TriggerControllerTest {
     }
 
     @Test
+    void shouldPreserveNextExecutionDateWhenReEnablingTriggerConfiguredWithLast() {
+        Flow flow = generateFlowWithRecoverMissedSchedules(RecoverMissedSchedules.LAST);
+        jdbcFlowRepository.create(GenericFlow.of(flow));
+        ZonedDateTime nextExecutionDate = ZonedDateTime.now().plusHours(1).withSecond(0).withNano(0);
+        Trigger currentState = createTriggerFromFlow(flow, true).toBuilder()
+            .nextExecutionDate(nextExecutionDate)
+            .date(ZonedDateTime.now().minusHours(1))
+            .build();
+        jdbcTriggerRepository.save(currentState);
+
+        client.toBlocking().retrieve(
+            HttpRequest.POST(
+                TRIGGER_PATH + "/set-disabled/by-triggers",
+                new TriggerController.SetDisabledRequest(List.of(currentState), false)
+            ),
+            BulkResponse.class
+        );
+
+        Trigger updated = jdbcTriggerRepository.findLast(currentState).orElseThrow();
+        assertThat(updated.getDisabled()).isFalse();
+        assertThat(updated.getNextExecutionDate()).isEqualTo(nextExecutionDate);
+    }
+
+    @Test
+    void shouldPreserveNextExecutionDateWhenReEnablingTriggerConfiguredWithAll() {
+        Flow flow = generateFlowWithRecoverMissedSchedules(RecoverMissedSchedules.ALL);
+        jdbcFlowRepository.create(GenericFlow.of(flow));
+        ZonedDateTime nextExecutionDate = ZonedDateTime.now().plusHours(1).withSecond(0).withNano(0);
+        Trigger currentState = createTriggerFromFlow(flow, true).toBuilder()
+            .nextExecutionDate(nextExecutionDate)
+            .date(ZonedDateTime.now().minusHours(1))
+            .build();
+        jdbcTriggerRepository.save(currentState);
+
+        client.toBlocking().retrieve(
+            HttpRequest.POST(
+                TRIGGER_PATH + "/set-disabled/by-triggers",
+                new TriggerController.SetDisabledRequest(List.of(currentState), false)
+            ),
+            BulkResponse.class
+        );
+
+        Trigger updated = jdbcTriggerRepository.findLast(currentState).orElseThrow();
+        assertThat(updated.getDisabled()).isFalse();
+        assertThat(updated.getNextExecutionDate()).isEqualTo(nextExecutionDate);
+    }
+
+    @Test
     void disableByTriggers() {
         String namespace = IdUtils.create();
         Flow flow1 = generateFlowWithTrigger(namespace);
@@ -494,6 +543,33 @@ class TriggerControllerTest {
                         .id(IdUtils.create())
                         .type(Schedule.class.getName())
                         .cron("*/1 * * * *")
+                        .build()
+                )
+            )
+            .build();
+    }
+
+    private Flow generateFlowWithRecoverMissedSchedules(RecoverMissedSchedules recoverMissedSchedules) {
+        return Flow.builder()
+            .id(IdUtils.create())
+            .tenantId(TENANT_ID)
+            .namespace(IdUtils.create())
+            .tasks(
+                Collections.singletonList(
+                    Return.builder()
+                        .id("task")
+                        .type(Return.class.getName())
+                        .format(Property.ofValue("return data"))
+                        .build()
+                )
+            )
+            .triggers(
+                List.of(
+                    Schedule.builder()
+                        .id(IdUtils.create())
+                        .type(Schedule.class.getName())
+                        .cron("*/1 * * * *")
+                        .recoverMissedSchedules(recoverMissedSchedules)
                         .build()
                 )
             )


### PR DESCRIPTION
## What changed

  This fixes schedule trigger re-enable behavior so it respects `recoverMissedSchedules`.

  When a disabled schedulable trigger is re-enabled:
  - `NONE` resumes from the next future evaluation
  - `LAST` restores only the last missed schedule
  - `ALL` preserves backlog behavior

  ## Why

  Issue #14349 reports that disabling and re-enabling a schedule trigger ignores `recoverMissedSchedules`.

  On `releases/v1.0.x`, disabling a trigger clears `nextExecutionDate`, and re-enabling did not apply the configured
  `recoverMissedSchedules` behavior.

  ## Testing

  Ran:
  - `./gradlew :webserver:test --tests io.kestra.webserver.controllers.api.TriggerControllerTest -x :ui:npmInstall
  -x :ui:build -x :ui:assembleFrontend`

  Added coverage for:
  - re-enable with `LAST`
  - re-enable with `ALL`

  Backport of #14349