### PR TITLE
fix(core): handle `,` , `;` and `:` in filename and throw at creation if file doesnt respect regex name

### DIFF
--- a/core/src/main/java/io/kestra/core/models/tasks/runners/ScriptService.java
+++ b/core/src/main/java/io/kestra/core/models/tasks/runners/ScriptService.java
@@ -33,7 +33,9 @@ import static io.kestra.core.utils.Rethrow.throwFunction;
  * Helper class for task runners and script tasks.
  */
 public final class ScriptService {
-    private static final Pattern INTERNAL_STORAGE_PATTERN = Pattern.compile("(kestra:\\/\\/[-\\p{Alnum}._\\+~#=/]*)", Pattern.UNICODE_CHARACTER_CLASS);
+    private static final String ALLOWED_PATH_CHARS = "-\\p{Alnum}._\\+~#=/,:;";
+    private static final Pattern INTERNAL_STORAGE_PATTERN = Pattern.compile("(kestra:\\/\\/[" + ALLOWED_PATH_CHARS + "]*)", Pattern.UNICODE_CHARACTER_CLASS);
+    private static final Pattern VALID_STORAGE_PATH_PATTERN = Pattern.compile("[" + ALLOWED_PATH_CHARS + "]+", Pattern.UNICODE_CHARACTER_CLASS);
 
     // These are the three common additional variables task runners must provide for variable rendering.
     public static final String VAR_WORKING_DIR = "workingDir";
@@ -136,6 +138,7 @@ public final class ScriptService {
                 .forEach(throwConsumer(path ->
                 {
                     String filename = outputDir.relativize(path).toString();
+                    validateStoragePath(filename);
 
                     uploaded.put(
                         filename,
@@ -145,6 +148,15 @@ public final class ScriptService {
         }
 
         return uploaded;
+    }
+
+    static void validateStoragePath(String filename) throws IOException {
+        if (!VALID_STORAGE_PATH_PATTERN.matcher(filename).matches()) {
+            throw new IOException(
+                "Output file '%s' contains unsupported characters. Allowed: letters, digits, hyphens, dots, underscores, plus, tilde, hash, equals, slashes, commas, colons, semicolons."
+                    .formatted(filename)
+            );
+        }
     }
 
     public static List<String> scriptCommands(List<String> interpreter, List<String> beforeCommands, String command) {

--- a/core/src/test/java/io/kestra/core/models/tasks/runners/ScriptServiceTest.java
+++ b/core/src/test/java/io/kestra/core/models/tasks/runners/ScriptServiceTest.java
@@ -26,6 +26,7 @@ import io.kestra.core.utils.IdUtils;
 import jakarta.inject.Inject;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 
@@ -94,6 +95,26 @@ class ScriptServiceTest {
     }
 
     @Test
+    void shouldRejectOutputFileWithUnsupportedChars() {
+        assertThatThrownBy(() -> ScriptService.validateStoragePath("file🐸name.txt"))
+            .isInstanceOf(IOException.class)
+            .hasMessageContaining("unsupported characters");
+
+        assertThatThrownBy(() -> ScriptService.validateStoragePath("file name.txt"))
+            .isInstanceOf(IOException.class)
+            .hasMessageContaining("unsupported characters");
+    }
+
+    @Test
+    void shouldAcceptOutputFileWithSupportedSpecialChars() throws IOException {
+        ScriptService.validateStoragePath("file,name.txt");
+        ScriptService.validateStoragePath("file:name.txt");
+        ScriptService.validateStoragePath("file;name.txt");
+        ScriptService.validateStoragePath("path/to/file.txt");
+        ScriptService.validateStoragePath("file-name_v2.txt");
+    }
+
+    @Test
     void uploadInputFiles() throws IOException {
         String tenant = IdUtils.create();
         var runContext = runContextFactory.of("id", "namespace", tenant);
@@ -136,6 +157,45 @@ class ScriptServiceTest {
         } finally {
             filesToDelete.forEach(File::delete);
             path.toFile().delete();
+        }
+    }
+
+    @Test
+    void shouldReplaceInternalStorageWithSpecialChars() throws IOException {
+        String tenant = IdUtils.create();
+        var runContext = runContextFactory.of("id", "namespace", tenant);
+
+        // Colon (:) is also supported by the regex but can't be tested here:
+        // WindowsUtils.windowsToUnixPath strips colons in LocalStorage path resolution,
+        // which is consistent between read/write in production but breaks test files created directly on disk.
+        Map<String, String> specialCharFiles = Map.of(
+            "file,name", "kestra://some/file,name.txt",
+            "file;name", "kestra://some/file;name.txt"
+        );
+
+        for (var entry : specialCharFiles.entrySet()) {
+            Path path = createFile(tenant, entry.getKey());
+            File localFile = null;
+            try {
+                var command = ScriptService.replaceInternalStorage(
+                    runContext,
+                    "my command with an internal storage file: " + entry.getValue(),
+                    false
+                );
+
+                Matcher matcher = COMMAND_PATTERN_CAPTURE_LOCAL_PATH.matcher(command);
+                assertThat(matcher.matches())
+                    .as("URI with special char should be matched: " + entry.getValue())
+                    .isTrue();
+                Path absoluteLocalFilePath = Path.of(matcher.group(1));
+                localFile = absoluteLocalFilePath.toFile();
+                assertThat(localFile.exists()).isTrue();
+            } finally {
+                if (localFile != null) {
+                    localFile.delete();
+                }
+                path.toFile().delete();
+            }
         }
     }
 
@@ -255,7 +315,7 @@ class ScriptServiceTest {
     private static Path createFile(String tenant, String fileName) throws IOException {
         Path path = Path.of("/tmp/unittest/%s/%s.txt".formatted(tenant, fileName));
         if (!path.toFile().exists()) {
-            Files.createDirectory(Path.of("/tmp/unittest/%s".formatted(tenant)));
+            Files.createDirectories(Path.of("/tmp/unittest/%s".formatted(tenant)));
             Files.createFile(path);
         }
         return path;


### PR DESCRIPTION
close #14224 