### PR TITLE
fix: propagate forced execution to flowable children

### DIFF
--- a/core/src/test/java/io/kestra/core/runners/AbstractRunnerTest.java
+++ b/core/src/test/java/io/kestra/core/runners/AbstractRunnerTest.java
@@ -713,6 +713,12 @@ public abstract class AbstractRunnerTest {
     }
 
     @Test
+    @ExecuteFlow("flows/valids/after-execution-flowable.yaml")
+    public void shouldCallFlowableTasksAfterExecution(Execution execution) {
+        afterExecutionTestCase.shouldCallFlowableTasksAfterExecution(execution);
+    }
+
+    @Test
     @LoadFlows({ "flows/valids/workertask-result-too-large.yaml" })
     protected void workerTaskResultTooLarge() throws Exception {
         List<LogEntry> logs = new CopyOnWriteArrayList<>();

--- a/core/src/test/java/io/kestra/core/runners/AfterExecutionTestCase.java
+++ b/core/src/test/java/io/kestra/core/runners/AfterExecutionTestCase.java
@@ -78,4 +78,14 @@ public class AfterExecutionTestCase {
         Map<String, Object> outputs = (Map<String, Object>) taskOutputService.getOutputs(afterExecution).get("values");
         assertThat(outputs.get("state")).isEqualTo("FAILED");
     }
+
+    public void shouldCallFlowableTasksAfterExecution(Execution execution) {
+        assertThat(execution.getState().getCurrent()).isEqualTo(SUCCESS);
+        assertThat(execution.getTaskRunList()).hasSize(4);
+
+        assertThat(execution.findTaskRunsByTaskId("mytask").getFirst().getState().getCurrent()).isEqualTo(SUCCESS);
+        assertThat(execution.findTaskRunsByTaskId("after_if").getFirst().getState().getCurrent()).isEqualTo(SUCCESS);
+        assertThat(execution.findTaskRunsByTaskId("after_if_log").getFirst().getState().getCurrent()).isEqualTo(SUCCESS);
+        assertThat(execution.findTaskRunsByTaskId("after_end").getFirst().getState().getCurrent()).isEqualTo(SUCCESS);
+    }
 }

--- a/core/src/test/resources/flows/valids/after-execution-flowable.yaml
+++ b/core/src/test/resources/flows/valids/after-execution-flowable.yaml
@@ -1,0 +1,20 @@
+id: after-execution-flowable
+namespace: io.kestra.tests
+
+tasks:
+  - id: mytask
+    type: io.kestra.plugin.core.debug.Return
+    format: done
+
+afterExecution:
+  - id: after_if
+    type: io.kestra.plugin.core.flow.If
+    condition: "{{ true }}"
+    then:
+      - id: after_if_log
+        type: io.kestra.plugin.core.log.Log
+        message: after execution if child ran
+
+  - id: after_end
+    type: io.kestra.plugin.core.log.Log
+    message: after execution following task ran

--- a/core/src/test/resources/flows/valids/sleep-long-after-execution-flowable.yml
+++ b/core/src/test/resources/flows/valids/sleep-long-after-execution-flowable.yml
@@ -1,0 +1,20 @@
+id: sleep-long-after-execution-flowable
+namespace: io.kestra.tests
+
+tasks:
+  - id: sleep-long
+    type: io.kestra.plugin.core.flow.Sleep
+    duration: PT30S
+
+afterExecution:
+  - id: after-if
+    type: io.kestra.plugin.core.flow.If
+    condition: "{{ true }}"
+    then:
+      - id: after-if-log
+        type: io.kestra.plugin.core.log.Log
+        message: after execution if child ran
+
+  - id: after-end
+    type: io.kestra.plugin.core.log.Log
+    message: after execution following task ran

--- a/executor/src/main/java/io/kestra/executor/ExecutorService.java
+++ b/executor/src/main/java/io/kestra/executor/ExecutorService.java
@@ -345,7 +345,13 @@ public class ExecutorService {
                 );
 
                 if (!nexts.isEmpty()) {
-                    return saveFlowableOutput(nexts, executor);
+                    List<TaskRun> taskRuns = saveFlowableOutput(nexts, executor);
+                    if (Boolean.TRUE.equals(parentTaskRun.getForceExecution())) {
+                        return taskRuns.stream()
+                            .map(taskRun -> taskRun.withForceExecution(true))
+                            .toList();
+                    }
+                    return taskRuns;
                 }
             } catch (Exception e) {
                 log.warn("Unable to resolve the next tasks to run", e);

--- a/webserver/src/test/java/io/kestra/webserver/controllers/api/ExecutionControllerRunnerTest.java
+++ b/webserver/src/test/java/io/kestra/webserver/controllers/api/ExecutionControllerRunnerTest.java
@@ -1739,6 +1739,29 @@ class ExecutionControllerRunnerTest {
     }
 
     @Test
+    @LoadFlows({ "flows/valids/sleep-long-after-execution-flowable.yml" })
+    void shouldRunFlowableAfterExecutionWhenExecutionIsKilled() {
+        Execution runningExecution = runnerUtils.runOneUntilRunning(TENANT_ID, TESTS_FLOW_NS, "sleep-long-after-execution-flowable");
+        assertThat(runningExecution.getState().isRunning()).isTrue();
+
+        HttpResponse<?> killResponse = client.toBlocking().exchange(
+            HttpRequest.DELETE("/api/v1/main/executions/" + runningExecution.getId() + "/actions/kill")
+        );
+        assertThat(killResponse.getStatus().getCode()).isEqualTo(HttpStatus.OK.getCode());
+
+        Execution execution = awaitExecution(runningExecution.getId(), exec ->
+            exec.getState().getCurrent() == State.Type.KILLED &&
+                exec.findTaskRunsByTaskId("after-if").stream().anyMatch(taskRun -> taskRun.getState().isTerminated()) &&
+                exec.findTaskRunsByTaskId("after-if-log").stream().anyMatch(taskRun -> taskRun.getState().isTerminated()) &&
+                exec.findTaskRunsByTaskId("after-end").stream().anyMatch(taskRun -> taskRun.getState().isTerminated())
+        );
+        assertThat(execution.findTaskRunsByTaskId("sleep-long").getFirst().getState().getCurrent()).isEqualTo(State.Type.KILLED);
+        assertThat(execution.findTaskRunsByTaskId("after-if").getFirst().getState().getCurrent()).isEqualTo(State.Type.SUCCESS);
+        assertThat(execution.findTaskRunsByTaskId("after-if-log").getFirst().getState().getCurrent()).isEqualTo(State.Type.SUCCESS);
+        assertThat(execution.findTaskRunsByTaskId("after-end").getFirst().getState().getCurrent()).isEqualTo(State.Type.SUCCESS);
+    }
+
+    @Test
     @LoadFlows(value = { "flows/valids/inputs.yaml" }, tenantId = "searchexecutions")
     void searchExecutions() {
         String tenantId = "searchexecutions";

--- a/webserver/src/test/java/io/kestra/webserver/controllers/api/ExecutionControllerRunnerTest.java
+++ b/webserver/src/test/java/io/kestra/webserver/controllers/api/ExecutionControllerRunnerTest.java
@@ -1740,7 +1740,7 @@ class ExecutionControllerRunnerTest {
 
     @Test
     @LoadFlows({ "flows/valids/sleep-long-after-execution-flowable.yml" })
-    void shouldRunFlowableAfterExecutionWhenExecutionIsKilled() {
+    void shouldRunFlowableAfterExecutionWhenExecutionIsKilled() throws QueueException {
         Execution runningExecution = runnerUtils.runOneUntilRunning(TENANT_ID, TESTS_FLOW_NS, "sleep-long-after-execution-flowable");
         assertThat(runningExecution.getState().isRunning()).isTrue();
 


### PR DESCRIPTION
### ✨ Description

This PR propagates `forceExecution` from a flowable parent task run to the child task runs it resolves.

`afterExecution` task runs are marked with `forceExecution=true` so they can run after a killed execution. When an `afterExecution` task is a flowable wrapper such as `If`, only the wrapper previously received that flag. Its resolved child tasks could still be blocked by the worker killed-execution guard, leaving the flowable wrapper unable to settle and preventing following `afterExecution` tasks from running.

This change keeps the existing behavior for normal flowable tasks and only propagates the flag when the parent task run was already forced.

### 🔗 Related Issue

No issue.

### 🛠️ Backend Checklist

- [ ] Code compiles successfully and passes all checks
- [ ] All unit and integration tests pass

### 📝 Additional Notes

Added coverage for:

- flowable tasks in `afterExecution`
- killed executions where an `afterExecution` `If` task resolves child tasks and a following `afterExecution` task must still run

Local verification:

- `git diff --check`
- Attempted `./gradlew :jdbc-h2:test --tests io.kestra.runner.h2.H2RunnerTest.shouldCallFlowableTasksAfterExecution`, but local Gradle configuration failed before test execution because this machine only has JDK 24 and the project requires a Java 25 toolchain.

### 🤖 AI Authors

Why did the cat review the PR? To make sure every purr-mission was inherited correctly.
