### PR TITLE
feat(flows): surface copyable webhook URL as a Monaco editor artifact

### DIFF
--- a/ui/packages/design-system/src/components/Form/KsEditor.vue
+++ b/ui/packages/design-system/src/components/Form/KsEditor.vue
@@ -1533,6 +1533,11 @@
         color: var(--ks-text-inactive) !important;
     }
 
+    .monaco-editor .codelens-decoration > a:hover,
+    .monaco-editor .codelens-decoration > a:hover .codicon {
+        color: var(--ks-text-link) !important;
+    }
+
     .ks-monaco-editor {
         position: absolute;
         width: 100%;

--- a/ui/packages/topology/src/utils/flowYamlUtils.ts
+++ b/ui/packages/topology/src/utils/flowYamlUtils.ts
@@ -792,6 +792,31 @@ export function extractFieldFromMaps<T extends string>(
     return maps
 }
 
+export interface TypedBlock {
+    type: string;
+    value: Record<string, any>;
+    range: Range;
+    path: string;
+}
+
+export function extractTypedBlocks(source: string): TypedBlock[] {
+    const yamlDoc = parseDocument(source) as any
+    const blocks: TypedBlock[] = []
+    visit(yamlDoc, {
+        Map(_, map: any, parents) {
+            const type = map.items?.find((item: any) => item?.key?.value === "type")?.value?.value
+            if (typeof type === "string" && map.range) {
+                const path = parents
+                    .filter((parent) => isPair(parent))
+                    .map((parent: any) => parent?.key?.value)
+                    .join(".")
+                blocks.push({type, value: map.toJSON(), range: map.range, path})
+            }
+        },
+    })
+    return blocks
+}
+
 function extractAllTypes(source: string, validTypes: string[] = []){
     return extractFieldFromMaps(source, "type", () => true, (value) =>
         validTypes.some((t) => t === value),

--- a/ui/packages/topology/src/utils/flowYamlUtils.ts
+++ b/ui/packages/topology/src/utils/flowYamlUtils.ts
@@ -800,6 +800,16 @@ export interface TypedBlock {
 }
 
 export function extractTypedBlocks(source: string): TypedBlock[] {
+    return extractTypedBlocksWithMeta(source).blocks
+}
+
+export interface FlowSourceData {
+    blocks: TypedBlock[];
+    namespace?: string;
+    id?: string;
+}
+
+export function extractTypedBlocksWithMeta(source: string): FlowSourceData {
     const yamlDoc = parseDocument(source) as any
     const blocks: TypedBlock[] = []
     visit(yamlDoc, {
@@ -814,7 +824,14 @@ export function extractTypedBlocks(source: string): TypedBlock[] {
             }
         },
     })
-    return blocks
+    const root = yamlDoc.contents
+    const namespace = isMap(root) ? root.get("namespace") : undefined
+    const id = isMap(root) ? root.get("id") : undefined
+    return {
+        blocks,
+        namespace: typeof namespace === "string" ? namespace : undefined,
+        id: typeof id === "string" ? id : undefined,
+    }
 }
 
 function extractAllTypes(source: string, validTypes: string[] = []){

--- a/ui/packages/topology/tests/units/utils/flowYamlUtils.test.ts
+++ b/ui/packages/topology/tests/units/utils/flowYamlUtils.test.ts
@@ -1448,3 +1448,59 @@ describe("stringify with preserveCronQuotes", () => {
         expect(result).toContain("cron: \"0 0 * * *\"")
     })
 })
+describe("extractTypedBlocks", () => {
+    test("returns every block carrying a type with its range", () => {
+        const source = `id: my-flow
+namespace: company.team
+tasks:
+  - id: hello
+    type: io.kestra.plugin.core.log.Log
+    message: Hello World
+triggers:
+  - id: webhook
+    type: io.kestra.plugin.core.trigger.Webhook
+    key: admin1234
+`
+
+        const blocks = YamlUtils.extractTypedBlocks(source)
+
+        const types = blocks.map((block) => block.type)
+        expect(types).toContain("io.kestra.plugin.core.log.Log")
+        expect(types).toContain("io.kestra.plugin.core.trigger.Webhook")
+
+        const webhook = blocks.find((block) => block.type === "io.kestra.plugin.core.trigger.Webhook")
+        expect(webhook?.value.id).toBe("webhook")
+        expect(webhook?.value.key).toBe("admin1234")
+        expect(webhook?.range[0]).toBeTypeOf("number")
+        expect(webhook?.path).toBe("triggers")
+
+        const log = blocks.find((block) => block.type === "io.kestra.plugin.core.log.Log")
+        expect(log?.path).toBe("tasks")
+    })
+
+    test("captures the parent section path so artifacts can scope to it", () => {
+        const source = `id: my-flow
+namespace: company.team
+pluginDefaults:
+  - type: io.kestra.plugin.core.trigger.Webhook
+    values:
+      key: shared
+triggers:
+  - id: webhook
+    type: io.kestra.plugin.core.trigger.Webhook
+    key: admin1234
+`
+
+        const webhookBlocks = YamlUtils.extractTypedBlocks(source)
+            .filter((block) => block.type === "io.kestra.plugin.core.trigger.Webhook")
+
+        expect(webhookBlocks.map((block) => block.path).sort()).toEqual(["pluginDefaults", "triggers"])
+    })
+
+    test("ignores blocks without a type", () => {
+        const source = `id: my-flow
+namespace: company.team
+`
+        expect(YamlUtils.extractTypedBlocks(source)).toEqual([])
+    })
+})

--- a/ui/packages/topology/tests/units/utils/flowYamlUtils.test.ts
+++ b/ui/packages/topology/tests/units/utils/flowYamlUtils.test.ts
@@ -1504,3 +1504,35 @@ namespace: company.team
         expect(YamlUtils.extractTypedBlocks(source)).toEqual([])
     })
 })
+
+describe("extractTypedBlocksWithMeta", () => {
+    test("returns blocks alongside top-level namespace and id in a single parse", () => {
+        const source = `id: my-flow
+namespace: company.team
+triggers:
+  - id: webhook
+    type: io.kestra.plugin.core.trigger.Webhook
+    key: admin1234
+`
+
+        const {blocks, namespace, id} = YamlUtils.extractTypedBlocksWithMeta(source)
+
+        expect(namespace).toBe("company.team")
+        expect(id).toBe("my-flow")
+        expect(blocks).toHaveLength(1)
+        expect(blocks[0].type).toBe("io.kestra.plugin.core.trigger.Webhook")
+    })
+
+    test("returns undefined namespace and id when not present in the source", () => {
+        const source = `triggers:
+  - id: webhook
+    type: io.kestra.plugin.core.trigger.Webhook
+    key: admin1234
+`
+
+        const {namespace, id} = YamlUtils.extractTypedBlocksWithMeta(source)
+
+        expect(namespace).toBeUndefined()
+        expect(id).toBeUndefined()
+    })
+})

--- a/ui/src/components/flows/FlowRun.vue
+++ b/ui/src/components/flows/FlowRun.vue
@@ -102,6 +102,7 @@
     import type {Flow} from "../../stores/flow"
     import {executeTask} from "../../utils/submitTask"
     import {executeFlowBehaviours, storageKeys} from "../../utils/constants"
+    import {WEBHOOK_TRIGGER_TYPE} from "../../utils/webhook"
     import {normalize} from "../../utils/inputs"
     import type {InputType} from "../../utils/inputs"
     import type {FormInstance} from "@kestra-io/design-system"
@@ -212,7 +213,7 @@
             return false
         }
         return flow.value.triggers.some(trigger =>
-            trigger.type === "io.kestra.plugin.core.trigger.Webhook" &&
+            trigger.type === WEBHOOK_TRIGGER_TYPE &&
             ("disabled" in trigger ? trigger.disabled === undefined || trigger.disabled === false : true),
         )
     })

--- a/ui/src/components/flows/TriggerAvatar.vue
+++ b/ui/src/components/flows/TriggerAvatar.vue
@@ -25,9 +25,9 @@
 </template>
 <script setup lang="ts">
     import {computed, ref, nextTick} from "vue"
-    import {useRoute} from "vue-router"
     import {usePluginsStore} from "../../stores/plugins"
     import * as Utils from "../../utils/utils"
+    import {webhookUrl, WEBHOOK_TRIGGER_TYPE} from "../../utils/webhook"
     import TriggerVars from "./TriggerVars.vue"
     import {KsTaskIcon} from "@kestra-io/design-system"
     import {useI18n} from "vue-i18n"
@@ -55,7 +55,6 @@
     }>()
 
     const pluginsStore = usePluginsStore()
-    const route = useRoute()
 
     const popoverRefs = ref<Map<string, any>>(new Map())
 
@@ -95,11 +94,8 @@
     const toast = useToast()
 
     async function copyLink(trigger: Trigger) {
-        if (trigger?.type === "io.kestra.plugin.core.trigger.Webhook" && props.flow) {
-            const tenant = route.params.tenant ? route.params.tenant + "/" : ""
-            const url =
-                new URL(window.location.href).origin +
-                `/api/v1/${tenant}executions/webhook/${props.flow.namespace}/${props.flow.id}/${trigger.key}`
+        if (trigger?.type === WEBHOOK_TRIGGER_TYPE && trigger.key && props.flow) {
+            const url = webhookUrl({namespace: props.flow.namespace, id: props.flow.id, key: trigger.key})
             try {
                 await Utils.copy(url)
                 toast.success(t("webhook link copied"))

--- a/ui/src/components/flows/WebhookCurl.vue
+++ b/ui/src/components/flows/WebhookCurl.vue
@@ -35,7 +35,7 @@
     import CopyToClipboard from "../layout/CopyToClipboard.vue"
     import {KsEditor} from "@kestra-io/design-system"
     import {useEditorBindings} from "../../composables/useEditorBindings"
-    import {baseUrl, basePath, apiUrl} from "override/utils/route"
+    import {webhookUrl, WEBHOOK_TRIGGER_TYPE} from "../../utils/webhook"
     import {useFlowStore} from "../../stores/flow"
 
     interface Flow {
@@ -68,22 +68,18 @@
         }
 
         return sourceFlow.triggers.filter((trigger: Trigger) =>
-            trigger.type === "io.kestra.plugin.core.trigger.Webhook" &&
+            trigger.type === WEBHOOK_TRIGGER_TYPE &&
             (trigger.disabled === undefined || trigger.disabled === false),
         )
     })
-
-    const generateWebhookUrl = (trigger: Trigger): string => {
-        const origin = baseUrl ? apiUrl() : `${location.origin}${basePath()}`
-        return `${origin}/executions/webhook/${props.flow.namespace}/${props.flow.id}/${trigger.key}`
-    }
 
     const generateWebhookCurlCommand = (trigger: Trigger): string => {
         if (!trigger.key) {
             return "Webhook key not available"
         }
 
-        const command = [`curl -X POST ${generateWebhookUrl(trigger)}`]
+        const url = webhookUrl({namespace: props.flow.namespace, id: props.flow.id, key: trigger.key})
+        const command = [`curl -X POST ${url}`]
         command.push("-H \"Content-Type: application/json\"")
 
         if (webhookPayload.value.trim()) {

--- a/ui/src/composables/monaco/artifacts/editorArtifacts.ts
+++ b/ui/src/composables/monaco/artifacts/editorArtifacts.ts
@@ -1,0 +1,55 @@
+export const ARTIFACT_COPY_COMMAND = "kestra.editorArtifact.copyToClipboard"
+
+export interface ArtifactBlock {
+    type: string;
+    value: Record<string, any>;
+    range: [number, number, number];
+    path: string;
+}
+
+export interface EditorArtifactContext {
+    namespace?: string;
+    id?: string;
+    t: (key: string, named?: Record<string, unknown>) => string;
+}
+
+export interface EditorArtifactLens {
+    title: string;
+    command: {id: string; arguments?: unknown[]};
+}
+
+export interface EditorArtifactProvider {
+    type: string;
+    provide(block: ArtifactBlock, context: EditorArtifactContext): EditorArtifactLens[];
+}
+
+export interface ResolvedArtifact {
+    range: [number, number, number];
+    lens: EditorArtifactLens;
+}
+
+const providers: EditorArtifactProvider[] = []
+
+export function registerEditorArtifactProvider(provider: EditorArtifactProvider): void {
+    if (!providers.some((existing) => existing.type === provider.type)) {
+        providers.push(provider)
+    }
+}
+
+export function provideEditorArtifacts(
+    blocks: ArtifactBlock[],
+    context: EditorArtifactContext,
+): ResolvedArtifact[] {
+    const resolved: ResolvedArtifact[] = []
+    for (const block of blocks) {
+        for (const provider of providers) {
+            if (provider.type !== block.type) {
+                continue
+            }
+            for (const lens of provider.provide(block, context)) {
+                resolved.push({range: block.range, lens})
+            }
+        }
+    }
+    return resolved
+}

--- a/ui/src/composables/monaco/artifacts/index.ts
+++ b/ui/src/composables/monaco/artifacts/index.ts
@@ -1,0 +1,6 @@
+import {registerEditorArtifactProvider} from "./editorArtifacts"
+import {webhookArtifactProvider} from "./webhookArtifact"
+
+registerEditorArtifactProvider(webhookArtifactProvider)
+
+export * from "./editorArtifacts"

--- a/ui/src/composables/monaco/artifacts/webhookArtifact.ts
+++ b/ui/src/composables/monaco/artifacts/webhookArtifact.ts
@@ -1,0 +1,24 @@
+import {webhookUrl, WEBHOOK_TRIGGER_TYPE} from "../../../utils/webhook"
+import {ARTIFACT_COPY_COMMAND, type EditorArtifactProvider} from "./editorArtifacts"
+
+export const webhookArtifactProvider: EditorArtifactProvider = {
+    type: WEBHOOK_TRIGGER_TYPE,
+    provide(block, context) {
+        const key = block.value?.key
+        if (block.path !== "triggers" || !key || !context.namespace || !context.id) {
+            return []
+        }
+
+        const url = webhookUrl({namespace: context.namespace, id: context.id, key})
+
+        return [
+            {
+                title: context.t("webhook.copy_url"),
+                command: {
+                    id: ARTIFACT_COPY_COMMAND,
+                    arguments: [{text: url, message: context.t("webhook link copied")}],
+                },
+            },
+        ]
+    },
+}

--- a/ui/src/composables/monaco/languages/yamlLanguageConfigurator.ts
+++ b/ui/src/composables/monaco/languages/yamlLanguageConfigurator.ts
@@ -20,6 +20,9 @@ import {
 } from "./pebbleLanguageConfigurator"
 import {usePluginsStore} from "../../../stores/plugins"
 import {useBlueprintsStore} from "../../../stores/blueprints"
+import * as Utils from "../../../utils/utils"
+import {makeToast} from "../../../utils/toast"
+import {provideEditorArtifacts, ARTIFACT_COPY_COMMAND} from "../artifacts"
 import IPosition = monaco.IPosition;
 import IDisposable = monaco.IDisposable;
 import IModel = monaco.editor.IModel;
@@ -368,11 +371,13 @@ export class YamlLanguageConfigurator extends AbstractLanguageConfigurator {
     }
 
     configureAutoCompletion(
-        _: ReturnType<typeof useI18n>["t"],
+        t: ReturnType<typeof useI18n>["t"],
         ___: monaco.editor.ICodeEditor | undefined,
     ) {
         const autoCompletionProviders: IDisposable[] = []
         const yamlAutoCompletion = this.yamlAutoCompletionObject
+
+        autoCompletionProviders.push(...this.registerEditorArtifacts(t))
 
         // Values autocompletion
         autoCompletionProviders.push(
@@ -604,5 +609,71 @@ export class YamlLanguageConfigurator extends AbstractLanguageConfigurator {
         )
 
         return autoCompletionProviders
+    }
+
+    private registerEditorArtifacts(t: ReturnType<typeof useI18n>["t"]): IDisposable[] {
+        const toast = makeToast(t)
+
+        const copyCommand = monaco.editor.registerCommand(
+            ARTIFACT_COPY_COMMAND,
+            async (_accessor, payload?: {text?: string; message?: string}) => {
+                if (!payload?.text) {
+                    return
+                }
+                try {
+                    await Utils.copy(payload.text)
+                    if (payload.message) {
+                        toast.success(payload.message)
+                    }
+                } catch (error) {
+                    console.error(error)
+                }
+            },
+        )
+
+        const codeLensProvider = monaco.languages.registerCodeLensProvider("yaml", {
+            provideCodeLenses(model) {
+                const noLenses = {lenses: [], dispose() {}}
+                if (!model.uri.path.includes("flow-")) {
+                    return noLenses
+                }
+
+                const source = model.getValue()
+                let artifacts
+                try {
+                    const blocks = YAML_UTILS.extractTypedBlocks(source)
+                    const parsed = YAML_UTILS.parse(source, false)
+                    artifacts = provideEditorArtifacts(blocks, {
+                        namespace: parsed?.namespace,
+                        id: parsed?.id,
+                        t,
+                    })
+                } catch {
+                    return noLenses
+                }
+
+                const lenses = artifacts.map(({range, lens}, index) => {
+                    const line = model.getPositionAt(range[0]).lineNumber
+                    return {
+                        id: `kestra-artifact-${index}`,
+                        range: {
+                            startLineNumber: line,
+                            startColumn: 1,
+                            endLineNumber: line,
+                            endColumn: 1,
+                        },
+                        command: {
+                            id: lens.command.id,
+                            title: lens.title,
+                            arguments: lens.command.arguments,
+                        },
+                    }
+                })
+
+                return {lenses, dispose() {}}
+            },
+        })
+
+        return [copyCommand, codeLensProvider]
     }
 }

--- a/ui/src/composables/monaco/languages/yamlLanguageConfigurator.ts
+++ b/ui/src/composables/monaco/languages/yamlLanguageConfigurator.ts
@@ -641,13 +641,8 @@ export class YamlLanguageConfigurator extends AbstractLanguageConfigurator {
                 const source = model.getValue()
                 let artifacts
                 try {
-                    const blocks = YAML_UTILS.extractTypedBlocks(source)
-                    const parsed = YAML_UTILS.parse(source, false)
-                    artifacts = provideEditorArtifacts(blocks, {
-                        namespace: parsed?.namespace,
-                        id: parsed?.id,
-                        t,
-                    })
+                    const {blocks, namespace, id} = YAML_UTILS.extractTypedBlocksWithMeta(source)
+                    artifacts = provideEditorArtifacts(blocks, {namespace, id, t})
                 } catch {
                     return noLenses
                 }

--- a/ui/src/translations/en.json
+++ b/ui/src/translations/en.json
@@ -1345,7 +1345,8 @@
       "curl_command": "Webhook cURL command",
       "payload": "Webhook Payload (JSON)",
       "curl_note": "Use this cURL command to trigger the flow via webhook with custom JSON payload",
-      "no_triggers": "This flow has no enabled webhook triggers"
+      "no_triggers": "This flow has no enabled webhook triggers",
+      "copy_url": "Copy webhook URL"
     },
     "logs_view": {
       "raw": "Temporal view",

--- a/ui/src/utils/webhook.ts
+++ b/ui/src/utils/webhook.ts
@@ -1,0 +1,14 @@
+import {apiUrl} from "override/utils/route"
+
+export const WEBHOOK_TRIGGER_TYPE = "io.kestra.plugin.core.trigger.Webhook"
+
+export interface WebhookUrlParams {
+    namespace: string;
+    id: string;
+    key: string;
+}
+
+export function webhookUrl({namespace, id, key}: WebhookUrlParams): string {
+    const url = `${apiUrl()}/executions/webhook/${namespace}/${id}/${key}`
+    return /^https?:\/\//.test(url) ? url : `${window.location.origin}${url}`
+}

--- a/ui/src/utils/webhook.ts
+++ b/ui/src/utils/webhook.ts
@@ -9,6 +9,6 @@ export interface WebhookUrlParams {
 }
 
 export function webhookUrl({namespace, id, key}: WebhookUrlParams): string {
-    const url = `${apiUrl()}/executions/webhook/${namespace}/${id}/${key}`
+    const url = `${apiUrl()}/executions/webhook/${encodeURIComponent(namespace)}/${encodeURIComponent(id)}/${encodeURIComponent(key)}`
     return /^https?:\/\//.test(url) ? url : `${window.location.origin}${url}`
 }

--- a/ui/tests/unit/composables/monaco/artifacts/editorArtifacts.spec.ts
+++ b/ui/tests/unit/composables/monaco/artifacts/editorArtifacts.spec.ts
@@ -1,0 +1,70 @@
+import {describe, expect, it} from "vitest"
+import {
+    provideEditorArtifacts,
+    registerEditorArtifactProvider,
+    ARTIFACT_COPY_COMMAND,
+    type ArtifactBlock,
+} from "../../../../../src/composables/monaco/artifacts"
+
+const t = (key: string) => key
+
+const webhookBlock: ArtifactBlock = {
+    type: "io.kestra.plugin.core.trigger.Webhook",
+    value: {id: "webhook", type: "io.kestra.plugin.core.trigger.Webhook", key: "admin1234"},
+    range: [40, 80, 80],
+    path: "triggers",
+}
+
+describe("provideEditorArtifacts", () => {
+    it("resolves a copy lens for a webhook trigger block", () => {
+        const artifacts = provideEditorArtifacts([webhookBlock], {namespace: "company.team", id: "my-flow", t})
+
+        expect(artifacts).toHaveLength(1)
+        expect(artifacts[0].range).toEqual([40, 80, 80])
+        expect(artifacts[0].lens.title).toBe("webhook.copy_url")
+        expect(artifacts[0].lens.command.id).toBe(ARTIFACT_COPY_COMMAND)
+
+        const [payload] = artifacts[0].lens.command.arguments as [{text: string; message: string}]
+        expect(payload.text).toContain("/executions/webhook/company.team/my-flow/admin1234")
+        expect(payload.message).toBe("webhook link copied")
+    })
+
+    it("skips the webhook block when the key is missing", () => {
+        const artifacts = provideEditorArtifacts(
+            [{...webhookBlock, value: {id: "webhook", type: webhookBlock.type}}],
+            {namespace: "company.team", id: "my-flow", t},
+        )
+
+        expect(artifacts).toEqual([])
+    })
+
+    it("skips blocks without a matching provider", () => {
+        const logBlock: ArtifactBlock = {
+            type: "io.kestra.plugin.core.log.Log",
+            value: {id: "hello", type: "io.kestra.plugin.core.log.Log"},
+            range: [0, 10, 10],
+            path: "tasks",
+        }
+
+        expect(provideEditorArtifacts([logBlock], {namespace: "n", id: "f", t})).toEqual([])
+    })
+
+    it("skips a webhook-typed block that is not inside the triggers section", () => {
+        const pluginDefaultBlock: ArtifactBlock = {
+            type: "io.kestra.plugin.core.trigger.Webhook",
+            value: {type: "io.kestra.plugin.core.trigger.Webhook", key: "shared"},
+            range: [10, 40, 40],
+            path: "pluginDefaults",
+        }
+
+        expect(provideEditorArtifacts([pluginDefaultBlock], {namespace: "company.team", id: "my-flow", t})).toEqual([])
+    })
+
+    it("does not register duplicate providers for the same type", () => {
+        const provider = {type: "io.kestra.plugin.core.trigger.Webhook", provide: () => []}
+        registerEditorArtifactProvider(provider)
+
+        const artifacts = provideEditorArtifacts([webhookBlock], {namespace: "company.team", id: "my-flow", t})
+        expect(artifacts).toHaveLength(1)
+    })
+})

--- a/ui/tests/unit/composables/monaco/artifacts/editorArtifacts.spec.ts
+++ b/ui/tests/unit/composables/monaco/artifacts/editorArtifacts.spec.ts
@@ -5,12 +5,13 @@ import {
     ARTIFACT_COPY_COMMAND,
     type ArtifactBlock,
 } from "../../../../../src/composables/monaco/artifacts"
+import {WEBHOOK_TRIGGER_TYPE} from "../../../../../src/utils/webhook"
 
 const t = (key: string) => key
 
 const webhookBlock: ArtifactBlock = {
-    type: "io.kestra.plugin.core.trigger.Webhook",
-    value: {id: "webhook", type: "io.kestra.plugin.core.trigger.Webhook", key: "admin1234"},
+    type: WEBHOOK_TRIGGER_TYPE,
+    value: {id: "webhook", type: WEBHOOK_TRIGGER_TYPE, key: "admin1234"},
     range: [40, 80, 80],
     path: "triggers",
 }
@@ -51,8 +52,8 @@ describe("provideEditorArtifacts", () => {
 
     it("skips a webhook-typed block that is not inside the triggers section", () => {
         const pluginDefaultBlock: ArtifactBlock = {
-            type: "io.kestra.plugin.core.trigger.Webhook",
-            value: {type: "io.kestra.plugin.core.trigger.Webhook", key: "shared"},
+            type: WEBHOOK_TRIGGER_TYPE,
+            value: {type: WEBHOOK_TRIGGER_TYPE, key: "shared"},
             range: [10, 40, 40],
             path: "pluginDefaults",
         }
@@ -61,7 +62,7 @@ describe("provideEditorArtifacts", () => {
     })
 
     it("does not register duplicate providers for the same type", () => {
-        const provider = {type: "io.kestra.plugin.core.trigger.Webhook", provide: () => []}
+        const provider = {type: WEBHOOK_TRIGGER_TYPE, provide: () => []}
         registerEditorArtifactProvider(provider)
 
         const artifacts = provideEditorArtifacts([webhookBlock], {namespace: "company.team", id: "my-flow", t})

--- a/ui/tests/unit/utils/webhook.spec.ts
+++ b/ui/tests/unit/utils/webhook.spec.ts
@@ -9,6 +9,12 @@ describe("webhookUrl", () => {
         expect(url).toContain("/api/v1/main/executions/webhook/company.team/my-flow/admin1234")
     })
 
+    it("URL-encodes path segments that contain special characters", () => {
+        const url = webhookUrl({namespace: "company.team", id: "my flow", key: "key/with/slashes"})
+
+        expect(url).toContain("/executions/webhook/company.team/my%20flow/key%2Fwith%2Fslashes")
+    })
+
     it("exposes the canonical webhook trigger type", () => {
         expect(WEBHOOK_TRIGGER_TYPE).toBe("io.kestra.plugin.core.trigger.Webhook")
     })

--- a/ui/tests/unit/utils/webhook.spec.ts
+++ b/ui/tests/unit/utils/webhook.spec.ts
@@ -1,0 +1,15 @@
+import {describe, expect, it} from "vitest"
+import {webhookUrl, WEBHOOK_TRIGGER_TYPE} from "../../../src/utils/webhook"
+
+describe("webhookUrl", () => {
+    it("builds an absolute webhook execution URL from namespace, id and key", () => {
+        const url = webhookUrl({namespace: "company.team", id: "my-flow", key: "admin1234"})
+
+        expect(url).toMatch(/^https?:\/\//)
+        expect(url).toContain("/api/v1/main/executions/webhook/company.team/my-flow/admin1234")
+    })
+
+    it("exposes the canonical webhook trigger type", () => {
+        expect(WEBHOOK_TRIGGER_TYPE).toBe("io.kestra.plugin.core.trigger.Webhook")
+    })
+})


### PR DESCRIPTION
## What

Adds an extensible **Monaco editor artifact** mechanism keyed by plugin type, and uses it to ship the first artifact: a **CodeLens above each Webhook trigger block** in the flow YAML editor that copies the webhook execution URL.

Before, the webhook URL was only reachable via the Triggers tab → trigger details panel → "Copy URL". A G2 reviewer reported it as missing entirely because it was too buried. Now it sits right where you write the trigger.

## How

The rendering layer is generic and decoupled from any single plugin — exactly the "Monaco editor artifacts based on plugin-types" direction discussed on the issue:

- **`extractTypedBlocks(source)`** (topology / `flowYamlUtils`) — section-aware extraction of every YAML block carrying a `type:`, with its range and parent path. Generic foundation.
- **Editor artifact registry** (`ui/src/composables/monaco/artifacts/`) — `type → provider`. The CodeLens provider in `yamlLanguageConfigurator` renders whatever descriptors a provider returns; it knows nothing about webhooks.
- **Webhook provider** — the only provider shipped. Scoped to the `triggers` section (so a `pluginDefaults` entry of the same type can never trigger a false lens) and to blocks with a `key`.
- **Single `webhookUrl()` util** — consolidates the three previously-duplicated URL builders (`WebhookCurl.vue`, `TriggerAvatar.vue`, the new artifact) and guarantees an **absolute** URL (the old builders could emit a relative `/ui/...` URL that wasn't usable in curl).
- The CodeLens is gray by default and turns the Kestra link purple (`--ks-text-link`) on hover.

## Testing

- Unit tests: `extractTypedBlocks` (path/section detection + `pluginDefaults` exclusion), `webhookUrl` (absolute URL), artifact registry + webhook provider.
- Type-check (design-system + app + tests), lint, i18n check all green.
- Manual QA in the live flow editor: lens renders above the webhook trigger, gray→purple on hover, click invokes the copy command.

## Follow-up

This ships the registry as the seam; the future direction (plugins declaring their own `artifacts:` — CodeLens links per plugin type without frontend hardcoding, and full widgets per type for infra/cloud-status use cases) is tracked separately.

Closes https://github.com/kestra-io/kestra-ee/issues/8401

🤖 Generated with [Claude Code](https://claude.com/claude-code)
