### PR TITLE
chore: fix queue migration script

### DIFF
--- a/jdbc-h2/src/main/java/io/kestra/repository/h2/H2QueueEnabled.java
+++ b/jdbc-h2/src/main/java/io/kestra/repository/h2/H2QueueEnabled.java
@@ -1,0 +1,12 @@
+package io.kestra.repository.h2;
+
+import java.lang.annotation.*;
+
+import io.micronaut.context.annotation.Requires;
+
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ ElementType.PACKAGE, ElementType.TYPE })
+@Requires(property = "kestra.queue.type", pattern = "h2|memory")
+public @interface H2QueueEnabled {
+}

--- a/jdbc-h2/src/main/java/io/kestra/repository/h2/migration/V2_0QueueIndexAndType.java
+++ b/jdbc-h2/src/main/java/io/kestra/repository/h2/migration/V2_0QueueIndexAndType.java
@@ -2,7 +2,7 @@ package io.kestra.repository.h2.migration;
 
 import io.kestra.core.migration.MigrationScript;
 import io.kestra.jdbc.migration.AbstractSQLMigrationScript;
-import io.micronaut.context.annotation.Requires;
+import io.kestra.repository.h2.H2QueueEnabled;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 
@@ -15,7 +15,7 @@ import javax.sql.DataSource;
  * Update the {@code queues} by replacing two indices by a single one and switching the type column to a VARCHAR
  */
 @Singleton
-@Requires(property = "kestra.queue.type", pattern = "h2|memory")
+@H2QueueEnabled
 public class V2_0QueueIndexAndType extends AbstractSQLMigrationScript {
 
     private static final String SCRIPT_ID = "2.0.1-queue-index-and-type";

--- a/jdbc-mysql/src/main/java/io/kestra/repository/mysql/MysqlQueueEnabled.java
+++ b/jdbc-mysql/src/main/java/io/kestra/repository/mysql/MysqlQueueEnabled.java
@@ -1,0 +1,12 @@
+package io.kestra.repository.mysql;
+
+import java.lang.annotation.*;
+
+import io.micronaut.context.annotation.Requires;
+
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ ElementType.PACKAGE, ElementType.TYPE })
+@Requires(property = "kestra.queue.type", value = "mysql")
+public @interface MysqlQueueEnabled {
+}

--- a/jdbc-mysql/src/main/java/io/kestra/repository/mysql/migration/V2_0QueueIndexAndType.java
+++ b/jdbc-mysql/src/main/java/io/kestra/repository/mysql/migration/V2_0QueueIndexAndType.java
@@ -2,7 +2,7 @@ package io.kestra.repository.mysql.migration;
 
 import io.kestra.core.migration.MigrationScript;
 import io.kestra.jdbc.migration.AbstractSQLMigrationScript;
-import io.micronaut.context.annotation.Requires;
+import io.kestra.repository.mysql.MysqlQueueEnabled;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 
@@ -15,7 +15,7 @@ import javax.sql.DataSource;
  * Update the {@code queues} by replacing two indices by a single one and switching the type column to a VARCHAR
  */
 @Singleton
-@Requires(property = "kestra.queue.type", pattern = "mysql|memory")
+@MysqlQueueEnabled
 public class V2_0QueueIndexAndType extends AbstractSQLMigrationScript {
 
     private static final String SCRIPT_ID = "2.0.1-queue-index-and-type";

--- a/jdbc-postgres/src/main/java/io/kestra/repository/postgres/PostgresQueueEnabled.java
+++ b/jdbc-postgres/src/main/java/io/kestra/repository/postgres/PostgresQueueEnabled.java
@@ -1,0 +1,12 @@
+package io.kestra.repository.postgres;
+
+import java.lang.annotation.*;
+
+import io.micronaut.context.annotation.Requires;
+
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ ElementType.PACKAGE, ElementType.TYPE })
+@Requires(property = "kestra.queue.type", value = "postgres")
+public @interface PostgresQueueEnabled {
+}

--- a/jdbc-postgres/src/main/java/io/kestra/repository/postgres/migration/V2_0QueueIndexAndType.java
+++ b/jdbc-postgres/src/main/java/io/kestra/repository/postgres/migration/V2_0QueueIndexAndType.java
@@ -2,7 +2,7 @@ package io.kestra.repository.postgres.migration;
 
 import io.kestra.core.migration.MigrationScript;
 import io.kestra.jdbc.migration.AbstractSQLMigrationScript;
-import io.micronaut.context.annotation.Requires;
+import io.kestra.repository.postgres.PostgresQueueEnabled;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 
@@ -15,7 +15,7 @@ import javax.sql.DataSource;
  * Update the {@code queues} by replacing two indices by a single one and switching the type column to a VARCHAR
  */
 @Singleton
-@Requires(property = "kestra.queue.type", pattern = "postgres|memory")
+@PostgresQueueEnabled
 public class V2_0QueueIndexAndType extends AbstractSQLMigrationScript {
 
     private static final String SCRIPT_ID = "2.0.1-queue-index-and-type";


### PR DESCRIPTION
### ✨ Description

Fixes a bean conflict that caused EE tests using in-memory queues to fail with `Index "IX_TYPE__OFFSET" not found` against an H2 datasource. All three `V2_0QueueIndexAndType` migration classes (`h2`, `mysql`, `postgres`) were gated on `@Requires(property = "kestra.queue.type", pattern = "<dialect>|memory")`, so when tests ran with `kestra.queue.type=memory` all three matched — and the MySQL/Postgres dialect SQL ran against the H2 datasource and blew up.

**This PR:**
- Introduces three new annotations (`@H2QueueEnabled`, `@MysqlQueueEnabled`, `@PostgresQueueEnabled`) alongside the existing `@*RepositoryEnabled` annotations, encapsulating the queue-type discriminator each module already uses on sibling queue migrations.
- Applies them to `V2_0QueueIndexAndType` in `jdbc-h2`, `jdbc-mysql`, and `jdbc-postgres`, removing the `|memory` overlap from the MySQL and Postgres variants and bringing them in line with `V2_0QueueMigration` / `V2_0QueueUpgradeMigration`.

### 🛠️ Backend Checklist

- [x] Code compiles successfully and passes all checks
- [x] All unit and integration tests pass

### 📝 Additional Notes

- **Follow-up suggestion:** Add package-level `@Requires` conditions (via `package-info.java`) to the `io.kestra.repository.{h2,mysql,postgres}.migration` packages so every bean in a dialect-specific migration package is automatically gated to that dialect. That would make this class of bug structurally impossible — a future migration added to the wrong package, or with a too-permissive `@Requires`, still wouldn't activate against the wrong `DataSource`.