### PR TITLE
feat(topology): surface task runners with accent border + dedicated slot

### DIFF
--- a/core/src/main/java/io/kestra/core/models/tasks/runners/TaskException.java
+++ b/core/src/main/java/io/kestra/core/models/tasks/runners/TaskException.java
@@ -1,5 +1,6 @@
 package io.kestra.core.models.tasks.runners;
 
+import jakarta.annotation.Nullable;
 import java.io.Serial;
 
 import lombok.Getter;
@@ -15,15 +16,32 @@ public class TaskException extends Exception {
 
     private transient AbstractLogConsumer logConsumer;
 
+    /**
+     * Optional task-runner detail captured before the failure was raised, so the failure
+     * branch can still report runner-specific post-execution info (job id, status, etc.)
+     * to the topology UI through {@code outputs.taskRunner}.
+     */
+    @Nullable
+    private final TaskRunnerDetailResult details;
+
     public TaskException(int exitCode, AbstractLogConsumer logConsumer) {
-        this("Command failed with exit code " + exitCode, exitCode, logConsumer);
+        this("Command failed with exit code " + exitCode, exitCode, logConsumer, null);
     }
 
     public TaskException(String message, int exitCode, AbstractLogConsumer logConsumer) {
+        this(message, exitCode, logConsumer, null);
+    }
+
+    public TaskException(int exitCode, AbstractLogConsumer logConsumer, @Nullable TaskRunnerDetailResult details) {
+        this("Command failed with exit code " + exitCode, exitCode, logConsumer, details);
+    }
+
+    public TaskException(String message, int exitCode, AbstractLogConsumer logConsumer, @Nullable TaskRunnerDetailResult details) {
         super(message);
         this.exitCode = exitCode;
         this.stdOutCount = logConsumer.getStdOutCount();
         this.stdErrCount = logConsumer.getStdErrCount();
         this.logConsumer = logConsumer;
+        this.details = details;
     }
 }

--- a/script/src/main/java/io/kestra/plugin/scripts/exec/scripts/runners/CommandsWrapper.java
+++ b/script/src/main/java/io/kestra/plugin/scripts/exec/scripts/runners/CommandsWrapper.java
@@ -221,6 +221,7 @@ public class CommandsWrapper implements TaskCommands {
                 .stdErrLineCount(e.getStdErrCount())
                 .vars(e.getLogConsumer() != null ? e.getLogConsumer().getOutputs() : null)
                 .outputFiles(getOutputFiles(taskRunnerRunContext))
+                .taskRunner(e.getDetails())
                 .build();
             throw new RunnableTaskException(e, output);
         }

--- a/ui/packages/design-system/src/assets/styles/ks-theme-dark-2.scss
+++ b/ui/packages/design-system/src/assets/styles/ks-theme-dark-2.scss
@@ -107,6 +107,7 @@ html.dark-2 {
     /* topology */
     #{--ks-topology-bg}: #31303b;
     #{--ks-topology-dash}: $base-gray-neutral-300;
+    #{--ks-topology-task-runner-border}: $base-primary-300;
 
 
     /* scrollbar */

--- a/ui/packages/design-system/src/assets/styles/ks-theme-dark-2.scss
+++ b/ui/packages/design-system/src/assets/styles/ks-theme-dark-2.scss
@@ -107,7 +107,7 @@ html.dark-2 {
     /* topology */
     #{--ks-topology-bg}: #31303b;
     #{--ks-topology-dash}: $base-gray-neutral-300;
-    #{--ks-topology-task-runner-border}: $base-primary-300;
+    #{--ks-topology-task-runner-border}: $base-orange-400;
 
 
     /* scrollbar */

--- a/ui/packages/design-system/src/assets/styles/ks-theme-dark.scss
+++ b/ui/packages/design-system/src/assets/styles/ks-theme-dark.scss
@@ -107,7 +107,7 @@ html.dark {
     /* topology */
     #{--ks-topology-bg}: $base-gray-600;
     #{--ks-topology-dash}: $base-white;
-    #{--ks-topology-task-runner-border}: $base-primary-300;
+    #{--ks-topology-task-runner-border}: $base-orange-400;
 
     /* scrollbar */
     #{--ks-scrollbar-bg}: $base-gray-900;

--- a/ui/packages/design-system/src/assets/styles/ks-theme-dark.scss
+++ b/ui/packages/design-system/src/assets/styles/ks-theme-dark.scss
@@ -107,6 +107,7 @@ html.dark {
     /* topology */
     #{--ks-topology-bg}: $base-gray-600;
     #{--ks-topology-dash}: $base-white;
+    #{--ks-topology-task-runner-border}: $base-primary-300;
 
     /* scrollbar */
     #{--ks-scrollbar-bg}: $base-gray-900;

--- a/ui/packages/design-system/src/assets/styles/ks-theme-light.scss
+++ b/ui/packages/design-system/src/assets/styles/ks-theme-light.scss
@@ -107,7 +107,7 @@
     /* topology */
     #{--ks-topology-bg}: $base-gray-neutral-100;
     #{--ks-topology-dash}: $base-gray-neutral-300;
-    #{--ks-topology-task-runner-border}: $base-primary-300;
+    #{--ks-topology-task-runner-border}: $base-orange-400;
 
     /* scrollbar */
     #{--ks-scrollbar-bg}: $base-gray-100;

--- a/ui/packages/design-system/src/assets/styles/ks-theme-light.scss
+++ b/ui/packages/design-system/src/assets/styles/ks-theme-light.scss
@@ -107,6 +107,7 @@
     /* topology */
     #{--ks-topology-bg}: $base-gray-neutral-100;
     #{--ks-topology-dash}: $base-gray-neutral-300;
+    #{--ks-topology-task-runner-border}: $base-primary-300;
 
     /* scrollbar */
     #{--ks-scrollbar-bg}: $base-gray-100;

--- a/ui/packages/slot-contracts/src/index.ts
+++ b/ui/packages/slot-contracts/src/index.ts
@@ -1,8 +1,9 @@
 import {z} from "zod"
 import topologyDetails from "./topology-details"
 import topologyTaskDrawer from "./topology-task-drawer"
+import topologyTaskRunnerDetails from "./topology-task-runner-details"
 
-const slots = [topologyDetails, topologyTaskDrawer] as const
+const slots = [topologyDetails, topologyTaskDrawer, topologyTaskRunnerDetails] as const
 
 type SlotTuple = typeof slots;
 type ByKey<T extends readonly { key: string }[]> = {

--- a/ui/packages/slot-contracts/src/topology-task-runner-details.ts
+++ b/ui/packages/slot-contracts/src/topology-task-runner-details.ts
@@ -1,0 +1,24 @@
+import type {Execution, Task} from "@kestra-io/kestra-sdk"
+import {z} from "zod"
+import {defineArtifactSlot} from "./define-artifact-slot"
+
+export const propsSchema = z.object({
+    taskType: z.string(),
+    taskRunnerType: z.string(),
+    task: z.custom<Task>(),
+    taskRunner: z.record(z.string(), z.unknown()),
+    execution: z.custom<Execution>().optional(),
+    taskRun: z.record(z.string(), z.unknown()).optional(),
+    taskRunnerDetail: z.record(z.string(), z.unknown()).optional(),
+    namespace: z.string().optional(),
+    flowId: z.string().optional(),
+})
+
+export default defineArtifactSlot(() => ({
+    key: "topology-task-runner-details",
+    props: propsSchema,
+    manifest: z.object({
+        heightWithExecution: z.number().optional(),
+        height: z.number().optional(),
+    }),
+}))

--- a/ui/packages/slot-contracts/src/topology-task-runner-details.ts
+++ b/ui/packages/slot-contracts/src/topology-task-runner-details.ts
@@ -4,9 +4,13 @@ import {defineArtifactSlot} from "./define-artifact-slot"
 
 export const propsSchema = z.object({
     taskType: z.string(),
-    taskRunnerType: z.string(),
     task: z.custom<Task>(),
-    taskRunner: z.record(z.string(), z.unknown()),
+    // Optional even though the LowCodeEditor only mounts the federated module
+    // when `task.taskRunner` is set — keeping them optional aligns the prop
+    // shape with the other slots so `KnownSlotProps[T]` stays structurally
+    // compatible across the registry.
+    taskRunnerType: z.string().optional(),
+    taskRunner: z.record(z.string(), z.unknown()).optional(),
     execution: z.custom<Execution>().optional(),
     taskRun: z.record(z.string(), z.unknown()).optional(),
     taskRunnerDetail: z.record(z.string(), z.unknown()).optional(),

--- a/ui/packages/topology/src/Topology.vue
+++ b/ui/packages/topology/src/Topology.vue
@@ -50,6 +50,9 @@
                 <template #details>
                     <slot name="taskDetails" v-bind="taskProps" />
                 </template>
+                <template #taskRunnerDetails>
+                    <slot name="taskRunnerDetails" v-bind="taskProps" />
+                </template>
             </TaskNode>
         </template>
 

--- a/ui/packages/topology/src/nodes/BasicNode.vue
+++ b/ui/packages/topology/src/nodes/BasicNode.vue
@@ -181,7 +181,12 @@
         }
 
         &.with-task-runner {
-            border: 2px solid var(--ks-topology-task-runner-border);
+            // Pre-execution: purple accent.
+            // Post-execution: the inline `border-color` style set by BasicNode (driven
+            // by `state`) overrides this rule, so success/failed/running keep their
+            // semantic color while the ring stays 2px thick to mark the runner.
+            border-color: var(--ks-topology-task-runner-border);
+            border-width: 2px;
         }
 
         .icon {

--- a/ui/packages/topology/src/nodes/BasicNode.vue
+++ b/ui/packages/topology/src/nodes/BasicNode.vue
@@ -1,11 +1,15 @@
 <template>
     <div
         class="node-wrapper"
-        :style="{borderColor: state ? `var(--ks-border-${state.toLowerCase()})` : undefined}"
+        :style="nodeStyle"
         :class="{...classes, 'running-border-animation': state === 'RUNNING'}"
         @mouseover="mouseover"
         @mouseleave="mouseleave"
     >
+        <!-- Runner name badge: floats above the top-left corner, orange pre-execution / state-colored post-execution -->
+        <div v-if="hasTaskRunner" class="runner-badge" :style="runnerBadgeStyle">
+            {{ runnerLabel }}
+        </div>
         <div class="main-content">
             <div class="icon">
                 <component :is="iconComponent || TaskIcon" :cls="cls" :class="taskIconBg" class="bg-white" theme="light" :icons="icons" />
@@ -122,6 +126,61 @@
 
     const hasTaskRunner = computed(() => Boolean(props.data.node?.task?.taskRunner))
 
+    /**
+     * Derive a short human-readable label from the taskRunner type.
+     * e.g. "io.kestra.plugin.aws.runner.Batch" → "AWS BATCH"
+     *      "io.kestra.plugin.gcp.runner.CloudRun" → "GCP CLOUD RUN"
+     *      "io.kestra.plugin.kubernetes.runner.Kubernetes" → "KUBERNETES"
+     */
+    const runnerLabel = computed(() => {
+        const type = props.data.node?.task?.taskRunner?.type as string | undefined
+        if (!type) return ""
+        const parts = type.split(".")
+        const runnerIdx = parts.findIndex((p: string) => p === "runner")
+        if (runnerIdx < 0) {
+            // No 'runner' segment — just split camelCase on the last part
+            return parts[parts.length - 1].replace(/([A-Z])/g, " $1").trim().toUpperCase()
+        }
+        const plugin = runnerIdx > 0 ? parts[runnerIdx - 1].toUpperCase() : ""
+        const cls = runnerIdx < parts.length - 1
+            ? parts[runnerIdx + 1].replace(/([A-Z])/g, " $1").trim().toUpperCase()
+            : ""
+        // Avoid duplication like "KUBERNETES KUBERNETES"
+        if (cls.includes(plugin)) return cls.trim()
+        return `${plugin} ${cls}`.trim()
+    })
+
+    /** Badge and border share the same color: orange pre-execution, state-colored post-execution. */
+    const runnerAccentColor = computed(() =>
+        props.state
+            ? `var(--ks-border-${props.state.toLowerCase()})`
+            : "var(--ks-topology-task-runner-border)",
+    )
+
+    const runnerBadgeStyle = computed(() => ({
+        backgroundColor: runnerAccentColor.value,
+    }))
+
+    /**
+     * Node border:
+     * - task-runner, no state  → 2px dashed orange
+     * - task-runner, with state → 2px solid state-color  (same inline override as before for non-runner nodes)
+     * - no runner, with state  → border-color only (default 1px width stays from CSS)
+     * - no runner, no state   → nothing (CSS default 1px solid ks-border-primary)
+     */
+    const nodeStyle = computed(() => {
+        if (hasTaskRunner.value) {
+            return {
+                borderColor: runnerAccentColor.value,
+                borderStyle: props.state ? "solid" : "dashed",
+                borderWidth: "2px",
+            }
+        }
+        return props.state
+            ? {borderColor: `var(--ks-border-${props.state.toLowerCase()})`}
+            : {}
+    })
+
     const classes = computed(() => {
         return [
             {
@@ -154,6 +213,7 @@
 
 <style lang="scss" scoped>
     .node-wrapper {
+        position: relative; // required for .runner-badge absolute positioning
         background-color: var(--ks-bg-surface);
         border-radius: var(--ks-border-radius-lg);
         margin: 0;
@@ -181,12 +241,26 @@
         }
 
         &.with-task-runner {
-            // Pre-execution: purple accent.
-            // Post-execution: the inline `border-color` style set by BasicNode (driven
-            // by `state`) overrides this rule, so success/failed/running keep their
-            // semantic color while the ring stays 2px thick to mark the runner.
-            border-color: var(--ks-topology-task-runner-border);
-            border-width: 2px;
+            // Border style (color, width, dashed/solid) is fully controlled by the
+            // inline `nodeStyle` computed — nothing to override here.
+            // The class is kept as a CSS hook for future runner-specific tweaks.
+        }
+
+        .runner-badge {
+            position: absolute;
+            // Bottom of the badge sits flush with the node's top border.
+            top: 0;
+            left: -1px; // align with the node's left border edge
+            transform: translateY(-100%);
+            padding: 2px 10px;
+            border-radius: 999px;
+            font-size: 0.6rem;
+            font-weight: 700;
+            color: white;
+            letter-spacing: 0.06em;
+            line-height: 1.6;
+            white-space: nowrap;
+            user-select: none;
         }
 
         .icon {

--- a/ui/packages/topology/src/nodes/BasicNode.vue
+++ b/ui/packages/topology/src/nodes/BasicNode.vue
@@ -120,11 +120,14 @@
         return !["default", "danger"].includes(props.data.color) ? props.data.color : ""
     })
 
+    const hasTaskRunner = computed(() => Boolean(props.data.node?.task?.taskRunner))
+
     const classes = computed(() => {
         return [
             {
                 "unused-path": props.data.unused,
                 disabled: node.value?.disabled || props.data.parent?.taskNode?.task?.disabled,
+                "with-task-runner": hasTaskRunner.value,
             },
             props.class,
         ]
@@ -175,6 +178,10 @@
                 color: var(--ks-text-secondary);
                 text-decoration: line-through;
             }
+        }
+
+        &.with-task-runner {
+            border: 2px solid var(--ks-topology-task-runner-border);
         }
 
         .icon {

--- a/ui/packages/topology/src/nodes/TaskNode.vue
+++ b/ui/packages/topology/src/nodes/TaskNode.vue
@@ -16,6 +16,10 @@
         <template #details>
             <Transition name="details-slide">
                 <div v-if="globalShowExtraDetails" class="details-wrapper">
+                    <slot
+                        v-if="data.node.task?.taskRunner"
+                        name="taskRunnerDetails"
+                    />
                     <slot name="details" />
                     <div v-if="actionConfig && data.node.task" class="view-details-action">
                         <button
@@ -159,6 +163,7 @@
         };
         namespace?: string;
         flowId?: string;
+        taskRunner?: Record<string, unknown>;
     }
 
     interface NodeData {

--- a/ui/src/components/inputs/LowCodeEditor.vue
+++ b/ui/src/components/inputs/LowCodeEditor.vue
@@ -49,6 +49,22 @@
                     />
                 </slot>
             </template>
+            <template #taskRunnerDetails="taskProps">
+                <slot name="taskRunnerDetails" v-bind="taskProps">
+                    <TopologyTaskRunnerDetailsRemote
+                        v-if="taskProps.data.node?.task?.taskRunner"
+                        :taskType="taskProps.data.node?.task?.type"
+                        :taskRunnerType="taskProps.data.node?.task?.taskRunner?.type"
+                        :task="taskProps.data.node?.task"
+                        :taskRunner="taskProps.data.node?.task?.taskRunner"
+                        :execution="execution"
+                        :taskRun="resolveTaskRun(taskProps.data.node?.task?.id)"
+                        :taskRunnerDetail="resolveTaskRunnerDetail(taskProps.data.node?.task?.id)"
+                        :namespace="props.namespace"
+                        :flowId="props.flowId"
+                    />
+                </slot>
+            </template>
         </Topology>
 
         <KsDrawer v-if="isDrawerOpen && selectedTask" v-model="isDrawerOpen">
@@ -173,6 +189,7 @@
 
     const {RemoteComponent:TopologyDetailsRemote, taskAdditionalInfoRemote, manifestReady, resolveRemoteComponent} = useFederatedModule("topology-details")
     const {RemoteComponent:TaskDrawerRemote, resolveRemoteComponent: resolveDrawerComponent} = useFederatedModule("topology-task-drawer")
+    const {RemoteComponent:TopologyTaskRunnerDetailsRemote} = useFederatedModule("topology-task-runner-details")
 
 
     const customActions = computed(() => {
@@ -188,6 +205,15 @@
 
     const taskMetrics = (taskId: string | undefined) =>
         executionsStore.metrics.filter((m) => m.taskId === taskId)
+
+    const resolveTaskRun = (taskId: string | undefined) => {
+        if (!taskId) return undefined
+        const list = executionsStore.execution?.taskRunList as any[] | undefined
+        return list?.filter((tr) => tr.taskId === taskId).at(-1)
+    }
+
+    const resolveTaskRunnerDetail = (taskId: string | undefined) =>
+        resolveTaskRun(taskId)?.outputs?.taskRunner as Record<string, unknown> | undefined
 
     function getNodeDimensions(node: any, getNodeWidth: (node: any) => number, getNodeHeight: (node: any) => number) {
         const taskType = node?.task?.type


### PR DESCRIPTION
## Summary

Closes #15498 on the OSS side. Follow-up to #15400 (which landed the generic `topology-details` slot mechanism).

- **Visual signal on the TaskNode.** When a task has a `taskRunner:` block, the TaskNode renders with a purple accent border (`--ks-topology-task-runner-border`) — so it's immediately distinguishable from a task that runs on a local worker. The top-right action icons (edit / delete / logs / etc.) are untouched.
- **New federated slot `topology-task-runner-details`.** Sibling to `topology-details`, lets a plugin ship a UI surface that renders inside the task details area *only* when the task uses a runner. Slot props include the static `taskRunner` config (for the pre-execution view) and pre-resolved `taskRun` + `taskRunnerDetail` (for the post-execution view) — plugin authors don't have to drill the execution shape themselves.
- **Post-execution detail survives failure.** `TaskException` now accepts an optional `TaskRunnerDetailResult`. `CommandsWrapper` applies it to `ScriptOutput.taskRunner` on the catch branch. Without this, plugins like AWS Batch could only report runner detail on success — so a failed job's `jobId`, `status`, `statusReason` never reached `outputs.taskRunner` and the topology UI could not display them.

## Why a separate slot from `topology-details`

A script task with a `taskRunner: Batch` could in principle want **both** a task-level detail UI (e.g. the script preview) **and** a runner-level detail UI (job stats). Sharing one slot means one plugin's federated module wins by task type and the other loses. Keeping the two slots orthogonal lets them compose cleanly.

## Pairing PR

- **plugin-ee-aws#153** — switches `AwsBatchTopologyDetails.vue` to register against the new slot and attaches `BatchRunnerDetailResult` to `TaskException` on failure (depends on the `TaskException` constructor added here).

## Test plan

- [ ] `./gradlew :core:compileJava :script:compileJava` — succeeds (only pre-existing unchecked warnings).
- [ ] `cd ui && npm run check:types` — no new errors (4 pre-existing errors in `useFederatedModule.ts`).
- [ ] `cd ui && npm run test:lint` — 0 errors.
- [ ] Manual: open a flow with a task using `taskRunner: io.kestra.plugin.core.runner.Process` and one without. Toggle "extra details" in the topology controls; only the runner-equipped task should show the purple accent border, and the `taskRunnerDetails` slot area appears when a federated module for the runner type is registered.
- [ ] Manual (with plugin-ee-aws#153 + a failing Batch job): topology shows failed-run details (`jobId` + `statusReason`).