### PR TITLE
fix(Duration): task node duration blinking

### DIFF
--- a/ui/packages/topology/src/misc/Duration.vue
+++ b/ui/packages/topology/src/misc/Duration.vue
@@ -11,7 +11,7 @@
             </span>
         </template>
         <template #default>
-            <span v-html="duration" />
+            <span class="ks-duration-value" v-html="duration" />
         </template>
     </KsTooltip>
 </template>
@@ -101,13 +101,18 @@
     }
 
     function computeDuration() {
-        duration.value =
-            filteredHistories.value.length === 0
-                ? "&nbsp;"
-                : Utils.humanDuration(delta() / 1000, {
-                    maxDecimalPoints: 2,
-                    units: ["h", "m", "s"],
-                })
+        if (filteredHistories.value.length === 0) {
+            duration.value = "&nbsp;"
+            return
+        }
+
+        const human = Utils.humanDuration(delta() / 1000, {
+            maxDecimalPoints: 2,
+            units: ["h", "m", "s"],
+        })
+
+        const isBareSeconds = human.endsWith("s") && !human.endsWith("ms") && !human.includes(".")
+        duration.value = isBareSeconds ? `${human.slice(0, -1)}.00s` : human
     }
 
     function squareClass(state: string) {
@@ -124,4 +129,10 @@
         cancel()
     })
 </script>
+
+<style scoped>
+    .ks-duration-value {
+        font-variant-numeric: tabular-nums;
+    }
+</style>
 

--- a/ui/packages/topology/src/nodes/TaskNode.vue
+++ b/ui/packages/topology/src/nodes/TaskNode.vue
@@ -434,7 +434,6 @@ button.playground-button {
 .status-tag__text {
     font-size: var(--ks-font-size-2xs);
     white-space: nowrap;
-    font-family: var(--ks-font-family-mono);
 }
 
 .details-wrapper {


### PR DESCRIPTION
closes https://github.com/kestra-io/kestra-ee/issues/8418

This pull request makes improvements to the display and formatting of durations in the `Duration.vue` component. The main focus is on ensuring consistent numeric alignment and formatting for durations, as well as minor style adjustments elsewhere.

**Duration formatting and display improvements:**

* Ensured durations that are bare seconds (e.g., `5s`) are always displayed with two decimal places (e.g., `5.00s`) for consistency.
* Introduced a scoped style for `.ks-duration-value` to use tabular numbers, improving alignment of numeric values in the UI.

**Other style adjustments:**

* Removed the monospace font family from the `.status-tag__text` class in `TaskNode.vue` to standardize text appearance.