### PR TITLE
test(flaky): tag intermittent backend tests as @FlakyTest for release v1.2.x

### DIFF
--- a/core/src/test/java/io/kestra/core/runners/AbstractRunnerConcurrencyTest.java
+++ b/core/src/test/java/io/kestra/core/runners/AbstractRunnerConcurrencyTest.java
@@ -49,6 +49,7 @@ public abstract class AbstractRunnerConcurrencyTest {
         flowConcurrencyCaseTest.flowConcurrencyWithForEachItem("flow-concurrency-with-for-each-item");
     }
 
+    @FlakyTest(description = "flaky on CI — release triage 2026-06: intermittent concurrency-queue restart timing")
     @Test
     @LoadFlows(value = {"flows/valids/flow-concurrency-queue-fail.yml"}, tenantId = "concurrency-queue-restarted")
     protected void concurrencyQueueRestarted() throws Exception {

--- a/core/src/test/java/io/kestra/core/tasks/test/SanityCheckTest.java
+++ b/core/src/test/java/io/kestra/core/tasks/test/SanityCheckTest.java
@@ -69,6 +69,7 @@ class SanityCheckTest {
         assertThat(execution.getState().getCurrent()).isEqualTo(State.Type.SUCCESS);
     }
 
+    @FlakyTest(description = "flaky on CI — release triage 2026-06: intermittent purge assertion")
     @Test
     @ExecuteFlow("sanity-checks/purge_current_execution_files.yaml")
     void qaPurgeExecutionFiles(Execution execution) {

--- a/jdbc/src/test/java/io/kestra/jdbc/runner/JdbcServiceLivenessCoordinatorTest.java
+++ b/jdbc/src/test/java/io/kestra/jdbc/runner/JdbcServiceLivenessCoordinatorTest.java
@@ -245,6 +245,7 @@ public abstract class JdbcServiceLivenessCoordinatorTest {
         newWorker.close();
     }
 
+    @FlakyTest(description = "flaky on CI — release triage 2026-06: intermittent liveness re-emit timing")
     @Test
     void shouldReEmitTriggerToTheSameWorkerGroup() throws Exception {
         String workerGroup = IdUtils.create();

--- a/scheduler/src/test/java/io/kestra/scheduler/SchedulerScheduleTest.java
+++ b/scheduler/src/test/java/io/kestra/scheduler/SchedulerScheduleTest.java
@@ -177,6 +177,7 @@ public class SchedulerScheduleTest extends AbstractSchedulerTest {
     }
 
     // Test to ensure behavior between 0.14 > 0.15
+    @FlakyTest(description = "flaky on CI — release triage 2026-06: intermittent scheduler timing / JDBC connection")
     @Test
     void retroSchedule() throws Exception {
         // mock flow listeners
@@ -435,6 +436,7 @@ public class SchedulerScheduleTest extends AbstractSchedulerTest {
         }
     }
 
+    @FlakyTest(description = "flaky on CI — release triage 2026-06: intermittent scheduler timing")
     @Test
     void stopAfterSchedule() throws Exception {
         // mock flow listeners

--- a/webserver/src/test/java/io/kestra/webserver/controllers/api/FlowControllerTest.java
+++ b/webserver/src/test/java/io/kestra/webserver/controllers/api/FlowControllerTest.java
@@ -575,6 +575,7 @@ class FlowControllerTest {
         assertThat(e.getResponse().getBody(String.class).get()).contains("Required QueryValue [revisions] not specified");
     }
 
+    @FlakyTest(description = "flaky on CI — release triage 2026-06: intermittent 'Unexpected exception type thrown'")
     @Test
     void updateFlowFlowFromJson() {
         String flowId = IdUtils.create();

--- a/worker/src/test/java/io/kestra/worker/WorkerTest.java
+++ b/worker/src/test/java/io/kestra/worker/WorkerTest.java
@@ -19,6 +19,7 @@ import io.kestra.core.utils.Await;
 import io.kestra.core.utils.IdUtils;
 import io.kestra.core.utils.TestsUtils;
 import io.micronaut.context.ApplicationContext;
+import io.kestra.core.junit.annotations.FlakyTest;
 import io.kestra.core.junit.annotations.KestraTest;
 import jakarta.inject.Inject;
 import jakarta.inject.Named;
@@ -141,6 +142,7 @@ class WorkerTest {
         assertThat(workerTaskResult.get().getTaskRun().getState().getHistories().size()).isEqualTo(3);
     }
 
+    @FlakyTest(description = "flaky on CI — release triage 2026-06: intermittent 'Await failed to terminate within PT1M'")
     @Test
     void killed() throws InterruptedException, TimeoutException, QueueException {
         Flux<LogEntry> receiveLogs = TestsUtils.receive(workerTaskLogQueue);


### PR DESCRIPTION
## Why
Part of stabilizing CI for the **releases/v1.2.x** release. CI triage (last ~3 weeks) identified intermittently-failing backend tests. Tag them `@FlakyTest` so they run in the non-build-failing `flakyTest` task instead of blocking the release.

## Changes
- `FlowControllerTest.updateFlowFlowFromJson`
- `SchedulerScheduleTest.stopAfterSchedule` / `retroSchedule`
- `JdbcServiceLivenessCoordinatorTest.shouldReEmitTriggerToTheSameWorkerGroup`
- `SanityCheckTest.qaPurgeExecutionFiles`
- `WorkerTest.killed`
- `AbstractRunnerConcurrencyTest.concurrencyQueueRestarted`

`shouldReEmitTasksWhenWorkerIsDetectedAsNonResponding` already carries `@FlakyTest`. `waitforNestedThreeLevels` and `AppTest.configBeforeSubcommandIsLoaded` do not exist on this branch.

## Verification
`:core:`, `:jdbc:`, `:scheduler:`, `:worker:` `compileTestJava` pass.

No companion EE PR — none of the listed EE flaky tests failed/exist on v1.2.x.