### PR TITLE
fix(core): theme KsTooltip with `--ks- ` tokens

### DIFF
--- a/ui/packages/design-system/src/components/Feedback/KsTooltip.vue
+++ b/ui/packages/design-system/src/components/Feedback/KsTooltip.vue
@@ -3,8 +3,9 @@
         :persistent="false"
         :hideAfter="0"
         transition=""
-        :effect="effectValue"
+        :effect="props.effect ?? 'light'"
         v-bind="({...filteredProps(), ...$attrs} as any)"
+        :popperClass="popperClass"
     >
         <template v-if="$slots.default" #default>
             <slot />
@@ -16,10 +17,9 @@
 </template>
 
 <script setup lang="ts">
-    import {computed} from "vue"
+    import {computed, useAttrs} from "vue"
     import {ElTooltip} from "element-plus"
     import {useFilteredProps} from "../../utils/filteredProps"
-    import {useTheme} from "../../composables/useTheme"
 
     defineOptions({inheritAttrs: false})
 
@@ -46,9 +46,12 @@
         content?(): unknown
     }>()
 
-    const {isDark} = useTheme()
+    const attrs = useAttrs()
 
-    const effectValue = computed(() => props.effect ?? (isDark.value ? "light" : "dark"))
+    const popperClass = computed(() => {
+        const extra = (attrs.popperClass as string | undefined) ?? ""
+        return `ks-tooltip ${extra}`.trim()
+    })
 
     const filteredProps = useFilteredProps(props, ["effect"])
 </script>
@@ -56,4 +59,20 @@
 <style lang="scss">
     @use '../../assets/styles/el-ns';
     @use 'element-plus/theme-chalk/src/tooltip';
+
+    .el-popper.ks-tooltip {
+        &.is-light,
+        &.is-dark {
+            background: var(--ks-bg-input);
+            color: var(--ks-text-primary);
+            border: 1px solid var(--ks-border-default);
+            box-shadow: 0 2px 6px var(--ks-shadow-element);
+        }
+
+        &.is-light .el-popper__arrow::before,
+        &.is-dark .el-popper__arrow::before {
+            background: var(--ks-bg-input);
+            border: 1px solid var(--ks-border-default);
+        }
+    }
 </style>

--- a/ui/packages/design-system/tests/units/Feedback/KsTooltip.test.ts
+++ b/ui/packages/design-system/tests/units/Feedback/KsTooltip.test.ts
@@ -51,10 +51,10 @@ describe("KsTooltip — default effect", () => {
         document.documentElement.classList.remove("dark")
     })
 
-    test("defaults to dark effect on light theme", () => {
+    test("defaults to light effect on light theme", () => {
         const wrapper = mount(KsTooltip, {global: globalConfigWithStub})
 
-        expect(wrapper.findComponent(ElTooltipStub).props("effect")).toBe("dark")
+        expect(wrapper.findComponent(ElTooltipStub).props("effect")).toBe("light")
     })
 
     test("defaults to light effect on dark theme", async () => {
@@ -65,8 +65,7 @@ describe("KsTooltip — default effect", () => {
         expect(wrapper.findComponent(ElTooltipStub).props("effect")).toBe("light")
     })
 
-    test("explicit effect prop overrides theme default", async () => {
-        document.documentElement.classList.add("dark")
+    test("explicit effect prop overrides default", async () => {
         const wrapper = mount(KsTooltip, {
             props: {effect: "dark"},
             global: globalConfigWithStub,


### PR DESCRIPTION
From

<img width="1076" height="756" alt="image" src="https://github.com/user-attachments/assets/6da3f9ec-9d36-4dd3-83d7-a8b72083aac2" />


To

<img width="1076" height="756" alt="image" src="https://github.com/user-attachments/assets/84381981-241e-4b88-96bf-d46708b482a7" />
