### PR TITLE
fix(ci): pass DEVELOCITY_ACCESS_KEY to backend-tests reusable workflow

### DIFF
--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -31,6 +31,7 @@ jobs:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
       SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
       GOOGLE_SERVICE_ACCOUNT: ${{ secrets.GOOGLE_SERVICE_ACCOUNT }}
+      DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
 
   frontend-tests:
     name: Frontend tests


### PR DESCRIPTION
The `kestra-oss-backend-tests` reusable workflow at `kestra-io/actions@main` now requires `DEVELOCITY_ACCESS_KEY`; without it Main Workflow ends in `startup_failure` with 0 jobs scheduled (visible on the last two pushes to this branch).

Mirrors `releases/v1.0.x` `main-build.yml`.