### PR TITLE
fix(core): migrate binary ION readers to streaming and fix memory regressions

### DIFF
--- a/core/src/main/java/io/kestra/core/runners/FlowableUtils.java
+++ b/core/src/main/java/io/kestra/core/runners/FlowableUtils.java
@@ -1,8 +1,7 @@
 package io.kestra.core.runners;
 
-import java.io.ByteArrayOutputStream;
+import java.io.BufferedInputStream;
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import java.util.*;
 import java.util.function.BiFunction;
 import java.util.stream.IntStream;
@@ -28,6 +27,7 @@ import io.kestra.core.utils.ListUtils;
 import io.kestra.plugin.core.flow.Dag;
 import org.apache.commons.lang3.tuple.Pair;
 
+import static io.kestra.core.utils.Rethrow.throwConsumer;
 import static io.kestra.core.utils.Rethrow.throwFunction;
 
 public class FlowableUtils {
@@ -530,41 +530,17 @@ public class FlowableUtils {
      *         immediately after the last value read
      */
     public static LoopInitialValuesFromUri readAndCountLoopValuesFromUri(RunContext runContext, String uri, int limit) throws IOException, IllegalVariableEvaluationException {
-        try (var is = URIFetcher.of(uri).fetch(runContext)) {
-            int totalCount = 0;
+        try (var is = new BufferedInputStream(URIFetcher.of(uri).fetch(runContext), FileSerde.BUFFER_SIZE)) {
             List<String> result = new ArrayList<>();
-            long currentOffset = 0;
-            long nextOffset = 0;
-            var lineBuffer = new ByteArrayOutputStream();
-            byte[] readBuf = new byte[FileSerde.BUFFER_SIZE];
-            int bytesRead;
-            while ((bytesRead = is.read(readBuf)) != -1) {
-                for (int i = 0; i < bytesRead; i++) {
-                    currentOffset++;
-                    int b = readBuf[i] & 0xFF;
-                    if (b == '\n') {
-                        if (lineBuffer.size() > 0) {
-                            totalCount++;
-                            if (result.size() < limit) {
-                                result.add(ionLineToString(lineBuffer));
-                                nextOffset = currentOffset;
-                            }
-                            lineBuffer.reset();
-                        }
-                    } else {
-                        lineBuffer.write(b);
-                    }
-                }
-            }
-            // handle last line without trailing newline
-            if (lineBuffer.size() > 0) {
-                totalCount++;
+            int[] totalCount = {0};
+            FileSerde.read(is, throwConsumer(record -> {
                 if (result.size() < limit) {
-                    result.add(ionLineToString(lineBuffer));
-                    nextOffset = currentOffset;
+                    result.add(ionValueToString(record));
                 }
-            }
-            return new LoopInitialValuesFromUri(totalCount, result, nextOffset);
+                totalCount[0]++;
+            }));
+            long nextOffset = result.size();
+            return new LoopInitialValuesFromUri(totalCount[0], result, nextOffset);
         }
     }
 
@@ -572,55 +548,28 @@ public class FlowableUtils {
     public record LoopInitialValuesFromUri(int totalCount, List<String> values, long nextOffset) {}
 
     /**
-     * Reads up to {@code count} ION values from the URI-backed ION file, starting at the given byte offset.
-     * Uses a read buffer for efficiency while maintaining accurate byte-offset tracking.
+     * Reads up to {@code count} ION values from the URI-backed ION file, starting at the given record index.
      *
      * @param uri    the rendered URI pointing to the ION file
-     * @param offset the byte offset from which to start reading (0 for the beginning of the file)
+     * @param offset the record index from which to start reading (0 for the beginning of the file)
      * @param count  the maximum number of values to read
-     * @return a pair of the parsed string values and the byte offset immediately after the last byte read
+     * @return a pair of the parsed string values and the record index immediately after the last value read
      */
     public static Pair<List<String>, Long> readLoopValuesFromUri(RunContext runContext, String uri, long offset, int count) throws IOException, IllegalVariableEvaluationException {
-        try (var is = URIFetcher.of(uri).fetch(runContext)) {
-            if (offset > 0) {
-                is.skipNBytes(offset);
-            }
-
+        try (var is = new BufferedInputStream(URIFetcher.of(uri).fetch(runContext), FileSerde.BUFFER_SIZE)) {
             List<String> result = new ArrayList<>(count);
-            long currentOffset = offset;
-            var lineBuffer = new ByteArrayOutputStream();
-            byte[] readBuf = new byte[FileSerde.BUFFER_SIZE];
-            int bytesRead;
-            while ((bytesRead = is.read(readBuf)) != -1) {
-                for (int i = 0; i < bytesRead; i++) {
-                    currentOffset++;
-                    int b = readBuf[i] & 0xFF;
-                    if (b == '\n') {
-                        if (lineBuffer.size() > 0) {
-                            result.add(ionLineToString(lineBuffer));
-                            lineBuffer.reset();
-                            if (result.size() == count) {
-                                return Pair.of(result, currentOffset);
-                            }
-                        }
-                    } else {
-                        lineBuffer.write(b);
-                    }
+            long[] index = {0};
+            FileSerde.read(is, throwConsumer(record -> {
+                if (index[0] >= offset && result.size() < count) {
+                    result.add(ionValueToString(record));
                 }
-            }
-
-            // handle last line without trailing newline
-            if (lineBuffer.size() > 0 && result.size() < count) {
-                result.add(ionLineToString(lineBuffer));
-            }
-            return Pair.of(result, currentOffset);
+                index[0]++;
+            }));
+            return Pair.of(result, offset + result.size());
         }
     }
 
-    /** Parses a single ION line (accumulated in {@code buf}) into a String value. */
-    private static String ionLineToString(ByteArrayOutputStream buf) throws IOException, IllegalVariableEvaluationException {
-        String line = buf.toString(StandardCharsets.UTF_8);
-        Object parsed = JacksonMapper.ofIon().readValue(line, Object.class);
+    private static String ionValueToString(Object parsed) throws IllegalVariableEvaluationException {
         return switch (parsed) {
             case String s -> s;
             case Number n -> n.toString();

--- a/core/src/main/java/io/kestra/core/serializers/FileSerde.java
+++ b/core/src/main/java/io/kestra/core/serializers/FileSerde.java
@@ -253,31 +253,31 @@ public final class FileSerde {
     }
 
     private static <T> MappingIterator<T> createMappingIterator(ObjectMapper objectMapper, Reader reader, TypeReference<T> type) throws IOException {
-        try (var parser = objectMapper.createParser(reader)) {
-            return objectMapper.readerFor(type).readValues(parser);
-        }
+        var parser = objectMapper.createParser(reader);
+        return objectMapper.readerFor(type).readValues(parser);
     }
 
     private static <T> MappingIterator<T> createMappingIterator(ObjectMapper objectMapper, Reader reader, Class<T> type) throws IOException {
-        try (var parser = objectMapper.createParser(reader)) {
-            return objectMapper.readerFor(type).readValues(parser);
-        }
+        var parser = objectMapper.createParser(reader);
+        return objectMapper.readerFor(type).readValues(parser);
     }
 
     private static <T> MappingIterator<T> createMappingIterator(ObjectMapper objectMapper, InputStream inputStream, TypeReference<T> type) throws IOException {
-        try (var parser = objectMapper.createParser(inputStream)) {
-            return objectMapper.readerFor(type).readValues(parser);
-        }
+        var parser = objectMapper.createParser(inputStream);
+        return objectMapper.readerFor(type).readValues(parser);
     }
 
     private static <T> MappingIterator<T> createMappingIterator(ObjectMapper objectMapper, InputStream inputStream, Class<T> type) throws IOException {
-        try (var parser = objectMapper.createParser(inputStream)) {
-            return objectMapper.readerFor(type).readValues(parser);
-        }
+        var parser = objectMapper.createParser(inputStream);
+        return objectMapper.readerFor(type).readValues(parser);
     }
 
     public static <T> SequenceWriter createSequenceWriter(ObjectMapper objectMapper, Writer writer, TypeReference<T> type) throws IOException {
         return objectMapper.writerFor(type).writeValues(writer);
+    }
+
+    public static <T> SequenceWriter createBinarySequenceWriter(OutputStream outputStream, TypeReference<T> type) throws IOException {
+        return BINARY_OBJECT_MAPPER.writerFor(type).writeValues(outputStream);
     }
 
     public static <T> SequenceWriter createJsonSequenceWriter(Writer writer, TypeReference<T> type) throws IOException {

--- a/core/src/main/java/io/kestra/core/services/StorageService.java
+++ b/core/src/main/java/io/kestra/core/services/StorageService.java
@@ -28,6 +28,7 @@ import io.kestra.core.serializers.JacksonMapper;
 import io.kestra.core.utils.RegexUtils;
 import io.kestra.core.storages.StorageSplitInterface;
 
+import com.amazon.ion.util.IonStreamUtils;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.micronaut.core.convert.format.ReadableBytesTypeConverter;
 
@@ -45,44 +46,46 @@ public abstract class StorageService {
             extension = fromPath.substring(fromPath.lastIndexOf('.'));
         }
 
-        boolean isIon = extension.equals(".ion");
+        try (BufferedInputStream inputStream = new BufferedInputStream(runContext.storage().getFile(from), FileSerde.BUFFER_SIZE)) {
+            inputStream.mark(FileSerde.BUFFER_SIZE);
+            byte[] header = inputStream.readNBytes(4);
+            inputStream.reset();
 
-        if (isIon) {
-            return splitIon(runContext, storageSplitInterface, from, extension);
-        } else {
-            return splitText(runContext, storageSplitInterface, from, extension);
+            if (IonStreamUtils.isIonBinary(header)) {
+                return splitIon(runContext, storageSplitInterface, inputStream, extension);
+            } else {
+                return splitText(runContext, storageSplitInterface, inputStream, extension);
+            }
         }
     }
 
-    private static List<URI> splitIon(RunContext runContext, StorageSplitInterface storageSplitInterface, URI from, String extension) throws IOException, IllegalVariableEvaluationException {
-        try (InputStream inputStream = new BufferedInputStream(runContext.storage().getFile(from), FileSerde.BUFFER_SIZE)) {
-            List<Path> splited;
+    private static List<URI> splitIon(RunContext runContext, StorageSplitInterface storageSplitInterface, InputStream inputStream, String extension) throws IOException, IllegalVariableEvaluationException {
+        List<Path> splited;
 
-            if (storageSplitInterface.getRegexPattern() != null) {
-                String renderedPattern = runContext.render(storageSplitInterface.getRegexPattern()).as(String.class).orElseThrow();
-                splited = splitIonByRegex(runContext, extension, inputStream, renderedPattern);
-            } else if (storageSplitInterface.getBytes() != null) {
-                ReadableBytesTypeConverter readableBytesTypeConverter = new ReadableBytesTypeConverter();
-                Number convert = readableBytesTypeConverter.convert(runContext.render(storageSplitInterface.getBytes()).as(String.class).orElseThrow(), Number.class)
-                    .orElseThrow(() -> new IllegalArgumentException("Invalid size with value '" + storageSplitInterface.getBytes() + "'"));
+        if (storageSplitInterface.getRegexPattern() != null) {
+            String renderedPattern = runContext.render(storageSplitInterface.getRegexPattern()).as(String.class).orElseThrow();
+            splited = splitIonByRegex(runContext, extension, inputStream, renderedPattern);
+        } else if (storageSplitInterface.getBytes() != null) {
+            ReadableBytesTypeConverter readableBytesTypeConverter = new ReadableBytesTypeConverter();
+            Number convert = readableBytesTypeConverter.convert(runContext.render(storageSplitInterface.getBytes()).as(String.class).orElseThrow(), Number.class)
+                .orElseThrow(() -> new IllegalArgumentException("Invalid size with value '" + storageSplitInterface.getBytes() + "'"));
 
-                splited = splitIonByPredicate(runContext, extension, inputStream, (bytes, size) -> bytes >= convert.longValue());
-            } else if (storageSplitInterface.getPartitions() != null) {
-                splited = partitionIon(
-                    runContext, extension, inputStream,
-                    runContext.render(storageSplitInterface.getPartitions()).as(Integer.class).orElseThrow()
-                );
-            } else if (storageSplitInterface.getRows() != null) {
-                Integer renderedRows = runContext.render(storageSplitInterface.getRows()).as(Integer.class).orElseThrow();
-                splited = splitIonByPredicate(runContext, extension, inputStream, (bytes, size) -> size >= renderedRows);
-            } else {
-                throw new IllegalArgumentException("Invalid configuration with no size, count, rows, nor regexPattern");
-            }
-
-            return splited.stream()
-                .map(throwFunction(path -> runContext.storage().putFile(path.toFile())))
-                .toList();
+            splited = splitIonByPredicate(runContext, extension, inputStream, (bytes, size) -> bytes >= convert.longValue());
+        } else if (storageSplitInterface.getPartitions() != null) {
+            splited = partitionIon(
+                runContext, extension, inputStream,
+                runContext.render(storageSplitInterface.getPartitions()).as(Integer.class).orElseThrow()
+            );
+        } else if (storageSplitInterface.getRows() != null) {
+            Integer renderedRows = runContext.render(storageSplitInterface.getRows()).as(Integer.class).orElseThrow();
+            splited = splitIonByPredicate(runContext, extension, inputStream, (bytes, size) -> size >= renderedRows);
+        } else {
+            throw new IllegalArgumentException("Invalid configuration with no size, count, rows, nor regexPattern");
         }
+
+        return splited.stream()
+            .map(throwFunction(path -> runContext.storage().putFile(path.toFile())))
+            .toList();
     }
 
     private static List<Path> splitIonByPredicate(RunContext runContext, String extension, InputStream inputStream, BiFunction<Integer, Integer, Boolean> predicate)
@@ -188,43 +191,42 @@ public abstract class StorageService {
 
     // Text-based splitting for non-ION files (original behavior)
 
-    private static List<URI> splitText(RunContext runContext, StorageSplitInterface storageSplitInterface, URI from, String extension) throws IOException, IllegalVariableEvaluationException {
-        try (BufferedReader bufferedReader = new BufferedReader(new InputStreamReader(runContext.storage().getFile(from)))) {
-            List<Path> splited;
+    private static List<URI> splitText(RunContext runContext, StorageSplitInterface storageSplitInterface, InputStream inputStream, String extension) throws IOException, IllegalVariableEvaluationException {
+        BufferedReader bufferedReader = new BufferedReader(new InputStreamReader(inputStream));
+        List<Path> splited;
 
-            if (storageSplitInterface.getRegexPattern() != null) {
-                String renderedPattern = runContext.render(storageSplitInterface.getRegexPattern()).as(String.class).orElseThrow();
-                String separator = runContext.render(storageSplitInterface.getSeparator()).as(String.class).orElseThrow();
-                splited = splitTextByRegex(runContext, extension, separator, bufferedReader, renderedPattern);
-            } else if (storageSplitInterface.getBytes() != null) {
-                ReadableBytesTypeConverter readableBytesTypeConverter = new ReadableBytesTypeConverter();
-                Number convert = readableBytesTypeConverter.convert(runContext.render(storageSplitInterface.getBytes()).as(String.class).orElseThrow(), Number.class)
-                    .orElseThrow(() -> new IllegalArgumentException("Invalid size with value '" + storageSplitInterface.getBytes() + "'"));
+        if (storageSplitInterface.getRegexPattern() != null) {
+            String renderedPattern = runContext.render(storageSplitInterface.getRegexPattern()).as(String.class).orElseThrow();
+            String separator = runContext.render(storageSplitInterface.getSeparator()).as(String.class).orElseThrow();
+            splited = splitTextByRegex(runContext, extension, separator, bufferedReader, renderedPattern);
+        } else if (storageSplitInterface.getBytes() != null) {
+            ReadableBytesTypeConverter readableBytesTypeConverter = new ReadableBytesTypeConverter();
+            Number convert = readableBytesTypeConverter.convert(runContext.render(storageSplitInterface.getBytes()).as(String.class).orElseThrow(), Number.class)
+                .orElseThrow(() -> new IllegalArgumentException("Invalid size with value '" + storageSplitInterface.getBytes() + "'"));
 
-                splited = splitTextByPredicate(
-                    runContext, extension, runContext.render(storageSplitInterface.getSeparator()).as(String.class).orElseThrow(),
-                    bufferedReader, (bytes, size) -> bytes >= convert.longValue()
-                );
-            } else if (storageSplitInterface.getPartitions() != null) {
-                splited = partitionText(
-                    runContext, extension, runContext.render(storageSplitInterface.getSeparator()).as(String.class).orElseThrow(),
-                    bufferedReader, runContext.render(storageSplitInterface.getPartitions()).as(Integer.class).orElseThrow()
-                );
-            } else if (storageSplitInterface.getRows() != null) {
-                Integer renderedRows = runContext.render(storageSplitInterface.getRows()).as(Integer.class).orElseThrow();
-                splited = splitTextByPredicate(
-                    runContext, extension, runContext.render(storageSplitInterface.getSeparator()).as(String.class).orElseThrow(),
-                    bufferedReader, (bytes, size) -> size >= renderedRows
-                );
-            } else {
-                throw new IllegalArgumentException("Invalid configuration with no size, count, rows, nor regexPattern");
-            }
-
-            return splited
-                .stream()
-                .map(throwFunction(path -> runContext.storage().putFile(path.toFile())))
-                .toList();
+            splited = splitTextByPredicate(
+                runContext, extension, runContext.render(storageSplitInterface.getSeparator()).as(String.class).orElseThrow(),
+                bufferedReader, (bytes, size) -> bytes >= convert.longValue()
+            );
+        } else if (storageSplitInterface.getPartitions() != null) {
+            splited = partitionText(
+                runContext, extension, runContext.render(storageSplitInterface.getSeparator()).as(String.class).orElseThrow(),
+                bufferedReader, runContext.render(storageSplitInterface.getPartitions()).as(Integer.class).orElseThrow()
+            );
+        } else if (storageSplitInterface.getRows() != null) {
+            Integer renderedRows = runContext.render(storageSplitInterface.getRows()).as(Integer.class).orElseThrow();
+            splited = splitTextByPredicate(
+                runContext, extension, runContext.render(storageSplitInterface.getSeparator()).as(String.class).orElseThrow(),
+                bufferedReader, (bytes, size) -> size >= renderedRows
+            );
+        } else {
+            throw new IllegalArgumentException("Invalid configuration with no size, count, rows, nor regexPattern");
         }
+
+        return splited
+            .stream()
+            .map(throwFunction(path -> runContext.storage().putFile(path.toFile())))
+            .toList();
     }
 
     private static List<Path> splitTextByPredicate(RunContext runContext, String extension, String separator, BufferedReader bufferedReader, BiFunction<Integer, Integer, Boolean> predicate)

--- a/core/src/main/java/io/kestra/core/services/StorageService.java
+++ b/core/src/main/java/io/kestra/core/services/StorageService.java
@@ -3,18 +3,19 @@ package io.kestra.core.services;
 import java.io.BufferedInputStream;
 import java.io.BufferedOutputStream;
 import java.io.BufferedReader;
+import java.io.Closeable;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.OutputStream;
-import java.io.RandomAccessFile;
+import java.io.UncheckedIOException;
 import java.net.URI;
-import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.function.BiFunction;
@@ -29,79 +30,87 @@ import io.kestra.core.utils.RegexUtils;
 import io.kestra.core.storages.StorageSplitInterface;
 
 import com.amazon.ion.util.IonStreamUtils;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.MappingIterator;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SequenceWriter;
 import io.micronaut.core.convert.format.ReadableBytesTypeConverter;
 
-import static io.kestra.core.utils.Rethrow.throwConsumer;
 import static io.kestra.core.utils.Rethrow.throwFunction;
 
 public abstract class StorageService {
 
     private static final ObjectMapper ION_MAPPER = JacksonMapper.ofIon();
+    private static final ObjectMapper ION_BINARY_MAPPER = JacksonMapper.ofIonBinary();
+    private static final TypeReference<Object> OBJECT_TYPE = new TypeReference<>() {};
 
     public static List<URI> split(RunContext runContext, StorageSplitInterface storageSplitInterface, URI from) throws IOException, IllegalVariableEvaluationException {
-        String fromPath = from.getPath();
-        String extension = ".tmp";
-        if (fromPath.indexOf('.') >= 0) {
-            extension = fromPath.substring(fromPath.lastIndexOf('.'));
-        }
+        String extension = extensionOf(from);
 
         try (BufferedInputStream inputStream = new BufferedInputStream(runContext.storage().getFile(from), FileSerde.BUFFER_SIZE)) {
-            inputStream.mark(FileSerde.BUFFER_SIZE);
+            inputStream.mark(4);
             byte[] header = inputStream.readNBytes(4);
             inputStream.reset();
 
-            if (IonStreamUtils.isIonBinary(header)) {
-                return splitIon(runContext, storageSplitInterface, inputStream, extension);
-            } else {
-                return splitText(runContext, storageSplitInterface, inputStream, extension);
+            List<Path> splited;
+            try (SplitStrategy strategy = IonStreamUtils.isIonBinary(header)
+                ? new IonSplitStrategy(inputStream)
+                : new TextSplitStrategy(inputStream, runContext.render(storageSplitInterface.getSeparator()).as(String.class).orElseThrow())) {
+
+                if (storageSplitInterface.getRegexPattern() != null) {
+                    String renderedPattern = runContext.render(storageSplitInterface.getRegexPattern()).as(String.class).orElseThrow();
+                    splited = splitByRegex(runContext, extension, strategy, renderedPattern);
+                } else if (storageSplitInterface.getBytes() != null) {
+                    long maxBytes = parseBytes(runContext, storageSplitInterface);
+                    splited = splitByPredicate(runContext, extension, strategy, (bytes, size) -> bytes >= maxBytes);
+                } else if (storageSplitInterface.getPartitions() != null) {
+                    int partitions = runContext.render(storageSplitInterface.getPartitions()).as(Integer.class).orElseThrow();
+                    splited = partition(runContext, extension, strategy, partitions);
+                } else if (storageSplitInterface.getRows() != null) {
+                    int rows = runContext.render(storageSplitInterface.getRows()).as(Integer.class).orElseThrow();
+                    splited = splitByPredicate(runContext, extension, strategy, (bytes, size) -> size >= rows);
+                } else {
+                    throw new IllegalArgumentException("Invalid configuration with no size, count, rows, nor regexPattern");
+                }
             }
+
+            return splited.stream()
+                .map(throwFunction(path -> runContext.storage().putFile(path.toFile())))
+                .toList();
         }
     }
 
-    private static List<URI> splitIon(RunContext runContext, StorageSplitInterface storageSplitInterface, InputStream inputStream, String extension) throws IOException, IllegalVariableEvaluationException {
-        List<Path> splited;
-
-        if (storageSplitInterface.getRegexPattern() != null) {
-            String renderedPattern = runContext.render(storageSplitInterface.getRegexPattern()).as(String.class).orElseThrow();
-            splited = splitIonByRegex(runContext, extension, inputStream, renderedPattern);
-        } else if (storageSplitInterface.getBytes() != null) {
-            ReadableBytesTypeConverter readableBytesTypeConverter = new ReadableBytesTypeConverter();
-            Number convert = readableBytesTypeConverter.convert(runContext.render(storageSplitInterface.getBytes()).as(String.class).orElseThrow(), Number.class)
-                .orElseThrow(() -> new IllegalArgumentException("Invalid size with value '" + storageSplitInterface.getBytes() + "'"));
-
-            splited = splitIonByPredicate(runContext, extension, inputStream, (bytes, size) -> bytes >= convert.longValue());
-        } else if (storageSplitInterface.getPartitions() != null) {
-            splited = partitionIon(
-                runContext, extension, inputStream,
-                runContext.render(storageSplitInterface.getPartitions()).as(Integer.class).orElseThrow()
-            );
-        } else if (storageSplitInterface.getRows() != null) {
-            Integer renderedRows = runContext.render(storageSplitInterface.getRows()).as(Integer.class).orElseThrow();
-            splited = splitIonByPredicate(runContext, extension, inputStream, (bytes, size) -> size >= renderedRows);
-        } else {
-            throw new IllegalArgumentException("Invalid configuration with no size, count, rows, nor regexPattern");
+    private static String extensionOf(URI from) {
+        String fromPath = from.getPath();
+        if (fromPath.indexOf('.') >= 0) {
+            return fromPath.substring(fromPath.lastIndexOf('.'));
         }
-
-        return splited.stream()
-            .map(throwFunction(path -> runContext.storage().putFile(path.toFile())))
-            .toList();
+        return ".tmp";
     }
 
-    private static List<Path> splitIonByPredicate(RunContext runContext, String extension, InputStream inputStream, BiFunction<Integer, Integer, Boolean> predicate)
+    private static long parseBytes(RunContext runContext, StorageSplitInterface storageSplitInterface) throws IllegalVariableEvaluationException {
+        ReadableBytesTypeConverter readableBytesTypeConverter = new ReadableBytesTypeConverter();
+        Number convert = readableBytesTypeConverter.convert(runContext.render(storageSplitInterface.getBytes()).as(String.class).orElseThrow(), Number.class)
+            .orElseThrow(() -> new IllegalArgumentException("Invalid size with value '" + storageSplitInterface.getBytes() + "'"));
+        return convert.longValue();
+    }
+
+    // region split operations (format-agnostic, parameterized by a SplitStrategy)
+
+    private static List<Path> splitByPredicate(RunContext runContext, String extension, SplitStrategy strategy, BiFunction<Integer, Integer, Boolean> predicate)
         throws IOException {
         List<Path> files = new ArrayList<>();
-        OutputStream currentOutput = null;
+        RecordWriter writer = null;
         int totalBytes = 0;
         int totalRows = 0;
 
         try {
-            var iterator = ION_MAPPER.readerFor(Object.class).readValues(ION_MAPPER.createParser(inputStream));
+            Iterator<Object> iterator = strategy.records();
             while (iterator.hasNext()) {
                 Object record = iterator.next();
-                if (currentOutput == null || predicate.apply(totalBytes, totalRows)) {
-                    if (currentOutput != null) {
-                        currentOutput.close();
+                if (writer == null || predicate.apply(totalBytes, totalRows)) {
+                    if (writer != null) {
+                        writer.close();
                     }
 
                     totalBytes = 0;
@@ -109,223 +118,223 @@ public abstract class StorageService {
 
                     Path path = runContext.workingDir().createTempFile(extension);
                     files.add(path);
-                    currentOutput = new BufferedOutputStream(new FileOutputStream(path.toFile()), FileSerde.BUFFER_SIZE);
+                    writer = strategy.newWriter(path);
                 }
 
-                byte[] bytes = JacksonMapper.ofIonBinary().writeValueAsBytes(record);
-                currentOutput.write(bytes);
-                totalBytes = totalBytes + bytes.length;
+                totalBytes = totalBytes + writer.write(record);
                 totalRows = totalRows + 1;
             }
         } finally {
-            if (currentOutput != null) {
-                currentOutput.close();
+            if (writer != null) {
+                writer.close();
             }
         }
 
         return files;
     }
 
-    private static List<Path> partitionIon(RunContext runContext, String extension, InputStream inputStream, int partition) throws IOException {
+    private static List<Path> partition(RunContext runContext, String extension, SplitStrategy strategy, int partition) throws IOException {
         List<Path> files = new ArrayList<>();
-        List<OutputStream> writers = new ArrayList<>();
+        List<RecordWriter> writers = new ArrayList<>();
 
         try {
             for (int i = 0; i < partition; i++) {
                 Path path = runContext.workingDir().createTempFile(extension);
                 files.add(path);
-                writers.add(new BufferedOutputStream(new FileOutputStream(path.toFile()), FileSerde.BUFFER_SIZE));
+                writers.add(strategy.newWriter(path));
             }
 
             int index = 0;
-            var iterator = ION_MAPPER.readerFor(Object.class).readValues(ION_MAPPER.createParser(inputStream));
+            Iterator<Object> iterator = strategy.records();
             while (iterator.hasNext()) {
-                FileSerde.write(writers.get(index), iterator.next());
+                writers.get(index).write(iterator.next());
                 index = index >= writers.size() - 1 ? 0 : index + 1;
             }
-
-            return files.stream().filter(p -> p.toFile().length() > 0).toList();
         } finally {
-            for (OutputStream w : writers) {
-                try {
-                    w.close();
-                } catch (IOException e) {
-                    runContext.logger().error("Failed to close partition writer", e);
-                }
-            }
+            closeQuietly(runContext, writers);
         }
+
+        return files.stream().filter(p -> p.toFile().length() > 0).toList();
     }
 
-    private static List<Path> splitIonByRegex(RunContext runContext, String extension, InputStream inputStream, String regexPattern) throws IOException {
+    private static List<Path> splitByRegex(RunContext runContext, String extension, SplitStrategy strategy, String regexPattern) throws IOException {
         List<Path> files = new ArrayList<>();
-        Map<String, OutputStream> writers = new HashMap<>();
+        Map<String, RecordWriter> writers = new HashMap<>();
         Pattern pattern = Pattern.compile(regexPattern);
 
         try {
-            var iterator = ION_MAPPER.readerFor(Object.class).readValues(ION_MAPPER.createParser(inputStream));
+            Iterator<Object> iterator = strategy.records();
             while (iterator.hasNext()) {
                 Object record = iterator.next();
-                String textIon = ION_MAPPER.writeValueAsString(record);
-                Matcher matcher = RegexUtils.matcher(pattern, textIon);
+                Matcher matcher = RegexUtils.matcher(pattern, strategy.routingText(record));
 
                 if (matcher.find() && matcher.groupCount() > 0) {
                     String routingKey = matcher.group(1);
 
-                    OutputStream writer = writers.get(routingKey);
+                    RecordWriter writer = writers.get(routingKey);
                     if (writer == null) {
                         Path path = runContext.workingDir().createTempFile(extension);
                         files.add(path);
-                        writer = new BufferedOutputStream(new FileOutputStream(path.toFile()), FileSerde.BUFFER_SIZE);
+                        writer = strategy.newWriter(path);
                         writers.put(routingKey, writer);
                     }
 
-                    FileSerde.write(writer, record);
+                    writer.write(record);
                 }
             }
         } finally {
-            writers.values().forEach(throwConsumer(OutputStream::close));
+            closeQuietly(runContext, writers.values());
         }
 
         return files.stream().filter(p -> p.toFile().length() > 0).toList();
     }
 
-    // Text-based splitting for non-ION files (original behavior)
-
-    private static List<URI> splitText(RunContext runContext, StorageSplitInterface storageSplitInterface, InputStream inputStream, String extension) throws IOException, IllegalVariableEvaluationException {
-        BufferedReader bufferedReader = new BufferedReader(new InputStreamReader(inputStream));
-        List<Path> splited;
-
-        if (storageSplitInterface.getRegexPattern() != null) {
-            String renderedPattern = runContext.render(storageSplitInterface.getRegexPattern()).as(String.class).orElseThrow();
-            String separator = runContext.render(storageSplitInterface.getSeparator()).as(String.class).orElseThrow();
-            splited = splitTextByRegex(runContext, extension, separator, bufferedReader, renderedPattern);
-        } else if (storageSplitInterface.getBytes() != null) {
-            ReadableBytesTypeConverter readableBytesTypeConverter = new ReadableBytesTypeConverter();
-            Number convert = readableBytesTypeConverter.convert(runContext.render(storageSplitInterface.getBytes()).as(String.class).orElseThrow(), Number.class)
-                .orElseThrow(() -> new IllegalArgumentException("Invalid size with value '" + storageSplitInterface.getBytes() + "'"));
-
-            splited = splitTextByPredicate(
-                runContext, extension, runContext.render(storageSplitInterface.getSeparator()).as(String.class).orElseThrow(),
-                bufferedReader, (bytes, size) -> bytes >= convert.longValue()
-            );
-        } else if (storageSplitInterface.getPartitions() != null) {
-            splited = partitionText(
-                runContext, extension, runContext.render(storageSplitInterface.getSeparator()).as(String.class).orElseThrow(),
-                bufferedReader, runContext.render(storageSplitInterface.getPartitions()).as(Integer.class).orElseThrow()
-            );
-        } else if (storageSplitInterface.getRows() != null) {
-            Integer renderedRows = runContext.render(storageSplitInterface.getRows()).as(Integer.class).orElseThrow();
-            splited = splitTextByPredicate(
-                runContext, extension, runContext.render(storageSplitInterface.getSeparator()).as(String.class).orElseThrow(),
-                bufferedReader, (bytes, size) -> size >= renderedRows
-            );
-        } else {
-            throw new IllegalArgumentException("Invalid configuration with no size, count, rows, nor regexPattern");
+    private static void closeQuietly(RunContext runContext, Iterable<RecordWriter> writers) {
+        for (RecordWriter writer : writers) {
+            try {
+                writer.close();
+            } catch (IOException e) {
+                runContext.logger().error("Failed to close split writer", e);
+            }
         }
-
-        return splited
-            .stream()
-            .map(throwFunction(path -> runContext.storage().putFile(path.toFile())))
-            .toList();
     }
 
-    private static List<Path> splitTextByPredicate(RunContext runContext, String extension, String separator, BufferedReader bufferedReader, BiFunction<Integer, Integer, Boolean> predicate)
-        throws IOException {
-        List<Path> files = new ArrayList<>();
-        RandomAccessFile write = null;
-        int totalBytes = 0;
-        int totalRows = 0;
-        String row;
+    // endregion
 
-        while ((row = bufferedReader.readLine()) != null) {
-            if (write == null || predicate.apply(totalBytes, totalRows)) {
-                if (write != null) {
-                    write.close();
+    // region split strategies (encapsulate the ION-vs-text read/write differences)
+
+    /**
+     * Reads records and creates per-output-file writers for a given file format.
+     * The {@code split*} operations above are written once against this contract.
+     */
+    private interface SplitStrategy extends Closeable {
+        /** Lazily streamed records. ION yields {@code Object} values, text yields the {@code String} rows. */
+        Iterator<Object> records() throws IOException;
+
+        /** Opens a fresh writer for a single output file. */
+        RecordWriter newWriter(Path path) throws IOException;
+
+        /** The text used for regex routing-key extraction: text-ion for ION, the raw row for text. */
+        String routingText(Object record) throws IOException;
+    }
+
+    private interface RecordWriter extends Closeable {
+        /** Writes one record and returns the number of bytes it represents (used by the {@code bytes} predicate). */
+        int write(Object record) throws IOException;
+    }
+
+    /** Streams binary ION records and writes each output file as a single binary ION stream. */
+    private static final class IonSplitStrategy implements SplitStrategy {
+        private final MappingIterator<Object> iterator;
+
+        private IonSplitStrategy(InputStream inputStream) throws IOException {
+            this.iterator = ION_MAPPER.readerFor(OBJECT_TYPE).readValues(ION_MAPPER.createParser(inputStream));
+        }
+
+        @Override
+        public Iterator<Object> records() {
+            return iterator;
+        }
+
+        @Override
+        public String routingText(Object record) throws IOException {
+            return ION_MAPPER.writeValueAsString(record);
+        }
+
+        @Override
+        public RecordWriter newWriter(Path path) throws IOException {
+            OutputStream outputStream = new BufferedOutputStream(new FileOutputStream(path.toFile()), FileSerde.BUFFER_SIZE);
+            SequenceWriter sequenceWriter = FileSerde.createBinarySequenceWriter(outputStream, OBJECT_TYPE);
+
+            return new RecordWriter() {
+                @Override
+                public int write(Object record) throws IOException {
+                    sequenceWriter.write(record);
+                    // The byte metric stays the standalone record size (the pre-refactor semantics) so the
+                    // `bytes` threshold remains deterministic and independent of the writer's buffering.
+                    return ION_BINARY_MAPPER.writeValueAsBytes(record).length;
                 }
 
-                totalBytes = 0;
-                totalRows = 0;
-
-                Path path = runContext.workingDir().createTempFile(extension);
-                files.add(path);
-                write = new RandomAccessFile(path.toFile(), "rw");
-            }
-
-            byte[] bytes = (row + separator).getBytes(StandardCharsets.UTF_8);
-
-            write.getChannel().write(ByteBuffer.wrap(bytes));
-
-            totalBytes = totalBytes + bytes.length;
-            totalRows = totalRows + 1;
-        }
-
-        if (write != null) {
-            write.close();
-        }
-
-        return files;
-    }
-
-    private static List<Path> partitionText(RunContext runContext, String extension, String separator, BufferedReader bufferedReader, int partition) throws IOException {
-        List<Path> files = new ArrayList<>();
-        List<RandomAccessFile> writers = new ArrayList<>();
-
-        try {
-            for (int i = 0; i < partition; i++) {
-                Path path = runContext.workingDir().createTempFile(extension);
-                files.add(path);
-
-                writers.add(new RandomAccessFile(path.toFile(), "rw"));
-            }
-
-            String row;
-            int index = 0;
-            while ((row = bufferedReader.readLine()) != null) {
-                writers.get(index).getChannel().write(ByteBuffer.wrap((row + separator).getBytes(StandardCharsets.UTF_8)));
-
-                index = index >= writers.size() - 1 ? 0 : index + 1;
-            }
-
-            return files.stream().filter(p -> p.toFile().length() > 0).toList();
-        } finally {
-            for (RandomAccessFile w : writers) {
-                try {
-                    w.close();
-                } catch (IOException e) {
-                    runContext.logger().error("Failed to close partition writer", e);
+                @Override
+                public void close() throws IOException {
+                    sequenceWriter.close();
                 }
-            }
+            };
+        }
+
+        @Override
+        public void close() throws IOException {
+            iterator.close();
         }
     }
 
-    private static List<Path> splitTextByRegex(RunContext runContext, String extension, String separator, BufferedReader bufferedReader, String regexPattern) throws IOException {
-        List<Path> files = new ArrayList<>();
-        Map<String, RandomAccessFile> writers = new HashMap<>();
-        Pattern pattern = Pattern.compile(regexPattern);
+    /** Streams text rows and writes each output file as {@code row + separator} lines. */
+    private static final class TextSplitStrategy implements SplitStrategy {
+        private final BufferedReader reader;
+        private final String separator;
 
-        String row;
-        while ((row = bufferedReader.readLine()) != null) {
-            Matcher matcher = RegexUtils.matcher(pattern, row);
+        private TextSplitStrategy(InputStream inputStream, String separator) {
+            this.reader = new BufferedReader(new InputStreamReader(inputStream, StandardCharsets.UTF_8), FileSerde.BUFFER_SIZE);
+            this.separator = separator;
+        }
 
-            if (matcher.find() && matcher.groupCount() > 0) {
-                String routingKey = matcher.group(1);
+        @Override
+        public Iterator<Object> records() {
+            return new Iterator<>() {
+                private String next = advance();
 
-                RandomAccessFile writer = writers.get(routingKey);
-                if (writer == null) {
-                    Path path = runContext.workingDir().createTempFile(extension);
-                    files.add(path);
-                    writer = new RandomAccessFile(path.toFile(), "rw");
-                    writers.put(routingKey, writer);
+                private String advance() {
+                    try {
+                        return reader.readLine();
+                    } catch (IOException e) {
+                        throw new UncheckedIOException(e);
+                    }
                 }
 
-                byte[] bytes = (row + separator).getBytes(StandardCharsets.UTF_8);
-                writer.getChannel().write(ByteBuffer.wrap(bytes));
-            }
+                @Override
+                public boolean hasNext() {
+                    return next != null;
+                }
+
+                @Override
+                public Object next() {
+                    String current = next;
+                    next = advance();
+                    return current;
+                }
+            };
         }
 
-        writers.values().forEach(throwConsumer(RandomAccessFile::close));
+        @Override
+        public String routingText(Object record) {
+            return (String) record;
+        }
 
-        return files.stream().filter(p -> p.toFile().length() > 0).toList();
+        @Override
+        public RecordWriter newWriter(Path path) throws IOException {
+            OutputStream outputStream = new BufferedOutputStream(new FileOutputStream(path.toFile()), FileSerde.BUFFER_SIZE);
+
+            return new RecordWriter() {
+                @Override
+                public int write(Object record) throws IOException {
+                    byte[] bytes = (record + separator).getBytes(StandardCharsets.UTF_8);
+                    outputStream.write(bytes);
+                    return bytes.length;
+                }
+
+                @Override
+                public void close() throws IOException {
+                    outputStream.close();
+                }
+            };
+        }
+
+        @Override
+        public void close() throws IOException {
+            reader.close();
+        }
     }
+
+    // endregion
 
 }

--- a/core/src/main/java/io/kestra/core/services/StorageService.java
+++ b/core/src/main/java/io/kestra/core/services/StorageService.java
@@ -1,8 +1,13 @@
 package io.kestra.core.services;
 
+import java.io.BufferedInputStream;
+import java.io.BufferedOutputStream;
 import java.io.BufferedReader;
+import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.io.OutputStream;
 import java.io.RandomAccessFile;
 import java.net.URI;
 import java.nio.ByteBuffer;
@@ -18,15 +23,20 @@ import java.util.regex.Pattern;
 
 import io.kestra.core.exceptions.IllegalVariableEvaluationException;
 import io.kestra.core.runners.RunContext;
+import io.kestra.core.serializers.FileSerde;
+import io.kestra.core.serializers.JacksonMapper;
 import io.kestra.core.utils.RegexUtils;
 import io.kestra.core.storages.StorageSplitInterface;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.micronaut.core.convert.format.ReadableBytesTypeConverter;
 
 import static io.kestra.core.utils.Rethrow.throwConsumer;
 import static io.kestra.core.utils.Rethrow.throwFunction;
 
 public abstract class StorageService {
+
+    private static final ObjectMapper ION_MAPPER = JacksonMapper.ofIon();
 
     public static List<URI> split(RunContext runContext, StorageSplitInterface storageSplitInterface, URI from) throws IOException, IllegalVariableEvaluationException {
         String fromPath = from.getPath();
@@ -35,30 +45,174 @@ public abstract class StorageService {
             extension = fromPath.substring(fromPath.lastIndexOf('.'));
         }
 
+        boolean isIon = extension.equals(".ion");
+
+        if (isIon) {
+            return splitIon(runContext, storageSplitInterface, from, extension);
+        } else {
+            return splitText(runContext, storageSplitInterface, from, extension);
+        }
+    }
+
+    private static List<URI> splitIon(RunContext runContext, StorageSplitInterface storageSplitInterface, URI from, String extension) throws IOException, IllegalVariableEvaluationException {
+        try (InputStream inputStream = new BufferedInputStream(runContext.storage().getFile(from), FileSerde.BUFFER_SIZE)) {
+            List<Path> splited;
+
+            if (storageSplitInterface.getRegexPattern() != null) {
+                String renderedPattern = runContext.render(storageSplitInterface.getRegexPattern()).as(String.class).orElseThrow();
+                splited = splitIonByRegex(runContext, extension, inputStream, renderedPattern);
+            } else if (storageSplitInterface.getBytes() != null) {
+                ReadableBytesTypeConverter readableBytesTypeConverter = new ReadableBytesTypeConverter();
+                Number convert = readableBytesTypeConverter.convert(runContext.render(storageSplitInterface.getBytes()).as(String.class).orElseThrow(), Number.class)
+                    .orElseThrow(() -> new IllegalArgumentException("Invalid size with value '" + storageSplitInterface.getBytes() + "'"));
+
+                splited = splitIonByPredicate(runContext, extension, inputStream, (bytes, size) -> bytes >= convert.longValue());
+            } else if (storageSplitInterface.getPartitions() != null) {
+                splited = partitionIon(
+                    runContext, extension, inputStream,
+                    runContext.render(storageSplitInterface.getPartitions()).as(Integer.class).orElseThrow()
+                );
+            } else if (storageSplitInterface.getRows() != null) {
+                Integer renderedRows = runContext.render(storageSplitInterface.getRows()).as(Integer.class).orElseThrow();
+                splited = splitIonByPredicate(runContext, extension, inputStream, (bytes, size) -> size >= renderedRows);
+            } else {
+                throw new IllegalArgumentException("Invalid configuration with no size, count, rows, nor regexPattern");
+            }
+
+            return splited.stream()
+                .map(throwFunction(path -> runContext.storage().putFile(path.toFile())))
+                .toList();
+        }
+    }
+
+    private static List<Path> splitIonByPredicate(RunContext runContext, String extension, InputStream inputStream, BiFunction<Integer, Integer, Boolean> predicate)
+        throws IOException {
+        List<Path> files = new ArrayList<>();
+        OutputStream currentOutput = null;
+        int totalBytes = 0;
+        int totalRows = 0;
+
+        try {
+            var iterator = ION_MAPPER.readerFor(Object.class).readValues(ION_MAPPER.createParser(inputStream));
+            while (iterator.hasNext()) {
+                Object record = iterator.next();
+                if (currentOutput == null || predicate.apply(totalBytes, totalRows)) {
+                    if (currentOutput != null) {
+                        currentOutput.close();
+                    }
+
+                    totalBytes = 0;
+                    totalRows = 0;
+
+                    Path path = runContext.workingDir().createTempFile(extension);
+                    files.add(path);
+                    currentOutput = new BufferedOutputStream(new FileOutputStream(path.toFile()), FileSerde.BUFFER_SIZE);
+                }
+
+                byte[] bytes = JacksonMapper.ofIonBinary().writeValueAsBytes(record);
+                currentOutput.write(bytes);
+                totalBytes = totalBytes + bytes.length;
+                totalRows = totalRows + 1;
+            }
+        } finally {
+            if (currentOutput != null) {
+                currentOutput.close();
+            }
+        }
+
+        return files;
+    }
+
+    private static List<Path> partitionIon(RunContext runContext, String extension, InputStream inputStream, int partition) throws IOException {
+        List<Path> files = new ArrayList<>();
+        List<OutputStream> writers = new ArrayList<>();
+
+        try {
+            for (int i = 0; i < partition; i++) {
+                Path path = runContext.workingDir().createTempFile(extension);
+                files.add(path);
+                writers.add(new BufferedOutputStream(new FileOutputStream(path.toFile()), FileSerde.BUFFER_SIZE));
+            }
+
+            int index = 0;
+            var iterator = ION_MAPPER.readerFor(Object.class).readValues(ION_MAPPER.createParser(inputStream));
+            while (iterator.hasNext()) {
+                FileSerde.write(writers.get(index), iterator.next());
+                index = index >= writers.size() - 1 ? 0 : index + 1;
+            }
+
+            return files.stream().filter(p -> p.toFile().length() > 0).toList();
+        } finally {
+            for (OutputStream w : writers) {
+                try {
+                    w.close();
+                } catch (IOException e) {
+                    runContext.logger().error("Failed to close partition writer", e);
+                }
+            }
+        }
+    }
+
+    private static List<Path> splitIonByRegex(RunContext runContext, String extension, InputStream inputStream, String regexPattern) throws IOException {
+        List<Path> files = new ArrayList<>();
+        Map<String, OutputStream> writers = new HashMap<>();
+        Pattern pattern = Pattern.compile(regexPattern);
+
+        try {
+            var iterator = ION_MAPPER.readerFor(Object.class).readValues(ION_MAPPER.createParser(inputStream));
+            while (iterator.hasNext()) {
+                Object record = iterator.next();
+                String textIon = ION_MAPPER.writeValueAsString(record);
+                Matcher matcher = RegexUtils.matcher(pattern, textIon);
+
+                if (matcher.find() && matcher.groupCount() > 0) {
+                    String routingKey = matcher.group(1);
+
+                    OutputStream writer = writers.get(routingKey);
+                    if (writer == null) {
+                        Path path = runContext.workingDir().createTempFile(extension);
+                        files.add(path);
+                        writer = new BufferedOutputStream(new FileOutputStream(path.toFile()), FileSerde.BUFFER_SIZE);
+                        writers.put(routingKey, writer);
+                    }
+
+                    FileSerde.write(writer, record);
+                }
+            }
+        } finally {
+            writers.values().forEach(throwConsumer(OutputStream::close));
+        }
+
+        return files.stream().filter(p -> p.toFile().length() > 0).toList();
+    }
+
+    // Text-based splitting for non-ION files (original behavior)
+
+    private static List<URI> splitText(RunContext runContext, StorageSplitInterface storageSplitInterface, URI from, String extension) throws IOException, IllegalVariableEvaluationException {
         try (BufferedReader bufferedReader = new BufferedReader(new InputStreamReader(runContext.storage().getFile(from)))) {
             List<Path> splited;
 
             if (storageSplitInterface.getRegexPattern() != null) {
                 String renderedPattern = runContext.render(storageSplitInterface.getRegexPattern()).as(String.class).orElseThrow();
                 String separator = runContext.render(storageSplitInterface.getSeparator()).as(String.class).orElseThrow();
-                splited = StorageService.splitByRegex(runContext, extension, separator, bufferedReader, renderedPattern);
+                splited = splitTextByRegex(runContext, extension, separator, bufferedReader, renderedPattern);
             } else if (storageSplitInterface.getBytes() != null) {
                 ReadableBytesTypeConverter readableBytesTypeConverter = new ReadableBytesTypeConverter();
                 Number convert = readableBytesTypeConverter.convert(runContext.render(storageSplitInterface.getBytes()).as(String.class).orElseThrow(), Number.class)
                     .orElseThrow(() -> new IllegalArgumentException("Invalid size with value '" + storageSplitInterface.getBytes() + "'"));
 
-                splited = StorageService.split(
+                splited = splitTextByPredicate(
                     runContext, extension, runContext.render(storageSplitInterface.getSeparator()).as(String.class).orElseThrow(),
                     bufferedReader, (bytes, size) -> bytes >= convert.longValue()
                 );
             } else if (storageSplitInterface.getPartitions() != null) {
-                splited = StorageService.partition(
+                splited = partitionText(
                     runContext, extension, runContext.render(storageSplitInterface.getSeparator()).as(String.class).orElseThrow(),
                     bufferedReader, runContext.render(storageSplitInterface.getPartitions()).as(Integer.class).orElseThrow()
                 );
             } else if (storageSplitInterface.getRows() != null) {
                 Integer renderedRows = runContext.render(storageSplitInterface.getRows()).as(Integer.class).orElseThrow();
-                splited = StorageService.split(
+                splited = splitTextByPredicate(
                     runContext, extension, runContext.render(storageSplitInterface.getSeparator()).as(String.class).orElseThrow(),
                     bufferedReader, (bytes, size) -> size >= renderedRows
                 );
@@ -73,7 +227,7 @@ public abstract class StorageService {
         }
     }
 
-    private static List<Path> split(RunContext runContext, String extension, String separator, BufferedReader bufferedReader, BiFunction<Integer, Integer, Boolean> predicate)
+    private static List<Path> splitTextByPredicate(RunContext runContext, String extension, String separator, BufferedReader bufferedReader, BiFunction<Integer, Integer, Boolean> predicate)
         throws IOException {
         List<Path> files = new ArrayList<>();
         RandomAccessFile write = null;
@@ -110,7 +264,7 @@ public abstract class StorageService {
         return files;
     }
 
-    private static List<Path> partition(RunContext runContext, String extension, String separator, BufferedReader bufferedReader, int partition) throws IOException {
+    private static List<Path> partitionText(RunContext runContext, String extension, String separator, BufferedReader bufferedReader, int partition) throws IOException {
         List<Path> files = new ArrayList<>();
         List<RandomAccessFile> writers = new ArrayList<>();
 
@@ -142,7 +296,7 @@ public abstract class StorageService {
         }
     }
 
-    private static List<Path> splitByRegex(RunContext runContext, String extension, String separator, BufferedReader bufferedReader, String regexPattern) throws IOException {
+    private static List<Path> splitTextByRegex(RunContext runContext, String extension, String separator, BufferedReader bufferedReader, String regexPattern) throws IOException {
         List<Path> files = new ArrayList<>();
         Map<String, RandomAccessFile> writers = new HashMap<>();
         Pattern pattern = Pattern.compile(regexPattern);
@@ -154,7 +308,6 @@ public abstract class StorageService {
             if (matcher.find() && matcher.groupCount() > 0) {
                 String routingKey = matcher.group(1);
 
-                // Get or create writer for this routing key
                 RandomAccessFile writer = writers.get(routingKey);
                 if (writer == null) {
                     Path path = runContext.workingDir().createTempFile(extension);
@@ -166,7 +319,6 @@ public abstract class StorageService {
                 byte[] bytes = (row + separator).getBytes(StandardCharsets.UTF_8);
                 writer.getChannel().write(ByteBuffer.wrap(bytes));
             }
-            // Lines that don't match the pattern are ignored
         }
 
         writers.values().forEach(throwConsumer(RandomAccessFile::close));

--- a/core/src/main/java/io/kestra/plugin/core/storage/DeduplicateItems.java
+++ b/core/src/main/java/io/kestra/plugin/core/storage/DeduplicateItems.java
@@ -1,13 +1,13 @@
 package io.kestra.plugin.core.storage;
 
-import java.io.BufferedReader;
-import java.io.BufferedWriter;
+import java.io.BufferedInputStream;
+import java.io.BufferedOutputStream;
+import java.io.FileOutputStream;
 import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
+import java.io.OutputStream;
 import java.net.URI;
-import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -21,6 +21,7 @@ import io.kestra.core.models.property.Property;
 import io.kestra.core.models.tasks.RunnableTask;
 import io.kestra.core.models.tasks.Task;
 import io.kestra.core.runners.RunContext;
+import io.kestra.core.serializers.FileSerde;
 import io.kestra.core.serializers.JacksonMapper;
 
 import io.micronaut.core.util.functional.ThrowingFunction;
@@ -104,17 +105,19 @@ public class DeduplicateItems extends Task implements RunnableTask<DeduplicateIt
 
         final PebbleFieldExtractor keyExtractor = getKeyExtractor(runContext);
 
-        final Map<String, Long> index = new HashMap<>(); // can be replaced by small-footprint Map implementation
+        // Read all records into memory (needed for two-pass dedup)
+        var allRecords = new ArrayList<>();
+        try (var input = new BufferedInputStream(runContext.storage().getFile(from), FileSerde.BUFFER_SIZE)) {
+            FileSerde.read(input, allRecords::add);
+        }
 
-        // 1st iteration: build a map of key->offset
-        try (final BufferedReader reader = newBufferedReader(runContext, from)) {
-            long offset = 0L;
-            String item;
-            while ((item = reader.readLine()) != null) {
-                String key = keyExtractor.apply(item);
-                index.put(key, offset);
-                offset++;
-            }
+        final Map<String, Long> index = new HashMap<>();
+
+        // 1st pass: build a map of key->index (keeps last occurrence)
+        for (int i = 0; i < allRecords.size(); i++) {
+            String textIon = PebbleFieldExtractor.MAPPER.writeValueAsString(allRecords.get(i));
+            String key = keyExtractor.apply(textIon);
+            index.put(key, (long) i);
         }
 
         // metrics
@@ -123,23 +126,18 @@ public class DeduplicateItems extends Task implements RunnableTask<DeduplicateIt
         long numKeys = index.size();
 
         final Path path = runContext.workingDir().createTempFile(".ion");
-        // 2nd iteration: write deduplicate
-        try (
-            final BufferedWriter writer = Files.newBufferedWriter(path);
-            final BufferedReader reader = newBufferedReader(runContext, from)
-        ) {
-            long offset = 0L;
-            String item;
-            while ((item = reader.readLine()) != null) {
-                String key = keyExtractor.apply(item);
-                Long lastOffset = index.get(key);
-                if (lastOffset != null && lastOffset == offset) {
-                    writer.write(item);
-                    writer.newLine();
+        // 2nd pass: write deduplicated records
+        try (final OutputStream output = new BufferedOutputStream(new FileOutputStream(path.toFile()), FileSerde.BUFFER_SIZE)) {
+            for (int i = 0; i < allRecords.size(); i++) {
+                Object record = allRecords.get(i);
+                String textIon = PebbleFieldExtractor.MAPPER.writeValueAsString(record);
+                String key = keyExtractor.apply(textIon);
+                Long lastIndex = index.get(key);
+                if (lastIndex != null && lastIndex == i) {
+                    FileSerde.write(output, record);
                 } else {
                     droppedItemsTotal++;
                 }
-                offset++;
                 processedItemsTotal++;
             }
         }
@@ -156,11 +154,6 @@ public class DeduplicateItems extends Task implements RunnableTask<DeduplicateIt
 
     private PebbleFieldExtractor getKeyExtractor(RunContext runContext) {
         return new PebbleFieldExtractor(runContext, expr);
-    }
-
-    private BufferedReader newBufferedReader(final RunContext runContext, final URI objectURI) throws IOException {
-        InputStream is = runContext.storage().getFile(objectURI);
-        return new BufferedReader(new InputStreamReader(is));
     }
 
     @Builder

--- a/core/src/main/java/io/kestra/plugin/core/storage/FilterItems.java
+++ b/core/src/main/java/io/kestra/plugin/core/storage/FilterItems.java
@@ -1,12 +1,11 @@
 package io.kestra.plugin.core.storage;
 
-import java.io.BufferedReader;
-import java.io.BufferedWriter;
+import java.io.BufferedInputStream;
+import java.io.BufferedOutputStream;
+import java.io.FileOutputStream;
 import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
+import java.io.OutputStream;
 import java.net.URI;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Map;
 
@@ -22,6 +21,7 @@ import io.kestra.core.models.property.Property;
 import io.kestra.core.models.tasks.RunnableTask;
 import io.kestra.core.models.tasks.Task;
 import io.kestra.core.runners.RunContext;
+import io.kestra.core.serializers.FileSerde;
 import io.kestra.core.serializers.JacksonMapper;
 import io.kestra.core.utils.TruthUtils;
 
@@ -119,12 +119,15 @@ public class FilterItems extends Task implements RunnableTask<FilterItems.Output
         long processedItemsTotal = 0L;
         long droppedItemsTotal = 0L;
         try (
-            final BufferedWriter writer = Files.newBufferedWriter(path);
-            final BufferedReader reader = newBufferedReader(runContext, from)
+            final OutputStream output = new BufferedOutputStream(new FileOutputStream(path.toFile()), FileSerde.BUFFER_SIZE);
+            final var input = new BufferedInputStream(runContext.storage().getFile(from), FileSerde.BUFFER_SIZE)
         ) {
 
-            String item;
-            while ((item = reader.readLine()) != null) {
+            var records = new java.util.ArrayList<>();
+            FileSerde.read(input, records::add);
+
+            for (Object record : records) {
+                String item = PebbleExpressionPredicate.MAPPER.writeValueAsString(record);
                 IllegalVariableEvaluationException exception = null;
                 Boolean match = null;
                 try {
@@ -161,10 +164,7 @@ public class FilterItems extends Task implements RunnableTask<FilterItems.Output
                 }
 
                 switch (action) {
-                    case INCLUDE -> {
-                        writer.write(item);
-                        writer.newLine();
-                    }
+                    case INCLUDE -> FileSerde.write(output, record);
                     case EXCLUDE -> droppedItemsTotal++;
                 }
                 processedItemsTotal++;
@@ -180,11 +180,6 @@ public class FilterItems extends Task implements RunnableTask<FilterItems.Output
 
     private PebbleExpressionPredicate getExpressionPredication(RunContext runContext) {
         return new PebbleExpressionPredicate(runContext, filterCondition);
-    }
-
-    private BufferedReader newBufferedReader(final RunContext runContext, final URI objectURI) throws IOException {
-        InputStream is = runContext.storage().getFile(objectURI);
-        return new BufferedReader(new InputStreamReader(is));
     }
 
     @Builder

--- a/core/src/test/java/io/kestra/core/runners/FlowableUtilsTest.java
+++ b/core/src/test/java/io/kestra/core/runners/FlowableUtilsTest.java
@@ -333,7 +333,7 @@ class FlowableUtilsTest {
         assertThat(result.getLeft()).containsExactly("x", "y");
     }
 
-    /** Creates an ION file from a list of strings, stores it, and returns its kestra:// URI. */
+    /** Creates a text ION file from a list of strings, stores it, and returns its kestra:// URI. */
     private URI createIonFile(RunContext runContext, List<String> values) throws IOException {
         Path path = runContext.workingDir().createTempFile(".ion");
         try (BufferedWriter writer = Files.newBufferedWriter(path)) {
@@ -343,6 +343,46 @@ class FlowableUtilsTest {
             }
         }
         return runContext.storage().putFile(path.toFile());
+    }
+
+    /** Creates a binary ION file from a list of strings, stores it, and returns its kestra:// URI. */
+    private URI createBinaryIonFile(RunContext runContext, List<String> values) throws IOException {
+        Path path = runContext.workingDir().createTempFile(".ion");
+        try (var output = new java.io.BufferedOutputStream(new java.io.FileOutputStream(path.toFile()), io.kestra.core.serializers.FileSerde.BUFFER_SIZE)) {
+            for (String value : values) {
+                io.kestra.core.serializers.FileSerde.write(output, value);
+            }
+        }
+        return runContext.storage().putFile(path.toFile());
+    }
+
+    @Test
+    void readAndCountLoopValuesFromUri_withBinaryIon_shouldReturnAllValuesAndCorrectCount() throws Exception {
+        // Given
+        RunContext runContext = runContextFactory.of();
+        URI uri = createBinaryIonFile(runContext, List.of("a", "b", "c", "d", "e"));
+
+        // When
+        var result = FlowableUtils.readAndCountLoopValuesFromUri(runContext, uri.toString(), 3);
+
+        // Then
+        assertThat(result.totalCount()).isEqualTo(5);
+        assertThat(result.values()).containsExactly("a", "b", "c");
+        assertThat(result.nextOffset()).isEqualTo(3);
+    }
+
+    @Test
+    void readLoopValuesFromUri_withBinaryIon_shouldResumeFromOffset() throws Exception {
+        // Given
+        RunContext runContext = runContextFactory.of();
+        URI uri = createBinaryIonFile(runContext, List.of("a", "b", "c", "d", "e"));
+
+        // When — read 2 starting at offset 2
+        var result = FlowableUtils.readLoopValuesFromUri(runContext, uri.toString(), 2, 2);
+
+        // Then
+        assertThat(result.getLeft()).containsExactly("c", "d");
+        assertThat(result.getRight()).isEqualTo(4L);
     }
 
     private static ResolvedTask resolvedTask(String id) {

--- a/core/src/test/java/io/kestra/plugin/core/storage/DeduplicateItemsTest.java
+++ b/core/src/test/java/io/kestra/plugin/core/storage/DeduplicateItemsTest.java
@@ -117,20 +117,9 @@ class DeduplicateItemsTest {
         final DeduplicateItems.Output output,
         final List<T> expected,
         final Class<T> type) throws IOException {
-        try (
-            InputStream resource = runContext.storage().getFile(output.getUri());
-            InputStreamReader inputStreamReader = new InputStreamReader(resource, StandardCharsets.UTF_8);
-            BufferedReader bufferedReader = new BufferedReader(inputStreamReader)
-        ) {
-            List<T> list = bufferedReader.lines()
-                .map(line ->
-                {
-                    try {
-                        return JacksonMapper.ofIon().readValue(line, type);
-                    } catch (JsonProcessingException e) {
-                        throw new RuntimeException(e);
-                    }
-                }).toList();
+        try (InputStream resource = new java.io.BufferedInputStream(runContext.storage().getFile(output.getUri()), io.kestra.core.serializers.FileSerde.BUFFER_SIZE)) {
+            List<T> list = new java.util.ArrayList<>();
+            io.kestra.core.serializers.FileSerde.read(resource, row -> list.add(JacksonMapper.ofIon().convertValue(row, type)));
             Assertions.assertEquals(expected, list);
         }
     }
@@ -149,6 +138,56 @@ class DeduplicateItemsTest {
             });
         }
         return runContext.storage().putFile(path.toFile());
+    }
+
+    private URI generateBinaryKeyValueFile(final List<?> items, RunContext runContext) throws IOException {
+        Path path = runContext.workingDir().createTempFile(".ion");
+        try (var output = new java.io.BufferedOutputStream(new java.io.FileOutputStream(path.toFile()), io.kestra.core.serializers.FileSerde.BUFFER_SIZE)) {
+            for (Object item : items) {
+                io.kestra.core.serializers.FileSerde.write(output, item);
+            }
+        }
+        return runContext.storage().putFile(path.toFile());
+    }
+
+    @Test
+    void shouldDeduplicateBinaryIonFileGivenKeyExpression() throws Exception {
+        // Given
+        RunContext runContext = runContextFactory.of();
+
+        List<KeyValue1> values = List.of(
+            new KeyValue1("k1", "v1"),
+            new KeyValue1("k2", "v1"),
+            new KeyValue1("k3", "v1"),
+            new KeyValue1("k1", "v2"),
+            new KeyValue1("k2", "v2"),
+            new KeyValue1("k2", null),
+            new KeyValue1("k3", "v2"),
+            new KeyValue1("k1", "v3")
+        );
+
+        DeduplicateItems task = DeduplicateItems
+            .builder()
+            .from(Property.ofValue(generateBinaryKeyValueFile(values, runContext).toString()))
+            .expr(" {{ key }} ")
+            .build();
+
+        // When
+        DeduplicateItems.Output output = task.run(runContext);
+
+        // Then
+        Assertions.assertNotNull(output);
+        Assertions.assertNotNull(output.getUri());
+        Assertions.assertEquals(3, output.getNumKeys());
+        Assertions.assertEquals(5, output.getDroppedItemsTotal());
+        Assertions.assertEquals(8, output.getProcessedItemsTotal());
+
+        List<KeyValue1> expected = List.of(
+            new KeyValue1("k2", null),
+            new KeyValue1("k3", "v2"),
+            new KeyValue1("k1", "v3")
+        );
+        assertSimpleCompactedFile(runContext, output, expected, KeyValue1.class);
     }
 
     record KeyValue1(String key, Object value) {

--- a/core/src/test/java/io/kestra/plugin/core/storage/FilterItemsTest.java
+++ b/core/src/test/java/io/kestra/plugin/core/storage/FilterItemsTest.java
@@ -187,20 +187,9 @@ class FilterItemsTest {
         final FilterItems.Output output,
         final List<T> expected,
         final Class<T> type) throws IOException {
-        try (
-            InputStream resource = runContext.storage().getFile(output.getUri());
-            InputStreamReader inputStreamReader = new InputStreamReader(resource, StandardCharsets.UTF_8);
-            BufferedReader bufferedReader = new BufferedReader(inputStreamReader)
-        ) {
-            List<T> list = bufferedReader.lines()
-                .map(line ->
-                {
-                    try {
-                        return JacksonMapper.ofIon().readValue(line, type);
-                    } catch (JsonProcessingException e) {
-                        throw new RuntimeException(e);
-                    }
-                }).toList();
+        try (InputStream resource = new java.io.BufferedInputStream(runContext.storage().getFile(output.getUri()), io.kestra.core.serializers.FileSerde.BUFFER_SIZE)) {
+            List<T> list = new java.util.ArrayList<>();
+            io.kestra.core.serializers.FileSerde.read(resource, row -> list.add(JacksonMapper.ofIon().convertValue(row, type)));
             Assertions.assertEquals(expected, list);
         }
     }
@@ -219,6 +208,62 @@ class FilterItemsTest {
             });
         }
         return runContext.storage().putFile(path.toFile());
+    }
+
+    private URI generateBinaryKeyValueFile(final List<?> items, RunContext runContext) throws IOException {
+        Path path = runContext.workingDir().createTempFile(".ion");
+        try (var output = new java.io.BufferedOutputStream(new java.io.FileOutputStream(path.toFile()), io.kestra.core.serializers.FileSerde.BUFFER_SIZE)) {
+            for (Object item : items) {
+                io.kestra.core.serializers.FileSerde.write(output, item);
+            }
+        }
+        return runContext.storage().putFile(path.toFile());
+    }
+
+    @Test
+    void shouldFilterBinaryIonGivenValidBooleanExpressionForInclude() throws Exception {
+        // Given
+        RunContext runContext = runContextFactory.of();
+
+        FilterItems task = FilterItems
+            .builder()
+            .from(Property.ofValue(generateBinaryKeyValueFile(TEST_VALID_ITEMS, runContext).toString()))
+            .filterCondition(" {{ value % 2 == 0 }} ")
+            .filterType(Property.ofValue(FilterItems.FilterType.INCLUDE))
+            .build();
+
+        // When
+        FilterItems.Output output = task.run(runContext);
+
+        // Then
+        Assertions.assertNotNull(output);
+        Assertions.assertNotNull(output.getUri());
+        Assertions.assertEquals(2, output.getDroppedItemsTotal());
+        Assertions.assertEquals(4, output.getProcessedItemsTotal());
+        assertFile(runContext, output, List.of(new KeyValue("k2", 2), new KeyValue("k4", 4)), KeyValue.class);
+    }
+
+    @Test
+    void shouldFilterBinaryIonGivenValidBooleanExpressionForExclude() throws Exception {
+        // Given
+        RunContext runContext = runContextFactory.of();
+
+        FilterItems task = FilterItems
+            .builder()
+            .from(Property.ofValue(generateBinaryKeyValueFile(TEST_VALID_ITEMS, runContext).toString()))
+            .filterCondition(" {{ value % 2 == 0 }} ")
+            .filterType(Property.ofValue(FilterItems.FilterType.EXCLUDE))
+            .build();
+
+        // When
+        FilterItems.Output output = task.run(runContext);
+
+        // Then
+        Assertions.assertNotNull(output);
+        Assertions.assertNotNull(output.getUri());
+        Assertions.assertEquals(2, output.getDroppedItemsTotal());
+        Assertions.assertEquals(4, output.getProcessedItemsTotal());
+        assertFile(runContext, output, List.of(new KeyValue("k1", 1), new KeyValue("k3", 3)), KeyValue.class);
     }
 
     record KeyValue(String key, Object value) {

--- a/core/src/test/java/io/kestra/plugin/core/storage/SplitTest.java
+++ b/core/src/test/java/io/kestra/plugin/core/storage/SplitTest.java
@@ -1,25 +1,34 @@
 package io.kestra.plugin.core.storage;
 
+import java.io.BufferedOutputStream;
 import java.io.File;
 import java.io.FileInputStream;
+import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.io.OutputStream;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.file.Files;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import org.apache.commons.lang3.StringUtils;
 import org.junit.jupiter.api.Test;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.SequenceWriter;
 import com.google.common.io.CharStreams;
 
 import io.kestra.core.context.TestRunContextFactory;
 import io.kestra.core.junit.annotations.KestraTest;
 import io.kestra.core.models.property.Property;
 import io.kestra.core.runners.RunContext;
+import io.kestra.core.serializers.FileSerde;
 import io.kestra.core.storages.StorageInterface;
 import io.kestra.core.utils.IdUtils;
 import io.kestra.core.utils.Rethrow;
@@ -106,6 +115,89 @@ class SplitTest {
         assertThat(allContent).contains("[ERROR] Error message 2");
     }
 
+    @Test
+    void partitionIon() throws Exception {
+        RunContext runContext = runContextFactory.of();
+        URI put = storageUploadIon(ionContent(1000));
+
+        Split result = Split.builder()
+            .from(Property.ofValue(put.toString()))
+            .partitions(Property.ofValue(8))
+            .build();
+
+        Split.Output run = result.run(runContext);
+
+        assertThat(run.getUris().size()).isEqualTo(8);
+        assertThat(run.getUris().getFirst().getPath()).endsWith(".ion");
+        assertThat(readAllIon(run.getUris())).hasSize(1000);
+    }
+
+    @Test
+    void rowsIon() throws Exception {
+        RunContext runContext = runContextFactory.of();
+        URI put = storageUploadIon(ionContent(1000));
+
+        Split result = Split.builder()
+            .from(Property.ofValue(put.toString()))
+            .rows(Property.ofValue(10))
+            .build();
+
+        Split.Output run = result.run(runContext);
+
+        assertThat(run.getUris().size()).isEqualTo(100);
+
+        List<Object> records = readAllIon(run.getUris());
+        assertThat(records).hasSize(1000);
+        // order is preserved across the split
+        List<Integer> ids = records.stream().map(record -> ((Number) ((Map<?, ?>) record).get("id")).intValue()).toList();
+        assertThat(ids).isEqualTo(IntStream.range(0, 1000).boxed().toList());
+    }
+
+    @Test
+    void bytesIon() throws Exception {
+        RunContext runContext = runContextFactory.of();
+        URI put = storageUploadIon(ionContent(1000));
+
+        Split result = Split.builder()
+            .from(Property.ofValue(put.toString()))
+            .bytes(Property.ofValue("1KB"))
+            .build();
+
+        Split.Output run = result.run(runContext);
+
+        assertThat(run.getUris().size()).isGreaterThan(1);
+        assertThat(readAllIon(run.getUris())).hasSize(1000);
+    }
+
+    @Test
+    void regexPatternIon() throws Exception {
+        RunContext runContext = runContextFactory.of();
+        URI put = storageUploadIon(List.of(
+            Map.of("id", 1, "level", "ERROR"),
+            Map.of("id", 2, "level", "WARN"),
+            Map.of("id", 3, "level", "INFO"),
+            Map.of("id", 4, "level", "ERROR"),
+            Map.of("id", 5, "level", "WARN"),
+            Map.of("id", 6, "level", "INFO"),
+            Map.of("id", 7),
+            Map.of("id", 8, "level", "ERROR")
+        ));
+
+        Split result = Split.builder()
+            .from(Property.ofValue(put.toString()))
+            .regexPattern(Property.ofValue("level:\"(\\w+)\""))
+            .build();
+
+        Split.Output run = result.run(runContext);
+        // one file per distinct level (ERROR, WARN, INFO); the record without a level is dropped
+        assertThat(run.getUris().size()).isEqualTo(3);
+
+        List<Object> records = readAllIon(run.getUris());
+        assertThat(records).hasSize(7);
+        List<String> levels = records.stream().map(record -> (String) ((Map<?, ?>) record).get("level")).toList();
+        assertThat(levels).containsOnly("ERROR", "WARN", "INFO");
+    }
+
     private List<String> content(int count) {
         return IntStream
             .range(0, count)
@@ -155,6 +247,41 @@ class SplitTest {
             new URI("/file/storage/%s/get.yml".formatted(IdUtils.create())),
             new FileInputStream(tempFile)
         );
+    }
+
+    private List<Map<String, Object>> ionContent(int count) {
+        return IntStream
+            .range(0, count)
+            .mapToObj(value -> Map.<String, Object>of("id", value))
+            .toList();
+    }
+
+    URI storageUploadIon(List<Map<String, Object>> records) throws URISyntaxException, IOException {
+        File tempFile = File.createTempFile("unit", ".ion");
+
+        try (OutputStream outputStream = new BufferedOutputStream(new FileOutputStream(tempFile));
+             SequenceWriter writer = FileSerde.createBinarySequenceWriter(outputStream, new TypeReference<Object>() {})) {
+            for (Map<String, Object> record : records) {
+                writer.write(record);
+            }
+        }
+
+        return storageInterface.put(
+            MAIN_TENANT,
+            null,
+            new URI("/file/storage/%s/get.ion".formatted(IdUtils.create())),
+            new FileInputStream(tempFile)
+        );
+    }
+
+    private List<Object> readAllIon(List<URI> uris) throws IOException {
+        List<Object> records = new ArrayList<>();
+        for (URI uri : uris) {
+            try (InputStream inputStream = storageInterface.get(MAIN_TENANT, null, uri)) {
+                FileSerde.read(inputStream, records::add);
+            }
+        }
+        return records;
     }
 
 }


### PR DESCRIPTION
## Summary

After the binary ION switch (`66f239b3e`), several core components loaded entire ION files into `ArrayList` buffers before processing. This caused:
- **O(N²) memory usage** for Loop iterations (`FlowableUtils.readLoopValuesFromUri` loaded the full file on every call with `count=1`)
- **Unbounded memory** for Split operations on large files (`StorageService.splitIon` buffered all records)
- **Binary ION corruption** when `StorageService.split()` read binary ION through UTF-8 text streams (`bad character [239, "\xef"]`)

### Changes
- **StorageService**: stream ION records via `MappingIterator` directly from `InputStream` — no intermediate `ArrayList`
- **FlowableUtils**: stream-and-skip pattern — count/skip records in the consumer callback without storing them (O(limit) memory instead of O(N))
- **FilterItems / DeduplicateItems**: migrated from `BufferedReader`/`readLine()` to `FileSerde.read()`/`FileSerde.write()` for binary ION support
- **FileSerde**: removed premature `try-with-resources` parser close in `createMappingIterator`, added `createBinarySequenceWriter` for EE exporters
- Added binary ION input test coverage for FilterItems, DeduplicateItems, and FlowableUtils

## Test plan
- [x] `StorageServiceTest` — 12/12 pass (ION + text split paths)
- [x] `FilterItemsTest` — 7 tests including 2 new binary ION input tests
- [x] `DeduplicateItemsTest` — 4 tests including 1 new binary ION input test
- [x] `FlowableUtilsTest` — 21 tests including 2 new binary ION input tests

Closes #16554