### PR TITLE
fix(variables): let KVSTORE VIEW users read KV values without UPDATE

### DIFF
--- a/ui/src/components/kv/KVTable.vue
+++ b/ui/src/components/kv/KVTable.vue
@@ -103,6 +103,19 @@
             </template>
         </KsTableColumn>
 
+        <KsTableColumn v-if="!paneView" columnKey="view" className="row-action">
+            <template #default="scope">
+                <KsIconButton
+                    v-if="!canUpdate(scope.row) && canRead(scope.row)"
+                    :tooltip="$t('show')"
+                    placement="left"
+                    @click="viewKvModal(scope.row)"
+                >
+                    <Eye />
+                </KsIconButton>
+            </template>
+        </KsTableColumn>
+
         <KsTableColumn v-if="!paneView" columnKey="update" className="row-action">
             <template #default="scope">
                 <KsIconButton
@@ -231,6 +244,30 @@
     </KsDrawer>
 
     <KsDrawer
+        v-if="viewKvDrawerVisible"
+        v-model="viewKvDrawerVisible"
+        :title="$t('show')"
+    >
+        <KsForm class="ks-horizontal">
+            <KsFormItem v-if="viewKv.namespace" :label="$t('namespace')">
+                <KsInput :modelValue="viewKv.namespace" disabled />
+            </KsFormItem>
+            <KsFormItem :label="$t('key')">
+                <KsInput :modelValue="viewKv.key" disabled />
+            </KsFormItem>
+            <KsFormItem :label="$t('kv.type')">
+                <KsInput :modelValue="viewKv.type" disabled />
+            </KsFormItem>
+            <KsFormItem :label="$t('value')">
+                <KsInput type="textarea" :rows="5" :modelValue="viewKv.value" readonly />
+            </KsFormItem>
+            <KsFormItem v-if="viewKv.description" :label="$t('description')">
+                <KsInput :modelValue="viewKv.description" disabled />
+            </KsFormItem>
+        </KsForm>
+    </KsDrawer>
+
+    <KsDrawer
         v-if="namespacesStore.inheritedKVModalVisible"
         v-model="namespacesStore.inheritedKVModalVisible"
         :title="$t('kv.inherited')"
@@ -250,11 +287,13 @@
     import ContentCopy from "vue-material-design-icons/ContentCopy.vue"
     import ContentSave from "vue-material-design-icons/ContentSave.vue"
     import FileDocumentEdit from "vue-material-design-icons/FileDocumentEdit.vue"
+    import Eye from "vue-material-design-icons/Eye.vue"
 
     import {KsId, KsIconButton, KsEditor, KsFilter as KSFilter} from "@kestra-io/design-system"
     import {useEditorBindings} from "../../composables/useEditorBindings"
     import {useDiscardGuard} from "../../composables/useDiscardGuard"
     import InheritedKVs from "./InheritedKVs.vue"
+    import {formatKvValueForDisplay} from "./kvValueDisplay"
     import TimeSelect from "../executions/date-select/TimeSelect.vue"
     import NamespaceSelect from "../namespaces/components/NamespaceSelect.vue"
     import useRestoreUrl from "../../composables/useRestoreUrl"
@@ -495,6 +534,10 @@
         return kvItem.namespace !== undefined && authStore.user?.isAllowed(resource.KVSTORE, action.DELETE, kvItem.namespace)
     }
 
+    function canRead(kvItem: {namespace: string}) {
+        return kvItem.namespace !== undefined && authStore.user?.isAllowed(resource.KVSTORE, action.VIEW, kvItem.namespace)
+    }
+
     function jsonValidator(_rule: any, value: string, callback: (error?: Error) => void) {
         try {
             const parsed = JSON.parse(value)
@@ -548,6 +591,22 @@
         kv.value.update = true
         kv.value.description = entry.description
         addKvDrawerVisible.value = true
+    }
+
+    const viewKvDrawerVisible = ref(false)
+    const viewKv = ref<{namespace?: string; key?: string; type?: string; value?: string; description?: string}>({})
+
+    async function viewKvModal(entry: any) {
+        const {type, value} = await namespacesStore.kv({namespace: entry.namespace, key: entry.key})
+        const userTimezone = localStorage.getItem(storageKeys.TIMEZONE_STORAGE_KEY) || moment.tz.guess()
+        viewKv.value = {
+            namespace: entry.namespace,
+            key: entry.key,
+            type,
+            value: formatKvValueForDisplay(type, value, userTimezone),
+            description: entry.description,
+        }
+        viewKvDrawerVisible.value = true
     }
 
     function removeKv(namespace: string, key: string) {

--- a/ui/src/components/kv/kvValueDisplay.ts
+++ b/ui/src/components/kv/kvValueDisplay.ts
@@ -1,0 +1,17 @@
+import moment from "moment-timezone"
+
+/**
+ * Formats a KV value into a human-readable string for the read-only viewer.
+ * Kept pure (timezone passed in) so it can be unit-tested without the DOM.
+ */
+export function formatKvValueForDisplay(type: string, value: any, timezone?: string): string {
+    if (type === "JSON") {
+        return JSON.stringify(value, null, 2)
+    }
+    if (type === "DATETIME") {
+        // Follow Timezone from Settings to display KV of type DATETIME (issue #9428)
+        const tz = timezone || moment.tz.guess()
+        return moment(value).tz(tz).format()
+    }
+    return String(value)
+}

--- a/ui/tests/unit/components/kv/kvValueDisplay.spec.ts
+++ b/ui/tests/unit/components/kv/kvValueDisplay.spec.ts
@@ -1,0 +1,28 @@
+import {describe, test, expect} from "vitest"
+
+import {formatKvValueForDisplay} from "../../../../src/components/kv/kvValueDisplay"
+
+describe("formatKvValueForDisplay", () => {
+    test("STRING is rendered as-is", () => {
+        expect(formatKvValueForDisplay("STRING", "hello")).toBe("hello")
+    })
+
+    test("NUMBER is stringified", () => {
+        expect(formatKvValueForDisplay("NUMBER", 42)).toBe("42")
+    })
+
+    test("BOOLEAN is stringified", () => {
+        expect(formatKvValueForDisplay("BOOLEAN", true)).toBe("true")
+    })
+
+    test("JSON is pretty-printed", () => {
+        expect(formatKvValueForDisplay("JSON", {a: 1})).toBe("{\n  \"a\": 1\n}")
+    })
+
+    test("DATETIME is formatted in the provided timezone", () => {
+        const utc = formatKvValueForDisplay("DATETIME", "2024-01-01T00:00:00Z", "UTC")
+        expect(utc).toContain("2024-01-01")
+        const tokyo = formatKvValueForDisplay("DATETIME", "2024-01-01T00:00:00Z", "Asia/Tokyo")
+        expect(tokyo).toContain("2024-01-01T09:00:00")
+    })
+})


### PR DESCRIPTION
## What

Forward-port of #16743 (v1.3.x) to `develop` / 2.x, so the KV-read bug isn't reintroduced in the next major.

A user granted only **KV Store VIEW** on a namespace can see the KV list but cannot read a value — today the value is only reachable through the **edit drawer**, gated by `KVSTORE.UPDATE`. A VIEW-only user has no affordance to open it.

This adds a **read-only value viewer** (built with the `Ks*` design system):
- An eye/"Show" `KsIconButton` appears on a KV row when the user `canRead(row) && !canUpdate(row)` (read = `action.VIEW` on `develop`).
- Clicking it opens a read-only `KsDrawer` (namespace, key, type, value, description — all disabled/readonly).
- The value is fetched via the existing `GET /namespaces/{ns}/kv/{key}`, which already authorizes `KVSTORE.VIEW` — **no backend change**.

Value formatting is extracted into a pure helper `formatKvValueForDisplay()` and unit-tested.

## Why

On `develop` the KV list already works for KVSTORE-scoped users (global `/kv` + repo filter), so unlike v1.0.x no namespace-discovery change is needed — the only shared gap with v1.3.x is reading the value. This keeps 2.x consistent with the 1.x fixes.

## Tests

- New `kvValueDisplay.spec.ts` (STRING / NUMBER / BOOLEAN / JSON / DATETIME-tz) — 5/5 pass.
- `check:types` clean, eslint clean.

Refs kestra-io/kestra-ee#7023

> 2.x companion of #16743 (v1.3.x). v1.0.x: #16744 (OSS) + kestra-io/kestra-ee#8561 (EE).