### PR TITLE
fix(apps): add tooltip and aria-label to icon-only buttons

### DIFF
--- a/ui/packages/design-system/src/components/Basic/KsButton/KsButton.vue
+++ b/ui/packages/design-system/src/components/Basic/KsButton/KsButton.vue
@@ -1,5 +1,28 @@
 <template>
+    <KsTooltip
+        v-if="tooltip"
+        :content="tooltip"
+        v-bind="tooltipPlacement ? {placement: tooltipPlacement} : {}"
+    >
+        <ElButton
+            :aria-label="tooltip"
+            v-bind="({...filteredProps(), ...$attrs} as any)"
+            @click="emit('click', $event)"
+            plain
+        >
+            <template v-if="$slots.default" #default>
+                <slot />
+            </template>
+            <template v-if="$slots.loading" #loading>
+                <slot name="loading" />
+            </template>
+            <template v-if="$slots.icon" #icon>
+                <slot name="icon" />
+            </template>
+        </ElButton>
+    </KsTooltip>
     <ElButton
+        v-else
         v-bind="({...filteredProps(), ...$attrs} as any)"
         @click="emit('click', $event)"
         plain
@@ -22,6 +45,7 @@
     import {ElButton} from "element-plus"
 
     import {useFilteredProps} from "../../../utils/filteredProps"
+    import KsTooltip from "../../Feedback/KsTooltip.vue"
 
     defineOptions({inheritAttrs: false})
 
@@ -40,6 +64,8 @@
         circle?: boolean
         color?: string
         tag?: string | Component
+        tooltip?: string
+        tooltipPlacement?: string
     }>()
 
     const emit = defineEmits<{
@@ -52,7 +78,7 @@
         icon?(): unknown
     }>()
 
-    const filteredProps = useFilteredProps(props)
+    const filteredProps = useFilteredProps(props, ["tooltip", "tooltipPlacement"])
 </script>
 
 <style lang="scss">

--- a/ui/packages/design-system/tests/storybook/Basic/KsButton.stories.ts
+++ b/ui/packages/design-system/tests/storybook/Basic/KsButton.stories.ts
@@ -1,5 +1,5 @@
 import type {Meta, StoryObj} from "@storybook/vue3-vite"
-import {within, userEvent, expect} from "storybook/test"
+import {within, userEvent, expect, waitFor} from "storybook/test"
 import {markRaw, ref} from "vue"
 import KsButton from "../../../src/components/Basic/KsButton/KsButton.vue"
 
@@ -18,6 +18,7 @@ const meta: Meta<typeof KsButton> = {
     argTypes: {
         type: {control: "select", options: ["default", "primary", "success", "warning", "info", "danger"]},
         size: {control: "select", options: ["small", "default", "large"]},
+        tooltip: {control: "text"},
         disabled: {control: "boolean"},
         loading: {control: "boolean"},
         plain: {control: "boolean"},
@@ -238,6 +239,27 @@ export const CustomColor: Story = {
             </div>
         `,
     }),
+}
+
+/** Tooltip – icon-only buttons get a hover tooltip; aria-label is derived from it */
+export const Tooltip: Story = {
+    render: (args) => ({
+        components: {KsButton},
+        setup() {
+            return {args, PlusIcon}
+        },
+        template: "<div style=\"padding:48px\"><ks-button v-bind=\"args\" :icon=\"PlusIcon\" /></div>",
+    }),
+    args: {type: "default", tooltip: "Add label"},
+    async play({canvasElement}) {
+        const canvas = within(canvasElement)
+        const btn = canvas.getByRole("button")
+        await expect(btn).toHaveAttribute("aria-label", "Add label")
+        await userEvent.hover(btn)
+        await waitFor(() =>
+            expect(document.body.querySelector("[role=\"tooltip\"]")?.textContent).toContain("Add label"),
+        )
+    },
 }
 
 /** Click event emission */

--- a/ui/packages/design-system/tests/units/Basic/KsButton.test.ts
+++ b/ui/packages/design-system/tests/units/Basic/KsButton.test.ts
@@ -105,4 +105,33 @@ describe("KsButton", () => {
         })
         expect(wrapper.find(".kel-button.is-text").exists()).toBe(true)
     })
+
+    test("tooltip prop renders the button and derives aria-label from it", () => {
+        const wrapper = mount(KsButton, {
+            props: {tooltip: "Delete"},
+            slots: {default: "x"},
+            global: globalConfig,
+        })
+        const button = wrapper.find(".kel-button")
+        expect(button.exists()).toBe(true)
+        expect(button.attributes("aria-label")).toBe("Delete")
+    })
+
+    test("without tooltip no aria-label is derived", () => {
+        const wrapper = mount(KsButton, {
+            slots: {default: "x"},
+            global: globalConfig,
+        })
+        expect(wrapper.find(".kel-button").attributes("aria-label")).toBeUndefined()
+    })
+
+    test("explicit aria-label overrides the tooltip-derived one", () => {
+        const wrapper = mount(KsButton, {
+            props: {tooltip: "Delete"},
+            attrs: {"aria-label": "Custom label"},
+            slots: {default: "x"},
+            global: globalConfig,
+        })
+        expect(wrapper.find(".kel-button").attributes("aria-label")).toBe("Custom label")
+    })
 })

--- a/ui/src/components/HamburgerDropdown.vue
+++ b/ui/src/components/HamburgerDropdown.vue
@@ -1,6 +1,6 @@
 <template>
     <KsDropdown>
-        <KsButton>
+        <KsButton :aria-label="$t('more actions')">
             <DotsVertical />
         </KsButton>
         <template #dropdown>

--- a/ui/src/components/MultiPanelTabs.vue
+++ b/ui/src/components/MultiPanelTabs.vue
@@ -86,7 +86,7 @@
                         </button>
 
                         <KsDropdown trigger="click" placement="bottom-end">
-                            <KsButton :icon="DotsVertical" link class="me-2 tab-icon" />
+                            <KsButton :icon="DotsVertical" link class="me-2 tab-icon" :aria-label="$t('panel actions')" />
                             <template #dropdown>
                                 <KsDropdownMenu>
                                     <KsDropdownItem

--- a/ui/src/components/admin/stats/Usages.vue
+++ b/ui/src/components/admin/stats/Usages.vue
@@ -15,7 +15,7 @@
                     {{ item.value }}
                 </KsText>
                 <router-link v-if="$route.params.type !== 'instance'" :to="{name: item.route}">
-                    <KsButton :icon="TextSearchVariant" link />
+                    <KsButton :icon="TextSearchVariant" link :tooltip="$t('search')" />
                 </router-link>
             </div>
             <slot name="additional-usages" />

--- a/ui/src/components/executions/Executions.vue
+++ b/ui/src/components/executions/Executions.vue
@@ -100,7 +100,7 @@
                 </KsButton>
 
                 <KsDropdown>
-                    <KsButton>
+                    <KsButton :aria-label="$t('bulk actions')">
                         <DotsVertical />
                     </KsButton>
                     <template #dropdown>

--- a/ui/src/components/executions/MetricsTable.vue
+++ b/ui/src/components/executions/MetricsTable.vue
@@ -68,7 +68,7 @@
                               query: {'filters[q][EQUALS]': scope.row.name}
                         }"
                     >
-                        <KsIconButton>
+                        <KsIconButton :tooltip="$t('view metrics')">
                             <ChartAreaspline />
                         </KsIconButton>
                     </router-link>

--- a/ui/src/components/executions/TaskRunLine.vue
+++ b/ui/src/components/executions/TaskRunLine.vue
@@ -59,8 +59,8 @@
         <slot name="buttons" />
 
         <KsDropdown trigger="click">
-            <KsButton type="default" class="task-run-buttons">
-                <DotsVertical title="" />
+            <KsButton type="default" class="task-run-buttons" :aria-label="$t('actions')">
+                <DotsVertical />
             </KsButton>
             <template #dropdown>
                 <KsDropdownMenu>

--- a/ui/src/components/flows/FlowPlayground.vue
+++ b/ui/src/components/flows/FlowPlayground.vue
@@ -11,7 +11,7 @@
                     :execution="executionsStore.execution"
                 />
                 <KsDropdown trigger="click" placement="bottom-end">
-                    <KsButton :icon="DotsVertical" link class="tab-icon" />
+                    <KsButton :icon="DotsVertical" link class="tab-icon" :aria-label="$t('playground actions')" />
                     <template #dropdown>
                         <KsDropdownMenu class="m-2">
                             <KsDropdownItem :icon="Backspace" @click="playgroundStore.clearExecutions()">

--- a/ui/src/components/inputs/FileExplorer.vue
+++ b/ui/src/components/inputs/FileExplorer.vue
@@ -61,7 +61,7 @@
                     @change="importFiles"
                 >
                 <KsDropdown>
-                    <KsButton>
+                    <KsButton :aria-label="$t('import')">
                         <PlusBox />
                     </KsButton>
                     <template #dropdown>

--- a/ui/src/components/inputs/InputsForm.vue
+++ b/ui/src/components/inputs/InputsForm.vue
@@ -181,7 +181,7 @@
                                 v-model="editableItems[input.id][index]"
                                 class="array-cell"
                             />
-                            <KsButton @click="removeArrayItem(input, index)" :icon="DeleteOutline" class="delete-input" />
+                            <KsButton @click="removeArrayItem(input, index)" :icon="DeleteOutline" class="delete-input" :tooltip="$t('remove this item')" />
                             <div class="d-flex flex-column controls-input">
                                 <ChevronUp @click="moveArrayItem(input, 'up', index)" />
                                 <ChevronDown @click="moveArrayItem(input, 'down', index)" />

--- a/ui/src/components/labels/LabelInput.vue
+++ b/ui/src/components/labels/LabelInput.vue
@@ -21,8 +21,8 @@
         </div>
         <div class="flex-shrink-1">
             <KsButtonGroup class="d-flex">
-                <KsButton :icon="Plus" @click="addItem" />
-                <KsButton :icon="Minus" @click="removeItem(index)" />
+                <KsButton :icon="Plus" @click="addItem" :tooltip="$t('add label')" />
+                <KsButton :icon="Minus" @click="removeItem(index)" :tooltip="$t('remove label')" />
             </KsButtonGroup>
         </div>
     </div>

--- a/ui/src/components/layout/Collapse.vue
+++ b/ui/src/components/layout/Collapse.vue
@@ -1,7 +1,7 @@
 <template>
     <div class="collapse mb-sm-4 mb-md-0">
         <div class="button mb-2">
-            <KsButton @click="isNavbarVisible = !isNavbarVisible">
+            <KsButton :tooltip="$t('toggle menu')" @click="isNavbarVisible = !isNavbarVisible">
                 <MenuIcon />
             </KsButton>
         </div>

--- a/ui/src/translations/en.json
+++ b/ui/src/translations/en.json
@@ -1,5 +1,14 @@
 {
   "en": {
+    "more actions": "More actions",
+    "toggle menu": "Toggle menu",
+    "panel actions": "Panel actions",
+    "playground actions": "Playground actions",
+    "bulk actions": "Bulk actions",
+    "view metrics": "View metrics",
+    "remove this item": "Remove this item",
+    "add label": "Add label",
+    "remove label": "Remove label",
     "id": "Id",
     "type": "Type",
     "ok": "OK",


### PR DESCRIPTION
## What

Gives icon-only buttons across the OSS UI a **hover tooltip + `aria-label`** so the action is discoverable and announced by screen readers. The tooltip comes from the design system, and **each button keeps the component it already used** — no appearance change.

Closes #16401

## Approach

- **`KsButton` gains an optional `tooltip` (+ `tooltipPlacement`) prop**, mirroring `KsIconButton`. It renders `KsTooltip` only when set (`v-if`-gated) and derives `aria-label` from it; props are excluded from the attrs forwarded to `ElButton`. Backward-compatible — existing buttons are untouched.
- **Icon-only `KsButton`s pass `:tooltip`** and keep their background/border (Collapse, InputsForm, LabelInput, Usages). No `KsIconButton` swap — an earlier attempt to swap made the buttons render as bare icons (no bg/border), so the component is preserved.
- **`KsIconButton` buttons keep their existing `:tooltip`** (MetricsTable).
- **Dropdown triggers keep `aria-label` only** (HamburgerDropdown, MultiPanelTabs, FlowPlayground, Executions bulk actions, TaskRunLine, FileExplorer): a tooltip on the trigger is swallowed by Element Plus's `ElDropdown` and **breaks the click-to-open** (verified), and hovering already reveals the labelled menu. Matches the existing `NavBarActionsDropdown` pattern.

Also removes the empty `title=""` on the task-run kebab. New i18n keys in `en.json` only; `actions`/`import`/`search` reused.

## Verification

Ran the UI locally: `:tooltip` shows the styled DS tooltip on hover and derives `aria-label`, buttons keep their bordered look (e.g. LabelInput +/- stay a bordered button group), dropdown menus still open, no regression / console errors. `npm run test:lint` passes.

The `KsButton` `tooltip` prop is covered by a unit test (`tests/units/Basic/KsButton.test.ts`) and a Storybook story (`tests/storybook/Basic/KsButton.stories.ts`): `npm run test:unit` (15/15) and `npm run test:storybook` (113/113) pass.

## Notes

- EE counterpart kestra-io/kestra-ee#8153 depends on the `KsButton tooltip` prop here landing first.
- `HamburgerDropdown.vue` appears unused (no references) — left fixed, worth a separate cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
