### PR TITLE
fix(test): stabilize PluginSearchCommandTest and flowConcurrencyKilled flakiness

### DIFF
--- a/cli/src/test/java/io/kestra/cli/commands/plugins/PluginSearchCommandTest.java
+++ b/cli/src/test/java/io/kestra/cli/commands/plugins/PluginSearchCommandTest.java
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
 import com.github.tomakehurst.wiremock.junit5.WireMockTest;
 
 import io.micronaut.configuration.picocli.PicocliRunner;
@@ -17,7 +18,7 @@ import io.micronaut.context.env.Environment;
 import static com.github.tomakehurst.wiremock.client.WireMock.*;
 import static org.assertj.core.api.Assertions.assertThat;
 
-@WireMockTest(httpPort = 28181)
+@WireMockTest
 class PluginSearchCommandTest {
     private ByteArrayOutputStream outputStreamCaptor;
     private final PrintStream originalOut = System.out;
@@ -34,7 +35,7 @@ class PluginSearchCommandTest {
     }
 
     @Test
-    void searchWithExactMatch() {
+    void searchWithExactMatch(WireMockRuntimeInfo wmInfo) {
         stubFor(
             get(urlEqualTo("/v1/plugins"))
                 .willReturn(
@@ -61,7 +62,7 @@ class PluginSearchCommandTest {
 
         try (
             ApplicationContext ctx = ApplicationContext.builder(Environment.CLI, Environment.TEST)
-                .properties(Map.of("micronaut.http.services.api.url", "http://localhost:28181"))
+                .properties(Map.of("micronaut.http.services.api.url", wmInfo.getHttpBaseUrl()))
                 .start()
         ) {
             String[] args = { "notifications" };
@@ -75,7 +76,7 @@ class PluginSearchCommandTest {
     }
 
     @Test
-    void searchWithEmptyQuery() {
+    void searchWithEmptyQuery(WireMockRuntimeInfo wmInfo) {
         stubFor(
             get(urlEqualTo("/v1/plugins"))
                 .willReturn(
@@ -102,7 +103,7 @@ class PluginSearchCommandTest {
 
         try (
             ApplicationContext ctx = ApplicationContext.builder(Environment.CLI, Environment.TEST)
-                .properties(Map.of("micronaut.http.services.api.url", "http://localhost:28181"))
+                .properties(Map.of("micronaut.http.services.api.url", wmInfo.getHttpBaseUrl()))
                 .start()
         ) {
 

--- a/core/src/test/resources/flows/valids/flow-concurrency-queue-killed.yml
+++ b/core/src/test/resources/flows/valids/flow-concurrency-queue-killed.yml
@@ -8,4 +8,4 @@ concurrency:
 tasks:
   - id: sleep
     type: io.kestra.plugin.core.flow.Sleep
-    duration: PT10S
+    duration: PT1M

--- a/scheduler/src/test/java/io/kestra/scheduler/TriggerSchedulingLoopTest.java
+++ b/scheduler/src/test/java/io/kestra/scheduler/TriggerSchedulingLoopTest.java
@@ -73,6 +73,8 @@ class TriggerSchedulingLoopTest {
         loop.pause();
         verify(triggerScheduler, times(1)).onStart(any(), any(), eq(Set.of(1)));
         verify(triggerScheduler, atLeast(2)).onSchedule(any(), any(), eq(Set.of(1)));
+        Thread.sleep(500); // let any in-flight iteration complete after pause
+        Mockito.clearInvocations(triggerScheduler);
         Thread.sleep(2000);
 
         // THEN


### PR DESCRIPTION
- `PluginSearchCommandTest`: use random WireMock port; fixes `Failed to bind to /0.0.0.0:28181` collision with webserver tests that also hardcode port 28181.
- `flow-concurrency-queue-killed.yml`: bump sleep `PT10S → PT1M` so exec1 stays RUNNING long enough for the kill signal to arrive on slow Kafka backends.
- `TriggerSchedulingLoopTest.shouldPauseAndResumeLoopGivenPausedState`: add 500ms grace period + `clearInvocations` after `pause()` so the in-flight iteration tail is discarded before `verifyNoMoreInteractions`.

Note: `flowTriggerWithPause` flakiness is addressed in a separate PR (#15989) which fixes the root cause in `DefaultExecutor` (intermediate state transitions dropped when two state changes collapse in one executor cycle, see #15988).