### PR TITLE
fix(design-system): widen KsButton icon prop type to avoid cross-instance Vue type conflict

### DIFF
--- a/ui/packages/design-system/src/components/Basic/KsButton/KsButton.vue
+++ b/ui/packages/design-system/src/components/Basic/KsButton/KsButton.vue
@@ -53,7 +53,7 @@
         type?: "default" | "primary" | "success" | "warning" | "info" | "danger" | "text" | ""
         size?: "small" | "default" | "large" | ""
         disabled?: boolean
-        icon?: string | Component
+        icon?: string | object
         nativeType?: "button" | "submit" | "reset"
         loading?: boolean
         text?: boolean


### PR DESCRIPTION
## Summary

- Changes `icon` prop type on `KsButton` from `string | Component` to `string | object`
- `Component` from Vue causes a type incompatibility when `KsButton` is consumed by a project that has a different Vue instance (e.g. `kestra-ee`), because TypeScript treats the two `CompatConfig` types as unrelated even though they are structurally identical
- `string | object` is compatible across Vue instances and still accepts any imported `.vue` component

## Test plan

- [ ] Pass an imported `vue-material-design-icons` component as `:icon` in a consuming project — no TypeScript error
- [ ] `KsButton` renders icons correctly at runtime