### PR TITLE
feat(plugindefaults): allow referencing named pluginDefaults by ref (#8740)

### DIFF
--- a/core/src/main/java/io/kestra/core/exceptions/PluginDefaultsRefNotFoundException.java
+++ b/core/src/main/java/io/kestra/core/exceptions/PluginDefaultsRefNotFoundException.java
@@ -1,0 +1,17 @@
+package io.kestra.core.exceptions;
+
+import java.io.Serial;
+
+/**
+ * Thrown when a plugin (task, trigger or task runner) references named plugin-defaults via
+ * {@code pluginDefaultsRef} that cannot be resolved — either none exists with that {@code ref} at flow,
+ * namespace or global level, or the one that exists is scoped to a different plugin type.
+ */
+public class PluginDefaultsRefNotFoundException extends KestraRuntimeException {
+    @Serial
+    private static final long serialVersionUID = 1L;
+
+    public PluginDefaultsRefNotFoundException(String ref) {
+        super("No plugin-defaults exists for pluginDefaultsRef: '" + ref + "'");
+    }
+}

--- a/core/src/main/java/io/kestra/core/models/flows/FlowPluginDefault.java
+++ b/core/src/main/java/io/kestra/core/models/flows/FlowPluginDefault.java
@@ -2,6 +2,8 @@ package io.kestra.core.models.flows;
 
 import java.util.Map;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+
 import io.kestra.core.validations.PluginDefaultValidation;
 
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -13,17 +15,28 @@ import lombok.NoArgsConstructor;
 
 /**
  * A plugin default entry scoped to a single flow.
- * The {@code forced} flag is intentionally absent: flow-level defaults cannot override
- * values enforced at namespace or tenant level by administrators.
+ * <p>
+ * The {@code forced} flag is always ignored at flow level (for type-matched and named ({@code ref})
+ * entries alike): only administrators can enforce plugin defaults, via namespace, tenant, or global
+ * configuration (see {@code PluginDefaultService#getFlowDefaults}).
  */
 @Getter
 @Builder(toBuilder = true)
 @AllArgsConstructor
 @NoArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_DEFAULT)
 @PluginDefaultValidation
 public class FlowPluginDefault implements PluginDefaultSpec {
     @NotNull
     private String type;
+
+    @Builder.Default
+    private boolean forced = false;
+
+    @Schema(
+        title = "Optional reference id used to apply this default only to plugins that opt in via `pluginDefaultsRef`."
+    )
+    private String ref;
 
     @Schema(
         type = "object",

--- a/core/src/main/java/io/kestra/core/models/flows/PluginDefault.java
+++ b/core/src/main/java/io/kestra/core/models/flows/PluginDefault.java
@@ -22,8 +22,20 @@ public class PluginDefault implements PluginDefaultSpec {
     private final boolean forced = false;
 
     @Schema(
+        title = "Optional reference id used to apply this default only to plugins that opt in via `pluginDefaultsRef`."
+    )
+    private final String ref;
+
+    @Schema(
         type = "object",
         additionalProperties = Schema.AdditionalPropertiesValue.FALSE
     )
     private final Map<String, Object> values;
+
+    /**
+     * Convenience constructor for type-matched (non-{@code ref}) defaults.
+     */
+    public PluginDefault(String type, boolean forced, Map<String, Object> values) {
+        this(type, forced, null, values);
+    }
 }

--- a/core/src/main/java/io/kestra/core/models/flows/PluginDefaultSpec.java
+++ b/core/src/main/java/io/kestra/core/models/flows/PluginDefaultSpec.java
@@ -11,4 +11,12 @@ public interface PluginDefaultSpec {
     String getType();
 
     Map<String, Object> getValues();
+
+    /**
+     * Optional named reference for this plugin default.
+     * <p>
+     * When set, the default is applied <em>only</em> to plugins that explicitly opt in via
+     * {@code pluginDefaultsRef}, never by {@code type} matching.
+     */
+    String getRef();
 }

--- a/core/src/main/java/io/kestra/core/models/tasks/Task.java
+++ b/core/src/main/java/io/kestra/core/models/tasks/Task.java
@@ -45,6 +45,10 @@ abstract public class Task implements TaskInterface {
     @PluginProperty(hidden = true, group = "advanced")
     protected String version;
 
+    @PluginProperty(group = "advanced")
+    @Schema(title = "Reference (`ref`) of the `pluginDefaults` to apply to this task.")
+    protected String pluginDefaultsRef;
+
     @PluginProperty(hidden = true, group = "advanced")
     private String description;
 

--- a/core/src/main/java/io/kestra/core/models/tasks/runners/TaskRunner.java
+++ b/core/src/main/java/io/kestra/core/models/tasks/runners/TaskRunner.java
@@ -20,6 +20,7 @@ import io.kestra.core.models.annotations.PluginProperty;
 import io.kestra.core.runners.RunContext;
 import io.kestra.plugin.core.runner.Process;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 import lombok.AccessLevel;
@@ -46,6 +47,10 @@ public abstract class TaskRunner<T extends TaskRunnerDetailResult> implements Pl
 
     @PluginProperty(hidden = true, group = "advanced")
     protected String version;
+
+    @PluginProperty(group = "advanced")
+    @Schema(title = "Reference (`ref`) of the `pluginDefaults` to apply to this task runner.")
+    protected String pluginDefaultsRef;
 
     @JsonIgnore
     @Getter(AccessLevel.NONE)

--- a/core/src/main/java/io/kestra/core/models/triggers/AbstractTrigger.java
+++ b/core/src/main/java/io/kestra/core/models/triggers/AbstractTrigger.java
@@ -42,6 +42,10 @@ abstract public class AbstractTrigger implements TriggerInterface {
     @PluginProperty(hidden = true, group = "advanced")
     protected String version;
 
+    @PluginProperty(group = "advanced")
+    @Schema(title = "Reference (`ref`) of the `pluginDefaults` to apply to this trigger.")
+    protected String pluginDefaultsRef;
+
     @PluginProperty(hidden = true, group = "advanced")
     private String description;
 

--- a/core/src/main/java/io/kestra/core/services/FlowService.java
+++ b/core/src/main/java/io/kestra/core/services/FlowService.java
@@ -30,6 +30,7 @@ import io.kestra.core.models.topologies.FlowTopology;
 import io.kestra.core.models.triggers.AbstractTrigger;
 import io.kestra.core.models.triggers.TriggerId;
 import io.kestra.core.models.triggers.WorkerTriggerInterface;
+import io.kestra.core.models.validations.ManualConstraintViolation;
 import io.kestra.core.models.validations.ModelValidator;
 import io.kestra.core.models.validations.ValidateConstraintViolation;
 import io.kestra.core.plugins.PluginRegistry;
@@ -130,7 +131,9 @@ public class FlowService {
         // Validate Flow with defaults values
         // Do not perform a strict parsing validation to ignore unknown
         // properties that might be injecting through default values.
-        modelValidator.validate(pluginDefaultService.injectAllDefaults(parsed, false));
+        FlowWithSource withDefaults = pluginDefaultService.injectAllDefaults(parsed, false);
+        modelValidator.validate(withDefaults);
+        validatePluginDefaultsRefs(withDefaults);
 
         FlowWithSource created = flowRepository.create(flow);
 
@@ -162,7 +165,9 @@ public class FlowService {
         // Validate Flow with defaults values
         // Do not perform a strict parsing validation to ignore unknown
         // properties that might be injecting through default values.
-        modelValidator.validate(pluginDefaultService.injectAllDefaults(parsed, false));
+        FlowWithSource withDefaults = pluginDefaultService.injectAllDefaults(parsed, false);
+        modelValidator.validate(withDefaults);
+        validatePluginDefaultsRefs(withDefaults);
 
         FlowWithSource updated = flowRepository.update(flow, previous);
 
@@ -170,6 +175,25 @@ public class FlowService {
         impactDownstreamConsumers(updated);
 
         return updated;
+    }
+
+    /**
+     * Validates that every {@code pluginDefaultsRef} used in the flow resolves to an applicable plugin-defaults
+     * (one that exists with that {@code ref} and is scoped to the plugin's type). Throws a
+     * {@link ConstraintViolationException} otherwise, so an unresolved reference is rejected on create/update
+     * and surfaced through the validate API exactly like other flow validation errors.
+     */
+    private void validatePluginDefaultsRefs(FlowWithSource flowWithDefaults) {
+        java.util.Set<String> unresolved = pluginDefaultService.unresolvedPluginDefaultsRefs(flowWithDefaults);
+        if (!unresolved.isEmpty()) {
+            throw ManualConstraintViolation.toConstraintViolationException(
+                "No plugin-defaults exists for pluginDefaultsRef: '" + String.join("', '", unresolved) + "'",
+                flowWithDefaults,
+                FlowWithSource.class,
+                "pluginDefaultsRef",
+                String.join(", ", unresolved)
+            );
+        }
     }
 
     /**
@@ -370,6 +394,7 @@ public class FlowService {
                 constraintsBuilder.namespace(flow.getNamespace());
 
                 modelValidator.validate(flowWithDefaults);
+                validatePluginDefaultsRefs(flowWithDefaults);
             } catch (ConstraintViolationException e) {
                 String friendlyMessage = formatValidationError(e.getMessage());
                 constraintsBuilder.constraints(friendlyMessage);

--- a/core/src/main/java/io/kestra/core/services/PluginDefaultService.java
+++ b/core/src/main/java/io/kestra/core/services/PluginDefaultService.java
@@ -5,6 +5,8 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -48,7 +50,50 @@ import jakarta.validation.ConstraintViolationException;
 import lombok.extern.slf4j.Slf4j;
 
 /**
- * Services for parsing flows and injecting plugin default values.
+ * Parses flows and injects plugin default values into every plugin (task, trigger, task runner, …).
+ *
+ * <h2>Sources &amp; precedence</h2>
+ * Defaults come from three levels, ordered most-important-first: <b>flow</b> &gt; <b>namespace</b> (EE, closest
+ * namespace first) &gt; <b>global</b> (configuration). Each default is either:
+ * <ul>
+ *   <li><b>type-matched</b> — applied to every plugin whose {@code type} equals or is prefixed by the default's
+ *       {@code type}; or</li>
+ *   <li><b>named</b> — carries a {@code ref} id and is applied <i>only</i> to plugins that opt in with
+ *       {@code pluginDefaultsRef: <id>}, never by type matching.</li>
+ * </ul>
+ *
+ * <h2>{@code forced}</h2>
+ * {@code forced: true} marks an administrator-enforced default. It is honored at namespace and global level only;
+ * at flow level it is always ignored (a flow cannot enforce). A non-forced default fills only values the plugin
+ * does not set (the plugin wins); a forced default overrides the plugin's values. Forced defaults follow the
+ * <i>reverse</i> precedence of non-forced ones: the lowest (admin) level wins, so a global forced default beats a
+ * namespace forced one and enforcement cannot be bypassed closer to the flow.
+ *
+ * <h2>How a single plugin is resolved</h2>
+ * <ol>
+ *   <li><b>No {@code pluginDefaultsRef}:</b> non-forced then forced type-matched defaults are applied (forced last,
+ *       so it wins).</li>
+ *   <li><b>With {@code pluginDefaultsRef: id}:</b> non-forced type-matched defaults are skipped. If a <i>forced</i>
+ *       type-matched default also applies, <b>it takes over entirely and the referenced default is ignored</b>
+ *       (no stacking) — enforcement always wins. Otherwise the referenced default is applied.</li>
+ * </ol>
+ *
+ * <h2>Resolving a {@code ref}</h2>
+ * All defaults sharing a {@code ref} collapse to a single winner (shadowing, not a merge): a forced entry beats a
+ * non-forced one; among forced entries the lowest-priority (admin) level wins (global over namespace; flow entries
+ * are never forced) so enforcement cannot be bypassed by a higher-level forced override; among non-forced entries
+ * the highest-priority level wins. The referenced default is applied only when its declared {@code type} matches
+ * the plugin's type (plugin aliases are canonicalized so an alias and its canonical name match).
+ * <p>
+ * Resulting precedence for a referenced plugin:
+ * {@code forced type-matched > forced ref > non-forced ref > the plugin's own values}.
+ *
+ * <h2>Unknown / inapplicable {@code ref}</h2>
+ * If a {@code pluginDefaultsRef} resolves to no default (none with that id) or to one declared for a different
+ * type, it is left unresolved: flow validation reports it as an error on create/update and via the validate API,
+ * and the plugin fails at runtime with {@code PluginDefaultsRefNotFoundException}. When a reference <i>is</i>
+ * applied (or is validly superseded by a forced type default), its marker is consumed so a surviving marker
+ * unambiguously means "unresolved or inapplicable".
  */
 @Singleton
 @Slf4j
@@ -60,6 +105,7 @@ public class PluginDefaultService {
     private static final ObjectMapper OBJECT_MAPPER = JacksonMapper.ofYaml().copy()
         .setDefaultPropertyInclusion(JsonInclude.Include.NON_NULL);
     private static final String PLUGIN_DEFAULTS_FIELD = "pluginDefaults";
+    private static final String PLUGIN_DEFAULTS_REF_FIELD = "pluginDefaultsRef";
 
     private static final TypeReference<List<PluginDefault>> PLUGIN_DEFAULTS_TYPE_REF = new TypeReference<>() {
     };
@@ -113,9 +159,10 @@ public class PluginDefaultService {
     /**
      * Gets the flow-level defaults values.
      * <p>
-     * The {@code forced} flag is intentionally ignored at flow level: only administrators can enforce
-     * plugin defaults (via namespace, tenant, or global configuration). Any {@code forced: true} entry
-     * in a flow's {@code pluginDefaults} section is silently treated as {@code forced: false}.
+     * The {@code forced} flag is intentionally ignored at flow level (for type-matched and named
+     * ({@code ref}) entries alike): only administrators can enforce plugin defaults (via namespace,
+     * tenant, or global configuration). Any {@code forced: true} entry in a flow's
+     * {@code pluginDefaults} section is silently treated as {@code forced: false}.
      *
      * @param flow the flow to extract default
      * @return list of {@code PluginDefault} ordered by most important first, all with forced=false
@@ -423,9 +470,24 @@ public class PluginDefaultService {
             return flowAsMap;
         }
 
+        // alias-canonicalize all defaults (type-matched and named) so a default declared with a plugin alias
+        // also matches the canonical plugin type.
         addAliases(allDefaults);
 
-        Map<Boolean, List<PluginDefault>> allDefaultsGroup = allDefaults
+        // split named (ref) defaults from type-matched defaults: a 'ref' default is applied only to plugins
+        // that explicitly opt in via 'pluginDefaultsRef', never by type matching.
+        Map<Boolean, List<PluginDefault>> byHasRef = allDefaults
+            .stream()
+            .collect(Collectors.partitioningBy(pluginDefault -> pluginDefault.getRef() != null));
+        List<PluginDefault> typeDefaults = byHasRef.get(false);
+
+        // resolve, per ref, the winning values (shadowing) and the set of types it accepts (incl. alias
+        // canonical forms). Shadowing: a forced default always wins over a non-forced one; among forced
+        // defaults the lowest-priority (admin) level wins so enforcement cannot be bypassed; among non-forced
+        // defaults the highest-priority level wins. (allDefaults is ordered most-important-first: flow, namespace, global.)
+        Map<String, RefMatch> refMatches = resolveRefMatches(byHasRef.get(true));
+
+        Map<Boolean, List<PluginDefault>> allDefaultsGroup = typeDefaults
             .stream()
             .collect(Collectors.groupingBy(PluginDefault::isForced, Collectors.toList()));
 
@@ -443,13 +505,29 @@ public class PluginDefaultService {
             flowAsMap.remove(PLUGIN_DEFAULTS_FIELD);
         }
 
-        // we apply default and overwrite with forced
+        // 1. non-forced type-matched defaults — suppressed for plugins that opted into a named (ref) default
         if (!defaults.isEmpty()) {
-            flowAsMap = (Map<String, Object>) recursiveDefaults(flowAsMap, defaults);
+            flowAsMap = (Map<String, Object>) recursiveDefaults(flowAsMap, defaults, false);
         }
 
+        // 2. named (ref) defaults — applied to plugins declaring a matching 'pluginDefaultsRef', UNLESS a forced
+        // type-matched default also applies to that plugin: enforcement takes over entirely and the ref is ignored
+        // (it must not stack on top of enforced values). Skipped when only injecting version defaults.
+        if (!onlyVersions && !refMatches.isEmpty()) {
+            flowAsMap = (Map<String, Object>) recursiveRefDefaults(flowAsMap, refMatches, forced.keySet());
+        }
+
+        // 3. forced type-matched defaults are admin enforcement and applied LAST so they win over everything,
+        // including a forced ref default — otherwise a flow could bypass enforcement via a forced ref.
+        // A WARN is logged when enforced onto a plugin that declared a 'pluginDefaultsRef'.
         if (!forced.isEmpty()) {
-            flowAsMap = (Map<String, Object>) recursiveDefaults(flowAsMap, forced);
+            flowAsMap = (Map<String, Object>) recursiveDefaults(flowAsMap, forced, true);
+        }
+
+        // 4. consume the 'pluginDefaultsRef' marker for refs that were actually applied (resolved + type match);
+        // a surviving marker therefore unambiguously means "unresolved or inapplicable" (validation error + runtime failure).
+        if (!onlyVersions && !refMatches.isEmpty()) {
+            flowAsMap = (Map<String, Object>) stripAppliedRefMarkers(flowAsMap, refMatches);
         }
 
         if (pluginDefaults != null) {
@@ -458,6 +536,39 @@ public class PluginDefaultService {
 
         return flowAsMap;
 
+    }
+
+    /**
+     * The values applied for a {@code ref} (the shadowing winner) and the set of plugin types it accepts
+     * (the declared types of every same-ref default, including alias canonical forms added by {@code addAliases}).
+     */
+    record RefMatch(PluginDefault winner, Set<String> types) {
+    }
+
+    /**
+     * Resolves, for each {@code ref}, the winning default and the set of accepted plugin types, given the list of
+     * all named defaults ordered most-important-first (flow, namespace, global). A {@code forced} default always
+     * wins over a non-forced one. Among forced defaults the lowest-priority (admin) level wins — the last forced
+     * occurrence; flow-level entries are never forced ({@link #getFlowDefaults} strips the flag) — so an enforced
+     * default cannot be bypassed by a higher-level forced override. Among non-forced defaults the highest-priority
+     * level wins — the first occurrence.
+     */
+    private static Map<String, RefMatch> resolveRefMatches(List<PluginDefault> refDefaults) {
+        Map<String, List<PluginDefault>> byRef = refDefaults
+            .stream()
+            .collect(Collectors.groupingBy(PluginDefault::getRef, LinkedHashMap::new, Collectors.toList()));
+
+        Map<String, RefMatch> matches = new LinkedHashMap<>();
+        byRef.forEach((ref, candidates) ->
+        {
+            List<PluginDefault> forced = candidates.stream().filter(PluginDefault::isForced).toList();
+            PluginDefault winner = forced.isEmpty() ? candidates.getFirst() : forced.getLast();
+            Set<String> types = candidates.stream()
+                .map(PluginDefault::getType)
+                .collect(Collectors.toCollection(LinkedHashSet::new));
+            matches.put(ref, new RefMatch(winner, types));
+        });
+        return matches;
     }
 
     /**
@@ -517,6 +628,10 @@ public class PluginDefaultService {
 
     @VisibleForTesting
     Object recursiveDefaults(Object object, Map<String, List<PluginDefault>> defaults) {
+        return recursiveDefaults(object, defaults, false);
+    }
+
+    Object recursiveDefaults(Object object, Map<String, List<PluginDefault>> defaults, boolean forcedPass) {
         if (object instanceof Map<?, ?> value) {
             value = value
                 .entrySet()
@@ -524,20 +639,20 @@ public class PluginDefaultService {
                 .map(
                     e -> new AbstractMap.SimpleEntry<>(
                         e.getKey(),
-                        recursiveDefaults(e.getValue(), defaults)
+                        recursiveDefaults(e.getValue(), defaults, forcedPass)
                     )
                 )
                 .collect(HashMap::new, (m, v) -> m.put(v.getKey(), v.getValue()), HashMap::putAll);
 
             if (value.containsKey("type")) {
-                value = defaults(value, defaults);
+                value = defaults(value, defaults, forcedPass);
             }
 
             return value;
         } else if (object instanceof Collection<?> value) {
             return value
                 .stream()
-                .map(r -> recursiveDefaults(r, defaults))
+                .map(r -> recursiveDefaults(r, defaults, forcedPass))
                 .toList();
         } else {
             return object;
@@ -545,7 +660,15 @@ public class PluginDefaultService {
     }
 
     @SuppressWarnings("unchecked")
-    private Map<?, ?> defaults(Map<?, ?> plugin, Map<String, List<PluginDefault>> defaults) {
+    private Map<?, ?> defaults(Map<?, ?> plugin, Map<String, List<PluginDefault>> defaults, boolean forcedPass) {
+        boolean hasRef = plugin.containsKey(PLUGIN_DEFAULTS_REF_FIELD);
+
+        // a plugin opting into a named (ref) default ('pluginDefaultsRef') ignores non-forced type-matched defaults;
+        // forced (admin-enforced) defaults are always applied regardless, see below.
+        if (hasRef && !forcedPass) {
+            return plugin;
+        }
+
         Object type = plugin.get("type");
         if (!(type instanceof String pluginType)) {
             return plugin;
@@ -559,6 +682,16 @@ public class PluginDefaultService {
 
         if (matching.isEmpty()) {
             return plugin;
+        }
+
+        if (hasRef) {
+            // forced defaults exist for a plugin that requested a named plugin-defaults: enforcement takes over
+            log.warn(
+                "A forced pluginDefault for type '{}' is enforced on a plugin declaring pluginDefaultsRef '{}'." +
+                " The referenced plugin-defaults is ignored.",
+                pluginType,
+                plugin.get(PLUGIN_DEFAULTS_REF_FIELD)
+            );
         }
 
         Map<String, Object> result = (Map<String, Object>) plugin;
@@ -580,5 +713,150 @@ public class PluginDefaultService {
         }
 
         return result;
+    }
+
+    /**
+     * Traverses the flow and applies the named ({@code ref}) plugin-defaults to every plugin that opts in via
+     * {@code pluginDefaultsRef}. Mirrors {@link #recursiveDefaults(Object, Map)} but matches on the referenced
+     * id and the plugin type instead of the plugin type alone. The {@code pluginDefaultsRef} marker is consumed
+     * afterwards by {@link #stripAppliedRefMarkers(Object, Map)}.
+     */
+    @VisibleForTesting
+    Object recursiveRefDefaults(Object object, Map<String, RefMatch> refMatches, Set<String> forcedTypes) {
+        if (object instanceof Map<?, ?> value) {
+            value = value
+                .entrySet()
+                .stream()
+                .map(
+                    e -> new AbstractMap.SimpleEntry<>(
+                        e.getKey(),
+                        recursiveRefDefaults(e.getValue(), refMatches, forcedTypes)
+                    )
+                )
+                .collect(HashMap::new, (m, v) -> m.put(v.getKey(), v.getValue()), HashMap::putAll);
+
+            if (value.containsKey(PLUGIN_DEFAULTS_REF_FIELD)) {
+                value = refDefaults(value, refMatches, forcedTypes);
+            }
+
+            return value;
+        } else if (object instanceof Collection<?> value) {
+            return value
+                .stream()
+                .map(r -> recursiveRefDefaults(r, refMatches, forcedTypes))
+                .toList();
+        } else {
+            return object;
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private Map<?, ?> refDefaults(Map<?, ?> plugin, Map<String, RefMatch> refMatches, Set<String> forcedTypes) {
+        Object ref = plugin.get(PLUGIN_DEFAULTS_REF_FIELD);
+        if (!(ref instanceof String refId)) {
+            return plugin;
+        }
+
+        RefMatch match = refMatches.get(refId);
+        if (match == null) {
+            // unknown ref: keep 'pluginDefaultsRef' so a surviving marker signals an unresolved reference
+            // (flagged as a validation error in the editor and failed at runtime).
+            log.warn("No plugin-defaults exists for pluginDefaultsRef '{}' referenced by plugin of type '{}'", refId, plugin.get("type"));
+            return plugin;
+        }
+
+        if (!typeMatches(plugin.get("type"), match.types())) {
+            // the named plugin-defaults is scoped to a different plugin type: do not apply it, and keep the
+            // marker so it surfaces the same way as an unresolved reference (validation error + runtime failure).
+            log.warn(
+                "The plugin-defaults for pluginDefaultsRef '{}' is declared for type(s) '{}' but is referenced by a plugin of type '{}'; it will not be applied",
+                refId, match.types(), plugin.get("type")
+            );
+            return plugin;
+        }
+
+        if (typeMatches(plugin.get("type"), forcedTypes)) {
+            // a forced (admin-enforced) type default also matches this plugin: enforcement takes over entirely
+            // and the referenced plugin-defaults is ignored (it must not stack on top of enforced values).
+            // The marker is still consumed by stripAppliedRefMarkers since the reference was valid.
+            return plugin;
+        }
+
+        PluginDefault winner = match.winner();
+        if (winner.isForced()) {
+            // forced plugin-defaults overrides the plugin's own values
+            return MapUtils.deepMerge((Map<String, Object>) plugin, winner.getValues());
+        }
+        // non-forced plugin-defaults yields to the plugin's explicit values
+        return MapUtils.deepMerge(winner.getValues(), (Map<String, Object>) plugin);
+    }
+
+    /**
+     * Whether the plugin-defaults referenced by a plugin both exists and is scoped to the plugin's type.
+     */
+    private static boolean refApplies(Map<?, ?> plugin, Map<String, RefMatch> refMatches) {
+        if (!(plugin.get(PLUGIN_DEFAULTS_REF_FIELD) instanceof String refId)) {
+            return false;
+        }
+        RefMatch match = refMatches.get(refId);
+        return match != null && typeMatches(plugin.get("type"), match.types());
+    }
+
+    private static boolean typeMatches(Object pluginType, Set<String> refTypes) {
+        return pluginType instanceof String type
+            && refTypes.stream().anyMatch(refType -> type.equals(refType) || type.startsWith(refType));
+    }
+
+    /**
+     * Removes the {@code pluginDefaultsRef} marker from every plugin whose reference was actually applied
+     * (i.e. it resolved and was type-compatible). A marker left in place means the reference was unresolved
+     * or inapplicable, which is surfaced as a validation error and fails the plugin at runtime.
+     */
+    @VisibleForTesting
+    Object stripAppliedRefMarkers(Object object, Map<String, RefMatch> refMatches) {
+        if (object instanceof Map<?, ?> value) {
+            Map<Object, Object> result = value
+                .entrySet()
+                .stream()
+                .map(e -> new AbstractMap.SimpleEntry<>(e.getKey(), stripAppliedRefMarkers(e.getValue(), refMatches)))
+                .collect(HashMap::new, (m, v) -> m.put(v.getKey(), v.getValue()), HashMap::putAll);
+
+            if (refApplies(result, refMatches)) {
+                result.remove(PLUGIN_DEFAULTS_REF_FIELD);
+            }
+
+            return result;
+        } else if (object instanceof Collection<?> value) {
+            return value
+                .stream()
+                .map(r -> stripAppliedRefMarkers(r, refMatches))
+                .toList();
+        } else {
+            return object;
+        }
+    }
+
+    /**
+     * Returns the distinct {@code pluginDefaultsRef} ids that remain unresolved (or inapplicable) in an
+     * already-defaulted flow. A reference is unresolved when no plugin-defaults with that {@code ref} exists
+     * at flow, namespace or global level, or when the one that exists is scoped to a different plugin type
+     * (the marker is otherwise stripped during {@link #stripAppliedRefMarkers(Object, Map)}).
+     */
+    public Set<String> unresolvedPluginDefaultsRefs(FlowInterface flowWithDefaults) {
+        Map<String, Object> flowAsMap = OBJECT_MAPPER.convertValue(flowWithDefaults, JacksonMapper.MAP_TYPE_REFERENCE);
+        Set<String> refs = new LinkedHashSet<>();
+        collectUnresolvedRefs(flowAsMap, refs);
+        return refs;
+    }
+
+    private void collectUnresolvedRefs(Object object, Set<String> refs) {
+        if (object instanceof Map<?, ?> value) {
+            if (value.get(PLUGIN_DEFAULTS_REF_FIELD) instanceof String ref) {
+                refs.add(ref);
+            }
+            value.values().forEach(v -> collectUnresolvedRefs(v, refs));
+        } else if (object instanceof Collection<?> value) {
+            value.forEach(v -> collectUnresolvedRefs(v, refs));
+        }
     }
 }

--- a/core/src/test/java/io/kestra/core/docs/ClassPluginDocumentationTest.java
+++ b/core/src/test/java/io/kestra/core/docs/ClassPluginDocumentationTest.java
@@ -51,7 +51,7 @@ class ClassPluginDocumentationTest {
 
             assertThat(doc.getDocExamples().size()).isEqualTo(2);
             assertThat(doc.getIcon()).isNotNull();
-            assertThat(doc.getInputs().size()).isEqualTo(5);
+            assertThat(doc.getInputs().size()).isEqualTo(6);
             assertThat(doc.getDocLicense()).isEqualTo("EE");
 
             // simple
@@ -157,7 +157,7 @@ class ClassPluginDocumentationTest {
             assertThat(doc.getCls()).isEqualTo("io.kestra.core.models.property.DynamicPropertyExampleTask");
             assertThat(doc.getDefs()).hasSize(9);
             Map<String, Object> properties = (Map<String, Object>) doc.getPropertiesSchema().get("properties");
-            assertThat(properties).hasSize(22);
+            assertThat(properties).hasSize(23);
 
             Map<String, Object> number = (Map<String, Object>) properties.get("number");
             assertThat(number.get("anyOf")).isNotNull();

--- a/core/src/test/java/io/kestra/core/docs/JsonSchemaGeneratorTest.java
+++ b/core/src/test/java/io/kestra/core/docs/JsonSchemaGeneratorTest.java
@@ -97,7 +97,7 @@ class JsonSchemaGeneratorTest {
             .orElseThrow();
 
         Map<String, Object> generate = jsonSchemaGenerator.properties(Task.class, cls);
-        assertThat(((Map<String, Map<String, Object>>) generate.get("properties")).size(), is(6));
+        assertThat(((Map<String, Map<String, Object>>) generate.get("properties")).size(), is(7));
 
         Map<String, Object> format = properties(generate).get("format");
         assertThat(format.get("default"), is("{}"));
@@ -203,11 +203,12 @@ class JsonSchemaGeneratorTest {
             Map<String, Object> jsonSchema = jsonSchemaGenerator.generate(AbstractTrigger.class, AbstractTrigger.class);
             assertThat(
                 (Map<String, Object>) jsonSchema.get("properties"), allOf(
-                    Matchers.aMapWithSize(4),
+                    Matchers.aMapWithSize(5),
                     hasKey("stopAfter"),
                     hasKey("type"),
                     hasKey("allowConcurrent"),
-                    hasKey("when")
+                    hasKey("when"),
+                    hasKey("pluginDefaultsRef")
                 )
             );
         });
@@ -288,7 +289,7 @@ class JsonSchemaGeneratorTest {
     void testEnum() {
         Map<String, Object> generate = jsonSchemaGenerator.properties(Task.class, TaskWithEnum.class);
         assertThat(generate, is(not(nullValue())));
-        assertThat(((Map<String, Map<String, Object>>) generate.get("properties")).size(), is(6));
+        assertThat(((Map<String, Map<String, Object>>) generate.get("properties")).size(), is(7));
         assertThat(((Map<String, Map<String, Object>>) generate.get("properties")).get("stringWithDefault").get("default"), is("default"));
         assertThat(((Map<String, Map<String, Object>>) generate.get("properties")).get("uri").get("$internalStorageURI"), is(true));
     }
@@ -299,7 +300,7 @@ class JsonSchemaGeneratorTest {
         Map<String, Object> generate = jsonSchemaGenerator.properties(Task.class, BetaTask.class);
         assertThat(generate, is(not(nullValue())));
         assertThat(generate.get("$beta"), is(true));
-        assertThat(((Map<String, Map<String, Object>>) generate.get("properties")).size(), is(2));
+        assertThat(((Map<String, Map<String, Object>>) generate.get("properties")).size(), is(3));
         assertThat(((Map<String, Map<String, Object>>) generate.get("properties")).get("beta").get("$beta"), is(true));
         assertThat(((Map<String, Map<String, Object>>) generate.get("properties")).get("beta").get("$language"), is(MonacoLanguages.PYTHON.toString()));
     }

--- a/core/src/test/java/io/kestra/core/runners/AbstractRunnerTest.java
+++ b/core/src/test/java/io/kestra/core/runners/AbstractRunnerTest.java
@@ -344,6 +344,11 @@ public abstract class AbstractRunnerTest {
     }
 
     @Test
+    void pluginDefaultsRefNotFound() throws Exception {
+        pluginDefaultsCaseTest.pluginDefaultsRefNotFound();
+    }
+
+    @Test
     @LoadFlows(
         value = { "flows/valids/switch.yaml",
             "flows/valids/task-flow.yaml",

--- a/core/src/test/java/io/kestra/core/runners/PluginDefaultsCaseTest.java
+++ b/core/src/test/java/io/kestra/core/runners/PluginDefaultsCaseTest.java
@@ -11,12 +11,15 @@ import io.kestra.core.exceptions.IllegalVariableEvaluationException;
 import io.kestra.core.models.executions.Execution;
 import io.kestra.core.models.executions.NextTaskRun;
 import io.kestra.core.models.executions.TaskRun;
+import io.kestra.core.models.flows.FlowWithSource;
+import io.kestra.core.models.flows.GenericFlow;
 import io.kestra.core.models.hierarchies.GraphCluster;
 import io.kestra.core.models.hierarchies.RelationType;
 import io.kestra.core.models.tasks.FlowableTask;
 import io.kestra.core.models.tasks.ResolvedTask;
 import io.kestra.core.models.tasks.Task;
 import io.kestra.core.queues.QueueException;
+import io.kestra.core.repositories.FlowRepositoryInterface;
 import io.kestra.core.services.TaskOutputService;
 import io.kestra.core.utils.GraphUtils;
 
@@ -38,6 +41,9 @@ public class PluginDefaultsCaseTest {
     @Inject
     private TaskOutputService taskOutputService;
 
+    @Inject
+    private FlowRepositoryInterface flowRepository;
+
     public void pluginDefaults() throws TimeoutException, QueueException, io.kestra.core.exceptions.InternalException {
         Execution execution = runnerUtils.runOne(MAIN_TENANT, "io.kestra.tests", "plugin-defaults", Duration.ofSeconds(60));
 
@@ -56,6 +62,34 @@ public class PluginDefaultsCaseTest {
         assertThat(taskOutputService.getOutputs(execution.getTaskRunList().get(5)).get("def")).isEqualTo("2");
         assertThat(execution.getTaskRunList().get(6).getTaskId()).isEqualTo("err-third");
         assertThat(taskOutputService.getOutputs(execution.getTaskRunList().get(6)).get("def")).isEqualTo("3");
+    }
+
+    public void pluginDefaultsRefNotFound() throws TimeoutException, QueueException, io.kestra.core.exceptions.InternalException {
+        // FlowService.create/update reject unresolved refs, so the only way an unresolved ref reaches runtime is a
+        // flow that became invalid after creation (e.g. its namespace plugin-defaults was removed). We reproduce
+        // that by storing the flow directly through the repository, which bypasses the ref validation.
+        String source = """
+            id: plugin-defaults-ref-not-found
+            namespace: io.kestra.tests
+            tasks:
+              - id: broken
+                type: io.kestra.plugin.core.debug.Return
+                format: "should never run"
+                pluginDefaultsRef: does-not-exist
+            """;
+        FlowWithSource created = flowRepository.create(GenericFlow.fromYaml(MAIN_TENANT, source));
+
+        try {
+            Execution execution = runnerUtils.runOne(MAIN_TENANT, "io.kestra.tests", "plugin-defaults-ref-not-found", Duration.ofSeconds(60));
+
+            // the task references a pluginDefaultsRef that does not resolve: it must fail at runtime
+            assertThat(execution.getState().getCurrent()).isEqualTo(io.kestra.core.models.flows.State.Type.FAILED);
+            assertThat(execution.getTaskRunList()).hasSize(1);
+            assertThat(execution.getTaskRunList().getFirst().getTaskId()).isEqualTo("broken");
+            assertThat(execution.getTaskRunList().getFirst().getState().getCurrent()).isEqualTo(io.kestra.core.models.flows.State.Type.FAILED);
+        } finally {
+            flowRepository.delete(created);
+        }
     }
 
     @SuperBuilder

--- a/core/src/test/java/io/kestra/core/services/FlowServiceTest.java
+++ b/core/src/test/java/io/kestra/core/services/FlowServiceTest.java
@@ -162,6 +162,27 @@ class FlowServiceTest {
     }
 
     @Test
+    void shouldReturnConstraintWhenPluginDefaultsRefIsUnknown() {
+        // Given — a task references a pluginDefaultsRef that does not resolve to any plugin-defaults
+        String source = """
+            id: test
+            namespace: io.kestra.unittest
+            tasks:
+              - id: download
+                type: io.kestra.plugin.core.http.Download
+                uri: https://kestra.io
+                pluginDefaultsRef: does-not-exist
+            """;
+
+        // When
+        List<ValidateConstraintViolation> results = flowService.validate("my-tenant", List.of(new FlowSource(null, source)));
+
+        // Then — surfaced as a constraint error naming the unresolved ref (same check create/update enforce)
+        assertThat(results).hasSize(1);
+        assertThat(results.getFirst().getConstraints()).contains("does-not-exist");
+    }
+
+    @Test
     void importFlow() throws FlowProcessingException {
         String source = """
             id: import

--- a/core/src/test/java/io/kestra/core/services/PluginDefaultServiceOverrideTest.java
+++ b/core/src/test/java/io/kestra/core/services/PluginDefaultServiceOverrideTest.java
@@ -100,6 +100,56 @@ class PluginDefaultServiceOverrideTest {
     }
 
     /**
+     * When a {@code forced} (admin-enforced) type default matches a plugin that also declares a
+     * {@code pluginDefaultsRef}, enforcement takes over entirely: the referenced plugin-defaults is ignored —
+     * not stacked. The forced value wins on the enforced property AND the ref's other (non-overlapping)
+     * properties are dropped.
+     */
+    @org.junit.jupiter.api.parallel.Execution(ExecutionMode.SAME_THREAD)
+    @Test
+    void forcedTypeDefaultBeatsForcedRef() throws FlowProcessingException {
+        final DefaultPrecedenceTester task = DefaultPrecedenceTester.builder()
+            .id("test")
+            .type(DefaultPrecedenceTester.class.getName())
+            .pluginDefaultsRef("bypass")
+            .propFoo("taskValue")
+            .build();
+
+        // 'forced: true' is ignored at flow level — declared here to prove the bypass attempt fails anyway
+        final FlowPluginDefault flowForcedRef = FlowPluginDefault.builder()
+            .type(DefaultPrecedenceTester.class.getName())
+            .ref("bypass")
+            .forced(true)
+            .values(ImmutableMap.of("propFoo", "refValue", "propBar", "refBar"))
+            .build();
+
+        final PluginDefault globalForcedType = new PluginDefault(
+            DefaultPrecedenceTester.class.getName(), true, ImmutableMap.of("propFoo", "globalValue")
+        );
+
+        var tenant = TestsUtils.randomTenant(PluginDefaultServiceOverrideTest.class.getSimpleName());
+        final Flow flow = Flow.builder()
+            .tenantId(tenant)
+            .tasks(Collections.singletonList(task))
+            .pluginDefaults(List.of(flowForcedRef))
+            .build();
+
+        final PluginGlobalDefaultConfiguration config = new PluginGlobalDefaultConfiguration();
+        config.defaults = List.of(globalForcedType);
+
+        var previous = pluginDefaultService.pluginGlobalDefault;
+        pluginDefaultService.pluginGlobalDefault = config;
+        final Flow injected = pluginDefaultService.injectAllDefaults(flow, true);
+        pluginDefaultService.pluginGlobalDefault = previous;
+
+        DefaultPrecedenceTester result = (DefaultPrecedenceTester) injected.getTasks().getFirst();
+        // forced TYPE default wins on the enforced property...
+        assertThat(result.getPropFoo(), is("globalValue"));
+        // ...and the ref is ignored entirely — its non-overlapping property does NOT stack on top
+        assertThat(result.getPropBar(), is((String) null));
+    }
+
+    /**
      * Forced defaults follow admin-first precedence: when both a namespace-level (EE) and a global
      * (configuration) forced default match the same plugin, the global one wins (kestra-ee#8262) —
      * the reverse of non-forced precedence (flow beats namespace beats global). The namespace level

--- a/core/src/test/java/io/kestra/core/services/PluginDefaultServiceTest.java
+++ b/core/src/test/java/io/kestra/core/services/PluginDefaultServiceTest.java
@@ -137,6 +137,108 @@ class PluginDefaultServiceTest {
     }
 
     @Test
+    void shouldApplyRefDefaultToNestedTaskRunner() {
+        // a nested taskRunner carrying its own pluginDefaultsRef receives the referenced plugin-defaults
+        Map<String, Object> flow = Map.of(
+            "id", "test",
+            "namespace", "type",
+            "tasks", List.of(
+                Map.of(
+                    "id", "my-task",
+                    "type", "io.kestra.test",
+                    "taskRunner", Map.of("type", "io.kestra.runner", "pluginDefaultsRef", "runner-cfg")
+                )
+            )
+        );
+        Map<String, PluginDefaultService.RefMatch> refDefaults = Map.of(
+            "runner-cfg", new PluginDefaultService.RefMatch(
+                new PluginDefault("io.kestra.runner", false, "runner-cfg", Map.of("cpus", 4)),
+                java.util.Set.of("io.kestra.runner")
+            )
+        );
+
+        // When — apply then consume the marker (the two passes the injection pipeline runs)
+        Object applied = pluginDefaultService.recursiveRefDefaults(flow, refDefaults, java.util.Set.of());
+        Object result = pluginDefaultService.stripAppliedRefMarkers(applied, refDefaults);
+
+        // Then — type matches (io.kestra.runner), values applied, marker consumed
+        Assertions.assertEquals(
+            Map.of(
+                "id", "test",
+                "namespace", "type",
+                "tasks", List.of(
+                    Map.of(
+                        "id", "my-task",
+                        "type", "io.kestra.test",
+                        "taskRunner", Map.of("type", "io.kestra.runner", "cpus", 4)
+                    )
+                )
+            ), result
+        );
+    }
+
+    @Test
+    void shouldNotApplyRefDefaultOnTypeMismatch() {
+        // the named plugin-defaults is declared for a different type than the referencing plugin
+        Map<String, Object> flow = Map.of(
+            "id", "test",
+            "namespace", "type",
+            "tasks", List.of(
+                Map.of("id", "my-task", "type", "io.kestra.other", "pluginDefaultsRef", "runner-cfg")
+            )
+        );
+        Map<String, PluginDefaultService.RefMatch> refDefaults = Map.of(
+            "runner-cfg", new PluginDefaultService.RefMatch(
+                new PluginDefault("io.kestra.runner", false, "runner-cfg", Map.of("cpus", 4)),
+                java.util.Set.of("io.kestra.runner")
+            )
+        );
+
+        // When
+        Object applied = pluginDefaultService.recursiveRefDefaults(flow, refDefaults, java.util.Set.of());
+        Object result = pluginDefaultService.stripAppliedRefMarkers(applied, refDefaults);
+
+        // Then — not applied (no 'cpus'), marker kept so it surfaces as unresolved/inapplicable
+        Assertions.assertEquals(
+            Map.of(
+                "id", "test",
+                "namespace", "type",
+                "tasks", List.of(
+                    Map.of("id", "my-task", "type", "io.kestra.other", "pluginDefaultsRef", "runner-cfg")
+                )
+            ), result
+        );
+    }
+
+    @Test
+    void shouldApplyRefDefaultDeclaredWithAliasType() throws FlowProcessingException {
+        // the named default is declared with a plugin alias; addAliases canonicalizes it so it still matches
+        // a task referencing it by the canonical type
+        String source = """
+                id: ref-alias-test
+                namespace: io.kestra.tests
+
+                tasks:
+                - id: referencing
+                  type: io.kestra.core.services.PluginDefaultServiceTest$DefaultTester
+                  pluginDefaultsRef: cfg
+
+                pluginDefaults:
+                - type: io.kestra.core.services.DefaultTesterAlias
+                  ref: cfg
+                  values:
+                    value: 7
+            """;
+
+        var tenant = TestsUtils.randomTenant(PluginDefaultServiceTest.class.getSimpleName());
+        FlowWithSource injected = pluginDefaultService.parseFlowWithAllDefaults(tenant, source, false);
+
+        // applied despite the alias/canonical type mismatch, and the marker consumed
+        assertThat(((DefaultTester) injected.getTasks().getFirst()).getValue(), is(7));
+        assertThat(injected.getTasks().getFirst().getPluginDefaultsRef(), is((String) null));
+    }
+
+    @Test
     public void injectFlowAndGlobals() throws FlowProcessingException {
         String source = String.format(
             """
@@ -383,6 +485,295 @@ class PluginDefaultServiceTest {
         } finally {
             serviceLogger.detachAppender(appender);
         }
+    }
+
+    @Test
+    void shouldApplyRefDefaultOnlyToReferencingPlugin() throws FlowProcessingException {
+        // Given — same-type tasks; only one opts into the named default
+        String source = """
+                id: ref-test
+                namespace: io.kestra.tests
+
+                tasks:
+                - id: referencing
+                  type: io.kestra.core.services.PluginDefaultServiceTest$DefaultTester
+                  pluginDefaultsRef: cfg
+                - id: plain
+                  type: io.kestra.core.services.PluginDefaultServiceTest$DefaultTester
+
+                pluginDefaults:
+                - type: io.kestra.core.services.PluginDefaultServiceTest$DefaultTester
+                  ref: cfg
+                  values:
+                    value: 7
+            """;
+
+        // When
+        var tenant = TestsUtils.randomTenant(PluginDefaultServiceTest.class.getSimpleName());
+        FlowWithSource injected = pluginDefaultService.parseFlowWithAllDefaults(tenant, source, false);
+
+        // Then
+        assertThat(((DefaultTester) injected.getTasks().getFirst()).getValue(), is(7));
+        assertThat(((DefaultTester) injected.getTasks().get(1)).getValue(), is((Integer) null));
+    }
+
+    @Test
+    void shouldSuppressTypeMatchedDefaultWhenRefIsSet() throws FlowProcessingException {
+        // Given — a type-matched default AND a ref default; the referencing task must get only the ref default
+        String source = """
+                id: ref-suppress-test
+                namespace: io.kestra.tests
+
+                tasks:
+                - id: referencing
+                  type: io.kestra.core.services.PluginDefaultServiceTest$DefaultTester
+                  pluginDefaultsRef: cfg
+
+                pluginDefaults:
+                - type: io.kestra.core.services.PluginDefaultServiceTest$DefaultTester
+                  values:
+                    value: 1
+                    defaultValue: typed
+                - type: io.kestra.core.services.PluginDefaultServiceTest$DefaultTester
+                  ref: cfg
+                  values:
+                    value: 7
+            """;
+
+        // When
+        var tenant = TestsUtils.randomTenant(PluginDefaultServiceTest.class.getSimpleName());
+        FlowWithSource injected = pluginDefaultService.parseFlowWithAllDefaults(tenant, source, false);
+
+        // Then — ref default applied, type-matched default ('defaultValue') suppressed
+        assertThat(((DefaultTester) injected.getTasks().getFirst()).getValue(), is(7));
+        assertThat(((DefaultTester) injected.getTasks().getFirst()).getDefaultValue(), is("default"));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void shouldEnforceForcedTypeDefaultOnRefPluginAndWarn() {
+        // capture WARN from PluginDefaultService logger
+        Logger serviceLogger = (Logger) LoggerFactory.getLogger(PluginDefaultService.class);
+        List<ILoggingEvent> capturedLogs = new ArrayList<>();
+        AppenderBase<ILoggingEvent> appender = new AppenderBase<>() {
+            @Override
+            protected void append(ILoggingEvent event) {
+                capturedLogs.add(event);
+            }
+        };
+        appender.setContext(serviceLogger.getLoggerContext());
+        appender.start();
+        serviceLogger.addAppender(appender);
+
+        try {
+            Map<String, Object> flow = Map.of(
+                "id", "test",
+                "namespace", "type",
+                "tasks", List.of(
+                    Map.of("id", "my-task", "type", "io.kestra.test", "pluginDefaultsRef", "cfg")
+                )
+            );
+            Map<String, List<PluginDefault>> forced = Map.of(
+                "io.kestra.test",
+                List.of(new PluginDefault("io.kestra.test", true, Map.of("forced-key", "enforced")))
+            );
+
+            // When — forced pass over a plugin that opted into a named default
+            Object result = pluginDefaultService.recursiveDefaults(flow, forced, true);
+
+            // Then — forced default is enforced despite pluginDefaultsRef, and a WARN is logged
+            Map<String, Object> task = (Map<String, Object>) ((List<Object>) ((Map<String, Object>) result).get("tasks")).getFirst();
+            assertThat(task.get("forced-key"), is("enforced"));
+            assertThat(
+                capturedLogs.stream()
+                    .filter(e -> e.getLevel() == ch.qos.logback.classic.Level.WARN)
+                    .anyMatch(e -> e.getFormattedMessage().contains("pluginDefaultsRef")),
+                is(true)
+            );
+        } finally {
+            serviceLogger.detachAppender(appender);
+        }
+    }
+
+    @Test
+    void shouldYieldToTaskValueForNonForcedRef() throws FlowProcessingException {
+        // Given — non-forced ref default, task sets the property explicitly
+        String source = """
+                id: ref-nonforced-test
+                namespace: io.kestra.tests
+
+                tasks:
+                - id: referencing
+                  type: io.kestra.core.services.PluginDefaultServiceTest$DefaultTester
+                  pluginDefaultsRef: cfg
+                  set: 1
+
+                pluginDefaults:
+                - type: io.kestra.core.services.PluginDefaultServiceTest$DefaultTester
+                  ref: cfg
+                  values:
+                    set: 99
+            """;
+
+        // When
+        var tenant = TestsUtils.randomTenant(PluginDefaultServiceTest.class.getSimpleName());
+        FlowWithSource injected = pluginDefaultService.parseFlowWithAllDefaults(tenant, source, false);
+
+        // Then — explicit task value wins
+        assertThat(((DefaultTester) injected.getTasks().getFirst()).getSet(), is(1));
+    }
+
+    @Test
+    void shouldIgnoreForcedOnFlowRefAndYieldToTaskValue() throws FlowProcessingException {
+        // Given — 'forced: true' on a flow-level ref default is ignored (only admins can enforce),
+        // so the referenced default behaves as non-forced and the explicit task value wins
+        String source = """
+                id: ref-forced-test
+                namespace: io.kestra.tests
+
+                tasks:
+                - id: referencing
+                  type: io.kestra.core.services.PluginDefaultServiceTest$DefaultTester
+                  pluginDefaultsRef: cfg
+                  set: 1
+
+                pluginDefaults:
+                - type: io.kestra.core.services.PluginDefaultServiceTest$DefaultTester
+                  ref: cfg
+                  forced: true
+                  values:
+                    set: 99
+            """;
+
+        // When
+        var tenant = TestsUtils.randomTenant(PluginDefaultServiceTest.class.getSimpleName());
+        FlowWithSource injected = pluginDefaultService.parseFlowWithAllDefaults(tenant, source, false);
+
+        // Then — explicit task value wins, the flow-level 'forced' flag is stripped
+        assertThat(((DefaultTester) injected.getTasks().getFirst()).getSet(), is(1));
+    }
+
+    @Test
+    void shouldIgnoreUnknownRef() throws FlowProcessingException {
+        // Given — task references a ref that does not exist
+        String source = """
+                id: ref-unknown-test
+                namespace: io.kestra.tests
+
+                tasks:
+                - id: referencing
+                  type: io.kestra.core.services.PluginDefaultServiceTest$DefaultTester
+                  pluginDefaultsRef: nope
+                  set: 5
+
+                pluginDefaults:
+                - type: io.kestra.core.services.PluginDefaultServiceTest$DefaultTester
+                  ref: cfg
+                  values:
+                    value: 7
+            """;
+
+        // When
+        var tenant = TestsUtils.randomTenant(PluginDefaultServiceTest.class.getSimpleName());
+        FlowWithSource injected = pluginDefaultService.parseFlowWithAllDefaults(tenant, source, false);
+
+        // Then — task unchanged; the 'cfg' default is not applied by type either
+        assertThat(((DefaultTester) injected.getTasks().getFirst()).getSet(), is(5));
+        assertThat(((DefaultTester) injected.getTasks().getFirst()).getValue(), is((Integer) null));
+        assertThat(injected.getTasks().getFirst().getPluginDefaultsRef(), is("nope"));
+    }
+
+    @Test
+    void shouldStrictParseRefFields() throws FlowProcessingException {
+        // Given — strict parsing must accept the new fields: pluginDefaultsRef on the task, ref + forced on the default
+        var tenant = TestsUtils.randomTenant(PluginDefaultServiceTest.class.getSimpleName());
+        GenericFlow flow = GenericFlow.fromYaml(
+            tenant, """
+                  id: ref-strict-test
+                  namespace: io.kestra.tests
+
+                  tasks:
+                  - id: referencing
+                    type: io.kestra.core.services.PluginDefaultServiceTest$DefaultTester
+                    pluginDefaultsRef: cfg
+                    set: 1
+
+                  pluginDefaults:
+                  - type: io.kestra.core.services.PluginDefaultServiceTest$DefaultTester
+                    ref: cfg
+                    forced: true
+                    values:
+                      set: 99
+                """
+        );
+
+        // When — strictParsing = true
+        FlowWithSource injected = pluginDefaultService.injectAllDefaults(flow, true);
+
+        // Then — ref resolved (as non-forced: flow-level 'forced' is ignored, the task value wins)
+        // and the marker is consumed (stripped) once the default is applied
+        assertThat(((DefaultTester) injected.getTasks().getFirst()).getSet(), is(1));
+        assertThat(injected.getTasks().getFirst().getPluginDefaultsRef(), is((String) null));
+    }
+
+    @Test
+    void shouldReportUnresolvedRefForValidation() throws FlowProcessingException {
+        // Given — one resolvable ref and one unknown ref
+        String source = """
+                id: ref-validate-test
+                namespace: io.kestra.tests
+
+                tasks:
+                - id: ok
+                  type: io.kestra.core.services.PluginDefaultServiceTest$DefaultTester
+                  pluginDefaultsRef: known
+                - id: broken
+                  type: io.kestra.core.services.PluginDefaultServiceTest$DefaultTester
+                  pluginDefaultsRef: missing
+
+                pluginDefaults:
+                - type: io.kestra.core.services.PluginDefaultServiceTest$DefaultTester
+                  ref: known
+                  values:
+                    value: 1
+            """;
+
+        var tenant = TestsUtils.randomTenant(PluginDefaultServiceTest.class.getSimpleName());
+        FlowWithSource injected = pluginDefaultService.parseFlowWithAllDefaults(tenant, source, false);
+
+        // When / Then — only the unknown ref survives and is reported
+        assertThat(pluginDefaultService.unresolvedPluginDefaultsRefs(injected), is(java.util.Set.of("missing")));
+    }
+
+    @Test
+    void shouldApplyRefDefaultToTrigger() throws FlowProcessingException {
+        // Given — a trigger opts into a named default
+        String source = """
+                id: ref-trigger-test
+                namespace: io.kestra.tests
+
+                triggers:
+                - id: trigger
+                  type: io.kestra.core.services.PluginDefaultServiceTest$DefaultTriggerTester
+                  pluginDefaultsRef: cfg
+
+                tasks:
+                - id: test
+                  type: io.kestra.core.services.PluginDefaultServiceTest$DefaultTester
+
+                pluginDefaults:
+                - type: io.kestra.core.services.PluginDefaultServiceTest$DefaultTriggerTester
+                  ref: cfg
+                  values:
+                    set: 42
+            """;
+
+        // When
+        var tenant = TestsUtils.randomTenant(PluginDefaultServiceTest.class.getSimpleName());
+        FlowWithSource injected = pluginDefaultService.parseFlowWithAllDefaults(tenant, source, false);
+
+        // Then
+        assertThat(((DefaultTriggerTester) injected.getTriggers().getFirst()).getSet(), is(42));
     }
 
     @SuperBuilder

--- a/executor/src/main/java/io/kestra/executor/ExecutorService.java
+++ b/executor/src/main/java/io/kestra/executor/ExecutorService.java
@@ -16,6 +16,7 @@ import io.kestra.core.assets.AssetService;
 import io.kestra.core.debug.Breakpoint;
 import io.kestra.core.exceptions.InternalException;
 import io.kestra.core.exceptions.NoMatchingWorkerQueueException;
+import io.kestra.core.exceptions.PluginDefaultsRefNotFoundException;
 import io.kestra.core.metrics.MetricRegistry;
 import io.kestra.core.models.Label;
 import io.kestra.core.models.assets.AssetIdentifier;
@@ -982,6 +983,13 @@ public class ExecutorService {
                     .task(task)
                     .executionKind(executor.getExecution().getKind())
                     .build();
+                // a surviving 'pluginDefaultsRef' means plugin-default injection could not resolve the referenced
+                // plugin-defaults: fail the task-run instead of sending a bad job to the worker
+                if (task.getPluginDefaultsRef() != null) {
+                    runContext.logger()
+                        .error(new PluginDefaultsRefNotFoundException(task.getPluginDefaultsRef()).getMessage());
+                    return new ExecutorContext.ExecutorWorkerTask(workerTask.withTaskRun(workerTask.getTaskRun().fail()), runContext);
+                }
                 // Resolve the target Worker Queue for this task
                 Optional<WorkerQueueRouting> routing;
                 try {

--- a/jmh-benchmarks/src/jmh/java/io/kestra/core/services/PluginDefaultServiceBenchmark.java
+++ b/jmh-benchmarks/src/jmh/java/io/kestra/core/services/PluginDefaultServiceBenchmark.java
@@ -19,12 +19,12 @@ import java.util.concurrent.TimeUnit;
 
 /**
  * Benchmarks {@link PluginDefaultService#injectAllDefaults} on large flows to track the cost of
- * type-matched plugin-default injection.
+ * plugin-default injection (type-matched and named/ref defaults).
  *
  * <p>Each invocation re-parses the flow source (two Jackson passes bracket the injection), so the
- * input flows are safely shared at trial level. The {@code noDefaults} scenario isolates the
- * parse + traversal cost, and {@code typeDefaults} adds the cost of matching and merging
- * type-matched defaults onto every task.
+ * input flows are safely shared at trial level. The {@code noDefaults} and {@code typeDefaults}
+ * scenarios are directly comparable against earlier revisions; the {@code refDefaults} and
+ * {@code mixedDefaults} scenarios characterize the named-defaults feature introduced in KESTRA#16446.
  */
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.MICROSECONDS)
@@ -38,21 +38,35 @@ public class PluginDefaultServiceBenchmark {
     private static final String LOG_TYPE = "io.kestra.plugin.core.log.Log";
     private static final String RETURN_TYPE = "io.kestra.plugin.core.debug.Return";
 
+    /** Which tasks opt into a named bundle via {@code pluginDefaultsRef}. */
+    private enum RefAssignment {
+        NONE,
+        EVERY_TASK,
+        /** Log tasks use ref bundles, Return tasks fall back to type-matched defaults. */
+        LOG_TASKS_ONLY
+    }
+
     private PluginDefaultService pluginDefaultService;
 
     private GenericFlow noDefaults;
     private GenericFlow typeDefaults;
+    private GenericFlow refDefaults;
+    private GenericFlow mixedDefaults;
 
     @Setup(Level.Trial)
     public void setup() {
         pluginDefaultService = new PluginDefaultService(null, null, DefaultPluginRegistry.getOrCreate());
 
-        noDefaults = GenericFlow.fromYaml("main", flowSource(""));
-        typeDefaults = GenericFlow.fromYaml("main", flowSource(typeDefaultEntries()));
+        noDefaults = GenericFlow.fromYaml("main", flowSource(RefAssignment.NONE, ""));
+        typeDefaults = GenericFlow.fromYaml("main", flowSource(RefAssignment.NONE, typeDefaultEntries()));
+        refDefaults = GenericFlow.fromYaml("main", flowSource(RefAssignment.EVERY_TASK, refDefaultEntries()));
+        mixedDefaults = GenericFlow.fromYaml("main", flowSource(RefAssignment.LOG_TASKS_ONLY, typeDefaultEntries() + refDefaultEntries()));
     }
 
     /**
      * Baseline: parse + traversal cost with no defaults to inject.
+     *
+     * @see <a href="https://github.com/kestra-io/kestra/pull/16446">KESTRA#16446</a>
      */
     @Benchmark
     public FlowWithSource injectNoDefaults() throws Exception {
@@ -61,6 +75,8 @@ public class PluginDefaultServiceBenchmark {
 
     /**
      * Type-matched defaults on every task.
+     *
+     * @see <a href="https://github.com/kestra-io/kestra/pull/16446">KESTRA#16446</a>
      */
     @Benchmark
     public FlowWithSource injectTypeDefaults() throws Exception {
@@ -68,9 +84,32 @@ public class PluginDefaultServiceBenchmark {
     }
 
     /**
-     * Builds a flow with {@link #TASK_COUNT} tasks, half Log and half Return.
+     * Named (ref) defaults: every task opts into a bundle via {@code pluginDefaultsRef}.
+     *
+     * @see <a href="https://github.com/kestra-io/kestra/pull/16446">KESTRA#16446</a>
      */
-    private static String flowSource(String pluginDefaultEntries) {
+    @Benchmark
+    public FlowWithSource injectRefDefaults() throws Exception {
+        return pluginDefaultService.injectAllDefaults(refDefaults, false);
+    }
+
+    /**
+     * Mixed type-matched and named (ref) defaults: half the tasks opt into a ref bundle, the other
+     * half receive type-matched defaults.
+     *
+     * @see <a href="https://github.com/kestra-io/kestra/pull/16446">KESTRA#16446</a>
+     */
+    @Benchmark
+    public FlowWithSource injectMixedDefaults() throws Exception {
+        return pluginDefaultService.injectAllDefaults(mixedDefaults, false);
+    }
+
+    /**
+     * Builds a flow with {@link #TASK_COUNT} tasks, half Log and half Return. Tasks selected by
+     * {@code refAssignment} reference one of the {@link #DEFAULTS_PER_TYPE} named bundles declared
+     * for their own type ({@code log-ref-*} for Log tasks, {@code return-ref-*} for Return tasks).
+     */
+    private static String flowSource(RefAssignment refAssignment, String pluginDefaultEntries) {
         StringBuilder sb = new StringBuilder();
         sb.append("id: plugin-default-benchmark\n");
         sb.append("namespace: io.kestra.benchmark\n");
@@ -80,34 +119,52 @@ public class PluginDefaultServiceBenchmark {
         sb.append("tasks:\n");
 
         for (int i = 0; i < TASK_COUNT / 2; i++) {
-            appendTask(sb, "log-task-" + i, LOG_TYPE, "message: hello " + i);
-            appendTask(sb, "return-task-" + i, RETURN_TYPE, "format: value " + i);
+            int bundle = i % DEFAULTS_PER_TYPE; // cycle through the declared bundle ids
+            appendTask(sb, "log-task-" + i, LOG_TYPE, "message: hello " + i,
+                refAssignment == RefAssignment.NONE ? null : "log-ref-" + bundle);
+            appendTask(sb, "return-task-" + i, RETURN_TYPE, "format: value " + i,
+                refAssignment == RefAssignment.EVERY_TASK ? "return-ref-" + bundle : null);
         }
 
         return sb.toString();
     }
 
-    private static void appendTask(StringBuilder sb, String id, String type, String property) {
+    private static void appendTask(StringBuilder sb, String id, String type, String property, String pluginDefaultsRef) {
         sb.append("  - id: ").append(id).append('\n');
         sb.append("    type: ").append(type).append('\n');
         sb.append("    ").append(property).append('\n');
+        if (pluginDefaultsRef != null) {
+            sb.append("    pluginDefaultsRef: ").append(pluginDefaultsRef).append('\n');
+        }
     }
 
     /** {@link #DEFAULTS_PER_TYPE} type-matched defaults per task type. */
     private static String typeDefaultEntries() {
         StringBuilder sb = new StringBuilder();
-        appendDefaultEntries(sb, LOG_TYPE);
-        appendDefaultEntries(sb, RETURN_TYPE);
+        appendDefaultEntries(sb, LOG_TYPE, null);
+        appendDefaultEntries(sb, RETURN_TYPE, null);
+        return sb.toString();
+    }
+
+    /** {@link #DEFAULTS_PER_TYPE} named (ref) defaults per task type. */
+    private static String refDefaultEntries() {
+        StringBuilder sb = new StringBuilder();
+        appendDefaultEntries(sb, LOG_TYPE, "log-ref-");
+        appendDefaultEntries(sb, RETURN_TYPE, "return-ref-");
         return sb.toString();
     }
 
     // note: no 'forced' entries — the flag is ignored (and warned about) at flow level
-    private static void appendDefaultEntries(StringBuilder sb, String type) {
+    private static void appendDefaultEntries(StringBuilder sb, String type, String refPrefix) {
+        boolean named = refPrefix != null;
         for (int i = 0; i < DEFAULTS_PER_TYPE; i++) {
             sb.append("  - type: ").append(type).append('\n');
+            if (named) {
+                sb.append("    ref: ").append(refPrefix).append(i).append('\n');
+            }
             sb.append("    values:\n");
-            sb.append("      logLevel: DEBUG\n");
-            sb.append("      description: type-default-").append(i).append('\n');
+            sb.append("      logLevel: ").append(named ? "TRACE" : "DEBUG").append('\n');
+            sb.append("      description: ").append(named ? "ref" : "type").append("-default-").append(i).append('\n');
         }
     }
 }

--- a/scheduler/src/main/java/io/kestra/scheduler/TriggerScheduler.java
+++ b/scheduler/src/main/java/io/kestra/scheduler/TriggerScheduler.java
@@ -23,6 +23,7 @@ import org.slf4j.event.Level;
 import com.google.common.base.Throwables;
 
 import io.kestra.core.exceptions.InvalidTriggerConfigurationException;
+import io.kestra.core.exceptions.PluginDefaultsRefNotFoundException;
 import io.kestra.core.metrics.MetricRegistry;
 import io.kestra.core.models.conditions.ConditionContext;
 import io.kestra.core.models.executions.Execution;
@@ -373,6 +374,13 @@ public class TriggerScheduler {
     }
 
     private void processWorkerTrigger(Clock clock, TriggerState triggerState, TriggerEvaluationContext triggerEvaluationContext, WorkerTriggerInterface trigger) {
+        // a surviving 'pluginDefaultsRef' means plugin-default injection could not resolve the referenced
+        // plugin-defaults: fail the trigger evaluation instead of sending a bad job to the worker
+        String unresolvedRef = ((AbstractTrigger) trigger).getPluginDefaultsRef();
+        if (unresolvedRef != null) {
+            throw new PluginDefaultsRefNotFoundException(unresolvedRef);
+        }
+
         final boolean mustBeLocked = trigger instanceof RealtimeTriggerInterface || !((AbstractTrigger) trigger).isAllowConcurrent();
         updateNextEvaluationDateAndGetOnSuccess(clock, triggerState, triggerEvaluationContext).ifPresent(state ->
         {

--- a/scheduler/src/test/java/io/kestra/scheduler/TriggerSchedulerTest.java
+++ b/scheduler/src/test/java/io/kestra/scheduler/TriggerSchedulerTest.java
@@ -191,6 +191,35 @@ class TriggerSchedulerTest {
     }
 
     @Test
+    void shouldSendFailedExecutionGivenUnresolvedPluginDefaultsRef() {
+        // region [GIVEN]
+        // a surviving 'pluginDefaultsRef' (no matching plugin-defaults entry) must fail the trigger
+        // evaluation instead of sending a bad job to the worker
+        FlowWithSource flow = Fixtures.flowWithTrigger(
+            TestPollingTrigger.builder()
+                .id("polling")
+                .type(TestPollingTrigger.class.getName())
+                .interval(Duration.ofMinutes(30))
+                .pluginDefaultsRef("does-not-exist")
+                .build()
+        );
+        TriggerScheduler scheduler = newTriggerScheduler(List.of(flow));
+        scheduler.onStart(SchedulerClock.getClock(), SchedulerClock.now().toInstant(), NODES_ASSIGNMENTS); // vNode are 0-based
+        // endregion [GIVEN]
+
+        // WHEN
+        scheduler.onSchedule(SchedulerClock.getClock(), SchedulerClock.now().toInstant(), NODES_ASSIGNMENTS);
+
+        // THEN - the trigger is not locked (no worker job sent) and a FAILED execution is sent
+        assertThat(triggerExecutionPublisher.executions().size()).isEqualTo(1);
+        assertThat(triggerExecutionPublisher.executions().getFirst().getState().getCurrent()).isEqualTo(State.Type.FAILED);
+
+        TriggerState state = triggerStateStore.findById(Fixtures.triggerId("polling")).orElse(null);
+        assertThat(state).isNotNull();
+        assertThat(state.isLocked()).isFalse();
+    }
+
+    @Test
     void shouldSucceedScheduleRealTimeTriggerGivenValidTimeZone() {
         // region [GIVEN]
         FlowWithSource flow = Fixtures.flowWithTrigger(

--- a/ui/src/override/services/flowAutoCompletionProvider.ts
+++ b/ui/src/override/services/flowAutoCompletionProvider.ts
@@ -303,9 +303,22 @@ export class FlowAutoCompletion extends YamlAutoCompletion {
                 }
                 return this.mcpServerIdsCache
             }
+            case "pluginDefaultsRef": {
+                return Promise.resolve(this.flowPluginDefaultsRefs(parsed))
+            }
         }
 
         return Promise.resolve([])
+    }
+
+    /**
+     * Distinct `ref` ids declared in the flow's own `pluginDefaults` block.
+     */
+    protected flowPluginDefaultsRefs(parsed: any | undefined): string[] {
+        const refs = (parsed?.pluginDefaults ?? [])
+            .map((pluginDefault: {ref?: string}) => pluginDefault?.ref)
+            .filter((ref: string | undefined): ref is string => Boolean(ref))
+        return [...new Set<string>(refs)]
     }
 
     private extractArgValue(arg: string | undefined) {

--- a/ui/tests/unit/services/flowAutoCompletionProvider.spec.ts
+++ b/ui/tests/unit/services/flowAutoCompletionProvider.spec.ts
@@ -266,6 +266,30 @@ tasks:
         expect(await provider.valueAutoCompletion(defaultFlow.substring(0, firstInputIndex) + "\n        " + defaultFlow.substring(firstInputIndex, defaultFlow.length), parsed, YAML_UTILS.localizeElementAtIndex(defaultFlow, firstInputIndex))).toEqual(["second-input:"])
     })
 
+    it("pluginDefaultsRef value autocompletions from flow pluginDefaults", async () => {
+        const flow = [
+            "tasks:",
+            "  - id: t1",
+            "    type: io.kestra.plugin.core.log.Log",
+            "    pluginDefaultsRef: ",
+            "pluginDefaults:",
+            "  - type: io.kestra.plugin.core.log.Log",
+            "    ref: io-config",
+            "    values:",
+            "      message: hi",
+            "  - type: io.kestra.plugin.core.log.Log",
+            "    ref: cpu-config",
+            "    values:",
+            "      message: yo",
+            "id: my-flow",
+            "namespace: my.namespace",
+        ].join("\n")
+        const flowParsed = YAML_UTILS.parse(flow)
+        const cursor = flow.indexOf("pluginDefaultsRef:") + "pluginDefaultsRef:".length
+        expect(await provider.valueAutoCompletion(flow, flowParsed, YAML_UTILS.localizeElementAtIndex(flow, cursor)))
+            .toEqual(["io-config", "cpu-config"])
+    })
+
     it("function autocompletions", async () => {
         expect(await provider.functionAutoCompletion(parsed, "secret", {})).toEqual(["'myFirstSecret'", "'mySecondSecret'", "'myInheritedSecret'"])
         expect(await provider.functionAutoCompletion(parsed, "secret", {namespace: "'another.namespace'"})).toEqual(["'anotherNsFirstSecret'", "'anotherNsSecondSecret'"])

--- a/webserver/src/test/java/io/kestra/webserver/controllers/api/PluginControllerTest.java
+++ b/webserver/src/test/java/io/kestra/webserver/controllers/api/PluginControllerTest.java
@@ -120,7 +120,7 @@ class PluginControllerTest {
         assertThat(doc.getMarkdown()).contains("Return a value for debugging purposes.");
         assertThat(doc.getMarkdown()).contains("The templated string to render");
         assertThat(doc.getMarkdown()).contains("The generated string");
-        assertThat(((Map<String, Object>) doc.getSchema().getProperties().get("properties")).size()).isEqualTo(1);
+        assertThat(((Map<String, Object>) doc.getSchema().getProperties().get("properties")).size()).isEqualTo(2);
         assertThat(((Map<String, Object>) doc.getSchema().getOutputs().get("properties")).size()).isEqualTo(1);
     }
 
@@ -133,7 +133,7 @@ class PluginControllerTest {
         );
 
         assertThat(doc.getMarkdown()).contains("io.kestra.plugin.templates.ExampleTask");
-        assertThat(((Map<String, Object>) doc.getSchema().getProperties().get("properties")).size()).isEqualTo(5);
+        assertThat(((Map<String, Object>) doc.getSchema().getProperties().get("properties")).size()).isEqualTo(6);
         assertThat(((Map<String, Object>) doc.getSchema().getOutputs().get("properties")).size()).isEqualTo(1);
     }
 
@@ -184,7 +184,7 @@ class PluginControllerTest {
         Map<String, Map<String, Object>> properties = (Map<String, Map<String, Object>>) doc.getSchema().getProperties().get("properties");
 
         assertThat(doc.getMarkdown()).contains("io.kestra.plugin.templates.ExampleTask");
-        assertThat(properties.size()).isEqualTo(19);
+        assertThat(properties.size()).isEqualTo(20);
         assertThat(properties.get("id").size()).isEqualTo(5);
         assertThat(((Map<String, Object>) doc.getSchema().getOutputs().get("properties")).size()).isEqualTo(1);
     }


### PR DESCRIPTION
Implements kestra-io/kestra#8740.

Adds a named-reference mechanism on top of `pluginDefaults`:

- `pluginDefaults` entries accept an optional `ref` id; tasks, triggers and task runners accept `pluginDefaultsRef` to opt into a named bundle.
- A `ref` bundle applies only to plugins that reference it, never by type matching. A plugin that sets `pluginDefaultsRef` ignores non-forced type-matched defaults.
- Refs resolve across levels (flow + namespace in EE) with whole-bundle shadowing — one winner per ref. Non-forced: highest level wins (flow > namespace > global). Forced: lowest/admin level wins (global > namespace > flow) so enforcement can't be bypassed.
- Forced (admin-enforced) defaults always apply even to a plugin declaring `pluginDefaultsRef`; a WARN is logged that the referenced bundle is ineffective for the enforced properties.
- An unknown `pluginDefaultsRef` is an error: flow validation reports it in the editor, and tasks/triggers fail at runtime with the new `PluginDefaultsRefNotFoundException`.
- Editor autocomplete suggests the flow's own `ref` ids (namespace-level refs added in the EE companion PR).

Companion EE PR added below.

Tested: `PluginDefaultServiceTest` (unit + override), H2 runner e2e for the runtime failure, autocomplete provider spec.