### PR TITLE
fix(namespaces): ensure non-empty body in namespace autocomplete request

### DIFF
--- a/ui/src/composables/useBaseNamespaces.ts
+++ b/ui/src/composables/useBaseNamespaces.ts
@@ -31,7 +31,7 @@ export const useBaseNamespacesStore = () => {
     const axios = useClient()
 
     async function loadAutocomplete(options?: {q?: string, ids?: string[], existingOnly?: boolean}) {
-        const response = await NamespaceAPI.autocompleteNamespaces(options ?? {})
+        const response = await NamespaceAPI.autocompleteNamespaces({existingOnly: false, ...options})
         autocomplete.value = response
         return response
     }


### PR DESCRIPTION
## Summary

- The SDK's `buildClientParams` has a `stripEmptySlots` helper that removes the `body` slot when it's an empty object `{}`
- Calling `autocompleteNamespaces({})` (no filter args) resulted in a bodyless POST, causing Micronaut to reject with `Required Body [autocomplete] not specified`
- Fix: always spread `existingOnly: false` so the body is never empty

Closes https://github.com/kestra-io/kestra-ee/issues/8113.
CLoses https://github.com/kestra-io/kestra-ee/issues/8162.

## Test plan
- [ ] Open the Namespace filter on any list page (Flows, Executions, Logs, etc.)
- [ ] Verify the dropdown populates with namespaces instead of showing "No options found"
- [ ] Verify no error toast appears