### PR TITLE
fix(design-system): remove purple focus color bleed and improve drop zone contrast in KsUpload

### DIFF
--- a/ui/packages/design-system/src/components/Form/KsUpload.vue
+++ b/ui/packages/design-system/src/components/Form/KsUpload.vue
@@ -53,4 +53,31 @@
 <style lang="scss">
     @use '../../assets/styles/el-ns';
     @use 'element-plus/theme-chalk/src/upload';
+
+    .kel-upload {
+        &:focus {
+            // Prevent purple color from propagating to child text nodes
+            color: inherit;
+
+            .kel-upload-dragger {
+                border-color: var(--ks-border-focus);
+            }
+        }
+    }
+
+    .kel-upload-dragger {
+        background-color: var(--ks-bg-input);
+        border-color: var(--ks-border-default);
+        border-radius: var(--ks-radius-base);
+
+        &:hover {
+            border-color: var(--ks-border-focus);
+        }
+
+        &.is-dragover {
+            background-color: var(--ks-bg-hover);
+            border-color: var(--ks-border-focus);
+            border-width: 2px;
+        }
+    }
 </style>


### PR DESCRIPTION
## Summary

- Override Element Plus upload focus state to use `color: inherit` instead of `--el-color-primary`, preventing purple from propagating to child text inside the drop zone
- Override dragger base styles to use `--ks-bg-input` / `--ks-border-default` design tokens
- Override `is-dragover` state to use `--ks-bg-hover` + `--ks-border-focus` instead of the purple `--el-color-primary-light-9` background

Fixes https://github.com/kestra-io/kestra-ee/issues/8512.

## Test plan

- [ ] Open the Upload New Storage Plugin modal
- [ ] Click the drop zone — border turns to focus color, text stays readable (no purple text)
- [ ] Drag a file over the drop zone — background turns light neutral gray, not purple
- [ ] Verify both light and dark mode look correct