### PR TITLE
fix(blueprints): missing required param "kind" and dead v-ks-loading on TopNavBar

### DIFF
--- a/ui/src/override/components/flows/blueprints/BlueprintDetail.vue
+++ b/ui/src/override/components/flows/blueprints/BlueprintDetail.vue
@@ -1,5 +1,5 @@
 <template>
-    <TopNavBar v-if="!embed && blueprint" :title="blueprint?.title" :breadcrumb="breadcrumb" v-ks-loading="!blueprint">
+    <TopNavBar v-if="!embed && blueprint" :title="blueprint?.title" :breadcrumb="breadcrumb">
         <template #actions>
             <ul v-if="userCanCreate">
                 <router-link :to="editorRoute">
@@ -197,6 +197,7 @@
                 name: "blueprints",
                 params: {
                     tenant: route.params?.tenant,
+                    kind: route.params?.kind || props.kind,
                     tab: tab.value,
                 },
             })


### PR DESCRIPTION
## Summary

- `goBack()` in `BlueprintDetail.vue` navigated to the `blueprints` route without the required `:kind` param, causing Vue Router to throw **"Missing required param kind"** and crash the `<RouterLink>` render in the breadcrumb
- Removed `v-ks-loading="!blueprint"` from `<TopNavBar>` — directives don't work on components with fragment roots; the loading state is already correctly handled by `v-ks-loading` on the `<section>` below

Companion PR in kestra-ee: https://github.com/kestra-io/kestra-ee/pull/8445.

Closes https://github.com/kestra-io/kestra-ee/issues/8444.

## Test plan

- [ ] Open a blueprint detail page directly via URL (e.g. `/blueprints/flow/community/<id>`) — no "Missing required param" console error
- [ ] Click the back button / breadcrumb — navigates correctly to the blueprints list
- [ ] No "Runtime directive used on component with non-element root node" warning in console