### PR TITLE
fix(apps): check routes before href in isItemActive to prevent false sidebar highlights

### DIFF
--- a/ui/src/components/layout/SideBar.vue
+++ b/ui/src/components/layout/SideBar.vue
@@ -152,8 +152,8 @@
     }
 
     function isItemActive(item: MenuItem): boolean {
-        if (typeof item.href !== "string" || item.href === "/") return false
         if (item.routes) return item.routes.includes($route.name)
+        if (typeof item.href !== "string" || item.href === "/") return false
         return $route.path.startsWith(item.href)
     }
 


### PR DESCRIPTION
## Summary
- Fix `isItemActive` in `SideBar.vue` to check `item.routes` before falling back to the `href` path-prefix check
- Previously, when `routes` was defined but checked after the `href` guard, items could incorrectly highlight via path prefix matching

## Test plan
- [ ] Navigate to Apps page — only "Apps" sidebar item should be active
- [ ] Navigate to Apps Catalog — only "Apps Catalog" sidebar item should be active, not "Apps"
- [ ] Verify other sidebar items are unaffected

Closes https://github.com/kestra-io/kestra-ee/issues/8451.