### PR TITLE
fix(executions): correct Postgres duration sort for executions over one minute

### DIFF
--- a/core/src/test/java/io/kestra/core/repositories/AbstractExecutionRepositoryTest.java
+++ b/core/src/test/java/io/kestra/core/repositories/AbstractExecutionRepositoryTest.java
@@ -1210,6 +1210,60 @@ public abstract class AbstractExecutionRepositoryTest {
     }
 
     @Test
+    protected void findShouldSortByTotalDurationAcrossMinuteBoundary() {
+        // given - two terminated executions whose durations straddle the one-minute boundary.
+        // This guards against backends that only compare the sub-minute part of the duration
+        // (e.g. the former Postgres EXTRACT(MILLISECONDS FROM interval) generated column), which
+        // would sort the multi-minute execution below the sub-minute one.
+        var tenant = TestsUtils.randomTenant(this.getClass().getSimpleName());
+        final Instant clock = Instant.now();
+
+        var longExecution = Execution.builder()
+            .id("longExecution__" + FriendlyId.createFriendlyId())
+            .namespace(NAMESPACE)
+            .tenantId(tenant)
+            .flowId(FLOW)
+            .flowRevision(1)
+            .state(State.of(
+                State.Type.SUCCESS,
+                List.of(
+                    new State.History(State.Type.CREATED, clock),
+                    new State.History(State.Type.SUCCESS, clock.plus(Duration.ofMinutes(5)))
+                )
+            )).build();
+        executionRepository.save(longExecution);
+
+        var shortExecution = Execution.builder()
+            .id("shortExecution__" + FriendlyId.createFriendlyId())
+            .namespace(NAMESPACE)
+            .tenantId(tenant)
+            .flowId(FLOW)
+            .flowRevision(1)
+            .state(State.of(
+                State.Type.SUCCESS,
+                List.of(
+                    new State.History(State.Type.CREATED, clock),
+                    new State.History(State.Type.SUCCESS, clock.plus(Duration.ofSeconds(20)))
+                )
+            )).build();
+        executionRepository.save(shortExecution);
+
+        // when / then
+        List<QueryFilter> emptyFilters = null;
+        var ascSort = createSortLikeInControllers(List.of("state.duration:asc"), executionRepository.sortMapping());
+        assertThat(executionRepository.find(Pageable.from(ascSort), tenant, emptyFilters).stream())
+            .as("shortest total duration first when sorting ascending")
+            .map(Execution::getId)
+            .containsExactly(shortExecution.getId(), longExecution.getId());
+
+        var descSort = createSortLikeInControllers(List.of("state.duration:desc"), executionRepository.sortMapping());
+        assertThat(executionRepository.find(Pageable.from(descSort), tenant, emptyFilters).stream())
+            .as("longest total duration first when sorting descending")
+            .map(Execution::getId)
+            .containsExactly(longExecution.getId(), shortExecution.getId());
+    }
+
+    @Test
     protected void findShouldOrderByStartDateAsc() {
         // given
         var tenant = TestsUtils.randomTenant(this.getClass().getSimpleName());

--- a/jdbc-postgres/src/main/resources/migrations/postgres/V1_57__fix_state_duration_total_millis.sql
+++ b/jdbc-postgres/src/main/resources/migrations/postgres/V1_57__fix_state_duration_total_millis.sql
@@ -1,0 +1,20 @@
+-- Fix the executions.state_duration generated column so it stores the TOTAL execution
+-- duration in milliseconds.
+--
+-- The previous expression used EXTRACT(MILLISECONDS FROM interval), which only returns the
+-- seconds field of the interval (0-59999) and silently drops minutes and hours. As a result,
+-- sorting executions by duration was wrong for any execution lasting >= 1 minute (a 7m run
+-- could sort below a 3m run). EXTRACT(EPOCH FROM interval) returns the total number of seconds
+-- across all interval fields, so multiplying by 1000 yields the correct total milliseconds.
+--
+-- state_duration is a STORED generated column, whose expression cannot be altered in place, so
+-- the column is dropped and re-created. Re-creation backfills (recomputes) every existing row.
+-- This takes an ACCESS EXCLUSIVE lock on the executions table for the duration of the rewrite.
+-- The column is kept nullable (V1_48 dropped NOT NULL: running executions have no duration).
+DROP INDEX IF EXISTS executions_state_duration;
+
+ALTER TABLE executions DROP COLUMN IF EXISTS state_duration;
+
+ALTER TABLE executions ADD COLUMN IF NOT EXISTS state_duration BIGINT GENERATED ALWAYS AS ((ROUND(EXTRACT(EPOCH FROM PARSE_ISO8601_DURATION(value #>> '{state, duration}')) * 1000))::bigint) STORED;
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS executions_state_duration ON executions ("deleted", "tenant_id", "state_duration");


### PR DESCRIPTION
## What
Fix sorting executions by **Duration** on PostgreSQL. The `executions.state_duration` generated column used `EXTRACT(MILLISECONDS FROM interval)`, which returns only the seconds field of the interval (0–59999) and drops minutes/hours. A `7m59.45s` execution was stored as `59450` instead of `479450`, so duration sort was wrong for any execution ≥ 1 minute. Replaced with `EXTRACT(EPOCH FROM interval) * 1000` (total milliseconds).

PostgreSQL only — MySQL and H2 already read the value as total seconds. Distinct from #11593/#13132 (NULL duration for running execs), which is unrelated to this.

Closes #16908

## How
Add Flyway migration **V1_57**. Column kept nullable (matches V1_48).

`state_duration` is a `STORED` generated column, so the migration drops and re-creates it (backfilling all rows; takes a brief `ACCESS EXCLUSIVE` lock on large tables) and recreates the `executions_state_duration` index.

## Tests
Added `findShouldSortByTotalDurationAcrossMinuteBoundary` asserting a 5-minute execution sorts above a 20-second one (and vice versa). Verified passing on Postgres and H2; confirmed it fails without the fix.

---
Companion PRs: develop + releases/v1.3.x + releases/v1.0.x.
