### PR TITLE
fix(storage): retry temp file deletion to handle transient Windows file locks

### DIFF
--- a/core/src/main/java/io/kestra/core/storages/InternalStorage.java
+++ b/core/src/main/java/io/kestra/core/storages/InternalStorage.java
@@ -6,7 +6,6 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
-import java.nio.file.Files;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.List;
@@ -15,6 +14,7 @@ import java.util.Optional;
 import org.slf4j.Logger;
 
 import io.kestra.core.services.NamespaceService;
+import io.kestra.core.utils.FileUtils;
 
 import jakarta.annotation.Nullable;
 import lombok.extern.slf4j.Slf4j;
@@ -188,11 +188,8 @@ public class InternalStorage implements Storage {
         try (InputStream is = new FileInputStream(file)) {
             return putFile(is, resolved);
         } finally {
-            try {
-                Files.delete(file.toPath());
-            } catch (IOException e) {
-                logger.warn("Failed to delete temporary file '{}'", file.toPath(), e);
-            }
+            FileUtils.deleteWithRetry(file.toPath())
+                .ifPresent(e -> logger.warn("Failed to delete temporary file '{}'", file.toPath(), e));
         }
     }
 
@@ -249,11 +246,8 @@ public class InternalStorage implements Storage {
         try (InputStream is = new FileInputStream(file)) {
             return this.putFile(is, uri);
         } finally {
-            try {
-                Files.delete(file.toPath());
-            } catch (IOException e) {
-                logger.warn("Failed to delete temporary file '{}'", file.toPath(), e);
-            }
+            FileUtils.deleteWithRetry(file.toPath())
+                .ifPresent(e -> logger.warn("Failed to delete temporary file '{}'", file.toPath(), e));
         }
     }
 

--- a/core/src/main/java/io/kestra/core/storages/configuration/TempFileDeletionConfiguration.java
+++ b/core/src/main/java/io/kestra/core/storages/configuration/TempFileDeletionConfiguration.java
@@ -1,0 +1,24 @@
+package io.kestra.core.storages.configuration;
+
+import io.micronaut.context.annotation.ConfigurationProperties;
+import io.micronaut.core.bind.annotation.Bindable;
+
+import java.time.Duration;
+
+/**
+ * Configuration for the deletion of the transient files created while uploading to the internal storage.
+ * <p>
+ * On Windows a file that has just been closed can stay briefly locked (asynchronous handle release,
+ * antivirus or indexing), making the deletion fail. Retrying after a short delay clears this in
+ * virtually all cases. These properties tune that retry behaviour and are bound from
+ * {@code kestra.storage.temp-file-deletion.*}.
+ *
+ * @param maxAttempts the number of deletion attempts before giving up and logging a warning.
+ * @param retryDelay  the delay between two deletion attempts.
+ */
+@ConfigurationProperties("kestra.storage.temp-file-deletion")
+public record TempFileDeletionConfiguration(
+    @Bindable(defaultValue = "5") Integer maxAttempts,
+    @Bindable(defaultValue = "50ms") Duration retryDelay
+) {
+}

--- a/core/src/main/java/io/kestra/core/storages/configuration/TempFileDeletionConfigurer.java
+++ b/core/src/main/java/io/kestra/core/storages/configuration/TempFileDeletionConfigurer.java
@@ -1,0 +1,20 @@
+package io.kestra.core.storages.configuration;
+
+import io.kestra.core.utils.FileUtils;
+import io.micronaut.context.annotation.Context;
+
+/**
+ * Applies {@link TempFileDeletionConfiguration} to the static retry settings of {@link FileUtils} at
+ * startup.
+ * <p>
+ * {@code FileUtils} is a static utility used from many non-managed call sites, so rather than thread
+ * the configuration through every caller we push the configured values into it once, eagerly
+ * ({@link Context}), before any flow is executed.
+ */
+@Context
+public class TempFileDeletionConfigurer {
+
+    public TempFileDeletionConfigurer(TempFileDeletionConfiguration configuration) {
+        FileUtils.configureDeletionRetry(configuration.maxAttempts(), configuration.retryDelay());
+    }
+}

--- a/core/src/main/java/io/kestra/core/utils/FileUtils.java
+++ b/core/src/main/java/io/kestra/core/utils/FileUtils.java
@@ -3,13 +3,49 @@ package io.kestra.core.utils;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.lang3.StringUtils;
 
+import java.io.IOException;
 import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
 import java.util.Optional;
 
 /**
  * Utility methods for manipulating files.
  */
 public final class FileUtils {
+
+    /**
+     * Default number of attempts made by {@link #deleteWithRetry(Path)} before giving up.
+     */
+    static final int DEFAULT_DELETE_MAX_ATTEMPTS = 5;
+
+    /**
+     * Default delay between two deletion attempts in {@link #deleteWithRetry(Path)}.
+     */
+    static final Duration DEFAULT_DELETE_RETRY_DELAY = Duration.ofMillis(50);
+
+    /**
+     * Retry settings for {@link #deleteWithRetry(Path)}. These are mutable so they can be tuned from
+     * Micronaut configuration at startup (see {@code TempFileDeletionConfigurer}); they default to
+     * sensible values for callers that run without the application context (e.g. tests).
+     */
+    private static volatile int deleteMaxAttempts = DEFAULT_DELETE_MAX_ATTEMPTS;
+    private static volatile Duration deleteRetryDelay = DEFAULT_DELETE_RETRY_DELAY;
+
+    /**
+     * Overrides the retry settings used by {@link #deleteWithRetry(Path)}.
+     * <p>
+     * Intended to be called once at startup from the configuration layer. Falls back to the defaults
+     * for non-positive attempts or a {@code null} delay.
+     *
+     * @param maxAttempts the number of deletion attempts before giving up.
+     * @param retryDelay  the delay between two attempts.
+     */
+    public static void configureDeletionRetry(final int maxAttempts, final Duration retryDelay) {
+        deleteMaxAttempts = maxAttempts > 0 ? maxAttempts : DEFAULT_DELETE_MAX_ATTEMPTS;
+        deleteRetryDelay = retryDelay != null ? retryDelay : DEFAULT_DELETE_RETRY_DELAY;
+    }
 
     /**
      * Get the file extension prefixed the '.' from the given file URI.
@@ -96,5 +132,45 @@ public final class FileUtils {
             || normalized.startsWith("../")
             || normalized.endsWith("/..")
             || normalized.contains("/../");
+    }
+
+    /**
+     * Best-effort deletion of a file, tolerant of transient file locks.
+     * <p>
+     * On Windows a file that has just been closed can stay briefly locked — the OS releases the
+     * handle asynchronously and antivirus/indexing may hold it open for a few milliseconds — which
+     * makes {@link Files#delete(Path)} fail with an {@code AccessDeniedException}. Retrying after a
+     * short pause clears this in virtually all cases. On Unix-like systems the first attempt
+     * succeeds and this method returns immediately.
+     *
+     * <p>
+     * The number of attempts and the delay between them are tunable via
+     * {@link #configureDeletionRetry(int, Duration)}.
+     *
+     * @param path the file to delete.
+     * @return the last {@link IOException} if the file could still not be deleted after all
+     *         attempts, otherwise {@link Optional#empty()}.
+     */
+    public static Optional<IOException> deleteWithRetry(final Path path) {
+        int attempts = Math.max(1, deleteMaxAttempts);
+        long delayMillis = Math.max(0, deleteRetryDelay.toMillis());
+        IOException last = null;
+        for (int attempt = 1; attempt <= attempts; attempt++) {
+            try {
+                Files.deleteIfExists(path);
+                return Optional.empty();
+            } catch (IOException e) {
+                last = e;
+                if (attempt < attempts && delayMillis > 0) {
+                    try {
+                        Thread.sleep(delayMillis);
+                    } catch (InterruptedException ie) {
+                        Thread.currentThread().interrupt();
+                        break;
+                    }
+                }
+            }
+        }
+        return Optional.ofNullable(last);
     }
 }

--- a/core/src/test/java/io/kestra/core/utils/FileUtilsTest.java
+++ b/core/src/test/java/io/kestra/core/utils/FileUtilsTest.java
@@ -1,10 +1,14 @@
 package io.kestra.core.utils;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
 import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -91,5 +95,51 @@ class FileUtilsTest {
     void isParentTraversal_handlesNull() {
         assertThat(FileUtils.isParentTraversal((URI) null)).isFalse();
         assertThat(FileUtils.isParentTraversal((String) null)).isFalse();
+    }
+
+    @Test
+    void shouldDeleteExistingFileWithRetry(@TempDir Path tempDir) throws Exception {
+        Path file = Files.createFile(tempDir.resolve("to-delete.ion"));
+
+        assertThat(FileUtils.deleteWithRetry(file)).isEmpty();
+        assertThat(Files.exists(file)).isFalse();
+    }
+
+    @Test
+    void shouldNotFailWhenFileAlreadyAbsent(@TempDir Path tempDir) {
+        Path file = tempDir.resolve("never-existed.ion");
+
+        // deleteIfExists semantics: a missing file is a no-op, not an error.
+        assertThat(FileUtils.deleteWithRetry(file)).isEmpty();
+    }
+
+    @Test
+    void shouldReturnErrorAfterExhaustingConfiguredAttempts(@TempDir Path tempDir) throws Exception {
+        // A non-empty directory cannot be deleted, so every attempt throws — this exercises the
+        // configurable retry/give-up path without depending on platform-specific locking.
+        Path dir = Files.createDirectory(tempDir.resolve("not-empty"));
+        Files.createFile(dir.resolve("child.txt"));
+
+        FileUtils.configureDeletionRetry(2, Duration.ofMillis(1));
+        try {
+            assertThat(FileUtils.deleteWithRetry(dir)).isPresent();
+            assertThat(Files.exists(dir)).isTrue();
+        } finally {
+            // Restore defaults so the tuning doesn't leak into other tests.
+            FileUtils.configureDeletionRetry(FileUtils.DEFAULT_DELETE_MAX_ATTEMPTS, FileUtils.DEFAULT_DELETE_RETRY_DELAY);
+        }
+    }
+
+    @Test
+    void shouldFallBackToDefaultsForInvalidRetrySettings(@TempDir Path tempDir) throws Exception {
+        // Non-positive attempts / null delay must not break deletion.
+        FileUtils.configureDeletionRetry(0, null);
+        try {
+            Path file = Files.createFile(tempDir.resolve("to-delete.ion"));
+            assertThat(FileUtils.deleteWithRetry(file)).isEmpty();
+            assertThat(Files.exists(file)).isFalse();
+        } finally {
+            FileUtils.configureDeletionRetry(FileUtils.DEFAULT_DELETE_MAX_ATTEMPTS, FileUtils.DEFAULT_DELETE_RETRY_DELAY);
+        }
     }
 }


### PR DESCRIPTION
Stops the spurious `Failed to delete temporary file '...'` warning that can occur on Windows after files are uploaded to internal storage.

The root cause is that `InternalStorage.putFile(File)` deletes temporary files immediately after upload using a single `Files.delete()` call. On Windows, recently closed files can remain temporarily locked, causing the delete to fail and log a warning even though the upload succeeded. This change adds retry logic for temporary file deletion and makes the retry behaviour configurable, so warnings are only logged when deletion still fails after all retry attempts.
