### PR TITLE
feat: add DeleteImage task to remove Docker images

### DIFF
--- a/script/src/main/java/io/kestra/plugin/scripts/runner/docker/DeleteImage.java
+++ b/script/src/main/java/io/kestra/plugin/scripts/runner/docker/DeleteImage.java
@@ -1,0 +1,119 @@
+package io.kestra.plugin.scripts.runner.docker;
+
+import com.github.dockerjava.api.DockerClient;
+import com.github.dockerjava.api.exception.NotFoundException;
+
+import io.kestra.core.models.annotations.Example;
+import io.kestra.core.models.annotations.Plugin;
+import io.kestra.core.models.annotations.PluginProperty;
+import io.kestra.core.models.property.Property;
+import io.kestra.core.models.tasks.RunnableTask;
+import io.kestra.core.models.tasks.Task;
+import io.kestra.core.models.tasks.VoidOutput;
+import io.kestra.core.runners.RunContext;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+import lombok.experimental.SuperBuilder;
+
+import java.util.Map;
+
+@SuperBuilder
+@ToString
+@EqualsAndHashCode
+@Getter
+@NoArgsConstructor
+@Schema(
+    title = "Delete a Docker image from the Docker daemon.",
+    description = """
+        This task removes a Docker image from the local Docker daemon.
+        This is useful when images are built dynamically (e.g. via `docker.Build`) and should not
+        accumulate on the Docker daemon between executions."""
+)
+@Plugin(
+    examples = {
+        @Example(
+            title = "Build and use a Docker image, then delete it.",
+            code = """
+                id: build_and_cleanup
+                namespace: company.team
+
+                tasks:
+                  - id: build
+                    type: io.kestra.plugin.docker.Build
+                    dockerfile: |
+                      FROM python:3.11
+                      RUN pip install requests
+                    tags:
+                      - my-image:latest
+
+                  - id: use
+                    type: io.kestra.plugin.scripts.python.Commands
+                    containerImage: my-image:latest
+                    commands:
+                      - python -c "import requests; print('OK')"
+
+                  - id: cleanup
+                    type: io.kestra.plugin.scripts.runner.docker.DeleteImage
+                    image: my-image:latest""",
+            full = true
+        ),
+    }
+)
+public class DeleteImage extends Task implements RunnableTask<VoidOutput> {
+    @Schema(
+        title = "Docker API URI."
+    )
+    @PluginProperty(dynamic = true)
+    private String host;
+
+    @Schema(
+        title = "Docker configuration file.",
+        description = "Docker configuration file that can set access credentials to private container registries. Usually located in `~/.docker/config.json`.",
+        anyOf = {String.class, Map.class}
+    )
+    @PluginProperty(dynamic = true)
+    private Object config;
+
+    @Schema(
+        title = "Credentials for a private container registry."
+    )
+    @PluginProperty(dynamic = true)
+    private Credentials credentials;
+
+    @Schema(
+        title = "The image to delete.",
+        description = "The full image name including tag (e.g. `my-image:latest`)."
+    )
+    @NotNull
+    private Property<String> image;
+
+    @Schema(
+        title = "Whether to force the image removal.",
+        description = "When true, the image is removed even if it is being used by stopped containers or has other tags."
+    )
+    @NotNull
+    @Builder.Default
+    private Property<Boolean> force = Property.ofValue(false);
+
+    @Override
+    public VoidOutput run(RunContext runContext) throws Exception {
+        var logger = runContext.logger();
+        String renderedImage = runContext.render(image).as(String.class).orElseThrow();
+        boolean renderedForce = runContext.render(force).as(Boolean.class).orElseThrow();
+
+        try (DockerClient client = DockerService.client(runContext, host, config, credentials, renderedImage)) {
+            client.removeImageCmd(renderedImage).withForce(renderedForce).exec();
+            logger.info("Image deleted: {}", renderedImage);
+        } catch (NotFoundException e) {
+            logger.warn("Image not found: {}", renderedImage);
+        }
+
+        return null;
+    }
+}

--- a/script/src/test/java/io/kestra/plugin/scripts/runner/docker/DeleteImageTest.java
+++ b/script/src/test/java/io/kestra/plugin/scripts/runner/docker/DeleteImageTest.java
@@ -1,0 +1,120 @@
+package io.kestra.plugin.scripts.runner.docker;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.github.dockerjava.api.exception.NotFoundException;
+
+import io.kestra.core.context.TestRunContextFactory;
+import io.kestra.core.junit.annotations.KestraTest;
+import io.kestra.core.models.executions.Execution;
+import io.kestra.core.models.executions.TaskRun;
+import io.kestra.core.models.flows.Flow;
+import io.kestra.core.models.flows.State;
+import io.kestra.core.models.property.Property;
+import io.kestra.core.models.tasks.Task;
+import io.kestra.core.runners.RunContext;
+import io.kestra.core.utils.IdUtils;
+
+import jakarta.inject.Inject;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@KestraTest
+class DeleteImageTest {
+    @Inject
+    private TestRunContextFactory runContextFactory;
+
+    @BeforeEach
+    void assumeDockerAvailable() {
+        String dockerHost = Optional.ofNullable(System.getenv("DOCKER_HOST"))
+            .filter(host -> !host.isBlank())
+            .orElse("unix:///var/run/docker.sock");
+
+        boolean dockerAvailable = !dockerHost.startsWith("unix://") ||
+            Files.exists(Path.of(dockerHost.substring("unix://".length())));
+
+        Assumptions.assumeTrue(
+            dockerAvailable,
+            "Skipping Docker tests: Docker host not available: " + dockerHost
+        );
+    }
+
+    private RunContext runContext() {
+        Task task = new Task() {
+            @Override
+            public String getId() {
+                return "task";
+            }
+
+            @Override
+            public String getType() {
+                return "Task";
+            }
+        };
+        TaskRun taskRun = TaskRun.builder().id(IdUtils.create()).taskId("task").flowId("flow").namespace("namespace").executionId("execution")
+            .state(new State().withState(State.Type.RUNNING))
+            .build();
+        Flow flow = Flow.builder().id("flow").namespace("namespace").revision(1)
+            .tasks(List.of(task))
+            .build();
+        Execution execution = Execution.builder().flowId("flow").namespace("namespace").id("execution")
+            .taskRunList(List.of(taskRun))
+            .state(new State().withState(State.Type.RUNNING))
+            .build();
+
+        return runContextFactory.of(flow, task, execution, taskRun);
+    }
+
+    @Test
+    void shouldDeleteImage() throws Exception {
+        // Given
+        var runContext = runContext();
+        String testImage = "alpine:3.19.0";
+
+        try (var client = DockerService.client(runContext, null, null, null, testImage)) {
+            client.pullImageCmd(testImage).start().awaitCompletion();
+            // Verify the image exists via inspect
+            var inspectBefore = client.inspectImageCmd(testImage).exec();
+            assertThat(inspectBefore).isNotNull();
+        }
+
+        var deleteImage = DeleteImage.builder()
+            .id("delete-image")
+            .type(DeleteImage.class.getName())
+            .image(Property.ofValue(testImage))
+            .force(Property.ofValue(true))
+            .build();
+
+        // When
+        deleteImage.run(runContext);
+
+        // Then — inspecting a deleted image should throw NotFoundException
+        try (var client = DockerService.client(runContext, null, null, null, testImage)) {
+            assertThrows(NotFoundException.class, () -> client.inspectImageCmd(testImage).exec());
+        }
+    }
+
+    @Test
+    void shouldNotFailWhenImageDoesNotExist() throws Exception {
+        // Given
+        var runContext = runContext();
+        String testImage = "nonexistent-image:nonexistent-tag-12345";
+
+        var deleteImage = DeleteImage.builder()
+            .id("delete-image")
+            .type(DeleteImage.class.getName())
+            .image(Property.ofValue(testImage))
+            .build();
+
+        // When / Then — should not throw
+        deleteImage.run(runContext);
+    }
+}


### PR DESCRIPTION
EDIT: Adds a standalone DeleteImage task instead of a deleteImage property on the Docker runner, as suggested in review