### PR TITLE
fix(ui): URL-controlled KsDataTable pagination (fixes logs page drift)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,4 @@ core/src/main/resources/gradle.properties
 charts/kestra/charts/
 charts/kestra-starter/charts/
 .claude/settings.local.json
+.gstack/

--- a/ui/AGENTS.md
+++ b/ui/AGENTS.md
@@ -70,6 +70,8 @@ Reject (or ask to fix) anything that:
 - Adds a CSS class that overrides `.el-...` selectors.
 - Duplicates a component that already exists in the design system.
 - Adds a `Ks*` component without a Storybook story or test.
+- Mounts `KsDataTable` without binding `:currentPage` / `:pageSize` (or `v-model:currentPage` / `v-model:pageSize`) — pagination is controlled; see "Data tables & pagination state".
+- Watches a `computed` that returns a fresh object (spread / `{...}`) with `{deep: true}` — that fires on every dependency change regardless of content. See "The deep-watch / computed-spread trap".
 
 ### Accessibility
 
@@ -95,6 +97,83 @@ Every async surface must render all four states. "Happy path only" is a bug.
 - **Empty:** `KsEmpty` with an action where possible — never a blank screen.
 - **Error:** `KsAlert type="error"` with retry affordance, or `KsMessage` for transient errors.
 - **Success / data:** the actual content.
+
+### Data tables & pagination state
+
+`KsDataTable` is a **fully controlled component** for pagination. `props.currentPage` and `props.pageSize` are the single source of truth — the component holds no internal page mirror. The parent owns the state, binds it (URL or local ref), and the component reacts.
+
+**The contract:**
+
+- Bind `:currentPage` / `:pageSize` (one-way) OR use `v-model:currentPage` / `v-model:pageSize` (two-way).
+- Listen to `@page-changed` (or rely on `@update:currentPage`/`@update:pageSize` via v-model) and propagate the change to the bound state — typically a `router.push({...route.query, page: String(page), size: String(size)})`.
+- The component watches `[currentPage, pageSize]` and re-fires `loadData` automatically when either prop changes. Do **not** call `dataTable.reload()` from the parent in response to a page click — the prop change handles it.
+- `resetAndReload()` emits `update:currentPage(1)` and `page-changed`; if the page was already 1 it just reloads. Useful from a filter-change watcher to bounce back to page 1 + re-fetch.
+
+**URL-driven pattern** — the default for top-level list pages (Logs, Flows, Executions, KV, Secrets, Triggers, FlowsSearch, Blueprints):
+
+```vue
+<KsDataTable
+    :loadData="loadData"
+    :currentPage="urlPage"
+    :pageSize="urlSize"
+    :total="store.total"
+    @page-changed="({page, size}) => router.push({query: {...route.query, page: String(page), size: String(size)}})"
+/>
+
+<script setup>
+const urlPage = computed(() => Number(route.query.page ?? 1) || 1)
+const urlSize = computed(() => Number(route.query.size ?? 25) || 25)
+</script>
+```
+
+**Local-state pattern** — for embedded tables that should not appear in the URL (MetricsTable, side-panel views):
+
+```vue
+<KsDataTable
+    v-model:currentPage="currentPage"
+    v-model:pageSize="pageSize"
+    :loadData="loadData"
+    :total="..."
+/>
+
+<script setup>
+const currentPage = ref(1)
+const pageSize = ref(25)
+</script>
+```
+
+**Never** maintain a separate `internalPage` / `pageNumber` ref *and* bind the prop to a different value — that re-introduces the drift bug (URL says page 2, UI shows page 1) that this contract exists to prevent.
+
+### The deep-watch / computed-spread trap
+
+A `computed` that returns a fresh object (via spread or `{...}`) returns a new reference on every evaluation. Watching it with `{deep: true}` does **not** add structural equality — `deep: true` enables deep dependency tracking; the equality check at the top is still `Object.is`. The callback therefore fires on every dependency change, even when the content is unchanged.
+
+This was the root cause of the logs pagination bug: the watcher reset the page to 1 on every `route.query` mutation, including page-only updates from the user clicking the pagination itself.
+
+**Don't:**
+
+```ts
+const filterQuery = computed(() => {
+    const {page: _p, size: _s, sort: _so, ...filters} = route.query
+    return filters  // new object reference on every route.query change
+})
+watch(filterQuery, () => dataTable.value?.resetAndReload(), {deep: true})
+// Fires on every route.query change — page clicks, sort clicks, anything —
+// and bounces the user back to page 1.
+```
+
+**Do:**
+
+```ts
+const filterQueryKey = computed(() => {
+    const {page: _p, size: _s, sort: _so, ...filters} = route.query
+    return JSON.stringify(filters)  // stable string — same content, same value
+})
+watch(filterQueryKey, () => dataTable.value?.resetAndReload())
+// Fires only when filter content actually changes.
+```
+
+The general rule: **if you find yourself reaching for `{deep: true}` on a computed source, the source should probably return a primitive (string / number) instead of an object.** Strings compare by value; references compare by identity. Picking the right primitive is the fix.
 
 ### Icons
 
@@ -216,7 +295,7 @@ If your `<style>` block needs to exist:
 |-----------|---------|
 | `KsCard` | Card container |
 | `KsTable` / `KsTableColumn` | Basic table |
-| `KsDataTable` / `KsFilter` / `KsBulkSelect` | Advanced data table with filtering, sorting, pagination, bulk actions |
+| `KsDataTable` / `KsFilter` / `KsBulkSelect` | Advanced data table with filtering, sorting, pagination, bulk actions. **Pagination is fully controlled** — bind `:currentPage` / `:pageSize` (or `v-model:`). See "Data tables & pagination state". |
 | `KsBadge` | Small indicator badge |
 | `KsTag` / `KsCheckTag` | Tag / label; clickable checkbox-style tag |
 | `KsAvatar` | Avatar with fallback |

--- a/ui/AGENTS.md
+++ b/ui/AGENTS.md
@@ -121,8 +121,8 @@ Every async surface must render all four states. "Happy path only" is a bug.
 />
 
 <script setup>
-const urlPage = computed(() => Number(route.query.page ?? 1) || 1)
-const urlSize = computed(() => Number(route.query.size ?? 25) || 25)
+const urlPage = computed(() => Number(route.query.page) || 1)
+const urlSize = computed(() => Number(route.query.size) || 25)
 </script>
 ```
 

--- a/ui/packages/design-system/src/components/Data/KsDataTable/KsDataTable.vue
+++ b/ui/packages/design-system/src/components/Data/KsDataTable/KsDataTable.vue
@@ -81,10 +81,13 @@
     defineOptions({inheritAttrs: false})
 
     const DEFAULT_PAGE_SIZE = 25
-    // Upper bound for page size — a hostile URL like `?size=10000000` must not
-    // turn into a 10M-row backend request. 1000 is far above any real UI need
-    // (the largest preset option is 100) and far below a memory/latency cliff.
+    // Upper bounds for page/size. A hostile URL (`?size=10000000`, `?page=1e308`)
+    // must not become a 10M-row request or a garbage offset string sent to the
+    // backend. 1000 is far above any real page size (largest preset is 100);
+    // 1e6 pages is far beyond any real deep-link and keeps page*size a sane,
+    // finite integer rather than `1e+308`.
     const MAX_PAGE_SIZE = 1000
+    const MAX_PAGE = 1_000_000
 
     const props = withDefaults(defineProps<{
         data?: any[]
@@ -154,7 +157,8 @@
     // feeding both loadData and the paginator, so clamp here for every caller.
     const normalizePage = (value: number | undefined): number => {
         const page = Math.floor(Number(value))
-        return Number.isFinite(page) && page >= 1 ? page : 1
+        if (!Number.isFinite(page) || page < 1) return 1
+        return Math.min(page, MAX_PAGE)
     }
     const normalizeSize = (value: number | undefined): number => {
         const size = Math.floor(Number(value))

--- a/ui/packages/design-system/src/components/Data/KsDataTable/KsDataTable.vue
+++ b/ui/packages/design-system/src/components/Data/KsDataTable/KsDataTable.vue
@@ -81,11 +81,6 @@
     defineOptions({inheritAttrs: false})
 
     const DEFAULT_PAGE_SIZE = 25
-    // Upper bounds for page/size. A hostile URL (`?size=10000000`, `?page=1e308`)
-    // must not become a 10M-row request or a garbage offset string sent to the
-    // backend. 1000 is far above any real page size (largest preset is 100);
-    // 1e6 pages is far beyond any real deep-link and keeps page*size a sane,
-    // finite integer rather than `1e+308`.
     const MAX_PAGE_SIZE = 1000
     const MAX_PAGE = 1_000_000
 
@@ -146,15 +141,6 @@
     const isLoading = ref(props.loading)
     const isReady = ref(false)
 
-    // page/size are derived from props. No local mirror — `props.currentPage`
-    // and `props.pageSize` are the single source of truth, controlled by the
-    // parent (typically bound to URL). Use v-model:currentPage / v-model:pageSize
-    // to opt into two-way binding, or :currentPage="..." + @page-changed for
-    // one-way URL-driven control.
-    //
-    // Values come from the URL, so they can be hostile or malformed (negative,
-    // fractional, Infinity, absurdly large). This is the single chokepoint
-    // feeding both loadData and the paginator, so clamp here for every caller.
     const normalizePage = (value: number | undefined): number => {
         const page = Math.floor(Number(value))
         if (!Number.isFinite(page) || page < 1) return 1
@@ -292,8 +278,6 @@
 
     const resetAndReload = () => {
         if (currentPageValue.value !== 1) {
-            // Ask the parent to set page back to 1. The resulting prop change
-            // triggers callLoad through the watcher below.
             emit("update:currentPage", 1)
             emit("page-changed", {page: 1, size: currentSizeValue.value})
         } else {
@@ -334,9 +318,6 @@
 
     watch(() => props.loading, (val) => { isLoading.value = val })
 
-    // Reload whenever the controlling parent updates page/size. This is the
-    // single trigger path for pagination loads — user clicks only emit; the
-    // parent updates state (URL or local ref) which propagates back here.
     watch([currentPageValue, currentSizeValue], () => callLoad(), {flush: "post"})
 
     const onPageChange = (page: number) => {

--- a/ui/packages/design-system/src/components/Data/KsDataTable/KsDataTable.vue
+++ b/ui/packages/design-system/src/components/Data/KsDataTable/KsDataTable.vue
@@ -80,6 +80,12 @@
 
     defineOptions({inheritAttrs: false})
 
+    const DEFAULT_PAGE_SIZE = 25
+    // Upper bound for page size — a hostile URL like `?size=10000000` must not
+    // turn into a 10M-row backend request. 1000 is far above any real UI need
+    // (the largest preset option is 100) and far below a memory/latency cliff.
+    const MAX_PAGE_SIZE = 1000
+
     const props = withDefaults(defineProps<{
         data?: any[]
         total?: number
@@ -142,8 +148,21 @@
     // parent (typically bound to URL). Use v-model:currentPage / v-model:pageSize
     // to opt into two-way binding, or :currentPage="..." + @page-changed for
     // one-way URL-driven control.
-    const currentPageValue = computed(() => props.currentPage ?? 1)
-    const currentSizeValue = computed(() => props.pageSize ?? 25)
+    //
+    // Values come from the URL, so they can be hostile or malformed (negative,
+    // fractional, Infinity, absurdly large). This is the single chokepoint
+    // feeding both loadData and the paginator, so clamp here for every caller.
+    const normalizePage = (value: number | undefined): number => {
+        const page = Math.floor(Number(value))
+        return Number.isFinite(page) && page >= 1 ? page : 1
+    }
+    const normalizeSize = (value: number | undefined): number => {
+        const size = Math.floor(Number(value))
+        if (!Number.isFinite(size) || size < 1) return DEFAULT_PAGE_SIZE
+        return Math.min(size, MAX_PAGE_SIZE)
+    }
+    const currentPageValue = computed(() => normalizePage(props.currentPage))
+    const currentSizeValue = computed(() => normalizeSize(props.pageSize))
     const internalSort = ref<string>()
 
     const tableRef = ref<InstanceType<typeof KsTable>>()

--- a/ui/packages/design-system/src/components/Data/KsDataTable/KsDataTable.vue
+++ b/ui/packages/design-system/src/components/Data/KsDataTable/KsDataTable.vue
@@ -55,8 +55,8 @@
 
             <KsPagination
                 v-if="total && total > 0"
-                :currentPage="internalPage"
-                :pageSize="internalSize"
+                :currentPage="currentPageValue"
+                :pageSize="currentSizeValue"
                 :total
                 layout="sizes, prev, pager, next, total"
                 size="small"
@@ -110,6 +110,8 @@
 
     const emit = defineEmits<{
         "page-changed": [payload: {page: number; size: number}]
+        "update:currentPage": [page: number]
+        "update:pageSize": [size: number]
         "sort-change": [sort: {column: any; prop: string; order: string | null}]
         "selection-change": [selection: any[]]
         "row-dblclick": [row: any, column: any, event: Event]
@@ -135,8 +137,13 @@
     const isLoading = ref(props.loading)
     const isReady = ref(false)
 
-    const internalPage = ref(props.currentPage)
-    const internalSize = ref(props.pageSize)
+    // page/size are derived from props. No local mirror — `props.currentPage`
+    // and `props.pageSize` are the single source of truth, controlled by the
+    // parent (typically bound to URL). Use v-model:currentPage / v-model:pageSize
+    // to opt into two-way binding, or :currentPage="..." + @page-changed for
+    // one-way URL-driven control.
+    const currentPageValue = computed(() => props.currentPage ?? 1)
+    const currentSizeValue = computed(() => props.pageSize ?? 25)
     const internalSort = ref<string>()
 
     const tableRef = ref<InstanceType<typeof KsTable>>()
@@ -243,8 +250,8 @@
         isLoading.value = true
         try {
             await props.loadData({
-                page: internalPage.value,
-                size: internalSize.value,
+                page: currentPageValue.value,
+                size: currentSizeValue.value,
                 sort: internalSort.value,
             })
         } finally {
@@ -261,8 +268,14 @@
     const reload = () => callLoad()
 
     const resetAndReload = () => {
-        internalPage.value = 1
-        callLoad()
+        if (currentPageValue.value !== 1) {
+            // Ask the parent to set page back to 1. The resulting prop change
+            // triggers callLoad through the watcher below.
+            emit("update:currentPage", 1)
+            emit("page-changed", {page: 1, size: currentSizeValue.value})
+        } else {
+            callLoad()
+        }
     }
 
     onMounted(() => {
@@ -297,20 +310,21 @@
     }, {immediate: true})
 
     watch(() => props.loading, (val) => { isLoading.value = val })
-    watch(() => props.currentPage, (val) => { internalPage.value = val ?? 1 })
-    watch(() => props.pageSize, (val) => { internalSize.value = val ?? 25 })
+
+    // Reload whenever the controlling parent updates page/size. This is the
+    // single trigger path for pagination loads — user clicks only emit; the
+    // parent updates state (URL or local ref) which propagates back here.
+    watch([currentPageValue, currentSizeValue], () => callLoad(), {flush: "post"})
 
     const onPageChange = (page: number) => {
-        internalPage.value = page
-        emit("page-changed", {page, size: internalSize.value})
-        callLoad()
+        emit("update:currentPage", page)
+        emit("page-changed", {page, size: currentSizeValue.value})
     }
 
     const onSizeChange = (size: number) => {
-        internalPage.value = 1
-        internalSize.value = size
+        emit("update:currentPage", 1)
+        emit("update:pageSize", size)
         emit("page-changed", {page: 1, size})
-        callLoad()
     }
 
     const onSortChange = (sort: {column: any; prop: string; order: string | null}) => {

--- a/ui/packages/design-system/tests/units/Data/KsDataTable.test.ts
+++ b/ui/packages/design-system/tests/units/Data/KsDataTable.test.ts
@@ -195,4 +195,57 @@ describe("KsDataTable", () => {
         ;(wrapper.vm as any).isLoading = true
         expect((wrapper.vm as any).isLoading).toBe(true)
     })
+
+    test("emits update:currentPage on page change (v-model contract)", async () => {
+        const wrapper = mount(KsDataTable, {
+            props: {data: SAMPLE_DATA, total: 100, pageSize: 10, currentPage: 1},
+            global: globalConfig,
+        })
+        await (wrapper.vm as any).onPageChange(4)
+        expect(wrapper.emitted("update:currentPage")?.[0]).toEqual([4])
+    })
+
+    test("emits update:currentPage and update:pageSize on size change", async () => {
+        const wrapper = mount(KsDataTable, {
+            props: {data: SAMPLE_DATA, total: 100, pageSize: 10, currentPage: 3},
+            global: globalConfig,
+        })
+        await (wrapper.vm as any).onSizeChange(50)
+        expect(wrapper.emitted("update:currentPage")?.[0]).toEqual([1])
+        expect(wrapper.emitted("update:pageSize")?.[0]).toEqual([50])
+    })
+
+    test("loadData only fires when controlling prop changes — no internal page state", async () => {
+        let loadCallCount = 0
+        const loadDataSpy = async () => { loadCallCount++ }
+
+        const wrapper = mount(KsDataTable, {
+            props: {
+                data: SAMPLE_DATA,
+                total: 100,
+                pageSize: 10,
+                currentPage: 1,
+                loadData: loadDataSpy,
+            },
+            global: globalConfig,
+        })
+
+        await new Promise<void>((resolve) => setTimeout(resolve, 0))
+        expect(loadCallCount).toBe(1) // initial mount load
+
+        // Simulate a user click without the parent updating the prop.
+        await (wrapper.vm as any).onPageChange(3)
+        await new Promise<void>((resolve) => setTimeout(resolve, 0))
+
+        // Without the parent honoring the emit and changing the prop, no
+        // additional load fires — proves there is no internal page mirror
+        // driving callLoad.
+        expect(loadCallCount).toBe(1)
+
+        // Now have the parent honor the contract: update the prop.
+        await wrapper.setProps({currentPage: 3})
+        await new Promise<void>((resolve) => setTimeout(resolve, 0))
+
+        expect(loadCallCount).toBe(2)
+    })
 })

--- a/ui/packages/design-system/tests/units/Data/KsDataTable.test.ts
+++ b/ui/packages/design-system/tests/units/Data/KsDataTable.test.ts
@@ -231,36 +231,23 @@ describe("KsDataTable", () => {
         })
 
         await new Promise<void>((resolve) => setTimeout(resolve, 0))
-        expect(loadCallCount).toBe(1) // initial mount load
+        expect(loadCallCount).toBe(1)
 
-        // Simulate a user click without the parent updating the prop.
         await (wrapper.vm as any).onPageChange(3)
         await new Promise<void>((resolve) => setTimeout(resolve, 0))
 
-        // Without the parent honoring the emit and changing the prop, no
-        // additional load fires — proves there is no internal page mirror
-        // driving callLoad.
         expect(loadCallCount).toBe(1)
 
-        // Now have the parent honor the contract: update the prop.
         await wrapper.setProps({currentPage: 3})
         await new Promise<void>((resolve) => setTimeout(resolve, 0))
 
         expect(loadCallCount).toBe(2)
     })
 
-    // ── Hardening: garbage page/size from the URL must never reach loadData ──
-    // The parent computes currentPage/pageSize from route.query; a hostile or
-    // careless URL can carry negatives, fractions, Infinity, or absurd sizes.
-    // KsDataTable is the single chokepoint feeding both loadData and the
-    // paginator, so it clamps here for every caller at once.
-
     type Load = {page: number; size: number; sort?: string}
     const tick = () => new Promise<void>((resolve) => setTimeout(resolve, 0))
     const lastLoad = (loads: Load[]): Load => loads[loads.length - 1]
 
-    // Returns the array of loadData calls so the test can assert what reached
-    // the backend after clamping.
     const mountWithSpy = (props: Record<string, any>): Load[] => {
         const loads: Load[] = []
         mount(KsDataTable, {
@@ -290,7 +277,6 @@ describe("KsDataTable", () => {
     test("caps an absurdly large currentPage (finite offset guard)", async () => {
         const loads = mountWithSpy({currentPage: 1e308, pageSize: 25})
         await tick()
-        // Must not forward `1e+308` as a page — keep it a sane finite integer.
         expect(lastLoad(loads).page).toBeLessThanOrEqual(1_000_000)
         expect(Number.isInteger(lastLoad(loads).page)).toBe(true)
     })
@@ -312,7 +298,6 @@ describe("KsDataTable", () => {
     test("caps an absurdly large pageSize (DoS guard)", async () => {
         const loads = mountWithSpy({currentPage: 1, pageSize: 10_000_000})
         await tick()
-        // Must not forward a 10M-row request to the backend.
         expect(lastLoad(loads).size).toBeLessThanOrEqual(1000)
         expect(lastLoad(loads).size).toBeGreaterThan(0)
     })

--- a/ui/packages/design-system/tests/units/Data/KsDataTable.test.ts
+++ b/ui/packages/design-system/tests/units/Data/KsDataTable.test.ts
@@ -248,4 +248,86 @@ describe("KsDataTable", () => {
 
         expect(loadCallCount).toBe(2)
     })
+
+    // ── Hardening: garbage page/size from the URL must never reach loadData ──
+    // The parent computes currentPage/pageSize from route.query; a hostile or
+    // careless URL can carry negatives, fractions, Infinity, or absurd sizes.
+    // KsDataTable is the single chokepoint feeding both loadData and the
+    // paginator, so it clamps here for every caller at once.
+
+    type Load = {page: number; size: number; sort?: string}
+    const tick = () => new Promise<void>((resolve) => setTimeout(resolve, 0))
+    const lastLoad = (loads: Load[]): Load => loads[loads.length - 1]
+
+    // Returns the array of loadData calls so the test can assert what reached
+    // the backend after clamping.
+    const mountWithSpy = (props: Record<string, any>): Load[] => {
+        const loads: Load[] = []
+        mount(KsDataTable, {
+            props: {
+                data: SAMPLE_DATA,
+                total: 100,
+                loadData: async (p: Load) => { loads.push(p) },
+                ...props,
+            },
+            global: globalConfig,
+        })
+        return loads
+    }
+
+    test("clamps negative currentPage to 1", async () => {
+        const loads = mountWithSpy({currentPage: -5, pageSize: 25})
+        await tick()
+        expect(lastLoad(loads).page).toBe(1)
+    })
+
+    test("floors a fractional currentPage", async () => {
+        const loads = mountWithSpy({currentPage: 2.9, pageSize: 25})
+        await tick()
+        expect(lastLoad(loads).page).toBe(2)
+    })
+
+    test("falls back to page 1 for NaN / Infinity currentPage", async () => {
+        const nan = mountWithSpy({currentPage: Number.NaN, pageSize: 25})
+        const inf = mountWithSpy({currentPage: Number.POSITIVE_INFINITY, pageSize: 25})
+        await tick()
+        expect(lastLoad(nan).page).toBe(1)
+        expect(lastLoad(inf).page).toBe(1)
+    })
+
+    test("treats currentPage=0 as page 1", async () => {
+        const loads = mountWithSpy({currentPage: 0, pageSize: 25})
+        await tick()
+        expect(lastLoad(loads).page).toBe(1)
+    })
+
+    test("caps an absurdly large pageSize (DoS guard)", async () => {
+        const loads = mountWithSpy({currentPage: 1, pageSize: 10_000_000})
+        await tick()
+        // Must not forward a 10M-row request to the backend.
+        expect(lastLoad(loads).size).toBeLessThanOrEqual(1000)
+        expect(lastLoad(loads).size).toBeGreaterThan(0)
+    })
+
+    test("falls back to default size for negative / zero / NaN pageSize", async () => {
+        const neg = mountWithSpy({currentPage: 1, pageSize: -10})
+        const zero = mountWithSpy({currentPage: 1, pageSize: 0})
+        const nan = mountWithSpy({currentPage: 1, pageSize: Number.NaN})
+        await tick()
+        expect(lastLoad(neg).size).toBe(25)
+        expect(lastLoad(zero).size).toBe(25)
+        expect(lastLoad(nan).size).toBe(25)
+    })
+
+    test("floors a fractional pageSize", async () => {
+        const loads = mountWithSpy({currentPage: 1, pageSize: 49.9})
+        await tick()
+        expect(lastLoad(loads).size).toBe(49)
+    })
+
+    test("keeps a legitimate page/size pair untouched", async () => {
+        const loads = mountWithSpy({currentPage: 3, pageSize: 50})
+        await tick()
+        expect(lastLoad(loads)).toEqual({page: 3, size: 50, sort: undefined})
+    })
 })

--- a/ui/packages/design-system/tests/units/Data/KsDataTable.test.ts
+++ b/ui/packages/design-system/tests/units/Data/KsDataTable.test.ts
@@ -287,6 +287,14 @@ describe("KsDataTable", () => {
         expect(lastLoad(loads).page).toBe(2)
     })
 
+    test("caps an absurdly large currentPage (finite offset guard)", async () => {
+        const loads = mountWithSpy({currentPage: 1e308, pageSize: 25})
+        await tick()
+        // Must not forward `1e+308` as a page — keep it a sane finite integer.
+        expect(lastLoad(loads).page).toBeLessThanOrEqual(1_000_000)
+        expect(Number.isInteger(lastLoad(loads).page)).toBe(true)
+    })
+
     test("falls back to page 1 for NaN / Infinity currentPage", async () => {
         const nan = mountWithSpy({currentPage: Number.NaN, pageSize: 25})
         const inf = mountWithSpy({currentPage: Number.POSITIVE_INFINITY, pageSize: 25})

--- a/ui/packages/design-system/tests/units/Data/KsDataTable.test.ts
+++ b/ui/packages/design-system/tests/units/Data/KsDataTable.test.ts
@@ -215,6 +215,35 @@ describe("KsDataTable", () => {
         expect(wrapper.emitted("update:pageSize")?.[0]).toEqual([50])
     })
 
+    test("resetAndReload on page > 1 emits page 1 and does NOT reload directly", async () => {
+        let loadCount = 0
+        const wrapper = mount(KsDataTable, {
+            props: {data: SAMPLE_DATA, total: 100, pageSize: 25, currentPage: 3, loadData: async () => { loadCount++ }},
+            global: globalConfig,
+        })
+        await new Promise<void>((resolve) => setTimeout(resolve, 0))
+        expect(loadCount).toBe(1)
+        ;(wrapper.vm as any).resetAndReload()
+        expect(wrapper.emitted("update:currentPage")?.[0]).toEqual([1])
+        expect(wrapper.emitted("page-changed")?.[0]).toEqual([{page: 1, size: 25}])
+        await new Promise<void>((resolve) => setTimeout(resolve, 0))
+        expect(loadCount).toBe(1)
+    })
+
+    test("resetAndReload on page 1 reloads directly without emitting page", async () => {
+        let loadCount = 0
+        const wrapper = mount(KsDataTable, {
+            props: {data: SAMPLE_DATA, total: 100, pageSize: 25, currentPage: 1, loadData: async () => { loadCount++ }},
+            global: globalConfig,
+        })
+        await new Promise<void>((resolve) => setTimeout(resolve, 0))
+        expect(loadCount).toBe(1)
+        ;(wrapper.vm as any).resetAndReload()
+        await new Promise<void>((resolve) => setTimeout(resolve, 0))
+        expect(loadCount).toBe(2)
+        expect(wrapper.emitted("update:currentPage")).toBeFalsy()
+    })
+
     test("loadData only fires when controlling prop changes — no internal page state", async () => {
         let loadCallCount = 0
         const loadDataSpy = async () => { loadCallCount++ }
@@ -274,11 +303,19 @@ describe("KsDataTable", () => {
         expect(lastLoad(loads).page).toBe(2)
     })
 
-    test("caps an absurdly large currentPage (finite offset guard)", async () => {
+    test("caps an absurdly large currentPage at exactly 1_000_000 (finite offset guard)", async () => {
         const loads = mountWithSpy({currentPage: 1e308, pageSize: 25})
         await tick()
-        expect(lastLoad(loads).page).toBeLessThanOrEqual(1_000_000)
+        expect(lastLoad(loads).page).toBe(1_000_000)
         expect(Number.isInteger(lastLoad(loads).page)).toBe(true)
+    })
+
+    test("pins the currentPage cap boundary (1_000_000 stays, 1_000_001 clamps)", async () => {
+        const atCap = mountWithSpy({currentPage: 1_000_000, pageSize: 25})
+        const overCap = mountWithSpy({currentPage: 1_000_001, pageSize: 25})
+        await tick()
+        expect(lastLoad(atCap).page).toBe(1_000_000)
+        expect(lastLoad(overCap).page).toBe(1_000_000)
     })
 
     test("falls back to page 1 for NaN / Infinity currentPage", async () => {
@@ -295,11 +332,18 @@ describe("KsDataTable", () => {
         expect(lastLoad(loads).page).toBe(1)
     })
 
-    test("caps an absurdly large pageSize (DoS guard)", async () => {
+    test("caps an absurdly large pageSize at exactly 1000 (DoS guard)", async () => {
         const loads = mountWithSpy({currentPage: 1, pageSize: 10_000_000})
         await tick()
-        expect(lastLoad(loads).size).toBeLessThanOrEqual(1000)
-        expect(lastLoad(loads).size).toBeGreaterThan(0)
+        expect(lastLoad(loads).size).toBe(1000)
+    })
+
+    test("pins the pageSize cap boundary (1000 stays, 1001 clamps)", async () => {
+        const atCap = mountWithSpy({currentPage: 1, pageSize: 1000})
+        const overCap = mountWithSpy({currentPage: 1, pageSize: 1001})
+        await tick()
+        expect(lastLoad(atCap).size).toBe(1000)
+        expect(lastLoad(overCap).size).toBe(1000)
     })
 
     test("falls back to default size for negative / zero / NaN pageSize", async () => {

--- a/ui/src/components/admin/triggers/TriggersManage.vue
+++ b/ui/src/components/admin/triggers/TriggersManage.vue
@@ -5,6 +5,8 @@
             :loadData="loadData"
             :data="triggersMerged"
             :total="total"
+            :currentPage="urlPage"
+            :pageSize="urlSize"
             :defaultSort="{prop: 'flowId', order: 'ascending'}"
             :selectable="canCheck"
             :selectionMapper="selectionMapper"
@@ -470,14 +472,22 @@
         }
     }
 
-    const filterQuery = computed(() => {
+    const urlPage = computed(() => Number(route.query.page ?? 1) || 1)
+    const urlSize = computed(() => Number(route.query.size ?? 25) || 25)
+
+    // Stringify so the watcher fires on actual filter content changes only.
+    // A `computed` returning a fresh object via spread compares unequal by
+    // reference each evaluation, and `watch(..., {deep: true})` does not
+    // perform structural equality — it would fire on every route.query
+    // change, including page/size updates.
+    const filterQueryKey = computed(() => {
         const {page: _p, size: _s, sort: _so, ...filters} = route.query
-        return filters
+        return JSON.stringify(filters)
     })
 
-    watch(filterQuery, () => {
+    watch(filterQueryKey, () => {
         dataTable.value?.resetAndReload()
-    }, {deep: true})
+    })
 
     const refresh = () => dataTable.value?.reload()
 

--- a/ui/src/components/admin/triggers/TriggersManage.vue
+++ b/ui/src/components/admin/triggers/TriggersManage.vue
@@ -437,7 +437,9 @@
     const toggleAllUnselected = () => dataTable.value?.toggleAllUnselected()
 
     const loadQuery = (base: any) => {
-        const {page: _p, size: _s, sort: _so, ...restQuery} = route.query as Record<string, any>
+        // logsPage/logsSize belong to the embedded LogsWrapper in the expand
+        // rows — exclude them so they never leak into the triggers search query.
+        const {page: _p, size: _s, sort: _so, logsPage: _lp, logsSize: _ls, ...restQuery} = route.query as Record<string, any>
         const queryFilter: Record<string, any> = {...restQuery}
 
         const timeRange = queryFilter["filters[timeRange][EQUALS]"]
@@ -481,7 +483,9 @@
     // perform structural equality — it would fire on every route.query
     // change, including page/size updates.
     const filterQueryKey = computed(() => {
-        const {page: _p, size: _s, sort: _so, ...filters} = route.query
+        // Exclude the embedded LogsWrapper's logsPage/logsSize so paginating a
+        // trigger's logs doesn't reset the outer triggers table.
+        const {page: _p, size: _s, sort: _so, logsPage: _lp, logsSize: _ls, ...filters} = route.query
         return JSON.stringify(filters)
     })
 

--- a/ui/src/components/admin/triggers/TriggersManage.vue
+++ b/ui/src/components/admin/triggers/TriggersManage.vue
@@ -472,8 +472,8 @@
         }
     }
 
-    const urlPage = computed(() => Number(route.query.page ?? 1) || 1)
-    const urlSize = computed(() => Number(route.query.size ?? 25) || 25)
+    const urlPage = computed(() => Number(route.query.page) || 1)
+    const urlSize = computed(() => Number(route.query.size) || 25)
 
     const filterQueryKey = computed(() => {
         const {page: _p, size: _s, sort: _so, logsPage: _lp, logsSize: _ls, ...filters} = route.query

--- a/ui/src/components/admin/triggers/TriggersManage.vue
+++ b/ui/src/components/admin/triggers/TriggersManage.vue
@@ -437,8 +437,6 @@
     const toggleAllUnselected = () => dataTable.value?.toggleAllUnselected()
 
     const loadQuery = (base: any) => {
-        // logsPage/logsSize belong to the embedded LogsWrapper in the expand
-        // rows — exclude them so they never leak into the triggers search query.
         const {page: _p, size: _s, sort: _so, logsPage: _lp, logsSize: _ls, ...restQuery} = route.query as Record<string, any>
         const queryFilter: Record<string, any> = {...restQuery}
 
@@ -477,14 +475,7 @@
     const urlPage = computed(() => Number(route.query.page ?? 1) || 1)
     const urlSize = computed(() => Number(route.query.size ?? 25) || 25)
 
-    // Stringify so the watcher fires on actual filter content changes only.
-    // A `computed` returning a fresh object via spread compares unequal by
-    // reference each evaluation, and `watch(..., {deep: true})` does not
-    // perform structural equality — it would fire on every route.query
-    // change, including page/size updates.
     const filterQueryKey = computed(() => {
-        // Exclude the embedded LogsWrapper's logsPage/logsSize so paginating a
-        // trigger's logs doesn't reset the outer triggers table.
         const {page: _p, size: _s, sort: _so, logsPage: _lp, logsSize: _ls, ...filters} = route.query
         return JSON.stringify(filters)
     })

--- a/ui/src/components/executions/Executions.vue
+++ b/ui/src/components/executions/Executions.vue
@@ -610,11 +610,6 @@
         }
     }
 
-    // Stringify so the watcher fires on actual filter content changes only.
-    // A `computed` returning a fresh object via spread compares unequal by
-    // reference each evaluation, and `watch(..., {deep: true})` does not
-    // perform structural equality — it would fire on every route.query
-    // change, including page/size updates.
     const filterQueryKey = computed(() => {
         const {page: _p, size: _s, sort: _so, ...filters} = route.query
         return JSON.stringify(filters)

--- a/ui/src/components/executions/Executions.vue
+++ b/ui/src/components/executions/Executions.vue
@@ -615,8 +615,8 @@
         return JSON.stringify(filters)
     })
 
-    const urlPage = computed(() => Number(route.query.page ?? 1) || 1)
-    const urlSize = computed(() => Number(route.query.size ?? 25) || 25)
+    const urlPage = computed(() => Number(route.query.page) || 1)
+    const urlSize = computed(() => Number(route.query.size) || 25)
 
     watch(filterQueryKey, () => {
         if (!props.embed) {

--- a/ui/src/components/executions/Executions.vue
+++ b/ui/src/components/executions/Executions.vue
@@ -610,19 +610,24 @@
         }
     }
 
-    const filterQuery = computed(() => {
+    // Stringify so the watcher fires on actual filter content changes only.
+    // A `computed` returning a fresh object via spread compares unequal by
+    // reference each evaluation, and `watch(..., {deep: true})` does not
+    // perform structural equality — it would fire on every route.query
+    // change, including page/size updates.
+    const filterQueryKey = computed(() => {
         const {page: _p, size: _s, sort: _so, ...filters} = route.query
-        return filters
+        return JSON.stringify(filters)
     })
 
     const urlPage = computed(() => Number(route.query.page ?? 1) || 1)
     const urlSize = computed(() => Number(route.query.size ?? 25) || 25)
 
-    watch(filterQuery, () => {
+    watch(filterQueryKey, () => {
         if (!props.embed) {
             dataTable.value?.resetAndReload()
         }
-    }, {deep: true})
+    })
 
     const routeInfo = computed(() => ({title: t("executions")}))
     useRouteContext(routeInfo, props.embed)

--- a/ui/src/components/executions/MetricsTable.vue
+++ b/ui/src/components/executions/MetricsTable.vue
@@ -1,6 +1,8 @@
 <template>
     <KsDataTable
         ref="dataTable"
+        v-model:currentPage="currentPage"
+        v-model:pageSize="pageSize"
         :loadData="loadData"
         :data="metrics"
         :total="metricsTotal"
@@ -124,6 +126,8 @@
 
     const metrics = ref<any[] | undefined>(undefined)
     const metricsTotal = ref<number>(0)
+    const currentPage = ref(1)
+    const pageSize = ref(25)
 
     const dataTable = useTemplateRef("dataTable")
 

--- a/ui/src/components/flows/Flows.vue
+++ b/ui/src/components/flows/Flows.vue
@@ -427,8 +427,8 @@
         return JSON.stringify(filters)
     })
 
-    const urlPage = computed(() => Number(route.query.page ?? 1) || 1)
-    const urlSize = computed(() => Number(route.query.size ?? 25) || 25)
+    const urlPage = computed(() => Number(route.query.page) || 1)
+    const urlSize = computed(() => Number(route.query.size) || 25)
 
     watch(filterQueryKey, () => {
         dataTable.value?.resetAndReload()

--- a/ui/src/components/flows/Flows.vue
+++ b/ui/src/components/flows/Flows.vue
@@ -422,17 +422,22 @@
         params: {...item, tenant: route.params.tenant},
     })
 
-    const filterQuery = computed(() => {
+    // Stringify so the watcher fires on actual filter content changes only.
+    // A `computed` returning a fresh object via spread compares unequal by
+    // reference each evaluation, and `watch(..., {deep: true})` does not
+    // perform structural equality — it would fire on every route.query
+    // change, including page/size updates.
+    const filterQueryKey = computed(() => {
         const {page: _p, size: _s, sort: _so, ...filters} = route.query
-        return filters
+        return JSON.stringify(filters)
     })
 
     const urlPage = computed(() => Number(route.query.page ?? 1) || 1)
     const urlSize = computed(() => Number(route.query.size ?? 25) || 25)
 
-    watch(filterQuery, () => {
+    watch(filterQueryKey, () => {
         dataTable.value?.resetAndReload()
-    }, {deep: true})
+    })
 
     function selectionMapper({id, namespace, disabled}: {id: string; namespace: string; disabled: boolean}) {
         return {

--- a/ui/src/components/flows/Flows.vue
+++ b/ui/src/components/flows/Flows.vue
@@ -422,11 +422,6 @@
         params: {...item, tenant: route.params.tenant},
     })
 
-    // Stringify so the watcher fires on actual filter content changes only.
-    // A `computed` returning a fresh object via spread compares unequal by
-    // reference each evaluation, and `watch(..., {deep: true})` does not
-    // perform structural equality — it would fire on every route.query
-    // change, including page/size updates.
     const filterQueryKey = computed(() => {
         const {page: _p, size: _s, sort: _so, ...filters} = route.query
         return JSON.stringify(filters)

--- a/ui/src/components/flows/FlowsSearch.vue
+++ b/ui/src/components/flows/FlowsSearch.vue
@@ -112,8 +112,8 @@
         })
     }
 
-    const urlPage = computed(() => Number(route.query.page ?? 1) || 1)
-    const urlSize = computed(() => Number(route.query.size ?? 25) || 25)
+    const urlPage = computed(() => Number(route.query.page) || 1)
+    const urlSize = computed(() => Number(route.query.size) || 25)
 
     const filterQueryKey = computed(() => {
         const {page: _p, size: _s, sort: _so, ...filters} = route.query

--- a/ui/src/components/flows/FlowsSearch.vue
+++ b/ui/src/components/flows/FlowsSearch.vue
@@ -5,6 +5,8 @@
             <KsDataTable
                 ref="dataTable"
                 :loadData="loadData"
+                :currentPage="urlPage"
+                :pageSize="urlSize"
                 @ready="ready = true"
                 @page-changed="({page, size}: {page: number; size: number}) => router.push({query: {...route.query, page: String(page), size: String(size)}})"
                 striped
@@ -110,13 +112,21 @@
         })
     }
 
-    const filterQuery = computed(() => {
+    const urlPage = computed(() => Number(route.query.page ?? 1) || 1)
+    const urlSize = computed(() => Number(route.query.size ?? 25) || 25)
+
+    // Stringify so the watcher fires on actual filter content changes only.
+    // A `computed` returning a fresh object via spread compares unequal by
+    // reference each evaluation, and `watch(..., {deep: true})` does not
+    // perform structural equality — it would fire on every route.query
+    // change, including page/size updates.
+    const filterQueryKey = computed(() => {
         const {page: _p, size: _s, sort: _so, ...filters} = route.query
-        return filters
+        return JSON.stringify(filters)
     })
-    watch(filterQuery, () => {
+    watch(filterQueryKey, () => {
         dataTable.value?.resetAndReload()
-    }, {deep: true})
+    })
 
     function sanitize(content: string) {
         return _escape(content)

--- a/ui/src/components/flows/FlowsSearch.vue
+++ b/ui/src/components/flows/FlowsSearch.vue
@@ -115,11 +115,6 @@
     const urlPage = computed(() => Number(route.query.page ?? 1) || 1)
     const urlSize = computed(() => Number(route.query.size ?? 25) || 25)
 
-    // Stringify so the watcher fires on actual filter content changes only.
-    // A `computed` returning a fresh object via spread compares unequal by
-    // reference each evaluation, and `watch(..., {deep: true})` does not
-    // perform structural equality — it would fire on every route.query
-    // change, including page/size updates.
     const filterQueryKey = computed(() => {
         const {page: _p, size: _s, sort: _so, ...filters} = route.query
         return JSON.stringify(filters)

--- a/ui/src/components/flows/blueprints/BlueprintsBrowser.vue
+++ b/ui/src/components/flows/blueprints/BlueprintsBrowser.vue
@@ -175,8 +175,8 @@
         searchText.value = query
     }
 
-    const urlPage = computed(() => Number(route.query.page ?? 1) || 1)
-    const urlSize = computed(() => Number(route.query.size ?? 25) || 25)
+    const urlPage = computed(() => Number(route.query.page) || 1)
+    const urlSize = computed(() => Number(route.query.size) || 25)
 
     const onPageChanged = ({page, size}: {page: number; size: number}) => {
         router.push({query: {...route.query, page: String(page), size: String(size)}})

--- a/ui/src/components/flows/blueprints/BlueprintsBrowser.vue
+++ b/ui/src/components/flows/blueprints/BlueprintsBrowser.vue
@@ -8,6 +8,8 @@
                 class="blueprints"
                 :loadData="loadData"
                 :total="total"
+                :currentPage="urlPage"
+                :pageSize="urlSize"
                 divider
                 @ready="ready = true"
                 @page-changed="onPageChanged"
@@ -173,8 +175,11 @@
         searchText.value = query
     }
 
-    const onPageChanged = ({page}: {page: number; size: number}) => {
-        router.push({query: {...route.query, page}})
+    const urlPage = computed(() => Number(route.query.page ?? 1) || 1)
+    const urlSize = computed(() => Number(route.query.size ?? 25) || 25)
+
+    const onPageChanged = ({page, size}: {page: number; size: number}) => {
+        router.push({query: {...route.query, page: String(page), size: String(size)}})
     }
 
     const pluginsStore = usePluginsStore()

--- a/ui/src/components/kv/KVTable.vue
+++ b/ui/src/components/kv/KVTable.vue
@@ -346,8 +346,8 @@
         return _merge(base, filters)
     }
 
-    const urlPage = computed(() => Number(route.query.page ?? 1) || 1)
-    const urlSize = computed(() => Number(route.query.size ?? 25) || 25)
+    const urlPage = computed(() => Number(route.query.page) || 1)
+    const urlSize = computed(() => Number(route.query.size) || 25)
 
     const filterQueryKey = computed(() => {
         const {page: _p, size: _s, sort: _so, ...filters} = route.query

--- a/ui/src/components/kv/KVTable.vue
+++ b/ui/src/components/kv/KVTable.vue
@@ -349,11 +349,6 @@
     const urlPage = computed(() => Number(route.query.page ?? 1) || 1)
     const urlSize = computed(() => Number(route.query.size ?? 25) || 25)
 
-    // Stringify so the watcher fires on actual filter content changes only.
-    // A `computed` returning a fresh object via spread compares unequal by
-    // reference each evaluation, and `watch(..., {deep: true})` does not
-    // perform structural equality — it would fire on every route.query
-    // change, including page/size updates.
     const filterQueryKey = computed(() => {
         const {page: _p, size: _s, sort: _so, ...filters} = route.query
         return JSON.stringify(filters)

--- a/ui/src/components/kv/KVTable.vue
+++ b/ui/src/components/kv/KVTable.vue
@@ -4,6 +4,8 @@
         :loadData="loadData"
         :data="kvs"
         :total="total"
+        :currentPage="urlPage"
+        :pageSize="urlSize"
         :defaultSort="{prop: 'key', order: 'ascending'}"
         @page-changed="({page, size}: {page: number; size: number}) => router.push({query: {...route.query, page: String(page), size: String(size)}})"
         @sort-change="({prop, order}: {column: any; prop: string; order: string | null}) => router.push({query: {...route.query, sort: `${prop}:${order === 'ascending' ? 'asc' : 'desc'}`}})"
@@ -344,14 +346,22 @@
         return _merge(base, filters)
     }
 
-    const filterQuery = computed(() => {
+    const urlPage = computed(() => Number(route.query.page ?? 1) || 1)
+    const urlSize = computed(() => Number(route.query.size ?? 25) || 25)
+
+    // Stringify so the watcher fires on actual filter content changes only.
+    // A `computed` returning a fresh object via spread compares unequal by
+    // reference each evaluation, and `watch(..., {deep: true})` does not
+    // perform structural equality — it would fire on every route.query
+    // change, including page/size updates.
+    const filterQueryKey = computed(() => {
         const {page: _p, size: _s, sort: _so, ...filters} = route.query
-        return filters
+        return JSON.stringify(filters)
     })
 
-    watch(filterQuery, () => {
+    watch(filterQueryKey, () => {
         dataTable.value?.resetAndReload()
-    }, {deep: true})
+    })
 
     interface KvItem {
         namespace?: string;

--- a/ui/src/components/logs/LogsWrapper.vue
+++ b/ui/src/components/logs/LogsWrapper.vue
@@ -8,7 +8,7 @@
                 :currentPage="urlPage"
                 :pageSize="urlSize"
                 @ready="ready = true"
-                @page-changed="({page, size}: {page: number; size: number}) => router.push({query: {...route.query, page: String(page), size: String(size)}})"
+                @page-changed="onPageChanged"
                 :total="logsStore.total"
             >
                 <template #navbar v-if="!embed || showFilters">
@@ -203,7 +203,7 @@
     ])
 
     const loadQuery = (base: any) => {
-        const {page: _p, size: _s, sort: _so, ...routeFilters} = route.query
+        const {page: _p, size: _s, sort: _so, logsPage: _lp, logsSize: _ls, ...routeFilters} = route.query
         let queryFilter = props.filters ?? {...routeFilters}
 
         if (isFlowEdit.value) {
@@ -251,16 +251,30 @@
         syncLevelFromAppliedFilters(filters)
     }
 
-    const urlPage = computed(() => Number(route.query.page ?? 1) || 1)
-    const urlSize = computed(() => Number(route.query.size ?? 25) || 25)
+    // Embedded tables share the host route's query string with a sibling
+    // URL-bound table (e.g. LogsWrapper inside a TriggersManage expand row).
+    // Both keeping their page in the URL is the goal (shareable/restorable),
+    // but they must not collide on the same `page` key. So an embedded
+    // instance namespaces its keys to `logsPage`/`logsSize`; standalone owns
+    // the canonical `page`/`size`. The host table must exclude logsPage/logsSize
+    // from its own filter/query parsing (TriggersManage does).
+    const pageKey = props.embed ? "logsPage" : "page"
+    const sizeKey = props.embed ? "logsSize" : "size"
+    const urlPage = computed(() => Number(route.query[pageKey] ?? 1) || 1)
+    const urlSize = computed(() => Number(route.query[sizeKey] ?? 25) || 25)
+
+    const onPageChanged = ({page, size}: {page: number; size: number}) => {
+        router.push({query: {...route.query, [pageKey]: String(page), [sizeKey]: String(size)}})
+    }
 
     // Stringify so the watcher fires on actual filter content changes only.
     // A `computed` returning a fresh object via spread compares unequal by
     // reference each evaluation, and `watch(..., {deep: true})` does not
     // perform structural equality — it would fire on every route.query
-    // change, including page/size updates.
+    // change, including page/size updates. Both key sets are excluded so a
+    // sibling embedded log table paginating (writing logsPage) never resets us.
     const filterQueryKey = computed(() => {
-        const {page: _p, size: _s, sort: _so, ...filters} = route.query
+        const {page: _p, size: _s, sort: _so, logsPage: _lp, logsSize: _ls, ...filters} = route.query
         return JSON.stringify(filters)
     })
     watch(filterQueryKey, () => {

--- a/ui/src/components/logs/LogsWrapper.vue
+++ b/ui/src/components/logs/LogsWrapper.vue
@@ -253,8 +253,8 @@
 
     const pageKey = props.embed ? "logsPage" : "page"
     const sizeKey = props.embed ? "logsSize" : "size"
-    const urlPage = computed(() => Number(route.query[pageKey] ?? 1) || 1)
-    const urlSize = computed(() => Number(route.query[sizeKey] ?? 25) || 25)
+    const urlPage = computed(() => Number(route.query[pageKey]) || 1)
+    const urlSize = computed(() => Number(route.query[sizeKey]) || 25)
 
     const onPageChanged = ({page, size}: {page: number; size: number}) => {
         router.push({query: {...route.query, [pageKey]: String(page), [sizeKey]: String(size)}})

--- a/ui/src/components/logs/LogsWrapper.vue
+++ b/ui/src/components/logs/LogsWrapper.vue
@@ -251,13 +251,6 @@
         syncLevelFromAppliedFilters(filters)
     }
 
-    // Embedded tables share the host route's query string with a sibling
-    // URL-bound table (e.g. LogsWrapper inside a TriggersManage expand row).
-    // Both keeping their page in the URL is the goal (shareable/restorable),
-    // but they must not collide on the same `page` key. So an embedded
-    // instance namespaces its keys to `logsPage`/`logsSize`; standalone owns
-    // the canonical `page`/`size`. The host table must exclude logsPage/logsSize
-    // from its own filter/query parsing (TriggersManage does).
     const pageKey = props.embed ? "logsPage" : "page"
     const sizeKey = props.embed ? "logsSize" : "size"
     const urlPage = computed(() => Number(route.query[pageKey] ?? 1) || 1)
@@ -267,12 +260,6 @@
         router.push({query: {...route.query, [pageKey]: String(page), [sizeKey]: String(size)}})
     }
 
-    // Stringify so the watcher fires on actual filter content changes only.
-    // A `computed` returning a fresh object via spread compares unequal by
-    // reference each evaluation, and `watch(..., {deep: true})` does not
-    // perform structural equality — it would fire on every route.query
-    // change, including page/size updates. Both key sets are excluded so a
-    // sibling embedded log table paginating (writing logsPage) never resets us.
     const filterQueryKey = computed(() => {
         const {page: _p, size: _s, sort: _so, logsPage: _lp, logsSize: _ls, ...filters} = route.query
         return JSON.stringify(filters)

--- a/ui/src/components/logs/LogsWrapper.vue
+++ b/ui/src/components/logs/LogsWrapper.vue
@@ -5,6 +5,8 @@
             <KsDataTable
                 ref="dataTable"
                 :loadData="loadData"
+                :currentPage="urlPage"
+                :pageSize="urlSize"
                 @ready="ready = true"
                 @page-changed="({page, size}: {page: number; size: number}) => router.push({query: {...route.query, page: String(page), size: String(size)}})"
                 :total="logsStore.total"
@@ -249,13 +251,21 @@
         syncLevelFromAppliedFilters(filters)
     }
 
-    const filterQuery = computed(() => {
+    const urlPage = computed(() => Number(route.query.page ?? 1) || 1)
+    const urlSize = computed(() => Number(route.query.size ?? 25) || 25)
+
+    // Stringify so the watcher fires on actual filter content changes only.
+    // A `computed` returning a fresh object via spread compares unequal by
+    // reference each evaluation, and `watch(..., {deep: true})` does not
+    // perform structural equality — it would fire on every route.query
+    // change, including page/size updates.
+    const filterQueryKey = computed(() => {
         const {page: _p, size: _s, sort: _so, ...filters} = route.query
-        return filters
+        return JSON.stringify(filters)
     })
-    watch(filterQuery, () => {
+    watch(filterQueryKey, () => {
         dataTable.value?.resetAndReload()
-    }, {deep: true})
+    })
 
     const showStatChart = () => showChart.value
 

--- a/ui/src/components/secrets/SecretsTable.vue
+++ b/ui/src/components/secrets/SecretsTable.vue
@@ -5,6 +5,8 @@
             :loadData="loadData"
             :data="secrets"
             :total="total"
+            :currentPage="urlPage"
+            :pageSize="urlSize"
             :defaultSort="{prop: 'key', order: 'ascending'}"
             :selectable="false"
             @page-changed="({page, size}: {page: number; size: number}) => router.push({query: {...route.query, page: String(page), size: String(size)}})"
@@ -490,14 +492,22 @@
         total.value = secretsResponse.total ?? 0
     }
 
-    const filterQuery = computed(() => {
+    const urlPage = computed(() => Number(route.query.page ?? 1) || 1)
+    const urlSize = computed(() => Number(route.query.size ?? 25) || 25)
+
+    // Stringify so the watcher fires on actual filter content changes only.
+    // A `computed` returning a fresh object via spread compares unequal by
+    // reference each evaluation, and `watch(..., {deep: true})` does not
+    // perform structural equality — it would fire on every route.query
+    // change, including page/size updates.
+    const filterQueryKey = computed(() => {
         const {page: _p, size: _s, sort: _so, ...filters} = route.query
-        return filters
+        return JSON.stringify(filters)
     })
 
-    watch(filterQuery, () => {
+    watch(filterQueryKey, () => {
         dataTable.value?.resetAndReload()
-    }, {deep: true})
+    })
 
     const updateSecretModal = (secretData: NamespaceSecret) => {
         secret.value.namespace = secretData?.namespace

--- a/ui/src/components/secrets/SecretsTable.vue
+++ b/ui/src/components/secrets/SecretsTable.vue
@@ -492,8 +492,8 @@
         total.value = secretsResponse.total ?? 0
     }
 
-    const urlPage = computed(() => Number(route.query.page ?? 1) || 1)
-    const urlSize = computed(() => Number(route.query.size ?? 25) || 25)
+    const urlPage = computed(() => Number(route.query.page) || 1)
+    const urlSize = computed(() => Number(route.query.size) || 25)
 
     const filterQueryKey = computed(() => {
         const {page: _p, size: _s, sort: _so, ...filters} = route.query

--- a/ui/src/components/secrets/SecretsTable.vue
+++ b/ui/src/components/secrets/SecretsTable.vue
@@ -495,11 +495,6 @@
     const urlPage = computed(() => Number(route.query.page ?? 1) || 1)
     const urlSize = computed(() => Number(route.query.size ?? 25) || 25)
 
-    // Stringify so the watcher fires on actual filter content changes only.
-    // A `computed` returning a fresh object via spread compares unequal by
-    // reference each evaluation, and `watch(..., {deep: true})` does not
-    // perform structural equality — it would fire on every route.query
-    // change, including page/size updates.
     const filterQueryKey = computed(() => {
         const {page: _p, size: _s, sort: _so, ...filters} = route.query
         return JSON.stringify(filters)

--- a/ui/tests/unit/components/logs/logsWrapperPaginationWiring.spec.ts
+++ b/ui/tests/unit/components/logs/logsWrapperPaginationWiring.spec.ts
@@ -24,8 +24,8 @@ function makeHarness(initialQuery: Record<string, string> = {}) {
                 loadCalls.push({page, size})
             }
 
-            const urlPage = computed(() => Number(routeQuery.page ?? 1) || 1)
-            const urlSize = computed(() => Number(routeQuery.size ?? 25) || 25)
+            const urlPage = computed(() => Number(routeQuery.page) || 1)
+            const urlSize = computed(() => Number(routeQuery.size) || 25)
 
             const filterQueryKey = computed(() => {
                 const {page: _p, size: _s, sort: _so, ...filters} = routeQuery

--- a/ui/tests/unit/components/logs/logsWrapperPaginationWiring.spec.ts
+++ b/ui/tests/unit/components/logs/logsWrapperPaginationWiring.spec.ts
@@ -117,7 +117,6 @@ describe("LogsWrapper-style pagination wiring", () => {
         await flushPromises()
         loadCalls.length = 0
 
-        delete routeQuery.page
         routeQuery["filters[level][EQUALS]"] = "DEBUG"
         await flushPromises()
 

--- a/ui/tests/unit/components/logs/logsWrapperPaginationWiring.spec.ts
+++ b/ui/tests/unit/components/logs/logsWrapperPaginationWiring.spec.ts
@@ -38,6 +38,7 @@ function makeHarness(initialQuery: Record<string, string> = {}) {
         components: {KsDataTable},
         setup() {
             const dataTable = ref<any>(null)
+            const setDataTable = (el: any) => { dataTable.value = el }
 
             const loadData = async ({page, size}: {page: number; size: number}) => {
                 loadCalls.push({page, size})
@@ -60,11 +61,11 @@ function makeHarness(initialQuery: Record<string, string> = {}) {
                 routeQuery.size = String(size)
             }
 
-            return {dataTable, loadData, urlPage, urlSize, onPageChanged}
+            return {setDataTable, loadData, urlPage, urlSize, onPageChanged}
         },
         template: `
             <KsDataTable
-                ref="dataTable"
+                :ref="setDataTable"
                 :loadData="loadData"
                 :currentPage="urlPage"
                 :pageSize="urlSize"
@@ -125,5 +126,30 @@ describe("LogsWrapper-style pagination wiring", () => {
         await flushPromises()
 
         expect(filterResets.count).toBe(baseline + 1)
+    })
+
+    test("filter change while on page > 1 ends on page 1 with a fresh fetch", async () => {
+        const {Harness, routeQuery, loadCalls} = makeHarness({
+            page: "3",
+            size: "25",
+            "filters[level][EQUALS]": "INFO",
+        })
+
+        mount(Harness, {global: globalConfig})
+        await flushPromises()
+        loadCalls.length = 0
+
+        // Change a filter the way useFilters.updateRoute(true) does: it drops
+        // `page` from the URL (back to 1) AND changes filter content in the
+        // same navigation.
+        delete routeQuery.page
+        routeQuery["filters[level][EQUALS]"] = "DEBUG"
+        await flushPromises()
+
+        // The fetch that hits the backend is page 1 with the new filter — never
+        // a stale page-3 request left over from before the filter changed.
+        expect(loadCalls.length).toBeGreaterThan(0)
+        expect(loadCalls.every((c) => c.page === 1)).toBe(true)
+        expect(loadCalls[loadCalls.length - 1]).toEqual({page: 1, size: 25})
     })
 })

--- a/ui/tests/unit/components/logs/logsWrapperPaginationWiring.spec.ts
+++ b/ui/tests/unit/components/logs/logsWrapperPaginationWiring.spec.ts
@@ -1,0 +1,129 @@
+/**
+ * Regression test for the logs pagination wiring bug.
+ *
+ * Bug: navigating to /logs?page=2 rendered page 1 because LogsWrapper did
+ * not bind `currentPage` to the URL, and the `filterQuery` watcher fired on
+ * every route.query change (including page-only updates) and called
+ * `resetAndReload()`, which forced internalPage back to 1.
+ *
+ * This test exercises the same wiring pattern in isolation (without the
+ * heavy LogsWrapper deps) and verifies that:
+ *   1. KsDataTable.internalPage tracks the URL page on mount.
+ *   2. The filter-change watcher does NOT fire when only `page`/`size`
+ *      change in the URL.
+ *   3. A real filter change still triggers exactly one reset.
+ */
+
+import {describe, test, expect} from "vitest"
+import {defineComponent, computed, watch, reactive, ref} from "vue"
+import {mount, flushPromises} from "@vue/test-utils"
+import {createI18n} from "vue-i18n"
+import KestraDesignSystem from "@kestra-io/design-system"
+import KsDataTable from "@kestra-io/design-system/components/Data/KsDataTable/KsDataTable.vue"
+
+const globalConfig = {
+    plugins: [createI18n({legacy: false, locale: "en"}), KestraDesignSystem],
+}
+
+// Minimal harness that mirrors the LogsWrapper wiring (after the fix):
+//   - urlPage/urlSize bound to a reactive route.query mock
+//   - filterQueryKey watcher (stringified) that triggers resetAndReload
+//   - @page-changed handler that mutates route.query (simulates router.push)
+function makeHarness(initialQuery: Record<string, string> = {}) {
+    const routeQuery = reactive<Record<string, string>>({...initialQuery})
+    const filterResets = {count: 0}
+    const loadCalls: Array<{page: number; size: number}> = []
+
+    const Harness = defineComponent({
+        components: {KsDataTable},
+        setup() {
+            const dataTable = ref<any>(null)
+
+            const loadData = async ({page, size}: {page: number; size: number}) => {
+                loadCalls.push({page, size})
+            }
+
+            const urlPage = computed(() => Number(routeQuery.page ?? 1) || 1)
+            const urlSize = computed(() => Number(routeQuery.size ?? 25) || 25)
+
+            const filterQueryKey = computed(() => {
+                const {page: _p, size: _s, sort: _so, ...filters} = routeQuery
+                return JSON.stringify(filters)
+            })
+            watch(filterQueryKey, () => {
+                filterResets.count += 1
+                dataTable.value?.resetAndReload()
+            })
+
+            const onPageChanged = ({page, size}: {page: number; size: number}) => {
+                routeQuery.page = String(page)
+                routeQuery.size = String(size)
+            }
+
+            return {dataTable, loadData, urlPage, urlSize, onPageChanged}
+        },
+        template: `
+            <KsDataTable
+                ref="dataTable"
+                :loadData="loadData"
+                :currentPage="urlPage"
+                :pageSize="urlSize"
+                :total="100"
+                @page-changed="onPageChanged"
+            />
+        `,
+    })
+
+    return {Harness, routeQuery, filterResets, loadCalls}
+}
+
+describe("LogsWrapper-style pagination wiring", () => {
+    test("mount with URL page=2 → loadData receives page 2 (not 1)", async () => {
+        const {Harness, loadCalls} = makeHarness({
+            page: "2",
+            size: "25",
+            "filters[level][EQUALS]": "INFO",
+        })
+
+        mount(Harness, {global: globalConfig})
+        await flushPromises()
+
+        expect(loadCalls.length).toBeGreaterThan(0)
+        expect(loadCalls[0]).toEqual({page: 2, size: 25})
+    })
+
+    test("page-only URL change does NOT trigger the filter-change reset", async () => {
+        const {Harness, routeQuery, filterResets} = makeHarness({
+            page: "1",
+            size: "25",
+            "filters[level][EQUALS]": "INFO",
+        })
+
+        mount(Harness, {global: globalConfig})
+        await flushPromises()
+        const baseline = filterResets.count
+
+        // Simulate the router.push that LogsWrapper does in @page-changed:
+        // only page and size move, filters untouched.
+        routeQuery.page = "5"
+        routeQuery.size = "25"
+        await flushPromises()
+
+        expect(filterResets.count).toBe(baseline)
+    })
+
+    test("real filter change still triggers exactly one reset", async () => {
+        const {Harness, routeQuery, filterResets} = makeHarness({
+            "filters[level][EQUALS]": "INFO",
+        })
+
+        mount(Harness, {global: globalConfig})
+        await flushPromises()
+        const baseline = filterResets.count
+
+        routeQuery["filters[level][EQUALS]"] = "DEBUG"
+        await flushPromises()
+
+        expect(filterResets.count).toBe(baseline + 1)
+    })
+})

--- a/ui/tests/unit/components/logs/logsWrapperPaginationWiring.spec.ts
+++ b/ui/tests/unit/components/logs/logsWrapperPaginationWiring.spec.ts
@@ -1,19 +1,3 @@
-/**
- * Regression test for the logs pagination wiring bug.
- *
- * Bug: navigating to /logs?page=2 rendered page 1 because LogsWrapper did
- * not bind `currentPage` to the URL, and the `filterQuery` watcher fired on
- * every route.query change (including page-only updates) and called
- * `resetAndReload()`, which forced internalPage back to 1.
- *
- * This test exercises the same wiring pattern in isolation (without the
- * heavy LogsWrapper deps) and verifies that:
- *   1. KsDataTable.internalPage tracks the URL page on mount.
- *   2. The filter-change watcher does NOT fire when only `page`/`size`
- *      change in the URL.
- *   3. A real filter change still triggers exactly one reset.
- */
-
 import {describe, test, expect} from "vitest"
 import {defineComponent, computed, watch, reactive, ref} from "vue"
 import {mount, flushPromises} from "@vue/test-utils"
@@ -25,10 +9,6 @@ const globalConfig = {
     plugins: [createI18n({legacy: false, locale: "en"}), KestraDesignSystem],
 }
 
-// Minimal harness that mirrors the LogsWrapper wiring (after the fix):
-//   - urlPage/urlSize bound to a reactive route.query mock
-//   - filterQueryKey watcher (stringified) that triggers resetAndReload
-//   - @page-changed handler that mutates route.query (simulates router.push)
 function makeHarness(initialQuery: Record<string, string> = {}) {
     const routeQuery = reactive<Record<string, string>>({...initialQuery})
     const filterResets = {count: 0}
@@ -104,8 +84,6 @@ describe("LogsWrapper-style pagination wiring", () => {
         await flushPromises()
         const baseline = filterResets.count
 
-        // Simulate the router.push that LogsWrapper does in @page-changed:
-        // only page and size move, filters untouched.
         routeQuery.page = "5"
         routeQuery.size = "25"
         await flushPromises()
@@ -139,15 +117,10 @@ describe("LogsWrapper-style pagination wiring", () => {
         await flushPromises()
         loadCalls.length = 0
 
-        // Change a filter the way useFilters.updateRoute(true) does: it drops
-        // `page` from the URL (back to 1) AND changes filter content in the
-        // same navigation.
         delete routeQuery.page
         routeQuery["filters[level][EQUALS]"] = "DEBUG"
         await flushPromises()
 
-        // The fetch that hits the backend is page 1 with the new filter — never
-        // a stale page-3 request left over from before the filter changed.
         expect(loadCalls.length).toBeGreaterThan(0)
         expect(loadCalls.every((c) => c.page === 1)).toBe(true)
         expect(loadCalls[loadCalls.length - 1]).toEqual({page: 1, size: 25})


### PR DESCRIPTION
## Summary
Fixes a logs pagination bug (URL says `page=2` but the UI renders page 1 and the backend gets `page=1`) and hardens the shared data table behind it.

- **`KsDataTable` is now fully controlled.** Removed the internal `internalPage`/`internalSize` mirror; `props.currentPage`/`props.pageSize` are the single source of truth (URL-bound in callers). The component emits `update:currentPage`/`update:pageSize` (v-model) and reloads via one watcher. This kills the URL↔component drift that caused the bug.
- **Stringified filter watcher.** Callers watched a `computed` that spreads `route.query` into a fresh object with `{deep:true}` — which fires on *every* route change (Vue compares by reference; `deep` doesn't add structural equality). It reset the page to 1 on every pagination click. Replaced with a `JSON.stringify`'d `filterQueryKey` so it only fires on real filter changes.
- **Hostile-input clamping.** `?size=10000000` could become a 10M-row request and `?page=1e308` a garbage offset. `KsDataTable` clamps page/size at the single chokepoint (page ≥ 1 integer ≤ 1e6, size ∈ [1, 1000]) so every caller is protected.
- **Embedded-table URL namespacing.** An embedded `LogsWrapper` (e.g. a `TriggersManage` expand row) shared the outer table's `page` key — paginating the logs moved the triggers table. Embedded instances now use `logsPage`/`logsSize`; both tables keep their page in the URL, no collision.
- Applied the controlled pattern across all 9 data-table callers (Logs, Flows, Executions, KV, Secrets, Triggers, FlowsSearch, Blueprints; MetricsTable via v-model).

## Design decisions (rationale for the bits that look arbitrary in the diff)
The code carries no explanatory comments, so here is the reasoning behind the choices a reviewer is most likely to question.

### Why pagination state lives in the URL
`page` and `size` are kept in the URL (not in component-local state) on purpose: **the URL is the application's addressable state.** Putting pagination there makes a view *shareable, deep-linkable, refresh-safe, and correct under browser back/forward* — the information-architecture principle that tools like Linear follow, and an important UX rule. This is also *why* the whole design is shaped the way it is:
- `KsDataTable` is **controlled** (the URL is the single source of truth) rather than holding its own page mirror — so the address bar and the rendered page can never disagree (the original bug).
- Embedded tables **namespace** their keys (`logsPage`/`logsSize`) instead of dropping page from the URL — so even a secondary table on the same route stays addressable.
- The one exception is a table that genuinely *shouldn't* be in the URL (a side-panel `MetricsTable`); it satisfies the same controlled contract with local `v-model` state instead.

### The two hard caps in `KsDataTable`
```ts
const DEFAULT_PAGE_SIZE = 25
const MAX_PAGE_SIZE = 1000
const MAX_PAGE = 1_000_000
```
These are deliberate magic numbers, not placeholders:

- **`MAX_PAGE_SIZE = 1000`** — `page`/`size` come straight from the URL, which is user-controlled. Nothing stops someone from typing `?size=10000000`; without a cap that flows through `loadData` into a 10M-row backend request (a trivial DoS / OOM). 1000 is chosen to sit comfortably **above** any legitimate page size — the largest size preset in the UI is 100 — while staying **far below** the row count where serialization/render cost falls off a cliff. So real users never hit it; only abusive values get clamped.
- **`MAX_PAGE = 1_000_000`** — the backend offset is `page * size`. With an unbounded page, `?page=1e308` (a valid JS number) makes that product `Infinity`/`1e+308`, which serializes into the query string as the literal garbage `"1e+308"` instead of an integer offset. Capping page at 1e6 keeps `page * size` a finite, sane integer. 1e6 is orders of magnitude beyond any real deep-link (a million pages of 25 = 25M rows), so it constrains nothing legitimate.

Both are clamped (not rejected) at one chokepoint — the `normalizePage`/`normalizeSize` computeds inside `KsDataTable` — rather than in each of the 9 callers, so every current and future caller is protected by construction and there is exactly one place to audit. Garbage in → nearest sane value out, and the request still returns 200 rather than a 422.

### Why `filterQueryKey` is a `JSON.stringify`, not the object
Watching `computed(() => ({...filters}))` looks like it should fire only on filter changes, but it fires on *every* `route.query` mutation — including page clicks — because Vue's watcher compares the source by reference (`Object.is`) and the spread produces a new object each time; `{deep:true}` adds deep traversal, not structural equality. Returning a `JSON.stringify` of the filters gives a primitive string that compares by value, so the "reset to page 1 + refetch" only runs when the filters actually change. This is the specific trap that caused the original drift.

### Why embedded tables use `logsPage`/`logsSize`
Two tables on one route can't both own the `page` URL key — whoever writes last wins, and paginating one silently moves the other. Rather than drop the embedded table's page out of the URL (which would break deep-linking/refresh — see "Why pagination state lives in the URL"), the embedded `LogsWrapper` namespaces its keys. Both tables stay URL-addressable with no collision.

## Test Coverage
- New `KsDataTable` contract tests (no internal page state, v-model emits) + 9 clamp tests (negative / fractional / NaN / Infinity / 0 page, size DoS cap, page cap, legitimate pair untouched).
- New `logsWrapperPaginationWiring.spec.ts` harness covering the URL→API→reset wiring.
- **659/659 unit tests pass.** lint clean.

## Pre-Landing Review
Ran `/review` + an independent adversarial subagent. Findings:
- **[FIXED] Uncapped page** → `?page=1e308` reached the backend. Capped at `MAX_PAGE=1e6`.
- **[FIXED] Embedded/outer table page-key collision** in TriggersManage → namespaced to `logsPage`/`logsSize`.
- **[CLEARED] Double-fetch on filter change** — hypothesized, verified it does NOT happen (single fetch).
- **[DEFERRED]** Pre-existing stale-response race in `callLoad` (rapid clicks) — not a regression of this branch, spun out to a follow-up.

## Verification
Verified live in the browser (authed): URL `page`/`size` propagate to the API exactly, clamping neutralizes hostile values (200 instead of 422/10M-row), and the embedded `logsPage` does not leak into the triggers search. Not verifiable in the dev instance: the embedded log table reading `logsPage` (no log data on dev triggers).

## Notes
- Doc added to `ui/AGENTS.md`: the controlled-pagination contract and the deep-watch/computed-spread trap.
- No version bump / CHANGELOG (Kestra uses centralized Gradle versioning, no per-PR VERSION file).

## Test plan
- [x] `vitest --project=unit` — 659 passed
- [x] lint clean on changed files
- [x] live browser verification of URL↔API↔UI sync + clamping

🤖 Generated with [Claude Code](https://claude.com/claude-code)