### PR TITLE
Add design-system locale.ts translation support

### DIFF
--- a/ui/packages/design-system/src/components/Data/KsDataTable/KsFilter.locale.ts
+++ b/ui/packages/design-system/src/components/Data/KsDataTable/KsFilter.locale.ts
@@ -419,6 +419,10 @@ export default {
                 "description": "Nach flow-ID filtern",
                 "label": "Flow-ID",
             },
+            "email": {
+                "description": "Nach E-Mail filtern",
+                "label": "E-Mail",
+            },
             "footer_apply": "Anwenden",
             "group": {
                 "description": "Nach Gruppe filtern",
@@ -602,6 +606,7 @@ export default {
             "timeRange": {
                 "description": "Nach Ausführungszeit filtern",
                 "label": "Intervall",
+                "applyTo": "Anwenden auf",
                 "chip": {
                     "end": "Beendet",
                     "start": "Gestartet",
@@ -758,6 +763,10 @@ export default {
             "flowId": {
                 "description": "Filtrar por flow ID",
                 "label": "ID de Flow",
+            },
+            "email": {
+                "description": "Filtrar por correo electrónico",
+                "label": "Correo electrónico",
             },
             "footer_apply": "Aplicar",
             "group": {
@@ -942,6 +951,7 @@ export default {
             "timeRange": {
                 "description": "Filtrar por tiempo de ejecución",
                 "label": "Intervalo",
+                "applyTo": "Aplicar a",
                 "chip": {
                     "end": "Finalizado",
                     "start": "Iniciado",
@@ -1098,6 +1108,10 @@ export default {
             "flowId": {
                 "description": "Filtrer par flow ID",
                 "label": "ID de flow",
+            },
+            "email": {
+                "description": "Filtrer par e-mail",
+                "label": "E-mail",
             },
             "footer_apply": "Appliquer",
             "group": {
@@ -1282,6 +1296,7 @@ export default {
             "timeRange": {
                 "description": "Filtrer par temps d'exécution",
                 "label": "Intervalle",
+                "applyTo": "Appliquer à",
                 "chip": {
                     "end": "Terminé",
                     "start": "Démarré",
@@ -1438,6 +1453,10 @@ export default {
             "flowId": {
                 "description": "flow ID द्वारा फ़िल्टर करें",
                 "label": "Flow ID",
+            },
+            "email": {
+                "description": "ईमेल द्वारा फ़िल्टर करें",
+                "label": "ईमेल",
             },
             "footer_apply": "लागू करें",
             "group": {
@@ -1622,6 +1641,7 @@ export default {
             "timeRange": {
                 "description": "कार्य समय द्वारा फ़िल्टर करें",
                 "label": "अंतराल",
+                "applyTo": "इस पर लागू करें",
                 "chip": {
                     "end": "समाप्त",
                     "start": "शुरू हुआ",
@@ -1778,6 +1798,10 @@ export default {
             "flowId": {
                 "description": "Filtra per flow ID",
                 "label": "ID del flow",
+            },
+            "email": {
+                "description": "Filtra per email",
+                "label": "Email",
             },
             "footer_apply": "Applica",
             "group": {
@@ -1962,6 +1986,7 @@ export default {
             "timeRange": {
                 "description": "Filtra per tempo di esecuzione",
                 "label": "Intervallo",
+                "applyTo": "Applica a",
                 "chip": {
                     "end": "Terminato",
                     "start": "Iniziato",
@@ -2118,6 +2143,10 @@ export default {
             "flowId": {
                 "description": "flow IDでフィルター",
                 "label": "Flow ID",
+            },
+            "email": {
+                "description": "メールでフィルター",
+                "label": "メール",
             },
             "footer_apply": "適用",
             "group": {
@@ -2302,6 +2331,7 @@ export default {
             "timeRange": {
                 "description": "実行時間でフィルター",
                 "label": "インターバル",
+                "applyTo": "適用先",
                 "chip": {
                     "end": "終了しました",
                     "start": "開始しました",
@@ -2458,6 +2488,10 @@ export default {
             "flowId": {
                 "description": "flow ID로 필터링",
                 "label": "Flow ID",
+            },
+            "email": {
+                "description": "이메일로 필터링",
+                "label": "이메일",
             },
             "footer_apply": "적용",
             "group": {
@@ -2642,6 +2676,7 @@ export default {
             "timeRange": {
                 "description": "실행 시간으로 필터링",
                 "label": "간격",
+                "applyTo": "적용 대상",
                 "chip": {
                     "end": "종료됨",
                     "start": "시작됨",
@@ -2798,6 +2833,10 @@ export default {
             "flowId": {
                 "description": "Filtruj według flow ID",
                 "label": "Identyfikator flow",
+            },
+            "email": {
+                "description": "Filtruj według e-mail",
+                "label": "E-mail",
             },
             "footer_apply": "Zastosuj",
             "group": {
@@ -2982,6 +3021,7 @@ export default {
             "timeRange": {
                 "description": "Filtruj według czasu wykonania",
                 "label": "Interwał",
+                "applyTo": "Zastosuj do",
                 "chip": {
                     "end": "Zakończono",
                     "start": "Rozpoczęto",
@@ -3138,6 +3178,10 @@ export default {
             "flowId": {
                 "description": "Filtrar por flow ID",
                 "label": "ID do Flow",
+            },
+            "email": {
+                "description": "Filtrar por e-mail",
+                "label": "E-mail",
             },
             "footer_apply": "Aplicar",
             "group": {
@@ -3322,6 +3366,7 @@ export default {
             "timeRange": {
                 "description": "Filtrar por tempo de execução",
                 "label": "Intervalo",
+                "applyTo": "Aplicar a",
                 "chip": {
                     "end": "Finalizado",
                     "start": "Iniciado",
@@ -3478,6 +3523,10 @@ export default {
             "flowId": {
                 "description": "Filtrar por flow ID",
                 "label": "ID do Flow",
+            },
+            "email": {
+                "description": "Filtrar por e-mail",
+                "label": "E-mail",
             },
             "footer_apply": "Aplicar",
             "group": {
@@ -3662,6 +3711,7 @@ export default {
             "timeRange": {
                 "description": "Filtrar por tempo de execução",
                 "label": "Intervalo",
+                "applyTo": "Aplicar a",
                 "chip": {
                     "end": "Finalizado",
                     "start": "Iniciado",
@@ -3818,6 +3868,10 @@ export default {
             "flowId": {
                 "description": "Фильтр по flow ID",
                 "label": "Идентификатор flow",
+            },
+            "email": {
+                "description": "Фильтр по электронной почте",
+                "label": "Электронная почта",
             },
             "footer_apply": "Применить",
             "group": {
@@ -4002,6 +4056,7 @@ export default {
             "timeRange": {
                 "description": "Фильтр по времени выполнения",
                 "label": "Интервал",
+                "applyTo": "Применить к",
                 "chip": {
                     "end": "Завершено",
                     "start": "Начато",
@@ -4158,6 +4213,10 @@ export default {
             "flowId": {
                 "description": "按 flow ID 筛选",
                 "label": "Flow ID",
+            },
+            "email": {
+                "description": "按邮箱筛选",
+                "label": "邮箱",
             },
             "footer_apply": "应用",
             "group": {
@@ -4342,6 +4401,7 @@ export default {
             "timeRange": {
                 "description": "按执行时间筛选",
                 "label": "间隔",
+                "applyTo": "应用于",
                 "chip": {
                     "end": "结束",
                     "start": "已启动",

--- a/ui/packages/design-system/tests/units/locale.test.ts
+++ b/ui/packages/design-system/tests/units/locale.test.ts
@@ -1,0 +1,107 @@
+/**
+ * Validates that every *.locale.ts file under the design-system components
+ * directory is complete: all supported languages are present and each
+ * non-English language has exactly the same set of nested keys as English.
+ *
+ * This test is intentionally kept simple and fast — it runs in jsdom with no
+ * Vue runtime.  Its sole purpose is to catch missing or extra translation keys
+ * introduced by contributors before they reach the autotranslate CI action.
+ */
+import {describe, it, expect} from "vitest"
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+/**
+ * Recursively collect every key path in a nested object, e.g.
+ * { a: { b: 1, c: 2 } } → ["a", "a.b", "a.c"]
+ */
+const getNestedKeys = (obj: Record<string, unknown>, prefix = ""): string[] =>
+    Object.keys(obj).reduce<string[]>((keys, key) => {
+        const fullKey = prefix ? `${prefix}.${key}` : key
+        keys.push(fullKey)
+        if (typeof obj[key] === "object" && obj[key] !== null) {
+            keys.push(...getNestedKeys(obj[key] as Record<string, unknown>, fullKey))
+        }
+        return keys
+    }, [])
+
+// ─── Constants ───────────────────────────────────────────────────────────────
+
+const SUPPORTED_LANGUAGES = [
+    "de",
+    "en",
+    "es",
+    "fr",
+    "hi",
+    "it",
+    "ja",
+    "ko",
+    "pl",
+    "pt",
+    "pt_BR",
+    "ru",
+    "zh_CN",
+] as const
+
+type Language = (typeof SUPPORTED_LANGUAGES)[number]
+const NON_ENGLISH_LANGUAGES = SUPPORTED_LANGUAGES.filter((l) => l !== "en") as Language[]
+
+// ─── Load all locale modules eagerly ─────────────────────────────────────────
+
+const localeModules = import.meta.glob<{default: Record<Language, Record<string, unknown>>}>(
+    "../../src/components/**/*.locale.ts",
+    {eager: true},
+)
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+describe("design-system locale files", () => {
+    it("at least one locale file is found", () => {
+        expect(Object.keys(localeModules).length).toBeGreaterThan(0)
+    })
+
+    for (const [filePath, module] of Object.entries(localeModules)) {
+        // Keep the path short for readability in test output
+        const shortPath = filePath.replace(/^.*\/components\//, "")
+        const translations = module.default
+
+        describe(shortPath, () => {
+            it("has all supported languages", () => {
+                const missingLanguages = SUPPORTED_LANGUAGES.filter(
+                    (lang) => !(lang in translations),
+                )
+                expect(
+                    missingLanguages,
+                    `Missing language entries: ${missingLanguages.join(", ")}`,
+                ).toEqual([])
+            })
+
+            it("every language has the same keys as English", () => {
+                const englishKeys = getNestedKeys((translations.en ?? {}) as Record<string, unknown>)
+                const errors: string[] = []
+
+                for (const lang of NON_ENGLISH_LANGUAGES) {
+                    if (!(lang in translations)) {
+                        // Already reported by the "has all supported languages" test above
+                        continue
+                    }
+
+                    const langKeys = getNestedKeys(
+                        translations[lang] as Record<string, unknown>,
+                    )
+                    const missing = englishKeys.filter((k) => !langKeys.includes(k))
+                    const extra = langKeys.filter((k) => !englishKeys.includes(k))
+
+                    if (missing.length) {
+                        errors.push(`[${lang}] missing keys: ${missing.join(", ")}`)
+                    }
+                    if (extra.length) {
+                        errors.push(`[${lang}] extra keys: ${extra.join(", ")}`)
+                    }
+                }
+
+                expect(errors, errors.join("\n")).toEqual([])
+            })
+        })
+    }
+})

--- a/ui/src/translations/check.js
+++ b/ui/src/translations/check.js
@@ -2,7 +2,9 @@ import fs from "fs"
 import path from "path"
 import {fileURLToPath} from "url"
 
-const getPath = (lang) => path.resolve(path.dirname(fileURLToPath(import.meta.url)), `./${lang}.json`)
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+
+const getPath = (lang) => path.resolve(__dirname, `./${lang}.json`)
 const readJSON = (filePath) => JSON.parse(fs.readFileSync(filePath, "utf-8"))
 
 const getNestedKeys = (obj, prefix = "") =>
@@ -17,6 +19,8 @@ const getNestedKeys = (obj, prefix = "") =>
         }
         return keys
     }, [])
+
+// ─── JSON translations check ─────────────────────────────────────────────────
 
 // Use English as a base language
 const content = getNestedKeys(readJSON(getPath("en"))["en"])
@@ -42,15 +46,110 @@ languages.forEach((lang, i) => {
     if(extra.length) globalExtra[lang] = extra
 })
 
+// ─── Design-system *.locale.ts files check ───────────────────────────────────
+
+/**
+ * Recursively find all files whose names end with ".locale.ts" under `dir`.
+ * @param {string} dir
+ * @returns {string[]}
+ */
+function findLocaleFiles(dir) {
+    const results = []
+    for (const item of fs.readdirSync(dir, {withFileTypes: true})) {
+        const fullPath = path.join(dir, item.name)
+        if (item.isDirectory()) {
+            results.push(...findLocaleFiles(fullPath))
+        } else if (item.name.endsWith(".locale.ts")) {
+            results.push(fullPath)
+        }
+    }
+    return results
+}
+
+/**
+ * Evaluate a *.locale.ts file that uses the pattern `export default { ... }`.
+ * The files contain only a plain object literal — no TypeScript type
+ * annotations — so stripping the ESM export keyword and using the Function
+ * constructor is safe and avoids any build-step dependency.
+ *
+ * @param {string} filePath
+ * @returns {Record<string, Record<string, unknown>>}
+ */
+function readLocaleTs(filePath) {
+    const raw = fs.readFileSync(filePath, "utf-8")
+    const objectLiteral = raw
+        .replace(/^export\s+default\s+/, "")
+        .trimEnd()
+        .replace(/;$/, "")
+    // The Function constructor is intentional here: locale files are
+    // build-time assets under our own control and contain only data.
+     
+    return new Function("return " + objectLiteral)()
+}
+
+const designSystemComponentsDir = path.resolve(
+    __dirname,
+    "../../packages/design-system/src/components",
+)
+
+const localeFiles = findLocaleFiles(designSystemComponentsDir)
+
+const globalMissingLocale = {}
+const globalExtraLocale = {}
+
+for (const localeFile of localeFiles) {
+    const relativePath = path.relative(designSystemComponentsDir, localeFile)
+    const translations = readLocaleTs(localeFile)
+    const englishKeys = getNestedKeys(translations.en ?? {})
+
+    console.log(`\n=== Checking design-system locale: ${relativePath} ===\n`)
+
+    // Check that all supported (non-English) language sections are present
+    const missingLangs = languages.filter((lang) => !(lang in translations))
+    if (missingLangs.length) {
+        console.log(`Missing language sections: \x1b[31m${missingLangs.join(", ")}\x1b[0m`)
+    }
+
+    for (const lang of languages) {
+        if (!(lang in translations)) continue
+
+        const langKeys = getNestedKeys(translations[lang])
+        const missing = englishKeys.filter((k) => !langKeys.includes(k))
+        const extra = langKeys.filter((k) => !englishKeys.includes(k))
+
+        console.log(`---\n\x1b[34mComparison with ${lang.toUpperCase()} in ${relativePath}\x1b[0m  \n`)
+        console.log(missing.length ? `Missing keys: \x1b[31m${missing.join(", ")}\x1b[0m` : "No missing keys.")
+        console.log(extra.length ? `Extra keys: \x1b[32m${extra.join(", ")}\x1b[0m` : "No extra keys.")
+        console.log("---\n")
+
+        if (missing.length) {
+            if (!globalMissingLocale[lang]) globalMissingLocale[lang] = {}
+            globalMissingLocale[lang][relativePath] = missing
+        }
+        if (extra.length) {
+            if (!globalExtraLocale[lang]) globalExtraLocale[lang] = {}
+            globalExtraLocale[lang][relativePath] = extra
+        }
+    }
+}
+
+// ─── Final error check ───────────────────────────────────────────────────────
+
 let errorString = ""
-if(Object.keys(globalMissing).length) {
-    errorString += "\nMissing keys in translations"
+
+if (Object.keys(globalMissing).length) {
+    errorString += "\nMissing keys in JSON translations"
+}
+if (Object.keys(globalExtra).length) {
+    errorString += "\nExtra keys in JSON translations"
+}
+if (Object.keys(globalMissingLocale).length) {
+    errorString += "\nMissing keys in design-system locale.ts files"
+}
+if (Object.keys(globalExtraLocale).length) {
+    errorString += "\nExtra keys in design-system locale.ts files"
 }
 
-if(Object.keys(globalExtra).length) {
-    errorString += "\nExtra keys in translations"
-}
-
-if(errorString.length){
+if (errorString.length) {
     throw new Error(errorString)
 }

--- a/ui/src/translations/generate_translations.py
+++ b/ui/src/translations/generate_translations.py
@@ -2,7 +2,10 @@
 To run it locally, add OPENAI_API_KEY env variable and pip install gitpython openai
 """
 import json
+import re
+import subprocess
 import sys
+import os
 import git
 from openai import OpenAI
 
@@ -10,7 +13,7 @@ client = OpenAI()
 
 
 def translate_text(text, target_language):
-    prompt = f"""Translate the text provided after "----------" into {target_language} for use in Kestra’s orchestration UI. Follow these guidelines:
+    prompt = f"""Translate the text provided after "----------" into {target_language} for use in Kestra's orchestration UI. Follow these guidelines:
         - Output Only the Translation: Provide only the translated text, with no additional commentary or explanation.
         - Maintain Technical Accuracy: Use correct translations for technical terms (avoid literal translations that change the meaning).
         - Reserved English Terms (Do Not Translate): Keep the following terms in English (adjusting capitalization or plural forms as needed): kv store, namespace, flow, subflow, task, log, blueprint, id, trigger, label, key, value, input, output, port, worker, backfill, healthcheck, min, max. For example, in German, "log" must remain "Log" in phrases: translate "Log level" as "Log-Ebene" (not "Protokoll-Ebene"), and "Task logs" stays "Task Logs" (not "Aufgabenprotokolle"). Important: do not alter "flow" or "namespace" at all – keep them exactly as "flow" and "namespace."
@@ -158,12 +161,153 @@ def main(language_code, target_language, input_file="ui/src/translations/en.json
     with open(f"ui/src/translations/{language_code}.json", "w") as f:
         json.dump({language_code: updated_target_dict}, f, ensure_ascii=False, indent=2, sort_keys=True)
 
+
+# ─── Design-system locale.ts helpers ─────────────────────────────────────────
+
+def _needs_quoting(key: str) -> bool:
+    """Return True if a JS/TS object key requires quoting."""
+    return not re.match(r'^[a-zA-Z_$][a-zA-Z0-9_$]*$', key)
+
+
+def _dict_to_ts_literal(obj: dict, indent: int = 1) -> str:
+    """
+    Recursively convert a Python dict to a TypeScript object-literal string
+    with 4-space indentation, trailing commas, and correct key quoting.
+    """
+    pad = "    " * indent
+    outer_pad = "    " * (indent - 1)
+    lines = []
+    for key, value in obj.items():
+        formatted_key = f'"{key}"' if _needs_quoting(key) else key
+        if isinstance(value, dict):
+            lines.append(
+                f"{pad}{formatted_key}: {_dict_to_ts_literal(value, indent + 1)},"
+            )
+        else:
+            lines.append(
+                f"{pad}{formatted_key}: {json.dumps(value, ensure_ascii=False)},"
+            )
+    return "{\n" + "\n".join(lines) + "\n" + outer_pad + "}"
+
+
+def read_locale_ts(file_path: str) -> dict:
+    """
+    Read a *.locale.ts file and return its content as a Python dict.
+
+    The files use the pattern ``export default { ... }`` with plain JS object
+    literal syntax (no TypeScript type annotations), so we can safely evaluate
+    them with Node.js's ``Function`` constructor without a full TS compile step.
+    """
+    # Build an inline Node.js CJS snippet that evaluates the file and prints JSON.
+    node_code = (
+        "var fs = require('fs');"
+        f"var raw = fs.readFileSync({json.dumps(file_path)}, 'utf-8');"
+        "var lit = raw.replace(/^export\\s+default\\s+/, '').replace(/;\\s*$/, '');"
+        "process.stdout.write(JSON.stringify(new Function('return ' + lit)()));"
+    )
+    result = subprocess.run(
+        ["node", "--eval", node_code],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return json.loads(result.stdout)
+
+
+def write_locale_ts(file_path: str, translations: dict) -> None:
+    """Write a translations dict back to a *.locale.ts file."""
+    content = "export default " + _dict_to_ts_literal(translations) + "\n"
+    with open(file_path, "w", encoding="utf-8") as f:
+        f.write(content)
+
+
+def find_locale_ts_files(components_dir: str) -> list[str]:
+    """Recursively find all *.locale.ts files under *components_dir*."""
+    results = []
+    for root, _dirs, files in os.walk(components_dir):
+        for name in files:
+            if name.endswith(".locale.ts"):
+                results.append(os.path.join(root, name))
+    return sorted(results)
+
+
+def translate_locale_ts_files(
+    language_code: str,
+    target_language: str,
+    components_dir: str = "ui/packages/design-system/src/components",
+    retranslate_modified_keys: bool = False,
+) -> None:
+    """
+    For every *.locale.ts file in *components_dir*, translate any English keys
+    that are missing (or have been modified) for *language_code*.
+
+    Strategy
+    --------
+    Rather than tracking git history for each locale file, we rely on the
+    simpler invariant that is always correct: if the target language is missing
+    a key that exists in English, that key needs to be translated.  This means
+    the function is idempotent and safe to re-run.
+    """
+    locale_files = find_locale_ts_files(components_dir)
+
+    for locale_file in locale_files:
+        print(f"\n--- Processing {locale_file} for {language_code} ---")
+
+        try:
+            translations = read_locale_ts(locale_file)
+        except Exception as exc:
+            print(f"  ERROR reading {locale_file}: {exc}")
+            continue
+
+        if "en" not in translations:
+            print(f"  Skipping — no 'en' section found.")
+            continue
+
+        english_flat = flatten_dict(translations["en"])
+
+        # Build or load the existing target-language section
+        if language_code not in translations:
+            print(f"  Language section '{language_code}' is missing — will create it.")
+            translations[language_code] = {}
+
+        target_flat = flatten_dict(translations[language_code])
+        updated = False
+
+        for key, en_value in english_flat.items():
+            already_translated = key in target_flat and target_flat[key]
+            if already_translated and not retranslate_modified_keys:
+                continue
+
+            translated_value = translate_text(en_value, target_language)
+            target_flat[key] = translated_value
+            print(f"  Translated [{language_code}] '{key}': '{en_value}' → '{translated_value}'")
+            updated = True
+
+        if not updated:
+            print(f"  No new keys to translate for '{language_code}'.")
+            continue
+
+        # Remove any keys in the target language that no longer exist in English
+        target_flat = {k: v for k, v in target_flat.items() if k in english_flat}
+
+        translations[language_code] = unflatten_dict(target_flat)
+
+        # Preserve the canonical language order: en first, then alphabetical
+        ordered = {"en": translations["en"]}
+        for lang in sorted(k for k in translations if k != "en"):
+            ordered[lang] = translations[lang]
+
+        write_locale_ts(locale_file, ordered)
+        print(f"  Written: {locale_file}")
+
+
 if __name__ == "__main__":
     # Default to 'false' if no argument is provided
     bool_from_ci = False
     if len(sys.argv) > 1 and sys.argv[1].lower() == "true":
         bool_from_ci = True
 
+    # ── Translate main JSON files ─────────────────────────────────────────────
     main(language_code="de", target_language="German", retranslate_modified_keys=bool_from_ci)
     main(language_code="es", target_language="Spanish", retranslate_modified_keys=bool_from_ci)
     main(language_code="fr", target_language="French", retranslate_modified_keys=bool_from_ci)
@@ -176,3 +320,17 @@ if __name__ == "__main__":
     main(language_code="pt_BR", target_language="Portuguese (Brazil)", retranslate_modified_keys=bool_from_ci)
     main(language_code="ru", target_language="Russian", retranslate_modified_keys=bool_from_ci)
     main(language_code="zh_CN", target_language="Simplified Chinese (Mandarin)", retranslate_modified_keys=bool_from_ci)
+
+    # ── Translate design-system *.locale.ts files ─────────────────────────────
+    translate_locale_ts_files(language_code="de", target_language="German", retranslate_modified_keys=bool_from_ci)
+    translate_locale_ts_files(language_code="es", target_language="Spanish", retranslate_modified_keys=bool_from_ci)
+    translate_locale_ts_files(language_code="fr", target_language="French", retranslate_modified_keys=bool_from_ci)
+    translate_locale_ts_files(language_code="hi", target_language="Hindi", retranslate_modified_keys=bool_from_ci)
+    translate_locale_ts_files(language_code="it", target_language="Italian", retranslate_modified_keys=bool_from_ci)
+    translate_locale_ts_files(language_code="ja", target_language="Japanese", retranslate_modified_keys=bool_from_ci)
+    translate_locale_ts_files(language_code="ko", target_language="Korean", retranslate_modified_keys=bool_from_ci)
+    translate_locale_ts_files(language_code="pl", target_language="Polish", retranslate_modified_keys=bool_from_ci)
+    translate_locale_ts_files(language_code="pt", target_language="Portuguese", retranslate_modified_keys=bool_from_ci)
+    translate_locale_ts_files(language_code="pt_BR", target_language="Portuguese (Brazil)", retranslate_modified_keys=bool_from_ci)
+    translate_locale_ts_files(language_code="ru", target_language="Russian", retranslate_modified_keys=bool_from_ci)
+    translate_locale_ts_files(language_code="zh_CN", target_language="Simplified Chinese (Mandarin)", retranslate_modified_keys=bool_from_ci)


### PR DESCRIPTION
closes #16200 

## ✨ Description

This PR extends the translation infrastructure to support `*.locale.ts` files in the design-system components directory, enabling automated translation of component-level locale strings alongside the existing JSON-based UI translations.

### Key Changes

1. **Translation Generation** (`generate_translations.py`)
   - Added helper functions to read/write TypeScript locale files (`read_locale_ts`, `write_locale_ts`)
   - Implemented `translate_locale_ts_files()` to automatically translate missing keys in design-system locale files
   - Uses Node.js to safely evaluate locale file object literals without requiring a TypeScript compiler
   - Integrated locale file translation into the main translation pipeline for all supported languages

2. **Translation Validation** (`check.js`)
   - Extended validation to check design-system `*.locale.ts` files for completeness
   - Verifies all supported languages are present in each locale file
   - Detects missing or extra translation keys across all locale files
   - Provides detailed reporting of translation gaps

3. **Unit Tests** (`locale.test.ts`)
   - Added comprehensive test suite for design-system locale files
   - Validates that all supported languages are present in each locale file
   - Ensures every non-English language has exactly the same nested keys as English
   - Uses Vitest with eager glob imports for fast, isolated testing

4. **Locale File Updates** (`KsFilter.locale.ts`)
   - Added missing translations for new filter fields (`email`) across all languages
   - Added missing translations for `timeRange.applyTo` field across all languages
   - Maintains consistent structure and key ordering

### Technical Details

- Locale files use plain JavaScript object literal syntax (no TypeScript annotations), making them safe to evaluate with Node.js's `Function` constructor
- Translation strategy is idempotent: any missing key in the target language is automatically translated
- Preserves canonical language order (English first, then alphabetical) in output files
- Properly handles key quoting for non-standard JavaScript identifiers

## 🔗 Related Issue

N/A

## 🎨 Frontend Checklist

- [x] Code builds without errors
- [x] New unit tests added and passing (`locale.test.ts`)
- [x] Existing translation validation extended and passing
- [x] All locale files updated with missing translations

## 📝 Additional Notes

The translation generation script is designed to be idempotent and safe to re-run. It only translates keys that are missing in the target language, making it suitable for both initial setup and ongoing maintenance as new locale files are added to the design-system.

https://claude.ai/code/session_01NZDj6Y3Lu6soM6sSM1TQCU