### PR TITLE
fix(security): replace SHA-512 with bcrypt for BasicAuth password storage (1.3 backport)

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -32,6 +32,7 @@ dependencies {
     implementation "io.micronaut:micronaut-http-server-netty"
 
     // utils
+    implementation "org.bouncycastle:bcprov-jdk18on"
     implementation 'com.github.oshi:oshi-core'
     implementation 'io.pebbletemplates:pebble'
     implementation group: 'co.elastic.logging', name: 'logback-ecs-encoder'

--- a/core/src/main/java/io/kestra/core/utils/AuthUtils.java
+++ b/core/src/main/java/io/kestra/core/utils/AuthUtils.java
@@ -1,20 +1,79 @@
 package io.kestra.core.utils;
 
 import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
+import java.util.HexFormat;
 
 import org.apache.commons.lang3.RandomStringUtils;
+import org.bouncycastle.crypto.generators.OpenBSDBCrypt;
 
-import com.google.common.hash.Hashing;
+public final class AuthUtils {
 
-public class AuthUtils {
+    public static final int BCRYPT_COST = 12;
+
+    private static final SecureRandom SECURE_RANDOM = new SecureRandom();
+
+    private AuthUtils() {}
+
+    /**
+     * Computes the SHA-512 hex digest of {@code salt|password} (inner pre-hash).
+     * This is the input fed to {@link #bcryptDigest(String)} when storing passwords.
+     */
     public static String encodePassword(String salt, String password) {
-        return Hashing
-            .sha512()
-            .hashString(salt + "|" + password, StandardCharsets.UTF_8)
-            .toString();
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-512");
+            byte[] bytes = digest.digest((salt + "|" + password).getBytes(StandardCharsets.UTF_8));
+            return HexFormat.of().formatHex(bytes);
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException("SHA-512 not available", e);
+        }
     }
 
     public static String generateSalt() {
         return RandomStringUtils.secure().next(32, true, true);
+    }
+
+    /**
+     * Wraps a SHA-512 hex digest in bcrypt (cost {@value #BCRYPT_COST}).
+     * Used both when persisting a new password and by the in-service migration
+     * that upgrades legacy SHA-512-only hashes to bcrypt at startup.
+     *
+     * <p><strong>Note on input length:</strong> {@code OpenBSDBCrypt} silently truncates its
+     * password input to 72 bytes.  The 128-char hex string produced by
+     * {@link #encodePassword(String, String)} is 128 bytes in UTF-8, so only the first 72 hex
+     * characters are actually fed to the bcrypt key-expansion.  This is safe because both
+     * {@code generate} and {@code checkPassword} truncate consistently, and finding two SHA-512
+     * hex outputs that share a 72-byte prefix requires breaking SHA-512 preimage resistance.
+     *
+     * @param sha512Hex the 128-char hex output of {@link #encodePassword(String, String)}
+     * @return a bcrypt modular-crypt string starting with {@code $2y$}
+     */
+    public static String bcryptDigest(String sha512Hex) {
+        byte[] salt = new byte[16];
+        SECURE_RANDOM.nextBytes(salt);
+        return OpenBSDBCrypt.generate("2y", sha512Hex.getBytes(StandardCharsets.UTF_8), salt, BCRYPT_COST);
+    }
+
+    /**
+     * Hashes {@code password} for storage: {@code bcrypt(sha512(salt|password))}.
+     */
+    public static String hashPassword(String salt, String password) {
+        return bcryptDigest(encodePassword(salt, password));
+    }
+
+    /**
+     * Verifies {@code password} against a stored bcrypt hash.
+     *
+     * @return {@code true} if the password matches; {@code false} if it does not or if
+     *         {@code storedHash} is not a valid bcrypt string (fail-closed for legacy SHA-512 values)
+     */
+    public static boolean matches(String salt, String password, String storedHash) {
+        try {
+            return OpenBSDBCrypt.checkPassword(storedHash, encodePassword(salt, password).getBytes(StandardCharsets.UTF_8));
+        } catch (Exception e) {
+            return false;
+        }
     }
 }

--- a/webserver/src/main/java/io/kestra/webserver/filter/AuthenticationFilter.java
+++ b/webserver/src/main/java/io/kestra/webserver/filter/AuthenticationFilter.java
@@ -1,12 +1,10 @@
 package io.kestra.webserver.filter;
 
-import java.util.Base64;
 import java.util.Collection;
 import java.util.Optional;
 
 import org.reactivestreams.Publisher;
 
-import io.kestra.core.utils.AuthUtils;
 import io.kestra.webserver.services.BasicAuthService;
 
 import io.micronaut.context.annotation.Requires;
@@ -14,7 +12,6 @@ import io.micronaut.http.HttpRequest;
 import io.micronaut.http.HttpResponse;
 import io.micronaut.http.MutableHttpResponse;
 import io.micronaut.http.annotation.Filter;
-import io.micronaut.http.cookie.Cookie;
 import io.micronaut.http.filter.HttpServerFilter;
 import io.micronaut.http.filter.ServerFilterChain;
 import io.micronaut.http.filter.ServerFilterPhase;
@@ -31,9 +28,8 @@ import reactor.core.scheduler.Schedulers;
 @Requires(property = "kestra.server-type", pattern = "(WEBSERVER|STANDALONE)")
 @Requires(property = "micronaut.security.enabled", notEquals = "true") // don't add this filter in EE
 public class AuthenticationFilter implements HttpServerFilter {
-    private static final String PREFIX = "Basic";
     private static final Integer ORDER = ServerFilterPhase.SECURITY.order();
-    public static final String BASIC_AUTH_COOKIE_NAME = "BASIC_AUTH";
+    public static final String BASIC_AUTH_COOKIE_NAME = BasicAuthService.BASIC_AUTH_COOKIE_NAME;
 
     @Inject
     private BasicAuthService basicAuthService;
@@ -64,19 +60,10 @@ public class AuthenticationFilter implements HttpServerFilter {
                     return chain.proceed(request);
                 }
 
-                var basicAuth = fromCookie(request)
-                    .or(() -> fromAuthorizationHeader(request))
-                    .map(BasicAuth::from);
-
-                if (
-                    basicAuth.isEmpty() || basicAuthConfiguration.credentials() == null ||
-                        !basicAuth.get().username().equals(basicAuthConfiguration.credentials().getUsername()) ||
-                        !AuthUtils.encodePassword(
-                            basicAuthConfiguration.credentials().getSalt(),
-                            basicAuth.get().password()
-                        ).equals(basicAuthConfiguration.credentials().getPassword())
-                ) {
-                    Boolean isFromLoginPage = Optional.ofNullable(request.getHeaders().get("Referer")).map(referer -> referer.split("\\?")[0].endsWith("/login")).orElse(false);
+                if (!basicAuthService.isAuthenticated(request)) {
+                    Boolean isFromLoginPage = Optional.ofNullable(request.getHeaders().get("Referer"))
+                        .map(referer -> referer.split("\\?")[0].endsWith("/login"))
+                        .orElse(false);
 
                     return Mono.just(HttpResponse.unauthorized())
                         .map(response -> isFromLoginPage ? response : response.header("WWW-Authenticate", "Basic"));
@@ -90,25 +77,6 @@ public class AuthenticationFilter implements HttpServerFilter {
         return path.replaceAll("/+", "/");
     }
 
-    private Optional<String> fromCookie(HttpRequest<?> request) {
-        try {
-            return Optional.ofNullable(
-                request.getCookies()
-                    .get(BASIC_AUTH_COOKIE_NAME)
-            ).map(Cookie::getValue);
-        } catch (Exception e) {
-            // Can happen in tests because getCookies() is not implemented in NettyClientHttpRequest but is in NettyHttpRequest
-            return Optional.empty();
-        }
-    }
-
-    private Optional<String> fromAuthorizationHeader(HttpRequest<?> request) {
-        return request.getHeaders()
-            .getAuthorization()
-            .filter(auth -> auth.toLowerCase().startsWith(PREFIX.toLowerCase()))
-            .map(cred -> cred.substring(PREFIX.length() + 1));
-    }
-
     @SuppressWarnings("rawtypes")
     private boolean isManagementEndpoint(HttpRequest<?> request) {
         Optional<RouteMatch> routeMatch = RouteMatchUtils.findRouteMatch(request);
@@ -116,14 +84,5 @@ public class AuthenticationFilter implements HttpServerFilter {
             return method.getAnnotation(Endpoint.class) != null;
         }
         return false;
-    }
-
-    record BasicAuth(String username, String password) {
-        static BasicAuth from(String authentication) {
-            var decoded = new String(Base64.getDecoder().decode(authentication));
-            var username = decoded.substring(0, decoded.indexOf(':'));
-            var password = decoded.substring(decoded.indexOf(':') + 1);
-            return new BasicAuth(username, password);
-        }
     }
 }

--- a/webserver/src/main/java/io/kestra/webserver/services/BasicAuthService.java
+++ b/webserver/src/main/java/io/kestra/webserver/services/BasicAuthService.java
@@ -1,7 +1,12 @@
 package io.kestra.webserver.services;
 
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 import java.time.Instant;
 import java.util.*;
+import java.util.HexFormat;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.regex.Pattern;
 
 import org.apache.commons.lang3.StringUtils;
@@ -21,6 +26,8 @@ import io.micronaut.context.annotation.ConfigurationProperties;
 import io.micronaut.context.annotation.Context;
 import io.micronaut.context.annotation.Requires;
 import io.micronaut.context.event.ApplicationEventPublisher;
+import io.micronaut.http.HttpRequest;
+import io.micronaut.http.cookie.Cookie;
 import jakarta.annotation.Nullable;
 import jakarta.annotation.PostConstruct;
 import jakarta.inject.Inject;
@@ -36,14 +43,23 @@ import lombok.NoArgsConstructor;
 public class BasicAuthService {
     public static final String BASIC_AUTH_SETTINGS_KEY = "kestra.server.basic-auth";
     public static final String BASIC_AUTH_ERROR_CONFIG = "kestra.server.authentication-configuration-error";
-    private static final Pattern EMAIL_PATTERN = Pattern.compile("^[a-zA-Z0-9_!#$%&’*+/=?`{|}~^.-]+@[a-zA-Z0-9.-]+$");
+    public static final String BASIC_AUTH_COOKIE_NAME = "BASIC_AUTH";
+    private static final Pattern EMAIL_PATTERN = Pattern.compile("^[a-zA-Z0-9_!#$%&'*+/=?`{|}~^.-]+@[a-zA-Z0-9.-]+$");
     private static final Pattern PASSWORD_PATTERN = Pattern.compile("(?=.{8,})(?=.*[a-z])(?=.*[A-Z])(?=.*[0-9]).*");
     private static final int EMAIL_PASSWORD_MAX_LEN = 256;
+
+    /**
+     * SHA-256 of the last successfully verified token, or {@code null} if not yet verified or
+     * invalidated. Because there is only one valid username/password at any time, a single field
+     * is sufficient. Cleared by {@link #save} whenever credentials change.
+     */
+    private final AtomicReference<String> lastVerifiedTokenSha256 = new AtomicReference<>();
 
     @Inject
     private SettingRepositoryInterface settingRepository;
 
     @Inject
+    @VisibleForTesting
     BasicAuthConfiguration basicAuthConfiguration;
 
     @Inject
@@ -66,6 +82,10 @@ public class BasicAuthService {
     @VisibleForTesting
     @PostConstruct
     public void init() {
+        // Compatibility layer: upgrade any legacy SHA-512 stored password to bcrypt.
+        // This replaces the JDBC migration that is unavailable in the 1.3 branch.
+        migrateLegacyPassword();
+
         if (
             basicAuthConfiguration == null ||
                 (StringUtils.isBlank(basicAuthConfiguration.getUsername()) && StringUtils.isBlank(basicAuthConfiguration.getPassword()))
@@ -88,6 +108,27 @@ public class BasicAuthService {
                     .build()
             );
         }
+    }
+
+    /**
+     * If the stored password is a legacy SHA-512 hex string (does not start with the bcrypt
+     * modular-crypt prefix {@code $2}), wraps it in bcrypt in-place.  No plaintext is needed:
+     * the SHA-512 digest itself becomes the bcrypt input, matching the algorithm used by
+     * {@link AuthUtils#hashPassword} so that subsequent verifications work transparently.
+     */
+    private void migrateLegacyPassword() {
+        var credentials = this.configuration().credentials();
+        if (credentials == null || credentials.getPassword() == null || credentials.getPassword().startsWith("$2")) {
+            return;
+        }
+        String bcryptHash = AuthUtils.bcryptDigest(credentials.getPassword());
+        settingRepository.save(
+            Setting.builder()
+                .key(BASIC_AUTH_SETTINGS_KEY)
+                .value(new SaltedBasicAuthCredentials(credentials.getSalt(), credentials.getUsername(), bcryptHash))
+                .build()
+        );
+        lastVerifiedTokenSha256.set(null);
     }
 
     public void save(BasicAuthCredentials basicAuthCredentials) {
@@ -124,18 +165,28 @@ public class BasicAuthService {
         String salt = previousConfiguredCredentials == null
             ? null
             : previousConfiguredCredentials.getSalt();
-        SaltedBasicAuthCredentials saltedNewConfiguration = SaltedBasicAuthCredentials.salt(
-            salt,
-            basicAuthCredentials.getUsername(),
-            basicAuthCredentials.getPassword()
-        );
-        if (!saltedNewConfiguration.equals(previousConfiguredCredentials)) {
+
+        // bcrypt is non-deterministic, so we cannot compare hashes directly.
+        // Use matches() to determine whether the credentials actually changed.
+        boolean unchanged = previousConfiguredCredentials != null
+            && previousConfiguredCredentials.getUsername().equals(basicAuthCredentials.getUsername())
+            && AuthUtils.matches(previousConfiguredCredentials.getSalt(), basicAuthCredentials.getPassword(), previousConfiguredCredentials.getPassword());
+
+        if (!unchanged) {
+            SaltedBasicAuthCredentials saltedNewConfiguration = SaltedBasicAuthCredentials.salt(
+                salt,
+                basicAuthCredentials.getUsername(),
+                basicAuthCredentials.getPassword()
+            );
             settingRepository.save(
                 Setting.builder()
                     .key(BASIC_AUTH_SETTINGS_KEY)
                     .value(saltedNewConfiguration)
                     .build()
             );
+
+            // Invalidate the token cache so an old password stops working immediately.
+            lastVerifiedTokenSha256.set(null);
 
             ossAuthEventPublisher.publishEventAsync(
                 OssAuthEvent.builder()
@@ -164,7 +215,9 @@ public class BasicAuthService {
             .map(value -> JacksonMapper.ofJson(false).convertValue(value, SaltedBasicAuthCredentials.class))
             .orElse(null);
         return new ConfiguredBasicAuth(
-            this.basicAuthConfiguration != null ? this.basicAuthConfiguration.realm : null, this.basicAuthConfiguration != null ? this.basicAuthConfiguration.openUrls : null, credentials
+            this.basicAuthConfiguration != null ? this.basicAuthConfiguration.realm : null,
+            this.basicAuthConfiguration != null ? this.basicAuthConfiguration.openUrls : null,
+            credentials
         );
     }
 
@@ -174,6 +227,91 @@ public class BasicAuthService {
         return configuration.credentials() != null &&
             !StringUtils.isBlank(configuration.credentials().getUsername()) &&
             !StringUtils.isBlank(configuration.credentials().getPassword());
+    }
+
+    /**
+     * Returns {@code true} if the request carries valid basic-auth credentials
+     * (either via the {@value BASIC_AUTH_COOKIE_NAME} cookie or an {@code Authorization: Basic} header).
+     *
+     * <p>bcrypt verification is only performed on a cache miss. Subsequent requests
+     * with the same token pay only a SHA-256 hash cost, keeping per-request latency
+     * negligible while the at-rest hash remains bcrypt-strength.
+     */
+    public boolean isAuthenticated(HttpRequest<?> request) {
+        SaltedBasicAuthCredentials credentials = configuration().credentials();
+        if (credentials == null) {
+            return false;
+        }
+        Optional<String> encoded = extractFromCookie(request).or(() -> extractFromAuthorizationHeader(request));
+        if (encoded.isEmpty()) {
+            return false;
+        }
+        try {
+            String token = encoded.get();
+            String tokenSha256 = sha256Hex(token);
+
+            // Fast path: same token as last verified — skip bcrypt entirely.
+            if (tokenSha256.equals(lastVerifiedTokenSha256.get())) {
+                return true;
+            }
+
+            String decoded = new String(Base64.getDecoder().decode(token));
+            int colonIdx = decoded.indexOf(':');
+            if (colonIdx < 0) {
+                return false;
+            }
+            String username = decoded.substring(0, colonIdx);
+            String password = decoded.substring(colonIdx + 1);
+
+            boolean valid = username.equals(credentials.getUsername())
+                && AuthUtils.matches(credentials.getSalt(), password, credentials.getPassword());
+
+            // Wrong passwords always pay the full bcrypt cost; only cache successes.
+            if (valid) {
+                lastVerifiedTokenSha256.set(tokenSha256);
+            }
+            return valid;
+        } catch (IllegalArgumentException e) {
+            return false;
+        }
+    }
+
+    private Optional<String> extractFromCookie(HttpRequest<?> request) {
+        try {
+            Cookie cookie = request.getCookies().get(BASIC_AUTH_COOKIE_NAME);
+            if (cookie != null) {
+                return Optional.of(cookie.getValue());
+            }
+        } catch (Exception ignored) {}
+        // Fallback: parse the raw Cookie header directly (handles Micronaut's SimpleHttpRequest in unit tests).
+        String raw = request.getHeaders().get("Cookie");
+        if (raw == null) {
+            return Optional.empty();
+        }
+        for (String pair : raw.split(";")) {
+            int eq = pair.indexOf('=');
+            if (eq > 0 && BASIC_AUTH_COOKIE_NAME.equals(pair.substring(0, eq).trim())) {
+                return Optional.of(pair.substring(eq + 1).trim());
+            }
+        }
+        return Optional.empty();
+    }
+
+    private Optional<String> extractFromAuthorizationHeader(HttpRequest<?> request) {
+        return request.getHeaders()
+            .getAuthorization()
+            .filter(auth -> auth.toLowerCase().startsWith("basic"))
+            .map(cred -> cred.substring("Basic ".length()));
+    }
+
+    private static String sha256Hex(String input) {
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            byte[] bytes = digest.digest(input.getBytes(StandardCharsets.UTF_8));
+            return HexFormat.of().formatHex(bytes);
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException("SHA-256 not available", e);
+        }
     }
 
     @Getter
@@ -230,7 +368,7 @@ public class BasicAuthService {
             return new SaltedBasicAuthCredentials(
                 salt1,
                 username,
-                AuthUtils.encodePassword(salt1, password)
+                AuthUtils.hashPassword(salt1, password)
             );
         }
     }

--- a/webserver/src/test/java/io/kestra/webserver/services/BasicAuthServiceTest.java
+++ b/webserver/src/test/java/io/kestra/webserver/services/BasicAuthServiceTest.java
@@ -18,6 +18,8 @@ import org.junit.jupiter.params.provider.MethodSource;
 import com.github.tomakehurst.wiremock.client.CountMatchingStrategy;
 import com.github.tomakehurst.wiremock.junit5.WireMockTest;
 
+import java.util.Base64;
+
 import io.kestra.core.exceptions.ValidationErrorException;
 import io.kestra.core.junit.annotations.KestraTest;
 import io.kestra.core.models.Setting;
@@ -32,6 +34,7 @@ import io.kestra.webserver.services.BasicAuthService.BasicAuthConfiguration;
 
 import io.micronaut.context.env.Environment;
 import io.micronaut.context.event.ApplicationEventPublisher;
+import io.micronaut.http.HttpRequest;
 import jakarta.inject.Inject;
 import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
@@ -228,10 +231,164 @@ class BasicAuthServiceTest {
             .satisfies(configuration ->
             {
                 assertThat(configuration.credentials().getUsername()).isEqualTo("username1@example.com");
-                assertThat(configuration.credentials().getPassword()).isNotBlank();
+                assertThat(configuration.credentials().getPassword()).startsWith("$2")
+                    .as("password must be stored as bcrypt");
                 assertThat(configuration.realm()).isEqualTo("NewRealmFromConf");
                 assertThat(configuration.openUrls()).isEqualTo(List.of("NewOpenurl-fromConf"));
             });
+    }
+
+    @Test
+    void shouldMigrateLegacySha512PasswordToBcrypt_atStartup() {
+        // Given: a stored SHA-512 credential (as it would exist before the security fix)
+        var tmpSettingsRepo = new InMemorySettingRepository();
+        String salt = AuthUtils.generateSalt();
+        String sha512Hash = AuthUtils.encodePassword(salt, "Kestra123");
+        tmpSettingsRepo.save(
+            Setting.builder()
+                .key(BASIC_AUTH_SETTINGS_KEY)
+                .value(new BasicAuthService.SaltedBasicAuthCredentials(salt, "admin@kestra.io", sha512Hash))
+                .build()
+        );
+
+        // Service with no YAML config — migration must still run
+        var tmpBasicAuthService = new BasicAuthService(tmpSettingsRepo, null, instanceService, ApplicationEventPublisher.noOp());
+
+        // When
+        tmpBasicAuthService.init();
+
+        // Then: stored hash is now bcrypt
+        var credentials = tmpBasicAuthService.configuration().credentials();
+        assertThat(credentials.getPassword())
+            .as("legacy SHA-512 hash must be migrated to bcrypt at startup")
+            .startsWith("$2y$");
+
+        // And: authentication still works with the original plaintext
+        assertThat(AuthUtils.matches(credentials.getSalt(), "Kestra123", credentials.getPassword()))
+            .as("bcrypt-wrapped hash must still verify against the original password")
+            .isTrue();
+    }
+
+    @Test
+    void shouldStorePasswordAsBcrypt() {
+        // Given
+        var tmpSettingsRepo = new InMemorySettingRepository();
+        var basicAuthService = new BasicAuthService(tmpSettingsRepo, yamlBasicAuthConfiguration, instanceService, ApplicationEventPublisher.noOp());
+
+        // When
+        basicAuthService.init();
+
+        // Then
+        var credentials = basicAuthService.configuration().credentials();
+        assertThat(credentials.getPassword())
+            .as("stored password must be a bcrypt modular-crypt string")
+            .startsWith("$2y$");
+    }
+
+    @Test
+    void shouldNotReSaveCredentials_whenSamePasswordIsUsedOnRestart() {
+        // Given – first startup persists bcrypt credentials
+        var tmpSettingsRepo = new InMemorySettingRepository();
+        var basicAuthService = new BasicAuthService(tmpSettingsRepo, yamlBasicAuthConfiguration, instanceService, ApplicationEventPublisher.noOp());
+        basicAuthService.init();
+        var firstCredentials = basicAuthService.configuration().credentials();
+
+        // When – simulate a second startup with the same YAML config
+        basicAuthService.init();
+        var secondCredentials = basicAuthService.configuration().credentials();
+
+        // Then – no re-save occurred: the stored hash is identical
+        assertThat(secondCredentials).isEqualTo(firstCredentials);
+    }
+
+    @Test
+    void shouldAuthenticate_withCorrectPassword() {
+        // Given
+        var tmpSettingsRepo = new InMemorySettingRepository();
+        var basicAuthService = new BasicAuthService(tmpSettingsRepo, yamlBasicAuthConfiguration, instanceService, ApplicationEventPublisher.noOp());
+        basicAuthService.init();
+
+        // When / Then – correct credentials accepted
+        HttpRequest<?> validRequest = HttpRequest.GET("/test")
+            .basicAuth("admin@kestra.io", "Kestra123");
+        assertThat(basicAuthService.isAuthenticated(validRequest)).isTrue();
+    }
+
+    @Test
+    void shouldNotAuthenticate_withWrongPassword() {
+        // Given
+        var tmpSettingsRepo = new InMemorySettingRepository();
+        var basicAuthService = new BasicAuthService(tmpSettingsRepo, yamlBasicAuthConfiguration, instanceService, ApplicationEventPublisher.noOp());
+        basicAuthService.init();
+
+        // When / Then – wrong password rejected
+        HttpRequest<?> badRequest = HttpRequest.GET("/test")
+            .basicAuth("admin@kestra.io", "WrongPassword1");
+        assertThat(basicAuthService.isAuthenticated(badRequest)).isFalse();
+    }
+
+    @Test
+    void shouldInvalidateCache_whenPasswordChanges() {
+        // Given – initialised with password "Kestra123"
+        var tmpSettingsRepo = new InMemorySettingRepository();
+        var basicAuthService = new BasicAuthService(tmpSettingsRepo, yamlBasicAuthConfiguration, instanceService, ApplicationEventPublisher.noOp());
+        basicAuthService.init();
+
+        HttpRequest<?> oldPasswordRequest = HttpRequest.GET("/test")
+            .basicAuth("admin@kestra.io", "Kestra123");
+
+        // Cache a positive verification
+        assertThat(basicAuthService.isAuthenticated(oldPasswordRequest)).isTrue();
+
+        // When – password is changed
+        basicAuthService.save(new BasicAuthCredentials(null, "admin@kestra.io", "NewPassword1"));
+
+        // Then – old password no longer accepted (cache must have been invalidated)
+        assertThat(basicAuthService.isAuthenticated(oldPasswordRequest)).isFalse();
+
+        // And new password works
+        HttpRequest<?> newPasswordRequest = HttpRequest.GET("/test")
+            .basicAuth("admin@kestra.io", "NewPassword1");
+        assertThat(basicAuthService.isAuthenticated(newPasswordRequest)).isTrue();
+    }
+
+    @Test
+    void shouldRejectAuthentication_withUnmigratedSha512StoredPassword() {
+        // Given – simulate a pre-migration row where the password is stored as plain SHA-512
+        var tmpSettingsRepo = new InMemorySettingRepository();
+        String salt = AuthUtils.generateSalt();
+        String sha512Hash = AuthUtils.encodePassword(salt, "Kestra123");
+        tmpSettingsRepo.save(
+            Setting.builder()
+                .key(BASIC_AUTH_SETTINGS_KEY)
+                .value(new BasicAuthService.SaltedBasicAuthCredentials(salt, "admin@kestra.io", sha512Hash))
+                .build()
+        );
+        // Service without calling init() — migration skipped, SHA-512 hash stays in repo
+        var basicAuthService = new BasicAuthService(tmpSettingsRepo, null, instanceService, ApplicationEventPublisher.noOp());
+
+        // When / Then – isAuthenticated must fail closed for an unmigrated SHA-512 hash
+        HttpRequest<?> request = HttpRequest.GET("/test")
+            .basicAuth("admin@kestra.io", "Kestra123");
+        assertThat(basicAuthService.isAuthenticated(request))
+            .as("pre-migration SHA-512 hash must not grant access (fail closed)")
+            .isFalse();
+    }
+
+    @Test
+    void shouldAuthenticate_usingBase64CookieToken() {
+        // Given
+        var tmpSettingsRepo = new InMemorySettingRepository();
+        var basicAuthService = new BasicAuthService(tmpSettingsRepo, yamlBasicAuthConfiguration, instanceService, ApplicationEventPublisher.noOp());
+        basicAuthService.init();
+
+        // When – token is a Base64-encoded "username:password" (cookie format)
+        String token = Base64.getEncoder().encodeToString("admin@kestra.io:Kestra123".getBytes());
+        HttpRequest<?> cookieRequest = HttpRequest.GET("/test")
+            .cookie(io.micronaut.http.cookie.Cookie.of(BasicAuthService.BASIC_AUTH_COOKIE_NAME, token));
+
+        // Then
+        assertThat(basicAuthService.isAuthenticated(cookieRequest)).isTrue();
     }
 
     @Test
@@ -328,18 +485,21 @@ class BasicAuthServiceTest {
 
     private void assertConfigurationMatchesApplicationYaml(BasicAuthService basicAuthService, SettingRepositoryInterface settingRepositoryInterface) {
         var actualConfiguration = basicAuthService.configuration().credentials();
-        var applicationYamlConfiguration = BasicAuthService.SaltedBasicAuthCredentials.salt(
+
+        // bcrypt is non-deterministic so we cannot compare hash values directly.
+        // Verify the stored hash is a bcrypt string and the YAML password still verifies against it.
+        assertThat(actualConfiguration.getUsername()).isEqualTo(basicAuthService.basicAuthConfiguration.getUsername());
+        assertThat(actualConfiguration.getPassword()).startsWith("$2");
+        assertThat(AuthUtils.matches(
             actualConfiguration.getSalt(),
-            basicAuthService.basicAuthConfiguration.getUsername(),
-            basicAuthService.basicAuthConfiguration.getPassword()
-        );
-        assertThat(actualConfiguration).isEqualTo(applicationYamlConfiguration);
+            basicAuthService.basicAuthConfiguration.getPassword(),
+            actualConfiguration.getPassword()
+        )).as("stored bcrypt hash must verify against the YAML password").isTrue();
 
         Optional<Setting> maybeSetting = settingRepositoryInterface.findByKey(
             BASIC_AUTH_SETTINGS_KEY
         );
         assertThat(maybeSetting.isPresent()).isTrue();
-        assertThat(maybeSetting.get().getValue()).isEqualTo(JacksonMapper.toMap(applicationYamlConfiguration));
     }
 
     private void awaitOssAuthEventApiCall(String email) {


### PR DESCRIPTION
## Summary

Backport of GHSA-m727-pcjm-j28h fix to `releases/v1.3.x`. Original PR: #16684.

Fixes **GHSA-m727-pcjm-j28h** (High, CWE-916): BasicAuth admin passwords were stored as salted SHA-512 digests. SHA-512 is a fast, general-purpose hash with no work factor — an attacker who gains read access to the `settings` table can brute-force the password offline in seconds-to-minutes on GPU hardware.

- Replaces the at-rest hash with **bcrypt cost 12** (`~250ms` per verification), GPU-resistant and computationally prohibitive for offline dictionary attacks.
- Passwords are stored as `bcrypt(sha512(salt|password))`. The SHA-512 pre-hash normalises input to a fixed-length 128-char hex string, making bcrypt's 72-byte input truncation unexploitable via SHA-512 preimage resistance.
- A **Caffeine-style `AtomicReference` cache** keyed by `sha256(token)` avoids running bcrypt on every API request; wrong passwords always pay the full bcrypt cost.
- Cache is invalidated on every `save()` so a changed password stops working immediately.

## 1.3-specific compatibility layer

Unlike `develop` which has a JDBC migration script (`V2_0_10BasicAuthPasswordMigration`), the 1.3 branch has no migration framework. Instead, `BasicAuthService.init()` calls `migrateLegacyPassword()` at startup:
- If the stored password does **not** start with `$2` (i.e. it is a legacy SHA-512 hex string), it is wrapped in bcrypt in-place — no plaintext required, and the auth code needs no dual-format detection branch.

## Changes

- `core/build.gradle` — added `org.bouncycastle:bcprov-jdk18on` (already in platform BOM)
- `core/.../AuthUtils.java` — replaced Guava `Hashing.sha512()` with `MessageDigest`; added `bcryptDigest`, `hashPassword`, `matches`
- `webserver/.../BasicAuthService.java` — in-place SHA-512→bcrypt migration in `init()`; bcrypt-aware `save()` using `matches()` for idempotency; `isAuthenticated()` with token cache
- `webserver/.../AuthenticationFilter.java` — delegates auth to `basicAuthService.isAuthenticated(request)` instead of inline SHA-512 comparison
- `webserver/.../BasicAuthServiceTest.java` — updated for bcrypt; added 8 new tests (migration, storage format, cache invalidation, cookie auth, fail-closed for unmigrated hashes)

## Test plan

- [x] `./gradlew :webserver:test --tests "io.kestra.webserver.services.BasicAuthServiceTest"` — 30/30 passing
- [x] `./gradlew :webserver:test --tests "io.kestra.webserver.filter.AuthenticationFilterTest"` — 13/13 passing
- [x] Verify login still works after upgrade (migration runs at startup, stored hash becomes `$2y$12$…`)
- [x] Verify wrong password returns 401
- [x] Verify repeated correct-password requests are fast (cache hit after first)