### PR TITLE
feat(executions): propagate configured execution labels to the logging MDC

### DIFF
--- a/core/src/main/java/io/kestra/core/runners/RunContextLogger.java
+++ b/core/src/main/java/io/kestra/core/runners/RunContextLogger.java
@@ -42,6 +42,7 @@ public class RunContextLogger implements Supplier<org.slf4j.Logger> {
     private Level loglevel;
     private final List<String> useSecrets = new ArrayList<>();
     private final boolean logToFile;
+    private final Map<String, String> mdcLabels;
 
     @Getter
     private File logFile;
@@ -51,9 +52,14 @@ public class RunContextLogger implements Supplier<org.slf4j.Logger> {
     public RunContextLogger() {
         this.loggerName = "unit-test";
         this.logToFile = false;
+        this.mdcLabels = Map.of();
     }
 
     public RunContextLogger(LogEntryEmitter logEmitter, LogEntry logEntry, org.slf4j.event.Level loglevel, boolean logToFile) {
+        this(logEmitter, logEntry, loglevel, logToFile, Map.of());
+    }
+
+    public RunContextLogger(LogEntryEmitter logEmitter, LogEntry logEntry, org.slf4j.event.Level loglevel, boolean logToFile, Map<String, String> mdcLabels) {
         if (logEntry.getTaskId() != null) {
             this.loggerName = baseLoggerName(logEntry) + "." + logEntry.getTaskId();
         } else if (logEntry.getTriggerId() != null) {
@@ -66,6 +72,24 @@ public class RunContextLogger implements Supplier<org.slf4j.Logger> {
         this.logEntry = logEntry;
         this.loglevel = loglevel == null ? Level.TRACE : Level.toLevel(loglevel.toString());
         this.logToFile = logToFile;
+        this.mdcLabels = mdcLabels == null ? Map.of() : mdcLabels;
+    }
+
+    /**
+     * Merges the configured execution labels with the {@link LogEntry} context for the MDC;
+     * {@link LogEntry} keys win over labels sharing the same name.
+     */
+    private Map<String, String> mdcContext() {
+        if (this.logEntry == null) {
+            return this.mdcLabels;
+        }
+        if (this.mdcLabels.isEmpty()) {
+            return this.logEntry.toMap();
+        }
+
+        Map<String, String> context = new HashMap<>(this.mdcLabels);
+        context.putAll(this.logEntry.toMap());
+        return context;
     }
 
     private String baseLoggerName(LogEntry logEntry) {
@@ -204,7 +228,7 @@ public class RunContextLogger implements Supplier<org.slf4j.Logger> {
             // set in BaseAppender.transform()) still sees the execution context. Paired with
             // resetMDC() below on cleanup. Today both are effectively no-ops because the
             // snapshot in transform() short-circuits event.getMDCPropertyMap().
-            loggerContext.getMDCAdapter().setContextMap(this.logEntry.toMap());
+            loggerContext.getMDCAdapter().setContextMap(this.mdcContext());
         }
 
         // unit tests don't always have the log queue as we construct a logger directly without it
@@ -340,10 +364,10 @@ public class RunContextLogger implements Supplier<org.slf4j.Logger> {
                     event.getThrowableProxy() instanceof ThrowableProxy throwableProxy ? throwableProxy.getThrowable() : null,
                     argumentArray
                 );
-                // The new LoggingEvent has no MDC by default; pull it from the LogEntry so
-                // forwarded events carry it
+                // The new LoggingEvent has no MDC by default; pull it from the LogEntry (and
+                // configured labels) so forwarded events carry it
                 if (this.runContextLogger.logEntry != null) {
-                    lle.setMDCPropertyMap(this.runContextLogger.logEntry.toMap());
+                    lle.setMDCPropertyMap(this.runContextLogger.mdcContext());
                 }
                 if (customTimestamp != null) {
                     lle.setTimeStamp(customTimestamp.toEpochMilli());

--- a/core/src/main/java/io/kestra/core/runners/RunContextLoggerFactory.java
+++ b/core/src/main/java/io/kestra/core/runners/RunContextLoggerFactory.java
@@ -1,12 +1,20 @@
 package io.kestra.core.runners;
 
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
 import org.slf4j.event.Level;
 
+import io.kestra.core.models.Label;
 import io.kestra.core.models.executions.*;
 import io.kestra.core.models.flows.FlowId;
 import io.kestra.core.models.tasks.Task;
 import io.kestra.core.models.triggers.AbstractTrigger;
 import io.kestra.core.models.triggers.TriggerId;
+import io.kestra.core.runners.configuration.LoggingConfiguration;
+import io.kestra.core.utils.ListUtils;
+import io.kestra.core.utils.MapUtils;
 
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
@@ -18,14 +26,23 @@ import jakarta.inject.Singleton;
 public class RunContextLoggerFactory {
 
     private final LogEntryEmitter logEmitter;
+    private final LoggingConfiguration loggingConfiguration;
 
     @Inject
-    public RunContextLoggerFactory(LogEntryEmitter logEmitter) {
+    public RunContextLoggerFactory(LogEntryEmitter logEmitter, LoggingConfiguration loggingConfiguration) {
         this.logEmitter = logEmitter;
+        this.loggingConfiguration = loggingConfiguration;
     }
 
     public RunContextLogger create(WorkerTask workerTask) {
-        return create(workerTask.getTaskRun(), workerTask.getTask(), workerTask.getExecutionKind());
+        Task task = workerTask.getTask();
+        return new RunContextLogger(
+            logEmitter,
+            LogEntry.of(workerTask.getTaskRun(), workerTask.getExecutionKind()),
+            task.getLogLevel(),
+            task.isLogToFile(),
+            mdcLabels(workerLabels(workerTask))
+        );
     }
 
     public RunContextLogger create(WorkerTaskResult workerTaskResult) {
@@ -52,7 +69,8 @@ public class RunContextLoggerFactory {
             logEmitter,
             LogEntry.of(execution),
             null,
-            false
+            false,
+            mdcLabels(Label.toMap(execution.getLabels()))
         );
     }
 
@@ -72,5 +90,40 @@ public class RunContextLoggerFactory {
             trigger.getLogLevel(),
             trigger.isLogToFile()
         );
+    }
+
+    /**
+     * Filters the given labels to the keys allow-listed by {@code kestra.logging.labels}.
+     */
+    private Map<String, String> mdcLabels(Map<String, String> labels) {
+        final List<String> configuredKeys = loggingConfiguration.labels();
+        if (ListUtils.isEmpty(configuredKeys) || MapUtils.isEmpty(labels)) {
+            return Map.of();
+        }
+
+        Map<String, String> result = new LinkedHashMap<>();
+        for (String key : configuredKeys) {
+            String value = labels.get(key);
+            if (value != null) {
+                result.put(key, value);
+            }
+        }
+        return result;
+    }
+
+    /**
+     * Reads the execution labels already carried in the worker task variables, to avoid a heavier worker message.
+     */
+    @SuppressWarnings("unchecked")
+    private Map<String, String> workerLabels(WorkerTask workerTask) {
+        Object labels = workerTask.getData().variables().get(RunVariables.LABELS);
+        if (!(labels instanceof Map<?, ?> nested)) {
+            return Map.of();
+        }
+
+        Map<String, String> result = new LinkedHashMap<>();
+        MapUtils.nestedToFlattenMap((Map<String, Object>) nested)
+            .forEach((key, value) -> result.put(key, value == null ? null : value.toString()));
+        return result;
     }
 }

--- a/core/src/main/java/io/kestra/core/runners/RunVariables.java
+++ b/core/src/main/java/io/kestra/core/runners/RunVariables.java
@@ -31,6 +31,7 @@ public final class RunVariables {
     public static final String SECRET_CONSUMER_VARIABLE_NAME = "addSecretConsumer";
     public static final String FIXTURE_FILES_KEY = "io.kestra.datatype:test_fixtures_files";
     public static final String ENVS = "envs";
+    public static final String LABELS = "labels";
 
     /**
      * Explicit, sorted list of all dot-separated expression paths structurally available
@@ -473,7 +474,7 @@ public final class RunVariables {
                 }
 
                 if (execution.getLabels() != null) {
-                    builder.put("labels", Label.toNestedMap(execution.getLabels()));
+                    builder.put(LABELS, Label.toNestedMap(execution.getLabels()));
                 }
 
                 if (flow == null) {
@@ -507,7 +508,7 @@ public final class RunVariables {
             } else if (flow != null) {
                 // if the execution is null, we should add flow labels
                 // this is useful for triggers that don't have an execution
-                builder.put("labels", Label.toNestedMap(flow.getLabels()));
+                builder.put(LABELS, Label.toNestedMap(flow.getLabels()));
             }
 
             // Kestra configuration

--- a/core/src/main/java/io/kestra/core/runners/configuration/LoggingConfiguration.java
+++ b/core/src/main/java/io/kestra/core/runners/configuration/LoggingConfiguration.java
@@ -1,0 +1,14 @@
+package io.kestra.core.runners.configuration;
+
+import java.util.List;
+
+import io.micronaut.context.annotation.ConfigurationProperties;
+import io.micronaut.core.annotation.Nullable;
+
+/**
+ * Configures which execution {@link io.kestra.core.models.Label} keys are propagated to the logging MDC context.
+ */
+@ConfigurationProperties("kestra.logging")
+public record LoggingConfiguration(
+    @Nullable List<String> labels) {
+}

--- a/core/src/test/java/io/kestra/core/runners/RunContextLoggerLabelsTest.java
+++ b/core/src/test/java/io/kestra/core/runners/RunContextLoggerLabelsTest.java
@@ -1,0 +1,117 @@
+package io.kestra.core.runners;
+
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.slf4j.LoggerFactory;
+import org.slf4j.event.Level;
+
+import io.kestra.core.models.Label;
+import io.kestra.core.models.executions.Execution;
+import io.kestra.core.models.executions.TaskRun;
+import io.kestra.core.models.flows.Flow;
+import io.kestra.core.models.flows.State;
+import io.kestra.core.models.tasks.Task;
+import io.kestra.core.runners.configuration.LoggingConfiguration;
+import io.kestra.core.utils.TestsUtils;
+
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+import jakarta.inject.Inject;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@MicronautTest
+@org.junit.jupiter.api.parallel.Execution(ExecutionMode.SAME_THREAD)
+class RunContextLoggerLabelsTest {
+    @Inject
+    private LogEntryEmitter logEntryEmitter;
+
+    @Test
+    void shouldPropagateOnlyAllowListedLabelsToMdc() {
+        // Given
+        RunContextLoggerFactory factory = new RunContextLoggerFactory(logEntryEmitter, new LoggingConfiguration(List.of("team")));
+        Execution execution = executionWithLabels(new Label("team", "payments"), new Label("env", "prod"));
+
+        // When
+        ILoggingEvent event = forwardAndCapture(factory.create(execution), "allow-listed-labels");
+
+        // Then
+        assertThat(event.getMDCPropertyMap()).containsEntry("team", "payments");
+        assertThat(event.getMDCPropertyMap()).doesNotContainKey("env");
+        assertThat(event.getMDCPropertyMap()).containsEntry("executionId", execution.getId());
+    }
+
+    @Test
+    void shouldNotPropagateLabelsWhenNoneConfigured() {
+        // Given
+        RunContextLoggerFactory factory = new RunContextLoggerFactory(logEntryEmitter, new LoggingConfiguration(null));
+        Execution execution = executionWithLabels(new Label("team", "payments"));
+
+        // When
+        ILoggingEvent event = forwardAndCapture(factory.create(execution), "no-labels-configured");
+
+        // Then
+        assertThat(event.getMDCPropertyMap()).doesNotContainKey("team");
+        assertThat(event.getMDCPropertyMap()).containsEntry("executionId", execution.getId());
+    }
+
+    @Test
+    void shouldPropagateAllowListedLabelsFromWorkerTaskVariables() {
+        // Given a worker task carrying labels in its variables (no dedicated message field)
+        RunContextLoggerFactory factory = new RunContextLoggerFactory(logEntryEmitter, new LoggingConfiguration(List.of("team")));
+        WorkerTask workerTask = workerTaskWithLabels(new Label("team", "payments"), new Label("env", "prod"));
+
+        // When
+        ILoggingEvent event = forwardAndCapture(factory.create(workerTask), "worker-task-labels");
+
+        // Then
+        assertThat(event.getMDCPropertyMap()).containsEntry("team", "payments");
+        assertThat(event.getMDCPropertyMap()).doesNotContainKey("env");
+        assertThat(event.getMDCPropertyMap()).containsEntry("taskId", "task");
+    }
+
+    private Execution executionWithLabels(Label... labels) {
+        Flow flow = TestsUtils.mockFlow();
+        return TestsUtils.mockExecution(flow, Map.of()).withLabels(List.of(labels));
+    }
+
+    private WorkerTask workerTaskWithLabels(Label... labels) {
+        TaskRun taskRun = TaskRun.builder()
+            .id("tr-1")
+            .executionId("exec-1")
+            .namespace("io.kestra.tests")
+            .flowId("flow")
+            .taskId("task")
+            .state(new State())
+            .build();
+        Task task = mock(Task.class);
+        when(task.getLogLevel()).thenReturn(Level.TRACE);
+        when(task.isLogToFile()).thenReturn(false);
+        WorkerTaskData data = new WorkerTaskData(Map.of(RunVariables.LABELS, Label.toNestedMap(List.of(labels))), List.of(), null);
+        return WorkerTask.builder().taskRun(taskRun).task(task).data(data).build();
+    }
+
+    private ILoggingEvent forwardAndCapture(RunContextLogger runContextLogger, String marker) {
+        Logger flowLogger = (Logger) LoggerFactory.getLogger("flow");
+        ListAppender<ILoggingEvent> appender = new ListAppender<>();
+        appender.start();
+        flowLogger.addAppender(appender);
+        try {
+            runContextLogger.logger().info(marker);
+        } finally {
+            flowLogger.detachAppender(appender);
+        }
+
+        return appender.list.stream()
+            .filter(event -> marker.equals(event.getFormattedMessage()))
+            .findFirst()
+            .orElseThrow();
+    }
+}


### PR DESCRIPTION
Closes #16338

### What

Adds an opt-in `kestra.logging.labels` allow-list. When configured, the matching execution labels are propagated into the SLF4J **MDC** of execution and task logs, so forwarded logs can be filtered by business labels (e.g. `team`, `env`) in the logging backend.

```yaml
kestra:
  logging:
    labels:
      - team
      - env
```

### Why

Per #16338, only `executionId`/`flowId`/etc. reach log metadata today, so logs can't be correlated by label. As discussed in the issue, this is implemented as a **config-driven allow-list with no defaults**, mirroring `kestra.metrics.labels`, to keep the MDC memory footprint and backend cardinality under control.

### How

- New `LoggingConfiguration` (`kestra.logging.labels`), empty by default.
- `RunContextLoggerFactory` filters execution labels to the allow-listed keys and passes them to `RunContextLogger`.
- `RunContextLogger` merges the filtered labels with the existing `LogEntry` MDC context (LogEntry keys win on collision).
- Labels are carried to the worker via a new `labels` field on `WorkerTask`.

### Scope / notes

- **MDC only** - logs are not persisted with labels (no `logs` table column). Out of scope here.
- Covers the primary execution and task-dispatch paths. Working-directory nested tasks and liveness resubmissions don't yet carry labels (the `Execution` isn't in scope at those build sites); can follow up if wanted.
- Trace-context-to-logs (`trace_id`/`span_id`) is intentionally a **separate PR**, per maintainer feedback on the issue.

### Tests

- `RunContextLoggerLabelsTest` - asserts only allow-listed labels reach the MDC, and that nothing is propagated when unconfigured.
- `H2RunnerTest` green (executor touched).

