### PR TITLE
feat(tests): add generateTestMetadata task for CI timeout detection

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -398,6 +398,11 @@ gradle.taskGraph.afterTask { Task task ->
     }
 }
 
+// Workaround for https://github.com/gradle/gradle/issues/36699
+// Gradle's test task `timeout` kills the JVM hard, so JUnit XML reports are never
+// generated for timed-out modules. This task captures per-module task states so that
+// kestra-devtools can detect missing results and report them in PR comments.
+// Remove this task once Gradle supports graceful test task timeouts.
 tasks.register('generateTestMetadata') {
     group = 'verification'
     description = 'Generates build/test-metadata.json with per-module test task states for CI reporting.'

--- a/build.gradle
+++ b/build.gradle
@@ -375,10 +375,72 @@ subprojects {subProj ->
     }
 }
 
+// Collect test task outcomes as they execute (for test-metadata.json)
+def testTaskOutcomes = new java.util.concurrent.ConcurrentHashMap<String, String>()
+gradle.taskGraph.afterTask { Task task ->
+    if (task instanceof Test) {
+        def state = task.state
+        String outcome
+        if (state.noSource) {
+            outcome = 'NO_SOURCE'
+        } else if (state.failure != null) {
+            outcome = 'FAILED'
+        } else if (state.didWork) {
+            outcome = 'SUCCESS'
+        } else if (state.upToDate) {
+            outcome = 'UP_TO_DATE'
+        } else if (state.skipped) {
+            outcome = 'SKIPPED'
+        } else {
+            outcome = 'FROM_CACHE'
+        }
+        testTaskOutcomes.put(task.project.name + ':' + task.name, outcome)
+    }
+}
+
+tasks.register('generateTestMetadata') {
+    group = 'verification'
+    description = 'Generates build/test-metadata.json with per-module test task states for CI reporting.'
+    mustRunAfter(subprojects.collectMany { it.tasks.withType(Test) })
+    def outputFile = layout.buildDirectory.file('test-metadata.json')
+    outputs.file(outputFile)
+    outputs.upToDateWhen { false }
+    doLast {
+        def timeoutMin = (System.getenv('GRADLE_TEST_TIMEOUT_MIN') ?: '30').toInteger()
+        def modules = new LinkedHashMap<String, Object>()
+        subprojects.each { sub ->
+            def hasTestSources = sub.file('src/test/java').isDirectory() &&
+                sub.fileTree('src/test/java').files.size() > 0
+            if (!hasTestSources && sub.file('src/test/kotlin').isDirectory()) {
+                hasTestSources = sub.fileTree('src/test/kotlin').files.size() > 0
+            }
+            def xmlDir = sub.file("build/test-results/test")
+            def hasXmlResults = xmlDir.isDirectory() &&
+                sub.fileTree(dir: xmlDir, includes: ['TEST-*.xml']).files.size() > 0
+            def state = testTaskOutcomes.getOrDefault(sub.name + ':test', 'NOT_RUN')
+
+            modules.put(sub.name, [
+                state: state,
+                hasTestSources: hasTestSources,
+                hasXmlResults: hasXmlResults
+            ])
+        }
+        def metadata = [
+            modules: modules,
+            timeoutMinutes: timeoutMin
+        ]
+        def json = groovy.json.JsonOutput.prettyPrint(groovy.json.JsonOutput.toJson(metadata))
+        outputFile.get().asFile.parentFile.mkdirs()
+        outputFile.get().asFile.text = json
+        logger.lifecycle("Test metadata written to ${outputFile.get().asFile.path}")
+    }
+}
+
 tasks.named('check') {
     dependsOn tasks.named('testCodeCoverageReport', JacocoReport)
     dependsOn(tasks.named('flakyTest'))
     finalizedBy jacocoTestReport
+    finalizedBy tasks.named('generateTestMetadata')
 }
 
 tasks.register('unitTest') {


### PR DESCRIPTION
## Summary

Adds a `generateTestMetadata` Gradle task that writes `build/test-metadata.json` after all test tasks complete. The JSON contains per-module:
- **Task state**: SUCCESS, FAILED, FROM_CACHE, UP_TO_DATE, SKIPPED, NO_SOURCE
- **hasTestSources**: whether `src/test/java` exists
- **hasXmlResults**: whether JUnit XML output was produced

### Why

When a Gradle test task times out (30 min default), no JUnit XML is generated — the module silently disappears from the CI test report. The team sees "0 failed" when an entire module's results are actually missing. This metadata file lets `kestra-devtools` detect the gap and flag it prominently.

Also surfaces which modules ran from Gradle cache vs were freshly executed.

## Companion PRs
- EE: kestra-io/kestra-ee#8272 (same Gradle task + webhook test fix)
- Devtools: kestra-io/kestra-devtools#TBD (consume metadata in reports)

## Test plan
- [x] `generateTestMetadata` task registers and compiles
- [x] Produces correct JSON with per-module states
- [x] Runs after all test tasks via `mustRunAfter` + `finalizedBy check`
- [ ] CI validates end-to-end with devtools consuming the metadata