### PR TITLE
fix(executions): allow restarting an execution that have no taskruns

### DIFF
--- a/core/src/main/java/io/kestra/core/services/ExecutionService.java
+++ b/core/src/main/java/io/kestra/core/services/ExecutionService.java
@@ -283,13 +283,34 @@ public class ExecutionService {
             );
         }
 
+        final String newExecutionId = revision != null ? IdUtils.create() : null;
+
+        // When an execution has no task runs (e.g., failed due to concurrency limit exceeded
+        // before any task ran), restart it as a fresh child execution with an empty task-run list.
+        if (ListUtils.isEmpty(execution.getTaskRunList())) {
+            List<Label> newLabels = new ArrayList<>(ListUtils.emptyOnNull(execution.getLabels()));
+            if (!newLabels.contains(new Label(Label.RESTARTED, "true"))) {
+                newLabels.add(new Label(Label.RESTARTED, "true"));
+            }
+            Execution newExecution = execution
+                .childExecution(newExecutionId, Collections.emptyList(), execution.withState(State.Type.RESTARTED).getState())
+                .withMetadata(execution.getMetadata().nextAttempt())
+                .withLabels(newLabels);
+            if (revision != null) {
+                newExecution = newExecution.withFlowRevision(revision);
+            }
+            if (emitEvent) {
+                eventPublisher.publishEvent(CrudEvent.create(newExecution));
+            }
+            return newExecution;
+        }
+
         Set<String> taskRunToRestart = this.taskRunToRestart(
             execution,
             taskRun -> taskRun.getState().canBeRestarted()
         );
 
         Map<String, String> mappingTaskRunId = this.mapTaskRunId(execution, revision == null);
-        final String newExecutionId = revision != null ? IdUtils.create() : null;
 
         List<TaskRun> newTaskRuns = execution
             .getTaskRunList()
@@ -353,8 +374,7 @@ public class ExecutionService {
         Set<String> finalTaskRunToRestart = this
             .taskRunWithAncestors(
                 execution,
-                execution
-                    .getTaskRunList()
+                execution.getTaskRunList()
                     .stream()
                     .filter(predicate)
                     .toList()

--- a/core/src/test/java/io/kestra/core/runners/ExecutionServiceTest.java
+++ b/core/src/test/java/io/kestra/core/runners/ExecutionServiceTest.java
@@ -408,7 +408,7 @@ class ExecutionServiceTest {
                 message: "{{ render(vars.greeting) }}"
             """;
         FlowWithSource updated = flowService.update(GenericFlow.fromYaml(flow.getTenantId(), newSource), flow);
-        
+
         Execution restart = executionService.replay(execution, updated, null, updated.getRevision(), Optional.empty());
 
         assertThat(restart.getFlowRevision()).isEqualTo(updated.getRevision());
@@ -715,5 +715,23 @@ class ExecutionServiceTest {
         // originalId must match the provided execution id, not the auto-generated id from newExecution().
         assertThat(execution.getId()).isEqualTo(executionId);
         assertThat(execution.getOriginalId()).isEqualTo(executionId);
+    }
+
+    @Test
+    @LoadFlows("flows/valids/minimal.yaml")
+    void restartShouldSuccessWhenNoTaskRun() throws Exception {
+        // Given
+        Flow flow = flowRepository.findById(MAIN_TENANT, "io.kestra.tests", "minimal").orElseThrow();
+        Execution newExecution = Execution.newExecution(flow, Collections.emptyList())
+            .withState(State.Type.FAILED);
+
+        // When
+        Execution restarted = executionService.restart(newExecution, flow, null);
+
+        // Then
+        assertThat(restarted.getState().getCurrent()).isEqualTo(State.Type.RESTARTED);
+        assertThat(restarted.getId()).isEqualTo(newExecution.getId());
+        assertThat(restarted.getOriginalId()).isEqualTo(newExecution.getId());
+        assertThat(restarted.getTaskRunList()).isEmpty();
     }
 }


### PR DESCRIPTION
Such executions can exist if they were FAILED for ex from concurrency or quotas limits.