### PR TITLE
test(flaky): tag intermittent backend tests as @FlakyTest for release v1.0.x

### DIFF
--- a/core/src/test/java/io/kestra/core/runners/AbstractRunnerConcurrencyTest.java
+++ b/core/src/test/java/io/kestra/core/runners/AbstractRunnerConcurrencyTest.java
@@ -3,6 +3,7 @@ package io.kestra.core.runners;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 
+import io.kestra.core.junit.annotations.FlakyTest;
 import io.kestra.core.junit.annotations.KestraTest;
 import io.kestra.core.junit.annotations.LoadFlows;
 
@@ -38,6 +39,7 @@ public abstract class AbstractRunnerConcurrencyTest {
         flowConcurrencyCaseTest.flowConcurrencyWithForEachItem("flow-concurrency-with-for-each-item");
     }
 
+    @FlakyTest(description = "flaky on CI — release triage 2026-06: intermittent concurrency-queue restart timing")
     @Test
     @LoadFlows(value = { "flows/valids/flow-concurrency-queue-fail.yml" }, tenantId = "concurrency-queue-fail")
     protected void concurrencyQueueRestarted() throws Exception {

--- a/core/src/test/java/io/kestra/core/runners/AbstractRunnerTest.java
+++ b/core/src/test/java/io/kestra/core/runners/AbstractRunnerTest.java
@@ -586,6 +586,7 @@ public abstract class AbstractRunnerTest {
         afterExecutionTestCase.shouldCallTasksAfterListener(execution);
     }
 
+    @FlakyTest(description = "flaky on CI — release triage 2026-06: intermittent execution-state race ('currently at the ...')")
     @Test
     @LoadFlows(value = { "flows/valids/waitfor-nested.yaml" }, tenantId = "waitfornested")
     void waitforNestedThreeLevels() throws Exception {

--- a/core/src/test/java/io/kestra/core/tasks/test/SanityCheckTest.java
+++ b/core/src/test/java/io/kestra/core/tasks/test/SanityCheckTest.java
@@ -3,6 +3,7 @@ package io.kestra.core.tasks.test;
 import org.junit.jupiter.api.Test;
 
 import io.kestra.core.junit.annotations.ExecuteFlow;
+import io.kestra.core.junit.annotations.FlakyTest;
 import io.kestra.core.junit.annotations.KestraTest;
 import io.kestra.core.models.executions.Execution;
 import io.kestra.core.models.executions.TaskRun;
@@ -68,6 +69,7 @@ class SanityCheckTest {
         assertThat(execution.getState().getCurrent()).isEqualTo(State.Type.SUCCESS);
     }
 
+    @FlakyTest(description = "flaky on CI — release triage 2026-06: intermittent purge assertion")
     @Test
     @ExecuteFlow("sanity-checks/purge_current_execution_files.yaml")
     void qaPurgeExecutionFiles(Execution execution) {

--- a/jdbc/src/test/java/io/kestra/jdbc/runner/JdbcServiceLivenessCoordinatorTest.java
+++ b/jdbc/src/test/java/io/kestra/jdbc/runner/JdbcServiceLivenessCoordinatorTest.java
@@ -104,6 +104,7 @@ public abstract class JdbcServiceLivenessCoordinatorTest {
         workerJobRunnings.forEach(workerJobRunning -> workerJobRunningRepository.deleteByKey(workerJobRunning.uid()));
     }
 
+    @FlakyTest(description = "flaky on CI — release triage 2026-06: intermittent liveness re-emit timing")
     @Test
     void shouldReEmitTasksWhenWorkerIsDetectedAsNonResponding() throws Exception {
         CountDownLatch runningLatch = new CountDownLatch(1);

--- a/scheduler/src/test/java/io/kestra/scheduler/SchedulerScheduleTest.java
+++ b/scheduler/src/test/java/io/kestra/scheduler/SchedulerScheduleTest.java
@@ -13,6 +13,7 @@ import org.junit.jupiter.api.Test;
 
 import com.devskiller.friendly_id.FriendlyId;
 
+import io.kestra.core.junit.annotations.FlakyTest;
 import io.kestra.core.models.executions.Execution;
 import io.kestra.core.models.executions.LogEntry;
 import io.kestra.core.models.executions.TaskRun;
@@ -181,6 +182,7 @@ public class SchedulerScheduleTest extends AbstractSchedulerTest {
     }
 
     // Test to ensure behavior between 0.14 > 0.15
+    @FlakyTest(description = "flaky on CI — release triage 2026-06: intermittent scheduler timing / JDBC connection")
     @Test
     void retroSchedule() throws Exception {
         // mock flow listeners
@@ -445,6 +447,7 @@ public class SchedulerScheduleTest extends AbstractSchedulerTest {
         }
     }
 
+    @FlakyTest(description = "flaky on CI — release triage 2026-06: intermittent scheduler timing")
     @Test
     void stopAfterSchedule() throws Exception {
         // mock flow listeners

--- a/worker/src/test/java/io/kestra/worker/WorkerTest.java
+++ b/worker/src/test/java/io/kestra/worker/WorkerTest.java
@@ -14,6 +14,7 @@ import org.junit.jupiter.api.Test;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.google.common.collect.ImmutableMap;
 
+import io.kestra.core.junit.annotations.FlakyTest;
 import io.kestra.core.junit.annotations.KestraTest;
 import io.kestra.core.models.executions.*;
 import io.kestra.core.models.flows.Flow;
@@ -145,6 +146,7 @@ class WorkerTest {
         assertThat(workerTaskResult.get().getTaskRun().getState().getHistories().size()).isEqualTo(3);
     }
 
+    @FlakyTest(description = "flaky on CI — release triage 2026-06: intermittent 'Await failed to terminate within PT1M'")
     @Test
     void killed() throws InterruptedException, TimeoutException, QueueException {
         Flux<LogEntry> receiveLogs = TestsUtils.receive(workerTaskLogQueue);


### PR DESCRIPTION
## Why
Part of stabilizing CI for the **releases/v1.0.x** release. CI triage (last ~3 weeks) identified intermittently-failing backend tests. Tag them `@FlakyTest` so they run in the non-build-failing `flakyTest` task instead of blocking the release.

## Changes
- `AbstractRunnerTest.waitforNestedThreeLevels` (covers H2/Mysql/Postgres + EE Kafka variant)
- `SchedulerScheduleTest.stopAfterSchedule` / `retroSchedule`
- `JdbcServiceLivenessCoordinatorTest.shouldReEmitTasksWhenWorkerIsDetectedAsNonResponding`
- `SanityCheckTest.qaPurgeExecutionFiles`
- `WorkerTest.killed`
- `AbstractRunnerConcurrencyTest.concurrencyQueueRestarted`

`updateFlowFlowFromJson` and `shouldReEmitTriggerToTheSameWorkerGroup` already carry `@FlakyTest` on this branch.

## Verification
`:core:`, `:jdbc:`, `:scheduler:`, `:worker:` `compileTestJava` pass.

Companion EE PR tags the EE-only flaky test (`BindingControllerTest.shouldListBindings`) on v1.0.x.