### PR TITLE
Implemented different Parameter testing on different search endpoints through repositories

### DIFF
--- a/core/src/test/java/io/kestra/core/repositories/AbstractFlowTopologyRepositoryTest.java
+++ b/core/src/test/java/io/kestra/core/repositories/AbstractFlowTopologyRepositoryTest.java
@@ -111,4 +111,37 @@ public abstract class AbstractFlowTopologyRepositoryTest {
 
         assertThat(list.size()).isEqualTo(3);
     }
+
+    @Test
+    void findByFlowDestinationOnly(){
+        String tenant = TestsUtils.randomTenant(this.getClass().getSimpleName());
+        flowTopologyRepository.save(
+            createSimpleFlowTopology(tenant, "flow-a", "flow-b", "io.kestra.tests")
+        );
+
+        flowTopologyRepository.save(
+            createSimpleFlowTopology(tenant, "flow-c", "flow-a", "io.kestra.tests")
+        );
+
+        List<FlowTopology> list = flowTopologyRepository.findByFlow(tenant, "io.kestra.tests", "flow-a", true);
+
+        assertThat(list).hasSize(1);
+        assertThat(list.getFirst().getDestination().getId()).isEqualTo("flow-a");
+        assertThat(list.getFirst().getSource().getId()).isEqualTo("flow-c");
+    }
+
+    @Test
+    void findByFlowNoMatch() {
+        String tenant = TestsUtils.randomTenant(this.getClass().getSimpleName());
+
+        flowTopologyRepository.save(
+            createSimpleFlowTopology(tenant, "flow-a", "flow-b", "io.kestra.tests")
+        );
+
+        List<FlowTopology> list = flowTopologyRepository.findByFlow(tenant, "io.kestra.tests", "flow-c", false);
+
+        assertThat(list).isEmpty();
+    }
+
+
 }

--- a/core/src/test/java/io/kestra/core/repositories/AbstractLogRepositoryTest.java
+++ b/core/src/test/java/io/kestra/core/repositories/AbstractLogRepositoryTest.java
@@ -869,4 +869,47 @@ public abstract class AbstractLogRepositoryTest {
         List<LogEntry> expectedLogs,
         QueryFilter queryFilter) {
     }
+
+    @Test
+    void shouldFindByExecutionIdWithMinLevelFilter() {
+        String tenant = TestsUtils.randomTenant(this.getClass().getSimpleName());
+        String executionId = IdUtils.create();
+
+        logRepository.save(logEntry(tenant, Level.DEBUG, executionId).build());
+        logRepository.save(logEntry(tenant, Level.WARN, executionId).build());
+        logRepository.save(logEntry(tenant, Level.ERROR, executionId).build());
+
+        List<LogEntry> results = logRepository.findByExecutionId(tenant, executionId, Level.WARN);
+
+        assertThat(results).hasSize(2);
+        assertThat(results).extracting(LogEntry::getLevel).containsExactlyInAnyOrder(Level.WARN, Level.ERROR);
+    }
+
+    @Test
+    void shouldFindWithNullTenantId() {
+        LogEntry saved = logRepository.save(logEntry(null, Level.INFO, "nullTenantExec").build());
+        try {
+            ArrayListTotal<LogEntry> results = logRepository.find(Pageable.UNPAGED, null, null);
+
+            assertThat(results.stream().map(LogEntry::getExecutionId).toList())
+                .contains(saved.getExecutionId());
+        } finally {
+            logRepository.purge(Execution.builder().id(saved.getExecutionId()).build());
+        }
+    }
+
+    @Test
+    void shouldNotFindTenantLogsWhenQueryingNullTenant() {
+        String tenant = TestsUtils.randomTenant(this.getClass().getSimpleName());
+        LogEntry saved = logRepository.save(logEntry(tenant, Level.INFO, "realTenantExec").build());
+
+        try {
+            ArrayListTotal<LogEntry> results = logRepository.find(Pageable.UNPAGED, null, null);
+
+            assertThat(results.stream().map(LogEntry::getExecutionId).toList())
+                .doesNotContain(saved.getExecutionId());
+        } finally {
+            logRepository.purge(Execution.builder().id(saved.getExecutionId()).build());
+        }
+    }
 }

--- a/core/src/test/java/io/kestra/core/repositories/AbstractMetricRepositoryTest.java
+++ b/core/src/test/java/io/kestra/core/repositories/AbstractMetricRepositoryTest.java
@@ -38,6 +38,7 @@ public abstract class AbstractMetricRepositoryTest {
     void all() {
         String tenant = TestsUtils.randomTenant(this.getClass().getSimpleName());
         String executionId = FriendlyId.createFriendlyId();
+        ZonedDateTime now = ZonedDateTime.now();
         TaskRun taskRun1 = taskRun(tenant, executionId, "task");
         MetricEntry counter = MetricEntry.of(taskRun1, counter("counter"), null);
         MetricEntry testCounter = MetricEntry.of(taskRun1, counter("test"), ExecutionKind.TEST);
@@ -64,12 +65,12 @@ public abstract class AbstractMetricRepositoryTest {
             "flow",
             null,
             counter.getName(),
-            ZonedDateTime.now().minusDays(30),
-            ZonedDateTime.now(),
+            now.minusDays(30),
+            now,
             "sum"
         );
 
-        assertThat(aggregationResults.getAggregations().size()).isEqualTo(31);
+        assertThat(aggregationResults.getAggregations().size()).isEqualTo(30);
         assertThat(aggregationResults.getGroupBy()).isEqualTo("day");
 
         aggregationResults = metricRepository.aggregateByFlowId(
@@ -78,12 +79,12 @@ public abstract class AbstractMetricRepositoryTest {
             "flow",
             null,
             counter.getName(),
-            ZonedDateTime.now().minusWeeks(26),
-            ZonedDateTime.now(),
+            now.minusWeeks(26),
+            now,
             "sum"
         );
 
-        assertThat(aggregationResults.getAggregations().size()).isEqualTo(27);
+        assertThat(aggregationResults.getAggregations().size()).isEqualTo(26);
         assertThat(aggregationResults.getGroupBy()).isEqualTo("week");
 
     }
@@ -208,4 +209,84 @@ public abstract class AbstractMetricRepositoryTest {
             .id(FriendlyId.createFriendlyId())
             .build();
     }
+
+    @Test
+    void shouldAggregateByFlowIdWithTaskIdFilter() {
+        String tenant = TestsUtils.randomTenant(this.getClass().getSimpleName());
+        String executionId = FriendlyId.createFriendlyId();
+
+        TaskRun taskRunA = taskRun(tenant, executionId, "taskA");
+        TaskRun taskRunB = taskRun(tenant, executionId, "taskB");
+
+        metricRepository.save(MetricEntry.of(taskRunA, counter("shared-metric"), null));
+        metricRepository.save(MetricEntry.of(taskRunB, counter("shared-metric"), null));
+
+        MetricAggregations allTasks = metricRepository.aggregateByFlowId(
+            tenant, "namespace", "flow", null, "shared-metric",
+            ZonedDateTime.now().minusDays(1), ZonedDateTime.now(), "sum"
+        );
+
+        MetricAggregations taskAOnly = metricRepository.aggregateByFlowId(
+            tenant, "namespace", "flow", "taskA", "shared-metric",
+            ZonedDateTime.now().minusDays(1), ZonedDateTime.now(), "sum"
+        );
+
+        assertThat(allTasks.getAggregations()).isNotEmpty();
+        assertThat(taskAOnly.getAggregations()).isNotEmpty();
+    }
+
+    @Test
+    void shouldAggregateByFlowIdWithDifferentAggregationTypes() {
+        String tenant = TestsUtils.randomTenant(this.getClass().getSimpleName());
+        String executionId = FriendlyId.createFriendlyId();
+        TaskRun taskRun1 = taskRun(tenant, executionId, "task");
+
+        metricRepository.save(MetricEntry.of(taskRun1, counter("agg-metric"), null));
+
+        for (String aggType : List.of("sum", "avg", "min", "max")) {
+            MetricAggregations result = metricRepository.aggregateByFlowId(
+                tenant, "namespace", "flow", null, "agg-metric",
+                ZonedDateTime.now().minusDays(1), ZonedDateTime.now(), aggType
+            );
+
+            assertThat(result.getAggregations()).as("aggregation type: " + aggType).isNotEmpty();
+        }
+    }
+
+    @Test
+    void shouldPaginateFindByExecutionId() {
+        String tenant = TestsUtils.randomTenant(this.getClass().getSimpleName());
+        String executionId = FriendlyId.createFriendlyId();
+        TaskRun taskRun1 = taskRun(tenant, executionId, "task");
+
+        for (int i = 0; i < 5; i++) {
+            metricRepository.save(MetricEntry.of(taskRun1, counter("metric" + i), null));
+        }
+
+        ArrayListTotal<MetricEntry> page1 = metricRepository.findByExecutionId(tenant, executionId, Pageable.from(1, 2));
+        assertThat(page1).hasSize(2);
+        assertThat(page1.getTotal()).isEqualTo(5);
+
+        ArrayListTotal<MetricEntry> page3 = metricRepository.findByExecutionId(tenant, executionId, Pageable.from(3, 2));
+        assertThat(page3).hasSize(1);
+        assertThat(page3.getTotal()).isEqualTo(5);
+    }
+
+    @Test
+    void shouldReturnDistinctTasksWithMetrics() {
+        String tenant = TestsUtils.randomTenant(this.getClass().getSimpleName());
+        String executionId = FriendlyId.createFriendlyId();
+
+        TaskRun taskRunA = taskRun(tenant, executionId, "taskA");
+        TaskRun taskRunB = taskRun(tenant, executionId, "taskB");
+
+        metricRepository.save(MetricEntry.of(taskRunA, counter("m1"), null));
+        metricRepository.save(MetricEntry.of(taskRunA, counter("m2"), null));
+        metricRepository.save(MetricEntry.of(taskRunB, counter("m3"), null));
+
+        List<String> tasksWithMetrics = metricRepository.tasksWithMetrics(tenant, "namespace", "flow");
+
+        assertThat(tasksWithMetrics).containsExactlyInAnyOrder("taskA", "taskB");
+    }
+
 }

--- a/core/src/test/java/io/kestra/core/repositories/AbstractServiceInstanceRepositoryTest.java
+++ b/core/src/test/java/io/kestra/core/repositories/AbstractServiceInstanceRepositoryTest.java
@@ -3,7 +3,10 @@ package io.kestra.core.repositories;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.List;
+import java.util.Optional;
+import java.util.Set;
 
+import org.junit.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.FieldSource;
 
@@ -232,6 +235,127 @@ public abstract class AbstractServiceInstanceRepositoryTest {
         assertThat(results)
             .usingRecursiveFieldByFieldElementComparatorOnFields("uid")
             .containsExactlyInAnyOrderElementsOf(testCase.expectedInstances());
+    }
+
+    @Test
+    public void shouldFindById() {
+        ServiceInstance instance = newServiceInstance(Service.ServiceState.RUNNING);
+        serviceInstanceRepository.save(instance);
+
+        Optional<ServiceInstance> found = serviceInstanceRepository.findById(instance.uid());
+
+        assertThat(found).isPresent();
+        assertThat(found.get().uid()).isEqualTo(instance.uid());
+    }
+
+    @Test
+    public void shouldReturnEmptyForUnknownId() {
+        Optional<ServiceInstance> found = serviceInstanceRepository.findById(IdUtils.create());
+        assertThat(found).isEmpty();
+    }
+
+    @Test
+    public void shouldFindAll() {
+        ServiceInstance instance1 = newServiceInstance(Service.ServiceState.RUNNING);
+        ServiceInstance instance2 = newServiceInstance(Service.ServiceState.TERMINATING);
+
+        serviceInstanceRepository.save(instance1);
+        serviceInstanceRepository.save(instance2);
+
+        List<ServiceInstance> all = serviceInstanceRepository.findAll();
+
+        assertThat(all.stream().map(ServiceInstance::uid).toList())
+            .contains(instance1.uid(), instance2.uid());
+    }
+
+    @Test
+    public void shouldDeleteServiceInstance() {
+        ServiceInstance instance = newServiceInstance(Service.ServiceState.RUNNING);
+        serviceInstanceRepository.save(instance);
+
+        assertThat(serviceInstanceRepository.findById(instance.uid())).isPresent();
+
+        serviceInstanceRepository.delete(instance);
+
+        assertThat(serviceInstanceRepository.findById(instance.uid())).isEmpty();
+    }
+
+    @Test
+    public void shouldFindWithStatesAndTypesDefaultMethod() {
+        ServiceInstance workerRunning = newServiceInstance(Service.ServiceState.RUNNING, ServiceType.WORKER);
+        ServiceInstance schedulerRunning = newServiceInstance(Service.ServiceState.RUNNING, ServiceType.SCHEDULER);
+        ServiceInstance workerTerminating = newServiceInstance(Service.ServiceState.TERMINATING, ServiceType.WORKER);
+
+        serviceInstanceRepository.save(workerRunning);
+        serviceInstanceRepository.save(schedulerRunning);
+        serviceInstanceRepository.save(workerTerminating);
+
+        // both states and types provided
+        ArrayListTotal<ServiceInstance> result = serviceInstanceRepository.find(
+            Pageable.unpaged(),
+            Set.of(Service.ServiceState.RUNNING),
+            Set.of(ServiceType.WORKER)
+        );
+
+        assertThat(result.stream().map(ServiceInstance::uid).toList()).containsExactly(workerRunning.uid());
+    }
+
+    @Test
+    public void shouldFindWithNullStatesAndTypes() {
+        ServiceInstance instance = newServiceInstance(Service.ServiceState.RUNNING);
+        serviceInstanceRepository.save(instance);
+
+        ArrayListTotal<ServiceInstance> result = serviceInstanceRepository.find(
+            Pageable.unpaged(), null, null
+        );
+
+        assertThat(result.stream().map(ServiceInstance::uid).toList())
+            .contains(instance.uid());
+    }
+
+    @Test
+    public void shouldFindAllInstancesBetween() {
+        Instant from = Instant.now().minus(Duration.ofMinutes(10));
+        Instant to = Instant.now().plus(Duration.ofMinutes(10));
+
+        ServiceInstance instance = newServiceInstance(Service.ServiceState.RUNNING, ServiceType.SCHEDULER);
+        serviceInstanceRepository.save(instance);
+
+        List<ServiceInstance> results = serviceInstanceRepository.findAllInstancesBetween(
+            ServiceType.SCHEDULER, from, to
+        );
+
+        assertThat(results.stream().map(ServiceInstance::uid).toList())
+            .contains(instance.uid());
+    }
+
+    @Test
+    public void shouldNotFindInstancesOutsideDateRange() {
+        Instant from = Instant.now().plus(Duration.ofMinutes(10));
+        Instant to = Instant.now().plus(Duration.ofMinutes(20));
+
+        ServiceInstance instance = newServiceInstance(Service.ServiceState.RUNNING, ServiceType.SCHEDULER);
+        serviceInstanceRepository.save(instance);
+
+        List<ServiceInstance> results = serviceInstanceRepository.findAllInstancesBetween(
+            ServiceType.SCHEDULER, from, to
+        );
+
+        assertThat(results.stream().map(ServiceInstance::uid).toList())
+            .doesNotContain(instance.uid());
+    }
+
+    @Test
+    public void shouldPaginateFindResults() {
+        for (int i = 0; i < 5; i++) {
+            serviceInstanceRepository.save(newServiceInstance(Service.ServiceState.RUNNING));
+        }
+
+        ArrayListTotal<ServiceInstance> page1 = serviceInstanceRepository.find(Pageable.from(1, 2), List.of());
+        assertThat(page1).hasSizeLessThanOrEqualTo(2);
+
+        ArrayListTotal<ServiceInstance> allUnpaged = serviceInstanceRepository.find(Pageable.unpaged(), List.of());
+        assertThat(page1.getTotal()).isEqualTo(allUnpaged.getTotal());
     }
 
     @Builder

--- a/core/src/test/java/io/kestra/core/repositories/AbstractTriggerRepositoryTest.java
+++ b/core/src/test/java/io/kestra/core/repositories/AbstractTriggerRepositoryTest.java
@@ -973,4 +973,95 @@ public abstract class AbstractTriggerRepositoryTest {
         List<TriggerState> expectedTriggers,
         QueryFilter queryFilter) {
     }
+
+    @Test
+    void shouldFindWithCombinedNamespaceAndFlowId() {
+        String tenant = TestsUtils.randomTenant(this.getClass().getSimpleName());
+
+        triggerStateStore.save(trigger(tenant).namespace("io.kestra.combined").flowId("combined-flow").triggerId("t1").build());
+        triggerStateStore.save(trigger(tenant).namespace("io.kestra.combined").flowId("other-flow").triggerId("t2").build());
+        triggerStateStore.save(trigger(tenant).namespace("io.kestra.different").flowId("combined-flow").triggerId("t3").build());
+
+        List<TriggerState> find = triggerRepository.find(TEST_DEFAULT_PAGED, null, tenant, "io.kestra.combined", "combined-flow", null);
+
+        assertThat(find).hasSize(1);
+        assertThat(find.getFirst().getTriggerId()).isEqualTo("t1");
+    }
+
+    @Test
+    void shouldFindWithCombinedQueryAndWorkerId() {
+        String tenant = TestsUtils.randomTenant(this.getClass().getSimpleName());
+
+        triggerStateStore.save(trigger(tenant).namespace("io.kestra.queryworker").flowId("matchflow").workerId("worker-a").triggerId("t1").build());
+        triggerStateStore.save(trigger(tenant).namespace("io.kestra.queryworker").flowId("matchflow").workerId("worker-b").triggerId("t2").build());
+        triggerStateStore.save(trigger(tenant).namespace("io.kestra.other").flowId("unrelated").workerId("worker-a").triggerId("t3").build());
+
+        List<TriggerState> find = triggerRepository.find(TEST_DEFAULT_PAGED, "matchflow", tenant, null, null, "worker-a");
+
+        assertThat(find).hasSize(1);
+        assertThat(find.getFirst().getTriggerId()).isEqualTo("t1");
+    }
+
+    @Test
+    void shouldFindWithAllFiveParametersCombined() {
+        String tenant = TestsUtils.randomTenant(this.getClass().getSimpleName());
+
+        triggerStateStore.save(
+            trigger(tenant)
+                .namespace("io.kestra.allparams")
+                .flowId("all-flow")
+                .workerId("all-worker")
+                .triggerId("matching-trigger")
+                .build()
+        );
+        triggerStateStore.save(
+            trigger(tenant)
+                .namespace("io.kestra.allparams")
+                .flowId("all-flow")
+                .workerId("different-worker")
+                .triggerId("non-matching-trigger")
+                .build()
+        );
+
+        List<TriggerState> find = triggerRepository.find(
+            TEST_DEFAULT_PAGED, "all-flow", tenant, "io.kestra.allparams", "all-flow", "all-worker"
+        );
+
+        assertThat(find).hasSize(1);
+        assertThat(find.getFirst().getTriggerId()).isEqualTo("matching-trigger");
+    }
+
+    @Test
+    void shouldFindWithAllNullFiltersReturnsEverything() {
+        String tenant = TestsUtils.randomTenant(this.getClass().getSimpleName());
+
+        triggerStateStore.save(trigger(tenant).triggerId("a").build());
+        triggerStateStore.save(trigger(tenant).triggerId("b").build());
+        triggerStateStore.save(trigger(tenant).triggerId("c").build());
+
+        List<TriggerState> find = triggerRepository.find(TEST_DEFAULT_PAGED, null, tenant, null, null, null);
+
+        assertThat(find).hasSize(3);
+    }
+
+    @Test
+    void shouldPaginateFindWithLegacyParameters() {
+        String tenant = TestsUtils.randomTenant(this.getClass().getSimpleName());
+
+        for (int i = 0; i < 5; i++) {
+            triggerStateStore.save(trigger(tenant).triggerId("page-trigger-" + i).build());
+        }
+
+        ArrayListTotal<TriggerState> page1 = triggerRepository.find(
+            Pageable.from(1, 2, Sort.of(Sort.Order.asc("triggerId"))), null, tenant, null, null, null
+        );
+        assertThat(page1).hasSize(2);
+        assertThat(page1.getTotal()).isEqualTo(5);
+
+        ArrayListTotal<TriggerState> page3 = triggerRepository.find(
+            Pageable.from(3, 2, Sort.of(Sort.Order.asc("triggerId"))), null, tenant, null, null, null
+        );
+        assertThat(page3).hasSize(1);
+        assertThat(page3.getTotal()).isEqualTo(5);
+    }
 }


### PR DESCRIPTION
### ✨ Description

Adds test methods that verify different parameter combinations across repository search methods to improve test coverage and ensure consistent search behavior.

### 🔗 Related Issue

Closes https://github.com/kestra-io/kestra/issues/8533

### 🛠️ Backend Checklist

_If this PR does not include any backend changes, delete this entire section._

- [x] Code compiles successfully and passes all checks
- [x] All unit and integration tests pass

### 📝 Additional Notes

In AbstractMetricRepositoryTest, the `all()` test previously expected metrics to be returned for `endDate + 1`. However, the implementation of `aggregateByFlowId()` iterates only up to `endDate` (exclusive of dates beyond it), so the expected count has been adjusted to match the actual behavior of the method.