### PR TITLE
[Backport releases/v1.3.x] fix(storage): parenTransversalGuard was not handling encoded characters

### DIFF
--- a/core/src/main/java/io/kestra/core/storages/StorageInterface.java
+++ b/core/src/main/java/io/kestra/core/storages/StorageInterface.java
@@ -1,22 +1,16 @@
 package io.kestra.core.storages;
 
-import java.io.BufferedInputStream;
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileNotFoundException;
-import java.io.IOException;
-import java.io.InputStream;
-import java.net.URI;
-import java.nio.file.NoSuchFileException;
-import java.util.List;
-
-import org.apache.commons.lang3.RandomStringUtils;
-
 import io.kestra.core.annotations.Retryable;
 import io.kestra.core.models.Plugin;
 import io.kestra.core.models.executions.Execution;
-
+import io.kestra.core.utils.FileUtils;
 import jakarta.annotation.Nullable;
+import org.apache.commons.lang3.RandomStringUtils;
+
+import java.io.*;
+import java.net.URI;
+import java.nio.file.NoSuchFileException;
+import java.util.List;
 
 /**
  * Interface for internal Kestra storage implementations. It handles file-like operations
@@ -329,10 +323,11 @@ public interface StorageInterface extends AutoCloseable, Plugin {
      * @throws IllegalArgumentException if the URI attempts to traverse parent directories
      */
     default void parentTraversalGuard(URI uri) {
-        if (uri != null && (uri.toString().contains(".." + File.separator) || uri.toString().contains(File.separator + "..") || uri.toString().equals(".."))) {
+        if (FileUtils.isParentTraversal(uri)) {
             throw new IllegalArgumentException("File should be accessed with their full path and not using relative '..' path.");
         }
     }
+
 
     /**
      * Builds the internal storage path based on the URI.

--- a/core/src/main/java/io/kestra/core/utils/FileUtils.java
+++ b/core/src/main/java/io/kestra/core/utils/FileUtils.java
@@ -1,10 +1,11 @@
 package io.kestra.core.utils;
 
-import java.net.URI;
-import java.util.Optional;
-
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.lang3.StringUtils;
+
+import java.io.File;
+import java.net.URI;
+import java.util.Optional;
 
 /**
  * Utility methods for manipulating files.
@@ -59,5 +60,19 @@ public final class FileUtils {
     public static String getFileName(final URI uri) {
         String path = uri.getPath();
         return path.substring(path.lastIndexOf('/') + 1);
+    }
+
+    /**
+     * Check if the provided URI does not contain relative parent path traversal (i.e., "..").
+     *
+     * @param uri the URI to validate
+     * @return true if there is a relative parent path traversal
+     */
+    public static boolean isParentTraversal(URI uri) {
+        if (uri == null) {
+            return false;
+        }
+        var path = uri.getPath();
+        return path != null && (path.contains(".." + File.separator) || path.contains(File.separator + "..") || path.equals(".."));
     }
 }

--- a/core/src/test/java/io/kestra/core/utils/FileUtilsTest.java
+++ b/core/src/test/java/io/kestra/core/utils/FileUtilsTest.java
@@ -1,6 +1,10 @@
 package io.kestra.core.utils;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.net.URI;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -14,5 +18,26 @@ class FileUtilsTest {
         assertThat(FileUtils.getExtension("/file/hello.txt")).isEqualTo(".txt");
         assertThat(FileUtils.getExtension("/file/hello.file with spaces.txt")).isEqualTo(".txt");
         assertThat(FileUtils.getExtension("/file/hello.file.with.multiple.dots.txt")).isEqualTo(".txt");
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+        "",
+        "kestra:///ns/flow/exec/abc/output",
+        "kestra:///ns/flow/exec/abc/.output",
+    })
+    void isParentTraversal_false(String path) {
+        assertThat(FileUtils.isParentTraversal(URI.create(path))).isFalse();
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+        "kestra:///ns/flow/exec/abc/../../../etc/passwd",
+        "kestra:///ns/flow/exec/abc/%2E%2E/%2E%2E/%2E%2E/etc/passwd",
+        "kestra:///ns/flow/exec/abc/%2e%2e/%2e%2e/%2e%2e/etc/passwd",
+        "kestra:///ns/flow/exec/abc%2F%2E%2E%2Fetc%2Fpasswd"
+    })
+    void isParentTraversal_true(String path) {
+        assertThat(FileUtils.isParentTraversal(URI.create(path))).isTrue();
     }
 }


### PR DESCRIPTION
Backport of #16014

---
- fixes https://github.com/kestra-io/kestra-ee/issues/7686
