### PR TITLE
fix(core): add trailing newline to generated translation files

### DIFF
--- a/ui/src/translations/generate_translations.py
+++ b/ui/src/translations/generate_translations.py
@@ -157,6 +157,7 @@ def main(language_code, target_language, input_file="ui/src/translations/en.json
     # Sort keys to keep output stable
     with open(f"ui/src/translations/{language_code}.json", "w") as f:
         json.dump({language_code: updated_target_dict}, f, ensure_ascii=False, indent=2, sort_keys=True)
+        f.write("\n")
 
 if __name__ == "__main__":
     # Default to 'false' if no argument is provided


### PR DESCRIPTION
## Summary
- Add a trailing newline after `json.dump()` in `generate_translations.py` so generated JSON files always end with a newline
- This prevents the script from opening PRs that only contain empty-line changes (like #16727)

## Test plan
- [ ] Run the translation script locally and verify the generated JSON files end with a newline
- [ ] Verify a subsequent run produces no diff