### PR TITLE
ci: add JRE-21 variants and Python pre-install to kestra-base images

### DIFF
--- a/.github/workflows/global-push-base-image.yml
+++ b/.github/workflows/global-push-base-image.yml
@@ -1,7 +1,7 @@
 name: Build and Push Base Image
 
-# This workflow builds and pushes kestra-base:latest-no-plugins — a lightweight image
-# with just the JRE and uv pre-installed. Used as the foundation for Kestra Docker builds.
+# Builds and pushes kestra-base image variants to GHCR.
+# Four variants: JRE 21/25 × no-python/python+kestra-pip.
 
 on:
   schedule:
@@ -21,8 +21,37 @@ on:
 
 jobs:
   build-and-push:
-    name: Build and Push kestra-base
+    name: Build and Push kestra-base (${{ matrix.variant.cache-tag }})
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        variant:
+          - cache-tag: latest-no-plugins
+            tags: |
+              ghcr.io/kestra-io/kestra-base:latest-no-plugins
+              ghcr.io/kestra-io/kestra-base:latest-jre25-no-plugins
+            jre: "25"
+            with-python: "false"
+            description: "Kestra base image (no plugins) — JRE 25 + uv pre-installed"
+          - cache-tag: latest
+            tags: |
+              ghcr.io/kestra-io/kestra-base:latest
+              ghcr.io/kestra-io/kestra-base:latest-jre25
+            jre: "25"
+            with-python: "true"
+            description: "Kestra base image — JRE 25 + uv + Python + kestra pip pre-installed"
+          - cache-tag: latest-jre21-no-plugins
+            tags: |
+              ghcr.io/kestra-io/kestra-base:latest-jre21-no-plugins
+            jre: "21"
+            with-python: "false"
+            description: "Kestra base image (no plugins) — JRE 21 + uv pre-installed"
+          - cache-tag: latest-jre21
+            tags: |
+              ghcr.io/kestra-io/kestra-base:latest-jre21
+            jre: "21"
+            with-python: "true"
+            description: "Kestra base image — JRE 21 + uv + Python + kestra pip pre-installed"
     steps:
       - uses: actions/checkout@v6
 
@@ -47,11 +76,11 @@ jobs:
           images: ghcr.io/kestra-io/kestra-base
           labels: |
             org.opencontainers.image.title=kestra-base
-            org.opencontainers.image.description=Kestra base image (no plugins) — JRE + uv pre-installed
+            org.opencontainers.image.description=${{ matrix.variant.description }}
             org.opencontainers.image.vendor=Kestra Technologies
           annotations: |
             org.opencontainers.image.title=kestra-base
-            org.opencontainers.image.description=Kestra base image (no plugins) — JRE + uv pre-installed
+            org.opencontainers.image.description=${{ matrix.variant.description }}
             org.opencontainers.image.vendor=Kestra Technologies
 
       - name: Build and push
@@ -61,12 +90,14 @@ jobs:
           file: Dockerfile.base
           platforms: linux/amd64,linux/arm64
           push: ${{ inputs.dry-run != true }}
-          tags: ghcr.io/kestra-io/kestra-base:latest-no-plugins
+          tags: ${{ matrix.variant.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           annotations: ${{ steps.meta.outputs.annotations }}
           build-args: |
             UV_VERSION=${{ inputs.uv-version || '0.6.17' }}
-          cache-from: type=registry,ref=ghcr.io/kestra-io/kestra-base:latest-no-plugins
+            JRE_VERSION=${{ matrix.variant.jre }}
+            WITH_PYTHON=${{ matrix.variant.with-python }}
+          cache-from: type=registry,ref=ghcr.io/kestra-io/kestra-base:${{ matrix.variant.cache-tag }}
           cache-to: type=inline
 
       - name: Slack - Notification

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -1,6 +1,8 @@
-FROM eclipse-temurin:25-jre
+ARG JRE_VERSION="25"
+FROM eclipse-temurin:${JRE_VERSION}-jre
 
 ARG UV_VERSION="0.6.17"
+ARG WITH_PYTHON="false"
 
 RUN groupadd kestra && \
     useradd -m -g kestra kestra
@@ -9,10 +11,19 @@ WORKDIR /app
 
 RUN apt-get update -y && \
     apt-get upgrade -y && \
-    apt-get install -y --no-install-recommends curl && \
+    apt-get install -y --no-install-recommends curl jattach && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* /var/tmp/* /tmp/*
 
 RUN curl -LsSf "https://astral.sh/uv/${UV_VERSION}/install.sh" | sh && \
     mv /root/.local/bin/uv /bin && \
     mv /root/.local/bin/uvx /bin
+
+RUN if [ "$WITH_PYTHON" = "true" ]; then \
+        apt-get update -y && \
+        apt-get install -y --no-install-recommends python3 python-is-python3 python3-pip && \
+        apt-get clean && \
+        rm -rf /var/lib/apt/lists/* && \
+        uv venv /app/.venv && \
+        PURE_PYTHON=1 uv pip install --python /app/.venv/bin/python kestra; \
+    fi


### PR DESCRIPTION
## Summary

- **`Dockerfile.base`** — adds `JRE_VERSION` ARG (default `25`) so both JRE 25 and JRE 21 base variants are built from the same file; adds `WITH_PYTHON` ARG (default `false`) that installs `python3` + `kestra` pip into `/app/.venv` when true; moves `jattach` into the base (always installed)
- **`global-push-base-image.yml`** — replaces the single build job with a 4-variant matrix:

  | Tag | JRE | Python + kestra pip |
  |---|---|---|
  | `latest-no-plugins`, `latest-jre25-no-plugins` | 25 | No |
  | `latest`, `latest-jre25` | 25 | Yes |
  | `latest-jre21-no-plugins` | 21 | No |
  | `latest-jre21` | 21 | Yes |

- **`Dockerfile`** — removes `PYTHON_LIBRARIES` ARG and install step; Python and `kestra` pip are now pre-baked into the `latest` / `latest-jre21` base images, eliminating the per-build `uv pip install kestra` step

## Why

Pre-baking Python into the base image eliminates repeated `apt-get install python3` + `uv pip install kestra` on every Docker publish run (~2–3 min saved per matrix leg). JRE-21 variants allow callers to select the JRE at publish time via `java-version` input.

## Backward compatibility

Old release branches (`v0.22`–`v1.3`) use their own `Dockerfile` from their branch history — they are not affected by the `Dockerfile` change here. The `PYTHON_LIBRARIES` build-arg being unknown to this new `Dockerfile` is silently ignored by Docker.

## Test plan

- [ ] Manually trigger `global-push-base-image` with `dry-run: true` — verify all 4 matrix jobs complete without errors
- [ ] Non-dry-run: `docker run ghcr.io/kestra-io/kestra-base:latest python3 -c "import kestra"` → works
- [ ] `docker run ghcr.io/kestra-io/kestra-base:latest-jre21 java -version` → JRE 21
- [ ] `docker run ghcr.io/kestra-io/kestra-base:latest-no-plugins python3` → command not found
- [ ] Develop Docker publish CI builds successfully using `kestra-base:latest-no-plugins` as base