### PR TITLE
fix(worker): commit worker job running entries before dispatching to workers

### DIFF
--- a/jdbc-h2/src/test/java/io/kestra/runner/h2/H2WorkerJobRunningStateStoreTest.java
+++ b/jdbc-h2/src/test/java/io/kestra/runner/h2/H2WorkerJobRunningStateStoreTest.java
@@ -1,0 +1,7 @@
+package io.kestra.runner.h2;
+
+import io.kestra.jdbc.runner.JdbcWorkerJobRunningStateStoreTest;
+
+class H2WorkerJobRunningStateStoreTest extends JdbcWorkerJobRunningStateStoreTest {
+
+}

--- a/jdbc-mysql/src/test/java/io/kestra/runner/mysql/MysqlWorkerJobRunningStateStoreTest.java
+++ b/jdbc-mysql/src/test/java/io/kestra/runner/mysql/MysqlWorkerJobRunningStateStoreTest.java
@@ -1,0 +1,7 @@
+package io.kestra.runner.mysql;
+
+import io.kestra.jdbc.runner.JdbcWorkerJobRunningStateStoreTest;
+
+class MysqlWorkerJobRunningStateStoreTest extends JdbcWorkerJobRunningStateStoreTest {
+
+}

--- a/jdbc-postgres/src/test/java/io/kestra/runner/postgres/PostgresWorkerJobRunningStateStoreTest.java
+++ b/jdbc-postgres/src/test/java/io/kestra/runner/postgres/PostgresWorkerJobRunningStateStoreTest.java
@@ -1,0 +1,7 @@
+package io.kestra.runner.postgres;
+
+import io.kestra.jdbc.runner.JdbcWorkerJobRunningStateStoreTest;
+
+class PostgresWorkerJobRunningStateStoreTest extends JdbcWorkerJobRunningStateStoreTest {
+
+}

--- a/jdbc/src/main/java/io/kestra/jdbc/JooqDSLContextWrapper.java
+++ b/jdbc/src/main/java/io/kestra/jdbc/JooqDSLContextWrapper.java
@@ -1,18 +1,25 @@
 package io.kestra.jdbc;
 
+import java.sql.Connection;
 import java.sql.SQLException;
 import java.time.Duration;
 import java.util.function.Predicate;
 
 import javax.sql.DataSource;
 
+import org.jooq.ConnectionProvider;
 import org.jooq.DSLContext;
 import org.jooq.TransactionalCallable;
 import org.jooq.TransactionalRunnable;
+import org.jooq.exception.DataAccessException;
+import org.jooq.impl.DSL;
+import org.jooq.impl.DefaultConnectionProvider;
+import org.jooq.impl.DefaultTransactionProvider;
 
 import io.kestra.core.models.tasks.retrys.Random;
 import io.kestra.core.utils.RetryUtils;
 
+import io.micronaut.data.connection.jdbc.advice.DelegatingDataSource;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 
@@ -28,15 +35,20 @@ public class JooqDSLContextWrapper {
     private static final DeadlockPredicate DEADLOCK_PREDICATE = new DeadlockPredicate();
 
     private final DSLContext dslContext;
+    private final DataSource rawDataSource;
 
     /**
-     * @param dataSource explicit dependency to ensure Micronaut destroys this bean before the DataSource.
+     * @param dataSource used by {@link #requireNewTransaction(TransactionalRunnable)}, and an
+     *        explicit dependency to ensure Micronaut destroys this bean before the DataSource.
      *        Without it, the @EachBean-derived DSLContext/Configuration may be destroyed
      *        together with the DataSource, leaving this wrapper with a stale DSLContext.
      */
     @Inject
     public JooqDSLContextWrapper(DSLContext dslContext, DataSource dataSource) {
         this.dslContext = dslContext;
+        // Unwrap any Micronaut Data AOP proxy: the wrapped DataSource hands back the current
+        // thread's transaction-bound connection instead of a new one.
+        this.rawDataSource = DelegatingDataSource.unwrapDataSource(dataSource);
     }
 
     private static <T> RetryUtils.Instance<T, RuntimeException> retryer() {
@@ -58,6 +70,39 @@ public class JooqDSLContextWrapper {
         return JooqDSLContextWrapper.<T>retryer().runRetryIf(
             DEADLOCK_PREDICATE,
             () -> dslContext.transactionResult(transactional)
+        );
+    }
+
+    /**
+     * Runs the given work in a transaction on a dedicated connection acquired directly from the
+     * underlying pool, so it is committed before this method returns and immediately visible to
+     * other connections — even when a transaction is already open on the current thread.
+     * <p>
+     * Regular {@link #transaction(TransactionalRunnable)} calls are bound to the calling thread
+     * and silently join a caller-owned transaction (e.g. the dispatch-queue poll transaction),
+     * deferring their writes until that transaction commits.
+     * <p>
+     * When the calling thread already has a connection checked out, this briefly holds a second
+     * one — keep the work short.
+     */
+    public void requireNewTransaction(TransactionalRunnable transactional) {
+        JooqDSLContextWrapper.<Void>retryer().runRetryIf(
+            DEADLOCK_PREDICATE,
+            () ->
+            {
+                try (Connection connection = rawDataSource.getConnection()) {
+                    // Same configuration (dialect, settings, execute listeners), but jOOQ-managed
+                    // transactions on this connection instead of the thread-bound ones.
+                    ConnectionProvider connectionProvider = new DefaultConnectionProvider(connection);
+                    DSL.using(dslContext.configuration()
+                            .derive(connectionProvider)
+                            .derive(new DefaultTransactionProvider(connectionProvider)))
+                        .transaction(transactional);
+                } catch (SQLException e) {
+                    throw new DataAccessException("Unable to run a transaction on a new connection", e);
+                }
+                return null;
+            }
         );
     }
 

--- a/jdbc/src/main/java/io/kestra/jdbc/runner/AbstractJdbcWorkerJobRunningStateStore.java
+++ b/jdbc/src/main/java/io/kestra/jdbc/runner/AbstractJdbcWorkerJobRunningStateStore.java
@@ -30,7 +30,13 @@ public abstract class AbstractJdbcWorkerJobRunningStateStore extends AbstractJdb
             var dslContext = txContext.unwrap(JdbcTransactionContext.class).getDslContext();
             this.jdbcRepository.persist(workerJobRunning, dslContext, this.jdbcRepository.persistFields(workerJobRunning));
         } else {
-            this.jdbcRepository.persist(workerJobRunning);
+            // Commit on a dedicated connection: the entry must be visible to concurrent result
+            // processing as soon as the job is sent to the worker, even when the caller holds an
+            // open thread-bound transaction (the dispatch-queue poll transaction) — otherwise the
+            // terminal result of a fast task deletes nothing and the entry leaks forever.
+            this.jdbcRepository.getDslContextWrapper().requireNewTransaction(configuration ->
+                this.jdbcRepository.persist(workerJobRunning, DSL.using(configuration), this.jdbcRepository.persistFields(workerJobRunning))
+            );
         }
         return workerJobRunning;
     }

--- a/jdbc/src/test/java/io/kestra/jdbc/runner/JdbcWorkerJobRunningStateStoreTest.java
+++ b/jdbc/src/test/java/io/kestra/jdbc/runner/JdbcWorkerJobRunningStateStoreTest.java
@@ -1,0 +1,123 @@
+package io.kestra.jdbc.runner;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+
+import io.kestra.core.junit.annotations.KestraTest;
+import io.kestra.core.models.executions.TaskRun;
+import io.kestra.core.models.flows.State;
+import io.kestra.core.runners.NoTransactionContext;
+import io.kestra.core.runners.WorkerInstance;
+import io.kestra.core.runners.WorkerTaskData;
+import io.kestra.core.runners.WorkerTaskRunning;
+import io.kestra.core.utils.IdUtils;
+import io.kestra.jdbc.JdbcTestUtils;
+import io.kestra.jdbc.JooqDSLContextWrapper;
+import io.kestra.plugin.core.log.Log;
+
+import jakarta.inject.Inject;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@KestraTest
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public abstract class JdbcWorkerJobRunningStateStoreTest {
+
+    @Inject
+    private AbstractJdbcWorkerJobRunningStateStore workerJobRunningStateStore;
+
+    @Inject
+    private JooqDSLContextWrapper dslContextWrapper;
+
+    @Inject
+    private JdbcTestUtils jdbcTestUtils;
+
+    @BeforeAll
+    void initSchema() {
+        jdbcTestUtils.drop();
+        jdbcTestUtils.migrate();
+    }
+
+    @AfterEach
+    void tearDown() {
+        workerJobRunningStateStore.findAll().forEach(it -> workerJobRunningStateStore.deleteByKey(it.uid()));
+    }
+
+    @Test
+    void shouldSaveAndDeleteWorkerJobRunning() {
+        // Given
+        WorkerTaskRunning workerTaskRunning = workerTaskRunning();
+
+        // When
+        workerJobRunningStateStore.save(NoTransactionContext.INSTANCE, workerTaskRunning);
+
+        // Then
+        assertThat(existsByKey(workerTaskRunning.uid())).isTrue();
+
+        // When
+        workerJobRunningStateStore.deleteByKey(workerTaskRunning.uid());
+
+        // Then
+        assertThat(existsByKey(workerTaskRunning.uid())).isFalse();
+    }
+
+    @Test
+    void shouldCommitSaveBeforeReturningWhenCallerTransactionIsOpen() {
+        // Given a save() performed while a caller-owned transaction is open on the
+        // current thread — as happens when the worker-controller dispatches jobs from
+        // inside the dispatch-queue poll transaction.
+        WorkerTaskRunning workerTaskRunning = workerTaskRunning();
+        AtomicBoolean visibleFromOtherConnection = new AtomicBoolean(false);
+
+        // When
+        dslContextWrapper.transaction(configuration ->
+            {
+                workerJobRunningStateStore.save(NoTransactionContext.INSTANCE, workerTaskRunning);
+
+                // Then the entry must already be committed and visible from another
+                // connection — otherwise the job's terminal result (processed
+                // concurrently) issues a delete that misses the row and the entry
+                // leaks forever. The check MUST run on another thread: on this one it
+                // would join the open transaction and see the uncommitted row.
+                visibleFromOtherConnection.set(
+                    CompletableFuture
+                        .supplyAsync(
+                            () -> existsByKey(workerTaskRunning.uid()),
+                            runnable -> new Thread(runnable, "other-connection").start()
+                        )
+                        .get(10, TimeUnit.SECONDS)
+                );
+            }
+        );
+
+        assertThat(visibleFromOtherConnection.get()).isTrue();
+    }
+
+    private boolean existsByKey(String key) {
+        return workerJobRunningStateStore.findAll().stream().anyMatch(it -> key.equals(it.uid()));
+    }
+
+    private static WorkerTaskRunning workerTaskRunning() {
+        return WorkerTaskRunning.builder()
+            .workerInstance(new WorkerInstance(IdUtils.create(), null))
+            .taskRun(TaskRun.builder()
+                .id(IdUtils.create())
+                .executionId(IdUtils.create())
+                .namespace("io.kestra.unittest")
+                .flowId("worker-job-running-state-store")
+                .taskId("log")
+                .state(new State().withState(State.Type.SUBMITTED))
+                .build())
+            .task(Log.builder().id("log").type(Log.class.getName()).message("test").build())
+            .data(new WorkerTaskData(Map.of(), List.of(), null))
+            .build();
+    }
+}

--- a/worker-controller/src/main/java/io/kestra/controller/grpc/services/WorkerJobDispatcher.java
+++ b/worker-controller/src/main/java/io/kestra/controller/grpc/services/WorkerJobDispatcher.java
@@ -885,8 +885,16 @@ public class WorkerJobDispatcher {
             return;
         }
 
-        // 1. PERSIST before sending (critical for recovery)
-        persistJobToStateStore(context, job, dispatchWorkerQueueId);
+        // 1. PERSIST before sending (critical for recovery). A transient failure (e.g. pool
+        // exhaustion) must not bubble up to the poller, which treats it as fatal and shuts down.
+        try {
+            persistJobToStateStore(context, job, dispatchWorkerQueueId);
+        } catch (Exception e) {
+            log.warn("Failed to persist running state for job {} on worker {}; re-queuing for redelivery: {}",
+                jobId, context.getWorkerId(), e.getMessage());
+            handlePersistFailure(context, job, originalEvent, dispatchWorkerQueueId, bucket);
+            return;
+        }
 
         // 2. Track in-flight locally
         context.trackInFlight(jobId, job, bucket);
@@ -947,6 +955,25 @@ public class WorkerJobDispatcher {
         workerJobRunningStateStore.deleteByKey(NoTransactionContext.INSTANCE, job.uid());
 
         // Re-queue the job
+        requeue(originalEvent);
+    }
+
+    /**
+     * Handles a failure to persist the running state before dispatch. The job is not yet tracked
+     * in-flight, so the reserved permit and bucket are released directly (as in
+     * {@link #rejectOversizedJob}), then the job is re-queued for redelivery.
+     */
+    private void handlePersistFailure(WorkerStreamContext<WorkerJobResponse> context, WorkerJob job,
+        WorkerJobEvent originalEvent, String dispatchWorkerQueueId, String bucket) {
+        metricRegistry.counter(
+            MetricRegistry.METRIC_CONTROLLER_JOB_DISPATCH_FAILED_TOTAL,
+            MetricRegistry.METRIC_CONTROLLER_JOB_DISPATCH_FAILED_TOTAL_DESCRIPTION,
+            metricRegistry.workerGroupAndQueueTags(context.getWorkerGroupId(), dispatchWorkerQueueId)
+        ).increment();
+
+        context.addPermits(1);
+        context.releaseBucket(bucket);
+
         requeue(originalEvent);
     }
 

--- a/worker-controller/src/test/java/io/kestra/controller/grpc/services/WorkerJobDispatcherTest.java
+++ b/worker-controller/src/test/java/io/kestra/controller/grpc/services/WorkerJobDispatcherTest.java
@@ -462,6 +462,27 @@ class WorkerJobDispatcherTest {
         }
 
         @Test
+        void shouldRequeueWhenStateStorePersistFails() throws QueueException {
+            // Given - persisting the running state fails transiently (e.g. pool exhaustion)
+            WorkerStreamContext<WorkerJobResponse> context = createWorkerContext("worker-1", WORKER_GROUP_A, 10);
+            context.addPermits(5);
+            dispatcher.registerWorker(context);
+            doThrow(new RuntimeException("connection pool exhausted")).when(mockStateStore).save(any(), any());
+
+            MockQueueSubscriber subscriber = getSubscriberForGroup(WORKER_GROUP_A);
+            WorkerJobEvent event = createJobEvent("job-1", WORKER_GROUP_A);
+
+            // When - the failure must not propagate to the poller
+            subscriber.deliverJob(event);
+
+            // Then - the job is re-queued, not sent, and the reserved capacity is restored
+            verify(mockQueue).emit(eq(WORKER_GROUP_A), eq(event));
+            verify(context.getResponseObserver(), never()).onNext(any(WorkerJobResponse.class));
+            assertThat(context.getInFlightCount()).isEqualTo(0);
+            assertThat(context.getAvailablePermits()).isEqualTo(5);
+        }
+
+        @Test
         void shouldDispatchToWorkerWithLowestInFlight() {
             // Given
             WorkerStreamContext<WorkerJobResponse> context1 = createWorkerContext("worker-1", WORKER_GROUP_A, 10);

--- a/worker/src/test/java/io/kestra/worker/senders/GrpcWorkerIOSenderTest.java
+++ b/worker/src/test/java/io/kestra/worker/senders/GrpcWorkerIOSenderTest.java
@@ -179,17 +179,20 @@ class GrpcWorkerIOSenderTest {
 
         WorkerTaskResult result = buildTaskResult(Map.of("key", "value"));
 
-        // When - the first send fails and the result is re-queued instead of dropped...
+        // When - the first send fails and the result is re-queued instead of dropped.
         taskResultSender.send(List.of(result));
-        // ...and the next loop iteration redrives it (the second send succeeds)
-        taskResultSender.doOnLoop();
 
-        // Then - the controller eventually receives the result (initial attempt + redelivery)
+        // Then - the loop redrives until the controller receives the result (initial attempt +
+        // redelivery). doOnLoop() runs inside the await because the first send fails asynchronously
+        // on a gRPC callback thread, so a single redrive could poll before the item is re-queued.
         ArgumentCaptor<OpaqueData> captor = ArgumentCaptor.forClass(OpaqueData.class);
         await()
-            .atMost(Duration.ofSeconds(5))
-            .untilAsserted(() -> verify(grpcWorkerControllerService, org.mockito.Mockito.atLeast(2))
-                .sendWorkerTaskResults(captor.capture(), any()));
+            .atMost(Duration.ofSeconds(10))
+            .untilAsserted(() -> {
+                taskResultSender.doOnLoop();
+                verify(grpcWorkerControllerService, org.mockito.Mockito.atLeast(2))
+                    .sendWorkerTaskResults(captor.capture(), any());
+            });
 
         WorkerTaskResult redelivered = deserialize(captor.getAllValues().getLast()).records().getFirst();
         assertThat(redelivered.getTaskRun().getId()).isEqualTo(result.getTaskRun().getId());
@@ -219,17 +222,20 @@ class GrpcWorkerIOSenderTest {
 
         WorkerTaskResult result = buildTaskResult(Map.of("key", "value"));
 
-        // When - RESOURCE_EXHAUSTED triggers the fallback resend, which fails transiently and is re-queued...
+        // When - RESOURCE_EXHAUSTED triggers the fallback resend, which fails transiently and is re-queued.
         taskResultSender.send(List.of(result));
-        // ...and the next loop iteration redrives the fallback result (the third send succeeds)
-        taskResultSender.doOnLoop();
 
-        // Then - the failed-state result (no outputs) is eventually delivered rather than dropped
+        // Then - the loop redrives until the failed-state result (no outputs) is delivered rather than
+        // dropped. doOnLoop() runs inside the await because the failures arrive asynchronously on gRPC
+        // callback threads, so a single redrive could poll before the fallback result is re-queued.
         ArgumentCaptor<OpaqueData> captor = ArgumentCaptor.forClass(OpaqueData.class);
         await()
-            .atMost(Duration.ofSeconds(5))
-            .untilAsserted(() -> verify(grpcWorkerControllerService, org.mockito.Mockito.atLeast(3))
-                .sendWorkerTaskResults(captor.capture(), any()));
+            .atMost(Duration.ofSeconds(10))
+            .untilAsserted(() -> {
+                taskResultSender.doOnLoop();
+                verify(grpcWorkerControllerService, org.mockito.Mockito.atLeast(3))
+                    .sendWorkerTaskResults(captor.capture(), any());
+            });
 
         WorkerTaskResult redelivered = deserialize(captor.getAllValues().getLast()).records().getFirst();
         assertThat(redelivered.getTaskRun().getId()).isEqualTo(result.getTaskRun().getId());


### PR DESCRIPTION
The worker-controller dispatches jobs from inside the JDBC dispatch-queue poll transaction, and the dispatch-time save of the worker_job_running entry silently joined that thread-bound transaction, which only commits after the whole polled batch is processed. A fast task could complete within that window: its terminal result, processed on another connection, deleted nothing (the entry was not visible yet) and the entry leaked forever once the batch committed — to be wrongly resubmitted as a zombie job the next time its worker disconnected.

Saving through a dedicated connection acquired directly from the pool restores the intended ordering: the entry is durable and visible before the job is sent, so the terminal result's delete always finds it.