### PR TITLE
fix(core): prevent path traversal in inputFiles filename resolution

### DIFF
--- a/core/src/main/java/io/kestra/core/runners/FilesService.java
+++ b/core/src/main/java/io/kestra/core/runners/FilesService.java
@@ -38,7 +38,7 @@ public abstract class FilesService {
         inputFiles
             .forEach(throwBiConsumer((fileName, input) ->
             {
-                var file = new File(runContext.workingDir().path().toString(), runContext.render(fileName, additionalVars));
+                var file = runContext.workingDir().resolve(Path.of(runContext.render(fileName, additionalVars))).toFile();
 
                 if (!file.getParentFile().exists()) {
                     //noinspection ResultOfMethodCallIgnored

--- a/core/src/test/java/io/kestra/core/runners/FilesServiceTest.java
+++ b/core/src/test/java/io/kestra/core/runners/FilesServiceTest.java
@@ -28,6 +28,7 @@ import jakarta.inject.Inject;
 
 import static io.kestra.core.tenant.TenantService.MAIN_TENANT;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @KestraTest(rebuildContext = true)
 @Execution(ExecutionMode.SAME_THREAD)
@@ -43,6 +44,22 @@ class FilesServiceTest {
 
     @Inject
     private NamespaceFactory namespaceFactory;
+
+    @Test
+    void shouldRejectPathTraversalInInputFileNames() {
+        RunContext runContext = runContextFactory.of();
+        assertThatThrownBy(() ->
+            FilesService.inputFiles(runContext, Map.of("../escape.txt", "content"))
+        ).isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void shouldRejectAbsolutePathInInputFileNames() {
+        RunContext runContext = runContextFactory.of();
+        assertThatThrownBy(() ->
+            FilesService.inputFiles(runContext, Map.of("/etc/passwd", "content"))
+        ).isInstanceOf(IllegalArgumentException.class);
+    }
 
     @Test
     void overrideExistingInputFile() throws Exception {


### PR DESCRIPTION
## Summary

- `FilesService.inputFiles()` was constructing `File` objects directly from rendered filenames with `new File(workingDir, renderedName)`, allowing keys like `../escape.txt` to escape the task working directory sandbox
- Routes filename resolution through the existing `workingDir().resolve()` guard, which already rejects paths that escape the base directory (checks both `../` segments and absolute path escape via `resolved.startsWith(baseDir)`)
- Adds two regression tests covering the traversal and absolute-path cases

Fixes [GHSA-q3fw-mvgv-pjr2](https://github.com/kestra-io/kestra/security/advisories/GHSA-q3fw-mvgv-pjr2) (medium severity, CVSS 6.5 — arbitrary file write on worker host).

> **Note:** This advisory is currently in draft. Consider publishing it alongside this PR merge, or coordinating a patch release.

## Test plan

- [x] `shouldRejectPathTraversalInInputFileNames` — `../escape.txt` key throws `IllegalArgumentException`
- [x] `shouldRejectAbsolutePathInInputFileNames` — `/etc/passwd` key throws `IllegalArgumentException`
- [x] All 10 existing `FilesServiceTest` tests still pass