### PR TITLE
fix(design-system): update main menu category text color to text-primary

### DIFF
--- a/ui/packages/design-system/src/components/Navigation/KsSideBar/KsSideBarSection.vue
+++ b/ui/packages/design-system/src/components/Navigation/KsSideBar/KsSideBarSection.vue
@@ -79,7 +79,7 @@
     margin-bottom: var(--ks-spacing-2);
     font-size: var(--ks-font-size-xs);
     font-weight: 400;
-    color: var(--ks-text-dim);
+    color: var(--ks-text-primary);
     background: none;
     border: none;
     text-align: left;


### PR DESCRIPTION
## Summary
- Change sidebar section category title text color from `--ks-text-dim` to `--ks-text-primary` to improve visibility and hierarchy

Closes https://github.com/kestra-io/kestra-ee/issues/8494.