### PR TITLE
fix(iam): surface login validation errors and refresh the sign-in screen

### DIFF
--- a/ui/src/components/basicauth/BasicAuthLogin.vue
+++ b/ui/src/components/basicauth/BasicAuthLogin.vue
@@ -1,12 +1,14 @@
 <template>
     <div class="basic-auth-login">
-        <div class="d-flex justify-content-center">
-            <Logo class="logo" />
+        <div class="basic-auth-login__brand">
+            <Logo class="basic-auth-login__logo" />
+            <KsText tag="h1" class="basic-auth-login__title">{{ $t("setup.login_title") }}</KsText>
+            <KsText tag="p" class="basic-auth-login__subtitle">{{ $t("setup.login_subtitle") }}</KsText>
         </div>
 
-        <KsForm @submit.prevent :model="credentials" ref="form" :rules="rules" :showMessage="false">
+        <KsForm @submit.prevent :model="credentials" ref="form" :rules="rules">
             <input type="hidden" name="from" :value="redirectPath">
-            <KsFormItem prop="username">
+            <KsFormItem prop="username" class="basic-auth-login__field">
                 <KsInput
                     name="username"
                     size="large"
@@ -18,14 +20,9 @@
                     <template #prepend>
                         <Account />
                     </template>
-                    <template #suffix v-if="getFieldError('username')">
-                        <KsTooltip placement="top" :content="getFieldError('username')">
-                            <InformationOutline class="validation-icon error" />
-                        </KsTooltip>
-                    </template>
                 </KsInput>
             </KsFormItem>
-            <KsFormItem prop="password">
+            <KsFormItem prop="password" class="basic-auth-login__field">
                 <KsInput
                     v-model="credentials.password"
                     size="large"
@@ -39,37 +36,33 @@
                     <template #prepend>
                         <Lock />
                     </template>
-                    <template #suffix v-if="getFieldError('password')">
-                        <KsTooltip placement="top" :content="getFieldError('password')">
-                            <InformationOutline class="validation-icon error" />
-                        </KsTooltip>
-                    </template>
                 </KsInput>
             </KsFormItem>
-            <KsFormItem>
+            <KsFormItem class="basic-auth-login__submit">
                 <KsButton
                     type="primary"
                     class="w-100"
                     size="large"
                     nativeType="submit"
                     @click.prevent="handleSubmit"
-                    :disabled="isLoginDisabled"
+                    :disabled="isLoading"
                     :loading="isLoading"
                 >
                     {{ $t("setup.login") }}
                 </KsButton>
             </KsFormItem>
-            <KsFormItem>
-                <KsButton
-                    type="default"
-                    class="w-100"
-                    size="large"
-                    @click="openTroubleshootingGuide"
-                >
-                    {{ $t("setup.troubleshooting") }}
-                </KsButton>
-            </KsFormItem>
         </KsForm>
+
+        <div class="basic-auth-login__footer">
+            <KsButton
+                text
+                type="primary"
+                :icon="OpenInNew"
+                @click="openTroubleshootingGuide"
+            >
+                {{ $t("setup.troubleshooting") }}
+            </KsButton>
+        </div>
     </div>
 </template>
 
@@ -84,7 +77,7 @@
 
     import Account from "vue-material-design-icons/Account.vue"
     import Lock from "vue-material-design-icons/Lock.vue"
-    import InformationOutline from "vue-material-design-icons/InformationOutline.vue"
+    import OpenInNew from "vue-material-design-icons/OpenInNew.vue"
     import Logo from "../home/Logo.vue"
 
     import {useCoreStore} from "../../stores/core"
@@ -143,22 +136,7 @@
         password: [{required: true, validator: validatePassword, trigger: "blur"}],
     }))
 
-    const getFieldError = (fieldName: string): string | undefined => {
-        if (!form.value) return undefined
-        const field = form.value.fields?.find((f: any) => f.prop === fieldName)
-        return field?.validateState === "error" ? field.validateMessage : undefined
-    }
-
     const redirectPath = computed(() => route.query.from as string | undefined)
-
-    const isLoginDisabled = computed(() =>
-        !credentials.value.username?.trim() ||
-        !credentials.value.password?.trim() ||
-        !EMAIL_REGEX.test(credentials.value.username) ||
-        !PASSWORD_REGEX.test(credentials.value.password) ||
-        !MailChecker.isValid(credentials.value.username) ||
-        isLoading.value,
-    )
 
     const axios = useClient()
 
@@ -289,25 +267,50 @@
     .basic-auth-login {
         width: 100%;
         max-width: 400px;
-        padding: 1rem;
-        display: flex;
-        flex-direction: column;
-        justify-content: center;
-        .logo {
-            width: 250px;
-            margin-bottom: 40px;
+        padding: 2rem;
+        background: var(--ks-bg-surface);
+        border: 1px solid var(--ks-border-default);
+        border-radius: var(--ks-radius-lg);
+        box-shadow: var(--ks-shadow-lg);
+
+        &__brand {
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            text-align: center;
+            margin-bottom: 1.75rem;
         }
 
-        .kel-button.kel-button--default {
-            background: var(--ks-bg-tag-hover);
+        &__logo {
+            width: 140px;
+            margin-bottom: 1.25rem;
+        }
 
-            html.dark & {
-                background: var(--ks-bg-input);
+        &__title {
+            margin: 0;
+            font-size: var(--ks-font-size-xl);
+            font-weight: 600;
+            color: var(--ks-text-primary);
+        }
 
-                &.kel-button {
-                    border: 0;
-                }
-            }
+        &__subtitle {
+            margin: 0.25rem 0 0;
+            font-size: var(--ks-font-size-sm);
+            color: var(--ks-text-secondary);
+        }
+
+        &__field {
+            margin-bottom: 1.75rem;
+        }
+
+        &__submit {
+            margin-bottom: 0;
+        }
+
+        &__footer {
+            display: flex;
+            justify-content: center;
+            margin-top: 0.75rem;
         }
 
         .kel-form-item {
@@ -322,13 +325,6 @@
                         height: var(--ks-font-size-xl);
                         bottom: -0.250em;
                     }
-                }
-            }
-
-            .validation-icon {
-                font-size:  var(--ks-font-size-lg);
-                &.error {
-                    color: var(--ks-status-error);
                 }
             }
         }

--- a/ui/src/translations/en.json
+++ b/ui/src/translations/en.json
@@ -1771,8 +1771,10 @@
     },
     "setup": {
       "login": "Login",
+      "login_title": "Sign in",
+      "login_subtitle": "Enter your credentials to access your Kestra instance",
       "logout": "Logout",
-      "troubleshooting": "Forgot Password?",
+      "troubleshooting": "Trouble signing in?",
       "steps": {
         "user": "Create admin user",
         "config": "Validate Configuration",


### PR DESCRIPTION
## Summary

The basic-auth login page was a top friction point. This PR makes login failures **visible** and refreshes the sign-in form.

## Why — PostHog data

`$rageclick` isn't captured on our instances, so `$dead_click` (a click on something that looks interactive but does nothing) is the best friction signal. `/login` is one of the worst offenders:

- **~1,270 users over 30 days** dead-clicked on `/login` (still active in the last 7 days).
- The **`Login` button** itself: ~214 users (30d) / 87 users (7d) clicking with no effect.
- **`Forgot Password?`**: ~137 users (30d) / 40 users (7d) clicking with no in-app result.

Root causes confirmed in code + browser:
- The submit button was `:disabled` until strict client-side validation passed, so clicking an invalid form did **nothing and gave no feedback**. `KsForm` also had `showMessage=false`, which **hid the inline validation messages entirely** — the only error affordance was a hover-only tooltip icon that often didn't render. So users clicked a dead button with no idea why.
- The help link read **"Forgot Password?"**, but OSS basic auth has **no password-reset flow** (credentials live in configuration, there is nothing to reset in-app). The button only opens the basic-auth **troubleshooting doc** in a new tab — so the label over-promised a reset that doesn't exist, which is exactly why users clicked it and were confused.

## Changes

- **Show validation errors.** Removed `showMessage=false` so `KsFormItem` renders inline error messages under each field; removed the redundant hover-tooltip mechanism (`getFieldError` + suffix icons + dead CSS).
- **Enable the submit button.** Disabled only while loading — a click now runs `validate()` and surfaces the inline errors (`Email is required`, `Invalid password`, …) instead of doing nothing.
- **Rename the help link.** `Forgot Password?` → **`Trouble signing in?`** to match what it actually does (opens troubleshooting docs; no in-app reset exists in OSS basic auth), plus an `OpenInNew` icon and a demotion from a full-width secondary button to a lighter text link. (Analytics event name kept as `forgot_password_click` for metric continuity.)
- **Refresh.** The form is wrapped in an elevated card (logo + `Sign in` title + subtitle), composed from design-system components and `--ks-*` tokens, with comfortable spacing that leaves room for error messages.

<img width="1600" height="1000" alt="01-login-light" src="https://github.com/user-attachments/assets/d17a3857-20c0-4645-baff-f9d6c5c90ecf" />
<img width="1600" height="1000" alt="02-login-light-errors" src="https://github.com/user-attachments/assets/4d37a1ff-420e-4cd7-a1e8-90890d5194fa" />
<img width="1600" height="1000" alt="03-login-dark" src="https://github.com/user-attachments/assets/262d20d7-7ea8-401e-8ba3-72da91fb4079" />
<img width="1600" height="1000" alt="04-login-dark-errors" src="https://github.com/user-attachments/assets/7a6a3b58-7d2b-4889-9027-6111894824b5" />

## i18n

Only `en.json` is edited (new keys under `setup`: `login_title`, `login_subtitle`, and the reworded `troubleshooting`); the auto-translate action handles the other locales.

🤖 Generated with [Claude Code](https://claude.com/claude-code)