### PR TITLE
fix(build): restore linux/arm64 for kestra-base:latest-no-plugins

### DIFF
--- a/.github/workflows/global-push-base-image.yml
+++ b/.github/workflows/global-push-base-image.yml
@@ -34,6 +34,9 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
 
@@ -64,7 +67,7 @@ jobs:
         with:
           context: .
           file: Dockerfile.base
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
           push: ${{ inputs.dry-run != true }}
           tags: ghcr.io/kestra-io/kestra-base:latest-no-plugins
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
## Summary

- Adds `docker/setup-qemu-action@v3` to the base image build job
- Restores `linux/arm64` to the `platforms` list for `kestra-base:latest-no-plugins`

`linux/arm64` was dropped in commit `66fdff877` after QEMU timed out on the eclipse-temurin pull. The release Docker CI builds both `linux/amd64,linux/arm64` using `kestra-base:latest-no-plugins` as the base, so a missing arm64 manifest causes an immediate failure ("no match for platform in manifest").

The `Dockerfile.base` only installs `curl` and `uv` on top of `eclipse-temurin:25-jre` (all thin layers over a pre-built multi-arch image), so QEMU handles it reliably here.

## Test plan

- [ ] Merge and manually trigger "Build and Push Base Image" workflow
- [ ] Verify `docker manifest inspect ghcr.io/kestra-io/kestra-base:latest-no-plugins` shows both `linux/amd64` and `linux/arm64`
- [ ] Re-run the failing CI job to confirm it passes