### PR TITLE
fix(triggers): expose Schedule timezone autocomplete in JSON schema

### DIFF
--- a/core/src/main/java/io/kestra/core/docs/JsonSchemaGenerator.java
+++ b/core/src/main/java/io/kestra/core/docs/JsonSchemaGenerator.java
@@ -3,9 +3,11 @@ package io.kestra.core.docs;
 import java.lang.reflect.*;
 import java.time.Duration;
 import java.time.LocalTime;
+import java.time.ZoneId;
 import java.util.*;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
 import com.fasterxml.classmate.ResolvedType;
@@ -51,6 +53,7 @@ import io.kestra.core.plugins.AdditionalPlugin;
 import io.kestra.core.plugins.PluginRegistry;
 import io.kestra.core.plugins.RegisteredPlugin;
 import io.kestra.core.serializers.JacksonMapper;
+import io.kestra.core.validations.TimezoneId;
 
 import io.micronaut.core.annotation.Nullable;
 import io.swagger.v3.oas.annotations.Hidden;
@@ -75,6 +78,17 @@ public class JsonSchemaGenerator {
 
     private static final ObjectMapper YAML_MAPPER = JacksonMapper.ofYaml().copy()
         .configure(SerializationFeature.WRITE_DURATIONS_AS_TIMESTAMPS, false);
+
+    private static final List<String> AVAILABLE_ZONE_IDS = Stream
+        .concat(ZoneId.getAvailableZoneIds().stream(), ZoneId.SHORT_IDS.keySet().stream())
+        .distinct()
+        .sorted()
+        .toList();
+
+    // Matches the offset-style timezone strings ZoneId.of() accepts but that are not in getAvailableZoneIds():
+    // `Z`, `+HH[:MM[:SS]]`, and `(UTC|GMT|UT)[+-]HH[:MM[:SS]]`.
+    private static final String TIMEZONE_OFFSET_PATTERN =
+        "^(Z|[+-]\\d{2}(:?\\d{2})?(:?\\d{2})?|(UTC|GMT|UT)[+-]\\d{2}(:?\\d{2})?(:?\\d{2})?)$";
 
     private final PluginRegistry pluginRegistry;
 
@@ -468,6 +482,25 @@ public class JsonSchemaGenerator {
             } else if (member.getDeclaredType().isInstanceOf(Data.class)) {
                 memberAttributes.put("$dynamic", false);
             }
+        });
+
+        // On @TimezoneId-annotated fields, expose ZoneId IDs for autocomplete while still accepting offset forms
+        // (e.g. `+02:00`, `GMT-05:00`) that ZoneId.of() parses but that are not in getAvailableZoneIds().
+        builder.forFields().withInstanceAttributeOverride((memberAttributes, member, context) ->
+        {
+            if (member.getAnnotationConsideringFieldAndGetter(TimezoneId.class) == null) {
+                return;
+            }
+            ArrayNode enumNode = context.getGeneratorConfig().createArrayNode();
+            AVAILABLE_ZONE_IDS.forEach(enumNode::add);
+            ObjectNode enumBranch = context.getGeneratorConfig().createObjectNode();
+            enumBranch.set("enum", enumNode);
+            ObjectNode patternBranch = context.getGeneratorConfig().createObjectNode();
+            patternBranch.put("pattern", TIMEZONE_OFFSET_PATTERN);
+            ArrayNode anyOf = context.getGeneratorConfig().createArrayNode();
+            anyOf.add(enumBranch);
+            anyOf.add(patternBranch);
+            memberAttributes.set("anyOf", anyOf);
         });
 
         // Add Plugin annotation special docs

--- a/core/src/main/java/io/kestra/plugin/core/trigger/Schedule.java
+++ b/core/src/main/java/io/kestra/plugin/core/trigger/Schedule.java
@@ -16,6 +16,7 @@ import io.kestra.core.runners.RunContext;
 import io.kestra.core.scheduler.SchedulerClock;
 import io.kestra.core.utils.TruthUtils;
 import io.kestra.core.validations.ScheduleValidation;
+import io.kestra.core.validations.TimezoneId;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Null;
@@ -189,6 +190,7 @@ public class Schedule extends AbstractTrigger implements Schedulable, TriggerOut
     private Boolean withSeconds = false;
 
     @PluginProperty
+    @TimezoneId
     @Builder.Default
     private String timezone = ZoneId.systemDefault().toString();
 

--- a/core/src/test/java/io/kestra/core/docs/JsonSchemaGeneratorTest.java
+++ b/core/src/test/java/io/kestra/core/docs/JsonSchemaGeneratorTest.java
@@ -36,6 +36,9 @@ import io.kestra.plugin.core.dashboard.data.Executions;
 import io.kestra.plugin.core.debug.Return;
 import io.kestra.plugin.core.flow.Dag;
 import io.kestra.plugin.core.log.Log;
+import io.kestra.plugin.core.trigger.Schedule;
+
+import java.time.ZoneId;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.inject.Inject;
@@ -188,6 +191,34 @@ class JsonSchemaGeneratorTest {
                 )
             );
         });
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    void shouldExposeAvailableZoneIdsAndOffsetPatternWhenFieldIsAnnotatedWithTimezoneId() {
+        Map<String, Object> generate = jsonSchemaGenerator.properties(AbstractTrigger.class, Schedule.class);
+
+        Map<String, Object> timezone = ((Map<String, Map<String, Object>>) generate.get("properties")).get("timezone");
+        assertThat(timezone, is(not(nullValue())));
+
+        // The schema is `anyOf: [{enum: [...zoneIds]}, {pattern: ...offset...}]` so YAML editors get autocomplete
+        // from the enum branch while still accepting offset-style timezones (e.g. `+02:00`, `GMT-05:00`).
+        List<Map<String, Object>> anyOf = (List<Map<String, Object>>) timezone.get("anyOf");
+        assertThat(anyOf, is(not(nullValue())));
+        assertThat(anyOf, hasSize(2));
+
+        List<String> enumValues = (List<String>) anyOf.get(0).get("enum");
+        assertThat(enumValues, hasItems("UTC", "Europe/Paris", "Asia/Tokyo", "America/New_York", "EST"));
+        assertThat(enumValues.size(), greaterThanOrEqualTo(ZoneId.getAvailableZoneIds().size()));
+
+        String pattern = (String) anyOf.get(1).get("pattern");
+        assertThat(pattern, is(not(nullValue())));
+        assertThat("+02:00".matches(pattern), is(true));
+        assertThat("-05:30".matches(pattern), is(true));
+        assertThat("Z".matches(pattern), is(true));
+        assertThat("GMT+01:00".matches(pattern), is(true));
+        assertThat("UTC-05:00".matches(pattern), is(true));
+        assertThat("not-a-timezone".matches(pattern), is(false));
     }
 
     @SuppressWarnings("unchecked")


### PR DESCRIPTION
Schedule trigger's `timezone` field had no enum in the generated JSON schema, so Monaco YAML autocomplete only suggested the JVM default timezone (e.g. when running with -Duser.timezone=Asia/Tokyo, only Asia/Tokyo was offered).

Teach JsonSchemaGenerator to recognize the existing @TimezoneId validation annotation and emit
`anyOf: [{enum: getAvailableZoneIds() U SHORT_IDS}, {pattern: offsetRegex}]` so the editor offers full timezone autocomplete while still accepting offset-style values (`+02:00`, `GMT-05:00`, `Z`) that ZoneId.of() parses.

Apply @TimezoneId to Schedule.timezone, which both drives the new schema enum and adds runtime validation for invalid timezone strings.

Refs kestra-ee#7576