### PR TITLE
fix(topology): stop click propagation on all Controls buttons

### DIFF
--- a/ui/packages/topology/src/Topology.vue
+++ b/ui/packages/topology/src/Topology.vue
@@ -92,16 +92,16 @@
         </template>
 
         <Controls v-if="controlsShown" :showInteractive="false" :showFitView="false">
-            <ControlButton @click="showExtraDetails = !showExtraDetails" :class="{'active': showExtraDetails}">
+            <ControlButton @click.stop="showExtraDetails = !showExtraDetails" :class="{'active': showExtraDetails}">
                 <Information />
             </ControlButton>
-            <ControlButton @click="fitView()">
+            <ControlButton @click.stop="fitView()">
                 <svg viewBox="0 0 32 32" style="width:12px;height:12px"><path d="M3.692 4.63c0-.53.4-.938.939-.938h5.215V0H4.708C2.13 0 0 2.054 0 4.63v5.216h3.692V4.631zM27.354 0h-5.2v3.692h5.17c.53 0 .984.4.984.939v5.215H32V4.631A4.624 4.624 0 0 0 27.354 0zm.954 24.83c0 .532-.4.94-.939.94h-5.215v3.768h5.215c2.577 0 4.631-2.13 4.631-4.707v-5.139h-3.692v5.139zm-23.677.94a.919.919 0 0 1-.939-.94v-5.138H0v5.139c0 2.577 2.13 4.707 4.708 4.707h5.138V25.77H4.631z" fill="currentColor" /></svg>
             </ControlButton>
-            <ControlButton @click="emit('toggle-orientation', $event)" v-if="toggleOrientationButton">
+            <ControlButton @click.stop="emit('toggle-orientation', $event)" v-if="toggleOrientationButton">
                 <component :is="isHorizontal ? SplitCellsHorizontal : SplitCellsVertical" />
             </ControlButton>
-            <ControlButton @click="toggleDropdown">
+            <ControlButton @click.stop="toggleDropdown">
                 <Download />
             </ControlButton>
             <ul v-if="isDropdownOpen" class="exporting">


### PR DESCRIPTION
## Summary
- `ControlButton` clicks were bubbling up to parent `router-link` elements, causing the router to navigate to the nearest tab route (e.g. `/edit`) and resulting in a 404 page.
- Added `.stop` modifier to all `ControlButton @click` handlers in `Topology.vue`.

## Test plan
- [ ] Click the info icon (bottom-left Controls) in the topology view — should toggle extra details, not redirect to 404
- [ ] Click fit-view, toggle-orientation, and export buttons — no unwanted navigation