### PR TITLE
fix: Docs code block spacing

### DIFF
--- a/ui/src/components/plugins/schema/SchemaToCode.vue
+++ b/ui/src/components/plugins/schema/SchemaToCode.vue
@@ -66,7 +66,6 @@
     .code-block {
         position: relative;
         padding: 0.75rem;
-        margin: 1rem 0;
         background-color: var(--ks-bg-input);
         border: 1px solid var(--ks-border-default);
         border-radius: 0.5rem;

--- a/ui/src/components/plugins/schema/SchemaToCode.vue
+++ b/ui/src/components/plugins/schema/SchemaToCode.vue
@@ -66,6 +66,7 @@
     .code-block {
         position: relative;
         padding: 0.75rem;
+        margin: 1rem 0;
         background-color: var(--ks-bg-input);
         border: 1px solid var(--ks-border-default);
         border-radius: 0.5rem;

--- a/ui/src/components/plugins/schema/SchemaToHtml.vue
+++ b/ui/src/components/plugins/schema/SchemaToHtml.vue
@@ -320,6 +320,7 @@
     .example-block {
         display: flex;
         flex-direction: column;
+        gap: 1rem
     }
 
     .example-block-tight {


### PR DESCRIPTION
<img width="2540" height="1267" alt="image" src="https://github.com/user-attachments/assets/4c31f6ff-dcc0-4781-8fe3-9b594788afb0" />

<img width="2094" height="1402" alt="Capture d’écran 2026-05-28 à 11 17 21" src="https://github.com/user-attachments/assets/47222d18-ce6e-4ced-b1db-5c878a6718bd" />
