### PR TITLE
fix(namespaces): stop passing unnecessary props to all namespace tab components

### DIFF
--- a/ui/src/components/Tabs.vue
+++ b/ui/src/components/Tabs.vue
@@ -48,6 +48,7 @@
     export interface Tab extends RouterTab {
         locked?: boolean;
         props?: any;
+        blueprintDetail?: boolean;
     }
 
     const props = withDefaults(defineProps<{
@@ -171,8 +172,7 @@
                     ...attrsWithoutClass.value,
                     ...toHandlers(tab["v-on"] ?? {}),
                     namespace: getNamespaceToForward(tab),
-                    embed: tab.props?.embed ?? true,
-                    onGoToDetail: (id: string) => (selectedBlueprintId.value = id),
+                    ...(tab.blueprintDetail ? {onGoToDetail: (id: string) => (selectedBlueprintId.value = id)} : {}),
                 })
             }
         },

--- a/ui/src/components/namespaces/utils/useHelpers.ts
+++ b/ui/src/components/namespaces/utils/useHelpers.ts
@@ -18,6 +18,7 @@ export interface Tab {
     component: Component;
     props?: Record<string, any>;
     count?: number;
+    blueprintDetail?: boolean;
 }
 
 export interface Breadcrumb {
@@ -86,7 +87,8 @@ export function useHelpers() {
                 name: "blueprints",
                 title: t("blueprints.title"),
                 component: BlueprintsBrowser,
-                props: {tab: "community", system: true},
+                props: {tab: "community", system: true, embed: true},
+                blueprintDetail: true,
             },
         ]
             : []),


### PR DESCRIPTION
<img width="580" height="939" alt="image" src="https://github.com/user-attachments/assets/d82d50e7-6da0-446b-b096-7abc943fbeaa" />

## Summary

- `Tabs.vue` was unconditionally injecting `embed` (defaulting to `true`) and `onGoToDetail` into every tab component rendered by `TabBody`. Multi-root (fragment) components that don't declare these props/emits — such as `Flows.vue` — triggered Vue's _"Extraneous non-props attributes / non-emits event listeners"_ console warnings when navigating to the Flows tab of a namespace.
- Removed the `embed: tab.props?.embed ?? true` override; `embed` now flows through `...tab.props` only for tabs that explicitly set it.
- Introduced a `blueprintDetail?: boolean` flag on the `Tab` interface; `onGoToDetail` is now only passed to tabs that opt in with `blueprintDetail: true`.
- The system-namespace `BlueprintsBrowser` tab is marked `blueprintDetail: true` and its `embed: true` is now explicit in `props` to preserve the previous behaviour.

## Test plan

- [ ] Navigate to a namespace → Flows tab: no Vue console warnings about `embed` or `goToDetail`
- [ ] Navigate to the `system` namespace → Blueprints tab: clicking a blueprint still opens the inline `BlueprintDetail` view
- [ ] Navigate to a namespace → Executions tab: `embed: false` still passed correctly (no regression)
- [ ] `npm run check:types` passes in both OSS and EE