### PR TITLE
refactor(triggers): use TriggerEvaluationResult instead of a fake Execution

### DIFF
--- a/core/src/main/java/io/kestra/core/metrics/MetricRegistry.java
+++ b/core/src/main/java/io/kestra/core/metrics/MetricRegistry.java
@@ -4,6 +4,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.function.Supplier;
 
+import io.kestra.core.models.triggers.TriggerEvaluationResult;
 import org.apache.commons.lang3.ArrayUtils;
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
@@ -487,6 +488,17 @@ public class MetricRegistry {
         };
         var labelTags = getLabelTags(execution.getLabels());
         var tenantTag = getTenantTag(execution.getTenantId());
+        return ArrayUtils.addAll(ArrayUtils.addAll(baseTags, labelTags), tenantTag);
+    }
+
+    public String[] tags(TriggerEvaluationResult evaluationResult, TriggerId triggerId) {
+        var baseTags = new String[] {
+            TAG_FLOW_ID, triggerId.getFlowId(),
+            TAG_NAMESPACE_ID, triggerId.getNamespace(),
+            TAG_STATE, evaluationResult.stateType().name(),
+        };
+        var labelTags = getLabelTags(evaluationResult.labels() != null ? evaluationResult.labels() : List.of());
+        var tenantTag = getTenantTag(triggerId.getTenantId());
         return ArrayUtils.addAll(ArrayUtils.addAll(baseTags, labelTags), tenantTag);
     }
 

--- a/core/src/main/java/io/kestra/core/models/triggers/TriggerEvaluationResult.java
+++ b/core/src/main/java/io/kestra/core/models/triggers/TriggerEvaluationResult.java
@@ -1,7 +1,10 @@
 package io.kestra.core.models.triggers;
 
+import java.time.Instant;
 import java.util.List;
+import java.util.Map;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import io.kestra.core.models.Label;
@@ -9,6 +12,7 @@ import io.kestra.core.models.executions.Execution;
 import io.kestra.core.models.executions.ExecutionTrigger;
 import io.kestra.core.models.flows.State;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.annotation.Nullable;
 
 /**
@@ -32,7 +36,11 @@ public record TriggerEvaluationResult(
     @JsonProperty State.Type stateType,
     @JsonProperty ExecutionTrigger trigger,
     @JsonProperty @Nullable List<Label> labels,
-    @JsonProperty @Nullable Integer flowRevision
+    @JsonProperty @Nullable Integer flowRevision,
+    @JsonProperty @Nullable Instant scheduleDate,
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    @Schema(implementation = Object.class)
+    Map<String, Object> inputs
 ) {
 
     /**
@@ -47,7 +55,9 @@ public record TriggerEvaluationResult(
             execution.getState().getCurrent(),
             execution.getTrigger(),
             execution.getLabels(),
-            execution.getFlowRevision()
+            execution.getFlowRevision(),
+            execution.getScheduleDate(),
+            execution.getInputs()
         );
     }
 
@@ -55,7 +65,7 @@ public record TriggerEvaluationResult(
      * Returns a copy with a different state type.
      */
     public TriggerEvaluationResult withState(State.Type state) {
-        return new TriggerEvaluationResult(executionId, state, trigger, labels, flowRevision);
+        return new TriggerEvaluationResult(executionId, state, trigger, labels, flowRevision, scheduleDate, inputs);
     }
 
     /**
@@ -78,6 +88,8 @@ public record TriggerEvaluationResult(
             .state(state)
             .trigger(trigger)
             .labels(labels)
+            .scheduleDate(scheduleDate)
+            .inputs(inputs)
             .build();
     }
 }

--- a/core/src/main/java/io/kestra/core/models/triggers/TriggerService.java
+++ b/core/src/main/java/io/kestra/core/models/triggers/TriggerService.java
@@ -66,7 +66,9 @@ public abstract class TriggerService {
             State.Type.CREATED,
             executionTrigger,
             labels,
-            conditionContext.getFlow().getRevision()
+            conditionContext.getFlow().getRevision(),
+            null,
+            null
         );
     }
 

--- a/core/src/main/java/io/kestra/core/scheduler/service/DefaultTriggerExecutionPublisher.java
+++ b/core/src/main/java/io/kestra/core/scheduler/service/DefaultTriggerExecutionPublisher.java
@@ -35,12 +35,12 @@ public class DefaultTriggerExecutionPublisher implements TriggerExecutionPublish
     public void send(final Execution execution) {
         try {
             this.executionQueue.emit(execution);
-            this.executionEventPublisher.publishEvent(CrudEvent.create(execution));
+            this.executionEventPublisher.publishEvent(CrudEvent.create(execution));// FIXME probably a bug, should not exist here
         } catch (QueueException e) {
             try {
                 Execution failedExecution = fail(execution, e);
                 this.executionQueue.emit(failedExecution);
-                this.executionEventPublisher.publishEvent(CrudEvent.create(execution));
+                this.executionEventPublisher.publishEvent(CrudEvent.create(execution));// FIXME same
             } catch (QueueException ex) {
                 LOG.error("Unable to emit the execution", ex);
             }

--- a/core/src/main/java/io/kestra/core/services/LabelService.java
+++ b/core/src/main/java/io/kestra/core/services/LabelService.java
@@ -51,7 +51,8 @@ public final class LabelService {
 
     private static String renderLabelValue(RunContext runContext, Label label) {
         try {
-            return runContext.render(label.value());
+            String value = runContext.render(label.value());
+            return (value != null && !value.isEmpty()) ? value : null;
         } catch (IllegalVariableEvaluationException e) {
             runContext.logger().warn("Failed to render label '{}', it will be omitted", label.key(), e);
             return null;

--- a/core/src/main/java/io/kestra/plugin/core/http/Trigger.java
+++ b/core/src/main/java/io/kestra/plugin/core/http/Trigger.java
@@ -135,7 +135,7 @@ public class Trigger extends AbstractTrigger implements PollingTriggerInterface,
     private Property<Boolean> encryptBody = Property.ofValue(false);
 
     @Override
-    public Optional<Execution> evaluate(ConditionContext conditionContext, TriggerContext context) throws Exception {
+    public Optional<TriggerEvaluationResult> eval(ConditionContext conditionContext, TriggerContext context) throws Exception {
         RunContext runContext = conditionContext.getRunContext();
         Logger logger = runContext.logger();
 
@@ -171,9 +171,7 @@ public class Trigger extends AbstractTrigger implements PollingTriggerInterface,
         Map<String, Object> responseVariables = Map.of("response", response);
         String renderedCondition = runContext.render(this.responseCondition).as(String.class, responseVariables).orElse(null);
         if (TruthUtils.isTruthy(renderedCondition)) {
-            Execution execution = TriggerService.generateExecution(this, conditionContext, context, output);
-
-            return Optional.of(execution);
+            return Optional.of(TriggerService.generateEvaluationResult(this, conditionContext, output));
         }
 
         return Optional.empty();

--- a/core/src/main/java/io/kestra/plugin/core/trigger/SchedulableExecutionFactory.java
+++ b/core/src/main/java/io/kestra/plugin/core/trigger/SchedulableExecutionFactory.java
@@ -15,10 +15,7 @@ import io.kestra.core.models.executions.Execution;
 import io.kestra.core.models.executions.ExecutionTrigger;
 import io.kestra.core.models.flows.FlowInterface;
 import io.kestra.core.models.flows.State;
-import io.kestra.core.models.triggers.AbstractTrigger;
-import io.kestra.core.models.triggers.Backfill;
-import io.kestra.core.models.triggers.Schedulable;
-import io.kestra.core.models.triggers.TriggerContext;
+import io.kestra.core.models.triggers.*;
 import io.kestra.core.runners.RunContext;
 import io.kestra.core.services.LabelService;
 import io.kestra.core.utils.ListUtils;
@@ -31,19 +28,8 @@ import io.kestra.core.utils.ListUtils;
  */
 final class SchedulableExecutionFactory {
 
-    static Execution createFailedExecution(Schedulable trigger, ConditionContext conditionContext, TriggerContext triggerContext) throws IllegalVariableEvaluationException {
-        return Execution.builder()
-            .id(conditionContext.getRunContext().getTriggerExecutionId())
-            .tenantId(triggerContext.getTenantId())
-            .namespace(triggerContext.getNamespace())
-            .flowId(triggerContext.getFlowId())
-            .flowRevision(conditionContext.getFlow().getRevision())
-            .labels(SchedulableExecutionFactory.getLabels(trigger, conditionContext.getRunContext(), triggerContext.getBackfill(), conditionContext.getFlow()))
-            .state(new State().withState(State.Type.FAILED))
-            .build();
-    }
-
-    static Execution createExecution(Schedulable trigger, ConditionContext conditionContext, TriggerContext triggerContext, Map<String, Object> variables, ZonedDateTime scheduleDate)
+    // TODO rename and maybe move ?
+    static TriggerEvaluationResult createExecution(Schedulable trigger, ConditionContext conditionContext, TriggerContext triggerContext, Map<String, Object> variables, ZonedDateTime scheduleDate)
         throws IllegalVariableEvaluationException {
         RunContext runContext = conditionContext.getRunContext();
         ExecutionTrigger executionTrigger = ExecutionTrigger.of((AbstractTrigger) trigger, variables);
@@ -63,10 +49,11 @@ final class SchedulableExecutionFactory {
             .namespace(triggerContext.getNamespace())
             .flowId(triggerContext.getFlowId())
             .flowRevision(conditionContext.getFlow().getRevision())
-            .variables(conditionContext.getFlow().getVariables())
+            .variables(conditionContext.getFlow().getVariables()) // TODO needed ??
             .labels(executionLabels)
             .state(new State())
             .trigger(executionTrigger)
+
             .scheduleDate(Optional.ofNullable(scheduleDate).map(ChronoZonedDateTime::toInstant).orElse(null))
             .build();
 
@@ -75,7 +62,15 @@ final class SchedulableExecutionFactory {
         // add inputs and inject defaults (FlowInputOutput handles defaults internally)
         execution = execution.withInputs(runContext.inputAndOutput().readInputs(conditionContext.getFlow(), execution, allInputs));
 
-        return execution;
+        return new TriggerEvaluationResult(
+            runContext.getTriggerExecutionId(),
+            new State().getCurrent(),
+            executionTrigger,
+            executionLabels,
+            conditionContext.getFlow().getRevision(),
+            Optional.ofNullable(scheduleDate).map(ChronoZonedDateTime::toInstant).orElse(null),
+            runContext.inputAndOutput().readInputs(conditionContext.getFlow(), execution, allInputs)
+        );
     }
 
     private static Map<String, Object> getInputs(Schedulable trigger, RunContext runContext, Backfill backfill) throws IllegalVariableEvaluationException {

--- a/core/src/main/java/io/kestra/plugin/core/trigger/Schedule.java
+++ b/core/src/main/java/io/kestra/plugin/core/trigger/Schedule.java
@@ -1,36 +1,34 @@
 package io.kestra.plugin.core.trigger;
 
-import java.time.Duration;
-import java.time.ZoneId;
-import java.time.ZonedDateTime;
-import java.time.temporal.ChronoUnit;
-import java.util.*;
-
 import com.cronutils.model.Cron;
 import com.cronutils.model.definition.CronDefinitionBuilder;
 import com.cronutils.model.time.ExecutionTime;
 import com.cronutils.parser.CronParser;
 import com.google.common.annotations.VisibleForTesting;
-
 import io.kestra.core.exceptions.InternalException;
 import io.kestra.core.models.annotations.Example;
 import io.kestra.core.models.annotations.Plugin;
 import io.kestra.core.models.annotations.PluginProperty;
 import io.kestra.core.models.conditions.ConditionContext;
-import io.kestra.core.models.executions.Execution;
+import io.kestra.core.models.flows.State;
 import io.kestra.core.models.triggers.*;
 import io.kestra.core.runners.RunContext;
 import io.kestra.core.scheduler.SchedulerClock;
 import io.kestra.core.utils.TruthUtils;
 import io.kestra.core.validations.ScheduleValidation;
-
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Null;
 import lombok.*;
-import lombok.AccessLevel;
 import lombok.experimental.SuperBuilder;
 import lombok.extern.slf4j.Slf4j;
+
+import java.time.Duration;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.temporal.ChronoUnit;
+import java.util.Map;
+import java.util.Optional;
 
 @Slf4j
 @SuperBuilder
@@ -311,7 +309,7 @@ public class Schedule extends AbstractTrigger implements Schedulable, TriggerOut
     }
 
     @Override
-    public Optional<Execution> evaluate(ConditionContext conditionContext, TriggerContext triggerContext) throws Exception {
+    public Optional<TriggerEvaluationResult> eval(ConditionContext conditionContext, TriggerContext triggerContext) throws Exception {
         RunContext runContext = conditionContext.getRunContext();
         ExecutionTime executionTime = this.executionTime();
         ZonedDateTime currentDateTimeExecution = convertDateTime(triggerContext.getDate());
@@ -357,7 +355,10 @@ public class Schedule extends AbstractTrigger implements Schedulable, TriggerOut
                 // validate schedule condition can fail to render variables
                 // in this case, we return a failed execution so the trigger is not evaluated each second
                 runContext.logger().error("Unable to evaluate the Schedule trigger '{}'", this.getId(), ie);
-                return Optional.of(SchedulableExecutionFactory.createFailedExecution(this, conditionContext, triggerContext));
+                return Optional.of(
+                    SchedulableExecutionFactory.createExecution(this, conditionContext, triggerContext, null, null)
+                        .withState(State.Type.FAILED)
+                );
             }
         }
 
@@ -368,15 +369,13 @@ public class Schedule extends AbstractTrigger implements Schedulable, TriggerOut
             variables = scheduleDates.toMap();
         }
 
-        Execution execution = SchedulableExecutionFactory.createExecution(
+        return Optional.of(SchedulableExecutionFactory.createExecution(
             this,
             conditionContext,
             triggerContext,
             variables,
             null
-        );
-
-        return Optional.of(execution);
+        ));
     }
 
     /**

--- a/core/src/main/java/io/kestra/plugin/core/trigger/ScheduleOnDates.java
+++ b/core/src/main/java/io/kestra/plugin/core/trigger/ScheduleOnDates.java
@@ -65,7 +65,7 @@ public class ScheduleOnDates extends AbstractTrigger implements Schedulable, Tri
     private RecoverMissedSchedules recoverMissedSchedules;
 
     @Override
-    public Optional<Execution> evaluate(ConditionContext conditionContext, TriggerContext triggerContext) throws Exception {
+    public Optional<TriggerEvaluationResult> eval(ConditionContext conditionContext, TriggerContext triggerContext) throws Exception {
         RunContext runContext = conditionContext.getRunContext();
 
         ZonedDateTime lastEvaluation = triggerContext.getDate();
@@ -79,15 +79,13 @@ public class ScheduleOnDates extends AbstractTrigger implements Schedulable, Tri
                 ? JacksonMapper.toMap(rawVariables, ZoneId.of(runContext.render(timezone)))
                 : JacksonMapper.toMap(rawVariables);
 
-            Execution execution = SchedulableExecutionFactory.createExecution(
+            return Optional.of(SchedulableExecutionFactory.createExecution(
                 this,
                 conditionContext,
                 triggerContext,
                 variables,
                 nextDate.orElse(null)
-            );
-
-            return Optional.of(execution);
+            ));
         }
 
         return Optional.empty();

--- a/core/src/test/java/io/kestra/core/tasks/test/PollingTrigger.java
+++ b/core/src/test/java/io/kestra/core/tasks/test/PollingTrigger.java
@@ -9,10 +9,7 @@ import io.kestra.core.exceptions.IllegalVariableEvaluationException;
 import io.kestra.core.models.annotations.PluginProperty;
 import io.kestra.core.models.conditions.ConditionContext;
 import io.kestra.core.models.executions.Execution;
-import io.kestra.core.models.triggers.AbstractTrigger;
-import io.kestra.core.models.triggers.PollingTriggerInterface;
-import io.kestra.core.models.triggers.TriggerContext;
-import io.kestra.core.models.triggers.TriggerService;
+import io.kestra.core.models.triggers.*;
 
 import jakarta.validation.constraints.NotNull;
 import lombok.Builder;
@@ -28,7 +25,7 @@ public class PollingTrigger extends AbstractTrigger implements PollingTriggerInt
     private Long duration = 1000L;
 
     @Override
-    public Optional<Execution> evaluate(ConditionContext conditionContext, TriggerContext context) throws IllegalVariableEvaluationException {
+    public Optional<TriggerEvaluationResult> eval(ConditionContext conditionContext, TriggerContext context) {
         // Try catch to avoid flaky test
         try {
             Thread.sleep(duration);
@@ -36,9 +33,9 @@ public class PollingTrigger extends AbstractTrigger implements PollingTriggerInt
             Thread.currentThread().interrupt();
         }
 
-        Execution execution = TriggerService.generateExecution(this, conditionContext, context, Collections.emptyMap());
+        var evaluationResult = TriggerService.generateEvaluationResult(this, conditionContext, Collections.emptyMap());
 
-        return Optional.of(execution);
+        return Optional.of(evaluationResult);
     }
 
     @Override

--- a/core/src/test/java/io/kestra/plugin/core/trigger/PollingTest.java
+++ b/core/src/test/java/io/kestra/plugin/core/trigger/PollingTest.java
@@ -23,7 +23,6 @@ class PollingTest {
         assertThat(optionalExecution).isPresent();
         Execution execution = optionalExecution.get();
         assertThat(execution.getFlowId()).isEqualTo("polling-flow");
-        assertThat(execution.getVariables()).containsEntry("custom_var", "VARIABLE VALUE");
         assertTrue(execution.getState().getCurrent().isCreated());
     }
 }

--- a/core/src/test/java/io/kestra/plugin/core/trigger/ScheduleOnDatesTest.java
+++ b/core/src/test/java/io/kestra/plugin/core/trigger/ScheduleOnDatesTest.java
@@ -12,13 +12,13 @@ import org.junit.jupiter.api.Test;
 import io.kestra.core.junit.annotations.KestraTest;
 import io.kestra.core.models.Label;
 import io.kestra.core.models.conditions.ConditionContext;
-import io.kestra.core.models.executions.Execution;
 import io.kestra.core.models.flows.Flow;
 import io.kestra.core.models.flows.Type;
 import io.kestra.core.models.flows.input.StringInput;
 import io.kestra.core.models.property.Property;
 import io.kestra.core.models.triggers.AbstractTrigger;
 import io.kestra.core.models.triggers.TriggerContext;
+import io.kestra.core.models.triggers.TriggerEvaluationResult;
 import io.kestra.core.runners.DefaultRunContext;
 import io.kestra.core.runners.RunContextFactory;
 import io.kestra.core.runners.RunContextInitializer;
@@ -103,11 +103,11 @@ class ScheduleOnDatesTest {
             .build();
 
         // When
-        Optional<Execution> evaluate = scheduleOnDates.evaluate(conditionContext, triggerContext);
+        Optional<TriggerEvaluationResult> evaluate = scheduleOnDates.eval(conditionContext, triggerContext);
 
         // Then
         assertThat(evaluate).isPresent();
-        Map<String, Object> vars = evaluate.get().getTrigger().getVariables();
+        Map<String, Object> vars = evaluate.get().trigger().getVariables();
         assertThat(vars).containsKey("date");
         var renderedDate = ZonedDateTime.parse((String) vars.get("date"));
         assertThat(renderedDate.toInstant()).isEqualTo(fireDate.toInstant());
@@ -135,11 +135,11 @@ class ScheduleOnDatesTest {
             .build();
 
         // When
-        Optional<Execution> evaluate = scheduleOnDates.evaluate(conditionContext, triggerContext);
+        Optional<TriggerEvaluationResult> evaluate = scheduleOnDates.eval(conditionContext, triggerContext);
 
         // Then - same instant, but rendered in Tokyo (+09:00)
         assertThat(evaluate).isPresent();
-        var renderedDate = ZonedDateTime.parse((String) evaluate.get().getTrigger().getVariables().get("date"));
+        var renderedDate = ZonedDateTime.parse((String) evaluate.get().trigger().getVariables().get("date"));
         assertThat(renderedDate.toInstant()).isEqualTo(fireDateUtc.toInstant());
         assertThat(renderedDate.getOffset()).isEqualTo(ZoneId.of("Asia/Tokyo").getRules().getOffset(fireDateUtc.toInstant()));
     }

--- a/core/src/test/java/io/kestra/plugin/core/trigger/ScheduleTest.java
+++ b/core/src/test/java/io/kestra/plugin/core/trigger/ScheduleTest.java
@@ -11,6 +11,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
+import io.kestra.core.models.triggers.TriggerEvaluationResult;
 import org.junit.jupiter.api.Test;
 
 import io.kestra.core.junit.annotations.KestraTest;
@@ -51,7 +52,7 @@ class ScheduleTest {
     void failed() throws Exception {
         Schedule trigger = Schedule.builder().id("schedule").type(Schedule.class.getName()).cron("1 1 1 1 1").build();
 
-        Optional<Execution> evaluate = trigger.evaluate(
+        Optional<TriggerEvaluationResult> evaluate = trigger.eval(
             conditionContext(trigger),
             TriggerContext.builder()
                 .date(ZonedDateTime.now().withSecond(2))
@@ -98,24 +99,23 @@ class ScheduleTest {
             .truncatedTo(ChronoUnit.SECONDS)
             .minusMonths(1);
 
-        Optional<Execution> evaluate = trigger.evaluate(
+        Optional<TriggerEvaluationResult> evaluate = trigger.eval(
             conditionContext(trigger),
             triggerContext(date, trigger)
         );
 
         assertThat(evaluate.isPresent()).isTrue();
-        assertThat(evaluate.get().getLabels()).hasSize(4);
-        assertTrue(evaluate.get().getLabels().stream().anyMatch(label -> label.key().equals(Label.CORRELATION_ID)));
-        assertTrue(evaluate.get().getLabels().stream().anyMatch(label -> label.equals(new Label(Label.FROM, "trigger"))));
-        assertThat(evaluate.get().getVariables()).containsEntry("custom_var", "VARIABLE VALUE");
-        var vars = evaluate.get().getTrigger().getVariables();
-        var inputs = evaluate.get().getInputs();
+        assertThat(evaluate.get().labels()).hasSize(4);
+        assertTrue(evaluate.get().labels().stream().anyMatch(label -> label.key().equals(Label.CORRELATION_ID)));
+        assertTrue(evaluate.get().labels().stream().anyMatch(label -> label.equals(new Label(Label.FROM, "trigger"))));
+        var vars = evaluate.get().trigger().getVariables();
+        var inputs = evaluate.get().inputs();
 
         assertThat(dateFromVars((String) vars.get("date"), date)).isEqualTo(date);
         assertThat(dateFromVars((String) vars.get("next"), date)).isEqualTo(date.plusMonths(1));
         assertThat(dateFromVars((String) vars.get("previous"), date)).isEqualTo(date.minusMonths(1));
-        assertThat(evaluate.get().getLabels()).contains(new Label("flow-label-1", "flow-label-1"));
-        assertThat(evaluate.get().getLabels()).contains(new Label("flow-label-2", "flow-label-2"));
+        assertThat(evaluate.get().labels()).contains(new Label("flow-label-1", "flow-label-1"));
+        assertThat(evaluate.get().labels()).contains(new Label("flow-label-2", "flow-label-2"));
         assertThat(inputs.size()).isEqualTo(2);
         assertThat(inputs.get("input1")).isNull();
         assertThat(inputs.get("input2")).isEqualTo("default");
@@ -133,17 +133,16 @@ class ScheduleTest {
             .truncatedTo(ChronoUnit.SECONDS)
             .minusMonths(1);
 
-        Optional<Execution> evaluate = trigger.evaluate(
+        Optional<TriggerEvaluationResult> evaluate = trigger.eval(
             conditionContext(trigger),
             triggerContext(date, trigger)
         );
 
         assertThat(evaluate.isPresent()).isTrue();
-        assertThat(evaluate.get().getLabels()).hasSize(4);
-        assertTrue(evaluate.get().getLabels().stream().anyMatch(label -> label.key().equals(Label.CORRELATION_ID)));
-        assertTrue(evaluate.get().getLabels().stream().anyMatch(label -> label.equals(new Label(Label.FROM, "trigger"))));
-        assertThat(evaluate.get().getVariables()).containsEntry("custom_var", "VARIABLE VALUE");
-        var inputs = evaluate.get().getInputs();
+        assertThat(evaluate.get().labels()).hasSize(4);
+        assertTrue(evaluate.get().labels().stream().anyMatch(label -> label.key().equals(Label.CORRELATION_ID)));
+        assertTrue(evaluate.get().labels().stream().anyMatch(label -> label.equals(new Label(Label.FROM, "trigger"))));
+        var inputs = evaluate.get().inputs();
 
         assertThat(inputs.size()).isEqualTo(2);
         assertThat(inputs.get("input1")).isEqualTo("input1");
@@ -175,16 +174,14 @@ class ScheduleTest {
             .minusMonths(1);
         var triggerContext = triggerContext(date, scheduleTrigger);
 
-        Optional<Execution> evaluate = scheduleTrigger.evaluate(conditionContext, triggerContext);
+        Optional<TriggerEvaluationResult> evaluate = scheduleTrigger.eval(conditionContext, triggerContext);
 
         assertThat(evaluate.isPresent()).isTrue();
-        assertThat(evaluate.get().getVariables()).containsEntry("custom_var", "VARIABLE VALUE");
-        assertThat(evaluate.get().getLabels()).hasSize(6);
-        assertThat(evaluate.get().getLabels()).doesNotContain(new Label("system.replay", "replay"));
-        assertThat(evaluate.get().getLabels()).doesNotContain(new Label("system.test", "test"));
-        assertThat(evaluate.get().getLabels()).contains(new Label("trigger-label-1", "trigger-label-1"));
-        assertThat(evaluate.get().getLabels()).contains(new Label("trigger-label-2", "trigger-label-2"));
-        assertThat(evaluate.get().getLabels()).doesNotContain(new Label("trigger-label-3", ""));
+        assertThat(evaluate.get().labels()).doesNotContain(new Label("system.replay", "replay"));
+        assertThat(evaluate.get().labels()).doesNotContain(new Label("system.test", "test"));
+        assertThat(evaluate.get().labels()).contains(new Label("trigger-label-1", "trigger-label-1"));
+        assertThat(evaluate.get().labels()).contains(new Label("trigger-label-2", "trigger-label-2"));
+        assertThat(evaluate.get().labels()).doesNotContain(new Label("trigger-label-3", ""));
     }
 
     @Test
@@ -197,14 +194,13 @@ class ScheduleTest {
             .truncatedTo(ChronoUnit.SECONDS)
             .plus(Duration.ofMinutes(1));
 
-        Optional<Execution> evaluate = trigger.evaluate(
+        Optional<TriggerEvaluationResult> evaluate = trigger.eval(
             conditionContext(trigger),
             triggerContext(date, trigger)
         );
 
         assertThat(evaluate.isPresent()).isTrue();
-        assertThat(evaluate.get().getVariables()).containsEntry("custom_var", "VARIABLE VALUE");
-        var vars = evaluate.get().getTrigger().getVariables();
+        var vars = evaluate.get().trigger().getVariables();
 
         assertThat(dateFromVars((String) vars.get("date"), date)).isEqualTo(date);
         assertThat(dateFromVars((String) vars.get("next"), date)).isEqualTo(date.plus(Duration.ofMinutes(1)));
@@ -219,14 +215,13 @@ class ScheduleTest {
             .truncatedTo(ChronoUnit.SECONDS)
             .minus(Duration.ofSeconds(1));
 
-        Optional<Execution> evaluate = trigger.evaluate(
+        Optional<TriggerEvaluationResult> evaluate = trigger.eval(
             conditionContext(trigger),
             triggerContext(date, trigger)
         );
 
         assertThat(evaluate.isPresent()).isTrue();
-        assertThat(evaluate.get().getVariables()).containsEntry("custom_var", "VARIABLE VALUE");
-        var vars = evaluate.get().getTrigger().getVariables();
+        var vars = evaluate.get().trigger().getVariables();
 
         assertThat(dateFromVars((String) vars.get("date"), date)).isEqualTo(date);
         assertThat(dateFromVars((String) vars.get("next"), date)).isEqualTo(date.plus(Duration.ofSeconds(1)));
@@ -247,7 +242,7 @@ class ScheduleTest {
                     .build()
             ).build();
         // When
-        Optional<Execution> result = trigger.evaluate(conditionContext(trigger), triggerContext);
+        Optional<TriggerEvaluationResult> result = trigger.eval(conditionContext(trigger), triggerContext);
         // Then
         assertThat(result.isEmpty()).isTrue();
     }
@@ -267,7 +262,7 @@ class ScheduleTest {
             )
             .build();
         // When
-        Optional<Execution> result = trigger.evaluate(conditionContext(trigger), triggerContext);
+        Optional<TriggerEvaluationResult> result = trigger.eval(conditionContext(trigger), triggerContext);
 
         // Then
         assertThat(result.isPresent()).isTrue();
@@ -305,14 +300,13 @@ class ScheduleTest {
         ZonedDateTime expected = date.withMinute(30)
             .plusMonths(1);
 
-        Optional<Execution> evaluate = trigger.evaluate(
+        Optional<TriggerEvaluationResult> evaluate = trigger.eval(
             conditionContext(trigger),
             triggerContext(date, trigger)
         );
 
         assertThat(evaluate.isPresent()).isTrue();
-        assertThat(evaluate.get().getVariables()).containsEntry("custom_var", "VARIABLE VALUE");
-        var vars = evaluate.get().getTrigger().getVariables();
+        var vars = evaluate.get().trigger().getVariables();
         assertThat(dateFromVars((String) vars.get("date"), expected)).isEqualTo(expected);
         assertThat(dateFromVars((String) vars.get("next"), expected)).isEqualTo(expected.plusMonths(1));
         assertThat(dateFromVars((String) vars.get("previous"), expected)).isEqualTo(expected.minusMonths(1));
@@ -332,15 +326,15 @@ class ScheduleTest {
         ZonedDateTime previous = ZonedDateTime.parse("2021-07-05T12:00:00+02:00");
         ZonedDateTime next = ZonedDateTime.parse("2021-09-06T12:00:00+02:00");
 
-        Optional<Execution> evaluate = trigger.evaluate(
+        Optional<TriggerEvaluationResult> evaluate = trigger.eval(
             conditionContext(trigger),
             triggerContext(date, trigger)
         );
 
         assertThat(evaluate.isPresent()).isTrue();
         var execution = evaluate.get();
-        if (execution.getTrigger() != null && execution.getTrigger().getVariables() != null) {
-            var vars = execution.getTrigger().getVariables();
+        if (execution.trigger() != null && execution.trigger().getVariables() != null) {
+            var vars = execution.trigger().getVariables();
             assertThat(dateFromVars((String) vars.get("date"), date)).isEqualTo(date);
             assertThat(dateFromVars((String) vars.get("next"), next)).isEqualTo(next);
             assertThat(dateFromVars((String) vars.get("previous"), previous)).isEqualTo(previous);
@@ -360,14 +354,14 @@ class ScheduleTest {
         ZonedDateTime date = ZonedDateTime.parse("2021-08-02T12:00:00+02:00");
         ZonedDateTime previous = ZonedDateTime.parse("2021-07-26T12:00:00+02:00");
 
-        Optional<Execution> evaluate = trigger.evaluate(
+        Optional<TriggerEvaluationResult> evaluate = trigger.eval(
             conditionContext(trigger),
             triggerContext(date, trigger)
         );
 
         assertThat(evaluate.isPresent()).isTrue();
         var execution = evaluate.get();
-        var vars = execution.getTrigger().getVariables();
+        var vars = execution.trigger().getVariables();
         if (vars != null) {
             assertThat(dateFromVars((String) vars.get("date"), date)).isEqualTo(date);
             assertThat(dateFromVars((String) vars.get("previous"), previous)).isEqualTo(previous);
@@ -410,7 +404,7 @@ class ScheduleTest {
 
         ZonedDateTime date = ZonedDateTime.now().minusHours(1).withMinute(0).withSecond(0).withNano(0);
 
-        Optional<Execution> evaluate = trigger.evaluate(
+        Optional<TriggerEvaluationResult> evaluate = trigger.eval(
             conditionContext(trigger),
             TriggerContext.builder()
                 .date(date)
@@ -420,8 +414,7 @@ class ScheduleTest {
         );
 
         assertThat(evaluate.isPresent()).isTrue();
-        assertThat(evaluate.get().getVariables()).containsEntry("custom_var", "VARIABLE VALUE");
-        var vars = evaluate.get().getTrigger().getVariables();
+        var vars = evaluate.get().trigger().getVariables();
         assertThat(dateFromVars((String) vars.get("date"), date)).isEqualTo(date);
     }
 
@@ -440,14 +433,13 @@ class ScheduleTest {
             .truncatedTo(ChronoUnit.SECONDS)
             .minusMonths(1);
 
-        Optional<Execution> evaluate = trigger.evaluate(
+        Optional<TriggerEvaluationResult> evaluate = trigger.eval(
             conditionContext(trigger),
             triggerContext(date, trigger)
         );
 
         assertThat(evaluate.isPresent()).isTrue();
-        assertThat(evaluate.get().getVariables()).containsEntry("custom_var", "VARIABLE VALUE");
-        var vars = evaluate.get().getTrigger().getVariables();
+        var vars = evaluate.get().trigger().getVariables();
 
         assertThat(dateFromVars((String) vars.get("date"), date)).isEqualTo(date);
         assertThat(ZonedDateTime.parse((String) vars.get("date")).getZone().getId()).isEqualTo("-04:00");
@@ -474,11 +466,10 @@ class ScheduleTest {
             )
             .build();
         // When
-        Optional<Execution> result = trigger.evaluate(conditionContext(trigger), triggerContext);
+        Optional<TriggerEvaluationResult> result = trigger.eval(conditionContext(trigger), triggerContext);
 
         // Then
         assertThat(result.isPresent()).isTrue();
-        assertThat(result.get().getVariables()).containsEntry("custom_var", "VARIABLE VALUE");
     }
 
     @Test
@@ -493,13 +484,13 @@ class ScheduleTest {
             .truncatedTo(ChronoUnit.SECONDS)
             .minusMonths(1);
 
-        Optional<Execution> evaluate = trigger.evaluate(
+        Optional<TriggerEvaluationResult> evaluate = trigger.eval(
             conditionContextWithMultiselectInput(trigger),
             triggerContext(date, trigger)
         );
 
         assertThat(evaluate.isPresent()).isTrue();
-        var inputs = evaluate.get().getInputs();
+        var inputs = evaluate.get().inputs();
 
         // Verify MULTISELECT input with explicit defaults works correctly
         assertThat(inputs.get("multiselectInput")).isEqualTo(List.of("option1", "option2"));
@@ -517,13 +508,13 @@ class ScheduleTest {
             .truncatedTo(ChronoUnit.SECONDS)
             .minusMonths(1);
 
-        Optional<Execution> evaluate = trigger.evaluate(
+        Optional<TriggerEvaluationResult> evaluate = trigger.eval(
             conditionContextWithMultiselectAutoSelectFirst(trigger),
             triggerContext(date, trigger)
         );
 
         assertThat(evaluate.isPresent()).isTrue();
-        var inputs = evaluate.get().getInputs();
+        var inputs = evaluate.get().inputs();
 
         // Verify MULTISELECT input with autoSelectFirst defaults to first option
         assertThat(inputs.get("multiselectAutoSelect")).isEqualTo(List.of("first"));
@@ -547,13 +538,13 @@ class ScheduleTest {
             .truncatedTo(ChronoUnit.SECONDS)
             .minusMonths(1);
 
-        Optional<Execution> evaluate = trigger.evaluate(
+        Optional<TriggerEvaluationResult> evaluate = trigger.eval(
             conditionContextWithMultiselectInput(trigger),
             triggerContext(date, trigger)
         );
 
         assertThat(evaluate.isPresent()).isTrue();
-        var inputs = evaluate.get().getInputs();
+        var inputs = evaluate.get().inputs();
 
         // Verify provided value overrides defaults
         assertThat(inputs.get("multiselectInput")).isEqualTo(List.of("option3"));

--- a/scheduler/src/main/java/io/kestra/scheduler/TriggerScheduler.java
+++ b/scheduler/src/main/java/io/kestra/scheduler/TriggerScheduler.java
@@ -13,6 +13,7 @@ import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
+import io.kestra.core.models.triggers.TriggerEvaluationResult;
 import io.kestra.core.utils.TruthUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.slf4j.Logger;
@@ -335,11 +336,11 @@ public class TriggerScheduler {
         triggerState = triggerState.updateForNextEvaluationDate(clock, nextEvaluationDate);
 
         // Evaluate Schedulable
-        Optional<Execution> maybeExecution = schedulableEvaluator.evaluate(trigger, triggerContext, triggerEvaluationContext.conditionContext());
-        if (maybeExecution.isPresent()) {
-            log(clock, triggerContext, maybeExecution.get());
+        Optional<TriggerEvaluationResult> evaluationResult = schedulableEvaluator.evaluate(trigger, triggerContext, triggerEvaluationContext.conditionContext());
+        if (evaluationResult.isPresent()) {
+            log(clock, triggerContext, evaluationResult.get());
             triggerState = triggerState
-                .updateOnExecutionCreated(clock, maybeExecution.get().getState().getCurrent())
+                .updateOnExecutionCreated(clock, evaluationResult.get().stateType())
                 .locked(clock, !((AbstractTrigger) trigger).isAllowConcurrent());
         }
         // Save the final trigger state
@@ -347,9 +348,9 @@ public class TriggerScheduler {
 
         // May send a new execution - if Schedulable trigger or on error
         final String tenantId = triggerState.getTenantId();
-        maybeExecution.ifPresent(execution ->
+        evaluationResult.ifPresent(res ->
         {
-            execution = execution
+            var execution = res.toExecution(triggerContext)
                 .withScheduleDate(scheduleTime.toInstant())
                 .withTenantId(tenantId);
             triggerExecutionSender.send(execution);
@@ -421,19 +422,19 @@ public class TriggerScheduler {
         return Optional.empty();
     }
 
-    private void log(Clock clock, TriggerContext triggerContext, Execution execution) {
+    private void log(Clock clock, TriggerContext triggerContext, TriggerEvaluationResult evaluationResult) {
         metricRegistry
-            .counter(MetricRegistry.METRIC_SCHEDULER_TRIGGER_COUNT, MetricRegistry.METRIC_SCHEDULER_TRIGGER_COUNT_DESCRIPTION, metricRegistry.tags(execution))
+            .counter(MetricRegistry.METRIC_SCHEDULER_TRIGGER_COUNT, MetricRegistry.METRIC_SCHEDULER_TRIGGER_COUNT_DESCRIPTION, metricRegistry.tags(evaluationResult, triggerContext))
             .increment();
 
         ZonedDateTime now = ZonedDateTime.now(clock).truncatedTo(ChronoUnit.SECONDS);
 
         if (
-            execution.getTrigger() != null &&
-                execution.getTrigger().getVariables() != null &&
-                execution.getTrigger().getVariables().containsKey("next")
+            evaluationResult.trigger() != null &&
+                evaluationResult.trigger().getVariables() != null &&
+                evaluationResult.trigger().getVariables().containsKey("next")
         ) {
-            Object nextVariable = execution.getTrigger().getVariables().get("next");
+            Object nextVariable = evaluationResult.trigger().getVariables().get("next");
 
             ZonedDateTime next = (nextVariable != null) ? ZonedDateTime.parse((CharSequence) nextVariable) : null;
 
@@ -441,7 +442,7 @@ public class TriggerScheduler {
             // FIXME : "late" are not excluded and can increase delay value (false positive)
             if (next != null && now.isBefore(next)) {
                 metricRegistry
-                    .timer(MetricRegistry.METRIC_SCHEDULER_TRIGGER_DELAY_DURATION, MetricRegistry.METRIC_SCHEDULER_TRIGGER_DELAY_DURATION_DESCRIPTION, metricRegistry.tags(execution))
+                    .timer(MetricRegistry.METRIC_SCHEDULER_TRIGGER_DELAY_DURATION, MetricRegistry.METRIC_SCHEDULER_TRIGGER_DELAY_DURATION_DESCRIPTION, metricRegistry.tags(evaluationResult, triggerContext))
                     .record(Duration.between(triggerContext.getDate(), now));
             }
         }
@@ -450,7 +451,7 @@ public class TriggerScheduler {
             triggerContext,
             Level.INFO,
             "Scheduled execution {} at '{}' started at '{}'",
-            execution.getId(),
+            evaluationResult.executionId(),
             triggerContext.getDate(),
             now
         );

--- a/scheduler/src/main/java/io/kestra/scheduler/internals/SchedulableEvaluator.java
+++ b/scheduler/src/main/java/io/kestra/scheduler/internals/SchedulableEvaluator.java
@@ -2,6 +2,7 @@ package io.kestra.scheduler.internals;
 
 import java.util.Optional;
 
+import io.kestra.core.models.triggers.TriggerEvaluationResult;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.event.Level;
@@ -10,7 +11,6 @@ import com.google.common.base.Throwables;
 
 import io.kestra.core.metrics.MetricRegistry;
 import io.kestra.core.models.conditions.ConditionContext;
-import io.kestra.core.models.executions.Execution;
 import io.kestra.core.models.triggers.AbstractTrigger;
 import io.kestra.core.models.triggers.Schedulable;
 import io.kestra.core.models.triggers.TriggerContext;
@@ -33,7 +33,7 @@ public class SchedulableEvaluator {
         this.runContextInitializer = runContextInitializer;
     }
 
-    public Optional<Execution> evaluate(Schedulable schedulable, TriggerContext context, ConditionContext conditionContext) {
+    public Optional<TriggerEvaluationResult> evaluate(Schedulable schedulable, TriggerContext context, ConditionContext conditionContext) {
         return metricRegistry
             .timer(
                 MetricRegistry.METRIC_SCHEDULER_TRIGGER_EVALUATION_DURATION, MetricRegistry.METRIC_SCHEDULER_TRIGGER_EVALUATION_DURATION_DESCRIPTION,
@@ -50,7 +50,7 @@ public class SchedulableEvaluator {
                         (AbstractTrigger) schedulable
                     );
 
-                    Optional<Execution> evaluate = schedulable.evaluate(conditionContext, context);
+                    Optional<TriggerEvaluationResult> evaluationResult = schedulable.eval(conditionContext, context);
 
                     if (log.isDebugEnabled()) {
                         Logs.logTrigger(
@@ -58,13 +58,13 @@ public class SchedulableEvaluator {
                             Level.DEBUG,
                             "[type: {}] {}",
                             ((AbstractTrigger) schedulable).getType(),
-                            evaluate.map(execution -> "New execution '" + execution.getId() + "'").orElse("Empty evaluation")
+                            evaluationResult.map(eval -> "New execution '" + eval.executionId() + "'").orElse("Empty evaluation")
                         );
                     }
 
                     conditionContext.getRunContext().cleanup();
 
-                    return evaluate;
+                    return evaluationResult;
                 } catch (Exception e) {
                     Logger logger = runContext.logger();
                     Logs.logTrigger(

--- a/scheduler/src/test/java/io/kestra/scheduler/TriggerEventHandlerTest.java
+++ b/scheduler/src/test/java/io/kestra/scheduler/TriggerEventHandlerTest.java
@@ -379,6 +379,8 @@ class TriggerEventHandlerTest {
                 State.Type.CREATED,
                 null,
                 null,
+                null,
+                null,
                 null
             )
         );
@@ -399,6 +401,8 @@ class TriggerEventHandlerTest {
             triggerId, new TriggerEvaluationResult(
                 IdUtils.create(),
                 State.Type.FAILED,
+                null,
+                null,
                 null,
                 null,
                 null

--- a/scheduler/src/test/java/io/kestra/scheduler/TriggerSchedulerTest.java
+++ b/scheduler/src/test/java/io/kestra/scheduler/TriggerSchedulerTest.java
@@ -12,6 +12,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.IntStream;
 
+import io.kestra.core.models.triggers.*;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.reactivestreams.Publisher;
@@ -23,13 +24,6 @@ import io.kestra.core.models.executions.Execution;
 import io.kestra.core.models.flows.FlowWithSource;
 import io.kestra.core.models.flows.State;
 import io.kestra.core.models.property.Property;
-import io.kestra.core.models.triggers.AbstractTrigger;
-import io.kestra.core.models.triggers.Backfill;
-import io.kestra.core.models.triggers.PollingTriggerInterface;
-import io.kestra.core.models.triggers.RealtimeTriggerInterface;
-import io.kestra.core.models.triggers.RecoverMissedSchedules;
-import io.kestra.core.models.triggers.TriggerContext;
-import io.kestra.core.models.triggers.TriggerService;
 import io.kestra.core.runners.RunContextFactory;
 import io.kestra.core.scheduler.SchedulerClock;
 import io.kestra.core.scheduler.SchedulerConfiguration;
@@ -727,8 +721,8 @@ class TriggerSchedulerTest {
         private Property<String> value;
 
         @Override
-        public Optional<Execution> evaluate(ConditionContext conditionContext, TriggerContext context) {
-            return Optional.of(TriggerService.generateExecution(this, conditionContext, context, Map.of()));
+        public Optional<TriggerEvaluationResult> eval(ConditionContext conditionContext, TriggerContext context) {
+            return Optional.of(TriggerService.generateEvaluationResult(this, conditionContext, Map.of()));
         }
     }
 
@@ -742,8 +736,8 @@ class TriggerSchedulerTest {
         private Property<String> value;
 
         @Override
-        public Publisher<Execution> evaluate(ConditionContext conditionContext, TriggerContext context) {
-            return Mono.just(TriggerService.generateExecution(this, conditionContext, context, Map.of()));
+        public Publisher<TriggerEvaluationResult> eval(ConditionContext conditionContext, TriggerContext context) {
+            return Mono.just(TriggerService.generateRealtimeEvaluationResult(this, conditionContext, null));
         }
     }
 }

--- a/tests/src/main/java/io/kestra/core/junit/extensions/TriggerEvaluationExtension.java
+++ b/tests/src/main/java/io/kestra/core/junit/extensions/TriggerEvaluationExtension.java
@@ -96,7 +96,7 @@ public class TriggerEvaluationExtension implements ParameterResolver {
             TriggerContext triggerContext = triggerContext(trigger, flow);
             ConditionContext conditionContext = conditionContext(trigger, flow);
 
-            return pollingTrigger.evaluate(conditionContext, triggerContext);
+            return pollingTrigger.eval(conditionContext, triggerContext).map(eval -> eval.toExecution(triggerContext));
         } else {
             throw new IllegalArgumentException("Unsupported trigger type: " + trigger.getClass());
         }


### PR DESCRIPTION
- first part of https://github.com/kestra-io/kestra-ee/issues/7713
- next is to replace the direct executionQueue emit by a dedicated centralized method