### PR TITLE
fix(scheduler): restrict JdbcCleaner to executor to prevent deadlocks

### DIFF
--- a/jdbc/src/main/java/io/kestra/jdbc/runner/JdbcCleaner.java
+++ b/jdbc/src/main/java/io/kestra/jdbc/runner/JdbcCleaner.java
@@ -29,6 +29,7 @@ import lombok.extern.slf4j.Slf4j;
 @JdbcRunnerEnabled
 @Slf4j
 @Requires(property = "kestra.jdbc.cleaner")
+@Requires(property = "kestra.server-type", pattern = "(EXECUTOR|STANDALONE)")
 public class JdbcCleaner {
     private static final Field<Object> UPDATED_FIELD = AbstractJdbcRepository.field("updated");
     private static final int MYSQL_BATCH_SIZE = 10_000;


### PR DESCRIPTION
## Summary
- `JdbcCleaner` runs on all Kestra components (webserver, executor, worker, scheduler). When two components fire their cleanup simultaneously, they deadlock on the `queues` table, causing executor stalls requiring manual restarts.
- Added `@Requires(property = "kestra.server-type", pattern = "(EXECUTOR|STANDALONE)")` to scope the cleaner to the executor only, following the same pattern used by `JdbcServiceLivenessCoordinator`.

Backport of https://github.com/kestra-io/kestra/pull/16380 to v1.0.x.

Closes: kestra-io/kestra-ee#7919

## Test plan
- [x] Existing `*CleanerTest` tests pass — test configs use `STANDALONE` which matches the new pattern
- [ ] Verify in a multi-component deployment that only the executor runs the cleaner