### PR TITLE
Add Design System 2.0 theme tokens and Mona Sans font

### DIFF
--- a/ui/AGENTS.md
+++ b/ui/AGENTS.md
@@ -18,12 +18,87 @@ Under the hood, the design system wraps Element Plus under the `kel` namespace a
 
 > **Note on `@kestra-io/ui-libs`:** The codebase may still contain imports from `@kestra-io/ui-libs`, the previous shared component library. That repository is sunsetting — all components have been migrated here into `ui/packages/`. Do not add new imports from `@kestra-io/ui-libs`; use `Ks*` components from the design system instead.
 
+## Design System 2.0 (in progress)
+
+DS 2.0 is being drafted on branch `draft-design-system-2`. It introduces breaking visual changes derived from the Figma "_2.0" file. Understanding the scope is essential before touching any styling work.
+
+### What changed from DS 1.0 → DS 2.0
+
+| Dimension | DS 1.0 | DS 2.0 |
+|---|---|---|
+| Primary font | Public Sans | **Mona Sans** |
+| Primary purple | `#8405FF` | **`#631BF3`** (cooler, deeper) |
+| Dark neutral ramp | blue-gray (`$base-gray-*`) | **violet-gray** (`$base-violet-gray-*`) |
+| Background model | 2-level (`body`/`card`) | **5-level elevation** (`base` → `overlay` → `surface` → `elevated` → `hover`) |
+| Shadow system | 3 generic (`sm`/`base`/`lg`) | **3 semantic** (`element` / `surface` / `elevated`) |
+| Status colors | green/red/blue/orange | **teal / coral / periwinkle / amber** (higher contrast) |
+| Token naming | `--ks-background-*`, `--ks-content-*` | **`--ks-bg-*`, `--ks-text-*`, `--ks-icon-*`** |
+
+### DS 2.0 token files
+
+| File | Purpose |
+|---|---|
+| `_color-palette.scss` | Primitive palette — now includes `$base-violet-gray-*`, `$base-primary-v2-*`, `$base-teal-*`, `$base-coral-*`, `$base-periwinkle-*`, `$base-amber-*`, `$base-pending-*` |
+| `ks-theme-v2-light.scss` | DS 2.0 semantic tokens for `:root` (light mode) |
+| `ks-theme-v2-dark.scss` | DS 2.0 semantic tokens for `html.dark` |
+| `ks-tokens.scss` | Extended with `--ks-radius-v2-*`, `--ks-shadow-v2-*`, `--ks-font-family-sans-v2`, `--ks-topbar-height`, `--ks-sidebar-width`, `--ks-focus-ring` |
+| `variables.scss` | Extended with `$font-family-sans-serif-v2` and `$colors-v2` map |
+| `fonts.scss` | Mona Sans `@font-face` declarations added (font files in `src/assets/fonts/mona-sans/` — **must be downloaded separately**) |
+
+### DS 2.0 token taxonomy
+
+```
+--ks-bg-*           background surfaces (5-level elevation model)
+--ks-text-*         text colors (primary / secondary / dim / inactive / link / status)
+--ks-icon-*         icon fill colors  (default / active / muted / hover / status)
+--ks-border-*       border colors     (default / subtle / strong / focus / status)
+--ks-btn-primary-*  primary button states  (bg / text per: default/hover/active/inactive)
+--ks-btn-secondary-* secondary button states (bg / border / text per state)
+--ks-toogle-*       toggle/switch states
+--ks-status-*       execution status dot colors (same in light + dark)
+--ks-shadow-*       box-shadow presets  (element / surface / elevated)
+--ks-artwork-*      illustration / empty-state fill & stroke
+--ks-radius-v2-*    border-radius scale (xs=4px, sm=6px, md=8px, lg=12px, xl=16px)
+--ks-shadow-v2-*    aliased shadows pointing to theme-defined values
+```
+
+### Migration strategy (DS 1.0 → 2.0)
+
+- **Phase 1 (current):** DS 2.0 tokens added *alongside* DS 1.0; no existing code broken.
+- **Phase 2:** New `Ks*` components or redesigned variants adopt `--ks-bg-*` / `--ks-text-*` / `--ks-btn-*` tokens.
+- **Phase 3:** Legacy `--ks-background-*` / `--ks-content-*` / `--ks-button-*` tokens deprecated and removed.
+
+**When writing new UI code today:**
+- Use `--ks-bg-surface` instead of `--ks-background-card`.
+- Use `--ks-text-primary` instead of `--ks-content-primary`.
+- Use `--ks-border-default` instead of `--ks-border-primary`.
+- Use `--ks-btn-primary-bg-default` for a primary action button background.
+- Use `--ks-status-*` for execution status indicator colors.
+- Use `--ks-shadow-v2-element` / `--ks-shadow-v2-surface` / `--ks-shadow-v2-elevated` for depth.
+- Use `--ks-font-family-sans-v2` (Mona Sans) for DS 2.0 surfaces.
+
+### Font file setup
+
+Mona Sans `.woff2` files are not included in the repository. Download them from the [GitHub release page](https://github.com/github/mona-sans/releases) and place them in:
+
+```
+ui/packages/design-system/src/assets/fonts/mona-sans/
+  MonaSans-Regular.woff2
+  MonaSans-Medium.woff2
+  MonaSans-SemiBold.woff2
+  MonaSans-Bold.woff2
+```
+
+Until these files are present, browsers fall back to any locally installed "Mona Sans", then `system-ui`.
+
+---
+
 ## Golden rules (non-negotiable)
 
 These rules are what keep the UI maintainable as it grows. Treat any deviation as a bug.
 
 1. **Use a `Ks*` component if one exists.** Check the tables below before writing anything custom or importing from `element-plus`. New screens that mix `<el-button>` and `<KsButton>` are a regression.
-2. **Colors come from `--ks-*` tokens. Always.** No hex codes, no `rgb(...)`, no Element Plus tokens (`--el-*`), no Bootstrap variables, no SCSS color variables in component code. If the token you need does not exist, talk to design and add it to `ks-theme-light.scss` / `ks-theme-dark.scss` — do not pick a one-off color.
+2. **Colors come from `--ks-*` tokens. Always.** No hex codes, no `rgb(...)`, no Element Plus tokens (`--el-*`), no Bootstrap variables, no SCSS color variables in component code. If the token you need does not exist, talk to design and add it to `ks-theme-v2-light.scss` / `ks-theme-v2-dark.scss` (DS 2.0) or `ks-theme-light.scss` / `ks-theme-dark.scss` (DS 1.0 legacy) — do not pick a one-off color.
 3. **Typography comes from `KsText` or typography tokens.** Use `<KsText>` (with `size`, `type`, `tag`, `truncated`, `lineClamp`) for body copy. For headings or one-off needs, use the `$font-family-*` and `$font-size-*` SCSS variables only inside the design-system package — feature code should not redefine them.
 4. **No `:deep()` selectors.** Reaching into a child component's internals breaks encapsulation and silently shatters when the design system is upgraded. If you need to style something inside a `Ks*` component, add a prop, a slot, or a CSS variable to the component upstream.
 5. **No SCSS variables (`$...`) in feature components.** Use `var(--ks-*)` CSS custom properties inside `<style>` blocks. SCSS variables don't react to dark mode, can't be overridden at runtime, and bind your component to a specific theme. SCSS variables are only acceptable inside `ui/packages/design-system/` itself, in mixins, or for math at build time.

--- a/ui/packages/design-system/src/assets/styles/_color-palette.scss
+++ b/ui/packages/design-system/src/assets/styles/_color-palette.scss
@@ -3,6 +3,9 @@
  * It is a summary of color choices made in Figma.
  * Should you need to make a change in it, ask a designer
  * at Kestra first, so your changes are not overwritten.
+ *
+ * DS 2.0 additions (violet-gray, primary-v2, teal, coral, periwinkle, amber)
+ * are appended below and follow the Figma "_2.0" file (node 27078:9083).
  */
 /* black */
 $base-black: #14181f;
@@ -94,3 +97,45 @@ $base-yellow-600: #ddc46d;
 $base-yellow-700: #bda85d;
 $base-yellow-800: #9e8c4e;
 $base-yellow-900: #7e703e;
+
+// ─── DS 2.0 palette additions ────────────────────────────────────────────────
+
+/* violet-gray — dark-mode surface / border neutral ramp */
+$base-violet-gray-950: #111115;
+$base-violet-gray-900: #1a1c22;
+$base-violet-gray-800: #23252e;
+$base-violet-gray-700: #2e2e3c;
+$base-violet-gray-600: #424256;
+$base-violet-gray-500: #5f5f7c;
+$base-violet-gray-400: #7e7e9b;
+$base-violet-gray-300: #adadbf;
+$base-violet-gray-200: #cfd3d6;
+
+/* primary-v2 — cooler, deeper purple (DS 2.0 brand shift from #8405FF → #631BF3) */
+$base-primary-v2-200: #cdb6fb;
+$base-primary-v2-300: #9869f7;
+$base-primary-v2-400: #7738f5;
+$base-primary-v2-500: #631bf3;
+$base-primary-v2-600: #5212d6;
+
+/* teal — DS 2.0 success green (brighter, higher contrast) */
+$base-teal-100: #bffddd;
+$base-teal-300: #43f6b6;
+$base-teal-500: #15b983;
+$base-teal-700: #1e875e;
+
+/* coral — DS 2.0 error red (softer salmon-red) */
+$base-coral-100: #ffacac;
+$base-coral-300: #ff6a6c;
+$base-coral-600: #ed0011;
+
+/* periwinkle — DS 2.0 info blue (indigo-leaning) */
+$base-periwinkle-200: #a9b5fe;
+$base-periwinkle-300: #718bfe;
+
+/* amber — DS 2.0 warning orange */
+$base-amber-300: #ff8b61;
+$base-amber-700: #a44500;
+
+/* pending — DS 2.0 queued/pending yellow */
+$base-pending-300: #fce070;

--- a/ui/packages/design-system/src/assets/styles/fonts.scss
+++ b/ui/packages/design-system/src/assets/styles/fonts.scss
@@ -53,6 +53,57 @@
     url('../fonts/public-sans/public-sans-v21-latin-800.woff2') format('woff2');
 }
 
+// ── Mona Sans (DS 2.0 primary typeface, replaces Public Sans) ────────────────
+// Font files must be placed in src/assets/fonts/mona-sans/ before these rules
+// activate.  Download from: https://github.com/github/mona-sans/releases
+// Weights shipped: 400 (Regular), 500 (Medium), 600 (SemiBold), 700 (Bold).
+// Until the files are present the browser falls back to any locally installed
+// "Mona Sans", then system-ui.
+
+@font-face {
+  font-family: 'Mona Sans';
+  font-style: normal;
+  font-weight: 400;
+  font-display: swap;
+  src:
+    local('Mona Sans'),
+    local('MonaSans-Regular'),
+    url('../fonts/mona-sans/MonaSans-Regular.woff2') format('woff2');
+}
+
+@font-face {
+  font-family: 'Mona Sans';
+  font-style: normal;
+  font-weight: 500;
+  font-display: swap;
+  src:
+    local('Mona Sans Medium'),
+    local('MonaSans-Medium'),
+    url('../fonts/mona-sans/MonaSans-Medium.woff2') format('woff2');
+}
+
+@font-face {
+  font-family: 'Mona Sans';
+  font-style: normal;
+  font-weight: 600;
+  font-display: swap;
+  src:
+    local('Mona Sans SemiBold'),
+    local('MonaSans-SemiBold'),
+    url('../fonts/mona-sans/MonaSans-SemiBold.woff2') format('woff2');
+}
+
+@font-face {
+  font-family: 'Mona Sans';
+  font-style: normal;
+  font-weight: 700;
+  font-display: swap;
+  src:
+    local('Mona Sans Bold'),
+    local('MonaSans-Bold'),
+    url('../fonts/mona-sans/MonaSans-Bold.woff2') format('woff2');
+}
+
 @font-face {
   font-family: 'Source Code Pro';
   font-style: normal;

--- a/ui/packages/design-system/src/assets/styles/index.scss
+++ b/ui/packages/design-system/src/assets/styles/index.scss
@@ -7,8 +7,13 @@
 // css variables
 @use "fonts.scss";
 @use "ks-tokens.scss";
+// DS 1.0 themes (kept for backward compatibility during migration)
 @use "ks-theme-light.scss";
 @use "ks-theme-dark.scss";
+// DS 2.0 themes — new --ks-bg-*, --ks-text-*, --ks-icon-*, --ks-btn-*, etc.
+// These add new tokens alongside DS 1.0; they do not replace anything yet.
+@use "ks-theme-v2-light.scss";
+@use "ks-theme-v2-dark.scss";
 
 // material-design-icon
 .material-design-icon {

--- a/ui/packages/design-system/src/assets/styles/ks-theme-v2-dark.scss
+++ b/ui/packages/design-system/src/assets/styles/ks-theme-v2-dark.scss
@@ -1,0 +1,130 @@
+/**
+ * DS 2.0 dark theme — derived from Figma file "_2.0" (node 27078:9083).
+ *
+ * Token naming convention (new in DS 2.0):
+ *   --ks-bg-*        background surfaces (5-level elevation model)
+ *   --ks-text-*      text colors
+ *   --ks-icon-*      icon colors
+ *   --ks-border-*    borders  (semantic + state)
+ *   --ks-btn-*       button states (bg, border, text per variant/state)
+ *   --ks-toogle-*    toggle/switch states
+ *   --ks-status-*    execution status dot colors (same in light + dark)
+ *   --ks-shadow-*    box-shadow presets (3-tier elevation)
+ *   --ks-artwork-*   illustration / empty-state fill & stroke
+ *
+ * The legacy --ks-background-*, --ks-content-*, --ks-button-* tokens from
+ * DS 1.0 (ks-theme-dark.scss) continue to work unchanged so existing
+ * components stay functional during the migration.
+ */
+@use "color-palette" as *;
+
+html.dark {
+
+    // ── Background surfaces ───────────────────────────────────────────────────
+    // 5-level elevation model (base → overlay → surface → elevated → hover)
+    #{--ks-bg-base}:          #{$base-violet-gray-950};   // #111115 deepest layer
+    #{--ks-bg-overlay}:       #{$base-violet-gray-900};   // #1a1c22 app shell / sidebar
+    #{--ks-bg-sidebar}:       #{$base-violet-gray-900};   // #1a1c22 left nav background
+    #{--ks-bg-surface}:       #{$base-violet-gray-800};   // #23252e cards, panels
+    #{--ks-bg-elevated}:      #{$base-violet-gray-900};   // #1a1c22 dropdowns, popovers
+    #{--ks-bg-hover}:         #{$base-violet-gray-800};   // #23252e hover on base layer
+    #{--ks-bg-hover-elevated}: #{$base-violet-gray-700};  // #2e2e3c hover on elevated layer
+    #{--ks-bg-active}:        #{$base-violet-gray-700};   // #2e2e3c active / selected
+    #{--ks-bg-input}:         #{$base-violet-gray-950};   // #111115 text inputs
+    #{--ks-bg-badge}:         #{$base-violet-gray-800};   // #23252e badge pill
+    #{--ks-bg-tag}:           rgba($base-white, 0.1);     // #ffffff1a default tag
+    #{--ks-bg-tag-hover}:     rgba($base-primary-v2-300, 0.2); // #9869f733
+    #{--ks-bg-tag-active}:    rgba($base-primary-v2-300, 0.4); // #9869f766
+
+    // State-semantic backgrounds (used by alert, log, execution row)
+    #{--ks-bg-success}:  #{$base-violet-gray-950};
+    #{--ks-bg-error}:    #{$base-violet-gray-950};
+    #{--ks-bg-info}:     #{$base-violet-gray-950};
+    #{--ks-bg-warning}:  #{$base-violet-gray-950};
+
+    // ── Text ─────────────────────────────────────────────────────────────────
+    #{--ks-text-primary}:   #{$base-white};               // #ffffff  body + headings
+    #{--ks-text-secondary}: #{$base-violet-gray-300};     // #adadbf  labels, meta
+    #{--ks-text-dim}:       #{$base-violet-gray-300};     // #adadbf  placeholder
+    #{--ks-text-inactive}:  #{$base-violet-gray-400};     // #7e7e9b  disabled text
+    #{--ks-text-link}:      #{$base-primary-v2-200};      // #cdb6fb  hyperlinks
+    #{--ks-text-link-hover}: #{$base-primary-v2-300};     // #9869f7  link hover
+
+    #{--ks-text-success}: #{$base-teal-100};              // #bffddd
+    #{--ks-text-error}:   #{$base-coral-100};             // #ffacac
+    #{--ks-text-info}:    #{$base-periwinkle-300};        // #718bfe
+    #{--ks-text-warning}: #{$base-amber-300};             // #ff8b61
+
+    // ── Icons ─────────────────────────────────────────────────────────────────
+    #{--ks-icon}:          #{$base-violet-gray-200};      // #cfd3d6 default icon
+    #{--ks-icon-default}:  #{$base-white};                // #ffffff  on-surface icon
+    #{--ks-icon-active}:   #{$base-primary-v2-200};       // #cdb6fb  active nav icon
+    #{--ks-icon-inactive}: #{$base-violet-gray-300};      // #adadbf  disabled icon
+    #{--ks-icon-muted}:    #{$base-violet-gray-300};      // #adadbf  secondary icon
+    #{--ks-icon-hover}:    #{$base-primary-v2-400};       // #7738f5  icon hover
+
+    #{--ks-icon-success}: #{$base-teal-300};              // #43f6b6
+    #{--ks-icon-error}:   #{$base-coral-100};             // #ffacac
+    #{--ks-icon-info}:    #{$base-periwinkle-300};        // #718bfe
+    #{--ks-icon-warning}: #{$base-amber-300};             // #ff8b61
+
+    // ── Borders ───────────────────────────────────────────────────────────────
+    #{--ks-border-default}:  #{$base-violet-gray-700};    // #2e2e3c standard divider
+    #{--ks-border-subtle}:   #{$base-violet-gray-700};    // #2e2e3c soft divider
+    #{--ks-border-strong}:   #{$base-violet-gray-600};    // #424256 prominent border
+    #{--ks-border-focus}:    #{$base-primary-v2-500};     // #631bf3 focus ring
+
+    #{--ks-border-success}: #{$base-teal-700};            // #1e875e
+    #{--ks-border-error}:   #{$base-coral-600};           // #ed0011
+    #{--ks-border-info}:    #{$base-periwinkle-300};      // #718bfe
+    #{--ks-border-warning}: #{$base-amber-700};           // #a44500
+
+    // ── Buttons — primary ─────────────────────────────────────────────────────
+    #{--ks-btn-primary-bg-default}:  #{$base-primary-v2-500}; // #631bf3
+    #{--ks-btn-primary-bg-hover}:    #{$base-primary-v2-400}; // #7738f5
+    #{--ks-btn-primary-bg-active}:   #{$base-primary-v2-600}; // #5212d6
+    #{--ks-btn-primary-bg-inactive}: #{$base-violet-gray-800}; // #23252e
+    #{--ks-btn-primary-text-default}:  #{$base-white};
+    #{--ks-btn-primary-text-inactive}: #{$base-violet-gray-400}; // #7e7e9b
+
+    // ── Buttons — secondary (outlined ghost) ─────────────────────────────────
+    #{--ks-btn-secondary-bg-default}:  #{$base-violet-gray-800}; // #23252e
+    #{--ks-btn-secondary-bg-hover}:    #{$base-violet-gray-700}; // #2e2e3c
+    #{--ks-btn-secondary-bg-active}:   #{$base-violet-gray-700}; // #2e2e3c
+    #{--ks-btn-secondary-bg-inactive}: #{$base-violet-gray-800}; // #23252e
+
+    #{--ks-btn-secondary-border-default}:  #{$base-violet-gray-600}; // #424256
+    #{--ks-btn-secondary-border-hover}:    #{$base-violet-gray-500}; // #5f5f7c
+    #{--ks-btn-secondary-border-active}:   #{$base-primary-v2-300};  // #9869f7
+    #{--ks-btn-secondary-border-inactive}: #{$base-violet-gray-600}; // #424256
+
+    #{--ks-btn-secondary-text-default}:  #{$base-white};
+    #{--ks-btn-secondary-text-inactive}: #{$base-violet-gray-400};   // #7e7e9b
+
+    // ── Toggle / switch ───────────────────────────────────────────────────────
+    #{--ks-toogle-bg-default}:  #{$base-violet-gray-600}; // #424256
+    #{--ks-toogle-bg-hover}:    #{$base-violet-gray-500}; // #5f5f7c
+    #{--ks-toogle-bg-active}:   #{$base-primary-v2-400};  // #7738f5
+    #{--ks-toogle-bg-inactive}: #{$base-violet-gray-800}; // #23252e
+
+    // ── Execution status dots (same in light + dark) ──────────────────────────
+    #{--ks-status-success}: #{$base-teal-300};            // #43f6b6
+    #{--ks-status-error}:   #{$base-coral-300};           // #ff6a6c
+    #{--ks-status-info}:    #{$base-periwinkle-300};      // #718bfe
+    #{--ks-status-running}: #{$base-primary-v2-300};      // #9869f7
+    #{--ks-status-warning}: #{$base-amber-300};           // #ff8b61
+    #{--ks-status-pending}: #{$base-pending-300};         // #fce070
+    #{--ks-status-neutral}: #{$base-violet-gray-300};     // #adadbf
+
+    // ── Shadows — 3-tier elevation ─────────────────────────────────────────────
+    // element: subtle depth for buttons, inputs, small cards
+    #{--ks-shadow-element}: 0 1px 4px rgba(0, 0, 0, 0.05);
+    // surface: panels, menus, popovers
+    #{--ks-shadow-surface}: 0 2px 8px rgba(0, 0, 0, 0.15);
+    // elevated: modals, dialogs, floating layers
+    #{--ks-shadow-elevated}: 0 8px 24px rgba(0, 0, 0, 0.65);
+
+    // ── Artwork / empty-state illustrations ───────────────────────────────────
+    #{--ks-artwork-fill}:   #{$base-primary-v2-300};  // #9869f7
+    #{--ks-artwork-border}: #{$base-periwinkle-200};  // #a9b5fe
+}

--- a/ui/packages/design-system/src/assets/styles/ks-theme-v2-light.scss
+++ b/ui/packages/design-system/src/assets/styles/ks-theme-v2-light.scss
@@ -1,0 +1,116 @@
+/**
+ * DS 2.0 light theme — derived from Figma file "_2.0" (node 27078:9083).
+ *
+ * Token taxonomy mirrors ks-theme-v2-dark.scss; values are inverted for
+ * light mode.  Status dot tokens are identical in both themes by design —
+ * those colours have been chosen for WCAG AA contrast against both light and
+ * dark backgrounds.
+ */
+@use "color-palette" as *;
+
+:root {
+
+    // ── Background surfaces ───────────────────────────────────────────────────
+    #{--ks-bg-base}:           #{$base-gray-50};           // #f9f9fa page background
+    #{--ks-bg-overlay}:        #{$base-white};              // #ffffff app shell / top-bar
+    #{--ks-bg-sidebar}:        #{$base-white};              // #ffffff left nav background
+    #{--ks-bg-surface}:        #{$base-white};              // #ffffff cards, panels
+    #{--ks-bg-elevated}:       #{$base-white};              // #ffffff dropdowns, popovers
+    #{--ks-bg-hover}:          #{$base-gray-50};            // #f9f9fa hover on base
+    #{--ks-bg-hover-elevated}: #{$base-gray-100};           // #ecebef hover on elevated
+    #{--ks-bg-active}:         #{$base-gray-100};           // #ecebef active / selected
+    #{--ks-bg-input}:          #{$base-white};
+    #{--ks-bg-badge}:          #{$base-gray-50};
+    #{--ks-bg-tag}:            rgba($base-black, 0.06);     // subtle neutral tag
+    #{--ks-bg-tag-hover}:      rgba($base-primary-v2-500, 0.1);
+    #{--ks-bg-tag-active}:     rgba($base-primary-v2-500, 0.2);
+
+    // State-semantic backgrounds
+    #{--ks-bg-success}: #{$base-green-50};
+    #{--ks-bg-error}:   #{$base-red-50};
+    #{--ks-bg-info}:    rgba($base-periwinkle-300, 0.1);
+    #{--ks-bg-warning}: #{$base-orange-50};
+
+    // ── Text ─────────────────────────────────────────────────────────────────
+    #{--ks-text-primary}:    #{$base-black};               // #14181f
+    #{--ks-text-secondary}:  #{$base-violet-gray-500};     // #5f5f7c
+    #{--ks-text-dim}:        #{$base-gray-300};            // #9797a6 placeholders
+    #{--ks-text-inactive}:   #{$base-gray-300};            // #9797a6 disabled
+    #{--ks-text-link}:       #{$base-primary-v2-500};      // #631bf3
+    #{--ks-text-link-hover}: #{$base-primary-v2-400};      // #7738f5
+
+    #{--ks-text-success}: #{$base-green-700};              // #016046
+    #{--ks-text-error}:   #{$base-red-500};                // #ab0009
+    #{--ks-text-info}:    #{$base-blue-600};               // #134ecc
+    #{--ks-text-warning}: #{$base-orange-500};             // #dd5f00
+
+    // ── Icons ─────────────────────────────────────────────────────────────────
+    #{--ks-icon}:          #{$base-gray-300};              // #9797a6
+    #{--ks-icon-default}:  #{$base-black};
+    #{--ks-icon-active}:   #{$base-primary-v2-500};        // #631bf3
+    #{--ks-icon-inactive}: #{$base-gray-200};              // #cfd3d6
+    #{--ks-icon-muted}:    #{$base-gray-300};              // #9797a6
+    #{--ks-icon-hover}:    #{$base-primary-v2-400};        // #7738f5
+
+    #{--ks-icon-success}: #{$base-green-500};              // #029e73
+    #{--ks-icon-error}:   #{$base-red-400};                // #e3262f
+    #{--ks-icon-info}:    #{$base-blue-600};               // #134ecc
+    #{--ks-icon-warning}: #{$base-orange-500};             // #dd5f00
+
+    // ── Borders ───────────────────────────────────────────────────────────────
+    #{--ks-border-default}:  #e1e3e5;                      // light divider
+    #{--ks-border-subtle}:   #ededf0;                      // barely-there divider
+    #{--ks-border-strong}:   #{$base-gray-200};            // #cfd3d6
+    #{--ks-border-focus}:    #{$base-primary-v2-500};      // #631bf3
+
+    #{--ks-border-success}: #{$base-teal-500};             // #15b983
+    #{--ks-border-error}:   #{$base-red-400};              // #e3262f
+    #{--ks-border-info}:    #{$base-periwinkle-300};       // #718bfe
+    #{--ks-border-warning}: #{$base-orange-500};           // #dd5f00
+
+    // ── Buttons — primary ─────────────────────────────────────────────────────
+    #{--ks-btn-primary-bg-default}:  #{$base-primary-v2-500}; // #631bf3  (same as dark)
+    #{--ks-btn-primary-bg-hover}:    #{$base-primary-v2-400}; // #7738f5
+    #{--ks-btn-primary-bg-active}:   #{$base-primary-v2-600}; // #5212d6
+    #{--ks-btn-primary-bg-inactive}: #{$base-gray-100};        // #ecebef  muted bg
+    #{--ks-btn-primary-text-default}:  #{$base-white};
+    #{--ks-btn-primary-text-inactive}: #{$base-gray-300};      // #9797a6
+
+    // ── Buttons — secondary ───────────────────────────────────────────────────
+    #{--ks-btn-secondary-bg-default}:  #{$base-white};
+    #{--ks-btn-secondary-bg-hover}:    #{$base-gray-50};       // #f9f9fa
+    #{--ks-btn-secondary-bg-active}:   #{$base-gray-100};      // #ecebef
+    #{--ks-btn-secondary-bg-inactive}: #{$base-gray-50};
+
+    #{--ks-btn-secondary-border-default}:  #e1e3e5;
+    #{--ks-btn-secondary-border-hover}:    #{$base-gray-200};  // #cfd3d6
+    #{--ks-btn-secondary-border-active}:   #{$base-primary-v2-500}; // #631bf3
+    #{--ks-btn-secondary-border-inactive}: #e1e3e5;
+
+    #{--ks-btn-secondary-text-default}:  #{$base-black};
+    #{--ks-btn-secondary-text-inactive}: #{$base-gray-300};
+
+    // ── Toggle / switch ───────────────────────────────────────────────────────
+    #{--ks-toogle-bg-default}:  #e1e3e5;
+    #{--ks-toogle-bg-hover}:    #{$base-gray-200};             // #cfd3d6
+    #{--ks-toogle-bg-active}:   #{$base-primary-v2-500};       // #631bf3
+    #{--ks-toogle-bg-inactive}: #{$base-gray-100};
+
+    // ── Execution status dots (identical to dark theme) ───────────────────────
+    #{--ks-status-success}: #{$base-teal-300};            // #43f6b6
+    #{--ks-status-error}:   #{$base-coral-300};           // #ff6a6c
+    #{--ks-status-info}:    #{$base-periwinkle-300};      // #718bfe
+    #{--ks-status-running}: #{$base-primary-v2-300};      // #9869f7
+    #{--ks-status-warning}: #{$base-amber-300};           // #ff8b61
+    #{--ks-status-pending}: #{$base-pending-300};         // #fce070
+    #{--ks-status-neutral}: #{$base-gray-300};            // #9797a6
+
+    // ── Shadows ───────────────────────────────────────────────────────────────
+    #{--ks-shadow-element}: 0 1px 4px rgba(0, 0, 0, 0.05);
+    #{--ks-shadow-surface}: 0 2px 8px rgba(0, 0, 0, 0.08);
+    #{--ks-shadow-elevated}: 0 8px 24px rgba(0, 0, 0, 0.12);
+
+    // ── Artwork / empty-state illustrations ───────────────────────────────────
+    #{--ks-artwork-fill}:   #{$base-primary-v2-300};  // #9869f7
+    #{--ks-artwork-border}: #{$base-periwinkle-200};  // #a9b5fe
+}

--- a/ui/packages/design-system/src/assets/styles/ks-tokens.scss
+++ b/ui/packages/design-system/src/assets/styles/ks-tokens.scss
@@ -5,6 +5,9 @@
     #{--ks-black}: #{v.$black};
     #{--ks-white}: #{v.$white};
 
+    // ── DS 2.0 typography ─────────────────────────────────────────────────────
+    --ks-font-family-sans-v2: #{v.$font-family-sans-serif-v2};
+
     // typography
     --ks-font-family-sans: #{v.$font-family-sans-serif};
     --ks-font-family-mono: #{v.$font-family-monospace};
@@ -77,4 +80,29 @@
     --ks-icon-size-base: 1.25rem;
     --ks-icon-size-lg: 1.5rem;
     --ks-icon-size-xl: 2rem;
+
+    // ── DS 2.0 tokens ─────────────────────────────────────────────────────────
+
+    // Radius — DS 2.0 defines three button-specific radii (from Figma btn-* frames)
+    --ks-radius-v2-xs:  0.25rem;   // 4px  alerts, tags
+    --ks-radius-v2-sm:  0.375rem;  // 6px  secondary/ghost buttons, icon buttons
+    --ks-radius-v2-md:  0.5rem;    // 8px  primary/danger/success buttons
+    --ks-radius-v2-lg:  0.75rem;   // 12px modals, drawers, cards
+    --ks-radius-v2-xl:  1rem;      // 16px toggles, pills
+
+    // Shadows — the three values below are theme-aware (defined in v2 theme files)
+    // and are referenced here as composite tokens for component consumption.
+    // element → smallest depth (buttons, inputs)
+    --ks-shadow-v2-element: var(--ks-shadow-element, 0 1px 4px rgba(0, 0, 0, 0.05));
+    // surface → medium depth (cards, panels, dropdowns)
+    --ks-shadow-v2-surface: var(--ks-shadow-surface, 0 2px 8px rgba(0, 0, 0, 0.10));
+    // elevated → high depth (modals, dialogs, floating layers)
+    --ks-shadow-v2-elevated: var(--ks-shadow-elevated, 0 8px 24px rgba(0, 0, 0, 0.15));
+
+    // Focus ring — used on interactive elements for keyboard accessibility
+    --ks-focus-ring: 0 0 0 3px rgba(99, 27, 243, 0.35);  // primary-v2-500 @ 35%
+
+    // Top-bar / nav chrome heights
+    --ks-topbar-height: 3.5rem;    // 56px  matches main-top-bar Figma component
+    --ks-sidebar-width: 14rem;     // 224px matches Left-sidebar Figma component
 }

--- a/ui/packages/design-system/src/assets/styles/variables.scss
+++ b/ui/packages/design-system/src/assets/styles/variables.scss
@@ -1,8 +1,13 @@
 @use "color-palette" as palette;
 
-// font family
+// ── DS 1.0 fonts (kept for backward compatibility) ────────────────────────────
 $font-family-sans-serif: "Public Sans", sans-serif;
 $font-family-monospace: "Source Code Pro", monospace;
+
+// ── DS 2.0 fonts ──────────────────────────────────────────────────────────────
+// "Mona Sans" is the new primary typeface.  @font-face declarations live in
+// fonts.scss; font files must be added to src/assets/fonts/mona-sans/.
+$font-family-sans-serif-v2: "Mona Sans", system-ui, sans-serif;
 
 // font sizes
 $font-size-base: 1rem;
@@ -36,6 +41,7 @@ $gray-dark-800: #A69FC1;
 $gray-dark-900: #CAC5DA;
 $gray-dark-950: #f9f9fa;
 
+// ── DS 1.0 semantic colors ─────────────────────────────────────────────────────
 $colors: (
     'primary': palette.$base-purple-500,
     'success': palette.$base-green-500,
@@ -43,6 +49,16 @@ $colors: (
     'danger': palette.$base-red-500,
     'error': palette.$base-red-500,
     'info': palette.$base-blue-500,
+);
+
+// ── DS 2.0 semantic colors ─────────────────────────────────────────────────────
+$colors-v2: (
+    'primary': palette.$base-primary-v2-500,   // #631bf3
+    'success': palette.$base-teal-500,          // #15b983
+    'warning': palette.$base-amber-300,         // #ff8b61
+    'danger':  palette.$base-coral-300,         // #ff6a6c
+    'error':   palette.$base-coral-300,         // #ff6a6c
+    'info':    palette.$base-periwinkle-300,    // #718bfe
 );
 
 // border radius


### PR DESCRIPTION
## ✨ Description

This PR introduces **Design System 2.0 (DS 2.0)** tokens and typography, laying the foundation for a visual refresh across the Kestra UI. DS 2.0 is being drafted on the `draft-design-system-2` branch and introduces breaking visual changes derived from the Figma "_2.0" file.

### What's included:

1. **New DS 2.0 theme files:**
   - `ks-theme-v2-light.scss` — semantic tokens for light mode (`:root`)
   - `ks-theme-v2-dark.scss` — semantic tokens for dark mode (`html.dark`)
   - Both define a new 5-level elevation background model and semantic token taxonomy (`--ks-bg-*`, `--ks-text-*`, `--ks-icon-*`, `--ks-btn-*`, `--ks-status-*`, `--ks-shadow-*`, `--ks-artwork-*`)

2. **Extended color palette:**
   - Added `$base-violet-gray-*` (dark-mode neutral ramp, replacing blue-gray)
   - Added `$base-primary-v2-*` (cooler, deeper purple: `#631BF3` vs. legacy `#8405FF`)
   - Added `$base-teal-*`, `$base-coral-*`, `$base-periwinkle-*`, `$base-amber-*`, `$base-pending-*` (higher-contrast status colors)

3. **Mona Sans font support:**
   - Added `@font-face` declarations for Mona Sans (weights: 400, 500, 600, 700)
   - Font files must be downloaded separately from [GitHub release](https://github.com/github/mona-sans/releases) and placed in `src/assets/fonts/mona-sans/`
   - Graceful fallback to locally installed "Mona Sans" or `system-ui` if files are unavailable

4. **Extended token definitions:**
   - Added `--ks-font-family-sans-v2` (Mona Sans)
   - Added `--ks-radius-v2-*` (4px, 6px, 8px, 12px, 16px)
   - Added `--ks-shadow-v2-*` (element, surface, elevated)
   - Added `--ks-focus-ring` and layout tokens (`--ks-topbar-height`, `--ks-sidebar-width`)
   - Added `$colors-v2` SCSS map for DS 2.0 semantic colors

5. **Documentation:**
   - Updated `AGENTS.md` with comprehensive DS 2.0 migration guide, token taxonomy, and setup instructions

### Migration approach:

DS 2.0 tokens are added **alongside** DS 1.0 tokens — no existing code is broken. Legacy `--ks-background-*`, `--ks-content-*`, and `--ks-button-*` tokens remain functional. New components or redesigned variants will adopt the new token names.

### Key visual changes (DS 1.0 → DS 2.0):

| Dimension | DS 1.0 | DS 2.0 |
|---|---|---|
| Primary font | Public Sans | **Mona Sans** |
| Primary purple | `#8405FF` | **`#631BF3`** |
| Dark neutral ramp | blue-gray | **violet-gray** |
| Background model | 2-level | **5-level elevation** |
| Status colors | green/red/blue/orange | **teal/coral/periwinkle/amber** |

### Notes for reviewers:

- Mona Sans `.woff2` files are **not** included in this PR; they must be downloaded separately per the instructions in `AGENTS.md` and `fonts.scss`.
- All new tokens are scoped to `:root` (light) and `html.dark` (dark) selectors and do not affect existing component styling.
- The theme files follow the Figma "_

https://claude.ai/code/session_01NQc3kv3WQQcC8UtmA5ArJw