### PR TITLE
ci: dont release helm charts when releasing an RC

### DIFF
--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -39,7 +39,7 @@ jobs:
   helm-release:
     name: Helm release
     needs: publish-docker
-    if: startsWith(github.ref, 'refs/tags/v')
+    if: startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, '-rc')
     permissions:
       contents: read
       id-token: write


### PR DESCRIPTION
- fixes https://github.com/kestra-io/kestra-ee/issues/8382
