### PR TITLE
fix(tests): make shouldGetWorkerMetrics robust against async metrics persistence

### DIFF
--- a/webserver/src/test/java/io/kestra/webserver/controllers/api/ClusterControllerTest.java
+++ b/webserver/src/test/java/io/kestra/webserver/controllers/api/ClusterControllerTest.java
@@ -49,14 +49,14 @@ class ClusterControllerTest {
 
     @Test
     void shouldGetWorkerMetrics() {
-        // When
-        Set<Metric> metrics = client.toBlocking().retrieve(
-            HttpRequest.GET("/api/v1/main/cluster/metrics/" + ServiceType.WORKER),
-            Argument.of(Set.class, Metric.class)
-        );
-
-        // Then
-        assertThat(metrics).isNotEmpty();
+        // Worker metrics are persisted asynchronously via liveness heartbeats; poll until non-empty.
+        Awaitility.await().atMost(Duration.ofSeconds(10)).pollInterval(Duration.ofMillis(200)).untilAsserted(() -> {
+            Set<Metric> metrics = client.toBlocking().retrieve(
+                HttpRequest.GET("/api/v1/main/cluster/metrics/" + ServiceType.WORKER),
+                Argument.of(Set.class, Metric.class)
+            );
+            assertThat(metrics).isNotEmpty();
+        });
     }
 
 }


### PR DESCRIPTION
## Summary

- `shouldGetWorkerMetrics` was flaky because it asserted metrics non-empty immediately after `@BeforeEach` waited for `worker.getState() != null`
- Worker metrics are persisted to `ServiceInstanceRepository` asynchronously via liveness heartbeats (`ServiceLivenessManager`), so the repository could be empty at assertion time on a loaded CI runner
- Wrapped the API call in `Awaitility.untilAsserted()` (10 s / 200 ms poll) so the test retries until running-worker metrics actually appear in the repository

## Test plan

- [ ] `./gradlew :webserver:test --tests "io.kestra.webserver.controllers.api.ClusterControllerTest"` passes