### PR TITLE
fix(core): stop posthog survey request spam

### DIFF
--- a/ui/src/composables/usePosthog.ts
+++ b/ui/src/composables/usePosthog.ts
@@ -59,6 +59,7 @@ function installSurveyHooksOnce() {
 }
 
 export async function initPostHogForSetup(config: Config): Promise<void> {
+    if (import.meta.env.MODE === "development") return
     try {
         const uid = ensureUid()
 
@@ -76,12 +77,28 @@ export async function initPostHogForSetup(config: Config): Promise<void> {
 
         if (!apiConfig?.posthog?.token) return
 
+        let redirectErrors = 0
+        const REDIRECT_ERROR_THRESHOLD = 3
+
         posthog.init(apiConfig.posthog.token, {
             api_host: apiConfig.posthog.apiHost,
             ui_host: "https://eu.posthog.com",
             capture_pageview: false,
             capture_pageleave: true,
             autocapture: false,
+            on_request_error: (res) => {
+                // 301/308 redirects that the browser can't follow (CORS) arrive here
+                // as status 0 (network error) or the redirect status itself.
+                // After a few consecutive failures, stop surveys from hammering the network.
+                if (res.statusCode === 0 || res.statusCode === 301 || res.statusCode === 308) {
+                    redirectErrors++
+                    if (redirectErrors >= REDIRECT_ERROR_THRESHOLD) {
+                        posthog.set_config({disable_surveys: true})
+                    }
+                } else {
+                    redirectErrors = 0
+                }
+            },
         })
 
         posthog.register_for_session(statsGlobalData(config, uid));


### PR DESCRIPTION
## Summary

- Skip PostHog initialization entirely when running in development mode (`MODE === "development"`) — previously the dev-mode guard in `posthog.ts` was bypassed via the `initPostHogForSetup` path which had no such check
- Use `on_request_error` to detect repeated 301/308 redirect failures (and CORS-blocked requests that arrive as `statusCode: 0`) and disable surveys after 3 consecutive errors, stopping the network spam visible in the browser devtools

## Test plan

- [ ] Start `npm run dev` and confirm no PostHog/surveys requests appear in the network tab
- [ ] In a non-dev build, confirm surveys still load normally and only disable after repeated redirect failures