### PR TITLE
fix(design-system): pin Logs pager to bottom across pages of differing heights

### DIFF
--- a/ui/packages/design-system/src/components/Data/KsDataTable/KsDataTable.vue
+++ b/ui/packages/design-system/src/components/Data/KsDataTable/KsDataTable.vue
@@ -126,6 +126,7 @@
         "selection-change": [selection: any[]]
         "row-dblclick": [row: any, column: any, event: Event]
         "ready": []
+        "loaded": []
     }>()
 
     defineSlots<{
@@ -299,6 +300,8 @@
                 isReady.value = true
                 emit("ready")
             }
+            await nextTick()
+            emit("loaded")
         }
     }
 

--- a/ui/packages/design-system/tests/units/Data/KsDataTable.test.ts
+++ b/ui/packages/design-system/tests/units/Data/KsDataTable.test.ts
@@ -273,6 +273,21 @@ describe("KsDataTable", () => {
         expect(loadCallCount).toBe(2)
     })
 
+    test("emits loaded after every load, not only the first", async () => {
+        const wrapper = mount(KsDataTable, {
+            props: {data: SAMPLE_DATA, total: 100, pageSize: 25, currentPage: 1, loadData: async () => {}},
+            global: globalConfig,
+        })
+        await new Promise<void>((resolve) => setTimeout(resolve, 0))
+        expect(wrapper.emitted("loaded")).toHaveLength(1)
+        expect(wrapper.emitted("ready")).toHaveLength(1)
+
+        await wrapper.setProps({currentPage: 2})
+        await new Promise<void>((resolve) => setTimeout(resolve, 0))
+        expect(wrapper.emitted("loaded")).toHaveLength(2)
+        expect(wrapper.emitted("ready")).toHaveLength(1)
+    })
+
     type Load = {page: number; size: number; sort?: string}
     const tick = () => new Promise<void>((resolve) => setTimeout(resolve, 0))
     const lastLoad = (loads: Load[]): Load => loads[loads.length - 1]

--- a/ui/src/components/logs/LogsWrapper.vue
+++ b/ui/src/components/logs/LogsWrapper.vue
@@ -8,6 +8,7 @@
                 :currentPage="urlPage"
                 :pageSize="urlSize"
                 @ready="ready = true"
+                @loaded="onLoaded"
                 @page-changed="onPageChanged"
                 :total="logsStore.total"
             >
@@ -282,8 +283,21 @@
     const urlPage = computed(() => Number(route.query[pageKey]) || 1)
     const urlSize = computed(() => Number(route.query[sizeKey]) || 25)
 
+    const pinToBottom = ref(false)
+
     const onPageChanged = ({page, size}: {page: number; size: number}) => {
+        pinToBottom.value = !props.embed
         router.push({query: {...route.query, [pageKey]: String(page), [sizeKey]: String(size)}})
+    }
+
+    const onLoaded = () => {
+        if (!pinToBottom.value) return
+        pinToBottom.value = false
+        const main = document.querySelector("main")
+        if (!main) return
+        requestAnimationFrame(() => {
+            main.scrollTop = main.scrollHeight
+        })
     }
 
     const filterQueryKey = computed(() => {


### PR DESCRIPTION
## What

On the Logs list, clicking the pager repeatedly kept you pinned to the bottom *most* of the time, but the viewport drifted up by ~50px when crossing pages of different total heights (e.g. a page with a taller multi-line log row).

Pagination is in-app (`router.push`, no reload), so `main.scrollTop` was preserved in pixels across the page change. Going to a shorter page clamps `scrollTop` down; returning to a taller page then leaves the viewport above the bottom where the pager sits.

## How

- **`KsDataTable`** now emits a generic `loaded` event after *every* load (the existing `ready` only fires on the first). The component stays generic and never touches the app shell.
- **`LogsWrapper`** reacts to `loaded`: on a pager click it re-scrolls the shell `<main>` to the bottom on the next animation frame (so the new rows have been laid out first — a synchronous scroll races the row growth and lands ~126px short). Only the page knows its scroll container is `<main>`; the DS component does not reach into `document.querySelector('main')`. Guarded with `!props.embed` so embedded log panels are unaffected.

## Testing

- Unit: added a `KsDataTable` test asserting `loaded` fires on every load, `ready` only once. 37/37 pass, type-check and lint clean.
- Browser QA on local dev (8 pages, varying row heights): every next/prev transition lands at the bottom (gap 0), including the taller-page cases that previously drifted; a fresh page load still lands at the top; no console errors.

Closes https://github.com/kestra-io/kestra-ee/issues/8010

🤖 Generated with [Claude Code](https://claude.com/claude-code)