### PR TITLE
feat(core): add maintenance status endpoint

### DIFF
--- a/core/src/main/java/io/kestra/core/models/MaintenanceStatusResponse.java
+++ b/core/src/main/java/io/kestra/core/models/MaintenanceStatusResponse.java
@@ -1,0 +1,30 @@
+package io.kestra.core.models;
+
+import java.util.Map;
+
+import io.kestra.core.server.ServiceType;
+
+/**
+ * Response payload for the maintenance status endpoint.
+ *
+ * @param maintenance whether maintenance mode is currently enabled.
+ * @param ready       whether all services have transitioned to MAINTENANCE state
+ *                    (i.e. the instance is safe to update).
+ * @param services    per-type breakdown: how many instances of each service type
+ *                    are in MAINTENANCE vs total running.
+ */
+public record MaintenanceStatusResponse(
+    boolean maintenance,
+    boolean ready,
+    Map<ServiceType, ServiceStatus> services
+) {
+
+    /**
+     * Status of a single service type.
+     *
+     * @param total         total number of running instances of this type.
+     * @param inMaintenance number of instances that have reached MAINTENANCE state.
+     */
+    public record ServiceStatus(int total, int inMaintenance) {
+    }
+}

--- a/core/src/main/java/io/kestra/core/services/MaintenanceService.java
+++ b/core/src/main/java/io/kestra/core/services/MaintenanceService.java
@@ -1,5 +1,16 @@
 package io.kestra.core.services;
 
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import io.kestra.core.models.MaintenanceStatusResponse;
+import io.kestra.core.models.MaintenanceStatusResponse.ServiceStatus;
+import io.kestra.core.server.Service.ServiceState;
+import io.kestra.core.server.ServiceInstance;
+import io.kestra.core.server.ServiceLivenessStore;
+import io.kestra.core.server.ServiceType;
 import io.kestra.core.utils.Disposable;
 
 import jakarta.inject.Singleton;
@@ -20,6 +31,39 @@ public interface MaintenanceService {
      * @return a {@link Disposable} to called to stop listening to.
      */
     Disposable listen(final MaintenanceListener listener);
+
+    /**
+     * Builds the current maintenance status including per-service readiness.
+     *
+     * @param livenessStore the store to query running service instances.
+     * @return a {@link MaintenanceStatusResponse}.
+     */
+    default MaintenanceStatusResponse getMaintenanceStatus(ServiceLivenessStore livenessStore) {
+        boolean maintenance = isInMaintenanceMode();
+        List<ServiceInstance> allRunning = livenessStore.findAllInstancesInStates(ServiceState.allRunningStates());
+
+        Map<ServiceType, ServiceStatus> services = allRunning.stream()
+            .collect(Collectors.groupingBy(ServiceInstance::type))
+            .entrySet()
+            .stream()
+            .sorted(Map.Entry.comparingByKey())
+            .collect(Collectors.toMap(
+                Map.Entry::getKey,
+                entry -> {
+                    int inMaintenance = (int) entry.getValue().stream()
+                        .filter(si -> ServiceState.MAINTENANCE.equals(si.state()))
+                        .count();
+                    return new ServiceStatus(entry.getValue().size(), inMaintenance);
+                },
+                (a, b) -> a,
+                LinkedHashMap::new
+            ));
+
+        boolean ready = maintenance && !allRunning.isEmpty() && allRunning.stream()
+            .allMatch(si -> ServiceState.MAINTENANCE.equals(si.state()));
+
+        return new MaintenanceStatusResponse(maintenance, ready, services);
+    }
 
     /**
      * Interface for listening on maintenance events.

--- a/core/src/test/java/io/kestra/core/services/MaintenanceServiceTest.java
+++ b/core/src/test/java/io/kestra/core/services/MaintenanceServiceTest.java
@@ -1,0 +1,132 @@
+package io.kestra.core.services;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+
+import io.kestra.core.models.MaintenanceStatusResponse;
+import io.kestra.core.models.MaintenanceStatusResponse.ServiceStatus;
+import io.kestra.core.server.Service.ServiceState;
+import io.kestra.core.server.ServerInstance;
+import io.kestra.core.server.ServiceInstance;
+import io.kestra.core.server.ServiceLivenessStore;
+import io.kestra.core.server.ServiceType;
+import io.kestra.core.utils.Disposable;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class MaintenanceServiceTest {
+
+    private final ServiceLivenessStore livenessStore = mock(ServiceLivenessStore.class);
+
+    @Test
+    void shouldReturnNotInMaintenanceWhenNoop() {
+        // Given
+        MaintenanceService service = new MaintenanceService.NoopMaintenanceService();
+        when(livenessStore.findAllInstancesInStates(ServiceState.allRunningStates())).thenReturn(List.of());
+
+        // When
+        MaintenanceStatusResponse response = service.getMaintenanceStatus(livenessStore);
+
+        // Then
+        assertThat(response.maintenance()).isFalse();
+        assertThat(response.ready()).isFalse();
+        assertThat(response.services()).isEmpty();
+    }
+
+    @Test
+    void shouldReturnNotReadyWhenInMaintenanceButServicesStillRunning() {
+        // Given
+        MaintenanceService service = maintenanceService(true);
+        when(livenessStore.findAllInstancesInStates(ServiceState.allRunningStates())).thenReturn(List.of(
+            serviceInstance(ServiceType.WORKER, ServiceState.RUNNING),
+            serviceInstance(ServiceType.WORKER, ServiceState.MAINTENANCE),
+            serviceInstance(ServiceType.EXECUTOR, ServiceState.RUNNING)
+        ));
+
+        // When
+        MaintenanceStatusResponse response = service.getMaintenanceStatus(livenessStore);
+
+        // Then
+        assertThat(response.maintenance()).isTrue();
+        assertThat(response.ready()).isFalse();
+        assertThat(response.services()).containsKey(ServiceType.WORKER);
+        assertThat(response.services()).containsKey(ServiceType.EXECUTOR);
+
+        ServiceStatus workerStatus = response.services().get(ServiceType.WORKER);
+        assertThat(workerStatus.total()).isEqualTo(2);
+        assertThat(workerStatus.inMaintenance()).isEqualTo(1);
+
+        ServiceStatus executorStatus = response.services().get(ServiceType.EXECUTOR);
+        assertThat(executorStatus.total()).isEqualTo(1);
+        assertThat(executorStatus.inMaintenance()).isEqualTo(0);
+    }
+
+    @Test
+    void shouldReturnReadyWhenAllServicesInMaintenance() {
+        // Given
+        MaintenanceService service = maintenanceService(true);
+        when(livenessStore.findAllInstancesInStates(ServiceState.allRunningStates())).thenReturn(List.of(
+            serviceInstance(ServiceType.WORKER, ServiceState.MAINTENANCE),
+            serviceInstance(ServiceType.EXECUTOR, ServiceState.MAINTENANCE)
+        ));
+
+        // When
+        MaintenanceStatusResponse response = service.getMaintenanceStatus(livenessStore);
+
+        // Then
+        assertThat(response.maintenance()).isTrue();
+        assertThat(response.ready()).isTrue();
+        assertThat(response.services().get(ServiceType.WORKER).inMaintenance()).isEqualTo(1);
+        assertThat(response.services().get(ServiceType.EXECUTOR).inMaintenance()).isEqualTo(1);
+    }
+
+    @Test
+    void shouldReturnNotReadyWhenInMaintenanceButNoServices() {
+        // Given
+        MaintenanceService service = maintenanceService(true);
+        when(livenessStore.findAllInstancesInStates(ServiceState.allRunningStates())).thenReturn(List.of());
+
+        // When
+        MaintenanceStatusResponse response = service.getMaintenanceStatus(livenessStore);
+
+        // Then
+        assertThat(response.maintenance()).isTrue();
+        assertThat(response.ready()).isFalse();
+        assertThat(response.services()).isEmpty();
+    }
+
+    private static MaintenanceService maintenanceService(boolean inMaintenance) {
+        return new MaintenanceService() {
+            @Override
+            public boolean isInMaintenanceMode() {
+                return inMaintenance;
+            }
+
+            @Override
+            public Disposable listen(MaintenanceListener listener) {
+                return Disposable.of(() -> {});
+            }
+        };
+    }
+
+    private static ServiceInstance serviceInstance(ServiceType type, ServiceState state) {
+        return new ServiceInstance(
+            "test-" + type.name().toLowerCase(),
+            type,
+            state,
+            new ServerInstance("server-1", ServerInstance.Type.STANDALONE, "1.0", "localhost", null, null),
+            Instant.now(),
+            Instant.now(),
+            null,
+            null,
+            null,
+            null,
+            0L
+        );
+    }
+}

--- a/webserver/src/test/java/io/kestra/webserver/controllers/api/ClusterControllerTest.java
+++ b/webserver/src/test/java/io/kestra/webserver/controllers/api/ClusterControllerTest.java
@@ -58,4 +58,5 @@ class ClusterControllerTest {
         // Then
         assertThat(metrics).isNotEmpty();
     }
+
 }


### PR DESCRIPTION
Add GET /cluster/maintenance/status endpoint returning maintenance mode state and per-service readiness breakdown.

Closes #14455

Companion PR: https://github.com/kestra-io/kestra-ee/pull/7425