### PR TITLE
fix(flows): remove duplicate topology tab from top navigation

### DIFF
--- a/ui/src/components/flows/FlowRoot.vue
+++ b/ui/src/components/flows/FlowRoot.vue
@@ -14,7 +14,6 @@
 </template>
 
 <script>
-    import Topology from "./Topology.vue"
     import FlowRevisions from "./FlowRevisions.vue"
     import LogsWrapper from "../logs/LogsWrapper.vue"
     import FlowExecutions from "./FlowExecutions.vue"
@@ -127,29 +126,15 @@
                 return this.$route.params.namespace + "/" + this.$route.params.id
             },
             getTabs() {
-                let tabs = [
-                    {
-                        name: undefined,
-                        component: Topology,
-                        title: this.$t("topology"),
-                        props: {
-                            isReadOnly: true,
-                            expandedSubflows: this.flowStore.expandedSubflows,
-                        },
-                    },
-                ]
+                let tabs = []
 
                 if (this.user?.hasAny(resource.EXECUTION)) {
-                    tabs[0].name = "topology"
-
-                    tabs = [
-                        {
-                            name: "overview",
-                            component: Overview,
-                            title: this.$t("overview"),
-                            containerClass: "full-container flex-grow-0 flex-shrink-0 flex-basis-0",
-                        },
-                    ].concat(tabs)
+                    tabs.push({
+                        name: "overview",
+                        component: Overview,
+                        title: this.$t("overview"),
+                        containerClass: "full-container flex-grow-0 flex-shrink-0 flex-basis-0",
+                    })
                 }
 
                 if (


### PR DESCRIPTION
## Summary

- Removes the standalone **Topology** top-level tab from the Flow page navigation
- The topology view is already embedded inside the **Edit** tab (`MultiPanelFlowEditorView`), making the top-level tab a duplicate
- Cleans up the now-unused `Topology` import in `FlowRoot.vue`

Closes https://github.com/kestra-io/kestra-ee/issues/8059.

## Test plan

- [ ] Open a flow — confirm the Topology tab is no longer in the top navigation
- [ ] Open the Edit tab — confirm the embedded topology still works as expected
- [ ] Verify the Overview, Executions, and other tabs are unaffected