### PR TITLE
fix(executions): don't spawn Pause subtasks when killing a paused execution

### DIFF
--- a/core/src/main/java/io/kestra/core/services/ExecutionService.java
+++ b/core/src/main/java/io/kestra/core/services/ExecutionService.java
@@ -485,6 +485,11 @@ public class ExecutionService {
                         } else if (newState == State.Type.KILLING) {
                             targetState = State.Type.KILLED;
                         }
+                    } else if (newState == State.Type.KILLING) {
+                        // when killing a paused execution, terminate the Pause task directly instead of
+                        // resuming it to RUNNING; otherwise its subtasks would be spawned during the kill
+                        // (regression covered by ExecutionControllerRunnerTest.killExecutionPaused).
+                        targetState = State.Type.KILLED;
                     } else {
                         // we should set the state to RUNNING so that subtasks are executed
                         targetState = State.Type.RUNNING;


### PR DESCRIPTION
## What

When killing a **paused** execution whose `Pause` task has subtasks, the subtasks were being spawned during the kill, leaving the execution with an extra `CREATED` taskRun.

This made `ExecutionControllerRunnerTest.killExecutionPaused` fail on `releases/v1.3.x`:

```
java.lang.AssertionError:
Expected size: 1 but was: 2
```
(the `pause` taskRun + a newly-spawned `subtask`)

## Root cause

`ExecutionService.kill()` resumes a paused `Pause` task so it can be terminated. In `markAs()`, a `Pause` task **with subtasks** was always set to `RUNNING` — even when the target state was `KILLING`:

```java
} else {
    // we should set the state to RUNNING so that subtasks are executed
    targetState = State.Type.RUNNING;
}
```

This was harmless until `1f6c31247d` (`fix(executions): after execution killing`) made `ExecutorService.handleChildNext` run in the `KILLED` state — needed so `afterExecution` flowable tasks (e.g. `If`) can resolve their children when an execution is killed. As a side effect, the Pause task resumed-to-`RUNNING` now had its children resolved during the kill.

## Fix

When `newState == KILLING`, terminate the `Pause` taskRun directly to `KILLED` instead of resuming it to `RUNNING`, so no children are spawned. The normal resume path (`newState == RUNNING`) is unchanged and still runs subtasks.

This mirrors `develop`, where the equivalent `markAs` branch already terminates the Pause on kill (develop dropped the `getTasks()` guard as part of the executor refactor; this is the minimal equivalent for the `1.3.x` executor).

## Tests

- `ExecutionControllerRunnerTest.killExecutionPaused` ✅ (was failing)
- `killExecution`, `updateExecutionStatusShouldFailForKilled`, `resume*` ✅
- `core` `PauseTest`, `ExecutionServiceTest` ✅