### PR TITLE
ci(release): use kestra base images when publishing docker

### DIFF
--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -34,6 +34,7 @@ jobs:
       retag-lts: ${{ inputs.retag-lts }}
       dry-run: ${{ inputs.dry-run }}
       java-version: ${{ inputs.java-version }}
+      use-kestra-base-images: true
     secrets: inherit
 
   helm-release:


### PR DESCRIPTION
## What

Set `use-kestra-base-images: true` on the `publish-docker` job in `.github/workflows/release-docker.yml`.

## Why

RC release images were being built without the kestra base images, so they shipped with **no plugins**. Enabling `use-kestra-base-images` builds the release images on top of the kestra base images that bundle the plugins, fixing the empty-plugin RC releases.

## Companion PR

Same fix for the EE release workflow is in the kestra-ee repo.