### PR TITLE
fix(storage): return 4xx for storage/authorization failures instead of 500 (1.0.x)

### DIFF
--- a/webserver/src/main/java/io/kestra/webserver/controllers/api/NamespaceFileController.java
+++ b/webserver/src/main/java/io/kestra/webserver/controllers/api/NamespaceFileController.java
@@ -43,6 +43,10 @@ import lombok.extern.slf4j.Slf4j;
 @Controller("/api/v1/{tenant}/namespaces")
 public class NamespaceFileController {
     public static final String FLOWS_FOLDER = "_flows";
+
+    // Maximum length of a single file-name component on common filesystems (e.g. 255 bytes on ext4).
+    private static final int MAX_FILE_NAME_LENGTH = 255;
+
     @Inject
     private StorageInterface storageInterface;
     @Inject
@@ -189,6 +193,17 @@ public class NamespaceFileController {
             return;
         }
         forbiddenPathsGuard(path);
+
+        // Reject over-long names before writing: otherwise the filesystem raises ENAMETOOLONG, which
+        // surfaces as a 500 leaking the absolute internal-storage path. The limit is per path component
+        // (255 bytes on common filesystems), so we check each segment rather than the whole path — a
+        // valid multi-component path must not be rejected. Return a clean 4xx instead.
+        for (Path component : Path.of(filePath)) {
+            if (component.toString().length() > MAX_FILE_NAME_LENGTH) {
+                throw new IllegalArgumentException("A file or folder name exceeds the maximum length of " + MAX_FILE_NAME_LENGTH + " characters.");
+            }
+        }
+
         storageInterface.put(tenantId, namespace, NamespaceFile.of(namespace, path).uri(), inputStream);
     }
 

--- a/webserver/src/main/java/io/kestra/webserver/exceptions/SecurityExceptionHandler.java
+++ b/webserver/src/main/java/io/kestra/webserver/exceptions/SecurityExceptionHandler.java
@@ -1,0 +1,26 @@
+package io.kestra.webserver.exceptions;
+
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.http.HttpRequest;
+import io.micronaut.http.HttpResponse;
+import io.micronaut.http.HttpStatus;
+import io.micronaut.http.MediaType;
+import io.micronaut.http.annotation.Produces;
+import io.micronaut.http.server.exceptions.ExceptionHandler;
+import jakarta.inject.Singleton;
+
+/**
+ * Maps a {@link SecurityException} to a clean {@code 403 FORBIDDEN} instead of letting it surface as a
+ * {@code 500}. This covers authorization denials such as a disabled local-file preview or a path that is
+ * not in the {@code kestra.local-files.allowed-paths} allow-list.
+ */
+@Produces(value = MediaType.TEXT_PLAIN)
+@Singleton
+@Requires(classes = { SecurityException.class, ExceptionHandler.class })
+@SuppressWarnings("rawtypes")
+public class SecurityExceptionHandler implements ExceptionHandler<SecurityException, HttpResponse> {
+    @Override
+    public HttpResponse handle(HttpRequest request, SecurityException exception) {
+        return HttpResponse.status(HttpStatus.FORBIDDEN).body(exception.getMessage());
+    }
+}

--- a/webserver/src/test/java/io/kestra/webserver/controllers/api/NamespaceFileControllerTest.java
+++ b/webserver/src/test/java/io/kestra/webserver/controllers/api/NamespaceFileControllerTest.java
@@ -183,6 +183,46 @@ class NamespaceFileControllerTest {
     }
 
     @Test
+    void createFileWithTooLongNameReturnsCleanError() {
+        String longName = "x".repeat(300) + ".txt";
+        MultipartBody tooLongBody = MultipartBody.builder()
+            .addPart("fileContent", "data", "Hello".getBytes())
+            .build();
+
+        HttpClientResponseException e = assertThrows(
+            HttpClientResponseException.class, () -> client.toBlocking().exchange(
+                HttpRequest.POST("/api/v1/main/namespaces/" + NAMESPACE + "/files?path=/" + longName, tooLongBody)
+                    .contentType(MediaType.MULTIPART_FORM_DATA_TYPE)
+            )
+        );
+
+        // Clean 422 (not a 500), and the body must not leak the absolute internal-storage filesystem path.
+        assertThat(e.getStatus().getCode()).isEqualTo(422);
+        String responseBody = e.getResponse().getBody(String.class).orElse("");
+        assertThat(responseBody).contains("maximum length");
+        assertThat(responseBody).doesNotContain("_files");
+        assertThat(responseBody).doesNotContain("Internal server error");
+    }
+
+    @Test
+    void createFileWithLongButValidComponentsSucceeds() throws IOException {
+        // The limit is per path component: a multi-segment path whose total length exceeds 255 but whose
+        // individual segments are each <= 255 must be accepted (it would succeed on the filesystem),
+        // i.e. validation must not reject on the whole-path length.
+        String segment = "a".repeat(150);
+        String path = "/" + segment + "/" + segment + ".txt";
+        MultipartBody body = MultipartBody.builder()
+            .addPart("fileContent", "data", "Hello".getBytes())
+            .build();
+
+        client.toBlocking().exchange(
+            HttpRequest.POST("/api/v1/main/namespaces/" + NAMESPACE + "/files?path=" + path, body)
+                .contentType(MediaType.MULTIPART_FORM_DATA_TYPE)
+        );
+        assertNamespaceGetFileContentContent(URI.create(path), "Hello");
+    }
+
+    @Test
     void createGetFileContentFlowException() {
         MultipartBody body = MultipartBody.builder()
             .addPart("fileContent", "_flows", "Hello".getBytes())


### PR DESCRIPTION
Backport of #16957 (develop) to `releases/v1.0.x` — fixes #16897:
- over-long namespace filename → clean **422** instead of a 500 leaking the absolute internal-storage path (guard added before `storageInterface.put`, adapted to this branch's controller);
- denied `file://` paths → **403** via a new `SecurityExceptionHandler`.

Note: this branch has a **pre-existing, unrelated** test-compilation error in `ExecutionControllerRunnerTest.java:1554` (an undeclared `TimeoutException`) that blocks running the webserver test module locally; the three files in this PR compile cleanly. Relying on CI to validate.

Refs #16897. (Auto-close handled by #16957 on develop.)
