### PR TITLE
fix: add bottom padding to News section

### DIFF
--- a/ui/src/components/layout/ContextNews.vue
+++ b/ui/src/components/layout/ContextNews.vue
@@ -6,7 +6,10 @@
         </header>
         <a
             class="post"
-            :class="{lastPost: index === 0}"
+            :class="{
+                topPost: index === 0,
+                bottomPost: index === feeds.length - 1
+            }"
             v-for="(feed, index) in feeds"
             :key="feed.id"
             :href="feed.href ?? feed.link"
@@ -120,7 +123,7 @@
         }
     }
 
-    .lastPost {
+    .topPost {
         flex-direction: column;
         gap: 0.5rem;
 
@@ -130,6 +133,10 @@
             border: none;
             border-radius: var(--kel-border-radius-round);
         }
+    }
+
+    .bottomPost {
+        margin-bottom: 2rem;
     }
 
     .openInNewIcon {
@@ -145,8 +152,5 @@
         font-size: 9px;
         font-weight: 400;
         color: var(--ks-text-secondary);
-    }
-    :deep(.content) {
-        padding-bottom: 1rem;
     }
 </style>

--- a/ui/src/components/layout/ContextNews.vue
+++ b/ui/src/components/layout/ContextNews.vue
@@ -146,4 +146,7 @@
         font-weight: 400;
         color: var(--ks-text-secondary);
     }
+    :deep(.content) {
+        padding-bottom: 1rem;
+    }
 </style>


### PR DESCRIPTION
### ✨ Description
Added bottom padding to the News section to match the existing top padding, improving visual consistency.

### 🔗 Related Issue
Closes https://github.com/kestra-io/kestra/issues/16249

### 🎨 Frontend Checklist
- [ ] Code builds without errors (`npm run build`)
- [ ] All existing E2E tests pass (`npm run test:e2e`)
- [x] Screenshots or video recordings attached showing the `UI` changes

### 📝 Additional Notes
Added `:deep(.content) { padding-bottom: 1rem; }` in `ContextNews.vue` to match the top padding of the News section.
<img width="895" height="264" alt="Screenshot 2026-05-27 132250" src="https://github.com/user-attachments/assets/bd585df6-eb1f-4bf2-b414-a0d16e520d8b" />
