### PR TITLE
fix(ci): use GH_BOT_APP_ID instead of GH_BOT_CLIENT_ID for GitHub App token

### DIFF
--- a/.github/workflows/global-create-new-release-branch.yml
+++ b/.github/workflows/global-create-new-release-branch.yml
@@ -35,7 +35,7 @@ jobs:
       # Checkout
       - uses: kestra-io/actions/composite/checkout-and-auth@main
         with:
-          gh-app-id: ${{ secrets.GH_BOT_CLIENT_ID }}
+          gh-app-id: ${{ secrets.GH_BOT_APP_ID }}
           gh-app-private-key: ${{ secrets.GH_BOT_PRIVATE_KEY }}
           fetch-depth: 0
           path: kestra

--- a/.github/workflows/global-start-release.yml
+++ b/.github/workflows/global-start-release.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Checkout
         uses: kestra-io/actions/composite/checkout-and-auth@main
         with:
-          gh-app-id: ${{ secrets.GH_BOT_CLIENT_ID }}
+          gh-app-id: ${{ secrets.GH_BOT_APP_ID }}
           gh-app-private-key: ${{ secrets.GH_BOT_PRIVATE_KEY }}
           fetch-depth: 0
           ref: ${{ steps.parse-and-check-inputs.outputs.release_branch }}

--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -31,7 +31,7 @@ jobs:
         if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/develop' }}
         uses: kestra-io/actions/composite/repository-dispatch@main
         with:
-          gh-app-id: ${{ secrets.GH_BOT_CLIENT_ID }}
+          gh-app-id: ${{ secrets.GH_BOT_APP_ID }}
           gh-app-private-key: ${{ secrets.GH_BOT_PRIVATE_KEY }}
           repository: kestra-io/kestra-ee
           event-type: "oss-updated"

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -17,7 +17,7 @@ jobs:
       if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false }}
       uses: actions/create-github-app-token@v3
       with:
-        app-id: ${{ secrets.GH_BOT_CLIENT_ID }}
+        app-id: ${{ secrets.GH_BOT_APP_ID }}
         private-key: ${{ secrets.GH_BOT_PRIVATE_KEY }}
         owner: kestra-io
         repositories: kestra-ee


### PR DESCRIPTION
Follow-up to #16012.

`GH_BOT_CLIENT_ID` is the OAuth client ID (not suitable for App JWT auth). `GH_BOT_APP_ID` is the correct secret for minting installation tokens via `actions/create-github-app-token`.