### PR TITLE
fix(blueprints): add padding to card grid

### DIFF
--- a/ui/src/components/flows/blueprints/BlueprintsBrowser.vue
+++ b/ui/src/components/flows/blueprints/BlueprintsBrowser.vue
@@ -413,15 +413,11 @@
         }
     }
 
-    .search-bar-row {
-        max-width: 800px;
-        margin: 0 auto 1.5rem auto;
-    }
-
     .card-grid {
         display: grid;
         grid-template-columns: repeat(auto-fill, minmax(297px, 1fr));
         gap: 1rem;
+        padding-inline: var(--ks-data-table-gutter);
     }
 
     .blueprint-card {


### PR DESCRIPTION
closes https://github.com/kestra-io/kestra-ee/issues/8154

This pull request makes a small UI adjustment to the `BlueprintsBrowser.vue` component, focusing on layout improvements for the card grid.

- The `.card-grid` now includes horizontal padding using the `--ks-data-table-gutter` variable to improve spacing.