### PR TITLE
fix(triggers): fence realtime lock release with a dispatch epoch

### DIFF
--- a/core/src/main/java/io/kestra/core/runners/WorkerTrigger.java
+++ b/core/src/main/java/io/kestra/core/runners/WorkerTrigger.java
@@ -27,6 +27,9 @@ public class WorkerTrigger extends WorkerJob {
     @NotNull
     private WorkerTriggerData data;
 
+    /** Dispatch generation, set by the scheduler, echoed back to fence lock-releasing events. */
+    private long dispatchEpoch;
+
     /**
      * {@inheritDoc}
      */

--- a/core/src/main/java/io/kestra/core/runners/WorkerTriggerRunning.java
+++ b/core/src/main/java/io/kestra/core/runners/WorkerTriggerRunning.java
@@ -26,6 +26,8 @@ public class WorkerTriggerRunning extends WorkerJobRunning {
     @NotNull
     private WorkerTriggerData data;
 
+    private long dispatchEpoch;
+
     /**
      * {@inheritDoc}
      */
@@ -43,6 +45,7 @@ public class WorkerTriggerRunning extends WorkerJobRunning {
         return WorkerTriggerRunning.builder()
             .trigger(workerTrigger.getTrigger())
             .data(workerTrigger.getData())
+            .dispatchEpoch(workerTrigger.getDispatchEpoch())
             .workerInstance(workerInstance)
             .build();
     }

--- a/core/src/main/java/io/kestra/core/scheduler/events/TriggerExecutionTerminated.java
+++ b/core/src/main/java/io/kestra/core/scheduler/events/TriggerExecutionTerminated.java
@@ -13,10 +13,15 @@ public record TriggerExecutionTerminated(
     TriggerId id,
     String executionId,
     State.Type executionState,
+    long dispatchEpoch,
     Instant timestamp,
     EventId eventId) implements TriggerEvent {
 
     public TriggerExecutionTerminated(TriggerId id, String executionId, State.Type executionState) {
-        this(id, executionId, executionState, Instant.now(), EventId.create());
+        this(id, executionId, executionState, 0L);
+    }
+
+    public TriggerExecutionTerminated(TriggerId id, String executionId, State.Type executionState, long dispatchEpoch) {
+        this(id, executionId, executionState, dispatchEpoch, Instant.now(), EventId.create());
     }
 }

--- a/core/src/main/java/io/kestra/core/scheduler/events/TriggerWorkerLost.java
+++ b/core/src/main/java/io/kestra/core/scheduler/events/TriggerWorkerLost.java
@@ -14,10 +14,11 @@ import io.kestra.core.models.triggers.TriggerId;
 public record TriggerWorkerLost(
     TriggerId id,
     String workerUid,
+    long dispatchEpoch,
     Instant timestamp,
     EventId eventId) implements TriggerEvent {
 
-    public TriggerWorkerLost(TriggerId id, String workerUid) {
-        this(id, workerUid, Instant.now(), EventId.create());
+    public TriggerWorkerLost(TriggerId id, String workerUid, long dispatchEpoch) {
+        this(id, workerUid, dispatchEpoch, Instant.now(), EventId.create());
     }
 }

--- a/core/src/main/java/io/kestra/core/scheduler/model/TriggerState.java
+++ b/core/src/main/java/io/kestra/core/scheduler/model/TriggerState.java
@@ -48,6 +48,7 @@ public final class TriggerState implements TriggerId {
     private final EventId lastEventId;
     private final Instant lastTriggeredDate;
     private final String executionId;
+    private final long dispatchEpoch;
 
     @JsonProperty
     public Long getNextEvaluationEpoch() {
@@ -102,7 +103,8 @@ public final class TriggerState implements TriggerId {
             type,
             null,
             null,
-            null
+            null,
+            0L
         );
     }
 
@@ -319,6 +321,18 @@ public final class TriggerState implements TriggerId {
             .build();
     }
 
+    /**
+     * Bumps the dispatch generation, marking a new dispatch to a worker.
+     *
+     * @param clock the scheduler clock.
+     * @return a new {@link TriggerState}
+     */
+    public TriggerState nextDispatchEpoch(final Clock clock) {
+        return update(clock)
+            .dispatchEpoch(dispatchEpoch + 1)
+            .build();
+    }
+
     private Backfill getBackFillForNextEvaluationDate(final Instant nextEvaluationDate) {
         final ZonedDateTime localNextEvaluationDate = toZonedDateTime(nextEvaluationDate);
         if (backfill != null && !backfill.getPaused()) {
@@ -353,7 +367,8 @@ public final class TriggerState implements TriggerId {
             .type(type)
             .lastEventId(lastEventId)
             .lastTriggeredDate(lastTriggeredDate)
-            .executionId(executionId);
+            .executionId(executionId)
+            .dispatchEpoch(dispatchEpoch);
     }
 
     // Lombok hack to properly generate Javadoc

--- a/core/src/main/java/io/kestra/core/worker/models/WorkerTriggerResult.java
+++ b/core/src/main/java/io/kestra/core/worker/models/WorkerTriggerResult.java
@@ -16,12 +16,14 @@ import jakarta.annotation.Nullable;
  * @param id the trigger id.
  * @param type the trigger type.
  * @param evaluation the lightweight trigger evaluation result, or {@code null} if the trigger did not match.
+ * @param dispatchEpoch the dispatch generation echoed from the {@link WorkerTrigger}.
  */
 public record WorkerTriggerResult(
     @JsonProperty
     @JsonDeserialize(as = TriggerId.Default.class) TriggerId id,
     @JsonProperty TriggerType type,
-    @JsonProperty @Nullable TriggerEvaluationResult evaluation) {
+    @JsonProperty @Nullable TriggerEvaluationResult evaluation,
+    @JsonProperty long dispatchEpoch) {
 
     /**
      * Create a new {@link WorkerTriggerResult} from a {@link WorkerTrigger} and a {@link TriggerEvaluationResult}.
@@ -34,7 +36,8 @@ public record WorkerTriggerResult(
         return new WorkerTriggerResult(
             trigger.triggerId(),
             TriggerType.from(trigger.getTrigger()),
-            evaluation
+            evaluation,
+            trigger.getDispatchEpoch()
         );
     }
 }

--- a/executor/src/main/java/io/kestra/executor/DefaultServiceLivenessCoordinator.java
+++ b/executor/src/main/java/io/kestra/executor/DefaultServiceLivenessCoordinator.java
@@ -447,7 +447,7 @@ public class DefaultServiceLivenessCoordinator extends AbstractServiceLivenessTa
             workerTriggerRunning.getTrigger().getId()
         );
         workerJobRunningStateStore.deleteByKey(txContext, workerTriggerRunning.uid());
-        triggerEventQueue.send(new TriggerWorkerLost(triggerId, workerTriggerRunning.getWorkerInstance().uid()));
+        triggerEventQueue.send(new TriggerWorkerLost(triggerId, workerTriggerRunning.getWorkerInstance().uid(), workerTriggerRunning.getDispatchEpoch()));
         Logs.logTrigger(
             triggerId,
             Level.WARN,

--- a/scheduler/src/main/java/io/kestra/scheduler/TriggerEventHandler.java
+++ b/scheduler/src/main/java/io/kestra/scheduler/TriggerEventHandler.java
@@ -251,30 +251,57 @@ public class TriggerEventHandler {
      * @param event the event.
      */
     void onTriggerExecutionTerminated(Clock clock, TriggerExecutionTerminated event) {
+        Optional<TriggerState> maybeState = triggerStateStore.findById(event.id());
+        if (maybeState.isEmpty()) {
+            Logs.logTrigger(event.id(), Level.WARN, "Cannot process event {}. Cause: Trigger state not found.", event.type());
+            return;
+        }
+
+        if (TriggerType.REALTIME.equals(maybeState.get().getType())) {
+            onRealtimeExecutionTerminated(clock, event, maybeState.get());
+            return;
+        }
+
         findTriggerState(event).ifPresent(state ->
-        {
-            // A running realtime trigger emits many executions whose terminations must not release the
-            // trigger's lock — unlocking here would resubmit a trigger that is still running on a worker.
-            // The only expected termination signal for a realtime trigger is the FAILED execution
-            // produced when the trigger could not be started.
-            if (TriggerType.REALTIME.equals(state.getType()) && !State.Type.FAILED.equals(event.executionState())) {
-                Logs.logTrigger(
-                    event.id(),
-                    Level.WARN,
-                    "Ignoring event '{}' for execution '{}' in state '{}'. Cause: a realtime trigger is only unlocked by a FAILED trigger-creation execution.",
-                    event.type(),
-                    event.executionId(),
-                    event.executionState()
-                );
-                return;
-            }
             triggerStateStore.save(
                 state
                     .lastEventId(clock, event.eventId())
                     .locked(clock, false)
                     .updateOnExecutionTerminated(clock, event.executionState())
+            )
+        );
+    }
+
+    /**
+     * A realtime termination releases the lock, so it is fenced by the dispatch epoch rather than
+     * event-id ordering: across the independent event producers, a causally-later termination can
+     * carry a lower event id and would otherwise be wrongly skipped, leaving the trigger locked.
+     */
+    private void onRealtimeExecutionTerminated(Clock clock, TriggerExecutionTerminated event, TriggerState state) {
+        // A running realtime trigger emits many executions whose terminations must not release the
+        // trigger's lock — unlocking here would resubmit a trigger that is still running on a worker.
+        // The only expected termination signal for a realtime trigger is the FAILED execution
+        // produced when the trigger could not be started.
+        if (!State.Type.FAILED.equals(event.executionState())) {
+            Logs.logTrigger(
+                event.id(),
+                Level.WARN,
+                "Ignoring event '{}' for execution '{}' in state '{}'. Cause: a realtime trigger is only unlocked by a FAILED trigger-creation execution.",
+                event.type(),
+                event.executionId(),
+                event.executionState()
             );
-        });
+            return;
+        }
+        // Stale termination from a superseded dispatch: a newer one already took the lock.
+        if (event.dispatchEpoch() < state.getDispatchEpoch()) {
+            return;
+        }
+        triggerStateStore.save(
+            state
+                .locked(clock, false)
+                .updateOnExecutionTerminated(clock, event.executionState())
+        );
     }
 
     /**
@@ -357,15 +384,18 @@ public class TriggerEventHandler {
      * @param event the event.
      */
     void onTriggerWorkerLost(Clock clock, TriggerWorkerLost event) {
-        findTriggerState(event).ifPresent(state ->
+        triggerStateStore.findById(event.id()).ifPresent(state ->
         {
             if (state.getWorkerId() != null && !state.getWorkerId().equals(event.workerUid())) {
                 // The trigger is already held by another worker.
                 return;
             }
+            if (event.dispatchEpoch() < state.getDispatchEpoch()) {
+                // A newer dispatch already superseded the lost one.
+                return;
+            }
             triggerStateStore.save(
                 state
-                    .lastEventId(clock, event.eventId())
                     .locked(clock, false)
                     .workerId(clock, null)
             );

--- a/scheduler/src/main/java/io/kestra/scheduler/TriggerScheduler.java
+++ b/scheduler/src/main/java/io/kestra/scheduler/TriggerScheduler.java
@@ -377,14 +377,16 @@ public class TriggerScheduler {
         updateNextEvaluationDateAndGetOnSuccess(clock, triggerState, triggerEvaluationContext).ifPresent(state ->
         {
             try {
-                if (this.triggerWorkerJobPublisher.send(state, triggerEvaluationContext.trigger(), triggerEvaluationContext.flow(), triggerEvaluationContext.conditionContext())) {
-                    state = state
+                TriggerState dispatched = state.nextDispatchEpoch(clock);
+                if (this.triggerWorkerJobPublisher.send(dispatched, triggerEvaluationContext.trigger(), triggerEvaluationContext.flow(), triggerEvaluationContext.conditionContext())) {
+                    triggerStateStore.save(dispatched
                         .lastTriggeredDate(clock)
-                        .locked(clock, mustBeLocked);
+                        .locked(clock, mustBeLocked));
+                } else {
+                    // When the job was not dispatched, save without taking the lock so the
+                    // trigger is retried at its next evaluation date.
+                    triggerStateStore.save(state);
                 }
-                // When the job was not dispatched, save without taking the lock so the
-                // trigger is retried at its next evaluation date.
-                triggerStateStore.save(state);
             } catch (Exception e) {
                 Logs.logTrigger(
                     triggerState,

--- a/scheduler/src/main/java/io/kestra/scheduler/pubsub/TriggerWorkerJobPublisher.java
+++ b/scheduler/src/main/java/io/kestra/scheduler/pubsub/TriggerWorkerJobPublisher.java
@@ -65,6 +65,7 @@ public class TriggerWorkerJobPublisher {
             .builder()
             .trigger(trigger)
             .data(WorkerTriggerData.from(conditionContext, triggerState.context()))
+            .dispatchEpoch(triggerState.getDispatchEpoch())
             .build();
         Optional<WorkerQueueRouting> routing;
         try {

--- a/scheduler/src/test/java/io/kestra/scheduler/TriggerEventHandlerTest.java
+++ b/scheduler/src/test/java/io/kestra/scheduler/TriggerEventHandlerTest.java
@@ -568,7 +568,7 @@ class TriggerEventHandlerTest {
             .workerId(CLOCK, "worker-1");
         triggerStateStore.save(realtimeState);
         handler = newTriggerEventHandler(List.of());
-        TriggerWorkerLost event = new TriggerWorkerLost(triggerId, "worker-1");
+        TriggerWorkerLost event = new TriggerWorkerLost(triggerId, "worker-1", realtimeState.getDispatchEpoch());
 
         // WHEN
         handler.handle(CLOCK, TEST_VNODE, event);
@@ -578,7 +578,6 @@ class TriggerEventHandlerTest {
         assertThat(updated).isPresent();
         assertThat(updated.get().isLocked()).isFalse();
         assertThat(updated.get().getWorkerId()).isNull();
-        assertThat(updated.get().getLastEventId()).isEqualTo(event.eventId());
     }
 
     @Test
@@ -590,7 +589,7 @@ class TriggerEventHandlerTest {
             .workerId(CLOCK, "worker-2");
         triggerStateStore.save(realtimeState);
         handler = newTriggerEventHandler(List.of());
-        TriggerWorkerLost event = new TriggerWorkerLost(triggerId, "worker-1");
+        TriggerWorkerLost event = new TriggerWorkerLost(triggerId, "worker-1", realtimeState.getDispatchEpoch());
 
         // WHEN
         handler.handle(CLOCK, TEST_VNODE, event);
@@ -672,7 +671,54 @@ class TriggerEventHandlerTest {
         assertThat(updated).isPresent();
         assertThat(updated.get().isLocked()).isFalse();
         assertThat(updated.get().getWorkerId()).isNull();
-        assertThat(updated.get().getLastEventId()).isEqualTo(event.eventId());
+    }
+
+    @Test
+    void shouldIgnoreStaleRealtimeTerminationWhenDispatchEpochSuperseded() {
+        // GIVEN — a realtime trigger on its second dispatch (epoch 2), running on worker-2
+        TriggerState realtimeState = TriggerState
+            .of(triggerId, TriggerType.REALTIME, null, false, 0)
+            .nextDispatchEpoch(CLOCK)
+            .nextDispatchEpoch(CLOCK)
+            .locked(CLOCK, true)
+            .workerId(CLOCK, "worker-2");
+        triggerStateStore.save(realtimeState);
+        handler = newTriggerEventHandler(List.of());
+        // a FAILED termination left over from the first dispatch (epoch 1)
+        TriggerExecutionTerminated event = new TriggerExecutionTerminated(triggerId, null, State.Type.FAILED, 1L);
+
+        // WHEN
+        handler.handle(CLOCK, TEST_VNODE, event);
+
+        // THEN — the current instance keeps its lock
+        Optional<TriggerState> updated = triggerStateStore.findById(triggerId);
+        assertThat(updated).isPresent();
+        assertThat(updated.get().isLocked()).isTrue();
+        assertThat(updated.get().getWorkerId()).isEqualTo("worker-2");
+    }
+
+    @Test
+    void shouldIgnoreStaleWorkerLostWhenDispatchEpochSuperseded() {
+        // GIVEN — a realtime trigger re-dispatched to the same worker (epoch 2)
+        TriggerState realtimeState = TriggerState
+            .of(triggerId, TriggerType.REALTIME, null, false, 0)
+            .nextDispatchEpoch(CLOCK)
+            .nextDispatchEpoch(CLOCK)
+            .locked(CLOCK, true)
+            .workerId(CLOCK, "worker-1");
+        triggerStateStore.save(realtimeState);
+        handler = newTriggerEventHandler(List.of());
+        // a worker-loss notice from the first dispatch (epoch 1) on the same worker
+        TriggerWorkerLost event = new TriggerWorkerLost(triggerId, "worker-1", 1L);
+
+        // WHEN
+        handler.handle(CLOCK, TEST_VNODE, event);
+
+        // THEN — the current instance keeps its lock
+        Optional<TriggerState> updated = triggerStateStore.findById(triggerId);
+        assertThat(updated).isPresent();
+        assertThat(updated.get().isLocked()).isTrue();
+        assertThat(updated.get().getWorkerId()).isEqualTo("worker-1");
     }
 
     @Test

--- a/worker-controller/src/main/java/io/kestra/controller/grpc/services/GrpcWorkerControllerService.java
+++ b/worker-controller/src/main/java/io/kestra/controller/grpc/services/GrpcWorkerControllerService.java
@@ -252,7 +252,7 @@ public class GrpcWorkerControllerService extends WorkerControllerServiceGrpc.Wor
                         // The realtime trigger stream ended without producing an execution — clean
                         // completion (stop, kill, stream end) or an error with failOnTriggerError=false:
                         // notify the scheduler directly so the trigger is unlocked and can be resubmitted.
-                        triggerEventQueue.send(new TriggerExecutionTerminated(workerTriggerResult.id(), null, State.Type.FAILED));
+                        triggerEventQueue.send(new TriggerExecutionTerminated(workerTriggerResult.id(), null, State.Type.FAILED, workerTriggerResult.dispatchEpoch()));
                     }
                     if (isTerminalRealtimeResult(evaluation)) {
                         workerJobRunningStateStore.deleteByKey(NoTransactionContext.INSTANCE, workerTriggerResult.id().uid());


### PR DESCRIPTION
The realtime unlock events (TriggerExecutionTerminated FAILED, TriggerWorkerLost) were gated by the event-id high-watermark, which assumes event-id order matches queue delivery order. It doesn't: a causally-later unlock can carry a lower event id and be skipped, leaving the trigger locked and silently unscheduled.

Fence by instance identity instead: TriggerState carries a monotonic dispatchEpoch threaded through to the unlock events; the handler unlocks unless the event's epoch is older than the state's. Non-realtime execution-terminated still uses the event-id guard.