### PR TITLE
chore(helm): set chart versions to 0.0.0 in develop; remove develop sync step

### DIFF
--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -19,14 +19,9 @@ on:
         required: false
         type: boolean
         default: false
-    secrets:
-      GH_PERSONAL_TOKEN:
-        required: false
-
 permissions:
-  contents: write
+  contents: read
   id-token: write
-  pull-requests: write
 
 jobs:
   helm-release:
@@ -191,41 +186,3 @@ jobs:
           echo "Published:"
           ls -lh release/*.tgz
 
-      - name: Sync Chart.yaml versions back to develop
-        if: ${{ steps.config.outputs.dry_run == 'false' }}
-        env:
-          VERSION: ${{ steps.config.outputs.version }}
-          TAG: ${{ steps.config.outputs.tag }}
-        run: |
-          set -euo pipefail
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-
-          # Use PAT to bypass branch protection on develop
-          TOKEN="${{ secrets.GH_PERSONAL_TOKEN }}"
-          git remote set-url origin "https://x-access-token:${TOKEN}@github.com/${{ github.repository }}.git"
-
-          # Rebase onto current develop so we don't clobber unrelated commits
-          git fetch origin develop
-          git checkout -B develop origin/develop
-
-          # Re-apply version bump (same logic as Update Chart.yaml versions step)
-          for chart in charts/kestra charts/kestra-starter; do
-            sed -i "s/^version:.*/version: \"${VERSION}\"/" ${chart}/Chart.yaml
-            sed -i "s/^appVersion:.*/appVersion: \"${TAG}\"/" ${chart}/Chart.yaml
-          done
-          awk -v ver="${VERSION}" '
-            /- name: kestra/ { found=1 }
-            found && /version:/ { sub(/version:.*/, "version: \"" ver "\""); found=0 }
-            { print }
-          ' charts/kestra-starter/Chart.yaml > /tmp/chart-starter.yaml
-          mv /tmp/chart-starter.yaml charts/kestra-starter/Chart.yaml
-
-          # Regenerate docs for the new versions
-          helm-docs
-
-          git add charts/kestra/Chart.yaml charts/kestra/README.md \
-                  charts/kestra-starter/Chart.yaml charts/kestra-starter/README.md
-          git diff --cached --quiet && echo "Nothing to commit — already in sync." && exit 0
-          git commit -m "chore(helm): bump chart versions to ${VERSION} [skip ci]"
-          git push origin develop

--- a/charts/kestra-starter/Chart.yaml
+++ b/charts/kestra-starter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 type: application
-version: "1.3.16"
-appVersion: "v1.3.16"
+version: "0.0.0"
+appVersion: "0.0.0"
 name: kestra-starter
 description: Infinitely scalable, event-driven, language-agnostic orchestration and scheduling platform to manage millions of workflows declaratively in code.
 home: https://kestra.io
@@ -40,4 +40,4 @@ dependencies:
     version: "1.5.7"
   - name: kestra
     repository: https://helm.kestra.io/
-    version: "1.3.16"
+    version: "0.0.0"

--- a/charts/kestra-starter/README.md
+++ b/charts/kestra-starter/README.md
@@ -26,7 +26,7 @@
 
 # kestra-starter
 
-![Version: 1.3.16](https://img.shields.io/badge/Version-1.3.16-informational?style=flat-square) ![AppVersion: v1.3.16](https://img.shields.io/badge/AppVersion-v1.3.16-informational?style=flat-square)
+![Version: 0.0.0](https://img.shields.io/badge/Version-0.0.0-informational?style=flat-square) ![AppVersion: 0.0.0](https://img.shields.io/badge/AppVersion-0.0.0-informational?style=flat-square)
 
 Infinitely scalable, event-driven, language-agnostic orchestration and scheduling platform to manage millions of workflows declaratively in code.
 
@@ -38,7 +38,7 @@ To install the chart with the release name `my-kestra-starter`:
 
 ```console
 $ helm repo add kestra https://helm.kestra.io/
-$ helm install my-kestra-starter kestra/kestra-starter --version 1.3.16
+$ helm install my-kestra-starter kestra/kestra-starter --version 0.0.0
 ```
 
 ## Requirements
@@ -46,7 +46,7 @@ $ helm install my-kestra-starter kestra/kestra-starter --version 1.3.16
 | Repository | Name | Version |
 |------------|------|---------|
 | https://groundhog2k.github.io/helm-charts/ | postgres | 1.5.7 |
-| https://helm.kestra.io/ | kestra | 1.3.16 |
+| https://helm.kestra.io/ | kestra | 0.0.0 |
 
 ## Values
 

--- a/charts/kestra/Chart.yaml
+++ b/charts/kestra/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 type: application
-version: "1.3.16"
-appVersion: "v1.3.16"
+version: "0.0.0"
+appVersion: "0.0.0"
 name: kestra
 description: Infinitely scalable, event-driven, language-agnostic orchestration and scheduling platform to manage millions of workflows declaratively in code.
 home: https://kestra.io

--- a/charts/kestra/README.md
+++ b/charts/kestra/README.md
@@ -26,7 +26,7 @@
 
 # kestra
 
-![Version: 1.3.16](https://img.shields.io/badge/Version-1.3.16-informational?style=flat-square) ![AppVersion: v1.3.16](https://img.shields.io/badge/AppVersion-v1.3.16-informational?style=flat-square)
+![Version: 0.0.0](https://img.shields.io/badge/Version-0.0.0-informational?style=flat-square) ![AppVersion: 0.0.0](https://img.shields.io/badge/AppVersion-0.0.0-informational?style=flat-square)
 
 Infinitely scalable, event-driven, language-agnostic orchestration and scheduling platform to manage millions of workflows declaratively in code.
 
@@ -38,7 +38,7 @@ To install the chart with the release name `my-kestra`:
 
 ```console
 $ helm repo add kestra https://helm.kestra.io/
-$ helm install my-kestra kestra/kestra --version 1.3.16
+$ helm install my-kestra kestra/kestra --version 0.0.0
 ```
 
 ## Migration from 0.x.x to 1.0.0


### PR DESCRIPTION
## Context

The `kestra` git repository is not the intended distribution channel for Helm charts. `helm.kestra.io` is the stable, versioned artifact that users and operators should consume.

## What this PR does

**Sets `version` and `appVersion` to `0.0.0`** in both `charts/kestra/Chart.yaml` and `charts/kestra-starter/Chart.yaml` on `develop`. This is a deliberate signal: anyone pointing ArgoCD or `helm` directly at the git repo will get an obviously non-release version, making clear they should use the published artifact instead:

```bash
helm pull kestra/kestra --version x.y.z
```

**Removes the post-release sync step** from `helm-release.yml`. That step tried to push bumped chart versions back to `develop` after each release, which required bypassing branch protection rules (PAT, bypass actors). It solved a problem that only exists if users consume charts from git rather than from the Helm repository, so the right fix is to remove the pattern, not to work around the branch protection.

**Tightens permissions** on `helm-release.yml`: `contents: write` and `pull-requests: write` are no longer needed now that nothing pushes back to the repo. Reduced to `contents: read` + `id-token: write`.

## Recommended consumption pattern for ArgoCD users

Create a wrapper chart in your own infrastructure repo:

```yaml
# Chart.yaml
dependencies:
  - name: kestra
    repository: https://helm.kestra.io
    version: "x.y.z"  # pin explicitly; upgrade by bumping this
```

ArgoCD watches your repo. When you decide to upgrade, bump the version, run `helm dependency update`, commit, and ArgoCD deploys. Nothing deploys until you approve the commit. Your `values.yaml` overrides sit alongside the wrapper chart in your repo.