### PR TITLE
fix(tests): fork a new JVM per webserver test class to prevent OOM cascade

### DIFF
--- a/webserver/build.gradle
+++ b/webserver/build.gradle
@@ -4,6 +4,15 @@ if (rootProject.name == "kestra") {
     }
 }
 
+test {
+    // Fork a new JVM per test class to prevent OOM cascade: runner test classes
+    // (ExecutionControllerRunnerTest, ClusterControllerTest, etc.) start a full
+    // Micronaut context with JdbcExecutor + Worker threads that do not fully GC
+    // before subsequent test classes run. Isolation prevents those heap leftovers
+    // from killing unrelated tests like FlowControllerTest.
+    forkEvery = 1
+}
+
 configurations {
     implementation.extendsFrom(micronaut)
 }


### PR DESCRIPTION
## Summary

- Runner test classes (`ExecutionControllerRunnerTest`, `ClusterControllerTest`, `TriggerControllerTest`, `MetricControllerTest`) start a full Micronaut context with JdbcExecutor + Worker threads that hold significant heap after shutdown.
- This pushes the 4 GB JVM limit over the edge during subsequent non-runner test classes. The server's I/O executor OOMs, stops responding, and tests like `updateFlowFlowFromJsonFromString` and `updateFlowFlowFromJson` hang ~17 minutes until the client read-timeout fires — followed by a `"database has been closed"` cascade for all remaining tests in `FlowControllerTest` (14 failures in CI run 25796444380 and similar in 25367972462).
- Observed OOM sequence in CI logs: `JFR Event Stream 7` → `JNA Cleaner` → `io-executor-thread-1` (the fatal one that kills HTTP handling).

Setting `forkEvery = 1` in the `webserver` test task gives each of the 33 test classes its own JVM, eliminating cross-class heap contamination at the cost of ~3–5 minutes of extra JVM-startup overhead per CI run.

## Test plan

- [x] `FlowControllerTest.updateFlowFlowFromJsonFromString` passes locally with `forkEvery = 1`
- [x] `FlowControllerTest.updateFlowFlowFromJson` passes locally with `forkEvery = 1`
- [ ] CI run on this branch should show all 33+ webserver test classes passing without OOM cascade