### PR TITLE
fix(topology): increase connector line stroke width and dash size for better visibility

### DIFF
--- a/ui/packages/topology/src/nodes/EdgeNode.vue
+++ b/ui/packages/topology/src/nodes/EdgeNode.vue
@@ -44,5 +44,5 @@
     .stroke-danger { stroke: var(--ks-border-error); }
     .stroke-error { stroke: var(--ks-border-error); }
     .stroke-warning { stroke: var(--ks-status-warning); }
-    .vue-flow__edge-path { stroke-dasharray: 1.5 3; }
+    .vue-flow__edge-path { stroke-dasharray: 4 4; }
 </style>

--- a/ui/packages/topology/src/topology.scss
+++ b/ui/packages/topology/src/topology.scss
@@ -138,7 +138,7 @@ html.dark {
 
     .vue-flow__edge-path {
         stroke: var(--ks-topology-dash);
-        stroke-width: 1;
+        stroke-width: 1.5;
         stroke-linecap: round;
         fill: none;
     }


### PR DESCRIPTION
## Summary

- Increases edge path `stroke-width` from `1` to `1.5` in `topology.scss` for thicker, more visible connector lines
- Updates `stroke-dasharray` from `1.5 3` to `4 4` in `EdgeNode.vue` for larger, more readable dashes

## Related

Closes https://github.com/kestra-io/kestra-ee/issues/8417.

## Test plan

- [ ] Open an execution and navigate to the Topology tab
- [ ] Verify connector lines between task nodes are clearly visible in both light and dark mode
- [ ] Verify error (red) and warning (orange) edge colors still render correctly