### PR TITLE
fix(release v1.3.x): fix missing translations + tag flaky backend tests

### DIFF
--- a/cli/src/test/java/io/kestra/cli/AppTest.java
+++ b/cli/src/test/java/io/kestra/cli/AppTest.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
+import io.kestra.core.junit.annotations.FlakyTest;
 import io.kestra.core.models.ServerType;
 import picocli.CommandLine;
 
@@ -53,6 +54,7 @@ class AppTest {
         assertThat(out.toString()).startsWith("Usage: kestra server " + serverType);
     }
 
+    @FlakyTest(description = "flaky on CI — release triage 2026-06: order-dependent config-recovery assertion")
     @Test
     void configBeforeSubcommandIsLoaded() throws Exception {
         // Regression test for: --config placed before the subcommand name was silently

--- a/core/src/test/java/io/kestra/core/runners/AbstractRunnerConcurrencyTest.java
+++ b/core/src/test/java/io/kestra/core/runners/AbstractRunnerConcurrencyTest.java
@@ -51,6 +51,7 @@ public abstract class AbstractRunnerConcurrencyTest {
         flowConcurrencyCaseTest.flowConcurrencyWithForEachItem("flow-concurrency-with-for-each-item");
     }
 
+    @FlakyTest(description = "flaky on CI — release triage 2026-06: intermittent concurrency-queue restart timing")
     @Test
     @LoadFlows(value = { "flows/valids/flow-concurrency-queue-fail.yml" }, tenantId = "concurrency-queue-restarted")
     protected void concurrencyQueueRestarted() throws Exception {

--- a/core/src/test/java/io/kestra/core/runners/AbstractRunnerTest.java
+++ b/core/src/test/java/io/kestra/core/runners/AbstractRunnerTest.java
@@ -628,6 +628,7 @@ public abstract class AbstractRunnerTest {
         afterExecutionTestCase.shouldCallTasksAfterListener(execution);
     }
 
+    @FlakyTest(description = "flaky on CI — release triage 2026-06: intermittent execution-state race ('currently at the ...')")
     @Test
     @LoadFlows(value = { "flows/valids/waitfor-nested.yaml" }, tenantId = "waitfornested")
     void waitforNestedThreeLevels() throws Exception {

--- a/core/src/test/java/io/kestra/core/tasks/test/SanityCheckTest.java
+++ b/core/src/test/java/io/kestra/core/tasks/test/SanityCheckTest.java
@@ -70,6 +70,7 @@ class SanityCheckTest {
         assertThat(execution.getState().getCurrent()).isEqualTo(State.Type.SUCCESS);
     }
 
+    @FlakyTest(description = "flaky on CI — release triage 2026-06: intermittent purge assertion")
     @Test
     @ExecuteFlow("sanity-checks/purge_current_execution_files.yaml")
     void qaPurgeExecutionFiles(Execution execution) {

--- a/jdbc/src/test/java/io/kestra/jdbc/runner/JdbcServiceLivenessCoordinatorTest.java
+++ b/jdbc/src/test/java/io/kestra/jdbc/runner/JdbcServiceLivenessCoordinatorTest.java
@@ -254,6 +254,7 @@ public abstract class JdbcServiceLivenessCoordinatorTest {
         newWorker.close();
     }
 
+    @FlakyTest(description = "flaky on CI — release triage 2026-06: intermittent liveness re-emit timing")
     @Test
     void shouldReEmitTriggerToTheSameWorkerGroup() throws Exception {
         String workerGroup = IdUtils.create();

--- a/scheduler/src/test/java/io/kestra/scheduler/SchedulerScheduleTest.java
+++ b/scheduler/src/test/java/io/kestra/scheduler/SchedulerScheduleTest.java
@@ -192,6 +192,7 @@ public class SchedulerScheduleTest extends AbstractSchedulerTest {
     }
 
     // Test to ensure behavior between 0.14 > 0.15
+    @FlakyTest(description = "flaky on CI — release triage 2026-06: intermittent scheduler timing / JDBC connection")
     @Test
     void retroSchedule() throws Exception {
         // mock flow listeners
@@ -456,6 +457,7 @@ public class SchedulerScheduleTest extends AbstractSchedulerTest {
         }
     }
 
+    @FlakyTest(description = "flaky on CI — release triage 2026-06: intermittent scheduler timing")
     @Test
     void stopAfterSchedule() throws Exception {
         // mock flow listeners

--- a/ui/src/translations/de.json
+++ b/ui/src/translations/de.json
@@ -569,6 +569,7 @@
     "execute backfill": "Backfill ausführen",
     "execute flow behaviour": "Den Flow ausführen",
     "execute flow now ?": "Möchten Sie diesen Flow ausführen?",
+    "discard execution confirmation": "Sie haben ungespeicherte Eingaben. Sind Sie sicher, dass Sie diese Ausführung verwerfen möchten?",
     "execute the flow": "Den Flow <code>{id}</code> ausführen",
     "execution": "Ausführung",
     "execution already finished": "Ausführung <code>{executionId}</code> bereits abgeschlossen",

--- a/ui/src/translations/es.json
+++ b/ui/src/translations/es.json
@@ -569,6 +569,7 @@
     "execute backfill": "Ejecutar backfill",
     "execute flow behaviour": "Ejecutar el flujo",
     "execute flow now ?": "¿Quieres ejecutar este flujo?",
+    "discard execution confirmation": "Tienes entradas no guardadas. ¿Estás seguro de que deseas descartar esta ejecución?",
     "execute the flow": "Ejecutar el flujo <code>{id}</code>",
     "execution": "Ejecución",
     "execution already finished": "Ejecución <code>{executionId}</code> ya finalizada",

--- a/ui/src/translations/fr.json
+++ b/ui/src/translations/fr.json
@@ -569,6 +569,7 @@
     "execute backfill": "Exécuter le backfill",
     "execute flow behaviour": "Exécuter le flow",
     "execute flow now ?": "Voulez-vous exécuter ce flow ?",
+    "discard execution confirmation": "Vous avez des inputs non enregistrés. Êtes-vous sûr de vouloir abandonner cette exécution ?",
     "execute the flow": "Exécuter le flow <code>{id}</code>",
     "execution": "Exécution",
     "execution already finished": "Exécution <code>{executionId}</code> déjà terminée",

--- a/ui/src/translations/hi.json
+++ b/ui/src/translations/hi.json
@@ -569,6 +569,7 @@
     "execute backfill": "Backfill निष्पादित करें",
     "execute flow behaviour": "Flow निष्पादित करें",
     "execute flow now ?": "क्या आप इस flow को निष्पादित करना चाहते हैं?",
+    "discard execution confirmation": "आपके पास बिना सहेजे गए input हैं। क्या आप वाकई इस execution को छोड़ना चाहते हैं?",
     "execute the flow": "Flow <code>{id}</code> निष्पादित करें",
     "execution": "निष्पादन",
     "execution already finished": "निष्पादन <code>{executionId}</code> पहले ही समाप्त हो चुका है",

--- a/ui/src/translations/it.json
+++ b/ui/src/translations/it.json
@@ -569,6 +569,7 @@
     "execute backfill": "Esegui backfill",
     "execute flow behaviour": "Esegui il flow",
     "execute flow now ?": "Vuoi eseguire questo flow?",
+    "discard execution confirmation": "Hai degli input non salvati. Sei sicuro di voler scartare questa esecuzione?",
     "execute the flow": "Esegui il flow <code>{id}</code>",
     "execution": "Esecuzione",
     "execution already finished": "Esecuzione <code>{executionId}</code> già terminata",

--- a/ui/src/translations/ja.json
+++ b/ui/src/translations/ja.json
@@ -569,6 +569,7 @@
     "execute backfill": "backfillを実行",
     "execute flow behaviour": "Flowを実行",
     "execute flow now ?": "このFlowを実行しますか？",
+    "discard execution confirmation": "未保存のinputがあります。このexecutionを破棄してもよろしいですか？",
     "execute the flow": "Flow <code>{id}</code>を実行",
     "execution": "Execution",
     "execution already finished": "実行<code>{executionId}</code>はすでに終了しています",

--- a/ui/src/translations/ko.json
+++ b/ui/src/translations/ko.json
@@ -569,6 +569,7 @@
     "execute backfill": "backfill 실행",
     "execute flow behaviour": "Flow 실행",
     "execute flow now ?": "이 flow를 실행하시겠습니까?",
+    "discard execution confirmation": "저장되지 않은 input이 있습니다. 이 실행을 취소하시겠습니까?",
     "execute the flow": "Flow <code>{id}</code> 실행",
     "execution": "실행",
     "execution already finished": "실행 <code>{executionId}</code>이(가) 이미 완료되었습니다",

--- a/ui/src/translations/pl.json
+++ b/ui/src/translations/pl.json
@@ -569,6 +569,7 @@
     "execute backfill": "Wykonaj backfill",
     "execute flow behaviour": "Wykonaj flow",
     "execute flow now ?": "Czy chcesz wykonać ten flow?",
+    "discard execution confirmation": "Masz niezapisane inputy. Czy na pewno chcesz odrzucić tę wykonanie?",
     "execute the flow": "Wykonaj flow <code>{id}</code>",
     "execution": "Wykonanie",
     "execution already finished": "Wykonanie <code>{executionId}</code> już zakończone",

--- a/ui/src/translations/pt.json
+++ b/ui/src/translations/pt.json
@@ -569,6 +569,7 @@
     "execute backfill": "Executar backfill",
     "execute flow behaviour": "Executar o flow",
     "execute flow now ?": "Deseja executar este flow?",
+    "discard execution confirmation": "Você tem inputs não salvos. Tem certeza de que deseja descartar esta execução?",
     "execute the flow": "Executar o flow <code>{id}</code>",
     "execution": "Execução",
     "execution already finished": "Execução <code>{executionId}</code> já finalizada",

--- a/ui/src/translations/pt_BR.json
+++ b/ui/src/translations/pt_BR.json
@@ -569,6 +569,7 @@
     "execute backfill": "Executar backfill",
     "execute flow behaviour": "Executar o flow",
     "execute flow now ?": "Deseja executar este flow?",
+    "discard execution confirmation": "Você tem inputs não salvos. Tem certeza de que deseja descartar esta execução?",
     "execute the flow": "Executar o flow <code>{id}</code>",
     "execution": "Execução",
     "execution already finished": "Execução <code>{executionId}</code> já finalizada",

--- a/ui/src/translations/ru.json
+++ b/ui/src/translations/ru.json
@@ -569,6 +569,7 @@
     "execute backfill": "Выполнить заполнение",
     "execute flow behaviour": "Выполнить flow",
     "execute flow now ?": "Вы хотите выполнить этот flow?",
+    "discard execution confirmation": "У вас есть несохраненные input. Вы уверены, что хотите отменить эту execution?",
     "execute the flow": "Выполнить flow <code>{id}</code>",
     "execution": "Выполнение",
     "execution already finished": "Выполнение <code>{executionId}</code> уже завершено",

--- a/ui/src/translations/zh_CN.json
+++ b/ui/src/translations/zh_CN.json
@@ -569,6 +569,7 @@
     "execute backfill": "执行回填",
     "execute flow behaviour": "执行流程",
     "execute flow now ?": "是否要执行此流程？",
+    "discard execution confirmation": "您有未保存的输入。您确定要放弃此执行吗？",
     "execute the flow": "执行流程 <code>{id}</code>",
     "execution": "执行",
     "execution already finished": "执行 <code>{executionId}</code> 已完成",

--- a/webserver/src/test/java/io/kestra/webserver/controllers/api/FlowControllerTest.java
+++ b/webserver/src/test/java/io/kestra/webserver/controllers/api/FlowControllerTest.java
@@ -603,6 +603,7 @@ class FlowControllerTest {
         assertThat(e.getResponse().getBody(String.class).get()).contains("Required QueryValue [revisions] not specified");
     }
 
+    @FlakyTest(description = "flaky on CI — release triage 2026-06: intermittent 'Unexpected exception type thrown'")
     @Test
     void updateFlowFlowFromJson() {
         String flowId = IdUtils.create();

--- a/worker/src/test/java/io/kestra/worker/WorkerTest.java
+++ b/worker/src/test/java/io/kestra/worker/WorkerTest.java
@@ -14,6 +14,7 @@ import org.junit.jupiter.api.Test;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.google.common.collect.ImmutableMap;
 
+import io.kestra.core.junit.annotations.FlakyTest;
 import io.kestra.core.junit.annotations.KestraTest;
 import io.kestra.core.models.executions.*;
 import io.kestra.core.models.flows.Flow;
@@ -145,6 +146,7 @@ class WorkerTest {
         assertThat(workerTaskResult.get().getTaskRun().getState().getHistories().size()).isEqualTo(3);
     }
 
+    @FlakyTest(description = "flaky on CI — release triage 2026-06: intermittent 'Await failed to terminate within PT1M'")
     @Test
     void killed() throws InterruptedException, TimeoutException, QueueException {
         Flux<LogEntry> receiveLogs = TestsUtils.receive(workerTaskLogQueue);


### PR DESCRIPTION
## Why
Part of stabilizing CI for the **releases/v1.3.x** release. CI triage over the last ~3 weeks separated genuine breakage from intermittently-failing tests.

## Changes
### 1. Frontend release blocker — missing translations (fix)
The EE `ui-ee` translations-completeness test failed on v1.3.x: the `discard execution confirmation` i18n key existed only in `en.json`. The v1.3.x backport added the key to en only, while develop (`35e83b2740`) localized it everywhere. Restored the localized values for the 12 other locales. Verified with `node ui/src/translations/check.js` → "No missing keys" for all locales.

### 2. Tag intermittently-failing backend tests as `@FlakyTest`
Moves known-flaky tests into the non-build-failing `flakyTest` task so the release isn't blocked by intermittent failures:
- `AbstractRunnerTest.waitforNestedThreeLevels` (covers H2/Mysql/Postgres + EE Kafka variant)
- `FlowControllerTest.updateFlowFlowFromJson`
- `SchedulerScheduleTest.stopAfterSchedule` / `retroSchedule`
- `JdbcServiceLivenessCoordinatorTest.shouldReEmitTriggerToTheSameWorkerGroup`
- `SanityCheckTest.qaPurgeExecutionFiles`
- `WorkerTest.killed`
- `AbstractRunnerConcurrencyTest.concurrencyQueueRestarted`
- `AppTest.configBeforeSubcommandIsLoaded` (the `--config` fix is already present on v1.3.x; the test is order-flaky)

## Verification
- `:core:`, `:jdbc:`, `:scheduler:`, `:cli:`, `:worker:` `compileTestJava` pass.
- Translations check passes for all locales.

Companion EE PR tags the EE-only flaky tests on v1.3.x.