### PR TITLE
Feat/query filter iam feedback

### DIFF
--- a/core/src/main/java/io/kestra/core/models/QueryFilter.java
+++ b/core/src/main/java/io/kestra/core/models/QueryFilter.java
@@ -383,6 +383,12 @@ public record QueryFilter(
                 return List.of(Op.IN, Op.EQUALS);
             }
         },
+        EXTERNAL_ID("external_id") {
+            @Override
+            public List<Op> supportedOp() {
+                return List.of(Op.EQUALS, Op.IN, Op.NOT_IN);
+            }
+        },
         EXPIRED_AT("expired_at") {
             @Override
             public List<Op> supportedOp() {
@@ -507,7 +513,7 @@ public record QueryFilter(
         BINDING {
             @Override
             public List<Field> supportedField() {
-                return List.of(Field.QUERY, Field.NAMESPACE, Field.TYPE);
+                return List.of(Field.QUERY, Field.NAMESPACE, Field.TYPE, Field.EXTERNAL_ID);
             }
         },
         SECURITY_INTEGRATION {

--- a/core/src/main/java/io/kestra/core/models/QueryFilter.java
+++ b/core/src/main/java/io/kestra/core/models/QueryFilter.java
@@ -368,7 +368,7 @@ public record QueryFilter(
         USERNAME("username") {
             @Override
             public List<Op> supportedOp() {
-                return List.of(Op.EQUALS);
+                return List.of(Op.EQUALS, Op.IN, Op.NOT_IN);
             }
         },
         NAME("name") {

--- a/core/src/main/java/io/kestra/core/models/QueryFilter.java
+++ b/core/src/main/java/io/kestra/core/models/QueryFilter.java
@@ -368,7 +368,7 @@ public record QueryFilter(
         USERNAME("username") {
             @Override
             public List<Op> supportedOp() {
-                return List.of(Op.EQUALS, Op.IN, Op.NOT_IN);
+                return List.of(Op.EQUALS, Op.IN, Op.NOT_IN, Op.CONTAINS);
             }
         },
         NAME("name") {

--- a/core/src/test/java/io/kestra/core/models/QueryFilterTest.java
+++ b/core/src/test/java/io/kestra/core/models/QueryFilterTest.java
@@ -343,7 +343,7 @@ public class QueryFilterTest {
             buildQueryFiltersForOperations(
                 Field.USERNAME, Resource.USER,
                 Set.of(
-                    Op.EQUALS
+                    Op.EQUALS, Op.CONTAINS
                 )
             ),
 
@@ -1069,11 +1069,8 @@ public class QueryFilterTest {
                     Op.LESS_THAN,
                     Op.GREATER_THAN_OR_EQUAL_TO,
                     Op.LESS_THAN_OR_EQUAL_TO,
-                    Op.IN,
-                    Op.NOT_IN,
                     Op.STARTS_WITH,
                     Op.ENDS_WITH,
-                    Op.CONTAINS,
                     Op.REGEX,
                     Op.PREFIX,
                     Op.NOT_EQUALS

--- a/core/src/test/java/io/kestra/core/models/QueryFilterTest.java
+++ b/core/src/test/java/io/kestra/core/models/QueryFilterTest.java
@@ -427,6 +427,15 @@ public class QueryFilterTest {
             ),
 
             buildQueryFiltersForOperations(
+                Field.EXTERNAL_ID, Resource.BINDING,
+                Set.of(
+                    Op.EQUALS,
+                    Op.IN,
+                    Op.NOT_IN
+                )
+            ),
+
+            buildQueryFiltersForOperations(
                 Field.TAGS, Resource.APP,
                 Set.of(
                     Op.IN,
@@ -1239,6 +1248,22 @@ public class QueryFilterTest {
                     Op.LESS_THAN_OR_EQUAL_TO,
                     Op.GREATER_THAN,
                     Op.GREATER_THAN_OR_EQUAL_TO
+                )
+            ),
+
+            buildQueryFiltersForOperations(
+                Field.EXTERNAL_ID, Resource.BINDING,
+                Set.of(
+                    Op.NOT_EQUALS,
+                    Op.GREATER_THAN,
+                    Op.LESS_THAN,
+                    Op.GREATER_THAN_OR_EQUAL_TO,
+                    Op.LESS_THAN_OR_EQUAL_TO,
+                    Op.STARTS_WITH,
+                    Op.ENDS_WITH,
+                    Op.CONTAINS,
+                    Op.REGEX,
+                    Op.PREFIX
                 )
             ),
 

--- a/ui/packages/design-system/src/components/Data/KsDataTable/KsFilter.locale.ts
+++ b/ui/packages/design-system/src/components/Data/KsDataTable/KsFilter.locale.ts
@@ -114,6 +114,10 @@ export default {
                 "label": "Name",
                 "description": "Filter by name",
             },
+            "member": {
+                "label": "Member",
+                "description": "Filter by member"
+            },
             "group": {
                 "label": "Group",
                 "description": "Filter by group",

--- a/ui/packages/design-system/src/components/Data/KsDataTable/KsFilter.locale.ts
+++ b/ui/packages/design-system/src/components/Data/KsDataTable/KsFilter.locale.ts
@@ -116,7 +116,7 @@ export default {
             },
             "member": {
                 "label": "Member",
-                "description": "Filter by member"
+                "description": "Filter by member",
             },
             "group": {
                 "label": "Group",

--- a/ui/packages/design-system/src/components/Data/KsDataTable/filter/layout/FilterEditPopover.vue
+++ b/ui/packages/design-system/src/components/Data/KsDataTable/filter/layout/FilterEditPopover.vue
@@ -63,9 +63,9 @@
             position: "absolute",
             top: `${chipRect.bottom + scrollY + 8}px`,
             left: `${chipRect.left + scrollX}px`,
-            width: `${popupWidth}px`,
-        }
-    }
+            "min-width": `${popupWidth}px`,
+        };
+    };
 
     const toggleDialog = () => {
         isDialogVisible.value = !isDialogVisible.value
@@ -122,6 +122,7 @@
         box-shadow: rgba(0, 0, 0, 0.09) 0px 3px 12px;
         padding: 0;
         min-height: var(--ks-font-size-lg);
+        max-width: 480px;
         position: relative;
     }
 }

--- a/ui/packages/design-system/src/components/Data/KsDataTable/filter/layout/FilterEditPopover.vue
+++ b/ui/packages/design-system/src/components/Data/KsDataTable/filter/layout/FilterEditPopover.vue
@@ -64,8 +64,8 @@
             top: `${chipRect.bottom + scrollY + 8}px`,
             left: `${chipRect.left + scrollX}px`,
             "min-width": `${popupWidth}px`,
-        };
-    };
+        }
+    }
 
     const toggleDialog = () => {
         isDialogVisible.value = !isDialogVisible.value

--- a/ui/packages/design-system/src/components/Data/KsDataTable/filter/layout/FilterMultiSelect.vue
+++ b/ui/packages/design-system/src/components/Data/KsDataTable/filter/layout/FilterMultiSelect.vue
@@ -203,6 +203,7 @@
             display: flex;
             align-items: center;
             justify-content: space-between;
+            gap: 0.75rem;
             padding: 0.5rem 1rem;
             transition: all 0.2s ease;
             cursor: pointer;
@@ -219,12 +220,13 @@
             .option-content {
                 display: flex;
                 align-items: center;
+                flex: 1;
+                min-width: 0;
 
                 .option-label {
-                    max-width: 250px;
                     font-size: var(--ks-font-size-sm);
                     font-weight: 400;
-                    padding-right: 0.25rem;
+                    word-break: break-word;
                 }
             }
         }

--- a/ui/packages/design-system/src/components/Data/KsDataTable/filter/layout/FilterMultiSelect.vue
+++ b/ui/packages/design-system/src/components/Data/KsDataTable/filter/layout/FilterMultiSelect.vue
@@ -172,7 +172,7 @@
             margin-bottom: 8px;
 
             .check-border {
-                border: 1px solid var(--ks-border-default);
+                border: 1px solid var(--ks-border-primary);
                 border-radius: 4px;
                 padding: 0 12px;
                 width: calc(50% - 0.5rem);

--- a/ui/packages/design-system/src/components/Data/KsDataTable/filter/utils/filterTypes.ts
+++ b/ui/packages/design-system/src/components/Data/KsDataTable/filter/utils/filterTypes.ts
@@ -17,8 +17,8 @@ export enum Comparators {
 export const KV_COMPARATORS = [Comparators.EQUALS, Comparators.NOT_EQUALS]
 export const TEXT_COMPARATORS = [
     Comparators.CONTAINS,
-    Comparators.ENDS_WITH, 
-    Comparators.STARTS_WITH, 
+    Comparators.ENDS_WITH,
+    Comparators.STARTS_WITH,
 ]
 
 export interface DateFilterOption {
@@ -94,17 +94,17 @@ export interface TableProperties {
 }
 
 export interface TableOptions {
-    chart?: { 
-        shown?: boolean; 
-        value?: boolean; 
-        callback?: (value: boolean) => void 
+    chart?: {
+        shown?: boolean;
+        value?: boolean;
+        callback?: (value: boolean) => void
     };
     columns?: {
         shown?: boolean
     };
-    refresh?: { 
-        shown?: boolean; 
-        callback?: () => void 
+    refresh?: {
+        shown?: boolean;
+        callback?: () => void
     };
 }
 


### PR DESCRIPTION
### ✨ Description

  Backend and design-system changes needed to land the IAM filter cleanup in `kestra-ee` (closes kestra-io/kestra-ee#6256, scope per kestra-io/kestra-ee#7087):
  
  - **`QueryFilter`** — widens `Field.USERNAME` to support `IN`, `NOT_IN`, `CONTAINS` (was `EQUALS` only) so the IAM Users/Service-Accounts/Tenant-Access tables can be
  filtered with a real multi-select dropdown.
  - **`QueryFilter`** — introduces `Field.EXTERNAL_ID("external_id")` with `EQUALS`, `IN`, `NOT_IN`, and adds it to `Resource.BINDING.supportedField()` so the new "Member"
   filter on the Access page is validated end-to-end.
  - **Design system** — `KsFilter.locale.ts` gains a `member` entry; `FilterEditPopover.vue` uses `min-width`/`max-width: 480px` so the new multi-select popover can grow
  without overflowing; `FilterMultiSelect.vue` polishes long-label rendering (gap, `word-break`) for the user/group label format used by the Member dropdown.
  
  #### Resource × Field × Operator additions

  | Resource | Field         | Operators                                            |
  |----------|---------------|------------------------------------------------------|
  | USER     | USERNAME      | EQUALS, IN, NOT_IN, CONTAINS *(added IN/NOT_IN/CONTAINS)* |
  | BINDING  | EXTERNAL_ID   | EQUALS, IN, NOT_IN *(new field on this resource)*    |

  `QueryFilterTest` is updated to assert both the new supported combos and the negative cases (rejecting unsupported ops on `USERNAME` and `EXTERNAL_ID`).
  
### 🔗 Related Issue

Closes kestra-io/kestra-ee#6256
Closes kestra-io/kestra-ee#7087
