### PR TITLE
fix(build): use DOCKERHUB_TOKEN and GHA cache in base image workflow

### DIFF
--- a/.github/workflows/global-push-base-image.yml
+++ b/.github/workflows/global-push-base-image.yml
@@ -31,7 +31,7 @@ jobs:
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Build and push
         uses: docker/build-push-action@v6
@@ -42,8 +42,8 @@ jobs:
           tags: kestra/kestra-base:latest
           build-args: |
             UV_VERSION=${{ inputs.uv-version || '0.6.17' }}
-          cache-from: type=registry,ref=kestra/kestra-base:latest
-          cache-to: type=inline
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
       - name: Slack - Notification
         if: ${{ failure() }}


### PR DESCRIPTION
## Summary

The `global-push-base-image` workflow was failing with two auth errors:

1. **Cache pull error**: `pull access denied, repository does not exist or may require authorization: server message: insufficient_scope: authorization failed`  
   — `kestra/kestra-base` doesn't exist yet on first run, and `DOCKERHUB_PASSWORD` doesn't have pull scope for it.

2. **Push error**: `access token has insufficient scopes`  
   — `DOCKERHUB_PASSWORD` is an org access token scoped specifically to `kestra/kestra`, so it cannot push to the new `kestra/kestra-base` repository.

## Fix

- Switch from `DOCKERHUB_PASSWORD` to `DOCKERHUB_TOKEN` for Docker Hub login — this token has org-wide scope and is already used for Docker Hub auth in the EE publish workflow.
- Switch cache from `type=registry` (which tries to pull `kestra/kestra-base:latest` — non-existent on first run) to `type=gha` (GitHub Actions cache), matching the pattern in `kestra-oss-publish-docker.yml`.

## Test plan

- [ ] Re-run `global-push-base-image` workflow in dry-run mode to verify the build completes without auth errors
- [ ] Run a non-dry-run to confirm the push to Docker Hub succeeds