### PR TITLE
fix(tests): update WorkerJobFetcherBackoffTest to match new constructor signature

### DIFF
--- a/worker/src/test/java/io/kestra/worker/fetchers/WorkerJobFetcherBackoffTest.java
+++ b/worker/src/test/java/io/kestra/worker/fetchers/WorkerJobFetcherBackoffTest.java
@@ -1,6 +1,7 @@
 package io.kestra.worker.fetchers;
 
 import io.kestra.controller.GrpcChannelManager;
+import io.kestra.controller.config.GrpcConfiguration;
 import io.kestra.controller.grpc.WorkerControllerServiceGrpc.WorkerControllerServiceStub;
 import io.kestra.worker.queues.WorkerQueueRegistry;
 import io.kestra.worker.services.ExecutionKilledManager;
@@ -20,7 +21,8 @@ class WorkerJobFetcherBackoffTest {
             mock(WorkerQueueRegistry.class),
             mock(ExecutionKilledManager.class),
             null,
-            List.of()
+            List.of(),
+            mock(GrpcConfiguration.class)
         );
     }
 


### PR DESCRIPTION
## Summary

`WorkerJobFetcher` gained a `GrpcConfiguration` parameter in a recent commit but `WorkerJobFetcherBackoffTest` was not updated, causing a compile error (`required 7 args, found 6`) that blocks the entire `worker:compileTestJava` task — breaking both OSS and kestra-ee CI on `develop`.

- Adds the missing `mock(GrpcConfiguration.class)` as the 7th constructor argument
- Adds the corresponding import

## Test plan

- [x] `./gradlew :worker:compileTestJava --rerun-tasks` passes locally with no errors
- [ ] CI passes on this PR