### PR TITLE
refactor(namespaces)!: rename ns-file pebble arg + model field 'version' to 'revision'

### DIFF
--- a/core/src/main/java/io/kestra/core/models/kv/PersistedKvMetadata.java
+++ b/core/src/main/java/io/kestra/core/models/kv/PersistedKvMetadata.java
@@ -9,6 +9,7 @@ import io.kestra.core.models.TenantInterface;
 import io.kestra.core.storages.kv.KVEntry;
 import io.kestra.core.utils.IdUtils;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.Hidden;
 import jakarta.annotation.Nullable;
 import jakarta.validation.constraints.NotNull;
@@ -37,8 +38,11 @@ public class PersistedKvMetadata implements SoftDeletable<PersistedKvMetadata>, 
 
     private String description;
 
+    // Field renamed to 'revision' but the persisted JSON key stays "version" (frozen via @JsonProperty)
+    // to avoid a JSONB backfill on existing installs; see VersionJsonKeyFreezeTest.
     @NotNull
-    private Integer version;
+    @JsonProperty("version")
+    private Integer revision;
 
     @Builder.Default
     private boolean last = true;
@@ -54,13 +58,13 @@ public class PersistedKvMetadata implements SoftDeletable<PersistedKvMetadata>, 
 
     private boolean deleted;
 
-    public PersistedKvMetadata(String tenantId, String namespace, String name, String description, Integer version, boolean last, @Nullable Instant expirationDate, @Nullable Instant created,
+    public PersistedKvMetadata(String tenantId, String namespace, String name, String description, @JsonProperty("version") Integer revision, boolean last, @Nullable Instant expirationDate, @Nullable Instant created,
         @Nullable Instant updated, boolean deleted) {
         this.tenantId = tenantId;
         this.namespace = namespace;
         this.name = name;
         this.description = description;
-        this.version = version;
+        this.revision = revision;
         this.last = last;
         this.expirationDate = expirationDate;
         this.created = Optional.ofNullable(created).orElse(Instant.now());
@@ -73,7 +77,7 @@ public class PersistedKvMetadata implements SoftDeletable<PersistedKvMetadata>, 
             .tenantId(tenantId)
             .namespace(kvEntry.namespace())
             .name(kvEntry.key())
-            .version(kvEntry.version())
+            .revision(kvEntry.revision())
             .description(kvEntry.description())
             .created(kvEntry.creationDate())
             .updated(kvEntry.updateDate())
@@ -92,6 +96,6 @@ public class PersistedKvMetadata implements SoftDeletable<PersistedKvMetadata>, 
 
     @Override
     public String uid() {
-        return IdUtils.fromParts(getTenantId(), getNamespace(), getName(), String.valueOf(getVersion()));
+        return IdUtils.fromParts(getTenantId(), getNamespace(), getName(), String.valueOf(getRevision()));
     }
 }

--- a/core/src/main/java/io/kestra/core/models/namespaces/files/NamespaceFileMetadata.java
+++ b/core/src/main/java/io/kestra/core/models/namespaces/files/NamespaceFileMetadata.java
@@ -4,6 +4,7 @@ import java.time.Instant;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 import io.kestra.core.models.HasUID;
 import io.kestra.core.models.SoftDeletable;
@@ -40,8 +41,11 @@ public class NamespaceFileMetadata implements SoftDeletable<NamespaceFileMetadat
 
     private String parentPath;
 
+    // Field renamed to 'revision' but the persisted JSON key stays "version" (frozen via @JsonProperty)
+    // to avoid a JSONB backfill on existing installs; see VersionJsonKeyFreezeTest.
     @NotNull
-    private Integer version;
+    @JsonProperty("version")
+    private Integer revision;
 
     @Builder.Default
     private boolean last = true;
@@ -58,13 +62,13 @@ public class NamespaceFileMetadata implements SoftDeletable<NamespaceFileMetadat
     private boolean deleted;
 
     @JsonCreator
-    public NamespaceFileMetadata(String tenantId, String namespace, String path, String parentPath, Integer version, boolean last, Long size, Instant created, @Nullable Instant updated,
+    public NamespaceFileMetadata(String tenantId, String namespace, String path, String parentPath, @JsonProperty("version") Integer revision, boolean last, Long size, Instant created, @Nullable Instant updated,
         boolean deleted) {
         this.tenantId = tenantId;
         this.namespace = namespace;
         this.path = path;
         this.parentPath = parentPath(path);
-        this.version = version;
+        this.revision = revision;
         this.last = last;
         this.size = size;
         this.created = created;
@@ -96,7 +100,7 @@ public class NamespaceFileMetadata implements SoftDeletable<NamespaceFileMetadat
             .tenantId(tenantId)
             .namespace(namespaceFile.namespace())
             .path(namespaceFile.filePath().toString())
-            .version(namespaceFile.version())
+            .revision(namespaceFile.revision())
             .build();
     }
 
@@ -108,7 +112,7 @@ public class NamespaceFileMetadata implements SoftDeletable<NamespaceFileMetadat
             .created(Instant.ofEpochMilli(fileAttributes.getCreationTime()))
             .updated(Instant.ofEpochMilli(fileAttributes.getLastModifiedTime()))
             .size(fileAttributes.getSize())
-            .version(1)
+            .revision(1)
             .build();
     }
 
@@ -124,7 +128,7 @@ public class NamespaceFileMetadata implements SoftDeletable<NamespaceFileMetadat
 
     @Override
     public String uid() {
-        return IdUtils.fromParts(getTenantId(), getNamespace(), getPath(), String.valueOf(getVersion()));
+        return IdUtils.fromParts(getTenantId(), getNamespace(), getPath(), String.valueOf(getRevision()));
     }
 
     @JsonIgnore

--- a/core/src/main/java/io/kestra/core/runners/pebble/functions/FileURIFunction.java
+++ b/core/src/main/java/io/kestra/core/runners/pebble/functions/FileURIFunction.java
@@ -20,7 +20,7 @@ import jakarta.inject.Singleton;
 @Singleton
 public class FileURIFunction extends AbstractFileFunction {
     public static final String NAME = "fileURI";
-    public static final String VERSION = "version";
+    public static final String REVISION = "revision";
 
     private static final String ERROR_MESSAGE = "The 'fileURI' function expects an argument 'path' that is a path to a namespace file.";
 
@@ -28,7 +28,7 @@ public class FileURIFunction extends AbstractFileFunction {
     public List<String> getArgumentNames() {
         return Stream.concat(
             super.getArgumentNames().stream(),
-            Stream.of(VERSION)
+            Stream.of(REVISION)
         ).toList();
     }
 
@@ -37,7 +37,7 @@ public class FileURIFunction extends AbstractFileFunction {
         HashMap<String, String> defaults = new HashMap<>();
         defaults.put(PATH, "'a/namespace/file'");
         defaults.put(NAMESPACE, null);
-        defaults.put(VERSION, null);
+        defaults.put(REVISION, null);
         return defaults;
     }
 
@@ -59,19 +59,19 @@ public class FileURIFunction extends AbstractFileFunction {
         Namespace namespaceStorage = namespaceFactory.get().of(tenantId, namespace, storageInterface.get());
         Path filePath = NamespaceFile.normalize(Path.of(pathStr));
 
-        if (args.containsKey(VERSION)) {
-            Integer version;
+        if (args.containsKey(REVISION)) {
+            Integer revision;
             try {
-                version = Integer.parseInt(args.get(VERSION).toString());
+                revision = Integer.parseInt(args.get(REVISION).toString());
             } catch (NumberFormatException e) {
-                throw new IllegalArgumentException("The 'fileURI' function expects the 'version' argument to be a valid integer.");
+                throw new IllegalArgumentException("The 'fileURI' function expects the 'revision' argument to be a valid integer.");
             }
             try {
-                namespaceStorage.getFileContent(filePath, version).close();
+                namespaceStorage.getFileContent(filePath, revision).close();
             } catch (FileNotFoundException e) {
-                throw new FileNotFoundException("Version " + version + " of file '" + filePath + "' was not found in namespace '" + namespace + "'.");
+                throw new FileNotFoundException("Revision " + revision + " of file '" + filePath + "' was not found in namespace '" + namespace + "'.");
             }
-            NamespaceFile namespaceFile = NamespaceFile.of(namespace, filePath, version);
+            NamespaceFile namespaceFile = NamespaceFile.of(namespace, filePath, revision);
             return namespaceFile.uri().toString();
         } else {
             NamespaceFile namespaceFile = namespaceStorage.get(filePath);

--- a/core/src/main/java/io/kestra/core/runners/pebble/functions/ReadFileFunction.java
+++ b/core/src/main/java/io/kestra/core/runners/pebble/functions/ReadFileFunction.java
@@ -23,7 +23,7 @@ import jakarta.inject.Singleton;
 @Singleton
 public class ReadFileFunction extends AbstractFileFunction {
     public static final String NAME = "read";
-    public static final String VERSION = "version";
+    public static final String REVISION = "revision";
 
     private static final String ERROR_MESSAGE = "The 'read' function expects an argument 'path' that is a path to a namespace file or an internal storage URI.";
 
@@ -31,7 +31,7 @@ public class ReadFileFunction extends AbstractFileFunction {
     public List<String> getArgumentNames() {
         return Stream.concat(
             super.getArgumentNames().stream(),
-            Stream.of(VERSION)
+            Stream.of(REVISION)
         ).toList();
     }
 
@@ -40,7 +40,7 @@ public class ReadFileFunction extends AbstractFileFunction {
         HashMap<String, String> defaults = new HashMap<>();
         defaults.put(PATH, "'a/namespace/file'");
         defaults.put(NAMESPACE, "flow.namespace");
-        defaults.put(VERSION, null);
+        defaults.put(REVISION, null);
         return defaults;
     }
 
@@ -78,10 +78,10 @@ public class ReadFileFunction extends AbstractFileFunction {
     private InputStream contentInputStream(URI path, String namespace, String tenantId, Map<String, Object> args) throws IOException {
         Namespace namespaceStorage = namespaceFactory.get().of(tenantId, namespace, storageInterface.get());
 
-        if (args.containsKey(VERSION)) {
+        if (args.containsKey(REVISION)) {
             return namespaceStorage.getFileContent(
                 NamespaceFile.normalize(Path.of(path.getPath())),
-                Integer.parseInt(args.get(VERSION).toString())
+                Integer.parseInt(args.get(REVISION).toString())
             );
         }
 

--- a/core/src/main/java/io/kestra/core/services/KVStoreService.java
+++ b/core/src/main/java/io/kestra/core/services/KVStoreService.java
@@ -135,7 +135,7 @@ public class KVStoreService {
         Integer purgedMetadataCount = getKvMetadataRepository().purge(kvEntries.stream().map(kv -> PersistedKvMetadata.from(tenant, kv)).toList());
 
         long actualDeletedEntries = kvEntries.stream()
-            .map(entry -> KVStore.storageUri(entry.key(), namespace, entry.version()))
+            .map(entry -> KVStore.storageUri(entry.key(), namespace, entry.revision()))
             .map(throwFunction(uri ->
             {
                 boolean deleted = this.storage.delete(tenant, namespace, uri);

--- a/core/src/main/java/io/kestra/core/storages/InternalNamespace.java
+++ b/core/src/main/java/io/kestra/core/storages/InternalNamespace.java
@@ -108,7 +108,7 @@ public class InternalNamespace implements Namespace {
 
         return namespaceFilesMetadata.stream()
             .filter(nsFileMetadata -> !nsFileMetadata.getPath().equals("/"))
-            .map(nsFileMetadata -> NamespaceFile.of(namespace, Path.of(nsFileMetadata.getPath()), nsFileMetadata.getVersion()))
+            .map(nsFileMetadata -> NamespaceFile.of(namespace, Path.of(nsFileMetadata.getPath()), nsFileMetadata.getRevision()))
             .toList();
     }
 
@@ -151,7 +151,7 @@ public class InternalNamespace implements Namespace {
             allMetas.addAll(descendants);
         }
 
-        allMetas.sort(Comparator.comparing(NamespaceFileMetadata::getVersion));
+        allMetas.sort(Comparator.comparing(NamespaceFileMetadata::getRevision));
 
         // Phase 1: Copy all entries to their new locations, tracking what was created for rollback
         List<Pair<NamespaceFile, NamespaceFile>> results = new ArrayList<>();
@@ -168,7 +168,7 @@ public class InternalNamespace implements Namespace {
                 }
                 final String finalNewPath = intermediateNewPath;
 
-                NamespaceFile beforeNamespaceFile = NamespaceFile.of(namespace, Path.of(oldPath), nsFileMetadata.getVersion());
+                NamespaceFile beforeNamespaceFile = NamespaceFile.of(namespace, Path.of(oldPath), nsFileMetadata.getRevision());
                 NamespaceFile afterNamespaceFile;
 
                 if (nsFileMetadata.isDirectory()) {
@@ -228,9 +228,9 @@ public class InternalNamespace implements Namespace {
     public NamespaceFile get(Path path) throws IOException {
         final Path normalizedPath = NamespaceFile.normalize(path);
 
-        int version = findByPath(normalizedPath).map(NamespaceFileMetadata::getVersion).orElse(1);
+        int revision = findByPath(normalizedPath).map(NamespaceFileMetadata::getRevision).orElse(1);
 
-        return NamespaceFile.of(namespace, normalizedPath, version);
+        return NamespaceFile.of(namespace, normalizedPath, revision);
     }
 
     public Path relativize(final URI uri) {
@@ -251,13 +251,13 @@ public class InternalNamespace implements Namespace {
      * {@inheritDoc}
      **/
     @Override
-    public InputStream getFileContent(Path path, @Nullable Integer version) throws IOException {
+    public InputStream getFileContent(Path path, @Nullable Integer revision) throws IOException {
         final Path normalizedPath = NamespaceFile.normalize(path);
 
         // Throw if file not found OR if it's deleted
-        NamespaceFileMetadata namespaceFileMetadata = findByPath(normalizedPath, version).orElseThrow(() -> fileNotFound(normalizedPath, version));
+        NamespaceFileMetadata namespaceFileMetadata = findByPath(normalizedPath, revision).orElseThrow(() -> fileNotFound(normalizedPath, revision));
 
-        Path namespaceFilePath = NamespaceFile.of(namespace, normalizedPath, namespaceFileMetadata.getVersion()).storagePath();
+        Path namespaceFilePath = NamespaceFile.of(namespace, normalizedPath, namespaceFileMetadata.getRevision()).storagePath();
         return storage.get(tenant, namespace, namespaceFilePath.toUri());
     }
 
@@ -271,22 +271,22 @@ public class InternalNamespace implements Namespace {
         return findByPath(normalizedPath).map(NamespaceFileAttributes::new).orElseThrow(() -> fileNotFound(normalizedPath, null));
     }
 
-    private FileNotFoundException fileNotFound(Path path, @Nullable Integer version) {
-        return new FileNotFoundException(Optional.ofNullable(version).map(v -> "Version " + v + " of file").orElse("File") + " '" + path + "' was not found in namespace '" + namespace + "'.");
+    private FileNotFoundException fileNotFound(Path path, @Nullable Integer revision) {
+        return new FileNotFoundException(Optional.ofNullable(revision).map(v -> "Revision " + v + " of file").orElse("File") + " '" + path + "' was not found in namespace '" + namespace + "'.");
     }
 
-    private Optional<NamespaceFileMetadata> findByPath(Path path, boolean allowDeleted, @Nullable Integer version) throws IOException {
+    private Optional<NamespaceFileMetadata> findByPath(Path path, boolean allowDeleted, @Nullable Integer revision) throws IOException {
         final Path normalizedPath = NamespaceFile.normalize(path);
 
-        return stateStore.findByPath(tenant, namespace, normalizedPath.toString(), version, allowDeleted);
+        return stateStore.findByPath(tenant, namespace, normalizedPath.toString(), revision, allowDeleted);
     }
 
     private Optional<NamespaceFileMetadata> findByPath(Path path, boolean allowDeleted) throws IOException {
         return findByPath(path, allowDeleted, null);
     }
 
-    private Optional<NamespaceFileMetadata> findByPath(Path path, @Nullable Integer version) throws IOException {
-        return findByPath(path, false, version);
+    private Optional<NamespaceFileMetadata> findByPath(Path path, @Nullable Integer revision) throws IOException {
+        return findByPath(path, false, revision);
     }
 
     private Optional<NamespaceFileMetadata> findByPath(Path path) throws IOException {
@@ -310,8 +310,8 @@ public class InternalNamespace implements Namespace {
         final Path normalizedPath = NamespaceFile.normalize(path);
 
         Optional<NamespaceFileMetadata> inRepository = findByPath(normalizedPath, true);
-        int currentVersion = inRepository.map(NamespaceFileMetadata::getVersion).orElse(0);
-        NamespaceFile namespaceFile = NamespaceFile.of(namespace, normalizedPath, currentVersion + 1);
+        int currentRevision = inRepository.map(NamespaceFileMetadata::getRevision).orElse(0);
+        NamespaceFile namespaceFile = NamespaceFile.of(namespace, normalizedPath, currentRevision + 1);
         Path storagePath = namespaceFile.storagePath();
         // Remove Windows letter
         URI cleanUri = new URI(storagePath.toUri().toString().replaceFirst("^file:///[a-zA-Z]:", ""));

--- a/core/src/main/java/io/kestra/core/storages/Namespace.java
+++ b/core/src/main/java/io/kestra/core/storages/Namespace.java
@@ -109,12 +109,12 @@ public interface Namespace {
      * Retrieves the content of the namespace file at the given path.
      *
      * @param path the file path.
-     * @param version optionally a file version, otherwise will retrieve the latest.
+     * @param revision optionally a file revision, otherwise will retrieve the latest.
      * @return the {@link InputStream}.
      * @throws IllegalArgumentException if the given {@link Path} is {@code null} or invalid.
      * @throws IOException if an error happens while accessing the file.
      */
-    InputStream getFileContent(Path path, @Nullable Integer version) throws IOException;
+    InputStream getFileContent(Path path, @Nullable Integer revision) throws IOException;
 
     /**
      * Retrieves the metadata of the namespace file at the given path.

--- a/core/src/main/java/io/kestra/core/storages/NamespaceFile.java
+++ b/core/src/main/java/io/kestra/core/storages/NamespaceFile.java
@@ -18,15 +18,15 @@ import jakarta.annotation.Nullable;
  * @param path The path of file relative to the namespace.
  * @param uri The URI of the namespace file in the Kestra's internal storage.
  * @param namespace The namespace of the file.
- * @param version The version of the file.
+ * @param revision The revision of the file.
  */
 public record NamespaceFile(
     String path,
     URI uri,
     String namespace,
-    int version) {
+    int revision) {
 
-    private static final Pattern capturePathWithoutVersion = Pattern.compile("(.*)(?:\\.v\\d+)?$");
+    private static final Pattern capturePathWithoutRevision = Pattern.compile("(.*)(?:\\.v\\d+)?$");
 
     public NamespaceFile(Path path, URI uri, String namespace) {
         this(path.toString(), uri, namespace, 1);
@@ -56,7 +56,7 @@ public record NamespaceFile(
         return of(
             metadata.getNamespace(),
             metadata.getPath(),
-            metadata.getVersion()
+            metadata.getRevision()
         );
     }
 
@@ -67,9 +67,9 @@ public record NamespaceFile(
      * @param namespace The namespace - cannot be {@code null}.
      * @return a new {@link NamespaceFile} object
      */
-    public static NamespaceFile of(final String namespace, @Nullable final URI uri, int version) {
+    public static NamespaceFile of(final String namespace, @Nullable final URI uri, int revision) {
         if (uri == null || uri.equals(URI.create("/"))) {
-            return of(namespace, (Path) null, version);
+            return of(namespace, (Path) null, revision);
         }
 
         Path path = Path.of(WindowsUtils.windowsToUnixPath(uri.getPath()));
@@ -89,9 +89,9 @@ public record NamespaceFile(
                     )
                 );
             }
-            namespaceFile = of(namespace, Path.of(StorageContext.namespaceFilePrefix(namespace)).relativize(path), version);
+            namespaceFile = of(namespace, Path.of(StorageContext.namespaceFilePrefix(namespace)).relativize(path), revision);
         } else {
-            namespaceFile = of(namespace, path, version);
+            namespaceFile = of(namespace, path, revision);
         }
 
         boolean trailingSlash = uri.toString().endsWith("/");
@@ -104,7 +104,7 @@ public record NamespaceFile(
             namespaceFile.path,
             URI.create(namespaceFile.uri.toString() + "/"),
             namespaceFile.namespace,
-            version
+            revision
         );
     }
 
@@ -119,38 +119,38 @@ public record NamespaceFile(
      * @param namespace The namespace - cannot be {@code null}.
      * @return a new {@link NamespaceFile} object
      */
-    public static NamespaceFile of(final String namespace, @Nullable final Path path, int version) {
+    public static NamespaceFile of(final String namespace, @Nullable final Path path, int revision) {
         Objects.requireNonNull(namespace, "namespace cannot be null");
         if (path == null || path.equals(Path.of("/"))) {
             return new NamespaceFile(
                 "",
                 URI.create(StorageContext.KESTRA_PROTOCOL + StorageContext.namespaceFilePrefix(namespace) + "/"),
                 namespace,
-                // Directory always has a single version
+                // Directory always has a single revision
                 1
             );
         }
 
-        return of(namespace, path.toString(), version);
+        return of(namespace, path.toString(), revision);
     }
 
-    public static NamespaceFile of(String namespace, String path, int version) {
+    public static NamespaceFile of(String namespace, String path, int revision) {
         Path namespacePrefixPath = Path.of(StorageContext.namespaceFilePrefix(namespace));
         // Need to remove starting trailing slash for Windows
         String pathWithoutLeadingSlash = path.replaceFirst("^[.]*[\\\\|/]+", "");
 
-        version = NamespaceFile.isDirectory(pathWithoutLeadingSlash) ? 1 : version;
+        revision = NamespaceFile.isDirectory(pathWithoutLeadingSlash) ? 1 : revision;
 
         String storagePath = pathWithoutLeadingSlash;
-        if (!pathWithoutLeadingSlash.endsWith("/") && version > 1) {
-            storagePath += ".v" + version;
+        if (!pathWithoutLeadingSlash.endsWith("/") && revision > 1) {
+            storagePath += ".v" + revision;
         }
 
         return new NamespaceFile(
             pathWithoutLeadingSlash,
             URI.create(StorageContext.KESTRA_PROTOCOL + namespacePrefixPath.resolve(storagePath).toString().replace("\\", "/") + (isDirectory(path) ? "/" : "")),
             namespace,
-            version
+            revision
         );
     }
 
@@ -175,7 +175,7 @@ public record NamespaceFile(
      */
     public Path filePath() {
         String strPath = path;
-        Matcher matcher = capturePathWithoutVersion.matcher(strPath);
+        Matcher matcher = capturePathWithoutRevision.matcher(strPath);
         if (matcher.matches()) {
             strPath = matcher.group(1);
         }

--- a/core/src/main/java/io/kestra/core/storages/kv/InternalKVStore.java
+++ b/core/src/main/java/io/kestra/core/storages/kv/InternalKVStore.java
@@ -90,7 +90,7 @@ public class InternalKVStore implements KVStore {
                 .build()
         );
         this.storage.put(
-            this.tenant, this.namespace, this.storageUri(key, saved.getVersion()), new StorageObject(
+            this.tenant, this.namespace, this.storageUri(key, saved.getRevision()), new StorageObject(
                 value.metadataAsMap(),
                 new ByteArrayInputStream(serialized)
             )
@@ -120,7 +120,7 @@ public class InternalKVStore implements KVStore {
         );
         KVValueAndMetadata wrapper = new KVValueAndMetadata(metadata, null);
         this.storage.put(
-            this.tenant, this.namespace, this.storageUri(key, saved.getVersion()), new StorageObject(
+            this.tenant, this.namespace, this.storageUri(key, saved.getRevision()), new StorageObject(
                 wrapper.metadataAsMap(),
                 new ByteArrayInputStream(rawValue)
             )
@@ -147,7 +147,7 @@ public class InternalKVStore implements KVStore {
 
         Optional<PersistedKvMetadata> maybeMetadata = this.kvMetadataStateStore.findByName(this.tenant, this.namespace, key);
 
-        int version = maybeMetadata.map(PersistedKvMetadata::getVersion).orElse(1);
+        int revision = maybeMetadata.map(PersistedKvMetadata::getRevision).orElse(1);
         if (maybeMetadata.isPresent()) {
             PersistedKvMetadata metadata = maybeMetadata.get();
             if (metadata.isDeleted()) {
@@ -162,7 +162,7 @@ public class InternalKVStore implements KVStore {
 
         StorageObject withMetadata;
         try {
-            withMetadata = this.storage.getWithMetadata(this.tenant, this.namespace, this.storageUri(key, version));
+            withMetadata = this.storage.getWithMetadata(this.tenant, this.namespace, this.storageUri(key, revision));
         } catch (FileNotFoundException e) {
             return Optional.empty();
         }

--- a/core/src/main/java/io/kestra/core/storages/kv/KVEntry.java
+++ b/core/src/main/java/io/kestra/core/storages/kv/KVEntry.java
@@ -12,14 +12,14 @@ import io.kestra.core.storages.FileAttributes;
 
 import jakarta.annotation.Nullable;
 
-public record KVEntry(String namespace, String key, Integer version, @Nullable String description, Instant creationDate, Instant updateDate, @Nullable Instant expirationDate) {
+public record KVEntry(String namespace, String key, Integer revision, @Nullable String description, Instant creationDate, Instant updateDate, @Nullable Instant expirationDate) {
 
-    private static final Pattern captureKeyAndVersion = Pattern.compile("(.*)\\.ion(?:\\.v(\\d+))?$");
+    private static final Pattern captureKeyAndRevision = Pattern.compile("(.*)\\.ion(?:\\.v(\\d+))?$");
 
     public static KVEntry from(String namespace, FileAttributes fileAttributes) throws IOException {
         Optional<KVMetadata> kvMetadata = Optional.ofNullable(fileAttributes.getMetadata()).map(KVMetadata::new);
         String fileName = fileAttributes.getFileName();
-        Matcher matcher = captureKeyAndVersion.matcher(fileName);
+        Matcher matcher = captureKeyAndRevision.matcher(fileName);
         if (!matcher.matches()) {
             throw new IOException("Invalid KV file name format: " + fileName);
         }
@@ -40,7 +40,7 @@ public record KVEntry(String namespace, String key, Integer version, @Nullable S
         return new KVEntry(
             persistedKvMetadata.getNamespace(),
             persistedKvMetadata.getName(),
-            persistedKvMetadata.getVersion(),
+            persistedKvMetadata.getRevision(),
             persistedKvMetadata.getDescription(),
             persistedKvMetadata.getCreated(),
             persistedKvMetadata.getUpdated(),

--- a/core/src/main/java/io/kestra/core/storages/kv/KVStore.java
+++ b/core/src/main/java/io/kestra/core/storages/kv/KVStore.java
@@ -29,17 +29,17 @@ public interface KVStore {
         return this.storageUri(key, 1);
     }
 
-    default URI storageUri(String key, int version) {
-        return KVStore.storageUri(key, namespace(), version);
+    default URI storageUri(String key, int revision) {
+        return KVStore.storageUri(key, namespace(), revision);
     }
 
-    static URI storageUri(String key, String namespace, int version) {
-        String fileName = kvFileName(key, version);
+    static URI storageUri(String key, String namespace, int revision) {
+        String fileName = kvFileName(key, revision);
         return URI.create(StorageContext.KESTRA_PROTOCOL + StorageContext.kvPrefix(namespace) + (fileName.isEmpty() ? fileName : ("/" + fileName)));
     }
 
-    static String kvFileName(String key, int version) {
-        return key == null ? "" : (key + ".ion") + (version > 1 ? (".v" + version) : "");
+    static String kvFileName(String key, int revision) {
+        return key == null ? "" : (key + ".ion") + (revision > 1 ? (".v" + revision) : "");
     }
 
     /**

--- a/core/src/test/java/io/kestra/core/namespace/AbstractDefaultNamespaceFileMetadataStateStoreTest.java
+++ b/core/src/test/java/io/kestra/core/namespace/AbstractDefaultNamespaceFileMetadataStateStoreTest.java
@@ -48,7 +48,7 @@ public abstract class AbstractDefaultNamespaceFileMetadataStateStoreTest {
 
         // Then
         assertThat(result).isPresent();
-        assertThat(result.get().getVersion()).isEqualTo(2);
+        assertThat(result.get().getRevision()).isEqualTo(2);
         assertThat(result.get().isLast()).isTrue();
         assertThat(result.get().isDeleted()).isFalse();
     }
@@ -82,7 +82,7 @@ public abstract class AbstractDefaultNamespaceFileMetadataStateStoreTest {
 
         // Then
         assertThat(result).isPresent();
-        assertThat(result.get().getVersion()).isEqualTo(1);
+        assertThat(result.get().getRevision()).isEqualTo(1);
         assertThat(result.get().isLast()).isFalse();
     }
 
@@ -356,7 +356,7 @@ public abstract class AbstractDefaultNamespaceFileMetadataStateStoreTest {
 
         // Then
         assertThat(result).hasSize(2);
-        assertThat(result).extracting(NamespaceFileMetadata::getVersion)
+        assertThat(result).extracting(NamespaceFileMetadata::getRevision)
             .containsExactlyInAnyOrder(1, 2);
     }
 
@@ -419,8 +419,8 @@ public abstract class AbstractDefaultNamespaceFileMetadataStateStoreTest {
         );
 
         // Then
-        assertThat(v1.getVersion()).isEqualTo(1);
-        assertThat(v2.getVersion()).isEqualTo(2);
+        assertThat(v1.getRevision()).isEqualTo(1);
+        assertThat(v2.getRevision()).isEqualTo(2);
     }
 
     @Test
@@ -522,7 +522,7 @@ public abstract class AbstractDefaultNamespaceFileMetadataStateStoreTest {
 
         // Then
         assertThat(result).isPresent();
-        assertThat(result.get().getVersion()).isEqualTo(2);
+        assertThat(result.get().getRevision()).isEqualTo(2);
         assertThat(result.get().isDeleted()).isTrue();
     }
 

--- a/core/src/test/java/io/kestra/core/repositories/AbstractKvMetadataRepositoryTest.java
+++ b/core/src/test/java/io/kestra/core/repositories/AbstractKvMetadataRepositoryTest.java
@@ -65,7 +65,7 @@ public abstract class AbstractKvMetadataRepositoryTest {
         kvMetadataRepositoryInterface.save(metadata);
 
         String changedDescription = "Changed description";
-        kvMetadataRepositoryInterface.save(metadata.toBuilder().description(changedDescription).version(2).build());
+        kvMetadataRepositoryInterface.save(metadata.toBuilder().description(changedDescription).revision(2).build());
 
         Optional<PersistedKvMetadata> found = kvMetadataRepositoryInterface.findByName(
             tenantId,
@@ -76,7 +76,7 @@ public abstract class AbstractKvMetadataRepositoryTest {
         assertThat(found).isPresent();
         assertThat(found.get().getName()).isEqualTo(key);
         assertThat(found.get().getDescription()).isEqualTo(changedDescription);
-        assertThat(found.get().getVersion()).isEqualTo(2);
+        assertThat(found.get().getRevision()).isEqualTo(2);
         assertThat(found.get().isLast()).isTrue();
         assertThat(found.get().isDeleted()).isFalse();
     }
@@ -90,7 +90,7 @@ public abstract class AbstractKvMetadataRepositoryTest {
             .tenantId(tenantId)
             .namespace(namespace)
             .name(key)
-            .version(1)
+            .revision(1)
             .build();
 
         kvMetadataRepositoryInterface.save(metadata);
@@ -118,7 +118,7 @@ public abstract class AbstractKvMetadataRepositoryTest {
         assertThat(found).isPresent();
         assertThat(found.get().getName()).isEqualTo(key);
         // Soft delete
-        assertThat(found.get().getVersion()).isEqualTo(1);
+        assertThat(found.get().getRevision()).isEqualTo(1);
         assertThat(found.get().isLast()).isTrue();
         assertThat(found.get().isDeleted()).isTrue();
         assertThat(found.get().getUpdated()).isAfter(beforeDeleteUpdateDate);
@@ -137,11 +137,11 @@ public abstract class AbstractKvMetadataRepositoryTest {
             .description(originalDescription)
             .build();
 
-        assertThat(metadata.getVersion()).isNull();
-        assertThat(kvMetadataRepositoryInterface.save(metadata).getVersion()).isEqualTo(1);
+        assertThat(metadata.getRevision()).isNull();
+        assertThat(kvMetadataRepositoryInterface.save(metadata).getRevision()).isEqualTo(1);
         String changedDescription = "Changed description";
         metadata = kvMetadataRepositoryInterface.save(metadata.toBuilder().description(changedDescription).build());
-        assertThat(metadata.getVersion()).isEqualTo(2);
+        assertThat(metadata.getRevision()).isEqualTo(2);
 
         String anotherNamespace = TestsUtils.randomNamespace();
         String anotherNamespaceDeletedKey = "test-another-kv";
@@ -179,7 +179,7 @@ public abstract class AbstractKvMetadataRepositoryTest {
         assertThat(found.getTotal()).isEqualTo(4);
         List<PersistedKvMetadata> versionsForKey = found.stream().filter(kv -> kv.getName().equals(key)).toList();
         assertThat(versionsForKey.size()).isEqualTo(2);
-        assertThat(versionsForKey.stream().map(PersistedKvMetadata::getVersion)).containsExactlyInAnyOrder(1, 2);
+        assertThat(versionsForKey.stream().map(PersistedKvMetadata::getRevision)).containsExactlyInAnyOrder(1, 2);
         assertThat(versionsForKey.stream().map(PersistedKvMetadata::getDescription)).containsExactlyInAnyOrder(originalDescription, changedDescription);
 
         // We get all versions but latest if we put FetchVersion.OLD
@@ -187,7 +187,7 @@ public abstract class AbstractKvMetadataRepositoryTest {
         assertThat(found).hasSize(1);
         assertThat(found.getTotal()).isEqualTo(1);
         assertThat(found.getFirst().getDescription()).isEqualTo(originalDescription);
-        assertThat(found.getFirst().getVersion()).isEqualTo(1);
+        assertThat(found.getFirst().getRevision()).isEqualTo(1);
         assertThat(found.getFirst().isLast()).isFalse();
 
         found = kvMetadataRepositoryInterface.find(
@@ -243,11 +243,11 @@ public abstract class AbstractKvMetadataRepositoryTest {
             .description("Some description")
             .build();
 
-        assertThat(metadata.getVersion()).isNull();
-        assertThat(kvMetadataRepositoryInterface.save(metadata).getVersion()).isEqualTo(1);
+        assertThat(metadata.getRevision()).isNull();
+        assertThat(kvMetadataRepositoryInterface.save(metadata).getRevision()).isEqualTo(1);
         String changedDescription = "Changed description";
         metadata = kvMetadataRepositoryInterface.save(metadata.toBuilder().description(changedDescription).build());
-        assertThat(metadata.getVersion()).isEqualTo(2);
+        assertThat(metadata.getRevision()).isEqualTo(2);
 
         Integer purgedAmount = kvMetadataRepositoryInterface.purge(
             List.of(
@@ -287,7 +287,7 @@ public abstract class AbstractKvMetadataRepositoryTest {
             .namespace(namespace)
             .name(key)
             .description("Test kv description")
-            .version(1)
+            .revision(1)
             .expirationDate(Instant.now().plus(5, ChronoUnit.MINUTES))
             .build();
     }

--- a/core/src/test/java/io/kestra/core/repositories/AbstractNamespaceFileMetadataRepositoryTest.java
+++ b/core/src/test/java/io/kestra/core/repositories/AbstractNamespaceFileMetadataRepositoryTest.java
@@ -38,13 +38,13 @@ public abstract class AbstractNamespaceFileMetadataRepositoryTest {
             .tenantId(tenantId)
             .namespace(namespace)
             .path(path)
-            .version(1)
+            .revision(1)
             .size(1L)
             .build();
 
         namespaceFileMetadataRepositoryInterface.save(metadata);
 
-        namespaceFileMetadataRepositoryInterface.save(metadata.toBuilder().version(2).build());
+        namespaceFileMetadataRepositoryInterface.save(metadata.toBuilder().revision(2).build());
 
         Optional<NamespaceFileMetadata> found = namespaceFileMetadataRepositoryInterface.findByPath(
             tenantId,
@@ -54,7 +54,7 @@ public abstract class AbstractNamespaceFileMetadataRepositoryTest {
 
         assertThat(found).isPresent();
         assertThat(found.get().getPath()).isEqualTo(path);
-        assertThat(found.get().getVersion()).isEqualTo(2);
+        assertThat(found.get().getRevision()).isEqualTo(2);
         assertThat(found.get().isLast()).isTrue();
         assertThat(found.get().isDeleted()).isFalse();
     }
@@ -68,7 +68,7 @@ public abstract class AbstractNamespaceFileMetadataRepositoryTest {
             .tenantId(tenantId)
             .namespace(namespace)
             .path(path)
-            .version(1)
+            .revision(1)
             .size(1L)
             .build();
 
@@ -97,7 +97,7 @@ public abstract class AbstractNamespaceFileMetadataRepositoryTest {
         assertThat(found).isPresent();
         assertThat(found.get().getPath()).isEqualTo(path);
         // Soft delete
-        assertThat(found.get().getVersion()).isEqualTo(1);
+        assertThat(found.get().getRevision()).isEqualTo(1);
         assertThat(found.get().isLast()).isTrue();
         assertThat(found.get().isDeleted()).isTrue();
         assertThat(found.get().getUpdated()).isAfter(beforeDeleteUpdateDate);
@@ -115,11 +115,11 @@ public abstract class AbstractNamespaceFileMetadataRepositoryTest {
             .size(1L)
             .build();
 
-        assertThat(metadata.getVersion()).isNull();
-        assertThat(namespaceFileMetadataRepositoryInterface.save(metadata).getVersion()).isEqualTo(1);
+        assertThat(metadata.getRevision()).isNull();
+        assertThat(namespaceFileMetadataRepositoryInterface.save(metadata).getRevision()).isEqualTo(1);
         // Resaving will increment version
         metadata = namespaceFileMetadataRepositoryInterface.save(metadata);
-        assertThat(metadata.getVersion()).isEqualTo(2);
+        assertThat(metadata.getRevision()).isEqualTo(2);
 
         assertThat(namespaceFileMetadataRepositoryInterface.find(Pageable.from(1, 1), tenantId, Collections.emptyList(), false).getTotal()).isEqualTo(1);
         assertThat(namespaceFileMetadataRepositoryInterface.find(Pageable.from(1, 1), tenantId, Collections.emptyList(), false, FetchVersion.ALL).getTotal()).isEqualTo(2);
@@ -134,12 +134,12 @@ public abstract class AbstractNamespaceFileMetadataRepositoryTest {
 
         found = namespaceFileMetadataRepositoryInterface.find(Pageable.from(1, 1), tenantId, Collections.emptyList(), false, FetchVersion.ALL);
         assertThat(found.getTotal()).isEqualTo(1);
-        assertThat(found.getFirst().getVersion()).isEqualTo(1);
+        assertThat(found.getFirst().getRevision()).isEqualTo(1);
         assertThat(found.getFirst().isDeleted()).isEqualTo(false);
 
         found = namespaceFileMetadataRepositoryInterface.find(Pageable.from(1, 1), tenantId, Collections.emptyList(), true);
         assertThat(found.getTotal()).isEqualTo(1);
-        assertThat(found.getFirst().getVersion()).isEqualTo(2);
+        assertThat(found.getFirst().getRevision()).isEqualTo(2);
         assertThat(found.getFirst().isDeleted()).isEqualTo(true);
 
         found = namespaceFileMetadataRepositoryInterface.find(Pageable.from(1, 1), tenantId, Collections.emptyList(), true, FetchVersion.ALL);
@@ -170,7 +170,7 @@ public abstract class AbstractNamespaceFileMetadataRepositoryTest {
                 namespaceFileMetadataNamespace.getTenantId(),
                 List.of(namespaceFileMetadataNamespace),
                 List.of(QueryFilter.builder().field(QueryFilter.Field.NAMESPACE).operation(QueryFilter.Op.EQUALS).value(namespaceFileMetadataNamespace.getNamespace()).build()),
-                List.of(namespaceFileMetadataNamespace.toBuilder().version(1).last(true).build()),
+                List.of(namespaceFileMetadataNamespace.toBuilder().revision(1).last(true).build()),
                 FetchVersion.ALL
             ),
             Arguments.of(
@@ -186,7 +186,7 @@ public abstract class AbstractNamespaceFileMetadataRepositoryTest {
                 namespaceFileMetadataQuery.getTenantId(),
                 List.of(namespaceFileMetadataQuery),
                 List.of(QueryFilter.builder().field(QueryFilter.Field.QUERY).operation(QueryFilter.Op.EQUALS).value("tes").build()),
-                List.of(namespaceFileMetadataQuery.toBuilder().version(1).last(true).build()),
+                List.of(namespaceFileMetadataQuery.toBuilder().revision(1).last(true).build()),
                 FetchVersion.ALL
             ),
             // endregion
@@ -195,7 +195,7 @@ public abstract class AbstractNamespaceFileMetadataRepositoryTest {
                 namespaceFileMetadataPath.getTenantId(),
                 List.of(namespaceFileMetadataPath),
                 List.of(QueryFilter.builder().field(QueryFilter.Field.PATH).operation(QueryFilter.Op.EQUALS).value("/test/ns/file").build()),
-                List.of(namespaceFileMetadataPath.toBuilder().version(1).last(true).build()),
+                List.of(namespaceFileMetadataPath.toBuilder().revision(1).last(true).build()),
                 FetchVersion.ALL
             ),
             Arguments.of(
@@ -211,7 +211,7 @@ public abstract class AbstractNamespaceFileMetadataRepositoryTest {
                 namespaceFileMetadataParentPath.getTenantId(),
                 List.of(namespaceFileMetadataParentPath),
                 List.of(QueryFilter.builder().field(QueryFilter.Field.PARENT_PATH).operation(QueryFilter.Op.EQUALS).value("/test/ns/").build()),
-                List.of(namespaceFileMetadataParentPath.toBuilder().version(1).last(true).build()),
+                List.of(namespaceFileMetadataParentPath.toBuilder().revision(1).last(true).build()),
                 FetchVersion.ALL
             ),
             Arguments.of(
@@ -227,21 +227,21 @@ public abstract class AbstractNamespaceFileMetadataRepositoryTest {
                 namespaceFileMetadataVersion.getTenantId(),
                 List.of(namespaceFileMetadataVersion, namespaceFileMetadataVersion),
                 List.of(QueryFilter.builder().field(QueryFilter.Field.VERSION).operation(QueryFilter.Op.EQUALS).value(1).build()),
-                List.of(namespaceFileMetadataVersion.toBuilder().version(1).last(false).build()),
+                List.of(namespaceFileMetadataVersion.toBuilder().revision(1).last(false).build()),
                 FetchVersion.ALL
             ),
             Arguments.of(
                 namespaceFileMetadataVersion2.getTenantId(),
                 List.of(namespaceFileMetadataVersion2, namespaceFileMetadataVersion2),
                 List.of(QueryFilter.builder().field(QueryFilter.Field.VERSION).operation(QueryFilter.Op.EQUALS).value(2).build()),
-                List.of(namespaceFileMetadataVersion2.toBuilder().version(2).last(true).build()),
+                List.of(namespaceFileMetadataVersion2.toBuilder().revision(2).last(true).build()),
                 FetchVersion.ALL
             ),
             Arguments.of(
                 namespaceFileMetadataVersion3.getTenantId(),
                 List.of(namespaceFileMetadataVersion3, namespaceFileMetadataVersion3),
                 Collections.emptyList(),
-                List.of(namespaceFileMetadataVersion3.toBuilder().version(2).last(true).build()),
+                List.of(namespaceFileMetadataVersion3.toBuilder().revision(2).last(true).build()),
                 // FetchVersion null should default to latest
                 null
             ),
@@ -249,14 +249,14 @@ public abstract class AbstractNamespaceFileMetadataRepositoryTest {
                 namespaceFileMetadataVersion4.getTenantId(),
                 List.of(namespaceFileMetadataVersion4, namespaceFileMetadataVersion4),
                 Collections.emptyList(),
-                List.of(namespaceFileMetadataVersion4.toBuilder().version(1).last(false).build()),
+                List.of(namespaceFileMetadataVersion4.toBuilder().revision(1).last(false).build()),
                 FetchVersion.OLD
             ),
             Arguments.of(
                 namespaceFileMetadataNotVersion.getTenantId(),
                 List.of(namespaceFileMetadataNotVersion, namespaceFileMetadataNotVersion),
                 List.of(QueryFilter.builder().field(QueryFilter.Field.VERSION).operation(QueryFilter.Op.NOT_EQUALS).value(2).build()),
-                List.of(namespaceFileMetadataNotVersion.toBuilder().version(1).last(false).build()),
+                List.of(namespaceFileMetadataNotVersion.toBuilder().revision(1).last(false).build()),
                 FetchVersion.ALL
             ),
             // endregion
@@ -265,7 +265,7 @@ public abstract class AbstractNamespaceFileMetadataRepositoryTest {
                 namespaceFileMetadataUpdated.getTenantId(),
                 List.of(namespaceFileMetadataUpdated),
                 List.of(QueryFilter.builder().field(QueryFilter.Field.UPDATED).operation(QueryFilter.Op.GREATER_THAN_OR_EQUAL_TO).value(Instant.now()).build()),
-                List.of(namespaceFileMetadataUpdated.toBuilder().version(1).last(true).build()),
+                List.of(namespaceFileMetadataUpdated.toBuilder().revision(1).last(true).build()),
                 FetchVersion.ALL
             ),
             Arguments.of(
@@ -350,10 +350,10 @@ public abstract class AbstractNamespaceFileMetadataRepositoryTest {
             .size(1L)
             .build();
 
-        assertThat(metadata.getVersion()).isNull();
-        assertThat(namespaceFileMetadataRepositoryInterface.save(metadata).getVersion()).isEqualTo(1);
+        assertThat(metadata.getRevision()).isNull();
+        assertThat(namespaceFileMetadataRepositoryInterface.save(metadata).getRevision()).isEqualTo(1);
         metadata = namespaceFileMetadataRepositoryInterface.save(metadata);
-        assertThat(metadata.getVersion()).isEqualTo(2);
+        assertThat(metadata.getRevision()).isEqualTo(2);
 
         Integer purgedAmount = namespaceFileMetadataRepositoryInterface.purge(
             List.of(

--- a/core/src/test/java/io/kestra/core/runners/pebble/PebbleExpressionServiceTest.java
+++ b/core/src/test/java/io/kestra/core/runners/pebble/PebbleExpressionServiceTest.java
@@ -110,6 +110,6 @@ class PebbleExpressionServiceTest {
         assertThat(findFunction("render").arguments()).extracting(PebbleFunction.Argument::name)
             .containsExactly("toRender", "recursive");
         assertThat(findFunction("read").arguments()).extracting(PebbleFunction.Argument::name)
-            .containsExactly("path", "namespace", "version");
+            .containsExactly("path", "namespace", "revision");
     }
 }

--- a/core/src/test/java/io/kestra/core/runners/pebble/functions/FileURIFunctionTest.java
+++ b/core/src/test/java/io/kestra/core/runners/pebble/functions/FileURIFunctionTest.java
@@ -98,10 +98,10 @@ class FileURIFunctionTest {
 
         Map<String, Object> variables = getVariables(namespace);
 
-        String render = variableRenderer.render("{{ fileURI('" + filePath + "', version=1) }}", variables);
+        String render = variableRenderer.render("{{ fileURI('" + filePath + "', revision=1) }}", variables);
         assertThat(render).isEqualTo("kestra:///" + namespace.replace(".", "/") + "/_files/" + filePath);
 
-        String readContent = variableRenderer.render("{{ read('" + filePath + "', version=1) }}", variables);
+        String readContent = variableRenderer.render("{{ read('" + filePath + "', revision=1) }}", variables);
         assertThat(readContent).isEqualTo("Version 1");
     }
 

--- a/core/src/test/java/io/kestra/core/runners/pebble/functions/ReadFileFunctionTest.java
+++ b/core/src/test/java/io/kestra/core/runners/pebble/functions/ReadFileFunctionTest.java
@@ -74,12 +74,25 @@ class ReadFileFunctionTest {
         assertThat(render).isEqualTo("Hello from version 3");
 
         IllegalVariableEvaluationException illegalVariableEvaluationException = assertThrows(
-            IllegalVariableEvaluationException.class, () -> variableRenderer.render("{{ render(read('" + nsFile.getPath() + "', version=2)) }}", getVariables(namespace))
+            IllegalVariableEvaluationException.class, () -> variableRenderer.render("{{ render(read('" + nsFile.getPath() + "', revision=2)) }}", getVariables(namespace))
         );
         assertThat(illegalVariableEvaluationException.getCause().getCause()).isInstanceOf(FileNotFoundException.class);
 
-        render = variableRenderer.render("{{ render(read('" + nsFile.getPath() + "', version=1)) }}", getVariables(namespace));
+        render = variableRenderer.render("{{ render(read('" + nsFile.getPath() + "', revision=1)) }}", getVariables(namespace));
         assertThat(render).isEqualTo("Hello from version 1");
+    }
+
+    @Test
+    void readNamespaceFileRejectsRemovedVersionArg() throws IOException, URISyntaxException {
+        String namespace = TestsUtils.randomNamespace();
+        URI nsFile = upsertNsFile(false, namespace, "Hello from version 1");
+
+        // The legacy 'version' argument was renamed to 'revision' in 2.0 - it must no longer be accepted
+        IllegalVariableEvaluationException exception = assertThrows(
+            IllegalVariableEvaluationException.class, () -> variableRenderer.render("{{ render(read('" + nsFile.getPath() + "', version=1)) }}", getVariables(namespace))
+        );
+        assertThat(exception.getCause()).isInstanceOf(PebbleException.class);
+        assertThat(exception.getCause().getMessage()).contains("The following named argument does not exist: version");
     }
 
     @Test

--- a/core/src/test/java/io/kestra/core/services/KVStoreServiceTest.java
+++ b/core/src/test/java/io/kestra/core/services/KVStoreServiceTest.java
@@ -74,7 +74,7 @@ class KVStoreServiceTest {
 
         List<KVEntry> kvEntries = storeService.listAll(MAIN_TENANT, kvStore.namespace());
         assertThat(kvEntries).hasSize(1);
-        assertThat(kvEntries.getFirst().version()).isEqualTo(2);
+        assertThat(kvEntries.getFirst().revision()).isEqualTo(2);
     }
 
     @MockBean(NamespaceService.class)

--- a/core/src/test/java/io/kestra/core/storages/kv/KVEntryRevisionJsonKeyTest.java
+++ b/core/src/test/java/io/kestra/core/storages/kv/KVEntryRevisionJsonKeyTest.java
@@ -1,0 +1,35 @@
+package io.kestra.core.storages.kv;
+
+import java.time.Instant;
+
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import io.kestra.core.serializers.JacksonMapper;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Guards the serialized JSON key for the {@code revision} component of {@link KVEntry}, returned by
+ * the KV list REST endpoint (GET /kv). Unlike the persisted metadata classes, {@link KVEntry} is a
+ * pure REST DTO (never stored), so the 2.0 rename moves its key to {@code "revision"} with no
+ * migration cost, matching the sibling GET /kv/{key} endpoint. This was a breaking change: the
+ * legacy {@code "version"} key is no longer emitted.
+ */
+class KVEntryRevisionJsonKeyTest {
+    private static final ObjectMapper MAPPER = JacksonMapper.ofJson();
+
+    @Test
+    void serializesRevisionJsonKey() throws JsonProcessingException {
+        KVEntry entry = new KVEntry("my.ns", "my-key", 7, "desc", Instant.now(), Instant.now(), null);
+
+        JsonNode node = MAPPER.readTree(MAPPER.writeValueAsString(entry));
+
+        assertThat(node.has("revision")).isTrue();
+        assertThat(node.get("revision").asInt()).isEqualTo(7);
+        assertThat(node.has("version")).isFalse();
+    }
+}

--- a/core/src/test/java/io/kestra/plugin/core/namespace/PurgeFilesTest.java
+++ b/core/src/test/java/io/kestra/plugin/core/namespace/PurgeFilesTest.java
@@ -180,7 +180,7 @@ public class PurgeFilesTest {
         assertThat(namespaceFiles.size()).isEqualTo(4);
         List<NamespaceFile> files = namespaceFiles.stream().filter(nsFile -> nsFile.path().endsWith("file.txt")).toList();
         assertThat(files.size()).isEqualTo(1);
-        assertThat(files.getFirst().version()).isEqualTo(2);
+        assertThat(files.getFirst().revision()).isEqualTo(2);
     }
 
     @Test
@@ -210,7 +210,7 @@ public class PurgeFilesTest {
         assertThat(namespaceFiles.size()).isEqualTo(5);
         List<NamespaceFile> files = namespaceFiles.stream().filter(nsFile -> nsFile.path().endsWith("file.txt")).toList();
         assertThat(files.size()).isEqualTo(2);
-        assertThat(files.stream().map(NamespaceFile::version)).containsExactlyInAnyOrder(2, 3);
+        assertThat(files.stream().map(NamespaceFile::revision)).containsExactlyInAnyOrder(2, 3);
     }
 
     @Test

--- a/jdbc/src/main/java/io/kestra/jdbc/repository/AbstractJdbcKvMetadataRepository.java
+++ b/jdbc/src/main/java/io/kestra/jdbc/repository/AbstractJdbcKvMetadataRepository.java
@@ -119,7 +119,7 @@ public abstract class AbstractJdbcKvMetadataRepository extends AbstractJdbcCrudR
                         .where(this.defaultFilter(e.getKey().tenantId(), true))
                         .and(field("namespace").eq(e.getKey().namespace()))
                         .and(field("last").in(true, false));
-                    if (e.getValue().getFirst().getVersion() == null) {
+                    if (e.getValue().getFirst().getRevision() == null) {
                         deleteCondition = deleteCondition.and(field("name").in(persistedKvsMetadata.stream().map(PersistedKvMetadata::getName).toList()));
                     } else {
                         deleteCondition = deleteCondition.and(
@@ -128,7 +128,7 @@ public abstract class AbstractJdbcKvMetadataRepository extends AbstractJdbcCrudR
                                     kvMetadata -> DSL.and(
                                         field("name").eq(kvMetadata.getName()),
                                         field("version").eq(
-                                            kvMetadata.getVersion()
+                                            kvMetadata.getRevision()
                                         )
                                     )
                                 ).toList()
@@ -157,11 +157,11 @@ public abstract class AbstractJdbcKvMetadataRepository extends AbstractJdbcCrudR
 
     private PersistedKvMetadata saveKvMetadata(DSLContext context, PersistedKvMetadata kvMetadata) {
         Optional<PersistedKvMetadata> maybePrevious = this.findByName(kvMetadata.getTenantId(), kvMetadata.getNamespace(), kvMetadata.getName());
-        PersistedKvMetadata kvMetadataToPersist = kvMetadata.asLast().toBuilder().version(maybePrevious.map(PersistedKvMetadata::getVersion).orElse(0) + 1).build();
+        PersistedKvMetadata kvMetadataToPersist = kvMetadata.asLast().toBuilder().revision(maybePrevious.map(PersistedKvMetadata::getRevision).orElse(0) + 1).build();
         if (maybePrevious.isPresent()) {
             PersistedKvMetadata previous = maybePrevious.get();
             if (kvMetadata.isDeleted()) {
-                // If we are deleting, we just mark the previous as deleted without changing version and we return directly
+                // If we are deleting, we just mark the previous as deleted without changing revision and we return directly
                 kvMetadataToPersist = previous.toBuilder().deleted(true).updated(Instant.now()).build();
             } else {
                 // We mark the previous as not last

--- a/jdbc/src/main/java/io/kestra/jdbc/repository/AbstractJdbcNamespaceFileMetadataRepository.java
+++ b/jdbc/src/main/java/io/kestra/jdbc/repository/AbstractJdbcNamespaceFileMetadataRepository.java
@@ -144,7 +144,7 @@ public abstract class AbstractJdbcNamespaceFileMetadataRepository extends Abstra
                         .where(this.defaultFilter(e.getKey().tenantId(), true))
                         .and(field("namespace").eq(e.getKey().namespace()))
                         .and(field("last").in(true, false));
-                    if (e.getValue().getFirst().getVersion() == null) {
+                    if (e.getValue().getFirst().getRevision() == null) {
                         deleteCondition = deleteCondition.and(
                             field("path").in(
                                 namespaceFilesMetadata.stream()
@@ -159,7 +159,7 @@ public abstract class AbstractJdbcNamespaceFileMetadataRepository extends Abstra
                                     namespaceFileMetadata -> DSL.and(
                                         pathCondition(namespaceFileMetadata.getPath()),
                                         field("version").eq(
-                                            namespaceFileMetadata.getVersion()
+                                            namespaceFileMetadata.getRevision()
                                         )
                                     )
                                 ).toList()
@@ -187,13 +187,13 @@ public abstract class AbstractJdbcNamespaceFileMetadataRepository extends Abstra
                 DSLContext context = DSL.using(configuration);
 
                 Optional<NamespaceFileMetadata> maybePrevious = this.findByPath(namespaceFileMetadata.getTenantId(), namespaceFileMetadata.getNamespace(), namespaceFileMetadata.getPath());
-                NamespaceFileMetadata nsFileMetadataToPersist = namespaceFileMetadata.asLast().toBuilder().deleted(false).version(maybePrevious.map(previous ->
+                NamespaceFileMetadata nsFileMetadataToPersist = namespaceFileMetadata.asLast().toBuilder().deleted(false).revision(maybePrevious.map(previous ->
                 {
                     if (previous.isDirectory()) {
-                        // Directories stay at version 1
+                        // Directories stay at revision 1
                         return 1;
                     }
-                    return previous.getVersion() + 1;
+                    return previous.getRevision() + 1;
                 }).orElse(1)).created(maybePrevious.map(NamespaceFileMetadata::getCreated).orElse(Instant.now())).build();
 
                 if (maybePrevious.isPresent()) {

--- a/jdbc/src/test/java/io/kestra/jdbc/VersionJsonKeyFreezeTest.java
+++ b/jdbc/src/test/java/io/kestra/jdbc/VersionJsonKeyFreezeTest.java
@@ -1,0 +1,69 @@
+package io.kestra.jdbc;
+
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+
+import io.kestra.core.models.kv.PersistedKvMetadata;
+import io.kestra.core.models.namespaces.files.NamespaceFileMetadata;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Guards the persisted JSON key for the (renamed) {@code revision} field of metadata stored in the
+ * JDBC JSONB {@code value} column. The Java field is named {@code revision}, but the serialized key
+ * MUST stay {@code "version"}: the DDL generated columns read {@code CAST(value ->> 'version' ...)}
+ * and renaming the persisted key would force a JSONB backfill across H2/Postgres/MySQL on every
+ * existing install. Uses {@link JdbcMapper#of()} — the exact mapper that writes/reads the column.
+ */
+class VersionJsonKeyFreezeTest {
+    @Test
+    void persistedKvMetadataKeepsVersionJsonKey() throws JsonProcessingException {
+        PersistedKvMetadata metadata = PersistedKvMetadata.builder()
+            .namespace("my.ns")
+            .name("my-key")
+            .revision(7)
+            .build();
+
+        JsonNode node = JdbcMapper.of().readTree(JdbcMapper.of().writeValueAsString(metadata));
+
+        assertThat(node.has("version")).isTrue();
+        assertThat(node.get("version").asInt()).isEqualTo(7);
+        assertThat(node.has("revision")).isFalse();
+    }
+
+    @Test
+    void persistedKvMetadataReadsLegacyVersionJsonKey() throws JsonProcessingException {
+        String legacy = "{\"namespace\":\"my.ns\",\"name\":\"my-key\",\"version\":7,\"last\":true,\"deleted\":false}";
+
+        PersistedKvMetadata metadata = JdbcMapper.of().readValue(legacy, PersistedKvMetadata.class);
+
+        assertThat(metadata.getRevision()).isEqualTo(7);
+    }
+
+    @Test
+    void namespaceFileMetadataKeepsVersionJsonKey() throws JsonProcessingException {
+        NamespaceFileMetadata metadata = NamespaceFileMetadata.builder()
+            .namespace("my.ns")
+            .path("/sub/file.txt")
+            .revision(7)
+            .size(12L)
+            .build();
+
+        JsonNode node = JdbcMapper.of().readTree(JdbcMapper.of().writeValueAsString(metadata));
+
+        assertThat(node.has("version")).isTrue();
+        assertThat(node.get("version").asInt()).isEqualTo(7);
+        assertThat(node.has("revision")).isFalse();
+    }
+
+    @Test
+    void namespaceFileMetadataReadsLegacyVersionJsonKey() throws JsonProcessingException {
+        String legacy = "{\"namespace\":\"my.ns\",\"path\":\"/sub/file.txt\",\"version\":7,\"size\":12,\"last\":true,\"deleted\":false}";
+
+        NamespaceFileMetadata metadata = JdbcMapper.of().readValue(legacy, NamespaceFileMetadata.class);
+
+        assertThat(metadata.getRevision()).isEqualTo(7);
+    }
+}

--- a/webserver/src/main/java/io/kestra/webserver/controllers/api/KVController.java
+++ b/webserver/src/main/java/io/kestra/webserver/controllers/api/KVController.java
@@ -115,7 +115,7 @@ public class KVController {
         // Should never throw as the above verifies the KV entry existence
         KVEntry kvEntry = nsKvStore.get(key).orElseThrow();
 
-        return new KvDetail(KVType.from(value), value, kvEntry.version(), kvEntry.updateDate());
+        return new KvDetail(KVType.from(value), value, kvEntry.revision(), kvEntry.updateDate());
     }
 
     @ExecuteOn(TaskExecutors.IO)

--- a/webserver/src/main/java/io/kestra/webserver/controllers/api/NamespaceFileController.java
+++ b/webserver/src/main/java/io/kestra/webserver/controllers/api/NamespaceFileController.java
@@ -141,7 +141,7 @@ public class NamespaceFileController {
             throw new FileNotFoundException("File not found: " + encodedPath.getPath());
         }
 
-        return namespaceFileMetadata.map(metadata -> new NamespaceFileRevision(metadata.getVersion()));
+        return namespaceFileMetadata.map(metadata -> new NamespaceFileRevision(metadata.getRevision()));
     }
 
     @ExecuteOn(TaskExecutors.IO)

--- a/worker/src/test/java/io/kestra/worker/stores/GrpcWorkerKVMetadataStateStoreTest.java
+++ b/worker/src/test/java/io/kestra/worker/stores/GrpcWorkerKVMetadataStateStoreTest.java
@@ -42,7 +42,7 @@ class GrpcWorkerKVMetadataStateStoreTest extends AbstractGrpcMetaStoreTest {
         String namespace = TestsUtils.randomNamespace();
         kvStateStore.save(
             PersistedKvMetadata.builder()
-                .tenantId(tenantId).namespace(namespace).name("myKey").version(1)
+                .tenantId(tenantId).namespace(namespace).name("myKey").revision(1)
                 .created(Instant.now()).build()
         );
 
@@ -54,7 +54,7 @@ class GrpcWorkerKVMetadataStateStoreTest extends AbstractGrpcMetaStoreTest {
         assertThat(result.get().getTenantId()).isEqualTo(tenantId);
         assertThat(result.get().getNamespace()).isEqualTo(namespace);
         assertThat(result.get().getName()).isEqualTo("myKey");
-        assertThat(result.get().getVersion()).isEqualTo(1);
+        assertThat(result.get().getRevision()).isEqualTo(1);
     }
 
     @Test
@@ -77,12 +77,12 @@ class GrpcWorkerKVMetadataStateStoreTest extends AbstractGrpcMetaStoreTest {
         String namespace = TestsUtils.randomNamespace();
         kvStateStore.save(
             PersistedKvMetadata.builder()
-                .tenantId(tenantId).namespace(namespace).name("key1").version(1)
+                .tenantId(tenantId).namespace(namespace).name("key1").revision(1)
                 .created(Instant.now()).build()
         );
         kvStateStore.save(
             PersistedKvMetadata.builder()
-                .tenantId(tenantId).namespace(namespace).name("key2").version(1)
+                .tenantId(tenantId).namespace(namespace).name("key2").revision(1)
                 .created(Instant.now()).build()
         );
 
@@ -114,7 +114,7 @@ class GrpcWorkerKVMetadataStateStoreTest extends AbstractGrpcMetaStoreTest {
         String namespace = TestsUtils.randomNamespace();
         kvStateStore.save(
             PersistedKvMetadata.builder()
-                .tenantId(tenantId).namespace(namespace).name("key").version(1)
+                .tenantId(tenantId).namespace(namespace).name("key").revision(1)
                 .created(Instant.now()).build()
         );
 
@@ -138,7 +138,7 @@ class GrpcWorkerKVMetadataStateStoreTest extends AbstractGrpcMetaStoreTest {
         String tenantId = TestsUtils.randomTenant();
         String namespace = TestsUtils.randomNamespace();
         PersistedKvMetadata input = PersistedKvMetadata.builder()
-            .tenantId(tenantId).namespace(namespace).name("saved-key").version(1)
+            .tenantId(tenantId).namespace(namespace).name("saved-key").revision(1)
             .created(Instant.now()).build();
 
         // When
@@ -157,7 +157,7 @@ class GrpcWorkerKVMetadataStateStoreTest extends AbstractGrpcMetaStoreTest {
         String namespace = TestsUtils.randomNamespace();
         PersistedKvMetadata saved = kvStateStore.save(
             PersistedKvMetadata.builder()
-                .tenantId(tenantId).namespace(namespace).name("to-delete").version(1)
+                .tenantId(tenantId).namespace(namespace).name("to-delete").revision(1)
                 .created(Instant.now()).build()
         );
 
@@ -177,7 +177,7 @@ class GrpcWorkerKVMetadataStateStoreTest extends AbstractGrpcMetaStoreTest {
         String namespace = TestsUtils.randomNamespace();
         Instant expiration = Instant.parse("2026-12-31T23:59:59Z");
         PersistedKvMetadata input = PersistedKvMetadata.builder()
-            .tenantId(tenantId).namespace(namespace).name("expiring").version(1)
+            .tenantId(tenantId).namespace(namespace).name("expiring").revision(1)
             .expirationDate(expiration).created(Instant.now()).build();
 
         // When

--- a/worker/src/test/java/io/kestra/worker/stores/GrpcWorkerNamespaceFileMetadataStateStoreTest.java
+++ b/worker/src/test/java/io/kestra/worker/stores/GrpcWorkerNamespaceFileMetadataStateStoreTest.java
@@ -53,7 +53,7 @@ class GrpcWorkerNamespaceFileMetadataStateStoreTest extends AbstractGrpcMetaStor
         assertThat(result.get().getNamespace()).isEqualTo(namespace);
         assertThat(result.get().getPath()).isEqualTo("/scripts/main.py");
         assertThat(result.get().getSize()).isEqualTo(42L);
-        assertThat(result.get().getVersion()).isEqualTo(1);
+        assertThat(result.get().getRevision()).isEqualTo(1);
     }
 
     @Test
@@ -89,7 +89,7 @@ class GrpcWorkerNamespaceFileMetadataStateStoreTest extends AbstractGrpcMetaStor
 
         // Then
         assertThat(result).isPresent();
-        assertThat(result.get().getVersion()).isEqualTo(1);
+        assertThat(result.get().getRevision()).isEqualTo(1);
     }
 
     @Test
@@ -273,7 +273,7 @@ class GrpcWorkerNamespaceFileMetadataStateStoreTest extends AbstractGrpcMetaStor
 
         // Then
         assertThat(result).hasSize(2);
-        assertThat(result).extracting(NamespaceFileMetadata::getVersion).containsExactlyInAnyOrder(1, 2);
+        assertThat(result).extracting(NamespaceFileMetadata::getRevision).containsExactlyInAnyOrder(1, 2);
     }
 
     @Test
@@ -316,7 +316,7 @@ class GrpcWorkerNamespaceFileMetadataStateStoreTest extends AbstractGrpcMetaStor
         assertThat(result.getNamespace()).isEqualTo(namespace);
         assertThat(result.getPath()).isEqualTo("/saved.py");
         assertThat(result.getSize()).isEqualTo(42L);
-        assertThat(result.getVersion()).isEqualTo(1);
+        assertThat(result.getRevision()).isEqualTo(1);
     }
 
     @Test


### PR DESCRIPTION
Renames the user-facing "version" concept to "revision" for Namespace Files and KV.

- Pebble `read()` / `fileURI()` named argument `version` → `revision`
- Java model fields/accessors renamed to `revision` (PersistedKvMetadata, NamespaceFileMetadata, NamespaceFile, KVEntry, InternalKVStore, …)
- `GET /kv` list response now emits `revision` per entry, matching the existing `GET /kv/{key}` endpoint
- Persisted JSONB keys for PersistedKvMetadata and NamespaceFileMetadata stay frozen at `version` via `@JsonProperty("version")` — only Java names change, avoiding a JSONB backfill across H2/Postgres/MySQL + an Elasticsearch reindex. Guarded by `VersionJsonKeyFreezeTest` (writes `version`, never emits `revision`, still reads legacy `version`).
- Elasticsearch / JDBC string field references, DDL generated columns, and the `.vN` storage blob suffix intentionally remain `version`
- Out of scope (unrelated concept, deliberately left `version`): `FetchVersion`, `QueryFilter.Field.VERSION`, state-store `findAllVersionsByPaths`, plugin/server `getVersion()`

BREAKING CHANGE: the `version` named argument of the `read()` / `fileURI()` Pebble functions is removed with no alias/fallback — use `revision` instead.
BREAKING CHANGE: `GET /kv` now emits `revision` instead of `version` in each list entry.
