### PR TITLE
fix(plugins): throw IOException when JAR manifest is null in PluginArtifact.fromFile

### DIFF
--- a/core/src/main/java/io/kestra/core/plugins/PluginArtifact.java
+++ b/core/src/main/java/io/kestra/core/plugins/PluginArtifact.java
@@ -55,6 +55,9 @@ public record PluginArtifact(
     public static PluginArtifact fromFile(final File file) throws IOException {
         try (JarFile jarFile = new JarFile(file)) {
             Manifest manifest = jarFile.getManifest();
+            if (manifest == null) {
+                throw new IOException("JAR file '" + file.getName() + "' has no manifest (META-INF/MANIFEST.MF). Kestra plugin JARs must include X-Kestra-Version, X-Kestra-Name and X-Kestra-Group manifest attributes.");
+            }
             final String version = manifest.getMainAttributes().getValue("X-Kestra-Version");
             final String artifactId = manifest.getMainAttributes().getValue("X-Kestra-Name");
             final String groupId = manifest.getMainAttributes().getValue("X-Kestra-Group");


### PR DESCRIPTION
## Summary

- `PluginArtifact.fromFile` called `manifest.getMainAttributes()` without null-checking the manifest first
- `JarFile.getManifest()` returns `null` when the JAR has no `META-INF/MANIFEST.MF`
- Uploading such a JAR via Versioned Plugins triggered an NPE surfaced as a 500 error

## Fix

Guard with an explicit null-check and throw a descriptive `IOException` naming the missing manifest and the three required attributes (`X-Kestra-Version`, `X-Kestra-Name`, `X-Kestra-Group`). The existing caller in `RemotePluginManager.install(File, ...)` already catches `IOException` and wraps it into a `KestraRuntimeException` with the filename — so the end user now gets a clear error message instead of a bare NPE.

## Test plan

- [ ] Upload a valid Kestra plugin JAR → installs normally
- [ ] Upload a plain JAR with no manifest → returns a clear error message (not a 500 NPE)