### PR TITLE
fix(flows): add missing 'valid' i18n key to all locale files

### DIFF
--- a/ui/src/translations/de.json
+++ b/ui/src/translations/de.json
@@ -1,5 +1,6 @@
 {
   "de": {
+    "valid": "Gültig",
     "Add flow": "Flow hinzufügen",
     "Default log level": "Standard-Log-Ebene",
     "Default namespace": "Standard-Namespace",

--- a/ui/src/translations/en.json
+++ b/ui/src/translations/en.json
@@ -3,6 +3,7 @@
     "id": "Id",
     "type": "Type",
     "ok": "OK",
+    "valid": "Valid",
     "close": "Close",
     "namespace": "Namespace",
     "description": "Description",

--- a/ui/src/translations/es.json
+++ b/ui/src/translations/es.json
@@ -1,5 +1,6 @@
 {
   "es": {
+    "valid": "Válido",
     "Add flow": "Añadir flujo",
     "Default log level": "Nivel de log predeterminado",
     "Default namespace": "Namespace predeterminado",

--- a/ui/src/translations/fr.json
+++ b/ui/src/translations/fr.json
@@ -1,5 +1,6 @@
 {
   "fr": {
+    "valid": "Valide",
     "Add flow": "Ajouter un flow",
     "Default log level": "Niveau de log par défaut",
     "Default namespace": "Espace de nom par défaut",

--- a/ui/src/translations/hi.json
+++ b/ui/src/translations/hi.json
@@ -1,5 +1,6 @@
 {
   "hi": {
+    "valid": "मान्य",
     "Add flow": "Flow जोड़ें",
     "Default log level": "पूर्व-निर्धारित log स्तर",
     "Default namespace": "पूर्व-निर्धारित namespace",

--- a/ui/src/translations/it.json
+++ b/ui/src/translations/it.json
@@ -1,5 +1,6 @@
 {
   "it": {
+    "valid": "Valido",
     "Add flow": "Aggiungi flow",
     "Default log level": "Livello di log predefinito",
     "Default namespace": "Namespace predefinito",

--- a/ui/src/translations/ja.json
+++ b/ui/src/translations/ja.json
@@ -1,5 +1,6 @@
 {
   "ja": {
+    "valid": "有効",
     "Add flow": "Flowを追加",
     "Default log level": "デフォルトlogレベル",
     "Default namespace": "デフォルトnamespace",

--- a/ui/src/translations/ko.json
+++ b/ui/src/translations/ko.json
@@ -1,5 +1,6 @@
 {
   "ko": {
+    "valid": "유효",
     "Add flow": "Flow 추가",
     "Default log level": "기본 log 레벨",
     "Default namespace": "기본 namespace",

--- a/ui/src/translations/pl.json
+++ b/ui/src/translations/pl.json
@@ -1,5 +1,6 @@
 {
   "pl": {
+    "valid": "Prawidłowy",
     "Add flow": "Dodaj flow",
     "Default log level": "Domyślny poziom log",
     "Default namespace": "Domyślny namespace",

--- a/ui/src/translations/pt.json
+++ b/ui/src/translations/pt.json
@@ -1,5 +1,6 @@
 {
   "pt": {
+    "valid": "Válido",
     "Add flow": "Adicionar flow",
     "Default log level": "Nível de log padrão",
     "Default namespace": "Namespace padrão",

--- a/ui/src/translations/pt_BR.json
+++ b/ui/src/translations/pt_BR.json
@@ -1,5 +1,6 @@
 {
   "pt_BR": {
+    "valid": "Válido",
     "Add flow": "Adicionar flow",
     "Default log level": "Nível de log padrão",
     "Default namespace": "Namespace padrão",

--- a/ui/src/translations/ru.json
+++ b/ui/src/translations/ru.json
@@ -1,5 +1,6 @@
 {
   "ru": {
+    "valid": "Действительный",
     "Add flow": "Добавить flow",
     "Default log level": "Уровень log по умолчанию",
     "Default namespace": "Namespace по умолчанию",

--- a/ui/src/translations/zh_CN.json
+++ b/ui/src/translations/zh_CN.json
@@ -1,5 +1,6 @@
 {
   "zh_CN": {
+    "valid": "有效",
     "Add flow": "添加流程",
     "Default log level": "默认日志级别",
     "Default namespace": "默认命名空间",


### PR DESCRIPTION
## Summary

- Adds the top-level `valid` translation key to all 13 locale files (`en`, `de`, `es`, `fr`, `hi`, `it`, `ja`, `ko`, `pl`, `pt`, `pt_BR`, `ru`, `zh_CN`)
- Fixes the console warning: `[intlify] Not found 'valid' key in 'en' locale messages` thrown on every render of `ValidationError.vue`

## Root cause

Introduced by 04480d7a03 (`feat(ui): introduce new color palette (#15967)`), which replaced the old `KsButton` with `KsCodeStatus` and added `:label="$t('valid')"` to `ValidationError.vue`, but forgot to add the `valid` key to the translation files.

## Test plan

- [ ] Open any flow in the editor — no `[intlify] Not found 'valid' key` warning in the console
- [ ] The valid/error/warning status badge still renders correctly