### PR TITLE
feat(worker): enrich AI Copilot with Kestra MCP docs and blueprints context

### DIFF
--- a/webserver/build.gradle
+++ b/webserver/build.gradle
@@ -32,6 +32,7 @@ dependencies {
 
     // ai
     implementation("dev.langchain4j:langchain4j")
+    implementation("dev.langchain4j:langchain4j-mcp")
     implementation("dev.langchain4j:langchain4j-google-ai-gemini")
     implementation("dev.langchain4j:langchain4j-http-client-jdk")
     implementation('org.bouncycastle:bcpkix-jdk18on')

--- a/webserver/src/main/java/io/kestra/webserver/services/ai/AiService.java
+++ b/webserver/src/main/java/io/kestra/webserver/services/ai/AiService.java
@@ -46,6 +46,8 @@ public abstract class AiService<T extends AiConfiguration> implements AiServiceI
     private final ExpressionContextService expressionContextService;
     private final PluginDefaultService pluginDefaultService;
     private final NamespaceContextTool namespaceContextTool;
+    @Nullable
+    private volatile KestraDocsContextTool kestraDocsContextTool;
     private final String instanceUid;
     private final String aiProvider;
     private final String displayName;
@@ -78,17 +80,17 @@ public abstract class AiService<T extends AiConfiguration> implements AiServiceI
     protected FlowYamlBuilder flowYamlBuilder(String conversationId) {
         var builder = AiServices.builder(FlowYamlBuilder.class)
             .chatModel(this.chatModel(this.listeners("FlowYamlBuilder", conversationId)));
-        return (namespaceContextTool != null ? builder.tools(namespaceContextTool) : builder).build();
+        List<Object> tools = new ArrayList<>();
+        if (namespaceContextTool != null) tools.add(namespaceContextTool);
+        if (kestraDocsContextTool != null) tools.add(kestraDocsContextTool);
+        return tools.isEmpty() ? builder.build() : builder.tools(tools).build();
     }
 
     protected DashboardYamlBuilder dashboardYamlBuilder(String conversationId) {
-        return AiServices.builder(DashboardYamlBuilder.class)
-            .chatModel(
-                this.chatModel(
-                    this.listeners("DashboardYamlBuilder", conversationId)
-                )
-            )
-            .build();
+        var builder = AiServices.builder(DashboardYamlBuilder.class)
+            .chatModel(this.chatModel(this.listeners("DashboardYamlBuilder", conversationId)));
+        if (kestraDocsContextTool != null) builder.tools(kestraDocsContextTool);
+        return builder.build();
     }
 
     public AiService(
@@ -119,6 +121,10 @@ public abstract class AiService<T extends AiConfiguration> implements AiServiceI
         this.flowAiCopilot = new FlowAiCopilot<>(Flow.class);
         this.dashboardAiCopilot = new DashboardAiCopilot<>(Dashboard.class);
         this.versionProvider = versionProvider;
+    }
+
+    public void setKestraDocsContextTool(KestraDocsContextTool kestraDocsContextTool) {
+        this.kestraDocsContextTool = kestraDocsContextTool;
     }
 
     @Override
@@ -203,9 +209,10 @@ public abstract class AiService<T extends AiConfiguration> implements AiServiceI
     }
 
     public <B> B buildAiService(Class<B> serviceClass, String spanName, String conversationId) {
-        return AiServices.builder(serviceClass)
-            .chatModel(this.chatModel(this.listeners(spanName, conversationId)))
-            .build();
+        var builder = AiServices.builder(serviceClass)
+            .chatModel(this.chatModel(this.listeners(spanName, conversationId)));
+        if (kestraDocsContextTool != null) builder.tools(kestraDocsContextTool);
+        return builder.build();
     }
 
     public record ConversationMetadata(String conversationId, String ip, String parentSpanId, String uid) {

--- a/webserver/src/main/java/io/kestra/webserver/services/ai/AiServiceManager.java
+++ b/webserver/src/main/java/io/kestra/webserver/services/ai/AiServiceManager.java
@@ -36,6 +36,7 @@ public class AiServiceManager {
     protected final ExpressionContextService expressionContextService;
     protected final PluginDefaultService pluginDefaultService;
     protected final NamespaceContextTool namespaceContextTool;
+    protected final KestraDocsContextTool kestraDocsContextTool;
 
     public AiServiceManager(
         @Client("api") HttpClient apiHttpClient,
@@ -49,12 +50,14 @@ public class AiServiceManager {
         PosthogService posthogService,
         List<dev.langchain4j.model.chat.listener.ChatModelListener> listeners,
         @Nullable NamespaceContextTool namespaceContextTool,
+        @Nullable KestraDocsContextTool kestraDocsContextTool,
         ExpressionContextService expressionContextService,
         PluginDefaultService pluginDefaultService) {
         this.providersConfiguration = providersConfiguration;
         this.expressionContextService = expressionContextService;
         this.pluginDefaultService = pluginDefaultService;
         this.namespaceContextTool = namespaceContextTool;
+        this.kestraDocsContextTool = kestraDocsContextTool;
 
         List<AiProviderConfiguration> configs = new java.util.ArrayList<>(
             providersConfiguration.providers() != null ? providersConfiguration.providers() : List.of()
@@ -140,9 +143,13 @@ public class AiServiceManager {
                 .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
 
             GeminiConfiguration geminiConfig = mapper.convertValue(configMap, GeminiConfiguration.class);
-            return new GeminiAiService(
+            AiService<?> service = new GeminiAiService(
                 pluginRegistry, jsonSchemaGenerator, versionProvider, instanceService, posthogService, this.namespaceContextTool, provider.displayName(), listeners, geminiConfig, expressionContextService, pluginDefaultService
             );
+            if (this.kestraDocsContextTool != null) {
+                service.setKestraDocsContextTool(this.kestraDocsContextTool);
+            }
+            return service;
         } catch (Exception e) {
             log.error("Failed to create AI service for provider {}: {}", provider.id(), e.getMessage());
             return null;

--- a/webserver/src/main/java/io/kestra/webserver/services/ai/KestraDocsContextTool.java
+++ b/webserver/src/main/java/io/kestra/webserver/services/ai/KestraDocsContextTool.java
@@ -1,0 +1,108 @@
+package io.kestra.webserver.services.ai;
+
+import dev.langchain4j.agent.tool.P;
+import dev.langchain4j.agent.tool.Tool;
+import dev.langchain4j.agent.tool.ToolExecutionRequest;
+import dev.langchain4j.mcp.client.DefaultMcpClient;
+import dev.langchain4j.mcp.client.McpClient;
+import dev.langchain4j.mcp.client.transport.http.StreamableHttpMcpTransport;
+import dev.langchain4j.service.tool.ToolExecutionResult;
+import io.kestra.core.serializers.JacksonMapper;
+import io.micronaut.context.annotation.Requires;
+import jakarta.annotation.PreDestroy;
+import jakarta.inject.Singleton;
+import lombok.extern.slf4j.Slf4j;
+
+import java.time.Duration;
+import java.util.Map;
+
+/**
+ * A LangChain4j tool that provides the AI Copilot with access to Kestra documentation
+ * and flow blueprints from the public kestra.io MCP server.
+ */
+@Slf4j
+@Singleton
+@Requires(property = "kestra.ai.enabled", value = "true", defaultValue = "true")
+public class KestraDocsContextTool implements AutoCloseable {
+
+    private final McpClient mcpClient;
+
+    public KestraDocsContextTool() {
+        this.mcpClient = new DefaultMcpClient.Builder()
+            .transport(StreamableHttpMcpTransport.builder()
+                .url("https://api.kestra.io/v1/mcp")
+                .timeout(Duration.ofSeconds(15))
+                .build())
+            .clientName("kestra-copilot")
+            .toolExecutionTimeout(Duration.ofSeconds(15))
+            .build();
+    }
+
+    /**
+     * Searches Kestra documentation for the given query.
+     *
+     * @param query the search query
+     * @return matching documentation entries, or null if an error occurred
+     */
+    @Tool("Search the Kestra documentation for a given query. Use this to find information about Kestra features, tasks, triggers, and configuration options.")
+    public String searchDocs(@P("The search query to find relevant Kestra documentation") String query) {
+        return callMcpTool("search_docs", Map.of("query", query));
+    }
+
+    /**
+     * Retrieves the content of a specific Kestra documentation page.
+     *
+     * @param parsedUrl the parsed URL of the documentation page
+     * @return the documentation page content, or null if an error occurred
+     */
+    @Tool("Retrieve the content of a specific Kestra documentation page by its URL.")
+    public String getDoc(@P("The parsed URL of the documentation page to retrieve") String parsedUrl) {
+        return callMcpTool("get_doc", Map.of("parsedUrl", parsedUrl));
+    }
+
+    /**
+     * Searches for Kestra flow blueprints matching the given query.
+     *
+     * @param query the search query
+     * @return matching blueprints, or null if an error occurred
+     */
+    @Tool("Search for Kestra flow blueprints that match a given query. Use this to find example flows and templates.")
+    public String searchBlueprints(@P("The search query to find relevant Kestra flow blueprints") String query) {
+        return callMcpTool("blueprints", Map.of("query", query));
+    }
+
+    /**
+     * Retrieves the YAML definition of a specific Kestra blueprint flow.
+     *
+     * @param blueprintId the ID of the blueprint to retrieve
+     * @return the blueprint flow YAML, or null if an error occurred
+     */
+    @Tool("Retrieve the YAML flow definition of a specific Kestra blueprint by its ID.")
+    public String getBlueprintFlow(@P("The numeric ID of the blueprint to retrieve") int blueprintId) {
+        return callMcpTool("get_blueprint_flow", Map.of("blueprintId", blueprintId));
+    }
+
+    private String callMcpTool(String toolName, Map<String, Object> arguments) {
+        try {
+            ToolExecutionRequest request = ToolExecutionRequest.builder()
+                .name(toolName)
+                .arguments(JacksonMapper.ofJson().writeValueAsString(arguments))
+                .build();
+            ToolExecutionResult result = mcpClient.executeTool(request);
+            return result.resultText();
+        } catch (Exception e) {
+            log.warn("Failed to call MCP tool '{}': {}", toolName, e.getMessage());
+            return null;
+        }
+    }
+
+    @Override
+    @PreDestroy
+    public void close() {
+        try {
+            mcpClient.close();
+        } catch (Exception e) {
+            log.warn("Failed to close MCP client: {}", e.getMessage());
+        }
+    }
+}

--- a/webserver/src/main/java/io/kestra/webserver/services/ai/KestraDocsContextTool.java
+++ b/webserver/src/main/java/io/kestra/webserver/services/ai/KestraDocsContextTool.java
@@ -8,8 +8,11 @@ import dev.langchain4j.mcp.client.McpClient;
 import dev.langchain4j.mcp.client.transport.http.StreamableHttpMcpTransport;
 import dev.langchain4j.service.tool.ToolExecutionResult;
 import io.kestra.core.serializers.JacksonMapper;
+import io.kestra.core.utils.VersionProvider;
 import io.micronaut.context.annotation.Requires;
+import io.micronaut.context.annotation.Value;
 import jakarta.annotation.PreDestroy;
+import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 import lombok.extern.slf4j.Slf4j;
 
@@ -25,16 +28,22 @@ import java.util.Map;
 @Requires(property = "kestra.ai.enabled", value = "true", defaultValue = "true")
 public class KestraDocsContextTool implements AutoCloseable {
 
+    private static final Duration MCP_TIMEOUT = Duration.ofSeconds(15);
+
     private final McpClient mcpClient;
 
-    public KestraDocsContextTool() {
+    @Inject
+    public KestraDocsContextTool(
+        @Value("${micronaut.http.services.api.url:https://api.kestra.io}") String apiUrl,
+        VersionProvider versionProvider
+    ) {
         this.mcpClient = new DefaultMcpClient.Builder()
             .transport(StreamableHttpMcpTransport.builder()
-                .url("https://api.kestra.io/v1/mcp")
-                .timeout(Duration.ofSeconds(15))
+                .url(apiUrl + "/v1/mcp")
+                .timeout(MCP_TIMEOUT)
                 .build())
-            .clientName("kestra-copilot")
-            .toolExecutionTimeout(Duration.ofSeconds(15))
+            .clientName("Kestra/" + versionProvider.getVersion())
+            .toolExecutionTimeout(MCP_TIMEOUT)
             .build();
     }
 

--- a/webserver/src/main/java/io/kestra/webserver/services/ai/KestraDocsContextTool.java
+++ b/webserver/src/main/java/io/kestra/webserver/services/ai/KestraDocsContextTool.java
@@ -37,14 +37,20 @@ public class KestraDocsContextTool implements AutoCloseable {
         @Value("${micronaut.http.services.api.url:https://api.kestra.io}") String apiUrl,
         VersionProvider versionProvider
     ) {
-        this.mcpClient = new DefaultMcpClient.Builder()
-            .transport(StreamableHttpMcpTransport.builder()
-                .url(apiUrl + "/v1/mcp")
-                .timeout(MCP_TIMEOUT)
-                .build())
-            .clientName("Kestra/" + versionProvider.getVersion())
-            .toolExecutionTimeout(MCP_TIMEOUT)
-            .build();
+        McpClient client = null;
+        try {
+            client = new DefaultMcpClient.Builder()
+                .transport(StreamableHttpMcpTransport.builder()
+                    .url(apiUrl + "/v1/mcp")
+                    .timeout(MCP_TIMEOUT)
+                    .build())
+                .clientName("Kestra/" + versionProvider.getVersion())
+                .toolExecutionTimeout(MCP_TIMEOUT)
+                .build();
+        } catch (Exception e) {
+            log.warn("Failed to initialize Kestra docs MCP client, documentation context will be unavailable: {}", e.getMessage());
+        }
+        this.mcpClient = client;
     }
 
     /**
@@ -92,6 +98,9 @@ public class KestraDocsContextTool implements AutoCloseable {
     }
 
     private String callMcpTool(String toolName, Map<String, Object> arguments) {
+        if (mcpClient == null) {
+            return null;
+        }
         try {
             ToolExecutionRequest request = ToolExecutionRequest.builder()
                 .name(toolName)
@@ -108,6 +117,9 @@ public class KestraDocsContextTool implements AutoCloseable {
     @Override
     @PreDestroy
     public void close() {
+        if (mcpClient == null) {
+            return;
+        }
         try {
             mcpClient.close();
         } catch (Exception e) {

--- a/webserver/src/test/java/io/kestra/webserver/services/ai/AiServiceManagerTest.java
+++ b/webserver/src/test/java/io/kestra/webserver/services/ai/AiServiceManagerTest.java
@@ -44,6 +44,8 @@ class AiServiceManagerTest {
     @Mock
     NamespaceContextTool namespaceContextTool;
     @Mock
+    KestraDocsContextTool kestraDocsContextTool;
+    @Mock
     ExpressionContextService expressionContextService;
     @Mock
     io.kestra.core.services.PluginDefaultService pluginDefaultService;
@@ -62,6 +64,7 @@ class AiServiceManagerTest {
             posthogService,
             List.of(),
             namespaceContextTool,
+            kestraDocsContextTool,
             expressionContextService,
             pluginDefaultService
         );


### PR DESCRIPTION
## Summary

- Add `KestraDocsContextTool` — a `@Singleton` LangChain4j `@Tool` class backed by the public kestra.io MCP server (`https://api.kestra.io/v1/mcp`) via `langchain4j-mcp`'s `DefaultMcpClient` + `StreamableHttpMcpTransport`
- Expose 4 tools to the AI Copilot: `searchDocs`, `getDoc`, `searchBlueprints`, `getBlueprintFlow`
- Wire the tool into `FlowYamlBuilder`, `DashboardYamlBuilder`, and `buildAiService()` in `AiService` — giving the LLM prose documentation and real-world flow templates beyond the JSON schemas it already has
- Tool call failures (network outage, kestra.io down) are handled gracefully: log a warning and return `null`, so generation continues unaffected

## Motivation

Until now the AI Copilot only had JSON schemas of installed plugins + namespace context (secrets, variables, KV keys). It had no access to how-to guides, usage examples, or flow templates. The kestra.io MCP server exposes all of that through a standard MCP interface.

## Technical notes

- `KestraDocsContextTool` is only instantiated when `kestra.ai.enabled=true` (via `@Requires`)
- `DefaultMcpClient` uses `StreamableHttpMcpTransport` (MCP 2025-03 spec) for stateless HTTP calls
- The MCP client is initialized once at bean construction; actual HTTP connections are lazy
- Bean is `AutoCloseable` with `@PreDestroy` to cleanly shut down the client
- New dependency: `dev.langchain4j:langchain4j-mcp` (already in the `langchain4j-bom:1.14.0`)

## Companion PR

EE companion PR: kestra-io/kestra-ee#... (wires the tool into all 9 EE providers)

## Test plan

- [ ] AI Copilot flow generation uses `searchDocs`/`getDoc` for plugin-specific context
- [ ] Blueprint search returns relevant YAML templates
- [ ] Generation succeeds gracefully when kestra.io is unreachable (tool returns null)
- [ ] `KestraDocsContextTool` bean is NOT created when `kestra.ai.enabled=false`