### PR TITLE
feat(ci): replace GH_PERSONAL_TOKEN with GitHub App installation tokens

### DIFF
--- a/.github/workflows/global-create-new-release-branch.yml
+++ b/.github/workflows/global-create-new-release-branch.yml
@@ -33,8 +33,10 @@ jobs:
             exit 1;
           fi
       # Checkout
-      - uses: actions/checkout@v6
+      - uses: kestra-io/actions/composite/checkout-and-auth@main
         with:
+          gh-app-id: ${{ secrets.GH_BOT_CLIENT_ID }}
+          gh-app-private-key: ${{ secrets.GH_BOT_PRIVATE_KEY }}
           fetch-depth: 0
           path: kestra
 
@@ -55,8 +57,6 @@ jobs:
 
       # Execute
       - name: Run Gradle Release
-        env:
-          GITHUB_PAT: ${{ secrets.GH_PERSONAL_TOKEN }}
         run: |
           # Extract the major and minor versions
           BASE_VERSION=$(echo "$RELEASE_VERSION" | sed -E 's/^([0-9]+\.[0-9]+)\..*/\1/')

--- a/.github/workflows/global-start-release.yml
+++ b/.github/workflows/global-start-release.yml
@@ -39,10 +39,11 @@ jobs:
 
       # Checkout
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: kestra-io/actions/composite/checkout-and-auth@main
         with:
+          gh-app-id: ${{ secrets.GH_BOT_CLIENT_ID }}
+          gh-app-private-key: ${{ secrets.GH_BOT_PRIVATE_KEY }}
           fetch-depth: 0
-          token: ${{ secrets.GH_PERSONAL_TOKEN }}
           ref: ${{ steps.parse-and-check-inputs.outputs.release_branch }}
 
       # Configure
@@ -53,8 +54,6 @@ jobs:
 
       # Execute
       - name: Start release by updating version and pushing a new tag
-        env:
-          GITHUB_PAT: ${{ secrets.GH_PERSONAL_TOKEN }}
         run: |
           # Update version
           sed -i "s/^version=.*/version=$RELEASE_VERSION/" ./gradle.properties

--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -28,10 +28,11 @@ jobs:
     steps:
       # Targeting develop branch from develop
       - name: Trigger EE Workflow (develop push, no payload)
-        uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697
         if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/develop' }}
+        uses: kestra-io/actions/composite/repository-dispatch@main
         with:
-          token: ${{ secrets.GH_PERSONAL_TOKEN }}
+          gh-app-id: ${{ secrets.GH_BOT_CLIENT_ID }}
+          gh-app-private-key: ${{ secrets.GH_BOT_PRIVATE_KEY }}
           repository: kestra-io/kestra-ee
           event-type: "oss-updated"
           client-payload: '{"ref": "${{ github.ref }}", "commit_sha": "${{ github.sha }}"}'
@@ -71,11 +72,7 @@ jobs:
     uses: kestra-io/actions/.github/workflows/kestra-oss-publish-docker.yml@main
     with:
       java-version: 25
-    secrets:
-      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
-      DOCKERHUB_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD }}
-      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-      GH_PERSONAL_TOKEN: ${{ secrets.GH_PERSONAL_TOKEN }}
+    secrets: inherit
 
 
   publish-develop-maven:

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -100,6 +100,4 @@ jobs:
     needs: [build-artifacts, backend-tests, frontend-tests]
     if: "!failure() && !cancelled()"
     uses: kestra-io/actions/.github/workflows/kestra-oss-publish-github.yml@main
-    secrets:
-      GH_PERSONAL_TOKEN: ${{ secrets.GH_PERSONAL_TOKEN }}
-      SLACK_RELEASES_WEBHOOK_URL: ${{ secrets.SLACK_RELEASES_WEBHOOK_URL }}
+    secrets: inherit

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -12,13 +12,23 @@ jobs:
   trigger-ee:
     runs-on: ubuntu-latest
     steps:
+    - name: Generate GitHub App token for kestra-ee dispatch
+      id: ee-token
+      if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false }}
+      uses: actions/create-github-app-token@v3
+      with:
+        app-id: ${{ secrets.GH_BOT_CLIENT_ID }}
+        private-key: ${{ secrets.GH_BOT_PRIVATE_KEY }}
+        owner: kestra-io
+        repositories: kestra-ee
+
     # PR pre-check: skip if PR from a fork OR EE already has a branch with same name
     - name: Check EE repo for branch with same name
       if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false }}
       id: check-ee-branch
       uses: actions/github-script@v9
       with:
-        github-token: ${{ secrets.GH_PERSONAL_TOKEN }}
+        github-token: ${{ steps.ee-token.outputs.token }}
         script: |
           const pr = context.payload.pull_request;
           if (!pr) {
@@ -46,7 +56,7 @@ jobs:
         && github.event.pull_request.head.repo.fork == false
         && steps.check-ee-branch.outputs.exists == 'false' }}
       with:
-        token: ${{ secrets.GH_PERSONAL_TOKEN }}
+        token: ${{ steps.ee-token.outputs.token }}
         repository: kestra-io/kestra-ee
         event-type: "oss-updated"
         client-payload: >-
@@ -59,7 +69,7 @@ jobs:
         && github.event.pull_request.number != ''
         && github.event.pull_request.head.repo.fork == false }}
       with:
-        token: ${{ secrets.GH_PERSONAL_TOKEN }}
+        token: ${{ steps.ee-token.outputs.token }}
         repository: kestra-io/kestra-ee
         event-type: "oss-pr-openapi-check"
         client-payload: >-

--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -34,12 +34,7 @@ jobs:
       retag-lts: ${{ inputs.retag-lts }}
       dry-run: ${{ inputs.dry-run }}
       java-version: ${{ inputs.java-version }}
-    secrets:
-      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
-      DOCKERHUB_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD }}
-      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-      SLACK_RELEASES_WEBHOOK_URL: ${{ secrets.SLACK_RELEASES_WEBHOOK_URL }}
-      GH_PERSONAL_TOKEN: ${{ secrets.GH_PERSONAL_TOKEN }}
+    secrets: inherit
 
   helm-release:
     name: Helm release


### PR DESCRIPTION
Migrates CI authentication from the shared `GH_PERSONAL_TOKEN` personal access token to short-lived GitHub App installation tokens, addressing kestra-io/kestra-ee#7793.

All token plumbing now happens inline (via `actions/create-github-app-token@v3`) or through the self-contained composites added in kestra-io/actions#98.

Changes per workflow:

- **main-build.yml** — mint token for kestra-ee `repository-dispatch`; pass `GH_BOT_CLIENT_ID` + `GH_BOT_PRIVATE_KEY` to `kestra-oss-publish-docker.yml` (replaces `GH_PERSONAL_TOKEN` secret)
- **pull-request.yml** — mint token once for the `trigger-ee` job; reuse for github-script branch check, PR dispatch, and OpenAPI-check dispatch
- **global-start-release.yml** — mint token; use for checkout and subsequent `git push` / `git tag --push`
- **global-create-new-release-branch.yml** — mint token; use for checkout and Gradle release plugin git operations
- **pre-release.yml** — pass `GH_BOT_CLIENT_ID` + `GH_BOT_PRIVATE_KEY` to `kestra-oss-publish-github.yml`
- **release-docker.yml** — pass `GH_BOT_CLIENT_ID` + `GH_BOT_PRIVATE_KEY` to `kestra-oss-publish-docker.yml`

Companion PR: kestra-io/actions#98 (new composites + refactored publish workflows)
EE companion PR: kestra-io/kestra-ee (fix/gh-app-token-xxk)