### PR TITLE
ci(release): use kestra base images when publishing docker

### DIFF
--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -28,4 +28,5 @@ jobs:
       retag-latest: ${{ inputs.retag-latest }}
       retag-lts: ${{ inputs.retag-lts }}
       dry-run: ${{ inputs.dry-run }}
+      use-kestra-base-images: true
     secrets: inherit

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,24 +1,13 @@
-FROM eclipse-temurin:21-jre-jammy
+ARG BASE_IMAGE="ghcr.io/kestra-io/kestra-base:latest-jre21-no-plugins"
+FROM ${BASE_IMAGE}
 
-ARG KESTRA_PLUGINS=""
-ARG APT_PACKAGES=""
-ARG PYTHON_LIBRARIES=""
-
-WORKDIR /app
-
-RUN groupadd kestra && \
-    useradd -m -g kestra kestra
+ENV PATH="/app/.venv/bin:$PATH"
 
 COPY --chown=kestra:kestra docker /
 
-RUN apt-get update -y && \
-    apt-get upgrade -y && \
-    if [ -n "${APT_PACKAGES}" ]; then apt-get install -y --no-install-recommends ${APT_PACKAGES}; fi && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/* /var/tmp/* /tmp/* && \
-    curl -LsSf https://astral.sh/uv/0.6.17/install.sh | sh && mv /root/.local/bin/uv /bin && mv /root/.local/bin/uvx /bin && \
-    if [ -n "${KESTRA_PLUGINS}" ]; then /app/kestra plugins install ${KESTRA_PLUGINS} && rm -rf /tmp/*; fi && \
-    if [ -n "${PYTHON_LIBRARIES}" ]; then uv pip install --system ${PYTHON_LIBRARIES}; fi && \
+RUN --mount=type=bind,target=/mnt/context \
+    mkdir -p /app/plugins && \
+    { cp -r /mnt/context/plugins/. /app/plugins/ 2>/dev/null || true; } && \
     chown -R kestra:kestra /app
 
 USER kestra


### PR DESCRIPTION
## What

Backports the `develop` Docker release setup to `releases/v1.2.x`, so this release line publishes Docker images the same way `develop` does.

### Changes
- **`Dockerfile`** — build `FROM` the `kestra-base` image variant instead of starting from `eclipse-temurin:21-jre-jammy` and installing the JRE/apt packages/`uv` at build time. Plugins are now provided by the base image + bind-mounted context. Base image defaults to **`ghcr.io/kestra-io/kestra-base:latest-jre21-no-plugins`** (this branch is Java 21).
- **`.github/workflows/release-docker.yml`** — enable `use-kestra-base-images: true` on `kestra-oss-publish-docker.yml@main`. That is the only workflow change.

## Why

`develop` already releases Docker via the `kestra-base` images; this brings `v1.2.x` to parity.

**No `java-version` input is needed:** `kestra-oss-publish-docker.yml@main` already defaults `java-version` to `'21'`, and its base-image selection keys off `java-version == '21'` → the JRE 21 base. Passing `'21'` explicitly would be a redundant no-op, so it is omitted to keep the change minimal. (Only Java 25 branches such as `v1.3.x` need to set `java-version: '25'` to override that default.)

## Scope

Docker-only minimal change: no new jobs; existing jobs/secrets untouched. The base image is selected at release time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)