### PR TITLE
fix(executions): null-safe Execution.getMetadata() for legacy executions

### DIFF
--- a/core/src/main/java/io/kestra/core/models/executions/Execution.java
+++ b/core/src/main/java/io/kestra/core/models/executions/Execution.java
@@ -128,6 +128,23 @@ public class Execution implements DeletedInterface, TenantInterface {
     }
 
     /**
+     * Returns the execution metadata, never {@code null}.
+     * <p>
+     * Executions persisted by very old versions (before {@link ExecutionMetadata} existed) carry a
+     * {@code null} metadata. Returning a safe default here guarantees callers can always read the
+     * attempt number and original creation date without a {@link NullPointerException}.
+     */
+    public ExecutionMetadata getMetadata() {
+        if (this.metadata != null) {
+            return this.metadata;
+        }
+
+        return ExecutionMetadata.builder()
+            .originalCreatedDate(this.state != null ? this.state.getStartDate() : null)
+            .build();
+    }
+
+    /**
      * Factory method for constructing a new {@link Execution} object for the given {@link Flow} and
      * inputs.
      *

--- a/core/src/test/java/io/kestra/core/models/executions/ExecutionTest.java
+++ b/core/src/test/java/io/kestra/core/models/executions/ExecutionTest.java
@@ -10,6 +10,7 @@ import java.util.List;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
 
 class ExecutionTest {
     private static final TaskRun.TaskRunBuilder TASK_RUN = TaskRun.builder()
@@ -149,6 +150,22 @@ class ExecutionTest {
             restart1.withState(State.Type.PAUSED).getState()
         );
         assertThat(restart2.getOriginalId(), is(execution.getId()));
+    }
+
+    @Test
+    void shouldReturnDefaultMetadataWhenNull() {
+        // Given an execution whose metadata is null (e.g. persisted by a very old version)
+        Execution execution = Execution.builder()
+            .id(IdUtils.create())
+            .state(new State(State.Type.RUNNING, new State()))
+            .build()
+            .withMetadata(null);
+
+        // When / Then getMetadata() never returns null and defaults the attempt number to 1
+        assertThat(execution.getMetadata(), is(notNullValue()));
+        assertThat(execution.getMetadata().getAttemptNumber(), is(1));
+        // originalCreatedDate is derived from the execution state so retry/maxDuration stays safe
+        assertThat(execution.getMetadata().getOriginalCreatedDate(), is(notNullValue()));
     }
 
     @Test


### PR DESCRIPTION
### What

Make `Execution.getMetadata()` never return `null`.

Closes #16784

### Why

Executions persisted by very old versions (before `ExecutionMetadata` existed) carry a `null` `metadata` — it is only populated by the builder's `prebuild()`. Dereferencing it (`getMetadata().getAttemptNumber()`) throws an NPE.

In the EE Kafka executor this turns a terminated **legacy subflow execution** into a poison pill on `kestra_executor_killed`: the subflow-end dedup key is built from `childExecution.getMetadata().getAttemptNumber()`, the stream thread fails repeatedly, and **all new executions stay stuck in `CREATED`** (reported on `0.22.43`, customer migrated from `0.16.x`).

```
NullPointerException: Cannot invoke "...ExecutionMetadata.getAttemptNumber()" because the return value of "...Execution.getMetadata()" is null
    at io.kestra.ee.runner.kafka.executors.ExecutorMain.lambda$handleSubflowExecution$113(ExecutorMain.java:1096)
```

### How

Add a null-safe `getMetadata()` override (mirroring the existing `getLabels()` override). `attemptNumber` defaults to `1` and `originalCreatedDate` is derived from the execution state so the retry / `maxDuration` paths stay null-safe.

This single change in OSS `core` covers **every** unsafe dereference site at once — `ExecutionService` (restart / replay / markAs / `nextRetryDate`), `TaskRun#nextRetryDate`, and the EE subflow-end dedup (`ExecutorMain:1096`) and purge (`:735`) lambdas. **No EE code change is required** (EE picks it up via its dependency on OSS `core`).

### Implications (reviewed)

- **Serialization:** legacy executions now emit a populated `metadata` object instead of `null` — benign and self-healing on rewrite.
- **`equals`/`hashCode`:** unchanged — they use the raw field, not the getter. EE dedup compares the stored record key, not the `Execution`.

### Tests

- New `ExecutionTest.shouldReturnDefaultMetadataWhenNull` (RED → GREEN).
- `ExecutionTest`, `TaskRunTest`, `ExecutionServiceTest` (21) pass.
- `H2RunnerTest`: 74 pass; the single failure is `for-each-item-no-wait`, an explicitly documented racy timing test unrelated to this change.
