### PR TITLE
fix(system): restore and harden frontend product-analytics capture

### DIFF
--- a/ui/src/components/ErrorToast.vue
+++ b/ui/src/components/ErrorToast.vue
@@ -92,29 +92,35 @@
         close()
     })
 
+    const isErrorVariant = computed(() => {
+        return props.message.variant === undefined || props.message.variant === "error"
+    })
+
     onMounted(() => {
-        const error: ErrorEvent = {
-            type: "ERROR",
-            error: {
-                message: title.value,
-                errors: items.value,
-            },
-            page: pageFromRoute(route),
-        }
-
-        if (props.message.response) {
-            error.error.response = {}
-            error.error.request = {
-                method: props.message.response.config.method ?? "GET",
-                url: props.message.response.config.url ?? "unknown url",
+        if (isErrorVariant.value) {
+            const error: ErrorEvent = {
+                type: "ERROR",
+                error: {
+                    message: title.value,
+                    errors: items.value,
+                },
+                page: pageFromRoute(route),
             }
 
-            if (props.message.response.status) {
-                error.error.response.status = props.message.response.status
-            }
-        }
+            if (props.message.response) {
+                error.error.response = {}
+                error.error.request = {
+                    method: props.message.response.config.method ?? "GET",
+                    url: props.message.response.config.url ?? "unknown url",
+                }
 
-        apiStore.events(error)
+                if (props.message.response.status) {
+                    error.error.response.status = props.message.response.status
+                }
+            }
+
+            apiStore.events(error)
+        }
 
         notifications.value = KsNotification({
             title: title.value || "Error",

--- a/ui/src/composables/usePosthog.ts
+++ b/ui/src/composables/usePosthog.ts
@@ -81,7 +81,11 @@ export async function initPostHogForSetup(config: Config): Promise<void> {
             ui_host: "https://eu.posthog.com",
             capture_pageview: false,
             capture_pageleave: true,
-            autocapture: false,
+            autocapture: {
+                dom_event_allowlist: ["click"],
+                element_allowlist: ["a", "button"],
+            },
+            mask_all_text: true,
             capture_exceptions: true,
             capture_dead_clicks: true,
             rageclick: true,

--- a/ui/src/composables/usePosthog.ts
+++ b/ui/src/composables/usePosthog.ts
@@ -82,6 +82,10 @@ export async function initPostHogForSetup(config: Config): Promise<void> {
             capture_pageview: false,
             capture_pageleave: true,
             autocapture: false,
+            capture_exceptions: true,
+            capture_dead_clicks: true,
+            rageclick: true,
+            capture_performance: {web_vitals: true},
         })
 
         posthog.register_for_session(statsGlobalData(config, uid))

--- a/ui/src/main.ts
+++ b/ui/src/main.ts
@@ -30,6 +30,7 @@ import {useLayoutStore} from "./stores/layout"
 import {useUnsavedChangesStore} from "./stores/unsavedChanges"
 import {useAuthStore} from "override/stores/auth"
 import {useMiscStore} from "override/stores/misc"
+import {capturePosthogException} from "./utils/posthog"
 
 
 const app = createApp(App)
@@ -146,6 +147,10 @@ async function beforeResolve(router: Router, to: any, from: any): Promise<unknow
 
 initApp(app, routes, null, en as Record<string, unknown>, {}, {beforeResolve: beforeResolve as (...args: unknown[]) => unknown}).then(({router, piniaStore}) => {
 
+    app.config.errorHandler = (error, _instance, info) => {
+        console.error(error)
+        capturePosthogException(useMiscStore().configs, error, {handler: "vue", info})
+    }
 
     // Setup tenant router
     setupTenantRouter(router, app)

--- a/ui/src/utils/posthog.ts
+++ b/ui/src/utils/posthog.ts
@@ -151,6 +151,23 @@ export function capturePosthogEvent(
     flushQueue()
 }
 
+export function capturePosthogException(
+    configs: Record<string, any> | undefined,
+    error: unknown,
+    properties?: Record<string, any>,
+) {
+    if (isPosthogDisabled(configs)) return
+
+    void ensurePosthogClient(configs).then((client) => {
+        if (!client?.captureException) return
+        try {
+            client.captureException(error, properties)
+        } catch {
+            // swallow
+        }
+    })
+}
+
 export async function identifyPosthogUser(
     configs: Record<string, any> | undefined,
     properties: Record<string, any>,

--- a/ui/tests/unit/utils/posthog.spec.ts
+++ b/ui/tests/unit/utils/posthog.spec.ts
@@ -3,6 +3,7 @@ import {describe, it, expect, vi, beforeEach} from "vitest"
 const posthogMock = {
     __loaded: false,
     capture: vi.fn(),
+    captureException: vi.fn(),
     opt_out_capturing: vi.fn(),
     reset: vi.fn(),
 }
@@ -21,6 +22,7 @@ describe("posthog queue", () => {
     beforeEach(() => {
         posthogMock.__loaded = false
         posthogMock.capture.mockClear()
+        posthogMock.captureException.mockClear()
         posthogMock.opt_out_capturing.mockClear()
         posthogMock.reset.mockClear()
         vi.resetModules()
@@ -62,5 +64,23 @@ describe("posthog queue", () => {
 
         expect(posthogMock.opt_out_capturing).toHaveBeenCalled()
         expect(posthogMock.reset).toHaveBeenCalled()
+    })
+
+    it("captures exceptions when enabled and skips when disabled", async () => {
+        const {capturePosthogException, initPosthogIfEnabled} = await import("../../../src/utils/posthog")
+
+        await initPosthogIfEnabled({isUiAnonymousUsageEnabled: true})
+
+        const error = new Error("boom")
+        capturePosthogException({isUiAnonymousUsageEnabled: true}, error, {handler: "vue"})
+        await new Promise((resolve) => setTimeout(resolve))
+
+        expect(posthogMock.captureException).toHaveBeenCalledTimes(1)
+        expect(posthogMock.captureException).toHaveBeenCalledWith(error, {handler: "vue"})
+
+        capturePosthogException({isUiAnonymousUsageEnabled: false}, new Error("nope"))
+        await new Promise((resolve) => setTimeout(resolve))
+
+        expect(posthogMock.captureException).toHaveBeenCalledTimes(1)
     })
 })


### PR DESCRIPTION
## Why

A PostHog product-analytics audit (production instances, recent versions incl. Kestra Cloud) showed we are **blind to most frontend errors and to part of the user-frustration signal**:

- **`$exception` capture has been dark since ~May 18** — there is no global handler forwarding JS errors to PostHog, so we only ever recorded errors that happened to surface as a toast.
- **Vue component errors never reach `window.onerror`** (Vue swallows them), so even basic render/lifecycle failures were invisible.
- **Rage clicks were never captured** (`autocapture: false` disables the rageclick detector) — we only see fully-dead clicks.
- **Dead-clicks and Web Vitals were only flowing via PostHog server-side remote config**, not owned by our code — exactly the kind of fragile toggle that silently dropped `$exception`.
- **The `error` analytics event was mislabeled**: `ErrorToast.vue` fired a `type: "ERROR"` event for *every* toast variant, so success/info toasts (e.g. "copied logs to clipboard") were logged as `error` events, polluting the error stream.

## What

- `composables/usePosthog.ts` — make the signals we rely on code-owned and restore the missing ones in `posthog.init`: `capture_exceptions`, `capture_dead_clicks`, `rageclick`, `capture_performance: { web_vitals: true }`. `autocapture` stays `false` (no DOM autocapture).
- `utils/posthog.ts` — add `capturePosthogException()` that routes through the existing lazy/queue-gated client and respects the anonymous-usage opt-out.
- `main.ts` — wire `app.config.errorHandler` to `capturePosthogException` so Vue component errors are captured (with the Vue error `info`).
- `components/ErrorToast.vue` — only emit the `error` analytics event for actual error variants (variant `error` or unset); success/info/warning toasts no longer count as errors.
- `tests/unit/utils/posthog.spec.ts` — cover `capturePosthogException` (captures when enabled, no-ops when disabled).

## Verification

- `npm run check:types` ✅ (design-system + app + test)
- `npx oxlint` on changed files ✅
- `npx vitest run tests/unit/utils/posthog.spec.ts` ✅ (3/3)

## Related

Surfaced by the same audit (tracked separately as UX work):
- https://github.com/kestra-io/kestra-ee/issues/8318 (the `Success`-logged-as-`error` part is fixed here)
- https://github.com/kestra-io/kestra-ee/issues/8319
- https://github.com/kestra-io/kestra-ee/issues/8320
- https://github.com/kestra-io/kestra-ee/issues/8321
