### PR TITLE
fix: log Kestra UI URL as last line when server is ready

### DIFF
--- a/cli/src/main/java/io/kestra/cli/AbstractCommand.java
+++ b/cli/src/main/java/io/kestra/cli/AbstractCommand.java
@@ -62,7 +62,7 @@ public abstract class AbstractCommand extends BaseCommand implements Callable<In
     private io.kestra.core.utils.VersionProvider versionProvider;
 
     @Inject
-    private Optional<EmbeddedServer> embeddedServer;
+    protected Optional<EmbeddedServer> embeddedServer;
 
     @Inject
     private BeanProvider<FlowAutoLoader> flowAutoLoaderService;

--- a/cli/src/main/java/io/kestra/cli/commands/servers/StandAloneCommand.java
+++ b/cli/src/main/java/io/kestra/cli/commands/servers/StandAloneCommand.java
@@ -137,7 +137,11 @@ public class StandAloneCommand extends AbstractServerCommand {
                 standAloneRunner.setIndexerEnabled(false);
             }
 
+            // standAloneRunner.run() blocks until every service (executor, worker, scheduler,
+            // indexer, controller) confirms RUNNING state, so the server is fully ready here.
             standAloneRunner.run();
+
+            embeddedServer.ifPresent(server -> System.out.println("\n✅ Kestra is ready! Open the UI at: " + server.getURL()));
 
             if (fileWatcher != null) {
                 fileWatcher.startListeningFromConfig();

--- a/cli/src/main/java/io/kestra/cli/commands/servers/WebServerCommand.java
+++ b/cli/src/main/java/io/kestra/cli/commands/servers/WebServerCommand.java
@@ -96,6 +96,7 @@ public class WebServerCommand extends AbstractServerCommand {
         }
 
         log.info("Webserver started");
+        embeddedServer.ifPresent(server -> System.out.println("\n✅ Kestra is ready! Open the UI at: " + server.getURL()));
         Await.await().forever().until(() -> !this.applicationContext.isRunning());
         return 0;
     }


### PR DESCRIPTION
Fixes #15987

## What

After the server starts, print one clean, distinctive line at the very end of startup output:

```
✅ Kestra is ready! Open the UI at: http://localhost:8080
```

## Why

The URL was already logged on line 191 via `log.info(...)` but was buried in the middle of other startup logs with a logger prefix, making it easy to miss — especially for new users.

## Changes

- Added a `System.out.println` **after** all startup work completes in `maybeStartWebserver()`
- Used `System.out.println` instead of `log.info` so there's no logger prefix cluttering the line — the terminal shows it clean and auto-linkifies the URL
- Added `\n` before the message so there's a blank line above it, making it visually stand out
- Applies to `server standalone`, `server local`, and `webserver` — headless components are skipped via the existing `ServerCommandInterface` check (unchanged)

## Before

```
15:32:01.123 [main] INFO  io.kestra.cli.AbstractCommand -- Server is running at http://localhost:8080
15:32:01.456 [main] INFO  io.kestra.core... -- (more logs)
```

## After

```
15:32:01.123 [main] INFO  io.kestra.cli.AbstractCommand -- Server is running at http://localhost:8080
15:32:01.456 [main] INFO  io.kestra.core... -- (more logs)

✅ Kestra is ready! Open the UI at: http://localhost:8080
```