### PR TITLE
fix(wrapper): handle undefined executionId in API URL construction

### DIFF
--- a/ui/src/components/executions/outputs/Wrapper.vue
+++ b/ui/src/components/executions/outputs/Wrapper.vue
@@ -264,7 +264,7 @@
 
         if (!taskRun) return
 
-        const URL = `${apiUrl()}/executions/${taskRun?.executionId}/actions/eval/${taskRun.id}`
+        const URL = `${apiUrl()}/executions/${taskRun?.executionId ?? execution.value?.id}/actions/eval/${taskRun.id}`
         axios
             .post(URL, expression, {headers: {"Content-type": "text/plain"}})
             .then((response) => {


### PR DESCRIPTION
Fixes https://github.com/kestra-io/kestra-ee/issues/7862

- Improved URL construction for evaluation actions:
[`ui/src/components/executions/outputs/Wrapper.vue`](diffhunk://#diff-6d25f31dbd904816cf2e89866e6c74d45775a39661f6933c46b724a516a8e27bL267-R267): Modified the URL template to use `execution.value?.id` as a fallback when `taskRun.executionId` is undefined, ensuring more robust handling of task execution IDs.