### PR TITLE
fix(core): restore trigger icon sizing.

### DIFF
--- a/ui/src/components/flows/TriggerAvatar.vue
+++ b/ui/src/components/flows/TriggerAvatar.vue
@@ -1,6 +1,6 @@
 <template>
     <div class="trigger">
-        <span v-for="trigger in triggers" :key="uid(trigger)" :id="uid(trigger)">
+        <span v-for="trigger in triggers" :key="uid(trigger)" :id="uid(trigger)" class="trigger-icon">
             <template v-if="trigger.disabled === undefined || trigger.disabled === false">
                 <KsPopover
                     :ref="(el: any) => setPopoverRef(el, trigger)"
@@ -118,17 +118,12 @@
     }
 
     .trigger-icon {
-        display: inline-flex !important;
+        display: inline-flex;
         align-items: center;
-        margin-right: .25rem;
-        border: none;
-        background-color: transparent;
-        padding: 2px;
-        cursor: default;
-    }
-
-    :deep(div.wrapper) {
+        justify-content: center;
         width: var(--ks-font-size-lg);
         height: var(--ks-font-size-lg);
+        margin-right: var(--ks-spacing-1);
+        cursor: default;
     }
 </style>


### PR DESCRIPTION
Closes https://github.com/kestra-io/kestra-ee/issues/8249

Flows:

<img width="3416" height="1878" alt="image" src="https://github.com/user-attachments/assets/b78f1347-a790-4bc6-8667-66586c968f8b" />

Executions:

<img width="3416" height="1878" alt="image" src="https://github.com/user-attachments/assets/dd271acc-5c9f-4c80-a638-0432a83059ac" />
