### PR TITLE
fix(core): fail fast on pebble function errors

### DIFF
--- a/core/src/main/java/io/kestra/core/runners/VariableRenderer.java
+++ b/core/src/main/java/io/kestra/core/runners/VariableRenderer.java
@@ -115,7 +115,15 @@ public class VariableRenderer {
             compiledTemplate.evaluate(writer, variables);
             result = writer.output();
         } catch (IOException | PebbleException e) {
-            String alternativeRender = this.alternativeRender(e, (String) inline, variables);
+            // The Handlebars fallback only exists to bridge legacy Handlebars-vs-Pebble syntax
+            // differences. If the failure originates from a function that hit a real error - e.g.
+            // the secret() function failing because the secret backend (Vault) is unreachable -
+            // re-rendering with Handlebars cannot help and only masks the real cause, surfacing a
+            // cryptic "found: '...', expected: 'id'" syntax error instead. Skip the fallback in that
+            // case and let the error propagate (properPebbleException keeps the real cause in the chain).
+            boolean hasNonTemplateCause = findNonTemplateCause(e) != null;
+
+            String alternativeRender = hasNonTemplateCause ? null : this.alternativeRender(e, (String) inline, variables);
             if (alternativeRender == null) {
                 if (e instanceof PebbleException pebbleException) {
                     throw properPebbleException(pebbleException);
@@ -143,6 +151,25 @@ public class VariableRenderer {
      * @return          The rendered string.
      */
     protected String alternativeRender(Exception e, String inline, Map<String, Object> variables) throws IllegalVariableEvaluationException {
+        return null;
+    }
+
+    /**
+     * Walks the cause chain looking for a failure that did not originate from template parsing/evaluation
+     * itself - i.e. a function or filter (e.g. {@code secret()}) that executed and failed for a real
+     * reason, surfaced as a non-Pebble wrapped cause. Such failures must be propagated rather than masked
+     * by the Handlebars fallback. Pure parse/attribute errors (legacy Handlebars syntax) have no wrapped
+     * non-Pebble cause, so the fallback is still attempted for those.
+     *
+     * @param e the exception thrown by the default Pebble renderer.
+     * @return  the underlying non-template cause if any, otherwise {@code null}.
+     */
+    private static Throwable findNonTemplateCause(Throwable e) {
+        for (Throwable cause = e.getCause(); cause != null; cause = cause.getCause()) {
+            if (!(cause instanceof PebbleException)) {
+                return cause;
+            }
+        }
         return null;
     }
 

--- a/core/src/main/java/io/kestra/core/runners/VariableRenderer.java
+++ b/core/src/main/java/io/kestra/core/runners/VariableRenderer.java
@@ -115,12 +115,9 @@ public class VariableRenderer {
             compiledTemplate.evaluate(writer, variables);
             result = writer.output();
         } catch (IOException | PebbleException e) {
-            // The Handlebars fallback only exists to bridge legacy Handlebars-vs-Pebble syntax
-            // differences. If the failure originates from a function that hit a real error - e.g.
-            // the secret() function failing because the secret backend (Vault) is unreachable -
-            // re-rendering with Handlebars cannot help and only masks the real cause, surfacing a
-            // cryptic "found: '...', expected: 'id'" syntax error instead. Skip the fallback in that
-            // case and let the error propagate (properPebbleException keeps the real cause in the chain).
+            // The Handlebars fallback only bridges legacy syntax differences; it can't fix a real
+            // runtime error (e.g. secret() failing because Vault is unreachable) and would only mask
+            // it behind a cryptic syntax error. Skip it in that case and let the real cause propagate.
             boolean hasNonTemplateCause = findNonTemplateCause(e) != null;
 
             String alternativeRender = hasNonTemplateCause ? null : this.alternativeRender(e, (String) inline, variables);

--- a/core/src/test/java/io/kestra/core/runners/VariableRendererTest.java
+++ b/core/src/test/java/io/kestra/core/runners/VariableRendererTest.java
@@ -3,9 +3,14 @@ package io.kestra.core.runners;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.kestra.core.exceptions.IllegalVariableEvaluationException;
+import io.kestra.core.secret.SecretException;
+import io.kestra.core.secret.SecretNotFoundException;
+import io.kestra.core.secret.SecretService;
 import io.micronaut.context.ApplicationContext;
 import io.kestra.core.junit.annotations.KestraTest;
+import io.micronaut.test.annotation.MockBean;
 import jakarta.inject.Inject;
+import java.io.IOException;
 import java.util.LinkedHashMap;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -29,6 +34,23 @@ class VariableRendererTest {
         TestVariableRenderer renderer = new TestVariableRenderer(applicationContext, variableConfiguration);
         String render = renderer.render("{{ dummy }}", Map.of());
         Assertions.assertEquals("result", render);
+    }
+
+    @Test
+    void shouldFailFastWhenSecretFunctionFailsInsteadOfFallingBackToHandlebars() {
+        // When
+        HandlebarsFallbackRenderer renderer = new HandlebarsFallbackRenderer(applicationContext, variableConfiguration);
+
+        IllegalVariableEvaluationException exception = Assertions.assertThrows(
+            IllegalVariableEvaluationException.class,
+            () -> renderer.render("{{ secret('hr-squad') }}", Map.of("flow", Map.of("namespace", "io.kestra.unittest")))
+        );
+
+        // Then: The real infrastructure failure (Vault 503) must be propagated in the cause chain...
+        assertThat(exception).hasRootCauseInstanceOf(SecretException.class);
+        assertThat(exception).rootCause().hasMessageContaining("503");
+        // ...and the Handlebars fallback must NOT have been invoked to mask it.
+        assertThat(renderer.handlebarsFallbackInvoked).isFalse();
     }
 
     @Test
@@ -99,6 +121,40 @@ class VariableRendererTest {
         @Override
         protected String alternativeRender(Exception e, String inline, Map<String, Object> variables) throws IllegalVariableEvaluationException {
             return "result";
+        }
+    }
+
+    /**
+     * Simulates the EE templates renderer ({@code io.kestra.plugin.templates.runners.VariableRenderer}):
+     * its {@code alternativeRender} re-renders with Handlebars, which chokes on native Pebble syntax
+     * and throws the cryptic {@code found: '...', expected: 'id'} error.
+     */
+    public static class HandlebarsFallbackRenderer extends VariableRenderer {
+
+        boolean handlebarsFallbackInvoked = false;
+
+        public HandlebarsFallbackRenderer(ApplicationContext applicationContext,
+                                          VariableConfiguration variableConfiguration) {
+            super(applicationContext, variableConfiguration);
+        }
+
+        @Override
+        protected String alternativeRender(Exception e, String inline, Map<String, Object> variables) throws IllegalVariableEvaluationException {
+            this.handlebarsFallbackInvoked = true;
+            throw new IllegalVariableEvaluationException(
+                "inline@4a54038:1:10: found: ''hr-squad'', expected: 'id'\n" + inline
+            );
+        }
+    }
+
+    /**
+     * Simulates a Vault-backed secret manager that is unreachable (HTTP 502/503) while under heavy load.
+     */
+    @MockBean(SecretService.class)
+    public static class VaultUnreachableSecretService extends SecretService {
+        @Override
+        public String findSecret(String tenantId, String namespace, String key) throws SecretNotFoundException, IOException {
+            throw new SecretException("Vault is unreachable: HTTP 503 Service Unavailable");
         }
     }
 


### PR DESCRIPTION
## ✨ Description

When a Pebble function such as `secret()` failed because the underlying secret backend (for example Vault) was unavailable or returned a server error, the original exception was masked instead of being propagated.

The failure path looked like this:

1. The secret backend throws a `SecretException`.
2. `SecretFunction` wraps it in a `PebbleException`, preserving the original cause.
3. `VariableRenderer.renderOnce(...)` catches every `PebbleException` and unconditionally falls back to the legacy Handlebars renderer (`alternativeRender`).

That fallback exists only to support legacy Handlebars syntax. Since the template is valid Pebble, Handlebars attempts to parse expressions such as `secret(...)` and fails with a misleading parse error like:

```text
found: '...', expected: 'id'
```

As a result, the real infrastructure error (for example a Vault connectivity failure or HTTP 5xx response) was lost.

This PR changes `renderOnce(...)` to inspect the exception cause before falling back to Handlebars. If the `PebbleException` wraps a non-Pebble exception, it indicates that template parsing succeeded and a function or filter failed during execution. In that case, the Handlebars fallback is skipped and the exception is propagated through `properPebbleException(...)`, preserving both the original cause and the template location.

Pure Pebble parsing and attribute-resolution errors (which have no wrapped runtime cause) continue to fall back to Handlebars as before, preserving compatibility with legacy templates.

This also aligns the behavior with `develop`, where the legacy Handlebars fallback has been removed entirely, so runtime exceptions are already propagated directly.
