### PR TITLE
fix(design-system): keep KsDropdown menu off the viewport edge

### DIFF
--- a/ui/packages/design-system/src/components/Navigation/KsDropdown/KsDropdown.vue
+++ b/ui/packages/design-system/src/components/Navigation/KsDropdown/KsDropdown.vue
@@ -1,6 +1,7 @@
 <template>
     <ElDropdown
         :persistent="false"
+        :popperOptions="POPPER_OPTIONS"
         v-bind="$attrs"
     >
         <template v-if="$slots.default" #default>
@@ -16,6 +17,13 @@
     import {ElDropdown} from "element-plus"
 
     defineOptions({inheritAttrs: false})
+
+    const POPPER_OPTIONS = {
+        modifiers: [
+            {name: "flip", options: {rootBoundary: "viewport", padding: 8}},
+            {name: "preventOverflow", options: {rootBoundary: "viewport", padding: 8}},
+        ],
+    }
 
     defineSlots<{
         default?(): unknown

--- a/ui/packages/design-system/tests/units/Navigation/KsDropdown.test.ts
+++ b/ui/packages/design-system/tests/units/Navigation/KsDropdown.test.ts
@@ -1,12 +1,16 @@
 import {describe, test, expect} from "vitest"
 import {mount} from "@vue/test-utils"
 import {defineComponent} from "vue"
+import {ElDropdown} from "element-plus"
 import KestraDesignSystem from "../../../src/index"
 import KsDropdown from "../../../src/components/Navigation/KsDropdown/KsDropdown.vue"
 import KsDropdownItem from "../../../src/components/Navigation/KsDropdown/KsDropdownItem.vue"
 import KsDropdownMenu from "../../../src/components/Navigation/KsDropdown/KsDropdownMenu.vue"
 
 const globalConfig = {plugins: [KestraDesignSystem]}
+
+const findModifier = (popperOptions: Record<string, unknown> | undefined, name: string) =>
+    (popperOptions?.modifiers as Array<Record<string, unknown>>)?.find((m) => m.name === name)
 
 const wrapInDropdown = (slotContent: string) =>
     defineComponent({
@@ -30,6 +34,29 @@ describe("KsDropdown", () => {
             global: globalConfig,
         })
         expect(wrapper).toBeTruthy()
+    })
+
+    test("keeps the menu away from the viewport edge by default", () => {
+        const wrapper = mount(KsDropdown, {
+            slots: {default: "<button>Actions</button>"},
+            global: globalConfig,
+        })
+
+        const popperOptions = wrapper.getComponent(ElDropdown).props("popperOptions") as Record<string, unknown>
+
+        expect(findModifier(popperOptions, "preventOverflow")?.options).toEqual({rootBoundary: "viewport", padding: 8})
+        expect(findModifier(popperOptions, "flip")?.options).toEqual({rootBoundary: "viewport", padding: 8})
+    })
+
+    test("lets a caller override the default popper-options", () => {
+        const custom = {strategy: "fixed", modifiers: [{name: "offset", options: {offset: [0, 12]}}]}
+        const wrapper = mount(KsDropdown, {
+            slots: {default: "<button>Actions</button>"},
+            attrs: {popperOptions: custom},
+            global: globalConfig,
+        })
+
+        expect(wrapper.getComponent(ElDropdown).props("popperOptions")).toEqual(custom)
     })
 })
 


### PR DESCRIPTION
## What

`KsDropdown` forwarded everything to `ElDropdown` via `$attrs` but set no popper options, so a menu opening near the right edge of the viewport sat flush against it. This is the Tests-page row-actions dropdown from the issue, but the fix lives at the shared component so it covers every `HamburgerDropdown` / `KsDropdown` call site.

## Change

`KsDropdown` now sets a default `popperOptions` — `flip` and `preventOverflow` with `rootBoundary: viewport` and `padding: 8` — mirroring the existing pattern in `KsEchart`. It is bound before `v-bind="$attrs"`, so a caller can still pass its own `popper-options` to override the default (no call site does today).

## Verification

- **Unit:** `KsDropdown.test.ts` 6/6 (2 new — default viewport padding + caller override). Full design-system unit suite 642/642. oxlint + eslint + vue-tsc clean.
- **Runtime** (Storybook, trigger pinned to the right edge of a 1280px viewport):
  - Before: menu right edge = 1280px (viewport width), 0px gap, overflowing — flush against the edge.
  - After: menu right edge = 1272px, 8px gap, no overflow.

Closes https://github.com/kestra-io/kestra-ee/issues/8116

🤖 Generated with [Claude Code](https://claude.com/claude-code)