### PR TITLE
feat: add full-text query (q) filter to banner and service instance

### DIFF
--- a/core/src/main/java/io/kestra/core/models/QueryFilter.java
+++ b/core/src/main/java/io/kestra/core/models/QueryFilter.java
@@ -678,7 +678,7 @@ public record QueryFilter(
         SERVICE_INSTANCE {
             @Override
             public List<Field> supportedField() {
-                return List.of(Field.STATE, Field.TYPE, Field.CREATED);
+                return List.of(Field.QUERY, Field.STATE, Field.TYPE, Field.CREATED);
             }
         },
         TENANT {
@@ -702,7 +702,7 @@ public record QueryFilter(
         BANNER {
             @Override
             public List<Field> supportedField() {
-                return List.of(Field.TYPE);
+                return List.of(Field.QUERY, Field.TYPE);
             }
         };
 

--- a/core/src/test/java/io/kestra/core/models/QueryFilterTest.java
+++ b/core/src/test/java/io/kestra/core/models/QueryFilterTest.java
@@ -364,6 +364,22 @@ public class QueryFilterTest {
             ),
 
             buildQueryFiltersForOperations(
+                Field.QUERY, Resource.BANNER,
+                Set.of(
+                    Op.EQUALS,
+                    Op.NOT_EQUALS
+                )
+            ),
+
+            buildQueryFiltersForOperations(
+                Field.QUERY, Resource.SERVICE_INSTANCE,
+                Set.of(
+                    Op.EQUALS,
+                    Op.NOT_EQUALS
+                )
+            ),
+
+            buildQueryFiltersForOperations(
                 Field.TYPE, Resource.BANNER,
                 Set.of(
                     Op.EQUALS,

--- a/core/src/test/java/io/kestra/core/repositories/AbstractServiceInstanceRepositoryTest.java
+++ b/core/src/test/java/io/kestra/core/repositories/AbstractServiceInstanceRepositoryTest.java
@@ -163,6 +163,55 @@ public abstract class AbstractServiceInstanceRepositoryTest {
                     .value(Instant.now().minusSeconds(60).toString())
                     .build()
             )
+            .build(),
+
+        FilterTestCase.builder()
+            .instances(List.of(runningInstance, schedulerInstance))
+            .expectedInstances(List.of(runningInstance))
+            .filter(
+                QueryFilter.builder()
+                    .field(QueryFilter.Field.QUERY)
+                    .operation(QueryFilter.Op.EQUALS)
+                    .value(runningInstance.uid())
+                    .build()
+            )
+            .build(),
+
+        FilterTestCase.builder()
+            .instances(List.of(runningInstance, schedulerInstance))
+            .expectedInstances(List.of(schedulerInstance))
+            .filter(
+                QueryFilter.builder()
+                    .field(QueryFilter.Field.QUERY)
+                    .operation(QueryFilter.Op.EQUALS)
+                    .value("scheduler")
+                    .build()
+            )
+            .build(),
+
+        FilterTestCase.builder()
+            .instances(List.of(runningInstance, schedulerInstance))
+            .expectedInstances(List.of(runningInstance))
+            .filter(
+                QueryFilter.builder()
+                    .field(QueryFilter.Field.QUERY)
+                    .operation(QueryFilter.Op.NOT_EQUALS)
+                    .value("scheduler")
+                    .build()
+            )
+            .build(),
+
+        // QUERY matches on the server hostname (all fixtures run on "localhost")
+        FilterTestCase.builder()
+            .instances(List.of(runningInstance, schedulerInstance))
+            .expectedInstances(List.of(runningInstance, schedulerInstance))
+            .filter(
+                QueryFilter.builder()
+                    .field(QueryFilter.Field.QUERY)
+                    .operation(QueryFilter.Op.EQUALS)
+                    .value("localhost")
+                    .build()
+            )
             .build()
     );
 

--- a/jdbc-h2/src/main/java/io/kestra/repository/h2/H2ServiceInstanceRepository.java
+++ b/jdbc-h2/src/main/java/io/kestra/repository/h2/H2ServiceInstanceRepository.java
@@ -1,5 +1,9 @@
 package io.kestra.repository.h2;
 
+import java.util.List;
+
+import org.jooq.Condition;
+
 import io.kestra.core.repositories.RepositoryBean;
 import io.kestra.core.server.ServiceInstance;
 import io.kestra.jdbc.repository.AbstractJdbcServiceInstanceRepository;
@@ -13,5 +17,10 @@ public class H2ServiceInstanceRepository extends AbstractJdbcServiceInstanceRepo
     @Inject
     public H2ServiceInstanceRepository(@Named("serviceinstance") H2Repository<ServiceInstance> repository) {
         super(repository);
+    }
+
+    @Override
+    protected Condition findQueryCondition(String query) {
+        return jdbcRepository.fullTextCondition(List.of("fulltext"), query);
     }
 }

--- a/jdbc-h2/src/main/java/io/kestra/repository/h2/migration/V2_0_10ServiceInstanceFulltextMigration.java
+++ b/jdbc-h2/src/main/java/io/kestra/repository/h2/migration/V2_0_10ServiceInstanceFulltextMigration.java
@@ -1,0 +1,49 @@
+package io.kestra.repository.h2.migration;
+
+import javax.sql.DataSource;
+
+import io.kestra.core.migration.MigrationScript;
+import io.kestra.jdbc.migration.AbstractSQLMigrationScript;
+
+import io.micronaut.context.annotation.Requires;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+
+/**
+ * OSS H2 migration: adds a generated {@code fulltext} column to {@code service_instance} for the
+ * query (free-text) filter, mirroring the full-text pattern of the other repositories.
+ */
+@Singleton
+@Requires(property = "kestra.repository.type", pattern = "h2|memory")
+public class V2_0_10ServiceInstanceFulltextMigration extends AbstractSQLMigrationScript {
+
+    private static final String SCRIPT_ID = "2.0.10-service-instance-fulltext";
+    private static final String RESOURCE = "/migrations/2.0.10-service-instance-fulltext-h2.sql";
+
+    private final DataSource dataSource;
+
+    @Inject
+    public V2_0_10ServiceInstanceFulltextMigration(final DataSource dataSource) {
+        this.dataSource = dataSource;
+    }
+
+    @Override
+    public String scriptId() {
+        return SCRIPT_ID;
+    }
+
+    @Override
+    public String description() {
+        return "OSS H2: add generated fulltext column to service_instance for the query filter";
+    }
+
+    @Override
+    public String checksum() {
+        return MigrationScript.checksumOfResources(RESOURCE);
+    }
+
+    @Override
+    public void migrate() throws Exception {
+        executeSqlResource(dataSource, RESOURCE);
+    }
+}

--- a/jdbc-h2/src/main/resources/migrations/2.0.10-service-instance-fulltext-h2.sql
+++ b/jdbc-h2/src/main/resources/migrations/2.0.10-service-instance-fulltext-h2.sql
@@ -1,0 +1,6 @@
+ALTER TABLE service_instance ADD COLUMN IF NOT EXISTS "fulltext" TEXT GENERATED ALWAYS AS (
+    JQ_STRING("value", '.id') || ' ' ||
+    JQ_STRING("value", '.type') || ' ' ||
+    COALESCE(JQ_STRING("value", '.server.hostname'), '') || ' ' ||
+    COALESCE(JQ_STRING("value", '.server.version'), '')
+);

--- a/jdbc-mysql/src/main/java/io/kestra/repository/mysql/MysqlServiceInstanceRepository.java
+++ b/jdbc-mysql/src/main/java/io/kestra/repository/mysql/MysqlServiceInstanceRepository.java
@@ -1,5 +1,9 @@
 package io.kestra.repository.mysql;
 
+import java.util.List;
+
+import org.jooq.Condition;
+
 import io.kestra.core.repositories.RepositoryBean;
 import io.kestra.core.server.ServiceInstance;
 import io.kestra.jdbc.repository.AbstractJdbcServiceInstanceRepository;
@@ -13,5 +17,10 @@ public class MysqlServiceInstanceRepository extends AbstractJdbcServiceInstanceR
     @Inject
     public MysqlServiceInstanceRepository(@Named("serviceinstance") MysqlRepository<ServiceInstance> repository) {
         super(repository);
+    }
+
+    @Override
+    protected Condition findQueryCondition(String query) {
+        return jdbcRepository.fullTextCondition(List.of("service_id", "service_type", "server_hostname", "server_version"), query);
     }
 }

--- a/jdbc-mysql/src/main/java/io/kestra/repository/mysql/migration/V2_0_10ServiceInstanceFulltextMigration.java
+++ b/jdbc-mysql/src/main/java/io/kestra/repository/mysql/migration/V2_0_10ServiceInstanceFulltextMigration.java
@@ -1,0 +1,50 @@
+package io.kestra.repository.mysql.migration;
+
+import javax.sql.DataSource;
+
+import io.kestra.core.migration.MigrationScript;
+import io.kestra.jdbc.migration.AbstractSQLMigrationScript;
+import io.kestra.repository.mysql.MysqlRepositoryEnabled;
+
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+
+/**
+ * OSS MySQL migration: adds a FULLTEXT index on {@code (service_id, service_type)} of
+ * {@code service_instance} for the query (free-text) filter, mirroring the full-text pattern of the
+ * other repositories.
+ */
+@Singleton
+@MysqlRepositoryEnabled
+public class V2_0_10ServiceInstanceFulltextMigration extends AbstractSQLMigrationScript {
+
+    private static final String SCRIPT_ID = "2.0.10-service-instance-fulltext";
+    private static final String RESOURCE = "/migrations/2.0.10-service-instance-fulltext-mysql.sql";
+
+    private final DataSource dataSource;
+
+    @Inject
+    public V2_0_10ServiceInstanceFulltextMigration(final DataSource dataSource) {
+        this.dataSource = dataSource;
+    }
+
+    @Override
+    public String scriptId() {
+        return SCRIPT_ID;
+    }
+
+    @Override
+    public String description() {
+        return "OSS MySQL: add FULLTEXT index on service_instance for the query filter";
+    }
+
+    @Override
+    public String checksum() {
+        return MigrationScript.checksumOfResources(RESOURCE);
+    }
+
+    @Override
+    public void migrate() throws Exception {
+        executeSqlResource(dataSource, RESOURCE);
+    }
+}

--- a/jdbc-mysql/src/main/resources/migrations/2.0.10-service-instance-fulltext-mysql.sql
+++ b/jdbc-mysql/src/main/resources/migrations/2.0.10-service-instance-fulltext-mysql.sql
@@ -1,0 +1,17 @@
+SET @col_hostname = (SELECT COUNT(*) FROM information_schema.columns WHERE table_schema = DATABASE() AND table_name = 'service_instance' AND column_name = 'server_hostname');
+SET @sql = IF(@col_hostname = 0, 'ALTER TABLE service_instance ADD COLUMN server_hostname VARCHAR(256) GENERATED ALWAYS AS (value ->> ''$.server.hostname'') STORED', 'SELECT 1');
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+SET @col_version = (SELECT COUNT(*) FROM information_schema.columns WHERE table_schema = DATABASE() AND table_name = 'service_instance' AND column_name = 'server_version');
+SET @sql = IF(@col_version = 0, 'ALTER TABLE service_instance ADD COLUMN server_version VARCHAR(100) GENERATED ALWAYS AS (value ->> ''$.server.version'') STORED', 'SELECT 1');
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+SET @idx_exists = (SELECT COUNT(*) FROM information_schema.statistics WHERE table_schema = DATABASE() AND table_name = 'service_instance' AND index_name = 'ix_fulltext');
+SET @sql = IF(@idx_exists = 0, 'ALTER TABLE service_instance ADD FULLTEXT INDEX ix_fulltext (service_id, service_type, server_hostname, server_version)', 'SELECT 1');
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;

--- a/jdbc-postgres/src/main/java/io/kestra/repository/postgres/PostgresServiceInstanceRepository.java
+++ b/jdbc-postgres/src/main/java/io/kestra/repository/postgres/PostgresServiceInstanceRepository.java
@@ -1,5 +1,9 @@
 package io.kestra.repository.postgres;
 
+import java.util.List;
+
+import org.jooq.Condition;
+
 import io.kestra.core.repositories.RepositoryBean;
 import io.kestra.core.server.ServiceInstance;
 import io.kestra.jdbc.repository.AbstractJdbcServiceInstanceRepository;
@@ -13,5 +17,10 @@ public class PostgresServiceInstanceRepository extends AbstractJdbcServiceInstan
     @Inject
     public PostgresServiceInstanceRepository(@Named("serviceinstance") PostgresRepository<ServiceInstance> repository) {
         super(repository);
+    }
+
+    @Override
+    protected Condition findQueryCondition(String query) {
+        return jdbcRepository.fullTextCondition(List.of("fulltext"), query);
     }
 }

--- a/jdbc-postgres/src/main/java/io/kestra/repository/postgres/migration/V2_0_10ServiceInstanceFulltextMigration.java
+++ b/jdbc-postgres/src/main/java/io/kestra/repository/postgres/migration/V2_0_10ServiceInstanceFulltextMigration.java
@@ -1,0 +1,50 @@
+package io.kestra.repository.postgres.migration;
+
+import javax.sql.DataSource;
+
+import io.kestra.core.migration.MigrationScript;
+import io.kestra.jdbc.migration.AbstractSQLMigrationScript;
+import io.kestra.repository.postgres.PostgresRepositoryEnabled;
+
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+
+/**
+ * OSS PostgreSQL migration: adds a generated {@code fulltext} TSVECTOR column to
+ * {@code service_instance} for the query (free-text) filter, mirroring the full-text pattern of the
+ * other repositories.
+ */
+@Singleton
+@PostgresRepositoryEnabled
+public class V2_0_10ServiceInstanceFulltextMigration extends AbstractSQLMigrationScript {
+
+    private static final String SCRIPT_ID = "2.0.10-service-instance-fulltext";
+    private static final String RESOURCE = "/migrations/2.0.10-service-instance-fulltext-postgres.sql";
+
+    private final DataSource dataSource;
+
+    @Inject
+    public V2_0_10ServiceInstanceFulltextMigration(final DataSource dataSource) {
+        this.dataSource = dataSource;
+    }
+
+    @Override
+    public String scriptId() {
+        return SCRIPT_ID;
+    }
+
+    @Override
+    public String description() {
+        return "OSS PostgreSQL: add generated fulltext column to service_instance for the query filter";
+    }
+
+    @Override
+    public String checksum() {
+        return MigrationScript.checksumOfResources(RESOURCE);
+    }
+
+    @Override
+    public void migrate() throws Exception {
+        executeSqlResource(dataSource, RESOURCE);
+    }
+}

--- a/jdbc-postgres/src/main/resources/migrations/2.0.10-service-instance-fulltext-postgres.sql
+++ b/jdbc-postgres/src/main/resources/migrations/2.0.10-service-instance-fulltext-postgres.sql
@@ -1,0 +1,8 @@
+ALTER TABLE service_instance ADD COLUMN IF NOT EXISTS fulltext TSVECTOR GENERATED ALWAYS AS (
+    FULLTEXT_INDEX(CAST(value ->> 'id' AS varchar)) ||
+    FULLTEXT_INDEX(CAST(value ->> 'type' AS varchar)) ||
+    FULLTEXT_INDEX(COALESCE(CAST(value -> 'server' ->> 'hostname' AS varchar), '')) ||
+    FULLTEXT_INDEX(COALESCE(CAST(value -> 'server' ->> 'version' AS varchar), ''))
+) STORED;
+
+CREATE INDEX IF NOT EXISTS service_instance_fulltext ON service_instance USING GIN (fulltext);


### PR DESCRIPTION
✨ Description

Adds free-text query (q / QueryFilter.Field.QUERY) support to two resources that previously rejected it BANNER and SERVICE_INSTANCE.

Field.QUERY is added to each resource's supportedField(), and the q value is translated into a real search condition using the same full-text mechanism already
used by Executions/Flows/Asset Usage/Tenant:
- Postgres: generated fulltext TSVECTOR column (@@ FULLTEXT_SEARCH(?))
- H2: fullTextCondition over the column(s)
- MySQL: FULLTEXT index + MATCH … AGAINST
- Elasticsearch: per-repo handleQueryFilter override (case-insensitive wildcard)

Searched fields per resource:
- BANNER → message
- SERVICE_INSTANCE → id, type, server.hostname, server.version

These are reachable from the existing admin search bars — Banner via Announcements (/admin/instance/announcements) and Service Instances via Services
(/admin/instance/services); both already render a free-text search box (searchPlaceholder) that emits filters[q][EQUALS].

🔗 Related Issue

Closes https://github.com/kestra-io/kestra-ee/issues/8158