### PR TITLE
fix(flows): downgrade read-only id/namespace toast from error to warning, show once per session

### DIFF
--- a/ui/src/stores/dashboard.ts
+++ b/ui/src/stores/dashboard.ts
@@ -39,6 +39,7 @@ export const useDashboardStore = defineStore("dashboard", () => {
     const defaultDashboards = ref<DashboardSettings>()
     const chartErrors = ref<string[]>([])
     const isCreating = ref<boolean>(false)
+    const readonlyToastShown = ref(false)
 
     const sourceCode = ref("")
     const sourceCodeOrigin = ref("")
@@ -186,6 +187,7 @@ export const useDashboardStore = defineStore("dashboard", () => {
         activeDashboard.value = data
         sourceCode.value = data.sourceCode ?? ""
         sourceCodeOrigin.value = sourceCode.value
+        readonlyToastShown.value = false
 
         return activeDashboard.value
     }
@@ -333,10 +335,13 @@ export const useDashboardStore = defineStore("dashboard", () => {
         }
 
         if (!isCreating.value && dbId !== undefined && YAML_UTILS.parse(sourceCode.value).id !== dbId) {
-            coreStore.message = {
-                variant: "error",
-                title: t("readonly property"),
-                message: t("dashboards.edition.id readonly"),
+            if (!readonlyToastShown.value) {
+                readonlyToastShown.value = true
+                coreStore.message = {
+                    variant: "warning",
+                    title: t("readonly property"),
+                    message: t("dashboards.edition.id readonly"),
+                }
             }
 
             await nextTick()

--- a/ui/src/stores/flow.ts
+++ b/ui/src/stores/flow.ts
@@ -109,6 +109,7 @@ export const useFlowStore = defineStore("flow", () => {
     const openAiCopilot = ref<boolean>(false)
     const lastSaveFlow = ref<string>()
     const isCreating = ref<boolean>(false)
+    const readonlyToastShown = ref(false)
     const flowYaml = ref<string>("")
     const flowYamlOrigin = ref<string>("")
     const previewSource = ref<string | undefined>(undefined)
@@ -231,10 +232,13 @@ export const useFlowStore = defineStore("flow", () => {
                         (flowOnValidation.id !== flowBeforeEdit.id ||
                             flowOnValidation.namespace !== flowBeforeEdit.namespace)) {
 
-                    coreStore.message = {
-                        variant: "error",
-                        title: t("readonly property"),
-                        message: t("namespace and id readonly"),
+                    if (!readonlyToastShown.value) {
+                        readonlyToastShown.value = true
+                        coreStore.message = {
+                            variant: "warning",
+                            title: t("readonly property"),
+                            message: t("namespace and id readonly"),
+                        }
                     }
                     flowYaml.value = YAML_UTILS.replaceIdAndNamespace(
                         source,
@@ -484,6 +488,7 @@ export const useFlowStore = defineStore("flow", () => {
         flowYaml.value = data.source
         flowYamlOrigin.value = data.source
         previewSource.value = undefined
+        readonlyToastShown.value = false
         overallTotal.value = 1
 
         return data


### PR DESCRIPTION
## Summary

- The \"Read-only property\" toast was firing on every editor validation cycle (every keystroke on `id:` / `namespace:`) with `variant: "error"`, making the flow editor appear broken for users editing those fields
- Downgraded to `variant: "warning"` — the constraint is expected behavior, not an error
- Added a per-session deduplication flag (`readonlyToastShown`) so the toast fires at most once per editing session; the flag resets when a new flow is loaded
- Applied the same fix to the dashboard editor (`dashboard.ts`)

Fixes https://github.com/kestra-io/kestra-ee/issues/8366 — 49 users / 59 flows affected in a single week

## Test plan

- [ ] Open an existing flow in the YAML editor, try typing in the `id:` field → toast appears once as a **warning** (yellow), not repeatedly as an error
- [ ] Reload another flow → confirm a new attempt triggers the toast once again (flag reset on load)
- [ ] Open an existing dashboard, try editing the `id:` field → same behavior
- [ ] Create a new flow (isCreating = true) → no toast at all

🤖 Generated with [Claude Code](https://claude.com/claude-code)