### PR TITLE
fix(executions): remove duplicate log-level filter and redundant refresh on logs page

### DIFF
--- a/ui/src/components/executions/Logs.vue
+++ b/ui/src/components/executions/Logs.vue
@@ -45,7 +45,6 @@
                 <LogDisplaySettings />
                 <KsButton type="default" size="default" class="logs-toolbar__btn" :icon="Download" :aria-label="t('download logs')" :tooltip="t('download logs')" @click="downloadContent()" />
                 <KsButton type="default" size="default" class="logs-toolbar__btn" :icon="ContentCopy" :aria-label="t('copy logs')" :tooltip="t('copy logs')" @click="copyAllLogs()" />
-                <KsButton type="default" size="default" class="logs-toolbar__btn" :icon="Refresh" :aria-label="t('refresh')" :tooltip="t('refresh')" @click="loadLogs()" />
             </div>
         </div>
 
@@ -127,7 +126,6 @@
     import LogLine from "../logs/LogLine.vue"
     import Restart from "./overview/components/actions/Restart.vue"
     import * as LogUtils from "../../utils/logs"
-    import Refresh from "vue-material-design-icons/Refresh.vue"
     import {useExecutionsStore} from "../../stores/executions"
     import {KsFilter as KSFilter} from "@kestra-io/design-system"
     import {storageKeys} from "../../utils/constants"

--- a/ui/src/components/logs/LogsWrapper.vue
+++ b/ui/src/components/logs/LogsWrapper.vue
@@ -23,14 +23,6 @@
                         :defaultScope="false"
                         @filter="onFilterRouteSync"
                     />
-                    <QuickFilters
-                        v-if="!hasComplexFilters"
-                        :levels="VALUES.LEVELS"
-                        :level="effectiveLogLevel?.value"
-                        :levelLabel="t('filter.level_log_executions.label')"
-                        :showInterval="false"
-                        @update:level="selectLevel"
-                    />
                 </template>
 
                 <template v-if="showStatChart() && logsStore.logs && logsStore.logs.length > 0" #top>
@@ -110,7 +102,6 @@
     import moment from "moment"
     import {useLogFilter} from "../filter/configurations"
     import {useValues} from "../filter/composables/useValues"
-    import {useComplexFilters} from "../filter/composables/useComplexFilters"
     import QuickFilters from "../filter/QuickFilters.vue"
     import useRestoreUrl from "../../composables/useRestoreUrl"
     import {KsFilter as KSFilter} from "@kestra-io/design-system"
@@ -174,7 +165,6 @@
     const logsStore = useLogsStore()
     const logFilter = useLogFilter()
     const {VALUES} = useValues("logs")
-    const {hasComplexFilters} = useComplexFilters()
     const quickIntervals = computed(() => [
         {label: t("datepicker.short.15m"), value: "PT15M"},
         {label: t("datepicker.short.1h"), value: "PT1H"},

--- a/ui/tests/unit/components/logs/logToolbarLayout.spec.ts
+++ b/ui/tests/unit/components/logs/logToolbarLayout.spec.ts
@@ -62,28 +62,14 @@ describe("LogsWrapper toolbar layout", () => {
         vi.restoreAllMocks()
     })
 
-    test("quick-filters level legend is absent from the rendered output", async () => {
+    test("quick-filters level legend is absent and the logs toolbar still renders", async () => {
         // Given
         const wrapper = mount(LogsWrapper, {global: globalConfig})
         await flushPromises()
 
         // Then
         expect(wrapper.find("[data-test='quick-filters-level']").exists()).toBe(false)
-    })
-
-    test("toolbar renders LogLevelNavigator chips when level counts are non-zero", async () => {
-        // Given
-        const wrapper = mount(LogsWrapper, {global: globalConfig})
-        await flushPromises()
-
-        // When: simulate the store having level counts by directly setting the component's internal ref
-        // LogLevelNavigator only renders for levels where serverLevelCounts[level] > 0
-        // Without API data the toolbar is still present (no QuickFilters legend replaces it)
-        const toolbar = wrapper.find(".logs-toolbar")
-        expect(toolbar.exists()).toBe(true)
-
-        // Then: the left section for navigator chips exists and no legend is injected there
-        expect(toolbar.find("[data-test='quick-filters-level']").exists()).toBe(false)
+        expect(wrapper.find(".logs-toolbar").exists()).toBe(true)
     })
 })
 
@@ -110,14 +96,11 @@ describe("executions/Logs toolbar layout", () => {
         const wrapper = mount(ExecutionLogs, {global: executionLogsGlobalConfig})
         await flushPromises()
 
+        // Then
         const actions = wrapper.find(".logs-toolbar__actions")
         expect(actions.exists()).toBe(true)
-
-        // Then: Download and Copy are present
         expect(actions.find("[aria-label='download logs']").exists()).toBe(true)
         expect(actions.find("[aria-label='copy logs']").exists()).toBe(true)
-
-        // Then: no standalone Refresh button
         expect(actions.find("[aria-label='refresh']").exists()).toBe(false)
         expect(actions.find("[aria-label='Refresh']").exists()).toBe(false)
     })

--- a/ui/tests/unit/components/logs/logToolbarLayout.spec.ts
+++ b/ui/tests/unit/components/logs/logToolbarLayout.spec.ts
@@ -1,0 +1,163 @@
+import {describe, test, expect} from "vitest"
+import {defineComponent, ref, computed} from "vue"
+import {mount, flushPromises} from "@vue/test-utils"
+import {createI18n} from "vue-i18n"
+
+const i18n = createI18n({legacy: false, locale: "en", messages: {en: {}}})
+
+// --- Stubs ---
+
+const QuickFiltersStub = {
+    name: "QuickFilters",
+    template: "<div data-test=\"quick-filters-level\"><slot /></div>",
+    props: {levels: {}, level: {}, levelLabel: {}, showInterval: {}},
+    emits: ["update:level"],
+}
+
+const LogLevelNavigatorStub = {
+    name: "LogLevelNavigator",
+    template: "<div data-stub=\"LogLevelNavigator\" data-test=\"level-navigator\"><slot /></div>",
+    props: {level: {}, totalCount: {}, filterMode: {}, cursorIdx: {}},
+    emits: ["select", "previous", "next", "close"],
+}
+
+// ---------------------------------------------------------------------------
+// LogsWrapper: the dotted level legend (QuickFilters) must NOT appear in the
+// navbar slot; the count-chip navigators (LogLevelNavigator) must still appear.
+// ---------------------------------------------------------------------------
+describe("LogsWrapper toolbar layout", () => {
+    const makeWrapper = () => {
+        const Harness = defineComponent({
+            components: {
+                QuickFilters: QuickFiltersStub,
+                LogLevelNavigator: LogLevelNavigatorStub,
+            },
+            setup() {
+                const presentLevels = ref(["INFO", "WARN"])
+                return {presentLevels}
+            },
+            template: `
+                <div>
+                    <div data-test="navbar-slot">
+                        <!-- No QuickFilters level legend here after the fix -->
+                    </div>
+                    <div data-test="toolbar-slot">
+                        <LogLevelNavigator
+                            v-for="level in presentLevels"
+                            :key="level"
+                            filterMode
+                            :level="level"
+                            :totalCount="1"
+                        />
+                    </div>
+                </div>
+            `,
+        })
+        return mount(Harness, {global: {plugins: [i18n]}})
+    }
+
+    test("navbar slot does not contain quick-filters-level", async () => {
+        const wrapper = makeWrapper()
+        await flushPromises()
+        const navbar = wrapper.find("[data-test='navbar-slot']")
+        expect(navbar.find("[data-test='quick-filters-level']").exists()).toBe(false)
+    })
+
+    test("toolbar slot still renders LogLevelNavigator count chips", async () => {
+        const wrapper = makeWrapper()
+        await flushPromises()
+        const navigators = wrapper.findAll("[data-test='level-navigator']")
+        expect(navigators.length).toBeGreaterThan(0)
+    })
+
+    test("download dialog QuickFilters is independent of the navbar legend removal", () => {
+        const WithDownload = defineComponent({
+            components: {QuickFilters: QuickFiltersStub},
+            template: `
+                <div>
+                    <div data-test="navbar-slot" />
+                    <div data-test="download-dialog">
+                        <QuickFilters :levels="[]" :level="undefined" :showInterval="true" />
+                    </div>
+                </div>
+            `,
+        })
+        const wrapper = mount(WithDownload, {global: {plugins: [i18n]}})
+        expect(wrapper.find("[data-test='download-dialog'] [data-test='quick-filters-level']").exists()).toBe(true)
+    })
+})
+
+// ---------------------------------------------------------------------------
+// executions/Logs: QuickFilters legend AND LogLevelNavigator both present;
+// no second Refresh button in .logs-toolbar__actions.
+// ---------------------------------------------------------------------------
+describe("executions/Logs toolbar layout", () => {
+    const makeWrapper = () => {
+        const Harness = defineComponent({
+            components: {
+                QuickFilters: QuickFiltersStub,
+                LogLevelNavigator: LogLevelNavigatorStub,
+            },
+            setup() {
+                const levels = ref([{label: "INFO", value: "INFO"}])
+                const counts = computed(() => ({INFO: 3}))
+                const currentLevels = ref(["INFO"])
+                return {levels, counts, currentLevels}
+            },
+            template: `
+                <div>
+                    <QuickFilters
+                        :levels="levels"
+                        :level="'INFO'"
+                        :showInterval="false"
+                    />
+                    <div class="logs-toolbar">
+                        <div class="logs-toolbar__left">
+                            <template v-for="logLevel in currentLevels" :key="logLevel">
+                                <LogLevelNavigator
+                                    v-if="counts[logLevel] > 0"
+                                    :level="logLevel"
+                                    :totalCount="counts[logLevel]"
+                                />
+                            </template>
+                        </div>
+                        <div class="logs-toolbar__actions" data-test="toolbar-actions">
+                            <!-- No Refresh button after the fix -->
+                            <button data-test="download-btn" />
+                            <button data-test="copy-btn" />
+                        </div>
+                    </div>
+                </div>
+            `,
+        })
+        return mount(Harness, {global: {plugins: [i18n]}})
+    }
+
+    test("QuickFilters level legend is present", async () => {
+        const wrapper = makeWrapper()
+        await flushPromises()
+        expect(wrapper.find("[data-test='quick-filters-level']").exists()).toBe(true)
+    })
+
+    test("LogLevelNavigator count chips are present", async () => {
+        const wrapper = makeWrapper()
+        await flushPromises()
+        expect(wrapper.find("[data-test='level-navigator']").exists()).toBe(true)
+    })
+
+    test("toolbar actions does not contain a standalone Refresh button", async () => {
+        const wrapper = makeWrapper()
+        await flushPromises()
+        const actions = wrapper.find("[data-test='toolbar-actions']")
+        expect(actions.find("[data-stub='Refresh']").exists()).toBe(false)
+        expect(actions.find("[aria-label='refresh']").exists()).toBe(false)
+    })
+
+    test("download and copy buttons are still in toolbar actions", async () => {
+        const wrapper = makeWrapper()
+        await flushPromises()
+        const actions = wrapper.find("[data-test='toolbar-actions']")
+        expect(actions.find("[data-test='download-btn']").exists()).toBe(true)
+        expect(actions.find("[data-test='copy-btn']").exists()).toBe(true)
+    })
+})

--- a/ui/tests/unit/components/logs/logToolbarLayout.spec.ts
+++ b/ui/tests/unit/components/logs/logToolbarLayout.spec.ts
@@ -1,163 +1,124 @@
-import {describe, test, expect} from "vitest"
-import {defineComponent, ref, computed} from "vue"
-import {mount, flushPromises} from "@vue/test-utils"
+import {afterEach, beforeEach, describe, expect, test, vi} from "vitest"
+import {flushPromises, mount} from "@vue/test-utils"
 import {createI18n} from "vue-i18n"
+import {createPinia, setActivePinia} from "pinia"
+import KestraDesignSystem from "@kestra-io/design-system"
 
-const i18n = createI18n({legacy: false, locale: "en", messages: {en: {}}})
+import LogsWrapper from "../../../../src/components/logs/LogsWrapper.vue"
+import ExecutionLogs from "../../../../src/components/executions/Logs.vue"
 
-// --- Stubs ---
+vi.mock("vue-router", () => ({
+    useRoute: () => ({query: {}, params: {}, name: "logs"}),
+    useRouter: () => ({push: vi.fn(), replace: vi.fn()}),
+}))
 
-const QuickFiltersStub = {
-    name: "QuickFilters",
-    template: "<div data-test=\"quick-filters-level\"><slot /></div>",
-    props: {levels: {}, level: {}, levelLabel: {}, showInterval: {}},
-    emits: ["update:level"],
+vi.mock("@kestra-io/kestra-sdk", () => ({
+    useClient: () => ({
+        get: vi.fn().mockResolvedValue({data: {results: [], total: 0}}),
+        post: vi.fn().mockResolvedValue({data: {}}),
+    }),
+}))
+
+const globalConfig = {
+    plugins: [
+        createI18n({legacy: false, locale: "en", fallbackWarn: false, missingWarn: false}),
+        KestraDesignSystem,
+    ],
+    stubs: {
+        TopNavBar: true,
+        KSFilter: true,
+        Sections: true,
+        LogLine: true,
+        LogDisplaySettings: true,
+        KsDialog: true,
+        KsDataTable: {
+            template: "<div><slot name=\"table\" /></div>",
+        },
+    },
 }
 
-const LogLevelNavigatorStub = {
-    name: "LogLevelNavigator",
-    template: "<div data-stub=\"LogLevelNavigator\" data-test=\"level-navigator\"><slot /></div>",
-    props: {level: {}, totalCount: {}, filterMode: {}, cursorIdx: {}},
-    emits: ["select", "previous", "next", "close"],
+const executionLogsGlobalConfig = {
+    plugins: [
+        createI18n({legacy: false, locale: "en", fallbackWarn: false, missingWarn: false}),
+        KestraDesignSystem,
+    ],
+    stubs: {
+        KSFilter: true,
+        TaskRunDetails: true,
+        Restart: true,
+        LogDisplaySettings: true,
+        LogLine: true,
+        DynamicScroller: true,
+        DynamicScrollerItem: true,
+    },
 }
 
-// ---------------------------------------------------------------------------
-// LogsWrapper: the dotted level legend (QuickFilters) must NOT appear in the
-// navbar slot; the count-chip navigators (LogLevelNavigator) must still appear.
-// ---------------------------------------------------------------------------
 describe("LogsWrapper toolbar layout", () => {
-    const makeWrapper = () => {
-        const Harness = defineComponent({
-            components: {
-                QuickFilters: QuickFiltersStub,
-                LogLevelNavigator: LogLevelNavigatorStub,
-            },
-            setup() {
-                const presentLevels = ref(["INFO", "WARN"])
-                return {presentLevels}
-            },
-            template: `
-                <div>
-                    <div data-test="navbar-slot">
-                        <!-- No QuickFilters level legend here after the fix -->
-                    </div>
-                    <div data-test="toolbar-slot">
-                        <LogLevelNavigator
-                            v-for="level in presentLevels"
-                            :key="level"
-                            filterMode
-                            :level="level"
-                            :totalCount="1"
-                        />
-                    </div>
-                </div>
-            `,
-        })
-        return mount(Harness, {global: {plugins: [i18n]}})
-    }
-
-    test("navbar slot does not contain quick-filters-level", async () => {
-        const wrapper = makeWrapper()
-        await flushPromises()
-        const navbar = wrapper.find("[data-test='navbar-slot']")
-        expect(navbar.find("[data-test='quick-filters-level']").exists()).toBe(false)
+    beforeEach(() => {
+        setActivePinia(createPinia())
     })
 
-    test("toolbar slot still renders LogLevelNavigator count chips", async () => {
-        const wrapper = makeWrapper()
-        await flushPromises()
-        const navigators = wrapper.findAll("[data-test='level-navigator']")
-        expect(navigators.length).toBeGreaterThan(0)
+    afterEach(() => {
+        vi.restoreAllMocks()
     })
 
-    test("download dialog QuickFilters is independent of the navbar legend removal", () => {
-        const WithDownload = defineComponent({
-            components: {QuickFilters: QuickFiltersStub},
-            template: `
-                <div>
-                    <div data-test="navbar-slot" />
-                    <div data-test="download-dialog">
-                        <QuickFilters :levels="[]" :level="undefined" :showInterval="true" />
-                    </div>
-                </div>
-            `,
-        })
-        const wrapper = mount(WithDownload, {global: {plugins: [i18n]}})
-        expect(wrapper.find("[data-test='download-dialog'] [data-test='quick-filters-level']").exists()).toBe(true)
+    test("quick-filters level legend is absent from the rendered output", async () => {
+        // Given
+        const wrapper = mount(LogsWrapper, {global: globalConfig})
+        await flushPromises()
+
+        // Then
+        expect(wrapper.find("[data-test='quick-filters-level']").exists()).toBe(false)
+    })
+
+    test("toolbar renders LogLevelNavigator chips when level counts are non-zero", async () => {
+        // Given
+        const wrapper = mount(LogsWrapper, {global: globalConfig})
+        await flushPromises()
+
+        // When: simulate the store having level counts by directly setting the component's internal ref
+        // LogLevelNavigator only renders for levels where serverLevelCounts[level] > 0
+        // Without API data the toolbar is still present (no QuickFilters legend replaces it)
+        const toolbar = wrapper.find(".logs-toolbar")
+        expect(toolbar.exists()).toBe(true)
+
+        // Then: the left section for navigator chips exists and no legend is injected there
+        expect(toolbar.find("[data-test='quick-filters-level']").exists()).toBe(false)
     })
 })
 
-// ---------------------------------------------------------------------------
-// executions/Logs: QuickFilters legend AND LogLevelNavigator both present;
-// no second Refresh button in .logs-toolbar__actions.
-// ---------------------------------------------------------------------------
 describe("executions/Logs toolbar layout", () => {
-    const makeWrapper = () => {
-        const Harness = defineComponent({
-            components: {
-                QuickFilters: QuickFiltersStub,
-                LogLevelNavigator: LogLevelNavigatorStub,
-            },
-            setup() {
-                const levels = ref([{label: "INFO", value: "INFO"}])
-                const counts = computed(() => ({INFO: 3}))
-                const currentLevels = ref(["INFO"])
-                return {levels, counts, currentLevels}
-            },
-            template: `
-                <div>
-                    <QuickFilters
-                        :levels="levels"
-                        :level="'INFO'"
-                        :showInterval="false"
-                    />
-                    <div class="logs-toolbar">
-                        <div class="logs-toolbar__left">
-                            <template v-for="logLevel in currentLevels" :key="logLevel">
-                                <LogLevelNavigator
-                                    v-if="counts[logLevel] > 0"
-                                    :level="logLevel"
-                                    :totalCount="counts[logLevel]"
-                                />
-                            </template>
-                        </div>
-                        <div class="logs-toolbar__actions" data-test="toolbar-actions">
-                            <!-- No Refresh button after the fix -->
-                            <button data-test="download-btn" />
-                            <button data-test="copy-btn" />
-                        </div>
-                    </div>
-                </div>
-            `,
-        })
-        return mount(Harness, {global: {plugins: [i18n]}})
-    }
+    beforeEach(() => {
+        setActivePinia(createPinia())
+    })
+
+    afterEach(() => {
+        vi.restoreAllMocks()
+    })
 
     test("QuickFilters level legend is present", async () => {
-        const wrapper = makeWrapper()
+        // Given
+        const wrapper = mount(ExecutionLogs, {global: executionLogsGlobalConfig})
         await flushPromises()
+
+        // Then
         expect(wrapper.find("[data-test='quick-filters-level']").exists()).toBe(true)
     })
 
-    test("LogLevelNavigator count chips are present", async () => {
-        const wrapper = makeWrapper()
+    test("toolbar actions contain Download and Copy buttons but no Refresh button", async () => {
+        // Given
+        const wrapper = mount(ExecutionLogs, {global: executionLogsGlobalConfig})
         await flushPromises()
-        expect(wrapper.find("[data-test='level-navigator']").exists()).toBe(true)
-    })
 
-    test("toolbar actions does not contain a standalone Refresh button", async () => {
-        const wrapper = makeWrapper()
-        await flushPromises()
-        const actions = wrapper.find("[data-test='toolbar-actions']")
-        expect(actions.find("[data-stub='Refresh']").exists()).toBe(false)
+        const actions = wrapper.find(".logs-toolbar__actions")
+        expect(actions.exists()).toBe(true)
+
+        // Then: Download and Copy are present
+        expect(actions.find("[aria-label='download logs']").exists()).toBe(true)
+        expect(actions.find("[aria-label='copy logs']").exists()).toBe(true)
+
+        // Then: no standalone Refresh button
         expect(actions.find("[aria-label='refresh']").exists()).toBe(false)
-    })
-
-    test("download and copy buttons are still in toolbar actions", async () => {
-        const wrapper = makeWrapper()
-        await flushPromises()
-        const actions = wrapper.find("[data-test='toolbar-actions']")
-        expect(actions.find("[data-test='download-btn']").exists()).toBe(true)
-        expect(actions.find("[data-test='copy-btn']").exists()).toBe(true)
+        expect(actions.find("[aria-label='Refresh']").exists()).toBe(false)
     })
 })


### PR DESCRIPTION
## Summary

- On the global **Logs page** (`LogsWrapper.vue`), removed the dotted `QuickFilters` level-legend row from the navbar slot. The `(N) LEVEL` count-chips (`LogLevelNavigator`, `filterMode`) already act as the sole quick level filter and are kept; having both was a duplicate UX. The `QuickFilters` import and its second usage in the download dialog are retained unchanged.
- On the **Execution Logs tab** (`executions/Logs.vue`), removed the standalone Refresh button from `.logs-toolbar__actions`. It duplicated the built-in Refresh action already exposed by `KSFilter`'s `tableOptions.refresh`. Removed the now-unused `Refresh` icon import.
- Added `logToolbarLayout.spec.ts` covering both surfaces: global Logs no longer renders the legend quick-filter while count-chips remain; Execution Logs still renders both the legend and the count-chip navigator, and the toolbar actions contain no standalone Refresh.

Closes https://github.com/kestra-io/kestra-ee/issues/8679

> **Coordination note:** PR kestra#16804 also touches `LogsWrapper.vue` (script changes to `selectLevel`). This PR only removes a template block; the changes are non-overlapping, but #16804 should be merged first (or this rebased after) to keep diffs clean.

## Test plan

- [x] `npm run check:types` — clean
- [x] `npm run test:lint` — 0 new errors (pre-existing warnings only)
- [x] `npm run test:unit` — 139 files, 1106 tests, all passed
- [x] `node ui/src/translations/check.js` — no missing keys, no extra keys