### PR TITLE
fix(core): fix flaky BadFlowableTest.flowableWithParentFail race condition

### DIFF
--- a/core/src/test/java/io/kestra/plugin/core/flow/BadFlowableTest.java
+++ b/core/src/test/java/io/kestra/plugin/core/flow/BadFlowableTest.java
@@ -1,6 +1,7 @@
 package io.kestra.plugin.core.flow;
 
 import io.kestra.core.repositories.ExecutionRepositoryInterface;
+import io.kestra.core.utils.Await;
 import jakarta.inject.Inject;
 import org.junit.jupiter.api.Test;
 
@@ -9,6 +10,9 @@ import io.kestra.core.junit.annotations.KestraTest;
 import io.kestra.core.models.executions.Execution;
 import io.kestra.core.models.flows.State;
 import io.kestra.core.serializers.JacksonMapper;
+
+import java.time.Duration;
+import java.util.concurrent.TimeoutException;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -28,10 +32,17 @@ public class BadFlowableTest {
 
     @Test
     @ExecuteFlow(value = "flows/valids/flowable-with-parent-fail.yaml", tenantId = "flowablewithparentfail")
-    void flowableWithParentFail(Execution execution) {
+    void flowableWithParentFail(Execution execution) throws TimeoutException {
         assertThat(execution.getTaskRunList()).hasSize(1);
         assertThat(execution.getState().getCurrent()).isEqualTo(State.Type.FAILED);
 
+        // The parent terminates when the first sub-execution fails, but concurrent sub-executions
+        // may still be running. Wait for all to reach a terminal state before asserting.
+        Await.until(
+            () -> executionRepository.findLoopSubExecutions(execution.getTenantId(), execution.getId()).stream().allMatch(e -> e.getState().isTerminated()),
+            Duration.ofMillis(100),
+            Duration.ofSeconds(30)
+        );
         var subExecutions = executionRepository.findLoopSubExecutions(execution.getTenantId(), execution.getId());
         assertThat(subExecutions).hasSize(2);
         assertThat(subExecutions).extracting("state.current").containsOnly(State.Type.FAILED);


### PR DESCRIPTION
## Summary

- `flowableWithParentFail` was flaky in CI because it asserted sub-execution states immediately after the parent execution completed
- The flow uses `concurrencyLimit: 0` (parallel loops), so the parent can reach `FAILED` while one sub-execution is still `RUNNING`
- Added `Await.until()` to wait for all sub-executions to reach a terminal state before asserting — the same pattern already used in `FinallyTest`

## Root cause

The assertion on line 37:
```java
assertThat(subExecutions).extracting("state.current").containsOnly(State.Type.FAILED);
```
was seeing `[FAILED, RUNNING]` because `@ExecuteFlow` only waits for the **parent** execution to terminate, not the concurrent loop sub-executions.

## Test plan

- [x] `./gradlew :core:test --tests "io.kestra.plugin.core.flow.BadFlowableTest" --rerun-tasks` passes (2/2 green)
- [x] Matches existing pattern in `FinallyTest.loopWithErrors` / `loopParallelWithErrors`