### PR TITLE
[backport releases/v1.3.x] fix(tasks): PurgeLogs should match namespace as a prefix

### DIFF
--- a/core/src/test/java/io/kestra/core/repositories/AbstractLogRepositoryTest.java
+++ b/core/src/test/java/io/kestra/core/repositories/AbstractLogRepositoryTest.java
@@ -335,6 +335,26 @@ public abstract class AbstractLogRepositoryTest {
     }
 
     @Test
+    void deleteByQueryWithNamespacePrefix() {
+        String tenant = TestsUtils.randomTenant(this.getClass().getSimpleName());
+        LogEntry parent = logEntry(tenant, Level.INFO, "exec-parent").namespace("io.kestra.purge").build();
+        LogEntry child = logEntry(tenant, Level.INFO, "exec-child").namespace("io.kestra.purge.child").build();
+        LogEntry sibling = logEntry(tenant, Level.INFO, "exec-sibling").namespace("io.kestra.purgeother").build();
+        logRepository.save(parent);
+        logRepository.save(child);
+        logRepository.save(sibling);
+
+        // Without a flowId, the namespace is a prefix: the namespace itself and its descendants are
+        // purged, while sibling namespaces sharing a textual prefix (io.kestra.purgeother) are kept.
+        int deleted = logRepository.deleteByQuery(tenant, "io.kestra.purge", null, null, null, null, ZonedDateTime.now().plusMinutes(1));
+
+        assertThat(deleted).isEqualTo(2);
+        assertThat(logRepository.findByExecutionId(tenant, parent.getExecutionId(), null)).isEmpty();
+        assertThat(logRepository.findByExecutionId(tenant, child.getExecutionId(), null)).isEmpty();
+        assertThat(logRepository.findByExecutionId(tenant, sibling.getExecutionId(), null)).hasSize(1);
+    }
+
+    @Test
     void findAllAsync() {
         String tenant = TestsUtils.randomTenant(this.getClass().getSimpleName());
         logRepository.save(logEntry(tenant, Level.INFO).build());

--- a/jdbc/src/main/java/io/kestra/jdbc/repository/AbstractJdbcLogRepository.java
+++ b/jdbc/src/main/java/io/kestra/jdbc/repository/AbstractJdbcLogRepository.java
@@ -239,7 +239,14 @@ public abstract class AbstractJdbcLogRepository extends AbstractJdbcCrudReposito
             }
 
             if (namespace != null) {
-                delete = delete.and(field("namespace").eq(namespace));
+                // Without a flowId, the namespace is a prefix: it matches the namespace itself and all
+                // its descendants, consistent with the documented behavior and PurgeExecutions. With a
+                // flowId, it targets that flow's exact namespace.
+                if (flowId != null) {
+                    delete = delete.and(field("namespace").eq(namespace));
+                } else {
+                    delete = delete.and(field("namespace").eq(namespace).or(field("namespace").startsWith(namespace + ".")));
+                }
             }
 
             if (flowId != null) {


### PR DESCRIPTION
Backport of:
- kestra-io/kestra#16720 — fix(tasks): PurgeLogs should match namespace as a prefix (cherry-picked from 67ceef74)

Cherry-picked with `-x`. The fix was adapted to the release branch: `develop` had extracted the condition logic into a `buildDeleteCondition(...)` helper that doesn't exist on `releases/v1.3.x`, so the prefix-match logic was applied inline in `deleteByQuery(...)`, and the test was adapted to the 7-arg `deleteByQuery` signature available on the branch.

OSS and EE `releases/v1.3.x` compile locally.