### PR TITLE
fix(scheduler): de-flake SchedulerScheduleTest.schedule() — two root-cause fixes

### DIFF
--- a/jdbc/src/main/java/io/kestra/jdbc/runner/JdbcQueue.java
+++ b/jdbc/src/main/java/io/kestra/jdbc/runner/JdbcQueue.java
@@ -39,6 +39,7 @@ import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.Timer;
 import io.micronaut.context.ApplicationContext;
 import io.micronaut.context.annotation.ConfigurationProperties;
+import io.micronaut.data.connection.jdbc.exceptions.CannotGetJdbcConnectionException;
 import io.micronaut.transaction.exceptions.CannotCreateTransactionException;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
@@ -473,7 +474,11 @@ public abstract class JdbcQueue<T> implements QueueInterface<T> {
                             // then select the last one (longest) or minPoll if all are beyond while means we are under the first interval
                             sleep = selectedSteps.isEmpty() ? configuration.minPollInterval : selectedSteps.getLast().pollInterval();
                         }
-                    } catch (CannotCreateTransactionException e) {
+                    } catch (CannotCreateTransactionException | CannotGetJdbcConnectionException e) {
+                        // These occur when the datasource / connection pool is closed during shutdown (e.g. context
+                        // teardown between rebuilt test contexts). They are benign teardown conditions, not fatal:
+                        // the poll loop will exit via running/isClosed once shutdown completes. Treating them as fatal
+                        // would needlessly shut the whole queue (and server) down.
                         if (log.isDebugEnabled()) {
                             log.debug("Can't poll on receive", e);
                         }

--- a/scheduler/src/main/java/io/kestra/scheduler/AbstractScheduler.java
+++ b/scheduler/src/main/java/io/kestra/scheduler/AbstractScheduler.java
@@ -281,18 +281,26 @@ public abstract class AbstractScheduler implements Scheduler {
                     }
 
                     WorkerTriggerResult workerTriggerResult = either.getLeft();
-                    if (workerTriggerResult.getTrigger() instanceof RealtimeTriggerInterface && workerTriggerResult.getExecution().isPresent()) {
-                        this.emitExecution(workerTriggerResult.getExecution().get(), workerTriggerResult.getTriggerContext());
-                    } else if (workerTriggerResult.getExecution().isPresent()) {
-                        SchedulerExecutionWithTrigger triggerExecution = new SchedulerExecutionWithTrigger(
-                            workerTriggerResult.getExecution().get(),
-                            workerTriggerResult.getTriggerContext()
-                        );
-                        ZonedDateTime nextExecutionDate = this.nextEvaluationDate(workerTriggerResult.getTrigger());
-                        this.handleEvaluateWorkerTriggerResult(triggerExecution, nextExecutionDate);
-                    } else {
-                        ZonedDateTime nextExecutionDate = this.nextEvaluationDate(workerTriggerResult.getTrigger());
-                        this.triggerState.update(Trigger.of(workerTriggerResult.getTriggerContext(), nextExecutionDate));
+                    // Processing a single worker trigger result must never crash the consumer: an error here (e.g. a
+                    // misconfigured trigger whose nextEvaluationDate() throws) would otherwise bubble up to the queue
+                    // poller, which treats it as fatal and shuts the whole scheduler down. Log and skip the bad result
+                    // instead, so the other triggers keep being scheduled.
+                    try {
+                        if (workerTriggerResult.getTrigger() instanceof RealtimeTriggerInterface && workerTriggerResult.getExecution().isPresent()) {
+                            this.emitExecution(workerTriggerResult.getExecution().get(), workerTriggerResult.getTriggerContext());
+                        } else if (workerTriggerResult.getExecution().isPresent()) {
+                            SchedulerExecutionWithTrigger triggerExecution = new SchedulerExecutionWithTrigger(
+                                workerTriggerResult.getExecution().get(),
+                                workerTriggerResult.getTriggerContext()
+                            );
+                            ZonedDateTime nextExecutionDate = this.nextEvaluationDate(workerTriggerResult.getTrigger());
+                            this.handleEvaluateWorkerTriggerResult(triggerExecution, nextExecutionDate);
+                        } else {
+                            ZonedDateTime nextExecutionDate = this.nextEvaluationDate(workerTriggerResult.getTrigger());
+                            this.triggerState.update(Trigger.of(workerTriggerResult.getTriggerContext(), nextExecutionDate));
+                        }
+                    } catch (Exception e) {
+                        log.error("Unable to process the worker trigger result for trigger '{}'. Skipping it.", workerTriggerResult.getTriggerContext().uid(), e);
                     }
                 }
             )


### PR DESCRIPTION
De-flakes `{Mysql,Postgres}SchedulerScheduleTest.schedule()` on `releases/v1.0.x` (issue #16969) by fixing **two distinct root causes**, both of which manifest as the same symptom — the `CountDownLatch` freezes and the test times out at ~61s with `expected: 0L but was: <n>L` (`SchedulerScheduleTest.java:177`). The common mechanism: a background queue poller throws, `JdbcQueue` treats it as **fatal**, calls `KestraContext.shutdown()`, and tears the whole scheduler down mid-test so backfill executions stop.

## Fix 1 — `JdbcQueue`: closed connection pool is not fatal (commit 1)

`JdbcQueue.poll()` caught `CannotCreateTransactionException` as benign but routed every other exception — including `CannotGetJdbcConnectionException` (HikariCP pool closed during context teardown under `@KestraTest(rebuildContext = true)`) — into the fatal branch. This was the mode observed in the original #16969 report (CI runs 27765498169 / 27674607099, Jun 17–18):

```
ERROR jdbc-queue-Trigger_0  JdbcQueue  Fatal error while polling the 'Trigger' queue. Initiating shutdown.
  CannotGetJdbcConnectionException: ... HikariDataSource (HikariPool-23) has been closed.
```

Fix: treat `CannotGetJdbcConnectionException` the same as `CannotCreateTransactionException` — a benign datasource-closed-during-shutdown condition, logged at debug. Mirrors the develop fix `f463b82ee2` (in the refactored `AbstractPollingSubscriber`), which can't be cherry-picked because the queue layer was restructured after v1.0.x was cut.

## Fix 2 — Scheduler: a bad worker trigger result must not crash the scheduler (commit 2)

Re-running this PR's CI surfaced a **second, distinct** mode. The `WorkerTriggerResult` queue consumer in `AbstractScheduler.run()` computed the next evaluation date with no error handling:

```
ERROR jdbc-queue-WorkerTriggerResult_0  JdbcQueue  Fatal error while polling the 'WorkerTriggerResult' queue. Initiating shutdown.
java.lang.NullPointerException: amountToAdd
  at java.time.ZonedDateTime.plus(ZonedDateTime.java:1555)
  at io.kestra.core.models.triggers.PollingTriggerInterface.nextEvaluationDate(PollingTriggerInterface.java:42)
  at io.kestra.scheduler.AbstractScheduler.nextEvaluationDate(AbstractScheduler.java:469)
  at io.kestra.scheduler.AbstractScheduler.lambda$run$5(AbstractScheduler.java:294)
```

A polling trigger whose `getInterval()` is null hits the default `PollingTriggerInterface.nextEvaluationDate()` (`now().plus(null)` → NPE). Because the call sits inside the queue consumer, the NPE bubbles to the poller → fatal → scheduler shutdown. (The in-scheduler evaluation path already tolerates such per-trigger errors — that's how the test's intentionally-invalid `Asia/Delhi` timezone trigger is merely logged as "Evaluate Failed".)

Fix: wrap the per-result processing in `AbstractScheduler.run()` in a try/catch — log and skip the offending result so the remaining triggers keep being scheduled.

## Testing

- `:jdbc:compileJava` and `:scheduler:compileJava` both succeed.
- The flake is not reliably reproducible locally (passes repeatedly even under CPU saturation); validation is via CI re-runs of the scheduler suite. The previous CI failures were `schedule()` (both DBs) plus other timing-sensitive tests amplified by an overloaded runner.

Fixes #16969