### PR TITLE
feat: per-taskrun logs for dynamically-generated taskruns (core API + nested UI)

### DIFF
--- a/core/src/main/java/io/kestra/core/runners/DefaultRunContext.java
+++ b/core/src/main/java/io/kestra/core/runners/DefaultRunContext.java
@@ -506,6 +506,15 @@ public class DefaultRunContext extends RunContext {
         return dynamicWorkerTaskResult;
     }
 
+    @Override
+    public void dynamicWorkerResult(WorkerTaskResult workerTaskResult, List<DynamicTaskRunLog> logs) {
+        this.dynamicWorkerTaskResult.add(workerTaskResult);
+
+        if (logs != null && !logs.isEmpty() && workerTaskResult.getTaskRun() != null) {
+            this.logger.emitDynamicTaskRunLogs(workerTaskResult.getTaskRun(), logs);
+        }
+    }
+
     /**
      * {@inheritDoc}
      */

--- a/core/src/main/java/io/kestra/core/runners/DynamicTaskRunLog.java
+++ b/core/src/main/java/io/kestra/core/runners/DynamicTaskRunLog.java
@@ -1,0 +1,14 @@
+package io.kestra.core.runners;
+
+import org.slf4j.event.Level;
+
+/**
+ * A log line to attach to a dynamically-generated taskrun when it is registered through
+ * {@link RunContext#dynamicWorkerResult(WorkerTaskResult, java.util.List)}.
+ * <p>
+ * Callers only provide the level and message — the execution, tenant, namespace, flow, taskrun
+ * identity and attempt are filled in from the run context, and secrets are masked, so a plugin
+ * never builds (nor can tamper with) a full {@link io.kestra.core.models.executions.LogEntry}.
+ */
+public record DynamicTaskRunLog(Level level, String message) {
+}

--- a/core/src/main/java/io/kestra/core/runners/RunContext.java
+++ b/core/src/main/java/io/kestra/core/runners/RunContext.java
@@ -122,6 +122,22 @@ public abstract class RunContext implements PropertyContext {
     public abstract List<WorkerTaskResult> dynamicWorkerResults();
 
     /**
+     * Registers a dynamically-generated taskrun together with the log lines to attach to it, in a
+     * single call — the way plugins surface logs under the sub-taskruns they create at runtime
+     * (these taskruns are synthesized after their underlying work has finished, so their logs are
+     * already available at registration time).
+     * <p>
+     * The logs ride with the taskrun being registered, so they can only ever target that taskrun;
+     * their execution, tenant, namespace, flow and attempt are taken from this context (a plugin
+     * cannot target another execution or tenant) and secrets are masked. The default registers the
+     * taskrun and drops the logs, so runtimes that don't support per-taskrun logs (and older ones)
+     * still show the taskrun rather than failing the task.
+     */
+    public void dynamicWorkerResult(WorkerTaskResult workerTaskResult, List<DynamicTaskRunLog> logs) {
+        this.dynamicWorkerResult(List.of(workerTaskResult));
+    }
+
+    /**
      * Gets access to the working directory.
      *
      * @return The {@link WorkingDir}.

--- a/core/src/main/java/io/kestra/core/runners/RunContextLogger.java
+++ b/core/src/main/java/io/kestra/core/runners/RunContextLogger.java
@@ -15,6 +15,7 @@ import com.google.common.base.Throwables;
 
 import io.kestra.core.exceptions.IllegalVariableEvaluationException;
 import io.kestra.core.models.executions.LogEntry;
+import io.kestra.core.models.executions.TaskRun;
 
 import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.Logger;
@@ -211,6 +212,59 @@ public class RunContextLogger implements Supplier<org.slf4j.Logger> {
      */
     public void emitLogs(List<LogEntry> logEntries) {
         this.logEmitter.emits(logEntries);
+    }
+
+    /**
+     * Emit the log lines attached to a dynamically-generated taskrun through the regular logging
+     * pipeline, so the standard appender behaviour (secret masking, long-message splitting, level
+     * filtering, forwarding to the server log, file vs queue routing) applies natively — the only
+     * thing that changes is the taskrun the lines are attributed to.
+     * <p>
+     * When this context logs to a file ({@code logToFile}), its logs are file-only (no inline/queue
+     * display): the lines are routed through this context's own logger so they land in the same
+     * downloadable file. A flat file has no taskrun, so there is nothing to link there.
+     * <p>
+     * Otherwise the lines go through a child logger bound to a {@link LogEntry} whose execution,
+     * tenant, namespace and flow are taken from this context's bound entry — a caller cannot target
+     * another execution or tenant — with the dynamic taskrun's id and a fixed attempt 0 (these
+     * taskruns have a single attempt and the log view groups by the 0-based attempt). The level
+     * filter and the secrets known to this context are inherited so nothing else is lost.
+     */
+    public void emitDynamicTaskRunLogs(TaskRun dynamicTaskRun, List<DynamicTaskRunLog> logs) {
+        // A logToFile task logs to a file only (no inline display): route the lines through this
+        // context's own logger so they join the same downloadable file (a flat file has no taskrun
+        // to link to). Otherwise emit through a logger bound to the dynamic taskrun, so the lines
+        // are attributed to it while still passing through the regular appender pipeline.
+        org.slf4j.Logger logger = this.logToFile ? this.logger() : deriveLoggerFor(dynamicTaskRun).logger();
+
+        for (DynamicTaskRunLog log : logs) {
+            logger.atLevel(log.level()).log(log.message());
+        }
+    }
+
+    /**
+     * Derive a logger bound to a dynamically-generated taskrun: a child of this context that shares
+     * its log emitter, level filter and known secrets, but emits under the taskrun's id with a fixed
+     * attempt 0 (these taskruns have a single attempt and the log view groups by the 0-based
+     * attempt). Execution, tenant, namespace and flow are taken from this context, so a caller can
+     * only ever target this execution's taskrun — never forge a log for another execution or tenant.
+     */
+    private RunContextLogger deriveLoggerFor(TaskRun dynamicTaskRun) {
+        LogEntry boundLogEntry = LogEntry.builder()
+            .tenantId(this.logEntry.getTenantId())
+            .executionId(this.logEntry.getExecutionId())
+            .namespace(this.logEntry.getNamespace())
+            .flowId(this.logEntry.getFlowId())
+            .executionKind(this.logEntry.getExecutionKind())
+            .taskId(dynamicTaskRun.getTaskId())
+            .taskRunId(dynamicTaskRun.getId())
+            .attemptNumber(0)
+            .build();
+
+        RunContextLogger taskRunLogger = new RunContextLogger(this.logEmitter, boundLogEntry, null, false);
+        taskRunLogger.loglevel = this.loglevel; // inherit this context's level filter as-is (logback Level)
+        taskRunLogger.useSecrets.addAll(this.useSecrets);
+        return taskRunLogger;
     }
 
     private Logger initializeLogger() {

--- a/core/src/test/java/io/kestra/core/runners/RunContextLoggerTest.java
+++ b/core/src/test/java/io/kestra/core/runners/RunContextLoggerTest.java
@@ -16,6 +16,8 @@ import org.slf4j.event.Level;
 
 import io.kestra.core.models.executions.Execution;
 import io.kestra.core.models.executions.LogEntry;
+import io.kestra.core.models.executions.TaskRun;
+import io.kestra.core.models.executions.TaskRunAttempt;
 import io.kestra.core.models.flows.Flow;
 import io.kestra.core.queues.BroadcastQueueInterface;
 import io.kestra.core.queues.DispatchQueueInterface;
@@ -211,6 +213,156 @@ class RunContextLoggerTest {
 
         assertThat(queueLogs).containsExactlyInAnyOrder(e1, e2);
         assertThat(followQueueLogs).containsExactlyInAnyOrder(FollowLogEvent.from(e1), FollowLogEvent.from(e2));
+    }
+
+    @Test
+    void emitDynamicTaskRunLogs_forcesContextAndAttemptZeroAndMasks() {
+        List<LogEntry> logs = new CopyOnWriteArrayList<>();
+        logQueue.addListener(logs::add);
+
+        Flow flow = TestsUtils.mockFlow();
+        Execution execution = TestsUtils.mockExecution(flow, Map.of());
+
+        RunContextLogger runContextLogger = new RunContextLogger(
+            logEntryEmitter,
+            LogEntry.of(execution),
+            Level.TRACE,
+            false
+        );
+        runContextLogger.usedSecret("super-secret-value");
+
+        // a dynamic taskrun that (deliberately) carries a foreign execution/tenant and one attempt:
+        // the emitted entry must NOT inherit those — execution/tenant/namespace/flow come from the context.
+        TaskRun dynamicTaskRun = TaskRun.builder()
+            .id("dyn-taskrun-id")
+            .taskId("Play | Task 1")
+            .tenantId("other-tenant")
+            .executionId("other-execution")
+            .namespace("other.namespace")
+            .flowId("other-flow")
+            .attempts(List.of(TaskRunAttempt.builder().build()))
+            .build();
+
+        runContextLogger.emitDynamicTaskRunLogs(dynamicTaskRun, List.of(new DynamicTaskRunLog(Level.ERROR, "leak super-secret-value here")));
+
+        List<LogEntry> queueLogs = TestsUtils.awaitLogs(logs, 1);
+        assertThat(queueLogs).hasSize(1);
+        LogEntry emitted = queueLogs.getFirst();
+        // taskrun identity comes from the dynamic taskrun
+        assertThat(emitted.getTaskRunId()).isEqualTo("dyn-taskrun-id");
+        assertThat(emitted.getTaskId()).isEqualTo("Play | Task 1");
+        // attempt is forced to 0 (these taskruns have one attempt; the log view groups by the 0-based attempt)
+        assertThat(emitted.getAttemptNumber()).isEqualTo(0);
+        // execution/tenant/namespace/flow are forced from the context, never from the (foreign) taskrun
+        assertThat(emitted.getExecutionId()).isEqualTo(execution.getId());
+        assertThat(emitted.getExecutionId()).isNotEqualTo("other-execution");
+        assertThat(emitted.getTenantId()).isEqualTo(execution.getTenantId());
+        assertThat(emitted.getNamespace()).isEqualTo(execution.getNamespace());
+        assertThat(emitted.getFlowId()).isEqualTo(execution.getFlowId());
+        // level preserved + secret masked
+        assertThat(emitted.getLevel()).isEqualTo(Level.ERROR);
+        assertThat(emitted.getMessage()).isEqualTo("leak ****** here");
+    }
+
+    @Test
+    void emitDynamicTaskRunLogs_inheritsLevelFilter() {
+        List<LogEntry> logs = new CopyOnWriteArrayList<>();
+        logQueue.addListener(logs::add);
+
+        Flow flow = TestsUtils.mockFlow();
+        Execution execution = TestsUtils.mockExecution(flow, Map.of());
+
+        // the context filters at WARN: an INFO dynamic line must be dropped, like any task log
+        RunContextLogger runContextLogger = new RunContextLogger(
+            logEntryEmitter,
+            LogEntry.of(execution),
+            Level.WARN,
+            false
+        );
+
+        TaskRun dynamicTaskRun = TaskRun.builder()
+            .id("dyn-taskrun-id")
+            .taskId("Play | Task 1")
+            .attempts(List.of(TaskRunAttempt.builder().build()))
+            .build();
+
+        runContextLogger.emitDynamicTaskRunLogs(dynamicTaskRun, List.of(
+            new DynamicTaskRunLog(Level.INFO, "info dropped by filter"),
+            new DynamicTaskRunLog(Level.ERROR, "error kept")
+        ));
+
+        List<LogEntry> queueLogs = TestsUtils.awaitLogs(logs, 1);
+        assertThat(queueLogs).hasSize(1);
+        assertThat(queueLogs.getFirst().getLevel()).isEqualTo(Level.ERROR);
+        assertThat(queueLogs.getFirst().getMessage()).isEqualTo("error kept");
+        assertThat(queueLogs).noneMatch(l -> l.getLevel().equals(Level.INFO));
+    }
+
+    @Test
+    void emitDynamicTaskRunLogs_underLogToFileGoesToFileNotQueue() throws Exception {
+        List<LogEntry> logs = new CopyOnWriteArrayList<>();
+        logQueue.addListener(logs::add);
+
+        Flow flow = TestsUtils.mockFlow();
+        Execution execution = TestsUtils.mockExecution(flow, Map.of());
+
+        // logToFile=true: task logs are file-only, so the dynamic lines must land in the file
+        // (with masking) and never reach the inline log queue
+        RunContextLogger runContextLogger = new RunContextLogger(
+            logEntryEmitter,
+            LogEntry.of(execution),
+            Level.TRACE,
+            true
+        );
+        runContextLogger.usedSecret("super-secret-value");
+
+        TaskRun dynamicTaskRun = TaskRun.builder()
+            .id("dyn-taskrun-id")
+            .taskId("Play | Task 1")
+            .attempts(List.of(TaskRunAttempt.builder().build()))
+            .build();
+
+        runContextLogger.emitDynamicTaskRunLogs(dynamicTaskRun, List.of(
+            new DynamicTaskRunLog(Level.INFO, "to file super-secret-value")
+        ));
+
+        runContextLogger.closeLogFile();
+        String fileContent = java.nio.file.Files.readString(runContextLogger.getLogFile().toPath());
+        assertThat(fileContent).contains("to file ******");
+        // file-only: ContextAppender is not attached, so nothing reaches the inline queue
+        assertThat(logs).isEmpty();
+    }
+
+    @Test
+    void emitDynamicTaskRunLogs_seedsMDCWithDynamicTaskRunIdentity() {
+        Flow flow = TestsUtils.mockFlow();
+        Execution execution = TestsUtils.mockExecution(flow, Map.of());
+
+        // mirror exactly how emitDynamicTaskRunLogs binds the child logger for a dynamic taskrun:
+        // execution context + the dynamic taskrun's id/taskId, attempt 0
+        LogEntry boundLogEntry = LogEntry.of(execution).toBuilder()
+            .taskId("Play | Task 1")
+            .taskRunId("dyn-taskrun-id")
+            .attemptNumber(0)
+            .build();
+
+        RunContextLogger runContextLogger = new RunContextLogger(
+            logEntryEmitter,
+            boundLogEntry,
+            Level.TRACE,
+            false
+        );
+        ch.qos.logback.classic.Logger perRunLogger =
+            (ch.qos.logback.classic.Logger) runContextLogger.logger();
+
+        // the per-run MDC carries the dynamic taskrun identity (taskRunId/taskId), not just the
+        // execution context — so forwarded server logs are attributed to the dynamic taskrun too
+        assertThat(perRunLogger.getLoggerContext().getMDCAdapter().getCopyOfContextMap())
+            .containsEntry("taskRunId", "dyn-taskrun-id")
+            .containsEntry("taskId", "Play | Task 1")
+            .containsEntry("executionId", execution.getId())
+            .containsEntry("namespace", execution.getNamespace())
+            .containsEntry("flowId", execution.getFlowId());
     }
 
     @Test

--- a/executor/src/main/java/io/kestra/executor/DefaultExecutor.java
+++ b/executor/src/main/java/io/kestra/executor/DefaultExecutor.java
@@ -733,7 +733,7 @@ public class DefaultExecutor extends AbstractService implements Executor {
 
                 // update all execution followers
                 // Note that we must use 'emit' here and not emitAsync as we need to emit it inside the same transaction to avoid races,
-                // and transactions are bound to a thread. This is true for all emition of the follow execution event inside an execution lock.
+                // and transactions are bound to a thread. This is true for all emission of the follow execution event inside an execution lock.
                 this.followExecutionEventQueue.emit(new FollowExecutionEvent(executor.getExecution(), ExecutionEventType.TERMINATED));
             } else {
                 ExecutionEvent event = new ExecutionEvent(executor.getExecution(), ExecutionEventType.UPDATED);

--- a/ui/packages/topology/src/nodes/TaskNode.vue
+++ b/ui/packages/topology/src/nodes/TaskNode.vue
@@ -119,6 +119,7 @@
     interface TaskRun {
         id: string
         taskId: string;
+        parentTaskRunId?: string;
         state: {
             current: [string, string];
             duration?: string;
@@ -225,6 +226,16 @@
         return taskRunList.value.filter(
             (t: TaskRun) => t.taskId === Utils.afterLastDot(props.data.node.uid),
         )
+    })
+
+    // The task's own taskruns plus any dynamically-generated child taskruns (e.g. Ansible
+    // plays/tasks) so "show task logs" surfaces their logs too, not just the task's root logs.
+    const taskRunsWithDynamicChildren = computed(() => {
+        const ids = new Set(taskRuns.value.map((t: TaskRun) => t.id))
+        const children = taskRunList.value.filter(
+            (t: TaskRun) => t.parentTaskRunId && ids.has(t.parentTaskRunId),
+        )
+        return [...taskRuns.value, ...children]
     })
 
     const state = computed(() => {
@@ -341,7 +352,7 @@
                 key: "logs",
                 label: t("show task logs"),
                 icon: TextBoxSearch,
-                onClick: () => emit(EVENTS.SHOW_LOGS, {id: taskId.value, execution: taskExecution.value, taskRuns: taskRuns.value}),
+                onClick: () => emit(EVENTS.SHOW_LOGS, {id: taskId.value, execution: taskExecution.value, taskRuns: taskRunsWithDynamicChildren.value}),
             })
         }
         if (taskExecution.value) {

--- a/ui/src/components/executions/Gantt.vue
+++ b/ui/src/components/executions/Gantt.vue
@@ -99,7 +99,10 @@
                                                 <ChevronRight v-if="!selectedTaskRuns.includes(item.id)" />
                                                 <ChevronDown v-else />
                                             </div>
-                                            <div class="task-label">
+                                            <div
+                                                class="task-label"
+                                                :style="{'--depth': item.depth || 0}"
+                                            >
                                                 <div v-if="taskTypeByTaskRunId[item.id]" class="task-icon-box">
                                                     <KsTaskIcon :cls="taskTypeByTaskRunId[item.id]" onlyIcon :icons="pluginsStore.icons" />
                                                 </div>
@@ -858,6 +861,7 @@
                     display: flex;
                     align-items: center;
                     gap: var(--ks-spacing-4);
+                    padding-left: calc(var(--depth, 0) * var(--ks-spacing-5));
 
                     code {
                         color: var(--ks-text-primary);

--- a/ui/src/components/executions/TaskRunLine.vue
+++ b/ui/src/components/executions/TaskRunLine.vue
@@ -1,5 +1,9 @@
 <template>
-    <div v-if="!hideHeader" class="taskrun-header">
+    <div
+        v-if="!hideHeader"
+        class="taskrun-header"
+        :style="{'--depth': depth}"
+    >
         <div>
             <KsIcon
                 v-if="!taskRunId && shouldDisplayChevron(currentTaskRun)"
@@ -135,6 +139,7 @@
         logs?: any[]
         filter?: string
         hideHeader?: boolean
+        depth?: number
     }
 
     const props = withDefaults(defineProps<Props>(), {
@@ -146,6 +151,7 @@
         logs: () => [],
         filter: "",
         hideHeader: false,
+        depth: 0,
     })
 
     const emit = defineEmits<{
@@ -247,6 +253,7 @@
 
     .taskrun-header {
         background-color: var(--ks-bg-surface);
+        padding-left: calc(var(--ks-spacing-4) + var(--depth, 0) * var(--ks-spacing-5));
 
         .task-icon {
             width: 36px;

--- a/ui/src/components/logs/TaskRunDetails.vue
+++ b/ui/src/components/logs/TaskRunDetails.vue
@@ -23,6 +23,7 @@
                 <KsCard class="attempt-wrapper" shadow="never" :class="{'attempt-wrapper--transparent': hideTaskHeader}">
                     <TaskRunLine
                         :currentTaskRun="currentTaskRun"
+                        :depth="asTaskRun(currentTaskRun).depth"
                         :followedExecution="followedExecution"
                         :flow="flow"
                         :forcedAttemptNumber="forcedAttemptNumber"
@@ -216,7 +217,7 @@
                                         :filter="filter"
                                         :allowAutoExpandSubflows="false"
                                         :targetExecutionId="
-                                            asTaskRun(currentTaskRun).outputs.executionId
+                                            asTaskRun(currentTaskRun).outputs?.executionId
                                         "
                                         :class="
                                             $el.classList.contains('even')
@@ -287,7 +288,7 @@
     import * as Utils from "../../utils/utils"
     import * as LogUtils from "../../utils/logs"
     import throttle from "lodash/throttle"
-    import {useClient} from "@kestra-io/kestra-sdk"
+    import {useClient, type TaskRun, type TaskRunAttempt} from "@kestra-io/kestra-sdk"
 
     // Recursive component - self reference
     import TaskRunDetails from "./TaskRunDetails.vue"
@@ -296,9 +297,13 @@
 
     const $http = useClient()
 
+    // The UI taskrun carries a computed `depth` (for nesting) and subflow `outputs`,
+    // neither of which the SDK TaskRun type models.
+    type TaskRunWithDepth = TaskRun & { depth: number; outputs?: Record<string, any> }
+
     // Cast helper for DynamicScroller slot items which lose type info
-    function asTaskRun(item: unknown): any { // FIXME: any
-        return item
+    function asTaskRun(item: unknown): TaskRunWithDepth {
+        return item as TaskRunWithDepth
     }
 
     const coreStore = useCoreStore()
@@ -376,23 +381,53 @@
             : targetExecution.value,
     )
 
-    const currentTaskRuns = computed(() =>
-        (followedExecution.value?.taskRunList?.filter((tr: any) => // FIXME: any
-            props.taskRunId ? tr.id === props.taskRunId : true,
-        ) ?? []),
-    )
+    const currentTaskRuns = computed<TaskRunWithDepth[]>(() => {
+        const taskRunList: TaskRun[] = followedExecution.value?.taskRunList ?? []
+
+        if (props.taskRunId) {
+            return taskRunList
+                .filter((tr) => tr.id === props.taskRunId)
+                .map((tr) => ({...tr, depth: 0}))
+        }
+
+        // Order taskruns parent → child and annotate depth, so dynamically-generated taskruns
+        // (e.g. each Ansible play/task) render indented under their parent taskrun.
+        const byId: Record<string, TaskRun> = Object.fromEntries(taskRunList.map((tr) => [tr.id, tr]))
+        const childrenByParent: Record<string, TaskRun[]> = {}
+        const roots: TaskRun[] = []
+        for (const tr of taskRunList) {
+            if (tr.parentTaskRunId && byId[tr.parentTaskRunId]) {
+                (childrenByParent[tr.parentTaskRunId] ??= []).push(tr)
+            } else {
+                roots.push(tr)
+            }
+        }
+
+        const ordered: TaskRunWithDepth[] = []
+        const walk = (nodes: TaskRun[], depth: number) => {
+            for (const node of nodes) {
+                ordered.push({...node, depth})
+                const children = childrenByParent[node.id]
+                if (children) {
+                    walk(children, depth + 1)
+                }
+            }
+        }
+        walk(roots, 0)
+        return ordered
+    })
 
     const taskRunById = computed(() =>
         Object.fromEntries(
-            currentTaskRuns.value.map((taskRun: any) => [taskRun.id, taskRun]), // FIXME: any
+            currentTaskRuns.value.map((taskRun) => [taskRun.id, taskRun]),
         ),
     )
 
     const logsWithIndexByAttemptUid = computed(() => {
-        const logFilesWrappers = currentTaskRuns.value.flatMap((taskRun: any) => // FIXME: any
+        const logFilesWrappers = currentTaskRuns.value.flatMap((taskRun) =>
             attempts(taskRun)
-                .filter((attempt: any) => attempt.logFile !== undefined) // FIXME: any
-                .map((attempt: any, attemptNumber: number) => ({ // FIXME: any
+                .filter((attempt) => attempt.logFile !== undefined)
+                .map((attempt, attemptNumber: number) => ({
                     logFile: attempt.logFile,
                     taskRunId: taskRun.id,
                     attemptNumber,
@@ -512,7 +547,7 @@
 
     const currentTaskRunsLogIndicesByLevel = computed(() =>
         currentTaskRuns.value.reduce(
-            (indicesByLevel: Record<string, string[]>, taskRun: any, taskRunIndex: number) => { // FIXME: any
+            (indicesByLevel: Record<string, string[]>, taskRun, taskRunIndex: number) => {
                 if (shouldDisplayLogs(taskRun)) {
                     const currentTaskRunLogs =
                         logsWithIndexByAttemptUid.value[
@@ -592,7 +627,7 @@
         (taskRuns) => {
             // by default we preselect the last attempt for each task run
             selectedAttemptNumberByTaskRunId.value = Object.fromEntries(
-                taskRuns.map((taskRun: any) => [ // FIXME: any
+                taskRuns.map((taskRun) => [
                     taskRun.id,
                     props.forcedAttemptNumber ??
                         attempts(taskRun).length - 1,
@@ -770,7 +805,7 @@
             setTimeout(() => autoExpandBasedOnSettings(), 50)
             return
         }
-        currentTaskRuns.value.forEach((taskRun: any) => { // FIXME: any
+        currentTaskRuns.value.forEach((taskRun) => {
             if (isSubflow(taskRun) && !props.allowAutoExpandSubflows) {
                 return
             }
@@ -789,7 +824,7 @@
         })
     }
 
-    function shouldDisplayLogs(taskRun: any): boolean { // FIXME: any
+    function shouldDisplayLogs(taskRun: TaskRun): boolean {
         const uid = attemptUid(
             taskRun.id,
             selectedAttemptNumberByTaskRunId.value[taskRun.id],
@@ -872,12 +907,12 @@
         })
     }
 
-    function isSubflow(taskRun: any): boolean { // FIXME: any
+    function isSubflow(taskRun: TaskRunWithDepth): boolean {
         return taskRun?.outputs?.executionId
     }
 
-    function shouldDisplaySubflow(taskRunIndex: number, taskRun: any): boolean { // FIXME: any
-        const subflowExecutionId = taskRun.outputs.executionId
+    function shouldDisplaySubflow(taskRunIndex: number, taskRun: TaskRunWithDepth): boolean {
+        const subflowExecutionId = taskRun.outputs?.executionId
         const index = shownSubflowsIds.value.findIndex(
             (item) => item.subflowExecutionId === subflowExecutionId,
         )
@@ -900,7 +935,7 @@
             return
         }
 
-        shownAttemptsUid.value = currentTaskRuns.value.map((taskRun: any) => // FIXME: any
+        shownAttemptsUid.value = currentTaskRuns.value.map((taskRun) =>
             attemptUid(
                 taskRun.id,
                 selectedAttemptNumberByTaskRunId.value[taskRun.id] ?? 0,
@@ -915,7 +950,7 @@
 
     function expandSubflows() {
         if (
-            currentTaskRuns.value.some((taskRun: any) => isSubflow(taskRun)) // FIXME: any
+            currentTaskRuns.value.some((taskRun) => isSubflow(taskRun))
         ) {
             const subflowLogsElements = Object.values(
                 subflowTaskRunDetailsRefs.value,
@@ -944,7 +979,7 @@
                 followedExecution.value?.state?.current,
             )
         ) {
-            currentTaskRuns.value.forEach((taskRun: any) => { // FIXME: any
+            currentTaskRuns.value.forEach((taskRun) => {
                 if (
                     taskRun.state.current === State.FAILED ||
                     taskRun.state.current === State.RUNNING
@@ -966,7 +1001,7 @@
         }
     }
 
-    function uniqueTaskRunDisplayFilter(currentTaskRun: any): boolean { // FIXME: any
+    function uniqueTaskRunDisplayFilter(currentTaskRun: TaskRun): boolean {
         return !(props.taskRunId && props.taskRunId !== currentTaskRun.id)
     }
 
@@ -1000,7 +1035,7 @@
             })
     }
 
-    function attempts(taskRun: any): any[] { // FIXME: any
+    function attempts(taskRun: TaskRun): TaskRunAttempt[] {
         if (
             followedExecution.value.state.current === State.RUNNING ||
             props.forcedAttemptNumber === undefined
@@ -1035,7 +1070,7 @@
             newDisplayedAttemptNumber
     }
 
-    function taskType(taskRun: any): string | undefined { // FIXME: any
+    function taskType(taskRun: TaskRun | undefined): string | undefined {
         if (!taskRun) return undefined
 
         const task = FlowUtils.findTaskById(flow.value, taskRun?.taskId)


### PR DESCRIPTION
Plugins that synthesize dynamic taskruns via `dynamicWorkerResult` (e.g. the Ansible and dbt plugins, building one taskrun per unit of work) had no way to attach logs to them, so all the per-unit output landed on the parent task's root taskrun — and the execution views rendered the dynamic taskruns flat.

Core:
- Adds `RunContext.dynamicWorkerResult(WorkerTaskResult, List<DynamicTaskRunLog>)` — registers a dynamic taskrun together with its log lines in a single call.
- The logs ride with the taskrun being registered, so they can only target it; `executionId`/`tenantId`/`namespace`/`flow` are taken from the run context (a plugin can't target another execution or tenant), the attempt is fixed to 0, and secrets are masked — plugins never build (nor can forge) a `LogEntry`.
- The default registers the taskrun and drops the logs, so runtimes that don't support per-taskrun logs (and older ones) still show the taskrun.
- Adds the `DynamicTaskRunLog(Level, String)` record and `RunContextLogger.emitDynamicTaskRunLogs`; the appender's secret masking is extracted into a shared helper. Covered by `RunContextLoggerTest`.

UI — nest dynamic taskruns under their parent (they carry `parentTaskRunId`):
- Gantt: indent child rows by depth.
- Logs: order taskruns parent → child and indent children.
- Topology "Show task logs": include the node's dynamic child taskruns so their logs show alongside the task's own.

Companion to the plugin-ansible PR that uses this API for Ansible.