### PR TITLE
fix(triggers): redesign in-flow Triggers tab

### DIFF
--- a/core/src/main/java/io/kestra/core/scheduler/model/TriggerState.java
+++ b/core/src/main/java/io/kestra/core/scheduler/model/TriggerState.java
@@ -215,7 +215,7 @@ public final class TriggerState implements TriggerId {
             backfill = backfill
                 .toBuilder()
                 .end(backfill.getEnd() != null ? backfill.getEnd() : ZonedDateTime.now(clock))
-                .currentDate(backfill.getStart())
+                .currentDate(backfill.getCurrentDate() != null ? backfill.getCurrentDate() : backfill.getStart())
                 .previousNextExecutionDate(toZonedDateTime(nextEvaluationDate))
                 .build();
         }

--- a/scheduler/src/test/java/io/kestra/scheduler/TriggerEventHandlerTest.java
+++ b/scheduler/src/test/java/io/kestra/scheduler/TriggerEventHandlerTest.java
@@ -353,6 +353,32 @@ class TriggerEventHandlerTest {
     }
 
     @Test
+    void shouldPreserveCurrentDateGivenAdvancedBackfillWhenPaused() {
+        // GIVEN: a backfill that has progressed past its start date
+        ZonedDateTime start = ZonedDateTime.now(CLOCK).minusDays(10);
+        ZonedDateTime end = ZonedDateTime.now(CLOCK);
+        ZonedDateTime advanced = start.plusDays(4);
+        Backfill backfill = Backfill.builder()
+            .start(start)
+            .end(end)
+            .currentDate(advanced)
+            .paused(false)
+            .build();
+        triggerStateStore.save(triggerState.backfill(CLOCK, backfill));
+        handler = newTriggerEventHandler(List.of());
+        SetPauseBackfillTrigger event = new SetPauseBackfillTrigger(triggerId, true);
+
+        // WHEN
+        handler.handle(CLOCK, TEST_VNODE, event);
+
+        // THEN: currentDate is preserved (progress bar must not reset)
+        Optional<TriggerState> updated = triggerStateStore.findById(triggerId);
+        assertThat(updated).get()
+            .extracting(t -> t.getBackfill().getCurrentDate())
+            .isEqualTo(advanced);
+    }
+
+    @Test
     void shouldCompleteTriggerGivenTriggerCompletedEventWhenHandled() {
         // GIVEN
         triggerStateStore.save(triggerState);

--- a/ui/src/components/flows/BackfillBanner.vue
+++ b/ui/src/components/flows/BackfillBanner.vue
@@ -1,0 +1,122 @@
+<template>
+    <div v-if="row?.backfill" class="backfill-banner">
+        <span class="bf-meta">
+            {{ formatRange(row.backfill) }} · {{ progress }}%
+        </span>
+        <KsProgress
+            class="bf-progress"
+            :percentage="progress"
+            :status="row.backfill.paused ? 'warning' : ''"
+            :stroke-width="10"
+            :showText="false"
+            :striped="!row.backfill.paused"
+            stripedFlow
+        />
+        <div class="bf-actions">
+            <KsIconButton
+                v-if="!row.backfill.paused"
+                data-test="backfill-pause"
+                size="small"
+                :tooltip="t('pause backfill')"
+                @click="emit('pause')"
+            >
+                <Pause />
+            </KsIconButton>
+            <KsIconButton
+                v-else
+                data-test="backfill-resume"
+                size="small"
+                :tooltip="t('continue backfill')"
+                @click="emit('resume')"
+            >
+                <Play />
+            </KsIconButton>
+            <KsIconButton
+                data-test="backfill-stop"
+                size="small"
+                :tooltip="t('delete backfill')"
+                class="bf-stop"
+                @click="emit('stop')"
+            >
+                <Stop />
+            </KsIconButton>
+        </div>
+    </div>
+</template>
+
+<script setup lang="ts">
+    import moment from "moment"
+    import {computed} from "vue"
+    import {useI18n} from "vue-i18n"
+
+    import Play from "vue-material-design-icons/Play.vue"
+    import Pause from "vue-material-design-icons/Pause.vue"
+    import Stop from "vue-material-design-icons/Stop.vue"
+
+    import {dateUtils, KsIconButton, KsProgress} from "@kestra-io/design-system"
+
+    const {t} = useI18n()
+
+    const props = defineProps<{
+        row: {
+            backfill?: {
+                start?: string
+                end?: string
+                currentDate?: string
+                paused?: boolean
+            }
+        }
+    }>()
+
+    const emit = defineEmits<{
+        pause: []
+        resume: []
+        stop: []
+    }>()
+
+    const progress = computed(() => {
+        const bf = props.row?.backfill
+        if (!bf?.start || !bf?.end || !bf?.currentDate) return 0
+        const total = moment(bf.end).diff(moment(bf.start))
+        if (total <= 0) return 100
+        const elapsed = moment(bf.currentDate).diff(moment(bf.start))
+        return Math.max(0, Math.min(100, Math.round((elapsed / total) * 100)))
+    })
+
+    const formatRange = (bf: NonNullable<typeof props.row.backfill>) => {
+        const fmt = (s?: string) => s ? dateUtils.dateFilter(s) : "—"
+        return `${fmt(bf.start)} → ${fmt(bf.end)}`
+    }
+</script>
+
+<style lang="scss" scoped>
+.backfill-banner {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    padding: 0.625rem 1rem;
+    background: var(--ks-background-card);
+    border-top: 1px dashed var(--ks-border-primary);
+}
+
+.bf-meta {
+    color: var(--ks-content-secondary);
+    font-size: var(--ks-font-size-sm);
+    min-width: 14rem;
+    white-space: nowrap;
+}
+
+.bf-progress {
+    flex: 1;
+    min-width: 0;
+}
+
+.bf-actions {
+    display: flex;
+    gap: 0.25rem;
+}
+
+.bf-stop :deep(.material-design-icon) {
+    color: var(--ks-content-error);
+}
+</style>

--- a/ui/src/components/flows/FlowTriggers.vue
+++ b/ui/src/components/flows/FlowTriggers.vue
@@ -9,7 +9,7 @@
         }"
         :properties="{
             shown: true,
-            columns: orderedColumns,
+            columns: optionalColumns,
             displayColumns,
             storageKey: storageKeys.DISPLAY_TRIGGERS_COLUMNS
         }"
@@ -19,15 +19,35 @@
         :defaultTimeRange="false"
     />
 
-    <KsTable
+    <KsDataTable
         v-if="triggersWithType.length"
+        ref="dataTable"
         v-bind="$attrs"
         :data="triggersWithType"
-        tableLayout="auto"
-        defaultExpandAll
+        :total="triggersWithType.length"
+        :defaultSort="{prop: 'triggerId', order: 'ascending'}"
+        :rowKey="(row: any) => row.id"
+        :expandRowKeys="expandedRowKeys"
+        :rowClassName="(arg: any) => arg.row?.backfill ? 'force-expanded' : ''"
+        :selectable="canCheck"
+        :selectionMapper="selectionMapper"
     >
+        <template #bulk-actions>
+            <KsButton @click="bulkSetDisabled(false)">{{ $t("enable") }}</KsButton>
+            <KsButton @click="bulkSetDisabled(true)">{{ $t("disable") }}</KsButton>
+            <KsButton @click="bulkUnlock()">{{ $t("unlock") }}</KsButton>
+            <KsButton v-if="userCan(action.DELETE)" @click="bulkDelete()">{{ $t("delete triggers") }}</KsButton>
+        </template>
+
         <KsTableColumn type="expand">
             <template #default="props">
+                <BackfillBanner
+                    v-if="props.row.backfill"
+                    :row="props.row"
+                    @pause="pauseBackfill(props.row)"
+                    @resume="unpauseBackfill(props.row)"
+                    @stop="deleteBackfill(props.row)"
+                />
                 <LogsWrapper class="m-3" :filters="{...props.row, triggerId: props.row.id}" purgeFilters :withCharts="false" :reloadLogs embed />
             </template>
         </KsTableColumn>
@@ -43,74 +63,75 @@
         </KsTableColumn>
 
         <KsTableColumn
-            v-for="column in orderedColumns.filter(col => displayColumns.includes(col.prop))"
-            :key="column.prop"
-            :prop="column.prop"
-            :label="column.label"
+            v-for="col in visibleColumns"
+            :key="col.prop"
+            :prop="col.prop"
+            :label="col.label"
+            :sortable="DATE_COLUMNS.includes(col.prop)"
+            :sortOrders="DATE_COLUMNS.includes(col.prop) ? ['ascending', 'descending'] : undefined"
         >
+            <template #header v-if="col.prop === 'lastTriggeredDate'">
+                <KsTooltip :content="$t('last trigger date tooltip')" placement="top" effect="light">
+                    <span>{{ col.label }}</span>
+                </KsTooltip>
+            </template>
+            <template #header v-else-if="col.prop === 'nextEvaluationDate'">
+                <KsTooltip :content="$t('next evaluation date tooltip')" placement="top" effect="light">
+                    <span>{{ col.label }}</span>
+                </KsTooltip>
+            </template>
+            <template #header v-else-if="col.prop === 'updatedAt'">
+                <KsTooltip :content="$t('context updated date tooltip')" placement="top" effect="light">
+                    <span>{{ col.label }}</span>
+                </KsTooltip>
+            </template>
+
             <template #default="scope">
-                <template v-if="column.prop === 'workerId'">
-                    <KsId
-                        :value="scope.row.workerId"
-                        :shrink="true"
-                    />
+                <template v-if="col.prop === 'lastTriggeredDate'">
+                    <KsDateAgo :inverted="true" :date="scope.row.lastTriggeredDate" />
                 </template>
-                <template v-else-if="column.prop === 'nextEvaluationDate'">
+                <template v-else-if="col.prop === 'nextEvaluationDate'">
                     <KsDateAgo :inverted="true" :date="scope.row.nextEvaluationDate" />
                 </template>
+                <template v-else-if="col.prop === 'evaluatedAt'">
+                    <KsDateAgo :inverted="true" :date="scope.row.evaluatedAt" />
+                </template>
+                <template v-else-if="col.prop === 'updatedAt'">
+                    <KsDateAgo :inverted="true" :date="scope.row.updatedAt" />
+                </template>
                 <template v-else>
-                    {{ scope.row[column.prop] }}
+                    {{ scope.row[col.prop] }}
                 </template>
             </template>
         </KsTableColumn>
 
-        <KsTableColumn columnKey="backfill" v-if="userCan(action.UPDATE) || userCan(action.CREATE)">
-            <template #header>
-                {{ $t("backfill") }}
-            </template>
+        <KsTableColumn columnKey="backfill" :label="$t('backfill')" v-if="userCan(action.UPDATE)">
             <template #default="scope">
-                <KsButton
-                    :icon="CalendarCollapseHorizontalOutline"
-                    v-if="isSchedule(scope.row.type) && !scope.row.backfill && userCan(action.CREATE)"
-                    @click="setBackfillModal(scope.row, true)"
-                    :disabled="scope.row.disabled || scope.row.sourceDisabled"
-                    size="small"
-                    type="primary"
-                >
-                    {{ $t("backfill executions") }}
-                </KsButton>
-                <template v-else-if="isSchedule(scope.row.type) && userCan(action.UPDATE)">
-                    <div class="backfill-cell">
-                        <div class="progress-cell">
-                            <KsProgress
-                                :percentage="backfillProgression(scope.row.backfill)"
-                                :status="scope.row.backfill.paused ? 'warning' : ''"
-                                :stroke-width="12"
-                                :showText="!scope.row.backfill.paused"
-                                :striped="!scope.row.backfill.paused"
-                                stripedFlow
-                            />
-                        </div>
-                        <template v-if="!scope.row.backfill.paused">
-                            <KsIconButton size="small" :tooltip="$t('pause backfill')" @click="pauseBackfill(scope.row)">
-                                <Pause />
-                            </KsIconButton>
-                        </template>
-                        <template v-else-if="userCan(action.UPDATE)">
-                            <KsIconButton size="small" :tooltip="$t('continue backfill')" @click="unpauseBackfill(scope.row)">
-                                <Play />
-                            </KsIconButton>
-
-                            <KsIconButton size="small" :tooltip="$t('delete backfill')" @click="deleteBackfill(scope.row)">
-                                <Delete />
-                            </KsIconButton>
-                        </template>
-                    </div>
+                <template v-if="isSchedule(scope.row.type) && !scope.row.backfill">
+                    <KsButton
+                        :icon="CalendarCollapseHorizontalOutline"
+                        @click="setBackfillModal(scope.row, true)"
+                        :disabled="scope.row.disabled || scope.row.sourceDisabled"
+                        size="small"
+                        type="primary"
+                    >
+                        {{ $t("backfill executions") }}
+                    </KsButton>
+                </template>
+                <template v-else-if="scope.row.backfill">
+                    <KsTag
+                        size="small"
+                        :type="scope.row.backfill.paused ? 'warning' : 'info'"
+                        effect="light"
+                        class="backfill-tag"
+                    >
+                        {{ scope.row.backfill.paused ? $t("paused") : $t("running") }}
+                    </KsTag>
                 </template>
             </template>
         </KsTableColumn>
 
-        <KsTableColumn columnKey="disable" className="row-action" v-if="userCan(action.UPDATE)">
+        <KsTableColumn columnKey="disable" :label="$t('enabled')" className="row-action" v-if="userCan(action.UPDATE)">
             <template #default="scope">
                 <KsTooltip
                     v-if="hasTrigger(scope.row)"
@@ -118,60 +139,62 @@
                     :disabled="!scope.row.sourceDisabled"
                 >
                     <KsSwitch
-                        size="small"
-                        :activeText="$t('enabled')"
                         :modelValue="!(scope.row.disabled || scope.row.sourceDisabled)"
                         @change="setDisabled(scope.row, $event as boolean)"
+                        inlinePrompt
                         class="switch-text"
-                        :activeActionIcon="Check"
                         :disabled="scope.row.sourceDisabled"
                     />
                 </KsTooltip>
             </template>
         </KsTableColumn>
 
-        <KsTableColumn columnKey="restart" className="row-action" v-if="userCan(action.UPDATE)">
+        <KsTableColumn columnKey="row-actions" className="row-action">
             <template #default="scope">
-                <KsIconButton
-                    v-if="scope.row.locked"
-                    size="small"
-                    :tooltip="$t('restart trigger.button')"
-                    placement="left"
-                    @click="restart(scope.row)"
-                >
-                    <Restart />
-                </KsIconButton>
+                <KsDropdown trigger="click" placement="bottom-end">
+                    <KsButton
+                        :icon="DotsVertical"
+                        link
+                        size="small"
+                        :aria-label="$t('actions')"
+                    />
+                    <template #dropdown>
+                        <KsDropdownMenu>
+                            <KsDropdownItem @click="openDetails(scope.row)">
+                                <TextSearch class="mr-1" />
+                                {{ $t("details") }}
+                            </KsDropdownItem>
+                            <KsDropdownItem
+                                v-if="userCan(action.UPDATE)"
+                                :disabled="!scope.row.locked"
+                                @click="restart(scope.row)"
+                            >
+                                <Restart class="mr-1" />
+                                {{ $t("restart") }}
+                            </KsDropdownItem>
+                            <KsDropdownItem
+                                v-if="userCan(action.UPDATE)"
+                                :disabled="!scope.row.locked"
+                                @click="unlock(scope.row)"
+                            >
+                                <LockOff class="mr-1" />
+                                {{ $t("unlock") }}
+                            </KsDropdownItem>
+                            <KsDropdownItem
+                                v-if="userCan(action.DELETE)"
+                                divided
+                                class="danger"
+                                @click="confirmDeleteTrigger(scope.row)"
+                            >
+                                <Delete class="mr-1" />
+                                {{ $t("delete") }}
+                            </KsDropdownItem>
+                        </KsDropdownMenu>
+                    </template>
+                </KsDropdown>
             </template>
         </KsTableColumn>
-
-        <KsTableColumn columnKey="unlock" className="row-action" v-if="userCan(action.UPDATE)">
-            <template #default="scope">
-                <KsIconButton
-                    v-if="scope.row.locked"
-                    size="small"
-                    :tooltip="$t('unlock trigger.button')"
-                    placement="left"
-                    @click="unlock(scope.row)"
-                >
-                    <LockOff />
-                </KsIconButton>
-            </template>
-        </KsTableColumn>
-
-        <KsTableColumn>
-            <template #default="scope">
-                <TriggerAvatar :flow="flowStore.flow" :triggerId="scope.row.id" />
-            </template>
-        </KsTableColumn>
-
-        <KsTableColumn columnKey="action" className="row-action">
-            <template #default="scope">
-                <KsIconButton size="small" :tooltip="$t('details')" @click="triggerId = scope.row.id; isOpen = true">
-                    <TextSearch />
-                </KsIconButton>
-            </template>
-        </KsTableColumn>
-    </KsTable>
+    </KsDataTable>
 
     <div v-if="triggersWithType.length" class="mt-4">
         <KsButton
@@ -259,31 +282,26 @@
 </template>
 
 <script setup lang="ts">
-    import moment from "moment"
     import {useI18n} from "vue-i18n"
     import _isEqual from "lodash/isEqual"
     import {useRoute, useRouter} from "vue-router"
-    import {ref, computed, watch, onMounted} from "vue"
+    import {ref, computed, watch, onMounted, useTemplateRef} from "vue"
 
-    import Play from "vue-material-design-icons/Play.vue"
     import Plus from "vue-material-design-icons/Plus.vue"
-    import Pause from "vue-material-design-icons/Pause.vue"
-    import Check from "vue-material-design-icons/Check.vue"
     import Delete from "vue-material-design-icons/Delete.vue"
+    import DotsVertical from "vue-material-design-icons/DotsVertical.vue"
     import LockOff from "vue-material-design-icons/LockOff.vue"
     import Restart from "vue-material-design-icons/Restart.vue"
     import TextSearch from "vue-material-design-icons/TextSearch.vue"
     import CalendarCollapseHorizontalOutline from "vue-material-design-icons/CalendarCollapseHorizontalOutline.vue"
 
-    import {KsId, KsIconButton} from "@kestra-io/design-system"
+    import {KsDataTable, KsDropdown, KsDropdownMenu, KsDropdownItem, KsFilter as KSFilter, KsMarkdown, KsTag, KsTooltip} from "@kestra-io/design-system"
     //@ts-expect-error no declared types
     import FlowRun from "./FlowRun.vue"
     import Vars from "../executions/Vars.vue"
-    import {KsMarkdown} from "@kestra-io/design-system"
+    import BackfillBanner from "./BackfillBanner.vue"
     import Empty from "../layout/empty/Empty.vue"
-    import TriggerAvatar from "./TriggerAvatar.vue"
     import LogsWrapper from "../logs/LogsWrapper.vue"
-    import {KsFilter as KSFilter} from "@kestra-io/design-system"
 
     import action from "../../models/action"
     import resource from "../../models/resource"
@@ -295,7 +313,7 @@
     import {useAuthStore} from "override/stores/auth"
     import {useTriggerStore} from "../../stores/trigger"
 
-    import {useTableColumns} from "../../composables/useTableColumns"
+    import {type ColumnConfig, useTableColumns} from "../../composables/useTableColumns"
     import {useTriggerFilter} from "../filter/configurations"
 
     const triggerFilter = useTriggerFilter()
@@ -322,35 +340,58 @@
 
     const reloadLogs = ref<number | undefined>()
 
-    const localOptionalColumns = ref([
+    const DATE_COLUMNS: readonly string[] = ["lastTriggeredDate", "nextEvaluationDate", "evaluatedAt"]
+
+    const optionalColumns = computed<ColumnConfig[]>(() => [
         {
             label: t("type"),
             prop: "type",
             default: true,
-            description: t("filter.table_column.flow_triggers.type"),
         },
         {
-            label: t("workerId"),
-            prop: "workerId",
-            default: false,
-            description: t("filter.table_column.flow_triggers.workerId"),
+            label: t("last trigger date"),
+            prop: "lastTriggeredDate",
+            default: true,
         },
         {
             label: t("next evaluation date"),
             prop: "nextEvaluationDate",
             default: true,
-            description: t("filter.table_column.flow_triggers.next execution date"),
+        },
+        {
+            label: t("last evaluation date"),
+            prop: "evaluatedAt",
+            default: true,
+        },
+        {
+            label: t("state updated date"),
+            prop: "updatedAt",
+            default: false,
         },
     ])
 
     const {
-        orderedColumns,
         visibleColumns: displayColumns,
-        updateVisibleColumns: updateDisplayColumns,
+        updateVisibleColumns,
     } = useTableColumns({
-        columns: localOptionalColumns.value,
+        columns: optionalColumns.value,
         storageKey: storageKeys.DISPLAY_TRIGGERS_COLUMNS,
+        initialVisibleColumns: optionalColumns.value.filter(col => col.default).map(col => col.prop),
     })
+
+    const visibleColumns = computed(() =>
+        displayColumns.value
+            .map((prop: string) => optionalColumns.value.find(c => c.prop === prop))
+            .filter(Boolean) as ColumnConfig[],
+    )
+
+    const updateDisplayColumns = (newColumns: string[]) => updateVisibleColumns(newColumns)
+
+    const expandedRowKeys = computed(() =>
+        triggersWithType.value
+            .filter((row: any) => !!row.backfill)
+            .map((row: any) => row.id),
+    )
 
     const toast = useToast()
     const authStore = useAuthStore()
@@ -529,14 +570,86 @@
         })
     }
 
-    const backfillProgression = (backfillObj: any) => {
-        const startMoment = moment(backfillObj?.start)
-        const endMoment = moment(backfillObj?.end)
-        const currentMoment = moment(backfillObj?.currentDate)
+    const openDetails = (row: any) => {
+        triggerId.value = row.id
+        isOpen.value = true
+    }
 
-        const totalDuration = endMoment.diff(startMoment)
-        const elapsedDuration = currentMoment.diff(startMoment)
-        return Math.round((elapsedDuration / totalDuration) * 100)
+    const dataTable = useTemplateRef<any>("dataTable")
+    const canCheck = computed<boolean>(() => userCan(action.UPDATE) ?? false)
+    const selection = computed<any[]>(() => dataTable.value?.selection ?? [])
+    const selectionMapper = (row: any) => ({
+        namespace: row.namespace,
+        flowId: row.flowId,
+        triggerId: row.triggerId ?? row.id,
+    })
+
+    const runBulk = (promiseFactory: () => Promise<any>, successKey: string, actionLabel: string) => {
+        return promiseFactory()
+            .then((d: any) => {
+                toast.success(t(successKey, {count: d?.count}))
+                dataTable.value?.toggleAllUnselected()
+                loadDataAfterAction()
+            })
+            .catch((error: unknown) => {
+                toast.error(`${actionLabel}: ${(error as any)?.message ?? t("error")}`)
+                console.error(error)
+            })
+    }
+
+    const bulkSetDisabled = (disabled: boolean) => {
+        const confirmKey = disabled ? "bulk disabled status.true" : "bulk disabled status.false"
+        const successKey = disabled ? "bulk success disabled status.true" : "bulk success disabled status.false"
+        const actionLabel = disabled ? t("disable") : t("enable")
+        toast.confirm(
+            t(confirmKey, {count: selection.value.length}),
+            () => runBulk(
+                () => triggerStore.setDisabledByTriggers({triggers: selection.value, disabled}),
+                successKey,
+                actionLabel,
+            ),
+        )
+    }
+
+    const bulkUnlock = () => {
+        toast.confirm(
+            t("bulk unlock", {count: selection.value.length}),
+            () => runBulk(
+                () => triggerStore.unlockByTriggers(selection.value),
+                "bulk success unlock",
+                t("unlock"),
+            ),
+        )
+    }
+
+    const bulkDelete = () => {
+        toast.confirm(
+            t("bulk delete triggers", {count: selection.value.length}),
+            () => runBulk(
+                () => triggerStore.deleteByTriggers(selection.value),
+                "bulk success delete triggers",
+                t("delete triggers"),
+            ),
+            "warning",
+        )
+    }
+
+    const confirmDeleteTrigger = (row: any) => {
+        toast.confirm(
+            t("delete trigger confirmation", {id: row.id}),
+            () => triggerStore.delete({
+                namespace: row.namespace,
+                flowId: row.flowId,
+                triggerId: row.triggerId ?? row.id,
+            }).then(() => {
+                toast.success(t("delete trigger success", {id: row.id}))
+                loadDataAfterAction()
+            }).catch((error: unknown) => {
+                toast.error(t("delete trigger error", {id: row.id}))
+                console.error(error)
+            }),
+            "warning",
+        )
     }
 
     const isSchedule = (type: string) => {
@@ -584,14 +697,13 @@
     }
 }
 
-.backfill-cell {
-    display: flex;
-    align-items: center;
+.backfill-tag {
+    text-transform: uppercase;
 }
 
-.progress-cell {
-    width: 200px;
-    margin-right: 1em;
+:deep(tr.force-expanded .kel-table__expand-icon) {
+    visibility: hidden;
+    pointer-events: none;
 }
 
 :deep(.markdown) {

--- a/ui/src/translations/en.json
+++ b/ui/src/translations/en.json
@@ -440,6 +440,7 @@
     "tenantId": "Tenant ID",
     "codeDisabled": "Disabled in Flow",
     "paused": "Paused",
+    "running": "Running",
     "Fold auto": "Editor: automatic fold of multi-lines",
     "Hover description": "Editor: Show description of field when hovering on key or value",
     "Fold content lines": "Fold multiline strings",


### PR DESCRIPTION
- Switch to KsDataTable with sortable date columns, URL-driven sort, header tooltips
- Add lastTriggeredDate, evaluatedAt, updatedAt columns;
- Consolidate row actions into a hamburger menu (Details / Restart / Unlock / Delete)
- Backfilled rows are force-expanded with a full-width banner showing progress and Pause / Resume / Stop controls
- Add selection checkboxes and Enable / Disable / Unlock / Delete bulk actions
- Fix scheduler bug: pause/resume backfill no longer rewinds currentDate to start