### PR TITLE
fix : Remove isConcurrencyViewEnabled config flag and make Concurrency Limits view always visible

### DIFF
--- a/ui/src/override/components/useLeftMenu.ts
+++ b/ui/src/override/components/useLeftMenu.ts
@@ -355,7 +355,6 @@ export function useLeftMenu() {
                         icon: {
                             element: Battery40,
                         },
-                        hidden: !configs?.isConcurrencyViewEnabled,
                     },
                     {
                         id: "iam",

--- a/ui/src/override/components/useLeftMenu.ts
+++ b/ui/src/override/components/useLeftMenu.ts
@@ -9,9 +9,6 @@ import type {
 
 import {useI18n} from "vue-i18n"
 
-import {useMiscStore} from "override/stores/misc"
-
-
 // Main icons
 import AiMenuIcon from "../../components/ai/AiMenuIcon.vue"
 import ChartLineVariant from "vue-material-design-icons/ChartLineVariant.vue"
@@ -60,8 +57,6 @@ export function useLeftMenu() {
     const $router = useRouter()
 
     const {t} = useI18n({useScope: "global"})
-
-    const configs = useMiscStore().configs
 
     /**
      * Returns the names of all registered routes whose name starts with the given prefix.
@@ -354,7 +349,7 @@ export function useLeftMenu() {
                         },
                         icon: {
                             element: Battery40,
-                        },
+                        }
                     },
                     {
                         id: "iam",

--- a/webserver/src/main/java/io/kestra/webserver/controllers/api/MiscController.java
+++ b/webserver/src/main/java/io/kestra/webserver/controllers/api/MiscController.java
@@ -153,6 +153,7 @@ public class MiscController {
             .url(kestraUrl)
             .pluginsHash(pluginRegistry.hash())
             .chartDefaultDuration(this.chartDefaultDuration)
+            .flowTemplate(this.flowTemplate)
             ;
 
         if (this.environmentName != null || this.environmentColor != null) {

--- a/webserver/src/main/java/io/kestra/webserver/controllers/api/MiscController.java
+++ b/webserver/src/main/java/io/kestra/webserver/controllers/api/MiscController.java
@@ -153,8 +153,7 @@ public class MiscController {
             .url(kestraUrl)
             .pluginsHash(pluginRegistry.hash())
             .chartDefaultDuration(this.chartDefaultDuration)
-            .flowTemplate(this.flowTemplate)
-            .isConcurrencyViewEnabled(!this.queueType.equals("kafka"));
+            ;
 
         if (this.environmentName != null || this.environmentColor != null) {
             builder.environment(
@@ -318,8 +317,6 @@ public class MiscController {
         Boolean isBasicAuthInitialized;
 
         Long pluginsHash;
-
-        Boolean isConcurrencyViewEnabled;
     }
 
     @Value


### PR DESCRIPTION
Remove the `isConcurrencyViewEnabled` feature flag and make the Concurrency Limits admin view always visible.
## Changes
- **Backend**: Removed `isConcurrencyViewEnabled` from the `/configs` API response — deleted the field from the `Configuration` DTO and the builder line that computed it (`!queueType.equals("kafka")`) in `MiscController.java`.
- **Frontend**: Changed `useLeftMenu.ts` to hardcode `hidden: false` for the "Concurrency Limits" nav item, so it always renders regardless of any backend flag.
## Rationale
The flag was originally used to hide the Concurrency Limits view when using Kafka as the queue type. Since the view should now be displayed unconditionally, the feature flag is no longer needed.
#16529 