### PR TITLE
feat(flows): redesign empty state for flows with a single revision

### DIFF
--- a/ui/src/components/layout/Revisions.vue
+++ b/ui/src/components/layout/Revisions.vue
@@ -105,10 +105,14 @@
             <span class="ml-2">Loading revisions...</span>
         </div>
     </div>
-    <div v-else>
-        <KsAlert class="mb-0" :closable="false">
-            {{ $t("no revisions found") }}
-        </KsAlert>
+    <div v-else class="no-revisions">
+        <div class="no-revisions-content">
+            <History class="no-revisions-icon" />
+            <div class="no-revisions-text">
+                <p class="no-revisions-title">{{ $t("no revisions") }}</p>
+                <p class="no-revisions-subtitle">{{ $t("no revisions found") }}</p>
+            </div>
+        </div>
     </div>
 </template>
 
@@ -116,6 +120,7 @@
     import {computed, ref, watch} from "vue"
     import {useI18n} from "vue-i18n"
     import {useRoute, useRouter} from "vue-router"
+    import History from "vue-material-design-icons/History.vue"
     import Restore from "vue-material-design-icons/Restore.vue"
     import TrashCanOutline from "vue-material-design-icons/TrashCanOutline.vue"
     import {KsEditor} from "@kestra-io/design-system"
@@ -424,4 +429,44 @@
         flex-shrink: 0;
     }
 
+    .no-revisions {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        min-height: calc(100vh - 190px);
+    }
+
+    .no-revisions-content {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        gap: var(--ks-spacing-2);
+    }
+
+    .no-revisions-text {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        gap: 2px;
+    }
+
+    .no-revisions-icon {
+        color: var(--ks-icon-muted);
+
+        :deep(svg) {
+            width: 28px;
+            height: 28px;
+        }
+    }
+
+    .no-revisions-title {
+        font-weight: var(--ks-font-weight-semibold);
+        color: var(--ks-text-primary);
+        margin: 0;
+    }
+
+    .no-revisions-subtitle {
+        color: var(--ks-text-secondary);
+        margin: 0;
+    }
 </style>

--- a/ui/src/translations/de.json
+++ b/ui/src/translations/de.json
@@ -1149,6 +1149,7 @@
     "no data current task": "Für die aktuelle Task sind keine Daten verfügbar.",
     "no inputs": "Dieser Flow hat keine Inputs.",
     "no result": "Es gibt keine Ergebnisse anzuzeigen.",
+    "no revisions": "Keine Revisionen",
     "no revisions found": "Es existiert nur eine Revision für diesen Flow",
     "no-executions-view": {
       "guidance_desc": "Benötigen Sie Unterstützung, um Ihren Flow auszuführen?",

--- a/ui/src/translations/en.json
+++ b/ui/src/translations/en.json
@@ -437,6 +437,7 @@
     "date count": "{count} on the {date}",
     "revisions": "Revisions",
     "no revisions found": "Only one revision exists for this flow",
+    "no revisions": "No Revisions",
     "see full revision": "See full revision",
     "side-by-side": "side-by-side",
     "line-by-line": "line-by-line",

--- a/ui/src/translations/es.json
+++ b/ui/src/translations/es.json
@@ -1149,6 +1149,7 @@
     "no data current task": "No hay datos disponibles para el task actual.",
     "no inputs": "Este flow no tiene inputs.",
     "no result": "No hay resultados para mostrar.",
+    "no revisions": "Sin revisiones",
     "no revisions found": "Solo existe una revisión para este flujo",
     "no-executions-view": {
       "guidance_desc": "¿Necesitas orientación para ejecutar tu flow?",

--- a/ui/src/translations/fr.json
+++ b/ui/src/translations/fr.json
@@ -1149,6 +1149,7 @@
     "no data current task": "Il n'y a pas de données disponibles pour la tâche actuelle.",
     "no inputs": "Ce flow n'a pas d'entrée.",
     "no result": "Il n'y a aucun résultat à afficher.",
+    "no revisions": "Aucune révision",
     "no revisions found": "Une seule révision existe pour ce flow",
     "no-executions-view": {
       "guidance_desc": "Besoin d'aide pour exécuter votre flow ?",

--- a/ui/src/translations/hi.json
+++ b/ui/src/translations/hi.json
@@ -1149,6 +1149,7 @@
     "no data current task": "वर्तमान task के लिए कोई डेटा उपलब्ध नहीं है।",
     "no inputs": "इस flow में कोई इनपुट्स नहीं हैं।",
     "no result": "कोई परिणाम दिखाने के लिए नहीं हैं।",
+    "no revisions": "कोई संशोधन नहीं",
     "no revisions found": "इस flow के लिए केवल एक पुनरीक्षण मौजूद है",
     "no-executions-view": {
       "guidance_desc": "क्या आपको अपने flow को निष्पादित करने के लिए मार्गदर्शन चाहिए?",

--- a/ui/src/translations/it.json
+++ b/ui/src/translations/it.json
@@ -1149,6 +1149,7 @@
     "no data current task": "Non ci sono dati disponibili per il task corrente",
     "no inputs": "Questo flow non ha inputs.",
     "no result": "Non ci sono risultati da mostrare.",
+    "no revisions": "Nessuna revisione",
     "no revisions found": "Esiste solo una revisione per questo flow",
     "no-executions-view": {
       "guidance_desc": "Hai bisogno di assistenza per eseguire il tuo flow?",

--- a/ui/src/translations/ja.json
+++ b/ui/src/translations/ja.json
@@ -1149,6 +1149,7 @@
     "no data current task": "現在のタスクに利用可能なデータがありません。",
     "no inputs": "このflowにはinputがありません。",
     "no result": "表示する結果がありません。",
+    "no revisions": "リビジョンなし",
     "no revisions found": "このFlowには1つのリビジョンしか存在しません",
     "no-executions-view": {
       "guidance_desc": "フローを実行するためのガイダンスが必要ですか？",

--- a/ui/src/translations/ko.json
+++ b/ui/src/translations/ko.json
@@ -1149,6 +1149,7 @@
     "no data current task": "현재 task에 대한 데이터가 없습니다.",
     "no inputs": "이 flow에는 입력이 없습니다.",
     "no result": "결과가 없습니다.",
+    "no revisions": "리비전 없음",
     "no revisions found": "이 flow에 대한 수정본이 하나만 존재합니다.",
     "no-executions-view": {
       "guidance_desc": "당신의 flow를 실행하는 데 도움이 필요하신가요?",

--- a/ui/src/translations/pl.json
+++ b/ui/src/translations/pl.json
@@ -1149,6 +1149,7 @@
     "no data current task": "Brak dostępnych danych dla bieżącego taska",
     "no inputs": "Ten flow nie ma inputs.",
     "no result": "Nie ma wyników do wyświetlenia.",
+    "no revisions": "Brak rewizji",
     "no revisions found": "Istnieje tylko jedna wersja dla tego flow",
     "no-executions-view": {
       "guidance_desc": "Potrzebujesz wskazówek, jak wykonać swój flow?",

--- a/ui/src/translations/pt.json
+++ b/ui/src/translations/pt.json
@@ -1149,6 +1149,7 @@
     "no data current task": "Não há dados disponíveis para a tarefa atual",
     "no inputs": "Este flow não tem inputs.",
     "no result": "Não há resultados para serem exibidos.",
+    "no revisions": "Sem revisões",
     "no revisions found": "Existe apenas uma revisão para este flow",
     "no-executions-view": {
       "guidance_desc": "Precisa de orientação para executar o seu flow?",

--- a/ui/src/translations/pt_BR.json
+++ b/ui/src/translations/pt_BR.json
@@ -1149,6 +1149,7 @@
     "no data current task": "Não há dados disponíveis para a tarefa atual",
     "no inputs": "Este flow não tem inputs.",
     "no result": "Não há resultados para serem exibidos.",
+    "no revisions": "Sem revisões",
     "no revisions found": "Existe apenas uma revisão para este flow",
     "no-executions-view": {
       "guidance_desc": "Precisa de orientação para executar o seu flow?",

--- a/ui/src/translations/ru.json
+++ b/ui/src/translations/ru.json
@@ -1149,6 +1149,7 @@
     "no data current task": "Для текущего task нет доступных данных",
     "no inputs": "Этот flow не имеет входных данных.",
     "no result": "Нет результатов для отображения.",
+    "no revisions": "Нет ревизий",
     "no revisions found": "Для этого flow существует только одна редакция",
     "no-executions-view": {
       "guidance_desc": "Нужна помощь для выполнения вашего flow?",

--- a/ui/src/translations/zh_CN.json
+++ b/ui/src/translations/zh_CN.json
@@ -1149,6 +1149,7 @@
     "no data current task": "当前task没有可用数据",
     "no inputs": "此流程没有输入。",
     "no result": "没有结果显示。",
+    "no revisions": "无修订",
     "no revisions found": "此流程只有一个修订版",
     "no-executions-view": {
       "guidance_desc": "需要指导来执行您的flow吗？",


### PR DESCRIPTION
<img width="1324" height="979" alt="image" src="https://github.com/user-attachments/assets/f430ddae-1d55-455d-bd63-5dcc63a2dcc8" />

## Summary

- Replaces the info alert banner with a centered empty state when a flow has only one revision
- Shows a `History` Material Design icon, "No Revisions" title, and "Only one revision exists for this flow" subtitle
- Adds `"no revisions"` translation key across all 13 supported languages

## Related issue

Closes https://github.com/kestra-io/kestra-ee/issues/8653

## Test plan

- [ ] Open a flow that has never been edited (single revision) and navigate to the Revisions tab — should show the centered empty state
- [ ] Verify the empty state looks correct in both light and dark mode
- [ ] Verify the empty state is not shown when a flow has 2+ revisions