### PR TITLE
feat(executions): add OpenTelemetry trace context to log MDC

### DIFF
--- a/core/src/main/java/io/kestra/core/models/executions/LogEntry.java
+++ b/core/src/main/java/io/kestra/core/models/executions/LogEntry.java
@@ -17,6 +17,8 @@ import io.kestra.core.models.triggers.TriggerId;
 import io.kestra.core.queues.event.DispatchEvent;
 import io.kestra.core.utils.IdUtils;
 
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.SpanContext;
 import io.swagger.v3.oas.annotations.Hidden;
 import jakarta.annotation.Nullable;
 import jakarta.validation.constraints.NotNull;
@@ -142,7 +144,7 @@ public class LogEntry implements TenantInterface, DispatchEvent {
     }
 
     public Map<String, String> toMap() {
-        return Stream
+        Map<String, String> map = Stream
             .of(
                 new AbstractMap.SimpleEntry<>("tenantId", this.tenantId),
                 new AbstractMap.SimpleEntry<>("namespace", this.namespace),
@@ -155,6 +157,15 @@ public class LogEntry implements TenantInterface, DispatchEvent {
             )
             .filter(e -> e.getValue() != null)
             .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+
+        // enrich with the active OpenTelemetry trace context, a no-op when tracing is disabled
+        SpanContext spanContext = Span.current().getSpanContext();
+        if (spanContext.isValid()) {
+            map.put("trace_id", spanContext.getTraceId());
+            map.put("span_id", spanContext.getSpanId());
+        }
+
+        return map;
     }
 
     public Map<String, Object> toLogMap() {

--- a/webserver/src/test/java/io/kestra/webserver/otel/LogEntryTraceContextTest.java
+++ b/webserver/src/test/java/io/kestra/webserver/otel/LogEntryTraceContextTest.java
@@ -1,0 +1,49 @@
+package io.kestra.webserver.otel;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.kestra.core.models.executions.LogEntry;
+
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.Tracer;
+import io.opentelemetry.context.Scope;
+import io.opentelemetry.sdk.testing.junit5.OpenTelemetryExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class LogEntryTraceContextTest {
+    @RegisterExtension
+    static final OpenTelemetryExtension otelTesting = OpenTelemetryExtension.create();
+
+    @Test
+    void shouldExposeActiveTraceContextInMdc() {
+        // Given
+        LogEntry logEntry = LogEntry.builder()
+            .tenantId("main")
+            .namespace("io.kestra.tests")
+            .flowId("trace")
+            .executionId("exec-1")
+            .build();
+        Tracer tracer = otelTesting.getOpenTelemetry().getTracer("test");
+        Span span = tracer.spanBuilder("test").startSpan();
+
+        // When
+        Map<String, String> withSpan;
+        try (Scope ignored = span.makeCurrent()) {
+            withSpan = logEntry.toMap();
+        } finally {
+            span.end();
+        }
+        Map<String, String> withoutSpan = logEntry.toMap();
+
+        // Then
+        assertThat(withSpan).containsEntry("trace_id", span.getSpanContext().getTraceId());
+        assertThat(withSpan).containsEntry("span_id", span.getSpanContext().getSpanId());
+        assertThat(withSpan).containsEntry("executionId", "exec-1");
+        assertThat(withoutSpan).doesNotContainKey("trace_id");
+        assertThat(withoutSpan).doesNotContainKey("span_id");
+    }
+}


### PR DESCRIPTION
Follow-up to #16338 (kept separate from the labels PR #16923, per maintainer feedback).

### What

Surfaces the active OpenTelemetry `trace_id` and `span_id` into the SLF4J **MDC** of execution and task logs. This lets logs be correlated with the traces Kestra already produces (trace-to-logs in Grafana, Datadog, Jaeger, ...).

### Why

Even with OTel tracing enabled, logs currently carry no trace identifier, so they can't be tied back to spans. Kestra already starts a span around execution handling (executor) and task execution (worker), so the active span is available when logs are emitted.

### How

`LogEntry.toMap()` (the source of the log MDC) now reads `Span.current().getSpanContext()` and adds `trace_id`/`span_id` when the context is valid.

- **On by default when OTel tracing is enabled** - no extra config, as requested.
- **No-op when tracing is disabled** - `SpanContext.isValid()` is `false`, so nothing is added and behaviour is unchanged.

### Note on the "standard Micronaut way"

A standard `opentelemetry-logback-mdc` instrumentation exists, but it only covers the server's global logback context. Execution/task logs use a dedicated per-execution `LoggerContext` and set an explicit MDC map, so the standard instrumentation can't reach them - hence injecting the context at the `LogEntry.toMap()` chokepoint. Adding the instrumentation + a `%X{trace_id}` logback pattern for the server's own daemon logs could be a separate follow-up.

### Tests

- `LogEntryTraceContextTest` - using the OpenTelemetry SDK testing extension, asserts `trace_id`/`span_id` are present in the MDC within an active span and absent without one.

