### PR TITLE
fix(executor): emit Flow trigger for every state transition in a cycle

### DIFF
--- a/core/src/test/java/io/kestra/core/runners/AbstractRunnerTest.java
+++ b/core/src/test/java/io/kestra/core/runners/AbstractRunnerTest.java
@@ -219,7 +219,7 @@ public abstract class AbstractRunnerTest {
         flowTriggerCaseTest.trigger("listener-tenant");
     }
 
-    @Test // flaky on CI but never fail locally
+    @Test
     @LoadFlows(
         { "flows/valids/trigger-flow-listener-with-pause.yaml",
             "flows/valids/trigger-flow-with-pause.yaml" }

--- a/executor/src/main/java/io/kestra/executor/DefaultExecutor.java
+++ b/executor/src/main/java/io/kestra/executor/DefaultExecutor.java
@@ -759,9 +759,14 @@ public class DefaultExecutor extends AbstractService implements Executor {
             boolean isTerminated = executor.getFlow() != null && executionService.isTerminated(executor.getFlow(), executor.getExecution());
 
             Execution execution = executor.getExecution();
-            // handle flow triggers on state change
-            if (!execution.getState().getCurrent().equals(executor.getOriginalState())) {
-                processFlowTriggers(execution);
+            // Fire flow triggers for every distinct state transition that occurred in this cycle.
+            // A single cycle can advance through multiple states (e.g. PAUSED → RUNNING → SUCCESS
+            // when a pause-resume delay fires and the executor immediately completes the next task).
+            // Iterating stateTransitions[1..n] ensures each intermediate state reaches the trigger
+            // pipeline, regardless of how many transitions collapsed into one executor cycle.
+            List<State.Type> transitions = executor.getStateTransitions();
+            for (int i = 1; i < transitions.size(); i++) {
+                processFlowTriggers(execution.withState(transitions.get(i)));
             }
 
             // IMPORTANT: this must be done before emitting the last execution message so that all consumers are notified that the execution ends.

--- a/executor/src/main/java/io/kestra/executor/ExecutorContext.java
+++ b/executor/src/main/java/io/kestra/executor/ExecutorContext.java
@@ -41,16 +41,21 @@ public class ExecutorContext {
     private final List<SubflowExecutionResult> subflowExecutionResults = new ArrayList<>(0);
     private final List<Execution> loopExecutions = new ArrayList<>(0);
     private State.Type originalState;
+    // Tracks every distinct state this execution passes through within a single cycle.
+    // Index 0 = state at cycle entry (== originalState); each subsequent entry is a new state.
+    private final List<State.Type> stateTransitions = new ArrayList<>(1);
 
     public ExecutorContext(Execution execution) {
         this.execution = execution;
         this.originalState = execution.getState().getCurrent();
+        this.stateTransitions.add(this.originalState);
     }
 
     public ExecutorContext(Execution execution, FlowWithSource flow) {
         this.execution = execution;
         this.flow = flow;
         this.originalState = execution.getState().getCurrent();
+        this.stateTransitions.add(this.originalState);
     }
 
     public Boolean canBeProcessed() {
@@ -68,6 +73,10 @@ public class ExecutorContext {
         this.execution = execution;
         this.from.add(from);
         this.executionUpdated = true;
+        State.Type newState = execution.getState().getCurrent();
+        if (!newState.equals(stateTransitions.getLast())) {
+            stateTransitions.add(newState);
+        }
 
         return this;
     }

--- a/executor/src/test/java/io/kestra/executor/ExecutorContextTest.java
+++ b/executor/src/test/java/io/kestra/executor/ExecutorContextTest.java
@@ -1,0 +1,83 @@
+package io.kestra.executor;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import io.kestra.core.models.executions.Execution;
+import io.kestra.core.models.flows.Flow;
+import io.kestra.core.models.flows.State;
+import io.kestra.plugin.core.log.Log;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ExecutorContextTest {
+
+    private static Execution blankExecution() {
+        var task = Log.builder()
+            .id("log")
+            .type(Log.class.getName())
+            .message("hello")
+            .build();
+        var flow = Flow.builder()
+            .id("test-flow")
+            .namespace("io.kestra.test")
+            .tasks(List.of(task))
+            .build();
+        return Execution.newExecution(flow, Collections.emptyList());
+    }
+
+    @Test
+    void shouldTrackInitialStateAsFirstTransition() {
+        var execution = blankExecution(); // starts CREATED
+        var ctx = new ExecutorContext(execution);
+
+        assertThat(ctx.getStateTransitions()).containsExactly(State.Type.CREATED);
+        assertThat(ctx.getOriginalState()).isEqualTo(State.Type.CREATED);
+    }
+
+    @Test
+    void shouldAppendDistinctStateTransitions() {
+        var execution = blankExecution();
+        var ctx = new ExecutorContext(execution);
+
+        ctx.withExecution(execution.withState(State.Type.RUNNING), "start");
+        ctx.withExecution(execution.withState(State.Type.PAUSED), "pause");
+        ctx.withExecution(execution.withState(State.Type.RUNNING), "resume");
+        ctx.withExecution(execution.withState(State.Type.SUCCESS), "done");
+
+        assertThat(ctx.getStateTransitions())
+            .containsExactly(
+                State.Type.CREATED,
+                State.Type.RUNNING,
+                State.Type.PAUSED,
+                State.Type.RUNNING,
+                State.Type.SUCCESS
+            );
+    }
+
+    @Test
+    void shouldNotDuplicateConsecutiveSameState() {
+        var execution = blankExecution();
+        var ctx = new ExecutorContext(execution);
+
+        ctx.withExecution(execution.withState(State.Type.RUNNING), "first");
+        ctx.withExecution(execution.withState(State.Type.RUNNING), "second"); // same state, ignored
+
+        assertThat(ctx.getStateTransitions())
+            .containsExactly(State.Type.CREATED, State.Type.RUNNING);
+    }
+
+    @Test
+    void shouldPreserveOriginalStateWhenExecutionAdvances() {
+        var execution = blankExecution();
+        var ctx = new ExecutorContext(execution);
+
+        ctx.withExecution(execution.withState(State.Type.RUNNING), "running");
+        ctx.withExecution(execution.withState(State.Type.SUCCESS), "success");
+
+        assertThat(ctx.getOriginalState()).isEqualTo(State.Type.CREATED);
+        assertThat(ctx.getStateTransitions()).hasSize(3);
+    }
+}


### PR DESCRIPTION
Fixes #15988

When two state changes collapse into a single executor cycle (e.g. a pause-resume delay fires and the executor pipeline immediately advances the execution to `SUCCESS`), `DefaultExecutor` previously fired `processFlowTriggers` only once — for the net `originalState → finalState` delta. Intermediate states were silently skipped, causing Flow trigger listeners to miss expected executions.

- `ExecutorContext` now records every distinct state in `stateTransitions` (appended on each `withExecution` call when the new state differs from the last)
- `DefaultExecutor.toExecution` iterates `stateTransitions[1..n]` and calls `processFlowTriggers` with an `execution.withState(state)` snapshot for each — making trigger evaluation independent of executor batching
- New unit tests in `ExecutorContextTest` verify transition tracking and deduplication

`AbstractRunnerTest.flowTriggerWithPause` is the regression test (was `// flaky on CI but never fail locally` — this fix makes it deterministic).