### PR TITLE
fix(build): excluse Micronaut 5 for dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -29,6 +29,9 @@ updates:
       # Ignore versions of Protobuf >= 4.0.0 because Orc still uses version 3
       - dependency-name: "com.google.protobuf:*"
         versions: ["[4,)"]
+      # Ignore Micronaut 5.x until migration is planned
+      - dependency-name: "io.micronaut*"
+        versions: ["[5,)"]
 
   # Maintain dependencies for NPM modules (core UI)
   - package-ecosystem: "npm"


### PR DESCRIPTION
We're not already capable to migrate, see https://github.com/kestra-io/kestra/issues/15745

