### PR TITLE
[backport releases/v1.3.x] fix(core): apply forced plugin defaults in admin-first order

### DIFF
--- a/core/src/main/java/io/kestra/core/services/PluginDefaultService.java
+++ b/core/src/main/java/io/kestra/core/services/PluginDefaultService.java
@@ -21,7 +21,6 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.collect.Lists;
 
 import io.kestra.core.exceptions.FlowProcessingException;
 import io.kestra.core.exceptions.KestraRuntimeException;
@@ -455,11 +454,14 @@ public class PluginDefaultService {
             .stream()
             .collect(Collectors.groupingBy(PluginDefault::isForced, Collectors.toList()));
 
-        // non-forced
+        // Both maps keep the most-important-first order (flow, namespace, global) of getAllDefaults; the
+        // merge direction in defaults() decides which end of the list wins, no reversal needed:
+        // non-forced defaults only fill missing keys, so the first (closest) entry wins — flow beats namespace
+        // beats global.
         Map<String, List<PluginDefault>> defaults = pluginDefaultsToMap(allDefaultsGroup.getOrDefault(false, Collections.emptyList()));
 
-        // forced plugin default need to be reverse, lower win
-        Map<String, List<PluginDefault>> forced = pluginDefaultsToMap(Lists.reverse(allDefaultsGroup.getOrDefault(true, Collections.emptyList())));
+        // forced defaults stamp over the result, so the last (admin-most) entry wins — global beats namespace.
+        Map<String, List<PluginDefault>> forced = pluginDefaultsToMap(allDefaultsGroup.getOrDefault(true, Collections.emptyList()));
 
         Object pluginDefaults = flowAsMap.get(PLUGIN_DEFAULTS_FIELD);
         if (pluginDefaults != null) {
@@ -586,6 +588,14 @@ public class PluginDefaultService {
 
         Map<String, Object> result = (Map<String, Object>) plugin;
 
+        // The merge direction decides who wins (deepMerge: second argument wins), and it differs on purpose.
+        // 'matching' is ordered most-important-first (flow, namespace closest-first, global):
+        // - non-forced: deepMerge(values, result) — the accumulated result (the plugin's own values plus
+        //   already-applied defaults) stays on the winning side, so a default only fills still-missing keys
+        //   and the FIRST matching default wins: plugin > flow > namespace > global.
+        // - forced: deepMerge(result, values) — the default stamps over the accumulated result, so the LAST
+        //   matching default wins, i.e. the admin-most level: global > namespace > flow, so an enforced
+        //   higher-level default cannot be bypassed by a forced default at a lower level.
         for (PluginDefault pluginDefault : matching) {
             if (pluginDefault.isForced()) {
                 result = MapUtils.deepMerge(result, pluginDefault.getValues());

--- a/core/src/test/java/io/kestra/core/services/PluginDefaultServiceOverrideTest.java
+++ b/core/src/test/java/io/kestra/core/services/PluginDefaultServiceOverrideTest.java
@@ -1,9 +1,12 @@
 package io.kestra.core.services;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Stream;
 
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.parallel.ExecutionMode;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -15,6 +18,7 @@ import io.kestra.core.exceptions.FlowProcessingException;
 import io.kestra.core.junit.annotations.KestraTest;
 import io.kestra.core.models.flows.Flow;
 import io.kestra.core.models.flows.PluginDefault;
+import io.kestra.core.plugins.PluginRegistry;
 import io.kestra.core.services.PluginDefaultServiceTest.DefaultPrecedenceTester;
 import io.kestra.core.utils.TestsUtils;
 
@@ -30,6 +34,21 @@ class PluginDefaultServiceOverrideTest {
     @Inject
     private PluginDefaultService pluginDefaultService;
 
+    @Inject
+    private PluginRegistry pluginRegistry;
+
+    /**
+     * Tests flow-vs-global default precedence across the forced/non-forced matrix:
+     * <ol>
+     *   <li>Non-forced defaults follow author-first precedence: explicit task values win, then flow
+     *       defaults, then global defaults.</li>
+     *   <li>A flow forced default is honored on this branch and overrides explicit task values, but
+     *       only when no global forced default sets the same property.</li>
+     *   <li>Forced defaults follow admin-first precedence: a global (admin) forced default wins over a
+     *       flow forced default and over explicit task values (kestra-ee#8262) — the reverse of the
+     *       non-forced order.</li>
+     * </ol>
+     */
     @org.junit.jupiter.api.parallel.Execution(ExecutionMode.SAME_THREAD)
     @ParameterizedTest
     @MethodSource
@@ -75,12 +94,64 @@ class PluginDefaultServiceOverrideTest {
         assertThat(((DefaultPrecedenceTester) injected.getTasks().getFirst()).getPropBaz(), is(bazValue));
     }
 
+    /**
+     * Forced defaults follow admin-first precedence: when both a namespace-level (EE) and a global
+     * (configuration) forced default match the same plugin, the global one wins (kestra-ee#8262) —
+     * the reverse of non-forced precedence (flow beats namespace beats global). The namespace level
+     * does not exist in OSS, so it is simulated by overriding {@code getAllDefaults}, which is exactly
+     * the seam the EE service uses to contribute namespace defaults.
+     */
+    @Test
+    void globalForcedDefaultBeatsNamespaceForcedDefault() throws FlowProcessingException {
+        final DefaultPrecedenceTester task = DefaultPrecedenceTester.builder()
+            .id("test")
+            .type(DefaultPrecedenceTester.class.getName())
+            .propFoo("taskValue")
+            .build();
+
+        final PluginDefault namespaceForced = new PluginDefault(
+            DefaultPrecedenceTester.class.getName(), true, ImmutableMap.of(
+                "propFoo", "namespaceValue",
+                "propBar", "namespaceValue"
+            )
+        );
+        final PluginDefault globalForced = new PluginDefault(
+            DefaultPrecedenceTester.class.getName(), true, ImmutableMap.of("propFoo", "globalValue")
+        );
+
+        // defaults are ordered most-important-first: flow, then namespace, then global
+        final PluginDefaultService service = new PluginDefaultService() {
+            @Override
+            protected List<PluginDefault> getAllDefaults(String tenantId, String namespace, Map<String, Object> flow) {
+                List<PluginDefault> defaults = new ArrayList<>(getFlowDefaults(flow));
+                defaults.add(namespaceForced);
+                defaults.add(globalForced);
+                return defaults;
+            }
+        };
+        service.pluginRegistry = pluginRegistry;
+
+        var tenant = TestsUtils.randomTenant(PluginDefaultServiceOverrideTest.class.getSimpleName());
+        final Flow flow = Flow.builder()
+            .tenantId(tenant)
+            .tasks(Collections.singletonList(task))
+            .build();
+
+        final Flow injected = service.injectAllDefaults(flow, true);
+
+        DefaultPrecedenceTester result = (DefaultPrecedenceTester) injected.getTasks().getFirst();
+        // the global (admin) forced default wins over the namespace forced one
+        assertThat(result.getPropFoo(), is("globalValue"));
+        // non-overlapping namespace forced values still apply
+        assertThat(result.getPropBar(), is("namespaceValue"));
+    }
+
     private static Stream<Arguments> flowDefaultsOverrideGlobalDefaults() {
         return Stream.of(
             Arguments.of(false, false, "globalValue", "flowValue", "taskValue"),
             Arguments.of(false, true, "globalValue", "globalValue", "globalValue"),
             Arguments.of(true, false, "globalValue", "flowValue", "flowValue"),
-            Arguments.of(true, true, "globalValue", "flowValue", "flowValue")
+            Arguments.of(true, true, "globalValue", "globalValue", "globalValue")
         );
     }
 }

--- a/core/src/test/java/io/kestra/core/services/PluginDefaultServiceTest.java
+++ b/core/src/test/java/io/kestra/core/services/PluginDefaultServiceTest.java
@@ -220,8 +220,10 @@ class PluginDefaultServiceTest {
         var tenant = TestsUtils.randomTenant(PluginDefaultServiceTest.class.getSimpleName());
         FlowWithSource injected = pluginDefaultService.parseFlowWithAllDefaults(tenant, source, false);
 
-        // Then
-        assertThat(((DefaultTester) injected.getTasks().getFirst()).getSet(), is(2));
+        // Then — forced defaults follow admin-first precedence (kestra-ee#8262): they stamp over the
+        // accumulated result, so the LAST matching forced default wins. With two same-level forced
+        // defaults the later-declared one (set: 3) wins, not the earlier one.
+        assertThat(((DefaultTester) injected.getTasks().getFirst()).getSet(), is(3));
     }
 
     @Test

--- a/jmh-benchmarks/build.gradle
+++ b/jmh-benchmarks/build.gradle
@@ -2,6 +2,12 @@ plugins {
     id "me.champeau.jmh" version "0.7.3"
 }
 
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 configurations {
     tests
     implementation.extendsFrom(micronaut)

--- a/jmh-benchmarks/src/jmh/java/io/kestra/core/services/PluginDefaultServiceBenchmark.java
+++ b/jmh-benchmarks/src/jmh/java/io/kestra/core/services/PluginDefaultServiceBenchmark.java
@@ -1,0 +1,113 @@
+package io.kestra.core.services;
+
+import io.kestra.core.models.flows.FlowWithSource;
+import io.kestra.core.models.flows.GenericFlow;
+import io.kestra.core.plugins.DefaultPluginRegistry;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Benchmarks {@link PluginDefaultService#injectAllDefaults} on large flows to track the cost of
+ * type-matched plugin-default injection.
+ *
+ * <p>Each invocation re-parses the flow source (two Jackson passes bracket the injection), so the
+ * input flows are safely shared at trial level. The {@code noDefaults} scenario isolates the
+ * parse + traversal cost, and {@code typeDefaults} adds the cost of matching and merging
+ * type-matched defaults onto every task.
+ */
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@State(Scope.Thread)
+@Fork(1)
+@Warmup(iterations = 3, time = 2)
+@Measurement(iterations = 5, time = 2)
+public class PluginDefaultServiceBenchmark {
+    private static final int TASK_COUNT = 100;
+    private static final int DEFAULTS_PER_TYPE = 10;
+    private static final String LOG_TYPE = "io.kestra.plugin.core.log.Log";
+    private static final String RETURN_TYPE = "io.kestra.plugin.core.debug.Return";
+
+    private PluginDefaultService pluginDefaultService;
+
+    private GenericFlow noDefaults;
+    private GenericFlow typeDefaults;
+
+    @Setup(Level.Trial)
+    public void setup() {
+        pluginDefaultService = new PluginDefaultService(null, null, DefaultPluginRegistry.getOrCreate());
+
+        noDefaults = GenericFlow.fromYaml("main", flowSource(""));
+        typeDefaults = GenericFlow.fromYaml("main", flowSource(typeDefaultEntries()));
+    }
+
+    /**
+     * Baseline: parse + traversal cost with no defaults to inject.
+     */
+    @Benchmark
+    public FlowWithSource injectNoDefaults() throws Exception {
+        return pluginDefaultService.injectAllDefaults(noDefaults, false);
+    }
+
+    /**
+     * Type-matched defaults on every task.
+     */
+    @Benchmark
+    public FlowWithSource injectTypeDefaults() throws Exception {
+        return pluginDefaultService.injectAllDefaults(typeDefaults, false);
+    }
+
+    /**
+     * Builds a flow with {@link #TASK_COUNT} tasks, half Log and half Return.
+     */
+    private static String flowSource(String pluginDefaultEntries) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("id: plugin-default-benchmark\n");
+        sb.append("namespace: io.kestra.benchmark\n");
+        if (!pluginDefaultEntries.isEmpty()) {
+            sb.append("pluginDefaults:\n").append(pluginDefaultEntries);
+        }
+        sb.append("tasks:\n");
+
+        for (int i = 0; i < TASK_COUNT / 2; i++) {
+            appendTask(sb, "log-task-" + i, LOG_TYPE, "message: hello " + i);
+            appendTask(sb, "return-task-" + i, RETURN_TYPE, "format: value " + i);
+        }
+
+        return sb.toString();
+    }
+
+    private static void appendTask(StringBuilder sb, String id, String type, String property) {
+        sb.append("  - id: ").append(id).append('\n');
+        sb.append("    type: ").append(type).append('\n');
+        sb.append("    ").append(property).append('\n');
+    }
+
+    /** {@link #DEFAULTS_PER_TYPE} type-matched defaults per task type. */
+    private static String typeDefaultEntries() {
+        StringBuilder sb = new StringBuilder();
+        appendDefaultEntries(sb, LOG_TYPE);
+        appendDefaultEntries(sb, RETURN_TYPE);
+        return sb.toString();
+    }
+
+    // note: no 'forced' entries — the flag is ignored (and warned about) at flow level
+    private static void appendDefaultEntries(StringBuilder sb, String type) {
+        for (int i = 0; i < DEFAULTS_PER_TYPE; i++) {
+            sb.append("  - type: ").append(type).append('\n');
+            sb.append("    values:\n");
+            sb.append("      logLevel: DEBUG\n");
+            sb.append("      description: type-default-").append(i).append('\n');
+        }
+    }
+}


### PR DESCRIPTION
Backport of:
- [kestra-io/kestra#16544](https://github.com/kestra-io/kestra/pull/16544) — fix(core): apply forced plugin defaults in admin-first order (cherry-picked from `18063e28c8`)

Fixes [kestra-io/kestra-ee#8262](https://github.com/kestra-io/kestra-ee/issues/8262) on the `releases/v1.3.x` branch.

### What this fixes

Forced (admin-enforced) plugin defaults were applied closest-level-first, so a namespace-level forced default could override a global one and a child-namespace forced default could override its parent's. Enforcement must work the other way: the lowest (admin) level wins — the reverse of non-forced precedence (flow beats namespace beats global). The fix removes the `Lists.reverse` on the forced list so forced defaults stamp over the accumulated result (last matching forced default wins = global > namespace > flow).

### Divergence from `develop` — read before reviewing

On `develop`, flow-level forced defaults are stripped (`getFlowDefaults` removes the forced flag for flow entries — [kestra-io/kestra#7109](https://github.com/kestra-io/kestra/pull/7109)). **`releases/v1.3.x` does NOT have #7109**, so it retains and honors flow-level forced defaults.

Because cross-level admin-first ordering and same-level "last-listed wins" share one code path (the merge direction), removing `Lists.reverse` on v1.3.x **additionally** reorders which of two same-level flow forced defaults wins: previously first-listed won (artifact of `Lists.reverse` composing with last-wins merge), now last-listed wins. This is the canonical post-fix behavior, not a regression — there is no user contract that "first-listed forced wins".

Consequently two tests were adapted versus the upstream commit (whose test file targeted the post-#7109 develop tree):
- `PluginDefaultServiceOverrideTest` case `[4]` — flow+global both forced: expected `flowValue` → `globalValue` (global admin forced wins).
- `PluginDefaultServiceTest.shouldInjectForcedDefaultsGivenForcedTrue` — two same-level forced defaults: expected `set: 2` → `set: 3` (last-listed forced wins).

#7109 is **not** part of this backport and must not be backported.

Cherry-picked with `-x`.
