### PR TITLE
fix(core): drop broken DS imports to fix broken ee build

### DIFF
--- a/ui/src/components/logs/TaskRunDetails.vue
+++ b/ui/src/components/logs/TaskRunDetails.vue
@@ -256,8 +256,6 @@
     import * as LogUtils from "../../utils/logs"
     import throttle from "lodash/throttle"
     import {useClient} from "@kestra-io/kestra-sdk"
-    import KsProgress from "@kestra-io/design-system/components/Data/KsProgress.vue"
-    import KsLink from "@kestra-io/design-system/components/Basic/KsLink.vue"
 
     export default {
         name: "TaskRunDetails",


### PR DESCRIPTION
```

> Task :ui-ee:assembleFrontend
✓ 8925 modules transformed.
✗ Build failed in 15.18s
error during build:
Build failed with 2 errors:

[UNLOADABLE_DEPENDENCY] Error: Could not load ../../kestra/ui/packages/design-system/components/Data/KsProgress.vue
    ╭─[ ../../kestra/ui/src/components/logs/TaskRunDetails.vue:31:28 ]
    │
 31 │     import KsProgress from "@kestra-io/design-system/components/Data/KsProgress.vue"
    │                            ────────────────────────────┬────────────────────────────  
    │                                                        ╰────────────────────────────── No such file or directory (os error 2)
────╯

[UNLOADABLE_DEPENDENCY] Error: Could not load ../../kestra/ui/packages/design-system/components/Basic/KsLink.vue
    ╭─[ ../../kestra/ui/src/components/logs/TaskRunDetails.vue:32:24 ]
    │
 32 │     import KsLink from "@kestra-io/design-system/components/Basic/KsLink.vue"
    │                        ───────────────────────────┬──────────────────────────  
    │                                                   ╰──────────────────────────── No such file or directory (os error 2)
────╯

    at aggregateBindingErrorsIntoJsError (file:///Users/rb/kestras/kestra-ee/ui-ee/node_modules/rolldown/dist/shared/error-BrnLyQ-g.mjs:48:18)
    at unwrapBindingResult (file:///Users/rb/kestras/kestra-ee/ui-ee/node_modules/rolldown/dist/shared/error-BrnLyQ-g.mjs:18:128)
    at #build (file:///Users/rb/kestras/kestra-ee/ui-ee/node_modules/rolldown/dist/shared/rolldown-build-D_ShytiL.mjs:3257:34)
    at async buildEnvironment (file:///Users/rb/kestras/kestra-ee/ui-ee/node_modules/vite/dist/node/chunks/node.js:33018:64)
    at async Object.build (file:///Users/rb/kestras/kestra-ee/ui-ee/node_modules/vite/dist/node/chunks/node.js:33440:19)
    at async Object.buildApp (file:///Users/rb/kestras/kestra-ee/ui-ee/node_modules/vite/dist/node/chunks/node.js:33437:153)
    at async CAC.<anonymous> (file:///Users/rb/kestras/kestra-ee/ui-ee/node_modules/vite/dist/node/cli.js:778:3) {
  errors: [Getter/Setter]
}

> Task :ui-ee:assembleFrontend FAILED

[Incubating] Problems report is available at: file:///Users/rb/kestras/kestra-ee/build/reports/problems/problems-report.html

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':ui-ee:assembleFrontend'.
> Process 'command '/Users/rb/kestras/kestra-ee/ui-ee/.gradle/nodejs/node-v22.18.0-darwin-arm64/bin/npm'' finished with non-zero exit value 1

* Try:
```