### PR TITLE
ci(release): use kestra base images when publishing docker

### DIFF
--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -34,6 +34,7 @@ jobs:
       retag-lts: ${{ inputs.retag-lts }}
       dry-run: ${{ inputs.dry-run }}
       java-version: ${{ inputs.java-version }}
+      use-kestra-base-images: true
     secrets: inherit
 
   helm-release:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,25 +1,13 @@
-FROM eclipse-temurin:25-jre-jammy
+ARG BASE_IMAGE="ghcr.io/kestra-io/kestra-base:latest-no-plugins"
+FROM ${BASE_IMAGE}
 
-ARG KESTRA_PLUGINS=""
-ARG APT_PACKAGES=""
-ARG PYTHON_LIBRARIES=""
-
-WORKDIR /app
-
-RUN groupadd kestra && \
-    useradd -m -g kestra kestra
+ENV PATH="/app/.venv/bin:$PATH"
 
 COPY --chown=kestra:kestra docker /
 
-RUN apt-get update -y && \
-    apt-get upgrade -y && \
-    apt-get install curl -y && \
-    if [ -n "${APT_PACKAGES}" ]; then apt-get install -y --no-install-recommends ${APT_PACKAGES}; fi && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/* /var/tmp/* /tmp/* && \
-    curl -LsSf https://astral.sh/uv/0.6.17/install.sh | sh && mv /root/.local/bin/uv /bin && mv /root/.local/bin/uvx /bin && \
-    if [ -n "${KESTRA_PLUGINS}" ]; then /app/kestra plugins install ${KESTRA_PLUGINS} && rm -rf /tmp/*; fi && \
-    if [ -n "${PYTHON_LIBRARIES}" ]; then uv pip install --system ${PYTHON_LIBRARIES}; fi && \
+RUN --mount=type=bind,target=/mnt/context \
+    mkdir -p /app/plugins && \
+    { cp -r /mnt/context/plugins/. /app/plugins/ 2>/dev/null || true; } && \
     chown -R kestra:kestra /app
 
 USER kestra


### PR DESCRIPTION
## What

Backports the `develop` Docker release setup to `releases/v1.3.x`, so this release line publishes Docker images the same way `develop` does.

### Changes
- **`Dockerfile`** — build `FROM` the `kestra-base` image variant (`ghcr.io/kestra-io/kestra-base:latest-no-plugins` by default) instead of starting from `eclipse-temurin:25-jre-jammy` and installing the JRE/apt packages/`uv` at build time. Plugins are now provided by the base image + bind-mounted context.
- **`.github/workflows/release-docker.yml`** — enable `use-kestra-base-images: true` on the `kestra-oss-publish-docker.yml@main` reusable workflow. The `java-version` input (default `'25'`) and the `helm-release` job were already present on this branch and are left untouched.

## Why

`develop` already releases Docker via the `kestra-base` images; this brings `v1.3.x` to parity. Since this branch builds on Java 25 (`java-version` default `'25'`), the publish workflow selects the JRE 25 base variant — same as `develop`.

## Scope

Docker-only minimal change: the only edit to `release-docker.yml` is the single `use-kestra-base-images: true` line. The `Dockerfile` is version-agnostic (base image selected at release time), identical to `develop`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)