### PR TITLE
fix(dashboards): improve active tab contrast in Executions card

### DIFF
--- a/ui/src/components/dashboard/sections/Table.vue
+++ b/ui/src/components/dashboard/sections/Table.vue
@@ -240,8 +240,8 @@
     align-items: center;
     padding: var(--ks-spacing-2) var(--ks-spacing-3);
     font-size: 0.75rem;
-    font-weight: 500;
-    color: var(--ks-text-secondary);
+    font-weight: 400;
+    color: var(--ks-text-inactive);
     background: none;
     border: none;
     cursor: pointer;
@@ -252,6 +252,7 @@
 
     &:hover {
         color: var(--tab-color);
+        font-weight: 500;
     }
 
     &.active {

--- a/ui/src/components/dashboard/sections/Table.vue
+++ b/ui/src/components/dashboard/sections/Table.vue
@@ -241,7 +241,7 @@
     padding: var(--ks-spacing-2) var(--ks-spacing-3);
     font-size: 0.75rem;
     font-weight: 400;
-    color: var(--ks-text-inactive);
+    color: var(--ks-text-secondary);
     background: none;
     border: none;
     cursor: pointer;

--- a/ui/src/components/dashboard/sections/Table.vue
+++ b/ui/src/components/dashboard/sections/Table.vue
@@ -166,7 +166,7 @@
 
     const tabColor = (tab: {key: string}) =>
         tab.key === "all"
-            ? cssVar("--ks-btn-primary-bg-default")
+            ? cssVar("--ks-text-link")
             : cssVar(TAB_STATUS_TOKEN[tab.key] ?? "")
 
     const activeStateFilter = computed((): FilterObject | null => {


### PR DESCRIPTION
## Summary

Fixes the poor contrast between selected and unselected quick-filter tabs in the default dashboard Executions card.

**Changes:**
- Reduce inactive tab `font-weight` from 500 → 400
- Add `font-weight: 500` on hover as an intermediate step
- Use `--ks-text-link` instead of `--ks-btn-primary-bg-default` for the "All" tab active color — adapts correctly to dark mode

**Result:** a clear 3-step visual gradient — inactive (400, muted) → hover (500, colored) → active (600, colored + underline).

Closes https://github.com/kestra-io/kestra-ee/issues/8411

<img width="529" height="395" alt="image" src="https://github.com/user-attachments/assets/4f807935-49bf-428a-8f5e-5697d211e6bd" />

🤖 Generated with [Claude Code](https://claude.com/claude-code)
