### PR TITLE
fix(system): remove sidebar entrance animation and customize footer button

### DIFF
--- a/ui/src/components/layout/SideBar.vue
+++ b/ui/src/components/layout/SideBar.vue
@@ -49,16 +49,6 @@
 
         <template #footer>
             <slot name="footer" />
-            <div class="sidebar-customize-trigger">
-                <KsButton
-                    type="text"
-                    size="small"
-                    class="customize-btn"
-                    @click="showCustomizeModal = true"
-                >
-                    {{ $t("customize sidebar") }}
-                </KsButton>
-            </div>
         </template>
     </KsSideBar>
 
@@ -86,7 +76,7 @@
     import type {PropType} from "vue"
     import {useRoute, RouterLink} from "vue-router"
     import {useI18n} from "vue-i18n"
-    import {KsSideBar, KsSideBarSection, KsSideBarItem, KsIconButton, KsButton, KsNewBadge} from "@kestra-io/design-system"
+    import {KsSideBar, KsSideBarSection, KsSideBarItem, KsIconButton, KsNewBadge} from "@kestra-io/design-system"
     import DockLeft from "vue-material-design-icons/DockLeft.vue"
     import SquareEditOutline from "vue-material-design-icons/SquareEditOutline.vue"
 
@@ -266,21 +256,6 @@
     right: var(--ks-spacing-4);
     z-index: 1;
     color: var(--ks-icon-muted);
-}
-
-.sidebar-customize-trigger {
-    padding: var(--ks-spacing-2) var(--ks-spacing-2) 0;
-
-    .customize-btn {
-        width: 100%;
-        justify-content: flex-start;
-        color: var(--ks-text-dim);
-        font-size: var(--ks-font-size-xs);
-
-        &:hover {
-            color: var(--ks-text-secondary);
-        }
-    }
 }
 
 .sidebar-context-menu {

--- a/ui/src/components/layout/SideBar.vue
+++ b/ui/src/components/layout/SideBar.vue
@@ -27,20 +27,13 @@
                 <template v-if="getSectionCollapsed(section) && sectionHasNewChild(section)" #suffix>
                     <KsNewBadge>{{ t("new") }}</KsNewBadge>
                 </template>
-                <Motion
-                    v-for="(item, iIdx) in getDisplayedItems(section)"
+                <MenuLink
+                    v-for="item in getDisplayedItems(section)"
                     :key="item.id"
-                    as="div"
-                    :initial="{opacity: 0, x: -10}"
-                    :animate="{opacity: 1, x: 0}"
-                    :transition="{...ITEM_SPRING, delay: itemEntranceDelay(section, iIdx)}"
-                >
-                    <MenuLink
-                        :item="item"
-                        :active="isItemActive(item)"
-                        :isNew="isItemNew(item)"
-                    />
-                </Motion>
+                    :item="item"
+                    :active="isItemActive(item)"
+                    :isNew="isItemNew(item)"
+                />
             </KsSideBarSection>
         </template>
 
@@ -94,7 +87,6 @@
     import {useRoute, RouterLink} from "vue-router"
     import {useI18n} from "vue-i18n"
     import {KsSideBar, KsSideBarSection, KsSideBarItem, KsIconButton, KsButton, KsNewBadge} from "@kestra-io/design-system"
-    import {Motion} from "motion-v"
     import DockLeft from "vue-material-design-icons/DockLeft.vue"
     import SquareEditOutline from "vue-material-design-icons/SquareEditOutline.vue"
 
@@ -137,17 +129,6 @@
 
     const CONTEXT_MENU_WIDTH = 200
     const CONTEXT_MENU_HEIGHT = 60
-
-    const ITEM_SPRING = {type: "spring", stiffness: 420, damping: 30, mass: 0.6}
-
-    function itemEntranceDelay(section: MenuItem, localIndex: number): number {
-        let offset = 0
-        for (const candidate of props.menu) {
-            if (candidate === section) break
-            if (candidate.child) offset += getDisplayedItems(candidate).length
-        }
-        return Math.min((offset + localIndex) * 0.04, 0.6)
-    }
 
     function onContextMenu(event: MouseEvent) {
         const x = Math.max(0, Math.min(event.clientX, window.innerWidth - CONTEXT_MENU_WIDTH))


### PR DESCRIPTION
## Summary

Two follow-up removals on the customizable sidebar introduced in #16671:

- **Entrance animation**: render `MenuLink` directly in the section `v-for` instead of wrapping each item in a `motion-v` `<Motion>` div (staggered fade + slide-in spring). Drops the now-unused `ITEM_SPRING` constant, `itemEntranceDelay()` helper, and the `motion-v` import in `SideBar.vue`. Items now appear instantly.
- **"Customize sidebar" footer button**: removed from the bottom of the sidebar, along with its styles and the now-unused `KsButton` import. The footer slot returns to its pre-#16671 shape. The customize modal stays reachable through the sidebar right-click context menu.

The `Motion` usages in `SidebarCustomizeModal.vue` (drag-and-drop feedback) are intentionally untouched, so the `motion-v` dependency stays.

Side benefits: items added to the menu at runtime no longer mount invisible (`opacity: 0`) for up to 0.6s, and the animation that ignored `prefers-reduced-motion` is gone.

## Test Coverage

Removal-only diff — no new code paths or branches. The render loop keeps the same `:key="item.id"` and props as before #16671; nothing in CSS, unit tests, or e2e selectors depended on the removed wrapper div or the footer trigger (verified).

## Pre-Landing Review

No issues found.

## Design Review

Design review (lite): no issues — no new CSS, colors, or interaction states; compliant with `ui/AGENTS.md`.

## Adversarial Review

Clean on this diff — removed symbols are reference-free, item spacing is pixel-identical (the Motion div was unstyled), and the section collapse animation lives in `KsSideBarSection`, unaffected. Pre-existing issues spotted along the way (SideBar Storybook story renders zero sections due to missing item ids; `menuItemOrder` from localStorage is not deduped) are tracked as follow-ups, out of scope here.

## Scope Drift

Scope Check: CLEAN — intent was "remove the entrance animation and the customize footer button from #16671"; the diff does exactly that, one file.

## Test plan

- [x] `npm run test:unit` — 113 files / 899 tests pass (re-run after each change)
- [x] `npm run check:types` — design-system + app + tests pass
- [x] ESLint clean on the changed file

🤖 Generated with [Claude Code](https://claude.com/claude-code)
