### PR TITLE
fix(worker): render default Worker Queue as 'default' in logs

### DIFF
--- a/core/src/main/java/io/kestra/core/worker/WorkerQueues.java
+++ b/core/src/main/java/io/kestra/core/worker/WorkerQueues.java
@@ -81,11 +81,11 @@ public final class WorkerQueues {
     }
 
     /**
-     * Format a Worker Queue id for log display. Returns {@code (default)} for the global
+     * Format a Worker Queue id for log display. Returns {@code default} for the global
      * default queue and the id otherwise.
      */
     public static String forLog(String id) {
-        return isDefault(id) ? "(default)" : id;
+        return isDefault(id) ? "default" : id;
     }
 
     /**

--- a/core/src/test/java/io/kestra/core/worker/WorkerQueuesTest.java
+++ b/core/src/test/java/io/kestra/core/worker/WorkerQueuesTest.java
@@ -24,7 +24,7 @@ class WorkerQueuesTest {
 
     @Test
     void shouldFormatAsDefaultPlaceholderWhenIdIsDefaultSentinel() {
-        assertThat(WorkerQueues.forLog(WorkerQueues.DEFAULT_ID)).isEqualTo("(default)");
+        assertThat(WorkerQueues.forLog(WorkerQueues.DEFAULT_ID)).isEqualTo("default");
     }
 
     @Test
@@ -46,7 +46,7 @@ class WorkerQueuesTest {
 
     @Test
     void shouldFallBackToDefaultPlaceholderWhenTagsAbsentAndIdIsDefault() {
-        assertThat(WorkerQueues.forLog(null, WorkerQueues.DEFAULT_ID)).isEqualTo("(default)");
-        assertThat(WorkerQueues.forLog(List.of(), WorkerQueues.DEFAULT_ID)).isEqualTo("(default)");
+        assertThat(WorkerQueues.forLog(null, WorkerQueues.DEFAULT_ID)).isEqualTo("default");
+        assertThat(WorkerQueues.forLog(List.of(), WorkerQueues.DEFAULT_ID)).isEqualTo("default");
     }
 }

--- a/worker-controller/src/main/java/io/kestra/controller/grpc/services/WorkerJobDispatcher.java
+++ b/worker-controller/src/main/java/io/kestra/controller/grpc/services/WorkerJobDispatcher.java
@@ -403,7 +403,7 @@ public class WorkerJobDispatcher {
                 if (++attempts >= REGISTER_MAX_RETRIES) {
                     throw new IllegalStateException(
                         "Could not register worker '" + context.getWorkerId()
-                            + "' in Worker Queue '" + workerQueueId
+                            + "' in Worker Queue '" + WorkerQueues.forLog(workerQueueId)
                             + "' after " + attempts + " retries (concurrent dispose)"
                     );
                 }
@@ -685,7 +685,7 @@ public class WorkerJobDispatcher {
      */
     private void handleIncomingJob(String workerQueueId, Either<WorkerJobEvent, DeserializationException> either) {
         if (either.isRight()) {
-            log.error("Deserialization error for job in Worker Queue '{}': {}", workerQueueId, either.getRight().getMessage());
+            log.error("Deserialization error for job in Worker Queue '{}': {}", WorkerQueues.forLog(workerQueueId), either.getRight().getMessage());
             handleDeserializationError(either.getRight());
             return;
         }


### PR DESCRIPTION
The default Worker Queue is stored internally as an empty string, which surfaced as '' in dispatcher logs. Format it as 'default' via WorkerQueues.forLog, and route the two direct call sites that logged the raw id through forLog as well.