### PR TITLE
fix(dashboards): use ks-text-primary for "All" quick filter tab color

### DIFF
--- a/ui/src/components/dashboard/sections/Table.vue
+++ b/ui/src/components/dashboard/sections/Table.vue
@@ -166,7 +166,7 @@
 
     const tabColor = (tab: {key: string}) =>
         tab.key === "all"
-            ? cssVar("--ks-btn-primary-bg-default")
+            ? cssVar("--ks-text-primary")
             : cssVar(TAB_STATUS_TOKEN[tab.key] ?? "")
 
     const activeStateFilter = computed((): FilterObject | null => {


### PR DESCRIPTION
## Summary

- Fixes the "All" tab text color in the Executions In Progress dashboard widget's quick filter tabs
- Was using `--ks-btn-primary-bg-default` (a button background token) as the text color, making it invisible/unreadable in certain themes
- Changed to `--ks-text-primary`, the correct semantic token for primary text content

Closes https://github.com/kestra-io/kestra-ee/issues/8465.

## Test plan

- [ ] Open a dashboard with an Executions table widget
- [ ] Verify the "All" quick filter tab text is visible in both light and dark mode
- [ ] Verify the active state indicator (underline) still appears correctly