### PR TITLE
build(ci): use GITHUB_READ_ORG_TOKEN for welcome workflow

### DIFF
--- a/.github/workflows/welcome.yml
+++ b/.github/workflows/welcome.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - uses: plbstl/first-contribution@v4
         env:
-          GH_PAT_READ_ORG: ${{ secrets.GITHUB_TOKEN }}
+          GH_PAT_READ_ORG: ${{ secrets.GITHUB_READ_ORG_TOKEN }}
         with:
           skip-internal-contributors: true
           pr-opened-msg: |


### PR DESCRIPTION
## Summary
- Replace `GITHUB_TOKEN` with `GITHUB_READ_ORG_TOKEN` as the value for `GH_PAT_READ_ORG` in the welcome workflow
- `GITHUB_TOKEN` lacks org-level read permissions needed to check if a contributor is an internal org member; the dedicated `GITHUB_READ_ORG_TOKEN` secret has the required scope