### PR TITLE
fix(flows): fix text overlapping issue in no-code form labels

### DIFF
--- a/ui/packages/design-system/src/components/Form/KsEditor.vue
+++ b/ui/packages/design-system/src/components/Form/KsEditor.vue
@@ -337,6 +337,7 @@
 
     const showPlaceholder = computed(() =>
         props.inline === true &&
+        !props.placeholder &&
         !mergedOptions.value.shouldFocus &&
         (!props.modelValue || (typeof props.modelValue === "string" && props.modelValue.trim() === "")) &&
         !isFocused.value,

--- a/ui/src/components/no-code/components/inputs/InputText.vue
+++ b/ui/src/components/no-code/components/inputs/InputText.vue
@@ -11,7 +11,7 @@
             :disabled
             :type="disabled ? '' : 'textarea'"
             :autosize="{minRows: 1}"
-            :inputStyle="haveError ? {boxShadow: '0 0 6px #ab0009'} : {}"
+            :inputStyle="{...(haveError ? {boxShadow: '0 0 6px #ab0009'} : {}), ...inputStyle}"
             :suffixIcon="SuffixIcon"
         />
     </div>
@@ -44,6 +44,7 @@
         margin: {type: String, default: "mt-1 mb-2"},
         class: {type: String, default: undefined},
         haveError: {type: Boolean, default: false},
+        inputStyle: {type: Object, default: () => ({})},
     })
 
     const input = computed({

--- a/ui/src/components/no-code/components/tasks/TaskDict.vue
+++ b/ui/src/components/no-code/components/tasks/TaskDict.vue
@@ -38,7 +38,7 @@
         </Wrapper>
     </template>
     <template v-else>
-        <KsRow v-for="(item, index) in currentValue" :key="index" :gutter="10" class="w-100" :data-testid="`task-dict-item-${item[0]}-${index}`">
+        <KsRow v-for="(item, index) in currentValue" :key="index" :gutter="10" class="w-100" style="align-items: center;" :data-testid="`task-dict-item-${item[0]}-${index}`">
             <KsCol :span="6">
                 <InputText
                     :ref="el => { if (el) keyInputRefs[index] = el }"
@@ -47,6 +47,7 @@
                     margin="m-0"
                     placeholder="Key"
                     :haveError="duplicatedKeys.includes(item[0])"
+                    :inputStyle="{minHeight: 'var(--kel-component-size)', padding: '7px 11px'}"
                 />
             </KsCol>
             <KsCol :span="16">

--- a/ui/src/components/no-code/components/tasks/TaskDict.vue
+++ b/ui/src/components/no-code/components/tasks/TaskDict.vue
@@ -151,7 +151,8 @@
     const emit = defineEmits(["update:modelValue"])
 
     function getKey(key: string) {
-        return props.root ? `${props.root}.${key}` : key
+        if (!props.root) return key
+        return key ? `${props.root}.${key}` : props.root
     }
 
     function isRequired(key: string) {

--- a/ui/src/components/no-code/components/tasks/TaskExpression.vue
+++ b/ui/src/components/no-code/components/tasks/TaskExpression.vue
@@ -61,8 +61,3 @@
     }
 </script>
 
-<style scoped lang="scss">
-:deep(.placeholder) {
-    top: -7px !important;
-}
-</style>

--- a/ui/src/components/no-code/components/tasks/TaskObjectField.vue
+++ b/ui/src/components/no-code/components/tasks/TaskObjectField.vue
@@ -212,6 +212,7 @@
         flex: 1;
         overflow: hidden;
         text-overflow: ellipsis;
+        white-space: nowrap;
         font-size: var(--ks-font-size-sm);
     }
 

--- a/ui/src/translations/de.json
+++ b/ui/src/translations/de.json
@@ -1152,7 +1152,8 @@
           "taskDefaults": "Standardwerte für Tasks",
           "updated": "Aktualisiert",
           "variables": "Variablen",
-          "workerGroup": "Worker-Gruppe"
+          "workerGroup": "Worker-Gruppe",
+          "workerSelector": "Worker-Selektor"
         },
         "main": {
           "description": "Beschreibung",

--- a/ui/src/translations/en.json
+++ b/ui/src/translations/en.json
@@ -1535,6 +1535,7 @@
           "listeners": "Listeners",
           "taskDefaults": "Task Defaults",
           "workerGroup": "Worker Group",
+          "workerSelector": "Worker Selector",
           "checks": "Checks",
           "updated": "Updated"
         }

--- a/ui/src/translations/es.json
+++ b/ui/src/translations/es.json
@@ -1152,7 +1152,8 @@
           "taskDefaults": "Predeterminados de Task",
           "updated": "Actualizado",
           "variables": "Variables",
-          "workerGroup": "Grupo de Worker"
+          "workerGroup": "Grupo de Worker",
+          "workerSelector": "Selector de Worker"
         },
         "main": {
           "description": "Descripción",

--- a/ui/src/translations/fr.json
+++ b/ui/src/translations/fr.json
@@ -1152,7 +1152,8 @@
           "taskDefaults": "Paramètres par défaut des Tasks",
           "updated": "Mis à jour",
           "variables": "Variables",
-          "workerGroup": "Groupe de Workers"
+          "workerGroup": "Groupe de Workers",
+          "workerSelector": "Sélecteur de Worker"
         },
         "main": {
           "description": "Description",

--- a/ui/src/translations/hi.json
+++ b/ui/src/translations/hi.json
@@ -1152,7 +1152,8 @@
           "taskDefaults": "डिफ़ॉल्ट Task",
           "updated": "अपडेट किया गया",
           "variables": "वेरिएबल्स",
-          "workerGroup": "वर्कर ग्रुप"
+          "workerGroup": "वर्कर ग्रुप",
+          "workerSelector": "वर्कर सेलेक्टर"
         },
         "main": {
           "description": "विवरण",

--- a/ui/src/translations/it.json
+++ b/ui/src/translations/it.json
@@ -1152,7 +1152,8 @@
           "taskDefaults": "Predefiniti Task",
           "updated": "Aggiornato",
           "variables": "Variabili",
-          "workerGroup": "Gruppo Worker"
+          "workerGroup": "Gruppo Worker",
+          "workerSelector": "Selettore Worker"
         },
         "main": {
           "description": "Descrizione",

--- a/ui/src/translations/ja.json
+++ b/ui/src/translations/ja.json
@@ -1152,7 +1152,8 @@
           "taskDefaults": "タスクデフォルト",
           "updated": "更新済み",
           "variables": "変数",
-          "workerGroup": "ワーカーグループ"
+          "workerGroup": "ワーカーグループ",
+          "workerSelector": "ワーカーセレクター"
         },
         "main": {
           "description": "説明",

--- a/ui/src/translations/ko.json
+++ b/ui/src/translations/ko.json
@@ -1152,7 +1152,8 @@
           "taskDefaults": "작업 기본값",
           "updated": "업데이트됨",
           "variables": "변수",
-          "workerGroup": "작업자 그룹"
+          "workerGroup": "작업자 그룹",
+          "workerSelector": "워커 선택기"
         },
         "main": {
           "description": "설명",

--- a/ui/src/translations/pl.json
+++ b/ui/src/translations/pl.json
@@ -1152,7 +1152,8 @@
           "taskDefaults": "Domyślne ustawienia Task",
           "updated": "Zaktualizowano",
           "variables": "Zmienne",
-          "workerGroup": "Grupa Worker"
+          "workerGroup": "Grupa Worker",
+          "workerSelector": "Selektor Worker"
         },
         "main": {
           "description": "Opis",

--- a/ui/src/translations/pt.json
+++ b/ui/src/translations/pt.json
@@ -1152,7 +1152,8 @@
           "taskDefaults": "Padrões de Task",
           "updated": "Atualizado",
           "variables": "Variáveis",
-          "workerGroup": "Grupo de Worker"
+          "workerGroup": "Grupo de Worker",
+          "workerSelector": "Seletor de Worker"
         },
         "main": {
           "description": "Descrição",

--- a/ui/src/translations/pt_BR.json
+++ b/ui/src/translations/pt_BR.json
@@ -1152,7 +1152,8 @@
           "taskDefaults": "Padrões de Task",
           "updated": "Atualizado",
           "variables": "Variáveis",
-          "workerGroup": "Grupo de Worker"
+          "workerGroup": "Grupo de Worker",
+          "workerSelector": "Seletor de Worker"
         },
         "main": {
           "description": "Descrição",

--- a/ui/src/translations/ru.json
+++ b/ui/src/translations/ru.json
@@ -1152,7 +1152,8 @@
           "taskDefaults": "Значения по умолчанию для Task",
           "updated": "Обновлено",
           "variables": "Переменные",
-          "workerGroup": "Группа Worker"
+          "workerGroup": "Группа Worker",
+          "workerSelector": "Селектор Worker"
         },
         "main": {
           "description": "Описание",

--- a/ui/src/translations/zh_CN.json
+++ b/ui/src/translations/zh_CN.json
@@ -1152,7 +1152,8 @@
           "taskDefaults": "任务默认值",
           "updated": "已更新",
           "variables": "变量",
-          "workerGroup": "工作组"
+          "workerGroup": "工作组",
+          "workerSelector": "Worker 选择器"
         },
         "main": {
           "description": "描述",


### PR DESCRIPTION
## Summary

- Add `white-space: nowrap` to the label in `TaskObjectField` so long field names truncate with ellipsis instead of wrapping and overlapping content below
- Remove `top: -7px !important` placeholder offset in `TaskExpression` that caused the placeholder to bleed into the label above
- Suppress the Vue div placeholder in `KsEditor` when a Monaco `PlaceholderContentWidget` is already active, preventing double placeholder rendering
- Fix trailing dot in `TaskDict.getKey()` when the key is empty — placeholder now reads `"Your labels here..."` instead of `"Your labels. here..."`
- Add missing `no_code.fields.general.workerSelector` translation key across all 13 locale files
- Vertically align the Key input and value editor in dict fields — add `inputStyle` prop to `InputText` and match the Monaco inline editor height (`min-height: var(--kel-component-size)` + `padding: 7px 11px`)

Closes https://github.com/kestra-io/kestra-ee/issues/8334.

## Test plan

- [ ] Open no-code editor on a flow — field labels with long names truncate correctly with ellipsis
- [ ] Check the `labels` dict field — single placeholder appears (not doubled), reads `"Your labels here..."`
- [ ] Check the Key and value inputs in the `labels` dict row are vertically aligned
- [ ] Check the `workerSelector` field renders with its label (no console warning about missing i18n key)
- [ ] Verify light and dark mode