### PR TITLE
ci: multi-JRE base images and kestractl-based release builds (proposition2)

### DIFF
--- a/.github/workflows/global-push-base-image.yml
+++ b/.github/workflows/global-push-base-image.yml
@@ -24,10 +24,15 @@ jobs:
       matrix:
         jre:
           - version: "25"
-            tag: "latest-no-plugins"
+            tags: |
+              ghcr.io/kestra-io/kestra-base:latest-no-plugins
+              ghcr.io/kestra-io/kestra-base:latest-jre25-no-plugins
+            cache-tag: "latest-no-plugins"
             description: "Kestra base image (no plugins) — JRE 25 + uv pre-installed"
           - version: "21"
-            tag: "latest-jre21-no-plugins"
+            tags: |
+              ghcr.io/kestra-io/kestra-base:latest-jre21-no-plugins
+            cache-tag: "latest-jre21-no-plugins"
             description: "Kestra base image (no plugins) — JRE 21 + uv pre-installed"
     steps:
       - uses: actions/checkout@v6
@@ -67,13 +72,13 @@ jobs:
           file: Dockerfile.base
           platforms: linux/amd64,linux/arm64
           push: ${{ inputs.dry-run != true }}
-          tags: ghcr.io/kestra-io/kestra-base:${{ matrix.jre.tag }}
+          tags: ${{ matrix.jre.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           annotations: ${{ steps.meta.outputs.annotations }}
           build-args: |
             UV_VERSION=${{ inputs.uv-version || '0.6.17' }}
             JRE_VERSION=${{ matrix.jre.version }}
-          cache-from: type=registry,ref=ghcr.io/kestra-io/kestra-base:${{ matrix.jre.tag }}
+          cache-from: type=registry,ref=ghcr.io/kestra-io/kestra-base:${{ matrix.jre.cache-tag }}
           cache-to: type=inline
 
       - name: Slack - Notification
@@ -92,10 +97,15 @@ jobs:
       matrix:
         jre:
           - no-plugins-tag: "latest-no-plugins"
-            tag: "latest"
+            tags: |
+              ghcr.io/kestra-io/kestra-base:latest
+              ghcr.io/kestra-io/kestra-base:latest-jre25
+            cache-tag: "latest"
             description: "Kestra base image (with OSS plugins) — JRE 25 + uv + plugins pre-installed"
           - no-plugins-tag: "latest-jre21-no-plugins"
-            tag: "latest-jre21"
+            tags: |
+              ghcr.io/kestra-io/kestra-base:latest-jre21
+            cache-tag: "latest-jre21"
             description: "Kestra base image (with OSS plugins) — JRE 21 + uv + plugins pre-installed"
     steps:
       - uses: actions/checkout@v6
@@ -135,13 +145,13 @@ jobs:
           file: Dockerfile.base.with-plugins
           platforms: linux/amd64,linux/arm64
           push: ${{ inputs.dry-run != true }}
-          tags: ghcr.io/kestra-io/kestra-base:${{ matrix.jre.tag }}
+          tags: ${{ matrix.jre.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           annotations: ${{ steps.meta.outputs.annotations }}
           build-args: |
             CACHE_BUST=${{ github.run_id }}
             BASE_IMAGE=ghcr.io/kestra-io/kestra-base:${{ matrix.jre.no-plugins-tag }}
-          cache-from: type=registry,ref=ghcr.io/kestra-io/kestra-base:${{ matrix.jre.tag }}
+          cache-from: type=registry,ref=ghcr.io/kestra-io/kestra-base:${{ matrix.jre.cache-tag }}
           cache-to: type=inline
 
       - name: Slack - Notification

--- a/.github/workflows/global-push-base-image.yml
+++ b/.github/workflows/global-push-base-image.yml
@@ -18,8 +18,17 @@ on:
 
 jobs:
   build-and-push:
-    name: Build and Push kestra-base
+    name: Build and Push kestra-base (${{ matrix.jre.tag }})
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        jre:
+          - version: "25"
+            tag: "latest-no-plugins"
+            description: "Kestra base image (no plugins) — JRE 25 + uv pre-installed"
+          - version: "21"
+            tag: "latest-jre21-no-plugins"
+            description: "Kestra base image (no plugins) — JRE 21 + uv pre-installed"
     steps:
       - uses: actions/checkout@v6
 
@@ -44,11 +53,11 @@ jobs:
           images: ghcr.io/kestra-io/kestra-base
           labels: |
             org.opencontainers.image.title=kestra-base
-            org.opencontainers.image.description=Kestra base image (no plugins) — JRE + uv pre-installed
+            org.opencontainers.image.description=${{ matrix.jre.description }}
             org.opencontainers.image.vendor=Kestra Technologies
           annotations: |
             org.opencontainers.image.title=kestra-base
-            org.opencontainers.image.description=Kestra base image (no plugins) — JRE + uv pre-installed
+            org.opencontainers.image.description=${{ matrix.jre.description }}
             org.opencontainers.image.vendor=Kestra Technologies
 
       - name: Build and push
@@ -58,12 +67,13 @@ jobs:
           file: Dockerfile.base
           platforms: linux/amd64,linux/arm64
           push: ${{ inputs.dry-run != true }}
-          tags: ghcr.io/kestra-io/kestra-base:latest-no-plugins
+          tags: ghcr.io/kestra-io/kestra-base:${{ matrix.jre.tag }}
           labels: ${{ steps.meta.outputs.labels }}
           annotations: ${{ steps.meta.outputs.annotations }}
           build-args: |
             UV_VERSION=${{ inputs.uv-version || '0.6.17' }}
-          cache-from: type=registry,ref=ghcr.io/kestra-io/kestra-base:latest-no-plugins
+            JRE_VERSION=${{ matrix.jre.version }}
+          cache-from: type=registry,ref=ghcr.io/kestra-io/kestra-base:${{ matrix.jre.tag }}
           cache-to: type=inline
 
       - name: Slack - Notification
@@ -74,10 +84,19 @@ jobs:
           channel: 'C09FF36GKE1'
 
   build-and-push-with-plugins:
-    name: Build and Push kestra-base with plugins
+    name: Build and Push kestra-base with plugins (${{ matrix.jre.tag }})
     runs-on: ubuntu-latest
     needs: build-and-push
     if: ${{ inputs.dry-run != true }}
+    strategy:
+      matrix:
+        jre:
+          - no-plugins-tag: "latest-no-plugins"
+            tag: "latest"
+            description: "Kestra base image (with OSS plugins) — JRE 25 + uv + plugins pre-installed"
+          - no-plugins-tag: "latest-jre21-no-plugins"
+            tag: "latest-jre21"
+            description: "Kestra base image (with OSS plugins) — JRE 21 + uv + plugins pre-installed"
     steps:
       - uses: actions/checkout@v6
 
@@ -102,11 +121,11 @@ jobs:
           images: ghcr.io/kestra-io/kestra-base
           labels: |
             org.opencontainers.image.title=kestra-base
-            org.opencontainers.image.description=Kestra base image (with OSS plugins) — JRE + uv + plugins pre-installed
+            org.opencontainers.image.description=${{ matrix.jre.description }}
             org.opencontainers.image.vendor=Kestra Technologies
           annotations: |
             org.opencontainers.image.title=kestra-base
-            org.opencontainers.image.description=Kestra base image (with OSS plugins) — JRE + uv + plugins pre-installed
+            org.opencontainers.image.description=${{ matrix.jre.description }}
             org.opencontainers.image.vendor=Kestra Technologies
 
       - name: Build and push
@@ -116,12 +135,13 @@ jobs:
           file: Dockerfile.base.with-plugins
           platforms: linux/amd64,linux/arm64
           push: ${{ inputs.dry-run != true }}
-          tags: ghcr.io/kestra-io/kestra-base:latest
+          tags: ghcr.io/kestra-io/kestra-base:${{ matrix.jre.tag }}
           labels: ${{ steps.meta.outputs.labels }}
           annotations: ${{ steps.meta.outputs.annotations }}
           build-args: |
             CACHE_BUST=${{ github.run_id }}
-          cache-from: type=registry,ref=ghcr.io/kestra-io/kestra-base:latest
+            BASE_IMAGE=ghcr.io/kestra-io/kestra-base:${{ matrix.jre.no-plugins-tag }}
+          cache-from: type=registry,ref=ghcr.io/kestra-io/kestra-base:${{ matrix.jre.tag }}
           cache-to: type=inline
 
       - name: Slack - Notification

--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -34,6 +34,7 @@ jobs:
       retag-lts: ${{ inputs.retag-lts }}
       dry-run: ${{ inputs.dry-run }}
       java-version: ${{ inputs.java-version }}
+      use-kestractl: true
     secrets: inherit
 
   helm-release:

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@ ARG BASE_IMAGE="ghcr.io/kestra-io/kestra-base:latest-no-plugins"
 FROM ${BASE_IMAGE}
 
 ARG KESTRA_PLUGINS=""
+ARG KESTRA_VERSION=""
 ARG APT_PACKAGES=""
 ARG PYTHON_LIBRARIES=""
 
@@ -15,7 +16,13 @@ RUN if [ -n "${APT_PACKAGES}" ]; then \
         apt-get clean && \
         rm -rf /var/lib/apt/lists/*; \
     fi && \
-    if [ -n "${KESTRA_PLUGINS}" ]; then /app/kestra plugins install ${KESTRA_PLUGINS} && rm -rf /tmp/*; fi && \
+    if [ -n "${KESTRA_VERSION}" ]; then \
+        curl -fsSL https://raw.githubusercontent.com/kestra-io/kestractl/main/install-scripts/install.sh | bash && \
+        kestractl plugins download "${KESTRA_VERSION}" --edition=OSS --concurrency=4 --plugins-dir=/app/plugins && \
+        rm -f "$(which kestractl)"; \
+    elif [ -n "${KESTRA_PLUGINS}" ]; then \
+        /app/kestra plugins install ${KESTRA_PLUGINS} && rm -rf /tmp/*; \
+    fi && \
     if [ -n "${PYTHON_LIBRARIES}" ]; then uv venv /app/.venv && uv pip install --python /app/.venv/bin/python ${PYTHON_LIBRARIES}; fi && \
     chown -R kestra:kestra /app
 

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -1,4 +1,5 @@
-FROM eclipse-temurin:25-jre
+ARG JRE_VERSION="25"
+FROM eclipse-temurin:${JRE_VERSION}-jre
 
 ARG UV_VERSION="0.6.17"
 

--- a/Dockerfile.base.with-plugins
+++ b/Dockerfile.base.with-plugins
@@ -1,4 +1,5 @@
-FROM ghcr.io/kestra-io/kestra-base:latest-no-plugins
+ARG BASE_IMAGE="ghcr.io/kestra-io/kestra-base:latest-no-plugins"
+FROM ${BASE_IMAGE}
 
 ARG CACHE_BUST
 


### PR DESCRIPTION
## Summary

- **`Dockerfile.base`** — adds `ARG JRE_VERSION="25"` so a single file produces both JRE 25 and JRE 21 base image variants via a CI matrix
- **`Dockerfile.base.with-plugins`** — adds `ARG BASE_IMAGE` so it can build on top of either no-plugins variant (JRE 25 or JRE 21)
- **`global-push-base-image.yml`** — replaces two single jobs with a 2-level matrix producing four nightly images:
  - `kestra-base:latest-no-plugins` + `kestra-base:latest-jre25-no-plugins` (JRE 25, no plugins)
  - `kestra-base:latest-jre21-no-plugins` (JRE 21, no plugins)
  - `kestra-base:latest` + `kestra-base:latest-jre25` (JRE 25 + all OSS plugins)
  - `kestra-base:latest-jre21` (JRE 21 + all OSS plugins)
- **`Dockerfile`** — adds `ARG KESTRA_VERSION`; when set, installs kestractl and runs `kestractl plugins download <version> --edition=OSS --concurrency=4`, skipping JARs already present in `/app/plugins` from the base layer. The old `KESTRA_PLUGINS` path is kept as fallback.
- **`release-docker.yml`** — passes `use-kestractl: true` to the actions workflow so new releases use the kestractl path

## Merge order

> ⚠️ **Merge the `actions` PR first** (`feat/proposition2-kestractl` in `kestra-io/actions`). `release-docker.yml` passes `use-kestractl: true` which is a new input — if `actions@main` doesn't know about it yet, the workflow call will fail.

1. Merge `kestra-io/actions` PR (`feat/proposition2-kestractl`)
2. Merge this PR

## Backward compatibility

Old release branches (v0.22–v1.3) calling `actions@main` without `use-kestractl` continue to work unchanged — the input defaults to `false`, preserving the existing `kestra plugins install` path.

## Test plan

- [ ] Dry-run `global-push-base-image.yml` — verify all 4 matrix jobs complete without error
- [ ] Confirm 4 image tags are pushed: `latest-no-plugins`, `latest-jre25-no-plugins`, `latest-jre21-no-plugins`, `latest-jre21`, `latest`, `latest-jre25`
- [ ] Trigger a dry-run of `release-docker.yml` on a release tag — verify `use-kestractl: true` is forwarded correctly