### PR TITLE
feat(worker): add WORKER_DISCONNECT_REQUESTED event and dispatcher eviction

### DIFF
--- a/core/src/main/java/io/kestra/core/server/ClusterEvent.java
+++ b/core/src/main/java/io/kestra/core/server/ClusterEvent.java
@@ -23,6 +23,7 @@ public record ClusterEvent(String uid, EventType eventType, LocalDateTime eventD
         PLUGINS_SYNC_REQUESTED,
         KILL_SWITCH_SYNC_REQUESTED,
         MCP_SERVER_CHANGED,
-        WORKER_GROUP_SYNC_REQUESTED
+        WORKER_GROUP_SYNC_REQUESTED,
+        WORKER_DISCONNECT_REQUESTED
     }
 }

--- a/worker-controller/src/main/java/io/kestra/controller/grpc/services/WorkerJobDispatcher.java
+++ b/worker-controller/src/main/java/io/kestra/controller/grpc/services/WorkerJobDispatcher.java
@@ -286,7 +286,8 @@ public class WorkerJobDispatcher {
         ClusterEvent.EventType.MAINTENANCE_ENTER,
         ClusterEvent.EventType.MAINTENANCE_EXIT,
         ClusterEvent.EventType.KILL_SWITCH_SYNC_REQUESTED,
-        ClusterEvent.EventType.WORKER_GROUP_SYNC_REQUESTED
+        ClusterEvent.EventType.WORKER_GROUP_SYNC_REQUESTED,
+        ClusterEvent.EventType.WORKER_DISCONNECT_REQUESTED
     );
 
     /**
@@ -296,6 +297,10 @@ public class WorkerJobDispatcher {
     private void onClusterEvent(ClusterEvent event) {
         if (event.eventType() == ClusterEvent.EventType.WORKER_GROUP_SYNC_REQUESTED) {
             onWorkerGroupSync(event.message());
+            return;
+        }
+        if (event.eventType() == ClusterEvent.EventType.WORKER_DISCONNECT_REQUESTED) {
+            evictWorker(event.message());
             return;
         }
         if (EXCLUDED_EVENT_TYPES.contains(event.eventType())) {
@@ -350,6 +355,26 @@ public class WorkerJobDispatcher {
                 );
             }
         }
+    }
+
+    /**
+     * Forcibly drops a single worker by id: unregisters it from all indices and closes its
+     * stream. Used to act on a {@link ClusterEvent.EventType#WORKER_DISCONNECT_REQUESTED} event
+     * The worker must reconnect and re-authenticate, which fails closed once the token is gone.
+     * <p>
+     * No-op if the worker is not connected to this controller.
+     *
+     * @param workerId the worker to drop
+     */
+    public void evictWorker(String workerId) {
+        WorkerStreamContext<WorkerJobResponse> context = activeStreams.get(workerId);
+        if (context == null) {
+            log.debug("Worker '{}' is not connected to this controller, nothing to evict", workerId);
+            return;
+        }
+        log.info("Evicting worker '{}': its registration token was revoked or removed", workerId);
+        unregisterWorker(context);
+        context.complete();
     }
 
     /**

--- a/worker-controller/src/test/java/io/kestra/controller/grpc/services/WorkerJobDispatcherTest.java
+++ b/worker-controller/src/test/java/io/kestra/controller/grpc/services/WorkerJobDispatcherTest.java
@@ -1434,6 +1434,44 @@ class WorkerJobDispatcherTest {
         assertThat(dispatcher.getActiveWorkerCount()).isEqualTo(1);
     }
 
+    @Test
+    void shouldEvictWorkerOnWorkerDisconnectClusterEvent() {
+        // Given - two workers in the same group
+        WorkerStreamContext<WorkerJobResponse> revoked = createWorkerContext("worker-revoked", WORKER_GROUP_A, WORKER_GROUP_A, 10);
+        WorkerStreamContext<WorkerJobResponse> kept = createWorkerContext("worker-kept", WORKER_GROUP_A, WORKER_GROUP_A, 10);
+        dispatcher.registerWorker(revoked);
+        dispatcher.registerWorker(kept);
+
+        // When — a disconnect event targets one worker (as EE emits on token revoke/delete)
+        ClusterEvent disconnectEvent = new ClusterEvent(
+            ClusterEvent.EventType.WORKER_DISCONNECT_REQUESTED,
+            LocalDateTime.now(),
+            "worker-revoked"
+        );
+        clusterEventConsumer.accept(Either.left(disconnectEvent));
+
+        // Then — the targeted worker is unregistered and its stream closed; the other stays
+        assertThat(dispatcher.getWorkerIdsByWorkerGroup(WORKER_GROUP_A)).containsExactly("worker-kept");
+        verify(revoked.getResponseObserver()).onCompleted();
+        verify(kept.getResponseObserver(), never()).onCompleted();
+    }
+
+    @Test
+    void shouldIgnoreWorkerDisconnectEventForUnknownWorker() {
+        // Given
+        WorkerStreamContext<WorkerJobResponse> context = createWorkerContext("worker-1", WORKER_GROUP_A, WORKER_GROUP_A, 10);
+        dispatcher.registerWorker(context);
+
+        // When — a disconnect event targets a worker not connected here
+        clusterEventConsumer.accept(Either.left(new ClusterEvent(
+            ClusterEvent.EventType.WORKER_DISCONNECT_REQUESTED, LocalDateTime.now(), "unknown-worker"
+        )));
+
+        // Then — no effect on connected workers
+        assertThat(dispatcher.getActiveWorkerCount()).isEqualTo(1);
+        verify(context.getResponseObserver(), never()).onCompleted();
+    }
+
     // shouldPreservePermitsDuringReRegistrationWithPercentageChange moved to EE
     // (worker-controller-ee/WorkerJobDispatcherReservationTest).
 


### PR DESCRIPTION
Add a WORKER_DISCONNECT_REQUESTED cluster event and WorkerJobDispatcher#evictWorker(workerId), which unregisters a worker and closes its stream. The dispatcher handles the event by evicting the named worker (no-op if it is not connected here); the worker must reconnect and re-authenticate.