### PR TITLE
fix(execution): replay to a different revision

### DIFF
--- a/core/src/main/java/io/kestra/core/services/ExecutionService.java
+++ b/core/src/main/java/io/kestra/core/services/ExecutionService.java
@@ -391,13 +391,17 @@ public class ExecutionService {
         }
         newExecution = newExecution.withMetadata(execution.getMetadata().nextAttempt()).withLabels(newLabels)
             .withBreakpoints(breakpoints.map(s -> Arrays.stream(s.split(",")).map(Breakpoint::of).toList()).orElse(null));
-        ;
 
-        newExecution = revision != null ? newExecution.withFlowRevision(revision) : newExecution;
+        newExecution = revision != null ? applyNewRevision(flow, newExecution) : newExecution;
         if (emitEvent) {
             eventPublisher.publishEvent(CrudEvent.create(newExecution));
         }
         return newExecution;
+    }
+
+    private Execution applyNewRevision(Flow flow, Execution newExecution) {
+        return newExecution.withFlowRevision(flow.getRevision())
+            .withVariables(flow.getVariables());
     }
 
     public Execution changeTaskRunState(final Execution execution, Flow flow, String taskRunId, State.Type newState) throws Exception {

--- a/core/src/test/java/io/kestra/core/runners/ExecutionServiceTest.java
+++ b/core/src/test/java/io/kestra/core/runners/ExecutionServiceTest.java
@@ -7,6 +7,8 @@ import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.TimeoutException;
 
+import io.kestra.core.models.flows.FlowWithSource;
+import io.kestra.core.services.FlowService;
 import org.junit.jupiter.api.Test;
 import org.slf4j.event.Level;
 
@@ -52,6 +54,9 @@ class ExecutionServiceTest {
 
     @Inject
     FlowRepositoryInterface flowRepository;
+
+    @Inject
+    FlowService flowService;
 
     @Inject
     ExecutionRepositoryInterface executionRepository;
@@ -376,6 +381,35 @@ class ExecutionServiceTest {
         assertThat(restart.findTaskRunsByTaskId("item").getFirst().getState().getCurrent()).isEqualTo(State.Type.RESTARTED);
         assertThat(restart.getId()).isNotEqualTo(execution.getId());
         assertThat(restart.getLabels()).contains(new Label(Label.REPLAY, "true"));
+    }
+
+    @Test
+    @LoadFlows(value = { "flows/valids/replay-revision.yaml" }, tenantId = TENANT_1)
+    void replayDifferentRevision() throws Exception {
+        Execution execution = runnerUtils.runOne(TENANT_1, "io.kestra.tests", "replay-revision");
+        assertThat(execution.getTaskRunList()).hasSize(1);
+        assertThat(execution.getState().getCurrent()).isEqualTo(State.Type.FAILED);
+
+        // update the flow with a new source
+        FlowWithSource flow = flowRepository.findByExecutionWithSource(execution);
+        String newSource = """
+            id: replay-revision
+            namespace: io.kestra.tests
+
+            variables:
+              greeting: "Hello World"
+
+            tasks:
+              - id: print
+                type: io.kestra.plugin.core.log.Log
+                message: "{{ render(vars.greeting) }}"
+            """;
+        FlowWithSource updated = flowService.update(GenericFlow.fromYaml(flow.getTenantId(), newSource), flow);
+        
+        Execution restart = executionService.replay(execution, updated, null, updated.getRevision(), Optional.empty());
+
+        assertThat(restart.getFlowRevision()).isEqualTo(updated.getRevision());
+        assertThat(restart.getVariables()).containsEntry("greeting", "Hello World");
     }
 
     @Test

--- a/core/src/test/resources/flows/valids/replay-revision.yaml
+++ b/core/src/test/resources/flows/valids/replay-revision.yaml
@@ -1,0 +1,10 @@
+id: replay-revision
+namespace: io.kestra.tests
+
+variables:
+  greeting: "{{ this_is_undefined }}"
+
+tasks:
+  - id: print
+    type: io.kestra.plugin.core.log.Log
+    message: "{{ render(vars.greeting) }}"


### PR DESCRIPTION
When replaying to a different revision, the revision and variables must be updated.

Fixes #15982
Fixes https://github.com/kestra-io/kestra-ee/issues/7699
