### PR TITLE
fix(scheduler): prevent recovering missed schedules when re-enabling a trigger via API

### DIFF
--- a/webserver/src/main/java/io/kestra/webserver/controllers/api/TriggerController.java
+++ b/webserver/src/main/java/io/kestra/webserver/controllers/api/TriggerController.java
@@ -595,6 +595,8 @@ public class TriggerController {
 
         if (disabled) {
             builder = builder.nextExecutionDate(null);
+        } else if (trigger instanceof Schedulable) {
+            builder = builder.nextExecutionDate(ZonedDateTime.now());
         }
 
         Trigger updated = builder.build();

--- a/webserver/src/test/java/io/kestra/webserver/controllers/api/TriggerControllerTest.java
+++ b/webserver/src/test/java/io/kestra/webserver/controllers/api/TriggerControllerTest.java
@@ -332,6 +332,30 @@ class TriggerControllerTest {
     }
 
     @Test
+    void enableScheduleTriggerResetsNextExecutionDate() {
+        // Re-enabling a Schedule trigger must reset nextExecutionDate to ~now so the scheduler resumes
+        // from the next future slot instead of recovering/skipping the upcoming one (regression of kestra-ee#8344).
+        String namespace = IdUtils.create();
+        Flow flow = generateFlowWithTrigger(namespace);
+        jdbcFlowRepository.create(GenericFlow.of(flow));
+
+        // A disabled schedule trigger has no nextExecutionDate, as left after disabling.
+        Trigger triggerDisabled = createTriggerFromFlow(flow, true);
+        jdbcTriggerRepository.save(triggerDisabled);
+
+        BulkResponse bulkResponse = client.toBlocking().retrieve(
+            HttpRequest.POST(
+                TRIGGER_PATH + "/set-disabled/by-triggers", new TriggerController.SetDisabledRequest(List.of(triggerDisabled), false)
+            ), BulkResponse.class
+        );
+
+        assertThat(bulkResponse.getCount()).isEqualTo(1);
+        Trigger updated = jdbcTriggerRepository.findLast(triggerDisabled).get();
+        assertThat(updated.getDisabled()).isFalse();
+        assertThat(updated.getNextExecutionDate()).isNotNull();
+    }
+
+    @Test
     void enableByQuery() {
         String namespace = IdUtils.create();
         Flow flow1 = generateFlowWithTrigger(namespace);


### PR DESCRIPTION
## What

Backport of `af816e2786` (shipped in v1.3.4) to the **v1.0.x** maintenance line.

## Why

A customer on EE v1.2.5 reported that disabling then re-enabling a Schedule trigger (around a Maintenance Mode upgrade window) **skips the upcoming scheduled slot** and advances the next execution date by a full day.

### Root cause (maintenance mode is incidental)

Disable/enable goes through `TriggerController.doSetTriggerDisabled()`. On disable, `nextExecutionDate` is set to `null`; on **re-enable** it was left `null`. The scheduler treats `null` as "recover missed schedules" and, with `recoverMissedSchedules: LAST`, advances past the still-future slot — hence the +1 period skip. Maintenance mode only pauses the scheduler; the customer just toggles the trigger around the upgrade window.

## Fix

```java
if (disabled) {
    builder = builder.nextExecutionDate(null);
} else if (trigger instanceof Schedulable) {
    builder = builder.nextExecutionDate(ZonedDateTime.now());
}
```

Re-enabling a Schedule trigger now resets `nextExecutionDate` to now, so the scheduler resumes from the next future slot.

## Tests

Added `TriggerControllerTest.enableScheduleTriggerResetsNextExecutionDate` asserting a re-enabled Schedule trigger has a non-null `nextExecutionDate`. Passes locally (`:webserver:test`).

Refs kestra-io/kestra-ee#8344