### PR TITLE
fix(security): derive CSRF cookie secure flag from request scheme

### DIFF
--- a/webserver/src/main/java/io/kestra/webserver/controllers/api/StaticFilter.java
+++ b/webserver/src/main/java/io/kestra/webserver/controllers/api/StaticFilter.java
@@ -117,7 +117,7 @@ public class StaticFilter implements HttpServerFilter {
         response.cookie(
             Cookie.of(csrfConfiguration.get().getCookieName(), csrfToken)
                 .httpOnly(true)
-                .secure(true)
+                .secure(request.isSecure())
                 .sameSite(SameSite.Strict)
                 .path("/")
         );


### PR DESCRIPTION
## Summary
- The CSRF cookie was hardcoded with `secure(true)`, preventing browsers from sending it over HTTP
- All POST/PUT/DELETE requests failed with 403 Forbidden in non-HTTPS environments (local dev, HTTP proxies)
- Changed to `request.isSecure()` so the cookie's secure flag matches the transport — HTTPS users still get `Secure` cookies, HTTP users get functional ones

## Test plan
- [x] `CsrfTokenFilterTest` passes
- [x] `StaticFilter` tests pass
- [ ] CI green