### PR TITLE
feat(core): add InputStream/OutputStream-based methods to FileSerde

### DIFF
--- a/core/src/main/java/io/kestra/core/serializers/FileSerde.java
+++ b/core/src/main/java/io/kestra/core/serializers/FileSerde.java
@@ -191,6 +191,56 @@ public final class FileSerde {
         }
     }
 
+    // region InputStream-based read methods (compatible with both text and binary ION in 2.0+)
+
+    /**
+     * For performance, it is advised to wrap the input stream inside a BufferedInputStream, see {@link #BUFFER_SIZE}.
+     */
+    public static Flux<Object> readAll(InputStream inputStream) throws IOException {
+        return readAll(new BufferedReader(new InputStreamReader(inputStream), BUFFER_SIZE));
+    }
+
+    /**
+     * For performance, it is advised to wrap the input stream inside a BufferedInputStream, see {@link #BUFFER_SIZE}.
+     */
+    public static <T> Flux<T> readAll(InputStream inputStream, TypeReference<T> type) throws IOException {
+        return readAll(new BufferedReader(new InputStreamReader(inputStream), BUFFER_SIZE), type);
+    }
+
+    /**
+     * For performance, it is advised to wrap the input stream inside a BufferedInputStream, see {@link #BUFFER_SIZE}.
+     */
+    public static <T> Flux<T> readAll(InputStream inputStream, Class<T> type) throws IOException {
+        return readAll(new BufferedReader(new InputStreamReader(inputStream), BUFFER_SIZE), type);
+    }
+
+    /**
+     * For performance, it is advised to wrap the input stream inside a BufferedInputStream, see {@link #BUFFER_SIZE}.
+     */
+    public static void reader(InputStream input, Consumer<Object> consumer) throws IOException {
+        reader(new BufferedReader(new InputStreamReader(input), BUFFER_SIZE), consumer);
+    }
+
+    /**
+     * For performance, it is advised to wrap the input stream inside a BufferedInputStream, see {@link #BUFFER_SIZE}.
+     */
+    public static boolean reader(InputStream input, int maxLines, Consumer<Object> consumer) throws IOException {
+        return reader(new BufferedReader(new InputStreamReader(input), BUFFER_SIZE), maxLines, consumer);
+    }
+
+    // endregion
+
+    // region OutputStream-based write methods (compatible with binary ION in 2.0+)
+
+    /**
+     * For performance, it is advised to wrap the output stream inside a BufferedOutputStream, see {@link #BUFFER_SIZE}.
+     */
+    public static <T> Mono<Long> writeAll(OutputStream outputStream, Flux<T> values) throws IOException {
+        return writeAll(new BufferedWriter(new OutputStreamWriter(outputStream), BUFFER_SIZE), values);
+    }
+
+    // endregion
+
     public static <T> SequenceWriter createSequenceWriter(ObjectMapper objectMapper, Writer writer, TypeReference<T> type) throws IOException {
         return objectMapper.writerFor(type).writeValues(writer);
     }


### PR DESCRIPTION
## Summary
- Adds `InputStream`-based `readAll()` and `reader()` methods to `FileSerde` that delegate to the existing `Reader`-based implementations
- Adds `OutputStream`-based `writeAll()` that delegates to the existing `Writer`-based implementation
- **No behavior change** — purely additive forward-compatibility layer so plugins compiled against these method signatures work on both 1.x and 2.0

## Context
Cherry-pick of the same commit from the [v1.3.x PR](https://github.com/kestra-io/kestra/pull/16110).

In 2.0, `FileSerde` will switch to binary ION for storage writes (~20-40% size reduction). Binary ION requires `InputStream`/`OutputStream` (not `Reader`/`Writer`) to avoid byte corruption from character decoding. Adding these signatures on 1.x means plugins can migrate to the new API now and remain compatible with both versions.

## Test plan
- [x] Cherry-pick applied cleanly
- [ ] CI passes