### PR TITLE
fix(ui): add inner vertical padding to dropdown menu component #4882

### DIFF
--- a/ui/packages/design-system/src/components/Navigation/KsDropdown/KsDropdownMenu.vue
+++ b/ui/packages/design-system/src/components/Navigation/KsDropdown/KsDropdownMenu.vue
@@ -1,5 +1,5 @@
 <template>
-    <ElDropdownMenu v-bind="$attrs">
+    <ElDropdownMenu v-bind="$attrs" class="ks-dropdown-menu-padding">
         <template v-if="$slots.default" #default>
             <slot />
         </template>
@@ -19,4 +19,10 @@
 <style lang="scss">
     @use '../../../assets/styles/el-ns';
     @use 'element-plus/theme-chalk/src/dropdown-menu';
+
+    // Inject explicit structural padding onto the menu list container
+    .ks-dropdown-menu-padding {
+        padding-top: 8px !important;
+        padding-bottom: 8px !important;
+    }
 </style>


### PR DESCRIPTION
### ✨ Description

What does this PR change?  
<KsDropdownMenu.vue>`. Element Plus’s default constraints wrapped the dynamic list items too tightly, causing the background hover states of the top item (Docs) and bottom item (Courses) to clip against the card's rounded borders. Introducing vertical padding ensures hover states sit comfortably inside the layout plane.

### 🔗 Related Issue

Closes https://github.com/kestra-io/docs/issues/4882


- [x] Code builds without errors (`npm run build`)
- [ ] All existing E2E tests pass (`npm run test:e2e`)
- [ ] Screenshots or video recordings attached showing the `UI` changes

###additional info
This fix was applied directly to the shared design system component layout layer (`KsDropdownMenu.vue`). This means the vertical breathing room handles edge boundaries elegantly for all navigation or actions dropdown menus across the application, without requiring row-level adjustments on individual elements.