### PR TITLE
fix(chart): disable tooltip confinement

### DIFF
--- a/ui/packages/design-system/src/components/Charts/KsEchart.vue
+++ b/ui/packages/design-system/src/components/Charts/KsEchart.vue
@@ -140,6 +140,7 @@
                 tooltip: {
                     trigger: "axis",
                     ...userTooltip,
+                    confine: false,
                     // Move the native tooltip offscreen so ECharts still computes
                     // the axis-pointer snap and calls our formatter, but nothing
                     // is visible to the user.


### PR DESCRIPTION
closes https://github.com/kestra-io/kestra-ee/issues/8338

In TooltipType.EXTERNAL mode, the native ECharts tooltip is pushed offscreen, but confine: true clamped it back into the chart, leaving an empty box in the top-left on hover. Forcing confine: false fixes it.