### PR TITLE
chore(system): combine queue indices and use queuName

### DIFF
--- a/jdbc-h2/src/main/java/io/kestra/repository/h2/migration/V2_0QueueIndexAndType.java
+++ b/jdbc-h2/src/main/java/io/kestra/repository/h2/migration/V2_0QueueIndexAndType.java
@@ -1,0 +1,49 @@
+package io.kestra.repository.h2.migration;
+
+import io.kestra.core.migration.MigrationScript;
+import io.kestra.jdbc.migration.AbstractSQLMigrationScript;
+import io.micronaut.context.annotation.Requires;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+
+import javax.sql.DataSource;
+
+/**
+ * H2 queue Flyway update migration script.
+ *
+ * <p>
+ * Update the {@code queues} by replacing two indices by a single one and switching the type column to a VARCHAR
+ */
+@Singleton
+@Requires(property = "kestra.queue.type", pattern = "h2|memory")
+public class V2_0QueueIndexAndType extends AbstractSQLMigrationScript {
+
+    private static final String SCRIPT_ID = "2.0.1-queue-index-and-type";
+
+    private final DataSource dataSource;
+
+    @Inject
+    public V2_0QueueIndexAndType(final DataSource dataSource) {
+        this.dataSource = dataSource;
+    }
+
+    @Override
+    public String scriptId() {
+        return SCRIPT_ID;
+    }
+
+    @Override
+    public String description() {
+        return "H2 queue upgrade: update queue indices and change type to be a string";
+    }
+
+    @Override
+    public String checksum() {
+        return MigrationScript.checksumOfResources("/migrations/2.0.1-queue-index-and-type-h2.sql");
+    }
+
+    @Override
+    public void migrate() throws Exception {
+        executeSqlResource(dataSource, "/migrations/2.0.1-queue-index-and-type-h2.sql");
+    }
+}

--- a/jdbc-h2/src/main/resources/migrations/2.0.1-queue-index-and-type-h2.sql
+++ b/jdbc-h2/src/main/resources/migrations/2.0.1-queue-index-and-type-h2.sql
@@ -3,3 +3,4 @@ DROP INDEX IF EXISTS queues_created ON queues;
 
 CREATE INDEX IF NOT EXISTS queues_created__type ON queues ("created", "type");
 
+ALTER TABLE queues ALTER COLUMN "type" TYPE VARCHAR(250);

--- a/jdbc-mysql/src/main/java/io/kestra/repository/mysql/migration/V2_0QueueIndexAndType.java
+++ b/jdbc-mysql/src/main/java/io/kestra/repository/mysql/migration/V2_0QueueIndexAndType.java
@@ -1,0 +1,49 @@
+package io.kestra.repository.mysql.migration;
+
+import io.kestra.core.migration.MigrationScript;
+import io.kestra.jdbc.migration.AbstractSQLMigrationScript;
+import io.micronaut.context.annotation.Requires;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+
+import javax.sql.DataSource;
+
+/**
+ * MySQL queue Flyway update migration script.
+ *
+ * <p>
+ * Update the {@code queues} by replacing two indices by a single one and switching the type column to a VARCHAR
+ */
+@Singleton
+@Requires(property = "kestra.queue.type", pattern = "mysql|memory")
+public class V2_0QueueIndexAndType extends AbstractSQLMigrationScript {
+
+    private static final String SCRIPT_ID = "2.0.1-queue-index-and-type";
+
+    private final DataSource dataSource;
+
+    @Inject
+    public V2_0QueueIndexAndType(final DataSource dataSource) {
+        this.dataSource = dataSource;
+    }
+
+    @Override
+    public String scriptId() {
+        return SCRIPT_ID;
+    }
+
+    @Override
+    public String description() {
+        return "MySQL queue upgrade: update queue indices and change type to be a string";
+    }
+
+    @Override
+    public String checksum() {
+        return MigrationScript.checksumOfResources("/migrations/2.0.1-queue-index-and-type-mysql.sql");
+    }
+
+    @Override
+    public void migrate() throws Exception {
+        executeSqlResource(dataSource, "/migrations/2.0.1-queue-index-and-type-mysql.sql");
+    }
+}

--- a/jdbc-mysql/src/main/resources/migrations/2.0.1-queue-index-and-type-mysql.sql
+++ b/jdbc-mysql/src/main/resources/migrations/2.0.1-queue-index-and-type-mysql.sql
@@ -1,0 +1,6 @@
+DROP INDEX `ix_type__offset` ON queues;
+DROP INDEX `ix_created` ON queues;
+
+CREATE INDEX ix_created__type ON queues (`created`, `type`);
+
+ALTER TABLE queues MODIFY COLUMN `type` VARCHAR(250);

--- a/jdbc-mysql/src/main/resources/migrations/V3_3__queues_v2_indices.sql
+++ b/jdbc-mysql/src/main/resources/migrations/V3_3__queues_v2_indices.sql
@@ -1,4 +1,0 @@
-DROP INDEX `ix_type__offset` ON queues;
-DROP INDEX `ix_created` ON queues;
-
-CREATE INDEX ix_created__type ON queues (`created`, `type`);

--- a/jdbc-postgres/src/main/java/io/kestra/repository/postgres/migration/V2_0QueueIndexAndType.java
+++ b/jdbc-postgres/src/main/java/io/kestra/repository/postgres/migration/V2_0QueueIndexAndType.java
@@ -1,0 +1,49 @@
+package io.kestra.repository.postgres.migration;
+
+import io.kestra.core.migration.MigrationScript;
+import io.kestra.jdbc.migration.AbstractSQLMigrationScript;
+import io.micronaut.context.annotation.Requires;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+
+import javax.sql.DataSource;
+
+/**
+ * PostgreSQL queue Flyway update migration script.
+ *
+ * <p>
+ * Update the {@code queues} by replacing two indices by a single one and switching the type column to a VARCHAR
+ */
+@Singleton
+@Requires(property = "kestra.queue.type", pattern = "postgres|memory")
+public class V2_0QueueIndexAndType extends AbstractSQLMigrationScript {
+
+    private static final String SCRIPT_ID = "2.0.1-queue-index-and-type";
+
+    private final DataSource dataSource;
+
+    @Inject
+    public V2_0QueueIndexAndType(final DataSource dataSource) {
+        this.dataSource = dataSource;
+    }
+
+    @Override
+    public String scriptId() {
+        return SCRIPT_ID;
+    }
+
+    @Override
+    public String description() {
+        return "Postgres queue upgrade: update queue indices and change type to be a string";
+    }
+
+    @Override
+    public String checksum() {
+        return MigrationScript.checksumOfResources("/migrations/2.0.1-queue-index-and-type-postgres.sql");
+    }
+
+    @Override
+    public void migrate() throws Exception {
+        executeSqlResource(dataSource, "/migrations/2.0.1-queue-index-and-type-postgres.sql");
+    }
+}

--- a/jdbc-postgres/src/main/resources/migrations/2.0.1-queue-index-and-type-postgres.sql
+++ b/jdbc-postgres/src/main/resources/migrations/2.0.1-queue-index-and-type-postgres.sql
@@ -3,3 +3,4 @@ DROP INDEX IF EXISTS queues_created;
 
 CREATE INDEX IF NOT EXISTS queues_created__type ON queues ("created", "type");
 
+ALTER TABLE queues ALTER COLUMN "type" TYPE VARCHAR(250);

--- a/jdbc/src/test/java/io/kestra/jdbc/runner/AbstractJdbcDeserializationIssuesTest.java
+++ b/jdbc/src/test/java/io/kestra/jdbc/runner/AbstractJdbcDeserializationIssuesTest.java
@@ -3,6 +3,7 @@ package io.kestra.jdbc.runner;
 import java.time.LocalDateTime;
 import java.util.*;
 
+import io.kestra.queue.QueueService;
 import org.jooq.*;
 import org.jooq.Record;
 import org.jooq.impl.DSL;
@@ -22,7 +23,6 @@ import io.kestra.core.utils.IdUtils;
 import io.kestra.jdbc.JdbcTableConfigs;
 import io.kestra.jdbc.JooqDSLContextWrapper;
 import io.kestra.jdbc.repository.AbstractJdbcRepository;
-import io.kestra.queue.jdbc.client.JdbcQueueClient;
 
 import io.micronaut.context.annotation.Replaces;
 import io.micronaut.test.annotation.MockBean;
@@ -40,6 +40,9 @@ public abstract class AbstractJdbcDeserializationIssuesTest {
 
     @Inject
     private JdbcTableConfigs jdbcTableConfigs;
+
+    @Inject
+    private QueueService queueService;
 
     @Test
     void workerTaskDeserializationIssue() throws Exception {
@@ -76,7 +79,7 @@ public abstract class AbstractJdbcDeserializationIssuesTest {
     protected Map<Field<Object>, Object> fields(DeserializationIssuesCaseTest.QueueMessage queueMessage) {
         String queueName = CaseFormat.UPPER_CAMEL.to(CaseFormat.LOWER_UNDERSCORE, queueMessage.type().getSimpleName());
         Map<Field<Object>, Object> fields = new HashMap<>();
-        fields.put(AbstractJdbcRepository.field("type"), JdbcQueueClient.queueNameToType(queueName));
+        fields.put(AbstractJdbcRepository.field("type"),queueName);
         fields.put(AbstractJdbcRepository.field("key"), queueMessage.key() != null ? queueMessage.key() : IdUtils.create());
         fields.put(AbstractJdbcRepository.field("value"), JSONB.valueOf(queueMessage.value()));
         fields.put(AbstractJdbcRepository.field("created"), LocalDateTime.now());

--- a/queue-jdbc/src/main/java/io/kestra/queue/jdbc/client/JdbcQueueCleaner.java
+++ b/queue-jdbc/src/main/java/io/kestra/queue/jdbc/client/JdbcQueueCleaner.java
@@ -52,16 +52,13 @@ public class JdbcQueueCleaner {
     public long deleteQueue() {
         LongAdder totalDeleted = new LongAdder();
         broadcastQueues.forEach(queue ->
-        {
-            Integer queueType = JdbcQueueClient.queueNameToType(queue.queueName());
             dslContextWrapper.transaction(configuration ->
             {
-                var condition = CREATED_FIELD.lessOrEqual(period(configuration, retention)).and(TYPE_FIELD.eq(queueType));
+                var condition = CREATED_FIELD.lessOrEqual(period(configuration, retention)).and(TYPE_FIELD.eq(queue.queueName()));
                 int deleted = delete(configuration, condition);
                 log.info("Cleaned {} records for the '{}' queue", deleted, queue.queueName());
                 totalDeleted.add(deleted);
-            });
-        });
+            }));
 
         return totalDeleted.longValue();
     }

--- a/queue-jdbc/src/main/java/io/kestra/queue/jdbc/client/JdbcQueueClient.java
+++ b/queue-jdbc/src/main/java/io/kestra/queue/jdbc/client/JdbcQueueClient.java
@@ -5,9 +5,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Consumer;
-import java.util.zip.CRC32;
 
 import org.apache.commons.lang3.tuple.Pair;
 import org.jooq.*;
@@ -33,13 +31,19 @@ import static io.kestra.jdbc.repository.AbstractJdbcRepository.field;
 
 @Singleton
 public class JdbcQueueClient {
-    private static final Map<String, Integer> QUEUE_NAME_CRC32 = new ConcurrentHashMap<>();
-    private static final List<Field<Object>> COLUMNS = List.of(
-        field("type"),
-        field("routing_key"),
-        field("key"),
-        field("value"),
-        field("created")
+    public static final Field<String> TYPE = field("type", String.class);
+    public static final Field<String> ROUTING_KEY = field("routing_key", String.class);
+    public static final Field<String> KEY = field("key", String.class);
+    public static final Field<JSONB> VALUE = field("value", JSONB.class);
+    public static final Field<Instant> CREATED = field("created", Instant.class);
+    public static final Field<Long> OFFSET = field("offset", Long.class);
+
+    private static final List<Field<?>> COLUMNS = List.of(
+        TYPE,
+        ROUTING_KEY,
+        KEY,
+        VALUE,
+        CREATED
     );
 
     private final AbstractJdbcRepository<JdbcQueueItem> jdbcRepository;
@@ -54,16 +58,6 @@ public class JdbcQueueClient {
         this.jdbcRepository = jdbcRepository;
         this.dslContextWrapper = dslContextWrapper;
         this.configuration = configuration;
-    }
-
-    public static Integer queueNameToType(String value) {
-        return QUEUE_NAME_CRC32.computeIfAbsent(value, s ->
-        {
-            CRC32 crc32 = new CRC32();
-            crc32.update(value.getBytes());
-
-            return (int) crc32.getValue();
-        });
     }
 
     private boolean isUnsupportedUnicode(DataException e) {
@@ -92,12 +86,12 @@ public class JdbcQueueClient {
             {
                 DSLContext context = DSL.using(configuration);
 
-                Map<Field<Object>, Object> fields = HashMap.newHashMap(5);
-                fields.put(field("type"), queueNameToType(queue));
-                fields.put(field("routing_key"), (routingKey == null || routingKey.isEmpty()) ? null : routingKey);
-                fields.put(field("key"), key);
-                fields.put(field("value"), JdbcJsonbUtils.valueOf(value));
-                fields.put(field("created"), Instant.now());
+                Map<Field<?>, Object> fields = HashMap.newHashMap(5);
+                fields.put(TYPE, queue);
+                fields.put(ROUTING_KEY, (routingKey == null || routingKey.isEmpty()) ? null : routingKey);
+                fields.put(KEY, key);
+                fields.put(VALUE, JdbcJsonbUtils.valueOf(value));
+                fields.put(CREATED, Instant.now());
 
                 var insert = context
                     .insertInto(jdbcRepository.getTable())
@@ -121,11 +115,11 @@ public class JdbcQueueClient {
         {
             DSLContext ctx = DSL.using(configuration);
 
-            var condition = field("type").eq(queueNameToType(queue));
+            var condition = TYPE.eq(queue);
             if (routingKey != null && !routingKey.isEmpty()) {
-                condition = condition.and(field("routing_key").eq(routingKey));
+                condition = condition.and(ROUTING_KEY.eq(routingKey));
             } else {
-                condition = condition.and(field("routing_key").isNull());
+                condition = condition.and(ROUTING_KEY.isNull());
             }
 
             return ctx.selectCount()
@@ -152,7 +146,7 @@ public class JdbcQueueClient {
                 Instant now = Instant.now();
                 for (PublishedMessage entry : messages) {
                     insert = insert.values(
-                        queueNameToType(entry.queue),
+                        entry.queue,
                         (entry.routingKey == null || entry.routingKey.isEmpty()) ? null : entry.routingKey,
                         entry.key,
                         JdbcJsonbUtils.valueOf(entry.value),
@@ -178,18 +172,18 @@ public class JdbcQueueClient {
         {
             DSLContext context = DSL.using(conf);
 
-            SelectConditionStep<Record2<Object, Object>> select = context.select(field("offset"), field("value"))
+            var select = context.select(OFFSET, VALUE)
                 .from(this.jdbcRepository.getTable())
-                .where(field("type").eq(queueNameToType(queue)));
+                .where(TYPE.eq(queue));
 
             if (routingKeys != null && !routingKeys.isEmpty()) {
-                select = select.and(field("routing_key").in(routingKeys));
+                select = select.and(ROUTING_KEY.in(routingKeys));
             } else {
-                select = select.and(field("routing_key").isNull());
+                select = select.and(ROUTING_KEY.isNull());
             }
 
-            Result<Record2<Object, Object>> result = select
-                .orderBy(field("offset").asc())
+            var result = select
+                .orderBy(OFFSET.asc())
                 .limit(configuration.pollSize())
                 .forUpdate()
                 .skipLocked()
@@ -200,15 +194,15 @@ public class JdbcQueueClient {
                     .stream()
                     .map(record ->
                     {
-                        consumer.accept(record.get("value").toString().getBytes());
-                        return record.get("offset", Long.class);
+                        consumer.accept(record.get(VALUE).data().getBytes());
+                        return record.get(OFFSET);
                     })
                     .filter(Objects::nonNull)
                     .toList();
 
                 if (!processedItems.isEmpty()) {
                     DeleteConditionStep<Record> delete = context.delete(this.jdbcRepository.getTable())
-                        .where(field("offset", Long.class).in(processedItems));
+                        .where(OFFSET.in(processedItems));
 
                     delete.execute();
                 }
@@ -223,33 +217,33 @@ public class JdbcQueueClient {
         {
             DSLContext context = DSL.using(conf);
 
-            SelectConditionStep<Record2<Object, Object>> select = context.select(field("offset"), field("value"))
+            var select = context.select(OFFSET, VALUE)
                 .from(this.jdbcRepository.getTable())
-                .where(field("type").eq(queueNameToType(queue)));
+                .where(TYPE.eq(queue));
 
             if (routingKeys != null && !routingKeys.isEmpty()) {
-                select = select.and(field("routing_key").in(routingKeys));
+                select = select.and(ROUTING_KEY.in(routingKeys));
             } else {
-                select = select.and(field("routing_key").isNull());
+                select = select.and(ROUTING_KEY.isNull());
             }
 
-            Result<Record2<Object, Object>> result = select
-                .orderBy(field("offset").asc())
+            var result = select
+                .orderBy(OFFSET.asc())
                 .limit(configuration.pollSize())
                 .forUpdate()
                 .skipLocked()
                 .fetch();
 
             if (!result.isEmpty()) {
-                consumer.accept(result.stream().map(record -> record.get("value").toString().getBytes()).toList());
+                consumer.accept(result.stream().map(record -> record.get(VALUE).data().getBytes()).toList());
 
                 List<Long> processedItems = result
                     .stream()
-                    .map(record -> record.get("offset", Long.class))
+                    .map(record -> record.get(OFFSET))
                     .toList();
 
                 DeleteConditionStep<Record> delete = context.delete(this.jdbcRepository.getTable())
-                    .where(field("offset", Long.class).in(processedItems));
+                    .where(OFFSET.in(processedItems));
                 delete.execute();
             }
 
@@ -262,9 +256,9 @@ public class JdbcQueueClient {
         {
             DSLContext context = DSL.using(conf);
 
-            return context.select(DSL.max(field("offset")))
+            return context.select(DSL.max(OFFSET))
                 .from(this.jdbcRepository.getTable())
-                .where(field("type").eq(queueNameToType(queue)))
+                .where(TYPE.eq(queue))
                 .fetchAny("max", Long.class);
         });
 
@@ -277,25 +271,25 @@ public class JdbcQueueClient {
             DSLContext context = DSL.using(conf);
             Long maxOffsetResult = null;
 
-            SelectConditionStep<Record2<Object, Object>> select = context.select(field("offset"), field("value"))
+            var select = context.select(OFFSET, VALUE)
                 .from(this.jdbcRepository.getTable())
-                .where(field("type").eq(queueNameToType(queue)));
+                .where(TYPE.eq(queue));
 
             if (maxOffset != null) {
-                select = select.and(field("offset").gt(maxOffset));
+                select = select.and(OFFSET.gt(maxOffset));
             }
 
-            Result<Record2<Object, Object>> result = select
-                .orderBy(field("offset").asc())
+            var result = select
+                .orderBy(OFFSET.asc())
                 .limit(configuration.pollSize())
                 .fetch();
 
             if (!result.isEmpty()) {
-                result.forEach(record -> consumer.accept(record.get("value").toString().getBytes()));
+                result.forEach(record -> consumer.accept(record.get(VALUE).data().getBytes()));
 
                 maxOffsetResult = result
                     .stream()
-                    .map(record -> record.get("offset", Long.class))
+                    .map(record -> record.get(OFFSET))
                     .max(Long::compareTo)
                     .orElse(null);
             }
@@ -310,25 +304,25 @@ public class JdbcQueueClient {
             DSLContext context = DSL.using(conf);
             Long maxOffsetResult = null;
 
-            SelectConditionStep<Record2<Object, Object>> select = context.select(field("offset"), field("value"))
+            var select = context.select(OFFSET, VALUE)
                 .from(this.jdbcRepository.getTable())
-                .where(field("type").eq(queueNameToType(queue)));
+                .where(TYPE.eq(queue));
 
             if (maxOffset != null) {
-                select = select.and(field("offset").gt(maxOffset));
+                select = select.and(OFFSET.gt(maxOffset));
             }
 
-            Result<Record2<Object, Object>> result = select
-                .orderBy(field("offset").asc())
+            var result = select
+                .orderBy(OFFSET.asc())
                 .limit(configuration.pollSize())
                 .fetch();
 
             if (!result.isEmpty()) {
-                consumer.accept(result.stream().map(record -> record.get("value").toString().getBytes()).toList());
+                consumer.accept(result.stream().map(record -> record.get(VALUE).data().getBytes()).toList());
 
                 maxOffsetResult = result
                     .stream()
-                    .map(record -> record.get("offset", Long.class))
+                    .map(record -> record.get(OFFSET))
                     .max(Long::compareTo)
                     .orElse(null);
             }


### PR DESCRIPTION
- Combine two indices in one, this was done before but forgotten in the new migration mechanism
- Use queuename instead of a CRC32, as all other queues use that to create topics/queue/channels
