### PR TITLE
fix(core): bound the ClassPluginDocumentation cache

### DIFF
--- a/core/src/main/java/io/kestra/core/docs/ClassPluginDocumentation.java
+++ b/core/src/main/java/io/kestra/core/docs/ClassPluginDocumentation.java
@@ -1,9 +1,12 @@
 package io.kestra.core.docs;
 
+import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
-import java.util.concurrent.ConcurrentHashMap;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
 
 import io.kestra.core.plugins.PluginClassAndMetadata;
 
@@ -16,7 +19,14 @@ import lombok.ToString;
 @EqualsAndHashCode
 @ToString
 public class ClassPluginDocumentation<T> extends AbstractClassDocumentation<T> {
-    private static final Map<PluginDocIdentifier, ClassPluginDocumentation<?>> CACHE = new ConcurrentHashMap<>();
+    // Bounded cache to avoid unbounded growth over the (pluginClass + version + allProperties) keyspace,
+    // which grows over time as users browse plugins/versions in the editor. Doc objects are deterministic
+    // per key, so an eviction just means the entry is regenerated on the next access.
+    private static final Cache<PluginDocIdentifier, ClassPluginDocumentation<?>> CACHE = Caffeine.newBuilder()
+        .maximumSize(1000)
+        .expireAfterAccess(Duration.ofHours(1))
+        .recordStats()
+        .build();
     private String icon;
     private String group;
     protected String docLicense;
@@ -87,7 +97,7 @@ public class ClassPluginDocumentation<T> extends AbstractClassDocumentation<T> {
 
     public static <T> ClassPluginDocumentation<T> of(JsonSchemaGenerator jsonSchemaGenerator, PluginClassAndMetadata<T> plugin, String version, boolean allProperties) {
         //noinspection unchecked
-        return (ClassPluginDocumentation<T>) CACHE.computeIfAbsent(
+        return (ClassPluginDocumentation<T>) CACHE.get(
             new PluginDocIdentifier(plugin.type(), version, allProperties),
             (key) -> new ClassPluginDocumentation<>(jsonSchemaGenerator, plugin, allProperties)
         );


### PR DESCRIPTION
## What

`ClassPluginDocumentation.CACHE` was an **unbounded** `static final ConcurrentHashMap`, keyed by `pluginClass.getName() + ":" + version` (+ the `allProperties` flag), holding large generated documentation objects (JSON schemas, `$defs`, outputs, metrics). It's populated by `of()` every time a user opens a task in the editor (via `PluginController` / `DocumentationGenerator`). With multiple plugin versions installed, the `version` dimension makes the keyspace grow without bound over a long-running instance → heap leak.

This replaces it with a bounded Caffeine cache, matching the existing idiom in `FlowWithDefaultCache` / `PebbleLruCache`:

```java
private static final Cache<PluginDocIdentifier, ClassPluginDocumentation<?>> CACHE = Caffeine.newBuilder()
    .maximumSize(1000)
    .expireAfterAccess(Duration.ofHours(1))
    .recordStats()
    .build();
```

`CACHE.computeIfAbsent(key, fn)` becomes `CACHE.get(key, fn)` (Caffeine's `get(key, mappingFunction)` has the same compute-if-absent semantics and exception propagation). Doc objects are deterministic per key, so an eviction just regenerates the entry on next access.

## Scope

`develop`/2.0 only — the `version` cache-key dimension and the `{cls}/versions/{version}` endpoint were introduced 2025-07-01 (`f402aa764`); not present in 1.x.

## Test

- `./gradlew :core:compileJava` ✅
- `./gradlew :core:test --tests ClassPluginDocumentationTest --tests DocumentationGeneratorTest` ✅ (12 tests)

Closes #16983
