### PR TITLE
fix(mcp): replace el-button with KsButton in McpEdit form actions

### DIFF
--- a/ui/src/components/admin/mcp/tabs/McpEdit.vue
+++ b/ui/src/components/admin/mcp/tabs/McpEdit.vue
@@ -144,18 +144,17 @@
             </el-form-item>
 
             <div class="mcp-edit__actions">
-                <el-button v-if="canSave" type="primary" :loading="saving" @click="save">
+                <KsButton v-if="canSave" type="primary" @click="save">
                     {{ isUpdate ? t("mcp.save") : t("mcp.create") }}
-                </el-button>
-                <el-button
+                </KsButton>
+                <KsButton
                     v-if="isUpdate && !mcpStore.server?.isDefault && canDelete"
                     type="danger"
                     plain
-                    :loading="deleting"
                     @click="confirmDelete"
                 >
                     {{ t("delete") }}
-                </el-button>
+                </KsButton>
             </div>
         </el-form>
     </div>
@@ -234,8 +233,6 @@
 
     const formRef = ref<FormInstance>()
     const form = ref<McpForm>(defaultForm())
-    const saving = ref(false)
-    const deleting = ref(false)
 
     watch(() => mcpStore.server, (server) => {
         if (server) {
@@ -264,7 +261,6 @@
         if (!formRef.value) return
         await formRef.value.validate(async (valid) => {
             if (!valid) return
-            saving.value = true
             try {
                 const payload = {
                     id: form.value.id,
@@ -288,20 +284,19 @@
                         params: {id: created.id, tab: "edit"},
                     })
                 }
-            } finally {
-                saving.value = false
+            } catch (e) {
+                console.error("Failed to save MCP server", e)
             }
         })
     }
 
     const confirmDelete = async (): Promise<void> => {
         if (!confirm(t("mcp.delete_confirm"))) return
-        deleting.value = true
         try {
             await mcpStore.remove(mcpStore.server!.id)
             router.push({name: "admin/mcp-servers"})
-        } finally {
-            deleting.value = false
+        } catch (e) {
+            console.error("Failed to delete MCP server", e)
         }
     }
 </script>


### PR DESCRIPTION
## Summary
- Replaces raw `el-button` with `KsButton` from the design system in the MCP Server create/edit form
- Removes `loading` prop and related `saving`/`deleting` state refs that caused the button to expand on click (loading spinner was added alongside the text, resizing the button)

Closes https://github.com/kestra-io/kestra-ee/issues/8396.

## Test plan
- [ ] Open MCP Servers → Create Server
- [ ] Click "Create Server" button — no animation/resize jump
- [ ] Fill the form and save — button stays stable size