### PR TITLE
fix(triggers): fix selectedTrigger type in TriggersManage

### DIFF
--- a/ui/src/components/admin/triggers/TriggersManage.vue
+++ b/ui/src/components/admin/triggers/TriggersManage.vue
@@ -357,7 +357,7 @@
     const isBackfillOpen = ref(false)
     const isDetailsOpen = ref(false)
     const detailsTriggerId = ref<string | undefined>()
-    const selectedTrigger = ref(null)
+    const selectedTrigger = ref<{inputs?: Record<string, unknown>} | undefined>(undefined)
 
     const DATE_COLUMNS: readonly string[] = ["lastTriggeredDate", "nextEvaluationDate", "evaluatedAt", "updatedAt"]
     const SORTABLE_COLUMNS: readonly string[] = ["flowId", "namespace", ...DATE_COLUMNS]
@@ -537,7 +537,7 @@
     const setBackfillModal = (trigger: any, bool: boolean) => {
         if (!trigger) {
             isBackfillOpen.value = false
-            selectedTrigger.value = null
+            selectedTrigger.value = undefined
             return
         }
 


### PR DESCRIPTION
## Summary

- `selectedTrigger` was typed as `null` but `FlowRun`'s prop expects `SelectedTrigger | undefined`
- Changed initial value and reset from `null` to `undefined` and added the correct inline type

## Test plan

- [ ] Type check passes: `npm run check:types`