### PR TITLE
feat: add task to remove orphan execution files

### DIFF
--- a/core/src/main/java/io/kestra/core/services/StoragePurgeService.java
+++ b/core/src/main/java/io/kestra/core/services/StoragePurgeService.java
@@ -41,10 +41,16 @@ public class StoragePurgeService {
 
     /**
      * Purges execution storage whose files fall within {@code [startDate, endDate]}.
-     * Namespace matching is exact: {@code namespace=a.b} does not reach {@code a.b.c}.
+     * Namespace matching is recursive: {@code namespace=a.b} also reaches {@code a.b.c}.
+     * <p>
+     * Sub-namespaces are discovered by walking the parent's storage subtree, so recursion only reaches
+     * children that share the parent's backend. A sub-namespace backed by its own dedicated storage is
+     * physically absent from the parent subtree and is therefore not discovered — target it explicitly via
+     * {@code namespace}. This walk-based discovery is deliberate: it lets the purge reclaim files of flows
+     * (and whole namespaces) that no longer exist, which a flow-metadata enumeration could not.
      *
      * @param tenantId  tenant identifier
-     * @param namespace exact namespace; {@code null} = walk every namespace under the tenant
+     * @param namespace namespace and all its sub-namespaces sharing its backend; {@code null} = walk every namespace under the tenant
      * @param flowId    restrict to a single flow (requires {@code namespace})
      * @param startDate inclusive lower bound on file mtime
      * @param endDate   inclusive upper bound on file mtime (acts as the in-flight guard)
@@ -69,7 +75,8 @@ public class StoragePurgeService {
         if (namespace != null && flowId != null) {
             purgeFlow(tenantId, namespace, flowId, startInstant, endInstant, dryRun, agg);
         } else if (namespace != null) {
-            purgeNamespace(tenantId, namespace, startInstant, endInstant, dryRun, agg);
+            walkNamespaceTree(tenantId, namespace, StorageContext.namespaceRootUri(namespace),
+                startInstant, endInstant, dryRun, agg);
         } else {
             walkNamespaceTree(tenantId, "", URI.create(StorageContext.KESTRA_PROTOCOL + "/"),
                 startInstant, endInstant, dryRun, agg);
@@ -104,20 +111,10 @@ public class StoragePurgeService {
         }
     }
 
-    /** Lists direct flow-dir children of {@code namespaceRoot} and purges each. Exact namespace, no recursion. */
-    private void purgeNamespace(@Nullable String tenantId, String namespace,
-        @Nullable Instant startDate, @Nullable Instant endDate, boolean dryRun, Aggregator agg) throws IOException {
-        URI namespaceRoot = StorageContext.namespaceRootUri(namespace);
-        for (FileAttributes child : safeList(tenantId, namespace, namespaceRoot)) {
-            if (!isFlowCandidate(child) || isAmbiguousFlowName(child.getFileName(), namespace)) {
-                continue;
-            }
-            purgeFlow(tenantId, namespace, child.getFileName(), startDate, endDate, dryRun, agg);
-        }
-    }
-
     /**
-     * Recursive tenant-wide walk. As we descend, we accumulate the dotted namespace from path segments and
+     * Recursive walk over a namespace subtree (or the whole tenant when {@code currentNamespace} is empty).
+     * A {@code namespace}-scoped purge reaches every sub-namespace beneath it; e.g. {@code namespace=a.b} also
+     * purges {@code a.b.c}. As we descend, we accumulate the dotted namespace from path segments and
      * thread it through {@link #safeList} so backends enforcing per-namespace isolation receive a valid
      * scope; only the tenant-root listing itself uses {@code null} (no namespace candidate exists yet).
      * <p>

--- a/core/src/main/java/io/kestra/core/services/StoragePurgeService.java
+++ b/core/src/main/java/io/kestra/core/services/StoragePurgeService.java
@@ -4,10 +4,11 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.net.URI;
 import java.nio.file.NoSuchFileException;
+import java.time.Instant;
 import java.time.ZonedDateTime;
-import java.util.ArrayList;
+import java.util.LinkedHashSet;
 import java.util.List;
-import java.util.OptionalLong;
+import java.util.Set;
 
 import io.kestra.core.storages.FileAttributes;
 import io.kestra.core.storages.StorageContext;
@@ -19,9 +20,14 @@ import jakarta.inject.Singleton;
 import lombok.extern.slf4j.Slf4j;
 
 /**
- * Storage-layer maintenance for orphaned execution files. Mirrors {@link ExecutionLogService} for logs: walks
- * storage without consulting any repository, so it can reclaim files of flows that no longer exist — including the
- * post-isolated-worker-group case in <a href="https://github.com/kestra-io/kestra-ee/issues/6699">kestra-ee#6699</a>.
+ * Maintenance service for orphaned execution storage. Resolves which
+ * {@code <ns>/<flow>/executions/} prefixes are in scope, then delegates per-file
+ * date filtering and deletion to {@link StorageInterface#purgeByLastModified}.
+ * <p>
+ * Mirrors {@link ExecutionLogService} for logs: walks storage directly (no flow
+ * repository) so it can reclaim files of flows that no longer exist, including
+ * the post-isolated-worker-group case in
+ * <a href="https://github.com/kestra-io/kestra-ee/issues/6699">kestra-ee#6699</a>.
  */
 @Singleton
 @Slf4j
@@ -34,14 +40,14 @@ public class StoragePurgeService {
     }
 
     /**
-     * Purges {@code executions/{id}/} subtrees whose newest contained file falls within {@code [startDate, endDate]}.
-     * Namespace matching is exact: {@code namespace=a.b} does not reach {@code a.b.c} (purge that explicitly).
+     * Purges execution storage whose files fall within {@code [startDate, endDate]}.
+     * Namespace matching is exact: {@code namespace=a.b} does not reach {@code a.b.c}.
      *
-     * @param tenantId  tenant identifier; {@code null} only meaningful for backends that don't enforce tenancy
-     * @param namespace exact namespace; {@code null} = every namespace under the tenant
+     * @param tenantId  tenant identifier
+     * @param namespace exact namespace; {@code null} = walk every namespace under the tenant
      * @param flowId    restrict to a single flow (requires {@code namespace})
-     * @param startDate lower bound on newest-file mtime (nullable)
-     * @param endDate   upper bound on newest-file mtime; also the in-flight guard (nullable)
+     * @param startDate inclusive lower bound on file mtime
+     * @param endDate   inclusive upper bound on file mtime (acts as the in-flight guard)
      * @param dryRun    when {@code true}, match but delete nothing
      */
     public StoragePurgeResult purgeByLastModified(
@@ -56,126 +62,90 @@ public class StoragePurgeService {
             throw new IllegalArgumentException("'namespace' is required when 'flowId' is set.");
         }
 
-        Long startMillis = startDate == null ? null : startDate.toInstant().toEpochMilli();
-        Long endMillis = endDate == null ? null : endDate.toInstant().toEpochMilli();
+        Instant startInstant = startDate == null ? null : startDate.toInstant();
+        Instant endInstant = endDate == null ? null : endDate.toInstant();
 
-        int scanned = 0;
-        int deletedFiles = 0;
-        List<URI> purgedUris = new ArrayList<>();
-
-        for (URI executionUri : findExecutionDirs(tenantId, namespace, flowId)) {
-            scanned++;
-            try {
-                // Use newest contained file, not the dir's own timestamp: directory timestamps are virtual on object
-                // stores and don't advance on nested writes on a local fs. Also naturally preserves in-flight runs.
-                OptionalLong lastModified = lastModifiedFileTime(tenantId, executionUri);
-                if (lastModified.isEmpty()
-                    || (startMillis != null && lastModified.getAsLong() < startMillis)
-                    || (endMillis != null && lastModified.getAsLong() > endMillis)) {
-                    continue;
-                }
-
-                if (!dryRun) {
-                    // Delete first, record after — failed deletes don't end up in purgedUris.
-                    deletedFiles += storageInterface.deleteByPrefix(tenantId, null, executionUri).size();
-                }
-                purgedUris.add(executionUri);
-            } catch (Exception e) {
-                // Per-execution isolation: one bad subtree must not abort the rest.
-                log.warn("Failed to purge storage at '{}'; skipping it.", executionUri, e);
-            }
-        }
-
-        return new StoragePurgeResult(scanned, deletedFiles, List.copyOf(purgedUris));
-    }
-
-    /**
-     * Resolves the {@code executions/{id}/} directories to scan by walking storage directly:
-     * {@code namespace+flowId} → one flow's executions; {@code namespace} only → its direct flow dirs (exact match,
-     * no sub-namespace recursion); neither → recursive tenant-wide walk (gated by {@code allowAllNamespaces}).
-     */
-    private List<URI> findExecutionDirs(@Nullable String tenantId, @Nullable String namespace, @Nullable String flowId) throws IOException {
-        List<URI> result = new ArrayList<>();
+        Aggregator agg = new Aggregator();
         if (namespace != null && flowId != null) {
-            addChildDirs(tenantId, StorageContext.executionsRootUri(namespace, flowId), result);
-            return result;
+            purgeFlow(tenantId, namespace, flowId, startInstant, endInstant, dryRun, agg);
+        } else if (namespace != null) {
+            purgeNamespace(tenantId, namespace, startInstant, endInstant, dryRun, agg);
+        } else {
+            walkNamespaceTree(tenantId, "", URI.create(StorageContext.KESTRA_PROTOCOL + "/"),
+                startInstant, endInstant, dryRun, agg);
         }
-        URI scanRoot = namespace == null
-            ? URI.create(StorageContext.KESTRA_PROTOCOL + "/")
-            : StorageContext.namespaceRootUri(namespace);
-        if (namespace != null) {
-            for (FileAttributes flowCandidate : listAsAdminOrEmpty(tenantId, scanRoot)) {
-                if (!isFlowCandidate(flowCandidate) || isAmbiguousFlowName(flowCandidate.getFileName(), namespace)) {
-                    continue;
-                }
-                addChildDirs(tenantId, resolveChildDir(scanRoot, flowCandidate.getFileName() + "/" + StorageContext.EXECUTIONS_DIR_NAME), result);
-            }
-            return result;
-        }
-        collectExecutionDirs(tenantId, scanRoot, result);
-        return result;
+
+        return new StoragePurgeResult(agg.scanned, agg.purgedExecutions.size(), agg.deletedFiles);
     }
 
     /**
-     * Recursive tenant-wide walk. At each level, probes {@code <child>/executions/} to distinguish flow dir (scan its
-     * executions/) from namespace level (recurse). Probing — instead of matching the literal name {@code "executions"}
-     * — avoids treating a sub-namespace segment or flow named {@code executions} as the executions terminal.
+     * Purges a single flow's executions in one storage call. The shallow listing of {@code executions/}
+     * before the purge call feeds the per-execution {@code scanned} counter so the caller can tell how
+     * much work was looked at vs deleted; backends that override {@link StorageInterface#purgeByLastModified}
+     * with a native primitive still benefit because the file-level walk happens inside the override.
      */
-    private void collectExecutionDirs(@Nullable String tenantId, URI dirUri, List<URI> out) throws IOException {
-        for (FileAttributes child : listAsAdminOrEmpty(tenantId, dirUri)) {
+    private void purgeFlow(@Nullable String tenantId, String namespace, String flowId,
+        @Nullable Instant startDate, @Nullable Instant endDate, boolean dryRun, Aggregator agg) throws IOException {
+        URI executionsPrefix = StorageContext.executionsRootUri(namespace, flowId);
+
+        for (FileAttributes child : safeList(tenantId, namespace, executionsPrefix)) {
+            if (child.getType() == FileAttributes.FileType.Directory) {
+                agg.scanned++;
+            }
+        }
+
+        List<URI> matched = storageInterface.purgeByLastModified(
+            tenantId, namespace, executionsPrefix, startDate, endDate, dryRun);
+        for (URI uri : matched) {
+            StorageContext.extractExecutionId(uri).ifPresent(agg.purgedExecutions::add);
+        }
+        if (!dryRun) {
+            agg.deletedFiles += matched.size();
+        }
+    }
+
+    /** Lists direct flow-dir children of {@code namespaceRoot} and purges each. Exact namespace, no recursion. */
+    private void purgeNamespace(@Nullable String tenantId, String namespace,
+        @Nullable Instant startDate, @Nullable Instant endDate, boolean dryRun, Aggregator agg) throws IOException {
+        URI namespaceRoot = StorageContext.namespaceRootUri(namespace);
+        for (FileAttributes child : safeList(tenantId, namespace, namespaceRoot)) {
+            if (!isFlowCandidate(child) || isAmbiguousFlowName(child.getFileName(), namespace)) {
+                continue;
+            }
+            purgeFlow(tenantId, namespace, child.getFileName(), startDate, endDate, dryRun, agg);
+        }
+    }
+
+    /**
+     * Recursive tenant-wide walk. As we descend, we accumulate the dotted namespace from path segments and
+     * thread it through {@link #safeList} so backends enforcing per-namespace isolation receive a valid
+     * scope; only the tenant-root listing itself uses {@code null} (no namespace candidate exists yet).
+     * <p>
+     * At each level we probe {@code <child>/executions/} to distinguish a flow dir (purge it) from a
+     * namespace segment (recurse). A directory literally named {@code executions} is ambiguous — could be
+     * a flow named "executions" or a sub-namespace named "executions" — so we recurse rather than purge
+     * to avoid orphaning legitimate sub-namespace flows; explicit {@code flowId} is needed to purge that.
+     */
+    private void walkNamespaceTree(@Nullable String tenantId, String currentNamespace, URI dirUri,
+        @Nullable Instant startDate, @Nullable Instant endDate, boolean dryRun, Aggregator agg) throws IOException {
+        String namespaceForList = currentNamespace.isEmpty() ? null : currentNamespace;
+        for (FileAttributes child : safeList(tenantId, namespaceForList, dirUri)) {
             if (!isFlowCandidate(child)) {
                 continue;
             }
-            URI childUri = resolveChildDir(dirUri, child.getFileName());
-            URI executionsSubdir = resolveChildDir(childUri, StorageContext.EXECUTIONS_DIR_NAME);
-            List<FileAttributes> executionDirs = listAsAdminOrEmpty(tenantId, executionsSubdir);
-            // Ambiguous-name case (child literally "executions"): recurse rather than skip — skipping would silently
-            // orphan a legitimate sub-namespace's flows under it, while recursing still reaches them at a deeper
-            // level where the parent-name ambiguity no longer applies.
-            if (executionDirs.isEmpty() || isAmbiguousFlowName(child.getFileName(), null)) {
-                collectExecutionDirs(tenantId, childUri, out);
-            } else {
-                for (FileAttributes executionDir : executionDirs) {
-                    if (executionDir.getType() == FileAttributes.FileType.Directory) {
-                        out.add(resolveChild(executionsSubdir, executionDir.getFileName()));
-                    }
-                }
+            String childName = child.getFileName();
+            URI childUri = URI.create(dirUri + childName + "/");
+            URI executionsSubdir = URI.create(childUri + StorageContext.EXECUTIONS_DIR_NAME + "/");
+            List<FileAttributes> executionDirs = safeList(tenantId, namespaceForList, executionsSubdir);
+
+            if (executionDirs.isEmpty() || isAmbiguousFlowName(childName, null)) {
+                String nextNamespace = currentNamespace.isEmpty() ? childName : currentNamespace + "." + childName;
+                walkNamespaceTree(tenantId, nextNamespace, childUri, startDate, endDate, dryRun, agg);
+            } else if (!currentNamespace.isEmpty()) {
+                // Kestra always stores flows under a namespace, so a flow-shaped dir at tenant root is malformed.
+                purgeFlow(tenantId, currentNamespace, childName, startDate, endDate, dryRun, agg);
             }
         }
-    }
-
-    /** Adds direct subdirectories of {@code dirUri} to {@code out} as slash-less URIs (deleteByPrefix-shaped). */
-    private void addChildDirs(@Nullable String tenantId, URI dirUri, List<URI> out) throws IOException {
-        for (FileAttributes child : listAsAdminOrEmpty(tenantId, dirUri)) {
-            if (child.getType() == FileAttributes.FileType.Directory) {
-                out.add(resolveChild(dirUri, child.getFileName()));
-            }
-        }
-    }
-
-    /**
-     * Newest file mtime under {@code prefix}, or empty if no files. Listing errors are isolated via
-     * {@link #listAsAdminOrEmpty}, so a transient failure deep in a subtree yields "no files found" rather than
-     * aborting the whole recursion.
-     */
-    private OptionalLong lastModifiedFileTime(@Nullable String tenantId, URI prefix) {
-        long max = Long.MIN_VALUE;
-        boolean found = false;
-
-        for (FileAttributes child : listAsAdminOrEmpty(tenantId, prefix)) {
-            if (child.getType() == FileAttributes.FileType.Directory) {
-                OptionalLong sub = lastModifiedFileTime(tenantId, resolveChild(prefix, child.getFileName()));
-                if (sub.isPresent()) {
-                    max = Math.max(max, sub.getAsLong());
-                    found = true;
-                }
-            } else {
-                max = Math.max(max, child.getLastModifiedTime());
-                found = true;
-            }
-        }
-
-        return found ? OptionalLong.of(max) : OptionalLong.empty();
     }
 
     private static boolean isFlowCandidate(FileAttributes attrs) {
@@ -184,9 +154,9 @@ public class StoragePurgeService {
     }
 
     /**
-     * True when a child name collides with the {@code executions/} path segment. Storage cannot distinguish a flow
-     * named {@code executions} from a sub-namespace whose last segment is {@code executions}, so namespace-scoped
-     * scans skip the ambiguous name and require explicit {@code flowId} to act on it.
+     * True when a child name collides with the {@code executions/} path segment. Storage cannot distinguish
+     * a flow named {@code executions} from a sub-namespace whose last segment is {@code executions}, so
+     * namespace-scoped scans skip the ambiguous name and require explicit {@code flowId} to act on it.
      */
     private boolean isAmbiguousFlowName(String childName, @Nullable String namespace) {
         if (!StorageContext.EXECUTIONS_DIR_NAME.equals(childName)) {
@@ -197,28 +167,14 @@ public class StoragePurgeService {
         return true;
     }
 
-    private static URI resolveChild(URI parent, String name) {
-        String base = parent.toString();
-        return URI.create(base.endsWith("/") ? base + name : base + "/" + name);
-    }
-
-    private static URI resolveChildDir(URI parent, String name) {
-        return URI.create(resolveChild(parent, name) + "/");
-    }
-
     /**
-     * Lists {@code uri} returning empty on missing paths and on any I/O error (logged at WARN). Passes {@code null}
-     * as the namespace to the backend: the task already validated ACL on the target namespace at entry, and threading
-     * the namespace through here would only shrink results on EE backends that filter list output by namespace.
-     * <p>
-     * <strong>Must remain {@code private}.</strong> This is an admin-grade listing primitive whose safety depends on
-     * the caller having performed the ACL check at the entry point. Exposing it package-private or higher would let a
-     * caller that hasn't validated namespace access enumerate any tenant's storage, silently bypassing namespace
-     * isolation.
+     * Lists {@code uri} returning empty on missing paths and on any I/O error (logged at WARN). The
+     * {@code namespace} is threaded through so backends enforcing per-namespace isolation (e.g. dedicated
+     * storage) receive the correct scope; only the very top of a tenant-wide walk passes {@code null}.
      */
-    private List<FileAttributes> listAsAdminOrEmpty(@Nullable String tenantId, URI uri) {
+    private List<FileAttributes> safeList(@Nullable String tenantId, @Nullable String namespace, URI uri) {
         try {
-            return storageInterface.list(tenantId, null, uri);
+            return storageInterface.list(tenantId, namespace, uri);
         } catch (FileNotFoundException | NoSuchFileException e) {
             return List.of();
         } catch (IOException e) {
@@ -228,16 +184,15 @@ public class StoragePurgeService {
     }
 
     /**
-     * Result of a {@link #purgeByLastModified} run. Mirrors {@link ExecutionLogService.PurgeResult}.
+     * Result of a {@link #purgeByLastModified} run. {@code purgedCount} counts distinct execution IDs that
+     * had at least one file in the window (or would in dry-run mode); {@code deletedFilesCount} is the
+     * raw file count (always 0 in dry-run).
      */
-    public record StoragePurgeResult(int scannedCount, int deletedFilesCount, List<URI> purgedUris) {
-        public StoragePurgeResult {
-            // Tolerate null (e.g. partial Jackson payload) since List.copyOf(null) would NPE.
-            purgedUris = purgedUris == null ? List.of() : List.copyOf(purgedUris);
-        }
+    public record StoragePurgeResult(int scannedCount, int purgedCount, int deletedFilesCount) { }
 
-        public int purgedCount() {
-            return purgedUris.size();
-        }
+    private static final class Aggregator {
+        int scanned;
+        int deletedFiles;
+        final Set<String> purgedExecutions = new LinkedHashSet<>();
     }
 }

--- a/core/src/main/java/io/kestra/core/services/StoragePurgeService.java
+++ b/core/src/main/java/io/kestra/core/services/StoragePurgeService.java
@@ -1,0 +1,243 @@
+package io.kestra.core.services;
+
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.net.URI;
+import java.nio.file.NoSuchFileException;
+import java.time.ZonedDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.OptionalLong;
+
+import io.kestra.core.storages.FileAttributes;
+import io.kestra.core.storages.StorageContext;
+import io.kestra.core.storages.StorageInterface;
+
+import io.micronaut.core.annotation.Nullable;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Storage-layer maintenance for orphaned execution files. Mirrors {@link ExecutionLogService} for logs: walks
+ * storage without consulting any repository, so it can reclaim files of flows that no longer exist — including the
+ * post-isolated-worker-group case in <a href="https://github.com/kestra-io/kestra-ee/issues/6699">kestra-ee#6699</a>.
+ */
+@Singleton
+@Slf4j
+public class StoragePurgeService {
+    private final StorageInterface storageInterface;
+
+    @Inject
+    public StoragePurgeService(StorageInterface storageInterface) {
+        this.storageInterface = storageInterface;
+    }
+
+    /**
+     * Purges {@code executions/{id}/} subtrees whose newest contained file falls within {@code [startDate, endDate]}.
+     * Namespace matching is exact: {@code namespace=a.b} does not reach {@code a.b.c} (purge that explicitly).
+     *
+     * @param tenantId  tenant identifier; {@code null} only meaningful for backends that don't enforce tenancy
+     * @param namespace exact namespace; {@code null} = every namespace under the tenant
+     * @param flowId    restrict to a single flow (requires {@code namespace})
+     * @param startDate lower bound on newest-file mtime (nullable)
+     * @param endDate   upper bound on newest-file mtime; also the in-flight guard (nullable)
+     * @param dryRun    when {@code true}, match but delete nothing
+     */
+    public StoragePurgeResult purgeByLastModified(
+        @Nullable String tenantId,
+        @Nullable String namespace,
+        @Nullable String flowId,
+        @Nullable ZonedDateTime startDate,
+        @Nullable ZonedDateTime endDate,
+        boolean dryRun
+    ) throws IOException {
+        if (flowId != null && namespace == null) {
+            throw new IllegalArgumentException("'namespace' is required when 'flowId' is set.");
+        }
+
+        Long startMillis = startDate == null ? null : startDate.toInstant().toEpochMilli();
+        Long endMillis = endDate == null ? null : endDate.toInstant().toEpochMilli();
+
+        int scanned = 0;
+        int deletedFiles = 0;
+        List<URI> purgedUris = new ArrayList<>();
+
+        for (URI executionUri : findExecutionDirs(tenantId, namespace, flowId)) {
+            scanned++;
+            try {
+                // Use newest contained file, not the dir's own timestamp: directory timestamps are virtual on object
+                // stores and don't advance on nested writes on a local fs. Also naturally preserves in-flight runs.
+                OptionalLong lastModified = lastModifiedFileTime(tenantId, executionUri);
+                if (lastModified.isEmpty()
+                    || (startMillis != null && lastModified.getAsLong() < startMillis)
+                    || (endMillis != null && lastModified.getAsLong() > endMillis)) {
+                    continue;
+                }
+
+                if (!dryRun) {
+                    // Delete first, record after — failed deletes don't end up in purgedUris.
+                    deletedFiles += storageInterface.deleteByPrefix(tenantId, null, executionUri).size();
+                }
+                purgedUris.add(executionUri);
+            } catch (Exception e) {
+                // Per-execution isolation: one bad subtree must not abort the rest.
+                log.warn("Failed to purge storage at '{}'; skipping it.", executionUri, e);
+            }
+        }
+
+        return new StoragePurgeResult(scanned, deletedFiles, List.copyOf(purgedUris));
+    }
+
+    /**
+     * Resolves the {@code executions/{id}/} directories to scan by walking storage directly:
+     * {@code namespace+flowId} → one flow's executions; {@code namespace} only → its direct flow dirs (exact match,
+     * no sub-namespace recursion); neither → recursive tenant-wide walk (gated by {@code allowAllNamespaces}).
+     */
+    private List<URI> findExecutionDirs(@Nullable String tenantId, @Nullable String namespace, @Nullable String flowId) throws IOException {
+        List<URI> result = new ArrayList<>();
+        if (namespace != null && flowId != null) {
+            addChildDirs(tenantId, StorageContext.executionsRootUri(namespace, flowId), result);
+            return result;
+        }
+        URI scanRoot = namespace == null
+            ? URI.create(StorageContext.KESTRA_PROTOCOL + "/")
+            : StorageContext.namespaceRootUri(namespace);
+        if (namespace != null) {
+            for (FileAttributes flowCandidate : listAsAdminOrEmpty(tenantId, scanRoot)) {
+                if (!isFlowCandidate(flowCandidate) || isAmbiguousFlowName(flowCandidate.getFileName(), namespace)) {
+                    continue;
+                }
+                addChildDirs(tenantId, resolveChildDir(scanRoot, flowCandidate.getFileName() + "/" + StorageContext.EXECUTIONS_DIR_NAME), result);
+            }
+            return result;
+        }
+        collectExecutionDirs(tenantId, scanRoot, result);
+        return result;
+    }
+
+    /**
+     * Recursive tenant-wide walk. At each level, probes {@code <child>/executions/} to distinguish flow dir (scan its
+     * executions/) from namespace level (recurse). Probing — instead of matching the literal name {@code "executions"}
+     * — avoids treating a sub-namespace segment or flow named {@code executions} as the executions terminal.
+     */
+    private void collectExecutionDirs(@Nullable String tenantId, URI dirUri, List<URI> out) throws IOException {
+        for (FileAttributes child : listAsAdminOrEmpty(tenantId, dirUri)) {
+            if (!isFlowCandidate(child)) {
+                continue;
+            }
+            URI childUri = resolveChildDir(dirUri, child.getFileName());
+            URI executionsSubdir = resolveChildDir(childUri, StorageContext.EXECUTIONS_DIR_NAME);
+            List<FileAttributes> executionDirs = listAsAdminOrEmpty(tenantId, executionsSubdir);
+            // Ambiguous-name case (child literally "executions"): recurse rather than skip — skipping would silently
+            // orphan a legitimate sub-namespace's flows under it, while recursing still reaches them at a deeper
+            // level where the parent-name ambiguity no longer applies.
+            if (executionDirs.isEmpty() || isAmbiguousFlowName(child.getFileName(), null)) {
+                collectExecutionDirs(tenantId, childUri, out);
+            } else {
+                for (FileAttributes executionDir : executionDirs) {
+                    if (executionDir.getType() == FileAttributes.FileType.Directory) {
+                        out.add(resolveChild(executionsSubdir, executionDir.getFileName()));
+                    }
+                }
+            }
+        }
+    }
+
+    /** Adds direct subdirectories of {@code dirUri} to {@code out} as slash-less URIs (deleteByPrefix-shaped). */
+    private void addChildDirs(@Nullable String tenantId, URI dirUri, List<URI> out) throws IOException {
+        for (FileAttributes child : listAsAdminOrEmpty(tenantId, dirUri)) {
+            if (child.getType() == FileAttributes.FileType.Directory) {
+                out.add(resolveChild(dirUri, child.getFileName()));
+            }
+        }
+    }
+
+    /**
+     * Newest file mtime under {@code prefix}, or empty if no files. Listing errors are isolated via
+     * {@link #listAsAdminOrEmpty}, so a transient failure deep in a subtree yields "no files found" rather than
+     * aborting the whole recursion.
+     */
+    private OptionalLong lastModifiedFileTime(@Nullable String tenantId, URI prefix) {
+        long max = Long.MIN_VALUE;
+        boolean found = false;
+
+        for (FileAttributes child : listAsAdminOrEmpty(tenantId, prefix)) {
+            if (child.getType() == FileAttributes.FileType.Directory) {
+                OptionalLong sub = lastModifiedFileTime(tenantId, resolveChild(prefix, child.getFileName()));
+                if (sub.isPresent()) {
+                    max = Math.max(max, sub.getAsLong());
+                    found = true;
+                }
+            } else {
+                max = Math.max(max, child.getLastModifiedTime());
+                found = true;
+            }
+        }
+
+        return found ? OptionalLong.of(max) : OptionalLong.empty();
+    }
+
+    private static boolean isFlowCandidate(FileAttributes attrs) {
+        return attrs.getType() == FileAttributes.FileType.Directory
+            && !attrs.getFileName().startsWith(StorageContext.RESERVED_NAMESPACE_DIR_PREFIX);
+    }
+
+    /**
+     * True when a child name collides with the {@code executions/} path segment. Storage cannot distinguish a flow
+     * named {@code executions} from a sub-namespace whose last segment is {@code executions}, so namespace-scoped
+     * scans skip the ambiguous name and require explicit {@code flowId} to act on it.
+     */
+    private boolean isAmbiguousFlowName(String childName, @Nullable String namespace) {
+        if (!StorageContext.EXECUTIONS_DIR_NAME.equals(childName)) {
+            return false;
+        }
+        log.warn("Skipping ambiguous flow/sub-namespace path segment '{}' under namespace '{}'; target the flow explicitly via 'flowId' to purge it.",
+            childName, namespace);
+        return true;
+    }
+
+    private static URI resolveChild(URI parent, String name) {
+        String base = parent.toString();
+        return URI.create(base.endsWith("/") ? base + name : base + "/" + name);
+    }
+
+    private static URI resolveChildDir(URI parent, String name) {
+        return URI.create(resolveChild(parent, name) + "/");
+    }
+
+    /**
+     * Lists {@code uri} returning empty on missing paths and on any I/O error (logged at WARN). Passes {@code null}
+     * as the namespace to the backend: the task already validated ACL on the target namespace at entry, and threading
+     * the namespace through here would only shrink results on EE backends that filter list output by namespace.
+     * <p>
+     * <strong>Must remain {@code private}.</strong> This is an admin-grade listing primitive whose safety depends on
+     * the caller having performed the ACL check at the entry point. Exposing it package-private or higher would let a
+     * caller that hasn't validated namespace access enumerate any tenant's storage, silently bypassing namespace
+     * isolation.
+     */
+    private List<FileAttributes> listAsAdminOrEmpty(@Nullable String tenantId, URI uri) {
+        try {
+            return storageInterface.list(tenantId, null, uri);
+        } catch (FileNotFoundException | NoSuchFileException e) {
+            return List.of();
+        } catch (IOException e) {
+            log.warn("Failed to list storage at '{}'; skipping this subtree.", uri, e);
+            return List.of();
+        }
+    }
+
+    /**
+     * Result of a {@link #purgeByLastModified} run. Mirrors {@link ExecutionLogService.PurgeResult}.
+     */
+    public record StoragePurgeResult(int scannedCount, int deletedFilesCount, List<URI> purgedUris) {
+        public StoragePurgeResult {
+            // Tolerate null (e.g. partial Jackson payload) since List.copyOf(null) would NPE.
+            purgedUris = purgedUris == null ? List.of() : List.copyOf(purgedUris);
+        }
+
+        public int purgedCount() {
+            return purgedUris.size();
+        }
+    }
+}

--- a/core/src/main/java/io/kestra/core/storages/StorageContext.java
+++ b/core/src/main/java/io/kestra/core/storages/StorageContext.java
@@ -18,6 +18,7 @@ import io.kestra.core.utils.Hashing;
 import io.kestra.core.utils.Slugify;
 
 import jakarta.annotation.Nullable;
+import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 
 /**
@@ -57,29 +58,23 @@ public class StorageContext {
 
     /**
      * {@code kestra:///<namespace-as-path>/} — namespace root, flow dirs as direct children.
-     *
-     * @throws NullPointerException if {@code namespace} is {@code null}
      */
-    public static URI namespaceRootUri(String namespace) {
+    public static URI namespaceRootUri(@NotNull String namespace) {
         return URI.create(KESTRA_PROTOCOL + "/" + namespaceAsPath(namespace) + "/");
     }
 
     /**
      * {@code kestra:///<namespace-as-path>/<flow-slug>/executions/} — a flow's executions subdir.
-     *
-     * @throws NullPointerException if {@code namespace} or {@code flowId} is {@code null}
      */
-    public static URI executionsRootUri(String namespace, String flowId) {
+    public static URI executionsRootUri(@NotNull String namespace, @NotNull String flowId) {
         Objects.requireNonNull(flowId, "flowId");
         return URI.create(KESTRA_PROTOCOL + "/" + namespaceAsPath(namespace) + "/" + Slugify.of(flowId) + "/" + EXECUTIONS_DIR_NAME + "/");
     }
 
     /**
      * Static counterpart of {@link #getNamespaceAsPath()}.
-     *
-     * @throws NullPointerException if {@code namespace} is {@code null}
      */
-    public static String namespaceAsPath(String namespace) {
+    public static String namespaceAsPath(@NotNull String namespace) {
         Objects.requireNonNull(namespace, "namespace");
         return namespace.replace(".", "/");
     }

--- a/core/src/main/java/io/kestra/core/storages/StorageContext.java
+++ b/core/src/main/java/io/kestra/core/storages/StorageContext.java
@@ -30,6 +30,12 @@ public class StorageContext {
     public static final String KESTRA_PROTOCOL = KESTRA_SCHEME + "://";
     public static final String PREFIX_MESSAGES = "/_messages";
 
+    /** Per-flow subdir that holds execution storage. */
+    public static final String EXECUTIONS_DIR_NAME = "executions";
+
+    /** Prefix of namespace-level metadata directories ({@code _files}, {@code _kv}, …). */
+    public static final String RESERVED_NAMESPACE_DIR_PREFIX = "_";
+
     // /{namespace}/_files
     static final String PREFIX_FORMAT_NAMESPACE_FILE = "/%s/_files";
     // /{namespace}/_kv
@@ -48,6 +54,35 @@ public class StorageContext {
     static final String PREFIX_FORMAT_CACHE_OBJECT = "/%s/%s/%s/cache/%s/cache.zip";
     // /{namespace}/{flow-id}/{cache-id}/cache/cache.zip
     static final String PREFIX_FORMAT_CACHE = "/%s/%s/%s/cache/cache.zip";
+
+    /**
+     * {@code kestra:///<namespace-as-path>/} — namespace root, flow dirs as direct children.
+     *
+     * @throws NullPointerException if {@code namespace} is {@code null}
+     */
+    public static URI namespaceRootUri(String namespace) {
+        return URI.create(KESTRA_PROTOCOL + "/" + namespaceAsPath(namespace) + "/");
+    }
+
+    /**
+     * {@code kestra:///<namespace-as-path>/<flow-slug>/executions/} — a flow's executions subdir.
+     *
+     * @throws NullPointerException if {@code namespace} or {@code flowId} is {@code null}
+     */
+    public static URI executionsRootUri(String namespace, String flowId) {
+        Objects.requireNonNull(flowId, "flowId");
+        return URI.create(KESTRA_PROTOCOL + "/" + namespaceAsPath(namespace) + "/" + Slugify.of(flowId) + "/" + EXECUTIONS_DIR_NAME + "/");
+    }
+
+    /**
+     * Static counterpart of {@link #getNamespaceAsPath()}.
+     *
+     * @throws NullPointerException if {@code namespace} is {@code null}
+     */
+    public static String namespaceAsPath(String namespace) {
+        Objects.requireNonNull(namespace, "namespace");
+        return namespace.replace(".", "/");
+    }
 
     /**
      * Factory method for constructing a new {@link StorageContext} scoped to a given {@link TaskRun}.

--- a/core/src/main/java/io/kestra/core/storages/StorageInterface.java
+++ b/core/src/main/java/io/kestra/core/storages/StorageInterface.java
@@ -10,6 +10,8 @@ import org.apache.commons.lang3.RandomStringUtils;
 import java.io.*;
 import java.net.URI;
 import java.nio.file.NoSuchFileException;
+import java.time.Instant;
+import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -299,6 +301,84 @@ public interface StorageInterface extends AutoCloseable, Plugin {
      */
     @Retryable(includes = { IOException.class })
     List<URI> deleteByPrefix(String tenantId, @Nullable String namespace, URI storagePrefix) throws IOException;
+
+    /**
+     * Deletes objects under {@code prefix} whose last-modified timestamp falls within the inclusive
+     * window {@code [startDate, endDate]}. The window bounds are both nullable: a {@code null} bound
+     * means "unbounded on that side."
+     *
+     * <p>Implementations are encouraged to override this method to use the native listing primitive
+     * of the underlying backend (e.g. {@code ListObjectsV2} on S3, {@code Bucket.list} on GCS) so
+     * that traversal cost scales with what the backend can natively filter or paginate over rather
+     * than the total object count. The default implementation walks the prefix using
+     * {@link #list(String, String, URI)} and {@link #delete(String, String, URI)}.
+     *
+     * <p>This is a maintenance primitive: callers must enforce authorization (namespace/tenant ACLs)
+     * before invoking it. The {@code namespace} parameter is threaded through to {@code list} and
+     * {@code delete} so that backends enforcing per-namespace isolation can apply it.
+     *
+     * @param tenantId  the tenant identifier
+     * @param namespace the namespace (may be {@code null} only for backends that do not enforce
+     *                  per-namespace isolation; passing {@code null} on an enforcing backend will
+     *                  yield empty results or an error from {@link #list})
+     * @param prefix    the URI prefix to scan
+     * @param startDate inclusive lower bound on last-modified time; {@code null} = unbounded
+     * @param endDate   inclusive upper bound on last-modified time; {@code null} = unbounded
+     * @param dryRun    when {@code true}, returns the URIs that would be deleted without deleting
+     * @return the URIs that were deleted (or would be deleted in dry-run mode)
+     * @throws IOException if listing or deletion fails
+     */
+    @Retryable(includes = { IOException.class })
+    default List<URI> purgeByLastModified(
+        String tenantId,
+        @Nullable String namespace,
+        URI prefix,
+        @Nullable Instant startDate,
+        @Nullable Instant endDate,
+        boolean dryRun
+    ) throws IOException {
+        Long startMillis = startDate == null ? null : startDate.toEpochMilli();
+        Long endMillis = endDate == null ? null : endDate.toEpochMilli();
+        List<URI> matched = new ArrayList<>();
+        collectFilesInWindow(tenantId, namespace, prefix, startMillis, endMillis, matched);
+        if (!dryRun) {
+            for (URI uri : matched) {
+                delete(tenantId, namespace, uri);
+            }
+        }
+        return matched;
+    }
+
+    /**
+     * Recursive helper for the default {@link #purgeByLastModified} implementation. Missing prefixes
+     * yield an empty result instead of an error: a non-existent prefix simply has nothing to purge.
+     */
+    private void collectFilesInWindow(
+        String tenantId,
+        @Nullable String namespace,
+        URI uri,
+        @Nullable Long startMillis,
+        @Nullable Long endMillis,
+        List<URI> out
+    ) throws IOException {
+        List<FileAttributes> children;
+        try {
+            children = list(tenantId, namespace, uri);
+        } catch (FileNotFoundException | NoSuchFileException e) {
+            return;
+        }
+        String base = uri.toString();
+        String parent = base.endsWith("/") ? base : base + "/";
+        for (FileAttributes child : children) {
+            URI childUri = URI.create(parent + child.getFileName());
+            if (child.getType() == FileAttributes.FileType.Directory) {
+                collectFilesInWindow(tenantId, namespace, URI.create(childUri + "/"), startMillis, endMillis, out);
+            } else if ((startMillis == null || child.getLastModifiedTime() >= startMillis)
+                && (endMillis == null || child.getLastModifiedTime() <= endMillis)) {
+                out.add(childUri);
+            }
+        }
+    }
 
     /**
      * Stores a file from a local File object into internal storage for an execution input.

--- a/core/src/main/java/io/kestra/plugin/core/storage/PurgeStorage.java
+++ b/core/src/main/java/io/kestra/plugin/core/storage/PurgeStorage.java
@@ -1,0 +1,177 @@
+package io.kestra.plugin.core.storage;
+
+import java.net.URI;
+import java.time.ZonedDateTime;
+import java.util.List;
+
+import io.kestra.core.models.annotations.Example;
+import io.kestra.core.models.annotations.Metric;
+import io.kestra.core.models.annotations.Plugin;
+import io.kestra.core.models.annotations.PluginProperty;
+import io.kestra.core.models.executions.metrics.Counter;
+import io.kestra.core.models.property.Property;
+import io.kestra.core.models.tasks.RunnableTask;
+import io.kestra.core.models.tasks.SystemTask;
+import io.kestra.core.models.tasks.Task;
+import io.kestra.core.runners.DefaultRunContext;
+import io.kestra.core.runners.RunContext;
+import io.kestra.core.services.StoragePurgeService;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import lombok.*;
+import lombok.experimental.SuperBuilder;
+
+@SuperBuilder
+@ToString
+@EqualsAndHashCode
+@Getter
+@NoArgsConstructor
+@Schema(
+    title = "Purge execution files from the internal storage by last-modified date.",
+    description = """
+        **Irreversible.** Always start with `dryRun: true` and review the `purgedUris` output before re-running with \
+        `dryRun: false`.
+
+        Walks storage directly (no flow repository) and deletes `executions/{id}/` subtrees whose newest file falls \
+        within `startDate`/`endDate`. Reclaims orphans left by flows that no longer exist — the primary use case. \
+        Unlike `PurgeExecutions` (DB-driven), this also remediates storage left after isolated worker-group purges.
+
+        `namespace` matching is exact (no sub-namespace recursion), aligned with the single-namespace ACL. To purge \
+        a sub-namespace, target it explicitly; omit `namespace` to walk every namespace under the tenant (requires \
+        `allowAllNamespaces`).
+
+        `endDate` is the safety bound and in-flight guard: set it to (or before) your `PurgeExecutions` retention.
+
+        Heavyweight: cost scales with stored objects. Scope with `namespace`/`flowId` and schedule off-peak."""
+)
+@Plugin(
+    examples = {
+        @Example(
+            title = "Delete execution storage files older than 7 days for a namespace.",
+            full = true,
+            code = """
+                id: purge_storage
+                namespace: system
+
+                tasks:
+                  - id: purge
+                    type: io.kestra.plugin.core.storage.PurgeStorage
+                    namespace: company.team
+                    endDate: "{{ now() | dateAdd(-7, 'DAYS') }}"
+                    dryRun: false
+                """
+        )
+    },
+    metrics = {
+        @Metric(name = "scanned", type = Counter.TYPE, description = "Number of execution storage subtrees scanned."),
+        @Metric(name = "purged", type = Counter.TYPE, description = "Number of execution storage subtrees matched (preview when `dryRun` is true)."),
+        @Metric(name = "deleted.files", type = Counter.TYPE, description = "Number of storage objects deleted (always 0 when `dryRun` is true).")
+    }
+)
+public class PurgeStorage extends Task implements RunnableTask<PurgeStorage.Output>, SystemTask {
+    @Schema(
+        title = "Namespace whose execution storage files should be purged",
+        description = "Exact match (no sub-namespace recursion). Omit to walk every namespace under the tenant "
+            + "(requires `allowAllNamespaces`)."
+    )
+    @PluginProperty(group = "main")
+    private Property<String> namespace;
+
+    @Schema(
+        title = "The flow ID to be purged",
+        description = "Provide `namespace` as well if you want to scope to a single flow."
+    )
+    @PluginProperty(group = "main")
+    private Property<String> flowId;
+
+    @Schema(
+        title = "Only purge files last modified after this date."
+    )
+    @PluginProperty(group = "main")
+    private Property<String> startDate;
+
+    @Schema(
+        title = "Only purge files last modified before this date.",
+        description = "Acts as the safety bound and in-flight guard: set it to (or before) your `PurgeExecutions` "
+            + "retention window so only files of already-purged executions are deleted."
+    )
+    @NotNull
+    @PluginProperty(group = "main")
+    private Property<String> endDate;
+
+    @Schema(
+        title = "If true, only report what would be deleted without deleting anything."
+    )
+    @Builder.Default
+    @PluginProperty(group = "reliability")
+    private Property<Boolean> dryRun = Property.ofValue(true);
+
+    @Override
+    public PurgeStorage.Output run(RunContext runContext) throws Exception {
+        StoragePurgeService storagePurgeService = ((DefaultRunContext) runContext).services().additionalService(StoragePurgeService.class);
+
+        var flowInfo = runContext.flowInfo();
+        String rNamespace = runContext.render(this.namespace).as(String.class).orElse(null);
+        String rFlowId = runContext.render(this.flowId).as(String.class).orElse(null);
+        ZonedDateTime rStartDate = runContext.render(this.startDate).as(String.class).map(ZonedDateTime::parse).orElse(null);
+        ZonedDateTime rEndDate = ZonedDateTime.parse(runContext.render(this.endDate).as(String.class).orElseThrow());
+        boolean rDryRun = runContext.render(this.dryRun).as(Boolean.class).orElseThrow();
+
+        // Reject before the ACL check so the user sees the actual mistake, not an "all namespaces" denial.
+        if (rFlowId != null && rNamespace == null) {
+            throw new IllegalArgumentException("'namespace' is required when 'flowId' is set.");
+        }
+
+        if (rNamespace == null) {
+            runContext.acl().allowAllNamespaces().check();
+        } else if (!rNamespace.equals(flowInfo.namespace())) {
+            runContext.acl().allowNamespace(rNamespace).check();
+        }
+
+        runContext.logger().info(
+            "Starting PurgeStorage (dryRun={}) scope=[namespace={}, flowId={}] window=[{}, {}]",
+            rDryRun, rNamespace, rFlowId, rStartDate, rEndDate
+        );
+
+        StoragePurgeService.StoragePurgeResult result = storagePurgeService.purgeByLastModified(
+            flowInfo.tenantId(), rNamespace, rFlowId, rStartDate, rEndDate, rDryRun
+        );
+
+        runContext.logger().info(
+            "PurgeStorage complete (dryRun={}): scanned={}, purged={}, deletedFiles={}",
+            rDryRun, result.scannedCount(), result.purgedCount(), result.deletedFilesCount()
+        );
+
+        runContext.metric(Counter.of("scanned", result.scannedCount()));
+        runContext.metric(Counter.of("purged", result.purgedCount()));
+        runContext.metric(Counter.of("deleted.files", result.deletedFilesCount()));
+
+        return Output.builder()
+            .scannedCount(result.scannedCount())
+            .purgedCount(result.purgedCount())
+            .deletedFilesCount(result.deletedFilesCount())
+            .purgedUris(result.purgedUris())
+            .build();
+    }
+
+    @Builder
+    @Getter
+    public static class Output implements io.kestra.core.models.tasks.Output {
+        @Schema(title = "Number of execution storage subtrees scanned.")
+        private final int scannedCount;
+
+        @Schema(title = "Number of execution storage subtrees matched by the date window (always preserved when `dryRun` is true).")
+        private final int purgedCount;
+
+        @Schema(title = "Number of storage objects deleted, including intermediate directories (always 0 when `dryRun` is true).")
+        private final int deletedFilesCount;
+
+        @Schema(
+            title = "URIs of execution storage subtrees that were (or would be) purged.",
+            description = "One entry per matched execution. Populated for both `dryRun: true` (preview of what would "
+                + "be deleted) and `dryRun: false` (record of what was deleted)."
+        )
+        private final List<URI> purgedUris;
+    }
+}

--- a/core/src/main/java/io/kestra/plugin/core/storage/PurgeStorage.java
+++ b/core/src/main/java/io/kestra/plugin/core/storage/PurgeStorage.java
@@ -30,6 +30,9 @@ import lombok.experimental.SuperBuilder;
     description = """
         **Irreversible.** Always start with `dryRun: true` and review the counters before re-running with `dryRun: false`.
 
+        When using per-namespace dedicated storage (EE), this task must be configured for each namespace to be able to \
+        clean the dedicated storage.
+
         Deletes execution files whose last-modified timestamp falls between `startDate` and `endDate`. The primary use \
         case is reclaiming files left behind by flows that no longer exist — files that `PurgeExecutions` cannot reach \
         because there is no execution record to delete.

--- a/core/src/main/java/io/kestra/plugin/core/storage/PurgeStorage.java
+++ b/core/src/main/java/io/kestra/plugin/core/storage/PurgeStorage.java
@@ -34,8 +34,9 @@ import lombok.experimental.SuperBuilder;
         case is reclaiming files left behind by flows that no longer exist — files that `PurgeExecutions` cannot reach \
         because there is no execution record to delete.
 
-        `namespace` matching is exact: it does not reach sub-namespaces. Omit `namespace` to purge across every \
-        namespace under the tenant.
+        `namespace` matching is recursive: `namespace: io.kestra` also purges sub-namespaces such as \
+        `io.kestra.team`. Omit `namespace` to purge across every namespace under the tenant. A sub-namespace \
+        configured with its own dedicated storage is not reached by recursion — target it explicitly.
 
         Set `endDate` to (or before) your `PurgeExecutions` retention window so that only files belonging to \
         already-purged executions are deleted."""
@@ -67,7 +68,7 @@ import lombok.experimental.SuperBuilder;
 public class PurgeStorage extends Task implements RunnableTask<PurgeStorage.Output>, SystemTask {
     @Schema(
         title = "Namespace whose execution storage files should be purged.",
-        description = "Exact match: a sub-namespace is not affected. Omit to purge across every namespace under the tenant."
+        description = "Recursive: sub-namespaces are also purged (e.g. `io.kestra` reaches `io.kestra.team`), except sub-namespaces with their own dedicated storage, which must be targeted explicitly. Omit to purge across every namespace under the tenant."
     )
     @PluginProperty(group = "main")
     private Property<String> namespace;

--- a/core/src/main/java/io/kestra/plugin/core/storage/PurgeStorage.java
+++ b/core/src/main/java/io/kestra/plugin/core/storage/PurgeStorage.java
@@ -1,8 +1,6 @@
 package io.kestra.plugin.core.storage;
 
-import java.net.URI;
 import java.time.ZonedDateTime;
-import java.util.List;
 
 import io.kestra.core.models.annotations.Example;
 import io.kestra.core.models.annotations.Metric;
@@ -30,20 +28,17 @@ import lombok.experimental.SuperBuilder;
 @Schema(
     title = "Purge execution files from the internal storage by last-modified date.",
     description = """
-        **Irreversible.** Always start with `dryRun: true` and review the `purgedUris` output before re-running with \
-        `dryRun: false`.
+        **Irreversible.** Always start with `dryRun: true` and review the counters before re-running with `dryRun: false`.
 
-        Walks storage directly (no flow repository) and deletes `executions/{id}/` subtrees whose newest file falls \
-        within `startDate`/`endDate`. Reclaims orphans left by flows that no longer exist — the primary use case. \
-        Unlike `PurgeExecutions` (DB-driven), this also remediates storage left after isolated worker-group purges.
+        Deletes execution files whose last-modified timestamp falls between `startDate` and `endDate`. The primary use \
+        case is reclaiming files left behind by flows that no longer exist — files that `PurgeExecutions` cannot reach \
+        because there is no execution record to delete.
 
-        `namespace` matching is exact (no sub-namespace recursion), aligned with the single-namespace ACL. To purge \
-        a sub-namespace, target it explicitly; omit `namespace` to walk every namespace under the tenant (requires \
-        `allowAllNamespaces`).
+        `namespace` matching is exact: it does not reach sub-namespaces. Omit `namespace` to purge across every \
+        namespace under the tenant.
 
-        `endDate` is the safety bound and in-flight guard: set it to (or before) your `PurgeExecutions` retention.
-
-        Heavyweight: cost scales with stored objects. Scope with `namespace`/`flowId` and schedule off-peak."""
+        Set `endDate` to (or before) your `PurgeExecutions` retention window so that only files belonging to \
+        already-purged executions are deleted."""
 )
 @Plugin(
     examples = {
@@ -71,16 +66,15 @@ import lombok.experimental.SuperBuilder;
 )
 public class PurgeStorage extends Task implements RunnableTask<PurgeStorage.Output>, SystemTask {
     @Schema(
-        title = "Namespace whose execution storage files should be purged",
-        description = "Exact match (no sub-namespace recursion). Omit to walk every namespace under the tenant "
-            + "(requires `allowAllNamespaces`)."
+        title = "Namespace whose execution storage files should be purged.",
+        description = "Exact match: a sub-namespace is not affected. Omit to purge across every namespace under the tenant."
     )
     @PluginProperty(group = "main")
     private Property<String> namespace;
 
     @Schema(
-        title = "The flow ID to be purged",
-        description = "Provide `namespace` as well if you want to scope to a single flow."
+        title = "The flow ID to be purged.",
+        description = "Requires `namespace` to also be set."
     )
     @PluginProperty(group = "main")
     private Property<String> flowId;
@@ -93,8 +87,8 @@ public class PurgeStorage extends Task implements RunnableTask<PurgeStorage.Outp
 
     @Schema(
         title = "Only purge files last modified before this date.",
-        description = "Acts as the safety bound and in-flight guard: set it to (or before) your `PurgeExecutions` "
-            + "retention window so only files of already-purged executions are deleted."
+        description = "Set this to (or before) your `PurgeExecutions` retention window so only files of "
+            + "already-purged executions are deleted."
     )
     @NotNull
     @PluginProperty(group = "main")
@@ -151,7 +145,6 @@ public class PurgeStorage extends Task implements RunnableTask<PurgeStorage.Outp
             .scannedCount(result.scannedCount())
             .purgedCount(result.purgedCount())
             .deletedFilesCount(result.deletedFilesCount())
-            .purgedUris(result.purgedUris())
             .build();
     }
 
@@ -161,17 +154,10 @@ public class PurgeStorage extends Task implements RunnableTask<PurgeStorage.Outp
         @Schema(title = "Number of execution storage subtrees scanned.")
         private final int scannedCount;
 
-        @Schema(title = "Number of execution storage subtrees matched by the date window (always preserved when `dryRun` is true).")
+        @Schema(title = "Number of executions with at least one file in the date window (preserved when `dryRun` is true).")
         private final int purgedCount;
 
-        @Schema(title = "Number of storage objects deleted, including intermediate directories (always 0 when `dryRun` is true).")
+        @Schema(title = "Number of storage objects deleted (always 0 when `dryRun` is true).")
         private final int deletedFilesCount;
-
-        @Schema(
-            title = "URIs of execution storage subtrees that were (or would be) purged.",
-            description = "One entry per matched execution. Populated for both `dryRun: true` (preview of what would "
-                + "be deleted) and `dryRun: false` (record of what was deleted)."
-        )
-        private final List<URI> purgedUris;
     }
 }

--- a/core/src/test/java/io/kestra/core/tasks/test/SanityCheckTest.java
+++ b/core/src/test/java/io/kestra/core/tasks/test/SanityCheckTest.java
@@ -126,4 +126,11 @@ class SanityCheckTest {
     void qaIonBinary(Execution execution) {
         assertThat(execution.getState().getCurrent()).isEqualTo(State.Type.SUCCESS);
     }
+
+    @Test
+    @ExecuteFlow("sanity-checks/purge_storage.yaml")
+    void qaPurgeStorage(Execution execution) {
+        assertThat(execution.getTaskRunList()).hasSize(5);
+        assertThat(execution.getState().getCurrent()).isEqualTo(State.Type.SUCCESS);
+    }
 }

--- a/core/src/test/java/io/kestra/core/tasks/test/SanityCheckTest.java
+++ b/core/src/test/java/io/kestra/core/tasks/test/SanityCheckTest.java
@@ -14,7 +14,7 @@ import jakarta.inject.Inject;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@KestraTest(startRunner = true)
+@KestraTest(startRunner = true, startSystemWorker = true)
 class SanityCheckTest {
     @Inject
     private TaskOutputService taskOutputService;

--- a/core/src/test/java/io/kestra/plugin/core/storage/PurgeStorageTest.java
+++ b/core/src/test/java/io/kestra/plugin/core/storage/PurgeStorageTest.java
@@ -173,9 +173,9 @@ class PurgeStorageTest {
         assertThat(storageInterface.exists(MAIN_TENANT, namespace, fileUri)).isFalse();
     }
 
-    /** ACL boundary: namespace-scoped purge must not reach sub-namespaces (the ACL check at entry only validates the exact namespace). */
+    /** Namespace-scoped purge is recursive: it reaches sub-namespaces (e.g. {@code a.b} also purges {@code a.b.child}). */
     @Test
-    void shouldNotReachSubNamespacesWhenScopedByExactNamespace() throws Exception {
+    void shouldReachSubNamespacesWhenScopedByNamespace() throws Exception {
         String parentNamespace = uniqueNamespace();
         String childNamespace = parentNamespace + ".child";
         String parentFlowId = IdUtils.create();
@@ -192,10 +192,10 @@ class PurgeStorageTest {
             .build();
         var output = purge.run(runContext(parentFlowId, parentNamespace));
 
-        assertThat(output.getScannedCount()).isEqualTo(1);
-        assertThat(output.getPurgedCount()).isEqualTo(1);
+        assertThat(output.getScannedCount()).isEqualTo(2);
+        assertThat(output.getPurgedCount()).isEqualTo(2);
         assertThat(storageInterface.exists(MAIN_TENANT, parentNamespace, parentFile)).isFalse();
-        assertThat(storageInterface.exists(MAIN_TENANT, childNamespace, childFile)).isTrue();
+        assertThat(storageInterface.exists(MAIN_TENANT, childNamespace, childFile)).isFalse();
     }
 
     /** Storage path /<ns>/executions/ is ambiguous between a flow named "executions" and a sub-namespace literally named "executions"; namespace-only scope skips it and requires explicit flowId. */

--- a/core/src/test/java/io/kestra/plugin/core/storage/PurgeStorageTest.java
+++ b/core/src/test/java/io/kestra/plugin/core/storage/PurgeStorageTest.java
@@ -70,25 +70,13 @@ class PurgeStorageTest {
         assertThat(storageInterface.exists(MAIN_TENANT, namespace, fileUri)).isTrue();
     }
 
+    /**
+     * Matching is per-file: within one execution, files older than endDate are deleted, newer files stay.
+     * The user's endDate is the in-flight guard — this task targets orphans (no live executions), so the
+     * trade-off of dropping the legacy "newest-file" subtree-level semantic is intentional.
+     */
     @Test
-    void shouldOnlyPurgeExecutionsWithinTheDateWindow() throws Exception {
-        String namespace = uniqueNamespace();
-        String flowId = IdUtils.create();
-        createFlow(namespace, flowId);
-
-        var files = putOldAndNewExecutionFiles(namespace, flowId);
-
-        var output = purgeStorage(namespace, flowId, files.midPoint()).run(runContext(flowId, namespace));
-
-        assertThat(output.getScannedCount()).isEqualTo(2);
-        assertThat(output.getPurgedCount()).isEqualTo(1);
-        assertThat(storageInterface.exists(MAIN_TENANT, namespace, files.oldFile())).isFalse();
-        assertThat(storageInterface.exists(MAIN_TENANT, namespace, files.newFile())).isTrue();
-    }
-
-    /** Age must come from the newest file: a min-instead-of-max regression would wrongly purge a still-active execution. */
-    @Test
-    void shouldDecideExecutionAgeFromItsNewestFile() throws Exception {
+    void shouldMatchPerFileWithinAnExecution() throws Exception {
         String namespace = uniqueNamespace();
         String flowId = IdUtils.create();
         createFlow(namespace, flowId);
@@ -104,12 +92,26 @@ class PurgeStorageTest {
         assertThat(newMtime).isGreaterThan(oldMtime);
 
         ZonedDateTime endDate = Instant.ofEpochMilli((oldMtime + newMtime) / 2).atZone(ZoneOffset.UTC);
-        var output = purgeStorage(namespace, flowId, endDate).run(runContext(flowId, namespace));
+        purgeStorage(namespace, flowId, endDate).run(runContext(flowId, namespace));
 
-        assertThat(output.getScannedCount()).isEqualTo(1);
-        assertThat(output.getPurgedCount()).isZero();
-        assertThat(storageInterface.exists(MAIN_TENANT, namespace, oldFile)).isTrue();
+        assertThat(storageInterface.exists(MAIN_TENANT, namespace, oldFile)).isFalse();
         assertThat(storageInterface.exists(MAIN_TENANT, namespace, newFile)).isTrue();
+    }
+
+    @Test
+    void shouldOnlyPurgeExecutionsWithinTheDateWindow() throws Exception {
+        String namespace = uniqueNamespace();
+        String flowId = IdUtils.create();
+        createFlow(namespace, flowId);
+
+        var files = putOldAndNewExecutionFiles(namespace, flowId);
+
+        var output = purgeStorage(namespace, flowId, files.midPoint()).run(runContext(flowId, namespace));
+
+        assertThat(output.getScannedCount()).isEqualTo(2);
+        assertThat(output.getPurgedCount()).isEqualTo(1);
+        assertThat(storageInterface.exists(MAIN_TENANT, namespace, files.oldFile())).isFalse();
+        assertThat(storageInterface.exists(MAIN_TENANT, namespace, files.newFile())).isTrue();
     }
 
     @Test
@@ -146,10 +148,6 @@ class PurgeStorageTest {
 
         assertThat(output.getPurgedCount()).isEqualTo(1);
         assertThat(output.getDeletedFilesCount()).isZero();
-        assertThat(output.getPurgedUris())
-            .hasSize(1)
-            .first()
-            .satisfies(uri -> assertThat(fileUri.getPath()).startsWith(uri.getPath()));
         assertThat(storageInterface.exists(MAIN_TENANT, namespace, fileUri)).isTrue();
     }
 

--- a/core/src/test/java/io/kestra/plugin/core/storage/PurgeStorageTest.java
+++ b/core/src/test/java/io/kestra/plugin/core/storage/PurgeStorageTest.java
@@ -1,0 +1,327 @@
+package io.kestra.plugin.core.storage;
+
+import java.io.ByteArrayInputStream;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import io.kestra.core.context.TestRunContextFactory;
+import io.kestra.core.junit.annotations.KestraTest;
+import io.kestra.core.models.executions.Execution;
+import io.kestra.core.models.flows.Flow;
+import io.kestra.core.models.flows.GenericFlow;
+import io.kestra.core.models.flows.State;
+import io.kestra.core.models.property.Property;
+import io.kestra.core.repositories.FlowRepositoryInterface;
+import io.kestra.core.runners.RunContext;
+import io.kestra.core.storages.StorageContext;
+import io.kestra.core.storages.StorageInterface;
+import io.kestra.core.utils.IdUtils;
+import io.kestra.plugin.core.debug.Return;
+
+import jakarta.inject.Inject;
+
+import static io.kestra.core.tenant.TenantService.MAIN_TENANT;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@KestraTest
+class PurgeStorageTest {
+    @Inject
+    private TestRunContextFactory runContextFactory;
+
+    @Inject
+    private StorageInterface storageInterface;
+
+    @Inject
+    private FlowRepositoryInterface flowRepository;
+
+    private final List<Flow> createdFlows = new ArrayList<>();
+
+    @AfterEach
+    void cleanUp() {
+        createdFlows.forEach(flowRepository::delete);
+        createdFlows.clear();
+    }
+
+    /** In-flight guard: files newer than endDate are preserved. */
+    @Test
+    void shouldPreserveExecutionFilesNewerThanEndDate() throws Exception {
+        String namespace = uniqueNamespace();
+        String flowId = IdUtils.create();
+        createFlow(namespace, flowId);
+
+        URI fileUri = putExecutionFile(namespace, flowId, "still running");
+        assertThat(storageInterface.exists(MAIN_TENANT, namespace, fileUri)).isTrue();
+
+        var output = purgeStorage(namespace, flowId, ZonedDateTime.now().minusMinutes(1)).run(runContext(flowId, namespace));
+
+        assertThat(output.getScannedCount()).isEqualTo(1);
+        assertThat(output.getPurgedCount()).isZero();
+        assertThat(output.getDeletedFilesCount()).isZero();
+        assertThat(storageInterface.exists(MAIN_TENANT, namespace, fileUri)).isTrue();
+    }
+
+    @Test
+    void shouldOnlyPurgeExecutionsWithinTheDateWindow() throws Exception {
+        String namespace = uniqueNamespace();
+        String flowId = IdUtils.create();
+        createFlow(namespace, flowId);
+
+        var files = putOldAndNewExecutionFiles(namespace, flowId);
+
+        var output = purgeStorage(namespace, flowId, files.midPoint()).run(runContext(flowId, namespace));
+
+        assertThat(output.getScannedCount()).isEqualTo(2);
+        assertThat(output.getPurgedCount()).isEqualTo(1);
+        assertThat(storageInterface.exists(MAIN_TENANT, namespace, files.oldFile())).isFalse();
+        assertThat(storageInterface.exists(MAIN_TENANT, namespace, files.newFile())).isTrue();
+    }
+
+    /** Age must come from the newest file: a min-instead-of-max regression would wrongly purge a still-active execution. */
+    @Test
+    void shouldDecideExecutionAgeFromItsNewestFile() throws Exception {
+        String namespace = uniqueNamespace();
+        String flowId = IdUtils.create();
+        createFlow(namespace, flowId);
+
+        Execution execution = newExecution(namespace, flowId);
+        URI oldFile = putFile(execution, "/tasks/task-a/run-1/old.txt", "old");
+        long oldMtime = lastModified(namespace, oldFile);
+
+        Thread.sleep(1_100);
+
+        URI newFile = putFile(execution, "/tasks/task-b/run-1/new.txt", "new");
+        long newMtime = lastModified(namespace, newFile);
+        assertThat(newMtime).isGreaterThan(oldMtime);
+
+        ZonedDateTime endDate = Instant.ofEpochMilli((oldMtime + newMtime) / 2).atZone(ZoneOffset.UTC);
+        var output = purgeStorage(namespace, flowId, endDate).run(runContext(flowId, namespace));
+
+        assertThat(output.getScannedCount()).isEqualTo(1);
+        assertThat(output.getPurgedCount()).isZero();
+        assertThat(storageInterface.exists(MAIN_TENANT, namespace, oldFile)).isTrue();
+        assertThat(storageInterface.exists(MAIN_TENANT, namespace, newFile)).isTrue();
+    }
+
+    @Test
+    void shouldNotPurgeExecutionsOlderThanStartDate() throws Exception {
+        String namespace = uniqueNamespace();
+        String flowId = IdUtils.create();
+        createFlow(namespace, flowId);
+
+        var files = putOldAndNewExecutionFiles(namespace, flowId);
+
+        var purge = PurgeStorage.builder()
+            .namespace(Property.ofValue(namespace))
+            .flowId(Property.ofValue(flowId))
+            .dryRun(Property.ofValue(false))
+            .startDate(Property.ofValue(files.midPoint().format(DateTimeFormatter.ISO_ZONED_DATE_TIME)))
+            .endDate(Property.ofValue(ZonedDateTime.now().plusMinutes(1).format(DateTimeFormatter.ISO_ZONED_DATE_TIME)))
+            .build();
+        var output = purge.run(runContext(flowId, namespace));
+
+        assertThat(output.getScannedCount()).isEqualTo(2);
+        assertThat(output.getPurgedCount()).isEqualTo(1);
+        assertThat(storageInterface.exists(MAIN_TENANT, namespace, files.oldFile())).isTrue();
+        assertThat(storageInterface.exists(MAIN_TENANT, namespace, files.newFile())).isFalse();
+    }
+
+    @Test
+    void shouldMatchButNotDeleteWhenDryRun() throws Exception {
+        String namespace = uniqueNamespace();
+        String flowId = IdUtils.create();
+        createFlow(namespace, flowId);
+        URI fileUri = putExecutionFile(namespace, flowId, "keep me");
+
+        var output = purgeStorage(namespace, flowId, ZonedDateTime.now().plusMinutes(1), true).run(runContext(flowId, namespace));
+
+        assertThat(output.getPurgedCount()).isEqualTo(1);
+        assertThat(output.getDeletedFilesCount()).isZero();
+        assertThat(output.getPurgedUris())
+            .hasSize(1)
+            .first()
+            .satisfies(uri -> assertThat(fileUri.getPath()).startsWith(uri.getPath()));
+        assertThat(storageInterface.exists(MAIN_TENANT, namespace, fileUri)).isTrue();
+    }
+
+    /** Regression for <a href="https://github.com/kestra-io/kestra-ee/issues/6699">kestra-ee#6699</a>: storage of deleted flows must be reachable from a namespace-only scan. */
+    @Test
+    void shouldFindOrphansOfDeletedFlowsWhenScopedByNamespaceOnly() throws Exception {
+        String namespace = uniqueNamespace();
+        String flowId = IdUtils.create();
+        createFlow(namespace, flowId);
+        URI fileUri = putExecutionFile(namespace, flowId, "orphan from deleted flow");
+        flowRepository.delete(createdFlows.removeLast());
+
+        var purge = PurgeStorage.builder()
+            .namespace(Property.ofValue(namespace))
+            .dryRun(Property.ofValue(false))
+            .endDate(Property.ofValue(ZonedDateTime.now().plusMinutes(1).format(DateTimeFormatter.ISO_ZONED_DATE_TIME)))
+            .build();
+        var output = purge.run(runContext(flowId, namespace));
+
+        assertThat(output.getScannedCount()).isEqualTo(1);
+        assertThat(output.getPurgedCount()).isEqualTo(1);
+        assertThat(output.getDeletedFilesCount()).isGreaterThanOrEqualTo(1);
+        assertThat(storageInterface.exists(MAIN_TENANT, namespace, fileUri)).isFalse();
+    }
+
+    /** ACL boundary: namespace-scoped purge must not reach sub-namespaces (the ACL check at entry only validates the exact namespace). */
+    @Test
+    void shouldNotReachSubNamespacesWhenScopedByExactNamespace() throws Exception {
+        String parentNamespace = uniqueNamespace();
+        String childNamespace = parentNamespace + ".child";
+        String parentFlowId = IdUtils.create();
+        String childFlowId = IdUtils.create();
+        createFlow(parentNamespace, parentFlowId);
+        createFlow(childNamespace, childFlowId);
+        URI parentFile = putExecutionFile(parentNamespace, parentFlowId, "in parent");
+        URI childFile = putExecutionFile(childNamespace, childFlowId, "in child");
+
+        var purge = PurgeStorage.builder()
+            .namespace(Property.ofValue(parentNamespace))
+            .dryRun(Property.ofValue(false))
+            .endDate(Property.ofValue(ZonedDateTime.now().plusMinutes(1).format(DateTimeFormatter.ISO_ZONED_DATE_TIME)))
+            .build();
+        var output = purge.run(runContext(parentFlowId, parentNamespace));
+
+        assertThat(output.getScannedCount()).isEqualTo(1);
+        assertThat(output.getPurgedCount()).isEqualTo(1);
+        assertThat(storageInterface.exists(MAIN_TENANT, parentNamespace, parentFile)).isFalse();
+        assertThat(storageInterface.exists(MAIN_TENANT, childNamespace, childFile)).isTrue();
+    }
+
+    /** Storage path /<ns>/executions/ is ambiguous between a flow named "executions" and a sub-namespace literally named "executions"; namespace-only scope skips it and requires explicit flowId. */
+    @Test
+    void shouldSkipAmbiguousExecutionsNameInNamespaceOnlyScan() throws Exception {
+        String namespace = uniqueNamespace();
+        String ambiguousFlowId = "executions";
+        createFlow(namespace, ambiguousFlowId);
+        URI fileUri = putExecutionFile(namespace, ambiguousFlowId, "may or may not be a flow");
+
+        var namespaceScope = PurgeStorage.builder()
+            .namespace(Property.ofValue(namespace))
+            .dryRun(Property.ofValue(false))
+            .endDate(Property.ofValue(ZonedDateTime.now().plusMinutes(1).format(DateTimeFormatter.ISO_ZONED_DATE_TIME)))
+            .build();
+        var namespaceOutput = namespaceScope.run(runContext(ambiguousFlowId, namespace));
+
+        assertThat(namespaceOutput.getScannedCount()).isZero();
+        assertThat(namespaceOutput.getPurgedCount()).isZero();
+        assertThat(storageInterface.exists(MAIN_TENANT, namespace, fileUri)).isTrue();
+
+        // Explicit flowId still works.
+        var explicitScope = PurgeStorage.builder()
+            .namespace(Property.ofValue(namespace))
+            .flowId(Property.ofValue(ambiguousFlowId))
+            .dryRun(Property.ofValue(false))
+            .endDate(Property.ofValue(ZonedDateTime.now().plusMinutes(1).format(DateTimeFormatter.ISO_ZONED_DATE_TIME)))
+            .build();
+        var explicitOutput = explicitScope.run(runContext(ambiguousFlowId, namespace));
+
+        assertThat(explicitOutput.getScannedCount()).isEqualTo(1);
+        assertThat(explicitOutput.getPurgedCount()).isEqualTo(1);
+        assertThat(storageInterface.exists(MAIN_TENANT, namespace, fileUri)).isFalse();
+    }
+
+    @Test
+    void shouldRequireNamespaceWhenFlowIdIsSet() {
+        var purge = PurgeStorage.builder()
+            .flowId(Property.ofValue("some-flow"))
+            .endDate(Property.ofValue(ZonedDateTime.now().format(DateTimeFormatter.ISO_ZONED_DATE_TIME)))
+            .build();
+
+        assertThatThrownBy(() -> purge.run(runContext("some-flow", "some.namespace")))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("namespace");
+    }
+
+    private void createFlow(String namespace, String flowId) {
+        Flow flow = Flow.builder()
+            .id(flowId)
+            .namespace(namespace)
+            .tenantId(MAIN_TENANT)
+            .tasks(List.of(Return.builder().id("return").type(Return.class.getName()).format(Property.ofValue("ok")).build()))
+            .build();
+        flowRepository.create(GenericFlow.of(flow));
+        createdFlows.add(flow);
+    }
+
+    private Execution newExecution(String namespace, String flowId) {
+        return Execution.builder()
+            .id(IdUtils.create())
+            .namespace(namespace)
+            .flowId(flowId)
+            .tenantId(MAIN_TENANT)
+            .state(new State().withState(State.Type.SUCCESS))
+            .build();
+    }
+
+    /** Writes one file under a fresh execution at {@code executions/{id}/tasks/my-task/my-run/output.txt}. */
+    private URI putExecutionFile(String namespace, String flowId, String content) throws Exception {
+        return putFile(newExecution(namespace, flowId), "/tasks/my-task/my-run/output.txt", content);
+    }
+
+    /** Writes two files ~1.1s apart so old/new mtimes are distinct on second-granularity filesystems. */
+    private OldNewFiles putOldAndNewExecutionFiles(String namespace, String flowId) throws Exception {
+        URI oldFile = putExecutionFile(namespace, flowId, "old");
+        long oldMtime = lastModified(namespace, oldFile);
+        Thread.sleep(1_100);
+        URI newFile = putExecutionFile(namespace, flowId, "new");
+        long newMtime = lastModified(namespace, newFile);
+        assertThat(newMtime).isGreaterThan(oldMtime);
+        return new OldNewFiles(oldFile, oldMtime, newFile, newMtime);
+    }
+
+    private URI putFile(Execution execution, String relativePath, String content) throws Exception {
+        URI fileUri = URI.create(StorageContext.forExecution(execution).getExecutionStorageURI() + relativePath);
+        storageInterface.put(
+            execution.getTenantId(),
+            execution.getNamespace(),
+            fileUri,
+            new ByteArrayInputStream(content.getBytes(StandardCharsets.UTF_8))
+        );
+        return fileUri;
+    }
+
+    private long lastModified(String namespace, URI fileUri) throws Exception {
+        return storageInterface.getAttributes(MAIN_TENANT, namespace, fileUri).getLastModifiedTime();
+    }
+
+    private PurgeStorage purgeStorage(String namespace, String flowId, ZonedDateTime endDate) {
+        return purgeStorage(namespace, flowId, endDate, false);
+    }
+
+    private PurgeStorage purgeStorage(String namespace, String flowId, ZonedDateTime endDate, boolean dryRun) {
+        return PurgeStorage.builder()
+            .namespace(Property.ofValue(namespace))
+            .flowId(Property.ofValue(flowId))
+            .dryRun(Property.ofValue(dryRun))
+            .endDate(Property.ofValue(endDate.format(DateTimeFormatter.ISO_ZONED_DATE_TIME)))
+            .build();
+    }
+
+    private RunContext runContext(String flowId, String namespace) {
+        return runContextFactory.of(flowId, namespace);
+    }
+
+    private static String uniqueNamespace() {
+        // Namespace segments must start with a letter; the id may start with a digit.
+        return "purgestorage.id" + IdUtils.create().toLowerCase();
+    }
+
+    private record OldNewFiles(URI oldFile, long oldMtime, URI newFile, long newMtime) {
+        ZonedDateTime midPoint() {
+            return Instant.ofEpochMilli((oldMtime + newMtime) / 2).atZone(ZoneOffset.UTC);
+        }
+    }
+}

--- a/core/src/test/resources/sanity-checks/purge_storage.yaml
+++ b/core/src/test/resources/sanity-checks/purge_storage.yaml
@@ -2,9 +2,8 @@ id: purge_storage
 namespace: sanitychecks.core
 description: |
   Sanity check for io.kestra.plugin.core.storage.PurgeStorage.
-  Phase 1: dryRun=true must preview the matched subtree without deleting (deletedFilesCount = 0,
-  purgedUris populated).
-  Phase 2: dryRun=false must actually delete (deletedFilesCount > 0, purgedUris populated).
+  Phase 1: dryRun=true must preview matches without deleting (deletedFilesCount = 0).
+  Phase 2: dryRun=false must actually delete (deletedFilesCount > 0).
 
 tasks:
   - id: write_marker
@@ -24,9 +23,8 @@ tasks:
     type: io.kestra.plugin.core.execution.Assert
     conditions:
       - "{{ outputs.purge_dry_run.scannedCount >= 1 }}"
-      - "{{ outputs.purge_dry_run.purgedCount == outputs.purge_dry_run.scannedCount }}"
+      - "{{ outputs.purge_dry_run.purgedCount >= 1 }}"
       - "{{ outputs.purge_dry_run.deletedFilesCount == 0 }}"
-      - "{{ outputs.purge_dry_run.purgedUris | length == outputs.purge_dry_run.purgedCount }}"
 
   - id: purge_real
     type: io.kestra.plugin.core.storage.PurgeStorage
@@ -39,6 +37,5 @@ tasks:
     type: io.kestra.plugin.core.execution.Assert
     conditions:
       - "{{ outputs.purge_real.scannedCount >= 1 }}"
-      - "{{ outputs.purge_real.purgedCount == outputs.purge_real.scannedCount }}"
+      - "{{ outputs.purge_real.purgedCount >= 1 }}"
       - "{{ outputs.purge_real.deletedFilesCount > 0 }}"
-      - "{{ outputs.purge_real.purgedUris | length == outputs.purge_real.purgedCount }}"

--- a/core/src/test/resources/sanity-checks/purge_storage.yaml
+++ b/core/src/test/resources/sanity-checks/purge_storage.yaml
@@ -1,0 +1,44 @@
+id: purge_storage
+namespace: sanitychecks.core
+description: |
+  Sanity check for io.kestra.plugin.core.storage.PurgeStorage.
+  Phase 1: dryRun=true must preview the matched subtree without deleting (deletedFilesCount = 0,
+  purgedUris populated).
+  Phase 2: dryRun=false must actually delete (deletedFilesCount > 0, purgedUris populated).
+
+tasks:
+  - id: write_marker
+    type: io.kestra.plugin.core.storage.Write
+    content: |
+      sanity-check marker
+    extension: .txt
+
+  - id: purge_dry_run
+    type: io.kestra.plugin.core.storage.PurgeStorage
+    namespace: sanitychecks.core
+    flowId: purge_storage
+    endDate: "{{ now() | dateAdd(1, 'DAYS') }}"
+    dryRun: true
+
+  - id: assert_dry_run_shape
+    type: io.kestra.plugin.core.execution.Assert
+    conditions:
+      - "{{ outputs.purge_dry_run.scannedCount >= 1 }}"
+      - "{{ outputs.purge_dry_run.purgedCount == outputs.purge_dry_run.scannedCount }}"
+      - "{{ outputs.purge_dry_run.deletedFilesCount == 0 }}"
+      - "{{ outputs.purge_dry_run.purgedUris | length == outputs.purge_dry_run.purgedCount }}"
+
+  - id: purge_real
+    type: io.kestra.plugin.core.storage.PurgeStorage
+    namespace: sanitychecks.core
+    flowId: purge_storage
+    endDate: "{{ now() | dateAdd(1, 'DAYS') }}"
+    dryRun: false
+
+  - id: assert_real_shape
+    type: io.kestra.plugin.core.execution.Assert
+    conditions:
+      - "{{ outputs.purge_real.scannedCount >= 1 }}"
+      - "{{ outputs.purge_real.purgedCount == outputs.purge_real.scannedCount }}"
+      - "{{ outputs.purge_real.deletedFilesCount > 0 }}"
+      - "{{ outputs.purge_real.purgedUris | length == outputs.purge_real.purgedCount }}"


### PR DESCRIPTION
closes https://github.com/kestra-io/kestra-ee/issues/6699

### QA done

- Checked that dry run mode is working (no deletion) :heavy_check_mark: 
- Checked that files are deleted after (checked on disk files are gone)  :heavy_check_mark: 
- Checked that namespace are used (no deletion outside of scope)  :heavy_check_mark: 

## Flow used : 

``` yaml
id: purge_storage
namespace: company.team

tasks:
  - id: purge
    type: io.kestra.plugin.core.storage.PurgeStorage
    namespace: company.team
    endDate: "{{ now() | dateAdd(-1, 'HOURS') }}"
    dryRun: false
````

## Missing QA

Didn't test on real environment with worker to reproduce customer use case