### PR TITLE
fix(executions): adjust left padding for log levels in Gantt view

### DIFF
--- a/ui/src/components/logs/TaskRunDetails.vue
+++ b/ui/src/components/logs/TaskRunDetails.vue
@@ -1194,7 +1194,6 @@
 
       .line {
         border-top: none;
-        padding-inline: 0;
       }
     }
 


### PR DESCRIPTION
### ✨ Description

Fixes a visual issue in the Gantt view where execution logs lacked left padding, causing the log levels to appear cramped against the edge of the container.

### 🔗 Related Issue

Closes https://github.com/kestra-io/kestra/issues/16866

### 🎨 Frontend Checklist

- [X] Code builds without errors (`npm run build`)
- [ ] All existing E2E tests pass (`npm run test:e2e`)
- [X] Screenshots or video recordings attached showing the `UI` changes

### 📝 Additional Notes

Before:
<img width="1576" height="677" alt="image" src="https://github.com/user-attachments/assets/677588f0-c775-4eb2-942f-ccfa34fa314c" />

After:
<img width="1576" height="677" alt="image" src="https://github.com/user-attachments/assets/aa92dd07-ba0f-44bf-a38e-18de4d9a379e" />


