### PR TITLE
fix(ui): add darkbkg variant to KsButton with transparent bg, white b…

### DIFF
--- a/ui/packages/design-system/src/components/Basic/KsButton/KsButton.vue
+++ b/ui/packages/design-system/src/components/Basic/KsButton/KsButton.vue
@@ -153,6 +153,19 @@
                 border-color: var(--ks-btn-secondary-border-inactive);
                 color: var(--ks-text-inactive);
             }
+            &.is-darkbkg {
+                --kel-button-bg-color: transparent;
+                --kel-button-border-color: var(--ks-text-primary);
+                --kel-button-text-color: var(--ks-text-primary);
+
+                --kel-button-hover-bg-color: var(--ks-text-primary);
+                --kel-button-hover-border-color: var(--ks-text-primary);
+                --kel-button-hover-text-color: var(--ks-bg-base);
+
+                --kel-button-active-bg-color: var(--ks-text-primary);
+                --kel-button-active-border-color: var(--ks-text-primary);
+                --kel-button-active-text-color: var(--ks-bg-base);
+            }
 
 
             &.kel-button--primary {


### PR DESCRIPTION
### ✨ Description

What does this PR change?  
Adds a is-darkbkg CSS modifier class to KsButton for rendering the secondary button correctly on dark backgrounds.
Default state: transparent background with white border and white text. Hover state: inverts to white background with dark text — matching the Button_Secondary-darkbkg Figma spec.

### 🔗 Related Issue
Closes https://github.com/kestra-io/docs/issues/4498

### 🎨 Frontend Checklist

_If this PR does not include any frontend changes, delete this entire section._

- [ ] Code builds without errors (`npm run build`)
- [ ] All existing E2E tests pass (`npm run test:e2e`)
- [ ] Screenshots or video recordings attached showing the `UI` changes
