### PR TITLE
fix(dependencies): dim dot background in flow dependencies graph

### DIFF
--- a/ui/src/components/dependencies/Dependencies.vue
+++ b/ui/src/components/dependencies/Dependencies.vue
@@ -137,9 +137,13 @@
             height: 100%;
             overflow: hidden;
             background-color: transparent;
-            background-image: radial-gradient(circle, var(--ks-topology-dash) 1px, transparent 1px);
+            background-image: radial-gradient(circle, color-mix(in srgb, var(--ks-topology-dash) 30%, transparent) 1px, transparent 1px);
             background-repeat: repeat;
             background-size: 24px 24px;
+
+            .dark & {
+                background-image: radial-gradient(circle, color-mix(in srgb, var(--ks-topology-dash) 20%, transparent) 1px, transparent 1px);
+            }
         }
 
         & .controls {


### PR DESCRIPTION
## Summary

- Dims the dot grid background in the flow dependencies graph, which was appearing too bright (white) in dark mode
- Uses `color-mix` to apply 30% opacity in light mode and 20% in dark mode

## Test plan

- [ ] Open flow dependencies view in light mode — dots should be subtle/dimmed
- [ ] Open flow dependencies view in dark mode — dots should be even more dimmed

Closes https://github.com/kestra-io/kestra-ee/issues/8167.