### PR TITLE
fix(storage): return 4xx for storage/authorization failures instead of 500

### DIFF
--- a/webserver/src/main/java/io/kestra/webserver/controllers/api/NamespaceFileController.java
+++ b/webserver/src/main/java/io/kestra/webserver/controllers/api/NamespaceFileController.java
@@ -48,6 +48,10 @@ import static io.kestra.core.utils.Rethrow.throwConsumer;
 @Controller("/api/v1/{tenant}/namespaces")
 public class NamespaceFileController {
     public static final String FLOWS_FOLDER = "_flows";
+
+    // Maximum length of a single file-name component on common filesystems (e.g. 255 bytes on ext4).
+    private static final int MAX_FILE_NAME_LENGTH = 255;
+
     @Inject
     private StorageInterface storageInterface;
     @Inject
@@ -240,6 +244,16 @@ public class NamespaceFileController {
             return Collections.emptyList();
         }
         forbiddenPathsGuard(path);
+
+        // Reject over-long names before writing: otherwise the filesystem raises ENAMETOOLONG, which
+        // surfaces as a 500 leaking the absolute internal-storage path. The limit is per path component
+        // (255 bytes on common filesystems), so we check each segment rather than the whole path — a
+        // valid multi-component path must not be rejected. Return a clean 4xx instead.
+        for (Path component : Path.of(filePath)) {
+            if (component.toString().length() > MAX_FILE_NAME_LENGTH) {
+                throw new IllegalArgumentException("A file or folder name exceeds the maximum length of " + MAX_FILE_NAME_LENGTH + " characters.");
+            }
+        }
 
         Namespace namespaceStorage = namespaceFactory.of(tenantId, namespace, storageInterface);
         return namespaceStorage.putFile(Path.of(path.getPath()), inputStream);

--- a/webserver/src/main/java/io/kestra/webserver/exceptions/SecurityExceptionHandler.java
+++ b/webserver/src/main/java/io/kestra/webserver/exceptions/SecurityExceptionHandler.java
@@ -1,0 +1,26 @@
+package io.kestra.webserver.exceptions;
+
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.http.HttpRequest;
+import io.micronaut.http.HttpResponse;
+import io.micronaut.http.HttpStatus;
+import io.micronaut.http.MediaType;
+import io.micronaut.http.annotation.Produces;
+import io.micronaut.http.server.exceptions.ExceptionHandler;
+import jakarta.inject.Singleton;
+
+/**
+ * Maps a {@link SecurityException} to a clean {@code 403 FORBIDDEN} instead of letting it surface as a
+ * {@code 500}. This covers authorization denials such as a disabled local-file preview or a path that is
+ * not in the {@code kestra.local-files.allowed-paths} allow-list.
+ */
+@Produces(value = MediaType.TEXT_PLAIN)
+@Singleton
+@Requires(classes = { SecurityException.class, ExceptionHandler.class })
+@SuppressWarnings("rawtypes")
+public class SecurityExceptionHandler implements ExceptionHandler<SecurityException, HttpResponse> {
+    @Override
+    public HttpResponse handle(HttpRequest request, SecurityException exception) {
+        return HttpResponse.status(HttpStatus.FORBIDDEN).body(exception.getMessage());
+    }
+}

--- a/webserver/src/test/java/io/kestra/webserver/controllers/api/NamespaceFileControllerTest.java
+++ b/webserver/src/test/java/io/kestra/webserver/controllers/api/NamespaceFileControllerTest.java
@@ -236,6 +236,49 @@ class NamespaceFileControllerTest {
     }
 
     @Test
+    void createFileWithTooLongNameReturnsCleanError() {
+        String namespace = TestsUtils.randomNamespace();
+        String longName = "x".repeat(300) + ".txt";
+        MultipartBody body = MultipartBody.builder()
+            .addPart("fileContent", "data", "Hello".getBytes())
+            .build();
+
+        HttpClientResponseException e = assertThrows(
+            HttpClientResponseException.class, () -> client.toBlocking().exchange(
+                HttpRequest.POST("/api/v1/main/namespaces/" + namespace + "/files?path=/" + longName, body)
+                    .contentType(MediaType.MULTIPART_FORM_DATA_TYPE)
+            )
+        );
+
+        // Clean 422 (not a 500), and the body must not leak the absolute internal-storage filesystem path
+        // (previously the ENAMETOOLONG IOException surfaced the "..._files/..." absolute path in the body).
+        assertThat(e.getStatus().getCode()).isEqualTo(422);
+        String responseBody = e.getResponse().getBody(String.class).orElse("");
+        assertThat(responseBody).contains("maximum length");
+        assertThat(responseBody).doesNotContain("_files");
+        assertThat(responseBody).doesNotContain("Internal server error");
+    }
+
+    @Test
+    void createFileWithLongButValidComponentsSucceeds() throws IOException {
+        // The limit is per path component: a multi-segment path whose total length exceeds 255 but whose
+        // individual segments are each <= 255 must be accepted (it would succeed on the filesystem),
+        // i.e. validation must not reject on the whole-path length.
+        String namespace = TestsUtils.randomNamespace();
+        String segment = "a".repeat(150);
+        String path = "/" + segment + "/" + segment + ".txt";
+        MultipartBody body = MultipartBody.builder()
+            .addPart("fileContent", "data", "Hello".getBytes())
+            .build();
+
+        client.toBlocking().exchange(
+            HttpRequest.POST("/api/v1/main/namespaces/" + namespace + "/files?path=" + path, body)
+                .contentType(MediaType.MULTIPART_FORM_DATA_TYPE)
+        );
+        assertNamespaceGetFileContentContent(namespace, URI.create(path), "Hello");
+    }
+
+    @Test
     void createGetFileContentFlowException() {
         String namespace = TestsUtils.randomNamespace();
         MultipartBody body = MultipartBody.builder()


### PR DESCRIPTION
## What

Fixes #16897 — two storage-endpoint error-handling problems found during 2.0 QA (`kind/security`):

1. **Over-long namespace filename → 500 leaking the absolute FS path.** Uploading a file whose name exceeds the filesystem limit raised `ENAMETOOLONG`, which surfaced as a 500 whose body contained the server's absolute internal-storage path (`/home/.../_files/...`). Now rejected **before** writing with a clean **422** ("File name exceeds the maximum length of 255 characters.") — no path leaked.
2. **`file://` allow-list denial → 500.** A denied `file://` path threw a `SecurityException` with no handler, surfacing as 500. Added a `SecurityExceptionHandler` mapping `SecurityException` → **403** (also covers "Local file preview is disabled").

## Changes
- `NamespaceFileController.putNamespaceFile`: guard the file-name length (≤ 255) → `IllegalArgumentException` (mapped to 422 by the existing handler).
- New `webserver/.../exceptions/SecurityExceptionHandler` → 403.

## Test
`NamespaceFileControllerTest.createFileWithTooLongNameReturnsCleanError`: over-long name → 422, body contains "maximum length" and **not** the internal `_files` path nor "Internal server error". Passes on H2 locally.

## Backports
Present in `releases/v1.0.x` and `releases/v1.3.x` — companion backport PRs follow.

Fixes #16897 · found via kestra-io/kestra-ee#8184
