### PR TITLE
fix(ci): replace GH_PERSONAL_TOKEN with GitHub App tokens

### DIFF
--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -47,11 +47,7 @@ jobs:
     uses: kestra-io/actions/.github/workflows/kestra-oss-publish-docker.yml@main
     with:
       plugin-version: 'LATEST-SNAPSHOT'
-    secrets:
-      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
-      DOCKERHUB_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD }}
-      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-      GH_PERSONAL_TOKEN: ${{ secrets.GH_PERSONAL_TOKEN }}
+    secrets: inherit
 
 
   publish-develop-maven:
@@ -72,10 +68,11 @@ jobs:
     if: always()
     steps:
       - name: Trigger EE Workflow
-        uses: peter-evans/repository-dispatch@v3
         if: github.ref == 'refs/heads/develop' && needs.release.result == 'success'
+        uses: kestra-io/actions/composite/repository-dispatch@main
         with:
-          token: ${{ secrets.GH_PERSONAL_TOKEN }}
+          gh-app-id: ${{ secrets.GH_BOT_APP_ID }}
+          gh-app-private-key: ${{ secrets.GH_BOT_PRIVATE_KEY }}
           repository: kestra-io/kestra-ee
           event-type: "oss-updated"
 

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -55,6 +55,4 @@ jobs:
     needs: [build-artifacts, backend-tests, frontend-tests]
     if: "!failure() && !cancelled()"
     uses: kestra-io/actions/.github/workflows/kestra-oss-publish-github.yml@main
-    secrets:
-      GH_PERSONAL_TOKEN: ${{ secrets.GH_PERSONAL_TOKEN }}
-      SLACK_RELEASES_WEBHOOK_URL: ${{ secrets.SLACK_RELEASES_WEBHOOK_URL }}
+    secrets: inherit

--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -28,9 +28,4 @@ jobs:
       retag-latest: ${{ inputs.retag-latest }}
       retag-lts: ${{ inputs.retag-lts }}
       dry-run: ${{ inputs.dry-run }}
-    secrets:
-      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
-      DOCKERHUB_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD }}
-      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-      SLACK_RELEASES_WEBHOOK_URL: ${{ secrets.SLACK_RELEASES_WEBHOOK_URL }}
-      GH_PERSONAL_TOKEN: ${{ secrets.GH_PERSONAL_TOKEN }}
+    secrets: inherit


### PR DESCRIPTION
Replace `GH_PERSONAL_TOKEN` usage with GitHub App installation tokens so release branch CI workflows continue working after `kestra-io/actions#98` is merged.

- `publish-docker` and `publish-github` jobs use `secrets: inherit` instead of forwarding `GH_PERSONAL_TOKEN`
- Repository dispatch steps use `composite/repository-dispatch@main`
- PR trigger step uses `composite/github-script@main`
- Release script steps use `composite/gh-cli@main` with org-wide token (GITHUB_PAT aliased from GH_TOKEN for script backward-compat)
- Checkout steps use `composite/checkout-and-auth@main`