### PR TITLE
feat: expand log filter fields

### DIFF
--- a/core/src/main/java/io/kestra/core/models/QueryFilter.java
+++ b/core/src/main/java/io/kestra/core/models/QueryFilter.java
@@ -299,6 +299,12 @@ public record QueryFilter(
                 return List.of(Op.EQUALS, Op.NOT_EQUALS, Op.CONTAINS, Op.STARTS_WITH, Op.ENDS_WITH, Op.IN, Op.NOT_IN);
             }
         },
+        ATTEMPT_NUMBER("attemptNumber") {
+            @Override
+            public List<Op> supportedOp() {
+                return List.of(Op.EQUALS, Op.NOT_EQUALS, Op.IN, Op.NOT_IN);
+            }
+        },
         CHILD_FILTER("childFilter") {
             @Override
             public List<Op> supportedOp() {
@@ -335,10 +341,10 @@ public record QueryFilter(
                 return List.of(Op.EQUALS);
             }
         },
-        MIN_LEVEL("level") {
+        LEVEL("level") {
             @Override
             public List<Op> supportedOp() {
-                return List.of(Op.EQUALS, Op.NOT_EQUALS);
+                return List.of(Op.GREATER_THAN_OR_EQUAL_TO, Op.LESS_THAN_OR_EQUAL_TO);
             }
         },
         PATH("path") {
@@ -428,7 +434,7 @@ public record QueryFilter(
         NAMESPACE {
             @Override
             public List<Field> supportedField() {
-                return List.of(Field.NAMESPACE);
+                return List.of(Field.NAMESPACE, Field.QUERY);
             }
         },
         EXECUTION {
@@ -446,7 +452,8 @@ public record QueryFilter(
             public List<Field> supportedField() {
                 return List.of(
                     Field.QUERY, Field.SCOPE, Field.NAMESPACE, Field.START_DATE,
-                    Field.END_DATE, Field.FLOW_ID, Field.TRIGGER_ID, Field.MIN_LEVEL, Field.EXECUTION_ID
+                    Field.END_DATE, Field.FLOW_ID, Field.TRIGGER_ID, Field.LEVEL, Field.EXECUTION_ID,
+                    Field.TASK_ID, Field.TASK_RUN_ID, Field.ATTEMPT_NUMBER
                 );
             }
         },

--- a/core/src/main/java/io/kestra/core/models/executions/LogEntry.java
+++ b/core/src/main/java/io/kestra/core/models/executions/LogEntry.java
@@ -74,6 +74,16 @@ public class LogEntry implements TenantInterface, DispatchEvent {
             .toList();
     }
 
+    public static List<Level> findLevelsByMax(Level maxLevel) {
+        if (maxLevel == null) {
+            return Arrays.asList(Level.values());
+        }
+
+        return Arrays.stream(Level.values())
+            .filter(level -> level.toInt() <= maxLevel.toInt())
+            .toList();
+    }
+
     public static LogEntry of(Execution execution) {
         return LogEntry.builder()
             .tenantId(execution.getTenantId())

--- a/core/src/main/java/io/kestra/core/services/FollowLogEventMatcher.java
+++ b/core/src/main/java/io/kestra/core/services/FollowLogEventMatcher.java
@@ -1,0 +1,18 @@
+package io.kestra.core.services;
+
+import java.util.List;
+
+import io.kestra.core.models.QueryFilter;
+import io.kestra.core.runners.FollowLogEvent;
+
+/**
+ * Predicate that decides whether a {@link FollowLogEvent} passes a list of {@link QueryFilter}s.
+ * Used by {@link LogStreamingService} to filter events being fanned out to SSE subscribers.
+ * <p>
+ * The implementation lives in the webserver module (backed by {@code Searchable<FollowLogEvent>})
+ * — this interface keeps {@code core} free of that dependency.
+ */
+@FunctionalInterface
+public interface FollowLogEventMatcher {
+    boolean matches(FollowLogEvent event, List<QueryFilter> filters);
+}

--- a/core/src/main/java/io/kestra/core/services/LogStreamingService.java
+++ b/core/src/main/java/io/kestra/core/services/LogStreamingService.java
@@ -6,6 +6,7 @@ import java.util.concurrent.ConcurrentHashMap;
 
 import org.apache.commons.lang3.tuple.Pair;
 
+import io.kestra.core.models.QueryFilter;
 import io.kestra.core.queues.BroadcastQueueInterface;
 import io.kestra.core.queues.QueueSubscriber;
 import io.kestra.core.runners.FollowLogEvent;
@@ -24,15 +25,22 @@ import reactor.core.publisher.FluxSink;
  * <p>
  * Consumers need first to register themselves via {@link #registerSubscriber(String, String, FluxSink, List)},
  * then unregister (ideally in a finally block to avoid any memory leak) via {@link #unregisterSubscriber(String, String)}.
+ * <p>
+ * Each subscriber is registered with a list of {@link QueryFilter}s. Incoming events are matched
+ * against those filters via the injected {@link Searchable}; only events that match every filter
+ * are forwarded to that subscriber.
  */
 @Slf4j
 @Singleton
 public class LogStreamingService {
-    private final Map<String, Map<String, Pair<FluxSink<Event<FollowLogEvent>>, List<String>>>> subscribers = new ConcurrentHashMap<>();
+    private final Map<String, Map<String, Pair<FluxSink<Event<FollowLogEvent>>, List<QueryFilter>>>> subscribers = new ConcurrentHashMap<>();
     private final Object subscriberLock = new Object();
 
     @Inject
     protected BroadcastQueueInterface<FollowLogEvent> logQueue;
+
+    @Inject
+    protected FollowLogEventMatcher followLogEventMatcher;
 
     private QueueSubscriber<FollowLogEvent> queueSubscriber;
 
@@ -58,15 +66,15 @@ public class LogStreamingService {
             }
 
             // Get all subscribers for this execution
-            Map<String, Pair<FluxSink<Event<FollowLogEvent>>, List<String>>> executionSubscribers = subscribers.get(current.executionId());
+            Map<String, Pair<FluxSink<Event<FollowLogEvent>>, List<QueryFilter>>> executionSubscribers = subscribers.get(current.executionId());
 
             if (executionSubscribers != null && !executionSubscribers.isEmpty()) {
                 executionSubscribers.values().forEach(pair ->
                 {
                     var sink = pair.getLeft();
-                    var levels = pair.getRight();
+                    var filters = pair.getRight();
 
-                    if (levels.contains(current.level().name())) {
+                    if (followLogEventMatcher.matches(current, filters)) {
                         sink.next(Event.of(current).id("progress"));
                     }
                 });
@@ -75,16 +83,17 @@ public class LogStreamingService {
     }
 
     /**
-     * Register a subscriber to an execution logs.
+     * Register a subscriber to an execution logs. The provided {@code filters} are applied to
+     * every event before it is forwarded; an empty or {@code null} list forwards everything.
      * All subscribers must ensure to call {@link #unregisterSubscriber(String, String)} to avoid any memory leak.
      */
-    public void registerSubscriber(String executionId, String subscriberId, FluxSink<Event<FollowLogEvent>> sink, List<String> levels) {
+    public void registerSubscriber(String executionId, String subscriberId, FluxSink<Event<FollowLogEvent>> sink, List<QueryFilter> filters) {
         // it needs to be synchronized as we get and remove if empty, so we must be sure that nobody else is adding a new one in-between
         synchronized (subscriberLock) {
             // Register the subscriber BEFORE resuming the queue to avoid a race where the polling
             // thread delivers an event between resume() and put(), causing events to be dropped.
             subscribers.computeIfAbsent(executionId, k -> new ConcurrentHashMap<>())
-                .put(subscriberId, Pair.of(sink, levels));
+                .put(subscriberId, Pair.of(sink, filters));
 
             if (this.queueSubscriber.isPaused()) {
                 this.queueSubscriber.resume();
@@ -99,7 +108,7 @@ public class LogStreamingService {
     public void unregisterSubscriber(String executionId, String subscriberId) {
         // it needs to be synchronized as we get and remove if empty, so we must be sure that nobody else is adding a new one in-between
         synchronized (subscriberLock) {
-            Map<String, Pair<FluxSink<Event<FollowLogEvent>>, List<String>>> executionSubscribers = subscribers.get(executionId);
+            Map<String, Pair<FluxSink<Event<FollowLogEvent>>, List<QueryFilter>>> executionSubscribers = subscribers.get(executionId);
             if (executionSubscribers != null) {
                 executionSubscribers.remove(subscriberId);
                 if (executionSubscribers.isEmpty()) {

--- a/core/src/main/java/io/kestra/plugin/core/dashboard/data/ILogs.java
+++ b/core/src/main/java/io/kestra/plugin/core/dashboard/data/ILogs.java
@@ -4,10 +4,14 @@ import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.slf4j.event.Level;
+
 import io.kestra.core.models.QueryFilter;
 import io.kestra.core.models.dashboards.filters.AbstractFilter;
 import io.kestra.core.models.dashboards.filters.GreaterThanOrEqualTo;
+import io.kestra.core.models.dashboards.filters.In;
 import io.kestra.core.models.dashboards.filters.LessThanOrEqualTo;
+import io.kestra.core.models.executions.LogEntry;
 
 public interface ILogs extends IData<ILogs.Fields> {
 
@@ -31,6 +35,24 @@ public interface ILogs extends IData<ILogs.Fields> {
                 flowFilters.forEach(f ->
                 {
                     updatedWhere.add(f.toDashboardFilterBuilder(Fields.FLOW_ID, f.value()));
+                });
+            }
+
+            List<QueryFilter> levelFilters = filters.stream().filter(f -> f.field().equals(QueryFilter.Field.LEVEL)).toList();
+            if (!levelFilters.isEmpty()) {
+                updatedWhere.removeIf(filter -> filter.getField().equals(Fields.LEVEL));
+                levelFilters.forEach(f ->
+                {
+                    Level level = f.value() instanceof Level l ? l : Level.valueOf((String) f.value());
+                    List<Level> levels = switch (f.operation()) {
+                        case GREATER_THAN_OR_EQUAL_TO -> LogEntry.findLevelsByMin(level);
+                        case LESS_THAN_OR_EQUAL_TO -> LogEntry.findLevelsByMax(level);
+                        default -> throw new IllegalArgumentException("Unsupported operation for LEVEL: " + f.operation());
+                    };
+                    updatedWhere.add(In.<Fields>builder()
+                        .field(Fields.LEVEL)
+                        .values(levels.stream().map(Enum::name).map(Object.class::cast).toList())
+                        .build());
                 });
             }
         }

--- a/core/src/test/java/io/kestra/core/models/QueryFilterTest.java
+++ b/core/src/test/java/io/kestra/core/models/QueryFilterTest.java
@@ -212,10 +212,10 @@ public class QueryFilterTest {
             ),
 
             buildQueryFiltersForOperations(
-                Field.MIN_LEVEL, Resource.LOG,
+                Field.LEVEL, Resource.LOG,
                 Set.of(
-                    Op.EQUALS,
-                    Op.NOT_EQUALS
+                    Op.GREATER_THAN_OR_EQUAL_TO,
+                    Op.LESS_THAN_OR_EQUAL_TO
                 )
             ),
 
@@ -916,12 +916,12 @@ public class QueryFilterTest {
             ),
 
             buildQueryFiltersForOperations(
-                Field.MIN_LEVEL, Resource.LOG,
+                Field.LEVEL, Resource.LOG,
                 Set.of(
+                    Op.EQUALS,
+                    Op.NOT_EQUALS,
                     Op.GREATER_THAN,
                     Op.LESS_THAN,
-                    Op.GREATER_THAN_OR_EQUAL_TO,
-                    Op.LESS_THAN_OR_EQUAL_TO,
                     Op.IN,
                     Op.NOT_IN,
                     Op.STARTS_WITH,
@@ -1031,8 +1031,6 @@ public class QueryFilterTest {
                 Set.of(
                     Op.GREATER_THAN,
                     Op.LESS_THAN,
-                    Op.GREATER_THAN_OR_EQUAL_TO,
-                    Op.LESS_THAN_OR_EQUAL_TO,
                     Op.IN,
                     Op.NOT_IN,
                     Op.STARTS_WITH,
@@ -1040,7 +1038,6 @@ public class QueryFilterTest {
                     Op.CONTAINS,
                     Op.REGEX,
                     Op.PREFIX
-
                 )
             ),
 

--- a/core/src/test/java/io/kestra/core/repositories/AbstractExecutionRepositoryTest.java
+++ b/core/src/test/java/io/kestra/core/repositories/AbstractExecutionRepositoryTest.java
@@ -397,7 +397,7 @@ public abstract class AbstractExecutionRepositoryTest {
             QueryFilter.builder().field(Field.TRIGGER_ID).value("test").operation(Op.EQUALS).build(),
             QueryFilter.builder().field(Field.EXECUTION_ID).value("test").operation(Op.EQUALS).build(),
             QueryFilter.builder().field(Field.WORKER_ID).value("test").operation(Op.EQUALS).build(),
-            QueryFilter.builder().field(Field.MIN_LEVEL).value(Level.DEBUG).operation(Op.EQUALS).build()
+            QueryFilter.builder().field(Field.LEVEL).value(Level.DEBUG).operation(Op.GREATER_THAN_OR_EQUAL_TO).build()
         );
     }
 

--- a/core/src/test/java/io/kestra/core/repositories/AbstractFlowRepositoryTest.java
+++ b/core/src/test/java/io/kestra/core/repositories/AbstractFlowRepositoryTest.java
@@ -243,7 +243,7 @@ public abstract class AbstractFlowRepositoryTest {
             QueryFilter.builder().field(Field.CHILD_FILTER).value(ChildFilter.CHILD).operation(Op.EQUALS).build(),
             QueryFilter.builder().field(Field.WORKER_ID).value("test").operation(Op.EQUALS).build(),
             QueryFilter.builder().field(Field.EXISTING_ONLY).value("test").operation(Op.EQUALS).build(),
-            QueryFilter.builder().field(Field.MIN_LEVEL).value(Level.DEBUG).operation(Op.EQUALS).build()
+            QueryFilter.builder().field(Field.LEVEL).value(Level.DEBUG).operation(Op.GREATER_THAN_OR_EQUAL_TO).build()
         );
     }
 

--- a/core/src/test/java/io/kestra/core/repositories/AbstractLogRepositoryTest.java
+++ b/core/src/test/java/io/kestra/core/repositories/AbstractLogRepositoryTest.java
@@ -10,8 +10,11 @@ import java.util.stream.Stream;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.FieldSource;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.slf4j.event.Level;
+
+import lombok.Builder;
 
 import io.kestra.core.exceptions.InvalidQueryFiltersException;
 import io.kestra.core.models.QueryFilter;
@@ -145,8 +148,8 @@ public abstract class AbstractLogRepositoryTest {
             QueryFilter.builder().field(Field.EXECUTION_ID).value("Id").operation(Op.ENDS_WITH).build(),
             QueryFilter.builder().field(Field.EXECUTION_ID).value(List.of("executionId")).operation(Op.IN).build(),
             QueryFilter.builder().field(Field.EXECUTION_ID).value(List.of("anotherId")).operation(Op.NOT_IN).build(),
-            QueryFilter.builder().field(Field.MIN_LEVEL).value(Level.DEBUG).operation(Op.EQUALS).build(),
-            QueryFilter.builder().field(Field.MIN_LEVEL).value(Level.ERROR).operation(Op.NOT_EQUALS).build()
+            QueryFilter.builder().field(Field.LEVEL).value(Level.DEBUG).operation(Op.GREATER_THAN_OR_EQUAL_TO).build(),
+            QueryFilter.builder().field(Field.LEVEL).value(Level.INFO).operation(Op.LESS_THAN_OR_EQUAL_TO).build()
         );
     }
 
@@ -172,7 +175,9 @@ public abstract class AbstractLogRepositoryTest {
             QueryFilter.builder().field(Field.TRIGGER_EXECUTION_ID).value("test").operation(Op.EQUALS).build(),
             QueryFilter.builder().field(Field.CHILD_FILTER).value(ChildFilter.CHILD).operation(Op.EQUALS).build(),
             QueryFilter.builder().field(Field.WORKER_ID).value("test").operation(Op.EQUALS).build(),
-            QueryFilter.builder().field(Field.EXISTING_ONLY).value("test").operation(Op.EQUALS).build()
+            QueryFilter.builder().field(Field.EXISTING_ONLY).value("test").operation(Op.EQUALS).build(),
+            QueryFilter.builder().field(Field.LEVEL).value(Level.INFO).operation(Op.EQUALS).build(),
+            QueryFilter.builder().field(Field.LEVEL).value(Level.INFO).operation(Op.NOT_EQUALS).build()
         );
     }
 
@@ -192,8 +197,8 @@ public abstract class AbstractLogRepositoryTest {
         assertThat(find.getFirst().getExecutionId()).isEqualTo(save.getExecutionId());
         var filters = List.of(
             QueryFilter.builder()
-                .field(QueryFilter.Field.MIN_LEVEL)
-                .operation(QueryFilter.Op.EQUALS)
+                .field(QueryFilter.Field.LEVEL)
+                .operation(QueryFilter.Op.GREATER_THAN_OR_EQUAL_TO)
                 .value(Level.WARN)
                 .build(),
             QueryFilter.builder()
@@ -423,5 +428,381 @@ public abstract class AbstractLogRepositoryTest {
 
         var result = logRepository.purge(List.of(Execution.builder().id("execution1").build(), Execution.builder().id("execution2").build()));
         assertThat(result).isEqualTo(4);
+    }
+
+    private static final LogEntry traceLog = logEntry(null, Level.TRACE, "exec-trace").build();
+    private static final LogEntry debugLog = logEntry(null, Level.DEBUG, "exec-debug").build();
+    private static final LogEntry infoLog = logEntry(null, Level.INFO, "exec-info").build();
+    private static final LogEntry warnLog = logEntry(null, Level.WARN, "exec-warn").build();
+    private static final LogEntry errorLog = logEntry(null, Level.ERROR, "exec-error").build();
+    private static final List<LogEntry> allLevels = List.of(traceLog, debugLog, infoLog, warnLog, errorLog);
+
+    private static final LogEntry loadDataLog = logEntry(null, Level.INFO, "exec-load-data")
+        .taskId("load-data").taskRunId("tr-load-data").attemptNumber(0).build();
+    private static final LogEntry transformLog = logEntry(null, Level.INFO, "exec-transform")
+        .taskId("transform").taskRunId("tr-transform").attemptNumber(1).build();
+    private static final LogEntry sinkLog = logEntry(null, Level.INFO, "exec-sink")
+        .taskId("sink").taskRunId("tr-sink").attemptNumber(2).build();
+    private static final List<LogEntry> taskVariedLogs = List.of(loadDataLog, transformLog, sinkLog);
+
+    private static final LogEntry alphaLog = logEntry(null, Level.INFO, "exec-alpha")
+        .namespace("io.kestra.alpha")
+        .flowId("alpha-flow").triggerId("alpha-trigger")
+        .taskId("alpha-task").taskRunId("alpha-tr")
+        .message("alpha message").build();
+    private static final LogEntry betaLog = logEntry(null, Level.INFO, "exec-beta")
+        .namespace("io.kestra.beta")
+        .flowId("beta-flow").triggerId("beta-trigger")
+        .taskId("beta-task").taskRunId("beta-tr")
+        .message("beta message").build();
+    private static final LogEntry gammaLog = logEntry(null, Level.INFO, "exec-gamma")
+        .namespace("com.example.gamma")
+        .flowId("gamma-flow").triggerId("gamma-trigger")
+        .taskId("gamma-task").taskRunId("gamma-tr")
+        .message("gamma message").build();
+    private static final List<LogEntry> distinctLogs = List.of(alphaLog, betaLog, gammaLog);
+
+    private static final LogEntry userScopeLog = logEntry(null, Level.INFO, "exec-user-scope")
+        .namespace("io.kestra.user").build();
+    private static final LogEntry systemScopeLog = logEntry(null, Level.INFO, "exec-system-scope")
+        .namespace("system").build();
+    private static final List<LogEntry> scopeLogs = List.of(userScopeLog, systemScopeLog);
+
+    private static final Instant T_PAST = Instant.parse("2020-01-01T00:00:00Z");
+    private static final Instant T_NOW = Instant.parse("2020-06-01T00:00:00Z");
+    private static final Instant T_FUTURE = Instant.parse("2020-12-31T00:00:00Z");
+    private static final LogEntry pastLog = logEntry(null, Level.INFO, "exec-past").timestamp(T_PAST).build();
+    private static final LogEntry nowLog = logEntry(null, Level.INFO, "exec-now").timestamp(T_NOW).build();
+    private static final LogEntry futureLog = logEntry(null, Level.INFO, "exec-future").timestamp(T_FUTURE).build();
+    private static final List<LogEntry> timeLogs = List.of(pastLog, nowLog, futureLog);
+
+    public static final List<FiltersTestCase> filtersTestCases = List.of(
+        FiltersTestCase.builder()
+            .logs(allLevels)
+            .expectedLogs(List.of(infoLog, warnLog, errorLog))
+            .queryFilter(QueryFilter.builder()
+                .field(Field.LEVEL).value(Level.INFO).operation(Op.GREATER_THAN_OR_EQUAL_TO)
+                .build())
+            .build(),
+
+        FiltersTestCase.builder()
+            .logs(allLevels)
+            .expectedLogs(List.of(traceLog, debugLog, infoLog))
+            .queryFilter(QueryFilter.builder()
+                .field(Field.LEVEL).value(Level.INFO).operation(Op.LESS_THAN_OR_EQUAL_TO)
+                .build())
+            .build(),
+
+        FiltersTestCase.builder()
+            .logs(allLevels)
+            .expectedLogs(allLevels)
+            .queryFilter(QueryFilter.builder()
+                .field(Field.LEVEL).value(Level.TRACE).operation(Op.GREATER_THAN_OR_EQUAL_TO)
+                .build())
+            .build(),
+
+        FiltersTestCase.builder()
+            .logs(allLevels)
+            .expectedLogs(allLevels)
+            .queryFilter(QueryFilter.builder()
+                .field(Field.LEVEL).value(Level.ERROR).operation(Op.LESS_THAN_OR_EQUAL_TO)
+                .build())
+            .build(),
+
+        FiltersTestCase.builder()
+            .logs(allLevels)
+            .expectedLogs(List.of(errorLog))
+            .queryFilter(QueryFilter.builder()
+                .field(Field.LEVEL).value(Level.ERROR).operation(Op.GREATER_THAN_OR_EQUAL_TO)
+                .build())
+            .build(),
+
+        FiltersTestCase.builder()
+            .logs(allLevels)
+            .expectedLogs(List.of(traceLog))
+            .queryFilter(QueryFilter.builder()
+                .field(Field.LEVEL).value(Level.TRACE).operation(Op.LESS_THAN_OR_EQUAL_TO)
+                .build())
+            .build(),
+
+        FiltersTestCase.builder()
+            .logs(taskVariedLogs)
+            .expectedLogs(List.of(loadDataLog))
+            .queryFilter(QueryFilter.builder()
+                .field(Field.TASK_ID).value("load-data").operation(Op.EQUALS)
+                .build())
+            .build(),
+
+        FiltersTestCase.builder()
+            .logs(taskVariedLogs)
+            .expectedLogs(List.of(transformLog, sinkLog))
+            .queryFilter(QueryFilter.builder()
+                .field(Field.TASK_ID).value("load-data").operation(Op.NOT_EQUALS)
+                .build())
+            .build(),
+
+        FiltersTestCase.builder()
+            .logs(taskVariedLogs)
+            .expectedLogs(List.of(loadDataLog, transformLog))
+            .queryFilter(QueryFilter.builder()
+                .field(Field.TASK_ID).value(List.of("load-data", "transform")).operation(Op.IN)
+                .build())
+            .build(),
+
+        FiltersTestCase.builder()
+            .logs(taskVariedLogs)
+            .expectedLogs(List.of(transformLog))
+            .queryFilter(QueryFilter.builder()
+                .field(Field.TASK_RUN_ID).value("tr-transform").operation(Op.EQUALS)
+                .build())
+            .build(),
+
+        FiltersTestCase.builder()
+            .logs(taskVariedLogs)
+            .expectedLogs(List.of(loadDataLog, sinkLog))
+            .queryFilter(QueryFilter.builder()
+                .field(Field.TASK_RUN_ID).value(List.of("tr-load-data", "tr-sink")).operation(Op.IN)
+                .build())
+            .build(),
+
+        FiltersTestCase.builder()
+            .logs(taskVariedLogs)
+            .expectedLogs(List.of(transformLog))
+            .queryFilter(QueryFilter.builder()
+                .field(Field.ATTEMPT_NUMBER).value(1).operation(Op.EQUALS)
+                .build())
+            .build(),
+
+        FiltersTestCase.builder()
+            .logs(taskVariedLogs)
+            .expectedLogs(List.of(loadDataLog, sinkLog))
+            .queryFilter(QueryFilter.builder()
+                .field(Field.ATTEMPT_NUMBER).value(1).operation(Op.NOT_EQUALS)
+                .build())
+            .build(),
+
+        FiltersTestCase.builder()
+            .logs(taskVariedLogs)
+            .expectedLogs(List.of(loadDataLog, transformLog))
+            .queryFilter(QueryFilter.builder()
+                .field(Field.ATTEMPT_NUMBER).value(List.of(0, 1)).operation(Op.IN)
+                .build()).build(),
+
+        FiltersTestCase.builder()
+            .logs(taskVariedLogs)
+            .expectedLogs(List.of(transformLog))
+            .queryFilter(QueryFilter.builder()
+                .field(Field.ATTEMPT_NUMBER).value(List.of(0, 2)).operation(Op.NOT_IN)
+                .build()).build(),
+
+        FiltersTestCase.builder()
+            .logs(distinctLogs).expectedLogs(List.of(alphaLog))
+            .queryFilter(QueryFilter.builder().field(Field.TASK_ID).value("alpha").operation(Op.CONTAINS).build()).build(),
+        FiltersTestCase.builder()
+            .logs(distinctLogs).expectedLogs(List.of(alphaLog))
+            .queryFilter(QueryFilter.builder().field(Field.TASK_ID).value("alpha").operation(Op.STARTS_WITH).build()).build(),
+        FiltersTestCase.builder()
+            .logs(distinctLogs).expectedLogs(List.of(alphaLog))
+            .queryFilter(QueryFilter.builder().field(Field.TASK_ID).value("alpha-task").operation(Op.ENDS_WITH).build()).build(),
+        FiltersTestCase.builder()
+            .logs(distinctLogs).expectedLogs(List.of(gammaLog))
+            .queryFilter(QueryFilter.builder().field(Field.TASK_ID).value(List.of("alpha-task", "beta-task")).operation(Op.NOT_IN).build()).build(),
+
+        FiltersTestCase.builder()
+            .logs(distinctLogs).expectedLogs(List.of(betaLog, gammaLog))
+            .queryFilter(QueryFilter.builder().field(Field.TASK_RUN_ID).value("alpha-tr").operation(Op.NOT_EQUALS).build()).build(),
+        FiltersTestCase.builder()
+            .logs(distinctLogs).expectedLogs(List.of(betaLog))
+            .queryFilter(QueryFilter.builder().field(Field.TASK_RUN_ID).value("beta").operation(Op.CONTAINS).build()).build(),
+        FiltersTestCase.builder()
+            .logs(distinctLogs).expectedLogs(List.of(alphaLog))
+            .queryFilter(QueryFilter.builder().field(Field.TASK_RUN_ID).value("alpha").operation(Op.STARTS_WITH).build()).build(),
+        FiltersTestCase.builder()
+            .logs(distinctLogs).expectedLogs(List.of(gammaLog))
+            .queryFilter(QueryFilter.builder().field(Field.TASK_RUN_ID).value("gamma-tr").operation(Op.ENDS_WITH).build()).build(),
+        FiltersTestCase.builder()
+            .logs(distinctLogs).expectedLogs(List.of(gammaLog))
+            .queryFilter(QueryFilter.builder().field(Field.TASK_RUN_ID).value(List.of("alpha-tr", "beta-tr")).operation(Op.NOT_IN).build()).build(),
+
+        FiltersTestCase.builder()
+            .logs(distinctLogs).expectedLogs(List.of(alphaLog))
+            .queryFilter(QueryFilter.builder().field(Field.QUERY).value("alpha message").operation(Op.EQUALS).build()).build(),
+        FiltersTestCase.builder()
+            .logs(distinctLogs).expectedLogs(List.of(betaLog, gammaLog))
+            .queryFilter(QueryFilter.builder().field(Field.QUERY).value("alpha message").operation(Op.NOT_EQUALS).build()).build(),
+
+        FiltersTestCase.builder()
+            .logs(scopeLogs).expectedLogs(List.of(userScopeLog))
+            .queryFilter(QueryFilter.builder().field(Field.SCOPE).value(List.of(io.kestra.core.models.flows.FlowScope.USER)).operation(Op.EQUALS).build()).build(),
+        FiltersTestCase.builder()
+            .logs(scopeLogs).expectedLogs(List.of(systemScopeLog))
+            .queryFilter(QueryFilter.builder().field(Field.SCOPE).value(List.of(io.kestra.core.models.flows.FlowScope.USER)).operation(Op.NOT_EQUALS).build()).build(),
+        FiltersTestCase.builder()
+            .logs(scopeLogs).expectedLogs(List.of(userScopeLog))
+            .queryFilter(QueryFilter.builder().field(Field.SCOPE).value(List.of(io.kestra.core.models.flows.FlowScope.USER)).operation(Op.IN).build()).build(),
+        FiltersTestCase.builder()
+            .logs(scopeLogs).expectedLogs(List.of(systemScopeLog))
+            .queryFilter(QueryFilter.builder().field(Field.SCOPE).value(List.of(io.kestra.core.models.flows.FlowScope.USER)).operation(Op.NOT_IN).build()).build(),
+
+        FiltersTestCase.builder()
+            .logs(distinctLogs).expectedLogs(List.of(alphaLog))
+            .queryFilter(QueryFilter.builder().field(Field.NAMESPACE).value("io.kestra.alpha").operation(Op.EQUALS).build()).build(),
+        FiltersTestCase.builder()
+            .logs(distinctLogs).expectedLogs(List.of(betaLog, gammaLog))
+            .queryFilter(QueryFilter.builder().field(Field.NAMESPACE).value("io.kestra.alpha").operation(Op.NOT_EQUALS).build()).build(),
+        FiltersTestCase.builder()
+            .logs(distinctLogs).expectedLogs(List.of(alphaLog, betaLog))
+            .queryFilter(QueryFilter.builder().field(Field.NAMESPACE).value("kestra").operation(Op.CONTAINS).build()).build(),
+        FiltersTestCase.builder()
+            .logs(distinctLogs).expectedLogs(List.of(alphaLog, betaLog))
+            .queryFilter(QueryFilter.builder().field(Field.NAMESPACE).value("io.kestra").operation(Op.STARTS_WITH).build()).build(),
+        FiltersTestCase.builder()
+            .logs(distinctLogs).expectedLogs(List.of(gammaLog))
+            .queryFilter(QueryFilter.builder().field(Field.NAMESPACE).value("gamma").operation(Op.ENDS_WITH).build()).build(),
+        FiltersTestCase.builder()
+            .logs(distinctLogs).expectedLogs(List.of(alphaLog, betaLog))
+            .queryFilter(QueryFilter.builder().field(Field.NAMESPACE).value("io\\.kestra.*").operation(Op.REGEX).build()).build(),
+        FiltersTestCase.builder()
+            .logs(distinctLogs).expectedLogs(List.of(alphaLog, betaLog))
+            .queryFilter(QueryFilter.builder().field(Field.NAMESPACE).value(List.of("io.kestra.alpha", "io.kestra.beta")).operation(Op.IN).build()).build(),
+        FiltersTestCase.builder()
+            .logs(distinctLogs).expectedLogs(List.of(gammaLog))
+            .queryFilter(QueryFilter.builder().field(Field.NAMESPACE).value(List.of("io.kestra.alpha", "io.kestra.beta")).operation(Op.NOT_IN).build()).build(),
+        FiltersTestCase.builder()
+            .logs(distinctLogs).expectedLogs(List.of(alphaLog, betaLog))
+            .queryFilter(QueryFilter.builder().field(Field.NAMESPACE).value("io.kestra").operation(Op.PREFIX).build()).build(),
+
+        FiltersTestCase.builder()
+            .logs(timeLogs).expectedLogs(List.of(nowLog, futureLog))
+            .queryFilter(QueryFilter.builder().field(Field.START_DATE).value(T_NOW.atZone(java.time.ZoneOffset.UTC)).operation(Op.GREATER_THAN_OR_EQUAL_TO).build()).build(),
+        FiltersTestCase.builder()
+            .logs(timeLogs).expectedLogs(List.of(futureLog))
+            .queryFilter(QueryFilter.builder().field(Field.START_DATE).value(T_NOW.atZone(java.time.ZoneOffset.UTC)).operation(Op.GREATER_THAN).build()).build(),
+        FiltersTestCase.builder()
+            .logs(timeLogs).expectedLogs(List.of(pastLog, nowLog))
+            .queryFilter(QueryFilter.builder().field(Field.START_DATE).value(T_NOW.atZone(java.time.ZoneOffset.UTC)).operation(Op.LESS_THAN_OR_EQUAL_TO).build()).build(),
+        FiltersTestCase.builder()
+            .logs(timeLogs).expectedLogs(List.of(pastLog))
+            .queryFilter(QueryFilter.builder().field(Field.START_DATE).value(T_NOW.atZone(java.time.ZoneOffset.UTC)).operation(Op.LESS_THAN).build()).build(),
+        FiltersTestCase.builder()
+            .logs(timeLogs).expectedLogs(List.of(nowLog))
+            .queryFilter(QueryFilter.builder().field(Field.START_DATE).value(T_NOW.atZone(java.time.ZoneOffset.UTC)).operation(Op.EQUALS).build()).build(),
+        FiltersTestCase.builder()
+            .logs(timeLogs).expectedLogs(List.of(pastLog, futureLog))
+            .queryFilter(QueryFilter.builder().field(Field.START_DATE).value(T_NOW.atZone(java.time.ZoneOffset.UTC)).operation(Op.NOT_EQUALS).build()).build(),
+
+        FiltersTestCase.builder()
+            .logs(timeLogs).expectedLogs(List.of(nowLog, futureLog))
+            .queryFilter(QueryFilter.builder().field(Field.END_DATE).value(T_NOW.atZone(java.time.ZoneOffset.UTC)).operation(Op.GREATER_THAN_OR_EQUAL_TO).build()).build(),
+        FiltersTestCase.builder()
+            .logs(timeLogs).expectedLogs(List.of(futureLog))
+            .queryFilter(QueryFilter.builder().field(Field.END_DATE).value(T_NOW.atZone(java.time.ZoneOffset.UTC)).operation(Op.GREATER_THAN).build()).build(),
+        FiltersTestCase.builder()
+            .logs(timeLogs).expectedLogs(List.of(pastLog, nowLog))
+            .queryFilter(QueryFilter.builder().field(Field.END_DATE).value(T_NOW.atZone(java.time.ZoneOffset.UTC)).operation(Op.LESS_THAN_OR_EQUAL_TO).build()).build(),
+        FiltersTestCase.builder()
+            .logs(timeLogs).expectedLogs(List.of(pastLog))
+            .queryFilter(QueryFilter.builder().field(Field.END_DATE).value(T_NOW.atZone(java.time.ZoneOffset.UTC)).operation(Op.LESS_THAN).build()).build(),
+        FiltersTestCase.builder()
+            .logs(timeLogs).expectedLogs(List.of(nowLog))
+            .queryFilter(QueryFilter.builder().field(Field.END_DATE).value(T_NOW.atZone(java.time.ZoneOffset.UTC)).operation(Op.EQUALS).build()).build(),
+        FiltersTestCase.builder()
+            .logs(timeLogs).expectedLogs(List.of(pastLog, futureLog))
+            .queryFilter(QueryFilter.builder().field(Field.END_DATE).value(T_NOW.atZone(java.time.ZoneOffset.UTC)).operation(Op.NOT_EQUALS).build()).build(),
+
+        FiltersTestCase.builder()
+            .logs(distinctLogs).expectedLogs(List.of(alphaLog))
+            .queryFilter(QueryFilter.builder().field(Field.FLOW_ID).value("alpha-flow").operation(Op.EQUALS).build()).build(),
+        FiltersTestCase.builder()
+            .logs(distinctLogs).expectedLogs(List.of(betaLog, gammaLog))
+            .queryFilter(QueryFilter.builder().field(Field.FLOW_ID).value("alpha-flow").operation(Op.NOT_EQUALS).build()).build(),
+        FiltersTestCase.builder()
+            .logs(distinctLogs).expectedLogs(List.of(alphaLog))
+            .queryFilter(QueryFilter.builder().field(Field.FLOW_ID).value("alpha").operation(Op.CONTAINS).build()).build(),
+        FiltersTestCase.builder()
+            .logs(distinctLogs).expectedLogs(List.of(alphaLog))
+            .queryFilter(QueryFilter.builder().field(Field.FLOW_ID).value("alpha").operation(Op.STARTS_WITH).build()).build(),
+        FiltersTestCase.builder()
+            .logs(distinctLogs).expectedLogs(distinctLogs)
+            .queryFilter(QueryFilter.builder().field(Field.FLOW_ID).value("-flow").operation(Op.ENDS_WITH).build()).build(),
+        FiltersTestCase.builder()
+            .logs(distinctLogs).expectedLogs(List.of(alphaLog))
+            .queryFilter(QueryFilter.builder().field(Field.FLOW_ID).value("alpha-.*").operation(Op.REGEX).build()).build(),
+        FiltersTestCase.builder()
+            .logs(distinctLogs).expectedLogs(List.of(alphaLog, betaLog))
+            .queryFilter(QueryFilter.builder().field(Field.FLOW_ID).value(List.of("alpha-flow", "beta-flow")).operation(Op.IN).build()).build(),
+        FiltersTestCase.builder()
+            .logs(distinctLogs).expectedLogs(List.of(gammaLog))
+            .queryFilter(QueryFilter.builder().field(Field.FLOW_ID).value(List.of("alpha-flow", "beta-flow")).operation(Op.NOT_IN).build()).build(),
+        FiltersTestCase.builder()
+            .logs(distinctLogs).expectedLogs(List.of(alphaLog))
+            .queryFilter(QueryFilter.builder().field(Field.FLOW_ID).value("alpha-flow").operation(Op.PREFIX).build()).build(),
+
+        FiltersTestCase.builder()
+            .logs(distinctLogs).expectedLogs(List.of(alphaLog))
+            .queryFilter(QueryFilter.builder().field(Field.TRIGGER_ID).value("alpha-trigger").operation(Op.EQUALS).build()).build(),
+        FiltersTestCase.builder()
+            .logs(distinctLogs).expectedLogs(List.of(betaLog, gammaLog))
+            .queryFilter(QueryFilter.builder().field(Field.TRIGGER_ID).value("alpha-trigger").operation(Op.NOT_EQUALS).build()).build(),
+        FiltersTestCase.builder()
+            .logs(distinctLogs).expectedLogs(List.of(alphaLog))
+            .queryFilter(QueryFilter.builder().field(Field.TRIGGER_ID).value("alpha").operation(Op.CONTAINS).build()).build(),
+        FiltersTestCase.builder()
+            .logs(distinctLogs).expectedLogs(List.of(alphaLog))
+            .queryFilter(QueryFilter.builder().field(Field.TRIGGER_ID).value("alpha").operation(Op.STARTS_WITH).build()).build(),
+        FiltersTestCase.builder()
+            .logs(distinctLogs).expectedLogs(distinctLogs)
+            .queryFilter(QueryFilter.builder().field(Field.TRIGGER_ID).value("-trigger").operation(Op.ENDS_WITH).build()).build(),
+        FiltersTestCase.builder()
+            .logs(distinctLogs).expectedLogs(List.of(alphaLog, betaLog))
+            .queryFilter(QueryFilter.builder().field(Field.TRIGGER_ID).value(List.of("alpha-trigger", "beta-trigger")).operation(Op.IN).build()).build(),
+        FiltersTestCase.builder()
+            .logs(distinctLogs).expectedLogs(List.of(gammaLog))
+            .queryFilter(QueryFilter.builder().field(Field.TRIGGER_ID).value(List.of("alpha-trigger", "beta-trigger")).operation(Op.NOT_IN).build()).build(),
+
+        FiltersTestCase.builder()
+            .logs(distinctLogs).expectedLogs(List.of(alphaLog))
+            .queryFilter(QueryFilter.builder().field(Field.EXECUTION_ID).value("exec-alpha").operation(Op.EQUALS).build()).build(),
+        FiltersTestCase.builder()
+            .logs(distinctLogs).expectedLogs(List.of(betaLog, gammaLog))
+            .queryFilter(QueryFilter.builder().field(Field.EXECUTION_ID).value("exec-alpha").operation(Op.NOT_EQUALS).build()).build(),
+        FiltersTestCase.builder()
+            .logs(distinctLogs).expectedLogs(List.of(alphaLog))
+            .queryFilter(QueryFilter.builder().field(Field.EXECUTION_ID).value("alpha").operation(Op.CONTAINS).build()).build(),
+        FiltersTestCase.builder()
+            .logs(distinctLogs).expectedLogs(distinctLogs)
+            .queryFilter(QueryFilter.builder().field(Field.EXECUTION_ID).value("exec-").operation(Op.STARTS_WITH).build()).build(),
+        FiltersTestCase.builder()
+            .logs(distinctLogs).expectedLogs(List.of(alphaLog))
+            .queryFilter(QueryFilter.builder().field(Field.EXECUTION_ID).value("alpha").operation(Op.ENDS_WITH).build()).build(),
+        FiltersTestCase.builder()
+            .logs(distinctLogs).expectedLogs(List.of(alphaLog, betaLog))
+            .queryFilter(QueryFilter.builder().field(Field.EXECUTION_ID).value(List.of("exec-alpha", "exec-beta")).operation(Op.IN).build()).build(),
+        FiltersTestCase.builder()
+            .logs(distinctLogs).expectedLogs(List.of(gammaLog))
+            .queryFilter(QueryFilter.builder().field(Field.EXECUTION_ID).value(List.of("exec-alpha", "exec-beta")).operation(Op.NOT_IN).build()).build()
+    );
+
+    @ParameterizedTest
+    @FieldSource("filtersTestCases")
+    void findWithFilters(FiltersTestCase testCase) {
+        String tenant = TestsUtils.randomTenant(this.getClass().getSimpleName());
+        testCase.logs().forEach(log -> logRepository.save(log.toBuilder().tenantId(tenant).build()));
+
+        ArrayListTotal<LogEntry> results = logRepository.find(
+            Pageable.UNPAGED, tenant, List.of(testCase.queryFilter()));
+
+        assertThat(results)
+            .extracting(LogEntry::getExecutionId)
+            .containsExactlyInAnyOrderElementsOf(
+                testCase.expectedLogs().stream().map(LogEntry::getExecutionId).toList()
+            );
+    }
+
+    @Builder
+    public record FiltersTestCase(
+        List<LogEntry> logs,
+        List<LogEntry> expectedLogs,
+        QueryFilter queryFilter) {
     }
 }

--- a/core/src/test/java/io/kestra/core/repositories/AbstractTriggerRepositoryTest.java
+++ b/core/src/test/java/io/kestra/core/repositories/AbstractTriggerRepositoryTest.java
@@ -123,7 +123,7 @@ public abstract class AbstractTriggerRepositoryTest {
             QueryFilter.builder().field(Field.TRIGGER_EXECUTION_ID).value("test").operation(Op.EQUALS).build(),
             QueryFilter.builder().field(Field.EXECUTION_ID).value("test").operation(Op.EQUALS).build(),
             QueryFilter.builder().field(Field.CHILD_FILTER).value(ChildFilter.CHILD).operation(Op.EQUALS).build(),
-            QueryFilter.builder().field(Field.MIN_LEVEL).value(Level.DEBUG).operation(Op.EQUALS).build()
+            QueryFilter.builder().field(Field.LEVEL).value(Level.DEBUG).operation(Op.GREATER_THAN_OR_EQUAL_TO).build()
         );
     }
 

--- a/core/src/test/java/io/kestra/plugin/core/dashboard/data/DashboardDataGlobalFiltersTest.java
+++ b/core/src/test/java/io/kestra/plugin/core/dashboard/data/DashboardDataGlobalFiltersTest.java
@@ -3,10 +3,12 @@ package io.kestra.plugin.core.dashboard.data;
 import io.kestra.core.models.QueryFilter;
 import io.kestra.core.models.dashboards.filters.In;
 import org.junit.jupiter.api.Test;
+import org.slf4j.event.Level;
 
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class DashboardDataGlobalFiltersTest {
     @Test
@@ -49,5 +51,139 @@ class DashboardDataGlobalFiltersTest {
         In<?> inFilter = (In<?>) where.get(0);
         assertThat(((Enum<?>) inFilter.getField()).name()).isEqualTo(IMetrics.Fields.NAMESPACE.name());
         assertThat(inFilter.getValues()).containsExactly("company.team");
+    }
+
+    @Test
+    void shouldExpandLevelGreaterThanOrEqualToForLogs() {
+        QueryFilter levelFilter = QueryFilter.builder()
+            .field(QueryFilter.Field.LEVEL)
+            .operation(QueryFilter.Op.GREATER_THAN_OR_EQUAL_TO)
+            .value(Level.INFO)
+            .build();
+
+        ILogs iLogs = new ILogs() {
+        };
+
+        var where = iLogs.whereWithGlobalFilters(List.of(levelFilter), null, null, null);
+
+        assertThat(where).hasSize(1);
+        assertThat(where.get(0)).isInstanceOf(In.class);
+
+        In<?> inFilter = (In<?>) where.get(0);
+        assertThat(((Enum<?>) inFilter.getField()).name()).isEqualTo(ILogs.Fields.LEVEL.name());
+        assertThat(inFilter.getValues()).containsExactlyInAnyOrder("INFO", "WARN", "ERROR");
+    }
+
+    @Test
+    void shouldExpandLevelLessThanOrEqualToForLogs() {
+        QueryFilter levelFilter = QueryFilter.builder()
+            .field(QueryFilter.Field.LEVEL)
+            .operation(QueryFilter.Op.LESS_THAN_OR_EQUAL_TO)
+            .value(Level.INFO)
+            .build();
+
+        ILogs iLogs = new ILogs() {
+        };
+
+        var where = iLogs.whereWithGlobalFilters(List.of(levelFilter), null, null, null);
+
+        assertThat(where).hasSize(1);
+        assertThat(where.get(0)).isInstanceOf(In.class);
+
+        In<?> inFilter = (In<?>) where.get(0);
+        assertThat(((Enum<?>) inFilter.getField()).name()).isEqualTo(ILogs.Fields.LEVEL.name());
+        assertThat(inFilter.getValues()).containsExactlyInAnyOrder("TRACE", "DEBUG", "INFO");
+    }
+
+    @Test
+    void shouldAcceptStringLevelValueForLogs() {
+        QueryFilter levelFilter = QueryFilter.builder()
+            .field(QueryFilter.Field.LEVEL)
+            .operation(QueryFilter.Op.GREATER_THAN_OR_EQUAL_TO)
+            .value("WARN")
+            .build();
+
+        ILogs iLogs = new ILogs() {
+        };
+
+        var where = iLogs.whereWithGlobalFilters(List.of(levelFilter), null, null, null);
+
+        In<?> inFilter = (In<?>) where.get(0);
+        assertThat(inFilter.getValues()).containsExactlyInAnyOrder("WARN", "ERROR");
+    }
+
+    @Test
+    void shouldRejectUnsupportedLevelOperationForLogs() {
+        QueryFilter levelFilter = QueryFilter.builder()
+            .field(QueryFilter.Field.LEVEL)
+            .operation(QueryFilter.Op.EQUALS)
+            .value(Level.INFO)
+            .build();
+
+        ILogs iLogs = new ILogs() {
+        };
+
+        assertThatThrownBy(() -> iLogs.whereWithGlobalFilters(List.of(levelFilter), null, null, null))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("LEVEL");
+    }
+
+    @Test
+    void shouldComposeLevelWithNamespaceAndFlowFiltersForLogs() {
+        List<QueryFilter> filters = List.of(
+            QueryFilter.builder()
+                .field(QueryFilter.Field.NAMESPACE)
+                .operation(QueryFilter.Op.IN)
+                .value(List.of("company.team"))
+                .build(),
+            QueryFilter.builder()
+                .field(QueryFilter.Field.FLOW_ID)
+                .operation(QueryFilter.Op.IN)
+                .value(List.of("my-flow"))
+                .build(),
+            QueryFilter.builder()
+                .field(QueryFilter.Field.LEVEL)
+                .operation(QueryFilter.Op.GREATER_THAN_OR_EQUAL_TO)
+                .value(Level.WARN)
+                .build()
+        );
+
+        ILogs iLogs = new ILogs() {
+        };
+
+        var where = iLogs.whereWithGlobalFilters(filters, null, null, null);
+
+        assertThat(where).hasSize(3);
+        assertThat(where).anyMatch(f -> ((Enum<?>) f.getField()).name().equals(ILogs.Fields.NAMESPACE.name()));
+        assertThat(where).anyMatch(f -> ((Enum<?>) f.getField()).name().equals(ILogs.Fields.FLOW_ID.name()));
+
+        In<?> levelIn = (In<?>) where.stream()
+            .filter(f -> ((Enum<?>) f.getField()).name().equals(ILogs.Fields.LEVEL.name()))
+            .findFirst()
+            .orElseThrow();
+        assertThat(levelIn.getValues()).containsExactlyInAnyOrder("WARN", "ERROR");
+    }
+
+    @Test
+    void shouldReplaceExistingLevelFilterInWhereClauseForLogs() {
+        QueryFilter levelFilter = QueryFilter.builder()
+            .field(QueryFilter.Field.LEVEL)
+            .operation(QueryFilter.Op.GREATER_THAN_OR_EQUAL_TO)
+            .value(Level.ERROR)
+            .build();
+
+        var existingLevelFilter = In.<ILogs.Fields>builder()
+            .field(ILogs.Fields.LEVEL)
+            .values(List.of("TRACE", "DEBUG"))
+            .build();
+
+        ILogs iLogs = new ILogs() {
+        };
+
+        var where = iLogs.whereWithGlobalFilters(List.of(levelFilter), null, null, List.of(existingLevelFilter));
+
+        assertThat(where).hasSize(1);
+        In<?> inFilter = (In<?>) where.get(0);
+        assertThat(inFilter.getValues()).containsExactly("ERROR");
     }
 }

--- a/jdbc/src/main/java/io/kestra/jdbc/repository/AbstractJdbcLogRepository.java
+++ b/jdbc/src/main/java/io/kestra/jdbc/repository/AbstractJdbcLogRepository.java
@@ -78,6 +78,20 @@ public abstract class AbstractJdbcLogRepository extends AbstractJdbcCrudReposito
         return findPage(pageable, tenantId, condition);
     }
 
+    /**
+     * The log table column for {@code TASK_RUN_ID} is {@code taskrun_id} (one word), not
+     * {@code task_run_id} as the default snake-case derivation would produce. Override the
+     * default mapping for that one mismatch; the rest of the column names line up with
+     * {@link QueryFilter.Field#name()} lower-cased.
+     */
+    @Override
+    protected Name getColumnName(QueryFilter.Field field) {
+        if (field == QueryFilter.Field.TASK_RUN_ID) {
+            return DSL.quotedName("taskrun_id");
+        }
+        return super.getColumnName(field);
+    }
+
     @Override
     public Flux<LogEntry> findAsync(@Nullable String tenantId, List<QueryFilter> filters) {
         var condition = NORMAL_KIND_CONDITION.and(this.filter(filters, DATE_COLUMN, Resource.LOG));

--- a/jdbc/src/main/java/io/kestra/jdbc/repository/AbstractJdbcRepository.java
+++ b/jdbc/src/main/java/io/kestra/jdbc/repository/AbstractJdbcRepository.java
@@ -296,9 +296,14 @@ public abstract class AbstractJdbcRepository {
         if (field.equals(QueryFilter.Field.CHILD_FILTER)) {
             return handleChildFilter(value, operation);
         }
-        // Handling for Field.MIN_LEVEL
-        if (field.equals(QueryFilter.Field.MIN_LEVEL)) {
-            return handleMinLevelField(value, operation);
+        // Handling for Field.LEVEL
+        if (field.equals(QueryFilter.Field.LEVEL)) {
+            return handleLevelField(value, operation);
+        }
+        // Handling for Field.ATTEMPT_NUMBER — integer column, URL value arrives as String
+        // and Postgres won't auto-coerce '1' to integer. Parse before binding.
+        if (field.equals(QueryFilter.Field.ATTEMPT_NUMBER)) {
+            return handleAttemptNumberField(value, operation);
         }
 
         // Special handling for START_DATE and END_DATE
@@ -548,24 +553,51 @@ public abstract class AbstractJdbcRepository {
         };
     }
 
-    private Condition handleMinLevelField(Object value, QueryFilter.Op operation) {
-        Level minLevel = value instanceof Level ? (Level) value : Level.valueOf((String) value);
+    private Condition handleLevelField(Object value, QueryFilter.Op operation) {
+        Level level = value instanceof Level ? (Level) value : Level.valueOf((String) value);
 
         return switch (operation) {
-            case EQUALS -> minLevelCondition(minLevel);
-            case NOT_EQUALS -> minLevelCondition(minLevel).not();
+            case GREATER_THAN_OR_EQUAL_TO -> levelsCondition(LogEntry.findLevelsByMin(level));
+            case LESS_THAN_OR_EQUAL_TO -> levelsCondition(LogEntry.findLevelsByMax(level));
             default -> throw new InvalidQueryFiltersException(
-                "Unsupported operation for MIN_LEVEL: " + operation
+                "Unsupported operation for LEVEL: " + operation
             );
         };
     }
 
-    private Condition minLevelCondition(Level minLevel) {
-        return levelsCondition(LogEntry.findLevelsByMin(minLevel));
-    }
-
     protected Condition levelsCondition(List<Level> levels) {
         return field("level").in(levels.stream().map(level -> level.name()).toList());
+    }
+
+    private Condition handleAttemptNumberField(Object value, QueryFilter.Op operation) {
+        Name columnName = getColumnName(QueryFilter.Field.ATTEMPT_NUMBER);
+        return switch (operation) {
+            case EQUALS -> DSL.field(columnName).eq(toInteger(value));
+            case NOT_EQUALS -> DSL.field(columnName).ne(toInteger(value));
+            case IN -> DSL.field(columnName).in(toIntegerList(value));
+            case NOT_IN -> DSL.field(columnName).notIn(toIntegerList(value));
+            default -> throw new InvalidQueryFiltersException(
+                "Unsupported operation for ATTEMPT_NUMBER: " + operation
+            );
+        };
+    }
+
+    // ToDo: We should create reusable classes for type conversion
+    private static Integer toInteger(Object value) {
+        if (value == null) {
+            return null;
+        }
+        if (value instanceof Number n) {
+            return n.intValue();
+        }
+        return Integer.parseInt(value.toString());
+    }
+
+    private static List<Integer> toIntegerList(Object value) {
+        if (value instanceof List<?> list) {
+            return list.stream().map(AbstractJdbcRepository::toInteger).toList();
+        }
+        return List.of(toInteger(value));
     }
 
     private Condition applyDateCondition(OffsetDateTime dateTime, QueryFilter.Op operation, String fieldName) {

--- a/jdbc/src/test/java/io/kestra/jdbc/repository/AbstractJdbcRepositoryTest.java
+++ b/jdbc/src/test/java/io/kestra/jdbc/repository/AbstractJdbcRepositoryTest.java
@@ -18,7 +18,7 @@ class AbstractJdbcRepositoryTest extends AbstractJdbcRepository {
         QueryFilter.Field.QUERY,
         QueryFilter.Field.STATE,
         QueryFilter.Field.CHILD_FILTER,
-        QueryFilter.Field.MIN_LEVEL,
+        QueryFilter.Field.LEVEL,
         QueryFilter.Field.START_DATE,
         QueryFilter.Field.END_DATE,
         QueryFilter.Field.UPDATED,
@@ -30,8 +30,9 @@ class AbstractJdbcRepositoryTest extends AbstractJdbcRepository {
         QueryFilter.Field.METADATA,
         QueryFilter.Field.GROUP,
         QueryFilter.Field.NAME,
-        QueryFilter.Field.SUPER_ADMIN,
-        QueryFilter.Field.TAGS
+        QueryFilter.Field.TAGS,
+        QueryFilter.Field.ATTEMPT_NUMBER,
+        QueryFilter.Field.SUPER_ADMIN
     );
 
     @Test

--- a/ui/packages/design-system/src/components/Data/KsDataTable/KsFilter.locale.ts
+++ b/ui/packages/design-system/src/components/Data/KsDataTable/KsFilter.locale.ts
@@ -217,7 +217,7 @@ export default {
             },
             "level": {
                 "label": "Level",
-                "description": "Show logs at or above this severity",
+                "description": "Filter logs by severity",
             },
             "level_log_executions": {
                 "label": "Log Level",
@@ -229,6 +229,18 @@ export default {
             "triggerId_trigger": {
                 "label": "Trigger ID",
                 "description": "Filter by trigger ID",
+            },
+            "taskId": {
+                "label": "Task ID",
+                "description": "Filter by task identifier",
+            },
+            "taskRunId": {
+                "label": "Task Run ID",
+                "description": "Filter by task run identifier",
+            },
+            "attemptNumber": {
+                "label": "Attempt Number",
+                "description": "Filter by task run attempt number",
             },
             "workerId": {
                 "label": "Worker ID",

--- a/ui/packages/design-system/src/components/Data/KsDataTable/filter/composables/useFilters.ts
+++ b/ui/packages/design-system/src/components/Data/KsDataTable/filter/composables/useFilters.ts
@@ -123,7 +123,7 @@ export function useFilters(
         key,
         keyLabel: config?.keyLabelProvider ? config.keyLabelProvider(meta) : config?.label,
         comparator,
-        comparatorLabel: COMPARATOR_LABELS[comparator],
+        comparatorLabel: config?.comparatorLabels?.[comparator] ?? COMPARATOR_LABELS[comparator],
         value,
         valueLabel,
         ...(meta ? {meta} : {}),

--- a/ui/packages/design-system/src/components/Data/KsDataTable/filter/layout/FilterComparatorSelect.vue
+++ b/ui/packages/design-system/src/components/Data/KsDataTable/filter/layout/FilterComparatorSelect.vue
@@ -41,7 +41,7 @@
     const props = defineProps<{
         shouldShowComparator: boolean;
         selectedComparator: Comparators;
-        filterKey: {comparators: Comparators[]};
+        filterKey: {comparators: Comparators[]; comparatorLabels?: Partial<Record<Comparators, string>>};
     }>()
 
     const emits = defineEmits<{
@@ -53,7 +53,8 @@
         set: (value: Comparators) => emits("update:selectedComparator", value),
     })
 
-    const getLabel = (comparator: Comparators) => COMPARATOR_LABELS[comparator]
+    const getLabel = (comparator: Comparators) =>
+        props.filterKey.comparatorLabels?.[comparator] ?? COMPARATOR_LABELS[comparator]
     const getDescription = (comparator: Comparators) => t(COMPARATOR_DESCRIPTIONS[comparator])
 </script>
 

--- a/ui/packages/design-system/src/components/Data/KsDataTable/filter/layout/FilterEditPopper.vue
+++ b/ui/packages/design-system/src/components/Data/KsDataTable/filter/layout/FilterEditPopper.vue
@@ -324,7 +324,7 @@
         const updatedFilter: any = {
             ...props.filter,
             comparator: state.selectedComparator,
-            comparatorLabel: COMPARATOR_LABELS[state.selectedComparator],
+            comparatorLabel: props.filterKey?.comparatorLabels?.[state.selectedComparator] ?? COMPARATOR_LABELS[state.selectedComparator],
             value: filterData.value,
             valueLabel: filterData.label,
         }

--- a/ui/packages/design-system/src/components/Data/KsDataTable/filter/utils/filterTypes.ts
+++ b/ui/packages/design-system/src/components/Data/KsDataTable/filter/utils/filterTypes.ts
@@ -17,8 +17,8 @@ export enum Comparators {
 export const KV_COMPARATORS = [Comparators.EQUALS, Comparators.NOT_EQUALS]
 export const TEXT_COMPARATORS = [
     Comparators.CONTAINS,
-    Comparators.ENDS_WITH, 
-    Comparators.STARTS_WITH, 
+    Comparators.ENDS_WITH,
+    Comparators.STARTS_WITH,
 ]
 
 export interface DateFilterOption {
@@ -48,6 +48,13 @@ export interface FilterKeyConfig {
     dateFilterOptions?: DateFilterOption[];
     /** Overrides the chip's keyLabel based on the active dateFilter meta value. */
     keyLabelProvider?: (meta?: Record<string, string>) => string;
+    /**
+     * Per-field override for comparator labels. When provided, supersedes
+     * the global COMPARATOR_LABELS for this filter only. Useful when the
+     * generic label doesn't fit the domain (e.g. "At or Above" for a log
+     * level filter rather than "Greater Than or Equal").
+     */
+    comparatorLabels?: Partial<Record<Comparators, string>>;
 }
 
 export interface FilterValue {
@@ -94,17 +101,17 @@ export interface TableProperties {
 }
 
 export interface TableOptions {
-    chart?: { 
-        shown?: boolean; 
-        value?: boolean; 
-        callback?: (value: boolean) => void 
+    chart?: {
+        shown?: boolean;
+        value?: boolean;
+        callback?: (value: boolean) => void
     };
     columns?: {
         shown?: boolean
     };
-    refresh?: { 
-        shown?: boolean; 
-        callback?: () => void 
+    refresh?: {
+        shown?: boolean;
+        callback?: () => void
     };
 }
 

--- a/ui/packages/design-system/src/components/Data/KsDataTable/filter/utils/logLevelQuery.ts
+++ b/ui/packages/design-system/src/components/Data/KsDataTable/filter/utils/logLevelQuery.ts
@@ -5,10 +5,26 @@ import type {
     LocationQueryValueRaw,
 } from "vue-router"
 import type {AppliedFilter} from "./filterTypes"
+import {Comparators} from "./filterTypes"
 
 const LEVEL_FILTER_PREFIX = "filters[level]["
+const LEVEL_GTE_FILTER_KEY = "filters[level][GREATER_THAN_OR_EQUAL_TO]"
+const LEVEL_LTE_FILTER_KEY = "filters[level][LESS_THAN_OR_EQUAL_TO]"
 const LEVEL_EQUALS_FILTER_KEY = "filters[level][EQUALS]"
 const LEGACY_LEVEL_FILTER_KEY = "level"
+
+const SUPPORTED_LEVEL_FILTER_KEYS = new Set([
+    LEVEL_GTE_FILTER_KEY,
+    LEVEL_LTE_FILTER_KEY,
+    LEVEL_EQUALS_FILTER_KEY,
+])
+
+export type LevelFilterDirection = "min" | "max";
+
+export interface LevelFilterValue {
+    value: string;
+    direction: LevelFilterDirection;
+}
 
 const firstStringValue = (
     value:
@@ -24,40 +40,64 @@ const firstStringValue = (
     return typeof value === "string" ? value : undefined
 }
 
-export const readRouteLevelFilter = (query: LocationQuery | LocationQueryRaw) => {
-    const value =
-        firstStringValue(query[LEVEL_EQUALS_FILTER_KEY]) ??
-        firstStringValue(query[LEGACY_LEVEL_FILTER_KEY])
+const nonEmpty = (value: string | undefined) =>
+    value && value.length > 0 ? value : undefined
 
-    return value && value.length > 0 ? value : undefined
+export const readRouteLevelFilter = (query: LocationQuery | LocationQueryRaw): LevelFilterValue | undefined => {
+    const lte = nonEmpty(firstStringValue(query[LEVEL_LTE_FILTER_KEY]))
+    if (lte) {
+        return {value: lte, direction: "max"}
+    }
+
+    const gte = nonEmpty(firstStringValue(query[LEVEL_GTE_FILTER_KEY]))
+    if (gte) {
+        return {value: gte, direction: "min"}
+    }
+
+    // Legacy: EQUALS (pre-rename) and bare `level` query param both meant "at or above"
+    const legacyEquals = nonEmpty(firstStringValue(query[LEVEL_EQUALS_FILTER_KEY]))
+    if (legacyEquals) {
+        return {value: legacyEquals, direction: "min"}
+    }
+
+    const legacyLevel = nonEmpty(firstStringValue(query[LEGACY_LEVEL_FILTER_KEY]))
+    if (legacyLevel) {
+        return {value: legacyLevel, direction: "min"}
+    }
+
+    return undefined
 }
 
 export const hasUnsupportedRouteLevelComparator = (query: LocationQuery | LocationQueryRaw) =>
     Object.keys(query).some(
         (key) =>
             key === LEGACY_LEVEL_FILTER_KEY ||
-            (key.startsWith(LEVEL_FILTER_PREFIX) && key !== LEVEL_EQUALS_FILTER_KEY),
+            (key.startsWith(LEVEL_FILTER_PREFIX) && !SUPPORTED_LEVEL_FILTER_KEYS.has(key)),
     )
 
-export const readAppliedLevelFilter = (filters: AppliedFilter[]) => {
+export const readAppliedLevelFilter = (filters: AppliedFilter[]): LevelFilterValue | undefined => {
     const levelFilter = filters.find((filter) => filter.key === "level")
     if (!levelFilter) {
         return undefined
     }
 
-    if (Array.isArray(levelFilter.value)) {
-        const value = levelFilter.value[0]
-        return typeof value === "string" && value.length > 0 ? value : undefined
+    const direction: LevelFilterDirection =
+        levelFilter.comparator === Comparators.LESS_THAN_OR_EQUAL_TO ? "max" : "min"
+
+    const rawValue = Array.isArray(levelFilter.value)
+        ? levelFilter.value[0]
+        : levelFilter.value
+
+    if (typeof rawValue !== "string" || rawValue.length === 0) {
+        return undefined
     }
 
-    return typeof levelFilter.value === "string" && levelFilter.value.length > 0
-        ? levelFilter.value
-        : undefined
+    return {value: rawValue, direction}
 }
 
 export const normalizeRouteLevelFilter = (
     query: Record<string, any>,
-    level: string | undefined,
+    level: LevelFilterValue | string | undefined,
 ) => {
     const normalized = {...query}
 
@@ -67,11 +107,25 @@ export const normalizeRouteLevelFilter = (
         }
     })
 
-    if (level) {
-        normalized[LEVEL_EQUALS_FILTER_KEY] = level
-    }
-
     delete normalized[LEGACY_LEVEL_FILTER_KEY]
 
+    if (level) {
+        // Backward-compat: plain string callers default to min (≥) semantic
+        const resolved: LevelFilterValue =
+            typeof level === "string" ? {value: level, direction: "min"} : level
+        const key = resolved.direction === "max" ? LEVEL_LTE_FILTER_KEY : LEVEL_GTE_FILTER_KEY
+        normalized[key] = resolved.value
+    }
+
     return normalized
+}
+
+export const levelToRequestParams = (
+    level: LevelFilterValue | undefined,
+): Record<string, string> => {
+    if (!level) {
+        return {}
+    }
+    const key = level.direction === "max" ? LEVEL_LTE_FILTER_KEY : LEVEL_GTE_FILTER_KEY
+    return {[key]: level.value}
 }

--- a/ui/packages/design-system/src/index.ts
+++ b/ui/packages/design-system/src/index.ts
@@ -146,6 +146,11 @@ export {
     hasUnsupportedRouteLevelComparator,
     readAppliedLevelFilter,
     normalizeRouteLevelFilter,
+    levelToRequestParams,
+} from "./components/Data/KsDataTable/filter/utils/logLevelQuery"
+export type {
+    LevelFilterValue,
+    LevelFilterDirection,
 } from "./components/Data/KsDataTable/filter/utils/logLevelQuery"
 export type {
     FilterConfiguration,

--- a/ui/src/components/executions/Gantt.vue
+++ b/ui/src/components/executions/Gantt.vue
@@ -105,7 +105,7 @@
                                         <TaskRunDetails
                                             :taskRunId="item.id"
                                             :excludeMetas="['namespace', 'flowId', 'taskId', 'executionId']"
-                                            :level="effectiveSelectedLogLevel"
+                                            :levelFilter="effectiveSelectedLogLevel"
                                             @follow="emit('follow', $event)"
                                             :targetFlow="executionsStore.flow"
                                             class="mh-100 mx-3"
@@ -161,6 +161,7 @@
         readRouteLevelFilter,
     } from "@kestra-io/design-system"
     import {useRouteFilterPolicy} from "@kestra-io/design-system"
+    import type {LevelFilterValue} from "@kestra-io/design-system"
     import {useExecutionsStore, type Execution} from "../../stores/executions"
 
     interface TaskRun {
@@ -256,10 +257,10 @@
 
     // Log level filter policy
     const defaultLogLevel = computed(() => localStorage.getItem("defaultLogLevel") || "INFO")
-    const {effectiveValue: effectiveSelectedLogLevel} = useRouteFilterPolicy<string>({
-        defaultValue: () => defaultLogLevel.value,
+    const {effectiveValue: effectiveSelectedLogLevel} = useRouteFilterPolicy<LevelFilterValue>({
+        defaultValue: () => ({value: defaultLogLevel.value, direction: "min"}),
         applyDefaultIfMissing: () => true,
-        fallbackValue: () => "TRACE",
+        fallbackValue: () => ({value: "TRACE", direction: "min"}),
         readFromRoute: readRouteLevelFilter,
         writeToRoute: normalizeRouteLevelFilter,
         hasUnsupportedRouteValue: hasUnsupportedRouteLevelComparator,

--- a/ui/src/components/executions/Logs.vue
+++ b/ui/src/components/executions/Logs.vue
@@ -56,7 +56,7 @@
         <TaskRunDetails
             v-if="!raw_view"
             ref="logs"
-            :level="effectiveLevel"
+            :levelFilter="effectiveLevel"
             :excludeMetas="['namespace', 'flowId', 'taskId', 'executionId']"
             :filter="filter"
             :levelToHighlight="cursorLogLevel"
@@ -137,6 +137,7 @@
     import {storageKeys} from "../../utils/constants"
     import {
         hasUnsupportedRouteLevelComparator,
+        levelToRequestParams,
         normalizeRouteLevelFilter,
         readAppliedLevelFilter,
         readRouteLevelFilter,
@@ -173,9 +174,9 @@
                 effectiveValue: effectiveLevel,
                 syncFromAppliedFilters,
             } = useRouteFilterPolicy({
-                defaultValue: () => defaultLogLevel.value,
+                defaultValue: () => ({value: defaultLogLevel.value, direction: "min"}),
                 applyDefaultIfMissing: () => true,
-                fallbackValue: () => "TRACE",
+                fallbackValue: () => ({value: "TRACE", direction: "min"}),
                 readFromRoute: readRouteLevelFilter,
                 writeToRoute: normalizeRouteLevelFilter,
                 hasUnsupportedRouteValue: hasUnsupportedRouteLevelComparator,
@@ -303,9 +304,7 @@
                 this.logsLoading = true
                 this.executionsStore.loadLogs({
                     executionId: this.executionId,
-                    params: {
-                        minLevel: this.effectiveLevel,
-                    },
+                    params: levelToRequestParams(this.effectiveLevel),
                 }).finally(() => {
                     this.logsLoading = false
                 })
@@ -313,9 +312,7 @@
             downloadContent() {
                 this.executionsStore.downloadLogs({
                     executionId: this.executionId,
-                    params: {
-                        minLevel: this.effectiveLevel,
-                    },
+                    params: levelToRequestParams(this.effectiveLevel),
                 }).then((response) => {
                     Utils.downloadUrl(window.URL.createObjectURL(new Blob([response])), this.downloadName)
                 })
@@ -323,9 +320,7 @@
             copyAllLogs() {
                 this.executionsStore.downloadLogs({
                     executionId: this.executionId,
-                    params: {
-                        minLevel: this.effectiveLevel,
-                    },
+                    params: levelToRequestParams(this.effectiveLevel),
                 }).then((response) => {
                     Utils.copy(response)
                 })

--- a/ui/src/components/filter/configurations/ganttExecutionFilter.ts
+++ b/ui/src/components/filter/configurations/ganttExecutionFilter.ts
@@ -16,7 +16,11 @@ export const useGanttExecutionFilter = (): ComputedRef<FilterConfiguration> => {
                     key: "level",
                     label: t("filter.level_log_executions.label"),
                     description: t("filter.level.description"),
-                    comparators: [Comparators.EQUALS],
+                    comparators: [Comparators.GREATER_THAN_OR_EQUAL_TO, Comparators.LESS_THAN_OR_EQUAL_TO],
+                    comparatorLabels: {
+                        [Comparators.GREATER_THAN_OR_EQUAL_TO]: "At or Above",
+                        [Comparators.LESS_THAN_OR_EQUAL_TO]: "At or Below",
+                    },
                     valueType: "select",
                     valueProvider: async () => {
                         const {VALUES} = useValues("logs")

--- a/ui/src/components/filter/configurations/logExecutionsFilter.ts
+++ b/ui/src/components/filter/configurations/logExecutionsFilter.ts
@@ -15,7 +15,11 @@ export const useLogExecutionsFilter = (): ComputedRef<FilterConfiguration> => {
                     key: "level",
                     label: t("filter.level_log_executions.label"),
                     description: t("filter.level.description"),
-                    comparators: [Comparators.EQUALS],
+                    comparators: [Comparators.GREATER_THAN_OR_EQUAL_TO, Comparators.LESS_THAN_OR_EQUAL_TO],
+                    comparatorLabels: {
+                        [Comparators.GREATER_THAN_OR_EQUAL_TO]: "At or Above",
+                        [Comparators.LESS_THAN_OR_EQUAL_TO]: "At or Below",
+                    },
                     valueType: "select",
                     valueProvider: async () => {
                         const {VALUES} = useValues("logs")
@@ -27,6 +31,42 @@ export const useLogExecutionsFilter = (): ComputedRef<FilterConfiguration> => {
                             : "INFO"
                     ),
                     visibleByDefault: true,
+                },
+                {
+                    key: "taskId",
+                    label: t("filter.taskId.label"),
+                    description: t("filter.taskId.description"),
+                    comparators: [
+                        Comparators.EQUALS,
+                        Comparators.NOT_EQUALS,
+                        Comparators.CONTAINS,
+                        Comparators.STARTS_WITH,
+                        Comparators.ENDS_WITH,
+                        Comparators.IN,
+                    ],
+                    valueType: "text",
+                },
+                {
+                    key: "taskRunId",
+                    label: t("filter.taskRunId.label"),
+                    description: t("filter.taskRunId.description"),
+                    comparators: [
+                        Comparators.EQUALS,
+                        Comparators.NOT_EQUALS,
+                        Comparators.IN,
+                    ],
+                    valueType: "text",
+                },
+                {
+                    key: "attemptNumber",
+                    label: t("filter.attemptNumber.label"),
+                    description: t("filter.attemptNumber.description"),
+                    comparators: [
+                        Comparators.EQUALS,
+                        Comparators.NOT_EQUALS,
+                        Comparators.IN,
+                    ],
+                    valueType: "text",
                 },
             ],
         }

--- a/ui/src/components/filter/configurations/logFilter.ts
+++ b/ui/src/components/filter/configurations/logFilter.ts
@@ -54,7 +54,11 @@ export const useLogFilter = (): ComputedRef<FilterConfiguration> => {
                     key: "level",
                     label: t("filter.level_log_executions.label"),
                     description: t("filter.level.description"),
-                    comparators: [Comparators.EQUALS],
+                    comparators: [Comparators.GREATER_THAN_OR_EQUAL_TO, Comparators.LESS_THAN_OR_EQUAL_TO],
+                    comparatorLabels: {
+                        [Comparators.GREATER_THAN_OR_EQUAL_TO]: "At or Above",
+                        [Comparators.LESS_THAN_OR_EQUAL_TO]: "At or Below",
+                    },
                     valueType: "select",
                     valueProvider: async () => {
                         const {VALUES} = useValues("logs")
@@ -118,6 +122,42 @@ export const useLogFilter = (): ComputedRef<FilterConfiguration> => {
                     ],
                     valueType: "text",
                 }] : []) as any,
+                {
+                    key: "taskId",
+                    label: t("filter.taskId.label"),
+                    description: t("filter.taskId.description"),
+                    comparators: [
+                        Comparators.EQUALS,
+                        Comparators.NOT_EQUALS,
+                        Comparators.CONTAINS,
+                        Comparators.STARTS_WITH,
+                        Comparators.ENDS_WITH,
+                        Comparators.IN,
+                    ],
+                    valueType: "text",
+                },
+                {
+                    key: "taskRunId",
+                    label: t("filter.taskRunId.label"),
+                    description: t("filter.taskRunId.description"),
+                    comparators: [
+                        Comparators.EQUALS,
+                        Comparators.NOT_EQUALS,
+                        Comparators.IN,
+                    ],
+                    valueType: "text",
+                },
+                {
+                    key: "attemptNumber",
+                    label: t("filter.attemptNumber.label"),
+                    description: t("filter.attemptNumber.description"),
+                    comparators: [
+                        Comparators.EQUALS,
+                        Comparators.NOT_EQUALS,
+                        Comparators.IN,
+                    ],
+                    valueType: "text",
+                },
             ],
         }
     })

--- a/ui/src/components/logs/LogsWrapper.vue
+++ b/ui/src/components/logs/LogsWrapper.vue
@@ -82,6 +82,7 @@
         readRouteLevelFilter,
     } from "@kestra-io/design-system"
     import {useRouteFilterPolicy} from "@kestra-io/design-system"
+    import type {LevelFilterValue} from "@kestra-io/design-system"
     import {flowYamlUtils as YAML_UTILS} from "@kestra-io/topology"
     import YAML_CHART from "../dashboard/assets/logs_timeseries_chart.yaml?raw"
     import {useLogsStore} from "../../stores/logs"
@@ -135,10 +136,10 @@
     const {
         effectiveValue: effectiveLogLevel,
         syncFromAppliedFilters: syncLevelFromAppliedFilters,
-    } = useRouteFilterPolicy<string>({
+    } = useRouteFilterPolicy<LevelFilterValue>({
         enabled: () => !props.filters && hasLevelFilterUI.value,
-        explicitValue: () => props.logLevel,
-        defaultValue: () => defaultLogLevel.value,
+        explicitValue: () => props.logLevel ? {value: props.logLevel, direction: "min"} : undefined,
+        defaultValue: () => ({value: defaultLogLevel.value, direction: "min"}),
         applyDefaultIfMissing: () => true,
         fallbackValue: () => undefined,
         readFromRoute: readRouteLevelFilter,
@@ -235,7 +236,6 @@
         await logsStore.findLogs(loadQuery({
             page,
             size,
-            minLevel: props.filters ? null : effectiveLogLevel.value,
             sort: "timestamp:desc",
         }))
             .finally(() => {

--- a/ui/src/components/logs/TaskRunDetails.vue
+++ b/ui/src/components/logs/TaskRunDetails.vue
@@ -19,7 +19,7 @@
                 :item="currentTaskRun"
                 :active="isTaskRunActive"
                 :data-index="currentTaskRunIndex"
-            >   
+            >
                 <KsCard class="attempt-wrapper">
                     <TaskRunLine
                         :currentTaskRun="currentTaskRun"
@@ -200,24 +200,24 @@
                         </template>
                     </DynamicScroller>
                 </KsCard>
-                <div 
-                    v-if="taskType(currentTaskRun) === 'io.kestra.plugin.core.flow.Loop' && isTaskRunActive" 
+                <div
+                    v-if="taskType(currentTaskRun) === 'io.kestra.plugin.core.flow.Loop' && isTaskRunActive"
                     style="display:flex; align-items: center; gap: 12px; margin-bottom: 12px"
                 >
                     <KsButton
                         :tag="RouterLink"
                         :to="{
-                            name: 'executions/list', 
+                            name: 'executions/list',
                             query: {
                                 'filters[parentId][EQUALS]': currentTaskRun.executionId,
                                 'filters[kind][EQUALS]': 'LOOP',
-                            }        
+                            }
                         }"
                     >
                         Iterations
                     </KsButton>
-                    <KsProgress 
-                        :percentage="Math.ceil((loopOutputsByTaskRunId[currentTaskRun.id]?.terminatedIterations ?? 0) / (loopOutputsByTaskRunId[currentTaskRun.id]?.iterationCount ?? 1) * 100)" 
+                    <KsProgress
+                        :percentage="Math.ceil((loopOutputsByTaskRunId[currentTaskRun.id]?.terminatedIterations ?? 0) / (loopOutputsByTaskRunId[currentTaskRun.id]?.iterationCount ?? 1) * 100)"
                         :strokeWidth="24"
                         :textInside="true"
                         class="progress-bar"
@@ -238,7 +238,7 @@
 <script>
     import * as OutputsAPI from "@kestra-io/kestra-sdk/outputs"
     import LogLine from "./LogLine.vue"
-    import {State} from "@kestra-io/design-system"
+    import {State, levelToRequestParams} from "@kestra-io/design-system"
     import _xor from "lodash/xor"
     import _groupBy from "lodash/groupBy"
     import moment from "moment"
@@ -282,9 +282,10 @@
                 type: String,
                 default: undefined,
             },
-            level: {
-                type: String,
-                default: "INFO",
+            levelFilter: {
+                // LevelFilterValue: { value: "INFO", direction: "min" | "max" }
+                type: Object,
+                default: () => ({value: "INFO", direction: "min"}),
             },
             filter: {
                 type: String,
@@ -351,7 +352,7 @@
             "shownAttemptsUid.length": function (openedTaskrunsCount) {
                 this.$emit("opened-taskruns-count", openedTaskrunsCount)
             },
-            level: function () {
+            levelFilter: function () {
                 this.rawLogs = []
                 if(this.followedExecution)
                     this.loadLogs(this.followedExecution.id)
@@ -480,13 +481,16 @@
                 )
             },
             params() {
-                let params = {minLevel: this.level}
+                let params = {...levelToRequestParams(this.levelFilter)}
 
                 if (this.taskRunId) {
-                    params.taskId = this.taskRunById[this.taskRunId]?.taskId
+                    const taskId = this.taskRunById[this.taskRunId]?.taskId
+                    if (taskId) {
+                        params["filters[taskId][EQUALS]"] = taskId
+                    }
 
-                    if (this.forcedAttemptNumber) {
-                        params.attempt = this.forcedAttemptNumber
+                    if (this.forcedAttemptNumber !== undefined && this.forcedAttemptNumber !== null) {
+                        params["filters[attemptNumber][EQUALS]"] = this.forcedAttemptNumber
                     }
                 }
 
@@ -620,8 +624,8 @@
                         executionId: this.followedExecution.id,
                         taskRunId,
                     })
-                    if(outputs === null 
-                        || !outputs.iterationCount 
+                    if(outputs === null
+                        || !outputs.iterationCount
                         || !outputs.terminatedIterations) {
                         return
                     }
@@ -866,13 +870,15 @@
                 return !(this.taskRunId && this.taskRunId !== currentTaskRun.id)
             },
             loadLogs(executionId) {
+                const params = {...levelToRequestParams(this.levelFilter)}
+                const taskId = this.taskRunById[this.taskRunId]?.taskId
+                if (taskId) {
+                    params["filters[taskId][EQUALS]"] = taskId
+                }
                 this.executionsStore
                     .loadLogs({
                         executionId,
-                        params: {
-                            minLevel: this.level,
-                            taskId: this.taskRunById[this.taskRunId]?.taskId,
-                        },
+                        params,
                     })
                     .then((logs) => {
                         // `loadLogs` returns a paginated response `{ results, total }`, and `rawLogs` must be an array of log lines.

--- a/ui/tests/storybook/components/executions/Logs.stories.tsx
+++ b/ui/tests/storybook/components/executions/Logs.stories.tsx
@@ -72,8 +72,15 @@ function makeDecorators() {
                 executionsStore.execution = FAKE_EXECUTION as any;
 
                 (executionsStore as any).loadLogs = async ({params}: {executionId: string; params?: Record<string, any>}) => {
-                    const minLevel = params?.minLevel ?? "TRACE";
-                    const filtered = filteredByMinLevel(FAKE_LOGS, minLevel);
+                    const gte = params?.["filters[level][GREATER_THAN_OR_EQUAL_TO]"];
+                    const lte = params?.["filters[level][LESS_THAN_OR_EQUAL_TO]"];
+                    let filtered: typeof FAKE_LOGS;
+                    if (lte) {
+                        const maxIdx = LEVEL_ORDER.indexOf(lte as Level);
+                        filtered = FAKE_LOGS.filter(log => LEVEL_ORDER.indexOf(log.level as Level) >= maxIdx);
+                    } else {
+                        filtered = filteredByMinLevel(FAKE_LOGS, (gte as string) ?? "TRACE");
+                    }
                     executionsStore.logs = filtered as any;
                     return filtered;
                 };
@@ -122,19 +129,27 @@ export const LevelFilterUpdatesRoute: Story = {
             {timeout: 5000}
         );
 
-        // 2. Open the filter chip popup.
+        // 2. Open the filter chip popup and grab the value combobox.
+        //    The popup now renders two comboboxes — the comparator select
+        //    (.comp-container, "At or Above" / "At or Below", added when the
+        //    level filter gained min/max directions) and the value select
+        //    (.select-panel). Scope to .select-panel so we drive the level
+        //    value, not the comparator, and avoid a multiple-match error.
         const combobox = await waitFor(
             async () => {
                 const chip = canvasElement.querySelector<HTMLElement>(".chip");
                 if (!chip) throw new Error("filter chip not found");
 
-                const popup = iframeBody.querySelector(".edit-popup");
+                const popup = iframeBody.querySelector<HTMLElement>(".edit-popup");
                 if (!popup) {
                     await userEvent.click(chip);
                     throw new Error("popup not yet open, retrying");
                 }
 
-                const cb = within(iframeBody).queryByRole("combobox");
+                const valuePanel = popup.querySelector<HTMLElement>(".select-panel");
+                if (!valuePanel) throw new Error("value select panel not yet rendered in popup");
+
+                const cb = within(valuePanel).queryByRole("combobox");
                 if (!cb) throw new Error("combobox not yet rendered in popup");
                 return cb;
             },

--- a/webserver/src/main/java/io/kestra/webserver/controllers/api/LogController.java
+++ b/webserver/src/main/java/io/kestra/webserver/controllers/api/LogController.java
@@ -90,7 +90,7 @@ public class LogController {
     @Operation(tags = { "Logs" }, summary = "Get logs for a specific execution, taskrun or task")
     public List<LogEntry> listLogsFromExecution(
         @Parameter(description = "The execution id") @PathVariable String executionId,
-        @Parameter(description = "Filters") @Nullable @QueryFilterFormat List<QueryFilter> filters) {
+        @Parameter(description = "Filters") @Nullable @QueryFilterFormat(Resource.LOG) List<QueryFilter> filters) {
         return logRepository
             .findAsync(tenantService.resolveTenant(), buildExecutionFilters(executionId, filters))
             .collectList()
@@ -102,7 +102,7 @@ public class LogController {
     @Operation(tags = { "Logs" }, summary = "Download logs for a specific execution, taskrun or task")
     public HttpResponse<StreamedFile> downloadLogsFromExecution(
         @Parameter(description = "The execution id") @PathVariable String executionId,
-        @Parameter(description = "Filters") @Nullable @QueryFilterFormat List<QueryFilter> filters) {
+        @Parameter(description = "Filters") @Nullable @QueryFilterFormat(Resource.LOG) List<QueryFilter> filters) {
         List<LogEntry> logs = logRepository
             .findAsync(tenantService.resolveTenant(), buildExecutionFilters(executionId, filters))
             .collectList()
@@ -127,7 +127,7 @@ public class LogController {
     @Operation(tags = { "Logs" }, summary = "Follow logs for a specific execution")
     public Flux<Event<FollowLogEvent>> followLogsFromExecution(
         @Parameter(description = "The execution id") @PathVariable String executionId,
-        @Parameter(description = "Filters") @Nullable @QueryFilterFormat List<QueryFilter> filters) {
+        @Parameter(description = "Filters") @Nullable @QueryFilterFormat(Resource.LOG) List<QueryFilter> filters) {
         String subscriberId = UUID.randomUUID().toString();
         List<QueryFilter> effectiveFilters = buildExecutionFilters(executionId, filters);
 

--- a/webserver/src/main/java/io/kestra/webserver/controllers/api/LogController.java
+++ b/webserver/src/main/java/io/kestra/webserver/controllers/api/LogController.java
@@ -90,19 +90,11 @@ public class LogController {
     @Operation(tags = { "Logs" }, summary = "Get logs for a specific execution, taskrun or task")
     public List<LogEntry> listLogsFromExecution(
         @Parameter(description = "The execution id") @PathVariable String executionId,
-        @Parameter(description = "The min log level filter") @Nullable @QueryValue Level minLevel,
-        @Parameter(description = "The taskrun id") @Nullable @QueryValue String taskRunId,
-        @Parameter(description = "The task id") @Nullable @QueryValue String taskId,
-        @Parameter(description = "The attempt number") @Nullable @QueryValue Integer attempt) {
-        return logService.getExecutionLogs(
-            tenantService.resolveTenant(),
-            executionId,
-            minLevel,
-            taskRunId,
-            Optional.ofNullable(taskId).map(List::of).orElse(null),
-            attempt,
-            true
-        );
+        @Parameter(description = "Filters") @Nullable @QueryFilterFormat List<QueryFilter> filters) {
+        return logRepository
+            .findAsync(tenantService.resolveTenant(), buildExecutionFilters(executionId, filters))
+            .collectList()
+            .block();
     }
 
     @ExecuteOn(TaskExecutors.IO)
@@ -110,18 +102,16 @@ public class LogController {
     @Operation(tags = { "Logs" }, summary = "Download logs for a specific execution, taskrun or task")
     public HttpResponse<StreamedFile> downloadLogsFromExecution(
         @Parameter(description = "The execution id") @PathVariable String executionId,
-        @Parameter(description = "The min log level filter") @Nullable @QueryValue Level minLevel,
-        @Parameter(description = "The taskrun id") @Nullable @QueryValue String taskRunId,
-        @Parameter(description = "The task id") @Nullable @QueryValue String taskId,
-        @Parameter(description = "The attempt number") @Nullable @QueryValue Integer attempt) {
-        InputStream inputStream = logService.getExecutionLogsAsStream(
-            tenantService.resolveTenant(),
-            executionId,
-            minLevel,
-            taskRunId,
-            Optional.ofNullable(taskId).map(List::of).orElse(null),
-            attempt,
-            true
+        @Parameter(description = "Filters") @Nullable @QueryFilterFormat List<QueryFilter> filters) {
+        List<LogEntry> logs = logRepository
+            .findAsync(tenantService.resolveTenant(), buildExecutionFilters(executionId, filters))
+            .collectList()
+            .block();
+        InputStream inputStream = new java.io.ByteArrayInputStream(
+            (logs == null ? List.<LogEntry>of() : logs).stream()
+                .map(LogEntry::toPrettyString)
+                .collect(java.util.stream.Collectors.joining("\n"))
+                .getBytes()
         );
 
         MutableHttpResponse<StreamedFile> response = HttpResponse.ok(new StreamedFile(inputStream, MediaType.TEXT_PLAIN_TYPE).attach(executionId + ".log"));
@@ -137,9 +127,9 @@ public class LogController {
     @Operation(tags = { "Logs" }, summary = "Follow logs for a specific execution")
     public Flux<Event<FollowLogEvent>> followLogsFromExecution(
         @Parameter(description = "The execution id") @PathVariable String executionId,
-        @Parameter(description = "The min log level filter") @Nullable @QueryValue Level minLevel) {
+        @Parameter(description = "Filters") @Nullable @QueryFilterFormat List<QueryFilter> filters) {
         String subscriberId = UUID.randomUUID().toString();
-        final List<String> levels = LogEntry.findLevelsByMin(minLevel).stream().map(Enum::name).toList();
+        List<QueryFilter> effectiveFilters = buildExecutionFilters(executionId, filters);
 
         return Flux.<Event<FollowLogEvent>> create(emitter ->
         {
@@ -147,15 +137,38 @@ public class LogController {
             emitter.next(Event.of(FollowLogEvent.from(LogEntry.builder().build())).id("start"));
 
             // fetch repository first
-            logService.getExecutionLogs(tenantService.resolveTenant(), executionId, minLevel, List.of(), true)
+            logRepository.findAsync(tenantService.resolveTenant(), effectiveFilters)
+                .toStream()
                 .forEach(logEntry -> emitter.next(Event.of(FollowLogEvent.from(logEntry)).id("progress")));
 
-            // consume in realtime
-            logStreamingService.registerSubscriber(executionId, subscriberId, emitter, levels);
+            // consume in realtime — pass the same filter list, the streaming service uses
+            // the FollowLogEventMatcher (backed by Searchable<FollowLogEvent>) to apply it
+            logStreamingService.registerSubscriber(executionId, subscriberId, emitter, effectiveFilters);
         }, FluxSink.OverflowStrategy.BUFFER)
             .timeout(Duration.ofHours(1)) // avoid idle SSE sockets by setting a between-item timeout
             .doFinally(ignored -> logStreamingService.unregisterSubscriber(executionId, subscriberId));
     }
+
+    /**
+     * Build the QueryFilter list for the per-execution endpoints. Purely additive: the
+     * path-variable {@code executionId} is always appended as an EQUALS filter, and any
+     * user-supplied filters (including a user-supplied {@code executionId} filter) are kept
+     * verbatim. The combined filter set is AND-ed by the repository, so a conflicting user
+     * filter just narrows the result to nothing — the URL path stays authoritative.
+     */
+    private static List<QueryFilter> buildExecutionFilters(String executionId, List<QueryFilter> userFilters) {
+        List<QueryFilter> merged = new java.util.ArrayList<>();
+        if (userFilters != null) {
+            merged.addAll(userFilters);
+        }
+        merged.add(QueryFilter.builder()
+            .field(QueryFilter.Field.EXECUTION_ID)
+            .operation(QueryFilter.Op.EQUALS)
+            .value(executionId)
+            .build());
+        return merged;
+    }
+
 
     @ExecuteOn(TaskExecutors.IO)
     @Delete(uri = "/{executionId}")

--- a/webserver/src/main/java/io/kestra/webserver/services/SearchableFactory.java
+++ b/webserver/src/main/java/io/kestra/webserver/services/SearchableFactory.java
@@ -3,6 +3,7 @@ package io.kestra.webserver.services;
 import java.util.List;
 import java.util.Objects;
 
+import org.apache.commons.lang3.Strings;
 import org.slf4j.event.Level;
 
 import io.kestra.core.contexts.configuration.SystemFlowsConfiguration;
@@ -29,7 +30,10 @@ public class SearchableFactory {
         return Searchable.<Namespace>builder()
             .searchableExtractor("id", Namespace::getId)
             .sortableExtractor("id", Namespace::getId)
-            .searchableQueryFilterExtractor(QueryFilter.Field.QUERY, Namespace::getId, QueryFilter.Op.EQUALS, QueryFilter.Op.NOT_EQUALS)
+            .searchableQueryFilterExtractor(QueryFilter.Field.QUERY, QueryFilter.Op.EQUALS,
+                (ns, v) -> Strings.CI.contains(ns.getId(), v.toString()))
+            .searchableQueryFilterExtractor(QueryFilter.Field.QUERY, QueryFilter.Op.NOT_EQUALS,
+                (ns, v) -> !Strings.CI.contains(ns.getId(), v.toString()))
             .searchableQueryFilterExtractor(QueryFilter.Field.NAMESPACE, Namespace::getId,
                 QueryFilter.Op.EQUALS, QueryFilter.Op.NOT_EQUALS, QueryFilter.Op.CONTAINS,
                 QueryFilter.Op.STARTS_WITH, QueryFilter.Op.ENDS_WITH, QueryFilter.Op.REGEX,

--- a/webserver/src/main/java/io/kestra/webserver/services/SearchableFactory.java
+++ b/webserver/src/main/java/io/kestra/webserver/services/SearchableFactory.java
@@ -1,11 +1,20 @@
 package io.kestra.webserver.services;
 
 import java.util.List;
+import java.util.Objects;
 
+import org.slf4j.event.Level;
+
+import io.kestra.core.contexts.configuration.SystemFlowsConfiguration;
 import io.kestra.core.models.QueryFilter;
+import io.kestra.core.models.flows.FlowScope;
 import io.kestra.core.models.namespaces.Namespace;
-import io.kestra.core.utils.RegexUtils;
+import io.kestra.core.runners.FollowLogEvent;
+import io.kestra.core.services.FollowLogEventMatcher;
 import io.kestra.webserver.utils.Searchable;
+
+import java.time.Instant;
+import java.time.ZonedDateTime;
 
 import io.micronaut.context.annotation.Factory;
 import jakarta.inject.Named;
@@ -20,26 +29,121 @@ public class SearchableFactory {
         return Searchable.<Namespace>builder()
             .searchableExtractor("id", Namespace::getId)
             .sortableExtractor("id", Namespace::getId)
-            .searchableQueryFilterExtractor(QueryFilter.Field.QUERY, QueryFilter.Op.EQUALS,
-                (ns, v) -> ns.getId().toLowerCase().contains(v.toString().toLowerCase()))
-            .searchableQueryFilterExtractor(QueryFilter.Field.NAMESPACE, QueryFilter.Op.EQUALS,
-                (ns, v) -> ns.getId().equals(v.toString()))
-            .searchableQueryFilterExtractor(QueryFilter.Field.NAMESPACE, QueryFilter.Op.NOT_EQUALS,
-                (ns, v) -> !ns.getId().equals(v.toString()))
-            .searchableQueryFilterExtractor(QueryFilter.Field.NAMESPACE, QueryFilter.Op.CONTAINS,
-                (ns, v) -> ns.getId().contains(v.toString()))
-            .searchableQueryFilterExtractor(QueryFilter.Field.NAMESPACE, QueryFilter.Op.STARTS_WITH,
-                (ns, v) -> ns.getId().startsWith(v.toString()))
-            .searchableQueryFilterExtractor(QueryFilter.Field.NAMESPACE, QueryFilter.Op.ENDS_WITH,
-                (ns, v) -> ns.getId().endsWith(v.toString()))
-            .searchableQueryFilterExtractor(QueryFilter.Field.NAMESPACE, QueryFilter.Op.REGEX,
-                (ns, v) -> RegexUtils.matches(v.toString(), ns.getId()))
-            .searchableQueryFilterExtractor(QueryFilter.Field.NAMESPACE, QueryFilter.Op.IN,
-                (ns, v) -> v instanceof List<?> list && list.stream().map(Object::toString).anyMatch(ns.getId()::equals))
-            .searchableQueryFilterExtractor(QueryFilter.Field.NAMESPACE, QueryFilter.Op.NOT_IN,
-                (ns, v) -> !(v instanceof List<?> list && list.stream().map(Object::toString).anyMatch(ns.getId()::equals)))
-            .searchableQueryFilterExtractor(QueryFilter.Field.NAMESPACE, QueryFilter.Op.PREFIX,
-                (ns, v) -> ns.getId().equals(v.toString()) || ns.getId().startsWith(v + "."))
+            .searchableQueryFilterExtractor(QueryFilter.Field.QUERY, Namespace::getId, QueryFilter.Op.EQUALS, QueryFilter.Op.NOT_EQUALS)
+            .searchableQueryFilterExtractor(QueryFilter.Field.NAMESPACE, Namespace::getId,
+                QueryFilter.Op.EQUALS, QueryFilter.Op.NOT_EQUALS, QueryFilter.Op.CONTAINS,
+                QueryFilter.Op.STARTS_WITH, QueryFilter.Op.ENDS_WITH, QueryFilter.Op.REGEX,
+                QueryFilter.Op.IN, QueryFilter.Op.NOT_IN, QueryFilter.Op.PREFIX)
             .build();
+    }
+
+    @Singleton
+    @Named("LOG")
+    public Searchable<FollowLogEvent> followLogEventSearchable(SystemFlowsConfiguration systemFlowsConfiguration) {
+        String systemNamespace = systemFlowsConfiguration.namespace();
+        return Searchable.<FollowLogEvent>builder()
+            .searchableQueryFilterExtractor(QueryFilter.Field.QUERY, QueryFilter.Op.EQUALS,
+                (event, v) -> event.message() != null && event.message().contains(v.toString()))
+            .searchableQueryFilterExtractor(QueryFilter.Field.QUERY, QueryFilter.Op.NOT_EQUALS,
+                (event, v) -> event.message() == null || !event.message().contains(v.toString()))
+
+            .searchableQueryFilterExtractor(QueryFilter.Field.SCOPE, QueryFilter.Op.EQUALS,
+                (event, v) -> scopeMatches(event, v, systemNamespace))
+            .searchableQueryFilterExtractor(QueryFilter.Field.SCOPE, QueryFilter.Op.NOT_EQUALS,
+                (event, v) -> !scopeMatches(event, v, systemNamespace))
+            .searchableQueryFilterExtractor(QueryFilter.Field.SCOPE, QueryFilter.Op.IN,
+                (event, v) -> v instanceof List<?> list
+                    && list.stream().anyMatch(item -> scopeMatches(event, item, systemNamespace)))
+            .searchableQueryFilterExtractor(QueryFilter.Field.SCOPE, QueryFilter.Op.NOT_IN,
+                (event, v) -> !(v instanceof List<?> list)
+                    || list.stream().noneMatch(item -> scopeMatches(event, item, systemNamespace)))
+
+            .searchableQueryFilterExtractor(QueryFilter.Field.NAMESPACE, FollowLogEvent::namespace,
+                QueryFilter.Op.EQUALS, QueryFilter.Op.NOT_EQUALS, QueryFilter.Op.CONTAINS,
+                QueryFilter.Op.STARTS_WITH, QueryFilter.Op.ENDS_WITH, QueryFilter.Op.REGEX,
+                QueryFilter.Op.IN, QueryFilter.Op.NOT_IN, QueryFilter.Op.PREFIX)
+
+            .searchableQueryFilterExtractor(QueryFilter.Field.START_DATE, QueryFilter.Op.GREATER_THAN_OR_EQUAL_TO,
+                (event, v) -> compareTimestamps(event, v) >= 0)
+            .searchableQueryFilterExtractor(QueryFilter.Field.START_DATE, QueryFilter.Op.GREATER_THAN,
+                (event, v) -> compareTimestamps(event, v) > 0)
+            .searchableQueryFilterExtractor(QueryFilter.Field.START_DATE, QueryFilter.Op.LESS_THAN_OR_EQUAL_TO,
+                (event, v) -> compareTimestamps(event, v) <= 0)
+            .searchableQueryFilterExtractor(QueryFilter.Field.START_DATE, QueryFilter.Op.LESS_THAN,
+                (event, v) -> compareTimestamps(event, v) < 0)
+            .searchableQueryFilterExtractor(QueryFilter.Field.START_DATE, QueryFilter.Op.EQUALS,
+                (event, v) -> compareTimestamps(event, v) == 0)
+            .searchableQueryFilterExtractor(QueryFilter.Field.START_DATE, QueryFilter.Op.NOT_EQUALS,
+                (event, v) -> compareTimestamps(event, v) != 0)
+
+            .searchableQueryFilterExtractor(QueryFilter.Field.END_DATE, QueryFilter.Op.GREATER_THAN_OR_EQUAL_TO,
+                (event, v) -> compareTimestamps(event, v) >= 0)
+            .searchableQueryFilterExtractor(QueryFilter.Field.END_DATE, QueryFilter.Op.GREATER_THAN,
+                (event, v) -> compareTimestamps(event, v) > 0)
+            .searchableQueryFilterExtractor(QueryFilter.Field.END_DATE, QueryFilter.Op.LESS_THAN_OR_EQUAL_TO,
+                (event, v) -> compareTimestamps(event, v) <= 0)
+            .searchableQueryFilterExtractor(QueryFilter.Field.END_DATE, QueryFilter.Op.LESS_THAN,
+                (event, v) -> compareTimestamps(event, v) < 0)
+            .searchableQueryFilterExtractor(QueryFilter.Field.END_DATE, QueryFilter.Op.EQUALS,
+                (event, v) -> compareTimestamps(event, v) == 0)
+            .searchableQueryFilterExtractor(QueryFilter.Field.END_DATE, QueryFilter.Op.NOT_EQUALS,
+                (event, v) -> compareTimestamps(event, v) != 0)
+
+            .searchableQueryFilterExtractor(QueryFilter.Field.FLOW_ID, FollowLogEvent::flowId,
+                QueryFilter.Op.EQUALS, QueryFilter.Op.NOT_EQUALS, QueryFilter.Op.CONTAINS,
+                QueryFilter.Op.STARTS_WITH, QueryFilter.Op.ENDS_WITH, QueryFilter.Op.REGEX,
+                QueryFilter.Op.IN, QueryFilter.Op.NOT_IN, QueryFilter.Op.PREFIX)
+
+            .searchableQueryFilterExtractor(QueryFilter.Field.TRIGGER_ID, FollowLogEvent::triggerId,
+                QueryFilter.Op.EQUALS, QueryFilter.Op.NOT_EQUALS, QueryFilter.Op.CONTAINS,
+                QueryFilter.Op.STARTS_WITH, QueryFilter.Op.ENDS_WITH, QueryFilter.Op.IN, QueryFilter.Op.NOT_IN)
+
+            .searchableQueryFilterExtractor(QueryFilter.Field.LEVEL, QueryFilter.Op.GREATER_THAN_OR_EQUAL_TO,
+                (event, v) -> event.level() != null && event.level().toInt() >= toLevel(v).toInt())
+            .searchableQueryFilterExtractor(QueryFilter.Field.LEVEL, QueryFilter.Op.LESS_THAN_OR_EQUAL_TO,
+                (event, v) -> event.level() != null && event.level().toInt() <= toLevel(v).toInt())
+
+            .searchableQueryFilterExtractor(QueryFilter.Field.EXECUTION_ID, FollowLogEvent::executionId,
+                QueryFilter.Op.EQUALS, QueryFilter.Op.NOT_EQUALS, QueryFilter.Op.CONTAINS,
+                QueryFilter.Op.STARTS_WITH, QueryFilter.Op.ENDS_WITH, QueryFilter.Op.IN, QueryFilter.Op.NOT_IN)
+
+            .searchableQueryFilterExtractor(QueryFilter.Field.TASK_ID, FollowLogEvent::taskId,
+                QueryFilter.Op.EQUALS, QueryFilter.Op.NOT_EQUALS, QueryFilter.Op.CONTAINS,
+                QueryFilter.Op.STARTS_WITH, QueryFilter.Op.ENDS_WITH, QueryFilter.Op.IN, QueryFilter.Op.NOT_IN)
+
+            .searchableQueryFilterExtractor(QueryFilter.Field.TASK_RUN_ID, FollowLogEvent::taskRunId,
+                QueryFilter.Op.EQUALS, QueryFilter.Op.NOT_EQUALS, QueryFilter.Op.CONTAINS,
+                QueryFilter.Op.STARTS_WITH, QueryFilter.Op.ENDS_WITH, QueryFilter.Op.IN, QueryFilter.Op.NOT_IN)
+
+            .searchableQueryFilterExtractor(QueryFilter.Field.ATTEMPT_NUMBER, FollowLogEvent::attemptNumber,
+                QueryFilter.Op.EQUALS, QueryFilter.Op.NOT_EQUALS, QueryFilter.Op.IN, QueryFilter.Op.NOT_IN)
+            .build();
+    }
+
+    private static boolean scopeMatches(FollowLogEvent event, Object value, String systemNamespace) {
+        FlowScope desired = value instanceof FlowScope fs ? fs : FlowScope.valueOf(value.toString());
+        boolean isSystem = systemNamespace.equals(event.namespace());
+        return (desired == FlowScope.SYSTEM) == isSystem;
+    }
+
+    private static int compareTimestamps(FollowLogEvent event, Object queryValue) {
+        if (event.timestamp() == null) {
+            return -1;
+        }
+        Instant target = queryValue instanceof Instant i ? i
+            : queryValue instanceof ZonedDateTime zdt ? zdt.toInstant()
+            : ZonedDateTime.parse(queryValue.toString()).toInstant();
+        return event.timestamp().compareTo(target);
+    }
+
+    @Singleton
+    public FollowLogEventMatcher followLogEventMatcher(
+        @Named("LOG") Searchable<FollowLogEvent> searchable
+    ) {
+        return searchable::matches;
+    }
+
+    private static Level toLevel(Object value) {
+        return value instanceof Level lvl ? lvl : Level.valueOf(value.toString());
     }
 }

--- a/webserver/src/main/java/io/kestra/webserver/utils/RequestUtils.java
+++ b/webserver/src/main/java/io/kestra/webserver/utils/RequestUtils.java
@@ -253,8 +253,8 @@ public class RequestUtils {
         if (minLevel != null) {
             filters.add(
                 QueryFilter.builder()
-                    .field(QueryFilter.Field.MIN_LEVEL)
-                    .operation(QueryFilter.Op.EQUALS)
+                    .field(QueryFilter.Field.LEVEL)
+                    .operation(QueryFilter.Op.GREATER_THAN_OR_EQUAL_TO)
                     .value(minLevel.name())
                     .build()
             );

--- a/webserver/src/main/java/io/kestra/webserver/utils/Searchable.java
+++ b/webserver/src/main/java/io/kestra/webserver/utils/Searchable.java
@@ -114,6 +114,13 @@ public final class Searchable<T> {
         return ArrayListTotal.of(pageable, results.toList());
     }
 
+    public boolean matches(T item, @Nullable List<QueryFilter> queryFilters) {
+        if (queryFilters == null || queryFilters.isEmpty()) {
+            return true;
+        }
+        return queryFilters.stream().allMatch(filter -> evaluate(item, filter));
+    }
+
     private boolean evaluate(T item, QueryFilter queryFilter) {
         if (queryFilter.isNode()) {
             Stream<QueryFilter> children = queryFilter.children().stream();

--- a/webserver/src/main/java/io/kestra/webserver/utils/Searchable.java
+++ b/webserver/src/main/java/io/kestra/webserver/utils/Searchable.java
@@ -3,12 +3,15 @@ package io.kestra.webserver.utils;
 import java.util.*;
 import java.util.function.BiPredicate;
 import java.util.function.Function;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import com.google.common.annotations.VisibleForTesting;
 import io.kestra.core.exceptions.InvalidQueryFiltersException;
 import io.kestra.core.models.QueryFilter;
 import io.kestra.core.repositories.ArrayListTotal;
+import io.kestra.core.utils.RegexUtils;
 
 import io.micronaut.core.annotation.Nullable;
 import io.micronaut.data.model.Pageable;
@@ -37,7 +40,8 @@ public final class Searchable<T> {
         this.queryFilterPredicateMap = queryFilterPredicateMap;
     }
 
-    public Set<QueryFilterPredicateKey>     registeredPredicateKeys() {
+    @VisibleForTesting
+    public Set<QueryFilterPredicateKey> registeredPredicateKeys() {
         return queryFilterPredicateMap.keySet();
     }
 
@@ -147,6 +151,55 @@ public final class Searchable<T> {
             F field, O operator, BiPredicate<T, Object> predicate) {
             this.queryFilterPredicateMap.put(new QueryFilterPredicateKey(field, operator), predicate);
             return this;
+        }
+
+        @SafeVarargs
+        public final <F extends QueryFilter.Field, O extends QueryFilter.Op> Builder<T> searchableQueryFilterExtractor(
+            F field, Function<? super T, ?> fieldFunction, O... operators) {
+            for (O operator : operators) {
+                BiPredicate<Object, Object> defaultPredicate = defaultPredicateFor(operator, field);
+                BiPredicate<T, Object> predicate = (item, value) ->
+                    defaultPredicate.test(fieldFunction.apply(item), value);
+                this.queryFilterPredicateMap.put(new QueryFilterPredicateKey(field, operator), predicate);
+            }
+            return this;
+        }
+
+        private static BiPredicate<Object, Object> defaultPredicateFor(QueryFilter.Op operator, QueryFilter.Field field) {
+            return switch (operator) {
+                case EQUALS -> (fieldValue, queryValue) ->
+                    fieldValue != null && fieldValue.toString().equals(queryValue.toString());
+                case NOT_EQUALS -> (fieldValue, queryValue) ->
+                    fieldValue == null || !fieldValue.toString().equals(queryValue.toString());
+                case CONTAINS -> (fieldValue, queryValue) ->
+                    fieldValue != null && fieldValue.toString().contains(queryValue.toString());
+                case STARTS_WITH -> (fieldValue, queryValue) ->
+                    fieldValue != null && fieldValue.toString().startsWith(queryValue.toString());
+                case ENDS_WITH -> (fieldValue, queryValue) ->
+                    fieldValue != null && fieldValue.toString().endsWith(queryValue.toString());
+                case REGEX -> (fieldValue, queryValue) ->
+                    fieldValue != null && RegexUtils.matches(queryValue.toString(), fieldValue.toString());
+                case IN -> (fieldValue, queryValue) ->
+                    fieldValue != null
+                        && queryValue instanceof List<?> list
+                        && list.stream().map(Object::toString).anyMatch(fieldValue.toString()::equals);
+                case NOT_IN -> (fieldValue, queryValue) ->
+                    fieldValue == null
+                        || !(queryValue instanceof List<?> list)
+                        || list.stream().map(Object::toString).noneMatch(fieldValue.toString()::equals);
+                case PREFIX -> (fieldValue, queryValue) -> {
+                    if (fieldValue == null) {
+                        return false;
+                    }
+                    String fv = fieldValue.toString();
+                    String qv = queryValue.toString();
+                    return fv.equals(qv) || fv.startsWith(qv + ".");
+                };
+                default -> throw new UnsupportedOperationException(
+                    "Operator " + operator + " has no default extractor for field " + field
+                        + ". Register an explicit BiPredicate via the (field, operator, BiPredicate) overload."
+                );
+            };
         }
 
         @SuppressWarnings("unchecked")

--- a/webserver/src/test/java/io/kestra/core/services/LogStreamingServiceTest.java
+++ b/webserver/src/test/java/io/kestra/core/services/LogStreamingServiceTest.java
@@ -1,0 +1,204 @@
+package io.kestra.core.services;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.TimeUnit;
+
+import org.awaitility.Awaitility;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.FieldSource;
+import org.slf4j.event.Level;
+
+import io.kestra.core.junit.annotations.KestraTest;
+import io.kestra.core.models.QueryFilter;
+import io.kestra.core.queues.BroadcastQueueInterface;
+import io.kestra.core.runners.FollowLogEvent;
+import io.kestra.core.utils.IdUtils;
+
+import io.micronaut.http.sse.Event;
+import jakarta.inject.Inject;
+import lombok.Builder;
+import reactor.core.publisher.Flux;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@KestraTest
+class LogStreamingServiceTest {
+
+    private static final String EXECUTION_ID = "exec-streaming-test";
+
+    @Inject
+    BroadcastQueueInterface<FollowLogEvent> queue;
+
+    @Inject
+    LogStreamingService service;
+
+    @ParameterizedTest
+    @FieldSource("filtersTestCases")
+    void shouldDispatchOnlyMatchingEvents(FiltersTestCase testCase) {
+        // Given
+        String subscriberId = IdUtils.create();
+        List<FollowLogEvent> received = new CopyOnWriteArrayList<>();
+
+        Flux.<Event<FollowLogEvent>>create(sink ->
+                service.registerSubscriber(EXECUTION_ID, subscriberId, sink, testCase.filters())
+            )
+            .doFinally(sig -> service.unregisterSubscriber(EXECUTION_ID, subscriberId))
+            .subscribe(event -> received.add(event.getData()));
+
+        // When
+        testCase.events().forEach(event -> {
+            try {
+                queue.emit(event);
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        });
+
+        // Then
+        try {
+            Awaitility.await()
+                .atMost(Duration.ofSeconds(5))
+                .pollInterval(50, TimeUnit.MILLISECONDS)
+                .until(() -> received.size() >= testCase.expectedEvents().size());
+        } finally {
+            service.unregisterSubscriber(EXECUTION_ID, subscriberId);
+        }
+
+        assertThat(received)
+            .usingRecursiveFieldByFieldElementComparatorOnFields("executionId", "level", "taskId", "taskRunId", "attemptNumber", "message")
+            .containsExactlyInAnyOrderElementsOf(testCase.expectedEvents());
+    }
+
+    private static final FollowLogEvent traceEvent = event(Level.TRACE, "load-data", "task-run-1", 0, "trace line");
+    private static final FollowLogEvent debugEvent = event(Level.DEBUG, "load-data", "task-run-1", 0, "debug line");
+    private static final FollowLogEvent infoEvent = event(Level.INFO, "load-data", "task-run-1", 0, "info line");
+    private static final FollowLogEvent warnEvent = event(Level.WARN, "transform", "task-run-2", 0, "warn line");
+    private static final FollowLogEvent errorEvent = event(Level.ERROR, "transform", "task-run-2", 1, "error line");
+    private static final List<FollowLogEvent> allEvents = List.of(traceEvent, debugEvent, infoEvent, warnEvent, errorEvent);
+
+    private static final List<FiltersTestCase> filtersTestCases = List.of(
+        FiltersTestCase.builder()
+            .events(allEvents)
+            .expectedEvents(allEvents)
+            .filters(List.of())
+            .build(),
+
+        FiltersTestCase.builder()
+            .events(allEvents)
+            .expectedEvents(List.of(infoEvent, warnEvent, errorEvent))
+            .filters(List.of(
+                QueryFilter.builder()
+                    .field(QueryFilter.Field.LEVEL)
+                    .operation(QueryFilter.Op.GREATER_THAN_OR_EQUAL_TO)
+                    .value(Level.INFO)
+                    .build()
+            ))
+            .build(),
+
+        FiltersTestCase.builder()
+            .events(allEvents)
+            .expectedEvents(List.of(traceEvent, debugEvent, infoEvent))
+            .filters(List.of(
+                QueryFilter.builder()
+                    .field(QueryFilter.Field.LEVEL)
+                    .operation(QueryFilter.Op.LESS_THAN_OR_EQUAL_TO)
+                    .value(Level.INFO)
+                    .build()
+            ))
+            .build(),
+
+        FiltersTestCase.builder()
+            .events(allEvents)
+            .expectedEvents(List.of(warnEvent, errorEvent))
+            .filters(List.of(
+                QueryFilter.builder()
+                    .field(QueryFilter.Field.TASK_ID)
+                    .operation(QueryFilter.Op.EQUALS)
+                    .value("transform")
+                    .build()
+            ))
+            .build(),
+
+        FiltersTestCase.builder()
+            .events(allEvents)
+            .expectedEvents(List.of(traceEvent, debugEvent, infoEvent))
+            .filters(List.of(
+                QueryFilter.builder()
+                    .field(QueryFilter.Field.TASK_RUN_ID)
+                    .operation(QueryFilter.Op.EQUALS)
+                    .value("task-run-1")
+                    .build()
+            ))
+            .build(),
+
+        FiltersTestCase.builder()
+            .events(allEvents)
+            .expectedEvents(List.of(errorEvent))
+            .filters(List.of(
+                QueryFilter.builder()
+                    .field(QueryFilter.Field.ATTEMPT_NUMBER)
+                    .operation(QueryFilter.Op.EQUALS)
+                    .value(1)
+                    .build()
+            ))
+            .build(),
+
+        FiltersTestCase.builder()
+            .events(allEvents)
+            .expectedEvents(List.of(infoEvent))
+            .filters(List.of(
+                QueryFilter.builder()
+                    .field(QueryFilter.Field.LEVEL)
+                    .operation(QueryFilter.Op.GREATER_THAN_OR_EQUAL_TO)
+                    .value(Level.INFO)
+                    .build(),
+                QueryFilter.builder()
+                    .field(QueryFilter.Field.TASK_ID)
+                    .operation(QueryFilter.Op.EQUALS)
+                    .value("load-data")
+                    .build()
+            ))
+            .build(),
+
+        FiltersTestCase.builder()
+            .events(allEvents)
+            .expectedEvents(List.of())
+            .filters(List.of(
+                QueryFilter.builder()
+                    .field(QueryFilter.Field.EXECUTION_ID)
+                    .operation(QueryFilter.Op.EQUALS)
+                    .value("some-other-execution")
+                    .build()
+            ))
+            .build()
+    );
+
+    private static FollowLogEvent event(Level level, String taskId, String taskRunId, Integer attempt, String message) {
+        return new FollowLogEvent(
+            null,
+            "io.kestra.demo",
+            "demo-flow",
+            taskId,
+            EXECUTION_ID,
+            taskRunId,
+            attempt,
+            null,
+            Instant.now(),
+            level,
+            "main",
+            message,
+            null
+        );
+    }
+
+    @Builder
+    private record FiltersTestCase(
+        List<FollowLogEvent> events,
+        List<FollowLogEvent> expectedEvents,
+        List<QueryFilter> filters
+    ) {
+    }
+}

--- a/webserver/src/test/java/io/kestra/webserver/controllers/api/LogControllerTest.java
+++ b/webserver/src/test/java/io/kestra/webserver/controllers/api/LogControllerTest.java
@@ -1,20 +1,26 @@
 package io.kestra.webserver.controllers.api;
 
+import java.time.Duration;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.Collections;
 import java.util.List;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.FieldSource;
 import org.slf4j.event.Level;
 
 import io.kestra.core.junit.annotations.KestraTest;
+import io.kestra.core.models.QueryFilter;
 import io.kestra.core.models.executions.*;
 import io.kestra.core.models.flows.State;
 import io.kestra.core.repositories.ExecutionRepositoryInterface;
 import io.kestra.core.repositories.LogRepositoryInterface;
+import io.kestra.core.runners.FollowLogEvent;
 import io.kestra.core.tenant.TenantService;
 import io.kestra.core.utils.IdUtils;
+import io.kestra.core.utils.QueryFilterTestUtils;
 import io.kestra.core.utils.TestsUtils;
 import io.kestra.webserver.responses.PagedResults;
 import io.kestra.webserver.tenants.TenantValidationFilter;
@@ -25,9 +31,12 @@ import io.micronaut.http.HttpResponse;
 import io.micronaut.http.HttpStatus;
 import io.micronaut.http.client.annotation.Client;
 import io.micronaut.http.client.exceptions.HttpClientResponseException;
+import io.micronaut.http.sse.Event;
+import io.micronaut.http.uri.UriBuilder;
 import io.micronaut.reactor.http.client.ReactorHttpClient;
 import io.micronaut.test.annotation.MockBean;
 import jakarta.inject.Inject;
+import lombok.Builder;
 
 import static io.micronaut.http.HttpRequest.GET;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -80,7 +89,7 @@ class LogControllerTest {
         assertThat(logs.getTotal()).isEqualTo(3L);
 
         logs = client.toBlocking().retrieve(
-            GET("/api/v1/" + tenant + "/logs/search?filters[level][EQUALS]=INFO"),
+            GET("/api/v1/" + tenant + "/logs/search?filters[level][GREATER_THAN_OR_EQUAL_TO]=INFO"),
             Argument.of(PagedResults.class, LogEntry.class)
         );
         assertThat(logs.getTotal()).isEqualTo(2L);
@@ -249,5 +258,236 @@ class LogControllerTest {
             .thread("")
             .message("john doe")
             .build();
+    }
+
+    @Inject
+    private LogController logController;
+
+    @ParameterizedTest
+    @FieldSource("filtersTestCases")
+    @SuppressWarnings("unchecked")
+    void listLogsFromExecutionShouldRespectFilters(FiltersTestCase testCase) {
+        String tenant = TestsUtils.randomTenant(this.getClass().getSimpleName());
+        when(tenantService.resolveTenant()).thenReturn(tenant);
+        seedLogs(tenant, testCase);
+
+        List<LogEntry> result = client.toBlocking().retrieve(
+            GET(filterUri(tenant, testCase.executionId(), "", testCase.filters())),
+            Argument.of(List.class, LogEntry.class)
+        );
+
+        assertThat(result)
+            .extracting(LogEntry::getMessage)
+            .containsExactlyInAnyOrderElementsOf(
+                testCase.expectedLogs().stream().map(LogEntry::getMessage).toList()
+            );
+    }
+
+    @ParameterizedTest
+    @FieldSource("filtersTestCases")
+    void downloadLogsFromExecutionShouldRespectFilters(FiltersTestCase testCase) {
+        String tenant = TestsUtils.randomTenant(this.getClass().getSimpleName());
+        when(tenantService.resolveTenant()).thenReturn(tenant);
+        seedExecution(tenant, testCase.executionId());
+        seedLogs(tenant, testCase);
+
+        String body = client.toBlocking().retrieve(
+            GET(filterUri(tenant, testCase.executionId(), "/download", testCase.filters())),
+            String.class
+        );
+
+        for (LogEntry expected : testCase.expectedLogs()) {
+            assertThat(body).contains(expected.getMessage());
+        }
+        List<LogEntry> excluded = testCase.logs().stream()
+            .filter(log -> testCase.expectedLogs().stream().noneMatch(e -> e.getMessage().equals(log.getMessage())))
+            .toList();
+        for (LogEntry omitted : excluded) {
+            assertThat(body).doesNotContain(omitted.getMessage());
+        }
+    }
+
+    @ParameterizedTest
+    @FieldSource("filtersTestCases")
+    void followLogsFromExecutionShouldReplayHistoricalLogsWithFilters(FiltersTestCase testCase) {
+        String tenant = TestsUtils.randomTenant(this.getClass().getSimpleName());
+        when(tenantService.resolveTenant()).thenReturn(tenant);
+        seedLogs(tenant, testCase);
+
+        List<Event<FollowLogEvent>> received = logController
+            .followLogsFromExecution(testCase.executionId(), testCase.filters())
+            .take(testCase.expectedLogs().size() + 1L) // +1 for the initial "start" event
+            .collectList()
+            .block(Duration.ofSeconds(5));
+
+        assertThat(received).isNotNull();
+        List<FollowLogEvent> historical = received.stream()
+            .filter(event -> "progress".equals(event.getId()))
+            .map(Event::getData)
+            .toList();
+
+        assertThat(historical)
+            .extracting(FollowLogEvent::message)
+            .containsExactlyInAnyOrderElementsOf(
+                testCase.expectedLogs().stream().map(LogEntry::getMessage).toList()
+            );
+    }
+
+    private void seedLogs(String tenant, FiltersTestCase testCase) {
+        testCase.logs().forEach(log -> logRepository.save(
+            log.toBuilder().tenantId(tenant).executionId(testCase.executionId()).build()
+        ));
+    }
+
+    private void seedExecution(String tenant, String executionId) {
+        executionRepository.save(
+            Execution.builder()
+                .id(executionId)
+                .namespace("io.kestra.unittest")
+                .tenantId(tenant)
+                .flowId("full")
+                .flowRevision(1)
+                .state(new State().withState(State.Type.RUNNING).withState(State.Type.SUCCESS))
+                .taskRunList(Collections.singletonList(
+                    TaskRun.builder()
+                        .id(IdUtils.create())
+                        .namespace("io.kestra.unittest")
+                        .flowId("full")
+                        .state(new State().withState(State.Type.RUNNING).withState(State.Type.SUCCESS))
+                        .attempts(Collections.singletonList(TaskRunAttempt.builder().build()))
+                        .build()
+                ))
+                .build()
+        );
+    }
+
+    private static String filterUri(String tenant, String executionId, String suffix, List<QueryFilter> filters) {
+        UriBuilder builder = UriBuilder.of("/api/v1/" + tenant + "/logs/" + executionId + suffix);
+        QueryFilterTestUtils.toQueryParams(filters).forEach(builder::queryParam);
+        return builder.build().toString();
+    }
+
+    private static final String TEST_EXECUTION_ID = "exec-filter-test";
+
+    private static final LogEntry traceLog = baseLog(Level.TRACE, "load-data", "task-run-1", 0, "trace line");
+    private static final LogEntry debugLog = baseLog(Level.DEBUG, "load-data", "task-run-1", 0, "debug line");
+    private static final LogEntry infoLog = baseLog(Level.INFO, "load-data", "task-run-1", 0, "info line");
+    private static final LogEntry warnLog = baseLog(Level.WARN, "transform", "task-run-2", 0, "warn line");
+    private static final LogEntry errorLog = baseLog(Level.ERROR, "transform", "task-run-2", 1, "error line");
+    private static final List<LogEntry> allLogs = List.of(traceLog, debugLog, infoLog, warnLog, errorLog);
+
+    private static final List<FiltersTestCase> filtersTestCases = List.of(
+        FiltersTestCase.builder()
+            .executionId(TEST_EXECUTION_ID)
+            .logs(allLogs)
+            .expectedLogs(allLogs)
+            .filters(List.of())
+            .build(),
+
+        FiltersTestCase.builder()
+            .executionId(TEST_EXECUTION_ID)
+            .logs(allLogs)
+            .expectedLogs(List.of(infoLog, warnLog, errorLog))
+            .filters(List.of(
+                QueryFilter.builder()
+                    .field(QueryFilter.Field.LEVEL)
+                    .operation(QueryFilter.Op.GREATER_THAN_OR_EQUAL_TO)
+                    .value(Level.INFO)
+                    .build()
+            ))
+            .build(),
+
+        FiltersTestCase.builder()
+            .executionId(TEST_EXECUTION_ID)
+            .logs(allLogs)
+            .expectedLogs(List.of(traceLog, debugLog, infoLog))
+            .filters(List.of(
+                QueryFilter.builder()
+                    .field(QueryFilter.Field.LEVEL)
+                    .operation(QueryFilter.Op.LESS_THAN_OR_EQUAL_TO)
+                    .value(Level.INFO)
+                    .build()
+            ))
+            .build(),
+
+        FiltersTestCase.builder()
+            .executionId(TEST_EXECUTION_ID)
+            .logs(allLogs)
+            .expectedLogs(List.of(warnLog, errorLog))
+            .filters(List.of(
+                QueryFilter.builder()
+                    .field(QueryFilter.Field.TASK_ID)
+                    .operation(QueryFilter.Op.EQUALS)
+                    .value("transform")
+                    .build()
+            ))
+            .build(),
+
+        FiltersTestCase.builder()
+            .executionId(TEST_EXECUTION_ID)
+            .logs(allLogs)
+            .expectedLogs(List.of(traceLog, debugLog, infoLog))
+            .filters(List.of(
+                QueryFilter.builder()
+                    .field(QueryFilter.Field.TASK_RUN_ID)
+                    .operation(QueryFilter.Op.EQUALS)
+                    .value("task-run-1")
+                    .build()
+            ))
+            .build(),
+
+        FiltersTestCase.builder()
+            .executionId(TEST_EXECUTION_ID)
+            .logs(allLogs)
+            .expectedLogs(List.of(errorLog))
+            .filters(List.of(
+                QueryFilter.builder()
+                    .field(QueryFilter.Field.ATTEMPT_NUMBER)
+                    .operation(QueryFilter.Op.EQUALS)
+                    .value(1)
+                    .build()
+            ))
+            .build(),
+
+        FiltersTestCase.builder()
+            .executionId(TEST_EXECUTION_ID)
+            .logs(allLogs)
+            .expectedLogs(List.of(infoLog))
+            .filters(List.of(
+                QueryFilter.builder()
+                    .field(QueryFilter.Field.LEVEL)
+                    .operation(QueryFilter.Op.GREATER_THAN_OR_EQUAL_TO)
+                    .value(Level.INFO)
+                    .build(),
+                QueryFilter.builder()
+                    .field(QueryFilter.Field.TASK_ID)
+                    .operation(QueryFilter.Op.EQUALS)
+                    .value("load-data")
+                    .build()
+            ))
+            .build()
+    );
+
+    private static LogEntry baseLog(Level level, String taskId, String taskRunId, Integer attempt, String message) {
+        return LogEntry.builder()
+            .flowId("filter-test-flow")
+            .namespace("io.kestra.unittest")
+            .taskId(taskId)
+            .taskRunId(taskRunId)
+            .attemptNumber(attempt)
+            .timestamp(Instant.now())
+            .level(level)
+            .thread("")
+            .message(message)
+            .build();
+    }
+
+    @Builder
+    private record FiltersTestCase(
+        String executionId,
+        List<LogEntry> logs,
+        List<LogEntry> expectedLogs,
+        List<QueryFilter> filters
+    ) {
     }
 }

--- a/webserver/src/test/java/io/kestra/webserver/services/FollowLogEventSearchableTest.java
+++ b/webserver/src/test/java/io/kestra/webserver/services/FollowLogEventSearchableTest.java
@@ -1,0 +1,235 @@
+package io.kestra.webserver.services;
+
+import java.time.Instant;
+import java.util.List;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.FieldSource;
+import org.slf4j.event.Level;
+
+import io.kestra.core.junit.annotations.KestraTest;
+import io.kestra.core.models.QueryFilter;
+import io.kestra.core.models.QueryFilter.Field;
+import io.kestra.core.models.QueryFilter.Op;
+import io.kestra.core.models.flows.FlowScope;
+import io.kestra.core.runners.FollowLogEvent;
+import io.kestra.webserver.utils.Searchable;
+
+import jakarta.inject.Inject;
+import jakarta.inject.Named;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@KestraTest
+class FollowLogEventSearchableTest {
+
+    @Inject
+    @Named("LOG")
+    private Searchable<FollowLogEvent> searchable;
+
+    @ParameterizedTest
+    @FieldSource("filtersTestCases")
+    void shouldEvaluatePredicateAsExpected(PredicateCase testCase) {
+        assertThat(searchable.matches(testCase.event(), List.of(testCase.filter())))
+            .as(testCase.filter().field().name() + " / " + testCase.filter().operation().name())
+            .isEqualTo(testCase.expected());
+    }
+
+    private static final Instant T_PAST = Instant.parse("2020-01-01T00:00:00Z");
+    private static final Instant T_NOW = Instant.parse("2020-06-01T00:00:00Z");
+    private static final Instant T_FUTURE = Instant.parse("2020-12-31T00:00:00Z");
+
+    private static final FollowLogEvent baseEvent = new FollowLogEvent(
+        null,                  // tenantId
+        "io.kestra.demo",
+        "demo-flow",
+        "load-data",
+        "exec-123",
+        "tr-load-1",
+        0,
+        "demo-trigger",
+        T_NOW,
+        Level.INFO,
+        "main",
+        "hello world",
+        null
+    );
+
+    private static final FollowLogEvent systemEvent = new FollowLogEvent(
+        null, "system", "demo-flow", "load-data", "exec-sys",
+        "tr-sys", 0, "demo-trigger", T_NOW, Level.INFO, "main", "system message", null
+    );
+
+    private static final FollowLogEvent pastEvent = new FollowLogEvent(
+        null, "io.kestra.demo", "demo-flow", "load-data", "exec-past",
+        "tr-past", 0, "demo-trigger", T_PAST, Level.INFO, "main", "past", null
+    );
+
+    private static final FollowLogEvent futureEvent = new FollowLogEvent(
+        null, "io.kestra.demo", "demo-flow", "load-data", "exec-future",
+        "tr-future", 0, "demo-trigger", T_FUTURE, Level.INFO, "main", "future", null
+    );
+
+    private static QueryFilter filter(Field field, Op op, Object value) {
+        return QueryFilter.builder().field(field).operation(op).value(value).build();
+    }
+
+    private record PredicateCase(FollowLogEvent event, QueryFilter filter, boolean expected) {
+    }
+
+    @SuppressWarnings("unused")
+    private static final List<PredicateCase> filtersTestCases = List.of(
+        new PredicateCase(baseEvent, filter(Field.QUERY, Op.EQUALS, "hello"), true),
+        new PredicateCase(baseEvent, filter(Field.QUERY, Op.EQUALS, "missing"), false),
+        new PredicateCase(baseEvent, filter(Field.QUERY, Op.NOT_EQUALS, "hello"), false),
+        new PredicateCase(baseEvent, filter(Field.QUERY, Op.NOT_EQUALS, "missing"), true),
+
+        new PredicateCase(baseEvent, filter(Field.SCOPE, Op.EQUALS, FlowScope.USER), true),
+        new PredicateCase(systemEvent, filter(Field.SCOPE, Op.EQUALS, FlowScope.USER), false),
+        new PredicateCase(systemEvent, filter(Field.SCOPE, Op.EQUALS, FlowScope.SYSTEM), true),
+        new PredicateCase(baseEvent, filter(Field.SCOPE, Op.NOT_EQUALS, FlowScope.USER), false),
+        new PredicateCase(systemEvent, filter(Field.SCOPE, Op.NOT_EQUALS, FlowScope.USER), true),
+        new PredicateCase(baseEvent, filter(Field.SCOPE, Op.IN, List.of(FlowScope.USER, FlowScope.SYSTEM)), true),
+        new PredicateCase(baseEvent, filter(Field.SCOPE, Op.IN, List.of(FlowScope.SYSTEM)), false),
+        new PredicateCase(baseEvent, filter(Field.SCOPE, Op.NOT_IN, List.of(FlowScope.SYSTEM)), true),
+        new PredicateCase(baseEvent, filter(Field.SCOPE, Op.NOT_IN, List.of(FlowScope.USER, FlowScope.SYSTEM)), false),
+
+        new PredicateCase(baseEvent, filter(Field.NAMESPACE, Op.EQUALS, "io.kestra.demo"), true),
+        new PredicateCase(baseEvent, filter(Field.NAMESPACE, Op.EQUALS, "other"), false),
+        new PredicateCase(baseEvent, filter(Field.NAMESPACE, Op.NOT_EQUALS, "other"), true),
+        new PredicateCase(baseEvent, filter(Field.NAMESPACE, Op.NOT_EQUALS, "io.kestra.demo"), false),
+        new PredicateCase(baseEvent, filter(Field.NAMESPACE, Op.CONTAINS, "kestra"), true),
+        new PredicateCase(baseEvent, filter(Field.NAMESPACE, Op.CONTAINS, "missing"), false),
+        new PredicateCase(baseEvent, filter(Field.NAMESPACE, Op.STARTS_WITH, "io.kestra"), true),
+        new PredicateCase(baseEvent, filter(Field.NAMESPACE, Op.STARTS_WITH, "kestra"), false),
+        new PredicateCase(baseEvent, filter(Field.NAMESPACE, Op.ENDS_WITH, "demo"), true),
+        new PredicateCase(baseEvent, filter(Field.NAMESPACE, Op.ENDS_WITH, "io"), false),
+        new PredicateCase(baseEvent, filter(Field.NAMESPACE, Op.REGEX, "io\\.kestra\\..*"), true),
+        new PredicateCase(baseEvent, filter(Field.NAMESPACE, Op.REGEX, "no\\..*"), false),
+        new PredicateCase(baseEvent, filter(Field.NAMESPACE, Op.IN, List.of("io.kestra.demo", "other")), true),
+        new PredicateCase(baseEvent, filter(Field.NAMESPACE, Op.IN, List.of("nothing", "other")), false),
+        new PredicateCase(baseEvent, filter(Field.NAMESPACE, Op.NOT_IN, List.of("nothing", "other")), true),
+        new PredicateCase(baseEvent, filter(Field.NAMESPACE, Op.NOT_IN, List.of("io.kestra.demo")), false),
+        new PredicateCase(baseEvent, filter(Field.NAMESPACE, Op.PREFIX, "io.kestra"), true),
+        new PredicateCase(baseEvent, filter(Field.NAMESPACE, Op.PREFIX, "io.kestrasomething"), false),
+
+        new PredicateCase(baseEvent, filter(Field.START_DATE, Op.GREATER_THAN_OR_EQUAL_TO, T_NOW), true),
+        new PredicateCase(pastEvent, filter(Field.START_DATE, Op.GREATER_THAN_OR_EQUAL_TO, T_NOW), false),
+        new PredicateCase(futureEvent, filter(Field.START_DATE, Op.GREATER_THAN, T_NOW), true),
+        new PredicateCase(baseEvent, filter(Field.START_DATE, Op.GREATER_THAN, T_NOW), false),
+        new PredicateCase(baseEvent, filter(Field.START_DATE, Op.LESS_THAN_OR_EQUAL_TO, T_NOW), true),
+        new PredicateCase(futureEvent, filter(Field.START_DATE, Op.LESS_THAN_OR_EQUAL_TO, T_NOW), false),
+        new PredicateCase(pastEvent, filter(Field.START_DATE, Op.LESS_THAN, T_NOW), true),
+        new PredicateCase(baseEvent, filter(Field.START_DATE, Op.LESS_THAN, T_NOW), false),
+        new PredicateCase(baseEvent, filter(Field.START_DATE, Op.EQUALS, T_NOW), true),
+        new PredicateCase(pastEvent, filter(Field.START_DATE, Op.EQUALS, T_NOW), false),
+        new PredicateCase(pastEvent, filter(Field.START_DATE, Op.NOT_EQUALS, T_NOW), true),
+        new PredicateCase(baseEvent, filter(Field.START_DATE, Op.NOT_EQUALS, T_NOW), false),
+
+        new PredicateCase(baseEvent, filter(Field.END_DATE, Op.GREATER_THAN_OR_EQUAL_TO, T_NOW), true),
+        new PredicateCase(pastEvent, filter(Field.END_DATE, Op.GREATER_THAN_OR_EQUAL_TO, T_NOW), false),
+        new PredicateCase(futureEvent, filter(Field.END_DATE, Op.GREATER_THAN, T_NOW), true),
+        new PredicateCase(baseEvent, filter(Field.END_DATE, Op.GREATER_THAN, T_NOW), false),
+        new PredicateCase(baseEvent, filter(Field.END_DATE, Op.LESS_THAN_OR_EQUAL_TO, T_NOW), true),
+        new PredicateCase(futureEvent, filter(Field.END_DATE, Op.LESS_THAN_OR_EQUAL_TO, T_NOW), false),
+        new PredicateCase(pastEvent, filter(Field.END_DATE, Op.LESS_THAN, T_NOW), true),
+        new PredicateCase(baseEvent, filter(Field.END_DATE, Op.LESS_THAN, T_NOW), false),
+        new PredicateCase(baseEvent, filter(Field.END_DATE, Op.EQUALS, T_NOW), true),
+        new PredicateCase(pastEvent, filter(Field.END_DATE, Op.EQUALS, T_NOW), false),
+        new PredicateCase(pastEvent, filter(Field.END_DATE, Op.NOT_EQUALS, T_NOW), true),
+        new PredicateCase(baseEvent, filter(Field.END_DATE, Op.NOT_EQUALS, T_NOW), false),
+
+        new PredicateCase(baseEvent, filter(Field.FLOW_ID, Op.EQUALS, "demo-flow"), true),
+        new PredicateCase(baseEvent, filter(Field.FLOW_ID, Op.EQUALS, "other"), false),
+        new PredicateCase(baseEvent, filter(Field.FLOW_ID, Op.NOT_EQUALS, "other"), true),
+        new PredicateCase(baseEvent, filter(Field.FLOW_ID, Op.NOT_EQUALS, "demo-flow"), false),
+        new PredicateCase(baseEvent, filter(Field.FLOW_ID, Op.CONTAINS, "demo"), true),
+        new PredicateCase(baseEvent, filter(Field.FLOW_ID, Op.CONTAINS, "nope"), false),
+        new PredicateCase(baseEvent, filter(Field.FLOW_ID, Op.STARTS_WITH, "demo"), true),
+        new PredicateCase(baseEvent, filter(Field.FLOW_ID, Op.STARTS_WITH, "flow"), false),
+        new PredicateCase(baseEvent, filter(Field.FLOW_ID, Op.ENDS_WITH, "flow"), true),
+        new PredicateCase(baseEvent, filter(Field.FLOW_ID, Op.ENDS_WITH, "demo"), false),
+        new PredicateCase(baseEvent, filter(Field.FLOW_ID, Op.REGEX, "demo-.*"), true),
+        new PredicateCase(baseEvent, filter(Field.FLOW_ID, Op.REGEX, "x-.*"), false),
+        new PredicateCase(baseEvent, filter(Field.FLOW_ID, Op.IN, List.of("demo-flow", "other")), true),
+        new PredicateCase(baseEvent, filter(Field.FLOW_ID, Op.IN, List.of("nothing")), false),
+        new PredicateCase(baseEvent, filter(Field.FLOW_ID, Op.NOT_IN, List.of("nothing")), true),
+        new PredicateCase(baseEvent, filter(Field.FLOW_ID, Op.NOT_IN, List.of("demo-flow")), false),
+        new PredicateCase(baseEvent, filter(Field.FLOW_ID, Op.PREFIX, "demo-flow"), true),
+        new PredicateCase(baseEvent, filter(Field.FLOW_ID, Op.PREFIX, "other"), false),
+
+        new PredicateCase(baseEvent, filter(Field.TRIGGER_ID, Op.EQUALS, "demo-trigger"), true),
+        new PredicateCase(baseEvent, filter(Field.TRIGGER_ID, Op.EQUALS, "other"), false),
+        new PredicateCase(baseEvent, filter(Field.TRIGGER_ID, Op.NOT_EQUALS, "other"), true),
+        new PredicateCase(baseEvent, filter(Field.TRIGGER_ID, Op.NOT_EQUALS, "demo-trigger"), false),
+        new PredicateCase(baseEvent, filter(Field.TRIGGER_ID, Op.CONTAINS, "trigger"), true),
+        new PredicateCase(baseEvent, filter(Field.TRIGGER_ID, Op.CONTAINS, "nope"), false),
+        new PredicateCase(baseEvent, filter(Field.TRIGGER_ID, Op.STARTS_WITH, "demo"), true),
+        new PredicateCase(baseEvent, filter(Field.TRIGGER_ID, Op.STARTS_WITH, "trigger"), false),
+        new PredicateCase(baseEvent, filter(Field.TRIGGER_ID, Op.ENDS_WITH, "trigger"), true),
+        new PredicateCase(baseEvent, filter(Field.TRIGGER_ID, Op.ENDS_WITH, "demo"), false),
+        new PredicateCase(baseEvent, filter(Field.TRIGGER_ID, Op.IN, List.of("demo-trigger", "other")), true),
+        new PredicateCase(baseEvent, filter(Field.TRIGGER_ID, Op.IN, List.of("nothing")), false),
+        new PredicateCase(baseEvent, filter(Field.TRIGGER_ID, Op.NOT_IN, List.of("nothing")), true),
+        new PredicateCase(baseEvent, filter(Field.TRIGGER_ID, Op.NOT_IN, List.of("demo-trigger")), false),
+
+        new PredicateCase(baseEvent, filter(Field.LEVEL, Op.GREATER_THAN_OR_EQUAL_TO, Level.INFO), true),
+        new PredicateCase(baseEvent, filter(Field.LEVEL, Op.GREATER_THAN_OR_EQUAL_TO, Level.ERROR), false),
+        new PredicateCase(baseEvent, filter(Field.LEVEL, Op.LESS_THAN_OR_EQUAL_TO, Level.INFO), true),
+        new PredicateCase(baseEvent, filter(Field.LEVEL, Op.LESS_THAN_OR_EQUAL_TO, Level.TRACE), false),
+
+        new PredicateCase(baseEvent, filter(Field.EXECUTION_ID, Op.EQUALS, "exec-123"), true),
+        new PredicateCase(baseEvent, filter(Field.EXECUTION_ID, Op.EQUALS, "other"), false),
+        new PredicateCase(baseEvent, filter(Field.EXECUTION_ID, Op.NOT_EQUALS, "other"), true),
+        new PredicateCase(baseEvent, filter(Field.EXECUTION_ID, Op.NOT_EQUALS, "exec-123"), false),
+        new PredicateCase(baseEvent, filter(Field.EXECUTION_ID, Op.CONTAINS, "exec"), true),
+        new PredicateCase(baseEvent, filter(Field.EXECUTION_ID, Op.CONTAINS, "nope"), false),
+        new PredicateCase(baseEvent, filter(Field.EXECUTION_ID, Op.STARTS_WITH, "exec"), true),
+        new PredicateCase(baseEvent, filter(Field.EXECUTION_ID, Op.STARTS_WITH, "123"), false),
+        new PredicateCase(baseEvent, filter(Field.EXECUTION_ID, Op.ENDS_WITH, "123"), true),
+        new PredicateCase(baseEvent, filter(Field.EXECUTION_ID, Op.ENDS_WITH, "exec"), false),
+        new PredicateCase(baseEvent, filter(Field.EXECUTION_ID, Op.IN, List.of("exec-123", "other")), true),
+        new PredicateCase(baseEvent, filter(Field.EXECUTION_ID, Op.IN, List.of("nothing")), false),
+        new PredicateCase(baseEvent, filter(Field.EXECUTION_ID, Op.NOT_IN, List.of("nothing")), true),
+        new PredicateCase(baseEvent, filter(Field.EXECUTION_ID, Op.NOT_IN, List.of("exec-123")), false),
+
+        new PredicateCase(baseEvent, filter(Field.TASK_ID, Op.EQUALS, "load-data"), true),
+        new PredicateCase(baseEvent, filter(Field.TASK_ID, Op.EQUALS, "other"), false),
+        new PredicateCase(baseEvent, filter(Field.TASK_ID, Op.NOT_EQUALS, "other"), true),
+        new PredicateCase(baseEvent, filter(Field.TASK_ID, Op.NOT_EQUALS, "load-data"), false),
+        new PredicateCase(baseEvent, filter(Field.TASK_ID, Op.CONTAINS, "load"), true),
+        new PredicateCase(baseEvent, filter(Field.TASK_ID, Op.CONTAINS, "nope"), false),
+        new PredicateCase(baseEvent, filter(Field.TASK_ID, Op.STARTS_WITH, "load"), true),
+        new PredicateCase(baseEvent, filter(Field.TASK_ID, Op.STARTS_WITH, "data"), false),
+        new PredicateCase(baseEvent, filter(Field.TASK_ID, Op.ENDS_WITH, "data"), true),
+        new PredicateCase(baseEvent, filter(Field.TASK_ID, Op.ENDS_WITH, "load"), false),
+        new PredicateCase(baseEvent, filter(Field.TASK_ID, Op.IN, List.of("load-data", "other")), true),
+        new PredicateCase(baseEvent, filter(Field.TASK_ID, Op.IN, List.of("nothing")), false),
+        new PredicateCase(baseEvent, filter(Field.TASK_ID, Op.NOT_IN, List.of("nothing")), true),
+        new PredicateCase(baseEvent, filter(Field.TASK_ID, Op.NOT_IN, List.of("load-data")), false),
+
+        new PredicateCase(baseEvent, filter(Field.TASK_RUN_ID, Op.EQUALS, "tr-load-1"), true),
+        new PredicateCase(baseEvent, filter(Field.TASK_RUN_ID, Op.EQUALS, "other"), false),
+        new PredicateCase(baseEvent, filter(Field.TASK_RUN_ID, Op.NOT_EQUALS, "other"), true),
+        new PredicateCase(baseEvent, filter(Field.TASK_RUN_ID, Op.NOT_EQUALS, "tr-load-1"), false),
+        new PredicateCase(baseEvent, filter(Field.TASK_RUN_ID, Op.CONTAINS, "load"), true),
+        new PredicateCase(baseEvent, filter(Field.TASK_RUN_ID, Op.CONTAINS, "nope"), false),
+        new PredicateCase(baseEvent, filter(Field.TASK_RUN_ID, Op.STARTS_WITH, "tr-"), true),
+        new PredicateCase(baseEvent, filter(Field.TASK_RUN_ID, Op.STARTS_WITH, "load"), false),
+        new PredicateCase(baseEvent, filter(Field.TASK_RUN_ID, Op.ENDS_WITH, "1"), true),
+        new PredicateCase(baseEvent, filter(Field.TASK_RUN_ID, Op.ENDS_WITH, "tr"), false),
+        new PredicateCase(baseEvent, filter(Field.TASK_RUN_ID, Op.IN, List.of("tr-load-1", "other")), true),
+        new PredicateCase(baseEvent, filter(Field.TASK_RUN_ID, Op.IN, List.of("nothing")), false),
+        new PredicateCase(baseEvent, filter(Field.TASK_RUN_ID, Op.NOT_IN, List.of("nothing")), true),
+        new PredicateCase(baseEvent, filter(Field.TASK_RUN_ID, Op.NOT_IN, List.of("tr-load-1")), false),
+
+        new PredicateCase(baseEvent, filter(Field.ATTEMPT_NUMBER, Op.EQUALS, 0), true),
+        new PredicateCase(baseEvent, filter(Field.ATTEMPT_NUMBER, Op.EQUALS, 1), false),
+        new PredicateCase(baseEvent, filter(Field.ATTEMPT_NUMBER, Op.NOT_EQUALS, 1), true),
+        new PredicateCase(baseEvent, filter(Field.ATTEMPT_NUMBER, Op.NOT_EQUALS, 0), false),
+        new PredicateCase(baseEvent, filter(Field.ATTEMPT_NUMBER, Op.IN, List.of(0, 1)), true),
+        new PredicateCase(baseEvent, filter(Field.ATTEMPT_NUMBER, Op.IN, List.of(1, 2)), false),
+        new PredicateCase(baseEvent, filter(Field.ATTEMPT_NUMBER, Op.NOT_IN, List.of(1, 2)), true),
+        new PredicateCase(baseEvent, filter(Field.ATTEMPT_NUMBER, Op.NOT_IN, List.of(0, 1)), false)
+    );
+}

--- a/webserver/src/test/java/io/kestra/webserver/utils/SearchableTest.java
+++ b/webserver/src/test/java/io/kestra/webserver/utils/SearchableTest.java
@@ -1,19 +1,24 @@
 package io.kestra.webserver.utils;
 
 import java.util.List;
+import java.util.function.Function;
 
 import io.kestra.core.exceptions.InvalidQueryFiltersException;
 import io.kestra.core.models.QueryFilter;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.FieldSource;
 
 import io.kestra.core.repositories.ArrayListTotal;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.tuple;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class SearchableTest {
     private List<TestEntity> entities;
@@ -450,5 +455,164 @@ class SearchableTest {
     }
 
     record TestEntity(String name, int age) {
+    }
+
+    @Test
+    void shouldMatchReturnTrueWhenFiltersIsNull() {
+        // Given
+        Searchable<TestEntity> searchable = Searchable.<TestEntity>builder()
+            .searchableQueryFilterExtractor(QueryFilter.Field.QUERY, QueryFilter.Op.EQUALS,
+                (entity, value) -> entity.name().equals(value))
+            .build();
+
+        // Then
+        assertTrue(searchable.matches(new TestEntity("Alice", 30), null));
+    }
+
+    @Test
+    void shouldMatchReturnTrueWhenFiltersIsEmpty() {
+        // Given
+        Searchable<TestEntity> searchable = Searchable.<TestEntity>builder()
+            .searchableQueryFilterExtractor(QueryFilter.Field.QUERY, QueryFilter.Op.EQUALS,
+                (entity, value) -> entity.name().equals(value))
+            .build();
+
+        // Then
+        assertTrue(searchable.matches(new TestEntity("Alice", 30), List.of()));
+    }
+
+    @Test
+    void shouldMatchReturnTrueWhenAllFiltersMatchAndedTogether() {
+        // Given
+        Searchable<TestEntity> searchable = Searchable.<TestEntity>builder()
+            .searchableQueryFilterExtractor(QueryFilter.Field.QUERY, QueryFilter.Op.EQUALS,
+                (entity, value) -> entity.name().equals(value))
+            .searchableQueryFilterExtractor(QueryFilter.Field.FLOW_ID, QueryFilter.Op.GREATER_THAN,
+                (entity, value) -> entity.age() > (Integer) value)
+            .build();
+
+        // When
+        List<QueryFilter> filters = List.of(
+            QueryFilter.builder().field(QueryFilter.Field.QUERY).operation(QueryFilter.Op.EQUALS).value("Alice").build(),
+            QueryFilter.builder().field(QueryFilter.Field.FLOW_ID).operation(QueryFilter.Op.GREATER_THAN).value(25).build()
+        );
+
+        // Then
+        assertTrue(searchable.matches(new TestEntity("Alice", 30), filters));
+    }
+
+    @Test
+    void shouldMatchReturnFalseWhenAnyFilterDoesNotMatch() {
+        // Given
+        Searchable<TestEntity> searchable = Searchable.<TestEntity>builder()
+            .searchableQueryFilterExtractor(QueryFilter.Field.QUERY, QueryFilter.Op.EQUALS,
+                (entity, value) -> entity.name().equals(value))
+            .searchableQueryFilterExtractor(QueryFilter.Field.FLOW_ID, QueryFilter.Op.GREATER_THAN,
+                (entity, value) -> entity.age() > (Integer) value)
+            .build();
+
+        // When
+        List<QueryFilter> filters = List.of(
+            QueryFilter.builder().field(QueryFilter.Field.QUERY).operation(QueryFilter.Op.EQUALS).value("Alice").build(),
+            QueryFilter.builder().field(QueryFilter.Field.FLOW_ID).operation(QueryFilter.Op.GREATER_THAN).value(100).build()
+        );
+
+        // Then
+        assertFalse(searchable.matches(new TestEntity("Alice", 30), filters));
+    }
+
+    @Test
+    void shouldMatchThrowWhenFieldOpPairNotRegistered() {
+        // Given
+        Searchable<TestEntity> searchable = Searchable.<TestEntity>builder()
+            .searchableQueryFilterExtractor(QueryFilter.Field.QUERY, QueryFilter.Op.EQUALS,
+                (entity, value) -> entity.name().equals(value))
+            .build();
+
+        // When
+        List<QueryFilter> filters = List.of(
+            QueryFilter.builder().field(QueryFilter.Field.FLOW_ID).operation(QueryFilter.Op.EQUALS).value("anything").build()
+        );
+
+        // Then
+        InvalidQueryFiltersException ex = assertThrows(
+            InvalidQueryFiltersException.class,
+            () -> searchable.matches(new TestEntity("Alice", 30), filters)
+        );
+        assertEquals(
+            "Provided query filters are invalid: Unsupported operation for FLOW_ID: EQUALS",
+            ex.getMessage()
+        );
+    }
+
+    @ParameterizedTest
+    @FieldSource("defaultOperatorCases")
+    void shouldApplyStandardSemanticsForFunctionOverload(DefaultOperatorCase testCase) {
+        // Given
+        Searchable<String> searchable = Searchable.<String>builder()
+            .searchableQueryFilterExtractor(QueryFilter.Field.QUERY, Function.identity(), testCase.op())
+            .build();
+
+        // When
+        QueryFilter filter = QueryFilter.builder()
+            .field(QueryFilter.Field.QUERY)
+            .operation(testCase.op())
+            .value(testCase.queryValue())
+            .build();
+
+        // Then
+        assertEquals(testCase.expectedMatch(), searchable.matches(testCase.input(), List.of(filter)),
+            testCase.description());
+    }
+
+    @SuppressWarnings("unused") // referenced via @FieldSource
+    private static final List<DefaultOperatorCase> defaultOperatorCases = List.of(
+        new DefaultOperatorCase(QueryFilter.Op.EQUALS, "hello", "hello", true, "EQUALS: identical strings match"),
+        new DefaultOperatorCase(QueryFilter.Op.EQUALS, "hello", "world", false, "EQUALS: different strings don't match"),
+        new DefaultOperatorCase(QueryFilter.Op.EQUALS, null, "hello", false, "EQUALS: null field value doesn't match"),
+
+        new DefaultOperatorCase(QueryFilter.Op.NOT_EQUALS, "hello", "world", true, "NOT_EQUALS: different strings match"),
+        new DefaultOperatorCase(QueryFilter.Op.NOT_EQUALS, "hello", "hello", false, "NOT_EQUALS: identical strings don't match"),
+        new DefaultOperatorCase(QueryFilter.Op.NOT_EQUALS, null, "hello", true, "NOT_EQUALS: null field value matches (absence ≠ value)"),
+
+        new DefaultOperatorCase(QueryFilter.Op.CONTAINS, "hello world", "world", true, "CONTAINS: substring present"),
+        new DefaultOperatorCase(QueryFilter.Op.CONTAINS, "hello", "world", false, "CONTAINS: substring absent"),
+        new DefaultOperatorCase(QueryFilter.Op.CONTAINS, null, "world", false, "CONTAINS: null field value"),
+
+        new DefaultOperatorCase(QueryFilter.Op.STARTS_WITH, "hello world", "hello", true, "STARTS_WITH: prefix matches"),
+        new DefaultOperatorCase(QueryFilter.Op.STARTS_WITH, "hello", "world", false, "STARTS_WITH: wrong prefix"),
+
+        new DefaultOperatorCase(QueryFilter.Op.ENDS_WITH, "hello world", "world", true, "ENDS_WITH: suffix matches"),
+        new DefaultOperatorCase(QueryFilter.Op.ENDS_WITH, "hello", "world", false, "ENDS_WITH: wrong suffix"),
+
+        new DefaultOperatorCase(QueryFilter.Op.REGEX, "hello", "h.*o", true, "REGEX: pattern matches"),
+        new DefaultOperatorCase(QueryFilter.Op.REGEX, "world", "h.*o", false, "REGEX: pattern doesn't match"),
+
+        new DefaultOperatorCase(QueryFilter.Op.IN, "hello", List.of("hello", "world"), true, "IN: present in list"),
+        new DefaultOperatorCase(QueryFilter.Op.IN, "foo", List.of("hello", "world"), false, "IN: absent from list"),
+        new DefaultOperatorCase(QueryFilter.Op.NOT_IN, "foo", List.of("hello", "world"), true, "NOT_IN: absent from list matches"),
+        new DefaultOperatorCase(QueryFilter.Op.NOT_IN, "hello", List.of("hello", "world"), false, "NOT_IN: present in list doesn't match"),
+
+        new DefaultOperatorCase(QueryFilter.Op.PREFIX, "com.example", "com.example", true, "PREFIX: equals the value"),
+        new DefaultOperatorCase(QueryFilter.Op.PREFIX, "com.example.app", "com.example", true, "PREFIX: starts with value+\".\""),
+        new DefaultOperatorCase(QueryFilter.Op.PREFIX, "com.examples", "com.example", false, "PREFIX: must be the value or a dotted descendant — \"com.examples\" is neither")
+    );
+
+    @Test
+    void shouldThrowAtBuilderTimeForOpWithoutDefault() {
+        assertThatThrownBy(() -> Searchable.<String>builder()
+                .searchableQueryFilterExtractor(QueryFilter.Field.QUERY, Function.identity(), QueryFilter.Op.GREATER_THAN))
+            .isInstanceOf(UnsupportedOperationException.class)
+            .hasMessageContaining("GREATER_THAN")
+            .hasMessageContaining("BiPredicate");
+    }
+
+    private record DefaultOperatorCase(
+        QueryFilter.Op op,
+        String input,
+        Object queryValue,
+        boolean expectedMatch,
+        String description
+    ) {
     }
 }


### PR DESCRIPTION
### ✨ Description

Reworks log filtering to fix a misleading `EQUALS` semantic and consolidate the per-execution log endpoints around the `QueryFilter` machinery.

**Backend (model + repository + controller):**

- `QueryFilter.Field`: renamed `MIN_LEVEL` → `LEVEL` (JSON wire value `"level"` unchanged). The old `EQUALS` op silently meant "at or above" — replaced with explicit `GREATER_THAN_OR_EQUAL_TO` and added `LESS_THAN_OR_EQUAL_TO`. `EQUALS`/`NOT_EQUALS` on `LEVEL` are now rejected.
- Added `TASK_ID`, `TASK_RUN_ID`, `ATTEMPT_NUMBER` to `Resource.LOG.supportedField()`. JDBC column-name override on `AbstractJdbcLogRepository` maps `TASK_RUN_ID → taskrun_id` (single mismatch with the default snake-case derivation). New `handleAttemptNumberField` parses values to `Integer` before binding so Postgres' strict type contract is honoured (H2 silently coerced before).
- `LogController.listLogsFromExecution` / `downloadLogsFromExecution` / `followLogsFromExecution`: dropped the typed `?minLevel=`, `?taskId=`, `?taskRunId=`, `?attempt=` query params. Endpoints now take a single `@QueryFilterFormat List<QueryFilter> filters` plus the existing `executionId` path variable. `buildExecutionFilters` appends the path-var `EXECUTION_ID = EQUALS` filter to the user-supplied list.
- `LogStreamingService` now stores `List<QueryFilter>` per subscriber and applies them via a new `FollowLogEventMatcher` interface (backed by a `Searchable<FollowLogEvent>` registered in `SearchableFactory`). Live SSE streaming now respects the full filter set, not just LEVEL — closes a gap where any non-`level` filter was silently ignored on `/follow`.
- `ILogs.whereWithGlobalFilters`: added the LEVEL branch so dashboard log charts can scope by level.

**Searchable utility:**

- Added `Searchable.matches(item, filters)` extracted from `filter()` for single-item evaluation.
- Added a `Function<? super T, ?>`-based overload of `searchableQueryFilterExtractor` that synthesises the predicate from the standard string-semantic for each operator (EQUALS, NOT_EQUALS, CONTAINS, STARTS_WITH, ENDS_WITH, REGEX, IN, NOT_IN, PREFIX). Lets factories register a field with a one-liner method reference instead of writing the same lambda shape repeatedly. Unsupported ops (`GREATER_THAN` etc.) throw at registration time.

**Frontend:**

- `logLevelQuery.ts`: route helpers now return `{value, direction}` instead of a bare string. Handles `GREATER_THAN_OR_EQUAL_TO`, `LESS_THAN_OR_EQUAL_TO`, and the legacy `EQUALS` shape (read-only — writes use the new form). New `levelToRequestParams` helper.
- `FilterKeyConfig.comparatorLabels` (optional per-field label override) — the level filter dropdown now shows **"At or Above" / "At or Below"** instead of "Greater Than or Equal To" / "Less Than or Equal To". Other filters using the same comparators are untouched.
- `logFilter.ts`, `logExecutionsFilter.ts`, `ganttExecutionFilter.ts`: comparators + labels for level; added `taskId`, `taskRunId`, `attemptNumber` filter entries to the main logs page and the per-execution Logs tab.
- `LogsWrapper.vue`, `Logs.vue`, `Gantt.vue`: typed `useRouteFilterPolicy<LevelFilterValue>` and propagated the richer value to children.
- `TaskRunDetails.vue`: `level` prop renamed to `levelFilter` (object). Internal fetch builds request params via `levelToRequestParams(levelFilter)` and explicit `filters[taskId][EQUALS]` / `filters[attemptNumber][EQUALS]` keys.
- `ErrorAlert.vue`: migrated from `?minLevel=ERROR` to `?filters[level][GREATER_THAN_OR_EQUAL_TO]=ERROR`.

**Tests added:**

- `QueryFilterTest`: LEVEL valid/invalid op sets.
- `DashboardDataGlobalFiltersTest`: 6 LEVEL cases on `ILogs.whereWithGlobalFilters`.
- `AbstractLogRepositoryTest`: refactored to `FiltersTestCase` pattern. 13 cases covering LEVEL ≥/≤, TASK_ID (EQUALS/NOT_EQUALS/IN), TASK_RUN_ID (EQUALS/IN — exercises the `taskrun_id` column-name override), ATTEMPT_NUMBER (EQUALS/NOT_EQUALS/IN — exercises the integer-parsing path).
- `LogStreamingServiceTest`: new file. 8 parameterized cases verifying that emitted `FollowLogEvent`s only reach subscribers whose `QueryFilter` list they match.
- `LogControllerTest`: 21 parameterized cases (7 × 3 endpoints — list / download / follow) end-to-end through the HTTP client (follow uses direct controller invocation for the historical replay assertion).
- `SearchableTest`: 5 `matches()` cases + 21 default-operator parameterized cases + builder-time rejection of unsupported ops.

**Breaking changes (major release):**

- `Field.MIN_LEVEL` → `Field.LEVEL` in `QueryFilter` (JSON `"level"` unchanged).
- `LEVEL` no longer accepts `EQUALS` / `NOT_EQUALS` — only `GREATER_THAN_OR_EQUAL_TO` and `LESS_THAN_OR_EQUAL_TO`.
- `/logs/{executionId}`, `/logs/{executionId}/download`, `/logs/{executionId}/follow`: typed `?minLevel=`, `?taskId=`, `?taskRunId=`, `?attempt=` query params removed. Use `?filters[level][GREATER_THAN_OR_EQUAL_TO]=...&filters[taskId][EQUALS]=...` etc.

### 🔗 Related Issue

Closes https://github.com/kestra-io/kestra/issues/15954

### 🎨 Frontend Checklist

- [ ] Code builds without errors (`npm run build`)
- [ ] All existing E2E tests pass (`npm run test:e2e`)
- [ ] Screenshots attached showing the level filter dropdown rendering "At or Above" / "At or Below"

### 🛠️ Backend Checklist

- [ ] Code compiles successfully and passes all checks
- [ ] All unit and integration tests pass (verified locally on H2; Postgres-specific `attempt_number` int-coercion is covered by the new `handleAttemptNumberField` helper)