### PR TITLE
[backport releases/v1.3.x] fix(copilot): clarify that AI generation limit resets daily at midnight UTC

### DIFF
--- a/ui/src/translations/de.json
+++ b/ui/src/translations/de.json
@@ -2104,7 +2104,7 @@
       },
       "need_help": "Brauchen Sie Hilfe?",
       "placeholder_prompt": "Sende mir um 9 Uhr morgens eine tägliche Begrüßungsnachricht.",
-      "remaining_quota": "Sie haben {count} AI-Generationen übrig",
+      "remaining_quota": "Sie haben {count} AI-Generationen übrig. Das Limit wird täglich um Mitternacht UTC zurückgesetzt.",
       "show_less": "Weniger Eingabeaufforderungen anzeigen",
       "show_more": "Mehr Eingabeaufforderungen anzeigen",
       "success_page": {

--- a/ui/src/translations/en.json
+++ b/ui/src/translations/en.json
@@ -2060,7 +2060,7 @@
             "placeholder_prompt": "Send me a daily greeting message at 9am.",
             "show_more": "Show more prompts",
             "show_less": "Show fewer prompts",
-            "remaining_quota": "You have {count} AI generations left",
+            "remaining_quota": "You have {count} AI generations left. Limit resets daily at midnight UTC.",
             "execute_hint": {
                 "title": "Save & Execute your flow",
                 "description": "Click to save your workflow and run it immediately."

--- a/ui/src/translations/es.json
+++ b/ui/src/translations/es.json
@@ -2104,7 +2104,7 @@
       },
       "need_help": "¿Necesitas ayuda?",
       "placeholder_prompt": "Envíame un mensaje de saludo diario a las 9am.",
-      "remaining_quota": "Te quedan {count} generaciones de IA",
+      "remaining_quota": "Te quedan {count} generaciones de IA. El límite se restablece diariamente a medianoche UTC.",
       "show_less": "Mostrar menos mensajes",
       "show_more": "Mostrar más indicaciones",
       "success_page": {

--- a/ui/src/translations/fr.json
+++ b/ui/src/translations/fr.json
@@ -2104,7 +2104,7 @@
       },
       "need_help": "Besoin d'aide ?",
       "placeholder_prompt": "Envoyez-moi un message de salutation quotidien à 9h.",
-      "remaining_quota": "Il vous reste {count} générations d'IA",
+      "remaining_quota": "Il vous reste {count} générations d'IA. La limite se réinitialise quotidiennement à minuit UTC.",
       "show_less": "Afficher moins d'invites",
       "show_more": "Afficher plus d'invites",
       "success_page": {

--- a/ui/src/translations/hi.json
+++ b/ui/src/translations/hi.json
@@ -2104,7 +2104,7 @@
       },
       "need_help": "मदद चाहिए?",
       "placeholder_prompt": "मुझे सुबह 9 बजे एक दैनिक अभिवादन संदेश भेजें।",
-      "remaining_quota": "आपके पास {count} AI generations शेष हैं",
+      "remaining_quota": "आपके पास {count} AI generations शेष हैं। सीमा प्रतिदिन मध्यरात्रि UTC पर रीसेट होती है।",
       "show_less": "कम प्रॉम्प्ट दिखाएं",
       "show_more": "अधिक प्रॉम्प्ट दिखाएं",
       "success_page": {

--- a/ui/src/translations/it.json
+++ b/ui/src/translations/it.json
@@ -2104,7 +2104,7 @@
       },
       "need_help": "Hai bisogno di aiuto?",
       "placeholder_prompt": "Mandami un messaggio di saluto giornaliero alle 9:00.",
-      "remaining_quota": "Hai {count} generazioni AI rimanenti",
+      "remaining_quota": "Hai {count} generazioni AI rimanenti. Il limite si resetta ogni giorno a mezzanotte UTC.",
       "show_less": "Mostra meno prompt",
       "show_more": "Mostra più prompt",
       "success_page": {

--- a/ui/src/translations/ja.json
+++ b/ui/src/translations/ja.json
@@ -2104,7 +2104,7 @@
       },
       "need_help": "お困りですか？",
       "placeholder_prompt": "毎朝9時に挨拶メッセージを送ってください。",
-      "remaining_quota": "あなたにはあと{count}回のAI生成が残っています",
+      "remaining_quota": "あなたにはあと{count}回のAI生成が残っています。制限は毎日深夜0時 UTCにリセットされます。",
       "show_less": "プロンプトを減らす",
       "show_more": "さらにプロンプトを表示",
       "success_page": {

--- a/ui/src/translations/ko.json
+++ b/ui/src/translations/ko.json
@@ -2104,7 +2104,7 @@
       },
       "need_help": "도움이 필요하신가요?",
       "placeholder_prompt": "매일 오전 9시에 인사 메시지를 보내주세요.",
-      "remaining_quota": "{count}개의 AI 생성이 남았습니다",
+      "remaining_quota": "{count}개의 AI 생성이 남았습니다. 제한은 매일 자정 UTC에 초기화됩니다.",
       "show_less": "더 적은 프롬프트 표시",
       "show_more": "더 많은 프롬프트 보기",
       "success_page": {

--- a/ui/src/translations/pl.json
+++ b/ui/src/translations/pl.json
@@ -2104,7 +2104,7 @@
       },
       "need_help": "Potrzebujesz pomocy?",
       "placeholder_prompt": "Wyślij mi codzienną wiadomość powitalną o 9 rano.",
-      "remaining_quota": "Masz {count} generacji AI pozostałych",
+      "remaining_quota": "Masz {count} generacji AI pozostałych. Limit resetuje się codziennie o północy UTC.",
       "show_less": "Pokaż mniej podpowiedzi",
       "show_more": "Pokaż więcej podpowiedzi",
       "success_page": {

--- a/ui/src/translations/pt.json
+++ b/ui/src/translations/pt.json
@@ -2104,7 +2104,7 @@
       },
       "need_help": "Precisa de Ajuda?",
       "placeholder_prompt": "Envie-me uma mensagem de saudação diária às 9h.",
-      "remaining_quota": "Você tem {count} gerações de IA restantes",
+      "remaining_quota": "Você tem {count} gerações de IA restantes. O limite é redefinido diariamente à meia-noite UTC.",
       "show_less": "Mostrar menos prompts",
       "show_more": "Mostrar mais prompts",
       "success_page": {

--- a/ui/src/translations/pt_BR.json
+++ b/ui/src/translations/pt_BR.json
@@ -2104,7 +2104,7 @@
       },
       "need_help": "Precisa de Ajuda?",
       "placeholder_prompt": "Envie-me uma mensagem de saudação diária às 9h.",
-      "remaining_quota": "Você tem {count} gerações de IA restantes",
+      "remaining_quota": "Você tem {count} gerações de IA restantes. O limite é redefinido diariamente à meia-noite UTC.",
       "show_less": "Mostrar menos prompts",
       "show_more": "Mostrar mais prompts",
       "success_page": {

--- a/ui/src/translations/ru.json
+++ b/ui/src/translations/ru.json
@@ -2104,7 +2104,7 @@
       },
       "need_help": "Нужна помощь?",
       "placeholder_prompt": "Отправляйте мне ежедневное приветственное сообщение в 9 утра.",
-      "remaining_quota": "У вас осталось {count} AI generations",
+      "remaining_quota": "У вас осталось {count} AI generations. Лимит сбрасывается ежедневно в полночь UTC.",
       "show_less": "Показать меньше подсказок",
       "show_more": "Показать больше подсказок",
       "success_page": {

--- a/ui/src/translations/zh_CN.json
+++ b/ui/src/translations/zh_CN.json
@@ -2104,7 +2104,7 @@
       },
       "need_help": "需要帮助？",
       "placeholder_prompt": "每天早上9点发送问候消息给我。",
-      "remaining_quota": "您还有 {count} 次 AI 生成机会",
+      "remaining_quota": "您还有 {count} 次 AI 生成机会。限制将在每天的UTC午夜重置。",
       "show_less": "显示更少提示",
       "show_more": "显示更多提示",
       "success_page": {


### PR DESCRIPTION
Backport of:
- kestra-io/kestra#15995 — fix(copilot): clarify that AI generation limit resets daily at midnight UTC (cherry-picked from ffa8cb56caf8da7407365eb7b8d148ae2a9772ee)