### PR TITLE
fix(cli): fail-fast on startup errors instead of hanging

### DIFF
--- a/cli/src/main/java/io/kestra/cli/Kestra.java
+++ b/cli/src/main/java/io/kestra/cli/Kestra.java
@@ -96,8 +96,18 @@ public class Kestra implements Callable<Integer> {
             System.err.println("Could not initialize picocli CommandLine, err: " + e.getMessage());
             e.printStackTrace();
             exitCode = 1;
+        } catch (Exception e) {
+            // A failure while starting the application context (e.g. an invalid configuration
+            // triggering a BeanInstantiationException during eager bean init) escapes here.
+            // Catch it so the JVM fails fast with a non-zero exit code instead of hanging: the
+            // main thread would otherwise die while non-daemon threads from the partially-started
+            // context keep the process alive forever.
+            System.err.println("Could not start Kestra, err: " + e.getMessage());
+            e.printStackTrace();
+            exitCode = 1;
+        } finally {
+            applicationContext.close();
         }
-        applicationContext.close();
 
         // exit code
         return exitCode;


### PR DESCRIPTION
Startup bean-init exceptions (e.g. invalid worker discovery config) escaped Kestra.execute() since only CommandLine.InitializationException was caught, so main() died before System.exit() while non-daemon threads kept the JVM alive. Catch any startup exception, return a non-zero code, and close the context in a finally block.