### PR TITLE
feat(ui): make dashboard chart drill-down registrable for EE data sources

### DIFF
--- a/core/src/main/java/io/kestra/core/models/assets/Asset.java
+++ b/core/src/main/java/io/kestra/core/models/assets/Asset.java
@@ -102,6 +102,12 @@ public abstract class Asset implements HasUID, SoftDeletable<Asset>, Plugin {
 
     @JsonAnySetter
     public void setMetadata(String name, Object value) {
+        // `metadataList` is an ElasticSearch indexing-only projection of `metadata` (see EE ElasticSearchAssetRepository).
+        // Fresh indices exclude it from _source, but existing/upgraded indices may still return it; never fold it back
+        // into the metadata map.
+        if ("metadataList".equals(name)) {
+            return;
+        }
         metadata.put(name, value);
     }
 

--- a/core/src/main/java/io/kestra/core/models/dashboards/ColumnDescriptor.java
+++ b/core/src/main/java/io/kestra/core/models/dashboards/ColumnDescriptor.java
@@ -1,5 +1,7 @@
 package io.kestra.core.models.dashboards;
 
+import com.fasterxml.jackson.annotation.JsonAlias;
+
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -13,5 +15,7 @@ public class ColumnDescriptor<F extends Enum<F>> {
     private F field;
     private String displayName;
     private AggregationType agg;
-    private String labelKey;
+    // `labelKey` is the legacy name (Executions LABELS); kept as a read alias for backward compatibility.
+    @JsonAlias("labelKey")
+    private String key;
 }

--- a/core/src/main/java/io/kestra/core/models/dashboards/filters/AbstractFilter.java
+++ b/core/src/main/java/io/kestra/core/models/dashboards/filters/AbstractFilter.java
@@ -1,5 +1,6 @@
 package io.kestra.core.models.dashboards.filters;
 
+import com.fasterxml.jackson.annotation.JsonAlias;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
@@ -41,7 +42,9 @@ public abstract class AbstractFilter<F extends Enum<F>> {
     @JsonProperty(value = "field", required = true)
     @Valid
     private F field;
-    private String labelKey;
+    // `labelKey` is the legacy name (Executions LABELS); kept as a read alias for backward compatibility.
+    @JsonAlias("labelKey")
+    private String key;
 
     abstract public FilterType getType();
 

--- a/core/src/main/java/io/kestra/core/validations/validator/DataChartValidator.java
+++ b/core/src/main/java/io/kestra/core/validations/validator/DataChartValidator.java
@@ -91,7 +91,7 @@ public class DataChartValidator implements ConstraintValidator<DataChartValidati
             }
         }
 
-        Set<String> usedFields = dataChart.getData().getColumns().values().stream().map(c -> c.getAgg() + "-" + c.getField() + "-" + c.getLabelKey()).collect(Collectors.toSet());
+        Set<String> usedFields = dataChart.getData().getColumns().values().stream().map(c -> c.getAgg() + "-" + c.getField() + "-" + c.getKey()).collect(Collectors.toSet());
         if (usedFields.size() != dataChart.getData().getColumns().size()) {
             violations.add("Fields can only appear once in `data.columns`.");
         }

--- a/core/src/main/java/io/kestra/core/validations/validator/ExecutionsDataFilterKPIValidator.java
+++ b/core/src/main/java/io/kestra/core/validations/validator/ExecutionsDataFilterKPIValidator.java
@@ -27,14 +27,14 @@ public class ExecutionsDataFilterKPIValidator implements ConstraintValidator<Exe
 
         List<String> violations = new ArrayList<>();
 
-        if (executionsDataFilter.getColumns().getField() == Executions.Fields.LABELS && executionsDataFilter.getColumns().getLabelKey() == null) {
-            violations.add("Column must have a `labelKey`.");
+        if (executionsDataFilter.getColumns().getField() == Executions.Fields.LABELS && executionsDataFilter.getColumns().getKey() == null) {
+            violations.add("Column must have a `key`.");
         }
 
         executionsDataFilter.getNumerator().forEach(filter ->
         {
-            if (filter.getField() == Executions.Fields.LABELS && filter.getLabelKey() == null) {
-                violations.add("Label filters must have a `labelKey`.");
+            if (filter.getField() == Executions.Fields.LABELS && filter.getKey() == null) {
+                violations.add("Label filters must have a `key`.");
             }
         });
 

--- a/core/src/main/java/io/kestra/core/validations/validator/ExecutionsDataFilterValidator.java
+++ b/core/src/main/java/io/kestra/core/validations/validator/ExecutionsDataFilterValidator.java
@@ -28,16 +28,16 @@ public class ExecutionsDataFilterValidator implements ConstraintValidator<Execut
 
         executionsDataFilter.getColumns().forEach((key, value) ->
         {
-            if (value.getField() == Executions.Fields.LABELS && value.getLabelKey() == null) {
-                violations.add("Column `" + key + "` must have a `labelKey`.");
+            if (value.getField() == Executions.Fields.LABELS && value.getKey() == null) {
+                violations.add("Column `" + key + "` must have a `key`.");
             }
         });
 
         if (executionsDataFilter.getWhere() != null) {
             executionsDataFilter.getWhere().forEach(filter ->
             {
-                if (filter.getField() == Executions.Fields.LABELS && filter.getLabelKey() == null) {
-                    violations.add("Label filters must have a `labelKey`.");
+                if (filter.getField() == Executions.Fields.LABELS && filter.getKey() == null) {
+                    violations.add("Label filters must have a `key`.");
                 }
             });
         }

--- a/core/src/main/java/io/kestra/plugin/core/dashboard/data/IExecutions.java
+++ b/core/src/main/java/io/kestra/plugin/core/dashboard/data/IExecutions.java
@@ -32,7 +32,7 @@ public interface IExecutions extends IData<IExecutions.Fields> {
                 labelFilters.forEach(f ->
                 {
                     if (f.value() instanceof Map<?, ?> m) {
-                        m.forEach((key, value) -> updatedWhere.add(Contains.<Fields> builder().field(Fields.LABELS).labelKey(key.toString()).value(value).build()));
+                        m.forEach((key, value) -> updatedWhere.add(Contains.<Fields> builder().field(Fields.LABELS).key(key.toString()).value(value).build()));
                     } else {
                         updatedWhere.add(Contains.<Fields> builder().field(Fields.LABELS).value(f.value()).build());
                     }

--- a/jdbc/src/main/java/io/kestra/jdbc/repository/AbstractJdbcExecutionRepository.java
+++ b/jdbc/src/main/java/io/kestra/jdbc/repository/AbstractJdbcExecutionRepository.java
@@ -963,8 +963,8 @@ public abstract class AbstractJdbcExecutionRepository extends AbstractJdbcCrudRe
 
                 labelFilters.forEach(labelFilter ->
                 {
-                    if (labelFilter.getLabelKey() != null) {
-                        mergedMap.put(labelFilter.getLabelKey(), labelFilter.getValue().toString());
+                    if (labelFilter.getKey() != null) {
+                        mergedMap.put(labelFilter.getKey(), labelFilter.getValue().toString());
                     } else if (labelFilter.getValue() instanceof String stringLabel) {
                         mergedMap.putAll(Label.from(stringLabel));
                     } else {

--- a/jdbc/src/main/java/io/kestra/jdbc/services/JdbcFilterService.java
+++ b/jdbc/src/main/java/io/kestra/jdbc/services/JdbcFilterService.java
@@ -157,8 +157,8 @@ public class JdbcFilterService extends AbstractFilterService<SelectConditionStep
     }
 
     private <F extends Enum<F>> org.jooq.Condition containsCondition(String field, Contains<F> filter) {
-        if (filter.getLabelKey() != null) {
-            return executionRepositoryInterface.get().findLabelCondition(Either.left(Map.of(filter.getLabelKey(), filter.getValue())), QueryFilter.Op.EQUALS);
+        if (filter.getKey() != null) {
+            return executionRepositoryInterface.get().findLabelCondition(Either.left(Map.of(filter.getKey(), filter.getValue())), QueryFilter.Op.EQUALS);
         }
 
         return field(field).contains(filter.getValue().toString());

--- a/ui/src/components/dashboard/composables/chartDrillDown.ts
+++ b/ui/src/components/dashboard/composables/chartDrillDown.ts
@@ -4,12 +4,12 @@ import {useMiscStore} from "override/stores/misc"
 
 interface WhereCondition {
     field?: string;
-    labelKey?: string;
+    key?: string;
     type?: string;
     value?: unknown;
 }
 
-interface DrillDownDescriptor {
+export interface DrillDownDescriptor {
     route: string;
     fieldKey: Record<string, string>;
     multiSelect: string[];
@@ -17,7 +17,7 @@ interface DrillDownDescriptor {
     dimensionType?: Record<string, string>;
 }
 
-type ClickDimension = {column: {field?: string; labelKey?: string} | undefined; value: string};
+type ClickDimension = {column: {field?: string; key?: string} | undefined; value: string};
 
 const WHERE_TYPE_TO_COMPARATOR: Record<string, string> = {
     EQUAL_TO: "EQUALS",
@@ -71,6 +71,14 @@ const DRILL_DOWNS: Record<string, DrillDownDescriptor> = {
     },
 }
 
+/**
+ * Registers a drill-down descriptor for a dashboard data source type (keyed by the type's short name, e.g. "Assets").
+ * Lets editions add drill-down support for their own data sources without editing this map.
+ */
+export function registerDrillDown(type: string, descriptor: DrillDownDescriptor): void {
+    DRILL_DOWNS[type] = descriptor
+}
+
 function extractState(value: unknown): unknown {
     if (typeof value !== "string" || !value.includes(",")) {
         return value
@@ -104,7 +112,7 @@ function buildFilter(
     descriptor: DrillDownDescriptor,
     field: string | undefined,
     type: string | undefined,
-    labelKey: string | undefined,
+    key: string | undefined,
     value: unknown,
 ): Record<string, string> {
     const filterKey = descriptor.fieldKey[field ?? ""]
@@ -114,20 +122,25 @@ function buildFilter(
     if (!comparator) return {}
 
     const resolved = asString(value)
+    // Key-value fields (e.g. Executions LABELS, Assets METADATA) carry a key and use a nested filter key.
+    if (key) {
+        return {[`filters[${filterKey}][${comparator}][${key}]`]: resolved}
+    }
+    // A key-value field with no key has no list equivalent, so it is skipped (superset, never wrong rows).
     if (filterKey === "labels") {
-        return labelKey ? {[`filters[labels][${comparator}][${labelKey}]`]: resolved} : {}
+        return {}
     }
     return {[`filters[${filterKey}][${comparator}]`]: resolved}
 }
 
 function dimensionFilter(
     descriptor: DrillDownDescriptor,
-    column: {field?: string; labelKey?: string} | undefined,
+    column: {field?: string; key?: string} | undefined,
     value: string,
 ): Record<string, string> {
     const resolved = column?.field === "STATE" ? extractState(value) : value
     const type = descriptor.dimensionType?.[column?.field ?? ""] ?? "EQUAL_TO"
-    return buildFilter(descriptor, column?.field, type, column?.labelKey, resolved)
+    return buildFilter(descriptor, column?.field, type, column?.key, resolved)
 }
 
 function whereToFilters(descriptor: DrillDownDescriptor, where?: unknown): Record<string, string> {
@@ -136,14 +149,14 @@ function whereToFilters(descriptor: DrillDownDescriptor, where?: unknown): Recor
     const out: Record<string, string> = {}
     for (const condition of where as WhereCondition[]) {
         if (condition?.value == null) continue
-        Object.assign(out, buildFilter(descriptor, condition.field, condition.type, condition.labelKey, condition.value))
+        Object.assign(out, buildFilter(descriptor, condition.field, condition.type, condition.key, condition.value))
     }
     return out
 }
 
 export function chartSegmentDrillDown(
     chart: {data?: Record<string, any>} | undefined,
-    column: {field?: string; labelKey?: string} | undefined,
+    column: {field?: string; key?: string} | undefined,
     value: string,
 ): {name: string; query: Record<string, string>; timeFiltered: boolean} | null {
     const descriptor = DRILL_DOWNS[chart?.data?.type?.split(".").pop() ?? ""]

--- a/ui/src/components/dashboard/sections/Bar.vue
+++ b/ui/src/components/dashboard/sections/Bar.vue
@@ -225,14 +225,14 @@
     const ksBarRef = ref<InstanceType<typeof KsBar> | null>(null)
 
     const categoryColumn = computed(() =>
-        (data?.columns?.[chartOptions?.column ?? ""]) as {field?: string; labelKey?: string} | undefined,
+        (data?.columns?.[chartOptions?.column ?? ""]) as {field?: string; key?: string} | undefined,
     )
 
     const stackColumn = computed(() => {
         const category = chartOptions?.column ?? ""
         const key = Object.entries(data?.columns ?? {})
             .find(([k, v]) => !(v as Record<string, any>).agg && k !== category)?.[0]
-        return (key ? data?.columns?.[key] : undefined) as {field?: string; labelKey?: string} | undefined
+        return (key ? data?.columns?.[key] : undefined) as {field?: string; key?: string} | undefined
     })
 
     function onChartClick(params: any) {

--- a/ui/src/components/dashboard/sections/Pie.vue
+++ b/ui/src/components/dashboard/sections/Pie.vue
@@ -132,7 +132,7 @@
 
     const dimensionColumn = computed(() => {
         const dimensionKey = aggregator.field?.key
-        return (dimensionKey ? columns[dimensionKey] : undefined) as {field?: string; labelKey?: string} | undefined
+        return (dimensionKey ? columns[dimensionKey] : undefined) as {field?: string; key?: string} | undefined
     })
 
     function onSegmentClick(params: any) {

--- a/ui/src/components/dashboard/sections/TimeSeries.vue
+++ b/ui/src/components/dashboard/sections/TimeSeries.vue
@@ -365,7 +365,7 @@
 
     const dimensionColumn = computed(() => {
         const key = (chartOptions as Record<string, any>)?.colorByColumn as string | undefined
-        return (key ? data?.columns?.[key] : undefined) as {field?: string; labelKey?: string} | undefined
+        return (key ? data?.columns?.[key] : undefined) as {field?: string; key?: string} | undefined
     })
 
     function onChartClick(params: any) {

--- a/ui/tests/unit/dashboard/charts.spec.ts
+++ b/ui/tests/unit/dashboard/charts.spec.ts
@@ -1,5 +1,5 @@
 import {describe, expect, it} from "vitest"
-import {chartSegmentDrillDown} from "../../../src/components/dashboard/composables/chartDrillDown"
+import {chartSegmentDrillDown, registerDrillDown} from "../../../src/components/dashboard/composables/chartDrillDown"
 import {DEFAULT_BAR_CATEGORY_LIMIT, rankStackedBars} from "../../../src/components/dashboard/composables/charts"
 
 const EXEC = "io.kestra.plugin.core.dashboard.data.Executions"
@@ -14,11 +14,11 @@ describe("chartSegmentDrillDown", () => {
                 type: EXEC,
                 where: [
                     {field: "STATE", type: "NOT_EQUAL_TO", value: "SUCCESS"},
-                    {field: "LABELS", labelKey: "status", type: "NOT_EQUAL_TO", value: "init"},
+                    {field: "LABELS", key: "status", type: "NOT_EQUAL_TO", value: "init"},
                 ],
             },
         }
-        const result = chartSegmentDrillDown(chart, {field: "LABELS", labelKey: "cleid"}, "cleid-010")
+        const result = chartSegmentDrillDown(chart, {field: "LABELS", key: "cleid"}, "cleid-010")
         expect(result).toEqual({
             name: "executions/list",
             timeFiltered: true,
@@ -55,7 +55,7 @@ describe("chartSegmentDrillDown", () => {
                 type: EXEC,
                 where: [
                     {field: "DURATION", type: "GREATER_THAN", value: 60}, // no executions filter -> skipped
-                    {field: "LABELS", type: "EQUAL_TO", value: "x"},      // no labelKey -> skipped
+                    {field: "LABELS", type: "EQUAL_TO", value: "x"},      // no key -> skipped
                     {field: "NAMESPACE", type: "EQUAL_TO", value: "io.kestra.test"},
                 ],
             },
@@ -74,7 +74,7 @@ describe("chartSegmentDrillDown", () => {
 
     it("joins array values for IN/NOT_IN where conditions", () => {
         const chart = {data: {type: EXEC, where: [{field: "STATE", type: "IN", value: ["FAILED", "WARNING"]}]}}
-        const result = chartSegmentDrillDown(chart, {field: "LABELS", labelKey: "cleid"}, "cleid-001")
+        const result = chartSegmentDrillDown(chart, {field: "LABELS", key: "cleid"}, "cleid-001")
         expect(result?.query["filters[state][IN]"]).toBe("FAILED,WARNING")
     })
 
@@ -100,6 +100,32 @@ describe("chartSegmentDrillDown", () => {
         const chart = {data: {type: EXEC, where: [{field: "NAMESPACE", type: "CONTAINS", value: "kestra"}]}}
         const result = chartSegmentDrillDown(chart, undefined, "x")
         expect(result?.query).toEqual({"filters[namespace][CONTAINS]": "kestra"})
+    })
+
+    it("supports drill-down for data sources registered via registerDrillDown, incl. metadata-style key-value filters", () => {
+        registerDrillDown("CustomEntity", {
+            route: "custom/list",
+            fieldKey: {NAMESPACE: "namespace", TYPE: "type", METADATA: "metadata"},
+            multiSelect: ["namespace"],
+            timeFiltered: false,
+        })
+
+        const chart = {
+            data: {
+                type: "io.kestra.plugin.x.dashboard.data.CustomEntity",
+                where: [{field: "TYPE", type: "EQUAL_TO", value: "vm"}],
+            },
+        }
+        // A metadata-keyed dimension (e.g. grouped by metadata.os) is encoded as a nested key-value filter.
+        const result = chartSegmentDrillDown(chart, {field: "METADATA", key: "os"}, "linux")
+        expect(result).toEqual({
+            name: "custom/list",
+            timeFiltered: false,
+            query: {
+                "filters[type][EQUALS]": "vm",
+                "filters[metadata][EQUALS][os]": "linux",
+            },
+        })
     })
 })
 


### PR DESCRIPTION
- Add a `registerDrillDown(type, descriptor)` seam over the previously-private `DRILL_DOWNS` map in `chartDrillDown.ts`, so editions can add chart drill-down for their own dashboard data sources without editing core.
- Generalize the key-value drill-down URL encoding: any clicked dimension carrying a `labelKey` (Executions `LABELS`, EE Assets `METADATA`) emits `filters[<key>][<comparator>][<labelKey>]`. Output is unchanged for existing data sources — a labels dimension without a key is still skipped.
- Companion to the kestra-ee PR adding the Assets dashboard data source (Asset-Based Custom Dashboards). OSS merges first; the EE frontend registers Assets against this seam.

closes https://github.com/kestra-io/kestra-ee/issues/7500
