### PR TITLE
fix(expression): operators should have a lower precedence than filters

### DIFF
--- a/core/src/main/java/io/kestra/core/runners/pebble/Extension.java
+++ b/core/src/main/java/io/kestra/core/runners/pebble/Extension.java
@@ -74,13 +74,13 @@ public class Extension extends AbstractExtension {
     public List<BinaryOperator> getBinaryOperators() {
         List<BinaryOperator> operators = new ArrayList<>();
 
-        operators.add(new BinaryOperatorImpl("??", 120, NullCoalescingExpression::new, NORMAL, Associativity.LEFT));
-        operators.add(new BinaryOperatorImpl("???", 120, UndefinedCoalescingExpression::new, NORMAL, Associativity.LEFT));
-        operators.add(new BinaryOperatorImpl("isIn", 120, InExpression::new, NORMAL, Associativity.LEFT));
-        operators.add(new BinaryOperatorImpl(">", 120, GreaterThanExpression::new, NORMAL, Associativity.LEFT));
-        operators.add(new BinaryOperatorImpl(">=", 120, GreaterThanEqualsExpression::new, NORMAL, Associativity.LEFT));
-        operators.add(new BinaryOperatorImpl("<", 120, LessThanExpression::new, NORMAL, Associativity.LEFT));
-        operators.add(new BinaryOperatorImpl("<=", 120, LessThanEqualsExpression::new, NORMAL, Associativity.LEFT));
+        operators.add(new BinaryOperatorImpl("??", 30, NullCoalescingExpression::new, NORMAL, Associativity.LEFT));
+        operators.add(new BinaryOperatorImpl("???", 30, UndefinedCoalescingExpression::new, NORMAL, Associativity.LEFT));
+        operators.add(new BinaryOperatorImpl("isIn", 30, InExpression::new, NORMAL, Associativity.LEFT));
+        operators.add(new BinaryOperatorImpl(">", 30, GreaterThanExpression::new, NORMAL, Associativity.LEFT));
+        operators.add(new BinaryOperatorImpl(">=", 30, GreaterThanEqualsExpression::new, NORMAL, Associativity.LEFT));
+        operators.add(new BinaryOperatorImpl("<", 30, LessThanExpression::new, NORMAL, Associativity.LEFT));
+        operators.add(new BinaryOperatorImpl("<=", 30, LessThanEqualsExpression::new, NORMAL, Associativity.LEFT));
 
         return operators;
     }

--- a/core/src/test/java/io/kestra/core/runners/VariableRendererTest.java
+++ b/core/src/test/java/io/kestra/core/runners/VariableRendererTest.java
@@ -158,6 +158,12 @@ class VariableRendererTest {
         assertThat(result).containsKey("key1");
     }
 
+    @Test
+    void shouldRenderMixedFilterAndOperator() throws IllegalVariableEvaluationException {
+        Map<String, Object> variables = Map.of("outputs", Map.of("after", Map.of("value", "300"), "before", Map.of("value", "250")));
+        assertThat(variableRenderer.render("{{ outputs.after.value | number - outputs.before.value | number >= 5 }}", variables)).isEqualTo("true");
+    }
+
     public static class TestVariableRenderer extends VariableRenderer {
 
         public TestVariableRenderer(PebbleEngineFactory pebbleEngineFactory,


### PR DESCRIPTION
Fixes https://github.com/kestra-io/kestra-ee/issues/7802