### PR TITLE
fix: filter worker groups by id with a working search bar

### DIFF
--- a/core/src/main/java/io/kestra/core/models/QueryFilter.java
+++ b/core/src/main/java/io/kestra/core/models/QueryFilter.java
@@ -436,12 +436,6 @@ public record QueryFilter(
             public List<Op> supportedOp() {
                 return List.of(Op.IN, Op.NOT_IN);
             }
-        },
-        KEY("key") {
-            @Override
-            public List<Op> supportedOp() {
-                return List.of(Op.EQUALS, Op.IN, Op.NOT_IN);
-            }
         };
 
         private static final Map<String, Field> BY_VALUE = Arrays.stream(values())
@@ -702,7 +696,7 @@ public record QueryFilter(
         WORKER_GROUP {
             @Override
             public List<Field> supportedField() {
-                return List.of(Field.KEY);
+                return List.of(Field.QUERY, Field.ID);
             }
         },
         BANNER {

--- a/core/src/test/java/io/kestra/core/models/QueryFilterTest.java
+++ b/core/src/test/java/io/kestra/core/models/QueryFilterTest.java
@@ -342,11 +342,24 @@ public class QueryFilterTest {
             ),
 
             buildQueryFiltersForOperations(
-                Field.KEY, Resource.WORKER_GROUP,
+                Field.ID, Resource.WORKER_GROUP,
                 Set.of(
                     Op.EQUALS,
+                    Op.NOT_EQUALS,
+                    Op.CONTAINS,
+                    Op.STARTS_WITH,
+                    Op.ENDS_WITH,
+                    Op.REGEX,
                     Op.IN,
                     Op.NOT_IN
+                )
+            ),
+
+            buildQueryFiltersForOperations(
+                Field.QUERY, Resource.WORKER_GROUP,
+                Set.of(
+                    Op.EQUALS,
+                    Op.NOT_EQUALS
                 )
             ),
 

--- a/jdbc/src/main/java/io/kestra/jdbc/repository/AbstractJdbcRepository.java
+++ b/jdbc/src/main/java/io/kestra/jdbc/repository/AbstractJdbcRepository.java
@@ -403,10 +403,6 @@ public abstract class AbstractJdbcRepository {
             return timeRangeCondition(value, operation);
         }
 
-        if (field == QueryFilter.Field.KEY) {
-            return keyCondition(value, operation);
-        }
-
         return defaultHandlers(field, value, operation);
     }
 
@@ -545,10 +541,6 @@ public abstract class AbstractJdbcRepository {
 
     protected Condition timeRangeCondition(Object value, QueryFilter.Op operation) {
         throw new InvalidQueryFiltersException("Unsupported field: TIME_RANGE");
-    }
-
-    protected Condition keyCondition(Object value, QueryFilter.Op operation) {
-        return defaultHandlers(QueryFilter.Field.KEY, value, operation);
     }
 
     protected Condition createdCondition(Object value, QueryFilter.Op operation, @Nullable String dateColumn) {


### PR DESCRIPTION
### ✨ Description

Fixes worker group filtering by consistently using **ID** terminology across the UI and API, and restores search bar functionality.

#### Naming Cleanup

Worker groups are identified by their **ID**, but parts of the filtering stack still referred to this field as a **key**.

Changes:

* Renamed the filter chip from **Worker Group Key** to **Worker Group ID**.
* Updated the `WORKER_GROUP` `QueryFilter` resource to support:

  * `ID` (used by the filter chip)
  * `QUERY` (used by the search bar)
* Removed the worker-group-specific `KEY` filter field.
* Removed the associated unused JDBC base hooks for `KEY`.

#### Search Bar Fix

The design-system search component always emits:

```text
filters[q][EQUALS]
```

However, `WORKER_GROUP` did not support the `QUERY` filter, causing searches to fail.

`WORKER_GROUP` now supports `QUERY`, implemented as a contains-on-ID search in both backends:

* **JDBC**: implemented via `findQueryCondition()` using a case-insensitive contains match on the underlying key column.
* **Elasticsearch**: translates the query into an ID `CONTAINS` filter using a `*value*` wildcard.

This aligns search behavior across both storage backends.

#### Columns Option

Worker groups use a custom card-based UI rather than `KsDataTable`, so the **Columns** table option is not applicable.
The option is now hidden.