### PR TITLE
feat(triggers): add actionable empty state to MCP tool flows tab

### DIFF
--- a/ui/src/components/admin/mcp/tabs/McpToolFlows.vue
+++ b/ui/src/components/admin/mcp/tabs/McpToolFlows.vue
@@ -1,6 +1,14 @@
 <template>
     <div class="mcp-tools">
+        <Empty v-if="loaded && tools.length === 0" type="mcpToolFlows">
+            <template v-if="canCreateFlow" #button>
+                <KsButton type="primary" :icon="Plus" @click="createToolFlow">
+                    {{ t("mcp.tools.create_tool_flow") }}
+                </KsButton>
+            </template>
+        </Empty>
         <KsDataTable
+            v-else
             :data="filteredTools"
             :total="filteredTools.length"
             :loading="loading"
@@ -92,22 +100,34 @@
 
 <script lang="ts" setup>
     import {computed, onMounted, ref, watch} from "vue"
-    import {useRoute} from "vue-router"
+    import {useRoute, useRouter} from "vue-router"
     import {useI18n} from "vue-i18n"
-    import {KsDataTable, KsFilter as KSFilter, KsId, KsTableColumn, KsTag, decodeSearchParams} from "@kestra-io/design-system"
+    import {KsButton, KsDataTable, KsFilter as KSFilter, KsId, KsTableColumn, KsTag, decodeSearchParams} from "@kestra-io/design-system"
     import FolderOpenOutline from "vue-material-design-icons/FolderOpenOutline.vue"
+    import Plus from "vue-material-design-icons/Plus.vue"
+    import Empty from "../../../layout/empty/Empty.vue"
     import {useMcpStore, type McpTool, type McpToolAnnotations} from "../../../../stores/mcp"
     import {useMcpToolsFilter} from "../../../filter/configurations"
     import {type ColumnConfig, useTableColumns} from "../../../../composables/useTableColumns"
     import {storageKeys} from "../../../../utils/constants"
+    import {useMiscStore} from "override/stores/misc"
+    import {useAuthStore} from "override/stores/auth"
+    import resource from "../../../../models/resource"
+    import action from "../../../../models/action"
 
     const {t} = useI18n({useScope: "global"})
     const route = useRoute()
+    const router = useRouter()
     const mcpStore = useMcpStore()
     const toolsFilter = useMcpToolsFilter()
+    const authStore = useAuthStore()
+
+    const isOSS = computed(() => useMiscStore().configs?.edition === "OSS")
+    const canCreateFlow = computed(() => isOSS.value || authStore.user?.hasAnyAction?.(resource.FLOW, action.CREATE))
 
     const tools = ref<McpTool[]>([])
     const loading = ref(false)
+    const loaded = ref(false)
 
     const serverId = () => route.params.id as string | undefined
 
@@ -119,6 +139,7 @@
             tools.value = await mcpStore.listTools(id)
         } finally {
             loading.value = false
+            loaded.value = true
         }
     }
 
@@ -184,6 +205,47 @@
         return ANNOTATION_KEYS
             .filter((k) => a[k])
             .map((k) => k.replace(/([A-Z])/g, "_$1").toLowerCase())
+    }
+
+    function starterFlow(mcpServer: string): string {
+        return `id: hello_world
+namespace: company.team
+
+inputs:
+  - id: user
+    type: STRING
+    defaults: John Doe
+    description: "The name of the user to greet."
+
+tasks:
+  - id: greet
+    type: io.kestra.plugin.core.output.OutputValues
+    values:
+      greeting: "Hello, {{ inputs.user }}!"
+
+outputs:
+  - id: greeting
+    type: STRING
+    value: "{{ outputs.greet.values.greeting }}"
+
+triggers:
+  - id: mcp
+    type: io.kestra.plugin.core.trigger.McpToolTrigger
+    toolName: hello_world
+    title: Hello World greeting tool
+    toolDescription: Returns a personalised greeting. Call this when the user asks for a greeting.
+    mcpServer: ${mcpServer}`
+    }
+
+    function createToolFlow() {
+        router.push({
+            name: "flows/create",
+            query: {
+                blueprintId: "mcp-tool-trigger",
+                blueprintSourceYaml: starterFlow(serverId() ?? "default"),
+            },
+            ...(route.params.tenant ? {params: {tenant: route.params.tenant}} : {}),
+        })
     }
 
     function flowRouteFor(tool: McpTool) {

--- a/ui/src/components/layout/empty/links.ts
+++ b/ui/src/components/layout/empty/links.ts
@@ -52,6 +52,10 @@ export const links: Record<string, EmptyLinks> = {
         video: "https://www.youtube.com/watch?v=qDiQtsVEETs",
         learnMore: "https://kestra.io/docs/workflow-components/triggers",
     },
+    mcpToolFlows: {
+        video: "https://www.youtube.com/watch?v=QxaMnGuu0kI",
+        learnMore: "https://kestra.io/docs/workflow-components/triggers/mcp-tool-trigger",
+    },
     concurrency_executions: {
         video: "https://www.youtube.com/watch?v=lDGOqqMyQEo",
         learnMore: "https://kestra.io/docs/workflow-components/concurrency",

--- a/ui/src/translations/en.json
+++ b/ui/src/translations/en.json
@@ -1660,6 +1660,10 @@
         "title": "Your flow doesn't have any Triggers.",
         "content": "Read more about <strong><a href=\"https://kestra.io/docs/workflow-components/triggers?utm_source=app&utm_medium=referral&utm_campaign=trigger-inlinedoc\" target=\"_blank\">Triggers</a></strong> in our documentation."
       },
+      "mcpToolFlows": {
+        "title": "No tool flows are registered on this server yet.",
+        "content": "Expose a flow as an MCP tool by adding an <code>McpToolTrigger</code> to it. Read more about the <strong><a href=\"https://kestra.io/docs/workflow-components/triggers/mcp-tool-trigger?utm_source=app&utm_medium=referral&utm_campaign=mcp-tool-trigger-inlinedoc\" target=\"_blank\">MCP Tool Trigger</a></strong> in our documentation."
+      },
       "versionPlugin": {
         "title": "You have no versioned plugin yet!",
         "content": "Here you can manage all the plugins installed on your Kestra instance. Newly installed plugins may not be immediately available in all Kestra services, depending on the configuration of your instance."
@@ -2035,7 +2039,8 @@
       "tab_tool_flows": "Tool Flows",
       "tab_tool_flows_placeholder": "Tool flows management is coming soon.",
       "tools": {
-        "no_tools": "No tool flows are registered on this server yet. Add an `McpToolTrigger` to a flow to expose it here.",
+        "no_tools": "No tool flows match your search.",
+        "create_tool_flow": "Create a tool flow",
         "tool_name": "Tool Name",
         "trigger_id": "Trigger ID",
         "title": "Title",


### PR DESCRIPTION
## What

The MCP server **Tool Flows** tab showed only a bare data-table "no tool flows registered" line when a server had no tools. This replaces it with the standard empty state — and goes a step further than a docs link.

An empty state that only describes the void is a UX dead end; it should offer the action that fills it. So the empty state now provides:

- **Create a tool flow** (primary CTA) — opens the flow editor pre-loaded with a valid `McpToolTrigger` example, already wired to `mcpServer: <the server you're on>`. One click from "nothing here" to a working tool flow.
- **Watch the video** — the Kestra MCP server walkthrough.
- **Learn more** — the `McpToolTrigger` docs page.

The CTA is gated on flow-create permission (no dead-end button for read-only users). The data-table `noDataText` now reads "No tool flows match your search." since it only renders on a filtered no-match.

## Screenshots

| Empty state (with action) | What the CTA opens |
|---|---|
| <img width="1280" height="720" alt="image" src="https://github.com/user-attachments/assets/75ab3cc2-3579-45b2-bf4c-e6560ee22c87" /> | <img width="1280" height="720" alt="image" src="https://github.com/user-attachments/assets/5ca11500-0bc0-4660-810c-e7b0440e9745" /> |

## Testing

- Type-check + eslint pass.
- Verified end-to-end in the running dev UI (light + dark): empty state renders, CTA navigates to `flows/create` with the starter YAML, `mcpServer` interpolated to the current server id, editor validates green.
- No component-mount unit test added — the repo has no component-test harness (`ui/tests/unit` is logic-only: stores/utils) and the new logic is a static YAML builder + `router.push`, covered by the live QA above.

## Notes

- The **Learn more** link points at `kestra.io/docs/workflow-components/triggers/mcp-tool-trigger`, which currently 404s until the referenced docs PR merges — should land together.
- English-only translation change; the auto-translate workflow fills the other locales.

Closes https://github.com/kestra-io/kestra-ee/issues/8191

🤖 Generated with [Claude Code](https://claude.com/claude-code)
