### PR TITLE
fix(flows): remove topology visualization from blueprints embed view

### DIFF
--- a/ui/src/components/flows/blueprints/BlueprintEmbedView.vue
+++ b/ui/src/components/flows/blueprints/BlueprintEmbedView.vue
@@ -15,19 +15,6 @@
     </header>
 
     <section class="content" v-ks-loading="!blueprint">
-        <KsCard v-if="blueprint && kind === 'flow' && flowGraph">
-            <div class="topology">
-                <LowCodeEditor
-                    viewType="source-blueprints"
-                    isReadOnly
-                    :flowId="parsedFlow.id"
-                    :namespace="parsedFlow.namespace"
-                    :flowGraph="flowGraph"
-                    :source="blueprint.source"
-                />
-            </div>
-        </KsCard>
-
         <template v-if="blueprint">
             <KsCard>
                 <KsEditor
@@ -54,13 +41,9 @@
 </template>
 
 <script setup lang="ts">
-    import {computed} from "vue"
-
     import {KsEditor} from "@kestra-io/design-system"
-    import {flowYamlUtils as YAML_UTILS} from "@kestra-io/topology"
     import ChevronLeft from "vue-material-design-icons/ChevronLeft.vue"
 
-    import LowCodeEditor from "../../inputs/LowCodeEditor.vue"
     import CopyToClipboard from "../../layout/CopyToClipboard.vue"
     import BlueprintOverview from "./BlueprintOverview.vue"
     import {useEditorBindings} from "../../../composables/useEditorBindings"
@@ -68,13 +51,11 @@
 
     const props = withDefaults(defineProps<{
         blueprint?: FlowBlueprint & {shortDescription?: string};
-        flowGraph?: any;
         tags?: Record<string, BlueprintTag>;
         icons?: Record<string, any>;
         kind?: string;
     }>(), {
         blueprint: undefined,
-        flowGraph: undefined,
         tags: undefined,
         icons: () => ({}),
         kind: "flow",
@@ -83,12 +64,6 @@
     const emit = defineEmits<{back: []}>()
 
     const editorBindings = useEditorBindings()
-
-    const parsedFlow = computed(() =>
-        props.blueprint?.source
-            ? {...YAML_UTILS.parse(props.blueprint.source), source: props.blueprint.source}
-            : {},
-    )
 </script>
 
 <style scoped lang="scss">
@@ -135,11 +110,6 @@
 
         :deep(.kel-card__body) {
             padding: 0;
-        }
-
-        .topology {
-            width: 100%;
-            height: 30vh;
         }
 
         .markdown {

--- a/ui/src/override/components/flows/blueprints/BlueprintDetail.vue
+++ b/ui/src/override/components/flows/blueprints/BlueprintDetail.vue
@@ -23,7 +23,6 @@
     <BlueprintEmbedView
         v-else
         :blueprint
-        :flowGraph
         :tags
         :icons="pluginsStore.icons"
         :kind


### PR DESCRIPTION
Related to https://github.com/kestra-io/kestra-ee/pull/8910.

Closes https://github.com/kestra-io/kestra-ee/issues/8884.

## Summary

- Drops the topology visualization card from `BlueprintEmbedView` (the Blueprints tab inside the flow editor)
- The full blueprints page (`BlueprintDetailView`) keeps its topology splitter unchanged
- Removes the now-unused `flowGraph` prop, `LowCodeEditor` import, `YAML_UTILS` import, and `parsedFlow` computed from `BlueprintEmbedView`

## Test plan

- [ ] Open a flow → Edit → Blueprints tab → select a blueprint: no topology shown, only YAML code + description
- [ ] Open /blueprints → select a blueprint: topology splitter still present on the full page