### PR TITLE
refactor: migrate flow-related API calls to kestra-sdk

### DIFF
--- a/ui/src/components/admin/triggers/TriggerConfigureModal.vue
+++ b/ui/src/components/admin/triggers/TriggerConfigureModal.vue
@@ -187,8 +187,12 @@
         }
         flowsLoading.value = true
         try {
-            const response = await flowStore.findFlows({namespace, size: 200, sort: "id:asc"})
-            flowOptions.value = (response?.results ?? []).map((f: any) => ({id: f.id, namespace: f.namespace}))
+            const response = await flowStore.findFlows({filters: [{
+                field: "NAMESPACE",
+                operation: "EQUALS",
+                value: namespace as any,
+            }], size: 200, sort: ["id:asc"]})
+            flowOptions.value = response.results.map((f: any) => ({id: f.id, namespace: f.namespace}))
         } finally {
             flowsLoading.value = false
         }

--- a/ui/src/components/dependencies/composables/useDependencies.ts
+++ b/ui/src/components/dependencies/composables/useDependencies.ts
@@ -484,7 +484,6 @@ export function useDependencies(
                             namespace: params.namespace as string,
                             subtype:  subtype === FLOW ? FLOW : EXECUTION,
                         },
-                        false,
                     )
                     elements.value = {data: result.data ?? [], count: result.count}
                 }

--- a/ui/src/components/executions/composables/useExecutionRoot.ts
+++ b/ui/src/components/executions/composables/useExecutionRoot.ts
@@ -149,7 +149,7 @@ export function useExecutionRoot() {
             follow()
             window.addEventListener("popstate", follow)
 
-            dependenciesCount.value = (await flowStore.loadDependencies({namespace: route.params.namespace as string, id: route.params.flowId as string, subtype: "FLOW"}, true)).count
+            dependenciesCount.value = (await flowStore.loadDependencies({namespace: route.params.namespace as string, id: route.params.flowId as string, subtype: "FLOW"})).count
             previousExecutionId.value = route.params.id as string
         })
 

--- a/ui/src/components/executions/overview/components/main/cascaders/DebugPanel.vue
+++ b/ui/src/components/executions/overview/components/main/cascaders/DebugPanel.vue
@@ -78,7 +78,7 @@
         async ([namespace, flowId, revision]) => {
             if (namespace && flowId && !flowStore.flowYaml) {
                 try {
-                    const flow = await flowStore.loadFlow({namespace: namespace as string, id: flowId as string, revision: revision as string | undefined, store: false})
+                    const flow = await flowStore.loadFlow({namespace: namespace as string, id: flowId as string, revision: revision ? Number(revision) : undefined, store: false})
                     if (flow?.source) {
                         flowStore.flowYaml = flow.source
                         flowStore.flowYamlOrigin = flow.source

--- a/ui/src/components/flows/FlowCreate.vue
+++ b/ui/src/components/flows/FlowCreate.vue
@@ -53,7 +53,7 @@
             ?? "company.team"
 
         if (route.query.copy && flowStore.flow) {
-            flowYaml = flowStore.flow.source
+            flowYaml = flowStore.flow.source ?? ""
         } else if (onboardingPresetFlow) {
             flowYaml = onboardingPresetFlow
             sessionStorage.removeItem(ONBOARDING_FLOW_PRESET_KEY)
@@ -93,7 +93,7 @@ tasks:
             namespace: selectedNamespace,
             ...parsedFlow,
             source: flowYaml,
-        }
+        } as any
 
         flowStore.initYamlSource()
     }

--- a/ui/src/components/flows/FlowRevisions.vue
+++ b/ui/src/components/flows/FlowRevisions.vue
@@ -65,7 +65,7 @@
                 namespace,
                 id,
             })
-            revisions.value = loaded ?? []
+            revisions.value = (loaded ?? []) as any
         } catch (err) {
             console.error("Failed to load revisions", err)
             revisions.value = []
@@ -108,7 +108,7 @@
         return (await flowStore.loadFlow({
             namespace: flow.value?.namespace ?? "",
             id: flow.value?.id ?? "",
-            revision: revision.toString(),
+            revision: revision,
             allowDeleted: true,
             store: false,
         })).source

--- a/ui/src/components/flows/Flows.vue
+++ b/ui/src/components/flows/Flows.vue
@@ -257,6 +257,7 @@
     import _merge from "lodash/merge"
     import * as FILTERS from "../../utils/filters"
     import {flowYamlUtils as YAML_UTILS} from "@kestra-io/design-system"
+    import * as FlowAPI from "@kestra-io/kestra-sdk/flows"
     import {useFlowFilter} from "../filter/configurations"
     import useRestoreUrl from "../../composables/useRestoreUrl"
 
@@ -530,15 +531,16 @@
             () => {
                 const flowCount = queryBulkAction.value ? flowStore.total : selection.value.length
                 if (queryBulkAction.value) {
-                    return flowStore.exportFlowByQuery(loadQuery()).then(() => {
+                    return FlowAPI.exportFlowsByQuery(loadQuery()).then(() => {
                         toast.success(t("flows exported", {count: flowCount}))
                         toggleAllUnselected()
                     })
                 } else {
-                    return flowStore.exportFlowByIds({ids: selection.value}).then(() => {
-                        toast.success(t("flows exported", {count: flowCount}))
-                        toggleAllUnselected()
-                    })
+                    return FlowAPI.exportFlowsByIds({body: selectionIds.value})
+                        .then(() => {
+                            toast.success(t("flows exported", {count: flowCount}))
+                            toggleAllUnselected()
+                        })
                 }
             },
         )
@@ -549,13 +551,13 @@
             t("flow disable", {flowCount: queryBulkAction.value ? flowStore.total : selection.value.length}),
             () => {
                 if (queryBulkAction.value) {
-                    return flowStore.disableFlowByQuery(loadQuery()).then((r: any) => {
+                    return FlowAPI.disableFlowsByQuery(loadQuery()).then((r: any) => {
                         toast.success(t("flows disabled", {count: r.data.count}))
                         toggleAllUnselected()
                         dataTable.value?.reload()
                     })
                 } else {
-                    return flowStore.disableFlowByIds({ids: selectionIds.value}).then((r: any) => {
+                    return FlowAPI.disableFlowsByIds({body: selectionIds.value}).then((r: any) => {
                         toast.success(t("flows disabled", {count: r.data.count}))
                         toggleAllUnselected()
                         dataTable.value?.reload()
@@ -578,13 +580,13 @@
             t("flow enable", {flowCount: queryBulkAction.value ? flowStore.total : selection.value.length}),
             () => {
                 if (queryBulkAction.value) {
-                    return flowStore.enableFlowByQuery(loadQuery()).then((r: any) => {
+                    return FlowAPI.enableFlowsByQuery(loadQuery()).then((r: any) => {
                         toast.success(t("flows enabled", {count: r.data.count}))
                         toggleAllUnselected()
                         dataTable.value?.reload()
                     })
                 } else {
-                    return flowStore.enableFlowByIds({ids: selectionIds.value}).then((r: any) => {
+                    return FlowAPI.enableFlowsByIds({body: selectionIds.value}).then((r: any) => {
                         toast.success(t("flows enabled", {count: r.data.count}))
                         toggleAllUnselected()
                         dataTable.value?.reload()
@@ -599,13 +601,13 @@
             t("flow delete", {flowCount: queryBulkAction.value ? flowStore.total : selection.value.length}),
             () => {
                 if (queryBulkAction.value) {
-                    return flowStore.deleteFlowByQuery(loadQuery()).then((r: any) => {
+                    return FlowAPI.deleteFlowsByQuery(loadQuery()).then((r: any) => {
                         toast.success(t("flows deleted", {count: r.data.count}))
                         toggleAllUnselected()
                         dataTable.value?.reload()
                     })
                 } else {
-                    return flowStore.deleteFlowByIds({ids: selectionIds.value}).then((r: any) => {
+                    return FlowAPI.deleteFlowsByIds({body: selectionIds.value}).then((r: any) => {
                         toast.success(t("flows deleted", {count: r.data.count}))
                         toggleAllUnselected()
                         dataTable.value?.reload()
@@ -616,18 +618,17 @@
     }
 
     function importFlows() {
-        const formData = new FormData()
         if (file.value && file.value.files && file.value.files[0]) {
-            formData.append("fileUpload", file.value.files[0])
-            flowStore.importFlows({file: formData, failOnError: true}).then((res: any) => {
-                if (res.data.length > 0) {
-                    toast.warning(t("flows not imported") + ": " + res.data.join(", "))
-                } else {
-                    toast.success(t("flows imported"))
-                }
-                if (file.value) file.value.value = ""
-                dataTable.value?.reload()
-            })
+            FlowAPI.importFlows({fileUpload: file.value.files[0], failOnError: true})
+                .then((res) => {
+                    if (res.length > 0) {
+                        toast.warning(t("flows not imported") + ": " + res.join(", "))
+                    } else {
+                        toast.success(t("flows imported"))
+                    }
+                    if (file.value) file.value.value = ""
+                    dataTable.value?.reload()
+                })
         }
     }
 
@@ -670,9 +671,17 @@
     }
 
     async function exportFlowsAsStream() {
-        await flowStore.exportFlowAsCSV(
+        const data = await FlowAPI.exportFlowsByQuery(
             route.query,
         )
+        const url = window.URL.createObjectURL(new Blob([data]))
+        const link = document.createElement("a")
+        link.href = url
+        link.setAttribute("download", "flows.csv")
+        document.body.appendChild(link)
+        link.click()
+        link.remove()
+        window.URL.revokeObjectURL(url)
     }
 </script>
 

--- a/ui/src/components/flows/TaskEdit.vue
+++ b/ui/src/components/flows/TaskEdit.vue
@@ -167,7 +167,7 @@
         await flowStore.loadFlow({
             namespace: props.namespace,
             id: props.flowId,
-            revision: props.revision?.toString(),
+            revision: props.revision ? Number(props.revision) : undefined,
         })
         if (props.revision) {
             if (!revisions.value?.[props.revision - 1]) {

--- a/ui/src/components/namespaces/components/NamespaceFilesEditorView.vue
+++ b/ui/src/components/namespaces/components/NamespaceFilesEditorView.vue
@@ -44,7 +44,7 @@
             revision: 0,
             source: `namespace: ${newVal}\n`,
             errors: [],
-        }
+        } as any
     }, {immediate: true})
 
     const sideBarSize = useStorage("namespace-files-editor-view-sidebar-size", 1)

--- a/ui/src/components/settings/BasicSettings.vue
+++ b/ui/src/components/settings/BasicSettings.vue
@@ -293,6 +293,7 @@
 </script>
 
 <script>
+    import * as FlowAPI from "@kestra-io/kestra-sdk/flows"
     import RouteContext from "../../mixins/routeContext"
     import TopNavBar from "../../components/layout/TopNavBar.vue"
     import NamespaceSelect from "../../components/namespaces/components/NamespaceSelect.vue"
@@ -577,7 +578,7 @@
                     .then((result) => {
                         const flowCount = result.total
 
-                        return this.flowStore.exportFlowByQuery({})
+                        return FlowAPI.exportFlowByQuery({})
                             .then(() => {
                                 this.$toast().success(
                                     this.$t("flows exported", {

--- a/ui/src/override/services/flowAutoCompletionProvider.ts
+++ b/ui/src/override/services/flowAutoCompletionProvider.ts
@@ -203,7 +203,7 @@ export class FlowAutoCompletion extends YamlAutoCompletion {
                     {
                         namespace,
                         id: flowId,
-                        revision,
+                        revision: revision ? Number(revision) : undefined,
                         source: false,
                         store: false,
                         deleted: true,

--- a/ui/src/stores/core.ts
+++ b/ui/src/stores/core.ts
@@ -4,7 +4,7 @@ import {ref} from "vue"
 import {useClient} from "@kestra-io/kestra-sdk"
 import {Message} from "../components/ErrorToast.vue"
 import {TUTORIAL_NAMESPACE} from "../utils/constants"
-import {Flow} from "./flow"
+import {Flow} from "@kestra-io/kestra-sdk"
 
 export const useCoreStore = defineStore("core", () => {
     const message = ref<Message>()

--- a/ui/src/stores/flow.ts
+++ b/ui/src/stores/flow.ts
@@ -251,7 +251,13 @@ export const useFlowStore = defineStore("flow", () => {
                 if (error?.response?.status === 422 && error?.response?.data?.message?.includes("Flow id already exists")) {
                     const shouldRedirect = await KsMessageBox({
                         title: t("confirmation"),
-                        message: () => h(KsMarkdown, {content: t("flow already exists message", {id: flowParsed.value.id, namespace: flowParsed.value.namespace})}),
+                        message: () => h(KsMarkdown, {
+                            content: t("flow already exists message", 
+                                {
+                                    id: flowParsed.value.id, 
+                                    namespace: flowParsed.value.namespace,
+                                }),
+                            }),
                         type: "warning",
                         showCancelButton: true,
                     }).then(async () => {

--- a/ui/src/stores/flow.ts
+++ b/ui/src/stores/flow.ts
@@ -1,10 +1,11 @@
 import {computed, h, ref, watch} from "vue"
 import {KsMarkdown, KsMessageBox} from "@kestra-io/design-system"
+import {AbstractTrigger, Flow, FlowWithSource, PagedResultsFlow, Task} from "@kestra-io/kestra-sdk"
+import {flowYamlUtils as YAML_UTILS} from "@kestra-io/design-system"
+import * as FlowAPI from "@kestra-io/kestra-sdk/flows"
+import * as MetricsAPI from "@kestra-io/kestra-sdk/metrics"
 import resource from "../models/resource"
 import action from "../models/action"
-import {flowYamlUtils as YAML_UTILS} from "@kestra-io/design-system"
-import * as Utils from "../utils/utils"
-import {apiUrl} from "override/utils/route"
 import {useCoreStore} from "./core"
 import {useUnsavedChangesStore} from "./unsavedChanges"
 import {defineStore} from "pinia"
@@ -15,30 +16,14 @@ import {globalI18n} from "../translations/i18n"
 import {transformResponse} from "../components/dependencies/composables/useDependencies"
 import {useAuthStore} from "override/stores/auth"
 import {useRoute} from "vue-router"
-import {useClient} from "@kestra-io/kestra-sdk"
 import {defaultNamespace} from "../composables/useNamespaces"
 import {TUTORIAL_NAMESPACE} from "../utils/constants"
+
 
 const textYamlHeader = {
     headers: {
         "Content-Type": "application/x-yaml",
     },
-}
-
-const VALIDATE = {validateStatus: (status: number) => status === 200 || status === 401}
-
-interface Trigger {
-    id: string;
-    type: string;
-    backfill?: {
-        start?: string;
-    };
-}
-
-export interface Task {
-    id: string,
-    type: string
-    tasks?: Task[]
 }
 
 export interface Input {
@@ -56,24 +41,6 @@ interface FlowValidations {
     deprecationPaths?: string[];
 }
 
-export interface Flow {
-    id: string;
-    namespace: string;
-    source: string;
-    revision?: number;
-    deleted?: boolean;
-    disabled?: boolean;
-    labels?: Record<string, string | boolean>;
-    triggers?: Trigger[];
-    inputs?: Input[];
-    errors?: { message: string; code?: string, id?: string }[];
-    concurrency?: {
-        limit: number;
-        behavior: string;
-    };
-    tasks?: Task[];
-}
-
 export type FlowSaveOutcome =
     | "saved"
     | "redirect_to_update"
@@ -87,9 +54,11 @@ export function isSuccessfulFlowSaveOutcome(
     return outcome === "saved" || outcome === "redirect_to_update"
 }
 
+export type {Flow, FlowWithSource}
+
 export const useFlowStore = defineStore("flow", () => {
     const flows = ref<Flow[]>()
-    const flow = ref<Flow>()
+    const flow = ref<FlowWithSource>()
     const task = ref<Task>()
     const search = ref<any[]>()
     const total = ref<number>(0)
@@ -112,8 +81,6 @@ export const useFlowStore = defineStore("flow", () => {
     const expandedSubflows = ref<string[]>([])
     const metadata = ref<Record<string, any>>()
     const creationId = ref<string>()
-
-    const axios = useClient()
 
     const coreStore = useCoreStore()
     const unsavedChangesStore = useUnsavedChangesStore()
@@ -343,177 +310,123 @@ export const useFlowStore = defineStore("flow", () => {
     async function initYamlSource() {
         if (!flow.value) return
         const {source} = flow.value
-        flowYaml.value = source
-        flowYamlOrigin.value = source
+        flowYaml.value = source ?? ""
+        flowYamlOrigin.value = source ?? ""
         if (flowHaveTasks.value) {
             fetchGraph()
         }
 
         // validate flow on first load
-        return validateFlow({flow: isCreating.value ? source : yamlWithNextRevision.value})
+        return validateFlow({flow: isCreating.value ? source ?? "" : yamlWithNextRevision.value})
     }
 
-    function findFlows(options: { [key: string]: any }) {
-        const sortString = options.sort ? `?sort=${options.sort}` : ""
-        delete options.sort
-        return axios.get(`${apiUrl()}/flows/search${sortString}`, {
-            params: options,
-        }).then(response => {
-            if (options.onlyTotal) {
-                return response.data.total
+    function findFlows(options: Parameters<typeof FlowAPI.searchFlows>[0] & { onlyTotal: true }): Promise<number>
+    function findFlows(options: Parameters<typeof FlowAPI.searchFlows>[0] & { onlyTotal?: false }): Promise<PagedResultsFlow>
+    function findFlows(options: Parameters<typeof FlowAPI.searchFlows>[0] & { onlyTotal?: boolean }){
+        return FlowAPI.searchFlows(
+            options,
+        ).then(data => {
+            if(options.onlyTotal) {
+                return data.total
             }
+            flows.value = data.results
+            total.value = data.total
+            overallTotal.value = data.results.filter((f: any) => f.namespace !== TUTORIAL_NAMESPACE).length
 
-            else {
-                flows.value = response.data.results
-                total.value = response.data.total
-                overallTotal.value = response.data.results.filter((f: any) => f.namespace !== TUTORIAL_NAMESPACE).length
-
-                return response.data
-            }
+            return data
         })
     }
-    function searchFlows(options: { [key: string]: any }) {
-        const sortString = options.sort ? `?sort=${options.sort}` : ""
-        delete options.sort
-        return axios.get(`${apiUrl()}/flows/source${sortString}`, {
-            params: options,
-        }).then(response => {
-            search.value = response.data.results
-            total.value = response.data.total
 
-            return response.data
+    function searchFlows(options: { [key: string]: any }) {
+        const {sort, ...rest} = options
+        return FlowAPI.searchFlowsBySourceCode({
+            ...rest,
+            ...(sort ? {sort: Array.isArray(sort) ? sort : [sort]} : {}),
+        }).then(data => {
+            search.value = data.results
+            total.value = data.total
+
+            return data
         })
     }
 
     function flowsByNamespace(namespace: string) {
-        return axios.get(`${apiUrl()}/flows/${namespace}`).then(response => {
-            return response.data
-        })
+        return FlowAPI.listFlowsByNamespace({namespace})
     }
 
-    async function loadFlow(options: { namespace: string, id: string, revision?: string, allowDeleted?: boolean, source?: boolean, store?: boolean, deleted?: boolean, httpClient?: any }) {
-        const httpClient = options.httpClient ?? axios
-        const response: {data:Flow & {exception?: string}} = await httpClient.get(`${apiUrl()}/flows/${options.namespace}/${options.id}`,
-            {
-                params: {
-                    revision: options.revision,
-                    allowDeleted: options.allowDeleted,
-                    source: options.source === undefined ? true : undefined,
-                },
+    async function loadFlow(options: Parameters<typeof FlowAPI.flow>[0] & { store?: boolean, deleted?: boolean }) {
+        const data = await FlowAPI.flow(
+                options,
+                {
                 validateStatus: (status: number) => {
                     return options.deleted ? status === 200 || status === 404 : status === 200
                 },
             })
 
-        if (response.data.exception) {
-            coreStore.message = {
-                title: "Invalid source code",
-                message: response.data.exception,
-                variant: "error",
-            }
-
-            // add this error to the list of errors
-            flowValidation.value = {
-                constraints: response.data.exception,
-                outdated: false,
-                infos: [],
-            }
-            delete response.data.exception
-        }
-
         validateFlow({
-            flow: `revision: ${(response.data.revision ?? 0) + 1}\n${response.data.source}`,
+            flow: `revision: ${(data.revision ?? 0) + 1}\n${data.source}`,
         })
 
         if (options.store === false) {
-            return response.data
+            return data
         }
 
-        flow.value = response.data
-        flowYaml.value = response.data.source
-        flowYamlOrigin.value = response.data.source
+        flow.value = data
+        flowYaml.value = data.source ?? ""
+        flowYamlOrigin.value = data.source ?? ""
         overallTotal.value = 1
 
-        return response.data
+        return data
 
     }
+
     function loadTask(options: { namespace: string, id: string, taskId: string, revision?: string }) {
-        return axios.get(
-            `${apiUrl()}/flows/${options.namespace}/${options.id}/tasks/${options.taskId}${options.revision ? "?revision=" + options.revision : ""}`,
+        return FlowAPI.taskFromFlow(
             {
-                validateStatus: (status: number) => {
-                    return status === 200 || status === 404
-                },
+                namespace: options.namespace,
+                id: options.id,
+                taskId: options.taskId,
+                ...(options.revision ? {revision: Number(options.revision)} : {}),
             },
         )
-            .then(response => {
-                if (response.status === 200) {
-                    task.value = response.data
+            .then(data => {
+                task.value = data
 
-                    return response.data
-                } else {
-                    return null
-                }
+                return data
             })
+            .catch(() => null)
     }
     function saveFlow(options: { flow: string }) {
         const flowData = YAML_UTILS.parse(options.flow)
-        return axios.put(`${apiUrl()}/flows/${flowData.namespace}/${flowData.id}`, options.flow, {
-            ...textYamlHeader,
-            ...VALIDATE,
-        })
-            .then(response => {
-                if (response.status >= 300) {
-                    return Promise.reject(response)
-                } else {
-                    flow.value = response.data
+        return FlowAPI.updateFlow({namespace: flowData.namespace, id: flowData.id, body: options.flow})
+            .then(data => {
+                flow.value = data
 
-                    return response.data
-                }
-            })
-    }
-    function updateFlowTask(options: { flow: Flow, task: Task }) {
-        return axios
-            .patch(`${apiUrl()}/flows/${options.flow.namespace}/${options.flow.id}/${options.task.id}`, options.task).then(response => {
-                flow.value = response.data
-
-                return response.data
-            })
-            .then(f => {
-                loadGraph({flow: f})
-
-                return f
+                return data
             })
     }
 
     function createFlow(options: { flow: string }) {
-        return axios.post(`${apiUrl()}/flows`, options.flow, {
-            ...textYamlHeader,
-            ...VALIDATE,
-            showMessageOnError: false,
-        }).then(response => {
-            if (response.status >= 300) {
-                return Promise.reject(response)
-            }
+        return FlowAPI.createFlow({body: options.flow})
+            .then(data => {
+                const creationPanels = localStorage.getItem(`el-fl-creation-${creationId.value}`) ?? YAML_UTILS.stringify([])
+                localStorage.setItem(`el-fl-${flow.value!.namespace}-${flow.value!.id}`, creationPanels)
 
-            const creationPanels = localStorage.getItem(`el-fl-creation-${creationId.value}`) ?? YAML_UTILS.stringify([])
-            localStorage.setItem(`el-fl-${flow.value!.namespace}-${flow.value!.id}`, creationPanels)
+                flow.value = data
 
-            flow.value = response.data
+                // clean-up
+                localStorage.removeItem(`el-fl-creation-${creationId.value}`)
+                creationId.value = undefined
 
-            // clean-up
-            localStorage.removeItem(`el-fl-creation-${creationId.value}`)
-            creationId.value = undefined
-
-            return response.data
-        })
+                return data
+            })
     }
 
-    function loadDependencies(options: { namespace: string, id: string, subtype: "FLOW" | "EXECUTION" }, onlyCount = false) {
-        return axios.get(`${apiUrl()}/flows/${options.namespace}/${options.id}/dependencies?expandAll=${!onlyCount}`).then(response => {
+    function loadDependencies(options: Parameters<typeof FlowAPI.flowDependencies>[0] & { subtype: "FLOW" | "EXECUTION" }) {
+        return FlowAPI.flowDependencies(options).then(data => {
             return {
-                ...(!onlyCount ? {data: transformResponse(response.data, options.subtype)} : {}),
-                count: response.data.nodes ? new Set(response.data.nodes.map((r:{uid:string}) => r.uid)).size : 0,
+                ...(options.expandAll ? {data: transformResponse(data as any, options.subtype)} : {}),
+                count: data.nodes ? new Set(data.nodes.map((r:{uid:string}) => r.uid)).size : 0,
             }
         })
     }
@@ -521,15 +434,15 @@ export const useFlowStore = defineStore("flow", () => {
 function deleteFlowAndDependencies() {
     const metadataForDelete = flowYamlMetadata.value
 
-    return axios
-        .get(
-            `${apiUrl()}/flows/${metadataForDelete.namespace}/${metadataForDelete.id}/dependencies`,
-            {params: {destinationOnly: true}},
-        )
-        .then((response) => {
+    return FlowAPI.flowDependencies({
+            namespace: metadataForDelete.namespace,
+            id: metadataForDelete.id,
+            destinationOnly: true,
+        })
+        .then((data) => {
             let warning = ""
-            if (response.data && response.data.nodes) {
-                const deps = response.data.nodes
+            if (data && data.nodes) {
+                const deps = data.nodes
                     .filter(
                         (n: any) =>
                             !(
@@ -576,7 +489,7 @@ function deleteFlowAndDependencies() {
 }
 
     function deleteFlow(options: { namespace: string, id: string }) {
-        return axios.delete(`${apiUrl()}/flows/${options.namespace}/${options.id}`).then(() => {
+        return FlowAPI.deleteFlow({namespace: options.namespace, id: options.id}).then(() => {
             flow.value = undefined
         })
     }
@@ -587,10 +500,10 @@ function deleteFlowAndDependencies() {
         if (flowVar.revision) {
             params["revision"] = flowVar.revision
         }
-        return axios.get(`${apiUrl()}/flows/${flowVar.namespace}/${flowVar.id}/graph`, {params}).then(response => {
+        return FlowAPI.generateFlowGraph({namespace: flowVar.namespace, id: flowVar.id, ...params}).then(data => {
             invalidGraph.value = false
-            flowGraph.value = response.data
-            return response.data
+            flowGraph.value = data as any
+            return data
         }).catch(() => {
             invalidGraph.value = true
         })
@@ -602,9 +515,14 @@ function deleteFlowAndDependencies() {
         if (!flowParsed.id || !flowParsed.namespace) {
             flowSource = YAML_UTILS.updateMetadata(flowSource, {id: "default", namespace: "default"})
         }
-        return axios.post(`${apiUrl()}/flows/graph`, flowSource, {...config, withCredentials: true})
-            .then(response => {
-                flowGraph.value = response.data
+        return FlowAPI.generateFlowGraphFromSource(
+            {
+                body: flowSource,
+                ...(config?.params?.subflows ? {subflows: config.params.subflows.split(",")} : {}),
+            },
+        )
+            .then(data => {
+                flowGraph.value = data as any
 
                 const flowVar = YAML_UTILS.parse(options.flow)
                 flowVar.id = flow.value?.id ?? flowVar.id
@@ -614,16 +532,16 @@ function deleteFlowAndDependencies() {
                 flowVar.revision = flow.value?.revision
                 flow.value = flowVar
 
-                return response
+                return data
             }).catch(error => {
-                if (error.response?.status === 422 && (!config?.params?.subflows || config?.params?.subflows?.length === 0)) {
-                    return Promise.resolve(error.response)
+                if (error?.response?.status === 422 && (!config?.params?.subflows || config?.params?.subflows?.length === 0)) {
+                    return Promise.resolve(error.response?.data)
                 }
 
-                if ([404, 422].includes(error.response?.status) && config?.params?.subflows?.length > 0) {
+                if ([404, 422].includes(error?.response?.status) && config?.params?.subflows?.length > 0) {
                     coreStore.message = {
                         title: "Couldn't expand subflow",
-                        message: error.response.data.message,
+                        message: error.response?.data?.message,
                         variant: "error",
                     }
                 }
@@ -639,78 +557,19 @@ function deleteFlowAndDependencies() {
         if (!flowParsed.id || !flowParsed.namespace) {
             flowSource = YAML_UTILS.updateMetadata(flowSource, {id: "default", namespace: "default"})
         }
-        return axios.post(`${apiUrl()}/flows/graph`, flowSource, {...config})
-            .then(response => response.data)
+        return FlowAPI.generateFlowGraphFromSource({
+            body: flowSource,
+            ...(config?.params?.subflows ? {subflows: config.params.subflows.split(",")} : {}),
+        })
     }
 
     function loadRevisions(options: { namespace: string, id: string, store?: boolean, allowDeleted?: boolean }) {
-        return axios.get(`${apiUrl()}/flows/${options.namespace}/${options.id}/revisions`).then(response => {
+        return FlowAPI.listFlowRevisions({namespace: options.namespace, id: options.id}).then(data => {
             if (options.store !== false) {
-                revisions.value = response.data
+                revisions.value = data
             }
-            return response.data
+            return data
         })
-    }
-
-    function exportFlowByIds(options: { ids: string[] }) {
-        return axios.post(`${apiUrl()}/flows/export/by-ids`, options.ids, {responseType: "blob"})
-            .then(response => {
-                const blob = new Blob([response.data], {type: "application/octet-stream"})
-                const url = window.URL.createObjectURL(blob)
-                Utils.downloadUrl(url, "flows.zip")
-            })
-    }
-
-    function exportFlowByQuery(options: { namespace: string, id: string }) {
-        return axios.get(`${apiUrl()}/flows/export/by-query`, {params: options, headers: {"Accept": "application/octet-stream"}})
-            .then(response => {
-                Utils.downloadUrl(response.request.responseURL, "flows.zip")
-            })
-    }
-
-    async function exportFlowAsCSV(params: any) {
-        const response = await axios.get(
-            `${apiUrl()}/flows/export/by-query/csv`,
-            {params, responseType: "blob"},
-        )
-        const url = window.URL.createObjectURL(new Blob([response.data]))
-        const link = document.createElement("a")
-        link.href = url
-        link.setAttribute("download", "flows.csv")
-        document.body.appendChild(link)
-        link.click()
-        link.remove()
-        window.URL.revokeObjectURL(url)
-    }
-
-    function importFlows(options: { file: FormData,  failOnError: boolean }) {
-         const {file, failOnError} = options
-        return axios.post(`${apiUrl()}/flows/import`, file, {
-            headers: {"Content-Type": "multipart/form-data"},
-            params: {failOnError},
-        }).then(response => {
-            return response
-        })
-    }
-    function disableFlowByIds(options: { ids: {id: string, namespace: string}[] }) {
-        return axios.post(`${apiUrl()}/flows/disable/by-ids`, options.ids)
-    }
-    function disableFlowByQuery(options: { namespace: string, id: string }) {
-        return axios.post(`${apiUrl()}/flows/disable/by-query`, options, {params: options})
-    }
-    function enableFlowByIds(options: { ids: {id: string, namespace: string}[] }) {
-        return axios.post(`${apiUrl()}/flows/enable/by-ids`, options.ids)
-    }
-    function enableFlowByQuery(options: { namespace: string, id: string }) {
-        return axios.post(`${apiUrl()}/flows/enable/by-query`, options, {params: options})
-    }
-
-    function deleteFlowByIds(options: { ids: {id: string, namespace: string}[] }) {
-        return axios.delete(`${apiUrl()}/flows/delete/by-ids`, {data: options.ids})
-    }
-
-    function deleteFlowByQuery(options: { namespace: string, id: string }) {
-        return axios.delete(`${apiUrl()}/flows/delete/by-query`, {params: options})
     }
 
     function validateFlow(options: { flow: string }) {
@@ -726,9 +585,9 @@ function deleteFlowAndDependencies() {
             }
         }
 
-        return axios.post(`${apiUrl()}/flows/validate`, options.flow, {...textYamlHeader, withCredentials: true})
-            .then(response => {
-                const validResults = response.data[0] ?? {}
+        return FlowAPI.validateFlows({body: options.flow})
+            .then(data => {
+                const validResults = data[0] ?? {}
 
                 const constraintsArray = [validResults.constraints, flowValidationIssues.constraints].filter(Boolean)
 
@@ -745,50 +604,50 @@ function deleteFlowAndDependencies() {
     }
 
     function validateTask(options: { task: string, section: string }) {
-        return axios.post(`${apiUrl()}/flows/validate/task`, options.task, {...textYamlHeader, withCredentials: true, params: {section: options.section}})
-            .then(response => {
-                taskError.value = response.data.constraints
-                return response.data
+        return FlowAPI.validateTask({body: options.task as any, section: options.section as any})
+            .then(data => {
+                taskError.value = data.constraints
+                return data
             })
     }
     function loadFlowMetrics(options: { namespace: string, id: string }) {
-        return axios.get(`${apiUrl()}/metrics/names/${options.namespace}/${options.id}`)
-            .then(response => {
-                metrics.value = response.data
-                return response.data
+        return MetricsAPI.listFlowMetrics({namespace: options.namespace, flowId: options.id})
+            .then(data => {
+                metrics.value = data
+                return data
             })
     }
     function loadTaskMetrics(options: { namespace: string, id: string, taskId: string }) {
-        return axios.get(`${apiUrl()}/metrics/names/${options.namespace}/${options.id}/${options.taskId}`)
-            .then(response => {
-                metrics.value = response.data
-                return response.data
+        return MetricsAPI.listTaskMetrics({namespace: options.namespace, flowId: options.id, taskId: options.taskId})
+            .then(data => {
+                metrics.value = data
+                return data
             })
     }
     function loadTasksWithMetrics(options: { namespace: string, id: string }) {
-        return axios.get(`${apiUrl()}/metrics/tasks/${options.namespace}/${options.id}`)
-            .then(response => {
-                tasksWithMetrics.value = response.data
-                return response.data
+        return MetricsAPI.listTasksWithMetrics({namespace: options.namespace, flowId: options.id})
+            .then(data => {
+                tasksWithMetrics.value = data
+                return data
             })
     }
     function loadFlowAggregatedMetrics(options: { namespace: string, id: string, metric: string, aggregation?: string, startDate?: string, endDate?: string }) {
-        return axios.get(`${apiUrl()}/metrics/aggregates/${options.namespace}/${options.id}/${options.metric}`, {params: options})
-            .then(response => {
-                aggregatedMetrics.value = response.data
-                return response.data
+        return MetricsAPI.aggregateMetricsFromFlow({namespace: options.namespace, flowId: options.id, metric: options.metric, aggregation: options.aggregation, startDate: options.startDate, endDate: options.endDate})
+            .then(data => {
+                aggregatedMetrics.value = data
+                return data
             })
     }
     function loadTaskAggregatedMetrics(options: { namespace: string, id: string, taskId: string, metric: string, aggregation?: string, startDate?: string, endDate?: string }) {
-        return axios.get(`${apiUrl()}/metrics/aggregates/${options.namespace}/${options.id}/${options.taskId}/${options.metric}`, {params: options})
-            .then(response => {
-                aggregatedMetrics.value = response.data
-                return response.data
+        return MetricsAPI.aggregateMetricsFromTask({namespace: options.namespace, flowId: options.id, taskId: options.taskId, metric: options.metric, aggregation: options.aggregation, startDate: options.startDate, endDate: options.endDate})
+            .then(data => {
+                aggregatedMetrics.value = data
+                return data
             })
     }
 
-    function setTrigger({index, trigger}: { index: number, trigger: Trigger }) {
-        const flowVar = flow.value ?? {} as Flow
+    function setTrigger({index, trigger}: { index: number, trigger: AbstractTrigger }) {
+        const flowVar = flow.value ?? {} as FlowWithSource
 
         if (flowVar.triggers === undefined) {
             flowVar.triggers = []
@@ -814,11 +673,11 @@ function deleteFlowAndDependencies() {
         openAiCopilot.value = value
     }
 
-    function addTrigger(trigger: Trigger) {
+    function addTrigger(trigger: AbstractTrigger) {
         const flowVar = flow.value ?? {} as Flow
 
-        if (trigger.backfill === undefined) {
-            trigger.backfill = {
+        if ((trigger as any).backfill === undefined) {
+            (trigger as any).backfill = {
                 start: undefined,
             }
         }
@@ -833,7 +692,7 @@ function deleteFlowAndDependencies() {
     }
 
     function deleteRevision(options: { namespace: string, id: string, revision: string }) {
-        return axios.delete(`${apiUrl()}/flows/${options.namespace}/${options.id}/revisions?revisions=${options.revision}`)
+        return FlowAPI.deleteRevisions({namespace: options.namespace, id: options.id, revisions: [Number(options.revision)]})
     }
 
     const authStore = useAuthStore()
@@ -856,7 +715,7 @@ function deleteFlowAndDependencies() {
             return false
         }
 
-        return (flow.value.labels?.["system.readOnly"] === "true") || (flow.value.labels?.["system.readOnly"] === true)
+        return ((flow.value.labels as any)?.["system.readOnly"] === "true") || ((flow.value.labels as any)?.["system.readOnly"] === true)
     })
 
     const isReadOnly = computed(() => {
@@ -967,7 +826,6 @@ function deleteFlowAndDependencies() {
         loadFlow,
         loadTask,
         saveFlow,
-        updateFlowTask,
         createFlow,
         loadDependencies,
         deleteFlowAndDependencies,
@@ -976,16 +834,6 @@ function deleteFlowAndDependencies() {
         loadGraphFromSource,
         getGraphFromSourceResponse,
         loadRevisions,
-        exportFlowByIds,
-        exportFlowByQuery,
-        exportFlowAsCSV,
-        importFlows,
-        disableFlowByIds,
-        disableFlowByQuery,
-        enableFlowByIds,
-        enableFlowByQuery,
-        deleteFlowByIds,
-        deleteFlowByQuery,
         validateFlow,
         validateTask,
         loadFlowMetrics,

--- a/ui/src/stores/playground.ts
+++ b/ui/src/stores/playground.ts
@@ -8,9 +8,10 @@ import {useRoute, useRouter} from "vue-router"
 import {State} from "@kestra-io/design-system"
 import {useToast} from "../utils/toast"
 import {useI18n} from "vue-i18n"
-import {Flow, useFlowStore} from "./flow"
+import {useFlowStore} from "./flow"
 import {useFileExplorerStore} from "./fileExplorer"
 import isEqual from "lodash/isEqual"
+import {FlowWithSource} from "@kestra-io/kestra-sdk"
 
 interface ExecutionWithGraph extends Execution {
     graph?: VueFlowUtils.FlowGraph;
@@ -68,7 +69,7 @@ export const usePlaygroundStore = defineStore("playground", () => {
 
     const taskIdToTaskRunIdMap: Map<string, string>  = new Map()
 
-    async function triggerExecution(flow: Flow, breakpoints?: string[]) {
+    async function triggerExecution(flow: FlowWithSource, breakpoints?: string[]) {
         const defaultInputValues: Record<string, any> = {}
         for (const input of (flow.inputs || [])) {
             const {type, defaults} = input
@@ -102,7 +103,7 @@ export const usePlaygroundStore = defineStore("playground", () => {
             const lastExecutionFlow = await flowStore.loadFlow({
                 namespace: flowStore.flow.namespace || "",
                 id: flowStore.flow.id || "",
-                revision: lastExecution.flowRevision.toString(),
+                revision: lastExecution.flowRevision,
                 store: false,
             })
 
@@ -148,9 +149,9 @@ export const usePlaygroundStore = defineStore("playground", () => {
         }
 
         // find the node uid of the task with the given taskId
-        const taskNode = graph.nodes.find((node: any) => node?.task?.id === taskId)
+        const taskNode = (graph as any)?.nodes?.find((node: any) => node?.task?.id === taskId)
 
-        const nextTasksNodes = VueFlowUtils.getNextTaskNodes(graph, taskNode)
+        const nextTasksNodes = VueFlowUtils.getNextTaskNodes(graph as any, taskNode)
 
         const nextTasksIds = nextTasksNodes.map((node: any) => node.task.id)
 
@@ -272,7 +273,7 @@ export const usePlaygroundStore = defineStore("playground", () => {
         executionsStore.execution = execution
 
         if(execution)
-            addExecution(execution, graph)
+            addExecution(execution, graph as any)
     }
 
     function updateExecution(execution: ExecutionWithGraph) {

--- a/ui/src/utils/welcomeGuard.ts
+++ b/ui/src/utils/welcomeGuard.ts
@@ -7,7 +7,7 @@ export const shouldShowWelcome = async () => {
     const nonTutorialFlows = await useFlowStore().findFlows({
         size: 1,
         onlyTotal: true,
-        "filters[namespace][NOT_EQUALS]": TUTORIAL_NAMESPACE,
+        filters: [{field: "NAMESPACE", operation: "NOT_EQUALS", value: TUTORIAL_NAMESPACE as any}],
     })
 
     return !nonTutorialFlows


### PR DESCRIPTION
- Updated flow fetching in TriggerConfigureModal to use new filter structure.
- Removed unnecessary parameter in useDependencies for loading dependencies.
- Adjusted useExecutionRoot to handle flow dependencies without the extra parameter.
- Modified DebugPanel to convert revision to a number when loading flow.
- Ensured flowYaml is initialized as an empty string in FlowCreate when copying.
- Cast loaded revisions in FlowRevisions to any for type safety.
- Updated Flows component to utilize FlowAPI for exporting, enabling, disabling, and deleting flows.
- Refactored TaskEdit to convert revision to a number when loading flow.
- Adjusted NamespaceFilesEditorView to cast the object as any for type safety.
- Integrated FlowAPI in BasicSettings for exporting flows.
- Updated flowAutoCompletionProvider to convert revision to a number.
- Refactored core store to import Flow from kestra-sdk.
- Updated flow store to utilize FlowAPI for various flow operations and removed deprecated axios calls.
- Refactored playground store to use FlowWithSource type for flow parameter in triggerExecution.
- Adjusted welcomeGuard to use new filter structure for checking non-tutorial flows.