### PR TITLE
[backport releases/v1.3.x] feat(plugindefaults): allow referencing named pluginDefaults by ref

### DIFF
--- a/core/src/main/java/io/kestra/core/exceptions/PluginDefaultsRefNotFoundException.java
+++ b/core/src/main/java/io/kestra/core/exceptions/PluginDefaultsRefNotFoundException.java
@@ -1,0 +1,17 @@
+package io.kestra.core.exceptions;
+
+import java.io.Serial;
+
+/**
+ * Thrown when a plugin (task, trigger or task runner) references named plugin-defaults via
+ * {@code pluginDefaultsRef} that cannot be resolved — either none exists with that {@code ref} at flow,
+ * namespace or global level, or the one that exists is scoped to a different plugin type.
+ */
+public class PluginDefaultsRefNotFoundException extends KestraRuntimeException {
+    @Serial
+    private static final long serialVersionUID = 1L;
+
+    public PluginDefaultsRefNotFoundException(String ref) {
+        super("No plugin-defaults exists for pluginDefaultsRef: '" + ref + "'");
+    }
+}

--- a/core/src/main/java/io/kestra/core/models/flows/PluginDefault.java
+++ b/core/src/main/java/io/kestra/core/models/flows/PluginDefault.java
@@ -4,16 +4,16 @@ import java.util.Map;
 
 import io.kestra.core.validations.PluginDefaultValidation;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import io.micronaut.core.annotation.Creator;
 import io.micronaut.core.annotation.Introspected;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
-import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 
 @Getter
 @Builder(toBuilder = true)
-@AllArgsConstructor
 @Introspected
 @PluginDefaultValidation
 public class PluginDefault {
@@ -24,8 +24,32 @@ public class PluginDefault {
     private final boolean forced = false;
 
     @Schema(
+        title = "Optional reference id used to apply this default only to plugins that opt in via `pluginDefaultsRef`."
+    )
+    private final String ref;
+
+    @Schema(
         type = "object",
         additionalProperties = Schema.AdditionalPropertiesValue.FALSE
     )
     private final Map<String, Object> values;
+
+    // explicit @Creator so bean introspection (Micronaut jackson-databind) deserializes through the full
+    // constructor — with the convenience constructor below also present, the creator must be unambiguous or
+    // the 'ref' property fails to map ("Invalid json mapping") on namespace plugin-defaults payloads.
+    @Creator
+    @JsonCreator
+    public PluginDefault(String type, boolean forced, String ref, Map<String, Object> values) {
+        this.type = type;
+        this.forced = forced;
+        this.ref = ref;
+        this.values = values;
+    }
+
+    /**
+     * Convenience constructor for type-matched (non-{@code ref}) defaults.
+     */
+    public PluginDefault(String type, boolean forced, Map<String, Object> values) {
+        this(type, forced, null, values);
+    }
 }

--- a/core/src/main/java/io/kestra/core/models/tasks/Task.java
+++ b/core/src/main/java/io/kestra/core/models/tasks/Task.java
@@ -43,6 +43,10 @@ abstract public class Task implements TaskInterface {
     @PluginProperty(hidden = true, group = PluginProperty.CORE_GROUP)
     protected String version;
 
+    @PluginProperty(group = "advanced")
+    @Schema(title = "Reference (`ref`) of the `pluginDefaults` to apply to this task.")
+    protected String pluginDefaultsRef;
+
     @PluginProperty(hidden = true, group = PluginProperty.CORE_GROUP)
     private String description;
 

--- a/core/src/main/java/io/kestra/core/models/tasks/runners/TaskRunner.java
+++ b/core/src/main/java/io/kestra/core/models/tasks/runners/TaskRunner.java
@@ -20,6 +20,7 @@ import io.kestra.core.models.annotations.PluginProperty;
 import io.kestra.core.runners.RunContext;
 import io.kestra.plugin.core.runner.Process;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 import lombok.AccessLevel;
@@ -46,6 +47,10 @@ public abstract class TaskRunner<T extends TaskRunnerDetailResult> implements Pl
 
     @PluginProperty(hidden = true, group = PluginProperty.CORE_GROUP)
     protected String version;
+
+    @PluginProperty(group = "advanced")
+    @Schema(title = "Reference (`ref`) of the `pluginDefaults` to apply to this task runner.")
+    protected String pluginDefaultsRef;
 
     @JsonIgnore
     @Getter(AccessLevel.NONE)

--- a/core/src/main/java/io/kestra/core/models/triggers/AbstractTrigger.java
+++ b/core/src/main/java/io/kestra/core/models/triggers/AbstractTrigger.java
@@ -41,6 +41,10 @@ abstract public class AbstractTrigger implements TriggerInterface {
     @PluginProperty(hidden = true, group = PluginProperty.CORE_GROUP)
     protected String version;
 
+    @PluginProperty(group = "advanced")
+    @Schema(title = "Reference (`ref`) of the `pluginDefaults` to apply to this trigger.")
+    protected String pluginDefaultsRef;
+
     @PluginProperty(hidden = true, group = PluginProperty.CORE_GROUP)
     private String description;
 

--- a/core/src/main/java/io/kestra/core/services/FlowService.java
+++ b/core/src/main/java/io/kestra/core/services/FlowService.java
@@ -25,6 +25,7 @@ import io.kestra.core.models.flows.check.Check;
 import io.kestra.core.models.tasks.RunnableTask;
 import io.kestra.core.models.topologies.FlowTopology;
 import io.kestra.core.models.triggers.AbstractTrigger;
+import io.kestra.core.models.validations.ManualConstraintViolation;
 import io.kestra.core.models.validations.ModelValidator;
 import io.kestra.core.models.validations.ValidateConstraintViolation;
 import io.kestra.core.plugins.PluginRegistry;
@@ -88,9 +89,30 @@ public class FlowService {
         // Validate Flow with defaults values
         // Do not perform a strict parsing validation to ignore unknown
         // properties that might be injecting through default values.
-        modelValidator.validate(pluginDefaultService.injectAllDefaults(parsed, false));
+        FlowWithSource withDefaults = pluginDefaultService.injectAllDefaults(parsed, false);
+        modelValidator.validate(withDefaults);
+        validatePluginDefaultsRefs(withDefaults);
 
         return repository().create(flow);
+    }
+
+    /**
+     * Validates that every {@code pluginDefaultsRef} used in the flow resolves to an applicable plugin-defaults
+     * (one that exists with that {@code ref} and is scoped to the plugin's type). Throws a
+     * {@link ConstraintViolationException} otherwise, so an unresolved reference is rejected on create/update
+     * and surfaced through the validate API exactly like other flow validation errors.
+     */
+    private void validatePluginDefaultsRefs(FlowWithSource flowWithDefaults) {
+        java.util.Set<String> unresolved = pluginDefaultService.unresolvedPluginDefaultsRefs(flowWithDefaults);
+        if (!unresolved.isEmpty()) {
+            throw ManualConstraintViolation.toConstraintViolationException(
+                "No plugin-defaults exists for pluginDefaultsRef: '" + String.join("', '", unresolved) + "'",
+                flowWithDefaults,
+                FlowWithSource.class,
+                "pluginDefaultsRef",
+                String.join(", ", unresolved)
+            );
+        }
     }
 
     private FlowRepositoryInterface repository() {
@@ -189,7 +211,9 @@ public class FlowService {
 
                 // Do not perform a strict parsing validation to ignore unknown
                 // properties that might be injecting through default values.
-                modelValidator.validate(pluginDefaultService.injectAllDefaults(flow, false));
+                FlowWithSource withDefaults = pluginDefaultService.injectAllDefaults(flow, false);
+                modelValidator.validate(withDefaults);
+                validatePluginDefaultsRefs(withDefaults);
             } catch (ConstraintViolationException e) {
                 String friendlyMessage = formatValidationError(e.getMessage());
                 constraintsBuilder.constraints(friendlyMessage);

--- a/core/src/main/java/io/kestra/core/services/PluginDefaultService.java
+++ b/core/src/main/java/io/kestra/core/services/PluginDefaultService.java
@@ -5,6 +5,8 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -53,7 +55,50 @@ import jakarta.validation.ConstraintViolationException;
 import lombok.extern.slf4j.Slf4j;
 
 /**
- * Services for parsing flows and injecting plugin default values.
+ * Parses flows and injects plugin default values into every plugin (task, trigger, task runner, …).
+ *
+ * <h2>Sources &amp; precedence</h2>
+ * Defaults come from three levels, ordered most-important-first: <b>flow</b> &gt; <b>namespace</b> (EE, closest
+ * namespace first) &gt; <b>global</b> (configuration). Each default is either:
+ * <ul>
+ *   <li><b>type-matched</b> — applied to every plugin whose {@code type} equals or is prefixed by the default's
+ *       {@code type}; or</li>
+ *   <li><b>named</b> — carries a {@code ref} id and is applied <i>only</i> to plugins that opt in with
+ *       {@code pluginDefaultsRef: <id>}, never by type matching.</li>
+ * </ul>
+ *
+ * <h2>{@code forced}</h2>
+ * {@code forced: true} marks an enforced default and is honored at every level (flow, namespace, global). A
+ * non-forced default fills only values the plugin does not set (the plugin wins); a forced default overrides the
+ * plugin's values. Forced defaults follow the <i>reverse</i> precedence of non-forced ones: the lowest (admin)
+ * level wins, so a global forced default beats a namespace forced one beats a flow forced one and enforcement at a
+ * higher (admin) level cannot be bypassed closer to the flow.
+ *
+ * <h2>How a single plugin is resolved</h2>
+ * <ol>
+ *   <li><b>No {@code pluginDefaultsRef}:</b> non-forced then forced type-matched defaults are applied (forced last,
+ *       so it wins).</li>
+ *   <li><b>With {@code pluginDefaultsRef: id}:</b> non-forced type-matched defaults are skipped. If a <i>forced</i>
+ *       type-matched default also applies, <b>it takes over entirely and the referenced default is ignored</b>
+ *       (no stacking) — enforcement always wins. Otherwise the referenced default is applied.</li>
+ * </ol>
+ *
+ * <h2>Resolving a {@code ref}</h2>
+ * All defaults sharing a {@code ref} collapse to a single winner (shadowing, not a merge): a forced entry beats a
+ * non-forced one; among forced entries the lowest-priority (admin) level wins (global over namespace over flow) so
+ * enforcement cannot be bypassed by a higher-level forced override; among non-forced entries the highest-priority
+ * level wins. The referenced default is applied only when its declared {@code type} matches the plugin's type
+ * (plugin aliases are canonicalized so an alias and its canonical name match).
+ * <p>
+ * Resulting precedence for a referenced plugin:
+ * {@code forced type-matched > forced ref > non-forced ref > the plugin's own values}.
+ *
+ * <h2>Unknown / inapplicable {@code ref}</h2>
+ * If a {@code pluginDefaultsRef} resolves to no default (none with that id) or to one declared for a different
+ * type, it is left unresolved: flow validation reports it as an error on create/update and via the validate API,
+ * and the plugin fails at runtime with {@code PluginDefaultsRefNotFoundException}. When a reference <i>is</i>
+ * applied (or is validly superseded by a forced type default), its marker is consumed so a surviving marker
+ * unambiguously means "unresolved or inapplicable".
  */
 @Singleton
 @Slf4j
@@ -65,6 +110,7 @@ public class PluginDefaultService {
     private static final ObjectMapper OBJECT_MAPPER = JacksonMapper.ofYaml().copy()
         .setDefaultPropertyInclusion(JsonInclude.Include.NON_NULL);
     private static final String PLUGIN_DEFAULTS_FIELD = "pluginDefaults";
+    private static final String PLUGIN_DEFAULTS_REF_FIELD = "pluginDefaultsRef";
     private static final String TASK_DEFAULTS_FIELD = "taskDefaults";
 
     private static final TypeReference<List<PluginDefault>> PLUGIN_DEFAULTS_TYPE_REF = new TypeReference<>() {
@@ -448,9 +494,24 @@ public class PluginDefaultService {
             return flowAsMap;
         }
 
+        // alias-canonicalize all defaults (type-matched and named) so a default declared with a plugin alias
+        // also matches the canonical plugin type.
         addAliases(allDefaults);
 
-        Map<Boolean, List<PluginDefault>> allDefaultsGroup = allDefaults
+        // split named (ref) defaults from type-matched defaults: a 'ref' default is applied only to plugins
+        // that explicitly opt in via 'pluginDefaultsRef', never by type matching.
+        Map<Boolean, List<PluginDefault>> byHasRef = allDefaults
+            .stream()
+            .collect(Collectors.partitioningBy(pluginDefault -> pluginDefault.getRef() != null));
+        List<PluginDefault> typeDefaults = byHasRef.get(false);
+
+        // resolve, per ref, the winning values (shadowing) and the set of types it accepts (incl. alias
+        // canonical forms). Shadowing: a forced default always wins over a non-forced one; among forced
+        // defaults the lowest-priority (admin) level wins so enforcement cannot be bypassed; among non-forced
+        // defaults the highest-priority level wins. (allDefaults is ordered most-important-first: flow, namespace, global.)
+        Map<String, RefMatch> refMatches = resolveRefMatches(byHasRef.get(true));
+
+        Map<Boolean, List<PluginDefault>> allDefaultsGroup = typeDefaults
             .stream()
             .collect(Collectors.groupingBy(PluginDefault::isForced, Collectors.toList()));
 
@@ -460,7 +521,7 @@ public class PluginDefaultService {
         // beats global.
         Map<String, List<PluginDefault>> defaults = pluginDefaultsToMap(allDefaultsGroup.getOrDefault(false, Collections.emptyList()));
 
-        // forced defaults stamp over the result, so the last (admin-most) entry wins — global beats namespace.
+        // forced defaults stamp over the result, so the last (admin-most) entry wins — global beats namespace beats flow.
         Map<String, List<PluginDefault>> forced = pluginDefaultsToMap(allDefaultsGroup.getOrDefault(true, Collections.emptyList()));
 
         Object pluginDefaults = flowAsMap.get(PLUGIN_DEFAULTS_FIELD);
@@ -468,13 +529,29 @@ public class PluginDefaultService {
             flowAsMap.remove(PLUGIN_DEFAULTS_FIELD);
         }
 
-        // we apply default and overwrite with forced
+        // 1. non-forced type-matched defaults — suppressed for plugins that opted into a named (ref) default
         if (!defaults.isEmpty()) {
-            flowAsMap = (Map<String, Object>) recursiveDefaults(flowAsMap, defaults);
+            flowAsMap = (Map<String, Object>) recursiveDefaults(flowAsMap, defaults, false);
         }
 
+        // 2. named (ref) defaults — applied to plugins declaring a matching 'pluginDefaultsRef', UNLESS a forced
+        // type-matched default also applies to that plugin: enforcement takes over entirely and the ref is ignored
+        // (it must not stack on top of enforced values). Skipped when only injecting version defaults.
+        if (!onlyVersions && !refMatches.isEmpty()) {
+            flowAsMap = (Map<String, Object>) recursiveRefDefaults(flowAsMap, refMatches, forced.keySet());
+        }
+
+        // 3. forced type-matched defaults are admin enforcement and applied LAST so they win over everything,
+        // including a forced ref default — otherwise a flow could bypass enforcement via a forced ref.
+        // A WARN is logged when enforced onto a plugin that declared a 'pluginDefaultsRef'.
         if (!forced.isEmpty()) {
-            flowAsMap = (Map<String, Object>) recursiveDefaults(flowAsMap, forced);
+            flowAsMap = (Map<String, Object>) recursiveDefaults(flowAsMap, forced, true);
+        }
+
+        // 4. consume the 'pluginDefaultsRef' marker for refs that were actually applied (resolved + type match);
+        // a surviving marker therefore unambiguously means "unresolved or inapplicable" (validation error + runtime failure).
+        if (!onlyVersions && !refMatches.isEmpty()) {
+            flowAsMap = (Map<String, Object>) stripAppliedRefMarkers(flowAsMap, refMatches);
         }
 
         if (pluginDefaults != null) {
@@ -483,6 +560,39 @@ public class PluginDefaultService {
 
         return flowAsMap;
 
+    }
+
+    /**
+     * The values applied for a {@code ref} (the shadowing winner) and the set of plugin types it accepts
+     * (the declared types of every same-ref default, including alias canonical forms added by {@code addAliases}).
+     */
+    record RefMatch(PluginDefault winner, Set<String> types) {
+    }
+
+    /**
+     * Resolves, for each {@code ref}, the winning default and the set of accepted plugin types, given the list of
+     * all named defaults ordered most-important-first (flow, namespace, global). A {@code forced} default always
+     * wins over a non-forced one. Among forced defaults the lowest-priority (admin) level wins — the last forced
+     * occurrence — so an enforced default cannot be bypassed by a higher-level forced override (e.g. a flow-forced
+     * ref cannot beat a namespace- or global-forced ref of the same name). Among non-forced defaults the
+     * highest-priority level wins — the first occurrence.
+     */
+    private static Map<String, RefMatch> resolveRefMatches(List<PluginDefault> refDefaults) {
+        Map<String, List<PluginDefault>> byRef = refDefaults
+            .stream()
+            .collect(Collectors.groupingBy(PluginDefault::getRef, LinkedHashMap::new, Collectors.toList()));
+
+        Map<String, RefMatch> matches = new LinkedHashMap<>();
+        byRef.forEach((ref, candidates) ->
+        {
+            List<PluginDefault> forced = candidates.stream().filter(PluginDefault::isForced).toList();
+            PluginDefault winner = forced.isEmpty() ? candidates.getFirst() : forced.getLast();
+            Set<String> types = candidates.stream()
+                .map(PluginDefault::getType)
+                .collect(Collectors.toCollection(LinkedHashSet::new));
+            matches.put(ref, new RefMatch(winner, types));
+        });
+        return matches;
     }
 
     /**
@@ -542,6 +652,10 @@ public class PluginDefaultService {
 
     @VisibleForTesting
     Object recursiveDefaults(Object object, Map<String, List<PluginDefault>> defaults) {
+        return recursiveDefaults(object, defaults, false);
+    }
+
+    Object recursiveDefaults(Object object, Map<String, List<PluginDefault>> defaults, boolean forcedPass) {
         if (object instanceof Map<?, ?> value) {
             value = value
                 .entrySet()
@@ -549,20 +663,20 @@ public class PluginDefaultService {
                 .map(
                     e -> new AbstractMap.SimpleEntry<>(
                         e.getKey(),
-                        recursiveDefaults(e.getValue(), defaults)
+                        recursiveDefaults(e.getValue(), defaults, forcedPass)
                     )
                 )
                 .collect(HashMap::new, (m, v) -> m.put(v.getKey(), v.getValue()), HashMap::putAll);
 
             if (value.containsKey("type")) {
-                value = defaults(value, defaults);
+                value = defaults(value, defaults, forcedPass);
             }
 
             return value;
         } else if (object instanceof Collection<?> value) {
             return value
                 .stream()
-                .map(r -> recursiveDefaults(r, defaults))
+                .map(r -> recursiveDefaults(r, defaults, forcedPass))
                 .toList();
         } else {
             return object;
@@ -570,7 +684,15 @@ public class PluginDefaultService {
     }
 
     @SuppressWarnings("unchecked")
-    private Map<?, ?> defaults(Map<?, ?> plugin, Map<String, List<PluginDefault>> defaults) {
+    private Map<?, ?> defaults(Map<?, ?> plugin, Map<String, List<PluginDefault>> defaults, boolean forcedPass) {
+        boolean hasRef = plugin.containsKey(PLUGIN_DEFAULTS_REF_FIELD);
+
+        // a plugin opting into a named (ref) default ('pluginDefaultsRef') ignores non-forced type-matched defaults;
+        // forced (admin-enforced) defaults are always applied regardless, see below.
+        if (hasRef && !forcedPass) {
+            return plugin;
+        }
+
         Object type = plugin.get("type");
         if (!(type instanceof String pluginType)) {
             return plugin;
@@ -584,6 +706,16 @@ public class PluginDefaultService {
 
         if (matching.isEmpty()) {
             return plugin;
+        }
+
+        if (hasRef) {
+            // forced defaults exist for a plugin that requested a named plugin-defaults: enforcement takes over
+            log.warn(
+                "A forced pluginDefault for type '{}' is enforced on a plugin declaring pluginDefaultsRef '{}'." +
+                    " The referenced plugin-defaults is ignored.",
+                pluginType,
+                plugin.get(PLUGIN_DEFAULTS_REF_FIELD)
+            );
         }
 
         Map<String, Object> result = (Map<String, Object>) plugin;
@@ -605,6 +737,151 @@ public class PluginDefaultService {
         }
 
         return result;
+    }
+
+    /**
+     * Traverses the flow and applies the named ({@code ref}) plugin-defaults to every plugin that opts in via
+     * {@code pluginDefaultsRef}. Mirrors {@link #recursiveDefaults(Object, Map)} but matches on the referenced
+     * id and the plugin type instead of the plugin type alone. The {@code pluginDefaultsRef} marker is consumed
+     * afterwards by {@link #stripAppliedRefMarkers(Object, Map)}.
+     */
+    @VisibleForTesting
+    Object recursiveRefDefaults(Object object, Map<String, RefMatch> refMatches, Set<String> forcedTypes) {
+        if (object instanceof Map<?, ?> value) {
+            value = value
+                .entrySet()
+                .stream()
+                .map(
+                    e -> new AbstractMap.SimpleEntry<>(
+                        e.getKey(),
+                        recursiveRefDefaults(e.getValue(), refMatches, forcedTypes)
+                    )
+                )
+                .collect(HashMap::new, (m, v) -> m.put(v.getKey(), v.getValue()), HashMap::putAll);
+
+            if (value.containsKey(PLUGIN_DEFAULTS_REF_FIELD)) {
+                value = refDefaults(value, refMatches, forcedTypes);
+            }
+
+            return value;
+        } else if (object instanceof Collection<?> value) {
+            return value
+                .stream()
+                .map(r -> recursiveRefDefaults(r, refMatches, forcedTypes))
+                .toList();
+        } else {
+            return object;
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private Map<?, ?> refDefaults(Map<?, ?> plugin, Map<String, RefMatch> refMatches, Set<String> forcedTypes) {
+        Object ref = plugin.get(PLUGIN_DEFAULTS_REF_FIELD);
+        if (!(ref instanceof String refId)) {
+            return plugin;
+        }
+
+        RefMatch match = refMatches.get(refId);
+        if (match == null) {
+            // unknown ref: keep 'pluginDefaultsRef' so a surviving marker signals an unresolved reference
+            // (flagged as a validation error in the editor and failed at runtime).
+            log.warn("No plugin-defaults exists for pluginDefaultsRef '{}' referenced by plugin of type '{}'", refId, plugin.get("type"));
+            return plugin;
+        }
+
+        if (!typeMatches(plugin.get("type"), match.types())) {
+            // the named plugin-defaults is scoped to a different plugin type: do not apply it, and keep the
+            // marker so it surfaces the same way as an unresolved reference (validation error + runtime failure).
+            log.warn(
+                "The plugin-defaults for pluginDefaultsRef '{}' is declared for type(s) '{}' but is referenced by a plugin of type '{}'; it will not be applied",
+                refId, match.types(), plugin.get("type")
+            );
+            return plugin;
+        }
+
+        if (typeMatches(plugin.get("type"), forcedTypes)) {
+            // a forced (admin-enforced) type default also matches this plugin: enforcement takes over entirely
+            // and the referenced plugin-defaults is ignored (it must not stack on top of enforced values).
+            // The marker is still consumed by stripAppliedRefMarkers since the reference was valid.
+            return plugin;
+        }
+
+        PluginDefault winner = match.winner();
+        if (winner.isForced()) {
+            // forced plugin-defaults overrides the plugin's own values
+            return MapUtils.deepMerge((Map<String, Object>) plugin, winner.getValues());
+        }
+        // non-forced plugin-defaults yields to the plugin's explicit values
+        return MapUtils.deepMerge(winner.getValues(), (Map<String, Object>) plugin);
+    }
+
+    /**
+     * Whether the plugin-defaults referenced by a plugin both exists and is scoped to the plugin's type.
+     */
+    private static boolean refApplies(Map<?, ?> plugin, Map<String, RefMatch> refMatches) {
+        if (!(plugin.get(PLUGIN_DEFAULTS_REF_FIELD) instanceof String refId)) {
+            return false;
+        }
+        RefMatch match = refMatches.get(refId);
+        return match != null && typeMatches(plugin.get("type"), match.types());
+    }
+
+    private static boolean typeMatches(Object pluginType, Set<String> refTypes) {
+        return pluginType instanceof String type
+            && refTypes.stream().anyMatch(refType -> type.equals(refType) || type.startsWith(refType));
+    }
+
+    /**
+     * Removes the {@code pluginDefaultsRef} marker from every plugin whose reference was actually applied
+     * (i.e. it resolved and was type-compatible). A marker left in place means the reference was unresolved
+     * or inapplicable, which is surfaced as a validation error and fails the plugin at runtime.
+     */
+    @VisibleForTesting
+    Object stripAppliedRefMarkers(Object object, Map<String, RefMatch> refMatches) {
+        if (object instanceof Map<?, ?> value) {
+            Map<Object, Object> result = value
+                .entrySet()
+                .stream()
+                .map(e -> new AbstractMap.SimpleEntry<>(e.getKey(), stripAppliedRefMarkers(e.getValue(), refMatches)))
+                .collect(HashMap::new, (m, v) -> m.put(v.getKey(), v.getValue()), HashMap::putAll);
+
+            if (refApplies(result, refMatches)) {
+                result.remove(PLUGIN_DEFAULTS_REF_FIELD);
+            }
+
+            return result;
+        } else if (object instanceof Collection<?> value) {
+            return value
+                .stream()
+                .map(r -> stripAppliedRefMarkers(r, refMatches))
+                .toList();
+        } else {
+            return object;
+        }
+    }
+
+    /**
+     * Returns the distinct {@code pluginDefaultsRef} ids that remain unresolved (or inapplicable) in an
+     * already-defaulted flow. A reference is unresolved when no plugin-defaults with that {@code ref} exists
+     * at flow, namespace or global level, or when the one that exists is scoped to a different plugin type
+     * (the marker is otherwise stripped during {@link #stripAppliedRefMarkers(Object, Map)}).
+     */
+    public Set<String> unresolvedPluginDefaultsRefs(FlowInterface flowWithDefaults) {
+        Map<String, Object> flowAsMap = OBJECT_MAPPER.convertValue(flowWithDefaults, JacksonMapper.MAP_TYPE_REFERENCE);
+        Set<String> refs = new LinkedHashSet<>();
+        collectUnresolvedRefs(flowAsMap, refs);
+        return refs;
+    }
+
+    private void collectUnresolvedRefs(Object object, Set<String> refs) {
+        if (object instanceof Map<?, ?> value) {
+            if (value.get(PLUGIN_DEFAULTS_REF_FIELD) instanceof String ref) {
+                refs.add(ref);
+            }
+            value.values().forEach(v -> collectUnresolvedRefs(v, refs));
+        } else if (object instanceof Collection<?> value) {
+            value.forEach(v -> collectUnresolvedRefs(v, refs));
+        }
     }
 
     // -----------------------------------------------------------------------------------------------------------------

--- a/core/src/test/java/io/kestra/core/docs/ClassPluginDocumentationTest.java
+++ b/core/src/test/java/io/kestra/core/docs/ClassPluginDocumentationTest.java
@@ -44,7 +44,7 @@ class ClassPluginDocumentationTest {
 
             assertThat(doc.getDocExamples().size()).isEqualTo(2);
             assertThat(doc.getIcon()).isNotNull();
-            assertThat(doc.getInputs().size()).isEqualTo(5);
+            assertThat(doc.getInputs().size()).isEqualTo(6);
             assertThat(doc.getDocLicense()).isEqualTo("EE");
 
             // simple
@@ -150,7 +150,7 @@ class ClassPluginDocumentationTest {
             assertThat(doc.getCls()).isEqualTo("io.kestra.core.models.property.DynamicPropertyExampleTask");
             assertThat(doc.getDefs()).hasSize(9);
             Map<String, Object> properties = (Map<String, Object>) doc.getPropertiesSchema().get("properties");
-            assertThat(properties).hasSize(22);
+            assertThat(properties).hasSize(23);
 
             Map<String, Object> number = (Map<String, Object>) properties.get("number");
             assertThat(number.get("anyOf")).isNotNull();

--- a/core/src/test/java/io/kestra/core/docs/JsonSchemaGeneratorTest.java
+++ b/core/src/test/java/io/kestra/core/docs/JsonSchemaGeneratorTest.java
@@ -69,7 +69,7 @@ class JsonSchemaGeneratorTest {
         Class<? extends Task> cls = scan.getFirst().getTasks().getFirst();
 
         Map<String, Object> generate = jsonSchemaGenerator.properties(Task.class, cls);
-        assertThat(((Map<String, Map<String, Object>>) generate.get("properties")).size(), is(6));
+        assertThat(((Map<String, Map<String, Object>>) generate.get("properties")).size(), is(7));
 
         Map<String, Object> format = properties(generate).get("format");
         assertThat(format.get("default"), is("{}"));
@@ -179,11 +179,12 @@ class JsonSchemaGeneratorTest {
             Map<String, Object> jsonSchema = jsonSchemaGenerator.generate(AbstractTrigger.class, AbstractTrigger.class);
             assertThat(
                 (Map<String, Object>) jsonSchema.get("properties"), allOf(
-                    Matchers.aMapWithSize(4),
+                    Matchers.aMapWithSize(5),
                     hasKey("conditions"),
                     hasKey("stopAfter"),
                     hasKey("type"),
-                    hasKey("allowConcurrent")
+                    hasKey("allowConcurrent"),
+                    hasKey("pluginDefaultsRef")
                 )
             );
         });
@@ -253,7 +254,7 @@ class JsonSchemaGeneratorTest {
     void testEnum() {
         Map<String, Object> generate = jsonSchemaGenerator.properties(Task.class, TaskWithEnum.class);
         assertThat(generate, is(not(nullValue())));
-        assertThat(((Map<String, Map<String, Object>>) generate.get("properties")).size(), is(6));
+        assertThat(((Map<String, Map<String, Object>>) generate.get("properties")).size(), is(7));
         assertThat(((Map<String, Map<String, Object>>) generate.get("properties")).get("stringWithDefault").get("default"), is("default"));
         assertThat(((Map<String, Map<String, Object>>) generate.get("properties")).get("uri").get("$internalStorageURI"), is(true));
     }
@@ -264,7 +265,7 @@ class JsonSchemaGeneratorTest {
         Map<String, Object> generate = jsonSchemaGenerator.properties(Task.class, BetaTask.class);
         assertThat(generate, is(not(nullValue())));
         assertThat(generate.get("$beta"), is(true));
-        assertThat(((Map<String, Map<String, Object>>) generate.get("properties")).size(), is(2));
+        assertThat(((Map<String, Map<String, Object>>) generate.get("properties")).size(), is(3));
         assertThat(((Map<String, Map<String, Object>>) generate.get("properties")).get("beta").get("$beta"), is(true));
         assertThat(((Map<String, Map<String, Object>>) generate.get("properties")).get("beta").get("$language"), is(MonacoLanguages.PYTHON.toString()));
     }

--- a/core/src/test/java/io/kestra/core/runners/AbstractRunnerTest.java
+++ b/core/src/test/java/io/kestra/core/runners/AbstractRunnerTest.java
@@ -320,6 +320,11 @@ public abstract class AbstractRunnerTest {
     }
 
     @Test
+    void pluginDefaultsRefNotFound() throws Exception {
+        pluginDefaultsCaseTest.pluginDefaultsRefNotFound();
+    }
+
+    @Test
     @LoadFlows(
         value = { "flows/valids/switch.yaml",
             "flows/valids/task-flow.yaml",

--- a/core/src/test/java/io/kestra/core/runners/PluginDefaultsCaseTest.java
+++ b/core/src/test/java/io/kestra/core/runners/PluginDefaultsCaseTest.java
@@ -11,12 +11,15 @@ import io.kestra.core.exceptions.IllegalVariableEvaluationException;
 import io.kestra.core.models.executions.Execution;
 import io.kestra.core.models.executions.NextTaskRun;
 import io.kestra.core.models.executions.TaskRun;
+import io.kestra.core.models.flows.FlowWithSource;
+import io.kestra.core.models.flows.GenericFlow;
 import io.kestra.core.models.hierarchies.GraphCluster;
 import io.kestra.core.models.hierarchies.RelationType;
 import io.kestra.core.models.tasks.FlowableTask;
 import io.kestra.core.models.tasks.ResolvedTask;
 import io.kestra.core.models.tasks.Task;
 import io.kestra.core.queues.QueueException;
+import io.kestra.core.repositories.FlowRepositoryInterface;
 import io.kestra.core.utils.GraphUtils;
 
 import jakarta.inject.Inject;
@@ -33,6 +36,37 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class PluginDefaultsCaseTest {
     @Inject
     private TestRunnerUtils runnerUtils;
+
+    @Inject
+    private FlowRepositoryInterface flowRepository;
+
+    public void pluginDefaultsRefNotFound() throws TimeoutException, QueueException, io.kestra.core.exceptions.InternalException {
+        // FlowService.create/update reject unresolved refs, so the only way an unresolved ref reaches runtime is a
+        // flow that became invalid after creation (e.g. its namespace plugin-defaults was removed). We reproduce
+        // that by storing the flow directly through the repository, which bypasses the ref validation.
+        String source = """
+            id: plugin-defaults-ref-not-found
+            namespace: io.kestra.tests
+            tasks:
+              - id: broken
+                type: io.kestra.plugin.core.debug.Return
+                format: "should never run"
+                pluginDefaultsRef: does-not-exist
+            """;
+        FlowWithSource created = flowRepository.create(GenericFlow.fromYaml(MAIN_TENANT, source));
+
+        try {
+            Execution execution = runnerUtils.runOne(MAIN_TENANT, "io.kestra.tests", "plugin-defaults-ref-not-found", Duration.ofSeconds(60));
+
+            // the task references a pluginDefaultsRef that does not resolve: it must fail at runtime
+            assertThat(execution.getState().getCurrent()).isEqualTo(io.kestra.core.models.flows.State.Type.FAILED);
+            assertThat(execution.getTaskRunList()).hasSize(1);
+            assertThat(execution.getTaskRunList().getFirst().getTaskId()).isEqualTo("broken");
+            assertThat(execution.getTaskRunList().getFirst().getState().getCurrent()).isEqualTo(io.kestra.core.models.flows.State.Type.FAILED);
+        } finally {
+            flowRepository.delete(created);
+        }
+    }
 
     public void taskDefaults() throws TimeoutException, QueueException {
         Execution execution = runnerUtils.runOne(MAIN_TENANT, "io.kestra.tests", "plugin-defaults", Duration.ofSeconds(60));

--- a/core/src/test/java/io/kestra/core/services/FlowServiceTest.java
+++ b/core/src/test/java/io/kestra/core/services/FlowServiceTest.java
@@ -111,6 +111,27 @@ class FlowServiceTest {
     }
 
     @Test
+    void shouldReturnConstraintWhenPluginDefaultsRefIsUnknown() {
+        // Given — a task references a pluginDefaultsRef that does not resolve to any plugin-defaults
+        String source = """
+            id: test
+            namespace: io.kestra.unittest
+            tasks:
+              - id: broken
+                type: io.kestra.plugin.core.debug.Return
+                format: "should never run"
+                pluginDefaultsRef: does-not-exist
+            """;
+
+        // When
+        List<ValidateConstraintViolation> results = flowService.validate("my-tenant", List.of(new FlowSource(null, source)));
+
+        // Then — surfaced as a constraint error naming the unresolved ref (same check create/update enforce)
+        assertThat(results).hasSize(1);
+        assertThat(results.getFirst().getConstraints()).contains("does-not-exist");
+    }
+
+    @Test
     void importFlow() throws FlowProcessingException {
         String source = """
             id: import

--- a/core/src/test/java/io/kestra/core/services/PluginDefaultServiceOverrideTest.java
+++ b/core/src/test/java/io/kestra/core/services/PluginDefaultServiceOverrideTest.java
@@ -146,6 +146,57 @@ class PluginDefaultServiceOverrideTest {
         assertThat(result.getPropBar(), is("namespaceValue"));
     }
 
+    /**
+     * When a {@code forced} (admin-enforced) type default matches a plugin that also declares a
+     * {@code pluginDefaultsRef}, enforcement takes over entirely: the referenced plugin-defaults is ignored —
+     * not stacked. The forced value wins on the enforced property AND the ref's other (non-overlapping)
+     * properties are dropped.
+     */
+    @org.junit.jupiter.api.parallel.Execution(ExecutionMode.SAME_THREAD)
+    @Test
+    void forcedTypeDefaultBeatsForcedRef() throws FlowProcessingException {
+        final DefaultPrecedenceTester task = DefaultPrecedenceTester.builder()
+            .id("test")
+            .type(DefaultPrecedenceTester.class.getName())
+            .pluginDefaultsRef("bypass")
+            .propFoo("taskValue")
+            .build();
+
+        // a forced ref cannot bypass a forced TYPE default: even though flow-level 'forced' is honored on this
+        // release line, the forced type default still takes over entirely and the ref is ignored (no stacking)
+        final PluginDefault flowForcedRef = PluginDefault.builder()
+            .type(DefaultPrecedenceTester.class.getName())
+            .ref("bypass")
+            .forced(true)
+            .values(ImmutableMap.of("propFoo", "refValue", "propBar", "refBar"))
+            .build();
+
+        final PluginDefault globalForcedType = new PluginDefault(
+            DefaultPrecedenceTester.class.getName(), true, ImmutableMap.of("propFoo", "globalValue")
+        );
+
+        var tenant = TestsUtils.randomTenant(PluginDefaultServiceOverrideTest.class.getSimpleName());
+        final Flow flow = Flow.builder()
+            .tenantId(tenant)
+            .tasks(Collections.singletonList(task))
+            .pluginDefaults(List.of(flowForcedRef))
+            .build();
+
+        final PluginGlobalDefaultConfiguration config = new PluginGlobalDefaultConfiguration();
+        config.defaults = List.of(globalForcedType);
+
+        var previous = pluginDefaultService.pluginGlobalDefault;
+        pluginDefaultService.pluginGlobalDefault = config;
+        final Flow injected = pluginDefaultService.injectAllDefaults(flow, true);
+        pluginDefaultService.pluginGlobalDefault = previous;
+
+        DefaultPrecedenceTester result = (DefaultPrecedenceTester) injected.getTasks().getFirst();
+        // forced TYPE default wins on the enforced property...
+        assertThat(result.getPropFoo(), is("globalValue"));
+        // ...and the ref is ignored entirely — its non-overlapping property does NOT stack on top
+        assertThat(result.getPropBar(), is((String) null));
+    }
+
     private static Stream<Arguments> flowDefaultsOverrideGlobalDefaults() {
         return Stream.of(
             Arguments.of(false, false, "globalValue", "flowValue", "taskValue"),

--- a/core/src/test/java/io/kestra/core/services/PluginDefaultServiceTest.java
+++ b/core/src/test/java/io/kestra/core/services/PluginDefaultServiceTest.java
@@ -1,14 +1,19 @@
 package io.kestra.core.services;
 
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.slf4j.LoggerFactory;
 import org.slf4j.event.Level;
 
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.AppenderBase;
 import com.fasterxml.jackson.core.JsonProcessingException;
 
 import io.kestra.core.exceptions.FlowProcessingException;
@@ -431,6 +436,398 @@ class PluginDefaultServiceTest {
 
         // Then
         assertThat(((Log) injected.getTasks().getFirst()).getLevel().toString(), is(Level.INFO.name()));
+    }
+
+    @Test
+    void shouldApplyRefDefaultToNestedTaskRunner() {
+        // a nested taskRunner carrying its own pluginDefaultsRef receives the referenced plugin-defaults
+        Map<String, Object> flow = Map.of(
+            "id", "test",
+            "namespace", "type",
+            "tasks", List.of(
+                Map.of(
+                    "id", "my-task",
+                    "type", "io.kestra.test",
+                    "taskRunner", Map.of("type", "io.kestra.runner", "pluginDefaultsRef", "runner-cfg")
+                )
+            )
+        );
+        Map<String, PluginDefaultService.RefMatch> refDefaults = Map.of(
+            "runner-cfg", new PluginDefaultService.RefMatch(
+                new PluginDefault("io.kestra.runner", false, "runner-cfg", Map.of("cpus", 4)),
+                java.util.Set.of("io.kestra.runner")
+            )
+        );
+
+        // When — apply then consume the marker (the two passes the injection pipeline runs)
+        Object applied = pluginDefaultService.recursiveRefDefaults(flow, refDefaults, java.util.Set.of());
+        Object result = pluginDefaultService.stripAppliedRefMarkers(applied, refDefaults);
+
+        // Then — type matches (io.kestra.runner), values applied, marker consumed
+        Assertions.assertEquals(
+            Map.of(
+                "id", "test",
+                "namespace", "type",
+                "tasks", List.of(
+                    Map.of(
+                        "id", "my-task",
+                        "type", "io.kestra.test",
+                        "taskRunner", Map.of("type", "io.kestra.runner", "cpus", 4)
+                    )
+                )
+            ), result
+        );
+    }
+
+    @Test
+    void shouldNotApplyRefDefaultOnTypeMismatch() {
+        // the named plugin-defaults is declared for a different type than the referencing plugin
+        Map<String, Object> flow = Map.of(
+            "id", "test",
+            "namespace", "type",
+            "tasks", List.of(
+                Map.of("id", "my-task", "type", "io.kestra.other", "pluginDefaultsRef", "runner-cfg")
+            )
+        );
+        Map<String, PluginDefaultService.RefMatch> refDefaults = Map.of(
+            "runner-cfg", new PluginDefaultService.RefMatch(
+                new PluginDefault("io.kestra.runner", false, "runner-cfg", Map.of("cpus", 4)),
+                java.util.Set.of("io.kestra.runner")
+            )
+        );
+
+        // When
+        Object applied = pluginDefaultService.recursiveRefDefaults(flow, refDefaults, java.util.Set.of());
+        Object result = pluginDefaultService.stripAppliedRefMarkers(applied, refDefaults);
+
+        // Then — not applied (no 'cpus'), marker kept so it surfaces as unresolved/inapplicable
+        Assertions.assertEquals(
+            Map.of(
+                "id", "test",
+                "namespace", "type",
+                "tasks", List.of(
+                    Map.of("id", "my-task", "type", "io.kestra.other", "pluginDefaultsRef", "runner-cfg")
+                )
+            ), result
+        );
+    }
+
+    @Test
+    void shouldApplyRefDefaultDeclaredWithAliasType() throws FlowProcessingException {
+        // the named default is declared with a plugin alias; addAliases canonicalizes it so it still matches
+        // a task referencing it by the canonical type
+        String source = """
+                id: ref-alias-test
+                namespace: io.kestra.tests
+
+                tasks:
+                - id: referencing
+                  type: io.kestra.core.services.PluginDefaultServiceTest$DefaultTester
+                  pluginDefaultsRef: cfg
+
+                pluginDefaults:
+                - type: io.kestra.core.services.DefaultTesterAlias
+                  ref: cfg
+                  values:
+                    value: 7
+            """;
+
+        var tenant = TestsUtils.randomTenant(PluginDefaultServiceTest.class.getSimpleName());
+        FlowWithSource injected = pluginDefaultService.parseFlowWithAllDefaults(tenant, source, false);
+
+        // applied despite the alias/canonical type mismatch, and the marker consumed
+        assertThat(((DefaultTester) injected.getTasks().getFirst()).getValue(), is(7));
+        assertThat(injected.getTasks().getFirst().getPluginDefaultsRef(), is((String) null));
+    }
+
+    @Test
+    void shouldApplyRefDefaultOnlyToReferencingPlugin() throws FlowProcessingException {
+        // Given — same-type tasks; only one opts into the named default
+        String source = """
+                id: ref-test
+                namespace: io.kestra.tests
+
+                tasks:
+                - id: referencing
+                  type: io.kestra.core.services.PluginDefaultServiceTest$DefaultTester
+                  pluginDefaultsRef: cfg
+                - id: plain
+                  type: io.kestra.core.services.PluginDefaultServiceTest$DefaultTester
+
+                pluginDefaults:
+                - type: io.kestra.core.services.PluginDefaultServiceTest$DefaultTester
+                  ref: cfg
+                  values:
+                    value: 7
+            """;
+
+        // When
+        var tenant = TestsUtils.randomTenant(PluginDefaultServiceTest.class.getSimpleName());
+        FlowWithSource injected = pluginDefaultService.parseFlowWithAllDefaults(tenant, source, false);
+
+        // Then
+        assertThat(((DefaultTester) injected.getTasks().getFirst()).getValue(), is(7));
+        assertThat(((DefaultTester) injected.getTasks().get(1)).getValue(), is((Integer) null));
+    }
+
+    @Test
+    void shouldSuppressTypeMatchedDefaultWhenRefIsSet() throws FlowProcessingException {
+        // Given — a type-matched default AND a ref default; the referencing task must get only the ref default
+        String source = """
+                id: ref-suppress-test
+                namespace: io.kestra.tests
+
+                tasks:
+                - id: referencing
+                  type: io.kestra.core.services.PluginDefaultServiceTest$DefaultTester
+                  pluginDefaultsRef: cfg
+
+                pluginDefaults:
+                - type: io.kestra.core.services.PluginDefaultServiceTest$DefaultTester
+                  values:
+                    value: 1
+                    defaultValue: typed
+                - type: io.kestra.core.services.PluginDefaultServiceTest$DefaultTester
+                  ref: cfg
+                  values:
+                    value: 7
+            """;
+
+        // When
+        var tenant = TestsUtils.randomTenant(PluginDefaultServiceTest.class.getSimpleName());
+        FlowWithSource injected = pluginDefaultService.parseFlowWithAllDefaults(tenant, source, false);
+
+        // Then — ref default applied, type-matched default ('defaultValue') suppressed
+        assertThat(((DefaultTester) injected.getTasks().getFirst()).getValue(), is(7));
+        assertThat(((DefaultTester) injected.getTasks().getFirst()).getDefaultValue(), is("default"));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void shouldEnforceForcedTypeDefaultOnRefPluginAndWarn() {
+        // capture WARN from PluginDefaultService logger
+        Logger serviceLogger = (Logger) LoggerFactory.getLogger(PluginDefaultService.class);
+        List<ILoggingEvent> capturedLogs = new ArrayList<>();
+        AppenderBase<ILoggingEvent> appender = new AppenderBase<>() {
+            @Override
+            protected void append(ILoggingEvent event) {
+                capturedLogs.add(event);
+            }
+        };
+        appender.setContext(serviceLogger.getLoggerContext());
+        appender.start();
+        serviceLogger.addAppender(appender);
+
+        try {
+            Map<String, Object> flow = Map.of(
+                "id", "test",
+                "namespace", "type",
+                "tasks", List.of(
+                    Map.of("id", "my-task", "type", "io.kestra.test", "pluginDefaultsRef", "cfg")
+                )
+            );
+            Map<String, List<PluginDefault>> forced = Map.of(
+                "io.kestra.test",
+                List.of(new PluginDefault("io.kestra.test", true, Map.of("forced-key", "enforced")))
+            );
+
+            // When — forced pass over a plugin that opted into a named default
+            Object result = pluginDefaultService.recursiveDefaults(flow, forced, true);
+
+            // Then — forced default is enforced despite pluginDefaultsRef, and a WARN is logged
+            Map<String, Object> task = (Map<String, Object>) ((List<Object>) ((Map<String, Object>) result).get("tasks")).getFirst();
+            assertThat(task.get("forced-key"), is("enforced"));
+            assertThat(
+                capturedLogs.stream()
+                    .filter(e -> e.getLevel() == ch.qos.logback.classic.Level.WARN)
+                    .anyMatch(e -> e.getFormattedMessage().contains("pluginDefaultsRef")),
+                is(true)
+            );
+        } finally {
+            serviceLogger.detachAppender(appender);
+        }
+    }
+
+    @Test
+    void shouldYieldToTaskValueForNonForcedRef() throws FlowProcessingException {
+        // Given — non-forced ref default, task sets the property explicitly
+        String source = """
+                id: ref-nonforced-test
+                namespace: io.kestra.tests
+
+                tasks:
+                - id: referencing
+                  type: io.kestra.core.services.PluginDefaultServiceTest$DefaultTester
+                  pluginDefaultsRef: cfg
+                  set: 1
+
+                pluginDefaults:
+                - type: io.kestra.core.services.PluginDefaultServiceTest$DefaultTester
+                  ref: cfg
+                  values:
+                    set: 99
+            """;
+
+        // When
+        var tenant = TestsUtils.randomTenant(PluginDefaultServiceTest.class.getSimpleName());
+        FlowWithSource injected = pluginDefaultService.parseFlowWithAllDefaults(tenant, source, false);
+
+        // Then — explicit task value wins
+        assertThat(((DefaultTester) injected.getTasks().getFirst()).getSet(), is(1));
+    }
+
+    @Test
+    void shouldLetFlowForcedRefOverrideTaskValue() throws FlowProcessingException {
+        // Given — 'forced: true' on a flow-level ref default IS honored on this release line (1.3 lets flows
+        // enforce, unlike develop where flow-level 'forced' was removed): the forced ref overrides the task value.
+        // (A namespace- or global-forced ref of the same name would still win via admin-first precedence.)
+        String source = """
+                id: ref-forced-test
+                namespace: io.kestra.tests
+
+                tasks:
+                - id: referencing
+                  type: io.kestra.core.services.PluginDefaultServiceTest$DefaultTester
+                  pluginDefaultsRef: cfg
+                  set: 1
+
+                pluginDefaults:
+                - type: io.kestra.core.services.PluginDefaultServiceTest$DefaultTester
+                  ref: cfg
+                  forced: true
+                  values:
+                    set: 99
+            """;
+
+        // When
+        var tenant = TestsUtils.randomTenant(PluginDefaultServiceTest.class.getSimpleName());
+        FlowWithSource injected = pluginDefaultService.parseFlowWithAllDefaults(tenant, source, false);
+
+        // Then — flow-level 'forced' is honored, so the ref value overrides the explicit task value
+        assertThat(((DefaultTester) injected.getTasks().getFirst()).getSet(), is(99));
+    }
+
+    @Test
+    void shouldIgnoreUnknownRef() throws FlowProcessingException {
+        // Given — task references a ref that does not exist
+        String source = """
+                id: ref-unknown-test
+                namespace: io.kestra.tests
+
+                tasks:
+                - id: referencing
+                  type: io.kestra.core.services.PluginDefaultServiceTest$DefaultTester
+                  pluginDefaultsRef: nope
+                  set: 5
+
+                pluginDefaults:
+                - type: io.kestra.core.services.PluginDefaultServiceTest$DefaultTester
+                  ref: cfg
+                  values:
+                    value: 7
+            """;
+
+        // When
+        var tenant = TestsUtils.randomTenant(PluginDefaultServiceTest.class.getSimpleName());
+        FlowWithSource injected = pluginDefaultService.parseFlowWithAllDefaults(tenant, source, false);
+
+        // Then — task unchanged; the 'cfg' default is not applied by type either
+        assertThat(((DefaultTester) injected.getTasks().getFirst()).getSet(), is(5));
+        assertThat(((DefaultTester) injected.getTasks().getFirst()).getValue(), is((Integer) null));
+        assertThat(injected.getTasks().getFirst().getPluginDefaultsRef(), is("nope"));
+    }
+
+    @Test
+    void shouldStrictParseRefFields() throws FlowProcessingException {
+        // Given — strict parsing must accept the new fields: pluginDefaultsRef on the task, ref + forced on the default
+        var tenant = TestsUtils.randomTenant(PluginDefaultServiceTest.class.getSimpleName());
+        GenericFlow flow = GenericFlow.fromYaml(
+            tenant, """
+                  id: ref-strict-test
+                  namespace: io.kestra.tests
+
+                  tasks:
+                  - id: referencing
+                    type: io.kestra.core.services.PluginDefaultServiceTest$DefaultTester
+                    pluginDefaultsRef: cfg
+                    set: 1
+
+                  pluginDefaults:
+                  - type: io.kestra.core.services.PluginDefaultServiceTest$DefaultTester
+                    ref: cfg
+                    forced: true
+                    values:
+                      set: 99
+                """
+        );
+
+        // When — strictParsing = true
+        FlowWithSource injected = pluginDefaultService.injectAllDefaults(flow, true);
+
+        // Then — ref resolved; 'forced' is honored at flow level on this release line, so the ref value wins,
+        // and the marker is consumed (stripped) once the default is applied
+        assertThat(((DefaultTester) injected.getTasks().getFirst()).getSet(), is(99));
+        assertThat(injected.getTasks().getFirst().getPluginDefaultsRef(), is((String) null));
+    }
+
+    @Test
+    void shouldReportUnresolvedRefForValidation() throws FlowProcessingException {
+        // Given — one resolvable ref and one unknown ref
+        String source = """
+                id: ref-validate-test
+                namespace: io.kestra.tests
+
+                tasks:
+                - id: ok
+                  type: io.kestra.core.services.PluginDefaultServiceTest$DefaultTester
+                  pluginDefaultsRef: known
+                - id: broken
+                  type: io.kestra.core.services.PluginDefaultServiceTest$DefaultTester
+                  pluginDefaultsRef: missing
+
+                pluginDefaults:
+                - type: io.kestra.core.services.PluginDefaultServiceTest$DefaultTester
+                  ref: known
+                  values:
+                    value: 1
+            """;
+
+        var tenant = TestsUtils.randomTenant(PluginDefaultServiceTest.class.getSimpleName());
+        FlowWithSource injected = pluginDefaultService.parseFlowWithAllDefaults(tenant, source, false);
+
+        // When / Then — only the unknown ref survives and is reported
+        assertThat(pluginDefaultService.unresolvedPluginDefaultsRefs(injected), is(java.util.Set.of("missing")));
+    }
+
+    @Test
+    void shouldApplyRefDefaultToTrigger() throws FlowProcessingException {
+        // Given — a trigger opts into a named default
+        String source = """
+                id: ref-trigger-test
+                namespace: io.kestra.tests
+
+                triggers:
+                - id: trigger
+                  type: io.kestra.core.services.PluginDefaultServiceTest$DefaultTriggerTester
+                  pluginDefaultsRef: cfg
+
+                tasks:
+                - id: test
+                  type: io.kestra.core.services.PluginDefaultServiceTest$DefaultTester
+
+                pluginDefaults:
+                - type: io.kestra.core.services.PluginDefaultServiceTest$DefaultTriggerTester
+                  ref: cfg
+                  values:
+                    set: 42
+            """;
+
+        // When
+        var tenant = TestsUtils.randomTenant(PluginDefaultServiceTest.class.getSimpleName());
+        FlowWithSource injected = pluginDefaultService.parseFlowWithAllDefaults(tenant, source, false);
+
+        // Then
+        assertThat(((DefaultTriggerTester) injected.getTriggers().getFirst()).getSet(), is(42));
     }
 
     @SuperBuilder

--- a/executor/src/main/java/io/kestra/executor/ExecutorService.java
+++ b/executor/src/main/java/io/kestra/executor/ExecutorService.java
@@ -12,6 +12,7 @@ import org.slf4j.event.Level;
 import io.kestra.core.assets.AssetService;
 import io.kestra.core.debug.Breakpoint;
 import io.kestra.core.exceptions.InternalException;
+import io.kestra.core.exceptions.PluginDefaultsRefNotFoundException;
 import io.kestra.core.metrics.MetricRegistry;
 import io.kestra.core.models.Label;
 import io.kestra.core.models.assets.AssetIdentifier;
@@ -887,6 +888,13 @@ public class ExecutorService {
                     .task(task)
                     .executionKind(executor.getExecution().getKind())
                     .build();
+                // a surviving 'pluginDefaultsRef' means plugin-default injection could not resolve the referenced
+                // plugin-defaults: fail the task-run instead of sending a bad job to the worker
+                if (task.getPluginDefaultsRef() != null) {
+                    runContext.logger()
+                        .error(new PluginDefaultsRefNotFoundException(task.getPluginDefaultsRef()).getMessage());
+                    return workerTask.withTaskRun(workerTask.getTaskRun().fail());
+                }
                 // Get worker group
                 Optional<WorkerGroup> workerGroup = workerGroupService.resolveGroupFromJob(executor.getFlow(), workerTask);
                 if (workerGroup.isPresent()) {

--- a/scheduler/src/main/java/io/kestra/scheduler/AbstractScheduler.java
+++ b/scheduler/src/main/java/io/kestra/scheduler/AbstractScheduler.java
@@ -24,6 +24,7 @@ import io.kestra.core.events.CrudEvent;
 import io.kestra.core.events.CrudEventType;
 import io.kestra.core.exceptions.InternalException;
 import io.kestra.core.exceptions.InvalidTriggerConfigurationException;
+import io.kestra.core.exceptions.PluginDefaultsRefNotFoundException;
 import io.kestra.core.metrics.MetricRegistry;
 import io.kestra.core.models.HasUID;
 import io.kestra.core.models.conditions.Condition;
@@ -734,6 +735,11 @@ public abstract class AbstractScheduler implements Scheduler {
                             if (this.interval(f.getAbstractTrigger()) != null) {
                                 // If it has an interval, the Worker will execute the trigger.
                                 // Normally, only the Schedule trigger has no interval.
+                                // a surviving 'pluginDefaultsRef' means plugin-default injection could not resolve the
+                                // referenced plugin-defaults: fail the trigger evaluation instead of sending a bad job to the worker
+                                if (f.getAbstractTrigger().getPluginDefaultsRef() != null) {
+                                    throw new PluginDefaultsRefNotFoundException(f.getAbstractTrigger().getPluginDefaultsRef());
+                                }
                                 Trigger triggerRunning = Trigger.of(f.getTriggerContext(), now);
                                 var flowWithTrigger = f.toBuilder().triggerContext(triggerRunning).build();
                                 try {

--- a/ui/src/override/services/flowAutoCompletionProvider.ts
+++ b/ui/src/override/services/flowAutoCompletionProvider.ts
@@ -311,10 +311,24 @@ export class FlowAutoCompletion extends YamlAutoCompletion {
                 if (parentTask !== undefined && parentTask.namespace !== undefined && parentTask.flowId !== undefined) {
                     return await this.subflowInputsAutoCompletion(parentTask.namespace, parentTask.flowId, parentTask.revision, Object.keys(yamlElement.value ?? {}));
                 }
+                break;
+            }
+            case "pluginDefaultsRef": {
+                return Promise.resolve(this.flowPluginDefaultsRefs(parsed));
             }
         }
 
         return Promise.resolve([]);
+    }
+
+    /**
+     * Distinct `ref` ids declared in the flow's own `pluginDefaults` block.
+     */
+    protected flowPluginDefaultsRefs(parsed: any | undefined): string[] {
+        const refs = (parsed?.pluginDefaults ?? [])
+            .map((pluginDefault: {ref?: string}) => pluginDefault?.ref)
+            .filter((ref: string | undefined): ref is string => Boolean(ref))
+        return [...new Set<string>(refs)]
     }
 
     private extractArgValue(arg: string | undefined) {

--- a/ui/tests/unit/services/flowAutoCompletionProvider.spec.ts
+++ b/ui/tests/unit/services/flowAutoCompletionProvider.spec.ts
@@ -261,6 +261,30 @@ tasks:
         expect(await provider.valueAutoCompletion(defaultFlow.substring(0, firstInputIndex) + "\n        " + defaultFlow.substring(firstInputIndex, defaultFlow.length), parsed, YAML_UTILS.localizeElementAtIndex(defaultFlow, firstInputIndex))).toEqual(["second-input:"]);
     })
 
+    it("pluginDefaultsRef value autocompletions from flow pluginDefaults", async () => {
+        const flow = [
+            "tasks:",
+            "  - id: t1",
+            "    type: io.kestra.plugin.core.log.Log",
+            "    pluginDefaultsRef: ",
+            "pluginDefaults:",
+            "  - type: io.kestra.plugin.core.log.Log",
+            "    ref: io-config",
+            "    values:",
+            "      message: hi",
+            "  - type: io.kestra.plugin.core.log.Log",
+            "    ref: cpu-config",
+            "    values:",
+            "      message: yo",
+            "id: my-flow",
+            "namespace: my.namespace",
+        ].join("\n")
+        const flowParsed = YAML_UTILS.parse(flow)
+        const cursor = flow.indexOf("pluginDefaultsRef:") + "pluginDefaultsRef:".length
+        expect(await provider.valueAutoCompletion(flow, flowParsed, YAML_UTILS.localizeElementAtIndex(flow, cursor)))
+            .toEqual(["io-config", "cpu-config"])
+    })
+
     it("function autocompletions", async () => {
         expect(await provider.functionAutoCompletion(parsed, "secret", {})).toEqual(["'myFirstSecret'", "'mySecondSecret'", "'myInheritedSecret'"]);
         expect(await provider.functionAutoCompletion(parsed, "secret", {namespace: "'another.namespace'"})).toEqual(["'anotherNsFirstSecret'", "'anotherNsSecondSecret'"]);

--- a/webserver/src/test/java/io/kestra/webserver/controllers/api/PluginControllerTest.java
+++ b/webserver/src/test/java/io/kestra/webserver/controllers/api/PluginControllerTest.java
@@ -110,7 +110,7 @@ class PluginControllerTest {
         assertThat(doc.getMarkdown()).contains("Return a value for debugging purposes.");
         assertThat(doc.getMarkdown()).contains("The templated string to render");
         assertThat(doc.getMarkdown()).contains("The generated string");
-        assertThat(((Map<String, Object>) doc.getSchema().getProperties().get("properties")).size()).isEqualTo(1);
+        assertThat(((Map<String, Object>) doc.getSchema().getProperties().get("properties")).size()).isEqualTo(2);
         assertThat(((Map<String, Object>) doc.getSchema().getOutputs().get("properties")).size()).isEqualTo(1);
     }
 
@@ -123,7 +123,7 @@ class PluginControllerTest {
         );
 
         assertThat(doc.getMarkdown()).contains("io.kestra.plugin.templates.ExampleTask");
-        assertThat(((Map<String, Object>) doc.getSchema().getProperties().get("properties")).size()).isEqualTo(5);
+        assertThat(((Map<String, Object>) doc.getSchema().getProperties().get("properties")).size()).isEqualTo(6);
         assertThat(((Map<String, Object>) doc.getSchema().getOutputs().get("properties")).size()).isEqualTo(1);
     }
 
@@ -149,7 +149,7 @@ class PluginControllerTest {
         Map<String, Map<String, Object>> properties = (Map<String, Map<String, Object>>) doc.getSchema().getProperties().get("properties");
 
         assertThat(doc.getMarkdown()).contains("io.kestra.plugin.templates.ExampleTask");
-        assertThat(properties.size()).isEqualTo(19);
+        assertThat(properties.size()).isEqualTo(20);
         assertThat(properties.get("id").size()).isEqualTo(5);
         assertThat(((Map<String, Object>) doc.getSchema().getOutputs().get("properties")).size()).isEqualTo(1);
     }


### PR DESCRIPTION
Backport of [#16446](https://github.com/kestra-io/kestra/pull/16446) to `releases/v1.3.x`.

- A `pluginDefaults` entry can declare an optional `ref`; tasks, triggers and task runners opt in via `pluginDefaultsRef`. A named default applies only to plugins referencing it (never by type matching), suppresses non-forced type-matched defaults for that plugin, and collapses same-`ref` entries to a single shadowing winner. A forced type-matched default always takes over entirely (ref ignored, WARN logged). Unresolved or type-mismatched refs are a validation error on create/update and fail at runtime (executor fails the task run, scheduler fails the trigger evaluation).
- **Re-implemented for the 1.3 architecture** (not a cherry-pick): 1.3 has the single `PluginDefault` model — the develop `FlowPluginDefault`/`PluginDefaultSpec` split from [#15812](https://github.com/kestra-io/kestra/pull/15812) is not present — and the runtime trigger guard is adapted to `AbstractScheduler` (1.3 has no `TriggerScheduler`).
- **⚠️ Behaviour differs from develop, by design:** on 1.3 flow-level `forced` is honored, so a flow-level `forced: true` `ref` bundle overrides a task's own value; on develop a flow cannot force (per [#15812](https://github.com/kestra-io/kestra/pull/15812)), so the task value wins. The same flow YAML therefore resolves differently across the two lines. Admin enforcement is preserved on both: a namespace/global `forced` `ref` still beats a flow `forced` ref via admin-first precedence.
- **Deliberate test gap:** develop's `TriggerSchedulerTest` case can't be ported (1.3's scheduler test harness is unrelated to develop's `TriggerScheduler`), and a 1.3 equivalent needs heavyweight JDBC-scheduler integration. The guard is verified by inspection — an unresolved trigger ref throws into the existing evaluate-loop catch then `handleFailedEvaluatedTrigger`, emitting a FAILED execution and leaving the trigger unlocked. The executor guard is covered end-to-end (`pluginDefaultsRefNotFound` on the H2 runner).
- Companion EE backport on the same branch name.
