### PR TITLE
fix(core): hide progress bar in KPI widget when value is 0

### DIFF
--- a/ui/src/components/dashboard/sections/KPI.vue
+++ b/ui/src/components/dashboard/sections/KPI.vue
@@ -7,7 +7,7 @@
         </p>
 
         <KsProgress
-            v-if="percentageShown"
+            v-if="percentageShown && progressValue > 0"
             class="progress"
             :percentage="progressValue"
             :strokeWidth="6"
@@ -99,7 +99,7 @@
         .progress {
             width: 100%;
             margin-top: var(--ks-spacing-3);
-            
+
             :deep(.kel-progress-bar__outer) {
                 background-color: var(--ks-bg-base);
             }


### PR DESCRIPTION
Looks weird with progress bar if it's on 0, so I removed it on that case. If it goes against the designs, let's close this.

<img width="1213" height="212" alt="image" src="https://github.com/user-attachments/assets/6c1573b9-c939-4139-91af-a66a0eaee0b8" />