### PR TITLE
fix(variables): let KVSTORE READ users view KV values without UPDATE

### DIFF
--- a/ui/src/components/kv/KVTable.vue
+++ b/ui/src/components/kv/KVTable.vue
@@ -109,6 +109,19 @@
                     </template>
                 </el-table-column>
 
+                <el-table-column v-if="!paneView" columnKey="view" className="row-action">
+                    <template #default="scope">
+                        <IconButton
+                            v-if="!canUpdate(scope.row) && canRead(scope.row)"
+                            :tooltip="$t('show')"
+                            placement="left"
+                            @click="viewKvModal(scope.row)"
+                        >
+                            <Eye />
+                        </IconButton>
+                    </template>
+                </el-table-column>
+
                 <el-table-column v-if="!paneView" columnKey="update" className="row-action">
                     <template #default="scope">
                         <IconButton
@@ -237,6 +250,30 @@
     </Drawer>
 
     <Drawer
+        v-if="viewKvDrawerVisible"
+        v-model="viewKvDrawerVisible"
+        :title="$t('show')"
+    >
+        <el-form class="ks-horizontal">
+            <el-form-item v-if="viewKv.namespace" :label="$t('namespace')">
+                <el-input :modelValue="viewKv.namespace" disabled />
+            </el-form-item>
+            <el-form-item :label="$t('key')">
+                <el-input :modelValue="viewKv.key" disabled />
+            </el-form-item>
+            <el-form-item :label="$t('kv.type')">
+                <el-input :modelValue="viewKv.type" disabled />
+            </el-form-item>
+            <el-form-item :label="$t('value')">
+                <el-input type="textarea" :rows="5" :modelValue="viewKv.value" readonly />
+            </el-form-item>
+            <el-form-item v-if="viewKv.description" :label="$t('description')">
+                <el-input :modelValue="viewKv.description" disabled />
+            </el-form-item>
+        </el-form>
+    </Drawer>
+
+    <Drawer
         v-if="namespacesStore.inheritedKVModalVisible"
         v-model="namespacesStore.inheritedKVModalVisible"
         :title="$t('kv.inherited')"
@@ -256,12 +293,14 @@
     import ContentCopy from "vue-material-design-icons/ContentCopy.vue";
     import ContentSave from "vue-material-design-icons/ContentSave.vue";
     import FileDocumentEdit from "vue-material-design-icons/FileDocumentEdit.vue";
+    import Eye from "vue-material-design-icons/Eye.vue";
 
     import Id from "../Id.vue";
     import IconButton from "../IconButton.vue";
     import Drawer from "../Drawer.vue";
     import Editor from "../inputs/Editor.vue";
     import InheritedKVs from "./InheritedKVs.vue";
+    import {formatKvValueForDisplay} from "./kvValueDisplay";
     import BulkSelect from "../layout/BulkSelect.vue";
     import SelectTable from "../layout/SelectTable.vue";
     import KSFilter from "../filter/components/KSFilter.vue";
@@ -502,6 +541,10 @@
         return kvItem.namespace !== undefined && authStore.user?.isAllowed(permission.KVSTORE, action.DELETE, kvItem.namespace);
     }
 
+    function canRead(kvItem: {namespace: string}) {
+        return kvItem.namespace !== undefined && authStore.user?.isAllowed(permission.KVSTORE, action.READ, kvItem.namespace);
+    }
+
     function jsonValidator(_rule: any, value: string, callback: (error?: Error) => void) {
         try {
             const parsed = JSON.parse(value);
@@ -555,6 +598,22 @@
         kv.value.update = true;
         kv.value.description = entry.description;
         addKvDrawerVisible.value = true;
+    }
+
+    const viewKvDrawerVisible = ref(false);
+    const viewKv = ref<{namespace?: string; key?: string; type?: string; value?: string; description?: string}>({});
+
+    async function viewKvModal(entry: any) {
+        const {type, value} = await namespacesStore.kv({namespace: entry.namespace, key: entry.key});
+        const userTimezone = localStorage.getItem(storageKeys.TIMEZONE_STORAGE_KEY) || moment.tz.guess();
+        viewKv.value = {
+            namespace: entry.namespace,
+            key: entry.key,
+            type,
+            value: formatKvValueForDisplay(type, value, userTimezone),
+            description: entry.description,
+        };
+        viewKvDrawerVisible.value = true;
     }
 
     function removeKv(namespace: string, key: string) {

--- a/ui/src/components/kv/kvValueDisplay.ts
+++ b/ui/src/components/kv/kvValueDisplay.ts
@@ -1,0 +1,17 @@
+import moment from "moment-timezone";
+
+/**
+ * Formats a KV value into a human-readable string for the read-only viewer.
+ * Kept pure (timezone passed in) so it can be unit-tested without the DOM.
+ */
+export function formatKvValueForDisplay(type: string, value: any, timezone?: string): string {
+    if (type === "JSON") {
+        return JSON.stringify(value, null, 2);
+    }
+    if (type === "DATETIME") {
+        // Follow Timezone from Settings to display KV of type DATETIME (issue #9428)
+        const tz = timezone || moment.tz.guess();
+        return moment(value).tz(tz).format();
+    }
+    return String(value);
+}

--- a/ui/tests/unit/components/kv/kvValueDisplay.spec.ts
+++ b/ui/tests/unit/components/kv/kvValueDisplay.spec.ts
@@ -1,0 +1,30 @@
+import {describe, test, expect} from "vitest"
+
+import {formatKvValueForDisplay} from "../../../../src/components/kv/kvValueDisplay"
+
+describe("formatKvValueForDisplay", () => {
+    test("STRING is rendered as-is", () => {
+        expect(formatKvValueForDisplay("STRING", "hello")).toBe("hello")
+    })
+
+    test("NUMBER is stringified", () => {
+        expect(formatKvValueForDisplay("NUMBER", 42)).toBe("42")
+    })
+
+    test("BOOLEAN is stringified", () => {
+        expect(formatKvValueForDisplay("BOOLEAN", true)).toBe("true")
+    })
+
+    test("JSON is pretty-printed", () => {
+        expect(formatKvValueForDisplay("JSON", {a: 1})).toBe("{\n  \"a\": 1\n}")
+    })
+
+    test("DATETIME is formatted in the provided timezone", () => {
+        // 2024-01-01T00:00:00Z viewed in UTC stays at midnight
+        const utc = formatKvValueForDisplay("DATETIME", "2024-01-01T00:00:00Z", "UTC")
+        expect(utc).toContain("2024-01-01")
+        // Same instant in a +ahead timezone shifts the local date/time
+        const tokyo = formatKvValueForDisplay("DATETIME", "2024-01-01T00:00:00Z", "Asia/Tokyo")
+        expect(tokyo).toContain("2024-01-01T09:00:00")
+    })
+})


### PR DESCRIPTION
## What

A user granted only **KV Store READ** on a namespace can see the KV list but cannot read a value. Today the value is reachable only through the **edit drawer**, which is gated by `KVSTORE.UPDATE` — so a READ-only user has no affordance to open it.

This adds a **read-only value viewer**:
- An eye/"show" icon appears on a KV row when the user `canRead(row) && !canUpdate(row)`.
- Clicking it opens a read-only drawer (namespace, key, type, value, description — all disabled).
- The value is fetched via the existing `GET /namespaces/{ns}/kv/{key}` endpoint, which already authorizes `KVSTORE.READ` — no backend change needed.

Value formatting is extracted into a pure helper `formatKvValueForDisplay()` and unit-tested.

## Why

Part of the RBAC cleanup for kestra-io/kestra-ee#7023. On `releases/v1.3.x` the KV list already works for KVSTORE-scoped users (global `/kv` + repo filter); the only remaining gap for a READ-only user is reading the value.

## Tests

- New `kvValueDisplay.spec.ts` (STRING / NUMBER / BOOLEAN / JSON / DATETIME-tz) — 5/5 pass.
- `check:types` clean, eslint clean.

Refs kestra-io/kestra-ee#7023

> Companion work for `releases/v1.0.x` (resource-aware namespace discovery + this viewer) is tracked separately.