### PR TITLE
feat(topology): update animation handling based on execution state

### DIFF
--- a/ui/packages/topology/src/Topology.vue
+++ b/ui/packages/topology/src/Topology.vue
@@ -136,7 +136,7 @@
     import Download from "vue-material-design-icons/Download.vue"
     import Information from "vue-material-design-icons/Information.vue"
     import ArrowExpandAll from "vue-material-design-icons/ArrowExpandAll.vue"
-    import {cssVar as cssVariable} from "@kestra-io/design-system"
+    import {cssVar as cssVariable, State} from "@kestra-io/design-system"
     import {CLUSTER_PREFIX} from "./utils/constants"
     import * as flowYamlUtils from "./utils/flowYamlUtils"
     import {type CustomActionConfig, type ShowDetailsConfig, EVENTS, NODE_SIZES} from "./utils/constants"
@@ -167,7 +167,6 @@
         getNodeDimensions?: (node: any, getNodeWidth: (node: any) => number, getNodeHeight: (node: any) => number) => { width: number, height: number };
         customActions?: Record<string, CustomActionConfig>;
         showDetails?: Record<string, ShowDetailsConfig>;
-        animated?: boolean;
     }>(), {
         isHorizontal: true,
         isReadOnly: true,
@@ -186,8 +185,9 @@
         getNodeDimensions: undefined,
         customActions: () => ({}),
         showDetails: () => ({}),
-        animated: true,
     })
+
+    const isRunning = computed(() => State.isRunning(props.execution?.state?.current) === true)
 
     const dragging = ref(false)
     const showExtraDetails = ref(false)
@@ -267,6 +267,10 @@
         generateGraph()
     })
 
+    watch(isRunning, () => {
+        generateGraph()
+    })
+
     const generateGraph = () => {
         removeEdges(getEdges.value)
         removeNodes(getNodes.value)
@@ -296,7 +300,7 @@
                 props.isAllowedEdit,
                 props.enableSubflowInteraction,
                 effectiveGetNodeDimensions.value,
-                props.animated,
+                isRunning.value,
             )
 
             if (elements) {

--- a/ui/src/components/flows/Topology.vue
+++ b/ui/src/components/flows/Topology.vue
@@ -11,7 +11,6 @@
                 :expandedSubflows="expandedSubflows"
                 @expand-subflow="onExpandSubflow"
                 @on-edit="(event) => emit('on-edit', event, true)"
-                :animated="false"
             >
                 <template #taskDetails="taskProps">
                     <slot name="taskDetails" v-bind="taskProps" />

--- a/ui/src/components/inputs/LowCodeEditor.vue
+++ b/ui/src/components/inputs/LowCodeEditor.vue
@@ -21,7 +21,6 @@
             :playgroundReadyToStart="playgroundStore.readyToStart"
             :getNodeDimensions="getNodeDimensions"
             :customActions="customActions"
-            :animated="animated"
             @toggle-orientation="toggleOrientation"
             @edit="onEditTask"
             @delete="onDelete"
@@ -246,7 +245,6 @@
             horizontalDefault?: boolean;
             toggleOrientationButton?: boolean;
             expandedSubflows?: string[];
-            animated?: boolean;
         }>(),
         {
             flowId: undefined,
@@ -258,7 +256,6 @@
             horizontalDefault: undefined,
             toggleOrientationButton: true,
             expandedSubflows: () => [],
-            animated: true,
         })
 
     watch(


### PR DESCRIPTION
closes https://github.com/kestra-io/kestra-ee/issues/8195

**Refactoring animation state handling:**

* Removed the `animated` prop from the `Topology.vue` and `LowCodeEditor.vue` components, simplifying their props and default values. [[1]](diffhunk://#diff-d4db08ff92e481eaba44480fd7e89fa6e2883ee7cbe6ec74c0f407006b410431L170) [[2]](diffhunk://#diff-d4db08ff92e481eaba44480fd7e89fa6e2883ee7cbe6ec74c0f407006b410431L189-R191) [[3]](diffhunk://#diff-4e12324e4c8758c01268ce4076a02c7cf9bc95fbb4fba4116c9b8bb1ccc38da5L24) [[4]](diffhunk://#diff-4e12324e4c8758c01268ce4076a02c7cf9bc95fbb4fba4116c9b8bb1ccc38da5L249) [[5]](diffhunk://#diff-4e12324e4c8758c01268ce4076a02c7cf9bc95fbb4fba4116c9b8bb1ccc38da5L261) [[6]](diffhunk://#diff-574eaea51ed242164d364c63a321abf67668bf307942c11f35257ec601b9ba36L14)
* Introduced a computed property `isRunning` in `Topology.vue` that determines if the current execution is running by using the `State.isRunning` method from the design system. [[1]](diffhunk://#diff-d4db08ff92e481eaba44480fd7e89fa6e2883ee7cbe6ec74c0f407006b410431L139-R139) [[2]](diffhunk://#diff-d4db08ff92e481eaba44480fd7e89fa6e2883ee7cbe6ec74c0f407006b410431L189-R191)
* Updated the graph generation logic to reactively watch the `isRunning` state and regenerate the graph when it changes, ensuring the visualization updates appropriately.
* Passed `isRunning.value` instead of the removed `animated` prop to the graph generation function, so animation is now controlled by execution state.