### PR TITLE
fix(flows): unify the flow tab selector across all flow tabs

### DIFF
--- a/ui/src/components/flows/FlowRoot.vue
+++ b/ui/src/components/flows/FlowRoot.vue
@@ -5,7 +5,7 @@
             :activeTabName="activeTabName"
         />
         <section
-            v-if="isEditTabActive && activeTab"
+            v-if="activeTab"
             :class="[containerClass, {maximized: activeTab.maximized, 'no-overflow': activeTab.noOverflow}, 'padding']"
         >
             <component
@@ -15,12 +15,6 @@
                 @expand-subflow="updateExpandedSubflows"
             />
         </section>
-        <Tabs
-            v-else
-            routeName="flows/update"
-            :tabs="tabs"
-            @expand-subflow="updateExpandedSubflows"
-        />
     </template>
 </template>
 
@@ -194,16 +188,12 @@
         })
 
         function syncTabsToStore() {
-            if (isEditTabActive.value) {
-                routeTabsStore.setTabs({
-                    ownerId: tabsOwnerId,
-                    tabs: tabs.value,
-                    routeName: "flows/update",
-                    displayMode: "select",
-                })
-            } else {
-                routeTabsStore.clearTabsIfOwner(tabsOwnerId)
-            }
+            routeTabsStore.setTabs({
+                ownerId: tabsOwnerId,
+                tabs: tabs.value,
+                routeName: "flows/update",
+                displayMode: "select",
+            })
         }
 
         function updateExpandedSubflows(expandedSubflows: any) {
@@ -216,8 +206,6 @@
         })
 
         const activeTabName = computed(() => activeTab.value?.name ?? "home")
-
-        const isEditTabActive = computed(() => activeTab.value?.name === "edit")
 
         const containerClass = computed(() => {
             if (activeTab.value?.locked) return {"px-0": true, "full-container": true}
@@ -257,7 +245,7 @@
 
         watch(() => route.fullPath, () => handleTitle())
 
-        watch([tabs, isEditTabActive], () => syncTabsToStore(), {immediate: true, deep: true})
+        watch(tabs, () => syncTabsToStore(), {immediate: true, deep: true})
 
         watch(route, (newValue, oldValue) => {
             if (oldValue.name === newValue.name) {
@@ -319,7 +307,6 @@
             tabs,
             activeTab,
             activeTabName,
-            isEditTabActive,
             containerClass,
             routeInfo,
             ready,
@@ -330,11 +317,10 @@
 
 <script setup lang="ts">
     import FlowRootTopBar from "./FlowRootTopBar.vue"
-    import Tabs from "../Tabs.vue"
 
     withDefaults(defineProps<{embed?: boolean}>(), {embed: false})
 
-    const {tabs, activeTab, activeTabName, isEditTabActive, containerClass, routeInfo, ready, updateExpandedSubflows} = useFlowRoot()
+    const {activeTab, activeTabName, containerClass, routeInfo, ready, updateExpandedSubflows} = useFlowRoot()
 </script>
 <style scoped lang="scss">
     .gray-700 {


### PR DESCRIPTION
## What

On the Flow detail page, only the **Edit** tab used the compact dropdown selector in the top nav bar. Every other flow tab (Overview, Executions, Logs, Triggers, …) rendered a separate **horizontal tab bar** instead. The selector changed shape depending on which tab you were on, which is confusing — see the EE issue thread (Rob, new to Kestra, was surprised the selector differed across tabs).

This unifies the selector: **all** flow tabs now use the same single dropdown selector in the top nav bar that the Edit tab already used.

## How

In `ui/src/components/flows/FlowRoot.vue`:
- `syncTabsToStore` now pushes the flow tab list into the top-nav dropdown (`displayMode: "select"`) for **all** tabs, not just Edit.
- The template renders the active tab's content inline for every tab and drops the `<Tabs>` horizontal-bar branch.
- Removed the now-unused `isEditTabActive` computed, the `Tabs` import, and dead destructured bindings.

The inline content `<section class="container tabs-flush-top">` is structurally identical to the section `KsRouterTab` already rendered, so content layout is preserved — only the horizontal bar is gone and the dropdown is now present everywhere.

## Verification

Ran the OSS UI against a local backend:
- Overview / Executions (non-Edit tabs): dropdown selector present, content renders, no horizontal bar, no double selector.
- Dropdown lists all tabs and switches routes correctly (Dependencies disabled at 0 deps, as before).
- Edit tab unchanged (dropdown + editor intact).
- Verified in light and dark mode, zero console errors.
- `eslint` clean; the existing `flow.spec.ts` e2e already navigates via the dropdown (`.tab-select` + `getByRole("option")`), so it stays green.

## Coordination

EE imports the shared `useFlowRoot` from this module. This OSS PR is the shared half; the EE companion PR mirrors the template change and closes the issue. **This PR should land (and EE pick it up) before the EE template change goes live**, otherwise EE's non-Edit tabs would briefly have neither a dropdown nor a tab bar.

Part of https://github.com/kestra-io/kestra-ee/issues/8572

🤖 Generated with [Claude Code](https://claude.com/claude-code)