### PR TITLE
fix(core): return 204 instead of 409 when webhook conditions are not met

### DIFF
--- a/core/src/main/java/io/kestra/core/services/WebhookService.java
+++ b/core/src/main/java/io/kestra/core/services/WebhookService.java
@@ -27,6 +27,7 @@ import io.kestra.core.utils.IdUtils;
 import io.kestra.core.utils.UriProvider;
 import io.kestra.plugin.core.trigger.AbstractWebhookTrigger;
 import io.kestra.plugin.core.trigger.WebhookContext;
+import io.kestra.plugin.core.trigger.WebhookInputRenderException;
 import io.kestra.plugin.core.trigger.WebhookResponse;
 
 import io.micronaut.context.event.ApplicationEventPublisher;
@@ -101,7 +102,8 @@ public class WebhookService {
      * @param context The webhook context containing request, path, flow, and services
      * @param trigger The webhook trigger
      * @param output The trigger output to attach to the execution
-     * @return The prepared execution, or empty if conditions are not met
+     * @return The prepared execution, or empty if the trigger conditions are not met
+     * @throws WebhookInputRenderException if the trigger inputs cannot be rendered or processed
      */
     public Optional<Execution> newExecution(WebhookContext context, Flow flow, AbstractWebhookTrigger trigger, io.kestra.core.models.tasks.Output output) {
         Execution execution = Execution.builder()
@@ -139,8 +141,10 @@ public class WebhookService {
                 renderedInputs = readExecutionInputs(flow, execution, renderedInputs);
                 execution = execution.withInputs(renderedInputs);
             } catch (Exception e) {
-                log.warn("Unable to render the webhook inputs. Webhook will be ignored", e);
-                return Optional.empty(); // Input rendering failed
+                // Distinct from "conditions not met": a rendering failure is a real error and must
+                // not be silently turned into a 204, so we surface it to the caller.
+                log.warn("Unable to render the webhook inputs", e);
+                throw new WebhookInputRenderException("Unable to render the webhook inputs", e);
             }
         }
 

--- a/core/src/main/java/io/kestra/plugin/core/trigger/Webhook.java
+++ b/core/src/main/java/io/kestra/plugin/core/trigger/Webhook.java
@@ -39,7 +39,7 @@ import reactor.core.publisher.Mono;
 
         Request data is available as `trigger.body`, `trigger.headers`, and `trigger.parameters`. Supports `wait`/`returnOutputs` to block and return Flow outputs, and optional `responseContentType`. Conditions are allowed except `MultipleCondition`.
 
-        Responses: 404 (not found), 200 (triggered), 204 (conditions not met)."""
+        Responses: 404 (not found), 200 (triggered), 204 (conditions not met), 422 (inputs could not be rendered)."""
 )
 @Plugin(
     examples = {
@@ -168,23 +168,30 @@ public class Webhook extends AbstractWebhookTrigger implements TriggerOutput<Web
 
         String body = context.request().getBody() != null ? (String) context.request().getBody().getContent() : null;
 
-        Optional<Execution> maybeExecution = context.webhookService().newExecution(
-            context,
-            context.flow(),
-            this,
-            Webhook.Output.builder()
-                .body(
-                    tryMap(body)
-                        .or(() -> tryArray(body))
-                        .orElse(body)
-                )
-                .headers(context.request().getHeaders() != null ? context.request().getHeaders().map() : null)
-                .parameters(context.webhookService().parseParameters(context))
-                .build()
-        );
+        Optional<Execution> maybeExecution;
+        try {
+            maybeExecution = context.webhookService().newExecution(
+                context,
+                context.flow(),
+                this,
+                Webhook.Output.builder()
+                    .body(
+                        tryMap(body)
+                            .or(() -> tryArray(body))
+                            .orElse(body)
+                    )
+                    .headers(context.request().getHeaders() != null ? context.request().getHeaders().map() : null)
+                    .parameters(context.webhookService().parseParameters(context))
+                    .build()
+            );
+        } catch (WebhookInputRenderException e) {
+            // The inputs could not be rendered: a real error, not a "conditions not met" outcome.
+            return Mono.just(HttpResponse.of(HttpResponse.Status.UNPROCESSABLE_ENTITY));
+        }
 
         if (maybeExecution.isEmpty()) {
-            return Mono.just(HttpResponse.of(HttpResponse.Status.CONFLICT));
+            // Conditions are not met: no execution is created, return 204 as documented.
+            return Mono.just(HttpResponse.of(HttpResponse.Status.NO_CONTENT));
         }
 
         Execution execution = maybeExecution.get();

--- a/core/src/main/java/io/kestra/plugin/core/trigger/WebhookInputRenderException.java
+++ b/core/src/main/java/io/kestra/plugin/core/trigger/WebhookInputRenderException.java
@@ -1,0 +1,21 @@
+package io.kestra.plugin.core.trigger;
+
+import java.io.Serial;
+
+import io.kestra.core.exceptions.KestraRuntimeException;
+
+/**
+ * Thrown when a webhook trigger's inputs cannot be rendered or processed.
+ *
+ * <p>This is intentionally distinct from a webhook whose conditions are not met: the latter is a
+ * normal outcome (no execution is created and the caller receives a {@code 204}), whereas a failure
+ * to render the inputs is a genuine error that must not be silently swallowed into a {@code 204}.
+ */
+public class WebhookInputRenderException extends KestraRuntimeException {
+    @Serial
+    private static final long serialVersionUID = 1L;
+
+    public WebhookInputRenderException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/core/src/test/java/io/kestra/plugin/core/trigger/WebhookTestPlugin.java
+++ b/core/src/test/java/io/kestra/plugin/core/trigger/WebhookTestPlugin.java
@@ -30,18 +30,23 @@ public class WebhookTestPlugin extends AbstractWebhookTrigger implements Trigger
             throw new Exception("Failed as requested");
         }
 
-        Optional<Execution> maybeExecution = context.webhookService().newExecution(
-            context,
-            context.flow(),
-            this,
-            WebhookTestOutput.builder()
-                .body(JacksonMapper.toMap((String) context.request().getBody().getContent()))
-                .encryptedString(EncryptedString.from("super-secret", context.webhookService().runContext(context.flow(), context.trigger())))
-                .build()
-        );
+        Optional<Execution> maybeExecution;
+        try {
+            maybeExecution = context.webhookService().newExecution(
+                context,
+                context.flow(),
+                this,
+                WebhookTestOutput.builder()
+                    .body(JacksonMapper.toMap((String) context.request().getBody().getContent()))
+                    .encryptedString(EncryptedString.from("super-secret", context.webhookService().runContext(context.flow(), context.trigger())))
+                    .build()
+            );
+        } catch (WebhookInputRenderException e) {
+            return Mono.just(HttpResponse.of(HttpResponse.Status.UNPROCESSABLE_ENTITY));
+        }
 
         if (maybeExecution.isEmpty()) {
-            return Mono.just(HttpResponse.of(HttpResponse.Status.CONFLICT));
+            return Mono.just(HttpResponse.of(HttpResponse.Status.NO_CONTENT));
         }
 
         Execution execution = maybeExecution.get();

--- a/webserver/src/test/java/io/kestra/webserver/controllers/api/ExecutionControllerRunnerTest.java
+++ b/webserver/src/test/java/io/kestra/webserver/controllers/api/ExecutionControllerRunnerTest.java
@@ -1127,18 +1127,16 @@ class ExecutionControllerRunnerTest {
         assertThat(execution).isNotNull();
         assertThat(execution.getId()).isNotNull();
 
-        HttpClientResponseException e = assertThrows(
-            HttpClientResponseException.class, () -> client.toBlocking().exchange(
-                HttpRequest
-                    .POST(
-                        "/api/v1/main/executions/webhook/" + TESTS_FLOW_NS + "/webhook-with-condition/webhookKey",
-                        new Hello("webhook")
-                    ),
-                Execution.class
-            )
+        // When the condition is not met, no execution is created and the webhook returns 204 (not 409).
+        var response = client.toBlocking().exchange(
+            HttpRequest
+                .POST(
+                    "/api/v1/main/executions/webhook/" + TESTS_FLOW_NS + "/webhook-with-condition/webhookKey",
+                    new Hello("webhook")
+                )
         );
-        assertThat(e.getResponse().getStatus().getCode()).isEqualTo(HttpStatus.CONFLICT.getCode());
-        assertThat(e.getResponse().body()).isNull();
+        assertThat(response.getStatus().getCode()).isEqualTo(HttpStatus.NO_CONTENT.getCode());
+        assertThat(response.body()).isNull();
     }
 
     @Test


### PR DESCRIPTION
### ✨ Description

The `Webhook` trigger returned `409 CONFLICT` when a trigger condition did not match, but its documented contract is `204 No Content` for "conditions not met".

The cause is that `WebhookService.newExecution(...)` returned `Optional.empty()` for two different reasons — conditions not met **and** input rendering failed — which `Webhook.evaluate` collapsed into a single `409`. This PR keeps `Optional.empty()` for "conditions not met" → `204`, and throws a new `WebhookInputRenderException` on render failure → `422` (previously an undocumented `409`), so the two cases are no longer conflated.

### 🔗 Related Issue

Closes #16601

### 🛠️ Backend Checklist

- [x] Code compiles successfully and passes all checks
- [x] All unit and integration tests pass

### 📝 Additional Notes

- The render-failure path now returns `422` (was an also-incorrect `409`). Happy to use a different code if preferred — it's a one-line change.
- All webhook tests pass locally across `:core` and `:webserver`, including `webhookWithCondition` → `204`.

### 🤖 AI Authors

I used Claude code to understand and fix the issue better but verified everything and ran all tests myself.

🐱 And because the template asks: why did the cat return a `204`? The condition didn't match, so it had *no content* to give.