### PR TITLE
fix: avoid render function stackOverflow by adding a configurable limit default to 16

### DIFF
--- a/core/src/main/java/io/kestra/core/runners/VariableRenderer.java
+++ b/core/src/main/java/io/kestra/core/runners/VariableRenderer.java
@@ -22,6 +22,7 @@ import jakarta.inject.Singleton;
 public class VariableRenderer {
     private static final Pattern RAW_PATTERN = Pattern.compile("(\\{%-*\\s*raw\\s*-*%}(.*?)\\{%-*\\s*endraw\\s*-*%})");
     public static final int MAX_RENDERING_AMOUNT = 100;
+    public static final String RENDER_DEPTH_VAR = "__kestra_render_depth";
 
     private volatile PebbleEngine pebbleEngine;
     private final VariableConfiguration variableConfiguration;
@@ -217,6 +218,14 @@ public class VariableRenderer {
 
         // Return the given object if it cannot be rendered.
         return Optional.ofNullable(object);
+    }
+
+    /**
+     * Renders an object while tracking render() nesting depth to prevent infinite recursion.
+     */
+    public Optional<Object> renderObject(Object object, Map<String, Object> variables, boolean recursive, int renderDepth) throws IllegalVariableEvaluationException {
+        variables.put(RENDER_DEPTH_VAR, renderDepth);
+        return renderObject(object, variables, recursive);
     }
 
     public List<Object> renderList(List<Object> list, Map<String, Object> variables) throws IllegalVariableEvaluationException {

--- a/core/src/main/java/io/kestra/core/runners/configuration/VariableConfiguration.java
+++ b/core/src/main/java/io/kestra/core/runners/configuration/VariableConfiguration.java
@@ -8,10 +8,13 @@ import lombok.Getter;
 @Getter
 @ConfigurationProperties("kestra.variables")
 public class VariableConfiguration {
+    public static final int DEFAULT_MAX_RENDER_DEPTH = 16;
+
     public VariableConfiguration() {
         this.cacheEnabled = true;
         this.cacheSize = 1000;
         this.recursiveRendering = false;
+        this.maxRenderDepth = DEFAULT_MAX_RENDER_DEPTH;
         this.redactedEnvVars = List.of(
             "KESTRA_PLUGINS_PATH", "KESTRA_CONFIGURATION_PATH", "KESTRA_CONFIGURATION", "KESTRA_JAVA_OPTS"
         );
@@ -20,5 +23,6 @@ public class VariableConfiguration {
     Boolean cacheEnabled;
     Integer cacheSize;
     Boolean recursiveRendering;
+    Integer maxRenderDepth;
     List<String> redactedEnvVars;
 }

--- a/core/src/main/java/io/kestra/core/runners/pebble/functions/RenderFunction.java
+++ b/core/src/main/java/io/kestra/core/runners/pebble/functions/RenderFunction.java
@@ -5,6 +5,8 @@ import java.util.List;
 import java.util.Map;
 
 import io.kestra.core.exceptions.IllegalVariableEvaluationException;
+import io.kestra.core.runners.VariableRenderer;
+import io.kestra.core.runners.configuration.VariableConfiguration;
 
 import io.micronaut.context.ApplicationContext;
 import io.micronaut.context.annotation.Requires;
@@ -24,6 +26,9 @@ public class RenderFunction implements KestraFunction, RenderingFunctionInterfac
     @Inject
     private ApplicationContext applicationContext;
 
+    @Inject
+    private VariableConfiguration variableConfiguration;
+
     public List<String> getArgumentNames() {
         return List.of("toRender", "recursive");
     }
@@ -38,6 +43,15 @@ public class RenderFunction implements KestraFunction, RenderingFunctionInterfac
 
     @Override
     public Object execute(Map<String, Object> args, PebbleTemplate self, EvaluationContext context, int lineNumber) {
+        int depth = context.getVariable(VariableRenderer.RENDER_DEPTH_VAR) instanceof Number n ? n.intValue() : 0;
+        int maxDepth = variableConfiguration.getMaxRenderDepth();
+        if (depth >= maxDepth) {
+            throw new PebbleException(null,
+                "Maximum render() nesting depth (" + maxDepth + ") exceeded at line " + lineNumber +
+                    " — check for circular render() calls in your template.",
+                lineNumber, self.getName());
+        }
+
         if (!args.containsKey("toRender")) {
             throw new PebbleException(null, "The 'render' function expects an argument 'toRender'.", lineNumber, self.getName());
         }
@@ -60,7 +74,7 @@ public class RenderFunction implements KestraFunction, RenderingFunctionInterfac
 
         try {
             return ((RenderingFunctionInterface) evaluationContext.getExtensionRegistry().getFunction(functionName())).variableRenderer(applicationContext)
-                .renderObject(toRender, variables, recursive).orElse(null);
+                .renderObject(toRender, variables, recursive, depth + 1).orElse(null);
         } catch (IllegalVariableEvaluationException e) {
             throw new PebbleException(e, e.getMessage());
         }

--- a/core/src/test/java/io/kestra/core/runners/pebble/functions/RenderFunctionTest.java
+++ b/core/src/test/java/io/kestra/core/runners/pebble/functions/RenderFunctionTest.java
@@ -4,11 +4,13 @@ import java.time.*;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import io.kestra.core.exceptions.IllegalVariableEvaluationException;
 import io.kestra.core.runners.VariableRenderer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
 import jakarta.inject.Inject;
@@ -21,25 +23,25 @@ class RenderFunctionTest {
     @Test
     void shouldRenderForString() throws IllegalVariableEvaluationException {
         String rendered = variableRenderer.render("{{ render(input) }}", Map.of("input", "test"));
-        Assertions.assertEquals("test", rendered);
+        assertThat(rendered).isEqualTo("test");
     }
 
     @Test
     void shouldRenderForInteger() throws IllegalVariableEvaluationException {
         String rendered = variableRenderer.render("{{ render(input) }}", Map.of("input", 42));
-        Assertions.assertEquals("42", rendered);
+        assertThat(rendered).isEqualTo("42");
     }
 
     @Test
     void shouldRenderForLong() throws IllegalVariableEvaluationException {
         String rendered = variableRenderer.render("{{ render(input) }}", Map.of("input", 42L));
-        Assertions.assertEquals("42", rendered);
+        assertThat(rendered).isEqualTo("42");
     }
 
     @Test
     void shouldRenderForBoolean() throws IllegalVariableEvaluationException {
         String rendered = variableRenderer.render("{{ render(input) }}", Map.of("input", true));
-        Assertions.assertEquals("true", rendered);
+        assertThat(rendered).isEqualTo("true");
     }
 
     @Test
@@ -49,7 +51,7 @@ class RenderFunctionTest {
                 put("input", null);
             }
         });
-        Assertions.assertEquals("", rendered);
+        assertThat(rendered).isEqualTo("");
     }
 
     @Test
@@ -57,12 +59,19 @@ class RenderFunctionTest {
         Instant now = Instant.now();
         LocalDateTime datetime = LocalDateTime.ofInstant(now, ZoneOffset.UTC);
         String rendered = variableRenderer.render("{{ render(input) }}", Map.of("input", datetime));
-        Assertions.assertEquals(datetime.toString(), rendered);
+        assertThat(rendered).isEqualTo(datetime.toString());
     }
 
     @Test
     void shouldRenderForDuration() throws IllegalVariableEvaluationException {
         String rendered = variableRenderer.render("{{ render(input) }}", Map.of("input", Duration.ofSeconds(5)));
-        Assertions.assertEquals(Duration.ofSeconds(5).toString(), rendered);
+        assertThat(rendered).isEqualTo(Duration.ofSeconds(5).toString());
+    }
+
+    @Test
+    void shouldThrowOnCircularRender() {
+        assertThatThrownBy(() -> variableRenderer.render("{{ render(input) }}", Map.of("input", "{{ render(input) }}")))
+            .isInstanceOf(IllegalVariableEvaluationException.class)
+            .hasMessageContaining("Maximum render() nesting depth");
     }
 }


### PR DESCRIPTION
Render() inside render() can create infiniting looping
Added a customizable max limit for recursive rendering
