### PR TITLE
fix: use text-primary for subcategories

### DIFF
--- a/ui/packages/design-system/src/components/Navigation/KsSideBar/KsSideBarItem.vue
+++ b/ui/packages/design-system/src/components/Navigation/KsSideBar/KsSideBarItem.vue
@@ -58,7 +58,7 @@
     min-height: 26px;
     border-radius: var(--ks-radius-base);
     text-decoration: none;
-    color: var(--ks-text-secondary);
+    color: var(--ks-text-primary);
     font-size: var(--ks-font-size-sm);
     font-weight: var(--ks-font-weight-medium);
     transition: background-color 0.15s ease, color 0.15s ease;


### PR DESCRIPTION
closes https://github.com/kestra-io/kestra-ee/issues/8756

After the update
<img width="487" height="902" alt="Screenshot 2026-06-22 at 12 07 28" src="https://github.com/user-attachments/assets/3b3d7b55-eff2-439c-9cbd-8c699d2e86f1" />
