### PR TITLE
fix(tests): fix race condition in shouldResubmitTaskWhenWorkerIsStopped

### DIFF
--- a/executor/src/test/java/io/kestra/executor/AbstractServiceLivenessCoordinatorTest.java
+++ b/executor/src/test/java/io/kestra/executor/AbstractServiceLivenessCoordinatorTest.java
@@ -120,8 +120,8 @@ public abstract class AbstractServiceLivenessCoordinatorTest {
         {
             if (item.uid().equals(workerTask.uid())) {
                 if (item.getTaskRun().getState().getCurrent() == State.Type.SUCCESS) {
-                    resubmitLatch.countDown();
                     workerTaskResult.set(item);
+                    resubmitLatch.countDown();
                 }
 
                 if (item.getTaskRun().getState().getCurrent() == State.Type.RUNNING) {


### PR DESCRIPTION
## Summary

- `shouldResubmitTaskWhenWorkerIsStopped` has been failing ~5 times in the last 7 days across `jdbc-postgres` and `jdbc-mysql` CI runs with `AssertionError: Expecting actual not to be null` at line 148

## Root cause

The listener decremented `resubmitLatch` *before* setting `workerTaskResult`:

```java
// before (buggy)
resubmitLatch.countDown();   // ← main thread wakes up here
workerTaskResult.set(item);  // ← write hasn't happened yet
```

This is a race: the main thread can unblock from `resubmitLatch.await()` and read `workerTaskResult.get()` between the `countDown()` and `set()` calls, returning null.

## Fix

Swap the two lines so the result is written before the latch is signalled:

```java
// after (correct)
workerTaskResult.set(item);  // ← write happens-before
resubmitLatch.countDown();   // ← main thread wakes up
```

The CountDownLatch happens-before guarantee now ensures any thread that returns from `await()` always observes the written value.

## Test plan

- [ ] `./gradlew :jdbc-postgres:test --tests "PostgresServiceLivenessCoordinatorTest.shouldResubmitTaskWhenWorkerIsStopped"` passes locally
- [ ] `./gradlew :jdbc-mysql:test --tests "MysqlServiceLivenessCoordinatorTest.shouldResubmitTaskWhenWorkerIsStopped"` passes locally