### PR TITLE
feat(core): let task runners emit detail on the failure path

### DIFF
--- a/core/src/main/java/io/kestra/core/models/tasks/runners/TaskException.java
+++ b/core/src/main/java/io/kestra/core/models/tasks/runners/TaskException.java
@@ -15,15 +15,31 @@ public class TaskException extends Exception {
 
     private transient AbstractLogConsumer logConsumer;
 
+    /**
+     * Optional post-execution detail produced by the task runner before it failed.
+     * Carried here so the script task can still expose it as the {@code taskRunner}
+     * output on the failure path (e.g. to render a FAILED state in the topology view).
+     */
+    private final transient TaskRunnerDetailResult details;
+
     public TaskException(int exitCode, AbstractLogConsumer logConsumer) {
-        this("Command failed with exit code " + exitCode, exitCode, logConsumer);
+        this("Command failed with exit code " + exitCode, exitCode, logConsumer, null);
     }
 
     public TaskException(String message, int exitCode, AbstractLogConsumer logConsumer) {
+        this(message, exitCode, logConsumer, null);
+    }
+
+    public TaskException(int exitCode, AbstractLogConsumer logConsumer, TaskRunnerDetailResult details) {
+        this("Command failed with exit code " + exitCode, exitCode, logConsumer, details);
+    }
+
+    public TaskException(String message, int exitCode, AbstractLogConsumer logConsumer, TaskRunnerDetailResult details) {
         super(message);
         this.exitCode = exitCode;
         this.stdOutCount = logConsumer.getStdOutCount();
         this.stdErrCount = logConsumer.getStdErrCount();
         this.logConsumer = logConsumer;
+        this.details = details;
     }
 }

--- a/script/src/main/java/io/kestra/plugin/scripts/exec/scripts/runners/CommandsWrapper.java
+++ b/script/src/main/java/io/kestra/plugin/scripts/exec/scripts/runners/CommandsWrapper.java
@@ -220,6 +220,7 @@ public class CommandsWrapper implements TaskCommands {
                 .stdOutLineCount(e.getStdOutCount())
                 .stdErrLineCount(e.getStdErrCount())
                 .vars(e.getLogConsumer() != null ? e.getLogConsumer().getOutputs() : null)
+                .taskRunner(e.getDetails())
                 .outputFiles(getOutputFiles(taskRunnerRunContext))
                 .build();
             throw new RunnableTaskException(e, output);


### PR DESCRIPTION
## What

Allow task runners to surface post-execution detail when the task **fails**, not only when it succeeds.

- `TaskException` now carries an optional `TaskRunnerDetailResult details`.
- `CommandsWrapper` sets `.taskRunner(e.getDetails())` in the `catch (TaskException)` branch, so the failed task's `taskRunner` output is populated (it was only populated on the success-return path before).

## Why

Today a failing task runner can only signal failure by throwing `TaskException`, and the catch branch builds the script output **without** the runner detail — so any post-execution detail (e.g. a job's final state) is lost on failure. This makes a "FAILED" state unreachable for topology-details UI components that read the `taskRunner` output.

## Companion PR

Required by **kestra-io/plugin-ee-gcp#133** (GCP CloudRun/Batch topology-details): the GCP runners now build a `GcpRunnerDetailResult` with the real `FAILED` state on the failure path and throw it via the new `TaskException` constructor, so the topology view can render a FAILED badge.

## Compatibility

Additive only — existing `TaskException` constructors are preserved (new overloads default `details` to `null`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<img width="2334" height="189" alt="image" src="https://github.com/user-attachments/assets/2fc59226-7cf1-4947-a443-4ed6b2e05897" />
