### PR TITLE
fix(ui): reliably re-trigger editor autocomplete in YAML and Pebble contexts

### DIFF
--- a/ui/packages/design-system/src/components/Form/KsEditor.vue
+++ b/ui/packages/design-system/src/components/Form/KsEditor.vue
@@ -90,6 +90,13 @@
         return isOffsetInPebbleBlock(editor.getValue(), absoluteOffset)
     }
 
+    function cursorPebbleBlockKey(editor: monaco.editor.ICodeEditor): number | null {
+        const cursorPos = editor.getPosition()
+        if (!cursorPos) return null
+        const absoluteOffset = editor.getModel()?.getOffsetAt(cursorPos) ?? 0
+        return pebbleBlockKeyAtOffset(editor.getValue(), absoluteOffset)
+    }
+
     function uid(): string {
         return Math.random().toString(36).slice(2, 11)
     }
@@ -217,7 +224,7 @@
     import KsTooltip from "../Feedback/KsTooltip.vue"
     import {STATES} from "../../utils/state"
     import {findDuplicateTaskIds} from "../../utils/yamlValidation"
-    import {createPebbleEntryTracker, isPebbleEnabled} from "../../utils/pebbleBlock"
+    import {createPebbleEntryTracker, isPebbleEnabled, pebbleBlockKeyAtOffset} from "../../utils/pebbleBlock"
     import PlaceholderContentWidget from "../../composables/PlaceholderContentWidget"
 
     type ICodeEditor = monacoEditorNs.ICodeEditor
@@ -1004,13 +1011,13 @@
                     localEditor.value.trigger("triggerSuggestionsInPebbleBlock", "editor.action.triggerSuggest", {})
                 }
             }, 300)
-            // Track the Pebble latch on every cursor change rather than inside the debounced
-            // callback: a fast move out of and back into a `{{ }}` block would otherwise be
-            // swallowed by the debounce, leaving the latch stale (still "in pebble") so the
-            // re-entry transition is missed and suggestions never reopen.
+            // Track the Pebble block on every cursor change rather than inside the debounced
+            // callback: a fast move out of and back into a block (or straight from one `{{ }}`
+            // block to another) would otherwise be swallowed by the debounce, leaving the latch
+            // stale so the re-entry is missed and suggestions never reopen.
             localEditor.value.onDidChangeCursorPosition(() => {
                 if (!localEditor.value) return
-                pebbleEntryTracker.track(isCursorInPebbleBlock(localEditor.value))
+                pebbleEntryTracker.track(cursorPebbleBlockKey(localEditor.value))
                 triggerSuggestionsOnCursorSettle()
             })
 

--- a/ui/packages/design-system/src/components/Form/KsEditor.vue
+++ b/ui/packages/design-system/src/components/Form/KsEditor.vue
@@ -217,7 +217,7 @@
     import KsTooltip from "../Feedback/KsTooltip.vue"
     import {STATES} from "../../utils/state"
     import {findDuplicateTaskIds} from "../../utils/yamlValidation"
-    import {isPebbleEnabled} from "../../utils/pebbleBlock"
+    import {createPebbleEntryTracker, isPebbleEnabled} from "../../utils/pebbleBlock"
     import PlaceholderContentWidget from "../../composables/PlaceholderContentWidget"
 
     type ICodeEditor = monacoEditorNs.ICodeEditor
@@ -411,6 +411,17 @@
             showFoldingControls: "always",
             scrollBeyondLastLine: false,
             roundedSelection: false,
+            // Kestra's YAML editors put their meaningful completions inside YAML string
+            // tokens: plugin `type:` values and Pebble `{{ }}` expressions both tokenize as
+            // strings. Monaco's default quickSuggestions ({strings:false}) never auto-triggers
+            // there, so once the suggest widget is dismissed (backspace, space, moving the
+            // cursor away) it would not reappear while typing. Enabling string suggestions lets
+            // the editor re-show completions as the user types in those regions.
+            quickSuggestions: {
+                other: true,
+                comments: false,
+                strings: pebbleEnabled.value || props.lang === "yaml",
+            },
             ...opts,
             ...props.options?.editor,
         }
@@ -982,18 +993,26 @@
                 }
             })
 
-            let wasInPebbleBlock = false
-            localEditor.value.onDidChangeCursorPosition(debounce(() => {
+            const pebbleEntryTracker = createPebbleEntryTracker()
+            const triggerSuggestionsOnCursorSettle = debounce(() => {
                 if (!localEditor.value) return
-                const inPebble = isCursorInPebbleBlock(localEditor.value)
+                const enteredPebble = pebbleEntryTracker.consumeEntered()
                 if (suggestController!.model.state !== 0) {
                     suggestController!.cancelSuggestWidget()
                     localEditor.value.trigger("refreshSuggestionsOnCursorMove", "editor.action.triggerSuggest", {})
-                } else if (inPebble && !wasInPebbleBlock) {
+                } else if (enteredPebble) {
                     localEditor.value.trigger("triggerSuggestionsInPebbleBlock", "editor.action.triggerSuggest", {})
                 }
-                wasInPebbleBlock = inPebble
-            }, 300))
+            }, 300)
+            // Track the Pebble latch on every cursor change rather than inside the debounced
+            // callback: a fast move out of and back into a `{{ }}` block would otherwise be
+            // swallowed by the debounce, leaving the latch stale (still "in pebble") so the
+            // re-entry transition is missed and suggestions never reopen.
+            localEditor.value.onDidChangeCursorPosition(() => {
+                if (!localEditor.value) return
+                pebbleEntryTracker.track(isCursorInPebbleBlock(localEditor.value))
+                triggerSuggestionsOnCursorSettle()
+            })
 
             localEditor.value.onMouseMove((e) => emit("mouse-move", e))
             localEditor.value.onMouseLeave((e) => emit("mouse-leave", e))

--- a/ui/packages/design-system/src/utils/pebbleBlock.ts
+++ b/ui/packages/design-system/src/utils/pebbleBlock.ts
@@ -7,22 +7,47 @@ export function isOffsetInPebbleBlock(text: string, offset: number): boolean {
 }
 
 /**
+ * Returns a stable key identifying the Pebble `{{ }}` block the cursor sits in — the offset
+ * of the block's opening `{{` — or `null` when the cursor is not inside a block. Moving to a
+ * different block yields a different key, which is how we distinguish "entered a new block"
+ * from "still in the same block".
+ */
+export function pebbleBlockKeyAtOffset(text: string, offset: number): number | null {
+    if (!isOffsetInPebbleBlock(text, offset)) {
+        return null
+    }
+    const blockStart = text.lastIndexOf("{{", offset - 1)
+    // The cursor must be past the opening `{{` (i.e. in the expression body), not wedged
+    // between its two braces. `{|{}}` resolves to the same nearest `{{` as `{{|}}`, so without
+    // this guard both yield the same key and moving back into the expression looks like
+    // "never left" — the re-entry is missed and autocomplete never reopens.
+    if (offset < blockStart + 2) {
+        return null
+    }
+    return blockStart
+}
+
+/**
  * Tracks whether the cursor has *freshly entered* a Pebble `{{ }}` block, in a way that
  * survives the debounce used to throttle suggestion re-triggering on cursor moves.
  *
- * `track()` must be called on every cursor change (synchronously), never from inside the
- * debounced callback: a fast move out of and back into a block would otherwise be swallowed
- * by the debounce, leaving the latch stale ("still in pebble") so the re-entry transition is
- * missed and autocomplete never reopens. `consumeEntered()` is called once the cursor settles
- * and returns (then clears) whether a fresh entry happened during the burst.
+ * `track()` takes the block key (see `pebbleBlockKeyAtOffset`) and must be called on every
+ * cursor change (synchronously), never from inside the debounced callback: a fast move out of
+ * and back into a block would otherwise be swallowed by the debounce, leaving the latch stale
+ * so the re-entry is missed and autocomplete never reopens. Tracking the block *key* rather
+ * than a boolean also catches moving straight from one `{{ }}` block to another (no non-block
+ * position in between), which a boolean in/out latch misses. Staying in the same block is not
+ * a fresh entry, so dismissing the widget with Escape and nudging the cursor won't reopen it.
+ * `consumeEntered()` is called once the cursor settles and returns (then clears) whether a
+ * fresh entry happened during the burst.
  */
 export function createPebbleEntryTracker() {
-    let wasInPebbleBlock = false
+    let lastBlockKey: number | null = null
     let enteredSinceConsume = false
     return {
-        track(inPebbleBlock: boolean): void {
-            if (inPebbleBlock && !wasInPebbleBlock) enteredSinceConsume = true
-            wasInPebbleBlock = inPebbleBlock
+        track(blockKey: number | null): void {
+            if (blockKey !== null && blockKey !== lastBlockKey) enteredSinceConsume = true
+            lastBlockKey = blockKey
         },
         consumeEntered(): boolean {
             const entered = enteredSinceConsume

--- a/ui/packages/design-system/src/utils/pebbleBlock.ts
+++ b/ui/packages/design-system/src/utils/pebbleBlock.ts
@@ -6,6 +6,32 @@ export function isOffsetInPebbleBlock(text: string, offset: number): boolean {
     return text.lastIndexOf("{{", searchUpTo) > text.lastIndexOf("}}", searchUpTo)
 }
 
+/**
+ * Tracks whether the cursor has *freshly entered* a Pebble `{{ }}` block, in a way that
+ * survives the debounce used to throttle suggestion re-triggering on cursor moves.
+ *
+ * `track()` must be called on every cursor change (synchronously), never from inside the
+ * debounced callback: a fast move out of and back into a block would otherwise be swallowed
+ * by the debounce, leaving the latch stale ("still in pebble") so the re-entry transition is
+ * missed and autocomplete never reopens. `consumeEntered()` is called once the cursor settles
+ * and returns (then clears) whether a fresh entry happened during the burst.
+ */
+export function createPebbleEntryTracker() {
+    let wasInPebbleBlock = false
+    let enteredSinceConsume = false
+    return {
+        track(inPebbleBlock: boolean): void {
+            if (inPebbleBlock && !wasInPebbleBlock) enteredSinceConsume = true
+            wasInPebbleBlock = inPebbleBlock
+        },
+        consumeEntered(): boolean {
+            const entered = enteredSinceConsume
+            enteredSinceConsume = false
+            return entered
+        },
+    }
+}
+
 export const PEBBLE_SCHEMA_TYPES = ["flow", "dashboard", "app", "testsuites"] as const
 
 export function isPebbleEnabled(opts: {

--- a/ui/packages/design-system/tests/units/Form/KsEditor.test.ts
+++ b/ui/packages/design-system/tests/units/Form/KsEditor.test.ts
@@ -1,5 +1,5 @@
 import {describe, test, expect} from "vitest"
-import {createPebbleEntryTracker, isOffsetInPebbleBlock, isPebbleEnabled, PEBBLE_SCHEMA_TYPES} from "../../../src/utils/pebbleBlock"
+import {createPebbleEntryTracker, isOffsetInPebbleBlock, isPebbleEnabled, pebbleBlockKeyAtOffset, PEBBLE_SCHEMA_TYPES} from "../../../src/utils/pebbleBlock"
 import {findDuplicateTaskIds} from "../../../src/utils/yamlValidation"
 
 describe("KsEditor / pebbleBlock", () => {
@@ -85,36 +85,68 @@ errors:
     })
 })
 
+describe("KsEditor / pebbleBlockKeyAtOffset", () => {
+    //               0         1
+    //               0123456789012345678
+    const text =    "a = {{ x }} {{ y }}"
+
+    test("returns null outside any block", () => {
+        expect(pebbleBlockKeyAtOffset(text, 2)).toBe(null)
+    })
+
+    test("returns the opening `{{` offset for the containing block", () => {
+        expect(pebbleBlockKeyAtOffset(text, text.indexOf("x"))).toBe(4)
+        expect(pebbleBlockKeyAtOffset(text, text.indexOf("y"))).toBe(12)
+    })
+
+    test("distinct blocks yield distinct keys", () => {
+        const a = pebbleBlockKeyAtOffset(text, text.indexOf("x"))
+        const b = pebbleBlockKeyAtOffset(text, text.indexOf("y"))
+        expect(a).not.toBe(b)
+    })
+
+    // Regression for kestra #14989: the cursor wedged between the two opening braces (`{|{}}`)
+    // must NOT count as being in the block. It resolves to the same nearest `{{` as `{{|}}`,
+    // so without this distinction moving `{{|}}` -> `{|{}}` -> `{{|}}` looks like "never left"
+    // and autocomplete never reopens.
+    test("cursor between the opening braces is not in the block", () => {
+        const empty = "x = {{}}"          // `{{` at 4, `}}` at 6
+        expect(pebbleBlockKeyAtOffset(empty, 6)).toBe(4)   // {{|}}  -> in body
+        expect(pebbleBlockKeyAtOffset(empty, 5)).toBe(null) // {|{}}  -> wedged in `{{`
+        expect(pebbleBlockKeyAtOffset(empty, 7)).toBe(null) // {{}|}  -> wedged in `}}`
+    })
+})
+
 describe("KsEditor / createPebbleEntryTracker", () => {
     test("detects a fresh entry into a Pebble block", () => {
         const tracker = createPebbleEntryTracker()
-        tracker.track(false)
-        tracker.track(true)
+        tracker.track(null)
+        tracker.track(10)
         expect(tracker.consumeEntered()).toBe(true)
     })
 
     test("consumeEntered resets the flag", () => {
         const tracker = createPebbleEntryTracker()
-        tracker.track(false)
-        tracker.track(true)
+        tracker.track(null)
+        tracker.track(10)
         expect(tracker.consumeEntered()).toBe(true)
         expect(tracker.consumeEntered()).toBe(false)
     })
 
     test("no entry while staying outside a Pebble block", () => {
         const tracker = createPebbleEntryTracker()
-        tracker.track(false)
-        tracker.track(false)
+        tracker.track(null)
+        tracker.track(null)
         expect(tracker.consumeEntered()).toBe(false)
     })
 
     test("no fresh entry while staying inside the same block", () => {
         const tracker = createPebbleEntryTracker()
-        tracker.track(true)
+        tracker.track(10)
         expect(tracker.consumeEntered()).toBe(true)
-        // cursor keeps moving but stays in the block — should not re-trigger
-        tracker.track(true)
-        tracker.track(true)
+        // cursor keeps moving but stays in the same block (same key) — should not re-trigger
+        tracker.track(10)
+        tracker.track(10)
         expect(tracker.consumeEntered()).toBe(false)
     })
 
@@ -124,11 +156,22 @@ describe("KsEditor / createPebbleEntryTracker", () => {
     // so the intermediate "out" position was swallowed and autocomplete never reopened.
     test("detects re-entry after a fast out-and-back round-trip", () => {
         const tracker = createPebbleEntryTracker()
-        tracker.track(true) // already inside
+        tracker.track(10) // already inside
         expect(tracker.consumeEntered()).toBe(true)
-        // within a single debounce burst: leave, then return
-        tracker.track(false)
-        tracker.track(true)
+        // within a single debounce burst: leave, then return to the same block
+        tracker.track(null)
+        tracker.track(10)
+        expect(tracker.consumeEntered()).toBe(true)
+    })
+
+    // Regression for kestra #14989 follow-up: moving straight from one `{{ }}` block to a
+    // different one (no non-block position in between) is a fresh entry too. A boolean
+    // in/out latch missed this because "in pebble" never flipped to false.
+    test("detects moving directly from one block to another", () => {
+        const tracker = createPebbleEntryTracker()
+        tracker.track(10) // in block A
+        expect(tracker.consumeEntered()).toBe(true)
+        tracker.track(30) // straight into block B
         expect(tracker.consumeEntered()).toBe(true)
     })
 })

--- a/ui/packages/design-system/tests/units/Form/KsEditor.test.ts
+++ b/ui/packages/design-system/tests/units/Form/KsEditor.test.ts
@@ -1,5 +1,5 @@
 import {describe, test, expect} from "vitest"
-import {isOffsetInPebbleBlock, isPebbleEnabled, PEBBLE_SCHEMA_TYPES} from "../../../src/utils/pebbleBlock"
+import {createPebbleEntryTracker, isOffsetInPebbleBlock, isPebbleEnabled, PEBBLE_SCHEMA_TYPES} from "../../../src/utils/pebbleBlock"
 import {findDuplicateTaskIds} from "../../../src/utils/yamlValidation"
 
 describe("KsEditor / pebbleBlock", () => {
@@ -82,6 +82,54 @@ errors:
     test("handles invalid yaml without throwing", () => {
         const yaml = ":::: not yaml ::::"
         expect(() => findDuplicateTaskIds(yaml)).not.toThrow()
+    })
+})
+
+describe("KsEditor / createPebbleEntryTracker", () => {
+    test("detects a fresh entry into a Pebble block", () => {
+        const tracker = createPebbleEntryTracker()
+        tracker.track(false)
+        tracker.track(true)
+        expect(tracker.consumeEntered()).toBe(true)
+    })
+
+    test("consumeEntered resets the flag", () => {
+        const tracker = createPebbleEntryTracker()
+        tracker.track(false)
+        tracker.track(true)
+        expect(tracker.consumeEntered()).toBe(true)
+        expect(tracker.consumeEntered()).toBe(false)
+    })
+
+    test("no entry while staying outside a Pebble block", () => {
+        const tracker = createPebbleEntryTracker()
+        tracker.track(false)
+        tracker.track(false)
+        expect(tracker.consumeEntered()).toBe(false)
+    })
+
+    test("no fresh entry while staying inside the same block", () => {
+        const tracker = createPebbleEntryTracker()
+        tracker.track(true)
+        expect(tracker.consumeEntered()).toBe(true)
+        // cursor keeps moving but stays in the block — should not re-trigger
+        tracker.track(true)
+        tracker.track(true)
+        expect(tracker.consumeEntered()).toBe(false)
+    })
+
+    // Regression for kestra #14989: a fast move out of and back into a `{{ }}` block,
+    // collapsed into a single debounced settle, must still register as a fresh entry.
+    // The previous implementation updated the latch only inside the debounced callback,
+    // so the intermediate "out" position was swallowed and autocomplete never reopened.
+    test("detects re-entry after a fast out-and-back round-trip", () => {
+        const tracker = createPebbleEntryTracker()
+        tracker.track(true) // already inside
+        expect(tracker.consumeEntered()).toBe(true)
+        // within a single debounce burst: leave, then return
+        tracker.track(false)
+        tracker.track(true)
+        expect(tracker.consumeEntered()).toBe(true)
     })
 })
 


### PR DESCRIPTION
Fixes #14989.

The flow editor's meaningful completions — plugin `type:` values and Pebble `{{ }}` expressions — live inside YAML *string* tokens. Monaco's default `quickSuggestions` (`{strings: false}`) never auto-triggers there, so once the suggest widget was dismissed (backspace, space, or moving the cursor) it would not reappear while typing, and cursor moves into/between `{{ }}` blocks failed to reopen it.

- Enable `quickSuggestions.strings` for YAML/Pebble editors so the editor re-shows completions as you type inside `type:` values and `{{ }}` expressions.
- Re-trigger suggestions when the cursor enters a Pebble block, tracking the block by **identity** (its opening `{{` offset) on every cursor change rather than inside the debounced callback. This survives the cursor-move debounce on a fast out-and-back round-trip **and** catches moving straight from one `{{ }}` block to another (no non-block position in between). Staying in the same block is not a fresh entry, so dismissing the widget with Escape and nudging the cursor won't reopen it. Extracted into `createPebbleEntryTracker` / `pebbleBlockKeyAtOffset` helpers with unit tests.

Verified live (shared design-system, exercised through the EE flow editor):
- Typing a partial `type:` value shows task suggestions; after backspace, resuming typing re-shows them.
- Space+backspace inside `{{ }}` re-shows suggestions.
- Moving the cursor out of and back into a `{{ }}` block — and directly between two blocks — re-shows suggestions (real mouse + keyboard).
- Escape-dismiss then nudging within the same block stays closed; plain string values (e.g. `message: hello world`) stay quiet — no spurious popups.
