### PR TITLE
test(runner): fix flaky tests with root-cause fixes instead of @FlakyTest

### DIFF
--- a/core/src/test/java/io/kestra/plugin/core/flow/WorkingDirectoryTest.java
+++ b/core/src/test/java/io/kestra/plugin/core/flow/WorkingDirectoryTest.java
@@ -56,6 +56,7 @@ import lombok.experimental.SuperBuilder;
 
 import static io.kestra.core.tenant.TenantService.MAIN_TENANT;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -286,7 +287,7 @@ public class WorkingDirectoryTest {
                 )
             ).containsAllEntriesOf(Map.of("uris", Collections.emptyMap()));
             assertThat(execution.getState().getCurrent()).isEqualTo(State.Type.SUCCESS);
-            assertTrue(storageInterface.exists(MAIN_TENANT, null, cacheURI));
+            await().atMost(Duration.ofSeconds(10)).until(() -> storageInterface.exists(MAIN_TENANT, null, cacheURI));
 
             // a second run should use the cache so the task `exists` should output the cached file
             execution = runnerUtils.runOne(MAIN_TENANT, "io.kestra.tests", "working-directory-cache");

--- a/worker/src/test/java/io/kestra/worker/stores/GrpcWorkerExecutionLogMetaStoreTest.java
+++ b/worker/src/test/java/io/kestra/worker/stores/GrpcWorkerExecutionLogMetaStoreTest.java
@@ -8,6 +8,7 @@ import org.slf4j.event.Level;
 
 import io.kestra.controller.grpc.ExecutionLogsServiceGrpc;
 import io.kestra.core.junit.annotations.KestraTest;
+import io.micronaut.context.annotation.Property;
 import io.kestra.core.models.executions.LogEntry;
 import io.kestra.core.repositories.LogRepositoryInterface;
 import io.kestra.core.utils.IdUtils;
@@ -17,6 +18,7 @@ import jakarta.inject.Inject;
 import static org.junit.jupiter.api.Assertions.*;
 
 @KestraTest
+@Property(name = "test.context.id", value = "grpc-exec-log")
 class GrpcWorkerExecutionLogMetaStoreTest extends AbstractGrpcMetaStoreTest {
 
     @Inject

--- a/worker/src/test/java/io/kestra/worker/stores/GrpcWorkerFlowMetaStoreTest.java
+++ b/worker/src/test/java/io/kestra/worker/stores/GrpcWorkerFlowMetaStoreTest.java
@@ -23,6 +23,7 @@ import jakarta.inject.Inject;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @KestraTest
+@io.micronaut.context.annotation.Property(name = "test.context.id", value = "grpc-flow")
 class GrpcWorkerFlowMetaStoreTest extends AbstractGrpcMetaStoreTest {
 
     @Inject

--- a/worker/src/test/java/io/kestra/worker/stores/GrpcWorkerKVMetadataStateStoreTest.java
+++ b/worker/src/test/java/io/kestra/worker/stores/GrpcWorkerKVMetadataStateStoreTest.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.Test;
 
 import io.kestra.controller.grpc.KVMetadataServiceGrpc.KVMetadataServiceBlockingStub;
 import io.kestra.core.junit.annotations.KestraTest;
+import io.micronaut.context.annotation.Property;
 import io.kestra.core.models.kv.PersistedKvMetadata;
 import io.kestra.core.runners.KVMetadataStateStore;
 import io.kestra.core.utils.TestsUtils;
@@ -18,6 +19,7 @@ import jakarta.inject.Inject;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @KestraTest
+@Property(name = "test.context.id", value = "grpc-kv")
 class GrpcWorkerKVMetadataStateStoreTest extends AbstractGrpcMetaStoreTest {
 
     @Inject

--- a/worker/src/test/java/io/kestra/worker/stores/GrpcWorkerNamespaceFileMetadataStateStoreTest.java
+++ b/worker/src/test/java/io/kestra/worker/stores/GrpcWorkerNamespaceFileMetadataStateStoreTest.java
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.Test;
 
 import io.kestra.controller.grpc.NamespaceFileMetadataServiceGrpc.NamespaceFileMetadataServiceBlockingStub;
 import io.kestra.core.junit.annotations.KestraTest;
+import io.micronaut.context.annotation.Property;
 import io.kestra.core.models.namespaces.files.NamespaceFileMetadata;
 import io.kestra.core.namespace.NamespaceFileMetadataStateStore;
 import io.kestra.core.utils.TestsUtils;
@@ -17,6 +18,7 @@ import jakarta.inject.Inject;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @KestraTest
+@Property(name = "test.context.id", value = "grpc-ns-file")
 class GrpcWorkerNamespaceFileMetadataStateStoreTest extends AbstractGrpcMetaStoreTest {
 
     @Inject


### PR DESCRIPTION
## Summary

Root-cause fix alternative to two open \`@FlakyTest\` PRs:
- Supersedes #8486 (\`workingDirectoryCache\` marked \`@FlakyTest\` in \`KafkaRunnerTest\`)
- Supersedes the OSS part of #16649 (\`AbstractGrpcMetaStoreTest\` marked \`@FlakyTest\`)

Companion EE fix: kestra-io/kestra-ee#8603

### \`WorkingDirectoryTest.Suite#cache()\` — Kafka async write race

**Root cause:** In Kafka mode the execution reaches \`SUCCESS\` (what \`runOne()\` waits for) just before the cache file write flushes to the storage layer. The one-shot \`assertTrue(storageInterface.exists(...))\` had zero tolerance for this lag.

**Fix:** Replace with \`await().atMost(Duration.ofSeconds(10)).until(...)\`. The test still fails if the file never appears — just with a meaningful timeout instead of a spurious one-shot false-negative.

### \`GrpcMetaStore*Test\` subclasses — shared Micronaut context port conflict

**Root cause:** All concrete subclasses had identical \`@KestraTest\` annotations → Micronaut cached a single shared context → \`${random.port}\` was evaluated once. When one subclass's \`@AfterAll stopController()\` closed the gRPC server and the next subclass's \`@BeforeAll startController()\` tried to rebind the same port, the OS port was still in \`TIME_WAIT\`, causing spurious \`IOException: Failed to bind to address\`.

**Fix:** Add a unique \`@Property(name = "test.context.id", value = "...")\` sentinel to each concrete subclass. Each class gets its own Micronaut context → its own fresh \`${random.port}\` → isolated ports, no \`TIME_WAIT\` conflict.

## Test plan

- [ ] \`./gradlew :core:test --tests "*.WorkingDirectoryTest"\` — confirm \`workingDirectoryCache\` passes
- [ ] \`./gradlew :worker:test --tests "*.Grpc*MetaStore*"\` — confirm no bind failures across all 4 subclasses