### PR TITLE
Add a linkify option to the Markdown renderer and expose it via the Markdown component. Disable linkify for SELECT/MULTISELECT option labels to prevent automatic navigation when labels contain URLs.

### DIFF
--- a/ui/src/components/inputs/InputsForm.vue
+++ b/ui/src/components/inputs/InputsForm.vue
@@ -40,7 +40,7 @@
                     :label="item"
                     :value="item"
                 >
-                    <Markdown :source="item" />
+                    <Markdown :source="item" :linkify="false" />
                 </el-option>
             </el-select>
             <el-radio-group
@@ -76,7 +76,7 @@
                     :label="item"
                     :value="item"
                 >
-                    <Markdown :source="item" />
+                    <Markdown :source="item" :linkify="false" />
                 </el-option>
             </el-select>
             <el-input

--- a/ui/src/components/layout/Markdown.vue
+++ b/ui/src/components/layout/Markdown.vue
@@ -38,6 +38,7 @@
             permalink?: boolean;
             fontSizeVar?: string;
             html?: boolean;
+            linkify?: boolean;
             showSearch?: boolean;
             collapseExamples?: boolean;
             variant?: "default" | "enhanced";
@@ -48,6 +49,7 @@
             permalink: false,
             fontSizeVar: "font-size-sm",
             html: true,
+            linkify: true,
             showSearch: false, // good default for OSS docs
             collapseExamples: false,
             variant: "enhanced",
@@ -126,6 +128,7 @@
             html: props.html,
             variant: props.variant,
             showCopyButtons: props.showCopyButtons,
+            linkify: props.linkify,
         });
 
         await nextTick();

--- a/ui/src/utils/markdown.ts
+++ b/ui/src/utils/markdown.ts
@@ -26,6 +26,7 @@ interface RenderOptions {
     html?: boolean;
     variant?: RenderVariant;
     showCopyButtons?: boolean;
+    linkify?: boolean;
 }
 
 export async function render(markdown: string, options: RenderOptions = {}) {
@@ -79,7 +80,7 @@ export async function render(markdown: string, options: RenderOptions = {}) {
         html: options.html,
         xhtmlOut: true,
         breaks: true,
-        linkify: true,
+        linkify: options.linkify ?? true,
         typographer: true,
         langPrefix: "language-",
         quotes: "“”‘’",


### PR DESCRIPTION
---

### ✨ Description

Add [linkify](vscode-file://vscode-app/c:/Users/IRFAN/AppData/Local/Programs/Microsoft%20VS%20Code/f6cfa2ea24/resources/app/out/vs/code/electron-browser/workbench/workbench.html) prop to the Markdown renderer and disable autolinks for select option labels ([InputsForm.vue](vscode-file://vscode-app/c:/Users/IRFAN/AppData/Local/Programs/Microsoft%20VS%20Code/f6cfa2ea24/resources/app/out/vs/code/electron-browser/workbench/workbench.html)) to prevent accidental navigation when option text contains URLs.

### 🔗 Related Issue

fixes: https://github.com/kestra-io/kestra/issues/16045

### 🎨 Frontend Checklist

- [x] Code builds without errors (`npm run build`)
- [ ] All existing E2E tests pass (`npm run test:e2e`)
- [x] Screenshots or video recordings attached showing the `UI` changes

---

Video preview: 

https://github.com/user-attachments/assets/85abfc82-e6f8-4e0c-829f-62a07046ee25

---

