### PR TITLE
fix: pass query filters to the namespaces search API

### DIFF
--- a/ui/src/composables/useBaseNamespaces.ts
+++ b/ui/src/composables/useBaseNamespaces.ts
@@ -36,15 +36,18 @@ export const useBaseNamespacesStore = () => {
         return response
     }
 
-    async function search(options: Parameters<typeof NamespaceAPI.searchNamespaces>[0] & {commit?: boolean}) {
+    async function search(options: {commit?: boolean, sort?: string, [key: string]: any}) {
         const shouldCommit = options.commit !== false
         delete options.commit
-        const response = await NamespaceAPI.searchNamespaces(options)
+        const sortString = options.sort ? `?sort=${options.sort}` : ""
+        delete options.sort
+
+        const {data} = await axios.get(`${apiUrl()}/namespaces/search${sortString}`, {params: options})
         if (shouldCommit) {
-            namespaces.value = response.results
-            total.value = response.total
+            namespaces.value = data.results
+            total.value = data.total
         }
-        return response
+        return data
     }
 
     async function load(id: string) {


### PR DESCRIPTION
✨ Description

Filters applied on the Namespaces list page (e.g. ?filters[namespace][PREFIX]=system) were not being sent to the backend the search request went out without them, so the list stayed unfiltered.
  
The page extracts flat filters[field][OP] keys from the URL, but the store routed the request through the typed SDK searchNamespaces, which only forwards a structured filters object parameter. The flat bracket keys matched nothing and were silently dropped before the request was built.  

This switches the store's search to use the axios client directly — the same approach Flows, Executions, Logs, and Triggers already use — so the flat filter keys pass straight through to the API. Only the search body in useBaseNamespaces.ts changed; Namespaces.vue is untouched and its URL filter extraction now works end-to-end. EE inherits the fix automatically.

Closes: https://github.com/kestra-io/kestra-ee/issues/6255