### PR TITLE
fix(flows): apply query and namespace filters in findSourceCode

### DIFF
--- a/core/src/test/java/io/kestra/core/repositories/AbstractFlowRepositoryTest.java
+++ b/core/src/test/java/io/kestra/core/repositories/AbstractFlowRepositoryTest.java
@@ -20,6 +20,7 @@ import io.kestra.core.events.CrudEvent;
 import io.kestra.core.events.CrudEventType;
 import io.kestra.core.exceptions.InvalidQueryFiltersException;
 import io.kestra.core.models.Label;
+import io.kestra.core.models.SearchResult;
 import io.kestra.core.models.QueryFilter;
 import io.kestra.core.models.QueryFilter.Field;
 import io.kestra.core.models.QueryFilter.Op;
@@ -879,6 +880,56 @@ public abstract class AbstractFlowRepositoryTest {
         } finally {
             deleteFlow(flow);
             executionRepository.delete(execution);
+        }
+    }
+
+    @Test
+    void shouldFilterSourceCodeByNamespaceAndQuery() {
+        // Given — two flows in the same tenant but different namespaces.
+        // Flow IDs use "alpha" / "beta" as distinct tokens that do not appear in each
+        // other's YAML (the common task type io.kestra.plugin.core.debug.Return
+        // contains neither word), enabling unambiguous query-filter assertions.
+        String tenant = TestsUtils.randomTenant(this.getClass().getSimpleName());
+        String namespaceA = "io.kestra.findsource.a";
+        String namespaceB = "io.kestra.findsource.b";
+
+        FlowWithSource flowA = builder(tenant, "source-flow-alpha", TEST_FLOW_ID)
+            .namespace(namespaceA)
+            .build();
+        FlowWithSource flowB = builder(tenant, "source-flow-beta", TEST_FLOW_ID)
+            .namespace(namespaceB)
+            .build();
+
+        flowA = flowRepository.create(GenericFlow.of(flowA));
+        flowB = flowRepository.create(GenericFlow.of(flowB));
+
+        try {
+            // When — filter by namespace only
+            ArrayListTotal<SearchResult<Flow>> byNamespaceA = flowRepository.findSourceCode(
+                Pageable.UNPAGED, null, tenant, namespaceA
+            );
+
+            // Then — only the flow in namespaceA is returned
+            assertThat(byNamespaceA)
+                .as("Expected only namespace %s but got: %s", namespaceA,
+                    byNamespaceA.stream().map(r -> r.getModel().getNamespace()).toList())
+                .hasSize(1);
+            assertThat(byNamespaceA.getFirst().getModel().getNamespace()).isEqualTo(namespaceA);
+
+            // When — filter by query using a token unique to flow-beta's source
+            ArrayListTotal<SearchResult<Flow>> byQuery = flowRepository.findSourceCode(
+                Pageable.UNPAGED, "beta", tenant, null
+            );
+
+            // Then — only the flow whose source contains "beta" is returned
+            assertThat(byQuery)
+                .as("Expected only flow-beta but got: %s",
+                    byQuery.stream().map(r -> r.getModel().getId()).toList())
+                .hasSize(1);
+            assertThat(byQuery.getFirst().getModel().getId()).isEqualTo("source-flow-beta");
+        } finally {
+            deleteFlow(flowA);
+            deleteFlow(flowB);
         }
     }
 

--- a/jdbc/src/main/java/io/kestra/jdbc/repository/AbstractJdbcFlowRepository.java
+++ b/jdbc/src/main/java/io/kestra/jdbc/repository/AbstractJdbcFlowRepository.java
@@ -787,11 +787,11 @@ public abstract class AbstractJdbcFlowRepository extends AbstractJdbcRepository 
                 SelectConditionStep<Record> select = this.fullTextSelect(tenantId, context, Collections.singletonList(field("source_code")));
 
                 if (query != null) {
-                    select.and(this.findSourceCodeCondition(query));
+                    select = select.and(this.findSourceCodeCondition(query));
                 }
 
                 if (namespace != null) {
-                    select.and(DSL.or(NAMESPACE_FIELD.eq(namespace), NAMESPACE_FIELD.startsWith(namespace + ".")));
+                    select = select.and(DSL.or(NAMESPACE_FIELD.eq(namespace), NAMESPACE_FIELD.startsWith(namespace + ".")));
                 }
 
                 return (ArrayListTotal) this.jdbcRepository.fetchPage(
@@ -1016,11 +1016,11 @@ public abstract class AbstractJdbcFlowRepository extends AbstractJdbcRepository 
                         select = select.and(condition);
                     }
 
-                    if (orderByFields != null) {
-                        select.orderBy(orderByFields);
-                    }
+                    var fetchQuery = orderByFields != null
+                        ? select.orderBy(orderByFields).fetchSize(FETCH_SIZE)
+                        : select.fetchSize(FETCH_SIZE);
 
-                    try (var stream = select.fetchSize(FETCH_SIZE).stream()) {
+                    try (var stream = fetchQuery.stream()) {
                         stream
                             .map(record -> (Flow) jdbcRepository.map(record))
                             .forEach(emitter::next);


### PR DESCRIPTION
jOOQ's SelectConditionStep.and() and orderBy() return new steps; the original code discarded their return values, silently dropping the query and namespace filter conditions in findSourceCode (security bypass: all flow source code was returned regardless of filters) and the orderBy in findAsync (flows always returned unordered).

Add regression test shouldFilterSourceCodeByNamespaceAndQuery that verifies both namespace and query filters work correctly.

Fixes https://github.com/kestra-io/kestra-ee/issues/7997