### PR TITLE
docs(flows): document Check 'when' boolean and eval-error semantics

### DIFF
--- a/core/src/main/java/io/kestra/core/models/flows/check/Check.java
+++ b/core/src/main/java/io/kestra/core/models/flows/check/Check.java
@@ -29,6 +29,15 @@ public class Check {
 
     /**
      * The condition to evaluate.
+     * <p>
+     * The expression must render to a real boolean {@code true} or {@code false}. A value that renders
+     * to anything else (for example the string {@code "true"} or {@code "yes"}, or a number) is treated
+     * as a <em>failed</em> check, because evaluation uses a strict {@code Boolean.TRUE.equals(...)} test.
+     * <p>
+     * If the expression cannot be evaluated at all (for example an undefined variable or a syntax error),
+     * the check fails safe: the execution is hard-blocked with {@link Behavior#BLOCK_EXECUTION} and
+     * {@link Style#ERROR}, overriding the declared {@code behavior} and {@code style} — a broken gate must
+     * never let a run through.
      */
     @NotNull
     @NotEmpty


### PR DESCRIPTION
## What

Adds javadoc to `Check.when` (`core/.../models/flows/check/Check.java`) documenting two intentional-but-undocumented behaviors of flow Checks, surfaced during 2.0 QA:

- The expression must render to a **real boolean** `true`/`false`. A value that renders to anything else (the string `"true"`/`"yes"`, a number, …) is treated as a **failed** check — evaluation uses a strict `Boolean.TRUE.equals(...)` in `FlowService.getFailedChecks`.
- If the expression **cannot be evaluated** (undefined variable, syntax error), the check fails safe to `BLOCK_EXECUTION` + `ERROR`, overriding the declared `behavior`/`style` — a broken gate must never let a run through.

No behavior change — javadoc only. Companion user-facing docs PR: kestra-io/docs (Checks page).

Refs kestra-io/kestra-ee#8711, part of kestra-io/kestra-ee#8184.
