### PR TITLE
fix(namespaces): prefill parent folder when creating file/folder from navbar

### DIFF
--- a/ui/src/components/inputs/FileExplorer.vue
+++ b/ui/src/components/inputs/FileExplorer.vue
@@ -733,9 +733,9 @@
             } else {
                 const selectedKey = tree.value.getCurrentKey ? tree.value.getCurrentKey() : null
                 const selectedNode = selectedKey ? tree.value.getNode(selectedKey) : null
-                if (selectedNode?.leaf === false) {
-                    node = selectedNode.id
-                    folder = filesStore.getPath(selectedNode.id)
+                if (selectedNode?.data?.leaf === false) {
+                    node = selectedNode.data.id
+                    folder = filesStore.getPath(selectedNode.data.id)
                 }
             }
             if(!type) return


### PR DESCRIPTION
## Summary

- When a folder is selected in the tree and the user clicks **Create File** or **Create Folder** from the navbar, the Parent Folder field was always empty instead of being prefilled with the selected folder.
- Root cause: `toggleDialog` was checking `selectedNode?.leaf` on the raw `ElTreeNode` returned by `tree.value.getNode()`, but the leaf flag lives on `selectedNode.data.leaf`. The condition was always falsy so the folder path was never set.
- Fix: changed the check and id lookup to go through `.data` (`selectedNode?.data?.leaf`, `selectedNode.data.id`).

Closes https://github.com/kestra-io/kestra-ee/issues/8823.

## Test plan

- [ ] Select a folder in Namespace Files tree
- [ ] Click the Create File button (FilePlus icon) in the navbar — Parent Folder field should be prefilled with the selected folder
- [ ] Click the Create Folder button (FolderPlus icon) in the navbar — same prefill
- [ ] With no folder selected, both buttons should open the dialog with an empty Parent Folder field (no regression)
- [ ] Right-click context menu on a folder → Create file/folder still works as before