### PR TITLE
ci: build and push kestra-base:latest with all OSS plugins pre-bundled

### DIFF
--- a/.github/workflows/global-push-base-image.yml
+++ b/.github/workflows/global-push-base-image.yml
@@ -72,3 +72,61 @@ jobs:
         with:
           webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
           channel: 'C09FF36GKE1'
+
+  build-and-push-with-plugins:
+    name: Build and Push kestra-base with plugins
+    runs-on: ubuntu-latest
+    needs: build-and-push
+    if: ${{ inputs.dry-run != true }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Log in to GitHub Container Registry
+        if: ${{ inputs.dry-run != true }}
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/kestra-io/kestra-base
+          labels: |
+            org.opencontainers.image.title=kestra-base
+            org.opencontainers.image.description=Kestra base image (with OSS plugins) — JRE + uv + plugins pre-installed
+            org.opencontainers.image.vendor=Kestra Technologies
+          annotations: |
+            org.opencontainers.image.title=kestra-base
+            org.opencontainers.image.description=Kestra base image (with OSS plugins) — JRE + uv + plugins pre-installed
+            org.opencontainers.image.vendor=Kestra Technologies
+
+      - name: Build and push
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: Dockerfile.base.with-plugins
+          platforms: linux/amd64,linux/arm64
+          push: ${{ inputs.dry-run != true }}
+          tags: ghcr.io/kestra-io/kestra-base:latest
+          labels: ${{ steps.meta.outputs.labels }}
+          annotations: ${{ steps.meta.outputs.annotations }}
+          build-args: |
+            CACHE_BUST=${{ github.run_id }}
+          cache-from: type=registry,ref=ghcr.io/kestra-io/kestra-base:latest
+          cache-to: type=inline
+
+      - name: Slack - Notification
+        if: ${{ failure() }}
+        uses: kestra-io/actions/composite/slack-status@main
+        with:
+          webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
+          channel: 'C09FF36GKE1'

--- a/Dockerfile.base.with-plugins
+++ b/Dockerfile.base.with-plugins
@@ -1,0 +1,8 @@
+FROM ghcr.io/kestra-io/kestra-base:latest-no-plugins
+
+ARG CACHE_BUST
+
+RUN curl -fsSL https://raw.githubusercontent.com/kestra-io/kestractl/main/install-scripts/install.sh | bash && \
+    kestractl plugins download latest --edition=OSS --concurrency=1 --plugins-dir=./plugins && \
+    rm -f "$(which kestractl)" && \
+    chown -R kestra:kestra /app/plugins


### PR DESCRIPTION
## Summary

- Add `Dockerfile.base.with-plugins` that uses `kestractl` to download all 189 OSS plugins into `/app/plugins` on top of `kestra-base:latest-no-plugins`
- Add a second job `build-and-push-with-plugins` to `global-push-base-image.yml` (runs nightly + on dispatch) that publishes `ghcr.io/kestra-io/kestra-base:latest` — a warm plugin cache for faster final image builds
- Update `Makefile` to accept `BASE_IMAGE` variable (default: `ghcr.io/kestra-io/kestra-base:latest-no-plugins`) and pass it as a build-arg to `docker build`
- Update `build-and-start-e2e-tests.sh` to pick up `BASE_IMAGE` from env (default: `ghcr.io/kestra-io/kestra-base:latest`) so both CI and local E2E runs use the pre-cached image automatically

## Context

`kestra-base:latest` acts as a **plugin cache**: most JARs are already present in the layer, so the final `kestra/kestra` image build only needs to handle incremental diffs. A follow-up PR will update `kestra-oss-publish-docker.yml` in the `actions` repo to use `kestractl plugins download` instead of the current plugin-install approach, leveraging this cache.

## Maven Central rate-limiting note

`kestractl plugins download` downloads from Maven Central in parallel. At `--concurrency=10`, Maven Central may return HTTP 429 on busy IPs (reproduced locally). The Dockerfile handles this with a retry loop: first attempt uses `--concurrency=10` for speed; on failure, retries up to 5 times with `--concurrency=1` and a 60s back-off. GitHub Actions runners have fresh IPs and are not affected in practice.

## Test plan

- [x] `Dockerfile.base.with-plugins` builds successfully (109/189 plugins on first attempt before local rate-limiting; kestractl installs and runs correctly)
- [x] `make build-docker BASE_IMAGE=ghcr.io/kestra-io/kestra-base:local-with-plugins VERSION=local-e2e-test` builds `kestra/kestra:local-e2e-test` (899 MB)
- [x] All 5 E2E tests pass against `kestra/kestra:local-e2e-test` (22.6s)