### PR TITLE
fix(design-system): add noGutter prop to KsDataTable

### DIFF
--- a/ui/packages/design-system/src/components/Data/KsDataTable/KsDataTable.vue
+++ b/ui/packages/design-system/src/components/Data/KsDataTable/KsDataTable.vue
@@ -3,7 +3,7 @@
         <slot name="empty" />
     </template>
 
-    <div class="ks-data-table-wrapper" :class="{'no-pagination-gutter': noPaginationGutter}" v-else>
+    <div class="ks-data-table-wrapper" :class="{'no-pagination-gutter': noPaginationGutter, 'no-gutter': noGutter}" v-else>
         <nav v-if="hasNavBar" class="ks-data-table-navbar mb-3">
             <slot name="navbar" />
         </nav>
@@ -101,6 +101,7 @@
         selectionMapper?: (element: any) => any
         forceExpandedRowKeys?: string[]
         noPaginationGutter?: boolean
+        noGutter?: boolean
     }>(), {
         data: () => [],
         total: 0,
@@ -116,6 +117,7 @@
         selectionMapper: undefined,
         forceExpandedRowKeys: () => [],
         noPaginationGutter: false,
+        noGutter: false,
     })
 
     export interface SortItem {
@@ -425,6 +427,14 @@
 
         &.no-pagination-gutter .kel-pagination {
             padding-inline: 0;
+        }
+
+        &.no-gutter {
+            > .ks-data-table-navbar,
+            .ks-data-table-top,
+            .kel-pagination {
+                padding-inline: 0;
+            }
         }
 
         .kel-checkbox__inner {


### PR DESCRIPTION
## Summary
- Adds a `noGutter` boolean prop to `KsDataTable` that zeroes the `padding-inline` on the filter toolbar (`.ks-data-table-top`), navbar, and pagination sections
- Follows the existing `noPaginationGutter` pattern
- Allows embedding `KsDataTable` inside containers that already manage their own padding (e.g. `PanelContainer`) without the filter bar appearing shifted relative to surrounding headings

Companion EE PR: https://github.com/kestra-io/kestra-ee/pull/8384.

Related to https://github.com/kestra-io/kestra-ee/issues/8370.

## Test plan
- [ ] Verify filter toolbar, navbar, and pagination have no left/right padding when `noGutter` is set
- [ ] Verify default behavior (24px gutter) is unchanged when `noGutter` is not set