### PR TITLE
fix(design-system): capture KsDrawer resize drag with an overlay

### DIFF
--- a/ui/packages/design-system/src/components/Feedback/KsDrawer.vue
+++ b/ui/packages/design-system/src/components/Feedback/KsDrawer.vue
@@ -92,19 +92,22 @@
         const panel = (event.target as HTMLElement).closest(".kel-drawer") as HTMLElement | null
         if (!panel) return
 
+        const overlay = document.createElement("div")
+        overlay.style.cssText = "position:fixed;inset:0;z-index:99999;cursor:ew-resize"
+
         const onMove = (move: MouseEvent) => {
             const raw = panel.getBoundingClientRect().right - move.clientX
             drawerWidth.value = Math.min(Math.max(raw, MIN_DRAWER_WIDTH), maxDrawerWidth())
         }
         const onUp = () => {
-            document.removeEventListener("mousemove", onMove)
-            document.removeEventListener("mouseup", onUp)
-            document.body.style.userSelect = ""
+            overlay.removeEventListener("mousemove", onMove)
+            overlay.removeEventListener("mouseup", onUp)
+            overlay.remove()
         }
 
-        document.body.style.userSelect = "none"
-        document.addEventListener("mousemove", onMove)
-        document.addEventListener("mouseup", onUp)
+        overlay.addEventListener("mousemove", onMove)
+        overlay.addEventListener("mouseup", onUp)
+        document.body.appendChild(overlay)
     }
 
     const filteredProps = useFilteredProps(props)


### PR DESCRIPTION
Follow-up to kestra-io/kestra#16388 (resizable KsDrawer). The resize listeners were on `document`, so an editor under the cursor (Monaco, in the EE audit-log diff) could swallow `mousemove` and stall the drag. On `mousedown`, attach a full-viewport overlay that captures move/up during the drag, then remove it on release — robust over editors and iframes.

Verified on a local EE audit-diff drawer: drag resizes continuously over the Monaco diff; the header expand/collapse icon stays coherent (collapse >=95%, expand below).

Generated with Claude Code