### PR TITLE
fix(repository): return HTTP 422 on unknown sort field instead of NPE

### DIFF
--- a/core/src/test/java/io/kestra/core/repositories/AbstractExecutionRepositoryTest.java
+++ b/core/src/test/java/io/kestra/core/repositories/AbstractExecutionRepositoryTest.java
@@ -1436,7 +1436,11 @@ public abstract class AbstractExecutionRepositoryTest {
                         String col = split[0];
 
                         if (sortMapper != null) {
-                            col = sortMapper.apply(col);
+                            String mapped = sortMapper.apply(col);
+                            if (mapped == null) {
+                                throw new HttpStatusException(HttpStatus.UNPROCESSABLE_ENTITY, "Invalid sort field: " + col);
+                            }
+                            col = mapped;
                         }
 
                         return split[1].equals("asc") ? Sort.Order.asc(col) : Sort.Order.desc(col);

--- a/webserver/src/main/java/io/kestra/webserver/utils/PageableUtils.java
+++ b/webserver/src/main/java/io/kestra/webserver/utils/PageableUtils.java
@@ -48,7 +48,11 @@ public class PageableUtils {
                         String col = split[0];
 
                         if (sortMapper != null) {
-                            col = sortMapper.apply(col);
+                            String mapped = sortMapper.apply(col);
+                            if (mapped == null) {
+                                throw new HttpStatusException(HttpStatus.UNPROCESSABLE_ENTITY, "Invalid sort field: " + col);
+                            }
+                            col = mapped;
                         }
 
                         return split[1].equals("asc") ? Sort.Order.asc(col) : Sort.Order.desc(col);

--- a/webserver/src/test/java/io/kestra/webserver/utils/PageableUtilsTest.java
+++ b/webserver/src/test/java/io/kestra/webserver/utils/PageableUtilsTest.java
@@ -2,12 +2,15 @@ package io.kestra.webserver.utils;
 
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import java.util.function.Function;
 
 import org.junit.jupiter.api.Test;
 
 import io.micronaut.data.model.Pageable;
 import io.micronaut.data.model.Sort;
+import io.micronaut.http.HttpStatus;
+import io.micronaut.http.exceptions.HttpStatusException;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
@@ -36,5 +39,19 @@ class PageableUtilsTest {
         assertThrows(IllegalArgumentException.class, () -> PageableUtils.from(1, -1, List.of("key:asc"), toUpper));
         assertThrows(IllegalArgumentException.class, () -> PageableUtils.from(1, -1, List.of("key:asc")));
         assertThrows(IllegalArgumentException.class, () -> PageableUtils.from(1, -1));
+    }
+
+    @Test
+    void shouldThrowWhenSortFieldIsUnknown() {
+        // Given a mapper that only knows "id" — any other field returns null
+        Function<String, String> mapper = Map.of("id", "id")::get;
+
+        // When an unknown sort field is supplied
+        HttpStatusException e = assertThrows(HttpStatusException.class,
+            () -> PageableUtils.from(1, 10, List.of("unknownColumn:asc"), mapper));
+
+        // Then a 422 is returned with the unknown field name
+        assertEquals(HttpStatus.UNPROCESSABLE_ENTITY, e.getStatus());
+        assertThat(e.getMessage()).contains("unknownColumn");
     }
 }


### PR DESCRIPTION
When a sortMapper returns null for an unrecognised column name, PageableUtils.sort() now throws HttpStatusException(UNPROCESSABLE_ENTITY) instead of propagating null into Sort.Order.asc(null) and subsequently crashing in camelToSnake(null) with an unhandled NullPointerException.

Fixes kestra-io/kestra-ee#8002