### PR TITLE
feat(flows): support label/value pairs in SELECT and MULTISELECT inputs

### DIFF
--- a/core/src/main/java/io/kestra/core/models/flows/input/MultiselectInput.java
+++ b/core/src/main/java/io/kestra/core/models/flows/input/MultiselectInput.java
@@ -9,9 +9,9 @@ import io.kestra.core.models.flows.Type;
 import io.kestra.core.models.property.Property;
 import io.kestra.core.models.validations.ManualConstraintViolation;
 import io.kestra.core.validations.MultiselectInputValidation;
-import io.kestra.core.validations.Regex;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.Valid;
 import jakarta.validation.ConstraintViolation;
 import jakarta.validation.ConstraintViolationException;
 import jakarta.validation.constraints.NotNull;
@@ -26,13 +26,14 @@ import lombok.experimental.SuperBuilder;
 @MultiselectInputValidation
 public class MultiselectInput extends Input<List<String>> implements ItemTypeInterface, RenderableInput {
     @Schema(
-        title = "List of values available."
+        title = "List of values available.",
+        description = "Each item is either a plain string (used as both label and value) or an object `{label, value}` to decouple the displayed label from the workflow value."
     )
     @NotNull
-    List<@Regex String> values;
+    List<@Valid ValueOption> values;
 
     @Schema(
-        title = "Expression to be used for dynamically generating the list of values"
+        title = "Expression to be used for dynamically generating the list of values."
     )
     String expression;
 
@@ -61,7 +62,7 @@ public class MultiselectInput extends Input<List<String>> implements ItemTypeInt
     public Property<List<String>> getDefaults() {
         Property<List<String>> baseDefaults = super.getDefaults();
         if (baseDefaults == null && autoSelectFirst && !Optional.ofNullable(values).map(Collection::isEmpty).orElse(true)) {
-            return Property.ofValue(List.of(values.getFirst()));
+            return Property.ofValue(List.of(values.getFirst().value()));
         }
 
         return baseDefaults;
@@ -72,11 +73,12 @@ public class MultiselectInput extends Input<List<String>> implements ItemTypeInt
         Set<ConstraintViolation<?>> violations = new HashSet<>();
 
         if (!this.getAllowCustomValue()) {
+            Set<String> allowedValues = this.values.stream().map(ValueOption::value).collect(java.util.stream.Collectors.toSet());
             for (String input : inputs) {
-                if (!this.values.contains(input)) {
+                if (!allowedValues.contains(input)) {
                     violations.add(
                         ManualConstraintViolation.of(
-                            "value `" + input + "` doesn't match the values `" + this.values + "`",
+                            "value `" + input + "` doesn't match the values `" + this.values.stream().map(ValueOption::value).toList() + "`",
                             this,
                             MultiselectInput.class,
                             getId(),
@@ -113,7 +115,7 @@ public class MultiselectInput extends Input<List<String>> implements ItemTypeInt
         return this;
     }
 
-    private List<String> renderExpressionValues(final Function<String, Object> renderer) {
+    private List<ValueOption> renderExpressionValues(final Function<String, Object> renderer) {
         Object result;
         try {
             result = renderer.apply(expression.trim());
@@ -128,11 +130,11 @@ public class MultiselectInput extends Input<List<String>> implements ItemTypeInt
         }
 
         if (result instanceof List<?> list) {
-            return list.stream().filter(Objects::nonNull).map(Object::toString).toList();
+            return list.stream().filter(Objects::nonNull).map(ValueOption::from).toList();
         }
 
         throw ManualConstraintViolation.toConstraintViolationException(
-            "Invalid expression result. Expected a list of strings",
+            "Invalid expression result. Expected a list of values",
             this,
             MultiselectInput.class,
             getId(),

--- a/core/src/main/java/io/kestra/core/models/flows/input/SelectInput.java
+++ b/core/src/main/java/io/kestra/core/models/flows/input/SelectInput.java
@@ -10,9 +10,9 @@ import io.kestra.core.models.flows.Input;
 import io.kestra.core.models.flows.RenderableInput;
 import io.kestra.core.models.property.Property;
 import io.kestra.core.models.validations.ManualConstraintViolation;
-import io.kestra.core.validations.Regex;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.Valid;
 import jakarta.validation.ConstraintViolationException;
 import jakarta.validation.constraints.NotNull;
 import lombok.Builder;
@@ -26,12 +26,13 @@ import lombok.experimental.SuperBuilder;
 public class SelectInput extends Input<String> implements RenderableInput {
 
     @Schema(
-        title = "List of values."
+        title = "List of values.",
+        description = "Each item is either a plain string (used as both label and value) or an object `{label, value}` to decouple the displayed label from the workflow value."
     )
-    List<@Regex String> values;
+    List<@Valid ValueOption> values;
 
     @Schema(
-        title = "Expression to be used for dynamically generating the list of values"
+        title = "Expression to be used for dynamically generating the list of values."
     )
     String expression;
 
@@ -60,7 +61,7 @@ public class SelectInput extends Input<String> implements RenderableInput {
     public Property<String> getDefaults() {
         Property<String> baseDefaults = super.getDefaults();
         if (baseDefaults == null && autoSelectFirst && !Optional.ofNullable(values).map(Collection::isEmpty).orElse(true)) {
-            return Property.ofValue(values.getFirst());
+            return Property.ofValue(values.getFirst().value());
         }
 
         return baseDefaults;
@@ -68,12 +69,12 @@ public class SelectInput extends Input<String> implements RenderableInput {
 
     @Override
     public void validate(String input) throws ConstraintViolationException {
-        if (!values.contains(input) && this.getRequired()) {
+        if (this.getRequired() && values.stream().noneMatch(v -> Objects.equals(v.value(), input))) {
             if (this.getAllowCustomValue()) {
                 return;
             }
             throw ManualConstraintViolation.toConstraintViolationException(
-                "it must match the values `" + values + "`",
+                "it must match the values `" + values.stream().map(ValueOption::value).toList() + "`",
                 this,
                 SelectInput.class,
                 getId(),
@@ -104,7 +105,7 @@ public class SelectInput extends Input<String> implements RenderableInput {
         return this;
     }
 
-    private List<String> renderExpressionValues(final Function<String, Object> renderer) {
+    private List<ValueOption> renderExpressionValues(final Function<String, Object> renderer) {
         Object result;
         try {
             result = renderer.apply(expression.trim());
@@ -119,12 +120,11 @@ public class SelectInput extends Input<String> implements RenderableInput {
         }
 
         if (result instanceof List<?> list) {
-            return list.stream().filter(Objects::nonNull).map(Object::toString).toList();
+            return list.stream().filter(Objects::nonNull).map(ValueOption::from).toList();
         }
 
-        String type = Optional.ofNullable(result).map(Object::getClass).map(Class::getSimpleName).orElse("<null>");
         throw ManualConstraintViolation.toConstraintViolationException(
-            "Invalid expression result. Expected a list of strings",
+            "Invalid expression result. Expected a list of values",
             this,
             SelectInput.class,
             getId(),

--- a/core/src/main/java/io/kestra/core/models/flows/input/ValueOption.java
+++ b/core/src/main/java/io/kestra/core/models/flows/input/ValueOption.java
@@ -1,0 +1,64 @@
+package io.kestra.core.models.flows.input;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Represents a single option in a {@link SelectInput} or {@link MultiselectInput} list of values.
+ * <p>
+ * Supports two YAML/JSON forms for backwards-compatibility:
+ * <ul>
+ *     <li>A plain scalar (e.g. {@code "V1"}) — label and value are both set to that scalar.</li>
+ *     <li>An object {@code {label: "Production", value: "123"}} — label and value are decoupled.</li>
+ * </ul>
+ * Serialization mirrors the input: a {@link ValueOption} whose label equals its value is emitted as a plain string,
+ * otherwise as an object — preserving the original schema for existing flows.
+ */
+@Schema(
+    description = "A select option. Accepts either a plain string (used as both label and value) or an object with `label` and `value` fields.",
+    anyOf = {String.class, ValueOption.ValueOptionObject.class}
+)
+public record ValueOption(@NotNull String label, @NotNull String value) {
+
+    @JsonCreator
+    public static ValueOption from(Object raw) {
+        if (raw == null) {
+            return null;
+        }
+        if (raw instanceof ValueOption v) {
+            return v;
+        }
+        if (raw instanceof Map<?, ?> map) {
+            Object rawValue = map.get("value");
+            if (rawValue == null) {
+                throw new IllegalArgumentException("Select option object must define a `value` field");
+            }
+            Object rawLabel = map.containsKey("label") ? map.get("label") : rawValue;
+            return new ValueOption(rawLabel.toString(), rawValue.toString());
+        }
+        String str = raw.toString();
+        return new ValueOption(str, str);
+    }
+
+    @JsonValue
+    public Object toJson() {
+        if (Objects.equals(label, value)) {
+            return value;
+        }
+        Map<String, String> map = new LinkedHashMap<>();
+        map.put("label", label);
+        map.put("value", value);
+        return map;
+    }
+
+    /** Schema-only helper to document the object form of a {@link ValueOption}. */
+    @Schema(name = "ValueOption", description = "Object form of a select option.")
+    record ValueOptionObject(@NotNull String label, @NotNull String value) {}
+}

--- a/core/src/test/java/io/kestra/core/docs/JsonSchemaGeneratorTest.java
+++ b/core/src/test/java/io/kestra/core/docs/JsonSchemaGeneratorTest.java
@@ -56,6 +56,26 @@ class JsonSchemaGeneratorTest {
     @Inject
     JsonSchemaGenerator jsonSchemaGenerator;
 
+    @SuppressWarnings("unchecked")
+    @Test
+    void selectInputValuesAcceptsStringOrObject() {
+        Map<String, Object> properties = jsonSchemaGenerator.properties(
+            io.kestra.core.models.flows.Input.class,
+            io.kestra.core.models.flows.input.SelectInput.class
+        );
+        var props = (Map<String, Map<String, Object>>) properties.get("properties");
+        var values = props.get("values");
+        assertThat((String) values.get("type"), is("array"));
+
+        // items must accept either a plain string or an object with label/value.
+        // Swagger2Module emits the anyOf when @Schema(anyOf=...) is set on the referenced type.
+        Map<String, Object> items = (Map<String, Object>) values.get("items");
+        String rendered = items.toString();
+        assertThat(rendered, anyOf(containsString("anyOf"), containsString("oneOf")));
+        assertThat(rendered, containsString("string"));
+        assertThat(rendered, anyOf(containsString("label"), containsString("ValueOption")));
+    }
+
     @Inject
     PluginRegistry pluginRegistry;
 

--- a/core/src/test/java/io/kestra/core/models/flows/input/MultiselectInputTest.java
+++ b/core/src/test/java/io/kestra/core/models/flows/input/MultiselectInputTest.java
@@ -15,6 +15,8 @@ import io.kestra.core.runners.RunContextFactory;
 
 import jakarta.inject.Inject;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
 @KestraTest
 class MultiselectInputTest {
 
@@ -40,7 +42,7 @@ class MultiselectInputTest {
             }
         });
         // Then
-        Assertions.assertEquals(((MultiselectInput) renderInput).getValues(), List.of("V1", "V2"));
+        Assertions.assertEquals(((MultiselectInput) renderInput).getValues(), List.of(new ValueOption("V1", "V1"), new ValueOption("V2", "V2")));
     }
 
     @Test
@@ -62,7 +64,38 @@ class MultiselectInputTest {
             }
         });
         // Then
-        Assertions.assertEquals(((MultiselectInput) renderInput).getValues(), List.of("1", "2"));
+        Assertions.assertEquals(((MultiselectInput) renderInput).getValues(), List.of(new ValueOption("1", "1"), new ValueOption("2", "2")));
+    }
+
+    @Test
+    void shouldRenderInputGivenExpressionReturningLabelValueObjects() {
+        // Given
+        RunContext runContext = runContextFactory.of(Map.of(
+            "options",
+            List.of(
+                Map.of("label", "Prod", "value", "123"),
+                Map.of("label", "Staging", "value", "456")
+            )
+        ));
+        MultiselectInput input = MultiselectInput
+            .builder()
+            .id("id")
+            .expression("{{ options }}")
+            .build();
+        // When
+        Input<?> renderInput = RenderableInput.mayRenderInput(input, s ->
+        {
+            try {
+                return runContext.renderTyped(s);
+            } catch (IllegalVariableEvaluationException e) {
+                throw new RuntimeException(e);
+            }
+        });
+        // Then
+        Assertions.assertEquals(
+            List.of(new ValueOption("Prod", "123"), new ValueOption("Staging", "456")),
+            ((MultiselectInput) renderInput).getValues()
+        );
     }
 
     @Test
@@ -71,11 +104,24 @@ class MultiselectInputTest {
         MultiselectInput input = MultiselectInput
             .builder()
             .id("id")
-            .values(List.of("V1", "V2"))
+            .values(List.of(new ValueOption("V1", "V1"), new ValueOption("V2", "V2")))
             .autoSelectFirst(true)
             .build();
 
         Assertions.assertEquals(List.of("V1"), runContext.render(input.getDefaults()).asList(String.class));
+    }
+
+    @Test
+    void autoselectFirstUsesValueNotLabel() throws IllegalVariableEvaluationException {
+        RunContext runContext = runContextFactory.of();
+        MultiselectInput input = MultiselectInput
+            .builder()
+            .id("id")
+            .values(List.of(new ValueOption("Prod", "123"), new ValueOption("Staging", "456")))
+            .autoSelectFirst(true)
+            .build();
+
+        Assertions.assertEquals(List.of("123"), runContext.render(input.getDefaults()).asList(String.class));
     }
 
     @Test
@@ -103,5 +149,21 @@ class MultiselectInputTest {
 
         // Then
         Assertions.assertEquals(List.of("V1"), runContext.render(((MultiselectInput) renderInput).getDefaults()).asList(String.class));
+    }
+
+    @Test
+    void validateAcceptsValuesButNotLabels() {
+        MultiselectInput input = MultiselectInput
+            .builder()
+            .id("id")
+            .values(List.of(new ValueOption("Prod", "123"), new ValueOption("Staging", "456")))
+            .build();
+
+        // values pass
+        input.validate(List.of("123", "456"));
+
+        // labels fail
+        assertThatThrownBy(() -> input.validate(List.of("Prod")))
+            .hasMessageContaining("[123, 456]");
     }
 }

--- a/core/src/test/java/io/kestra/core/models/flows/input/SelectInputTest.java
+++ b/core/src/test/java/io/kestra/core/models/flows/input/SelectInputTest.java
@@ -15,6 +15,9 @@ import io.kestra.core.runners.RunContextFactory;
 
 import jakarta.inject.Inject;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
 @KestraTest
 class SelectInputTest {
 
@@ -40,7 +43,7 @@ class SelectInputTest {
             }
         });
         // Then
-        Assertions.assertEquals(((SelectInput) renderInput).getValues(), List.of("V1", "V2"));
+        Assertions.assertEquals(((SelectInput) renderInput).getValues(), List.of(new ValueOption("V1", "V1"), new ValueOption("V2", "V2")));
     }
 
     @Test
@@ -62,7 +65,38 @@ class SelectInputTest {
             }
         });
         // Then
-        Assertions.assertEquals(((SelectInput) renderInput).getValues(), List.of("1", "2"));
+        Assertions.assertEquals(((SelectInput) renderInput).getValues(), List.of(new ValueOption("1", "1"), new ValueOption("2", "2")));
+    }
+
+    @Test
+    void shouldRenderInputGivenExpressionReturningLabelValueObjects() {
+        // Given
+        RunContext runContext = runContextFactory.of(Map.of(
+            "options",
+            List.of(
+                Map.of("label", "Prod", "value", "123"),
+                Map.of("label", "Staging", "value", "456")
+            )
+        ));
+        SelectInput input = SelectInput
+            .builder()
+            .id("id")
+            .expression("{{ options }}")
+            .build();
+        // When
+        Input<?> renderInput = RenderableInput.mayRenderInput(input, s ->
+        {
+            try {
+                return runContext.renderTyped(s);
+            } catch (IllegalVariableEvaluationException e) {
+                throw new RuntimeException(e);
+            }
+        });
+        // Then
+        Assertions.assertEquals(
+            List.of(new ValueOption("Prod", "123"), new ValueOption("Staging", "456")),
+            ((SelectInput) renderInput).getValues()
+        );
     }
 
     @Test
@@ -71,11 +105,24 @@ class SelectInputTest {
         SelectInput input = SelectInput
             .builder()
             .id("id")
-            .values(List.of("V1", "V2"))
+            .values(List.of(new ValueOption("V1", "V1"), new ValueOption("V2", "V2")))
             .autoSelectFirst(true)
             .build();
 
         Assertions.assertEquals("V1", runContext.render(input.getDefaults()).as(String.class).orElseThrow());
+    }
+
+    @Test
+    void autoselectFirstUsesValueNotLabel() throws IllegalVariableEvaluationException {
+        RunContext runContext = runContextFactory.of();
+        SelectInput input = SelectInput
+            .builder()
+            .id("id")
+            .values(List.of(new ValueOption("Prod", "123"), new ValueOption("Staging", "456")))
+            .autoSelectFirst(true)
+            .build();
+
+        Assertions.assertEquals("123", runContext.render(input.getDefaults()).as(String.class).orElseThrow());
     }
 
     @Test
@@ -103,5 +150,38 @@ class SelectInputTest {
 
         // Then
         Assertions.assertEquals("V1", runContext.render(((SelectInput) renderInput).getDefaults()).as(String.class).orElseThrow());
+    }
+
+    @Test
+    void validateAcceptsValueButNotLabel() {
+        SelectInput input = SelectInput
+            .builder()
+            .id("id")
+            .values(List.of(new ValueOption("Prod", "123"), new ValueOption("Staging", "456")))
+            .required(true)
+            .build();
+
+        // value passes
+        input.validate("123");
+
+        // label does not
+        assertThatThrownBy(() -> input.validate("Prod"))
+            .hasMessageContaining("[123, 456]");
+    }
+
+    @Test
+    void valueOptionDeserializesFromStringOrObject() {
+        ValueOption fromString = ValueOption.from("V1");
+        assertThat(fromString.label()).isEqualTo("V1");
+        assertThat(fromString.value()).isEqualTo("V1");
+
+        ValueOption fromMap = ValueOption.from(Map.of("label", "Prod", "value", "123"));
+        assertThat(fromMap.label()).isEqualTo("Prod");
+        assertThat(fromMap.value()).isEqualTo("123");
+
+        // value-only map: label defaults to value
+        ValueOption valueOnly = ValueOption.from(Map.of("value", "789"));
+        assertThat(valueOnly.label()).isEqualTo("789");
+        assertThat(valueOnly.value()).isEqualTo("789");
     }
 }

--- a/core/src/test/java/io/kestra/core/models/flows/input/ValueOptionTest.java
+++ b/core/src/test/java/io/kestra/core/models/flows/input/ValueOptionTest.java
@@ -1,0 +1,101 @@
+package io.kestra.core.models.flows.input;
+
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import io.kestra.core.serializers.JacksonMapper;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ValueOptionTest {
+
+    private static final ObjectMapper YAML = JacksonMapper.ofYaml();
+    private static final ObjectMapper JSON = JacksonMapper.ofJson();
+
+    @Test
+    void shouldDeserializeYamlFromStringArray() throws Exception {
+        String yaml = """
+            id: aws
+            type: SELECT
+            values:
+              - V1
+              - V2
+            """;
+
+        SelectInput input = YAML.readValue(yaml, SelectInput.class);
+
+        assertThat(input.getValues())
+            .containsExactly(new ValueOption("V1", "V1"), new ValueOption("V2", "V2"));
+    }
+
+    @Test
+    void shouldDeserializeYamlFromObjectArray() throws Exception {
+        String yaml = """
+            id: aws
+            type: SELECT
+            values:
+              - label: Production (Main)
+                value: "123456789"
+              - label: Staging (Sandbox)
+                value: "987654321"
+            """;
+
+        SelectInput input = YAML.readValue(yaml, SelectInput.class);
+
+        assertThat(input.getValues())
+            .containsExactly(
+                new ValueOption("Production (Main)", "123456789"),
+                new ValueOption("Staging (Sandbox)", "987654321")
+            );
+    }
+
+    @Test
+    void shouldDeserializeMixedScalarsAndObjects() throws Exception {
+        String yaml = """
+            id: aws
+            type: MULTISELECT
+            values:
+              - V1
+              - label: Prod
+                value: "123"
+            """;
+
+        MultiselectInput input = YAML.readValue(yaml, MultiselectInput.class);
+
+        assertThat(input.getValues())
+            .containsExactly(new ValueOption("V1", "V1"), new ValueOption("Prod", "123"));
+    }
+
+    @Test
+    void shouldSerializeAsStringWhenLabelEqualsValue() throws Exception {
+        SelectInput input = SelectInput.builder()
+            .id("id")
+            .values(List.of(new ValueOption("V1", "V1"), new ValueOption("V2", "V2")))
+            .build();
+
+        @SuppressWarnings("unchecked")
+        Map<String, Object> json = JSON.convertValue(input, Map.class);
+        assertThat((List<Object>) json.get("values")).containsExactly("V1", "V2");
+    }
+
+    @Test
+    void shouldSerializeAsObjectWhenLabelDiffersFromValue() throws Exception {
+        SelectInput input = SelectInput.builder()
+            .id("id")
+            .values(List.of(new ValueOption("Prod", "123"), new ValueOption("V2", "V2")))
+            .build();
+
+        @SuppressWarnings("unchecked")
+        Map<String, Object> json = JSON.convertValue(input, Map.class);
+        List<?> values = (List<?>) json.get("values");
+        assertThat(values).hasSize(2);
+        @SuppressWarnings("unchecked")
+        Map<String, Object> first = (Map<String, Object>) values.get(0);
+        assertThat(first).containsEntry("label", "Prod").containsEntry("value", "123");
+        assertThat(values.get(1)).isEqualTo("V2");
+    }
+}

--- a/core/src/test/java/io/kestra/core/runners/FlowInputOutputTest.java
+++ b/core/src/test/java/io/kestra/core/runners/FlowInputOutputTest.java
@@ -386,7 +386,7 @@ class FlowInputOutputTest {
         List<InputAndValue> results = flowInputOutput.validateExecutionInputs(List.of(input), null, DEFAULT_TEST_EXECUTION, Mono.empty()).block();
 
         // Then
-        Assertions.assertEquals(TEST_SECRET_VALUE, ((MultiselectInput) results.getFirst().input()).getValues().getFirst());
+        Assertions.assertEquals(TEST_SECRET_VALUE, ((MultiselectInput) results.getFirst().input()).getValues().getFirst().value());
     }
 
     @Test

--- a/core/src/test/java/io/kestra/plugin/core/trigger/ScheduleTest.java
+++ b/core/src/test/java/io/kestra/plugin/core/trigger/ScheduleTest.java
@@ -597,7 +597,11 @@ class ScheduleTest {
                     MultiselectInput.builder()
                         .id("multiselectInput")
                         .type(Type.MULTISELECT)
-                        .values(List.of("option1", "option2", "option3"))
+                        .values(List.of(
+                            new io.kestra.core.models.flows.input.ValueOption("option1", "option1"),
+                            new io.kestra.core.models.flows.input.ValueOption("option2", "option2"),
+                            new io.kestra.core.models.flows.input.ValueOption("option3", "option3")
+                        ))
                         .defaults(Property.ofValue(List.of("option1", "option2")))
                         .build()
                 )
@@ -637,7 +641,11 @@ class ScheduleTest {
                     MultiselectInput.builder()
                         .id("multiselectAutoSelect")
                         .type(Type.MULTISELECT)
-                        .values(List.of("first", "second", "third"))
+                        .values(List.of(
+                            new io.kestra.core.models.flows.input.ValueOption("first", "first"),
+                            new io.kestra.core.models.flows.input.ValueOption("second", "second"),
+                            new io.kestra.core.models.flows.input.ValueOption("third", "third")
+                        ))
                         .autoSelectFirst(true)
                         .build()
                 )

--- a/ui/src/components/inputs/InputsForm.vue
+++ b/ui/src/components/inputs/InputsForm.vue
@@ -35,12 +35,12 @@
                 clearable
             >
                 <KsOption
-                    v-for="item in input.values"
-                    :key="item"
-                    :label="item"
-                    :value="item"
+                    v-for="item in (input.values ?? []).map(toOption)"
+                    :key="item.value"
+                    :label="item.label"
+                    :value="item.value"
                 >
-                    <KsMarkdown :content="item" />
+                    <KsMarkdown :content="item.label" />
                 </KsOption>
             </KsSelect>
             <KsRadioGroup
@@ -49,7 +49,7 @@
                 v-model="inputsValues[input.id]"
                 @update:model-value="onChange(input)"
             >
-                <KsRadio v-for="item in input.values" :key="item" :label="item" :value="item" />
+                <KsRadio v-for="item in (input.values ?? []).map(toOption)" :key="item.value" :label="item.label" :value="item.value" />
                 <KsInput
                     v-if="input.allowCustomValue"
                     v-model="inputsValues[input.id]"
@@ -71,12 +71,12 @@
                 :allowCreate="input.allowCustomValue"
             >
                 <KsOption
-                    v-for="item in (input.values ?? input.options)"
-                    :key="item"
-                    :label="item"
-                    :value="item"
+                    v-for="item in ((input.values ?? input.options) ?? []).map(toOption)"
+                    :key="item.value"
+                    :label="item.label"
+                    :value="item.value"
                 >
-                    <KsMarkdown :content="item" />
+                    <KsMarkdown :content="item.label" />
                 </KsOption>
             </KsSelect>
             <KsInput
@@ -268,6 +268,8 @@
         message: string;
     }
 
+    type ValueOptionLike = string | {label: string; value: string};
+
     interface InputMetaData {
         id: string;
         type: InputType
@@ -276,8 +278,8 @@
         required?: boolean;
         defaults?: unknown;
         value?: unknown;
-        values?: string[];
-        options?: string[];
+        values?: ValueOptionLike[];
+        options?: ValueOptionLike[];
         errors?: InputError[];
         isDefault?: boolean;
         isRadio?: boolean;
@@ -287,6 +289,10 @@
         allowedFileExtensions?: string[];
         accept?: string;
         prefill?: unknown;
+    }
+
+    function toOption(item: ValueOptionLike): {label: string; value: string} {
+        return typeof item === "string" ? {label: item, value: item} : item
     }
 
     interface SelectedTrigger {

--- a/webserver/src/main/java/io/kestra/mcp/FlowToolSchemaMapper.java
+++ b/webserver/src/main/java/io/kestra/mcp/FlowToolSchemaMapper.java
@@ -260,7 +260,7 @@ public class FlowToolSchemaMapper {
 
     private static Map<String, Object> toMultiselectType(MultiselectInput input, Map<String, Object> baseSchema) {
         baseSchema.putAll(Map.of(
-            "items", buildItemsForMultiselectInput(input, input.getValues()),
+            "items", buildItemsForMultiselectInput(input, input.getValues().stream().map(ValueOption::value).toList()),
             "uniqueItems", true
         ));
 
@@ -288,7 +288,7 @@ public class FlowToolSchemaMapper {
 
     private static Map<String, Object> toSelectType(SelectInput input, Map<String, Object> baseSchema) {
         baseSchema.put(
-            "enum", input.getValues()
+            "enum", input.getValues().stream().map(ValueOption::value).toList()
         );
 
         return baseSchema;

--- a/webserver/src/test/java/io/kestra/mcp/FlowToolSchemaMapperTest.java
+++ b/webserver/src/test/java/io/kestra/mcp/FlowToolSchemaMapperTest.java
@@ -107,7 +107,7 @@ class FlowToolSchemaMapperTest {
             ))
             .build(),
         InputConversionTestCase.builder()
-            .input(MultiselectInput.builder().type(Type.MULTISELECT).itemType(Type.STRING).values(List.of("x", "y")).build())
+            .input(MultiselectInput.builder().type(Type.MULTISELECT).itemType(Type.STRING).values(List.of(new io.kestra.core.models.flows.input.ValueOption("x", "x"), new io.kestra.core.models.flows.input.ValueOption("y", "y"))).build())
             .expectedSchema(Map.of("type", "array", "items", Map.of("type", "string", "enum", List.of("x", "y")), "uniqueItems", true))
             .build(),
         InputConversionTestCase.builder()
@@ -115,7 +115,7 @@ class FlowToolSchemaMapperTest {
             .expectedSchema(Map.of("type", "string"))
             .build(),
         InputConversionTestCase.builder()
-            .input(SelectInput.builder().type(Type.SELECT).values(List.of("a", "b")).build())
+            .input(SelectInput.builder().type(Type.SELECT).values(List.of(new io.kestra.core.models.flows.input.ValueOption("a", "a"), new io.kestra.core.models.flows.input.ValueOption("b", "b"))).build())
             .expectedSchema(Map.of("type", "string", "enum", List.of("a", "b")))
             .build(),
         InputConversionTestCase.builder()


### PR DESCRIPTION
## Summary
SELECT/MULTISELECT inputs accept either a plain string or `{label, value}`. UI shows the label, expressions resolve to the value.

The `@Regex` annotation on `values` has been dropped — it was copy-pasted from `Input.validator` (where it correctly checks a regex pattern) onto option values, which are literal strings, not regexes. So it only ever rejected strings that happened to be malformed regex syntax, which nobody writes.

Closes kestra-io/kestra-ee#7488