### PR TITLE
fix(core): inject plugin defaults before computing validation warnings

### DIFF
--- a/core/src/main/java/io/kestra/core/services/FlowService.java
+++ b/core/src/main/java/io/kestra/core/services/FlowService.java
@@ -360,15 +360,14 @@ public class FlowService {
                     constraintsBuilder.outdated(!sentRevision.equals(lastRevision + 1));
                 }
 
-                constraintsBuilder.deprecationPaths(deprecationPaths(flow));
-                constraintsBuilder.warnings(warnings(flow, tenantId));
+                FlowWithSource flowWithDefaults = pluginDefaultService.injectAllDefaults(flow, false);
+                constraintsBuilder.deprecationPaths(deprecationPaths(flowWithDefaults));
+                constraintsBuilder.warnings(warnings(flowWithDefaults, tenantId));
                 constraintsBuilder.infos(relocations(source).stream().map(relocation -> relocation.from() + " is replaced by " + relocation.to()).toList());
                 constraintsBuilder.flow(flow.getId());
                 constraintsBuilder.namespace(flow.getNamespace());
 
-                // Do not perform a strict parsing validation to ignore unknown
-                // properties that might be injecting through default values.
-                modelValidator.validate(pluginDefaultService.injectAllDefaults(flow, false));
+                modelValidator.validate(flowWithDefaults);
             } catch (ConstraintViolationException e) {
                 String friendlyMessage = formatValidationError(e.getMessage());
                 constraintsBuilder.constraints(friendlyMessage);

--- a/core/src/main/java/io/kestra/core/services/FlowService.java
+++ b/core/src/main/java/io/kestra/core/services/FlowService.java
@@ -360,6 +360,8 @@ public class FlowService {
                     constraintsBuilder.outdated(!sentRevision.equals(lastRevision + 1));
                 }
 
+                // Do not perform a strict parsing validation to ignore unknown
+                // properties that might be injecting through default values.
                 FlowWithSource flowWithDefaults = pluginDefaultService.injectAllDefaults(flow, false);
                 constraintsBuilder.deprecationPaths(deprecationPaths(flowWithDefaults));
                 constraintsBuilder.warnings(warnings(flowWithDefaults, tenantId));

--- a/core/src/test/java/io/kestra/core/services/FlowServiceTest.java
+++ b/core/src/test/java/io/kestra/core/services/FlowServiceTest.java
@@ -138,6 +138,30 @@ class FlowServiceTest {
     }
 
     @Test
+    void shouldReturnNoWarningsWhenPropertiesProvidedByPluginDefaults() {
+        // Given
+        String source = """
+            id: test
+            namespace: io.kestra.unittest
+            tasks:
+              - id: download
+                type: io.kestra.plugin.core.http.Download
+            pluginDefaults:
+              - type: io.kestra.plugin.core.http.Download
+                values:
+                  uri: https://kestra.io
+            """;
+
+        // When
+        List<ValidateConstraintViolation> results = flowService.validate("my-tenant", List.of(new FlowSource(null, source)));
+
+        // Then
+        assertThat(results).hasSize(1);
+        assertThat(results.getFirst().getConstraints()).isNull();
+        assertThat(results.getFirst().getWarnings()).isEmpty();
+    }
+
+    @Test
     void importFlow() throws FlowProcessingException {
         String source = """
             id: import


### PR DESCRIPTION
## Summary
- Inject all plugin defaults (flow-level, namespace-level, global) **before** computing warnings and deprecation paths during flow validation
- Previously, `warnings()` and `deprecationPaths()` ran on the flow before defaults were applied, causing false warnings in the UI for properties provided by plugin defaults
- Added test: `shouldReturnNoWarningsWhenPropertiesProvidedByPluginDefaults`

Fixes #14471

## Test plan
- [x] Existing `FlowServiceTest` tests pass
- [x] New test validates that a flow with required properties provided only via `pluginDefaults` produces no warnings or constraint violations