### PR TITLE
fix(ui): correct Save Filter dialog label translation

### DIFF
--- a/ui/packages/design-system/src/components/Data/KsDataTable/filter/segments/SaveFilters.vue
+++ b/ui/packages/design-system/src/components/Data/KsDataTable/filter/segments/SaveFilters.vue
@@ -24,7 +24,7 @@
                 </template>
             </KsAlert>
             <div>
-                <label>{{ $t("filter.name") }}</label>
+                <label>{{ $t("filter.name.label") }}</label>
                 <KsInput
                     v-model="filterName"
                     :placeholder="$t('filter.enter name')"


### PR DESCRIPTION
### ✨ Description

Fixes a missing translation in the “Save filter” dialog where the label was displayed as `filter.name` instead of a human-readable translated string.

### 🔗 Related Issue

Closes https://github.com/kestra-io/kestra/issues/16435

### 🎨 Frontend Checklist

- [x] Code builds without errors (`npm run build`)
- [ ] All existing E2E tests pass (`npm run test:e2e`)
- [x] Screenshots or video recordings attached showing the `UI` changes

### 📝 Additional Notes

Screenshot:
<img width="487" height="358" alt="image" src="https://github.com/user-attachments/assets/fbe65a50-1cfe-4556-9986-53b75a21e60d" />

