### PR TITLE
fix(core): propagate the real secret/Pebble error instead of the Handlebars fallback

### DIFF
--- a/core/src/main/java/io/kestra/core/runners/VariableRenderer.java
+++ b/core/src/main/java/io/kestra/core/runners/VariableRenderer.java
@@ -114,7 +114,7 @@ public class VariableRenderer {
             OutputWriter writer = stringify ? new JsonWriter() : new TypedObjectWriter();
             compiledTemplate.evaluate(writer, variables);
             result = writer.output();
-        } catch (IOException | PebbleException e) {
+        } catch (IOException | RuntimeException e) {
             if (e instanceof PebbleException pebbleException) {
                 throw properPebbleException(pebbleException);
             }

--- a/core/src/main/java/io/kestra/core/runners/VariableRenderer.java
+++ b/core/src/main/java/io/kestra/core/runners/VariableRenderer.java
@@ -115,15 +115,10 @@ public class VariableRenderer {
             compiledTemplate.evaluate(writer, variables);
             result = writer.output();
         } catch (IOException | PebbleException e) {
-            String alternativeRender = this.alternativeRender(e, (String) inline, variables);
-            if (alternativeRender == null) {
-                if (e instanceof PebbleException pebbleException) {
-                    throw properPebbleException(pebbleException);
-                }
-                throw new IllegalVariableEvaluationException(e);
-            } else {
-                result = alternativeRender;
+            if (e instanceof PebbleException pebbleException) {
+                throw properPebbleException(pebbleException);
             }
+            throw new IllegalVariableEvaluationException(e);
         }
 
         if (result instanceof String stringValue && replacers != null) {
@@ -132,18 +127,6 @@ public class VariableRenderer {
         }
 
         return result;
-    }
-
-    /**
-     * This method can be used in fallback for rendering an input string.
-     *
-     * @param e         The exception that was throw by the default variable renderer.
-     * @param inline    The expression to be rendered.
-     * @param variables The context variables.
-     * @return          The rendered string.
-     */
-    protected String alternativeRender(Exception e, String inline, Map<String, Object> variables) throws IllegalVariableEvaluationException {
-        return null;
     }
 
     private static String putBackRawTags(Map<String, String> replacers, String result) {

--- a/core/src/test/java/io/kestra/core/runners/VariableRendererTest.java
+++ b/core/src/test/java/io/kestra/core/runners/VariableRendererTest.java
@@ -16,9 +16,6 @@ class VariableRendererTest {
     @Inject
     VariableRenderer variableRenderer;
 
-    @Inject
-    PebbleEngineFactory pebbleEngineFactory;
-
     @Test
     void shouldKeepKeyOrderWhenRenderingMap() throws IllegalVariableEvaluationException {
         final Map<String, Object> input = new LinkedHashMap<>();

--- a/core/src/test/java/io/kestra/core/runners/VariableRendererTest.java
+++ b/core/src/test/java/io/kestra/core/runners/VariableRendererTest.java
@@ -3,7 +3,6 @@ package io.kestra.core.runners;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.kestra.core.exceptions.IllegalVariableEvaluationException;
-import io.micronaut.context.ApplicationContext;
 import io.kestra.core.junit.annotations.KestraTest;
 import jakarta.inject.Inject;
 import java.util.LinkedHashMap;
@@ -14,22 +13,11 @@ import java.util.Map;
 
 @KestraTest
 class VariableRendererTest {
-
-    @Inject
-    ApplicationContext applicationContext;
-
-    @Inject
-    VariableRenderer.VariableConfiguration variableConfiguration;
-
     @Inject
     VariableRenderer variableRenderer;
 
-    @Test
-    void shouldRenderUsingAlternativeRendering() throws IllegalVariableEvaluationException {
-        TestVariableRenderer renderer = new TestVariableRenderer(applicationContext, variableConfiguration);
-        String render = renderer.render("{{ dummy }}", Map.of());
-        Assertions.assertEquals("result", render);
-    }
+    @Inject
+    PebbleEngineFactory pebbleEngineFactory;
 
     @Test
     void shouldKeepKeyOrderWhenRenderingMap() throws IllegalVariableEvaluationException {
@@ -88,19 +76,4 @@ class VariableRendererTest {
         assertThat(result.get("key3")).isEqualTo("static");
         assertThat(result).containsKey("key1");
     }
-
-    public static class TestVariableRenderer extends VariableRenderer {
-
-        public TestVariableRenderer(ApplicationContext applicationContext,
-                                    VariableConfiguration variableConfiguration) {
-            super(applicationContext, variableConfiguration);
-        }
-
-        @Override
-        protected String alternativeRender(Exception e, String inline, Map<String, Object> variables) throws IllegalVariableEvaluationException {
-            return "result";
-        }
-    }
-
-
 }

--- a/core/src/test/java/io/kestra/core/runners/pebble/functions/FileSizeFunctionTest.java
+++ b/core/src/test/java/io/kestra/core/runners/pebble/functions/FileSizeFunctionTest.java
@@ -119,11 +119,11 @@ public class FileSizeFunctionTest {
         );
 
         Exception ex = assertThrows(
-            IllegalArgumentException.class,
+            IllegalVariableEvaluationException.class,
             () -> variableRenderer.render("{{ fileSize('" + internalStorageFile + "') }}", variables)
         );
 
-        assertTrue(ex.getMessage().startsWith("Unable to read the file"), "Exception message doesn't match expected one");
+        assertTrue(ex.getCause().getMessage().startsWith("Unable to read the file"), "Exception message doesn't match expected one");
     }
 
     @Test

--- a/core/src/test/java/io/kestra/core/runners/pebble/functions/FileURIFunctionTest.java
+++ b/core/src/test/java/io/kestra/core/runners/pebble/functions/FileURIFunctionTest.java
@@ -3,6 +3,7 @@ package io.kestra.core.runners.pebble.functions;
 import java.util.Map;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -45,8 +46,9 @@ class FileURIFunctionTest {
             "fileA", "../test"
         );
 
-        var exception = assertThrows(IllegalArgumentException.class, () -> variableRenderer.render("{{ fileURI(fileA) }}", variables));
-        assertThat(exception.getMessage(), is("Path must not contain '../'"));
+        var exception = assertThrows(IllegalVariableEvaluationException.class, () -> variableRenderer.render("{{ fileURI(fileA) }}", variables));
+        assertThat(exception.getCause(), instanceOf(IllegalArgumentException.class));
+        assertThat(exception.getCause().getMessage(), is("Path must not contain '../'"));
     }
 
 }


### PR DESCRIPTION
## What

Backport of two `develop` commits to `releases/v0.22.x` so that when a Pebble expression fails for a **runtime / infrastructure** reason (e.g. `{{ secret('...') }}` while Vault returns 502/503, or the older `addSecretConsumer is null` NPE), Kestra **fails fast with the real error** instead of masking it.

Cherry-picked from `develop`:
- `77f0ee6667` chore(execution): remove the alternate variable renderer
- `a80052ed6a` feat(execution): make the VariableRender tolerant about any runtime exception

## Why

Customer report (Leroy Merlin, ticket #1916, on v0.22.43): flows using `{{ secret('...') }}` failed during a Vault incident with a cryptic error:

```
com.github.jknack.handlebars.HandlebarsException: found: ''hr-squad'', expected: 'id'
{{ secret('hr-squad') }}
    at io.kestra.plugin.templates.runners.VariableRenderer.alternativeRender(VariableRenderer.java:304)
    at io.kestra.core.runners.VariableRenderer.renderOnce(VariableRenderer.java:118)
```

**Root cause:** on a Vault 502/503 the secret manager throws `IOException`, which `SecretFunction` wraps in a `PebbleException`. `VariableRenderer.renderOnce` then routed that through the legacy **Handlebars** `alternativeRender` fallback (provided by `plugin-templates`), which cannot parse native Pebble syntax and throws a `HandlebarsException` — discarding the real Vault error. Same mechanism masked the previous `addSecretConsumer is null` NPE variant.

After this change the original error propagates as `IllegalVariableEvaluationException` (wrapping the actual IO/secret failure), and any raw `RuntimeException` thrown by a Pebble function is wrapped cleanly rather than crashing the worker/scheduler.

## Notes
- Already fixed on `develop` (2.0); not present in any released line — this backports it to 0.22.x. Companion PRs target `releases/v1.0.x` (LTS) and `releases/v1.3.x`.
- Removing the core hook is runtime-safe with the existing `plugin-templates` JAR (the override is simply never called). Retiring the now-dead override in `plugin-templates` is a separate follow-up.

## Tests
`./gradlew :core:test` for `VariableRendererTest` and the affected `*FunctionTest` classes pass locally. 0.22.x-specific tests that asserted a raw runtime exception from `render(...)` were updated to assert the wrapped `IllegalVariableEvaluationException` + cause.
