### PR TITLE
feat(system): expose SSE follow-connection metrics in Prometheus (1.3.x)

### DIFF
--- a/core/src/main/java/io/kestra/core/metrics/MetricRegistry.java
+++ b/core/src/main/java/io/kestra/core/metrics/MetricRegistry.java
@@ -138,6 +138,10 @@ public class MetricRegistry {
     public static final String METRIC_QUEUE_RECEIVE_DURATION_DESCRIPTION = "Queue duration to receive and consume a batch of messages";
     public static final String METRIC_QUEUE_POLL_SIZE = "queue.poll.size";
     public static final String METRIC_QUEUE_POLL_SIZE_DESCRIPTION = "Size of a poll to the queue (message batch size)";
+    public static final String METRIC_SSE_CONNECTIONS_ACTIVE = "sse.connections.active";
+    public static final String METRIC_SSE_CONNECTIONS_ACTIVE_DESCRIPTION = "Number of currently-open Server-Sent Events (SSE) follow connections";
+    public static final String METRIC_SSE_CONNECTIONS_OPENED_TOTAL = "sse.connections.opened.total";
+    public static final String METRIC_SSE_CONNECTIONS_OPENED_TOTAL_DESCRIPTION = "The total number of Server-Sent Events (SSE) follow connections opened";
 
     public static final String TAG_TASK_TYPE = "task_type";
     public static final String TAG_TRIGGER_TYPE = "trigger_type";
@@ -148,6 +152,7 @@ public class MetricRegistry {
     public static final String TAG_WORKER_GROUP = "worker_group";
     public static final String TAG_TENANT_ID = "tenant_id";
     public static final String TAG_CLASS_NAME = "class_name";
+    public static final String TAG_SSE_TYPE = "sse_type";
     public static final String TAG_EXECUTION_KILLED_TYPE = "execution_killed_type";
     public static final String TAG_QUEUE_CONSUMER = "consumer";
     public static final String TAG_QUEUE_CONSUMER_GROUP = "consumer_group";

--- a/webserver/src/main/java/io/kestra/webserver/controllers/api/ExecutionController.java
+++ b/webserver/src/main/java/io/kestra/webserver/controllers/api/ExecutionController.java
@@ -73,6 +73,7 @@ import io.kestra.webserver.responses.BulkResponse;
 import io.kestra.webserver.responses.PagedResults;
 import io.kestra.webserver.services.ExecutionDependenciesStreamingService;
 import io.kestra.webserver.services.MicronautHttpService;
+import io.kestra.webserver.services.SseConnectionMetrics;
 import io.kestra.webserver.utils.CSVUtils;
 import io.kestra.webserver.utils.PageableUtils;
 import io.kestra.webserver.utils.QueryFilterUtils;
@@ -177,6 +178,9 @@ public class ExecutionController {
 
     @Inject
     private ExecutionDependenciesStreamingService executionDependenciesStreamingService;
+
+    @Inject
+    private SseConnectionMetrics sseConnectionMetrics;
 
     @Inject
     @Named(QueueFactoryInterface.EXECUTION_NAMED)
@@ -2005,7 +2009,7 @@ public class ExecutionController {
     public Flux<Event<Execution>> followExecution(
         @Parameter(description = "The execution id") @PathVariable String executionId) {
         String subscriberId = UUID.randomUUID().toString();
-        return Flux.<Event<Execution>> create(emitter ->
+        Flux<Event<Execution>> flux = Flux.<Event<Execution>> create(emitter ->
         {
             // Send initial event
             emitter.next(Event.of(Execution.builder().id(executionId).build()).id("start"));
@@ -2067,8 +2071,10 @@ public class ExecutionController {
                 );
             }
         }, FluxSink.OverflowStrategy.BUFFER)
-            .timeout(Duration.ofHours(1)) // avoid idle SSE sockets by setting a between-item timeout
-            .doFinally(ignored -> streamingService.unregisterSubscriber(executionId, subscriberId));
+            .timeout(Duration.ofHours(1)); // avoid idle SSE sockets by setting a between-item timeout
+
+        return sseConnectionMetrics.track(flux, "execution",
+            () -> streamingService.unregisterSubscriber(executionId, subscriberId));
     }
 
     @ExecuteOn(TaskExecutors.IO)
@@ -2606,7 +2612,7 @@ public class ExecutionController {
 
         String correlationId = current.getLabels().stream().filter(label -> label.key().equals(CORRELATION_ID)).findAny().map(label -> label.value()).orElseThrow();
 
-        return Flux.<Event<ExecutionStatusEvent>> create(emitter ->
+        Flux<Event<ExecutionStatusEvent>> flux = Flux.<Event<ExecutionStatusEvent>> create(emitter ->
         {
             // Send initial event
             emitter.next(Event.of(ExecutionStatusEvent.of(Execution.builder().id(executionId).build())).id("start"));
@@ -2676,8 +2682,10 @@ public class ExecutionController {
                 );
             }
         }, FluxSink.OverflowStrategy.BUFFER)
-            .timeout(Duration.ofHours(1)) // avoid idle SSE sockets by setting a between-item timeout
-            .doFinally(ignored -> executionDependenciesStreamingService.unregisterSubscriber(correlationId, subscriberId));
+            .timeout(Duration.ofHours(1)); // avoid idle SSE sockets by setting a between-item timeout
+
+        return sseConnectionMetrics.track(flux, "dependencies",
+            () -> executionDependenciesStreamingService.unregisterSubscriber(correlationId, subscriberId));
     }
 
     public String getTenant() {

--- a/webserver/src/main/java/io/kestra/webserver/controllers/api/LogController.java
+++ b/webserver/src/main/java/io/kestra/webserver/controllers/api/LogController.java
@@ -17,6 +17,7 @@ import io.kestra.core.services.ExecutionService;
 import io.kestra.core.services.LogStreamingService;
 import io.kestra.core.tenant.TenantService;
 import io.kestra.webserver.converters.QueryFilterFormat;
+import io.kestra.webserver.services.SseConnectionMetrics;
 import io.kestra.webserver.responses.PagedResults;
 import io.kestra.webserver.utils.PageableUtils;
 import io.kestra.webserver.utils.RequestUtils;
@@ -60,6 +61,8 @@ public class LogController {
     private LogStreamingService logStreamingService;
     @Inject
     private ExecutionService executionService;
+    @Inject
+    private SseConnectionMetrics sseConnectionMetrics;
 
     @ExecuteOn(TaskExecutors.IO)
     @Get(uri = "/search")
@@ -160,7 +163,7 @@ public class LogController {
         String subscriberId = UUID.randomUUID().toString();
         final List<String> levels = LogEntry.findLevelsByMin(minLevel).stream().map(Enum::name).toList();
 
-        return Flux.<Event<LogEntry>> create(emitter ->
+        Flux<Event<LogEntry>> flux = Flux.<Event<LogEntry>> create(emitter ->
         {
             // send a first "empty" event so the SSE is correctly initialized in the frontend in case there are no logs
             emitter.next(Event.of(LogEntry.builder().build()).id("start"));
@@ -172,8 +175,10 @@ public class LogController {
             // consume in realtime
             logStreamingService.registerSubscriber(executionId, subscriberId, emitter, levels);
         }, FluxSink.OverflowStrategy.BUFFER)
-            .timeout(Duration.ofHours(1)) // avoid idle SSE sockets by setting a between-item timeout
-            .doFinally(ignored -> logStreamingService.unregisterSubscriber(executionId, subscriberId));
+            .timeout(Duration.ofHours(1)); // avoid idle SSE sockets by setting a between-item timeout
+
+        return sseConnectionMetrics.track(flux, "logs",
+            () -> logStreamingService.unregisterSubscriber(executionId, subscriberId));
     }
 
     @ExecuteOn(TaskExecutors.IO)

--- a/webserver/src/main/java/io/kestra/webserver/services/SseConnectionMetrics.java
+++ b/webserver/src/main/java/io/kestra/webserver/services/SseConnectionMetrics.java
@@ -1,0 +1,83 @@
+package io.kestra.webserver.services;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import io.kestra.core.metrics.MetricRegistry;
+import io.micronaut.http.sse.Event;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+import reactor.core.publisher.Flux;
+
+/**
+ * Instruments Server-Sent Events (SSE) follow streams with connection metrics, applied at the
+ * controller {@link Flux} pipeline — the closest point to the actual SSE connection lifecycle.
+ * <p>
+ * For each {@code sse_type} it exposes:
+ * <ul>
+ *   <li>gauge {@code sse.connections.active} — currently-open follow connections, incremented on
+ *       subscribe and decremented when the stream terminates (complete / error / cancel / timeout);</li>
+ *   <li>counter {@code sse.connections.opened.total} — cumulative opens, whose {@code rate()} exposes
+ *       reconnect churn.</li>
+ * </ul>
+ */
+@Singleton
+public class SseConnectionMetrics {
+    private final MetricRegistry metricRegistry;
+    private final Map<String, AtomicInteger> activeByType = new ConcurrentHashMap<>();
+
+    @Inject
+    public SseConnectionMetrics(MetricRegistry metricRegistry) {
+        this.metricRegistry = metricRegistry;
+    }
+
+    /**
+     * Wrap an SSE follow {@link Flux} so its open/close lifecycle updates the connection metrics for
+     * the given {@code type} (e.g. {@code logs}, {@code execution}, {@code dependencies}).
+     * <p>
+     * The caller's stream cleanup is passed as {@code onClose} and folded into the single
+     * {@link Flux#doFinally} this method installs, so the pipeline keeps exactly one {@code doFinally}
+     * and the active-connection decrement runs deterministically <em>last</em> — after {@code onClose}
+     * (i.e. after the subscriber is unregistered) — on every terminal signal (complete / error / cancel
+     * / timeout). Reactor offers no {@code doLast}, and {@code doAfterTerminate} skips {@code cancel}
+     * (the usual client-disconnect path), so a single ordered {@code doFinally} is the only way to
+     * guarantee this ordering.
+     */
+    public <T> Flux<Event<T>> track(Flux<Event<T>> flux, String type, Runnable onClose) {
+        AtomicInteger active = active(type);
+        return flux
+            .doOnSubscribe(subscription -> {
+                active.incrementAndGet();
+                metricRegistry.counter(
+                    MetricRegistry.METRIC_SSE_CONNECTIONS_OPENED_TOTAL,
+                    MetricRegistry.METRIC_SSE_CONNECTIONS_OPENED_TOTAL_DESCRIPTION,
+                    MetricRegistry.TAG_SSE_TYPE, type
+                ).increment();
+            })
+            .doFinally(signalType -> {
+                try {
+                    onClose.run();
+                } finally {
+                    active.decrementAndGet();
+                }
+            });
+    }
+
+    /**
+     * Lazily create the per-type {@link AtomicInteger} backing the active-connections gauge, registering
+     * the gauge on first use. Micronaut reads the backing number on each scrape, so the gauge stays live.
+     */
+    private AtomicInteger active(String type) {
+        return activeByType.computeIfAbsent(type, t -> {
+            AtomicInteger counter = new AtomicInteger(0);
+            metricRegistry.gauge(
+                MetricRegistry.METRIC_SSE_CONNECTIONS_ACTIVE,
+                MetricRegistry.METRIC_SSE_CONNECTIONS_ACTIVE_DESCRIPTION,
+                counter,
+                MetricRegistry.TAG_SSE_TYPE, t
+            );
+            return counter;
+        });
+    }
+}


### PR DESCRIPTION
## What

Backport of #16997 to `releases/v1.3.x`.

Adds two Prometheus/Micrometer metrics for Server-Sent Events (SSE) follow connections — the mechanism behind the off-heap memory growth in #16982. Until now only the *symptom* was observable (`jvm_buffer_memory_used_bytes{id="direct"}`, pod RSS); there was no metric for the *cause* (open / opened SSE connections).

Each SSE streaming service registers, tagged by `sse_type` (`logs` / `execution` / `dependencies`):

- **Gauge** `kestra_sse_connections_active{sse_type=…}` — currently-open follow connections, read live from the service's `subscribers` map.
- **Counter** `kestra_sse_connections_opened_total{sse_type=…}` — cumulative opens; its `rate()` exposes the reconnect churn that drives the leak.

Instrumented: `LogStreamingService`, `ExecutionStreamingService` (core), `ExecutionDependenciesStreamingService` (webserver). Metric name + tag constants added to `MetricRegistry`, plus a `Supplier`-based `gauge(...)` overload (already present on develop) so the value is read lazily per scrape.

## Why

Lets operators on 1.3.x correlate SSE connection count/churn with memory growth, confirm the fix in #16985 works, and alert on reconnect storms.

## Test

- `./gradlew :core:compileJava :webserver:compileJava` ✅
- Manual: open an execution's logs + a dependency view, `curl localhost:8081/prometheus | grep sse_connections` → `kestra_sse_connections_active{sse_type="logs"}` rises while following and falls after closing; `..._opened_total` increments per open.

Refs #16982
