### PR TITLE
fix(core): hide KsDataTable pagination for size 10

### DIFF
--- a/ui/packages/design-system/src/components/Data/KsDataTable/KsDataTable.vue
+++ b/ui/packages/design-system/src/components/Data/KsDataTable/KsDataTable.vue
@@ -56,7 +56,7 @@
             </template>
 
             <KsPagination
-                v-if="total && total > 0"
+                v-if="showPagination"
                 :currentPage="currentPageValue"
                 :pageSize="currentSizeValue"
                 :total
@@ -303,6 +303,12 @@
     }
 
     const showEmpty = computed(() => props.data.length === 0 && !isLoading.value)
+
+    const showPagination = computed(() => {
+        if (!props.total || props.total <= 0) return false
+        const minSize = props.pageSizeOptions.length ? Math.min(...props.pageSizeOptions) : DEFAULT_PAGE_SIZE
+        return props.total > minSize
+    })
 
     const reload = () => callLoad()
 

--- a/ui/tests/e2e/executions/execution-bulk-actions.spec.ts
+++ b/ui/tests/e2e/executions/execution-bulk-actions.spec.ts
@@ -17,6 +17,7 @@ test.describe("Executions' view Bulk Actions", () => {
                 await executionsApi.generateExecutionViaApi([["foo", "bar"]])
             }
             await executionsApi.generateExecutionViaApi([["a", "b"]])
+            await page.reload()
         })
 
         await test.step("Filter just the executions featuring the 'foo:bar' label", async () => {
@@ -56,6 +57,7 @@ test.describe("Executions' view Bulk Actions", () => {
                 await executionsApi.generateExecutionViaApi([["foo", "bar"]])
             }
             await executionsApi.generateExecutionViaApi([["a", "b"]])
+            await page.reload()
         })
 
         await test.step("Filter just 'FAILED' executions featuring the 'foo:bar' label", async () => {
@@ -102,6 +104,7 @@ test.describe("Executions' view Bulk Actions", () => {
                 await executionsApi.generateExecutionViaApi([["foo", "bar"]])
             }
             await executionsApi.generateExecutionViaApi([["a", "b"]])
+            await page.reload()
         })
 
         await test.step("Filter just 'FAILED' executions featuring the 'foo:bar' label", async () => {


### PR DESCRIPTION
Closes https://github.com/kestra-io/kestra-ee/issues/8199

Don't show the pagination bar when there's only one page of results and no smaller page size would split it into more. Keeps the size selector available whenever switching to a smaller size would actually paginate the data.