### PR TITLE
feat(executions): redesign Set labels popup for clearer add/edit

### DIFF
--- a/ui/AGENTS.md
+++ b/ui/AGENTS.md
@@ -48,6 +48,7 @@ A design system rots fast if it's treated as a one-time deliverable. Apply these
 - Build screens by *composing* `Ks*` components. A new feature should read like a list of design-system blocks plus business logic — not a wall of custom CSS.
 - Keep `<style>` blocks small. If a component file has more than ~50 lines of CSS, you probably need a new prop, a new slot, or a new `Ks*` component.
 - Prefer `scoped` styles and rely on design tokens for theming. If you find yourself writing `:deep(.el-...)`, stop — it's a signal the design system needs to expose something.
+- Write each CSS class selector as a full literal — never construct it with SCSS `&` nesting (`&__row`, `&--active`). Constructed selectors can't be found by search and devtools can't jump from a class to its rule. With `scoped` styles, BEM-style namespacing is redundant anyway: use flat, hyphenated names (`.label-input-row`, not `.label-input { &__row }`).
 - Use semantic tokens, not raw colors. `var(--ks-text-link)` communicates intent; `var(--ks-text-blue-500)` does not exist for a reason.
 - Co-locate component-specific tokens (e.g. `--ks-card-shadow`) in the component's SCSS, but always derive them from semantic tokens.
 

--- a/ui/src/components/executions/SetLabels.vue
+++ b/ui/src/components/executions/SetLabels.vue
@@ -11,7 +11,7 @@
         <template #reference>
             <button class="set-labels-tag" :class="{'is-active': isOpen}" :disabled="!enabled">
                 <Plus />
-                {{ $t("set_extra_labels") }}
+                {{ $t("manage labels") }}
             </button>
         </template>
 
@@ -37,7 +37,7 @@
                         {{ $t("cancel") }}
                     </KsButton>
                     <KsButton type="primary" :loading="isSaving" @click="setLabels()">
-                        {{ $t("ok") }}
+                        {{ $t("save") }}
                     </KsButton>
                 </div>
             </div>

--- a/ui/src/components/labels/LabelInput.vue
+++ b/ui/src/components/labels/LabelInput.vue
@@ -1,29 +1,32 @@
 <template>
-    <div
-        class="d-flex w-100 mb-2"
-        v-for="(label, index) in locals"
-        :key="index"
-    >
-        <div class="flex-grow-1 d-flex align-items-center">
+    <div class="label-input">
+        <KsButton class="label-input__add" :icon="Plus" @click="addItem">
+            {{ $t("add label") }}
+        </KsButton>
+
+        <div
+            class="label-input__row"
+            v-for="(label, index) in locals"
+            :key="index"
+        >
             <KsInput
-                class="form-control me-2"
+                class="label-input__field"
                 :placeholder="$t('key')"
                 :modelValue="(label.key as string | undefined)"
                 :disabled="existingRows.has(label)"
                 @update:model-value="update(index, $event, 'key')"
             />
             <KsInput
-                class="form-control me-2"
+                class="label-input__field"
                 :placeholder="$t('value')"
                 :modelValue="(label.value as string | undefined)"
                 @update:model-value="update(index, $event, 'value')"
             />
-        </div>
-        <div class="flex-shrink-1">
-            <KsButtonGroup class="d-flex">
-                <KsButton :icon="Plus" @click="addItem" :tooltip="$t('add label')" />
-                <KsButton :icon="Minus" @click="removeItem(index)" :tooltip="$t('remove label')" />
-            </KsButtonGroup>
+            <KsButton
+                :icon="Minus"
+                :tooltip="$t('remove label')"
+                @click="removeItem(index)"
+            />
         </div>
     </div>
 </template>
@@ -57,9 +60,6 @@
 
     const removeItem = (index: number) => {
         locals.value.splice(index, 1)
-        if (locals.value.length === 0) {
-            addItem()
-        }
         emit("update:labels", locals.value)
     }
 
@@ -104,3 +104,26 @@
         },
     )
 </script>
+
+<style scoped lang="scss">
+    .label-input {
+        display: flex;
+        flex-direction: column;
+        gap: var(--ks-spacing-2);
+
+        &__add {
+            align-self: flex-start;
+        }
+
+        &__row {
+            display: flex;
+            align-items: center;
+            gap: var(--ks-spacing-2);
+        }
+
+        &__field {
+            flex: 1;
+            min-width: 0;
+        }
+    }
+</style>

--- a/ui/src/components/labels/LabelInput.vue
+++ b/ui/src/components/labels/LabelInput.vue
@@ -1,23 +1,23 @@
 <template>
     <div class="label-input">
-        <KsButton class="label-input__add" :icon="Plus" @click="addItem">
+        <KsButton class="label-input-add" :icon="Plus" @click="addItem">
             {{ $t("add label") }}
         </KsButton>
 
         <div
-            class="label-input__row"
+            class="label-input-row"
             v-for="(label, index) in locals"
             :key="index"
         >
             <KsInput
-                class="label-input__field"
+                class="label-input-field"
                 :placeholder="$t('key')"
                 :modelValue="(label.key as string | undefined)"
                 :disabled="existingRows.has(label)"
                 @update:model-value="update(index, $event, 'key')"
             />
             <KsInput
-                class="label-input__field"
+                class="label-input-field"
                 :placeholder="$t('value')"
                 :modelValue="(label.value as string | undefined)"
                 @update:model-value="update(index, $event, 'value')"
@@ -110,20 +110,20 @@
         display: flex;
         flex-direction: column;
         gap: var(--ks-spacing-2);
+    }
 
-        &__add {
-            align-self: flex-start;
-        }
+    .label-input-add {
+        align-self: flex-start;
+    }
 
-        &__row {
-            display: flex;
-            align-items: center;
-            gap: var(--ks-spacing-2);
-        }
+    .label-input-row {
+        display: flex;
+        align-items: center;
+        gap: var(--ks-spacing-2);
+    }
 
-        &__field {
-            flex: 1;
-            min-width: 0;
-        }
+    .label-input-field {
+        flex: 1;
+        min-width: 0;
     }
 </style>

--- a/ui/src/translations/de.json
+++ b/ui/src/translations/de.json
@@ -952,6 +952,7 @@
       "raw_details": "Vollständige Task Logs und Flow Logs in einem rohen, nach Zeitstempel geordneten Format anzeigen"
     },
     "main_configuration": "Hauptkonfiguration",
+    "manage labels": "Labels verwalten",
     "management port": "Management-Port",
     "mark as": "Als <code>{status}</code> markieren",
     "max": "Max",
@@ -1671,7 +1672,6 @@
     "sequential": "Sequenziell",
     "server type": "Servertyp",
     "services": "Dienste",
-    "set_extra_labels": "Zusätzliche Labels festlegen",
     "settings": {
       "blocks": {
         "configuration": {

--- a/ui/src/translations/en.json
+++ b/ui/src/translations/en.json
@@ -891,7 +891,7 @@
     "backfill": "Backfill",
     "Set labels tooltip": "Set labels to the execution",
     "Set labels": "Set labels",
-    "set_extra_labels": "Set extra labels",
+    "manage labels": "Manage labels",
     "Set labels to execution": "Add or update the labels of the execution <code>{id}</code>",
     "Set labels done": "Successfully set the labels of the execution",
     "bulk set labels": "Are you sure you want to set labels to <code>{executionCount}</code> executions(s)?",

--- a/ui/src/translations/es.json
+++ b/ui/src/translations/es.json
@@ -952,6 +952,7 @@
       "raw_details": "Mostrar task logs y flow logs completos en un formato crudo ordenado por marca de tiempo"
     },
     "main_configuration": "Configuración Principal",
+    "manage labels": "Gestionar etiquetas",
     "management port": "Puerto de gestión",
     "mark as": "Marcar como <code>{status}</code>",
     "max": "Max",
@@ -1671,7 +1672,6 @@
     "sequential": "Secuencial",
     "server type": "Tipo de servidor",
     "services": "Servicios",
-    "set_extra_labels": "Establecer etiquetas adicionales",
     "settings": {
       "blocks": {
         "configuration": {

--- a/ui/src/translations/fr.json
+++ b/ui/src/translations/fr.json
@@ -952,6 +952,7 @@
       "raw_details": "Affiche les logs des tâches et du flow dans un format brut ordonné par horodatage"
     },
     "main_configuration": "Configuration Principale",
+    "manage labels": "Gérer les labels",
     "management port": "Port de gestion",
     "mark as": "Marqué comme <code>{status}</code>",
     "max": "Maximum",
@@ -1671,7 +1672,6 @@
     "sequential": "Séquentiel",
     "server type": "Type de serveur",
     "services": "Services",
-    "set_extra_labels": "Définir des labels supplémentaires",
     "settings": {
       "blocks": {
         "configuration": {

--- a/ui/src/translations/hi.json
+++ b/ui/src/translations/hi.json
@@ -952,6 +952,7 @@
       "raw_details": "कच्चे timestamp-क्रमबद्ध प्रारूप में पूर्ण task logs और flow logs दिखाएं"
     },
     "main_configuration": "मुख्य कॉन्फ़िगरेशन",
+    "manage labels": "labels प्रबंधित करें",
     "management port": "प्रबंधन पोर्ट",
     "mark as": "<code>{status}</code> के रूप में चिह्नित करें",
     "max": "अधिकतम",
@@ -1671,7 +1672,6 @@
     "sequential": "अनुक्रमिक",
     "server type": "सर्वर प्रकार",
     "services": "सेवाएँ",
-    "set_extra_labels": "अतिरिक्त labels सेट करें",
     "settings": {
       "blocks": {
         "configuration": {

--- a/ui/src/translations/it.json
+++ b/ui/src/translations/it.json
@@ -952,6 +952,7 @@
       "raw_details": "Mostra i task logs e i flow logs completi in un formato grezzo ordinato per timestamp"
     },
     "main_configuration": "Configurazione Principale",
+    "manage labels": "Gestisci etichette",
     "management port": "Porta di gestione",
     "mark as": "Contrassegna come <code>{status}</code>",
     "max": "Max",
@@ -1671,7 +1672,6 @@
     "sequential": "Sequenziale",
     "server type": "Tipo di server",
     "services": "Servizi",
-    "set_extra_labels": "Imposta etichette extra",
     "settings": {
       "blocks": {
         "configuration": {

--- a/ui/src/translations/ja.json
+++ b/ui/src/translations/ja.json
@@ -952,6 +952,7 @@
       "raw_details": "タスクログとフローのログをタイムスタンプ順に生の形式で表示"
     },
     "main_configuration": "メイン設定",
+    "manage labels": "ラベルを管理",
     "management port": "管理ポート",
     "mark as": "<code>{status}</code>としてマーク",
     "max": "Max",
@@ -1671,7 +1672,6 @@
     "sequential": "逐次",
     "server type": "サーバータイプ",
     "services": "サービス",
-    "set_extra_labels": "追加のラベルを設定",
     "settings": {
       "blocks": {
         "configuration": {

--- a/ui/src/translations/ko.json
+++ b/ui/src/translations/ko.json
@@ -952,6 +952,7 @@
       "raw_details": "전체 task logs 및 flow logs를 원시 타임스탬프 순서로 표시"
     },
     "main_configuration": "주요 설정",
+    "manage labels": "label 관리",
     "management port": "관리 포트",
     "mark as": "<code>{status}</code>로 표시",
     "max": "Max",
@@ -1671,7 +1672,6 @@
     "sequential": "순차적",
     "server type": "서버 유형",
     "services": "서비스",
-    "set_extra_labels": "추가 label 설정",
     "settings": {
       "blocks": {
         "configuration": {

--- a/ui/src/translations/pl.json
+++ b/ui/src/translations/pl.json
@@ -952,6 +952,7 @@
       "raw_details": "Pokaż pełne task logs i flow logs w surowym formacie uporządkowanym według znaczników czasu"
     },
     "main_configuration": "Główna konfiguracja",
+    "manage labels": "Zarządzaj label",
     "management port": "Port zarządzania",
     "mark as": "Oznacz jako <code>{status}</code>",
     "max": "Max",
@@ -1671,7 +1672,6 @@
     "sequential": "Sekwencyjny",
     "server type": "Typ serwera",
     "services": "Usługi",
-    "set_extra_labels": "Ustaw dodatkowe label",
     "settings": {
       "blocks": {
         "configuration": {

--- a/ui/src/translations/pt.json
+++ b/ui/src/translations/pt.json
@@ -952,6 +952,7 @@
       "raw_details": "Mostrar logs completos de task e flow em formato bruto ordenado por timestamp"
     },
     "main_configuration": "Configuração Principal",
+    "manage labels": "Gerenciar labels",
     "management port": "Port de gerenciamento",
     "mark as": "Marcar como <code>{status}</code>",
     "max": "Max",
@@ -1671,7 +1672,6 @@
     "sequential": "Sequencial",
     "server type": "Tipo de servidor",
     "services": "Serviços",
-    "set_extra_labels": "Definir labels extras",
     "settings": {
       "blocks": {
         "configuration": {

--- a/ui/src/translations/pt_BR.json
+++ b/ui/src/translations/pt_BR.json
@@ -952,6 +952,7 @@
       "raw_details": "Mostrar logs completos de task e flow em formato bruto ordenado por timestamp"
     },
     "main_configuration": "Configuração Principal",
+    "manage labels": "Gerenciar labels",
     "management port": "Port de gerenciamento",
     "mark as": "Marcar como <code>{status}</code>",
     "max": "Max",
@@ -1671,7 +1672,6 @@
     "sequential": "Sequencial",
     "server type": "Tipo de servidor",
     "services": "Serviços",
-    "set_extra_labels": "Definir labels extras",
     "settings": {
       "blocks": {
         "configuration": {

--- a/ui/src/translations/ru.json
+++ b/ui/src/translations/ru.json
@@ -952,6 +952,7 @@
       "raw_details": "Показать полные task logs и flow логи в формате необработанных временных меток"
     },
     "main_configuration": "Основная конфигурация",
+    "manage labels": "Управление labels",
     "management port": "Порт управления",
     "mark as": "Пометить как <code>{status}</code>",
     "max": "Макс",
@@ -1671,7 +1672,6 @@
     "sequential": "Последовательный",
     "server type": "Тип сервера",
     "services": "Сервисы",
-    "set_extra_labels": "Установить дополнительные labels",
     "settings": {
       "blocks": {
         "configuration": {

--- a/ui/src/translations/zh_CN.json
+++ b/ui/src/translations/zh_CN.json
@@ -952,6 +952,7 @@
       "raw_details": "以原始时间顺序显示完整任务日志和流程日志"
     },
     "main_configuration": "主配置",
+    "manage labels": "管理labels",
     "management port": "管理端口",
     "mark as": "标记为 <code>{status}</code>",
     "max": "最大",
@@ -1671,7 +1672,6 @@
     "sequential": "顺序",
     "server type": "服务器类型",
     "services": "服务",
-    "set_extra_labels": "设置额外的labels",
     "settings": {
       "blocks": {
         "configuration": {

--- a/ui/tests/storybook/components/labels/LabelInput.stories.tsx
+++ b/ui/tests/storybook/components/labels/LabelInput.stories.tsx
@@ -1,6 +1,7 @@
 import LabelInput from "../../../../src/components/labels/LabelInput.vue";
 import {ref} from "vue";
 import {Meta, StoryFn} from "@storybook/vue3";
+import {within, userEvent, expect, waitFor} from "storybook/test";
 
 export default {
   title: "Components/Labels/LabelInput",
@@ -17,6 +18,11 @@ const Template: StoryFn<typeof LabelInput> = (args) => ({
 export const Default = Template.bind({});
 Default.args = {
   labels: [],
+};
+Default.play = async ({canvasElement}) => {
+  const canvas = within(canvasElement);
+  await expect(canvas.getByRole("button", {name: /add label/i})).toBeVisible();
+  await expect(canvasElement.querySelectorAll(".label-input-row").length).toBe(1);
 };
 
 export const WithValue = Template.bind({});
@@ -37,4 +43,14 @@ WithExistingLabels.args = {
     key: "existing-label",
     value: "existing-value",
   }],
+};
+WithExistingLabels.play = async ({canvasElement}) => {
+  const rows = canvasElement.querySelectorAll(".label-input-row");
+  await expect(rows.length).toBe(1);
+  const key = rows[0].querySelector("input") as HTMLInputElement;
+  await expect(key.disabled).toBe(true);
+  await expect(rows[0].querySelectorAll("button").length).toBe(1);
+
+  await userEvent.click(within(canvasElement).getByRole("button", {name: /add label/i}));
+  await waitFor(() => expect(canvasElement.querySelectorAll(".label-input-row").length).toBe(2));
 };

--- a/ui/tests/unit/components/labels/LabelInput.spec.ts
+++ b/ui/tests/unit/components/labels/LabelInput.spec.ts
@@ -1,0 +1,73 @@
+import {describe, expect, test} from "vitest"
+import {mount, flushPromises} from "@vue/test-utils"
+import LabelInput from "../../../../src/components/labels/LabelInput.vue"
+
+const KsButton = {
+    name: "KsButton",
+    props: ["icon", "tooltip", "type", "loading"],
+    emits: ["click"],
+    template: "<button @click=\"$emit('click')\"><slot/></button>",
+}
+const KsInput = {
+    name: "KsInput",
+    props: ["modelValue", "placeholder", "disabled"],
+    emits: ["update:modelValue"],
+    template: "<input :value=\"modelValue\" :disabled=\"disabled\" @input=\"$emit('update:modelValue', $event.target.value)\"/>",
+}
+
+const mountInput = async (props = {}) => {
+    const wrapper = mount(LabelInput, {
+        props: {labels: [], ...props},
+        global: {mocks: {$t: (key: string) => key}, stubs: {KsButton, KsInput}},
+    })
+    await flushPromises()
+    return wrapper
+}
+
+describe("LabelInput", () => {
+    test("shows one empty row when there are no labels", async () => {
+        const wrapper = await mountInput({labels: []})
+        expect(wrapper.findAll(".label-input__row")).toHaveLength(1)
+    })
+
+    test("renders one row per provided label", async () => {
+        const wrapper = await mountInput({labels: [{key: "a", value: "1"}, {key: "b", value: "2"}]})
+        expect(wrapper.findAll(".label-input__row")).toHaveLength(2)
+    })
+
+    test("the Add label button appends a fresh empty row", async () => {
+        const wrapper = await mountInput({labels: [{key: "a", value: "1"}]})
+        await wrapper.find(".label-input__add").trigger("click")
+        expect(wrapper.findAll(".label-input__row")).toHaveLength(2)
+    })
+
+    test("removing the last row leaves zero rows", async () => {
+        const wrapper = await mountInput({labels: [{key: "a", value: "1"}]})
+        await wrapper.find(".label-input__row button").trigger("click")
+        expect(wrapper.findAll(".label-input__row")).toHaveLength(0)
+    })
+
+    test("locks the key field for existing labels but keeps the value editable", async () => {
+        const labels = [{key: "team", value: "data"}]
+        const wrapper = await mountInput({labels, existingLabels: labels})
+        const inputs = wrapper.find(".label-input__row").findAll("input")
+        expect(inputs[0].attributes("disabled")).toBeDefined()
+        expect(inputs[1].attributes("disabled")).toBeUndefined()
+    })
+
+    test("a newly added row has an editable key", async () => {
+        const labels = [{key: "team", value: "data"}]
+        const wrapper = await mountInput({labels, existingLabels: labels})
+        await wrapper.find(".label-input__add").trigger("click")
+        const rows = wrapper.findAll(".label-input__row")
+        expect(rows[1].findAll("input")[0].attributes("disabled")).toBeUndefined()
+    })
+
+    test("emits update:labels with the new row count when a label is added", async () => {
+        const wrapper = await mountInput({labels: [{key: "a", value: "1"}]})
+        await wrapper.find(".label-input__add").trigger("click")
+        const events = wrapper.emitted("update:labels")
+        expect(events).toBeTruthy()
+        expect(events![events!.length - 1][0]).toHaveLength(2)
+    })
+})

--- a/ui/tests/unit/components/labels/LabelInput.spec.ts
+++ b/ui/tests/unit/components/labels/LabelInput.spec.ts
@@ -27,30 +27,30 @@ const mountInput = async (props = {}) => {
 describe("LabelInput", () => {
     test("shows one empty row when there are no labels", async () => {
         const wrapper = await mountInput({labels: []})
-        expect(wrapper.findAll(".label-input__row")).toHaveLength(1)
+        expect(wrapper.findAll(".label-input-row")).toHaveLength(1)
     })
 
     test("renders one row per provided label", async () => {
         const wrapper = await mountInput({labels: [{key: "a", value: "1"}, {key: "b", value: "2"}]})
-        expect(wrapper.findAll(".label-input__row")).toHaveLength(2)
+        expect(wrapper.findAll(".label-input-row")).toHaveLength(2)
     })
 
     test("the Add label button appends a fresh empty row", async () => {
         const wrapper = await mountInput({labels: [{key: "a", value: "1"}]})
-        await wrapper.find(".label-input__add").trigger("click")
-        expect(wrapper.findAll(".label-input__row")).toHaveLength(2)
+        await wrapper.find(".label-input-add").trigger("click")
+        expect(wrapper.findAll(".label-input-row")).toHaveLength(2)
     })
 
     test("removing the last row leaves zero rows", async () => {
         const wrapper = await mountInput({labels: [{key: "a", value: "1"}]})
-        await wrapper.find(".label-input__row button").trigger("click")
-        expect(wrapper.findAll(".label-input__row")).toHaveLength(0)
+        await wrapper.find(".label-input-row button").trigger("click")
+        expect(wrapper.findAll(".label-input-row")).toHaveLength(0)
     })
 
     test("locks the key field for existing labels but keeps the value editable", async () => {
         const labels = [{key: "team", value: "data"}]
         const wrapper = await mountInput({labels, existingLabels: labels})
-        const inputs = wrapper.find(".label-input__row").findAll("input")
+        const inputs = wrapper.find(".label-input-row").findAll("input")
         expect(inputs[0].attributes("disabled")).toBeDefined()
         expect(inputs[1].attributes("disabled")).toBeUndefined()
     })
@@ -58,14 +58,14 @@ describe("LabelInput", () => {
     test("a newly added row has an editable key", async () => {
         const labels = [{key: "team", value: "data"}]
         const wrapper = await mountInput({labels, existingLabels: labels})
-        await wrapper.find(".label-input__add").trigger("click")
-        const rows = wrapper.findAll(".label-input__row")
+        await wrapper.find(".label-input-add").trigger("click")
+        const rows = wrapper.findAll(".label-input-row")
         expect(rows[1].findAll("input")[0].attributes("disabled")).toBeUndefined()
     })
 
     test("emits update:labels with the new row count when a label is added", async () => {
         const wrapper = await mountInput({labels: [{key: "a", value: "1"}]})
-        await wrapper.find(".label-input__add").trigger("click")
+        await wrapper.find(".label-input-add").trigger("click")
         const events = wrapper.emitted("update:labels")
         expect(events).toBeTruthy()
         expect(events![events!.length - 1][0]).toHaveLength(2)


### PR DESCRIPTION
## Summary

Reworks the execution **Set labels** popup so adding and editing labels reads clearly, per [kestra-ee#8480](https://github.com/kestra-io/kestra-ee/issues/8480). Today every row (including rows for labels that already exist) carries its own `+` and `−`, which feels off next to an already-created label.

This applies the same principle as [#16387](https://github.com/kestra-io/kestra/pull/16387) (turning a redundant inline `+` into a single clear "Add" affordance):

- **One "Add label" button at the top** of the list opens a fresh empty row.
- **Existing label rows keep only a remove (`−`) action** — no more per-row `+`. Their key stays locked (unchanged); the value remains editable.
- Removing all rows is now allowed (clears the labels); the top button re-adds.
- Trigger renamed **"Set extra labels" → "Manage labels"** (it manages add/edit/remove, not just add).
- Primary action renamed **"OK" → "Save"**.

The change lives in the shared `LabelInput`, so the **flow-run** ("Other properties → Execution labels") and **bulk set-labels** dialogs get the same layout for free.

## Demo

> _Drag-and-drop the `manage-labels-demo.mp4` here (GitHub only accepts video uploads via the browser)._ Add → type → Save → reopen, showing the new label persist as a locked existing row.

## Screenshots (before / after)

| Before | After |
|--------|-------|
| Per-row `+`/`−` on every row, incl. existing labels | Single "Add label" on top; existing rows keep only `−` |

https://github.com/user-attachments/assets/c831b15d-e491-4e51-bb84-5f3c1bb61d06



## Test plan

- [x] New unit test `ui/tests/unit/components/labels/LabelInput.spec.ts` (7 tests) — add row, remove-to-zero, existing-key lock, value editable, new-row editable key, `update:labels` emit
- [x] ESLint clean on changed files
- [x] `check.js`: no extra keys across all 12 locales
- [x] Manual QA on dev server (light): execution popup, flow-run labels, no console errors
- [ ] CI: UI lint, type-check, unit tests

Closes https://github.com/kestra-io/kestra-ee/issues/8480

🤖 Generated with [Claude Code](https://claude.com/claude-code)