### PR TITLE
fix(tasks): parse DATE kvType as LocalDate in KV Set task

### DIFF
--- a/core/src/main/java/io/kestra/plugin/core/kv/Set.java
+++ b/core/src/main/java/io/kestra/plugin/core/kv/Set.java
@@ -2,6 +2,9 @@ package io.kestra.plugin.core.kv;
 
 import java.time.Duration;
 import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeParseException;
 
 import io.kestra.core.models.annotations.Example;
 import io.kestra.core.models.annotations.Plugin;
@@ -114,7 +117,8 @@ public class Set extends Task implements RunnableTask<VoidOutput> {
                 renderedValue = switch (renderedKvType) {
                     case NUMBER -> JacksonMapper.ofJson().readValue(renderedValueStr, Number.class);
                     case BOOLEAN -> Boolean.parseBoolean((String) renderedValue);
-                    case DATETIME, DATE -> Instant.parse(renderedValueStr);
+                    case DATETIME -> Instant.parse(renderedValueStr);
+                    case DATE -> parseDate(renderedValueStr);
                     // We parse duration to make sure it's valid but we store it as a raw duration string
                     case DURATION -> {
                         Duration.parse(renderedValueStr);
@@ -139,5 +143,20 @@ public class Set extends Task implements RunnableTask<VoidOutput> {
         );
 
         return null;
+    }
+
+    /**
+     * Parses a {@code DATE}-typed KV value into a {@link LocalDate}.
+     * <p>
+     * A date-only value (e.g. {@code 2023-05-02}) is the expected form. A full ISO-8601
+     * instant (e.g. {@code 2023-05-02T01:02:03Z}) is also accepted — previously {@code DATE}
+     * shared {@code DATETIME}'s {@code Instant.parse} branch — and is truncated to its UTC date.
+     */
+    private static LocalDate parseDate(String value) {
+        try {
+            return LocalDate.parse(value);
+        } catch (DateTimeParseException e) {
+            return LocalDate.ofInstant(Instant.parse(value), ZoneOffset.UTC);
+        }
     }
 }

--- a/core/src/test/java/io/kestra/plugin/core/kv/SetTest.java
+++ b/core/src/test/java/io/kestra/plugin/core/kv/SetTest.java
@@ -2,6 +2,7 @@ package io.kestra.plugin.core.kv;
 
 import java.time.Duration;
 import java.time.Instant;
+import java.time.LocalDate;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.Map;
@@ -226,6 +227,13 @@ class SetTest {
 
         kv = createAndPerformSetTask(key, "2023-05-02T01:02:03Z", KVType.DATETIME);
         assertThat(kv.getValue(key).orElseThrow().value()).isEqualTo(Instant.parse("2023-05-02T01:02:03Z"));
+
+        kv = createAndPerformSetTask(key, "2023-05-02", KVType.DATE);
+        assertThat(kv.getValue(key).orElseThrow().value()).isEqualTo(LocalDate.parse("2023-05-02"));
+
+        // a full ISO instant with DATE type is also accepted and truncated to its UTC date
+        kv = createAndPerformSetTask(key, "2023-05-02T01:02:03Z", KVType.DATE);
+        assertThat(kv.getValue(key).orElseThrow().value()).isEqualTo(LocalDate.parse("2023-05-02"));
 
         kv = createAndPerformSetTask(key, "P1DT5S", KVType.DURATION);
         assertThat(kv.getValue(key).orElseThrow().value()).isEqualTo(Duration.ofDays(1).plus(Duration.ofSeconds(5)));


### PR DESCRIPTION
### ✨ Description

Fixes an issue where `io.kestra.plugin.core.kv.Set` could not correctly store values of type `DATE`.

Previously, `DATE` and `DATETIME` shared the same parsing path and were both parsed using:

```java
Instant.parse(...)
```

Because `Instant.parse()` requires a full ISO-8601 instant, for example:

```text
2023-05-02T00:00:00Z
```

a date-only value such as:

```text
2023-05-02
```

failed immediately with:

```text
Text '2023-05-02' could not be parsed at index 10
```

### Fix

`DATE` now has its own parsing logic:

- Date-only values are parsed using `LocalDate.parse(...)`
- Full ISO instants are still accepted for backward compatibility and are normalized to their UTC date

Examples:

| Input | `kvType` | Result |
|---------|---------|---------|
| `2023-05-02` | `DATE` | `LocalDate(2023-05-02)` |
| `2023-05-02T01:02:03Z` | `DATE` | `LocalDate(2023-05-02)` |
| `2023-05-02T01:02:03Z` | `DATETIME` | `Instant(2023-05-02T01:02:03Z)` |

This aligns the task with the rest of the KV stack:

- `KVType.from(...)` already maps `LocalDate` → `DATE`
- The ION serializer already round-trips `LocalDate` values as day-precision timestamps
- The UI and API already treat date values as true dates

### 🔁 Backward Compatibility

This change is backward compatible.

#### Before

`DATE` was effectively an alias for `DATETIME`.

Because both types used `Instant.parse(...)`:

- Date-only values always failed
- Only full ISO instants were accepted
- Accepted values were stored and read back as datetimes, not dates

#### After

- Date-only values now work as expected
- Existing flows that pass a full ISO instant with `kvType: DATE` continue to work without error
- Full instants are normalized to a `LocalDate` rather than stored as an `Instant`

The only behavioral change is that successful `DATE` writes now produce a true date value instead of a datetime value, which is the correct behavior for a `DATE` key.

Users who require timestamp precision should continue using:

```yaml
kvType: DATETIME
```

which is unchanged.

#### Existing Data

Already-stored KV entries are unaffected.

This is a write-path change only:

- No migration is performed
- Existing KV values remain unchanged on disk
- The read path is unchanged
- Previously stored values continue to deserialize and display exactly as before

The new behavior only applies to future executions of the `Set` task.

### 🔗 Related Issue

Closes https://github.com/kestra-io/kestra-ee/issues/8413

### 🛠️ Backend Checklist

- [x] Code compiles successfully and passes all checks
- [x] All unit and integration tests pass