### PR TITLE
fix(tasks): honor explicit taskRunner over deprecated runner PluginDefault

### DIFF
--- a/script/src/main/java/io/kestra/plugin/scripts/exec/AbstractExecScript.java
+++ b/script/src/main/java/io/kestra/plugin/scripts/exec/AbstractExecScript.java
@@ -45,15 +45,12 @@ public abstract class AbstractExecScript extends Task implements NamespaceFilesI
 
     @Schema(
         title = "The task runner to use.",
-        description = "Task runners are provided by plugins, each have their own properties."
+        description = "Task runners are provided by plugins, each have their own properties.",
+        defaultValue = "{type: io.kestra.plugin.scripts.runner.docker.Docker, pullPolicy: IF_NOT_PRESENT}"
     )
     @PluginProperty
-    @Builder.Default
     @Valid
-    protected TaskRunner<?> taskRunner = Docker.builder()
-        .type(Docker.class.getName())
-        .pullPolicy(Property.ofValue(PullPolicy.IF_NOT_PRESENT))
-        .build();
+    protected TaskRunner<?> taskRunner;
 
     @Schema(
         title = "A list of commands that will run before the `commands`, allowing to set up the environment e.g. `pip install -r requirements.txt`."
@@ -161,8 +158,16 @@ public abstract class AbstractExecScript extends Task implements NamespaceFilesI
     }
 
     protected CommandsWrapper commands(RunContext runContext) throws IllegalVariableEvaluationException {
-        if (this.getRunner() == null) {
-            runContext.logger().debug("Using task runner '{}'", this.getTaskRunner().getType());
+        TaskRunner<?> effectiveTaskRunner = this.getTaskRunner();
+        if (effectiveTaskRunner == null && this.getRunner() == null) {
+            // No taskRunner and no legacy runner set: fall back to the historical default Docker runner.
+            effectiveTaskRunner = Docker.builder()
+                .type(Docker.class.getName())
+                .pullPolicy(Property.ofValue(PullPolicy.IF_NOT_PRESENT))
+                .build();
+        }
+        if (effectiveTaskRunner != null && this.getRunner() == null) {
+            runContext.logger().debug("Using task runner '{}'", effectiveTaskRunner.getType());
         }
 
         Map<String, String> renderedEnv = runContext.render(this.getEnv()).asMap(String.class, String.class);
@@ -170,7 +175,7 @@ public abstract class AbstractExecScript extends Task implements NamespaceFilesI
             .withEnv(renderedEnv.isEmpty() ? new HashMap<>() : renderedEnv)
             .withRunnerType(this.getRunner())
             .withContainerImage(runContext.render(this.getContainerImage()).as(String.class).orElse(null))
-            .withTaskRunner(this.getTaskRunner())
+            .withTaskRunner(effectiveTaskRunner)
             .withDockerOptions(this.getDocker() != null ? this.injectDefaults(runContext, this.getDocker()) : null)
             .withNamespaceFiles(this.getNamespaceFiles())
             .withInputFiles(this.getInputFiles())

--- a/script/src/main/java/io/kestra/plugin/scripts/exec/scripts/runners/CommandsWrapper.java
+++ b/script/src/main/java/io/kestra/plugin/scripts/exec/scripts/runners/CommandsWrapper.java
@@ -231,6 +231,16 @@ public class CommandsWrapper implements TaskCommands {
 
     @SuppressWarnings("unchecked")
     public <T extends TaskRunnerDetailResult> TaskRunner<T> getTaskRunner() {
+        // User-explicit taskRunner takes precedence over the deprecated runnerType (fixes PluginDefault precedence
+        // where a non-forced default sets `runner` but the flow explicitly sets `taskRunner`).
+        if (taskRunner != null) {
+            // special case to take into account the deprecated dockerOptions if set
+            if (taskRunner instanceof Docker && dockerOptions != null) {
+                return (TaskRunner<T>) Docker.from(dockerOptions);
+            }
+            return (TaskRunner<T>) taskRunner;
+        }
+
         if (runnerType != null) {
             return switch (runnerType) {
                 case DOCKER -> (TaskRunner<T>) Docker.from(dockerOptions);
@@ -238,18 +248,14 @@ public class CommandsWrapper implements TaskCommands {
             };
         }
 
-        // special case to take into account the deprecated dockerOptions if set
-        if (taskRunner instanceof Docker && dockerOptions != null) {
-            return (TaskRunner<T>) Docker.from(dockerOptions);
-        }
-
-        return (TaskRunner<T>) taskRunner;
+        return null;
     }
 
     public Boolean getEnableOutputDirectory() {
         if (this.enableOutputDirectory == null) {
-            // For compatibility reasons, if legacy runnerType property is used, we enable the output directory
-            return this.runnerType != null;
+            // For compatibility reasons, if legacy runnerType property is used (and no explicit taskRunner overrides it),
+            // we enable the output directory. Mirrors getTaskRunner() precedence: taskRunner wins over runnerType.
+            return this.runnerType != null && this.taskRunner == null;
         }
 
         return this.enableOutputDirectory;

--- a/script/src/test/java/io/kestra/plugin/scripts/exec/AbstractExecScriptTaskRunnerPriorityTest.java
+++ b/script/src/test/java/io/kestra/plugin/scripts/exec/AbstractExecScriptTaskRunnerPriorityTest.java
@@ -1,0 +1,93 @@
+package io.kestra.plugin.scripts.exec;
+
+import com.google.common.collect.ImmutableMap;
+import io.kestra.core.context.TestRunContextFactory;
+import io.kestra.core.junit.annotations.KestraTest;
+import io.kestra.core.models.property.Property;
+import io.kestra.core.models.tasks.Task;
+import io.kestra.core.runners.RunContext;
+import io.kestra.core.utils.TestsUtils;
+import io.kestra.plugin.core.runner.Process;
+import io.kestra.plugin.scripts.exec.scripts.models.RunnerType;
+import io.kestra.plugin.scripts.exec.scripts.runners.CommandsWrapper;
+import io.kestra.plugin.scripts.runner.docker.Docker;
+import jakarta.inject.Inject;
+import lombok.experimental.SuperBuilder;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@KestraTest
+class AbstractExecScriptTaskRunnerPriorityTest {
+
+    @Inject
+    private TestRunContextFactory runContextFactory;
+
+    @SuperBuilder
+    static class TestScript extends AbstractExecScript {
+        @Override
+        public Property<String> getContainerImage() {
+            return null;
+        }
+    }
+
+    private RunContext mockRunContext(Task task) {
+        return TestsUtils.mockRunContext(runContextFactory, task, ImmutableMap.of());
+    }
+
+    @Test
+    void shouldFallBackToDefaultDockerWhenNeitherTaskRunnerNorRunnerIsSet() throws Exception {
+        // Given — historical default path: neither property set
+        TestScript script = TestScript.builder().id("t").type("t").build();
+
+        // When
+        CommandsWrapper wrapper = script.commands(mockRunContext(script));
+
+        // Then
+        assertThat(wrapper.getTaskRunner()).isInstanceOf(Docker.class);
+    }
+
+    @Test
+    void shouldUseLegacyRunnerWhenOnlyRunnerIsSet() throws Exception {
+        // Given — legacy YAML: only deprecated `runner` set
+        TestScript script = TestScript.builder().id("t").type("t").runner(RunnerType.PROCESS).build();
+
+        // When
+        CommandsWrapper wrapper = script.commands(mockRunContext(script));
+
+        // Then — no default Docker injection; legacy path resolves via CommandsWrapper
+        assertThat(wrapper.getTaskRunner()).isInstanceOf(Process.class);
+    }
+
+    @Test
+    void shouldUseTaskRunnerWhenOnlyTaskRunnerIsSet() throws Exception {
+        // Given — modern YAML: only `taskRunner` set
+        Docker docker = Docker.instance();
+        TestScript script = TestScript.builder().id("t").type("t").taskRunner(docker).build();
+
+        // When
+        CommandsWrapper wrapper = script.commands(mockRunContext(script));
+
+        // Then
+        assertThat(wrapper.getTaskRunner()).isSameAs(docker);
+    }
+
+    @Test
+    void shouldPreferExplicitTaskRunnerWhenBothAreSet() throws Exception {
+        // Given — bug scenario: PluginDefault sets runner=PROCESS, flow sets taskRunner=Docker.
+        // Merged task has both fields populated; explicit taskRunner must win.
+        Docker docker = Docker.instance();
+        TestScript script = TestScript.builder()
+            .id("t")
+            .type("t")
+            .runner(RunnerType.PROCESS)
+            .taskRunner(docker)
+            .build();
+
+        // When
+        CommandsWrapper wrapper = script.commands(mockRunContext(script));
+
+        // Then
+        assertThat(wrapper.getTaskRunner()).isSameAs(docker);
+    }
+}

--- a/script/src/test/java/io/kestra/plugin/scripts/exec/scripts/runners/CommandsWrapperTaskRunnerPriorityTest.java
+++ b/script/src/test/java/io/kestra/plugin/scripts/exec/scripts/runners/CommandsWrapperTaskRunnerPriorityTest.java
@@ -1,0 +1,105 @@
+package io.kestra.plugin.scripts.exec.scripts.runners;
+
+import io.kestra.core.models.tasks.runners.TaskRunner;
+import io.kestra.core.runners.RunContext;
+import io.kestra.core.runners.WorkingDir;
+import io.kestra.plugin.core.runner.Process;
+import io.kestra.plugin.scripts.exec.scripts.models.RunnerType;
+import io.kestra.plugin.scripts.runner.docker.Docker;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class CommandsWrapperTaskRunnerPriorityTest {
+
+    private static RunContext mockRunContext() {
+        RunContext runContext = mock(RunContext.class);
+        WorkingDir workingDir = mock(WorkingDir.class);
+        when(workingDir.path()).thenReturn(Paths.get("/tmp"));
+        when(runContext.workingDir()).thenReturn(workingDir);
+        return runContext;
+    }
+
+    @Test
+    void shouldReturnNullWhenBothTaskRunnerAndRunnerTypeAreNull() {
+        // Given
+        CommandsWrapper wrapper = new CommandsWrapper(mockRunContext());
+
+        // When
+        TaskRunner<?> resolved = wrapper.getTaskRunner();
+
+        // Then
+        assertThat(resolved).isNull();
+    }
+
+    @Test
+    void shouldUseLegacyRunnerTypeWhenTaskRunnerIsNull() {
+        // Given — only legacy runnerType set (PROCESS), no taskRunner
+        CommandsWrapper wrapper = new CommandsWrapper(mockRunContext())
+            .withRunnerType(RunnerType.PROCESS);
+
+        // When
+        TaskRunner<?> resolved = wrapper.getTaskRunner();
+
+        // Then
+        assertThat(resolved).isInstanceOf(Process.class);
+    }
+
+    @Test
+    void shouldUseExplicitTaskRunnerWhenRunnerTypeIsNull() {
+        // Given — only taskRunner set, no legacy runnerType
+        Docker docker = Docker.instance();
+        CommandsWrapper wrapper = new CommandsWrapper(mockRunContext())
+            .withTaskRunner(docker);
+
+        // When
+        TaskRunner<?> resolved = wrapper.getTaskRunner();
+
+        // Then
+        assertThat(resolved).isSameAs(docker);
+    }
+
+    @Test
+    void shouldPreferExplicitTaskRunnerOverLegacyRunnerType() {
+        // Given — both set: simulates a PluginDefault (non-forced) setting runner=PROCESS
+        // while the flow explicitly sets taskRunner=Docker. User-explicit must win.
+        Docker docker = Docker.instance();
+        CommandsWrapper wrapper = new CommandsWrapper(mockRunContext())
+            .withRunnerType(RunnerType.PROCESS)
+            .withTaskRunner(docker);
+
+        // When
+        TaskRunner<?> resolved = wrapper.getTaskRunner();
+
+        // Then
+        assertThat(resolved).isSameAs(docker);
+    }
+
+    @Test
+    void shouldNotEnableOutputDirectoryWhenTaskRunnerOverridesLegacyRunnerType() {
+        // Given — bug scenario: legacy runnerType set (which historically enabled outputDirectory)
+        // but explicit taskRunner overrides it. Output directory must mirror task runner precedence.
+        CommandsWrapper wrapper = new CommandsWrapper(mockRunContext())
+            .withRunnerType(RunnerType.PROCESS)
+            .withTaskRunner(Docker.instance());
+
+        // When / Then
+        assertThat(wrapper.getEnableOutputDirectory()).isFalse();
+    }
+
+    @Test
+    void shouldEnableOutputDirectoryWhenOnlyLegacyRunnerTypeIsSet() {
+        // Given — legacy-only path: compat behavior must still enable output directory
+        CommandsWrapper wrapper = new CommandsWrapper(mockRunContext())
+            .withRunnerType(RunnerType.PROCESS);
+
+        // When / Then
+        assertThat(wrapper.getEnableOutputDirectory()).isTrue();
+    }
+}


### PR DESCRIPTION
## Summary
- When a PluginDefault (non-forced) sets the deprecated `runner` property and a flow explicitly sets `taskRunner`, the merged task ends up with both populated. Previously `CommandsWrapper.getTaskRunner()` returned the legacy `runner` value, ignoring the user-explicit `taskRunner`.
- Flip priority so user-explicit `taskRunner` wins. Drop the inline `@Builder.Default` initializer so we can distinguish "user did not set it" from "user set it explicitly"; inject the historical Docker default in `AbstractExecScript.commands()` only when both fields are null.
- Gate `getEnableOutputDirectory()` the same way (`runnerType != null && taskRunner == null`) so the legacy compat behavior does not leak when `taskRunner` overrides `runner`.

Closes https://github.com/kestra-io/kestra-ee/issues/7968