### PR TITLE
fix(executions): close SSE streams on error to stop off-heap leak

### DIFF
--- a/ui/src/components/dependencies/composables/useDependencies.ts
+++ b/ui/src/components/dependencies/composables/useDependencies.ts
@@ -555,6 +555,11 @@ export function useDependencies(
                 title:   t("error"),
                 message: t("something_went_wrong.loading_execution"),
             }
+
+            // Close on error: EventSource auto-reconnects unless explicitly closed,
+            // and each reconnect leaks a server-side SSE connection (Netty direct
+            // buffers) over time. See kestra-io/kestra#16982.
+            closeSSE()
         }
     }
 

--- a/ui/src/components/executions/Logs.vue
+++ b/ui/src/components/executions/Logs.vue
@@ -287,6 +287,13 @@
                     sseFlushTimer = setTimeout(flushSseBuffer, 200)
                 }
             }
+            // Close on error: without this, EventSource auto-reconnects (~every 3s)
+            // and each reconnect opens a fresh server-side log-follow stream whose
+            // Netty direct buffers are not promptly reclaimed, leaking off-heap
+            // memory over time. See kestra-io/kestra#16982.
+            sse.onerror = () => {
+                closeLogsSSE()
+            }
         })
     }
 

--- a/ui/src/stores/executions.ts
+++ b/ui/src/stores/executions.ts
@@ -511,6 +511,12 @@ export const useExecutionsStore = defineStore("executions", () => {
                     },
                 }
             }
+
+            // Close the stream on error: EventSource auto-reconnects (~every 3s)
+            // unless explicitly closed, and each reconnect opens a fresh server-side
+            // SSE connection whose Netty direct buffers are not promptly reclaimed,
+            // leaking off-heap memory over time. See kestra-io/kestra#16982.
+            closeSSE()
         }
 
         return Promise.resolve(sse.value)


### PR DESCRIPTION
## What

The UI live-follow streams (execution, logs, dependencies) use the native `EventSource`, which **auto-reconnects (~every 3s) on any error unless explicitly closed**. The `onerror` handlers showed a "connection lost" toast but never called `close()`, and the logs stream had no `onerror` at all. So any stream error (the 1h server-side timeout firing, a proxy idle-cut, a transient network blip, an abandoned tab) made the browser silently reconnect forever. Each reconnect opens a **fresh server-side SSE connection** whose Netty pooled direct buffers are not promptly reclaimed → off-heap memory (pod RSS) grows over time while the JVM heap stays healthy.

This closes the `EventSource` in all three `onerror` handlers so an error is terminal instead of triggering unbounded reconnect churn:

- `ui/src/stores/executions.ts` — `followExecution` `onerror` now calls `closeSSE()`.
- `ui/src/components/executions/Logs.vue` — `streamLogs` now sets an `onerror` that calls `closeLogsSSE()`.
- `ui/src/components/dependencies/composables/useDependencies.ts` — `openSSE` `onerror` now calls `closeSSE()`.

## Why

This is the highest-leverage, lowest-risk part of #16982 — it stops the client from generating unbounded server-side connection churn, which is what turns UI usage into monotonic RSS growth. The existing code already treats `onerror` as terminal (it shows a "connection lost" message); this completes that intent.

## Notes / follow-ups (tracked in #16982)

- Server-side: proactively complete idle terminal-execution follow streams and bound the `OverflowStrategy.BUFFER` sinks.
- Defaults: ship a sane `-XX:MaxDirectMemorySize` / `io.netty.maxDirectMemory` in the Docker image / Helm chart.
- Operator workaround in the meantime: set `-XX:MaxDirectMemorySize` to cap off-heap and confirm via `jvm_buffer_memory_used_bytes{id="direct"}`.

## Test

- `npm run check:types` ✅
- `eslint` ✅ (pre-commit lint-staged passed)

Refs #16982
