### PR TITLE
fix(worker): prevent kill events from being dropped when gRPC job queue is full

### DIFF
--- a/worker/src/main/java/io/kestra/worker/fetchers/WorkerJobFetcher.java
+++ b/worker/src/main/java/io/kestra/worker/fetchers/WorkerJobFetcher.java
@@ -4,6 +4,8 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
@@ -123,6 +125,16 @@ public class WorkerJobFetcher extends WorkerLoop {
      * Set in {@code onError()} and cleared on successful connection.
      */
     private final AtomicLong reconnectNotBefore = new AtomicLong(0L);
+
+    /**
+     * Executor for the blocking workerJobQueue.put() calls.
+     * <p>
+     * gRPC delivers stream messages via a SerializingExecutor that processes one message at a time.
+     * If put() blocks (queue full), every subsequent message — including kill event broadcasts — is
+     * stuck behind it. Virtual threads are cheap and absorb the blocking without tying up the
+     * gRPC executor thread.
+     */
+    private final ExecutorService jobIngestExecutor = Executors.newVirtualThreadPerTaskExecutor();
 
     /**
      * Creates a new {@code WorkerJobFetcher} instance.
@@ -282,12 +294,13 @@ public class WorkerJobFetcher extends WorkerLoop {
      * Handles a job response from the controller.
      */
     private void handleJobResponse(WorkerJobResponse response) {
-        ClientCallStreamObserver<WorkerJobRequest> observer = requestObserverRef.get();
-        if (observer == null || !isRunning()) {
+        if (!isRunning()) {
             return;
         }
 
         // Process broadcast events (kill commands, cluster events, etc.)
+        // Kill events must be processed regardless of observer state — a null observer
+        // (e.g. after a transient stream error) must never silently drop a kill command.
         for (ByteString eventData : response.getEventsList()) {
             try {
                 WorkerBroadcastEvent event = MessageFormats.JSON.fromByteString(eventData, WorkerBroadcastEvent.class);
@@ -308,29 +321,44 @@ public class WorkerJobFetcher extends WorkerLoop {
             }
         }
 
+        // Job ingestion must not block the gRPC onNext thread.
+        // workerJobQueue.put() blocks when the queue is full; if it runs on the gRPC
+        // SerializingExecutor, every subsequent message (including kill broadcasts) is stuck
+        // behind it. Submit each batch to a virtual thread so the gRPC thread stays free.
+        List<WorkerJobPayload> jobs = response.getJobsList();
+        if (!jobs.isEmpty()) {
+            jobIngestExecutor.submit(() -> ingestJobsAndAck(new ArrayList<>(jobs)));
+        }
+    }
+
+    /**
+     * Puts each job into the local queue and sends a single ACK+permits response.
+     * Runs on a virtual thread so the blocking {@code put()} never stalls the gRPC executor.
+     */
+    private void ingestJobsAndAck(List<WorkerJobPayload> payloads) {
         List<String> acks = new ArrayList<>();
-        for (WorkerJobPayload payload : response.getJobsList()) {
+        for (WorkerJobPayload payload : payloads) {
             try {
                 String jobId = payload.getJobId();
                 WorkerJob job = MessageFormats.JSON.fromByteString(payload.getJobData(), WorkerJob.class);
-
                 log.debug("Received job: {}", jobId);
-
-                // Put job in local queue (blocking if full - provides local backpressure)
                 workerJobQueue.put(job);
-
-                // Collect ACK for this job (receipt acknowledgment)
                 acks.add(jobId);
-
             } catch (Exception e) {
+                if (e instanceof RuntimeException re && re.getCause() instanceof InterruptedException) {
+                    Thread.currentThread().interrupt();
+                    log.debug("Job ingestion interrupted");
+                    break;
+                }
                 log.error("Error processing job payload: {}", e.getMessage(), e);
             }
         }
 
-        // Send ACKs and request more permits based on remaining capacity
-        // Only send if there were jobs (event-only responses don't need permit updates)
         if (!acks.isEmpty()) {
-            sendPermitsAndAcks(observer, calculatePermits(), acks);
+            ClientCallStreamObserver<WorkerJobRequest> observer = requestObserverRef.get();
+            if (observer != null) {
+                sendPermitsAndAcks(observer, calculatePermits(), acks);
+            }
         }
     }
 
@@ -424,6 +452,8 @@ public class WorkerJobFetcher extends WorkerLoop {
      */
     @Override
     protected void cleanup() {
+        jobIngestExecutor.shutdownNow();
+
         ClientCallStreamObserver<WorkerJobRequest> observer = requestObserverRef.getAndSet(null);
         if (observer != null) {
             try {

--- a/worker/src/test/java/io/kestra/worker/WorkerTest.java
+++ b/worker/src/test/java/io/kestra/worker/WorkerTest.java
@@ -170,7 +170,12 @@ class WorkerTest {
             workerJobEventQueue.emit(null, WorkerJobEvent.of(workerTask(Duration.ofSeconds(60), executionId), null));
             workerJobEventQueue.emit(null, WorkerJobEvent.of(workerTask(Duration.ofSeconds(1)), null));
 
-            Thread.sleep(500);
+            // Wait until the worker has actually started executing a task before sending the kill.
+            // Thread.sleep() was insufficient — the gRPC handshake is async and 500ms is not guaranteed.
+            await()
+                .atMost(Duration.ofSeconds(10))
+                .pollInterval(Duration.ofMillis(50))
+                .until(() -> !worker.getRunningJobs().isEmpty());
 
             // When
             ExecutionKilledExecution killedExecution = ExecutionKilledExecution.builder()


### PR DESCRIPTION
## Summary

- `WorkerJobFetcher.handleJobResponse()` called `workerJobQueue.put()` directly on the gRPC `SerializingExecutor` thread. When the local job queue was full (capacity = `workerThreads * 2`), `put()` blocked that thread indefinitely — causing every subsequent gRPC message, including kill-event broadcasts from the controller, to pile up in the serializing executor and never be processed until the running task finished.
- Fix: move the blocking `put()` + ACK into a virtual-thread executor (`jobIngestExecutor`). The gRPC `onNext` thread now always returns immediately; kill broadcasts are processed without delay.
- Also moves the `observer == null` guard past the broadcast-event loop so kill events are not silently dropped if the request observer is transiently null after a stream error.
- Test fix: replaces the `Thread.sleep(500)` before the kill event with an `Awaitility` await on `worker.getRunningJobs()`, eliminating the timing race between gRPC stream setup and kill delivery.

## Root cause (detailed)

With `concurrency=1` the worker queue has capacity 2. On a fast machine the consumer dequeues task 1 before `calculatePermits()` is called, so the worker advertises `permits=2`. The controller dispatches two more tasks (tasks 3 and 4). By the time task 4 arrives, the queue holds tasks 2 and 3 and is full. `put(task4)` blocks the gRPC `SerializingExecutor` thread. The kill-event broadcast arrives as a separate gRPC message but can never be delivered — `onNext()` is serialized behind the blocked `put()`.

## Test plan

- [x] `WorkerTest.shouldKillTasksWhenExecutionKillEventReceived()` passes 5/5 runs locally (was failing ~3/5, 38 s timeout each failure)
- [x] Full `worker` test + `flakyTest` suite passes (`BUILD SUCCESSFUL`)