### PR TITLE
fix(design-system): use light tooltip effect for sidebar version badge in light mode

### DIFF
--- a/ui/src/components/admin/AdminItem.vue
+++ b/ui/src/components/admin/AdminItem.vue
@@ -7,7 +7,7 @@
         @click="open"
     >
         <template v-if="configs?.version" #suffix>
-            <KsTooltip placement="top">
+            <KsTooltip placement="top" effect="light">
                 <template #content>
                     <div class="admin-item__tooltip">
                         <div>{{ t("version") }}: {{ configs.version }}</div>


### PR DESCRIPTION
## Summary

- The version tooltip in the sidebar used `effect="dark"` (dark background) in light mode by default
- The commit hash color (`--ks-text-link`) resolves to a dark purple in light mode, making it invisible against the dark tooltip background
- Forcing `effect="light"` gives a consistent white background in both modes, so the commit hash is clearly readable

Closes https://github.com/kestra-io/kestra-ee/issues/8080.

## Test plan

- [ ] Open Kestra in light mode, hover over the version badge in the sidebar — commit hash is visible
- [ ] Open Kestra in dark mode, hover over the version badge — still looks correct