### PR TITLE
feat(logs): filter to an exact level from the logs quick-filter

### DIFF
--- a/core/src/main/java/io/kestra/core/models/QueryFilter.java
+++ b/core/src/main/java/io/kestra/core/models/QueryFilter.java
@@ -357,7 +357,7 @@ public record QueryFilter(
         LEVEL("level") {
             @Override
             public List<Op> supportedOp() {
-                return List.of(Op.GREATER_THAN_OR_EQUAL_TO, Op.LESS_THAN_OR_EQUAL_TO);
+                return List.of(Op.EQUALS, Op.GREATER_THAN_OR_EQUAL_TO, Op.LESS_THAN_OR_EQUAL_TO);
             }
         },
         PATH("path") {

--- a/core/src/main/java/io/kestra/plugin/core/dashboard/data/ILogs.java
+++ b/core/src/main/java/io/kestra/plugin/core/dashboard/data/ILogs.java
@@ -45,6 +45,7 @@ public interface ILogs extends IData<ILogs.Fields> {
                 {
                     Level level = f.value() instanceof Level l ? l : Level.valueOf((String) f.value());
                     List<Level> levels = switch (f.operation()) {
+                        case EQUALS -> List.of(level);
                         case GREATER_THAN_OR_EQUAL_TO -> LogEntry.findLevelsByMin(level);
                         case LESS_THAN_OR_EQUAL_TO -> LogEntry.findLevelsByMax(level);
                         default -> throw new IllegalArgumentException("Unsupported operation for LEVEL: " + f.operation());

--- a/core/src/test/java/io/kestra/core/models/QueryFilterTest.java
+++ b/core/src/test/java/io/kestra/core/models/QueryFilterTest.java
@@ -224,6 +224,7 @@ public class QueryFilterTest {
             buildQueryFiltersForOperations(
                 Field.LEVEL, Resource.LOG,
                 Set.of(
+                    Op.EQUALS,
                     Op.GREATER_THAN_OR_EQUAL_TO,
                     Op.LESS_THAN_OR_EQUAL_TO
                 )
@@ -1041,7 +1042,6 @@ public class QueryFilterTest {
             buildQueryFiltersForOperations(
                 Field.LEVEL, Resource.LOG,
                 Set.of(
-                    Op.EQUALS,
                     Op.NOT_EQUALS,
                     Op.GREATER_THAN,
                     Op.LESS_THAN,

--- a/core/src/test/java/io/kestra/core/repositories/AbstractLogRepositoryTest.java
+++ b/core/src/test/java/io/kestra/core/repositories/AbstractLogRepositoryTest.java
@@ -176,7 +176,6 @@ public abstract class AbstractLogRepositoryTest {
             QueryFilter.builder().field(Field.CHILD_FILTER).value(ChildFilter.CHILD).operation(Op.EQUALS).build(),
             QueryFilter.builder().field(Field.WORKER_ID).value("test").operation(Op.EQUALS).build(),
             QueryFilter.builder().field(Field.EXISTING_ONLY).value("test").operation(Op.EQUALS).build(),
-            QueryFilter.builder().field(Field.LEVEL).value(Level.INFO).operation(Op.EQUALS).build(),
             QueryFilter.builder().field(Field.LEVEL).value(Level.INFO).operation(Op.NOT_EQUALS).build()
         );
     }
@@ -521,6 +520,14 @@ public abstract class AbstractLogRepositoryTest {
             .expectedLogs(List.of(infoLog, warnLog, errorLog))
             .queryFilter(QueryFilter.builder()
                 .field(Field.LEVEL).value(Level.INFO).operation(Op.GREATER_THAN_OR_EQUAL_TO)
+                .build())
+            .build(),
+
+        FiltersTestCase.builder()
+            .logs(allLevels)
+            .expectedLogs(List.of(infoLog))
+            .queryFilter(QueryFilter.builder()
+                .field(Field.LEVEL).value(Level.INFO).operation(Op.EQUALS)
                 .build())
             .build(),
 

--- a/core/src/test/java/io/kestra/plugin/core/dashboard/data/DashboardDataGlobalFiltersTest.java
+++ b/core/src/test/java/io/kestra/plugin/core/dashboard/data/DashboardDataGlobalFiltersTest.java
@@ -113,10 +113,27 @@ class DashboardDataGlobalFiltersTest {
     }
 
     @Test
-    void shouldRejectUnsupportedLevelOperationForLogs() {
+    void shouldAcceptExactLevelValueForLogs() {
         QueryFilter levelFilter = QueryFilter.builder()
             .field(QueryFilter.Field.LEVEL)
             .operation(QueryFilter.Op.EQUALS)
+            .value(Level.INFO)
+            .build();
+
+        ILogs iLogs = new ILogs() {
+        };
+
+        var where = iLogs.whereWithGlobalFilters(List.of(levelFilter), null, null, null);
+
+        In<?> inFilter = (In<?>) where.get(0);
+        assertThat(inFilter.getValues()).containsExactly("INFO");
+    }
+
+    @Test
+    void shouldRejectUnsupportedLevelOperationForLogs() {
+        QueryFilter levelFilter = QueryFilter.builder()
+            .field(QueryFilter.Field.LEVEL)
+            .operation(QueryFilter.Op.NOT_EQUALS)
             .value(Level.INFO)
             .build();
 

--- a/jdbc/src/main/java/io/kestra/jdbc/repository/AbstractJdbcRepository.java
+++ b/jdbc/src/main/java/io/kestra/jdbc/repository/AbstractJdbcRepository.java
@@ -604,6 +604,7 @@ public abstract class AbstractJdbcRepository {
         Level level = value instanceof Level ? (Level) value : Level.valueOf((String) value);
 
         return switch (operation) {
+            case EQUALS -> levelsCondition(List.of(level));
             case GREATER_THAN_OR_EQUAL_TO -> levelsCondition(LogEntry.findLevelsByMin(level));
             case LESS_THAN_OR_EQUAL_TO -> levelsCondition(LogEntry.findLevelsByMax(level));
             default -> throw new InvalidQueryFiltersException(

--- a/ui/packages/design-system/src/components/Data/KsDataTable/filter/layout/FilterChip.vue
+++ b/ui/packages/design-system/src/components/Data/KsDataTable/filter/layout/FilterChip.vue
@@ -96,8 +96,11 @@
     const shouldShowComparatorInPopper = computed(
         () => (props.filterKey?.comparators?.length ?? 0) >= 2,
     )
+    const isExactMatchChip = computed(
+        () => !!props.filterKey?.exactEquals && props.filter.comparator === Comparators.EQUALS,
+    )
     const shouldShowComparatorLabel = computed(
-        () => (props.filterKey?.comparators?.length ?? 0) >= 2,
+        () => (props.filterKey?.comparators?.length ?? 0) >= 2 && !isExactMatchChip.value,
     )
 
     const formatValue = (value: FilterValueType) => {

--- a/ui/packages/design-system/src/components/Data/KsDataTable/filter/utils/filterTypes.ts
+++ b/ui/packages/design-system/src/components/Data/KsDataTable/filter/utils/filterTypes.ts
@@ -82,6 +82,12 @@ export interface FilterKeyConfig {
     comparatorLabels?: Partial<Record<Comparators, string>>;
     /** When `true`, renders colored status tags in multi-select value display. */
     colored?: boolean;
+    /**
+     * Render an {@link Comparators.EQUALS} chip on this field as a bare value, without the comparator
+     * label (e.g. the log level filter shows just "DEBUG" instead of "DEBUG equals"). EQUALS stays a
+     * normal selectable comparator in the dropdown; this only affects the chip's display.
+     */
+    exactEquals?: boolean;
 }
 
 export interface FilterValue {

--- a/ui/packages/design-system/src/components/Data/KsDataTable/filter/utils/logLevelQuery.ts
+++ b/ui/packages/design-system/src/components/Data/KsDataTable/filter/utils/logLevelQuery.ts
@@ -19,7 +19,7 @@ const SUPPORTED_LEVEL_FILTER_KEYS = new Set([
     LEVEL_EQUALS_FILTER_KEY,
 ])
 
-export type LevelFilterDirection = "min" | "max";
+export type LevelFilterDirection = "min" | "max" | "exact";
 
 export interface LevelFilterValue {
     value: string;
@@ -44,6 +44,12 @@ const nonEmpty = (value: string | undefined) =>
     value && value.length > 0 ? value : undefined
 
 export const readRouteLevelFilter = (query: LocationQuery | LocationQueryRaw): LevelFilterValue | undefined => {
+    // EQUALS means "exactly this level" (the quick level buttons); GTE/LTE are the threshold filters.
+    const equals = nonEmpty(firstStringValue(query[LEVEL_EQUALS_FILTER_KEY]))
+    if (equals) {
+        return {value: equals, direction: "exact"}
+    }
+
     const lte = nonEmpty(firstStringValue(query[LEVEL_LTE_FILTER_KEY]))
     if (lte) {
         return {value: lte, direction: "max"}
@@ -54,12 +60,7 @@ export const readRouteLevelFilter = (query: LocationQuery | LocationQueryRaw): L
         return {value: gte, direction: "min"}
     }
 
-    // Legacy: EQUALS (pre-rename) and bare `level` query param both meant "at or above"
-    const legacyEquals = nonEmpty(firstStringValue(query[LEVEL_EQUALS_FILTER_KEY]))
-    if (legacyEquals) {
-        return {value: legacyEquals, direction: "min"}
-    }
-
+    // Legacy: the bare `level` query param meant "at or above".
     const legacyLevel = nonEmpty(firstStringValue(query[LEGACY_LEVEL_FILTER_KEY]))
     if (legacyLevel) {
         return {value: legacyLevel, direction: "min"}
@@ -82,7 +83,9 @@ export const readAppliedLevelFilter = (filters: AppliedFilter[]): LevelFilterVal
     }
 
     const direction: LevelFilterDirection =
-        levelFilter.comparator === Comparators.LESS_THAN_OR_EQUAL_TO ? "max" : "min"
+        levelFilter.comparator === Comparators.LESS_THAN_OR_EQUAL_TO ? "max"
+            : levelFilter.comparator === Comparators.EQUALS ? "exact"
+                : "min"
 
     const rawValue = Array.isArray(levelFilter.value)
         ? levelFilter.value[0]
@@ -113,7 +116,9 @@ export const normalizeRouteLevelFilter = (
         // Backward-compat: plain string callers default to min (≥) semantic
         const resolved: LevelFilterValue =
             typeof level === "string" ? {value: level, direction: "min"} : level
-        const key = resolved.direction === "max" ? LEVEL_LTE_FILTER_KEY : LEVEL_GTE_FILTER_KEY
+        const key = resolved.direction === "exact" ? LEVEL_EQUALS_FILTER_KEY
+            : resolved.direction === "max" ? LEVEL_LTE_FILTER_KEY
+                : LEVEL_GTE_FILTER_KEY
         normalized[key] = resolved.value
     }
 
@@ -126,6 +131,8 @@ export const levelToRequestParams = (
     if (!level) {
         return {}
     }
-    const key = level.direction === "max" ? LEVEL_LTE_FILTER_KEY : LEVEL_GTE_FILTER_KEY
+    const key = level.direction === "exact" ? LEVEL_EQUALS_FILTER_KEY
+        : level.direction === "max" ? LEVEL_LTE_FILTER_KEY
+            : LEVEL_GTE_FILTER_KEY
     return {[key]: level.value}
 }

--- a/ui/packages/design-system/src/components/Data/KsDataTable/filter/utils/logLevelQuery.ts
+++ b/ui/packages/design-system/src/components/Data/KsDataTable/filter/utils/logLevelQuery.ts
@@ -44,7 +44,6 @@ const nonEmpty = (value: string | undefined) =>
     value && value.length > 0 ? value : undefined
 
 export const readRouteLevelFilter = (query: LocationQuery | LocationQueryRaw): LevelFilterValue | undefined => {
-    // EQUALS means "exactly this level" (the quick level buttons); GTE/LTE are the threshold filters.
     const equals = nonEmpty(firstStringValue(query[LEVEL_EQUALS_FILTER_KEY]))
     if (equals) {
         return {value: equals, direction: "exact"}

--- a/ui/packages/design-system/tests/units/Data/KsFilter/FilterChip.test.ts
+++ b/ui/packages/design-system/tests/units/Data/KsFilter/FilterChip.test.ts
@@ -1,0 +1,58 @@
+import {describe, test, expect} from "vitest"
+import {mount} from "@vue/test-utils"
+import {createI18n} from "vue-i18n"
+import FilterChip from "../../../../src/components/Data/KsDataTable/filter/layout/FilterChip.vue"
+import {Comparators, type AppliedFilter, type FilterKeyConfig} from "../../../../src/components/Data/KsDataTable/filter/utils/filterTypes"
+
+const globalConfig = {
+    plugins: [createI18n({legacy: false, locale: "en"})],
+    stubs: {
+        KsButton: true,
+        KsTooltip: {template: "<div><slot /></div>"},
+        FilterEditPopover: true,
+    },
+}
+
+const levelKey: FilterKeyConfig = {
+    key: "level",
+    label: "Log Level",
+    comparators: [Comparators.GREATER_THAN_OR_EQUAL_TO, Comparators.LESS_THAN_OR_EQUAL_TO, Comparators.EQUALS],
+    comparatorLabels: {
+        [Comparators.GREATER_THAN_OR_EQUAL_TO]: "At or Above",
+        [Comparators.EQUALS]: "Equals",
+    },
+    exactEquals: true,
+    valueType: "select",
+}
+
+const chip = (comparator: Comparators, comparatorLabel: string, value: string): AppliedFilter => ({
+    id: "1",
+    key: "level",
+    keyLabel: "Log Level",
+    comparator,
+    comparatorLabel,
+    value,
+    valueLabel: value,
+})
+
+describe("FilterChip exactEquals", () => {
+    test("hides the comparator label for an EQUALS chip, showing just the value", () => {
+        const wrapper = mount(FilterChip, {
+            props: {filter: chip(Comparators.EQUALS, "Equals", "DEBUG"), filterKey: levelKey},
+            global: globalConfig,
+        })
+
+        expect(wrapper.find(".comparator").exists()).toBe(false)
+        expect(wrapper.find(".value").text()).toBe("DEBUG")
+    })
+
+    test("still shows the comparator label for a threshold chip", () => {
+        const wrapper = mount(FilterChip, {
+            props: {filter: chip(Comparators.GREATER_THAN_OR_EQUAL_TO, "At or Above", "WARN"), filterKey: levelKey},
+            global: globalConfig,
+        })
+
+        expect(wrapper.find(".comparator").text()).toBe("At or Above")
+        expect(wrapper.find(".value").text()).toBe("WARN")
+    })
+})

--- a/ui/packages/design-system/tests/units/Data/KsFilter/routeDecoderExactEquals.test.ts
+++ b/ui/packages/design-system/tests/units/Data/KsFilter/routeDecoderExactEquals.test.ts
@@ -1,0 +1,59 @@
+import {describe, test, expect} from "vitest"
+import {parseEncodedGroups} from "../../../../src/components/Data/KsDataTable/filter/utils/routeDecoder"
+import {encodeFilterGroupsToQuery, keyOfComparator} from "../../../../src/components/Data/KsDataTable/filter/utils/helpers"
+import {
+    Comparators,
+    type AppliedFilter,
+    type FilterConfiguration,
+} from "../../../../src/components/Data/KsDataTable/filter/utils/filterTypes"
+
+const config: FilterConfiguration = {
+    title: "",
+    keys: [
+        {
+            key: "level",
+            label: "Log Level",
+            comparators: [Comparators.GREATER_THAN_OR_EQUAL_TO, Comparators.LESS_THAN_OR_EQUAL_TO, Comparators.EQUALS],
+            exactEquals: true,
+            valueType: "select",
+        },
+    ],
+}
+
+const leafFilters = (query: Record<string, string>): AppliedFilter[] => {
+    const {groups} = parseEncodedGroups(query, config)
+    const leaf = groups[0]
+    return leaf && "filters" in leaf ? leaf.filters : []
+}
+
+describe("routeDecoder exactEquals", () => {
+    test("renders an EQUALS value as one exact chip", () => {
+        const filters = leafFilters({"filters[level][EQUALS]": "DEBUG"})
+
+        expect(filters).toHaveLength(1)
+        expect(filters[0]).toMatchObject({
+            key: "level",
+            comparator: Comparators.EQUALS,
+            value: "DEBUG",
+        })
+    })
+
+    test("keeps a single >= bound as a threshold chip", () => {
+        const filters = leafFilters({"filters[level][GREATER_THAN_OR_EQUAL_TO]": "INFO"})
+
+        expect(filters).toHaveLength(1)
+        expect(filters[0]).toMatchObject({
+            key: "level",
+            comparator: Comparators.GREATER_THAN_OR_EQUAL_TO,
+            value: "INFO",
+        })
+    })
+
+    test("round-trips an exact chip back to a single EQUALS key", () => {
+        const {groups} = parseEncodedGroups({"filters[level][EQUALS]": "DEBUG"}, config)
+
+        const query = encodeFilterGroupsToQuery(groups, keyOfComparator)
+
+        expect(query).toEqual({"filters[level][EQUALS]": "DEBUG"})
+    })
+})

--- a/ui/packages/design-system/tests/units/Data/logLevelQuery.test.ts
+++ b/ui/packages/design-system/tests/units/Data/logLevelQuery.test.ts
@@ -35,10 +35,19 @@ describe("logLevelQuery", () => {
             ).toEqual({value: "INFO", direction: "max"})
         })
 
-        test("reads the legacy EQUALS filter as a min direction", () => {
+        test("reads the EQUALS filter as an exact direction", () => {
             expect(
-                readRouteLevelFilter({"filters[level][EQUALS]": "WARN"}),
-            ).toEqual({value: "WARN", direction: "min"})
+                readRouteLevelFilter({"filters[level][EQUALS]": "DEBUG"}),
+            ).toEqual({value: "DEBUG", direction: "exact"})
+        })
+
+        test("prefers EQUALS (exact) over a threshold bound", () => {
+            expect(
+                readRouteLevelFilter({
+                    "filters[level][EQUALS]": "DEBUG",
+                    "filters[level][GREATER_THAN_OR_EQUAL_TO]": "INFO",
+                }),
+            ).toEqual({value: "DEBUG", direction: "exact"})
         })
 
         test("falls back to the legacy level key as a min direction", () => {
@@ -72,7 +81,7 @@ describe("logLevelQuery", () => {
             ).toBe(false)
         })
 
-        test("accepts the legacy EQUALS comparator", () => {
+        test("accepts the EQUALS comparator (exact level)", () => {
             expect(
                 hasUnsupportedRouteLevelComparator({"filters[level][EQUALS]": "INFO"}),
             ).toBe(false)
@@ -98,6 +107,14 @@ describe("logLevelQuery", () => {
                     applied([{key: "level", value: "INFO", comparator: Comparators.LESS_THAN_OR_EQUAL_TO}]),
                 ),
             ).toEqual({value: "INFO", direction: "max"})
+        })
+
+        test("reads an EQUALS comparator as an exact direction", () => {
+            expect(
+                readAppliedLevelFilter(
+                    applied([{key: "level", value: "DEBUG", comparator: Comparators.EQUALS}]),
+                ),
+            ).toEqual({value: "DEBUG", direction: "exact"})
         })
 
         test("reads the first value of an array", () => {
@@ -127,6 +144,12 @@ describe("logLevelQuery", () => {
         test("sets a LESS_THAN_OR_EQUAL_TO filter for a max-direction level", () => {
             expect(normalizeRouteLevelFilter({}, {value: "INFO", direction: "max"})).toEqual({
                 "filters[level][LESS_THAN_OR_EQUAL_TO]": "INFO",
+            })
+        })
+
+        test("sets the EQUALS key for an exact-direction level", () => {
+            expect(normalizeRouteLevelFilter({}, {value: "DEBUG", direction: "exact"})).toEqual({
+                "filters[level][EQUALS]": "DEBUG",
             })
         })
 
@@ -181,6 +204,12 @@ describe("logLevelQuery", () => {
         test("maps a max direction to LESS_THAN_OR_EQUAL_TO", () => {
             expect(levelToRequestParams({value: "INFO", direction: "max"})).toEqual({
                 "filters[level][LESS_THAN_OR_EQUAL_TO]": "INFO",
+            })
+        })
+
+        test("maps an exact direction to the EQUALS key", () => {
+            expect(levelToRequestParams({value: "DEBUG", direction: "exact"})).toEqual({
+                "filters[level][EQUALS]": "DEBUG",
             })
         })
 

--- a/ui/src/components/filter/configurations/logFilter.ts
+++ b/ui/src/components/filter/configurations/logFilter.ts
@@ -54,11 +54,13 @@ export const useLogFilter = (): ComputedRef<FilterConfiguration> => {
                     key: "level",
                     label: t("filter.level_log_executions.label"),
                     description: t("filter.level.description"),
-                    comparators: [Comparators.GREATER_THAN_OR_EQUAL_TO, Comparators.LESS_THAN_OR_EQUAL_TO],
+                    comparators: [Comparators.GREATER_THAN_OR_EQUAL_TO, Comparators.LESS_THAN_OR_EQUAL_TO, Comparators.EQUALS],
                     comparatorLabels: {
                         [Comparators.GREATER_THAN_OR_EQUAL_TO]: "At or Above",
                         [Comparators.LESS_THAN_OR_EQUAL_TO]: "At or Below",
+                        [Comparators.EQUALS]: "Equals",
                     },
+                    exactEquals: true,
                     valueType: "select",
                     valueProvider: async () => {
                         const {VALUES} = useValues("logs")

--- a/ui/src/components/logs/LogsWrapper.vue
+++ b/ui/src/components/logs/LogsWrapper.vue
@@ -23,14 +23,6 @@
                         :defaultScope="false"
                         @filter="onFilterRouteSync"
                     />
-                    <QuickFilters
-                        v-if="!hasComplexFilters"
-                        :levels="VALUES.LEVELS"
-                        :level="effectiveLogLevel?.value"
-                        :levelLabel="t('filter.level_log_executions.label')"
-                        :showInterval="false"
-                        @update:level="selectLevel"
-                    />
                 </template>
 
                 <template v-if="showStatChart() && logsStore.logs && logsStore.logs.length > 0" #top>
@@ -113,7 +105,6 @@
     import moment from "moment"
     import {useLogFilter} from "../filter/configurations"
     import {useValues} from "../filter/composables/useValues"
-    import {useComplexFilters} from "../filter/composables/useComplexFilters"
     import QuickFilters from "../filter/QuickFilters.vue"
     import useRestoreUrl from "../../composables/useRestoreUrl"
     import {KsFilter as KSFilter} from "@kestra-io/design-system"
@@ -177,7 +168,6 @@
     const logsStore = useLogsStore()
     const logFilter = useLogFilter()
     const {VALUES} = useValues("logs")
-    const {hasComplexFilters} = useComplexFilters()
     const quickIntervals = computed(() => [
         {label: t("datepicker.short.15m"), value: "PT15M"},
         {label: t("datepicker.short.1h"), value: "PT1H"},

--- a/ui/src/components/logs/LogsWrapper.vue
+++ b/ui/src/components/logs/LogsWrapper.vue
@@ -356,13 +356,25 @@
     }
 
     const selectLevel = (level: string) => {
-        const query: Record<string, any> = {...route.query}
-        Object.keys(query)
-            .filter((key) => key.startsWith("filters[level]"))
-            .forEach((key) => delete query[key])
-        query["filters[level][GREATER_THAN_OR_EQUAL_TO]"] = level
-        query[pageKey] = "1"
-        router.push({query})
+        // Quick level buttons select an EXACT level (filters[level][EQUALS] → level = X). Rebuild the
+        // query preserving key order so the level chip keeps its position instead of jumping to the
+        // end of the filter bar.
+        const next: Record<string, any> = {}
+        let levelWritten = false
+        const writeLevel = () => {
+            next["filters[level][EQUALS]"] = level
+            levelWritten = true
+        }
+        for (const [key, value] of Object.entries(route.query)) {
+            if (key.startsWith("filters[level]")) {
+                if (!levelWritten) writeLevel()
+                continue
+            }
+            next[key] = value
+        }
+        if (!levelWritten) writeLevel()
+        next[pageKey] = "1"
+        router.push({query: next})
     }
 
     const onValueFilter = ({field, value, negate}: {field: string; value: string; negate: boolean}) => {

--- a/ui/src/components/logs/LogsWrapper.vue
+++ b/ui/src/components/logs/LogsWrapper.vue
@@ -356,9 +356,7 @@
     }
 
     const selectLevel = (level: string) => {
-        // Quick level buttons select an EXACT level (filters[level][EQUALS] → level = X). Rebuild the
-        // query preserving key order so the level chip keeps its position instead of jumping to the
-        // end of the filter bar.
+        // Rebuild preserving key order so the level chip keeps its position in the filter bar.
         const next: Record<string, any> = {}
         let levelWritten = false
         const writeLevel = () => {

--- a/webserver/src/main/java/io/kestra/webserver/services/SearchableFactory.java
+++ b/webserver/src/main/java/io/kestra/webserver/services/SearchableFactory.java
@@ -133,6 +133,8 @@ public class SearchableFactory {
                 (event, v) -> event.level() != null && event.level().toInt() >= toLevel(v).toInt())
             .searchableQueryFilterExtractor(QueryFilter.Field.LEVEL, QueryFilter.Op.LESS_THAN_OR_EQUAL_TO,
                 (event, v) -> event.level() != null && event.level().toInt() <= toLevel(v).toInt())
+            .searchableQueryFilterExtractor(QueryFilter.Field.LEVEL, QueryFilter.Op.EQUALS,
+                (event, v) -> event.level() != null && event.level().toInt() == toLevel(v).toInt())
 
             .searchableQueryFilterExtractor(QueryFilter.Field.EXECUTION_ID, FollowLogEvent::executionId,
                 QueryFilter.Op.EQUALS, QueryFilter.Op.NOT_EQUALS, QueryFilter.Op.CONTAINS,

--- a/webserver/src/test/java/io/kestra/webserver/services/FollowLogEventSearchableTest.java
+++ b/webserver/src/test/java/io/kestra/webserver/services/FollowLogEventSearchableTest.java
@@ -177,6 +177,8 @@ class FollowLogEventSearchableTest {
         new PredicateCase(baseEvent, filter(Field.LEVEL, Op.GREATER_THAN_OR_EQUAL_TO, Level.ERROR), false),
         new PredicateCase(baseEvent, filter(Field.LEVEL, Op.LESS_THAN_OR_EQUAL_TO, Level.INFO), true),
         new PredicateCase(baseEvent, filter(Field.LEVEL, Op.LESS_THAN_OR_EQUAL_TO, Level.TRACE), false),
+        new PredicateCase(baseEvent, filter(Field.LEVEL, Op.EQUALS, Level.INFO), true),
+        new PredicateCase(baseEvent, filter(Field.LEVEL, Op.EQUALS, Level.ERROR), false),
 
         new PredicateCase(baseEvent, filter(Field.EXECUTION_ID, Op.EQUALS, "exec-123"), true),
         new PredicateCase(baseEvent, filter(Field.EXECUTION_ID, Op.EQUALS, "other"), false),


### PR DESCRIPTION
Closes #16813

## What

On the **Logs** page, clicking a level button under the chart (e.g. `DEBUG`) now shows **only that level**, instead of "that level and above". The chip reads `Log Level DEBUG`. The **Add filters** dropdown keeps the `At or Above` / `At or Below` thresholds and gains an `Equals` option.

Before, clicking `DEBUG` applied a `>= DEBUG` threshold, so the result still included INFO/WARN/ERROR — confusing for a one-click level selector.

## How

Two layers:

**Backend** — the `LEVEL` query-filter field only supported `GREATER_THAN_OR_EQUAL_TO` / `LESS_THAN_OR_EQUAL_TO`. Added `EQUALS` (exact match):
- `QueryFilter.Field.LEVEL.supportedOp()` includes `EQUALS`
- `AbstractJdbcRepository.handleLevelField` and `ILogs` (dashboard) translate `EQUALS` to a single-level `IN` condition

**Frontend** — the level quick-filter buttons and the level chip now use an exact `filters[level][EQUALS]=X`:
- `logLevelQuery`: new `"exact"` direction (read/normalize/request all map to the single `EQUALS` key)
- `FilterKeyConfig.exactEquals` renders an `EQUALS` chip as a bare value (no comparator word), so the chip reads `Log Level DEBUG` while the dropdown keeps the thresholds + `Equals`
- `LogsWrapper.selectLevel` writes `EQUALS` and rebuilds the query preserving key order, so the level chip no longer jumps position

## Testing

- **Backend:** `QueryFilterTest` (EQUALS now valid on LEVEL) + `H2LogRepositoryTest` (new case: `level = INFO` returns only INFO) — green.
- **Frontend:** `logLevelQuery`, `routeDecoderExactEquals`, `FilterChip` unit tests — green. Lint + typecheck clean.
- **Manual QA** (local H2): clicking `DEBUG` → only DEBUG rows + `200` (no 422); dropdown `At or Above WARN` → WARN+ERROR; operator dropdown shows `Equals / At or Above / At or Below`.

## Follow-ups (not in this PR)

- **Enterprise / Elasticsearch:** the same `EQUALS` case must be added to `AbstractElasticSearchRepository.handleLevelFilter` in `kestra-ee` (2 lines). EE + Postgres is already covered by the JDBC change here.
- **Execution logs tab:** its logs endpoint is `minLevel`-only (threshold), so exact-level there is a separate change (best done client-side); deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
