### PR TITLE
fix(build): handle absent plugins/ dir in Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,9 +7,11 @@ ARG PYTHON_LIBRARIES=""
 ENV PATH="/app/.venv/bin:$PATH"
 
 COPY --chown=kestra:kestra docker /
-COPY --chown=kestra:kestra plugins/ /app/plugins/
 
-RUN if [ -n "${APT_PACKAGES}" ]; then \
+RUN --mount=type=bind,target=/mnt/context \
+    mkdir -p /app/plugins && \
+    { cp -r /mnt/context/plugins/. /app/plugins/ 2>/dev/null || true; }; \
+    if [ -n "${APT_PACKAGES}" ]; then \
         apt-get update -y && \
         apt-get install -y --no-install-recommends ${APT_PACKAGES} && \
         apt-get clean && \


### PR DESCRIPTION
## Problem

The new `Dockerfile` added in #16568 uses `COPY plugins/ /app/plugins/` which requires the `plugins/` directory to exist in the build context. This breaks e2e and local builds (`make build-docker`) where no plugins are pre-downloaded:

```
#8 ERROR: failed to calculate checksum of ref ...: "/plugins": not found
```

## Fix

Replace `COPY plugins/ /app/plugins/` with a `RUN --mount=type=bind` that mounts the entire build context and copies plugins only if the directory exists:

```dockerfile
RUN --mount=type=bind,target=/mnt/context \
    mkdir -p /app/plugins && \
    { cp -r /mnt/context/plugins/. /app/plugins/ 2>/dev/null || true; }; \
```

- When `plugins/` is absent (e2e, local builds): `cp` fails silently, `/app/plugins/` stays empty
- When `plugins/` is present (CI kestractl download): JARs are copied in correctly
- **No layer size regression**: `--mount=type=bind` is not persisted to image layers; the `cp` + `chown` happen in the same RUN so no duplication