### PR TITLE
feat(blueprint): migrate community blueprint API to QueryFilter format

### DIFF
--- a/core/src/main/java/io/kestra/core/models/QueryFilter.java
+++ b/core/src/main/java/io/kestra/core/models/QueryFilter.java
@@ -450,6 +450,12 @@ public record QueryFilter(
                 return List.of(Field.QUERY, Field.NAME);
             }
         },
+        BLUEPRINT {
+            @Override
+            public List<Field> supportedField() {
+                return List.of(Field.QUERY, Field.TAGS);
+            }
+        },
         BINDING {
             @Override
             public List<Field> supportedField() {

--- a/core/src/test/java/io/kestra/core/models/QueryFilterTest.java
+++ b/core/src/test/java/io/kestra/core/models/QueryFilterTest.java
@@ -486,8 +486,12 @@ public class QueryFilterTest {
             buildQueryFiltersForOperations(
                 Field.TAGS, Resource.BLUEPRINT,
                 Set.of(
+                    Op.IN,
+                    Op.NOT_IN,
+                    Op.PREFIX,
                     Op.CONTAINS,
-                    Op.IN
+                    Op.STARTS_WITH,
+                    Op.ENDS_WITH
                 )
             ),
 
@@ -1276,11 +1280,7 @@ public class QueryFilterTest {
                     Op.LESS_THAN,
                     Op.GREATER_THAN_OR_EQUAL_TO,
                     Op.LESS_THAN_OR_EQUAL_TO,
-                    Op.NOT_IN,
-                    Op.STARTS_WITH,
-                    Op.ENDS_WITH,
-                    Op.REGEX,
-                    Op.PREFIX
+                    Op.REGEX
                 )
             ),
 

--- a/core/src/test/java/io/kestra/core/models/QueryFilterTest.java
+++ b/core/src/test/java/io/kestra/core/models/QueryFilterTest.java
@@ -476,6 +476,22 @@ public class QueryFilterTest {
             ),
 
             buildQueryFiltersForOperations(
+                Field.QUERY, Resource.BLUEPRINT,
+                Set.of(
+                    Op.EQUALS,
+                    Op.NOT_EQUALS
+                )
+            ),
+
+            buildQueryFiltersForOperations(
+                Field.TAGS, Resource.BLUEPRINT,
+                Set.of(
+                    Op.CONTAINS,
+                    Op.IN
+                )
+            ),
+
+            buildQueryFiltersForOperations(
                 Field.QUERY, Resource.TENANT,
                 Set.of(
                     Op.EQUALS,
@@ -1231,6 +1247,40 @@ public class QueryFilterTest {
                     Op.LESS_THAN,
                     Op.GREATER_THAN_OR_EQUAL_TO,
                     Op.LESS_THAN_OR_EQUAL_TO
+                )
+            ),
+
+            buildQueryFiltersForOperations(
+                Field.QUERY, Resource.BLUEPRINT,
+                Set.of(
+                    Op.GREATER_THAN,
+                    Op.LESS_THAN,
+                    Op.GREATER_THAN_OR_EQUAL_TO,
+                    Op.LESS_THAN_OR_EQUAL_TO,
+                    Op.IN,
+                    Op.NOT_IN,
+                    Op.STARTS_WITH,
+                    Op.ENDS_WITH,
+                    Op.CONTAINS,
+                    Op.REGEX,
+                    Op.PREFIX
+                )
+            ),
+
+            buildQueryFiltersForOperations(
+                Field.TAGS, Resource.BLUEPRINT,
+                Set.of(
+                    Op.EQUALS,
+                    Op.NOT_EQUALS,
+                    Op.GREATER_THAN,
+                    Op.LESS_THAN,
+                    Op.GREATER_THAN_OR_EQUAL_TO,
+                    Op.LESS_THAN_OR_EQUAL_TO,
+                    Op.NOT_IN,
+                    Op.STARTS_WITH,
+                    Op.ENDS_WITH,
+                    Op.REGEX,
+                    Op.PREFIX
                 )
             ),
 

--- a/jdbc/src/main/java/io/kestra/jdbc/repository/AbstractJdbcRepository.java
+++ b/jdbc/src/main/java/io/kestra/jdbc/repository/AbstractJdbcRepository.java
@@ -347,6 +347,10 @@ public abstract class AbstractJdbcRepository {
             return typeCondition(value, operation);
         }
 
+        if (field == QueryFilter.Field.TAGS) {
+            return tagsCondition(value, operation);
+        }
+
         if (field == QueryFilter.Field.RESOURCES) {
             return resourceTypesCondition(value, operation);
         }
@@ -489,6 +493,10 @@ public abstract class AbstractJdbcRepository {
 
     protected Condition nameCondition(Object value, QueryFilter.Op operation) {
         return defaultHandlers(QueryFilter.Field.NAME, value, operation);
+    }
+
+    protected Condition tagsCondition(Object value, QueryFilter.Op operation) {
+        throw new InvalidQueryFiltersException("Unsupported operation for TAGS field: " + operation);
     }
 
     protected Condition typeCondition(Object value, QueryFilter.Op operation) {

--- a/jdbc/src/main/java/io/kestra/jdbc/repository/AbstractJdbcRepository.java
+++ b/jdbc/src/main/java/io/kestra/jdbc/repository/AbstractJdbcRepository.java
@@ -460,10 +460,6 @@ public abstract class AbstractJdbcRepository {
         throw new InvalidQueryFiltersException("getSuperAdminCondition must be overridden for JSONB-backed superAdmin field");
     }
 
-    protected Condition tagsCondition(Object value, QueryFilter.Op operation) {
-        throw new InvalidQueryFiltersException("Unsupported operation for TAGS field: " + operation);
-    }
-
     // Generate the condition for Field.STATE
     @SuppressWarnings("unchecked")
     protected Condition generateStateCondition(Object value, QueryFilter.Op operation) {

--- a/jdbc/src/test/java/io/kestra/jdbc/repository/AbstractJdbcRepositoryTest.java
+++ b/jdbc/src/test/java/io/kestra/jdbc/repository/AbstractJdbcRepositoryTest.java
@@ -30,8 +30,8 @@ class AbstractJdbcRepositoryTest extends AbstractJdbcRepository {
         QueryFilter.Field.METADATA,
         QueryFilter.Field.GROUP,
         QueryFilter.Field.NAME,
-        QueryFilter.Field.TAGS,
-        QueryFilter.Field.SUPER_ADMIN
+        QueryFilter.Field.SUPER_ADMIN,
+        QueryFilter.Field.TAGS
     );
 
     @Test

--- a/ui/src/stores/blueprints.ts
+++ b/ui/src/stores/blueprints.ts
@@ -60,7 +60,8 @@ export const useBlueprintsStore = defineStore("blueprints", () => {
     const validateYAML = ref<boolean>(true) // Used to enable/disable YAML validation in Monaco editor, for the purpose of Templated Blueprints
 
     const getBlueprints = async (options: Options) => {
-        const PARAMS = {params: options.params, ...VALIDATE}
+        const params = options.type === "custom" ? toCustomBlueprintFilterParams(options.params) : options.params
+        const PARAMS = {params, ...VALIDATE}
 
         const COMMUNITY = `${API_URL}/blueprints/kinds/${options.kind}/versions/${version}${edition === "OSS" ? "?ee=false" : ""}`
         const CUSTOM = `${apiUrl()}/blueprints/${options.type}`
@@ -69,6 +70,28 @@ export const useBlueprintsStore = defineStore("blueprints", () => {
 
         blueprints.value = response.data
         return response.data
+    }
+
+    /**
+     * The /blueprints/custom backend reads search/tag filters from the QueryFilter format
+     * (`filters[q][EQUALS]=…`, `filters[tags][IN]=…`). Legacy callers still pass `q` / `tags`
+     * as scalar params, so translate them here. The external community API (api.kestra.io)
+     * still expects the legacy scalar form, so we only translate for `custom`.
+     */
+    function toCustomBlueprintFilterParams(params?: Record<string, any>): Record<string, any> | undefined {
+        if (!params) return params
+        const translated: Record<string, any> = {}
+        for (const [key, value] of Object.entries(params)) {
+            if (value === undefined || value === null) continue
+            if (key === "q") {
+                translated["filters[q][EQUALS]"] = value
+            } else if (key === "tags") {
+                translated["filters[tags][IN]"] = Array.isArray(value) ? value.join(",") : value
+            } else {
+                translated[key] = value
+            }
+        }
+        return translated
     }
 
     const getBlueprint = async (options: Options) => {
@@ -106,7 +129,8 @@ export const useBlueprintsStore = defineStore("blueprints", () => {
     }
 
     const getBlueprintTags = async (options: Options) => {
-        const PARAMS = {params: options.params, ...VALIDATE}
+        const params = options.type === "custom" ? toCustomBlueprintFilterParams(options.params) : options.params
+        const PARAMS = {params, ...VALIDATE}
 
         const COMMUNITY = `${API_URL}/blueprints/kinds/${options.kind}/versions/${version}/tags`
         const CUSTOM = `${apiUrl()}/blueprints/${options.type}/tags`

--- a/webserver/src/main/java/io/kestra/webserver/controllers/api/BlueprintController.java
+++ b/webserver/src/main/java/io/kestra/webserver/controllers/api/BlueprintController.java
@@ -2,6 +2,7 @@ package io.kestra.webserver.controllers.api;
 
 import java.net.URISyntaxException;
 import java.time.Instant;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -9,8 +10,11 @@ import java.util.Optional;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonInclude;
 
+import io.kestra.core.exceptions.InvalidQueryFiltersException;
+import io.kestra.core.models.QueryFilter;
 import io.kestra.core.utils.Enums;
 import io.kestra.core.utils.VersionProvider;
+import io.kestra.webserver.converters.QueryFilterFormat;
 import io.kestra.webserver.responses.PagedResults;
 
 import io.micronaut.core.annotation.Nullable;
@@ -46,14 +50,17 @@ public class BlueprintController {
     @Get("/{kind}")
     @Operation(tags = { "Blueprints" }, summary = "List all blueprints")
     public PagedResults<ApiBlueprintItem> searchBlueprints(
-        @Parameter(description = "A string filter") @Nullable @QueryValue(value = "q") Optional<String> q,
         @Parameter(description = "The sort of current page") @Nullable @QueryValue(value = "sort") Optional<String> sort,
-        @Parameter(description = "A tags filter") @Nullable @QueryValue(value = "tags") Optional<List<String>> tags,
         @Parameter(description = "The current page") @QueryValue(defaultValue = "1") @Min(1) Integer page,
         @Parameter(description = "The current page size") @QueryValue(defaultValue = "1") @Min(1) Integer size,
         @Parameter(description = "The blueprint kind") Kind kind,
+        @Parameter(description = "A list of query filters") @Nullable @QueryFilterFormat List<QueryFilter> filters,
         HttpRequest<?> httpRequest) throws URISyntaxException {
-        return fastForwardToKestraApi(httpRequest, getApiBasePath(kind), Map.of("ee", false), Argument.of(PagedResults.class, ApiBlueprintItem.class));
+
+        Map<String, Object> extraParams = new LinkedHashMap<>(blueprintFilterQueryParams(filters));
+        extraParams.put("ee", false);
+
+        return fastForwardToKestraApi(httpRequest, getApiBasePath(kind), extraParams, Argument.of(PagedResults.class, ApiBlueprintItem.class));
     }
 
     @ExecuteOn(TaskExecutors.IO)
@@ -92,9 +99,64 @@ public class BlueprintController {
     @Operation(tags = { "Blueprint Tags" }, summary = "List blueprint tags matching the filter")
     public List<ApiBlueprintTagItem> listBlueprintTags(
         @Parameter(description = "The blueprint kind") Kind kind,
-        @Parameter(description = "A string filter to get tags with matching blueprints only") @Nullable @QueryValue(value = "q") Optional<String> q,
+        @Parameter(description = "A list of query filters") @Nullable @QueryFilterFormat List<QueryFilter> filters,
         HttpRequest<?> httpRequest) throws URISyntaxException {
-        return fastForwardToKestraApi(httpRequest, getApiBasePath(kind) + "/tags", Argument.of(List.class, ApiBlueprintTagItem.class));
+
+        return fastForwardToKestraApi(httpRequest, getApiBasePath(kind) + "/tags", blueprintFilterQueryParams(filters), Argument.of(List.class, ApiBlueprintTagItem.class));
+    }
+
+    /**
+     * Translates {@link QueryFilter} entries for the BLUEPRINT resource into the legacy
+     * {@code q} / {@code tags} query string params the downstream community API expects.
+     * Validates field/operation pairs against {@link QueryFilter.Resource#BLUEPRINT}.
+     * Returns an empty map when no relevant filters are present.
+     */
+    protected static Map<String, Object> blueprintFilterQueryParams(@Nullable List<QueryFilter> filters) {
+        QueryFilter.validateQueryFilters(filters, QueryFilter.Resource.BLUEPRINT);
+        String q = parseQueryFiltersForBlueprint(filters);
+        List<String> tags = parseTagsFromQueryFiltersForBlueprint(filters);
+        Map<String, Object> params = new LinkedHashMap<>();
+        if (q != null && !q.isEmpty()) {
+            params.put("q", q);
+        }
+        if (tags != null && !tags.isEmpty()) {
+            params.put("tags", tags);
+        }
+        return params;
+    }
+
+    protected static String parseQueryFiltersForBlueprint(@Nullable List<QueryFilter> queryFilters) {
+        if (queryFilters == null || queryFilters.isEmpty()) {
+            return null;
+        }
+
+        List<QueryFilter> queryFieldFilters = queryFilters.stream()
+            .filter(f -> f.field() == QueryFilter.Field.QUERY)
+            .toList();;
+
+        if (queryFieldFilters.size() > 1) {
+            throw new InvalidQueryFiltersException("Resource: BLUEPRINT does not support multiple conditions on QUERY Field");
+        }
+
+        return queryFieldFilters.isEmpty() ? null : queryFieldFilters.getFirst().value().toString();
+    }
+
+    protected static List<String> parseTagsFromQueryFiltersForBlueprint(@Nullable List<QueryFilter> queryFilters) {
+        if (queryFilters == null || queryFilters.isEmpty()) {
+            return null;
+        }
+
+        return queryFilters.stream()
+            .filter(f -> f.field() == QueryFilter.Field.TAGS)
+            .findFirst()
+            .map(f -> {
+                Object value = f.value();
+                if (value instanceof List<?> list) {
+                    return list.stream().map(Object::toString).toList();
+                }
+                return value == null ? null : List.of(value.toString());
+            })
+            .orElse(null);
     }
 
     private String getApiBasePath(final Kind kind) {
@@ -109,12 +171,18 @@ public class BlueprintController {
         return this.fastForwardToKestraApi(originalRequest, newPath, null, returnType);
     }
 
-    private <T> T fastForwardToKestraApi(HttpRequest<?> originalRequest, String newPath, Map<String, Object> additionalQueryParams, Argument<T> returnType) throws URISyntaxException {
+    protected <T> T fastForwardToKestraApi(HttpRequest<?> originalRequest, String newPath, Map<String, Object> additionalQueryParams, Argument<T> returnType) throws URISyntaxException {
         UriBuilder uriBuilder = UriBuilder.of(originalRequest.getUri())
             .replacePath(originalRequest.getUri().getPath().toString().replaceAll("^[^?]*", newPath));
 
         if (additionalQueryParams != null) {
-            additionalQueryParams.forEach(uriBuilder::queryParam);
+            additionalQueryParams.forEach((name, value) -> {
+                if (value instanceof List<?> list) {
+                    uriBuilder.queryParam(name, list.toArray());
+                } else {
+                    uriBuilder.queryParam(name, value);
+                }
+            });
         }
 
         return httpClient

--- a/webserver/src/test/java/io/kestra/webserver/controllers/api/BlueprintControllerTest.java
+++ b/webserver/src/test/java/io/kestra/webserver/controllers/api/BlueprintControllerTest.java
@@ -17,6 +17,7 @@ import io.micronaut.core.type.Argument;
 import io.micronaut.http.HttpRequest;
 import io.micronaut.http.client.HttpClient;
 import io.micronaut.http.client.annotation.Client;
+import io.micronaut.http.client.exceptions.HttpClientResponseException;
 import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
 import jakarta.inject.Inject;
 
@@ -25,6 +26,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.emptyOrNullString;
 import static org.hamcrest.Matchers.not;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @MicronautTest
 @WireMockTest(httpPort = 28181)
@@ -38,8 +40,8 @@ class BlueprintControllerTest {
     private static final String API_BLUEPRINT_GET_SOURCE = API_BLUEPRINT_GET + "/source";
     // GET "/v1/blueprints/kinds/{kind}/{id}/versions/{version}/graph"
     private static final String API_BLUEPRINT_GET_GRAPH = API_BLUEPRINT_GET + "/graph";
-    // GET "/v1/blueprints/kinds/{kind}/{id}/versions/{version}/graph"
-    private static final String API_BLUEPRINT_GET_TAGS = "/v1/blueprints/kinds/%s/versions/%s/tags?q=%s";
+    // GET "/v1/blueprints/kinds/{kind}/versions/{version}/tags"
+    private static final String API_BLUEPRINT_GET_TAGS_PATH = "/v1/blueprints/kinds/%s/versions/%s/tags";
     private static final String KIND_FLOW = BlueprintController.Kind.FLOW.val();
     public static final String API_V1_BLUEPRINT_COMMUNITY_FLOW_PATH = "/api/v1/main/blueprints/community/flow";
 
@@ -52,7 +54,7 @@ class BlueprintControllerTest {
 
     @SuppressWarnings("unchecked")
     @Test
-    void shouldFindSearchBlueprints(WireMockRuntimeInfo wmRuntimeInfo) {
+    void shouldFindSearchBlueprintsTranslatesFiltersToLegacyQueryParams(WireMockRuntimeInfo wmRuntimeInfo) {
         stubFor(
             get(urlMatching("/v1/blueprints.*"))
                 .willReturn(
@@ -63,24 +65,60 @@ class BlueprintControllerTest {
         );
 
         PagedResults<BlueprintController.ApiBlueprintItem> blueprintsWithTotal = client.toBlocking().retrieve(
-            HttpRequest.GET(API_V1_BLUEPRINT_COMMUNITY_FLOW_PATH + "?page=1&size=5&q=someTitle&sort=title:asc&tags=3"),
+            HttpRequest.GET(API_V1_BLUEPRINT_COMMUNITY_FLOW_PATH + "?page=1&size=5&sort=title:asc&filters[q][EQUALS]=someTitle&filters[tags][CONTAINS]=3"),
             Argument.of(PagedResults.class, BlueprintController.ApiBlueprintItem.class)
         );
 
         assertThat(blueprintsWithTotal.getTotal()).isEqualTo(2L);
-        List<BlueprintController.ApiBlueprintItem> blueprints = blueprintsWithTotal.getResults();
-        assertThat(blueprints.size()).isEqualTo(2);
-        assertThat(blueprints.getFirst().getId()).isEqualTo("1");
-        assertThat(blueprints.getFirst().getTitle()).isEqualTo("GCS Trigger");
-        assertThat(blueprints.getFirst().getDescription()).isEqualTo("GCS trigger flow");
-        assertThat(blueprints.getFirst().getPublishedAt()).isEqualTo(Instant.parse("2023-06-01T08:37:34.661Z"));
-        assertThat(blueprints.getFirst().getTags().size()).isEqualTo(2);
-        assertThat(blueprints.getFirst().getTags()).containsExactly("3", "2");
-        assertThat(blueprints.get(1).getId()).isEqualTo("2");
+        assertThat(blueprintsWithTotal.getResults()).hasSize(2);
 
         WireMock wireMock = wmRuntimeInfo.getWireMock();
         wireMock.verifyThat(
-            getRequestedFor(urlEqualTo(String.format(API_BLUEPRINT_SEARCH_KIND_FLOW, KIND_FLOW, versionProvider.getVersion()) + "?page=1&size=5&q=someTitle&sort=title%3Aasc&tags=3&ee=false"))
+            getRequestedFor(urlPathEqualTo(String.format(API_BLUEPRINT_SEARCH_KIND_FLOW, KIND_FLOW, versionProvider.getVersion())))
+                .withQueryParam("q", equalTo("someTitle"))
+                .withQueryParam("tags", equalTo("3"))
+                .withQueryParam("ee", equalTo("false"))
+                .withQueryParam("page", equalTo("1"))
+                .withQueryParam("size", equalTo("5"))
+                .withQueryParam("sort", equalTo("title:asc"))
+        );
+    }
+
+    @Test
+    void shouldRejectUnsupportedOperationForTagsFilter() {
+        HttpClientResponseException e = assertThrows(
+            HttpClientResponseException.class,
+            () -> client.toBlocking().retrieve(
+                HttpRequest.GET(API_V1_BLUEPRINT_COMMUNITY_FLOW_PATH + "?filters[tags][EQUALS]=foo"),
+                Argument.of(PagedResults.class, BlueprintController.ApiBlueprintItem.class)
+            )
+        );
+        assertThat(e.getMessage()).contains("Operation EQUALS is not supported for field TAGS");
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    void shouldFindSearchBlueprintsWithoutFiltersOmitsLegacyParams(WireMockRuntimeInfo wmRuntimeInfo) {
+        stubFor(
+            get(urlMatching("/v1/blueprints.*"))
+                .willReturn(
+                    aResponse()
+                        .withHeader("Content-Type", "application/json")
+                        .withBodyFile("blueprints.json")
+                )
+        );
+
+        client.toBlocking().retrieve(
+            HttpRequest.GET(API_V1_BLUEPRINT_COMMUNITY_FLOW_PATH + "?page=1&size=5"),
+            Argument.of(PagedResults.class, BlueprintController.ApiBlueprintItem.class)
+        );
+
+        WireMock wireMock = wmRuntimeInfo.getWireMock();
+        wireMock.verifyThat(
+            getRequestedFor(urlPathEqualTo(String.format(API_BLUEPRINT_SEARCH_KIND_FLOW, KIND_FLOW, versionProvider.getVersion())))
+                .withQueryParam("ee", equalTo("false"))
+                .withoutQueryParam("q")
+                .withoutQueryParam("tags")
         );
     }
 
@@ -165,7 +203,7 @@ class BlueprintControllerTest {
 
     @SuppressWarnings("unchecked")
     @Test
-    void shouldGetTags(WireMockRuntimeInfo wmRuntimeInfo) {
+    void shouldGetTagsTranslatesFilterToLegacyQueryParam(WireMockRuntimeInfo wmRuntimeInfo) {
         stubFor(
             get(urlMatching("/v1/blueprints/.*/tags.*"))
                 .willReturn(
@@ -176,16 +214,41 @@ class BlueprintControllerTest {
         );
 
         List<BlueprintController.ApiBlueprintTagItem> blueprintTags = client.toBlocking().retrieve(
-            HttpRequest.GET(API_V1_BLUEPRINT_COMMUNITY_FLOW_PATH + "/tags?q=someQuery"),
+            HttpRequest.GET(API_V1_BLUEPRINT_COMMUNITY_FLOW_PATH + "/tags?filters[q][EQUALS]=someQuery"),
             Argument.of(List.class, BlueprintController.ApiBlueprintTagItem.class)
         );
 
         assertThat(blueprintTags.size()).isEqualTo(3);
         assertThat(blueprintTags.getFirst().getId()).isEqualTo("3");
-        assertThat(blueprintTags.getFirst().getName()).isEqualTo("Cloud");
-        assertThat(blueprintTags.getFirst().getPublishedAt()).isEqualTo(Instant.parse("2023-06-01T08:37:10.171Z"));
 
         WireMock wireMock = wmRuntimeInfo.getWireMock();
-        wireMock.verifyThat(getRequestedFor(urlEqualTo(String.format(API_BLUEPRINT_GET_TAGS, KIND_FLOW, versionProvider.getVersion(), "someQuery"))));
+        wireMock.verifyThat(
+            getRequestedFor(urlPathEqualTo(String.format(API_BLUEPRINT_GET_TAGS_PATH, KIND_FLOW, versionProvider.getVersion())))
+                .withQueryParam("q", equalTo("someQuery"))
+        );
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    void shouldGetTagsWithoutFiltersOmitsLegacyQueryParam(WireMockRuntimeInfo wmRuntimeInfo) {
+        stubFor(
+            get(urlMatching("/v1/blueprints/.*/tags.*"))
+                .willReturn(
+                    aResponse()
+                        .withHeader("Content-Type", "application/json")
+                        .withBodyFile("blueprint-tags.json")
+                )
+        );
+
+        client.toBlocking().retrieve(
+            HttpRequest.GET(API_V1_BLUEPRINT_COMMUNITY_FLOW_PATH + "/tags"),
+            Argument.of(List.class, BlueprintController.ApiBlueprintTagItem.class)
+        );
+
+        WireMock wireMock = wmRuntimeInfo.getWireMock();
+        wireMock.verifyThat(
+            getRequestedFor(urlPathEqualTo(String.format(API_BLUEPRINT_GET_TAGS_PATH, KIND_FLOW, versionProvider.getVersion())))
+                .withoutQueryParam("q")
+        );
     }
 }


### PR DESCRIPTION
### ✨ Description

Adds the `BLUEPRINT` resource to `QueryFilter` and migrates every blueprint search/list endpoint (community + internal, search + tags) from the legacy `q` / `tags` scalar query params to the standard `filters[<field>][<OP>]=<value>` format.

Backend changes
- `QueryFilter.Resource.BLUEPRINT` added with supported fields `QUERY` and `TAGS`.
- `AbstractJdbcRepository`: route `TAGS` through a new `tagsCondition` hook (throws by default; dialects opt in).
- OSS `BlueprintController`: accept `@QueryFilterFormat List<QueryFilter> filters`, validate against `Resource.BLUEPRINT`, and translate back to the legacy `q` / `tags` scalar params expected by the
downstream `api.kestra.io` endpoint.
- EE `BlueprintRepositoryInterface.find` / `findWithFlow` / `findTags`: now take `List<QueryFilter>` instead of `(String query, List<String> tags)`.
- `AbstractJdbcBlueprintRepository`: builds conditions via `filter(..., Resource.BLUEPRINT)`; implements `TAGS CONTAINS` (single tag) and `TAGS IN` (OR of tags). Renames per-dialect
`tagsCondition(List<String>)` → `tagsContainAllCondition(List<String>)`.

Frontend changes
- `ui/src/stores/blueprints.ts`: `getBlueprints` / `getBlueprintTags` translate `q` and `tags` into `filters[q][EQUALS]` / `filters[tags][IN]` when hitting the internal `/custom` endpoint. The community API
(`api.kestra.io`) is unchanged.

Added Resource, Field, and Operators Combinations

| Resource  | Field | Operators           |
|-----------|-------|---------------------|
| BLUEPRINT | QUERY | EQUALS, NOT_EQUALS  |
| BLUEPRINT | TAGS  | CONTAINS, IN        |

### 🔗 Related Issue
relates to: https://github.com/kestra-io/kestra-ee/issues/7634

### 🎨 Frontend Checklist

- [x] Code builds without errors (`npm run build`)
- [x] All existing E2E tests pass (`npm run test:e2e`)
- [x] Screenshots or video recordings attached showing the `UI` changes

### 🛠️ Backend Checklist

- [x] Code compiles successfully and passes all checks
- [x] All unit and integration tests pass (`QueryFilterTest`, `BlueprintControllerTest` OSS + EE, `AbstractBlueprintRepositoryTest` incl. new `findWithFilters` parameterized cases)