### PR TITLE
fix(ci): build slot-contracts before syncing dist to artifact-sdk

### DIFF
--- a/.github/workflows/sync-slot-contracts.yml
+++ b/.github/workflows/sync-slot-contracts.yml
@@ -24,6 +24,15 @@ jobs:
           token: ${{ secrets.GH_PERSONAL_TOKEN }}
           path: artifact-sdk
 
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22.x
+
+      - name: Build slot-contracts
+        working-directory: ui/packages/slot-contracts
+        run: npm install && npm run build
+
       - name: Set up Git
         run: |
           git config --global user.name "GitHub Action"


### PR DESCRIPTION
## Summary
- `sync-slot-contracts` workflow was copying `ui/packages/slot-contracts/dist/` which doesn't exist after a fresh checkout (it's gitignored)
- Add Node.js 22 setup and `npm install && npm run build` in `ui/packages/slot-contracts` before the `cp -r dist/` step

## Root cause
```
cp: cannot stat 'ui/packages/slot-contracts/dist/.': No such file or directory
```
`dist/` is a build artifact — workflow needs to produce it first.

## Test plan
- [ ] Trigger the `sync-slot-contracts` workflow on a `ui/packages/slot-contracts/src/**` change and verify it completes without error