### PR TITLE
fix(triggers): gate trigger UI on TRIGGER permission instead of EXECUTION

### DIFF
--- a/ui/src/components/admin/triggers/TriggersManage.vue
+++ b/ui/src/components/admin/triggers/TriggersManage.vue
@@ -179,7 +179,7 @@
                             {{ scope.row.backfill.paused ? $t("paused") : $t("running") }}
                         </KsTag>
                     </template>
-                    <template v-else-if="isSchedule(scope.row.type) && authStore.user?.hasAnyAction(resource.EXECUTION, action.UPDATE)">
+                    <template v-else-if="isSchedule(scope.row.type) && authStore.user?.hasAnyAction(resource.TRIGGER, action.BACKFILL)">
                         <KsButton
                             :icon="CalendarCollapseHorizontalOutline"
                             @click="setBackfillModal(scope.row, true)"
@@ -193,7 +193,7 @@
                 </template>
             </KsTableColumn>
 
-            <KsTableColumn :label="$t('enabled')" columnKey="disable" className="row-action">
+            <KsTableColumn v-if="authStore.user?.hasAnyAction(resource.TRIGGER, action.DISABLE)" :label="$t('enabled')" columnKey="disable" className="row-action">
                 <template #default="scope">
                     <KsTooltip
                         v-if="!scope.row.missingSource"
@@ -216,7 +216,7 @@
             </KsTableColumn>
 
             <KsTableColumn
-                v-if="authStore.user?.hasAnyAction(resource.EXECUTION, action.UPDATE)"
+                v-if="authStore.user?.hasAny(resource.TRIGGER)"
                 columnKey="row-actions"
                 className="row-action"
             >
@@ -235,6 +235,7 @@
                                     {{ $t("details") }}
                                 </KsDropdownItem>
                                 <KsDropdownItem
+                                    v-if="authStore.user?.hasAnyAction(resource.TRIGGER, action.RESTART)"
                                     :disabled="!scope.row.locked"
                                     @click="restart(scope.row)"
                                 >
@@ -242,6 +243,7 @@
                                     {{ $t("restart") }}
                                 </KsDropdownItem>
                                 <KsDropdownItem
+                                    v-if="authStore.user?.hasAnyAction(resource.TRIGGER, action.UNLOCK)"
                                     :disabled="!scope.row.locked"
                                     @click="unlock(scope.row)"
                                 >
@@ -249,6 +251,7 @@
                                     {{ $t("unlock") }}
                                 </KsDropdownItem>
                                 <KsDropdownItem
+                                    v-if="authStore.user?.hasAnyAction(resource.TRIGGER, action.DELETE)"
                                     divided
                                     class="danger"
                                     @click="confirmDeleteTrigger(scope.row)"
@@ -481,7 +484,7 @@
         updateVisibleColumns(newColumns)
     }
 
-    const canCheck = computed(() => authStore.user?.hasAnyAction(resource.EXECUTION, action.UPDATE) ?? false)
+    const canCheck = computed(() => authStore.user?.hasAny(resource.TRIGGER) ?? false)
 
     const selectionMapper = (row: any) => ({
         namespace: row.namespace,

--- a/ui/src/components/flows/FlowTriggers.vue
+++ b/ui/src/components/flows/FlowTriggers.vue
@@ -122,7 +122,7 @@
             </template>
         </KsTableColumn>
 
-        <KsTableColumn columnKey="backfill" :label="$t('backfill')" v-if="userCan(action.UPDATE)">
+        <KsTableColumn columnKey="backfill" :label="$t('backfill')" v-if="userCan(action.BACKFILL)">
             <template #default="scope">
                 <template v-if="isSchedule(scope.row.type) && !scope.row.backfill">
                     <KsButton
@@ -148,7 +148,7 @@
             </template>
         </KsTableColumn>
 
-        <KsTableColumn columnKey="disable" :label="$t('enabled')" className="row-action" v-if="userCan(action.UPDATE)">
+        <KsTableColumn columnKey="disable" :label="$t('enabled')" className="row-action" v-if="userCan(action.DISABLE)">
             <template #default="scope">
                 <KsTooltip
                     v-if="hasTrigger(scope.row)"
@@ -182,7 +182,7 @@
                                 {{ $t("details") }}
                             </KsDropdownItem>
                             <KsDropdownItem
-                                v-if="userCan(action.UPDATE)"
+                                v-if="userCan(action.RESTART)"
                                 :disabled="!scope.row.locked"
                                 @click="restart(scope.row)"
                             >
@@ -190,7 +190,7 @@
                                 {{ $t("restart") }}
                             </KsDropdownItem>
                             <KsDropdownItem
-                                v-if="userCan(action.UPDATE)"
+                                v-if="userCan(action.UNLOCK)"
                                 :disabled="!scope.row.locked"
                                 @click="unlock(scope.row)"
                             >
@@ -512,7 +512,7 @@
 
     const userCan = (act: any) => {
         if (!flowStore.flow) return false
-        return authStore.user?.isAllowed(resource.EXECUTION, act ? act : action.VIEW, flowStore.flow?.namespace)
+        return authStore.user?.isAllowed(resource.TRIGGER, act ? act : action.VIEW, flowStore.flow?.namespace)
     }
 
     const loadData = () => {

--- a/ui/src/models/resource.ts
+++ b/ui/src/models/resource.ts
@@ -1,6 +1,7 @@
 export default {
     FLOW: "FLOW",
     EXECUTION: "EXECUTION",
+    TRIGGER: "TRIGGER",
     NAMESPACE: "NAMESPACE",
     KVSTORE: "KVSTORE",
     DASHBOARD: "DASHBOARD",


### PR DESCRIPTION
## What

The trigger UI controls (`FlowTriggers.vue`, `TriggersManage.vue`) were guarded by `resource.EXECUTION` + `action.UPDATE`, but the backend `TriggerController` enforces `Resource.TRIGGER` with `BACKFILL / DISABLE / ENABLE / UNLOCK / RESTART / DELETE / LIST`. `UPDATE`/`EXECUTE` aren't even valid `TRIGGER` actions.

Consequence (EE): a user with `TRIGGER` permissions but not `EXECUTION.UPDATE` saw no trigger controls; a user with `EXECUTION.UPDATE` but no `TRIGGER` saw buttons that 403.

## Changes
- `ui/src/models/resource.ts` — add `TRIGGER` (it was only declared in the EE merge, so `resource.TRIGGER` was `undefined` in these OSS components → guards would silently deny in EE).
- `ui/src/components/flows/FlowTriggers.vue` — `userCan` now checks `resource.TRIGGER`; per-control actions: backfill→`BACKFILL`, enable/disable→`DISABLE`, restart→`RESTART`, unlock→`UNLOCK`, delete→`DELETE`.
- `ui/src/components/admin/triggers/TriggersManage.vue` — same mapping; backfill→`BACKFILL`, enable/disable column→`DISABLE`, row actions guarded per item (restart/unlock/delete), bulk selection (`canCheck`) → `hasAny(TRIGGER)`.

Permission checks are no-ops in OSS (always-true stub) and only enforce in EE; the `resource.ts` `TRIGGER` addition is what makes the shared components resolve correctly in the EE build.

## Companion
EE PR (kestra-ee) covers `ServiceTriggers.vue` + the TestSuite Run-button guard. Tracking: kestra-io/kestra-ee#8473.

## Tests
`npm run check:types` and `npm run test:lint` pass (0 errors).