### PR TITLE
[backport releases/v1.3.x] fix(flows): register pebble filter autocompletion in YAML flow editor

### DIFF
--- a/ui/src/composables/monaco/languages/yamlLanguageConfigurator.ts
+++ b/ui/src/composables/monaco/languages/yamlLanguageConfigurator.ts
@@ -13,6 +13,7 @@ import * as YamlUtils from "@kestra-io/ui-libs/flow-yaml-utils";
 import {
     endOfWordColumn,
     NO_SUGGESTIONS,
+    registerFilterAutoCompletion,
     registerFunctionParametersAutoCompletion,
     registerNestedValueAutoCompletion,
     registerPebbleAutocompletion,
@@ -578,6 +579,12 @@ export class YamlLanguageConfigurator extends AbstractLanguageConfigurator {
         );
 
         registerNestedValueAutoCompletion(
+            autoCompletionProviders,
+            yamlAutoCompletion,
+            ["yaml", "plaintext"],
+        );
+
+        registerFilterAutoCompletion(
             autoCompletionProviders,
             yamlAutoCompletion,
             ["yaml", "plaintext"],


### PR DESCRIPTION
Backport of:
- kestra-io/kestra#16296 — fix(flows): register pebble filter autocompletion in YAML flow editor (cherry-picked from 6510d724c02fe58cc43e285b35b35d5e944d23b3)

Cherry-picked with `-x`.