### PR TITLE
fix(flows): fix execute permission check and polish actions column

### DIFF
--- a/ui/src/components/flows/Flows.vue
+++ b/ui/src/components/flows/Flows.vue
@@ -218,7 +218,7 @@
                     </KsTableColumn>
                 </template>
 
-                <KsTableColumn columnKey="action" className="row-action">
+                <KsTableColumn columnKey="action" className="row-action" :label="$t('actions')">
                     <template #default="scope">
                         <div class="flow-actions-cell">
                             <KsIconButton
@@ -705,9 +705,8 @@
     cursor: pointer;
 }
 
-:deep(.flows-table) .kel-table__body tr:not(:hover) .flow-actions-cell {
-    opacity: 0;
-    pointer-events: none;
+:deep(.flows-table) th.row-action .cell {
+    padding-right: var(--ks-spacing-4);
 }
 
 .header-actions-list {
@@ -721,8 +720,8 @@
 .flow-actions-cell {
     display: flex;
     align-items: center;
+    justify-content: center;
     gap: 0.25rem;
-    transition: opacity 0.15s ease;
-    padding: 0 var(--ks-spacing-2);
+    padding-right: var(--ks-spacing-4);
 }
 </style>


### PR DESCRIPTION
## Summary

- Fix `canExecute` permission check: was using `EXECUTION.CREATE` but should use `FLOW.EXECUTE` to be consistent with the single-flow execute button
- Restore the `Actions` column header label
- Center action buttons within the cell
- Add right padding to both the cell and header so the content isn't stuck to the right edge

## Test plan

- [ ] With a user that has `FLOW.EXECUTE` permission, verify the execute button appears in the flows list
- [ ] Verify the "Actions" header label is visible
- [ ] Verify action buttons are centered and have proper spacing from the right edge

Closes https://github.com/kestra-io/kestra-ee/issues/8335.