### PR TITLE
chore: deprecate TOOL plugin sub group

### DIFF
--- a/model/src/main/java/io/kestra/core/models/annotations/PluginSubGroup.java
+++ b/model/src/main/java/io/kestra/core/models/annotations/PluginSubGroup.java
@@ -17,19 +17,30 @@ public @interface PluginSubGroup {
     PluginCategory[] categories() default { OTHER };
 
     enum PluginCategory {
+        @Deprecated
         DATABASE,
+        @Deprecated
         MESSAGING,
+        @Deprecated
         SCRIPT,
+        @Deprecated
         TRANSFORMATION,
+        @Deprecated
         BATCH,
+        @Deprecated
         ALERTING,
         CLOUD,
+        @Deprecated
         STORAGE,
+        @Deprecated
         OTHER,
+        @Deprecated
         TOOL,
         AI,
         CORE,
+        @Deprecated
         INGESTION,
+        @Deprecated
         BI,
         BUSINESS,
         DATA,


### PR DESCRIPTION
Deprecate plugin sub group. See https://kestra.io/plugins for current plugin sub groups. 