### PR TITLE
test(cli): fix configBeforeSubcommandIsLoaded on releases/v1.3.x

### DIFF
--- a/cli/src/test/java/io/kestra/cli/AppTest.java
+++ b/cli/src/test/java/io/kestra/cli/AppTest.java
@@ -2,6 +2,7 @@ package io.kestra.cli;
 
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
+import java.lang.reflect.Method;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
@@ -10,6 +11,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
 import io.kestra.core.models.ServerType;
+import picocli.CommandLine;
 
 import io.micronaut.context.ApplicationContext;
 import io.micronaut.context.env.Environment;
@@ -62,13 +64,25 @@ class AppTest {
         try {
             Files.writeString(configFile, "kestra:\n  test:\n    marker: config-loaded\n");
 
-            // --config BEFORE "flow" — this is the position that previously failed
-            String[] args = { "--config", configFile.toString(), "flow", "namespace", "update" };
+            // --config BEFORE "plugins" — this is the position that previously failed.
+            // plugins list has no required positional args so picocli can parse to the leaf
+            // command even when --config is silently dropped by continueOnParsingErrors.
+            String[] args = { "--config", configFile.toString(), "plugins", "list" };
 
-            try (ApplicationContext ctx = App.applicationContext(App.class, new String[] { Environment.CLI }, args)) {
-                assertThat(ctx.getProperty("kestra.test.marker", String.class))
-                    .hasValue("config-loaded");
-            }
+            // Access the private getCommandLine() via reflection — keeps it private in
+            // production code while still letting us verify recoverConfigOption() works.
+            // We deliberately avoid creating an ApplicationContext here because doing so
+            // has global side effects in the test JVM (datasource / gRPC initialization)
+            // that break subsequent tests.
+            Method getCommandLine = App.class.getDeclaredMethod("getCommandLine", Class.class, String[].class);
+            getCommandLine.setAccessible(true);
+            CommandLine leafCmd = (CommandLine) getCommandLine.invoke(null, App.class, args);
+
+            Object userObject = leafCmd.getCommandSpec().userObject();
+            assertThat(userObject).isInstanceOf(AbstractCommand.class);
+            AbstractCommand abstractCmd = (AbstractCommand) userObject;
+            assertThat(abstractCmd.propertiesFromConfig())
+                .containsEntry("kestra.test.marker", "config-loaded");
         } finally {
             Files.deleteIfExists(configFile);
         }


### PR DESCRIPTION
## Summary

- The `configBeforeSubcommandIsLoaded` regression test (added in the `--config` before subcommand fix) was failing because `ctx.getProperty()` returns empty without an explicit `Environment.start()` call, and calling `start()` has global side effects in the test JVM
- Also fixes a subtle issue: the original test used `flow namespace update` as the subcommand, which has required positional args — picocli fails to parse to the leaf command, leaving the root `App` instance instead of the expected `AbstractCommand`
- Companion test fix for kestra-io/kestra#16775 (develop branch)

## Changes

- Switch from `applicationContext()` + `ctx.getProperty()` to reflection-based access of the private `getCommandLine()`, testing `propertiesFromConfig()` directly
- Switch subcommand from `flow namespace update` (required args) to `plugins list` (no required args)

## Test plan

- [ ] `./gradlew :cli:test --tests "io.kestra.cli.AppTest"` — all 10 tests pass