### PR TITLE
fix(breadcrumb): adjust font sizes

### DIFF
--- a/ui/packages/design-system/src/components/Navigation/KsBreadcrumb/KsBreadcrumb.vue
+++ b/ui/packages/design-system/src/components/Navigation/KsBreadcrumb/KsBreadcrumb.vue
@@ -116,6 +116,7 @@
         align-items: center;
         gap: var(--ks-spacing-1);
         align-self: stretch;
+        font-size: var(--ks-font-size-md);
 
         &__leading {
             display: inline-flex;
@@ -129,7 +130,6 @@
         }
 
         &__separator {
-            font-size: var(--ks-font-size-sm);
             font-weight: var(--ks-font-weight-semibold);
             color: var(--ks-border-strong);
             user-select: none;
@@ -158,7 +158,6 @@
             display: inline-flex;
             align-items: center;
             gap: var(--ks-spacing-2);
-            font-size: var(--ks-font-size-sm);
             font-weight: var(--ks-font-weight-regular);
             color: inherit;
             text-decoration: none;
@@ -169,7 +168,6 @@
             display: inline-flex;
             align-items: center;
             font-size: var(--ks-font-size-lg);
-            color: var(--ks-text-primary);
 
             :deep(svg) {
                 stroke-width: 1.5;
@@ -182,7 +180,8 @@
             gap: var(--ks-spacing-2);
             margin: 0;
             padding: var(--ks-spacing-1) var(--ks-spacing-2);
-            font-size: var(--ks-font-size-sm);
+            font-size: inherit;
+            line-height: 1.5;
             font-weight: var(--ks-font-weight-semibold);
             color: var(--ks-text-primary);
             white-space: nowrap;
@@ -193,7 +192,7 @@
         }
 
         &__ellipsis {
-            font-size: var(--ks-font-size-sm);
+            font-size: inherit;
             color: var(--ks-text-primary);
             background: none;
             border: 0;


### PR DESCRIPTION
closes https://github.com/kestra-io/kestra-ee/issues/8342

* Set the root breadcrumb container to use `font-size: var(--ks-font-size-md)` for consistent base sizing.
* Updated `.KsBreadcrumb__item`, `.KsBreadcrumb__ellipsis`, and related elements to use `font-size: inherit` instead of specifying a smaller font size, ensuring they follow the parent’s font size. [[1]](diffhunk://#diff-90743da5e3b160644357321a0de275cb0dc10866d01774ef59031660ef67638dL185-R184) [[2]](diffhunk://#diff-90743da5e3b160644357321a0de275cb0dc10866d01774ef59031660ef67638dL196-R195)
* Removed explicit font size declarations from `.KsBreadcrumb__separator` and `.KsBreadcrumb__item`, relying on inherited or parent font size for better consistency. [[1]](diffhunk://#diff-90743da5e3b160644357321a0de275cb0dc10866d01774ef59031660ef67638dL132) [[2]](diffhunk://#diff-90743da5e3b160644357321a0de275cb0dc10866d01774ef59031660ef67638dL161)
* Removed the explicit color from `.KsBreadcrumb__current`, allowing it to inherit color, and kept the larger font size for emphasis.
* Added `line-height: 1.5` to `.KsBreadcrumb__item` for improved vertical alignment.