### PR TITLE
test(build): verify assembleFrontend task graph ordering with Gradle TestKit

### DIFF
--- a/tests/build.gradle
+++ b/tests/build.gradle
@@ -18,4 +18,9 @@ dependencies {
     api 'org.assertj:assertj-core:3.27.7'
 
     testImplementation "com.tngtech.archunit:archunit-junit5"
+    testImplementation gradleTestKit()
+}
+
+tasks.withType(Test).configureEach {
+    systemProperty 'rootProjectDir', rootProject.projectDir.absolutePath
 }

--- a/tests/src/test/java/io/kestra/tests/gradle/BuildTaskGraphTest.java
+++ b/tests/src/test/java/io/kestra/tests/gradle/BuildTaskGraphTest.java
@@ -1,0 +1,76 @@
+package io.kestra.tests.gradle;
+
+import org.gradle.testkit.runner.BuildResult;
+import org.gradle.testkit.runner.GradleRunner;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Verifies that the assembleFrontend task is correctly wired in the Gradle task graph:
+ * - included and ordered before webserver:processResources when building the final JAR
+ * - excluded from the check/test graph to avoid a costly npm build on every compile cycle
+ */
+class BuildTaskGraphTest {
+
+    private static final Path ROOT_PROJECT_DIR =
+        Paths.get(System.getProperty("rootProjectDir"));
+
+    @Test
+    void shouldRunAssembleFrontendBeforeWebserverProcessResourcesWhenBuildingJar() {
+        // Given / When
+        BuildResult result = GradleRunner.create()
+            .withProjectDir(ROOT_PROJECT_DIR.toFile())
+            .withArguments("shadowJar", "--dry-run")
+            .build();
+
+        List<String> tasks = parseDryRunTasks(result.getOutput());
+
+        // Then
+        assertThat(tasks)
+            .as("Both assembleFrontend and webserver:processResources must be in the shadowJar task graph")
+            .contains(":ui:assembleFrontend", ":webserver:processResources");
+
+        assertThat(tasks.indexOf(":ui:assembleFrontend"))
+            .as("assembleFrontend must precede webserver:processResources — " +
+                "the built UI files are written to webserver/src/main/resources/ui and must " +
+                "be present when processResources copies them into the build output")
+            .isLessThan(tasks.indexOf(":webserver:processResources"));
+    }
+
+    // Enable once https://github.com/kestra-io/kestra/pull/16304 is merged.
+    // On develop, processResources uses dependsOn(':ui:assembleFrontend') which pulls
+    // assembleFrontend into every compile/test task graph. The fix switches to mustRunAfter
+    // so assembleFrontend is only triggered when shadowJar (or executableJar) is requested.
+    @Disabled
+    @Test
+    void shouldNotRunAssembleFrontendWhenRunningCheck() {
+        // Given / When
+        BuildResult result = GradleRunner.create()
+            .withProjectDir(ROOT_PROJECT_DIR.toFile())
+            .withArguments(":webserver:check", "--dry-run")
+            .build();
+
+        // Then
+        assertThat(result.getOutput())
+            .as("assembleFrontend must not be triggered by check — " +
+                "it would force an expensive npm build on every compile/test cycle")
+            .doesNotContain(":ui:assembleFrontend");
+    }
+
+    /** Extracts ordered task names from Gradle --dry-run output (lines like ":task:name SKIPPED"). */
+    private static List<String> parseDryRunTasks(String output) {
+        return Arrays.stream(output.split("\n"))
+            .map(String::trim)
+            .filter(line -> line.startsWith(":") && line.endsWith("SKIPPED"))
+            .map(line -> line.substring(0, line.lastIndexOf(' ')).trim())
+            .collect(Collectors.toList());
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `BuildTaskGraphTest` in the `tests` module using **Gradle TestKit** (`GradleRunner`) to encode the two invariants of the `assembleFrontend` build wiring as automated tests.
- Adds `gradleTestKit()` dependency and a `rootProjectDir` system property to `tests/build.gradle` so the runner can locate the root project.

## Tests

| Test | Status | Description |
|------|--------|-------------|
| `shouldRunAssembleFrontendBeforeWebserverProcessResourcesWhenBuildingJar` | ✅ active | Runs `shadowJar --dry-run` and asserts `:ui:assembleFrontend` precedes `:webserver:processResources` in the task graph |
| `shouldNotRunAssembleFrontendWhenRunningCheck` | ⏸️ `@Disabled` | Runs `:webserver:check --dry-run` and asserts `assembleFrontend` is absent. Enable once #16304 merges (that PR switches `processResources` from `dependsOn` to `mustRunAfter`, which is what makes this invariant hold) |

## How to run

```bash
./gradlew :tests:test --tests "io.kestra.tests.gradle.BuildTaskGraphTest"
```

## Related
- companion PR: https://github.com/kestra-io/kestra-ee/pull/8094
- Fix PR: #16304