### PR TITLE
fix(variables): let KVSTORE-scoped users find and read KVs without NAMESPACE

### DIFF
--- a/ui/src/components/kv/KVTable.vue
+++ b/ui/src/components/kv/KVTable.vue
@@ -70,6 +70,18 @@
             </template>
         </el-table-column>
 
+        <el-table-column v-if="!paneView" column-key="view" class-name="row-action">
+            <template #default="scope">
+                <el-tooltip v-if="!canUpdate(scope.row) && canRead(scope.row)" :content="$t('show')">
+                    <el-button
+                        :icon="Eye"
+                        link
+                        @click="viewKvModal(scope.row.namespace, scope.row.key, scope.row.description)"
+                    />
+                </el-tooltip>
+            </template>
+        </el-table-column>
+
         <el-table-column v-if="!paneView" column-key="update" class-name="row-action">
             <template #default="scope">
                 <el-button
@@ -104,6 +116,7 @@
                     v-model="kv.namespace"
                     :readonly="kv.update"
                     :include-system-namespace="true"
+                    resource="KVSTORE"
                     all
                 />
             </el-form-item>
@@ -190,6 +203,30 @@
         </template>
     </Drawer>
 
+    <Drawer
+        v-if="viewKvDrawerVisible"
+        v-model="viewKvDrawerVisible"
+        :title="$t('show')"
+    >
+        <el-form class="ks-horizontal">
+            <el-form-item v-if="viewKv.namespace" :label="$t('namespace')">
+                <el-input :model-value="viewKv.namespace" disabled />
+            </el-form-item>
+            <el-form-item :label="$t('key')">
+                <el-input :model-value="viewKv.key" disabled />
+            </el-form-item>
+            <el-form-item :label="$t('kv.type')">
+                <el-input :model-value="viewKv.type" disabled />
+            </el-form-item>
+            <el-form-item :label="$t('value')">
+                <el-input type="textarea" :rows="5" :model-value="viewKv.value" readonly />
+            </el-form-item>
+            <el-form-item v-if="viewKv.description" :label="$t('description')">
+                <el-input :model-value="viewKv.description" disabled />
+            </el-form-item>
+        </el-form>
+    </Drawer>
+
     <drawer
         v-if="namespacesStore.inheritedKVModalVisible"
         v-model="namespacesStore.inheritedKVModalVisible"
@@ -209,6 +246,7 @@
     import ContentSave from "vue-material-design-icons/ContentSave.vue";
     import TimeSelect from "../executions/date-select/TimeSelect.vue";
     import Check from "vue-material-design-icons/Check.vue";
+    import Eye from "vue-material-design-icons/Eye.vue";
     import NamespaceSelect from "../namespaces/components/NamespaceSelect.vue";
 
     import Utils from "../../utils/utils";
@@ -229,6 +267,8 @@
     import action from "../../models/action";
     import permission from "../../models/permission";
     import {useAuthStore} from "override/stores/auth"
+    import {formatKvValueForDisplay} from "./kvValueDisplay";
+    import {TIMEZONE_STORAGE_KEY} from "../settings/BasicSettings.vue";
 
     export default {
         inheritAttrs: false,
@@ -301,6 +341,8 @@
                 },
                 kvs: undefined,
                 namespaceIterator: undefined,
+                viewKvDrawerVisible: false,
+                viewKv: {},
                 rules: {
                     key: [
                         {required: true, trigger: "change"},
@@ -334,6 +376,21 @@
             canDelete(kv: {namespace: string}) {
                 return kv.namespace !== undefined && this.authStore.user?.isAllowed(permission.KVSTORE, action.DELETE, kv.namespace)
             },
+            canRead(kv: {namespace: string}) {
+                return kv.namespace !== undefined && this.authStore.user?.isAllowed(permission.KVSTORE, action.READ, kv.namespace)
+            },
+            async viewKvModal(namespace, key, description) {
+                const {type, value} = await this.namespacesStore.kv({namespace, key});
+                const timezone = localStorage.getItem(TIMEZONE_STORAGE_KEY) || undefined;
+                this.viewKv = {
+                    namespace,
+                    key,
+                    type,
+                    value: formatKvValueForDisplay(type, value, timezone),
+                    description,
+                };
+                this.viewKvDrawerVisible = true;
+            },
             jsonValidator(_rule: any, value: string, callback: (error?: Error) => void) {
                 try {
                     const parsed = JSON.parse(value);
@@ -357,7 +414,9 @@
                 let kvFetch;
                 if (this.namespace === undefined) {
                     if (this.namespaceIterator === undefined) {
-                        this.namespaceIterator = useNamespaces(this.$store, 20);
+                        // Authorize namespace discovery through the KVSTORE permission so a user with
+                        // only KV access (no NAMESPACE permission) can still find their namespaces.
+                        this.namespaceIterator = useNamespaces(this.$store, 20, {resource: permission.KVSTORE});
                     }
 
                     const namespaces = (await ((this.namespaceIterator as NamespaceIterator).next())).map(n => n.id);

--- a/ui/src/components/kv/KVTable.vue
+++ b/ui/src/components/kv/KVTable.vue
@@ -261,8 +261,6 @@
     import {mapStores} from "pinia";
     import {groupBy} from "lodash";
     import {useNamespacesStore} from "override/stores/namespaces";
-    import useNamespaces from "../../composables/useNamespaces";
-    import {NamespaceIterator} from "../../composables/useNamespaces";
     import SelectTableActions from "../../mixins/selectTableActions";
     import action from "../../models/action";
     import permission from "../../models/permission";
@@ -340,7 +338,10 @@
                     update: undefined
                 },
                 kvs: undefined,
-                namespaceIterator: undefined,
+                // Namespaces the user has a KV binding on (discovered without NAMESPACE permission),
+                // paged through by the infinite-scroll loader via namespaceCursor.
+                boundNamespaces: undefined as string[] | undefined,
+                namespaceCursor: 0,
                 viewKvDrawerVisible: false,
                 viewKv: {} as {namespace?: string; key?: string; type?: string; value?: string; description?: string},
                 rules: {
@@ -411,15 +412,18 @@
                 }
             },
             async fetchKvs() {
+                const NAMESPACE_BATCH_SIZE = 20;
                 let kvFetch;
                 if (this.namespace === undefined) {
-                    if (this.namespaceIterator === undefined) {
-                        // Authorize namespace discovery through the KVSTORE permission so a user with
-                        // only KV access (no NAMESPACE permission) can still find their namespaces.
-                        this.namespaceIterator = useNamespaces(this.$store, 20, {resource: permission.KVSTORE});
+                    if (this.boundNamespaces === undefined) {
+                        // Discover the namespaces the user has a KV binding on through the KVSTORE
+                        // permission, so a user with only KV access (no NAMESPACE permission) can
+                        // still find their namespaces.
+                        this.boundNamespaces = await this.namespacesStore.namespacesWithBinding({resource: permission.KVSTORE});
                     }
 
-                    const namespaces = (await ((this.namespaceIterator as NamespaceIterator).next())).map(n => n.id);
+                    const namespaces = (this.boundNamespaces as string[]).slice(this.namespaceCursor, this.namespaceCursor + NAMESPACE_BATCH_SIZE);
+                    this.namespaceCursor += namespaces.length;
                     if (namespaces.length !== 0) {
                         const kvsPromises = Promise.all(namespaces.filter(n => this.authStore.user?.isAllowed(permission.KVSTORE, action.READ, n)).map(async n => {
                             const kvs = await this.namespacesStore.kvsList({id: n});
@@ -503,7 +507,8 @@
                     });
             },
             async reloadKvs() {
-                this.namespaceIterator = undefined;
+                this.boundNamespaces = undefined;
+                this.namespaceCursor = 0;
 
                 const previousLength = this.secrets?.length ?? 0;
                 await this.$refs.selectTable.resetInfiniteScroll();

--- a/ui/src/components/kv/KVTable.vue
+++ b/ui/src/components/kv/KVTable.vue
@@ -342,7 +342,7 @@
                 kvs: undefined,
                 namespaceIterator: undefined,
                 viewKvDrawerVisible: false,
-                viewKv: {},
+                viewKv: {} as {namespace?: string; key?: string; type?: string; value?: string; description?: string},
                 rules: {
                     key: [
                         {required: true, trigger: "change"},

--- a/ui/src/components/kv/kvValueDisplay.ts
+++ b/ui/src/components/kv/kvValueDisplay.ts
@@ -1,0 +1,16 @@
+import moment from "moment-timezone";
+
+/**
+ * Formats a KV value into a human-readable string for the read-only viewer.
+ * Kept pure (timezone passed in) so it can be unit-tested without the DOM.
+ */
+export function formatKvValueForDisplay(type: string, value: any, timezone?: string): string {
+    if (type === "JSON") {
+        return JSON.stringify(value, null, 2);
+    }
+    if (type === "DATETIME") {
+        const tz = timezone || moment.tz.guess();
+        return moment(value).tz(tz).format();
+    }
+    return String(value);
+}

--- a/ui/src/components/namespaces/components/NamespaceSelect.vue
+++ b/ui/src/components/namespaces/components/NamespaceSelect.vue
@@ -36,7 +36,7 @@
 </template>
 
 <script setup lang="ts">
-    import {computed, onMounted} from "vue"
+    import {computed, onMounted, ref} from "vue"
     import {useI18n} from "vue-i18n"
     import {useNamespacesStore} from "override/stores/namespaces"
     import DotsSquare from "vue-material-design-icons/DotsSquare.vue"
@@ -67,7 +67,17 @@
         [modelValue.value].flat().filter(Boolean)
     )
 
+    // In resource mode we discover namespaces through the resource-scoped ids endpoint (no
+    // NAMESPACE permission required) and filter client-side; otherwise we use namespace autocomplete.
+    const boundNamespaces = ref<string[]>([]);
+    const query = ref("");
+
     const options = computed(() => {
+        if (props.resource) {
+            return boundNamespaces.value
+                .filter(value => !query.value || value.toLowerCase().includes(query.value.toLowerCase()))
+                .map(value => ({id: value, label: value}));
+        }
         return namespacesStore.autocomplete === undefined ? [] : namespacesStore.autocomplete
             .map((value: any) => {
                 return {id: value, label: value}
@@ -75,14 +85,20 @@
     })
 
     const onSearch = (search: string) => {
+        if (props.resource) {
+            query.value = search;
+            return;
+        }
         namespacesStore.loadAutocomplete({
             q: search,
             ids: modelValue.value as string[] ?? [],
-            ...(props.resource ? {resource: props.resource} : {}),
         })
     }
 
-    onMounted(() => {
+    onMounted(async () => {
+        if (props.resource) {
+            boundNamespaces.value = await namespacesStore.namespacesWithBinding({resource: props.resource});
+        }
         if (modelValue.value === undefined || modelValue.value.length === 0) {
             const defaultNamespaceVal = defaultNamespace();
             if (Array.isArray(modelValue.value)) {

--- a/ui/src/components/namespaces/components/NamespaceSelect.vue
+++ b/ui/src/components/namespaces/components/NamespaceSelect.vue
@@ -45,14 +45,18 @@
 
     const {t} = useI18n();
 
-    withDefaults(defineProps<{
+    const props = withDefaults(defineProps<{
         multiple?: boolean,
         readOnly?: boolean,
         clearable?: boolean,
-        taggable?: boolean
+        taggable?: boolean,
+        // When set, authorize namespace discovery through this resource permission (e.g. KVSTORE)
+        // instead of NAMESPACE, so users entitled to the resource can list their namespaces.
+        resource?: string
     }>(), {
         multiple: false,
-        clearable: true
+        clearable: true,
+        resource: undefined
     });
 
     const modelValue = defineModel<string | string[]>();
@@ -74,6 +78,7 @@
         namespacesStore.loadAutocomplete({
             q: search,
             ids: modelValue.value as string[] ?? [],
+            ...(props.resource ? {resource: props.resource} : {}),
         })
     }
 

--- a/ui/src/composables/useBaseNamespaces.ts
+++ b/ui/src/composables/useBaseNamespaces.ts
@@ -24,9 +24,17 @@ export function useBaseNamespacesStore() {
     const total = ref(0);
     const existing = ref(true);
 
-    async function loadAutocomplete(this: any, options?: {q?: string, ids?: string[], existingOnly?: boolean, resource?: string}) {
+    async function loadAutocomplete(this: any, options?: {q?: string, ids?: string[], existingOnly?: boolean}) {
         const response = await this.$http.post(`${apiUrlWithTenant(this.vuexStore, this.$router.currentRoute)}/namespaces/autocomplete`, options ?? {});
         autocomplete.value = response.data;
+        return response.data;
+    }
+
+    // Lists the ids of the namespaces the current user has a binding on for the given resource
+    // (e.g. KVSTORE), so resource-scoped users can discover their namespaces without requiring
+    // the NAMESPACE permission. Returns ids only — never namespace content.
+    async function namespacesWithBinding(this: any, options: {resource: string}): Promise<string[]> {
+        const response = await this.$http.get(`${apiUrl(this.vuexStore)}/namespaces/ids`, {params: options, ...VALIDATE});
         return response.data;
     }
 
@@ -242,6 +250,7 @@ export function useBaseNamespacesStore() {
     return {
         autocomplete,
         loadAutocomplete,
+        namespacesWithBinding,
         search,
         total,
         load,

--- a/ui/src/composables/useBaseNamespaces.ts
+++ b/ui/src/composables/useBaseNamespaces.ts
@@ -24,7 +24,7 @@ export function useBaseNamespacesStore() {
     const total = ref(0);
     const existing = ref(true);
 
-    async function loadAutocomplete(this: any, options?: {q?: string, ids?: string[], existingOnly?: boolean}) {
+    async function loadAutocomplete(this: any, options?: {q?: string, ids?: string[], existingOnly?: boolean, resource?: string}) {
         const response = await this.$http.post(`${apiUrlWithTenant(this.vuexStore, this.$router.currentRoute)}/namespaces/autocomplete`, options ?? {});
         autocomplete.value = response.data;
         return response.data;

--- a/ui/tests/unit/components/kv/kvValueDisplay.spec.ts
+++ b/ui/tests/unit/components/kv/kvValueDisplay.spec.ts
@@ -1,0 +1,28 @@
+import {describe, test, expect} from "vitest"
+
+import {formatKvValueForDisplay} from "../../../../src/components/kv/kvValueDisplay"
+
+describe("formatKvValueForDisplay", () => {
+    test("STRING is rendered as-is", () => {
+        expect(formatKvValueForDisplay("STRING", "hello")).toBe("hello")
+    })
+
+    test("NUMBER is stringified", () => {
+        expect(formatKvValueForDisplay("NUMBER", 42)).toBe("42")
+    })
+
+    test("BOOLEAN is stringified", () => {
+        expect(formatKvValueForDisplay("BOOLEAN", true)).toBe("true")
+    })
+
+    test("JSON is pretty-printed", () => {
+        expect(formatKvValueForDisplay("JSON", {a: 1})).toBe("{\n  \"a\": 1\n}")
+    })
+
+    test("DATETIME is formatted in the provided timezone", () => {
+        const utc = formatKvValueForDisplay("DATETIME", "2024-01-01T00:00:00Z", "UTC")
+        expect(utc).toContain("2024-01-01")
+        const tokyo = formatKvValueForDisplay("DATETIME", "2024-01-01T00:00:00Z", "Asia/Tokyo")
+        expect(tokyo).toContain("2024-01-01T09:00:00")
+    })
+})

--- a/webserver/src/main/java/io/kestra/webserver/controllers/api/NamespaceController.java
+++ b/webserver/src/main/java/io/kestra/webserver/controllers/api/NamespaceController.java
@@ -133,7 +133,8 @@ public class NamespaceController<N extends Namespace> {
         @Parameter(description = "The current page") @QueryValue(defaultValue = "1") @Min(1) int page,
         @Parameter(description = "The current page size") @QueryValue(defaultValue = "10") @Min(1) int size,
         @Parameter(description = "The sort of current page") @Nullable @QueryValue List<String> sort,
-        @Parameter(description = "Return only existing namespace") @Nullable @QueryValue(value = "existing", defaultValue = "false") boolean existingOnly) throws HttpStatusException {
+        @Parameter(description = "Return only existing namespace") @Nullable @QueryValue(value = "existing", defaultValue = "false") boolean existingOnly,
+        @Parameter(description = "Authorize discovery through this resource permission instead of NAMESPACE (e.g. KVSTORE); only honored in Enterprise Edition") @Nullable @QueryValue(value = "resource") String resource) throws HttpStatusException {
         return PagedResults.of(
             getNamespaces(
                 PageableUtils.from(page, size, sort),

--- a/webserver/src/main/java/io/kestra/webserver/controllers/api/NamespaceController.java
+++ b/webserver/src/main/java/io/kestra/webserver/controllers/api/NamespaceController.java
@@ -148,7 +148,7 @@ public class NamespaceController<N extends Namespace> {
     @ExecuteOn(TaskExecutors.IO)
     @Operation(tags = { "Namespaces" }, summary = "List ids of namespaces the user can access for a given resource")
     public List<String> namespaceForResource(
-        @Parameter(description = "The resource permission to scope discovery (e.g. KVSTORE); only honored in Enterprise Edition") @Nullable @QueryValue(value = "resource") String resource) throws HttpStatusException {
+        @Parameter(description = "The resource permission to scope discovery (e.g. KVSTORE); only honored in Enterprise Edition") @NotNull @QueryValue(value = "resource") String resource) throws HttpStatusException {
         // Open source has no RBAC, so every namespace is accessible — the resource hint is honored only in Enterprise Edition.
         return Stream.concat(
                 flowRepository.findDistinctNamespace(tenantService.resolveTenant()).stream(),

--- a/webserver/src/main/java/io/kestra/webserver/controllers/api/NamespaceController.java
+++ b/webserver/src/main/java/io/kestra/webserver/controllers/api/NamespaceController.java
@@ -133,8 +133,7 @@ public class NamespaceController<N extends Namespace> {
         @Parameter(description = "The current page") @QueryValue(defaultValue = "1") @Min(1) int page,
         @Parameter(description = "The current page size") @QueryValue(defaultValue = "10") @Min(1) int size,
         @Parameter(description = "The sort of current page") @Nullable @QueryValue List<String> sort,
-        @Parameter(description = "Return only existing namespace") @Nullable @QueryValue(value = "existing", defaultValue = "false") boolean existingOnly,
-        @Parameter(description = "Authorize discovery through this resource permission instead of NAMESPACE (e.g. KVSTORE); only honored in Enterprise Edition") @Nullable @QueryValue(value = "resource") String resource) throws HttpStatusException {
+        @Parameter(description = "Return only existing namespace") @Nullable @QueryValue(value = "existing", defaultValue = "false") boolean existingOnly) throws HttpStatusException {
         return PagedResults.of(
             getNamespaces(
                 PageableUtils.from(page, size, sort),

--- a/webserver/src/main/java/io/kestra/webserver/controllers/api/NamespaceController.java
+++ b/webserver/src/main/java/io/kestra/webserver/controllers/api/NamespaceController.java
@@ -147,7 +147,7 @@ public class NamespaceController<N extends Namespace> {
     @Get(uri = "/ids")
     @ExecuteOn(TaskExecutors.IO)
     @Operation(tags = { "Namespaces" }, summary = "List ids of namespaces the user can access for a given resource")
-    public List<String> namespacesWithBinding(
+    public List<String> namespaceForResource(
         @Parameter(description = "The resource permission to scope discovery (e.g. KVSTORE); only honored in Enterprise Edition") @Nullable @QueryValue(value = "resource") String resource) throws HttpStatusException {
         // Open source has no RBAC, so every namespace is accessible — the resource hint is honored only in Enterprise Edition.
         return Stream.concat(

--- a/webserver/src/main/java/io/kestra/webserver/controllers/api/NamespaceController.java
+++ b/webserver/src/main/java/io/kestra/webserver/controllers/api/NamespaceController.java
@@ -144,6 +144,22 @@ public class NamespaceController<N extends Namespace> {
         );
     }
 
+    @Get(uri = "/ids")
+    @ExecuteOn(TaskExecutors.IO)
+    @Operation(tags = { "Namespaces" }, summary = "List ids of namespaces the user can access for a given resource")
+    public List<String> namespacesWithBinding(
+        @Parameter(description = "The resource permission to scope discovery (e.g. KVSTORE); only honored in Enterprise Edition") @Nullable @QueryValue(value = "resource") String resource) throws HttpStatusException {
+        // Open source has no RBAC, so every namespace is accessible — the resource hint is honored only in Enterprise Edition.
+        return Stream.concat(
+                flowRepository.findDistinctNamespace(tenantService.resolveTenant()).stream(),
+                Stream.of(namespaceUtils.getSystemFlowNamespace())
+            )
+            .flatMap(n -> NamespaceUtils.asTree(n).stream())
+            .distinct()
+            .sorted()
+            .toList();
+    }
+
     @ExecuteOn(TaskExecutors.IO)
     @Get(uri = "{namespace}/dependencies")
     @Operation(tags = { "Flows" }, summary = "Get flow dependencies")

--- a/webserver/src/main/java/io/kestra/webserver/models/api/ApiAutocomplete.java
+++ b/webserver/src/main/java/io/kestra/webserver/models/api/ApiAutocomplete.java
@@ -20,7 +20,4 @@ public class ApiAutocomplete {
     List<String> ids;
     @Parameter(description = "Return only existing namespace")
     boolean existingOnly;
-    @Parameter(description = "Authorize discovery through this resource permission instead of NAMESPACE (e.g. KVSTORE); only honored in Enterprise Edition")
-    @Nullable
-    String resource;
 }

--- a/webserver/src/main/java/io/kestra/webserver/models/api/ApiAutocomplete.java
+++ b/webserver/src/main/java/io/kestra/webserver/models/api/ApiAutocomplete.java
@@ -20,4 +20,7 @@ public class ApiAutocomplete {
     List<String> ids;
     @Parameter(description = "Return only existing namespace")
     boolean existingOnly;
+    @Parameter(description = "Authorize discovery through this resource permission instead of NAMESPACE (e.g. KVSTORE); only honored in Enterprise Edition")
+    @Nullable
+    String resource;
 }

--- a/webserver/src/test/java/io/kestra/webserver/controllers/api/NamespaceControllerTest.java
+++ b/webserver/src/test/java/io/kestra/webserver/controllers/api/NamespaceControllerTest.java
@@ -112,6 +112,19 @@ public class NamespaceControllerTest {
     }
 
     @Test
+    void namespacesWithBinding() {
+        flow("my.ns");
+        flow("another.ns");
+
+        // Open source has no RBAC: the endpoint returns every namespace id; the resource hint is ignored.
+        List<String> ids = client.toBlocking().retrieve(
+            HttpRequest.GET("/api/v1/main/namespaces/ids?resource=KVSTORE"),
+            Argument.listOf(String.class)
+        );
+        assertThat(ids).containsExactlyInAnyOrder("my", "my.ns", "another", "another.ns", "system");
+    }
+
+    @Test
     void namespaceTopology() {
         flowTopologyRepository.save(createSimpleFlowTopology("flow-a", "flow-b"));
         flowTopologyRepository.save(createSimpleFlowTopology("flow-a", "flow-c"));


### PR DESCRIPTION
## What

OSS side of kestra-io/kestra-ee#7023 for `releases/v1.0.x`. Companion to **kestra-io/kestra-ee#8561**.

On v1.0.x a user with only KV Store permission on a namespace could neither **find** their KVs nor **read** a value:
1. The KV page enumerates namespaces through the NAMESPACE-gated `search`/`autocomplete` endpoints → a KV-only user got an empty list.
2. The value is only reachable through the edit drawer, gated by `KVSTORE.UPDATE` → a READ-only user had no way to read it.

This PR:
- Adds an optional **`resource`** hint to namespace discovery: a field on `ApiAutocomplete` and a `resource` query param on `/namespaces/search`. OSS ignores it; **Enterprise** (companion PR) honors it to authorize discovery through that resource permission.
- The KV page passes `resource=KVSTORE` when listing namespaces (`useNamespaces` iterator) and in the add-KV namespace picker (`NamespaceSelect` gains a `resource` prop, forwarded to autocomplete).
- Adds a **read-only value viewer** (eye icon) for users who can read but not update a KV, fetching the value via the existing READ-authorized `GET /namespaces/{ns}/kv/{key}`. Value formatting extracted into a pure, unit-tested helper.

## Tests

- `kvValueDisplay.spec.ts` (STRING / NUMBER / BOOLEAN / JSON / DATETIME-tz) — 5/5 pass.
- `check:types` clean, eslint clean.

Refs kestra-io/kestra-ee#7023