### PR TITLE
feat(dashboards): add quick_filters i18n keys to en.json

### DIFF
--- a/ui/src/translations/en.json
+++ b/ui/src/translations/en.json
@@ -1783,7 +1783,15 @@
         "confirmation": "Are you sure you want to delete <code>{title}</code> dashboard?"
       },
       "chart_preview": "Click on a chart source code to see its preview",
-      "export": "Export to CSV"
+      "export": "Export to CSV",
+      "quick_filters": {
+        "all": "All",
+        "running": "Running",
+        "paused": "Paused",
+        "success": "Success",
+        "warning": "Warning",
+        "failed": "Failed"
+      }
     },
     "setup": {
       "login": "Login",


### PR DESCRIPTION
## Summary

- Backports the `dashboards.quick_filters` translation keys from [bd68963](https://github.com/kestra-io/kestra/commit/bd68963469c698faf818410c2bee4d80bbfdc8d0) that were missing from `en.json`
- Adds: `all`, `running`, `paused`, `success`, `warning`, `failed`

## Test plan

- [ ] Run `cd ui/src/translations && node check.js` and confirm no missing/extra keys