### PR TITLE
fix(execution): clean all ancestor states in loop untils

### DIFF
--- a/core/src/main/java/io/kestra/core/services/ExecutionService.java
+++ b/core/src/main/java/io/kestra/core/services/ExecutionService.java
@@ -5,7 +5,6 @@ import java.net.URI;
 import java.time.Instant;
 import java.time.ZonedDateTime;
 import java.util.*;
-import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -156,27 +155,42 @@ public class ExecutionService {
     }
 
     public Execution retryWaitFor(Execution execution, String flowableTaskRunId) {
-        AtomicReference<Boolean> firstDone = new AtomicReference<>(false);
+        if (execution.getTaskRunList() == null) {
+            return execution.withState(State.Type.RUNNING);
+        }
+
+        // Pre-build an id→TaskRun map, so ancestor-chain walks are O(1) per step.
+        Map<String, TaskRun> byId = execution.getTaskRunList().stream()
+            .collect(Collectors.toMap(TaskRun::getId, t -> t));
+
+        // Remove all descendants (not just direct children) of the iterating LoopUntil so that nested
+        // LoopUntil tasks start the next iteration with a clean state and don't inherit stale outputs.
         List<TaskRun> newTaskRuns = execution
             .getTaskRunList()
             .stream()
-            .map(taskRun ->
-            {
+            .map(taskRun -> {
                 if (taskRun.getId().equals(flowableTaskRunId)) {
                     return taskRun.resetAttempts().incrementIteration();
                 }
-
-                if (flowableTaskRunId.equals(taskRun.getParentTaskRunId())) {
-                    // Clean children
+                if (isDescendantOf(taskRun, flowableTaskRunId, byId)) {
                     return null;
                 }
-
                 return taskRun;
             })
             .filter(Objects::nonNull)
             .toList();
 
         return execution.withTaskRunList(newTaskRuns).withState(State.Type.RUNNING);
+    }
+
+    private boolean isDescendantOf(TaskRun taskRun, String ancestorId, Map<String, TaskRun> byId) {
+        String parentId = taskRun.getParentTaskRunId();
+        while (parentId != null) {
+            if (ancestorId.equals(parentId)) return true;
+            TaskRun parent = byId.get(parentId);
+            parentId = parent != null ? parent.getParentTaskRunId() : null;
+        }
+        return false;
     }
 
     public Execution pauseFlowable(Execution execution, TaskRun updateFlowableTaskRun) throws InternalException {

--- a/core/src/test/java/io/kestra/core/runners/AbstractRunnerTest.java
+++ b/core/src/test/java/io/kestra/core/runners/AbstractRunnerTest.java
@@ -748,6 +748,12 @@ public abstract class AbstractRunnerTest {
     }
 
     @Test
+    @LoadFlows(value = { "flows/valids/waitfor-nested.yaml" }, tenantId = "waitfornested")
+    void waitforNestedThreeLevels() throws Exception {
+        loopUntilTestCaseTest.waitforNestedThreeLevels("waitfornested");
+    }
+
+    @Test
     @LoadFlows("flows/valids/errors.yaml")
     void errors() throws Exception {
         List<LogEntry> logs = new CopyOnWriteArrayList<>();

--- a/core/src/test/java/io/kestra/plugin/core/flow/LoopUntilCaseTest.java
+++ b/core/src/test/java/io/kestra/plugin/core/flow/LoopUntilCaseTest.java
@@ -1,5 +1,6 @@
 package io.kestra.plugin.core.flow;
 
+import java.time.Duration;
 import java.time.temporal.ChronoUnit;
 import java.util.Map;
 import java.util.concurrent.TimeoutException;
@@ -83,5 +84,20 @@ public class LoopUntilCaseTest {
 
         assertThat(execution.getState().getCurrent()).isEqualTo(State.Type.FAILED);
         assertThat((Integer) taskOutputService.getOutputs(execution.getTaskRunList().getFirst()).get("iterationCount")).isGreaterThan(1);
+    }
+
+    public void waitforNestedThreeLevels(String tenantId) throws TimeoutException, QueueException, io.kestra.core.exceptions.InternalException {
+        Execution execution = runnerUtils.runOne(tenantId, "io.kestra.tests", "waitfor-nested", Duration.ofSeconds(60));
+
+        assertThat(execution.getState().getCurrent()).isEqualTo(State.Type.SUCCESS);
+        // Outer loop ran all 3 iterations
+        TaskRun loop1 = execution.findTaskRunsByTaskId("loop_1").getFirst();
+        assertThat((Integer) taskOutputService.getOutputs(loop1).get("iterationCount")).isEqualTo(3);
+        // The `iteration` field of the last loop_3_log encodes how deeply the outer loops reset.
+        // With the bug (stale outputs not cleaned), loop_3 exits after 1 inner iteration giving iteration=3.
+        // With the fix (all descendants removed on outer-loop reset), loop_3 runs 3 inner iterations each
+        // time giving iteration=6, confirming the inner loops properly restarted from scratch.
+        TaskRun lastLoop3Log = execution.findTaskRunsByTaskId("loop_3_log").getFirst();
+        assertThat(lastLoop3Log.getIteration()).isEqualTo(6);
     }
 }

--- a/core/src/test/resources/flows/valids/waitfor-nested.yaml
+++ b/core/src/test/resources/flows/valids/waitfor-nested.yaml
@@ -1,0 +1,34 @@
+id: waitfor-nested
+namespace: io.kestra.tests
+
+tasks:
+  - id: loop_1
+    type: io.kestra.plugin.core.flow.LoopUntil
+    condition: "{{ outputs.loop_1_return.value | number >= 3 }}"
+    checkFrequency:
+      interval: PT0.2S
+    tasks:
+      - id: loop_1_return
+        type: io.kestra.plugin.core.debug.Return
+        format: "{{ outputs.loop_1.iterationCount }}"
+      - id: loop_2
+        type: io.kestra.plugin.core.flow.LoopUntil
+        condition: "{{ outputs.loop_2_return.value | number >= 3 }}"
+        checkFrequency:
+          interval: PT0.2S
+        tasks:
+          - id: loop_2_return
+            type: io.kestra.plugin.core.debug.Return
+            format: "{{ outputs.loop_2.iterationCount }}"
+          - id: loop_3
+            type: io.kestra.plugin.core.flow.LoopUntil
+            condition: "{{ outputs.loop_3_return.value | number >= 3 }}"
+            checkFrequency:
+              interval: PT0.2S
+            tasks:
+              - id: loop_3_return
+                type: io.kestra.plugin.core.debug.Return
+                format: "{{ outputs.loop_3.iterationCount }}"
+              - id: loop_3_log
+                type: io.kestra.plugin.core.log.Log
+                message: "loop_3 iteration: {{ outputs.loop_3_return.value }}"


### PR DESCRIPTION
For a deeply nested loop until, all ancestor states were not cleaned, as when we reset taskrun, we were only resetting those of the direct parent.

We now correctly climb up the hierarchy of parents and clean all ancestor states.

Fixes https://github.com/kestra-io/kestra/issues/14811