### PR TITLE
refactor(tasks): remove deprecated runner property

### DIFF
--- a/script/src/main/java/io/kestra/plugin/scripts/exec/AbstractExecScript.java
+++ b/script/src/main/java/io/kestra/plugin/scripts/exec/AbstractExecScript.java
@@ -36,7 +36,7 @@ import lombok.experimental.SuperBuilder;
 public abstract class AbstractExecScript extends Task implements NamespaceFilesInterface, InputFilesInterface, OutputFilesInterface {
     @Schema(
         title = "Deprecated - use the 'taskRunner' property instead.",
-        description = "Only used if the `taskRunner` property is not set",
+        description = "Ignored for task runner selection. The deprecated `runner` property is no longer honored — set `taskRunner` instead.",
         deprecated = true
     )
     @PluginProperty
@@ -45,7 +45,8 @@ public abstract class AbstractExecScript extends Task implements NamespaceFilesI
 
     @Schema(
         title = "The task runner to use.",
-        description = "Task runners are provided by plugins, each have their own properties."
+        description = "Task runners are provided by plugins, each have their own properties.",
+        defaultValue = "{type: io.kestra.plugin.scripts.runner.docker.Docker, pullPolicy: IF_NOT_PRESENT}"
     )
     @PluginProperty
     @Builder.Default

--- a/script/src/main/java/io/kestra/plugin/scripts/exec/AbstractExecScript.java
+++ b/script/src/main/java/io/kestra/plugin/scripts/exec/AbstractExecScript.java
@@ -17,7 +17,6 @@ import io.kestra.core.models.tasks.runners.TaskRunner;
 import io.kestra.core.runners.RunContext;
 import io.kestra.plugin.core.runner.Process;
 import io.kestra.plugin.scripts.exec.scripts.models.DockerOptions;
-import io.kestra.plugin.scripts.exec.scripts.models.RunnerType;
 import io.kestra.plugin.scripts.exec.scripts.runners.CommandsWrapper;
 import io.kestra.plugin.scripts.runner.docker.Docker;
 import io.kestra.plugin.scripts.runner.docker.PullPolicy;
@@ -35,18 +34,8 @@ import lombok.experimental.SuperBuilder;
 @NoArgsConstructor
 public abstract class AbstractExecScript extends Task implements NamespaceFilesInterface, InputFilesInterface, OutputFilesInterface {
     @Schema(
-        title = "Deprecated - use the 'taskRunner' property instead.",
-        description = "Ignored for task runner selection. The deprecated `runner` property is no longer honored — set `taskRunner` instead.",
-        deprecated = true
-    )
-    @PluginProperty
-    @Deprecated
-    protected RunnerType runner;
-
-    @Schema(
         title = "The task runner to use.",
-        description = "Task runners are provided by plugins, each have their own properties.",
-        defaultValue = "{type: io.kestra.plugin.scripts.runner.docker.Docker, pullPolicy: IF_NOT_PRESENT}"
+        description = "Task runners are provided by plugins, each have their own properties."
     )
     @PluginProperty
     @Builder.Default


### PR DESCRIPTION
## Summary
- Remove the deprecated `runner` property entirely from `AbstractExecScript`. The user-facing fix for the precedence bug landed in v1.3.x ([#16274](https://github.com/kestra-io/kestra/pull/16274)); on develop we can drop the field since no in-repo caller references it.
- Drop the redundant `defaultValue` from the `taskRunner` schema — the existing `@Builder.Default` assignment is already picked up by the schema generator.

Refs https://github.com/kestra-io/kestra-ee/issues/7968