### PR TITLE
fix(secrets): label KV store edit action "Edit" instead of "Update"

### DIFF
--- a/ui/src/components/kv/KVTable.vue
+++ b/ui/src/components/kv/KVTable.vue
@@ -120,7 +120,7 @@
             <template #default="scope">
                 <KsIconButton
                     v-if="canUpdate(scope.row)"
-                    :tooltip="$t('update')"
+                    :tooltip="$t('edit')"
                     placement="left"
                     @click="updateKvModal(scope.row)"
                 >


### PR DESCRIPTION
Changes the KV store row action tooltip from "Update" to "Edit" by pointing it at the existing `edit` translation key, so it reads correctly in every language without touching the shared `update` key.

Closes https://github.com/kestra-io/kestra-ee/issues/8573

🤖 Generated with [Claude Code](https://claude.com/claude-code)