### PR TITLE
build: push kestra-base image to GitHub Container Registry

### DIFF
--- a/.github/workflows/global-push-base-image.yml
+++ b/.github/workflows/global-push-base-image.yml
@@ -26,13 +26,6 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
 
-      - name: Log in to Docker Hub
-        if: ${{ inputs.dry-run != true }}
-        uses: docker/login-action@v4
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_PASSWORD }}
-
       - name: Log in to GitHub Container Registry
         if: ${{ inputs.dry-run != true }}
         uses: docker/login-action@v4
@@ -47,9 +40,7 @@ jobs:
           context: .
           file: Dockerfile.base
           push: ${{ inputs.dry-run != true }}
-          tags: |
-            kestra/kestra-base:latest
-            ghcr.io/kestra-io/kestra-base:latest
+          tags: ghcr.io/kestra-io/kestra-base:latest
           build-args: |
             UV_VERSION=${{ inputs.uv-version || '0.6.17' }}
           cache-from: type=registry,ref=kestra/kestra-base:latest

--- a/.github/workflows/global-push-base-image.yml
+++ b/.github/workflows/global-push-base-image.yml
@@ -33,13 +33,23 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
+      - name: Log in to GitHub Container Registry
+        if: ${{ inputs.dry-run != true }}
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Build and push
         uses: docker/build-push-action@v7
         with:
           context: .
           file: Dockerfile.base
           push: ${{ inputs.dry-run != true }}
-          tags: kestra/kestra-base:latest
+          tags: |
+            kestra/kestra-base:latest
+            ghcr.io/kestra-io/kestra-base:latest
           build-args: |
             UV_VERSION=${{ inputs.uv-version || '0.6.17' }}
           cache-from: type=registry,ref=kestra/kestra-base:latest


### PR DESCRIPTION
## Summary

- Adds a GitHub Container Registry (`ghcr.io`) login step to the base image workflow
- Pushes `kestra/kestra-base:latest` to both Docker Hub and `ghcr.io/kestra-io/kestra-base:latest`
- The `dry-run` guard applies to both logins and the push, keeping the existing dry-run behaviour intact

## Test plan

- [ ] Trigger the workflow manually with `dry-run: true` — no push should occur to either registry
- [ ] Trigger with `dry-run: false` — image should appear at `ghcr.io/kestra-io/kestra-base:latest`