### PR TITLE
fix(settings): three Preferences-page bugs — select empty-state padding, env name input & filterable fit-select width

### DIFF
--- a/ui/packages/design-system/src/components/Form/KsSelect/KsSelect.vue
+++ b/ui/packages/design-system/src/components/Form/KsSelect/KsSelect.vue
@@ -173,10 +173,14 @@
 
         .kel-select-dropdown__list {
             padding: var(--ks-spacing-1);
-            
+
             .kel-select-dropdown__item + .kel-select-dropdown__item {
                 margin-top: var(--ks-spacing-1);
             }
+        }
+
+        .kel-select-dropdown__empty {
+            padding: var(--ks-spacing-3) var(--ks-spacing-4);
         }
 
         .kel-select-dropdown__item {

--- a/ui/packages/design-system/src/components/Form/KsSelect/KsSelect.vue
+++ b/ui/packages/design-system/src/components/Form/KsSelect/KsSelect.vue
@@ -106,6 +106,21 @@
             .kel-select__input-wrapper {
                 position: absolute;
             }
+
+            &:focus-within:has(input:not([readonly])) {
+                .kel-select__placeholder {
+                    position: absolute;
+                }
+
+                .kel-select__input-wrapper {
+                    position: relative;
+                }
+
+                .kel-select__input {
+                    width: fit-content;
+                    min-width: 120px;
+                }
+            }
         }
 
 

--- a/ui/src/components/settings/BasicSettings.vue
+++ b/ui/src/components/settings/BasicSettings.vue
@@ -540,8 +540,7 @@
         persist("editorPlayground", settings.editorPlayground)
     }
 
-    function onEnvName(value: string | number) {
-        settings.envName = String(value)
+    function onEnvName() {
         layoutStore.setEnvName(settings.envName)
         notifySaved(`${THEME}.fields.environment_name`)
     }


### PR DESCRIPTION
Three bugs on the **Settings → Preferences** page.

## 1. Select empty state has no horizontal padding (`fix(design-system)`)

The `KsSelect` dropdown empty state (`.kel-select-dropdown__empty`) inherited Element Plus's default `padding: 10px 0` — vertical only, **zero horizontal padding** — so "No data" / "No matching data" text sat flush against the dropdown edges (reported on the Default Namespace dropdown).

Fixed at the design-system level so every `Ks*` select empty state gets breathing room:

```scss
.kel-select-dropdown__empty {
    padding: var(--ks-spacing-3) var(--ks-spacing-4);
}
```

| Before (`10px 0`) | After (`10.5px 14px`) |
|---|---|
| ![before](https://raw.githubusercontent.com/kestra-io/kestra/chore/pr-16576-screenshots/.github/pr-assets/16576/namespace-empty-before.png) | ![after](https://raw.githubusercontent.com/kestra-io/kestra/chore/pr-16576-screenshots/.github/pr-assets/16576/namespace-empty-after.png) |

Verified in Storybook (`Components/Form/KsSelect` → Filterable) and in the running app on the real Default Namespace dropdown, light + dark mode.

## 2. Environment Name input becomes untypeable after clear/blur (`fix(system)`)

The Environment Name field bound `KsInput` one-way (`:modelValue` + `@change`) with no `v-model`. While untouched, `defineModel`'s local mode let typing through, but after the first `@change` (clicking the clearable ✕, or blurring) `settings.envName` became a controlled value the parent never updated per keystroke. ElInput then re-synced its native value on every input, silently wiping each new character — the field looked focused and enabled but rejected typing.

Fixed by binding two-way with `v-model` (`@change` still persists on commit).

![envname](https://raw.githubusercontent.com/kestra-io/kestra/chore/pr-16576-screenshots/.github/pr-assets/16576/envname-typeable-after.png)

Verified: type → clear ✕ → retype works (was blocked); type "dev" → blur → retype "2" → `dev2` (was blocked).

## 3. Fit-mode select collapses while filtering (`fix(design-system)`)

In `kel-select--fit` mode the width is driven by the placeholder (forced `position: static`) while the input wrapper is `position: absolute`, out of flow. For a **filterable** fit-select (the Default Namespace dropdown), typing hides the placeholder, so the wrapper collapsed to ~44px and the text input to ~11px — unusable.

Fix: while editing a filterable fit-select, take the placeholder out of flow, put the input wrapper back in flow, and let the input size to its content. Scoped with `:has(input:not([readonly]))` so non-filterable fit-selects (Log Level, etc.) keep their compact width.

![fit](https://raw.githubusercontent.com/kestra-io/kestra/chore/pr-16576-screenshots/.github/pr-assets/16576/namespace-fit-typing-after.png)

Verified on the served code: typing `company.team.payments` → field grows to 170px / input 126px (was 44px / 11px); non-filterable fit-selects unchanged.

Closes https://github.com/kestra-io/kestra-ee/issues/8327

---
<sub>Screenshots live on the throwaway branch `chore/pr-16576-screenshots` (not merged into `develop`); safe to delete after merge.</sub>

🤖 Generated with [Claude Code](https://claude.com/claude-code)