### PR TITLE
fix(core): delegate TAGS filtering to repository default handlers

### DIFF
--- a/jdbc/src/main/java/io/kestra/jdbc/repository/AbstractJdbcRepository.java
+++ b/jdbc/src/main/java/io/kestra/jdbc/repository/AbstractJdbcRepository.java
@@ -475,6 +475,10 @@ public abstract class AbstractJdbcRepository {
         throw new InvalidQueryFiltersException("getSuperAdminCondition must be overridden for JSONB-backed superAdmin field");
     }
 
+    protected Condition tagsCondition(Object value, QueryFilter.Op operation) {
+        return defaultHandlers(QueryFilter.Field.TAGS, value, operation);
+    }
+
     // Generate the condition for Field.STATE
     @SuppressWarnings("unchecked")
     protected Condition generateStateCondition(Object value, QueryFilter.Op operation) {

--- a/jdbc/src/main/java/io/kestra/jdbc/repository/AbstractJdbcRepository.java
+++ b/jdbc/src/main/java/io/kestra/jdbc/repository/AbstractJdbcRepository.java
@@ -510,10 +510,6 @@ public abstract class AbstractJdbcRepository {
         return defaultHandlers(QueryFilter.Field.NAME, value, operation);
     }
 
-    protected Condition tagsCondition(Object value, QueryFilter.Op operation) {
-        throw new InvalidQueryFiltersException("Unsupported operation for TAGS field: " + operation);
-    }
-
     protected Condition typeCondition(Object value, QueryFilter.Op operation) {
         return defaultHandlers(QueryFilter.Field.TYPE, value, operation);
     }

--- a/jdbc/src/test/java/io/kestra/jdbc/repository/AbstractJdbcRepositoryTest.java
+++ b/jdbc/src/test/java/io/kestra/jdbc/repository/AbstractJdbcRepositoryTest.java
@@ -89,4 +89,21 @@ class AbstractJdbcRepositoryTest extends AbstractJdbcRepository {
             .isInstanceOf(InvalidQueryFiltersException.class)
             .hasMessageContaining("STARTS_WITH operation requires a string value, got a List");
     }
+    
+    @Test
+    void tagsConditionShouldDelegateToDefaultHandlers() {
+        String assertValue = "my-tag";
+        Name columnName = DSL.quotedName(QueryFilter.Field.TAGS.name().toLowerCase());
+    
+        assertThat(
+            this.getConditionOnField(
+                QueryFilter.Field.TAGS,
+                List.of(assertValue),
+                QueryFilter.Op.IN,
+                null
+            )
+        ).isEqualTo(
+            DSL.field(columnName).in(List.of(assertValue))
+        );
+    }
 }


### PR DESCRIPTION
Fixes #16323 

### Summary

This PR fixes an inconsistency between query filter validation and JDBC execution for `QueryFilter.Field.TAGS`.

`TAGS.supportedOp()` currently advertises support for:

* `IN`
* `NOT_IN`
* `PREFIX`
* `CONTAINS`
* `STARTS_WITH`
* `ENDS_WITH`

These filters pass `validateQueryFilters()`, but `AbstractJdbcRepository.tagsCondition()` always throws `InvalidQueryFiltersException`, causing runtime failure.

### Changes

Updated `AbstractJdbcRepository.tagsCondition()` to delegate to the existing repository filtering logic instead of unconditionally throwing.

```java
return defaultHandlers(QueryFilter.Field.TAGS, value, operation);
```

### Result

This aligns execution behavior with the operations already exposed by `QueryFilter.Field.TAGS.supportedOp()` and prevents TAGS filters from failing after validation.
