### PR TITLE
feat(worker): expose task completion rate in worker heartbeat

### DIFF
--- a/core/src/main/java/io/kestra/core/metrics/MetricRegistry.java
+++ b/core/src/main/java/io/kestra/core/metrics/MetricRegistry.java
@@ -47,6 +47,8 @@ public class MetricRegistry {
     public static final String METRIC_WORKER_TIMEOUT_COUNT_DESCRIPTION = "The total number of tasks that timeout inside the Worker";
     public static final String METRIC_WORKER_ENDED_COUNT = "worker.ended.count";
     public static final String METRIC_WORKER_ENDED_COUNT_DESCRIPTION = "The total number of tasks ended by the Worker";
+    public static final String METRIC_WORKER_TASKS_RATE = "worker.tasks.rate";
+    public static final String METRIC_WORKER_TASKS_RATE_DESCRIPTION = "The smoothed rate of tasks completed by the Worker, in tasks per second";
     public static final String METRIC_WORKER_ENDED_DURATION = "worker.ended.duration";
     public static final String METRIC_WORKER_ENDED_DURATION_DESCRIPTION = "Task run duration inside the Worker";
     public static final String METRIC_WORKER_TRIGGER_DURATION = "worker.trigger.duration";

--- a/worker/src/main/java/io/kestra/worker/AbstractWorker.java
+++ b/worker/src/main/java/io/kestra/worker/AbstractWorker.java
@@ -75,6 +75,9 @@ public abstract class AbstractWorker extends AbstractService {
 
     protected String workerGroupId;
 
+    // Single per-Worker meter deriving the task completion rate from worker.ended.count.
+    private RateMeter rateMeter;
+
     protected AbstractWorker(
         final ServiceType serviceType,
         final ApplicationEventPublisher<ServiceStateChangeEvent> eventPublisher,
@@ -140,6 +143,10 @@ public abstract class AbstractWorker extends AbstractService {
             numThreads + WorkerQueueRegistry.bufferSize(numThreads),
             metricRegistry.workerGroupTags(workerGroupId)
         );
+        // Tasks-completed throughput (tasks/s), surfaced in the Worker Group UI. The
+        // rate is derived from the existing worker.ended.count counter and sampled on
+        // each heartbeat (see getMetrics) — no extra metric is registered.
+        this.rateMeter = new RateMeter(metricRegistry, workerGroupId);
 
         WorkerContext workerContext = new WorkerContext(getId(), workerGroupId, numThreads);
 
@@ -208,13 +215,29 @@ public abstract class AbstractWorker extends AbstractService {
 
         String ownGroup = WorkerGroups.normalize(this.workerGroupId);
         // Only expose worker-level (global) gauges in the heartbeat.
-        return metrics
+        Set<Metric> result = metrics
             .flatMap(metric -> metricRegistry.findGauges(metric).stream())
             .filter(gauge -> ownGroup.equals(gauge.getId().getTag(MetricRegistry.TAG_WORKER_GROUP)))
             .filter(gauge -> gauge.getId().getTag(MetricRegistry.TAG_TENANT_ID) == null
                 && gauge.getId().getTag(MetricRegistry.TAG_NAMESPACE_ID) == null)
             .map(Metric::of)
             .collect(Collectors.toSet());
+
+        // Task completion rate (tasks/s). Sampled here rather than registered as a
+        // Micrometer gauge — the heartbeat is the only consumer, and getMetrics() is
+        // serialized by the liveness manager so the meter is sampled single-threaded.
+        if (rateMeter != null) {
+            result.add(new Metric(
+                MetricRegistry.METRIC_WORKER_TASKS_RATE,
+                "GAUGE",
+                MetricRegistry.METRIC_WORKER_TASKS_RATE_DESCRIPTION,
+                null,
+                List.of(new Metric.Tag(MetricRegistry.TAG_WORKER_GROUP, ownGroup)),
+                rateMeter.sampleRatePerSecond()
+            ));
+        }
+
+        return result;
     }
 
     @Override

--- a/worker/src/main/java/io/kestra/worker/RateMeter.java
+++ b/worker/src/main/java/io/kestra/worker/RateMeter.java
@@ -1,0 +1,73 @@
+package io.kestra.worker;
+
+import io.kestra.core.metrics.MetricRegistry;
+import io.kestra.core.worker.WorkerGroups;
+import io.micrometer.core.instrument.Counter;
+
+/**
+ * Derives how fast a single Worker completes tasks, reusing the existing
+ * {@code worker.ended.count} counter — no extra counter is maintained and nothing
+ * new is registered in Micrometer. The heartbeat thread calls
+ * {@link #sampleRatePerSecond()} periodically; each call diffs the counter total
+ * against the previous sample and feeds the instantaneous rate through an
+ * exponential moving average so the value the UI shows doesn't jump between
+ * samples. One instance per Worker.
+ *
+ * <p>Expected to be sampled from a single thread (the liveness heartbeat, which is
+ * serialized under its state lock), so the book-keeping fields need no synchronization.
+ */
+public final class RateMeter {
+
+    /** Smoothing factor: higher reacts faster, lower is steadier. */
+    private static final double ALPHA = 0.3;
+
+    private final MetricRegistry metricRegistry;
+    private final String workerGroupId;
+
+    private double lastCount;
+    private long lastNanos;
+    private double smoothedRate = 0.0;
+    private boolean initialized = false;
+
+    public RateMeter(final MetricRegistry metricRegistry, final String workerGroupId) {
+        this.metricRegistry = metricRegistry;
+        this.workerGroupId = workerGroupId;
+    }
+
+    /**
+     * @return the EWMA-smoothed tasks/sec completed since the previous call. The first
+     *         call only establishes the baseline and returns 0.
+     */
+    public double sampleRatePerSecond() {
+        double current = currentTaskCount();
+        long now = System.nanoTime();
+
+        if (!initialized) {
+            this.lastCount = current;
+            this.lastNanos = now;
+            this.initialized = true;
+            return 0.0;
+        }
+
+        double elapsedSeconds = (now - lastNanos) / 1_000_000_000.0;
+        double instantRate = elapsedSeconds > 0 ? (current - lastCount) / elapsedSeconds : 0.0;
+        this.smoothedRate = ALPHA * instantRate + (1 - ALPHA) * smoothedRate;
+
+        this.lastCount = current;
+        this.lastNanos = now;
+        return smoothedRate;
+    }
+
+    /**
+     * Sums the existing {@code worker.ended.count} counter across all
+     * task_type / namespace / flow series for this worker's group.
+     */
+    private double currentTaskCount() {
+        return metricRegistry.find(MetricRegistry.METRIC_WORKER_ENDED_COUNT)
+            .tag(MetricRegistry.TAG_WORKER_GROUP, WorkerGroups.normalize(workerGroupId))
+            .counters()
+            .stream()
+            .mapToDouble(Counter::count)
+            .sum();
+    }
+}


### PR DESCRIPTION
Add a per-Worker RateMeter that derives the task completion rate (tasks/sec) from the existing worker.ended.count counter — EWMA-smoothed (ALPHA=0.3), sampled on each heartbeat and emitted as the worker.tasks.rate metric in the heartbeat set. No new Micrometer meter is registered; the rate is an operational figure for the Worker Group UI only.