### PR TITLE
feat(executions): keep the time filter as a global scope, outside conditional groups

### DIFF
--- a/ui/packages/design-system/src/components/Data/KsDataTable/filter/FilterGroupRenderer.vue
+++ b/ui/packages/design-system/src/components/Data/KsDataTable/filter/FilterGroupRenderer.vue
@@ -25,7 +25,7 @@
                 class="filter-group-dropzone"
                 :class="{
                     'drag-over': dragOverGroupId === childLeaf.id,
-                    'empty': childLeaf.filters.length === 0,
+                    'empty': renderableFilters(childLeaf.filters).length === 0,
                 }"
                 @dragover.stop="(e) => $emit('drag-over', e, childLeaf.id)"
                 @dragleave.stop="(e) => $emit('drag-leave', e, childLeaf.id)"
@@ -41,7 +41,7 @@
                     @dragend="$emit('drag-end')"
                 ><Drag /></span>
                 <div
-                    v-for="appliedFilter in childLeaf.filters"
+                    v-for="appliedFilter in renderableFilters(childLeaf.filters)"
                     :key="appliedFilter.id"
                     class="filter-chip-wrap"
                     :class="{'dragging': isDraggingFilter(appliedFilter.id)}"
@@ -76,8 +76,8 @@
             :class="{
                 'filters-hidden': filter.searchInputFullWidth?.value,
                 'drag-over': dragOverGroupId === unit.id,
-                'empty': unit.filters.length === 0,
-                'collapsed': unit.filters.length === 0 && !draggingEntity && totalUnits <= 1,
+                'empty': renderableFilters(unit.filters).length === 0,
+                'collapsed': renderableFilters(unit.filters).length === 0 && !draggingEntity && totalUnits <= 1,
             }"
             @dragover="(e) => $emit('drag-over', e, unit.id)"
             @dragleave="(e) => $emit('drag-leave', e, unit.id)"
@@ -93,7 +93,7 @@
                 @dragend="$emit('drag-end')"
             ><Drag /></span>
             <div
-                v-for="appliedFilter in unit.filters"
+                v-for="appliedFilter in renderableFilters(unit.filters)"
                 :key="appliedFilter.id"
                 class="filter-chip-wrap"
                 :class="{'dragging': isDraggingFilter(appliedFilter.id)}"
@@ -160,6 +160,9 @@
 
     const getFilterKeyConfig = (appliedFilter: AppliedFilter) =>
         filter.configuration.value.keys?.find((key) => key.key === appliedFilter.key) ?? null
+
+    const renderableFilters = (filters: AppliedFilter[]) =>
+        filters.filter((appliedFilter) => getFilterKeyConfig(appliedFilter)?.groupable !== false)
 </script>
 
 <style lang="scss" scoped>

--- a/ui/packages/design-system/src/components/Data/KsDataTable/filter/MainFilter.vue
+++ b/ui/packages/design-system/src/components/Data/KsDataTable/filter/MainFilter.vue
@@ -1,5 +1,38 @@
 <template>
     <div class="filter-container" :class="{'filter-grow': filter.searchInputFullWidth?.value}">
+        <template v-if="globalFilters.length || (unappliedGlobalKeys.length && !filter.readOnly?.value)">
+            <div class="global-filters">
+                <div
+                    v-for="gf in globalFilters"
+                    :key="gf.id"
+                    class="filter-chip-wrap"
+                >
+                    <FilterChip
+                        :ref="(el: any) => setChipRef(gf.id, el)"
+                        :filter="gf"
+                        :filterKey="keyConfigFor(gf)"
+                        :class="{'read-only': filter.readOnly?.value}"
+                        class="filter-chip"
+                        @remove="filter.removeFilter"
+                        @update="filter.updateFilter"
+                    />
+                </div>
+                <template v-if="!filter.readOnly?.value">
+                    <KsButton
+                        v-for="key in unappliedGlobalKeys"
+                        :key="`add-${key.key}`"
+                        :icon="Plus"
+                        size="default"
+                        class="add-global-btn"
+                        @click="addGlobalFilter(key)"
+                    >
+                        {{ key.label }}
+                    </KsButton>
+                </template>
+            </div>
+            <span class="global-filters-divider" aria-hidden="true" />
+        </template>
+
         <KsPopover
             v-if="filter.hasFilterKeys?.value"
             v-model:visible="isCustomizeFiltersVisible"
@@ -117,13 +150,15 @@
     import {ref, inject, nextTick, computed, watch} from "vue"
     import {useDebounceFn} from "@vueuse/core"
 
-    import {FilterOutline} from "./utils/icons"
+    import {FilterOutline, Plus} from "./utils/icons"
 
     import CustomizeFilters from "./segments/CustomizeFilters.vue"
     import LogicalSeparator from "./segments/LogicalSeparator.vue"
     import FilterGroupRenderer from "./FilterGroupRenderer.vue"
+    import FilterChip from "./layout/FilterChip.vue"
 
-    import {COMPARATOR_LABELS, type AppliedFilter} from "./utils/filterTypes"
+    import {type AppliedFilter, type FilterKeyConfig} from "./utils/filterTypes"
+    import {buildNewFilter} from "./utils/filterChipFactory"
     import {FILTER_CONTEXT_INJECTION_KEY} from "./utils/filterInjectionKeys"
 
     const isCustomizeFiltersVisible = ref(false)
@@ -131,6 +166,28 @@
     const filter = inject(FILTER_CONTEXT_INJECTION_KEY)!
 
     const hoveredTopSeparator = ref(false)
+
+    const keyConfigFor = (appliedFilter: AppliedFilter): FilterKeyConfig | null =>
+        filter.configuration?.value?.keys?.find((key) => key.key === appliedFilter.key) ?? null
+
+    const globalFilters = computed(() =>
+        (filter.appliedFilters?.value ?? []).filter(
+            (appliedFilter: AppliedFilter) => keyConfigFor(appliedFilter)?.groupable === false,
+        ),
+    )
+
+    const unappliedGlobalKeys = computed(() =>
+        (filter.configuration?.value?.keys ?? [])
+            .filter((key: FilterKeyConfig) => key.groupable === false)
+            .filter((key: FilterKeyConfig) => !globalFilters.value.some((f: AppliedFilter) => f.key === key.key)),
+    )
+
+    const addGlobalFilter = (key: FilterKeyConfig) => {
+        const newFilter = buildNewFilter(key)
+        if (!newFilter) return
+        filter.addFilter(newFilter)
+        nextTick(() => chipRefs.value[newFilter.id]?.editPopover?.toggleDialog())
+    }
 
     type DragKind = "filter" | "group" | "field"
     interface DragEntity { kind: DragKind; id: string }
@@ -216,17 +273,9 @@
 
     const addFieldChipToGroup = (keyName: string, targetGroupId: string) => {
         const key = filter.configuration.value.keys?.find((k) => k.key === keyName)
-        const comparator = key?.comparators?.[0]
-        if (!key || !comparator) return
-        const newFilter: AppliedFilter = {
-            id: `${key.key}-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`,
-            key: key.key,
-            keyLabel: key.label,
-            comparator,
-            comparatorLabel: COMPARATOR_LABELS[comparator],
-            value: [],
-            valueLabel: "",
-        }
+        if (!key) return
+        const newFilter = buildNewFilter(key)
+        if (!newFilter) return
         filter.addFilter(newFilter, targetGroupId)
         isCustomizeFiltersVisible.value = false
         nextTick(() => chipRefs.value[newFilter.id]?.editPopover?.toggleDialog())
@@ -293,6 +342,48 @@
     &.filter-grow {
         flex-wrap: nowrap;
         flex-grow: 1;
+    }
+}
+
+.global-filters {
+    display: inline-flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: var(--ks-spacing-2);
+
+    .filter-chip-wrap {
+        flex-shrink: 0;
+    }
+
+    .filter-chip {
+        flex-shrink: 0;
+        box-shadow: var(--ks-box-shadow);
+
+        &.read-only {
+            pointer-events: none;
+            opacity: 0.6;
+        }
+    }
+}
+
+.global-filters-divider {
+    width: 1px;
+    align-self: stretch;
+    min-height: 1.75rem;
+    background: var(--ks-border-default);
+    flex-shrink: 0;
+}
+
+.add-global-btn {
+    flex-shrink: 0;
+    font-size: var(--ks-font-size-xs);
+    color: var(--ks-text-secondary);
+    border: 1px dashed var(--ks-border-default);
+    background: transparent;
+
+    &:hover {
+        color: var(--ks-text-primary);
+        background: var(--ks-bg-hover);
     }
 }
 

--- a/ui/packages/design-system/src/components/Data/KsDataTable/filter/segments/CustomizeFilters.vue
+++ b/ui/packages/design-system/src/components/Data/KsDataTable/filter/segments/CustomizeFilters.vue
@@ -16,7 +16,7 @@
 
         <div class="list">
             <div
-                v-for="key in configuration.keys"
+                v-for="key in groupableKeys"
                 :key="key.key"
                 class="item"
                 :draggable="true"
@@ -49,11 +49,11 @@
     import {computed} from "vue"
     import {Close, Plus} from "../utils/icons"
     import {
-        COMPARATOR_LABELS,
         type FilterConfiguration,
         type FilterKeyConfig,
         type AppliedFilter,
     } from "../utils/filterTypes"
+    import {buildNewFilter} from "../utils/filterChipFactory"
 
     const props = defineProps<{
         configuration: FilterConfiguration;
@@ -68,6 +68,10 @@
     }>()
 
     const FIELD_DRAG_MIME = "application/x-kestra-filter-entity"
+
+    const groupableKeys = computed(() =>
+        props.configuration.keys.filter((key) => key.groupable !== false),
+    )
 
     /**
      * Build a transient DOM node styled to look like an empty FilterChip so the browser's
@@ -120,21 +124,11 @@
     const selectedCount = computed(() =>
         new Set(props.appliedFilters.map(f => f.key)).size,
     )
-    const totalCount = computed(() => props.configuration.keys.length)
+    const totalCount = computed(() => groupableKeys.value.length)
 
     const addFilterForKey = (key: FilterKeyConfig) => {
-        const comparator = key.comparators?.[0]
-        if (!comparator) return
-        const newFilter: AppliedFilter = {
-            id: `${key.key}-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`,
-            key: key.key,
-            keyLabel: key.label,
-            comparator,
-            comparatorLabel: COMPARATOR_LABELS[comparator],
-            value: [],
-            valueLabel: "",
-        }
-        emits("add-filter", newFilter)
+        const newFilter = buildNewFilter(key)
+        if (newFilter) emits("add-filter", newFilter)
     }
 
 </script>

--- a/ui/packages/design-system/src/components/Data/KsDataTable/filter/utils/filterChipFactory.ts
+++ b/ui/packages/design-system/src/components/Data/KsDataTable/filter/utils/filterChipFactory.ts
@@ -8,6 +8,20 @@ import {
 import {type DecodedParam, keyOfComparator} from "./helpers"
 import {TIME_RANGE_KEY} from "./constants"
 
+export const buildNewFilter = (key: FilterKeyConfig): AppliedFilter | null => {
+    const comparator = key.comparators?.[0]
+    if (!comparator) return null
+    return {
+        id: `${key.key}-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`,
+        key: key.key,
+        keyLabel: key.label,
+        comparator,
+        comparatorLabel: COMPARATOR_LABELS[comparator],
+        value: [],
+        valueLabel: "",
+    }
+}
+
 export const createAppliedFilter = (
     key: string,
     config: FilterKeyConfig | undefined,

--- a/ui/packages/design-system/src/components/Data/KsDataTable/filter/utils/filterTypes.ts
+++ b/ui/packages/design-system/src/components/Data/KsDataTable/filter/utils/filterTypes.ts
@@ -64,6 +64,11 @@ export interface FilterKeyConfig {
     customDateMode?: "single" | "range";
     visibleByDefault?: boolean;
     defaultValue?: AppliedFilter["value"] | (() => AppliedFilter["value"]);
+    /**
+     * When `false`, the filter is a global AND scope: it cannot be added to or moved into a
+     * conditional group, and is omitted from the "add field" menu. Defaults to `true`.
+     */
+    groupable?: boolean;
     /** When set, renders an "Apply to" segmented selector inside the timeRange popover. */
     dateFilterOptions?: DateFilterOption[];
     /** Overrides the chip's keyLabel based on the active dateFilter meta value. */

--- a/ui/packages/design-system/src/components/Data/KsDataTable/filter/utils/helpers.ts
+++ b/ui/packages/design-system/src/components/Data/KsDataTable/filter/utils/helpers.ts
@@ -138,11 +138,12 @@ const writeFilter = (
 
     switch (key) {
         case "timeRange": {
+            // timeRange is a global AND scope: always top-level, never under a group prefix.
             if (typeof value === "object" && "startDate" in value) {
                 query["filters[startDate][GREATER_THAN_OR_EQUAL_TO]"] = value.startDate.toISOString()
                 query["filters[endDate][LESS_THAN_OR_EQUAL_TO]"] = value.endDate.toISOString()
             } else {
-                query[`${prefix}[${key}][${comparatorKey}]`] = value?.toString() ?? ""
+                query[`filters[${key}][${comparatorKey}]`] = value?.toString() ?? ""
             }
             const dateFilter = (filter as any).meta?.dateFilter
             if (dateFilter) {

--- a/ui/src/components/executions/Executions.vue
+++ b/ui/src/components/executions/Executions.vue
@@ -53,6 +53,13 @@
             :rowKey="(row: any) => row.id"
         >
             <template #navbar v-if="isDisplayedTop">
+                <QuickFilters
+                    :intervals="quickIntervals"
+                    :timeRange="selectedTimeRange"
+                    :intervalLabel="t('filter.timeRange.label')"
+                    :showLevel="false"
+                    @update:timeRange="onQuickFilterTimeRange"
+                />
                 <KSFilter
                     :configuration="namespace === undefined || flowId === undefined ? executionFilter : flowExecutionFilter"
                     :properties="{
@@ -68,13 +75,6 @@
                     }"
                     @update-properties="updateDisplayColumns"
                     :defaultScope="defaultScopeFilter"
-                />
-                <QuickFilters
-                    :intervals="quickIntervals"
-                    :timeRange="selectedTimeRange"
-                    :intervalLabel="t('filter.timeRange.label')"
-                    :showLevel="false"
-                    @update:timeRange="onQuickFilterTimeRange"
                 />
             </template>
 

--- a/ui/src/components/filter/configurations/executionFilter.ts
+++ b/ui/src/components/filter/configurations/executionFilter.ts
@@ -131,6 +131,7 @@ export const useExecutionFilter = (): ComputedRef<FilterConfiguration> => {
                     description: t("filter.timeRange.description"),
                     comparators: [Comparators.EQUALS],
                     valueType: "select",
+                    groupable: false,
                     valueProvider: async () => {
                         const {VALUES} = useValues("executions", t)
                         return VALUES.RELATIVE_DATE

--- a/ui/src/components/filter/configurations/flowExecutionFilter.ts
+++ b/ui/src/components/filter/configurations/flowExecutionFilter.ts
@@ -64,6 +64,7 @@ export const useFlowExecutionFilter = (): ComputedRef<FilterConfiguration> => {
                     description: t("filter.timeRange.description"),
                     comparators: [Comparators.EQUALS],
                     valueType: "select",
+                    groupable: false,
                     valueProvider: async () => {
                         const {VALUES} = useValues("executions")
                         return VALUES.RELATIVE_DATE

--- a/ui/tests/unit/filter/utils/helpers.spec.ts
+++ b/ui/tests/unit/filter/utils/helpers.spec.ts
@@ -44,6 +44,16 @@ describe("Filter Helpers", () => {
             ])
         })
 
+        it("decodes a global timeRange alongside grouped filters without a groupIndex", () => {
+            expect(decodeSearchParams({
+                "filters[timeRange][EQUALS]": "PT24H",
+                "filters[or][0][state][EQUALS]": "RUNNING",
+            })).toEqual([
+                {field: "timeRange", value: "PT24H", operation: "EQUALS"},
+                {field: "state", value: "RUNNING", operation: "EQUALS", groupIndex: 0, topLogical: "OR"},
+            ])
+        })
+
         it("should decode wrapper-nested params with both operators", () => {
             expect(decodeSearchParams({"filters[or][0][and][1][namespace][EQUALS]": "io.kestra"})).toEqual([
                 {
@@ -127,6 +137,39 @@ describe("Filter Helpers", () => {
             expect(encodeFilterGroupsToQuery(groups, keyOfComparator, "AND")).toEqual({
                 "filters[and][0][state][EQUALS]": "RUNNING",
                 "filters[and][1][namespace][EQUALS]": "io.kestra",
+            })
+        })
+
+        it("keeps timeRange global (no group prefix) across multiple OR groups", () => {
+            const groups: FilterGroup[] = [
+                leaf("g1", [
+                    {key: "timeRange", comparator: Comparators.EQUALS, value: "PT24H"},
+                    {key: "state", comparator: Comparators.EQUALS, value: "RUNNING"},
+                ]),
+                leaf("g2", [{key: "state", comparator: Comparators.EQUALS, value: "FAILED"}]),
+            ]
+            expect(encodeFilterGroupsToQuery(groups, keyOfComparator)).toEqual({
+                "filters[timeRange][EQUALS]": "PT24H",
+                "filters[or][0][state][EQUALS]": "RUNNING",
+                "filters[or][1][state][EQUALS]": "FAILED",
+            })
+        })
+
+        it("keeps a custom timeRange range global (startDate/endDate) across multiple OR groups", () => {
+            const startDate = new Date("2024-01-01T00:00:00Z")
+            const endDate = new Date("2024-01-31T23:59:59Z")
+            const groups: FilterGroup[] = [
+                leaf("g1", [
+                    {key: "timeRange", comparator: Comparators.GREATER_THAN_OR_EQUAL_TO, value: {startDate, endDate}},
+                    {key: "state", comparator: Comparators.EQUALS, value: "RUNNING"},
+                ]),
+                leaf("g2", [{key: "state", comparator: Comparators.EQUALS, value: "FAILED"}]),
+            ]
+            expect(encodeFilterGroupsToQuery(groups, keyOfComparator)).toEqual({
+                "filters[startDate][GREATER_THAN_OR_EQUAL_TO]": startDate.toISOString(),
+                "filters[endDate][LESS_THAN_OR_EQUAL_TO]": endDate.toISOString(),
+                "filters[or][0][state][EQUALS]": "RUNNING",
+                "filters[or][1][state][EQUALS]": "FAILED",
             })
         })
 


### PR DESCRIPTION
## Summary

The execution-list time range was a regular chip inside the `AND`/`OR` group builder, so it could end up in an `OR` branch and the quick-interval selector was ambiguous (*"which group should receive the interval?"* — issue #16433). A time range is always an **AND** scope, never an `OR` member, so it does not belong inside the group builder.

This makes the time filter a **global scope** rendered outside the conditional groups, and introduces a reusable `groupable` capability in the design-system filter to express that.

**Design-system** — new optional `groupable` flag on `FilterKeyConfig`. When `false`, a filter:
- is excluded from the *Add filters* menu and cannot be dragged into a group
- renders in a dedicated slot in `MainFilter`, separated from the groups by a divider, with a persistent `+ <label>` placeholder when unset that reopens the full editor (predefined + custom range + applyTo)
- always encodes at the top level (`filters[<key>][...]`), never under an `or][n]` / `and][n]` prefix, so the backend `AND`s it with the group expression — `timeRange AND (g1 OR g2)` — matching the AND/OR query support added in #16170

**Executions** — set `groupable: false` on the `timeRange` key of the execution and flow-execution filters, and move the quick-interval presets above the filter builder so they stay visible.

Also extracts a shared `buildNewFilter(key)` chip factory, removing duplicated chip construction across the add-menu, drag-drop and global-slot flows.

## Test Coverage
- `helpers.spec.ts`: timeRange stays global (`filters[timeRange][EQUALS]`) across multiple `OR` groups; custom range (`startDate`/`endDate`) stays global in multi-group; global timeRange decodes alongside grouped filters without a `groupIndex`.
- UI filter unit tests: 55 passing. Design-system filter logic tests passing.

## Verification
Verified live on the executions list: quick interval keeps the time global with conditional groups active; the time chip renders outside the `OR`/`AND` groups and is no longer addable/draggable into one; deleting it shows the `+ Interval` placeholder that reopens the editor (predefined + custom + applyTo).

## Screenshots

**Time filter as a global slot, presets on top**
<img width="1480" height="230" alt="1-layout" src="https://github.com/user-attachments/assets/2fc0d831-ff67-4532-8b4b-43227e97f905" />


**Always outside the AND/OR groups**
<img width="1480" height="250" alt="2-time-outside-or-groups" src="https://github.com/user-attachments/assets/f61d1684-04e2-4628-ab36-4aa98e4442f2" />


**Full editor preserved (predefined + custom range + apply to)**
<img width="1480" height="520" alt="3-time-editor" src="https://github.com/user-attachments/assets/68d97cee-b14d-4c0b-8fdb-b8503a02def1" />


**Empty state — `+ Interval` placeholder reopens the editor**
<img width="1480" height="230" alt="4-empty-state" src="https://github.com/user-attachments/assets/29fe32f5-ed4b-4ec5-9cb8-0b0774c28abf" />


## Notes
- Pure frontend change; no backend changes (the AND/OR support it relies on landed in #16170).
- The DS component test suites fail locally on an unrelated monaco-editor + jsdom interaction (`document.queryCommandSupported`) present on `develop`, not touched by this diff.

Closes #16433

🤖 Generated with [Claude Code](https://claude.com/claude-code)