### PR TITLE
fix(dashboards): prevent axis name labels from being clipped in bar charts

### DIFF
--- a/ui/src/components/dashboard/sections/Bar.vue
+++ b/ui/src/components/dashboard/sections/Bar.vue
@@ -110,11 +110,13 @@
                 data: categories.value,
                 show: showAxes,
                 name: showAxes ? (chartOptions?.column ? (data?.columns?.[chartOptions.column]?.displayName ?? chartOptions.column) : "") : undefined,
+                nameTextStyle: {align: "right"},
             },
             yAxis: {
                 type: "value",
                 show: showAxes,
                 name: showAxes ? (aggregator[0][1].displayName ?? aggregator[0][0]) : undefined,
+                nameTextStyle: {align: "left"},
                 axisLabel: isDurationAgg()
                     ? {formatter: (v: number) => durationUtils.humanDuration(v)}
                     : {},


### PR DESCRIPTION
## Summary

- ECharts' `containLabel: true` only accommodates **tick labels** within the grid bounds — axis **names** are positioned independently and can overflow the container when the default center alignment is used near a chart edge
- Y-axis name (e.g. "Executions") was center-aligned on the axis line, which sits near the left edge → left half clipped → showed "cutions" instead of "Executions"
- X-axis name (e.g. "namespace") had the same issue on the right edge
- Fix: `nameTextStyle: { align: "left" }` on y-axis anchors the text rightward from the axis; `nameTextStyle: { align: "right" }` on x-axis anchors it leftward from the axis end

Closes https://github.com/kestra-io/kestra-ee/issues/8084.

## Test plan

- [ ] Open the Default Dashboard
- [ ] Verify the "Executions (per namespace)" bar chart shows "Executions" in full on the y-axis and "namespace" in full on the x-axis
- [ ] Verify other bar charts with axis names render correctly
- [ ] Verify compact/short chart mode is unaffected (axis names are hidden in compact mode)