### PR TITLE
feat(helm): sync chart versions to develop via PR instead of direct push

### DIFF
--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -19,10 +19,6 @@ on:
         required: false
         type: boolean
         default: false
-    secrets:
-      GH_PERSONAL_TOKEN:
-        required: false
-
 permissions:
   contents: write
   id-token: write
@@ -196,18 +192,17 @@ jobs:
         env:
           VERSION: ${{ steps.config.outputs.version }}
           TAG: ${{ steps.config.outputs.tag }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
-          # Use PAT to bypass branch protection on develop
-          TOKEN="${{ secrets.GH_PERSONAL_TOKEN }}"
-          git remote set-url origin "https://x-access-token:${TOKEN}@github.com/${{ github.repository }}.git"
+          BRANCH="chore/helm-sync-${VERSION}"
 
-          # Rebase onto current develop so we don't clobber unrelated commits
+          # Branch off current develop
           git fetch origin develop
-          git checkout -B develop origin/develop
+          git checkout -B "${BRANCH}" origin/develop
 
           # Re-apply version bump (same logic as Update Chart.yaml versions step)
           for chart in charts/kestra charts/kestra-starter; do
@@ -228,4 +223,10 @@ jobs:
                   charts/kestra-starter/Chart.yaml charts/kestra-starter/README.md
           git diff --cached --quiet && echo "Nothing to commit — already in sync." && exit 0
           git commit -m "chore(helm): bump chart versions to ${VERSION} [skip ci]"
-          git push origin develop
+          git push origin "${BRANCH}"
+
+          gh pr create \
+            --base develop \
+            --head "${BRANCH}" \
+            --title "chore(helm): bump chart versions to ${VERSION}" \
+            --body "Automated chart version sync after ${TAG} release. Bumps \`charts/kestra\` and \`charts/kestra-starter\` to \`${VERSION}\` / \`${TAG}\`."


### PR DESCRIPTION
## Context

After each Helm chart release the workflow needs to sync the bumped `Chart.yaml` versions back to `develop`. The current approach tries to push directly to `develop`, which is blocked by the branch ruleset (`Changes must be made through a pull request` — no bypass actors configured).

## What this changes

Instead of pushing directly to `develop`, the sync step now:
1. Creates a branch `chore/helm-sync-{VERSION}` off `develop`
2. Applies the version bump + helm-docs regen
3. Pushes the branch
4. Opens a PR targeting `develop` automatically via `gh pr create`

The release master gets a ready-to-merge PR with no manual file editing required. Uses the default `GITHUB_TOKEN` — no PAT needed.

## Trade-off

Introduces one manual merge step for the release master after each release. The alternative (direct push) requires adding GitHub Actions as a bypass actor in the `develop` branch ruleset.