### PR TITLE
build(deps): upgrade gRPC to 1.81.0 and protobuf to 4.33.2

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -26,9 +26,6 @@ updates:
     open-pull-requests-limit: 50
     labels: ["dependency-upgrade", "area/backend"]
     ignore:
-      # Ignore versions of Protobuf >= 4.0.0 because Orc still uses version 3
-      - dependency-name: "com.google.protobuf:*"
-        versions: ["[4,)"]
       # Ignore Micronaut 5.x until migration is planned
       - dependency-name: "io.micronaut*"
         versions: ["[5,)"]

--- a/platform/build.gradle
+++ b/platform/build.gradle
@@ -12,7 +12,7 @@ javaPlatform {
 dependencies {
     // versions for libraries with multiple module but no BOM
     def slf4jVersion = "2.0.18"
-    def protobufVersion = "3.25.9" // Orc still uses 3 see https://github.com/apache/orc/blob/main/java/pom.xml
+    def protobufVersion = "4.33.2" // aligned with Google Cloud libraries-bom (grpc 1.81 + protobuf 4.33.2)
     def bouncycastleVersion = "1.84"
     def mavenResolverVersion = "2.0.10"
     def jollydayVersion = "1.5.6"
@@ -41,9 +41,8 @@ dependencies {
     api platform("dev.langchain4j:langchain4j-community-bom:$langchain4jCommunityVersion")
 
     constraints {
-        // downgrade to proto 1.3.2-alpha as 1.5.0 needs protobuf 4
-        api("io.opentelemetry.proto:opentelemetry-proto:1.3.2-alpha")
-        // need to force this dep as mysql-connector brings a version incompatible with the Google Cloud libs
+        api("io.opentelemetry.proto:opentelemetry-proto:1.5.0-alpha")
+        // align protobuf across mysql-connector, Google Cloud libs, micrometer-otlp and grpc
         api("com.google.protobuf:protobuf-java:$protobufVersion")
         api("com.google.protobuf:protobuf-java-util:$protobufVersion")
         // ugly hack for elastic plugins

--- a/worker-controller/build.gradle
+++ b/worker-controller/build.gradle
@@ -3,8 +3,8 @@ plugins {
 }
 
 ext {
-    grpcVersion = '1.71.0'
-    protobufVersion = '3.25.9'
+    grpcVersion = '1.81.0'
+    protobufVersion = '4.33.2'
 }
 
 configurations {


### PR DESCRIPTION
protoc 4.x emits @com.google.protobuf.Generated on generated stubs, a class absent from the BOM-pinned protobuf-java 3.25.9, so the protoc bump failed to compile. Move the platform BOM to protobuf-java 4.33.2 (the version Google Cloud libraries-bom 26.83.0 already ships, paired with grpc 1.81.0) and bump the worker-controller protoc/grpc codegen to match. The 3.25.9 pin was a stale lowest-common-denominator that force-downgraded mysql-connector (4.31.1) and the Google Cloud libs (4.33.2); ORC is irrelevant as it shades protobuf. opentelemetry-proto moves to 1.5.0-alpha (the protobuf-4 line).

Companion to the kestra-ee worker-controller-ee bump.

Refs #16376