### PR TITLE
fix(topology): fix dependency graph hidden on load, list selection, and jump on click

### DIFF
--- a/ui/src/components/Tabs.vue
+++ b/ui/src/components/Tabs.vue
@@ -184,6 +184,8 @@
         margin: 0 !important;
         padding: 0;
         flex-grow: 1;
+        min-height: 0;
+        overflow: hidden;
     }
 
     section.no-overflow {

--- a/ui/src/components/dependencies/composables/useDependencies.ts
+++ b/ui/src/components/dependencies/composables/useDependencies.ts
@@ -420,9 +420,19 @@ export function useDependencies(
     // ─── Data loading ─────────────────────────────────────────────────────────
 
     /**
-     * Polls until KsEchart's deferred `canRender` flag has triggered and ECharts
-     * has initialised, then registers a one-shot `finished` handler so positions
-     * are captured only after the force simulation has fully settled.
+     * Polls until ECharts has completed the initial force layout and node positions
+     * are available, then centres the view on the selected node (or fits all nodes
+     * for NAMESPACE graphs where no node is pre-selected).
+     *
+     * Why polling instead of listening for the `finished` event:
+     * `chartNodes` is set synchronously, which schedules a Vue microtask flush.
+     * That flush updates KsGraph's props, VChart calls setOption, and ECharts
+     * queues its own RAF for rendering.  `captureAndFocusWhenReady` is called
+     * right afterwards and queues *our* RAF.  Because both RAFs are in the same
+     * browser frame, ECharts renders (and fires `finished`) before our first poll
+     * fires — so the event is missed and positions are never captured.
+     * Polling `capturePositions()` every frame avoids that race: positions become
+     * non-empty one frame after ECharts renders, and we capture them reliably.
      */
     const captureAndFocusWhenReady = (): void => {
         let attempts = 0
@@ -434,18 +444,17 @@ export function useDependencies(
                 requestAnimationFrame(poll)
                 return
             }
-            // ECharts 'finished' fires once all animations (incl. force layout) complete.
-            const onFinished = () => {
-                chart.off("finished", onFinished)
-                capturePositions()
-                // Defer focusNode — calling setOption inside a 'finished' handler
-                // causes ECharts "setOption during main process" error.
-                if (selectedNodeID.value) {
-                    const id = selectedNodeID.value
-                    requestAnimationFrame(() => focusNode(id))
-                }
+            capturePositions()
+            if (storedPositions.value.size > 0) {
+                const id = selectedNodeID.value
+                requestAnimationFrame(() => {
+                    if (id) focusNode(id)
+                    else fitGraph()
+                })
+                return
             }
-            chart.on("finished", onFinished)
+            if (++attempts >= MAX_ATTEMPTS) return
+            requestAnimationFrame(poll)
         }
         requestAnimationFrame(poll)
     }


### PR DESCRIPTION
## Summary

- **Graph hidden on load**: `section.maximized` in `Tabs.vue` was missing `min-height: 0`, so the flex item expanded to its content height (2844 px) instead of being bounded by the viewport. ECharts rendered across that huge canvas, placing all nodes off-screen.
- **List selection not focusing**: `captureAndFocusWhenReady` registered an ECharts `finished` listener via `requestAnimationFrame`, but ECharts' own RAF (triggered by Vue's microtask DOM flush) always fired first — so the listener was missed, positions were never stored, and `focusNode` / `fitGraph` were never called. Replaced with a poll that calls `capturePositions()` each frame until positions are non-empty.
- **Graph jumps/disappears on click after panning**: With no stored positions, `applyStylesToChart` fell back to `layout: "force"`, restarting the force simulation on every node click.

Fixes https://github.com/kestra-io/kestra-ee/issues/8470.

## Test plan

- [ ] Navigate to a namespace dependencies tab — graph should be visible and centered on load
- [ ] Click a flow in the right-hand list — graph should focus and highlight that node
- [ ] Pan the graph, then click a node in the graph — view should snap to that node without the graph jumping/disappearing
- [ ] Click the fit-to-screen button — graph should fit all nodes in view
- [ ] Verify flow and execution dependency tabs are unaffected