### PR TITLE
fix(dashboards): increase bottom padding on bar chart to prevent x-axis label clipping

### DIFF
--- a/ui/src/components/dashboard/sections/Bar.vue
+++ b/ui/src/components/dashboard/sections/Bar.vue
@@ -104,7 +104,7 @@
         return {
             grid: isCompact
                 ? {top: 2, right: 2, bottom: 2, left: 2, containLabel: false}
-                : {left: "3%", right: "4%", bottom: "3%", top: chartOptions?.legend?.enabled ? "60px" : "5%", containLabel: true},
+                : {left: "3%", right: "4%", bottom: "8%", top: chartOptions?.legend?.enabled ? "60px" : "5%", containLabel: true},
             xAxis: {
                 type: "category",
                 data: categories.value,


### PR DESCRIPTION
## Summary

- Increases the ECharts grid `bottom` from `3%` to `8%` in the dashboard bar chart component
- Prevents x-axis labels from being clipped when the chart is empty or has sparse data

Closes https://github.com/kestra-io/kestra-ee/issues/8530.

## Test plan

- [ ] Open the Dashboard and view a bar chart (e.g. "Executions per namespace") with no data — x-axis labels should be fully visible
- [ ] Verify charts with data still render correctly