### PR TITLE
revert(tests): remove expectedState field from UnitTest

### DIFF
--- a/core/src/main/java/io/kestra/core/services/ExecutionStreamingService.java
+++ b/core/src/main/java/io/kestra/core/services/ExecutionStreamingService.java
@@ -108,16 +108,13 @@ public class ExecutionStreamingService {
     public void registerSubscriber(String executionId, String subscriberId, FluxSink<Event<Execution>> sink, Flow flow) {
         // it needs to be synchronized as we get and remove if empty, so we must be sure that nobody else is adding a new one in-between
         synchronized (subscriberLock) {
-            boolean wasEmpty = MapUtils.isEmpty(subscribers);
-
             // Register the subscriber BEFORE resuming the queue. If the queue is resumed first,
             // the polling thread can deliver a terminal FollowExecutionEvent between resume() and put(),
             // missing the event and leaving Flux.last() hanging forever.
             subscribers.computeIfAbsent(executionId, k -> new ConcurrentHashMap<>())
                 .put(subscriberId, Pair.of(sink, flow));
 
-            // resume the subscription if it was paused with no subscribers
-            if (wasEmpty && this.queueSubscriber.isPaused()) {
+            if (this.queueSubscriber.isPaused()) {
                 this.queueSubscriber.resume();
             }
         }

--- a/core/src/main/java/io/kestra/core/services/ExecutionStreamingService.java
+++ b/core/src/main/java/io/kestra/core/services/ExecutionStreamingService.java
@@ -108,13 +108,18 @@ public class ExecutionStreamingService {
     public void registerSubscriber(String executionId, String subscriberId, FluxSink<Event<Execution>> sink, Flow flow) {
         // it needs to be synchronized as we get and remove if empty, so we must be sure that nobody else is adding a new one in-between
         synchronized (subscriberLock) {
-            // resume the subscription if paused
-            if (MapUtils.isEmpty(subscribers) && this.queueSubscriber.isPaused()) {
-                this.queueSubscriber.resume();
-            }
+            boolean wasEmpty = MapUtils.isEmpty(subscribers);
 
+            // Register the subscriber BEFORE resuming the queue. If the queue is resumed first,
+            // the polling thread can deliver a terminal FollowExecutionEvent between resume() and put(),
+            // missing the event and leaving Flux.last() hanging forever.
             subscribers.computeIfAbsent(executionId, k -> new ConcurrentHashMap<>())
                 .put(subscriberId, Pair.of(sink, flow));
+
+            // resume the subscription if it was paused with no subscribers
+            if (wasEmpty && this.queueSubscriber.isPaused()) {
+                this.queueSubscriber.resume();
+            }
         }
     }
 

--- a/core/src/main/java/io/kestra/core/services/LogStreamingService.java
+++ b/core/src/main/java/io/kestra/core/services/LogStreamingService.java
@@ -81,13 +81,14 @@ public class LogStreamingService {
     public void registerSubscriber(String executionId, String subscriberId, FluxSink<Event<FollowLogEvent>> sink, List<String> levels) {
         // it needs to be synchronized as we get and remove if empty, so we must be sure that nobody else is adding a new one in-between
         synchronized (subscriberLock) {
-            // resume the subscription if paused
-            if (MapUtils.isEmpty(subscribers) && this.queueSubscriber.isPaused()) {
-                this.queueSubscriber.resume();
-            }
-
+            // Register the subscriber BEFORE resuming the queue to avoid a race where the polling
+            // thread delivers an event between resume() and put(), causing events to be dropped.
             subscribers.computeIfAbsent(executionId, k -> new ConcurrentHashMap<>())
                 .put(subscriberId, Pair.of(sink, levels));
+
+            if (this.queueSubscriber.isPaused()) {
+                this.queueSubscriber.resume();
+            }
         }
     }
 

--- a/core/src/main/java/io/kestra/core/test/flow/UnitTest.java
+++ b/core/src/main/java/io/kestra/core/test/flow/UnitTest.java
@@ -2,7 +2,6 @@ package io.kestra.core.test.flow;
 
 import java.util.List;
 
-import io.kestra.core.models.flows.State;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
@@ -30,8 +29,6 @@ public class UnitTest {
 
     @Valid
     private Fixtures fixtures;
-
-    private State.Type expectedState;
 
     @NotNull
     @Valid

--- a/core/src/main/java/io/kestra/core/test/flow/UnitTest.java
+++ b/core/src/main/java/io/kestra/core/test/flow/UnitTest.java
@@ -2,6 +2,7 @@ package io.kestra.core.test.flow;
 
 import java.util.List;
 
+import io.kestra.core.models.flows.State;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
@@ -29,6 +30,8 @@ public class UnitTest {
 
     @Valid
     private Fixtures fixtures;
+
+    private State.Type expectedState;
 
     @NotNull
     @Valid

--- a/webserver/src/main/java/io/kestra/webserver/services/ExecutionDependenciesStreamingService.java
+++ b/webserver/src/main/java/io/kestra/webserver/services/ExecutionDependenciesStreamingService.java
@@ -125,13 +125,14 @@ public class ExecutionDependenciesStreamingService {
     public void registerSubscriber(String correlationId, String subscriberId, Subscriber consumer) {
         // it needs to be synchronized as we get and remove if empty, so we must be sure that nobody else is adding a new one in-between
         synchronized (subscriberLock) {
-            // resume the subscription if paused
-            if (MapUtils.isEmpty(subscribers) && this.queueSubscriber.isPaused()) {
-                this.queueSubscriber.resume();
-            }
-
+            // Register the subscriber BEFORE resuming the queue to avoid a race where the polling
+            // thread delivers an event between resume() and put(), causing events to be dropped.
             subscribers.computeIfAbsent(correlationId, k -> new ConcurrentHashMap<>())
                 .put(subscriberId, consumer);
+
+            if (this.queueSubscriber.isPaused()) {
+                this.queueSubscriber.resume();
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

Reverts the `expectedState` field that was tentatively added to `UnitTest`. No new field is needed.

Users who want to assert on execution state use the standard `assertions` list:

```yaml
assertions:
  - value: "{{ execution.state }}"
    equalTo: "FAILED"
```

`{{ execution.state }}` is already a first-class variable in `RunContext` (whitelisted in `RunVariables.java`).

## Companion PR

kestra-io/kestra-ee#8089 — removes the implicit state check from `TestSuiteService` and adds a test for the `{{ execution.state }}` assertion pattern.