### PR TITLE
fix(dashboards): "All" quick-filter tab shows every execution state

### DIFF
--- a/ui/src/components/dashboard/sections/Table.vue
+++ b/ui/src/components/dashboard/sections/Table.vue
@@ -60,6 +60,7 @@
     import {isPaginationEnabled, useChartGenerator} from "../composables/useDashboards"
     import {FilterObject} from "../../../utils/filters"
     import TableQuickFilter from "./TableQuickFilter.vue"
+    import {stateFilterForTab} from "./quickFilters"
     import Date from "./table/columns/Date.vue"
     import Duration from "./table/columns/Duration.vue"
     import Link from "./table/columns/Link.vue"
@@ -124,7 +125,7 @@
 
     const data = ref()
     const activeTab = ref("all")
-    const stateFilter = ref<FilterObject | null>(null)
+    const stateFilter = ref<FilterObject | null>(stateFilterForTab(props.chart, "all"))
     const pageNumber = ref(1)
     const pageSize = ref(25)
 

--- a/ui/src/components/dashboard/sections/TableQuickFilter.vue
+++ b/ui/src/components/dashboard/sections/TableQuickFilter.vue
@@ -64,6 +64,8 @@
         },
     ] as const
 
+    const ALL_STATES = QUICK_FILTER_TABS.flatMap((tab) => tab.states)
+
     type TabKey = (typeof QUICK_FILTER_TABS)[number]["key"]
 
     const props = defineProps<{chart: Chart}>()
@@ -80,11 +82,20 @@
         return Object.values(columns).some((col: Record<string, any>) => col.field === "STATE")
     })
 
+    const chartConstrainsState = computed(() =>
+        ((props.chart.data?.where as {field?: string}[] | undefined) ?? [])
+            .some((condition) => String(condition?.field).toUpperCase() === "STATE"),
+    )
+
     const activeTab = ref<TabKey>("all")
 
     const stateFilter = (key: TabKey): FilterObject | null => {
         const tab = QUICK_FILTER_TABS.find((t) => t.key === key)
-        if (!tab?.states.length) return null
+        if (!tab?.states.length) {
+            return chartConstrainsState.value
+                ? {field: "state", operation: "IN", value: [...ALL_STATES]}
+                : null
+        }
         return {field: "state", operation: "IN", value: [...tab.states]}
     }
 

--- a/ui/src/components/dashboard/sections/TableQuickFilter.vue
+++ b/ui/src/components/dashboard/sections/TableQuickFilter.vue
@@ -30,79 +30,27 @@
 
     import type {Chart} from "../types.ts"
     import {FilterObject} from "../../../utils/filters"
-
-    const QUICK_FILTER_TABS = [
-        {
-            key: "all",
-            token: "--ks-text-link",
-            states: [] as string[],
-        },
-        {
-            key: "running",
-            token: "--ks-status-running",
-            states: ["SUBMITTED", "CREATED", "RESTARTED", "QUEUED", "RUNNING", "RETRYING", "KILLING"],
-        },
-        {
-            key: "paused",
-            token: "--ks-status-paused",
-            states: ["PAUSED", "BREAKPOINT"],
-        },
-        {
-            key: "success",
-            token: "--ks-status-success",
-            states: ["SUCCESS"],
-        },
-        {
-            key: "warning",
-            token: "--ks-status-warning",
-            states: ["WARNING"],
-        },
-        {
-            key: "failed",
-            token: "--ks-status-error",
-            states: ["FAILED", "KILLED", "CANCELLED", "SKIPPED", "RETRIED"],
-        },
-    ] as const
-
-    const ALL_STATES = QUICK_FILTER_TABS.flatMap((tab) => tab.states)
-
-    type TabKey = (typeof QUICK_FILTER_TABS)[number]["key"]
+    import {
+        QUICK_FILTER_TABS,
+        QuickFilterTabKey,
+        hasQuickFilters as chartHasQuickFilters,
+        stateFilterForTab,
+    } from "./quickFilters"
 
     const props = defineProps<{chart: Chart}>()
 
-    const emit = defineEmits<{change: [filter: FilterObject | null, tab: TabKey]}>()
+    const emit = defineEmits<{change: [filter: FilterObject | null, tab: QuickFilterTabKey]}>()
 
     const {t} = useI18n({useScope: "global"})
 
-    const EXECUTIONS_DATA_TYPE = "io.kestra.plugin.core.dashboard.data.Executions"
+    const hasQuickFilters = computed(() => chartHasQuickFilters(props.chart))
 
-    const hasQuickFilters = computed(() => {
-        if (props.chart.data?.type !== EXECUTIONS_DATA_TYPE) return false
-        const columns = props.chart.data?.columns ?? {}
-        return Object.values(columns).some((col: Record<string, any>) => col.field === "STATE")
-    })
+    const activeTab = ref<QuickFilterTabKey>("all")
 
-    const chartConstrainsState = computed(() =>
-        ((props.chart.data?.where as {field?: string}[] | undefined) ?? [])
-            .some((condition) => String(condition?.field).toUpperCase() === "STATE"),
-    )
-
-    const activeTab = ref<TabKey>("all")
-
-    const stateFilter = (key: TabKey): FilterObject | null => {
-        const tab = QUICK_FILTER_TABS.find((t) => t.key === key)
-        if (!tab?.states.length) {
-            return chartConstrainsState.value
-                ? {field: "state", operation: "IN", value: [...ALL_STATES]}
-                : null
-        }
-        return {field: "state", operation: "IN", value: [...tab.states]}
-    }
-
-    const selectTab = (key: TabKey) => {
+    const selectTab = (key: QuickFilterTabKey) => {
         if (activeTab.value === key) return
         activeTab.value = key
-        emit("change", stateFilter(key), key)
+        emit("change", stateFilterForTab(props.chart, key), key)
     }
 </script>
 

--- a/ui/src/components/dashboard/sections/quickFilters.ts
+++ b/ui/src/components/dashboard/sections/quickFilters.ts
@@ -1,0 +1,61 @@
+import type {Chart} from "../types.ts"
+import {FilterObject} from "../../../utils/filters"
+
+export const QUICK_FILTER_TABS = [
+    {
+        key: "all",
+        token: "--ks-text-link",
+        states: [] as string[],
+    },
+    {
+        key: "running",
+        token: "--ks-status-running",
+        states: ["SUBMITTED", "CREATED", "RESTARTED", "QUEUED", "RUNNING", "RETRYING", "KILLING"],
+    },
+    {
+        key: "paused",
+        token: "--ks-status-paused",
+        states: ["PAUSED", "BREAKPOINT"],
+    },
+    {
+        key: "success",
+        token: "--ks-status-success",
+        states: ["SUCCESS"],
+    },
+    {
+        key: "warning",
+        token: "--ks-status-warning",
+        states: ["WARNING"],
+    },
+    {
+        key: "failed",
+        token: "--ks-status-error",
+        states: ["FAILED", "KILLED", "CANCELLED", "SKIPPED", "RETRIED"],
+    },
+] as const
+
+export type QuickFilterTabKey = (typeof QUICK_FILTER_TABS)[number]["key"]
+
+export const ALL_STATES = QUICK_FILTER_TABS.flatMap((tab) => tab.states)
+
+const EXECUTIONS_DATA_TYPE = "io.kestra.plugin.core.dashboard.data.Executions"
+
+export const hasQuickFilters = (chart: Chart): boolean => {
+    if (chart.data?.type !== EXECUTIONS_DATA_TYPE) return false
+    const columns = chart.data?.columns ?? {}
+    return Object.values(columns).some((col: Record<string, any>) => col.field === "STATE")
+}
+
+export const chartConstrainsState = (chart: Chart): boolean =>
+    ((chart.data?.where as {field?: string}[] | undefined) ?? [])
+        .some((condition) => String(condition?.field).toUpperCase() === "STATE")
+
+export const stateFilterForTab = (chart: Chart, key: QuickFilterTabKey): FilterObject | null => {
+    const tab = QUICK_FILTER_TABS.find((t) => t.key === key)
+    if (!tab?.states.length) {
+        return chartConstrainsState(chart)
+            ? {field: "state", operation: "IN", value: [...ALL_STATES]}
+            : null
+    }
+    return {field: "state", operation: "IN", value: [...tab.states]}
+}

--- a/ui/tests/unit/components/dashboard/quickFilters.spec.ts
+++ b/ui/tests/unit/components/dashboard/quickFilters.spec.ts
@@ -1,0 +1,81 @@
+import {describe, expect, it} from "vitest"
+import {
+    stateFilterForTab,
+    hasQuickFilters,
+    chartConstrainsState,
+    ALL_STATES,
+} from "../../../../src/components/dashboard/sections/quickFilters"
+
+const EXECUTIONS = "io.kestra.plugin.core.dashboard.data.Executions"
+
+const chart = (data: Record<string, unknown> = {}) => ({
+    id: "c",
+    type: "io.kestra.plugin.core.dashboard.chart.Table",
+    data: {type: EXECUTIONS, columns: {state: {field: "STATE"}}, ...data},
+}) as any
+
+describe("quickFilters", () => {
+    describe("stateFilterForTab", () => {
+        it("returns null for the All tab when the chart does not constrain STATE", () => {
+            expect(stateFilterForTab(chart(), "all")).toBeNull()
+        })
+
+        it("returns every state for the All tab when the chart constrains STATE", () => {
+            const where = [{type: "IN", field: "STATE", values: ["RUNNING", "PAUSED"]}]
+            expect(stateFilterForTab(chart({where}), "all")).toEqual({
+                field: "state",
+                operation: "IN",
+                value: ALL_STATES,
+            })
+        })
+
+        it("returns the tab's own states for a state tab", () => {
+            expect(stateFilterForTab(chart(), "failed")).toEqual({
+                field: "state",
+                operation: "IN",
+                value: ["FAILED", "KILLED", "CANCELLED", "SKIPPED", "RETRIED"],
+            })
+        })
+
+        it("keeps the All tab as a superset of every state tab", () => {
+            const where = [{type: "IN", field: "STATE", values: ["RUNNING"]}]
+            const all = stateFilterForTab(chart({where}), "all")!.value as string[]
+            for (const key of ["running", "paused", "success", "warning", "failed"] as const) {
+                const states = stateFilterForTab(chart({where}), key)!.value as string[]
+                expect(states.every((s) => all.includes(s))).toBe(true)
+            }
+        })
+    })
+
+    describe("chartConstrainsState", () => {
+        it("is true when a STATE where exists", () => {
+            expect(chartConstrainsState(chart({where: [{field: "STATE", values: []}]}))).toBe(true)
+        })
+
+        it("is case-insensitive on the field name", () => {
+            expect(chartConstrainsState(chart({where: [{field: "state", values: []}]}))).toBe(true)
+        })
+
+        it("is false when only non-STATE wheres exist", () => {
+            expect(chartConstrainsState(chart({where: [{field: "NAMESPACE", values: []}]}))).toBe(false)
+        })
+
+        it("is false when there is no where", () => {
+            expect(chartConstrainsState(chart())).toBe(false)
+        })
+    })
+
+    describe("hasQuickFilters", () => {
+        it("is true for an executions table with a STATE column", () => {
+            expect(hasQuickFilters(chart())).toBe(true)
+        })
+
+        it("is false for a non-executions data type", () => {
+            expect(hasQuickFilters(chart({type: "io.kestra.plugin.core.dashboard.data.Logs"}))).toBe(false)
+        })
+
+        it("is false without a STATE column", () => {
+            expect(hasQuickFilters(chart({columns: {id: {field: "ID"}}}))).toBe(false)
+        })
+    })
+})

--- a/ui/tests/unit/components/dashboard/tableInitialFilter.spec.ts
+++ b/ui/tests/unit/components/dashboard/tableInitialFilter.spec.ts
@@ -1,0 +1,69 @@
+import {describe, expect, it, vi, beforeEach} from "vitest"
+import {mount, flushPromises} from "@vue/test-utils"
+import {createI18n} from "vue-i18n"
+
+const {generate} = vi.hoisted(() => ({generate: vi.fn()}))
+
+vi.mock("../../../../src/components/dashboard/composables/useDashboards", () => ({
+    useChartGenerator: () => ({EMPTY_TEXT: "", generate}),
+    isPaginationEnabled: () => true,
+}))
+
+vi.mock("vue-router", () => ({
+    useRoute: () => ({params: {}, query: {}}),
+}))
+
+import Table from "../../../../src/components/dashboard/sections/Table.vue"
+
+const i18n = createI18n({legacy: false, locale: "en", fallbackWarn: false, missingWarn: false})
+
+const EXECUTIONS = "io.kestra.plugin.core.dashboard.data.Executions"
+
+const ALL_STATES = [
+    "SUBMITTED", "CREATED", "RESTARTED", "QUEUED", "RUNNING", "RETRYING", "KILLING",
+    "PAUSED", "BREAKPOINT",
+    "SUCCESS",
+    "WARNING",
+    "FAILED", "KILLED", "CANCELLED", "SKIPPED", "RETRIED",
+]
+
+const mountTable = (where?: unknown) =>
+    mount(Table, {
+        props: {
+            dashboardId: "d1",
+            chart: {
+                id: "executions",
+                type: "io.kestra.plugin.core.dashboard.chart.Table",
+                data: {type: EXECUTIONS, columns: {state: {field: "STATE"}}, ...(where ? {where} : {})},
+            },
+        },
+        global: {
+            plugins: [i18n],
+            stubs: {KsDataTable: true, KsTableColumn: true, KsTableEmpty: true, TableQuickFilter: true, Motion: true},
+        },
+    })
+
+describe("Table initial quick-filter state", () => {
+    beforeEach(() => {
+        generate.mockReset()
+        generate.mockResolvedValue({results: [], total: 0})
+    })
+
+    it("seeds the All-tab override on first load when the chart constrains STATE", async () => {
+        mountTable([{type: "IN", field: "STATE", values: ["RUNNING"]}])
+        await flushPromises()
+
+        expect(generate).toHaveBeenCalled()
+        expect(generate.mock.calls[0][2]).toEqual([
+            {field: "state", operation: "IN", value: ALL_STATES},
+        ])
+    })
+
+    it("sends no state override on first load when the chart does not constrain STATE", async () => {
+        mountTable()
+        await flushPromises()
+
+        expect(generate).toHaveBeenCalled()
+        expect(generate.mock.calls[0][2]).toBeUndefined()
+    })
+})

--- a/ui/tests/unit/components/dashboard/tableQuickFilter.spec.ts
+++ b/ui/tests/unit/components/dashboard/tableQuickFilter.spec.ts
@@ -1,0 +1,72 @@
+import {describe, expect, it} from "vitest"
+import {mount} from "@vue/test-utils"
+import {createI18n} from "vue-i18n"
+import TableQuickFilter from "../../../../src/components/dashboard/sections/TableQuickFilter.vue"
+
+const i18n = createI18n({legacy: false, locale: "en", fallbackWarn: false, missingWarn: false})
+
+const EXECUTIONS = "io.kestra.plugin.core.dashboard.data.Executions"
+
+const ALL_STATES = [
+    "SUBMITTED", "CREATED", "RESTARTED", "QUEUED", "RUNNING", "RETRYING", "KILLING",
+    "PAUSED", "BREAKPOINT",
+    "SUCCESS",
+    "WARNING",
+    "FAILED", "KILLED", "CANCELLED", "SKIPPED", "RETRIED",
+]
+
+const executionsChart = (where?: unknown) => ({
+    id: "executions",
+    type: "io.kestra.plugin.core.dashboard.chart.Table",
+    data: {type: EXECUTIONS, columns: {state: {field: "STATE"}}, ...(where ? {where} : {})},
+})
+
+const mountFilter = (chart: Record<string, unknown>) =>
+    mount(TableQuickFilter, {
+        props: {chart},
+        global: {plugins: [i18n], stubs: {Motion: true}},
+    })
+
+const tabButtons = (wrapper: ReturnType<typeof mountFilter>) =>
+    wrapper.findAll("button.quick-filter-tab")
+
+const lastChange = (wrapper: ReturnType<typeof mountFilter>) =>
+    (wrapper.emitted("change") as [unknown, string][]).at(-1)
+
+describe("TableQuickFilter", () => {
+    it("emits no state filter for the All tab when the chart does not constrain STATE", async () => {
+        const wrapper = mountFilter(executionsChart())
+        const buttons = tabButtons(wrapper)
+
+        await buttons[1].trigger("click")
+        await buttons[0].trigger("click")
+
+        expect(lastChange(wrapper)).toEqual([null, "all"])
+    })
+
+    it("emits every state for the All tab when the chart constrains STATE via where", async () => {
+        const wrapper = mountFilter(
+            executionsChart([{type: "IN", field: "STATE", values: ["RUNNING", "PAUSED"]}]),
+        )
+        const buttons = tabButtons(wrapper)
+
+        await buttons[1].trigger("click")
+        await buttons[0].trigger("click")
+
+        expect(lastChange(wrapper)).toEqual([
+            {field: "state", operation: "IN", value: ALL_STATES},
+            "all",
+        ])
+    })
+
+    it("emits the tab's own states for a state tab", async () => {
+        const wrapper = mountFilter(executionsChart())
+
+        await tabButtons(wrapper)[5].trigger("click")
+
+        expect(lastChange(wrapper)).toEqual([
+            {field: "state", operation: "IN", value: ["FAILED", "KILLED", "CANCELLED", "SKIPPED", "RETRIED"]},
+            "failed",
+        ])
+    })
+})

--- a/ui/tests/unit/components/dashboard/tableQuickFilter.spec.ts
+++ b/ui/tests/unit/components/dashboard/tableQuickFilter.spec.ts
@@ -23,7 +23,7 @@ const executionsChart = (where?: unknown) => ({
 
 const mountFilter = (chart: Record<string, unknown>) =>
     mount(TableQuickFilter, {
-        props: {chart},
+        props: {chart: chart as never},
         global: {plugins: [i18n], stubs: {Motion: true}},
     })
 


### PR DESCRIPTION
Closes #16812

## Problem

On the dashboard Executions table, clicking the **All** quick-filter tab shows nothing, while clicking a state tab (e.g. **Success**) shows plenty of executions. Reproduced on deployed environments.

## Cause

The quick-filter tabs auto-enable on any executions table with a `STATE` column. The backend merges the runtime global filter into the chart's static `where` by **per-field replacement** (`IExecutions.whereWithGlobalFilters`): a global `STATE` filter *removes* the chart's `STATE` `where`.

So the per-state tabs (Success / Failed / …) escape any chart-level `STATE` constraint, while the **All** tab — which sent no state filter — stayed bound by it. On any dashboard whose chart constrains `STATE` via `where` (custom / DB-stored dashboards, or the pre-#16616 "Executions In Progress" widget), **All** only showed those states and was empty whenever none were present, even though the per-state tabs were full.

#16616 only removed the `where` from the bundled default dashboard; this fixes the underlying feature for every dashboard.

## Fix

`TableQuickFilter.vue`: the **All** tab now emits the union of every tab's states **when the chart constrains `STATE`**, overriding that `where` through the existing replacement semantics — so **All** always shows at least what any individual tab can. Charts without a `STATE` `where` still send no filter (truly all states, `RESUBMITTED` included), so nothing changes for the default dashboards.

## Tests

Added `tableQuickFilter.spec.ts`:
- no `STATE` where → All emits no filter
- `STATE` where → All emits the full state set
- a state tab emits its own states

`check:types` and ESLint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)