### PR TITLE
fix(scheduler): skip realtime triggers in TriggerSchedulerMonitor

### DIFF
--- a/scheduler/src/main/java/io/kestra/scheduler/TriggerSchedulerMonitor.java
+++ b/scheduler/src/main/java/io/kestra/scheduler/TriggerSchedulerMonitor.java
@@ -15,6 +15,7 @@ import io.kestra.core.models.executions.Execution;
 import io.kestra.core.repositories.ExecutionRepositoryInterface;
 import io.kestra.core.scheduler.SchedulerClock;
 import io.kestra.core.scheduler.model.TriggerState;
+import io.kestra.core.scheduler.model.TriggerType;
 import io.kestra.core.scheduler.store.TriggerStateStore;
 import io.kestra.core.utils.Logs;
 
@@ -51,9 +52,14 @@ public class TriggerSchedulerMonitor implements Runnable {
     @Override
     public void run() {
         try {
-            // Retrieve all locked triggers from all corresponding virtual nodes
+            // Retrieve all locked triggers from all corresponding virtual nodes.
+            // Realtime triggers stay locked for their entire processing lifetime and are not bound to a
+            // single execution lifecycle, so they would otherwise be reported as blocked indefinitely.
             ZonedDateTime now = SchedulerClock.now();
-            List<TriggerState> triggers = this.triggerStateStore.findTriggersEligibleForScheduling(now, defaultScheduler.currentVNodesAssignment(), true);
+            List<TriggerState> triggers = this.triggerStateStore.findTriggersEligibleForScheduling(now, defaultScheduler.currentVNodesAssignment(), true)
+                .stream()
+                .filter(state -> !TriggerType.REALTIME.equals(state.getType()))
+                .toList();
             if (CollectionUtils.isEmpty(triggers)) {
                 LOG.debug("No locked triggers. Skip trigger monitoring.");
                 return;

--- a/scheduler/src/test/java/io/kestra/scheduler/TriggerSchedulerMonitorTest.java
+++ b/scheduler/src/test/java/io/kestra/scheduler/TriggerSchedulerMonitorTest.java
@@ -1,0 +1,98 @@
+package io.kestra.scheduler;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Set;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import io.kestra.core.metrics.MetricRegistry;
+import io.kestra.core.models.executions.Execution;
+import io.kestra.core.models.triggers.TriggerId;
+import io.kestra.core.repositories.ExecutionRepositoryInterface;
+import io.kestra.core.scheduler.model.TriggerState;
+import io.kestra.core.scheduler.model.TriggerType;
+import io.kestra.scheduler.utils.InMemoryTriggerStateStore;
+
+import io.micrometer.core.instrument.Meter;
+import io.micrometer.core.instrument.noop.NoopTimer;
+import reactor.core.publisher.Flux;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class TriggerSchedulerMonitorTest {
+
+    private static final int TEST_VNODE = 0;
+
+    private MetricRegistry metricRegistry;
+    private ExecutionRepositoryInterface executionRepository;
+    private InMemoryTriggerStateStore triggerStateStore;
+    private DefaultScheduler defaultScheduler;
+    private TriggerSchedulerMonitor monitor;
+
+    @BeforeEach
+    void setUp() {
+        metricRegistry = mock(MetricRegistry.class);
+        when(metricRegistry.tags(any(TriggerId.class))).thenReturn(new String[0]);
+        when(metricRegistry.timer(anyString(), anyString())).thenReturn(new NoopTimer(mock(Meter.Id.class)));
+
+        executionRepository = mock(ExecutionRepositoryInterface.class);
+        when(executionRepository.findAllByTrigger(any())).thenReturn(Flux.empty());
+
+        triggerStateStore = new InMemoryTriggerStateStore();
+
+        defaultScheduler = mock(DefaultScheduler.class);
+        when(defaultScheduler.currentVNodesAssignment()).thenReturn(Set.of(TEST_VNODE));
+
+        monitor = new TriggerSchedulerMonitor(metricRegistry, executionRepository, triggerStateStore, defaultScheduler);
+    }
+
+    @Test
+    void shouldSkipRealtimeTriggersWhenMonitoring() {
+        // Given a locked realtime trigger that would otherwise be reported as blocked indefinitely.
+        triggerStateStore.save(lockedTriggerOf("realtime-trigger", TriggerType.REALTIME));
+
+        // When the monitor runs
+        monitor.run();
+
+        // Then the realtime trigger is never inspected for executions and produces no metrics.
+        verify(executionRepository, never()).findAllByTrigger(any());
+        verify(metricRegistry, never()).timer(anyString(), anyString());
+    }
+
+    @Test
+    void shouldStillMonitorScheduleAndPollingTriggersWhenRealtimeAreMixedIn() {
+        // Given a mix of locked triggers across types.
+        triggerStateStore.save(lockedTriggerOf("schedule-trigger", TriggerType.SCHEDULE));
+        triggerStateStore.save(lockedTriggerOf("polling-trigger", TriggerType.POLLING));
+        triggerStateStore.save(lockedTriggerOf("realtime-trigger", TriggerType.REALTIME));
+
+        // When the monitor runs
+        monitor.run();
+
+        // Then findAllByTrigger is invoked once per non-realtime trigger.
+        verify(executionRepository, times(2)).findAllByTrigger(any());
+    }
+
+    private static TriggerState lockedTriggerOf(String triggerId, TriggerType type) {
+        return TriggerState.builder()
+            .tenantId("tenant")
+            .namespace("io.kestra.unittest")
+            .flowId("flow")
+            .triggerId(triggerId)
+            .updatedAt(Instant.now().minusSeconds(120))
+            .nextEvaluationDate(Instant.now().minusSeconds(60))
+            .vnode(TEST_VNODE)
+            .locked(true)
+            .type(type)
+            .stopAfter(List.of())
+            .build();
+    }
+}


### PR DESCRIPTION
Realtime triggers stay locked for their entire processing lifetime and are not bound to a single execution lifecycle, so they were reported indefinitely as "No execution found, schedule is blocked".

Filter them out before the execution lookup so the monitor only flags genuinely stuck schedule/polling triggers.

Fixes #15729