### PR TITLE
feat: add IN/NOT_IN multi-select for flowId filter

### DIFF
--- a/core/src/main/java/io/kestra/core/repositories/DistinctFieldValuesQueryInterface.java
+++ b/core/src/main/java/io/kestra/core/repositories/DistinctFieldValuesQueryInterface.java
@@ -1,0 +1,35 @@
+package io.kestra.core.repositories;
+
+import java.util.List;
+
+import io.kestra.core.models.QueryFilter;
+
+import io.micronaut.core.annotation.Nullable;
+import io.micronaut.data.model.Pageable;
+
+/**
+ * Capability interface for repositories that can return distinct values of one of their fields,
+ * optionally narrowed by any combination of additional {@link QueryFilter} criteria.
+ * <p>
+ * Resource-specific repository interfaces (e.g. {@link ExecutionRepositoryInterface}) should
+ * extend this interface to declare that they support the operation. Concrete implementations
+ * typically inherit the behavior from the matching abstract base
+ * ({@code AbstractJdbcCrudRepository} on the JDBC side, {@code AbstractElasticSearchRepository}
+ * on the ElasticSearch side), so opting in is a one-line {@code extends} on the resource interface.
+ */
+public interface DistinctFieldValuesQueryInterface {
+    /**
+     * Returns distinct values of {@code field}, optionally narrowed by {@code filters}.
+     * <p>
+     * {@code filters} can reference any combination of fields (including {@code field} itself for
+     * a same-field substring narrowing); they are combined with AND. When {@code filters} is null
+     * or empty, the full distinct set under the tenant default filter is returned.
+     * {@code pageable.getSize()} caps the number of distinct values returned.
+     */
+    List<String> findDistinctFieldValues(
+        String tenantId,
+        QueryFilter.Field field,
+        @Nullable List<QueryFilter> filters,
+        Pageable pageable
+    );
+}

--- a/core/src/main/java/io/kestra/core/repositories/ExecutionRepositoryInterface.java
+++ b/core/src/main/java/io/kestra/core/repositories/ExecutionRepositoryInterface.java
@@ -27,7 +27,7 @@ import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
 import reactor.core.publisher.Flux;
 
-public interface ExecutionRepositoryInterface extends QueryBuilderInterface<Executions.Fields> {
+public interface ExecutionRepositoryInterface extends QueryBuilderInterface<Executions.Fields>, DistinctFieldValuesQueryInterface {
     default Optional<Execution> findById(String tenantId, String id) {
         return findById(tenantId, id, false);
     }

--- a/core/src/test/java/io/kestra/core/repositories/AbstractExecutionRepositoryTest.java
+++ b/core/src/test/java/io/kestra/core/repositories/AbstractExecutionRepositoryTest.java
@@ -288,6 +288,94 @@ public abstract class AbstractExecutionRepositoryTest {
     }
 
     @Test
+    void givenSeededExecutions_whenFindDistinctFieldValuesWithoutFilters_thenReturnsAllDistinctValues() {
+        // Given
+        var tenant = TestsUtils.randomTenant(this.getClass().getSimpleName());
+        inject(tenant);
+
+        // When
+        List<String> ids = executionRepository.findDistinctFieldValues(tenant, Field.FLOW_ID, null, Pageable.from(0, 100));
+
+        // Then — inject() seeds executions with two flow ids: FLOW ("full") and "second"
+        assertThat(ids).containsExactlyInAnyOrder(FLOW, "second");
+    }
+
+    @Test
+    void givenSeededExecutions_whenFindDistinctFieldValuesNarrowedBySameFieldContains_thenReturnsMatchingValueOnly() {
+        // Given
+        var tenant = TestsUtils.randomTenant(this.getClass().getSimpleName());
+        inject(tenant);
+        QueryFilter narrow = QueryFilter.builder()
+            .field(Field.FLOW_ID).operation(Op.CONTAINS).value("cond")
+            .build();
+
+        // When
+        List<String> ids = executionRepository.findDistinctFieldValues(tenant, Field.FLOW_ID, List.of(narrow), Pageable.from(0, 100));
+
+        // Then
+        assertThat(ids).containsExactly("second");
+    }
+
+    @Test
+    void givenSeededExecutions_whenFindDistinctFieldValuesNarrowedByOtherField_thenReturnsValuesMatchingThatField() {
+        // Given — only the running executions all have flowId="full" (first 5 in inject() are RUNNING)
+        var tenant = TestsUtils.randomTenant(this.getClass().getSimpleName());
+        inject(tenant);
+        QueryFilter narrow = QueryFilter.builder()
+            .field(Field.STATE).operation(Op.IN).value(List.of(State.Type.RUNNING.name()))
+            .build();
+
+        // When
+        List<String> ids = executionRepository.findDistinctFieldValues(tenant, Field.FLOW_ID, List.of(narrow), Pageable.from(0, 100));
+
+        // Then
+        assertThat(ids).containsExactly(FLOW);
+    }
+
+    @Test
+    void givenSeededExecutions_whenFindDistinctFieldValuesWithNonMatchingFilter_thenReturnsEmpty() {
+        // Given
+        var tenant = TestsUtils.randomTenant(this.getClass().getSimpleName());
+        inject(tenant);
+        QueryFilter narrow = QueryFilter.builder()
+            .field(Field.FLOW_ID).operation(Op.CONTAINS).value("no-such-flow-id")
+            .build();
+
+        // When
+        List<String> ids = executionRepository.findDistinctFieldValues(tenant, Field.FLOW_ID, List.of(narrow), Pageable.from(0, 100));
+
+        // Then
+        assertThat(ids).isEmpty();
+    }
+
+    @Test
+    void givenSeededExecutions_whenFindDistinctFieldValuesWithSizeOne_thenReturnsAtMostOneValue() {
+        // Given
+        var tenant = TestsUtils.randomTenant(this.getClass().getSimpleName());
+        inject(tenant);
+
+        // When
+        List<String> ids = executionRepository.findDistinctFieldValues(tenant, Field.FLOW_ID, null, Pageable.from(0, 1));
+
+        // Then
+        assertThat(ids).hasSize(1);
+    }
+
+    @Test
+    void givenSeededExecutionsForOneTenant_whenFindDistinctFieldValuesForOtherTenant_thenReturnsEmpty() {
+        // Given
+        var tenant = TestsUtils.randomTenant(this.getClass().getSimpleName());
+        var otherTenant = TestsUtils.randomTenant(this.getClass().getSimpleName());
+        inject(tenant);
+
+        // When
+        List<String> ids = executionRepository.findDistinctFieldValues(otherTenant, Field.FLOW_ID, null, Pageable.from(0, 100));
+
+        // Then
+        assertThat(ids).isEmpty();
+    }
+
+    @Test
     protected void find() {
         var tenant = TestsUtils.randomTenant(this.getClass().getSimpleName());
         inject(tenant);

--- a/core/src/test/java/io/kestra/core/repositories/AbstractLogRepositoryTest.java
+++ b/core/src/test/java/io/kestra/core/repositories/AbstractLogRepositoryTest.java
@@ -119,6 +119,8 @@ public abstract class AbstractLogRepositoryTest {
             QueryFilter.builder().field(Field.FLOW_ID).value("flow").operation(Op.STARTS_WITH).build(),
             QueryFilter.builder().field(Field.FLOW_ID).value("Id").operation(Op.ENDS_WITH).build(),
             QueryFilter.builder().field(Field.FLOW_ID).value(".lowI.").operation(Op.REGEX).build(),
+            QueryFilter.builder().field(Field.FLOW_ID).value(List.of("flowId", "other")).operation(Op.IN).build(),
+            QueryFilter.builder().field(Field.FLOW_ID).value(List.of("anotherFlowId")).operation(Op.NOT_IN).build(),
             QueryFilter.builder().field(Field.START_DATE).value(ZonedDateTime.now().minusMinutes(1)).operation(Op.GREATER_THAN_OR_EQUAL_TO).build(),
             QueryFilter.builder().field(Field.START_DATE).value(ZonedDateTime.now().minusMinutes(1)).operation(Op.GREATER_THAN).build(),
             QueryFilter.builder().field(Field.START_DATE).value(ZonedDateTime.now().plusMinutes(1)).operation(Op.LESS_THAN_OR_EQUAL_TO).build(),

--- a/core/src/test/java/io/kestra/core/repositories/AbstractTriggerRepositoryTest.java
+++ b/core/src/test/java/io/kestra/core/repositories/AbstractTriggerRepositoryTest.java
@@ -100,6 +100,8 @@ public abstract class AbstractTriggerRepositoryTest {
             QueryFilter.builder().field(Field.SCOPE).value(List.of(USER)).operation(Op.EQUALS).build(),
             QueryFilter.builder().field(Field.NAMESPACE).value("trigger.namespace").operation(Op.EQUALS).build(),
             QueryFilter.builder().field(Field.FLOW_ID).value("flowId").operation(Op.EQUALS).build(),
+            QueryFilter.builder().field(Field.FLOW_ID).value(List.of("flowId")).operation(Op.IN).build(),
+            QueryFilter.builder().field(Field.FLOW_ID).value(List.of("anotherFlowId")).operation(Op.NOT_IN).build(),
             QueryFilter.builder().field(Field.START_DATE).value(ZonedDateTime.now().minusMinutes(1)).operation(Op.GREATER_THAN).build(),
             QueryFilter.builder().field(Field.END_DATE).value(ZonedDateTime.now().plusMinutes(1)).operation(Op.LESS_THAN).build(),
             QueryFilter.builder().field(Field.TRIGGER_ID).value("triggerId").operation(Op.EQUALS).build(),

--- a/jdbc/src/main/java/io/kestra/jdbc/repository/AbstractJdbcCrudRepository.java
+++ b/jdbc/src/main/java/io/kestra/jdbc/repository/AbstractJdbcCrudRepository.java
@@ -9,6 +9,7 @@ import org.jooq.Record;
 import org.jooq.impl.DSL;
 
 import io.kestra.core.models.HasUID;
+import io.kestra.core.models.QueryFilter;
 import io.kestra.core.models.SoftDeletable;
 import io.kestra.core.repositories.ArrayListTotal;
 import io.kestra.core.utils.ListUtils;
@@ -492,6 +493,40 @@ public abstract class AbstractJdbcCrudRepository<T> extends AbstractJdbcReposito
 
                 return this.jdbcRepository.fetch(select);
             });
+    }
+
+    /**
+     * Returns distinct values of {@code field}, optionally narrowed by {@code filters}.
+     * <p>
+     * Filters are routed through {@link #filter(List, String, QueryFilter.Resource)} which validates
+     * them against {@code resource} and combines each filter's condition via
+     * {@link #getConditionOnField}. Per-repository {@link #getColumnName} overrides (e.g.
+     * FLOW_ID → {@code id} on flows, → {@code detail_flow_id} on audit logs) are therefore
+     * honored. Pass {@code null} or an empty filter list to fetch the full distinct set under
+     * the tenant default filter.
+     * <p>
+     * Concrete repositories should expose this via a public override that supplies their resource.
+     */
+    protected List<String> findDistinctFieldValues(
+        String tenantId,
+        QueryFilter.Field field,
+        List<QueryFilter> filters,
+        Pageable pageable,
+        QueryFilter.Resource resource
+    ) {
+        Field<String> column = DSL.field(getColumnName(field), String.class);
+        Condition where = defaultFilter(tenantId).and(filter(filters, null, resource));
+
+        return this.jdbcRepository
+            .getDslContextWrapper()
+            .transactionResult(configuration -> DSL
+                .using(configuration)
+                .selectDistinct(column)
+                .from(this.jdbcRepository.getTable())
+                .where(where)
+                .orderBy(column.asc())
+                .limit(pageable.getSize())
+                .fetch(column));
     }
 
     /**

--- a/jdbc/src/main/java/io/kestra/jdbc/repository/AbstractJdbcExecutionRepository.java
+++ b/jdbc/src/main/java/io/kestra/jdbc/repository/AbstractJdbcExecutionRepository.java
@@ -133,6 +133,11 @@ public abstract class AbstractJdbcExecutionRepository extends AbstractJdbcCrudRe
     }
 
     @Override
+    public List<String> findDistinctFieldValues(String tenantId, QueryFilter.Field field, List<QueryFilter> filters, Pageable pageable) {
+        return findDistinctFieldValues(tenantId, field, filters, pageable, QueryFilter.Resource.EXECUTION);
+    }
+
+    @Override
     public Optional<Execution> findById(String tenantId, String id, boolean allowDeleted) {
         return findById(tenantId, id, allowDeleted, true);
     }

--- a/ui/packages/design-system/src/components/Data/KsDataTable/filter/layout/FilterEditPopper.vue
+++ b/ui/packages/design-system/src/components/Data/KsDataTable/filter/layout/FilterEditPopper.vue
@@ -109,6 +109,11 @@
         props.filterKey?.valueType === "key-value",
     )
 
+    // Server-side search is opted into by declaring an `options` param on valueProvider.
+    const supportsServerSideSearch = computed(() =>
+        (props.filterKey?.valueProvider?.length ?? 0) > 0,
+    )
+
     const valueComponent = computed(() => {
         if (isTextOp.value) {
             return {
@@ -170,9 +175,11 @@
                     searchable: props.filterKey?.searchable,
                     label: props.filterKey?.label,
                     filterKey: props.filterKey?.key,
+                    serverSideSearch: supportsServerSideSearch.value,
                 },
                 events: {
                     "update:modelValue": (value: string[]) => (state.keyValuePair = value),
+                    "update:search": (value: string) => onSearchChange(value),
                 },
             },
             date: {
@@ -403,10 +410,10 @@
         }
     }
 
-    const loadValueOptions = async () => {
+    const loadValueOptions = async (search?: string) => {
         if (!props.filterKey?.valueProvider) return
 
-        state.valueOptions = await props.filterKey.valueProvider()
+        state.valueOptions = await props.filterKey.valueProvider({search})
 
         if (
             props.filterKey?.key === "timeRange" &&
@@ -423,6 +430,15 @@
                 })
             }
         }
+    }
+
+    let searchDebounceHandle: ReturnType<typeof setTimeout> | null = null
+    const onSearchChange = (search: string) => {
+        if (!supportsServerSideSearch.value) return
+        if (searchDebounceHandle) clearTimeout(searchDebounceHandle)
+        searchDebounceHandle = setTimeout(() => {
+            loadValueOptions(search)
+        }, 250)
     }
 
     const initializeFilter = async () => {

--- a/ui/packages/design-system/src/components/Data/KsDataTable/filter/layout/FilterMultiSelect.vue
+++ b/ui/packages/design-system/src/components/Data/KsDataTable/filter/layout/FilterMultiSelect.vue
@@ -68,7 +68,7 @@
 </template>
 
 <script setup lang="ts">
-    import {computed, ref} from "vue"
+    import {computed, ref, watch} from "vue"
     import {Magnify, InformationOutline} from "../utils/icons"
     import KsExecutionStatus from "../../../KsExecutionStatus/KsExecutionStatus.vue"
 
@@ -79,17 +79,27 @@
         searchable?: boolean;
         placeholder?: string;
         options: {value: string; label: string}[];
+        /** When true, emit `update:search` instead of filtering options locally — parent reloads via valueProvider. */
+        serverSideSearch?: boolean;
     }>()
 
     const emits = defineEmits<{
         "apply": [];
         "reset": [];
         "update:modelValue": [value: string[]];
+        "update:search": [search: string];
     }>()
 
     const searchQuery = ref("")
 
+    watch(searchQuery, (value) => {
+        if (props.serverSideSearch) {
+            emits("update:search", value)
+        }
+    })
+
     const filteredOptions = computed(() => {
+        if (props.serverSideSearch) return props.options
         const query = searchQuery.value.trim().toLowerCase()
         return query
             ? props.options.filter(option =>

--- a/ui/packages/design-system/src/components/Data/KsDataTable/filter/utils/filterTypes.ts
+++ b/ui/packages/design-system/src/components/Data/KsDataTable/filter/utils/filterTypes.ts
@@ -33,7 +33,14 @@ export interface FilterKeyConfig {
     searchable?: boolean;
     comparators: Comparators[];
     showComparatorSelection?: boolean;
-    valueProvider?: () => Promise<FilterValue[]>;
+    /**
+     * Returns the dropdown options for a filter.
+     * Declare an `options` parameter (any name) to opt into server-side search:
+     * the multi-select will call `valueProvider({search})` on user input instead
+     * of filtering the loaded list client-side. Server-side support is detected
+     * via `valueProvider.length > 0`, so avoid default-valued or rest params.
+     */
+    valueProvider?: (options?: {search?: string}) => Promise<FilterValue[]>;
     valueType: "text" | "select" | "date" | "multi-select" | "key-value" | "radio";
     visibleByDefault?: boolean;
     defaultValue?: AppliedFilter["value"] | (() => AppliedFilter["value"]);

--- a/ui/src/components/filter/configurations/executionFilter.ts
+++ b/ui/src/components/filter/configurations/executionFilter.ts
@@ -4,6 +4,7 @@ import resource from "../../../models/resource"
 import action from "../../../models/action"
 import {useNamespacesStore} from "override/stores/namespaces"
 import {useAuthStore} from "override/stores/auth"
+import {useExecutionsStore} from "../../../stores/executions"
 import {useValues} from "../composables/useValues"
 import {useI18n} from "vue-i18n"
 import {useRoute} from "vue-router"
@@ -55,13 +56,26 @@ export const useExecutionFilter = (): ComputedRef<FilterConfiguration> => {
                     label: t("filter.flowId.label"),
                     description: t("filter.flowId.description"),
                     comparators: [
+                        Comparators.IN,
+                        Comparators.NOT_IN,
                         Comparators.EQUALS,
                         Comparators.NOT_EQUALS,
                         Comparators.CONTAINS,
                         Comparators.STARTS_WITH,
                         Comparators.ENDS_WITH,
                     ],
-                    valueType: "text",
+                    valueType: "multi-select" as const,
+                    valueProvider: async (options?: {search?: string}) => {
+                        const search = options?.search?.trim()
+                        const ids = await useExecutionsStore().findDistinctFieldValues({
+                            field: "FLOW_ID",
+                            filters: search ? {"filters[flowId][CONTAINS]": search} : undefined,
+                            size: 100,
+                        })
+                        return ids.map(id => ({label: id, value: id}))
+                    },
+                    searchable: true,
+                    showComparatorSelection: true,
                 }] : []) as any,
                 {
                     key: "kind",

--- a/ui/src/stores/executions.ts
+++ b/ui/src/stores/executions.ts
@@ -300,6 +300,21 @@ export const useExecutionsStore = defineStore("executions", () => {
         })
     }
 
+    const findDistinctFieldValues = async (options: {
+        field: string;
+        filters?: Record<string, string>;
+        size?: number;
+    }): Promise<string[]> => {
+        const response = await axios.get(`${apiUrl()}/executions/distinct-field-values`, {
+            params: {
+                field: options.field,
+                ...(options.filters ?? {}),
+                size: options.size ?? 100,
+            },
+        })
+        return response.data as string[]
+    }
+
     const validateExecution = (options: { namespace: string; id: string; formData: any; labels?: string[]; scheduleDate?: string }) => {
         return axios.post(`${apiUrl()}/executions/${options.namespace}/${options.id}/validate`, Utils.toFormData(options.formData), {
             timeout: 60 * 60 * 1000,
@@ -798,6 +813,7 @@ export const useExecutionsStore = defineStore("executions", () => {
         queryPauseExecution,
         loadExecution,
         findExecutions,
+        findDistinctFieldValues,
         validateExecution,
         triggerExecution,
         deleteExecution,

--- a/webserver/src/main/java/io/kestra/webserver/controllers/api/ExecutionController.java
+++ b/webserver/src/main/java/io/kestra/webserver/controllers/api/ExecutionController.java
@@ -258,6 +258,28 @@ public class ExecutionController {
     }
 
     @ExecuteOn(TaskExecutors.IO)
+    @Get(uri = "/distinct-field-values")
+    @Operation(tags = { "Executions" }, summary = "List distinct values for one of the executions filter fields, optionally narrowed by additional query filters")
+    public List<String> findDistinctFieldValues(
+        @Parameter(description = "The field whose distinct values to return. Must be a field supported by the EXECUTION resource.") @QueryValue QueryFilter.Field field,
+        @Parameter(description = "Additional filters to narrow the distinct values. PHP-style nested query is used - examples: `filters[flowId][CONTAINS]=test`, `filters[state][IN]=FAILED,WARNING`", in = ParameterIn.QUERY)
+            @QueryFilterFormat List<QueryFilter> filters,
+        @Parameter(description = "Maximum number of distinct values to return.") @QueryValue(defaultValue = "100") @Min(1) int size) {
+        if (!QueryFilter.Resource.EXECUTION.supportedField().contains(field)) {
+            throw new HttpStatusException(
+                HttpStatus.BAD_REQUEST,
+                "Field " + field + " is not supported for executions"
+            );
+        }
+        return executionRepository.findDistinctFieldValues(
+            tenantService.resolveTenant(),
+            field,
+            filters,
+            Pageable.from(0, size)
+        );
+    }
+
+    @ExecuteOn(TaskExecutors.IO)
     @Get(uri = "/{executionId}/graph")
     @Operation(tags = { "Executions" }, summary = "Generate a graph for an execution")
     public FlowGraph getExecutionFlowGraph(

--- a/webserver/src/test/java/io/kestra/webserver/controllers/api/ExecutionControllerTest.java
+++ b/webserver/src/test/java/io/kestra/webserver/controllers/api/ExecutionControllerTest.java
@@ -347,6 +347,93 @@ class ExecutionControllerTest {
         assertThat(result.size()).isGreaterThanOrEqualTo(2);
     }
 
+    @SuppressWarnings("unchecked")
+    @Test
+    void findDistinctFieldValues_flowId_returnsListOfStrings() {
+        seedExecutionWithFlowId(MAIN_TENANT, "distinct-flow-test-a");
+        seedExecutionWithFlowId(MAIN_TENANT, "distinct-flow-test-b");
+
+        List<String> all = client.toBlocking().retrieve(
+            GET("/api/v1/main/executions/distinct-field-values?field=FLOW_ID&size=100"),
+            Argument.of(List.class, String.class)
+        );
+
+        assertThat(all).contains("distinct-flow-test-a", "distinct-flow-test-b");
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    void findDistinctFieldValues_flowId_narrowsByContainsFilter() {
+        seedExecutionWithFlowId(MAIN_TENANT, "distinct-flow-narrow-alpha");
+        seedExecutionWithFlowId(MAIN_TENANT, "distinct-flow-narrow-beta");
+
+        List<String> filtered = client.toBlocking().retrieve(
+            GET("/api/v1/main/executions/distinct-field-values?field=FLOW_ID&filters[flowId][CONTAINS]=narrow-alpha&size=100"),
+            Argument.of(List.class, String.class)
+        );
+
+        assertThat(filtered).contains("distinct-flow-narrow-alpha");
+        assertThat(filtered).doesNotContain("distinct-flow-narrow-beta");
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    void findDistinctFieldValues_namespace_returnsListOfStrings() {
+        seedExecutionWithFlowIdAndNamespace(MAIN_TENANT, "distinct-ns-flow", "io.kestra.distinct.alpha");
+        seedExecutionWithFlowIdAndNamespace(MAIN_TENANT, "distinct-ns-flow", "io.kestra.distinct.beta");
+
+        List<String> namespaces = client.toBlocking().retrieve(
+            GET("/api/v1/main/executions/distinct-field-values?field=NAMESPACE&size=100"),
+            Argument.of(List.class, String.class)
+        );
+
+        assertThat(namespaces).contains("io.kestra.distinct.alpha", "io.kestra.distinct.beta");
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    void findDistinctFieldValues_narrowsByCrossFieldFilter() {
+        seedExecutionWithFlowIdAndNamespace(MAIN_TENANT, "cross-flow-in-target", "io.kestra.cross-test.target");
+        seedExecutionWithFlowIdAndNamespace(MAIN_TENANT, "cross-flow-not-in-target", "io.kestra.cross-test.other");
+
+        List<String> filtered = client.toBlocking().retrieve(
+            GET("/api/v1/main/executions/distinct-field-values?field=FLOW_ID&filters[namespace][EQUALS]=io.kestra.cross-test.target&size=100"),
+            Argument.of(List.class, String.class)
+        );
+
+        assertThat(filtered).contains("cross-flow-in-target");
+        assertThat(filtered).doesNotContain("cross-flow-not-in-target");
+    }
+
+    @Test
+    void findDistinctFieldValues_unsupportedField_returnsBadRequest() {
+        HttpClientResponseException exception = assertThrows(
+            HttpClientResponseException.class,
+            () -> client.toBlocking().retrieve(
+                GET("/api/v1/main/executions/distinct-field-values?field=USERNAME&size=100"),
+                Argument.of(List.class, String.class)
+            )
+        );
+        assertThat(exception.getStatus().getCode()).isEqualTo(HttpStatus.BAD_REQUEST.getCode());
+    }
+
+    private void seedExecutionWithFlowId(String tenant, String flowId) {
+        seedExecutionWithFlowIdAndNamespace(tenant, flowId, "io.kestra.distinct-test");
+    }
+
+    private void seedExecutionWithFlowIdAndNamespace(String tenant, String flowId, String namespace) {
+        executionRepository.save(
+            Execution.builder()
+                .id(io.kestra.core.utils.IdUtils.create())
+                .namespace(namespace)
+                .tenantId(tenant)
+                .flowId(flowId)
+                .flowRevision(1)
+                .state(new io.kestra.core.models.flows.State().withState(io.kestra.core.models.flows.State.Type.SUCCESS))
+                .build()
+        );
+    }
+
     @Test
     void badQueryFilters() {
         HttpClientResponseException exception = assertThrows(


### PR DESCRIPTION
# feat(executions): add IN/NOT_IN multi-select for flowId filter

## ✨ Description

| Resource | Field | Operator |
| :--- | :--- | :--- |
| EXECUTION | FLOW_ID | IN, NOT_IN |

Surfaces the existing `FLOW_ID` `IN`/`NOT_IN` backend support in the UI as a server-backed multi-select. The dropdown loads distinct flow IDs from the executions index and narrows live as the user types via a new `/executions/distinct-field-values` endpoint.

---

## 📝 Summary of Changes

* **Backend (OSS):**
  * New `GET /api/v1/{tenant}/executions/distinct-field-values?field=...&filters=...&size=...` endpoint on `ExecutionController` returning distinct values for any field supported by the `EXECUTION` resource, optionally narrowed by `@QueryFilterFormat List<QueryFilter>`. Unsupported fields return a 400.
  * New `DistinctFieldValuesQueryInterface` capability interface added to `ExecutionRepositoryInterface`.
  * `AbstractJdbcCrudRepository.findDistinctFieldValues(...)` and `AbstractElasticSearchRepository.findDistinctFieldValues(...)` route through the existing `getConditionOnField` / `getBoolQueryFilterBuilder` paths.

* **UI:**
  * `executionFilter.ts` flowId entry: comparators now include `IN`/`NOT_IN`, `valueType: "multi-select"`, `valueProvider: async ({search}) => useExecutionsStore().findDistinctFieldValues(...)`. `EQUALS`/`CONTAINS`/`STARTS_WITH`/`ENDS_WITH` continue to render as a free-text input.
  * `FilterEditPopper.vue` detects server-side search by introspecting `valueProvider` arity (no new prop needed) and debounces input by 250ms.
  * `FilterMultiSelect.vue` forwards an `update:search` event and exposes a `serverSideSearch` prop.
  * `filterTypes.ts` widens `valueProvider` to `(options?: {search?: string}) => Promise<FilterValue[]>`.
  * `executions.ts` store: new `findDistinctFieldValues({field, filters?, size?})` action.

### Breaking Changes
* None.

---

## 🔗 Related Issue

Closes: https://github.com/kestra-io/kestra/issues/13882

---