### PR TITLE
ci(build): drop APT_PACKAGES and PYTHON_LIBRARIES from OSS Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,23 +1,13 @@
 ARG BASE_IMAGE="ghcr.io/kestra-io/kestra-base:latest-no-plugins"
 FROM ${BASE_IMAGE}
 
-ARG APT_PACKAGES=""
-ARG PYTHON_LIBRARIES=""
-
 ENV PATH="/app/.venv/bin:$PATH"
 
 COPY --chown=kestra:kestra docker /
 
 RUN --mount=type=bind,target=/mnt/context \
     mkdir -p /app/plugins && \
-    { cp -r /mnt/context/plugins/. /app/plugins/ 2>/dev/null || true; }; \
-    if [ -n "${APT_PACKAGES}" ]; then \
-        apt-get update -y && \
-        apt-get install -y --no-install-recommends ${APT_PACKAGES} && \
-        apt-get clean && \
-        rm -rf /var/lib/apt/lists/*; \
-    fi && \
-    if [ -n "${PYTHON_LIBRARIES}" ]; then uv venv /app/.venv && PURE_PYTHON=1 uv pip install --python /app/.venv/bin/python ${PYTHON_LIBRARIES}; fi && \
+    { cp -r /mnt/context/plugins/. /app/plugins/ 2>/dev/null || true; } && \
     chown -R kestra:kestra /app
 
 USER kestra


### PR DESCRIPTION
## Summary

Removes `APT_PACKAGES` and `PYTHON_LIBRARIES` ARGs and their associated install steps from `Dockerfile`.

Both are now pre-baked into `kestra-base:latest` and `kestra-base:latest-jre21`:
- `jattach` — always installed in the base
- `python3` + `kestra` pip — installed when `WITH_PYTHON=true` (the `latest` / `latest-jre21` variants)

The `Dockerfile` is now minimal — no runtime apt or pip steps needed.

## Merge order

> ⚠️ **Must merge after** kestra#16613 **and** after `global-push-base-image` has been manually triggered to publish the new variants with Python pre-installed.

1. Merge kestra#16613 — adds JRE_VERSION + WITH_PYTHON to Dockerfile.base, expands workflow to 4-variant matrix
2. Manually trigger `global-push-base-image` to publish `latest` / `latest-jre21` with Python
3. Merge this PR
4. Update `kestra-oss-publish-docker.yml` to pass `BASE_IMAGE=kestra-base:latest` for the full image

## Test plan

- [ ] Develop Docker publish CI still builds correctly after merge
- [ ] `docker run kestra/kestra:develop python3 -c "import kestra"` → works (Python from base)