### PR TITLE
fix(core): use binary ION for task cache output serialization

### DIFF
--- a/worker/src/main/java/io/kestra/worker/processors/WorkerTaskProcessor.java
+++ b/worker/src/main/java/io/kestra/worker/processors/WorkerTaskProcessor.java
@@ -314,7 +314,7 @@ public class WorkerTaskProcessor extends AbstractWorkerJobProcessor<WorkerTask> 
                 ) {
                     var zipEntry = new ZipEntry("outputs.ion");
                     archive.putNextEntry(zipEntry);
-                    archive.write(JacksonMapper.ofIon().writeValueAsBytes(taskRunWithOutput.outputs()));
+                    archive.write(JacksonMapper.ofIonBinary().writeValueAsBytes(taskRunWithOutput.outputs()));
                     archive.closeEntry();
                     archive.finish();
                     Path archiveFile = runContext.workingDir().createTempFile(".zip");


### PR DESCRIPTION
### ✨ Description

switching task cache output serialization from text ION `(JacksonMapper.ofIon())` to binary ION `(JacksonMapper.ofIonBinary())`. Text ION serializes map keys as symbols with
  single quotes ('key') instead of strings with double quotes ("key"), which
  causes deserialization failures when parent flows try to read cached outputs
  from subflows using WorkingDirectory.

closes #16626

### 🛠️ Backend Checklist

_If this PR does not include any backend changes, delete this entire section._

- [x] Code compiles successfully and passes all checks

Flow that I used:
```yaml
id: parent-flow
namespace: test
description: Parent flow that calls the subflow and reads its output files

tasks:
    - id: call_subflow
      type: io.kestra.plugin.core.flow.Subflow
      flowId: subflow-with-working-dir
      namespace: test
      wait: true 
      
    - id: log_output
      type: io.kestra.plugin.core.log.Log
      message: "Subflow outputs: {{ outputs.call_subflow }}"
```

```yaml
id: subflow-with-working-dir
namespace: test
description: Subflow that uses WorkingDirectory with outputFiles
  
tasks:
    - id: working_dir
      type: io.kestra.plugin.core.flow.WorkingDirectory
      outputFiles:
        - "output.txt"
      tasks:
        - id: create_file
          type: io.kestra.plugin.scripts.bun.Commands
          commands:
            - echo "Hello from subflow" > output.txt
```

<img width="1705" height="937" alt="image" src="https://github.com/user-attachments/assets/9a6aeae5-f0b2-4ed3-a2ee-f1c3f0f708a5" />

<img width="1703" height="940" alt="image" src="https://github.com/user-attachments/assets/70cce62c-80e1-4278-aa74-167234d8158f" />


