### PR TITLE
fix(executions): close SSE streams on error to stop off-heap leak (1.3.x)

### DIFF
--- a/ui/src/components/dependencies/composables/useDependencies.ts
+++ b/ui/src/components/dependencies/composables/useDependencies.ts
@@ -464,6 +464,11 @@ export function useDependencies(
 
         sse.value.onerror = () => {
             coreStore.message = {variant: "error", title: t("error"), message: t("something_went_wrong.loading_execution")};
+
+            // Close on error: EventSource auto-reconnects unless explicitly closed,
+            // and each reconnect leaks a server-side SSE connection (Netty direct
+            // buffers) over time. See kestra-io/kestra#16982.
+            closeSSE();
         };
     };
 

--- a/ui/src/components/logs/TaskRunDetails.vue
+++ b/ui/src/components/logs/TaskRunDetails.vue
@@ -734,6 +734,13 @@
                                 this.throttledExecutionUpdate.flush();
                             }
                         };
+
+                        // Close on error: without this, EventSource auto-reconnects
+                        // and each reconnect leaks a server-side SSE connection
+                        // (Netty direct buffers) over time. See kestra-io/kestra#16982.
+                        this.executionSSE.onerror = (_) => {
+                            this.closeTargetExecutionSSE();
+                        };
                     });
             },
             followLogs(executionId) {
@@ -774,6 +781,12 @@
                                 "something_went_wrong.loading_execution",
                             ),
                         };
+
+                        // Close on error: EventSource auto-reconnects unless
+                        // explicitly closed, and each reconnect leaks a server-side
+                        // log-follow stream (Netty direct buffers) over time.
+                        // See kestra-io/kestra#16982.
+                        this.closeLogsSSE();
                     };
                 });
             },

--- a/ui/src/stores/executions.ts
+++ b/ui/src/stores/executions.ts
@@ -484,6 +484,12 @@ export const useExecutionsStore = defineStore("executions", () => {
                     }
                 };
             }
+
+            // Close the stream on error: EventSource auto-reconnects (~every 3s)
+            // unless explicitly closed, and each reconnect opens a fresh server-side
+            // SSE connection whose Netty direct buffers are not promptly reclaimed,
+            // leaking off-heap memory over time. See kestra-io/kestra#16982.
+            closeSSE();
         }
 
         return Promise.resolve(sse.value);


### PR DESCRIPTION
## What

Backport of #16984 to `releases/v1.3.x`.

The UI live-follow streams use the native `EventSource`, which **auto-reconnects (~every 3s) on any error unless explicitly closed**. The `onerror` handlers showed a "connection lost" toast but never called `close()`, and some streams had no `onerror` at all. So any stream error (the 1h server-side timeout firing, a proxy idle-cut, a transient network blip, an abandoned tab) made the browser silently reconnect forever. Each reconnect opens a fresh server-side SSE connection whose Netty pooled direct buffers are not promptly reclaimed → off-heap memory (pod RSS) grows over time while the JVM heap stays healthy.

This closes the `EventSource` on every error path:

- `ui/src/stores/executions.ts` — `followExecution` `onerror` now calls `closeSSE()`.
- `ui/src/components/logs/TaskRunDetails.vue` — `followLogs` `onerror` now calls `closeLogsSSE()`; the target-execution (`rawSSE`) follow gains an `onerror` that calls `closeTargetExecutionSSE()`.
- `ui/src/components/dependencies/composables/useDependencies.ts` — `openSSE` `onerror` now calls `closeSSE()`.

## Why

On 1.3.x this is the off-heap memory growth several deployments see: pod RSS climbs over days, correlated with UI usage, while the JVM heap stays healthy. Stopping the client's unbounded reconnect churn is the highest-leverage, lowest-risk mitigation.

## Operator workaround (in the meantime)

Set `-XX:MaxDirectMemorySize=<cap, e.g. 512m>` to bound off-heap memory; confirm the diagnosis by graphing `jvm_buffer_memory_used_bytes{id="direct"}` against RSS. Keep `MALLOC_ARENA_MAX=2` and `-XX:ActiveProcessorCount=<pod CPU limit>`.

## Test

- `npm run check:types` ✅
- `eslint` ✅ (pre-commit lint-staged passed)

Refs #16982
