### PR TITLE
fix(cli): reconstruct namespace file version history during metadata migration

### DIFF
--- a/cli/src/main/java/io/kestra/cli/commands/migrations/metadata/MetadataMigrationService.java
+++ b/cli/src/main/java/io/kestra/cli/commands/migrations/metadata/MetadataMigrationService.java
@@ -7,6 +7,7 @@ import java.nio.file.NoSuchFileException;
 import java.time.Instant;
 import java.util.*;
 import java.util.function.Function;
+import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -34,7 +35,9 @@ import static io.kestra.core.utils.Rethrow.throwFunction;
 
 @Singleton
 public class MetadataMigrationService {
-    private static final Pattern REVISION_FILE_PATTERN = Pattern.compile(".*\\.v\\d+$");
+    // Captures the logical path (group 1) and the revision number (group 2) of a stored namespace
+    // file. Version 1 is stored under the bare path, later versions under a ".vN" suffix.
+    private static final Pattern REVISION_FILE_PATTERN = Pattern.compile("(.*)\\.v(\\d+)$");
 
     protected FlowRepositoryInterface flowRepository;
     protected TenantService tenantService;
@@ -106,24 +109,52 @@ public class MetadataMigrationService {
     }
 
     public void nsFilesMigration(boolean verbose, String tenantFilter) throws IOException {
-        filterTenants(this.namespacesPerTenant(), tenantFilter).entrySet().stream()
-            .flatMap(namespacesForTenant -> namespacesForTenant.getValue().stream().map(namespace -> Map.entry(namespacesForTenant.getKey(), namespace)))
-            .flatMap(throwFunction(namespaceForTenant ->
-            {
-                List<PathAndAttributes> list = listAllFromStorage(storageInterface, StorageContext::namespaceFilePrefix, namespaceForTenant.getKey(), namespaceForTenant.getValue());
-                return list.stream()
-                    .filter(pathAndAttributes -> !REVISION_FILE_PATTERN.matcher(pathAndAttributes.path()).matches())
-                    .map(pathAndAttributes -> NamespaceFileMetadata.of(namespaceForTenant.getKey(), namespaceForTenant.getValue(), pathAndAttributes.path(), pathAndAttributes.attributes()));
-            }))
-            .forEach(throwConsumer(nsFileMetadata ->
-            {
-                if (namespaceFileMetadataRepository.findByPath(nsFileMetadata.getTenantId(), nsFileMetadata.getNamespace(), nsFileMetadata.getPath()).isEmpty()) {
-                    namespaceFileMetadataRepository.save(nsFileMetadata);
-                    if (verbose) {
-                        System.out.println("Migrated namespace file metadata: " + nsFileMetadata.getNamespace() + " - " + nsFileMetadata.getPath());
-                    }
+        for (Map.Entry<String, List<String>> tenantNamespaces : filterTenants(this.namespacesPerTenant(), tenantFilter).entrySet()) {
+            String tenant = tenantNamespaces.getKey();
+            for (String namespace : tenantNamespaces.getValue()) {
+                List<PathAndAttributes> list = listAllFromStorage(storageInterface, StorageContext::namespaceFilePrefix, tenant, namespace);
+
+                // Group every stored object (the bare file plus its ".vN" revisions) by logical path
+                // so the full version history is reconstructed instead of keeping only the bare file.
+                Map<String, List<PathAndAttributes>> revisionsByPath = list.stream()
+                    .collect(Collectors.groupingBy(pathAndAttributes -> logicalPath(pathAndAttributes.path())));
+
+                for (Map.Entry<String, List<PathAndAttributes>> revisions : revisionsByPath.entrySet()) {
+                    String path = revisions.getKey();
+
+                    // Highest version already indexed (0 if the path was never migrated). A previously
+                    // broken run only indexed the bare file as v1, so the higher ".vN" revisions still
+                    // need backfilling; replaying only revisions above this threshold keeps the
+                    // migration idempotent while repairing partially-migrated paths.
+                    int alreadyMigratedVersions = namespaceFileMetadataRepository.findByPath(tenant, namespace, path)
+                        .map(NamespaceFileMetadata::getVersion)
+                        .orElse(0);
+
+                    // Replay the missing revisions from oldest to newest: save() increments the version
+                    // and flags the latest one as "last", mirroring how files are normally versioned.
+                    revisions.getValue().stream()
+                        .sorted(Comparator.comparingInt(pathAndAttributes -> revisionNumber(pathAndAttributes.path())))
+                        .filter(pathAndAttributes -> revisionNumber(pathAndAttributes.path()) > alreadyMigratedVersions)
+                        .forEach(pathAndAttributes ->
+                        {
+                            namespaceFileMetadataRepository.save(NamespaceFileMetadata.of(tenant, namespace, path, pathAndAttributes.attributes()));
+                            if (verbose) {
+                                System.out.println("Migrated namespace file metadata: " + namespace + " - " + path + " (v" + revisionNumber(pathAndAttributes.path()) + ")");
+                            }
+                        });
                 }
-            }));
+            }
+        }
+    }
+
+    private static String logicalPath(String path) {
+        Matcher matcher = REVISION_FILE_PATTERN.matcher(path);
+        return matcher.matches() ? matcher.group(1) : path;
+    }
+
+    private static int revisionNumber(String path) {
+        Matcher matcher = REVISION_FILE_PATTERN.matcher(path);
+        return matcher.matches() ? Integer.parseInt(matcher.group(2)) : 1;
     }
 
     public void secretMigration(String tenantFilter) throws Exception {

--- a/cli/src/main/java/io/kestra/cli/commands/migrations/metadata/MetadataMigrationService.java
+++ b/cli/src/main/java/io/kestra/cli/commands/migrations/metadata/MetadataMigrationService.java
@@ -29,14 +29,18 @@ import io.kestra.core.storages.kv.KVEntry;
 import io.kestra.core.tenant.TenantService;
 
 import jakarta.inject.Singleton;
+import lombok.extern.slf4j.Slf4j;
 
 import static io.kestra.core.utils.Rethrow.throwConsumer;
 import static io.kestra.core.utils.Rethrow.throwFunction;
 
+@Slf4j
 @Singleton
 public class MetadataMigrationService {
     // Captures the logical path (group 1) and the revision number (group 2) of a stored namespace
-    // file. Version 1 is stored under the bare path, later versions under a ".vN" suffix.
+    // file. Version 1 is stored under the bare path (no suffix); later versions use a ".vN" suffix
+    // where N >= 2. A ".v1" suffix is therefore invalid: it would collide with the bare path and
+    // corrupt the version chain if both existed simultaneously.
     private static final Pattern REVISION_FILE_PATTERN = Pattern.compile("(.*)\\.v(\\d+)$");
 
     protected FlowRepositoryInterface flowRepository;
@@ -109,37 +113,53 @@ public class MetadataMigrationService {
     }
 
     public void nsFilesMigration(boolean verbose, String tenantFilter) throws IOException {
-        for (Map.Entry<String, List<String>> tenantNamespaces : filterTenants(this.namespacesPerTenant(), tenantFilter).entrySet()) {
-            String tenant = tenantNamespaces.getKey();
-            for (String namespace : tenantNamespaces.getValue()) {
-                List<PathAndAttributes> list = listAllFromStorage(storageInterface, StorageContext::namespaceFilePrefix, tenant, namespace);
+        for (var tenantNamespaces : filterTenants(this.namespacesPerTenant(), tenantFilter).entrySet()) {
+            var tenant = tenantNamespaces.getKey();
+            for (var namespace : tenantNamespaces.getValue()) {
+                var list = listAllFromStorage(storageInterface, StorageContext::namespaceFilePrefix, tenant, namespace);
 
                 // Group every stored object (the bare file plus its ".vN" revisions) by logical path
                 // so the full version history is reconstructed instead of keeping only the bare file.
-                Map<String, List<PathAndAttributes>> revisionsByPath = list.stream()
+                var revisionsByPath = list.stream()
                     .collect(Collectors.groupingBy(pathAndAttributes -> logicalPath(pathAndAttributes.path())));
 
-                for (Map.Entry<String, List<PathAndAttributes>> revisions : revisionsByPath.entrySet()) {
-                    String path = revisions.getKey();
+                for (var revisions : revisionsByPath.entrySet()) {
+                    var path = revisions.getKey();
 
                     // Highest version already indexed (0 if the path was never migrated). A previously
                     // broken run only indexed the bare file as v1, so the higher ".vN" revisions still
                     // need backfilling; replaying only revisions above this threshold keeps the
                     // migration idempotent while repairing partially-migrated paths.
-                    int alreadyMigratedVersions = namespaceFileMetadataRepository.findByPath(tenant, namespace, path)
+                    var alreadyMigratedVersions = namespaceFileMetadataRepository.findByPath(tenant, namespace, path)
                         .map(NamespaceFileMetadata::getVersion)
                         .orElse(0);
 
+                    // Compute revision numbers once per element so the sort key, filter, and log
+                    // all share the same value without repeated Matcher allocations.
+                    var withRevision = revisions.getValue().stream()
+                        .map(paa -> Map.entry(paa, revisionNumber(tenant, namespace, paa.path())))
+                        .toList();
+
                     // Replay the missing revisions from oldest to newest: save() increments the version
                     // and flags the latest one as "last", mirroring how files are normally versioned.
-                    revisions.getValue().stream()
-                        .sorted(Comparator.comparingInt(pathAndAttributes -> revisionNumber(pathAndAttributes.path())))
-                        .filter(pathAndAttributes -> revisionNumber(pathAndAttributes.path()) > alreadyMigratedVersions)
-                        .forEach(pathAndAttributes ->
+                    withRevision.stream()
+                        .sorted(Comparator.comparingInt(Map.Entry::getValue))
+                        .filter(entry -> entry.getValue() > alreadyMigratedVersions)
+                        .forEach(entry ->
                         {
-                            namespaceFileMetadataRepository.save(NamespaceFileMetadata.of(tenant, namespace, path, pathAndAttributes.attributes()));
-                            if (verbose) {
-                                System.out.println("Migrated namespace file metadata: " + namespace + " - " + path + " (v" + revisionNumber(pathAndAttributes.path()) + ")");
+                            try {
+                                var saved = namespaceFileMetadataRepository.save(
+                                    NamespaceFileMetadata.of(tenant, namespace, path, entry.getKey().attributes())
+                                );
+                                if (verbose) {
+                                    System.out.println("Migrated namespace file metadata: " + namespace + " - " + path + " (v" + saved.getVersion() + ")");
+                                }
+                            } catch (Exception e) {
+                                log.error(
+                                    "Failed to migrate namespace file metadata for tenant='{}' namespace='{}' path='{}' storageRevision={} — migration aborted at this entry",
+                                    tenant, namespace, path, entry.getValue(), e
+                                );
+                                throw e instanceof RuntimeException re ? re : new RuntimeException(e);
                             }
                         });
                 }
@@ -152,9 +172,24 @@ public class MetadataMigrationService {
         return matcher.matches() ? matcher.group(1) : path;
     }
 
-    private static int revisionNumber(String path) {
-        Matcher matcher = REVISION_FILE_PATTERN.matcher(path);
-        return matcher.matches() ? Integer.parseInt(matcher.group(2)) : 1;
+    // Returns the storage revision for a given object path. Bare paths (no ".vN" suffix) are
+    // revision 1. A ".v1" suffix is invalid: it would collide with the bare path and produce two
+    // objects with revision 1, silently overwriting the first on save(). Fail loudly to prevent
+    // silent corruption; the operator must inspect and remove the offending object manually.
+    private static int revisionNumber(String tenant, String namespace, String path) {
+        var matcher = REVISION_FILE_PATTERN.matcher(path);
+        if (!matcher.matches()) {
+            return 1;
+        }
+        var revision = Integer.parseInt(matcher.group(2));
+        if (revision == 1) {
+            throw new IllegalStateException(
+                "Storage object with '.v1' suffix found — this collides with the bare path and would corrupt the version chain. " +
+                "Tenant='" + tenant + "' namespace='" + namespace + "' path='" + path + "'. " +
+                "Remove or rename the offending object and re-run the migration."
+            );
+        }
+        return revision;
     }
 
     public void secretMigration(String tenantFilter) throws Exception {

--- a/cli/src/test/java/io/kestra/cli/commands/migrations/metadata/MetadataMigrationServiceTest.java
+++ b/cli/src/test/java/io/kestra/cli/commands/migrations/metadata/MetadataMigrationServiceTest.java
@@ -12,9 +12,11 @@ import org.mockito.Mockito;
 
 import io.kestra.core.contexts.KestraConfig;
 import io.kestra.core.models.namespaces.NamespaceInterface;
+import io.kestra.core.models.namespaces.files.NamespaceFileMetadata;
 import io.kestra.core.repositories.FlowRepositoryInterface;
 import io.kestra.core.repositories.NamespaceFileMetadataRepositoryInterface;
 import io.kestra.core.storages.FileAttributes;
+import io.kestra.core.storages.StorageContext;
 import io.kestra.core.storages.StorageInterface;
 import io.kestra.core.tenant.TenantService;
 import io.kestra.core.utils.TestsUtils;
@@ -81,7 +83,7 @@ public class MetadataMigrationServiceTest<T extends MetadataMigrationService> {
     }
 
     @Test
-    void shouldNotMigrateRevisionFiles() throws Exception {
+    void shouldMigrateRevisionsAsVersionsOfTheSamePath() throws Exception {
         NamespaceFileMetadataRepositoryInterface repo = Mockito.mock(NamespaceFileMetadataRepositoryInterface.class);
         StorageInterface storage = Mockito.mock(StorageInterface.class);
 
@@ -106,19 +108,17 @@ public class MetadataMigrationServiceTest<T extends MetadataMigrationService> {
             }
         };
 
-        URI normalUri = URI.create("kestra://namespace/test.namespace/file.yaml");
-        URI revisionUri = URI.create("kestra://namespace/test.namespace/file.yaml.v1");
+        String prefix = StorageContext.namespaceFilePrefix(namespace);
+        URI v1 = URI.create("kestra://namespace" + prefix + "/file.yaml");
+        URI v2 = URI.create("kestra://namespace" + prefix + "/file.yaml.v2");
+        URI v3 = URI.create("kestra://namespace" + prefix + "/file.yaml.v3");
 
-        Mockito.doReturn(List.of(normalUri, revisionUri))
+        Mockito.doReturn(List.of(v1, v2, v3))
             .when(storage)
             .allByPrefix(Mockito.any(), Mockito.any(), Mockito.any(), Mockito.anyBoolean());
 
         FileAttributes attributes = Mockito.mock(FileAttributes.class);
-
-        Mockito.when(storage.getAttributes(Mockito.any(), Mockito.any(), Mockito.eq(normalUri)))
-            .thenReturn(attributes);
-
-        Mockito.when(storage.getAttributes(Mockito.any(), Mockito.any(), Mockito.eq(revisionUri)))
+        Mockito.when(storage.getAttributes(Mockito.any(), Mockito.any(), Mockito.any()))
             .thenReturn(attributes);
 
         Mockito.when(repo.findByPath(Mockito.any(), Mockito.any(), Mockito.any()))
@@ -126,11 +126,63 @@ public class MetadataMigrationServiceTest<T extends MetadataMigrationService> {
 
         service.nsFilesMigration(false, null);
 
+        // All three revisions are migrated under the logical path, never under a ".vN" path; save()
+        // then rebuilds the v1/v2/v3 chain (verified end-to-end in NsFilesMetadataMigrationCommandTest).
+        Mockito.verify(repo, Mockito.times(3))
+            .save(Mockito.argThat(meta -> meta.getPath().equals("/file.yaml")));
         Mockito.verify(repo, Mockito.never())
-            .save(Mockito.argThat(meta -> meta.getPath().endsWith(".v1")));
+            .save(Mockito.argThat(meta -> meta.getPath().contains(".v")));
+    }
 
-        Mockito.verify(repo)
-            .save(Mockito.argThat(meta -> !meta.getPath().endsWith(".v1")));
+    @Test
+    void shouldBackfillMissingRevisionsForAlreadyMigratedPath() throws Exception {
+        NamespaceFileMetadataRepositoryInterface repo = Mockito.mock(NamespaceFileMetadataRepositoryInterface.class);
+        StorageInterface storage = Mockito.mock(StorageInterface.class);
+
+        String namespace = "test.namespace";
+
+        MetadataMigrationService service = new MetadataMigrationService(
+            Mockito.mock(FlowRepositoryInterface.class),
+            new TenantService() {
+                @Override
+                public String resolveTenant() {
+                    return TENANT_ID;
+                }
+            },
+            null,
+            repo,
+            storage,
+            Mockito.mock(KestraConfig.class)
+        ) {
+            @Override
+            public Map<String, List<String>> namespacesPerTenant() {
+                return Map.of(TENANT_ID, List.of(namespace));
+            }
+        };
+
+        String prefix = StorageContext.namespaceFilePrefix(namespace);
+        URI v1 = URI.create("kestra://namespace" + prefix + "/file.yaml");
+        URI v2 = URI.create("kestra://namespace" + prefix + "/file.yaml.v2");
+        URI v3 = URI.create("kestra://namespace" + prefix + "/file.yaml.v3");
+
+        Mockito.doReturn(List.of(v1, v2, v3))
+            .when(storage)
+            .allByPrefix(Mockito.any(), Mockito.any(), Mockito.any(), Mockito.anyBoolean());
+
+        FileAttributes attributes = Mockito.mock(FileAttributes.class);
+        Mockito.when(storage.getAttributes(Mockito.any(), Mockito.any(), Mockito.any()))
+            .thenReturn(attributes);
+
+        // Simulate a previously broken migration that indexed only the bare file as v1.
+        NamespaceFileMetadata alreadyMigrated = NamespaceFileMetadata.of(TENANT_ID, namespace, "/file.yaml", attributes);
+        Mockito.when(repo.findByPath(Mockito.any(), Mockito.any(), Mockito.any()))
+            .thenReturn(Optional.of(alreadyMigrated));
+
+        service.nsFilesMigration(false, null);
+
+        // v1 is already indexed: only the missing v2 and v3 revisions are backfilled, never re-saving v1.
+        Mockito.verify(repo, Mockito.times(2))
+            .save(Mockito.argThat(meta -> meta.getPath().equals("/file.yaml")));
     }
 
     protected T metadataMigrationService(Map<String, List<String>> namespacesPerTenant) {

--- a/cli/src/test/java/io/kestra/cli/commands/migrations/metadata/NsFilesMetadataMigrationCommandTest.java
+++ b/cli/src/test/java/io/kestra/cli/commands/migrations/metadata/NsFilesMetadataMigrationCommandTest.java
@@ -10,6 +10,8 @@ import java.util.Optional;
 import org.junit.jupiter.api.Test;
 
 import io.kestra.cli.App;
+import io.kestra.core.models.FetchVersion;
+import io.kestra.core.models.QueryFilter;
 import io.kestra.core.models.flows.Flow;
 import io.kestra.core.models.flows.GenericFlow;
 import io.kestra.core.models.namespaces.files.NamespaceFileMetadata;
@@ -25,6 +27,7 @@ import io.micronaut.configuration.picocli.PicocliRunner;
 import io.micronaut.context.ApplicationContext;
 import io.micronaut.context.env.Environment;
 import io.micronaut.core.annotation.NonNull;
+import io.micronaut.data.model.Pageable;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -139,6 +142,138 @@ public class NsFilesMetadataMigrationCommandTest {
     }
 
     @Test
+    void shouldReconstructVersionHistoryFromStorageRevisions() throws IOException {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        System.setOut(new PrintStream(out));
+
+        try (ApplicationContext ctx = ApplicationContext.run(Environment.CLI, Environment.TEST)) {
+            String tenantId = TenantService.MAIN_TENANT;
+            String namespace = TestsUtils.randomNamespace();
+            StorageInterface storage = ctx.getBean(StorageInterface.class);
+
+            /*
+             * A file that went through three versions. v1 is stored under the bare path, v2 and v3
+             * under ".vN" suffixes. It lives in a subdirectory to mirror the reported issue (#8665).
+             */
+            String path = "/scripts/main.py";
+            putOldNsFile(storage, namespace, path, "v1");
+            putOldNsFile(storage, namespace, path + ".v2", "v2-content");
+            putOldNsFile(storage, namespace, path + ".v3", "v3-longer-content");
+
+            // The namespace must own a flow, otherwise the migration does not pick it up.
+            FlowRepositoryInterface flowRepository = ctx.getBean(FlowRepositoryInterface.class);
+            flowRepository.create(
+                GenericFlow.of(
+                    Flow.builder()
+                        .tenantId(tenantId)
+                        .id("a-flow")
+                        .namespace(namespace)
+                        .tasks(List.of(Log.builder().id("log").type(Log.class.getName()).message("logging").build()))
+                        .build()
+                )
+            );
+
+            String[] nsFilesMetadataMigrationCommand = { "migrate", "metadata", "nsfiles" };
+            PicocliRunner.call(App.class, ctx, nsFilesMetadataMigrationCommand);
+
+            NamespaceFileMetadataRepositoryInterface namespaceFileMetadataRepository = ctx.getBean(NamespaceFileMetadataRepositoryInterface.class);
+
+            // The latest version is recorded as version 3 and flagged as the last one.
+            Optional<NamespaceFileMetadata> last = namespaceFileMetadataRepository.findByPath(tenantId, namespace, path);
+            assertThat(last.isPresent()).isTrue();
+            assertThat(last.get().getVersion()).isEqualTo(3);
+            assertThat(last.get().isLast()).isTrue();
+            assertThat(last.get().getSize()).isEqualTo("v3-longer-content".length());
+
+            // All three versions are now visible: this is what PurgeFiles relies on to purge old ones.
+            List<QueryFilter> namespaceFilter = List.of(
+                QueryFilter.builder()
+                    .field(QueryFilter.Field.NAMESPACE)
+                    .operation(QueryFilter.Op.EQUALS)
+                    .value(namespace)
+                    .build()
+            );
+            assertThat(versionsOf(namespaceFileMetadataRepository, tenantId, namespaceFilter, path))
+                .containsExactlyInAnyOrder(1, 2, 3);
+
+            // Running the migration again is idempotent: still three versions, not six.
+            out.reset();
+            PicocliRunner.call(App.class, ctx, nsFilesMetadataMigrationCommand);
+            assertThat(namespaceFileMetadataRepository.findByPath(tenantId, namespace, path).get().getVersion()).isEqualTo(3);
+            assertThat(versionsOf(namespaceFileMetadataRepository, tenantId, namespaceFilter, path))
+                .containsExactlyInAnyOrder(1, 2, 3);
+        }
+    }
+
+    @Test
+    void shouldBackfillVersionsForAlreadyMigratedFile() throws IOException {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        System.setOut(new PrintStream(out));
+
+        try (ApplicationContext ctx = ApplicationContext.run(Environment.CLI, Environment.TEST)) {
+            String tenantId = TenantService.MAIN_TENANT;
+            String namespace = TestsUtils.randomNamespace();
+            StorageInterface storage = ctx.getBean(StorageInterface.class);
+
+            /*
+             * Storage holds the full history (bare + .v2 + .v3), as it would on a real instance...
+             */
+            String path = "/scripts/main.py";
+            putOldNsFile(storage, namespace, path, "v1");
+            putOldNsFile(storage, namespace, path + ".v2", "v2-content");
+            putOldNsFile(storage, namespace, path + ".v3", "v3-longer-content");
+
+            FlowRepositoryInterface flowRepository = ctx.getBean(FlowRepositoryInterface.class);
+            flowRepository.create(
+                GenericFlow.of(
+                    Flow.builder()
+                        .tenantId(tenantId)
+                        .id("a-flow")
+                        .namespace(namespace)
+                        .tasks(List.of(Log.builder().id("log").type(Log.class.getName()).message("logging").build()))
+                        .build()
+                )
+            );
+
+            NamespaceFileMetadataRepositoryInterface namespaceFileMetadataRepository = ctx.getBean(NamespaceFileMetadataRepositoryInterface.class);
+
+            /*
+             * ...but the metadata table only has the bare file as v1, exactly as left behind by the
+             * previous (broken) migration that discarded the ".vN" revisions.
+             */
+            FileAttributes v1Attributes = storage.getAttributes(tenantId, namespace, getNsFileStorageUri(namespace, path));
+            namespaceFileMetadataRepository.save(NamespaceFileMetadata.of(tenantId, namespace, path, v1Attributes));
+            assertThat(namespaceFileMetadataRepository.findByPath(tenantId, namespace, path).get().getVersion()).isEqualTo(1);
+
+            // Running the fixed migration backfills the missing v2 and v3 revisions.
+            String[] nsFilesMetadataMigrationCommand = { "migrate", "metadata", "nsfiles" };
+            PicocliRunner.call(App.class, ctx, nsFilesMetadataMigrationCommand);
+
+            Optional<NamespaceFileMetadata> last = namespaceFileMetadataRepository.findByPath(tenantId, namespace, path);
+            assertThat(last.isPresent()).isTrue();
+            assertThat(last.get().getVersion()).isEqualTo(3);
+            assertThat(last.get().isLast()).isTrue();
+            assertThat(last.get().getSize()).isEqualTo("v3-longer-content".length());
+
+            // The full history is now visible, so PurgeFiles can purge the old versions.
+            List<QueryFilter> namespaceFilter = List.of(
+                QueryFilter.builder()
+                    .field(QueryFilter.Field.NAMESPACE)
+                    .operation(QueryFilter.Op.EQUALS)
+                    .value(namespace)
+                    .build()
+            );
+            assertThat(versionsOf(namespaceFileMetadataRepository, tenantId, namespaceFilter, path))
+                .containsExactlyInAnyOrder(1, 2, 3);
+
+            // Re-running stays idempotent: still three versions, no duplicate backfill.
+            PicocliRunner.call(App.class, ctx, nsFilesMetadataMigrationCommand);
+            assertThat(versionsOf(namespaceFileMetadataRepository, tenantId, namespaceFilter, path))
+                .containsExactlyInAnyOrder(1, 2, 3);
+        }
+    }
+
+    @Test
     void namespaceWithoutNsFile() {
         ByteArrayOutputStream out = new ByteArrayOutputStream();
         System.setOut(new PrintStream(out));
@@ -170,6 +305,13 @@ public class NsFilesMetadataMigrationCommandTest {
             assertThat(out.toString()).contains("✅ Namespace Files Metadata migration complete.");
             assertThat(err.toString()).doesNotContain("java.nio.file.NoSuchFileException");
         }
+    }
+
+    private static List<Integer> versionsOf(NamespaceFileMetadataRepositoryInterface repository, String tenantId, List<QueryFilter> namespaceFilter, String path) {
+        return repository.find(Pageable.UNPAGED, tenantId, namespaceFilter, true, FetchVersion.ALL).stream()
+            .filter(metadata -> metadata.getPath().equals(path))
+            .map(NamespaceFileMetadata::getVersion)
+            .toList();
     }
 
     private static void putOldNsFile(StorageInterface storage, String namespace, String path, String value) throws IOException {


### PR DESCRIPTION
## What

The `kestra migrate metadata nsfiles` command discarded namespace file version history. It filtered out every `.vN` revision object and indexed only the bare file as a single version (`version=1, last=true`).

`PurgeFiles` builds its purge list from the metadata table, so it only ever saw **one version per path** → `keepAmount: 1` left nothing to skip → **nothing was purged**, and old `.vN` revisions stayed on storage forever. This is the root cause of kestra-ee#8665.

## Fix

Group every stored object (bare file + `.vN` revisions) by logical path and replay the revisions oldest-first through `save()`, which increments the version and flags the latest as `last` — exactly the state normal sequential uploads produce.

The idempotency guard is a **version threshold** rather than a binary skip, so the same command repairs both populations:

| Install state | versions already indexed | result |
|---|---|---|
| Never migrated (future runs) | 0 | replay all → v1, v2, v3 |
| Migrated by the broken command | 1 | backfill v2, v3 |
| Fully migrated | N (max) | replay nothing (idempotent) |

Re-running `kestra migrate metadata nsfiles` is the single remediation path for already-affected installs — no new command, no config surface.

## Scope

`releases/v1.3.x` only — the migration command was removed on `develop` (2.0), so no backport is needed.

## Tests

- **Unit** `MetadataMigrationServiceTest`:
  - `shouldMigrateRevisionsAsVersionsOfTheSamePath` — all three revisions migrate under the logical path, never under a `.vN` path.
  - `shouldBackfillMissingRevisionsForAlreadyMigratedPath` — with a pre-existing v1 row, only v2/v3 are saved.
- **Integration** `NsFilesMetadataMigrationCommandTest`:
  - `shouldReconstructVersionHistoryFromStorageRevisions` — fresh migration ends at v1/v2/v3, v3 `last`, idempotent on re-run.
  - `shouldBackfillVersionsForAlreadyMigratedFile` — simulates the broken state (v1-only row + full storage history), runs the migration, asserts backfill to v1/v2/v3 and idempotency.

closes https://github.com/kestra-io/kestra-ee/issues/8665