### PR TITLE
fix(tests): fix macOS-specific test failures in local-files and echo commands

### DIFF
--- a/core/src/main/java/io/kestra/core/runners/LocalPathFactory.java
+++ b/core/src/main/java/io/kestra/core/runners/LocalPathFactory.java
@@ -17,13 +17,23 @@ import jakarta.inject.Singleton;
 
 @Singleton
 public class LocalPathFactory {
-    private final List<String> globalAllowedPaths;
+    private final List<Path> globalAllowedPaths;
 
     @Inject
     public LocalPathFactory(LocalFilesConfiguration localFilesConfiguration) {
         this.globalAllowedPaths = localFilesConfiguration.allowedPaths() != null
-            ? localFilesConfiguration.allowedPaths()
+            ? localFilesConfiguration.allowedPaths().stream().map(LocalPathFactory::resolveAllowedPath).toList()
             : Collections.emptyList();
+    }
+
+    // Resolve symlinks so that configured paths like /tmp match their real location (e.g. /private/tmp on macOS).
+    // Falls back to normalized absolute path if the directory does not yet exist.
+    private static Path resolveAllowedPath(String p) {
+        try {
+            return Path.of(p).toRealPath();
+        } catch (IOException e) {
+            return Path.of(p).toAbsolutePath().normalize();
+        }
     }
 
     /**
@@ -87,10 +97,10 @@ public class LocalPathFactory {
     }
 
     static class RunContextLocalPath extends AbstractLocalPath {
-        private final List<String> globalAllowedPaths;
+        private final List<Path> globalAllowedPaths;
         private final RunContext runContext;
 
-        RunContextLocalPath(List<String> globalAllowedPaths, RunContext runContext) {
+        RunContextLocalPath(List<Path> globalAllowedPaths, RunContext runContext) {
             this.globalAllowedPaths = globalAllowedPaths;
             this.runContext = runContext;
         }
@@ -104,7 +114,7 @@ public class LocalPathFactory {
             if (!path.startsWith(workingDirectory) && globalAllowedPaths.stream().noneMatch(path::startsWith)) {
                 // if not globally allowed, we check if it's allowed for this specific plugin
                 List<String> pluginAllowedPaths = (List<String>) runContext.pluginConfiguration("allowed-paths").orElse(Collections.emptyList());
-                if (pluginAllowedPaths.stream().noneMatch(path::startsWith)) {
+                if (pluginAllowedPaths.stream().map(LocalPathFactory::resolveAllowedPath).noneMatch(path::startsWith)) {
                     throw new SecurityException(
                         "The path " + path + " is not authorized. " +
                             "Only files inside the working directory are allowed by default, other path must be allowed either globally inside the Kestra configuration using the `"
@@ -119,9 +129,9 @@ public class LocalPathFactory {
     }
 
     static class DefaultLocalPath extends AbstractLocalPath {
-        private final List<String> globalAllowedPaths;
+        private final List<Path> globalAllowedPaths;
 
-        DefaultLocalPath(List<String> globalAllowedPaths) {
+        DefaultLocalPath(List<Path> globalAllowedPaths) {
             this.globalAllowedPaths = globalAllowedPaths;
         }
 

--- a/core/src/test/java/io/kestra/core/models/property/URIFetcherTest.java
+++ b/core/src/test/java/io/kestra/core/models/property/URIFetcherTest.java
@@ -74,7 +74,7 @@ class URIFetcherTest {
     @Test
     void shouldFetchFromLocalFileWhenAllowedGlobally() throws IOException {
         URI uri = createFile();
-        RunContext runContext = buildRunContext(List.of("/tmp"));
+        RunContext runContext = buildRunContext(List.of(System.getProperty("java.io.tmpdir")));
 
         try (var fetch = URIFetcher.of(uri).fetch(runContext)) {
             String fetchedContent = new String(fetch.readAllBytes());
@@ -85,7 +85,7 @@ class URIFetcherTest {
     @Test
     void shouldFetchFromLocalFileWhenAllowedForPlugin() throws IOException {
         URI uri = createFile();
-        RunContext runContext = buildRunContext(Collections.emptyList(), List.of("/tmp"));
+        RunContext runContext = buildRunContext(Collections.emptyList(), List.of(System.getProperty("java.io.tmpdir")));
 
         try (var fetch = URIFetcher.of(uri).fetch(runContext)) {
             String fetchedContent = new String(fetch.readAllBytes());
@@ -134,7 +134,7 @@ class URIFetcherTest {
     }
 
     private URI createFile() throws IOException {
-        File tempFile = File.createTempFile("file", ".txt", new File("/tmp"));
+        File tempFile = File.createTempFile("file", ".txt");
         Files.write(tempFile.toPath(), "Hello World".getBytes());
         return tempFile.toPath().toUri();
     }

--- a/core/src/test/java/io/kestra/core/models/property/URIFetcherTest.java
+++ b/core/src/test/java/io/kestra/core/models/property/URIFetcherTest.java
@@ -134,7 +134,7 @@ class URIFetcherTest {
     }
 
     private URI createFile() throws IOException {
-        File tempFile = File.createTempFile("file", ".txt");
+        File tempFile = File.createTempFile("file", ".txt", new File("/tmp"));
         Files.write(tempFile.toPath(), "Hello World".getBytes());
         return tempFile.toPath().toUri();
     }

--- a/core/src/test/java/io/kestra/core/runners/FilesServiceTest.java
+++ b/core/src/test/java/io/kestra/core/runners/FilesServiceTest.java
@@ -138,7 +138,7 @@ class FilesServiceTest {
     }
 
     private URI createFile() throws IOException {
-        File tempFile = File.createTempFile("file", ".txt");
+        File tempFile = File.createTempFile("file", ".txt", new File("/tmp"));
         Files.write(tempFile.toPath(), "Hello World".getBytes());
         return tempFile.toPath().toUri();
     }

--- a/core/src/test/java/io/kestra/core/runners/FilesServiceTest.java
+++ b/core/src/test/java/io/kestra/core/runners/FilesServiceTest.java
@@ -138,7 +138,7 @@ class FilesServiceTest {
     }
 
     private URI createFile() throws IOException {
-        File tempFile = File.createTempFile("file", ".txt", new File("/tmp"));
+        File tempFile = Files.createTempFile(Path.of("/tmp"), "file", ".txt").toFile();
         Files.write(tempFile.toPath(), "Hello World".getBytes());
         return tempFile.toPath().toUri();
     }

--- a/core/src/test/java/io/kestra/core/runners/pebble/functions/FileExistsFunctionTest.java
+++ b/core/src/test/java/io/kestra/core/runners/pebble/functions/FileExistsFunctionTest.java
@@ -217,7 +217,7 @@ class FileExistsFunctionTest {
     }
 
     private URI createFile() throws IOException {
-        File tempFile = File.createTempFile("%s-file".formatted(IdUtils.create()), ".txt", new File("/tmp"));
+        File tempFile = Files.createTempFile(Path.of("/tmp"), "%s-file".formatted(IdUtils.create()), ".txt").toFile();
         Files.write(tempFile.toPath(), "Hello World".getBytes());
         return tempFile.toPath().toUri();
     }

--- a/core/src/test/java/io/kestra/core/runners/pebble/functions/FileExistsFunctionTest.java
+++ b/core/src/test/java/io/kestra/core/runners/pebble/functions/FileExistsFunctionTest.java
@@ -217,7 +217,7 @@ class FileExistsFunctionTest {
     }
 
     private URI createFile() throws IOException {
-        File tempFile = File.createTempFile("%s-file".formatted(IdUtils.create()), ".txt");
+        File tempFile = File.createTempFile("%s-file".formatted(IdUtils.create()), ".txt", new File("/tmp"));
         Files.write(tempFile.toPath(), "Hello World".getBytes());
         return tempFile.toPath().toUri();
     }

--- a/core/src/test/java/io/kestra/core/runners/pebble/functions/FileSizeFunctionTest.java
+++ b/core/src/test/java/io/kestra/core/runners/pebble/functions/FileSizeFunctionTest.java
@@ -282,7 +282,7 @@ public class FileSizeFunctionTest {
     }
 
     private URI createFile() throws IOException {
-        File tempFile = File.createTempFile("%sfile".formatted(IdUtils.create()), ".txt", new File("/tmp"));
+        File tempFile = Files.createTempFile(Path.of("/tmp"), "%sfile".formatted(IdUtils.create()), ".txt").toFile();
         Files.write(tempFile.toPath(), "Hello World".getBytes());
         return tempFile.toPath().toUri();
     }

--- a/core/src/test/java/io/kestra/core/runners/pebble/functions/FileSizeFunctionTest.java
+++ b/core/src/test/java/io/kestra/core/runners/pebble/functions/FileSizeFunctionTest.java
@@ -282,7 +282,7 @@ public class FileSizeFunctionTest {
     }
 
     private URI createFile() throws IOException {
-        File tempFile = File.createTempFile("%sfile".formatted(IdUtils.create()), ".txt");
+        File tempFile = File.createTempFile("%sfile".formatted(IdUtils.create()), ".txt", new File("/tmp"));
         Files.write(tempFile.toPath(), "Hello World".getBytes());
         return tempFile.toPath().toUri();
     }

--- a/core/src/test/java/io/kestra/core/runners/pebble/functions/IsFileEmptyFunctionTest.java
+++ b/core/src/test/java/io/kestra/core/runners/pebble/functions/IsFileEmptyFunctionTest.java
@@ -215,7 +215,7 @@ class IsFileEmptyFunctionTest {
     }
 
     private URI createFile() throws IOException {
-        File tempFile = File.createTempFile("file", ".txt", new File("/tmp"));
+        File tempFile = Files.createTempFile(Path.of("/tmp"), "file", ".txt").toFile();
         Files.write(tempFile.toPath(), "Hello World".getBytes());
         return tempFile.toPath().toUri();
     }

--- a/core/src/test/java/io/kestra/core/runners/pebble/functions/IsFileEmptyFunctionTest.java
+++ b/core/src/test/java/io/kestra/core/runners/pebble/functions/IsFileEmptyFunctionTest.java
@@ -215,7 +215,7 @@ class IsFileEmptyFunctionTest {
     }
 
     private URI createFile() throws IOException {
-        File tempFile = File.createTempFile("file", ".txt");
+        File tempFile = File.createTempFile("file", ".txt", new File("/tmp"));
         Files.write(tempFile.toPath(), "Hello World".getBytes());
         return tempFile.toPath().toUri();
     }

--- a/core/src/test/java/io/kestra/core/runners/pebble/functions/ReadFileFunctionTest.java
+++ b/core/src/test/java/io/kestra/core/runners/pebble/functions/ReadFileFunctionTest.java
@@ -329,7 +329,7 @@ class ReadFileFunctionTest {
     }
 
     private URI createFile() throws IOException {
-        File tempFile = File.createTempFile("file", ".txt");
+        File tempFile = File.createTempFile("file", ".txt", new File("/tmp"));
         Files.write(tempFile.toPath(), "Hello World".getBytes());
         return tempFile.toPath().toUri();
     }

--- a/core/src/test/java/io/kestra/core/runners/pebble/functions/ReadFileFunctionTest.java
+++ b/core/src/test/java/io/kestra/core/runners/pebble/functions/ReadFileFunctionTest.java
@@ -329,7 +329,7 @@ class ReadFileFunctionTest {
     }
 
     private URI createFile() throws IOException {
-        File tempFile = File.createTempFile("file", ".txt", new File("/tmp"));
+        File tempFile = Files.createTempFile(Path.of("/tmp"), "file", ".txt").toFile();
         Files.write(tempFile.toPath(), "Hello World".getBytes());
         return tempFile.toPath().toUri();
     }

--- a/script/src/test/java/io/kestra/plugin/scripts/exec/scripts/runners/CommandsWrapperOutputFilesTest.java
+++ b/script/src/test/java/io/kestra/plugin/scripts/exec/scripts/runners/CommandsWrapperOutputFilesTest.java
@@ -51,7 +51,7 @@ class CommandsWrapperOutputFilesTest {
             .withTaskRunner(Process.instance())
             .withOutputFiles(List.of("outfile"))
             .withInterpreter(Property.ofValue(List.of("/bin/sh", "-c")))
-            .withCommands(Property.<List<String>>ofExpression("[\"echo -n {{ outputFiles.outfile }} > outfile\"]"))
+            .withCommands(Property.<List<String>>ofExpression("[\"printf '%s' {{ outputFiles.outfile }} > outfile\"]"))
             .run();
 
         // Then

--- a/tests/src/main/java/io/kestra/core/models/tasks/runners/AbstractTaskRunnerTest.java
+++ b/tests/src/main/java/io/kestra/core/models/tasks/runners/AbstractTaskRunnerTest.java
@@ -131,9 +131,9 @@ public abstract class AbstractTaskRunnerTest {
                     "cat " + wdir + "{{internalStorageFile}} && echo",
                     "cat " + wdir + "hello.txt && echo",
                     "cat " + wdir + "hello.txt > " + wdir + "output.txt",
-                    "echo -n 'file from output dir' > {{outputDir}}/file.txt",
+                    "printf '%s' 'file from output dir' > {{outputDir}}/file.txt",
                     "mkdir {{outputDir}}/nested",
-                    "echo -n 'nested file from output dir' > {{outputDir}}/nested/file.txt",
+                    "printf '%s' 'nested file from output dir' > {{outputDir}}/nested/file.txt",
                     "echo '::{\"outputs\":{\"logOutput\":\"Hello World\"}}::'"
                 )
             ),


### PR DESCRIPTION
## Summary

- **`LocalPathFactory`**: resolve allowed paths via `toRealPath()` at construction time so that symlinks (e.g. `/tmp` → `/private/tmp` on macOS) are accounted for when checking file authorization. Same resolution applied to plugin-level allowed paths. Without this, `checkPath()` resolved the _file_ URI through `toRealPath()` but compared it against raw unresolved strings, causing false rejections on macOS.
- **6 test `createFile()` helpers**: explicitly pass `new File("/tmp")` to `File.createTempFile()` so temp files land under `/tmp` (which resolves to `/private/tmp`) rather than the macOS default `java.io.tmpdir` (`/private/var/folders/...`), which has no relation to the `/tmp` allowed path used by the tests.
- **`echo -n` → `printf '%s'`**: macOS `/bin/echo` does not support the `-n` flag and prints it literally, producing `-n text` instead of `text`. Replaced with `printf '%s'` which is POSIX-portable and behaves identically on both macOS and Linux.

## Test plan

- [ ] `URIFetcherTest.shouldFetchFromLocalFileWhenAllowedGlobally`
- [ ] `URIFetcherTest.shouldFetchFromLocalFileWhenAllowedForPlugin`
- [ ] `FilesServiceTest.localFileAsInputFile`
- [ ] `FileExistsFunctionTest.shouldSucceedProcessingAllowedFile`
- [ ] `FileSizeFunctionTest.shouldSucceedProcessingAllowedFile`
- [ ] `IsFileEmptyFunctionTest.shouldSucceedProcessingAllowedFile`
- [ ] `ReadFileFunctionTest.shouldSucceedProcessingAllowedFile`
- [ ] `ProcessTest.inputAndOutputFiles`
- [ ] `CommandsWrapperOutputFilesTest.shouldResolveOutputFilesPebbleExpressionInScript`