### PR TITLE
fix(tests): increase liveness coordinator test timeouts to prevent flakiness

### DIFF
--- a/jdbc/src/test/java/io/kestra/jdbc/runner/JdbcServiceLivenessCoordinatorTest.java
+++ b/jdbc/src/test/java/io/kestra/jdbc/runner/JdbcServiceLivenessCoordinatorTest.java
@@ -129,14 +129,14 @@ public abstract class JdbcServiceLivenessCoordinatorTest {
         });
 
         workerJobQueue.emit(workerTask(Duration.ofSeconds(5)));
-        boolean runningLatchAwait = runningLatch.await(5, TimeUnit.SECONDS);
+        boolean runningLatchAwait = runningLatch.await(10, TimeUnit.SECONDS);
         assertThat(runningLatchAwait).isTrue();
         worker.close(); // stop processing task
 
         // create second worker (this will revoke previously one).
         Worker newWorker = applicationContext.createBean(TestMethodScopedWorker.class, IdUtils.create(), 1, null);
         newWorker.run();
-        boolean resubmitLatchAwait = resubmitLatch.await(10, TimeUnit.SECONDS);
+        boolean resubmitLatchAwait = resubmitLatch.await(30, TimeUnit.SECONDS);
         assertThat(resubmitLatchAwait).isTrue();
         WorkerTaskResult workerTaskResult = receive.blockLast();
         assertThat(workerTaskResult).isNotNull();


### PR DESCRIPTION
## Summary

- `shouldReEmitTasksWhenWorkerIsDetectedAsNonResponding` had `runningLatch.await(5s)` and `resubmitLatch.await(10s)`
- The resubmit path requires at least 8s under ideal conditions: 3s liveness timeout + 5s task re-execution — leaving only 2s of headroom under CI load
- The sibling test `shouldReEmitTasksToTheSameWorkerGroup` already uses 30s for the same reason
- `origin/develop` has already applied the same fix — this is a backport to `releases/v1.0.x`

## Test plan

- [x] `MysqlServiceLivenessCoordinatorTest.shouldReEmitTasksWhenWorkerIsDetectedAsNonResponding` passes locally with the new timeouts
- [ ] Verify CI passes on this branch