### PR TITLE
fix: show meaningful empty state in Gantt view

### DIFF
--- a/ui/src/components/executions/Gantt.vue
+++ b/ui/src/components/executions/Gantt.vue
@@ -122,6 +122,10 @@
                             </DynamicScrollerItem>
                         </template>
                     </DynamicScroller>
+                    <KsEmpty
+                        v-else
+                        :description="emptyDescription"
+                    />
                 </template>
             </KsCard>
         </div>
@@ -387,6 +391,24 @@
 
     const isExecutionStarted = computed<boolean>(() => {
         return !!execution.value?.state?.current && !["CREATED", "QUEUED"].includes(execution.value.state.current)
+    })
+
+    // Empty-state message shown when the Gantt has no rows to display.
+    const emptyDescription = computed<string>(() => {
+        // Some task runs exist but the active search / state / task filters hid them all.
+        if (series.value.length > 0) {
+            return t("gantt_no_tasks_match_filters")
+        }
+
+        // The execution reached a terminal state (e.g. cancelled or failed by a
+        // concurrency limit) before any task started — nothing will ever be plotted.
+        const current = execution.value?.state?.current
+        if (current && !State.isRunning(current)) {
+            return t("gantt_no_tasks_executed")
+        }
+
+        // The execution is running but its first task run has not been created yet.
+        return t("no_tasks_running")
     })
 
     const hasValidDate = computed<boolean>(() => isFinite(delta()))

--- a/ui/src/translations/en.json
+++ b/ui/src/translations/en.json
@@ -79,6 +79,8 @@
     "details": "Details",
     "overview": "Overview",
     "gantt": "Gantt",
+    "gantt_no_tasks_executed": "This execution ended without running any task. <br> Check the execution's overview and logs for the reason (for example, it may have been cancelled or failed by a concurrency limit).",
+    "gantt_no_tasks_match_filters": "No tasks match the selected filters. <br> Try adjusting the search, state, or log-level filters.",
     "logs": "Logs",
     "no_logs_data": "No Data",
     "no_logs_data_description": "No logs found for the selected filters. <br> Please try adjusting your filters, changing the time range, or check if the flow has executed recently.",


### PR DESCRIPTION
✨ Description

Fixes a misleading empty state in the execution Gantt view.

Previously, when the Gantt had no task runs to plot, the card rendered completely blank. When a concurrency limit cancels or fails a second execution (behavior: CANCEL / FAIL), the execution reaches a terminal state with zero task runs — and the view showed "No tasks are running yet", which is wrong because nothing will ever run.

This PR renders a KsEmpty state with a message chosen from the execution state:

- Terminal state, no task runs (the concurrency CANCEL/FAIL case) → "This execution ended without running any task…"
- Task runs exist but filters/search hid them all → "No tasks match the selected filters…"
- Running, first task run not yet created (brief transient) → "No tasks are running yet."

Note: QUEUE behavior is unaffected — queued executions still render ExecutionPending.

Changes:
- ui/src/components/executions/Gantt.vue — add KsEmpty in the card's #default slot + an emptyDescription computed that branches on State.isRunning(...).
- ui/src/translations/en.json — two new keys (gantt_no_tasks_executed, gantt_no_tasks_match_filters). Other locales fall back to English.

🔗 Related Issue

Closes https://github.com/kestra-io/kestra-ee/issues/7346
