### PR TITLE
fix(flow): Use the tenant from the URL when updating a concurrency limit

### DIFF
--- a/webserver/src/main/java/io/kestra/webserver/controllers/api/ConcurrencyLimitController.java
+++ b/webserver/src/main/java/io/kestra/webserver/controllers/api/ConcurrencyLimitController.java
@@ -36,7 +36,7 @@ public class ConcurrencyLimitController {
     @Put("/{namespace}/{flowId}")
     @Operation(tags = { "Flows" }, summary = "Update a flow concurrency limit")
     public HttpResponse<ConcurrencyLimit> updateConcurrencyLimit(@Body ConcurrencyLimit concurrencyLimit) {
-        var existing = concurrencyLimitRepository.findById(concurrencyLimit.getTenantId(), concurrencyLimit.getNamespace(), concurrencyLimit.getFlowId());
+        var existing = concurrencyLimitRepository.findById(tenantService.resolveTenant(), concurrencyLimit.getNamespace(), concurrencyLimit.getFlowId());
         if (existing.isEmpty()) {
             return HttpResponse.notFound();
         }


### PR DESCRIPTION
Fixes https://github.com/kestra-io/kestra-ee/issues/7982
