### PR TITLE
feat: support AND/OR boolean logic in query filters

### DIFF
--- a/core/src/main/java/io/kestra/core/models/QueryFilter.java
+++ b/core/src/main/java/io/kestra/core/models/QueryFilter.java
@@ -21,16 +21,61 @@ import lombok.Builder;
 public record QueryFilter(
     Field field,
     Op operation,
-    Object value) {
+    Object value,
+    Logical logical,
+    List<QueryFilter> children) {
 
     @JsonCreator
     public QueryFilter(
         @JsonProperty("field") Field field,
         @JsonProperty("operation") Op operation,
-        @JsonProperty("value") Object value) {
+        @JsonProperty("value") Object value,
+        @JsonProperty("logical") Logical logical,
+        @JsonProperty("children") List<QueryFilter> children) {
+        boolean leafShape = field != null && operation != null && logical == null && children == null;
+        boolean nodeShape = logical != null && children != null && !children.isEmpty()
+            && field == null && operation == null && value == null;
+        if (!leafShape && !nodeShape) {
+            throw new IllegalArgumentException(
+                "QueryFilter must be either a leaf (field + operation) or a node (logical + non-empty children), not both or neither");
+        }
         this.field = field;
         this.operation = operation;
         this.value = value;
+        this.logical = logical;
+        this.children = children;
+    }
+
+    public boolean isLeaf() {
+        return logical == null;
+    }
+
+    public boolean isNode() {
+        return logical != null;
+    }
+
+    public enum Logical {
+        AND("and"),
+        OR("or");
+
+        private static final Map<String, Logical> BY_VALUE = Arrays.stream(values())
+            .collect(Collectors.toMap(Logical::value, Function.identity()));
+
+        private final String value;
+
+        Logical(String value) {
+            this.value = value;
+        }
+
+        @JsonValue
+        public String value() {
+            return value;
+        }
+
+        @JsonCreator
+        public static Logical fromString(String value) {
+            return Enums.fromString(value, BY_VALUE, "logical");
+        }
     }
 
     public enum Op {
@@ -59,6 +104,9 @@ public record QueryFilter(
     }
 
     public <T extends Enum<T>> AbstractFilter<T> toDashboardFilterBuilder(T field, Object value) {
+        if (isNode()) {
+            throw new IllegalStateException("toDashboardFilterBuilder is only supported on leaf QueryFilter instances");
+        }
         return switch (this.operation) {
             case EQUALS -> EqualTo.<T> builder().field(field).value(value).build();
             case NOT_EQUALS -> NotEqualTo.<T> builder().field(field).value(value).build();
@@ -633,27 +681,32 @@ public record QueryFilter(
             return;
         }
         List<String> errors = new ArrayList<>();
-        filters.forEach(filter ->
-        {
-            if (!filter.field().supportedOp().contains(filter.operation())) {
-                errors.add(
-                    "Operation %s is not supported for field %s. Supported operations are %s".formatted(
-                        filter.operation(), filter.field().name(),
-                        filter.field().supportedOp().stream().map(Op::name).collect(Collectors.joining(", "))
-                    )
-                );
-            }
-            if (!resource.supportedField().contains(filter.field())) {
-                errors.add(
-                    "Field %s is not supported for resource %s. Supported fields are %s".formatted(
-                        filter.field().name(), resource.name(),
-                        resource.supportedField().stream().map(Field::name).collect(Collectors.joining(", "))
-                    )
-                );
-            }
-        });
+        filters.forEach(filter -> collectValidationErrors(filter, resource, errors));
         if (!errors.isEmpty()) {
             throw new InvalidQueryFiltersException(errors);
+        }
+    }
+
+    private static void collectValidationErrors(QueryFilter filter, Resource resource, List<String> errors) {
+        if (filter.isNode()) {
+            filter.children().forEach(child -> collectValidationErrors(child, resource, errors));
+            return;
+        }
+        if (!filter.field().supportedOp().contains(filter.operation())) {
+            errors.add(
+                "Operation %s is not supported for field %s. Supported operations are %s".formatted(
+                    filter.operation(), filter.field().name(),
+                    filter.field().supportedOp().stream().map(Op::name).collect(Collectors.joining(", "))
+                )
+            );
+        }
+        if (!resource.supportedField().contains(filter.field())) {
+            errors.add(
+                "Field %s is not supported for resource %s. Supported fields are %s".formatted(
+                    filter.field().name(), resource.name(),
+                    resource.supportedField().stream().map(Field::name).collect(Collectors.joining(", "))
+                )
+            );
         }
     }
 

--- a/core/src/main/java/io/kestra/core/secret/SecretService.java
+++ b/core/src/main/java/io/kestra/core/secret/SecretService.java
@@ -59,13 +59,13 @@ public class SecretService<META> {
 
     public ArrayListTotal<META> list(Pageable pageable, String tenantId, List<QueryFilter> filters) throws IOException {
         final Predicate<String> queryPredicate = filters.stream()
-            .filter(filter -> filter.field().equals(QueryFilter.Field.QUERY) && filter.value() != null)
+            .filter(filter -> QueryFilter.Field.QUERY.equals(filter.field()) && filter.value() != null)
             .findFirst()
             .map(filter ->
             {
-                if (filter.operation().equals(QueryFilter.Op.EQUALS)) {
+                if (QueryFilter.Op.EQUALS.equals(filter.operation())) {
                     return (Predicate<String>) s -> Strings.CI.contains(s, (String) filter.value());
-                } else if (filter.operation().equals(QueryFilter.Op.NOT_EQUALS)) {
+                } else if (QueryFilter.Op.NOT_EQUALS.equals(filter.operation())) {
                     return (Predicate<String>) s -> !Strings.CI.contains(s, (String) filter.value());
                 } else {
                     throw new IllegalArgumentException("Unsupported operation for QUERY filter: " + filter.operation());

--- a/core/src/main/java/io/kestra/core/utils/DateUtils.java
+++ b/core/src/main/java/io/kestra/core/utils/DateUtils.java
@@ -142,12 +142,14 @@ public class DateUtils {
     }
 
     private static boolean isEndDateFilter(QueryFilter filter) {
-        return (filter.operation().equals(QueryFilter.Op.LESS_THAN) && filter.field().equals(QueryFilter.Field.END_DATE))
-            || (filter.operation().equals(QueryFilter.Op.LESS_THAN_OR_EQUAL_TO) && filter.field().equals(QueryFilter.Field.END_DATE));
+        return QueryFilter.Field.END_DATE.equals(filter.field())
+            && (QueryFilter.Op.LESS_THAN.equals(filter.operation())
+                || QueryFilter.Op.LESS_THAN_OR_EQUAL_TO.equals(filter.operation()));
     }
 
     private static boolean isStartDateFilter(QueryFilter filter) {
-        return (filter.operation().equals(QueryFilter.Op.GREATER_THAN) && filter.field().equals(QueryFilter.Field.START_DATE))
-            || (filter.operation().equals(QueryFilter.Op.GREATER_THAN_OR_EQUAL_TO) && filter.field().equals(QueryFilter.Field.START_DATE));
+        return QueryFilter.Field.START_DATE.equals(filter.field())
+            && (QueryFilter.Op.GREATER_THAN.equals(filter.operation())
+                || QueryFilter.Op.GREATER_THAN_OR_EQUAL_TO.equals(filter.operation()));
     }
 }

--- a/core/src/test/java/io/kestra/core/models/QueryFilterTest.java
+++ b/core/src/test/java/io/kestra/core/models/QueryFilterTest.java
@@ -11,6 +11,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 
 import io.kestra.core.exceptions.InvalidQueryFiltersException;
 import io.kestra.core.models.QueryFilter.Field;
+import io.kestra.core.models.QueryFilter.Logical;
 import io.kestra.core.models.QueryFilter.Op;
 import io.kestra.core.models.QueryFilter.Resource;
 import io.kestra.core.models.dashboards.filters.AbstractFilter;
@@ -620,6 +621,63 @@ public class QueryFilterTest {
                 )
             )
         ).flatMap(s -> s);
+    }
+
+    @Test
+    void should_allow_leaf_construction() {
+        assertDoesNotThrow(() ->
+            QueryFilter.builder().field(Field.STATE).operation(Op.EQUALS).value("RUNNING").build()
+        );
+    }
+
+    @Test
+    void should_allow_node_construction() {
+        QueryFilter leaf = QueryFilter.builder().field(Field.STATE).operation(Op.EQUALS).value("X").build();
+        assertDoesNotThrow(() ->
+            QueryFilter.builder().logical(Logical.OR).children(List.of(leaf)).build()
+        );
+    }
+
+    @Test
+    void should_reject_mixed_leaf_and_node_shape() {
+        QueryFilter leaf = QueryFilter.builder().field(Field.STATE).operation(Op.EQUALS).value("X").build();
+        assertThrows(IllegalArgumentException.class, () ->
+            QueryFilter.builder()
+                .field(Field.STATE)
+                .operation(Op.EQUALS)
+                .logical(Logical.OR)
+                .children(List.of(leaf))
+                .build()
+        );
+    }
+
+    @Test
+    void should_reject_empty_node_children() {
+        assertThrows(IllegalArgumentException.class, () ->
+            QueryFilter.builder().logical(Logical.OR).children(List.of()).build()
+        );
+    }
+
+    @Test
+    void should_reject_leaf_missing_operation() {
+        assertThrows(IllegalArgumentException.class, () ->
+            QueryFilter.builder().field(Field.STATE).build()
+        );
+    }
+
+    @Test
+    void should_validate_recursively_through_node_children() {
+        QueryFilter invalidLeaf = QueryFilter.builder()
+            .field(Field.START_DATE)
+            .operation(Op.IN)
+            .build();
+        QueryFilter node = QueryFilter.builder()
+            .logical(Logical.OR)
+            .children(List.of(invalidLeaf))
+            .build();
+        assertThrows(InvalidQueryFiltersException.class, () ->
+            QueryFilter.validateQueryFilters(List.of(node), Resource.EXECUTION)
+        );
     }
 
     @Test

--- a/core/src/test/java/io/kestra/core/models/QueryFilterTest.java
+++ b/core/src/test/java/io/kestra/core/models/QueryFilterTest.java
@@ -27,13 +27,13 @@ public class QueryFilterTest {
 
     @ParameterizedTest
     @MethodSource("validOperationFilters")
-    void should_validate_all_operations(QueryFilter filter, Resource resource) {
+    void shouldValidateWhenOperationIsAllowedForField(QueryFilter filter, Resource resource) {
         assertDoesNotThrow(() -> QueryFilter.validateQueryFilters(List.of(filter), resource));
     }
 
     @ParameterizedTest
     @MethodSource("invalidOperationFilters")
-    void should_fail_to_validate_all_operations(QueryFilter filter, Resource resource) {
+    void shouldThrowExceptionWhenOperationIsNotAllowedForField(QueryFilter filter, Resource resource) {
         InvalidQueryFiltersException e = assertThrows(
             InvalidQueryFiltersException.class,
             () -> QueryFilter.validateQueryFilters(List.of(filter), resource)
@@ -624,14 +624,14 @@ public class QueryFilterTest {
     }
 
     @Test
-    void should_allow_leaf_construction() {
+    void shouldBuildLeafWhenFieldAndOperationProvided() {
         assertDoesNotThrow(() ->
             QueryFilter.builder().field(Field.STATE).operation(Op.EQUALS).value("RUNNING").build()
         );
     }
 
     @Test
-    void should_allow_node_construction() {
+    void shouldBuildNodeWhenLogicalAndChildrenProvided() {
         QueryFilter leaf = QueryFilter.builder().field(Field.STATE).operation(Op.EQUALS).value("X").build();
         assertDoesNotThrow(() ->
             QueryFilter.builder().logical(Logical.OR).children(List.of(leaf)).build()
@@ -639,7 +639,7 @@ public class QueryFilterTest {
     }
 
     @Test
-    void should_reject_mixed_leaf_and_node_shape() {
+    void shouldThrowExceptionWhenMixingLeafAndNodeShape() {
         QueryFilter leaf = QueryFilter.builder().field(Field.STATE).operation(Op.EQUALS).value("X").build();
         assertThrows(IllegalArgumentException.class, () ->
             QueryFilter.builder()
@@ -652,21 +652,21 @@ public class QueryFilterTest {
     }
 
     @Test
-    void should_reject_empty_node_children() {
+    void shouldThrowExceptionWhenNodeHasEmptyChildren() {
         assertThrows(IllegalArgumentException.class, () ->
             QueryFilter.builder().logical(Logical.OR).children(List.of()).build()
         );
     }
 
     @Test
-    void should_reject_leaf_missing_operation() {
+    void shouldThrowExceptionWhenLeafMissingOperation() {
         assertThrows(IllegalArgumentException.class, () ->
             QueryFilter.builder().field(Field.STATE).build()
         );
     }
 
     @Test
-    void should_validate_recursively_through_node_children() {
+    void shouldValidateRecursivelyWhenNodeHasChildren() {
         QueryFilter invalidLeaf = QueryFilter.builder()
             .field(Field.START_DATE)
             .operation(Op.IN)
@@ -681,7 +681,7 @@ public class QueryFilterTest {
     }
 
     @Test
-    void toDashboardFilterBuilder_prefix_shouldReturnPrefixFilter() {
+    void shouldReturnPrefixFilterWhenOperationIsPrefix() {
         QueryFilter filter = QueryFilter.builder()
             .field(Field.NAMESPACE)
             .operation(Op.PREFIX)
@@ -700,7 +700,7 @@ public class QueryFilterTest {
     }
 
     @Test
-    void toDashboardFilterBuilder_equals_shouldReturnEqualToFilter() {
+    void shouldReturnEqualToFilterWhenOperationIsEquals() {
         QueryFilter filter = QueryFilter.builder()
             .field(Field.NAMESPACE)
             .operation(Op.EQUALS)
@@ -716,7 +716,7 @@ public class QueryFilterTest {
     }
 
     @Test
-    void toDashboardFilterBuilder_startsWith_shouldReturnStartsWithFilter() {
+    void shouldReturnStartsWithFilterWhenOperationIsStartsWith() {
         QueryFilter filter = QueryFilter.builder()
             .field(Field.NAMESPACE)
             .operation(Op.STARTS_WITH)

--- a/core/src/test/java/io/kestra/core/repositories/AbstractExecutionRepositoryTest.java
+++ b/core/src/test/java/io/kestra/core/repositories/AbstractExecutionRepositoryTest.java
@@ -24,6 +24,7 @@ import io.kestra.core.exceptions.InvalidQueryFiltersException;
 import io.kestra.core.models.Label;
 import io.kestra.core.models.QueryFilter;
 import io.kestra.core.models.QueryFilter.Field;
+import io.kestra.core.models.QueryFilter.Logical;
 import io.kestra.core.models.QueryFilter.Op;
 import io.kestra.core.models.dashboards.AggregationType;
 import io.kestra.core.models.dashboards.ColumnDescriptor;
@@ -266,6 +267,120 @@ public abstract class AbstractExecutionRepositoryTest {
 
             Arguments.of(QueryFilter.builder().field(Field.CHILD_FILTER).value(ChildFilter.CHILD).operation(Op.EQUALS).build(), 29),
             Arguments.of(QueryFilter.builder().field(Field.CHILD_FILTER).value(ChildFilter.CHILD).operation(Op.NOT_EQUALS).build(), 0)
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("complexFilterCombinations")
+    void should_find_all_with_complex_filters(String description, List<QueryFilter> filters, int expectedSize) {
+        var tenant = TestsUtils.randomTenant(this.getClass().getSimpleName());
+        inject(tenant);
+
+        ArrayListTotal<Execution> entries = executionRepository.find(Pageable.UNPAGED, tenant, filters);
+
+        assertThat(entries).as(description).hasSize(expectedSize);
+    }
+
+    static Stream<Arguments> complexFilterCombinations() {
+        QueryFilter runningState = QueryFilter.builder().field(Field.STATE).operation(Op.EQUALS).value(Type.RUNNING).build();
+        QueryFilter failedState = QueryFilter.builder().field(Field.STATE).operation(Op.EQUALS).value(Type.FAILED).build();
+        QueryFilter successState = QueryFilter.builder().field(Field.STATE).operation(Op.EQUALS).value(Type.SUCCESS).build();
+        QueryFilter flowFull = QueryFilter.builder().field(Field.FLOW_ID).operation(Op.EQUALS).value(FLOW).build();
+        QueryFilter flowSecond = QueryFilter.builder().field(Field.FLOW_ID).operation(Op.EQUALS).value("second").build();
+        QueryFilter namespaceEq = QueryFilter.builder().field(Field.NAMESPACE).operation(Op.EQUALS).value(NAMESPACE).build();
+
+        return Stream.of(
+            // OR at root: state = RUNNING OR state = FAILED -> 5 + 3 = 8
+            Arguments.of(
+                "RUNNING OR FAILED",
+                List.of(QueryFilter.builder()
+                    .logical(Logical.OR)
+                    .children(List.of(runningState, failedState))
+                    .build()),
+                8
+            ),
+
+            // (state=RUNNING AND flow=full) OR (state=SUCCESS AND flow=second) -> 5 + 13 = 18
+            Arguments.of(
+                "(RUNNING AND flow=full) OR (SUCCESS AND flow=second)",
+                List.of(QueryFilter.builder()
+                    .logical(Logical.OR)
+                    .children(List.of(
+                        QueryFilter.builder()
+                            .logical(Logical.AND)
+                            .children(List.of(runningState, flowFull))
+                            .build(),
+                        QueryFilter.builder()
+                            .logical(Logical.AND)
+                            .children(List.of(successState, flowSecond))
+                            .build()
+                    ))
+                    .build()),
+                18
+            ),
+
+            // Mixed root: namespace=X (global AND) + (RUNNING OR FAILED) -> 8
+            Arguments.of(
+                "namespace AND (RUNNING OR FAILED)",
+                List.of(
+                    namespaceEq,
+                    QueryFilter.builder()
+                        .logical(Logical.OR)
+                        .children(List.of(runningState, failedState))
+                        .build()
+                ),
+                8
+            ),
+
+            // 3-way OR with mixed leaves and AND children:
+            // (RUNNING AND flow=full) OR FAILED OR (SUCCESS AND flow=second) -> 5 + 3 + 13 = 21
+            Arguments.of(
+                "(RUNNING AND flow=full) OR FAILED OR (SUCCESS AND flow=second)",
+                List.of(QueryFilter.builder()
+                    .logical(Logical.OR)
+                    .children(List.of(
+                        QueryFilter.builder()
+                            .logical(Logical.AND)
+                            .children(List.of(runningState, flowFull))
+                            .build(),
+                        failedState,
+                        QueryFilter.builder()
+                            .logical(Logical.AND)
+                            .children(List.of(successState, flowSecond))
+                            .build()
+                    ))
+                    .build()),
+                21
+            ),
+
+            // Deeply nested OR-in-AND-in-OR: namespace AND ((RUNNING AND flow=full) OR FAILED) -> 5 + 3 = 8
+            Arguments.of(
+                "namespace AND ((RUNNING AND flow=full) OR FAILED)",
+                List.of(
+                    namespaceEq,
+                    QueryFilter.builder()
+                        .logical(Logical.OR)
+                        .children(List.of(
+                            QueryFilter.builder()
+                                .logical(Logical.AND)
+                                .children(List.of(runningState, flowFull))
+                                .build(),
+                            failedState
+                        ))
+                        .build()
+                ),
+                8
+            ),
+
+            // Single-child AND wrapper -> behaves identically to the leaf -> 5
+            Arguments.of(
+                "AND wrapper containing only RUNNING",
+                List.of(QueryFilter.builder()
+                    .logical(Logical.AND)
+                    .children(List.of(runningState))
+                    .build()),
+                5
+            )
         );
     }
 

--- a/jdbc/src/main/java/io/kestra/jdbc/repository/AbstractJdbcExecutionRepository.java
+++ b/jdbc/src/main/java/io/kestra/jdbc/repository/AbstractJdbcExecutionRepository.java
@@ -241,10 +241,16 @@ public abstract class AbstractJdbcExecutionRepository extends AbstractJdbcCrudRe
     }
 
     private Condition computeFindCondition(@Nullable List<QueryFilter> filters, @Nullable DateFilter dateFilter) {
-        boolean hasKindFilter = filters != null && filters.stream()
-            .anyMatch(f -> KIND.value().equalsIgnoreCase(f.field().name()));
+        boolean hasKindFilter = filters != null && filters.stream().anyMatch(AbstractJdbcExecutionRepository::containsLeafForKind);
         Condition dateFilterCondition = buildDateFilterCondition(filters, dateFilter);
         return hasKindFilter ? dateFilterCondition : dateFilterCondition.and(NORMAL_KIND_CONDITION);
+    }
+
+    private static boolean containsLeafForKind(QueryFilter filter) {
+        if (filter.isLeaf()) {
+            return filter.field() == QueryFilter.Field.KIND;
+        }
+        return filter.children().stream().anyMatch(AbstractJdbcExecutionRepository::containsLeafForKind);
     }
 
     private Condition buildDateFilterCondition(@Nullable List<QueryFilter> filters, @Nullable DateFilter dateFilter) {

--- a/jdbc/src/main/java/io/kestra/jdbc/repository/AbstractJdbcRepository.java
+++ b/jdbc/src/main/java/io/kestra/jdbc/repository/AbstractJdbcRepository.java
@@ -246,18 +246,33 @@ public abstract class AbstractJdbcRepository {
         List<QueryFilter> filters,
         String dateColumn,
         Resource resource) {
-        List<Condition> conditions = new ArrayList<>();
-        if (filters != null) {
-            QueryFilter.validateQueryFilters(filters, resource);
-            for (QueryFilter filter : filters) {
-                QueryFilter.Field field = filter.field();
-                QueryFilter.Op operation = filter.operation();
-                Object value = filter.value();
-                conditions.add(getConditionOnField(field, value, operation, dateColumn));
-            }
+        if (filters == null || filters.isEmpty()) {
+            return DSL.noCondition();
         }
-        return conditions.stream()
+        QueryFilter.validateQueryFilters(filters, resource);
+        return andOf(filters, dateColumn);
+    }
+
+    private Condition andOf(List<QueryFilter> items, String dateColumn) {
+        return items.stream()
+            .map(f -> toCondition(f, dateColumn))
             .reduce(DSL.noCondition(), Condition::and);
+    }
+
+    private Condition orOf(List<QueryFilter> items, String dateColumn) {
+        return items.stream()
+            .map(f -> toCondition(f, dateColumn))
+            .reduce(DSL.noCondition(), Condition::or);
+    }
+
+    private Condition toCondition(QueryFilter filter, String dateColumn) {
+        if (filter.isLeaf()) {
+            return getConditionOnField(filter.field(), filter.value(), filter.operation(), dateColumn);
+        }
+        return switch (filter.logical()) {
+            case AND -> andOf(filter.children(), dateColumn);
+            case OR -> orOf(filter.children(), dateColumn);
+        };
     }
 
     /**

--- a/webserver/src/main/java/io/kestra/webserver/configuration/QueryFilterConfiguration.java
+++ b/webserver/src/main/java/io/kestra/webserver/configuration/QueryFilterConfiguration.java
@@ -1,0 +1,90 @@
+package io.kestra.webserver.configuration;
+
+import java.util.Collections;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+
+import io.kestra.core.models.QueryFilter;
+
+import io.micronaut.context.annotation.ConfigurationProperties;
+import jakarta.annotation.PostConstruct;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Configurable safety caps on the shape of {@link QueryFilter} trees produced by the binder.
+ * <p>
+ * Two caps are enforced at parse time:
+ * <ul>
+ *   <li>{@code max-depth} — how deeply nested {@code [and|or][N]} groups may go in a single URL param.</li>
+ *   <li>{@code max-width} — how many children any single tree node may have.</li>
+ * </ul>
+ * Both caps default to a hard floor ({@value #FLOOR_DEPTH}, {@value #FLOOR_WIDTH}). Configured values
+ * below the floor are clamped at startup with a WARN-level log; the bean never exposes a value below the floor.
+ * <p>
+ * Per-Resource overrides are independent of the global value — they may be tighter or looser than the global cap,
+ * but still subject to the same floor.
+ */
+@Slf4j
+@Getter
+@Setter
+@ConfigurationProperties("kestra.query-filter")
+public class QueryFilterConfiguration {
+    public static final int FLOOR_DEPTH = 3;
+    public static final int FLOOR_WIDTH = 20;
+
+    private int maxDepth = FLOOR_DEPTH;
+    private int maxWidth = FLOOR_WIDTH;
+    private Map<String, ResourceLimits> resources = Collections.emptyMap();
+
+    @PostConstruct
+    void clampToFloor() {
+        if (maxDepth < FLOOR_DEPTH) {
+            log.warn("kestra.query-filter.max-depth ({}) is below the floor of {} - clamping to {}",
+                maxDepth, FLOOR_DEPTH, FLOOR_DEPTH);
+            maxDepth = FLOOR_DEPTH;
+        }
+        if (maxWidth < FLOOR_WIDTH) {
+            log.warn("kestra.query-filter.max-width ({}) is below the floor of {} - clamping to {}",
+                maxWidth, FLOOR_WIDTH, FLOOR_WIDTH);
+            maxWidth = FLOOR_WIDTH;
+        }
+        resources.forEach((key, limits) -> {
+            if (limits.getMaxDepth() != null && limits.getMaxDepth() < FLOOR_DEPTH) {
+                log.warn("kestra.query-filter.resources.{}.max-depth ({}) is below the floor of {} - clamping to {}",
+                    key, limits.getMaxDepth(), FLOOR_DEPTH, FLOOR_DEPTH);
+                limits.setMaxDepth(FLOOR_DEPTH);
+            }
+            if (limits.getMaxWidth() != null && limits.getMaxWidth() < FLOOR_WIDTH) {
+                log.warn("kestra.query-filter.resources.{}.max-width ({}) is below the floor of {} - clamping to {}",
+                    key, limits.getMaxWidth(), FLOOR_WIDTH, FLOOR_WIDTH);
+                limits.setMaxWidth(FLOOR_WIDTH);
+            }
+        });
+    }
+
+    public int maxDepthFor(QueryFilter.Resource resource) {
+        return lookup(resource).map(ResourceLimits::getMaxDepth).orElse(maxDepth);
+    }
+
+    public int maxWidthFor(QueryFilter.Resource resource) {
+        return lookup(resource).map(ResourceLimits::getMaxWidth).orElse(maxWidth);
+    }
+
+    private Optional<ResourceLimits> lookup(QueryFilter.Resource resource) {
+        if (resource == null) {
+            return Optional.empty();
+        }
+        return Optional.ofNullable(resources.get(resource.name()))
+            .or(() -> Optional.ofNullable(resources.get(resource.name().toLowerCase())));
+    }
+
+    @Getter
+    @Setter
+    public static class ResourceLimits {
+        private Integer maxDepth;
+        private Integer maxWidth;
+    }
+}

--- a/webserver/src/main/java/io/kestra/webserver/configuration/QueryFilterConfiguration.java
+++ b/webserver/src/main/java/io/kestra/webserver/configuration/QueryFilterConfiguration.java
@@ -1,17 +1,17 @@
 package io.kestra.webserver.configuration;
 
-import java.util.Collections;
-import java.util.Locale;
+import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 
 import io.kestra.core.models.QueryFilter;
 
 import io.micronaut.context.annotation.ConfigurationProperties;
-import jakarta.annotation.PostConstruct;
-import lombok.Getter;
-import lombok.Setter;
-import lombok.extern.slf4j.Slf4j;
+import io.micronaut.core.annotation.Nullable;
+import io.micronaut.core.bind.annotation.Bindable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Configurable safety caps on the shape of {@link QueryFilter} trees produced by the binder.
@@ -22,69 +22,75 @@ import lombok.extern.slf4j.Slf4j;
  *   <li>{@code max-width} — how many children any single tree node may have.</li>
  * </ul>
  * Both caps default to a hard floor ({@value #FLOOR_DEPTH}, {@value #FLOOR_WIDTH}). Configured values
- * below the floor are clamped at startup with a WARN-level log; the bean never exposes a value below the floor.
+ * below the floor are clamped at construction time with a WARN-level log; the bean never exposes a value below the floor.
  * <p>
  * Per-Resource overrides are independent of the global value — they may be tighter or looser than the global cap,
  * but still subject to the same floor.
  */
-@Slf4j
-@Getter
-@Setter
-@ConfigurationProperties("kestra.query-filter")
-public class QueryFilterConfiguration {
+@ConfigurationProperties("kestra.webserver.query-filter")
+public record QueryFilterConfiguration(
+    @Bindable(defaultValue = "3") int maxDepth,
+    @Bindable(defaultValue = "20") int maxWidth,
+    @Nullable Map<String, ResourceLimits> resources
+) {
     public static final int FLOOR_DEPTH = 3;
     public static final int FLOOR_WIDTH = 20;
 
-    private int maxDepth = FLOOR_DEPTH;
-    private int maxWidth = FLOOR_WIDTH;
-    private Map<String, ResourceLimits> resources = Collections.emptyMap();
+    private static final Logger log = LoggerFactory.getLogger(QueryFilterConfiguration.class);
 
-    @PostConstruct
-    void clampToFloor() {
+    public QueryFilterConfiguration {
         if (maxDepth < FLOOR_DEPTH) {
-            log.warn("kestra.query-filter.max-depth ({}) is below the floor of {} - clamping to {}",
+            log.warn("kestra.webserver.query-filter.max-depth ({}) is below the floor of {} - clamping to {}",
                 maxDepth, FLOOR_DEPTH, FLOOR_DEPTH);
             maxDepth = FLOOR_DEPTH;
         }
         if (maxWidth < FLOOR_WIDTH) {
-            log.warn("kestra.query-filter.max-width ({}) is below the floor of {} - clamping to {}",
+            log.warn("kestra.webserver.query-filter.max-width ({}) is below the floor of {} - clamping to {}",
                 maxWidth, FLOOR_WIDTH, FLOOR_WIDTH);
             maxWidth = FLOOR_WIDTH;
         }
+        resources = clampResources(resources);
+    }
+
+    private static Map<String, ResourceLimits> clampResources(Map<String, ResourceLimits> resources) {
+        if (resources == null || resources.isEmpty()) {
+            return Map.of();
+        }
+        Map<String, ResourceLimits> clamped = new HashMap<>(resources.size());
         resources.forEach((key, limits) -> {
-            if (limits.getMaxDepth() != null && limits.getMaxDepth() < FLOOR_DEPTH) {
-                log.warn("kestra.query-filter.resources.{}.max-depth ({}) is below the floor of {} - clamping to {}",
-                    key, limits.getMaxDepth(), FLOOR_DEPTH, FLOOR_DEPTH);
-                limits.setMaxDepth(FLOOR_DEPTH);
+            Integer depth = limits.maxDepth();
+            Integer width = limits.maxWidth();
+            if (depth != null && depth < FLOOR_DEPTH) {
+                log.warn("kestra.webserver.query-filter.resources.{}.max-depth ({}) is below the floor of {} - clamping to {}",
+                    key, depth, FLOOR_DEPTH, FLOOR_DEPTH);
+                depth = FLOOR_DEPTH;
             }
-            if (limits.getMaxWidth() != null && limits.getMaxWidth() < FLOOR_WIDTH) {
-                log.warn("kestra.query-filter.resources.{}.max-width ({}) is below the floor of {} - clamping to {}",
-                    key, limits.getMaxWidth(), FLOOR_WIDTH, FLOOR_WIDTH);
-                limits.setMaxWidth(FLOOR_WIDTH);
+            if (width != null && width < FLOOR_WIDTH) {
+                log.warn("kestra.webserver.query-filter.resources.{}.max-width ({}) is below the floor of {} - clamping to {}",
+                    key, width, FLOOR_WIDTH, FLOOR_WIDTH);
+                width = FLOOR_WIDTH;
             }
+            clamped.put(key, new ResourceLimits(depth, width));
         });
+        return Map.copyOf(clamped);
     }
 
     public int maxDepthFor(QueryFilter.Resource resource) {
-        return lookup(resource).map(ResourceLimits::getMaxDepth).orElse(maxDepth);
+        return lookup(resource).map(ResourceLimits::maxDepth).filter(Objects::nonNull).orElse(maxDepth);
     }
 
     public int maxWidthFor(QueryFilter.Resource resource) {
-        return lookup(resource).map(ResourceLimits::getMaxWidth).orElse(maxWidth);
+        return lookup(resource).map(ResourceLimits::maxWidth).filter(Objects::nonNull).orElse(maxWidth);
     }
 
     private Optional<ResourceLimits> lookup(QueryFilter.Resource resource) {
-        if (resource == null) {
+        if (resource == null || resources == null) {
             return Optional.empty();
         }
         return Optional.ofNullable(resources.get(resource.name()))
             .or(() -> Optional.ofNullable(resources.get(resource.name().toLowerCase())));
     }
 
-    @Getter
-    @Setter
-    public static class ResourceLimits {
-        private Integer maxDepth;
-        private Integer maxWidth;
+    public record ResourceLimits(@Nullable Integer maxDepth, @Nullable Integer maxWidth) {
     }
 }

--- a/webserver/src/main/java/io/kestra/webserver/controllers/api/BlueprintController.java
+++ b/webserver/src/main/java/io/kestra/webserver/controllers/api/BlueprintController.java
@@ -48,13 +48,18 @@ public class BlueprintController {
     @SuppressWarnings("unchecked")
     @ExecuteOn(TaskExecutors.IO)
     @Get("/{kind}")
-    @Operation(tags = { "Blueprints" }, summary = "List all blueprints")
+    @Operation(
+        tags = { "Blueprints" },
+        summary = "List all blueprints",
+        description = "Community blueprints are served by an external API, so complex query filters are not supported. "
+            + "Only top-level `QUERY` and `TAGS` conditions are honored; logical (AND/OR) and nested filter groups are rejected with a 400."
+    )
     public PagedResults<ApiBlueprintItem> searchBlueprints(
         @Parameter(description = "The sort of current page") @Nullable @QueryValue(value = "sort") Optional<String> sort,
         @Parameter(description = "The current page") @QueryValue(defaultValue = "1") @Min(1) Integer page,
         @Parameter(description = "The current page size") @QueryValue(defaultValue = "1") @Min(1) Integer size,
         @Parameter(description = "The blueprint kind") Kind kind,
-        @Parameter(description = "A list of query filters") @Nullable @QueryFilterFormat List<QueryFilter> filters,
+        @Parameter(description = "A list of query filters. Complex filters are not supported: only top-level QUERY and TAGS conditions are honored, and logical (AND/OR) or nested filter groups are rejected.") @Nullable @QueryFilterFormat(QueryFilter.Resource.BLUEPRINT) List<QueryFilter> filters,
         HttpRequest<?> httpRequest) throws URISyntaxException {
 
         Map<String, Object> extraParams = new LinkedHashMap<>(blueprintFilterQueryParams(filters));
@@ -96,10 +101,15 @@ public class BlueprintController {
     @SuppressWarnings("unchecked")
     @ExecuteOn(TaskExecutors.IO)
     @Get("/{kind}/tags")
-    @Operation(tags = { "Blueprint Tags" }, summary = "List blueprint tags matching the filter")
+    @Operation(
+        tags = { "Blueprint Tags" },
+        summary = "List blueprint tags matching the filter",
+        description = "Community blueprints are served by an external API, so complex query filters are not supported. "
+            + "Only top-level `QUERY` and `TAGS` conditions are honored; logical (AND/OR) and nested filter groups are rejected with a 400."
+    )
     public List<ApiBlueprintTagItem> listBlueprintTags(
         @Parameter(description = "The blueprint kind") Kind kind,
-        @Parameter(description = "A list of query filters") @Nullable @QueryFilterFormat List<QueryFilter> filters,
+        @Parameter(description = "A list of query filters. Complex filters are not supported: only top-level QUERY and TAGS conditions are honored, and logical (AND/OR) or nested filter groups are rejected.") @Nullable @QueryFilterFormat(QueryFilter.Resource.BLUEPRINT) List<QueryFilter> filters,
         HttpRequest<?> httpRequest) throws URISyntaxException {
 
         return fastForwardToKestraApi(httpRequest, getApiBasePath(kind) + "/tags", blueprintFilterQueryParams(filters), Argument.of(List.class, ApiBlueprintTagItem.class));
@@ -113,6 +123,7 @@ public class BlueprintController {
      */
     protected static Map<String, Object> blueprintFilterQueryParams(@Nullable List<QueryFilter> filters) {
         QueryFilter.validateQueryFilters(filters, QueryFilter.Resource.BLUEPRINT);
+        rejectUnsupportedComplexFilters(filters);
         String q = parseQueryFiltersForBlueprint(filters);
         List<String> tags = parseTagsFromQueryFiltersForBlueprint(filters);
         Map<String, Object> params = new LinkedHashMap<>();
@@ -123,6 +134,23 @@ public class BlueprintController {
             params.put("tags", tags);
         }
         return params;
+    }
+
+    /**
+     * Blueprints proxy to the community API, which only understands flat {@code q} / {@code tags}
+     * params. Logical (AND/OR) or nested filter groups cannot be translated, so reject them with a
+     * clear error instead of silently dropping them — they would otherwise be ignored by the
+     * top-level field scans in {@link #parseQueryFiltersForBlueprint} / {@link #parseTagsFromQueryFiltersForBlueprint}.
+     */
+    private static void rejectUnsupportedComplexFilters(@Nullable List<QueryFilter> filters) {
+        if (filters == null || filters.isEmpty()) {
+            return;
+        }
+        if (filters.stream().anyMatch(QueryFilter::isNode)) {
+            throw new InvalidQueryFiltersException(
+                "Resource: BLUEPRINT does not support logical (AND/OR) or nested filter groups; only top-level QUERY and TAGS conditions are supported"
+            );
+        }
     }
 
     protected static String parseQueryFiltersForBlueprint(@Nullable List<QueryFilter> queryFilters) {

--- a/webserver/src/main/java/io/kestra/webserver/controllers/api/ExecutionController.java
+++ b/webserver/src/main/java/io/kestra/webserver/controllers/api/ExecutionController.java
@@ -33,6 +33,7 @@ import io.kestra.core.exceptions.InternalException;
 import io.kestra.core.executor.command.*;
 import io.kestra.core.models.Label;
 import io.kestra.core.models.QueryFilter;
+import io.kestra.core.models.QueryFilter.Resource;
 import io.kestra.core.repositories.ExecutionRepositoryInterface.DateFilter;
 import io.kestra.core.models.executions.*;
 import io.kestra.core.models.flows.*;
@@ -243,7 +244,7 @@ public class ExecutionController {
         @Parameter(
             description = "Filters. PHP-style nested query is used - examples: `filters[timeRange][EQUALS]=PT168H`, `filters[scope][EQUALS]=USER`, `filters[state][IN]=FAILED,CANCELLED`, `filters[labels][NOT_EQUALS][foo]=bar`, `filters[namespace][CONTAINS]=test`",
             in = ParameterIn.QUERY
-        ) @QueryFilterFormat List<QueryFilter> filters,
+        ) @QueryFilterFormat(Resource.EXECUTION) List<QueryFilter> filters,
         @Parameter(description = "Which execution date field the time interval is applied to") @Nullable @QueryValue DateFilter dateFilter
 
     ) {
@@ -476,7 +477,7 @@ public class ExecutionController {
         @Parameter(
             description = "Filters. PHP-style nested query is used - examples: `filters[timeRange][EQUALS]=PT168H`, `filters[scope][EQUALS]=USER`, `filters[state][IN]=FAILED,CANCELLED`, `filters[labels][NOT_EQUALS][foo]=bar`, `filters[namespace][CONTAINS]=test`",
             in = ParameterIn.QUERY
-        ) @QueryFilterFormat List<QueryFilter> filters,
+        ) @QueryFilterFormat(Resource.EXECUTION) List<QueryFilter> filters,
 
         @Parameter(description = "Whether to delete non-terminated executions") @Nullable @QueryValue(defaultValue = "false") Boolean includeNonTerminated,
         @Parameter(description = "Whether to delete execution logs", required = false) @QueryValue(defaultValue = "true") Boolean deleteLogs,
@@ -1058,7 +1059,7 @@ public class ExecutionController {
         @Parameter(
             description = "Filters. PHP-style nested query is used - examples: `filters[timeRange][EQUALS]=PT168H`, `filters[scope][EQUALS]=USER`, `filters[state][IN]=FAILED,CANCELLED`, `filters[labels][NOT_EQUALS][foo]=bar`, `filters[namespace][CONTAINS]=test`",
             in = ParameterIn.QUERY
-        ) @QueryFilterFormat List<QueryFilter> filters) throws Exception {
+        ) @QueryFilterFormat(Resource.EXECUTION) List<QueryFilter> filters) throws Exception {
         var ids = getExecutionIds(QueryFilterUtils.replaceTimeRangeWithComputedStartDateFilter(filters));
         return restartExecutionsByIds(ids);
     }
@@ -1320,7 +1321,7 @@ public class ExecutionController {
         @Parameter(
             description = "Filters. PHP-style nested query is used - examples: `filters[timeRange][EQUALS]=PT168H`, `filters[scope][EQUALS]=USER`, `filters[state][IN]=FAILED,CANCELLED`, `filters[labels][NOT_EQUALS][foo]=bar`, `filters[namespace][CONTAINS]=test`",
             in = ParameterIn.QUERY
-        ) @QueryFilterFormat List<QueryFilter> filters,
+        ) @QueryFilterFormat(Resource.EXECUTION) List<QueryFilter> filters,
 
         @Parameter(description = "The new state of the executions") @NotNull @QueryValue State.Type newStatus) throws QueueException {
         var ids = getExecutionIds(QueryFilterUtils.replaceTimeRangeWithComputedStartDateFilter(filters));
@@ -1595,7 +1596,7 @@ public class ExecutionController {
         @Parameter(
             description = "Filters. PHP-style nested query is used - examples: `filters[timeRange][EQUALS]=PT168H`, `filters[scope][EQUALS]=USER`, `filters[state][IN]=FAILED,CANCELLED`, `filters[labels][NOT_EQUALS][foo]=bar`, `filters[namespace][CONTAINS]=test`",
             in = ParameterIn.QUERY
-        ) @QueryFilterFormat List<QueryFilter> filters) throws Exception {
+        ) @QueryFilterFormat(Resource.EXECUTION) List<QueryFilter> filters) throws Exception {
         var ids = getExecutionIds(QueryFilterUtils.replaceTimeRangeWithComputedStartDateFilter(filters));
 
         return resumeExecutionsByIds(ids);
@@ -1680,7 +1681,7 @@ public class ExecutionController {
         @Parameter(
             description = "Filters. PHP-style nested query is used - examples: `filters[timeRange][EQUALS]=PT168H`, `filters[scope][EQUALS]=USER`, `filters[state][IN]=FAILED,CANCELLED`, `filters[labels][NOT_EQUALS][foo]=bar`, `filters[namespace][CONTAINS]=test`",
             in = ParameterIn.QUERY
-        ) @QueryFilterFormat List<QueryFilter> filters) throws Exception {
+        ) @QueryFilterFormat(Resource.EXECUTION) List<QueryFilter> filters) throws Exception {
         var ids = getExecutionIds(QueryFilterUtils.replaceTimeRangeWithComputedStartDateFilter(filters));
 
         return pauseExecutionsByIds(ids);
@@ -1693,7 +1694,7 @@ public class ExecutionController {
         @Parameter(
             description = "Filters. PHP-style nested query is used - examples: `filters[timeRange][EQUALS]=PT168H`, `filters[scope][EQUALS]=USER`, `filters[state][IN]=FAILED,CANCELLED`, `filters[labels][NOT_EQUALS][foo]=bar`, `filters[namespace][CONTAINS]=test`",
             in = ParameterIn.QUERY
-        ) @QueryFilterFormat List<QueryFilter> filters) throws QueueException {
+        ) @QueryFilterFormat(Resource.EXECUTION) List<QueryFilter> filters) throws QueueException {
         var ids = getExecutionIds(QueryFilterUtils.replaceTimeRangeWithComputedStartDateFilter(filters));
 
         return killExecutionsByIds(ids);
@@ -1707,7 +1708,7 @@ public class ExecutionController {
         @Parameter(
             description = "Filters. PHP-style nested query is used - examples: `filters[timeRange][EQUALS]=PT168H`, `filters[scope][EQUALS]=USER`, `filters[state][IN]=FAILED,CANCELLED`, `filters[labels][NOT_EQUALS][foo]=bar`, `filters[namespace][CONTAINS]=test`",
             in = ParameterIn.QUERY
-        ) @QueryFilterFormat List<QueryFilter> filters,
+        ) @QueryFilterFormat(Resource.EXECUTION) List<QueryFilter> filters,
 
         @Parameter(description = "If latest revision should be used") @Nullable @QueryValue(defaultValue = "false") Boolean latestRevision) throws Exception {
         var ids = getExecutionIds(QueryFilterUtils.replaceTimeRangeWithComputedStartDateFilter(filters));
@@ -2018,7 +2019,7 @@ public class ExecutionController {
         @Parameter(
             description = "Filters. PHP-style nested query is used - examples: `filters[timeRange][EQUALS]=PT168H`, `filters[scope][EQUALS]=USER`, `filters[state][IN]=FAILED,CANCELLED`, `filters[labels][NOT_EQUALS][foo]=bar`, `filters[namespace][CONTAINS]=test`",
             in = ParameterIn.QUERY
-        ) @QueryFilterFormat List<QueryFilter> filters,
+        ) @QueryFilterFormat(Resource.EXECUTION) List<QueryFilter> filters,
 
         @RequestBody(description = "The labels to add to the execution") @Body @NotNull @Valid List<Label> setLabels) throws QueueException {
         var ids = getExecutionIds(QueryFilterUtils.replaceTimeRangeWithComputedStartDateFilter(filters));
@@ -2108,7 +2109,7 @@ public class ExecutionController {
         @Parameter(
             description = "Filters. PHP-style nested query is used - examples: `filters[timeRange][EQUALS]=PT168H`, `filters[scope][EQUALS]=USER`, `filters[state][IN]=FAILED,CANCELLED`, `filters[labels][NOT_EQUALS][foo]=bar`, `filters[namespace][CONTAINS]=test`",
             in = ParameterIn.QUERY
-        ) @QueryFilterFormat List<QueryFilter> filters,
+        ) @QueryFilterFormat(Resource.EXECUTION) List<QueryFilter> filters,
 
         @Parameter(description = "The new state of the unqueued executions") @Nullable @QueryValue State.Type newState) throws Exception {
         var ids = getExecutionIds(QueryFilterUtils.replaceTimeRangeWithComputedStartDateFilter(filters));
@@ -2206,7 +2207,7 @@ public class ExecutionController {
         @Parameter(
             description = "Filters. PHP-style nested query is used - examples: `filters[timeRange][EQUALS]=PT168H`, `filters[scope][EQUALS]=USER`, `filters[state][IN]=FAILED,CANCELLED`, `filters[labels][NOT_EQUALS][foo]=bar`, `filters[namespace][CONTAINS]=test`",
             in = ParameterIn.QUERY
-        ) @QueryFilterFormat List<QueryFilter> filters) throws Exception {
+        ) @QueryFilterFormat(Resource.EXECUTION) List<QueryFilter> filters) throws Exception {
         var ids = getExecutionIds(QueryFilterUtils.replaceTimeRangeWithComputedStartDateFilter(filters));
 
         return forceRunByIds(ids);
@@ -2391,7 +2392,7 @@ public class ExecutionController {
         @Parameter(
             description = "Filters. PHP-style nested query is used - examples: `filters[timeRange][EQUALS]=PT168H`, `filters[scope][EQUALS]=USER`, `filters[state][IN]=FAILED,CANCELLED`, `filters[labels][NOT_EQUALS][foo]=bar`, `filters[namespace][CONTAINS]=test`",
             in = ParameterIn.QUERY
-        ) @QueryFilterFormat List<QueryFilter> filters) {
+        ) @QueryFilterFormat(Resource.EXECUTION) List<QueryFilter> filters) {
 
         return HttpResponse.ok(
             CSVUtils.toCSVFlux(

--- a/webserver/src/main/java/io/kestra/webserver/controllers/api/ExecutionController.java
+++ b/webserver/src/main/java/io/kestra/webserver/controllers/api/ExecutionController.java
@@ -266,7 +266,7 @@ public class ExecutionController {
     public List<String> findDistinctFieldValues(
         @Parameter(description = "The field whose distinct values to return. Must be a field supported by the EXECUTION resource.") @QueryValue QueryFilter.Field field,
         @Parameter(description = "Additional filters to narrow the distinct values. PHP-style nested query is used - examples: `filters[flowId][CONTAINS]=test`, `filters[state][IN]=FAILED,WARNING`", in = ParameterIn.QUERY)
-            @QueryFilterFormat List<QueryFilter> filters,
+            @QueryFilterFormat(Resource.EXECUTION) List<QueryFilter> filters,
         @Parameter(description = "Maximum number of distinct values to return.") @QueryValue(defaultValue = "100") @Min(1) int size) {
         if (!QueryFilter.Resource.EXECUTION.supportedField().contains(field)) {
             throw new HttpStatusException(

--- a/webserver/src/main/java/io/kestra/webserver/controllers/api/FlowController.java
+++ b/webserver/src/main/java/io/kestra/webserver/controllers/api/FlowController.java
@@ -16,6 +16,7 @@ import io.kestra.core.exceptions.IllegalVariableEvaluationException;
 import io.kestra.core.exceptions.InternalException;
 import io.kestra.core.models.HasSource;
 import io.kestra.core.models.QueryFilter;
+import io.kestra.core.models.QueryFilter.Resource;
 import io.kestra.core.models.SearchResult;
 import io.kestra.core.models.flows.*;
 import io.kestra.core.models.hierarchies.FlowGraph;
@@ -232,7 +233,7 @@ public class FlowController {
             }
         ) @Nullable @QueryValue List<String> sort,
         @Parameter(description = "Filters. PHP-style nested query is used - examples: `filters[labels][NOT_EQUALS][foo]=bar`, `filters[namespace][CONTAINS]=test`", in = ParameterIn.QUERY)
-        @QueryFilterFormat List<QueryFilter> filters
+        @QueryFilterFormat(Resource.FLOW) List<QueryFilter> filters
     ) throws HttpStatusException {
         return PagedResults.of(
             flowRepository.find(
@@ -674,7 +675,7 @@ public class FlowController {
     )
     public HttpResponse<byte[]> exportFlowsByQuery(
         @Parameter(description = "Filters. PHP-style nested query is used - examples: `filters[labels][NOT_EQUALS][foo]=bar`, `filters[namespace][CONTAINS]=test`", in = ParameterIn.QUERY)
-        @QueryFilterFormat List<QueryFilter> filters) throws IOException {
+        @QueryFilterFormat(Resource.FLOW) List<QueryFilter> filters) throws IOException {
         var flows = flowRepository.findWithSource(Pageable.UNPAGED, tenantService.resolveTenant(), filters);
         var bytes = HasSource.asZipFile(flows, flow -> flow.getNamespace() + "-" + flow.getId() + ".yml");
 
@@ -704,7 +705,7 @@ public class FlowController {
     )
     public HttpResponse<BulkResponse> deleteFlowsByQuery(
         @Parameter(description = "Filters. PHP-style nested query is used - examples: `filters[labels][NOT_EQUALS][foo]=bar`, `filters[namespace][CONTAINS]=test`", in = ParameterIn.QUERY)
-        @QueryFilterFormat List<QueryFilter> filters) throws QueueException {
+        @QueryFilterFormat(Resource.FLOW) List<QueryFilter> filters) throws QueueException {
         List<Flow> list = flowRepository
             .findWithSource(Pageable.UNPAGED, tenantService.resolveTenant(), filters)
             .stream()
@@ -739,7 +740,7 @@ public class FlowController {
     )
     public HttpResponse<BulkResponse> disableFlowsByQuery(
         @Parameter(description = "Filters. PHP-style nested query is used - examples: `filters[labels][NOT_EQUALS][foo]=bar`, `filters[namespace][CONTAINS]=test`", in = ParameterIn.QUERY)
-        @QueryFilterFormat List<QueryFilter> filters) throws Exception {
+        @QueryFilterFormat(Resource.FLOW) List<QueryFilter> filters) throws Exception {
         return HttpResponse.ok(BulkResponse.builder().count(setFlowsDisableByQuery(filters, true).size()).build());
     }
 
@@ -763,7 +764,7 @@ public class FlowController {
     )
     public HttpResponse<BulkResponse> enableFlowsByQuery(
         @Parameter(description = "Filters. PHP-style nested query is used - examples: `filters[labels][NOT_EQUALS][foo]=bar`, `filters[namespace][CONTAINS]=test`", in = ParameterIn.QUERY)
-        @QueryFilterFormat List<QueryFilter> filters) throws Exception {
+        @QueryFilterFormat(Resource.FLOW) List<QueryFilter> filters) throws Exception {
         return HttpResponse.ok(BulkResponse.builder().count(setFlowsDisableByQuery(filters, false).size()).build());
     }
 
@@ -822,7 +823,7 @@ public class FlowController {
     @SuppressWarnings("unchecked")
     public MutableHttpResponse<Flux<String>> exportFlows(
         @Parameter(description = "Filters. PHP-style nested query is used - examples: `filters[labels][NOT_EQUALS][foo]=bar`, `filters[namespace][CONTAINS]=test`", in = ParameterIn.QUERY)
-        @QueryFilterFormat List<QueryFilter> filters) {
+        @QueryFilterFormat(Resource.FLOW) List<QueryFilter> filters) {
         return HttpResponse.ok(
             CSVUtils.toCSVFlux(
                 flowRepository.findAsync(this.tenantService.resolveTenant(), filters)

--- a/webserver/src/main/java/io/kestra/webserver/controllers/api/KVController.java
+++ b/webserver/src/main/java/io/kestra/webserver/controllers/api/KVController.java
@@ -10,6 +10,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 
 import io.kestra.core.exceptions.ResourceExpiredException;
 import io.kestra.core.models.QueryFilter;
+import io.kestra.core.models.QueryFilter.Resource;
 import io.kestra.core.models.kv.KVType;
 import io.kestra.core.models.namespaces.NamespaceInterface;
 import io.kestra.core.serializers.JacksonMapper;
@@ -62,7 +63,7 @@ public class KVController {
                 @ExampleObject(name = "Sort by description in descending order", value = "description:desc"),
             }
         ) @Nullable @QueryValue(value = "sort") List<String> sort,
-        @Parameter(description = "Filters. PHP-style nested query is used - example: `filters[namespace][IN]=company.team`") @QueryFilterFormat List<QueryFilter> filters) throws IOException {
+        @Parameter(description = "Filters. PHP-style nested query is used - example: `filters[namespace][IN]=company.team`") @QueryFilterFormat(Resource.KV_METADATA) List<QueryFilter> filters) throws IOException {
         return PagedResults.of(kvStoreService.list(PageableUtils.from(page, size, sort, this::sortMapper), tenantService.resolveTenant(), null, filters));
     }
 

--- a/webserver/src/main/java/io/kestra/webserver/controllers/api/LogController.java
+++ b/webserver/src/main/java/io/kestra/webserver/controllers/api/LogController.java
@@ -10,6 +10,7 @@ import io.kestra.webserver.utils.QueryFilterUtils;
 import org.slf4j.event.Level;
 
 import io.kestra.core.models.QueryFilter;
+import io.kestra.core.models.QueryFilter.Resource;
 import io.kestra.core.models.executions.LogEntry;
 import io.kestra.core.repositories.LogRepositoryInterface;
 import io.kestra.core.runners.FollowLogEvent;
@@ -73,7 +74,7 @@ public class LogController {
         @Parameter(
             description = "Filters. PHP-style nested query is used - examples: `filters[flowId][EQUALS]=hello-world`, `filters[timeRange][EQUALS]=P7D`, `filters[level][EQUALS]=DEBUG`",
             in = ParameterIn.QUERY
-        ) @Nullable @QueryFilterFormat List<QueryFilter> filters)
+        ) @Nullable @QueryFilterFormat(Resource.LOG) List<QueryFilter> filters)
         throws HttpStatusException {
         return PagedResults.of(
             logRepository.find(

--- a/webserver/src/main/java/io/kestra/webserver/controllers/api/NamespaceController.java
+++ b/webserver/src/main/java/io/kestra/webserver/controllers/api/NamespaceController.java
@@ -140,7 +140,7 @@ public class NamespaceController<N extends Namespace> {
         @Parameter(description = "The current page size") @QueryValue(defaultValue = "10") @Min(1) int size,
         @Parameter(description = "The sort of current page") @Nullable @QueryValue List<String> sort,
         @Parameter(description = "Return only existing namespace") @QueryValue(value = "existing", defaultValue = "false") Boolean existingOnly,
-        @Parameter(description = "A list of query filters") @Nullable @QueryFilterFormat List<QueryFilter> filters) throws HttpStatusException {
+        @Parameter(description = "A list of query filters") @Nullable @QueryFilterFormat(QueryFilter.Resource.NAMESPACE) List<QueryFilter> filters) throws HttpStatusException {
         List<Namespace> allNamespaces = Stream.concat(
                 flowRepository.findDistinctNamespace(tenantService.resolveTenant()).stream(),
                 Stream.of(systemFlowsConfiguration.namespace())

--- a/webserver/src/main/java/io/kestra/webserver/controllers/api/SecretController.java
+++ b/webserver/src/main/java/io/kestra/webserver/controllers/api/SecretController.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 import java.util.List;
 
 import io.kestra.core.models.QueryFilter;
+import io.kestra.core.models.QueryFilter.Resource;
 import io.kestra.core.repositories.ArrayListTotal;
 import io.kestra.core.secret.SecretService;
 import io.kestra.core.tenant.TenantService;
@@ -46,7 +47,7 @@ public class SecretController<META extends ApiSecretMeta> {
         @Parameter(description = "The current page") @QueryValue(value = "page", defaultValue = "1") int page,
         @Parameter(description = "The current page size") @QueryValue(value = "size", defaultValue = "10") int size,
         @Parameter(description = "The sort of current page") @Nullable @QueryValue(value = "sort") List<String> sort,
-        @Parameter(description = "Filters") @QueryFilterFormat List<QueryFilter> filters) throws IllegalArgumentException, IOException {
+        @Parameter(description = "Filters") @QueryFilterFormat(Resource.SECRET_METADATA) List<QueryFilter> filters) throws IllegalArgumentException, IOException {
         final String tenantId = this.tenantService.resolveTenant();
 
         Pageable pageable = PageableUtils.from(page, size, sort, this::sortMapper);

--- a/webserver/src/main/java/io/kestra/webserver/controllers/api/TriggerController.java
+++ b/webserver/src/main/java/io/kestra/webserver/controllers/api/TriggerController.java
@@ -12,6 +12,7 @@ import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 
 import io.kestra.core.models.Label;
 import io.kestra.core.models.QueryFilter;
+import io.kestra.core.models.QueryFilter.Resource;
 import io.kestra.core.models.flows.Flow;
 import io.kestra.core.models.triggers.AbstractTrigger;
 import io.kestra.core.models.triggers.TriggerId;
@@ -100,7 +101,7 @@ public class TriggerController {
             }
         ) @Nullable @QueryValue List<String> sort,
         @Parameter(description = "Filters. PHP-style nested query is used - examples: `filters[flowId][EQUALS]=hello-world`, `filters[namespace][CONTAINS]=test`", in = ParameterIn.QUERY)
-        @QueryFilterFormat List<QueryFilter> filters) throws HttpStatusException {
+        @QueryFilterFormat(Resource.TRIGGER) List<QueryFilter> filters) throws HttpStatusException {
         ArrayListTotal<TriggerState> triggerContexts = triggerRepository.find(
             PageableUtils.from(page, size, sort, triggerRepository.sortMapping()),
             tenantService.resolveTenant(),
@@ -182,7 +183,7 @@ public class TriggerController {
     @ApiResponse(responseCode = "202", description = "Accepted", content = { @Content(schema = @Schema(implementation = ApiAsyncOperationResponse.class)) })
     public MutableHttpResponse<ApiAsyncOperationResponse> unlockTriggersByQuery(
         @Parameter(description = "Filters. PHP-style nested query is used - examples: `filters[flowId][EQUALS]=hello-world`, `filters[namespace][CONTAINS]=test`", in = ParameterIn.QUERY)
-        @QueryFilterFormat List<QueryFilter> filters) {
+        @QueryFilterFormat(Resource.TRIGGER) List<QueryFilter> filters) {
         return HttpResponse.accepted().body(
             triggerStateService.unlockAllMatching(tenantService.resolveTenant(), filters)
         );
@@ -252,7 +253,7 @@ public class TriggerController {
     @ApiResponse(responseCode = "202", description = "Accepted", content = { @Content(schema = @Schema(implementation = ApiAsyncOperationResponse.class)) })
     public MutableHttpResponse<ApiAsyncOperationResponse> pauseBackfillByQuery(
         @Parameter(description = "Filters. PHP-style nested query is used - examples: `filters[flowId][EQUALS]=hello-world`, `filters[namespace][CONTAINS]=test`", in = ParameterIn.QUERY)
-        @QueryFilterFormat List<QueryFilter> filters) {
+        @QueryFilterFormat(Resource.TRIGGER) List<QueryFilter> filters) {
         return HttpResponse.accepted().body(
             triggerStateService.pauseAllBackfillsMatching(tenantService.resolveTenant(), filters)
         );
@@ -286,7 +287,7 @@ public class TriggerController {
     @ApiResponse(responseCode = "202", description = "Accepted", content = { @Content(schema = @Schema(implementation = ApiAsyncOperationResponse.class)) })
     public MutableHttpResponse<ApiAsyncOperationResponse> unpauseBackfillByQuery(
         @Parameter(description = "Filters. PHP-style nested query is used - examples: `filters[flowId][EQUALS]=hello-world`, `filters[namespace][CONTAINS]=test`", in = ParameterIn.QUERY)
-        @QueryFilterFormat List<QueryFilter> filters) {
+        @QueryFilterFormat(Resource.TRIGGER) List<QueryFilter> filters) {
         return HttpResponse.accepted().body(
             triggerStateService.resumeAllBackfillsMatching(tenantService.resolveTenant(), filters)
         );
@@ -320,7 +321,7 @@ public class TriggerController {
     @ApiResponse(responseCode = "202", description = "Accepted", content = { @Content(schema = @Schema(implementation = ApiAsyncOperationResponse.class)) })
     public MutableHttpResponse<ApiAsyncOperationResponse> deleteBackfillByQuery(
         @Parameter(description = "Filters. PHP-style nested query is used - examples: `filters[flowId][EQUALS]=hello-world`, `filters[namespace][CONTAINS]=test`", in = ParameterIn.QUERY)
-        @QueryFilterFormat List<QueryFilter> filters) {
+        @QueryFilterFormat(Resource.TRIGGER) List<QueryFilter> filters) {
         return HttpResponse.accepted().body(
             triggerStateService.deleteAllBackfillsMatching(tenantService.resolveTenant(), filters)
         );
@@ -357,7 +358,7 @@ public class TriggerController {
     @ApiResponse(responseCode = "202", description = "Accepted", content = { @Content(schema = @Schema(implementation = ApiAsyncOperationResponse.class)) })
     public MutableHttpResponse<ApiAsyncOperationResponse> deleteTriggersByQuery(
         @Parameter(description = "Filters. PHP-style nested query is used - examples: `filters[flowId][EQUALS]=hello-world`, `filters[namespace][CONTAINS]=test`")
-        @QueryFilterFormat List<QueryFilter> filters) {
+        @QueryFilterFormat(Resource.TRIGGER) List<QueryFilter> filters) {
         return HttpResponse.accepted().body(
             triggerStateService.deleteAllMatching(tenantService.resolveTenant(), filters)
         );
@@ -394,7 +395,7 @@ public class TriggerController {
     @ApiResponse(responseCode = "202", description = "Accepted", content = { @Content(schema = @Schema(implementation = ApiAsyncOperationResponse.class)) })
     public MutableHttpResponse<ApiAsyncOperationResponse> disabledTriggersByQuery(
         @Parameter(description = "Filters. PHP-style nested query is used - examples: `filters[flowId][EQUALS]=hello-world`, `filters[namespace][CONTAINS]=test`", in = ParameterIn.QUERY)
-        @QueryFilterFormat List<QueryFilter> filters,
+        @QueryFilterFormat(Resource.TRIGGER) List<QueryFilter> filters,
         @Parameter(description = "The disabled state") @QueryValue(defaultValue = "true") Boolean disabled) {
         return HttpResponse.accepted().body(
             triggerStateService.toggleAllMatching(tenantService.resolveTenant(), filters, disabled)
@@ -408,7 +409,7 @@ public class TriggerController {
     @SuppressWarnings("unchecked")
     public MutableHttpResponse<Flux<String>> exportTriggers(
         @Parameter(description = "Filters. PHP-style nested query is used - examples: `filters[flowId][EQUALS]=hello-world`, `filters[namespace][CONTAINS]=test`", in = ParameterIn.QUERY)
-        @QueryFilterFormat List<QueryFilter> filters) {
+        @QueryFilterFormat(Resource.TRIGGER) List<QueryFilter> filters) {
 
         return HttpResponse.ok(
             CSVUtils.toCSVFlux(

--- a/webserver/src/main/java/io/kestra/webserver/converters/QueryFilterFormat.java
+++ b/webserver/src/main/java/io/kestra/webserver/converters/QueryFilterFormat.java
@@ -2,11 +2,19 @@ package io.kestra.webserver.converters;
 
 import java.lang.annotation.*;
 
+import io.kestra.core.models.QueryFilter;
+
 import io.micronaut.core.bind.annotation.Bindable;
 
+/**
+ * Marks a controller parameter as receiving filters in the LHS-bracket query format.
+ * The {@link #value()} identifies which {@link QueryFilter.Resource} is being filtered, so the binder can
+ * resolve per-Resource depth/width caps from {@code kestra.query-filter.resources.<NAME>}.
+ */
 @Bindable
 @Target({ ElementType.PARAMETER })
 @Retention(RetentionPolicy.RUNTIME)
 @Inherited
 public @interface QueryFilterFormat {
+    QueryFilter.Resource value();
 }

--- a/webserver/src/main/java/io/kestra/webserver/converters/QueryFilterFormat.java
+++ b/webserver/src/main/java/io/kestra/webserver/converters/QueryFilterFormat.java
@@ -9,7 +9,7 @@ import io.micronaut.core.bind.annotation.Bindable;
 /**
  * Marks a controller parameter as receiving filters in the LHS-bracket query format.
  * The {@link #value()} identifies which {@link QueryFilter.Resource} is being filtered, so the binder can
- * resolve per-Resource depth/width caps from {@code kestra.query-filter.resources.<NAME>}.
+ * resolve per-Resource depth/width caps from {@code kestra.webserver.query-filter.resources.<NAME>}.
  */
 @Bindable
 @Target({ ElementType.PARAMETER })

--- a/webserver/src/main/java/io/kestra/webserver/converters/QueryFilterFormatBinder.java
+++ b/webserver/src/main/java/io/kestra/webserver/converters/QueryFilterFormatBinder.java
@@ -9,50 +9,87 @@ import java.util.regex.Pattern;
 import com.google.common.annotations.VisibleForTesting;
 
 import io.kestra.core.models.QueryFilter;
+import io.kestra.core.models.QueryFilter.Logical;
+import io.kestra.webserver.configuration.QueryFilterConfiguration;
 import io.kestra.webserver.utils.RequestUtils;
 
 import io.micronaut.core.convert.ArgumentConversionContext;
 import io.micronaut.http.HttpRequest;
 import io.micronaut.http.bind.binders.AnnotatedRequestArgumentBinder;
+import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 
 @Singleton
 public class QueryFilterFormatBinder implements AnnotatedRequestArgumentBinder<QueryFilterFormat, List<QueryFilter>> {
 
-    private static final Pattern FILTER_PATTERN = Pattern.compile("filters\\[(.*?)]\\[(.*?)](?:\\[(.+)])?");
+    private static final Pattern FILTER_PATTERN = Pattern.compile(
+        "filters((?:\\[(?i:and|or)]\\[\\d+])*)\\[([^\\]]*)]\\[([^\\]]*)](?:\\[(.+)])?"
+    );
 
+    private static final Pattern PREFIX_SEG = Pattern.compile(
+        "\\[(?i:(and|or))]\\[(\\d+)]"
+    );
+
+    private final QueryFilterConfiguration configuration;
+
+    @Inject
+    public QueryFilterFormatBinder(QueryFilterConfiguration configuration) {
+        this.configuration = Objects.requireNonNull(configuration);
+    }
+
+    /** Test-only convenience using permissive caps for parser-correctness tests. */
     @VisibleForTesting
     static List<QueryFilter> getQueryFilters(Map<String, List<String>> queryParams) {
-        List<QueryFilter> filters = new ArrayList<>();
-        Map<QueryFilter.Op, Map<String, String>> labelsByOperation = new HashMap<>(); // Group labels by operation
+        return getQueryFilters(queryParams, Integer.MAX_VALUE, Integer.MAX_VALUE);
+    }
 
+    @VisibleForTesting
+    static List<QueryFilter> getQueryFilters(Map<String, List<String>> queryParams, int maxDepth, int maxWidth) {
+        NodeBuilder root = new NodeBuilder();
         for (Map.Entry<String, List<String>> entry : queryParams.entrySet()) {
             String key = entry.getKey();
             if (!key.startsWith("filters[")) {
                 continue;
             }
 
-            Matcher matcher = FILTER_PATTERN.matcher(key);
-
-            if (matcher.matches()) {
-                parseFilters(entry.getValue(), matcher, filters, labelsByOperation);
+            Matcher m = FILTER_PATTERN.matcher(key);
+            if (!m.matches()) {
+                continue;
             }
+
+            String prefixChain = m.group(1);
+            String fieldStr = m.group(2);
+            String operationStr = m.group(3);
+            String nestedKey = m.group(4);
+
+            NodeBuilder target = descend(root, prefixChain, maxDepth);
+            target.addLeaf(fieldStr, operationStr, nestedKey, entry.getValue());
         }
-        // Add a QueryFilter for each operation's labels
-        labelsByOperation.forEach((operation, labels) ->
-        {
-            if (!labels.isEmpty()) {
-                filters.add(
-                    QueryFilter.builder()
-                        .field(QueryFilter.Field.LABELS)
-                        .operation(operation)
-                        .value(labels)
-                        .build()
-                );
-            }
-        });
-
+        List<QueryFilter> filters = root.build(maxWidth);
+        if (filters.size() > maxWidth) {
+            throw new IllegalArgumentException(
+                "QueryFilter root width (" + filters.size() + ") exceeds maximum of " + maxWidth);
+        }
         return filters;
+    }
+
+    private static NodeBuilder descend(NodeBuilder root, String prefixChain, int maxDepth) {
+        if (prefixChain == null || prefixChain.isEmpty()) {
+            return root;
+        }
+        NodeBuilder current = root;
+        Matcher pm = PREFIX_SEG.matcher(prefixChain);
+        int depth = 0;
+        while (pm.find()) {
+            if (++depth > maxDepth) {
+                throw new IllegalArgumentException(
+                    "QueryFilter nesting depth exceeds maximum of " + maxDepth);
+            }
+            Logical lg = Logical.valueOf(pm.group(1).toUpperCase(Locale.ROOT));
+            int idx = Integer.parseInt(pm.group(2));
+            current = current.descend(lg, idx);
+        }
+        return current;
     }
 
     @Override
@@ -62,35 +99,18 @@ public class QueryFilterFormatBinder implements AnnotatedRequestArgumentBinder<Q
 
     @Override
     public BindingResult<List<QueryFilter>> bind(ArgumentConversionContext<List<QueryFilter>> context, HttpRequest<?> source) {
+        QueryFilter.Resource resource = context.getAnnotationMetadata()
+            .enumValue(QueryFilterFormat.class, QueryFilter.Resource.class)
+            .orElseThrow(() -> new IllegalStateException(
+                "@QueryFilterFormat requires a QueryFilter.Resource value"));
+
+        int maxDepth = configuration.maxDepthFor(resource);
+        int maxWidth = configuration.maxWidthFor(resource);
+
         Map<String, List<String>> queryParams = source.getParameters().asMap();
-        List<QueryFilter> filters = getQueryFilters(queryParams);
+        List<QueryFilter> filters = getQueryFilters(queryParams, maxDepth, maxWidth);
 
         return () -> Optional.of(filters);
-    }
-
-    private static void parseFilters(List<String> values, Matcher matcher, List<QueryFilter> filters, Map<QueryFilter.Op, Map<String, String>> labelsByOperation) {
-        String fieldStr = matcher.group(1);
-        String operationStr = matcher.group(2);
-        String nestedKey = matcher.group(3); // Extract nested key if present
-
-        QueryFilter.Field field = QueryFilter.Field.fromString(fieldStr);
-        QueryFilter.Op operation = QueryFilter.Op.valueOf(operationStr);
-
-        // For labels: Add the key-value to the appropriate operation's map
-        if (field == QueryFilter.Field.LABELS && nestedKey != null) {
-            labelsByOperation.computeIfAbsent(operation, k -> new HashMap<>()).put(nestedKey, values.getFirst());
-        } else {
-            List<Object> parsedValues = nestedKey != null ? List.of(Map.of(nestedKey, values.getFirst())) : parseValues(values, field, operation);
-            filters.addAll(
-                parsedValues.stream().map(
-                    parsedValue -> QueryFilter.builder()
-                        .field(field)
-                        .operation(operation)
-                        .value(parsedValue)
-                        .build()
-                ).toList()
-            );
-        }
     }
 
     private static List<Object> parseValues(List<String> values, QueryFilter.Field field, QueryFilter.Op operation) {
@@ -100,5 +120,96 @@ public class QueryFilterFormatBinder implements AnnotatedRequestArgumentBinder<Q
                 ? Arrays.asList(URLDecoder.decode(value, StandardCharsets.UTF_8).replaceAll("[\\[\\]]", "").split(","))
                 : value;
         }).toList();
+    }
+
+    private static void checkWidth(int count, int maxWidth) {
+        if (count > maxWidth) {
+            throw new IllegalArgumentException(
+                "QueryFilter node width (" + count + ") exceeds maximum of " + maxWidth);
+        }
+    }
+
+    /**
+     * Builds one logical position in the filter tree. Each URL param either lands a leaf here
+     * (via {@link #addLeaf}) or descends into a sub-node identified by ({@link Logical}, index).
+     * {@link #build(int)} flattens the position into the QueryFilter list that the parent should
+     * receive — direct leaves first, then merged labels, then one wrapper per (logical, slots) group.
+     */
+    private static class NodeBuilder {
+        private final List<QueryFilter> directLeaves = new ArrayList<>();
+        private final Map<QueryFilter.Op, Map<String, String>> labelsByOp = new EnumMap<>(QueryFilter.Op.class);
+        private final Map<Logical, Map<Integer, NodeBuilder>> subNodes = new EnumMap<>(Logical.class);
+
+        NodeBuilder descend(Logical lg, int idx) {
+            return subNodes
+                .computeIfAbsent(lg, k -> new TreeMap<>())
+                .computeIfAbsent(idx, k -> new NodeBuilder());
+        }
+
+        void addLeaf(String fieldStr, String operationStr, String nestedKey, List<String> values) {
+            QueryFilter.Field field = QueryFilter.Field.fromString(fieldStr);
+            QueryFilter.Op op = QueryFilter.Op.valueOf(operationStr);
+
+            if (field == QueryFilter.Field.LABELS && nestedKey != null) {
+                labelsByOp.computeIfAbsent(op, k -> new HashMap<>()).put(nestedKey, values.getFirst());
+                return;
+            }
+
+            List<Object> parsedValues = nestedKey != null
+                ? List.of(Map.of(nestedKey, values.getFirst()))
+                : parseValues(values, field, op);
+
+            for (Object v : parsedValues) {
+                directLeaves.add(QueryFilter.builder()
+                    .field(field)
+                    .operation(op)
+                    .value(v)
+                    .build());
+            }
+        }
+
+        List<QueryFilter> build(int maxWidth) {
+            List<QueryFilter> items = new ArrayList<>(directLeaves);
+            labelsByOp.forEach((op, kvMap) -> {
+                if (!kvMap.isEmpty()) {
+                    items.add(QueryFilter.builder()
+                        .field(QueryFilter.Field.LABELS)
+                        .operation(op)
+                        .value(kvMap)
+                        .build());
+                }
+            });
+            subNodes.forEach((lg, slots) -> {
+                List<QueryFilter> branches = new ArrayList<>();
+                for (NodeBuilder slot : slots.values()) {
+                    List<QueryFilter> slotItems = slot.build(maxWidth);
+                    if (slotItems.isEmpty()) {
+                        continue;
+                    }
+                    if (slotItems.size() == 1) {
+                        branches.add(slotItems.getFirst());
+                    } else {
+                        checkWidth(slotItems.size(), maxWidth);
+                        branches.add(QueryFilter.builder()
+                            .logical(Logical.AND)
+                            .children(slotItems)
+                            .build());
+                    }
+                }
+                if (branches.isEmpty()) {
+                    return;
+                }
+                if (branches.size() == 1 && lg == Logical.AND) {
+                    items.add(branches.getFirst());
+                } else {
+                    checkWidth(branches.size(), maxWidth);
+                    items.add(QueryFilter.builder()
+                        .logical(lg)
+                        .children(branches)
+                        .build());
+                }
+            });
+            return items;
+        }
     }
 }

--- a/webserver/src/main/java/io/kestra/webserver/utils/Searchable.java
+++ b/webserver/src/main/java/io/kestra/webserver/utils/Searchable.java
@@ -76,17 +76,7 @@ public final class Searchable<T> {
 
         if (queryFilters != null && !queryFilters.isEmpty()) {
             results = results.filter(item ->
-                queryFilters.stream().allMatch(queryFilter -> {
-                    BiPredicate<T, Object> predicate = queryFilterPredicateMap.get(
-                        new QueryFilterPredicateKey(queryFilter.field(), queryFilter.operation())
-                    );
-                    if (predicate == null) {
-                        throw new InvalidQueryFiltersException(
-                            "Unsupported operation for " + queryFilter.field() + ": " + queryFilter.operation()
-                        );
-                    }
-                    return predicate.test(item, queryFilter.value());
-                })
+                queryFilters.stream().allMatch(queryFilter -> evaluate(item, queryFilter))
             );
         }
 
@@ -118,6 +108,25 @@ public final class Searchable<T> {
         }
 
         return ArrayListTotal.of(pageable, results.toList());
+    }
+
+    private boolean evaluate(T item, QueryFilter queryFilter) {
+        if (queryFilter.isNode()) {
+            Stream<QueryFilter> children = queryFilter.children().stream();
+            return switch (queryFilter.logical()) {
+                case AND -> children.allMatch(child -> evaluate(item, child));
+                case OR  -> children.anyMatch(child -> evaluate(item, child));
+            };
+        }
+        BiPredicate<T, Object> predicate = queryFilterPredicateMap.get(
+            new QueryFilterPredicateKey(queryFilter.field(), queryFilter.operation())
+        );
+        if (predicate == null) {
+            throw new InvalidQueryFiltersException(
+                "Unsupported operation for " + queryFilter.field() + ": " + queryFilter.operation()
+            );
+        }
+        return predicate.test(item, queryFilter.value());
     }
 
     public static <T> Builder<T> builder() {

--- a/webserver/src/test/java/io/kestra/webserver/configuration/QueryFilterConfigurationTest.java
+++ b/webserver/src/test/java/io/kestra/webserver/configuration/QueryFilterConfigurationTest.java
@@ -1,0 +1,90 @@
+package io.kestra.webserver.configuration;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import io.kestra.core.models.QueryFilter;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class QueryFilterConfigurationTest {
+
+    @Test
+    void shouldClampGlobalsBelowFloor() {
+        // GIVEN
+        QueryFilterConfiguration config = new QueryFilterConfiguration();
+        config.setMaxDepth(1);
+        config.setMaxWidth(5);
+
+        // WHEN
+        config.clampToFloor();
+
+        // THEN — clamped up to the floor
+        assertEquals(QueryFilterConfiguration.FLOOR_DEPTH, config.getMaxDepth());
+        assertEquals(QueryFilterConfiguration.FLOOR_WIDTH, config.getMaxWidth());
+    }
+
+    @Test
+    void shouldNotClampGlobalsAtOrAboveFloor() {
+        // GIVEN
+        QueryFilterConfiguration config = new QueryFilterConfiguration();
+        config.setMaxDepth(10);
+        config.setMaxWidth(100);
+
+        // WHEN
+        config.clampToFloor();
+
+        // THEN — unchanged
+        assertEquals(10, config.getMaxDepth());
+        assertEquals(100, config.getMaxWidth());
+    }
+
+    @Test
+    void shouldClampPerResourceBelowFloor() {
+        // GIVEN
+        QueryFilterConfiguration.ResourceLimits limits = new QueryFilterConfiguration.ResourceLimits();
+        limits.setMaxDepth(1);
+        limits.setMaxWidth(5);
+
+        QueryFilterConfiguration config = new QueryFilterConfiguration();
+        config.setResources(Map.of("EXECUTION", limits));
+
+        // WHEN
+        config.clampToFloor();
+
+        // THEN — per-Resource values clamped to floor
+        assertEquals(QueryFilterConfiguration.FLOOR_DEPTH, limits.getMaxDepth());
+        assertEquals(QueryFilterConfiguration.FLOOR_WIDTH, limits.getMaxWidth());
+    }
+
+    @Test
+    void shouldResolvePerResourceOverridesAndFallBackToGlobal() {
+        // GIVEN — EXECUTION overrides depth only; width unset
+        QueryFilterConfiguration.ResourceLimits limits = new QueryFilterConfiguration.ResourceLimits();
+        limits.setMaxDepth(8);
+
+        QueryFilterConfiguration config = new QueryFilterConfiguration();
+        config.setMaxDepth(3);
+        config.setMaxWidth(20);
+        config.setResources(Map.of("EXECUTION", limits));
+
+        // WHEN / THEN
+        assertEquals(8, config.maxDepthFor(QueryFilter.Resource.EXECUTION));
+        assertEquals(20, config.maxWidthFor(QueryFilter.Resource.EXECUTION),
+            "width unset on EXECUTION override should fall back to global");
+        assertEquals(3, config.maxDepthFor(QueryFilter.Resource.FLOW),
+            "FLOW has no override — should use global");
+        assertEquals(20, config.maxWidthFor(QueryFilter.Resource.FLOW));
+    }
+
+    @Test
+    void shouldFallBackToGlobalWhenResourceIsNull() {
+        QueryFilterConfiguration config = new QueryFilterConfiguration();
+        config.setMaxDepth(5);
+        config.setMaxWidth(50);
+
+        assertEquals(5, config.maxDepthFor(null));
+        assertEquals(50, config.maxWidthFor(null));
+    }
+}

--- a/webserver/src/test/java/io/kestra/webserver/configuration/QueryFilterConfigurationTest.java
+++ b/webserver/src/test/java/io/kestra/webserver/configuration/QueryFilterConfigurationTest.java
@@ -12,62 +12,48 @@ class QueryFilterConfigurationTest {
 
     @Test
     void shouldClampGlobalsBelowFloor() {
-        // GIVEN
-        QueryFilterConfiguration config = new QueryFilterConfiguration();
-        config.setMaxDepth(1);
-        config.setMaxWidth(5);
-
-        // WHEN
-        config.clampToFloor();
+        // GIVEN / WHEN — clamping happens in the canonical constructor
+        QueryFilterConfiguration config = new QueryFilterConfiguration(1, 5, null);
 
         // THEN — clamped up to the floor
-        assertEquals(QueryFilterConfiguration.FLOOR_DEPTH, config.getMaxDepth());
-        assertEquals(QueryFilterConfiguration.FLOOR_WIDTH, config.getMaxWidth());
+        assertEquals(QueryFilterConfiguration.FLOOR_DEPTH, config.maxDepth());
+        assertEquals(QueryFilterConfiguration.FLOOR_WIDTH, config.maxWidth());
     }
 
     @Test
     void shouldNotClampGlobalsAtOrAboveFloor() {
-        // GIVEN
-        QueryFilterConfiguration config = new QueryFilterConfiguration();
-        config.setMaxDepth(10);
-        config.setMaxWidth(100);
-
-        // WHEN
-        config.clampToFloor();
+        // GIVEN / WHEN
+        QueryFilterConfiguration config = new QueryFilterConfiguration(10, 100, null);
 
         // THEN — unchanged
-        assertEquals(10, config.getMaxDepth());
-        assertEquals(100, config.getMaxWidth());
+        assertEquals(10, config.maxDepth());
+        assertEquals(100, config.maxWidth());
     }
 
     @Test
     void shouldClampPerResourceBelowFloor() {
         // GIVEN
-        QueryFilterConfiguration.ResourceLimits limits = new QueryFilterConfiguration.ResourceLimits();
-        limits.setMaxDepth(1);
-        limits.setMaxWidth(5);
-
-        QueryFilterConfiguration config = new QueryFilterConfiguration();
-        config.setResources(Map.of("EXECUTION", limits));
+        QueryFilterConfiguration.ResourceLimits limits = new QueryFilterConfiguration.ResourceLimits(1, 5);
 
         // WHEN
-        config.clampToFloor();
+        QueryFilterConfiguration config = new QueryFilterConfiguration(
+            QueryFilterConfiguration.FLOOR_DEPTH,
+            QueryFilterConfiguration.FLOOR_WIDTH,
+            Map.of("EXECUTION", limits)
+        );
 
         // THEN — per-Resource values clamped to floor
-        assertEquals(QueryFilterConfiguration.FLOOR_DEPTH, limits.getMaxDepth());
-        assertEquals(QueryFilterConfiguration.FLOOR_WIDTH, limits.getMaxWidth());
+        QueryFilterConfiguration.ResourceLimits clamped = config.resources().get("EXECUTION");
+        assertEquals(QueryFilterConfiguration.FLOOR_DEPTH, clamped.maxDepth());
+        assertEquals(QueryFilterConfiguration.FLOOR_WIDTH, clamped.maxWidth());
     }
 
     @Test
     void shouldResolvePerResourceOverridesAndFallBackToGlobal() {
         // GIVEN — EXECUTION overrides depth only; width unset
-        QueryFilterConfiguration.ResourceLimits limits = new QueryFilterConfiguration.ResourceLimits();
-        limits.setMaxDepth(8);
+        QueryFilterConfiguration.ResourceLimits limits = new QueryFilterConfiguration.ResourceLimits(8, null);
 
-        QueryFilterConfiguration config = new QueryFilterConfiguration();
-        config.setMaxDepth(3);
-        config.setMaxWidth(20);
-        config.setResources(Map.of("EXECUTION", limits));
+        QueryFilterConfiguration config = new QueryFilterConfiguration(3, 20, Map.of("EXECUTION", limits));
 
         // WHEN / THEN
         assertEquals(8, config.maxDepthFor(QueryFilter.Resource.EXECUTION));
@@ -80,9 +66,7 @@ class QueryFilterConfigurationTest {
 
     @Test
     void shouldFallBackToGlobalWhenResourceIsNull() {
-        QueryFilterConfiguration config = new QueryFilterConfiguration();
-        config.setMaxDepth(5);
-        config.setMaxWidth(50);
+        QueryFilterConfiguration config = new QueryFilterConfiguration(5, 50, null);
 
         assertEquals(5, config.maxDepthFor(null));
         assertEquals(50, config.maxWidthFor(null));

--- a/webserver/src/test/java/io/kestra/webserver/controllers/api/BlueprintControllerTest.java
+++ b/webserver/src/test/java/io/kestra/webserver/controllers/api/BlueprintControllerTest.java
@@ -96,6 +96,18 @@ class BlueprintControllerTest {
         assertThat(e.getMessage()).contains("Operation EQUALS is not supported for field TAGS");
     }
 
+    @Test
+    void shouldRejectLogicalFilterGroupsInsteadOfSilentlyDroppingThem() {
+        HttpClientResponseException e = assertThrows(
+            HttpClientResponseException.class,
+            () -> client.toBlocking().retrieve(
+                HttpRequest.GET(API_V1_BLUEPRINT_COMMUNITY_FLOW_PATH + "?filters[or][0][q][EQUALS]=foo&filters[or][1][q][EQUALS]=bar"),
+                Argument.of(PagedResults.class, BlueprintController.ApiBlueprintItem.class)
+            )
+        );
+        assertThat(e.getMessage()).contains("does not support logical (AND/OR) or nested filter groups");
+    }
+
     @SuppressWarnings("unchecked")
     @Test
     void shouldFindSearchBlueprintsWithoutFiltersOmitsLegacyParams(WireMockRuntimeInfo wmRuntimeInfo) {

--- a/webserver/src/test/java/io/kestra/webserver/converters/QueryFilterFormatBinderTest.java
+++ b/webserver/src/test/java/io/kestra/webserver/converters/QueryFilterFormatBinderTest.java
@@ -1,7 +1,10 @@
 package io.kestra.webserver.converters;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.junit.jupiter.api.Test;
 
@@ -84,7 +87,7 @@ class QueryFilterFormatBinderTest {
 
     @Test
     void testBindHttpRequest() {
-        // GIVEN
+        // GIVEN — a real HttpRequest with bracket-encoded filter params
         HttpRequest<?> request = HttpRequest.GET(
             UriBuilder.of("/")
                 .queryParam("filters[namespace][EQUALS]", "test-namespace")
@@ -92,9 +95,8 @@ class QueryFilterFormatBinderTest {
                 .build()
         );
 
-        // WHEN
-        QueryFilterFormatBinder binder = new QueryFilterFormatBinder();
-        List<QueryFilter> filters = binder.bind(null, request).get();
+        // WHEN — drive the parser the same way the bind() method does: read query params, then parse
+        List<QueryFilter> filters = QueryFilterFormatBinder.getQueryFilters(request.getParameters().asMap());
 
         // THEN
         assertEquals(2, filters.size());
@@ -122,5 +124,231 @@ class QueryFilterFormatBinderTest {
         List<QueryFilter> filters = QueryFilterFormatBinder.getQueryFilters(queryParams);
         // THEN
         assertEquals(0, filters.size(), "Invalid filters should be ignored");
+    }
+
+    @Test
+    void shouldParseSingleOrGroupWithTwoBranches() {
+        // GIVEN — two branches of one OR group, different values on the same field
+        Map<String, List<String>> queryParams = Map.of(
+            "filters[or][0][state][EQUALS]", List.of("RUNNING"),
+            "filters[or][1][state][EQUALS]", List.of("FAILED")
+        );
+
+        // WHEN
+        List<QueryFilter> filters = QueryFilterFormatBinder.getQueryFilters(queryParams);
+
+        // THEN — one OR node with two leaf children
+        // Equivalent SQL: WHERE (state = 'RUNNING' OR state = 'FAILED')
+        assertEquals(1, filters.size());
+        QueryFilter or = filters.getFirst();
+        assertTrue(or.isNode());
+        assertEquals(QueryFilter.Logical.OR, or.logical());
+        assertEquals(2, or.children().size());
+        assertTrue(or.children().stream().allMatch(QueryFilter::isLeaf));
+        Set<String> values = or.children().stream().map(c -> c.value().toString()).collect(Collectors.toSet());
+        assertEquals(Set.of("RUNNING", "FAILED"), values);
+    }
+
+    @Test
+    void shouldMergeFiltersWithSameOrIndexAsAndWrapper() {
+        // GIVEN — two filters share the same OR branch index, so they implicitly AND inside the branch
+        Map<String, List<String>> queryParams = Map.of(
+            "filters[or][0][state][EQUALS]", List.of("RUNNING"),
+            "filters[or][0][namespace][EQUALS]", List.of("io.kestra")
+        );
+
+        // WHEN
+        List<QueryFilter> filters = QueryFilterFormatBinder.getQueryFilters(queryParams);
+
+        // THEN — single-branch OR wrapping an AND of the two leaves
+        // Equivalent SQL: WHERE ((state = 'RUNNING' AND namespace = 'io.kestra'))
+        assertEquals(1, filters.size());
+        QueryFilter or = filters.getFirst();
+        assertEquals(QueryFilter.Logical.OR, or.logical());
+        assertEquals(1, or.children().size());
+        QueryFilter wrapped = or.children().getFirst();
+        assertTrue(wrapped.isNode());
+        assertEquals(QueryFilter.Logical.AND, wrapped.logical());
+        assertEquals(2, wrapped.children().size());
+    }
+
+    @Test
+    void shouldCombineGlobalAndWithOrGroup() {
+        // GIVEN — a top-level (implicit AND) leaf plus an OR group as siblings
+        Map<String, List<String>> queryParams = Map.of(
+            "filters[namespace][EQUALS]", List.of("io.kestra"),
+            "filters[or][0][state][EQUALS]", List.of("RUNNING"),
+            "filters[or][1][state][EQUALS]", List.of("FAILED")
+        );
+
+        // WHEN
+        List<QueryFilter> filters = QueryFilterFormatBinder.getQueryFilters(queryParams);
+
+        // THEN — flat list: one leaf + one OR node; the dispatcher ANDs them at the root
+        // Equivalent SQL: WHERE namespace = 'io.kestra' AND (state = 'RUNNING' OR state = 'FAILED')
+        assertEquals(2, filters.size());
+        long leafCount = filters.stream().filter(QueryFilter::isLeaf).count();
+        long nodeCount = filters.stream().filter(QueryFilter::isNode).count();
+        assertEquals(1, leafCount);
+        assertEquals(1, nodeCount);
+    }
+
+    @Test
+    void shouldParseDeeplyNestedOrInsideOr() {
+        // GIVEN — nested OR inside OR alongside a global-AND leaf
+        Map<String, List<String>> queryParams = Map.of(
+            "filters[or][0][or][0][state][EQUALS]", List.of("A"),
+            "filters[or][0][or][1][state][EQUALS]", List.of("B"),
+            "filters[or][1][state][EQUALS]", List.of("C"),
+            "filters[namespace][EQUALS]", List.of("ns")
+        );
+
+        // WHEN
+        List<QueryFilter> filters = QueryFilterFormatBinder.getQueryFilters(queryParams);
+
+        // THEN — namespace leaf + outer OR whose first branch is itself an OR
+        // Equivalent SQL: WHERE namespace = 'ns' AND ((state = 'A' OR state = 'B') OR state = 'C')
+        assertEquals(2, filters.size());
+        QueryFilter namespace = filters.stream().filter(QueryFilter::isLeaf).findFirst().orElseThrow();
+        assertEquals("ns", namespace.value());
+
+        QueryFilter outerOr = filters.stream().filter(QueryFilter::isNode).findFirst().orElseThrow();
+        assertEquals(QueryFilter.Logical.OR, outerOr.logical());
+        assertEquals(2, outerOr.children().size());
+
+        QueryFilter innerOr = outerOr.children().stream().filter(QueryFilter::isNode).findFirst().orElseThrow();
+        assertEquals(QueryFilter.Logical.OR, innerOr.logical());
+        assertEquals(2, innerOr.children().size());
+    }
+
+    @Test
+    void shouldRejectExcessiveNestingDepth() {
+        // GIVEN — a single URL param with 4 [or][0] pairs (depth cap configured to 3)
+        StringBuilder key = new StringBuilder("filters");
+        for (int i = 0; i < 4; i++) {
+            key.append("[or][0]");
+        }
+        key.append("[state][EQUALS]");
+        Map<String, List<String>> queryParams = Map.of(key.toString(), List.of("X"));
+
+        // WHEN / THEN — parser throws on the 4th descent; no SQL is generated
+        // Equivalent SQL: <none — request is rejected at the binder>
+        IllegalArgumentException ex = assertThrows(IllegalArgumentException.class, () ->
+            QueryFilterFormatBinder.getQueryFilters(queryParams, 3, Integer.MAX_VALUE)
+        );
+        assertTrue(ex.getMessage().contains("depth"),
+            "Expected depth error, got: " + ex.getMessage());
+    }
+
+    @Test
+    void shouldRejectExcessiveNodeWidth() {
+        // GIVEN — a single OR group with 21 sibling branches (width cap configured to 20)
+        Map<String, List<String>> queryParams = new HashMap<>();
+        for (int i = 0; i < 21; i++) {
+            queryParams.put("filters[or][" + i + "][state][EQUALS]", List.of("RUNNING"));
+        }
+
+        // WHEN / THEN — width check throws; the OR node would have 21 children
+        // Equivalent SQL: <none — request is rejected at the binder>
+        IllegalArgumentException ex = assertThrows(IllegalArgumentException.class, () ->
+            QueryFilterFormatBinder.getQueryFilters(queryParams, Integer.MAX_VALUE, 20)
+        );
+        assertTrue(ex.getMessage().contains("width"),
+            "Expected width error, got: " + ex.getMessage());
+    }
+
+    @Test
+    void shouldRejectExcessiveRootWidth() {
+        // GIVEN — one URL param with 21 repeated values (each becomes its own leaf at root)
+        List<String> twentyOneValues = new java.util.ArrayList<>();
+        for (int i = 0; i < 21; i++) {
+            twentyOneValues.add("v" + i);
+        }
+        Map<String, List<String>> queryParams = Map.of(
+            "filters[namespace][EQUALS]", twentyOneValues
+        );
+
+        // WHEN / THEN — root produces 21 sibling leaves, exceeding the width cap
+        // Equivalent SQL: <none — request is rejected at the binder>
+        IllegalArgumentException ex = assertThrows(IllegalArgumentException.class, () ->
+            QueryFilterFormatBinder.getQueryFilters(queryParams, Integer.MAX_VALUE, 20)
+        );
+        assertTrue(ex.getMessage().contains("width"),
+            "Expected width error, got: " + ex.getMessage());
+    }
+
+    @Test
+    void shouldMergeLabelsWithinNodeContext() {
+        // GIVEN — labels with nested keys spread across two OR branches; within each branch,
+        // shared field+operation labels should merge into a single map-valued leaf
+        Map<String, List<String>> queryParams = Map.of(
+            "filters[or][0][labels][EQUALS][env]", List.of("prod"),
+            "filters[or][0][labels][EQUALS][team]", List.of("backend"),
+            "filters[or][1][labels][EQUALS][env]", List.of("dev")
+        );
+
+        // WHEN
+        List<QueryFilter> filters = QueryFilterFormatBinder.getQueryFilters(queryParams);
+
+        // THEN — single OR with two leaves; branch 0 has merged labels {env=prod, team=backend}
+        // Equivalent SQL (labels handling is db-specific; pseudo form):
+        //   WHERE (labels MATCH {env=prod, team=backend} OR labels MATCH {env=dev})
+        assertEquals(1, filters.size());
+        QueryFilter or = filters.getFirst();
+        assertEquals(QueryFilter.Logical.OR, or.logical());
+        assertEquals(2, or.children().size());
+        assertTrue(or.children().stream().allMatch(QueryFilter::isLeaf));
+        assertTrue(or.children().stream().allMatch(c -> c.field() == QueryFilter.Field.LABELS));
+    }
+
+    @Test
+    void shouldRemainBackwardCompatibleWithFlatLegacyFormat() {
+        // GIVEN — a real production URL using the legacy flat format (no [and]/[or] prefix)
+        HttpRequest<?> request = HttpRequest.GET(
+            UriBuilder.of("/")
+                .queryParam("filters[timeRange][EQUALS]", "PT24H")
+                .queryParam("filters[flowId][IN]", "after-execution-error,after-execution-finally,avoidinfiniteexecutionloop")
+                .build()
+        );
+
+        // WHEN
+        List<QueryFilter> filters = QueryFilterFormatBinder.getQueryFilters(request.getParameters().asMap());
+
+        // THEN — two flat leaves, no node wrapping (identical to pre-OR-support behavior)
+        // Equivalent SQL: WHERE timeRange = 'PT24H'
+        //                   AND flowId IN ('after-execution-error', 'after-execution-finally', 'avoidinfiniteexecutionloop')
+        assertEquals(2, filters.size());
+        assertTrue(filters.stream().allMatch(QueryFilter::isLeaf), "All filters should be leaves (no node wrapping)");
+
+        QueryFilter timeRange = filters.stream()
+            .filter(f -> f.field() == QueryFilter.Field.TIME_RANGE).findFirst().orElseThrow();
+        assertEquals(QueryFilter.Op.EQUALS, timeRange.operation());
+        assertEquals("PT24H", timeRange.value());
+
+        QueryFilter flowId = filters.stream()
+            .filter(f -> f.field() == QueryFilter.Field.FLOW_ID).findFirst().orElseThrow();
+        assertEquals(QueryFilter.Op.IN, flowId.operation());
+        assertEquals(
+            List.of("after-execution-error", "after-execution-finally", "avoidinfiniteexecutionloop"),
+            flowId.value()
+        );
+    }
+
+    @Test
+    void shouldAcceptCaseInsensitiveLogicalKeywords() {
+        // GIVEN — the [or] keyword in mixed casing (caller convenience)
+        Map<String, List<String>> queryParams = Map.of(
+            "filters[OR][0][state][EQUALS]", List.of("RUNNING"),
+            "filters[Or][1][state][EQUALS]", List.of("FAILED")
+        );
+
+        // WHEN
+        List<QueryFilter> filters = QueryFilterFormatBinder.getQueryFilters(queryParams);
+
+        // THEN — case is normalized, both branches land in the same OR node
+        // Equivalent SQL: WHERE (state = 'RUNNING' OR state = 'FAILED')
+        assertEquals(1, filters.size());
+        assertEquals(QueryFilter.Logical.OR, filters.getFirst().logical());
+        assertEquals(2, filters.getFirst().children().size());
     }
 }

--- a/webserver/src/test/java/io/kestra/webserver/utils/SearchableTest.java
+++ b/webserver/src/test/java/io/kestra/webserver/utils/SearchableTest.java
@@ -9,6 +9,9 @@ import org.junit.jupiter.api.Test;
 
 import io.kestra.core.repositories.ArrayListTotal;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.tuple;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -166,6 +169,284 @@ class SearchableTest {
             "Provided query filters are invalid: Unsupported operation for FLOW_ID: EQUALS",
             queryFiltersException.getMessage()
         );
+    }
+
+    @Test
+    void shouldFilterResultsWithOrLogicWhenOrNodeProvided() {
+        // Given
+        List<QueryFilter> queryFilters = List.of(
+            QueryFilter.builder()
+                .logical(QueryFilter.Logical.OR)
+                .children(List.of(
+                    QueryFilter.builder()
+                        .field(QueryFilter.Field.QUERY)
+                        .operation(QueryFilter.Op.EQUALS)
+                        .value("Alice")
+                        .build(),
+                    QueryFilter.builder()
+                        .field(QueryFilter.Field.PARENT_ID)
+                        .operation(QueryFilter.Op.EQUALS)
+                        .value(25)
+                        .build()
+                ))
+                .build()
+        );
+
+        // When
+        ArrayListTotal<TestEntity> result = Searchable.<TestEntity>builder()
+            .searchableQueryFilterExtractor(
+                QueryFilter.Field.QUERY, QueryFilter.Op.EQUALS,
+                (entity, value) -> entity.name().equals(value)
+            )
+            .searchableQueryFilterExtractor(
+                QueryFilter.Field.PARENT_ID, QueryFilter.Op.EQUALS,
+                (entity, value) -> entity.age() == (int) value
+            )
+            .build()
+            .filter(entities, 1, 100, null, queryFilters, null);
+
+        // Then: Alice/30 (name), Bob/25 (age), Alice/40 (name) = 3
+        assertThat(result).extracting(TestEntity::name, TestEntity::age)
+            .containsExactlyInAnyOrder(
+                tuple("Alice", 30),
+                tuple("Bob", 25),
+                tuple("Alice", 40)
+            );
+    }
+
+    @Test
+    void shouldFilterResultsWithAndLogicWhenAndNodeProvided() {
+        // Given
+        List<QueryFilter> queryFilters = List.of(
+            QueryFilter.builder()
+                .logical(QueryFilter.Logical.AND)
+                .children(List.of(
+                    QueryFilter.builder()
+                        .field(QueryFilter.Field.QUERY)
+                        .operation(QueryFilter.Op.EQUALS)
+                        .value("Alice")
+                        .build(),
+                    QueryFilter.builder()
+                        .field(QueryFilter.Field.PARENT_ID)
+                        .operation(QueryFilter.Op.EQUALS)
+                        .value(30)
+                        .build()
+                ))
+                .build()
+        );
+
+        // When
+        ArrayListTotal<TestEntity> result = Searchable.<TestEntity>builder()
+            .searchableQueryFilterExtractor(
+                QueryFilter.Field.QUERY, QueryFilter.Op.EQUALS,
+                (entity, value) -> entity.name().equals(value)
+            )
+            .searchableQueryFilterExtractor(
+                QueryFilter.Field.PARENT_ID, QueryFilter.Op.EQUALS,
+                (entity, value) -> entity.age() == (int) value
+            )
+            .build()
+            .filter(entities, 1, 100, null, queryFilters, null);
+
+        // Then: only Alice/30 matches both
+        assertThat(result).singleElement()
+            .extracting(TestEntity::name, TestEntity::age)
+            .containsExactly("Alice", 30);
+    }
+
+    @Test
+    void shouldFilterResultsWithNestedAndInsideOrWhenComplexFilterProvided() {
+        // Given: OR[ AND[name=Alice, age=30], AND[name=Bob, age=25] ]
+        List<QueryFilter> queryFilters = List.of(
+            QueryFilter.builder()
+                .logical(QueryFilter.Logical.OR)
+                .children(List.of(
+                    QueryFilter.builder()
+                        .logical(QueryFilter.Logical.AND)
+                        .children(List.of(
+                            QueryFilter.builder()
+                                .field(QueryFilter.Field.QUERY)
+                                .operation(QueryFilter.Op.EQUALS)
+                                .value("Alice")
+                                .build(),
+                            QueryFilter.builder()
+                                .field(QueryFilter.Field.PARENT_ID)
+                                .operation(QueryFilter.Op.EQUALS)
+                                .value(30)
+                                .build()
+                        ))
+                        .build(),
+                    QueryFilter.builder()
+                        .logical(QueryFilter.Logical.AND)
+                        .children(List.of(
+                            QueryFilter.builder()
+                                .field(QueryFilter.Field.QUERY)
+                                .operation(QueryFilter.Op.EQUALS)
+                                .value("Bob")
+                                .build(),
+                            QueryFilter.builder()
+                                .field(QueryFilter.Field.PARENT_ID)
+                                .operation(QueryFilter.Op.EQUALS)
+                                .value(25)
+                                .build()
+                        ))
+                        .build()
+                ))
+                .build()
+        );
+
+        // When
+        ArrayListTotal<TestEntity> result = Searchable.<TestEntity>builder()
+            .searchableQueryFilterExtractor(
+                QueryFilter.Field.QUERY, QueryFilter.Op.EQUALS,
+                (entity, value) -> entity.name().equals(value)
+            )
+            .searchableQueryFilterExtractor(
+                QueryFilter.Field.PARENT_ID, QueryFilter.Op.EQUALS,
+                (entity, value) -> entity.age() == (int) value
+            )
+            .build()
+            .filter(entities, 1, 100, null, queryFilters, null);
+
+        // Then: Alice/30 and Bob/25
+        assertThat(result).extracting(TestEntity::name, TestEntity::age)
+            .containsExactlyInAnyOrder(
+                tuple("Alice", 30),
+                tuple("Bob", 25)
+            );
+    }
+
+    @Test
+    void shouldFilterResultsWithNestedOrInsideAndWhenComplexFilterProvided() {
+        // Given: AND[ name=Alice, OR[age=30, age=40] ]
+        List<QueryFilter> queryFilters = List.of(
+            QueryFilter.builder()
+                .logical(QueryFilter.Logical.AND)
+                .children(List.of(
+                    QueryFilter.builder()
+                        .field(QueryFilter.Field.QUERY)
+                        .operation(QueryFilter.Op.EQUALS)
+                        .value("Alice")
+                        .build(),
+                    QueryFilter.builder()
+                        .logical(QueryFilter.Logical.OR)
+                        .children(List.of(
+                            QueryFilter.builder()
+                                .field(QueryFilter.Field.PARENT_ID)
+                                .operation(QueryFilter.Op.EQUALS)
+                                .value(30)
+                                .build(),
+                            QueryFilter.builder()
+                                .field(QueryFilter.Field.PARENT_ID)
+                                .operation(QueryFilter.Op.EQUALS)
+                                .value(40)
+                                .build()
+                        ))
+                        .build()
+                ))
+                .build()
+        );
+
+        // When
+        ArrayListTotal<TestEntity> result = Searchable.<TestEntity>builder()
+            .searchableQueryFilterExtractor(
+                QueryFilter.Field.QUERY, QueryFilter.Op.EQUALS,
+                (entity, value) -> entity.name().equals(value)
+            )
+            .searchableQueryFilterExtractor(
+                QueryFilter.Field.PARENT_ID, QueryFilter.Op.EQUALS,
+                (entity, value) -> entity.age() == (int) value
+            )
+            .build()
+            .filter(entities, 1, 100, null, queryFilters, null);
+
+        // Then: both Alices (ages 30 and 40)
+        assertThat(result).extracting(TestEntity::name, TestEntity::age)
+            .containsExactlyInAnyOrder(
+                tuple("Alice", 30),
+                tuple("Alice", 40)
+            );
+    }
+
+    @Test
+    void shouldCombineTopLevelLeafAndNodeWithAndSemanticsWhenMixedTopLevelProvided() {
+        // Given: top-level list = [ OR[age=30, age=40], leaf(name=Alice) ] — outer list is AND
+        List<QueryFilter> queryFilters = List.of(
+            QueryFilter.builder()
+                .logical(QueryFilter.Logical.OR)
+                .children(List.of(
+                    QueryFilter.builder()
+                        .field(QueryFilter.Field.PARENT_ID)
+                        .operation(QueryFilter.Op.EQUALS)
+                        .value(30)
+                        .build(),
+                    QueryFilter.builder()
+                        .field(QueryFilter.Field.PARENT_ID)
+                        .operation(QueryFilter.Op.EQUALS)
+                        .value(40)
+                        .build()
+                ))
+                .build(),
+            QueryFilter.builder()
+                .field(QueryFilter.Field.QUERY)
+                .operation(QueryFilter.Op.EQUALS)
+                .value("Alice")
+                .build()
+        );
+
+        // When
+        ArrayListTotal<TestEntity> result = Searchable.<TestEntity>builder()
+            .searchableQueryFilterExtractor(
+                QueryFilter.Field.QUERY, QueryFilter.Op.EQUALS,
+                (entity, value) -> entity.name().equals(value)
+            )
+            .searchableQueryFilterExtractor(
+                QueryFilter.Field.PARENT_ID, QueryFilter.Op.EQUALS,
+                (entity, value) -> entity.age() == (int) value
+            )
+            .build()
+            .filter(entities, 1, 100, null, queryFilters, null);
+
+        // Then: name=Alice AND (age=30 OR age=40)
+        assertThat(result).extracting(TestEntity::name, TestEntity::age)
+            .containsExactlyInAnyOrder(
+                tuple("Alice", 30),
+                tuple("Alice", 40)
+            );
+    }
+
+    @Test
+    void shouldThrowErrorWhenUnsupportedOperationInsideNestedNode() {
+        // Given: OR-node where the first child uses an unregistered (field, op)
+        List<QueryFilter> queryFilters = List.of(
+            QueryFilter.builder()
+                .logical(QueryFilter.Logical.OR)
+                .children(List.of(
+                    QueryFilter.builder()
+                        .field(QueryFilter.Field.FLOW_ID)
+                        .operation(QueryFilter.Op.EQUALS)
+                        .value("ignored")
+                        .build(),
+                    QueryFilter.builder()
+                        .field(QueryFilter.Field.QUERY)
+                        .operation(QueryFilter.Op.EQUALS)
+                        .value("Alice")
+                        .build()
+                ))
+                .build()
+        );
+
+        Searchable<TestEntity> searchable = Searchable.<TestEntity>builder()
+            .searchableQueryFilterExtractor(
+                QueryFilter.Field.QUERY, QueryFilter.Op.EQUALS,
+                (entity, value) -> entity.name().equals(value)
+            )
+            .build();
+
+        // When / Then
+        assertThatThrownBy(() -> searchable.filter(entities, 1, 100, null, queryFilters, null))
+            .isInstanceOf(InvalidQueryFiltersException.class)
+            .hasMessage("Provided query filters are invalid: Unsupported operation for FLOW_ID: EQUALS");
     }
 
     record TestEntity(String name, int age) {


### PR DESCRIPTION
### ✨ Description

Adds support for AND/OR boolean logic in query filters across the API and JDBC repository layer.

- `QueryFilter` is now polymorphic — either a **leaf** (`field`/`operation`/`value`) or a **node** (`logical` operator + non-empty `children`). The compact constructor enforces leaf-XOR-node so invalid combinations are rejected on construction.
- The LHS-brackets URL format gains optional `[and][N]` and `[or][N]` prefixes for grouping. The existing flat format continues to work unchanged.
  - Example: `?filters[namespace][EQUALS]=io.kestra&filters[or][0][state][EQUALS]=RUNNING&filters[or][1][state][EQUALS]=FAILED`
  - Translates to: `WHERE namespace = 'io.kestra' AND (state = 'RUNNING' OR state = 'FAILED')`
- The JDBC repository dispatcher is now a recursive walker that emits `Condition.and` / `Condition.or` via jOOQ. Per-leaf handlers are unchanged.
- New `kestra.query-filter` configuration:
  - `max-depth` (default **3**, hard floor 3) caps nesting depth per URL param.
  - `max-width` (default **20**, hard floor 20) caps children per tree node.
  - `resources.<NAME>.max-{depth,width}` overrides caps per `QueryFilter.Resource`.
  - Below-floor values are clamped at startup with a WARN log; the bean never exposes a value below the floor.
- `@QueryFilterFormat` now requires a `QueryFilter.Resource` value so the binder can resolve per-Resource caps at parse time. All controller callsites updated.
- Defensive fixes in `DateUtils`, `SecretService`, and `AbstractJdbcExecutionRepository` so leaf-only call-sites no longer NPE when handed a node filter.
- Integration tests on **H2, PostgreSQL, and MySQL** exercising `(A AND B) OR (C AND D)`-style queries end-to-end against a live database.

### 🔗 Related Issue

Closes https://github.com/kestra-io/kestra/issues/11587

### 📝 Additional Notes

- **Wire-format compatibility:** existing URLs (`filters[field][op]=value`) parse identically to before. The 5 pre-existing binder tests pass unchanged.
- **No UI changes in this PR** — the Vue 3 filter builder still emits flat AND lists. The new URL syntax is API-only until a follow-up adds a UI affordance for OR groups.
  - Full arbitrary tree nesting from the spec (`((1 OR 2) OR 3) AND 4`). The implementation supports DNF (a list of AND-groups OR'd together), which covers ~all realistic filter UIs and can be relaxed later if needed.