### PR TITLE
fix(helm): replace losisin action with direct helm-docs binary call

### DIFF
--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -51,7 +51,7 @@ jobs:
           tar -xzf /tmp/hd.tar.gz -C /usr/local/bin helm-docs
 
       - name: Verify helm-docs are up to date
-        uses: losisin/helm-docs-github-action@v2
+        run: helm-docs
 
       - name: Fail on uncommitted README diffs
         run: git diff --exit-code -- 'charts/**/README.md'
@@ -91,7 +91,7 @@ jobs:
           mv /tmp/chart-starter.yaml charts/kestra-starter/Chart.yaml
 
       - name: Regenerate helm-docs after version bump
-        uses: losisin/helm-docs-github-action@v2
+        run: helm-docs
 
       - name: Lint kestra chart
         run: |


### PR DESCRIPTION
## Summary

Every published Helm chart `.tgz` from v1.3.16–v1.3.20 contains stale version badges in its `README.md` (showing `Version: 1.0.53` / `AppVersion: v1.3.14`). Artifact Hub displays this README on the package page. The root cause is `losisin/helm-docs-github-action@v1` silently not writing files after the Chart.yaml version bump. Since `helm-docs` is already installed in the same job, this PR replaces both action usages with a direct binary call.

## Changes

- Replace `uses: losisin/helm-docs-github-action@v1` with `run: helm-docs` in **Verify helm-docs are up to date** step
- Replace `uses: losisin/helm-docs-github-action@v1` with `run: helm-docs` in **Regenerate helm-docs after version bump** step

close kestra-io/kestra#16294