### PR TITLE
fix(core): use flush instead of close in deprecated FileSerde.writeAll Writer path

### DIFF
--- a/core/src/main/java/io/kestra/core/serializers/FileSerde.java
+++ b/core/src/main/java/io/kestra/core/serializers/FileSerde.java
@@ -226,7 +226,11 @@ public final class FileSerde {
     public static <T> Mono<Long> writeAll(ObjectMapper objectMapper, Writer writer, Flux<T> values) throws IOException {
         SequenceWriter seqWriter = createSequenceWriter(objectMapper, writer, new TypeReference<T>() {
         });
-        return writeAll(values, seqWriter);
+        return values
+            .filter(Objects::nonNull)
+            .doOnNext(throwConsumer(seqWriter::write))
+            .doFinally(throwConsumer(ignored -> seqWriter.flush()))
+            .count();
     }
 
     // endregion


### PR DESCRIPTION
## Summary
- The deprecated `writeAll(ObjectMapper, Writer, Flux)` method in `FileSerde` was delegating to the shared `writeAll(Flux, SequenceWriter)` which calls `seqWriter.close()` at the end.
- `IonGenerator.close()` closes the underlying `Writer`, then attempts to flush it — causing a "Stream closed" exception on the deprecated text-based Writer path.
- This inlines the write loop with `flush()` instead of `close()`, matching the original 1.x behavior. The binary ION path (OutputStream-based) continues to use `close()` as needed to finalize the binary stream.

Related: #3155, #16144

## Test plan
- [x] QA flow validated binary ION roundtrips (JsonToIon, IonToJson, IonToCsv, CsvToIon, Split, Concat, etc.)
- [x] Groovy FileTransform plugin confirmed working with both binary and text ION paths
- [ ] CI passes