### PR TITLE
fix(ui): only use large notification style when there are errors to display

### DIFF
--- a/ui/src/components/ErrorToast.vue
+++ b/ui/src/components/ErrorToast.vue
@@ -84,6 +84,10 @@
         return Array.isArray(messages) ? messages : [messages]
     })
 
+    const isLargeNotification = computed(() => {
+        return items.value.length > 0 || (props.message.content?.message?.length ?? 0) > 100
+    })
+
     watch(route, () => {
         close()
     })
@@ -127,7 +131,7 @@
             type: props.message.variant || "error",
             duration: 0,
             dangerouslyUseHTMLString: true,
-            customClass: "error-notification kel-notification__large",
+            customClass: isLargeNotification.value ? "error-notification kel-notification__large" : "error-notification",
         })
     })
 </script>


### PR DESCRIPTION
Closes https://github.com/kestra-io/kestra-ee/issues/8074.

## Summary
- The error notification toast was always using `kel-notification__large` CSS class, making it oversized even for short error messages (e.g. a simple "Error" title with no body content)
- Now `kel-notification__large` is only applied when there are embedded error items or the error message is longer than 100 characters

## Test plan
- [ ] Trigger a short error (e.g. click Export CSV on Audit Logs without permission) — toast should appear in compact size
- [ ] Trigger an error with multiple validation items — toast should still appear in large size