### PR TITLE
docs(flows): document Check 'condition' boolean and eval-error semantics (1.3.x)

### DIFF
--- a/core/src/main/java/io/kestra/core/models/flows/check/Check.java
+++ b/core/src/main/java/io/kestra/core/models/flows/check/Check.java
@@ -28,6 +28,15 @@ public class Check {
 
     /**
      * The condition to evaluate.
+     * <p>
+     * The expression must render to a real boolean {@code true} or {@code false}. A value that renders
+     * to anything else (for example the string {@code "true"} or {@code "yes"}, or a number) is treated
+     * as a <em>failed</em> check, because evaluation uses a strict {@code Boolean.TRUE.equals(...)} test.
+     * <p>
+     * If the expression cannot be evaluated at all (for example an undefined variable or a syntax error),
+     * the check fails safe: the execution is hard-blocked with {@link Behavior#BLOCK_EXECUTION} and
+     * {@link Style#ERROR}, overriding the declared {@code behavior} and {@code style} — a broken gate must
+     * never let a run through.
      */
     @NotNull
     @NotEmpty


### PR DESCRIPTION
## What

Backport of #16954 to `releases/v1.3.x`. Adds javadoc to `Check.condition` (named `condition` on this branch; `when` on develop) documenting two intentional behaviors of flow Checks, surfaced during 2.0 QA:

- The expression must render to a **real boolean**; a non-boolean (string `"true"`/`"yes"`, a number, …) is treated as a **failed** check (strict `Boolean.TRUE.equals(...)`).
- An **un-evaluatable** expression fails safe to `BLOCK_EXECUTION` + `ERROR`, overriding the declared `behavior`/`style`.

No behavior change — javadoc only.

Refs kestra-io/kestra-ee#8711, part of kestra-io/kestra-ee#8184.
