### PR TITLE
fix(topology): compute EE flow topology by bypassing ACLs in updateTopology

### DIFF
--- a/core/src/main/java/io/kestra/core/services/FlowService.java
+++ b/core/src/main/java/io/kestra/core/services/FlowService.java
@@ -201,17 +201,26 @@ public class FlowService {
     }
 
     private void updateTopology(FlowWithSource flow) {
-        flowTopologyRepository.save(
-            flow,
-            (flow.isDeleted() ? Stream.<FlowTopology> empty()
-                : flowTopologyService
-                    .topology(
-                        flow,
-                        flowRepository.findAllWithSource(flow.getTenantId())
-                    ))
-                .distinct()
-                .toList()
-        );
+        // Runs on a background thread with no HTTP request / user context, so the ACL-aware
+        // findAllWithSource() would return zero flows in EE and produce an empty topology.
+        // Topology is a system-wide computation: bypass ACLs with findAllWithSourceWithNoAcl().
+        try {
+            flowTopologyRepository.save(
+                flow,
+                (flow.isDeleted() ? Stream.<FlowTopology> empty()
+                    : flowTopologyService
+                        .topology(
+                            flow,
+                            flowRepository.findAllWithSourceWithNoAcl(flow.getTenantId())
+                        ))
+                    .distinct()
+                    .toList()
+            );
+        } catch (Exception e) {
+            // The Future returned by executorService.submit(...) is never get()-ed, so without
+            // this log a topology failure would be silently swallowed.
+            log.error("Unable to update the flow topology for flow '{}'", flow.uidWithoutRevision(), e);
+        }
     }
 
     private void recomputeTriggers(FlowWithSource flow) {


### PR DESCRIPTION
## What

`FlowService.updateTopology()` now queries flows with `findAllWithSourceWithNoAcl()` instead of the ACL-aware `findAllWithSource()`, and logs failures at `error` instead of swallowing them.

## Why

Fixes kestra-io/kestra-ee#8814 (EE-specific; OSS is unaffected).

`updateTopology()` is dispatched on a background thread via `executorService.submit(...)` and therefore has **no HTTP request / user context**. In EE, the flow repository's `defaultFilter()` ANDs in an ACL namespace filter built from `currentUserContext.allowedNamespaces(FLOW)`:

```java
List<Condition> ors = new ArrayList<>();
for (String namespace : currentUserContext.allowedNamespaces(Resource.FLOW)) {
    ors.add(field("namespace").eq(namespace));
    ors.add(field("namespace").startsWith(namespace + "."));
}
return condition.and(DSL.or(ors)); // DSL.or([]) → false when no user context
```

With no user context that list is empty, so the query returns **0 flows**, the topology is computed against an empty flow set, no edges are produced, and `flow_topologies` stays permanently empty. The "Dependencies" tab shows nodes but no edges.

Topology is a **system-wide** computation, not a user-scoped read, so it should bypass ACLs — matching how EE already treats whole-tenant flow operations elsewhere (e.g. `TenantController` uses `findAllWithSourceWithNoAcl` / `deleteWithoutAcl`). OSS `findAllWithSource` and `findAllWithSourceWithNoAcl` resolve identically, so OSS behavior is unchanged.

## Observability

The `Future` returned by `executorService.submit(...)` is never `.get()`-ed, so topology exceptions were previously silent. The lambda is now wrapped in a try/catch that logs at `error`, so future regressions are visible.

## Tests

- OSS: `:core:test --tests FlowServiceTest` (24 tests, incl. the async `create()`/`update()` topology assertions) — green.
- A companion regression test lands in kestra-ee (the bug only manifests with the EE repository's ACL filter): kestra-io/kestra-ee#8816.
