### PR TITLE
feat: add support for App filter on TAGS, ENABLED, NAMESPACE, and FLO…

### DIFF
--- a/core/src/main/java/io/kestra/core/models/QueryFilter.java
+++ b/core/src/main/java/io/kestra/core/models/QueryFilter.java
@@ -110,7 +110,7 @@ public record QueryFilter(
         TAGS("tags") {
             @Override
             public List<Op> supportedOp() {
-                return List.of(Op.CONTAINS, Op.IN);
+                return List.of(Op.IN, Op.NOT_IN, Op.PREFIX, Op.CONTAINS, Op.STARTS_WITH, Op.ENDS_WITH);
             }
         },
         METADATA("metadata") {
@@ -591,7 +591,7 @@ public record QueryFilter(
         APP {
             @Override
             public List<Field> supportedField() {
-                return List.of(Field.QUERY, Field.TAGS, Field.NAMESPACE, Field.FLOW_ID);
+                return List.of(Field.QUERY, Field.TAGS, Field.NAMESPACE, Field.FLOW_ID, Field.ENABLED);
             }
         };
 

--- a/core/src/test/java/io/kestra/core/models/QueryFilterTest.java
+++ b/core/src/test/java/io/kestra/core/models/QueryFilterTest.java
@@ -421,8 +421,12 @@ public class QueryFilterTest {
             buildQueryFiltersForOperations(
                 Field.TAGS, Resource.APP,
                 Set.of(
+                    Op.IN,
+                    Op.NOT_IN,
+                    Op.PREFIX,
                     Op.CONTAINS,
-                    Op.IN
+                    Op.STARTS_WITH,
+                    Op.ENDS_WITH
                 )
             ),
 
@@ -461,6 +465,13 @@ public class QueryFilterTest {
                     Op.IN,
                     Op.NOT_IN,
                     Op.PREFIX
+                )
+            ),
+
+            buildQueryFiltersForOperations(
+                Field.ENABLED, Resource.APP,
+                Set.of(
+                    Op.EQUALS
                 )
             ),
 
@@ -1182,11 +1193,7 @@ public class QueryFilterTest {
                     Op.LESS_THAN,
                     Op.GREATER_THAN_OR_EQUAL_TO,
                     Op.LESS_THAN_OR_EQUAL_TO,
-                    Op.NOT_IN,
-                    Op.STARTS_WITH,
-                    Op.ENDS_WITH,
-                    Op.REGEX,
-                    Op.PREFIX
+                    Op.REGEX
                 )
             ),
 

--- a/jdbc/src/main/java/io/kestra/jdbc/repository/AbstractJdbcRepository.java
+++ b/jdbc/src/main/java/io/kestra/jdbc/repository/AbstractJdbcRepository.java
@@ -313,6 +313,10 @@ public abstract class AbstractJdbcRepository {
             return nameCondition(value, operation);
         }
 
+        if (field == QueryFilter.Field.TAGS) {
+            return tagsCondition(value, operation);
+        }
+
         if (field == QueryFilter.Field.EXPIRATION_DATE) {
             return getDateCondition(value, operation, QueryFilter.Field.EXPIRATION_DATE.name().toLowerCase());
         }
@@ -450,6 +454,10 @@ public abstract class AbstractJdbcRepository {
 
     protected Condition getSuperAdminCondition(Object value, Op operation) {
         throw new InvalidQueryFiltersException("getSuperAdminCondition must be overridden for JSONB-backed superAdmin field");
+    }
+
+    protected Condition tagsCondition(Object value, QueryFilter.Op operation) {
+        throw new InvalidQueryFiltersException("Unsupported operation for TAGS field: " + operation);
     }
 
     // Generate the condition for Field.STATE

--- a/jdbc/src/test/java/io/kestra/jdbc/repository/AbstractJdbcRepositoryTest.java
+++ b/jdbc/src/test/java/io/kestra/jdbc/repository/AbstractJdbcRepositoryTest.java
@@ -30,6 +30,7 @@ class AbstractJdbcRepositoryTest extends AbstractJdbcRepository {
         QueryFilter.Field.METADATA,
         QueryFilter.Field.GROUP,
         QueryFilter.Field.NAME,
+        QueryFilter.Field.TAGS,
         QueryFilter.Field.SUPER_ADMIN
     );
 


### PR DESCRIPTION
# feat(apps): implement App page query filters

## ✨ Description
Added Query Filter support 

| Resource | Field | Operator |
| :--- | :--- | :--- |
| APP | TAGS | IN, NOT_IN, PREFIX, CONTAINS, STARTS_WITH, ENDS_WITH |
| APP | ENABLED | EQUALS |
| APP | NAMESPACE | EQUALS, NOT_EQUALS, CONTAINS, STARTS_WITH, ENDS_WITH, REGEX, IN, NOT_IN, PREFIX |
| APP | FLOW_ID | EQUALS, NOT_EQUALS, CONTAINS, STARTS_WITH, ENDS_WITH, REGEX |

---

## 📝 Summary of Changes

* **TAGS operator expansion:** `Field.TAGS` now supports `NOT_IN`, `PREFIX`, `STARTS_WITH`, and `ENDS_WITH` in addition to the existing `IN` and `CONTAINS`. Pattern operators match any single tag element.
* **ENABLED filter on apps:** `Field.ENABLED` is added to `Resource.APP`. Since the app model stores disabled (inverted), the abstract App repository handles the inversion and routes the query against a new generated disabled column.
* **tagsCondition dispatch hook in AbstractJdbcRepository:** `TAGS` now follows the same pattern as `ENABLED`/`STATUS`/`GROUP`/`NAME` — the parent dispatches to a protected `tagsCondition(value, op)` hook with a default that throws `InvalidQueryFiltersException`, and resource-specific repositories override it. The App-specific dispatch (`CONTAINS`/`IN`/`NOT_IN`/pattern) lives in `AbstractJdbcAppRepository`.
* **handleEnabledFilter hook in AbstractElasticSearchRepository:** Mirrors `handleTagsFilter` so resources can customise `ENABLED` handling. `ElasticSearchAppRepository` overrides it to invert `enabled` → `!disabled` and to treat documents missing the `disabled` field as enabled (back-compat for docs indexed before the mapping update).
* **DB migration — generated disabled column:** New `V2_0AppDisabledMigration` per driver (Postgres / H2 / MySQL) adds a `disabled` boolean generated column to the `apps` table (extracted from the JSON value, with `COALESCE(..., false)` so existing rows without the field default to enabled). The per-driver `findConditionForDisabled` JSON extraction code is gone — the abstract repo now compares against the column directly via `DSL.name("disabled")` for dialect-correct quoting.
* **Per-driver tag-pattern SQL:**
  * **Postgres:** `EXISTS (SELECT 1 FROM unnest(tags) ...) LIKE ?`
  * **H2:** `JQ_STRING("value", '[.tags[]? | select(startswith|endswith|prefix-logic)][0]') IS NOT NULL` (H2 can't correlate `UNNEST` into a subquery, so we evaluate jq against the JSON value)
  * **MySQL:** `JSON_SEARCH(tags, 'one', 'pattern%') IS NOT NULL`

### Breaking Changes
* None.

---

## 🔗 Related Issue

Closes: https://github.com/kestra-io/kestra-ee/issues/6253

---

## 🎨 Frontend Checklist

- [x] Code builds without errors (`npm run build`)
- [x] All existing E2E tests pass (`npm run test:e2e`)
- [x] Screenshots or video recordings attached showing the UI changes

---

## 🛠️ Backend Checklist

- [x] Code compiles successfully and passes all checks
- [ x] All unit and integration tests pass