### PR TITLE
fix(security): override CSRF cookie name for HTTP compatibility

### DIFF
--- a/cli/src/main/resources/application.yml
+++ b/cli/src/main/resources/application.yml
@@ -59,6 +59,7 @@ micronaut:
     csrf:
       enabled: true
       signature-key: ${kestra.encryption.secret-key:}
+      cookie-name: csrfToken
       filter:
         enabled: false
   caches:


### PR DESCRIPTION
## Summary
- Override Micronaut's default CSRF cookie name from `__Host-csrfToken` to `csrfToken`
- The `__Host-` prefix requires HTTPS — browsers reject the cookie on plain HTTP, breaking CSRF for all HTTP deployments (local dev, behind reverse proxies)
- `httpOnly + SameSite=Strict` already provide equivalent protections

Companion PR: EE repo (re-enables SecurityFilter for JWT cookie auth)

## Test plan
- [ ] Run Kestra on `http://localhost:8080`
- [ ] Check browser console — no `__Host-csrfToken` cookie rejection errors
- [ ] Verify state-changing requests (POST/PUT/DELETE) succeed without 403