### PR TITLE
fix(build): unblock 0.22.44 release (version rollback + RequestTest.head fix)

### DIFF
--- a/core/src/test/java/io/kestra/plugin/core/http/RequestTest.java
+++ b/core/src/test/java/io/kestra/plugin/core/http/RequestTest.java
@@ -92,7 +92,7 @@ class RequestTest {
             Request.Output output = task.run(runContext);
 
         assertThat(output.getUri(), is(URI.create(url)));
-        assertThat(output.getHeaders().get("content-length").getFirst(), is("512789"));
+        assertThat(output.getCode(), is(200));
         }
     }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=0.22.44
+version=0.22.43
 
 org.gradle.jvmargs=-Xmx2g -XX:MaxMetaspaceSize=512m -XX:+HeapDumpOnOutOfMemoryError
 org.gradle.parallel=true


### PR DESCRIPTION
## Why
The 0.22.44 release is stuck: the `v0.22.44` tag was never created.

`gradle.properties` on `releases/v0.22.x` was left at `0.22.44` by a half-completed release run. The release workflow (`global-start-release.yml`) does:
```
sed -i "s/^version=.*/version=$RELEASE_VERSION/" gradle.properties
git commit -m "..."   # fails: nothing to commit when version already matches
git push && git tag -a "v$RELEASE_VERSION" && git push --tags   # never reached
```
Because the version already equals `0.22.44`, `sed` is a no-op, the commit fails, and the tag is never pushed. (This also broke the EE release, which fell back to building against OSS `develop` when it couldn't find the OSS `v0.22.44` tag.)

## What
1. **Roll back `gradle.properties` to `0.22.43`** (last released version) so the release flow bumps `0.22.43 → 0.22.44`, commits, and tags cleanly.
2. **Fix `RequestTest.head()`** — it asserted `getHeaders().get("content-length").getFirst()` but the `/headonly` controller returns `HttpResponse.ok()` with no `content-length` header → NPE. Now asserts the response code, matching the fix already on `releases/v1.x`.

## Verification
`./gradlew :core:test --tests "io.kestra.plugin.core.http.RequestTest"` → 21 tests pass (including `head()`).