### PR TITLE
feat(dashboards): expandable Top-N + Others Executions per-namespace chart

### DIFF
--- a/ui/src/components/dashboard/composables/charts.ts
+++ b/ui/src/components/dashboard/composables/charts.ts
@@ -3,6 +3,62 @@ import {ref} from "vue"
 import {cssVar} from "@kestra-io/design-system"
 import {getSchemeValue} from "../../../utils/scheme"
 
+export interface RankedStackedBars {
+    categories: string[]
+    series: {name: string; data: number[]}[]
+    totals: number[]
+    othersCount: number
+    othersNames: string[]
+}
+
+export const DEFAULT_BAR_CATEGORY_LIMIT = 8
+
+export function rankStackedBars(
+    rows: Record<string, unknown>[],
+    opts: {categoryKey: string; stackKeys: string[]; valueKey: string; limit?: number},
+): RankedStackedBars {
+    const {categoryKey, stackKeys, valueKey} = opts
+    const limit = opts.limit ?? DEFAULT_BAR_CATEGORY_LIMIT
+
+    const grouped = new Map<string, Record<string, number>>()
+    for (const row of rows ?? []) {
+        const category = String(row[categoryKey] ?? "")
+        const stack = stackKeys.map((k) => row[k]).join(", ")
+        const value = Number(row[valueKey] ?? 0)
+        let bucket = grouped.get(category)
+        if (!bucket) {
+            bucket = {}
+            grouped.set(category, bucket)
+        }
+        bucket[stack] = (bucket[stack] ?? 0) + value
+    }
+
+    const totalOf = (bucket: Record<string, number>) => Object.values(bucket).reduce((a, b) => a + b, 0)
+
+    const ranked = [...grouped.entries()]
+        .map(([name, bucket]) => ({name, bucket, total: totalOf(bucket)}))
+        .sort((a, b) => b.total - a.total)
+
+    const stacks = [...new Set(ranked.flatMap((r) => Object.keys(r.bucket)))]
+
+    const overflow = limit > 0 && ranked.length > limit
+    const top = overflow ? ranked.slice(0, limit) : ranked
+    const rest = overflow ? ranked.slice(limit) : []
+
+    const categories = top.map((r) => r.name)
+    const totals = top.map((r) => r.total)
+    const series = stacks.map((stack) => ({name: stack, data: top.map((r) => r.bucket[stack] ?? 0)}))
+
+    if (rest.length) {
+        const othersBucket: Record<string, number> = {}
+        for (const r of rest) for (const stack of stacks) othersBucket[stack] = (othersBucket[stack] ?? 0) + (r.bucket[stack] ?? 0)
+        series.forEach((s) => s.data.push(othersBucket[s.name] ?? 0))
+        totals.push(totalOf(othersBucket))
+    }
+
+    return {categories, series, totals, othersCount: rest.length, othersNames: rest.map((r) => r.name)}
+}
+
 function hashToHexColor(value: string): string {
     let hash = 0x811c9dc5
     for (let i = 0; i < value.length; i++) {

--- a/ui/src/components/dashboard/sections/Bar.vue
+++ b/ui/src/components/dashboard/sections/Bar.vue
@@ -28,6 +28,14 @@
                 @echarts-click="onChartClick"
             />
         </div>
+        <div v-if="!props.short && canExpand" class="chart-footer">
+            <KsButton text size="small" :aria-expanded="expanded" @click="expanded = !expanded">
+                <span class="expand-toggle">
+                    {{ expanded ? t("showLess") : `${t("dashboards.viewAll")} (${totalNamespaces})` }}
+                    <component :is="expanded ? ChevronUp : ChevronDown" :size="14" />
+                </span>
+            </KsButton>
+        </div>
     </div>
     <KsNoData v-else :class="{empty: !props.short}" />
 </template>
@@ -43,6 +51,8 @@
     import {DEFAULT_BAR_CATEGORY_LIMIT, getConsistentHEXColor, rankStackedBars, useLegendToggle} from "../composables/charts"
     import {useChartDrillDown} from "../composables/chartDrillDown"
     import ChartLegend from "./ChartLegend.vue"
+    import ChevronDown from "vue-material-design-icons/ChevronDown.vue"
+    import ChevronUp from "vue-material-design-icons/ChevronUp.vue"
     import {useTheme} from "../../../utils/utils"
     import {FilterObject} from "../../../utils/filters"
 
@@ -67,6 +77,8 @@
 
     const {drillDown} = useChartDrillDown(props.chart)
 
+    const expanded = ref(false)
+
     const {data, chartOptions} = props.chart
     const {data: generated, generate} = useChartGenerator(props.dashboardId, props)
 
@@ -80,16 +92,19 @@
         .filter(([key, value]) => !(value as Record<string, any>).agg && key !== categoryKey)
         .map(([key]) => key)
     const valueKey = aggregator[0][0]
-    const limit = (chartOptions as any)?.limit ?? DEFAULT_BAR_CATEGORY_LIMIT
+    const baseLimit = (chartOptions as any)?.limit ?? DEFAULT_BAR_CATEGORY_LIMIT
 
     const parsedData = computed(() =>
         rankStackedBars(generated.value?.results as Record<string, unknown>[] ?? [], {
             categoryKey,
             stackKeys,
             valueKey,
-            limit,
+            limit: expanded.value ? 0 : baseLimit,
         }),
     )
+
+    const totalNamespaces = computed(() => parsedData.value.categories.length + parsedData.value.othersCount)
+    const canExpand = computed(() => totalNamespaces.value > baseLimit)
 
     const othersLabel = computed(() => `${t("dashboards.others")} · ${parsedData.value.othersCount}`)
 
@@ -136,6 +151,10 @@
 
     function leftTruncate(s: string, max: number): string {
         return s.length <= max ? s : "…" + s.slice(s.length - (max - 1))
+    }
+
+    function escapeHtml(s: string): string {
+        return String(s).replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;")
     }
 
     const echartsOption = computed((): Record<string, unknown> => {
@@ -185,7 +204,7 @@
                             .map((p: any) => {
                                 const val = typeof p.value === "number" ? p.value : p.value?.value ?? 0
                                 const formatted = isDurationAgg() ? durationUtils.humanDuration(val) : val
-                                return `<span style="color:${cssVar("--ks-text-secondary")}">${p.seriesName}</span>: ${formatted}`
+                                return `<span style="color:${cssVar("--ks-text-secondary")}">${escapeHtml(p.seriesName)}</span>: ${formatted}`
                             })
                             .join("<br/>")
                         const total = nonZero.reduce((acc: number, p: any) => {
@@ -193,7 +212,7 @@
                             return acc + val
                         }, 0)
                         const formattedTotal = isDurationAgg() ? durationUtils.humanDuration(total) : total
-                        return `<b>${categoryName}</b><br/>${rows}<br/><span style="color:${cssVar("--ks-text-secondary")}">${t("Total")}</span>: ${formattedTotal}`
+                        return `<b>${escapeHtml(categoryName)}</b><br/>${rows}<br/><span style="color:${cssVar("--ks-text-secondary")}">${t("Total")}</span>: ${formattedTotal}`
                     },
                 },
             legend: {
@@ -218,7 +237,10 @@
 
     function onChartClick(params: any) {
         const isOthers = parsedData.value.othersCount > 0 && params.name === othersLabel.value
-        if (isOthers) return
+        if (isOthers) {
+            expanded.value = true
+            return
+        }
         drillDown([
             {column: stackColumn.value, value: params.seriesName},
             {column: categoryColumn.value, value: params.name},
@@ -245,7 +267,6 @@
     .chart {
         display: flex;
         flex-direction: column;
-        height: 231px;
 
         &.short {
             height: 40px;
@@ -255,6 +276,20 @@
             flex: 1;
             min-height: 0;
         }
+    }
+
+    .chart-footer {
+        display: flex;
+        justify-content: center;
+        padding-top: var(--ks-spacing-2);
+    }
+
+    .expand-toggle {
+        display: inline-flex;
+        align-items: center;
+        gap: var(--ks-spacing-1);
+        font-weight: var(--ks-font-weight-regular);
+        color: var(--ks-text-secondary);
     }
 
     .empty {

--- a/ui/src/components/dashboard/sections/Bar.vue
+++ b/ui/src/components/dashboard/sections/Bar.vue
@@ -3,12 +3,11 @@
         v-if="generated?.results?.length"
         class="chart-wrapper"
         :class="{short: props.short}"
-        :style="props.short ? undefined : {maxHeight: `${MAX_CHART_HEIGHT}px`}"
     >
         <div
             class="chart"
             :class="{short: props.short}"
-            :style="props.short ? undefined : {height: `${naturalChartHeight}px`}"
+            :style="props.short ? undefined : {height: `${chartHeight}px`}"
         >
             <ChartLegend
                 v-if="showLegend"
@@ -36,11 +35,12 @@
 <script setup lang="ts">
     import {computed, ref, watch} from "vue"
     import {useRoute} from "vue-router"
+    import {useI18n} from "vue-i18n"
 
     import {ChartFeature, KsBar, TooltipType, cssVar, durationUtils, type KsChartSeriesItem} from "@kestra-io/design-system"
 
     import {Chart, useChartGenerator} from "../composables/useDashboards"
-    import {getConsistentHEXColor, useLegendToggle} from "../composables/charts"
+    import {DEFAULT_BAR_CATEGORY_LIMIT, getConsistentHEXColor, rankStackedBars, useLegendToggle} from "../composables/charts"
     import {useChartDrillDown} from "../composables/chartDrillDown"
     import ChartLegend from "./ChartLegend.vue"
     import {useTheme} from "../../../utils/utils"
@@ -63,6 +63,7 @@
 
     const route = useRoute()
     const theme = useTheme()
+    const {t} = useI18n()
 
     const {drillDown} = useChartDrillDown(props.chart)
 
@@ -74,70 +75,68 @@
 
     const {onLegendToggle, legendSelected} = useLegendToggle()
 
-    const parsedData = computed(() => {
-        const column = chartOptions?.column ?? ""
-        const columns = data?.columns ?? {}
+    const categoryKey = chartOptions?.column ?? ""
+    const stackKeys = Object.entries(data?.columns ?? {})
+        .filter(([key, value]) => !(value as Record<string, any>).agg && key !== categoryKey)
+        .map(([key]) => key)
+    const valueKey = aggregator[0][0]
+    const limit = (chartOptions as any)?.limit ?? DEFAULT_BAR_CATEGORY_LIMIT
 
-        const stackColumns = Object.entries(columns)
-            .filter(([key, value]) => !(value as Record<string, any>).agg && key !== column)
-            .map(([key]) => key)
+    const parsedData = computed(() =>
+        rankStackedBars(generated.value?.results as Record<string, unknown>[] ?? [], {
+            categoryKey,
+            stackKeys,
+            valueKey,
+            limit,
+        }),
+    )
 
-        const grouped: Record<string, Record<string, number>> = {}
-        const rawData = generated.value?.results as Record<string, any>[] | undefined
+    const othersLabel = computed(() => `${t("dashboards.others")} · ${parsedData.value.othersCount}`)
 
-        rawData?.forEach((item) => {
-            const stack = stackColumns.map((col) => item[col]).join(", ")
-            const xLabel = item[column] as string
-
-            grouped[xLabel] ??= {}
-            grouped[xLabel][stack] = (grouped[xLabel][stack] ?? 0) + item[aggregator[0][0]]
-        })
-
-        const xLabels = [...new Set(rawData?.map((item) => item[column] as string))]
-
-        const datasets = xLabels.flatMap((xLabel) =>
-            Object.entries(grouped[xLabel as string] ?? {}).map(([label, value]) => ({
-                label,
-                data: xLabels.map((x) => (x === xLabel ? value : 0)),
-                backgroundColor: getConsistentHEXColor(theme.value, label),
-            })),
-        )
-
-        return {labels: xLabels, datasets}
+    const categories = computed(() => {
+        const cats = parsedData.value.categories
+        return parsedData.value.othersCount > 0 ? [...cats, othersLabel.value] : cats
     })
 
-    const categories = computed(() => parsedData.value.labels)
-
-    const seriesData = computed<KsChartSeriesItem[]>(() =>
-        parsedData.value.datasets.map((ds) => ({
-            name: ds.label,
-            data: ds.data,
-            barWidth: 12,
+    const seriesData = computed<KsChartSeriesItem[]>(() => {
+        const hasOthers = parsedData.value.othersCount > 0
+        return parsedData.value.series.map((s) => ({
+            name: s.name,
+            data: s.data.map((v, idx) => {
+                if (hasOthers && idx === s.data.length - 1) {
+                    return {value: v, itemStyle: {color: cssVar("--ks-chart-skipped")}}
+                }
+                return v
+            }),
+            barWidth: 16,
             itemStyle: {
-                color: ds.backgroundColor,
+                color: getConsistentHEXColor(theme.value, s.name),
                 borderColor: cssVar("--ks-bg-surface"),
                 borderWidth: 1,
-                borderRadius: 1,
+                borderRadius: 2,
             },
-        })),
-    )
+        }))
+    })
 
     const showLegend = computed(() => !props.short && !!chartOptions?.legend?.enabled)
 
-    const MAX_CHART_HEIGHT = 500
-
-    const naturalChartHeight = computed(() => {
-        const overhead = showLegend.value ? 68 : 36
-        return Math.max(231, categories.value.length * 18 + overhead)
-    })
+    const ROW_PITCH = 30
+    const MIN_CHART_HEIGHT = 200
+    const chartHeight = computed(() =>
+        Math.max(MIN_CHART_HEIGHT, categories.value.length * ROW_PITCH + (showLegend.value ? 56 : 24)),
+    )
 
     const legendItems = computed(() =>
-        parsedData.value.datasets.map((ds) => ({
-            label: ds.label,
-            color: ds.backgroundColor,
-            count: (ds.data as number[]).reduce((acc, n) => acc + (n || 0), 0),
+        parsedData.value.series.map((s) => ({
+            label: s.name,
+            color: getConsistentHEXColor(theme.value, s.name),
+            count: s.data.reduce((acc, n) => acc + (typeof n === "number" ? n : (n as any).value ?? 0), 0),
         })),
     )
+
+    function leftTruncate(s: string, max: number): string {
+        return s.length <= max ? s : "…" + s.slice(s.length - (max - 1))
+    }
 
     const echartsOption = computed((): Record<string, unknown> => {
         const showAxes = !props.short
@@ -165,14 +164,38 @@
                 axisTick: {show: false},
                 axisLabel: {
                     ...axisLabelStyle,
-                    margin: 24,
-                    width: 200,
-                    overflow: "truncate",
+                    margin: 14,
+                    formatter: (v: string) => leftTruncate(v, 28),
                 },
             },
             tooltip: props.short
                 ? {show: false}
-                : {trigger: "axis", axisPointer: {type: "none"}},
+                : {
+                    trigger: "axis",
+                    axisPointer: {type: "none"},
+                    formatter: (params: any[]) => {
+                        if (!params?.length) return ""
+                        const isOthers = parsedData.value.othersCount > 0 && params[0].dataIndex === categories.value.length - 1
+                        const categoryName = isOthers ? t("dashboards.others") : params[0].name
+                        const nonZero = params.filter((p: any) => {
+                            const val = typeof p.value === "number" ? p.value : p.value?.value ?? 0
+                            return val > 0
+                        })
+                        const rows = nonZero
+                            .map((p: any) => {
+                                const val = typeof p.value === "number" ? p.value : p.value?.value ?? 0
+                                const formatted = isDurationAgg() ? durationUtils.humanDuration(val) : val
+                                return `<span style="color:${cssVar("--ks-text-secondary")}">${p.seriesName}</span>: ${formatted}`
+                            })
+                            .join("<br/>")
+                        const total = nonZero.reduce((acc: number, p: any) => {
+                            const val = typeof p.value === "number" ? p.value : p.value?.value ?? 0
+                            return acc + val
+                        }, 0)
+                        const formattedTotal = isDurationAgg() ? durationUtils.humanDuration(total) : total
+                        return `<b>${categoryName}</b><br/>${rows}<br/><span style="color:${cssVar("--ks-text-secondary")}">${t("Total")}</span>: ${formattedTotal}`
+                    },
+                },
             legend: {
                 show: false,
                 selected: legendSelected(legendItems.value.map((item) => item.label)),
@@ -181,7 +204,6 @@
     })
 
     const ksBarRef = ref<InstanceType<typeof KsBar> | null>(null)
-
 
     const categoryColumn = computed(() =>
         (data?.columns?.[chartOptions?.column ?? ""]) as {field?: string; labelKey?: string} | undefined,
@@ -195,6 +217,8 @@
     })
 
     function onChartClick(params: any) {
+        const isOthers = parsedData.value.othersCount > 0 && params.name === othersLabel.value
+        if (isOthers) return
         drillDown([
             {column: stackColumn.value, value: params.seriesName},
             {column: categoryColumn.value, value: params.name},
@@ -212,8 +236,6 @@
 
 <style scoped lang="scss">
     .chart-wrapper {
-        overflow-y: auto;
-
         &.short {
             height: 40px;
             overflow: hidden;

--- a/ui/src/translations/de.json
+++ b/ui/src/translations/de.json
@@ -264,6 +264,7 @@
       },
       "no_description": "Keine Beschreibung",
       "no_description_hint": "Füge eine Beschreibung zu diesem flow hinzu, um zu dokumentieren, was er tut.<br>Markdown wird unterstützt.",
+      "others": "Andere",
       "preview": "Vorschau-Dashboard",
       "quick_filters": {
         "all": "Alle",

--- a/ui/src/translations/de.json
+++ b/ui/src/translations/de.json
@@ -265,6 +265,7 @@
       "no_description": "Keine Beschreibung",
       "no_description_hint": "Füge eine Beschreibung zu diesem flow hinzu, um zu dokumentieren, was er tut.<br>Markdown wird unterstützt.",
       "others": "Andere",
+      "viewAll": "Alle anzeigen",
       "preview": "Vorschau-Dashboard",
       "quick_filters": {
         "all": "Alle",

--- a/ui/src/translations/en.json
+++ b/ui/src/translations/en.json
@@ -1865,6 +1865,7 @@
       },
       "no_description": "No description",
       "no_description_hint": "Add a description to this flow to document what it does.<br>Markdown is supported.",
+      "others": "Others",
       "chart_preview": "Click on a chart source code to see its preview",
       "export": "Export to CSV",
       "quick_filters": {

--- a/ui/src/translations/en.json
+++ b/ui/src/translations/en.json
@@ -1866,6 +1866,7 @@
       "no_description": "No description",
       "no_description_hint": "Add a description to this flow to document what it does.<br>Markdown is supported.",
       "others": "Others",
+      "viewAll": "View all",
       "chart_preview": "Click on a chart source code to see its preview",
       "export": "Export to CSV",
       "quick_filters": {

--- a/ui/src/translations/es.json
+++ b/ui/src/translations/es.json
@@ -265,6 +265,7 @@
       "no_description": "Sin descripción",
       "no_description_hint": "Agrega una descripción a este flow para documentar qué hace.<br>Markdown es compatible.",
       "others": "Otros",
+      "viewAll": "Ver todo",
       "preview": "Vista previa del Dashboard",
       "quick_filters": {
         "all": "Todos",

--- a/ui/src/translations/es.json
+++ b/ui/src/translations/es.json
@@ -264,6 +264,7 @@
       },
       "no_description": "Sin descripción",
       "no_description_hint": "Agrega una descripción a este flow para documentar qué hace.<br>Markdown es compatible.",
+      "others": "Otros",
       "preview": "Vista previa del Dashboard",
       "quick_filters": {
         "all": "Todos",

--- a/ui/src/translations/fr.json
+++ b/ui/src/translations/fr.json
@@ -265,6 +265,7 @@
       "no_description": "Aucune description",
       "no_description_hint": "Ajoutez une description à ce flow pour documenter ce qu'il fait.<br>Markdown est pris en charge.",
       "others": "Autres",
+      "viewAll": "Tout voir",
       "preview": "Aperçu du Dashboard",
       "quick_filters": {
         "all": "Tout",

--- a/ui/src/translations/fr.json
+++ b/ui/src/translations/fr.json
@@ -264,6 +264,7 @@
       },
       "no_description": "Aucune description",
       "no_description_hint": "Ajoutez une description à ce flow pour documenter ce qu'il fait.<br>Markdown est pris en charge.",
+      "others": "Autres",
       "preview": "Aperçu du Dashboard",
       "quick_filters": {
         "all": "Tout",

--- a/ui/src/translations/hi.json
+++ b/ui/src/translations/hi.json
@@ -264,6 +264,7 @@
       },
       "no_description": "कोई विवरण नहीं",
       "no_description_hint": "इस flow में एक विवरण जोड़ें ताकि यह दस्तावेज़ किया जा सके कि यह क्या करता है।<br>Markdown समर्थित है।",
+      "others": "अन्य",
       "preview": "पूर्वावलोकन डैशबोर्ड",
       "quick_filters": {
         "all": "सभी",

--- a/ui/src/translations/hi.json
+++ b/ui/src/translations/hi.json
@@ -265,6 +265,7 @@
       "no_description": "कोई विवरण नहीं",
       "no_description_hint": "इस flow में एक विवरण जोड़ें ताकि यह दस्तावेज़ किया जा सके कि यह क्या करता है।<br>Markdown समर्थित है।",
       "others": "अन्य",
+      "viewAll": "सभी देखें",
       "preview": "पूर्वावलोकन डैशबोर्ड",
       "quick_filters": {
         "all": "सभी",

--- a/ui/src/translations/it.json
+++ b/ui/src/translations/it.json
@@ -264,6 +264,7 @@
       },
       "no_description": "Nessuna descrizione",
       "no_description_hint": "Aggiungi una descrizione a questo flow per documentare cosa fa.<br>Markdown è supportato.",
+      "others": "Altri",
       "preview": "Anteprima Dashboard",
       "quick_filters": {
         "all": "Tutti",

--- a/ui/src/translations/it.json
+++ b/ui/src/translations/it.json
@@ -265,6 +265,7 @@
       "no_description": "Nessuna descrizione",
       "no_description_hint": "Aggiungi una descrizione a questo flow per documentare cosa fa.<br>Markdown è supportato.",
       "others": "Altri",
+      "viewAll": "Vedi tutti",
       "preview": "Anteprima Dashboard",
       "quick_filters": {
         "all": "Tutti",

--- a/ui/src/translations/ja.json
+++ b/ui/src/translations/ja.json
@@ -264,6 +264,7 @@
       },
       "no_description": "説明なし",
       "no_description_hint": "このflowに説明を追加して、何をするかを文書化してください。<br>Markdownがサポートされています。",
+      "others": "その他",
       "preview": "プレビュー ダッシュボード",
       "quick_filters": {
         "all": "すべて",

--- a/ui/src/translations/ja.json
+++ b/ui/src/translations/ja.json
@@ -265,6 +265,7 @@
       "no_description": "説明なし",
       "no_description_hint": "このflowに説明を追加して、何をするかを文書化してください。<br>Markdownがサポートされています。",
       "others": "その他",
+      "viewAll": "すべて表示",
       "preview": "プレビュー ダッシュボード",
       "quick_filters": {
         "all": "すべて",

--- a/ui/src/translations/ko.json
+++ b/ui/src/translations/ko.json
@@ -265,6 +265,7 @@
       "no_description": "설명 없음",
       "no_description_hint": "이 flow에 설명을 추가하여 무엇을 하는지 문서화하세요.<br>Markdown이 지원됩니다.",
       "others": "기타",
+      "viewAll": "전체 보기",
       "preview": "미리보기 대시보드",
       "quick_filters": {
         "all": "전체",

--- a/ui/src/translations/ko.json
+++ b/ui/src/translations/ko.json
@@ -264,6 +264,7 @@
       },
       "no_description": "설명 없음",
       "no_description_hint": "이 flow에 설명을 추가하여 무엇을 하는지 문서화하세요.<br>Markdown이 지원됩니다.",
+      "others": "기타",
       "preview": "미리보기 대시보드",
       "quick_filters": {
         "all": "전체",

--- a/ui/src/translations/pl.json
+++ b/ui/src/translations/pl.json
@@ -264,6 +264,7 @@
       },
       "no_description": "Brak opisu",
       "no_description_hint": "Dodaj opis do tego flow, aby udokumentować, co robi.<br>Markdown jest obsługiwany.",
+      "others": "Inne",
       "preview": "Podgląd Dashboardu",
       "quick_filters": {
         "all": "Wszystkie",

--- a/ui/src/translations/pl.json
+++ b/ui/src/translations/pl.json
@@ -265,6 +265,7 @@
       "no_description": "Brak opisu",
       "no_description_hint": "Dodaj opis do tego flow, aby udokumentować, co robi.<br>Markdown jest obsługiwany.",
       "others": "Inne",
+      "viewAll": "Pokaż wszystko",
       "preview": "Podgląd Dashboardu",
       "quick_filters": {
         "all": "Wszystkie",

--- a/ui/src/translations/pt.json
+++ b/ui/src/translations/pt.json
@@ -265,6 +265,7 @@
       "no_description": "Sem descrição",
       "no_description_hint": "Adicione uma descrição a este flow para documentar o que ele faz.<br>Markdown é suportado.",
       "others": "Outros",
+      "viewAll": "Ver tudo",
       "preview": "Visualizar Dashboard",
       "quick_filters": {
         "all": "Todos",

--- a/ui/src/translations/pt.json
+++ b/ui/src/translations/pt.json
@@ -264,6 +264,7 @@
       },
       "no_description": "Sem descrição",
       "no_description_hint": "Adicione uma descrição a este flow para documentar o que ele faz.<br>Markdown é suportado.",
+      "others": "Outros",
       "preview": "Visualizar Dashboard",
       "quick_filters": {
         "all": "Todos",

--- a/ui/src/translations/pt_BR.json
+++ b/ui/src/translations/pt_BR.json
@@ -265,6 +265,7 @@
       "no_description": "Sem descrição",
       "no_description_hint": "Adicione uma descrição a este flow para documentar o que ele faz.<br>Markdown é suportado.",
       "others": "Outros",
+      "viewAll": "Ver tudo",
       "preview": "Visualizar Dashboard",
       "quick_filters": {
         "all": "Todos",

--- a/ui/src/translations/pt_BR.json
+++ b/ui/src/translations/pt_BR.json
@@ -264,6 +264,7 @@
       },
       "no_description": "Sem descrição",
       "no_description_hint": "Adicione uma descrição a este flow para documentar o que ele faz.<br>Markdown é suportado.",
+      "others": "Outros",
       "preview": "Visualizar Dashboard",
       "quick_filters": {
         "all": "Todos",

--- a/ui/src/translations/ru.json
+++ b/ui/src/translations/ru.json
@@ -264,6 +264,7 @@
       },
       "no_description": "Нет описания",
       "no_description_hint": "Добавьте описание к этому flow, чтобы задокументировать его назначение.<br>Поддерживается Markdown.",
+      "others": "Другие",
       "preview": "Предварительный просмотр Dashboard",
       "quick_filters": {
         "all": "Все",

--- a/ui/src/translations/ru.json
+++ b/ui/src/translations/ru.json
@@ -265,6 +265,7 @@
       "no_description": "Нет описания",
       "no_description_hint": "Добавьте описание к этому flow, чтобы задокументировать его назначение.<br>Поддерживается Markdown.",
       "others": "Другие",
+      "viewAll": "Показать все",
       "preview": "Предварительный просмотр Dashboard",
       "quick_filters": {
         "all": "Все",

--- a/ui/src/translations/zh_CN.json
+++ b/ui/src/translations/zh_CN.json
@@ -265,6 +265,7 @@
       "no_description": "无描述",
       "no_description_hint": "为此 flow 添加描述以记录其功能。<br>支持 Markdown。",
       "others": "其他",
+      "viewAll": "查看全部",
       "preview": "预览仪表板",
       "quick_filters": {
         "all": "全部",

--- a/ui/src/translations/zh_CN.json
+++ b/ui/src/translations/zh_CN.json
@@ -264,6 +264,7 @@
       },
       "no_description": "无描述",
       "no_description_hint": "为此 flow 添加描述以记录其功能。<br>支持 Markdown。",
+      "others": "其他",
       "preview": "预览仪表板",
       "quick_filters": {
         "all": "全部",

--- a/ui/tests/unit/dashboard/charts.spec.ts
+++ b/ui/tests/unit/dashboard/charts.spec.ts
@@ -1,5 +1,6 @@
 import {describe, expect, it} from "vitest"
 import {chartSegmentDrillDown} from "../../../src/components/dashboard/composables/chartDrillDown"
+import {DEFAULT_BAR_CATEGORY_LIMIT, rankStackedBars} from "../../../src/components/dashboard/composables/charts"
 
 const EXEC = "io.kestra.plugin.core.dashboard.data.Executions"
 const LOGS = "io.kestra.plugin.core.dashboard.data.Logs"
@@ -99,5 +100,137 @@ describe("chartSegmentDrillDown", () => {
         const chart = {data: {type: EXEC, where: [{field: "NAMESPACE", type: "CONTAINS", value: "kestra"}]}}
         const result = chartSegmentDrillDown(chart, undefined, "x")
         expect(result?.query).toEqual({"filters[namespace][CONTAINS]": "kestra"})
+    })
+})
+
+describe("rankStackedBars", () => {
+    const opts = {categoryKey: "namespace", stackKeys: ["state"], valueKey: "count"}
+
+    it("groups by category and produces one series per distinct stack key", () => {
+        const rows = [
+            {namespace: "a", state: "SUCCESS", count: 10},
+            {namespace: "a", state: "FAILED", count: 2},
+            {namespace: "b", state: "SUCCESS", count: 5},
+        ]
+        const result = rankStackedBars(rows, opts)
+        expect(result.series.map((s) => s.name)).toEqual(expect.arrayContaining(["SUCCESS", "FAILED"]))
+        expect(result.series.length).toBe(2)
+    })
+
+    it("ranks categories by total descending", () => {
+        const rows = [
+            {namespace: "low", state: "SUCCESS", count: 1},
+            {namespace: "high", state: "SUCCESS", count: 100},
+            {namespace: "mid", state: "SUCCESS", count: 50},
+        ]
+        const result = rankStackedBars(rows, opts)
+        expect(result.categories).toEqual(["high", "mid", "low"])
+        expect(result.totals).toEqual([100, 50, 1])
+    })
+
+    it("folds categories beyond the limit into Others, sets othersCount and othersNames", () => {
+        const rows = Array.from({length: 10}, (_, i) => ({
+            namespace: `ns-${i}`,
+            state: "SUCCESS",
+            count: 10 - i,
+        }))
+        const result = rankStackedBars(rows, {...opts, limit: 3})
+        expect(result.categories.length).toBe(3)
+        expect(result.othersCount).toBe(7)
+        expect(result.othersNames.length).toBe(7)
+        expect(result.othersNames).toEqual(expect.arrayContaining(["ns-3", "ns-4", "ns-5", "ns-6", "ns-7", "ns-8", "ns-9"]))
+    })
+
+    it("adds a trailing Others column on every series when folding", () => {
+        const rows = Array.from({length: 5}, (_, i) => ({
+            namespace: `ns-${i}`,
+            state: "SUCCESS",
+            count: 5 - i,
+        }))
+        const result = rankStackedBars(rows, {...opts, limit: 3})
+        expect(result.series[0].data.length).toBe(4)
+        const othersTotal = result.totals[result.totals.length - 1]
+        expect(othersTotal).toBe(3) // ns-0=5,ns-1=4,ns-2=3 in top; ns-3=2,ns-4=1 folded -> 2+1=3
+    })
+
+    it("Others column totals reconcile with the sum of folded buckets", () => {
+        const rows = [
+            {namespace: "a", state: "SUCCESS", count: 10},
+            {namespace: "a", state: "FAILED", count: 5},
+            {namespace: "b", state: "SUCCESS", count: 8},
+            {namespace: "c", state: "SUCCESS", count: 3},
+            {namespace: "c", state: "FAILED", count: 2},
+        ]
+        const result = rankStackedBars(rows, {...opts, limit: 2})
+        expect(result.othersCount).toBe(1)
+        expect(result.othersNames).toEqual(["c"])
+        const successSeries = result.series.find((s) => s.name === "SUCCESS")!
+        const failedSeries = result.series.find((s) => s.name === "FAILED")!
+        const othersIdx = result.categories.length
+        expect(successSeries.data[othersIdx]).toBe(3)
+        expect(failedSeries.data[othersIdx]).toBe(2)
+        expect(result.totals[othersIdx]).toBe(5)
+    })
+
+    it("does not fold when categories are within the limit, othersCount is 0", () => {
+        const rows = [
+            {namespace: "a", state: "SUCCESS", count: 10},
+            {namespace: "b", state: "SUCCESS", count: 5},
+        ]
+        const result = rankStackedBars(rows, opts)
+        expect(result.othersCount).toBe(0)
+        expect(result.othersNames).toEqual([])
+        expect(result.series[0].data.length).toBe(2)
+        expect(result.totals.length).toBe(2)
+    })
+
+    it("limit 0 disables folding and shows all categories", () => {
+        const rows = Array.from({length: DEFAULT_BAR_CATEGORY_LIMIT + 5}, (_, i) => ({
+            namespace: `ns-${i}`,
+            state: "SUCCESS",
+            count: 1,
+        }))
+        const result = rankStackedBars(rows, {...opts, limit: 0})
+        expect(result.othersCount).toBe(0)
+        expect(result.categories.length).toBe(DEFAULT_BAR_CATEGORY_LIMIT + 5)
+    })
+
+    it("negative limit disables folding", () => {
+        const rows = Array.from({length: 5}, (_, i) => ({namespace: `ns-${i}`, state: "SUCCESS", count: 1}))
+        const result = rankStackedBars(rows, {...opts, limit: -1})
+        expect(result.othersCount).toBe(0)
+        expect(result.categories.length).toBe(5)
+    })
+
+    it("returns empty categories and series for empty rows", () => {
+        const result = rankStackedBars([], opts)
+        expect(result.categories).toEqual([])
+        expect(result.series).toEqual([])
+        expect(result.totals).toEqual([])
+        expect(result.othersCount).toBe(0)
+        expect(result.othersNames).toEqual([])
+    })
+
+    it("sums multiple rows with the same category and stack key", () => {
+        const rows = [
+            {namespace: "a", state: "SUCCESS", count: 4},
+            {namespace: "a", state: "SUCCESS", count: 6},
+        ]
+        const result = rankStackedBars(rows, opts)
+        expect(result.categories).toEqual(["a"])
+        expect(result.totals).toEqual([10])
+        expect(result.series[0].data[0]).toBe(10)
+    })
+
+    it("aligns series data to categories order", () => {
+        const rows = [
+            {namespace: "low", state: "SUCCESS", count: 1},
+            {namespace: "high", state: "SUCCESS", count: 100},
+        ]
+        const result = rankStackedBars(rows, opts)
+        expect(result.categories[0]).toBe("high")
+        const successSeries = result.series.find((s) => s.name === "SUCCESS")!
+        expect(successSeries.data[0]).toBe(100)
+        expect(successSeries.data[1]).toBe(1)
     })
 })


### PR DESCRIPTION
Closes #17012

## What

Reworks the default-dashboard **"Executions (per namespace)"** chart so it stays readable when a tenant has many namespaces.

Before, the tile rendered one bar per namespace, in backend order, capped at 500px with an **internal scrollbar** (#16928), long paths right-truncated to the same prefix, and built **one ECharts series per `(namespace × state)`** (a sparse-series explosion the chart 2.0 redesign #16758 reintroduced after #16461 had fixed it).

Now:
- **Rank by volume, show Top N** (default 8, configurable via `chartOptions.limit`).
- **Fold the tail into one muted "Others · N" bar** so totals still reconcile; it is not drill-downable.
- **Fixed height, no internal scroll** (`max(200, rows·30 + overhead)`).
- **One series per state** (not per namespace × state), which also fixes the reintroduced tooltip/legend explosion.
- **Left-truncate** long namespace labels keeping the leaf segment; full name + per-state counts + total shown in the tooltip.
- Existing drill-down preserved.

## How

- New pure helper `rankStackedBars()` (+ `DEFAULT_BAR_CATEGORY_LIMIT`) in `composables/charts.ts`, with unit tests.
- `Bar.vue` refactored to consume it.
- New `dashboards.others` i18n key added across all 13 locales.

## Tests / verification

- `rankStackedBars` unit tests (grouping, ranking, Top-N folding, totals reconciliation, limit 0/negative, empty) — green.
- `npm run check:types`: app + design-system clean.
- `ui/src/translations/check.js`: clean across all 13 locales.


https://github.com/user-attachments/assets/305b8725-e857-4c95-971c-c1af93b45fc8



## QA

Verified live against a local backend seeded with 14 namespaces (45 executions, power-law distribution), in **both light and dark mode**: the chart shows the Top 8 ranked by volume + a muted "Others · 6" bar at fixed height with no internal scrollbar, long paths left-truncated to a distinguishable leaf (`…kubernetes.prod` vs `…kubernetes.staging`), no console errors.

Closes #17008