### PR TITLE
fix(design-system): fix filter chip OR-group sync, drag grouping, and group operator

### DIFF
--- a/ui/packages/design-system/src/components/Data/KsDataTable/filter/FilterGroupRenderer.vue
+++ b/ui/packages/design-system/src/components/Data/KsDataTable/filter/FilterGroupRenderer.vue
@@ -18,7 +18,8 @@
                 :linked="hoveredWrapperId === unit.id"
                 inner
                 @change="(op) => filter.setWrapperLogical(unit.id, op)"
-                @hover="(v) => hoveredWrapperId = v ? unit.id : null"
+                @mouseenter="hoveredWrapperId = unit.id"
+                @mouseleave="hoveredWrapperId = null"
             />
             <div
                 class="filter-group-dropzone"

--- a/ui/packages/design-system/src/components/Data/KsDataTable/filter/FilterGroupRenderer.vue
+++ b/ui/packages/design-system/src/components/Data/KsDataTable/filter/FilterGroupRenderer.vue
@@ -15,8 +15,10 @@
                 v-if="childIndex > 0"
                 :logical="unit.logical"
                 :disabled="filter.readOnly?.value"
+                :linked="hoveredWrapperId === unit.id"
                 inner
                 @change="(op) => filter.setWrapperLogical(unit.id, op)"
+                @hover="(v) => hoveredWrapperId = v ? unit.id : null"
             />
             <div
                 class="filter-group-dropzone"
@@ -119,7 +121,7 @@
 </template>
 
 <script setup lang="ts">
-    import {inject} from "vue"
+    import {inject, ref} from "vue"
 
     import FilterChip from "./layout/FilterChip.vue"
     import GroupActions from "./segments/GroupActions.vue"
@@ -147,6 +149,10 @@
     }>()
 
     const filter = inject(FILTER_CONTEXT_INJECTION_KEY)!
+
+    // A group shares one operator. Track which wrapper is hovered so every separator in it
+    // highlights together — signalling the operator is group-wide rather than per-junction.
+    const hoveredWrapperId = ref<string | null>(null)
 
     const isDraggingFilter = (id: string) =>
         props.draggingEntity?.kind === "filter" && props.draggingEntity.id === id

--- a/ui/packages/design-system/src/components/Data/KsDataTable/filter/MainFilter.vue
+++ b/ui/packages/design-system/src/components/Data/KsDataTable/filter/MainFilter.vue
@@ -60,7 +60,9 @@
                 :logical="filter.topLogical?.value"
                 :disabled="filter.readOnly?.value"
                 :hidden="filter.searchInputFullWidth?.value"
+                :linked="hoveredTopSeparator"
                 @change="filter.setTopLogical"
+                @hover="(v) => hoveredTopSeparator = v"
             />
             <FilterGroupRenderer
                 :unit="unit"
@@ -126,6 +128,8 @@
     const isCustomizeFiltersVisible = ref(false)
     const chipRefs = ref<Record<string, any>>({})
     const filter = inject(FILTER_CONTEXT_INJECTION_KEY)!
+
+    const hoveredTopSeparator = ref(false)
 
     type DragKind = "filter" | "group" | "field"
     interface DragEntity { kind: DragKind; id: string }

--- a/ui/packages/design-system/src/components/Data/KsDataTable/filter/MainFilter.vue
+++ b/ui/packages/design-system/src/components/Data/KsDataTable/filter/MainFilter.vue
@@ -62,7 +62,8 @@
                 :hidden="filter.searchInputFullWidth?.value"
                 :linked="hoveredTopSeparator"
                 @change="filter.setTopLogical"
-                @hover="(v) => hoveredTopSeparator = v"
+                @mouseenter="hoveredTopSeparator = true"
+                @mouseleave="hoveredTopSeparator = false"
             />
             <FilterGroupRenderer
                 :unit="unit"

--- a/ui/packages/design-system/src/components/Data/KsDataTable/filter/composables/useFilterGroups.ts
+++ b/ui/packages/design-system/src/components/Data/KsDataTable/filter/composables/useFilterGroups.ts
@@ -118,6 +118,15 @@ export function useFilterGroups() {
         groups.value = [...before, ...unit.children, ...after]
     }
 
+    const sameField = (a: AppliedFilter | undefined, b: AppliedFilter): boolean =>
+        a?.key === b.key && a?.comparator === b.comparator
+
+    const leafOf = (filters: AppliedFilter[]): LeafFilterGroup => ({
+        id: newGroupId(),
+        kind: "leaf",
+        filters,
+    })
+
     const moveFilter = (filterId: string, targetGroupId: string) => {
         const sourceLeaf = findLeafContaining(groups.value, filterId)
         const targetLeaf = findLeafById(groups.value, targetGroupId)
@@ -130,15 +139,29 @@ export function useFilterGroups() {
             ...leaf,
             filters: leaf.filters.filter(f => f?.id !== filterId),
         }))
-        updateLeaf(targetLeaf.id, leaf => ({
-            ...leaf,
-            filters: [
-                ...leaf.filters.filter(f =>
-                    !(f?.key === filterToMove.key && f?.comparator === filterToMove.comparator),
-                ),
-                filterToMove,
-            ],
-        }))
+
+        if (!targetLeaf.filters.some(f => sameField(f, filterToMove))) {
+            updateLeaf(targetLeaf.id, leaf => ({
+                ...leaf,
+                filters: [...leaf.filters, filterToMove],
+            }))
+            return
+        }
+
+        groups.value = groups.value.map(unit => {
+            if (isWrapperGroup(unit)) {
+                if (!unit.children.some(c => c.id === targetLeaf.id)) return unit
+                return {...unit, children: [...unit.children, leafOf([filterToMove])]}
+            }
+            if (unit.id !== targetLeaf.id) return unit
+            const others = unit.filters.filter(f => !sameField(f, filterToMove))
+            const conflicting = unit.filters.filter(f => sameField(f, filterToMove))
+            const children: LeafFilterGroup[] = []
+            if (others.length > 0) children.push(leafOf(others))
+            conflicting.forEach(c => children.push(leafOf([c])))
+            children.push(leafOf([filterToMove]))
+            return {id: newGroupId(), kind: "wrapper", logical: "AND", children}
+        })
     }
 
     const setTopLogical = (op: LogicalOperator) => {

--- a/ui/packages/design-system/src/components/Data/KsDataTable/filter/composables/useRouteFilterPolicy.ts
+++ b/ui/packages/design-system/src/components/Data/KsDataTable/filter/composables/useRouteFilterPolicy.ts
@@ -21,6 +21,18 @@ interface UseRouteFilterPolicyOptions<T> {
     readFromAppliedFilters?: (filters: AppliedFilter[]) => T | undefined;
     shouldSyncFromAppliedFilters?: (filters: AppliedFilter[], routeQuery: Record<string, any>) => boolean;
 }
+/**
+ * Compare two policy values by content, not identity. Policy values may be objects
+ * (e.g. the log level's {value, direction}); a reference check would never match two
+ * freshly-built objects and would fire a redundant `router.replace` on every sync.
+ */
+const isSameValue = <T>(a: T | undefined, b: T | undefined): boolean => {
+    if (a === b) return true
+    if (a == null || b == null) return false
+    if (typeof a !== "object" || typeof b !== "object") return false
+    return JSON.stringify(a) === JSON.stringify(b)
+}
+
 export function useRouteFilterPolicy<T>(options: UseRouteFilterPolicyOptions<T>) {
     const route = useRoute()
     const router = useRouter()
@@ -85,7 +97,7 @@ export function useRouteFilterPolicy<T>(options: UseRouteFilterPolicyOptions<T>)
             return
         }
 
-        if (value === routeValue.value && !hasUnsupportedRouteValue.value) {
+        if (isSameValue(value, routeValue.value) && !hasUnsupportedRouteValue.value) {
             return
         }
 

--- a/ui/packages/design-system/src/components/Data/KsDataTable/filter/segments/LogicalSeparator.vue
+++ b/ui/packages/design-system/src/components/Data/KsDataTable/filter/segments/LogicalSeparator.vue
@@ -10,9 +10,11 @@
             <button
                 type="button"
                 class="logical-separator"
-                :class="{inner, 'filters-hidden': hidden}"
+                :class="{inner, 'filters-hidden': hidden, linked}"
                 :disabled="disabled"
                 :aria-label="logical"
+                @mouseenter="$emit('hover', true)"
+                @mouseleave="$emit('hover', false)"
             >{{ logical === "AND" ? $t("filter.and") : $t("filter.or") }}</button>
         </template>
         <LogicalChooser
@@ -31,14 +33,17 @@
         disabled?: boolean;
         hidden?: boolean;
         inner?: boolean;
+        linked?: boolean;
     }>(), {
         disabled: false,
         hidden: false,
         inner: false,
+        linked: false,
     })
 
     defineEmits<{
         change: [op: LogicalOperator];
+        hover: [value: boolean];
     }>()
 </script>
 
@@ -57,7 +62,8 @@
     letter-spacing: 0.05em;
     cursor: pointer;
 
-    &:hover:not(:disabled) {
+    &:hover:not(:disabled),
+    &.linked:not(:disabled) {
         color: var(--ks-text-primary);
         border-color: var(--ks-text-dim);
     }

--- a/ui/packages/design-system/src/components/Data/KsDataTable/filter/segments/LogicalSeparator.vue
+++ b/ui/packages/design-system/src/components/Data/KsDataTable/filter/segments/LogicalSeparator.vue
@@ -13,8 +13,8 @@
                 :class="{inner, 'filters-hidden': hidden, linked}"
                 :disabled="disabled"
                 :aria-label="logical"
-                @mouseenter="$emit('hover', true)"
-                @mouseleave="$emit('hover', false)"
+                @mouseenter="$emit('mouseenter', $event)"
+                @mouseleave="$emit('mouseleave', $event)"
             >{{ logical === "AND" ? $t("filter.and") : $t("filter.or") }}</button>
         </template>
         <LogicalChooser
@@ -43,7 +43,8 @@
 
     defineEmits<{
         change: [op: LogicalOperator];
-        hover: [value: boolean];
+        mouseenter: [event: MouseEvent];
+        mouseleave: [event: MouseEvent];
     }>()
 </script>
 

--- a/ui/tests/unit/filter/composables/useFilterGroups.spec.ts
+++ b/ui/tests/unit/filter/composables/useFilterGroups.spec.ts
@@ -186,6 +186,31 @@ describe("useFilterGroups", () => {
             const targetLeaf = findLeafById(tree.groups.value, g2)!
             expect(targetLeaf.filters.map(f => f.id).sort()).toEqual(["moving", "survivor"])
         })
+
+        it("groups same key + comparator chips into an AND wrapper instead of discarding one", () => {
+            const tree = useFilterGroups()
+            tree.addGroup()
+            const [g1, g2] = tree.groups.value.map(g => g.id)
+            const moving = filter("moving", "taskId", Comparators.EQUALS, "B")
+            const existing = filter("existing", "taskId", Comparators.EQUALS, "A")
+            tree.updateLeaf(g1, l => ({...l, filters: [moving]}))
+            tree.updateLeaf(g2, l => ({...l, filters: [existing]}))
+
+            tree.moveFilter("moving", g2)
+
+            // Both chips must survive (none discarded).
+            expect(allFilters(tree.groups.value).map(f => f.id).sort()).toEqual(["existing", "moving"])
+
+            // The target leaf is promoted to an AND wrapper with each conflicting chip isolated.
+            const target = tree.groups.value.find(g => isWrapperGroup(g) && g.children.some(c => c.id === g2))
+                ?? tree.groups.value.find(isWrapperGroup)
+            expect(target && isWrapperGroup(target)).toBe(true)
+            const wrapper = target as Extract<typeof target, {kind: "wrapper"}>
+            expect(wrapper.logical).toBe("AND")
+            expect(wrapper.children.flatMap(c => c.filters).map(f => f.id).sort()).toEqual(["existing", "moving"])
+            // Each conflicting chip lives in its own leaf so they don't collide on one URL param.
+            wrapper.children.forEach(c => expect(c.filters).toHaveLength(1))
+        })
     })
 
     describe("setTopLogical / setWrapperLogical", () => {


### PR DESCRIPTION
# Description 

Fixes three issues in the shared filter chip UI:

- Adding a second OR-group condition that duplicates an existing value (e.g. (taskId=fail AND level>=ERROR) OR (taskId=fail)) was silently dropped from the URL until the chip was edited.
- Dragging a chip onto a group that already had a chip with the same key discarded one of them instead of grouping them with AND.
- A group's logical operator looked editable per-junction, so changing one "AND" appeared to unexpectedly change the others.