### PR TITLE
fix(worker-controller): drop unsupported DNS SRV record type

### DIFF
--- a/worker-controller/src/main/java/io/kestra/controller/GrpcChannelManager.java
+++ b/worker-controller/src/main/java/io/kestra/controller/GrpcChannelManager.java
@@ -54,7 +54,7 @@ import java.util.function.Supplier;
  * Supports three service discovery strategies:
  * <ul>
  * <li>STATIC: Explicit list of controller endpoints with gRPC load-balancing</li>
- * <li>DNS: DNS SRV/A record resolution with gRPC load-balancing</li>
+ * <li>DNS: DNS A-record resolution with gRPC load-balancing</li>
  * <li>STORAGE: Dynamic discovery via Kestra internal storage (controllers self-register)</li>
  * </ul>
  * <p>
@@ -275,16 +275,11 @@ public class GrpcChannelManager {
             throw new IllegalStateException("DNS configuration requires a hostname");
         }
 
-        String target = switch (dnsConfig.recordType()) {
-            case SRV -> {
-                log.info("Configuring DNS discovery with SRV records for: {}", dnsConfig.hostname());
-                yield "dns:///" + dnsConfig.hostname();
-            }
-            case A -> {
-                log.info("Configuring DNS discovery with A records for: {}:{}", dnsConfig.hostname(), dnsConfig.defaultPort());
-                yield "dns:///" + dnsConfig.hostname() + ":" + dnsConfig.defaultPort();
-            }
-        };
+        // The gRPC DNS name resolver performs A/AAAA record lookups of the hostname and connects to
+        // each resolved address on defaultPort. It does not query _grpc._tcp.<host> SRV records, so
+        // SRV-based discovery is intentionally not offered here.
+        log.info("Configuring DNS discovery with A records for: {}:{}", dnsConfig.hostname(), dnsConfig.defaultPort());
+        String target = "dns:///" + dnsConfig.hostname() + ":" + dnsConfig.defaultPort();
         return Grpc.newChannelBuilder(target, createChannelCredentials());
     }
 

--- a/worker-controller/src/main/java/io/kestra/controller/config/WorkerControllersConfiguration.java
+++ b/worker-controller/src/main/java/io/kestra/controller/config/WorkerControllersConfiguration.java
@@ -21,7 +21,7 @@ import static io.kestra.controller.config.ControllerConfiguration.DEFAULT_GRPC_P
  * Supports three discovery strategies:
  * <ul>
  * <li>STATIC: Explicit list of controller endpoints with gRPC load-balancing</li>
- * <li>DNS: DNS SRV/A record resolution with gRPC load-balancing</li>
+ * <li>DNS: DNS A-record resolution with gRPC load-balancing</li>
  * <li>STORAGE: Dynamic discovery via Kestra internal storage (controllers self-register)</li>
  * </ul>
  * <p>
@@ -42,6 +42,12 @@ public record WorkerControllersConfiguration(
     @Valid HealthCheck healthCheck,
 
     @Valid WaitForReady waitForReady) {
+
+    /**
+     * Default interval at which DNS/storage discovery re-resolves controller endpoints.
+     */
+    public static final String DEFAULT_REFRESH_INTERVAL = "PT30S";
+
     /**
      * Service discovery type.
      */
@@ -81,6 +87,11 @@ public record WorkerControllersConfiguration(
 
     /**
      * DNS-based discovery configuration.
+     * <p>
+     * Resolution uses the gRPC DNS name resolver, which performs A/AAAA record lookups of
+     * {@code hostname} and connects to each resolved address on {@code defaultPort}. SRV-record
+     * discovery is not supported: the gRPC DNS resolver does not query {@code _grpc._tcp.<host>}
+     * SRV records, so no SRV record type is offered.
      */
     @ConfigurationProperties("dns")
     @Requires(property = "kestra.worker.controllers.type", value = "DNS")
@@ -89,22 +100,7 @@ public record WorkerControllersConfiguration(
 
         @Bindable(defaultValue = DEFAULT_GRPC_PORT_STRING) int defaultPort,
 
-        @Bindable(defaultValue = "SRV") DnsRecordType recordType,
-
-        @Bindable(defaultValue = "PT30S") Duration refreshInterval) {
-        /**
-         * DNS record type for discovery.
-         */
-        public enum DnsRecordType {
-            /**
-             * SRV records (includes port information).
-             */
-            SRV,
-            /**
-             * A records (requires default port).
-             */
-            A
-        }
+        @Bindable(defaultValue = DEFAULT_REFRESH_INTERVAL) Duration refreshInterval) {
     }
 
     /**
@@ -113,7 +109,7 @@ public record WorkerControllersConfiguration(
     @ConfigurationProperties("storage")
     @Requires(property = "kestra.worker.controllers.type", value = "STORAGE")
     public record StorageConfig(
-        @Bindable(defaultValue = "PT30S") Duration refreshInterval) {
+        @Bindable(defaultValue = DEFAULT_REFRESH_INTERVAL) Duration refreshInterval) {
     }
 
     /**

--- a/worker-controller/src/test/java/io/kestra/controller/GrpcChannelManagerTest.java
+++ b/worker-controller/src/test/java/io/kestra/controller/GrpcChannelManagerTest.java
@@ -87,24 +87,9 @@ class GrpcChannelManagerTest {
     }
 
     @Test
-    void shouldCreateChannelWithDnsSrvConfiguration() {
+    void shouldCreateChannelWithDnsConfiguration() {
         // Given
-        WorkerControllersConfiguration config = createDnsSrvConfig("kestra-controller.default.svc.cluster.local");
-        GrpcChannelConfiguration channelConfig = createDefaultChannelConfig();
-
-        // When
-        channelManager = new GrpcChannelManager(channelConfig, createDefaultGrpcConfig(), config, null);
-        channelManager.init();
-
-        // Then
-        Channel channel = channelManager.getDefaultChannel();
-        assertThat(channel).isNotNull();
-    }
-
-    @Test
-    void shouldCreateChannelWithDnsARecordConfiguration() {
-        // Given
-        WorkerControllersConfiguration config = createDnsARecordConfig("controllers.example.com", 9096);
+        WorkerControllersConfiguration config = createDnsConfig("controllers.example.com", 9096);
         GrpcChannelConfiguration channelConfig = createDefaultChannelConfig();
 
         // When
@@ -156,7 +141,7 @@ class GrpcChannelManagerTest {
         WorkerControllersConfiguration config = new WorkerControllersConfiguration(
             DiscoveryType.DNS,
             null,
-            new DnsConfig("", 9096, DnsConfig.DnsRecordType.SRV, Duration.ofSeconds(30)),
+            new DnsConfig("", 9096, Duration.ofSeconds(30)),
             null,
             new LoadBalancing(LoadBalancing.Policy.ROUND_ROBIN),
             new HealthCheck(true),
@@ -480,23 +465,11 @@ class GrpcChannelManagerTest {
         );
     }
 
-    private static WorkerControllersConfiguration createDnsSrvConfig(String hostname) {
+    private static WorkerControllersConfiguration createDnsConfig(String hostname, int defaultPort) {
         return new WorkerControllersConfiguration(
             DiscoveryType.DNS,
             null,
-            new DnsConfig(hostname, 9096, DnsConfig.DnsRecordType.SRV, Duration.ofSeconds(30)),
-            null,
-            new LoadBalancing(LoadBalancing.Policy.ROUND_ROBIN),
-            new HealthCheck(true),
-            new WorkerControllersConfiguration.WaitForReady(true, Duration.ofSeconds(1))
-        );
-    }
-
-    private static WorkerControllersConfiguration createDnsARecordConfig(String hostname, int defaultPort) {
-        return new WorkerControllersConfiguration(
-            DiscoveryType.DNS,
-            null,
-            new DnsConfig(hostname, defaultPort, DnsConfig.DnsRecordType.A, Duration.ofSeconds(30)),
+            new DnsConfig(hostname, defaultPort, Duration.ofSeconds(30)),
             null,
             new LoadBalancing(LoadBalancing.Policy.ROUND_ROBIN),
             new HealthCheck(true),

--- a/worker-controller/src/test/java/io/kestra/controller/config/WorkerControllersConfigurationTest.java
+++ b/worker-controller/src/test/java/io/kestra/controller/config/WorkerControllersConfigurationTest.java
@@ -41,31 +41,10 @@ class WorkerControllersConfigurationTest {
     }
 
     @Test
-    void shouldParseDnsSrvConfiguration() {
-        Map<String, Object> properties = Map.of(
-            "kestra.worker.controllers.type", "DNS",
-            "kestra.worker.controllers.dns.hostname", "kestra-controller.default.svc.cluster.local",
-            "kestra.worker.controllers.dns.record-type", "SRV",
-            "kestra.worker.controllers.dns.refresh-interval", "30s"
-        );
-
-        try (ApplicationContext context = ApplicationContext.run(PropertySource.of("test", properties))) {
-            WorkerControllersConfiguration config = context.getBean(WorkerControllersConfiguration.class);
-
-            assertThat(config.type()).isEqualTo(WorkerControllersConfiguration.DiscoveryType.DNS);
-            assertThat(config.dnsConfig()).isNotNull();
-            assertThat(config.dnsConfig().hostname()).isEqualTo("kestra-controller.default.svc.cluster.local");
-            assertThat(config.dnsConfig().recordType()).isEqualTo(WorkerControllersConfiguration.DnsConfig.DnsRecordType.SRV);
-            assertThat(config.dnsConfig().refreshInterval()).isEqualTo(Duration.ofSeconds(30));
-        }
-    }
-
-    @Test
-    void shouldParseDnsARecordConfiguration() {
+    void shouldParseDnsConfiguration() {
         Map<String, Object> properties = Map.of(
             "kestra.worker.controllers.type", "DNS",
             "kestra.worker.controllers.dns.hostname", "controllers.internal.company.com",
-            "kestra.worker.controllers.dns.record-type", "A",
             "kestra.worker.controllers.dns.default-port", "9096",
             "kestra.worker.controllers.dns.refresh-interval", "60s"
         );
@@ -76,7 +55,6 @@ class WorkerControllersConfigurationTest {
             assertThat(config.type()).isEqualTo(WorkerControllersConfiguration.DiscoveryType.DNS);
             assertThat(config.dnsConfig()).isNotNull();
             assertThat(config.dnsConfig().hostname()).isEqualTo("controllers.internal.company.com");
-            assertThat(config.dnsConfig().recordType()).isEqualTo(WorkerControllersConfiguration.DnsConfig.DnsRecordType.A);
             assertThat(config.dnsConfig().defaultPort()).isEqualTo(9096);
             assertThat(config.dnsConfig().refreshInterval()).isEqualTo(Duration.ofSeconds(60));
         }


### PR DESCRIPTION
The DNS discovery 'recordType: SRV' option never performed SRV resolution. Both record types built a 'dns:///<host>' target handed to gRPC's built-in DNS name resolver, which only does A/AAAA lookups of the hostname and never queries _grpc._tcp.<host> SRV records (grpc-java has no SRV endpoint discovery; see grpc/grpc-java#2109). SRV mode therefore A-looked-up the bare hostname and failed with UnknownHostException.

Remove the recordType knob and DnsRecordType enum; DNS discovery is now A-records only (dns:///<host>:<defaultPort>). Also extract the shared PT30S default into a DEFAULT_REFRESH_INTERVAL constant.