### PR TITLE
fix(tests): fix two flaky CI tests

### DIFF
--- a/executor/src/test/java/io/kestra/executor/AbstractServiceLivenessCoordinatorTest.java
+++ b/executor/src/test/java/io/kestra/executor/AbstractServiceLivenessCoordinatorTest.java
@@ -129,7 +129,7 @@ public abstract class AbstractServiceLivenessCoordinatorTest {
             }
         });
         workerJobEventQueue.emit(workerGroupKey, WorkerJobEvent.of(workerTask, workerGroupKey));
-        assertThat(runningLatch.await(10, TimeUnit.SECONDS)).isTrue();
+        assertThat(runningLatch.await(30, TimeUnit.SECONDS)).isTrue();
 
         // WHEN - stop first worker. The task is guaranteed to still be running because it is
         // blocked on holdLatch.
@@ -200,7 +200,7 @@ public abstract class AbstractServiceLivenessCoordinatorTest {
         });
 
         workerJobEventQueue.emit(null, WorkerJobEvent.of(workerTask, null));
-        assertThat(runningLatch.await(10, TimeUnit.SECONDS)).isTrue();
+        assertThat(runningLatch.await(30, TimeUnit.SECONDS)).isTrue();
 
         // Task is held by holdLatch, guaranteed still running when we stop the worker.
         worker.close();

--- a/worker/src/test/java/io/kestra/worker/WorkerTest.java
+++ b/worker/src/test/java/io/kestra/worker/WorkerTest.java
@@ -166,10 +166,17 @@ class WorkerTest {
             workerJobEventQueue.emit(null, WorkerJobEvent.of(workerTask(Duration.ofSeconds(60), executionId), null));
             workerJobEventQueue.emit(null, WorkerJobEvent.of(workerTask(Duration.ofSeconds(1)), null));
 
+            // Wait until both jobs are running AND the kill target has transitioned to RUNNING
+            // state. getRunningJobs() is satisfied before the task-run state is updated, so
+            // sending the kill without the second condition races and produces [CREATED, KILLED]
+            // instead of [CREATED, RUNNING, KILLED].
             await()
                 .atMost(Duration.ofSeconds(10))
                 .pollInterval(Duration.ofMillis(100))
-                .until(() -> worker.getRunningJobs().size() >= 2);
+                .until(() -> worker.getRunningJobs().size() >= 2
+                    && results.stream().anyMatch(r ->
+                        r.getTaskRun().getExecutionId().equals(executionId)
+                        && r.getTaskRun().getState().getCurrent() == State.Type.RUNNING));
 
             // When
             ExecutionKilledExecution killedExecution = ExecutionKilledExecution.builder()


### PR DESCRIPTION
## Summary

Fixes two tests that were consistently flaking in CI, identified via Develocity data from the past week (37 and 23 failures respectively).

### `WorkerTest.shouldKillTasksWhenExecutionKillEventReceived`

**Root cause:** `worker.getRunningJobs().size() >= 2` is satisfied as soon as the Worker registers the jobs internally, before the task-run state machine transitions to `RUNNING`. Sending the kill immediately after caused a race: the kill arrived before `RUNNING` was written, producing `[CREATED, KILLED]` instead of `[CREATED, RUNNING, KILLED]`, which broke `assertThat(histories).hasSize(3)`.

**Fix:** Extend the await condition to also require that the kill target has emitted a `RUNNING` state via `workerTaskResultQueue` — the same pattern used in `AbstractServiceLivenessCoordinatorTest`.

### `AbstractServiceLivenessCoordinatorTest.shouldResubmitTaskWhenWorkerIsStopped`

**Root cause:** `runningLatch.await(10, TimeUnit.SECONDS)` timed out on slow CI runners before the worker picked up the task and emitted `RUNNING` state, causing the parameterized test variants `[1]` and `[2]` to fail.

**Fix:** Increase both `runningLatch` timeouts from 10 s to 30 s (consistent with the `resubmitLatch` timeout already set to 30 s in the same test).

## Test plan

- [x] `./gradlew :worker:test --tests "io.kestra.worker.WorkerTest.shouldKillTasksWhenExecutionKillEventReceived" --rerun-tasks` — passes
- [x] `./gradlew :jdbc-h2:test --tests "io.kestra.runner.h2.H2ServiceLivenessCoordinatorTest.shouldResubmitTaskWhenWorkerIsStopped" --rerun-tasks` — both parameterized variants pass