### PR TITLE
fix(core): fix exponential retry delay — first retry was 0s, growth w…

### DIFF
--- a/core/src/main/java/io/kestra/core/models/tasks/retrys/Exponential.java
+++ b/core/src/main/java/io/kestra/core/models/tasks/retrys/Exponential.java
@@ -50,16 +50,12 @@ public class Exponential extends AbstractRetry {
 
     @Override
     public Instant nextRetryDate(Integer attemptCount, Instant lastAttempt) {
-        Duration computedInterval = interval.multipliedBy(
-            (long) (this.delayFactor == null ? 2 : this.delayFactor.intValue()) * (attemptCount - 1)
-        );
-        Instant next = lastAttempt.plus(computedInterval);
-        if (next.isAfter(lastAttempt.plus(maxInterval))) {
-
-            return lastAttempt.plus(maxInterval);
-        }
-
-        return next;
+        double factor = this.delayFactor == null ? 2d : this.delayFactor;
+        double delayMillis = interval.toMillis() * Math.pow(factor, attemptCount - 1);
+        long maxMillis = maxInterval.toMillis();
+        // delayMillis may be Double.POSITIVE_INFINITY for very large attemptCount — the >= guard handles that correctly
+        long cappedMillis = delayMillis >= maxMillis ? maxMillis : Math.round(delayMillis);
+        return lastAttempt.plusMillis(cappedMillis);
     }
 
     @AssertTrue(message = "'interval' must be less than 'maxDuration'")

--- a/core/src/test/java/io/kestra/core/models/tasks/retrys/ConstantTest.java
+++ b/core/src/test/java/io/kestra/core/models/tasks/retrys/ConstantTest.java
@@ -1,0 +1,55 @@
+package io.kestra.core.models.tasks.retrys;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.time.Instant;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ConstantTest {
+
+    private static final Instant BASE = Instant.parse("2024-01-01T00:00:00Z");
+
+    @Test
+    void shouldReturnIntervalDelayForFirstRetry() {
+        // Given
+        var retry = Constant.builder()
+            .interval(Duration.ofSeconds(5))
+            .build();
+
+        // When
+        Instant next = retry.nextRetryDate(1, BASE);
+
+        // Then
+        assertThat(Duration.between(BASE, next)).isEqualTo(Duration.ofSeconds(5));
+    }
+
+    @Test
+    void shouldReturnSameDelayRegardlessOfAttemptCount() {
+        // Given
+        var retry = Constant.builder()
+            .interval(Duration.ofSeconds(10))
+            .build();
+
+        // When / Then – delay is always interval, independent of attempt number
+        assertThat(Duration.between(BASE, retry.nextRetryDate(1, BASE))).isEqualTo(Duration.ofSeconds(10));
+        assertThat(Duration.between(BASE, retry.nextRetryDate(2, BASE))).isEqualTo(Duration.ofSeconds(10));
+        assertThat(Duration.between(BASE, retry.nextRetryDate(5, BASE))).isEqualTo(Duration.ofSeconds(10));
+    }
+
+    @Test
+    void shouldAddIntervalToLastAttemptTimestamp() {
+        // Given
+        var retry = Constant.builder()
+            .interval(Duration.ofMinutes(2))
+            .build();
+        Instant lastAttempt = Instant.parse("2024-06-15T12:30:00Z");
+
+        // When
+        Instant next = retry.nextRetryDate(3, lastAttempt);
+
+        // Then
+        assertThat(next).isEqualTo(Instant.parse("2024-06-15T12:32:00Z"));
+    }
+}

--- a/core/src/test/java/io/kestra/core/models/tasks/retrys/ExponentialTest.java
+++ b/core/src/test/java/io/kestra/core/models/tasks/retrys/ExponentialTest.java
@@ -1,0 +1,78 @@
+package io.kestra.core.models.tasks.retrys;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.time.Instant;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unit tests for {@link Exponential#nextRetryDate(Integer, Instant)}.
+ *
+ * <p>Verifies that the scheduler path matches Failsafe {@code withBackoff} semantics:
+ * delay before retry {@code n} = {@code interval * factor^(n-1)}, clamped to {@code maxInterval}.
+ */
+class ExponentialTest {
+
+    private static final Instant BASE = Instant.parse("2024-01-01T00:00:00Z");
+
+    @Test
+    void shouldReturnIntervalForFirstRetry() {
+        // Given
+        var retry = Exponential.builder()
+            .interval(Duration.ofSeconds(5))
+            .maxInterval(Duration.ofHours(1))
+            .build();
+
+        // When
+        Instant next = retry.nextRetryDate(1, BASE);
+
+        // Then – delay == interval (factor^0 == 1)
+        assertThat(Duration.between(BASE, next)).isEqualTo(Duration.ofSeconds(5));
+    }
+
+    @Test
+    void shouldGrowExponentiallyWithDefaultFactor() {
+        // Given – interval=1s, maxInterval=1h, factor=2 (default)
+        var retry = Exponential.builder()
+            .interval(Duration.ofSeconds(1))
+            .maxInterval(Duration.ofHours(1))
+            .build();
+
+        // When / Then – 1s, 2s, 4s, 8s (= interval * 2^(n-1))
+        assertThat(Duration.between(BASE, retry.nextRetryDate(1, BASE))).isEqualTo(Duration.ofSeconds(1));
+        assertThat(Duration.between(BASE, retry.nextRetryDate(2, BASE))).isEqualTo(Duration.ofSeconds(2));
+        assertThat(Duration.between(BASE, retry.nextRetryDate(3, BASE))).isEqualTo(Duration.ofSeconds(4));
+        assertThat(Duration.between(BASE, retry.nextRetryDate(4, BASE))).isEqualTo(Duration.ofSeconds(8));
+    }
+
+    @Test
+    void shouldGrowExponentiallyWithCustomFactor() {
+        // Given – interval=1s, maxInterval=1h, factor=3
+        var retry = Exponential.builder()
+            .interval(Duration.ofSeconds(1))
+            .maxInterval(Duration.ofHours(1))
+            .delayFactor(3d)
+            .build();
+
+        // When / Then – 1s, 3s, 9s (= interval * 3^(n-1))
+        assertThat(Duration.between(BASE, retry.nextRetryDate(1, BASE))).isEqualTo(Duration.ofSeconds(1));
+        assertThat(Duration.between(BASE, retry.nextRetryDate(2, BASE))).isEqualTo(Duration.ofSeconds(3));
+        assertThat(Duration.between(BASE, retry.nextRetryDate(3, BASE))).isEqualTo(Duration.ofSeconds(9));
+    }
+
+    @Test
+    void shouldClampToMaxInterval() {
+        // Given – interval=5s, maxInterval=10s, factor=2 (default)
+        var retry = Exponential.builder()
+            .interval(Duration.ofSeconds(5))
+            .maxInterval(Duration.ofSeconds(10))
+            .build();
+
+        // When / Then – attempt 1: 5s (5*2^0), attempt 2: 10s (5*2^1 = maxInterval), attempt 3: capped at 10s (would be 20s)
+        assertThat(Duration.between(BASE, retry.nextRetryDate(1, BASE))).isEqualTo(Duration.ofSeconds(5));
+        assertThat(Duration.between(BASE, retry.nextRetryDate(2, BASE))).isEqualTo(Duration.ofSeconds(10));
+        assertThat(Duration.between(BASE, retry.nextRetryDate(3, BASE))).isEqualTo(Duration.ofSeconds(10));
+    }
+}

--- a/core/src/test/java/io/kestra/core/models/tasks/retrys/RandomTest.java
+++ b/core/src/test/java/io/kestra/core/models/tasks/retrys/RandomTest.java
@@ -1,0 +1,81 @@
+package io.kestra.core.models.tasks.retrys;
+
+import org.junit.jupiter.api.RepeatedTest;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.time.Instant;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class RandomTest {
+
+    private static final Instant BASE = Instant.parse("2024-01-01T00:00:00Z");
+
+    @Test
+    void shouldReturnDelayWithinConfiguredBounds() {
+        // Given
+        var retry = Random.builder()
+            .minInterval(Duration.ofSeconds(5))
+            .maxInterval(Duration.ofSeconds(15))
+            .build();
+
+        // When
+        Instant next = retry.nextRetryDate(1, BASE);
+
+        // Then
+        Duration delay = Duration.between(BASE, next);
+        assertThat(delay).isGreaterThanOrEqualTo(Duration.ofSeconds(5));
+        assertThat(delay).isLessThan(Duration.ofSeconds(15));
+    }
+
+    @RepeatedTest(20)
+    void shouldAlwaysStayWithinBoundsAcrossMultipleInvocations() {
+        // Given
+        var retry = Random.builder()
+            .minInterval(Duration.ofSeconds(1))
+            .maxInterval(Duration.ofSeconds(10))
+            .build();
+
+        // When
+        Instant next = retry.nextRetryDate(1, BASE);
+
+        // Then
+        Duration delay = Duration.between(BASE, next);
+        assertThat(delay).isGreaterThanOrEqualTo(Duration.ofSeconds(1));
+        assertThat(delay).isLessThan(Duration.ofSeconds(10));
+    }
+
+    @Test
+    void shouldReturnDelayWithinBoundsRegardlessOfAttemptCount() {
+        // Given
+        var retry = Random.builder()
+            .minInterval(Duration.ofSeconds(2))
+            .maxInterval(Duration.ofSeconds(8))
+            .build();
+
+        // When / Then – attemptCount has no effect on bounds (delay is always random within range)
+        for (int attempt = 1; attempt <= 5; attempt++) {
+            Duration delay = Duration.between(BASE, retry.nextRetryDate(attempt, BASE));
+            assertThat(delay).isGreaterThanOrEqualTo(Duration.ofSeconds(2));
+            assertThat(delay).isLessThan(Duration.ofSeconds(8));
+        }
+    }
+
+    @Test
+    void shouldAddDelayToLastAttemptTimestamp() {
+        // Given
+        var retry = Random.builder()
+            .minInterval(Duration.ofSeconds(3))
+            .maxInterval(Duration.ofSeconds(7))
+            .build();
+        Instant lastAttempt = Instant.parse("2024-06-15T12:00:00Z");
+
+        // When
+        Instant next = retry.nextRetryDate(1, lastAttempt);
+
+        // Then – result is always after lastAttempt + minInterval and before lastAttempt + maxInterval
+        assertThat(next).isAfterOrEqualTo(lastAttempt.plusSeconds(3));
+        assertThat(next).isBefore(lastAttempt.plusSeconds(7));
+    }
+}


### PR DESCRIPTION
…as linear not exponential

nextRetryDate() was computing interval * factor * (attemptCount-1), which produced a 0s delay on the first retry and grew linearly instead of exponentially. Switch to interval * factor^(attemptCount-1) to match the Failsafe withBackoff() semantics already used by toPolicy(). Also preserve the full double precision of delayFactor (was truncated via intValue()) and use Math.round instead of a cast to avoid IEEE 754 truncation undercount.

Add nextRetryDate unit tests for all three retry types: Exponential, Constant, and Random.

Fixes kestra-io/kestra-ee#8821