### PR TITLE
fix(core): remove grow of toggle knob on hover

### DIFF
--- a/ui/packages/design-system/src/components/Form/KsSwitch.vue
+++ b/ui/packages/design-system/src/components/Form/KsSwitch.vue
@@ -64,7 +64,7 @@
                 border-radius: 7px;
                 background-color: palette.$base-gray-neutral-white;
                 box-shadow: 0 1px 4px var(--ks-shadow-element);
-                transition: left 0.2s ease, width 0.2s ease;
+                transition: left 0.2s ease;
             }
         }
 
@@ -80,14 +80,6 @@
             }
         }
 
-        &:hover:not(.is-disabled):not(.is-checked) .kel-switch__core .kel-switch__action {
-            width: 18px;
-        }
-
-        &.is-checked:hover:not(.is-disabled) .kel-switch__core .kel-switch__action {
-            width: 18px;
-            left: calc(100% - 21px);
-        }
 
         &.is-disabled {
             opacity: 1;


### PR DESCRIPTION
## Summary

- Removes the CSS rules that expanded the toggle knob width from 14px to 18px on hover, causing it to visually grow
- Removes the now-unused `width` from the knob's CSS transition

## Test plan

- [ ] Hover over a `KsSwitch` (unchecked) — knob stays at 14px
- [ ] Hover over a `KsSwitch` (checked) — knob stays at 14px, position unchanged
- [ ] Disabled state still renders correctly (no hover effect)