### PR TITLE
fix(ui): remove redundant X close button from context drawer

### DIFF
--- a/ui/packages/design-system/src/components/Navigation/KsSideBar/KsSideBar.vue
+++ b/ui/packages/design-system/src/components/Navigation/KsSideBar/KsSideBar.vue
@@ -42,6 +42,7 @@
 .ks-sidebar__header {
     flex: 0 0 auto;
     padding: 0 var(--ks-spacing-4);
+    margin-bottom: var(--ks-spacing-3);
 }
 
 .ks-sidebar__body {

--- a/ui/src/components/ContextDrawer.vue
+++ b/ui/src/components/ContextDrawer.vue
@@ -32,9 +32,6 @@
                                 </KsTabPane>
                             </KsTabs>
 
-                            <KsIconButton class="close-btn" :ariaLabel="$t('close')" @click="setActiveTab('')">
-                                <Close />
-                            </KsIconButton>
                         </div>
 
                         <div class="panelContent">
@@ -58,7 +55,6 @@
     import {useStorage, useWindowSize} from "@vueuse/core"
 
     import OpenInNew from "vue-material-design-icons/OpenInNew.vue"
-    import Close from "vue-material-design-icons/Close.vue"
 
     import {useApiStore} from "../stores/api"
     import {useMiscStore} from "override/stores/misc"
@@ -215,14 +211,6 @@
 
         .open-in-new {
             opacity: 0.5;
-        }
-
-        .close-btn {
-            align-self: center;
-            margin-right: 0.5rem;
-            border: none;
-            color: var(--ks-text-dim);
-            flex-shrink: 0;
         }
 
         .newsDot {


### PR DESCRIPTION
## Summary

- Removes the redundant X close button from the context drawer (News/Docs/Help panel)
- The toggle button in the top-right header already closes the panel, making the in-panel X button unnecessary

Closes https://github.com/kestra-io/kestra-ee/issues/8627.

## Test plan

- [ ] Open the right side panel (News, Docs, or Help)
- [ ] Confirm the panel can still be closed via the toggle button in the header
- [ ] Confirm the X button is no longer visible inside the panel