### PR TITLE
fix(security): stabilize CSRF token across page loads and fix generated OpenAPI client

### DIFF
--- a/ui/src/composables/useBaseNamespaces.ts
+++ b/ui/src/composables/useBaseNamespaces.ts
@@ -36,15 +36,18 @@ export const useBaseNamespacesStore = () => {
         return response
     }
 
-    async function search(options: Parameters<typeof NamespaceAPI.searchNamespaces>[0] & {commit?: boolean}) {
+    async function search(options: {commit?: boolean, sort?: string, [key: string]: any}) {
         const shouldCommit = options.commit !== false
         delete options.commit
-        const response = await NamespaceAPI.searchNamespaces(options)
+        const sortString = options.sort ? `?sort=${options.sort}` : ""
+        delete options.sort
+
+        const {data} = await axios.get(`${apiUrl()}/namespaces/search${sortString}`, {params: options})
         if (shouldCommit) {
-            namespaces.value = response.results
-            total.value = response.total
+            namespaces.value = data.results
+            total.value = data.total
         }
-        return response
+        return data
     }
 
     async function load(id: string) {

--- a/ui/src/main.ts
+++ b/ui/src/main.ts
@@ -19,7 +19,7 @@ loadNodeTypes()
 
 import App from "./App.vue"
 import initApp from "./utils/init"
-import {configureAxios} from "@kestra-io/kestra-sdk"
+import {configureAxios, configureClient} from "@kestra-io/kestra-sdk"
 import routes from "./routes/routes"
 import en from "./translations/en.json"
 import {setupTenantRouter} from "./composables/useTenant"
@@ -79,6 +79,11 @@ function setupAxios(router: Router) {
         }
         return config
     })
+
+    // The generated OpenAPI client (client.gen) is configured via configureClient() inside
+    // configureAxios(), but its internal axios instance is created before the CSRF interceptor
+    // above is added. Re-bind it now so all generated-client POSTs also carry the CSRF token.
+    configureClient({axios: axiosInstance})
 
     return axiosInstance
 }

--- a/ui/src/remoteComponents/useFederatedModule.ts
+++ b/ui/src/remoteComponents/useFederatedModule.ts
@@ -4,6 +4,7 @@ import {loadRemote, registerRemotes, registerShared} from "@module-federation/en
 import * as PluginsAPI from "@kestra-io/kestra-sdk/plugins"
 import {KnownSlotsPropNames, ManifestsRegistry, type KnownSlotProps} from "@kestra-io/slot-contracts"
 import {PluginUiModuleWithGroup} from "@kestra-io/kestra-sdk"
+import {getCsrfToken} from "../utils/csrf"
 
 
 function wrapWithErrorBoundary(inner: any) {
@@ -58,9 +59,14 @@ export function useFederatedModule<T extends keyof typeof KnownSlotsPropNames>(s
         try {
             // get the manifest of the all the tasks we will
             // have in the graph
-            const pluginTaskManifestsResponse = await PluginsAPI.pluginUiManifest({
-                body: Array.from(taskTypes),
-            })
+            // The generated SDK client (client.gen) uses its own axios.create() instance
+            // which does not pick up the CSRF interceptor configured in main.ts.
+            // Explicitly forward the CSRF token so this POST is not rejected by CsrfTokenFilter.
+            const csrfToken = getCsrfToken()
+            const pluginTaskManifestsResponse = await PluginsAPI.pluginUiManifest(
+                {body: Array.from(taskTypes)},
+                csrfToken ? {headers: {"X-CSRF-TOKEN": csrfToken}} : undefined,
+            )
             pluginTaskManifests = pluginTaskManifestsResponse?.manifest ?? {}
         } catch (error) {
             console.error("[FederatedModule] Failed to load plugin UI manifest:", error)

--- a/webserver/src/main/java/io/kestra/webserver/controllers/api/StaticFilter.java
+++ b/webserver/src/main/java/io/kestra/webserver/controllers/api/StaticFilter.java
@@ -107,7 +107,12 @@ public class StaticFilter implements HttpServerFilter {
             return response;
         }
 
-        String csrfToken = csrfTokenGenerator.get().generateCsrfToken(request);
+        // Reuse the existing cookie token so multiple tabs and BFCache-restored pages
+        // all share one stable token. Generate only when the cookie is absent.
+        String csrfToken = request.getCookies()
+            .findCookie(csrfConfiguration.get().getCookieName())
+            .map(Cookie::getValue)
+            .orElseGet(() -> csrfTokenGenerator.get().generateCsrfToken(request));
         if (csrfToken == null) {
             return response;
         }

--- a/webserver/src/main/java/io/kestra/webserver/filter/CsrfTokenFilter.java
+++ b/webserver/src/main/java/io/kestra/webserver/filter/CsrfTokenFilter.java
@@ -19,7 +19,6 @@ import io.micronaut.http.annotation.ServerFilter;
 import io.micronaut.http.filter.FilterPatternStyle;
 import io.micronaut.http.filter.ServerFilterPhase;
 import io.micronaut.http.server.HttpServerConfiguration;
-import io.micronaut.security.csrf.generator.CsrfTokenGenerator;
 import io.micronaut.security.csrf.resolver.CsrfTokenResolver;
 import io.micronaut.security.csrf.validator.CsrfTokenValidator;
 import lombok.extern.slf4j.Slf4j;
@@ -30,13 +29,9 @@ import static io.kestra.webserver.services.BasicAuthService.BASIC_AUTH_COOKIE_NA
  * Custom CSRF filter that only enforces token validation on cookie-authenticated requests.
  * SDK/API clients using the Authorization header bypass CSRF since they are not vulnerable
  * to cross-site request forgery (attackers cannot set custom headers cross-origin).
- *
- * Requires CsrfTokenGenerator to be registered: if no generator exists (e.g. empty signature-key),
- * no CSRF token is injected into the page, so validation would always fail — the filter must be
- * disabled in that case too.
  */
 @Requires(property = "micronaut.security.csrf.enabled", value = StringUtils.TRUE, defaultValue = StringUtils.TRUE)
-@Requires(beans = {CsrfTokenValidator.class, CsrfTokenGenerator.class})
+@Requires(beans = CsrfTokenValidator.class)
 @ServerFilter(patternStyle = FilterPatternStyle.REGEX, value = "/api/.*")
 @Slf4j
 public class CsrfTokenFilter implements Ordered {

--- a/webserver/src/main/java/io/kestra/webserver/filter/CsrfTokenFilter.java
+++ b/webserver/src/main/java/io/kestra/webserver/filter/CsrfTokenFilter.java
@@ -19,6 +19,7 @@ import io.micronaut.http.annotation.ServerFilter;
 import io.micronaut.http.filter.FilterPatternStyle;
 import io.micronaut.http.filter.ServerFilterPhase;
 import io.micronaut.http.server.HttpServerConfiguration;
+import io.micronaut.security.csrf.generator.CsrfTokenGenerator;
 import io.micronaut.security.csrf.resolver.CsrfTokenResolver;
 import io.micronaut.security.csrf.validator.CsrfTokenValidator;
 import lombok.extern.slf4j.Slf4j;
@@ -29,9 +30,13 @@ import static io.kestra.webserver.services.BasicAuthService.BASIC_AUTH_COOKIE_NA
  * Custom CSRF filter that only enforces token validation on cookie-authenticated requests.
  * SDK/API clients using the Authorization header bypass CSRF since they are not vulnerable
  * to cross-site request forgery (attackers cannot set custom headers cross-origin).
+ *
+ * Requires CsrfTokenGenerator to be registered: if no generator exists (e.g. empty signature-key),
+ * no CSRF token is injected into the page, so validation would always fail — the filter must be
+ * disabled in that case too.
  */
 @Requires(property = "micronaut.security.csrf.enabled", value = StringUtils.TRUE, defaultValue = StringUtils.TRUE)
-@Requires(beans = CsrfTokenValidator.class)
+@Requires(beans = {CsrfTokenValidator.class, CsrfTokenGenerator.class})
 @ServerFilter(patternStyle = FilterPatternStyle.REGEX, value = "/api/.*")
 @Slf4j
 public class CsrfTokenFilter implements Ordered {


### PR DESCRIPTION
## Root causes fixed

### 1. CSRF token mismatch (backend — `StaticFilter`)

`RepositoryCsrfTokenValidator` uses the **double-submit cookie pattern**: the token in the `X-CSRF-TOKEN` header must equal the `csrfToken` cookie. `StaticFilter.addCsrfToken()` was generating a **new** token on every HTML response, so:

- A second tab / hard-refresh / BFCache restore would overwrite the cookie with a fresh token
- The original tab's meta-tag still held the old token
- Every POST from the original tab → header ≠ cookie → `false` → 403

**Fix:** read the existing `csrfToken` cookie and inject it into the meta tag; only generate a new token when the cookie is absent. This makes the token stable for the lifetime of the browser session.

### 2. Generated OpenAPI client bypassed CSRF interceptor (UI — `main.ts`, `useFederatedModule.ts`)

`PluginsAPI.pluginUiManifest()` (and other SDK-generated functions) uses an internal `axios.create()` instance that never received the CSRF request interceptor configured in `main.ts`.

**Fix:**
- `main.ts`: call `configureClient({axios: axiosInstance})` after adding the CSRF interceptor so the generated client inherits the same CSRF-aware instance
- `useFederatedModule.ts`: explicitly forward `X-CSRF-TOKEN` on the `pluginUiManifest` POST as defence-in-depth

## Test plan

- [ ] Open two browser tabs on the same Kestra instance
- [ ] Execute a flow from tab 1 after tab 2 has loaded — should succeed (no 403)
- [ ] Navigate away and use the browser back button (BFCache restore) — POST should still succeed
- [ ] Load the flow editor: `pluginUiManifest` POST should return 200, not 403