### PR TITLE
fix(tests): fix OOM-cascade flakiness in webserver test suite

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -214,6 +214,7 @@ subprojects {
         def commonTestConfig = { Test t ->
             // set Xmx for test workers
             t.maxHeapSize = '4g'
+            t.jvmArgs '-XX:+ExitOnOutOfMemoryError'
 
             // configure en_US default locale for tests
             t.systemProperty 'user.language', 'en'

--- a/webserver/build.gradle
+++ b/webserver/build.gradle
@@ -8,6 +8,15 @@ configurations {
     implementation.extendsFrom(micronaut)
 }
 
+// The webserver test JVM runs a full Micronaut server + H2 in-memory DB + 30 test classes.
+// Several classes (FlowControllerTest, ExecutionControllerTest, etc.) reload 273 flows before
+// each test method, creating heavy GC pressure that exceeds the default 4g limit.
+// ExitOnOutOfMemoryError ensures a fast failure instead of a 17-minute read-timeout hang.
+tasks.withType(Test).configureEach {
+    maxHeapSize = '6g'
+    jvmArgs '-XX:+ExitOnOutOfMemoryError'
+}
+
 dependencies {
 
     annotationProcessor "io.micronaut.openapi:micronaut-openapi"

--- a/webserver/build.gradle
+++ b/webserver/build.gradle
@@ -11,10 +11,8 @@ configurations {
 // The webserver test JVM runs a full Micronaut server + H2 in-memory DB + 30 test classes.
 // Several classes (FlowControllerTest, ExecutionControllerTest, etc.) reload 273 flows before
 // each test method, creating heavy GC pressure that exceeds the default 4g limit.
-// ExitOnOutOfMemoryError ensures a fast failure instead of a 17-minute read-timeout hang.
 tasks.withType(Test).configureEach {
     maxHeapSize = '6g'
-    jvmArgs '-XX:+ExitOnOutOfMemoryError'
 }
 
 dependencies {


### PR DESCRIPTION
## Summary

- Increases `maxHeapSize` for `webserver` tests from 4g to 6g — the webserver test JVM runs a full Micronaut server + H2 in-memory DB + 30 test classes in a single fork, with several classes (`FlowControllerTest`, `ExecutionControllerTest`, `TriggerControllerTest`) reloading 273 flows before every test method (52 tests × 273 flows = 14,196 flow operations in `FlowControllerTest` alone)
- Adds `-XX:+ExitOnOutOfMemoryError` to **all** test tasks via `commonTestConfig` — ensures a fast, clean failure instead of a 17-minute hang when OOM occurs

## Root cause

When the 4g heap was exhausted, the Micronaut IO executor thread died mid-request. The Netty timer threads also died, preventing `read-timeout: 60s` from firing. The HTTP client blocked for ~17 minutes until GC recovered enough memory for the timer to fire, throwing `ReadTimeoutException` instead of the expected `HttpClientResponseException`. H2 was closed by then, causing 10+ subsequent tests to fail with `The database has been closed`.

## Test plan

- [ ] Re-run the failing CI job — `FlowControllerTest.updateFlowFlowFromJson()` and the cascade of `database has been closed` failures should no longer appear
- [ ] Verify `-Xmx6g -XX:+ExitOnOutOfMemoryError` appear in the webserver test JVM command line (visible in Gradle `--info` output)