### PR TITLE
fix(executor): emit FollowExecutionEvent in the same transaction

### DIFF
--- a/core/src/test/java/io/kestra/core/services/ExecutionStreamingServiceTest.java
+++ b/core/src/test/java/io/kestra/core/services/ExecutionStreamingServiceTest.java
@@ -1,0 +1,99 @@
+package io.kestra.core.services;
+
+import java.util.Collections;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.api.Test;
+
+import io.kestra.core.junit.annotations.KestraTest;
+import io.kestra.core.models.executions.Execution;
+import io.kestra.core.models.flows.Flow;
+import io.kestra.core.models.flows.GenericFlow;
+import io.kestra.core.models.flows.State;
+import io.kestra.core.queues.BroadcastQueueInterface;
+import io.kestra.core.repositories.ExecutionRepositoryInterface;
+import io.kestra.core.repositories.FlowRepositoryInterface;
+import io.kestra.core.runners.FollowExecutionEvent;
+import io.kestra.core.runners.ExecutionEventType;
+import io.kestra.core.utils.IdUtils;
+import io.kestra.plugin.core.log.Log;
+import io.micronaut.http.sse.Event;
+import jakarta.inject.Inject;
+import reactor.core.publisher.Flux;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link ExecutionStreamingService}.
+ */
+@KestraTest
+class ExecutionStreamingServiceTest {
+
+    @Inject
+    private BroadcastQueueInterface<FollowExecutionEvent> executionEventQueue;
+
+    @Inject
+    private ExecutionStreamingService executionStreamingService;
+
+    @Inject
+    private ExecutionRepositoryInterface executionRepositoryInterface;
+
+    @Inject
+    private FlowRepositoryInterface flowRepositoryInterface;
+
+    /**
+     * Core contract for the fix of kestra-io/kestra-ee#8824: when a {@code TERMINATED} {@link FollowExecutionEvent}
+     * arrives and the execution is already findable in the repository, the streaming
+     * {@link Flux} must complete.
+     */
+    @Test
+    void shouldCompleteFluxWhenTerminatedEventArrivesAndExecutionIsPersistedInRepository() throws Exception {
+        // Given — a flow and a FAILED execution (mimicking what the executor exception path
+        // now persists before emitting the follow event)
+        var flow = flowRepositoryInterface.create(GenericFlow.of(
+            Flow.builder()
+                .tenantId(null)
+                .namespace("io.kestra.tests")
+                .id(IdUtils.create())
+                .tasks(Collections.singletonList(
+                    Log.builder().id("log").type(Log.class.getName()).message("test").build()
+                ))
+                .build()
+        ));
+
+        var execution = Execution.newExecution(flow, Collections.emptyList())
+            .withState(State.Type.FAILED);
+
+        // Register the subscriber BEFORE saving the execution so the post-registration
+        // guard in registerSubscriber does not fire prematurely.
+        var subscriberId = IdUtils.create();
+        CompletableFuture<Void> completed = new CompletableFuture<>();
+
+        Flux.<Event<Execution>>create(sink ->
+            executionStreamingService.registerSubscriber(execution.getId(), subscriberId, sink, flow)
+        )
+        .timeout(java.time.Duration.ofSeconds(5))
+        .doFinally(sig -> executionStreamingService.unregisterSubscriber(execution.getId(), subscriberId))
+        .subscribe(
+            event -> { /* progress events — not relevant here */ },
+            completed::completeExceptionally,
+            () -> completed.complete(null)  // sink.complete() unblocks the webhook
+        );
+
+        // Persist the execution into the repository — this is what the fixed executor
+        // failure path now does (returning a non-null ExecutorContext from the lock lambda
+        // instead of null). Without this, findById() returns empty and the event is dropped.
+        executionRepositoryInterface.save(execution);
+
+        // Emit the TERMINATED FollowExecutionEvent — this is what the fixed executor now
+        // emits (TERMINATED, not UPDATED) post-commit, outside the lock lambda.
+        executionEventQueue.emit(new FollowExecutionEvent(execution, ExecutionEventType.TERMINATED));
+
+        // Then — the Flux must complete within a reasonable time, meaning ExecutionStreamingService
+        // called sink.complete() after finding the terminal execution in the repository.
+        // A timeout here means the event was dropped (e.g. findById returned empty) or the
+        // event type was not TERMINATED, reproducing the webhook wait:true hang.
+        assertThat(completed.get(5, TimeUnit.SECONDS)).isNull();
+    }
+}

--- a/executor/src/main/java/io/kestra/executor/DefaultExecutor.java
+++ b/executor/src/main/java/io/kestra/executor/DefaultExecutor.java
@@ -742,21 +742,29 @@ public class DefaultExecutor extends AbstractService implements Executor {
             }
         } catch (QueueException | FlowNotFoundException | InternalException e) {
             if (!ignoreFailure) {
-                // If we cannot add the new worker task result to the execution, we fail it
-                executionStateStore.lock(executor.getExecution().getId(), execution ->
-                {
-                    try {
+                // If we cannot add the new worker task result to the execution, we fail it.
+                // Persist the FAILED state first, then emit the queue events
+                // only after the transaction commits to avoid potential race conditions inside the follow endpoint.
+                Optional<ExecutorContext> failedExecutorOpt = executionStateStore.lock(
+                    executor.getExecution().getId(), execution ->
+                    {
                         Execution failed = execution.failedExecutionFromExecutor(e).execution().withState(State.Type.FAILED);
-                        ExecutionEvent event = new ExecutionEvent(failed, ExecutionEventType.TERMINATED);
-                        this.executionEventQueue.emit(event);
-
-                        // update all execution followers
-                        this.followExecutionEventQueue.emitAsync(new FollowExecutionEvent(failed, ExecutionEventType.UPDATED));
-                    } catch (QueueException ex) {
-                        log.error("Unable to emit the execution {}", execution.getId(), ex);
+                        return new ExecutorContext(execution).withExecution(failed, "toExecutionFailure");
                     }
-                    return null;
-                });
+                );
+
+                if (failedExecutorOpt.isPresent()) {
+                    Execution failedExecution = failedExecutorOpt.get().getExecution();
+                    try {
+                        this.executionEventQueue.emit(new ExecutionEvent(failedExecution, ExecutionEventType.TERMINATED));
+
+                        // update all execution followers — emitted post-commit so the execution
+                        // row is already visible when ExecutionStreamingService looks it up
+                        this.followExecutionEventQueue.emitAsync(new FollowExecutionEvent(failedExecution, ExecutionEventType.TERMINATED));
+                    } catch (QueueException ex) {
+                        log.error("Unable to emit the execution {}", failedExecution.getId(), ex);
+                    }
+                }
             }
         }
     }

--- a/executor/src/main/java/io/kestra/executor/DefaultExecutor.java
+++ b/executor/src/main/java/io/kestra/executor/DefaultExecutor.java
@@ -598,7 +598,7 @@ public class DefaultExecutor extends AbstractService implements Executor {
                 // We need to detect that and reset them as they will never reach the reset code later on this method.
                 if (execution.getTrigger() != null && execution.getState().isFailed() && ListUtils.isEmpty(execution.getTaskRunList())) {
                     sendTriggerExecutionTerminated(execution);
-                    this.followExecutionEventQueue.emitAsync(new FollowExecutionEvent(execution, ExecutionEventType.TERMINATED));
+                    this.followExecutionEventQueue.emit(new FollowExecutionEvent(execution, ExecutionEventType.TERMINATED));
                 }
 
                 return;
@@ -732,13 +732,15 @@ public class DefaultExecutor extends AbstractService implements Executor {
                 this.executionEventQueue.emit(event);
 
                 // update all execution followers
-                this.followExecutionEventQueue.emitAsync(new FollowExecutionEvent(executor.getExecution(), ExecutionEventType.TERMINATED));
+                // Note that we must use 'emit' here and not emitAsync as we need to emit it inside the same transaction to avoid races,
+                // and transactions are bound to a thread. This is true for all emition of the follow execution event inside an execution lock.
+                this.followExecutionEventQueue.emit(new FollowExecutionEvent(executor.getExecution(), ExecutionEventType.TERMINATED));
             } else {
                 ExecutionEvent event = new ExecutionEvent(executor.getExecution(), ExecutionEventType.UPDATED);
                 this.executionEventQueue.emit(event);
 
                 // update all execution followers
-                this.followExecutionEventQueue.emitAsync(new FollowExecutionEvent(executor.getExecution(), ExecutionEventType.UPDATED));
+                this.followExecutionEventQueue.emit(new FollowExecutionEvent(executor.getExecution(), ExecutionEventType.UPDATED));
             }
         } catch (QueueException | FlowNotFoundException | InternalException e) {
             if (!ignoreFailure) {
@@ -758,9 +760,8 @@ public class DefaultExecutor extends AbstractService implements Executor {
                     try {
                         this.executionEventQueue.emit(new ExecutionEvent(failedExecution, ExecutionEventType.TERMINATED));
 
-                        // update all execution followers — emitted post-commit so the execution
-                        // row is already visible when ExecutionStreamingService looks it up
-                        this.followExecutionEventQueue.emitAsync(new FollowExecutionEvent(failedExecution, ExecutionEventType.TERMINATED));
+                        // update all execution followers
+                        this.followExecutionEventQueue.emit(new FollowExecutionEvent(failedExecution, ExecutionEventType.TERMINATED));
                     } catch (QueueException ex) {
                         log.error("Unable to emit the execution {}", failedExecution.getId(), ex);
                     }

--- a/executor/src/main/java/io/kestra/executor/handler/LoopExecutionEventMessageHandler.java
+++ b/executor/src/main/java/io/kestra/executor/handler/LoopExecutionEventMessageHandler.java
@@ -136,7 +136,7 @@ public class LoopExecutionEventMessageHandler implements ExecutorMessageHandler<
                         }
 
                         // we don't update the execution itself as the loop is still running, but we send a follow execution event to update the UI
-                        followExecutionEventQueue.emitAsync(new FollowExecutionEvent(execution, ExecutionEventType.UPDATED));
+                        followExecutionEventQueue.emit(new FollowExecutionEvent(execution, ExecutionEventType.UPDATED));
                         return null;
                     } else {
                         // All iterations have been started — save the decremented counts and either
@@ -148,7 +148,7 @@ public class LoopExecutionEventMessageHandler implements ExecutorMessageHandler<
                         } else {
                             // Some iterations are still running — wait for them.
                             // we don't update the execution itself as the loop is still running, but we send a follow execution event to update the UI
-                            followExecutionEventQueue.emitAsync(new FollowExecutionEvent(execution, ExecutionEventType.UPDATED));
+                            followExecutionEventQueue.emit(new FollowExecutionEvent(execution, ExecutionEventType.UPDATED));
                             return null;
                         }
                     }


### PR DESCRIPTION
…to fix webhook wait:true hang

In the catch block of toExecution(), the lock lambda previously returned null (execution never persisted) and called followExecutionEventQueue.emitAsync() inside the transaction, allowing the FollowExecutionEvent INSERT to commit before the execution row was visible. ExecutionStreamingService would then fail to find the execution, drop the terminal event, and leave webhook wait:true callers blocked forever on Flux.last().

Fix: return a non-null ExecutorContext from the lock lambda so the FAILED execution is persisted, move both queue emits outside the lambda (post-commit), and correct the FollowExecutionEvent type from UPDATED to TERMINATED.

Closes kestra-io/kestra-ee#8824