### PR TITLE
fix(design-system): increase gap between sidebar search and first subcategory

### DIFF
--- a/ui/packages/design-system/src/components/Navigation/KsSideBar/KsSideBar.vue
+++ b/ui/packages/design-system/src/components/Navigation/KsSideBar/KsSideBar.vue
@@ -42,6 +42,7 @@
 .ks-sidebar__header {
     flex: 0 0 auto;
     padding: 0 var(--ks-spacing-4);
+    margin-bottom: var(--ks-spacing-3);
 }
 
 .ks-sidebar__body {


### PR DESCRIPTION
## Summary
- Adds `margin-bottom: var(--ks-spacing-3)` to `.ks-sidebar__header` in `KsSideBar.vue`
- Fixes the missing gap between the search input and the first subcategory in the plugin sidebar

Closes https://github.com/kestra-io/kestra-ee/issues/8642.

## Test plan
- [ ] Open the plugin detail page (e.g. a plugin with multiple subgroups)
- [ ] Verify there is a visible gap between the search input and the first subcategory section title