### PR TITLE
fix(topology): conditionally render details toggle in Topology

### DIFF
--- a/ui/packages/topology/src/Topology.vue
+++ b/ui/packages/topology/src/Topology.vue
@@ -10,7 +10,7 @@
     >
         <Background :patternColor="cssVariable('--ks-topology-bg')" />
 
-        <Panel position="top-right">
+        <Panel v-if="showDetailsToggle" position="top-right">
             <KsSwitch v-model="showExtraDetails" :activeText="$t('show more details')" size="small"/>
         </Panel>
 
@@ -176,6 +176,7 @@
         getNodeDimensions?: (node: any, getNodeWidth: (node: any) => number, getNodeHeight: (node: any) => number) => { width: number, height: number };
         customActions?: Record<string, CustomActionConfig>;
         showDetails?: Record<string, ShowDetailsConfig>;
+        showDetailsToggle?: boolean;
     }>(), {
         isHorizontal: true,
         isReadOnly: true,
@@ -194,6 +195,7 @@
         getNodeDimensions: undefined,
         customActions: () => ({}),
         showDetails: () => ({}),
+        showDetailsToggle: true,
     })
 
     const isRunning = computed(() => State.isRunning(props.execution?.state?.current) === true)

--- a/ui/src/components/inputs/LowCodeEditor.vue
+++ b/ui/src/components/inputs/LowCodeEditor.vue
@@ -10,7 +10,7 @@
             :isAllowedEdit="isAllowedEdit"
             :source="source"
             :toggleOrientationButton="toggleOrientationButton"
-            :flowGraph="playgroundStore.enabled ? (executionsStore.flowGraph ?? props.flowGraph) : props.flowGraph"
+            :flowGraph="effectiveFlowGraph"
             :flowId="flowId"
             :namespace="namespace"
             :expandedSubflows="props.expandedSubflows"
@@ -170,6 +170,9 @@
 
     const execution = computed(() => executionsStore.execution as any as Execution)
 
+    const effectiveFlowGraph = computed(() =>
+        playgroundStore.enabled ? (executionsStore.flowGraph ?? props.flowGraph) : props.flowGraph,
+    )
 
     const {RemoteComponent:TopologyDetailsRemote, taskAdditionalInfoRemote, manifestReady, resolveRemoteComponent} = useFederatedModule("topology-details")
     const {RemoteComponent:TaskDrawerRemote, resolveRemoteComponent: resolveDrawerComponent} = useFederatedModule("topology-task-drawer")
@@ -188,8 +191,7 @@
 
     const hasExtraDetails = computed(() => {
         const types = taskAdditionalInfoRemote.value
-        const graph = playgroundStore.enabled ? (executionsStore.flowGraph ?? props.flowGraph) : props.flowGraph
-        return (graph?.nodes ?? []).some((n: any) => n.task?.type && types[n.task.type])
+        return (effectiveFlowGraph.value?.nodes ?? []).some((n: any) => n.task?.type && types[n.task.type])
     })
 
     const taskMetrics = (taskId: string | undefined) =>

--- a/ui/src/components/inputs/LowCodeEditor.vue
+++ b/ui/src/components/inputs/LowCodeEditor.vue
@@ -21,6 +21,7 @@
             :playgroundReadyToStart="playgroundStore.readyToStart"
             :getNodeDimensions="getNodeDimensions"
             :customActions="customActions"
+            :showDetailsToggle="hasExtraDetails"
             @toggle-orientation="toggleOrientation"
             @edit="onEditTask"
             @delete="onDelete"
@@ -183,6 +184,12 @@
             }
         }
         return result
+    })
+
+    const hasExtraDetails = computed(() => {
+        const types = taskAdditionalInfoRemote.value
+        const graph = playgroundStore.enabled ? (executionsStore.flowGraph ?? props.flowGraph) : props.flowGraph
+        return (graph?.nodes ?? []).some((n: any) => n.task?.type && types[n.task.type])
     })
 
     const taskMetrics = (taskId: string | undefined) =>


### PR DESCRIPTION
closes https://github.com/kestra-io/kestra-ee/issues/8415, closes https://github.com/kestra-io/kestra-ee/issues/8459

This pull request adds a new feature to conditionally display the "show more details" toggle in the topology panel, based on whether there are extra details available for any node type in the flow graph. The logic for determining the presence of extra details is computed in the `LowCodeEditor.vue` component and passed as a prop to `Topology.vue`. By default, the toggle is shown unless overridden.

**Feature: Conditional display of details toggle**

* Added a new prop `showDetailsToggle` to `Topology.vue` to control whether the "show more details" toggle is displayed.
* Defaulted `showDetailsToggle` to `true` in `Topology.vue` props, maintaining backward compatibility.
* Updated the template in `Topology.vue` to only render the details `Panel` if `showDetailsToggle` is `true`.

**Logic: Detecting extra details**

* Introduced a new computed property `hasExtraDetails` in `LowCodeEditor.vue` to determine if any node in the flow graph has additional details available, based on node types and available info.
* Passed the computed `hasExtraDetails` value as the `showDetailsToggle` prop to the `Topology` component, ensuring the toggle only appears when relevant.