### PR TITLE
fix: render router-md as anchors using linkify

### DIFF
--- a/ui/src/components/layout/Markdown.vue
+++ b/ui/src/components/layout/Markdown.vue
@@ -26,8 +26,12 @@
 
 <script setup lang="ts">
     import {ref, watch, nextTick, onBeforeUnmount, onMounted, computed} from "vue";
+    import {useRouter} from "vue-router";
     import Magnify from "vue-material-design-icons/Magnify.vue";
     import * as Markdown from "../../utils/markdown";
+    import linkifyRouterMd from "../logs/linkify";
+
+    const router = useRouter();
 
     /**
      * Unified component props
@@ -144,6 +148,7 @@
         const root = markdownContainer.value;
         if (!root) return;
 
+        linkifyRouterMd(root, router);
         transformTables(root);
         setupCardToggles(root);
         setupCollapsibles(root);

--- a/ui/src/utils/markdown_plugins/link.ts
+++ b/ui/src/utils/markdown_plugins/link.ts
@@ -19,7 +19,7 @@ export function linkTag(md: MarkdownIt) {
 
         const token = state.push("link_custom_open", "link", 1);
         token.markup = "[[link]]";
-        token.attrs = attrs;
+        token.attrs = attrs ? attrs.filter(([name, value]) => ["execution", "flowId", "namespace"].includes(name) && value) : [];
         state.push("link_custom_close", "link_custom", -1);
 
         state.pos = state.pos + match[0].length;


### PR DESCRIPTION
- filter attributes in router-md `link.ts`
- linkify the router-md so it does not appear as a custom element.