### PR TITLE
[backport releases/v1.0.x] fix(ui): update logs route-level filtering to prevent flickering

### DIFF
--- a/ui/src/components/executions/ExecutionRoot.vue
+++ b/ui/src/components/executions/ExecutionRoot.vue
@@ -65,6 +65,7 @@
             $route() {
                 this.executionsStore.taskRun = undefined;
                 if (this.previousExecutionId !== this.$route.params.id) {
+                    this.executionsStore.logs = {total: 0, results: []}
                     this.flowStore.flow = undefined;
                     this.flowStore.flowGraph = undefined;
                     this.follow();

--- a/ui/src/components/executions/Logs.vue
+++ b/ui/src/components/executions/Logs.vue
@@ -87,11 +87,13 @@
         />
         <el-card v-else class="attempt-wrapper">
             <DynamicScroller
+                v-if="temporalLogs.length > 0"
                 ref="logScroller"
                 :items="temporalLogs"
                 :min-item-size="50"
                 key-field="index"
                 class="log-lines temporal"
+                :style="{maxHeight: 'calc(100vh - 335px)', marginTop: '0.5rem'}"
                 :buffer="200"
                 :prerender="20"
             >
@@ -163,7 +165,8 @@
                 openedTaskrunsCount: 0,
                 raw_view: false,
                 logIndicesByLevel: Object.fromEntries(LogUtils.levelOrLower(undefined).map(level => [level, []])),
-                logCursor: undefined
+                logCursor: undefined,
+                logsLoading: false,
             };
         },
         created() {
@@ -171,9 +174,19 @@
             this.filter = (this.$route.query.q || undefined);
         },
         watch:{
+            "executionsStore.execution": {
+                immediate: true,
+                handler(execution, oldExecution) {
+                    if (execution && !oldExecution && this.raw_view && !this.logsLoading && !this.executionsStore.logs?.length) {
+                        this.loadLogs()
+                    }
+                },
+            },
             level: {
                 handler() {
-                    if (this.raw_view) {
+                    if (this.raw_view && this.executionsStore.execution) {
+                        this.executionsStore.logs = {total: 0, results: []}
+                        this.logsLoading = false
                         this.loadLogs();
                     }
                 }
@@ -247,9 +260,13 @@
         },
         methods: {
             loadLogs(){
+                if (this.logsLoading) return
+                this.logsLoading = true
                 this.executionsStore.loadLogs({
                     executionId: this.executionId,
                     minLevel: this.level
+                }).finally(() => {
+                    this.logsLoading = false
                 })
             },
             downloadContent() {
@@ -326,8 +343,8 @@
                 this.logCursor = sortedIndices?.[sortedIndices.indexOf(this.logCursor) + 1] ?? sortedIndices[0];
             },
             scrollToLog(index) {
-                this.$refs.logScroller.scrollToItem(index);
-            }
+                this.$refs.logScroller?.scrollToItem(index)
+            },
         }
     };
 </script>
@@ -347,16 +364,16 @@
     }
 
     .log-lines {
-        max-height: calc(100vh - 335px);
-        transition: max-height 0.2s ease-out;
-        margin-top: .5rem;
-
         .line {
             padding: .5rem;
         }
+
+        :deep(.vue-recycle-scroller__item-view > div) {
+            min-height: 2rem;
+        }
     }
 
-    .temporal {
+    .log-lines.temporal {
         .line {
             align-items: flex-start;
         }

--- a/ui/src/components/logs/TaskRunDetails.vue
+++ b/ui/src/components/logs/TaskRunDetails.vue
@@ -41,7 +41,7 @@
                     <DynamicScroller
                         v-if="shouldDisplayLogs(currentTaskRun)"
                         :items="logsWithIndexByAttemptUid[attemptUid(currentTaskRun.id, selectedAttemptNumberByTaskRunId[currentTaskRun.id])] ?? []"
-                        :min-item-size="1"
+                        :minItemSize="32"
                         key-field="index"
                         class="log-lines"
                         :class="{'single-line': currentTaskRuns.length === 1}"
@@ -719,6 +719,10 @@
         .log-lines {
             transition: max-height 0.2s ease-out;
             max-height: 50vh;
+
+            :deep(.vue-recycle-scroller__item-view > div) {
+                min-height: 2rem;
+            }
 
             &.single-line {
                 max-height: calc(100vh - 250px);


### PR DESCRIPTION
Backport of kestra-io/kestra#15943.

Cherry-picked from eb8302468aa7f1fb1dcfd520dc8cf9205aaafaa4 (cherry-pick sha: 7fae48f589dd1794fde535a2af8839eb71038b1e).

**Adaptation notes:** `@kestra-io/design-system` does not exist on v1.0.x (only `@kestra-io/ui-libs`). The `KsFilter`/`useRouteFilterPolicy` migration, `Logs.stories.tsx`, and vite.config.js blank-line removal were dropped. The portable subset was applied: `logsLoading` guard, `executionsStore.execution` watcher, `logs` reset on level change and on navigation, `:minItemSize="32"` fix, and `:deep` CSS min-height fix.