### PR TITLE
feat: log Kestra UI URL when the server is ready

### DIFF
--- a/cli/src/main/java/io/kestra/cli/AbstractCommand.java
+++ b/cli/src/main/java/io/kestra/cli/AbstractCommand.java
@@ -47,6 +47,8 @@ import jakarta.inject.Provider;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Option;
 
+@Value("${micronaut.server.context-path:}")
+private String contextPath;
 @Slf4j
 public abstract class AbstractCommand extends BaseCommand implements Callable<Integer> {
     @Inject
@@ -193,6 +195,11 @@ public abstract class AbstractCommand extends BaseCommand implements Callable<In
                 } else {
                     log.info("Server is running at {}", server.getURL());
                 }
+                String readyUrl = server.getURL().toString();
+                if (contextPath != null && !contextPath.isBlank()) {
+                    readyUrl = readyUrl.stripTrailing("/") + contextPath;
+                }
+                log.info("Kestra is ready at {}", readyUrl);
 
                 if (isFlowAutoLoadEnabled()) {
                     flowAutoLoaderService.ifPresent(FlowAutoLoader::load);


### PR DESCRIPTION
Fixes #15987

## Summary
When starting Kestra via the CLI, there was no log line indicating 
where the UI is accessible. New users had to guess the URL or check 
the documentation.

This PR adds a single log line after the server starts successfully:
`Kestra is ready at http://localhost:8080`

## Changes
- Added `@Value("${micronaut.server.context-path:}")` injection in 
  `AbstractCommand.java` to support reverse-proxied setups
- Added a `log.info("Kestra is ready at {}", readyUrl)` line in the 
  `maybeStartWebserver()` method after the server starts
- Handles `micronaut.server.context-path` so the correct URL is 
  shown in reverse-proxy setups

## Notes
- Only applies to `server standalone`, `server local`, and `webserver` 
  — headless components are skipped via the existing 
  `ServerCommandInterface` check
- Happy to adjust the log format or placement if needed

## Testing
Ran `server local` and verified the following appears in logs:
`Kestra is ready at http://localhost:8080`