### PR TITLE
chore(design-system): drop redundant OIDC token exchange

### DIFF
--- a/.github/workflows/publish-design-system.yml
+++ b/.github/workflows/publish-design-system.yml
@@ -43,16 +43,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
         
-      - name: Get OIDC Token
-        env:
-          AUDIENCE: "npm:registry.npmjs.org"
-        run: |
-          TOKEN_JSON=$(curl -s -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" "$ACTIONS_ID_TOKEN_REQUEST_URL&audience=$AUDIENCE")
-          ID_TOKEN=$(echo "$TOKEN_JSON" | jq -r .value)
-          echo "$TOKEN_JSON"
-          echo "NODE_AUTH_TOKEN=$ID_TOKEN" >> "$GITHUB_ENV"
-          echo "$ID_TOKEN" | awk -F. '{print $2}' | base64 -d 2>/dev/null | jq -r
-
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:


### PR DESCRIPTION
### ✨ Description

The manual OIDC token exchange is unused, the later `npm publish` command mints its own OIDC token, and replaces it in .npmrc's _authToken for the publish step. No other step reads that `NODE_AUTH_TOKEN` env var.

Pre-minting an OIDC token early could lead to its exfiltration in a later step. The printout for the token value (`echo $TOKEN_JSON`) are redacted  in public logs, but the claims printed out by `echo $ID_TOKEN` don't actually correspond to what will be applied during provenance signature, since that token is not the one that's going to be used. So the whole step can be removed as a precaution.

### 🔗 Related Issue

No related issue.

### 📝 Additional Notes

Flagged by Opus 4.7 using the [`/audit-github-actions`](https://github.com/franky47/dotfiles/blob/main/dot-claude/skills/audit-github-actions/SKILL.md) skill in [`franky47/dotfiles`](https://github.com/franky47/dotfiles).

<details>
<summary>
AI-generated summary of our research:
</summary>
Removes the manual Get OIDC Token step from the design-system publish workflow. It hand-fetched a GitHub OIDC JWT and stuffed it into NODE_AUTH_TOKEN, but the npm CLI (≥ 11.5.1, already required by this workflow) does the OIDC mint + registry token-exchange itself during trusted publishing — see lib/commands/publish.js and lib/utils/oidc.js in npm/cli. The manual token was unused on the success path (npm overwrites the configured _authToken), and on the failure path it remained as an invali dtoken that masked npm's clear ENEEDAUTH error with an opaque 401. The id-token: write permission and registry-url config that the built-in flow needs are already present.
</details>

### 🤖 AI Authors

I edited, commited & opened the PR myself (but Opus 4.7 did the research work). Y'a encore des gens qui codent à la main? Chat alors! 😸