### PR TITLE
[backport releases/v1.3.x] feat(core): add full arg to the secret() pebble function

### DIFF
--- a/core/src/main/java/io/kestra/core/runners/pebble/functions/SecretFunction.java
+++ b/core/src/main/java/io/kestra/core/runners/pebble/functions/SecretFunction.java
@@ -1,6 +1,7 @@
 package io.kestra.core.runners.pebble.functions;
 
 import java.io.IOException;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
@@ -12,6 +13,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.kestra.core.runners.RunVariables;
 import io.kestra.core.secret.SecretException;
 import io.kestra.core.secret.SecretNotFoundException;
+import io.kestra.core.secret.SecretObject;
 import io.kestra.core.secret.SecretService;
 import io.kestra.core.serializers.JacksonMapper;
 import io.kestra.core.services.NamespaceService;
@@ -33,6 +35,9 @@ public class SecretFunction implements Function {
     private static final String SUBKEY_ARG = "subkey";
     private static final String NAMESPACE_ARG = "namespace";
     private static final String KEY_ARG = "key";
+    private static final String FULL_ARG = "full";
+    private static final String VALUE_KEY = "value";
+    private static final String METADATA_KEY = "metadata";
 
     @Inject
     private SecretService secretService;
@@ -42,7 +47,7 @@ public class SecretFunction implements Function {
 
     @Override
     public List<String> getArgumentNames() {
-        return List.of(KEY_ARG, NAMESPACE_ARG, SUBKEY_ARG);
+        return List.of(KEY_ARG, NAMESPACE_ARG, SUBKEY_ARG, FULL_ARG);
     }
 
     @SuppressWarnings("unchecked")
@@ -61,10 +66,29 @@ public class SecretFunction implements Function {
             namespaceService.checkAllowedNamespace(flowTenantId, namespace, flowTenantId, flowNamespace);
         }
 
+        final String subkey = (String) args.get(SUBKEY_ARG);
+        final boolean full = Boolean.TRUE.equals(args.get(FULL_ARG));
+
+        if (full && subkey != null && !subkey.isEmpty()) {
+            throw new PebbleException(null, "The 'secret' function cannot be called with both 'subkey' and 'full' arguments.", lineNumber, self.getName());
+        }
+
         try {
+            if (full) {
+                SecretObject secretObject = secretService.findSecretObject(flowTenantId, namespace, key);
+                consumeSecret(context, secretObject.value());
+
+                Map<String, Object> result = new LinkedHashMap<>();
+                result.put(VALUE_KEY, secretObject.value());
+                if (!secretObject.metadata().isEmpty()) {
+                    secretObject.metadata().values().forEach(value -> consumeSecret(context, value));
+                    result.put(METADATA_KEY, secretObject.metadata());
+                }
+                return result;
+            }
+
             String secret = secretService.findSecret(flowTenantId, namespace, key);
 
-            final String subkey = (String) args.get(SUBKEY_ARG);
             if (subkey != null && !subkey.isEmpty()) {
                 try {
                     JsonNode subkeys = OBJECT_MAPPER.readTree(secret);
@@ -85,16 +109,20 @@ public class SecretFunction implements Function {
                 }
             }
 
-            try {
-                Consumer<String> addSecretConsumer = (Consumer<String>) context.getVariable(RunVariables.SECRET_CONSUMER_VARIABLE_NAME);
-                addSecretConsumer.accept(secret);
-            } catch (Exception e) {
-                log.warn("Unable to get secret consumer", e);
-            }
-
+            consumeSecret(context, secret);
             return secret;
         } catch (SecretException | IOException e) {
             throw new PebbleException(e, e.getMessage(), lineNumber, self.getName());
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private void consumeSecret(EvaluationContext context, String value) {
+        try {
+            Consumer<String> addSecretConsumer = (Consumer<String>) context.getVariable(RunVariables.SECRET_CONSUMER_VARIABLE_NAME);
+            addSecretConsumer.accept(value);
+        } catch (Exception e) {
+            log.warn("Unable to get secret consumer", e);
         }
     }
 

--- a/core/src/main/java/io/kestra/core/secret/SecretObject.java
+++ b/core/src/main/java/io/kestra/core/secret/SecretObject.java
@@ -1,0 +1,20 @@
+package io.kestra.core.secret;
+
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * A secret in full mode: the main value plus any additional fields.
+ *
+ * @param value the main secret value.
+ * @param metadata the additional fields, empty when there are none. Never null.
+ */
+public record SecretObject(String value, Map<String, String> metadata) {
+    public SecretObject {
+        Objects.requireNonNull(metadata, "metadata cannot be null");
+    }
+
+    public SecretObject(String value) {
+        this(value, Map.of());
+    }
+}

--- a/core/src/main/java/io/kestra/core/secret/SecretService.java
+++ b/core/src/main/java/io/kestra/core/secret/SecretService.java
@@ -57,6 +57,14 @@ public class SecretService<META> {
         return secret;
     }
 
+    /**
+     * Finds the secret in full mode, as a value plus metadata.
+     * The default returns the value with empty metadata. Multi-field secret managers override this to add metadata.
+     */
+    public SecretObject findSecretObject(String tenantId, String namespace, String key) throws SecretNotFoundException, IOException {
+        return new SecretObject(findSecret(tenantId, namespace, key));
+    }
+
     public ArrayListTotal<META> list(Pageable pageable, String tenantId, List<QueryFilter> filters) throws IOException {
         final Predicate<String> queryPredicate = filters.stream()
             .filter(filter -> filter.field().equals(QueryFilter.Field.QUERY) && filter.value() != null)

--- a/core/src/test/java/io/kestra/core/secret/SecretFunctionTest.java
+++ b/core/src/test/java/io/kestra/core/secret/SecretFunctionTest.java
@@ -1,6 +1,7 @@
 package io.kestra.core.secret;
 
 import java.io.IOException;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -117,6 +118,39 @@ public class SecretFunctionTest {
     }
 
     @Test
+    void shouldGetSecretGivenFull() throws IllegalVariableEvaluationException {
+        // Given
+        Map<String, Object> context = Map.of(
+            "flow", Map.of("namespace", "io.kestra.unittest")
+        );
+
+        // When / Then
+        // structured secret manager: value plus metadata
+        assertThat(variableRenderer.render("{{ secret('credential', full=true).value }}", context)).isEqualTo("my-password");
+        assertThat(variableRenderer.render("{{ secret('credential', full=true).metadata.username }}", context)).isEqualTo("my-user");
+        assertThat(variableRenderer.render("{{ secret('credential', full=true).metadata.domain }}", context)).isEqualTo("kestra-io");
+
+        // single-value secret: only value, no metadata
+        assertThat(variableRenderer.render("{{ secret('string-secret', full=true).value }}", context)).isEqualTo("string-value");
+    }
+
+    @Test
+    void shouldFailedGivenBothSubKeyAndFull() {
+        // Given
+        Map<String, Object> context = Map.of(
+            "flow", Map.of("namespace", "io.kestra.unittest")
+        );
+
+        // When / Then
+        Throwable cause = Assertions.assertThrows(IllegalVariableEvaluationException.class, () ->
+        {
+            variableRenderer.render("{{ secret('json-secret', subkey='string', full=true) }}", context);
+        }).getCause();
+        assertThat(cause.getMessage())
+            .isEqualTo("The 'secret' function cannot be called with both 'subkey' and 'full' arguments. ({{ secret('json-secret', subkey='string', full=true) }}:1)");
+    }
+
+    @Test
     void getUnknownSecret() {
         var exception = assertThrows(SecretNotFoundException.class, () -> secretService.findSecret(null, null, "unknown_secret_key"));
         assertThat(exception.getMessage()).isEqualTo("Cannot find secret for key 'unknown_secret_key'.");
@@ -144,6 +178,17 @@ public class SecretFunctionTest {
                 return optional.get();
             }
             return super.findSecret(tenantId, namespace, key);
+        }
+
+        @Override
+        public SecretObject findSecretObject(String tenantId, String namespace, String key) throws SecretNotFoundException, IOException {
+            if ("credential".equals(key)) {
+                Map<String, String> metadata = new LinkedHashMap<>();
+                metadata.put("username", "my-user");
+                metadata.put("domain", "kestra-io");
+                return new SecretObject("my-password", metadata);
+            }
+            return super.findSecretObject(tenantId, namespace, key);
         }
     }
 }


### PR DESCRIPTION
Backport of #16731 to `releases/v1.3.x`. Manual re-apply, not a clean cherry-pick: v1.3 diverged from develop.

Adds the `full` argument to `secret()`, returning the whole secret as `{value, metadata}`. Default behaviour unchanged.

1.3 adaptations:
- Re-applied onto v1.3.x's `SecretFunction` (still implements `Function`, not `KestraFunction`, direct `@Inject SecretService` with no `Provider`).
- Dropped `PebbleExpressionServiceTest` (does not exist on 1.3).

Verified locally: core `compileJava`/`compileTestJava` and `SecretFunctionTest` pass.

(cherry picked from commit 050a539436730923217e843986a4fc314271c813)