### PR TITLE
fix(security): use configured axios instance in AI store for CSRF support

### DIFF
--- a/ui/src/components/ai/AiCopilot.vue
+++ b/ui/src/components/ai/AiCopilot.vue
@@ -278,6 +278,8 @@
     import type {InputInstance} from "@kestra-io/design-system"
     import {useMiscStore} from "override/stores/misc"
     import {aiGenerationTypes, AiGenerationType} from "../../utils/constants"
+    import {AiControllerAiProviderResponse} from "@kestra-io/kestra-sdk"
+    import * as AiApi from "@kestra-io/kestra-sdk/ai"
 
     const aiStore = useAiStore()
     const apiStore = useApiStore()
@@ -389,12 +391,12 @@
         return matchedExample?.flow
     })
 
-    const providers = ref<{id?: string | undefined, displayName?: string | undefined }[]>([])
+    const providers = ref<AiControllerAiProviderResponse[]>([])
     const selectedProvider = ref<string | undefined>(undefined)
 
     async function fetchProviders() {
         try {
-            const list = await aiStore.fetchProviders()
+            const list = await AiApi.providers()
             providers.value = list ?? []
             if (providers.value.length > 0) {
                 selectedProvider.value = providers.value[0].id

--- a/ui/src/components/ai/AiCopilot.vue
+++ b/ui/src/components/ai/AiCopilot.vue
@@ -389,7 +389,7 @@
         return matchedExample?.flow
     })
 
-    const providers = ref<{id: string, displayName: string}[]>([])
+    const providers = ref<{id?: string | undefined, displayName?: string | undefined }[]>([])
     const selectedProvider = ref<string | undefined>(undefined)
 
     async function fetchProviders() {
@@ -513,7 +513,6 @@
                     conversationId: props.conversationId,
                     providerId: selectedProvider.value,
                     namespace: props.namespace,
-                    type: type,
                     ...(effectiveFlowYaml.value ? {yaml: effectiveFlowYaml.value} : {}),
                 })
             } else {

--- a/ui/src/stores/ai.ts
+++ b/ui/src/stores/ai.ts
@@ -1,49 +1,73 @@
 import {defineStore} from "pinia"
+import * as AiApi from "@kestra-io/kestra-sdk/ai"
 import {useClient} from "@kestra-io/kestra-sdk"
-import {apiUrl} from "override/utils/route"
-import {AiGenerationType} from "../utils/constants"
+import {AiGenerationType, aiGenerationTypes} from "../utils/constants"
 import {getUid} from "../utils/uid"
+import {ref} from "vue"
 
 export const useAiStore = defineStore("ai", () => {
-    const axios = useClient()
+    const client = useClient()
+    const remainingQuota = ref("")
+
+    client.interceptors.response.use((response) => {
+        if (response.headers["x-kestra-ai-quota"] !== undefined) {
+            remainingQuota.value = response.headers["x-kestra-ai-quota"]
+        }
+        return response
+    })
 
     async function fetchProviders() {
-        const response = await axios.get(`${apiUrl()}/ai/providers`)
-        return response.data ?? []
+        return await AiApi.providers()
     }
 
-    async function generate({userPrompt, yaml, conversationId, providerId, type}: {userPrompt: string, yaml?: string, conversationId: string, providerId?: string, type: AiGenerationType}) {
-        const response = await axios.post(`${apiUrl()}/ai/generate/${type}`, {
+    async function generate({
+        userPrompt, 
+        yaml, 
+        conversationId, 
+        providerId, 
+        type,
+    }: {
+            userPrompt: string, 
+            yaml?: string, 
+            conversationId: string, 
+            providerId?: string, 
+            type: AiGenerationType
+    }) {
+        const methodMap = {
+            [aiGenerationTypes.FLOW]: AiApi.generateFlow,
+            [aiGenerationTypes.APP]: AiApi.generateApp,
+            [aiGenerationTypes.DASHBOARD]: AiApi.generateDashboard,
+            [aiGenerationTypes.TEST]: AiApi.generateTestSuite,
+        } as const
+
+        const response = await methodMap[type]({
             userPrompt,
             conversationId,
             providerId,
             ...(yaml !== undefined ? {yaml} : {}),
-        }, {
+            
+        },{
             headers: {
                 "X-Kestra-User-Id": getUid(),
             },
+            client: client,
         })
 
-        const remainingQuota = response.headers["x-kestra-ai-quota"]
-        return {data: response.data, remainingQuota: remainingQuota ?? undefined}
+        return {data: response, remainingQuota: remainingQuota.value ?? undefined}
     }
 
-    async function generateFlow({userPrompt, yaml, conversationId, providerId, namespace, tenantId}: {userPrompt: string, yaml?: string, conversationId: string, providerId?: string, namespace?: string, tenantId?: string, type: AiGenerationType}) {
-        const response = await axios.post(`${apiUrl()}/ai/generate/flow`, {
-            userPrompt,
-            conversationId,
-            providerId,
-            namespace,
-            tenantId,
-            ...(yaml !== undefined ? {yaml} : {}),
-        }, {
-            headers: {
-                "X-Kestra-User-Id": getUid(),
-            },
+    async function generateFlow(options: {
+        userPrompt: string, 
+        yaml?: string, 
+        conversationId: string, 
+        providerId?: string, 
+        namespace?: string, 
+        tenantId?: string
+    }) {
+        return generate({
+            ...options,
+            type: aiGenerationTypes.FLOW,
         })
-
-        const remainingQuota = response.headers["x-kestra-ai-quota"]
-        return {data: response.data, remainingQuota: remainingQuota ?? undefined}
     }
 
     return {fetchProviders, generate, generateFlow}

--- a/ui/src/stores/ai.ts
+++ b/ui/src/stores/ai.ts
@@ -1,20 +1,12 @@
 import {defineStore} from "pinia"
-import * as AiApi from "@kestra-io/kestra-sdk/ai"
 import {useClient} from "@kestra-io/kestra-sdk"
+import * as AiApi from "@kestra-io/kestra-sdk/ai"
 import {AiGenerationType, aiGenerationTypes} from "../utils/constants"
 import {getUid} from "../utils/uid"
-import {ref} from "vue"
+import {apiUrl} from "override/utils/route"
 
 export const useAiStore = defineStore("ai", () => {
     const client = useClient()
-    const remainingQuota = ref("")
-
-    client.interceptors.response.use((response) => {
-        if (response.headers["x-kestra-ai-quota"] !== undefined) {
-            remainingQuota.value = response.headers["x-kestra-ai-quota"]
-        }
-        return response
-    })
 
     async function fetchProviders() {
         return await AiApi.providers()
@@ -25,45 +17,36 @@ export const useAiStore = defineStore("ai", () => {
         yaml, 
         conversationId, 
         providerId, 
+        namespace, 
+        tenantId,
         type,
     }: {
-            userPrompt: string, 
-            yaml?: string, 
-            conversationId: string, 
-            providerId?: string, 
-            type: AiGenerationType
-    }) {
-        const methodMap = {
-            [aiGenerationTypes.FLOW]: AiApi.generateFlow,
-            [aiGenerationTypes.APP]: AiApi.generateApp,
-            [aiGenerationTypes.DASHBOARD]: AiApi.generateDashboard,
-            [aiGenerationTypes.TEST]: AiApi.generateTestSuite,
-        } as const
-
-        const response = await methodMap[type]({
-            userPrompt,
-            conversationId,
-            providerId,
-            ...(yaml !== undefined ? {yaml} : {}),
-            
-        },{
-            headers: {
-                "X-Kestra-User-Id": getUid(),
-            },
-            client: client,
-        })
-
-        return {data: response, remainingQuota: remainingQuota.value ?? undefined}
-    }
-
-    async function generateFlow(options: {
         userPrompt: string, 
         yaml?: string, 
         conversationId: string, 
         providerId?: string, 
         namespace?: string, 
-        tenantId?: string
+        tenantId?: string,
+        type: AiGenerationType
     }) {
+        const response = await client.post(`${apiUrl()}/ai/generate/${type}`, {
+            userPrompt,
+            conversationId,
+            providerId,
+            namespace, 
+            tenantId,
+            ...(yaml !== undefined ? {yaml} : {}),
+        }, {
+            headers: {
+                "X-Kestra-User-Id": getUid(),
+            },
+        })
+
+        const remainingQuota = response.headers["x-kestra-ai-quota"]
+        return {data: response.data, remainingQuota: remainingQuota ?? undefined}
+    }
+
+    async function generateFlow(options: Omit<Parameters<typeof generate>[0], "type">) {
         return generate({
             ...options,
             type: aiGenerationTypes.FLOW,

--- a/ui/src/stores/ai.ts
+++ b/ui/src/stores/ai.ts
@@ -1,49 +1,50 @@
-import axios from "axios"
 import {defineStore} from "pinia"
+import {useClient} from "@kestra-io/kestra-sdk"
 import {apiUrl} from "override/utils/route"
 import {AiGenerationType} from "../utils/constants"
 import {getUid} from "../utils/uid"
 
-export const useAiStore = defineStore("ai", {
-    actions: {
-        async fetchProviders() {
-            const response = await axios.get(`${apiUrl()}/ai/providers`)
-            return response.data ?? []
-        },
+export const useAiStore = defineStore("ai", () => {
+    const axios = useClient()
 
-        async generate({userPrompt, yaml, conversationId, providerId, type}: {userPrompt: string, yaml?: string, conversationId: string, providerId?: string, type: AiGenerationType}) {
-            const response = await axios.post(`${apiUrl()}/ai/generate/${type}`, {
-                userPrompt,
-                conversationId,
-                providerId,
-                ...(yaml !== undefined ? {yaml} : {}),
-            }, {
-                headers: {
-                    "X-Kestra-User-Id": getUid(),
-                },
-            })
+    async function fetchProviders() {
+        const response = await axios.get(`${apiUrl()}/ai/providers`)
+        return response.data ?? []
+    }
 
-            const remainingQuota = response.headers["x-kestra-ai-quota"]
-            return {data: response.data, remainingQuota: remainingQuota ?? undefined}
-        },
+    async function generate({userPrompt, yaml, conversationId, providerId, type}: {userPrompt: string, yaml?: string, conversationId: string, providerId?: string, type: AiGenerationType}) {
+        const response = await axios.post(`${apiUrl()}/ai/generate/${type}`, {
+            userPrompt,
+            conversationId,
+            providerId,
+            ...(yaml !== undefined ? {yaml} : {}),
+        }, {
+            headers: {
+                "X-Kestra-User-Id": getUid(),
+            },
+        })
 
-        async generateFlow({userPrompt, yaml, conversationId, providerId, namespace, tenantId}: {userPrompt: string, yaml?: string, conversationId: string, providerId?: string, namespace?: string, tenantId?: string, type: AiGenerationType}) {
-            const response = await axios.post(`${apiUrl()}/ai/generate/flow`, {
-                userPrompt,
-                conversationId,
-                providerId,
-                namespace,
-                tenantId,
-                ...(yaml !== undefined ? {yaml} : {}),
-            }, {
-                headers: {
-                    "X-Kestra-User-Id": getUid(),
-                },
-            })
+        const remainingQuota = response.headers["x-kestra-ai-quota"]
+        return {data: response.data, remainingQuota: remainingQuota ?? undefined}
+    }
 
-            const remainingQuota = response.headers["x-kestra-ai-quota"]
-            return {data: response.data, remainingQuota: remainingQuota ?? undefined}
-        },
+    async function generateFlow({userPrompt, yaml, conversationId, providerId, namespace, tenantId}: {userPrompt: string, yaml?: string, conversationId: string, providerId?: string, namespace?: string, tenantId?: string, type: AiGenerationType}) {
+        const response = await axios.post(`${apiUrl()}/ai/generate/flow`, {
+            userPrompt,
+            conversationId,
+            providerId,
+            namespace,
+            tenantId,
+            ...(yaml !== undefined ? {yaml} : {}),
+        }, {
+            headers: {
+                "X-Kestra-User-Id": getUid(),
+            },
+        })
 
-    },
+        const remainingQuota = response.headers["x-kestra-ai-quota"]
+        return {data: response.data, remainingQuota: remainingQuota ?? undefined}
+    }
+
+    return {fetchProviders, generate, generateFlow}
 })

--- a/ui/src/stores/ai.ts
+++ b/ui/src/stores/ai.ts
@@ -1,16 +1,11 @@
 import {defineStore} from "pinia"
 import {useClient} from "@kestra-io/kestra-sdk"
-import * as AiApi from "@kestra-io/kestra-sdk/ai"
 import {AiGenerationType, aiGenerationTypes} from "../utils/constants"
 import {getUid} from "../utils/uid"
 import {apiUrl} from "override/utils/route"
 
 export const useAiStore = defineStore("ai", () => {
     const client = useClient()
-
-    async function fetchProviders() {
-        return await AiApi.providers()
-    }
 
     async function generate({
         userPrompt, 
@@ -53,5 +48,5 @@ export const useAiStore = defineStore("ai", () => {
         })
     }
 
-    return {fetchProviders, generate, generateFlow}
+    return {generate, generateFlow}
 })


### PR DESCRIPTION
## Summary
- The AI store (`ui/src/stores/ai.ts`) imported the bare `axios` default instance instead of the configured one from `useClient()`
- The configured instance has the CSRF interceptor that adds the `X-CSRF-TOKEN` header to requests
- Without it, POST requests to `/ai/generate/*` (Copilot) fail with 403 when CSRF protection is enabled
- Migrated the store from Options API to Composition API using `useClient()`, matching the pattern used by other migrated stores (`blueprints.ts`, `logs.ts`, `plugins.ts`, etc.)

## Test plan
- [ ] Type check passes (`npm run check:types`)
- [ ] Open Copilot in the UI, submit a prompt — should get a response instead of 403
- [ ] Verify the `X-CSRF-TOKEN` header is present on `/ai/generate/*` requests in the Network tab