### PR TITLE
fix(ui): improve upgrade section spacing and layout

### DIFF
--- a/ui/src/components/secrets/Secrets.vue
+++ b/ui/src/components/secrets/Secrets.vue
@@ -109,11 +109,13 @@
 
 <style scoped lang="scss">
     .no-secret-manager-block {
-        padding: 0 0 1.5rem;
+        padding: 0 var(--ks-spacing-5) 1.5rem;
 
         *[style*="display: none"] { display: none !important }
 
         .header-block {
+            width: 100%;
+
             p {
                 font-size: var(--ks-font-size-sm);
                 color: var(--ks-text-secondary);
@@ -124,16 +126,19 @@
         .ee-promo-layout {
             display: flex;
             gap: 1.5rem;
-            align-items: center;
+            align-items: stretch;
+            justify-content: space-between;
+            width: 100%;
         }
 
         .ee-promo-content {
-            flex: 1;
+            flex: 1 1 0;
+            min-width: 0;
         }
 
         .video-container {
-            width: 100%;
-            flex: 1;
+            flex: 1 1 0;
+            min-width: 0;
             aspect-ratio: 16 / 9;
             border-radius: 8px;
             border: 1px solid var(--ks-border-default);
@@ -143,12 +148,6 @@
                 width: 100%;
                 height: 100%;
                 border: 0;
-            }
-        }
-
-        @media (max-width: 1200px) {
-            .ee-promo-layout {
-                flex-direction: column;
             }
         }
 


### PR DESCRIPTION
fixes: https://github.com/kestra-io/kestra/issues/16981

---

Ref img: 
<img width="1636" height="647" alt="image" src="https://github.com/user-attachments/assets/f9489cc7-9fa8-4919-a982-8716010a6732" />

---

Note: The upper spacing reported by Pradumna in issue needs an update on the `EE` side as it seems to appear only after adding some Secrets. 

<img width="1278" height="1080" alt="IMG_20260624_161557" src="https://github.com/user-attachments/assets/3a6689c6-6604-40b1-913f-9d687bb2acb5" />

---
