### PR TITLE
test(e2e): fix strict-mode locator violation for INPUT_A in flow.spec.ts

### DIFF
--- a/ui/tests/e2e/flow.spec.ts
+++ b/ui/tests/e2e/flow.spec.ts
@@ -89,7 +89,7 @@ test.describe("Flow Page", () => {
 
             await page.getByRole("button", {name: "Execute"}).first().click();
 
-            await expect(page.getByRole("dialog").getByText("INPUT_A")).toBeVisible();
+            await expect(page.getByRole("dialog").getByText("INPUT_A", {exact: true})).toBeVisible();
             await page.getByRole("dialog").getByTestId("monaco-editor").getByRole("textbox").fill(inputValue);
             await page.waitForTimeout(2100);
             await page.getByRole("dialog").getByRole("button", {name: "Execute"}).click();


### PR DESCRIPTION
## Summary

- `getByText("INPUT_A")` without `exact: true` now resolves to **two elements** in the execute dialog: the input label `<p>INPUT_A</p>` and a new validation warning span `Missing required input:INPUT_A`
- Playwright's strict mode rejects locators that match more than one element, causing the test to fail on every retry
- The same fix was already applied to `develop` in a prior commit

## Changes

- `ui/tests/e2e/flow.spec.ts`: add `{ exact: true }` to the `getByText("INPUT_A")` locator so it only matches the label element

## Test plan

- [ ] E2E tests pass: `cd ui && npx playwright test tests/e2e/flow.spec.ts`
- [ ] Specifically `Flow Page > should create and execute a Flow with input` no longer fails with strict mode violation