### PR TITLE
fix(worker): close race between kill event and callable registration

### DIFF
--- a/worker/src/main/java/io/kestra/worker/processors/AbstractWorkerJobProcessor.java
+++ b/worker/src/main/java/io/kestra/worker/processors/AbstractWorkerJobProcessor.java
@@ -29,6 +29,7 @@ public abstract class AbstractWorkerJobProcessor<T extends WorkerJob> implements
     private final AtomicReference<AbstractWorkerCallable> currentWorkerCallable = new AtomicReference<>();
 
     private final AtomicBoolean stopped = new AtomicBoolean(false);
+    private final AtomicBoolean killRequested = new AtomicBoolean(false);
 
     public AbstractWorkerJobProcessor(String workerGroup,
         MetricRegistry metricRegistry,
@@ -65,6 +66,11 @@ public abstract class AbstractWorkerJobProcessor<T extends WorkerJob> implements
 
     protected io.kestra.core.models.flows.State.Type callJob(AbstractWorkerCallable workerJobCallable) {
         this.currentWorkerCallable.set(workerJobCallable);
+        // Propagate a kill that arrived before currentWorkerCallable was set
+        // (between register() and here, kill() was a no-op).
+        if (killRequested.get()) {
+            workerJobCallable.kill();
+        }
         try {
             return tracer.inCurrentContext(
                 workerJobCallable.getRunContext(),
@@ -91,6 +97,7 @@ public abstract class AbstractWorkerJobProcessor<T extends WorkerJob> implements
 
     @Override
     public void kill() {
+        killRequested.set(true);
         Optional.ofNullable(currentWorkerCallable.get()).ifPresent(AbstractWorkerCallable::kill);
     }
 

--- a/worker/src/main/java/io/kestra/worker/processors/internals/AbstractWorkerCallable.java
+++ b/worker/src/main/java/io/kestra/worker/processors/internals/AbstractWorkerCallable.java
@@ -65,6 +65,11 @@ public abstract class AbstractWorkerCallable implements Callable<State.Type> {
         this.currentThread.setContextClassLoader(classLoader);
 
         try {
+            // Guard against a kill received before currentThread was recorded:
+            // interrupt() was a no-op, so honor the killed flag here.
+            if (this.killed) {
+                return KILLED;
+            }
             return doCall();
         } catch (Throwable e) {
             Exceptions.throwIfFatal(e);


### PR DESCRIPTION
A kill event arriving after `register()` but before `callJob()` sets `currentWorkerCallable` was silently dropped: the killable callback ran on a null callable, and the early `isExecutionKilled` cache check in `runTask` had already returned false. The task then ran to completion.

Track the kill request on the processor so it survives the gap, and honor `killed` at the start of `AbstractWorkerCallable.call()` for the sub-window where `interrupt()` was a no-op (currentThread not yet set).