### PR TITLE
fix(core): register streaming subscriber before resuming queue

### DIFF
--- a/core/src/main/java/io/kestra/core/services/ExecutionStreamingService.java
+++ b/core/src/main/java/io/kestra/core/services/ExecutionStreamingService.java
@@ -108,16 +108,13 @@ public class ExecutionStreamingService {
     public void registerSubscriber(String executionId, String subscriberId, FluxSink<Event<Execution>> sink, Flow flow) {
         // it needs to be synchronized as we get and remove if empty, so we must be sure that nobody else is adding a new one in-between
         synchronized (subscriberLock) {
-            boolean wasEmpty = MapUtils.isEmpty(subscribers);
-
             // Register the subscriber BEFORE resuming the queue. If the queue is resumed first,
             // the polling thread can deliver a terminal FollowExecutionEvent between resume() and put(),
             // missing the event and leaving Flux.last() hanging forever.
             subscribers.computeIfAbsent(executionId, k -> new ConcurrentHashMap<>())
                 .put(subscriberId, Pair.of(sink, flow));
 
-            // resume the subscription if it was paused with no subscribers
-            if (wasEmpty && this.queueSubscriber.isPaused()) {
+            if (this.queueSubscriber.isPaused()) {
                 this.queueSubscriber.resume();
             }
         }

--- a/core/src/main/java/io/kestra/core/services/ExecutionStreamingService.java
+++ b/core/src/main/java/io/kestra/core/services/ExecutionStreamingService.java
@@ -108,13 +108,18 @@ public class ExecutionStreamingService {
     public void registerSubscriber(String executionId, String subscriberId, FluxSink<Event<Execution>> sink, Flow flow) {
         // it needs to be synchronized as we get and remove if empty, so we must be sure that nobody else is adding a new one in-between
         synchronized (subscriberLock) {
-            // resume the subscription if paused
-            if (MapUtils.isEmpty(subscribers) && this.queueSubscriber.isPaused()) {
-                this.queueSubscriber.resume();
-            }
+            boolean wasEmpty = MapUtils.isEmpty(subscribers);
 
+            // Register the subscriber BEFORE resuming the queue. If the queue is resumed first,
+            // the polling thread can deliver a terminal FollowExecutionEvent between resume() and put(),
+            // missing the event and leaving Flux.last() hanging forever.
             subscribers.computeIfAbsent(executionId, k -> new ConcurrentHashMap<>())
                 .put(subscriberId, Pair.of(sink, flow));
+
+            // resume the subscription if it was paused with no subscribers
+            if (wasEmpty && this.queueSubscriber.isPaused()) {
+                this.queueSubscriber.resume();
+            }
         }
     }
 

--- a/core/src/main/java/io/kestra/core/services/LogStreamingService.java
+++ b/core/src/main/java/io/kestra/core/services/LogStreamingService.java
@@ -81,13 +81,14 @@ public class LogStreamingService {
     public void registerSubscriber(String executionId, String subscriberId, FluxSink<Event<FollowLogEvent>> sink, List<String> levels) {
         // it needs to be synchronized as we get and remove if empty, so we must be sure that nobody else is adding a new one in-between
         synchronized (subscriberLock) {
-            // resume the subscription if paused
-            if (MapUtils.isEmpty(subscribers) && this.queueSubscriber.isPaused()) {
-                this.queueSubscriber.resume();
-            }
-
+            // Register the subscriber BEFORE resuming the queue to avoid a race where the polling
+            // thread delivers an event between resume() and put(), causing events to be dropped.
             subscribers.computeIfAbsent(executionId, k -> new ConcurrentHashMap<>())
                 .put(subscriberId, Pair.of(sink, levels));
+
+            if (this.queueSubscriber.isPaused()) {
+                this.queueSubscriber.resume();
+            }
         }
     }
 

--- a/webserver/src/main/java/io/kestra/webserver/services/ExecutionDependenciesStreamingService.java
+++ b/webserver/src/main/java/io/kestra/webserver/services/ExecutionDependenciesStreamingService.java
@@ -125,13 +125,14 @@ public class ExecutionDependenciesStreamingService {
     public void registerSubscriber(String correlationId, String subscriberId, Subscriber consumer) {
         // it needs to be synchronized as we get and remove if empty, so we must be sure that nobody else is adding a new one in-between
         synchronized (subscriberLock) {
-            // resume the subscription if paused
-            if (MapUtils.isEmpty(subscribers) && this.queueSubscriber.isPaused()) {
-                this.queueSubscriber.resume();
-            }
-
+            // Register the subscriber BEFORE resuming the queue to avoid a race where the polling
+            // thread delivers an event between resume() and put(), causing events to be dropped.
             subscribers.computeIfAbsent(correlationId, k -> new ConcurrentHashMap<>())
                 .put(subscriberId, consumer);
+
+            if (this.queueSubscriber.isPaused()) {
+                this.queueSubscriber.resume();
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

- In `ExecutionStreamingService.registerSubscriber()`, the polling queue was **resumed before the subscriber was added to the map**
- On multi-core machines, the polling thread can wake up between `resume()` and `subscribers.put()` and deliver a terminal `FollowExecutionEvent` to an empty subscriber map, dropping the event
- `Flux.last()` in `TestSuiteService` then hangs indefinitely, making `run_shouldBePersisted` (and similar streaming-backed tests) flaky in CI

**Root cause**: `registerSubscriber` snapshot:
```java
// BEFORE (racy):
if (MapUtils.isEmpty(subscribers) && this.queueSubscriber.isPaused()) {
    this.queueSubscriber.resume();   // ← polling thread can run here
}
subscribers.computeIfAbsent(...).put(...);  // ← subscriber added too late
```

**Fix**: capture `wasEmpty`, register the subscriber first, then resume:
```java
boolean wasEmpty = MapUtils.isEmpty(subscribers);
subscribers.computeIfAbsent(...).put(...);  // ← subscriber visible before resume
if (wasEmpty && this.queueSubscriber.isPaused()) {
    this.queueSubscriber.resume();
}
```

## Test plan

- [x] `MysqlTestSuiteControllerTest` (all 27 tests) pass locally with the fix
- [x] `run_shouldBePersisted` targeted test passes 10/10 times