### PR TITLE
fix(helm): do not render Service when only workerGroups are enabled

### DIFF
--- a/charts/kestra/templates/service.yaml
+++ b/charts/kestra/templates/service.yaml
@@ -1,3 +1,4 @@
+{{- if or .Values.deployments.standalone.enabled .Values.deployments.webserver.enabled }}
 {{ $deployment := ternary "standalone" "webserver" .Values.deployments.standalone.enabled }}
 apiVersion: v1
 kind: Service
@@ -24,3 +25,4 @@ spec:
   selector:
     {{- include "kestra.selectorLabels" . | nindent 4 }}
     app.kubernetes.io/component: "{{ $deployment }}"
+{{- end }}


### PR DESCRIPTION
## Summary

- The `Service` resource is a load-balancing construct meant to front an HTTP server (webserver/standalone). Kestra Workers are outbound, pull-based processes and do not expose an HTTP server.
- When only `workerGroups` are enabled (all standard deployments disabled), the chart was still rendering a `Service` with a selector pointing to `webserver` or `standalone` — resulting in a Service with no endpoints.
- The `Service` is now only rendered when `deployments.standalone.enabled` or `deployments.webserver.enabled` is `true`.

Fixes https://github.com/kestra-io/kestra-ee/issues/7736

## Test plan

- [ ] `helm template` with only `workerGroups` enabled → no `Service` in output
- [ ] `helm template` with `deployments.webserver.enabled: true` → `Service` present with correct selector
- [ ] `helm template` with `deployments.standalone.enabled: true` → `Service` present with correct selector