### PR TITLE
fix(core): prevent scrollbar appearance from shifting page layout

### DIFF
--- a/ui/src/styles/app.scss
+++ b/ui/src/styles/app.scss
@@ -274,6 +274,7 @@ body{
 #app main {
     flex: 1;
     overflow: auto;
+    scrollbar-gutter: stable;
 }
 
 #ks-monaco-overflow-widgets {


### PR DESCRIPTION
## Summary

- Adds `scrollbar-gutter: stable` to `#app main` (the main scroll container) so that the scrollbar slot is always reserved
- This prevents layout shift when the scrollbar appears or disappears — e.g. when a user resizes a textarea tall enough to make the page scroll

## Test plan

- [ ] Open a Namespace Edit page with no scrollbar visible (zoom out if needed)
- [ ] Drag the Description textarea taller until a scrollbar would appear
- [ ] Confirm the layout does not shift left

Companion fix for https://github.com/kestra-io/kestra-ee/issues/8765.