### PR TITLE
fix(worker-controller): deliver storage discovery results on the gRPC SynchronizationContext

### DIFF
--- a/worker-controller/src/main/java/io/kestra/controller/grpc/resolver/StorageNameResolver.java
+++ b/worker-controller/src/main/java/io/kestra/controller/grpc/resolver/StorageNameResolver.java
@@ -13,6 +13,7 @@ import java.util.function.Supplier;
 import io.grpc.EquivalentAddressGroup;
 import io.grpc.NameResolver;
 import io.grpc.StatusOr;
+import io.grpc.SynchronizationContext;
 import io.kestra.core.utils.ExecutorsUtils;
 import lombok.extern.slf4j.Slf4j;
 
@@ -31,6 +32,7 @@ public class StorageNameResolver extends NameResolver {
 
     private final Supplier<List<EquivalentAddressGroup>> addressSupplier;
     private final Duration refreshInterval;
+    private final SynchronizationContext syncContext;
 
     private volatile Listener2 listener;
     private volatile ScheduledExecutorService scheduler;
@@ -42,12 +44,16 @@ public class StorageNameResolver extends NameResolver {
      *
      * @param addressSupplier supplies the current list of controller endpoints.
      * @param refreshInterval how often to poll the supplier.
+     * @param syncContext     the channel's synchronization context; all listener notifications
+     *                        must be delivered on it (see {@link #resolve()}).
      */
     public StorageNameResolver(
         final Supplier<List<EquivalentAddressGroup>> addressSupplier,
-        final Duration refreshInterval) {
+        final Duration refreshInterval,
+        final SynchronizationContext syncContext) {
         this.addressSupplier = Objects.requireNonNull(addressSupplier);
         this.refreshInterval = Objects.requireNonNull(refreshInterval);
+        this.syncContext = Objects.requireNonNull(syncContext);
     }
 
     /**
@@ -119,8 +125,9 @@ public class StorageNameResolver extends NameResolver {
             return;
         }
         lastAddresses = next;
-        listener.onResult2(ResolutionResult.newBuilder()
+        // onResult2 must run on the channel's SynchronizationContext, not our scheduler thread.
+        syncContext.execute(() -> listener.onResult2(ResolutionResult.newBuilder()
             .setAddressesOrError(StatusOr.fromValue(addresses))
-            .build());
+            .build()));
     }
 }

--- a/worker-controller/src/main/java/io/kestra/controller/grpc/resolver/StorageNameResolverProvider.java
+++ b/worker-controller/src/main/java/io/kestra/controller/grpc/resolver/StorageNameResolverProvider.java
@@ -46,7 +46,7 @@ public class StorageNameResolverProvider extends NameResolverProvider {
         if (!SCHEME.equals(targetUri.getScheme())) {
             return null;
         }
-        return new StorageNameResolver(addressSupplier, refreshInterval);
+        return new StorageNameResolver(addressSupplier, refreshInterval, args.getSynchronizationContext());
     }
 
     @Override

--- a/worker-controller/src/test/java/io/kestra/controller/resolver/StorageNameResolverTest.java
+++ b/worker-controller/src/test/java/io/kestra/controller/resolver/StorageNameResolverTest.java
@@ -5,6 +5,7 @@ import java.net.URI;
 import java.time.Duration;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -16,10 +17,14 @@ import io.kestra.controller.grpc.resolver.StorageNameResolverProvider;
 
 import io.grpc.EquivalentAddressGroup;
 import io.grpc.NameResolver;
+import io.grpc.SynchronizationContext;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 class StorageNameResolverTest {
+
+    private final SynchronizationContext syncContext =
+        new SynchronizationContext((t, e) -> { /* no-op */ });
 
     @Test
     void shouldPublishInitialAddressesOnStart() {
@@ -28,7 +33,7 @@ class StorageNameResolverTest {
             new EquivalentAddressGroup(new InetSocketAddress("controller-1", 9096)),
             new EquivalentAddressGroup(new InetSocketAddress("controller-2", 9097))
         );
-        StorageNameResolver resolver = new StorageNameResolver(() -> addresses, Duration.ofMinutes(1));
+        StorageNameResolver resolver = new StorageNameResolver(() -> addresses, Duration.ofMinutes(1), syncContext);
         AtomicReference<NameResolver.ResolutionResult> result = new AtomicReference<>();
 
         // When
@@ -47,7 +52,7 @@ class StorageNameResolverTest {
         List<EquivalentAddressGroup> addresses = List.of(
             new EquivalentAddressGroup(new InetSocketAddress("controller-1", 9096))
         );
-        StorageNameResolver resolver = new StorageNameResolver(() -> addresses, Duration.ofMinutes(1));
+        StorageNameResolver resolver = new StorageNameResolver(() -> addresses, Duration.ofMinutes(1), syncContext);
         AtomicInteger callCount = new AtomicInteger();
         resolver.start(new TestListener(new AtomicReference<>(), callCount));
 
@@ -67,7 +72,7 @@ class StorageNameResolverTest {
         AtomicReference<List<EquivalentAddressGroup>> supplied = new AtomicReference<>(List.of(
             new EquivalentAddressGroup(new InetSocketAddress("controller-1", 9096))
         ));
-        StorageNameResolver resolver = new StorageNameResolver(supplied::get, Duration.ofMinutes(1));
+        StorageNameResolver resolver = new StorageNameResolver(supplied::get, Duration.ofMinutes(1), syncContext);
         AtomicInteger callCount = new AtomicInteger();
         AtomicReference<NameResolver.ResolutionResult> result = new AtomicReference<>();
         resolver.start(new TestListener(result, callCount));
@@ -93,7 +98,7 @@ class StorageNameResolverTest {
         StorageNameResolver resolver = new StorageNameResolver(() -> {
             supplierCalls.incrementAndGet();
             return List.of(new EquivalentAddressGroup(new InetSocketAddress("controller", 9096)));
-        }, Duration.ofMillis(100));
+        }, Duration.ofMillis(100), syncContext);
         resolver.start(new TestListener(new AtomicReference<>(), new AtomicInteger()));
 
         // When — wait for the scheduler to tick at least a couple of times
@@ -114,7 +119,7 @@ class StorageNameResolverTest {
         StorageNameResolverProvider provider = new StorageNameResolverProvider(List::of, Duration.ofMinutes(1));
 
         // When
-        NameResolver resolver = provider.newNameResolver(URI.create("storage:///controllers"), null);
+        NameResolver resolver = provider.newNameResolver(URI.create("storage:///controllers"), resolverArgs());
 
         // Then
         assertThat(resolver).isInstanceOf(StorageNameResolver.class);
@@ -128,6 +133,72 @@ class StorageNameResolverTest {
 
         // When / Then
         assertThat(provider.newNameResolver(URI.create("dns:///localhost"), null)).isNull();
+    }
+
+    @Test
+    void shouldDeliverScheduledResolutionOnSynchronizationContext() {
+        // Given — a sub-second interval so the scheduled tick (off the sync context thread) fires
+        AtomicReference<List<EquivalentAddressGroup>> supplied = new AtomicReference<>(List.of(
+            new EquivalentAddressGroup(new InetSocketAddress("controller-1", 9096))
+        ));
+        StorageNameResolver resolver = new StorageNameResolver(supplied::get, Duration.ofMillis(100), syncContext);
+        AtomicBoolean offContext = new AtomicBoolean(false);
+        AtomicInteger notifications = new AtomicInteger();
+        resolver.start(new ContextCheckingListener(offContext, notifications));
+
+        // When — change the addresses so the scheduled refresh (not start()) notifies the listener
+        supplied.set(List.of(
+            new EquivalentAddressGroup(new InetSocketAddress("controller-1", 9096)),
+            new EquivalentAddressGroup(new InetSocketAddress("controller-2", 9097))
+        ));
+        Awaitility.await()
+            .atMost(Duration.ofSeconds(2))
+            .pollInterval(50, TimeUnit.MILLISECONDS)
+            .until(() -> notifications.get() >= 2);
+        resolver.shutdown();
+
+        // Then — every onResult2 must run on the channel's SynchronizationContext, including the
+        // one delivered from the scheduler thread (the regression this guards against).
+        assertThat(offContext.get()).isFalse();
+    }
+
+    private NameResolver.Args resolverArgs() {
+        return NameResolver.Args.newBuilder()
+            .setDefaultPort(50051)
+            .setProxyDetector(target -> null)
+            .setSynchronizationContext(syncContext)
+            .setServiceConfigParser(new NameResolver.ServiceConfigParser() {
+                @Override
+                public NameResolver.ConfigOrError parseServiceConfig(java.util.Map<String, ?> rawServiceConfig) {
+                    return NameResolver.ConfigOrError.fromConfig(rawServiceConfig);
+                }
+            })
+            .build();
+    }
+
+    private class ContextCheckingListener extends NameResolver.Listener2 {
+        private final AtomicBoolean offContext;
+        private final AtomicInteger callCount;
+
+        ContextCheckingListener(AtomicBoolean offContext, AtomicInteger callCount) {
+            this.offContext = offContext;
+            this.callCount = callCount;
+        }
+
+        @Override
+        public void onResult(NameResolver.ResolutionResult resolutionResult) {
+            try {
+                syncContext.throwIfNotInThisSynchronizationContext();
+            } catch (IllegalStateException e) {
+                offContext.set(true);
+            }
+            callCount.incrementAndGet();
+        }
+
+        @Override
+        public void onError(io.grpc.Status error) {
+            // Not used in tests
+        }
     }
 
     private static class TestListener extends NameResolver.Listener2 {


### PR DESCRIPTION
StorageNameResolver invoked Listener2.onResult2 from its background refresh thread, but gRPC requires that callback to run on the channel's SynchronizationContext. The scheduled refresh therefore threw IllegalStateException, the discovered controller endpoints were dropped, and on cold start the worker never received an address — connect failed with DEADLINE_EXCEEDED.

Pass the channel's SynchronizationContext into the resolver (via NameResolver.Args) and dispatch onResult2 through it. Add a regression test asserting scheduled resolutions are delivered on the context.