### PR TITLE
fix(tests): update PostgresQueueTest to match null-byte sanitization behavior

### DIFF
--- a/jdbc-postgres/src/test/java/io/kestra/runner/postgres/PostgresQueueTest.java
+++ b/jdbc-postgres/src/test/java/io/kestra/runner/postgres/PostgresQueueTest.java
@@ -15,11 +15,12 @@ import io.kestra.core.utils.IdUtils;
 import io.kestra.jdbc.runner.JdbcQueueTest;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class PostgresQueueTest extends JdbcQueueTest {
     @Test
-    void invalidWorkerTaskShouldThrowDataException() throws QueueException {
+    void invalidWorkerTaskWithNullCharShouldBeSanitized() {
         var workerTaskResult = WorkerTaskResult.builder()
             .taskRun(
                 TaskRun.builder()
@@ -33,10 +34,9 @@ class PostgresQueueTest extends JdbcQueueTest {
             .outputs(Variables.inMemory(Map.of("value", "\u0000")))
             .build();
 
-        var exception = assertThrows(QueueException.class, () -> workerTaskResultQueue.emit(workerTaskResult));
-        assertThat(exception).isInstanceOf(UnsupportedMessageException.class);
-        assertThat(exception.getMessage()).contains("ERROR: unsupported Unicode escape sequence");
-        assertThat(exception.getCause()).isInstanceOf(DataException.class);
+        // JdbcJsonbUtils strips null bytes and their JSON-escaped form before storage,
+        // so the emit must succeed rather than throw.
+        assertThatNoException().isThrownBy(() -> workerTaskResultQueue.emit(workerTaskResult));
     }
 
     @Test


### PR DESCRIPTION
## Summary

- `invalidWorkerTaskShouldThrowDataException` was failing locally because commit #15983 changed `JdbcJsonbUtils.valueOf()` to also strip the JSON-escaped form of null bytes (`\u0000`) before inserting into Postgres.
- With both forms stripped, Postgres never sees an invalid payload, so no `DataException` is thrown — the old `assertThrows` assertion was broken.
- Renamed the test to `invalidWorkerTaskWithNullCharShouldBeSanitized` and changed the assertion to `assertThatNoException()` to reflect the current sanitization behavior.
- The two lone-surrogate tests (`\uD800` / `\uDC59`) are unchanged and still pass — surrogates are not stripped by `JdbcJsonbUtils` and still cause Postgres to reject the payload.

## Test plan

- [ ] `./gradlew :jdbc-postgres:test --tests "io.kestra.runner.postgres.PostgresQueueTest"` → 7/7 passing