### PR TITLE
fix(execution): markAs should also mark the taskrun attempt

### DIFF
--- a/core/src/test/java/io/kestra/core/runners/SLATestCase.java
+++ b/core/src/test/java/io/kestra/core/runners/SLATestCase.java
@@ -1,10 +1,13 @@
 package io.kestra.core.runners;
 
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeoutException;
 
 import io.kestra.core.models.Label;
 import io.kestra.core.models.executions.Execution;
+import io.kestra.core.models.executions.TaskRun;
+import io.kestra.core.models.executions.TaskRunAttempt;
 import io.kestra.core.models.flows.State;
 import io.kestra.core.queues.QueueException;
 
@@ -23,6 +26,24 @@ public class SLATestCase {
         Execution execution = runnerUtils.runOne(MAIN_TENANT, "io.kestra.tests", "sla-max-duration-fail");
 
         assertThat(execution.getState().getCurrent()).isEqualTo(State.Type.FAILED);
+
+        // Every task run (and its last attempt) must be in a terminal state so the UI
+        // does not display a stuck "still running" duration after an SLA FAIL.
+        List<TaskRun> taskRuns = execution.getTaskRunList();
+        if (taskRuns != null) {
+            for (TaskRun taskRun : taskRuns) {
+                assertThat(taskRun.getState().isTerminated())
+                    .as("taskRun '%s' must be terminal after SLA FAIL", taskRun.getTaskId())
+                    .isTrue();
+                List<TaskRunAttempt> attempts = taskRun.getAttempts();
+                if (attempts != null && !attempts.isEmpty()) {
+                    TaskRunAttempt lastAttempt = attempts.getLast();
+                    assertThat(lastAttempt.getState().isTerminated())
+                        .as("last attempt of taskRun '%s' must be terminal after SLA FAIL", taskRun.getTaskId())
+                        .isTrue();
+                }
+            }
+        }
     }
 
     public void maxDurationSLAShouldPass() throws QueueException, TimeoutException {
@@ -41,6 +62,24 @@ public class SLATestCase {
         Execution execution = runnerUtils.runOne(tenantId, "io.kestra.tests", "sla-execution-condition", null, (f, e) -> Map.of("string", "CANCEL"));
 
         assertThat(execution.getState().getCurrent()).isEqualTo(State.Type.CANCELLED);
+
+        // Every task run (and its last attempt) must be in a terminal state so the UI
+        // does not display a stuck "still running" duration after an SLA CANCEL.
+        List<TaskRun> taskRuns = execution.getTaskRunList();
+        if (taskRuns != null) {
+            for (TaskRun taskRun : taskRuns) {
+                assertThat(taskRun.getState().isTerminated())
+                    .as("taskRun '%s' must be terminal after SLA CANCEL", taskRun.getTaskId())
+                    .isTrue();
+                List<TaskRunAttempt> attempts = taskRun.getAttempts();
+                if (attempts != null && !attempts.isEmpty()) {
+                    TaskRunAttempt lastAttempt = attempts.getLast();
+                    assertThat(lastAttempt.getState().isTerminated())
+                        .as("last attempt of taskRun '%s' must be terminal after SLA CANCEL", taskRun.getTaskId())
+                        .isTrue();
+                }
+            }
+        }
     }
 
     public void executionConditionSLAShouldLabel(String tenantId) throws QueueException, TimeoutException {

--- a/executor/src/main/java/io/kestra/executor/ExecutorService.java
+++ b/executor/src/main/java/io/kestra/executor/ExecutorService.java
@@ -1616,7 +1616,7 @@ public class ExecutorService {
             .map(taskRun ->
             {
                 try {
-                    return execution.withTaskRun(taskRun.withState(state));
+                    return execution.withTaskRun(taskRun.withStateAndAttempt(state));
                 } catch (InternalException e) {
                     // in case we cannot update the last not terminated task run, we ignore it
                     return execution;


### PR DESCRIPTION
Fixes https://github.com/kestra-io/kestra/issues/15622

Note that SLA FAIL/CANCEL is inherently racy as late worker tasks may update the execution so it may not fix all edge cases.