### PR TITLE
fix(executions): handle purged output files (backport #16480)

### DIFF
--- a/ui/src/components/executions/VarValue.vue
+++ b/ui/src/components/executions/VarValue.vue
@@ -147,8 +147,13 @@
     const getFileSize = async (): Promise<void> => {
         if (isFile(props.value) && props.execution?.id) {
             try {
-                const response = await axios.get<FileMetadata>(`${apiUrl()}/executions/${props.execution.id}/file/metas?path=${props.value}`);
-                humanSize.value = Utils.humanFileSize(response.data.size);
+                const response = await axios.get<FileMetadata>(
+                    `${apiUrl()}/executions/${props.execution.id}/file/metas?path=${props.value}`,
+                    {validateStatus: (status: number) => status === 200 || status === 404 || status === 422},
+                );
+                if (response.status === 200) {
+                    humanSize.value = Utils.humanFileSize(response.data.size);
+                }
             } catch (error) {
                 console.error("Failed to fetch file size:", error);
             }


### PR DESCRIPTION
Backport of #16480 to 1.3. Minimal fix: validateStatus on file/metas so a purged file's 404 doesn't trigger the global error page.