### PR TITLE
fix(flows): add top spacing to flow source search

### DIFF
--- a/ui/packages/design-system/src/components/Data/KsDataTable/KsDataTable.vue
+++ b/ui/packages/design-system/src/components/Data/KsDataTable/KsDataTable.vue
@@ -429,6 +429,10 @@
             padding-inline: var(--ks-data-table-gutter);
         }
 
+        > .ks-data-table-navbar {
+            padding-block-start: var(--ks-data-table-navbar-padding-block-start, 0px);
+        }
+
         .kel-pagination {
             display: flex;
             padding-inline: var(--ks-data-table-gutter);

--- a/ui/src/components/flows/FlowsSearch.vue
+++ b/ui/src/components/flows/FlowsSearch.vue
@@ -143,6 +143,10 @@
 </script>
 
 <style scoped lang="scss">
+section {
+    --ks-data-table-navbar-padding-block-start: var(--ks-spacing-5);
+}
+
 .search-splitter {
     flex: 1;
     min-height: 0;


### PR DESCRIPTION
## Summary
- Adds `padding-block-start` support to `KsDataTable` navbar via a CSS variable (`--ks-data-table-navbar-padding-block-start`, defaulting to `0px` — no impact on other pages)
- Sets that variable on the `FlowsSearch` section so the source search bar gets proper top spacing matching the rest of the UI

Closes https://github.com/kestra-io/kestra-ee/issues/8770.