### PR TITLE
chore(deps): ignore develop pre-release bumps of @kestra-io/kestra-sdk in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -124,6 +124,10 @@ updates:
           ]
 
     ignore:
+      # Ignore develop pre-release versions of kestra-sdk (managed internally, not via Dependabot)
+      - dependency-name: "@kestra-io/kestra-sdk"
+        versions: ["*-develop*"]
+
       # Ignore TypeScript major updates (v6 currently conflicts with @typescript-eslint/parser which requires <6.0.0)
       - dependency-name: "typescript"
         update-types: ["version-update:semver-major"]
@@ -231,6 +235,39 @@ updates:
             "remark-*",
             "unified",
           ]
+
+  # Maintain dependencies for ui/packages/slot-contracts
+  - package-ecosystem: "npm"
+    directory: "/ui/packages/slot-contracts"
+    commit-message:
+      prefix: "build(deps)"
+      prefix-development: "build(deps)"
+    schedule:
+      interval: "weekly"
+      day: "wednesday"
+      timezone: "Europe/Paris"
+      time: "08:00"
+    open-pull-requests-limit: 50
+    labels: ["dependency-upgrade", "area/frontend"]
+    groups:
+      build:
+        applies-to: version-updates
+        patterns: ["tsdown"]
+
+      major:
+        update-types: ["major"]
+        applies-to: version-updates
+        exclude-patterns: ["tsdown"]
+
+      minor:
+        update-types: ["minor"]
+        applies-to: version-updates
+        exclude-patterns: ["tsdown"]
+
+      patch:
+        update-types: ["patch"]
+        applies-to: version-updates
+        exclude-patterns: ["tsdown"]
 
   # Maintain dependencies for ui/packages/topology
   - package-ecosystem: "npm"


### PR DESCRIPTION
## Summary

- Adds an ignore rule for `@kestra-io/kestra-sdk` versions matching `*-develop*` so Dependabot stops opening PRs for internal develop pre-releases (e.g. `2.0.0-develop.17797027.1f59eb1f.3afa0199`)
- Adds `ui/packages/slot-contracts` as a tracked npm ecosystem alongside `design-system` and `topology`