### PR TITLE
feat(core): add full arg to the secret() pebble function

### DIFF
--- a/core/src/main/java/io/kestra/core/runners/pebble/functions/SecretFunction.java
+++ b/core/src/main/java/io/kestra/core/runners/pebble/functions/SecretFunction.java
@@ -2,6 +2,7 @@ package io.kestra.core.runners.pebble.functions;
 
 import java.io.IOException;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
@@ -13,6 +14,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.kestra.core.runners.RunVariables;
 import io.kestra.core.secret.SecretException;
 import io.kestra.core.secret.SecretNotFoundException;
+import io.kestra.core.secret.SecretObject;
 import io.kestra.core.secret.SecretService;
 import io.kestra.core.serializers.JacksonMapper;
 import io.kestra.core.services.NamespaceService;
@@ -34,6 +36,9 @@ public class SecretFunction implements KestraFunction {
     private static final String SUBKEY_ARG = "subkey";
     private static final String NAMESPACE_ARG = "namespace";
     private static final String KEY_ARG = "key";
+    private static final String FULL_ARG = "full";
+    private static final String VALUE_KEY = "value";
+    private static final String METADATA_KEY = "metadata";
 
     @Inject
     private Provider<SecretService> secretService;
@@ -43,7 +48,7 @@ public class SecretFunction implements KestraFunction {
 
     @Override
     public List<String> getArgumentNames() {
-        return List.of(KEY_ARG, NAMESPACE_ARG, SUBKEY_ARG);
+        return List.of(KEY_ARG, NAMESPACE_ARG, SUBKEY_ARG, FULL_ARG);
     }
 
     @SuppressWarnings("unchecked")
@@ -62,10 +67,29 @@ public class SecretFunction implements KestraFunction {
             namespaceService.get().checkAllowedNamespace(flowTenantId, namespace, flowTenantId, flowNamespace);
         }
 
+        final String subkey = (String) args.get(SUBKEY_ARG);
+        final boolean full = Boolean.TRUE.equals(args.get(FULL_ARG));
+
+        if (full && subkey != null && !subkey.isEmpty()) {
+            throw new PebbleException(null, "The 'secret' function cannot be called with both 'subkey' and 'full' arguments.", lineNumber, self.getName());
+        }
+
         try {
+            if (full) {
+                SecretObject secretObject = secretService.get().findSecretObject(flowTenantId, namespace, key);
+                consumeSecret(context, secretObject.value());
+
+                Map<String, Object> result = new LinkedHashMap<>();
+                result.put(VALUE_KEY, secretObject.value());
+                if (!secretObject.metadata().isEmpty()) {
+                    secretObject.metadata().values().forEach(value -> consumeSecret(context, value));
+                    result.put(METADATA_KEY, secretObject.metadata());
+                }
+                return result;
+            }
+
             String secret = secretService.get().findSecret(flowTenantId, namespace, key);
 
-            final String subkey = (String) args.get(SUBKEY_ARG);
             if (subkey != null && !subkey.isEmpty()) {
                 try {
                     JsonNode subkeys = OBJECT_MAPPER.readTree(secret);
@@ -86,16 +110,20 @@ public class SecretFunction implements KestraFunction {
                 }
             }
 
-            try {
-                Consumer<String> addSecretConsumer = (Consumer<String>) context.getVariable(RunVariables.SECRET_CONSUMER_VARIABLE_NAME);
-                addSecretConsumer.accept(secret);
-            } catch (Exception e) {
-                log.warn("Unable to get secret consumer", e);
-            }
-
+            consumeSecret(context, secret);
             return secret;
         } catch (SecretException | IOException e) {
             throw new PebbleException(e, e.getMessage(), lineNumber, self.getName());
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private void consumeSecret(EvaluationContext context, String value) {
+        try {
+            Consumer<String> addSecretConsumer = (Consumer<String>) context.getVariable(RunVariables.SECRET_CONSUMER_VARIABLE_NAME);
+            addSecretConsumer.accept(value);
+        } catch (Exception e) {
+            log.warn("Unable to get secret consumer", e);
         }
     }
 
@@ -105,6 +133,7 @@ public class SecretFunction implements KestraFunction {
         defaults.put(KEY_ARG, "'MY_SECRET'");
         defaults.put(NAMESPACE_ARG, "flow.namespace");
         defaults.put(SUBKEY_ARG, null);
+        defaults.put(FULL_ARG, null);
         return defaults;
     }
 

--- a/core/src/main/java/io/kestra/core/secret/SecretObject.java
+++ b/core/src/main/java/io/kestra/core/secret/SecretObject.java
@@ -1,0 +1,20 @@
+package io.kestra.core.secret;
+
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * A secret in full mode: the main value plus any additional fields.
+ *
+ * @param value the main secret value.
+ * @param metadata the additional fields, empty when there are none. Never null.
+ */
+public record SecretObject(String value, Map<String, String> metadata) {
+    public SecretObject {
+        Objects.requireNonNull(metadata, "metadata cannot be null");
+    }
+
+    public SecretObject(String value) {
+        this(value, Map.of());
+    }
+}

--- a/core/src/main/java/io/kestra/core/secret/SecretService.java
+++ b/core/src/main/java/io/kestra/core/secret/SecretService.java
@@ -57,6 +57,14 @@ public class SecretService<META> {
         return secret;
     }
 
+    /**
+     * Finds the secret in full mode, as a value plus metadata.
+     * The default returns the value with empty metadata. Multi-field secret managers override this to add metadata.
+     */
+    public SecretObject findSecretObject(String tenantId, String namespace, String key) throws SecretNotFoundException, IOException {
+        return new SecretObject(findSecret(tenantId, namespace, key));
+    }
+
     public ArrayListTotal<META> list(Pageable pageable, String tenantId, List<QueryFilter> filters) throws IOException {
         final Predicate<String> queryPredicate = filters.stream()
             .filter(filter -> QueryFilter.Field.QUERY.equals(filter.field()) && filter.value() != null)

--- a/core/src/test/java/io/kestra/core/runners/pebble/PebbleExpressionServiceTest.java
+++ b/core/src/test/java/io/kestra/core/runners/pebble/PebbleExpressionServiceTest.java
@@ -44,10 +44,11 @@ class PebbleExpressionServiceTest {
         // secret function
         PebbleFunction secret = findFunction("secret");
         assertThat(secret.arguments()).extracting(PebbleFunction.Argument::name)
-            .containsExactly("key", "namespace", "subkey");
+            .containsExactly("key", "namespace", "subkey", "full");
         assertThat(secret.arguments().get(0).defaultValue()).isEqualTo("'MY_SECRET'");
         assertThat(secret.arguments().get(1).defaultValue()).isEqualTo("flow.namespace");
         assertThat(secret.arguments().get(2).defaultValue()).isNull();
+        assertThat(secret.arguments().get(3).defaultValue()).isNull();
 
         // kv function
         PebbleFunction kv = findFunction("kv");

--- a/core/src/test/java/io/kestra/core/secret/SecretFunctionTest.java
+++ b/core/src/test/java/io/kestra/core/secret/SecretFunctionTest.java
@@ -1,6 +1,7 @@
 package io.kestra.core.secret;
 
 import java.io.IOException;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -117,6 +118,39 @@ public class SecretFunctionTest {
     }
 
     @Test
+    void shouldGetSecretGivenFull() throws IllegalVariableEvaluationException {
+        // Given
+        Map<String, Object> context = Map.of(
+            "flow", Map.of("namespace", "io.kestra.unittest")
+        );
+
+        // When / Then
+        // structured secret manager: value plus metadata
+        assertThat(variableRenderer.render("{{ secret('credential', full=true).value }}", context)).isEqualTo("my-password");
+        assertThat(variableRenderer.render("{{ secret('credential', full=true).metadata.username }}", context)).isEqualTo("my-user");
+        assertThat(variableRenderer.render("{{ secret('credential', full=true).metadata.domain }}", context)).isEqualTo("kestra-io");
+
+        // single-value secret: only value, no metadata
+        assertThat(variableRenderer.render("{{ secret('string-secret', full=true).value }}", context)).isEqualTo("string-value");
+    }
+
+    @Test
+    void shouldFailedGivenBothSubKeyAndFull() {
+        // Given
+        Map<String, Object> context = Map.of(
+            "flow", Map.of("namespace", "io.kestra.unittest")
+        );
+
+        // When / Then
+        Throwable cause = Assertions.assertThrows(IllegalVariableEvaluationException.class, () ->
+        {
+            variableRenderer.render("{{ secret('json-secret', subkey='string', full=true) }}", context);
+        }).getCause();
+        assertThat(cause.getMessage())
+            .isEqualTo("The 'secret' function cannot be called with both 'subkey' and 'full' arguments. ({{ secret('json-secret', subkey='string', full=true) }}:1)");
+    }
+
+    @Test
     void getUnknownSecret() {
         var exception = assertThrows(SecretNotFoundException.class, () -> secretService.findSecret(null, null, "unknown_secret_key"));
         assertThat(exception.getMessage()).isEqualTo("Cannot find secret for key 'unknown_secret_key'.");
@@ -144,6 +178,17 @@ public class SecretFunctionTest {
                 return optional.get();
             }
             return super.findSecret(tenantId, namespace, key);
+        }
+
+        @Override
+        public SecretObject findSecretObject(String tenantId, String namespace, String key) throws SecretNotFoundException, IOException {
+            if ("credential".equals(key)) {
+                Map<String, String> metadata = new LinkedHashMap<>();
+                metadata.put("username", "my-user");
+                metadata.put("domain", "kestra-io");
+                return new SecretObject("my-password", metadata);
+            }
+            return super.findSecretObject(tenantId, namespace, key);
         }
     }
 }


### PR DESCRIPTION
Adds an optional `full` argument to `secret()` to get the whole secret in one call, shaped as `{value, metadata}`: `value` is the secret, `metadata` holds any extra fields. Default behaviour is unchanged. Each field is masked in logs.

```
{% set cred = secret('prod-mssql', full=true) %}
{{ cred.value }} / {{ cred.metadata.username }}
```

Part of kestra-io/secret-delinea#15