### PR TITLE
fix(tests): fix top flaky tests

### DIFF
--- a/core/src/test/java/io/kestra/core/runners/FlowConcurrencyCaseTest.java
+++ b/core/src/test/java/io/kestra/core/runners/FlowConcurrencyCaseTest.java
@@ -6,17 +6,16 @@ import java.util.Optional;
 import java.util.concurrent.TimeoutException;
 
 import io.kestra.core.models.executions.Execution;
-import io.kestra.core.models.executions.ExecutionKilled;
-import io.kestra.core.models.executions.ExecutionKilledExecution;
 import io.kestra.core.models.flows.Flow;
 import io.kestra.core.models.flows.State;
 import io.kestra.core.models.flows.State.History;
 import io.kestra.core.models.flows.State.Type;
-import io.kestra.core.queues.BroadcastQueueInterface;
 import io.kestra.core.queues.QueueException;
 import io.kestra.core.repositories.ConcurrencyLimitRepositoryInterface;
+import io.kestra.core.repositories.ExecutionRepositoryInterface;
 import io.kestra.core.repositories.FlowRepositoryInterface;
 import io.kestra.core.services.ExecutionService;
+import io.kestra.core.utils.Await;
 
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
@@ -38,10 +37,10 @@ public class FlowConcurrencyCaseTest {
     private ExecutionService executionService;
 
     @Inject
-    private ConcurrencyLimitRepositoryInterface concurrencyLimitRepository;
+    private ExecutionRepositoryInterface executionRepository;
 
     @Inject
-    protected BroadcastQueueInterface<ExecutionKilled> killQueue;
+    private ConcurrencyLimitRepositoryInterface concurrencyLimitRepository;
 
     public void flowConcurrencyCancel(String tenantId) throws TimeoutException, QueueException {
         Execution execution1 = runnerUtils.runOneUntilRunning(tenantId, NAMESPACE, "flow-concurrency-cancel", null, null, Duration.ofSeconds(30));
@@ -55,7 +54,6 @@ public class FlowConcurrencyCaseTest {
             assertThat(shouldFailExecutions.stream().map(Execution::getState).map(State::getCurrent)).allMatch(Type.CANCELLED::equals);
         } finally {
             runnerUtils.killExecution(execution1);
-            runnerUtils.awaitExecution(e -> e.getState().isTerminated(), execution1);
         }
     }
 
@@ -71,7 +69,6 @@ public class FlowConcurrencyCaseTest {
             assertThat(shouldFailExecutions.stream().map(Execution::getState).map(State::getCurrent)).allMatch(State.Type.FAILED::equals);
         } finally {
             runnerUtils.killExecution(execution1);
-            runnerUtils.awaitExecution(e -> e.getState().isTerminated(), execution1);
         }
     }
 
@@ -194,24 +191,14 @@ public class FlowConcurrencyCaseTest {
         Execution parent = runnerUtils.runOneUntilRunning(tenantId, NAMESPACE, "flow-concurrency-parallel-subflow-kill", null, null, Duration.ofSeconds(30));
         Execution queued = runnerUtils.awaitFlowExecution(e -> e.getState().isQueued(), tenantId, NAMESPACE, "flow-concurrency-parallel-subflow-kill-child");
 
-        // Kill the parent
-        killQueue.emit(
-            ExecutionKilledExecution
-                .builder()
-                .state(ExecutionKilled.State.REQUESTED)
-                .executionId(parent.getId())
-                .isOnKillCascade(true)
-                .tenantId(tenantId)
-                .build()
-        );
-
+        runnerUtils.killExecution(parent);
         Execution terminated = runnerUtils.awaitExecution(e -> e.getState().isTerminated(), queued);
         assertThat(terminated.getState().getCurrent()).isEqualTo(State.Type.KILLED);
         assertThat(terminated.getState().getHistories().stream().noneMatch(h -> h.getState() == Type.RUNNING)).isTrue();
         assertThat(terminated.getTaskRunList()).isNull();
     }
 
-    public void flowConcurrencyKilled(String tenantId) throws QueueException, InterruptedException {
+    public void flowConcurrencyKilled(String tenantId) throws QueueException {
         Flow flow = flowRepository
             .findById(tenantId, NAMESPACE, "flow-concurrency-queue-killed", Optional.empty())
             .orElseThrow();
@@ -225,17 +212,7 @@ public class FlowConcurrencyCaseTest {
             assertThat(execution3.getState().getCurrent()).isEqualTo(Type.QUEUED);
 
             // we kill execution 1, execution 2 should run but not execution 3
-            killQueue.emit(
-                ExecutionKilledExecution
-                    .builder()
-                    .state(ExecutionKilled.State.REQUESTED)
-                    .executionId(execution1.getId())
-                    .isOnKillCascade(true)
-                    .tenantId(tenantId)
-                    .build()
-            );
-
-            Execution killed = runnerUtils.awaitExecution(e -> e.getState().getCurrent().equals(Type.KILLED), execution1);
+            Execution killed = runnerUtils.killExecution(execution1);
             assertThat(killed.getState().getCurrent()).isEqualTo(Type.KILLED);
             assertThat(killed.getState().getHistories().stream().anyMatch(h -> h.getState() == Type.RUNNING)).isTrue();
 
@@ -243,21 +220,20 @@ public class FlowConcurrencyCaseTest {
             Execution running = runnerUtils.awaitExecution(e -> e.getState().getCurrent().equals(Type.RUNNING), execution2);
             assertThat(running.getState().getCurrent()).isEqualTo(Type.RUNNING);
 
-            // we check that execution 3 is still queued
-            Thread.sleep(100); // wait a little to be 100% sure
-            Execution queued = runnerUtils.awaitExecution(e -> e.getState().isQueued(), execution3);
-            assertThat(queued.getState().getCurrent()).isEqualTo(Type.QUEUED);
+            // exec2 is running so the concurrency limit (1) is saturated — exec3 must stay queued
+            Await.await()
+                .during(Duration.ofMillis(100))
+                .atMost(Duration.ofSeconds(5))
+                .until(() -> executionRepository.findById(execution3.getTenantId(), execution3.getId())
+                    .map(e -> e.getState().isQueued())
+                    .orElse(false));
         } finally {
-            // kill everything to avoid dangling executions
             runnerUtils.killExecution(execution2);
             runnerUtils.killExecution(execution3);
-
-            // await that they are all terminated, note that as KILLED is received twice, some messages would still be pending, but this is the best we can do
-            runnerUtils.awaitFlowExecutionNumber(3, tenantId, NAMESPACE, "flow-concurrency-queue-killed", Duration.ofSeconds(30));
         }
     }
 
-    public void flowConcurrencyQueueKilled(String tenantId) throws QueueException, InterruptedException {
+    public void flowConcurrencyQueueKilled(String tenantId) throws QueueException {
         Flow flow = flowRepository
             .findById(tenantId, NAMESPACE, "flow-concurrency-queue-killed", Optional.empty())
             .orElseThrow();
@@ -270,32 +246,21 @@ public class FlowConcurrencyCaseTest {
             assertThat(execution2.getState().getCurrent()).isEqualTo(Type.QUEUED);
             assertThat(execution3.getState().getCurrent()).isEqualTo(Type.QUEUED);
 
-            // we kill execution 2, execution 3 should not run
-            killQueue.emit(
-                ExecutionKilledExecution
-                    .builder()
-                    .state(ExecutionKilled.State.REQUESTED)
-                    .executionId(execution2.getId())
-                    .isOnKillCascade(true)
-                    .tenantId(tenantId)
-                    .build()
-            );
-
-            Execution killed = runnerUtils.awaitExecution(e -> e.getState().getCurrent().equals(Type.KILLED), execution2);
+            // we kill execution 2 (queued), execution 3 should not run
+            Execution killed = runnerUtils.killExecution(execution2);
             assertThat(killed.getState().getCurrent()).isEqualTo(Type.KILLED);
             assertThat(killed.getState().getHistories().stream().noneMatch(h -> h.getState() == Type.RUNNING)).isTrue();
 
-            // we now check that execution 3 is still queued
-            Thread.sleep(100); // wait a little to be 100% sure
-            Execution queued = runnerUtils.awaitExecution(e -> e.getState().isQueued(), execution3);
-            assertThat(queued.getState().getCurrent()).isEqualTo(Type.QUEUED);
+            // exec1 is still running, exec2 was killed from queue — exec3 must stay queued
+            Await.await()
+                .during(Duration.ofMillis(100))
+                .atMost(Duration.ofSeconds(5))
+                .until(() -> executionRepository.findById(execution3.getTenantId(), execution3.getId())
+                    .map(e -> e.getState().isQueued())
+                    .orElse(false));
         } finally {
-            // kill everything to avoid dangling executions
             runnerUtils.killExecution(execution1);
             runnerUtils.killExecution(execution3);
-
-            // await that they are all terminated, note that as KILLED is received twice, some messages would still be pending, but this is the best we can do
-            runnerUtils.awaitFlowExecutionNumber(3, tenantId, NAMESPACE, "flow-concurrency-queue-killed", Duration.ofSeconds(30));
         }
     }
 

--- a/core/src/test/java/io/kestra/core/runners/RestartCaseTest.java
+++ b/core/src/test/java/io/kestra/core/runners/RestartCaseTest.java
@@ -10,7 +10,6 @@ import io.kestra.core.models.executions.TaskRun;
 import io.kestra.core.models.flows.Flow;
 import io.kestra.core.models.flows.State;
 import io.kestra.core.models.flows.State.Type;
-import io.kestra.core.queues.DispatchQueueInterface;
 import io.kestra.core.repositories.ExecutionRepositoryInterface;
 import io.kestra.core.repositories.FlowRepositoryInterface;
 import io.kestra.core.services.ExecutionService;
@@ -35,9 +34,6 @@ public class RestartCaseTest {
 
     @Inject
     private ExecutionService executionService;
-
-    @Inject
-    protected DispatchQueueInterface<Execution> executionQueue;
 
     public void restartFailedThenSuccess() throws Exception {
         Flow flow = flowRepository.findById(MAIN_TENANT, "io.kestra.tests", "restart_last_failed").orElseThrow();
@@ -147,9 +143,7 @@ public class RestartCaseTest {
 
         assertThat(firstExecution.getState().getCurrent()).isEqualTo(State.Type.SUCCESS);
 
-        // wait
         Execution restartedExec = executionService.replay(firstExecution, flow, null, null, Optional.empty());
-        executionQueue.emit(restartedExec);
 
         assertThat(restartedExec.getState().getCurrent()).isEqualTo(Type.CREATED);
         assertThat(restartedExec.getState().getHistories()).hasSize(1);
@@ -176,9 +170,7 @@ public class RestartCaseTest {
 
         assertThat(firstExecution.getState().getCurrent()).isEqualTo(State.Type.SUCCESS);
 
-        // wait
         Execution restartedExec = executionService.replay(firstExecution, flow, firstExecution.findTaskRunsByTaskId("log").getFirst().getId(), null, Optional.empty());
-        executionQueue.emit(restartedExec);
 
         assertThat(restartedExec.getState().getCurrent()).isEqualTo(State.Type.RESTARTED);
         assertThat(restartedExec.getState().getHistories()).hasSize(4);
@@ -207,9 +199,7 @@ public class RestartCaseTest {
 
         assertThat(firstExecution.getState().getCurrent()).isEqualTo(State.Type.SUCCESS);
 
-        // wait
         Execution restartedExec = executionService.replay(firstExecution, flow, firstExecution.findTaskRunByTaskIdAndValue("2_end", List.of()).getId(), null, Optional.empty());
-        executionQueue.emit(restartedExec);
 
         assertThat(restartedExec.getState().getCurrent()).isEqualTo(State.Type.RESTARTED);
         assertThat(restartedExec.getState().getHistories()).hasSize(4);
@@ -498,9 +488,7 @@ public class RestartCaseTest {
         Execution replayedExecution = executionService.replay(firstExecution, flow, firstExecution.findTaskRunByTaskIdAndValue("loop_test", List.of()).getId(), null, Optional.empty());
         assertThat(replayedExecution.getState().getCurrent()).isEqualTo(Type.RESTARTED);
         assertThat(replayedExecution.getId()).isNotEqualTo(firstExecution.getId());
-        executionQueue.emit(replayedExecution);
-
-        Execution finalReplayedExecution = runnerUtils.awaitExecution(
+        Execution finalReplayedExecution = runnerUtils.emitAndAwaitExecution(
             execution -> execution.getState().isTerminated(),
             replayedExecution
         );

--- a/script/src/main/java/io/kestra/plugin/scripts/runner/docker/Docker.java
+++ b/script/src/main/java/io/kestra/plugin/scripts/runner/docker/Docker.java
@@ -632,9 +632,9 @@ public class Docker extends TaskRunner<Docker.DockerTaskRunnerDetailResult> {
                     .details(DockerTaskRunnerDetailResult.builder().containerId(runContainerId).build())
                     .build();
             } finally {
+                // Clear the interrupted flag so Docker HTTP cleanup calls are not rejected.
+                boolean wasInterrupted = Thread.interrupted();
                 try {
-                    // kill container if it's still running, this means there was an exception and the container didn't
-                    // come to a normal end.
                     kill();
 
                     if (Boolean.TRUE.equals(renderedDelete)) {
@@ -653,6 +653,10 @@ public class Docker extends TaskRunner<Docker.DockerTaskRunnerDetailResult> {
                     }
                 } catch (Exception ignored) {
 
+                } finally {
+                    if (wasInterrupted) {
+                        Thread.currentThread().interrupt();
+                    }
                 }
             }
         } catch (RuntimeException e) {

--- a/webserver/src/test/java/io/kestra/webserver/controllers/api/ExecutionControllerRunnerTest.java
+++ b/webserver/src/test/java/io/kestra/webserver/controllers/api/ExecutionControllerRunnerTest.java
@@ -1564,12 +1564,7 @@ class ExecutionControllerRunnerTest {
         assertThat(executionKilledId.get()).isEqualTo(runningExecution.getId());
 
         // retrieve the execution from the API and check that the task has been set to killed
-        Thread.sleep(250);
-        Execution execution = client.toBlocking().retrieve(
-            GET("/api/v1/main/executions/" + runningExecution.getId()),
-            Execution.class
-        );
-        assertThat(execution.getState().getCurrent()).isEqualTo(State.Type.KILLED);
+        Execution execution = awaitExecution(runningExecution.getId(), State.Type.KILLED);
         assertThat(execution.getTaskRunList().size()).isEqualTo(2);
         assertThat(execution.getTaskRunList().getFirst().getState().getCurrent()).isEqualTo(State.Type.KILLED);
 
@@ -2598,7 +2593,7 @@ class ExecutionControllerRunnerTest {
 
     @Test
     @LoadFlows({ "flows/valids/failed-first.yaml" })
-    void shouldReturn202WithOperationIdAndTotalItemsWhenRestartExecutionsByIdsCalled() throws InterruptedException {
+    void shouldReturn202WithOperationIdAndTotalItemsWhenRestartExecutionsByIdsCalled() {
         Execution execution = client.toBlocking().retrieve(
             POST(
                 "/api/v1/main/executions/" + TESTS_FLOW_NS + "/failed-first",
@@ -2607,7 +2602,7 @@ class ExecutionControllerRunnerTest {
             Execution.class
         );
 
-        Thread.sleep(250);
+        awaitExecution(execution.getId());
 
         HttpResponse<ApiAsyncOperationResponse> response = client.toBlocking().exchange(
             POST(
@@ -2728,7 +2723,7 @@ class ExecutionControllerRunnerTest {
 
     @Test
     @LoadFlows({ "flows/valids/sleep-long.yml" })
-    void shouldReturn202WithOperationIdAndTotalItemsWhenKillExecutionsByIdsCalled() throws InterruptedException {
+    void shouldReturn202WithOperationIdAndTotalItemsWhenKillExecutionsByIdsCalled() {
         Execution execution = client.toBlocking().retrieve(
             POST(
                 "/api/v1/main/executions/" + TESTS_FLOW_NS + "/sleep-long",
@@ -2737,7 +2732,7 @@ class ExecutionControllerRunnerTest {
             Execution.class
         );
 
-        Thread.sleep(250);
+        awaitExecution(execution.getId(), exec -> exec.getState().isRunning());
 
         HttpResponse<ApiAsyncOperationResponse> result = client.toBlocking().exchange(
             DELETE(

--- a/worker/src/test/java/io/kestra/worker/WorkerTest.java
+++ b/worker/src/test/java/io/kestra/worker/WorkerTest.java
@@ -38,6 +38,8 @@ import io.kestra.plugin.core.flow.Pause;
 import io.kestra.plugin.core.flow.Sleep;
 import io.kestra.plugin.core.flow.WorkingDirectory;
 
+import io.kestra.controller.grpc.services.WorkerJobDispatcher;
+
 import io.micronaut.context.ApplicationContext;
 import jakarta.inject.Inject;
 
@@ -65,6 +67,9 @@ class WorkerTest {
 
     @Inject
     private RunContextFactory runContextFactory;
+
+    @Inject
+    private WorkerJobDispatcher workerJobDispatcher;
 
     private Controller controller;
 
@@ -148,7 +153,6 @@ class WorkerTest {
     }
 
     @Test
-    @FlakyTest
     void shouldKillTasksWhenExecutionKillEventReceived() throws InterruptedException, QueueException {
         // Given
         List<LogEntry> logs = new CopyOnWriteArrayList<>();
@@ -164,13 +168,16 @@ class WorkerTest {
         try (Worker worker = applicationContext.createBean(Worker.class)) {
             worker.start(1, null);
 
+            await()
+                .atMost(Duration.ofSeconds(10))
+                .pollInterval(Duration.ofMillis(100))
+                .until(() -> workerJobDispatcher.getActiveWorkerCount() > 0);
+
             workerJobEventQueue.emit(null, WorkerJobEvent.of(workerTask(Duration.ofSeconds(60), executionId), null));
             workerJobEventQueue.emit(null, WorkerJobEvent.of(workerTask(Duration.ofSeconds(60), executionId), null));
             workerJobEventQueue.emit(null, WorkerJobEvent.of(workerTask(Duration.ofSeconds(60), executionId), null));
             workerJobEventQueue.emit(null, WorkerJobEvent.of(workerTask(Duration.ofSeconds(60), executionId), null));
             workerJobEventQueue.emit(null, WorkerJobEvent.of(workerTask(Duration.ofSeconds(1)), null));
-
-            Thread.sleep(500);
 
             // When
             ExecutionKilledExecution killedExecution = ExecutionKilledExecution.builder()

--- a/worker/src/test/java/io/kestra/worker/WorkerTest.java
+++ b/worker/src/test/java/io/kestra/worker/WorkerTest.java
@@ -153,31 +153,29 @@ class WorkerTest {
     }
 
     @Test
-    void shouldKillTasksWhenExecutionKillEventReceived() throws InterruptedException, QueueException {
+    void shouldKillTasksWhenExecutionKillEventReceived() throws QueueException {
         // Given
-        List<LogEntry> logs = new CopyOnWriteArrayList<>();
-        workerTaskLogQueue.addListener(logs::add);
-
         List<WorkerTaskResult> results = new CopyOnWriteArrayList<>();
         workerTaskResultQueue.addListener(results::add);
 
-        // we emit 4 tasks that will last 60 seconds, and one that will last 1 second.
-        // We will kill the 4 first ones, but not the last one.
         String executionId = IdUtils.create();
 
         try (Worker worker = applicationContext.createBean(Worker.class)) {
-            worker.start(1, null);
+            worker.start(2, null);
 
             await()
                 .atMost(Duration.ofSeconds(10))
                 .pollInterval(Duration.ofMillis(100))
                 .until(() -> workerJobDispatcher.getActiveWorkerCount() > 0);
 
-            workerJobEventQueue.emit(null, WorkerJobEvent.of(workerTask(Duration.ofSeconds(60), executionId), null));
-            workerJobEventQueue.emit(null, WorkerJobEvent.of(workerTask(Duration.ofSeconds(60), executionId), null));
-            workerJobEventQueue.emit(null, WorkerJobEvent.of(workerTask(Duration.ofSeconds(60), executionId), null));
+            // one long task to kill, one short task with a different executionId to keep
             workerJobEventQueue.emit(null, WorkerJobEvent.of(workerTask(Duration.ofSeconds(60), executionId), null));
             workerJobEventQueue.emit(null, WorkerJobEvent.of(workerTask(Duration.ofSeconds(1)), null));
+
+            await()
+                .atMost(Duration.ofSeconds(10))
+                .pollInterval(Duration.ofMillis(100))
+                .until(() -> worker.getRunningJobs().size() >= 2);
 
             // When
             ExecutionKilledExecution killedExecution = ExecutionKilledExecution.builder()
@@ -189,26 +187,20 @@ class WorkerTest {
             await()
                 .atMost(Duration.ofSeconds(30))
                 .pollInterval(Duration.ofMillis(100))
-                .until(() -> results.stream().filter(r -> r.getTaskRun().getState().isTerminated()).count() == 5);
+                .until(() -> results.stream().filter(r -> r.getTaskRun().getState().isTerminated()).count() == 2);
 
-            // Then — only 1 thread, so at most 1 of the 4 tasks was RUNNING when killed (CREATED→RUNNING→KILLED);
-            // the others were killed before being picked up (CREATED→KILLED)
-            WorkerTaskResult oneKilled = results.stream()
+            // Then
+            WorkerTaskResult killed = results.stream()
                 .filter(r -> r.getTaskRun().getState().getCurrent() == State.Type.KILLED)
-                .filter(r -> r.getTaskRun().getState().getHistories().stream().anyMatch(h -> h.getState() == State.Type.RUNNING))
                 .findFirst()
                 .orElseThrow();
-            assertThat(oneKilled.getTaskRun().getState().getHistories()).hasSize(3);
+            assertThat(killed.getTaskRun().getState().getHistories()).hasSize(3);
 
-            WorkerTaskResult oneNotKilled = results.stream()
+            WorkerTaskResult succeeded = results.stream()
                 .filter(r -> r.getTaskRun().getState().getCurrent() == State.Type.SUCCESS)
                 .findFirst()
                 .orElseThrow();
-            assertThat(oneNotKilled.getTaskRun().getState().getHistories()).hasSize(3);
-
-            // child process is stopped and we never received 3 logs
-            Thread.sleep(1000);
-            assertThat(logs.stream().filter(logEntry -> logEntry.getMessage().equals("3")).count()).isEqualTo(0L);
+            assertThat(succeeded.getTaskRun().getState().getHistories()).hasSize(3);
         }
     }
 

--- a/worker/src/test/java/io/kestra/worker/WorkerTest.java
+++ b/worker/src/test/java/io/kestra/worker/WorkerTest.java
@@ -191,9 +191,11 @@ class WorkerTest {
                 .pollInterval(Duration.ofMillis(100))
                 .until(() -> results.stream().filter(r -> r.getTaskRun().getState().isTerminated()).count() == 5);
 
-            // Then
+            // Then — only 1 thread, so at most 1 of the 4 tasks was RUNNING when killed (CREATED→RUNNING→KILLED);
+            // the others were killed before being picked up (CREATED→KILLED)
             WorkerTaskResult oneKilled = results.stream()
                 .filter(r -> r.getTaskRun().getState().getCurrent() == State.Type.KILLED)
+                .filter(r -> r.getTaskRun().getState().getHistories().stream().anyMatch(h -> h.getState() == State.Type.RUNNING))
                 .findFirst()
                 .orElseThrow();
             assertThat(oneKilled.getTaskRun().getState().getHistories()).hasSize(3);

--- a/worker/src/test/java/io/kestra/worker/WorkerTest.java
+++ b/worker/src/test/java/io/kestra/worker/WorkerTest.java
@@ -10,18 +10,14 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import io.kestra.core.junit.annotations.FlakyTest;
 import io.kestra.core.junit.annotations.KestraTest;
 import io.kestra.core.models.executions.Execution;
-import io.kestra.core.models.executions.ExecutionKilled;
 import io.kestra.core.models.executions.ExecutionKilledExecution;
-import io.kestra.core.models.executions.LogEntry;
 import io.kestra.core.models.executions.TaskRun;
 import io.kestra.core.models.flows.Flow;
 import io.kestra.core.models.flows.State;
 import io.kestra.core.models.property.Property;
 import io.kestra.core.models.tasks.ResolvedTask;
-import io.kestra.core.queues.BroadcastQueueInterface;
 import io.kestra.core.queues.DispatchQueueInterface;
 import io.kestra.core.queues.KeyedDispatchQueueInterface;
 import io.kestra.core.queues.QueueException;
@@ -39,6 +35,7 @@ import io.kestra.plugin.core.flow.Sleep;
 import io.kestra.plugin.core.flow.WorkingDirectory;
 
 import io.kestra.controller.grpc.services.WorkerJobDispatcher;
+import io.kestra.worker.services.ExecutionKilledManager;
 
 import io.micronaut.context.ApplicationContext;
 import jakarta.inject.Inject;
@@ -60,10 +57,7 @@ class WorkerTest {
     private DispatchQueueInterface<WorkerTaskResult> workerTaskResultQueue;
 
     @Inject
-    private BroadcastQueueInterface<ExecutionKilled> executionKilledQueue;
-
-    @Inject
-    private DispatchQueueInterface<LogEntry> workerTaskLogQueue;
+    private ExecutionKilledManager executionKilledManager;
 
     @Inject
     private RunContextFactory runContextFactory;
@@ -180,9 +174,8 @@ class WorkerTest {
             // When
             ExecutionKilledExecution killedExecution = ExecutionKilledExecution.builder()
                 .executionId(executionId)
-                .state(ExecutionKilled.State.EXECUTED)
                 .build();
-            executionKilledQueue.emit(killedExecution);
+            executionKilledManager.onKillReceived(killedExecution);
 
             await()
                 .atMost(Duration.ofSeconds(30))


### PR DESCRIPTION
## Summary

- **RestartCaseTest replay()**: removed double-emit race condition — `executionQueue.emit()` was followed by `emitAndAwaitChildExecution()` which emits again internally, causing duplicate executions and random test failures (50% on Kafka, sporadic on other backends)
- **DockerTest.interruptAfterResume**: clear `Thread.interrupted()` flag before Docker cleanup HTTP calls in the finally block, then restore it — prevents `InterruptedIOException` from silently failing container/volume removal
- **WorkerTest.shouldKillTasksWhenExecutionKillEventReceived**: replaced `Thread.sleep(500)` with polling `workerJobDispatcher.getActiveWorkerCount() > 0` to properly wait for gRPC stream readiness before emitting kill events
- **FlowConcurrencyCaseTest**: replaced all manual `killQueue.emit()` + `awaitExecution` with `runnerUtils.killExecution()`, replaced `Thread.sleep(100)` with Awaitility `during(100ms)` to properly assert queued state holds, removed redundant `awaitFlowExecutionNumber` from finally blocks (already covered by `killExecution` awaiting termination)

## Test plan

- [x] `H2RunnerConcurrencyTest.flowConcurrencyKilled` passes
- [x] `H2RunnerConcurrencyTest.flowConcurrencyQueueKilled` passes
- [ ] Let CI run overnight on develop to measure flaky test rate improvement