### PR TITLE
fix: paginate aggregation tables and fix Elasticsearch chart drill-down

### DIFF
--- a/ui/packages/design-system/src/components/Charts/KsEchart.vue
+++ b/ui/packages/design-system/src/components/Charts/KsEchart.vue
@@ -26,6 +26,7 @@
                 autoresize
                 @mouseover="emit('echarts-mouseover', $event)"
                 @mouseout="emit('echarts-mouseout', $event)"
+                @click="emit('echarts-click', $event)"
             />
         </div>
     </KsTooltip>
@@ -84,6 +85,7 @@
     const emit = defineEmits<{
         "echarts-mouseover": [params: unknown]
         "echarts-mouseout": [params: unknown]
+        "echarts-click": [params: unknown]
     }>()
 
     const props = withDefaults(

--- a/ui/packages/design-system/src/components/Charts/KsPie.vue
+++ b/ui/packages/design-system/src/components/Charts/KsPie.vue
@@ -11,6 +11,7 @@
         type="pie"
         @echarts-mouseover="emit('echarts-mouseover', $event)"
         @echarts-mouseout="emit('echarts-mouseout', $event)"
+        @echarts-click="emit('echarts-click', $event)"
     />
 </template>
 
@@ -31,6 +32,7 @@
     const emit = defineEmits<{
         "echarts-mouseover": [params: unknown]
         "echarts-mouseout": [params: unknown]
+        "echarts-click": [params: unknown]
     }>()
 
     const props = withDefaults(

--- a/ui/src/components/dashboard/composables/charts.ts
+++ b/ui/src/components/dashboard/composables/charts.ts
@@ -118,6 +118,150 @@ export function extractState(value: any) {
     return value
 }
 
+// Maps a dashboard `where` FilterType to the list comparator key used in the URL.
+// Types with no list equivalent (OR, REGEX, IS_NULL/IS_NOT_NULL, IS_TRUE/IS_FALSE) are omitted (skipped).
+const WHERE_TYPE_TO_COMPARATOR: Record<string, string> = {
+    EQUAL_TO: "EQUALS",
+    NOT_EQUAL_TO: "NOT_EQUALS",
+    IN: "IN",
+    NOT_IN: "NOT_IN",
+    CONTAINS: "CONTAINS",
+    STARTS_WITH: "STARTS_WITH",
+    ENDS_WITH: "ENDS_WITH",
+    PREFIX: "PREFIX",
+    GREATER_THAN: "GREATER_THAN",
+    GREATER_THAN_OR_EQUAL_TO: "GREATER_THAN_OR_EQUAL_TO",
+    LESS_THAN: "LESS_THAN",
+    LESS_THAN_OR_EQUAL_TO: "LESS_THAN_OR_EQUAL_TO",
+}
+
+interface WhereCondition {
+    field?: string;
+    labelKey?: string;
+    type?: string;
+    value?: unknown;
+}
+
+interface DrillDownDescriptor {
+    /** Router name of the list view to drill into. */
+    route: string;
+    /** Dashboard field enum name -> list filter key. Fields absent here have no list filter and are skipped. */
+    fieldKey: Record<string, string>;
+    /** Filter keys the list models as multi-select, so equality maps to IN/NOT_IN. */
+    multiSelect: string[];
+    /** Whether the list supports a `timeRange` filter (flows, for instance, do not — passing it 400s). */
+    timeFiltered: boolean;
+}
+
+// Per data-source drill-down config, keyed by the short name of `chart.data.type`
+// (io.kestra.plugin.core.dashboard.data.<Name>). Sources without a list to drill into (e.g. Metrics) are omitted,
+// so a click on such a chart simply does not navigate rather than landing on the wrong page.
+const DRILL_DOWNS: Record<string, DrillDownDescriptor> = {
+    Executions: {
+        route: "executions/list",
+        fieldKey: {NAMESPACE: "namespace", FLOW_ID: "flowId", STATE: "state", LABELS: "labels", SCOPE: "scope", TRIGGER_EXECUTION_ID: "triggerExecutionId"},
+        multiSelect: ["namespace", "flowId", "state", "scope"],
+        timeFiltered: true,
+    },
+    Logs: {
+        route: "logs/list",
+        fieldKey: {NAMESPACE: "namespace", FLOW_ID: "flowId", TRIGGER_ID: "triggerId", TASK_ID: "taskId", TASK_RUN_ID: "taskRunId", ATTEMPT_NUMBER: "attemptNumber"},
+        multiSelect: ["namespace"],
+        timeFiltered: true,
+    },
+    Flows: {
+        // Flows.Fields only exposes ID / NAMESPACE / REVISION; NAMESPACE is the one with a flows-list filter.
+        // Flows have no time dimension — the flows list rejects a timeRange filter — so timeFiltered is false.
+        route: "flows/list",
+        fieldKey: {NAMESPACE: "namespace"},
+        multiSelect: ["namespace"],
+        timeFiltered: false,
+    },
+    Triggers: {
+        route: "admin/triggers",
+        fieldKey: {NAMESPACE: "namespace", FLOW_ID: "flowId", TRIGGER_ID: "triggerId", WORKER_ID: "workerId"},
+        multiSelect: ["namespace"],
+        timeFiltered: true,
+    },
+}
+
+function drillDownFor(dataType?: string): DrillDownDescriptor | undefined {
+    const sourceName = dataType?.split(".").pop()
+    return sourceName ? DRILL_DOWNS[sourceName] : undefined
+}
+
+// Resolves the list comparator for a (filterKey, dashboard FilterType), honoring multi-select fields
+// (equality -> IN/NOT_IN). Returns null when the operator can't be represented for that field.
+function comparatorFor(descriptor: DrillDownDescriptor, filterKey: string, type?: string): string | null {
+    if (descriptor.multiSelect.includes(filterKey)) {
+        // Multi-select fields use IN/NOT_IN for (in)equality; other operators (CONTAINS, STARTS_WITH, …)
+        // still pass through to the generic mapping below.
+        if (type === "EQUAL_TO" || type === "IN") return "IN"
+        if (type === "NOT_EQUAL_TO" || type === "NOT_IN") return "NOT_IN"
+    }
+    return WHERE_TYPE_TO_COMPARATOR[type ?? ""] ?? null
+}
+
+function encodeFilter(filterKey: string, comparator: string, labelKey: string | undefined, value: string): Record<string, string> {
+    if (filterKey === "labels") {
+        return labelKey ? {[`filters[labels][${comparator}][${labelKey}]`]: value} : {}
+    }
+    return {[`filters[${filterKey}][${comparator}]`]: value}
+}
+
+function asString(value: unknown): string {
+    return Array.isArray(value) ? value.join(",") : String(value)
+}
+
+
+export function dimensionFilter(
+    descriptor: DrillDownDescriptor,
+    column: {field?: string; labelKey?: string} | undefined,
+    value: string,
+): Record<string, string> {
+    const filterKey = descriptor.fieldKey[column?.field ?? ""]
+    if (!filterKey) return {}
+    const comparator = comparatorFor(descriptor, filterKey, "EQUAL_TO")
+    if (!comparator) return {}
+    const resolved = filterKey === "state" ? extractState(value) : value
+    return encodeFilter(filterKey, comparator, column?.labelKey, resolved)
+}
+
+
+// Translates a chart's `where` conditions into list `filters[...]` query params
+export function whereToFilters(descriptor: DrillDownDescriptor, where?: unknown): Record<string, string> {
+    const out: Record<string, string> = {}
+    if (!Array.isArray(where)) return out
+
+    for (const condition of where as WhereCondition[]) {
+        if (condition?.value === undefined || condition.value === null) continue
+        const filterKey = descriptor.fieldKey[condition.field ?? ""]
+        if (!filterKey) continue
+        const comparator = comparatorFor(descriptor, filterKey, condition.type)
+        if (!comparator) continue
+        Object.assign(out, encodeFilter(filterKey, comparator, condition.labelKey, asString(condition.value)))
+    }
+
+    return out
+}
+
+export function chartSegmentDrillDown(
+    chart: {data?: Record<string, any>} | undefined,
+    column: {field?: string; labelKey?: string} | undefined,
+    value: string,
+): {name: string; query: Record<string, string>; timeFiltered: boolean} | null {
+    const descriptor = drillDownFor(chart?.data?.type)
+    if (!descriptor) return null
+    return {
+        name: descriptor.route,
+        timeFiltered: descriptor.timeFiltered,
+        query: {
+            ...whereToFilters(descriptor, chart?.data?.where),
+            ...dimensionFilter(descriptor, column, value),
+        },
+    }
+}
+
 export function chartClick(moment: any, router: any, route: any, event: any, parsedData: any, elements: any, type = "label", filters: Record<string, any> = {}) {
     const query: Record<string, any> = {}
 

--- a/ui/src/components/dashboard/sections/Pie.vue
+++ b/ui/src/components/dashboard/sections/Pie.vue
@@ -4,13 +4,13 @@
     >
         <KsPie
             v-if="generated !== undefined"
-            ref="ksPieRef"
             :data="pieData"
             :loading="false"
             :donut="chartOptions?.graphStyle !== 'PIE'"
             :options="pieOptions"
             :disableFeatures="[ChartFeature.LEGEND]"
             :tooltipType="TooltipType.EXTERNAL"
+            @echarts-click="onSegmentClick"
         />
         <div
             v-if="generated !== undefined"
@@ -23,10 +23,10 @@
 </template>
 
 <script setup lang="ts">
-    import {computed, PropType, ref, watch} from "vue"
+    import {computed, PropType, watch} from "vue"
 
     import {Chart, useChartGenerator} from "../composables/useDashboards"
-    import {extractState, getConsistentHEXColor} from "../composables/charts"
+    import {getConsistentHEXColor, chartSegmentDrillDown} from "../composables/charts"
     import {FilterObject} from "../../../utils/filters"
     import {KsPie, durationUtils} from "@kestra-io/design-system"
     import type {KsChartSeriesItem} from "@kestra-io/design-system"
@@ -47,8 +47,6 @@
         filters: {type: Array as PropType<FilterObject[]>, default: () => []},
         showDefault: {type: Boolean, default: false},
     })
-
-    const ksPieRef = ref<InstanceType<typeof KsPie> | null>(null)
 
     const {chartOptions} = props.chart
     const columns = props.chart.data?.columns ?? {}
@@ -112,25 +110,29 @@
         return opts
     })
 
-    watch(ksPieRef, (newRef) => {
-        if (!newRef) return
-        const instance = newRef.getEchartsInstance()
-        if (!instance) return
-        instance.on("click", (params: any) => {
-            if (!params.name) return
-            router.push({
-                name: "executions/list",
-                params: {tenant: route.params.tenant},
-                query: {
-                    state: extractState(params.name),
-                    scope: "USER",
-                    size: 100,
-                    page: 1,
-                    "filters[timeRange][EQUALS]": useMiscStore()?.configs?.chartDefaultDuration ?? "PT24H",
-                },
-            })
-        })
+    const dimensionColumn = computed(() => {
+        const dimensionKey = aggregator.field?.key
+        return (dimensionKey ? columns[dimensionKey] : undefined) as {field?: string; labelKey?: string} | undefined
     })
+
+    function onSegmentClick(params: any) {
+        if (!params?.name) return
+        const drillDown = chartSegmentDrillDown(props.chart, dimensionColumn.value, params.name)
+        if (!drillDown) return
+        router.push({
+            name: drillDown.name,
+            params: {tenant: route.params.tenant},
+            query: {
+                ...drillDown.query,
+                scope: "USER",
+                size: 100,
+                page: 1,
+                ...(drillDown.timeFiltered
+                    ? {"filters[timeRange][EQUALS]": useMiscStore()?.configs?.chartDefaultDuration ?? "PT24H"}
+                    : {}),
+            },
+        })
+    }
 
     function refresh() {
         return generate()

--- a/ui/tests/unit/dashboard/charts.spec.ts
+++ b/ui/tests/unit/dashboard/charts.spec.ts
@@ -1,0 +1,103 @@
+import {describe, expect, it} from "vitest"
+import {chartSegmentDrillDown} from "../../../src/components/dashboard/composables/charts"
+
+const EXEC = "io.kestra.plugin.core.dashboard.data.Executions"
+const LOGS = "io.kestra.plugin.core.dashboard.data.Logs"
+const FLOWS = "io.kestra.plugin.core.dashboard.data.Flows"
+const METRICS = "io.kestra.plugin.core.dashboard.data.Metrics"
+
+describe("chartSegmentDrillDown", () => {
+    it("reproduces the CLEID dashboard: clicked label + the chart's where conditions, on the executions route", () => {
+        const chart = {
+            data: {
+                type: EXEC,
+                where: [
+                    {field: "STATE", type: "NOT_EQUAL_TO", value: "SUCCESS"},
+                    {field: "LABELS", labelKey: "status", type: "NOT_EQUAL_TO", value: "init"},
+                ],
+            },
+        }
+        const result = chartSegmentDrillDown(chart, {field: "LABELS", labelKey: "cleid"}, "cleid-010")
+        expect(result).toEqual({
+            name: "executions/list",
+            timeFiltered: true,
+            query: {
+                "filters[state][NOT_IN]": "SUCCESS",
+                "filters[labels][NOT_EQUALS][status]": "init",
+                "filters[labels][EQUALS][cleid]": "cleid-010",
+            },
+        })
+    })
+
+    it("maps a state-grouped executions pie to filters[state][IN] (state is multi-select)", () => {
+        const result = chartSegmentDrillDown({data: {type: EXEC}}, {field: "STATE"}, "FAILED")
+        expect(result).toEqual({name: "executions/list", timeFiltered: true, query: {"filters[state][IN]": "FAILED"}})
+    })
+
+    it("routes a Logs chart to the logs list with logs-specific filter keys", () => {
+        const result = chartSegmentDrillDown({data: {type: LOGS}}, {field: "TASK_ID"}, "my-task")
+        expect(result).toEqual({name: "logs/list", timeFiltered: true, query: {"filters[taskId][EQUALS]": "my-task"}})
+    })
+
+    it("returns null for a data source with no drill-down list (Metrics)", () => {
+        expect(chartSegmentDrillDown({data: {type: METRICS}}, {field: "NAMESPACE"}, "x")).toBeNull()
+    })
+
+    it("returns null when the chart has no data type", () => {
+        expect(chartSegmentDrillDown({data: {}}, {field: "STATE"}, "FAILED")).toBeNull()
+        expect(chartSegmentDrillDown(undefined, undefined, "FAILED")).toBeNull()
+    })
+
+    it("skips where conditions and dimensions with no list equivalent (superset, never wrong rows)", () => {
+        const chart = {
+            data: {
+                type: EXEC,
+                where: [
+                    {field: "DURATION", type: "GREATER_THAN", value: 60}, // no executions filter -> skipped
+                    {field: "LABELS", type: "EQUAL_TO", value: "x"},      // no labelKey -> skipped
+                    {field: "NAMESPACE", type: "EQUAL_TO", value: "io.kestra.test"},
+                ],
+            },
+        }
+        // NAMESPACE is multi-select -> EQUAL_TO becomes IN; clicked FLOW_ID dimension also multi-select -> IN
+        const result = chartSegmentDrillDown(chart, {field: "FLOW_ID"}, "always-fail")
+        expect(result).toEqual({
+            name: "executions/list",
+            timeFiltered: true,
+            query: {
+                "filters[namespace][IN]": "io.kestra.test",
+                "filters[flowId][IN]": "always-fail",
+            },
+        })
+    })
+
+    it("joins array values for IN/NOT_IN where conditions", () => {
+        const chart = {data: {type: EXEC, where: [{field: "STATE", type: "IN", value: ["FAILED", "WARNING"]}]}}
+        const result = chartSegmentDrillDown(chart, {field: "LABELS", labelKey: "cleid"}, "cleid-001")
+        expect(result?.query["filters[state][IN]"]).toBe("FAILED,WARNING")
+    })
+
+    it("routes a Flows chart to the flows list, carrying a namespace where", () => {
+        const chart = {
+            data: {
+                type: FLOWS,
+                where: [{field: "NAMESPACE", type: "NOT_EQUAL_TO", value: "system"}],
+            },
+        }
+        const result = chartSegmentDrillDown(chart, {field: "NAMESPACE"}, "dashboard.test")
+        expect(result).toEqual({
+            name: "flows/list",
+            timeFiltered: false, // flows have no time dimension
+            query: {
+                "filters[namespace][NOT_IN]": "system",
+                "filters[namespace][IN]": "dashboard.test",
+            },
+        })
+    })
+
+    it("passes non-equality operators through on a multi-select field (namespace CONTAINS)", () => {
+        const chart = {data: {type: EXEC, where: [{field: "NAMESPACE", type: "CONTAINS", value: "kestra"}]}}
+        const result = chartSegmentDrillDown(chart, undefined, "x")
+        expect(result?.query).toEqual({"filters[namespace][CONTAINS]": "kestra"})
+    })
+})


### PR DESCRIPTION
✨ Description

Clicking a dashboard chart segment always navigated to the executions list with a hardcoded state=<value> query parameter. When a chart is grouped by a label (or any non-state dimension), that produced an invalid state filter and an empty/broken list.

The drill-down is now data-source-aware and maps the clicked dimension to the correct filter:
- LABELS → filters[labels][EQUALS][<labelKey>]
- STATE → filters[state][IN]
- NAMESPACE / FLOW_ID → their filter keys
- routes to the list view for the chart's data source (Executions / Logs / Flows / Triggers); a source with no corresponding list (Metrics) simply doesn't navigate

It also carries the chart's where conditions into the target list (so the list matches the clicked segment), and only adds a timeRange filter for sources that support one. Finally, it adds an echarts-click event to KsEchart/KsPie (mirroring the existing echarts-mouseover/-mouseout) so segment clicks fire reliably across instance re-renders.