### PR TITLE
fix(execution): replay to a different revision

### DIFF
--- a/core/src/main/java/io/kestra/core/services/ExecutionService.java
+++ b/core/src/main/java/io/kestra/core/services/ExecutionService.java
@@ -279,12 +279,10 @@ public class ExecutionService {
         return finalTaskRunToRestart;
     }
 
-    public Execution replay(final Execution execution, @Nullable String taskRunId, @Nullable Integer revision) throws Exception {
+    public Execution replay(final Execution execution, final Flow flow, @Nullable String taskRunId, @Nullable Integer revision) throws Exception {
         final String newExecutionId = IdUtils.create();
         List<TaskRun> newTaskRuns = new ArrayList<>();
         if (taskRunId != null) {
-            final Flow flow = flowRepositoryInterface.findByExecutionWithoutAcl(execution);
-
             GraphCluster graphCluster = GraphUtils.of(flow, execution);
 
             Set<String> taskRunToRestart = this.taskRunToRestart(
@@ -380,7 +378,13 @@ public class ExecutionService {
         }
         newExecution = newExecution.withMetadata(execution.getMetadata().nextAttempt()).withLabels(newLabels);
 
-        return revision != null ? newExecution.withFlowRevision(revision) : newExecution;
+        newExecution = revision != null ? applyNewRevision(flow, newExecution) : newExecution;
+        return newExecution;
+    }
+
+    private Execution applyNewRevision(Flow flow, Execution newExecution) {
+        return newExecution.withFlowRevision(flow.getRevision())
+            .withVariables(flow.getVariables());
     }
 
     public Execution changeTaskRunState(final Execution execution, Flow flow, String taskRunId, State.Type newState) throws Exception {

--- a/core/src/test/java/io/kestra/core/runners/ExecutionServiceTest.java
+++ b/core/src/test/java/io/kestra/core/runners/ExecutionServiceTest.java
@@ -6,6 +6,8 @@ import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.TimeoutException;
 
+import io.kestra.core.models.flows.FlowWithSource;
+import io.kestra.core.services.FlowService;
 import org.junit.jupiter.api.Test;
 import org.junitpioneer.jupiter.RetryingTest;
 import org.slf4j.event.Level;
@@ -53,6 +55,9 @@ class ExecutionServiceTest {
 
     @Inject
     FlowRepositoryInterface flowRepository;
+
+    @Inject
+    FlowService flowService;
 
     @Inject
     ExecutionRepositoryInterface executionRepository;
@@ -170,7 +175,8 @@ class ExecutionServiceTest {
         assertThat(execution.getTaskRunList()).hasSize(5);
         assertThat(execution.getState().getCurrent()).isEqualTo(State.Type.SUCCESS);
 
-        Execution restart = executionService.replay(execution, null, null);
+        Flow flow = flowRepository.findByExecution(execution);
+        Execution restart = executionService.replay(execution, flow, null, null);
 
         assertThat(restart.getId()).isNotEqualTo(execution.getId());
         assertThat(restart.getNamespace()).isEqualTo("io.kestra.tests");
@@ -191,7 +197,8 @@ class ExecutionServiceTest {
         assertThat(execution.getTaskRunList()).hasSize(5);
         assertThat(execution.getState().getCurrent()).isEqualTo(State.Type.SUCCESS);
 
-        Execution restart = executionService.replay(execution, execution.getTaskRunList().get(1).getId(), null);
+        Flow flow = flowRepository.findByExecution(execution);
+        Execution restart = executionService.replay(execution, flow, execution.getTaskRunList().get(1).getId(), null);
 
         assertThat(restart.getState().getCurrent()).isEqualTo(State.Type.RESTARTED);
         assertThat(restart.getState().getHistories()).hasSize(4);
@@ -210,7 +217,8 @@ class ExecutionServiceTest {
         assertThat(execution.getTaskRunList()).hasSize(20);
         assertThat(execution.getState().getCurrent()).isEqualTo(State.Type.SUCCESS);
 
-        Execution restart = executionService.replay(execution, execution.findTaskRunByTaskIdAndValue("2_end", List.of()).getId(), null);
+        Flow flow = flowRepository.findByExecution(execution);
+        Execution restart = executionService.replay(execution, flow, execution.findTaskRunByTaskIdAndValue("2_end", List.of()).getId(), null);
 
         assertThat(restart.getState().getCurrent()).isEqualTo(State.Type.RESTARTED);
         assertThat(restart.getState().getHistories()).hasSize(4);
@@ -228,7 +236,8 @@ class ExecutionServiceTest {
         assertThat(execution.getTaskRunList()).hasSize(11);
         assertThat(execution.getState().getCurrent()).isEqualTo(State.Type.SUCCESS);
 
-        Execution restart = executionService.replay(execution, execution.findTaskRunByTaskIdAndValue("1-3-2_par", List.of()).getId(), null);
+        Flow flow = flowRepository.findByExecution(execution);
+        Execution restart = executionService.replay(execution, flow, execution.findTaskRunByTaskIdAndValue("1-3-2_par", List.of()).getId(), null);
 
         assertThat(restart.getState().getCurrent()).isEqualTo(State.Type.RESTARTED);
         assertThat(restart.getState().getHistories()).hasSize(4);
@@ -262,7 +271,8 @@ class ExecutionServiceTest {
                 .toList()
         );
 
-        Execution restart = executionService.replay(executionWithRunningSibling, replayTarget.getId(), null);
+        Flow flow = flowRepository.findByExecution(execution);
+        Execution restart = executionService.replay(executionWithRunningSibling, flow, replayTarget.getId(), null);
 
         TaskRun restartedSibling = restart.findTaskRunByTaskIdAndValue("1-3-3_end", List.of());
         assertThat(restartedSibling.getState().getCurrent()).isEqualTo(State.Type.RESTARTED);
@@ -279,7 +289,8 @@ class ExecutionServiceTest {
         assertThat(execution.getTaskRunList()).hasSize(23);
         assertThat(execution.getState().getCurrent()).isEqualTo(State.Type.SUCCESS);
 
-        Execution restart = executionService.replay(execution, execution.findTaskRunByTaskIdAndValue("1-2_each", List.of("s1")).getId(), null);
+        Flow flow = flowRepository.findByExecution(execution);
+        Execution restart = executionService.replay(execution, flow, execution.findTaskRunByTaskIdAndValue("1-2_each", List.of("s1")).getId(), null);
 
         assertThat(restart.getState().getCurrent()).isEqualTo(State.Type.RESTARTED);
         assertThat(restart.getState().getHistories()).hasSize(4);
@@ -298,7 +309,8 @@ class ExecutionServiceTest {
         assertThat(execution.getTaskRunList()).hasSize(23);
         assertThat(execution.getState().getCurrent()).isEqualTo(State.Type.SUCCESS);
 
-        Execution restart = executionService.replay(execution, execution.findTaskRunByTaskIdAndValue("1-2-1_return", List.of("s1", "a a")).getId(), null);
+        Flow flow = flowRepository.findByExecution(execution);
+        Execution restart = executionService.replay(execution, flow, execution.findTaskRunByTaskIdAndValue("1-2-1_return", List.of("s1", "a a")).getId(), null);
 
         assertThat(restart.getState().getCurrent()).isEqualTo(State.Type.RESTARTED);
         assertThat(restart.getState().getHistories()).hasSize(4);
@@ -318,7 +330,8 @@ class ExecutionServiceTest {
         assertThat(execution.getTaskRunList()).hasSize(3);
         assertThat(execution.getState().getCurrent()).isEqualTo(State.Type.SUCCESS);
 
-        Execution restart = executionService.replay(execution, execution.getTaskRunList().get(2).getId(), null);
+        Flow flow = flowRepository.findByExecution(execution);
+        Execution restart = executionService.replay(execution, flow, execution.getTaskRunList().get(2).getId(), null);
 
         assertThat(restart.getState().getCurrent()).isEqualTo(State.Type.RESTARTED);
         assertThat(restart.getState().getHistories()).hasSize(4);
@@ -338,7 +351,8 @@ class ExecutionServiceTest {
         assertThat(execution.getTaskRunList()).hasSize(11);
         assertThat(execution.getState().getCurrent()).isEqualTo(State.Type.SUCCESS);
 
-        Execution restart = executionService.replay(execution, execution.findTaskRunByTaskIdAndValue("2-1_seq", List.of("value 1")).getId(), null);
+        Flow flow = flowRepository.findByExecution(execution);
+        Execution restart = executionService.replay(execution, flow, execution.findTaskRunByTaskIdAndValue("2-1_seq", List.of("value 1")).getId(), null);
 
         assertThat(restart.getState().getCurrent()).isEqualTo(State.Type.RESTARTED);
         assertThat(restart.getState().getHistories()).hasSize(4);
@@ -349,6 +363,35 @@ class ExecutionServiceTest {
         assertThat(restart.getId()).isNotEqualTo(execution.getId());
         assertThat(restart.getTaskRunList().get(1).getId()).isNotEqualTo(execution.getTaskRunList().get(1).getId());
         assertThat(restart.getLabels()).contains(new Label(Label.REPLAY, "true"));
+    }
+
+    @Test
+    @LoadFlows(value = { "flows/valids/replay-revision.yaml" }, tenantId = TENANT_1)
+    void replayDifferentRevision() throws Exception {
+        Execution execution = runnerUtils.runOne(TENANT_1, "io.kestra.tests", "replay-revision");
+        assertThat(execution.getTaskRunList()).hasSize(1);
+        assertThat(execution.getState().getCurrent()).isEqualTo(State.Type.FAILED);
+
+        // update the flow with a new source
+        FlowWithSource flow = flowRepository.findByExecutionWithSource(execution);
+        String newSource = """
+            id: replay-revision
+            namespace: io.kestra.tests
+
+            variables:
+              greeting: "Hello World"
+
+            tasks:
+              - id: print
+                type: io.kestra.plugin.core.log.Log
+                message: "{{ render(vars.greeting) }}"
+            """;
+        FlowWithSource updated = flowRepository.update(GenericFlow.fromYaml(flow.getTenantId(), newSource), flow);
+
+        Execution restart = executionService.replay(execution, updated, null, updated.getRevision());
+
+        assertThat(restart.getFlowRevision()).isEqualTo(updated.getRevision());
+        assertThat(restart.getVariables()).containsEntry("greeting", "Hello World");
     }
 
     @Test
@@ -514,7 +557,8 @@ class ExecutionServiceTest {
         String sequentialTaskRunId = execution.findTaskRunByTaskIdAndValue("sequential", List.of()).getId();
 
         // When: replay from the parent Sequential task
-        Execution replay = executionService.replay(execution, sequentialTaskRunId, null);
+        Flow flow = flowRepository.findByExecution(execution);
+        Execution replay = executionService.replay(execution, flow, sequentialTaskRunId, null);
 
         // Then: the stale error-handler task run must be removed
         assertThat(replay.getState().getCurrent()).isEqualTo(State.Type.RESTARTED);

--- a/core/src/test/java/io/kestra/core/runners/RestartCaseTest.java
+++ b/core/src/test/java/io/kestra/core/runners/RestartCaseTest.java
@@ -140,7 +140,7 @@ public class RestartCaseTest {
         assertThat(firstExecution.getState().getCurrent()).isEqualTo(State.Type.SUCCESS);
 
         // wait
-        Execution restartedExec = executionService.replay(firstExecution, firstExecution.findTaskRunByTaskIdAndValue("2_end", List.of()).getId(), null);
+        Execution restartedExec = executionService.replay(firstExecution, flow, firstExecution.findTaskRunByTaskIdAndValue("2_end", List.of()).getId(), null);
 
         assertThat(restartedExec.getState().getCurrent()).isEqualTo(State.Type.RESTARTED);
         assertThat(restartedExec.getState().getHistories()).hasSize(4);
@@ -310,7 +310,7 @@ public class RestartCaseTest {
         assertThat(lastRestarted1.getDate().plus(3, ChronoUnit.SECONDS)).isBefore(lastState1.getDate());
 
         // replaying case
-        Execution replayedExecution = executionService.replay(firstExecution, firstExecution.findTaskRunByTaskIdAndValue("loop_test", List.of()).getId(), null);
+        Execution replayedExecution = executionService.replay(firstExecution, flow, firstExecution.findTaskRunByTaskIdAndValue("loop_test", List.of()).getId(), null);
         assertThat(replayedExecution.getState().getCurrent()).isEqualTo(Type.RESTARTED);
         assertThat(replayedExecution.getId()).isNotEqualTo(firstExecution.getId());
 

--- a/core/src/test/resources/flows/valids/replay-revision.yaml
+++ b/core/src/test/resources/flows/valids/replay-revision.yaml
@@ -1,0 +1,10 @@
+id: replay-revision
+namespace: io.kestra.tests
+
+variables:
+  greeting: "{{ this_is_undefined }}"
+
+tasks:
+  - id: print
+    type: io.kestra.plugin.core.log.Log
+    message: "{{ render(vars.greeting) }}"

--- a/jdbc/src/main/java/io/kestra/jdbc/runner/JdbcExecutor.java
+++ b/jdbc/src/main/java/io/kestra/jdbc/runner/JdbcExecutor.java
@@ -1475,7 +1475,7 @@ public class JdbcExecutor implements ExecutorInterface {
                     }
                     // Handle failed flow retries
                     else if (executionDelay.getDelayType().equals(ExecutionDelay.DelayType.RESTART_FAILED_FLOW)) {
-                        Execution newExecution = executionService.replay(executor.getExecution(), null, null);
+                        Execution newExecution = executionService.replay(executor.getExecution(), findFlowOrThrow(executor.getExecution()), null, null);
                         executor = executor.withExecution(newExecution, "retryFailedFlow");
                     }
                     // Handle WaitFor

--- a/webserver/src/main/java/io/kestra/webserver/controllers/api/ExecutionController.java
+++ b/webserver/src/main/java/io/kestra/webserver/controllers/api/ExecutionController.java
@@ -1205,7 +1205,8 @@ public class ExecutionController {
     }
 
     private Execution innerReplay(Execution execution, @Nullable String taskRunId, @Nullable Integer revision, Optional<String> breakpoints) throws Exception {
-        Execution replay = executionService.replay(execution, taskRunId, revision)
+        Flow flow = flowService.getFlowIfExecutableOrThrow(tenantService.resolveTenant(), execution.getNamespace(), execution.getFlowId(), Optional.ofNullable(revision));
+        Execution replay = executionService.replay(execution, flow, taskRunId, revision)
             .withBreakpoints(breakpoints.map(s -> Arrays.stream(s.split(",")).map(Breakpoint::of).toList()).orElse(null));
         executionQueue.emit(replay);
         eventPublisher.publishEvent(new CrudEvent<>(replay, execution, CrudEventType.CREATE));
@@ -2787,7 +2788,7 @@ public class ExecutionController {
 
     /**
      * For override purpose.
-     * 
+     *
      * @param execution
      * @return true if the user has the authorization, false else.
      */


### PR DESCRIPTION
When replaying to a different revision, the revision and variables must be updated.

Fixes #15982
Fixes https://github.com/kestra-io/kestra-ee/issues/7699

Backport of #16109
