### PR TITLE
fix(tests): override CSRF cookie name in E2E backend config for HTTP

### DIFF
--- a/ui/tests/e2e/data/application-postgres.yml
+++ b/ui/tests/e2e/data/application-postgres.yml
@@ -26,6 +26,9 @@ datasources:
     password: k3str4
 # Common configuration
 micronaut:
+  security:
+    csrf:
+      cookie-name: csrfToken
   server:
     cors:
       enabled: true


### PR DESCRIPTION
## Summary

- The E2E backend runs on plain HTTP (port 9011); browsers silently reject cookies with the `__Host-` prefix on non-HTTPS connections
- `c65189a5ba` fixed `application.yml` 87 minutes after the E2E Docker image was last built, leaving the image with the broken `__Host-csrfToken` cookie name
- All POST/PUT/DELETE API calls returned **403 Forbidden**, causing every write operation to fail silently: flow saves had no effect, bulk actions (labels, restart, replay) were all blocked, and all 5 E2E tests failed

## Fix

Add `cookie-name: csrfToken` to `data/application-postgres.yml` — the config file mounted into the E2E Docker container. This mirrors the application-level fix and ensures existing images work correctly without requiring a full rebuild.

## Test plan

- [x] All 5 E2E tests pass locally (`5 passed (16.0s)`)
  - `flow.spec.ts` › should create and execute the example Flow
  - `flow.spec.ts` › should create and execute a Flow with input
  - `execution-bulk-actions.spec.ts` › Labels changed only on a filtered set
  - `execution-bulk-actions.spec.ts` › Restart only on a filtered set
  - `execution-bulk-actions.spec.ts` › Replay only on a filtered set