### PR TITLE
fix: worker test completion issue

### DIFF
--- a/worker/src/test/java/io/kestra/worker/senders/GrpcWorkerIOSenderTest.java
+++ b/worker/src/test/java/io/kestra/worker/senders/GrpcWorkerIOSenderTest.java
@@ -50,7 +50,6 @@ class GrpcWorkerIOSenderTest {
     ApplicationContext applicationContext;
 
     @Inject
-    @Named(GrpcWorkerIOSenderFactory.GRPC)
     GrpcWorkerIOSender<WorkerTaskResult> taskResultSender;
 
     @Inject

--- a/worker/src/test/java/io/kestra/worker/systemworker/SystemWorkerTest.java
+++ b/worker/src/test/java/io/kestra/worker/systemworker/SystemWorkerTest.java
@@ -33,7 +33,7 @@ class SystemWorkerTest {
             mock(ApplicationEventPublisher.class),
             mock(WorkerJobExecutor.class),
             mock(DirectQueueJobFetcher.class),
-            List.<WorkerIOSender>of(),
+            List.of(),
             mock(MaintenanceService.class),
             mock(MetricRegistry.class),
             mock(ServerConfig.class)
@@ -47,7 +47,7 @@ class SystemWorkerTest {
             ApplicationEventPublisher<ServiceStateChangeEvent> eventPublisher,
             WorkerJobExecutor workerJobExecutor,
             DirectQueueJobFetcher directQueueJobFetcher,
-            List<WorkerIOSender> workerIOSenders,
+            List<DirectQueueWorkerIOSender<?>> workerIOSenders,
             MaintenanceService maintenanceService,
             MetricRegistry metricRegistry,
             ServerConfig serverConfig


### PR DESCRIPTION
Currently the worker test are failing to compile due to a refactor of the GrpcWorkerIOSenderFactory. This PR resolve the completion issues. 

Example of the worker modules tests failing to compile: https://develocity.kestra.io/s/6woo5zvy6jftk