### PR TITLE
fix(cli): recover --config option when placed before the subcommand

### DIFF
--- a/cli/src/main/java/io/kestra/cli/AbstractCommand.java
+++ b/cli/src/main/java/io/kestra/cli/AbstractCommand.java
@@ -223,6 +223,10 @@ public abstract class AbstractCommand extends BaseCommand implements Callable<In
         );
     }
 
+    void setConfig(Path config) {
+        this.config = config;
+    }
+
     @SuppressWarnings({ "unused" })
     public Map<String, Object> propertiesFromConfig() {
         if (this.config.toFile().exists()) {

--- a/cli/src/main/java/io/kestra/cli/Kestra.java
+++ b/cli/src/main/java/io/kestra/cli/Kestra.java
@@ -114,7 +114,7 @@ public class Kestra implements Callable<Integer> {
         return exitCode;
     }
 
-    static CommandLine getCommandLine(Class<?> cls, String[] args) {
+    private static CommandLine getCommandLine(Class<?> cls, String[] args) {
         CommandLine cmd = new CommandLine(cls, CommandLine.defaultFactory());
         continueOnParsingErrors(cmd);
 

--- a/cli/src/main/java/io/kestra/cli/Kestra.java
+++ b/cli/src/main/java/io/kestra/cli/Kestra.java
@@ -3,6 +3,7 @@ package io.kestra.cli;
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.nio.file.Paths;
 import java.util.*;
 import java.util.concurrent.Callable;
 import java.util.stream.Stream;
@@ -113,14 +114,43 @@ public class Kestra implements Callable<Integer> {
         return exitCode;
     }
 
-    private static CommandLine getCommandLine(Class<?> cls, String[] args) {
+    static CommandLine getCommandLine(Class<?> cls, String[] args) {
         CommandLine cmd = new CommandLine(cls, CommandLine.defaultFactory());
         continueOnParsingErrors(cmd);
 
         CommandLine.ParseResult parseResult = cmd.parseArgs(args);
         List<CommandLine> parsedCommands = parseResult.asCommandLineList();
+        CommandLine leafCmd = parsedCommands.getLast();
 
-        return parsedCommands.getLast();
+        // continueOnParsingErrors silently drops unrecognized options at the root level,
+        // including --config/-c when it appears before the subcommand name. Recover it here.
+        recoverConfigOption(args, leafCmd);
+
+        return leafCmd;
+    }
+
+    /**
+     * If {@code --config/-c} was placed before the subcommand name it is silently swallowed by
+     * {@code continueOnParsingErrors}. This method scans the raw args for a config path and
+     * injects it into the leaf command so that {@code propertiesFromConfig()} picks it up.
+     */
+    private static void recoverConfigOption(String[] args, CommandLine leafCmd) {
+        Object userObject = leafCmd.getCommandSpec().userObject();
+        if (!(userObject instanceof AbstractCommand abstractCmd)) {
+            return;
+        }
+        // If --config was already parsed on the leaf command (placed after the subcommand), nothing to do.
+        CommandLine.ParseResult leafResult = leafCmd.getParseResult();
+        if (leafResult != null && leafResult.matchedOptions().stream()
+                .anyMatch(opt -> opt.longestName().equals("--config"))) {
+            return;
+        }
+        for (int i = 0; i < args.length - 1; i++) {
+            if ("--config".equals(args[i]) || "-c".equals(args[i])) {
+                abstractCmd.setConfig(Paths.get(args[i + 1]));
+                break;
+            }
+        }
     }
 
     public static ApplicationContext applicationContext(Class<?> mainClass,
@@ -147,10 +177,13 @@ public class Kestra implements Callable<Integer> {
         Class<?> cls = commandLine.getCommandSpec().userObject().getClass();
 
         if (AbstractCommand.class.isAssignableFrom(cls)) {
-            // if class have propertiesFromConfig, add configuration files
-            builder.properties(getPropertiesFromMethod(cls, "propertiesFromConfig", commandLine.getCommandSpec().userObject()));
-
             Map<String, Object> properties = new HashMap<>();
+
+            // if class have propertiesFromConfig, add configuration files
+            Map<String, Object> configProperties = getPropertiesFromMethod(cls, "propertiesFromConfig", commandLine.getCommandSpec().userObject());
+            if (configProperties != null) {
+                properties.putAll(configProperties);
+            }
 
             // if class have propertiesOverrides, add force properties for this class
             Map<String, Object> propertiesOverrides = getPropertiesFromMethod(cls, "propertiesOverrides", null);

--- a/cli/src/test/java/io/kestra/cli/KestraTest.java
+++ b/cli/src/test/java/io/kestra/cli/KestraTest.java
@@ -2,6 +2,7 @@ package io.kestra.cli;
 
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
+import java.lang.reflect.Method;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
@@ -10,10 +11,10 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
 import io.kestra.core.models.ServerType;
+import picocli.CommandLine;
 
 import io.micronaut.context.ApplicationContext;
 import io.micronaut.context.env.Environment;
-import picocli.CommandLine;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -64,16 +65,20 @@ class KestraTest {
             Files.writeString(configFile, "kestra:\n  test:\n    marker: config-loaded\n");
 
             // --config BEFORE "plugins" — this is the position that previously failed.
-            // plugins list extends AbstractCommand (no required positional args), so the
-            // parse chain completes cleanly and recoverConfigOption() can inject the config.
             String[] args = { "--config", configFile.toString(), "plugins", "list" };
 
-            CommandLine leafCmd = Kestra.getCommandLine(Kestra.class, args);
-            Object userObject = leafCmd.getCommandSpec().userObject();
+            // Access the private getCommandLine() via reflection — keeps it private in
+            // production code while still letting us verify recoverConfigOption() works.
+            // We deliberately avoid creating an ApplicationContext here because doing so
+            // has global side effects in the test JVM (datasource / gRPC initialization)
+            // that break subsequent tests.
+            Method getCommandLine = Kestra.class.getDeclaredMethod("getCommandLine", Class.class, String[].class);
+            getCommandLine.setAccessible(true);
+            CommandLine leafCmd = (CommandLine) getCommandLine.invoke(null, Kestra.class, args);
 
+            Object userObject = leafCmd.getCommandSpec().userObject();
             assertThat(userObject).isInstanceOf(AbstractCommand.class);
             AbstractCommand abstractCmd = (AbstractCommand) userObject;
-            // Verify the config path was injected and propertiesFromConfig() reads the right file
             assertThat(abstractCmd.propertiesFromConfig())
                 .containsEntry("kestra.test.marker", "config-loaded");
         } finally {

--- a/cli/src/test/java/io/kestra/cli/KestraTest.java
+++ b/cli/src/test/java/io/kestra/cli/KestraTest.java
@@ -2,6 +2,8 @@ package io.kestra.cli;
 
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -11,6 +13,7 @@ import io.kestra.core.models.ServerType;
 
 import io.micronaut.context.ApplicationContext;
 import io.micronaut.context.env.Environment;
+import picocli.CommandLine;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -47,6 +50,35 @@ class KestraTest {
         assertThat(Kestra.runCli(args)).isZero();
 
         assertThat(out.toString()).contains("Usage: kestra server " + serverType);
+    }
+
+    @Test
+    void configBeforeSubcommandIsLoaded() throws Exception {
+        // Regression test for: --config placed before the subcommand name was silently
+        // dropped by continueOnParsingErrors (introduced in v1.2.0), causing the config
+        // file to be ignored and startup to fail with NoSuchBeanException on EE builds.
+        // Fix: Kestra.recoverConfigOption() scans raw args and injects the config path into
+        // the leaf command instance after continueOnParsingErrors swallows the option.
+        Path configFile = Files.createTempFile("kestra-test-", ".yml");
+        try {
+            Files.writeString(configFile, "kestra:\n  test:\n    marker: config-loaded\n");
+
+            // --config BEFORE "plugins" — this is the position that previously failed.
+            // plugins list extends AbstractCommand (no required positional args), so the
+            // parse chain completes cleanly and recoverConfigOption() can inject the config.
+            String[] args = { "--config", configFile.toString(), "plugins", "list" };
+
+            CommandLine leafCmd = Kestra.getCommandLine(Kestra.class, args);
+            Object userObject = leafCmd.getCommandSpec().userObject();
+
+            assertThat(userObject).isInstanceOf(AbstractCommand.class);
+            AbstractCommand abstractCmd = (AbstractCommand) userObject;
+            // Verify the config path was injected and propertiesFromConfig() reads the right file
+            assertThat(abstractCmd.propertiesFromConfig())
+                .containsEntry("kestra.test.marker", "config-loaded");
+        } finally {
+            Files.deleteIfExists(configFile);
+        }
     }
 
     @Test


### PR DESCRIPTION
## Summary

- Since v1.2.0, `continueOnParsingErrors` silently drops `--config`/`-c` when placed before the subcommand name (e.g. `kestra --config /path server standalone`), causing the config file to be ignored and EE builds to fail with `NoSuchBeanException` for `TenantRepositoryInterface`
- Add `recoverConfigOption()` to scan raw args after picocli parsing and inject the config path into the leaf command via `setConfig()`, so `propertiesFromConfig()` reads the correct file
- Add `setConfig(Path)` package-private setter on `AbstractCommand` for the injection

Closes https://github.com/kestra-io/kestra-ee/issues/8564

Companion fix for releases/v1.3.x: https://github.com/kestra-io/kestra/commits/releases/v1.3.x (commit 4e75d21b5)

## Test plan

- [x] `KestraTest.configBeforeSubcommandIsLoaded` — new regression test: verifies that when `--config /path` is placed before the subcommand, `recoverConfigOption()` injects the config path so `propertiesFromConfig()` reads the right file
- [x] Full `cli` test suite passes with no new failures (9 pre-existing failures are infra-related, not code changes)