### PR TITLE
fix(core): align usage card icons with their row text in system overview

### DIFF
--- a/ui/src/components/admin/stats/Usages.vue
+++ b/ui/src/components/admin/stats/Usages.vue
@@ -199,13 +199,17 @@
             align-items: center;
             justify-content: center;
             width: 24px;
-            height: 24px;
             flex-shrink: 0;
 
+            :deep(.material-design-icon) {
+                display: flex;
+                align-items: center;
+            }
+
             :deep(.material-design-icon__svg) {
+                display: block;
                 font-size: var(--ks-font-size-xl);
                 color: var(--ks-text-secondary);
-                vertical-align: middle;
             }
         }
 


### PR DESCRIPTION
## Summary

- Removes the fixed `height: 24px` from the `.usage-icon` wrapper in the Usage card on the System Overview page — the row's `align-items: center` now correctly centers icons vertically without interference
- Switches the `material-design-icon` span to `display: flex` and the SVG to `display: block`, replacing `vertical-align: middle` which is ignored in flex contexts and was causing a slight upward offset

Fixes https://github.com/kestra-io/kestra-ee/issues/8412.

## Related PRs

- EE companion PR: kestra-io/kestra-ee#8424

## Test plan

- [ ] Open System Overview → Usage card
- [ ] Verify all row icons (Namespaces, Flows, Tasks, Triggers, Executions, Total executions duration) are vertically aligned with their text labels
- [ ] Check in both light and dark mode