### PR TITLE
fix(executions): close SSE streams on error to stop off-heap leak (1.0.x)

### DIFF
--- a/ui/src/components/dependencies/composables/useDependencies.ts
+++ b/ui/src/components/dependencies/composables/useDependencies.ts
@@ -404,6 +404,11 @@ export function useDependencies(container: Ref<HTMLElement | null>, subtype: typ
 
         sse.value.onerror = () => {
             coreStore.message = {variant: "error", title: t("error"), message: t("something_went_wrong.loading_execution")};
+
+            // Close on error: EventSource auto-reconnects unless explicitly closed,
+            // and each reconnect leaks a server-side SSE connection (Netty direct
+            // buffers) over time. See kestra-io/kestra#16982.
+            closeSSE();
         };
     };
 

--- a/ui/src/components/logs/TaskRunDetails.vue
+++ b/ui/src/components/logs/TaskRunDetails.vue
@@ -41,7 +41,7 @@
                     <DynamicScroller
                         v-if="shouldDisplayLogs(currentTaskRun)"
                         :items="logsWithIndexByAttemptUid[attemptUid(currentTaskRun.id, selectedAttemptNumberByTaskRunId[currentTaskRun.id])] ?? []"
-                        :minItemSize="32"
+                        :min-item-size="32"
                         key-field="index"
                         class="log-lines"
                         :class="{'single-line': currentTaskRuns.length === 1}"
@@ -488,6 +488,13 @@
                                 this.throttledExecutionUpdate.flush();
                             }
                         }
+
+                        // Close on error: without this, EventSource auto-reconnects
+                        // and each reconnect leaks a server-side SSE connection
+                        // (Netty direct buffers) over time. See kestra-io/kestra#16982.
+                        this.executionSSE.onerror = _ => {
+                            this.closeTargetExecutionSSE();
+                        }
                     });
             },
             followLogs(executionId) {
@@ -527,6 +534,12 @@
                                 title: this.$t("error"),
                                 message: this.$t("something_went_wrong.loading_execution"),
                             };
+
+                            // Close on error: EventSource auto-reconnects unless
+                            // explicitly closed, and each reconnect leaks a server-side
+                            // log-follow stream (Netty direct buffers) over time.
+                            // See kestra-io/kestra#16982.
+                            this.closeLogsSSE();
                         }
                     })
 

--- a/ui/src/stores/executions.ts
+++ b/ui/src/stores/executions.ts
@@ -394,6 +394,12 @@ export const useExecutionsStore = defineStore("executions", () => {
                     message: translate("something_went_wrong.loading_execution"),
                 };
             }
+
+            // Close the stream on error: EventSource auto-reconnects (~every 3s)
+            // unless explicitly closed, and each reconnect opens a fresh server-side
+            // SSE connection whose Netty direct buffers are not promptly reclaimed,
+            // leaking off-heap memory over time. See kestra-io/kestra#16982.
+            closeSSE();
         }
 
         return Promise.resolve(sse.value);


### PR DESCRIPTION
## What

Backport of #16984 to `releases/v1.0.x`.

The UI live-follow streams use the native `EventSource`, which **auto-reconnects (~every 3s) on any error unless explicitly closed**. The `onerror` handlers showed a "connection lost" toast but never called `close()`, and some streams had no `onerror` at all. So any stream error (the 1h server-side timeout firing, a proxy idle-cut, a transient network blip, an abandoned tab) made the browser silently reconnect forever. Each reconnect opens a fresh server-side SSE connection whose Netty pooled direct buffers are not promptly reclaimed → off-heap memory (pod RSS) grows over time while the JVM heap stays healthy.

This closes the `EventSource` on every error path:

- `ui/src/stores/executions.ts` — `followExecution` `onerror` now calls `closeSSE()`.
- `ui/src/components/logs/TaskRunDetails.vue` — `followLogs` `onerror` now calls `closeLogsSSE()`; the target-execution (`rawSSE`) follow gains an `onerror` that calls `closeTargetExecutionSSE()`.
- `ui/src/components/dependencies/composables/useDependencies.ts` — `openSSE` `onerror` now calls `closeSSE()`.

Consumers that follow through the store's managed stream (`Topology.vue`, `FlowPlayground.vue`, `ExecutionRoot.vue`) do not override `onerror`, so they inherit the store-level fix automatically.

## Why

This is the off-heap memory growth some deployments see: pod RSS climbs over days, correlated with UI usage, while the JVM heap stays healthy. Stopping the client's unbounded reconnect churn is the highest-leverage, lowest-risk mitigation.

## Operator workaround (in the meantime)

Set `-XX:MaxDirectMemorySize=<cap, e.g. 512m>` to bound off-heap memory; confirm via `jvm_buffer_memory_used_bytes{id="direct"}` vs RSS. Keep `MALLOC_ARENA_MAX=2` and `-XX:ActiveProcessorCount=<pod CPU limit>`.

## Test

- `eslint` ✅ (pre-commit lint-staged passed; 0 errors)
- (`check:types` is a no-op on this release line)

Refs #16982
