### PR TITLE
fix(ui): clear conflicting date filter query parameters

### DIFF
--- a/ui/packages/design-system/src/components/Data/KsDataTable/filter/utils/helpers.ts
+++ b/ui/packages/design-system/src/components/Data/KsDataTable/filter/utils/helpers.ts
@@ -193,8 +193,16 @@ export const getUniqueFilters = <T extends { key: string; comparator?: any }>(fi
 
 export const clearFilterQueryParams = (query: Record<string, any>): void => {
     for (const key of Object.keys(query)) {
-        if (key.startsWith("filters[") || key === "dateFilter") delete query[key]
-    }
+           if (
+               key.startsWith("filters[") ||
+               key === "dateFilter" ||
+               key === "startDate" ||
+               key === "endDate" ||
+               key === "timeRange"
+           ) {
+               delete query[key]
+           }
+       }
 }
 
 /**


### PR DESCRIPTION
## Description

Fixes an issue where execution requests could include both an absolute date range (`startDate`/`endDate`) and a relative `timeRange` filter at the same time.

### Changes

* Clear stale date-related query parameters when rebuilding filter query state.
* Ensure absolute date range filters and relative time range filters remain mutually exclusive.
* Prevent backend validation errors caused by conflicting date filter parameters.

### Result

Switching between custom date ranges and relative time filters now generates a consistent query state and avoids failed execution requests.

##Fixes #16428 


## ScreenShots 

[Screencast from 2026-06-02 11-17-18.webm](https://github.com/user-attachments/assets/cc8b7212-84e1-4a0f-b168-008d2336aedd)

