### PR TITLE
fix(ui): extract MonacoEnvironment worker setup into a shared module

### DIFF
--- a/ui/src/main.ts
+++ b/ui/src/main.ts
@@ -1,28 +1,7 @@
 import {createApp} from "vue"
 import type {Router} from "vue-router"
 
-import EditorWorker from "monaco-editor/esm/vs/editor/editor.worker?worker"
-import JsonWorker from "monaco-editor/esm/vs/language/json/json.worker?worker"
-import TypeScriptWorker from "monaco-editor/esm/vs/language/typescript/ts.worker?worker"
-import YamlWorker from "./components/inputs/yaml.worker.js?worker"
-
-window.MonacoEnvironment = {
-    getWorker(_moduleId, label) {
-        switch (label) {
-        case "editorWorkerService":
-            return new EditorWorker()
-        case "yaml":
-            return new YamlWorker()
-        case "json":
-            return new JsonWorker()
-        case "javascript":
-        case "typescript":
-            return new TypeScriptWorker()
-        default:
-            throw new Error(`Unknown label ${label}`)
-        }
-    },
-}
+import "./utils/monacoEnvironment"
 
 const NodeTypesRaw = import.meta.glob("/node_modules/@types/node/**/*.d.ts", {eager: true, query: "?raw", import: "default"}) as Record<string, string>
 function loadNodeTypes(tries = 0) {

--- a/ui/src/utils/monacoEnvironment.ts
+++ b/ui/src/utils/monacoEnvironment.ts
@@ -1,0 +1,22 @@
+import EditorWorker from "monaco-editor/esm/vs/editor/editor.worker?worker"
+import JsonWorker from "monaco-editor/esm/vs/language/json/json.worker?worker"
+import TypeScriptWorker from "monaco-editor/esm/vs/language/typescript/ts.worker?worker"
+import YamlWorker from "../components/inputs/yaml.worker.js?worker"
+
+window.MonacoEnvironment = {
+    getWorker(_moduleId, label) {
+        switch (label) {
+        case "editorWorkerService":
+            return new EditorWorker()
+        case "yaml":
+            return new YamlWorker()
+        case "json":
+            return new JsonWorker()
+        case "javascript":
+        case "typescript":
+            return new TypeScriptWorker()
+        default:
+            throw new Error(`Unknown label ${label}`)
+        }
+    },
+}

--- a/ui/tests/unit/utils/monacoEnvironment.spec.ts
+++ b/ui/tests/unit/utils/monacoEnvironment.spec.ts
@@ -1,0 +1,8 @@
+import {describe, expect, it} from "vitest"
+import "../../../src/utils/monacoEnvironment"
+
+describe("monacoEnvironment", () => {
+    it("defines window.MonacoEnvironment.getWorker so Monaco can spawn web workers", () => {
+        expect(typeof window.MonacoEnvironment?.getWorker).toBe("function")
+    })
+})


### PR DESCRIPTION
- Extracted the Monaco init logic (`MonacoEnvironment` worker setup) from `main.ts` into a shared utility `ui/src/utils/monacoEnvironment.ts` so both the OSS and EE entrypoints can import it
- Companion EE PR: https://github.com/kestra-io/kestra-ee/pull/8222