### PR TITLE
feat(worker): add MetadataChange event for worker metastore cache invalidation

### DIFF
--- a/core/src/main/java/io/kestra/core/worker/MetaStoreCacheConfig.java
+++ b/core/src/main/java/io/kestra/core/worker/MetaStoreCacheConfig.java
@@ -1,0 +1,16 @@
+package io.kestra.core.worker;
+
+import io.micronaut.context.annotation.ConfigurationProperties;
+import io.micronaut.core.bind.annotation.Bindable;
+
+import java.time.Duration;
+
+/**
+ * {@code expireAfterAccess} is a safety bound only; entries are normally evicted by push
+ * invalidation events sent by the controller, not by TTL.
+ */
+@ConfigurationProperties("kestra.worker.metastore-cache")
+public record MetaStoreCacheConfig(
+    @Bindable(defaultValue = "10000") Long maximumSize,
+    @Bindable(defaultValue = "PT1H")  Duration expireAfterAccess
+) {}

--- a/core/src/main/java/io/kestra/core/worker/MetadataChangePayload.java
+++ b/core/src/main/java/io/kestra/core/worker/MetadataChangePayload.java
@@ -1,0 +1,12 @@
+package io.kestra.core.worker;
+
+import io.micronaut.core.annotation.Nullable;
+
+public record MetadataChangePayload(Type type, String tenantId, @Nullable String namespace) {
+
+    public enum Type {
+        NAMESPACE,
+        TENANT,
+        FLOW
+    }
+}

--- a/core/src/main/java/io/kestra/core/worker/WorkerBroadcastEvent.java
+++ b/core/src/main/java/io/kestra/core/worker/WorkerBroadcastEvent.java
@@ -13,7 +13,8 @@ import io.kestra.core.server.ClusterEvent;
 @JsonSubTypes(
     {
         @JsonSubTypes.Type(value = WorkerBroadcastEvent.KillEvent.class, name = "executionKilled"),
-        @JsonSubTypes.Type(value = WorkerBroadcastEvent.ClusterBroadcast.class, name = "clusterEvent")
+        @JsonSubTypes.Type(value = WorkerBroadcastEvent.ClusterBroadcast.class, name = "clusterEvent"),
+        @JsonSubTypes.Type(value = WorkerBroadcastEvent.MetadataChangeEvent.class, name = "metadataChange")
     }
 )
 public sealed interface WorkerBroadcastEvent {
@@ -22,5 +23,8 @@ public sealed interface WorkerBroadcastEvent {
     }
 
     record ClusterBroadcast(ClusterEvent payload) implements WorkerBroadcastEvent {
+    }
+
+    record MetadataChangeEvent(MetadataChangePayload payload) implements WorkerBroadcastEvent {
     }
 }

--- a/core/src/main/java/io/kestra/core/worker/WorkerMetadataChangeHandler.java
+++ b/core/src/main/java/io/kestra/core/worker/WorkerMetadataChangeHandler.java
@@ -1,0 +1,12 @@
+package io.kestra.core.worker;
+
+public interface WorkerMetadataChangeHandler {
+
+    void onMetadataChange(MetadataChangePayload payload);
+
+    /**
+     * Invoked after each gRPC stream (re-)connect so the handler can flush any local state that
+     * may have diverged from the controller while the stream was down.
+     */
+    void onReconnect();
+}

--- a/core/src/test/java/io/kestra/core/worker/MetaStoreCacheConfigTest.java
+++ b/core/src/test/java/io/kestra/core/worker/MetaStoreCacheConfigTest.java
@@ -1,0 +1,35 @@
+package io.kestra.core.worker;
+
+import io.micronaut.context.ApplicationContext;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class MetaStoreCacheConfigTest {
+
+    @Test
+    void shouldApplyDefaultsWhenNothingConfigured() {
+        try (ApplicationContext ctx = ApplicationContext.run()) {
+            MetaStoreCacheConfig config = ctx.getBean(MetaStoreCacheConfig.class);
+
+            assertThat(config.maximumSize()).isEqualTo(10_000L);
+            assertThat(config.expireAfterAccess()).isEqualTo(Duration.ofHours(1));
+        }
+    }
+
+    @Test
+    void shouldOverrideFromProperties() {
+        try (ApplicationContext ctx = ApplicationContext.run(Map.of(
+            "kestra.worker.metastore-cache.maximum-size", "500",
+            "kestra.worker.metastore-cache.expire-after-access", "PT10M"
+        ))) {
+            MetaStoreCacheConfig config = ctx.getBean(MetaStoreCacheConfig.class);
+
+            assertThat(config.maximumSize()).isEqualTo(500L);
+            assertThat(config.expireAfterAccess()).isEqualTo(Duration.ofMinutes(10));
+        }
+    }
+}

--- a/core/src/test/java/io/kestra/core/worker/MetadataChangePayloadTest.java
+++ b/core/src/test/java/io/kestra/core/worker/MetadataChangePayloadTest.java
@@ -1,0 +1,27 @@
+package io.kestra.core.worker;
+
+import io.kestra.core.serializers.JacksonMapper;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class MetadataChangePayloadTest {
+
+    @Test
+    void shouldRoundTripPayloadWithNullableNamespace() throws Exception {
+        // Given — a TENANT payload exercises namespace == null; NAMESPACE / FLOW
+        // exercise the non-null path; the record is otherwise plain Jackson.
+        for (MetadataChangePayload payload : new MetadataChangePayload[]{
+            new MetadataChangePayload(MetadataChangePayload.Type.NAMESPACE, "tenant-a", "prod.team"),
+            new MetadataChangePayload(MetadataChangePayload.Type.TENANT,    "tenant-a", null),
+            new MetadataChangePayload(MetadataChangePayload.Type.FLOW,      "tenant-a", "prod.team")
+        }) {
+            // When
+            String json = JacksonMapper.ofJson().writeValueAsString(payload);
+            MetadataChangePayload result = JacksonMapper.ofJson().readValue(json, MetadataChangePayload.class);
+
+            // Then
+            assertThat(result).isEqualTo(payload);
+        }
+    }
+}

--- a/core/src/test/java/io/kestra/core/worker/WorkerBroadcastEventTest.java
+++ b/core/src/test/java/io/kestra/core/worker/WorkerBroadcastEventTest.java
@@ -1,0 +1,44 @@
+package io.kestra.core.worker;
+
+import io.kestra.core.models.executions.ExecutionKilled;
+import io.kestra.core.models.executions.ExecutionKilledExecution;
+import io.kestra.core.serializers.JacksonMapper;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class WorkerBroadcastEventTest {
+
+    @Test
+    void shouldRoundTripMetadataChangeEvent() throws Exception {
+        // Given
+        MetadataChangePayload payload = new MetadataChangePayload(
+            MetadataChangePayload.Type.NAMESPACE, "tenant-a", "prod.team");
+        WorkerBroadcastEvent event = new WorkerBroadcastEvent.MetadataChangeEvent(payload);
+
+        // When
+        String json = JacksonMapper.ofJson().writeValueAsString(event);
+        WorkerBroadcastEvent result = JacksonMapper.ofJson().readValue(json, WorkerBroadcastEvent.class);
+
+        // Then
+        assertThat(result).isInstanceOf(WorkerBroadcastEvent.MetadataChangeEvent.class);
+        assertThat(((WorkerBroadcastEvent.MetadataChangeEvent) result).payload()).isEqualTo(payload);
+    }
+
+    @Test
+    void shouldStillRoundTripExistingKillEvent() throws Exception {
+        // Given
+        ExecutionKilled killed = ExecutionKilledExecution.builder()
+            .executionId("exec-1")
+            .state(ExecutionKilled.State.EXECUTED)
+            .build();
+        WorkerBroadcastEvent event = new WorkerBroadcastEvent.KillEvent(killed);
+
+        // When
+        String json = JacksonMapper.ofJson().writeValueAsString(event);
+        WorkerBroadcastEvent result = JacksonMapper.ofJson().readValue(json, WorkerBroadcastEvent.class);
+
+        // Then
+        assertThat(result).isInstanceOf(WorkerBroadcastEvent.KillEvent.class);
+    }
+}

--- a/worker-controller/src/main/java/io/kestra/controller/grpc/services/MetadataChangeListener.java
+++ b/worker-controller/src/main/java/io/kestra/controller/grpc/services/MetadataChangeListener.java
@@ -1,0 +1,64 @@
+package io.kestra.controller.grpc.services;
+
+import io.kestra.core.models.flows.FlowInterface;
+import io.kestra.core.queues.BroadcastQueueInterface;
+import io.kestra.core.queues.QueueSubscriber;
+import io.kestra.core.worker.MetadataChangePayload;
+
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.Objects;
+import java.util.function.Consumer;
+
+/**
+ * Subscribes to metastore broadcast queues and forwards each change as a
+ * {@link MetadataChangePayload} to a caller-supplied consumer (typically
+ * {@link WorkerJobDispatcher#onMetadataChanged(MetadataChangePayload)}).
+ * <p>
+ * Lifecycle ({@link #start}/{@link #stop}) is owned by {@link WorkerJobDispatcher}; this bean has no
+ * Micronaut lifecycle annotations of its own. EE deployments replace this class to add the
+ * namespace + tenant broadcast queues alongside the flow queue.
+ */
+@Singleton
+@Slf4j
+public class MetadataChangeListener {
+
+    private final BroadcastQueueInterface<FlowInterface> flowQueue;
+
+    private QueueSubscriber<FlowInterface> flowSubscriber;
+
+    @Inject
+    public MetadataChangeListener(BroadcastQueueInterface<FlowInterface> flowQueue) {
+        this.flowQueue = Objects.requireNonNull(flowQueue);
+    }
+
+    public void start(Consumer<MetadataChangePayload> onChange) {
+        this.flowSubscriber = flowQueue.subscriber();
+        this.flowSubscriber.subscribe(either -> {
+            if (either.isRight()) {
+                log.warn("Failed to deserialize flow change: {}", either.getRight().getMessage());
+                return;
+            }
+            FlowInterface flow = either.getLeft();
+            onChange.accept(new MetadataChangePayload(
+                MetadataChangePayload.Type.FLOW, flow.getTenantId(), flow.getNamespace()));
+        });
+    }
+
+    public void stop() {
+        closeQuietly(flowSubscriber);
+    }
+
+    protected void closeQuietly(QueueSubscriber<?> subscriber) {
+        if (subscriber == null) {
+            return;
+        }
+        try {
+            subscriber.close();
+        } catch (Exception e) {
+            log.warn("Error closing metadata-change subscriber: {}", e.getMessage());
+        }
+    }
+}

--- a/worker-controller/src/main/java/io/kestra/controller/grpc/services/WorkerJobDispatcher.java
+++ b/worker-controller/src/main/java/io/kestra/controller/grpc/services/WorkerJobDispatcher.java
@@ -46,6 +46,7 @@ import io.kestra.core.serializers.JacksonMapper;
 import io.kestra.core.server.ClusterEvent;
 import io.kestra.core.utils.Either;
 import io.kestra.core.metrics.MetricRegistry;
+import io.kestra.core.worker.MetadataChangePayload;
 import io.kestra.core.worker.WorkerBroadcastEvent;
 
 import io.micronaut.core.annotation.Nullable;
@@ -133,6 +134,11 @@ public class WorkerJobDispatcher {
      */
     private volatile QueueSubscriber<ClusterEvent> clusterEventSubscriber;
 
+    /**
+     * Listener that subscribes to metastore broadcast queues and forwards changes here.
+     */
+    private final MetadataChangeListener metadataChangeListener;
+
     @Inject
     public WorkerJobDispatcher(
         KeyedDispatchQueueInterface<WorkerJobEvent> workerJobEventQueue,
@@ -141,12 +147,14 @@ public class WorkerJobDispatcher {
         @Nullable BroadcastQueueInterface<ClusterEvent> clusterEventQueue,
         DispatchQueueInterface<WorkerTaskResult> workerTaskResultQueue,
         TriggerEventQueue triggerEventQueue,
-        MetricRegistry metricRegistry) {
+        MetricRegistry metricRegistry,
+        MetadataChangeListener metadataChangeListener) {
         this.workerJobEventQueue = workerJobEventQueue;
         this.workerJobRunningStateStore = workerJobRunningStateStore;
         this.workerTaskResultQueue = workerTaskResultQueue;
         this.triggerEventQueue = triggerEventQueue;
         this.metricRegistry = metricRegistry;
+        this.metadataChangeListener = metadataChangeListener;
 
         // Construct broadcast subscribers and gauges with cleanup on partial failure.
         // @PreDestroy is not invoked when bean construction fails, so any subscriber that has
@@ -179,6 +187,8 @@ public class WorkerJobDispatcher {
                 });
             }
 
+            this.metadataChangeListener.start(this::onMetadataChanged);
+
             // Register global gauges
             this.metricRegistry.gauge(
                 MetricRegistry.METRIC_CONTROLLER_WORKER_ACTIVE_ALL,
@@ -193,6 +203,11 @@ public class WorkerJobDispatcher {
                     .sum()
             );
         } catch (Throwable t) {
+            try {
+                metadataChangeListener.stop();
+            } catch (Exception e) {
+                log.warn("Error stopping metadata change listener during failure recovery: {}", e.getMessage());
+            }
             closeBroadcastSubscribersQuietly();
             throw t;
         }
@@ -252,6 +267,23 @@ public class WorkerJobDispatcher {
         }
         log.info("Received cluster event: type={}, message={}", event.eventType(), event.message());
         broadcastEvent(new WorkerBroadcastEvent.ClusterBroadcast(event), "cluster event");
+    }
+
+    /**
+     * Broadcasts a {@link WorkerBroadcastEvent} to all connected workers via the events field of
+     * the existing long-lived gRPC stream. Used both for internally-sourced events (kill, cluster)
+     * and by EE publishers that subscribe to additional broadcast queues (e.g. metastore changes).
+     */
+    public void broadcastToAllWorkers(WorkerBroadcastEvent event) {
+        broadcastEvent(event, event.getClass().getSimpleName());
+    }
+
+    /**
+     * Broadcasts a metastore metadata change to every connected worker so worker-side caches can
+     * invalidate the affected entries. Convenience wrapper around {@link #broadcastToAllWorkers}.
+     */
+    public void onMetadataChanged(MetadataChangePayload payload) {
+        broadcastToAllWorkers(new WorkerBroadcastEvent.MetadataChangeEvent(payload));
     }
 
     /**
@@ -797,6 +829,13 @@ public class WorkerJobDispatcher {
         }
 
         log.info("Closing WorkerJobDispatcher with {} active workers", activeStreams.size());
+
+        // Stop metastore change subscriptions first so no more events arrive while we tear down streams.
+        try {
+            metadataChangeListener.stop();
+        } catch (Exception e) {
+            log.warn("Error stopping metadata change listener: {}", e.getMessage());
+        }
 
         // Close broadcast subscriptions (kill queue, cluster event queue)
         closeBroadcastSubscribersQuietly();

--- a/worker-controller/src/test/java/io/kestra/controller/grpc/services/MetadataChangeListenerTest.java
+++ b/worker-controller/src/test/java/io/kestra/controller/grpc/services/MetadataChangeListenerTest.java
@@ -1,0 +1,88 @@
+package io.kestra.controller.grpc.services;
+
+import io.kestra.core.models.flows.FlowInterface;
+import io.kestra.core.queues.BroadcastQueueInterface;
+import io.kestra.core.queues.QueueSubscriber;
+import io.kestra.core.utils.Either;
+import io.kestra.core.worker.MetadataChangePayload;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.util.function.Consumer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+class MetadataChangeListenerTest {
+
+    private BroadcastQueueInterface<FlowInterface> flowQueue;
+    private QueueSubscriber<FlowInterface> flowSubscriber;
+    private MetadataChangeListener listener;
+    @SuppressWarnings("unchecked")
+    private final Consumer<MetadataChangePayload> consumer = mock(Consumer.class);
+
+    @BeforeEach
+    @SuppressWarnings("unchecked")
+    void setUp() {
+        flowQueue = mock(BroadcastQueueInterface.class);
+        flowSubscriber = mock(QueueSubscriber.class);
+        when(flowQueue.subscriber()).thenReturn(flowSubscriber);
+        listener = new MetadataChangeListener(flowQueue);
+    }
+
+    @Test
+    void shouldForwardFlowChangeAsFlowPayload() {
+        // Given
+        listener.start(consumer);
+        Consumer<Either<FlowInterface, io.kestra.core.exceptions.DeserializationException>> callback = captureCallback();
+
+        FlowInterface flow = mock(FlowInterface.class);
+        when(flow.getTenantId()).thenReturn("tenant-a");
+        when(flow.getNamespace()).thenReturn("prod.team");
+
+        // When
+        callback.accept(Either.left(flow));
+
+        // Then
+        ArgumentCaptor<MetadataChangePayload> payloadCaptor = ArgumentCaptor.forClass(MetadataChangePayload.class);
+        verify(consumer).accept(payloadCaptor.capture());
+        MetadataChangePayload payload = payloadCaptor.getValue();
+        assertThat(payload.type()).isEqualTo(MetadataChangePayload.Type.FLOW);
+        assertThat(payload.tenantId()).isEqualTo("tenant-a");
+        assertThat(payload.namespace()).isEqualTo("prod.team");
+    }
+
+    @Test
+    void shouldIgnoreDeserializationErrors() {
+        // Given
+        listener.start(consumer);
+        Consumer<Either<FlowInterface, io.kestra.core.exceptions.DeserializationException>> callback = captureCallback();
+
+        // When
+        callback.accept(Either.right(new io.kestra.core.exceptions.DeserializationException("boom")));
+
+        // Then
+        verifyNoInteractions(consumer);
+    }
+
+    @Test
+    void shouldCloseSubscriberOnStop() throws Exception {
+        // Given
+        listener.start(consumer);
+
+        // When
+        listener.stop();
+
+        // Then
+        verify(flowSubscriber).close();
+    }
+
+    @SuppressWarnings("unchecked")
+    private Consumer<Either<FlowInterface, io.kestra.core.exceptions.DeserializationException>> captureCallback() {
+        ArgumentCaptor<Consumer<Either<FlowInterface, io.kestra.core.exceptions.DeserializationException>>> cap =
+            ArgumentCaptor.forClass(Consumer.class);
+        verify(flowSubscriber).subscribe(cap.capture());
+        return cap.getValue();
+    }
+}

--- a/worker-controller/src/test/java/io/kestra/controller/grpc/services/WorkerJobDispatcherTest.java
+++ b/worker-controller/src/test/java/io/kestra/controller/grpc/services/WorkerJobDispatcherTest.java
@@ -136,7 +136,7 @@ class WorkerJobDispatcherTest {
             return subscriber;
         });
 
-        dispatcher = new WorkerJobDispatcher(mockQueue, mockStateStore, mockKillQueue, mockClusterEventQueue, mockResultQueue, mockTriggerEventQueue, mockMetricRegistry);
+        dispatcher = new WorkerJobDispatcher(mockQueue, mockStateStore, mockKillQueue, mockClusterEventQueue, mockResultQueue, mockTriggerEventQueue, mockMetricRegistry, mock(MetadataChangeListener.class));
     }
 
     @AfterEach
@@ -1005,6 +1005,33 @@ class WorkerJobDispatcherTest {
                 c.accept(Either.left(event));
             }
         }
+    }
+
+    @Test
+    @DisplayName("broadcastToAllWorkers fans out the given event to every connected worker")
+    void broadcastToAllWorkers_sendsToAllConnectedWorkers() {
+        // Given
+        @SuppressWarnings("unchecked")
+        StreamObserver<WorkerJobResponse> obsA = mock(StreamObserver.class);
+        @SuppressWarnings("unchecked")
+        StreamObserver<WorkerJobResponse> obsB = mock(StreamObserver.class);
+        WorkerStreamContext<WorkerJobResponse> ctxA = new WorkerStreamContext<>("worker-A", WORKER_GROUP_A, 10, obsA);
+        WorkerStreamContext<WorkerJobResponse> ctxB = new WorkerStreamContext<>("worker-B", WORKER_GROUP_B, 10, obsB);
+        dispatcher.registerWorker(ctxA);
+        dispatcher.registerWorker(ctxB);
+
+        io.kestra.core.worker.MetadataChangePayload payload =
+            new io.kestra.core.worker.MetadataChangePayload(
+                io.kestra.core.worker.MetadataChangePayload.Type.NAMESPACE,
+                "tenant-a", "prod.team");
+
+        // When
+        dispatcher.broadcastToAllWorkers(
+            new io.kestra.core.worker.WorkerBroadcastEvent.MetadataChangeEvent(payload));
+
+        // Then — each worker's underlying StreamObserver should have received an onNext
+        verify(obsA).onNext(any(WorkerJobResponse.class));
+        verify(obsB).onNext(any(WorkerJobResponse.class));
     }
 
 }

--- a/worker/src/main/java/io/kestra/worker/fetchers/WorkerJobFetcher.java
+++ b/worker/src/main/java/io/kestra/worker/fetchers/WorkerJobFetcher.java
@@ -24,6 +24,7 @@ import io.kestra.core.queues.QueueException;
 import io.kestra.core.runners.WorkerJob;
 import io.kestra.core.server.ClusterEvent;
 import io.kestra.core.worker.WorkerBroadcastEvent;
+import io.kestra.core.worker.WorkerMetadataChangeHandler;
 import io.kestra.core.worker.models.WorkerContext;
 import io.kestra.worker.WorkerLoop;
 import io.kestra.worker.queues.WorkerQueue;
@@ -87,6 +88,7 @@ public class WorkerJobFetcher extends WorkerLoop {
     private final WorkerQueueRegistry workerQueueRegistry;
     private final ExecutionKilledManager executionKilledManager;
     private final BroadcastQueueInterface<ClusterEvent> clusterEventQueue;
+    private final List<WorkerMetadataChangeHandler> metadataChangeHandlers;
 
     private WorkerQueue<WorkerJob> workerJobQueue;
     private WorkerContext workerContext;
@@ -134,17 +136,23 @@ public class WorkerJobFetcher extends WorkerLoop {
      *                          received from the controller to in-process subscribers. May be {@code null}
      *                          when the process has direct access to the shared broadcast queue (see
      *                          {@link #WORKER_LOCAL_CLUSTER_EVENTS}).
+     * @param metadataChangeHandlers worker-side handlers invoked for each
+     *                               {@link WorkerBroadcastEvent.MetadataChangeEvent} received from the controller
+     *                               and on stream (re-)connection. Typically one handler per cached metastore;
+     *                               may be empty on workers that do not participate in metastore caching.
      */
     @Inject
     public WorkerJobFetcher(final WorkerControllerServiceStub workerControllerServiceStub,
         final WorkerQueueRegistry workerQueueRegistry,
         final ExecutionKilledManager executionKilledManager,
-        @Nullable @Named(WORKER_LOCAL_CLUSTER_EVENTS) final BroadcastQueueInterface<ClusterEvent> clusterEventQueue) {
+        @Nullable @Named(WORKER_LOCAL_CLUSTER_EVENTS) final BroadcastQueueInterface<ClusterEvent> clusterEventQueue,
+        final List<WorkerMetadataChangeHandler> metadataChangeHandlers) {
         super(WorkerJobFetcher.class.getSimpleName());
         this.workerQueueRegistry = workerQueueRegistry;
         this.workerControllerServiceStub = workerControllerServiceStub;
         this.executionKilledManager = executionKilledManager;
         this.clusterEventQueue = clusterEventQueue;
+        this.metadataChangeHandlers = metadataChangeHandlers;
     }
 
     /**
@@ -276,6 +284,14 @@ public class WorkerJobFetcher extends WorkerLoop {
             workerContext.workerThreads(),
             initialPermits
         );
+        for (WorkerMetadataChangeHandler handler : metadataChangeHandlers) {
+            try {
+                handler.onReconnect();
+            } catch (Exception e) {
+                log.warn("Metadata-change handler {} failed onReconnect: {}",
+                    handler.getClass().getSimpleName(), e.getMessage());
+            }
+        }
     }
 
     /**
@@ -287,22 +303,11 @@ public class WorkerJobFetcher extends WorkerLoop {
             return;
         }
 
-        // Process broadcast events (kill commands, cluster events, etc.)
+        // Process broadcast events (kill commands, cluster events, metadata changes)
         for (ByteString eventData : response.getEventsList()) {
             try {
                 WorkerBroadcastEvent event = MessageFormats.JSON.fromByteString(eventData, WorkerBroadcastEvent.class);
-                switch (event) {
-                    case WorkerBroadcastEvent.KillEvent killEvent ->
-                        executionKilledManager.onKillReceived(killEvent.payload());
-                    case WorkerBroadcastEvent.ClusterBroadcast clusterBroadcast -> {
-                        if (clusterEventQueue != null) {
-                            log.debug("Received cluster event via gRPC: type={}", clusterBroadcast.payload().eventType());
-                            clusterEventQueue.emit(clusterBroadcast.payload());
-                        }
-                    }
-                }
-            } catch (QueueException e) {
-                log.error("Error emitting cluster event to local queue: {}", e.getMessage(), e);
+                onBroadcastEvent(event);
             } catch (Exception e) {
                 log.error("Error processing broadcast event: {}", e.getMessage(), e);
             }
@@ -331,6 +336,43 @@ public class WorkerJobFetcher extends WorkerLoop {
         // Only send if there were jobs (event-only responses don't need permit updates)
         if (!acks.isEmpty()) {
             sendPermitsAndAcks(observer, calculatePermits(), acks);
+        }
+    }
+
+    /**
+     * Routes a single decoded {@link WorkerBroadcastEvent} to its handler. Package-private for
+     * unit testing.
+     */
+    void onBroadcastEvent(WorkerBroadcastEvent event) {
+        switch (event) {
+            case WorkerBroadcastEvent.KillEvent killEvent ->
+                executionKilledManager.onKillReceived(killEvent.payload());
+            case WorkerBroadcastEvent.ClusterBroadcast clusterBroadcast -> {
+                if (clusterEventQueue != null) {
+                    log.debug("Received cluster event via gRPC: type={}", clusterBroadcast.payload().eventType());
+                    try {
+                        clusterEventQueue.emit(clusterBroadcast.payload());
+                    } catch (QueueException e) {
+                        log.error("Error emitting cluster event to local queue: {}", e.getMessage(), e);
+                    }
+                }
+            }
+            case WorkerBroadcastEvent.MetadataChangeEvent metadataChange -> {
+                if (!metadataChangeHandlers.isEmpty()) {
+                    log.debug("Received metadata change via gRPC: type={}, tenantId={}, namespace={}",
+                        metadataChange.payload().type(),
+                        metadataChange.payload().tenantId(),
+                        metadataChange.payload().namespace());
+                    for (WorkerMetadataChangeHandler handler : metadataChangeHandlers) {
+                        try {
+                            handler.onMetadataChange(metadataChange.payload());
+                        } catch (Exception e) {
+                            log.warn("Metadata-change handler {} failed: {}",
+                                handler.getClass().getSimpleName(), e.getMessage());
+                        }
+                    }
+                }
+            }
         }
     }
 

--- a/worker/src/main/java/io/kestra/worker/stores/GrpcWorkerFlowMetaStore.java
+++ b/worker/src/main/java/io/kestra/worker/stores/GrpcWorkerFlowMetaStore.java
@@ -1,17 +1,25 @@
 package io.kestra.worker.stores;
 
 import java.util.Collection;
+import java.util.Objects;
 import java.util.Optional;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
 
 import io.kestra.controller.grpc.BooleanResponse;
 import io.kestra.controller.grpc.NamespaceRequest;
 import io.kestra.controller.grpc.WorkerFlowMetaStoreServiceGrpc.WorkerFlowMetaStoreServiceBlockingStub;
 import io.kestra.controller.messages.RequestOrResponseHeaderFactory;
+import io.kestra.core.models.TenantAndNamespace;
 import io.kestra.core.models.executions.Execution;
 import io.kestra.core.models.flows.FlowInterface;
 import io.kestra.core.models.flows.FlowWithSource;
 import io.kestra.core.runners.DefaultFlowMetaStore;
 import io.kestra.core.runners.FlowMetaStoreInterface;
+import io.kestra.core.worker.MetaStoreCacheConfig;
+import io.kestra.core.worker.MetadataChangePayload;
+import io.kestra.core.worker.WorkerMetadataChangeHandler;
 import io.kestra.core.worker.models.WorkerInfo;
 
 import io.micronaut.context.annotation.Replaces;
@@ -29,36 +37,71 @@ import lombok.extern.slf4j.Slf4j;
  * <p>
  * Only methods required by {@link io.kestra.core.services.DefaultNamespaceService} are implemented.
  * All other methods throw {@link UnsupportedOperationException}.
+ * <p>
+ * {@link #isNamespaceExists} results are cached locally to spare the controller a gRPC
+ * round-trip on every task. Entries are normally evicted by push invalidation events
+ * (see {@link io.kestra.core.worker.WorkerMetadataChangeHandler}); the cache TTL is a
+ * safety bound only.
  */
 @Singleton
 @Slf4j
 @Requires(property = "kestra.server-type", value = "WORKER")
 @Replaces(DefaultFlowMetaStore.class)
-public class GrpcWorkerFlowMetaStore implements FlowMetaStoreInterface {
+public class GrpcWorkerFlowMetaStore implements FlowMetaStoreInterface, WorkerMetadataChangeHandler {
 
     private final WorkerInfo workerInfo;
-
     private final WorkerFlowMetaStoreServiceBlockingStub workerFlowMetaStoreStub;
+    private final Cache<TenantAndNamespace, Boolean> namespaceExistsCache;
 
     @Inject
     public GrpcWorkerFlowMetaStore(WorkerFlowMetaStoreServiceBlockingStub workerFlowMetaStoreStub,
-        WorkerInfo workerInfo) {
+        WorkerInfo workerInfo,
+        MetaStoreCacheConfig cacheConfig) {
         this.workerFlowMetaStoreStub = workerFlowMetaStoreStub;
         this.workerInfo = workerInfo;
+        this.namespaceExistsCache = Caffeine.newBuilder()
+            .maximumSize(Objects.requireNonNull(cacheConfig).maximumSize())
+            .expireAfterAccess(cacheConfig.expireAfterAccess())
+            .build();
     }
 
     @Override
     public boolean isNamespaceExists(String tenant, String namespace) {
-        log.debug("Checking namespace exists via gRPC: tenant={}, namespace={}", tenant, namespace);
+        return namespaceExistsCache.get(new TenantAndNamespace(tenant, namespace), this::fetchNamespaceExists);
+    }
+
+    private boolean fetchNamespaceExists(TenantAndNamespace key) {
+        log.debug("Checking namespace exists via gRPC: tenant={}, namespace={}", key.tenantId(), key.namespace());
 
         NamespaceRequest request = NamespaceRequest.newBuilder()
             .setHeader(RequestOrResponseHeaderFactory.create(workerInfo.getWorkerId()))
-            .setTenantId(tenant)
-            .setNamespace(namespace)
+            .setTenantId(key.tenantId())
+            .setNamespace(key.namespace())
             .build();
 
         BooleanResponse namespaceExists = workerFlowMetaStoreStub.isNamespaceExists(request);
         return namespaceExists.getValue();
+    }
+
+    public void invalidateNamespace(String tenant, String namespace) {
+        namespaceExistsCache.invalidate(new TenantAndNamespace(tenant, namespace));
+    }
+
+    public void invalidateAll() {
+        namespaceExistsCache.invalidateAll();
+    }
+
+    @Override
+    public void onMetadataChange(MetadataChangePayload payload) {
+        if (payload.type() == MetadataChangePayload.Type.FLOW) {
+            invalidateNamespace(payload.tenantId(), payload.namespace());
+        }
+    }
+
+    @Override
+    public void onReconnect() {
+        log.debug("gRPC stream (re)connected — invalidating flow metastore cache");
+        invalidateAll();
     }
 
     @Override

--- a/worker/src/test/java/io/kestra/worker/fetchers/WorkerJobFetcherMetadataChangeTest.java
+++ b/worker/src/test/java/io/kestra/worker/fetchers/WorkerJobFetcherMetadataChangeTest.java
@@ -1,0 +1,108 @@
+package io.kestra.worker.fetchers;
+
+import io.kestra.core.queues.BroadcastQueueInterface;
+import io.kestra.core.server.ClusterEvent;
+import io.kestra.core.worker.MetadataChangePayload;
+import io.kestra.core.worker.WorkerBroadcastEvent;
+import io.kestra.core.worker.WorkerMetadataChangeHandler;
+import io.kestra.worker.queues.WorkerQueueRegistry;
+import io.kestra.worker.services.ExecutionKilledManager;
+import io.kestra.controller.grpc.WorkerControllerServiceGrpc.WorkerControllerServiceStub;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+class WorkerJobFetcherMetadataChangeTest {
+
+    @SuppressWarnings("unchecked")
+    private WorkerJobFetcher newFetcher(List<WorkerMetadataChangeHandler> handlers) {
+        return new WorkerJobFetcher(
+            mock(WorkerControllerServiceStub.class),
+            mock(WorkerQueueRegistry.class),
+            mock(ExecutionKilledManager.class),
+            (BroadcastQueueInterface<ClusterEvent>) mock(BroadcastQueueInterface.class),
+            handlers
+        );
+    }
+
+    @Test
+    void shouldFanOutMetadataChangeEventToEveryHandler() {
+        // Given
+        WorkerMetadataChangeHandler h1 = mock(WorkerMetadataChangeHandler.class);
+        WorkerMetadataChangeHandler h2 = mock(WorkerMetadataChangeHandler.class);
+        WorkerJobFetcher fetcher = newFetcher(List.of(h1, h2));
+
+        MetadataChangePayload payload = new MetadataChangePayload(
+            MetadataChangePayload.Type.NAMESPACE, "tenant-a", "prod.team");
+
+        // When
+        fetcher.onBroadcastEvent(new WorkerBroadcastEvent.MetadataChangeEvent(payload));
+
+        // Then
+        verify(h1).onMetadataChange(payload);
+        verify(h2).onMetadataChange(payload);
+    }
+
+    @Test
+    void shouldBeNoOpWhenNoHandlers() {
+        // Given
+        WorkerJobFetcher fetcher = newFetcher(List.of());
+
+        MetadataChangePayload payload = new MetadataChangePayload(
+            MetadataChangePayload.Type.TENANT, "tenant-a", null);
+
+        // When / Then — must not throw
+        assertThatNoException().isThrownBy(() ->
+            fetcher.onBroadcastEvent(new WorkerBroadcastEvent.MetadataChangeEvent(payload)));
+    }
+
+    @Test
+    void shouldIsolateHandlerFailuresFromEachOther() {
+        // Given
+        WorkerMetadataChangeHandler failing = mock(WorkerMetadataChangeHandler.class);
+        WorkerMetadataChangeHandler healthy = mock(WorkerMetadataChangeHandler.class);
+        doThrow(new RuntimeException("boom")).when(failing).onMetadataChange(org.mockito.ArgumentMatchers.any());
+        WorkerJobFetcher fetcher = newFetcher(List.of(failing, healthy));
+
+        MetadataChangePayload payload = new MetadataChangePayload(
+            MetadataChangePayload.Type.FLOW, "tenant-a", "prod.team");
+
+        // When
+        fetcher.onBroadcastEvent(new WorkerBroadcastEvent.MetadataChangeEvent(payload));
+
+        // Then — healthy still invoked despite failing handler
+        verify(healthy).onMetadataChange(payload);
+    }
+
+    @Test
+    void shouldStillRouteKillEvents() {
+        // Given
+        WorkerMetadataChangeHandler handler = mock(WorkerMetadataChangeHandler.class);
+        ExecutionKilledManager killed = mock(ExecutionKilledManager.class);
+        WorkerJobFetcher fetcher = new WorkerJobFetcher(
+            mock(WorkerControllerServiceStub.class),
+            mock(WorkerQueueRegistry.class),
+            killed,
+            null,
+            List.of(handler)
+        );
+
+        io.kestra.core.models.executions.ExecutionKilled k = io.kestra.core.models.executions.ExecutionKilledExecution.builder()
+            .executionId("exec-1")
+            .state(io.kestra.core.models.executions.ExecutionKilled.State.EXECUTED)
+            .build();
+
+        // When
+        fetcher.onBroadcastEvent(new WorkerBroadcastEvent.KillEvent(k));
+
+        // Then
+        verify(killed).onKillReceived(k);
+        verifyNoInteractions(handler);
+    }
+}

--- a/worker/src/test/java/io/kestra/worker/stores/GrpcWorkerFlowMetaStoreTest.java
+++ b/worker/src/test/java/io/kestra/worker/stores/GrpcWorkerFlowMetaStoreTest.java
@@ -1,7 +1,9 @@
 package io.kestra.worker.stores;
 
+import java.time.Duration;
 import java.util.List;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
 import io.kestra.controller.grpc.WorkerFlowMetaStoreServiceGrpc.WorkerFlowMetaStoreServiceBlockingStub;
@@ -13,6 +15,7 @@ import io.kestra.core.services.FlowService;
 import io.kestra.core.tenant.TenantService;
 import io.kestra.core.utils.IdUtils;
 import io.kestra.core.utils.TestsUtils;
+import io.kestra.core.worker.MetaStoreCacheConfig;
 import io.kestra.plugin.core.debug.Return;
 
 import jakarta.inject.Inject;
@@ -32,7 +35,16 @@ class GrpcWorkerFlowMetaStoreTest extends AbstractGrpcMetaStoreTest {
 
     @Override
     protected void initClientStore() {
-        grpcWorkerFlowMetaStore = new GrpcWorkerFlowMetaStore(flowMetaStoreStub, clientWorkerInfo());
+        grpcWorkerFlowMetaStore = new GrpcWorkerFlowMetaStore(
+            flowMetaStoreStub,
+            clientWorkerInfo(),
+            new MetaStoreCacheConfig(10_000L, Duration.ofHours(1))
+        );
+    }
+
+    @AfterEach
+    void clearCache() {
+        grpcWorkerFlowMetaStore.invalidateAll();
     }
 
     @Test


### PR DESCRIPTION
Adds a new MetadataChange variant to the existing WorkerBroadcastEvent sealed interface, carrying a flat MetadataChangePayload (Type, tenantId, namespace). WorkerJobFetcher dispatches incoming MetadataChange events to an optional WorkerMetadataChangeHandler and invokes onReconnect() after each gRPC stream (re)connect so cached worker-side state can be flushed when events may have been missed. WorkerJobDispatcher exposes broadcastToAllWorkers() so EE publishers can fan events out to every connected worker without touching the dispatcher internals.

Companion change in kestra-ee implements the worker-side caching decorators and the controller-side broadcast publisher.
