### PR TITLE
fix(executions): don't spawn Pause subtasks when killing a paused execution

### DIFF
--- a/core/src/main/java/io/kestra/core/services/ExecutionService.java
+++ b/core/src/main/java/io/kestra/core/services/ExecutionService.java
@@ -465,6 +465,11 @@ public class ExecutionService {
                         } else if (newState == State.Type.KILLING) {
                             targetState = State.Type.KILLED;
                         }
+                    } else if (newState == State.Type.KILLING) {
+                        // when killing a paused execution, terminate the Pause task directly instead of
+                        // resuming it to RUNNING; otherwise its subtasks would be spawned during the kill
+                        // (regression covered by ExecutionControllerRunnerTest.killExecutionPaused).
+                        targetState = State.Type.KILLED;
                     } else {
                         // we should set the state to RUNNING so that subtasks are executed
                         targetState = State.Type.RUNNING;


### PR DESCRIPTION
## What

Fixes the deterministically-failing `ExecutionControllerRunnerTest > killExecutionPaused()` on `releases/v1.0.x`.

## Root cause

When killing a **PAUSED** execution whose `Pause` task has subtasks (as in `pause-test.yaml`), `ExecutionService.markAs()` unconditionally resumed the Pause to `RUNNING` so its subtasks would execute — even on the kill path. This transitioned the Pause `PAUSED -> RUNNING` (producing the `Can't change state, already RUNNING` warning) and spawned the subtask `TaskRun` during the kill, leaving a `TaskRunList` of size 2 instead of 1.

The **no-subtask** branch already handled the `KILLING` transition by terminating the Pause to `KILLED`. This applies the same handling to the **with-subtask** branch: when `newState == KILLING`, set the Pause's `targetState` to `KILLED` instead of `RUNNING`, so no subtasks are spawned while killing.

## Verification

```
./gradlew :webserver:test --tests "*ExecutionControllerRunnerTest.killExecutionPaused" \
  --tests "*ExecutionControllerRunnerTest.killExecution" --tests "*ExecutionControllerRunnerTest.resume*"
./gradlew :core:test --tests "*ExecutionServiceTest" --tests "*PauseTest"
```

All green. The failing test reproduced deterministically before the change (size 2 ≠ 1, with the `Can't change state, already RUNNING` warning) and passes after.

Sibling fix to #16962 (same root cause on `releases/v1.3.x`); the 1.0.x code structure nests the kill handling differently, so the fix lands in the with-subtask branch here.