### PR TITLE
fix(tasks): PurgeLogs should match namespace as a prefix

### DIFF
--- a/core/src/test/java/io/kestra/core/repositories/AbstractLogRepositoryTest.java
+++ b/core/src/test/java/io/kestra/core/repositories/AbstractLogRepositoryTest.java
@@ -357,6 +357,26 @@ public abstract class AbstractLogRepositoryTest {
     }
 
     @Test
+    void deleteByQueryWithNamespacePrefix() {
+        String tenant = TestsUtils.randomTenant(this.getClass().getSimpleName());
+        LogEntry parent = logEntry(tenant, Level.INFO, "exec-parent").namespace("io.kestra.purge").build();
+        LogEntry child = logEntry(tenant, Level.INFO, "exec-child").namespace("io.kestra.purge.child").build();
+        LogEntry sibling = logEntry(tenant, Level.INFO, "exec-sibling").namespace("io.kestra.purgeother").build();
+        logRepository.save(parent);
+        logRepository.save(child);
+        logRepository.save(sibling);
+
+        // Without a flowId, the namespace is a prefix: the namespace itself and its descendants are
+        // purged, while sibling namespaces sharing a textual prefix (io.kestra.purgeother) are kept.
+        int deleted = logRepository.deleteByQuery(tenant, "io.kestra.purge", null, null, null, null, ZonedDateTime.now().plusMinutes(1), true, true, null);
+
+        assertThat(deleted).isEqualTo(2);
+        assertThat(logRepository.findByExecutionId(tenant, parent.getExecutionId(), null)).isEmpty();
+        assertThat(logRepository.findByExecutionId(tenant, child.getExecutionId(), null)).isEmpty();
+        assertThat(logRepository.findByExecutionId(tenant, sibling.getExecutionId(), null)).hasSize(1);
+    }
+
+    @Test
     void findAllAsync() {
         String tenant = TestsUtils.randomTenant(this.getClass().getSimpleName());
         logRepository.save(logEntry(tenant, Level.INFO).build());

--- a/jdbc/src/main/java/io/kestra/jdbc/repository/AbstractJdbcLogRepository.java
+++ b/jdbc/src/main/java/io/kestra/jdbc/repository/AbstractJdbcLogRepository.java
@@ -271,7 +271,14 @@ public abstract class AbstractJdbcLogRepository extends AbstractJdbcCrudReposito
             condition = condition.and(field(DATE_COLUMN).greaterOrEqual(startDate.toOffsetDateTime()));
         }
         if (namespace != null) {
-            condition = condition.and(field("namespace").eq(namespace));
+            // Without a flowId, the namespace is a prefix: it matches the namespace itself and all
+            // its descendants, consistent with the documented behavior and PurgeExecutions. With a
+            // flowId, it targets that flow's exact namespace.
+            if (flowId != null) {
+                condition = condition.and(field("namespace").eq(namespace));
+            } else {
+                condition = condition.and(field("namespace").eq(namespace).or(field("namespace").startsWith(namespace + ".")));
+            }
         }
         if (flowId != null) {
             condition = condition.and(field("flow_id").eq(flowId));


### PR DESCRIPTION
closes: https://github.com/kestra-io/kestra/issues/16757

## What

`PurgeLogs` (and any caller of the log repository's bulk `deleteByQuery`) filtered the namespace with an **exact** equality:

```java
condition = condition.and(field("namespace").eq(namespace));
```

whereas `PurgeExecutions` matches the namespace **and all its descendants**, and the `PurgeLogs.namespace` property is documented as a *prefix*:

> If `flowId` isn't provided, this is a namespace prefix, else the namespace of the flow.

## Why

A common purge flow iterates over parent namespaces and runs `PurgeExecutions` (prefix match) + `PurgeLogs` (exact match) per namespace:

```yaml
- id: purge_executions
  type: io.kestra.plugin.core.execution.PurgeExecutions
  purgeLog: false
  namespace: "{{ taskrun.value }}"   # e.g. "automation"
- id: purge_logs
  type: io.kestra.plugin.core.log.PurgeLogs
  namespace: "{{ taskrun.value }}"   # e.g. "automation"
```

Since all logs live in **child** namespaces (`automation.*`), `PurgeExecutions` deletes the executions but `PurgeLogs` matches nothing — the `logs` table keeps growing despite a daily purge. This was reported by a customer whose `logs` table reached ~388 GB (a single child namespace accounted for ~73 M rows that the purge never touched).

The order of the tasks is **not** the cause — `PurgeLogs` deletes directly from the `logs` table by namespace/date and never joins to executions. The root cause is purely the exact-vs-prefix namespace filter.

## What changed

In `AbstractJdbcLogRepository#buildDeleteCondition`, align the namespace filter with `PurgeExecutions`:

- **no `flowId`** → prefix match: `namespace = X OR namespace LIKE 'X.%'`
- **with a `flowId`** → keep the exact-namespace match (targets that flow's namespace)

The `X.` boundary ensures sibling namespaces sharing a textual prefix (e.g. `automation` vs `automationfoo`) are not affected.

## Tests

Added `deleteByQueryWithNamespacePrefix` to `AbstractLogRepositoryTest` (runs on H2 / MySQL / Postgres): a parent namespace purge removes logs in the parent and its descendants while leaving a sibling namespace untouched. Verified green on H2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)