### PR TITLE
fix(tabs): replace spread operator with toHandlers for event binding

### DIFF
--- a/ui/src/components/Tabs.vue
+++ b/ui/src/components/Tabs.vue
@@ -38,7 +38,7 @@
 </template>
 
 <script setup lang="ts">
-    import {ref, computed, useAttrs, onMounted, onBeforeUnmount, watch, h, defineComponent, type Component} from "vue"
+    import {ref, computed, useAttrs, onMounted, onBeforeUnmount, watch, h, defineComponent, toHandlers, type Component} from "vue"
     import {useRoute} from "vue-router"
     import EnterpriseBadge from "./EnterpriseBadge.vue"
     import BlueprintDetail from "override/components/flows/blueprints/BlueprintDetail.vue"
@@ -165,7 +165,7 @@
                 return h(tab.component as Component, {
                     ...tab.props,
                     ...attrsWithoutClass.value,
-                    ...tab["v-on"],
+                    ...toHandlers(tab["v-on"] ?? {}),
                     namespace: getNamespaceToForward(tab),
                     embed: tab.props?.embed ?? true,
                     onGoToDetail: (id: string) => (selectedBlueprintId.value = id),


### PR DESCRIPTION
closes https://github.com/kestra-io/kestra-ee/issues/8294, closes https://github.com/kestra-io/kestra-ee/issues/8295, closes https://github.com/kestra-io/kestra-ee/issues/8296, closes https://github.com/kestra-io/kestra-ee/issues/8297, closes https://github.com/kestra-io/kestra-ee/issues/8298

This pull request introduces a minor update to the `Tabs.vue` component, improving how event listeners are passed to dynamic tab components. The change uses Vue's `toHandlers` utility to ensure event bindings are correctly formatted.
**Event handling improvements:**

* Replaced direct spreading of the `v-on` property with `toHandlers(tab["v-on"] ?? {})` when rendering tab components, ensuring proper event handler binding. (`ui/src/components/Tabs.vue`)
* Added the `toHandlers` import from Vue to support the above change. (`ui/src/components/Tabs.vue`)