### PR TITLE
fix(namespaces): amend invisible selected text in disabled segmented control

### DIFF
--- a/ui/packages/design-system/src/components/Data/KsSegmented.vue
+++ b/ui/packages/design-system/src/components/Data/KsSegmented.vue
@@ -41,4 +41,9 @@
     .kel-segmented.is-disabled .kel-segmented__item-selected {
         background-color: var(--ks-bg-inactive);
     }
+
+    .el-segmented.is-disabled .el-segmented__item.is-selected,
+    .kel-segmented.is-disabled .kel-segmented__item.is-selected {
+        color: var(--ks-text-secondary);
+    }
 </style>


### PR DESCRIPTION
## Summary

- In the Namespaces edit page, the Match strategy segmented control is disabled when no worker tags are set
- The Kestra theme overrides the selected item's background to `--ks-bg-inactive` (light gray / near-white) but left the text color as `--kel-color-white` (white, the Element Plus default), making the selected label invisible
- Added a text color override for the disabled+selected state using `--ks-text-secondary` (medium gray), which is readable against the light inactive background

## Test plan

- [ ] Go to Namespaces → open any namespace → Edit tab → Default Worker Selector section
- [ ] With no tags set, the Match strategy control should be disabled — verify the selected option text ("Match all") is now visible
- [ ] Add tags to enable the control — verify the active selected state (purple background, white text) still looks correct
- [ ] Verify in both light and dark modes

Closes https://github.com/kestra-io/kestra-ee/issues/8764.