### PR TITLE
fix(core): close emit-before-subscribe race in ExecutionStreamingService

### DIFF
--- a/core/src/main/java/io/kestra/core/services/ExecutionStreamingService.java
+++ b/core/src/main/java/io/kestra/core/services/ExecutionStreamingService.java
@@ -118,6 +118,20 @@ public class ExecutionStreamingService {
                 this.queueSubscriber.resume();
             }
         }
+
+        // Guard against the race where the queue was already running (other subscribers
+        // exist) and the terminal FollowExecutionEvent arrived and was consumed before
+        // this subscriber was registered. In that case the event is lost and Flux.last()
+        // would hang forever. Recover by checking the current execution state: if it is
+        // already in a terminal state, deliver the "end" event directly.
+        // FluxSink is thread-safe: duplicate complete() calls are no-ops, and next()
+        // after complete() is silently dropped, so double-delivery is harmless.
+        executionRepository.findById(flow.getTenantId(), executionId).ifPresent(execution -> {
+            if (isStopFollow(flow, execution)) {
+                sink.next(Event.of(execution).id("end"));
+                sink.complete();
+            }
+        });
     }
 
     /**


### PR DESCRIPTION
## Summary

- When the `FollowExecutionEvent` queue was already running (other subscribers present), a terminal event for execution X could be consumed before `registerSubscriber()` was called for X — silently dropping the event and leaving `Flux.last()` hanging forever
- The existing `synchronized(subscriberLock)` + pause/resume pattern only handles the case where the queue is **paused** (no subscribers at all); it does not protect when the queue is already running
- After registering the subscriber, we now do a one-shot repository check: if the execution is already terminal, we deliver the `"end"` event immediately to recover from the missed event
- `FluxSink` is thread-safe and `complete()` is idempotent, so concurrent delivery from the queue consumer is harmless

## Test plan

- [ ] `MysqlTestSuiteControllerTest.run_shouldBePersisted` — previously intermittently got HTTP 404 because the result was never persisted (reactive chain hung); should now complete reliably
- [ ] `MysqlTestSuiteControllerTest.run` — previously intermittently returned `total=1` instead of `2`; both rows should now be present
- [ ] No regression in `WebhookService`, `ExecutionController`, `McpToolService` callers — all use the same `registerSubscriber` signature with no change needed