### PR TITLE
fix(triggers): make JDBC trigger create() idempotent

### DIFF
--- a/jdbc-h2/src/test/java/io/kestra/repository/h2/H2JdbcTriggerRepositoryTest.java
+++ b/jdbc-h2/src/test/java/io/kestra/repository/h2/H2JdbcTriggerRepositoryTest.java
@@ -1,0 +1,6 @@
+package io.kestra.repository.h2;
+
+import io.kestra.jdbc.repository.AbstractJdbcTriggerRepositoryTest;
+
+public class H2JdbcTriggerRepositoryTest extends AbstractJdbcTriggerRepositoryTest {
+}

--- a/jdbc-mysql/src/test/java/io/kestra/repository/mysql/MysqlJdbcTriggerRepositoryTest.java
+++ b/jdbc-mysql/src/test/java/io/kestra/repository/mysql/MysqlJdbcTriggerRepositoryTest.java
@@ -1,0 +1,6 @@
+package io.kestra.repository.mysql;
+
+import io.kestra.jdbc.repository.AbstractJdbcTriggerRepositoryTest;
+
+public class MysqlJdbcTriggerRepositoryTest extends AbstractJdbcTriggerRepositoryTest {
+}

--- a/jdbc-postgres/src/test/java/io/kestra/repository/postgres/PostgresJdbcTriggerRepositoryTest.java
+++ b/jdbc-postgres/src/test/java/io/kestra/repository/postgres/PostgresJdbcTriggerRepositoryTest.java
@@ -1,0 +1,6 @@
+package io.kestra.repository.postgres;
+
+import io.kestra.jdbc.repository.AbstractJdbcTriggerRepositoryTest;
+
+public class PostgresJdbcTriggerRepositoryTest extends AbstractJdbcTriggerRepositoryTest {
+}

--- a/jdbc/src/main/java/io/kestra/jdbc/repository/AbstractJdbcTriggerRepository.java
+++ b/jdbc/src/main/java/io/kestra/jdbc/repository/AbstractJdbcTriggerRepository.java
@@ -8,6 +8,7 @@ import java.util.stream.Collectors;
 
 import org.jooq.*;
 import org.jooq.Record;
+import org.jooq.exception.IntegrityConstraintViolationException;
 import org.jooq.impl.DSL;
 
 import io.kestra.core.models.QueryFilter;
@@ -130,18 +131,27 @@ public abstract class AbstractJdbcTriggerRepository extends AbstractJdbcCrudRepo
     }
 
     public Trigger create(Trigger trigger) {
-        return this.jdbcRepository
-            .getDslContextWrapper()
-            .transactionResult(configuration ->
-            {
-                DSL.using(configuration)
-                    .insertInto(this.jdbcRepository.getTable())
-                    .set(KEY_FIELD, this.jdbcRepository.key(trigger))
-                    .set(this.jdbcRepository.persistFields(trigger))
-                    .execute();
+        // Idempotent insert: the trigger row may already exist when this runs. The scheduler creates triggers on every
+        // flow change/import (initializedTriggers), while the trigger-evaluation path concurrently upserts the same row
+        // via save(). A plain INSERT then collides on the primary key (triggers_pkey). We let that insert roll back its
+        // own transaction and treat the violation as a no-op, so create() means "insert this trigger unless it already
+        // exists" without clobbering the existing row (which save()/upsert would). The catch is outside the transaction
+        // on purpose: catching it inside would leave a Postgres transaction in an aborted state.
+        try {
+            this.jdbcRepository
+                .getDslContextWrapper()
+                .transactionResult(configuration ->
+                    DSL.using(configuration)
+                        .insertInto(this.jdbcRepository.getTable())
+                        .set(KEY_FIELD, this.jdbcRepository.key(trigger))
+                        .set(this.jdbcRepository.persistFields(trigger))
+                        .execute()
+                );
+        } catch (IntegrityConstraintViolationException ignored) {
+            // row already exists (created concurrently) — create() is idempotent
+        }
 
-                return trigger;
-            });
+        return trigger;
     }
 
     @Override

--- a/jdbc/src/test/java/io/kestra/jdbc/repository/AbstractJdbcTriggerRepositoryTest.java
+++ b/jdbc/src/test/java/io/kestra/jdbc/repository/AbstractJdbcTriggerRepositoryTest.java
@@ -1,0 +1,49 @@
+package io.kestra.jdbc.repository;
+
+import java.time.ZonedDateTime;
+
+import org.junit.jupiter.api.Test;
+
+import io.kestra.core.junit.annotations.KestraTest;
+import io.kestra.core.models.triggers.Trigger;
+import io.kestra.core.utils.IdUtils;
+
+import jakarta.inject.Inject;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+@KestraTest
+public abstract class AbstractJdbcTriggerRepositoryTest {
+
+    @Inject
+    protected AbstractJdbcTriggerRepository triggerRepository;
+
+    /**
+     * Guards against the {@code duplicate key value violates unique constraint "triggers_pkey"} error seen in
+     * production when a flow holding a running (realtime) trigger is re-imported.
+     * <p>
+     * The trigger row is written by two paths that share the same primary key
+     * ({@code tenant_namespace_flowId_triggerId}): the trigger-evaluation path persists it through an upsert
+     * ({@link AbstractJdbcTriggerRepository#save}), while the scheduler initialization path
+     * ({@code AbstractScheduler.initializedTriggers}) inserts it through {@link AbstractJdbcTriggerRepository#create}.
+     * When the row already exists, {@code create} must be idempotent (a no-op) rather than collide on the primary key.
+     * <p>
+     * The production failure is a race between these two writers, but the underlying defect — a non-idempotent
+     * {@code create} — is deterministic and needs no concurrency to reproduce.
+     */
+    @Test
+    protected void shouldNotThrowWhenCreatingTriggerThatAlreadyExists() {
+        // Given — a trigger row already persisted, as the trigger-evaluation/realtime path does via an upsert
+        Trigger trigger = Trigger.builder()
+            .tenantId(IdUtils.create())
+            .namespace("io.kestra.unittest")
+            .flowId("flowId")
+            .triggerId("triggerId")
+            .nextExecutionDate(ZonedDateTime.now())
+            .build();
+        triggerRepository.save(trigger);
+
+        // When / Then — the scheduler init path re-creates the same key; create() must ignore the existing row.
+        assertDoesNotThrow(() -> triggerRepository.create(trigger));
+    }
+}


### PR DESCRIPTION
The scheduler inserts a trigger row with a plain INSERT on every flow import (initializedTriggers) while the evaluation path concurrently upserts the same key via save(), causing "duplicate key ... triggers_pkey". Let the failing INSERT roll back and ignore the violation outside the transaction (catching inside would abort a Postgres transaction), so create() means "insert unless present" without clobbering a running trigger's row.

Add AbstractJdbcTriggerRepositoryTest (H2/Postgres/MySQL).