### PR TITLE
fix(ui): update execution status styles and replace restart icon with…

### DIFF
--- a/ui/packages/design-system/src/assets/styles/ks-tokens.scss
+++ b/ui/packages/design-system/src/assets/styles/ks-tokens.scss
@@ -114,21 +114,21 @@
     --ks-status-border-skipped: color-mix(in srgb, var(--ks-status-skipped), var(--ks-bg-base) 80%);
     --ks-status-border-queued: color-mix(in srgb, var(--ks-status-queued), var(--ks-bg-base) 80%);
 
-    --ks-status-background-created: color-mix(in srgb, var(--ks-status-created), var(--ks-bg-base) 95%);
-    --ks-status-background-restarted: color-mix(in srgb, var(--ks-status-restarted), var(--ks-bg-base) 95%);
-    --ks-status-background-retried: color-mix(in srgb, var(--ks-status-retried), var(--ks-bg-base) 95%);
-    --ks-status-background-failed: color-mix(in srgb, var(--ks-status-failed), var(--ks-bg-base) 95%);
-    --ks-status-background-killed: color-mix(in srgb, var(--ks-status-killed), var(--ks-bg-base) 95%);
-    --ks-status-background-success: color-mix(in srgb, var(--ks-status-success), var(--ks-bg-base) 95%);
-    --ks-status-background-running: color-mix(in srgb, var(--ks-status-running), var(--ks-bg-base) 95%);
-    --ks-status-background-breakpoint: color-mix(in srgb, var(--ks-status-breakpoint), var(--ks-bg-base) 95%);
-    --ks-status-background-paused: color-mix(in srgb, var(--ks-status-paused), var(--ks-bg-base) 95%);
-    --ks-status-background-warning: color-mix(in srgb, var(--ks-status-warning), var(--ks-bg-base) 95%);
-    --ks-status-background-retrying: color-mix(in srgb, var(--ks-status-retrying), var(--ks-bg-base) 95%);
-    --ks-status-background-killing: color-mix(in srgb, var(--ks-status-killing), var(--ks-bg-base) 95%);
-    --ks-status-background-cancelled: color-mix(in srgb, var(--ks-status-cancelled), var(--ks-bg-base) 95%);
-    --ks-status-background-skipped: color-mix(in srgb, var(--ks-status-skipped), var(--ks-bg-base) 95%);
-    --ks-status-background-queued: color-mix(in srgb, var(--ks-status-queued), var(--ks-bg-base) 95%);
+    --ks-status-background-created: color-mix(in srgb, var(--ks-status-created), var(--ks-bg-badge) 90%);
+    --ks-status-background-restarted: color-mix(in srgb, var(--ks-status-restarted), var(--ks-bg-badge) 90%);
+    --ks-status-background-retried: color-mix(in srgb, var(--ks-status-retried), var(--ks-bg-badge) 90%);
+    --ks-status-background-failed: color-mix(in srgb, var(--ks-status-failed), var(--ks-bg-badge) 90%);
+    --ks-status-background-killed: color-mix(in srgb, var(--ks-status-killed), var(--ks-bg-badge) 90%);
+    --ks-status-background-success: color-mix(in srgb, var(--ks-status-success), var(--ks-bg-badge) 90%);
+    --ks-status-background-running: color-mix(in srgb, var(--ks-status-running), var(--ks-bg-badge) 90%);
+    --ks-status-background-breakpoint: color-mix(in srgb, var(--ks-status-breakpoint), var(--ks-bg-badge) 90%);
+    --ks-status-background-paused: color-mix(in srgb, var(--ks-status-paused), var(--ks-bg-badge) 90%);
+    --ks-status-background-warning: color-mix(in srgb, var(--ks-status-warning), var(--ks-bg-badge) 90%);
+    --ks-status-background-retrying: color-mix(in srgb, var(--ks-status-retrying), var(--ks-bg-badge) 90%);
+    --ks-status-background-killing: color-mix(in srgb, var(--ks-status-killing), var(--ks-bg-badge) 90%);
+    --ks-status-background-cancelled: color-mix(in srgb, var(--ks-status-cancelled), var(--ks-bg-badge) 90%);
+    --ks-status-background-skipped: color-mix(in srgb, var(--ks-status-skipped), var(--ks-bg-badge) 90%);
+    --ks-status-background-queued: color-mix(in srgb, var(--ks-status-queued), var(--ks-bg-badge) 90%);
 
     // logs
     --ks-log-trace: var(--ks-status-neutral);

--- a/ui/packages/design-system/src/components/Data/KsExecutionStatus/KsExecutionStatus.vue
+++ b/ui/packages/design-system/src/components/Data/KsExecutionStatus/KsExecutionStatus.vue
@@ -72,8 +72,8 @@ $statusList: created, restarted, success, running, killing, killed, warning, fai
     user-select: none;
     vertical-align: middle;
     appearance: none;
-    border: 1px solid var(--ks-border-default);
-    border-radius: 100px;
+    border: none;
+    border-radius: var(--ks-radius-sm);
     background: var(--ks-bg-badge);
     font-family: inherit;
     height: 2rem;
@@ -105,7 +105,7 @@ $statusList: created, restarted, success, running, killing, killed, warning, fai
 
     &.ks-execution-status--small {
         height: 1.5rem;
-        padding: 0.3125rem 0.6875rem;
+        padding: 0 var(--ks-spacing-2);
         font-size: var(--ks-font-size-xs);
         gap: 0.25rem;
     }
@@ -114,7 +114,6 @@ $statusList: created, restarted, success, running, killing, killed, warning, fai
 @each $status in $statusList {
     .ks-execution-status--#{$status} {
         color: var(--ks-status-#{$status});
-        border-color: var(--ks-status-#{$status});
         background-color: var(--ks-status-background-#{$status});
     }
 }

--- a/ui/packages/design-system/src/components/Data/KsExecutionStatus/types.ts
+++ b/ui/packages/design-system/src/components/Data/KsExecutionStatus/types.ts
@@ -13,7 +13,7 @@ import Restore from "vue-material-design-icons/Restore.vue"
 import Cancel from "vue-material-design-icons/Cancel.vue"
 import SkipNextCircleOutline from "vue-material-design-icons/SkipNextCircleOutline.vue"
 import ClockTimeFourOutline from "vue-material-design-icons/ClockTimeFourOutline.vue"
-import Restart from "vue-material-design-icons/Restart.vue"
+import RestartAlert from "vue-material-design-icons/RestartAlert.vue"
 
 export interface ExecutionStatusModel {
     name: string;
@@ -110,7 +110,7 @@ export const EXECUTION_STATUSES: Record<string, ExecutionStatusModel> = Object.f
     },
     RETRYING: {
         name: "RETRYING",
-        icon: Restart,
+        icon: RestartAlert,
         isRunning: false,
         isKillable: true,
         isFailed: false,


### PR DESCRIPTION
**Visual and style updates:**

* Changed the background color mix for all status badges to use `--ks-bg-badge` at 90% instead of `--ks-bg-base` at 95%. (`ks-tokens.scss`)
* Removed borders from execution status badges, set border radius to `var(--ks-radius-sm)` instead of a fixed value, and adjusted padding for small badges. (`KsExecutionStatus.vue`) [[1]](diffhunk://#diff-b9355595c3ebb6b76bcd74260f8732c471d1bc41da7543b9b27f675e6606bebdL75-R76) [[2]](diffhunk://#diff-b9355595c3ebb6b76bcd74260f8732c471d1bc41da7543b9b27f675e6606bebdL108-R108)
* Removed the use of status-specific border colors on badges, relying solely on background color and text color for status indication. (`KsExecutionStatus.vue`)

**Icon updates:**

* Updated the icon for the "RETRYING" execution status from `Restart` to `RestartAlert`. (`types.ts`) [[1]](diffhunk://#diff-b7deb444758a2125ee37a5b1c5a55f94ca5289fcea4771c3500622966c46c9a7L16-R16) [[2]](diffhunk://#diff-b7deb444758a2125ee37a5b1c5a55f94ca5289fcea4771c3500622966c46c9a7L113-R113)

closes https://github.com/kestra-io/kestra-ee/issues/8226