### PR TITLE
fix(core): navigate bookmarks via router-link

### DIFF
--- a/ui/src/components/layout/BookmarkLink.vue
+++ b/ui/src/components/layout/BookmarkLink.vue
@@ -11,9 +11,9 @@
             <CheckCircle @click.stop="renameBookmark" class="save" />
         </div>
         <template v-else>
-            <a
+            <router-link
                 class="bookmark-anchor"
-                :href="href"
+                :to="href"
                 :title="updatedTitle"
             >
                 <span class="bookmark-title">{{ updatedTitle }}</span>
@@ -27,7 +27,7 @@
                         :title="$t('delete')"
                     />
                 </div>
-            </a>
+            </router-link>
         </template>
     </div>
 </template>


### PR DESCRIPTION
Hey!
This PR fixes #16234  where clicking on a bookmarked item in the left menu wasn't working smoothly.
**What changed:**
I noticed that the `BookmarkLink.vue` component was using a standard HTML `<a>` tag for its links. I swapped this out for Vue Router's native `<router-link>` component (and updated the `:href` prop to `:to`).

This ensures that clicking a bookmark now correctly hooks into our client-side SPA routing, giving a much smoother transition without forcing the entire app to re-bootstrap and lose state.

Tested locally and everything routes perfectly now!