### PR TITLE
docs(core): clarify database migration error message at startup

### DIFF
--- a/core/src/main/java/io/kestra/core/migration/MigrationPendingException.java
+++ b/core/src/main/java/io/kestra/core/migration/MigrationPendingException.java
@@ -39,9 +39,9 @@ public class MigrationPendingException extends KestraRuntimeException {
 
     private static String buildMessage(final List<String> pendingScriptIds) {
         return """
-            Kestra cannot start: the database schema is not up to date and automatic migration is disabled.
-            The following migration scripts have not been applied: %s
-            To update the database schema, either:
+            Kestra cannot start: one or more database schema migrations are needed first.
+            Migration scripts to apply: %s
+            To run the migrations, either:
               - Run: kestra migrate run
               - Or enable automatic migration by setting: kestra.migration.auto=true
             """.formatted(pendingScriptIds);

--- a/core/src/main/java/io/kestra/core/migration/MigrationPendingException.java
+++ b/core/src/main/java/io/kestra/core/migration/MigrationPendingException.java
@@ -39,11 +39,11 @@ public class MigrationPendingException extends KestraRuntimeException {
 
     private static String buildMessage(final List<String> pendingScriptIds) {
         return """
-            Database migrations are pending and automatic migration is disabled.
-            Pending scripts: %s
-            To apply migrations, either:
+            Kestra cannot start: the database schema is not up to date and automatic migration is disabled.
+            The following migration scripts have not been applied: %s
+            To update the database schema, either:
               - Run: kestra migrate run
-              - Or set: kestra.migration.auto=true
+              - Or enable automatic migration by setting: kestra.migration.auto=true
             """.formatted(pendingScriptIds);
     }
 }


### PR DESCRIPTION
## What

Improves the error message shown when Kestra refuses to start because database migrations are not applied and `kestra.migration.auto=false`.

## Before

```
Database migrations are pending and automatic migration is disabled.
Pending scripts: [...]
To apply migrations, either:
  - Run: kestra migrate run
  - Or set: kestra.migration.auto=true
```

## After

```
Kestra cannot start: one or more database schema migrations are needed first.
Migration scripts to apply: [...]
To run the migrations, either:
  - Run: kestra migrate run
  - Or enable automatic migration by setting: kestra.migration.auto=true
```

## Why

The word "pending" is opaque to users unfamiliar with database migration terminology. The old message also didn't make it clear that Kestra **will not start** until the issue is resolved. The new first line is the only thing most users need to read to understand what is wrong and what to do next.