### PR TITLE
fix(cli): load config when required params are missing

### DIFF
--- a/cli/src/main/java/io/kestra/cli/Kestra.java
+++ b/cli/src/main/java/io/kestra/cli/Kestra.java
@@ -122,11 +122,39 @@ public class Kestra implements Callable<Integer> {
         List<CommandLine> parsedCommands = parseResult.asCommandLineList();
         CommandLine leafCmd = parsedCommands.getLast();
 
+        // When a subcommand fails to parse (e.g. missing required positional parameters),
+        // continueOnParsingErrors detaches the subcommand chain from the parse result, so
+        // getLast() returns the root command and the config file is never loaded. On EE builds
+        // startup then fails with a misleading NoSuchBeanException (no TenantRepository) instead
+        // of a proper "Missing required parameters" message. Recover the intended leaf by walking
+        // the subcommand names so the configuration is still resolved for the right command.
+        if (!(leafCmd.getCommandSpec().userObject() instanceof AbstractCommand)
+                && !parseResult.errors().isEmpty()) {
+            leafCmd = resolveSubcommandByName(cls, args);
+        }
+
         // continueOnParsingErrors silently drops unrecognized options at the root level,
         // including --config/-c when it appears before the subcommand name. Recover it here.
         recoverConfigOption(args, leafCmd);
 
         return leafCmd;
+    }
+
+    /**
+     * Resolves the deepest subcommand whose name appears in {@code args}, ignoring options and
+     * positional parameters. Used to recover the target command when {@code parseArgs} aborts the
+     * subcommand chain due to a parsing error (e.g. missing required parameters), so the
+     * configuration file can still be loaded for the right command.
+     */
+    private static CommandLine resolveSubcommandByName(Class<?> cls, String[] args) {
+        CommandLine current = new CommandLine(cls, CommandLine.defaultFactory());
+        for (String arg : args) {
+            CommandLine sub = current.getSubcommands().get(arg);
+            if (sub != null) {
+                current = sub;
+            }
+        }
+        return current;
     }
 
     /**
@@ -192,13 +220,17 @@ public class Kestra implements Callable<Integer> {
             }
 
             // custom server configuration
-            commandLine
-                .getParseResult()
-                .matchedArgs()
-                .stream()
-                .filter(argSpec -> ((Field) argSpec.userObject()).getName().equals("serverPort"))
-                .findFirst()
-                .ifPresent(argSpec -> properties.put("micronaut.server.port", argSpec.getValue()));
+            // getParseResult() is null when the leaf was recovered via resolveSubcommandByName()
+            // (the command was never parsed because of a parsing error), so guard against it.
+            CommandLine.ParseResult leafParseResult = commandLine.getParseResult();
+            if (leafParseResult != null) {
+                leafParseResult
+                    .matchedArgs()
+                    .stream()
+                    .filter(argSpec -> ((Field) argSpec.userObject()).getName().equals("serverPort"))
+                    .findFirst()
+                    .ifPresent(argSpec -> properties.put("micronaut.server.port", argSpec.getValue()));
+            }
 
             builder.properties(properties);
         }

--- a/cli/src/test/java/io/kestra/cli/KestraTest.java
+++ b/cli/src/test/java/io/kestra/cli/KestraTest.java
@@ -87,6 +87,39 @@ class KestraTest {
     }
 
     @Test
+    void configLoadedWhenRequiredParamsMissing() throws Exception {
+        // Regression test for Pylon #1698: when a subcommand is invoked without its required
+        // positional parameters, continueOnParsingErrors detaches the subcommand chain so the
+        // leaf resolved to the root Kestra command and the config file was never loaded — on EE
+        // builds this surfaced as a misleading NoSuchBeanException (TenantRepository) instead of a
+        // proper "Missing required parameters" message. Fix: getCommandLine() recovers the real
+        // leaf via resolveSubcommandByName() so the config is loaded for the right command.
+        Path configFile = Files.createTempFile("kestra-test-", ".yml");
+        try {
+            Files.writeString(configFile, "kestra:\n  test:\n    marker: config-loaded\n");
+
+            // "flow namespace update" requires the <namespace> and <directory> positionals; they
+            // are deliberately omitted here so the parse fails and the leaf would otherwise be the
+            // root Kestra command.
+            String[] args = { "flow", "namespace", "update", "--config", configFile.toString() };
+
+            Method getCommandLine = Kestra.class.getDeclaredMethod("getCommandLine", Class.class, String[].class);
+            getCommandLine.setAccessible(true);
+            CommandLine leafCmd = (CommandLine) getCommandLine.invoke(null, Kestra.class, args);
+
+            Object userObject = leafCmd.getCommandSpec().userObject();
+            assertThat(userObject)
+                .as("leaf should be recovered as the real subcommand, not the root command")
+                .isInstanceOf(AbstractCommand.class);
+            AbstractCommand abstractCmd = (AbstractCommand) userObject;
+            assertThat(abstractCmd.propertiesFromConfig())
+                .containsEntry("kestra.test.marker", "config-loaded");
+        } finally {
+            Files.deleteIfExists(configFile);
+        }
+    }
+
+    @Test
     void missingRequiredParamsPrintHelpInsteadOfException() {
         final ByteArrayOutputStream out = new ByteArrayOutputStream();
         System.setErr(new PrintStream(out));


### PR DESCRIPTION
### What

When a CLI subcommand is invoked **without its required positional parameters**, the configuration file is silently not loaded. On EE builds this surfaces as a misleading error:

```
No bean of type [io.kestra.ee.repositories.TenantRepositoryInterface] exists.
  * [PostgresTenantRepository] disabled: Required property [kestra.repository.type] ... not present
```

…instead of a proper `Missing required parameters: '<namespace>', '<directory>'` message.

### Root cause

`getCommandLine()` parses with `continueOnParsingErrors` (`collectErrors(true)`). When a subcommand fails required-parameter validation, picocli **collects** the error and **detaches the subcommand chain** from the `ParseResult` — `parseResult.asCommandLineList().getLast()` returns the root command, and the failing-command instance is unreachable (even `ParameterException.getCommandLine()` returns the root). Since the root is not an `AbstractCommand`, `applicationContext()` skips `propertiesFromConfig()` entirely, so neither `--config` nor the default `~/.kestra/config.yml` is loaded. The EE `TenantIdSelectorEEService` (which `@Replaces` the OSS service and injects `TenantRepositoryInterface`) then can't be created.

This is independent of `--config` placement, and distinct from the `--config`-before-subcommand case fixed in #16775.

### Fix

- `getCommandLine()`: when the parsed leaf is not an `AbstractCommand` **and** the parse produced errors, recover the intended leaf by walking subcommand **names** on a fresh `CommandLine` (`resolveSubcommandByName()`). Config is then loaded for the right command, and picocli reports a proper "Missing required parameters" message.
- `applicationContext()`: null-guard `commandLine.getParseResult()` — the recovered leaf was never parsed (the `serverPort` lookup must not NPE).

### Test

- New `KestraTest.configLoadedWhenRequiredParamsMissing()` — runs `flow namespace update` **without** positionals + `--config`, asserts the recovered leaf is an `AbstractCommand` and `propertiesFromConfig()` contains the config.

### Verification

Built an EE shadowJar from this branch and ran the reported commands (`flow namespace update`, `namespace files update`) with missing positionals and `--config` before/after: config now loads, **no bean error**. With a self-contained repository (H2), the missing-args case prints `Missing required parameters: '<namespace>', '<directory>'` + usage. Companion v1.3.x PR: #16845.

### ⚠️ Known CI interaction — `testServerCommandHelp[controller]` (please advise)

This fix surfaces a **pre-existing test-isolation weakness** in `KestraTest` that I did not want to mask:

- CLI invocations in the test JVM share an in-memory H2 (`DB_CLOSE_DELAY=-1`).
- With this fix, `missingRequiredParamsPrintHelpInsteadOfException` (`flow delete`, missing args) now resolves to the real `FlowDeleteCommand` and initializes that shared H2 **without** the queue migrations.
- A later `testServerCommandHelp[controller]` then fails because `server controller --help` **eagerly instantiates** `GrpcWorkerControllerService`, which queries the `QUEUES` table → `Table "QUEUES" not found (this database is empty)` → exit 1.

This is a **same-JVM test artifact only** — in production each CLI call is a separate process against a real, migrated database, and the `controller --help` path is unaffected. It does not occur on `releases/v1.3.x` (#16845) because that branch has no `controller` server type.

Rather than mask it (e.g. `@FlakyTest`), I'm flagging it: the underlying issues are (a) `server controller --help` instantiating a DB-querying bean just to print help, and (b) CLI tests sharing an in-memory H2 across contexts. Happy to follow the maintainers' preferred direction — guard the `--help` path, isolate the datasource per test, or split these into separate JVMs.

### Related

- Companion of #16775 / #16845.
- Customer issue: kestra-io/kestra-ee#8564.