### PR TITLE
fix(tests): backport flaky WorkerTest and liveness coordinator fixes to releases/v1.2.x

### DIFF
--- a/jdbc/src/test/java/io/kestra/jdbc/runner/JdbcServiceLivenessCoordinatorTest.java
+++ b/jdbc/src/test/java/io/kestra/jdbc/runner/JdbcServiceLivenessCoordinatorTest.java
@@ -118,7 +118,7 @@ public abstract class JdbcServiceLivenessCoordinatorTest {
         });
 
         workerJobQueue.emit(workerTask(Duration.ofSeconds(5)));
-        boolean runningLatchAwait = runningLatch.await(5, TimeUnit.SECONDS);
+        boolean runningLatchAwait = runningLatch.await(30, TimeUnit.SECONDS);
         assertThat(runningLatchAwait).isTrue();
         worker.close(); // stop processing task
 
@@ -158,7 +158,7 @@ public abstract class JdbcServiceLivenessCoordinatorTest {
         });
 
         workerJobQueue.emit(workerGroup, workerTask(Duration.ofSeconds(5), workerGroup));
-        boolean runningLatchAwait = runningLatch.await(5, TimeUnit.SECONDS);
+        boolean runningLatchAwait = runningLatch.await(30, TimeUnit.SECONDS);
         assertThat(runningLatchAwait).isTrue();
         worker.close(); // stop processing task
 
@@ -199,7 +199,7 @@ public abstract class JdbcServiceLivenessCoordinatorTest {
         });
 
         workerJobQueue.emit(workerTask);
-        boolean runningLatchAwait = runningLatch.await(10, TimeUnit.SECONDS);
+        boolean runningLatchAwait = runningLatch.await(30, TimeUnit.SECONDS);
         assertThat(runningLatchAwait).isTrue();
         worker.close();
 

--- a/worker/src/test/java/io/kestra/worker/WorkerTest.java
+++ b/worker/src/test/java/io/kestra/worker/WorkerTest.java
@@ -161,7 +161,17 @@ class WorkerTest {
         WorkerTask notKilled = workerTask(2000);
         workerTaskQueue.emit(notKilled);
 
-        Thread.sleep(500);
+        // Wait for the kill target to emit RUNNING state before sending the kill.
+        // Thread.sleep(500) was not sufficient on slow CI runners, causing the kill to
+        // arrive before the RUNNING transition and producing [CREATED, KILLED] instead of
+        // the expected [CREATED, RUNNING, KILLED].
+        Await.until(
+            () -> workerTaskResult.stream().anyMatch(r ->
+                r.getTaskRun().getExecutionId().equals(workerTask.getTaskRun().getExecutionId())
+                && r.getTaskRun().getState().getCurrent() == State.Type.RUNNING),
+            Duration.ofMillis(100),
+            Duration.ofSeconds(30)
+        );
 
         executionKilledQueue.emit(ExecutionKilledExecution.builder().executionId(workerTask.getTaskRun().getExecutionId()).build());
 


### PR DESCRIPTION
## Summary

Backport of flaky test fixes from \`develop\` to this release branch.

- **WorkerTest.killed**: replaced \`Thread.sleep(500)\` with a deterministic \`Await.until()\` that waits for the kill target to emit \`RUNNING\` state via the result queue before sending the kill event. The sleep was insufficient on slow CI runners, causing the kill to race the RUNNING transition and produce \`[CREATED, KILLED]\` instead of \`[CREATED, RUNNING, KILLED]\`.

- **JdbcServiceLivenessCoordinatorTest**: increased \`runningLatch\` timeouts from 5s/10s to 30s to accommodate slow CI runners where the worker takes longer to pick up a task and emit RUNNING state.