### PR TITLE
fix(security): skip CSRF validation for allowed CORS origins

### DIFF
--- a/webserver/src/main/java/io/kestra/webserver/filter/CsrfTokenFilter.java
+++ b/webserver/src/main/java/io/kestra/webserver/filter/CsrfTokenFilter.java
@@ -10,6 +10,7 @@ import io.micronaut.core.annotation.Nullable;
 import io.micronaut.core.order.Ordered;
 import io.micronaut.core.util.StringUtils;
 import io.micronaut.http.HttpMethod;
+import io.micronaut.http.HttpHeaders;
 import io.micronaut.http.HttpRequest;
 import io.micronaut.http.HttpResponse;
 import io.micronaut.http.HttpStatus;
@@ -17,6 +18,7 @@ import io.micronaut.http.annotation.RequestFilter;
 import io.micronaut.http.annotation.ServerFilter;
 import io.micronaut.http.filter.FilterPatternStyle;
 import io.micronaut.http.filter.ServerFilterPhase;
+import io.micronaut.http.server.HttpServerConfiguration;
 import io.micronaut.security.csrf.resolver.CsrfTokenResolver;
 import io.micronaut.security.csrf.validator.CsrfTokenValidator;
 
@@ -35,11 +37,14 @@ public class CsrfTokenFilter implements Ordered {
 
     private final List<CsrfTokenResolver<HttpRequest<?>>> csrfTokenResolvers;
     private final CsrfTokenValidator<HttpRequest<?>> csrfTokenValidator;
+    private final HttpServerConfiguration serverConfiguration;
 
     public CsrfTokenFilter(List<CsrfTokenResolver<HttpRequest<?>>> csrfTokenResolvers,
-                            CsrfTokenValidator<HttpRequest<?>> csrfTokenValidator) {
+                            CsrfTokenValidator<HttpRequest<?>> csrfTokenValidator,
+                            HttpServerConfiguration serverConfiguration) {
         this.csrfTokenResolvers = csrfTokenResolvers;
         this.csrfTokenValidator = csrfTokenValidator;
+        this.serverConfiguration = serverConfiguration;
     }
 
     @RequestFilter
@@ -50,6 +55,10 @@ public class CsrfTokenFilter implements Ordered {
         }
 
         if (!hasCookieAuth(request)) {
+            return null;
+        }
+
+        if (isCorsOrigin(request)) {
             return null;
         }
 
@@ -77,6 +86,20 @@ public class CsrfTokenFilter implements Ordered {
             }
         }
         return null;
+    }
+
+    private boolean isCorsOrigin(@NonNull HttpRequest<?> request) {
+        String origin = request.getHeaders().get(HttpHeaders.ORIGIN);
+        if (origin == null) {
+            return false;
+        }
+        var corsConfig = serverConfiguration.getCors();
+        if (!corsConfig.isEnabled()) {
+            return false;
+        }
+        return corsConfig.getConfigurations().values().stream()
+            .flatMap(c -> c.getAllowedOrigins().stream())
+            .anyMatch(origin::equals);
     }
 
     @Override

--- a/webserver/src/test/java/io/kestra/webserver/filter/CsrfTokenFilterTest.java
+++ b/webserver/src/test/java/io/kestra/webserver/filter/CsrfTokenFilterTest.java
@@ -98,6 +98,37 @@ class CsrfTokenFilterTest {
     }
 
     @Test
+    void shouldAcceptPostWithCookieAndAllowedCorsOrigin() {
+        // Given - CORS origin from application-test.yml, no CSRF token needed
+        MutableHttpRequest<?> request = HttpRequest.POST("/api/v1/main/executions/webhook/unit_test/webhook_test", "")
+            .cookie(Cookie.of(BasicAuthService.BASIC_AUTH_COOKIE_NAME, basicAuthCookieValue()))
+            .header("Origin", "http://bad-origin");
+
+        // When/Then - should not be rejected by CSRF filter
+        try {
+            var response = client.toBlocking().exchange(request);
+            assertThat(response.getStatus().getCode()).isNotEqualTo(HttpStatus.FORBIDDEN.getCode());
+        } catch (HttpClientResponseException e) {
+            assertThat(e.getStatus().getCode()).isNotEqualTo(HttpStatus.FORBIDDEN.getCode());
+        }
+    }
+
+    @Test
+    void shouldRejectPostWithCookieAndUnknownCorsOrigin() {
+        // Given - unknown origin should NOT bypass CSRF
+        MutableHttpRequest<?> request = HttpRequest.POST("/api/v1/main/executions/webhook/unit_test/webhook_test", "")
+            .cookie(Cookie.of(BasicAuthService.BASIC_AUTH_COOKIE_NAME, basicAuthCookieValue()))
+            .header("Origin", "http://unknown-origin");
+
+        // When/Then
+        HttpClientResponseException exception = assertThrows(
+            HttpClientResponseException.class,
+            () -> client.toBlocking().exchange(request)
+        );
+        assertThat(exception.getStatus().getCode()).isEqualTo(HttpStatus.FORBIDDEN.getCode());
+    }
+
+    @Test
     void shouldRejectPostWithCookieAndInvalidCsrfToken() {
         // Given - browser path with an invalid CSRF token
         MutableHttpRequest<?> request = HttpRequest.POST("/api/v1/main/executions/webhook/unit_test/webhook_test", "")


### PR DESCRIPTION
## Summary
- Skip CSRF token validation when the request `Origin` header matches an allowed CORS origin
- Fixes 403 errors for devs running the frontend via Vite (`localhost:5173`) against the backend (`localhost:8080`)
- Root cause: `StaticFilter` injects the CSRF `<meta>` tag into HTML, but Vite serves its own HTML — so the token is never available to the UI

## Why this is safe
- CORS already restricts which origins can make cross-origin requests
- The `Origin` header is set by the browser and cannot be spoofed by JavaScript
- Same-origin requests (production) don't send an `Origin` header, so CSRF remains enforced

## Test plan
- [x] Existing `CsrfTokenFilterTest` passes (no `Origin` header → CSRF still enforced)
- [ ] Run backend (`./gradlew runLocal`) + frontend (`npm run dev` on 5173) → POST/PUT/DELETE requests succeed
- [ ] Same-origin requests via `localhost:8080/ui/` still enforce CSRF