### PR TITLE
fix(no-code): surface AdditionalPlugin subtypes (ToolProvider, ModelProvider…) in autocomplete

### DIFF
--- a/ui/src/components/no-code/components/tasks/getTaskComponent.ts
+++ b/ui/src/components/no-code/components/tasks/getTaskComponent.ts
@@ -62,8 +62,10 @@ function getType(property: any, definitions: Record<string, any>, key?: string):
             return "dict"
         }
 
-        // for dag tasks
-        if (property.anyOf.length > 10 || key === "taskRunner") {
+        // for dag tasks and task-runner properties: use the single-task editor
+        // Note: avoid matching by anyOf.length — AdditionalPlugin subtypes (e.g. ToolProvider)
+        // can also have many anyOf entries and must render as "any-of", not "task".
+        if (key === "tasks" || key === "taskRunner") {
             return "task"
         }
         return "any-of"
@@ -97,7 +99,10 @@ function getType(property: any, definitions: Record<string, any>, key?: string):
 
     if (property.type === "array") {
         const items = definitions ? resolve$ref({definitions: definitions}, property.items) : property.items
-        if (items?.anyOf?.length === 0 || items?.anyOf?.length > 10 || LIST_FIELDS.includes(key ?? "")) {
+        // Note: avoid matching by items.anyOf.length — AdditionalPlugin subtypes (e.g. ToolProvider, ModelProvider)
+        // can have many anyOf entries and must render as "array" so the no-code editor surfaces a type-selector
+        // for each item. Section fields (tasks, triggers, …) are already covered by LIST_FIELDS.
+        if (items?.anyOf?.length === 0 || LIST_FIELDS.includes(key ?? "")) {
             return "list"
         }
 

--- a/ui/src/components/plugins/PluginSelect.vue
+++ b/ui/src/components/plugins/PluginSelect.vue
@@ -66,7 +66,10 @@
     })
 
     onBeforeMount(() => {
-        if (blockType === "pluginDefaults" || isPluginBlock) {
+        // Load plugin list for known plugin-block properties, pluginDefaults, and any schema-driven
+        // anyOf property (e.g. AdditionalPlugin subtypes such as ToolProvider, ModelProvider).
+        const hasAnyOfOptions = (fieldDefinition.value?.anyOf?.length ?? 0) > 0
+        if (blockType === "pluginDefaults" || isPluginBlock || hasAnyOfOptions) {
             pluginsStore.listWithSubgroup({includeDeprecated: false})
         }
     })


### PR DESCRIPTION
## Problem

Closes #16204

Tools registered in `plugin-ai` (e.g. `io.kestra.plugin.ai.tool.TavilyWebSearch`, `io.kestra.plugin.ai.tool.AIAgent`, `io.kestra.plugin.ai.tool.CodeExecution`, …) did not appear in the no-code editor autocomplete when editing the `tools` list of an `AIAgent` task.

The same issue affects any `AdditionalPlugin`-typed array property: `modelProvider`, `contentRetrievers`, `memoryProvider`, `embeddingStore`.

## Root cause

`getTaskComponent.ts` used a **count-based heuristic** to classify polymorphic plugin properties:

```ts
// anyOf branch (property-level union)
if (property.anyOf.length > 10 || key === "taskRunner") return "task"

// array branch (typed array)
if (items?.anyOf?.length === 0 || items?.anyOf?.length > 10 || LIST_FIELDS.includes(key ?? "")) return "list"
```

The intent was to catch DAG task arrays (hundreds of `Task` subtypes). But `plugin-ai` registers **12** `ToolProvider` implementations — enough to exceed both `> 10` thresholds — so:

| Property | Expected | Actual (before fix) |
|---|---|---|
| `tools[]` array | `"array"` → `TaskArray.vue` + type-selector | `"list"` → plain list, no type-selector |
| each item's `anyOf` schema | `"any-of"` → `TaskAnyOf.vue` | `"task"` → single-task picker |

The no-code editor either showed a plain untyped list or a mismatched single-task picker — neither lets users pick a `ToolProvider` subtype.

## Fix

Replace the fragile `anyOf.length > 10` thresholds with **explicit key-based guards**:

- **`anyOf` branch**: keep only `key === "tasks" || key === "taskRunner"` — DAG tasks and task-runners are the only properties that need the single-task editor.
- **`array` branch**: remove `items?.anyOf?.length > 10` entirely — `"tasks"` is already caught by `LIST_FIELDS`, and every other typed array with `anyOf` items should render as `"array"` so the type-selector is available.

Also broaden `PluginSelect.vue`'s `onBeforeMount` guard to eagerly load plugin metadata for any schema-driven `anyOf` property (not just the four hardcoded block names).

## Affected files

- `ui/src/components/no-code/components/tasks/getTaskComponent.ts`
- `ui/src/components/plugins/PluginSelect.vue`

## Testing

With `plugin-ai` installed, create a flow with `type: io.kestra.plugin.ai.agent.AIAgent` and open the no-code editor. The `tools` list should now surface all `io.kestra.plugin.ai.tool.*` subtypes in the type-selector dropdown. The same improvement applies to `modelProvider`, `contentRetrievers`, `memoryProvider`, and `embeddingStore`.