### PR TITLE
fix: Restore text color for default buttons (#15994)

### DIFF
--- a/ui/src/components/inputs/InputsForm.vue
+++ b/ui/src/components/inputs/InputsForm.vue
@@ -40,7 +40,6 @@
                     :label="item"
                     :value="item"
                 >
-                    <KsMarkdown :content="item" />
                 </KsOption>
             </KsSelect>
             <KsRadioGroup
@@ -76,7 +75,6 @@
                     :label="item"
                     :value="item"
                 >
-                    <KsMarkdown :content="item" />
                 </KsOption>
             </KsSelect>
             <KsInput


### PR DESCRIPTION
Fixes #15994

Missing `--el-button-text-color` CSS variable for default buttons in Element Plus overrides.

**File**: ui/src/styles/layout/element-plus-overload.scss