### PR TITLE
ci: push base image tag as latest-no-plugins and enable daily schedule

### DIFF
--- a/.github/workflows/global-push-base-image.yml
+++ b/.github/workflows/global-push-base-image.yml
@@ -34,6 +34,16 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/kestra-io/kestra-base
+          labels: |
+            org.opencontainers.image.title=kestra-base
+            org.opencontainers.image.description=Kestra base image (no plugins) — JRE + uv pre-installed
+            org.opencontainers.image.vendor=Kestra Technologies
+
       - name: Build and push
         uses: docker/build-push-action@v7
         with:
@@ -41,6 +51,7 @@ jobs:
           file: Dockerfile.base
           push: ${{ inputs.dry-run != true }}
           tags: ghcr.io/kestra-io/kestra-base:latest-no-plugins
+          labels: ${{ steps.meta.outputs.labels }}
           build-args: |
             UV_VERSION=${{ inputs.uv-version || '0.6.17' }}
           cache-from: type=registry,ref=ghcr.io/kestra-io/kestra-base:latest-no-plugins

--- a/.github/workflows/global-push-base-image.yml
+++ b/.github/workflows/global-push-base-image.yml
@@ -23,6 +23,9 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
 
@@ -53,6 +56,7 @@ jobs:
         with:
           context: .
           file: Dockerfile.base
+          platforms: linux/amd64,linux/arm64
           push: ${{ inputs.dry-run != true }}
           tags: ghcr.io/kestra-io/kestra-base:latest-no-plugins
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/global-push-base-image.yml
+++ b/.github/workflows/global-push-base-image.yml
@@ -43,7 +43,7 @@ jobs:
           tags: ghcr.io/kestra-io/kestra-base:latest-no-plugins
           build-args: |
             UV_VERSION=${{ inputs.uv-version || '0.6.17' }}
-          cache-from: type=registry,ref=kestra/kestra-base:latest
+          cache-from: type=registry,ref=ghcr.io/kestra-io/kestra-base:latest-no-plugins
           cache-to: type=inline
 
       - name: Slack - Notification

--- a/.github/workflows/global-push-base-image.yml
+++ b/.github/workflows/global-push-base-image.yml
@@ -1,8 +1,8 @@
 name: Build and Push Base Image
 
 on:
-#  schedule: FIXME enable once it's prod ready, disabled for now to try with dry run manually
-#    - cron: '0 2 * * *'
+  schedule:
+    - cron: '0 2 * * *'
   workflow_dispatch:
     inputs:
       uv-version:
@@ -40,7 +40,7 @@ jobs:
           context: .
           file: Dockerfile.base
           push: ${{ inputs.dry-run != true }}
-          tags: ghcr.io/kestra-io/kestra-base:latest
+          tags: ghcr.io/kestra-io/kestra-base:latest-no-plugins
           build-args: |
             UV_VERSION=${{ inputs.uv-version || '0.6.17' }}
           cache-from: type=registry,ref=kestra/kestra-base:latest

--- a/.github/workflows/global-push-base-image.yml
+++ b/.github/workflows/global-push-base-image.yml
@@ -43,6 +43,10 @@ jobs:
             org.opencontainers.image.title=kestra-base
             org.opencontainers.image.description=Kestra base image (no plugins) — JRE + uv pre-installed
             org.opencontainers.image.vendor=Kestra Technologies
+          annotations: |
+            org.opencontainers.image.title=kestra-base
+            org.opencontainers.image.description=Kestra base image (no plugins) — JRE + uv pre-installed
+            org.opencontainers.image.vendor=Kestra Technologies
 
       - name: Build and push
         uses: docker/build-push-action@v7
@@ -52,6 +56,7 @@ jobs:
           push: ${{ inputs.dry-run != true }}
           tags: ghcr.io/kestra-io/kestra-base:latest-no-plugins
           labels: ${{ steps.meta.outputs.labels }}
+          annotations: ${{ steps.meta.outputs.annotations }}
           build-args: |
             UV_VERSION=${{ inputs.uv-version || '0.6.17' }}
           cache-from: type=registry,ref=ghcr.io/kestra-io/kestra-base:latest-no-plugins


### PR DESCRIPTION
## Summary

- Rename the pushed Docker tag from `latest` to `latest-no-plugins` to clarify this is the base image without bundled plugins
- Uncomment and enable the daily cron schedule (`0 2 * * *`) — the workflow has been validated and is production-ready

## Test plan

- [ ] Trigger `workflow_dispatch` manually on this branch to verify the image pushes to `ghcr.io/kestra-io/kestra-base:latest-no-plugins`