### PR TITLE
fix(build): use updated configuration-schema action with Java 25 and GCS upload

### DIFF
--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -108,23 +108,14 @@ jobs:
       - name: Prepare executable
         run: cp build/executable/* build/executable/kestra && chmod +x build/executable/kestra
 
-      - name: Generate schema
+      - name: Generate and publish schema
         uses: kestra-io/actions/composite/kestra/kestra-configuration-schema@main
         with:
           kestra-version: develop
           executable-path: build/executable/kestra
           output-path: oss.json
-
-      - name: GCP - Auth
-        uses: 'google-github-actions/auth@v3'
-        with:
-          credentials_json: '${{ secrets.GCP_SERVICE_ACCOUNT }}'
-
-      - name: Upload schema to GCS
-        uses: 'google-github-actions/upload-cloud-storage@v2'
-        with:
-          path: oss.json
-          destination: kestra-api-storage_prd/configuration-schema/develop/
+          gcs-destination: kestra-api-storage_prd/configuration-schema/develop/
+          gcp-credentials-json: ${{ secrets.GCP_SERVICE_ACCOUNT }}
 
       - name: Slack - Schema generation failure
         if: failure()

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -79,23 +79,14 @@ jobs:
       - name: Prepare executable
         run: cp build/executable/* build/executable/kestra && chmod +x build/executable/kestra
 
-      - name: Generate schema
+      - name: Generate and publish schema
         uses: kestra-io/actions/composite/kestra/kestra-configuration-schema@main
         with:
           kestra-version: ${{ github.ref_name }}
           executable-path: build/executable/kestra
           output-path: oss.json
-
-      - name: GCP - Auth
-        uses: 'google-github-actions/auth@v3'
-        with:
-          credentials_json: '${{ secrets.GCP_SERVICE_ACCOUNT }}'
-
-      - name: Upload schema to GCS
-        uses: 'google-github-actions/upload-cloud-storage@v2'
-        with:
-          path: oss.json
-          destination: kestra-api-storage_prd/configuration-schema/${{ github.ref_name }}/
+          gcs-destination: kestra-api-storage_prd/configuration-schema/${{ github.ref_name }}/
+          gcp-credentials-json: ${{ secrets.GCP_SERVICE_ACCOUNT }}
 
       - name: Slack - Schema generation failure
         if: failure()


### PR DESCRIPTION
Delegate Java setup, GCP auth, and GCS upload to the shared `kestra-configuration-schema` composite action, fixing the Java 25 `UnsupportedClassVersionError` on schema generation.

Companion PRs:
- https://github.com/kestra-io/actions/pull/99 (must be merged first)
- kestra-ee counterpart