### PR TITLE
feat(core): autocomplete subflow() namespace and id arguments

### DIFF
--- a/ui/src/override/services/flowAutoCompletionProvider.ts
+++ b/ui/src/override/services/flowAutoCompletionProvider.ts
@@ -344,6 +344,30 @@ export class FlowAutoCompletion extends YamlAutoCompletion {
             case "tasksWithState": {
                 return State.arrayAllStates().map(({name}) => QUOTE + name + QUOTE)
             }
+            case "subflow": {
+                // subflow(namespace='...', id='...'): the arg under the cursor is the last one parsed
+                const argNames = Object.keys(args)
+                const currentArg = argNames[argNames.length - 1]
+                if (currentArg === "namespace") {
+                    const availableNamespaces = this.namespacesStore.autocomplete
+                        ?? await this.namespacesStore.loadAutocomplete()
+                    return availableNamespaces.map((namespace: string) => QUOTE + namespace + QUOTE)
+                }
+                if (currentArg === "id") {
+                    const namespace = this.extractArgValue(namespaceArg)
+                    if (namespace === undefined) {
+                        return Promise.resolve([])
+                    }
+                    let flowIds: string[] = (await this.flowStore.flowsByNamespace(namespace))
+                        .map((flow: {id: string}) => flow.id)
+                    // avoid suggesting the flow itself: subflow() on its own id recurses (depth-capped)
+                    if (parsed?.id !== undefined && parsed?.namespace === namespace) {
+                        flowIds = flowIds.filter(flowId => flowId !== parsed?.id)
+                    }
+                    return flowIds.map(flowId => QUOTE + flowId + QUOTE)
+                }
+                break
+            }
         }
         return Promise.resolve([])
     }

--- a/ui/tests/unit/services/flowAutoCompletionProvider.spec.ts
+++ b/ui/tests/unit/services/flowAutoCompletionProvider.spec.ts
@@ -272,4 +272,13 @@ tasks:
         expect(await provider.functionAutoCompletion(parsed, "kv", {})).toEqual(["'myFirstKv'", "'mySecondKv'"])
         expect(await provider.functionAutoCompletion(parsed, "kv", {namespace: "'another.namespace'"})).toEqual(["'anotherNsFirstKv'", "'anotherNsSecondKv'"])
     })
+
+    it("subflow function autocompletions suggest namespaces and flow ids", async () => {
+        // editing the `namespace` arg → all namespaces, quoted (Monaco does the prefix filtering)
+        expect(await provider.functionAutoCompletion(parsed, "subflow", {namespace: "'m"})).toEqual(["'my.namespace'", "'another.namespace'"])
+        // editing the `id` arg → flow ids of the chosen namespace, quoted
+        expect(await provider.functionAutoCompletion(parsed, "subflow", {namespace: "'another.namespace'", id: "'fl"})).toEqual(["'flow-other-namespace'", "'another-flow-other-namespace'"])
+        // editing the `id` arg in the flow's own namespace excludes the flow itself (avoids self-recursion)
+        expect(await provider.functionAutoCompletion(parsed, "subflow", {namespace: "'my.namespace'", id: "'m"})).toEqual([])
+    })
 })


### PR DESCRIPTION
Follow-up to #16653 (subflow() Pebble function): adds value autocompletion for the namespace and id arguments.