### PR TITLE
chore(deps): remove invalid kestra-sdk dependabot ignore rule

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -124,10 +124,6 @@ updates:
           ]
 
     ignore:
-      # Ignore develop pre-release versions of kestra-sdk (managed internally, not via Dependabot)
-      - dependency-name: "@kestra-io/kestra-sdk"
-        versions: ["*-develop*"]
-
       # Ignore TypeScript major updates (v6 currently conflicts with @typescript-eslint/parser which requires <6.0.0)
       - dependency-name: "typescript"
         update-types: ["version-update:semver-major"]


### PR DESCRIPTION
The `*-develop*` glob is not valid npm semver — GitHub flagged it as an invalid version requirement. Removing the rule entirely.