### PR TITLE
fix(topology): add @click.stop to show-more-details Panel

### DIFF
--- a/ui/packages/topology/src/Topology.vue
+++ b/ui/packages/topology/src/Topology.vue
@@ -10,7 +10,7 @@
     >
         <Background :patternColor="cssVariable('--ks-topology-bg')" />
 
-        <Panel v-if="showDetailsToggle" position="top-right">
+        <Panel v-if="showDetailsToggle" position="top-right" @click.stop>
             <KsSwitch v-model="showExtraDetails" :activeText="$t('show more details')" size="small"/>
         </Panel>
 


### PR DESCRIPTION
## Summary

- The `KsSwitch` (\"show more details\" toggle) inside the VueFlow `Panel` was missing `@click.stop`
- All `ControlButton` elements in the same file already carry `@click.stop`; the Panel was the only outlier
- Clicks on the switch bubbled into the VueFlow canvas layer

## Test plan

- [ ] Open an execution with a task runner that has extra topology details (e.g. AWS Batch runner)
- [ ] Toggle the \"show more details\" switch in the top-right of the topology panel
- [ ] Verify the toggle works and no unintended side-effects occur (no navigation, no node selection)