### PR TITLE
Fix: trigger execution

### DIFF
--- a/core/src/main/java/io/kestra/core/scheduler/model/TriggerState.java
+++ b/core/src/main/java/io/kestra/core/scheduler/model/TriggerState.java
@@ -47,6 +47,7 @@ public final class TriggerState implements TriggerId {
     // the last-event id that mutate this state.
     private final EventId lastEventId;
     private final Instant lastTriggeredDate;
+    private final String executionId;
 
     @JsonProperty
     public Long getNextEvaluationEpoch() {
@@ -99,6 +100,7 @@ public final class TriggerState implements TriggerId {
             false,
             null,
             type,
+            null,
             null,
             null
         );
@@ -166,6 +168,18 @@ public final class TriggerState implements TriggerId {
      */
     public TriggerState workerId(final Clock clock, String workerId) {
         return update(clock).workerId(workerId).build();
+    }
+
+    /**
+     * Records the id of the execution currently holding this trigger's lock.
+     * <p>
+     * Set only for non-concurrent triggers (allowConcurrent=false); pass {@code null} to clear.
+     *
+     * @param clock the scheduler clock.
+     * @return a new {@link TriggerState}
+     */
+    public TriggerState executionId(final Clock clock, String executionId) {
+        return update(clock).executionId(executionId).build();
     }
 
     /**
@@ -251,7 +265,10 @@ public final class TriggerState implements TriggerId {
         // switch disabled automatically if the executionEndState is one of the stopAfter states
         boolean disabled = getStopAfter() != null ? getStopAfter().contains(state) : isDisabled();
 
-        return update(clock).disabled(disabled).build();
+        return update(clock)
+            .disabled(disabled)
+            .executionId(null)
+            .build();
     }
 
     /**
@@ -265,6 +282,7 @@ public final class TriggerState implements TriggerId {
             .nextEvaluationDate(null)
             .locked(false)
             .workerId(null)
+            .executionId(null)
             .build();
     }
 
@@ -333,7 +351,8 @@ public final class TriggerState implements TriggerId {
             .disabled(disabled)
             .type(type)
             .lastEventId(lastEventId)
-            .lastTriggeredDate(lastTriggeredDate);
+            .lastTriggeredDate(lastTriggeredDate)
+            .executionId(executionId);
     }
 
     // Lombok hack to properly generate Javadoc

--- a/scheduler/src/main/java/io/kestra/scheduler/TriggerEventHandler.java
+++ b/scheduler/src/main/java/io/kestra/scheduler/TriggerEventHandler.java
@@ -273,6 +273,9 @@ public class TriggerEventHandler {
 
             if (event.evaluation() != null) {
                 newState = newState.updateOnExecutionCreated(clock, event.evaluation().stateType());
+                if (data.getRight() != null && !data.getRight().isAllowConcurrent()) {
+                    newState = newState.executionId(clock, event.evaluation().executionId());
+                }
             }
 
             newState = newState.lastEventId(clock, event.eventId());

--- a/scheduler/src/main/java/io/kestra/scheduler/TriggerScheduler.java
+++ b/scheduler/src/main/java/io/kestra/scheduler/TriggerScheduler.java
@@ -339,9 +339,11 @@ public class TriggerScheduler {
         Optional<TriggerEvaluationResult> evaluationResult = schedulableEvaluator.evaluate(trigger, triggerContext, triggerEvaluationContext.conditionContext());
         if (evaluationResult.isPresent()) {
             log(clock, triggerContext, evaluationResult.get());
+            boolean allowConcurrent = ((AbstractTrigger) trigger).isAllowConcurrent();
             triggerState = triggerState
                 .updateOnExecutionCreated(clock, evaluationResult.get().stateType())
-                .locked(clock, !((AbstractTrigger) trigger).isAllowConcurrent());
+                .locked(clock, !allowConcurrent)
+                .executionId(clock, allowConcurrent ? null : evaluationResult.get().executionId());
         }
         // Save the final trigger state
         triggerStateStore.save(triggerState);

--- a/scheduler/src/test/java/io/kestra/scheduler/TriggerEventHandlerTest.java
+++ b/scheduler/src/test/java/io/kestra/scheduler/TriggerEventHandlerTest.java
@@ -419,6 +419,78 @@ class TriggerEventHandlerTest {
     }
 
     @Test
+    void shouldPersistExecutionIdGivenNonConcurrentTriggerWhenEvaluated() {
+        // GIVEN — default flow's Schedule trigger is non-concurrent (allowConcurrent=false by default)
+        triggerStateStore.save(triggerState);
+        handler = newTriggerEventHandler(List.of(Fixtures.defaultFlow()));
+        String executionId = IdUtils.create();
+        TriggerEvaluated event = new TriggerEvaluated(
+            triggerId, new TriggerEvaluationResult(
+                executionId,
+                State.Type.CREATED,
+                null,
+                null,
+                null,
+                null,
+                null
+            )
+        );
+
+        // WHEN
+        handler.handle(CLOCK, TEST_VNODE, event);
+
+        // THEN
+        Optional<TriggerState> updated = triggerStateStore.findById(triggerId);
+        assertThat(updated).isPresent();
+        assertThat(updated.get().getExecutionId()).isEqualTo(executionId);
+    }
+
+    @Test
+    void shouldNotPersistExecutionIdGivenConcurrentTriggerWhenEvaluated() {
+        // GIVEN — a flow whose trigger explicitly allows concurrent executions
+        triggerStateStore.save(triggerState);
+        handler = newTriggerEventHandler(
+            List.of(Fixtures.defaultFlow(build -> build.allowConcurrent(true).build()))
+        );
+        TriggerEvaluated event = new TriggerEvaluated(
+            triggerId, new TriggerEvaluationResult(
+                IdUtils.create(),
+                State.Type.CREATED,
+                null,
+                null,
+                null,
+                null,
+                null
+            )
+        );
+
+        // WHEN
+        handler.handle(CLOCK, TEST_VNODE, event);
+
+        // THEN
+        Optional<TriggerState> updated = triggerStateStore.findById(triggerId);
+        assertThat(updated).isPresent();
+        assertThat(updated.get().getExecutionId()).isNull();
+    }
+
+    @Test
+    void shouldClearExecutionIdGivenExecutionTerminatedWhenHandled() {
+        // GIVEN — a locked trigger that already holds a locking execution id
+        triggerStateStore.save(triggerState.locked(CLOCK, true).executionId(CLOCK, "exec-123"));
+        handler = newTriggerEventHandler(List.of());
+        TriggerExecutionTerminated event = new TriggerExecutionTerminated(triggerId, "exec-123", State.Type.SUCCESS);
+
+        // WHEN
+        handler.handle(CLOCK, TEST_VNODE, event);
+
+        // THEN
+        Optional<TriggerState> updated = triggerStateStore.findById(triggerId);
+        assertThat(updated).isPresent();
+        assertThat(updated.get().isLocked()).isFalse();
+        assertThat(updated.get().getExecutionId()).isNull();
+    }
+
+    @Test
     void shouldExecuteFailedTriggerGivenFlowAndFailedEvaluationWhenHandled() {
         // GIVEN
         triggerStateStore.save(triggerState);

--- a/scheduler/src/test/java/io/kestra/scheduler/TriggerSchedulerTest.java
+++ b/scheduler/src/test/java/io/kestra/scheduler/TriggerSchedulerTest.java
@@ -130,6 +130,9 @@ class TriggerSchedulerTest {
         assertThat(execution.getTenantId()).isEqualTo(flow.getTenantId());
         assertThat(execution.getNamespace()).isEqualTo(flow.getNamespace());
         assertThat(execution.getFlowId()).isEqualTo(flow.getId());
+
+        // The locking execution id is persisted on the trigger state (allowConcurrent defaults to false).
+        assertThat(state.getExecutionId()).isEqualTo(execution.getId());
     }
 
     @Test

--- a/scheduler/src/test/java/io/kestra/scheduler/TriggerStateExecutionIdTest.java
+++ b/scheduler/src/test/java/io/kestra/scheduler/TriggerStateExecutionIdTest.java
@@ -1,0 +1,58 @@
+package io.kestra.scheduler;
+
+import java.time.Clock;
+
+import io.kestra.core.models.flows.State;
+import io.kestra.core.scheduler.model.TriggerState;
+import io.kestra.core.scheduler.model.TriggerType;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class TriggerStateExecutionIdTest {
+
+    private static final Clock CLOCK = Clock.systemUTC();
+
+    private static TriggerState newState() {
+        return TriggerState.of(Fixtures.triggerId(), TriggerType.SCHEDULE, null, false, 0);
+    }
+
+    @Test
+    void shouldDefaultExecutionIdToNull() {
+        assertThat(newState().getExecutionId()).isNull();
+    }
+
+    @Test
+    void shouldSetExecutionIdWhenAssigned() {
+        TriggerState state = newState().executionId(CLOCK, "exec-123");
+        assertThat(state.getExecutionId()).isEqualTo("exec-123");
+    }
+
+    @Test
+    void shouldPreserveExecutionIdAcrossUpdate() {
+        TriggerState state = newState()
+            .executionId(CLOCK, "exec-123")
+            .locked(CLOCK, true);
+        assertThat(state.getExecutionId()).isEqualTo("exec-123");
+        assertThat(state.isLocked()).isTrue();
+    }
+
+    @Test
+    void shouldClearExecutionIdWhenReset() {
+        TriggerState state = newState()
+            .executionId(CLOCK, "exec-123")
+            .locked(CLOCK, true)
+            .reset(CLOCK);
+        assertThat(state.getExecutionId()).isNull();
+        assertThat(state.isLocked()).isFalse();
+    }
+
+    @Test
+    void shouldClearExecutionIdWhenExecutionTerminated() {
+        TriggerState state = newState()
+            .executionId(CLOCK, "exec-123")
+            .updateOnExecutionTerminated(CLOCK, State.Type.SUCCESS);
+        assertThat(state.getExecutionId()).isNull();
+    }
+}

--- a/ui/src/components/admin/triggers/TriggersManage.vue
+++ b/ui/src/components/admin/triggers/TriggersManage.vue
@@ -143,6 +143,15 @@
                     <template v-else-if="col.prop === 'workerId'">
                         <KsId :value="scope.row.workerId" :shrink="true" />
                     </template>
+                    <template v-else-if="col.prop === 'executionId'">
+                        <router-link
+                            v-if="scope.row.executionId && scope.row.namespace && scope.row.flowId"
+                            :to="{name: 'executions/update', params: {tenant: route.params?.tenant, namespace: scope.row.namespace, flowId: scope.row.flowId, id: scope.row.executionId}}"
+                        >
+                            <KsId :value="scope.row.executionId" :shrink="true" />
+                        </router-link>
+                        <span v-else />
+                    </template>
                     <template v-else-if="col.prop === 'lastTriggeredDate'">
                         <KsDateAgo :inverted="true" :date="scope.row.lastTriggeredDate" />
                     </template>
@@ -408,6 +417,12 @@
             prop: "workerId",
             default: false,
             description: t("filter.table_column.triggers.workerId"),
+        },
+        {
+            label: t("execution id"),
+            prop: "executionId",
+            default: true,
+            description: t("filter.table_column.triggers.execution id"),
         },
         {
             label: t("last trigger date"),

--- a/ui/src/components/flows/FlowTriggers.vue
+++ b/ui/src/components/flows/FlowTriggers.vue
@@ -107,6 +107,15 @@
                 <template v-else-if="col.prop === 'updatedAt'">
                     <KsDateAgo :inverted="true" :date="scope.row.updatedAt" />
                 </template>
+                <template v-else-if="col.prop === 'executionId'">
+                    <router-link
+                        v-if="scope.row.executionId && scope.row.namespace && scope.row.flowId"
+                        :to="{name: 'executions/update', params: {tenant: route.params?.tenant, namespace: scope.row.namespace, flowId: scope.row.flowId, id: scope.row.executionId}}"
+                    >
+                        <KsId :value="scope.row.executionId" :shrink="true" />
+                    </router-link>
+                    <span v-else />
+                </template>
                 <template v-else>
                     {{ scope.row[col.prop] }}
                 </template>
@@ -355,6 +364,11 @@
         {
             label: t("type"),
             prop: "type",
+            default: true,
+        },
+        {
+            label: t("execution id"),
+            prop: "executionId",
             default: true,
         },
         {

--- a/ui/src/translations/en.json
+++ b/ui/src/translations/en.json
@@ -65,6 +65,7 @@
     "edit flow": "Edit flow",
     "executions": "Executions",
     "execution": "Execution",
+    "execution id": "Execution Id",
     "recent_executions": "Recent Executions",
     "details": "Details",
     "overview": "Overview",

--- a/webserver/src/main/java/io/kestra/webserver/models/api/ApiTriggerState.java
+++ b/webserver/src/main/java/io/kestra/webserver/models/api/ApiTriggerState.java
@@ -27,7 +27,8 @@ public record ApiTriggerState(
     boolean disabled,
     boolean locked,
     String workerId,
-    Instant lastTriggeredDate
+    Instant lastTriggeredDate,
+    String executionId
 ) {
     public static ApiTriggerState from(TriggerState state) {
         return new ApiTriggerState(
@@ -42,7 +43,8 @@ public record ApiTriggerState(
             state.isDisabled(),
             state.isLocked(),
             state.getWorkerId(),
-            truncate(state.getLastTriggeredDate())
+            truncate(state.getLastTriggeredDate()),
+            state.getExecutionId()
         );
     }
 

--- a/webserver/src/test/java/io/kestra/webserver/models/api/ApiTriggerStateTest.java
+++ b/webserver/src/test/java/io/kestra/webserver/models/api/ApiTriggerStateTest.java
@@ -1,0 +1,25 @@
+package io.kestra.webserver.models.api;
+
+import java.time.Clock;
+
+import io.kestra.core.models.triggers.TriggerId;
+import io.kestra.core.scheduler.model.TriggerState;
+import io.kestra.core.scheduler.model.TriggerType;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ApiTriggerStateTest {
+
+    @Test
+    void shouldExposeExecutionId() {
+        TriggerState state = TriggerState
+            .of(TriggerId.of("tenant", "namespace", "flow", "trigger"), TriggerType.SCHEDULE, null, false, 0)
+            .executionId(Clock.systemUTC(), "exec-123");
+
+        ApiTriggerState dto = ApiTriggerState.from(state);
+
+        assertThat(dto.executionId()).isEqualTo("exec-123");
+    }
+}


### PR DESCRIPTION
When a polling or schedule trigger has allowConcurrent=false, record the id
of the execution holding the lock on the trigger state and clear it when the
execution terminates or the trigger is reset. Expose it through ApiTriggerState.

No DB migration: the execution_id generated column on the triggers table
already reads the 'executionId' JSON key in all three dialects.