### PR TITLE
fix: prevent NPE in ScriptService.labels() when called from trigger-evaluation context

### DIFF
--- a/core/src/main/java/io/kestra/core/models/tasks/runners/ScriptService.java
+++ b/core/src/main/java/io/kestra/core/models/tasks/runners/ScriptService.java
@@ -205,13 +205,14 @@ public final class ScriptService {
         Map<String, String> execution = (Map<String, String>) runContext.getVariables().get("execution");
         Map<String, String> taskrun = (Map<String, String>) runContext.getVariables().get("taskrun");
 
+        // task, execution and taskrun may be absent when labels() is called from a trigger-evaluation context
         return ImmutableMap.of(
             withPrefix("namespace", prefix), normalizeValue(flow.get("namespace"), normalizeValue, lowerCase),
             withPrefix("flow-id", prefix), normalizeValue(flow.get("id"), normalizeValue, lowerCase),
-            withPrefix("task-id", prefix), normalizeValue(task.get("id"), normalizeValue, lowerCase),
-            withPrefix("execution-id", prefix), normalizeValue(execution.get("id"), normalizeValue, lowerCase),
-            withPrefix("taskrun-id", prefix), normalizeValue(taskrun.get("id"), normalizeValue, lowerCase),
-            withPrefix("taskrun-attempt", prefix), normalizeValue(String.valueOf(taskrun.get("attemptsCount")), normalizeValue, lowerCase)
+            withPrefix("task-id", prefix), task != null ? normalizeValue(task.get("id"), normalizeValue, lowerCase) : "",
+            withPrefix("execution-id", prefix), execution != null ? normalizeValue(execution.get("id"), normalizeValue, lowerCase) : "",
+            withPrefix("taskrun-id", prefix), taskrun != null ? normalizeValue(taskrun.get("id"), normalizeValue, lowerCase) : "",
+            withPrefix("taskrun-attempt", prefix), taskrun != null ? normalizeValue(String.valueOf(taskrun.get("attemptsCount")), normalizeValue, lowerCase) : "0"
         );
     }
 


### PR DESCRIPTION
## Problem

When a `ScriptTrigger` or `CommandsTrigger` uses the Docker task runner (the default since the Docker runner replaced the Process runner for script triggers), the Docker runner calls `ScriptService.labels()` to label the container. In trigger-evaluation context, `RunContext` variables only contain `flow` and `trigger` — **`task`, `execution`, and `taskrun` are absent**.

This causes a `NullPointerException` at:
```java
withPrefix("task-id", prefix), normalizeValue(task.get("id"), ...) // task is null → NPE
```

The exception propagates out of `evaluate()`, which blocks the scheduler from processing subsequent triggers.

## Root cause

`ScriptService.labels()` unconditionally dereferences `task`, `execution`, and `taskrun` maps that are guaranteed to exist during normal task execution but are absent during trigger evaluation.

## Fix

Add null guards for `task`, `execution`, and `taskrun`: return an empty string for those label fields when the maps are not present in the context. This matches the semantic expectation — a trigger evaluation has no associated task run or execution yet.

## Impact

- Affects all `ScriptTrigger` / `CommandsTrigger` classes across plugin-scripts submodules (shell, python, node, go, ruby, bun, deno, …) when using the Docker task runner
- Without this fix, a single NPE during trigger evaluation locks the scheduler for that trigger indefinitely (related fix: [kestra-io/plugin-scripts#369](https://github.com/kestra-io/plugin-scripts/pull/369))

## Testing

Unit tests for `CommandsTriggerTest` and `ScriptTriggerTest` across shell, python, node, go, and ruby submodules all pass with this fix applied.