### PR TITLE
fix(execution): multiple small flow trigger fixes

### DIFF
--- a/core/src/main/java/io/kestra/core/models/property/Property.java
+++ b/core/src/main/java/io/kestra/core/models/property/Property.java
@@ -288,7 +288,7 @@ public class Property<T> {
 
     @Override
     public String toString() {
-        return value != null ? value.toString() : expression;
+        return expression != null ? expression : Objects.toString(value);
     }
 
     @Override

--- a/core/src/main/java/io/kestra/plugin/core/trigger/Flow.java
+++ b/core/src/main/java/io/kestra/plugin/core/trigger/Flow.java
@@ -167,7 +167,7 @@ import static io.kestra.core.topologies.FlowTopologyService.SIMULATED_EXECUTION;
                     states:
                       - FAILED
                       - WARNING
-                    when: "{{execution.namespace | startsWith 'company'}}\""""
+                    when: "{{flow.namespace | startsWith('company')}}\""""
         ),
         @Example(
             full = true,
@@ -499,7 +499,7 @@ public class Flow extends AbstractTrigger implements TriggerOutput<Flow.Output> 
                 "_", // avoid possible mismatch between namespace and flowId
                 dependency.flowId,
                 dependency.when != null ? dependency.when.toString() : null,
-                ListUtils.emptyOnNull(dependency.states).stream().sorted().map(Enum::name).collect(Collectors.joining(",")),
+                ListUtils.emptyOnNull(dependency.states).stream().map(Enum::name).sorted().collect(Collectors.joining(",")),
                 MapUtils.emptyOnNull(dependency.labels).entrySet().stream().sorted(Map.Entry.comparingByKey()).map(entry -> entry.getKey() + ":" + entry.getValue()).collect(Collectors.joining(","))
             );
         }

--- a/executor/src/main/java/io/kestra/executor/FlowTriggerService.java
+++ b/executor/src/main/java/io/kestra/executor/FlowTriggerService.java
@@ -133,7 +133,7 @@ public class FlowTriggerService {
             return null;
         }
 
-        RunContext runContext = runContextFactory.of(flowWithMultipleCondition.getFlow(), execution);
+        RunContext runContext = runContextFactory.of(null, execution);
 
         // evaluate multiple conditions and accumulate with previously stored results
         Map<String, Boolean> results = flowWithMultipleCondition.getMultipleCondition()
@@ -195,7 +195,7 @@ public class FlowTriggerService {
             return Collections.emptyList();
         }
 
-        RunContext runContext = runContextFactory.of(flow, execution);
+        RunContext runContext = runContextFactory.of(null, execution);
         return flowTriggers(flow).map(trigger -> new FlowWithFlowTrigger(flow, trigger))
             // filter on the execution state the flow listen to
             .filter(flowWithFlowTrigger -> flowWithFlowTrigger.getTrigger().getStates().contains(execution.getState().getCurrent()))

--- a/executor/src/test/java/io/kestra/executor/FlowTriggerServiceTest.java
+++ b/executor/src/test/java/io/kestra/executor/FlowTriggerServiceTest.java
@@ -2,11 +2,11 @@ package io.kestra.executor;
 
 import java.util.List;
 
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import io.kestra.core.context.TestRunContextFactory;
-import io.kestra.core.junit.annotations.KestraTest;
 import io.kestra.core.models.Label;
 import io.kestra.core.models.executions.Execution;
 import io.kestra.core.models.executions.ExecutionKind;
@@ -23,7 +23,7 @@ import static io.kestra.core.repositories.AbstractFlowRepositoryTest.TEST_NAMESP
 import static io.kestra.core.tenant.TenantService.MAIN_TENANT;
 import static org.assertj.core.api.Assertions.assertThat;
 
-@KestraTest
+@MicronautTest
 class FlowTriggerServiceTest {
     private static final List<Label> EMPTY_LABELS = List.of();
 
@@ -211,6 +211,30 @@ class FlowTriggerServiceTest {
 
         // Then
         assertThat(resultingExecutionsToRun).isEmpty();
+    }
+
+    @Test
+    void computeExecutionsFromFlowTriggers_whenStartWithNamespace() {
+        // Given - malformed Pebble expression causes IllegalVariableEvaluationException, treated as false
+        var simpleFlow = aSimpleFlow();
+        var flowWithFlowTrigger = Flow.builder()
+            .id("flow-with-flow-trigger")
+            .namespace(TEST_NAMESPACE)
+            .tenantId(MAIN_TENANT)
+            .tasks(List.of(simpleLogTask()))
+            .triggers(List.of(flowTriggerWithWhen("{{ flow.namespace | startsWith('io.kestra') }}")))
+            .build();
+        var simpleFlowExecution = Execution.newExecution(simpleFlow, EMPTY_LABELS).withState(State.Type.SUCCESS);
+
+        // When
+        var resultingExecutionsToRun = flowTriggerService.computeExecutionsFromFlowTriggerConditions(
+            simpleFlowExecution,
+            flowWithFlowTrigger
+        );
+
+        // Then
+        assertThat(resultingExecutionsToRun).hasSize(1);
+        assertThat(resultingExecutionsToRun.getFirst().getFlowId()).isEqualTo(flowWithFlowTrigger.getId());
     }
 
     private static io.kestra.plugin.core.trigger.Flow flowTriggerWithNoConditions() {


### PR DESCRIPTION
- Stable property toString() so when can be stable
- Stable states list sorting
- Create a runContext with the flow from the execution so flow.namespace is the flow from the execution not the trigger
- Correct the Flow example

Fixes #15805