### PR TITLE
fix(design-system): render KsDescriptions rows

### DIFF
--- a/ui/packages/design-system/src/components/Data/KsDescriptionsItem.vue
+++ b/ui/packages/design-system/src/components/Data/KsDescriptionsItem.vue
@@ -13,7 +13,7 @@
     import {ElDescriptionsItem} from "element-plus"
     import {useFilteredProps} from "../../utils/filteredProps"
 
-    defineOptions({inheritAttrs: false})
+    defineOptions({inheritAttrs: false, name: "ElDescriptionsItem"})
 
     const props = defineProps<{
         label?: string

--- a/ui/packages/design-system/tests/units/Data/KsDescriptions.test.ts
+++ b/ui/packages/design-system/tests/units/Data/KsDescriptions.test.ts
@@ -1,0 +1,44 @@
+import {describe, test, expect} from "vitest"
+import {mount} from "@vue/test-utils"
+import KsDescriptions from "../../../src/components/Data/KsDescriptions.vue"
+import KsDescriptionsItem from "../../../src/components/Data/KsDescriptionsItem.vue"
+
+// Mount the two components directly (they import Element Plus themselves) rather than the whole
+// design-system plugin, to avoid unrelated heavy deps in the index.
+const globalConfig = {}
+
+describe("KsDescriptions", () => {
+    // Regression: ElDescriptions collects rows by filtering slot children whose component name is
+    // exactly "ElDescriptionsItem". KsDescriptionsItem must be detectable as such, otherwise every
+    // row is dropped and the descriptions block renders empty.
+    test("renders rows declared with KsDescriptionsItem", () => {
+        const wrapper = mount({
+            components: {KsDescriptions, KsDescriptionsItem},
+            template: `
+                <ks-descriptions border :column="1">
+                    <ks-descriptions-item label="Status">RUNNING</ks-descriptions-item>
+                </ks-descriptions>
+            `,
+        }, {global: globalConfig})
+
+        expect(wrapper.text()).toContain("Status")
+        expect(wrapper.text()).toContain("RUNNING")
+    })
+
+    test("renders the #label slot of a KsDescriptionsItem", () => {
+        const wrapper = mount({
+            components: {KsDescriptions, KsDescriptionsItem},
+            template: `
+                <ks-descriptions border :column="1">
+                    <ks-descriptions-item>
+                        <template #label>Custom Label</template>
+                        VALUE
+                    </ks-descriptions-item>
+                </ks-descriptions>
+            `,
+        }, {global: globalConfig})
+
+        expect(wrapper.text()).toContain("Custom Label")
+        expect(wrapper.text()).toContain("VALUE")
+    })
+})


### PR DESCRIPTION
`KsDescriptionsItem` are currently drop from `ksDescription` because of the missing name