### PR TITLE
test(storage): add explicit test coverage for GHSA-h7c7-3mfc-m7pj forward-slash path traversal

### DIFF
--- a/core/src/test/java/io/kestra/core/storages/NamespaceFileTest.java
+++ b/core/src/test/java/io/kestra/core/storages/NamespaceFileTest.java
@@ -157,6 +157,16 @@ class NamespaceFileTest {
     }
 
     @Test
+    void shouldThrowOnForwardSlashPathTraversal() {
+        // GHSA-h7c7-3mfc-m7pj: on a Windows JVM Path.of("/x/../../../foo.txt").toString()
+        // produces "\x\..\..\..\foo.txt"; toLogicalPath() converts backslashes back to "/",
+        // so the guard must catch the forward-slash form regardless of host OS.
+        Assertions.assertThrows(IllegalArgumentException.class, () -> NamespaceFile.normalize(Path.of("/x/../../../escaped.txt")));
+        Assertions.assertThrows(IllegalArgumentException.class, () -> NamespaceFile.normalize(Path.of("x/../../../escaped.txt")));
+        Assertions.assertThrows(IllegalArgumentException.class, () -> NamespaceFile.normalize(Path.of("/x/y/../../..")));
+    }
+
+    @Test
     void shouldAllowLegitimatePathsWithSingleDotAndMultiLevelDirs() {
         assertThat(toLogicalPath(NamespaceFile.normalize(Path.of("/foo/./bar")))).isEqualTo("/foo/bar");
         assertThat(toLogicalPath(NamespaceFile.normalize(Path.of("/foo/bar")))).isEqualTo("/foo/bar");

--- a/core/src/test/java/io/kestra/core/utils/FileUtilsTest.java
+++ b/core/src/test/java/io/kestra/core/utils/FileUtilsTest.java
@@ -44,6 +44,11 @@ class FileUtilsTest {
         "kestra:///ns/flow/exec/abc%5C%2E%2E%5C%2E%2E%5Cetc%5Cpasswd",
         // mixed separators
         "kestra:///ns/flow/exec/abc/..%5C..%5Cetc%5Cpasswd",
+        // GHSA-h7c7-3mfc-m7pj: on a Windows JVM File.separator is '\', so the old guard
+        // checked for "..\" and "\.." and never matched forward-slash HTTP URI payloads.
+        // These must be rejected regardless of the host OS.
+        "kestra:///ns/flow/exec/x/../../../escaped.txt",
+        "kestra:///ns/flow/exec/x%2F..%2F..%2F..%2Fescaped.txt",
     })
     void isParentTraversal_true(String path) {
         assertThat(FileUtils.isParentTraversal(URI.create(path))).isTrue();
@@ -59,6 +64,13 @@ class FileUtilsTest {
         "..\\" + "etc\\passwd",
         "ns\\exec\\..\\.." + "\\etc\\passwd",
         "ns/exec/abc\\..\\..\\.." + "\\etc\\passwd",
+        // GHSA-h7c7-3mfc-m7pj: forward-slash payloads that bypass the old Windows guard
+        // (which checked "..\\" and "\\.." from File.separator and never matched "/" paths).
+        // These represent the decoded form of HTTP query-param paths, as they arrive after
+        // URI.getPath() decodes percent-encoding.
+        "/x/../../../escaped.txt",
+        "x/../../../escaped.txt",
+        "/x/y/../../..",
     })
     void isParentTraversalString_true(String path) {
         assertThat(FileUtils.isParentTraversal(path)).isTrue();

--- a/webserver/src/test/java/io/kestra/webserver/controllers/api/NamespaceFileControllerTest.java
+++ b/webserver/src/test/java/io/kestra/webserver/controllers/api/NamespaceFileControllerTest.java
@@ -386,6 +386,37 @@ class NamespaceFileControllerTest {
             client.toBlocking().exchange(HttpRequest.PUT("/api/v1/main/namespaces/" + namespace + "/files?from=/foo/../../test.txt&to=/bar", null)));
     }
 
+    @Test
+    void shouldRejectForwardSlashPathTraversalOnWriteAndDelete() throws IOException, URISyntaxException {
+        // GHSA-h7c7-3mfc-m7pj: the old guard used File.separator ('\' on Windows) to build
+        // its check strings, so forward-slash HTTP URI payloads like /x/../../../foo.txt were
+        // never matched on a Windows JVM, allowing arbitrary file write and delete.
+        // Verify that POST (write) and DELETE are both rejected with the fixed guard.
+        String namespace = TestsUtils.randomNamespace();
+        Namespace namespaceStorage = namespaceFactory.of(TENANT_ID, namespace, storageInterface);
+        namespaceStorage.putFile(Path.of("/safe.txt"), new ByteArrayInputStream("safe".getBytes()));
+
+        MultipartBody body = MultipartBody.builder()
+            .addPart("fileContent", "x.txt", "OWNED via path traversal".getBytes())
+            .build();
+
+        // Write primitive: POST with a forward-slash traversal path must be rejected
+        Assertions.assertThrows(HttpClientResponseException.class, () ->
+            client.toBlocking().exchange(
+                HttpRequest.POST("/api/v1/main/namespaces/" + namespace + "/files?path=/x/../../../escaped.txt", body)
+                    .contentType(MediaType.MULTIPART_FORM_DATA_TYPE)
+            ));
+
+        // Delete primitive: DELETE with a forward-slash traversal path must be rejected
+        Assertions.assertThrows(HttpClientResponseException.class, () ->
+            client.toBlocking().exchange(
+                HttpRequest.DELETE("/api/v1/main/namespaces/" + namespace + "/files?path=/x/../../../safe.txt", null)
+            ));
+
+        // The legitimate file must be unaffected
+        assertThat(namespaceStorage.exists(Path.of("/safe.txt"))).isTrue();
+    }
+
     private void assertForbiddenErrorThrown(Executable executable) {
         HttpClientResponseException httpClientResponseException = Assertions.assertThrows(HttpClientResponseException.class, executable);
         assertThat(httpClientResponseException.getMessage()).startsWith("Illegal argument: Forbidden path: ");


### PR DESCRIPTION
## Summary

- Adds dedicated test cases for [GHSA-h7c7-3mfc-m7pj](https://github.com/kestra-io/kestra/security/advisories/GHSA-h7c7-3mfc-m7pj) — the Windows-specific path traversal where `File.separator` (`\` on Windows) was used in the guard, causing forward-slash HTTP URI payloads like `/x/../../../foo.txt` to bypass it entirely
- The fix was shipped in commit `b41d0ceeeb` as part of GHSA-qw4v-6w32-xx9h, but carried no test cases for this specific forward-slash / Windows-JVM attack surface
- The reporter correctly pointed out the gap; this PR closes it

## What changed

- **`FileUtilsTest`** — adds forward-slash traversal cases (`/x/../../../escaped.txt`, etc.) to both the `URI` and `String` parameterized tests, labeled `GHSA-h7c7-3mfc-m7pj`
- **`NamespaceFileTest`** — adds `shouldThrowOnForwardSlashPathTraversal()` asserting that `NamespaceFile.normalize()` rejects these payloads; the `toLogicalPath()` + `FileUtils.isParentTraversal()` chain normalizes `\`→`/` regardless of host OS, so forward-slash `/../` segments are always caught
- **`NamespaceFileControllerTest`** — adds `shouldRejectForwardSlashPathTraversalOnWriteAndDelete()` exercising the two primitives the advisory demonstrated end-to-end: `POST .../files?path=/x/../../../escaped.txt` (write) and `DELETE .../files?path=/x/../../../safe.txt` (delete), both over HTTP

## Test plan

- [x] `FileUtilsTest` — 29 tests, 0 failures
- [x] `NamespaceFileTest` — 17 tests, 0 failures
- [x] `NamespaceFileControllerTest#shouldRejectForwardSlashPathTraversalOnWriteAndDelete` — passes