### PR TITLE
fix: return empty manifest instead of 404 when plugin UI is missing

### DIFF
--- a/webserver/src/main/java/io/kestra/webserver/controllers/api/PluginController.java
+++ b/webserver/src/main/java/io/kestra/webserver/controllers/api/PluginController.java
@@ -19,7 +19,6 @@ import io.kestra.core.models.ui.TaskWithVersion;
 import io.kestra.core.plugins.PluginRegistry;
 import io.kestra.core.plugins.RegisteredPlugin;
 import io.kestra.core.repositories.ArrayListTotal;
-import io.kestra.core.utils.ListUtils;
 import io.kestra.core.utils.MapUtils;
 import io.kestra.webserver.converters.QueryFilterFormat;
 import io.kestra.webserver.responses.PagedResults;
@@ -383,16 +382,8 @@ public class PluginController {
             );
         }
 
-        if (pluginTasks.isEmpty()) {
-            throw new NotFoundException();
-        }
-
         Set<String> groups = pluginTasks.keySet();
         List<RegisteredPlugin> plugins = pluginRegistry.plugins(registeredPlugin -> groups.contains(registeredPlugin.group()));
-
-        if (ListUtils.isEmpty(plugins)) {
-            throw new NotFoundException();
-        }
 
         Map<String, List<PluginUiModuleWithGroup>> manifest = new HashMap<>();
         for (RegisteredPlugin plugin : plugins) {

--- a/webserver/src/test/java/io/kestra/webserver/controllers/api/PluginControllerTest.java
+++ b/webserver/src/test/java/io/kestra/webserver/controllers/api/PluginControllerTest.java
@@ -265,17 +265,37 @@ class PluginControllerTest {
     }
 
     @Test
-    void should_not_get_plugin_manifest_for_groups() {
-        HttpClientResponseException exception = assertThrows(
-            HttpClientResponseException.class, () -> client.toBlocking().retrieve(
-                HttpRequest.POST(
-                    PATH + "/pluginUiManifest",
-                    List.of(new TaskWithVersion("io.kestra.plugin.redis", null))
-                ),
-                PluginUiManifest.class
-            )
+    void shouldReturnEmptyManifestGivenUnresolvedClasses() {
+        // A group name (not a task class) does not resolve to any task; the endpoint must
+        // return an empty manifest with HTTP 200 rather than a hard 404.
+        PluginUiManifest manifest = client.toBlocking().retrieve(
+            HttpRequest.POST(
+                PATH + "/pluginUiManifest",
+                List.of(new TaskWithVersion("io.kestra.plugin.redis", null))
+            ),
+            PluginUiManifest.class
         );
-        assertThat(exception.code()).isEqualTo(HttpStatus.NOT_FOUND.getCode());
+
+        assertThat(manifest.manifest()).isEmpty();
+    }
+
+    @Test
+    void shouldReturnEmptyManifestGivenPluginsNotInstalled() {
+        // Blueprints may reference plugins that aren't installed on this instance; the
+        // endpoint must degrade gracefully (empty manifest, HTTP 200) so the UI keeps
+        // rendering instead of navigating to the global "Page not found" page.
+        PluginUiManifest manifest = client.toBlocking().retrieve(
+            HttpRequest.POST(
+                PATH + "/pluginUiManifest",
+                List.of(
+                    new TaskWithVersion("io.kestra.plugin.ai.rag.IngestDocument", null),
+                    new TaskWithVersion("io.kestra.plugin.slack.notifications.SlackIncomingWebhook", null)
+                )
+            ),
+            PluginUiManifest.class
+        );
+
+        assertThat(manifest.manifest()).isEmpty();
     }
 
     @Test


### PR DESCRIPTION
### ✨ Description

Fixes an issue where opening community blueprints that reference uninstalled plugins could incorrectly redirect users to the global **Page Not Found** view.

`POST /api/v1/plugins/pluginUiManifest` previously behaved as an all-or-nothing endpoint. If none of the requested task classes could be resolved from the plugin registry, it threw a `NotFoundException` (`HTTP 404`).

This commonly occurred when viewing community blueprints that reference plugins not installed on the current instance, such as:

* `io.kestra.plugin.ai.*`
* `io.kestra.plugin.googleworkspace.*`
* `io.kestra.plugin.slack.*`

For example:

```text
/ui/main/blueprints/flow/community/ai-gdpr-dpa-reviewer
```

Although the blueprint itself was valid, the manifest request returned a 404, which the frontend interpreted as a fatal routing error and redirected to the global **Page Not Found** page.

### Backend Changes

#### `PluginController.getPluginUiManifest`

Removed the two `NotFoundException` throws.

The endpoint already supports partial manifest generation, so the all-miss case now behaves consistently with partial matches:

* **Before:** returns `404 Not Found`
* **After:** returns `200 OK` with an empty or partial manifest

Example response:

```json
{
  "manifest": {}
}
```

This allows consumers to gracefully handle missing plugins without treating them as a request failure.

### Result

Community blueprints that reference unavailable plugins now open normally:

* Installed plugins continue to provide their custom UI.
* Missing plugins simply contribute no manifest entries.
* Users no longer see a false "Page Not Found" error when viewing otherwise valid blueprints.

### 🔗 Related Issue

Closes https://github.com/kestra-io/kestra-ee/issues/8402
Closes https://github.com/kestra-io/kestra-ee/issues/8446
