### PR TITLE
fix(executions): trigger initial linkify on log lines

### DIFF
--- a/ui/src/components/logs/LogLine.vue
+++ b/ui/src/components/logs/LogLine.vue
@@ -154,7 +154,7 @@
         nextTick(() => {
             linkify(lineContent.value, router);
         });
-    });
+    }, {immediate: true});
 </script>
 <style scoped lang="scss">
 div.line {


### PR DESCRIPTION
## Summary
- Storybook test `LogLine > With Router Link In Markdown` started failing on `releases/v1.1.x` after the #15943 backport (#16232).
- Root cause: the cherry-pick switched the watch target from a `ref` (`renderedMarkdown`) to a `computed` (`renderedHtml`). The computed never "changes" after init, so the watch never fires and `linkify()` never replaces `<router-md>` placeholders with anchor tags.
- Fix: add `{ immediate: true }` to the watch (matches the develop branch, which also has it after the original change).