### PR TITLE
fix(namespaces): clear blueprint detail when switching tabs

### DIFF
--- a/ui/src/components/Tabs.vue
+++ b/ui/src/components/Tabs.vue
@@ -142,6 +142,10 @@
         {deep: true},
     )
 
+    watch(activeTab, () => {
+        selectedBlueprintId.value = undefined
+    })
+
     onMounted(syncStore)
     onBeforeUnmount(() => routeTabsStore.clearTabsIfOwner(tabsOwnerId))
 


### PR DESCRIPTION
## Summary

- When a blueprint was opened in the Namespace > Blueprints tab, switching to any other tab (Overview, Edit, Executions, etc.) left the blueprint detail view visible because `selectedBlueprintId` was never cleared on tab change.
- Added a watcher on `activeTab` in `Tabs.vue` that resets `selectedBlueprintId` to `undefined` whenever the active tab changes.

## Test plan

- [ ] Open a namespace, go to Blueprints tab, click a blueprint to open its detail view
- [ ] Click Overview, Edit, Executions, or any other tab — confirm the tab content switches correctly and the blueprint detail is dismissed
- [ ] Confirm navigating back to Blueprints tab shows the blueprint list (not the previously open detail)

Closes https://github.com/kestra-io/kestra-ee/issues/8371.