### PR TITLE
[backport releases/v1.3.x] feat: add task to remove orphan execution files

### DIFF
--- a/core/src/main/java/io/kestra/core/services/StoragePurgeService.java
+++ b/core/src/main/java/io/kestra/core/services/StoragePurgeService.java
@@ -1,0 +1,195 @@
+package io.kestra.core.services;
+
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.net.URI;
+import java.nio.file.NoSuchFileException;
+import java.time.Instant;
+import java.time.ZonedDateTime;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+import io.kestra.core.storages.FileAttributes;
+import io.kestra.core.storages.StorageContext;
+import io.kestra.core.storages.StorageInterface;
+
+import io.micronaut.core.annotation.Nullable;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Maintenance service for orphaned execution storage. Resolves which
+ * {@code <ns>/<flow>/executions/} prefixes are in scope, then delegates per-file
+ * date filtering and deletion to {@link StorageInterface#purgeByLastModified}.
+ * <p>
+ * Mirrors {@link ExecutionLogService} for logs: walks storage directly (no flow
+ * repository) so it can reclaim files of flows that no longer exist, including
+ * the post-isolated-worker-group case in
+ * <a href="https://github.com/kestra-io/kestra-ee/issues/6699">kestra-ee#6699</a>.
+ */
+@Singleton
+@Slf4j
+public class StoragePurgeService {
+    private final StorageInterface storageInterface;
+
+    @Inject
+    public StoragePurgeService(StorageInterface storageInterface) {
+        this.storageInterface = storageInterface;
+    }
+
+    /**
+     * Purges execution storage whose files fall within {@code [startDate, endDate]}.
+     * Namespace matching is recursive: {@code namespace=a.b} also reaches {@code a.b.c}.
+     * <p>
+     * Sub-namespaces are discovered by walking the parent's storage subtree, so recursion only reaches
+     * children that share the parent's backend. A sub-namespace backed by its own dedicated storage is
+     * physically absent from the parent subtree and is therefore not discovered — target it explicitly via
+     * {@code namespace}. This walk-based discovery is deliberate: it lets the purge reclaim files of flows
+     * (and whole namespaces) that no longer exist, which a flow-metadata enumeration could not.
+     *
+     * @param tenantId  tenant identifier
+     * @param namespace namespace and all its sub-namespaces sharing its backend; {@code null} = walk every namespace under the tenant
+     * @param flowId    restrict to a single flow (requires {@code namespace})
+     * @param startDate inclusive lower bound on file mtime
+     * @param endDate   inclusive upper bound on file mtime (acts as the in-flight guard)
+     * @param dryRun    when {@code true}, match but delete nothing
+     */
+    public StoragePurgeResult purgeByLastModified(
+        @Nullable String tenantId,
+        @Nullable String namespace,
+        @Nullable String flowId,
+        @Nullable ZonedDateTime startDate,
+        @Nullable ZonedDateTime endDate,
+        boolean dryRun
+    ) throws IOException {
+        if (flowId != null && namespace == null) {
+            throw new IllegalArgumentException("'namespace' is required when 'flowId' is set.");
+        }
+
+        Instant startInstant = startDate == null ? null : startDate.toInstant();
+        Instant endInstant = endDate == null ? null : endDate.toInstant();
+
+        Aggregator agg = new Aggregator();
+        if (namespace != null && flowId != null) {
+            purgeFlow(tenantId, namespace, flowId, startInstant, endInstant, dryRun, agg);
+        } else if (namespace != null) {
+            walkNamespaceTree(tenantId, namespace, StorageContext.namespaceRootUri(namespace),
+                startInstant, endInstant, dryRun, agg);
+        } else {
+            walkNamespaceTree(tenantId, "", URI.create(StorageContext.KESTRA_PROTOCOL + "/"),
+                startInstant, endInstant, dryRun, agg);
+        }
+
+        return new StoragePurgeResult(agg.scanned, agg.purgedExecutions.size(), agg.deletedFiles);
+    }
+
+    /**
+     * Purges a single flow's executions in one storage call. The shallow listing of {@code executions/}
+     * before the purge call feeds the per-execution {@code scanned} counter so the caller can tell how
+     * much work was looked at vs deleted; backends that override {@link StorageInterface#purgeByLastModified}
+     * with a native primitive still benefit because the file-level walk happens inside the override.
+     */
+    private void purgeFlow(@Nullable String tenantId, String namespace, String flowId,
+        @Nullable Instant startDate, @Nullable Instant endDate, boolean dryRun, Aggregator agg) throws IOException {
+        URI executionsPrefix = StorageContext.executionsRootUri(namespace, flowId);
+
+        for (FileAttributes child : safeList(tenantId, namespace, executionsPrefix)) {
+            if (child.getType() == FileAttributes.FileType.Directory) {
+                agg.scanned++;
+            }
+        }
+
+        List<URI> matched = storageInterface.purgeByLastModified(
+            tenantId, namespace, executionsPrefix, startDate, endDate, dryRun);
+        for (URI uri : matched) {
+            StorageContext.extractExecutionId(uri).ifPresent(agg.purgedExecutions::add);
+        }
+        if (!dryRun) {
+            agg.deletedFiles += matched.size();
+        }
+    }
+
+    /**
+     * Recursive walk over a namespace subtree (or the whole tenant when {@code currentNamespace} is empty).
+     * A {@code namespace}-scoped purge reaches every sub-namespace beneath it; e.g. {@code namespace=a.b} also
+     * purges {@code a.b.c}. As we descend, we accumulate the dotted namespace from path segments and
+     * thread it through {@link #safeList} so backends enforcing per-namespace isolation receive a valid
+     * scope; only the tenant-root listing itself uses {@code null} (no namespace candidate exists yet).
+     * <p>
+     * At each level we probe {@code <child>/executions/} to distinguish a flow dir (purge it) from a
+     * namespace segment (recurse). A directory literally named {@code executions} is ambiguous — could be
+     * a flow named "executions" or a sub-namespace named "executions" — so we recurse rather than purge
+     * to avoid orphaning legitimate sub-namespace flows; explicit {@code flowId} is needed to purge that.
+     */
+    private void walkNamespaceTree(@Nullable String tenantId, String currentNamespace, URI dirUri,
+        @Nullable Instant startDate, @Nullable Instant endDate, boolean dryRun, Aggregator agg) throws IOException {
+        String namespaceForList = currentNamespace.isEmpty() ? null : currentNamespace;
+        for (FileAttributes child : safeList(tenantId, namespaceForList, dirUri)) {
+            if (!isFlowCandidate(child)) {
+                continue;
+            }
+            String childName = child.getFileName();
+            URI childUri = URI.create(dirUri + childName + "/");
+            URI executionsSubdir = URI.create(childUri + StorageContext.EXECUTIONS_DIR_NAME + "/");
+            List<FileAttributes> executionDirs = safeList(tenantId, namespaceForList, executionsSubdir);
+
+            if (executionDirs.isEmpty() || isAmbiguousFlowName(childName, null)) {
+                String nextNamespace = currentNamespace.isEmpty() ? childName : currentNamespace + "." + childName;
+                walkNamespaceTree(tenantId, nextNamespace, childUri, startDate, endDate, dryRun, agg);
+            } else if (!currentNamespace.isEmpty()) {
+                // Kestra always stores flows under a namespace, so a flow-shaped dir at tenant root is malformed.
+                purgeFlow(tenantId, currentNamespace, childName, startDate, endDate, dryRun, agg);
+            }
+        }
+    }
+
+    private static boolean isFlowCandidate(FileAttributes attrs) {
+        return attrs.getType() == FileAttributes.FileType.Directory
+            && !attrs.getFileName().startsWith(StorageContext.RESERVED_NAMESPACE_DIR_PREFIX);
+    }
+
+    /**
+     * True when a child name collides with the {@code executions/} path segment. Storage cannot distinguish
+     * a flow named {@code executions} from a sub-namespace whose last segment is {@code executions}, so
+     * namespace-scoped scans skip the ambiguous name and require explicit {@code flowId} to act on it.
+     */
+    private boolean isAmbiguousFlowName(String childName, @Nullable String namespace) {
+        if (!StorageContext.EXECUTIONS_DIR_NAME.equals(childName)) {
+            return false;
+        }
+        log.warn("Skipping ambiguous flow/sub-namespace path segment '{}' under namespace '{}'; target the flow explicitly via 'flowId' to purge it.",
+            childName, namespace);
+        return true;
+    }
+
+    /**
+     * Lists {@code uri} returning empty on missing paths and on any I/O error (logged at WARN). The
+     * {@code namespace} is threaded through so backends enforcing per-namespace isolation (e.g. dedicated
+     * storage) receive the correct scope; only the very top of a tenant-wide walk passes {@code null}.
+     */
+    private List<FileAttributes> safeList(@Nullable String tenantId, @Nullable String namespace, URI uri) {
+        try {
+            return storageInterface.list(tenantId, namespace, uri);
+        } catch (FileNotFoundException | NoSuchFileException e) {
+            return List.of();
+        } catch (IOException e) {
+            log.warn("Failed to list storage at '{}'; skipping this subtree.", uri, e);
+            return List.of();
+        }
+    }
+
+    /**
+     * Result of a {@link #purgeByLastModified} run. {@code purgedCount} counts distinct execution IDs that
+     * had at least one file in the window (or would in dry-run mode); {@code deletedFilesCount} is the
+     * raw file count (always 0 in dry-run).
+     */
+    public record StoragePurgeResult(int scannedCount, int purgedCount, int deletedFilesCount) { }
+
+    private static final class Aggregator {
+        int scanned;
+        int deletedFiles;
+        final Set<String> purgedExecutions = new LinkedHashSet<>();
+    }
+}

--- a/core/src/main/java/io/kestra/core/storages/StorageContext.java
+++ b/core/src/main/java/io/kestra/core/storages/StorageContext.java
@@ -18,6 +18,7 @@ import io.kestra.core.utils.Hashing;
 import io.kestra.core.utils.Slugify;
 
 import jakarta.annotation.Nullable;
+import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 
 /**
@@ -29,6 +30,12 @@ public class StorageContext {
     public static final String KESTRA_SCHEME = "kestra";
     public static final String KESTRA_PROTOCOL = KESTRA_SCHEME + "://";
     public static final String PREFIX_MESSAGES = "/_messages";
+
+    /** Per-flow subdir that holds execution storage. */
+    public static final String EXECUTIONS_DIR_NAME = "executions";
+
+    /** Prefix of namespace-level metadata directories ({@code _files}, {@code _kv}, …). */
+    public static final String RESERVED_NAMESPACE_DIR_PREFIX = "_";
 
     // /{namespace}/_files
     static final String PREFIX_FORMAT_NAMESPACE_FILE = "/%s/_files";
@@ -48,6 +55,29 @@ public class StorageContext {
     static final String PREFIX_FORMAT_CACHE_OBJECT = "/%s/%s/%s/cache/%s/cache.zip";
     // /{namespace}/{flow-id}/{cache-id}/cache/cache.zip
     static final String PREFIX_FORMAT_CACHE = "/%s/%s/%s/cache/cache.zip";
+
+    /**
+     * {@code kestra:///<namespace-as-path>/} — namespace root, flow dirs as direct children.
+     */
+    public static URI namespaceRootUri(@NotNull String namespace) {
+        return URI.create(KESTRA_PROTOCOL + "/" + namespaceAsPath(namespace) + "/");
+    }
+
+    /**
+     * {@code kestra:///<namespace-as-path>/<flow-slug>/executions/} — a flow's executions subdir.
+     */
+    public static URI executionsRootUri(@NotNull String namespace, @NotNull String flowId) {
+        Objects.requireNonNull(flowId, "flowId");
+        return URI.create(KESTRA_PROTOCOL + "/" + namespaceAsPath(namespace) + "/" + Slugify.of(flowId) + "/" + EXECUTIONS_DIR_NAME + "/");
+    }
+
+    /**
+     * Static counterpart of {@link #getNamespaceAsPath()}.
+     */
+    public static String namespaceAsPath(@NotNull String namespace) {
+        Objects.requireNonNull(namespace, "namespace");
+        return namespace.replace(".", "/");
+    }
 
     /**
      * Factory method for constructing a new {@link StorageContext} scoped to a given {@link TaskRun}.

--- a/core/src/main/java/io/kestra/core/storages/StorageInterface.java
+++ b/core/src/main/java/io/kestra/core/storages/StorageInterface.java
@@ -10,6 +10,8 @@ import org.apache.commons.lang3.RandomStringUtils;
 import java.io.*;
 import java.net.URI;
 import java.nio.file.NoSuchFileException;
+import java.time.Instant;
+import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -299,6 +301,84 @@ public interface StorageInterface extends AutoCloseable, Plugin {
      */
     @Retryable(includes = { IOException.class })
     List<URI> deleteByPrefix(String tenantId, @Nullable String namespace, URI storagePrefix) throws IOException;
+
+    /**
+     * Deletes objects under {@code prefix} whose last-modified timestamp falls within the inclusive
+     * window {@code [startDate, endDate]}. The window bounds are both nullable: a {@code null} bound
+     * means "unbounded on that side."
+     *
+     * <p>Implementations are encouraged to override this method to use the native listing primitive
+     * of the underlying backend (e.g. {@code ListObjectsV2} on S3, {@code Bucket.list} on GCS) so
+     * that traversal cost scales with what the backend can natively filter or paginate over rather
+     * than the total object count. The default implementation walks the prefix using
+     * {@link #list(String, String, URI)} and {@link #delete(String, String, URI)}.
+     *
+     * <p>This is a maintenance primitive: callers must enforce authorization (namespace/tenant ACLs)
+     * before invoking it. The {@code namespace} parameter is threaded through to {@code list} and
+     * {@code delete} so that backends enforcing per-namespace isolation can apply it.
+     *
+     * @param tenantId  the tenant identifier
+     * @param namespace the namespace (may be {@code null} only for backends that do not enforce
+     *                  per-namespace isolation; passing {@code null} on an enforcing backend will
+     *                  yield empty results or an error from {@link #list})
+     * @param prefix    the URI prefix to scan
+     * @param startDate inclusive lower bound on last-modified time; {@code null} = unbounded
+     * @param endDate   inclusive upper bound on last-modified time; {@code null} = unbounded
+     * @param dryRun    when {@code true}, returns the URIs that would be deleted without deleting
+     * @return the URIs that were deleted (or would be deleted in dry-run mode)
+     * @throws IOException if listing or deletion fails
+     */
+    @Retryable(includes = { IOException.class })
+    default List<URI> purgeByLastModified(
+        String tenantId,
+        @Nullable String namespace,
+        URI prefix,
+        @Nullable Instant startDate,
+        @Nullable Instant endDate,
+        boolean dryRun
+    ) throws IOException {
+        Long startMillis = startDate == null ? null : startDate.toEpochMilli();
+        Long endMillis = endDate == null ? null : endDate.toEpochMilli();
+        List<URI> matched = new ArrayList<>();
+        collectFilesInWindow(tenantId, namespace, prefix, startMillis, endMillis, matched);
+        if (!dryRun) {
+            for (URI uri : matched) {
+                delete(tenantId, namespace, uri);
+            }
+        }
+        return matched;
+    }
+
+    /**
+     * Recursive helper for the default {@link #purgeByLastModified} implementation. Missing prefixes
+     * yield an empty result instead of an error: a non-existent prefix simply has nothing to purge.
+     */
+    private void collectFilesInWindow(
+        String tenantId,
+        @Nullable String namespace,
+        URI uri,
+        @Nullable Long startMillis,
+        @Nullable Long endMillis,
+        List<URI> out
+    ) throws IOException {
+        List<FileAttributes> children;
+        try {
+            children = list(tenantId, namespace, uri);
+        } catch (FileNotFoundException | NoSuchFileException e) {
+            return;
+        }
+        String base = uri.toString();
+        String parent = base.endsWith("/") ? base : base + "/";
+        for (FileAttributes child : children) {
+            URI childUri = URI.create(parent + child.getFileName());
+            if (child.getType() == FileAttributes.FileType.Directory) {
+                collectFilesInWindow(tenantId, namespace, URI.create(childUri + "/"), startMillis, endMillis, out);
+            } else if ((startMillis == null || child.getLastModifiedTime() >= startMillis)
+                && (endMillis == null || child.getLastModifiedTime() <= endMillis)) {
+                out.add(childUri);
+            }
+        }
+    }
 
     /**
      * Stores a file from a local File object into internal storage for an execution input.

--- a/core/src/main/java/io/kestra/plugin/core/storage/PurgeStorage.java
+++ b/core/src/main/java/io/kestra/plugin/core/storage/PurgeStorage.java
@@ -1,0 +1,166 @@
+package io.kestra.plugin.core.storage;
+
+import java.time.ZonedDateTime;
+
+import io.kestra.core.models.annotations.Example;
+import io.kestra.core.models.annotations.Metric;
+import io.kestra.core.models.annotations.Plugin;
+import io.kestra.core.models.annotations.PluginProperty;
+import io.kestra.core.models.executions.metrics.Counter;
+import io.kestra.core.models.property.Property;
+import io.kestra.core.models.tasks.RunnableTask;
+import io.kestra.core.models.tasks.Task;
+import io.kestra.core.runners.DefaultRunContext;
+import io.kestra.core.runners.RunContext;
+import io.kestra.core.services.StoragePurgeService;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import lombok.*;
+import lombok.experimental.SuperBuilder;
+
+@SuperBuilder
+@ToString
+@EqualsAndHashCode
+@Getter
+@NoArgsConstructor
+@Schema(
+    title = "Purge execution files from the internal storage by last-modified date.",
+    description = """
+        **Irreversible.** Always start with `dryRun: true` and review the counters before re-running with `dryRun: false`.
+
+        When using per-namespace dedicated storage (EE), this task must be configured for each namespace to be able to \
+        clean the dedicated storage.
+
+        Deletes execution files whose last-modified timestamp falls between `startDate` and `endDate`. The primary use \
+        case is reclaiming files left behind by flows that no longer exist — files that `PurgeExecutions` cannot reach \
+        because there is no execution record to delete.
+
+        `namespace` matching is recursive: `namespace: io.kestra` also purges sub-namespaces such as \
+        `io.kestra.team`. Omit `namespace` to purge across every namespace under the tenant. A sub-namespace \
+        configured with its own dedicated storage is not reached by recursion — target it explicitly.
+
+        Set `endDate` to (or before) your `PurgeExecutions` retention window so that only files belonging to \
+        already-purged executions are deleted."""
+)
+@Plugin(
+    examples = {
+        @Example(
+            title = "Delete execution storage files older than 7 days for a namespace.",
+            full = true,
+            code = """
+                id: purge_storage
+                namespace: system
+
+                tasks:
+                  - id: purge
+                    type: io.kestra.plugin.core.storage.PurgeStorage
+                    namespace: company.team
+                    endDate: "{{ now() | dateAdd(-7, 'DAYS') }}"
+                    dryRun: false
+                """
+        )
+    },
+    metrics = {
+        @Metric(name = "scanned", type = Counter.TYPE, description = "Number of execution storage subtrees scanned."),
+        @Metric(name = "purged", type = Counter.TYPE, description = "Number of execution storage subtrees matched (preview when `dryRun` is true)."),
+        @Metric(name = "deleted.files", type = Counter.TYPE, description = "Number of storage objects deleted (always 0 when `dryRun` is true).")
+    }
+)
+public class PurgeStorage extends Task implements RunnableTask<PurgeStorage.Output> {
+    @Schema(
+        title = "Namespace whose execution storage files should be purged.",
+        description = "Recursive: sub-namespaces are also purged (e.g. `io.kestra` reaches `io.kestra.team`), except sub-namespaces with their own dedicated storage, which must be targeted explicitly. Omit to purge across every namespace under the tenant."
+    )
+    @PluginProperty(group = "main")
+    private Property<String> namespace;
+
+    @Schema(
+        title = "The flow ID to be purged.",
+        description = "Requires `namespace` to also be set."
+    )
+    @PluginProperty(group = "main")
+    private Property<String> flowId;
+
+    @Schema(
+        title = "Only purge files last modified after this date."
+    )
+    @PluginProperty(group = "main")
+    private Property<String> startDate;
+
+    @Schema(
+        title = "Only purge files last modified before this date.",
+        description = "Set this to (or before) your `PurgeExecutions` retention window so only files of "
+            + "already-purged executions are deleted."
+    )
+    @NotNull
+    @PluginProperty(group = "main")
+    private Property<String> endDate;
+
+    @Schema(
+        title = "If true, only report what would be deleted without deleting anything."
+    )
+    @Builder.Default
+    @PluginProperty(group = "reliability")
+    private Property<Boolean> dryRun = Property.ofValue(true);
+
+    @Override
+    public PurgeStorage.Output run(RunContext runContext) throws Exception {
+        StoragePurgeService storagePurgeService = ((DefaultRunContext) runContext).services().additionalService(StoragePurgeService.class);
+
+        var flowInfo = runContext.flowInfo();
+        String rNamespace = runContext.render(this.namespace).as(String.class).orElse(null);
+        String rFlowId = runContext.render(this.flowId).as(String.class).orElse(null);
+        ZonedDateTime rStartDate = runContext.render(this.startDate).as(String.class).map(ZonedDateTime::parse).orElse(null);
+        ZonedDateTime rEndDate = ZonedDateTime.parse(runContext.render(this.endDate).as(String.class).orElseThrow());
+        boolean rDryRun = runContext.render(this.dryRun).as(Boolean.class).orElseThrow();
+
+        // Reject before the ACL check so the user sees the actual mistake, not an "all namespaces" denial.
+        if (rFlowId != null && rNamespace == null) {
+            throw new IllegalArgumentException("'namespace' is required when 'flowId' is set.");
+        }
+
+        if (rNamespace == null) {
+            runContext.acl().allowAllNamespaces().check();
+        } else if (!rNamespace.equals(flowInfo.namespace())) {
+            runContext.acl().allowNamespace(rNamespace).check();
+        }
+
+        runContext.logger().info(
+            "Starting PurgeStorage (dryRun={}) scope=[namespace={}, flowId={}] window=[{}, {}]",
+            rDryRun, rNamespace, rFlowId, rStartDate, rEndDate
+        );
+
+        StoragePurgeService.StoragePurgeResult result = storagePurgeService.purgeByLastModified(
+            flowInfo.tenantId(), rNamespace, rFlowId, rStartDate, rEndDate, rDryRun
+        );
+
+        runContext.logger().info(
+            "PurgeStorage complete (dryRun={}): scanned={}, purged={}, deletedFiles={}",
+            rDryRun, result.scannedCount(), result.purgedCount(), result.deletedFilesCount()
+        );
+
+        runContext.metric(Counter.of("scanned", result.scannedCount()));
+        runContext.metric(Counter.of("purged", result.purgedCount()));
+        runContext.metric(Counter.of("deleted.files", result.deletedFilesCount()));
+
+        return Output.builder()
+            .scannedCount(result.scannedCount())
+            .purgedCount(result.purgedCount())
+            .deletedFilesCount(result.deletedFilesCount())
+            .build();
+    }
+
+    @Builder
+    @Getter
+    public static class Output implements io.kestra.core.models.tasks.Output {
+        @Schema(title = "Number of execution storage subtrees scanned.")
+        private final int scannedCount;
+
+        @Schema(title = "Number of executions with at least one file in the date window (preserved when `dryRun` is true).")
+        private final int purgedCount;
+
+        @Schema(title = "Number of storage objects deleted (always 0 when `dryRun` is true).")
+        private final int deletedFilesCount;
+    }
+}

--- a/core/src/test/java/io/kestra/core/tasks/test/SanityCheckTest.java
+++ b/core/src/test/java/io/kestra/core/tasks/test/SanityCheckTest.java
@@ -121,4 +121,11 @@ class SanityCheckTest {
         assertThat(execution.getTaskRunList()).hasSize(2);
         assertThat(execution.getState().getCurrent()).isEqualTo(State.Type.SUCCESS);
     }
+
+    @Test
+    @ExecuteFlow("sanity-checks/purge_storage.yaml")
+    void qaPurgeStorage(Execution execution) {
+        assertThat(execution.getTaskRunList()).hasSize(5);
+        assertThat(execution.getState().getCurrent()).isEqualTo(State.Type.SUCCESS);
+    }
 }

--- a/core/src/test/java/io/kestra/plugin/core/storage/PurgeStorageTest.java
+++ b/core/src/test/java/io/kestra/plugin/core/storage/PurgeStorageTest.java
@@ -1,0 +1,325 @@
+package io.kestra.plugin.core.storage;
+
+import java.io.ByteArrayInputStream;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import io.kestra.core.context.TestRunContextFactory;
+import io.kestra.core.junit.annotations.KestraTest;
+import io.kestra.core.models.executions.Execution;
+import io.kestra.core.models.flows.Flow;
+import io.kestra.core.models.flows.GenericFlow;
+import io.kestra.core.models.flows.State;
+import io.kestra.core.models.property.Property;
+import io.kestra.core.repositories.FlowRepositoryInterface;
+import io.kestra.core.runners.RunContext;
+import io.kestra.core.storages.StorageContext;
+import io.kestra.core.storages.StorageInterface;
+import io.kestra.core.utils.IdUtils;
+import io.kestra.plugin.core.debug.Return;
+
+import jakarta.inject.Inject;
+
+import static io.kestra.core.tenant.TenantService.MAIN_TENANT;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@KestraTest
+class PurgeStorageTest {
+    @Inject
+    private TestRunContextFactory runContextFactory;
+
+    @Inject
+    private StorageInterface storageInterface;
+
+    @Inject
+    private FlowRepositoryInterface flowRepository;
+
+    private final List<Flow> createdFlows = new ArrayList<>();
+
+    @AfterEach
+    void cleanUp() {
+        createdFlows.forEach(flowRepository::delete);
+        createdFlows.clear();
+    }
+
+    /** In-flight guard: files newer than endDate are preserved. */
+    @Test
+    void shouldPreserveExecutionFilesNewerThanEndDate() throws Exception {
+        String namespace = uniqueNamespace();
+        String flowId = IdUtils.create();
+        createFlow(namespace, flowId);
+
+        URI fileUri = putExecutionFile(namespace, flowId, "still running");
+        assertThat(storageInterface.exists(MAIN_TENANT, namespace, fileUri)).isTrue();
+
+        var output = purgeStorage(namespace, flowId, ZonedDateTime.now().minusMinutes(1)).run(runContext(flowId, namespace));
+
+        assertThat(output.getScannedCount()).isEqualTo(1);
+        assertThat(output.getPurgedCount()).isZero();
+        assertThat(output.getDeletedFilesCount()).isZero();
+        assertThat(storageInterface.exists(MAIN_TENANT, namespace, fileUri)).isTrue();
+    }
+
+    /**
+     * Matching is per-file: within one execution, files older than endDate are deleted, newer files stay.
+     * The user's endDate is the in-flight guard — this task targets orphans (no live executions), so the
+     * trade-off of dropping the legacy "newest-file" subtree-level semantic is intentional.
+     */
+    @Test
+    void shouldMatchPerFileWithinAnExecution() throws Exception {
+        String namespace = uniqueNamespace();
+        String flowId = IdUtils.create();
+        createFlow(namespace, flowId);
+
+        Execution execution = newExecution(namespace, flowId);
+        URI oldFile = putFile(execution, "/tasks/task-a/run-1/old.txt", "old");
+        long oldMtime = lastModified(namespace, oldFile);
+
+        Thread.sleep(1_100);
+
+        URI newFile = putFile(execution, "/tasks/task-b/run-1/new.txt", "new");
+        long newMtime = lastModified(namespace, newFile);
+        assertThat(newMtime).isGreaterThan(oldMtime);
+
+        ZonedDateTime endDate = Instant.ofEpochMilli((oldMtime + newMtime) / 2).atZone(ZoneOffset.UTC);
+        purgeStorage(namespace, flowId, endDate).run(runContext(flowId, namespace));
+
+        assertThat(storageInterface.exists(MAIN_TENANT, namespace, oldFile)).isFalse();
+        assertThat(storageInterface.exists(MAIN_TENANT, namespace, newFile)).isTrue();
+    }
+
+    @Test
+    void shouldOnlyPurgeExecutionsWithinTheDateWindow() throws Exception {
+        String namespace = uniqueNamespace();
+        String flowId = IdUtils.create();
+        createFlow(namespace, flowId);
+
+        var files = putOldAndNewExecutionFiles(namespace, flowId);
+
+        var output = purgeStorage(namespace, flowId, files.midPoint()).run(runContext(flowId, namespace));
+
+        assertThat(output.getScannedCount()).isEqualTo(2);
+        assertThat(output.getPurgedCount()).isEqualTo(1);
+        assertThat(storageInterface.exists(MAIN_TENANT, namespace, files.oldFile())).isFalse();
+        assertThat(storageInterface.exists(MAIN_TENANT, namespace, files.newFile())).isTrue();
+    }
+
+    @Test
+    void shouldNotPurgeExecutionsOlderThanStartDate() throws Exception {
+        String namespace = uniqueNamespace();
+        String flowId = IdUtils.create();
+        createFlow(namespace, flowId);
+
+        var files = putOldAndNewExecutionFiles(namespace, flowId);
+
+        var purge = PurgeStorage.builder()
+            .namespace(Property.ofValue(namespace))
+            .flowId(Property.ofValue(flowId))
+            .dryRun(Property.ofValue(false))
+            .startDate(Property.ofValue(files.midPoint().format(DateTimeFormatter.ISO_ZONED_DATE_TIME)))
+            .endDate(Property.ofValue(ZonedDateTime.now().plusMinutes(1).format(DateTimeFormatter.ISO_ZONED_DATE_TIME)))
+            .build();
+        var output = purge.run(runContext(flowId, namespace));
+
+        assertThat(output.getScannedCount()).isEqualTo(2);
+        assertThat(output.getPurgedCount()).isEqualTo(1);
+        assertThat(storageInterface.exists(MAIN_TENANT, namespace, files.oldFile())).isTrue();
+        assertThat(storageInterface.exists(MAIN_TENANT, namespace, files.newFile())).isFalse();
+    }
+
+    @Test
+    void shouldMatchButNotDeleteWhenDryRun() throws Exception {
+        String namespace = uniqueNamespace();
+        String flowId = IdUtils.create();
+        createFlow(namespace, flowId);
+        URI fileUri = putExecutionFile(namespace, flowId, "keep me");
+
+        var output = purgeStorage(namespace, flowId, ZonedDateTime.now().plusMinutes(1), true).run(runContext(flowId, namespace));
+
+        assertThat(output.getPurgedCount()).isEqualTo(1);
+        assertThat(output.getDeletedFilesCount()).isZero();
+        assertThat(storageInterface.exists(MAIN_TENANT, namespace, fileUri)).isTrue();
+    }
+
+    /** Regression for <a href="https://github.com/kestra-io/kestra-ee/issues/6699">kestra-ee#6699</a>: storage of deleted flows must be reachable from a namespace-only scan. */
+    @Test
+    void shouldFindOrphansOfDeletedFlowsWhenScopedByNamespaceOnly() throws Exception {
+        String namespace = uniqueNamespace();
+        String flowId = IdUtils.create();
+        createFlow(namespace, flowId);
+        URI fileUri = putExecutionFile(namespace, flowId, "orphan from deleted flow");
+        flowRepository.delete(createdFlows.removeLast());
+
+        var purge = PurgeStorage.builder()
+            .namespace(Property.ofValue(namespace))
+            .dryRun(Property.ofValue(false))
+            .endDate(Property.ofValue(ZonedDateTime.now().plusMinutes(1).format(DateTimeFormatter.ISO_ZONED_DATE_TIME)))
+            .build();
+        var output = purge.run(runContext(flowId, namespace));
+
+        assertThat(output.getScannedCount()).isEqualTo(1);
+        assertThat(output.getPurgedCount()).isEqualTo(1);
+        assertThat(output.getDeletedFilesCount()).isGreaterThanOrEqualTo(1);
+        assertThat(storageInterface.exists(MAIN_TENANT, namespace, fileUri)).isFalse();
+    }
+
+    /** Namespace-scoped purge is recursive: it reaches sub-namespaces (e.g. {@code a.b} also purges {@code a.b.child}). */
+    @Test
+    void shouldReachSubNamespacesWhenScopedByNamespace() throws Exception {
+        String parentNamespace = uniqueNamespace();
+        String childNamespace = parentNamespace + ".child";
+        String parentFlowId = IdUtils.create();
+        String childFlowId = IdUtils.create();
+        createFlow(parentNamespace, parentFlowId);
+        createFlow(childNamespace, childFlowId);
+        URI parentFile = putExecutionFile(parentNamespace, parentFlowId, "in parent");
+        URI childFile = putExecutionFile(childNamespace, childFlowId, "in child");
+
+        var purge = PurgeStorage.builder()
+            .namespace(Property.ofValue(parentNamespace))
+            .dryRun(Property.ofValue(false))
+            .endDate(Property.ofValue(ZonedDateTime.now().plusMinutes(1).format(DateTimeFormatter.ISO_ZONED_DATE_TIME)))
+            .build();
+        var output = purge.run(runContext(parentFlowId, parentNamespace));
+
+        assertThat(output.getScannedCount()).isEqualTo(2);
+        assertThat(output.getPurgedCount()).isEqualTo(2);
+        assertThat(storageInterface.exists(MAIN_TENANT, parentNamespace, parentFile)).isFalse();
+        assertThat(storageInterface.exists(MAIN_TENANT, childNamespace, childFile)).isFalse();
+    }
+
+    /** Storage path /<ns>/executions/ is ambiguous between a flow named "executions" and a sub-namespace literally named "executions"; namespace-only scope skips it and requires explicit flowId. */
+    @Test
+    void shouldSkipAmbiguousExecutionsNameInNamespaceOnlyScan() throws Exception {
+        String namespace = uniqueNamespace();
+        String ambiguousFlowId = "executions";
+        createFlow(namespace, ambiguousFlowId);
+        URI fileUri = putExecutionFile(namespace, ambiguousFlowId, "may or may not be a flow");
+
+        var namespaceScope = PurgeStorage.builder()
+            .namespace(Property.ofValue(namespace))
+            .dryRun(Property.ofValue(false))
+            .endDate(Property.ofValue(ZonedDateTime.now().plusMinutes(1).format(DateTimeFormatter.ISO_ZONED_DATE_TIME)))
+            .build();
+        var namespaceOutput = namespaceScope.run(runContext(ambiguousFlowId, namespace));
+
+        assertThat(namespaceOutput.getScannedCount()).isZero();
+        assertThat(namespaceOutput.getPurgedCount()).isZero();
+        assertThat(storageInterface.exists(MAIN_TENANT, namespace, fileUri)).isTrue();
+
+        // Explicit flowId still works.
+        var explicitScope = PurgeStorage.builder()
+            .namespace(Property.ofValue(namespace))
+            .flowId(Property.ofValue(ambiguousFlowId))
+            .dryRun(Property.ofValue(false))
+            .endDate(Property.ofValue(ZonedDateTime.now().plusMinutes(1).format(DateTimeFormatter.ISO_ZONED_DATE_TIME)))
+            .build();
+        var explicitOutput = explicitScope.run(runContext(ambiguousFlowId, namespace));
+
+        assertThat(explicitOutput.getScannedCount()).isEqualTo(1);
+        assertThat(explicitOutput.getPurgedCount()).isEqualTo(1);
+        assertThat(storageInterface.exists(MAIN_TENANT, namespace, fileUri)).isFalse();
+    }
+
+    @Test
+    void shouldRequireNamespaceWhenFlowIdIsSet() {
+        var purge = PurgeStorage.builder()
+            .flowId(Property.ofValue("some-flow"))
+            .endDate(Property.ofValue(ZonedDateTime.now().format(DateTimeFormatter.ISO_ZONED_DATE_TIME)))
+            .build();
+
+        assertThatThrownBy(() -> purge.run(runContext("some-flow", "some.namespace")))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("namespace");
+    }
+
+    private void createFlow(String namespace, String flowId) {
+        Flow flow = Flow.builder()
+            .id(flowId)
+            .namespace(namespace)
+            .tenantId(MAIN_TENANT)
+            .tasks(List.of(Return.builder().id("return").type(Return.class.getName()).format(Property.ofValue("ok")).build()))
+            .build();
+        flowRepository.create(GenericFlow.of(flow));
+        createdFlows.add(flow);
+    }
+
+    private Execution newExecution(String namespace, String flowId) {
+        return Execution.builder()
+            .id(IdUtils.create())
+            .namespace(namespace)
+            .flowId(flowId)
+            .tenantId(MAIN_TENANT)
+            .state(new State().withState(State.Type.SUCCESS))
+            .build();
+    }
+
+    /** Writes one file under a fresh execution at {@code executions/{id}/tasks/my-task/my-run/output.txt}. */
+    private URI putExecutionFile(String namespace, String flowId, String content) throws Exception {
+        return putFile(newExecution(namespace, flowId), "/tasks/my-task/my-run/output.txt", content);
+    }
+
+    /** Writes two files ~1.1s apart so old/new mtimes are distinct on second-granularity filesystems. */
+    private OldNewFiles putOldAndNewExecutionFiles(String namespace, String flowId) throws Exception {
+        URI oldFile = putExecutionFile(namespace, flowId, "old");
+        long oldMtime = lastModified(namespace, oldFile);
+        Thread.sleep(1_100);
+        URI newFile = putExecutionFile(namespace, flowId, "new");
+        long newMtime = lastModified(namespace, newFile);
+        assertThat(newMtime).isGreaterThan(oldMtime);
+        return new OldNewFiles(oldFile, oldMtime, newFile, newMtime);
+    }
+
+    private URI putFile(Execution execution, String relativePath, String content) throws Exception {
+        URI fileUri = URI.create(StorageContext.forExecution(execution).getExecutionStorageURI() + relativePath);
+        storageInterface.put(
+            execution.getTenantId(),
+            execution.getNamespace(),
+            fileUri,
+            new ByteArrayInputStream(content.getBytes(StandardCharsets.UTF_8))
+        );
+        return fileUri;
+    }
+
+    private long lastModified(String namespace, URI fileUri) throws Exception {
+        return storageInterface.getAttributes(MAIN_TENANT, namespace, fileUri).getLastModifiedTime();
+    }
+
+    private PurgeStorage purgeStorage(String namespace, String flowId, ZonedDateTime endDate) {
+        return purgeStorage(namespace, flowId, endDate, false);
+    }
+
+    private PurgeStorage purgeStorage(String namespace, String flowId, ZonedDateTime endDate, boolean dryRun) {
+        return PurgeStorage.builder()
+            .namespace(Property.ofValue(namespace))
+            .flowId(Property.ofValue(flowId))
+            .dryRun(Property.ofValue(dryRun))
+            .endDate(Property.ofValue(endDate.format(DateTimeFormatter.ISO_ZONED_DATE_TIME)))
+            .build();
+    }
+
+    private RunContext runContext(String flowId, String namespace) {
+        return runContextFactory.of(flowId, namespace);
+    }
+
+    private static String uniqueNamespace() {
+        // Namespace segments must start with a letter; the id may start with a digit.
+        return "purgestorage.id" + IdUtils.create().toLowerCase();
+    }
+
+    private record OldNewFiles(URI oldFile, long oldMtime, URI newFile, long newMtime) {
+        ZonedDateTime midPoint() {
+            return Instant.ofEpochMilli((oldMtime + newMtime) / 2).atZone(ZoneOffset.UTC);
+        }
+    }
+}

--- a/core/src/test/resources/sanity-checks/purge_storage.yaml
+++ b/core/src/test/resources/sanity-checks/purge_storage.yaml
@@ -1,0 +1,41 @@
+id: purge_storage
+namespace: sanitychecks.core
+description: |
+  Sanity check for io.kestra.plugin.core.storage.PurgeStorage.
+  Phase 1: dryRun=true must preview matches without deleting (deletedFilesCount = 0).
+  Phase 2: dryRun=false must actually delete (deletedFilesCount > 0).
+
+tasks:
+  - id: write_marker
+    type: io.kestra.plugin.core.storage.Write
+    content: |
+      sanity-check marker
+    extension: .txt
+
+  - id: purge_dry_run
+    type: io.kestra.plugin.core.storage.PurgeStorage
+    namespace: sanitychecks.core
+    flowId: purge_storage
+    endDate: "{{ now() | dateAdd(1, 'DAYS') }}"
+    dryRun: true
+
+  - id: assert_dry_run_shape
+    type: io.kestra.plugin.core.execution.Assert
+    conditions:
+      - "{{ outputs.purge_dry_run.scannedCount >= 1 }}"
+      - "{{ outputs.purge_dry_run.purgedCount >= 1 }}"
+      - "{{ outputs.purge_dry_run.deletedFilesCount == 0 }}"
+
+  - id: purge_real
+    type: io.kestra.plugin.core.storage.PurgeStorage
+    namespace: sanitychecks.core
+    flowId: purge_storage
+    endDate: "{{ now() | dateAdd(1, 'DAYS') }}"
+    dryRun: false
+
+  - id: assert_real_shape
+    type: io.kestra.plugin.core.execution.Assert
+    conditions:
+      - "{{ outputs.purge_real.scannedCount >= 1 }}"
+      - "{{ outputs.purge_real.purgedCount >= 1 }}"
+      - "{{ outputs.purge_real.deletedFilesCount > 0 }}"


### PR DESCRIPTION
Backport of:
- kestra-io/kestra#16332 — feat: add task to remove orphan execution files (cherry-picked from 7b79ccd3)

Cherry-picked with `-x`. Adapted for the release branch:
- `PurgeStorage` no longer implements `SystemTask` (the SystemTask/SystemWorker framework is not on 1.3); it runs as a plain `RunnableTask`. The task only needs `StorageInterface`, so no behavioral change on 1.3 where workers retain storage access.
- `SanityCheckTest` uses `@KestraTest(startRunner = true)` (dropped `startSystemWorker`) and only the `qaPurgeStorage` check (the `qaIonBinary` block belonged to an unrelated develop commit and its flow is not on 1.3).

OSS and EE `releases/v1.3.x` compile locally.