### PR TITLE
chore(execution): remove outputs from SubflowExecutionEnd

### DIFF
--- a/core/src/main/java/io/kestra/core/runners/ExecutableUtils.java
+++ b/core/src/main/java/io/kestra/core/runners/ExecutableUtils.java
@@ -72,8 +72,7 @@ public final class ExecutableUtils {
         Map<String, Object> inputs,
         List<Label> labels,
         boolean inheritLabels,
-        Property<ZonedDateTime> scheduleDate,
-        Map<String, Object> outputMap) throws InternalException {
+        Property<ZonedDateTime> scheduleDate) throws InternalException {
 
         // extract a trace context for propagation
         final Optional<TextMapPropagator> propagator = ((DefaultRunContext) runContext).services().tracerFactory()
@@ -217,9 +216,6 @@ public final class ExecutableUtils {
                         "taskId", currentTaskRun.getTaskId()
                     )
                 );
-                if (outputMap != null) {
-                    variables.put("taskRunOutputs", outputMap);
-                }
                 if (currentTaskRun.getValue() != null) {
                     variables.put("taskRunValue", currentTaskRun.getValue());
                 }
@@ -275,7 +271,6 @@ public final class ExecutableUtils {
                         .parentTask(currentTask)
                         .parentTaskRun(currentTaskRun.withState(State.Type.RUNNING))
                         .execution(execution)
-                        .outputs(outputMap)
                         .build()
                 );
             })
@@ -299,10 +294,10 @@ public final class ExecutableUtils {
     }
 
     public static SubflowExecutionResult subflowExecutionResultFromChildExecution(RunContext runContext, FlowInterface flow, Execution execution, ExecutableTask<?> executableTask,
-        TaskRun taskRun, Map<String, Object> outputs) {
+        TaskRun taskRun) {
         try {
             return executableTask
-                .createSubflowExecutionResult(runContext, taskRun, flow, execution, outputs)
+                .createSubflowExecutionResult(runContext, taskRun, flow, execution, null)
                 .orElse(null);
         } catch (Exception e) {
             log.error("Unable to create the Subflow Execution Result", e);
@@ -311,7 +306,6 @@ public final class ExecutableUtils {
                 .executionId(execution.getId())
                 .state(State.Type.FAILED)
                 .parentTaskRun(taskRun.withState(State.Type.FAILED).withAttempts(List.of(TaskRunAttempt.builder().state(new State().withState(State.Type.FAILED)).build())))
-                .outputs(outputs)
                 .build();
         }
     }

--- a/core/src/main/java/io/kestra/core/runners/SubflowExecutionEnd.java
+++ b/core/src/main/java/io/kestra/core/runners/SubflowExecutionEnd.java
@@ -1,9 +1,5 @@
 package io.kestra.core.runners;
 
-import java.util.Map;
-
-import com.fasterxml.jackson.annotation.JsonInclude;
-
 import io.kestra.core.models.HasUID;
 import io.kestra.core.models.executions.Execution;
 import io.kestra.core.models.flows.State;
@@ -14,8 +10,7 @@ public record SubflowExecutionEnd(
     String parentExecutionId,
     String taskRunId,
     String taskId,
-    State.Type state,
-    @JsonInclude(JsonInclude.Include.ALWAYS) Map<String, Object> outputs) implements HasUID, DispatchEvent {
+    State.Type state) implements HasUID, DispatchEvent {
 
     public String toStringState() {
         return "SubflowExecutionEnd(" +

--- a/core/src/main/java/io/kestra/plugin/core/flow/Subflow.java
+++ b/core/src/main/java/io/kestra/plugin/core/flow/Subflow.java
@@ -179,8 +179,7 @@ public class Subflow extends Task implements ExecutableTask<Subflow.Output>, Chi
             inputs,
             labels,
             runContext.render(inheritLabels).as(Boolean.class).orElseThrow(),
-            scheduleDate,
-            null
+            scheduleDate
         )
             .<List<SubflowExecution<?>>> map(subflowExecution -> List.of(subflowExecution))
             .orElse(Collections.emptyList());

--- a/executor/src/main/java/io/kestra/executor/DefaultExecutor.java
+++ b/executor/src/main/java/io/kestra/executor/DefaultExecutor.java
@@ -778,11 +778,7 @@ public class DefaultExecutor extends AbstractService implements Executor {
                     String parentExecutionId = (String) execution.getTrigger().getVariables().get("executionId");
                     String taskRunId = (String) execution.getTrigger().getVariables().get("taskRunId");
                     String taskId = (String) execution.getTrigger().getVariables().get("taskId");
-                    @SuppressWarnings("unchecked")
-                    Map<String, Object> outputs = (Map<String, Object>) execution.getTrigger().getVariables().get("taskRunOutputs");
-                    SubflowExecutionEnd subflowExecutionEnd = new SubflowExecutionEnd(
-                        executor.getExecution(), parentExecutionId, taskRunId, taskId, execution.getState().getCurrent(), outputs
-                    );
+                    SubflowExecutionEnd subflowExecutionEnd = new SubflowExecutionEnd(executor.getExecution(), parentExecutionId, taskRunId, taskId, execution.getState().getCurrent());
                     this.subflowExecutionEndQueue.emit(subflowExecutionEnd);
                 }
 

--- a/executor/src/main/java/io/kestra/executor/ExecutorService.java
+++ b/executor/src/main/java/io/kestra/executor/ExecutorService.java
@@ -40,7 +40,6 @@ import io.kestra.core.services.*;
 import io.kestra.core.test.flow.TaskFixture;
 import io.kestra.core.trace.propagation.RunContextTextMapSetter;
 
-import io.micronaut.context.ApplicationContext;
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.context.propagation.ContextPropagators;

--- a/executor/src/main/java/io/kestra/executor/handler/SubflowExecutionEndMessageHandler.java
+++ b/executor/src/main/java/io/kestra/executor/handler/SubflowExecutionEndMessageHandler.java
@@ -60,7 +60,7 @@ public class SubflowExecutionEndMessageHandler implements MessageHandler<Subflow
                 );
 
                 SubflowExecutionResult subflowExecutionResult = ExecutableUtils
-                    .subflowExecutionResultFromChildExecution(runContext, childFlow, message.childExecution(), executableTask, taskRun, message.outputs());
+                    .subflowExecutionResultFromChildExecution(runContext, childFlow, message.childExecution(), executableTask, taskRun);
                 if (subflowExecutionResult != null) {
                     try {
                         this.subflowExecutionResultQueue.emit(subflowExecutionResult);

--- a/executor/src/test/java/io/kestra/executor/handler/SubflowExecutionEndMessageHandlerTest.java
+++ b/executor/src/test/java/io/kestra/executor/handler/SubflowExecutionEndMessageHandlerTest.java
@@ -38,8 +38,7 @@ class SubflowExecutionEndMessageHandlerTest {
             parentExecution.getId(),
             "task",
             "taskRun",
-            State.Type.SUCCESS,
-            Collections.emptyMap()
+            State.Type.SUCCESS
         );
 
         subflowExecutionEndMessageHandler.handle(subflowExecutionEnd);


### PR DESCRIPTION
They was only used by the ForEachItem, Subflow always returns null
