### PR TITLE
fix(settings): theme switching inconsistency

### DIFF
--- a/ui/src/components/settings/BasicSettings.vue
+++ b/ui/src/components/settings/BasicSettings.vue
@@ -634,6 +634,7 @@
             async saveAllSettings() {
                 let refreshWhenSaved = false
                 const previousDefaultNamespace = localStorage.getItem("defaultNamespace")
+                const previousLang = localStorage.getItem("lang")
                 for (const key in this.pendingSettings){
                     const storedKey = this.settingsKeyMapping[key]
                     switch(key) {
@@ -674,7 +675,9 @@
                         // NOTE2: We have to wait until all values are saved
                         // before refreshing. If we don't, some values will be saved
                         // but the page will refresh before all is saved.
-                        refreshWhenSaved = true
+                        // Only refresh when the language actually changed
+                        if (this.pendingSettings[key] && this.pendingSettings[key] !== previousLang)
+                            refreshWhenSaved = true
                         break
                     }
                     default:

--- a/ui/src/utils/utils.ts
+++ b/ui/src/utils/utils.ts
@@ -164,6 +164,10 @@ export function switchTheme(miscStore: any, theme?: string) {
         }
     }
 
+    const disableTransitions = document.createElement("style")
+    disableTransitions.appendChild(document.createTextNode("*,*::before,*::after{transition:none !important}"))
+    document.head.appendChild(disableTransitions)
+
     // class name
     const htmlClass = document.getElementsByTagName("html")[0].classList
 
@@ -189,6 +193,9 @@ export function switchTheme(miscStore: any, theme?: string) {
     miscStore.theme = theme
 
     localStorage.setItem("theme", theme)
+
+    void document.body.offsetHeight
+    requestAnimationFrame(() => disableTransitions.remove())
 }
 
 export function getTheme(): "light" | "dark" {


### PR DESCRIPTION
closes https://github.com/kestra-io/kestra-ee/issues/8081

Settings save logic:

* Modified `BasicSettings.vue` so that the page only refreshes when the language setting (`lang`) actually changes, preventing unnecessary refreshes when other settings are updated. [[1]](diffhunk://#diff-15fd5025633138038c25fef93288dae67ee6c262c8a6fb5c2c9873a8f9e113c9R637) [[2]](diffhunk://#diff-15fd5025633138038c25fef93288dae67ee6c262c8a6fb5c2c9873a8f9e113c9R678-R679)

Theme switching UX improvements:

* Updated `switchTheme` in `utils.ts` to temporarily disable all CSS transitions during theme changes, preventing unwanted transition effects and ensuring a smoother visual update. The disabling style is removed immediately after the theme switch. [[1]](diffhunk://#diff-42a24da6d4344139a68d36a16961046d3d36c99710dd5374793727d49ba19921R167-R170) [[2]](diffhunk://#diff-42a24da6d4344139a68d36a16961046d3d36c99710dd5374793727d49ba19921R196-R198)