### PR TITLE
fix(storage): reject backslash path traversal in LocalStorage (GHSA-qw4v-6w32-xx9h)

### DIFF
--- a/core/src/main/java/io/kestra/core/utils/FileUtils.java
+++ b/core/src/main/java/io/kestra/core/utils/FileUtils.java
@@ -3,7 +3,6 @@ package io.kestra.core.utils;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.lang3.StringUtils;
 
-import java.io.File;
 import java.net.URI;
 import java.util.Optional;
 
@@ -63,16 +62,39 @@ public final class FileUtils {
     }
 
     /**
-     * Check if the provided URI does not contain relative parent path traversal (i.e., "..").
+     * Check if the provided URI contains a relative parent path traversal segment (i.e., "..").
      *
      * @param uri the URI to validate
      * @return true if there is a relative parent path traversal
      */
     public static boolean isParentTraversal(URI uri) {
-        if (uri == null) {
+        return uri != null && isParentTraversal(uri.getPath());
+    }
+
+    /**
+     * Check if the provided path contains a relative parent path traversal segment (i.e., "..").
+     * <p>
+     * Both {@code /} and {@code \} are treated as path separators so that Windows-style backslash
+     * payloads (e.g. {@code "..\..\"}) cannot bypass the check. Only forward slashes were previously
+     * matched, allowing backslash payloads to slip through on Linux/containers before being
+     * canonicalized (GHSA-qw4v-6w32-xx9h).
+     * <p>
+     * The {@code path} argument must already be percent-decoded. {@link URI#getPath()} performs this
+     * decoding automatically, so callers that obtain the path via a URI do not need to decode it
+     * manually. Callers that pass a raw URL string should decode it first.
+     *
+     * @param path the path to validate (must be percent-decoded)
+     * @return true if there is a relative parent path traversal
+     */
+    public static boolean isParentTraversal(String path) {
+        if (path == null) {
             return false;
         }
-        var path = uri.getPath();
-        return path != null && (path.contains(".." + File.separator) || path.contains(File.separator + "..") || path.equals(".."));
+        // Normalize both separators to '/' so the check is platform- and payload-agnostic.
+        String normalized = path.replace('\\', '/');
+        return normalized.equals("..")
+            || normalized.startsWith("../")
+            || normalized.endsWith("/..")
+            || normalized.contains("/../");
     }
 }

--- a/core/src/test/java/io/kestra/core/utils/FileUtilsTest.java
+++ b/core/src/test/java/io/kestra/core/utils/FileUtilsTest.java
@@ -25,6 +25,8 @@ class FileUtilsTest {
         "",
         "kestra:///ns/flow/exec/abc/output",
         "kestra:///ns/flow/exec/abc/.output",
+        // a filename that merely contains ".." is not a traversal segment
+        "kestra:///ns/flow/exec/abc/my..file.txt",
     })
     void isParentTraversal_false(String path) {
         assertThat(FileUtils.isParentTraversal(URI.create(path))).isFalse();
@@ -35,9 +37,47 @@ class FileUtilsTest {
         "kestra:///ns/flow/exec/abc/../../../etc/passwd",
         "kestra:///ns/flow/exec/abc/%2E%2E/%2E%2E/%2E%2E/etc/passwd",
         "kestra:///ns/flow/exec/abc/%2e%2e/%2e%2e/%2e%2e/etc/passwd",
-        "kestra:///ns/flow/exec/abc%2F%2E%2E%2Fetc%2Fpasswd"
+        "kestra:///ns/flow/exec/abc%2F%2E%2E%2Fetc%2Fpasswd",
+        // GHSA-qw4v-6w32-xx9h: Windows-style backslash traversal must also be rejected.
+        // %5C decodes to '\' in URI.getPath().
+        "kestra:///ns/flow/exec/abc%5C..%5C..%5C..%5Cetc%5Cpasswd",
+        "kestra:///ns/flow/exec/abc%5C%2E%2E%5C%2E%2E%5Cetc%5Cpasswd",
+        // mixed separators
+        "kestra:///ns/flow/exec/abc/..%5C..%5Cetc%5Cpasswd",
     })
     void isParentTraversal_true(String path) {
         assertThat(FileUtils.isParentTraversal(URI.create(path))).isTrue();
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+        "..",
+        "../etc/passwd",
+        "ns/exec/../../etc/passwd",
+        "ns/exec/output/..",
+        // GHSA-qw4v-6w32-xx9h: backslash variants (already decoded, as from URI.getPath())
+        "..\\" + "etc\\passwd",
+        "ns\\exec\\..\\.." + "\\etc\\passwd",
+        "ns/exec/abc\\..\\..\\.." + "\\etc\\passwd",
+    })
+    void isParentTraversalString_true(String path) {
+        assertThat(FileUtils.isParentTraversal(path)).isTrue();
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+        "",
+        "ns/flow/exec/abc/output",
+        "ns/flow/exec/abc/.output",
+        "ns/flow/exec/abc/my..file.txt",
+    })
+    void isParentTraversalString_false(String path) {
+        assertThat(FileUtils.isParentTraversal(path)).isFalse();
+    }
+
+    @Test
+    void isParentTraversal_handlesNull() {
+        assertThat(FileUtils.isParentTraversal((URI) null)).isFalse();
+        assertThat(FileUtils.isParentTraversal((String) null)).isFalse();
     }
 }

--- a/storage-local/src/main/java/io/kestra/storage/local/LocalStorage.java
+++ b/storage-local/src/main/java/io/kestra/storage/local/LocalStorage.java
@@ -27,6 +27,7 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 
+import static io.kestra.core.utils.FileUtils.isParentTraversal;
 import static io.kestra.core.utils.Rethrow.throwFunction;
 import static io.kestra.core.utils.WindowsUtils.windowsToUnixPath;
 
@@ -66,8 +67,22 @@ public class LocalStorage implements StorageInterface {
             return basePath;
         }
 
-        parentTraversalGuard(uri);
-        return Paths.get(basePath.toString(), windowsToUnixPath(uri.getPath()));
+        // Canonicalize Windows-style separators *before* validating. Otherwise a backslash
+        // payload ("..\..\\") slips past the traversal guard and is only rewritten to "../../"
+        // afterwards, escaping the storage directory (GHSA-qw4v-6w32-xx9h).
+        String relativePath = windowsToUnixPath(uri.getPath());
+        if (isParentTraversal(relativePath)) {
+            throw new IllegalArgumentException("File should be accessed with their full path and not using relative '..' path.");
+        }
+
+        Path resolved = Paths.get(basePath.toString(), relativePath).normalize();
+
+        // Defense in depth: the resolved path must never escape the storage base directory.
+        if (!resolved.startsWith(basePath.toAbsolutePath().normalize())) {
+            throw new IllegalArgumentException("File should be accessed with their full path and not using relative '..' path.");
+        }
+
+        return resolved;
     }
 
     @Override

--- a/storage-local/src/test/java/io/kestra/storage/local/LocalStorageTest.java
+++ b/storage-local/src/test/java/io/kestra/storage/local/LocalStorageTest.java
@@ -13,6 +13,7 @@ import io.kestra.core.utils.IdUtils;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.not;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class LocalStorageTest extends StorageTestSuite {
@@ -33,4 +34,32 @@ class LocalStorageTest extends StorageTestSuite {
         String suffix = put.getPath().substring(7); // we remove the random 5 char + '-'
         assertTrue(longObjectName.endsWith(suffix));
     }
+
+    // GHSA-qw4v-6w32-xx9h: a Windows-style backslash traversal must not escape the storage
+    // base directory. Before the fix, the guard ran before backslashes were converted to '/',
+    // so this payload reached arbitrary host files (e.g. /etc/passwd).
+    // %5C decodes to '\' in URI.getPath().
+    @Test
+    void shouldRejectBackslashParentTraversal() {
+        URI backslashTraversal = URI.create(
+            "kestra:///abc%5C..%5C..%5C..%5C..%5C..%5C..%5C..%5C..%5C..%5C..%5Cetc%5Cpasswd"
+        );
+
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> storageInterface.get(IdUtils.create(), null, backslashTraversal)
+        );
+    }
+
+    // The classic forward-slash traversal must keep being rejected as well.
+    @Test
+    void shouldRejectForwardSlashParentTraversal() {
+        URI traversal = URI.create("kestra:///abc/../../../../../../../../etc/passwd");
+
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> storageInterface.get(IdUtils.create(), null, traversal)
+        );
+    }
 }
+


### PR DESCRIPTION
modified PR of @StarPlatinu

## Summary

Fixes the path traversal reported in advisory **GHSA-qw4v-6w32-xx9h** (authenticated arbitrary file read via the execution file-download API).

### Root cause

`LocalStorage.getPath()` ran the parent-traversal guard **before** `windowsToUnixPath()` converted Windows-style backslashes to `/`:

```java
parentTraversalGuard(uri);                                              // (1) validate
return Paths.get(basePath.toString(), windowsToUnixPath(uri.getPath())); // (2) canonicalize, then use
```

`FileUtils.isParentTraversal()` used `File.separator` (always `/` on Linux/containers), so it only recognised forward-slash traversal (`../`, `/..`). A payload using backslashes (`..\..\..`) passed the guard unchanged, was then rewritten to `../../../` by `windowsToUnixPath()`, and escaped the storage base directory — exposing any file readable by the Kestra process (`/etc/passwd`, `/proc/self/environ`, the H2 database, cross-namespace internal storage, …). CWE-22 / CWE-180.

### Fix (defense in depth)

1. **`FileUtils.isParentTraversal`** — add a `String` overload that normalises `\` → `/` before segment matching; the `URI` overload delegates to it. Drops the `File.separator` dependency entirely. This also hardens the shared `StorageInterface.parentTraversalGuard` used by every storage backend.
2. **`LocalStorage.getPath`** — canonicalize separators **before** validating, then add a containment check (`resolved.startsWith(basePath)`) so a resolved path can never escape the base directory even if a future guard regresses.

### Tests

- `FileUtilsTest` — backslash, mixed-separator and percent-encoded payloads are now rejected; filenames that merely contain `..` (e.g. `my..file.txt`) are still allowed; null inputs handled safely.
- `LocalStorageTest` — `shouldRejectBackslashParentTraversal` / `shouldRejectForwardSlashParentTraversal` assert `storageInterface.get()` throws on traversal URIs.

Verified the patched logic against the original PoC payloads: all traversal variants are blocked, all legitimate paths still resolve.

### Notes for maintainers

- Patch targets `develop`. For older release lines where the guard is inlined in `StorageInterface.parentTraversalGuard`, the same `isParentTraversal` hardening should be backported.
- The `ExecutionController.validateFile()` prefix check (`path.getPath().startsWith(prefix)`) is weak but no longer reachable for traversal once the storage layer rejects it; tightening it to a normalised containment check would be a good follow-up hardening.