### PR TITLE
fix(system): init metrics whenever possible

### DIFF
--- a/core/src/main/java/io/kestra/core/metrics/MetricRegistry.java
+++ b/core/src/main/java/io/kestra/core/metrics/MetricRegistry.java
@@ -62,7 +62,7 @@ public class MetricRegistry {
     public static final String METRIC_WORKER_TRIGGER_EXECUTION_COUNT = "worker.trigger.execution.count";
     public static final String METRIC_WORKER_TRIGGER_EXECUTION_COUNT_DESCRIPTION = "The total number of triggers evaluated by the Worker";
     public static final String METRIC_WORKER_KILLED_COUNT = "worker.killed.count";
-    public static final String METRIC_WORKER_KILLED_COUNT_DESCRIPTION = "The total number of executions killed events received the Executor";
+    public static final String METRIC_WORKER_KILLED_COUNT_DESCRIPTION = "The total number of executions killed events received the Worker";
 
     // Controller (WorkerJobDispatcher) metrics
     public static final String METRIC_CONTROLLER_WORKER_ACTIVE = "controller.worker.active";

--- a/executor/src/main/java/io/kestra/executor/DefaultServiceLivenessCoordinator.java
+++ b/executor/src/main/java/io/kestra/executor/DefaultServiceLivenessCoordinator.java
@@ -26,9 +26,11 @@ import io.kestra.core.server.*;
 import io.kestra.core.utils.IdUtils;
 import io.kestra.core.utils.Logs;
 
+import io.micrometer.core.instrument.Counter;
 import io.micronaut.context.annotation.Context;
 import io.micronaut.context.annotation.Requires;
 import io.micronaut.scheduling.annotation.Scheduled;
+import jakarta.annotation.PostConstruct;
 import jakarta.inject.Inject;
 import lombok.extern.slf4j.Slf4j;
 
@@ -66,6 +68,7 @@ public class DefaultServiceLivenessCoordinator extends AbstractServiceLivenessTa
     private final WorkerJobRunningStateStore workerJobRunningStateStore;
     private final MetricRegistry metricRegistry;
     private final VNodeController vNodeController;
+    private Counter workerJobResubmitCounter;
     // mutable for testing purpose
     String serverId = ServerInstance.INSTANCE_ID;
 
@@ -106,6 +109,14 @@ public class DefaultServiceLivenessCoordinator extends AbstractServiceLivenessTa
             ? serverConfig.service().purge().retention()
             : null;
         this.vNodeController = vNodeController;
+    }
+
+    @PostConstruct
+    void initMetrics() {
+        this.workerJobResubmitCounter = metricRegistry.counter(
+            MetricRegistry.METRIC_EXECUTOR_WORKER_JOB_RESUBMIT_COUNT,
+            MetricRegistry.METRIC_EXECUTOR_WORKER_JOB_RESUBMIT_COUNT_DESCRIPTION
+        );
     }
 
     /**
@@ -238,8 +249,7 @@ public class DefaultServiceLivenessCoordinator extends AbstractServiceLivenessTa
     }
 
     private void reEmitWorkerJobsForWorker(final TransactionContext txContext, final String id) {
-        metricRegistry.counter(MetricRegistry.METRIC_EXECUTOR_WORKER_JOB_RESUBMIT_COUNT, MetricRegistry.METRIC_EXECUTOR_WORKER_JOB_RESUBMIT_COUNT_DESCRIPTION)
-            .increment();
+        workerJobResubmitCounter.increment();
 
         workerJobRunningStateStore.processWorkerJobsForDeadWorker(txContext, id, (txContext2, workerJobRunning) ->
         {

--- a/worker/src/main/java/io/kestra/worker/services/ExecutionKilledManager.java
+++ b/worker/src/main/java/io/kestra/worker/services/ExecutionKilledManager.java
@@ -17,6 +17,7 @@ import io.kestra.core.runners.WorkerTask;
 import io.kestra.core.runners.WorkerTrigger;
 import io.kestra.core.utils.Logs;
 
+import io.micrometer.core.instrument.Counter;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 import lombok.extern.slf4j.Slf4j;
@@ -37,8 +38,6 @@ public class ExecutionKilledManager {
 
     private static final Duration KILLED_CACHE_TTL = Duration.ofHours(24);
 
-    private final MetricRegistry metricRegistry;
-
     /**
      * Cache of killed execution IDs with TTL auto-eviction.
      */
@@ -49,12 +48,17 @@ public class ExecutionKilledManager {
      */
     private final ConcurrentHashMap<String, KillableJob> runningJobs = new ConcurrentHashMap<>();
 
+    private final Counter workerKilledCounter;
+
     @Inject
     public ExecutionKilledManager(MetricRegistry metricRegistry) {
-        this.metricRegistry = metricRegistry;
         this.killedExecutions = Caffeine.newBuilder()
             .expireAfterWrite(KILLED_CACHE_TTL)
             .build();
+        this.workerKilledCounter = metricRegistry.counter(
+            MetricRegistry.METRIC_WORKER_KILLED_COUNT,
+            MetricRegistry.METRIC_WORKER_KILLED_COUNT_DESCRIPTION
+        );
     }
 
     /**
@@ -67,9 +71,7 @@ public class ExecutionKilledManager {
             log.info("[tenant: {}] [execution: {}] Received kill command", killedExecution.getTenantId(), killedExecution.getExecutionId());
             killedExecutions.put(killedExecution.getExecutionId(), killedExecution);
 
-            metricRegistry
-                .counter(MetricRegistry.METRIC_WORKER_KILLED_COUNT, MetricRegistry.METRIC_WORKER_KILLED_COUNT_DESCRIPTION)
-                .increment();
+            workerKilledCounter.increment();
 
             // Kill any matching running jobs
             runningJobs.forEach((_, killableJob) ->

--- a/worker/src/test/java/io/kestra/worker/services/ExecutionKilledManagerTest.java
+++ b/worker/src/test/java/io/kestra/worker/services/ExecutionKilledManagerTest.java
@@ -2,6 +2,8 @@ package io.kestra.worker.services;
 
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import jakarta.inject.Inject;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -15,27 +17,23 @@ import io.kestra.core.runners.WorkerTask;
 import io.kestra.core.runners.WorkerTrigger;
 import io.kestra.core.runners.WorkerTriggerData;
 
-import io.micrometer.core.instrument.Counter;
-
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 
 /**
  * Unit tests for {@link ExecutionKilledManager}.
  */
+@MicronautTest
 class ExecutionKilledManagerTest {
 
+    @Inject
     private MetricRegistry metricRegistry;
+
     private ExecutionKilledManager manager;
 
     @BeforeEach
     void setUp() {
-        metricRegistry = mock(MetricRegistry.class);
-        Counter mockCounter = mock(Counter.class);
-        when(metricRegistry.counter(anyString(), anyString())).thenReturn(mockCounter);
-
         manager = new ExecutionKilledManager(metricRegistry);
     }
 
@@ -236,15 +234,11 @@ class ExecutionKilledManagerTest {
 
     @Test
     void shouldIncrementMetricOnKill() {
-        // Given
-        Counter mockCounter = mock(Counter.class);
-        when(
-            metricRegistry.counter(
-                eq(MetricRegistry.METRIC_WORKER_KILLED_COUNT),
-                eq(MetricRegistry.METRIC_WORKER_KILLED_COUNT_DESCRIPTION)
-            )
-        ).thenReturn(mockCounter);
+        double count = metricRegistry.findCounter(
+            MetricRegistry.METRIC_WORKER_KILLED_COUNT
+        ).count();
 
+        // Given
         ExecutionKilledExecution killEvent = ExecutionKilledExecution.builder()
             .executionId("exec-1")
             .build();
@@ -253,7 +247,10 @@ class ExecutionKilledManagerTest {
         manager.onKillReceived(killEvent);
 
         // Then
-        verify(mockCounter).increment();
+        double newCount = metricRegistry.findCounter(
+            MetricRegistry.METRIC_WORKER_KILLED_COUNT
+        ).count();
+        assertThat(newCount).isEqualTo(count + 1);
     }
 
     // --- onKillReceived - ExecutionKilledTrigger ---


### PR DESCRIPTION
This would set them to 0 and avoid NoData in Prometheus.

Fixes https://github.com/kestra-io/kestra-ee/issues/4206
