### PR TITLE
fix(core): make Webhook wait for execution to be created

### DIFF
--- a/core/src/main/java/io/kestra/core/async/AsyncOperationsConfiguration.java
+++ b/core/src/main/java/io/kestra/core/async/AsyncOperationsConfiguration.java
@@ -1,4 +1,4 @@
-package io.kestra.webserver.configuration;
+package io.kestra.core.async;
 
 import java.time.Duration;
 

--- a/core/src/main/java/io/kestra/core/services/WebhookService.java
+++ b/core/src/main/java/io/kestra/core/services/WebhookService.java
@@ -7,6 +7,8 @@ import java.util.stream.Collectors;
 import org.apache.hc.core5.http.NameValuePair;
 import org.apache.hc.core5.net.URIBuilder;
 
+import io.kestra.core.async.AsyncOperationProcessedEvent;
+import io.kestra.core.async.AsyncOperationsConfiguration;
 import io.kestra.core.events.CrudEvent;
 import io.kestra.core.models.Label;
 import io.kestra.core.models.executions.Execution;
@@ -18,7 +20,6 @@ import io.kestra.core.executor.command.Create;
 import io.kestra.core.executor.command.ExecutionCommand;
 import io.kestra.core.models.executions.ExecutionId;
 import io.kestra.core.queues.DispatchQueueInterface;
-import io.kestra.core.queues.QueueException;
 import io.kestra.core.runners.FlowInputOutput;
 import io.kestra.core.runners.RunContext;
 import io.kestra.core.runners.RunContextFactory;
@@ -38,6 +39,7 @@ import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 import lombok.extern.slf4j.Slf4j;
 import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
 
 import static io.kestra.core.models.Label.CORRELATION_ID;
 
@@ -67,6 +69,12 @@ public class WebhookService {
 
     @Inject
     private Optional<OpenTelemetry> openTelemetry;
+
+    @Inject
+    private AsyncOperationWaiter asyncOperationWaiter;
+
+    @Inject
+    private AsyncOperationsConfiguration asyncOperationsConfiguration;
 
     /**
      * Parse query parameters from the webhook request URI.
@@ -140,13 +148,16 @@ public class WebhookService {
     }
 
     /**
-     * Start the execution by injecting trace context and emitting it to the execution queue.
+     * Start the execution by injecting trace context, emitting a {@link Create} command to the
+     * execution queue tagged with an {@code operationId}, and waiting asynchronously for the
+     * executor to confirm processing via {@link AsyncOperationProcessedEvent}.
      *
      * @param execution The execution to start
-     * @throws QueueException If there is an error emitting to the queue
+     * @return a {@link Mono} that completes with the processed event once the executor confirms,
+     *         or signals a {@link java.util.concurrent.TimeoutException} if no confirmation
+     *         arrives within the configured timeout
      */
-    public void startExecution(Execution execution) throws QueueException {
-        // extract traceparent from the current OTel context
+    public Mono<AsyncOperationProcessedEvent> startExecution(Execution execution) {
         Optional<String> traceParent = openTelemetry
             .map(OpenTelemetry::getPropagators)
             .map(ContextPropagators::getTextMapPropagator)
@@ -156,13 +167,25 @@ public class WebhookService {
                 return carrier.get("traceparent");
             });
 
-        executionCommandQueue.emit(Create.of(new ExecutionId(execution.getTenantId(), execution.getNamespace(), execution.getFlowId(), execution.getId(), execution.getFlowRevision()))
+        Create command = Create.of(new ExecutionId(execution.getTenantId(), execution.getNamespace(), execution.getFlowId(), execution.getId(), execution.getFlowRevision()))
             .withKind(execution.getKind())
             .withTrigger(execution.getTrigger())
             .withLabels(execution.getLabels())
             .withInputs(execution.getInputs())
-            .withTraceParent(traceParent.orElse(null)));
-        eventPublisher.publishEvent(CrudEvent.create(execution));
+            .withTraceParent(traceParent.orElse(null));
+
+        return asyncOperationWaiter.submit(
+            execution.getId(),
+            operationId -> {
+                try {
+                    executionCommandQueue.emit(command.withOperationId(operationId));
+                    eventPublisher.publishEvent(CrudEvent.create(execution));
+                } catch (Exception e) {
+                    throw new RuntimeException(e);
+                }
+            },
+            asyncOperationsConfiguration.waitTimeout()
+        );
     }
 
     /**

--- a/core/src/main/java/io/kestra/plugin/core/trigger/Webhook.java
+++ b/core/src/main/java/io/kestra/plugin/core/trigger/Webhook.java
@@ -15,7 +15,6 @@ import io.kestra.core.models.annotations.PluginProperty;
 import io.kestra.core.models.executions.Execution;
 import io.kestra.core.models.property.Property;
 import io.kestra.core.models.triggers.TriggerOutput;
-import io.kestra.core.queues.QueueException;
 import io.kestra.core.runners.RunContext;
 import io.kestra.core.serializers.JacksonMapper;
 import io.kestra.core.validations.WebhookValidation;
@@ -27,7 +26,6 @@ import lombok.*;
 import lombok.experimental.SuperBuilder;
 import reactor.core.publisher.Mono;
 
-import static io.kestra.core.utils.Rethrow.throwFunction;
 
 @SuperBuilder
 @ToString
@@ -191,31 +189,31 @@ public class Webhook extends AbstractWebhookTrigger implements TriggerOutput<Web
 
         Execution execution = maybeExecution.get();
 
-        try {
-            context.webhookService().startExecution(execution);
-        } catch (QueueException e) {
-            return Mono.just(HttpResponse.of(HttpResponse.Status.INTERNAL_SERVER_ERROR));
-        }
-
-        if (!this.wait) {
-            return Mono.just(HttpResponse.of(context.webhookService().executionResponse(execution)));
-        }
-
-        return context
-            .webhookService()
-            .followExecution(execution, context.flow())
-            .last()
-            .map(throwFunction(event ->
-            {
-                RunContext runContext = context.webhookService().runContext(context.flow(), event.getData());
-                int responseCode = runContext.render(this.responseCode).as(Integer.class).orElse(event.getData().getState().isFailed() ? 500 : 200);
-
-                if (this.getReturnOutputs()) {
-                    return buildOutputResponse(event.getData().getOutputs(), responseContentType, HttpResponse.Status.valueOf(responseCode));
-                } else {
-                    return HttpResponse.of(HttpResponse.Status.valueOf(responseCode), context.webhookService().executionResponse(event.getData()));
+        return context.webhookService().startExecution(execution)
+            .flatMap(__ -> {
+                if (!this.wait) {
+                    return Mono.<HttpResponse<?>>just(HttpResponse.of(context.webhookService().executionResponse(execution)));
                 }
-            }));
+
+                return context
+                    .webhookService()
+                    .followExecution(execution, context.flow())
+                    .last()
+                    .flatMap(event -> {
+                        try {
+                            RunContext runContext = context.webhookService().runContext(context.flow(), event.getData());
+                            int responseCode = runContext.render(this.responseCode).as(Integer.class).orElse(event.getData().getState().isFailed() ? 500 : 200);
+
+                            HttpResponse<?> response = this.getReturnOutputs()
+                                ? buildOutputResponse(event.getData().getOutputs(), responseContentType, HttpResponse.Status.valueOf(responseCode))
+                                : HttpResponse.of(HttpResponse.Status.valueOf(responseCode), context.webhookService().executionResponse(event.getData()));
+                            return Mono.<HttpResponse<?>>just(response);
+                        } catch (Exception e) {
+                            return Mono.error(e);
+                        }
+                    });
+            })
+            .onErrorReturn(HttpResponse.of(HttpResponse.Status.INTERNAL_SERVER_ERROR));
     }
 
     private HttpResponse<?> buildOutputResponse(Object body, String responseContentType, HttpResponse.Status responseCode) {

--- a/core/src/test/java/io/kestra/plugin/core/trigger/WebhookBuilderTest.java
+++ b/core/src/test/java/io/kestra/plugin/core/trigger/WebhookBuilderTest.java
@@ -9,12 +9,12 @@ import io.kestra.core.http.HttpRequest;
 import io.kestra.core.models.flows.Flow;
 import io.kestra.core.services.WebhookService;
 
-import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import io.kestra.core.junit.annotations.KestraTest;
 import jakarta.inject.Inject;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@MicronautTest
+@KestraTest(startRunner = true)
 public class WebhookBuilderTest {
     @Inject
     WebhookService webhookService;

--- a/core/src/test/java/io/kestra/plugin/core/trigger/WebhookBuilderTest.java
+++ b/core/src/test/java/io/kestra/plugin/core/trigger/WebhookBuilderTest.java
@@ -1,27 +1,44 @@
 package io.kestra.plugin.core.trigger;
 
 import java.net.URI;
+import java.time.Instant;
 import java.util.Objects;
 
 import org.junit.jupiter.api.Test;
 
+import io.kestra.core.async.AsyncOperationProcessedEvent;
 import io.kestra.core.http.HttpRequest;
 import io.kestra.core.models.flows.Flow;
+import io.kestra.core.services.AsyncOperationWaiter;
 import io.kestra.core.services.WebhookService;
 
-import io.kestra.core.junit.annotations.KestraTest;
+import io.micronaut.test.annotation.MockBean;
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
 import jakarta.inject.Inject;
+import reactor.core.publisher.Mono;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
-@KestraTest(startRunner = true)
+@MicronautTest
 public class WebhookBuilderTest {
     @Inject
     WebhookService webhookService;
 
+    @MockBean(AsyncOperationWaiter.class)
+    AsyncOperationWaiter asyncOperationWaiter() {
+        AsyncOperationWaiter mock = mock(AsyncOperationWaiter.class);
+        when(mock.submit(any(), any(), any()))
+            .thenReturn(Mono.just(new AsyncOperationProcessedEvent(
+                "op-id", null, "item-id", AsyncOperationProcessedEvent.Outcome.SUCCEEDED, null, Instant.now()
+            )));
+        return mock;
+    }
+
     @Test
     void testWebhookBuilder() {
-        // Test that the Webhook class can be built with the new hierarchy
         Webhook webhook = Webhook.builder()
             .id("test-webhook")
             .type(Webhook.class.getName())
@@ -47,16 +64,8 @@ public class WebhookBuilderTest {
             .build();
 
         HttpRequest request = HttpRequest.of(URI.create("/api/v1/main/executions/webhook/io.kestra.tests/test-flow/testkey"));
-        String path = null;
 
-        var webhookContext = new WebhookContext(
-            request,
-            path,
-            flow,
-            webhook,
-            webhookService
-        );
-
+        var webhookContext = new WebhookContext(request, null, flow, webhook, webhookService);
         var evaluate = webhook.evaluate(webhookContext);
 
         assertThat(evaluate).isNotNull();

--- a/core/src/test/java/io/kestra/plugin/core/trigger/WebhookTestPlugin.java
+++ b/core/src/test/java/io/kestra/plugin/core/trigger/WebhookTestPlugin.java
@@ -7,7 +7,6 @@ import io.kestra.core.models.annotations.Plugin;
 import io.kestra.core.models.executions.Execution;
 import io.kestra.core.models.tasks.common.EncryptedString;
 import io.kestra.core.models.triggers.TriggerOutput;
-import io.kestra.core.queues.QueueException;
 import io.kestra.core.serializers.JacksonMapper;
 
 import io.micronaut.http.HttpStatus;
@@ -47,13 +46,9 @@ public class WebhookTestPlugin extends AbstractWebhookTrigger implements Trigger
 
         Execution execution = maybeExecution.get();
 
-        try {
-            context.webhookService().startExecution(execution);
-        } catch (QueueException e) {
-            return Mono.just(HttpResponse.of(HttpResponse.Status.INTERNAL_SERVER_ERROR));
-        }
-
-        return Mono.just(HttpResponse.of(HttpStatus.OK));
+        return context.webhookService().startExecution(execution)
+            .<HttpResponse<?>>thenReturn(HttpResponse.of(HttpStatus.OK))
+            .onErrorReturn(HttpResponse.of(HttpResponse.Status.INTERNAL_SERVER_ERROR));
     }
 
     @Builder

--- a/webserver/src/main/java/io/kestra/webserver/controllers/api/ExecutionController.java
+++ b/webserver/src/main/java/io/kestra/webserver/controllers/api/ExecutionController.java
@@ -71,7 +71,7 @@ import io.kestra.core.utils.Logs;
 import io.kestra.plugin.core.trigger.AbstractWebhookTrigger;
 import io.kestra.plugin.core.trigger.WebhookContext;
 import io.kestra.plugin.core.trigger.WebhookResponse;
-import io.kestra.webserver.configuration.AsyncOperationsConfiguration;
+import io.kestra.core.async.AsyncOperationsConfiguration;
 import io.kestra.webserver.converters.QueryFilterFormat;
 import io.kestra.webserver.models.api.ApiAsyncOperationResponse;
 import io.kestra.webserver.models.api.ApiExecution;

--- a/webserver/src/main/java/io/kestra/webserver/services/TriggerStateService.java
+++ b/webserver/src/main/java/io/kestra/webserver/services/TriggerStateService.java
@@ -30,7 +30,7 @@ import io.kestra.core.scheduler.model.TriggerState;
 import io.kestra.core.scheduler.queue.TriggerEventQueue;
 import io.kestra.core.utils.IdUtils;
 import io.kestra.core.services.AsyncOperationWaiter;
-import io.kestra.webserver.configuration.AsyncOperationsConfiguration;
+import io.kestra.core.async.AsyncOperationsConfiguration;
 import io.kestra.webserver.models.api.ApiAsyncOperationResponse;
 
 import io.micronaut.http.HttpStatus;

--- a/webserver/src/test/java/io/kestra/webserver/controllers/api/ExecutionControllerRunnerTest.java
+++ b/webserver/src/test/java/io/kestra/webserver/controllers/api/ExecutionControllerRunnerTest.java
@@ -1057,6 +1057,27 @@ class ExecutionControllerRunnerTest {
     }
 
     @Test
+    @LoadFlows({ "flows/valids/webhook.yaml" })
+    void shouldPersistExecutionBeforeWebhookResponds() {
+        // Given
+        Flow webhook = flowRepositoryInterface.findById(TENANT_ID, TESTS_FLOW_NS, "webhook").orElseThrow();
+        String key = ((Webhook) webhook.getTriggers().getFirst()).getKey();
+
+        // When — call the webhook and get the execution back
+        Execution execution = client.toBlocking().retrieve(
+            HttpRequest.POST(
+                "/api/v1/main/executions/webhook/" + TESTS_FLOW_NS + "/webhook/" + key,
+                ImmutableMap.of("a", 1)
+            ),
+            Execution.class
+        );
+
+        // Then — the execution must already be in the repository by the time the response arrives,
+        // no polling needed (AsyncOperationWaiter guarantees it)
+        assertThat(executionRepositoryInterface.findById(TENANT_ID, execution.getId())).isPresent();
+    }
+
+    @Test
     @LoadFlows({ "flows/valids/webhook-wait.yaml" })
     void shouldWaitForWebhookAndReturnOutput() {
         Flow webhook = flowRepositoryInterface.findById(TENANT_ID, TESTS_FLOW_NS, "webhook-wait").orElseThrow();

--- a/webserver/src/test/java/io/kestra/webserver/controllers/api/ExecutionControllerRunnerTest.java
+++ b/webserver/src/test/java/io/kestra/webserver/controllers/api/ExecutionControllerRunnerTest.java
@@ -26,6 +26,7 @@ import java.util.stream.IntStream;
 import org.hamcrest.Matcher;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.google.common.collect.ImmutableMap;
@@ -44,8 +45,10 @@ import io.kestra.core.models.executions.ExecutionKind;
 import io.kestra.core.models.executions.TaskRun;
 import io.kestra.core.models.flows.Flow;
 import io.kestra.core.models.flows.FlowInterface;
+import io.kestra.core.models.flows.FlowForExecution;
 import io.kestra.core.models.flows.State;
 import io.kestra.core.models.flows.State.Type;
+import io.kestra.core.models.triggers.AbstractTriggerForExecution;
 import io.kestra.core.models.storage.FileMetas;
 import io.kestra.core.models.tasks.common.EncryptedString;
 import io.kestra.core.queues.*;
@@ -1075,6 +1078,112 @@ class ExecutionControllerRunnerTest {
         // Then — the execution must already be in the repository by the time the response arrives,
         // no polling needed (AsyncOperationWaiter guarantees it)
         assertThat(executionRepositoryInterface.findById(TENANT_ID, execution.getId())).isPresent();
+    }
+
+    @Test
+    @LoadFlows(value = { "flows/valids/webhook-dynamic-key.yaml" })
+    void webhookDynamicKey() {
+        Execution execution = client.toBlocking().retrieve(
+            GET(
+                "/api/v1/main/executions/webhook/" + TESTS_FLOW_NS + "/webhook-dynamic-key/webhook-dynamic-key"
+            ),
+            Execution.class
+        );
+
+        assertThat(execution).isNotNull();
+        assertThat(execution.getId()).isNotNull();
+    }
+
+    @Test
+    @LoadFlows(value = { "flows/valids/webhook-secret-key.yaml" })
+    @EnabledIfEnvironmentVariable(named = "SECRET_WEBHOOK_KEY", matches = ".*")
+    void webhookDynamicKeyFromASecret() {
+        Execution execution = client.toBlocking().retrieve(
+            GET(
+                "/api/v1/main/executions/webhook/" + TESTS_FLOW_NS + "/webhook-secret-key/secretKey"
+            ),
+            Execution.class
+        );
+
+        assertThat(execution).isNotNull();
+        assertThat(execution.getId()).isNotNull();
+    }
+
+    @Test
+    @LoadFlows(value = { "flows/valids/webhook-with-condition.yaml" })
+    void webhookWithCondition() {
+        record Hello(String hello) {
+        }
+
+        Execution execution = client.toBlocking().retrieve(
+            HttpRequest
+                .POST(
+                    "/api/v1/main/executions/webhook/" + TESTS_FLOW_NS + "/webhook-with-condition/webhookKey",
+                    new Hello("world")
+                ),
+            Execution.class
+        );
+
+        assertThat(execution).isNotNull();
+        assertThat(execution.getId()).isNotNull();
+
+        HttpClientResponseException e = assertThrows(
+            HttpClientResponseException.class, () -> client.toBlocking().exchange(
+                HttpRequest
+                    .POST(
+                        "/api/v1/main/executions/webhook/" + TESTS_FLOW_NS + "/webhook-with-condition/webhookKey",
+                        new Hello("webhook")
+                    ),
+                Execution.class
+            )
+        );
+        assertThat(e.getResponse().getStatus().getCode()).isEqualTo(HttpStatus.CONFLICT.getCode());
+        assertThat(e.getResponse().body()).isNull();
+    }
+
+    @Test
+    @LoadFlows(value = { "flows/valids/webhook-inputs.yaml" })
+    void webhookWithInputs() {
+        record Hello(String hello) {
+        }
+
+        Execution execution = client.toBlocking().retrieve(
+            HttpRequest
+                .POST(
+                    "/api/v1/main/executions/webhook/" + TESTS_FLOW_NS + "/webhook-inputs/webhookKey",
+                    new Hello("world")
+                ),
+            Execution.class
+        );
+
+        assertThat(execution).isNotNull();
+        assertThat(execution.getId()).isNotNull();
+    }
+
+    @SuppressWarnings("DataFlowIssue")
+    @Test
+    @LoadFlows(value = { "flows/valids/webhook.yaml" })
+    void getExecutionFlowForExecutionById() {
+        Flow webhook = flowRepositoryInterface.findById(TENANT_ID, TESTS_FLOW_NS, "webhook").orElseThrow();
+        String key = ((Webhook) webhook.getTriggers().getFirst()).getKey();
+
+        Execution execution = client.toBlocking().retrieve(
+            HttpRequest
+                .POST(
+                    "/api/v1/main/executions/webhook/" + TESTS_FLOW_NS + "/webhook/" + key + "?name=john&age=12&age=13",
+                    ImmutableMap.of("a", 1, "b", true)
+                ),
+            Execution.class
+        );
+
+        FlowForExecution result = client.toBlocking().retrieve(
+            GET("/api/v1/main/executions/" + execution.getId() + "/flow"),
+            FlowForExecution.class
+        );
+
+        assertThat(result.getId()).isEqualTo(execution.getFlowId());
+        assertThat(result.getTriggers()).hasSize(1);
+        assertThat((result.getTriggers().getFirst() instanceof AbstractTriggerForExecution)).isTrue();
     }
 
     @Test

--- a/webserver/src/test/java/io/kestra/webserver/controllers/api/ExecutionControllerTest.java
+++ b/webserver/src/test/java/io/kestra/webserver/controllers/api/ExecutionControllerTest.java
@@ -11,8 +11,6 @@ import java.util.Objects;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
-
 import com.google.common.collect.ImmutableMap;
 
 import io.kestra.core.junit.annotations.KestraTest;
@@ -59,7 +57,6 @@ class ExecutionControllerTest {
     private ReactorHttpClient client;
 
     public static final String TESTS_FLOW_NS = "io.kestra.tests";
-    public static final String TESTS_WEBHOOK_KEY = "a-secret-key";
 
     @Test
     void getExecutionNotFound() {
@@ -169,86 +166,6 @@ class ExecutionControllerTest {
     }
 
     @Test
-    @LoadFlows(value = { "flows/valids/webhook-dynamic-key.yaml" })
-    void webhookDynamicKey() {
-        Execution execution = client.toBlocking().retrieve(
-            GET(
-                "/api/v1/main/executions/webhook/" + TESTS_FLOW_NS + "/webhook-dynamic-key/webhook-dynamic-key"
-            ),
-            Execution.class
-        );
-
-        assertThat(execution).isNotNull();
-        assertThat(execution.getId()).isNotNull();
-    }
-
-    @Test
-    @LoadFlows(value = { "flows/valids/webhook-secret-key.yaml" })
-    @EnabledIfEnvironmentVariable(named = "SECRET_WEBHOOK_KEY", matches = ".*")
-    void webhookDynamicKeyFromASecret() {
-        Execution execution = client.toBlocking().retrieve(
-            GET(
-                "/api/v1/main/executions/webhook/" + TESTS_FLOW_NS + "/webhook-secret-key/secretKey"
-            ),
-            Execution.class
-        );
-
-        assertThat(execution).isNotNull();
-        assertThat(execution.getId()).isNotNull();
-    }
-
-    @Test
-    @LoadFlows(value = { "flows/valids/webhook-with-condition.yaml" })
-    void webhookWithCondition() {
-        record Hello(String hello) {
-        }
-
-        Execution execution = client.toBlocking().retrieve(
-            HttpRequest
-                .POST(
-                    "/api/v1/main/executions/webhook/" + TESTS_FLOW_NS + "/webhook-with-condition/webhookKey",
-                    new Hello("world")
-                ),
-            Execution.class
-        );
-
-        assertThat(execution).isNotNull();
-        assertThat(execution.getId()).isNotNull();
-
-        HttpClientResponseException e = assertThrows(
-            HttpClientResponseException.class, () -> client.toBlocking().exchange(
-                HttpRequest
-                    .POST(
-                        "/api/v1/main/executions/webhook/" + TESTS_FLOW_NS + "/webhook-with-condition/webhookKey",
-                        new Hello("webhook")
-                    ),
-                Execution.class
-            )
-        );
-        assertThat(e.getResponse().getStatus().getCode()).isEqualTo(HttpStatus.CONFLICT.getCode());
-        assertThat(e.getResponse().body()).isNull();
-    }
-
-    @Test
-    @LoadFlows(value = { "flows/valids/webhook-inputs.yaml" })
-    void webhookWithInputs() {
-        record Hello(String hello) {
-        }
-
-        Execution execution = client.toBlocking().retrieve(
-            HttpRequest
-                .POST(
-                    "/api/v1/main/executions/webhook/" + TESTS_FLOW_NS + "/webhook-inputs/webhookKey",
-                    new Hello("world")
-                ),
-            Execution.class
-        );
-
-        assertThat(execution).isNotNull();
-        assertThat(execution.getId()).isNotNull();
-    }
-
-    @Test
     void nullLabels() {
         MultipartBody requestBody = createExecutionInputsFlowBody();
 
@@ -301,30 +218,6 @@ class ExecutionControllerTest {
         assertThat(result).isNotNull();
         assertThat(result.getTasks()).hasSize(5);
         assertThat((result.getTasks().getFirst() instanceof TaskForExecution)).isEqualTo(true);
-    }
-
-    @SuppressWarnings("DataFlowIssue")
-    @Test
-    @LoadFlows(value = { "flows/valids/webhook.yaml" })
-    void getExecutionFlowForExecutionById() {
-        Execution execution = client.toBlocking().retrieve(
-            HttpRequest
-                .POST(
-                    "/api/v1/main/executions/webhook/" + TESTS_FLOW_NS + "/webhook/" + TESTS_WEBHOOK_KEY + "?name=john&age=12&age=13",
-                    ImmutableMap.of("a", 1, "b", true)
-                ),
-            Execution.class
-        );
-        executionRepository.save(execution);
-
-        FlowForExecution result = client.toBlocking().retrieve(
-            GET("/api/v1/main/executions/" + execution.getId() + "/flow"),
-            FlowForExecution.class
-        );
-
-        assertThat(result.getId()).isEqualTo(execution.getFlowId());
-        assertThat(result.getTriggers()).hasSize(1);
-        assertThat((result.getTriggers().getFirst() instanceof AbstractTriggerForExecution)).isTrue();
     }
 
     @SuppressWarnings("unchecked")

--- a/webserver/src/test/java/io/kestra/webserver/controllers/api/WebhookRoutingTest.java
+++ b/webserver/src/test/java/io/kestra/webserver/controllers/api/WebhookRoutingTest.java
@@ -1,22 +1,41 @@
 package io.kestra.webserver.controllers.api;
 
+import java.time.Instant;
+
 import org.junit.jupiter.api.Test;
 
+import io.kestra.core.async.AsyncOperationProcessedEvent;
 import io.kestra.core.junit.annotations.KestraTest;
 import io.kestra.core.junit.annotations.LoadFlows;
+import io.kestra.core.services.AsyncOperationWaiter;
 
 import io.micronaut.http.HttpStatus;
 import io.micronaut.http.client.annotation.Client;
 import io.micronaut.http.client.exceptions.HttpClientResponseException;
 import io.micronaut.reactor.http.client.ReactorHttpClient;
+import io.micronaut.test.annotation.MockBean;
 import jakarta.inject.Inject;
+import reactor.core.publisher.Mono;
 
 import static io.micronaut.http.HttpRequest.*;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
-@KestraTest(startRunner = true)
+@KestraTest
 public class WebhookRoutingTest {
+
+    @MockBean(AsyncOperationWaiter.class)
+    AsyncOperationWaiter asyncOperationWaiter() {
+        AsyncOperationWaiter mock = mock(AsyncOperationWaiter.class);
+        when(mock.submit(any(), any(), any()))
+            .thenReturn(Mono.just(new AsyncOperationProcessedEvent(
+                "op-id", null, "item-id", AsyncOperationProcessedEvent.Outcome.SUCCEEDED, null, Instant.now()
+            )));
+        return mock;
+    }
 
     @Inject
     @Client("/")

--- a/webserver/src/test/java/io/kestra/webserver/controllers/api/WebhookRoutingTest.java
+++ b/webserver/src/test/java/io/kestra/webserver/controllers/api/WebhookRoutingTest.java
@@ -15,7 +15,7 @@ import static io.micronaut.http.HttpRequest.*;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-@KestraTest
+@KestraTest(startRunner = true)
 public class WebhookRoutingTest {
 
     @Inject


### PR DESCRIPTION
- fixes https://github.com/kestra-io/kestra-ee/issues/8170

## Summary

Since v2, the webhook API was fire-and-forgetting the `Create` execution command: the HTTP response could return before the executor had persisted the execution, causing callers to receive an execution ID that did not yet exist in the repository.

This PR fixes the race by:

- **Rewrites `WebhookService.startExecution`** to use `AsyncOperationWaiter.submit()` instead of a bare `executionCommandQueue.emit()`. The `Create` command is now tagged with an `operationId`, and the method returns `Mono<AsyncOperationProcessedEvent>` — the response is only sent once the executor confirms the execution is created.
- **Updates callers** (`Webhook`, `WebhookTestPlugin`) to chain on the returned `Mono`, mapping it to the appropriate `HttpResponse` and propagating errors reactively.
- **Moves `AsyncOperationsConfiguration`** from `io.kestra.webserver.configuration` to `io.kestra.core.async` so it is accessible to core services; updates `ExecutionController` and `TriggerStateService` imports accordingly.

## Test

`ExecutionControllerRunnerTest.shouldPersistExecutionBeforeWebhookResponds` — calls the webhook endpoint, then immediately asserts `executionRepository.findById(id)` is present with no polling. This would be a race before the fix; it is guaranteed after.