### PR TITLE
fix(scheduler): prevent flow-listener from resurrecting a terminated trigger's execution lock

### DIFF
--- a/scheduler/src/main/java/io/kestra/scheduler/AbstractScheduler.java
+++ b/scheduler/src/main/java/io/kestra/scheduler/AbstractScheduler.java
@@ -402,21 +402,15 @@ public abstract class AbstractScheduler implements Scheduler {
                         RecoverMissedSchedules recoverMissedSchedules = Optional.ofNullable(schedule.getRecoverMissedSchedules())
                             .orElseGet(() -> schedule.defaultRecoverMissedSchedules(runContext));
                         try {
-                            Trigger lastUpdate = trigger.get();
-                            if (recoverMissedSchedules == RecoverMissedSchedules.LAST) {
-                                ZonedDateTime previousDate = schedule.previousEvaluationDate(conditionContext);
-                                if (previousDate.isAfter(trigger.get().getDate())) {
-                                    lastUpdate = trigger.get().toBuilder().nextExecutionDate(previousDate).build();
-
-                                    this.triggerState.update(lastUpdate);
-                                }
-                            } else {
-                                ZonedDateTime nextEvaluationDate = schedule.nextEvaluationDate();
-                                if (recoverMissedSchedules == RecoverMissedSchedules.NONE && !Objects.equals(trigger.get().getNextExecutionDate(), nextEvaluationDate)) {
-                                    lastUpdate = trigger.get().toBuilder().nextExecutionDate(nextEvaluationDate).build();
-
-                                    this.triggerState.update(lastUpdate);
-                                }
+                            // Re-read the trigger from its store rather than trusting the snapshot taken at the start of this
+                            // method: the executor may have just unlocked it (cleared the executionId) concurrently, and acting
+                            // on a stale snapshot could resurrect that lock.
+                            Trigger current = this.triggerState.findLast(trigger.get()).orElse(trigger.get());
+                            Trigger lastUpdate = current;
+                            Optional<Trigger> toPersist = computeScheduleInitialization(schedule, current, recoverMissedSchedules, conditionContext);
+                            if (toPersist.isPresent()) {
+                                lastUpdate = toPersist.get();
+                                this.triggerState.update(lastUpdate);
                             }
                             // Used for schedulableNextDate
                             FlowWithWorkerTrigger flowWithWorkerTrigger = FlowWithWorkerTrigger.builder()
@@ -435,6 +429,34 @@ public abstract class AbstractScheduler implements Scheduler {
         }
 
         this.isReady = true;
+    }
+
+    /**
+     * Computes the Schedule trigger state to persist when the flow-change listener re-initializes a trigger.
+     * Returns an empty {@link Optional} when nothing should be written.
+     *
+     * @param current the current trigger state to base the decision on
+     */
+    @VisibleForTesting
+    static Optional<Trigger> computeScheduleInitialization(Schedulable schedule, Trigger current, RecoverMissedSchedules recoverMissedSchedules, ConditionContext conditionContext) throws Exception {
+        // Never rewrite a locked trigger (an execution is in flight). Its next execution date is owned by the
+        // execution-termination path; rewriting it here from a possibly stale snapshot could resurrect a stale
+        // executionId and lock the trigger forever.
+        if (current.getExecutionId() != null) {
+            return Optional.empty();
+        }
+        if (recoverMissedSchedules == RecoverMissedSchedules.LAST) {
+            ZonedDateTime previousDate = schedule.previousEvaluationDate(conditionContext);
+            if (previousDate.isAfter(current.getDate())) {
+                return Optional.of(current.toBuilder().nextExecutionDate(previousDate).build());
+            }
+        } else if (recoverMissedSchedules == RecoverMissedSchedules.NONE) {
+            ZonedDateTime nextEvaluationDate = schedule.nextEvaluationDate();
+            if (!Objects.equals(current.getNextExecutionDate(), nextEvaluationDate)) {
+                return Optional.of(current.toBuilder().nextExecutionDate(nextEvaluationDate).build());
+            }
+        }
+        return Optional.empty();
     }
 
     private void enterMaintenance() {

--- a/scheduler/src/test/java/io/kestra/scheduler/SchedulerInitializeTriggersTest.java
+++ b/scheduler/src/test/java/io/kestra/scheduler/SchedulerInitializeTriggersTest.java
@@ -1,0 +1,71 @@
+package io.kestra.scheduler;
+
+import java.time.ZonedDateTime;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+
+import io.kestra.core.models.triggers.RecoverMissedSchedules;
+import io.kestra.core.models.triggers.Trigger;
+import io.kestra.plugin.core.trigger.Schedule;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unit tests for the Schedule (re)initialization decision made by the flow-change listener
+ * (AbstractScheduler.initializedTriggers). The listener re-runs over every flow whenever any flow
+ * in the instance changes, so it must never resurrect a stale execution lock on a trigger whose
+ * execution already terminated.
+ */
+class SchedulerInitializeTriggersTest {
+
+    private static Schedule schedule() {
+        return Schedule.builder()
+            .id("schedule")
+            .type(Schedule.class.getName())
+            .cron("*/16 * * * *")
+            .recoverMissedSchedules(RecoverMissedSchedules.NONE)
+            .build();
+    }
+
+    private static Trigger.TriggerBuilder<?, ?> trigger() {
+        return Trigger.builder()
+            .namespace("io.kestra.unittest")
+            .flowId("flow")
+            .triggerId("schedule")
+            .date(ZonedDateTime.now().minusHours(1));
+    }
+
+    @Test
+    void shouldNotRewriteLockedTriggerOnInitialize() throws Exception {
+        Schedule schedule = schedule();
+        Trigger locked = trigger()
+            .executionId("running-execution-id")
+            // stale next date in the past so the NONE branch would otherwise recompute and rewrite
+            .nextExecutionDate(ZonedDateTime.now().minusMinutes(30))
+            .build();
+
+        Optional<Trigger> result = AbstractScheduler.computeScheduleInitialization(
+            schedule, locked, RecoverMissedSchedules.NONE, null
+        );
+
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    void shouldRecomputeNextDateForUnlockedTrigger() throws Exception {
+        Schedule schedule = schedule();
+        Trigger unlocked = trigger()
+            .executionId(null)
+            .nextExecutionDate(ZonedDateTime.now().minusMinutes(30))
+            .build();
+
+        Optional<Trigger> result = AbstractScheduler.computeScheduleInitialization(
+            schedule, unlocked, RecoverMissedSchedules.NONE, null
+        );
+
+        assertThat(result).isPresent();
+        assertThat(result.get().getExecutionId()).isNull();
+        assertThat(result.get().getNextExecutionDate()).isEqualTo(schedule.nextEvaluationDate());
+    }
+}


### PR DESCRIPTION
The flow-change listener re-runs over all flows on any flow change and, for Schedulables with recoverMissedSchedules=NONE, rewrites the trigger from a start-of-method snapshot. If the executor cleared the execution lock in between, the stale executionId is written back, re-locking the trigger forever and stopping the schedule until manually unlocked.

Never rewrite a locked trigger from the listener, and decide from a fresh read of the trigger store instead of the snapshot.

Related-to: kestra-io/kestra-ee#8507