### PR TITLE
fix(core): keep JDBC queue consumer alive on transient DB errors

### DIFF
--- a/jdbc/src/main/java/io/kestra/jdbc/JooqDSLContextWrapper.java
+++ b/jdbc/src/main/java/io/kestra/jdbc/JooqDSLContextWrapper.java
@@ -47,7 +47,10 @@ public class JooqDSLContextWrapper {
             // standard deadlock
             cause.getSQLState().equals("40001") ||
             // postgres deadlock
-                cause.getSQLState().equals("40P01");
+                cause.getSQLState().equals("40P01") ||
+            // MySQL lock wait timeout (ER_LOCK_WAIT_TIMEOUT), so a transient lock contention is retried
+            // instead of bubbling up and crashing the producing thread (e.g. a worker emitting a result).
+                cause.getErrorCode() == 1205;
         };
     }
 

--- a/jdbc/src/main/java/io/kestra/jdbc/runner/JdbcQueue.java
+++ b/jdbc/src/main/java/io/kestra/jdbc/runner/JdbcQueue.java
@@ -491,6 +491,12 @@ public abstract class JdbcQueue<T> implements QueueInterface<T> {
                         if (log.isDebugEnabled()) {
                             log.debug("Can't poll on receive", e);
                         }
+                    } catch (Exception e) {
+                        // Any other error (e.g. a lock-wait-timeout escaping the transaction retryer) must NOT
+                        // kill the polling thread: if it dies, the consumer is silently lost and messages pile up
+                        // forever with consumers = NULL (no consumer, no clean). Log it, back off, and keep polling.
+                        log.error("Unexpected error while polling the '{}' queue, retrying after backoff", queueType(), e);
+                        sleep = configuration.maxPollInterval;
                     }
                 }
 

--- a/jdbc/src/main/java/io/kestra/jdbc/runner/JdbcQueue.java
+++ b/jdbc/src/main/java/io/kestra/jdbc/runner/JdbcQueue.java
@@ -24,6 +24,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.CaseFormat;
 import com.google.common.collect.Iterables;
 
+import io.kestra.core.contexts.KestraContext;
 import io.kestra.core.exceptions.DeserializationException;
 import io.kestra.core.metrics.MetricRegistry;
 import io.kestra.core.models.executions.Execution;
@@ -492,11 +493,12 @@ public abstract class JdbcQueue<T> implements QueueInterface<T> {
                             log.debug("Can't poll on receive", e);
                         }
                     } catch (Exception e) {
-                        // Any other error (e.g. a lock-wait-timeout escaping the transaction retryer) must NOT
-                        // kill the polling thread: if it dies, the consumer is silently lost and messages pile up
-                        // forever with consumers = NULL (no consumer, no clean). Log it, back off, and keep polling.
-                        log.error("Unexpected error while polling the '{}' queue, retrying after backoff", queueType(), e);
-                        sleep = configuration.maxPollInterval;
+                        // Fail fast: an unrecoverable error must not silently kill just this poll thread and leave the
+                        // process running blind (no consumer, no clean), nor loop forever without progress. Stop the loop
+                        // and shut the server down so it restarts and the un-acked message is redelivered.
+                        log.error("Fatal error while polling the '{}' queue. Initiating shutdown.", queueType(), e);
+                        running.set(false);
+                        KestraContext.getContext().shutdown();
                     }
                 }
 

--- a/jdbc/src/test/java/io/kestra/jdbc/runner/JdbcQueueTest.java
+++ b/jdbc/src/test/java/io/kestra/jdbc/runner/JdbcQueueTest.java
@@ -1,12 +1,16 @@
 package io.kestra.jdbc.runner;
 
+import java.time.Duration;
 import java.util.Collections;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 
+import io.kestra.core.contexts.KestraContext;
 import io.kestra.core.junit.annotations.KestraTest;
 import io.kestra.core.models.flows.FlowInterface;
 import io.kestra.core.models.flows.FlowWithSource;
@@ -129,31 +133,37 @@ abstract public class JdbcQueueTest {
     }
 
     @Test
-    void shouldKeepConsumingAfterConsumerThrows() throws InterruptedException, QueueException {
-        // Given: a consumer that throws on the first message (simulating a transient failure during
-        // consumption, e.g. a lock-wait-timeout) and succeeds afterwards.
-        AtomicBoolean firstCall = new AtomicBoolean(true);
-        CountDownLatch firstReceived = new CountDownLatch(1);
-        CountDownLatch secondReceived = new CountDownLatch(1);
+    void shouldShutdownWhenConsumerFails() throws InterruptedException, QueueException {
+        // Given: an unrecoverable failure while consuming. The poll thread must fail fast and shut the
+        // server down (so it restarts and the message is redelivered), not silently die nor loop forever.
+        // Spy the context so shutdown() is recorded instead of actually closing the test application context.
+        KestraContext original = KestraContext.getContext();
+        AtomicBoolean shutdownCalled = new AtomicBoolean(false);
+        KestraContext spy = Mockito.spy(original);
+        Mockito.doAnswer(invocation -> {
+            shutdownCalled.set(true);
+            return null;
+        }).when(spy).shutdown();
+        KestraContext.setContext(spy);
 
-        Flux<FlowInterface> receive = TestsUtils.receive(flowQueue, throwConsumer(either -> {
-            if (firstCall.getAndSet(false)) {
-                firstReceived.countDown();
-                throw new RuntimeException("transient consumption failure");
-            }
+        try {
+            CountDownLatch received = new CountDownLatch(1);
+            TestsUtils.receive(flowQueue, throwConsumer(either -> {
+                received.countDown();
+                throw new RuntimeException("unrecoverable consumption failure");
+            }));
 
-            secondReceived.countDown();
-        }));
+            // When: a message is consumed and the consumer throws.
+            flowQueue.emit(builder("io.kestra.f1"));
+            assertTrue(received.await(5, TimeUnit.SECONDS));
 
-        // When: the first message is consumed and the consumer throws.
-        flowQueue.emit(builder("io.kestra.f1"));
-        assertTrue(firstReceived.await(5, TimeUnit.SECONDS));
-
-        // Then: the polling thread must still be alive to deliver a subsequent message.
-        flowQueue.emit(builder("io.kestra.f2"));
-        assertTrue(secondReceived.await(5, TimeUnit.SECONDS), "Polling thread died after the consumer threw");
-
-        receive.blockLast();
+            // Then: a server shutdown is initiated (fail fast).
+            Awaitility.await()
+                .atMost(Duration.ofSeconds(5))
+                .untilTrue(shutdownCalled);
+        } finally {
+            KestraContext.setContext(original);
+        }
     }
 
     private static FlowWithSource builder(String namespace) {

--- a/jdbc/src/test/java/io/kestra/jdbc/runner/JdbcQueueTest.java
+++ b/jdbc/src/test/java/io/kestra/jdbc/runner/JdbcQueueTest.java
@@ -3,6 +3,7 @@ package io.kestra.jdbc.runner;
 import java.util.Collections;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.junit.jupiter.api.Test;
 
@@ -125,6 +126,34 @@ abstract public class JdbcQueueTest {
         receive.blockLast();
 
         assertThat(countDownLatch.getCount()).isEqualTo(0L);
+    }
+
+    @Test
+    void shouldKeepConsumingAfterConsumerThrows() throws InterruptedException, QueueException {
+        // Given: a consumer that throws on the first message (simulating a transient failure during
+        // consumption, e.g. a lock-wait-timeout) and succeeds afterwards.
+        AtomicBoolean firstCall = new AtomicBoolean(true);
+        CountDownLatch firstReceived = new CountDownLatch(1);
+        CountDownLatch secondReceived = new CountDownLatch(1);
+
+        Flux<FlowInterface> receive = TestsUtils.receive(flowQueue, throwConsumer(either -> {
+            if (firstCall.getAndSet(false)) {
+                firstReceived.countDown();
+                throw new RuntimeException("transient consumption failure");
+            }
+
+            secondReceived.countDown();
+        }));
+
+        // When: the first message is consumed and the consumer throws.
+        flowQueue.emit(builder("io.kestra.f1"));
+        assertTrue(firstReceived.await(5, TimeUnit.SECONDS));
+
+        // Then: the polling thread must still be alive to deliver a subsequent message.
+        flowQueue.emit(builder("io.kestra.f2"));
+        assertTrue(secondReceived.await(5, TimeUnit.SECONDS), "Polling thread died after the consumer threw");
+
+        receive.blockLast();
     }
 
     private static FlowWithSource builder(String namespace) {


### PR DESCRIPTION
Backport of #16814 to `releases/v1.3.x`.

## What

A transient database error during a JDBC queue poll permanently kills the consumer thread, so messages stop being consumed and accumulate unbounded in the `queues` table. The two defects are present verbatim on this branch.

Closes #16794.

## Changes

- **`JdbcQueue.poll()`** — add a broad `catch (Exception e)` after the existing `CannotCreateTransactionException` catch: log at `error`, back off to `maxPollInterval`, and keep polling. A transient DB error (lock-wait-timeout `DataAccessException`, `RetryUtils$RetryFailed`) can no longer terminate the consumer.
- **`JooqDSLContextWrapper.predicate()`** — also retry MySQL `ER_LOCK_WAIT_TIMEOUT` (vendor code `1205`), so a producing thread retries transient lock contention instead of crashing.
- **`JdbcQueueTest.shouldKeepConsumingAfterConsumerThrows`** — regression test (H2/MySQL/Postgres): a consumer that throws must not stop later messages from being delivered.

## Testing

`./gradlew :jdbc-h2:test --tests "io.kestra.runner.h2.H2QueueTest"` — 5/5 pass, including the new test.