### PR TITLE
feat(flows): default to Edit tab on the Flow page

### DIFF
--- a/ui/src/components/flows/FlowRoot.vue
+++ b/ui/src/components/flows/FlowRoot.vue
@@ -277,7 +277,7 @@
 
         // created logic
         if (!route.params.tab) {
-            const tab = localStorage.getItem("flowDefaultTab") || "overview"
+            const tab = localStorage.getItem("flowDefaultTab") || "edit"
             router.replace({
                 name: "flows/update",
                 params: {...route.params, tab},

--- a/ui/src/components/settings/BasicSettings.vue
+++ b/ui/src/components/settings/BasicSettings.vue
@@ -304,7 +304,7 @@
         editorType: localStorage.getItem(storageKeys.EDITOR_VIEW_TYPE) || "YAML",
         executeFlowBehaviour: localStorage.getItem(storageKeys.EXECUTE_FLOW_BEHAVIOUR) || executeFlowBehaviours.SAME_TAB,
         executeDefaultTab: localStorage.getItem("executeDefaultTab") || "gantt",
-        flowDefaultTab: localStorage.getItem("flowDefaultTab") || "overview",
+        flowDefaultTab: localStorage.getItem("flowDefaultTab") || "edit",
         triggersDefaultTab: localStorage.getItem("triggersDefaultTab") || "add",
         autoRefreshInterval: parseInt(localStorage.getItem(storageKeys.AUTO_REFRESH_INTERVAL) ?? "") || 10,
         theme: Utils.getSelectedTheme(),


### PR DESCRIPTION
## What

Open flows on the **Edit** tab instead of **Overview** by default.

## Why

Most users want to see the flow definition/topology when they open a flow, not the Overview dashboard. For new users getting started with no executions yet, the Overview is completely empty. What they want is to edit the flow, or at least see the code before running the first execution.

Users can still change the default tab in settings (the per-user preference stored in `flowDefaultTab` is unchanged) — this only changes the fallback when no preference is set.

## Changes

- `FlowRoot.vue` — fallback default tab changed from `overview` to `edit`.
- `BasicSettings.vue` — settings UI reflects the same `edit` fallback so it stays consistent.

Closes https://github.com/kestra-io/kestra-ee/issues/8612

🤖 Generated with [Claude Code](https://claude.com/claude-code)